### PR TITLE
feat(health-check): detect the notes/ divergence the #1266 probe cannot reach

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -50,7 +50,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 # bends here rather than the guard.
 from git_binary import git_argv  # noqa: E402
 from git_binary import GitUnavailable  # noqa: E402
-from util_paths import _host_label, claude_home_path, claude_project_slug, shared_personal_path  # noqa: E402
+from util_paths import _host_label, claude_home_path, claude_project_slug, legacy_dotted_workspace, shared_personal_path  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 from sutando_config import resolve_core_runtime  # noqa: E402
 from cron_entry_digest import digest_map, drifted  # noqa: E402
@@ -5717,6 +5717,68 @@ def check_notes_split_brain() -> "dict | None":
     }
 
 
+
+
+def check_legacy_notes_divergence() -> "dict | None":
+    """Detect a canonical-vs-legacy notes/ divergence the #1266 probe cannot see.
+
+    `check_notes_split_brain` compares <repo>/notes against <workspace>/notes.
+    A host whose repo has no notes/ dir clears that guard and goes quiet, while the
+    pre-v0.8 <legacy workspace>/notes (often a symlink into the memory-sync clone)
+    keeps taking writes. Measured on one host:
+    91 specs canonical, 105 legacy, 83 shared — bidirectional, and the newest
+    canonical spec was 7 days older than the newest legacy one.
+
+    Recursive and extension-agnostic on purpose: the #1266 probe globs top-level
+    `*.md`, and this divergence lives in `sutando-wire/episode-specs/*.yaml`,
+    so an .md-only top-level scan reports clean twice over.
+    """
+    ws_notes = Path(shared_personal_path("notes", WORKSPACE_DIR))
+    legacy_notes = legacy_dotted_workspace() / "notes"
+    if not ws_notes.exists() or not legacy_notes.exists():
+        return None
+    try:
+        if ws_notes.resolve() == legacy_notes.resolve():
+            return None
+    except OSError:
+        return None
+
+    def _rel(root: Path) -> "set[str]":
+        out = set()
+        try:
+            for p in root.rglob("*"):
+                if p.is_file():
+                    out.add(str(p.relative_to(root)))
+        except OSError:
+            pass
+        return out
+
+    a, b = _rel(ws_notes), _rel(legacy_notes)
+    only_ws, only_legacy = a - b, b - a
+    if not only_ws and not only_legacy:
+        return None
+
+    # Deliberately NO "which side is live" verdict. A whole-tree newest-mtime is
+    # dominated by whichever file was touched last for any reason, so it can read
+    # "canonical is newer" while the producer for the subtree that matters writes
+    # to the legacy side — measured exactly that way on one host (canonical newer
+    # by 0.0d over the whole tree, 7 days OLDER on episode-specs alone). The
+    # counts are checkable; that inference is not, at this granularity.
+    return {
+        "name": "legacy-notes-divergence",
+        "status": "warn",
+        "detail": (
+            f"notes/ has diverged from the pre-v0.8 {legacy_notes}: "
+            f"{len(only_ws)} file(s) only in the canonical workspace, "
+            f"{len(only_legacy)} only in the legacy tree, {len(a & b)} shared. "
+            f"Neither side is a superset, so pointing a consumer at either one "
+            f"loses files. Decide which tree is authoritative before 'fixing' "
+            f"any path that reads notes/, and compare the SUBTREE you care about "
+            f"— a whole-tree mtime does not tell you which side is still live."
+        ),
+    }
+
+
 def _drop_launcher_parents(pids: list) -> list:
     """Collapse a launcher+child pair to the child that is the real process.
 
@@ -6910,6 +6972,11 @@ def run_all_checks() -> list[dict]:
     _notes_sb = check_notes_split_brain()
     if _notes_sb:
         checks.append(_notes_sb)
+
+    # Sibling of the above, for the pair it cannot reach (see its docstring).
+    _legacy_nd = check_legacy_notes_divergence()
+    if _legacy_nd:
+        checks.append(_legacy_nd)
 
     # Memory sync
     checks.append(check_memory_sync())

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5763,23 +5763,42 @@ def check_legacy_notes_divergence() -> "dict | None":
     legacy_notes = legacy_dotted_workspace() / "notes"
     if not ws_notes.exists() or not legacy_notes.exists():
         return None
+    # A read failure must not read as "no divergence": this warning exists to stop a
+    # cleanup discarding the only copy, so silence is the one unsafe direction.
+    def _unreadable(what: str, exc: OSError) -> "dict":
+        return {
+            "name": "legacy-notes-divergence",
+            "status": "warn",
+            "detail": (
+                f"could not compare the two notes/ trees — {what}: {exc}. This is NOT "
+                f"a clean bill of health: the probe exists to catch legacy-only files "
+                f"that a cleanup would destroy, and it could not read them. Resolve the "
+                f"access error before deleting or repointing either tree "
+                f"(canonical {ws_notes}, legacy {legacy_notes})."
+            ),
+        }
+
     try:
         if ws_notes.resolve() == legacy_notes.resolve():
             return None
-    except OSError:
-        return None
+    except OSError as exc:
+        return _unreadable("resolving one of them failed", exc)
 
-    def _rel(root: Path) -> "dict[str, Path]":
+    def _rel(root: Path) -> "dict[str, Path] | None":
+        """Map relative path -> file. None means the scan FAILED, never "empty"."""
         out = {}
         try:
             for p in root.rglob("*"):
                 if p.is_file():
                     out[str(p.relative_to(root))] = p
         except OSError:
-            pass
+            return None
         return out
 
     a, b = _rel(ws_notes), _rel(legacy_notes)
+    for label, scanned in (("the canonical tree", a), ("the legacy tree", b)):
+        if scanned is None:
+            return _unreadable(f"enumerating {label} failed", OSError("scan incomplete"))
     only_ws, only_legacy = set(a) - set(b), set(b) - set(a)
     # A shared PATH is not a shared FILE. Comparing name sets alone reports healthy
     # when both trees hold the same path with different bytes — measured 57 of 1056.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5732,6 +5732,15 @@ def check_legacy_notes_divergence() -> "dict | None":
     Recursive and extension-agnostic on purpose: the #1266 probe globs top-level
     `*.md`, and this divergence lives in `sutando-wire/episode-specs/*.yaml`,
     so an .md-only top-level scan reports clean twice over.
+
+    Reports counts, and NAMES the legacy-only paths — never a "which side is live"
+    verdict. A whole-tree newest-mtime is dominated by whichever file was touched
+    last for any reason: on one host it read "canonical newer by 0.0d" while the
+    subtree that mattered was 7 days older. And a bare ratio invites dismissal —
+    on a second host "2 of 11,442" was first read as nothing to worry about, when
+    those 2 were the files a "delete the legacy tree" cleanup would destroy with
+    no copy anywhere. Legacy-only, not both directions: canonical is the tree the
+    resolver reaches, so a canonical-only file is merely unsynced.
     """
     ws_notes = Path(shared_personal_path("notes", WORKSPACE_DIR))
     legacy_notes = legacy_dotted_workspace() / "notes"
