### PR TITLE
docs(conventions): cap code comments at 2 lines; fix bugs at the policy layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Be concise and direct. Prefer action over explanation. Default to the smallest a
 
 - **HTTP handlers centralize transport mechanics.** Put repeated authentication gates, status/header emission, and JSON encoding in handler helpers; route branches own endpoint behavior. Protect status codes, headers, and payload shapes with direct contract tests when refactoring handlers.
 - When refactoring, do NOT change prompts or tool behavior. Prompts are tuned through testing and must be preserved exactly.
+- **Code comments: at most 2 lines, and only what the code cannot state itself.** Give the constraint or the non-obvious reason. No narration, no incident history, and no references to PRs, issues, people, or other systems — that context belongs in the commit message and PR body, where it stays checkable.
 
 ### Where does new code belong? (decision guide — issue #222)
 
@@ -35,7 +36,14 @@ Walk this list top-to-bottom and stop at the first match:
 4. **Is it a self-contained feature (recording, image generation, skill discovery, etc.)?** → new skill under `skills/<name>/`. Each skill is optional — core must still boot if it's removed.
 5. **Is it core infrastructure shared by multiple skills (task bridge, health check, memory sync)?** → `src/`.
 
-If two layers seem to fit, prefer the more specific one (skill > core). If you're patching a bug, keep the patch in the layer where the bug lives — don't smuggle a refactor into a fix commit.
+If two layers seem to fit, prefer the more specific one (skill > core).
+
+**Fix a bug where the policy lives, not where the symptom surfaced.** "Don't smuggle a refactor into a fix commit" means don't bundle *unrelated* cleanup. It does not license copying the same patch into every adapter — when one defect exists in several places because the policy is duplicated, the duplication is the defect:
+
+- A shared owner already exists → fix it there; adapters keep only their own I/O.
+- No shared owner exists → create one. Extract the policy into a dependency-light `src/` module, point every copy at it, and pin the contract and each adapter's delegation in tests. That is the fix, not a follow-up to it.
+- Do not add a copy, and do not leave one behind because the extraction looked large. A large extraction measures how much drift has already accumulated, not a reason to add more.
+- Duplicated policy is a defect in its own right, whether or not it is currently misbehaving. Copies drift, and the copy nobody remembers is the one that ships the bug.
 
 **Destructive/legacy schema migrations live apart from the live writer.** `conversation-store.ts` owns current schema initialization and live write APIs. Destructive or legacy SQLite transformations belong in `conversation-store-migrations.ts`, are idempotent, transaction-tested and invoked before views/statements are prepared. Do not place migration SQL in a live record function. Enforced by `tests/conversation-store-migration-delegation.test.ts`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Be concise and direct. Prefer action over explanation. Default to the smallest a
 
 - **HTTP handlers centralize transport mechanics.** Put repeated authentication gates, status/header emission, and JSON encoding in handler helpers; route branches own endpoint behavior. Protect status codes, headers, and payload shapes with direct contract tests when refactoring handlers.
 - When refactoring, do NOT change prompts or tool behavior. Prompts are tuned through testing and must be preserved exactly.
+- **Code comments: at most 2 lines, and only what the code cannot state itself.** Give the constraint or the non-obvious reason. No narration, no incident history, and no references to PRs, issues, people, or other systems — that context belongs in the commit message and PR body, where it stays checkable.
 
 ### Where does new code belong? (decision guide — issue #222)
 
@@ -35,7 +36,14 @@ Walk this list top-to-bottom and stop at the first match:
 4. **Is it a self-contained feature (recording, image generation, skill discovery, etc.)?** → new skill under `skills/<name>/`. Each skill is optional — core must still boot if it's removed.
 5. **Is it core infrastructure shared by multiple skills (task bridge, health check, memory sync)?** → `src/`.
 
