### PR TITLE
feat(gateway): vault-set intercept — store via pluggable sink, never persist plaintext

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/chat_secret_filter.py
+++ b/packages/ag2-sparrow/ag2_sparrow/chat_secret_filter.py
@@ -49,6 +49,41 @@ _FALLBACK_PATTERNS: Tuple[Tuple[str, re.Pattern], ...] = (
         r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----"
     )),
 )
+# The explicit vault-set command shape. The WHOLE body must be the command —
+# a command quoted inside prose is not an intent to store (and redacting it is
+# the generic filter's job when the value matches a known pattern). KEY is
+# env-var-shaped; VALUE is any non-whitespace run (client secrets and the like
+# have no reliable shape — see the 2026-08-06 MS365 secret, which matched no
+# fallback pattern and reached disk).
+VAULT_SET_RE = re.compile(
+    r"^\s*vault\s+set\s+([A-Za-z_][A-Za-z0-9_]*)\s+(\S+)\s*$"
+)
+
+
+def extract_vault_set(text: str) -> "tuple[str, str] | None":
+    """Return (key, value) when the entire body is a `vault set KEY VALUE`
+    command, else None."""
+    m = VAULT_SET_RE.match(text or "")
+    return (m.group(1), m.group(2)) if m else None
+
+
+def vault_set_replacement(key: str, *, stored: bool, owner: bool) -> str:
+    """The persisted body replacing an intercepted vault-set command. Never
+    contains the value; tells the core exactly what happened so its reply to
+    the sender is truthful without re-requesting the secret."""
+    if stored:
+        return (f"vault set {key} [REDACTED — value stored to the vault by the "
+                "bridge; plaintext never persisted]. Confirm storage to the "
+                "sender briefly.")
+    if not owner:
+        return (f"vault set {key} [REDACTED — NOT stored: sender is not "
+                "owner-tier; only the owner may write vault keys]. Tell the "
+                "sender their request was declined.")
+    return (f"vault set {key} [REDACTED — NOT stored: this bridge has no vault "
+            "sink configured]. Ask the owner to store the key via a "
+            "vault-capable channel (Slack/Discord) or on the host directly.")
+
+
 _ENTROPY_TYPES = {"Base64 High Entropy String", "Hex High Entropy String"}
 _TOKENISH_RUN = re.compile(r"[A-Za-z0-9_+/=-]{20,}")
 

--- a/packages/ag2-sparrow/ag2_sparrow/chat_secret_filter.py
+++ b/packages/ag2-sparrow/ag2_sparrow/chat_secret_filter.py
@@ -80,6 +80,47 @@ def extract_vault_set(text: str) -> "tuple[str, str] | None":
     return (m.group(1), value) if value else None
 
 
+# Embedded (mid-prose) vault-set candidates. The whole-body form above is a
+# STORE intent; a candidate inside prose is not — but review P1 2026-08-06
+# proved it still leaks: `please store this: vault set K "secret" for later`
+# persisted the plaintext because only the generic pattern filter saw it. The
+# shipped Slack/Discord parser (vault_intercept._VAULT_SET_RE) intentionally
+# finds candidates ANYWHERE and fail-closes on them; this ports that pattern
+# and its #2074 false-positive guard (prose = key fullmatches [a-z]+ AND the
+# value is not secret-shaped; anything else is deliberate → redact). Embedded
+# candidates are REDACTED, never stored — quoting a command is not an intent
+# to store, but the value must not persist either way.
+EMBEDDED_VAULT_SET_RE = re.compile(
+    r"\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)"
+    r"(?:\"([^\"]*)\"|'([^']*)'|`([^`]*)`|(\S+))",
+    re.IGNORECASE,
+)
+_PLAIN_LOWER_WORD = re.compile(r"[a-z]+")
+
+
+def scrub_embedded_vault_sets(text: str) -> "tuple[str, tuple[str, ...]]":
+    """Redact vault-set candidates embedded in prose (fail-closed, no store).
+    Returns (scrubbed_text, keys). Mirrors vault_intercept's FP guard: a
+    candidate is left alone ONLY when the key is a single plain lowercase
+    word AND the value is not secret-shaped — ordinary sentences pass
+    through; deliberately-named keys are always scrubbed."""
+    keys: list = []
+
+    def _sub(m: "re.Match") -> str:
+        key = m.group(1)
+        value = next((g for g in m.groups()[1:] if g is not None), "")
+        prose_key = _PLAIN_LOWER_WORD.fullmatch(key) is not None
+        secret_shaped = bool(_TOKENISH_RUN.fullmatch(value)) or any(
+            p.fullmatch(value) for _, p in _FALLBACK_PATTERNS)
+        if prose_key and not secret_shaped:
+            return m.group(0)
+        keys.append(key)
+        return (f"vault set {key} [REDACTED — embedded in prose; NOT stored. "
+                "Send `vault set` as its own message to store]")
+
+    return EMBEDDED_VAULT_SET_RE.sub(_sub, text or ""), tuple(keys)
+
+
 def vault_set_replacement(key: str, *, stored: bool, owner: bool) -> str:
     """The persisted body replacing an intercepted vault-set command. Never
     contains the value; tells the core exactly what happened so its reply to

--- a/packages/ag2-sparrow/ag2_sparrow/chat_secret_filter.py
+++ b/packages/ag2-sparrow/ag2_sparrow/chat_secret_filter.py
@@ -51,20 +51,33 @@ _FALLBACK_PATTERNS: Tuple[Tuple[str, re.Pattern], ...] = (
 )
 # The explicit vault-set command shape. The WHOLE body must be the command —
 # a command quoted inside prose is not an intent to store (and redacting it is
-# the generic filter's job when the value matches a known pattern). KEY is
-# env-var-shaped; VALUE is any non-whitespace run (client secrets and the like
-# have no reliable shape — see the 2026-08-06 MS365 secret, which matched no
-# fallback pattern and reached disk).
+# the generic filter's job when the value matches a known pattern). VALUE
+# shapes and the key/value separator MIRROR the shipped vault parser
+# (`_VAULT_SET_RE` in src/vault_intercept.py): double/single/backtick-quoted
+# strings (spaces allowed, quotes stripped), bare non-space token, and both
+# `KEY VALUE` and `KEY=VALUE` / `KEY = VALUE` separators. Review P1
+# 2026-08-06: matching only `KEY <bare-token>` left the other documented
+# forms — exactly the ones owners use for secrets with punctuation or
+# spaces — persisting in plaintext with no sink call. KEY is `[^\s=]+` like
+# the shipped parser; the whole-body anchor is what keeps prose out, so the
+# looser key shape adds no FP surface.
 VAULT_SET_RE = re.compile(
-    r"^\s*vault\s+set\s+([A-Za-z_][A-Za-z0-9_]*)\s+(\S+)\s*$"
+    r"^\s*vault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)"
+    r"(?:\"([^\"]*)\"|'([^']*)'|`([^`]*)`|(\S+))\s*$",
+    re.IGNORECASE,
 )
 
 
 def extract_vault_set(text: str) -> "tuple[str, str] | None":
     """Return (key, value) when the entire body is a `vault set KEY VALUE`
-    command, else None."""
+    command (any supported value shape), else None. Quotes are stripped —
+    the stored value is the content, matching vault_intercept semantics. An
+    empty value (`vault set K ""`) returns None: nothing to store."""
     m = VAULT_SET_RE.match(text or "")
-    return (m.group(1), m.group(2)) if m else None
+    if not m:
+        return None
+    value = next((g for g in m.groups()[1:] if g is not None), "")
+    return (m.group(1), value) if value else None
 
 
 def vault_set_replacement(key: str, *, stored: bool, owner: bool) -> str:

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1389,7 +1389,8 @@ def _fleet_agent_ids() -> set[str]:
     return _fleet_agents_cache["ids"]
 
 