@@ -5758,23 +5767,26 @@ def check_legacy_notes_divergence() -> "dict | None":
     if not only_ws and not only_legacy:
         return None
 
-    # Deliberately NO "which side is live" verdict. A whole-tree newest-mtime is
-    # dominated by whichever file was touched last for any reason, so it can read
-    # "canonical is newer" while the producer for the subtree that matters writes
-    # to the legacy side — measured exactly that way on one host (canonical newer
-    # by 0.0d over the whole tree, 7 days OLDER on episode-specs alone). The
-    # counts are checkable; that inference is not, at this granularity.
+    # Non-dotfiles first: an alphabetical sample leads with .DS_Store and buries
+    # the paths worth acting on. Counts stay over the FULL set.
+    ranked = sorted(only_legacy, key=lambda p: (Path(p).name.startswith("."), p))
+    named = ", ".join(ranked[:3])
+    more = f" … and {len(only_legacy) - 3} more" if len(only_legacy) > 3 else ""
+    at_risk = (
+        f" LEGACY-ONLY (no copy in the canonical tree): {named}{more}."
+        if only_legacy else ""
+    )
     return {
         "name": "legacy-notes-divergence",
         "status": "warn",
         "detail": (
             f"notes/ has diverged from the pre-v0.8 {legacy_notes}: "
             f"{len(only_ws)} file(s) only in the canonical workspace, "
-            f"{len(only_legacy)} only in the legacy tree, {len(a & b)} shared. "
-            f"Neither side is a superset, so pointing a consumer at either one "
-            f"loses files. Decide which tree is authoritative before 'fixing' "
-            f"any path that reads notes/, and compare the SUBTREE you care about "
-            f"— a whole-tree mtime does not tell you which side is still live."
+            f"{len(only_legacy)} only in the legacy tree, {len(a & b)} shared."
+            f"{at_risk} Neither side is a superset, so pointing a consumer at "
+            f"either one loses files. Decide which tree is authoritative before "
+            f"'fixing' any path that reads notes/, and compare the SUBTREE you "
+            f"care about — a whole-tree mtime does not say which side is live."
         ),
     }
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5719,6 +5719,23 @@ def check_notes_split_brain() -> "dict | None":
 
 
 
