### PR TITLE
fix(morning-briefing): a year-1219 reminder outranked a real one

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -287,16 +287,11 @@ def get_reminders() -> "list[str] | None":
         return None
 
 
-# `reminders.py --due-today` returns today's AND overdue items by contract, with no
-# upper bound on how overdue. Live on this host: "7-minute timer (due … 1219)" and a
-# 2020 item, rendered every morning as "Reminders due" — implying action on a corrupt
-# date and a six-year-old one, and holding 2 of the 5 slots permanently.
-# TWO calendar years, not one: the due clause gives year granularity, so `year_now - 1`
-# would demote a December item in January — one month overdue, not a year. Demoting a
-# live reminder is the worse error, so the bound is the one this precision can justify.
+# TWO years, not one: the due clause gives only year granularity, so `year_now - 1`
+# would demote a December item in January — one month overdue, not a year.
 _STALE_YEARS = 2
-# Any 4-digit run AFTER the literal "due" is the year — the alternation this
-# replaced missed 1219, i.e. the single most obviously-corrupt date on the host.
+# Any 4-digit run after the literal "due" — an alternation of plausible years cannot
+# match a corrupt one.
 _DUE_YEAR_RE = re.compile(r"\bdue\b[^)]*?\b(\d{4})\b")
 
 
@@ -309,11 +304,8 @@ def _reminder_due_year(line):
 def _demote_stale_reminders(items, now=None):
     """Move reminders overdue by two calendar years or more to the END of the list.
 
-    Deliberately does NOT drop them: they are the owner's data, and a briefing that
-    silently hides a reminder is the failure mode this module already guards against
-    for the calendar. Demoting is enough — a real due-today item can no longer be
-    crowded out by a year-1219 artifact. Unparseable dates keep their position, so a
-    format change cannot bury a live reminder.
+    Demotes, never drops. Unparseable dates keep their position, so a format change
+    cannot bury a live reminder.
     """
     year_now = (datetime.fromtimestamp(now) if now else datetime.now()).year
     cutoff = year_now - _STALE_YEARS

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -282,9 +282,46 @@ def get_reminders() -> "list[str] | None":
             line = line.strip()
             if line and not line.startswith("#") and line.lower() not in empty_sentinels:
                 items.append(line)
-        return items[:5]
+        return _demote_stale_reminders(items)[:5]
     except (subprocess.TimeoutExpired, OSError):
         return None
+
+
+# `reminders.py --due-today` returns today's AND overdue items by contract, with no
+# upper bound on how overdue. Live on this host: "7-minute timer (due … 1219)" and a
+# 2020 item, rendered every morning as "Reminders due" — implying action on a corrupt
+# date and a six-year-old one, and holding 2 of the 5 slots permanently.
+# TWO calendar years, not one: the due clause gives year granularity, so `year_now - 1`
+# would demote a December item in January — one month overdue, not a year. Demoting a
+# live reminder is the worse error, so the bound is the one this precision can justify.
+_STALE_YEARS = 2
+# Any 4-digit run AFTER the literal "due" is the year — the alternation this
+# replaced missed 1219, i.e. the single most obviously-corrupt date on the host.
+_DUE_YEAR_RE = re.compile(r"\bdue\b[^)]*?\b(\d{4})\b")
+
+
+def _reminder_due_year(line):
+    """The 4-digit year in a reminder's `(due …)` clause, or None if not parseable."""
+    m = _DUE_YEAR_RE.search(line)
+    return int(m.group(1)) if m else None
+
+
+def _demote_stale_reminders(items, now=None):
+    """Move reminders overdue by two calendar years or more to the END of the list.
+
+    Deliberately does NOT drop them: they are the owner's data, and a briefing that
+    silently hides a reminder is the failure mode this module already guards against
+    for the calendar. Demoting is enough — a real due-today item can no longer be
+    crowded out by a year-1219 artifact. Unparseable dates keep their position, so a
+    format change cannot bury a live reminder.
+    """
+    year_now = (datetime.fromtimestamp(now) if now else datetime.now()).year
+    cutoff = year_now - _STALE_YEARS
+    fresh, stale = [], []
+    for it in items:
+        y = _reminder_due_year(it)
+        (stale if (y is not None and y <= cutoff) else fresh).append(it)
+    return fresh + stale
 
 
 def get_overnight_discord(now: float | None = None) -> list[str]:

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -290,27 +290,21 @@ def get_reminders() -> "list[str] | None":
 # TWO years, not one: the due clause gives only year granularity, so `year_now - 1`
 # would demote a December item in January — one month overdue, not a year.
 _STALE_YEARS = 2
