### PR TITLE
feat(voice-transport): fail-fast client hardening + canonical transport consolidation (voice plan WS1 Steps 15–18)

### DIFF
--- a/src/voice-connect-resolver.ts
+++ b/src/voice-connect-resolver.ts
@@ -48,7 +48,7 @@ export async function resolveVoiceEndpoint(
 ): Promise<VoiceEndpoint | null> {
 	const timeoutMs = opts.timeoutMs ?? 2500;
 	for (const ep of candidates) {
-		let ok = false;
+		let ok: boolean;
 		try {
 			ok = await withTimeout(opts.probe(ep.url), timeoutMs);
 		} catch {

--- a/src/voice-connect-resolver.ts
+++ b/src/voice-connect-resolver.ts
@@ -3,8 +3,8 @@
  * endpoint for "call your agent" so the user never chooses a tier.
  *
  * The candidate order encodes the tier ladder, best/fastest first:
- *   local core on this machine (Tier 0) → same-LAN core (Tier 0-LAN) →
- *   relay to the core (Tier 2b) → cloud daemon (Tier 1, always-available).
+ *   local (T0) → direct via Tailscale/LAN (T1–2) → relay/Element (T3).
+ *   Canonical taxonomy: docs/voice-tiers.md.
  * Each is PROBED in order; the first reachable wins. This is the "user never
  * picks a tier" behaviour: the app resolves the best available path invisibly
  * and only the latency/capability differs — never the agent's behaviour.
@@ -18,7 +18,7 @@
  * resolver falls through to the next tier.
  */
 
-export type VoiceTier = 'local' | 'lan' | 'relay' | 'cloud';
+export type VoiceTier = 'local' | 'tailnet' | 'lan' | 'relay' | 'cloud';
 
 export interface VoiceEndpoint {
 	tier: VoiceTier;
@@ -48,7 +48,7 @@ export async function resolveVoiceEndpoint(
 ): Promise<VoiceEndpoint | null> {
 	const timeoutMs = opts.timeoutMs ?? 2500;
 	for (const ep of candidates) {
-		let ok: boolean;
+		let ok = false;
 		try {
 			ok = await withTimeout(opts.probe(ep.url), timeoutMs);
 		} catch {
@@ -79,21 +79,69 @@ function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
 
 /**
  * Build the default candidate ladder for a user's own core. Any field omitted
- * is skipped (e.g. no LAN host known → no LAN candidate). `local` is always
- * first (best) and `cloud` last (the always-available fallback).
+ * is skipped (e.g. no tailnet host known → no tailnet candidate). `local` is
+ * always first (best) and `cloud` last (the always-available fallback).
+ *
+ * Two distinct ports matter:
+ *  - `localPort` (default 9900) is the voice-agent WS, bound to loopback on the
+ *    core — reachable ONLY from the same machine, so it backs the `local` tier.
+ *  - `proxyPort` (default 8080) is the core webUI's opt-in `/ws` proxy (guarded
+ *    by SUTANDO_LAN_SHARE, sonichi/sutando#2021). Off-localhost callers can't
+ *    reach loopback:9900, so tailnet/LAN candidates go through `:proxyPort/ws`.
+ *
+ * `tailnet` sits directly after `local`: a mesh-VPN (Tailscale) address is a
+ * superset of LAN — it reaches the core on the same network AND remotely, with a
+ * stable address — so it's preferred over the same-subnet-only `lan` path.
+ *
+ * A browser on an HTTPS page blocks insecure `ws://` to a non-localhost host
+ * (mixed content), so a directly-reachable core must be reached over `wss://`.
+ * The core advertises this: when it's fronted by `tailscale serve` (TLS on the
+ * MagicDNS name, sonichi/sutando#2035) it publishes an `https://<host>` endpoint,
+ * and `directWsUrl` turns that into `wss://<host>/ws`. A plain `http://host:port`
+ * or bare host stays `ws://…/ws` (native/non-browser clients); from a hosted page
+ * that probe simply fails and the resolver falls through — safe either way.
  */
+export function directWsUrl(endpoint: string, proxyPort: number): string {
+	// https://<host>  → wss://<host>/ws  (tailscale serve fronts :443, no port)
+	if (/^https:\/\//i.test(endpoint)) {
+		return `wss://${endpoint.replace(/^https:\/\//i, '').replace(/\/+$/, '')}/ws`;
+	}
+	// http://<host>[:port] → ws://<host>[:port]/ws  (preserve the advertised port)
+	if (/^http:\/\//i.test(endpoint)) {
+		return `ws://${endpoint.replace(/^http:\/\//i, '').replace(/\/+$/, '')}/ws`;
+	}
+	// bare host → assume the plain /ws proxy on proxyPort
+	return `ws://${endpoint}:${proxyPort}/ws`;
+}
+
 export function defaultCandidates(opts: {
-	localPort?: number;     // default 9900 (the local voice-agent WS port)
-	lanHost?: string;       // e.g. "192.168.1.20" — same-wifi core
+	localPort?: number;     // default 9900 (loopback voice-agent WS → local tier)
+	proxyPort?: number;     // default 8080 (webUI /ws proxy → off-localhost tiers)
+	tailnetHost?: string;   // "host.ts.net" | "https://host.ts.net" — mesh-VPN core (preferred)
+	lanHost?: string;       // "192.168.1.20" | "http://192.168.1.20:8080" — same-wifi core
 	relayWsUrl?: string;    // wss://relay/.../<agent> — Tier 2b bridge to the core
 	cloudUrl?: string;      // the Tier-1 cloud fallback
+	agentEndpoint?: string;  // target room-agent's advertised endpoint (https://<magicdns>) — identity-routed, wins over local
 }): VoiceEndpoint[] {
 	const port = opts.localPort ?? 9900;
+	const proxyPort = opts.proxyPort ?? 8080;
+	// Identity-routed: a specific room-agent advertised its endpoint. Dial THAT agent
+	// and never the generic local host (which would answer as the wrong agent). Element
+	// Call (relay/cloud) stays a valid fallback since it routes to the same agent.
+	if (opts.agentEndpoint) {
+		const ep: VoiceEndpoint[] = [
+			{ tier: 'tailnet', url: directWsUrl(opts.agentEndpoint, proxyPort), label: "this room's agent, direct over Tailscale (T1–2)" },
+		];
+		if (opts.relayWsUrl) ep.push({ tier: 'relay', url: opts.relayWsUrl, label: 'relay to the agent (T3)' });
+		if (opts.cloudUrl) ep.push({ tier: 'cloud', url: opts.cloudUrl, label: 'relay via Element (T3)' });
+		return ep;
+	}
 	const out: VoiceEndpoint[] = [
-		{ tier: 'local', url: `ws://localhost:${port}`, label: 'this machine (Tier 0)' },
+		{ tier: 'local', url: `ws://localhost:${port}`, label: 'this machine (T0 · local)' },
 	];
-	if (opts.lanHost) out.push({ tier: 'lan', url: `ws://${opts.lanHost}:${port}`, label: 'same network (Tier 0-LAN)' });
-	if (opts.relayWsUrl) out.push({ tier: 'relay', url: opts.relayWsUrl, label: 'relay to your core (Tier 2b)' });
-	if (opts.cloudUrl) out.push({ tier: 'cloud', url: opts.cloudUrl, label: 'cloud agent (Tier 1)' });
+	if (opts.tailnetHost) out.push({ tier: 'tailnet', url: directWsUrl(opts.tailnetHost, proxyPort), label: 'your core, direct over Tailscale (T1–2)' });
+	if (opts.lanHost) out.push({ tier: 'lan', url: directWsUrl(opts.lanHost, proxyPort), label: 'same network, direct (T1 · LAN)' });
+	if (opts.relayWsUrl) out.push({ tier: 'relay', url: opts.relayWsUrl, label: 'relay to your core (T3)' });
+	if (opts.cloudUrl) out.push({ tier: 'cloud', url: opts.cloudUrl, label: 'relay via Element (T3)' });
 	return out;
 }

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -860,6 +860,12 @@ fetch('http://localhost:7844/stand-identity').then(r=>r.json()).then(s=>{
 <div style="height:80px"></div>
 </div>
 
+<!-- The ONE canonical browser voice transport (src/web-voice-transport.ts),
+     served as a classic-script IIFE that installs the SutandoVoice global.
+     Loaded before the page script so SutandoVoice is defined when voice
+     wiring below runs. A 503 here (packaging error) logs to the console and
+     connectWs() reports it to the user. -->
+<script src="${BROWSER_TRANSPORT_ROUTE}"></script>
 <script>
 // ─── Config ───────────────────────────────────────────────
 let INPUT_RATE  = 16000;
@@ -969,7 +975,8 @@ document.addEventListener('visibilitychange', () => {
 });
 
 // ─── State ────────────────────────────────────────────────
-let ws = null;
+// Page-level AudioContext is for tool cues ONLY — the voice audio graph
+// (mic capture + playback) lives inside the canonical transport.
 let audioCtx = null;
 // Play a short, low-volume Web Audio blip to signal a tool/core invocation
 // (owner ask 2026-07-09). Reuses the AudioContext created on the call's user
@@ -1006,22 +1013,22 @@ function playToolCue(kind) {
     });
   } catch (e) {}
 }
-let micStream = null;
-let processor = null;
+// Voice session surface state. The audio pipeline + WS protocol live in the
+// canonical transport (SutandoVoice.VoiceTransport, loaded from
+// /web-voice-transport.js); the page keeps ONLY surface concerns: transcript
+// DOM, status text, stats mirror, reconnect policy, avatar analyser.
+let voice = null;               // SutandoVoice.VoiceTransport of the active session
 let connected = false;
 let reconnectAttempts = 0;
 const MAX_RECONNECT_ATTEMPTS = 5;
-let nextPlayTime = 0;
-let analyserNode = null;
+let analyserNode = null;        // playback AnalyserNode handed over via onAnalyser
 let speakingRAF = null;
-let activeSources = [];
-let playbackRate = 1.0;
-let bytesSent = 0;
+let bytesSent = 0;              // onStats mirror (stats panel + debug dump)
 let bytesRecv = 0;
-let audioChunksRecv = 0;
-let playChunkCount = 0;
-let statsTimer = null;
 let muted = false;
+let micAnnounced = false;       // one "Microphone active" system line per session
+let cleanupDone = true;         // doCleanup idempotence latch (reset on connect)
+let _voiceUrlOverride = null;   // takeoverVoice() one-shot URL override
 
 // Chrome STT state — provides real-time interim display; server STT replaces with final
 let recognition = null;
@@ -1773,9 +1780,10 @@ hydrateTaskHistory();
 startTaskPolling();
 
 function updateStats() {
+  // Fed by the transport's onStats (byte totals). Per-chunk detail lives in
+  // the debug log via the transport's onDebug audio channel.
   $('stats').textContent =
-    'Sent ' + fmtBytes(bytesSent) + ' / Recv ' + fmtBytes(bytesRecv) +
-    ' (' + audioChunksRecv + ' chunks, ' + playChunkCount + ' played)';
+    'Sent ' + fmtBytes(bytesSent) + ' / Recv ' + fmtBytes(bytesRecv);
 }
 
 function fmtBytes(n) {
@@ -1790,7 +1798,7 @@ function saveDebug() {
     config: { INPUT_RATE, OUTPUT_RATE, CAPTURE_BUF },
     audioCtxState: audioCtx?.state ?? null,
     audioCtxSampleRate: audioCtx?.sampleRate ?? null,
-    bytesSent, bytesRecv, audioChunksRecv, playChunkCount,
+    bytesSent, bytesRecv,
     log: debugLog,
   };
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -1802,94 +1810,9 @@ function saveDebug() {
   dbg('Debug data saved');
 }
 
-// ─── PCM helpers ──────────────────────────────────────────
-function downsample(input, fromRate, toRate) {
-  if (fromRate === toRate) return input;
-  const ratio = fromRate / toRate;
-  const len = Math.floor(input.length / ratio);
-  const out = new Float32Array(len);
-  for (let i = 0; i < len; i++) {
-    const pos = i * ratio;
-    const idx = Math.floor(pos);
-    const frac = pos - idx;
-    out[i] = input[idx] * (1 - frac) + (input[idx + 1] || 0) * frac;
-  }
-  return out;
-}
-
-function float32ToInt16(f32) {
-  const i16 = new Int16Array(f32.length);
-  for (let i = 0; i < f32.length; i++) {
-    const s = Math.max(-1, Math.min(1, f32[i]));
-    i16[i] = s < 0 ? (s * 0x8000) | 0 : (s * 0x7FFF) | 0;
-  }
-  return i16;
-}
-
-function int16ToFloat32(buf) {
-  const view = new DataView(buf);
-  const len = buf.byteLength / 2;
-  const out = new Float32Array(len);
-  for (let i = 0; i < len; i++) {
-    out[i] = view.getInt16(i * 2, true) / 32768;
-  }
-  return out;
-}
-
-// ─── Audio playback (gapless scheduling) ──────────────────
-function playChunk(arrayBuf) {
-  if (!audioCtx || audioCtx.state === 'closed') {
-    try {
-      audioCtx = new AudioContext();
-      dbg('playChunk: created new AudioContext: ' + audioCtx.sampleRate + ' Hz');
-    } catch (e) {
-      dbg('playChunk: failed to create AudioContext: ' + e, 'err');
-      return;
-    }
-  }
-  if (audioCtx.state === 'suspended') {
-    audioCtx.resume();
-    dbg('playChunk: resumed suspended audioCtx');
-  }
-
-  const f32 = int16ToFloat32(arrayBuf);
-  if (f32.length === 0) return;
-
-  try {
-    const audioBuf = audioCtx.createBuffer(1, f32.length, OUTPUT_RATE);
-    audioBuf.getChannelData(0).set(f32);
-
-    const src = audioCtx.createBufferSource();
-    src.buffer = audioBuf;
-    src.playbackRate.value = playbackRate;
-    if (!analyserNode) {
-      analyserNode = audioCtx.createAnalyser();
-      analyserNode.fftSize = 256;
-      analyserNode.connect(audioCtx.destination);
-      startSpeakingDetection();
-    }
-    src.connect(analyserNode);
-
-    const now = audioCtx.currentTime;
-    if (nextPlayTime < now) {
-      nextPlayTime = now + 0.05;
-    }
-    src.start(nextPlayTime);
-    nextPlayTime += audioBuf.duration / playbackRate;
-    activeSources.push(src);
-    src.onended = () => {
-      const idx = activeSources.indexOf(src);
-      if (idx >= 0) activeSources.splice(idx, 1);
-    };
-    playChunkCount++;
-
-    if (playChunkCount <= 5) {
-      dbg('Played chunk #' + playChunkCount + ': ' + f32.length + ' samples, scheduled at ' + nextPlayTime.toFixed(3) + 's (ctx.state=' + audioCtx.state + ')', 'audio');
-    }
-  } catch (err) {
-    dbg('playChunk error: ' + err.message, 'err');
-  }
-}
+// PCM DSP + gapless playback live in the canonical transport
+// (SutandoVoice — src/web-voice-transport.ts). The page receives the
+// playback AnalyserNode via onAnalyser for the avatar animation below.
 
 // ─── Speaking detection (avatar animation) ────────────────
 function startSpeakingDetection() {
@@ -2003,288 +1926,105 @@ function stopSpeakingDetection() {
   if (canvas) { var ctx = canvas.getContext('2d'); if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height); }
 }
 
-// ─── Microphone capture ───────────────────────────────────
-async function startMic() {
-  // Check if getUserMedia is available (requires HTTPS or localhost)
-  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-    const isLocalhost = window.location.hostname === 'localhost' || 
-                       window.location.hostname === '127.0.0.1' ||
-                       window.location.hostname === '[::1]';
-    const isHttps = window.location.protocol === 'https:';
-    
-    if (!isLocalhost && !isHttps) {
-      throw new Error('Microphone access requires HTTPS. Please access this page via HTTPS (https://your-domain.com) or use localhost. Modern browsers block getUserMedia on HTTP for security.');
-    } else {
-      throw new Error('Microphone access is not available in this browser. Please use a modern browser that supports getUserMedia.');
-    }
-  }
+// ─── Voice session wiring (canonical transport) ───────────
+// Mic capture, playback, WS protocol, connect timeout, and failure
+// classification all live in SutandoVoice.VoiceTransport (the canonical
+// src/web-voice-transport.ts served at /web-voice-transport.js). The page
+// supplies callbacks for its surface concerns and keeps reconnect policy.
 
-  micStream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: true,
-    }
-  });
-
-  const trackSettings = micStream.getAudioTracks()[0].getSettings();
-  dbg('Mic stream: ' + (trackSettings.sampleRate || '?') + ' Hz, device=' + (trackSettings.deviceId || '?').slice(0, 8));
-
-  // Reuse AudioContext created in toggle() on user gesture
-  if (!audioCtx || audioCtx.state === 'closed') {
-    audioCtx = new AudioContext();
-    dbg('Created new AudioContext: ' + audioCtx.sampleRate + ' Hz');
-  }
-  dbg('AudioContext state=' + audioCtx.state + ' sampleRate=' + audioCtx.sampleRate);
-
-  if (audioCtx.state === 'suspended') {
-    await audioCtx.resume();
-    dbg('AudioContext resumed');
-  }
-
-  const source = audioCtx.createMediaStreamSource(micStream);
-
-  processor = audioCtx.createScriptProcessor(CAPTURE_BUF, 1, 1);
-  let sendCount = 0;
-  processor.onaudioprocess = (e) => {
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    const raw = e.inputBuffer.getChannelData(0);
-    const down = downsample(raw, audioCtx.sampleRate, INPUT_RATE);
-    const pcm = float32ToInt16(down);
-    ws.send(pcm.buffer);
-    bytesSent += pcm.buffer.byteLength;
-    sendCount++;
-    if (sendCount <= 3) {
-      dbg('Sent mic #' + sendCount + ': ' + pcm.buffer.byteLength + 'B (' + down.length + ' samples @ ' + INPUT_RATE + 'Hz)', 'audio');
-    }
-  };
-
-  source.connect(processor);
-  const silence = audioCtx.createGain();
-  silence.gain.value = 0;
-  processor.connect(silence);
-  silence.connect(audioCtx.destination);
-
-  dbg('Mic capture started');
-  reconnectAttempts = 0;
-  addSystem('Microphone active — speak now.');
-
-  // Start Chrome STT for real-time interim display (server final replaces)
-  startChromeStt();
-}
-
-function stopMic() {
-  stopChromeStt();
-  if (processor) { processor.disconnect(); processor = null; }
-  if (micStream) { micStream.getTracks().forEach(t => t.stop()); micStream = null; }
-  // Don't close audioCtx here — playback may still be draining
-}
-
-// ─── WebSocket ────────────────────────────────────────────
 function connectWs() {
-  const url = $('wsUrl').value.trim();
+  const url = _voiceUrlOverride || $('wsUrl').value.trim();
+  _voiceUrlOverride = null;
   if (!url) return;
+  if (typeof SutandoVoice === 'undefined' || !SutandoVoice.VoiceTransport) {
+    // The classic <script> for /web-voice-transport.js failed (packaging
+    // error → 503; console already has the server-side reason).
+    setStatus('Voice unavailable', 'error');
+    addSystem('Voice transport failed to load (/web-voice-transport.js) — check the server logs, then reload this page.');
+    doCleanup({ keepStatus: true });
+    return;
+  }
 
   dbg('Connecting to ' + url);
   setStatus('Connecting...', '');
 
-  ws = new WebSocket(url);
-  ws.binaryType = 'arraybuffer';
+  voice = new SutandoVoice.VoiceTransport({
+    captureBuf: CAPTURE_BUF,
+    inputRate: INPUT_RATE,
+    outputRate: OUTPUT_RATE,
+    onStatus: onVoiceStatus,
+    onConnectFailure: onVoiceConnectFailure,
+    onDebug: function (msg, kind) { dbg(msg, kind); },
+    onTranscript: function (role, text, partial) { handleTranscript(role, text, partial); },
+    // turn.end and turn.interrupted need the same per-turn transcript reset
+    // here; the transport already handles the barge-in playback flush itself.
+    onTurnEnd: resetTurnTranscriptState,
+    onInterrupted: resetTurnTranscriptState,
+    onSessionConfig: function (inRate, outRate) {
+      INPUT_RATE = inRate;
+      OUTPUT_RATE = outRate;
+      dbg('Audio format configured: input=' + INPUT_RATE + 'Hz output=' + OUTPUT_RATE + 'Hz', 'event');
+    },
+    onProtocolMessage: handleProtocolMessage,
+    onMicError: function (name, message, friendly) { addSystem(friendly); },
+    onAnalyser: function (node) { analyserNode = node; startSpeakingDetection(); },
+    onStats: function (s) { bytesSent = s.bytesSent; bytesRecv = s.bytesRecv; updateStats(); },
+  });
+  // Fire-and-forget by contract: async outcomes arrive via the callbacks.
+  voice.connect(url).catch(function (e) {
+    dbg('connect failed: ' + e, 'err');
+    setStatus('Connection failed', 'error');
+    doCleanup({ keepStatus: true });
+  });
+}
 
-  ws.onopen = async () => {
-    dbg('WebSocket connected');
-    setStatus('Starting mic...', 'live');
-    try {
-      await startMic();
-      setStatus('Live — speak now', 'live');
-      statsTimer = setInterval(updateStats, 500);
-    } catch (err) {
-      dbg('Mic error: ' + (err && err.name ? err.name + ': ' : '') + err.message, 'err');
-      setStatus('Mic error', 'error');
-      // Not every failure is a permission denial — name the real cause so the user
-      // isn't sent to "browser settings" when the mic is merely busy or absent.
-      let micMsg;
-      switch (err && err.name) {
-        case 'NotAllowedError':
-        case 'SecurityError':
-          micMsg = 'Microphone access denied. Allow mic for this site in browser settings, then click Connect again.';
-          break;
-        case 'NotReadableError':
-        case 'AbortError':
-          micMsg = 'Microphone is in use by another app or tab (Zoom, Photo Booth, another tab, or a prior session). Close it, then click Connect again.';
-          break;
-        case 'NotFoundError':
-        case 'OverconstrainedError':
-          micMsg = 'No microphone found. Connect an input device and select it as the default in your OS sound settings, then Connect.';
-          break;
-        default:
-          micMsg = 'Microphone error (' + (err && err.name ? err.name : 'unknown') + '): ' + (err && err.message ? err.message : 'could not start capture') + '. Click Connect to retry.';
-      }
-      addSystem(micMsg);
-      connected = false;  // prevent auto-reconnect loop
-      ws.close();
+function resetTurnTranscriptState() {
+  // Remove orphaned Chrome STT interim — if server never finalized it,
+  // it's echo from the assistant's voice picked up by mic.
+  if (currentUserEl && currentUserEl.classList.contains('t-interim')) {
+    currentUserEl.remove();
+  }
+  currentUserEl = null;
+  currentAssistantEl = null;
+  serverUserTextReceived = false;
+}
+
+function onVoiceStatus(status, detail, close) {
+  if (status === 'connecting') {
+    setStatus(detail || 'Connecting...', '');
+    return;
+  }
+  if (status === 'live') {
+    setStatus(detail || 'Live', 'live');
+    // The transport emits exactly this detail when mic capture is up;
+    // announce once per session and start the Chrome interim-STT display.
+    if (!micAnnounced && detail === 'Live — speak now') {
+      micAnnounced = true;
+      reconnectAttempts = 0;
+      addSystem('Microphone active — speak now.');
+      startChromeStt();
     }
-  };
-
-  ws.onmessage = (event) => {
-    if (event.data instanceof ArrayBuffer) {
-      bytesRecv += event.data.byteLength;
-      audioChunksRecv++;
-      if (audioChunksRecv <= 5) {
-        dbg('Recv audio #' + audioChunksRecv + ': ' + event.data.byteLength + 'B', 'audio');
-      }
-      playChunk(event.data);
-    } else {
-      try {
-        const msg = JSON.parse(event.data);
-        dbg('Recv: ' + JSON.stringify(msg), 'event');
-
-        if (msg.type === 'session.config' && msg.audioFormat) {
-          INPUT_RATE = msg.audioFormat.inputSampleRate;
-          OUTPUT_RATE = msg.audioFormat.outputSampleRate;
-          dbg('Audio format configured: input=' + INPUT_RATE + 'Hz output=' + OUTPUT_RATE + 'Hz', 'event');
-        } else if (msg.type === 'transcript') {
-          handleTranscript(msg.role, msg.text, msg.partial !== false);
-        } else if (msg.type === 'turn.end') {
-          // Remove orphaned Chrome STT interim — if server never finalized it,
-          // it's echo from the assistant's voice picked up by mic.
-          if (currentUserEl && currentUserEl.classList.contains('t-interim')) {
-            currentUserEl.remove();
-          }
-          currentUserEl = null;
-          currentAssistantEl = null;
-          serverUserTextReceived = false;
-        } else if (msg.type === 'turn.interrupted') {
-          for (const s of activeSources) {
-            try { s.stop(); } catch {}
-          }
-          activeSources = [];
-          nextPlayTime = 0;
-          if (currentUserEl && currentUserEl.classList.contains('t-interim')) {
-            currentUserEl.remove();
-          }
-          currentUserEl = null;
-          currentAssistantEl = null;
-          serverUserTextReceived = false;
-        } else if (msg.type === 'gui.update') {
-          const guiData = msg.payload?.data;
-          if (guiData?.type === 'subprocess_log' && guiData.line) {
-            dbg('subprocess  ' + guiData.line, 'audio');
-          } else if (guiData?.type === 'image' && guiData.base64) {
-            const imgEl = document.createElement('div');
-            imgEl.className = 't-entry t-system';
-            const img = document.createElement('img');
-            const imgDataUrl = 'data:' + (guiData.mimeType || 'image/png') + ';base64,' + guiData.base64;
-            img.src = imgDataUrl;
-            img.alt = guiData.description || 'Generated image';
-            img.style.maxWidth = '100%';
-            img.style.borderRadius = '8px';
-            img.style.marginTop = '8px';
-            imgEl.appendChild(img);
-            const dlLink = document.createElement('a');
-            dlLink.className = 'btn-download';
-            dlLink.href = imgDataUrl;
-            const ext = (guiData.mimeType || 'image/png').split('/')[1] || 'png';
-            dlLink.download = 'generated-image-' + Date.now() + '.' + ext;
-            dlLink.textContent = 'Download image';
-            imgEl.appendChild(dlLink);
-            $('transcript').appendChild(imgEl);
-            scrollTranscript();
-            dbg('Image received via gui.update: ' + (guiData.description || '').slice(0, 50), 'event');
-          } else if (guiData?.type === 'video' && guiData.base64) {
-            const vidEl = document.createElement('div');
-            vidEl.className = 't-entry t-system';
-            const vidDataUrl = 'data:' + (guiData.mimeType || 'video/mp4') + ';base64,' + guiData.base64;
-            const video = document.createElement('video');
-            video.src = vidDataUrl;
-            video.controls = true;
-            video.autoplay = true;
-            video.muted = true;
-            video.style.maxWidth = '100%';
-            video.style.borderRadius = '8px';
-            video.style.marginTop = '8px';
-            if (guiData.description) {
-              const caption = document.createElement('div');
-              caption.style.fontSize = '12px';
-              caption.style.color = '#888';
-              caption.style.marginTop = '4px';
-              caption.textContent = guiData.description;
-              vidEl.appendChild(caption);
-            }
-            vidEl.appendChild(video);
-            const dlLink = document.createElement('a');
-            dlLink.className = 'btn-download';
-            dlLink.href = vidDataUrl;
-            const vidExt = (guiData.mimeType || 'video/mp4').split('/')[1] || 'mp4';
-            dlLink.download = 'generated-video-' + Date.now() + '.' + vidExt;
-            dlLink.textContent = 'Download video';
-            vidEl.appendChild(dlLink);
-            $('transcript').appendChild(vidEl);
-            scrollTranscript();
-            dbg('Video received via gui.update: ' + (guiData.description || '').slice(0, 50), 'event');
-          } else {
-            addSystem('[gui] ' + JSON.stringify(guiData));
-          }
-        } else if (msg.type === 'gui.command') {
-          if (msg.command === 'collapse_tasks') { collapseAllTasks(); }
-          else if (msg.command === 'expand_tasks') { Object.keys(taskMap).forEach(id => { if (taskMap[id].result) expandedTasks.add(id); }); renderTasks(); }
-        } else if (msg.type === 'gui.notification') {
-          addSystem('[notification] ' + (msg.payload?.message || ''));
-        } else if (msg.type === 'image') {
-          const imgEl = document.createElement('div');
-          imgEl.className = 't-entry t-system';
-          const img = document.createElement('img');
-          const legacyDataUrl = 'data:' + (msg.data.mimeType || 'image/png') + ';base64,' + msg.data.base64;
-          img.src = legacyDataUrl;
-          img.alt = msg.data.description || 'Generated image';
-          img.style.maxWidth = '100%';
-          img.style.borderRadius = '8px';
-          img.style.marginTop = '8px';
-          imgEl.appendChild(img);
-          const dlLink2 = document.createElement('a');
-          dlLink2.className = 'btn-download';
-          dlLink2.href = legacyDataUrl;
-          const ext2 = (msg.data.mimeType || 'image/png').split('/')[1] || 'png';
-          dlLink2.download = 'generated-image-' + Date.now() + '.' + ext2;
-          dlLink2.textContent = 'Download image';
-          imgEl.appendChild(dlLink2);
-          $('transcript').appendChild(imgEl);
-          scrollTranscript();
-          dbg('Image received: ' + (msg.data.description || '').slice(0, 50), 'event');
-        } else if (msg.type === 'speech_speed') {
-          const speeds = { slow: 0.85, normal: 1.0, fast: 1.2 };
-          playbackRate = speeds[msg.speed] || 1.0;
-          addSystem('[speed] Speech speed set to ' + msg.speed + ' (' + playbackRate + 'x)');
-        } else if (msg.type === 'session_end') {
-          addSystem('Session ended by voice command.');
-          dbg('session_end received — disconnecting', 'event');
-          connected = false; // prevent auto-reconnect
-          if (ws) { ws.close(); ws = null; }
-          doCleanup();
-        } else if (msg.type === 'task.status') {
-          updateTask(msg.taskId, msg.status, msg.text, msg.result);
-        } else if (msg.type === 'grounding') {
-          const chunks = msg.payload?.groundingChunks;
-          if (Array.isArray(chunks) && chunks.length > 0) {
-            const sources = chunks.map(c => c.web?.title || c.web?.uri || '').filter(Boolean).join(', ');
-            if (sources) addSystem('[sources] ' + sources);
-          }
-        }
-      } catch {
-        dbg('Bad JSON text frame', 'warn');
-      }
-    }
-  };
-
-  ws.onclose = (e) => {
-    dbg('WS closed: code=' + e.code + ' reason=' + e.reason);
+    return;
+  }
+  if (status === 'error') {
+    setStatus(detail || 'Error', 'error');
+    return;
+  }
+  if (status === 'superseded') {
+    // Close 4410 (superseded-by-takeover): a user-confirmed takeover moved
+    // the call to another surface. Terminal — never auto-reconnect into a
+    // fight over the call.
+    addSystem('Voice call moved to another surface (window or device).');
+    doCleanup({ keepStatus: true });
+    setStatus('Call moved', 'error');
+    return;
+  }
+  if (status === 'closed') {
     // Server-initiated clean close (goodbye code 4000) or user clicked Disconnect
-    const wasCleanDisconnect = !connected || e.code === 4000;
+    const wasCleanDisconnect = !connected || (close && close.code === 4000);
     // Always reset connected here so subsequent toggle calls (from auto-
     // reconnect or the external SSE toggle path) take the open-new-ws
-    // branch instead of seeing stale state. Without this, an unclean drop
-    // (e.g. voice-agent restart) leaves the page in a wedged state where
-    // ws=null but connected=true, requiring a hard reload to recover.
+    // branch instead of seeing stale state.
     connected = false;
     doCleanup();
     if (wasCleanDisconnect) {
@@ -2293,12 +2033,7 @@ function connectWs() {
       // Unexpected drop (Gemini timeout, voice-agent restart) — auto-reconnect with limit
       reconnectAttempts++;
       if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
-        addSystem('Still trying to connect. Common causes:');
-        addSystem('1. GEMINI_API_KEY not set — edit .env and add your key from ai.google.dev');
-        addSystem('2. Voice agent not running — run: bash src/startup.sh');
-        addSystem('3. Port 9900 blocked — check: lsof -i :9900');
-        addSystem('You can type commands below while reconnecting.');
-        addSystem('<a href="https://discord.gg/uZHWXXmrCS" target="_blank" style="color:#5865F2">Ask for help on Discord</a> · <a href="https://github.com/sonichi/sutando/issues" target="_blank" style="color:#4ecca3">Report an issue</a> · <span style="color:#8899a6;cursor:pointer;text-decoration:underline" onclick="copyLogs()">Copy logs</span>', true);
+        showVoiceTroubleshooting('Still trying to connect. Common causes:');
         setStatus('Reconnecting...', 'error');
         reconnectAttempts = 0;  // reset counter and keep retrying
       } else {
@@ -2313,23 +2048,176 @@ function connectWs() {
         }
       }, 3000);
     }
-  };
-
-  ws.onerror = () => {
-    dbg('WS error', 'err');
-    setStatus('Connection failed', 'error');
-    addSystem('Connection error — is the agent server running?');
-  };
+  }
 }
 
-function doCleanup() {
-  stopMic();
-  if (audioCtx && audioCtx.state !== 'closed') {
-    // Close audio context immediately — don't use a delayed timeout
-    // (a delayed null can race with reconnect and kill the new AudioContext)
-    if (audioCtx) { try { audioCtx.close(); } catch {} audioCtx = null; }
+function showVoiceTroubleshooting(lead) {
+  addSystem(lead);
+  addSystem('1. GEMINI_API_KEY not set — edit .env and add your key from ai.google.dev');
+  addSystem('2. Voice agent not running — run: bash src/startup.sh');
+  addSystem('3. Port 9900 blocked — check: lsof -i :9900');
+  addSystem('You can type commands below in the meantime.');
+  addSystem('<a href="https://discord.gg/uZHWXXmrCS" target="_blank" style="color:#5865F2">Ask for help on Discord</a> · <a href="https://github.com/sonichi/sutando/issues" target="_blank" style="color:#4ecca3">Report an issue</a> · <span style="color:#8899a6;cursor:pointer;text-decoration:underline" onclick="copyLogs()">Copy logs</span>', true);
+}
+
+// Terminal connect-attempt failures (design 1e): the transport latched the
+// 'error' status and suppressed its own close, so the page resets its UI here
+// — fail fast with actionable copy instead of the eternal reconnect spinner.
+function onVoiceConnectFailure(f) {
+  dbg('Voice connect failure: ' + f.kind + ' — ' + f.detail, 'err');
+  doCleanup({ keepStatus: true });
+  if (f.kind === 'mic-permission' || f.kind === 'mic-device' || f.kind === 'mic-other') {
+    return; // onMicError already printed the classified mic guidance
   }
-  setStatus('Text only', '');
+  if (f.kind === 'client-busy') {
+    // W5: voice is in use elsewhere — offer the user-confirmed take-over.
+    addSystem(f.detail + ' <span style="color:#4ecca3;cursor:pointer;text-decoration:underline" onclick="takeoverVoice()">Take over the call here</span>', true);
+    return;
+  }
+  addSystem(f.detail + (f.remediation ? ' ' + f.remediation : ''));
+  if (f.kind === 'timeout' || f.kind === 'connect-error') {
+    showVoiceTroubleshooting('Voice did not come up. Common causes:');
+  }
+}
+
+// W5 take-over affordance: the click IS the user confirmation. The challenger
+// reconnects with ?takeover=1; the server closes the incumbent with 4410
+// (its surface shows "call moved") and attaches us.
+function takeoverVoice() {
+  if (connected) return; // already in a call here
+  const url = $('wsUrl').value.trim();
+  if (!url) return;
+  const sep = url.indexOf('?') >= 0 ? '&' : '?';
+  _voiceUrlOverride = url + sep + 'takeover=1';
+  toggle();
+}
+window.takeoverVoice = takeoverVoice;
+
+// Non-audio protocol frames the transport forwards raw. Types the transport
+// itself owns (session.config, transcript, turn.*, agent.state) are handled
+// via the typed callbacks above and deliberately NOT re-handled here.
+function handleProtocolMessage(msg) {
+  if (!msg || !msg.type) return;
+  if (msg.type === 'gui.update') {
+    const guiData = msg.payload?.data;
+    if (guiData?.type === 'subprocess_log' && guiData.line) {
+      dbg('subprocess  ' + guiData.line, 'audio');
+    } else if (guiData?.type === 'image' && guiData.base64) {
+      const imgEl = document.createElement('div');
+      imgEl.className = 't-entry t-system';
+      const img = document.createElement('img');
+      const imgDataUrl = 'data:' + (guiData.mimeType || 'image/png') + ';base64,' + guiData.base64;
+      img.src = imgDataUrl;
+      img.alt = guiData.description || 'Generated image';
+      img.style.maxWidth = '100%';
+      img.style.borderRadius = '8px';
+      img.style.marginTop = '8px';
+      imgEl.appendChild(img);
+      const dlLink = document.createElement('a');
+      dlLink.className = 'btn-download';
+      dlLink.href = imgDataUrl;
+      const ext = (guiData.mimeType || 'image/png').split('/')[1] || 'png';
+      dlLink.download = 'generated-image-' + Date.now() + '.' + ext;
+      dlLink.textContent = 'Download image';
+      imgEl.appendChild(dlLink);
+      $('transcript').appendChild(imgEl);
+      scrollTranscript();
+      dbg('Image received via gui.update: ' + (guiData.description || '').slice(0, 50), 'event');
+    } else if (guiData?.type === 'video' && guiData.base64) {
+      const vidEl = document.createElement('div');
+      vidEl.className = 't-entry t-system';
+      const vidDataUrl = 'data:' + (guiData.mimeType || 'video/mp4') + ';base64,' + guiData.base64;
+      const video = document.createElement('video');
+      video.src = vidDataUrl;
+      video.controls = true;
+      video.autoplay = true;
+      video.muted = true;
+      video.style.maxWidth = '100%';
+      video.style.borderRadius = '8px';
+      video.style.marginTop = '8px';
+      if (guiData.description) {
+        const caption = document.createElement('div');
+        caption.style.fontSize = '12px';
+        caption.style.color = '#888';
+        caption.style.marginTop = '4px';
+        caption.textContent = guiData.description;
+        vidEl.appendChild(caption);
+      }
+      vidEl.appendChild(video);
+      const dlLink = document.createElement('a');
+      dlLink.className = 'btn-download';
+      dlLink.href = vidDataUrl;
+      const vidExt = (guiData.mimeType || 'video/mp4').split('/')[1] || 'mp4';
+      dlLink.download = 'generated-video-' + Date.now() + '.' + vidExt;
+      dlLink.textContent = 'Download video';
+      vidEl.appendChild(dlLink);
+      $('transcript').appendChild(vidEl);
+      scrollTranscript();
+      dbg('Video received via gui.update: ' + (guiData.description || '').slice(0, 50), 'event');
+    } else {
+      addSystem('[gui] ' + JSON.stringify(guiData));
+    }
+  } else if (msg.type === 'gui.command') {
+    if (msg.command === 'collapse_tasks') { collapseAllTasks(); }
+    else if (msg.command === 'expand_tasks') { Object.keys(taskMap).forEach(id => { if (taskMap[id].result) expandedTasks.add(id); }); renderTasks(); }
+  } else if (msg.type === 'gui.notification') {
+    addSystem('[notification] ' + (msg.payload?.message || ''));
+  } else if (msg.type === 'image') {
+    const imgEl = document.createElement('div');
+    imgEl.className = 't-entry t-system';
+    const img = document.createElement('img');
+    const legacyDataUrl = 'data:' + (msg.data.mimeType || 'image/png') + ';base64,' + msg.data.base64;
+    img.src = legacyDataUrl;
+    img.alt = msg.data.description || 'Generated image';
+    img.style.maxWidth = '100%';
+    img.style.borderRadius = '8px';
+    img.style.marginTop = '8px';
+    imgEl.appendChild(img);
+    const dlLink2 = document.createElement('a');
+    dlLink2.className = 'btn-download';
+    dlLink2.href = legacyDataUrl;
+    const ext2 = (msg.data.mimeType || 'image/png').split('/')[1] || 'png';
+    dlLink2.download = 'generated-image-' + Date.now() + '.' + ext2;
+    dlLink2.textContent = 'Download image';
+    imgEl.appendChild(dlLink2);
+    $('transcript').appendChild(imgEl);
+    scrollTranscript();
+    dbg('Image received: ' + (msg.data.description || '').slice(0, 50), 'event');
+  } else if (msg.type === 'speech_speed') {
+    const speeds = { slow: 0.85, normal: 1.0, fast: 1.2 };
+    const rate = speeds[msg.speed] || 1.0;
+    if (voice) voice.setPlaybackRate(rate);
+    addSystem('[speed] Speech speed set to ' + msg.speed + ' (' + rate + 'x)');
+  } else if (msg.type === 'session_end') {
+    addSystem('Session ended by voice command.');
+    dbg('session_end received — disconnecting', 'event');
+    connected = false; // prevent auto-reconnect
+    // disconnect() emits one synchronous 'closed'; the status handler
+    // sees connected=false → clean path ("Disconnected.", no retry).
+    if (voice) { voice.disconnect(); }
+    doCleanup();
+  } else if (msg.type === 'task.status') {
+    updateTask(msg.taskId, msg.status, msg.text, msg.result);
+  } else if (msg.type === 'grounding') {
+    const chunks = msg.payload?.groundingChunks;
+    if (Array.isArray(chunks) && chunks.length > 0) {
+      const sources = chunks.map(c => c.web?.title || c.web?.uri || '').filter(Boolean).join(', ');
+      if (sources) addSystem('[sources] ' + sources);
+    }
+  }
+}
+
+// Page-surface reset after a voice session ends (any path: user disconnect,
+// server close, terminal failure, takeover). The TRANSPORT owns mic/playback/
+// audio-graph teardown; this only resets what the page itself put up.
+// Idempotent via cleanupDone — several paths may reach it for one session.
+function doCleanup(opts) {
+  if (cleanupDone) return;
+  cleanupDone = true;
+  const keepStatus = opts && opts.keepStatus; // preserve an error status line
+  voice = null; // drop the handle — a dead session must not be reused
+  stopChromeStt();
+  if (!keepStatus) setStatus('Text only', '');
   connected = false;
   muted = false;
   fetch('/mute-state?muted=false&voice=false').catch(() => {}); // Reset state on disconnect
@@ -2345,7 +2233,6 @@ function doCleanup() {
   stopVisionPoll();
   $('voice-status').className = 'status-pill voice-off';
   try { sessionStorage.removeItem('sutando-voice'); } catch {}
-  if (statsTimer) { clearInterval(statsTimer); statsTimer = null; }
   updateStats();
 }
 
@@ -2625,9 +2512,11 @@ window.toggleWatch = toggleWatch;
 
 // ─── Mute toggle ──────────────────────────────────────────
 function toggleMute() {
-  if (!micStream) return;
+  if (!voice || !connected) return;
   muted = !muted;
-  micStream.getAudioTracks().forEach(t => { t.enabled = !muted; });
+  // Transport call-control gate (also flips the track so the OS mic
+  // indicator reflects the mute).
+  voice.setMicMuted(muted);
   const btn = document.getElementById('btn-mute');
   btn.textContent = muted ? 'Unmute' : 'Mute';
   btn.className = muted ? 'btn-mute muted' : 'btn-mute';
@@ -2680,10 +2569,17 @@ setInterval(reportAgentState, 1000);
 // ─── UI toggle (user gesture context!) ────────────────────
 function toggle() {
   if (connected) {
-    if (ws) { ws.close(); ws = null; }
-    doCleanup();
+    // Set connected=false BEFORE disconnect(): the transport synchronously
+    // emits one 'closed', and the status handler must read it as a clean
+    // user stop (no auto-reconnect).
+    connected = false;
+    const v = voice;
+    if (v) v.disconnect();
+    doCleanup(); // idempotent — no-op when the closed handler already ran
   } else {
-    // Create AudioContext if not already created (may exist from page load or prior toggle)
+    // Page-level AudioContext (tool cues) on the user gesture; the transport
+    // creates its own voice audio graph inside connect(), also within this
+    // gesture's synchronous call stack.
     if (!audioCtx || audioCtx.state === 'closed') {
       audioCtx = new AudioContext();
     } else if (audioCtx.state === 'suspended') {
@@ -2691,12 +2587,11 @@ function toggle() {
     }
     dbg('AudioContext: state=' + audioCtx.state + ' sampleRate=' + audioCtx.sampleRate);
 
-    // Reset counters
-    nextPlayTime = 0;
+    // Reset per-session surface state
     bytesSent = 0;
     bytesRecv = 0;
-    audioChunksRecv = 0;
-    playChunkCount = 0;
+    micAnnounced = false;
+    cleanupDone = false;
 
     connected = true;
     muted = false;
@@ -2904,9 +2799,8 @@ function sendText() {
   scrollTranscript(true);
   input.value = '';
 
-  if (ws && ws.readyState === WebSocket.OPEN) {
-    // Voice connected — send through voice agent
-    ws.send(JSON.stringify({ type: 'text_input', text }));
+  if (voice && voice.sendTextInput(text)) {
+    // Voice connected — sent through the voice agent's live socket
     dbg('Sent text via voice: "' + text.slice(0, 50) + '"', 'event');
   } else {
     // Voice disconnected — route through task bridge (same as Telegram/Discord)

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -58,7 +58,16 @@
  *     that resolves once the underlying socket's real close handshake
  *     completes (bounded), so lease owners can await teardown before
  *     releasing exclusivity — the synchronous `closed` status still fires
- *     first, exactly as before.
+ *     first, exactly as before;
+ *   - EVERY attempt conclusion exposes that same completion via
+ *     `closeSettled()` (T8 generalized): self-initiated terminal closes
+ *     (connect timeout, mic failure, pre-open socket error, upstream-failed)
+ *     track their socket's real close handshake exactly like disconnect(),
+ *     and close-derived conclusions (statuses decoded from a WS close frame)
+ *     are already settled when they emit. After any terminal status /
+ *     onConnectFailure, consumers releasing single-client resources must
+ *     await closeSettled() before releasing, or the server may still count
+ *     the departing client (spurious 4409 on the next attempt).
  *
  * The DSP functions are pure and exported standalone so they unit-test in Node
  * (see tests/web-voice-transport.test.ts). The class is drivable from node:test
@@ -333,6 +342,13 @@ export interface VoiceTransportEvents {
    * Fires alongside the latched `error` status; surfaces route on `kind`
    * (mic-permission → permission flow, agent-failed/timeout → voice setup,
    * client-busy → take-over affordance, …).
+   *
+   * Lease-release contract (P1): after this fires (or any terminal status),
+   * `closeSettled()` settles once the underlying socket's close handshake is
+   * done — already resolved for close-derived conclusions, tracked (bounded)
+   * for self-initiated terminal closes. Consumers releasing single-client
+   * resources (e.g. a voice lease) must await it before releasing, or the
+   * server may still count this client and reject the next attempt with 4409.
    */
   onConnectFailure?(failure: VoiceConnectFailure): void;
   /**
@@ -463,6 +479,9 @@ export class VoiceTransport {
   private agentStateSeen = false;
   private legacyServer = false;
   private lastUpstream: AgentUpstreamState | null = null;
+  /** Current attempt-conclusion close completion — see closeSettled(). Starts
+   *  resolved: no socket ever existed. */
+  private closeCompletion: Promise<void> = Promise.resolve();
 
   // Debug-panel counters. They exist to bound the trace output (first N only),
   // not as protocol state — the surface reads byte totals from onStats.
@@ -625,9 +644,12 @@ export class VoiceTransport {
    * underlying WebSocket's real close handshake completes — i.e. the socket's
    * own `close` event has fired — so lease owners can await teardown before
    * releasing exclusivity. The synchronous behavior above is unchanged and the
-   * synchronous `closed` status always fires BEFORE the promise resolves. With
-   * no socket, or one already CLOSED, the promise resolves immediately; a
-   * wedged handshake is bounded by `disconnectCloseTimeoutMs` (default
+   * synchronous `closed` status always fires BEFORE the promise resolves. An
+   * already-CLOSED socket resolves immediately; with no socket the current
+   * attempt-conclusion completion is returned (immediately resolved unless a
+   * terminal latch already closed a socket whose handshake is still in
+   * flight — so `await disconnect()` always covers the last real teardown);
+   * a wedged handshake is bounded by `disconnectCloseTimeoutMs` (default
    * DISCONNECT_CLOSE_TIMEOUT_MS) so teardown can never hang.
    */
   disconnect(): Promise<void> {
@@ -637,37 +659,7 @@ export class VoiceTransport {
     const emitClosed = this.attemptActive && !this.terminal;
     this.attemptActive = false;
     const ws = this.ws;
-    let completion: Promise<void>;
-    if (!ws || ws.readyState === WebSocket.CLOSED) {
-      // Nothing to hand-shake: no socket, or its close already completed.
-      completion = Promise.resolve();
-    } else {
-      // Listen for the socket's REAL close event — attached BEFORE close() is
-      // called and BEFORE this.ws is cleared. The wsFactory seam guarantees
-      // only the onopen/onmessage/onerror/onclose property surface (fakes
-      // provide no addEventListener), so wrap the current onclose handler:
-      // it is connect()'s generation-fenced closure, already a guaranteed
-      // no-op after the bump above, and close fires at most once.
-      completion = new Promise<void>((resolve) => {
-        let settled = false;
-        let fallback: ReturnType<typeof setTimeout> | null = null;
-        const settle = (): void => {
-          if (settled) return;
-          settled = true;
-          if (fallback) clearTimeout(fallback);
-          resolve();
-        };
-        fallback = setTimeout(settle, this.disconnectCloseTimeoutMs);
-        const prevOnClose = ws.onclose;
-        ws.onclose = (event: CloseEvent) => {
-          try {
-            if (prevOnClose) prevOnClose.call(ws, event);
-          } finally {
-            settle();
-          }
-        };
-      });
-    }
+    const completion = this.trackCloseCompletion(ws);
     if (ws) {
       try {
         ws.close();
@@ -687,6 +679,72 @@ export class VoiceTransport {
    *  the same awaitable close-handshake completion (T8). */
   close(): Promise<void> {
     return this.disconnect();
+  }
+
+  /**
+   * Track the REAL close-handshake completion of a socket this side is about
+   * to close (factored from disconnect(); T8, generalized by the P1 fix to
+   * every self-initiated terminal close). The returned promise resolves once
+   * the socket's own `close` event has fired; a wedged handshake is bounded
+   * by `disconnectCloseTimeoutMs`. Must be called BEFORE `close()` and BEFORE
+   * `this.ws` is cleared. The wsFactory seam guarantees only the
+   * onopen/onmessage/onerror/onclose property surface (fakes provide no
+   * addEventListener), so this wraps the current onclose handler: it is
+   * connect()'s generation-fenced closure — already a guaranteed no-op once
+   * the caller has bumped the generation — and close fires at most once.
+   * The result is latched as the attempt-conclusion completion returned by
+   * `closeSettled()`; an already-CLOSED socket latches an immediately
+   * resolved completion, and with no socket the prior completion is kept
+   * (nothing new to hand-shake).
+   */
+  private trackCloseCompletion(ws: WebSocket | null): Promise<void> {
+    if (!ws) return this.closeCompletion;
+    if (ws.readyState === WebSocket.CLOSED) {
+      // Nothing to hand-shake: the socket's close already completed.
+      this.closeCompletion = Promise.resolve();
+      return this.closeCompletion;
+    }
+    const completion = new Promise<void>((resolve) => {
+      let settled = false;
+      let fallback: ReturnType<typeof setTimeout> | null = null;
+      const settle = (): void => {
+        if (settled) return;
+        settled = true;
+        if (fallback) clearTimeout(fallback);
+        resolve();
+      };
+      fallback = setTimeout(settle, this.disconnectCloseTimeoutMs);
+      const prevOnClose = ws.onclose;
+      ws.onclose = (event: CloseEvent) => {
+        try {
+          if (prevOnClose) prevOnClose.call(ws, event);
+        } finally {
+          settle();
+        }
+      };
+    });
+    this.closeCompletion = completion;
+    return completion;
+  }
+
+  /**
+   * The CURRENT attempt-conclusion close completion (P1 lease-release
+   * contract). After ANY terminal status / onConnectFailure, the returned
+   * promise settles once the underlying socket's close handshake is done:
+   * self-initiated terminal closes (connect timeout, mic failure, pre-open
+   * socket error, upstream-failed) track their own socket's close exactly
+   * like disconnect() does — the completion is latched BEFORE the terminal
+   * status/failure emits, so it can be read from inside the callbacks —
+   * while close-derived conclusions ('closed'/'error'/'superseded' decoded
+   * from a WS close frame) are already settled when they emit, because the
+   * socket is already closed. Resolved immediately when no socket ever
+   * existed; bounded by `disconnectCloseTimeoutMs`, so it can never hang.
+   * Consumers releasing single-client resources (e.g. a voice lease) MUST
+   * await this before releasing, or the server may still count the departing
+   * client and reject the next attempt with 4409.
+   */
+  closeSettled(): Promise<void> {
+    return this.closeCompletion;
   }
 
   /**
@@ -745,15 +803,22 @@ export class VoiceTransport {
     this.terminal = true;
     this.attemptActive = false;
     this.teardownAudio();
+    // P1: latch the close-handshake completion BEFORE the terminal status/
+    // failure emit, so closeSettled() read from inside the callbacks is
+    // already THIS conclusion's completion (a lease released before the
+    // handshake finishes leaves the server counting the old client →
+    // spurious 4409 on the next attempt).
+    const ws = this.ws;
+    this.trackCloseCompletion(ws);
     this.status('error', detail);
     this.emitFailure({
       kind: 'timeout',
       detail,
       remediation: VOICE_FAILURE_REMEDIATION.timeout,
     });
-    if (this.ws) {
+    if (ws) {
       try {
-        this.ws.close();
+        ws.close();
       } catch {
         /* already closed */
       }
@@ -799,6 +864,9 @@ export class VoiceTransport {
       this.attemptActive = false;
       this.clearLegacyTimer();
       this.teardownAudio();
+      // P1: latch the self-inflicted close-handshake completion before any
+      // callback emits (see onConnectTimeout).
+      this.trackCloseCompletion(ws);
       this.status('error', 'Mic error');
       this.ev.onMicError?.(name, err?.message ?? '', friendly);
       this.emitFailure({ kind, detail: friendly, remediation: VOICE_FAILURE_REMEDIATION[kind] });
@@ -827,15 +895,20 @@ export class VoiceTransport {
       this.attemptActive = false;
       this.clearConnectTimer();
       this.teardownAudio();
+      // P1: latch the close-handshake completion before the terminal emits
+      // (see onConnectTimeout). The browser's trailing 1006 close lands on
+      // the wrapped handler and settles it.
+      const ws = this.ws;
+      this.trackCloseCompletion(ws);
       this.status('error', detail);
       this.emitFailure({
         kind: 'connect-error',
         detail,
         remediation: VOICE_FAILURE_REMEDIATION['connect-error'],
       });
-      if (this.ws) {
+      if (ws) {
         try {
-          this.ws.close();
+          ws.close();
         } catch {
           /* already closed */
         }
@@ -863,6 +936,13 @@ export class VoiceTransport {
     // overwrite the close-derived status emitted below, the just-granted mic
     // stream would stay captured, and the statsTimer would leak.
     this.attemptGen++;
+    // P1: a close-derived conclusion needs no handshake tracking — the event
+    // driving this method IS the socket's close, so the attempt-conclusion
+    // completion is already settled by definition (closeSettled() resolves
+    // immediately for every status emitted below). Self-initiated terminal
+    // closes never reach here: their tracking wrapper replaced this socket's
+    // onclose.
+    this.closeCompletion = Promise.resolve();
     if (this.terminal) {
       // Latched terminal attempt (timeout / mic / pre-open error /
       // upstream-failed / client-busy / superseded): the self-inflicted or
@@ -969,6 +1049,9 @@ export class VoiceTransport {
         this.clearConnectTimer();
         this.teardownAudio();
         const ws = this.ws;
+        // P1: latch the self-initiated close-handshake completion before the
+        // terminal status/failure emit (see onConnectTimeout).
+        this.trackCloseCompletion(ws);
         this.ws = null;
         if (ws) {
           try {

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -53,7 +53,12 @@
  *     a server that sends no frame within the legacy window simply behaves
  *     exactly as before the protocol existed;
  *   - every failed attempt is classified into the exported
- *     `VoiceConnectFailure` union exactly once via `onConnectFailure`.
+ *     `VoiceConnectFailure` union exactly once via `onConnectFailure`;
+ *   - teardown is awaitable (T8): `disconnect()`/`close()` return a promise
+ *     that resolves once the underlying socket's real close handshake
+ *     completes (bounded), so lease owners can await teardown before
+ *     releasing exclusivity — the synchronous `closed` status still fires
+ *     first, exactly as before.
  *
  * The DSP functions are pure and exported standalone so they unit-test in Node
  * (see tests/web-voice-transport.test.ts). The class is drivable from node:test
@@ -318,7 +323,9 @@ export interface VoiceTransportEvents {
    * every `'closed'` decoded from a WS close frame carries it, as do the
    * close-derived terminal states (`'error'` on 4409/pre-open closes,
    * `'superseded'` on 4410). A user-initiated `disconnect()` emits `'closed'`
-   * WITHOUT close info — no WS close frame is involved in that transition.
+   * WITHOUT close info — no WS close frame is involved in that transition
+   * (the promise `disconnect()` returns tracks the socket's real close
+   * handshake instead; the synchronous `closed` always fires first).
    */
   onStatus?(status: VoiceStatus, detail?: string, close?: VoiceCloseInfo): void;
   /**
@@ -370,6 +377,12 @@ export const CONNECT_TIMEOUT_MS = 6000;
  *  before the protocol existed. */
 export const AGENT_STATE_LEGACY_MS = 3000;
 
+/** Bound on the awaited close handshake in `disconnect()` (amendment T8): if
+ *  the socket's real `close` event never arrives within this window, the
+ *  returned teardown promise resolves anyway — a wedged handshake must not
+ *  hang lease release. */
+export const DISCONNECT_CLOSE_TIMEOUT_MS = 1500;
+
 export interface VoiceTransportOptions extends VoiceTransportEvents {
   /** Mic capture buffer size (ScriptProcessor). Default 2048, matching web-client. */
   captureBuf?: number;
@@ -383,6 +396,9 @@ export interface VoiceTransportOptions extends VoiceTransportEvents {
   connectTimeoutMs?: number;
   /** Legacy-detection window override (tests). Default AGENT_STATE_LEGACY_MS. */
   agentStateLegacyMs?: number;
+  /** Bound on disconnect()'s awaited close handshake (tests). Default
+   *  DISCONNECT_CLOSE_TIMEOUT_MS. */
+  disconnectCloseTimeoutMs?: number;
   /**
    * Socket factory seam so the state machine is drivable from node:test
    * without a browser. Default `new WebSocket(url)`. Fakes provide the
@@ -406,6 +422,7 @@ export class VoiceTransport {
   private playbackRate: number;
   private connectTimeoutMs: number;
   private agentStateLegacyMs: number;
+  private disconnectCloseTimeoutMs: number;
   private wsFactory: (url: string) => WebSocket;
 
   private ws: WebSocket | null = null;
@@ -461,6 +478,7 @@ export class VoiceTransport {
     this.playbackRate = opts.playbackRate ?? 1.0;
     this.connectTimeoutMs = opts.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
     this.agentStateLegacyMs = opts.agentStateLegacyMs ?? AGENT_STATE_LEGACY_MS;
+    this.disconnectCloseTimeoutMs = opts.disconnectCloseTimeoutMs ?? DISCONNECT_CLOSE_TIMEOUT_MS;
     this.wsFactory = opts.wsFactory ?? ((url: string) => new WebSocket(url));
   }
 
@@ -602,16 +620,57 @@ export class VoiceTransport {
    * in `connecting`/`live` forever. The terminal-ERROR cleanup path stays
    * separate: after a latched `error` (timeout / upstream-failed / mic),
    * disconnect() only cleans up and PRESERVES the latched error status.
+   *
+   * Amendment T8 (awaitable teardown): the RETURNED PROMISE resolves once the
+   * underlying WebSocket's real close handshake completes — i.e. the socket's
+   * own `close` event has fired — so lease owners can await teardown before
+   * releasing exclusivity. The synchronous behavior above is unchanged and the
+   * synchronous `closed` status always fires BEFORE the promise resolves. With
+   * no socket, or one already CLOSED, the promise resolves immediately; a
+   * wedged handshake is bounded by `disconnectCloseTimeoutMs` (default
+   * DISCONNECT_CLOSE_TIMEOUT_MS) so teardown can never hang.
    */
-  disconnect(): void {
+  disconnect(): Promise<void> {
     this.attemptGen++;
     this.clearConnectTimer();
     this.clearLegacyTimer();
     const emitClosed = this.attemptActive && !this.terminal;
     this.attemptActive = false;
-    if (this.ws) {
+    const ws = this.ws;
+    let completion: Promise<void>;
+    if (!ws || ws.readyState === WebSocket.CLOSED) {
+      // Nothing to hand-shake: no socket, or its close already completed.
+      completion = Promise.resolve();
+    } else {
+      // Listen for the socket's REAL close event — attached BEFORE close() is
+      // called and BEFORE this.ws is cleared. The wsFactory seam guarantees
+      // only the onopen/onmessage/onerror/onclose property surface (fakes
+      // provide no addEventListener), so wrap the current onclose handler:
+      // it is connect()'s generation-fenced closure, already a guaranteed
+      // no-op after the bump above, and close fires at most once.
+      completion = new Promise<void>((resolve) => {
+        let settled = false;
+        let fallback: ReturnType<typeof setTimeout> | null = null;
+        const settle = (): void => {
+          if (settled) return;
+          settled = true;
+          if (fallback) clearTimeout(fallback);
+          resolve();
+        };
+        fallback = setTimeout(settle, this.disconnectCloseTimeoutMs);
+        const prevOnClose = ws.onclose;
+        ws.onclose = (event: CloseEvent) => {
+          try {
+            if (prevOnClose) prevOnClose.call(ws, event);
+          } finally {
+            settle();
+          }
+        };
+      });
+    }
+    if (ws) {
       try {
-        this.ws.close();
+        ws.close();
       } catch {
         /* already closed */
       }
@@ -621,11 +680,13 @@ export class VoiceTransport {
     if (emitClosed) {
       this.status('closed', 'Disconnected');
     }
+    return completion;
   }
 
-  /** Alias for disconnect — teardown already closes the AudioContext. */
-  close(): void {
-    this.disconnect();
+  /** Alias for disconnect — teardown already closes the AudioContext. Returns
+   *  the same awaitable close-handshake completion (T8). */
+  close(): Promise<void> {
+    return this.disconnect();
   }
 
   /**

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -39,6 +39,11 @@
  * R10/R12/S6/W5/X6/Z6):
  *   - every `connect()` is one ATTEMPT with a generation token; stale socket
  *     callbacks and stale post-`await` continuations are silently discarded;
+ *   - attempt concluded ⇒ generation invalidated: EVERY path that concludes
+ *     an attempt (timeout, mic failure, pre-open error, every close branch,
+ *     upstream-failed, disconnect(), a superseding connect()) bumps the
+ *     generation, so a continuation parked in an `await` (getUserMedia
+ *     prompt, AudioContext.resume) can never resume a dead attempt;
  *   - a connect attempt that does not reach `onopen` within CONNECT_TIMEOUT_MS
  *     fails with a latched terminal `error`;
  *   - terminal failures LATCH: the close they trigger never overwrites the
@@ -310,8 +315,10 @@ export interface VoiceTransportEvents {
   /**
    * Connection lifecycle. `detail` is a human string for the status line.
    * `close` is present when the transition was decoded from a WS close frame:
-   * always for `status === 'closed'`, and for the close-derived terminal
-   * states (`'error'` on 4409/pre-open closes, `'superseded'` on 4410).
+   * every `'closed'` decoded from a WS close frame carries it, as do the
+   * close-derived terminal states (`'error'` on 4409/pre-open closes,
+   * `'superseded'` on 4410). A user-initiated `disconnect()` emits `'closed'`
+   * WITHOUT close info — no WS close frame is involved in that transition.
    */
   onStatus?(status: VoiceStatus, detail?: string, close?: VoiceCloseInfo): void;
   /**
@@ -422,8 +429,10 @@ export class VoiceTransport {
 
   // ── Attempt state (impl plan Step 18) ──
   // One `connect()` = one attempt. The generation token invalidates every
-  // stale socket callback and stale post-`await` continuation (R10); the
-  // terminal latch keeps a failed attempt's `error` from being overwritten by
+  // stale socket callback and stale post-`await` continuation (R10) — and the
+  // invariant is uniform: attempt concluded ⇒ generation invalidated, i.e.
+  // every concluding path bumps `attemptGen` (see handleClose). The terminal
+  // latch keeps a failed attempt's `error` from being overwritten by
   // its own self-inflicted close; `attemptActive` guarantees exactly one
   // final status per attempt (S6); `failureEmitted` guarantees exactly one
   // onConnectFailure per attempt.
@@ -505,6 +514,11 @@ export class VoiceTransport {
     }
     this.stopMic();
     this.stopStats();
+    // A direct connect() over a still-live session (no disconnect() between)
+    // must not let the old session's scheduled playback keep speaking into
+    // the new attempt — and nextPlayTime must restart from the new clock
+    // instead of continuing the old session's schedule.
+    this.flushPlayback();
 
     this.status('connecting', 'Connecting…');
 
@@ -663,8 +677,10 @@ export class VoiceTransport {
     if (gen !== this.attemptGen || this.terminal) return;
     const detail = 'Connection timed out';
     this.debug('Connect timeout after ' + this.connectTimeoutMs + 'ms', 'err');
-    // Terminal latch BEFORE closing: the self-inflicted onclose must see
-    // terminal=true and suppress its status emission.
+    // Attempt concluded ⇒ generation invalidated: the bump fences out the
+    // self-inflicted onclose and any stale continuation of this attempt; the
+    // terminal latch (set BEFORE closing) stays as the second line of defense.
+    this.attemptGen++;
     this.terminal = true;
     this.attemptActive = false;
     this.teardownAudio();
@@ -709,13 +725,23 @@ export class VoiceTransport {
       const kind: VoiceConnectFailureKind =
         code === 'permission' ? 'mic-permission' : code === 'device' ? 'mic-device' : 'mic-other';
       this.debug('Mic error: ' + (err?.name ? err.name + ': ' : '') + err?.message, 'err');
-      // Terminal for this attempt: the close we trigger below must not
-      // overwrite the error, and a hard mic failure must not auto-reconnect.
+      // Attempt concluded ⇒ generation invalidated: the bump fences out the
+      // self-inflicted onclose below and any continuation of this attempt
+      // still parked in an await; the terminal latch keeps the error from
+      // being overwritten, and a hard mic failure must not auto-reconnect.
+      // That same fencing means no trailing handleClose will clean up for
+      // this attempt — so tear the audio graph down HERE (startMic can have
+      // captured a stream before throwing, e.g. a resume() failure after
+      // getUserMedia was already granted).
+      this.attemptGen++;
       this.terminal = true;
       this.attemptActive = false;
+      this.clearLegacyTimer();
+      this.teardownAudio();
       this.status('error', 'Mic error');
       this.ev.onMicError?.(name, err?.message ?? '', friendly);
       this.emitFailure({ kind, detail: friendly, remediation: VOICE_FAILURE_REMEDIATION[kind] });
+      if (this.ws === ws) this.ws = null;
       try {
         ws.close();
       } catch {
@@ -730,9 +756,12 @@ export class VoiceTransport {
     if (!this.opened) {
       // Pre-open failure. The browser exposes no errno/TLS/DNS detail here
       // (Z6) — just a generic error followed by close 1006 — so this is the
-      // one browser-observable pre-open kind: 'connect-error'. Latch now so
-      // the trailing onclose can't overwrite the error with 'closed'.
+      // one browser-observable pre-open kind: 'connect-error'. Attempt
+      // concluded ⇒ generation invalidated: the bump fences the trailing
+      // 1006 close out at the closure; the terminal latch stays as the
+      // second line of defense against a 'closed' overwrite.
       const detail = 'Connection failed';
+      this.attemptGen++;
       this.terminal = true;
       this.attemptActive = false;
       this.clearConnectTimer();
@@ -764,11 +793,24 @@ export class VoiceTransport {
     this.debug('WS closed: code=' + code + ' reason=' + reason);
     this.clearConnectTimer();
     this.clearLegacyTimer();
+    // Attempt concluded ⇒ generation invalidated. Every branch below
+    // concludes the attempt, and the gen fence in connect()'s onclose closure
+    // guarantees this method only ever runs for the CURRENT attempt — so one
+    // unconditional bump covers them all. Without it, a continuation parked
+    // in startMic's getUserMedia/resume() await would sail past its gen fence
+    // once the prompt resolved: the dead attempt's status('live') would
+    // overwrite the close-derived status emitted below, the just-granted mic
+    // stream would stay captured, and the statsTimer would leak.
+    this.attemptGen++;
     if (this.terminal) {
       // Latched terminal attempt (timeout / mic / pre-open error /
       // upstream-failed / client-busy / superseded): the self-inflicted or
       // trailing close still tears the audio graph down, but must NOT
       // overwrite the latched status (design 1e terminal-state latching).
+      // Defense in depth: every latching path now bumps the generation
+      // itself, fencing its trailing close out at the closure before it
+      // reaches here — this branch stays as the net for any future
+      // terminal-setter that forgets.
       this.teardownAudio();
       return;
     }

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -10,7 +10,10 @@
  * web-voice-transport — the framework-agnostic browser voice-client CORE.
  *
  * This is the ONE canonical transport used by every Sutando voice surface:
- *   - the Sutando webUI (src/web-client.ts)
+ *   - the Sutando webUI (src/web-client.ts — loads the IIFE artifact served
+ *     at /web-voice-transport.js and instantiates SutandoVoice.VoiceTransport)
+ *   - the cinny desktop client (vendored VERBATIM — any change lands here
+ *     first and is re-copied; see the desktop repo's vendor gate)
  *   - any embedded/host-app client that mounts a "call your agent" surface
  *
  * It owns exactly the parts that must be identical across surfaces — the audio
@@ -23,20 +26,34 @@
  *   recv PCM → gapless playback          image / video rendering
  *   WS connect + binary/JSON split       status text, stats panel
  *   session.config rate negotiation      Chrome interim-STT display
- *   turn.end barge-in (flush playback)
+ *   turn.end barge-in (flush playback)   reconnect policy
+ *   connect timeout + failure decoding   error-card routing / rescue flow
+ *   `agent.state` (L3) client handling
+ *   mute / deafen call-control gates
  *
  * The seam is the event callbacks: the transport plays audio itself and emits
  * every non-audio protocol frame to `onProtocolMessage` (plus typed shortcuts
  * for the common ones) so each surface renders in its own framework.
  *
- * The DSP functions are pure and exported standalone so they unit-test in Node
- * (see tests/web-voice-transport.test.ts). The class needs a browser (AudioContext,
- * getUserMedia, WebSocket) and is exercised by the surfaces + the happy-path spike.
+ * Reliability contract (design 1e; impl plan WS1 Step 18, amendments
+ * R10/R12/S6/W5/X6/Z6):
+ *   - every `connect()` is one ATTEMPT with a generation token; stale socket
+ *     callbacks and stale post-`await` continuations are silently discarded;
+ *   - a connect attempt that does not reach `onopen` within CONNECT_TIMEOUT_MS
+ *     fails with a latched terminal `error`;
+ *   - terminal failures LATCH: the close they trigger never overwrites the
+ *     `error` status with `closed`;
+ *   - `agent.state` v1 frames drive L3 handling — `upstream:'failed'` is a
+ *     terminal CLIENT transition (the server deliberately stays reachable);
+ *     a server that sends no frame within the legacy window simply behaves
+ *     exactly as before the protocol existed;
+ *   - every failed attempt is classified into the exported
+ *     `VoiceConnectFailure` union exactly once via `onConnectFailure`.
  *
- * Transcribed faithfully from src/web-client.ts (the source of truth as of
- * 2026-07-08). The webUI-side dedup — pointing web-client.ts at this module
- * instead of its inline copy — is a follow-up that needs a browser-serve step;
- * until then a drift-guard test pins the two copies' DSP to equivalence.
+ * The DSP functions are pure and exported standalone so they unit-test in Node
+ * (see tests/web-voice-transport.test.ts). The class is drivable from node:test
+ * through the `wsFactory` seam; browser-only paths (AudioContext, getUserMedia)
+ * are exercised by the surfaces + the happy-path spike.
  */
 
 // ─── Pure PCM DSP (Node-testable) ─────────────────────────────
@@ -110,9 +127,170 @@ export function classifyMicError(name: string | undefined, message?: string): st
   }
 }
 
+/** Machine-readable mic-error class (impl plan Step 15 — Step 19's routing
+ *  needs a code, not prose). Same DOMException partition as classifyMicError. */
+export type MicErrorCode = 'permission' | 'device' | 'unknown';
+
+export function classifyMicErrorCode(name: string | undefined): MicErrorCode {
+  switch (name) {
+    case 'NotAllowedError':
+    case 'SecurityError':
+      return 'permission';
+    case 'NotReadableError':
+    case 'AbortError':
+    case 'NotFoundError':
+    case 'OverconstrainedError':
+      return 'device';
+    default:
+      return 'unknown';
+  }
+}
+
+// ─── `agent.state` v1 (design 1a′) ────────────────────────────
+// Duplicated from src/voice-agent-state.ts on purpose: this module is vendored
+// standalone into other repos and must not import server-side modules. Pinned
+// to the v1 frame — the schema is WIRE CONTRACT v1; if the emitter ever bumps
+// `v`, this copy (and the legacy fallback below) must be revisited together.
+
+/** L3 upstream states (design readiness model). */
+export type AgentUpstreamState = 'live' | 'idle' | 'connecting' | 'backoff' | 'failed';
+
+/** Terminal-failure classes carried by `agent.state` frames. */
+export type AgentStateCategory = 'auth' | 'quota' | 'network' | 'other';
+
+/** `agent.state` v1 frame — design 1a′, verbatim schema. */
+export interface AgentStateV1 {
+  type: 'agent.state';
+  v: 1;
+  initialized: boolean;
+  upstream: AgentUpstreamState;
+  reason?: string;
+  category?: AgentStateCategory;
+  clientAttached: boolean;
+  credentialSource?: 'managed' | 'byok';
+  credentialGeneration?: string;
+  launchdContract?: 1;
+}
+
+// ─── Connect-failure union (impl plan Step 18; R12 + W5 + X6 + Z6) ──────────
+
+/**
+ * Application close code the server uses to reject a second real client while
+ * one is attached (amendment W5). All surfaces decode it identically.
+ */
+export const CLOSE_CODE_CLIENT_BUSY = 4409;
+
+/**
+ * Application close code the server sends to the INCUMBENT client when a
+ * user-confirmed takeover moves the call to another surface (amendment W5).
+ * Decoded as its own terminal status (`'superseded'`), not a connect failure.
+ */
+export const CLOSE_CODE_SUPERSEDED_BY_TAKEOVER = 4410;
+
+/**
+ * Why a connect attempt failed, as one closed discriminated union (R12):
+ *
+ *   'timeout'        — no `onopen` within the connect timeout.
+ *   'connect-error'  — browser-observable pre-open failure. Browsers expose
+ *                      only a generic error + close 1006 here — no
+ *                      ECONNREFUSED/TLS/DNS distinction (Z6), so a `refused`
+ *                      refinement deliberately does NOT exist in this union;
+ *                      only a native probe with an errno could supply one.
+ *   'mic-permission' — getUserMedia permission denied.
+ *   'mic-device'     — mic busy / missing / unreadable.
+ *   'mic-other'      — unclassified mic failure (X6): remediation is Retry —
+ *                      it must never be routed to credential repair.
+ *   'agent-failed'   — `agent.state` reported `upstream:'failed'` (terminal:
+ *                      bad key / quota / credits). Carries reason + category.
+ *   'service-down'   — a SUPERVISOR-STATUS conclusion, produced by surfaces
+ *                      that consult supervisor-status; the transport itself
+ *                      never emits it (the browser cannot observe it — Z6).
+ *   'client-busy'    — server rejected this client with close 4409 while
+ *                      another real client is attached (W5). Surfaces show
+ *                      "voice is in use elsewhere" with a take-over
+ *                      affordance (`?takeover=1` on the next connect).
+ */
+export type VoiceConnectFailureKind =
+  | 'timeout'
+  | 'connect-error'
+  | 'mic-permission'
+  | 'mic-device'
+  | 'mic-other'
+  | 'agent-failed'
+  | 'service-down'
+  | 'client-busy';
+
+export interface VoiceConnectFailure {
+  kind: VoiceConnectFailureKind;
+  /** Classified human-readable detail (safe to render). */
+  detail: string;
+  /** Actionable remediation hint (safe to render). */
+  remediation: string;
+  /** Stable failure code from `agent.state` (kind 'agent-failed' only). */
+  reason?: string;
+  /** Failure class from `agent.state` (kind 'agent-failed' only). */
+  category?: AgentStateCategory;
+  /** Raw WS close info when the failure was decoded from a close frame. */
+  close?: VoiceCloseInfo;
+}
+
+/** Default remediation hint per failure kind — one shared vocabulary so every
+ *  surface (rail, webUI page, flow verifier) says the same thing. */
+export const VOICE_FAILURE_REMEDIATION: Record<VoiceConnectFailureKind, string> = {
+  timeout: 'Retry; if it keeps timing out, open voice setup to check the voice service.',
+  'connect-error': 'Check that the voice service is running, then retry.',
+  'mic-permission': 'Allow microphone access for this app in system/browser settings, then retry.',
+  'mic-device': 'Close other apps using the microphone or connect an input device, then retry.',
+  // X6: unclassified mic failures get Retry — never credential repair.
+  'mic-other': 'Retry.',
+  'agent-failed': 'Open voice setup to check the voice service.',
+  'service-down': 'Restart the voice service from voice setup.',
+  'client-busy': 'Voice is in use on another surface. Close it there, or take over the call here.',
+};
+
+/**
+ * Classify an `agent.state` terminal failure into detail + remediation. The
+ * server deliberately keeps serving while upstream is failed, so this text is
+ * what the user sees instead of an eternal spinner.
+ */
+export function describeAgentFailure(
+  reason?: string,
+  category?: AgentStateCategory,
+): { detail: string; remediation: string } {
+  const code = reason ? ' (' + reason + ')' : '';
+  switch (category) {
+    case 'auth':
+      return {
+        detail: 'Voice agent rejected by Gemini: credential problem' + code + '.',
+        remediation: 'Fix your Gemini key in voice setup, then retry.',
+      };
+    case 'quota':
+      return {
+        detail: 'Voice agent out of Gemini quota or credits' + code + '.',
+        remediation: 'Check your Gemini plan/quota, then retry.',
+      };
+    case 'network':
+      return {
+        detail: 'Voice agent cannot reach Gemini' + code + '.',
+        remediation: 'Check your network connection, then retry.',
+      };
+    default:
+      return {
+        detail: 'Voice agent upstream failed' + code + '.',
+        remediation: VOICE_FAILURE_REMEDIATION['agent-failed'],
+      };
+  }
+}
+
 // ─── Transport ────────────────────────────────────────────────
 
-export type VoiceStatus = 'idle' | 'connecting' | 'live' | 'error' | 'closed';
+/**
+ * Connection lifecycle status. `'superseded'` is the terminal state of an
+ * incumbent whose call was moved by a user-confirmed takeover (close 4410) —
+ * distinct from `'closed'` so surfaces can render "call moved elsewhere"
+ * instead of a generic disconnect (and must not auto-reconnect into a fight).
+ */
+export type VoiceStatus = 'idle' | 'connecting' | 'live' | 'error' | 'closed' | 'superseded';
 
 /**
  * Why the close event carries the raw code/reason: the surface — not the
@@ -131,10 +309,25 @@ export interface VoiceCloseInfo {
 export interface VoiceTransportEvents {
   /**
    * Connection lifecycle. `detail` is a human string for the status line.
-   * `close` is present only for `status === 'closed'`, carrying the WS close
-   * code and reason so the surface can apply its own reconnect policy.
+   * `close` is present when the transition was decoded from a WS close frame:
+   * always for `status === 'closed'`, and for the close-derived terminal
+   * states (`'error'` on 4409/pre-open closes, `'superseded'` on 4410).
    */
   onStatus?(status: VoiceStatus, detail?: string, close?: VoiceCloseInfo): void;
+  /**
+   * Exactly-once-per-attempt classified connect failure (impl plan Step 18).
+   * Fires alongside the latched `error` status; surfaces route on `kind`
+   * (mic-permission → permission flow, agent-failed/timeout → voice setup,
+   * client-busy → take-over affordance, …).
+   */
+  onConnectFailure?(failure: VoiceConnectFailure): void;
+  /**
+   * Every `agent.state` v1 frame received on the live connection, verbatim
+   * (design 1a′). The transport already applies the client rules (progress
+   * detail for connecting/backoff, terminal handling for failed); surfaces
+   * use this for richer readiness UI. Never fires on legacy servers.
+   */
+  onAgentState?(state: AgentStateV1): void;
   /**
    * Optional trace sink for the surface's debug panel and its downloadable
    * debug dump. `kind` mirrors web-client's dbg() channels ('audio' | 'event' |
@@ -161,6 +354,15 @@ export interface VoiceTransportEvents {
   onStats?(stats: { bytesSent: number; bytesRecv: number }): void;
 }
 
+/** Default connect timeout (design 1e): if the WS has not reached `onopen`
+ *  within this window, the attempt fails with a latched terminal error. */
+export const CONNECT_TIMEOUT_MS = 6000;
+
+/** Legacy-server detection window (design 1a′ client rules): no `agent.state`
+ *  frame within this window after open ⇒ legacy server, behave exactly as
+ *  before the protocol existed. */
+export const AGENT_STATE_LEGACY_MS = 3000;
+
 export interface VoiceTransportOptions extends VoiceTransportEvents {
   /** Mic capture buffer size (ScriptProcessor). Default 2048, matching web-client. */
   captureBuf?: number;
@@ -170,6 +372,17 @@ export interface VoiceTransportOptions extends VoiceTransportEvents {
   outputRate?: number;
   /** Playback speed multiplier. Default 1.0. */
   playbackRate?: number;
+  /** Connect timeout override (tests). Default CONNECT_TIMEOUT_MS. */
+  connectTimeoutMs?: number;
+  /** Legacy-detection window override (tests). Default AGENT_STATE_LEGACY_MS. */
+  agentStateLegacyMs?: number;
+  /**
+   * Socket factory seam so the state machine is drivable from node:test
+   * without a browser. Default `new WebSocket(url)`. Fakes provide the
+   * `onopen/onmessage/onerror/onclose` + `send/close/readyState` surface and
+   * cast to WebSocket.
+   */
+  wsFactory?: (url: string) => WebSocket;
 }
 
 /**
@@ -184,6 +397,9 @@ export class VoiceTransport {
   private inputRate: number;
   private outputRate: number;
   private playbackRate: number;
+  private connectTimeoutMs: number;
+  private agentStateLegacyMs: number;
+  private wsFactory: (url: string) => WebSocket;
 
   private ws: WebSocket | null = null;
   private audioCtx: AudioContext | null = null;
@@ -197,6 +413,31 @@ export class VoiceTransport {
   private bytesRecv = 0;
   private statsTimer: ReturnType<typeof setInterval> | null = null;
 
+  // Call controls (owner 2026-07-15; reconciled from the cinny surface —
+  // impl plan Step 15): mute self = stop sending mic to the agent; deafen =
+  // stop playing the agent's audio. Both are additive gates on the existing
+  // capture/playback paths — they don't touch the transport lifecycle.
+  private micMuted = false;
+  private deafened = false;
+
+  // ── Attempt state (impl plan Step 18) ──
+  // One `connect()` = one attempt. The generation token invalidates every
+  // stale socket callback and stale post-`await` continuation (R10); the
+  // terminal latch keeps a failed attempt's `error` from being overwritten by
+  // its own self-inflicted close; `attemptActive` guarantees exactly one
+  // final status per attempt (S6); `failureEmitted` guarantees exactly one
+  // onConnectFailure per attempt.
+  private attemptGen = 0;
+  private terminal = false;
+  private attemptActive = false;
+  private opened = false;
+  private failureEmitted = false;
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
+  private legacyTimer: ReturnType<typeof setTimeout> | null = null;
+  private agentStateSeen = false;
+  private legacyServer = false;
+  private lastUpstream: AgentUpstreamState | null = null;
+
   // Debug-panel counters. They exist to bound the trace output (first N only),
   // not as protocol state — the surface reads byte totals from onStats.
   private audioChunksRecv = 0;
@@ -209,20 +450,62 @@ export class VoiceTransport {
     this.inputRate = opts.inputRate ?? 16000;
     this.outputRate = opts.outputRate ?? 24000;
     this.playbackRate = opts.playbackRate ?? 1.0;
+    this.connectTimeoutMs = opts.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
+    this.agentStateLegacyMs = opts.agentStateLegacyMs ?? AGENT_STATE_LEGACY_MS;
+    this.wsFactory = opts.wsFactory ?? ((url: string) => new WebSocket(url));
   }
 
   get connected(): boolean {
     return !!this.ws && this.ws.readyState === WebSocket.OPEN;
   }
 
+  /** What the server's `agent.state` support turned out to be for the current
+   *  attempt: 'v1' once a frame arrived, 'legacy' once the detection window
+   *  elapsed with none, 'unknown' before either. */
+  get agentStateSupport(): 'unknown' | 'v1' | 'legacy' {
+    if (this.agentStateSeen) return 'v1';
+    if (this.legacyServer) return 'legacy';
+    return 'unknown';
+  }
+
   /**
    * Open the session. Creates the AudioContext eagerly (call from a user
    * gesture so it isn't born suspended), connects the WS, and starts the mic
-   * on open. Rejects only on synchronous setup failure; mic errors surface via
-   * onMicError (the session stays up so the user can retry).
+   * on open.
+   *
+   * FIRE-AND-FORGET CONTRACT: the returned promise resolves when the attempt
+   * is *initiated* (or rejects only on synchronous setup failure such as an
+   * empty url). Every asynchronous outcome — open, timeout, mic failure,
+   * agent failure, close — is reported via the callbacks, never the promise.
    */
   async connect(url: string): Promise<void> {
     if (!url) throw new Error('connect: empty url');
+
+    // New attempt: invalidate everything from the previous one (its socket
+    // callbacks are generation-fenced below) and reset the attempt state.
+    const gen = ++this.attemptGen;
+    this.terminal = false;
+    this.attemptActive = true;
+    this.opened = false;
+    this.failureEmitted = false;
+    this.agentStateSeen = false;
+    this.legacyServer = false;
+    this.lastUpstream = null;
+    this.clearConnectTimer();
+    this.clearLegacyTimer();
+    if (this.ws) {
+      // A Retry on the same transport must not stack a second socket or
+      // audio graph on top of a leftover one.
+      try {
+        this.ws.close();
+      } catch {
+        /* already closed */
+      }
+      this.ws = null;
+    }
+    this.stopMic();
+    this.stopStats();
+
     this.status('connecting', 'Connecting…');
 
     // Create the AudioContext up front (ideally on a user gesture) so playback
@@ -236,56 +519,82 @@ export class VoiceTransport {
       } catch {
         /* resumed lazily in playChunk if this races */
       }
+      // R10: re-check the generation after EVERY await — a disconnect() (or a
+      // newer connect()) during resume() must not create a replacement socket.
+      if (gen !== this.attemptGen) return;
     }
 
-    const ws = new WebSocket(url);
+    const ws = this.wsFactory(url);
     ws.binaryType = 'arraybuffer';
     this.ws = ws;
 
-    ws.onopen = async () => {
-      this.status('live', 'Starting mic…');
-      try {
-        await this.startMic();
-        this.status('live', 'Live — speak now');
-        this.statsTimer = setInterval(() => {
-          this.ev.onStats?.({ bytesSent: this.bytesSent, bytesRecv: this.bytesRecv });
-        }, 500);
-      } catch (err: any) {
-        const name = err?.name ?? 'unknown';
-        const friendly = classifyMicError(err?.name, err?.message);
-        this.debug('Mic error: ' + (err?.name ? err.name + ': ' : '') + err?.message, 'err');
-        this.status('error', 'Mic error');
-        this.ev.onMicError?.(name, err?.message ?? '', friendly);
-        // Prevent an auto-reconnect loop on a hard mic failure.
-        try {
-          ws.close();
-        } catch {
-          /* already closing */
-        }
-      }
+    // Design 1e: a connection that never reaches onopen must fail visibly.
+    this.connectTimer = setTimeout(() => this.onConnectTimeout(gen), this.connectTimeoutMs);
+
+    ws.onopen = () => {
+      void this.handleOpen(gen, ws);
     };
-
-    ws.onmessage = (event: MessageEvent) => this.onMessage(event);
-
+    ws.onmessage = (event: MessageEvent) => {
+      if (gen !== this.attemptGen) return; // stale socket — discard silently
+      this.onMessage(event);
+    };
     ws.onerror = () => {
-      this.debug('WS error', 'err');
-      this.status('error', 'Connection failed');
+      if (gen !== this.attemptGen) return;
+      this.handleSocketError();
     };
-
     ws.onclose = (event: CloseEvent) => {
-      // A server-initiated close must tear down the whole audio graph, not just
-      // the stats timer — otherwise mic capture keeps running and stale audio
-      // state lingers. Mirrors web-client's doCleanup() on ws.onclose.
-      const code = event?.code ?? 0;
-      const reason = event?.reason ?? '';
-      this.debug('WS closed: code=' + code + ' reason=' + reason);
-      this.teardownAudio();
-      this.status('closed', 'Disconnected', { code, reason });
+      if (gen !== this.attemptGen) return; // a stale close can't clobber a newer attempt
+      this.handleClose(event);
     };
   }
 
-  /** Tear down mic + WS + playback + audio graph. Idempotent. */
+  /** Mute/unmute the local mic — stop/resume sending audio to the agent. Also
+   *  flips the mic track so the OS mic indicator reflects the mute. */
+  setMicMuted(muted: boolean): void {
+    this.micMuted = muted;
+    // Flip the track (typically one) so the OS mic indicator reflects the mute.
+    const track = this.micStream?.getAudioTracks()[0];
+    if (track) track.enabled = !muted;
+  }
+
+  /** Deafen/undeafen — stop/resume playing the agent's audio. Deafening flushes
+   *  any in-flight playback so it stops immediately. */
+  setDeafened(deafened: boolean): void {
+    this.deafened = deafened;
+    if (deafened) this.flushPlayback();
+  }
+
+  /** Live playback-speed control (the `speech_speed` protocol frame is
+   *  interpreted by the surface, which applies it here). */
+  setPlaybackRate(rate: number): void {
+    this.playbackRate = rate;
+  }
+
+  /** Send a typed text input over the live session (the surface's text box
+   *  during voice). Returns false when no socket is open. */
+  sendTextInput(text: string): boolean {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false;
+    this.ws.send(JSON.stringify({ type: 'text_input', text }));
+    return true;
+  }
+
+  /**
+   * User-initiated teardown of mic + WS + playback + audio graph. Idempotent.
+   *
+   * Amendment S6: disconnect() invalidates the attempt FIRST — every in-flight
+   * `await` continuation and socket callback goes stale — then synchronously
+   * emits exactly ONE `closed` transition. It must not depend on the socket's
+   * `onclose` (now generation-fenced, hence suppressed), or the UI could stick
+   * in `connecting`/`live` forever. The terminal-ERROR cleanup path stays
+   * separate: after a latched `error` (timeout / upstream-failed / mic),
+   * disconnect() only cleans up and PRESERVES the latched error status.
+   */
   disconnect(): void {
+    this.attemptGen++;
+    this.clearConnectTimer();
+    this.clearLegacyTimer();
+    const emitClosed = this.attemptActive && !this.terminal;
+    this.attemptActive = false;
     if (this.ws) {
       try {
         this.ws.close();
@@ -295,6 +604,9 @@ export class VoiceTransport {
       this.ws = null;
     }
     this.teardownAudio();
+    if (emitClosed) {
+      this.status('closed', 'Disconnected');
+    }
   }
 
   /** Alias for disconnect — teardown already closes the AudioContext. */
@@ -323,9 +635,273 @@ export class VoiceTransport {
     this.analyserNode = null; // recreated against the next ctx in playChunk
   }
 
+  // ─── attempt outcome handling (Step 18) ─────────────────────
+
+  private clearConnectTimer(): void {
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+  }
+
+  private clearLegacyTimer(): void {
+    if (this.legacyTimer) {
+      clearTimeout(this.legacyTimer);
+      this.legacyTimer = null;
+    }
+  }
+
+  /** Exactly one classified failure per attempt. */
+  private emitFailure(failure: VoiceConnectFailure): void {
+    if (this.failureEmitted) return;
+    this.failureEmitted = true;
+    this.ev.onConnectFailure?.(failure);
+  }
+
+  private onConnectTimeout(gen: number): void {
+    this.connectTimer = null;
+    if (gen !== this.attemptGen || this.terminal) return;
+    const detail = 'Connection timed out';
+    this.debug('Connect timeout after ' + this.connectTimeoutMs + 'ms', 'err');
+    // Terminal latch BEFORE closing: the self-inflicted onclose must see
+    // terminal=true and suppress its status emission.
+    this.terminal = true;
+    this.attemptActive = false;
+    this.teardownAudio();
+    this.status('error', detail);
+    this.emitFailure({
+      kind: 'timeout',
+      detail,
+      remediation: VOICE_FAILURE_REMEDIATION.timeout,
+    });
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        /* already closed */
+      }
+      this.ws = null;
+    }
+  }
+
+  private async handleOpen(gen: number, ws: WebSocket): Promise<void> {
+    if (gen !== this.attemptGen) return;
+    this.opened = true;
+    this.clearConnectTimer();
+    this.armLegacyTimer(gen);
+    this.status('live', 'Starting mic…');
+    try {
+      await this.startMic(gen);
+      // R10: a slow permission prompt can outlive the attempt it belonged to.
+      // startMic() itself stopped any stale capture under its own generation
+      // checks — this stale branch must NOT touch instance state (this.micStream
+      // may already belong to a newer attempt).
+      if (gen !== this.attemptGen) return;
+      this.status('live', 'Live — speak now');
+      this.statsTimer = setInterval(() => {
+        this.ev.onStats?.({ bytesSent: this.bytesSent, bytesRecv: this.bytesRecv });
+      }, 500);
+    } catch (err: any) {
+      if (gen !== this.attemptGen) return;
+      const name = err?.name ?? 'unknown';
+      const friendly = classifyMicError(err?.name, err?.message);
+      const code = classifyMicErrorCode(err?.name);
+      const kind: VoiceConnectFailureKind =
+        code === 'permission' ? 'mic-permission' : code === 'device' ? 'mic-device' : 'mic-other';
+      this.debug('Mic error: ' + (err?.name ? err.name + ': ' : '') + err?.message, 'err');
+      // Terminal for this attempt: the close we trigger below must not
+      // overwrite the error, and a hard mic failure must not auto-reconnect.
+      this.terminal = true;
+      this.attemptActive = false;
+      this.status('error', 'Mic error');
+      this.ev.onMicError?.(name, err?.message ?? '', friendly);
+      this.emitFailure({ kind, detail: friendly, remediation: VOICE_FAILURE_REMEDIATION[kind] });
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+    }
+  }
+
+  private handleSocketError(): void {
+    this.debug('WS error', 'err');
+    if (this.terminal) return;
+    if (!this.opened) {
+      // Pre-open failure. The browser exposes no errno/TLS/DNS detail here
+      // (Z6) — just a generic error followed by close 1006 — so this is the
+      // one browser-observable pre-open kind: 'connect-error'. Latch now so
+      // the trailing onclose can't overwrite the error with 'closed'.
+      const detail = 'Connection failed';
+      this.terminal = true;
+      this.attemptActive = false;
+      this.clearConnectTimer();
+      this.teardownAudio();
+      this.status('error', detail);
+      this.emitFailure({
+        kind: 'connect-error',
+        detail,
+        remediation: VOICE_FAILURE_REMEDIATION['connect-error'],
+      });
+      if (this.ws) {
+        try {
+          this.ws.close();
+        } catch {
+          /* already closed */
+        }
+        this.ws = null;
+      }
+      return;
+    }
+    // Mid-session socket error: not an attempt-terminal state — the close
+    // that follows carries the code, and the surface owns reconnect policy.
+    this.status('error', 'Connection failed');
+  }
+
+  private handleClose(event: CloseEvent): void {
+    const code = event?.code ?? 0;
+    const reason = event?.reason ?? '';
+    this.debug('WS closed: code=' + code + ' reason=' + reason);
+    this.clearConnectTimer();
+    this.clearLegacyTimer();
+    if (this.terminal) {
+      // Latched terminal attempt (timeout / mic / pre-open error /
+      // upstream-failed / client-busy / superseded): the self-inflicted or
+      // trailing close still tears the audio graph down, but must NOT
+      // overwrite the latched status (design 1e terminal-state latching).
+      this.teardownAudio();
+      return;
+    }
+    this.teardownAudio();
+    const close: VoiceCloseInfo = { code, reason };
+    if (code === CLOSE_CODE_CLIENT_BUSY) {
+      // W5: another real client is attached — surfaces render "voice is in
+      // use elsewhere" with a take-over affordance.
+      const detail = 'Voice is in use on another surface.';
+      this.terminal = true;
+      this.attemptActive = false;
+      this.ws = null;
+      this.status('error', detail, close);
+      this.emitFailure({
+        kind: 'client-busy',
+        detail,
+        remediation: VOICE_FAILURE_REMEDIATION['client-busy'],
+        close,
+      });
+      return;
+    }
+    if (code === CLOSE_CODE_SUPERSEDED_BY_TAKEOVER) {
+      // W5: a user-confirmed takeover moved the call to another surface.
+      // Terminal state of its own — NOT a connect failure and NOT a plain
+      // close (a surface auto-reconnecting here would fight the takeover).
+      this.terminal = true;
+      this.attemptActive = false;
+      this.ws = null;
+      this.status('superseded', 'Voice call moved to another surface', close);
+      return;
+    }
+    if (!this.opened) {
+      // Pre-open close without a usable close code (Z6: browsers surface
+      // only 1006 here). Same terminal 'connect-error' as handleSocketError —
+      // whichever of the two events arrives first latches, the other is
+      // suppressed by the terminal check above.
+      const detail = 'Connection failed';
+      this.terminal = true;
+      this.attemptActive = false;
+      this.ws = null;
+      this.status('error', detail, close);
+      this.emitFailure({
+        kind: 'connect-error',
+        detail,
+        remediation: VOICE_FAILURE_REMEDIATION['connect-error'],
+        close,
+      });
+      return;
+    }
+    // Ordinary post-open close (server goodbye or unexpected drop). The
+    // surface applies its own reconnect policy from the code/reason.
+    this.attemptActive = false;
+    this.ws = null;
+    this.status('closed', 'Disconnected', close);
+  }
+
+  // ─── `agent.state` client handling (design 1a′) ─────────────
+
+  private armLegacyTimer(gen: number): void {
+    this.clearLegacyTimer();
+    this.legacyTimer = setTimeout(() => {
+      this.legacyTimer = null;
+      if (gen !== this.attemptGen || this.agentStateSeen) return;
+      // Legacy fallback: no frame within the window ⇒ older/external server.
+      // Behave exactly as today — mic start and "Live" were already keyed on
+      // onopen, so there is nothing to undo; just stop expecting frames.
+      this.legacyServer = true;
+      this.debug(
+        'agent.state: no frame within ' + this.agentStateLegacyMs + 'ms — legacy server, no L3 signal',
+        'warn',
+      );
+    }, this.agentStateLegacyMs);
+  }
+
+  private handleAgentState(frame: AgentStateV1): void {
+    this.agentStateSeen = true;
+    this.legacyServer = false;
+    this.clearLegacyTimer();
+    const prev = this.lastUpstream;
+    this.lastUpstream = frame.upstream;
+    this.ev.onAgentState?.(frame);
+    if (this.terminal) return; // latched attempt — frames are informational only
+    switch (frame.upstream) {
+      case 'failed': {
+        // Terminal CLIENT transition (design 1e): the server deliberately
+        // stays reachable, so no close will arrive — the client itself must
+        // invalidate the attempt, stop mic/stats/playback, close the socket,
+        // latch the error, and suppress the self-inflicted onclose. Otherwise
+        // the mic keeps streaming behind the error card and a Retry stacks a
+        // second socket/audio graph.
+        const { detail, remediation } = describeAgentFailure(frame.reason, frame.category);
+        this.attemptGen++; // invalidate: no callback of this socket runs again
+        this.terminal = true;
+        this.attemptActive = false;
+        this.clearConnectTimer();
+        this.teardownAudio();
+        const ws = this.ws;
+        this.ws = null;
+        if (ws) {
+          try {
+            ws.close();
+          } catch {
+            /* already closed */
+          }
+        }
+        this.status('error', detail);
+        const failure: VoiceConnectFailure = { kind: 'agent-failed', detail, remediation };
+        if (frame.reason !== undefined) failure.reason = frame.reason;
+        if (frame.category !== undefined) failure.category = frame.category;
+        this.emitFailure(failure);
+        return;
+      }
+      case 'connecting':
+      case 'backoff':
+        // Progress, not an error: idle→connecting→live after connect is the
+        // normal wake-up sequence.
+        this.status('live', frame.upstream === 'connecting' ? 'Waking up…' : 'Reconnecting to the model…');
+        return;
+      case 'live':
+        if (prev !== null && prev !== 'live') {
+          this.status('live', 'Live — speak now');
+        }
+        return;
+      default:
+        // 'idle' — healthy torn-down upstream; our attach wakes it (the
+        // connecting frame follows). Nothing to render yet.
+        return;
+    }
+  }
+
   // ─── mic capture ────────────────────────────────────────────
 
-  private async startMic(): Promise<void> {
+  private async startMic(gen: number): Promise<void> {
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
       // Condition and copy are verbatim from web-client. Deliberately keyed on
       // location rather than isSecureContext: the two agree on every surface we
@@ -348,19 +924,34 @@ export class VoiceTransport {
       }
     }
 
-    this.micStream = await navigator.mediaDevices.getUserMedia({
+    const stream = await navigator.mediaDevices.getUserMedia({
       audio: {
         echoCancellation: true,
         noiseSuppression: true,
         autoGainControl: true,
       },
     });
+    // R10: the permission prompt is an await — if the attempt died while it
+    // was up (disconnect, timeout, replacement), the grant must not leave a
+    // live capture behind.
+    if (gen !== this.attemptGen) {
+      for (const t of stream.getTracks()) t.stop();
+      return;
+    }
+    this.micStream = stream;
 
     if (!this.audioCtx || this.audioCtx.state === 'closed') {
       this.audioCtx = new AudioContext();
     }
     if (this.audioCtx.state === 'suspended') {
       await this.audioCtx.resume();
+      if (gen !== this.attemptGen) {
+        // Stop OUR capture only — this.micStream may already belong to a
+        // newer attempt (its connect() re-ran stopMic + startMic).
+        for (const t of stream.getTracks()) t.stop();
+        if (this.micStream === stream) this.micStream = null;
+        return;
+      }
     }
 
     const ctx = this.audioCtx;
@@ -370,6 +961,9 @@ export class VoiceTransport {
 
     processor.onaudioprocess = (e: AudioProcessingEvent) => {
       if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+      // Muted: keep the processor running (it must stay in the graph) but
+      // don't send mic audio to the agent.
+      if (this.micMuted) return;
       const raw = e.inputBuffer.getChannelData(0);
       const down = downsample(raw, ctx.sampleRate, this.inputRate);
       const pcm = float32ToInt16(down);
@@ -435,7 +1029,9 @@ export class VoiceTransport {
     }
     this.debug('Recv: ' + JSON.stringify(msg), 'event');
 
-    if (msg?.type === 'session.config' && msg.audioFormat) {
+    if (msg?.type === 'agent.state') {
+      this.handleAgentState(msg as AgentStateV1);
+    } else if (msg?.type === 'session.config' && msg.audioFormat) {
       this.inputRate = msg.audioFormat.inputSampleRate ?? this.inputRate;
       this.outputRate = msg.audioFormat.outputSampleRate ?? this.outputRate;
       this.ev.onSessionConfig?.(this.inputRate, this.outputRate);
@@ -460,6 +1056,9 @@ export class VoiceTransport {
   // ─── gapless playback ───────────────────────────────────────
 
   private playChunk(arrayBuf: ArrayBuffer): void {
+    // Deafened: drop the agent's audio (like a call deafen — you don't hear
+    // what was said while deafened).
+    if (this.deafened) return;
     if (!this.audioCtx || this.audioCtx.state === 'closed') {
       try {
         this.audioCtx = new AudioContext();

--- a/tests/voice-connect-resolver.test.ts
+++ b/tests/voice-connect-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveVoiceEndpoint, defaultCandidates } from '../src/voice-connect-resolver.js';
+import { resolveVoiceEndpoint, defaultCandidates, directWsUrl } from '../src/voice-connect-resolver.js';
 
 describe('voice-connect-resolver', () => {
 	it('defaultCandidates: local first, cloud last, omits unknowns', () => {
@@ -9,6 +9,41 @@ describe('voice-connect-resolver', () => {
 		assert.ok(full[0].url.includes('localhost:9900'));
 		const minimal = defaultCandidates({});
 		assert.deepEqual(minimal.map((x) => x.tier), ['local']); // only local when nothing else known
+	});
+
+	it('tailnet slots between local and lan — mesh VPN beats same-subnet-only (upstream reconciliation)', () => {
+		const full = defaultCandidates({
+			tailnetHost: 'core.tail1234.ts.net',
+			lanHost: '192.168.1.5',
+			relayWsUrl: 'wss://r',
+			cloudUrl: 'wss://c',
+		});
+		assert.deepEqual(full.map((x) => x.tier), ['local', 'tailnet', 'lan', 'relay', 'cloud']);
+	});
+
+	it('off-localhost candidates dial the webUI /ws proxy, never the loopback-only voice port', () => {
+		const [local, tailnet, lan] = defaultCandidates({ tailnetHost: 'core.ts.net', lanHost: '192.168.1.5' });
+		assert.equal(local.url, 'ws://localhost:9900', 'local keeps the loopback voice-agent WS');
+		assert.equal(tailnet.url, 'ws://core.ts.net:8080/ws', 'tailnet goes through :proxyPort/ws');
+		assert.equal(lan.url, 'ws://192.168.1.5:8080/ws', 'lan goes through :proxyPort/ws');
+	});
+
+	it('directWsUrl: https → wss (tailscale serve fronts :443); http keeps its port; bare host gets proxyPort', () => {
+		assert.equal(directWsUrl('https://core.ts.net', 8080), 'wss://core.ts.net/ws');
+		assert.equal(directWsUrl('https://core.ts.net/', 8080), 'wss://core.ts.net/ws', 'trailing slash trimmed');
+		assert.equal(directWsUrl('http://192.168.1.5:8080', 9999), 'ws://192.168.1.5:8080/ws', 'advertised port preserved');
+		assert.equal(directWsUrl('core.ts.net', 8080), 'ws://core.ts.net:8080/ws');
+	});
+
+	it('agentEndpoint identity-routes: dial THAT agent, never generic local; relay/cloud stay as fallbacks', () => {
+		const cands = defaultCandidates({
+			agentEndpoint: 'https://agent.ts.net',
+			relayWsUrl: 'wss://r',
+			cloudUrl: 'wss://c',
+		});
+		assert.deepEqual(cands.map((x) => x.tier), ['tailnet', 'relay', 'cloud']);
+		assert.equal(cands[0].url, 'wss://agent.ts.net/ws');
+		assert.ok(!cands.some((x) => x.tier === 'local'), 'generic local would answer as the wrong agent');
 	});
 
 	it('returns the first reachable in ladder order (local down → relay up)', async () => {

--- a/tests/web-voice-transport-delivery.test.ts
+++ b/tests/web-voice-transport-delivery.test.ts
@@ -17,11 +17,13 @@
  * build fails the test rather than passing a string comparison.
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
 import vm from 'node:vm';
 
 import {
@@ -29,6 +31,7 @@ import {
 	BROWSER_TRANSPORT_GLOBAL,
 	buildBrowserTransportSource,
 } from '../scripts/browser-transport-build.mjs';
+import { setupTempWorkspace } from './_helpers/temp-workspace.js';
 
 const repo = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -78,6 +81,36 @@ describe('browser transport delivery — source mode (on-demand compile)', () =>
 		// Halving the rate halves the sample count.
 		assert.equal(api.downsample(new Float32Array(100), 32000, 16000).length, 50);
 	});
+
+	// Amendment R11: the artifact must be the classic-script IIFE build — the
+	// page loads it with a plain <script> tag, which cannot execute ESM. An
+	// accidental format switch to ESM would parse (as a module) and even lint,
+	// but the browser would throw "Unexpected token 'export'" and the Connect
+	// button would just be dead.
+	it('is a classic script, not ESM (R11): parses as vm.Script and installs the global', async () => {
+		const js = await buildBrowserTransportSource();
+		// vm.Script compiles CLASSIC scripts only — top-level `import`/`export`
+		// (ESM output) is a SyntaxError here, exactly like a <script> tag.
+		assert.doesNotThrow(() => new vm.Script(js), 'artifact must compile as a classic script');
+		const api = evaluateArtifact(js);
+		assert.equal(
+			typeof api?.VoiceTransport,
+			'function',
+			`classic-script evaluation must define ${BROWSER_TRANSPORT_GLOBAL}.VoiceTransport`,
+		);
+	});
+
+	// Step 15/18 additions ride the same artifact: the page (and any surface
+	// loading the IIFE) must see the new exports, not just the original four.
+	it('exposes the Step-15/18 surface: classifyMicErrorCode + close codes + failure vocabulary', async () => {
+		const api = evaluateArtifact(await buildBrowserTransportSource());
+		assert.ok(api, 'global must be defined');
+		assert.equal(typeof api!.classifyMicErrorCode, 'function');
+		assert.equal((api!.classifyMicErrorCode as (n?: string) => string)('NotAllowedError'), 'permission');
+		assert.equal(api!.CLOSE_CODE_CLIENT_BUSY, 4409);
+		assert.equal(api!.CLOSE_CODE_SUPERSEDED_BY_TAKEOVER, 4410);
+		assert.equal(typeof api!.VOICE_FAILURE_REMEDIATION, 'object');
+	});
 });
 
 describe('browser transport delivery — artifact name agreement', () => {
@@ -107,5 +140,104 @@ describe('browser transport delivery — artifact name agreement', () => {
 		const js = await buildBrowserTransportSource();
 		// esbuild emits `var <globalName> = (() => { ... })()`.
 		assert.match(js, new RegExp(`\\b${BROWSER_TRANSPORT_GLOBAL}\\b`));
+	});
+});
+
+// ─── Serve-path smoke (impl plan Step 16, amendment R11) ─────────────────────
+//
+// The page integration is only real if the RUNNING web-client actually serves
+// the artifact at the route the page's <script> names, and serves it as
+// classic-script JavaScript defining SutandoVoice.VoiceTransport — NOT ESM.
+// Spawns web-client on its own port (pattern: tests/agent-state-endpoint.test.ts).
+
+describe('browser transport delivery — serve path (spawned web-client)', () => {
+	const PORT = 18094; // distinct from agent-state-endpoint's 18081
+	const { workspace: TEMP_WORKSPACE, cleanup: cleanupTempWorkspace } =
+		setupTempWorkspace('transport-delivery');
+	let child: ChildProcess | null = null;
+
+	async function ensureStarted(): Promise<void> {
+		if (child) return;
+		child = spawn('npx', ['tsx', 'src/web-client.ts'], {
+			cwd: repo,
+			env: {
+				...process.env,
+				CLIENT_PORT: String(PORT),
+				PORT: '19902',
+				CLIENT_HOST: '127.0.0.1',
+				SUTANDO_WORKSPACE: TEMP_WORKSPACE,
+				SUTANDO_TEST_MODE: '1',
+			},
+			stdio: 'ignore',
+		});
+		const deadline = Date.now() + 20_000;
+		while (Date.now() < deadline) {
+			try {
+				const res = await fetch(`http://127.0.0.1:${PORT}/sse-status`);
+				if (res.ok) return;
+			} catch {
+				/* not ready */
+			}
+			await delay(200);
+		}
+		throw new Error('web-client did not start within 20s');
+	}
+
+	after(async () => {
+		if (child && !child.killed) {
+			await new Promise<void>((resolve) => {
+				const hardKill = setTimeout(() => {
+					try {
+						child!.kill('SIGKILL');
+					} catch {
+						/* already dead */
+					}
+					resolve();
+				}, 2_000);
+				child!.once('exit', () => {
+					clearTimeout(hardKill);
+					resolve();
+				});
+				child!.kill('SIGTERM');
+			});
+		}
+		cleanupTempWorkspace();
+	});
+
+	it('GET /web-voice-transport.js → 200 classic-script IIFE defining the transport global (R11)', async () => {
+		await ensureStarted();
+		const res = await fetch(`http://127.0.0.1:${PORT}/web-voice-transport.js`);
+		assert.equal(res.status, 200);
+		assert.match(res.headers.get('content-type') ?? '', /javascript/);
+		const js = await res.text();
+
+		// Classic script, not ESM: must compile under vm.Script (a top-level
+		// `export`/`import` would throw exactly like it would in <script>).
+		assert.doesNotThrow(() => new vm.Script(js), 'served JS must be a classic script (IIFE), not ESM');
+		const api = evaluateArtifact(js);
+		assert.ok(api, `served JS must define ${BROWSER_TRANSPORT_GLOBAL}`);
+		assert.equal(
+			typeof api!.VoiceTransport,
+			'function',
+			`served JS must define ${BROWSER_TRANSPORT_GLOBAL}.VoiceTransport`,
+		);
+		assert.equal(typeof api!.classifyMicErrorCode, 'function', 'Step-15 export rides the served artifact');
+	});
+
+	it('the served page loads the artifact via a classic <script> tag (no type="module")', async () => {
+		await ensureStarted();
+		const res = await fetch(`http://127.0.0.1:${PORT}/`);
+		assert.equal(res.status, 200);
+		const html = await res.text();
+		assert.ok(
+			html.includes('<script src="/web-voice-transport.js"></script>'),
+			'page must load the served artifact with a classic script tag',
+		);
+		assert.ok(
+			!/<script[^>]*type="module"[^>]*web-voice-transport/.test(html),
+			'the transport must not be loaded as an ESM module',
+		);
+		// The page instantiates the canonical transport — the inline copies are gone.
+		assert.match(html, /new SutandoVoice\.VoiceTransport\(/);
 	});
 });

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -1,11 +1,22 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { setTimeout as delay } from 'node:timers/promises';
 import {
 	downsample,
 	float32ToInt16,
 	int16ToFloat32,
 	classifyMicError,
+	classifyMicErrorCode,
+	describeAgentFailure,
 	VoiceTransport,
+	CLOSE_CODE_CLIENT_BUSY,
+	CLOSE_CODE_SUPERSEDED_BY_TAKEOVER,
+	CONNECT_TIMEOUT_MS,
+	AGENT_STATE_LEGACY_MS,
+	VOICE_FAILURE_REMEDIATION,
+	type VoiceConnectFailure,
+	type VoiceTransportOptions,
+	type AgentStateV1,
 } from '../src/web-voice-transport.js';
 
 // Feed a JSON frame straight into the private router. The frame path touches no
@@ -104,7 +115,7 @@ describe('web-voice-transport classifyMicError', () => {
 	});
 });
 
-describe('web-voice-transport turn lifecycle (drift guard vs web-client)', () => {
+describe('web-voice-transport turn lifecycle', () => {
 	it('turn.end fires onTurnEnd and does NOT flush/interrupt (final audio drains)', () => {
 		let ended = 0;
 		let interrupted = 0;
@@ -239,5 +250,652 @@ describe('web-voice-transport mic-error wording matches the shipped web UI', () 
 	it('classified cases are unaffected by the added message argument', () => {
 		assert.match(classifyMicError('NotAllowedError', 'ignored'), /denied/i);
 		assert.match(classifyMicError('NotFoundError', 'ignored'), /no microphone found/i);
+	});
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Step 15/18 state-machine coverage (impl plan WS1; amendments R10/R12/S6/W5/
+// X6/Z6). The class is driven from Node through the wsFactory seam plus
+// minimal AudioContext/getUserMedia stand-ins — no browser required.
+// ═════════════════════════════════════════════════════════════════════════════
+
+class FakeMicTrack {
+	stopped = false;
+	enabled = true;
+	stop(): void {
+		this.stopped = true;
+	}
+}
+
+class FakeMediaStream {
+	tracks = [new FakeMicTrack()];
+	getTracks(): FakeMicTrack[] {
+		return this.tracks;
+	}
+	getAudioTracks(): FakeMicTrack[] {
+		return this.tracks;
+	}
+}
+
+class FakeAudioContext {
+	static created: FakeAudioContext[] = [];
+	/** State the NEXT constructed context starts in ('running' | 'suspended'). */
+	static nextState = 'running';
+	/** Optional gate awaited inside resume() — lets tests park an attempt
+	 *  inside the exact `await` R10 fences. */
+	static resumeHook: (() => Promise<void>) | null = null;
+
+	state: string;
+	sampleRate = 48000;
+	currentTime = 0;
+	destination = {};
+	bufferSourcesStarted = 0;
+
+	constructor() {
+		this.state = FakeAudioContext.nextState;
+		FakeAudioContext.nextState = 'running';
+		FakeAudioContext.created.push(this);
+	}
+	async resume(): Promise<void> {
+		if (FakeAudioContext.resumeHook) await FakeAudioContext.resumeHook();
+		this.state = 'running';
+	}
+	close(): void {
+		this.state = 'closed';
+	}
+	createMediaStreamSource(): any {
+		return { connect() {} };
+	}
+	createScriptProcessor(): any {
+		return { onaudioprocess: null, connect() {}, disconnect() {} };
+	}
+	createGain(): any {
+		return { gain: { value: 0 }, connect() {} };
+	}
+	createAnalyser(): any {
+		return { fftSize: 0, connect() {} };
+	}
+	createBuffer(_ch: number, len: number, rate: number): any {
+		return { duration: len / rate, getChannelData: () => new Float32Array(len) };
+	}
+	createBufferSource(): any {
+		return {
+			buffer: null,
+			playbackRate: { value: 1 },
+			connect() {},
+			start: () => {
+				this.bufferSourcesStarted++;
+			},
+			stop() {},
+			onended: null,
+		};
+	}
+}
+
+class FakeSocket {
+	static instances: FakeSocket[] = [];
+	url: string;
+	binaryType = '';
+	readyState = 0; // CONNECTING
+	sent: Array<ArrayBuffer | string> = [];
+	closeCalls = 0;
+	onopen: (() => void) | null = null;
+	onmessage: ((ev: { data: unknown }) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: ((ev: { code: number; reason: string }) => void) | null = null;
+
+	constructor(url: string) {
+		this.url = url;
+		FakeSocket.instances.push(this);
+	}
+	send(data: ArrayBuffer | string): void {
+		this.sent.push(data);
+	}
+	close(): void {
+		this.closeCalls++;
+		this.readyState = 3; // CLOSED
+	}
+	// ── test drivers ──
+	open(): void {
+		this.readyState = 1; // OPEN
+		this.onopen?.();
+	}
+	message(obj: unknown): void {
+		this.onmessage?.({ data: JSON.stringify(obj) });
+	}
+	binary(buf: ArrayBuffer): void {
+		this.onmessage?.({ data: buf });
+	}
+	error(): void {
+		this.onerror?.();
+	}
+	serverClose(code: number, reason = ''): void {
+		this.readyState = 3;
+		this.onclose?.({ code, reason });
+	}
+}
+
+// Browser globals the class touches. Each test FILE runs in its own process
+// under the node:test runner, so this stubbing cannot leak into other suites.
+let gumImpl: () => Promise<FakeMediaStream>;
+Object.defineProperty(globalThis, 'AudioContext', {
+	value: FakeAudioContext,
+	configurable: true,
+	writable: true,
+});
+Object.defineProperty(globalThis, 'navigator', {
+	value: { mediaDevices: { getUserMedia: () => gumImpl() } },
+	configurable: true,
+	writable: true,
+});
+
+interface SeenStatus {
+	status: string;
+	detail?: string;
+	close?: { code: number; reason: string };
+}
+
+function harness(opts: Partial<VoiceTransportOptions> = {}) {
+	const statuses: SeenStatus[] = [];
+	const failures: VoiceConnectFailure[] = [];
+	const micErrors: Array<{ name: string; message: string; friendly: string }> = [];
+	const frames: AgentStateV1[] = [];
+	const t = new VoiceTransport({
+		connectTimeoutMs: 20,
+		agentStateLegacyMs: 20,
+		wsFactory: (url: string) => new FakeSocket(url) as unknown as WebSocket,
+		onStatus: (status, detail, close) => statuses.push({ status, detail, close }),
+		onConnectFailure: (f) => failures.push(f),
+		onMicError: (name, message, friendly) => micErrors.push({ name, message, friendly }),
+		onAgentState: (s) => frames.push(s),
+		...opts,
+	});
+	const sock = (): FakeSocket => FakeSocket.instances[FakeSocket.instances.length - 1];
+	return { t, statuses, failures, micErrors, frames, sock };
+}
+
+/** Drive a transport to fully-live over the newest fake socket. */
+async function goLive(h: ReturnType<typeof harness>): Promise<FakeSocket> {
+	await h.t.connect('ws://fake:9900/');
+	const s = h.sock();
+	s.open();
+	await delay(5); // let handleOpen's startMic await settle
+	assert.ok(
+		h.statuses.some((x) => x.status === 'live' && x.detail === 'Live — speak now'),
+		'harness precondition: attempt must reach live',
+	);
+	return s;
+}
+
+beforeEach(() => {
+	FakeSocket.instances = [];
+	FakeAudioContext.created = [];
+	FakeAudioContext.nextState = 'running';
+	FakeAudioContext.resumeHook = null;
+	gumImpl = async () => new FakeMediaStream();
+});
+
+describe('classifyMicErrorCode (Step 15 — machine-readable class)', () => {
+	it('partitions the DOMException names exactly like classifyMicError', () => {
+		for (const n of ['NotAllowedError', 'SecurityError']) {
+			assert.equal(classifyMicErrorCode(n), 'permission');
+		}
+		for (const n of ['NotReadableError', 'AbortError', 'NotFoundError', 'OverconstrainedError']) {
+			assert.equal(classifyMicErrorCode(n), 'device');
+		}
+		assert.equal(classifyMicErrorCode('WeirdError'), 'unknown');
+		assert.equal(classifyMicErrorCode(undefined), 'unknown');
+	});
+});
+
+describe('mute/deafen call controls (Step 15 — reconciled from the cinny surface)', () => {
+	it('setMicMuted gates the capture send path and flips the track', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		const processor = (h.t as any).processor;
+		assert.ok(processor?.onaudioprocess, 'capture processor must be wired');
+		const fakeEvent = { inputBuffer: { getChannelData: () => new Float32Array([0.5, -0.5, 0.25, -0.25]) } };
+
+		processor.onaudioprocess(fakeEvent);
+		const sentBefore = s.sent.length;
+		assert.ok(sentBefore > 0, 'unmuted capture must send PCM');
+
+		h.t.setMicMuted(true);
+		processor.onaudioprocess(fakeEvent);
+		assert.equal(s.sent.length, sentBefore, 'muted capture must not send');
+		const track = ((h.t as any).micStream as FakeMediaStream).getAudioTracks()[0];
+		assert.equal(track.enabled, false, 'OS mic indicator: track disabled while muted');
+
+		h.t.setMicMuted(false);
+		processor.onaudioprocess(fakeEvent);
+		assert.ok(s.sent.length > sentBefore, 'unmute resumes sending');
+		assert.equal(track.enabled, true);
+		h.t.disconnect();
+	});
+
+	it('setDeafened drops incoming playback (and undeafen restores it)', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		const ctx = FakeAudioContext.created[FakeAudioContext.created.length - 1];
+
+		s.binary(new Int16Array([1000, -1000, 500]).buffer);
+		assert.equal(ctx.bufferSourcesStarted, 1, 'undeafened audio plays');
+
+		h.t.setDeafened(true);
+		s.binary(new Int16Array([1000, -1000, 500]).buffer);
+		assert.equal(ctx.bufferSourcesStarted, 1, 'deafened audio is dropped');
+
+		h.t.setDeafened(false);
+		s.binary(new Int16Array([1000, -1000, 500]).buffer);
+		assert.equal(ctx.bufferSourcesStarted, 2, 'undeafen resumes playback');
+		h.t.disconnect();
+	});
+});
+
+describe('connect timeout (Step 18 — design 1e)', () => {
+	it('exports the 6s default; the constructor can override it', () => {
+		assert.equal(CONNECT_TIMEOUT_MS, 6000);
+		assert.equal(AGENT_STATE_LEGACY_MS, 3000);
+	});
+
+	it('no onopen within the window → latched error + timeout failure; the self-inflicted close never emits closed', async () => {
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		await delay(45); // > connectTimeoutMs
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'error');
+		assert.equal(h.statuses[h.statuses.length - 1].detail, 'Connection timed out');
+		assert.equal(h.failures.length, 1);
+		assert.equal(h.failures[0].kind, 'timeout');
+		assert.equal(h.failures[0].remediation, VOICE_FAILURE_REMEDIATION.timeout);
+		assert.ok(s.closeCalls >= 1, 'socket closed on timeout');
+
+		s.serverClose(1006); // the close the timeout triggered
+		assert.ok(!h.statuses.some((x) => x.status === 'closed'), 'terminal latch: no closed after timeout');
+		assert.equal(h.failures.length, 1, 'exactly one failure per attempt');
+	});
+
+	it('timer is cleared on open — a live session never times out retroactively', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		await delay(45);
+		assert.ok(!h.statuses.some((x) => x.status === 'error'), 'no timeout error after open');
+		h.t.disconnect();
+		assert.equal(s.closeCalls, 1);
+	});
+});
+
+describe('attempt-generation fencing (Step 18 / R10)', () => {
+	it('a stale socket\'s onclose cannot clobber a newer attempt', async () => {
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s1 = h.sock();
+		s1.open();
+		await delay(5);
+		await h.t.connect('ws://fake:9900/'); // second attempt supersedes
+		const s2 = h.sock();
+		assert.notEqual(s1, s2);
+		assert.ok(s1.closeCalls >= 1, 'superseded socket is closed');
+		const before = h.statuses.length;
+		s1.serverClose(1006, 'stale'); // stale close event
+		assert.equal(h.statuses.length, before, 'stale onclose is silently discarded');
+		assert.ok(!h.statuses.some((x) => x.status === 'closed'));
+		h.t.disconnect();
+	});
+
+	it('slow startMic resolving after a second connect() does not touch the new attempt', async () => {
+		const streams: FakeMediaStream[] = [];
+		let releaseFirst!: () => void;
+		const firstGum = new Promise<void>((res) => (releaseFirst = res));
+		let call = 0;
+		gumImpl = async () => {
+			call++;
+			const stream = new FakeMediaStream();
+			streams.push(stream);
+			if (call === 1) await firstGum; // park attempt 1 in the permission prompt
+			return stream;
+		};
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		h.sock().open();
+		await delay(5); // attempt 1 parked inside getUserMedia
+
+		await h.t.connect('ws://fake:9900/'); // supersedes while the prompt is up
+		h.sock().open();
+		await delay(5);
+		const liveCount = h.statuses.filter((x) => x.detail === 'Live — speak now').length;
+		assert.equal(liveCount, 1, 'only the new attempt reports live');
+
+		releaseFirst(); // the old prompt finally resolves
+		await delay(5);
+		assert.equal(streams.length, 2);
+		assert.equal(streams[0].tracks[0].stopped, true, 'stale grant is stopped — no capture leak');
+		assert.equal(streams[1].tracks[0].stopped, false, 'new attempt keeps its mic');
+		assert.equal((h.t as any).micStream, streams[1], 'instance mic belongs to the new attempt');
+		assert.equal(
+			h.statuses.filter((x) => x.detail === 'Live — speak now').length,
+			liveCount,
+			'stale continuation adds no status',
+		);
+		h.t.disconnect();
+	});
+
+	it('disconnect during the connect-side AudioContext.resume await → no replacement socket', async () => {
+		FakeAudioContext.nextState = 'suspended';
+		let release!: () => void;
+		FakeAudioContext.resumeHook = () => new Promise((res) => (release = res));
+		const h = harness();
+		const p = h.t.connect('ws://fake:9900/'); // parks inside resume()
+		await delay(2);
+		assert.equal(FakeSocket.instances.length, 0, 'no socket yet while resume pending');
+		h.t.disconnect();
+		release();
+		await p;
+		await delay(2);
+		assert.equal(FakeSocket.instances.length, 0, 'R10: stale continuation must not create a socket');
+		assert.deepEqual(
+			h.statuses.map((x) => x.status),
+			['connecting', 'closed'],
+			'S6: exactly one synchronous closed; UI not stuck in connecting',
+		);
+	});
+
+	it('disconnect during getUserMedia → grant stopped, exactly one closed, no live', async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((res) => (release = res));
+		const streams: FakeMediaStream[] = [];
+		gumImpl = async () => {
+			const stream = new FakeMediaStream();
+			streams.push(stream);
+			await gate;
+			return stream;
+		};
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		h.sock().open();
+		await delay(5); // parked in the prompt
+		h.t.disconnect();
+		release();
+		await delay(5);
+		assert.equal(streams[0].tracks[0].stopped, true, 'no mic capture outlives the attempt');
+		assert.ok(!h.statuses.some((x) => x.detail === 'Live — speak now'));
+		assert.equal(h.statuses.filter((x) => x.status === 'closed').length, 1);
+	});
+});
+
+describe('user disconnect() (Step 18 / S6)', () => {
+	it('while connecting: synchronous single closed, socket close, timer cleared', async () => {
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		h.t.disconnect(); // before open
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'closed');
+		assert.equal(s.closeCalls, 1);
+		s.serverClose(1006); // fenced — must add nothing
+		await delay(45); // past the connect timeout — timer must be cleared
+		assert.equal(h.statuses.filter((x) => x.status === 'closed').length, 1, 'exactly one closed');
+		assert.ok(!h.statuses.some((x) => x.status === 'error'), 'no late timeout after disconnect');
+	});
+
+	it('while live: synchronous single closed + full teardown; double disconnect adds nothing', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		const track = ((h.t as any).micStream as FakeMediaStream).getAudioTracks()[0];
+		h.t.disconnect();
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'closed');
+		assert.equal(track.stopped, true, 'mic stopped');
+		assert.equal((h.t as any).statsTimer, null, 'stats stopped');
+		s.serverClose(1000);
+		h.t.disconnect(); // idempotent
+		assert.equal(h.statuses.filter((x) => x.status === 'closed').length, 1, 'exactly one closed');
+	});
+
+	it('after a latched terminal error: cleanup only — the error status is preserved', async () => {
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		await delay(45); // timeout → latched error
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'error');
+		h.t.disconnect();
+		assert.equal(
+			h.statuses[h.statuses.length - 1].status,
+			'error',
+			'S6: the terminal-error path stays separate — no closed overwrite',
+		);
+	});
+});
+
+describe('`agent.state` client handling (Step 18 — design 1a′)', () => {
+	const frame = (over: Partial<AgentStateV1>): AgentStateV1 => ({
+		type: 'agent.state',
+		v: 1,
+		initialized: true,
+		upstream: 'live',
+		clientAttached: true,
+		...over,
+	});
+
+	it('legacy server: no frame within the window ⇒ behavior identical to today', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		assert.equal(h.t.agentStateSupport, 'unknown');
+		await delay(45); // > agentStateLegacyMs
+		assert.equal(h.t.agentStateSupport, 'legacy');
+		assert.deepEqual(
+			h.statuses.map((x) => x.status),
+			['connecting', 'live', 'live'],
+			'exactly the pre-protocol status sequence — no error, no extra states',
+		);
+		assert.equal(h.failures.length, 0);
+		assert.equal(h.frames.length, 0);
+		h.t.disconnect();
+		void s;
+	});
+
+	it('connecting/backoff frames are progress detail, never an error', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		s.message(frame({ upstream: 'connecting' }));
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'live');
+		assert.equal(h.statuses[h.statuses.length - 1].detail, 'Waking up…');
+		s.message(frame({ upstream: 'backoff' }));
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'live');
+		assert.equal(h.statuses[h.statuses.length - 1].detail, 'Reconnecting to the model…');
+		assert.equal(h.failures.length, 0, 'backoff must not produce a failure');
+		assert.ok(!h.statuses.some((x) => x.status === 'error'));
+		// idle→connecting→live is the normal wake-up: live after progress restores the live detail
+		s.message(frame({ upstream: 'live' }));
+		assert.equal(h.statuses[h.statuses.length - 1].detail, 'Live — speak now');
+		assert.equal(h.t.agentStateSupport, 'v1');
+		assert.equal(h.frames.length, 3, 'every frame forwarded to onAgentState');
+		h.t.disconnect();
+	});
+
+	it('upstream failed = terminal CLIENT transition: teardown, close, latched classified error, suppressed onclose', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		const track = ((h.t as any).micStream as FakeMediaStream).getAudioTracks()[0];
+		s.message(frame({ upstream: 'failed', reason: 'upstream-auth', category: 'auth' }));
+
+		const last = h.statuses[h.statuses.length - 1];
+		assert.equal(last.status, 'error');
+		assert.match(last.detail!, /credential/i, 'classified auth detail');
+		assert.equal(track.stopped, true, 'mic stopped — not streaming behind the error card');
+		assert.equal((h.t as any).statsTimer, null, 'stats stopped');
+		assert.ok(s.closeCalls >= 1, 'client closes the socket itself (server stays reachable)');
+		assert.equal((h.t as any).ws, null);
+
+		assert.equal(h.failures.length, 1);
+		assert.equal(h.failures[0].kind, 'agent-failed');
+		assert.equal(h.failures[0].reason, 'upstream-auth');
+		assert.equal(h.failures[0].category, 'auth');
+		assert.match(h.failures[0].remediation, /key|voice setup/i);
+
+		s.serverClose(1000); // the self-inflicted close
+		assert.ok(!h.statuses.some((x) => x.status === 'closed'), 'suppressed — error stays latched');
+	});
+
+	it('describeAgentFailure classifies auth/quota/network/other', () => {
+		assert.match(describeAgentFailure('r', 'auth').detail, /credential/i);
+		assert.match(describeAgentFailure('r', 'quota').detail, /quota|credits/i);
+		assert.match(describeAgentFailure('r', 'network').detail, /reach/i);
+		assert.match(describeAgentFailure('r', undefined).detail, /upstream failed/i);
+	});
+});
+
+describe('close-code decoding (Step 18 — W5 client-busy 4409 + superseded 4410)', () => {
+	it('4409 → terminal client-busy error with close info + take-over remediation', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		s.serverClose(CLOSE_CODE_CLIENT_BUSY, 'client-busy');
+		const last = h.statuses[h.statuses.length - 1];
+		assert.equal(last.status, 'error');
+		assert.equal(last.close?.code, 4409);
+		assert.equal(h.failures.length, 1);
+		assert.equal(h.failures[0].kind, 'client-busy');
+		assert.equal(h.failures[0].close?.code, 4409);
+		assert.match(h.failures[0].detail, /in use/i);
+		assert.match(h.failures[0].remediation, /take over/i);
+		assert.ok(!h.statuses.some((x) => x.status === 'closed'), 'not a plain close');
+	});
+
+	it('4410 → its own terminal superseded state, no connect failure, disconnect preserves it', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		const track = ((h.t as any).micStream as FakeMediaStream).getAudioTracks()[0];
+		s.serverClose(CLOSE_CODE_SUPERSEDED_BY_TAKEOVER, 'superseded-by-takeover');
+		const last = h.statuses[h.statuses.length - 1];
+		assert.equal(last.status, 'superseded');
+		assert.equal(last.close?.code, 4410);
+		assert.equal(track.stopped, true, 'audio torn down for the moved call');
+		assert.equal(h.failures.length, 0, 'a takeover is not a connect failure');
+		h.t.disconnect();
+		assert.equal(
+			h.statuses[h.statuses.length - 1].status,
+			'superseded',
+			'terminal latch: no closed overwrite',
+		);
+	});
+});
+
+describe('pre-open failures (Step 18 / Z6 — the browser-observable kind is connect-error)', () => {
+	it('onerror before open → latched connect-error; the trailing 1006 close is suppressed', async () => {
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		s.error();
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'error');
+		assert.equal(h.failures.length, 1);
+		assert.equal(h.failures[0].kind, 'connect-error');
+		s.serverClose(1006);
+		assert.ok(!h.statuses.some((x) => x.status === 'closed'));
+		assert.equal(h.failures.length, 1, 'exactly one failure per attempt');
+	});
+
+	it('pre-open close without onerror → connect-error carrying the close info', async () => {
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		h.sock().serverClose(1006, '');
+		const last = h.statuses[h.statuses.length - 1];
+		assert.equal(last.status, 'error');
+		assert.equal(last.close?.code, 1006);
+		assert.equal(h.failures.length, 1);
+		assert.equal(h.failures[0].kind, 'connect-error');
+		assert.equal(h.failures[0].close?.code, 1006);
+	});
+
+	it('post-open ordinary close stays a plain closed with code/reason (surface reconnect policy)', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		s.serverClose(4000, 'goodbye');
+		const last = h.statuses[h.statuses.length - 1];
+		assert.equal(last.status, 'closed');
+		assert.equal(last.close?.code, 4000);
+		assert.equal(last.close?.reason, 'goodbye');
+		assert.equal(h.failures.length, 0);
+	});
+});
+
+describe('mic failure classification (Step 18 / R12 + X6)', () => {
+	async function failMic(name: string, message = 'boom') {
+		gumImpl = async () => {
+			const err = new Error(message);
+			err.name = name;
+			throw err;
+		};
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		s.open();
+		await delay(5);
+		return { h, s };
+	}
+
+	it('NotAllowedError → mic-permission failure + onMicError + latched error', async () => {
+		const { h, s } = await failMic('NotAllowedError');
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'error');
+		assert.equal(h.micErrors.length, 1);
+		assert.match(h.micErrors[0].friendly, /denied/i);
+		assert.equal(h.failures.length, 1);
+		assert.equal(h.failures[0].kind, 'mic-permission');
+		assert.ok(s.closeCalls >= 1, 'no auto-reconnect loop on a hard mic failure');
+		s.serverClose(1006);
+		assert.ok(!h.statuses.some((x) => x.status === 'closed'), 'latched — no closed overwrite');
+	});
+
+	it('NotReadableError → mic-device', async () => {
+		const { h } = await failMic('NotReadableError');
+		assert.equal(h.failures[0].kind, 'mic-device');
+		assert.match(h.failures[0].detail, /in use/i);
+	});
+
+	it('X6: unclassified DOM exception → mic-other with Retry remediation (never credential repair)', async () => {
+		const { h } = await failMic('SomethingNewError');
+		assert.equal(h.failures[0].kind, 'mic-other');
+		assert.equal(h.failures[0].remediation, 'Retry.');
+		assert.doesNotMatch(h.failures[0].remediation, /key|credential|setup/i);
+	});
+});
+
+describe('transport public API additions (Steps 15/16/18)', () => {
+	it('sendTextInput: false when not open, true + JSON frame when live', async () => {
+		const h = harness();
+		assert.equal(h.t.sendTextInput('hi'), false);
+		const s = await goLive(h);
+		const before = s.sent.length;
+		assert.equal(h.t.sendTextInput('hello agent'), true);
+		const sent = s.sent[s.sent.length - 1];
+		assert.equal(typeof sent, 'string');
+		assert.deepEqual(JSON.parse(sent as string), { type: 'text_input', text: 'hello agent' });
+		assert.equal(s.sent.length, before + 1);
+		h.t.disconnect();
+	});
+
+	it('setPlaybackRate drives subsequent playback scheduling', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		h.t.setPlaybackRate(1.2);
+		s.binary(new Int16Array([100, 200, 300]).buffer);
+		assert.equal((h.t as any).playbackRate, 1.2);
+		h.t.disconnect();
+	});
+
+	it('failure-union remediation table covers every kind exactly once', () => {
+		const kinds = [
+			'timeout',
+			'connect-error',
+			'mic-permission',
+			'mic-device',
+			'mic-other',
+			'agent-failed',
+			'service-down',
+			'client-busy',
+		];
+		assert.deepEqual(Object.keys(VOICE_FAILURE_REMEDIATION).sort(), [...kinds].sort());
+		for (const k of kinds) {
+			assert.ok(
+				(VOICE_FAILURE_REMEDIATION as Record<string, string>)[k].length > 0,
+				k + ' has a remediation hint',
+			);
+		}
 	});
 });

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -623,6 +623,136 @@ describe('attempt-generation fencing (Step 18 / R10)', () => {
 	});
 });
 
+describe('attempt conclusion invalidates the generation (fix round — server-close-while-parked repro)', () => {
+	/** Park getUserMedia behind a gate and capture every granted stream. */
+	function parkGum() {
+		let release!: () => void;
+		const gate = new Promise<void>((res) => (release = res));
+		const streams: FakeMediaStream[] = [];
+		gumImpl = async () => {
+			const stream = new FakeMediaStream();
+			streams.push(stream);
+			await gate;
+			return stream;
+		};
+		return { release: () => release(), streams };
+	}
+
+	it('server close (1006) while getUserMedia is parked → closed stays final, grant stopped, no stats leak', async () => {
+		const gum = parkGum();
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		s.open();
+		await delay(5); // attempt parked in the permission prompt
+		s.serverClose(1006, 'dropped'); // the server drops while the prompt is up
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'closed');
+		assert.equal(h.statuses[h.statuses.length - 1].close?.code, 1006);
+
+		gum.release(); // the user then grants the mic — for a dead attempt
+		await delay(5);
+		assert.equal(
+			h.statuses[h.statuses.length - 1].status,
+			'closed',
+			'the close-derived final status stays — the dead attempt must not resume',
+		);
+		assert.ok(
+			!h.statuses.some((x) => x.detail === 'Live — speak now'),
+			'the dead attempt never reports live',
+		);
+		assert.equal(h.statuses.filter((x) => x.status === 'closed').length, 1, 'exactly one final status');
+		assert.equal(gum.streams.length, 1);
+		assert.equal(gum.streams[0].tracks[0].stopped, true, 'granted tracks stopped — no capture leak');
+		assert.equal((h.t as any).micStream, null, 'no stream captured for the dead attempt');
+		assert.equal((h.t as any).statsTimer, null, 'no statsTimer keeps the runner alive');
+	});
+
+	it('close 4409 while getUserMedia is parked → latched client-busy error survives the late grant', async () => {
+		const gum = parkGum();
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		s.open();
+		await delay(5); // attempt parked in the permission prompt
+		s.serverClose(CLOSE_CODE_CLIENT_BUSY, 'client-busy'); // another surface owns the call
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'error');
+		assert.equal(h.failures.length, 1);
+		assert.equal(h.failures[0].kind, 'client-busy');
+
+		gum.release();
+		await delay(5);
+		assert.equal(
+			h.statuses[h.statuses.length - 1].status,
+			'error',
+			'latched client-busy error survives — never overwritten by live',
+		);
+		assert.ok(!h.statuses.some((x) => x.detail === 'Live — speak now'));
+		assert.ok(!h.statuses.some((x) => x.status === 'closed'), 'terminal latch holds');
+		assert.equal(h.failures.length, 1, 'exactly one failure per attempt');
+		assert.equal(gum.streams[0].tracks[0].stopped, true, 'granted tracks stopped');
+		assert.equal((h.t as any).statsTimer, null, 'no stats leak');
+	});
+
+	it('R10: disconnect during startMic\'s INTERNAL resume() await — grant stopped, newer attempt untouched', async () => {
+		const streams: FakeMediaStream[] = [];
+		gumImpl = async () => {
+			const stream = new FakeMediaStream();
+			streams.push(stream);
+			return stream;
+		};
+		let release!: () => void;
+		const h = harness();
+		await h.t.connect('ws://fake:9900/'); // ctx born 'running' → no connect-side resume
+		h.sock().open(); // handleOpen → startMic parks at the getUserMedia microtask
+		// Suspend the context BEFORE getUserMedia resolves so the await the
+		// attempt parks in is startMic's OWN resume() (post-capture), not
+		// connect()'s — the R10 fence at that await is otherwise uncovered.
+		FakeAudioContext.created[0].state = 'suspended';
+		FakeAudioContext.resumeHook = () => new Promise((res) => (release = res));
+		await delay(5); // getUserMedia resolved → stream captured → parked in resume()
+		assert.equal(streams.length, 1);
+		assert.equal((h.t as any).micStream, streams[0], 'precondition: captured before the resume await');
+
+		h.t.disconnect(); // while parked in resume()
+		assert.equal(h.statuses[h.statuses.length - 1].status, 'closed');
+
+		FakeAudioContext.resumeHook = null; // the newer attempt must not park
+		await h.t.connect('ws://fake:9900/'); // newer attempt while attempt 1 is still parked
+		h.sock().open();
+		await delay(5);
+		assert.equal(streams.length, 2, 'newer attempt captured its own stream');
+		assert.equal((h.t as any).micStream, streams[1], 'newer attempt owns the mic');
+
+		release(); // attempt 1's parked resume finally resolves
+		await delay(5);
+		assert.equal(streams[0].tracks[0].stopped, true, 'attempt-1 grant stopped, not leaked');
+		assert.equal(streams[1].tracks[0].stopped, false, 'stale continuation must not stop the newer mic');
+		assert.equal((h.t as any).micStream, streams[1], 'stale continuation must not clobber micStream');
+		assert.equal(h.statuses.filter((x) => x.status === 'closed').length, 1, 'exactly one closed emitted');
+		assert.equal(
+			h.statuses.filter((x) => x.detail === 'Live — speak now').length,
+			1,
+			'only the newer attempt reports live',
+		);
+		h.t.disconnect();
+	});
+
+	it('a direct second connect() over live flushes the old session\'s scheduled playback', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		s.binary(new Int16Array([1000, -1000, 500]).buffer);
+		assert.ok(((h.t as any).activeSources as unknown[]).length > 0, 'precondition: audio scheduled');
+		await h.t.connect('ws://fake:9900/'); // no disconnect() in between
+		assert.equal(
+			((h.t as any).activeSources as unknown[]).length,
+			0,
+			'old session audio is stopped, not carried into the new attempt',
+		);
+		assert.equal((h.t as any).nextPlayTime, 0, 'playback clock restarts for the new attempt');
+		h.t.disconnect();
+	});
+});
+
 describe('user disconnect() (Step 18 / S6)', () => {
 	it('while connecting: synchronous single closed, socket close, timer cleared', async () => {
 		const h = harness();

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -872,6 +872,180 @@ describe('disconnect() awaitable teardown (T8 — teardown awaited before lease 
 	});
 });
 
+describe('closeSettled() — attempt-conclusion close completion (P1: lease release must await the handshake)', () => {
+	it('fresh transport: resolved immediately (no socket ever existed)', async () => {
+		const t = new VoiceTransport();
+		let settled = false;
+		void t.closeSettled().then(() => {
+			settled = true;
+		});
+		await delay(0);
+		assert.equal(settled, true);
+	});
+
+	it('mic-error while the socket is open → the completion read INSIDE onConnectFailure settles only after the socket close event', async () => {
+		gumImpl = async () => {
+			const err = new Error('denied');
+			err.name = 'NotAllowedError';
+			throw err;
+		};
+		const failures: VoiceConnectFailure[] = [];
+		let atFailure: Promise<void> | null = null;
+		const h = harness({
+			onConnectFailure: (f) => {
+				failures.push(f);
+				// The contract consumers rely on: the completion is already
+				// latched when the failure callback runs.
+				atFailure = h.t.closeSettled();
+			},
+		});
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		s.open();
+		await delay(5); // startMic throws → latched mic error
+		assert.equal(failures[0]?.kind, 'mic-permission');
+		assert.ok(atFailure, 'closeSettled() readable from inside onConnectFailure');
+		assert.ok(s.closeCalls >= 1, 'transport closed its socket');
+		let settled = false;
+		void atFailure!.then(() => {
+			settled = true;
+		});
+		await delay(10);
+		assert.equal(settled, false, 'not settled while the self-inflicted close handshake is in flight');
+		s.serverClose(1006); // the handshake completes
+		await delay(0);
+		assert.equal(settled, true, 'settles once the socket close event fires');
+	});
+
+	it('connect timeout → closeSettled() resolves only after the socket close event', async () => {
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		await delay(45); // > connectTimeoutMs → latched timeout error
+		assert.equal(h.failures[0]?.kind, 'timeout');
+		let settled = false;
+		void h.t.closeSettled().then(() => {
+			settled = true;
+		});
+		await delay(10);
+		assert.equal(settled, false, 'timeout latched but the close handshake is still in flight');
+		s.serverClose(1006);
+		await delay(0);
+		assert.equal(settled, true);
+	});
+
+	it('pre-open socket error → closeSettled() resolves only after the trailing close event', async () => {
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		s.error(); // pre-open → latched connect-error
+		assert.equal(h.failures[0]?.kind, 'connect-error');
+		let settled = false;
+		void h.t.closeSettled().then(() => {
+			settled = true;
+		});
+		await delay(10);
+		assert.equal(settled, false, 'error latched but the trailing 1006 close has not fired yet');
+		s.serverClose(1006); // the browser's trailing close
+		await delay(0);
+		assert.equal(settled, true);
+	});
+
+	it('upstream-failed teardown → closeSettled() resolves only after the self-inflicted close event', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		s.message({
+			type: 'agent.state',
+			v: 1,
+			initialized: true,
+			upstream: 'failed',
+			reason: 'upstream-auth',
+			category: 'auth',
+			clientAttached: true,
+		});
+		assert.equal(h.failures[0]?.kind, 'agent-failed');
+		let settled = false;
+		void h.t.closeSettled().then(() => {
+			settled = true;
+		});
+		await delay(10);
+		assert.equal(settled, false, 'agent-failed latched but the close handshake is still in flight');
+		s.serverClose(1000); // the self-inflicted close completes
+		await delay(0);
+		assert.equal(settled, true);
+	});
+
+	it('server-initiated closes (plain / 4409 / 4410) → closeSettled() captured at the terminal status is already settled', async () => {
+		for (const code of [4000, CLOSE_CODE_CLIENT_BUSY, CLOSE_CODE_SUPERSEDED_BY_TAKEOVER]) {
+			let captured: Promise<void> | null = null;
+			const h = harness({
+				onStatus: (status, detail, close) => {
+					h.statuses.push({ status, detail, close });
+					if (status === 'closed' || status === 'error' || status === 'superseded') {
+						captured = h.t.closeSettled();
+					}
+				},
+			});
+			const s = await goLive(h);
+			s.serverClose(code, 'server-close');
+			assert.ok(captured, `code ${code}: terminal status observed`);
+			let settled = false;
+			void captured!.then(() => {
+				settled = true;
+			});
+			await delay(0); // no close event, no fallback — a microtask must suffice
+			assert.equal(settled, true, `code ${code}: socket already closed ⇒ completion already settled`);
+		}
+	});
+
+	it('bounded fallback: a wedged self-close handshake resolves after disconnectCloseTimeoutMs', async () => {
+		gumImpl = async () => {
+			const err = new Error('busy');
+			err.name = 'NotReadableError';
+			throw err;
+		};
+		const h = harness({ disconnectCloseTimeoutMs: 20 });
+		await h.t.connect('ws://fake:9900/');
+		h.sock().open();
+		await delay(5); // mic-error latch; the fake deliberately never emits its close event
+		assert.equal(h.failures[0]?.kind, 'mic-device');
+		let settled = false;
+		void h.t.closeSettled().then(() => {
+			settled = true;
+		});
+		await delay(5);
+		assert.equal(settled, false, 'still awaiting a close that never comes');
+		await delay(40); // past the injected bound
+		assert.equal(settled, true, 'fallback fires — a wedged handshake cannot hang lease release');
+	});
+
+	it('a later disconnect() with the socket already gone returns the still-pending conclusion completion', async () => {
+		// Consumer shape: transport-initiated failure → surface ALSO calls
+		// disconnect() for cleanup. The returned promise must still cover the
+		// in-flight handshake of the socket the latch already closed.
+		gumImpl = async () => {
+			const err = new Error('denied');
+			err.name = 'NotAllowedError';
+			throw err;
+		};
+		const h = harness();
+		await h.t.connect('ws://fake:9900/');
+		const s = h.sock();
+		s.open();
+		await delay(5); // mic-error latch: socket closed + nulled by the transport
+		assert.equal(h.failures[0]?.kind, 'mic-permission');
+		let settled = false;
+		void h.t.disconnect().then(() => {
+			settled = true;
+		});
+		await delay(10);
+		assert.equal(settled, false, 'disconnect() after the latch still awaits the old handshake');
+		s.serverClose(1006);
+		await delay(0);
+		assert.equal(settled, true);
+	});
+});
+
 describe('`agent.state` client handling (Step 18 — design 1a′)', () => {
 	const frame = (over: Partial<AgentStateV1>): AgentStateV1 => ({
 		type: 'agent.state',

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -13,6 +13,7 @@ import {
 	CLOSE_CODE_SUPERSEDED_BY_TAKEOVER,
 	CONNECT_TIMEOUT_MS,
 	AGENT_STATE_LEGACY_MS,
+	DISCONNECT_CLOSE_TIMEOUT_MS,
 	VOICE_FAILURE_REMEDIATION,
 	type VoiceConnectFailure,
 	type VoiceTransportOptions,
@@ -496,6 +497,7 @@ describe('connect timeout (Step 18 — design 1e)', () => {
 	it('exports the 6s default; the constructor can override it', () => {
 		assert.equal(CONNECT_TIMEOUT_MS, 6000);
 		assert.equal(AGENT_STATE_LEGACY_MS, 3000);
+		assert.equal(DISCONNECT_CLOSE_TIMEOUT_MS, 1500);
 	});
 
 	it('no onopen within the window → latched error + timeout failure; the self-inflicted close never emits closed', async () => {
@@ -791,6 +793,82 @@ describe('user disconnect() (Step 18 / S6)', () => {
 			'error',
 			'S6: the terminal-error path stays separate — no closed overwrite',
 		);
+	});
+});
+
+describe('disconnect() awaitable teardown (T8 — teardown awaited before lease release)', () => {
+	it('over a live session: the promise resolves only after the socket\'s real close event', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		let resolved = false;
+		const p = h.t.disconnect().then(() => {
+			resolved = true;
+		});
+		assert.equal(
+			h.statuses[h.statuses.length - 1].status,
+			'closed',
+			'the synchronous closed status fires before the promise resolves',
+		);
+		await delay(10);
+		assert.equal(resolved, false, 'not resolved while the close handshake is still in flight');
+		s.serverClose(1000); // the async close handshake completes
+		await p;
+		assert.equal(resolved, true);
+		assert.equal(
+			h.statuses.filter((x) => x.status === 'closed').length,
+			1,
+			'the real close event resolves the promise but adds no second status (still fenced)',
+		);
+	});
+
+	it('close() alias returns the same awaitable completion', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		let resolved = false;
+		void h.t.close().then(() => {
+			resolved = true;
+		});
+		await delay(10);
+		assert.equal(resolved, false, 'alias also waits for the close handshake');
+		s.serverClose(1000);
+		await delay(0);
+		assert.equal(resolved, true);
+	});
+
+	it('with no socket: resolves immediately', async () => {
+		const t = new VoiceTransport();
+		let resolved = false;
+		void t.disconnect().then(() => {
+			resolved = true;
+		});
+		await delay(0);
+		assert.equal(resolved, true, 'no socket ⇒ nothing to await');
+	});
+
+	it('over an already-CLOSED socket: resolves immediately (no close event will ever fire)', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		s.readyState = 3; // CLOSED under the transport — its event already spent/fenced
+		let resolved = false;
+		void h.t.disconnect().then(() => {
+			resolved = true;
+		});
+		await delay(0);
+		assert.equal(resolved, true, 'already-CLOSED socket ⇒ immediate resolve');
+	});
+
+	it('a wedged handshake is bounded: the fallback resolves after disconnectCloseTimeoutMs', async () => {
+		const h = harness({ disconnectCloseTimeoutMs: 20 });
+		const s = await goLive(h);
+		let resolved = false;
+		void h.t.disconnect().then(() => {
+			resolved = true;
+		});
+		await delay(5);
+		assert.equal(resolved, false, 'still waiting on a close that never comes');
+		await delay(40); // past the injected bound
+		assert.equal(resolved, true, 'fallback fires — a wedged handshake cannot hang teardown');
+		void s; // the fake deliberately never emits close
 	});
 });
 


### PR DESCRIPTION
Part of the voice reliability & onboarding plan (desktop repo: `docs/design-voice-reliability-and-onboarding.md` §1e, `docs/impl-plan-voice-reliability-and-onboarding.md` WS1 Steps 15–18 + amendments R10/R11/R12/S6/W5/X6/Z6). #2689 is merged; this branch is rebuilt on its merge and current `main`, so the PR diff is transport-only.

## What changed, and why?

Seven commits, one concern: **the web voice client fails fast and predictably, from one canonical transport**.

1. **`4aa02b86`** — `src/web-voice-transport.ts` becomes the single canonical client transport (design 1e):
   - **6 s connect timeout** with terminal-state latching — the incident class this plan exists for (agent wedged, socket never opens or drops immediately) now surfaces a typed failure instead of "Connecting…" forever.
   - **Attempt-generation fencing (R10)**: every `await` boundary (AudioContext resume, `getUserMedia`, mic start) re-checks the attempt generation, so stale continuations can't resurrect a dead attempt.
   - **`agent.state` handling**: consumes the #2689 protocol (`connecting`/`backoff`/`failed` reflected in status detail; `upstream: failed` is a terminal client teardown), with a 3 s legacy fallback for pre-protocol agents.
   - **Typed failure union (R12/X6/Z6)**: `onConnectFailure` reports `timeout | connect-error | mic-permission | mic-device | mic-other | agent-failed | service-down | client-busy`; close codes **4409** (client-busy, W5) and **4410** (superseded-by-takeover → its own terminal `superseded` status, never a failure callback) are decoded.
   - **Step 15 reconciliation**: cinny's mute/deafen gates and `classifyMicErrorCode` merged upstream so the vendored copies can be verbatim again.
2. **`c7662cfb`** — `web-client.ts`'s voice page drops its inline duplicate transport and runs on the served `SutandoVoice` IIFE (`/web-voice-transport.js`), Step 16/R11: one implementation, surface concerns only. Two additive public methods (`sendTextInput`, `setPlaybackRate`) keep the page at feature parity.
3. **`710b75bd`** — fix round from adversarial review (blocker): attempt-concluding paths (`handleClose` all branches, connect timeout, mic-error) now **bump the attempt generation** — uniform invariant *attempt concluded ⇒ generation invalidated*. Without it, a server close arriving while the `getUserMedia` prompt was open let the dead attempt resume to `live` with the mic captured and the stats timer leaked (repro'd in tests, below). Also: `connect()`-over-live flushes stale scheduled playback; events-doc correction.
4. **`8e3dedb3`** — `src/voice-connect-resolver.ts` reconciles cinny's `tailnet` tier ladder upstream (byte-identical to the cinny copy), so **both** vendored voice files are now verbatim and drift-gated in cinny.
5. **`d8947985`** — `disconnect()` returns an awaitable completion that settles after the WebSocket close handshake (bounded for wedged peers), so lease release cannot race transport teardown.
6. **`370e2f58`** — every terminal conclusion exposes the same awaitable `closeSettled()` contract, including timeout, mic failure, server close, 4409/4410, and upstream-failed paths.
7. **`a48577fb`** — removes redundant probe initialization from the reconciled resolver.

## What files / sections should reviewers look at first?

- `src/web-voice-transport.ts`: the class-header invariants comment, then `handleClose` / `onConnectTimeout` / the mic-error catch (the generation-invalidation fix), then `decodeCloseInfo` (4409/4410).
- `tests/web-voice-transport.test.ts`: the "fix round" describe block — the two blocker repros are the spec of the bug.
- `src/web-client.ts`: the voice page script block (now plain JS on `SutandoVoice`, per the CONTRIBUTING embedded-script rule).

## What user behavior or bug does this prove?

- Mic click against a dead/wedged agent: "Connecting…" resolves to a typed error within 6 s (previously indefinite).
- Agent crash mid-prompt (or 4409 busy rejection): the error stays latched — previously the UI could flip to "Live — speak now" with the mic captured and **no socket** (OS mic indicator on, nobody listening).
- A second client while a call is active: decoded `client-busy`; a takeover supersedes the old client with its own `superseded` terminal state instead of a spurious error.

## Feature/documentation consistency

N/A for `docs/` canonical documents — same rationale the reviewers accepted on #2689: `docs/catalog.json` has no canonical doc for the web voice client; the canonical spec for this cross-repo feature is the desktop repo's `docs/design-voice-reliability-and-onboarding.md` (§1e), and module-level docs live in the source headers here. `docs/voice-agent-test-framework.md` (agent-side test framework) is unaffected.

## Before/after evidence

New discriminating vectors run against the parent commit (detached worktree at `387539a2`, test file only overlaid from `3eff47bf`):

```
$ git worktree add --detach /tmp/wt-prefix 387539a2 && cd /tmp/wt-prefix
$ git checkout 3eff47bf -- tests/web-voice-transport.test.ts
$ npx tsx --test --test-force-exit tests/web-voice-transport.test.ts
✖ attempt conclusion invalidates the generation (fix round — server-close-while-parked repro)
ℹ tests 57
ℹ pass 54
ℹ fail 3
✖ failing tests:
✖ server close (1006) while getUserMedia is parked → closed stays final, grant stopped, no stats leak
✖ close 4409 while getUserMedia is parked → latched client-busy error survives the late grant
✖ a direct second connect() over live flushes the old session's scheduled playback
```

(`--test-force-exit` is required *before* the fix: the leaked statsTimer from the repro hangs the runner — the leak is itself part of the bug.)

Same suite at HEAD:

```
$ npx tsx --test tests/web-voice-transport.test.ts
ℹ tests 57
ℹ pass 57
ℹ fail 0
```

## What tests did you run?

- Post-rebuild targeted run: `npx --no-install tsx --test tests/web-voice-transport.test.ts tests/web-voice-transport-delivery.test.ts tests/voice-connect-resolver.test.ts` — **91/91**, 0 fail (transport 70, delivery 9, resolver 12).
- `npx --no-install tsc --noEmit` — clean.
- `git diff origin/main...HEAD | bash scripts/review-checks.sh` — PASS (hardcoded paths clean).
- Prior cumulative evidence remains: full TS suite **812/812**, `npm run build:bundle` OK (28 KB IIFE), and the affected Python web-client suites green.

## Touching a live path?

The served voice page and its transport are client-side; the delivery suite spawns the real `web-client` and exercises the serve path (above). The full user-visible round trip (mic click → typed failure / live call on a real agent) runs through the desktop app: it will be verified via the desktop repo's `scripts/verify-branch-build.sh` DMG pass with this branch pinned — same protocol as the Phase-1 PRs — and the transcript/console evidence will be appended here before this PR leaves draft.

## Stacked PR?

Parent **#2689** merged as `ffc0e0af`. This branch was rebuilt on that merge/current `main`; all seven transport patches are unchanged by `range-diff`, and the PR diff is now child-only. Next: **this PR**; **bodhi #27** provides the 4409/4410 server half (either order — the client tolerates it absent). The paired cinny PR must re-vendor the rebuilt source tree verbatim.

## Hardcoded-path check

`git diff origin/main...HEAD | bash scripts/review-checks.sh` → PASS on rebuilt head `a48577fb`.

## Manual verification — packaged DMG pass (2026-08-06)

Local DMG with this branch as the engine transport (integration merge @ `4bb2d9a9` + phase-3 preference; bodhi pinned at the dist-rebuilt PR-27 head `9f027da`; desktop `voice/phase3-control-plane`; cinny `voice/phase3-enable-flow` — whose vendored copy is byte-identical to this branch's file, so every client scenario below exercised this transport verbatim).

**Live-path round trips (CONTRIBUTING evidence).** Real conversation through the transport, from `conversation.sqlite` (`SELECT ts_unix,kind,substr(text,1,60) FROM voice ORDER BY ts_unix DESC`):

```
1786041790.268|agent|Is there a specific directory or file you'd like to explore?
1786041780.839|agent|Your workspace has twelve top-level items, including tasks,
1786041765.249|agent|[task:task-1786041727122] Your workspace has twelve top-leve
1786041728.845|user|Uh what's in my workspace?
1786041727.125|tool_call|work
1786041708.026|user|Hello. Hello
```

The `tasks/task-1786041727122.txt → results/` file round trip completed in the same exchange — the voice→core bridge through this transport, not just the Gemini loop.

**Fail-fast + reconnect (incident class).** Three `kill -9`s of the agent mid-session: the client latched a typed error each time (no self-resurrecting "Live"), and each user-initiated reconnect attached to the replacement within seconds. The `[VoiceFailure] classifier wired into transport.onClose` boot line confirms the classifier active in the packaged agent.

**W5/4409/4410 decode, end-to-end through a real bodhi server** (first live proof of the takeover wire contract): with a call active in the app, the webUI second client showed "Voice is in use on another surface — Take over the call here" (4409 busy + affordance, no call stealing); taking over superseded the app client, which rendered its own calm terminal ("Call moved — your voice call was taken over on another surface"), i.e. the 4410 → `superseded` status path, not an error. Reverse direction also checked: second client busy-rejected, incumbent call unaffected.

**Step-16 page on the canonical IIFE**: the webUI surface used throughout S6 is the served `SutandoVoice` transport page from this branch — connect, converse, busy-reject, and take over all through `/web-voice-transport.js`.

Verification/handoff timing through this transport: `stage=verify code=live` then `enable-voice-handoff … ms=44` / `ms=41` (same live attempt handed to the session, no second dial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


