### PR TITLE
fix(discord): bound oversized result delivery

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -301,14 +301,45 @@ def _extract_user_id_mentions(mention_strs):
     return out
 
 
-def _chunk_for_discord(text: str, max_len: int = 1900):
-    """Discord-facing alias for the shared fence-aware chunker (Result Router S3).
-
-    Behaviour and the default (max_len=1900) are unchanged; the implementation
-    now lives in src/message_chunking.py:chunk_message so Slack (and any future
-    surface) share the exact same fence-preservation logic.
-    """
+def _chunk_for_discord_unbounded(text: str, max_len: int = 1900):
+    """Lossless Discord-sized chunks for golden tests and local processing."""
     yield from chunk_message(text, max_len)
+
+# One malformed result used to monopolize the bridge for 512 sequential Discord
+# sends, so even the owner's stop request could not be delivered until the flood
+# finished. Keep the low-level chunker lossless for callers/tests that need it,
+# but put a hard budget on every network delivery from this bridge.
+DISCORD_DELIVERY_MAX_CHUNKS = 4
+DISCORD_TRUNCATION_NOTICE = (
+    "⚠️ Result truncated: additional content was suppressed to keep Discord "
+    "responsive."
+)
+
+
+def _chunk_for_discord(
+    text: str,
+    max_len: int = 1900,
+    max_chunks: int = DISCORD_DELIVERY_MAX_CHUNKS,
+):
+    """Yield at most ``max_chunks`` sends, reserving the last for a notice.
+
+    Reads only one chunk beyond the budget, so a very large result does not
+    need to be expanded into a second in-memory list merely to discover that it
+    is oversized. Each preview chunk remains fence-safe because the shared
+    chunker closes Markdown fences at every boundary.
+    """
+    if max_chunks < 1:
+        raise ValueError("max_chunks must be at least 1")
+    preview = []
+    for chunk in _chunk_for_discord_unbounded(text, max_len=max_len):
+        preview.append(chunk)
+        if len(preview) > max_chunks:
+            break
+    if len(preview) <= max_chunks:
+        yield from preview
+        return
+    yield from preview[: max_chunks - 1]
+    yield DISCORD_TRUNCATION_NOTICE
 
 # Thin alias — actual logic lives in src/send_allowlist.py so the
 # REST-fallback delivery path (src/dm-result.py) stays in lock-step.
@@ -5516,11 +5547,10 @@ async def poll_dm_fallback():
 def _send_via_rest(channel_id: str, message: str):
     """Send a message via Discord REST API (no gateway connection).
 
-    Chunks via `_chunk_for_discord` so messages over Discord's 2000-char limit
-    (or with code fences spanning chunk boundaries) deliver intact across N
-    sequential POSTs. Without chunking the API returns 400 and the message
-    is silently dropped — this caused codex-output replies (often >2KB) to
-    never reach the channel.
+    Chunks via `_chunk_for_discord` so messages over Discord's 2000-char
+    limit render correctly without allowing one oversized payload to monopolize
+    the bridge. Without chunking the API returns 400; without the delivery budget,
+    a malformed result can produce hundreds of sequential POSTs.
     """
     import urllib.request
     url = f"https://discord.com/api/v10/channels/{channel_id}/messages"

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -302,7 +302,7 @@ def _extract_user_id_mentions(mention_strs):
 
 
 def _chunk_for_discord_unbounded(text: str, max_len: int = 1900):
-    """Lossless Discord-sized chunks for golden tests and local processing."""
+    """Yield lossless Discord-sized chunks for local callers."""
     yield from chunk_message(text, max_len)
 
 # Network delivery is bounded; local and golden chunking remains lossless.
@@ -318,7 +318,7 @@ def _chunk_for_discord(
     max_len: int = 1900,
     max_chunks: int = DISCORD_DELIVERY_MAX_CHUNKS,
 ):
