### PR TITLE
feat(credentials): S1 voice-source truth table — voicePreference + logout quarantine across every consumer (voice plan WS2 Steps 3–6)

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -6,7 +6,7 @@
       "audience": ["contributors", "maintainers"],
       "status": "draft",
       "canonical_for": "the capability-not-key credential-resolver contract: tier order, managed-file schema, source observability, and the reader-sweep migration plan",
-      "last_verified": "2026-08-02"
+      "last_verified": "2026-08-05"
     },
     "docs/runtime-dependencies.md": {
       "title": "External runtime dependencies",

--- a/docs/design-credential-capability-resolver.md
+++ b/docs/design-credential-capability-resolver.md
@@ -22,7 +22,7 @@ A consumer asks for a **capability** — what it needs to *do* — and the
 resolver decides which credential satisfies it:
 
 ```ts
-resolveCredential('gemini-voice')  →  { key, source: 'managed' | 'env' | 'none' }
+resolveCredential('gemini-voice')  →  { key, source: 'managed' | 'env' | 'none', credentialGeneration? }
 ```
 
 Three rules, all load-bearing. Rules 1–2 and the *resolver-seam* half of rule 3
@@ -54,11 +54,60 @@ are implemented by #2197's `src/credential-resolver.ts`; rule 3's Settings/healt
    desktop first-run banner (G5) and Settings (G6) build on the returned
    property to do.
 
+### Voice-source policy gates (S1)
+
+Two top-level managed-file fields modulate rules 1–2 for the **voice**
+capability (design authority: the desktop repo's
+`docs/design-voice-reliability-and-onboarding.md` §2b, amendment S1):
+
+- **`voicePreference`** (`"managed" | "byok"`; unset ⇒ legacy):
+  - *unset* — rules 1–2 apply unchanged (managed → env, voice → text).
+  - *`managed`* — only a non-quarantined **managed** entry satisfies
+    `gemini-voice`; env keys never silently substitute. A managed-preference
+    install with no managed key resolves `none` — a typed absence the
+    desktop enable-voice flow routes on, rather than a wrong-source key.
+  - *`byok`* — only **env** keys satisfy `gemini-voice`; managed slots are
+    skipped entirely.
+- **`quarantined`** (honored only as strict JSON `true`; stamped by the
+  desktop host at logout): every managed entry is treated as absent, in
+  every mode — a preserved managed key must never satisfy a resolution
+  after logout.
+
+The preference governs the voice capability; `gemini-text` resolution is
+preference-independent (its consumers are not voice surfaces) but still
+honors `quarantined`. Resolution also returns the satisfying credential's
+**`credentialGeneration`** (opaque `cg1-<UUID>`: the managed entry's
+`generation` field, or `SUTANDO_VOICE_CREDENTIAL_GENERATION` for env keys
+when present) so a supervisor can verify *which* credential a running agent
+loaded. The full truth table is pinned one-for-one across all four
+consumers — TS resolver, Python twin, startup gate, health check — by
+`tests/voice-preference-consumers.test.sh` +
+`tests/fixtures/voice-preference-matrix.json` (the desktop supervisor
+asserts the same fixture verbatim on its side).
+
 ## Managed-file schema
 
 ```json
-{ "version": 1, "capabilities": { "gemini-voice": { "key": "…" }, "gemini-text": { "key": "…" } } }
+{
+  "version": 1,
+  "capabilities": {
+    "gemini-voice": { "key": "…", "generation": "cg1-…" },
+    "gemini-text": { "key": "…" }
+  },
+  "voicePreference": "managed",
+  "preferenceRevision": 4,
+  "sessionRevision": 2,
+  "quarantined": false
+}
 ```
+
+The policy fields (`voicePreference`, `preferenceRevision`,
+`sessionRevision`, `quarantined`) and the per-entry `generation` are written
+by the desktop host's credential provisioner (desktop design doc §2b; the
+Rust writer is in flight as of 2026-08). Readers here honor them per S1 and
+keep the existing failure posture: malformed file ⇒ managed tier skipped,
+`voicePreference` outside the two literals ⇒ unset, `quarantined` anything
+but strict `true` ⇒ not quarantined.
 
 Writers (**required of a future provisioner — not yet implemented**): the
 desktop onboarding flow (G1/G2, air's lane) or AU provisioning. **No production

--- a/src/credential-resolver.ts
+++ b/src/credential-resolver.ts
@@ -14,6 +14,28 @@
  * mirroring the existing GEMINI_VOICE_API_KEY → GEMINI_API_KEY chain, so a
  * single-key setup keeps working unchanged at every tier.
  *
+ * `voicePreference` truth table (design 2b; amendment S1 — the SHARED
+ * credential-source table this resolver, the supervisor injection/`requires`
+ * gate, `startup-runtime.sh`'s shell gate, `health-check.py`, and Rust status
+ * all implement; `tests/voice-preference-consumers.test.sh` pins agreement):
+ *
+ *   - unset (legacy — every pre-preference install): managed(voice→text)→env,
+ *     exactly the tier walk above.
+ *   - 'managed': ONLY a non-quarantined managed entry satisfies the voice
+ *     capability. A present env key must NOT silently satisfy a managed
+ *     preference — that would be the logout-quarantine bypass. No usable
+ *     managed entry ⇒ `{key:'', source:'none'}` (fail actionably).
+ *   - 'byok': the managed tier is skipped entirely for the voice capability
+ *     (both fallback slots); only env keys satisfy. No env key ⇒
+ *     `{key:'', source:'none'}` (fail actionably).
+ *   - `quarantined: true` (signed-out quarantine, design 2b): every managed
+ *     entry is treated as ABSENT in every mode and for every capability.
+ *
+ * `voicePreference` scopes the VOICE capability; 'gemini-text' resolution is
+ * preference-independent (its consumers are not voice surfaces) but still
+ * honors the quarantine marker — quarantine is about revoking managed
+ * credentials after logout, not about source choice.
+ *
  * With no managed file present (every pre-managed install), resolution is
  * byte-for-byte identical to the legacy env chain — this module changes where
  * the decision lives, not what it decides.
@@ -21,10 +43,19 @@
  * The `source` field is the point of G8: Settings and health-check surface
  * WHICH tier satisfied the capability ("voice: managed" / "voice: BYO"), so
  * managed-vs-BYO drop-in is observable rather than asserted.
+ * `credentialSourceLabel()` maps it onto the design's user-facing
+ * 'managed' | 'byok' | 'none' vocabulary without breaking 'env' consumers.
  *
  * Managed-file schema (version 1):
- *   { "version": 1, "capabilities": { "gemini-voice": { "key": "..." }, ... } }
- * Malformed or unreadable files skip the managed tier — never throw.
+ *   { "version": 1, "capabilities": { "gemini-voice": { "key": "...",
+ *     "generation": "cg1-…"? }, ... },
+ *     "voicePreference": "managed"|"byok"?, "quarantined": bool?,
+ *     "preferenceRevision": u64?, "sessionRevision": u64? }
+ * `preferenceRevision`/`sessionRevision` are top-level coordination metadata
+ * committed in the same atomic write as the policy fields (amendment R15);
+ * this read side tolerates and ignores them. Malformed or unreadable files
+ * skip the managed tier (empty caps, unset preference, not quarantined) —
+ * never throw.
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -66,13 +97,33 @@ export function managedCredentialsPath(): string {
 	return join(resolveWorkspace(), 'state', 'auth', 'managed-credentials.json');
 }
 
-function readManaged(path: string): Record<string, { key?: unknown; generation?: unknown }> {
+/** The user-committed voice credential-source preference (design 2b). */
+export type VoicePreference = 'managed' | 'byok';
+
+interface ManagedFile {
+	caps: Record<string, { key?: unknown; generation?: unknown }>;
+	/** Top-level `voicePreference`; anything but the two literals ⇒ unset. */
+	voicePreference: VoicePreference | undefined;
+	/**
+	 * Top-level signed-out quarantine marker (strictly `true` — the only
+	 * writer is the Rust host, which writes real JSON booleans; a whole-file
+	 * corruption fails the parse and skips the managed tier anyway).
+	 */
+	quarantined: boolean;
+}
+
+function readManaged(path: string): ManagedFile {
 	try {
 		const parsed = JSON.parse(readFileSync(path, 'utf8'));
 		const caps = parsed?.capabilities;
-		return caps && typeof caps === 'object' && !Array.isArray(caps) ? caps : {};
+		const pref = parsed?.voicePreference;
+		return {
+			caps: caps && typeof caps === 'object' && !Array.isArray(caps) ? caps : {},
+			voicePreference: pref === 'managed' || pref === 'byok' ? pref : undefined,
+			quarantined: parsed?.quarantined === true,
+		};
 	} catch {
-		return {};
+		return { caps: {}, voicePreference: undefined, quarantined: false };
 	}
 }
 
@@ -82,21 +133,32 @@ export function resolveCredential(
 ): ResolvedCredential {
 	const slots = CAPABILITY_FALLBACKS[capability];
 	const managed = readManaged(opts?.managedPath ?? managedCredentialsPath());
-	for (const slot of slots) {
-		const entry = managed[slot];
-		const key = entry?.key;
-		if (typeof key === 'string' && key) {
-			// S3: managed entries may carry an opaque Rust-minted `generation`.
-			// Report it verbatim; legacy entries without one omit the field.
-			const generation = entry?.generation;
-			return {
-				key,
-				source: 'managed',
-				...(typeof generation === 'string' && generation
-					? { credentialGeneration: generation }
-					: {}),
-			};
+	// S1: the preference governs the VOICE capability; quarantine hides
+	// managed entries from every capability in every mode.
+	const preference = capability === 'gemini-voice' ? managed.voicePreference : undefined;
+	if (preference !== 'byok' && !managed.quarantined) {
+		for (const slot of slots) {
+			const entry = managed.caps[slot];
+			const key = entry?.key;
+			if (typeof key === 'string' && key) {
+				// S3: managed entries may carry an opaque Rust-minted `generation`.
+				// Report it verbatim; legacy entries without one omit the field.
+				const generation = entry?.generation;
+				return {
+					key,
+					source: 'managed',
+					...(typeof generation === 'string' && generation
+						? { credentialGeneration: generation }
+						: {}),
+				};
+			}
 		}
+	}
+	if (preference === 'managed') {
+		// S1: ONLY a non-quarantined managed entry satisfies a managed
+		// preference — a present env key must not silently satisfy it (the
+		// logout-quarantine bypass the design closes). Fail actionably.
+		return { key: '', source: 'none' };
 	}
 	for (const slot of slots) {
 		const key = process.env[ENV_VARS[slot]];
@@ -104,7 +166,8 @@ export function resolveCredential(
 			// S3/U4: for the voice capability the launcher injects
 			// SUTANDO_VOICE_CREDENTIAL_GENERATION beside a materialized BYOK
 			// key. Report it verbatim; manual/legacy .env keys (no injected
-			// generation) stay generationless.
+			// generation) stay generationless (Y4/Z4: a generic vault write
+			// never carries a transactional generation).
 			const generation =
 				capability === 'gemini-voice'
 					? process.env.SUTANDO_VOICE_CREDENTIAL_GENERATION
@@ -117,4 +180,18 @@ export function resolveCredential(
 		}
 	}
 	return { key: '', source: 'none' };
+}
+
+/**
+ * Map the resolver's internal source onto the design's user-facing
+ * vocabulary (design 2b / impl plan WS2 Step 3): `agent.state`, Settings and
+ * health surfaces say 'byok' where the resolver says 'env'. Kept as a mapper
+ * (not a rename) so existing 'env' consumers keep working unchanged.
+ */
+export function credentialSourceLabel(
+	source: CredentialSource,
+): 'managed' | 'byok' | 'none' {
+	if (source === 'managed') return 'managed';
+	if (source === 'env') return 'byok';
+	return 'none';
 }

--- a/src/credential_resolver.py
+++ b/src/credential_resolver.py
@@ -23,10 +23,36 @@ is byte-for-byte identical to the legacy env chain — this module changes where
 the decision lives, not what it decides. ``source`` surfaces WHICH tier satisfied
 the capability so managed-vs-BYO drop-in is observable (Settings / health-check).
 
+``voicePreference`` truth table (design 2b; amendment S1 — the SHARED
+credential-source table this resolver, the TS twin, the supervisor
+injection/``requires`` gate, ``startup-runtime.sh``'s shell gate,
+``health-check.py``, and Rust status all implement;
+``tests/voice-preference-consumers.test.sh`` pins agreement):
+
+  - unset (legacy — every pre-preference install): managed(voice->text)->env.
+  - 'managed': ONLY a non-quarantined managed entry satisfies the voice
+    capability — a present env key must NOT silently satisfy a managed
+    preference (the logout-quarantine bypass). No usable managed entry =>
+    ``('', 'none')`` (fail actionably).
+  - 'byok': the managed tier is skipped entirely for the voice capability
+    (both fallback slots); only env keys satisfy.
+  - ``quarantined: true`` (signed-out quarantine): every managed entry is
+    treated as ABSENT in every mode and for every capability.
+
+``voicePreference`` scopes the VOICE capability; 'gemini-text' resolution is
+preference-independent but still honors the quarantine marker.
+
 Managed-file schema (version 1):
-  {"version": 1, "capabilities": {"gemini-voice": {"key": "..."}, ...}}
-Malformed or unreadable files skip the managed tier — never raise. ``version`` is
-reserved for future schema changes and is NOT yet enforced (matches the TS twin).
+  {"version": 1,
+   "capabilities": {"gemini-voice": {"key": "...", "generation": "cg1-..."?}, ...},
+   "voicePreference": "managed"|"byok"?, "quarantined": bool?,
+   "preferenceRevision": u64?, "sessionRevision": u64?}
+``preferenceRevision``/``sessionRevision`` are top-level coordination metadata
+committed in the same atomic write as the policy fields (amendment R15); this
+read side tolerates and ignores them. Malformed or unreadable files skip the
+managed tier (empty caps, unset preference, not quarantined) — never raise.
+``version`` is reserved for future schema changes and is NOT yet enforced
+(matches the TS twin).
 """
 
 from __future__ import annotations
@@ -41,11 +67,22 @@ from workspace_default import resolve_workspace
 # Literal capability names (kept as plain strings for py3.8+ compatibility).
 Capability = str  # 'gemini-voice' | 'gemini-text'
 CredentialSource = str  # 'managed' | 'env' | 'none'
+VoicePreference = str  # 'managed' | 'byok'
 
 
 class ResolvedCredential(NamedTuple):
     key: str
     source: CredentialSource
+    # S3: opaque Rust-minted generation (e.g. `cg1-<UUID>`) — REPORTED
+    # verbatim, never minted or derived here. Legacy credentials omit it
+    # (None), matching the TS twin's absent `credentialGeneration` field.
+    credential_generation: Optional[str] = None
+
+
+class _ManagedFile(NamedTuple):
+    caps: dict
+    voice_preference: Optional[VoicePreference]
+    quarantined: bool
 
 
 # Per-capability lookup order within a tier (voice falls back to text).
@@ -65,20 +102,30 @@ def managed_credentials_path() -> Path:
     return resolve_workspace() / "state" / "auth" / "managed-credentials.json"
 
 
-def _read_managed(path: Union[os.PathLike, str]) -> dict:
-    """Return the managed file's ``capabilities`` mapping, or {} on any problem.
+def _read_managed(path: Union[os.PathLike, str]) -> _ManagedFile:
+    """Return the managed file's caps + policy fields, empty/unset on any problem.
 
     Never raises: missing/unreadable/malformed/wrong-shape all skip the tier.
     Mirrors the TS ``readManaged`` — a non-dict ``capabilities`` (list, etc.)
-    yields {}.
+    yields {}; ``voicePreference`` outside the two literals reads as unset;
+    ``quarantined`` is honored only as a strict JSON ``true`` (the only writer
+    is the Rust host, which writes real booleans; whole-file corruption fails
+    the parse and skips the managed tier anyway).
     """
     try:
         with open(path, encoding="utf-8") as fh:
             parsed = json.load(fh)
-        caps = parsed.get("capabilities") if isinstance(parsed, dict) else None
-        return caps if isinstance(caps, dict) else {}
+        if not isinstance(parsed, dict):
+            return _ManagedFile({}, None, False)
+        caps = parsed.get("capabilities")
+        pref = parsed.get("voicePreference")
+        return _ManagedFile(
+            caps if isinstance(caps, dict) else {},
+            pref if pref in ("managed", "byok") else None,
+            parsed.get("quarantined") is True,
+        )
     except (OSError, ValueError, TypeError):
-        return {}
+        return _ManagedFile({}, None, False)
 
 
 def resolve_credential(
@@ -89,17 +136,61 @@ def resolve_credential(
 
     Managed tier (walking the capability's fallback slots) wins over env; within
     each tier voice falls back to text. Tier order beats slot order — a managed
-    TEXT key beats an env VOICE key. Byte-identical to the TS twin.
+    TEXT key beats an env VOICE key. The S1 ``voicePreference``/``quarantined``
+    truth table (module docstring) gates the tiers. Byte-identical to the TS
+    twin.
     """
     slots = _CAPABILITY_FALLBACKS[capability]
     managed = _read_managed(managed_path if managed_path is not None else managed_credentials_path())
-    for slot in slots:
-        entry = managed.get(slot)
-        key = entry.get("key") if isinstance(entry, dict) else None
-        if isinstance(key, str) and key:
-            return ResolvedCredential(key=key, source="managed")
+    # S1: the preference governs the VOICE capability; quarantine hides
+    # managed entries from every capability in every mode.
+    preference = managed.voice_preference if capability == "gemini-voice" else None
+    if preference != "byok" and not managed.quarantined:
+        for slot in slots:
+            entry = managed.caps.get(slot)
+            key = entry.get("key") if isinstance(entry, dict) else None
+            if isinstance(key, str) and key:
+                # S3: report the entry's opaque generation verbatim, when present.
+                generation = entry.get("generation")
+                return ResolvedCredential(
+                    key=key,
+                    source="managed",
+                    credential_generation=generation
+                    if isinstance(generation, str) and generation
+                    else None,
+                )
+    if preference == "managed":
+        # S1: ONLY a non-quarantined managed entry satisfies a managed
+        # preference — a present env key must not silently satisfy it (the
+        # logout-quarantine bypass the design closes). Fail actionably.
+        return ResolvedCredential(key="", source="none")
     for slot in slots:
         key = os.environ.get(_ENV_VARS[slot])
         if key:
-            return ResolvedCredential(key=key, source="env")
+            # S3/U4: for the voice capability the launcher injects
+            # SUTANDO_VOICE_CREDENTIAL_GENERATION beside a materialized BYOK
+            # key. Manual/legacy .env keys stay generationless (Y4/Z4: a
+            # generic vault write never carries a transactional generation).
+            generation = (
+                os.environ.get("SUTANDO_VOICE_CREDENTIAL_GENERATION")
+                if capability == "gemini-voice"
+                else None
+            )
+            return ResolvedCredential(
+                key=key, source="env", credential_generation=generation or None
+            )
     return ResolvedCredential(key="", source="none")
+
+
+def credential_source_label(source: CredentialSource) -> str:
+    """Map the internal source onto the design's 'managed'|'byok'|'none' vocabulary.
+
+    Twin of the TS ``credentialSourceLabel`` (WS2 Step 3): surfaces say 'byok'
+    where the resolver says 'env'. A mapper, not a rename, so existing 'env'
+    consumers keep working unchanged.
+    """
+    if source == "managed":
+        return "managed"
+    if source == "env":
+        return "byok"
+    return "none"

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -282,9 +282,13 @@ def managed_voice_credential_present(path: Optional[Path] = None) -> bool:
     """True when the managed-credentials file carries a usable voice key.
 
     Mirrors `_managed_voice_credential_present` in startup-runtime.sh, including
-    its fallback order (`CAPABILITY_FALLBACKS['gemini-voice']`) and its
-    malformed-file contract: an unreadable or malformed file SKIPS the tier
-    rather than raising, matching readManaged()'s try/catch.
+    its fallback order (`CAPABILITY_FALLBACKS['gemini-voice']`), its
+    malformed-file contract — an unreadable or malformed file SKIPS the tier
+    rather than raising, matching readManaged()'s try/catch — and the S1 truth
+    table (design 2b): a `quarantined: true` file's entries are ABSENT in every
+    mode, and an explicit `voicePreference: "byok"` skips the managed tier
+    entirely. Guards identical to the resolvers and the shell gate;
+    tests/voice-preference-consumers.test.sh pins the agreement.
 
     Deliberately NOT fail-closed, unlike the dotenv parsing above. The two cases
     differ: a malformed SKIP_VOICE means someone configured voice and we cannot
@@ -296,10 +300,13 @@ def managed_voice_credential_present(path: Optional[Path] = None) -> bool:
     if path is None:
         path = WORKSPACE_DIR / "state" / "auth" / "managed-credentials.json"
     try:
-        caps = (json.loads(Path(path).read_text()) or {}).get("capabilities") or {}
+        doc = json.loads(Path(path).read_text()) or {}
+        caps = doc.get("capabilities") or {}
         if not isinstance(caps, dict):
             return False
     except Exception:
+        return False
+    if doc.get("quarantined") is True or doc.get("voicePreference") == "byok":
         return False
     for slot in ("gemini-voice", "gemini-text"):
         entry = caps.get(slot)
@@ -307,6 +314,25 @@ def managed_voice_credential_present(path: Optional[Path] = None) -> bool:
         if isinstance(key, str) and key:
             return True
     return False
+
+
+def managed_voice_preference(path: Optional[Path] = None) -> str:
+    """The committed voice credential-source preference: managed | byok | unset.
+
+    Twin of `_voice_credential_preference` in startup-runtime.sh. Every failure
+    mode — missing file, malformed JSON, out-of-vocabulary value — reads as
+    "unset": the legacy resolution every pre-preference install runs under.
+    The byok/quarantine enforcement never rides on this helper alone;
+    managed_voice_credential_present re-checks the marker fields directly.
+    """
+    if path is None:
+        path = WORKSPACE_DIR / "state" / "auth" / "managed-credentials.json"
+    try:
+        doc = json.loads(Path(path).read_text())
+        pref = doc.get("voicePreference") if isinstance(doc, dict) else None
+    except Exception:
+        pref = None
+    return pref if pref in ("managed", "byok") else "unset"
 
 
 def resolve_voice_health_config(
@@ -366,7 +392,31 @@ def resolve_voice_health_config(
         return str(value).strip()
 
     skip_voice = effective("SKIP_VOICE")
+    # S1 truth table (design 2b): an explicit `voicePreference: managed` is
+    # decided by the managed gate ALONE — a present env key must NOT silently
+    # satisfy a managed preference (that is the logout-quarantine bypass:
+    # quarantined managed entries + a leftover BYO env key would otherwise
+    # report voice enabled off a source the resolver refuses). Same order as
+    # configure_startup_runtime; tests/voice-preference-consumers.test.sh pins
+    # launcher/health/resolver agreement per matrix row.
+    preference = managed_voice_preference()
+    if preference == "managed":
+        if managed_voice_credential_present():
+            return {"enabled": True, "detail": "managed voice credential configured"}
+        return {
+            "enabled": False,
+            "detail": (
+                "disabled (voicePreference=managed but no usable managed credential"
+                " — quarantined or missing; env keys do not satisfy a managed"
+                " preference; sign in to renew or switch to BYOK)"
+            ),
+        }
     if effective("GEMINI_VOICE_API_KEY") or effective("GEMINI_API_KEY"):
+        if preference == "byok":
+            return {
+                "enabled": True,
+                "detail": "Gemini voice credential configured (BYOK preference)",
+            }
         return {"enabled": True, "detail": "Gemini voice credential configured"}
     if skip_voice not in ("", "0", "1"):
         return {"enabled": True, "error": f"invalid SKIP_VOICE={skip_voice!r}"}
@@ -384,10 +434,23 @@ def resolve_voice_health_config(
     # inherited SKIP_VOICE=1" still had startup booting voice while health reported
     # disabled. The managed-only test could not catch it because it omits SKIP_VOICE.
     # (#2197 review blocker, john-the-dev 2026-07-31T05:37.)
+    # (Under `byok` or quarantine the gate is False by construction, so this
+    # branch cannot re-enable a source the resolver refuses.)
     if managed_voice_credential_present():
         return {"enabled": True, "detail": "managed voice credential configured"}
     if skip_voice == "1":
         return {"enabled": False, "detail": "disabled by SKIP_VOICE=1"}
+    if preference == "byok":
+        # Named reason, not a generic "no credential": a BYOK preference with
+        # managed entries on disk must read as *disabled with a reason*, never
+        # as "managed credential configured" (impl plan WS2 Step 4).
+        return {
+            "enabled": False,
+            "detail": (
+                "disabled (BYOK preference set (managed entries ignored); set"
+                " GEMINI_VOICE_API_KEY or GEMINI_API_KEY)"
+            ),
+        }
     return {"enabled": False, "detail": "disabled (no Gemini voice credential configured)"}
 
 

--- a/src/startup-runtime.sh
+++ b/src/startup-runtime.sh
@@ -84,42 +84,49 @@ preflight_selected_core_auth() {
 # fallback chain. Only the slot-lookup rule is restated, and
 # tests/startup-voice-gate.test.sh pins it to the same fixtures as the TS
 # resolver so the two cannot drift apart silently.
-_managed_voice_credential_present() {
-  local _repo _ws _file
+# Path of the canonical managed-credentials file, resolved through
+# sutando-config.sh (the same canonical resolver resolveWorkspace() uses).
+# Prints the path; returns 1 when the workspace cannot be resolved.
+_voice_managed_credentials_file() {
+  local _repo _ws
   _repo="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
   _ws="$(bash "$_repo/scripts/sutando-config.sh" workspace 2>/dev/null)" || return 1
   [ -n "$_ws" ] || return 1
-  _file="$_ws/state/auth/managed-credentials.json"
-  [ -f "$_file" ] || return 1
+  printf '%s\n' "$_ws/state/auth/managed-credentials.json"
+}
 
-  # Mirrors CAPABILITY_FALLBACKS['gemini-voice'] = ['gemini-voice','gemini-text'].
-  # Malformed/unreadable files skip the tier rather than throwing, matching
-  # readManaged()'s try/catch contract.
-  # Resolve an interpreter that actually RUNS before reading. A bare `python3`
-  # on a fresh Mac resolves to the Xcode Command Line Tools stub, which exits
-  # non-zero — and this function returns 1 on any failure, so a stub would be
-  # indistinguishable from "no managed credential configured". That is a silent
-  # wrong answer, not a crash: startup would proceed BYO-only while a managed
-  # credential sat on disk.
-  #
-  # PROBE, don't path-match. `command -v` finds the stub because the stub IS on
-  # PATH; only running it tells you whether it works.
-  #
-  # ORDER comes from scripts/sutando-config.sh, asked for rather than restated.
-  # An earlier version of this gate probed `command -v python3` and then Homebrew
-  # and stopped there, skipping the two tiers that actually matter on a bundled
-  # install: $SUTANDO_PY and <engine>/runtime/python. A host with a broken
-  # `python3` first on PATH and a valid $SUTANDO_PY therefore concluded "no usable
-  # python3" and left voice disabled while a managed credential sat on disk —
-  # exactly the silent managed-user outage this function exists to prevent, and
-  # inconsistent with the workspace lookup ABOVE, which resolves fine because
-  # sutando-config.sh honours $SUTANDO_PY internally.
-  #
-  # `python-bin` is consulted FIRST so the precedence has one definition. The
-  # explicit tiers after it are a fallback for the case where that script cannot
-  # run at all; Homebrew stays last, beyond the canonical order, because it was
-  # added for a real host and dropping it would regress that case. brew's
-  # location is asked for, never written down (REVIEW.md hardcoded-paths).
+# Resolve an interpreter that actually RUNS for the credential-gate JSON reads.
+# A bare `python3` on a fresh Mac resolves to the Xcode Command Line Tools
+# stub, which exits non-zero — and the gate returns 1 on any failure, so a
+# stub would be indistinguishable from "no managed credential configured".
+# That is a silent wrong answer, not a crash: startup would proceed BYO-only
+# while a managed credential sat on disk.
+#
+# PROBE, don't path-match. `command -v` finds the stub because the stub IS on
+# PATH; only running it tells you whether it works.
+#
+# ORDER comes from scripts/sutando-config.sh, asked for rather than restated.
+# An earlier version of this gate probed `command -v python3` and then Homebrew
+# and stopped there, skipping the two tiers that actually matter on a bundled
+# install: $SUTANDO_PY and <engine>/runtime/python. A host with a broken
+# `python3` first on PATH and a valid $SUTANDO_PY therefore concluded "no usable
+# python3" and left voice disabled while a managed credential sat on disk —
+# exactly the silent managed-user outage this gate exists to prevent, and
+# inconsistent with the workspace lookup in _voice_managed_credentials_file,
+# which resolves fine because sutando-config.sh honours $SUTANDO_PY internally.
+#
+# `python-bin` is consulted FIRST so the precedence has one definition. The
+# explicit tiers after it are a fallback for the case where that script cannot
+# run at all; Homebrew stays last, beyond the canonical order, because it was
+# added for a real host and dropping it would regress that case. brew's
+# location is asked for, never written down (REVIEW.md hardcoded-paths).
+#
+# Prints the interpreter path; returns 1 (printing nothing) when no candidate
+# is usable. Callers own the loud warning — silence at the CALL SITE is the
+# defect the stub tests pin.
+_voice_gate_python() {
+  local _repo
+  _repo="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
   _usable_python() {
     # No `-x` test: `python-bin` may return a bare command name, and a name that
     # is not on PATH simply fails to execute. Running it IS the test.
@@ -138,7 +145,46 @@ _managed_voice_credential_present() {
       break
     fi
   done
-  if [ -z "$_py" ]; then
+  [ -n "$_py" ] || return 1
+  printf '%s\n' "$_py"
+}
+
+# The committed voice credential-source preference (design 2b; amendment S1).
+# Prints exactly one of: managed | byok | unset. Every failure mode — no
+# workspace, no file, no usable python, malformed JSON, out-of-vocabulary
+# value — prints "unset": the legacy resolution every pre-preference install
+# runs under. The quarantine/byok enforcement itself never rides on this
+# helper alone: _managed_voice_credential_present re-checks the marker file
+# directly, so an unreadable preference degrades to legacy behavior, never to
+# a managed key satisfying an explicit BYOK/quarantined state.
+_voice_credential_preference() {
+  local _file _py
+  _file="$(_voice_managed_credentials_file)" || { echo "unset"; return 0; }
+  [ -f "$_file" ] || { echo "unset"; return 0; }
+  _py="$(_voice_gate_python)" || { echo "unset"; return 0; }
+  "$_py" - "$_file" <<'PY' 2>/dev/null || echo "unset"
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        doc = json.load(fh)
+    pref = doc.get("voicePreference") if isinstance(doc, dict) else None
+except Exception:
+    pref = None
+print(pref if pref in ("managed", "byok") else "unset")
+PY
+}
+
+_managed_voice_credential_present() {
+  local _file _py
+  _file="$(_voice_managed_credentials_file)" || return 1
+  [ -f "$_file" ] || return 1
+
+  # Mirrors CAPABILITY_FALLBACKS['gemini-voice'] = ['gemini-voice','gemini-text'].
+  # Malformed/unreadable files skip the tier rather than throwing, matching
+  # readManaged()'s try/catch contract. Interpreter resolution lives in
+  # _voice_gate_python (probe-first, canonical order); the LOUD warning stays
+  # here because "no usable python" must never read as "no managed credential".
+  if ! _py="$(_voice_gate_python)"; then
     echo "  ~ managed-credential gate: no usable python3 —" \
          "cannot read $_file; treating as UNKNOWN, not as absent" >&2
     return 1
@@ -148,10 +194,18 @@ _managed_voice_credential_present() {
 import json, sys
 try:
     with open(sys.argv[1]) as fh:
-        caps = (json.load(fh) or {}).get("capabilities") or {}
+        doc = json.load(fh) or {}
+    caps = doc.get("capabilities") or {}
     if not isinstance(caps, dict):
         raise ValueError("capabilities is not an object")
 except Exception:
+    sys.exit(1)
+# S1 truth table (design 2b): a quarantined file's entries are ABSENT in every
+# mode (signed-out quarantine — the token stays on disk for later renewal but
+# must never satisfy a consumer), and under an explicit BYOK preference the
+# managed tier is skipped entirely. Same guards as the TS/python resolvers and
+# health-check.py; tests/voice-preference-consumers.test.sh pins the agreement.
+if doc.get("quarantined") is True or doc.get("voicePreference") == "byok":
     sys.exit(1)
 for slot in ("gemini-voice", "gemini-text"):
     entry = caps.get(slot)
@@ -169,9 +223,29 @@ configure_startup_runtime() {
     echo "  ~ .env not found — continuing with credential-free services"
   fi
 
-  # Order mirrors resolveCredential(): managed tier first, then BYO env. Only the
-  # *reason* differs between the two enabled branches — both start voice.
-  if [ -n "${GEMINI_VOICE_API_KEY:-${GEMINI_API_KEY:-}}" ]; then
+  # Order mirrors resolveCredential() under the S1 truth table (design 2b):
+  # an explicit `voicePreference: managed` is decided by the managed gate
+  # ALONE, otherwise managed tier and BYO env both enable (only the *reason*
+  # differs). tests/voice-preference-consumers.test.sh pins this against the
+  # resolver, health-check.py, and the desktop supervisor's spawn-env twin.
+  local _voice_pref
+  _voice_pref="$(_voice_credential_preference)"
+  if [ "$_voice_pref" = "managed" ]; then
+    # S1: ONLY a non-quarantined managed entry satisfies a managed
+    # preference — a present env key must NOT silently satisfy it (that is
+    # the logout-quarantine bypass the design closes: quarantined managed
+    # entries with a leftover BYO env key would otherwise boot voice).
+    if _managed_voice_credential_present; then
+      unset SKIP_VOICE
+      echo "  ✓ voice agent enabled (managed credentials)"
+    else
+      export SKIP_VOICE=1
+      echo "  ~ voice agent disabled (voicePreference=managed but no usable" \
+           "managed credential — quarantined or missing in" \
+           "<workspace>/state/auth/managed-credentials.json; sign in to renew" \
+           "the managed key or switch the preference to BYOK)"
+    fi
+  elif [ -n "${GEMINI_VOICE_API_KEY:-${GEMINI_API_KEY:-}}" ]; then
     unset SKIP_VOICE
   elif _managed_voice_credential_present; then
     unset SKIP_VOICE
@@ -180,9 +254,14 @@ configure_startup_runtime() {
     export SKIP_VOICE=1
     # Say WHY, and name the two ways out — a gate that disables a feature without
     # explaining itself is the screen-capture failure mode repeated.
-    echo "  ~ voice agent disabled (no managed credentials in" \
-         "<workspace>/state/auth/managed-credentials.json; set GEMINI_VOICE_API_KEY" \
-         "or GEMINI_API_KEY for a BYO key)"
+    if [ "$_voice_pref" = "byok" ]; then
+      echo "  ~ voice agent disabled (BYOK preference set (managed entries" \
+           "ignored); set GEMINI_VOICE_API_KEY or GEMINI_API_KEY)"
+    else
+      echo "  ~ voice agent disabled (no managed credentials in" \
+           "<workspace>/state/auth/managed-credentials.json; set GEMINI_VOICE_API_KEY" \
+           "or GEMINI_API_KEY for a BYO key)"
+    fi
   fi
 }
 

--- a/src/voice-agent-state.ts
+++ b/src/voice-agent-state.ts
@@ -33,6 +33,7 @@ import { dirname } from 'node:path';
 import { statusPath } from './workspace_default.js';
 import type { ProtocolFailure, ProtocolFailureCategory } from './voice-error-classifier.js';
 import type { ResolvedCredential } from './credential-resolver.js';
+import { credentialSourceLabel as resolverSourceLabel } from './credential-resolver.js';
 
 /** L3 upstream states (design readiness model). */
 export type UpstreamState = 'live' | 'idle' | 'connecting' | 'backoff' | 'failed';
@@ -53,15 +54,16 @@ export interface AgentStateV1 {
 
 /**
  * Map the resolver's source labels onto the frame's enum (amendment A10:
- * source comes from the EXISTING `voiceCredential.source`, labels mapped
- * here — `env` means a BYO key on the wire; `none` omits the field).
+ * source comes from the EXISTING `voiceCredential.source`). The vocabulary
+ * mapping itself ('env' means BYOK on the wire) has ONE definition — the
+ * resolver's `credentialSourceLabel` (WS2 Step 3); this wrapper only turns
+ * its 'none' into `undefined` because the frame OMITS the field.
  */
 export function credentialSourceLabel(
 	source: ResolvedCredential['source'],
 ): 'managed' | 'byok' | undefined {
-	if (source === 'managed') return 'managed';
-	if (source === 'env') return 'byok';
-	return undefined;
+	const label = resolverSourceLabel(source);
+	return label === 'none' ? undefined : label;
 }
 
 /** Inputs the provider polls at build time — all late-bound getters. */

--- a/tests/credential-resolver.test.py
+++ b/tests/credential-resolver.test.py
@@ -10,6 +10,13 @@ reflected in BOTH suites with identical inputs/outputs.
   2. Managed tier wins over env; voice falls back to the managed TEXT credential
      BEFORE dropping to env (tier order beats slot order).
   3. Malformed / wrong-shape managed files skip the tier — never raise.
+  4. The S1 voicePreference/quarantined truth table (design 2b): unset =>
+     legacy managed->env; 'managed' => ONLY a non-quarantined managed entry
+     satisfies (env keys never silently satisfy it); 'byok' => env only;
+     quarantined entries are absent in EVERY mode.
+  5. S3/R15 read side: opaque generations REPORTED (managed `generation` field /
+     SUTANDO_VOICE_CREDENTIAL_GENERATION), never minted; top-level
+     preferenceRevision/sessionRevision tolerated and ignored.
 """
 
 import json
@@ -21,9 +28,17 @@ from pathlib import Path
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO / "src"))
 
-from credential_resolver import resolve_credential, ResolvedCredential  # noqa: E402
+from credential_resolver import (  # noqa: E402
+    ResolvedCredential,
+    credential_source_label,
+    resolve_credential,
+)
 
-_ENV_KEYS = ("GEMINI_VOICE_API_KEY", "GEMINI_API_KEY")
+_ENV_KEYS = (
+    "GEMINI_VOICE_API_KEY",
+    "GEMINI_API_KEY",
+    "SUTANDO_VOICE_CREDENTIAL_GENERATION",
+)
 _failures = []
 _dir = Path(tempfile.mkdtemp(prefix="credresolver-"))
 
@@ -37,14 +52,27 @@ def _missing() -> str:
     return str(_dir / "does-not-exist.json")
 
 
-def _write_managed(caps: dict) -> str:
+def _write_managed(caps, top_level=None) -> str:
+    doc = {"version": 1, "capabilities": caps}
+    doc.update(top_level or {})
     p = _dir / "managed-credentials.json"
-    p.write_text(json.dumps({"version": 1, "capabilities": caps}))
+    p.write_text(json.dumps(doc))
     return str(p)
 
 
+# Both managed slots filled — the design's canonical S1 fixture shape.
+_BOTH_SLOTS = {
+    "gemini-voice": {"key": "managed-v"},
+    "gemini-text": {"key": "managed-t"},
+}
+
+
 def check(name, got, expected):
-    exp = ResolvedCredential(key=expected["key"], source=expected["source"])
+    exp = ResolvedCredential(
+        key=expected["key"],
+        source=expected["source"],
+        credential_generation=expected.get("credential_generation"),
+    )
     if tuple(got) != tuple(exp):
         _failures.append(f"{name}: got {tuple(got)} expected {tuple(exp)}")
         print(f"  FAIL {name}: got {tuple(got)} expected {tuple(exp)}")
@@ -90,6 +118,86 @@ _reset_env(); os.environ["GEMINI_API_KEY"] = "mk"
 _arr = _dir / "arr.json"; _arr.write_text(json.dumps({"version": 1, "capabilities": []}))
 check("wrong-shape (array capabilities) skips managed", resolve_credential("gemini-voice", str(_arr)), {"key": "mk", "source": "env"})
 check("wrong-shape (non-string key) skips managed", resolve_credential("gemini-voice", _write_managed({"gemini-voice": {"key": 42}})), {"key": "mk", "source": "env"})
+
+# 9b. non-object ROOT document: caps empty, preference unset, not quarantined
+_reset_env(); os.environ["GEMINI_API_KEY"] = "mk"
+_rootarr = _dir / "root-arr.json"; _rootarr.write_text(json.dumps([1, 2]))
+check("non-object root document skips managed", resolve_credential("gemini-voice", str(_rootarr)), {"key": "mk", "source": "env"})
+
+# --- S1 truth table: voicePreference x quarantined (design 2b) ---------------
+
+# 10. byok preference: managed voice+text entries + env key -> env wins
+_reset_env(); os.environ["GEMINI_API_KEY"] = "byo-mk"
+check("byok pref: managed entries + env key -> env wins", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"voicePreference": "byok"})), {"key": "byo-mk", "source": "env"})
+
+# 11. byok preference + NO env key -> none (the "fail actionably" input)
+_reset_env()
+check("byok pref + no env key -> none", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"voicePreference": "byok"})), {"key": "", "source": "none"})
+
+# 12. managed preference: non-quarantined managed entry satisfies (env irrelevant)
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"
+check("managed pref: managed entry satisfies", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"voicePreference": "managed"})), {"key": "managed-v", "source": "managed"})
+
+# 13. S1: managed preference + env key + managed entries MISSING -> none, never env
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"; os.environ["GEMINI_API_KEY"] = "mk"
+check("S1: managed pref + env key + managed missing -> none", resolve_credential("gemini-voice", _write_managed({}, {"voicePreference": "managed"})), {"key": "", "source": "none"})
+
+# 14. S1: managed preference + env key + QUARANTINED entries -> none, never env
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"
+check("S1: managed pref + env key + quarantined -> none", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"voicePreference": "managed", "quarantined": True})), {"key": "", "source": "none"})
+
+# 15. quarantined (unset preference): managed entries absent -> env fallback
+_reset_env(); os.environ["GEMINI_API_KEY"] = "mk"
+check("quarantined (unset pref) -> env fallback", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"quarantined": True})), {"key": "mk", "source": "env"})
+
+# 16. quarantined (unset preference) + no env key -> none
+_reset_env()
+check("quarantined (unset pref) + no env -> none", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"quarantined": True})), {"key": "", "source": "none"})
+
+# 17. quarantined only as strict JSON true; false/absent keep the tier
+_reset_env()
+check("quarantined=false keeps the tier", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"quarantined": False})), {"key": "managed-v", "source": "managed"})
+
+# 18. R15 read side: revisions + unset preference -> byte-identical legacy behavior
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"
+check("R15: revisions tolerated, legacy walk", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"preferenceRevision": 7, "sessionRevision": 3})), {"key": "managed-v", "source": "managed"})
+
+# 19. out-of-vocabulary voicePreference reads as unset (legacy walk)
+_reset_env()
+for _bad in ("MANAGED", "Byok", 42, None, {}):
+    check(f"out-of-vocabulary voicePreference {_bad!r} -> unset", resolve_credential("gemini-voice", _write_managed(_BOTH_SLOTS, {"voicePreference": _bad})), {"key": "managed-v", "source": "managed"})
+
+# 20. voicePreference scopes VOICE: gemini-text ignores byok; quarantine still hides it
+_reset_env()
+check("text ignores byok preference", resolve_credential("gemini-text", _write_managed(_BOTH_SLOTS, {"voicePreference": "byok"})), {"key": "managed-t", "source": "managed"})
+check("text still honors quarantine", resolve_credential("gemini-text", _write_managed(_BOTH_SLOTS, {"voicePreference": "byok", "quarantined": True})), {"key": "", "source": "none"})
+
+# --- S3/Y4 read side: opaque generation reporting ----------------------------
+
+# 21. managed entry generation is reported verbatim; legacy entries omit it
+_reset_env()
+check("managed generation reported verbatim", resolve_credential("gemini-voice", _write_managed({"gemini-voice": {"key": "managed-v", "generation": "cg1-abc"}})), {"key": "managed-v", "source": "managed", "credential_generation": "cg1-abc"})
+check("legacy managed entry stays generationless", resolve_credential("gemini-voice", _write_managed({"gemini-voice": {"key": "managed-v"}})), {"key": "managed-v", "source": "managed"})
+
+# 22. env voice key reports SUTANDO_VOICE_CREDENTIAL_GENERATION only when injected
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"; os.environ["SUTANDO_VOICE_CREDENTIAL_GENERATION"] = "cg1-injected"
+check("env + injected generation reported", resolve_credential("gemini-voice", _missing()), {"key": "vk", "source": "env", "credential_generation": "cg1-injected"})
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"
+check("manual/legacy env key stays generationless (Y4/Z4)", resolve_credential("gemini-voice", _missing()), {"key": "vk", "source": "env"})
+
+# 23. gemini-text env key never picks up the VOICE generation env var
+_reset_env(); os.environ["GEMINI_API_KEY"] = "mk"; os.environ["SUTANDO_VOICE_CREDENTIAL_GENERATION"] = "cg1-injected"
+check("text env key never carries the voice generation", resolve_credential("gemini-text", _missing()), {"key": "mk", "source": "env"})
+
+# 24. credential_source_label: the design's user-facing vocabulary
+_reset_env()
+for _src, _label in (("managed", "managed"), ("env", "byok"), ("none", "none")):
+    got_label = credential_source_label(_src)
+    if got_label != _label:
+        _failures.append(f"label({_src}): got {got_label} expected {_label}")
+        print(f"  FAIL label({_src}): got {got_label} expected {_label}")
+    else:
+        print(f"  ok   label({_src}) == {_label}")
 
 if _failures:
     print(f"\nFAIL — {len(_failures)} check(s) failed")

--- a/tests/credential-resolver.test.ts
+++ b/tests/credential-resolver.test.ts
@@ -7,15 +7,29 @@
  *  2. Managed tier wins over env when present; voice falls back to the managed
  *     text credential BEFORE dropping to env (tier order beats slot order).
  *  3. Malformed/wrong-shape managed files skip the tier — never throw.
+ *  4. The S1 `voicePreference`/`quarantined` truth table (design 2b):
+ *     unset ⇒ legacy managed→env; 'managed' ⇒ ONLY a non-quarantined managed
+ *     entry satisfies (env keys never silently satisfy it); 'byok' ⇒ env
+ *     only; quarantined entries are absent in EVERY mode.
+ *  5. S3/R15 read side: opaque generations are REPORTED (managed `generation`
+ *     field / SUTANDO_VOICE_CREDENTIAL_GENERATION), never minted; top-level
+ *     `preferenceRevision`/`sessionRevision` are tolerated and ignored.
+ *
+ * TWIN: tests/credential-resolver.test.py mirrors this file one-for-one; any
+ * contract change must land in both (policy-twin lesson, #2516).
  */
 import { strict as assert } from 'node:assert';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, test } from 'node:test';
-import { resolveCredential } from '../src/credential-resolver.js';
+import { credentialSourceLabel, resolveCredential } from '../src/credential-resolver.js';
 
-const ENV_KEYS = ['GEMINI_VOICE_API_KEY', 'GEMINI_API_KEY'] as const;
+const ENV_KEYS = [
+	'GEMINI_VOICE_API_KEY',
+	'GEMINI_API_KEY',
+	'SUTANDO_VOICE_CREDENTIAL_GENERATION',
+] as const;
 let savedEnv: Record<string, string | undefined> = {};
 let dir: string;
 
@@ -34,11 +48,17 @@ afterEach(() => {
 
 const missing = () => join(dir, 'no-such-file.json');
 
-function writeManaged(caps: unknown): string {
+function writeManaged(caps: unknown, topLevel: Record<string, unknown> = {}): string {
 	const p = join(dir, 'managed-credentials.json');
-	writeFileSync(p, JSON.stringify({ version: 1, capabilities: caps }));
+	writeFileSync(p, JSON.stringify({ version: 1, capabilities: caps, ...topLevel }));
 	return p;
 }
+
+/** Both managed slots filled — the design's canonical S1 fixture shape. */
+const BOTH_SLOTS = {
+	'gemini-voice': { key: 'managed-v' },
+	'gemini-text': { key: 'managed-t' },
+};
 
 test('legacy equivalence: no managed file, VOICE key wins', () => {
 	process.env.GEMINI_VOICE_API_KEY = 'vk';
@@ -102,4 +122,131 @@ test('wrong-shape capabilities (array / non-string key) skip managed tier', () =
 	const pNum = writeManaged({ 'gemini-voice': { key: 42 } });
 	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: pNum }),
 		{ key: 'mk', source: 'env' });
+});
+
+test('non-object ROOT document: caps empty, preference unset, not quarantined', () => {
+	process.env.GEMINI_API_KEY = 'mk';
+	const p = join(dir, 'root-arr.json');
+	writeFileSync(p, JSON.stringify([1, 2]));
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: 'mk', source: 'env' });
+});
+
+// --- S1 truth table: voicePreference × quarantined (design 2b) --------------
+
+test('byok preference: managed voice+text entries + env key → env wins', () => {
+	process.env.GEMINI_API_KEY = 'byo-mk';
+	const p = writeManaged(BOTH_SLOTS, { voicePreference: 'byok' });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: 'byo-mk', source: 'env' });
+});
+
+test('byok preference + NO env key → none (the "fail actionably" input)', () => {
+	const p = writeManaged(BOTH_SLOTS, { voicePreference: 'byok' });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: '', source: 'none' });
+});
+
+test('managed preference: non-quarantined managed entry satisfies (env key irrelevant)', () => {
+	process.env.GEMINI_VOICE_API_KEY = 'vk';
+	const p = writeManaged(BOTH_SLOTS, { voicePreference: 'managed' });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: 'managed-v', source: 'managed' });
+});
+
+test('S1: managed preference + env key + managed entries MISSING → none, never env', () => {
+	// The logout-quarantine bypass row: a present env key must NOT silently
+	// satisfy a managed preference.
+	process.env.GEMINI_VOICE_API_KEY = 'vk';
+	process.env.GEMINI_API_KEY = 'mk';
+	const p = writeManaged({}, { voicePreference: 'managed' });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: '', source: 'none' });
+});
+
+test('S1: managed preference + env key + QUARANTINED entries → none, never env', () => {
+	process.env.GEMINI_VOICE_API_KEY = 'vk';
+	const p = writeManaged(BOTH_SLOTS, { voicePreference: 'managed', quarantined: true });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: '', source: 'none' });
+});
+
+test('quarantined (unset preference): managed entries absent → env fallback', () => {
+	process.env.GEMINI_API_KEY = 'mk';
+	const p = writeManaged(BOTH_SLOTS, { quarantined: true });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: 'mk', source: 'env' });
+});
+
+test('quarantined (unset preference) + no env key → none', () => {
+	const p = writeManaged(BOTH_SLOTS, { quarantined: true });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: '', source: 'none' });
+});
+
+test('quarantined only as strict JSON true; false/absent keep the tier', () => {
+	const p = writeManaged(BOTH_SLOTS, { quarantined: false });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: 'managed-v', source: 'managed' });
+});
+
+test('R15 read side: revisions + unset preference → byte-identical legacy behavior', () => {
+	process.env.GEMINI_VOICE_API_KEY = 'vk';
+	const p = writeManaged(BOTH_SLOTS, { preferenceRevision: 7, sessionRevision: 3 });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: 'managed-v', source: 'managed' });
+});
+
+test('out-of-vocabulary voicePreference reads as unset (legacy walk)', () => {
+	for (const bad of ['MANAGED', 'Byok', 42, null, {}]) {
+		const p = writeManaged(BOTH_SLOTS, { voicePreference: bad });
+		assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+			{ key: 'managed-v', source: 'managed' }, `voicePreference=${JSON.stringify(bad)}`);
+	}
+});
+
+test('voicePreference scopes VOICE: gemini-text ignores byok; quarantine still hides it', () => {
+	const p = writeManaged(BOTH_SLOTS, { voicePreference: 'byok' });
+	assert.deepEqual(resolveCredential('gemini-text', { managedPath: p }),
+		{ key: 'managed-t', source: 'managed' });
+	const q = writeManaged(BOTH_SLOTS, { voicePreference: 'byok', quarantined: true });
+	assert.deepEqual(resolveCredential('gemini-text', { managedPath: q }),
+		{ key: '', source: 'none' });
+});
+
+// --- S3/Y4 read side: opaque generation reporting ---------------------------
+
+test('managed entry generation is reported verbatim; legacy entries omit it', () => {
+	const p = writeManaged({ 'gemini-voice': { key: 'managed-v', generation: 'cg1-abc' } });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: p }),
+		{ key: 'managed-v', source: 'managed', credentialGeneration: 'cg1-abc' });
+	const legacy = writeManaged({ 'gemini-voice': { key: 'managed-v' } });
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: legacy }),
+		{ key: 'managed-v', source: 'managed' });
+});
+
+test('env voice key reports SUTANDO_VOICE_CREDENTIAL_GENERATION only when injected', () => {
+	process.env.GEMINI_VOICE_API_KEY = 'vk';
+	process.env.SUTANDO_VOICE_CREDENTIAL_GENERATION = 'cg1-injected';
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: missing() }),
+		{ key: 'vk', source: 'env', credentialGeneration: 'cg1-injected' });
+	delete process.env.SUTANDO_VOICE_CREDENTIAL_GENERATION;
+	// Y4/Z4: manual/legacy env keys stay generationless.
+	assert.deepEqual(resolveCredential('gemini-voice', { managedPath: missing() }),
+		{ key: 'vk', source: 'env' });
+});
+
+test('gemini-text env key never picks up the VOICE generation env var', () => {
+	process.env.GEMINI_API_KEY = 'mk';
+	process.env.SUTANDO_VOICE_CREDENTIAL_GENERATION = 'cg1-injected';
+	assert.deepEqual(resolveCredential('gemini-text', { managedPath: missing() }),
+		{ key: 'mk', source: 'env' });
+});
+
+// --- credentialSourceLabel: the design's user-facing vocabulary -------------
+
+test("credentialSourceLabel: managed→managed, env→byok, none→none", () => {
+	assert.equal(credentialSourceLabel('managed'), 'managed');
+	assert.equal(credentialSourceLabel('env'), 'byok');
+	assert.equal(credentialSourceLabel('none'), 'none');
 });

--- a/tests/fixtures/voice-preference-matrix.json
+++ b/tests/fixtures/voice-preference-matrix.json
@@ -1,0 +1,351 @@
+{
+  "comment": [
+    "Cross-consumer agreement matrix for the S1 credential-source truth table",
+    "(design 2b; impl plan WS2 Step 6). One row per combination of",
+    "{managed voice+text entries present|absent} x {voicePreference unset|managed|byok}",
+    "x {quarantined yes|no} x {BYO env key present|absent}; every credential",
+    "consumer must produce the SAME column for the same row:",
+    "  - resolverSource / resolvedKey / credentialGeneration: the TS resolver",
+    "    (src/credential-resolver.ts) and its python twin",
+    "    (src/credential_resolver.py) — internal vocabulary ('env' = BYOK).",
+    "  - effectiveSourceLabel: credentialSourceLabel(resolverSource) — the",
+    "    design's user-facing 'managed'|'byok'|'none' vocabulary.",
+    "  - managedGatePresent: startup-runtime.sh _managed_voice_credential_present",
+    "    AND health-check.py managed_voice_credential_present — true iff a",
+    "    non-quarantined managed entry may satisfy the voice capability.",
+    "  - voiceEnabled: the launch/enable decision — configure_startup_runtime",
+    "    (SKIP_VOICE unset) and health-check.py resolve_voice_health_config.",
+    "  - supervisorInjectedManagedKey: DESKTOP-SIDE column — what the",
+    "    ag2space-cinny-desktop supervisor's managedGeminiVoiceKey() may inject",
+    "    into the spawn env ('' = no injection). Asserted by that repo's twin",
+    "    engine/backend-supervisor.voice-preference.test.mjs, which copies this",
+    "    fixture verbatim; the engine-side driver",
+    "    (tests/voice-preference-consumers.test.sh) does not execute it.",
+    "S1 semantics pinned here: unset => legacy managed->env; managed => ONLY a",
+    "non-quarantined managed entry satisfies (env keys never silently satisfy",
+    "it); byok => env only; quarantined entries are absent in EVERY mode.",
+    "Files carry preferenceRevision/sessionRevision (amendment R15) and a",
+    "managed generation (S3) so every consumer proves it tolerates them."
+  ],
+  "envKeyValue": "byo-mk",
+  "rows": [
+    {
+      "name": "entries.prefUnset.fresh.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "preferenceRevision": 4,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "managed",
+        "resolvedKey": "managed-v",
+        "credentialGeneration": "cg1-matrix-0001",
+        "effectiveSourceLabel": "managed",
+        "managedGatePresent": true,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": "managed-v"
+      }
+    },
+    {
+      "name": "entries.prefUnset.fresh.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "preferenceRevision": 4,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "managed",
+        "resolvedKey": "managed-v",
+        "credentialGeneration": "cg1-matrix-0001",
+        "effectiveSourceLabel": "managed",
+        "managedGatePresent": true,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": "managed-v"
+      }
+    },
+    {
+      "name": "entries.prefUnset.quarantined.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "quarantined": true,
+        "preferenceRevision": 4,
+        "sessionRevision": 3
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "env",
+        "resolvedKey": "byo-mk",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "byok",
+        "managedGatePresent": false,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "entries.prefUnset.quarantined.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "quarantined": true,
+        "preferenceRevision": 4,
+        "sessionRevision": 3
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "entries.prefManaged.fresh.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "voicePreference": "managed",
+        "preferenceRevision": 5,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "managed",
+        "resolvedKey": "managed-v",
+        "credentialGeneration": "cg1-matrix-0001",
+        "effectiveSourceLabel": "managed",
+        "managedGatePresent": true,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": "managed-v"
+      }
+    },
+    {
+      "name": "entries.prefManaged.fresh.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "voicePreference": "managed",
+        "preferenceRevision": 5,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "managed",
+        "resolvedKey": "managed-v",
+        "credentialGeneration": "cg1-matrix-0001",
+        "effectiveSourceLabel": "managed",
+        "managedGatePresent": true,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": "managed-v"
+      }
+    },
+    {
+      "name": "entries.prefManaged.quarantined.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "voicePreference": "managed",
+        "quarantined": true,
+        "preferenceRevision": 5,
+        "sessionRevision": 3
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "entries.prefManaged.quarantined.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "voicePreference": "managed",
+        "quarantined": true,
+        "preferenceRevision": 5,
+        "sessionRevision": 3
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "entries.prefByok.fresh.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "voicePreference": "byok",
+        "preferenceRevision": 6,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "env",
+        "resolvedKey": "byo-mk",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "byok",
+        "managedGatePresent": false,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "entries.prefByok.fresh.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "voicePreference": "byok",
+        "preferenceRevision": 6,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "entries.prefByok.quarantined.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "voicePreference": "byok",
+        "quarantined": true,
+        "preferenceRevision": 6,
+        "sessionRevision": 3
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "env",
+        "resolvedKey": "byo-mk",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "byok",
+        "managedGatePresent": false,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "entries.prefByok.quarantined.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {
+          "gemini-voice": { "key": "managed-v", "generation": "cg1-matrix-0001" },
+          "gemini-text": { "key": "managed-t" }
+        },
+        "voicePreference": "byok",
+        "quarantined": true,
+        "preferenceRevision": 6,
+        "sessionRevision": 3
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "noEntries.prefManaged.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {},
+        "voicePreference": "managed",
+        "preferenceRevision": 5,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "noEntries.prefManaged.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {},
+        "voicePreference": "managed",
+        "preferenceRevision": 5,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    }
+  ]
+}

--- a/tests/fixtures/voice-preference-matrix.json
+++ b/tests/fixtures/voice-preference-matrix.json
@@ -25,7 +25,14 @@
     "non-quarantined managed entry satisfies (env keys never silently satisfy",
     "it); byok => env only; quarantined entries are absent in EVERY mode.",
     "Files carry preferenceRevision/sessionRevision (amendment R15) and a",
-    "managed generation (S3) so every consumer proves it tolerates them."
+    "managed generation (S3) so every consumer proves it tolerates them.",
+    "Rows with managedFile: null exercise the FILE-ABSENT branch (every",
+    "pre-managed install): the harness materializes no managed-credentials.json",
+    "at all, and resolution must be byte-for-byte the legacy env chain.",
+    "noEntries.* rows keep the file present but capabilities empty, across",
+    "prefUnset/prefManaged/prefByok — an empty managed tier must never be",
+    "satisfied by an env key under 'managed', and must fall through to env",
+    "under unset/'byok'."
   ],
   "envKeyValue": "byo-mk",
   "rows": [
@@ -308,6 +315,44 @@
       }
     },
     {
+      "name": "noEntries.prefUnset.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {},
+        "preferenceRevision": 4,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "env",
+        "resolvedKey": "byo-mk",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "byok",
+        "managedGatePresent": false,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "noEntries.prefUnset.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {},
+        "preferenceRevision": 4,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
       "name": "noEntries.prefManaged.envKey",
       "managedFile": {
         "version": 1,
@@ -336,6 +381,74 @@
         "preferenceRevision": 5,
         "sessionRevision": 2
       },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "noEntries.prefByok.envKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {},
+        "voicePreference": "byok",
+        "preferenceRevision": 6,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "env",
+        "resolvedKey": "byo-mk",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "byok",
+        "managedGatePresent": false,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "noEntries.prefByok.noEnvKey",
+      "managedFile": {
+        "version": 1,
+        "capabilities": {},
+        "voicePreference": "byok",
+        "preferenceRevision": 6,
+        "sessionRevision": 2
+      },
+      "envKeyPresent": false,
+      "expected": {
+        "resolverSource": "none",
+        "resolvedKey": "",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "none",
+        "managedGatePresent": false,
+        "voiceEnabled": false,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "noFile.envKey",
+      "managedFile": null,
+      "envKeyPresent": true,
+      "expected": {
+        "resolverSource": "env",
+        "resolvedKey": "byo-mk",
+        "credentialGeneration": null,
+        "effectiveSourceLabel": "byok",
+        "managedGatePresent": false,
+        "voiceEnabled": true,
+        "supervisorInjectedManagedKey": ""
+      }
+    },
+    {
+      "name": "noFile.noEnvKey",
+      "managedFile": null,
       "envKeyPresent": false,
       "expected": {
         "resolverSource": "none",

--- a/tests/health-check-voice-config.test.py
+++ b/tests/health-check-voice-config.test.py
@@ -94,6 +94,104 @@ class VoiceHealthConfigTests(unittest.TestCase):
                 self.assertFalse(hc.resolve_voice_health_config(
                     env={}, env_path=self._no_dotenv)["enabled"])
 
+    # --- S1 truth table: voicePreference / quarantined (design 2b, WS2 Step 4)
+    # health-check implements the SHARED credential-source table (amendment S1)
+    # alongside the launcher, the TS/python resolvers, and the desktop
+    # supervisor's spawn-env gate; tests/voice-preference-consumers.test.sh
+    # drives them all over one fixture matrix — these cases pin this module's
+    # own decisions + detail strings.
+
+    _BOTH_SLOTS = ('"capabilities": {"gemini-voice": {"key": "managed-v"},'
+                   ' "gemini-text": {"key": "managed-t"}}')
+
+    def test_byok_preference_hides_managed_entries_from_the_gate(self) -> None:
+        root = self.write_managed('{%s, "voicePreference": "byok"}' % self._BOTH_SLOTS)
+        path = root / "state" / "auth" / "managed-credentials.json"
+        self.assertFalse(hc.managed_voice_credential_present(path))
+
+    def test_byok_preference_without_env_key_reads_disabled_with_a_reason(self) -> None:
+        # Impl plan WS2 Step 4: a byok-with-no-env-key install must read as
+        # *disabled with a reason*, not "managed credential configured".
+        self.write_managed('{%s, "voicePreference": "byok"}' % self._BOTH_SLOTS)
+        cfg = hc.resolve_voice_health_config(env={}, env_path=self._no_dotenv)
+        self.assertFalse(cfg["enabled"])
+        self.assertIn("BYOK preference set (managed entries ignored)", cfg["detail"])
+
+    def test_byok_preference_with_env_key_is_enabled_via_env(self) -> None:
+        self.write_managed('{%s, "voicePreference": "byok"}' % self._BOTH_SLOTS)
+        cfg = hc.resolve_voice_health_config(
+            env={"GEMINI_API_KEY": "byo-mk"}, env_path=self._no_dotenv)
+        self.assertTrue(cfg["enabled"])
+        self.assertIn("BYOK preference", cfg["detail"])
+        self.assertNotIn("managed voice credential", cfg["detail"])
+
+    def test_quarantined_entries_are_absent_in_every_mode(self) -> None:
+        root = self.write_managed('{%s, "quarantined": true}' % self._BOTH_SLOTS)
+        path = root / "state" / "auth" / "managed-credentials.json"
+        self.assertFalse(hc.managed_voice_credential_present(path))
+        # Unset preference: the legacy walk falls through to env...
+        cfg = hc.resolve_voice_health_config(
+            env={"GEMINI_API_KEY": "byo-mk"}, env_path=self._no_dotenv)
+        self.assertTrue(cfg["enabled"])
+        # ...and with no env key the quarantined entries must not enable.
+        cfg = hc.resolve_voice_health_config(env={}, env_path=self._no_dotenv)
+        self.assertFalse(cfg["enabled"])
+
+    def test_quarantined_false_keeps_the_tier(self) -> None:
+        root = self.write_managed('{%s, "quarantined": false}' % self._BOTH_SLOTS)
+        path = root / "state" / "auth" / "managed-credentials.json"
+        self.assertTrue(hc.managed_voice_credential_present(path))
+
+    def test_managed_preference_with_usable_entry_is_enabled(self) -> None:
+        self.write_managed('{%s, "voicePreference": "managed"}' % self._BOTH_SLOTS)
+        cfg = hc.resolve_voice_health_config(env={}, env_path=self._no_dotenv)
+        self.assertTrue(cfg["enabled"])
+        self.assertIn("managed", cfg["detail"])
+
+    def test_s1_env_key_never_satisfies_a_managed_preference(self) -> None:
+        """S1's load-bearing row: managed preference + quarantined/missing managed
+        entries + a present env key -> DISABLED.
+
+        An env key silently satisfying a managed preference is the
+        logout-quarantine bypass the design closes (design 2b).
+        """
+        for doc in (
+            '{%s, "voicePreference": "managed", "quarantined": true}' % self._BOTH_SLOTS,
+            '{"capabilities": {}, "voicePreference": "managed"}',
+        ):
+            with self.subTest(doc=doc):
+                self.write_managed(doc)
+                cfg = hc.resolve_voice_health_config(
+                    env={"GEMINI_VOICE_API_KEY": "vk", "GEMINI_API_KEY": "mk"},
+                    env_path=self._no_dotenv)
+                self.assertFalse(cfg["enabled"])
+                self.assertIn("voicePreference=managed", cfg["detail"])
+
+    def test_r15_revision_fields_are_tolerated_and_ignored(self) -> None:
+        self.write_managed(
+            '{%s, "preferenceRevision": 7, "sessionRevision": 3}' % self._BOTH_SLOTS)
+        cfg = hc.resolve_voice_health_config(env={}, env_path=self._no_dotenv)
+        self.assertTrue(cfg["enabled"])
+        self.assertIn("managed", cfg["detail"])
+
+    def test_managed_voice_preference_vocabulary(self) -> None:
+        rows = (
+            ('{"capabilities": {}, "voicePreference": "managed"}', "managed"),
+            ('{"capabilities": {}, "voicePreference": "byok"}', "byok"),
+            ('{"capabilities": {}}', "unset"),
+            ('{"capabilities": {}, "voicePreference": "MANAGED"}', "unset"),
+            ('{"capabilities": {}, "voicePreference": 42}', "unset"),
+            ("{not json", "unset"),
+        )
+        for doc, expected in rows:
+            with self.subTest(doc=doc):
+                root = self.write_managed(doc)
+                path = root / "state" / "auth" / "managed-credentials.json"
+                self.assertEqual(hc.managed_voice_preference(path), expected)
+        missing = Path(tempfile.gettempdir()) / "no-such-managed-credentials.json"
+        missing.unlink(missing_ok=True)
+        self.assertEqual(hc.managed_voice_preference(missing), "unset")
+
     def test_managed_credential_wins_over_inherited_skip_voice(self) -> None:
         """Managed key + inherited SKIP_VOICE=1 must report ENABLED, like the launcher.
 

--- a/tests/startup-voice-managed-gate.test.sh
+++ b/tests/startup-voice-managed-gate.test.sh
@@ -303,3 +303,65 @@ esac
 # Summary last: printing PASS before the tier-2 assertions below would have
 # announced success for checks that had not run yet.
 echo "PASS: interpreter precedence (SUTANDO_PY / bundled) is honoured by the gate"
+
+# --- S1 truth table: voicePreference / quarantined (design 2b, WS2 Step 4) ----
+#     The launcher implements the SHARED credential-source table (amendment S1)
+#     alongside the TS/python resolvers, health-check.py and the desktop
+#     supervisor's spawn-env gate; tests/voice-preference-consumers.test.sh
+#     drives all the engine-side consumers over one fixture matrix — these
+#     cases pin the launcher's own decision + its user-facing reasons.
+
+# 8. BYOK preference: managed entries must NOT enable voice (the resolver would
+#    refuse them, so booting off them here would resurrect the disagreement
+#    this whole suite exists to prevent).
+write_managed '{"capabilities":{"gemini-voice":{"key":"managed-v"},"gemini-text":{"key":"managed-t"}},"voicePreference":"byok"}'
+out="$(run_gate)"
+grep -q 'SKIP_VOICE=1' <<<"$out" || fail "byok preference still booted voice off a managed entry: $out"
+grep -q 'BYOK preference set (managed entries ignored)' <<<"$out" \
+  || fail "byok-with-no-env-key must read as disabled WITH the preference named: $out"
+grep -q 'GEMINI_VOICE_API_KEY' <<<"$out" || fail "byok-disabled message must name the env escape hatch: $out"
+
+# 9. BYOK preference + env key -> enabled (env is the only satisfying source).
+out="$(run_gate byo-main-key)"
+grep -q 'SKIP_VOICE=0' <<<"$out" || fail "byok preference + env key should enable voice: $out"
+
+# 10. Quarantined entries are absent in EVERY mode (signed-out quarantine):
+#     no preference marker, quarantined file, no env key -> disabled.
+write_managed '{"capabilities":{"gemini-voice":{"key":"managed-v"}},"quarantined":true}'
+out="$(run_gate)"
+grep -q 'SKIP_VOICE=1' <<<"$out" || fail "quarantined managed entry still booted voice: $out"
+
+# 11. ...but quarantine only hides the MANAGED tier: an env key still enables
+#     under an unset preference (legacy walk).
+grep -q 'SKIP_VOICE=0' <<<"$(run_gate byo-main-key)" \
+  || fail "quarantine must not disable a BYO env key under an unset preference"
+
+# 12. Managed preference + usable managed entry -> enabled via the managed tier.
+write_managed '{"capabilities":{"gemini-voice":{"key":"managed-v"}},"voicePreference":"managed"}'
+out="$(run_gate)"
+grep -q 'SKIP_VOICE=0' <<<"$out" || fail "managed preference + managed entry did not enable voice: $out"
+grep -q 'managed credentials' <<<"$out" || fail "managed-preference enable must credit the managed tier: $out"
+
+# 13. S1's load-bearing row: managed preference + env key + QUARANTINED managed
+#     entries -> voice stays OFF. A present env key must not silently satisfy a
+#     managed preference — that is the logout-quarantine bypass.
+write_managed '{"capabilities":{"gemini-voice":{"key":"managed-v"}},"voicePreference":"managed","quarantined":true}'
+out="$(run_gate byo-main-key byo-voice-key)"
+grep -q 'SKIP_VOICE=1' <<<"$out" \
+  || fail "S1 VIOLATION: env key satisfied a managed preference with quarantined entries: $out"
+grep -q 'voicePreference=managed' <<<"$out" \
+  || fail "managed-preference disable must name the preference: $out"
+
+# 14. Same with the managed entries MISSING outright.
+write_managed '{"capabilities":{},"voicePreference":"managed"}'
+out="$(run_gate byo-main-key)"
+grep -q 'SKIP_VOICE=1' <<<"$out" \
+  || fail "S1 VIOLATION: env key satisfied a managed preference with no managed entry: $out"
+
+# 15. Marker-free file (with only the R15 revision fields) -> byte-identical
+#     legacy behavior: the managed entry boots voice. Regression pin.
+write_managed '{"capabilities":{"gemini-voice":{"key":"managed-v"}},"preferenceRevision":7,"sessionRevision":3}'
+out="$(run_gate)"
+grep -q 'SKIP_VOICE=0' <<<"$out" || fail "marker-free managed file regressed (revisions must be ignored): $out"
+
+echo "PASS: launcher honours the S1 voicePreference/quarantine truth table"

--- a/tests/voice-preference-consumers.test.sh
+++ b/tests/voice-preference-consumers.test.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# Cross-consumer agreement matrix for the S1 credential-source truth table
+# (design 2b; impl plan WS2 Step 6 — "the 2b guardrail test").
+#
+# One fixture set, four engine-side consumers, one expected column per row:
+# the TS resolver, its python twin, startup-runtime.sh's shell gate + launcher
+# decision, and health-check.py must all agree on the effective voice
+# credential source for every {managed entries x voicePreference x quarantined
+# x env key} combination in tests/fixtures/voice-preference-matrix.json.
+# Without this, one consumer can honor the preference while another silently
+# boots voice off a source the resolver refuses — the exact two-reader
+# disagreement (resolver vs. supervisor injection) design 2b calls out.
+#
+# DESKTOP TWIN: the supervisor half — managedGeminiVoiceKey() spawn-env
+# injection and the `requires` gate (impl plan WS2 Step 5) — lives in the
+# ag2space-cinny-desktop repo and is asserted by its
+# engine/backend-supervisor.voice-preference.test.mjs, which copies the same
+# fixture verbatim (the `supervisorInjectedManagedKey` / `voiceEnabled`
+# columns). This driver deliberately does NOT reach across repos; the twin
+# header comment names this file so the two cannot drift silently.
+#
+# Isolation mirrors tests/startup-voice-managed-gate.test.sh: the gate
+# resolves its workspace through "$REPO"/scripts/sutando-config.sh, so a stub
+# repo redirects the lookup at per-row temp workspaces.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURE="$REPO/tests/fixtures/voice-preference-matrix.json"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+PY="$(command -v python3 2>/dev/null)"
+[ -x "${PY:-}" ] || PY=/usr/bin/python3
+[ -x "$PY" ] || fail "no python3 available to drive the matrix"
+
+# --- materialize every row's workspace ONCE; all consumers read these bytes --
+ROWS="$("$PY" - "$FIXTURE" "$TMP" <<'PYEOF'
+import json, sys
+from pathlib import Path
+fixture = json.loads(Path(sys.argv[1]).read_text())
+root = Path(sys.argv[2])
+for i, row in enumerate(fixture["rows"]):
+    ws = root / f"row-{i}"
+    (ws / "state" / "auth").mkdir(parents=True)
+    if row["managedFile"] is not None:
+        (ws / "state" / "auth" / "managed-credentials.json").write_text(
+            json.dumps(row["managedFile"]))
+print(len(fixture["rows"]))
+PYEOF
+)"
+echo "matrix: $ROWS rows materialized under $TMP"
+
+# --- consumer 1: the TS resolver (one tsx pass over all rows) ----------------
+TSX="$REPO/node_modules/.bin/tsx"
+if [ ! -x "$TSX" ]; then
+  fail "node_modules/.bin/tsx missing — run npm ci first (CI installs it in this job)"
+fi
+# The driver lives in $TMP (never written into the repo) and imports the real
+# resolver by absolute file URL, so the repo tree stays pristine mid-run.
+cat > "$TMP/resolver-driver.mts" <<'TSEOF'
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [repoRoot, fixturePath, rowsRoot] = process.argv.slice(2);
+const resolver = await import(
+	pathToFileURL(join(repoRoot, 'src', 'credential-resolver.ts')).href
+);
+const { credentialSourceLabel, resolveCredential } = resolver;
+
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+let failures = 0;
+fixture.rows.forEach((row: any, i: number) => {
+	delete process.env.GEMINI_VOICE_API_KEY;
+	delete process.env.SUTANDO_VOICE_CREDENTIAL_GENERATION;
+	if (row.envKeyPresent) process.env.GEMINI_API_KEY = fixture.envKeyValue;
+	else delete process.env.GEMINI_API_KEY;
+	const managedPath = join(rowsRoot, `row-${i}`, 'state', 'auth', 'managed-credentials.json');
+	const got = resolveCredential('gemini-voice', { managedPath });
+	const exp = row.expected;
+	const gotGen = got.credentialGeneration ?? null;
+	const label = credentialSourceLabel(got.source);
+	const ok =
+		got.source === exp.resolverSource &&
+		got.key === exp.resolvedKey &&
+		gotGen === exp.credentialGeneration &&
+		label === exp.effectiveSourceLabel;
+	if (!ok) {
+		failures += 1;
+		console.error(
+			`FAIL ts-resolver ${row.name}: got {source:${got.source}, key:${got.key}, ` +
+			`gen:${gotGen}, label:${label}} expected {source:${exp.resolverSource}, ` +
+			`key:${exp.resolvedKey}, gen:${exp.credentialGeneration}, label:${exp.effectiveSourceLabel}}`,
+		);
+	} else {
+		console.log(`  ok  ts-resolver   ${row.name} -> ${exp.effectiveSourceLabel}`);
+	}
+});
+process.exit(failures ? 1 : 0);
+TSEOF
+"$TSX" "$TMP/resolver-driver.mts" "$REPO" "$FIXTURE" "$TMP" \
+  || fail "TS resolver disagrees with the matrix"
+
+# --- consumer 2: the python resolver twin ------------------------------------
+"$PY" - "$FIXTURE" "$TMP" "$REPO" <<'PYEOF' || fail "python resolver twin disagrees with the matrix"
+import json, os, sys
+from pathlib import Path
+repo = sys.argv[3]
+sys.path.insert(0, str(Path(repo) / "src"))
+from credential_resolver import credential_source_label, resolve_credential
+fixture = json.loads(Path(sys.argv[1]).read_text())
+root = Path(sys.argv[2])
+failures = 0
+for i, row in enumerate(fixture["rows"]):
+    os.environ.pop("GEMINI_VOICE_API_KEY", None)
+    os.environ.pop("SUTANDO_VOICE_CREDENTIAL_GENERATION", None)
+    if row["envKeyPresent"]:
+        os.environ["GEMINI_API_KEY"] = fixture["envKeyValue"]
+    else:
+        os.environ.pop("GEMINI_API_KEY", None)
+    managed = root / f"row-{i}" / "state" / "auth" / "managed-credentials.json"
+    got = resolve_credential("gemini-voice", str(managed))
+    exp = row["expected"]
+    label = credential_source_label(got.source)
+    ok = (got.source == exp["resolverSource"] and got.key == exp["resolvedKey"]
+          and got.credential_generation == exp["credentialGeneration"]
+          and label == exp["effectiveSourceLabel"])
+    if not ok:
+        failures += 1
+        print(f"FAIL py-resolver {row['name']}: got {tuple(got)} label={label} expected {exp}",
+              file=sys.stderr)
+    else:
+        print(f"  ok  py-resolver   {row['name']} -> {exp['effectiveSourceLabel']}")
+sys.exit(1 if failures else 0)
+PYEOF
+
+# --- consumer 3: health-check.py (gate + composed voice-enabled answer) ------
+"$PY" - "$FIXTURE" "$TMP" "$REPO" <<'PYEOF' || fail "health-check.py disagrees with the matrix"
+import importlib.util, json, sys, tempfile
+from pathlib import Path
+repo = sys.argv[3]
+spec = importlib.util.spec_from_file_location("hc", str(Path(repo) / "src" / "health-check.py"))
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+fixture = json.loads(Path(sys.argv[1]).read_text())
+root = Path(sys.argv[2])
+missing = Path(tempfile.gettempdir()) / "voice-matrix-missing-dotenv"
+missing.unlink(missing_ok=True)
+failures = 0
+for i, row in enumerate(fixture["rows"]):
+    hc.WORKSPACE_DIR = root / f"row-{i}"
+    exp = row["expected"]
+    env = {"GEMINI_API_KEY": fixture["envKeyValue"]} if row["envKeyPresent"] else {}
+    gate = hc.managed_voice_credential_present()
+    cfg = hc.resolve_voice_health_config(env=env, env_path=missing)
+    ok = gate == exp["managedGatePresent"] and cfg["enabled"] == exp["voiceEnabled"]
+    if not ok:
+        failures += 1
+        print(f"FAIL health-check {row['name']}: gate={gate} enabled={cfg['enabled']} "
+              f"expected gate={exp['managedGatePresent']} enabled={exp['voiceEnabled']} "
+              f"({cfg.get('detail', cfg.get('error', ''))})", file=sys.stderr)
+    else:
+        print(f"  ok  health-check  {row['name']} -> gate={gate} enabled={cfg['enabled']}")
+sys.exit(1 if failures else 0)
+PYEOF
+
+# --- consumer 4: startup-runtime.sh (gate function + launcher decision) ------
+# Stub repo redirecting the workspace lookup; the workspace itself comes from
+# $VOICE_MATRIX_WS so one stub serves every row. python-bin deliberately
+# answers nothing (exit 1) so _voice_gate_python falls through to the real
+# /usr/bin/python3 inside the hermetic env — same shape as the managed-gate
+# suite's stub.
+STUB="$TMP/stub-repo"
+mkdir -p "$STUB/scripts"
+cat > "$STUB/scripts/sutando-config.sh" <<'STUBEOF'
+#!/bin/bash
+[ "${1:-}" = "workspace" ] && printf '%s\n' "$VOICE_MATRIX_WS"
+STUBEOF
+chmod +x "$STUB/scripts/sutando-config.sh"
+
+i=0
+while [ "$i" -lt "$ROWS" ]; do
+  name="$("$PY" -c 'import json,sys; print(json.load(open(sys.argv[1]))["rows"][int(sys.argv[2])]["name"])' "$FIXTURE" "$i")"
+  env_present="$("$PY" -c 'import json,sys; print("1" if json.load(open(sys.argv[1]))["rows"][int(sys.argv[2])]["envKeyPresent"] else "")' "$FIXTURE" "$i")"
+  gate_expected="$("$PY" -c 'import json,sys; print("1" if json.load(open(sys.argv[1]))["rows"][int(sys.argv[2])]["expected"]["managedGatePresent"] else "")' "$FIXTURE" "$i")"
+  enabled_expected="$("$PY" -c 'import json,sys; print("0" if json.load(open(sys.argv[1]))["rows"][int(sys.argv[2])]["expected"]["voiceEnabled"] else "1")' "$FIXTURE" "$i")"
+  ws="$TMP/row-$i"
+
+  # 4a. the gate function itself: true iff a managed entry may satisfy voice.
+  if env -i PATH="/usr/bin:/bin" REPO="$STUB" VOICE_MATRIX_WS="$ws" \
+      bash -c 'source "$1/src/startup-runtime.sh"; _managed_voice_credential_present' _ "$REPO" 2>/dev/null; then
+    gate_got="1"
+  else
+    gate_got=""
+  fi
+  [ "$gate_got" = "$gate_expected" ] \
+    || fail "shell gate disagrees on $name: managed-present=${gate_got:-0} expected ${gate_expected:-0}"
+
+  # 4b. the launcher decision (SKIP_VOICE after configure_startup_runtime).
+  out="$(env -i PATH="/usr/bin:/bin" REPO="$STUB" VOICE_MATRIX_WS="$ws" \
+      GEMINI_API_KEY="${env_present:+byo-mk}" GEMINI_VOICE_API_KEY="" \
+      bash -c 'cd "$1"; source "$2/src/startup-runtime.sh"; configure_startup_runtime; printf "SKIP_VOICE=%s\n" "${SKIP_VOICE:-0}"' \
+      _ "$TMP" "$REPO")"
+  grep -q "SKIP_VOICE=$enabled_expected" <<<"$out" \
+    || fail "launcher disagrees on $name: $out (expected SKIP_VOICE=$enabled_expected)"
+
+  echo "  ok  shell-gate    $name -> gate=${gate_got:-0} SKIP_VOICE=$enabled_expected"
+  i=$((i + 1))
+done
+
+echo "PASS: resolver (TS+py), shell gate, launcher and health check agree on every S1 matrix row"


### PR DESCRIPTION
Part of the voice reliability & onboarding plan (desktop repo: `docs/design-voice-reliability-and-onboarding.md` §2b, `docs/impl-plan-voice-reliability-and-onboarding.md` WS2 Steps 3–6 + amendments S1/S3/Y4-read-side). #2689 and #2690 are merged; this branch is rebuilt on current `main` and pairs with the desktop control-plane PR (the writer of the fields this PR reads).

## What changed, and why?

**The S1 credential-source truth table, honored by every engine consumer.** `managed-credentials.json` gains two policy readers:

- **`voicePreference`** (`managed | byok`, unset ⇒ legacy): under *managed*, only a non-quarantined managed entry satisfies `gemini-voice` — env keys never silently substitute (resolving `none` is a typed absence the desktop enable-voice flow routes on, instead of a wrong-source key that "works" until it doesn't). Under *byok*, managed slots are skipped entirely. Unset keeps today's chain byte-for-byte.
- **`quarantined`** (stamped by the desktop host at logout): every managed entry treated as absent, in every mode — a preserved managed key must never satisfy a resolution after logout.

Consumers updated to agree exactly: `src/credential-resolver.ts` + its Python twin `src/credential_resolver.py` (which also gains the S3 `credentialGeneration` read side — opaque `cg1-<UUID>` from the entry's `generation` field, or `SUTANDO_VOICE_CREDENTIAL_GENERATION` for env keys), `startup-runtime.sh`'s managed-voice gate, and `health-check.py`'s voice-config resolution. A canonical `credentialSourceLabel` mapper lands in the resolver per Step 3; the phase-1 `voice-agent-state` mapper now delegates to it (zero wire change).

Rebuilt commits: `56a77843` (truth table + consumers + matrix), `e6edb5cb` (review follow-up: fixture rows for the no-managed-file and no-entries states), `fc15f908` (canonical doc update).

## What files / sections should reviewers look at first?

- `src/credential-resolver.ts` / `src/credential_resolver.py` — the S1 gate (module docstring holds the truth table); the two are one-for-one twins.
- `tests/voice-preference-consumers.test.sh` + `tests/fixtures/voice-preference-matrix.json` — **20 rows × 4 consumers, all asserted to agree**; this is the PR's spine.
- `startup-runtime.sh` `configure_startup_runtime` (managed-preference branch bypasses the env-key check) and `health-check.py` `resolve_voice_health_config` (same preference-first ordering).

## What user behavior or bug does this prove?

Two incident-class behaviors, shown in the evidence below: (1) after logout, the preserved managed token no longer resolves (the engine-side half of the desktop plan's revocation guarantee — the desktop supervisor's Z2 proof rules assume exactly this); (2) an explicit "use managed key" preference is never silently satisfied by a leftover env key.

## Feature/documentation consistency

`docs/design-credential-capability-resolver.md` is canonical for the resolution contract and **is updated in this PR** (`fc15f908`): new "Voice-source policy gates (S1)" subsection, schema example extended with the policy fields + per-entry `generation`, `catalog.json` `last_verified` bumped. `docs/README.md` navigation unchanged (same doc set).

## Before/after evidence

Python-twin resolver, identical script (fixture file + env key), run at the branch's base (`ab6d75ee`, worktree) and at HEAD:

```
=== BASE (ab6d75ee):
logout-quarantined file, managed key on disk -> ('managed', 'managed-key-...')
preference=managed, only env key present     -> ('env', 'env-key-AAAA')
=== HEAD (47d6b369):
logout-quarantined file, managed key on disk -> ('env', 'env-key-AAAA...')
preference=managed, only env key present     -> ('none', '<none>')
```

Base loads the preserved managed token after logout and silently substitutes an env key under a managed preference; HEAD does neither.

## What tests did you run?

- Post-rebuild `bash tests/voice-preference-consumers.test.sh` — PASS: 20-row matrix × 4 consumers (TS resolver, Python resolver, shell gate/launcher, health check), all agreeing.
- `npx --no-install tsx --test tests/credential-resolver.test.ts` — 25/25; `python3 tests/credential-resolver.test.py` — PASS.
- `python3 tests/health-check-voice-config.test.py` — 25/25; `bash tests/startup-voice-managed-gate.test.sh` — both T1 and S1 summaries PASS.
- `npx --no-install tsc --noEmit` — clean; `python3 tests/release-docs-audit.test.py` — 5/5; `git diff origin/main...HEAD | bash scripts/review-checks.sh` — PASS.

Stack-rebuild note: #2684's T1 fail-closed startup-test correction is already on `main`. The sole cherry-pick conflict was resolved by retaining that merged two-line contract and adding #2691's S1 cases below it; no duplicate T1 change remains in this PR.

## Touching a live path (startup)?

The startup gate decides whether the voice agent launches — covered by the gate suite + matrix rows for the launcher decision. The packaged DMG evidence below exercised the same three child patches before the history-only rebuild; `range-diff` confirms the fixture/docs patches are identical and the implementation differs only by dropping its duplicate T1 test correction.

## Stack status

#2689 merged as `ffc0e0af` and #2690 merged as `4c79ccdf`. This branch is rebuilt directly on that current `main`; its diff is now the three-commit S1 credential-policy layer only. The desktop control-plane PR remains the paired writer side for preference/quarantine/generation fields and revocation proof.

## Hardcoded-path check

`git diff origin/main...HEAD | bash scripts/review-checks.sh` → PASS on rebuilt head `fc15f908`.

## Manual verification — packaged DMG pass (2026-08-06)

Local DMG with the content-equivalent pre-rebuild commits in the engine (integration merge: phase-2 transport `4bb2d9a9` + S1 branch `72084dd`; rebuilt equivalents are `4c79ccdf` + `fc15f908`); desktop `voice/phase3-control-plane` (the writer of the fields this branch reads); cinny `voice/phase3-enable-flow`.

**Keyless truth-table row, engine-side, live** (`sidecar boot summary`):

```
{"name":"voice-agent","port":9900,"state":"failed","pid":null,"restarts":0,
 "lastError":"GEMINI_VOICE_API_KEY or GEMINI_API_KEY not set"}
```

Clean config-gate, zero restarts, no crash loop — and the UI side surfaced the same truth as "Effective source: none" in the enable-voice flow's credential stage (the resolver's source readout reaching the user).

**Key present** (after the BYOK commit materialized): `voice-agent … state:"ready" … errors:[]` — same boot path, opposite row.

**Quarantine honored with BYOK preference** (S1 rows `byok × quarantined`): after sign-out stamped `quarantined: true` (+ `sessionRevision` bump) with `voicePreference: "byok"`, voice **kept working on the user's own env key** — quarantine hides managed entries only, exactly the truth-table's byok column. The managed-preference logout variant (quarantined managed entry must config-gate voice) remains to be exercised once a managed key is minted; the row is pinned by the cross-consumer matrix tests meanwhile.

**Transcript evidence (CONTRIBUTING)** — the resolved key drove a real session (`conversation.sqlite`):

```
1786041728.845|user|Uh what's in my workspace?
1786041727.125|tool_call|work
1786041780.839|agent|Your workspace has twelve top-level items, including tasks,
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