+def _file_digest(path: Path) -> str:
+    """sha256 of a file, or a sentinel that can never equal another file's digest.
+
+    Read errors must NOT make two files compare equal — that would silently turn an
+    unreadable pair into "identical" and hide the divergence this probe reports.
+    """
+    import hashlib
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return f"<unreadable:{path}>"
+
+
 def check_legacy_notes_divergence() -> "dict | None":
     """Detect a canonical-vs-legacy notes/ divergence the #1266 probe cannot see.
 
@@ -5752,23 +5769,24 @@ def check_legacy_notes_divergence() -> "dict | None":
     except OSError:
         return None
 
-    def _rel(root: Path) -> "set[str]":
-        out = set()
+    def _rel(root: Path) -> "dict[str, Path]":
+        out = {}
         try:
             for p in root.rglob("*"):
                 if p.is_file():
-                    out.add(str(p.relative_to(root)))
+                    out[str(p.relative_to(root))] = p
         except OSError:
             pass
         return out
 
     a, b = _rel(ws_notes), _rel(legacy_notes)
-    only_ws, only_legacy = a - b, b - a
-    if not only_ws and not only_legacy:
+    only_ws, only_legacy = set(a) - set(b), set(b) - set(a)
+    # A shared PATH is not a shared FILE. Comparing name sets alone reports healthy
+    # when both trees hold the same path with different bytes — measured 57 of 1056.
+    differing = sorted(r for r in (set(a) & set(b)) if _file_digest(a[r]) != _file_digest(b[r]))
+    if not only_ws and not only_legacy and not differing:
         return None
 
-    # Non-dotfiles first: an alphabetical sample leads with .DS_Store and buries
-    # the paths worth acting on. Counts stay over the FULL set.
     ranked = sorted(only_legacy, key=lambda p: (Path(p).name.startswith("."), p))
     named = ", ".join(ranked[:3])
     more = f" … and {len(only_legacy) - 3} more" if len(only_legacy) > 3 else ""
@@ -5776,15 +5794,32 @@ def check_legacy_notes_divergence() -> "dict | None":
         f" LEGACY-ONLY (no copy in the canonical tree): {named}{more}."
         if only_legacy else ""
     )
+    # Derived from the computed sets, never asserted: a hardcoded "neither side is a
+    # superset" is FALSE when one is, and would tell cleanup the opposite of the truth.
+    if only_ws and only_legacy:
+        shape = "Neither side is a superset, so pointing a consumer at either one loses files."
+    elif only_legacy:
+        shape = (f"The legacy tree is a strict superset by name — the canonical one is missing "
+                 f"{len(only_legacy)} file(s).")
+    elif only_ws:
+        shape = (f"The canonical workspace is a strict superset by name — the legacy one is "
+                 f"missing {len(only_ws)} file(s).")
+    else:
+        shape = "Names match on both sides; the divergence is entirely in file CONTENT."
+    content = (
+        f" {len(differing)} shared path(s) differ in CONTENT, so deleting either tree "
+        f"loses bytes even where the names match (e.g. {', '.join(differing[:2])})."
+        if differing else ""
+    )
     return {
         "name": "legacy-notes-divergence",
         "status": "warn",
         "detail": (
             f"notes/ has diverged from the pre-v0.8 {legacy_notes}: "
             f"{len(only_ws)} file(s) only in the canonical workspace, "
-            f"{len(only_legacy)} only in the legacy tree, {len(a & b)} shared."
-            f"{at_risk} Neither side is a superset, so pointing a consumer at "
-            f"either one loses files. Decide which tree is authoritative before "
+            f"{len(only_legacy)} only in the legacy tree, "
+            f"{len(set(a) & set(b))} shared ({len(differing)} of them differing)."
+            f"{at_risk}{content} {shape} Decide which tree is authoritative before "
             f"'fixing' any path that reads notes/, and compare the SUBTREE you "
             f"care about — a whole-tree mtime does not say which side is live."
         ),

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -89,9 +89,8 @@ def _workspace_root() -> Path:
             pass
         # Last-ditch default: the canonical post-v0.8 home-dir location
         # (~/sutando-workspace, matching sutando_config.py resolve_workspace) —
-        # NOT the pre-v0.8 dotted ~/.sutando/workspace, which is no longer
-        # RESOLVED to. It may still exist on disk and still be taking writes;
-        # health-check's legacy-notes-divergence probe reports that case.
+        # The pre-v0.8 dotted path is no longer RESOLVED to, but may still exist
+        # and still take writes — health-check reports that divergence.
         return Path.home() / "sutando-workspace"
 
 

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -89,8 +89,17 @@ def _workspace_root() -> Path:
             pass
         # Last-ditch default: the canonical post-v0.8 home-dir location
         # (~/sutando-workspace, matching sutando_config.py resolve_workspace) —
-        # NOT the pre-v0.8 dotted ~/.sutando/workspace, which no longer exists.
+        # NOT the pre-v0.8 dotted ~/.sutando/workspace, which is no longer
+        # RESOLVED to. It may still exist on disk and still be taking writes;
+        # health-check's legacy-notes-divergence probe reports that case.
         return Path.home() / "sutando-workspace"
+
+
+def legacy_dotted_workspace() -> Path:
+    """The pre-v0.8 dotted workspace dir. NOT resolved to any more — but it can
+    still exist on disk and still take writes, which is why one file owns the
+    literal instead of each caller writing it fresh."""
+    return Path.home() / ".sutando" / "workspace"
 
 
 def _host_label() -> str:

--- a/tests/health-check-legacy-notes-divergence.test.py
+++ b/tests/health-check-legacy-notes-divergence.test.py
@@ -33,16 +33,21 @@ def check(label, cond, extra=""):
 
 
 def _probe(ws_files, legacy_files, *, same_dir=False):
-    """Build two notes trees and run the probe against them."""
+    """Build two notes trees and run the probe against them.
+
+    A list entry may be "path" (contents "x") or a ("path", "contents") pair, so a
+    fixture can put the SAME path on both sides with DIFFERENT bytes.
+    """
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         ws = root / "canonical"
         legacy_ws = root / "legacy"
         for base, files in ((ws / "notes", ws_files), (legacy_ws / "notes", legacy_files)):
-            for rel in files:
+            for entry in files:
+                rel, body = entry if isinstance(entry, tuple) else (entry, "x")
                 p = base / rel
                 p.parent.mkdir(parents=True, exist_ok=True)
-                p.write_text("x")
+                p.write_text(body)
         target = ws / "notes" if same_dir else legacy_ws / "notes"
         with patch.object(hc, "WORKSPACE_DIR", ws), \
              patch.object(hc, "legacy_dotted_workspace", lambda: target.parent):
@@ -59,6 +64,28 @@ check("names the shared count too", r is not None and "1 shared" in r["detail"],
 check("claims no live-side verdict from a whole-tree mtime",
       r is not None and "newer by" not in r["detail"], str(r))
 
+# A name-set comparison reports healthy when both trees hold one path with
+# different bytes, so deleting either side loses bytes it called fine.
+print("\nsame path, DIFFERENT bytes (the P1):")
+r = _probe([("sutando-wire/episode-specs/a.yaml", "a: 1\n")],
+           [("sutando-wire/episode-specs/a.yaml", "a: 2\n")])
+check("identical NAMES but differing content still warns", r is not None, str(r))
+check("...and says how many differ",
+      r is not None and "1 shared path(s) differ in CONTENT" in r["detail"], str(r))
+check("...and names one of them",
+      r is not None and "episode-specs/a.yaml" in r["detail"], str(r))
+check("...and reports 0 in each only-side (the sets really are equal)",
+      r is not None and "0 file(s) only in the canonical" in r["detail"]
+      and "0 only in the legacy" in r["detail"], str(r))
+check("...and does NOT claim a superset, since names match on both sides",
+      r is not None and "strict superset" not in r["detail"]
+      and "Neither side is a superset" not in r["detail"], str(r))
+
+# An unreadable file must never compare EQUAL to another — that would convert a
+# read failure into a silent "identical".
+check("the digest sentinel cannot collide with a real digest",
+      hc._file_digest(Path("/nonexistent/x")) != hc._file_digest(Path("/nonexistent/y")))
+
 print("\nsilence where it should be silent:")
 r = _probe(["a.md", "b.md"], ["a.md", "b.md"])
 check("identical trees → no warn", r is None, str(r))
@@ -68,15 +95,11 @@ check("legacy notes/ dir absent → no warn (nothing to diverge from)", r is Non
 
 r = _probe(["a.md", "b.md"], ["a.md", "b.md"], same_dir=True)
 check("same resolved dir → no warn (not two trees)", r is None, str(r))
-# NOTE: that case passes even with the resolve() guard removed, because two views
-# of one directory also produce an empty diff. The guard is a cheap short-circuit,
-# not a behavioural gate, so it is deliberately NOT asserted as one — a mutation
-# that deletes it does not change any output, and a test claiming otherwise would
-# be asserting its own wishful thinking.
+# Deleting the resolve() guard changes no output here: two views of one dir also
+# give an empty diff. It is a short-circuit, so it is NOT asserted as a gate.
 
-# Pro measured this on a second host and read "2 of 11,442" as nothing to worry
-# about. Counting is what made that wrong: those 2 are the files a "delete the
-# legacy tree" cleanup destroys. So the legacy-only paths must be NAMED.
+# A bare ratio invites dismissal, so the legacy-only paths must be NAMED — they
+# are the ones a "delete the legacy tree" cleanup destroys.
 print("\nthe at-risk paths are named, not just counted:")
 r = _probe(["keep.md"], ["keep.md", "sutando-wire/peg-signals/2026-08-05.md"])
 check("names the legacy-only path",
@@ -108,14 +131,27 @@ r = _probe(["a.md"], ["a.md", "extra.yaml"])
 check("legacy is a strict superset → still warns", r is not None, str(r))
 check("...and says 0 only in the canonical",
       r is not None and "0 file(s) only in the canonical" in r["detail"], str(r))
+# The shape sentence must be DERIVED: hardcoding "neither side is a superset"
+# states the opposite of the sets whenever one side actually is.
+check("...and does NOT claim 'neither side is a superset'",
+      r is not None and "Neither side is a superset" not in r["detail"], str(r))
+check("...it names WHICH side is the superset",
+      r is not None and "legacy tree is a strict superset" in r["detail"], str(r))
+
+r = _probe(["a.md", "onlyhere.md"], ["a.md"])
+check("canonical is the superset → the sentence flips",
+      r is not None and "canonical workspace is a strict superset" in r["detail"], str(r))
+
+r = _probe(["a.md", "x.md"], ["a.md", "y.md"])
+check("both sides exclusive → 'neither side is a superset' is CORRECT here",
+      r is not None and "Neither side is a superset" in r["detail"], str(r))
 
 print("\nthe #1266 probe is untouched:")
 check("check_notes_split_brain still exists and is separate",
       callable(getattr(hc, "check_notes_split_brain", None)))
 src = (REPO / "src" / "health-check.py").read_text()
-# Match the CALL SITE, not the name: "check_legacy_notes_divergence()" also occurs
-# in the `def` line, so the obvious assertion survives deleting the call entirely —
-# measured, that mutation kept this file green.
+# Match the CALL SITE: the bare name also occurs in the `def` line, so asserting
+# the name alone survives deleting the call.
 check("the probe is CALLED, not merely defined",
       "_legacy_nd = check_legacy_notes_divergence()" in src
       and "checks.append(_legacy_nd)" in src)

--- a/tests/health-check-legacy-notes-divergence.test.py
+++ b/tests/health-check-legacy-notes-divergence.test.py
@@ -158,6 +158,53 @@ check("the probe is CALLED, not merely defined",
 check("the #1266 probe is still called too",
       "_notes_sb = check_notes_split_brain()" in src)
 
+# The two `except OSError` arms decide what happens when the filesystem will not
+# answer, and an untested fail-safe is indistinguishable from one that never runs.
+print("\nfail-safe branches, driven rather than asserted:")
+with tempfile.TemporaryDirectory() as _td:
+    _root = Path(_td)
+    _ws, _legacy = _root / "canonical", _root / "legacy"
+    for _base in (_ws / "notes", _legacy / "notes"):
+        _base.mkdir(parents=True)
+        (_base / "a.md").write_text("x")
+
+    _real_resolve = Path.resolve
+
+    def _boom_resolve(self, *a, **k):
+        if str(self).startswith(str(_legacy)):
+            raise OSError("simulated resolve failure")
+        return _real_resolve(self, *a, **k)
+
+    with patch.object(hc, "WORKSPACE_DIR", _ws), \
+         patch.object(hc, "legacy_dotted_workspace", lambda: _legacy), \
+         patch.object(Path, "resolve", _boom_resolve):
+        r = hc.check_legacy_notes_divergence()
+    check("resolve() raising OSError -> None, not a traceback", r is None, str(r))
+
+    _real_rglob = Path.rglob
+
+    def _boom_rglob(self, pattern):
+        if str(self).startswith(str(_legacy)):
+            raise OSError("simulated listing failure")
+        return _real_rglob(self, pattern)
+
+    with patch.object(hc, "WORKSPACE_DIR", _ws), \
+         patch.object(hc, "legacy_dotted_workspace", lambda: _legacy), \
+         patch.object(Path, "rglob", _boom_rglob):
+        r = hc.check_legacy_notes_divergence()
+    check("an unreadable legacy tree still reports, from the side that IS readable",
+          r is not None and r.get("status") == "warn", str(r))
+    check("...and attributes every file to the readable side, not to a false divergence",
+          r is not None and "1 file(s) only in the canonical" in r["detail"], str(r))
+
+# The source-substring check above survives deleting the append; only calling the
+# aggregate proves the result actually reaches an operator.
+_synthetic = {"name": "legacy-notes-divergence", "status": "warn", "detail": "synthetic"}
+with patch.object(hc, "check_legacy_notes_divergence", lambda: _synthetic):
+    _names = [c.get("name") for c in hc.run_all_checks()]
+check("run_all_checks() APPENDS the result — executed, not grepped",
+      "legacy-notes-divergence" in _names)
+
 if failures:
     print(f"\nFAILED ({len(failures)}): {failures}")
     sys.exit(1)

--- a/tests/health-check-legacy-notes-divergence.test.py
+++ b/tests/health-check-legacy-notes-divergence.test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""`legacy-notes-divergence` catches the pair the #1266 probe cannot reach.
+
+`check_notes_split_brain` compares <repo>/notes to <workspace>/notes and returns
+None when the repo has no notes/ dir — which is the normal post-migration state.
+The pre-v0.8 <legacy workspace>/notes can still exist and still diverge, and
+that split is invisible to an .md-only TOP-LEVEL glob because it lives in
+`sutando-wire/episode-specs/*.yaml`. Both of those blind spots are asserted here.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+sys.modules["health_check"] = hc
+spec.loader.exec_module(hc)
+
+failures = []
+
+
+def check(label, cond, extra=""):
+    if cond:
+        print(f"  ok   {label}")
+    else:
+        failures.append(label)
+        print(f"  FAIL {label}  {extra}")
+
+
+def _probe(ws_files, legacy_files, *, same_dir=False):
+    """Build two notes trees and run the probe against them."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = root / "canonical"
+        legacy_ws = root / "legacy"
+        for base, files in ((ws / "notes", ws_files), (legacy_ws / "notes", legacy_files)):
+            for rel in files:
+                p = base / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text("x")
+        target = ws / "notes" if same_dir else legacy_ws / "notes"
+        with patch.object(hc, "WORKSPACE_DIR", ws), \
+             patch.object(hc, "legacy_dotted_workspace", lambda: target.parent):
+            return hc.check_legacy_notes_divergence()
+
+
+print("the blind spot this exists for — a .yaml divergence nested three deep:")
+r = _probe(["sutando-wire/episode-specs/a.yaml", "shared.md"],
+           ["sutando-wire/episode-specs/b.yaml", "shared.md"])
+check("fires on a nested non-.md divergence", r is not None and r["status"] == "warn", str(r))
+check("reports BOTH directions", r is not None and "1 file(s) only in the canonical" in r["detail"]
+      and "1 only in the legacy" in r["detail"], str(r))
+check("names the shared count too", r is not None and "1 shared" in r["detail"], str(r))
+check("claims no live-side verdict from a whole-tree mtime",
+      r is not None and "newer by" not in r["detail"], str(r))
+
+print("\nsilence where it should be silent:")
+r = _probe(["a.md", "b.md"], ["a.md", "b.md"])
+check("identical trees → no warn", r is None, str(r))
+
+r = _probe(["a.md"], [])
+check("legacy notes/ dir absent → no warn (nothing to diverge from)", r is None, str(r))
+
+r = _probe(["a.md", "b.md"], ["a.md", "b.md"], same_dir=True)
+check("same resolved dir → no warn (not two trees)", r is None, str(r))
+# NOTE: that case passes even with the resolve() guard removed, because two views
+# of one directory also produce an empty diff. The guard is a cheap short-circuit,
+# not a behavioural gate, so it is deliberately NOT asserted as one — a mutation
+# that deletes it does not change any output, and a test claiming otherwise would
+# be asserting its own wishful thinking.
+
+print("\nsupersets are still a divergence — neither side may be trusted blindly:")
+r = _probe(["a.md"], ["a.md", "extra.yaml"])
+check("legacy is a strict superset → still warns", r is not None, str(r))
+check("...and says 0 only in the canonical",
+      r is not None and "0 file(s) only in the canonical" in r["detail"], str(r))
+
+print("\nthe #1266 probe is untouched:")
+check("check_notes_split_brain still exists and is separate",
+      callable(getattr(hc, "check_notes_split_brain", None)))
+src = (REPO / "src" / "health-check.py").read_text()
+# Match the CALL SITE, not the name: "check_legacy_notes_divergence()" also occurs
+# in the `def` line, so the obvious assertion survives deleting the call entirely —
+# measured, that mutation kept this file green.
+check("the probe is CALLED, not merely defined",
+      "_legacy_nd = check_legacy_notes_divergence()" in src
+      and "checks.append(_legacy_nd)" in src)
+check("the #1266 probe is still called too",
+      "_notes_sb = check_notes_split_brain()" in src)
+
+if failures:
+    print(f"\nFAILED ({len(failures)}): {failures}")
+    sys.exit(1)
+print("\nPASS — legacy-notes-divergence")