-    """Bound network delivery and reserve the final send for truncation notice."""
+    """Bound network sends; reserve the final send for truncation."""
     if max_chunks < 1:
         raise ValueError("max_chunks must be at least 1")
     preview = []

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -305,10 +305,7 @@ def _chunk_for_discord_unbounded(text: str, max_len: int = 1900):
     """Lossless Discord-sized chunks for golden tests and local processing."""
     yield from chunk_message(text, max_len)
 
-# One malformed result used to monopolize the bridge for 512 sequential Discord
-# sends, so even the owner's stop request could not be delivered until the flood
-# finished. Keep the low-level chunker lossless for callers/tests that need it,
-# but put a hard budget on every network delivery from this bridge.
+# Network delivery is bounded; local and golden chunking remains lossless.
 DISCORD_DELIVERY_MAX_CHUNKS = 4
 DISCORD_TRUNCATION_NOTICE = (
     "⚠️ Result truncated: additional content was suppressed to keep Discord "
@@ -321,16 +318,11 @@ def _chunk_for_discord(
     max_len: int = 1900,
     max_chunks: int = DISCORD_DELIVERY_MAX_CHUNKS,
 ):
-    """Yield at most ``max_chunks`` sends, reserving the last for a notice.
-
-    Reads only one chunk beyond the budget, so a very large result does not
-    need to be expanded into a second in-memory list merely to discover that it
-    is oversized. Each preview chunk remains fence-safe because the shared
-    chunker closes Markdown fences at every boundary.
-    """
+    """Bound network delivery and reserve the final send for truncation notice."""
     if max_chunks < 1:
         raise ValueError("max_chunks must be at least 1")
     preview = []
+    # Read one chunk past the limit instead of expanding the full result.
     for chunk in _chunk_for_discord_unbounded(text, max_len=max_len):
         preview.append(chunk)
         if len(preview) > max_chunks:

--- a/src/message_chunking.py
+++ b/src/message_chunking.py
@@ -17,8 +17,8 @@ Slack and Telegram each hand-rolled a naive `range(0, len, N)` byte-slice, so:
 
 Pure functions only — no I/O, no bridge state — so any delivery path can adopt
 it without coupling. `chunk_message` is the single source of truth; the Discord
-bridge keeps its `_chunk_for_discord(text)` name as a thin `max_len=1900` alias
-so its call sites and byte-for-byte output are unchanged.
+bridge uses it beneath its network-facing delivery budget while retaining a
+lossless private alias for golden reassembly tests.
 """
 
 from __future__ import annotations

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -312,6 +312,28 @@ def case_c_directive_only_first_chunk():
     return fails
 
 
+def case_d_oversized_result_has_a_delivery_budget():
+    """A malformed result must not monopolize the Discord delivery loop.
+
+    The live incident produced 512 sequential sends from one 955 KB result,
+    leaving the owner's stop request queued behind the flood. Four sends keep
+    a useful preview while bounding how long one result can occupy the loop.
+    """
+    fails = []
+    ch = _MockChannel(channel_id=888999000)
+    body = "oversized-review-output\n" * 1200
+    sent = asyncio.run(_run_one_poll_iteration("test-task-d", ch, body))
+    if len(sent) != 4:
+        fails.append(f"d) oversized result should use exactly 4 sends (got {len(sent)})")
+        return fails
+    if not (sent[0]["content"] or "").startswith("oversized-review-output"):
+        fails.append("d) first send should retain the beginning of the result")
+    notice = sent[-1]["content"] or ""
+    if "truncated" not in notice.lower() or "suppressed" not in notice.lower():
+        fails.append(f"d) final send should explain truncation (got {notice!r})")
+    return fails
+
+
 def test_resolver_bindings_restored_after_the_context() -> int:
     """Protect the late-import restore sweep with an activated assertion.
 
@@ -358,7 +380,7 @@ def _workspace_fingerprint(ws) -> dict:
         try:
             # CONTENT hash under results/ — that subtree holds the owner's
             # archived task evidence, and the fixture task ids are FIXED
-            # (test-task-a/b/c), so a destructive OVERWRITE of an existing file
+            # (test-task-a/b/c/d), so a destructive OVERWRITE of an existing file
             # is the realistic collision (john-the-dev, #2619). A same-size
             # rewrite is exactly what a name-only or size-only check misses.
             # (size, mtime) elsewhere keeps a whole-workspace scan cheap.
@@ -426,6 +448,7 @@ def main():
         ("a-directive-present-constructs-reference", case_a_directive_present_constructs_reference),
         ("b-no-directive-no-reference", case_b_no_directive_no_reference),
         ("c-directive-only-first-chunk", case_c_directive_only_first_chunk),
+        ("d-oversized-result-has-a-delivery-budget", case_d_oversized_result_has_a_delivery_budget),
     ]
     failures = []
     with _bridge_writes_redirected() as (_tmp, _redirected):

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -313,12 +313,7 @@ def case_c_directive_only_first_chunk():
 
 
 def case_d_oversized_result_has_a_delivery_budget():