-def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
+def _write_owner_activity(task: dict, sender_tier: str | None = None,
+                          redacted_body: str | None = None) -> None:
     """Record that the owner was active on this transport right now — but only
     when THIS node resolves the SENDER to owner tier. Gated on the sender's
     resolved tier, NOT the gateway-wide LOCAL_TIER: in a shared room a
@@ -1428,13 +1429,27 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
         return
     try:
         OWNER_ACTIVITY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        # The summary derives from the ALREADY-REDACTED body when the caller
+        # (`_write_task`) provides it — a single redaction pipeline, so this
+        # sink can never diverge from the task file (review P1 2026-08-06: it
+        # re-derived from the raw task dict, so an intercepted `vault set`
+        # value that never reached tasks/ still landed here in plaintext).
+        body = (redacted_body if redacted_body is not None
+                else (task.get("task") or "")).lstrip()
         # Strip a bracket prefix a gateway may add (e.g. "[Provider @user] body").
-        body = (task.get("task") or "").lstrip()
         if body.startswith("[") and "]" in body:
             body = body[body.index("]") + 1:].lstrip()
-        # #2267 parity: the presence summary is persisted state too — a pasted
-        # token must not survive in last-owner-activity.json either.
-        body = filter_chat_secrets(body).text
+        if redacted_body is None:
+            # Direct-caller fallback: run the SAME two-stage redaction the task
+            # writer uses. The vault-set replacement here is the summary-safe
+            # short form — storage state is unknown (and irrelevant) in a
+            # presence summary; what matters is the value never lands.
+            _kv = extract_vault_set(body)
+            if _kv:
+                body = f"vault set {_kv[0]} [REDACTED]"
+            # #2267 parity: the presence summary is persisted state too — a
+            # pasted token must not survive in last-owner-activity.json either.
+            body = filter_chat_secrets(body).text
         payload = {
             "ts": int(time.time()),
             "channel": task.get("source") or PROVIDER,
@@ -1511,6 +1526,7 @@ def _write_task(task: dict) -> str | None:
     sender_tier = _tier_for(task.get("user_id"))
     lines = []
     _secret_types: tuple = ()
+    _task_body_redacted: "str | None" = None  # threaded to _write_owner_activity
     for f in _TASK_FIELDS:
         if f == "source":
             lines.append(f"source: {_one_line(task.get('source') or PROVIDER)}")
@@ -1562,6 +1578,7 @@ def _write_task(task: dict) -> str | None:
                 _secret_types = tuple(_filtered.secret_types)
                 _log(f"redacted pasted secret(s) in {tid} body: "
                      f"{', '.join(sorted(_secret_types))}")
+            _task_body_redacted = _filtered.text
             lines.append(f"task: {_one_line(_filtered.text)}")
             # interaction-model 4D, step 1.5: if a media marker was fetched,
             # stamp structured attachments[]/content_modalities/media_form
@@ -1614,7 +1631,7 @@ def _write_task(task: dict) -> str | None:
     _record_task_room(tid, str(task.get("channel_id") or ""))
     # Bridges-as-siblings: feed the proactive-loop's active-engagement gate — but
     # only for owner-tier senders (same resolved tier as the task above).
-    _write_owner_activity(task, sender_tier)
+    _write_owner_activity(task, sender_tier, redacted_body=_task_body_redacted)
     return tid
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -181,7 +181,9 @@ socket.getaddrinfo = _getaddrinfo_prefer_v4
 # the path (no repo-walking; the old triple-parent form predated the move into
 # src/ and pointed outside the repo).
 from ._dirs import task_dir as _task_dir, result_dir as _result_dir, state_dir as _state_dir
-from .chat_secret_filter import filter_chat_secrets, secret_handling_instruction
+from .chat_secret_filter import (extract_vault_set, filter_chat_secrets,
+                                 secret_handling_instruction,
+                                 vault_set_replacement)
 from .task_archive import find_task_file
 from . import local_task_protocol
 from .result_markers import parse_markers
@@ -513,6 +515,13 @@ _URL_FROM_TOKEN, TOKEN = _parse_onboarding_token(_RAW)
 URL = (_env_compat("REMOTE_TASK_URL", "AG2_REMOTE_URL")
        or _URL_FROM_TOKEN or _URL_FALLBACK).rstrip("/")
 PROVIDER = os.environ.get("REMOTE_TASK_PROVIDER") or "remote"
+
+# Optional secret sink for intercepted `vault set KEY VALUE` bodies. The
+# transport is provider-neutral, so it does NOT assume a keychain: a launcher
+# (e.g. sutando's loader) assigns a callable (key, value) -> bool. With no
+# sink, the command body is still redacted before persistence — the value
+# never reaches disk either way; only storage is skipped.
+VAULT_SINK = None
 POLL_WAIT = int(os.environ.get("REMOTE_TASK_POLL_WAIT") or "25")
 # The ONE auth-header dict shared with long-lived consumers (event channel,
 # card poster). They must hold this dict BY REFERENCE (no copy) so a token
@@ -1496,6 +1505,10 @@ def _write_task(task: dict) -> str | None:
         _log(f"dedup: {tid} already handled — not re-queued")
         return tid
     TASKS_DIR.mkdir(parents=True, exist_ok=True)
+    # Resolved ONCE, before the field loop: the vault-set intercept inside the
+    # task branch needs the tier, and the access_tier header + owner-activity
+    # gate below reuse the same resolution (single source of truth preserved).
+    sender_tier = _tier_for(task.get("user_id"))
     lines = []
     _secret_types: tuple = ()
     for f in _TASK_FIELDS:
@@ -1526,6 +1539,24 @@ def _write_task(task: dict) -> str | None:
             # room message must never land on disk. Runs AFTER media
             # resolution so a signed media-proxy URL is consumed intact and
             # only the resolved text is filtered.
+            # Explicit `vault set KEY VALUE` bodies are INTERCEPTED, not just
+            # redacted (owner gap-report 2026-08-06: the MS365 client secret
+            # matched no fallback pattern and persisted in plaintext). Owner-
+            # tier only — a non-owner sender must not be able to write into
+            # the owner's vault — and only when the launcher wired a sink.
+            _vault_kv = extract_vault_set(_fetched)
+            if _vault_kv:
+                _vk, _vv = _vault_kv
+                _stored = False
+                if sender_tier == "owner" and VAULT_SINK is not None:
+                    try:
+                        _stored = bool(VAULT_SINK(_vk, _vv))
+                    except Exception as _e:  # sink failure must not lose the task
+                        _log(f"vault sink error for {tid}: {type(_e).__name__}")
+                _fetched = vault_set_replacement(
+                    _vk, stored=_stored, owner=(sender_tier == "owner"))
+                _log(f"vault-set intercepted in {tid}: key={_vk} "
+                     f"stored={_stored} tier={sender_tier}")
             _filtered = filter_chat_secrets(_fetched)
             if _filtered.secret_types:
                 _secret_types = tuple(_filtered.secret_types)
@@ -1567,8 +1598,8 @@ def _write_task(task: dict) -> str | None:
     # Resolve ONCE and reuse for both the task tier AND the owner-activity gate
     # below, so the two decisions can never diverge (a single source of truth,
     # no double read of the tierMap).
-    # user_id is broker-attested here — see the CONTRACT note in _tier_for.
-    sender_tier = _tier_for(task.get("user_id"))
+    # user_id is broker-attested here — see the CONTRACT note in _tier_for
+    # (sender_tier resolved once, above the field loop).
     lines.append(f"access_tier: {sender_tier}")
     # #2267 parity, second half: the other bridges append the in-band security
     # notice so the core neither reproduces nor re-requests the redacted value.

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -182,6 +182,7 @@ socket.getaddrinfo = _getaddrinfo_prefer_v4
 # src/ and pointed outside the repo).
 from ._dirs import task_dir as _task_dir, result_dir as _result_dir, state_dir as _state_dir
 from .chat_secret_filter import (extract_vault_set, filter_chat_secrets,
+                                 scrub_embedded_vault_sets,
                                  secret_handling_instruction,
                                  vault_set_replacement)
 from .task_archive import find_task_file
@@ -1447,6 +1448,8 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None,
             _kv = extract_vault_set(body)
             if _kv:
                 body = f"vault set {_kv[0]} [REDACTED]"
+            else:
+                body, _ = scrub_embedded_vault_sets(body)
             # #2267 parity: the presence summary is persisted state too — a
             # pasted token must not survive in last-owner-activity.json either.
             body = filter_chat_secrets(body).text
@@ -1573,6 +1576,16 @@ def _write_task(task: dict) -> str | None:
                     _vk, stored=_stored, owner=(sender_tier == "owner"))
                 _log(f"vault-set intercepted in {tid}: key={_vk} "
                      f"stored={_stored} tier={sender_tier}")
+            else:
+                # Embedded (mid-prose) candidates: never stored, but the value
+                # must not persist either (review P1 2026-08-06 — the generic
+                # filter alone missed a quoted mid-prose secret). Runs only
+                # when the whole-body branch didn't, so a real store intent is
+                # never double-processed.
+                _fetched, _embedded_keys = scrub_embedded_vault_sets(_fetched)
+                if _embedded_keys:
+                    _log(f"embedded vault-set candidate(s) scrubbed in {tid}: "
+                         f"{', '.join(_embedded_keys)}")
             _filtered = filter_chat_secrets(_fetched)
             if _filtered.secret_types:
                 _secret_types = tuple(_filtered.secret_types)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -34,6 +34,13 @@ Config (env / .env):
   REMOTE_TASK_URL        gateway base URL (only needed with a bare secret)
   REMOTE_TASK_URL/_TOKEN  legacy aliases
   REMOTE_TASK_PROVIDER  label used for the task `source:` field (default "remote")
+  REMOTE_TASK_CHANNEL_DIR  name of this instance's config dir under
+                        $CLAUDE_CONFIG_DIR/channels/ (default "ag2space") —
+                        selects which .env fallback and access.json a bridge
+                        instance reads, so a second instance (e.g. a dev
+                        homeserver's "dev-ag2space") cannot inherit prod's
+                        credentials or tier map. Env-only by necessity: the
+                        .env file cannot name its own directory.
   REMOTE_TASK_POLL_WAIT long-poll seconds (default 25)
 
 Stdlib only (urllib) — no new dependencies.
@@ -353,6 +360,12 @@ def _parse_onboarding_token(raw):
     return raw[:m.start()], raw[m.end():]  # URL + secret, both verbatim
 
 
+# Which channels/<dir>/ this instance reads (.env fallback + access.json).
+# Env-only — the .env file can't name its own directory. Default preserves the
+# historical single-instance layout.
+CHANNEL_DIR = os.environ.get("REMOTE_TASK_CHANNEL_DIR") or "ag2space"
+
+
 def _token_from_ag2space_env():
     """Fallback token source when the launcher didn't export it into the env.
 
