### PR TITLE
test(telemetry): opt every test runner out of product telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main, staging-interaction-planes]
 
+# Tests must never emit product telemetry (no PostHog writes from CI).
+env:
+  SUTANDO_TELEMETRY: "0"
+
 jobs:
   typecheck-and-test:
     name: tsc + tests (clean install)

--- a/.github/workflows/python39-compat.yml
+++ b/.github/workflows/python39-compat.yml
@@ -22,6 +22,10 @@ on:
       - 'tests/check-python39-compat.test.py'
       - '.github/workflows/python39-compat.yml'
 
+# Tests must never emit product telemetry (no PostHog writes from CI).
+env:
+  SUTANDO_TELEMETRY: "0"
+
 jobs:
   parse-on-the-floor:
     runs-on: ubuntu-latest

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -32,6 +32,10 @@
 
 set -euo pipefail
 
+# Tests must never emit product telemetry. The suite runs real code paths and
+# an unstubbed one would hit PostHog from CI/dev; opt out for every test here.
+export SUTANDO_TELEMETRY=0
+
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$REPO_ROOT"
 

--- a/tests/telemetry-test-optout-guard.test.py
+++ b/tests/telemetry-test-optout-guard.test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Regression pin: the test suite must never emit product telemetry.
+
+A test that exercises a real code path without stubbing the network boundary
+would POST to PostHog from CI or a dev box — the exact "a test was sending
+metrics" incident this guards against. Every place that RUNS the suite opts
+out via SUTANDO_TELEMETRY=0, and telemetry honors that opt-out. This test
+fails if either half regresses:
+
+  1. each test runner sets SUTANDO_TELEMETRY=0
+     - scripts/coverage-gate.sh (local + coverage-gate.yml)
+     - .github/workflows/ci.yml           (node + python tests)
+     - .github/workflows/python39-compat.yml
+  2. telemetry.opted_out() honors SUTANDO_TELEMETRY=0 (and enabled() → False)
+
+Run: python3 tests/telemetry-test-optout-guard.test.py
+"""
+import importlib.util
+import os
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("ok   " if cond else "FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+# 1. every runner opts the suite out.
+gate = (REPO / "scripts" / "coverage-gate.sh").read_text()
+check("coverage-gate.sh exports SUTANDO_TELEMETRY=0",
+      re.search(r"^\s*export\s+SUTANDO_TELEMETRY=0\b", gate, re.MULTILINE) is not None)
+
+for wf in ("ci.yml", "python39-compat.yml"):
+    text = (REPO / ".github" / "workflows" / wf).read_text()
+    # a workflow-level `env:` mapping (top-level, not nested under a step) with
+    # SUTANDO_TELEMETRY: "0" — applies to every job/step in the workflow.
+    has = re.search(r'(?m)^env:\s*$', text) and re.search(
+        r'(?m)^\s+SUTANDO_TELEMETRY:\s*["\']?0["\']?\s*$', text)
+    check(f"{wf} sets SUTANDO_TELEMETRY=0", bool(has))
+
+
+# 2. telemetry actually honors the opt-out (load the real module).
+def _load_telemetry(env_value):
+    prev = os.environ.get("SUTANDO_TELEMETRY")
+    if env_value is None:
+        os.environ.pop("SUTANDO_TELEMETRY", None)
+    else:
+        os.environ["SUTANDO_TELEMETRY"] = env_value
+    # a key must be present, else _enabled() is already False for want of a key
+    # and the test would pass vacuously — we want to prove the opt-out gates it.
+    os.environ["POSTHOG_API_KEY"] = "phc_test"
+    try:
+        spec = importlib.util.spec_from_file_location("telemetry", REPO / "src" / "telemetry.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        mod._KEY = "phc_test"
+        return mod.opted_out(), mod.enabled()
+    finally:
+        if prev is None:
+            os.environ.pop("SUTANDO_TELEMETRY", None)
+        else:
+            os.environ["SUTANDO_TELEMETRY"] = prev
+
+
+opted, enab = _load_telemetry("0")
+check("SUTANDO_TELEMETRY=0 → opted_out() True", opted is True)
+check("SUTANDO_TELEMETRY=0 → enabled() False (no emission)", enab is False)
+
+# control: with a key and no opt-out, telemetry WOULD emit — proving the opt-out
+# above is what gates it, not a missing key.
+opted_on, enab_on = _load_telemetry(None)
+check("without opt-out (key present) → enabled() True (opt-out is the gate)",
+      opted_on is False and enab_on is True)
+
+print()
+if failures:
+    print(f"{len(failures)} FAILURE(S): {failures}")
+    raise SystemExit(1)
+print(f"ALL PASS ({6} checks)")


### PR DESCRIPTION
## Problem

Tests must never emit product telemetry, but nothing enforced it. A test that runs a real code path without stubbing the network boundary (`telemetry._post`) will POST to PostHog from CI or a dev box — the "a test was sending metrics to PostHog" incident. Protection was per-test (each test remembering to stub/opt out), which is exactly how it leaks: one unstubbed path is enough.

## Fix

Opt the **whole suite** out at every place that runs it. `telemetry.opted_out()` already honors `SUTANDO_TELEMETRY=0` (→ `enabled()` False → no emit), so setting it at the runner level makes emission impossible regardless of any individual test:

- `scripts/coverage-gate.sh` — `export SUTANDO_TELEMETRY=0` (local runs **and** `coverage-gate.yml`, which shells out to it)
- `.github/workflows/ci.yml` — workflow-level `env` (the node + python test job)
- `.github/workflows/python39-compat.yml` — workflow-level `env`

## Regression pin + evidence

`tests/telemetry-test-optout-guard.test.py` (6 checks, all pass) fails if any runner drops the opt-out, and proves the semantics end-to-end:

```
ok   coverage-gate.sh exports SUTANDO_TELEMETRY=0
ok   ci.yml sets SUTANDO_TELEMETRY=0
ok   python39-compat.yml sets SUTANDO_TELEMETRY=0
ok   SUTANDO_TELEMETRY=0 → opted_out() True
ok   SUTANDO_TELEMETRY=0 → enabled() False (no emission)
ok   without opt-out (key present) → enabled() True (opt-out is the gate)
```

The last check is the control: with a key present and no opt-out, telemetry **would** emit — proving the opt-out (not a coincidentally-missing key) is what gates it.

## Scope note

This covers the systematic runners — CI and the coverage gate — which is where the whole suite executes and where a leak actually ships. An ad-hoc single-test run (`python3 tests/x.test.py` with no opt-out in the shell) is still up to that test to stub its own `_post`; centralizing that would require a shared test bootstrap the standalone-script suite doesn't have today (noted as possible follow-up).