-    """A malformed result must not monopolize the Discord delivery loop.
-
-    The live incident produced 512 sequential sends from one 955 KB result,
-    leaving the owner's stop request queued behind the flood. Four sends keep
-    a useful preview while bounding how long one result can occupy the loop.
-    """
+    """Oversized results must reserve the fourth send for truncation notice."""
     fails = []
     ch = _MockChannel(channel_id=888999000)
     body = "oversized-review-output\n" * 1200

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -313,7 +313,7 @@ def case_c_directive_only_first_chunk():
 
 
 def case_d_oversized_result_has_a_delivery_budget():
-    """Oversized results must reserve the fourth send for truncation notice."""
+    """Oversized results use three previews plus a truncation notice."""
     fails = []
     ch = _MockChannel(channel_id=888999000)
     body = "oversized-review-output\n" * 1200

--- a/tests/discord-chunker.test.py
+++ b/tests/discord-chunker.test.py
@@ -74,19 +74,24 @@ dm = _load("dm_result", REPO / "src" / "dm-result.py")
 
 
 def _run_against(mod, label):
+    # The bridge's network-facing alias is intentionally bounded. Exercise the
+    # lossless primitive here so these golden checks remain about fence-safe
+    # reassembly; dm-result.py still exposes only its lossless alias.
+    chunk = getattr(mod, "_chunk_for_discord_unbounded", mod._chunk_for_discord)
+
     # Test 1: empty/short
-    assert list(mod._chunk_for_discord("")) == []
-    assert list(mod._chunk_for_discord("hi")) == ["hi"]
+    assert list(chunk("")) == []
+    assert list(chunk("hi")) == ["hi"]
 
     # Test 2: long plain text → multiple chunks, all <= max_len
     src = "\n".join(["line " + str(i) * 40 for i in range(200)])
-    chunks = list(mod._chunk_for_discord(src, max_len=300))
+    chunks = list(chunk(src, max_len=300))
     assert all(len(c) <= 300 for c in chunks), f"{label}: chunk too long"
     assert len(chunks) > 1
 
     # Test 3: code block spanning multiple chunks preserves opener with language tag
     src = "intro\n```python\n" + ("x = 1\n" * 400) + "```\nouter"
-    chunks = list(mod._chunk_for_discord(src, max_len=300))
+    chunks = list(chunk(src, max_len=300))
     assert len(chunks) >= 3, f"{label}: expected multi-chunk, got {len(chunks)}"
     # All but last must end with ``` (closer)
     for i, c in enumerate(chunks[:-1]):
@@ -96,7 +101,7 @@ def _run_against(mod, label):
 
     # Test 4: print("```") inside fenced block must NOT close the fence early
     src = '```python\nprint("```")\nx = 1\nmore = 2\n```'