@@ -386,7 +399,7 @@ def _token_from_ag2space_env():
     candidates = [os.environ.get("AG2_DEVICE_ENV")]
     _cfg = os.environ.get("CLAUDE_CONFIG_DIR")
     if _cfg:
-        candidates.append(os.path.join(_cfg, "channels", "ag2space", ".env"))
+        candidates.append(os.path.join(_cfg, "channels", CHANNEL_DIR, ".env"))
     for path in candidates:
         if not path:
             continue
@@ -597,7 +610,7 @@ if LOCAL_TIER not in ("owner", "team", "other"):
 # revoke them without a restart.
 def _ag2space_access_path():
     base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
-    return os.path.join(base, "channels", "ag2space", "access.json")
+    return os.path.join(base, "channels", CHANNEL_DIR, "access.json")
 
 
 # Known tier vocabulary. Also an ordering (higher == more privileged); kept for

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -217,8 +217,12 @@ def send_telegram(chat_id: str, message: str) -> bool:
 # Gateway provider names come from task files, i.e. from OUTSIDE the trust
 # boundary — a `source` like `../evil` must never become a path segment
 # (traversal reads an arbitrary .env-shaped file and posts its bearer to the
-# URL named in that same file). Safe slug only.
-_SOURCE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+# URL named in that same file). Safe slug only. Dots are allowed so channel
+# lanes can be named by homeserver domain (owner convention 2026-08-06:
+# `ag2.space`, `dev.ag2.space`), but every dot must sit BETWEEN alphanumerics
+# — no leading/trailing dot, no "..", so every traversal shape is rejected
+# before the realpath containment check below even runs.
+_SOURCE_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]|\.(?=[a-z0-9]))*$")
 
 
 def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
@@ -226,7 +230,8 @@ def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
     channels/<source>/.env carrying REMOTE_TASK_URL + REMOTE_TASK_TOKEN)."""
     if not _SOURCE_SLUG_RE.match(source or ""):
         print(f"[task-progress] invalid gateway source {source!r} — "
-              "provider names must match ^[a-z0-9][a-z0-9_-]*$", file=sys.stderr)
+              "provider names are lowercase slugs; dots allowed only between "
+              "alphanumerics (e.g. dev.ag2.space)", file=sys.stderr)
         return False
     # Mirrors util_paths.claude_home_path ($CLAUDE_CONFIG_DIR -> $CLAUDE_HOME -> ~/.claude).
     _base = os.environ.get("CLAUDE_CONFIG_DIR") or os.environ.get("CLAUDE_HOME")

--- a/src/chat_secret_filter.py
+++ b/src/chat_secret_filter.py
@@ -49,6 +49,41 @@ _FALLBACK_PATTERNS: Tuple[Tuple[str, re.Pattern], ...] = (
         r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----"
     )),
 )
+# The explicit vault-set command shape. The WHOLE body must be the command —
+# a command quoted inside prose is not an intent to store (and redacting it is
+# the generic filter's job when the value matches a known pattern). KEY is
+# env-var-shaped; VALUE is any non-whitespace run (client secrets and the like
+# have no reliable shape — see the 2026-08-06 MS365 secret, which matched no
+# fallback pattern and reached disk).
+VAULT_SET_RE = re.compile(
+    r"^\s*vault\s+set\s+([A-Za-z_][A-Za-z0-9_]*)\s+(\S+)\s*$"
+)
+
+
+def extract_vault_set(text: str) -> "tuple[str, str] | None":
+    """Return (key, value) when the entire body is a `vault set KEY VALUE`
+    command, else None."""
+    m = VAULT_SET_RE.match(text or "")
+    return (m.group(1), m.group(2)) if m else None
+
+
+def vault_set_replacement(key: str, *, stored: bool, owner: bool) -> str:
+    """The persisted body replacing an intercepted vault-set command. Never
+    contains the value; tells the core exactly what happened so its reply to
+    the sender is truthful without re-requesting the secret."""
+    if stored:
+        return (f"vault set {key} [REDACTED — value stored to the vault by the "
+                "bridge; plaintext never persisted]. Confirm storage to the "
+                "sender briefly.")
+    if not owner:
+        return (f"vault set {key} [REDACTED — NOT stored: sender is not "
+                "owner-tier; only the owner may write vault keys]. Tell the "
+                "sender their request was declined.")
+    return (f"vault set {key} [REDACTED — NOT stored: this bridge has no vault "
+            "sink configured]. Ask the owner to store the key via a "
+            "vault-capable channel (Slack/Discord) or on the host directly.")
+
+
 _ENTROPY_TYPES = {"Base64 High Entropy String", "Hex High Entropy String"}
 _TOKENISH_RUN = re.compile(r"[A-Za-z0-9_+/=-]{20,}")
 

--- a/src/chat_secret_filter.py
+++ b/src/chat_secret_filter.py
@@ -80,6 +80,47 @@ def extract_vault_set(text: str) -> "tuple[str, str] | None":
     return (m.group(1), value) if value else None
 
 
+# Embedded (mid-prose) vault-set candidates. The whole-body form above is a
+# STORE intent; a candidate inside prose is not — but review P1 2026-08-06
+# proved it still leaks: `please store this: vault set K "secret" for later`
+# persisted the plaintext because only the generic pattern filter saw it. The
+# shipped Slack/Discord parser (vault_intercept._VAULT_SET_RE) intentionally
+# finds candidates ANYWHERE and fail-closes on them; this ports that pattern
+# and its #2074 false-positive guard (prose = key fullmatches [a-z]+ AND the
+# value is not secret-shaped; anything else is deliberate → redact). Embedded
+# candidates are REDACTED, never stored — quoting a command is not an intent
+# to store, but the value must not persist either way.
+EMBEDDED_VAULT_SET_RE = re.compile(
+    r"\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)"
+    r"(?:\"([^\"]*)\"|'([^']*)'|`([^`]*)`|(\S+))",
+    re.IGNORECASE,
+)
+_PLAIN_LOWER_WORD = re.compile(r"[a-z]+")
+
+
+def scrub_embedded_vault_sets(text: str) -> "tuple[str, tuple[str, ...]]":
+    """Redact vault-set candidates embedded in prose (fail-closed, no store).
+    Returns (scrubbed_text, keys). Mirrors vault_intercept's FP guard: a
+    candidate is left alone ONLY when the key is a single plain lowercase
+    word AND the value is not secret-shaped — ordinary sentences pass
+    through; deliberately-named keys are always scrubbed."""
+    keys: list = []
+
+    def _sub(m: "re.Match") -> str:
+        key = m.group(1)
+        value = next((g for g in m.groups()[1:] if g is not None), "")
+        prose_key = _PLAIN_LOWER_WORD.fullmatch(key) is not None
+        secret_shaped = bool(_TOKENISH_RUN.fullmatch(value)) or any(
+            p.fullmatch(value) for _, p in _FALLBACK_PATTERNS)
+        if prose_key and not secret_shaped:
+            return m.group(0)
+        keys.append(key)
+        return (f"vault set {key} [REDACTED — embedded in prose; NOT stored. "
+                "Send `vault set` as its own message to store]")
+
+    return EMBEDDED_VAULT_SET_RE.sub(_sub, text or ""), tuple(keys)
+
+
 def vault_set_replacement(key: str, *, stored: bool, owner: bool) -> str:
     """The persisted body replacing an intercepted vault-set command. Never
     contains the value; tells the core exactly what happened so its reply to

--- a/src/chat_secret_filter.py
+++ b/src/chat_secret_filter.py
@@ -51,20 +51,33 @@ _FALLBACK_PATTERNS: Tuple[Tuple[str, re.Pattern], ...] = (
 )
 # The explicit vault-set command shape. The WHOLE body must be the command —
 # a command quoted inside prose is not an intent to store (and redacting it is
