### PR TITLE
fix(test): a 2s pipe-drain budget flaked the workstream worker shutdown test

### DIFF
--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -18,6 +18,9 @@ from unittest import mock
 
 
 REPO = Path(__file__).resolve().parents[1]
+# Guards a hang, not promptness — a leaked worker holds stdout open forever, so any
+# bound catches it. Every timing claim here is a separate assert; keep this generous.
+SHUTDOWN_DRAIN_TIMEOUT_S = 30
 WORKER = REPO / "skills" / "task-workstream-sessions" / "scripts" / "session-worker.py"
 spec = importlib.util.spec_from_file_location("workstream_session_worker", WORKER)
 worker = importlib.util.module_from_spec(spec)
@@ -377,7 +380,7 @@ def test_slow_handler_does_not_block_the_next_task_event() -> None:
             assert elapsed < 1.0, f"second task event was blocked for {elapsed:.2f}s"
         finally:
             os.killpg(process.pid, signal.SIGTERM)
-            process.communicate(timeout=2)
+            process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
 
 
 def test_watcher_bounds_provider_backlog_and_drains_every_receipt_once() -> None:
@@ -477,7 +480,7 @@ lock.rmdir()
             assert int((state / "maximum").read_text()) <= 2
         finally:
             os.killpg(process.pid, signal.SIGTERM)
-            process.communicate(timeout=2)
+            process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
 
 
 def test_overlapping_watcher_preserves_live_claim_and_owner_shutdown_falls_back() -> None:
