### PR TITLE
fix(discord): a human @-mentioning another agent is not addressing everyone

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -3106,17 +3106,24 @@ async def _handle_discord_message(message, force=False):
             _ref = getattr(message, "reference", None)
             _ref_resolved = getattr(_ref, "resolved", None) if _ref is not None else None
             _ref_author = getattr(_ref_resolved, "author", None)
+            _self_id = getattr(client.user, "id", None)
+            _other_agent_mentioned = any(
+                getattr(u, "bot", False) and getattr(u, "id", None) != _self_id
+                for u in (getattr(message, "mentions", None) or [])
+            )
             if not is_addressed_in_shared_channel(
                 author_is_bot=bool(getattr(message.author, "bot", False)),
                 bot_mentioned=bot_mentioned,
                 role_mentioned=role_mentioned,
                 is_reply=_ref is not None,
                 reply_author_id=(getattr(_ref_author, "id", None) if _ref_author is not None else None),
-                self_id=getattr(client.user, "id", None),
+                self_id=_self_id,
+                other_agent_mentioned=_other_agent_mentioned,
             ):
                 print(f"  [skip] shared channel: not addressed to me "
                       f"(author_bot={bool(getattr(message.author, 'bot', False))}, "
-                      f"reply={_ref is not None})", flush=True)
+                      f"reply={_ref is not None}, "
+                      f"other_agent_mentioned={_other_agent_mentioned})", flush=True)
                 return
 
         # Strip role mentions only. User mentions (this bot's and other

--- a/src/discord_addressee.py
+++ b/src/discord_addressee.py
@@ -34,6 +34,7 @@ def is_addressed_in_shared_channel(
     is_reply: bool,
     reply_author_id,
     self_id,
+    other_agent_mentioned: bool = False,
 ) -> bool:
     """Return True iff this message should be processed as addressed to us.
 
@@ -47,13 +48,18 @@ def is_addressed_in_shared_channel(
 
     Otherwise the message is addressed elsewhere (→ False) when it is:
       * another agent's own post — `author_is_bot` and not addressed to us; or
-      * a reply to a DIFFERENT author — `is_reply` whose target is not us.
+      * a reply to a DIFFERENT author — `is_reply` whose target is not us; or
+      * a human message that @-mentions a DIFFERENT agent and not us
+        (`other_agent_mentioned`) — it addressed that agent, not everyone.
 
-    A fresh (non-reply) message from a human that doesn't address anyone is still
+    A fresh (non-reply) message from a human that addresses NOBODY is still
     processed (→ True): the owner posting directly is for whoever is listening —
     that is the pre-existing `requireMention:false` behavior and is out of scope
     for this fix (the multi-agent "who owns an unaddressed message" question
     belongs to the channel-IFC design, not the addressee gate).
+
+    `other_agent_mentioned` is resolved by the adapter (which mentioned users are
+    bots other than us); the policy decision stays here.
     """
     replying_to_me = bool(
         is_reply and reply_author_id is not None and reply_author_id == self_id
@@ -63,6 +69,10 @@ def is_addressed_in_shared_channel(
 
     replying_to_other = bool(is_reply) and not replying_to_me
     if author_is_bot or replying_to_other:
+        return False
+
+    # A human who @-mentioned another agent addressed THAT agent, not everyone.
+    if other_agent_mentioned:
         return False
 
     return True

--- a/tests/discord-bridge-shared-channel-addressee.test.py
+++ b/tests/discord-bridge-shared-channel-addressee.test.py
@@ -7,7 +7,12 @@ In a shared channel configured `requireMention:false` (non-bot2bot), the bridge
 was processing messages NOT addressed to this bot:
   * the owner replying to another agent (Discord auto-adds the reply-target to
     mentions; the old gate *excluded* it from the addressee check — backwards);
-  * another agent's own posts (e.g. a sibling bot's "⏳ working…" status).
+  * another agent's own posts (e.g. a sibling bot's "⏳ working…" status);
+  * a human @-mentioning a DIFFERENT agent — observed 2026-08-06, when the owner
+    posted "<@PRO> keep improving the arcade" twice in five minutes in a channel
+    named "arcade — Pro iterating, Chi reviews". Every listening bot ingested it:
+    this one queued tasks it could only discard, and its progress-streamer posted
+    "⏳ working…" into the lane the owner had pointed at one agent.
 
 The fix moves the decision into the pure `src/discord_addressee.py`
 (`is_addressed_in_shared_channel`) so the truth table is tested directly, and
@@ -82,6 +87,46 @@ def main() -> int:
     assert '_channel_role(str(message.channel.id)) != "bot2bot"' in bridge, \
         "discord-bridge.py does not carve out role:'bot2bot' channels"
     print("  ok  bridge carves out bot2bot channels")
