### PR TITLE
fix(telemetry): bucket gateway task sources to a known surface, not "unknown"

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1581,16 +1581,12 @@ def _write_task(task: dict) -> str | None:
     tmp.write_text("\n".join(lines) + "\n")
     tmp.rename(dest)  # atomic publish so the watcher never sees a partial file
     _log(f"queued {tid}")
-    # Anonymous product telemetry — #2274 parity for the gateway surface: one
-    # task_processed{source} per NEWLY queued task (the dedup/idempotent early
-    # returns above never reach here, so redeliveries aren't double-counted).
-    # Same fire-and-forget shape as the discord/slack/telegram bridges. The
-    # `telemetry` module lives in the host repo's src/, which the
-    # src/remote-gateway-bridge.py launcher puts on sys.path; a standalone
-    # PyPI install has no such module and this silently no-ops.
+    # #2274 parity: one task_processed per NEWLY queued task (idempotent early
+    # returns never reach here), bucketed to this gateway's own "remote" surface
+    # when the source label isn't an allowlisted bucket so activity isn't lost.
     try:
-        from telemetry import task_processed
-        task_processed(_one_line(task.get("source") or PROVIDER))
+        from telemetry import bucket_source, task_processed
+        task_processed(bucket_source(_one_line(task.get("source") or PROVIDER), "remote"))
     except Exception:
         pass
     _record_task_room(tid, str(task.get("channel_id") or ""))

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -300,6 +300,17 @@ def _coarse_source(source: str) -> str:
     return s if s in _KNOWN_SOURCES else "unknown"
 
 
