### PR TITLE
fix(ms365): MS365_AUTH_FLOW=public — support public-client app registrations

### DIFF
--- a/skills/ms365-connect/SKILL.md
+++ b/skills/ms365-connect/SKILL.md
@@ -66,6 +66,7 @@ Secrets are read from the environment (populate them from the Sutando vault;
 | `MS365_CLIENT_ID` | Azure AD application (client) ID |
 | `MS365_CLIENT_SECRET` | Azure AD client secret value |
 | `MS365_TENANT_ID` | Directory (tenant) ID, or `common` / `organizations` |
+| `MS365_AUTH_FLOW` | `credentials` (default; confidential client, id+secret) or `public` (native client, id only — required when the app's redirect is registered under "Mobile and desktop applications"; symptom of the mismatch: `AADSTS700025` on token exchange). In `public` flow `MS365_CLIENT_SECRET` is not required. |
 
 If any is unset, the CLI exits with a clear message naming the missing variable.
 

--- a/skills/ms365-connect/scripts/ms365.py
+++ b/skills/ms365-connect/scripts/ms365.py
@@ -153,13 +153,30 @@ def _owner_only_backend(FileSystemTokenBackend, token_dir, filename=_TOKEN_FILEN
     return _OwnerOnlyTokenBackend(token_path=token_dir, token_filename=filename)
 
 
+def _auth_flow() -> str:
+    """"credentials" (confidential client, id+secret — the default) or "public"
+    (native/public client, id only). Env-selected because Azure decides this at
+    the app registration: an app whose redirect lives under "Mobile and desktop
+    applications" is a PUBLIC client, and presenting a client_secret to it fails
+    the token exchange with AADSTS700025 ("Client is public so neither
+    'client_assertion' nor 'client_secret' should be presented") — hit live on
+    2026-08-06. Set MS365_AUTH_FLOW=public for such registrations."""
+    flow = (os.environ.get("MS365_AUTH_FLOW") or "credentials").strip().lower()
+    if flow not in ("credentials", "public"):
+        sys.stderr.write(
+            f"Invalid MS365_AUTH_FLOW {flow!r}: use 'credentials' or 'public'.\n")
+        sys.exit(2)
+    return flow
+
+
 def _require_credentials():
-    """Return (client_id, client_secret, tenant_id) or exit if any is unset."""
-    missing = [
-        name
-        for name in ("MS365_CLIENT_ID", "MS365_CLIENT_SECRET", "MS365_TENANT_ID")
-        if not os.environ.get(name)
-    ]
+    """Return (client_id, client_secret, tenant_id) or exit if any required one
+    is unset. In public flow the client secret is NOT required (and never sent);
+    client_secret comes back as None there."""
+    required = ["MS365_CLIENT_ID", "MS365_TENANT_ID"]
+    if _auth_flow() == "credentials":
+        required.insert(1, "MS365_CLIENT_SECRET")
+    missing = [name for name in required if not os.environ.get(name)]
     if missing:
         sys.stderr.write(
             "Missing required environment variable(s): "
@@ -169,7 +186,7 @@ def _require_credentials():
         sys.exit(2)
     return (
         os.environ["MS365_CLIENT_ID"],
-        os.environ["MS365_CLIENT_SECRET"],
+        os.environ.get("MS365_CLIENT_SECRET") or None,
         os.environ["MS365_TENANT_ID"],
     )
 
@@ -182,12 +199,23 @@ def _build_account():  # pragma: no cover  (live Graph calls; not unit-testable)
     token_dir = _secure_dir(_token_dir())
     token_backend = _owner_only_backend(FileSystemTokenBackend, token_dir)
 
-    account = Account(
-        credentials=(client_id, client_secret),
-        auth_flow_type="authorization",  # confidential client (id + secret)
-        tenant_id=tenant_id,
-        token_backend=token_backend,
-    )
+    if _auth_flow() == "public":
+        # Native/public client: id only; O365 runs the same authorization-code
+        # flow but never presents a secret (matches an app registered under
+        # "Mobile and desktop applications" — see _auth_flow).
+        account = Account(
+            credentials=client_id,
+            auth_flow_type="public",
+            tenant_id=tenant_id,
+            token_backend=token_backend,
+        )
+    else:
+        account = Account(
+            credentials=(client_id, client_secret),
+            auth_flow_type="authorization",  # confidential client (id + secret)
+            tenant_id=tenant_id,
+            token_backend=token_backend,
+        )
     return account
 
 

--- a/tests/ms365-connect.test.py
+++ b/tests/ms365-connect.test.py
@@ -64,6 +64,33 @@ class TestCredentialGuard(unittest.TestCase):
         os.environ.update(MS365_CLIENT_ID="id", MS365_CLIENT_SECRET="sec", MS365_TENANT_ID="ten")
         self.assertEqual(ms365._require_credentials(), ("id", "sec", "ten"))
 
+    def test_public_flow_does_not_require_secret(self):
+        # An app registered under "Mobile and desktop applications" is a PUBLIC
+        # client: the exchange must not present a secret (AADSTS700025, live
+        # 2026-08-06) — so the guard must not demand one either.
+        os.environ.update(MS365_CLIENT_ID="id", MS365_TENANT_ID="ten",
+                          MS365_AUTH_FLOW="public")
+        try:
+            self.assertEqual(ms365._require_credentials(), ("id", None, "ten"))
+        finally:
+            os.environ.pop("MS365_AUTH_FLOW", None)
+
+    def test_default_flow_still_requires_secret(self):
+        os.environ.update(MS365_CLIENT_ID="id", MS365_TENANT_ID="ten")
+        with self.assertRaises(SystemExit) as cm:
+            ms365._require_credentials()
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_invalid_flow_exits_2(self):
+        os.environ.update(MS365_CLIENT_ID="id", MS365_TENANT_ID="ten",
+                          MS365_AUTH_FLOW="pkce")
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                ms365._auth_flow()
+            self.assertEqual(cm.exception.code, 2)
+        finally:
+            os.environ.pop("MS365_AUTH_FLOW", None)
+
 
 class TestTokenDir(unittest.TestCase):
     def test_honors_state_dir_env(self):


### PR DESCRIPTION
Owner ask (2026-08-06: "make a PR to do the skill fix"), from a live finding completing her MS365 consent flow an hour after #2682 merged.

## The finding (live evidence)
Her Entra app's redirect is registered under "Mobile and desktop applications" → Azure treats it as a **public client**. The skill's hardcoded confidential flow presented the client secret and the token exchange failed:

```
invalid_client | AADSTS700025: Client is public so neither 'client_assertion'
nor 'client_secret' should be presented.
```

Retrying the same exchange without the secret succeeded immediately (token now live; calendar + OneDrive proof calls returned real data). The skill's own CLI would hit the same wall on `auth` AND on every token refresh against such registrations.

## Change
- `MS365_AUTH_FLOW` env: `credentials` (default — unchanged behavior) or `public` (id only; `MS365_CLIENT_SECRET` not required and never sent; `Account(..., auth_flow_type="public")`).
- `_require_credentials` demands the secret only in credentials flow.
- SKILL.md config table documents the flag with the AADSTS700025 symptom as the tell.

## Evidence
- `python3 tests/ms365-connect.test.py` → 19/19 (3 new: public skips secret requirement; default still requires it; invalid value exits 2).
- `--help` still imports cleanly without O365 (the suite's lazy-import pin holds).
- Default-path behavior is byte-identical — no existing setup changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)