-    chunks = list(mod._chunk_for_discord(src))
+    chunks = list(chunk(src))
     # Single chunk — but more important: fence is balanced (one opener, one closer)
     full = "\n".join(chunks)
     fence_lines = [
@@ -109,7 +114,7 @@ def _run_against(mod, label):
 
     # Test 5: nested 4-tick outer fence preserved (Markdown allows ```` to wrap ```)
     src = "````markdown\n```python\ninner\n```\nstill outer\n````"
-    chunks = list(mod._chunk_for_discord(src))
+    chunks = list(chunk(src))
     # Outer ```` opener present in first chunk
     assert "````markdown" in chunks[0], f"{label}: outer 4-tick opener lost"
 
@@ -131,7 +136,7 @@ def _run_against(mod, label):
 
     # Test 7: tilde fence closes with tildes (not backticks) — token-kind preservation
     src = "~~~python\n" + ("x = 1\n" * 400) + "~~~"
-    chunks = list(mod._chunk_for_discord(src, max_len=300))
+    chunks = list(chunk(src, max_len=300))
     assert len(chunks) >= 2
     # First chunk closes with ~~~ (matching opener kind), not ```
     assert chunks[0].rstrip().endswith("~~~"), (
@@ -141,9 +146,28 @@ def _run_against(mod, label):
     print(f"[{label}] all 7 cases OK")
 
 
+def _run_delivery_budget_cases():
+    assert list(bridge._chunk_for_discord("hi")) == ["hi"]
+
+    chunks = list(bridge._chunk_for_discord("oversized\n" * 100, max_len=40, max_chunks=4))
+    assert len(chunks) == 4, f"budget: expected 4 sends, got {len(chunks)}"
+    assert chunks[0].startswith("oversized"), "budget: preview lost the beginning"
+    assert chunks[-1] == bridge.DISCORD_TRUNCATION_NOTICE
+
+    try:
+        list(bridge._chunk_for_discord("x", max_chunks=0))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("budget: max_chunks=0 should raise ValueError")
+
+    print("[discord delivery budget] all 3 cases OK")
+
+
 def main():
     _run_against(bridge, "discord-bridge.py")
     _run_against(dm, "dm-result.py")
+    _run_delivery_budget_cases()
     print("All chunker tests passed.")
 
 


### PR DESCRIPTION
## What changed, and why?

Discord delivery now has a hard four-send budget per payload. Oversized output sends three fence-safe preview chunks followed by one explicit truncation notice. Previously, one malformed 955,818-byte review result expanded into 512 sequential channel posts and kept the owner's stop request queued until delivery finished.

The low-level chunker remains lossless; the budget is applied only at Discord network-send call sites.

## Review first

- `src/discord-bridge.py`: the centrally budgeted `_chunk_for_discord` network alias and lossless `_chunk_for_discord_unbounded` primitive.
- `tests/discord-bridge-reply-directive.test.py`: behavioral `poll_results` regression using a mock Discord channel.

## User behavior proved

An arbitrarily large result can no longer monopolize the Discord bridge. Normal one-to-four-chunk replies remain unchanged; larger replies use at most four sends and tell the recipient that additional content was suppressed.

## Documentation consistency

N/A — this is an internal safety bound, not a setup/configuration or advertised capability change. There is no canonical Discord behavior document in `docs/catalog.json`.

## Before / after evidence

Parent `73e7df2cb833b945e392a85c86188d573ac8f780` with the regression added:

```text
$ python3 tests/discord-bridge-reply-directive.test.py
  ✗ case d-oversized-result-has-a-delivery-budget
      d) oversized result should use exactly 4 sends (got 16)
...
1 failure(s)
```

HEAD `89270f66eaa8a17ba2a02bc8e4a7c28ce5bc9b81`:

```text
$ python3 tests/discord-bridge-reply-directive.test.py
  ✓ case a-directive-present-constructs-reference
  ✓ case b-no-directive-no-reference
  ✓ case c-directive-only-first-chunk
  Replied: oversized-review-output
oversized-review-output
oversized-review-output
oversize...
  ✓ case d-oversized-result-has-a-delivery-budget
  ✓ observability event redirected into the throwaway tree (events-2026-08-07.jsonl)
  ✓ resolver bindings restored after the context (2 lazy consumers checked)
  ✓ live workspace untouched (1 paths compared, union of before+after)

All [reply: <id>] directive invariants hold.
```

## Live post-restart round trip

Ran the bridge from a detached worktree pinned to the live workspace at exact commit `89270f66eaa8a17ba2a02bc8e4a7c28ce5bc9b81`. Replayed the exact archived incident result (9,469 lines / 955,818 bytes) through `poll_results`, routed to the owner's DM.

```text
$ wc -lc workspace/results/task-1786140039123.txt
    9469  955818 workspace/results/task-1786140039123.txt

$ tail workspace/logs/discord-budget-live.log
Discord bridge ready: rui-sutando-codex#0032
  Replied: Mechanical checks (review-checks.sh):
review-checks: PASS (hardcoded-paths clean...

$ python3 src/discord-read.py 1526767280925577328
[2026-08-07T22:01:08] rui-sutando-codex: Mechanical checks (review-checks.sh): ...
[2026-08-07T22:01:08] rui-sutando-codex: +        "bodhi-realtime-agent": ...
[2026-08-07T22:01:09] rui-sutando-codex: "integrity": "sha512-bGdAIrZ0..." ...
[2026-08-07T22:01:09] rui-sutando-codex: ⚠️ Result truncated: additional content was suppressed to keep Discord responsive.

$ cat workspace/state/discord-pending-replies.json
{}
$ find workspace/results/archive -name task-1786140039123.txt
workspace/results/archive/2026-08/task-1786140039123.txt
```

Observed: exactly four messages over about one second, result archived, queue drained, heartbeat fresh. The normal-checkout Discord bridge was restored afterward and reported `Discord bridge ready: rui-sutando-codex#0032`.

## Tests run

```text
python3 tests/discord-bridge-reply-directive.test.py       PASS
python3 tests/discord-chunker.test.py                      PASS (14 fence cases + 3 budget cases)
python3 tests/message-chunking.test.py                     PASS (33 golden checks)
python3 tests/discord-bridge-file-markers.test.py          PASS
python3 tests/discord-bridge-delivery-failure-visible.test.py PASS
python3 tests/discord-bridge-delivery-sentinel.test.py     PASS (9 tests)
python3 tests/bridge-audit-wiring.test.py                  PASS
python3 tests/bridge-timeout-guards.test.py                PASS
python3 -m py_compile src/discord-bridge.py                PASS
bash scripts/review-checks.sh < <(git diff origin/main...HEAD) PASS (hardcoded-paths clean)
git diff --check                                           PASS
diff-cover coverage.xml --compare-branch=origin/main --fail-under=95 PASS (17/17 changed executable lines, 100%)
```

## Edge cases checked

- Empty/short and ordinary multi-chunk replies are unchanged.
- Only the first chunk carries a Discord reply reference.
- Oversized results retain their beginning and end with the truncation notice.
- Markdown fences stay balanced across preview chunks.
- File markers, failure reporting, delivery sentinels, and audit writes remain green.

## Stack / migrations / risks / rollback

- Stack: N/A; based directly on `origin/main`.
- Migrations/config/permissions: none.
- Risk: long legitimate Discord output is now intentionally truncated after three preview chunks. Full result files continue through the existing archive path.
- Rollback: revert `89270f66`.

## Known gaps

The review wrapper can still produce unnecessarily verbose local results. That is a separate producer-quality issue; this bridge-level bound prevents any current or future producer from recreating the channel flood.