### PR TITLE
fix(web): hide internal system task history

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1186,6 +1186,14 @@ const PERSIST_KEY_TASKS = 'sutando-taskmap-v1';
 const PERSIST_KEY_EXPAND = 'sutando-expanded-v1';
 const PERSIST_KEY_SHOW_DONE = 'sutando-show-done-v1';
 const PERSIST_KEY_WORKSTREAM_DISPLAY = 'sutando-task-workstream-display-v1';
+// The Codex scheduler represents each silent proactive-loop tick as a task so
+// the durable runner can claim, retry, and audit it. Those bookkeeping rows are
+// not owner work and would otherwise accumulate in archive-backed task history.
+// Keep useful scheduled outputs (briefings, scans, etc.) visible by filtering
+// only the canonical internal main-loop task id.
+function isOwnerVisibleTaskId(taskId) {
+  return !String(taskId || '').startsWith('task-cron-main-loop-');
+}
 // Default-hide done tasks. With Tasks growing to top-30, completed work was
 // crowding out active items and the watcher-glance use case ("what's still
 // running?") got lost. Toggle persists across reloads.
@@ -1202,6 +1210,9 @@ function loadPersistedTaskMap() {
     const raw = localStorage.getItem(PERSIST_KEY_TASKS);
     if (!raw) return {};
     const parsed = JSON.parse(raw);
+    Object.keys(parsed).forEach(function(taskId) {
+      if (!isOwnerVisibleTaskId(taskId)) delete parsed[taskId];
+    });
     // Reconstruct Date objects on time fields
     Object.values(parsed).forEach(t => { if (t && t.time) t.time = new Date(t.time); });
     return parsed;
@@ -1307,6 +1318,7 @@ function mergeTaskRow(existing, row) {
 }
 
 function updateTask(taskId, status, text, result) {
+  if (!isOwnerVisibleTaskId(taskId)) return;
   const existing = taskMap[taskId] || {};
   const isNew = !existing.status;
   taskMap[taskId] = Object.assign({}, existing, {
@@ -1462,7 +1474,9 @@ function summarizeTaskText(raw) {
 // canonical numbered display order used by rendering and voice expand:N.
 const UNGROUPED_WORKSTREAM_ID = '__ungrouped__';
 function groupedTaskDisplay(entries, limit) {
-  let chronological = entries.slice().sort(function(a, b) {
+  let chronological = entries.filter(function(entry) {
+    return isOwnerVisibleTaskId(entry[0]);
+  }).sort(function(a, b) {
     return b[1].time - a[1].time;
   });
   if (Number.isInteger(limit) && limit >= 0) chronological = chronological.slice(0, limit);
@@ -1526,7 +1540,9 @@ function renderTaskWorkstreamGroups(display, renderEntry) {
 
 function renderTasks() {
   const container = $('tasks');
-  const entries = Object.entries(taskMap);
+  const entries = Object.entries(taskMap).filter(function(entry) {
+    return isOwnerVisibleTaskId(entry[0]);
+  });
   window._drTaskCount = entries.length;
   const hdr = $('tasks-header');
   if (entries.length === 0) { container.innerHTML = ''; if (hdr) hdr.style.display = 'none'; return; }
@@ -1658,7 +1674,7 @@ async function hydrateTaskHistory() {
     const data = await resp.json();
     rememberTaskWorkstreams(data.workstreams);
     for (const row of (data.tasks || [])) {
-      if (!row || !row.id) continue;
+      if (!row || !row.id || !isOwnerVisibleTaskId(row.id)) continue;
       knownTaskIds.add(row.id);
       taskMap[row.id] = mergeTaskRow(taskMap[row.id] || {}, row);
       if (row.workstream_id) taskWorkstreamRefreshRequested.delete(row.id);
@@ -1690,6 +1706,7 @@ function startTaskPolling() {
       // Replace taskMap with API data (preserve expanded state and WebSocket-delivered results)
       const apiTasks = new Set();
       for (const t of (data.tasks || [])) {
+        if (!t || !isOwnerVisibleTaskId(t.id)) continue;
         apiTasks.add(t.id);
         const existing = taskMap[t.id] || {};
         if (t.workstream_id) {

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1186,13 +1186,15 @@ const PERSIST_KEY_TASKS = 'sutando-taskmap-v1';
 const PERSIST_KEY_EXPAND = 'sutando-expanded-v1';
 const PERSIST_KEY_SHOW_DONE = 'sutando-show-done-v1';
 const PERSIST_KEY_WORKSTREAM_DISPLAY = 'sutando-task-workstream-display-v1';
-// The Codex scheduler represents each silent proactive-loop tick as a task so
-// the durable runner can claim, retry, and audit it. Those bookkeeping rows are
-// not owner work and would otherwise accumulate in archive-backed task history.
-// Keep useful scheduled outputs (briefings, scans, etc.) visible by filtering
-// only the canonical internal main-loop task id.
-function isOwnerVisibleTaskId(taskId) {
-  return !String(taskId || '').startsWith('task-cron-main-loop-');
+// Durable schedulers and health probes use normal task records for claiming,
+// retries, and audit. Archive-backed history must keep those records available
+// to the API without turning them into owner work in the Tasks UI.
+function isOwnerVisibleTask(taskId, task) {
+  const id = String(taskId || '');
+  const source = String((task && task.source) || '').toLowerCase();
+  return source !== 'cron' && source !== 'health-check' &&
+    !id.startsWith('task-cron-') && !id.startsWith('task-health-') &&
+    !id.startsWith('task-smoke-') && !id.startsWith('task-discord-e2e-');
 }
 // Default-hide done tasks. With Tasks growing to top-30, completed work was
 // crowding out active items and the watcher-glance use case ("what's still
@@ -1211,7 +1213,7 @@ function loadPersistedTaskMap() {
     if (!raw) return {};
     const parsed = JSON.parse(raw);
     Object.keys(parsed).forEach(function(taskId) {
-      if (!isOwnerVisibleTaskId(taskId)) delete parsed[taskId];
+      if (!isOwnerVisibleTask(taskId, parsed[taskId])) delete parsed[taskId];
     });
     // Reconstruct Date objects on time fields
     Object.values(parsed).forEach(t => { if (t && t.time) t.time = new Date(t.time); });
@@ -1318,7 +1320,7 @@ function mergeTaskRow(existing, row) {
 }
 
 function updateTask(taskId, status, text, result) {
-  if (!isOwnerVisibleTaskId(taskId)) return;
+  if (!isOwnerVisibleTask(taskId, null)) return;
   const existing = taskMap[taskId] || {};
   const isNew = !existing.status;
   taskMap[taskId] = Object.assign({}, existing, {
@@ -1475,7 +1477,7 @@ function summarizeTaskText(raw) {
 const UNGROUPED_WORKSTREAM_ID = '__ungrouped__';
 function groupedTaskDisplay(entries, limit) {
   let chronological = entries.filter(function(entry) {
-    return isOwnerVisibleTaskId(entry[0]);
+    return isOwnerVisibleTask(entry[0], entry[1]);
   }).sort(function(a, b) {
     return b[1].time - a[1].time;
   });
@@ -1541,7 +1543,7 @@ function renderTaskWorkstreamGroups(display, renderEntry) {
 function renderTasks() {
   const container = $('tasks');
   const entries = Object.entries(taskMap).filter(function(entry) {
-    return isOwnerVisibleTaskId(entry[0]);
+    return isOwnerVisibleTask(entry[0], entry[1]);
   });
   window._drTaskCount = entries.length;
   const hdr = $('tasks-header');
@@ -1674,7 +1676,7 @@ async function hydrateTaskHistory() {
     const data = await resp.json();
     rememberTaskWorkstreams(data.workstreams);
     for (const row of (data.tasks || [])) {
-      if (!row || !row.id || !isOwnerVisibleTaskId(row.id)) continue;
+      if (!row || !row.id || !isOwnerVisibleTask(row.id, row)) continue;
       knownTaskIds.add(row.id);
       taskMap[row.id] = mergeTaskRow(taskMap[row.id] || {}, row);
       if (row.workstream_id) taskWorkstreamRefreshRequested.delete(row.id);
@@ -1706,7 +1708,7 @@ function startTaskPolling() {
       // Replace taskMap with API data (preserve expanded state and WebSocket-delivered results)
       const apiTasks = new Set();
       for (const t of (data.tasks || [])) {
-        if (!t || !isOwnerVisibleTaskId(t.id)) continue;
+        if (!t || !isOwnerVisibleTask(t.id, t)) continue;
         apiTasks.add(t.id);
         const existing = taskMap[t.id] || {};
         if (t.workstream_id) {

--- a/tests/web-client-task-workstream-grouping.test.py
+++ b/tests/web-client-task-workstream-grouping.test.py
@@ -22,7 +22,7 @@ def _helper_source() -> str:
 
 
 def _visibility_policy_source() -> str:
-    marker = "function isOwnerVisibleTaskId"
+    marker = "function isOwnerVisibleTask"
     assert marker in SOURCE, "owner task history has no internal-task visibility policy"
     start = SOURCE.index(marker)
     end = SOURCE.index("\n}", start) + 2
@@ -98,9 +98,12 @@ function persistTaskWorkstreamDisplayState() {}
 function esc(value) { return String(value); }
 """ + _visibility_policy_source() + _helper_source() + r"""
 const display = groupedTaskDisplay([
-  ['task-owner-message', {time: new Date(30), status: 'working'}],
-  ['task-cron-main-loop-123', {time: new Date(20), status: 'working'}],
-  ['task-cron-daily-brief-456', {time: new Date(10), status: 'done'}],
+  ['task-owner-message', {time: new Date(60), status: 'working', source: 'discord'}],
+  ['task-owner-api', {time: new Date(50), status: 'done', source: 'api'}],
+  ['task-cron-main-loop-123', {time: new Date(40), status: 'working', source: 'cron'}],
+  ['task-cron-daily-brief-456', {time: new Date(30), status: 'done', source: 'cron'}],
+  ['task-health-789', {time: new Date(20), status: 'working', source: 'health-check'}],
+  ['task-discord-e2e-012', {time: new Date(10), status: 'done', source: 'discord'}],
 ]);
 process.stdout.write(JSON.stringify({
   entries: display.entries.map(function(entry) { return entry[0]; }),
@@ -116,9 +119,9 @@ process.stdout.write(JSON.stringify({
     return json.loads(result.stdout)
 
 
-def test_internal_main_loop_is_hidden_but_other_crons_remain() -> None:
+def test_internal_system_tasks_are_hidden_from_owner_history() -> None:
     data = _run_visibility_probe()
-    assert data["entries"] == ["task-owner-message", "task-cron-daily-brief-456"]
+    assert data["entries"] == ["task-owner-message", "task-owner-api"]
 
 
 def test_group_order_chronology_numbering_and_escaping() -> None:
@@ -174,10 +177,10 @@ def test_all_three_display_paths_share_order_and_history_is_quiet() -> None:
     load = SOURCE[SOURCE.index("function loadPersistedTaskMap"):SOURCE.index("function loadPersistedExpanded")]
     update = SOURCE[SOURCE.index("function updateTask"):SOURCE.index("const expandedTasks")]
     poll = SOURCE[SOURCE.index("function startTaskPolling"):SOURCE.index("function stopTaskPolling")]
-    assert "!isOwnerVisibleTaskId(taskId)" in load
-    assert "if (!isOwnerVisibleTaskId(taskId)) return" in update
-    assert "!isOwnerVisibleTaskId(row.id)" in hydrate
-    assert poll.index("!isOwnerVisibleTaskId(t.id)") < poll.index("apiTasks.add(t.id)")
+    assert "!isOwnerVisibleTask(taskId, parsed[taskId])" in load
+    assert "if (!isOwnerVisibleTask(taskId, null)) return" in update
+    assert "!isOwnerVisibleTask(row.id, row)" in hydrate
+    assert poll.index("!isOwnerVisibleTask(t.id, t)") < poll.index("apiTasks.add(t.id)")
     assert "Object.assign({}, existing" in update
     assert "taskMap[t.id] = mergeTaskRow(existing, t)" in poll
     assert "if (taskHistoryInitialLoadComplete)" in poll
@@ -196,7 +199,7 @@ def test_all_three_display_paths_share_order_and_history_is_quiet() -> None:
 
 def main() -> None:
     tests = [
-        test_internal_main_loop_is_hidden_but_other_crons_remain,
+        test_internal_system_tasks_are_hidden_from_owner_history,
         test_group_order_chronology_numbering_and_escaping,
         test_all_ungrouped_keeps_flat_appearance,
         test_all_three_display_paths_share_order_and_history_is_quiet,

--- a/tests/web-client-task-workstream-grouping.test.py
+++ b/tests/web-client-task-workstream-grouping.test.py
@@ -21,6 +21,14 @@ def _helper_source() -> str:
     return SOURCE[start:end]
 
 
+def _visibility_policy_source() -> str:
+    marker = "function isOwnerVisibleTaskId"
+    assert marker in SOURCE, "owner task history has no internal-task visibility policy"
+    start = SOURCE.index(marker)
+    end = SOURCE.index("\n}", start) + 2
+    return SOURCE[start:end]
+
+
 def _run_helper_probe() -> dict:
     # Execute the exact browser helper source. A tiny DOM-free esc stand-in is
     # sufficient here because its contract is the same text-to-HTML escaping
@@ -38,7 +46,7 @@ function esc(value) {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 }
-""" + _helper_source() + r"""
+""" + _visibility_policy_source() + _helper_source() + r"""
 const rows = [
   ['a1', {time: new Date(10), status: 'done', workstream_id: 'a', workstream_name: '<img src=x onerror=boom>'}],
   ['b1', {time: new Date(20), status: 'done', workstream_id: 'b', workstream_name: 'Mission B'}],
@@ -79,6 +87,38 @@ process.stdout.write(JSON.stringify({
         check=True,
     )
     return json.loads(result.stdout)
+
+
+def _run_visibility_probe() -> dict:
+    probe = r"""
+let taskWorkstreamNames = Object.create(null);
+const collapsedTaskWorkstreams = new Set();
+const seenTaskWorkstreams = new Set();
+function persistTaskWorkstreamDisplayState() {}
+function esc(value) { return String(value); }
+""" + _visibility_policy_source() + _helper_source() + r"""
+const display = groupedTaskDisplay([
+  ['task-owner-message', {time: new Date(30), status: 'working'}],
+  ['task-cron-main-loop-123', {time: new Date(20), status: 'working'}],
+  ['task-cron-daily-brief-456', {time: new Date(10), status: 'done'}],
+]);
+process.stdout.write(JSON.stringify({
+  entries: display.entries.map(function(entry) { return entry[0]; }),
+}));
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_internal_main_loop_is_hidden_but_other_crons_remain() -> None:
+    data = _run_visibility_probe()
+    assert data["entries"] == ["task-owner-message", "task-cron-daily-brief-456"]
 
 
 def test_group_order_chronology_numbering_and_escaping() -> None:
@@ -131,8 +171,13 @@ def test_all_three_display_paths_share_order_and_history_is_quiet() -> None:
     assert "setTimeout(function()" in SOURCE[SOURCE.index("function scheduleTaskHistoryHydration"):SOURCE.index("async function hydrateTaskHistory")]
 
     # Both live update paths preserve the additive workstream metadata.
+    load = SOURCE[SOURCE.index("function loadPersistedTaskMap"):SOURCE.index("function loadPersistedExpanded")]
     update = SOURCE[SOURCE.index("function updateTask"):SOURCE.index("const expandedTasks")]
     poll = SOURCE[SOURCE.index("function startTaskPolling"):SOURCE.index("function stopTaskPolling")]
+    assert "!isOwnerVisibleTaskId(taskId)" in load
+    assert "if (!isOwnerVisibleTaskId(taskId)) return" in update
+    assert "!isOwnerVisibleTaskId(row.id)" in hydrate
+    assert poll.index("!isOwnerVisibleTaskId(t.id)") < poll.index("apiTasks.add(t.id)")
     assert "Object.assign({}, existing" in update
     assert "taskMap[t.id] = mergeTaskRow(existing, t)" in poll
     assert "if (taskHistoryInitialLoadComplete)" in poll
@@ -151,6 +196,7 @@ def test_all_three_display_paths_share_order_and_history_is_quiet() -> None:
 
 def main() -> None:
     tests = [
+        test_internal_main_loop_is_hidden_but_other_crons_remain,
         test_group_order_chronology_numbering_and_escaping,
         test_all_ungrouped_keeps_flat_appearance,
         test_all_three_display_paths_share_order_and_history_is_quiet,


### PR DESCRIPTION
Closes #2699.

## What changed, and why?

The owner-facing web task UI now filters internal scheduler and probe records at every client ingestion/display boundary:

- source classes `cron` and `health-check`;
- stable internal IDs `task-cron-*`, `task-health-*`, `task-smoke-*`, and `task-discord-e2e-*`;
- persisted local task state is pruned on load;
- WebSocket updates, durable history hydration, and active polling reject internal rows before they can toast or persist;
- the shared grouped-display helper filters them defensively, keeping Tasks-tab and voice `expand:N` ordering aligned.

The API, scheduler, task files, retry behavior, archive, and schedule-specific delivery remain unchanged.

The root cause is that #2586 intentionally hydrated up to 500 live and archived task records but only excluded its classifier maintenance tasks. Pre-existing scheduler and health-probe tasks were not part of the owner-UI visibility policy, so current passes appeared as active work and completed runs became durable owner-facing history.

## Review first

- `src/web-client.ts`: `isOwnerVisibleTask` and its ingestion/display call sites
- `tests/web-client-task-workstream-grouping.test.py`: executable browser-helper regression

## What user behavior does this prove?

Opening the dashboard no longer shows or toasts internal cron, health-check, smoke, or Discord E2E task records. Real owner tasks from Discord, voice, chat, API, and context-drop remain visible. The private history API still retains the full audit corpus.

## Feature/documentation consistency

N/A. This fixes filtering in an existing Tasks UI; `docs/catalog.json` has no canonical task-history/workstream UI document to update.

## Before/after evidence

Parent `826d08e0`, with the regression test added but production code unchanged:

```text
$ python3 tests/web-client-task-workstream-grouping.test.py
FAILED: owner task history has no internal-task visibility policy
...
AssertionError: owner task history has no internal-task visibility policy
```

HEAD `d93fd030`:

```text
$ python3 tests/web-client-task-workstream-grouping.test.py
  ✓ test_internal_system_tasks_are_hidden_from_owner_history
  ✓ test_group_order_chronology_numbering_and_escaping
  ✓ test_all_ungrouped_keeps_flat_appearance
  ✓ test_all_three_display_paths_share_order_and_history_is_quiet
web-client inferred-workstream grouping tests passed
```

Isolated worktree web client on port 18080, backed by the real local agent API:

```json
{
  "api_total": 402,
  "api_internal_system_count": 112,
  "api_cron_count": 109,
  "api_health_check_count": 2,
  "ui_task_map_count": 291,
  "ui_internal_system_count": 0,
  "rendered_internal_system_count": 0,
  "dynamic_task_count": 291,
  "browser_errors": []
}
```

This proves all 112 classified internal rows remain available through the API while none enter or render in the owner UI. The isolated server was stopped after the probe; the normal dashboard was never replaced.

## Tests

```text
python3 tests/web-client-task-workstream-grouping.test.py  PASS (4/4)
npm run typecheck                                      PASS
npx eslint src/web-client.ts                           PASS (0 errors; 5 pre-existing warnings)
git diff --check                                       PASS
git diff | bash scripts/review-checks.sh               PASS
```

## Touching a live path?

No bridge, network-delivery, startup, scheduler, or API behavior changes. The browser proof above runs the real worktree web client against the live history endpoint without restarting the owner service.

## Stacked PR?

N/A. Based directly on current `origin/main`.

## Hardcoded-path check

`git diff | bash scripts/review-checks.sh` reports `review-checks: PASS (hardcoded-paths clean)`.

## Edge cases and risks

- Old localStorage copies of hidden rows are pruned on the next page load.
- Future cron/health tasks are source-filtered even when their ID naming changes; stable prefixes defend source-less live updates and old persisted rows.
- Owner-facing API/chat/Discord/voice/context-drop tasks remain visible.
- No schema, migration, permission, config, scheduler, or API changes.
- Rollback is reverting the two commits; scheduler and audit data never change.