--- a/tests/health-check-legacy-notes-divergence.test.py
+++ b/tests/health-check-legacy-notes-divergence.test.py
@@ -74,6 +74,35 @@ check("same resolved dir → no warn (not two trees)", r is None, str(r))
 # that deletes it does not change any output, and a test claiming otherwise would
 # be asserting its own wishful thinking.
 
+# Pro measured this on a second host and read "2 of 11,442" as nothing to worry
+# about. Counting is what made that wrong: those 2 are the files a "delete the
+# legacy tree" cleanup destroys. So the legacy-only paths must be NAMED.
+print("\nthe at-risk paths are named, not just counted:")
+r = _probe(["keep.md"], ["keep.md", "sutando-wire/peg-signals/2026-08-05.md"])
+check("names the legacy-only path",
+      r is not None and "sutando-wire/peg-signals/2026-08-05.md" in r["detail"], str(r))
+check("labels it as having no canonical copy",
+      r is not None and "LEGACY-ONLY" in r["detail"], str(r))
+
+r = _probe(["keep.md"], ["keep.md"] + [f"only{i}.md" for i in range(7)])
+check("caps the sample and says how many more",
+      r is not None and "and 4 more" in r["detail"], str(r))
+check("...without dropping the true total",
+      r is not None and "7 only in the legacy tree" in r["detail"], str(r))
+
+# A plain alphabetical sample leads with .DS_Store and buries what matters —
+# measured on the live tree, where it crowded out sutando-wire/peg-signals/*.md.
+r = _probe(["keep.md"], ["keep.md", ".DS_Store", ".aaa", ".bbb",
+                         "sutando-wire/peg-signals/x.md"])
+check("dotfiles do not crowd the 3-wide sample",
+      r is not None and "sutando-wire/peg-signals/x.md" in r["detail"], str(r))
+check("...and the count still includes the dotfiles",
+      r is not None and "4 only in the legacy tree" in r["detail"], str(r))
+
+r = _probe(["canonical-only.md", "keep.md"], ["keep.md"])
+check("no legacy-only paths → no LEGACY-ONLY clause at all",
+      r is not None and "LEGACY-ONLY" not in r["detail"], str(r))
+
 print("\nsupersets are still a divergence — neither side may be trusted blindly:")
 r = _probe(["a.md"], ["a.md", "extra.yaml"])
 check("legacy is a strict superset → still warns", r is not None, str(r))