+
+    # --- a human addressing a DIFFERENT agent ---
+    assert not addressed(author_is_bot=False, bot_mentioned=False, role_mentioned=False,
+                         is_reply=False, reply_author_id=None,
+                         other_agent_mentioned=True), "owner @-mentions ANOTHER agent"
+    print("  ok  owner @-mentions another agent -> not ours")
+
+    # Reachability must survive: naming us AND a peer is still ours.
+    assert addressed(author_is_bot=False, bot_mentioned=True, role_mentioned=False,
+                     is_reply=False, reply_author_id=None,
+                     other_agent_mentioned=True), "owner @-mentions BOTH us and a peer"
+    print("  ok  owner @-mentions us AND a peer -> still ours")
+
+    assert addressed(author_is_bot=False, bot_mentioned=False, role_mentioned=True,
+                     is_reply=False, reply_author_id=None,
+                     other_agent_mentioned=True), "role-mention of us alongside a peer"
+    print("  ok  role-mention of us alongside a peer -> still ours")
+
+    assert addressed(author_is_bot=False, bot_mentioned=False, role_mentioned=False,
+                     is_reply=True, reply_author_id=ME,
+                     other_agent_mentioned=True), "reply to US that also names a peer"
+    print("  ok  reply to us that also names a peer -> still ours")
+
+    # Unaddressed owner messages are unchanged (out of scope).
+    assert addressed(author_is_bot=False, bot_mentioned=False, role_mentioned=False,
+                     is_reply=False, reply_author_id=None,
+                     other_agent_mentioned=False), "owner addresses nobody"
+    print("  ok  owner addresses nobody -> still ours (unchanged)")
+
+    # Omitting the kwarg entirely must behave as before this change.
+    assert addressed(author_is_bot=False, bot_mentioned=False, role_mentioned=False,
+                     is_reply=False, reply_author_id=None), "default keeps old behavior"
+    print("  ok  parameter defaults to False (back-compatible)")
+
+    assert "other_agent_mentioned=_other_agent_mentioned" in bridge, \
+        "discord-bridge.py does not pass other_agent_mentioned to the gate"
+    print("  ok  bridge resolves and passes other_agent_mentioned")
+    assert 'getattr(u, "bot", False)' in bridge and "message, \"mentions\"" in bridge, \
+        "discord-bridge.py does not derive peer mentions from message.mentions"
+    print("  ok  bridge derives peer mentions from message.mentions")
 
     print("\nAll addressee-gate cases pass.")
     return 0


### PR DESCRIPTION
## The defect

In a `requireMention:false` channel the addressee gate had three ways to say "not for us" — another bot's post, a reply to someone else, a reply to us — and **no way to notice that a human named a different agent**. So `<@PRO> ...` fell through to the "addresses nobody, process it" branch.

## Observed live, twice in five minutes

Channel: **"arcade — Pro iterating, Chi reviews"** (the name states whose lane it is).

```
14:59:35  sonichi: <@PRO> can you make the sutando nightshift more minecraftish? 32x32?
14:59:44  Sutando-Pro:  ⏳ Comm sweep … (Pro answers, 9s)
14:59:44  Sutando-Mini: ⏳ working… (14s)      <-- this instance, uninvited

15:04:23  sonichi: <@PRO> keep improving the arcade. …
15:04:31  Sutando-Pro:  ⏳ … (8s)
15:04:34  Sutando-Mini: ⏳ working… (14s)      <-- again
```

Both arrived here as owner tasks this instance could only discard, and the progress-streamer narrated into a review thread the owner had pointed at one agent. Pro was live and answered both within nine seconds.

This is the same noise class the suite's own docstring already cites — *"another agent's own posts (e.g. a sibling bot's ⏳ working… status)"* — one step upstream: the **human** doing the addressing.

## Before / after — the gate, on that exact message shape

```
PARENT (origin/main)   owner posts "<@PRO> keep improving the arcade" -> ingested as MY task: True
HEAD                                                                  -> ingested as MY task: False
```

Test suite: **exit 1 at parent, exit 0 here** (unpiped exit codes — `| tail` would have reported the pipe's status).

## Reachability is preserved — the part worth reviewing

Guarding on "a peer was mentioned" alone would silence this bot whenever the owner addresses two agents at once. All of these still resolve to **ours**:

| case | result |
|---|---|
| owner @-mentions us **and** a peer | ours |
| role-mention of us alongside a peer | ours |
| reply to **us** that also names a peer | ours |
| owner addresses nobody | ours (unchanged) |
| owner @-mentions **only** a peer | **not ours** |

An unaddressed owner message is deliberately unchanged — who owns those is the channel-IFC question, not this gate's.

## Shape

- `other_agent_mentioned` defaults to `False`, so any caller that doesn't pass it behaves exactly as before.
- The **adapter** resolves which mentioned users are bots other than us (`message.mentions`); the **policy** stays in the pure, unit-tested `discord_addressee`.
- The skip log gained the new field. Without it, a skip from this branch prints `author_bot=False, reply=False` and reads as unexplained.

## Tests

6 new cases in the existing assertion-style suite, plus 2 pinning the bridge wiring (that it passes the kwarg, and derives it from `message.mentions`). All **31** other `discord-bridge-*` suites and `progress-stream` green.
