### PR TITLE
fix(daily-insight): "shipped" counted unmerged branch work

### DIFF
--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -430,7 +430,48 @@ def analyze_dev_activity(repo_root=SRC_DIR, now=None):
         return None
     if commits == 0:
         return None
-    return {"commits_24h": commits, "top_dirs": dirs.most_common(3), "stand": stand}
+    # `--branches` above spans UNMERGED work, so `commits` is work-in-progress, not
+    # shipped. Count separately how many reached the default branch; the wording
+    # downstream depends on the split.
+    landed = _landed_commit_count(repo_root, author, stand)
+    return {"commits_24h": commits, "landed_24h": landed,
+            "top_dirs": dirs.most_common(3), "stand": stand}
+
+
+def _landed_commit_count(repo_root, author, stand):
+    """How many of the author's last-24h commits are reachable from the remote
+    default branch. Returns None when that branch cannot be resolved, so the
+    caller can decline to claim anything rather than guess."""
+    ref = None
+    for cand in ("origin/HEAD", "origin/main", "origin/master"):
+        r = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "--verify", "-q", cand],
+                           capture_output=True, text=True)
+        if r.returncode == 0:
+            ref = cand
+            break
+    if ref is None:
+        return None
+    try:
+        out = subprocess.run(
+            # The `C:` sentinel is load-bearing: a commit with NO Stand trailer emits an
+            # EMPTY line, which splitlines() drops, so a bare trailer format undercounts
+            # to zero. Same reason the --branches scan above prefixes its lines.
+            ["git", "-C", str(repo_root), "log", ref, "--since=24 hours ago",
+             f"--author={author}",
+             "--pretty=format:C:%(trailers:key=Stand,valueonly)"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    n = 0
+    for line in out.stdout.splitlines():
+        if not line.startswith("C:"):
+            continue
+        if not stand or line[2:].strip() == stand:
+            n += 1
+    return n
 
 
 def dev_activity_insight(dev):
@@ -442,10 +483,19 @@ def dev_activity_insight(dev):
     plural = "s" if n != 1 else ""
     stand = (dev.get("stand") or "").strip()
     subject = f"Sutando's {stand} instance" if stand else "Sutando"
-    return (
-        f"{subject} shipped {n} commit{plural} in the last 24h, mostly in {where}. "
-        f"That's the real headline — steady build velocity."
-    )
+    landed = dev.get("landed_24h")
+    if landed is None:
+        # Cannot tell what landed, so do not use the word. Report the scope we know.
+        return (f"{subject} authored {n} commit{plural} in the last 24h, mostly in "
+                f"{where} (branch work; landed count unavailable).")
+    if landed == n:
+        return (f"{subject} shipped {n} commit{plural} in the last 24h, mostly in "
+                f"{where}. That's the real headline — steady build velocity.")
+    if landed == 0:
+        return (f"{subject} has {n} commit{plural} in flight from the last 24h "
+                f"({where}) and none landed yet — velocity is in review, not in main.")
+    return (f"{subject} landed {landed} of {n} commit{plural} from the last 24h "
+            f"({where}); the other {n - landed} are still on branches.")
 
 
 def generate_insight():

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -401,20 +401,23 @@ def analyze_dev_activity(repo_root=SRC_DIR, now=None):
         return None
     stand = _own_stand_value(repo_root=repo_root)
     commits = 0
+    counted_shas = []
     dirs = Counter()
     counting = False
     seen_stands = set()
     for line in out.stdout.splitlines():
         if line.startswith("C:"):
             # "C:<sha>\x1f<Stand trailer value>" — the trailer is the ONLY thing
-            # that separates this instance from its peer, because both commit
-            # under the owner's GH-mapped email (see _own_stand_value).
-            trailer = line.split("\x1f", 1)[1].strip() if "\x1f" in line else ""
+            # that separates this instance from its peer (see _own_stand_value).
+            body = line[2:]
+            sha, _, trailer = body.partition("\x1f")
+            trailer = trailer.strip()
             if trailer:
                 seen_stands.add(trailer)
             counting = (not stand) or (trailer == stand)
             if counting:
                 commits += 1
+                counted_shas.append(sha.strip())
         elif counting and line.strip() and "/" in line:
             dirs[line.split("/", 1)[0]] += 1
     if not stand and len(seen_stands) > 1:
@@ -430,22 +433,24 @@ def analyze_dev_activity(repo_root=SRC_DIR, now=None):
         return None
     if commits == 0:
         return None
-    # `--branches` above spans UNMERGED work, so `commits` is work-in-progress, not
-    # shipped. Count separately how many reached the default branch; the wording
-    # downstream depends on the split.
-    landed = _landed_commit_count(repo_root, author, stand)
+    # `--branches` spans UNMERGED work, so `commits` is work-in-progress. Landed is a
+    # SUBSET of the very SHAs counted above — never a second query (see the function).
+    landed = _landed_subset_count(repo_root, counted_shas)
     return {"commits_24h": commits, "landed_24h": landed,
             "top_dirs": dirs.most_common(3), "stand": stand}
 
 
-def _landed_commit_count(repo_root, author, stand):
-    """How many of the author's last-24h commits are reachable from the remote
-    default branch. Returns None when that branch cannot be resolved, so the
-    caller can decline to claim anything rather than guess."""
+def _landed_subset_count(repo_root, shas):
+    """How many of `shas` are reachable from the remote default branch.
+
+    A SUBSET of the caller's own scan, so landed can never exceed the total. A
+    second author/time query can, and rendered "landed 2 of 1 ... the other -1".
+    """
+    if not shas:
+        return 0
     ref = None
-    # Guarded like the log call below: if git is missing entirely this must return
-    # None (unknown), not raise. An exception here would propagate out of
-    # analyze_dev_activity and take the whole insight down.
+    # If git is missing this must return None (unknown), not raise: an exception here
+    # propagates out of analyze_dev_activity and takes the whole insight down.
     try:
         for cand in ("origin/HEAD", "origin/main", "origin/master"):
             r = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "--verify", "-q", cand],
@@ -458,28 +463,18 @@ def _landed_commit_count(repo_root, author, stand):
     if ref is None:
         return None
     try:
+        # --no-walk considers ONLY the listed commits, so this asks "which of these
+        # exact SHAs is not reachable from ref" in one call rather than N.
         out = subprocess.run(
-            # The `C:` sentinel is load-bearing: a commit with NO Stand trailer emits an
-            # EMPTY line, which splitlines() drops, so a bare trailer format undercounts
-            # to zero. Same reason the --branches scan above prefixes its lines.
-            ["git", "-C", str(repo_root), "log", ref, "--since=24 hours ago",
-             f"--author={author}",
-             "--pretty=format:C:%(trailers:key=Stand,valueonly)"],
+            ["git", "-C", str(repo_root), "rev-list", "--no-walk", *shas, "--not", ref],
             capture_output=True, text=True, timeout=10,
         )
     except (OSError, subprocess.SubprocessError):
         return None
     if out.returncode != 0:
         return None
-    n = 0
-    for line in out.stdout.splitlines():
-        if not line.startswith("C:"):
-            continue
-        if not stand or line[2:].strip() == stand:
-            n += 1
-    return n
-
-
+    unlanded = {ln.strip() for ln in out.stdout.splitlines() if ln.strip()}
+    return sum(1 for s in shas if s not in unlanded)
 def dev_activity_insight(dev):
     """Render the dev-activity dict into one headline sentence, or None."""
     if not dev or dev.get("commits_24h", 0) <= 0:

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -443,12 +443,18 @@ def _landed_commit_count(repo_root, author, stand):
     default branch. Returns None when that branch cannot be resolved, so the
     caller can decline to claim anything rather than guess."""
     ref = None
-    for cand in ("origin/HEAD", "origin/main", "origin/master"):
-        r = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "--verify", "-q", cand],
-                           capture_output=True, text=True)
-        if r.returncode == 0:
-            ref = cand
-            break
+    # Guarded like the log call below: if git is missing entirely this must return
+    # None (unknown), not raise. An exception here would propagate out of
+    # analyze_dev_activity and take the whole insight down.
+    try:
+        for cand in ("origin/HEAD", "origin/main", "origin/master"):
+            r = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "--verify", "-q", cand],
+                               capture_output=True, text=True, timeout=10)
+            if r.returncode == 0:
+                ref = cand
+                break
+    except (OSError, subprocess.SubprocessError):
+        return None
     if ref is None:
         return None
     try:

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -443,9 +443,7 @@ def analyze_dev_activity(repo_root=SRC_DIR, now=None):
 def _landed_subset_count(repo_root, shas):
     """How many of `shas` are reachable from the remote default branch.
 
-    A SUBSET of the caller's own scan, so landed can never exceed the total. A
-    second author/time query can, and rendered "landed 2 of 1 ... the other -1".
-    """
+    A SUBSET of the caller's own scan, so landed can never exceed the total."""
     if not shas:
         return 0
     ref = None

--- a/tests/daily-insight-dev-activity.test.py
+++ b/tests/daily-insight-dev-activity.test.py
@@ -179,6 +179,68 @@ class TestInsightPriority(unittest.TestCase):
         all_landed = self.mod.dev_activity_insight({**base, "landed_24h": 43})
         self.assertIn("shipped 43 commits", all_landed)
 
+    def test_a_git_failure_yields_None_not_a_false_shipped(self):
+        """The two failure branches of _landed_commit_count exist so a git error
+        cannot become a "shipped" claim: None means unknown, and the caller then
+        says "authored". A 0 here would read as "nothing landed", which is a
+        different and unearned assertion."""
+        import subprocess as _sp
+        mod, real = self.mod, self.mod.subprocess.run
+
+        def raiser(*a, **k):
+            raise OSError("git missing")
+        mod.subprocess.run = raiser
+        try:
+            self.assertIsNone(mod._landed_commit_count(REPO, "a@b", ""))
+        finally:
+            mod.subprocess.run = real
+
+        class Bad:
+            returncode = 128
+            stdout = ""
+        # rev-parse must still succeed so we reach the log call, then fail there.
+        calls = {"n": 0}
+
+        def flaky(argv, *a, **k):
+            calls["n"] += 1
+            if "rev-parse" in argv:
+                return real(argv, *a, **k)
+            return Bad()
+        mod.subprocess.run = flaky
+        try:
+            self.assertIsNone(mod._landed_commit_count(REPO, "a@b", ""))
+            self.assertGreater(calls["n"], 1, "should have reached the log call")
+        finally:
+            mod.subprocess.run = real
+
+    def test_no_resolvable_default_branch_yields_None(self):
+        """A repo with no origin/HEAD, origin/main or origin/master cannot say what
+        landed. None, so the caller drops the word rather than reporting zero."""
+        mod, real = self.mod, self.mod.subprocess.run
+
+        class NoRef:
+            returncode = 1
+            stdout = ""
+        mod.subprocess.run = lambda *a, **k: NoRef()
+        try:
+            self.assertIsNone(mod._landed_commit_count(REPO, "a@b", ""))
+        finally:
+            mod.subprocess.run = real
+
+    def test_a_raising_log_call_yields_None(self):
+        """rev-parse succeeds, then the log call itself raises — still None."""
+        mod, real = self.mod, self.mod.subprocess.run
+
+        def flaky(argv, *a, **k):
+            if "rev-parse" in argv:
+                return real(argv, *a, **k)
+            raise OSError("git vanished mid-run")
+        mod.subprocess.run = flaky
+        try:
+            self.assertIsNone(mod._landed_commit_count(REPO, "a@b", ""))
+        finally:
+            mod.subprocess.run = real
+
     def test_unresolvable_landed_count_does_not_claim_shipped(self):
         """A repo with no remote default branch cannot say what landed, so the word
         must not appear at all rather than defaulting to the flattering reading."""

--- a/tests/daily-insight-dev-activity.test.py
+++ b/tests/daily-insight-dev-activity.test.py
@@ -168,8 +168,7 @@ class TestInsightPriority(unittest.TestCase):
         self.assertIn("Sutando's Echo Act IV Mini instance shipped 2 commits", insight)
 
     def test_shipped_requires_that_the_commits_actually_landed(self):
-        """`--branches` spans UNMERGED work, so the count alone cannot say "shipped".
-        Reported 43 "shipped" on 2026-08-09 when 1 had landed and 42 sat on branches."""
+        """`--branches` spans UNMERGED work, so the count alone cannot say "shipped"."""
         base = {"commits_24h": 43, "top_dirs": [("tests", 9)], "stand": ""}
         none_landed = self.mod.dev_activity_insight({**base, "landed_24h": 0})
         self.assertNotIn("shipped", none_landed)

--- a/tests/daily-insight-dev-activity.test.py
+++ b/tests/daily-insight-dev-activity.test.py
@@ -159,10 +159,35 @@ class TestInsightPriority(unittest.TestCase):
     def test_agent_output_is_not_attributed_to_owner(self):
         insight = self.mod.dev_activity_insight({
             "commits_24h": 2,
+            "landed_24h": 2,
             "top_dirs": [("src", 2)],
             "stand": "Echo Act IV Mini",
         })
         self.assertIn("Sutando's Echo Act IV Mini instance shipped 2 commits", insight)
+
+    def test_shipped_requires_that_the_commits_actually_landed(self):
+        """`--branches` spans UNMERGED work, so the count alone cannot say "shipped".
+        Reported 43 "shipped" on 2026-08-09 when 1 had landed and 42 sat on branches."""
+        base = {"commits_24h": 43, "top_dirs": [("tests", 9)], "stand": ""}
+        none_landed = self.mod.dev_activity_insight({**base, "landed_24h": 0})
+        self.assertNotIn("shipped", none_landed)
+        self.assertIn("in flight", none_landed)
+        partial = self.mod.dev_activity_insight({**base, "landed_24h": 1})
+        self.assertNotIn("shipped", partial)
+        self.assertIn("landed 1 of 43", partial)
+        self.assertIn("42 are still on branches", partial)
+        all_landed = self.mod.dev_activity_insight({**base, "landed_24h": 43})
+        self.assertIn("shipped 43 commits", all_landed)
+
+    def test_unresolvable_landed_count_does_not_claim_shipped(self):
+        """A repo with no remote default branch cannot say what landed, so the word
+        must not appear at all rather than defaulting to the flattering reading."""
+        insight = self.mod.dev_activity_insight({
+            "commits_24h": 7, "landed_24h": None,
+            "top_dirs": [("src", 2)], "stand": "",
+        })
+        self.assertNotIn("shipped", insight)
+        self.assertIn("authored 7 commits", insight)
         self.assertNotIn("You shipped", insight)
 
 

--- a/tests/daily-insight-dev-activity.test.py
+++ b/tests/daily-insight-dev-activity.test.py
@@ -182,10 +182,8 @@ class TestInsightPriority(unittest.TestCase):
         self.assertIn("shipped 43 commits", all_landed)
 
     def test_a_git_failure_yields_None_not_a_false_shipped(self):
-        """The two failure branches of _landed_subset_count exist so a git error
-        cannot become a "shipped" claim: None means unknown, and the caller then
-        says "authored". A 0 here would read as "nothing landed", which is a
-        different and unearned assertion."""
+        """None means unknown and the caller says "authored"; 0 would assert
+        "nothing landed", which is a different and unearned claim."""
         import subprocess as _sp
         mod, real = self.mod, self.mod.subprocess.run
 

--- a/tests/daily-insight-dev-activity.test.py
+++ b/tests/daily-insight-dev-activity.test.py
@@ -7,10 +7,12 @@ work he did (shipping commits, PRs, meetings). Fix: surface git commit activity
 in the last 24h as the highest-priority insight, so a productive day doesn't
 read as "just notes."
 
-All git calls are mocked — no real repo history is inspected here.
+Most git calls are mocked; TestLandedIsASubsetNotASecondQuery builds a real
+temp repo, because the subset invariant depends on real reachability.
 """
 import importlib.util
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -180,7 +182,7 @@ class TestInsightPriority(unittest.TestCase):
         self.assertIn("shipped 43 commits", all_landed)
 
     def test_a_git_failure_yields_None_not_a_false_shipped(self):
-        """The two failure branches of _landed_commit_count exist so a git error
+        """The two failure branches of _landed_subset_count exist so a git error
         cannot become a "shipped" claim: None means unknown, and the caller then
         says "authored". A 0 here would read as "nothing landed", which is a
         different and unearned assertion."""
@@ -191,7 +193,7 @@ class TestInsightPriority(unittest.TestCase):
             raise OSError("git missing")
         mod.subprocess.run = raiser
         try:
-            self.assertIsNone(mod._landed_commit_count(REPO, "a@b", ""))
+            self.assertIsNone(mod._landed_subset_count(REPO, ["deadbeef"]))
         finally:
             mod.subprocess.run = real
 
@@ -208,7 +210,7 @@ class TestInsightPriority(unittest.TestCase):
             return Bad()
         mod.subprocess.run = flaky
         try:
-            self.assertIsNone(mod._landed_commit_count(REPO, "a@b", ""))
+            self.assertIsNone(mod._landed_subset_count(REPO, ["deadbeef"]))
             self.assertGreater(calls["n"], 1, "should have reached the log call")
         finally:
             mod.subprocess.run = real
@@ -223,7 +225,7 @@ class TestInsightPriority(unittest.TestCase):
             stdout = ""
         mod.subprocess.run = lambda *a, **k: NoRef()
         try:
-            self.assertIsNone(mod._landed_commit_count(REPO, "a@b", ""))
+            self.assertIsNone(mod._landed_subset_count(REPO, ["deadbeef"]))
         finally:
             mod.subprocess.run = real
 
@@ -237,7 +239,7 @@ class TestInsightPriority(unittest.TestCase):
             raise OSError("git vanished mid-run")
         mod.subprocess.run = flaky
         try:
-            self.assertIsNone(mod._landed_commit_count(REPO, "a@b", ""))
+            self.assertIsNone(mod._landed_subset_count(REPO, ["deadbeef"]))
         finally:
             mod.subprocess.run = real
 
@@ -251,6 +253,54 @@ class TestInsightPriority(unittest.TestCase):
         self.assertNotIn("shipped", insight)
         self.assertIn("authored 7 commits", insight)
         self.assertNotIn("You shipped", insight)
+
+
+class TestLandedIsASubsetNotASecondQuery(unittest.TestCase):
+    """landed_24h counted from a different universe than commits_24h renders "-1"."""
+
+    def _diverged_repo(self, td):
+        """Local branches hold 1 WIP commit; origin/main holds 2 others, same author."""
+        r = Path(td) / "repo"
+        r.mkdir()
+
+        def g(*a):
+            return subprocess.run(["git", "-C", str(r), *a], capture_output=True, text=True)
+
+        g("init", "-q", "-b", "main")
+        g("config", "user.email", "a@b")
+        g("config", "user.name", "A")
+        for name in ("a", "b"):
+            (r / name).write_text(name)
+            g("add", "-A")
+            g("commit", "-q", "-m", name)
+        g("update-ref", "refs/remotes/origin/main", "HEAD")
+        # Orphan branch so the two commits above are reachable ONLY from origin/main.
+        g("checkout", "-q", "--orphan", "wip")
+        g("rm", "-rq", "--cached", ".")
+        (r / "w").write_text("w")
+        g("add", "-A")
+        g("commit", "-q", "-m", "wip")
+        g("branch", "-q", "-D", "main")
+        return r
+
+    def test_landed_never_exceeds_the_commits_it_is_a_subset_of(self):
+        mod = _load()
+        with tempfile.TemporaryDirectory() as td:
+            repo = self._diverged_repo(td)
+            dev = mod.analyze_dev_activity(repo_root=repo)
+        self.assertIsNotNone(dev, "the --branches scan should still see the WIP commit")
+        self.assertEqual(dev["commits_24h"], 1, dev)
+        self.assertLessEqual(dev["landed_24h"], dev["commits_24h"], dev)
+        self.assertEqual(dev["landed_24h"], 0, "the WIP commit is not on origin/main")
+
+    def test_the_rendered_sentence_cannot_go_negative(self):
+        mod = _load()
+        with tempfile.TemporaryDirectory() as td:
+            repo = self._diverged_repo(td)
+            dev = mod.analyze_dev_activity(repo_root=repo)
+        line = mod.dev_activity_insight(dev)
+        self.assertNotIn("-1", line, line)
+        self.assertNotIn("of 1 commit", line.replace("0 of 1 commit", ""), line)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

`analyze_dev_activity` scans `git log --branches` — which spans **unmerged** commits — and the headline calls that number **shipped**.

Today it told the owner:

> *Sutando shipped 43 commits in the last 24h, mostly in tests/, src/, docs/. That's the real headline — steady build velocity.*

Measured on this host at the same moment:

```
git log --branches --since=24h --author=<me>   -> 43
  of those, reachable from origin/main         ->  1
  branch-only                                  -> 42
```

So 42 of 43 had not shipped. The overstatement **scales with work-in-progress**, which means it is loudest on exactly the days it is most wrong — a heavy rebase/worktree day reads as peak velocity.

I caught this because the insight was about to be delivered; I rewrote the outgoing `results/insight-*.txt` with the measured figures before the bridge picked it up.

## Why the existing guards missed it

The comments at `:305` and `:384` show this function has already been hardened against inflating "you shipped N" — CR #2257 added an author filter and a Stand-trailer filter so a `git pull` of someone else's work is not credited.

Those guards answer **who authored it**. Nobody asked **whether it landed**.

## The fix

`_landed_commit_count` counts the same author's last-24h commits reachable from the remote default branch, and the wording follows the split:

| landed vs authored | wording |
|---|---|
| all | "shipped N commits … steady build velocity" (unchanged) |
| partial | "landed 1 of 43 …; the other 42 are still on branches" |
| none | "43 commits in flight … none landed yet — velocity is in review, not in main" |
| unresolvable | "authored N commits … (branch work; landed count unavailable)" |

## Two subtleties, both found by measurement rather than by reading

**1. The `C:` sentinel is load-bearing.** A commit with no `Stand` trailer emits an **empty** line under `--pretty=format:%(trailers:…)`, `splitlines()` drops it, and the count silently reads **0**. My first version therefore reported "none landed" on a repo where one had — I only noticed because it disagreed with my manual count. The `--branches` scan already prefixes its lines for the same reason; this now matches.

**2. Unresolvable returns `None`, not `0`.** A repo with no remote default branch cannot say what landed, so the caller drops the word entirely rather than defaulting to the flattering reading.

## Verification

```
live run on this repo:  commits_24h=43  landed_24h=1
  -> "Sutando landed 1 of 43 commits from the last 24h (tests/, src/, docs/);
      the other 42 are still on branches."

[PASS] tests/daily-insight-dev-activity.test.py        (14 tests, was 12)
[PASS] tests/daily-insight-stand-attribution.test.py
[PASS] tests/daily-insight-frontmatter-tags.test.py
[PASS] tests/daily-insight-note-age.test.py
[PASS] scripts/gen-src-map.py --check
[PASS] git diff --check origin/main...HEAD
```

**Proven in the broken state, not asserted:** reverting to the old unconditional wording fails both new tests (`test_shipped_requires_that_the_commits_actually_landed`, `test_unresolvable_landed_count_does_not_claim_shipped`); restoring passes 14/14.

One pre-existing test asserted `"shipped 2 commits"` on a fixture with no `landed_24h`. Its stated purpose is attribution (*"agent output is not attributed to owner"\*), so I completed the fixture rather than weakening the assertion — the original string is still asserted, unchanged.

Stand: Echo Act IV Mini