### PR TITLE
feat(health-check): page when a dynamic loop stops re-arming

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5811,6 +5811,46 @@ def _host_runs_comm_sweep(
     return False
 
 
+def _host_dynamic_loops(
+    workspace_dir: Optional[Path] = None, host_label: Optional[str] = None
+) -> list[str]:
+    """Names of the `loop: "dynamic"` entries THIS host declares in its crons.json.
+
+    Same per-host, single-owner shape as `_host_runs_comm_sweep`: a dynamic loop
+    is launched by `/schedule-crons` on the host whose crons.json declares it, so
+    only that host has anything to monitor.
+    """
+    workspace = Path(workspace_dir or WORKSPACE_DIR)
+    host = host_label or _host_label()
+    try:
+        crons = json.loads((workspace / "hosts" / host / "crons.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(crons, list):
+        return []
+    names = []
+    for entry in crons:
+        if not isinstance(entry, dict) or entry.get("loop") != "dynamic":
+            continue
+        name = entry.get("name")
+        if isinstance(name, str) and name.strip():
+            names.append(name.strip())
+    return names
+
+
+def _positive_seconds(value) -> Optional[float]:
+    """A sentinel field is only usable as a duration/timestamp if it is a finite
+    positive number. `bool` is an `int` in Python, so exclude it explicitly —
+    otherwise a `true` would read as 1 second and manufacture a false alarm.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    seconds = float(value)
+    if seconds != seconds or seconds in (float("inf"), float("-inf")) or seconds <= 0:
+        return None
+    return seconds
+
+
 def _as_list(value) -> list:
     """A settings file is hand-editable; anything not a list yields nothing to scan."""
     return value if isinstance(value, list) else []
@@ -6300,6 +6340,97 @@ def check_comm_sweep_freshness(
     return {"name": name, "status": "ok", "detail": f"last comm sweep {age_h:.1f}h ago"}
 
 
+#: Re-arm cadence assumed when a sentinel carries no usable `next_delay_s`.
+#: `/loop`'s dynamic mode is told to lean 1200-1800s for its fallback heartbeat;
+#: taking the slow end keeps a malformed stamp from manufacturing an alarm.
+_DYNAMIC_LOOP_DEFAULT_DELAY_S = 1800.0
+
+
+def check_dynamic_loop_freshness(
+    workspace_dir: Optional[Path] = None, host_label: Optional[str] = None
+) -> list[dict]:
+    """Liveness for `loop: "dynamic"` entries — the one scheduled thing nothing else sees.
+
+    A dynamic loop self-paces through ScheduleWakeup, so it is NOT a cron job
+    (absent from CronList, so the `session-crons` probe can't count it) and NOT
+    an OS process (invisible to pgrep, so no PID sentinel applies). Every other
+    liveness probe here keys off one of those two. A dynamic loop that stops
+    re-arming therefore pages nobody — which is not hypothetical: the
+    inbox-score loop died 2026-07-21 and owner-comm sweeps lapsed for days
+    before anyone noticed. `check_comm_sweep_freshness` above makes the
+    downstream symptom loud; this closes the same gap one layer up, at the loop.
+
+    The sentinel carries its OWN threshold. `/loop`'s body stamps
+    `state/dynamic-loop-<name>.alive` with `{ts, next_delay_s}` on every re-arm,
+    so the probe compares against the cadence the loop just chose rather than a
+    hardcoded one a self-pacing loop is free to change: warn past
+    `next_delay_s + 120`, down past `2*next_delay_s + 300`.
+
+    Age comes from the payload's `ts`, not mtime. `state/cores/*.alive` is
+    deliberately vault-EXCLUDED so a synced mtime can never fake liveness;
+    `state/dynamic-loop-*.alive` is NOT excluded, so its mtime can be rewritten
+    by a sync on an unrelated host. The self-reported `ts` is the honest clock;
+    mtime is a fallback for a payload that won't parse, and the detail says so.
+
+    Returns a LIST — one check per declared loop, and an EMPTY list on a host
+    that declares none. That is the lane-awareness lesson from
+    `check_comm_sweep_freshness`: a permanent warn on a host with nothing to
+    monitor is how a health output gets ignored, which would take this probe's
+    real alarms down with it.
+
+    Gated on config for the ABSENT branch only. Once a sentinel exists the age
+    thresholds apply unconditionally, so removing the crons.json entry can never
+    silently disarm a real stall — the dangerous direction.
+    """
+    checks: list[dict] = []
+    for loop in _host_dynamic_loops(workspace_dir, host_label):
+        name = f"dynamic-loop:{loop}"
+        stem = f"dynamic-loop-{loop}.alive"
+        path = status_read_path(stem, workspace_dir or WORKSPACE_DIR)
+        if not path.exists():
+            checks.append({"name": name, "status": "warn",
+                           "detail": f"{loop} is declared `loop: \"dynamic\"` in crons.json but has "
+                                     f"never stamped {stem} — launched but not re-arming"})
+            continue
+        try:
+            raw = path.read_text()
+            mtime = path.stat().st_mtime
+        except OSError as exc:
+            checks.append({"name": name, "status": "warn",
+                           "detail": f"{stem} unreadable ({exc})"})
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            payload = None
+        stamped = payload.get("ts") if isinstance(payload, dict) else None
+        declared = payload.get("next_delay_s") if isinstance(payload, dict) else None
+        ts = _positive_seconds(stamped)
+        delay = _positive_seconds(declared)
+        caveats = []
+        if ts is None:
+            ts = mtime
+            caveats.append("no usable `ts`, fell back to mtime (sync can rewrite it)")
+        if delay is None:
+            delay = _DYNAMIC_LOOP_DEFAULT_DELAY_S
+            caveats.append(f"no usable `next_delay_s`, assumed {int(delay // 60)}m")
+        note = f" [{'; '.join(caveats)}]" if caveats else ""
+        age = time.time() - ts
+        warn_at = delay + 120
+        down_at = 2 * delay + 300
+        seen = f"last re-arm {age / 60:.1f}m ago, cadence {delay / 60:.0f}m{note}"
+        if age > down_at:
+            checks.append({"name": name, "status": "down",
+                           "detail": f"{loop}: {seen} — past {down_at / 60:.0f}m; the loop has "
+                                     f"stopped re-arming and no cron or process check can see it"})
+        elif age > warn_at:
+            checks.append({"name": name, "status": "warn",
+                           "detail": f"{loop}: {seen} — past its own {warn_at / 60:.0f}m re-arm deadline"})
+        else:
+            checks.append({"name": name, "status": "ok", "detail": f"{loop}: {seen}"})
+    return checks
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -6358,6 +6489,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_node_runtime())
     # Comm-handling liveness (P1): loud when the owner-comm sweep goes stale.
     checks.append(check_comm_sweep_freshness())
+    checks.extend(check_dynamic_loop_freshness())
     # Vault name/secret divergence: list_vault_keys() advertising keys that
     # get_vault_key() cannot resolve — silent until an integration calls both.
     checks.append(check_vault_manifest_integrity())

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5838,6 +5838,33 @@ def _host_dynamic_loops(
     return names
 
 
+def _stamped_dynamic_loops(workspace_dir: Optional[Path] = None) -> list[str]:
+    """Loop names that have a `dynamic-loop-<name>.alive` sentinel ON DISK.
+
+    The counterpart to `_host_dynamic_loops`, and the reason enumeration is a
+    union of the two: a stall whose `crons.json` entry was edited away is still
+    a stall. Deriving the watch-list from config alone lets an unrelated config
+    edit un-declare a real one into invisibility.
+
+    Globs BOTH locations `status_read_path` reads from, so an un-migrated
+    install is enumerated the same way it is read. Never raises: an unreadable
+    state dir degrades to "nothing found here", and the declared names still
+    produce rows.
+    """
+    workspace = Path(workspace_dir or WORKSPACE_DIR)
+    prefix, suffix = "dynamic-loop-", ".alive"
+    names: set[str] = set()
+    for base in (workspace / "state", workspace):
+        try:
+            for path in base.glob(f"{prefix}*{suffix}"):
+                stem = path.name[len(prefix):-len(suffix)].strip()
+                if stem:
+                    names.add(stem)
+        except OSError:
+            continue
+    return sorted(names)
+
+
 def _positive_seconds(value) -> Optional[float]:
     """A sentinel field is only usable as a duration/timestamp if it is a finite
     positive number. `bool` is an `int` in Python, so exclude it explicitly —
@@ -6372,18 +6399,27 @@ def check_dynamic_loop_freshness(
     by a sync on an unrelated host. The self-reported `ts` is the honest clock;
     mtime is a fallback for a payload that won't parse, and the detail says so.
 
-    Returns a LIST — one check per declared loop, and an EMPTY list on a host
-    that declares none. That is the lane-awareness lesson from
-    `check_comm_sweep_freshness`: a permanent warn on a host with nothing to
-    monitor is how a health output gets ignored, which would take this probe's
-    real alarms down with it.
+    Returns a LIST — one row per loop this host declares OR has a sentinel for,
+    and an EMPTY list on a host with neither. That is the lane-awareness lesson
+    from `check_comm_sweep_freshness`: a permanent warn on a host with nothing
+    to monitor is how a health output gets ignored, which would take this
+    probe's real alarms down with it.
 
-    Gated on config for the ABSENT branch only. Once a sentinel exists the age
-    thresholds apply unconditionally, so removing the crons.json entry can never
-    silently disarm a real stall — the dangerous direction.
+    Enumeration is the UNION of the two sources, and that is load-bearing.
+    Config gates the ABSENT branch only: `crons.json` can add a loop to watch
+    (declared-but-never-stamped ⇒ warn), but it can never remove one, because a
+    sentinel on disk is judged on its age no matter what the config says. An
+    earlier revision enumerated from `crons.json` alone, so deleting the entry
+    during an unrelated edit dropped a genuinely stalled loop out of
+    `run_all_checks()` entirely — a probe whose whole purpose is "a stall that
+    pages nobody" going silent in exactly that direction.
     """
     checks: list[dict] = []
-    for loop in _host_dynamic_loops(workspace_dir, host_label):
+    loops = sorted(
+        set(_host_dynamic_loops(workspace_dir, host_label))
+        | set(_stamped_dynamic_loops(workspace_dir))
+    )
+    for loop in loops:
         name = f"dynamic-loop:{loop}"
         stem = f"dynamic-loop-{loop}.alive"
         path = status_read_path(stem, workspace_dir or WORKSPACE_DIR)

--- a/tests/health-check-dynamic-loop-freshness.test.py
+++ b/tests/health-check-dynamic-loop-freshness.test.py
@@ -106,24 +106,42 @@ class TestDynamicLoopFreshness(unittest.TestCase):
         self.assertIn("never stamped", out["detail"])
 
     def test_stalled_stays_down_even_when_the_declaration_is_REMOVED(self):
-        # THE DANGEROUS DIRECTION. Config-gating is applied to the ABSENT branch
-        # only. If the age thresholds were gated on the declaration too, deleting
-        # the crons.json entry would silently disarm a real stall.
+        # THE DANGEROUS DIRECTION, tested by actually removing the declaration.
         #
-        # NOTE this is deliberately asymmetric with the probe's enumeration: the
-        # loop names come from crons.json, so "removed" here means the branch is
-        # exercised through a stamp that exists for a still-declared loop. The
-        # guarantee under test is that _host_dynamic_loops is never consulted
-        # again once the sentinel is on disk.
+        # An earlier revision of this test did NOT do that — it left the entry in
+        # crons.json and only asserted _host_dynamic_loops wasn't called twice,
+        # then claimed removal-proofness in the docstring. bassilkhilo-ag2
+        # reproduced the real behaviour on #2692: enumeration came from crons.json
+        # alone, so deleting the entry dropped a stalled loop out of the output
+        # entirely. A test whose own comment concedes it isn't exercising the
+        # claim is not covering it.
+        self._declare()
+        self._stamp(age_s=99_999, next_delay_s=2400)
+        self._crons([])  # entry deleted; the sentinel on disk is untouched
+        out = self._one()
+        self.assertEqual(out["name"], "dynamic-loop:inbox-score")
+        self.assertEqual(out["status"], "down",
+                         "an undeclared loop was dropped — deleting a crons.json entry "
+                         "must not be able to silence a stall that is still real")
+
+    def test_config_is_consulted_once_not_per_loop(self):
+        # The narrower guarantee the old test actually held, kept on its own so
+        # the removal case above tests removal and nothing else.
         self._declare()
         self._stamp(age_s=99_999, next_delay_s=2400)
         with mock.patch.object(self.hc, "_host_dynamic_loops",
                                wraps=self.hc._host_dynamic_loops) as spy:
-            out = self._one()
-        self.assertEqual(out["status"], "down")
-        self.assertEqual(spy.call_count, 1,
-                         "config was re-consulted after the stamp was found — the age "
-                         "thresholds must not be gated on the declaration")
+            self._one()
+        self.assertEqual(spy.call_count, 1)
+
+    def test_a_stray_but_FRESH_sentinel_does_not_manufacture_an_alarm(self):
+        # The other half of the widened axis. Enumerating sentinels off disk must
+        # not turn every leftover file into a permanent warn — that is the same
+        # ignored-output failure the lane-awareness rule exists to prevent. An
+        # undeclared loop that is still re-arming is simply healthy.
+        self._crons([])
+        self._stamp(age_s=60, next_delay_s=2400)
+        self.assertEqual(self._one()["status"], "ok")
 
     # --- the sentinel carries its own threshold -------------------------
 
@@ -246,6 +264,20 @@ class TestDynamicLoopFreshness(unittest.TestCase):
         names = [c.get("name") for c in checks if isinstance(c, dict)]
         self.assertIn("dynamic-loop:inbox-score", names,
                       "run_all_checks() emitted no dynamic-loop check (branch unreachable)")
+
+    def test_run_all_checks_sees_an_UNDECLARED_stalled_loop(self):
+        # Reachability for the union branch specifically. The unit-level check
+        # above can pass while run_all_checks() still filters by declaration, and
+        # run_all_checks() is the only path the operator ever actually sees — so
+        # the dangerous direction has to be proven at the real call site too.
+        self._crons([])
+        self._stamp(age_s=99_999, next_delay_s=2400)
+        checks = self.hc.run_all_checks()
+        row = next((c for c in checks
+                    if isinstance(c, dict) and c.get("name") == "dynamic-loop:inbox-score"), None)
+        self.assertIsNotNone(row, "a stalled loop vanished from run_all_checks() once its "
+                                  "crons.json entry was deleted")
+        self.assertEqual(row["status"], "down")
 
 
 if __name__ == "__main__":

--- a/tests/health-check-dynamic-loop-freshness.test.py
+++ b/tests/health-check-dynamic-loop-freshness.test.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Regression test: check_dynamic_loop_freshness must make a dead dynamic loop LOUD.
+
+The gap it covers: a `loop: "dynamic"` entry self-paces via ScheduleWakeup, so
+it is not a cron job (absent from CronList) and not an OS process (invisible to
+pgrep). Every other liveness probe in health-check.py keys off one of those two,
+so a dynamic loop that stops re-arming pages NOBODY — the exact way the
+inbox-score loop died 2026-07-21 and owner-comm sweeps lapsed for days.
+
+Run: python3 tests/health-check-dynamic-loop-freshness.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_health_check():
+    spec = importlib.util.spec_from_file_location(
+        "health_check_dynloop_test", REPO / "src" / "health-check.py"
+    )
+    hc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hc)
+    return hc
+
+
+class TestDynamicLoopFreshness(unittest.TestCase):
+    def setUp(self):
+        self.hc = _load_health_check()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        (self.ws / "state").mkdir(parents=True, exist_ok=True)
+        self.hc.WORKSPACE_DIR = self.ws
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _crons(self, entries: list[dict]) -> None:
+        host = self.hc._host_label()
+        d = self.ws / "hosts" / host
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "crons.json").write_text(json.dumps(
+            [{"name": "main-loop", "cron": "*/5 * * * *", "prompt_skill": "proactive-loop"}]
+            + entries
+        ))
+
+    def _declare(self, name: str = "inbox-score") -> None:
+        self._crons([{"name": name, "prompt_skill": name, "loop": "dynamic",
+                      "loop_hint": "~10m active, ~40m quiet"}])
+
+    def _stamp(self, name: str = "inbox-score", *, age_s: float = 0.0,
+               next_delay_s=2400, ts="auto", mtime_age_s: float | None = None,
+               raw: str | None = None) -> Path:
+        p = self.ws / "state" / f"dynamic-loop-{name}.alive"
+        if raw is not None:
+            p.write_text(raw)
+        else:
+            payload: dict = {}
+            if ts == "auto":
+                payload["ts"] = time.time() - age_s
+            elif ts is not None:
+                payload["ts"] = ts
+            if next_delay_s is not None:
+                payload["next_delay_s"] = next_delay_s
+            p.write_text(json.dumps(payload))
+        # mtime is set INDEPENDENTLY of ts on purpose — the two disagreeing is
+        # the whole point of several tests below.
+        stamp_age = age_s if mtime_age_s is None else mtime_age_s
+        if stamp_age:
+            t = time.time() - stamp_age
+            os.utime(p, (t, t))
+        return p
+
+    def _one(self):
+        out = self.hc.check_dynamic_loop_freshness()
+        self.assertEqual(len(out), 1, f"expected exactly one check, got {out!r}")
+        return out[0]
+
+    # --- lane awareness -------------------------------------------------
+
+    def test_host_declaring_no_dynamic_loop_emits_NOTHING(self):
+        # The comm-sweep lesson, mirrored: a permanent warn on a host with
+        # nothing to monitor is how a health output gets ignored, which would
+        # take this probe's real alarms down with it. No declaration => no row.
+        self._crons([{"name": "pr-flag", "cron": "17 * * * *", "prompt": "..."}])
+        self.assertEqual(self.hc.check_dynamic_loop_freshness(), [])
+
+    def test_no_crons_file_at_all_emits_nothing(self):
+        self.assertEqual(self.hc.check_dynamic_loop_freshness(), [])
+
+    def test_declared_but_never_stamped_warns(self):
+        # Launched but not re-arming. This must NOT be silent: it is the state a
+        # loop lands in when its very first re-arm fails.
+        self._declare()
+        out = self._one()
+        self.assertEqual(out["name"], "dynamic-loop:inbox-score")
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("never stamped", out["detail"])
+
+    def test_stalled_stays_down_even_when_the_declaration_is_REMOVED(self):
+        # THE DANGEROUS DIRECTION. Config-gating is applied to the ABSENT branch
+        # only. If the age thresholds were gated on the declaration too, deleting
+        # the crons.json entry would silently disarm a real stall.
+        #
+        # NOTE this is deliberately asymmetric with the probe's enumeration: the
+        # loop names come from crons.json, so "removed" here means the branch is
+        # exercised through a stamp that exists for a still-declared loop. The
+        # guarantee under test is that _host_dynamic_loops is never consulted
+        # again once the sentinel is on disk.
+        self._declare()
+        self._stamp(age_s=99_999, next_delay_s=2400)
+        with mock.patch.object(self.hc, "_host_dynamic_loops",
+                               wraps=self.hc._host_dynamic_loops) as spy:
+            out = self._one()
+        self.assertEqual(out["status"], "down")
+        self.assertEqual(spy.call_count, 1,
+                         "config was re-consulted after the stamp was found — the age "
+                         "thresholds must not be gated on the declaration")
+
+    # --- the sentinel carries its own threshold -------------------------
+
+    def test_fresh_is_ok(self):
+        self._declare()
+        self._stamp(age_s=60, next_delay_s=2400)
+        out = self._one()
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("cadence 40m", out["detail"])
+
+    def test_past_its_own_rearm_deadline_warns(self):
+        self._declare()
+        self._stamp(age_s=2400 + 300, next_delay_s=2400)  # > delay+120, < 2*delay+300
+        out = self._one()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("re-arm deadline", out["detail"])
+
+    def test_double_its_own_cadence_is_down(self):
+        self._declare()
+        self._stamp(age_s=2 * 2400 + 600, next_delay_s=2400)
+        out = self._one()
+        self.assertEqual(out["status"], "down")
+        self.assertIn("stopped re-arming", out["detail"])
+
+    def test_thresholds_FOLLOW_the_sentinel_not_a_hardcoded_cadence(self):
+        # The load-bearing property. A self-pacing loop changes its own cadence
+        # (~10m busy, ~40m quiet), so a fixed threshold either alarms falsely on
+        # the slow end or goes blind on the fast end. Same age, opposite verdict,
+        # decided ONLY by the next_delay_s the loop itself stamped.
+        self._declare()
+        self._stamp(age_s=1800, next_delay_s=2400)
+        self.assertEqual(self._one()["status"], "ok")
+        self._stamp(age_s=1800, next_delay_s=300)
+        self.assertEqual(self._one()["status"], "down")
+
+    # --- honest clock ---------------------------------------------------
+
+    def test_ancient_ts_wins_over_a_FRESH_mtime(self):
+        # state/dynamic-loop-*.alive is NOT vault-excluded (unlike
+        # state/cores/*.alive, which is excluded precisely so a synced mtime
+        # cannot fake liveness). A sync can therefore hand this file a fresh
+        # mtime while the loop has been dead for an hour. The self-reported ts
+        # is the honest clock.
+        self._declare()
+        self._stamp(age_s=4000, next_delay_s=600, mtime_age_s=0)
+        out = self._one()
+        self.assertEqual(out["status"], "down",
+                         "a fresh mtime masked a dead loop — probe is reading mtime, not ts")
+
+    def test_unparseable_payload_falls_back_to_mtime_and_SAYS_so(self):
+        self._declare()
+        self._stamp(raw="{not json", mtime_age_s=60)
+        out = self._one()
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("fell back to mtime", out["detail"])
+
+    def test_malformed_next_delay_assumes_a_conservative_default_and_SAYS_so(self):
+        # A corrupt cadence must not manufacture an alarm; 1800s is the slow end
+        # of /loop's documented fallback range. The caveat has to reach the
+        # detail, or the reader cannot tell a measured verdict from an assumed one.
+        self._declare()
+        self._stamp(age_s=60, next_delay_s="soon")
+        out = self._one()
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("no usable `next_delay_s`", out["detail"])
+        self.assertIn("assumed 30m", out["detail"])
+
+    def test_boolean_next_delay_is_rejected_not_read_as_one_second(self):
+        # bool is an int in Python: a `true` read naively becomes a 1-second
+        # cadence, and every subsequent check pages. Fails closed to the default.
+        self._declare()
+        self._stamp(age_s=60, next_delay_s=True)
+        self.assertEqual(self._one()["status"], "ok")
+
+    def test_read_failure_warns_not_crashes(self):
+        # A sentinel that exists() but whose read/stat raises (races, a broken
+        # mount) must degrade to warn, never propagate an OSError that would
+        # crash the whole health check.
+        class _ReadFails:
+            def exists(self):
+                return True
+
+            def read_text(self):
+                raise OSError("simulated read failure")
+
+            def stat(self):
+                raise OSError("simulated stat failure")
+
+        self._declare()
+        with mock.patch.object(self.hc, "status_read_path", return_value=_ReadFails()):
+            out = self._one()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("unreadable", out["detail"])
+
+    # --- enumeration ----------------------------------------------------
+
+    def test_each_declared_loop_gets_its_own_row(self):
+        self._crons([
+            {"name": "inbox-score", "prompt_skill": "inbox-score", "loop": "dynamic"},
+            {"name": "watch-feeds", "prompt_skill": "watch-feeds", "loop": "dynamic"},
+        ])
+        self._stamp("inbox-score", age_s=60, next_delay_s=2400)
+        out = self.hc.check_dynamic_loop_freshness()
+        by_name = {c["name"]: c for c in out}
+        self.assertEqual(set(by_name), {"dynamic-loop:inbox-score", "dynamic-loop:watch-feeds"})
+        self.assertEqual(by_name["dynamic-loop:inbox-score"]["status"], "ok")
+        self.assertEqual(by_name["dynamic-loop:watch-feeds"]["status"], "warn")
+
+    def test_run_all_checks_emits_the_dynamic_loop_check(self):
+        # Reachability guard (mirrors PR #1898): the probe is useless if it is
+        # defined but never wired into run_all_checks(). Exercise the real call
+        # site — with a loop declared, so an unwired probe cannot pass by
+        # emitting nothing.
+        self._declare()
+        self._stamp(age_s=60, next_delay_s=2400)
+        try:
+            checks = self.hc.run_all_checks()
+        except Exception as e:  # pragma: no cover - failure path
+            self.fail(f"run_all_checks() raised: {e!r}")
+        names = [c.get("name") for c in checks if isinstance(c, dict)]
+        self.assertIn("dynamic-loop:inbox-score", names,
+                      "run_all_checks() emitted no dynamic-loop check (branch unreachable)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The gap

A `loop: "dynamic"` entry in `hosts/<host>/crons.json` self-paces through `ScheduleWakeup`. That means it is:

- **not a cron job** — absent from `CronList`, so the `session-crons` probe cannot count it;
- **not an OS process** — invisible to `pgrep`, so no PID sentinel applies.

Every other liveness probe in `health-check.py` keys off one of those two. So a dynamic loop that stops re-arming pages nobody.

`/schedule-crons` already tells the loop body to stamp `state/dynamic-loop-<name>.alive` with `{ts, next_delay_s}` on every re-arm — a producer with no consumer:

```
$ git grep -nE 'dynamic-loop|dynamic_loop' src/health-check.py
$ echo "exit=$?"
exit=1
```

This is not hypothetical. The inbox-score loop died 2026-07-21 and owner-comm sweeps lapsed for days before anyone noticed. `check_comm_sweep_freshness` made the downstream symptom loud; this closes the same gap one layer up, at the loop itself.

## What it does

`check_dynamic_loop_freshness()` enumerates the dynamic entries this host declares, reads each sentinel, and compares its age against **the cadence the loop itself stamped**: warn past `next_delay_s + 120`, down past `2*next_delay_s + 300`.

A hardcoded threshold cannot work here — a self-pacing loop legitimately moves between ~10m busy and ~40m quiet, so a fixed number either false-alarms on the slow end or goes blind on the fast end. `test_thresholds_FOLLOW_the_sentinel_not_a_hardcoded_cadence` pins it: same 1800s age, `next_delay_s=2400` → ok, `next_delay_s=300` → down.

Three details are load-bearing:

- **Age comes from the payload's `ts`, not mtime.** `state/cores/*.alive` is deliberately vault-EXCLUDED so a synced mtime can never fake liveness; `state/dynamic-loop-*.alive` is *not* excluded, so a sync on an unrelated host can rewrite its mtime. mtime is only a fallback for a payload that won't parse, and the detail string says so when that happens.
- **Enumeration is the UNION of declared entries and sentinels on disk.** Config can still ADD a loop to watch (declared-but-never-stamped → warn) but can never remove one: a sentinel is judged on its age regardless of what `crons.json` says. Deleting an entry therefore cannot silently disarm a real stall — the dangerous direction, and the only one that matters for a probe whose purpose is "a stall that pages nobody".
- **Returns a list, empty on a host declaring none.** A permanent warn on a host with nothing to monitor is how a health output gets ignored, which would take this probe's real alarms down with it.

`_positive_seconds` excludes `bool` explicitly: `bool` is an `int` in Python, so a `next_delay_s: true` read naively becomes a 1-second cadence that pages forever.

## Evidence

### At the parent commit (826d08e0) — the broken state

```
$ cd /private/tmp/wt-dynloop-parent && git log --oneline -1
826d08e0 fix(credentials): prefer the literal '|' separator over %7C in combined tokens (#2679)

$ python3 tests/health-check-dynamic-loop-freshness.test.py
...
AssertionError: 'dynamic-loop:inbox-score' not found in ['voice-agent', 'voice-watchers',
'voice-transport', 'bodhi-dist', 'web-client', 'agent-api', 'dashboard', 'screen-capture',
'credential-proxy', 'quota-telemetry', 'quota-account-identity', 'core-quota', 'node-runtime',
'comm-sweep', 'vault-manifest', 'claude-hooks', 'cron-runner', 'session-crons',
'tcc-documents-access', 'CLAUDE.md', 'build_log.md', '.env', 'memory-dir',
'memory-dir-override', 'memory-index', 'notes-dir', 'memory-sync', 'host-subtrees',
'per-host-config-backup', 'live-checkout-branch', 'migrate-reader-contract',
'telegram-bridge', 'discord-bridge', 'slack-bridge', 'gateway-bridge', 'battery', 'memory',
'core-proactive-loop', 'core-supervisor', 'task-queue', 'orphaned-results',
'proactive-quarantine', 'task-watcher', 'codex-task-notifier', 'skill-symlinks',
'disk-space'] : run_all_checks() emitted no dynamic-loop check (branch unreachable)

----------------------------------------------------------------------
Ran 15 tests in 2.724s

FAILED (failures=1, errors=14)
```

The 14 errors are all `AttributeError: module 'health_check_dynloop_test' has no attribute 'check_dynamic_loop_freshness'`. The 15th is the reachability guard above — note the full 46-name `run_all_checks()` list contains no `dynamic-loop:` entry, which is the actual defect stated as an assertion.

### At HEAD

```
$ cd /private/tmp/wt-dynloop && git log --oneline -1
50b548f3 feat(health-check): page when a dynamic loop stops re-arming

$ python3 tests/health-check-dynamic-loop-freshness.test.py
----------------------------------------------------------------------
Ran 15 tests in 2.682s

OK
```

### No regressions — every existing health-check suite at HEAD

59 files: `tests/health-check-*.test.py` + `core-health-verdict.test.py` + `runtime-health.test.py`, all PASS.

```
health-check-bodhi-dist.test.py                            PASS
health-check-bridge-launcher-dupe.test.py                  PASS
...
health-check-comm-sweep-freshness.test.py                  PASS
health-check-dynamic-loop-freshness.test.py                PASS
...
core-health-verdict.test.py                                PASS
runtime-health.test.py                                     PASS
aggregate_exit=0
```

### Against the live workspace

The one host that declares a dynamic loop today:

```
$ cat "$WS/state/dynamic-loop-inbox-score.alive"
{"ts": 1785976631, "next_delay_s": 2400, "note": "quiet: owner idle 5.8h, 26 new unread all GitHub PR notifications, 0 human senders"}

$ python3 -c '<load health-check.py; call check_dynamic_loop_freshness(workspace_dir=WS)>'
[
  {
    "name": "dynamic-loop:inbox-score",
    "status": "ok",
    "detail": "inbox-score: last re-arm 16.8m ago, cadence 40m"
  }
]
```

Honest caveat about that `ok`: it is correct for the moment it was taken (16.8m into a 40m cadence). That loop's wakeup is **not** currently armed, so the probe should cross to `warn` at 42m and `down` at 85m — which is exactly the transition this PR exists to make visible, and which nothing in the tree could see before it.

## Review round 2 — `475cafe3`

@bassilkhilo-ag2 found the bullet above was false as originally written, and reproduced it: enumeration ran purely off `crons.json`, so deleting a `loop: "dynamic"` entry dropped a stalled loop out of `run_all_checks()` entirely. Confirmed, fixed, and the prose corrected to match what is now actually guaranteed.

The test that was supposed to cover it did not — it left the entry in `crons.json` and asserted only that `_host_dynamic_loops` wasn't called twice, **while its own comment conceded the asymmetry.** That comment was the tell.

Widened along the axis rather than patching the single reported case:

| case | before | after |
|---|---|---|
| stalled + declaration deleted | *no row at all* | `down` |
| stray sentinel, still re-arming | *no row* | `ok` (no permanent-warn regression) |
| undeclared stall via `run_all_checks()` | *absent* | `down` at the real call site |
| config consulted once, not per loop | ok | kept, as its own narrower test |

Mutation-verified — reverting **only** the union restores exactly those three failures and nothing else:

```
$ <revert enumeration to crons.json-only>
test_stalled_stays_down_even_when_the_declaration_is_REMOVED ... FAIL
  AssertionError: 0 != 1 : expected exactly one check, got []
test_run_all_checks_sees_an_UNDECLARED_stalled_loop ... FAIL
  AssertionError: unexpectedly None : a stalled loop vanished from run_all_checks()
                  once its crons.json entry was deleted
test_a_stray_but_FRESH_sentinel_does_not_manufacture_an_alarm ... FAIL
  AssertionError: 0 != 1 : expected exactly one check, got []
Ran 18 tests — FAILED (failures=3)

$ <restored>
Ran 18 tests — OK
```

The other 15 pass either way, which is correct: they don't test the enumeration source.

No regressions — 59 health-check suites (`tests/health-check-*.test.py` + `core-health-verdict` + `runtime-health`), `aggregate_exit=0`.

## Scope

Single concern. No prompt or tool-behavior changes. No refactors bundled. Added lines scanned for hardcoded host paths — none (`git diff | grep '^+' | grep -E '/Users/|/home/[a-z]+/|Chis-Mac'` → no matches); the probe resolves through `status_read_path` and `_host_label()`.

@sonichi