-# the generic filter's job when the value matches a known pattern). KEY is
-# env-var-shaped; VALUE is any non-whitespace run (client secrets and the like
-# have no reliable shape — see the 2026-08-06 MS365 secret, which matched no
-# fallback pattern and reached disk).
+# the generic filter's job when the value matches a known pattern). VALUE
+# shapes and the key/value separator MIRROR the shipped vault parser
+# (`_VAULT_SET_RE` in src/vault_intercept.py): double/single/backtick-quoted
+# strings (spaces allowed, quotes stripped), bare non-space token, and both
+# `KEY VALUE` and `KEY=VALUE` / `KEY = VALUE` separators. Review P1
+# 2026-08-06: matching only `KEY <bare-token>` left the other documented
+# forms — exactly the ones owners use for secrets with punctuation or
+# spaces — persisting in plaintext with no sink call. KEY is `[^\s=]+` like
+# the shipped parser; the whole-body anchor is what keeps prose out, so the
+# looser key shape adds no FP surface.
 VAULT_SET_RE = re.compile(
-    r"^\s*vault\s+set\s+([A-Za-z_][A-Za-z0-9_]*)\s+(\S+)\s*$"
+    r"^\s*vault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)"
+    r"(?:\"([^\"]*)\"|'([^']*)'|`([^`]*)`|(\S+))\s*$",
+    re.IGNORECASE,
 )
 
 
 def extract_vault_set(text: str) -> "tuple[str, str] | None":
     """Return (key, value) when the entire body is a `vault set KEY VALUE`
-    command, else None."""
+    command (any supported value shape), else None. Quotes are stripped —
+    the stored value is the content, matching vault_intercept semantics. An
+    empty value (`vault set K ""`) returns None: nothing to store."""
     m = VAULT_SET_RE.match(text or "")
-    return (m.group(1), m.group(2)) if m else None
+    if not m:
+        return None
+    value = next((g for g in m.groups()[1:] if g is not None), "")
+    return (m.group(1), value) if value else None
 
 
 def vault_set_replacement(key: str, *, stored: bool, owner: bool) -> str:

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -42,6 +42,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import subprocess
 import sys
 
@@ -189,7 +190,27 @@ def run_cycle(signal, state_file, *, macos=True, source="", channel="", dry_run=
 # Surfaces task-progress notify.py can actually DELIVER to. Other values that
 # land in last-owner-activity.json ("voice", "github-commits", …) are activity
 # signals, not deliverable channels — never route an escalation to them.
+# Beyond the static set, any source with a configured channel dir
+# ($CLAUDE_CONFIG_DIR/channels/<source>/ containing a *.env) counts — that
+# mirrors notify.py's own resolution rule, so a NEW homeserver bridge (e.g.
+# "dev-ag2space") becomes routable by creating its config dir, no code change.
 _DELIVERABLE_SURFACES = {"discord", "slack", "telegram", "ag2space"}
+
+# Same slug shape notify.py enforces — keeps a malformed/hostile activity file
+# from steering the existence probe at an arbitrary path.
+_SOURCE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+def _is_deliverable(source):
+    if source in _DELIVERABLE_SURFACES:
+        return True
+    if not source or not _SOURCE_SLUG_RE.match(source):
+        return False
+    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
+    try:
+        return any(n.endswith(".env") for n in os.listdir(os.path.join(base, "channels", source)))
+    except OSError:
+        return False
 
 
 def resolve_active_target(activity_path):
@@ -210,7 +231,7 @@ def resolve_active_target(activity_path):
         return "", ""
     source = str(data.get("channel", "")).strip()
     channel = str(data.get("channel_id", "")).strip()
-    if source in _DELIVERABLE_SURFACES and channel:
+    if _is_deliverable(source) and channel:
         return source, channel
     return "", ""
 

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -207,10 +207,12 @@ def _is_deliverable(source):
     if not source or not _SOURCE_SLUG_RE.match(source):
         return False
     base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
-    try:
-        return any(n.endswith(".env") for n in os.listdir(os.path.join(base, "channels", source)))
-    except OSError:
-        return False
+    # Probe for exactly what notify.py's sender reads — channels/<source>/.env.
+    # A broader *.env glob would mark lanes deliverable that the sender then
+    # fails on (exit 1), losing the escalation AND blocking the debounce latch
+    # (review P1 on #2701). If notify.py ever learns more filenames (#2686's
+    # try-both), widen BOTH sides together.
+    return os.path.isfile(os.path.join(base, "channels", source, ".env"))
 
 
 def resolve_active_target(activity_path):

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -197,8 +197,10 @@ def run_cycle(signal, state_file, *, macos=True, source="", channel="", dry_run=
 _DELIVERABLE_SURFACES = {"discord", "slack", "telegram", "ag2space"}
 
 # Same slug shape notify.py enforces — keeps a malformed/hostile activity file
-# from steering the existence probe at an arbitrary path.
-_SOURCE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+# from steering the existence probe at an arbitrary path. Dots allowed only
+# BETWEEN alphanumerics (domain-named lanes like dev.ag2.space); "..", leading
+# and trailing dots are all rejected. Keep in lockstep with notify.py's rule.
+_SOURCE_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]|\.(?=[a-z0-9]))*$")
 
 
 def _is_deliverable(source):

--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -78,3 +78,19 @@ for _root in (
 _IMPL = _REPO / "packages" / "ag2-sparrow" / "ag2_sparrow" / "remote_gateway_bridge.py"
 __package__ = "ag2_sparrow"  # PEP 328: makes the source's relative imports resolve
 exec(compile(_IMPL.read_text(encoding="utf-8"), str(_IMPL), "exec"), globals())
+
+# Sutando wiring: intercepted `vault set KEY VALUE` bodies store to the macOS
+# Keychain vault (skills/secret-vault) instead of persisting plaintext — the
+# same guarantee the Slack/Discord bridges give (owner gap-report 2026-08-06).
+# Assigned AFTER the exec so the canonical module's default (None) is replaced
+# in the very namespace the running code reads.
+def _keychain_vault_sink(key: str, value: str) -> bool:
+    import subprocess as _sp
+    _p = _sp.run(
+        [sys.executable, str(_REPO / "skills" / "secret-vault" / "secret-vault.py"),
+         "set", key],
+        input=value.encode(), capture_output=True, timeout=15)
+    return _p.returncode == 0
+
+
+VAULT_SINK = _keychain_vault_sink

--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -69,21 +69,9 @@ for _root in (
     if str(_root) not in _send_allowlist._EXTRA_ROOTS:
         _send_allowlist.register_extra_roots(_root)
 
-# Run the canonical client source in-place. exec (not import) is deliberate:
-# module-level config (tier fail-closed parsing, URL/TOKEN, dirs) must
-# re-evaluate on EVERY load of this file — the mock-gateway test harness loads
-# it repeatedly under different env — and attribute reads/writes
-# (``rtc._ack_disabled_until = 0.0``) must hit the same namespace the running code
-# uses. A cached ``import ag2_sparrow.remote_gateway_bridge`` gives neither.
-_IMPL = _REPO / "packages" / "ag2-sparrow" / "ag2_sparrow" / "remote_gateway_bridge.py"
-__package__ = "ag2_sparrow"  # PEP 328: makes the source's relative imports resolve
-exec(compile(_IMPL.read_text(encoding="utf-8"), str(_IMPL), "exec"), globals())
-
 # Sutando wiring: intercepted `vault set KEY VALUE` bodies store to the macOS
 # Keychain vault (skills/secret-vault) instead of persisting plaintext — the
 # same guarantee the Slack/Discord bridges give (owner gap-report 2026-08-06).
-# Assigned AFTER the exec so the canonical module's default (None) is replaced
-# in the very namespace the running code reads.
 def _keychain_vault_sink(key: str, value: str) -> bool:
     import subprocess as _sp
     _p = _sp.run(
@@ -93,4 +81,35 @@ def _keychain_vault_sink(key: str, value: str) -> bool:
     return _p.returncode == 0
 
 
+# Run the canonical client source in-place. exec (not import) is deliberate:
+# module-level config (tier fail-closed parsing, URL/TOKEN, dirs) must
+# re-evaluate on EVERY load of this file — the mock-gateway test harness loads
+# it repeatedly under different env — and attribute reads/writes
+# (``rtc._ack_disabled_until = 0.0``) must hit the same namespace the running code
+# uses. A cached ``import ag2_sparrow.remote_gateway_bridge`` gives neither.
+#
+# The canonical source ends with `if __name__ == "__main__": main()`. In
+# SCRIPT MODE (`python3 src/remote-gateway-bridge.py`) this loader's __name__
+# IS "__main__", so an unmasked exec would fire the canonical main() DURING
+# the exec — the poll loop starts and the VAULT_SINK assignment below never
+# runs, leaving the live script path sink-less (review P1 2026-08-06:
+# LIVE_MAIN_ENTRY_VAULT_SINK=None). So mask __name__ across the exec, wire
+# the sink into the SAME namespace the running code reads, THEN run main()
+# ourselves if we are the entrypoint. Import-mode callers (__name__ != main)
+# are unaffected: masking is a no-op and main() is not auto-run either way.
+_IMPL = _REPO / "packages" / "ag2-sparrow" / "ag2_sparrow" / "remote_gateway_bridge.py"
+__package__ = "ag2_sparrow"  # PEP 328: makes the source's relative imports resolve
+_entrypoint = (__name__ == "__main__")
+_real_name = __name__
+__name__ = "_ag2_sparrow_bridge_impl"  # neutralize the canonical main-guard
+try:
+    exec(compile(_IMPL.read_text(encoding="utf-8"), str(_IMPL), "exec"), globals())
+finally:
+    __name__ = _real_name
+
+# Assigned AFTER the exec (which sets the canonical default None) but BEFORE
+# main() runs, so the running code reads the real sink.
 VAULT_SINK = _keychain_vault_sink
+
+if _entrypoint:
+    main()  # noqa: F821 — defined by the exec'd canonical source above

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -304,13 +304,32 @@ class TestResolveActiveTarget(unittest.TestCase):
         # own resolution rule) — adding a homeserver is config-only.
         with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
             os.makedirs(os.path.join(cfg, "channels", "dev-ag2space"))
-            with open(os.path.join(cfg, "channels", "dev-ag2space", "relay-client.env"), "w") as f:
+            with open(os.path.join(cfg, "channels", "dev-ag2space", ".env"), "w") as f:
                 f.write("REMOTE_TASK_TOKEN=x\n")
             p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:dev.ag2.space"})
             old = os.environ.get("CLAUDE_CONFIG_DIR")
             os.environ["CLAUDE_CONFIG_DIR"] = cfg
             try:
                 self.assertEqual(resolve_active_target(p), ("dev-ag2space", "!r:dev.ag2.space"))
+            finally:
+                if old is None:
+                    del os.environ["CLAUDE_CONFIG_DIR"]
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def test_relay_client_env_alone_is_not_deliverable(self):
+        # notify.py reads exactly channels/<source>/.env; a lane holding only
+        # relay-client.env would fail the actual send — must NOT be selected
+        # (the #2701 review P1 failure mode).
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
+            os.makedirs(os.path.join(cfg, "channels", "dev-ag2space"))
+            with open(os.path.join(cfg, "channels", "dev-ag2space", "relay-client.env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:dev.ag2.space"})
+            old = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            try:
+                self.assertEqual(resolve_active_target(p), ("", ""))
             finally:
                 if old is None:
                     del os.environ["CLAUDE_CONFIG_DIR"]

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -349,6 +349,24 @@ class TestResolveActiveTarget(unittest.TestCase):
                 else:
                     os.environ["CLAUDE_CONFIG_DIR"] = old
 
+    def test_domain_named_lane_with_env_is_deliverable(self):
+        # Dots between alphanumerics are legal (domain-named lanes, in lockstep
+        # with notify.py's rule).
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
+            os.makedirs(os.path.join(cfg, "channels", "dev.ag2.space"))
+            with open(os.path.join(cfg, "channels", "dev.ag2.space", ".env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            p = self._write(td, {"channel": "dev.ag2.space", "channel_id": "!r:dev.ag2.space"})
+            old = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            try:
+                self.assertEqual(resolve_active_target(p), ("dev.ag2.space", "!r:dev.ag2.space"))
+            finally:
+                if old is None:
+                    del os.environ["CLAUDE_CONFIG_DIR"]
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
     def test_traversal_shaped_source_is_never_probed(self):
         # The slug guard must reject path-shaped sources outright.
         with tempfile.TemporaryDirectory() as td:

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -298,6 +298,44 @@ class TestResolveActiveTarget(unittest.TestCase):
             p = self._write(td, {"channel": "voice", "channel_id": "x"})
             self.assertEqual(resolve_active_target(p), ("", ""))
 
+    def test_configured_channel_dir_makes_new_surface_deliverable(self):
+        # New-homeserver rule: a source outside the static set is deliverable
+        # iff $CLAUDE_CONFIG_DIR/channels/<source>/ holds a *.env (notify.py's
+        # own resolution rule) — adding a homeserver is config-only.
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
+            os.makedirs(os.path.join(cfg, "channels", "dev-ag2space"))
+            with open(os.path.join(cfg, "channels", "dev-ag2space", "relay-client.env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:dev.ag2.space"})
+            old = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            try:
+                self.assertEqual(resolve_active_target(p), ("dev-ag2space", "!r:dev.ag2.space"))
+            finally:
+                if old is None:
+                    del os.environ["CLAUDE_CONFIG_DIR"]
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def test_unconfigured_new_surface_stays_macos_only(self):
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as cfg:
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:dev.ag2.space"})
+            old = os.environ.get("CLAUDE_CONFIG_DIR")
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            try:
+                self.assertEqual(resolve_active_target(p), ("", ""))
+            finally:
+                if old is None:
+                    del os.environ["CLAUDE_CONFIG_DIR"]
+                else:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def test_traversal_shaped_source_is_never_probed(self):
+        # The slug guard must reject path-shaped sources outright.
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, {"channel": "../discord", "channel_id": "x"})
+            self.assertEqual(resolve_active_target(p), ("", ""))
+
     def test_missing_file_is_macos_only(self):
         self.assertEqual(resolve_active_target("/no/such/activity.json"), ("", ""))
 

--- a/tests/gateway-channel-dir.test.py
+++ b/tests/gateway-channel-dir.test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""REMOTE_TASK_CHANNEL_DIR contract: a gateway-bridge instance reads its
+.env fallback and access.json from $CLAUDE_CONFIG_DIR/channels/<CHANNEL_DIR>/,
+default "ag2space". This is what makes a second homeserver instance (e.g.
+"dev-ag2space") unable to inherit prod's credentials or tier map.
+
+Loads the SHIPPED loader (src/remote-gateway-bridge.py → canonical ag2-sparrow
+module) fresh per case, because CHANNEL_DIR is import-time env.
+
+Run: python3 tests/gateway-channel-dir.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py"
+
+
+import contextlib
+
+
+@contextlib.contextmanager
+def _load(env: dict, name: str):
+    """Load the shipped module with `env` applied, keeping it applied for the
+    body (CHANNEL_DIR is import-time, but the access path reads env per call)."""
+    old = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+    try:
+        spec = importlib.util.spec_from_file_location(name, _SRC)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        yield mod
+    finally:
+        for k, v in old.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class TestChannelDir(unittest.TestCase):
+    def test_default_is_ag2space(self):
+        with tempfile.TemporaryDirectory() as cfg, _load(
+            {"CLAUDE_CONFIG_DIR": cfg, "REMOTE_TASK_TOKEN": "https://gw|s"},
+            "rgb_chandir_default",
+        ) as mod:
+            self.assertEqual(mod.CHANNEL_DIR, "ag2space")
+            self.assertEqual(
+                mod._ag2space_access_path(),
+                os.path.join(cfg, "channels", "ag2space", "access.json"),
+            )
+
+    def test_override_moves_both_paths(self):
+        with tempfile.TemporaryDirectory() as cfg:
+            # Lay a token .env ONLY under the override dir; the fallback reader
+            # must find it there (and would not under ag2space/).
+            d = os.path.join(cfg, "channels", "dev-ag2space")
+            os.makedirs(d)
+            with open(os.path.join(d, ".env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=https://dev-gw|devsecret\n")
+            with _load(
+                {
+                    "CLAUDE_CONFIG_DIR": cfg,
+                    "REMOTE_TASK_CHANNEL_DIR": "dev-ag2space",
+                    "REMOTE_TASK_TOKEN": "",
+                    "AG2_DEVICE_ENV": "",
+                },
+                "rgb_chandir_override",
+            ) as mod:
+                self.assertEqual(mod.CHANNEL_DIR, "dev-ag2space")
+                self.assertEqual(
+                    mod._ag2space_access_path(),
+                    os.path.join(cfg, "channels", "dev-ag2space", "access.json"),
+                )
+                raw, _url, _tf = mod._token_from_ag2space_env()
+                self.assertIn("devsecret", raw or "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway-vault-intercept.test.py
+++ b/tests/gateway-vault-intercept.test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""`vault set KEY VALUE` interception in the gateway bridge (owner gap-report
+2026-08-06: an MS365 client secret matched no redaction pattern and persisted
+in plaintext; the ag2space lane must give the same store-don't-persist
+guarantee as the Slack/Discord bridges).
+
+Contract pinned here, on the SHIPPED loader (src/remote-gateway-bridge.py):
+ 1. owner-tier + sink wired  -> sink called with (key, value); persisted body
+    redacted, plaintext absent, body says stored.
+ 2. owner-tier + NO sink     -> no storage; body redacted, says not-stored.
+ 3. non-owner sender          -> sink NOT called even when wired; body redacted,
+    says declined.
+ 4. prose mentioning the command is NOT intercepted (whole-body match only).
+
+Run: python3 tests/gateway-vault-intercept.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py"
+
+SECRET = "si68Q-testvalue-not-a-real-secret"
+
+
+def _load(name: str, ws: str):
+    """Load the shipped loader with sandboxed dirs. The CALLER owns env
+    lifetime — CLAUDE_CONFIG_DIR must stay applied across _write_task calls
+    (the tierMap is resolved per call), so setUp applies and tearDown restores."""
+    spec = importlib.util.spec_from_file_location(name, _SRC)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    # Override the module GLOBALS directly (post-exec set_dirs() cannot rebind
+    # names the module captured at import — the exact mistake that let a draft
+    # of this test write into the LIVE tasks dir).
+    mod.TASKS_DIR = Path(ws) / "tasks"
+    mod.RESULTS_DIR = Path(ws) / "results"
+    mod.ARCHIVE_RESULTS_DIR = Path(ws) / "results" / "archive"
+    assert str(mod.TASKS_DIR).startswith(ws), "test dirs must be sandboxed"
+    return mod
+
+
+class TestVaultIntercept(unittest.TestCase):
+    def _task(self, body: str, user: str = "@qingyun:ag2.space") -> dict:
+        return {"id": "task-vaulttest%d" % self._i, "task": body, "user_id": user,
+                "source": "ag2space", "channel_id": "!r:ag2.space"}
+
+    def setUp(self):
+        self._i = 0
+        self.tmp = tempfile.TemporaryDirectory()
+        ws = Path(self.tmp.name)
+        (ws / "tasks").mkdir()
+        (ws / "results").mkdir()
+        (ws / "state").mkdir()
+        self.ws = ws
+        env = {
+            "CLAUDE_CONFIG_DIR": str(ws / "cfg"),
+            "REMOTE_TASK_TOKEN": "https://gw.example|s",
+        }
+        self._old_env = {k: os.environ.get(k) for k in env}
+        os.environ.update(env)
+        self.mod = _load("rgb_vault_intercept", str(ws))
+
+    def tearDown(self):
+        for k, v in self._old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self.tmp.cleanup()
+
+    def _write(self, body, user="@qingyun:ag2.space"):
+        self._i += 1
+        tid = self.mod._write_task(self._task(body, user))
+        return (self.ws / "tasks" / f"{tid}.txt").read_text()
+
+    def test_owner_with_sink_stores_and_redacts(self):
+        calls = []
+        self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
+        content = self._write(f"vault set MS365_CLIENT_SECRET {SECRET}")
+        self.assertEqual(calls, [("MS365_CLIENT_SECRET", SECRET)])
+        self.assertNotIn(SECRET, content)
+        self.assertIn("stored to the vault", content)
+
+    def test_owner_without_sink_redacts_but_does_not_store(self):
+        self.mod.VAULT_SINK = None
+        content = self._write(f"vault set K1 {SECRET}")
+        self.assertNotIn(SECRET, content)
+        self.assertIn("no vault sink configured", content)
+
+    def test_non_owner_never_reaches_sink(self):
+        calls = []
+        self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
+        # Down-tier the sender via the lane's tierMap (LOCAL file the bridge reads).
+        import json
+        acc = Path(os.environ.get("CLAUDE_CONFIG_DIR", "")) or self.ws / "cfg"
+        acc_dir = self.ws / "cfg" / "channels" / "ag2space"
+        acc_dir.mkdir(parents=True, exist_ok=True)
+        (acc_dir / "access.json").write_text(
+            json.dumps({"tierMap": {"@teammate:ag2.space": "team"}}))
+        content = self._write(f"vault set K2 {SECRET}", user="@teammate:ag2.space")
+        self.assertEqual(calls, [])
+        self.assertNotIn(SECRET, content)
+        self.assertIn("NOT stored", content)
+
+    def test_prose_mention_not_intercepted(self):
+        calls = []
+        self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
+        content = self._write("how do I use vault set KEY VALUE from here?")
+        self.assertEqual(calls, [])
+        self.assertIn("vault set KEY VALUE", content)
+
+    def test_sink_failure_still_redacts(self):
+        def _boom(k, v):
+            raise RuntimeError("keychain locked")
+        self.mod.VAULT_SINK = _boom
+        content = self._write(f"vault set K3 {SECRET}")
+        self.assertNotIn(SECRET, content)
+        self.assertIn("NOT stored", content)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway-vault-intercept.test.py
+++ b/tests/gateway-vault-intercept.test.py
@@ -353,5 +353,53 @@ class TestKeychainSinkWiring(unittest.TestCase):
             self.assertFalse(self.mod._keychain_vault_sink("K1", "v"))
 
 
+class TestScriptModeSinkWired(unittest.TestCase):
+    """Review P1 2026-08-06: the loader execs the canonical source, which ends
+    `if __name__ == "__main__": main()`. In SCRIPT MODE the loader IS
+    __main__, so an unmasked exec fired main() before the sink was wired and
+    the live path ran with VAULT_SINK=None. Run the loader as __main__ in a
+    subprocess with main() stubbed, and assert VAULT_SINK is the keychain sink
+    at the moment main() is entered — the exact production entry order."""
+
+    def test_sink_precedes_entrypoint_main_in_source_order(self):
+        # Structural guard: the exec (which defines the real symbols and sets
+        # the canonical VAULT_SINK=None) comes first, THEN the sink is wired,
+        # THEN the entrypoint main() runs — and the canonical main-guard is
+        # masked across the exec so it can't auto-fire mid-exec.
+        loader = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py"
+        text = loader.read_text()
+        i_sink = text.index("VAULT_SINK = _keychain_vault_sink")
+        i_exec = text.index("exec(compile(_IMPL")
+        i_main = text.rindex("main()")
+        self.assertLess(i_exec, i_sink, "sink must be assigned AFTER the exec (real defs)")
+        self.assertLess(i_sink, i_main, "sink must be wired BEFORE the entrypoint main()")
+        # And the canonical main-guard is masked across the exec:
+        self.assertIn('__name__ = "_ag2_sparrow_bridge_impl"', text)
+        self.assertIn("_entrypoint = (__name__ == \"__main__\")", text)
+
+    def test_live_main_entry_vault_sink_not_none(self):
+        # Behavioral: exec the loader as __main__ with the canonical main
+        # replaced by a recorder, and assert VAULT_SINK is callable at entry.
+        import subprocess as sp
+        loader = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py"
+        prog = (
+            "import sys, types, pathlib\n"
+            f"loader = pathlib.Path({str(loader)!r})\n"
+            "src = loader.read_text()\n"
+            # Neuter the poll loop: after exec defines main, the loader calls it;
+            # we replace the trailing 'main()' entry with a sink-capture.\n"
+            "src = src.replace('\\nif _entrypoint:\\n    main()',"
+            "                  '\\nif _entrypoint:\\n    print(\\'LIVE_MAIN_ENTRY_VAULT_SINK=\\' + type(VAULT_SINK).__name__)')\n"
+            "g = {'__name__': '__main__', '__file__': str(loader)}\n"
+            "exec(compile(src, str(loader), 'exec'), g)\n"
+        )
+        env = dict(os.environ, REMOTE_TASK_TOKEN="https://gw.example|s",
+                   CLAUDE_CONFIG_DIR="/tmp/rgb-scriptmode-probe")
+        r = sp.run([sys.executable, "-c", prog], capture_output=True, text=True,
+                   env=env, timeout=30)
+        self.assertIn("LIVE_MAIN_ENTRY_VAULT_SINK=function", r.stdout,
+                      f"stdout={r.stdout!r} stderr={r.stderr[-400:]!r}")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/gateway-vault-intercept.test.py
+++ b/tests/gateway-vault-intercept.test.py
@@ -114,6 +114,39 @@ class TestVaultIntercept(unittest.TestCase):
         self.assertNotIn(SECRET, content)
         self.assertIn("NOT stored", content)
 
+    def test_quoted_and_equals_forms_intercepted(self):
+        # Review P1 2026-08-06: the shipped vault parser (vault_intercept)
+        # documents quoted values and =-separated forms; the gateway intercept
+        # must cover the same shapes or those bodies persist in plaintext with
+        # no sink call. Each case pins sink args, task-file redaction, AND
+        # last-owner-activity.json redaction.
+        cases = [
+            (f'vault set QUOTED "{SECRET} with spaces"',
+             "QUOTED", f"{SECRET} with spaces"),
+            (f"vault set SINGLE '{SECRET}'", "SINGLE", SECRET),
+            (f"vault set TICK `{SECRET}`", "TICK", SECRET),
+            (f"vault set EQUALS={SECRET}", "EQUALS", SECRET),
+            (f"vault set SPACED = {SECRET}", "SPACED", SECRET),
+            (f"VAULT SET UPPER {SECRET}", "UPPER", SECRET),
+        ]
+        for body, key, value in cases:
+            with self.subTest(body=body):
+                calls = []
+                self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
+                content = self._write(body)
+                self.assertEqual(calls, [(key, value)])
+                self.assertNotIn(SECRET, content)
+                self.assertIn("stored to the vault", content)
+                activity = (self.ws / "state" / "last-owner-activity.json").read_text()
+                self.assertNotIn(SECRET, activity)
+
+    def test_empty_quoted_value_not_intercepted(self):
+        calls = []
+        self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
+        content = self._write('vault set EMPTY ""')
+        self.assertEqual(calls, [])                 # nothing to store
+        self.assertIn('vault set EMPTY ""', content)  # left as ordinary text
+
     def test_prose_mention_not_intercepted(self):
         calls = []
         self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True

--- a/tests/gateway-vault-intercept.test.py
+++ b/tests/gateway-vault-intercept.test.py
@@ -140,19 +140,49 @@ class TestVaultIntercept(unittest.TestCase):
                 activity = (self.ws / "state" / "last-owner-activity.json").read_text()
                 self.assertNotIn(SECRET, activity)
 
-    def test_empty_quoted_value_not_intercepted(self):
+    def test_empty_quoted_value_scrubbed_not_stored(self):
+        # Nothing to store (empty value) — but EMPTY is a deliberate key, so
+        # the embedded fail-closed scrub still replaces the fragment rather
+        # than leaving command-shaped text in the task body.
         calls = []
         self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
         content = self._write('vault set EMPTY ""')
         self.assertEqual(calls, [])                 # nothing to store
-        self.assertIn('vault set EMPTY ""', content)  # left as ordinary text
+        self.assertIn("vault set EMPTY [REDACTED", content)
 
-    def test_prose_mention_not_intercepted(self):
+    def test_embedded_candidate_scrubbed_not_stored(self):
+        # Review P1 (mid-prose repro): a quoted secret after a deliberate key
+        # inside prose must not persist ANYWHERE — and must NOT be stored
+        # (quoting a command is not a store intent). Mirrors the shipped
+        # Slack/Discord parser's fail-closed posture.
+        calls = []
+        self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
+        body = f'please store this: vault set MIDPROSE "{SECRET} with spaces" for later'
+        content = self._write(body)
+        self.assertEqual(calls, [])                       # never stored
+        self.assertNotIn(SECRET, content)
+        self.assertIn("embedded in prose; NOT stored", content)
+        activity = (self.ws / "state" / "last-owner-activity.json").read_text()
+        self.assertNotIn(SECRET, activity)
+
+    def test_embedded_env_shaped_key_fail_closed(self):
+        # #2074 guard parity: an env-shaped key is a deliberate key — the
+        # candidate is scrubbed even when the value looks harmless. The value
+        # is lost fail-closed; the sender is told how to store properly.
         calls = []
         self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
         content = self._write("how do I use vault set KEY VALUE from here?")
         self.assertEqual(calls, [])
-        self.assertIn("vault set KEY VALUE", content)
+        self.assertNotIn("KEY VALUE", content)            # value gone
+        self.assertIn("vault set KEY [REDACTED", content)
+
+    def test_true_prose_untouched(self):
+        # Guard's other half: plain-lowercase key + non-secret value = prose.
+        calls = []
+        self.mod.VAULT_SINK = lambda k, v: calls.append((k, v)) or True
+        content = self._write("btw the vault set command works fine now")
+        self.assertEqual(calls, [])
+        self.assertIn("the vault set command works fine now", content)
 
     def test_sink_failure_still_redacts(self):
         def _boom(k, v):

--- a/tests/gateway-vault-intercept.test.py
+++ b/tests/gateway-vault-intercept.test.py
@@ -254,6 +254,49 @@ class TestCanonicalSrcCopy(unittest.TestCase):
         self.assertIsNone(self.csf.extract_vault_set("vault set K v\nx"))
         self.assertIsNone(self.csf.extract_vault_set(""))
 
+    def test_extract_value_shapes_and_empty(self):
+        # quoted/backtick/= alternatives on the whole-body extractor
+        self.assertEqual(self.csf.extract_vault_set('vault set K "a b"'), ("K", "a b"))
+        self.assertEqual(self.csf.extract_vault_set("vault set K 'a b'"), ("K", "a b"))
+        self.assertEqual(self.csf.extract_vault_set("vault set K `a b`"), ("K", "a b"))
+        self.assertEqual(self.csf.extract_vault_set("vault set K=v1"), ("K", "v1"))
+        self.assertEqual(self.csf.extract_vault_set("vault set K = v1"), ("K", "v1"))
+        self.assertIsNone(self.csf.extract_vault_set('vault set K ""'))  # empty: no store
+
+    def test_scrub_embedded_all_value_shapes(self):
+        # every value alternative through the embedded scrub, deliberate key
+        for frag in ('vault set MID "a b"', "vault set MID 'a b'",
+                     "vault set MID `a b`", "vault set MID=abv", "vault set MID tok1"):
+            text, keys = self.csf.scrub_embedded_vault_sets(f"pre {frag} post")
+            self.assertEqual(keys, ("MID",), frag)
+            self.assertNotIn("a b", text, frag)
+            self.assertIn("NOT stored", text, frag)
+            self.assertTrue(text.startswith("pre ") and text.endswith(" post"), frag)
+
+    def test_scrub_guard_prose_vs_secret_shaped(self):
+        # prose: lowercase word key + plain value → untouched
+        t, k = self.csf.scrub_embedded_vault_sets("the vault set command works fine")
+        self.assertEqual(k, ())
+        self.assertIn("vault set command works", t)
+        # lowercase key BUT secret-shaped value (tokenish run) → scrubbed
+        tok = "A" * 24
+        t, k = self.csf.scrub_embedded_vault_sets(f"hey vault set apollo {tok} now")
+        self.assertEqual(k, ("apollo",))
+        self.assertNotIn(tok, t)
+        # lowercase key + curated-pattern value (OpenAI shape) → scrubbed
+        sk = "sk-proj-" + "x" * 34
+        t, k = self.csf.scrub_embedded_vault_sets(f"use vault set key {sk} ok")
+        self.assertEqual(k, ("key",))
+        self.assertNotIn(sk, t)
+        # multiple candidates in one body: both scrubbed
+        t, k = self.csf.scrub_embedded_vault_sets(
+            "vault set K1 v1secrettoken and vault set K2 v2secrettoken")
+        self.assertEqual(k, ("K1", "K2"))
+        self.assertNotIn("v1secrettoken", t)
+        self.assertNotIn("v2secrettoken", t)
+        # empty input passes through
+        self.assertEqual(self.csf.scrub_embedded_vault_sets(""), ("", ()))
+
     def test_replacement_branches_never_contain_value(self):
         for kwargs, marker in (
             (dict(stored=True, owner=True), "stored to the vault"),

--- a/tests/gateway-vault-intercept.test.py
+++ b/tests/gateway-vault-intercept.test.py
@@ -125,5 +125,81 @@ class TestVaultIntercept(unittest.TestCase):
         self.assertIn("NOT stored", content)
 
 
+class TestCanonicalSrcCopy(unittest.TestCase):
+    """The canonical src/chat_secret_filter.py (package copy is generated from
+    it) must carry the same vault-set behavior — covered directly so the diff
+    gate sees the canonical lines, not just the package mirror."""
+
+    def setUp(self):
+        spec = importlib.util.spec_from_file_location(
+            "csf_canonical", Path(__file__).resolve().parent.parent / "src" / "chat_secret_filter.py")
+        self.csf = importlib.util.module_from_spec(spec)
+        # dataclass decoration resolves cls.__module__ via sys.modules — the
+        # module must be registered BEFORE exec or the import dies.
+        sys.modules["csf_canonical"] = self.csf
+        spec.loader.exec_module(self.csf)
+
+    def test_extract_shapes(self):
+        self.assertEqual(self.csf.extract_vault_set("vault set K v"), ("K", "v"))
+        self.assertIsNone(self.csf.extract_vault_set("say vault set K v"))
+        self.assertIsNone(self.csf.extract_vault_set("vault set K v\nx"))
+        self.assertIsNone(self.csf.extract_vault_set(""))
+
+    def test_replacement_branches_never_contain_value(self):
+        for kwargs, marker in (
+            (dict(stored=True, owner=True), "stored to the vault"),
+            (dict(stored=False, owner=False), "not owner-tier"),
+            (dict(stored=False, owner=True), "no vault sink configured"),
+        ):
+            body = self.csf.vault_set_replacement("KEY", **kwargs)
+            self.assertIn("KEY", body)
+            self.assertIn(marker, body)
+            self.assertIn("REDACTED", body)
+
+
+class TestKeychainSinkWiring(unittest.TestCase):
+    """The loader's _keychain_vault_sink shells to skills/secret-vault with the
+    value on STDIN (never argv) and maps the exit code to bool."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        ws = Path(self.tmp.name)
+        for d in ("tasks", "results", "state"):
+            (ws / d).mkdir()
+        env = {"CLAUDE_CONFIG_DIR": str(ws / "cfg"),
+               "REMOTE_TASK_TOKEN": "https://gw.example|s"}
+        self._old_env = {k: os.environ.get(k) for k in env}
+        os.environ.update(env)
+        self.mod = _load("rgb_sink_wiring", str(ws))
+
+    def tearDown(self):
+        for k, v in self._old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self.tmp.cleanup()
+
+    def test_sink_invokes_secret_vault_with_stdin_value(self):
+        import subprocess as sp
+        from unittest.mock import patch
+        with patch.object(sp, "run") as run:
+            run.return_value = type("R", (), {"returncode": 0})()
+            ok = self.mod._keychain_vault_sink("K1", "v-secret")
+        self.assertTrue(ok)
+        args, kwargs = run.call_args
+        self.assertIn("secret-vault.py", " ".join(map(str, args[0])))
+        self.assertEqual(args[0][-2:], ["set", "K1"])
+        self.assertEqual(kwargs.get("input"), b"v-secret")
+        self.assertNotIn("v-secret", " ".join(map(str, args[0])))
+
+    def test_sink_maps_nonzero_to_false(self):
+        import subprocess as sp
+        from unittest.mock import patch
+        with patch.object(sp, "run") as run:
+            run.return_value = type("R", (), {"returncode": 1})()
+            self.assertFalse(self.mod._keychain_vault_sink("K1", "v"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/gateway-vault-intercept.test.py
+++ b/tests/gateway-vault-intercept.test.py
@@ -42,7 +42,12 @@ def _load(name: str, ws: str):
     mod.TASKS_DIR = Path(ws) / "tasks"
     mod.RESULTS_DIR = Path(ws) / "results"
     mod.ARCHIVE_RESULTS_DIR = Path(ws) / "results" / "archive"
+    # Owner-presence file too — _write_task ends in _write_owner_activity, so
+    # without this the suite stomps the LIVE last-owner-activity.json (and the
+    # redaction tests below would assert against real state).
+    mod.OWNER_ACTIVITY_FILE = Path(ws) / "state" / "last-owner-activity.json"
     assert str(mod.TASKS_DIR).startswith(ws), "test dirs must be sandboxed"
+    assert str(mod.OWNER_ACTIVITY_FILE).startswith(ws), "presence file must be sandboxed"
     return mod
 
 
@@ -123,6 +128,47 @@ class TestVaultIntercept(unittest.TestCase):
         content = self._write(f"vault set K3 {SECRET}")
         self.assertNotIn(SECRET, content)
         self.assertIn("NOT stored", content)
+
+
+class TestOwnerActivityRedaction(TestVaultIntercept):
+    """bassil P1 2026-08-06: the presence summary (last-owner-activity.json)
+    re-derived from the RAW task dict, so an intercepted vault-set value that
+    never reached tasks/ still persisted here in plaintext. The summary must
+    ride the same redaction pipeline as the task body — shipped path AND the
+    direct-caller fallback. Inherits the sandboxed harness (incl. the
+    OWNER_ACTIVITY_FILE redirect) and its intercept cases keep passing."""
+
+    def _summary(self) -> str:
+        import json
+        return json.loads(
+            (self.ws / "state" / "last-owner-activity.json").read_text())["summary"]
+
+    def test_vault_set_never_reaches_presence_summary(self):
+        self.mod.VAULT_SINK = lambda k, v: True
+        self._write(f"vault set MS365_CLIENT_SECRET {SECRET}")
+        s = self._summary()
+        self.assertNotIn(SECRET, s)
+        self.assertIn("vault set MS365_CLIENT_SECRET", s)  # key stays legible
+
+    def test_summary_is_parity_with_persisted_task_body(self):
+        # The invariant is PARITY: the summary derives from the exact text the
+        # task file persisted (post vault-intercept + generic filter), never
+        # from the rawer pre-redaction dict. Pin it byte-for-byte at the
+        # 80-char summary cap.
+        self.mod.VAULT_SINK = lambda k, v: True
+        content = self._write(f"vault set K7 {SECRET}")
+        task_line = next(l for l in content.splitlines() if l.startswith("task: "))
+        self.assertEqual(self._summary(), task_line[len("task: "):][:80])
+
+    def test_direct_caller_fallback_redacts_too(self):
+        # A caller that skips _write_task must get the same guarantee.
+        self.mod._write_owner_activity(
+            {"task": f"vault set K9 {SECRET}", "user_id": "@qingyun:ag2.space",
+             "source": "ag2space", "channel_id": "!r:ag2.space"},
+            sender_tier="owner")
+        s = self._summary()
+        self.assertNotIn(SECRET, s)
+        self.assertIn("K9", s)
 
 
 class TestCanonicalSrcCopy(unittest.TestCase):

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -505,6 +505,26 @@ class TestGatewaySourceTraversal(unittest.TestCase):
         for bad in ("EVIL", "a b", "a/b", ".hidden", "", "-lead"):
             self.assertFalse(self.mod.send_remote_gateway(bad, "!r:s", "hi"), bad)
 
+    def test_dotted_traversal_shapes_still_refused(self):
+        # Dots are legal BETWEEN alphanumerics (domain-named lanes) — every
+        # traversal-adjacent shape stays out, before containment even runs.
+        for bad in ("..", "../evil", "a..b", "a.", ".a", "a.-b", "dev.ag2.space."):
+            self.assertFalse(self.mod.send_remote_gateway(bad, "!r:s", "hi"), bad)
+
+    def test_domain_named_source_reads_its_channel_env(self):
+        # The owner-ideal naming: channels/dev.ag2.space/ is a valid lane and
+        # its .env is read (send reaches _post with that lane's gateway).
+        lane = self.cfg / "channels" / "dev.ag2.space"
+        lane.mkdir()
+        (lane / ".env").write_text(
+            "REMOTE_TASK_URL=https://dev-gw.example\nREMOTE_TASK_TOKEN=dev-token\n")
+        posts = []
+        with patch.object(self.mod, "_post", side_effect=lambda *a, **k: posts.append(a) or True):
+            ok = self.mod.send_remote_gateway("dev.ag2.space", "!r:dev.ag2.space", "hi")
+        self.assertTrue(ok)
+        self.assertEqual(len(posts), 1)
+        self.assertIn("dev-gw.example", str(posts[0]))
+
 
 class TestCLI(unittest.TestCase):
     def test_missing_channel_id_exits_1(self):


### PR DESCRIPTION
**Stacked on #2702** (← #2701) — merge order: 2701 → 2702 → this. Will rebase + rerun checks as parents land.

Owner gap-report (2026-08-06, live incident): a `vault set MS365_CLIENT_SECRET <value>` sent through the ag2space lane persisted the plaintext secret in the task file — the command shape matches no redaction pattern, and the gateway lane lacked the intercept the Slack/Discord bridges have. Two secrets crossed that gap today (both scrubbed from archives by hand).

## Change
- `chat_secret_filter.extract_vault_set`: whole-body `vault set KEY VALUE` match (prose mentions are NOT intercepted); `vault_set_replacement` bodies state exactly what happened — stored / no-sink / non-owner-declined — so the core replies truthfully without re-requesting the secret.
- `remote_gateway_bridge.VAULT_SINK`: provider-neutral hook, default None (transport stays keychain-agnostic; no sink still means the value never reaches disk). Called **only for owner-tier senders** — the tier gate stops a teammate from writing into the owner's keychain. `sender_tier` now resolves once above the field loop; the access_tier header + owner-activity gate reuse the same resolution.
- Sutando loader wires the sink to `skills/secret-vault` (macOS Keychain).

## Evidence
`tests/gateway-vault-intercept.test.py` (5/5, against the shipped loader): owner+sink stores exact (key,value) and persists a redacted body; no-sink redacts and says so; tierMap-down-tiered sender never reaches the sink; prose passes through; a sink exception still redacts. Existing `src/remote-gateway-bridge.test.py` harness: PASS.

Test-harness note baked into the file: dir overrides assign module globals directly — a draft using post-exec `set_dirs()` wrote into the LIVE tasks dir (caught by the watcher, cleaned); the sandbox assert now makes that impossible to repeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)