@@ -544,12 +547,12 @@ def test_overlapping_watcher_preserves_live_claim_and_owner_shutdown_falls_back(
             assert calls.read_text().splitlines() == ["provider"]
 
             os.killpg(overlap.pid, signal.SIGTERM)
-            overlap.communicate(timeout=2)
+            overlap.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
             overlap = None
             assert claim.is_file(), "non-owner cleanup must not remove another watcher's claim"
 
             os.killpg(owner.pid, signal.SIGTERM)
-            owner_stdout, _ = owner.communicate(timeout=2)
+            owner_stdout, _ = owner.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
             owner_events = [
                 line.removeprefix("TASK_FILE: ")
                 for line in owner_stdout.splitlines()
@@ -563,10 +566,10 @@ def test_overlapping_watcher_preserves_live_claim_and_owner_shutdown_falls_back(
         finally:
             if overlap is not None and overlap.poll() is None:
                 os.killpg(overlap.pid, signal.SIGKILL)
-                overlap.communicate(timeout=2)
+                overlap.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
             if owner.poll() is None:
                 os.killpg(owner.pid, signal.SIGKILL)
-                owner.communicate(timeout=2)
+                owner.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
 
 
 def _assert_shutdown_falls_back_without_surviving_workers() -> None:
@@ -621,7 +624,7 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
             assert sorted(path.name for path in claims.glob("task-*.txt")) == names
 
             os.killpg(process.pid, signal.SIGTERM)
-            stdout, stderr = process.communicate(timeout=2)
+            stdout, stderr = process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
             process = None
             remaining_claims = sorted(path.name for path in claims.glob("task-*.txt"))
             fallbacks = workspace / "state" / "task-event-handler-fallbacks"
@@ -652,7 +655,7 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
         finally:
             if process is not None and process.poll() is None:
                 os.killpg(process.pid, signal.SIGKILL)
-                process.communicate(timeout=2)
+                process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
 
 
 def test_shutdown_falls_back_without_surviving_workers() -> None:
@@ -718,7 +721,7 @@ def test_codex_notifier_dispatches_each_isolated_task_once_without_waiting() -> 
             assert time.monotonic() - started < 1.0
         finally:
             os.killpg(process.pid, signal.SIGTERM)
-            process.communicate(timeout=2)
+            process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
 
 
 def test_codex_notifier_never_submits_a_watcher_claim_to_live_core() -> None:
@@ -797,7 +800,7 @@ def test_codex_notifier_never_submits_a_watcher_claim_to_live_core() -> None:
             assert handler_log.read_text().splitlines() == ["task-z-isolated.txt"]
         finally:
             os.killpg(process.pid, signal.SIGTERM)
-            process.communicate(timeout=2)
+            process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
 
 
 def test_runtime_wiring_is_optional_and_adapter_injected() -> None:


### PR DESCRIPTION
## Why

`tests/task-workstream-session-worker.test.py` fails intermittently in CI with an unhandled `subprocess.TimeoutExpired` — not an assertion, so the output is a traceback rather than a diagnosis:

```text
File ".../task-workstream-session-worker.test.py", line 835, in <module>
File ".../task-workstream-session-worker.test.py", line 660, in test_shutdown_falls_back_without_surviving_workers
File ".../task-workstream-session-worker.test.py", line 624, in _assert_shutdown_falls_back_without_surviving_workers
subprocess.TimeoutExpired: Command '[... src/watch-tasks-stream.sh ...]' timed out after 2 seconds
```

Seen twice today with a byte-identical call chain — **including once on `main` with no PR involved**, so it is not branch-specific:

| where | sha | run | when (UTC) |
|---|---|---|---|
| `main` | `0d24cf23` | [31238841984](https://github.com/sonichi/sutando/actions/runs/31238841984) | 2026-08-08 04:16 |
| #2749 | `751680a1` | [31279212186](https://github.com/sonichi/sutando/actions/runs/31279212186) | 2026-08-08 21:34 |

## The measurement

The wait is `communicate()` after `killpg(SIGTERM)`. It blocks on **stdout EOF**, which arrives only once every child that inherited the pipe is gone — so its duration tracks runner contention, not the watcher's own exit. Measured on an idle dev machine, 30 iterations:

```text
communicate() waits: n=30 min=0.312s median=0.370s p95=0.409s max=0.409s  BUDGET=2.000s
margin (budget/max) = 4.9x
```

`test_shutdown_falls_back_without_surviving_workers` calls the helper **ten times per run**, so each CI run takes ten independent draws against that 4.9x margin. A loaded runner closes it.

## Why raising the bound weakens nothing

**No site used the `communicate()` timeout as its assertion** — `grep -nE 'TimeoutExpired|except .*Timeout'` over the file on `origin/main` returns **zero**, so nothing catches it and nothing measures with it. That is the checkable form of the claim, and it is the one that matters: if any site had asserted promptness *by* the timeout, raising it to 30s would have silently weakened the test instead of de-flaking it. Every timing claim in this file is instead a **separate** check — `assert elapsed < 1.0` at the call sites, and a `deadline = time.monotonic() + 1` loop asserting the process group is dead. The `communicate()` bound is not a deadline; it is the guard that turns a leaked worker holding stdout from a hang into a failure. A genuine leak never closes the pipe, so 30s catches it exactly as 2s did, only later.

Note the current value also fails *before* the process-group assertion is reached, so a correct-but-slow shutdown reports as a raw `TimeoutExpired` instead of the real check.

## Why one constant instead of patching line 624

The same policy was spelled as a bare `2` at all **ten** drain sites. The site that flaked first is not the defect — the other nine carry the identical margin, and patching only the observed one leaves the duplication that produced it. Only 624 has actually been seen failing.

## After

```text
budget now: 30 s
targeted helper: 30 iterations, 0 failures
```

## Not addressed here

To keep this to one concern: on macOS this file *also* fails at `test_watcher_bounds_provider_backlog_and_drains_every_receipt_once`. That reproduces unchanged on `origin/main` at `ee245073` (baseline line 465 / this branch line 468 — same assertion, offset by the 3 added lines), so it predates this branch and is a separate issue.

@sonichi flagging for you — small test-only change, but it is currently red on `main`.



## Coverage and worst case (checkable)

Scoped to the one file this PR touches, `tests/task-workstream-session-worker.test.py`:

```
bare timeout=2 on origin/main   10
removed by this diff            10
added references                11   (10 call sites + SHUTDOWN_DRAIN_TIMEOUT_S = 30)
```

A partial sweep would have left the flake live, so the count is part of the claim.

Two of the ten — `:566` and `:569` — carry **no** assert at all: they sit in a `finally:` immediately
after `os.killpg(..., SIGKILL)`. Those are the strongest case for the change rather than exceptions to
it, since a 2s bound on a post-SIGKILL reap was never measuring anything.

**Worst case, stated plainly:** 30s per drain across 10 sites is up to **300s added before a real hang
surfaces**, and I could not find a per-file CI timeout in this repo to bound it. A genuine leak still
fails the test — just later. Test-only; no production path is touched.

*Known follow-up, deliberately out of scope:* one constant covers both a graceful SIGTERM drain and a
post-SIGKILL reap. The reap should complete in milliseconds and arguably wants a tighter dedicated
bound so a kernel-level stall surfaces fast. Kept out of this de-flaking change.
