### PR TITLE
feat(gateway): per-instance channel dir + config-derived deliverable surfaces (multi-homeserver)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -34,6 +34,13 @@ Config (env / .env):
   REMOTE_TASK_URL        gateway base URL (only needed with a bare secret)
   REMOTE_TASK_URL/_TOKEN  legacy aliases
   REMOTE_TASK_PROVIDER  label used for the task `source:` field (default "remote")
+  REMOTE_TASK_CHANNEL_DIR  name of this instance's config dir under
+                        $CLAUDE_CONFIG_DIR/channels/ (default "ag2space") —
+                        selects which .env fallback and access.json a bridge
+                        instance reads, so a second instance (e.g. a dev
+                        homeserver's "dev-ag2space") cannot inherit prod's
+                        credentials or tier map. Env-only by necessity: the
+                        .env file cannot name its own directory.
   REMOTE_TASK_POLL_WAIT long-poll seconds (default 25)
 
 Stdlib only (urllib) — no new dependencies.
@@ -353,6 +360,12 @@ def _parse_onboarding_token(raw):
     return raw[:m.start()], raw[m.end():]  # URL + secret, both verbatim
 
 
+# Which channels/<dir>/ this instance reads (.env fallback + access.json).
+# Env-only — the .env file can't name its own directory. Default preserves the
+# historical single-instance layout.
+CHANNEL_DIR = os.environ.get("REMOTE_TASK_CHANNEL_DIR") or "ag2space"
+
+
 def _token_from_ag2space_env():
     """Fallback token source when the launcher didn't export it into the env.
 
@@ -386,7 +399,7 @@ def _token_from_ag2space_env():
     candidates = [os.environ.get("AG2_DEVICE_ENV")]
     _cfg = os.environ.get("CLAUDE_CONFIG_DIR")
     if _cfg:
-        candidates.append(os.path.join(_cfg, "channels", "ag2space", ".env"))
+        candidates.append(os.path.join(_cfg, "channels", CHANNEL_DIR, ".env"))
     for path in candidates:
         if not path:
             continue
@@ -597,7 +610,7 @@ if LOCAL_TIER not in ("owner", "team", "other"):
 # revoke them without a restart.
 def _ag2space_access_path():
     base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
-    return os.path.join(base, "channels", "ag2space", "access.json")
+    return os.path.join(base, "channels", CHANNEL_DIR, "access.json")
 
 
 # Known tier vocabulary. Also an ordering (higher == more privileged); kept for

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -206,13 +206,23 @@ def _is_deliverable(source):
         return True
     if not source or not _SOURCE_SLUG_RE.match(source):
         return False
-    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
-    # Probe for exactly what notify.py's sender reads — channels/<source>/.env.
-    # A broader *.env glob would mark lanes deliverable that the sender then
-    # fails on (exit 1), losing the escalation AND blocking the debounce latch
-    # (review P1 on #2701). If notify.py ever learns more filenames (#2686's
-    # try-both), widen BOTH sides together.
-    return os.path.isfile(os.path.join(base, "channels", source, ".env"))
+    # Probe for exactly what notify.py's sender reads, mirroring its FULL
+    # resolution contract (review P1 x2 on #2701 — filename alone was not
+    # enough): (1) same three-tier base, CLAUDE_CONFIG_DIR -> CLAUDE_HOME ->
+    # ~/.claude; (2) same realpath containment — a channel entry symlinked
+    # OUTSIDE channels/ is one the sender refuses, so probing it deliverable
+    # would recreate the selected-then-send-fails class via a different
+    # mismatch. If notify.py ever learns more filenames (#2686's try-both),
+    # widen BOTH sides together.
+    base = (os.environ.get("CLAUDE_CONFIG_DIR") or os.environ.get("CLAUDE_HOME")
+            or os.path.join(os.path.expanduser("~"), ".claude"))
+    channels_dir = os.path.join(base, "channels")
+    env_path = os.path.join(channels_dir, source, ".env")
+    if not os.path.isfile(env_path):
+        return False
+    real_env = os.path.realpath(env_path)
+    real_root = os.path.realpath(channels_dir)
+    return real_env.startswith(real_root + os.sep)
 
 
 def resolve_active_target(activity_path):

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -42,6 +42,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import subprocess
 import sys
 
@@ -189,7 +190,27 @@ def run_cycle(signal, state_file, *, macos=True, source="", channel="", dry_run=
 # Surfaces task-progress notify.py can actually DELIVER to. Other values that
 # land in last-owner-activity.json ("voice", "github-commits", …) are activity
 # signals, not deliverable channels — never route an escalation to them.
+# Beyond the static set, any source with a configured channel dir
+# ($CLAUDE_CONFIG_DIR/channels/<source>/ containing a *.env) counts — that
+# mirrors notify.py's own resolution rule, so a NEW homeserver bridge (e.g.
+# "dev-ag2space") becomes routable by creating its config dir, no code change.
 _DELIVERABLE_SURFACES = {"discord", "slack", "telegram", "ag2space"}
+
+# Same slug shape notify.py enforces — keeps a malformed/hostile activity file
+# from steering the existence probe at an arbitrary path.
+_SOURCE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+def _is_deliverable(source):
+    if source in _DELIVERABLE_SURFACES:
+        return True
+    if not source or not _SOURCE_SLUG_RE.match(source):
+        return False
+    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
+    try:
+        return any(n.endswith(".env") for n in os.listdir(os.path.join(base, "channels", source)))
+    except OSError:
+        return False
 
 
 def resolve_active_target(activity_path):
@@ -210,7 +231,7 @@ def resolve_active_target(activity_path):
         return "", ""
     source = str(data.get("channel", "")).strip()
     channel = str(data.get("channel_id", "")).strip()
-    if source in _DELIVERABLE_SURFACES and channel:
+    if _is_deliverable(source) and channel:
         return source, channel
     return "", ""
 

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -207,10 +207,12 @@ def _is_deliverable(source):
     if not source or not _SOURCE_SLUG_RE.match(source):
         return False
     base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
-    try:
-        return any(n.endswith(".env") for n in os.listdir(os.path.join(base, "channels", source)))
-    except OSError:
-        return False
+    # Probe for exactly what notify.py's sender reads — channels/<source>/.env.
+    # A broader *.env glob would mark lanes deliverable that the sender then
+    # fails on (exit 1), losing the escalation AND blocking the debounce latch
+    # (review P1 on #2701). If notify.py ever learns more filenames (#2686's
+    # try-both), widen BOTH sides together.
+    return os.path.isfile(os.path.join(base, "channels", source, ".env"))
 
 
 def resolve_active_target(activity_path):

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1116,7 +1116,17 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
     # leaving the success line outside it still reported a launch that never
     # happened — per named instance, on a configured remote-control surface.
     if [ -n "$PY" ]; then
+      # REMOTE_TASK_CHANNEL_DIR isolates this instance's channel config
+      # (.env fallback + access.json). Without it the named instance defaults
+      # to channels/ag2space/ and inherits PROD's credentials and tier map —
+      # the exact failure #2701 exists to prevent (review P1, bassil).
+      # Convention: instance "dev" → channels/dev-ag2space/; anything else →
+      # channels/<inst>-ag2space/ unless the operator overrides via
+      # REMOTE_TASK_CHANNEL_DIR_<INST>.
+      _gw_chdir_var="REMOTE_TASK_CHANNEL_DIR_${_gw_var#AG2_REMOTE_TOKEN_}"
+      _gw_chdir="${!_gw_chdir_var:-${_gw_inst}-ag2space}"
       SUTANDO_SUPERVISED=1 GATEWAY_INSTANCE="$_gw_inst" REMOTE_TASK_TOKEN="${!_gw_var}" \
+        REMOTE_TASK_CHANNEL_DIR="$_gw_chdir" \
         REMOTE_PROACTIVE_ROOM= \
         "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &
       echo "  ✓ gateway bridge ($_gw_inst — self-defers if already running)"

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -304,13 +304,32 @@ class TestResolveActiveTarget(unittest.TestCase):
         # own resolution rule) — adding a homeserver is config-only.
         with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
             os.makedirs(os.path.join(cfg, "channels", "dev-ag2space"))
-            with open(os.path.join(cfg, "channels", "dev-ag2space", "relay-client.env"), "w") as f:
+            with open(os.path.join(cfg, "channels", "dev-ag2space", ".env"), "w") as f:
                 f.write("REMOTE_TASK_TOKEN=x\n")
             p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:dev.ag2.space"})
             old = os.environ.get("CLAUDE_CONFIG_DIR")
             os.environ["CLAUDE_CONFIG_DIR"] = cfg
             try:
                 self.assertEqual(resolve_active_target(p), ("dev-ag2space", "!r:dev.ag2.space"))
+            finally:
+                if old is None:
+                    del os.environ["CLAUDE_CONFIG_DIR"]
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def test_relay_client_env_alone_is_not_deliverable(self):
+        # notify.py reads exactly channels/<source>/.env; a lane holding only
+        # relay-client.env would fail the actual send — must NOT be selected
+        # (the #2701 review P1 failure mode).
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
+            os.makedirs(os.path.join(cfg, "channels", "dev-ag2space"))
+            with open(os.path.join(cfg, "channels", "dev-ag2space", "relay-client.env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:dev.ag2.space"})
+            old = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            try:
+                self.assertEqual(resolve_active_target(p), ("", ""))
             finally:
                 if old is None:
                     del os.environ["CLAUDE_CONFIG_DIR"]

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -349,6 +349,49 @@ class TestResolveActiveTarget(unittest.TestCase):
                 else:
                     os.environ["CLAUDE_CONFIG_DIR"] = old
 
+    def test_symlinked_out_channel_dir_is_not_deliverable(self):
+        # notify.py's sender REFUSES a channel entry that resolves outside
+        # channels/ (realpath containment); the probe must agree or we recreate
+        # selected-then-send-fails via the symlink mismatch (#2701 review P1).
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg, \
+             tempfile.TemporaryDirectory() as outside:
+            os.makedirs(os.path.join(cfg, "channels"), exist_ok=True)
+            with open(os.path.join(outside, ".env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            os.symlink(outside, os.path.join(cfg, "channels", "sneaky"))
+            p = self._write(td, {"channel": "sneaky", "channel_id": "!r:s"})
+            old = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            try:
+                self.assertEqual(resolve_active_target(p), ("", ""))
+            finally:
+                if old is None:
+                    del os.environ["CLAUDE_CONFIG_DIR"]
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def test_claude_home_tier_is_honored(self):
+        # notify.py resolves CLAUDE_CONFIG_DIR -> CLAUDE_HOME -> ~/.claude; the
+        # probe must walk the SAME tiers (a CLAUDE_HOME-only env previously
+        # made probe and sender disagree — #2701 review P1).
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as home:
+            os.makedirs(os.path.join(home, "channels", "dev-ag2space"))
+            with open(os.path.join(home, "channels", "dev-ag2space", ".env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:d"})
+            old_cfg = os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            old_home = os.environ.get("CLAUDE_HOME")
+            os.environ["CLAUDE_HOME"] = home
+            try:
+                self.assertEqual(resolve_active_target(p), ("dev-ag2space", "!r:d"))
+            finally:
+                if old_cfg is not None:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old_cfg
+                if old_home is None:
+                    del os.environ["CLAUDE_HOME"]
+                else:
+                    os.environ["CLAUDE_HOME"] = old_home
+
     def test_traversal_shaped_source_is_never_probed(self):
         # The slug guard must reject path-shaped sources outright.
         with tempfile.TemporaryDirectory() as td:

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -298,6 +298,44 @@ class TestResolveActiveTarget(unittest.TestCase):
             p = self._write(td, {"channel": "voice", "channel_id": "x"})
             self.assertEqual(resolve_active_target(p), ("", ""))
 
+    def test_configured_channel_dir_makes_new_surface_deliverable(self):
+        # New-homeserver rule: a source outside the static set is deliverable
+        # iff $CLAUDE_CONFIG_DIR/channels/<source>/ holds a *.env (notify.py's
+        # own resolution rule) — adding a homeserver is config-only.
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
+            os.makedirs(os.path.join(cfg, "channels", "dev-ag2space"))
+            with open(os.path.join(cfg, "channels", "dev-ag2space", "relay-client.env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:dev.ag2.space"})
+            old = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            try:
+                self.assertEqual(resolve_active_target(p), ("dev-ag2space", "!r:dev.ag2.space"))
+            finally:
+                if old is None:
+                    del os.environ["CLAUDE_CONFIG_DIR"]
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def test_unconfigured_new_surface_stays_macos_only(self):
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:dev.ag2.space"})
+            old = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            try:
+                self.assertEqual(resolve_active_target(p), ("", ""))
+            finally:
+                if old is None:
+                    del os.environ["CLAUDE_CONFIG_DIR"]
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def test_traversal_shaped_source_is_never_probed(self):
+        # The slug guard must reject path-shaped sources outright.
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, {"channel": "../discord", "channel_id": "x"})
+            self.assertEqual(resolve_active_target(p), ("", ""))
+
     def test_missing_file_is_macos_only(self):
         self.assertEqual(resolve_active_target("/no/such/activity.json"), ("", ""))
 

--- a/tests/gateway-channel-dir.test.py
+++ b/tests/gateway-channel-dir.test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""REMOTE_TASK_CHANNEL_DIR contract: a gateway-bridge instance reads its
+.env fallback and access.json from $CLAUDE_CONFIG_DIR/channels/<CHANNEL_DIR>/,
+default "ag2space". This is what makes a second homeserver instance (e.g.
+"dev-ag2space") unable to inherit prod's credentials or tier map.
+
+Loads the SHIPPED loader (src/remote-gateway-bridge.py → canonical ag2-sparrow
+module) fresh per case, because CHANNEL_DIR is import-time env.
+
+Run: python3 tests/gateway-channel-dir.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py"
+
+
+import contextlib
+
+
+@contextlib.contextmanager
+def _load(env: dict, name: str):
+    """Load the shipped module with `env` applied, keeping it applied for the
+    body (CHANNEL_DIR is import-time, but the access path reads env per call)."""
+    old = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+    try:
+        spec = importlib.util.spec_from_file_location(name, _SRC)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        yield mod
+    finally:
+        for k, v in old.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class TestChannelDir(unittest.TestCase):
+    def test_default_is_ag2space(self):
+        with tempfile.TemporaryDirectory() as cfg, _load(
+            {"CLAUDE_CONFIG_DIR": cfg, "REMOTE_TASK_TOKEN": "https://gw|s"},
+            "rgb_chandir_default",
+        ) as mod:
+            self.assertEqual(mod.CHANNEL_DIR, "ag2space")
+            self.assertEqual(
+                mod._ag2space_access_path(),
+                os.path.join(cfg, "channels", "ag2space", "access.json"),
+            )
+
+    def test_override_moves_both_paths(self):
+        with tempfile.TemporaryDirectory() as cfg:
+            # Lay a token .env ONLY under the override dir; the fallback reader
+            # must find it there (and would not under ag2space/).
+            d = os.path.join(cfg, "channels", "dev-ag2space")
+            os.makedirs(d)
+            with open(os.path.join(d, ".env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=https://dev-gw|devsecret\n")
+            with _load(
+                {
+                    "CLAUDE_CONFIG_DIR": cfg,
+                    "REMOTE_TASK_CHANNEL_DIR": "dev-ag2space",
+                    "REMOTE_TASK_TOKEN": "",
+                    "AG2_DEVICE_ENV": "",
+                },
+                "rgb_chandir_override",
+            ) as mod:
+                self.assertEqual(mod.CHANNEL_DIR, "dev-ag2space")
+                self.assertEqual(
+                    mod._ag2space_access_path(),
+                    os.path.join(cfg, "channels", "dev-ag2space", "access.json"),
+                )
+                raw, _url, _tf = mod._token_from_ag2space_env()
+                self.assertIn("devsecret", raw or "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/startup-gateway-channel-dir.test.sh
+++ b/tests/startup-gateway-channel-dir.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Wiring test for the REAL launcher (#2701 review P1, bassil): the named
+# secondary-gateway loop in src/startup.sh must thread REMOTE_TASK_CHANNEL_DIR
+# per instance, or a dev bridge inherits prod's channels/ag2space/ config.
+# Runs the actual loop body with a stub python that records its environment.
+set -euo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# Stub interpreter: dump the env we care about, exit (no real bridge).
+cat > "$TMP/py-stub" <<'STUB'
+#!/usr/bin/env bash
+env | grep -E '^(REMOTE_TASK_CHANNEL_DIR|GATEWAY_INSTANCE|REMOTE_TASK_TOKEN)=' \
+  >> "$ENV_DUMP"
+STUB
+chmod +x "$TMP/py-stub"
+
+# Extract the named-gateway loop from the real startup.sh (single source: the
+# test fails if the loop moves or the marker comment is renamed).
+LOOP="$(awk '/# Named secondary gateways \(multi-gateway\)/,/^  done$/' "$REPO/src/startup.sh")"
+[ -n "$LOOP" ] || { echo "FAIL: named-gateway loop not found in startup.sh"; exit 1; }
+
+run_loop() {  # $1 = extra env assignments (string), evaluated before the loop
+  ENV_DUMP="$TMP/env-dump"; : > "$ENV_DUMP"; export ENV_DUMP
+  ( eval "$1"
+    PY="$TMP/py-stub"; REPO="$REPO"; LOGS_DIR="$TMP"
+    eval "$LOOP"
+    wait ) >/dev/null 2>&1
+  cat "$ENV_DUMP"
+}
+
+# Case 1: default convention — instance "dev" gets channels/dev-ag2space/.
+OUT="$(run_loop 'export AG2_REMOTE_TOKEN_DEV=tok-dev')"
+echo "$OUT" | grep -q '^REMOTE_TASK_CHANNEL_DIR=dev-ag2space$' \
+  || { echo "FAIL: dev instance did not get REMOTE_TASK_CHANNEL_DIR=dev-ag2space"; echo "$OUT"; exit 1; }
+echo "  ok  dev instance defaults to dev-ag2space"
+
+# Case 2: operator override wins.
+OUT="$(run_loop 'export AG2_REMOTE_TOKEN_DEV=tok-dev REMOTE_TASK_CHANNEL_DIR_DEV=dev.ag2.space')"
+echo "$OUT" | grep -q '^REMOTE_TASK_CHANNEL_DIR=dev.ag2.space$' \
+  || { echo "FAIL: override REMOTE_TASK_CHANNEL_DIR_DEV not honored"; echo "$OUT"; exit 1; }
+echo "  ok  per-instance override honored"
+
+# Case 3: the instance never runs with prod's dir.
+echo "$OUT" | grep -q '^REMOTE_TASK_CHANNEL_DIR=ag2space$' \
+  && { echo "FAIL: instance leaked prod channel dir"; exit 1; }
+echo "  ok  prod channel dir never inherited"
+echo "PASS — launcher threads REMOTE_TASK_CHANNEL_DIR per instance"


### PR DESCRIPTION
Owner ask (2026-08-06): connect to the dev homeserver (dev.ag2.space) via its own `channels/dev-ag2space/` — and more broadly, make adding ANY future homeserver easy.

## Before (on main)
- `packages/ag2-sparrow/.../remote_gateway_bridge.py` hardcodes `channels/ag2space/` for the .env fallback (line ~389) and `access.json` (~line 600): a second bridge instance would read **prod's credentials and tier map** — the same single-homed failure class as the 2026-08-04 dev-homed bridge regression.
- `src/core-supervisor-relay.py` has a static `_DELIVERABLE_SURFACES` set: a new source is unroutable until someone edits code.

## After
- `REMOTE_TASK_CHANNEL_DIR` (default `ag2space`, env-only by necessity — a .env can't name its own directory) selects the instance's config dir for both paths. Also works if the naming later moves to literal domains (`dev.ag2.space`) — the value is just a directory name.
- Deliverable surfaces = static set ∪ {slug-valid source with a `channels/<source>/*.env`} — mirroring notify.py's own resolution rule, with notify.py's slug guard so a malformed activity file can't steer the existence probe. Adding homeserver N+1 = create its config dir + launch a bridge instance with two env vars. No code change.

## Evidence
- New `tests/gateway-channel-dir.test.py` (2/2): default stays `ag2space`; override moves BOTH paths and the token fallback actually reads from the override dir (exercises the shipped loader, not a copy).
- `tests/core-supervisor-relay.test.py`: 35/35 including new configured-dir-routable, unconfigured-stays-macos-only, and traversal-shaped-source-rejected cases.
- `python3 src/remote-gateway-bridge.test.py` → PASS (no regression in the existing env-permutation harness).

Back-compat: with the env unset, every path is byte-identical to today. ag2-sparrow PyPI release + pin bump can follow once this lands; the sutando checkout runs the vendored module directly meanwhile.

Live-path note: the dev bridge instance itself can't round-trip until the owner connects the dev homeserver (creds don't exist yet) — that first connect is the natural live E2E and I'll run it with her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)