### PR TITLE
voice: agent.state v1 protocol emitter + lifecycle snapshot (phase 1, stacked on #2684)

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -139,6 +139,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`vision-tools.ts`** — Vision pipeline — pipe JPEG frames from a source (screen, webcam) into the Gemini Live voice session.
 - **`vision_push.py`** — Small helper for posting one-shot vision frames to the active voice session.
 - **`voice-agent-config.ts`** — Voice agent tuned-prompt configuration — step 5a-1 of the interaction-planes refactor (LiveAgentRuntime extraction, slice 1).
+- **`voice-agent-state.ts`** — `agent.state` v1 protocol provider + lifecycle snapshot publisher (design 1a′; impl plan WS1 Step 12, amendments R8/A9/A10/S3/Z3).
 - **`voice-agent.ts`** — Sutando — Voice Interface
 - **`voice-config-switch.ts`** — Voice tool: switch voice-agent's model + googleSearch preset at runtime.
 - **`voice-config.ts`** — Per-surface voice configuration loader.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-200 modules indexed.
+201 modules indexed.
 
 ## `src/`
 

--- a/src/credential-resolver.ts
+++ b/src/credential-resolver.ts
@@ -37,6 +37,17 @@ export type CredentialSource = 'managed' | 'env' | 'none';
 export interface ResolvedCredential {
 	key: string;
 	source: CredentialSource;
+	/**
+	 * Opaque credential-generation ID (e.g. `cg1-<UUID>`) minted by the Rust
+	 * host when the credential was committed/materialized (design 1a′;
+	 * amendments R7/S3). This resolver only REPORTS it — never mints, never
+	 * derives it from the secret:
+	 *   - managed tier: the managed entry's `generation` field, when present;
+	 *   - env tier (voice): `SUTANDO_VOICE_CREDENTIAL_GENERATION`, injected
+	 *     into the child env by the launcher after materialization.
+	 * Legacy credentials without a generation omit the field.
+	 */
+	credentialGeneration?: string;
 }
 
 /** Per-capability lookup order within a tier (voice falls back to text). */
@@ -55,7 +66,7 @@ export function managedCredentialsPath(): string {
 	return join(resolveWorkspace(), 'state', 'auth', 'managed-credentials.json');
 }
 
-function readManaged(path: string): Record<string, { key?: unknown }> {
+function readManaged(path: string): Record<string, { key?: unknown; generation?: unknown }> {
 	try {
 		const parsed = JSON.parse(readFileSync(path, 'utf8'));
 		const caps = parsed?.capabilities;
@@ -72,12 +83,38 @@ export function resolveCredential(
 	const slots = CAPABILITY_FALLBACKS[capability];
 	const managed = readManaged(opts?.managedPath ?? managedCredentialsPath());
 	for (const slot of slots) {
-		const key = managed[slot]?.key;
-		if (typeof key === 'string' && key) return { key, source: 'managed' };
+		const entry = managed[slot];
+		const key = entry?.key;
+		if (typeof key === 'string' && key) {
+			// S3: managed entries may carry an opaque Rust-minted `generation`.
+			// Report it verbatim; legacy entries without one omit the field.
+			const generation = entry?.generation;
+			return {
+				key,
+				source: 'managed',
+				...(typeof generation === 'string' && generation
+					? { credentialGeneration: generation }
+					: {}),
+			};
+		}
 	}
 	for (const slot of slots) {
 		const key = process.env[ENV_VARS[slot]];
-		if (key) return { key, source: 'env' };
+		if (key) {
+			// S3/U4: for the voice capability the launcher injects
+			// SUTANDO_VOICE_CREDENTIAL_GENERATION beside a materialized BYOK
+			// key. Report it verbatim; manual/legacy .env keys (no injected
+			// generation) stay generationless.
+			const generation =
+				capability === 'gemini-voice'
+					? process.env.SUTANDO_VOICE_CREDENTIAL_GENERATION
+					: undefined;
+			return {
+				key,
+				source: 'env',
+				...(generation ? { credentialGeneration: generation } : {}),
+			};
+		}
 	}
 	return { key: '', source: 'none' };
 }

--- a/src/voice-agent-state.ts
+++ b/src/voice-agent-state.ts
@@ -1,0 +1,282 @@
+/**
+ * `agent.state` v1 protocol provider + lifecycle snapshot publisher
+ * (design 1a′; impl plan WS1 Step 12, amendments R8/A9/A10/S3/Z3).
+ *
+ * This module owns the pure/testable pieces of the Step-12 emitter:
+ *
+ *  - `createAgentStateProvider()` — assembles the versioned
+ *    `{type:'agent.state', v:1, …}` frame from live getters supplied by
+ *    voice-agent.ts (bodhi session state, client attachment, fatal-backoff
+ *    deadline, the classifier's persisted terminal classification, and the
+ *    credential resolver result). voice-agent passes the provider's `build`
+ *    to bodhi as the `probeState` option (when the pin supports it), sends
+ *    the frame on every accepted real connection, and re-sends on every
+ *    upstream transition.
+ *  - `publishLifecycleSnapshot()` — the ONE writer (amendment A9) of
+ *    `<workspace>/state/voice-lifecycle.json`, atomically via
+ *    temp-file + `renameSync` with unique temp names. `writeVoiceState`'s
+ *    plain `writeFileSync` is explicitly NOT the pattern here: WS2's control
+ *    consumer reads this file cross-process and must never see a torn write.
+ *  - `createIsolatedIdleRestore()` — amendment Z3's isolated idle-teardown
+ *    timer: the initial idle timer in voice-agent is one-shot and rearmed
+ *    only by the REAL-client disconnect wrapper, so a verifier/probe that
+ *    observes (or wakes) the upstream after that timer already fired would
+ *    otherwise leave the upstream connected forever. On verifier/probe close
+ *    with no real client attached, this fence restores the prior idle state
+ *    — and a later real connection fences (invalidates) any pending restore.
+ *
+ * The frame schema is WIRE CONTRACT v1 (design 1a′). Do not add/rename
+ * fields without a version bump.
+ */
+import { mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { statusPath } from './workspace_default.js';
+import type { ProtocolFailure, ProtocolFailureCategory } from './voice-error-classifier.js';
+import type { ResolvedCredential } from './credential-resolver.js';
+
+/** L3 upstream states (design readiness model). */
+export type UpstreamState = 'live' | 'idle' | 'connecting' | 'backoff' | 'failed';
+
+/** `agent.state` v1 frame — design 1a′, verbatim schema. */
+export interface AgentStateV1 {
+	type: 'agent.state';
+	v: 1;
+	initialized: boolean;
+	upstream: UpstreamState;
+	reason?: string;
+	category?: ProtocolFailureCategory;
+	clientAttached: boolean;
+	credentialSource?: 'managed' | 'byok';
+	credentialGeneration?: string;
+	launchdContract?: 1;
+}
+
+/**
+ * Map the resolver's source labels onto the frame's enum (amendment A10:
+ * source comes from the EXISTING `voiceCredential.source`, labels mapped
+ * here — `env` means a BYO key on the wire; `none` omits the field).
+ */
+export function credentialSourceLabel(
+	source: ResolvedCredential['source'],
+): 'managed' | 'byok' | undefined {
+	if (source === 'managed') return 'managed';
+	if (source === 'env') return 'byok';
+	return undefined;
+}
+
+/** Inputs the provider polls at build time — all late-bound getters. */
+export interface AgentStateInputs {
+	/** L2: tools loaded + VoiceSession constructed + WS server listening. */
+	initialized: () => boolean;
+	/** bodhi `session.sessionManager.state` (CREATED/CONNECTING/ACTIVE/…). */
+	sessionState: () => string;
+	/** Real clients only — probe/verifier sockets never attach. */
+	clientAttached: () => boolean;
+	/** voice-agent's `voiceFatalBackoffUntil` (ms epoch; 0 = none). */
+	backoffUntil: () => number;
+	/** Classifier-persisted last terminal classification (R8), or null. */
+	lastTerminalFailure: () => ProtocolFailure | null;
+	/** The resolver result the agent actually loaded its key from (A10). */
+	credential: () => Pick<ResolvedCredential, 'source' | 'credentialGeneration'>;
+	/** SUTANDO_VOICE_LAUNCHD_CONTRACT=1 marker present in the env (R17). */
+	launchdContract: () => boolean;
+	now?: () => number;
+}
+
+/**
+ * Pure upstream mapping (impl plan Step 12):
+ *   ACTIVE → 'live';
+ *   CONNECTING / RECONNECTING / TRANSFERRING → 'connecting';
+ *   terminal classification persisted → 'failed' + reason + category;
+ *   otherwise (CLOSED/CREATED): client attached or fatal backoff pending →
+ *   'backoff'; idle-teardown with no client → 'idle'.
+ * A live ACTIVE session always wins over a stale terminal classification —
+ * voice-agent clears the classification on the ACTIVE transition, but the
+ * mapping is safe even if the clear races the build.
+ */
+export function mapUpstream(args: {
+	sessionState: string;
+	clientAttached: boolean;
+	backoffUntil: number;
+	terminal: ProtocolFailure | null;
+	now: number;
+}): { upstream: UpstreamState; reason?: string; category?: ProtocolFailureCategory } {
+	const { sessionState, clientAttached, backoffUntil, terminal, now } = args;
+	if (sessionState === 'ACTIVE') return { upstream: 'live' };
+	if (terminal) {
+		return { upstream: 'failed', reason: terminal.reason, category: terminal.category };
+	}
+	if (
+		sessionState === 'CONNECTING'
+		|| sessionState === 'RECONNECTING'
+		|| sessionState === 'TRANSFERRING'
+	) {
+		return { upstream: 'connecting' };
+	}
+	// CLOSED / CREATED / unknown: upstream is down. With a client attached
+	// (or a fatal-backoff window pending) the agent is waiting to reconnect;
+	// with neither, this is the healthy idle-teardown fixed point.
+	if (clientAttached || backoffUntil > now) return { upstream: 'backoff' };
+	return { upstream: 'idle' };
+}
+
+export interface AgentStateProvider {
+	build(): AgentStateV1;
+}
+
+export function createAgentStateProvider(inputs: AgentStateInputs): AgentStateProvider {
+	const now = inputs.now ?? Date.now;
+	return {
+		build(): AgentStateV1 {
+			const mapped = mapUpstream({
+				sessionState: inputs.sessionState(),
+				clientAttached: inputs.clientAttached(),
+				backoffUntil: inputs.backoffUntil(),
+				terminal: inputs.lastTerminalFailure(),
+				now: now(),
+			});
+			const cred = inputs.credential();
+			const source = credentialSourceLabel(cred.source);
+			const frame: AgentStateV1 = {
+				type: 'agent.state',
+				v: 1,
+				initialized: inputs.initialized(),
+				upstream: mapped.upstream,
+				clientAttached: inputs.clientAttached(),
+			};
+			if (mapped.reason !== undefined) frame.reason = mapped.reason;
+			if (mapped.category !== undefined) frame.category = mapped.category;
+			if (source !== undefined) frame.credentialSource = source;
+			// The agent only REPORTS the Rust-minted opaque generation (R7/S3)
+			// — legacy credentials without one omit the field.
+			if (cred.credentialGeneration) frame.credentialGeneration = cred.credentialGeneration;
+			// launchdContract:1 echoed only when the launchd contract env
+			// marker is set (R17) — never synthesized.
+			if (inputs.launchdContract()) frame.launchdContract = 1;
+			return frame;
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle snapshot — state/voice-lifecycle.json (amendment A9)
+// ---------------------------------------------------------------------------
+
+/** On-disk lifecycle snapshot schema (A9 + S3). */
+export interface VoiceLifecycleSnapshot {
+	at: number;
+	clientAttached: boolean;
+	initialized: boolean;
+	upstream: UpstreamState;
+	category?: ProtocolFailureCategory;
+	credentialSource?: 'managed' | 'byok';
+	credentialGeneration?: string;
+}
+
+export function voiceLifecyclePath(workspace: string): string {
+	// Canonical runtime-state path resolution (workspace contract): the
+	// caller supplies the resolved workspace; statusPath owns the state/
+	// layout.
+	return statusPath('voice-lifecycle.json', workspace);
+}
+
+// Unique temp names: pid + monotonic counter — two writers (or one writer's
+// interleaved transitions) can never collide on the temp file, and rename()
+// is atomic on the same filesystem.
+let _tmpCounter = 0;
+
+/**
+ * Atomically publish the lifecycle snapshot derived from an `agent.state`
+ * frame. The SINGLE writer of this file (A9) — voice-agent calls it on every
+ * relevant transition (client attach/detach, initialized flip, upstream
+ * change). Failure-silent by contract: a snapshot write must never take the
+ * voice path down (callers log via `onError`).
+ */
+export function publishLifecycleSnapshot(
+	workspace: string,
+	frame: AgentStateV1,
+	opts?: { now?: () => number; onError?: (err: unknown) => void },
+): void {
+	const target = voiceLifecyclePath(workspace);
+	const snapshot: VoiceLifecycleSnapshot = {
+		at: (opts?.now ?? Date.now)(),
+		clientAttached: frame.clientAttached,
+		initialized: frame.initialized,
+		upstream: frame.upstream,
+	};
+	if (frame.category !== undefined) snapshot.category = frame.category;
+	if (frame.credentialSource !== undefined) snapshot.credentialSource = frame.credentialSource;
+	if (frame.credentialGeneration !== undefined) snapshot.credentialGeneration = frame.credentialGeneration;
+	const tmp = `${target}-tmp-${process.pid}-${++_tmpCounter}`;
+	try {
+		mkdirSync(dirname(target), { recursive: true });
+		writeFileSync(tmp, JSON.stringify(snapshot));
+		renameSync(tmp, target);
+	} catch (err) {
+		opts?.onError?.(err);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Isolated idle-teardown restore (amendment Z3)
+// ---------------------------------------------------------------------------
+
+export interface IsolatedIdleRestore {
+	/**
+	 * Arm the isolated restore timer. Called on verifier/probe-role close
+	 * with no real client attached (SEAM NOTE: the pinned bodhi has no
+	 * probe/verifier role yet — until the Step-11 pin lands, voice-agent
+	 * arms this from its `probeState` callback, the only probe-shaped hook
+	 * this repo controls; when bodhi's role close hook exists it should call
+	 * `arm()` directly on verifier close). No-op while a real client is
+	 * attached.
+	 */
+	arm(): void;
+	/**
+	 * Fence: a later REAL connection invalidates any pending restore — the
+	 * restore must never tear down the upstream under a real client that
+	 * connected after the probe closed.
+	 */
+	fence(): void;
+	/** True while a restore is armed and not yet fired/fenced. */
+	pending(): boolean;
+}
+
+export function createIsolatedIdleRestore(opts: {
+	delayMs: number;
+	clientAttached: () => boolean;
+	/** Restore the prior idle state (close the upstream transport). */
+	teardown: () => void | Promise<void>;
+}): IsolatedIdleRestore {
+	let epoch = 0;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	const clear = () => {
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+		}
+	};
+	return {
+		arm(): void {
+			if (opts.clientAttached()) return;
+			clear();
+			const armedEpoch = epoch;
+			timer = setTimeout(() => {
+				timer = null;
+				// Re-check the fence AND real attachment at fire time: a real
+				// client that connected after arming owns the upstream now.
+				if (armedEpoch !== epoch || opts.clientAttached()) return;
+				void opts.teardown();
+			}, opts.delayMs);
+			// Never keep the process alive just for the restore timer.
+			timer.unref?.();
+		},
+		fence(): void {
+			epoch++;
+			clear();
+		},
+		pending(): boolean {
+			return timer !== null;
+		},
+	};
+}

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -52,7 +52,19 @@ import { acquireVoiceLock, releaseOnExitUnlessFatal, resolveLockPython, voiceLoc
 import { recordToolCall } from './conversation-store.js';
 import { buildGreeting, buildInstructions, type VoiceConfigContext } from './voice-agent-config.js';
 import { wireDurableChannels, createSessionRecorder } from './live-agent-runtime.js';
-import { classifyTransportClose, type ClassifiedClose } from './voice-error-classifier.js';
+import {
+	classifyTransportClose,
+	recordTerminalClassification,
+	lastTerminalClassification,
+	clearTerminalClassification,
+	type ClassifiedClose,
+} from './voice-error-classifier.js';
+import {
+	createAgentStateProvider,
+	createIsolatedIdleRestore,
+	publishLifecycleSnapshot,
+	type AgentStateV1,
+} from './voice-agent-state.js';
 
 import { sharedPersonalPath, claudeHomePath } from './util_paths.js';
 
@@ -787,6 +799,60 @@ async function main() {
 	}
 
 
+	// Bumped 5min into the future on every non-retryable transport close
+	// (set inside the classifier IIFE below). Read by the 30s health
+	// monitor — when the deadline is in the future, the monitor skips its
+	// reconnect-trigger so a permanent upstream failure (credits depleted,
+	// key invalid, quota exceeded) doesn't produce a tight 60s retry loop
+	// that spams logs + Gemini API requests until the user fixes things.
+	// Auto-recovery resumes ~5min after the last fatal close. Reset to 0
+	// when the session reaches ACTIVE so a transient close after recovery
+	// doesn't inherit a stale backoff window. (Declared BEFORE the
+	// VoiceSession construction so the agent.state provider below can read
+	// it — Step 12's `backoff` upstream mapping.)
+	let voiceFatalBackoffUntil = 0;
+
+	// =========================================================================
+	// `agent.state` v1 provider (design 1a′; impl plan WS1 Step 12,
+	// amendments R8/A9/A10/S3). All getters are late-bound: `sessionRef` is
+	// assigned right after the constructor, and no client (or probe) can
+	// reach the WS server before session.start() runs below.
+	// =========================================================================
+	let agentInitialized = false;
+	const agentStateProvider = createAgentStateProvider({
+		initialized: () => agentInitialized,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		sessionState: () => String((sessionRef as any)?.sessionManager?.state ?? 'CREATED'),
+		// Real clients only — probe sockets never attach (Step 11's bodhi
+		// interception keeps them off `clientConnected`).
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		clientAttached: () => Boolean((sessionRef as any)?.clientConnected),
+		backoffUntil: () => voiceFatalBackoffUntil,
+		// R8: the persisted last terminal classification lives in the
+		// classifier module — one classifier, one store.
+		lastTerminalFailure: () => lastTerminalClassification(),
+		// A10: the EXISTING resolver result the agent loaded its key from —
+		// `voiceApiKey()`'s string signature is untouched; label mapping
+		// (env→byok) happens inside the provider. `credentialGeneration` is
+		// only ever REPORTED (Rust mints it; S3 plumbs it via the managed
+		// file / SUTANDO_VOICE_CREDENTIAL_GENERATION).
+		credential: () => voiceCredential,
+		// R17: echo launchdContract:1 only when the launchd contract env
+		// marker is present.
+		launchdContract: () => process.env.SUTANDO_VOICE_LAUNCHD_CONTRACT === '1',
+	});
+	const buildAgentState = (): AgentStateV1 => agentStateProvider.build();
+
+	// Feature-detect Step-11 probe support in the pinned bodhi. The
+	// `probeState` constructor option ships with the bodhi PR + pin bump
+	// (impl plan PR group E); until that pin lands the option would be
+	// silently ignored, so the detect keeps the wiring intent explicit and
+	// lets the pin bump activate it without touching this file. Detection:
+	// the bundled VoiceSession source must mention the option.
+	const bodhiSupportsProbeState = (() => {
+		try { return String(VoiceSession).includes('probeState'); } catch { return false; }
+	})();
+
 	const session = new VoiceSession({
 		sessionId: SESSION_ID,
 		userId: 'user',
@@ -799,6 +865,22 @@ async function main() {
 		geminiModel: VOICE_NATIVE_AUDIO_MODEL,
 		speechConfig: { voiceName: VOICE_NAME },
 		inputAudioTranscription: true,
+		// Step 11/12: when the pinned bodhi supports `?probe=1` probe
+		// interception, hand it the agent.state builder — probes get one
+		// frame + close 1000 without ever touching `this.client`. The Z3
+		// isolated idle-restore arms here too: a probe is the only
+		// probe-shaped hook this repo controls until bodhi exposes a
+		// dedicated probe/verifier-close callback (seam documented on
+		// `createIsolatedIdleRestore().arm`).
+		...(bodhiSupportsProbeState
+			? {
+				probeState: (): AgentStateV1 => {
+					const frame = buildAgentState();
+					probeIdleRestore.arm();
+					return frame;
+				},
+			}
+			: {}),
 		hooks: {
 			onSessionStart: (e) => {
 				userTurnCount = 0; userHasInterrupted = false; sessionEnding = false;
@@ -856,6 +938,58 @@ async function main() {
 	});
 
 	sessionRef = session;
+
+	// =========================================================================
+	// `agent.state` emission + lifecycle snapshot (Step 12 + amendment A9).
+	// One emitter, three triggers: an immediate frame on every accepted real
+	// connection, a repeat frame on every upstream transition, and an atomic
+	// `state/voice-lifecycle.json` publish on every relevant transition
+	// (client attach/detach, initialized flip, upstream change). This module
+	// is the ONLY writer of the lifecycle file (A9) — WS2's control consumer
+	// reads it cross-process.
+	// =========================================================================
+	let lastEmittedUpstream: string | null = null;
+	let lastLifecycleKey = '';
+	const sendAgentStateFrame = (frame: AgentStateV1): void => {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(session as any).clientTransport?.sendJsonToClient?.(frame);
+		} catch (err) {
+			console.error(`${ts()} [AgentState] frame send failed: ${(err as Error)?.message ?? err}`);
+		}
+	};
+	const emitAgentState = (opts: { immediate?: boolean } = {}): void => {
+		const frame = buildAgentState();
+		// A transition includes reason/category changes within 'failed'
+		// (e.g. auth-invalid → quota-exceeded after a key rotation) — those
+		// are meaningful upstream transitions even when the state name
+		// doesn't change.
+		const upstreamKey = `${frame.upstream}|${frame.reason ?? ''}|${frame.category ?? ''}`;
+		const upstreamChanged = upstreamKey !== lastEmittedUpstream;
+		lastEmittedUpstream = upstreamKey;
+		if (opts.immediate || upstreamChanged) sendAgentStateFrame(frame);
+		// A9: publish the lifecycle snapshot when any relevant field flipped
+		// (attach/detach, initialized, upstream) — atomic temp+rename with
+		// unique temp names inside publishLifecycleSnapshot; NOT the
+		// writeVoiceState plain-writeFileSync pattern.
+		const lifecycleKey = `${frame.clientAttached}|${frame.initialized}|${upstreamKey}`;
+		if (lifecycleKey !== lastLifecycleKey) {
+			lastLifecycleKey = lifecycleKey;
+			publishLifecycleSnapshot(WORKSPACE_DIR, frame, {
+				onError: (err) => console.error(`${ts()} [AgentState] lifecycle snapshot write failed: ${(err as Error)?.message ?? err}`),
+			});
+		}
+	};
+	// Upstream transitions: bodhi's sessionManager publishes
+	// `session.stateChange` on every transitionTo() — the same seam the
+	// health monitor's state reads observe. ACTIVE proves the credential
+	// works again, so it clears the persisted terminal classification (R8)
+	// before the frame is built.
+	session.eventBus.subscribe('session.stateChange', (e) => {
+		if ((e as { toState?: string })?.toState === 'ACTIVE') clearTerminalClassification();
+		emitAgentState();
+	});
+
 	// Wire vision streaming — the start_vision tool needs the live session
 	// to call session.transport.sendFile for each frame. Also boot the local
 	// HTTP control endpoint so the web-client Watch button can drive the
@@ -866,17 +1000,6 @@ async function main() {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	setSessionToolUpdater((tools) => (session as any).transport?.updateTools?.(tools), mainAgentTools);
 	startVisionControlServer();
-
-	// Bumped 5min into the future on every non-retryable transport close
-	// (set inside the classifier IIFE below). Read by the 30s health
-	// monitor — when the deadline is in the future, the monitor skips its
-	// reconnect-trigger so a permanent upstream failure (credits depleted,
-	// key invalid, quota exceeded) doesn't produce a tight 60s retry loop
-	// that spams logs + Gemini API requests until the user fixes things.
-	// Auto-recovery resumes ~5min after the last fatal close. Reset to 0
-	// when the session reaches ACTIVE so a transient close after recovery
-	// doesn't inherit a stale backoff window.
-	let voiceFatalBackoffUntil = 0;
 
 	// Wire voice-failure classifier: when the Gemini Live transport closes
 	// with a non-retryable reason (credits depleted, quota exceeded, key
@@ -895,12 +1018,19 @@ async function main() {
 		const notifiedCategories = new Set<string>();
 		const handleClose = (c: ClassifiedClose): void => {
 			if (c.retryable) return;
+			// R8: persist the terminal classification (one classifier, one
+			// store — voice-error-classifier.ts) so buildAgentState() reports
+			// `upstream:'failed'` with the stable reason/category between
+			// closes, then emit the upstream transition to any attached
+			// client + the lifecycle snapshot (Step 12).
+			recordTerminalClassification(c);
 			// Push the health-monitor reconnect window out by 5min on every
 			// non-retryable close — including repeats of an already-notified
 			// category — so the 60s retry loop doesn't keep firing while the
 			// upstream issue persists. Without this, a 1011 credit-depleted
 			// loop produces ~6 log lines / 60s indefinitely.
 			voiceFatalBackoffUntil = Date.now() + 5 * 60 * 1000;
+			emitAgentState();
 			if (notifiedCategories.has(c.category)) return;
 			notifiedCategories.add(c.category);
 			console.error(`${ts()} [VoiceFailure] ${c.category}: ${c.userMessage} (raw="${c.rawReason}")`);
@@ -941,6 +1071,26 @@ async function main() {
 		};
 		console.log(`${ts()} [VoiceFailure] classifier wired into transport.onClose`);
 	})();
+
+	// Test-only fault injection (SUTANDO_TEST_MODE only): synthesize an
+	// upstream transport close through the REAL wrapped `transport.onClose`
+	// seam above, so integration tests can drive classifier →
+	// recordTerminalClassification → agent.state 'failed' emission
+	// deterministically offline (no dependency on live Gemini responses).
+	// File-triggered so the test controls WHEN the close fires relative to
+	// its own client connection (boot timing on CI is unbounded).
+	// Format: SUTANDO_TEST_UPSTREAM_CLOSE="<triggerFile>|<code>|<reason>".
+	if (process.env.SUTANDO_TEST_MODE === '1' && process.env.SUTANDO_TEST_UPSTREAM_CLOSE) {
+		const [trigger, codeRaw, ...reasonParts] = process.env.SUTANDO_TEST_UPSTREAM_CLOSE.split('|');
+		const poll = setInterval(() => {
+			if (!existsSync(trigger)) return;
+			clearInterval(poll);
+			try {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				(session as any).transport?.onClose?.(Number(codeRaw) || 1011, reasonParts.join('|'));
+			} catch { /* test-only */ }
+		}, 250);
+	}
 
 	// Wire narration-tee: capture Gemini's outbound audio for screen recordings
 	try {
@@ -1110,6 +1260,22 @@ async function main() {
 	const IDLE_TEARDOWN_MS = Number(process.env.SUTANDO_VOICE_IDLE_TEARDOWN_MS) || 60_000;
 	let idleTeardownTimer: ReturnType<typeof setTimeout> | null = null;
 
+	// Shared teardown body — used by the one-shot idle timer below AND by the
+	// Z3 isolated idle-restore (probe/verifier fence). Re-checks real-client
+	// attachment at fire time so a client that connected while the timer was
+	// pending is never torn down under.
+	const teardownIdleUpstream = async (via: string) => {
+		if ((session as any).clientConnected) return;
+		const transport = (session as any).transport;
+		if (!transport?.disconnect) return;
+		console.log(`${ts()} [VoiceSession] Idle (${via}) — closing Gemini transport (no phantoms while CLOSED)`);
+		try {
+			await transport.disconnect();
+		} catch (err) {
+			console.error(`${ts()} [VoiceSession] Idle teardown failed: ${(err as Error)?.message ?? err}`);
+		}
+	};
+
 	const cancelIdleTeardown = () => {
 		if (idleTeardownTimer) {
 			clearTimeout(idleTeardownTimer);
@@ -1120,17 +1286,28 @@ async function main() {
 		cancelIdleTeardown();
 		idleTeardownTimer = setTimeout(async () => {
 			idleTeardownTimer = null;
-			if ((session as any).clientConnected) return;
-			const transport = (session as any).transport;
-			if (!transport?.disconnect) return;
-			console.log(`${ts()} [VoiceSession] Idle ${IDLE_TEARDOWN_MS / 1000}s — closing Gemini transport (no phantoms while CLOSED)`);
-			try {
-				await transport.disconnect();
-			} catch (err) {
-				console.error(`${ts()} [VoiceSession] Idle teardown failed: ${(err as Error)?.message ?? err}`);
-			}
+			await teardownIdleUpstream(`${IDLE_TEARDOWN_MS / 1000}s idle`);
 		}, IDLE_TEARDOWN_MS);
 	};
+
+	// Amendment Z3 — verifier/probe idle restoration. The initial idle timer
+	// above is one-shot and rearmed only by the REAL-client disconnect
+	// wrapper; a probe/verifier that closes after that timer already fired
+	// would otherwise leave a woken upstream connected forever (no real
+	// client will ever rearm it). The isolated restore timer arms on
+	// probe-role close with no real client attached and restores the prior
+	// idle state (upstream → CLOSED); a later real connection fences it
+	// (handleClientConnected wrapper below). SEAM: until the Step-11 bodhi
+	// pin exposes a probe/verifier-close hook, the only in-repo arm point is
+	// the `probeState` callback passed to the VoiceSession constructor —
+	// when bodhi's role close hook lands, wire it to `probeIdleRestore.arm()`
+	// directly.
+	const probeIdleRestore = createIsolatedIdleRestore({
+		delayMs: IDLE_TEARDOWN_MS,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		clientAttached: () => Boolean((session as any).clientConnected),
+		teardown: () => teardownIdleUpstream('probe-idle-restore'),
+	});
 
 	// Flush metrics on client disconnect — bodhi's handleClientDisconnected()
 	// doesn't trigger onSessionEnd, so metrics would never be written. Also
@@ -1142,6 +1319,9 @@ async function main() {
 			recorder.flush();
 			writeVoiceState(false);
 			scheduleIdleTeardown();
+			// Step 12/A9: client detach is a lifecycle transition (and may
+			// flip upstream backoff→idle now that no client is attached).
+			emitAgentState();
 		};
 	}
 
@@ -1163,6 +1343,10 @@ async function main() {
 	if (origConnect) {
 		(session as any).handleClientConnected = () => {
 			cancelIdleTeardown();
+			// Z3 fence: a REAL connection invalidates any pending
+			// probe/verifier idle-restore — the restore must never tear the
+			// upstream down under this client.
+			probeIdleRestore.fence();
 			if (recorder.wasFlushed) {
 				userTurnCount = 0; userHasInterrupted = false; sessionEnding = false;
 				recorder.reset();
@@ -1174,6 +1358,11 @@ async function main() {
 			}
 			writeVoiceState(true);
 			origConnect();
+			// Step 12: immediate `agent.state` frame on every accepted real
+			// connection (after origConnect so `clientAttached` reads true),
+			// then repeats ride the upstream-transition subscription. Also
+			// publishes the A9 lifecycle attach transition.
+			emitAgentState({ immediate: true });
 		};
 	}
 
@@ -1207,6 +1396,14 @@ async function main() {
 		} catch (err) { console.error(`${ts()} [CallResult] Error:`, err); }
 	}, 2000);
 
+	// L2 initialized (Step 12): tools are loaded, the VoiceSession is
+	// constructed, and the WS server is about to listen (session.start()
+	// binds the WS listener before the LLM transport, per bodhi internals) —
+	// set immediately before the start() try, per the readiness model, and
+	// publish the lifecycle flip (A9).
+	agentInitialized = true;
+	emitAgentState();
+
 	// Start session — don't let a transient Gemini failure kill the process.
 	// WS server starts *before* the LLM transport (per bodhi internals), so the
 	// listener on :PORT is already healthy; only the upstream Gemini connection is broken.
@@ -1217,6 +1414,12 @@ async function main() {
 		const msg = (err as Error)?.message || String(err);
 		console.error(`${ts()} [Startup] session.start() failed: ${msg}`);
 		console.error(`${ts()} [Startup] Staying alive — WS server on :${PORT}, will retry LLM transport on next client connect`);
+		// The regex below is a LOGGING HINT only (amendment R8) — the
+		// protocol classification seam is voice-error-classifier.ts: run the
+		// startup failure message through the same classifier as transport
+		// closes so a terminal cause (bad key, quota) is persisted for
+		// buildAgentState() and reported as upstream:'failed'.
+		recordTerminalClassification(classifyTransportClose(undefined, msg));
 		if (/credit|quota|billing|auth|401|403/i.test(msg)) {
 			console.error(`${ts()} [Startup] Likely cause: Gemini API key invalid or prepayment credits depleted`);
 			console.error(`${ts()} [Startup] Fix: top up at https://ai.studio/projects or rotate GEMINI_API_KEY in .env`);
@@ -1234,6 +1437,11 @@ async function main() {
 		} catch (e) {
 			console.error(`${ts()} [Startup] Could not transition to CLOSED (state=${session.sessionManager.state}): ${(e as Error)?.message ?? e}`);
 		}
+		// Belt-and-braces: the transitionTo above already emits via the
+		// stateChange subscription; when it throws (state already CLOSED)
+		// this still publishes the terminal classification (dedup makes a
+		// double call a no-op).
+		emitAgentState();
 	}
 
 	// Health monitor — runs regardless of whether initial start() succeeded.

--- a/src/voice-error-classifier.ts
+++ b/src/voice-error-classifier.ts
@@ -104,3 +104,87 @@ export function classifyTransportClose(
 		rawReason: text,
 	};
 }
+
+// ---------------------------------------------------------------------------
+// `agent.state` protocol mapping (design 1a′; impl plan WS1 Step 12,
+// amendment R8).
+//
+// THIS module is the single classifier seam: the `agent.state` failure
+// classification extends the transport-close classifier above with a STABLE
+// protocol mapper — classification → {upstream:'failed', reason code,
+// category} — rather than growing a second classifier elsewhere. (The
+// `/credit|quota|…/i` regex in voice-agent's startup path is a logging hint
+// only; startup failures route through `classifyTransportClose` +
+// `recordTerminalClassification` like transport closes.)
+//
+// Reason codes and the category enum are WIRE CONTRACT: supervisor-status,
+// the WS2 control consumers, and the desktop UI key on them. Change them
+// only with a protocol version bump.
+// ---------------------------------------------------------------------------
+
+/** `agent.state` frame category enum (design 1a′). */
+export type ProtocolFailureCategory = 'auth' | 'quota' | 'network' | 'other';
+
+/** Stable terminal-failure protocol mapping for `agent.state` frames. */
+export interface ProtocolFailure {
+	upstream: 'failed';
+	/** Stable protocol reason code (wire contract — not a message). */
+	reason: string;
+	category: ProtocolFailureCategory;
+}
+
+/**
+ * classification → protocol mapping. Only TERMINAL (non-retryable)
+ * classifications map to `upstream:'failed'`; retryable ones return null —
+ * they are represented in `agent.state` by the ordinary
+ * `connecting`/`backoff`/`idle` upstream states, never by `failed`.
+ */
+const PROTOCOL_MAP: Partial<Record<FailureCategory, { reason: string; category: ProtocolFailureCategory }>> = {
+	auth_invalid: { reason: 'auth-invalid', category: 'auth' },
+	quota_exceeded: { reason: 'quota-exceeded', category: 'quota' },
+	credits_depleted: { reason: 'credits-depleted', category: 'quota' },
+	model_not_found: { reason: 'model-not-found', category: 'other' },
+};
+
+/**
+ * Map a classified close to the `agent.state` failure protocol.
+ * Returns null for retryable/unrecognized closes (not terminal).
+ */
+export function protocolFailureFor(c: ClassifiedClose): ProtocolFailure | null {
+	if (c.retryable) return null;
+	const m = PROTOCOL_MAP[c.category];
+	// A non-retryable classification MUST have a mapping; fail safe to
+	// 'other' if a future category forgets to register one.
+	return { upstream: 'failed', ...(m ?? { reason: c.category, category: 'other' as const }) };
+}
+
+// Last terminal classification, persisted for buildAgentState() (R8): the
+// `agent.state` provider reads it between transport closes, so a probe that
+// arrives while the session sits in fatal backoff still sees
+// `upstream:'failed'` with the classified reason/category.
+let _lastTerminal: ProtocolFailure | null = null;
+
+/**
+ * Classify + persist in one step. Records only terminal classifications;
+ * returns the protocol mapping (null when retryable). Callers pass the same
+ * (code, reason) they hand to `classifyTransportClose` — or a startup
+ * failure message with `code` undefined.
+ */
+export function recordTerminalClassification(c: ClassifiedClose): ProtocolFailure | null {
+	const failure = protocolFailureFor(c);
+	if (failure) _lastTerminal = failure;
+	return failure;
+}
+
+/** Last persisted terminal classification (null when none / cleared). */
+export function lastTerminalClassification(): ProtocolFailure | null {
+	return _lastTerminal;
+}
+
+/**
+ * Clear the persisted terminal classification — called when the upstream
+ * recovers to ACTIVE (a live session proves the credential works again).
+ */
+export function clearTerminalClassification(): void {
+	_lastTerminal = null;
+}

--- a/tests/agent-state-protocol.test.ts
+++ b/tests/agent-state-protocol.test.ts
@@ -1,0 +1,569 @@
+/**
+ * `agent.state` v1 protocol emitter (design 1a′; impl plan WS1 Step 12,
+ * amendments R8/A9/A10/S3/Z3).
+ *
+ * Unit:
+ *  - frame shape/vectors from `createAgentStateProvider` (upstream mapping,
+ *    credentialSource label mapping, opaque generation echo, legacy
+ *    no-generation omission, launchdContract echo);
+ *  - resolver generation REPORTING (S3 — managed `generation` field /
+ *    SUTANDO_VOICE_CREDENTIAL_GENERATION; the agent never mints);
+ *  - lifecycle-file atomicity (A9 — temp+rename, unique temp names, a
+ *    cross-process reader never sees a torn write);
+ *  - Z3 isolated idle-restore (arm/fire/fence semantics).
+ *
+ * Integration (spawned agents against a temp workspace, offline — the fake
+ * key + file-triggered upstream-close injection make the classifier path
+ * deterministic without live Gemini):
+ *  - immediate v1 frame on every accepted real connection;
+ *  - repeat frame on an upstream transition (injected terminal close →
+ *    `failed`/`quota`/`quota-exceeded` through the REAL transport.onClose
+ *    seam — classifier mapping pinned end-to-end);
+ *  - `state/voice-lifecycle.json` published on attach/transition/detach;
+ *  - legacy spawn (no injected generation, no launchd marker): frame omits
+ *    `credentialGeneration` and `launchdContract`.
+ *
+ * NOTE (Step 11 seam): the pinned bodhi has no `?probe=1` interception yet —
+ * `probeState` is passed behind a feature-detect in voice-agent.ts and the
+ * probe-frame + live-call acceptance tests activate with the bodhi pin bump
+ * (impl plan PR group E).
+ */
+
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+	createAgentStateProvider,
+	createIsolatedIdleRestore,
+	credentialSourceLabel,
+	mapUpstream,
+	publishLifecycleSnapshot,
+	voiceLifecyclePath,
+	type AgentStateV1,
+} from '../src/voice-agent-state.ts';
+import { resolveCredential } from '../src/credential-resolver.ts';
+import type { ProtocolFailure } from '../src/voice-error-classifier.ts';
+
+const REPO_ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const FAKE_KEY = 'AIza-fake-key-for-agent-state-protocol-tests';
+const UPSTREAM_ENUM = ['live', 'idle', 'connecting', 'backoff', 'failed'];
+
+// ---------------------------------------------------------------------------
+// Unit: frame shape / vectors
+// ---------------------------------------------------------------------------
+
+function makeProvider(overrides: {
+	initialized?: boolean;
+	sessionState?: string;
+	clientAttached?: boolean;
+	backoffUntil?: number;
+	terminal?: ProtocolFailure | null;
+	source?: 'managed' | 'env' | 'none';
+	generation?: string;
+	launchdContract?: boolean;
+	now?: number;
+} = {}) {
+	return createAgentStateProvider({
+		initialized: () => overrides.initialized ?? true,
+		sessionState: () => overrides.sessionState ?? 'CLOSED',
+		clientAttached: () => overrides.clientAttached ?? false,
+		backoffUntil: () => overrides.backoffUntil ?? 0,
+		lastTerminalFailure: () => overrides.terminal ?? null,
+		credential: () => ({
+			source: overrides.source ?? 'env',
+			...(overrides.generation ? { credentialGeneration: overrides.generation } : {}),
+		}),
+		launchdContract: () => overrides.launchdContract ?? false,
+		now: () => overrides.now ?? 1_000_000,
+	});
+}
+
+describe('buildAgentState — frame shape and vectors (design 1a′)', () => {
+	it('base frame: exact v1 envelope, byok label, no optional fields', () => {
+		const frame = makeProvider().build();
+		assert.deepEqual(frame, {
+			type: 'agent.state',
+			v: 1,
+			initialized: true,
+			upstream: 'idle',
+			clientAttached: false,
+			credentialSource: 'byok',
+		});
+		// Legacy no-generation: the property must be ABSENT, not undefined.
+		assert.equal('credentialGeneration' in frame, false);
+		assert.equal('launchdContract' in frame, false);
+		assert.equal('reason' in frame, false);
+		assert.equal('category' in frame, false);
+	});
+
+	it('upstream vectors: ACTIVE/CONNECTING/RECONNECTING/TRANSFERRING/CLOSED', () => {
+		const vectors: Array<[Parameters<typeof makeProvider>[0], string]> = [
+			[{ sessionState: 'ACTIVE' }, 'live'],
+			[{ sessionState: 'CONNECTING' }, 'connecting'],
+			[{ sessionState: 'RECONNECTING' }, 'connecting'],
+			[{ sessionState: 'TRANSFERRING' }, 'connecting'],
+			[{ sessionState: 'CLOSED', clientAttached: true }, 'backoff'],
+			[{ sessionState: 'CLOSED', backoffUntil: 2_000_000 }, 'backoff'],
+			[{ sessionState: 'CLOSED' }, 'idle'],
+			[{ sessionState: 'CREATED' }, 'idle'],
+		];
+		for (const [inputs, expected] of vectors) {
+			const frame = makeProvider(inputs).build();
+			assert.equal(frame.upstream, expected, JSON.stringify(inputs));
+			assert.ok(UPSTREAM_ENUM.includes(frame.upstream));
+		}
+	});
+
+	it('terminal classification → failed with stable reason + category', () => {
+		const terminal: ProtocolFailure = { upstream: 'failed', reason: 'auth-invalid', category: 'auth' };
+		const frame = makeProvider({ sessionState: 'CLOSED', terminal, clientAttached: true }).build();
+		assert.equal(frame.upstream, 'failed');
+		assert.equal(frame.reason, 'auth-invalid');
+		assert.equal(frame.category, 'auth');
+	});
+
+	it('live ACTIVE wins over a stale terminal classification', () => {
+		const terminal: ProtocolFailure = { upstream: 'failed', reason: 'quota-exceeded', category: 'quota' };
+		const frame = makeProvider({ sessionState: 'ACTIVE', terminal }).build();
+		assert.equal(frame.upstream, 'live');
+		assert.equal('reason' in frame, false);
+	});
+
+	it('credentialSource label mapping (A10): managed/env/none', () => {
+		assert.equal(credentialSourceLabel('managed'), 'managed');
+		assert.equal(credentialSourceLabel('env'), 'byok');
+		assert.equal(credentialSourceLabel('none'), undefined);
+		assert.equal(makeProvider({ source: 'managed' }).build().credentialSource, 'managed');
+		assert.equal(makeProvider({ source: 'env' }).build().credentialSource, 'byok');
+		assert.equal('credentialSource' in makeProvider({ source: 'none' }).build(), false);
+	});
+
+	it('opaque generation is echoed verbatim, never derived (R7/S3)', () => {
+		const frame = makeProvider({ generation: 'cg1-0f9a3b2c-echo' }).build();
+		assert.equal(frame.credentialGeneration, 'cg1-0f9a3b2c-echo');
+	});
+
+	it('launchdContract:1 echoed only under the env marker (R17)', () => {
+		assert.equal(makeProvider({ launchdContract: true }).build().launchdContract, 1);
+		assert.equal('launchdContract' in makeProvider({ launchdContract: false }).build(), false);
+	});
+
+	it('mapUpstream: backoff only while the deadline is in the future', () => {
+		assert.equal(mapUpstream({ sessionState: 'CLOSED', clientAttached: false, backoffUntil: 999, terminal: null, now: 1000 }).upstream, 'idle');
+		assert.equal(mapUpstream({ sessionState: 'CLOSED', clientAttached: false, backoffUntil: 1001, terminal: null, now: 1000 }).upstream, 'backoff');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unit: resolver generation reporting (S3 — agent side)
+// ---------------------------------------------------------------------------
+
+describe('resolveCredential — generation reporting (S3)', () => {
+	const savedEnv: Record<string, string | undefined> = {};
+	const ENV_KEYS = ['GEMINI_VOICE_API_KEY', 'GEMINI_API_KEY', 'SUTANDO_VOICE_CREDENTIAL_GENERATION'];
+	const stash = () => { for (const k of ENV_KEYS) { savedEnv[k] = process.env[k]; delete process.env[k]; } };
+	const restore = () => {
+		for (const k of ENV_KEYS) {
+			if (savedEnv[k] === undefined) delete process.env[k];
+			else process.env[k] = savedEnv[k];
+		}
+	};
+
+	it('managed entry with a generation field reports it verbatim', () => {
+		stash();
+		try {
+			const dir = mkdtempSync(join(tmpdir(), 'agent-state-managed-'));
+			const managedPath = join(dir, 'managed-credentials.json');
+			writeFileSync(managedPath, JSON.stringify({
+				version: 1,
+				capabilities: { 'gemini-voice': { key: 'managed-key-1', generation: 'cg1-rust-minted-42' } },
+			}));
+			const r = resolveCredential('gemini-voice', { managedPath });
+			assert.equal(r.source, 'managed');
+			assert.equal(r.credentialGeneration, 'cg1-rust-minted-42');
+			rmSync(dir, { recursive: true, force: true });
+		} finally { restore(); }
+	});
+
+	it('legacy managed entry without generation omits the field', () => {
+		stash();
+		try {
+			const dir = mkdtempSync(join(tmpdir(), 'agent-state-managed-legacy-'));
+			const managedPath = join(dir, 'managed-credentials.json');
+			writeFileSync(managedPath, JSON.stringify({
+				version: 1,
+				capabilities: { 'gemini-voice': { key: 'managed-key-legacy' } },
+			}));
+			const r = resolveCredential('gemini-voice', { managedPath });
+			assert.equal(r.source, 'managed');
+			assert.equal('credentialGeneration' in r, false);
+			rmSync(dir, { recursive: true, force: true });
+		} finally { restore(); }
+	});
+
+	it('env key + injected SUTANDO_VOICE_CREDENTIAL_GENERATION reports it; without it, omits', () => {
+		stash();
+		try {
+			process.env.GEMINI_VOICE_API_KEY = 'byok-key-1';
+			process.env.SUTANDO_VOICE_CREDENTIAL_GENERATION = 'cg1-injected-7';
+			const withGen = resolveCredential('gemini-voice', { managedPath: '/nonexistent/managed.json' });
+			assert.equal(withGen.source, 'env');
+			assert.equal(withGen.credentialGeneration, 'cg1-injected-7');
+
+			delete process.env.SUTANDO_VOICE_CREDENTIAL_GENERATION;
+			const legacy = resolveCredential('gemini-voice', { managedPath: '/nonexistent/managed.json' });
+			assert.equal(legacy.source, 'env');
+			assert.equal('credentialGeneration' in legacy, false);
+		} finally { restore(); }
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unit: lifecycle snapshot atomicity (A9)
+// ---------------------------------------------------------------------------
+
+function frameFixture(overrides: Partial<AgentStateV1> = {}): AgentStateV1 {
+	return {
+		type: 'agent.state',
+		v: 1,
+		initialized: true,
+		upstream: 'idle',
+		clientAttached: false,
+		credentialSource: 'byok',
+		credentialGeneration: 'cg1-lifecycle-test',
+		...overrides,
+	};
+}
+
+describe('publishLifecycleSnapshot — atomic temp+rename (A9)', () => {
+	it('writes the derived snapshot schema and leaves no temp files behind', () => {
+		const ws = mkdtempSync(join(tmpdir(), 'agent-state-lifecycle-'));
+		try {
+			for (let i = 0; i < 50; i++) {
+				publishLifecycleSnapshot(ws, frameFixture({ upstream: i % 2 ? 'idle' : 'backoff' }), { now: () => 555 + i });
+			}
+			const snap = JSON.parse(readFileSync(voiceLifecyclePath(ws), 'utf-8'));
+			assert.deepEqual(snap, {
+				at: 604,
+				clientAttached: false,
+				initialized: true,
+				upstream: 'idle',
+				credentialSource: 'byok',
+				credentialGeneration: 'cg1-lifecycle-test',
+			});
+			// Unique temp names + rename: nothing but the target remains.
+			assert.deepEqual(readdirSync(join(ws, 'state')), ['voice-lifecycle.json']);
+		} finally { rmSync(ws, { recursive: true, force: true }); }
+	});
+
+	it('category included only for failed frames; write errors go to onError (never throw)', () => {
+		const ws = mkdtempSync(join(tmpdir(), 'agent-state-lifecycle-cat-'));
+		try {
+			publishLifecycleSnapshot(ws, frameFixture({ upstream: 'failed', reason: 'quota-exceeded', category: 'quota' }));
+			const snap = JSON.parse(readFileSync(voiceLifecyclePath(ws), 'utf-8'));
+			assert.equal(snap.upstream, 'failed');
+			assert.equal(snap.category, 'quota');
+			assert.equal('reason' in snap, false, 'snapshot schema carries category, not reason');
+
+			let seen: unknown = null;
+			// Unwritable workspace path (a file where the state dir should be).
+			const bogus = join(ws, 'not-a-dir');
+			writeFileSync(bogus, 'x');
+			publishLifecycleSnapshot(join(bogus, 'nested'), frameFixture(), { onError: (e) => { seen = e; } });
+			assert.ok(seen !== null, 'write failure surfaced via onError');
+		} finally { rmSync(ws, { recursive: true, force: true }); }
+	});
+
+	it('a concurrent cross-process reader never sees a torn write', async () => {
+		const ws = mkdtempSync(join(tmpdir(), 'agent-state-lifecycle-race-'));
+		mkdirSync(join(ws, 'state'), { recursive: true });
+		try {
+			// Child process hammers publishLifecycleSnapshot with alternating
+			// payload sizes; the parent reads concurrently — every read must
+			// parse. A plain writeFileSync writer fails this test.
+			const script = `
+				import { publishLifecycleSnapshot } from '${join(REPO_ROOT, 'src', 'voice-agent-state.ts').replace(/\\/g, '\\\\')}';
+				const ws = process.argv[1];
+				const big = 'cg1-' + 'x'.repeat(4000);
+				for (let i = 0; i < 300; i++) {
+					publishLifecycleSnapshot(ws, {
+						type: 'agent.state', v: 1, initialized: true,
+						upstream: i % 2 ? 'idle' : 'failed',
+						...(i % 2 ? {} : { category: 'quota' }),
+						clientAttached: false, credentialSource: 'byok',
+						credentialGeneration: i % 2 ? 'cg1-small' : big,
+					});
+				}
+			`;
+			const child = spawn('npx', ['tsx', '-e', script, ws], { cwd: REPO_ROOT, stdio: 'ignore' });
+			const exited = new Promise<number | null>((resolve) => child.once('exit', resolve));
+			const target = voiceLifecyclePath(ws);
+			let reads = 0;
+			let sawFile = false;
+			// Read as fast as we can while the child writes.
+			for (;;) {
+				if (existsSync(target)) {
+					sawFile = true;
+					const text = readFileSync(target, 'utf-8');
+					assert.doesNotThrow(() => JSON.parse(text), `torn read after ${reads} reads: ${text.slice(0, 80)}`);
+					reads++;
+				}
+				if (child.exitCode !== null) break;
+				await delay(1);
+			}
+			assert.equal(await exited, 0, 'writer child exited cleanly');
+			assert.ok(sawFile, 'reader observed the lifecycle file');
+			assert.ok(reads > 0, 'reader raced at least one write');
+		} finally { rmSync(ws, { recursive: true, force: true }); }
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unit: Z3 isolated idle restore
+// ---------------------------------------------------------------------------
+
+describe('createIsolatedIdleRestore — Z3 fence', () => {
+	it('arms after probe close and fires teardown when no real client arrives', async () => {
+		let toreDown = 0;
+		const restore = createIsolatedIdleRestore({
+			delayMs: 30,
+			clientAttached: () => false,
+			teardown: () => { toreDown++; },
+		});
+		restore.arm();
+		assert.equal(restore.pending(), true);
+		await delay(80);
+		assert.equal(toreDown, 1, 'teardown restored the prior idle state');
+		assert.equal(restore.pending(), false);
+	});
+
+	it('no-op while a real client is attached at arm time', async () => {
+		let toreDown = 0;
+		const restore = createIsolatedIdleRestore({ delayMs: 10, clientAttached: () => true, teardown: () => { toreDown++; } });
+		restore.arm();
+		assert.equal(restore.pending(), false);
+		await delay(40);
+		assert.equal(toreDown, 0);
+	});
+
+	it('a later real connection fences a pending restore', async () => {
+		let toreDown = 0;
+		const restore = createIsolatedIdleRestore({ delayMs: 30, clientAttached: () => false, teardown: () => { toreDown++; } });
+		restore.arm();
+		restore.fence(); // real client connected before the timer fired
+		assert.equal(restore.pending(), false);
+		await delay(80);
+		assert.equal(toreDown, 0, 'fenced restore must never tear down under a real client');
+	});
+
+	it('re-checks real attachment at fire time', async () => {
+		let attached = false;
+		let toreDown = 0;
+		const restore = createIsolatedIdleRestore({ delayMs: 30, clientAttached: () => attached, teardown: () => { toreDown++; } });
+		restore.arm();
+		attached = true; // client raced in without fence() (belt and braces)
+		await delay(80);
+		assert.equal(toreDown, 0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration: spawned voice-agent — frames + lifecycle file
+// ---------------------------------------------------------------------------
+
+const children: ChildProcess[] = [];
+const tempDirs: string[] = [];
+
+function makeWorkspace(tag: string): string {
+	const ws = mkdtempSync(join(tmpdir(), `agent-state-proto-${tag}-`));
+	tempDirs.push(ws);
+	return ws;
+}
+
+interface AgentHandle {
+	child: ChildProcess;
+	stderr: () => string;
+	stdout: () => string;
+}
+
+function spawnAgent(ws: string, port: number, visionPort: number, extraEnv: Record<string, string> = {}): AgentHandle {
+	const child = spawn('npx', ['tsx', 'src/voice-agent.ts'], {
+		cwd: REPO_ROOT,
+		detached: true,
+		env: {
+			...process.env,
+			SUTANDO_WORKSPACE: ws,
+			SUTANDO_TEST_MODE: '1',
+			GEMINI_VOICE_API_KEY: FAKE_KEY,
+			PORT: String(port),
+			VISION_CONTROL_PORT: String(visionPort),
+			...extraEnv,
+		},
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	children.push(child);
+	let out = '';
+	let err = '';
+	child.stdout?.on('data', (c) => { out += String(c); });
+	child.stderr?.on('data', (c) => { err += String(c); });
+	return { child, stderr: () => err, stdout: () => out };
+}
+
+async function killAndWait(child: ChildProcess): Promise<void> {
+	try { if (child.pid) process.kill(-child.pid, 'SIGKILL'); } catch { /* gone */ }
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	await new Promise<void>((resolve) => {
+		const hard = setTimeout(() => { try { child.kill('SIGKILL'); } catch {} resolve(); }, 2000);
+		child.once('exit', () => { clearTimeout(hard); resolve(); });
+		try { child.kill('SIGKILL'); } catch { clearTimeout(hard); resolve(); }
+	});
+}
+
+/** Connect a real WS client, retrying until the agent's server accepts. */
+async function connectClient(port: number, timeoutMs: number): Promise<WebSocket> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		try {
+			const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+			await new Promise<void>((resolve, reject) => {
+				ws.addEventListener('open', () => resolve(), { once: true });
+				ws.addEventListener('error', () => reject(new Error('connect failed')), { once: true });
+			});
+			return ws;
+		} catch {
+			if (Date.now() > deadline) throw new Error(`could not connect to ws://127.0.0.1:${port} within ${timeoutMs}ms`);
+			await delay(300);
+		}
+	}
+}
+
+/** Collect agent.state frames off a socket into an array (text frames only). */
+function collectFrames(ws: WebSocket): AgentStateV1[] {
+	const frames: AgentStateV1[] = [];
+	ws.addEventListener('message', (ev) => {
+		if (typeof ev.data !== 'string') return;
+		try {
+			const msg = JSON.parse(ev.data);
+			if (msg?.type === 'agent.state') frames.push(msg);
+		} catch { /* non-JSON frame */ }
+	});
+	return frames;
+}
+
+async function waitFor(cond: () => boolean, ms: number, what: string): Promise<void> {
+	const deadline = Date.now() + ms;
+	while (Date.now() < deadline) {
+		if (cond()) return;
+		await delay(150);
+	}
+	throw new Error(`timed out waiting for ${what}`);
+}
+
+function assertValidV1(frame: AgentStateV1, label: string): void {
+	assert.equal(frame.type, 'agent.state', label);
+	assert.equal(frame.v, 1, label);
+	assert.equal(typeof frame.initialized, 'boolean', label);
+	assert.equal(typeof frame.clientAttached, 'boolean', label);
+	assert.ok(UPSTREAM_ENUM.includes(frame.upstream), `${label}: upstream ${frame.upstream} in enum`);
+}
+
+describe('agent.state emission (integration, spawned agent)', () => {
+	after(async () => {
+		for (const c of children) await killAndWait(c);
+		for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+	});
+
+	it('immediate frame on connect; transition frame on injected terminal close; lifecycle file tracks it', async () => {
+		const ws = makeWorkspace('main');
+		const port = 19981;
+		const trigger = join(ws, 'close-trigger');
+		const GEN = 'cg1-11111111-2222-3333-4444-555555555555';
+		spawnAgent(ws, port, 19982, {
+			SUTANDO_VOICE_CREDENTIAL_GENERATION: GEN,
+			SUTANDO_VOICE_LAUNCHD_CONTRACT: '1',
+			// Injected close fires only when the trigger file appears — the
+			// quota reason pins the classifier's quota mapping end-to-end
+			// (the auth mapping is pinned in voice-error-classifier.test.ts
+			// and, opportunistically, by the fake key's own startup failure).
+			SUTANDO_TEST_UPSTREAM_CLOSE: `${trigger}|1011|You exceeded your current quota, please check your plan and billing details.`,
+		});
+
+		const client = await connectClient(port, 90_000);
+		try {
+			const frames = collectFrames(client);
+
+			// Step 12: immediate frame on every accepted real connection.
+			await waitFor(() => frames.length >= 1, 20_000, 'immediate agent.state frame');
+			const first = frames[0];
+			assertValidV1(first, 'immediate frame');
+			assert.equal(first.initialized, true, 'L2 initialized by the time a client can connect');
+			assert.equal(first.clientAttached, true, 'real client counted');
+			assert.equal(first.credentialSource, 'byok', 'env key maps to byok on the wire (A10)');
+			assert.equal(first.credentialGeneration, GEN, 'opaque generation echoed verbatim (S3)');
+			assert.equal(first.launchdContract, 1, 'launchd contract marker echoed (R17)');
+
+			// Lifecycle snapshot published (attach transition, A9).
+			await waitFor(() => existsSync(voiceLifecyclePath(ws)), 10_000, 'voice-lifecycle.json');
+
+			// Force an upstream transition through the REAL wrapped
+			// transport.onClose seam → classifier → failed/quota frame.
+			const before = frames.length;
+			writeFileSync(trigger, '1');
+			await waitFor(
+				() => frames.length > before && frames.some((f) => f.upstream === 'failed' && f.category === 'quota'),
+				20_000,
+				'transition frame with failed/quota',
+			);
+			const failedFrame = frames.find((f) => f.upstream === 'failed' && f.category === 'quota')!;
+			assertValidV1(failedFrame, 'transition frame');
+			assert.equal(failedFrame.reason, 'quota-exceeded', 'stable protocol reason code (R8)');
+			assert.equal(failedFrame.credentialGeneration, GEN);
+
+			// Lifecycle mirrors the terminal upstream (A9 + S3 fields).
+			await waitFor(() => {
+				try {
+					const snap = JSON.parse(readFileSync(voiceLifecyclePath(ws), 'utf-8'));
+					return snap.upstream === 'failed' && snap.category === 'quota';
+				} catch { return false; }
+			}, 10_000, 'lifecycle snapshot upstream=failed');
+			const snap = JSON.parse(readFileSync(voiceLifecyclePath(ws), 'utf-8'));
+			assert.equal(typeof snap.at, 'number');
+			assert.equal(snap.clientAttached, true);
+			assert.equal(snap.initialized, true);
+			assert.equal(snap.credentialSource, 'byok');
+			assert.equal(snap.credentialGeneration, GEN);
+		} finally {
+			client.close();
+		}
+
+		// Detach transition: lifecycle flips clientAttached → false (A9).
+		await waitFor(() => {
+			try { return JSON.parse(readFileSync(voiceLifecyclePath(ws), 'utf-8')).clientAttached === false; } catch { return false; }
+		}, 15_000, 'lifecycle clientAttached=false after disconnect');
+	});
+
+	it('legacy spawn (no injected generation, no launchd marker) omits both fields', async () => {
+		const ws = makeWorkspace('legacy');
+		const port = 19983;
+		spawnAgent(ws, port, 19984);
+
+		const client = await connectClient(port, 90_000);
+		try {
+			const frames = collectFrames(client);
+			await waitFor(() => frames.length >= 1, 20_000, 'immediate agent.state frame');
+			const first = frames[0];
+			assertValidV1(first, 'legacy frame');
+			assert.equal(first.credentialSource, 'byok');
+			assert.equal('credentialGeneration' in first, false, 'legacy env key stays generationless (S3)');
+			assert.equal('launchdContract' in first, false, 'no contract marker → no echo (R17)');
+		} finally {
+			client.close();
+		}
+	});
+});

--- a/tests/agent-state-protocol.test.ts
+++ b/tests/agent-state-protocol.test.ts
@@ -32,6 +32,7 @@
 import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer } from 'node:net';
 import { setTimeout as delay } from 'node:timers/promises';
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -392,6 +393,20 @@ interface AgentHandle {
 	stdout: () => string;
 }
 
+// Ephemeral free port (bind :0, read the assigned port, release) so parallel
+// CI runners or a stray listener never collide with a hardcoded number.
+function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const srv = createServer();
+		srv.on('error', reject);
+		srv.listen(0, '127.0.0.1', () => {
+			const addr = srv.address();
+			const p = typeof addr === 'object' && addr ? addr.port : 0;
+			srv.close(() => (p ? resolve(p) : reject(new Error('no port'))));
+		});
+	});
+}
+
 function spawnAgent(ws: string, port: number, visionPort: number, extraEnv: Record<string, string> = {}): AgentHandle {
 	const child = spawn('npx', ['tsx', 'src/voice-agent.ts'], {
 		cwd: REPO_ROOT,
@@ -481,10 +496,10 @@ describe('agent.state emission (integration, spawned agent)', () => {
 
 	it('immediate frame on connect; transition frame on injected terminal close; lifecycle file tracks it', async () => {
 		const ws = makeWorkspace('main');
-		const port = 19981;
+		const port = await freePort();
 		const trigger = join(ws, 'close-trigger');
 		const GEN = 'cg1-11111111-2222-3333-4444-555555555555';
-		spawnAgent(ws, port, 19982, {
+		spawnAgent(ws, port, await freePort(), {
 			SUTANDO_VOICE_CREDENTIAL_GENERATION: GEN,
 			SUTANDO_VOICE_LAUNCHD_CONTRACT: '1',
 			// Injected close fires only when the trigger file appears — the
@@ -550,8 +565,8 @@ describe('agent.state emission (integration, spawned agent)', () => {
 
 	it('legacy spawn (no injected generation, no launchd marker) omits both fields', async () => {
 		const ws = makeWorkspace('legacy');
-		const port = 19983;
-		spawnAgent(ws, port, 19984);
+		const port = await freePort();
+		spawnAgent(ws, port, await freePort());
 
 		const client = await connectClient(port, 90_000);
 		try {

--- a/tests/voice-error-classifier.test.ts
+++ b/tests/voice-error-classifier.test.ts
@@ -5,7 +5,13 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyTransportClose } from '../src/voice-error-classifier.ts';
+import {
+	classifyTransportClose,
+	protocolFailureFor,
+	recordTerminalClassification,
+	lastTerminalClassification,
+	clearTerminalClassification,
+} from '../src/voice-error-classifier.ts';
 
 test('credits_depleted: paid-tier prepayment exhausted', () => {
 	const r = classifyTransportClose(
@@ -78,4 +84,76 @@ test('rawCode and rawReason are preserved', () => {
 	const r = classifyTransportClose(1011, 'Your prepayment credits are depleted.');
 	assert.equal(r.rawCode, 1011);
 	assert.match(r.rawReason, /prepayment/);
+});
+
+// ---------------------------------------------------------------------------
+// `agent.state` protocol mapper + persisted terminal classification
+// (design 1a′; impl plan WS1 Step 12, amendment R8)
+// ---------------------------------------------------------------------------
+
+test('protocol mapper: auth_invalid → failed/auth with stable reason code', () => {
+	const c = classifyTransportClose(1011, 'API key not valid. Please pass a valid API key.');
+	const p = protocolFailureFor(c);
+	assert.deepEqual(p, { upstream: 'failed', reason: 'auth-invalid', category: 'auth' });
+});
+
+test('protocol mapper: quota_exceeded → failed/quota — distinct from auth', () => {
+	const c = classifyTransportClose(1011, 'You exceeded your current quota, please check your plan and billing details.');
+	const p = protocolFailureFor(c);
+	assert.deepEqual(p, { upstream: 'failed', reason: 'quota-exceeded', category: 'quota' });
+});
+
+test('protocol mapper: credits_depleted → failed/quota with its own reason code', () => {
+	const c = classifyTransportClose(1011, 'Your prepayment credits are depleted.');
+	const p = protocolFailureFor(c);
+	assert.deepEqual(p, { upstream: 'failed', reason: 'credits-depleted', category: 'quota' });
+});
+
+test('protocol mapper: model_not_found → failed/other', () => {
+	const c = classifyTransportClose(1011, 'models/gemini-3.1-flash-live-preview is not found for API version v1beta');
+	const p = protocolFailureFor(c);
+	assert.deepEqual(p, { upstream: 'failed', reason: 'model-not-found', category: 'other' });
+});
+
+test('protocol mapper: retryable classifications never map to failed', () => {
+	for (const [code, reason] of [
+		[1011, 'Too Many Requests: rate-limit exceeded'],
+		[1000, 'normal close'],
+		[1011, 'something we have not seen before'],
+		[undefined, undefined],
+	] as Array<[number | undefined, string | undefined]>) {
+		assert.equal(protocolFailureFor(classifyTransportClose(code, reason)), null,
+			`retryable close (${code}, ${reason}) must not map to failed`);
+	}
+});
+
+test('recordTerminalClassification persists ONLY terminal classifications for buildAgentState', () => {
+	clearTerminalClassification();
+	assert.equal(lastTerminalClassification(), null);
+
+	// Retryable close: nothing recorded, returns null.
+	const r = recordTerminalClassification(classifyTransportClose(1011, 'rate-limit exceeded'));
+	assert.equal(r, null);
+	assert.equal(lastTerminalClassification(), null);
+
+	// Terminal close: recorded + returned.
+	const t = recordTerminalClassification(
+		classifyTransportClose(1011, 'API key not valid. Please pass a valid API key.'),
+	);
+	assert.deepEqual(t, { upstream: 'failed', reason: 'auth-invalid', category: 'auth' });
+	assert.deepEqual(lastTerminalClassification(), t);
+
+	// A later retryable close does NOT clear the persisted terminal one —
+	// the agent stays 'failed' until recovery (ACTIVE) clears it.
+	recordTerminalClassification(classifyTransportClose(1000, 'normal close'));
+	assert.deepEqual(lastTerminalClassification(), t);
+
+	// A later terminal close of a DIFFERENT category replaces it (auth → quota).
+	recordTerminalClassification(classifyTransportClose(1011, 'You exceeded your current quota'));
+	assert.deepEqual(lastTerminalClassification(),
+		{ upstream: 'failed', reason: 'quota-exceeded', category: 'quota' });
+
+	// Recovery clears.
+	clearTerminalClassification();
+	assert.equal(lastTerminalClassification(), null);
 });


### PR DESCRIPTION
Phase 1 / PR group C-partial of the desktop voice-reliability plan (ag2-space/ag2space-cinny-desktop#281, merged there). Structured per CONTRIBUTING.md ("The PR body should answer").

## Stack status

Parent #2684 merged as `1a3733aa`. This branch was rebuilt on that merge and current `main`, so the PR diff is now the child-only `agent.state`/lifecycle layer. Rebuild commits: `675c8b3d` (feature), `3daddc22` (ephemeral-port test fix), and `ea8a00c1` (regenerated source-map count). Intended next order: **this** → sonichi/bodhi_realtime_agent#27 → desktop #282.

## What changed, and why?

The desktop supervisor needs a truthful, streaming view of the agent's state (initialized? upstream live/idle/backoff/failed? which credential loaded?) to supervise without guessing — and the incident showed "port is open" proves nothing. This adds:

- **`src/voice-agent-state.ts`** — `buildAgentState()`: versioned frame `{type:'agent.state', v:1, initialized, upstream, reason?, category?, clientAttached, credentialSource?, credentialGeneration?, launchdContract?:1}`. `credentialSource` from the existing resolver result (`voiceApiKey()` signature untouched); `credentialGeneration` is **reported, never minted** (opaque, host-supplied); `launchdContract:1` echoed only under the env marker.
- **Classifier mapper** — extends `src/voice-error-classifier.ts` (auth/quota/credits/network → `{upstream:'failed', reason, category}`), persisting the last terminal classification; deliberately no second classifier.
- **`state/voice-lifecycle.json`** — atomic (temp+rename, unique temp names) crash-safe snapshot on every relevant transition; the desktop's call-aware decisions read this, not `voice-state.json`'s plain `writeFileSync`.
- **Z3 idle fence** — verifier/probe-role closes with no real client re-arm the isolated idle-teardown timer, fenced against a later real connection.

## What files should reviewers look at first?

`src/voice-agent-state.ts`, the `voice-error-classifier.ts` mapper additions, then the `voice-agent.ts` wiring (frame emission on connect + upstream transitions; lifecycle publisher; `probeState` behind a feature-detect).

## What user behavior or bug does this prove?

The supervisor/UI can distinguish "agent up but upstream dead (bad key/quota)" from "healthy idle" from "wedged" — the confusions that made the incident invisible.

## Feature/documentation consistency

N/A for `docs/` canonical documents: `docs/catalog.json` has no canonical doc for the agent wire protocol; the protocol's canonical spec is the desktop design doc (`docs/design-voice-reliability-and-onboarding.md`, 1a′, merged in the desktop repo) which governs this cross-repo feature; module-level docs are in the source headers here. `design-credential-capability-resolver.md` is unaffected (this PR *reads* the resolver's result; resolution semantics unchanged).

## Before/after evidence

Before: no `agent.state` frame exists (a probe/client learns only "socket opened"); `voice-lifecycle.json` doesn't exist; classifier verdicts die in the log.
After (bot-verify — suites don't exist at base, green at HEAD):

```
npx tsx --test tests/agent-state-protocol.test.ts     → 20 pass / 0 fail
  (frame vectors; S3 generation echo incl. legacy omission; lifecycle atomicity
   incl. cross-process torn-read; Z3 arm/fence; spawned-agent integration:
   immediate frame on connect, injected terminal close → failed/quota transition)
npx tsx --test tests/voice-error-classifier.test.ts   → 15 pass / 0 fail
```

## What tests did you run?

Post-rebuild on current `main`: `npx --no-install tsx --test tests/agent-state-protocol.test.ts tests/voice-error-classifier.test.ts` → 35/35; `python3 tests/src-map.test.py` → 25/25; `npx --no-install tsc --noEmit` → clean; `git diff origin/main...HEAD | bash scripts/review-checks.sh` → PASS. Integration tests use ephemeral ports (`3daddc22`).

## Live-path / voice manual evidence (owner, 2026-08-05)

This branch was the `engine/sutando` ref bundled into the desktop phase-1 verification DMG. Voice exercised over the rail mic **and** the room-header **Start Call → Voice** dropdown (force-tier menu rendered: T0-a/T0-b local rows, T1–2 direct n/a, T3 relay rows); real `work` round trips completed — transcript excerpt in #2684's evidence section (same live sessions, `data/conversation.sqlite`). Lifecycle transitions observed in the logs: `state=ACTIVE client=false` → 60 s idle → transport closed → `state=CLOSED` (clean idle teardown with the emitter active).

## Edge cases / non-happy paths checked

Legacy no-generation spawn (fields correctly absent, not undefined); torn-read race on the lifecycle file from a second process; terminal-close during an attached client (failed/quota frame streamed); `probeState` feature-detect is false at the current bodhi pin (no dead wiring).

## Migrations, config, rollback risks

Additive protocol + one new state file; older clients ignore unknown frames (documented fallback). No config changes; rollback = revert.

## Known gaps / follow-ups

Probe-frame + live-call acceptance tests activate with the bodhi pin bump (PR group E, sonichi/bodhi_realtime_agent#27); documented in the test header.

---

CLA: signed. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