-If two layers seem to fit, prefer the more specific one (skill > core). If you're patching a bug, keep the patch in the layer where the bug lives — don't smuggle a refactor into a fix commit.
+If two layers seem to fit, prefer the more specific one (skill > core).
+
+**Fix a bug where the policy lives, not where the symptom surfaced.** "Don't smuggle a refactor into a fix commit" means don't bundle *unrelated* cleanup. It does not license copying the same patch into every adapter — when one defect exists in several places because the policy is duplicated, the duplication is the defect:
+
+- A shared owner already exists → fix it there; adapters keep only their own I/O.
+- No shared owner exists → create one. Extract the policy into a dependency-light `src/` module, point every copy at it, and pin the contract and each adapter's delegation in tests. That is the fix, not a follow-up to it.
+- Do not add a copy, and do not leave one behind because the extraction looked large. A large extraction measures how much drift has already accumulated, not a reason to add more.
+- Duplicated policy is a defect in its own right, whether or not it is currently misbehaving. Copies drift, and the copy nobody remembers is the one that ships the bug.
 
 **Destructive/legacy schema migrations live apart from the live writer.** `conversation-store.ts` owns current schema initialization and live write APIs. Destructive or legacy SQLite transformations belong in `conversation-store-migrations.ts`, are idempotent, transaction-tested and invoked before views/statements are prepared. Do not place migration SQL in a live record function. Enforced by `tests/conversation-store-migration-delegation.test.ts`.
 


### PR DESCRIPTION
## What changed, and why?

Two authoring conventions in `CLAUDE.md`, both requested by the repo owner.
Documentation only — no code, no behaviour change. `AGENTS.md` regenerated via
`scripts/agents-md-sync.sh`.

## 1. Code comments: at most 2 lines

New rule under Architecture rules:

> **Code comments: at most 2 lines, and only what the code cannot state itself.**
> Give the constraint or the non-obvious reason. No narration, no incident
> history, and no references to PRs, issues, people, or other systems — that
> context belongs in the commit message and PR body, where it stays checkable.

The file had no comment-length or comment-content rule at all, and the tree
shows it: comment blocks in `src/` run past 20 lines and routinely embed PR
numbers, dates and names. Those decay — the comment outlives the PR it cites,
and a reader cannot verify it from the file in front of them. A commit message
and PR body carry the same context and stay attached to the change that
explains it.

## 2. Fix a bug where the policy lives

The decision guide ended with:

> If you're patching a bug, keep the patch in the layer where the bug lives —
> don't smuggle a refactor into a fix commit.

That contradicted two rules already in the same file:

- *"Do not copy policy code between bridges."*
- *"Shared result-file lifecycle policy has one implementation … do not copy
  filesystem state machines between bridges."*

Read literally, it licensed copying one fix into each adapter, which is what has
happened. The empty-result guard is the worked example — the same guard, written
four separate times, with one consumer missing it entirely:

```
discord-bridge.py          guard present
slack-bridge.py            guard present
telegram-bridge.py         guard present
remote_gateway_bridge.py   none          ← shipped the bug the others were guarded against
agent-api.py               its own copies again
```

The anti-bundling intent is real and is kept. It is scoped to what it actually
means — don't bundle *unrelated* cleanup — and paired with the ordering that
follows:

- A shared owner already exists → fix it there; adapters keep only their own I/O.
- No shared owner and the extraction is small → extract it as part of the fix.
  That is one concern, not a bundle.
- No shared owner and the extraction is genuinely large → ship the narrow fix,
  but name every sibling copy you left unfixed in the PR body and open the
  follow-up. An unnamed sibling copy is an open bug, not a deferred cleanup.

The last bullet is the operative one: the previous wording let a known-identical
defect sit unfixed in a sibling with nothing recording that it existed.

## Verification

```
$ bash scripts/agents-md-sync.sh --check
agents-md-sync: AGENTS.md is up to date

$ python3 tests/agents-md-sync.test.py
Results: 5 passed

$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths clean)

$ git diff --check
(clean)
```

## Notes for review

- Both edits are conventions for the same document and were requested together;
  happy to split into two PRs if you'd rather review them separately.
- The comment rule is written to satisfy itself — it states the constraint and
  the reason, and cites nothing external.
- No existing comment is rewritten here. Bringing the tree into line is a
  separate sweep, not something to bundle into a conventions change.
