### PR TITLE
fix(startup): relaunch the menu-bar app that restart.sh stops

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -711,6 +711,24 @@ else
   echo "  ✓ services-status emitter (already running)"
 fi
 
+# Menu-bar app — only for the loose-binary layout. restart.sh stops
+# src/Sutando/Sutando but nothing restarted it, so every restart silently
+# dropped the menu bar. Skipped when com.sutando.menubar owns the app, or when
+# the .app bundle exists, since that layout relaunches via launchd KeepAlive.
+if launchctl print "gui/$(id -u)/com.sutando.menubar" > /dev/null 2>&1; then
+  echo "  ✓ menu bar app (launchd-supervised)"
+elif [ -d "$REPO/src/Sutando/Sutando.app" ]; then
+  echo "  ⊘ menu bar app skipped — .app bundle present, install the launchd job to supervise it"
+elif [ ! -x "$REPO/src/Sutando/Sutando" ]; then
+  echo "  ⊘ menu bar app skipped — no binary at src/Sutando/Sutando"
+elif ! pgrep -f "$REPO/src/Sutando/Sutando" > /dev/null 2>&1; then
+  echo "  Starting menu bar app..."
+  "$REPO/src/Sutando/Sutando" >> "$WORKSPACE/logs/sutando-app.relaunch.log" 2>&1 &
+  echo "  ✓ menu bar app"
+else
+  echo "  ✓ menu bar app (already running)"
+fi
+
 # 0. Credential proxy for quota tracking (port 7846).
 # Prefer the launchd-supervised job (KeepAlive + ThrottleInterval=10s) so the
 # proxy restarts on crash instead of leaving a proxy-routed core stranded on a


### PR DESCRIPTION
## What

`src/restart.sh` stops the menu-bar app and `src/startup.sh` never started it again. Adds the missing relaunch, scoped to the layout that has no other supervisor.

Found live: the owner asked "why is the menu bar app gone?" ~12 minutes after a routine `src/restart.sh`.

## The gap, on origin/main (deaaaf50)

```
$ grep -c "Sutando/Sutando" src/restart.sh
2                 # line 73 pkill, line 91 STOP_PATTERNS drain
$ grep -c "Sutando/Sutando" src/startup.sh
0
```

The stop half is deliberate and careful — `restart.sh` waits for the app to exit cleanly (#499). The start half is simply absent, and because the core, bridges and watcher all return, a restart looks successful from inside the session.

## Why not just install com.sutando.menubar (#1294)

That is the designed owner of relaunch, and it is the right answer **when the .app bundle exists**. It cannot be the answer for a loose-binary host:

```
$ bash src/install-sutando-app-launchd.sh
ERROR: Sutando binary not found: .../src/Sutando/Sutando.app/Contents/MacOS/Sutando
  Build with: swiftc src/Sutando/main.swift -o .../Sutando.app/Contents/MacOS/Sutando

$ ls -d src/Sutando/Sutando.app          # absent
$ codesign -dv src/Sutando/Sutando
Identifier=Sutando
Signature=adhoc                          # linker-signed, no TeamIdentifier
```

Building the bundle re-signs the binary, and the installer's own header warns that macOS resolves TCC by bundle identity — Accessibility and Screen Recording grants do not survive a signing-identity change. So on this layout the choice is "no supervisor" or "a rebuild that silently drops the app's permissions". This PR takes neither: it starts the app on the loose-binary layout and **defers to launchd wherever launchd is in charge**.

## Guard behavior — all four branches exercised

The block was extracted verbatim from the patched `startup.sh` and run against synthetic `$REPO` layouts:

```
CASE 1  no binary                        ->  skipped — no binary at src/Sutando/Sutando
CASE 2  .app bundle present              ->  skipped — .app bundle present, install the launchd job
CASE 3  loose binary, not running        ->  Starting menu bar app... / process started? YES
CASE 4  same host, second run            ->  already running / instance count: 1
```

CASE 4 is the one that matters for `startup.sh` being re-runnable: two invocations leave exactly one process, so a re-run cannot double-start the app.

`launchctl print gui/$(id -u)/com.sutando.menubar` short-circuits ahead of everything else, so a host that later installs the bundle + job gets the launchd path and this block goes quiet on its own.

```
$ bash -n src/startup.sh
bash -n OK
```

## Placement

Immediately after the services-status emitter, matching the surrounding
`if ! pgrep ... else "already running"` convention. `$WORKSPACE` is set at line 613 and `mkdir -p "$WORKSPACE/logs"` runs at 617, both before this block.

## Scope

One concern, one file, +18/-0. No prompt or tool-behavior changes. Does not touch `restart.sh` — the stop half is correct as written.

## Not covered

A host that *should* be on the bundle layout still needs the bundle built and `install-sutando-app-launchd.sh` run; this PR deliberately does not rebuild or re-sign anything, because that trades a missing menu bar for lost TCC grants. That migration is worth doing separately and deliberately.