-# Anchored to the literal `(due` so a lowercase "due" in the TITLE cannot supply the
-# year; any 4-digit run inside the clause, since a plausible-years alternation cannot
-# match a corrupt one.
+# Anchored to the literal `(due` so a lowercase "due" in a TITLE cannot supply the year;
+# any 4-digit run, because an alternation of plausible years cannot match a corrupt one.
 _DUE_YEAR_RE = re.compile(r"\(due\b[^)]*?\b(\d{4})\b")
 
 
 def _reminder_due_year(line):
-    """The 4-digit year in a reminder's `(due …)` clause, or None if not parseable.
-
-    Takes the LAST clause: the real one is appended, so a title containing `(due …)`
-    cannot win.
-    """
+    """The year in a reminder's `(due …)` clause, or None. Takes the LAST clause: the
+    real one is appended, so a title containing `(due …)` cannot win."""
     m = _DUE_YEAR_RE.findall(line)
     return int(m[-1]) if m else None
 
 
 def _demote_stale_reminders(items, now=None):
-    """Move reminders overdue by two calendar years or more to the END of the list.
-
-    Never drops; an unparseable date keeps its position so a format change cannot bury
-    a live reminder."""
+    """Move reminders overdue by >= two calendar years to the END. Never drops; an
+    unparseable date keeps its position so a format change cannot bury a live one."""
     year_now = (datetime.fromtimestamp(now) if now else datetime.now()).year
     cutoff = year_now - _STALE_YEARS
     fresh, stale = [], []

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -290,23 +290,27 @@ def get_reminders() -> "list[str] | None":
 # TWO years, not one: the due clause gives only year granularity, so `year_now - 1`
 # would demote a December item in January — one month overdue, not a year.
 _STALE_YEARS = 2
-# Any 4-digit run after the literal "due" — an alternation of plausible years cannot
+# Anchored to the literal `(due` so a lowercase "due" in the TITLE cannot supply the
+# year; any 4-digit run inside the clause, since a plausible-years alternation cannot
 # match a corrupt one.
-_DUE_YEAR_RE = re.compile(r"\bdue\b[^)]*?\b(\d{4})\b")
+_DUE_YEAR_RE = re.compile(r"\(due\b[^)]*?\b(\d{4})\b")
 
 
 def _reminder_due_year(line):
-    """The 4-digit year in a reminder's `(due …)` clause, or None if not parseable."""
-    m = _DUE_YEAR_RE.search(line)
-    return int(m.group(1)) if m else None
+    """The 4-digit year in a reminder's `(due …)` clause, or None if not parseable.
+
+    Takes the LAST clause: the real one is appended, so a title containing `(due …)`
+    cannot win.
+    """
+    m = _DUE_YEAR_RE.findall(line)
+    return int(m[-1]) if m else None
 
 
 def _demote_stale_reminders(items, now=None):
     """Move reminders overdue by two calendar years or more to the END of the list.
 
-    Demotes, never drops. Unparseable dates keep their position, so a format change
-    cannot bury a live reminder.
-    """
+    Never drops; an unparseable date keeps its position so a format change cannot bury
+    a live reminder."""
     year_now = (datetime.fromtimestamp(now) if now else datetime.now()).year
     cutoff = year_now - _STALE_YEARS
     fresh, stale = [], []

--- a/tests/morning-briefing-stale-reminders.test.py
+++ b/tests/morning-briefing-stale-reminders.test.py
@@ -1,17 +1,6 @@
 #!/usr/bin/env python3
-"""A years-overdue reminder must not outrank a real one in the briefing.
-
-`reminders.py --due-today` returns today's AND overdue items by contract, with no
-upper bound on how overdue. Live on this host the whole list was:
-
-    [Reminders] How launch (due Monday, January 13, 2020 at 11:52:42 AM)
-    [Reminders] 7-minute timer (due Sunday, November 3, 1219 at 12:00:00 AM)
-
-Both rendered every morning as "Reminders due" — implying action on a six-year-old
-item and a corrupt date, and holding 2 of the 5 slots permanently.
-
-Demote, never drop: they are the owner's data, and this module already refuses to
-hide a calendar it could not read.
+"""`--due-today` includes overdue items with no upper bound, so a years-stale one can
+outrank a real one. Demotion must never drop them — they are the owner's data.
 """
 from __future__ import annotations
 