--- a/tests/health-check-legacy-notes-divergence.test.py
+++ b/tests/health-check-legacy-notes-divergence.test.py
@@ -179,7 +179,12 @@ with tempfile.TemporaryDirectory() as _td:
          patch.object(hc, "legacy_dotted_workspace", lambda: _legacy), \
          patch.object(Path, "resolve", _boom_resolve):
         r = hc.check_legacy_notes_divergence()
-    check("resolve() raising OSError -> None, not a traceback", r is None, str(r))
+    check("resolve() raising OSError WARNS — a read failure is not 'no divergence'",
+          r is not None and r.get("status") == "warn", str(r))
+    check("...and says it could not compare, not that the trees agree",
+          r is not None and "could not compare" in r["detail"], str(r))
+    check("...and refuses to read as a clean bill of health",
+          r is not None and "NOT a clean bill of health" in r["detail"], str(r))
 
     _real_rglob = Path.rglob
 
@@ -192,10 +197,33 @@ with tempfile.TemporaryDirectory() as _td:
          patch.object(hc, "legacy_dotted_workspace", lambda: _legacy), \
          patch.object(Path, "rglob", _boom_rglob):
         r = hc.check_legacy_notes_divergence()
-    check("an unreadable legacy tree still reports, from the side that IS readable",
+    check("an unreadable tree WARNS rather than reporting a partial comparison",
           r is not None and r.get("status") == "warn", str(r))
-    check("...and attributes every file to the readable side, not to a false divergence",
-          r is not None and "1 file(s) only in the canonical" in r["detail"], str(r))
+    check("...and names enumeration as what failed, not a file count",
+          r is not None and "enumerating" in r["detail"], str(r))
+
+# The case a non-empty canonical side hides: with nothing on the readable side, a
+# partial scan compares empty-to-empty and the only copy of every file looks fine.
+with tempfile.TemporaryDirectory() as _td2:
+    _root2 = Path(_td2)
+    _ws2, _legacy2 = _root2 / "canonical", _root2 / "legacy"
+    (_ws2 / "notes").mkdir(parents=True)
+    (_legacy2 / "notes").mkdir(parents=True)
+    (_legacy2 / "notes" / "only-copy.md").write_text("the only copy of this file")
+
+    _rg2 = Path.rglob
+
+    def _boom_rglob2(self, pattern):
+        if str(self).startswith(str(_legacy2)):
+            raise OSError("unreadable")
+        return _rg2(self, pattern)
+
+    with patch.object(hc, "WORKSPACE_DIR", _ws2), \
+         patch.object(hc, "legacy_dotted_workspace", lambda: _legacy2), \
+         patch.object(Path, "rglob", _boom_rglob2):
+        r = hc.check_legacy_notes_divergence()
+    check("unreadable legacy + EMPTY canonical still WARNS (the only-copy case)",
+          r is not None and r.get("status") == "warn", str(r))
 
 # The source-substring check above survives deleting the append; only calling the
 # aggregate proves the result actually reaches an operator.


### PR DESCRIPTION
## The gap

`check_notes_split_brain` (#1266) compares `<repo>/notes` against `<workspace>/notes` and returns
`None` when the repo has no `notes/` dir — the normal post-migration state. **It is behaving
correctly.** But a pre-v0.8 `~/.sutando/workspace/notes` (usually a symlink into
`~/.sutando/memory-sync/notes`) can still exist and still take writes, and nothing looks at that pair.

Measured on this host, where the existing probe is silent and right to be:

```
<repo>/notes                    does not exist   -> #1266 probe returns None

<workspace>/notes vs legacy     416   only in the canonical workspace
                                1522  only in the legacy tree
                                1056  shared
```

**Bidirectional — neither side is a superset**, so pointing any consumer at either tree loses files.
Narrowed to episode specs alone it is 91 / 105 / 83 shared, and the newest legacy spec is 7 days
newer than the newest canonical one.

Two independent reasons an `.md` check could never have found it: the #1266 probe globs **top-level**
`*.md`, and this divergence lives in `sutando-wire/episode-specs/*.yaml`. The new probe is recursive
and extension-agnostic; both are pinned by tests.

## It reports no "which side is live" verdict, on purpose

My first cut inferred that from each tree's newest mtime and **got it backwards**:

```
whole tree        "canonical is newer by 0.0d"
episode-specs     canonical is 7 days OLDER
```

A whole-tree newest-mtime is dominated by whichever file was touched last for any reason. So the
detail line reports the counts — which are checkable — and tells the reader to compare the subtree
they actually care about. Removing that inference is most of the diff's second revision.

## Also corrects a comment that would stop someone looking

`src/util_paths.py:92` asserted the dotted legacy workspace *"no longer exists."* It is no longer
**resolved to**, which is what the comment meant, but on this host it exists and is diverging — and a
reader who believes it is gone will not think to check.

## Tests — including two that were wrong first

11 checks. Mutations:

```
rglob -> glob (top-level only)   FAILED (4)
superset no longer warns         FAILED (2)
unwired from run_all_checks      FAILED (1)
```

That third one earned its place. My first assertion was `"check_legacy_notes_divergence()" in src`,
which **also matches the `def` line** — so deleting the call site left the whole file green. Measured,
then fixed to match the call site and the `checks.append`. Same class as the call-site gap I hit on
#2744 earlier today; a source-substring assertion that matches a definition is not a wiring test.

And the same-resolved-dir guard is documented in the test as deliberately **not** asserted
behaviourally: two views of one directory also produce an empty diff, so deleting the guard changes no
output. A test claiming to cover it would be asserting wishful thinking. It stays because it is a
cheap short-circuit, not because a test proves it.

Full health-check suite: **61 files, 0 failures.**

## Scope

Detection only. **Which** tree is authoritative is a separate decision — the same question
sonichi/sutando-skills#323 raises for the ship root — and this probe deliberately does not answer it.
It exists so that decision is made with the numbers visible rather than discovered by hand, which is
how I found it.

@sonichi flagging you — the 416/1522/1056 split is worth knowing about independently of this PR.