+def bucket_source(source: str, default: str = "unknown") -> str:
+    """Resolve a ``source:`` to a known bucket, falling back to ``default``
+    instead of the generic ``unknown``. A surface with a known home passes its
+    own bucket — e.g. the gateway is the ``remote`` surface, so a gateway task
+    whose per-task/per-deployment label isn't allowlisted counts as ``remote``,
+    not lost to ``unknown``. ``default`` is itself validated, so it can't smuggle
+    cardinality either."""
+    coarse = _coarse_source(source)
+    return coarse if coarse != "unknown" else _coarse_source(default)
+
+
 def task_processed(source: str, *, flush: bool = False) -> None:
     """One anonymous event per task the core accepts, tagged only with the
     inbound surface (``discord`` / ``slack`` / ``telegram`` / ``voice`` /

--- a/tests/gateway-task-telemetry.test.py
+++ b/tests/gateway-task-telemetry.test.py
@@ -50,6 +50,12 @@ from ag2_sparrow.event_consumer import TaskifyHandler  # noqa: E402
 # Deterministic local trust default regardless of the host's REMOTE_LOCAL_TIER.
 rgb.LOCAL_TIER = "owner"
 
+# The REAL bucket_source (pure) so fake-telemetry cases exercise the SAME
+# source-bucketing the production caller uses, not a divergent passthrough.
+_REAL_TEL_SPEC = importlib.util.spec_from_file_location("telemetry", REPO / "src" / "telemetry.py")
+_REAL_TEL = importlib.util.module_from_spec(_REAL_TEL_SPEC)
+_REAL_TEL_SPEC.loader.exec_module(_REAL_TEL)
+
 failures = []
 
 
@@ -94,6 +100,7 @@ class _FakeTelemetry:
                 raise RuntimeError("telemetry backend down")
 
         self.mod.task_processed = task_processed
+        self.mod.bucket_source = _REAL_TEL.bucket_source
 
     def __enter__(self):
         self._prev = sys.modules.get("telemetry")
@@ -300,14 +307,19 @@ check("taskify emit tagged events-promotion",
       bool(tp) and tp[0]["properties"].get("source") == "events-promotion",
       repr(tp and tp[0]["properties"]))
 
-# 7c. the allowlist still collapses junk — adding gateway sources must not
-#     open the cardinality/leak gate the allowlist exists for.
+# 7c. leak/cardinality guard preserved under the fix: a secret-ish source is
+#     never emitted as-is. It now collapses to this gateway's "remote" surface
+#     bucket (not "unknown"), and the raw identifier appears NOWHERE in the
+#     payload — the cardinality/leak posture the allowlist exists for is intact.
 _t, payloads = _write_with_real_telemetry(
     {"id": "task-telem7c", "task": "x", "source": "secret-user-identifier-123"})
 tp = [p for p in payloads if p.get("event") == "task_processed"]
-check("unknown source still collapses to unknown",
-      bool(tp) and tp[0]["properties"].get("source") == "unknown",
+check("secret-ish gateway source buckets to remote (surface, not unknown)",
+      bool(tp) and tp[0]["properties"].get("source") == "remote",
       repr(tp and tp[0]["properties"]))
+check("raw secret value never reaches the payload",
+      bool(tp) and "secret-user-identifier-123" not in repr(tp[0]),
+      repr(tp and tp[0]))
 
 # 7d. hostile-tier control (P1-2 regression pin): with the CONTROLLED temp
 #     access.json down-tiering the fixture sender to "team", production must
@@ -339,6 +351,29 @@ check("hostile tier: task written with access_tier team",
       "access_tier: team" in (tmp7d / "tasks" / "task-telem7d.txt").read_text())
 check("hostile tier: owner-activity stamp suppressed for non-owner",
       not (tmp7d / "state" / "last-owner-activity.json").exists())
+
+# 7e. REGRESSION (#2432 aftermath): a gateway task whose source is neither
+#     `ag2space` nor `events-promotion` (e.g. a custom REMOTE_TASK_PROVIDER, or
+#     any label the core allowlist doesn't recognize) was recorded as
+#     source="unknown" — burying real gateway activity as the single largest
+#     bucket fleet-wide. It must now count as this gateway's own surface,
+#     "remote", not "unknown".
+_t, payloads = _write_with_real_telemetry(
+    {"id": "task-telem7e", "task": "x", "source": "acme-cloud-deployment"})
+tp = [p for p in payloads if p.get("event") == "task_processed"]
+check("non-allowlisted gateway source buckets to remote, not unknown",
+      bool(tp) and tp[0]["properties"].get("source") == "remote",
+      repr(tp and tp[0]["properties"]))
+
+# 7f. bucket_source unit: known source kept; unknown falls to the given default;
+#     a non-allowlisted default can't itself smuggle cardinality (→ unknown).
+import telemetry as _tel  # the REAL module (src/ on sys.path from the header)
+check("bucket_source keeps a known source",
+      _tel.bucket_source("slack", "remote") == "slack")
+check("bucket_source falls back to a known default",
+      _tel.bucket_source("acme-cloud", "remote") == "remote")
+check("bucket_source rejects a bad default (no cardinality via default)",
+      _tel.bucket_source("acme-cloud", "acme-default") == "unknown")
 
 print()
 if failures:


### PR DESCRIPTION
## Problem

`task_processed{source="unknown"}` spiked to the **single largest** task bucket fleet-wide starting Aug 7 — 5040 events across 156 installs (≈32/install), where it had been ~0 the prior days. Root cause is a regression from #2432 (merged Aug 6, deployed → fleet Aug 7), not a test leak (spread across many distinct cloud IPs) and not new volume (it's *mislabeled* existing gateway activity).

#2432 added `task_processed` to the gateway task-accept point (`ag2_sparrow/remote_gateway_bridge.py:_write_task`), tagging the task's free-form source:

```python
task_processed(_one_line(task.get("source") or PROVIDER))
```

`_coarse_source` collapses anything outside `_KNOWN_SOURCES` to `"unknown"` (by design — cardinality/leak guard). The gateway's allowlisted sources (`ag2space`, `remote`, `events-promotion`) bucket fine, but a **custom `REMOTE_TASK_PROVIDER`** or any other per-task source label collapses to `"unknown"` — so real gateway/remote activity was recorded as "unknown" rather than under its surface, burying the exact activation signal #2432 set out to add.

## Fix

Add `telemetry.bucket_source(source, default)` — resolve to a known bucket, falling back to a caller-supplied **validated** default instead of the generic `"unknown"`. The gateway *is* the `"remote"` surface, so `_write_task` now emits `bucket_source(..., "remote")`. A bad default is itself coarsened, so it can't smuggle cardinality — the leak posture the allowlist exists for is unchanged.

## Before / after (real telemetry module, network sink stubbed)

```
gateway-stamped source   BEFORE            AFTER
acme-cloud-deployment    unknown           remote
matrix                   unknown           remote
gateway                  unknown           remote
ag2space                 ag2space          ag2space   (allowlisted, unchanged)
events-promotion         events-promotion  events-promotion
remote                   remote            remote
slack                    slack             slack
```

## Tests

`tests/gateway-task-telemetry.test.py` extended (all 27 checks pass):
- **7e** non-allowlisted gateway source → `remote`, not `unknown` (the regression pin)
- **7c** a secret-ish source still never leaks its raw value (buckets to `remote`, raw string absent from the payload)
- **7f** `bucket_source` unit: known kept / unknown→default / bad-default→unknown

`src/telemetry.py` suite unaffected (24 checks pass). The `_FakeTelemetry` harness now delegates to the real `bucket_source` so fake cases exercise the same bucketing as production.

## Scope note

This attributes non-allowlisted gateway sources to the `remote` surface, which is correct and value-agnostic. If specific gateway sub-surfaces beyond `ag2space`/`events-promotion` deserve their own distinct bucket, that's an additive follow-up (allowlist the specific value) — orthogonal to stopping the "unknown" bleed.