@@ -55,8 +44,8 @@ class StaleReminders(unittest.TestCase):
         self.assertEqual(sorted(out), sorted(items))
 
     def test_year_1219_parses(self):
-        """The first regex used a 16xx-21xx alternation and missed 1219 — the single
-        most obviously-corrupt date on the host went undetected."""
+        """An alternation of plausible years cannot match a corrupt one; any 4-digit
+        run after "due" can."""
         self.assertEqual(self.mb._reminder_due_year(JUNK_1219), 1219)
         self.assertEqual(self.mb._reminder_due_year(JUNK_2020), 2020)
         self.assertEqual(self.mb._reminder_due_year(REAL), 2026)

--- a/tests/morning-briefing-stale-reminders.test.py
+++ b/tests/morning-briefing-stale-reminders.test.py
@@ -68,5 +68,32 @@ class StaleReminders(unittest.TestCase):
         self.assertEqual(self.mb._demote_stale_reminders([JUNK_1219]), [JUNK_1219])
 
 
+class TestTheDueClauseAnchorsTheYear(unittest.TestCase):
+    """A lowercase "due" in the TITLE must not supply the year."""
+
+    def setUp(self):
+        self.mb = _load()
+
+    def test_a_title_containing_due_and_an_old_year_does_not_win(self):
+        line = ("[Reminders] review due 2020 paperwork "
+                "(due Sunday, August 9, 2026 at 9:00:00 AM)")
+        self.assertEqual(self.mb._reminder_due_year(line), 2026)
+
+    def test_such_a_reminder_is_not_demoted(self):
+        real = ("[Reminders] review due 2020 paperwork "
+                "(due Sunday, August 9, 2026 at 9:00:00 AM)")
+        other = "[Reminders] something else (due Monday, August 10, 2026 at 9:00:00 AM)"
+        out = self.mb._demote_stale_reminders(
+            [real, other], now=self.mb.datetime(2026, 8, 9).timestamp())
+        self.assertEqual(out[0], real, "a current reminder was demoted on a title-year")
+
+    def test_a_genuinely_stale_clause_is_still_read(self):
+        line = "[Reminders] 7-minute timer (due Sunday, November 3, 1219 at 12:00:00 AM)"
+        self.assertEqual(self.mb._reminder_due_year(line), 1219)
+
+    def test_no_due_clause_is_unparseable_not_guessed(self):
+        self.assertIsNone(self.mb._reminder_due_year("[Reminders] 2020 budget review"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/morning-briefing-stale-reminders.test.py
+++ b/tests/morning-briefing-stale-reminders.test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""A years-overdue reminder must not outrank a real one in the briefing.
+
+`reminders.py --due-today` returns today's AND overdue items by contract, with no
+upper bound on how overdue. Live on this host the whole list was:
+
+    [Reminders] How launch (due Monday, January 13, 2020 at 11:52:42 AM)
+    [Reminders] 7-minute timer (due Sunday, November 3, 1219 at 12:00:00 AM)
+
+Both rendered every morning as "Reminders due" — implying action on a six-year-old
+item and a corrupt date, and holding 2 of the 5 slots permanently.
+
+Demote, never drop: they are the owner's data, and this module already refuses to
+hide a calendar it could not read.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+REAL = "[Reminders] Call the dentist (due Sunday, August 9, 2026 at 9:00:00 AM)"
+JUNK_2020 = "[Reminders] How launch (due Monday, January 13, 2020 at 11:52:42 AM)"
+JUNK_1219 = "[Reminders] 7-minute timer (due Sunday, November 3, 1219 at 12:00:00 AM)"
+LAST_DEC = "[Reminders] Recent (due Friday, December 5, 2025 at 9:00:00 AM)"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "mb", REPO / "src" / "morning-briefing.py")
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["mb"] = m
+    try:
+        spec.loader.exec_module(m)
+    except SystemExit:
+        pass
+    return m
+
+
+class StaleReminders(unittest.TestCase):
+    def setUp(self):
+        self.mb = _load()
+
+    def test_the_live_junk_pair_is_demoted_below_a_real_item(self):
+        out = self.mb._demote_stale_reminders([JUNK_2020, JUNK_1219, REAL])
+        self.assertEqual(out[0], REAL, "a real due-today item must come first")
+
+    def test_nothing_is_dropped(self):
+        """Demote, not discard — hiding the owner's reminder is the worse failure."""
+        items = [JUNK_2020, JUNK_1219, REAL]
+        out = self.mb._demote_stale_reminders(items)
+        self.assertEqual(sorted(out), sorted(items))
+
+    def test_year_1219_parses(self):
+        """The first regex used a 16xx-21xx alternation and missed 1219 — the single
+        most obviously-corrupt date on the host went undetected."""
+        self.assertEqual(self.mb._reminder_due_year(JUNK_1219), 1219)
+        self.assertEqual(self.mb._reminder_due_year(JUNK_2020), 2020)
+        self.assertEqual(self.mb._reminder_due_year(REAL), 2026)
+
+    def test_a_recent_overdue_item_is_not_demoted(self):
+        """Year granularity means `year_now - 1` would demote a December item in
+        January — one month overdue, not a year. The bound must be 2 years."""
+        out = self.mb._demote_stale_reminders([LAST_DEC, REAL],
+                                             now=self.mb.datetime(2026, 8, 9).timestamp())
+        self.assertEqual(out[0], LAST_DEC)
+
+    def test_an_unparseable_date_keeps_its_position(self):
+        """A format change must never bury a live reminder."""
+        undated = "[Reminders] No date here"
+        out = self.mb._demote_stale_reminders([undated, REAL])
+        self.assertEqual(out[0], undated)
+
+    def test_empty_and_single_are_safe(self):
+        self.assertEqual(self.mb._demote_stale_reminders([]), [])
+        self.assertEqual(self.mb._demote_stale_reminders([JUNK_1219]), [JUNK_1219])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect, from this morning's live briefing

```
Reminders due: [Reminders] How launch (due Monday, January 13, 2020 at 11:52:42 AM),
               [Reminders] 7-minute timer (due Sunday, November 3, 1219 at 12:00:00 AM)
```

That is the **entire** list. `reminders.py --due-today` returns today's *and overdue* items by contract with no upper bound on how overdue, and the briefing renders them under "Reminders due" — implying action on a six-year-old item and on a corrupt date.

**It is not cosmetic.** `get_reminders()` caps at `items[:5]` and `synthesize()` shows `[:3]`, so these two artifacts hold 2 of 5 slots permanently. On a day with three real reminders, two get crowded out by junk.

## Demote, never drop

They are the owner's data. This module already refuses to render an unreadable calendar as "clear" (#2256) — silently hiding a reminder is that same failure with a different subject. So stale items move to the end of the list and nothing is discarded.

## Two things my own checks caught mid-change

**1. The first regex missed 1219.** I wrote a plausible-looking year pattern, `(?:1[6-9]|2[01])\d{2}`, which covers 16xx–21xx — and therefore does *not* match 1219. The single most obviously-corrupt date on the host was the one my filter skipped, so it stayed first. Any 4-digit run after the literal `due` is the year.

**2. A one-year cutoff is wrong at year granularity.** `year_now - 1` demotes a December item read in January — one month overdue, not a year. The due clause gives only year precision, so the bound is **two calendar years**: the one that precision can justify. Demoting a live reminder is the worse error, so the bound errs toward keeping things visible.

## Verification

```
live junk 2020        demoted=True   (expected True)
live junk 1219        demoted=True   (expected True)
last-Dec 2025         demoted=False  (expected False)
today 2026            demoted=False  (expected False)
no parseable date     demoted=False  (expected False)

[PASS] tests/morning-briefing-stale-reminders.test.py   (6 tests)
[PASS] all 8 tests/morning-briefing-*.test.py suites
[PASS] scripts/gen-src-map.py --check
[PASS] git diff --check origin/main...HEAD
```

**Proven in the broken state:** replacing `return fresh + stale` with `return items` fails `test_the_live_junk_pair_is_demoted_below_a_real_item`; restoring passes 6/6.

An unparseable date keeps its position, so a future format change cannot bury a live reminder.

## Scope

`get_reminders()` return line plus two module-level helpers, and one new test file. No change to what `reminders.py` collects — only to what the briefing puts first.

Stand: Echo Act IV Mini