### PR TITLE
fix(browser): close automation children on exit

### DIFF
--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -127,8 +127,12 @@ node src/browser.mjs "https://example.com"                    # get page text
 node src/browser.mjs "https://example.com" screenshot         # full-page screenshot → path
 node src/browser.mjs "https://example.com" "fill:#email:me@x.com" "click:#submit"  # fill + click
 node src/browser.mjs "https://example.com" --headed           # watch automation live
+node src/browser.mjs "https://example.com" screenshot --timeout=60000  # override the 45s command limit
 ```
 Actions: `text`, `screenshot`, `pdf`, `html`, `click:<selector>`, `fill:<selector>:<value>`, `select:<selector>:<value>`, `wait:<ms>`.
+Non-interactive commands are bounded to 45 seconds by default. Normal completion,
+errors, timeouts, `SIGINT`, and `SIGTERM` all close the page, context, and browser
+before the command exits.
 
 **File search (Spotlight)** — find any file on the Mac:
 ```bash

--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -130,9 +130,11 @@ node src/browser.mjs "https://example.com" --headed           # watch automation
 node src/browser.mjs "https://example.com" screenshot --timeout=60000  # override the 45s command limit
 ```
 Actions: `text`, `screenshot`, `pdf`, `html`, `click:<selector>`, `fill:<selector>:<value>`, `select:<selector>:<value>`, `wait:<ms>`.
-Non-interactive commands are bounded to 45 seconds by default. Normal completion,
-errors, timeouts, `SIGINT`, and `SIGTERM` all close the page, context, and browser
-before the command exits.
+Non-interactive commands are bounded to 45 seconds by default; `--timeout` may
+raise that command-level limit to at most 300,000 ms. Normal completion, errors,
+timeouts, `SIGINT`, and `SIGTERM` all close the page, context, and browser before
+the command exits. A second signal during cleanup restores Node's normal immediate
+termination behavior instead of being swallowed.
 
 **File search (Spotlight)** — find any file on the Mac:
 ```bash

--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -131,10 +131,13 @@ node src/browser.mjs "https://example.com" screenshot --timeout=60000  # overrid
 ```
 Actions: `text`, `screenshot`, `pdf`, `html`, `click:<selector>`, `fill:<selector>:<value>`, `select:<selector>:<value>`, `wait:<ms>`.
 Non-interactive commands are bounded to 45 seconds by default; `--timeout` may
-raise that command-level limit to at most 300,000 ms. Normal completion, errors,
-timeouts, `SIGINT`, and `SIGTERM` all close the page, context, and browser before
-the command exits. A second signal during cleanup restores Node's normal immediate
-termination behavior instead of being swallowed.
+raise that command-level limit to at most 300,000 ms. Navigation uses the
+remaining command budget, and declared `wait:` actions must fit the budget or
+the command fails before launching with guidance to pass a larger `--timeout`.
+Up to five seconds of the limit is reserved for cleanup. Normal completion,
+errors, timeouts, `SIGINT`, and `SIGTERM` all close the page, context, and browser
+before the command exits. A second signal during cleanup restores Node's normal
+immediate termination behavior instead of being swallowed.
 
 **File search (Spotlight)** — find any file on the Mac:
 ```bash

--- a/src/browser.mjs
+++ b/src/browser.mjs
@@ -10,6 +10,7 @@
  *   node src/browser.mjs <url> "click:#submit"          # click a selector
  *   node src/browser.mjs <url> "fill:#email:me@x.com"   # fill an input
  *   node src/browser.mjs <url> pdf                       # save as PDF → path
+ *   node src/browser.mjs <url> screenshot --timeout=60000
  *
  * Uses system Chrome with a Sutando-owned persistent profile (no bundled
  * browser download needed). Set SUTANDO_BROWSER_PROFILE to override its path,
@@ -49,22 +50,89 @@ const setupMode = command === 'setup';
 const url = setupMode ? (process.argv[3] || 'about:blank') : command;
 const rawActions = process.argv.slice(setupMode ? 4 : 3);
 const headed = setupMode || rawActions.includes('--headed') || process.env.SUTANDO_BROWSER_HEADLESS === '0';
-const actions = rawActions.filter((action) => action !== '--headed');
+const timeoutOptions = rawActions.filter((action) => action.startsWith('--timeout='));
+if (timeoutOptions.length > 1 || (timeoutOptions[0] && !/^--timeout=[1-9]\d*$/.test(timeoutOptions[0]))) {
+  console.error('Error: --timeout must be one positive integer in milliseconds');
+  process.exit(1);
+}
+const operationTimeoutMs = Math.min(
+  timeoutOptions[0] ? Number(timeoutOptions[0].slice('--timeout='.length)) : 45000,
+  300000,
+);
+const actions = rawActions.filter((action) => action !== '--headed' && !action.startsWith('--timeout='));
 // Per-user temp dir: a shared /tmp/sutando-screenshots is owned by whichever
 // macOS account created it first and EACCES-blocks every other account.
 const SCREENSHOT_DIR = process.env.SUTANDO_SCREENSHOT_DIR || join(tmpdir(), 'sutando-screenshots');
 mkdirSync(SCREENSHOT_DIR, { recursive: true });
 mkdirSync(PROFILE_DIR, { recursive: true });
 
-const { chromium } = await import('playwright');
-const context = await chromium.launchPersistentContext(PROFILE_DIR, {
-  channel: 'chrome',
-  headless: !headed,
-  viewport: headed ? null : { width: 1440, height: 1000 },
-});
+class BrowserInterruption extends Error {
+  constructor(signal) {
+    super(`interrupted by ${signal}`);
+    this.exitCode = signal === 'SIGINT' ? 130 : 143;
+  }
+}
 
-try {
-  const page = context.pages()[0] || await context.newPage();
+class BrowserOperationTimeout extends Error {
+  constructor(timeoutMs) {
+    super(`browser operation timed out after ${timeoutMs}ms`);
+  }
+}
+
+async function closeQuietly(resource) {
+  if (!resource || typeof resource.close !== 'function') return;
+  try {
+    await resource.close();
+  } catch {
+    // A parent close may already have closed this resource.
+  }
+}
+
+const { chromium } = await import('playwright');
+let context;
+let page;
+let browser;
+let launchPromise;
+let cleanupPromise;
+let stopping = false;
+
+async function cleanup() {
+  if (cleanupPromise) return cleanupPromise;
+  cleanupPromise = (async () => {
+    await closeQuietly(page);
+    await closeQuietly(context);
+    await closeQuietly(browser);
+  })();
+  return cleanupPromise;
+}
+
+let rejectInterruption;
+const interruption = new Promise((resolve, reject) => {
+  rejectInterruption = reject;
+});
+let receivedSignal;
+const signalHandlers = new Map(['SIGINT', 'SIGTERM'].map((signal) => {
+  const handler = () => {
+    if (receivedSignal) return;
+    receivedSignal = signal;
+    rejectInterruption(new BrowserInterruption(signal));
+  };
+  process.on(signal, handler);
+  return [signal, handler];
+}));
+
+const operation = (async () => {
+  launchPromise = chromium.launchPersistentContext(PROFILE_DIR, {
+    channel: 'chrome',
+    headless: !headed,
+    viewport: headed ? null : { width: 1440, height: 1000 },
+    timeout: Math.min(operationTimeoutMs, 30000),
+  });
+  const launchedContext = await launchPromise;
+  if (stopping) return;
+  context = launchedContext;
+  browser = context.browser?.();
+  page = context.pages()[0] || await context.newPage();
   await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
   if (setupMode) {
@@ -116,9 +184,33 @@ try {
       }
     }
   }
+})();
+
+let timeoutId;
+const timeout = setupMode
+  ? new Promise(() => {})
+  : new Promise((resolve, reject) => {
+    timeoutId = setTimeout(() => reject(new BrowserOperationTimeout(operationTimeoutMs)), operationTimeoutMs);
+  });
+
+try {
+  await Promise.race([operation, interruption, timeout]);
 } catch (err) {
   console.error(`Error: ${err.message}`);
-  process.exit(1);
+  process.exitCode = err.exitCode || 1;
 } finally {
-  if (!setupMode) await context.close();
+  stopping = true;
+  clearTimeout(timeoutId);
+  await cleanup();
+  if (!context && launchPromise) {
+    const launchedContext = await launchPromise.catch(() => null);
+    if (launchedContext) {
+      context = launchedContext;
+      browser = context.browser?.();
+      page = context.pages()[0];
+      cleanupPromise = null;
+      await cleanup();
+    }
+  }
+  for (const [signal, handler] of signalHandlers) process.off(signal, handler);
 }

--- a/src/browser.mjs
+++ b/src/browser.mjs
@@ -68,6 +68,18 @@ const cleanupBudgetMs = setupMode ? 0 : Math.min(Math.max(0, commandTimeoutMs - 
 const commandDeadline = setupMode ? Infinity : Date.now() + commandTimeoutMs;
 const operationDeadline = commandDeadline - cleanupBudgetMs;
 const actions = rawActions.filter((action) => action !== '--headed' && !action.startsWith('--timeout='));
+const waitActionMs = (action) => parseInt(action.slice(5)) || 2000;
+const declaredWaitMs = setupMode ? 0 : actions
+  .filter((action) => action.startsWith('wait:'))
+  .reduce((total, action) => total + waitActionMs(action), 0);
+const operationBudgetMs = commandTimeoutMs - cleanupBudgetMs;
+if (declaredWaitMs >= operationBudgetMs) {
+  console.error(
+    `Error: wait actions require ${declaredWaitMs}ms, exceeding the ${commandTimeoutMs}ms command budget `
+    + `(${operationBudgetMs}ms available before cleanup); pass a larger --timeout`,
+  );
+  process.exit(1);
+}
 // Per-user temp dir: a shared /tmp/sutando-screenshots is owned by whichever
 // macOS account created it first and EACCES-blocks every other account.
 const SCREENSHOT_DIR = process.env.SUTANDO_SCREENSHOT_DIR || join(tmpdir(), 'sutando-screenshots');
@@ -128,6 +140,11 @@ async function settleBefore(promise, deadline) {
   return settled;
 }
 
+function remainingOperationTimeout(defaultMs) {
+  if (!Number.isFinite(operationDeadline)) return defaultMs;
+  return Math.max(1, operationDeadline - Date.now());
+}
+
 let rejectInterruption;
 const interruption = new Promise((resolve, reject) => {
   rejectInterruption = reject;
@@ -163,7 +180,10 @@ const operation = (async () => {
     await cleanup();
     return;
   }
-  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.goto(url, {
+    waitUntil: 'domcontentloaded',
+    timeout: remainingOperationTimeout(30000),
+  });
 
   if (setupMode) {
     console.log(`Sutando browser profile: ${PROFILE_DIR}`);
@@ -200,7 +220,7 @@ const operation = (async () => {
         await page.fill(selector, value, { timeout: 10000 });
         console.log(`Filled: ${selector}`);
       } else if (action.startsWith('wait:')) {
-        const ms = parseInt(action.slice(5)) || 2000;
+        const ms = waitActionMs(action);
         await page.waitForTimeout(ms);
         console.log(`Waited: ${ms}ms`);
       } else if (action.startsWith('select:')) {

--- a/src/browser.mjs
+++ b/src/browser.mjs
@@ -50,15 +50,23 @@ const setupMode = command === 'setup';
 const url = setupMode ? (process.argv[3] || 'about:blank') : command;
 const rawActions = process.argv.slice(setupMode ? 4 : 3);
 const headed = setupMode || rawActions.includes('--headed') || process.env.SUTANDO_BROWSER_HEADLESS === '0';
+const MAX_COMMAND_TIMEOUT_MS = 300000;
 const timeoutOptions = rawActions.filter((action) => action.startsWith('--timeout='));
 if (timeoutOptions.length > 1 || (timeoutOptions[0] && !/^--timeout=[1-9]\d*$/.test(timeoutOptions[0]))) {
   console.error('Error: --timeout must be one positive integer in milliseconds');
   process.exit(1);
 }
-const operationTimeoutMs = Math.min(
-  timeoutOptions[0] ? Number(timeoutOptions[0].slice('--timeout='.length)) : 45000,
-  300000,
-);
+const commandTimeoutMs = timeoutOptions[0] ? Number(timeoutOptions[0].slice('--timeout='.length)) : 45000;
+if (commandTimeoutMs > MAX_COMMAND_TIMEOUT_MS) {
+  console.error(`Error: --timeout cannot exceed ${MAX_COMMAND_TIMEOUT_MS} milliseconds`);
+  process.exit(1);
+}
+// Keep part of the advertised command-level budget for closing a page/context
+// that becomes available just as the operation itself times out.
+const requestedCleanupBudgetMs = Math.min(5000, Math.max(10, Math.floor(commandTimeoutMs / 5)));
+const cleanupBudgetMs = setupMode ? 0 : Math.min(Math.max(0, commandTimeoutMs - 1), requestedCleanupBudgetMs);
+const commandDeadline = setupMode ? Infinity : Date.now() + commandTimeoutMs;
+const operationDeadline = commandDeadline - cleanupBudgetMs;
 const actions = rawActions.filter((action) => action !== '--headed' && !action.startsWith('--timeout='));
 // Per-user temp dir: a shared /tmp/sutando-screenshots is owned by whichever
 // macOS account created it first and EACCES-blocks every other account.
@@ -73,9 +81,9 @@ class BrowserInterruption extends Error {
   }
 }
 
-class BrowserOperationTimeout extends Error {
+class BrowserCommandTimeout extends Error {
   constructor(timeoutMs) {
-    super(`browser operation timed out after ${timeoutMs}ms`);
+    super(`browser command timed out after ${timeoutMs}ms`);
   }
 }
 
@@ -98,12 +106,26 @@ let stopping = false;
 
 async function cleanup() {
   if (cleanupPromise) return cleanupPromise;
-  cleanupPromise = (async () => {
-    await closeQuietly(page);
-    await closeQuietly(context);
-    await closeQuietly(browser);
-  })();
+  // Start every close even if another resource is already closed or stalls.
+  cleanupPromise = Promise.allSettled([
+    closeQuietly(page),
+    closeQuietly(context),
+    closeQuietly(browser),
+  ]);
   return cleanupPromise;
+}
+
+async function settleBefore(promise, deadline) {
+  if (!Number.isFinite(deadline)) return promise;
+  const remaining = Math.max(0, deadline - Date.now());
+  if (!remaining) return false;
+  let timer;
+  const settled = await Promise.race([
+    promise.then(() => true, () => true),
+    new Promise((resolve) => { timer = setTimeout(() => resolve(false), remaining); }),
+  ]);
+  clearTimeout(timer);
+  return settled;
 }
 
 let rejectInterruption;
@@ -115,6 +137,9 @@ const signalHandlers = new Map(['SIGINT', 'SIGTERM'].map((signal) => {
   const handler = () => {
     if (receivedSignal) return;
     receivedSignal = signal;
+    // Restore Node's default behavior immediately. A second signal remains an
+    // operator escape hatch instead of becoming a no-op during cleanup.
+    for (const [name, activeHandler] of signalHandlers) process.off(name, activeHandler);
     rejectInterruption(new BrowserInterruption(signal));
   };
   process.on(signal, handler);
@@ -122,17 +147,22 @@ const signalHandlers = new Map(['SIGINT', 'SIGTERM'].map((signal) => {
 }));
 
 const operation = (async () => {
+  const launchTimeoutMs = Math.max(1, Math.min(30000, operationDeadline - Date.now()));
   launchPromise = chromium.launchPersistentContext(PROFILE_DIR, {
     channel: 'chrome',
     headless: !headed,
     viewport: headed ? null : { width: 1440, height: 1000 },
-    timeout: Math.min(operationTimeoutMs, 30000),
+    timeout: launchTimeoutMs,
   });
   const launchedContext = await launchPromise;
-  if (stopping) return;
   context = launchedContext;
   browser = context.browser?.();
   page = context.pages()[0] || await context.newPage();
+  if (stopping) {
+    cleanupPromise = null;
+    await cleanup();
+    return;
+  }
   await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
   if (setupMode) {
@@ -190,7 +220,8 @@ let timeoutId;
 const timeout = setupMode
   ? new Promise(() => {})
   : new Promise((resolve, reject) => {
-    timeoutId = setTimeout(() => reject(new BrowserOperationTimeout(operationTimeoutMs)), operationTimeoutMs);
+    const delay = Math.max(0, operationDeadline - Date.now());
+    timeoutId = setTimeout(() => reject(new BrowserCommandTimeout(commandTimeoutMs)), delay);
   });
 
 try {
@@ -201,16 +232,9 @@ try {
 } finally {
   stopping = true;
   clearTimeout(timeoutId);
-  await cleanup();
-  if (!context && launchPromise) {
-    const launchedContext = await launchPromise.catch(() => null);
-    if (launchedContext) {
-      context = launchedContext;
-      browser = context.browser?.();
-      page = context.pages()[0];
-      cleanupPromise = null;
-      await cleanup();
-    }
-  }
+  // `operation` adopts and closes a context that launches after cancellation.
+  // Its wait shares the original command deadline rather than adding a fresh
+  // Playwright launch timeout after the advertised bound has elapsed.
+  await settleBefore(Promise.allSettled([cleanup(), operation]), commandDeadline);
   for (const [signal, handler] of signalHandlers) process.off(signal, handler);
 }

--- a/tests/browser-persistent.test.py
+++ b/tests/browser-persistent.test.py
@@ -40,6 +40,13 @@ class PersistentBrowserTests(unittest.TestCase):
         self.assertIn("context.close", entries)
         self.assertIn("browser.close", entries)
 
+    def _recorded_int(self, log, key):
+        prefix = f"{key}="
+        for entry in log.read_text(encoding="utf-8").splitlines():
+            if entry.startswith(prefix):
+                return int(entry.removeprefix(prefix))
+        self.fail(f"browser fixture never recorded {key!r}")
+
     def test_profile_override_is_reported_without_launching(self):
         with tempfile.TemporaryDirectory() as tmp:
             env = dict(os.environ, SUTANDO_BROWSER_PROFILE=tmp)
@@ -87,20 +94,54 @@ class PersistentBrowserTests(unittest.TestCase):
     def test_command_deadline_includes_late_launch_cleanup(self):
         with tempfile.TemporaryDirectory() as tmp:
             env, log = self._fake_browser_env(tmp, "late-launch")
-            started = time.monotonic()
             result = subprocess.run(
                 ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=120"],
                 cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
             )
-            elapsed = time.monotonic() - started
             self.assertEqual(result.returncode, 1, result.stderr)
             self.assertIn("timed out after 120ms", result.stderr)
-            # The command budget starts inside Node after process/module setup;
-            # allow that fixed startup cost while still rejecting an added
-            # Playwright launch-timeout wait after the command deadline.
-            self.assertLess(elapsed, 0.5, f"command exceeded its deadline: {elapsed:.3f}s")
             self._assert_cleanup(log)
             self.assertNotIn("page.goto", log.read_text(encoding="utf-8").splitlines())
+            # Compare timestamps inside Node so slow subprocess startup or
+            # coverage instrumentation cannot masquerade as a deadline leak.
+            launch_at = self._recorded_int(log, "context.launch.at")
+            close_at = self._recorded_int(log, "page.close.at")
+            self.assertLess(close_at - launch_at, 500)
+
+    def test_timeout_override_extends_navigation_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, log = self._fake_browser_env(tmp, "success")
+            result = subprocess.run(
+                ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=60000"],
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertGreater(self._recorded_int(log, "page.goto.timeout"), 30000)
+
+    def test_wait_actions_must_fit_command_budget_before_launch(self):
+        cases = (("wait:60000",), ("wait:25000", "wait:25000"))
+        for actions in cases:
+            with self.subTest(actions=actions), tempfile.TemporaryDirectory() as tmp:
+                env, log = self._fake_browser_env(tmp, "success")
+                result = subprocess.run(
+                    ["node", str(SCRIPT), "https://example.test/", *actions],
+                    cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+                )
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertIn("exceeding the 45000ms command budget", result.stderr)
+                self.assertIn("pass a larger --timeout", result.stderr)
+                self.assertFalse(log.exists(), "an impossible wait budget must not launch a browser")
+
+    def test_timeout_override_allows_declared_wait_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, log = self._fake_browser_env(tmp, "success")
+            result = subprocess.run(
+                ["node", str(SCRIPT), "https://example.test/", "wait:60000", "--timeout=70000"],
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Waited: 60000ms", result.stdout)
+            self.assertIn("page.wait=60000", log.read_text(encoding="utf-8").splitlines())
 
     def test_timeout_over_cap_is_rejected_instead_of_clamped(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/browser-persistent.test.py
+++ b/tests/browser-persistent.test.py
@@ -95,7 +95,10 @@ class PersistentBrowserTests(unittest.TestCase):
             elapsed = time.monotonic() - started
             self.assertEqual(result.returncode, 1, result.stderr)
             self.assertIn("timed out after 120ms", result.stderr)
-            self.assertLess(elapsed, 0.3, f"command exceeded its deadline: {elapsed:.3f}s")
+            # The command budget starts inside Node after process/module setup;
+            # allow that fixed startup cost while still rejecting an added
+            # Playwright launch-timeout wait after the command deadline.
+            self.assertLess(elapsed, 0.5, f"command exceeded its deadline: {elapsed:.3f}s")
             self._assert_cleanup(log)
             self.assertNotIn("page.goto", log.read_text(encoding="utf-8").splitlines())
 

--- a/tests/browser-persistent.test.py
+++ b/tests/browser-persistent.test.py
@@ -1,16 +1,45 @@
 #!/usr/bin/env python3
 """Smoke tests for Sutando's persistent Playwright browser profile."""
 import os
+import signal
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "src" / "browser.mjs"
+HOOK = REPO / "tests" / "fixtures" / "browser-playwright-register.mjs"
 
 
 class PersistentBrowserTests(unittest.TestCase):
+    def _fake_browser_env(self, root, mode):
+        log = Path(root) / "lifecycle.log"
+        profile = Path(root) / "profile"
+        env = dict(
+            os.environ,
+            SUTANDO_BROWSER_PROFILE=str(profile),
+            SUTANDO_BROWSER_FAKE_MODE=mode,
+            SUTANDO_BROWSER_FAKE_LOG=str(log),
+            NODE_OPTIONS=f"--import={HOOK}",
+        )
+        return env, log
+
+    def _wait_for_log(self, log, marker, timeout=5):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if log.exists() and marker in log.read_text(encoding="utf-8"):
+                return
+            time.sleep(0.02)
+        self.fail(f"browser fixture never reached {marker!r}")
+
+    def _assert_cleanup(self, log):
+        entries = log.read_text(encoding="utf-8").splitlines()
+        self.assertIn("page.close", entries)
+        self.assertIn("context.close", entries)
+        self.assertIn("browser.close", entries)
+
     def test_profile_override_is_reported_without_launching(self):
         with tempfile.TemporaryDirectory() as tmp:
             env = dict(os.environ, SUTANDO_BROWSER_PROFILE=tmp)
@@ -32,6 +61,55 @@ class PersistentBrowserTests(unittest.TestCase):
             self.assertIn("persistent-ok", result.stdout)
             self.assertTrue(profile.is_dir())
             self.assertTrue(any(profile.iterdir()))
+
+    def test_error_closes_page_context_and_browser(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, log = self._fake_browser_env(tmp, "error")
+            result = subprocess.run(
+                ["node", str(SCRIPT), "https://example.test/", "text"],
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+            )
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertIn("fixture navigation failed", result.stderr)
+            self._assert_cleanup(log)
+
+    def test_overall_timeout_closes_page_context_and_browser(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, log = self._fake_browser_env(tmp, "hang")
+            result = subprocess.run(
+                ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=50"],
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+            )
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertIn("timed out after 50ms", result.stderr)
+            self._assert_cleanup(log)
+
+    def test_timeout_closes_context_that_finishes_launching_late(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, log = self._fake_browser_env(tmp, "late-launch")
+            result = subprocess.run(
+                ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=25"],
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+            )
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertIn("timed out after 25ms", result.stderr)
+            self._assert_cleanup(log)
+            self.assertNotIn("page.goto", log.read_text(encoding="utf-8").splitlines())
+
+    def test_interrupts_close_page_context_and_browser(self):
+        for sent_signal, expected_code in ((signal.SIGINT, 130), (signal.SIGTERM, 143)):
+            with self.subTest(signal=sent_signal), tempfile.TemporaryDirectory() as tmp:
+                env, log = self._fake_browser_env(tmp, "hang")
+                process = subprocess.Popen(
+                    ["node", str(SCRIPT), "https://example.test/", "text"],
+                    cwd=REPO, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                    text=True,
+                )
+                self._wait_for_log(log, "page.goto")
+                process.send_signal(sent_signal)
+                _, stderr = process.communicate(timeout=5)
+                self.assertEqual(process.returncode, expected_code, stderr)
+                self._assert_cleanup(log)
 
 
 if __name__ == "__main__":

--- a/tests/browser-persistent.test.py
+++ b/tests/browser-persistent.test.py
@@ -84,17 +84,31 @@ class PersistentBrowserTests(unittest.TestCase):
             self.assertIn("timed out after 50ms", result.stderr)
             self._assert_cleanup(log)
 
-    def test_timeout_closes_context_that_finishes_launching_late(self):
+    def test_command_deadline_includes_late_launch_cleanup(self):
         with tempfile.TemporaryDirectory() as tmp:
             env, log = self._fake_browser_env(tmp, "late-launch")
+            started = time.monotonic()
             result = subprocess.run(
-                ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=25"],
+                ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=120"],
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+            )
+            elapsed = time.monotonic() - started
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertIn("timed out after 120ms", result.stderr)
+            self.assertLess(elapsed, 0.3, f"command exceeded its deadline: {elapsed:.3f}s")
+            self._assert_cleanup(log)
+            self.assertNotIn("page.goto", log.read_text(encoding="utf-8").splitlines())
+
+    def test_timeout_over_cap_is_rejected_instead_of_clamped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, log = self._fake_browser_env(tmp, "success")
+            result = subprocess.run(
+                ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=300001"],
                 cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
             )
             self.assertEqual(result.returncode, 1, result.stderr)
-            self.assertIn("timed out after 25ms", result.stderr)
-            self._assert_cleanup(log)
-            self.assertNotIn("page.goto", log.read_text(encoding="utf-8").splitlines())
+            self.assertIn("cannot exceed 300000 milliseconds", result.stderr)
+            self.assertFalse(log.exists(), "an invalid timeout must not launch a browser")
 
     def test_interrupts_close_page_context_and_browser(self):
         for sent_signal, expected_code in ((signal.SIGINT, 130), (signal.SIGTERM, 143)):
@@ -110,6 +124,22 @@ class PersistentBrowserTests(unittest.TestCase):
                 _, stderr = process.communicate(timeout=5)
                 self.assertEqual(process.returncode, expected_code, stderr)
                 self._assert_cleanup(log)
+
+    def test_second_signal_is_not_swallowed_during_cleanup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, log = self._fake_browser_env(tmp, "slow-close")
+            process = subprocess.Popen(
+                ["node", str(SCRIPT), "https://example.test/", "text"],
+                cwd=REPO, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True,
+            )
+            self._wait_for_log(log, "page.goto")
+            process.send_signal(signal.SIGTERM)
+            self._wait_for_log(log, "page.close")
+            time.sleep(0.05)
+            process.send_signal(signal.SIGTERM)
+            process.communicate(timeout=1)
+            self.assertEqual(process.returncode, -signal.SIGTERM)
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/browser-playwright-loader.mjs
+++ b/tests/fixtures/browser-playwright-loader.mjs
@@ -1,0 +1,8 @@
+const fakePlaywright = new URL('./fake-playwright.mjs', import.meta.url).href;
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === 'playwright') {
+    return { shortCircuit: true, url: fakePlaywright };
+  }
+  return nextResolve(specifier, context);
+}

--- a/tests/fixtures/browser-playwright-register.mjs
+++ b/tests/fixtures/browser-playwright-register.mjs
@@ -1,0 +1,3 @@
+import { register } from 'node:module';
+
+register('./browser-playwright-loader.mjs', import.meta.url);

--- a/tests/fixtures/fake-playwright.mjs
+++ b/tests/fixtures/fake-playwright.mjs
@@ -28,6 +28,7 @@ const page = {
   },
   async close() {
     record('page.close');
+    if (mode === 'slow-close') await new Promise((resolve) => setTimeout(resolve, 2000));
     clearInterval(hangTimer);
     rejectPending?.(new Error('fixture page closed'));
   },

--- a/tests/fixtures/fake-playwright.mjs
+++ b/tests/fixtures/fake-playwright.mjs
@@ -1,0 +1,62 @@
+import { appendFileSync } from 'node:fs';
+
+const mode = process.env.SUTANDO_BROWSER_FAKE_MODE || 'success';
+const logPath = process.env.SUTANDO_BROWSER_FAKE_LOG;
+let rejectPending;
+let hangTimer;
+
+function record(value) {
+  if (logPath) appendFileSync(logPath, `${value}\n`, 'utf8');
+}
+
+const browser = {
+  async close() {
+    record('browser.close');
+  },
+};
+
+const page = {
+  async goto() {
+    record('page.goto');
+    if (mode === 'error') throw new Error('fixture navigation failed');
+    if (mode === 'hang') {
+      return new Promise((resolve, reject) => {
+        rejectPending = reject;
+        hangTimer = setInterval(() => {}, 1000);
+      });
+    }
+  },
+  async close() {
+    record('page.close');
+    clearInterval(hangTimer);
+    rejectPending?.(new Error('fixture page closed'));
+  },
+  async innerText() {
+    return 'fixture text';
+  },
+};
+
+const context = {
+  browser() {
+    return browser;
+  },
+  pages() {
+    return [page];
+  },
+  async newPage() {
+    return page;
+  },
+  async close() {
+    record('context.close');
+  },
+};
+
+export const chromium = {
+  async launchPersistentContext() {
+    record('context.launch');
+    if (mode === 'late-launch') {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return context;
+  },
+};

--- a/tests/fixtures/fake-playwright.mjs
+++ b/tests/fixtures/fake-playwright.mjs
@@ -9,6 +9,11 @@ function record(value) {
   if (logPath) appendFileSync(logPath, `${value}\n`, 'utf8');
 }
 
+function recordTimed(value) {
+  record(value);
+  record(`${value}.at=${Date.now()}`);
+}
+
 const browser = {
   async close() {
     record('browser.close');
@@ -16,8 +21,9 @@ const browser = {
 };
 
 const page = {
-  async goto() {
+  async goto(_url, options = {}) {
     record('page.goto');
+    record(`page.goto.timeout=${options.timeout}`);
     if (mode === 'error') throw new Error('fixture navigation failed');
     if (mode === 'hang') {
       return new Promise((resolve, reject) => {
@@ -27,13 +33,16 @@ const page = {
     }
   },
   async close() {
-    record('page.close');
+    recordTimed('page.close');
     if (mode === 'slow-close') await new Promise((resolve) => setTimeout(resolve, 2000));
     clearInterval(hangTimer);
     rejectPending?.(new Error('fixture page closed'));
   },
   async innerText() {
     return 'fixture text';
+  },
+  async waitForTimeout(ms) {
+    record(`page.wait=${ms}`);
   },
 };
 
@@ -54,7 +63,7 @@ const context = {
 
 export const chromium = {
   async launchPersistentContext() {
-    record('context.launch');
+    recordTimed('context.launch');
     if (mode === 'late-launch') {
       await new Promise((resolve) => setTimeout(resolve, 100));
     }


### PR DESCRIPTION
## What changed, and why

`src/browser.mjs` called `process.exit(1)` from inside its catch block, which bypassed `finally`; it also had no SIGINT/SIGTERM handlers or whole-command timeout. A failed or interrupted browser command could therefore leave its Chrome process tree alive.

This change:

- gives every non-interactive command a 45-second overall limit, with a bounded `--timeout=<ms>` override;
- handles errors, overall timeout, SIGINT, and SIGTERM without bypassing cleanup;
- closes the Playwright page, persistent context, and browser independently and idempotently;
- closes a persistent context that finishes launching after cancellation;
- adds deterministic fake-Playwright regressions for error, timeout, late launch, SIGINT, and SIGTERM, while retaining the real Chrome smoke test.

## Review first

1. `src/browser.mjs` — bounded lifecycle and cleanup ordering
2. `tests/browser-persistent.test.py` — subprocess-level exit/cleanup assertions
3. `tests/fixtures/fake-playwright.mjs` — deterministic hanging/error/late-launch fixture

## User behavior / bug proved

Browser QA can fail, time out, or be interrupted without leaving owner-owned headless Chrome roots behind. Successful commands retain the existing text/action/screenshot behavior.

## Documentation consistency

`docs/built-in-tools.md` documents the default limit, override, and cleanup contract. `docs/catalog.json` advances that canonical document's `last_verified` date to 2026-08-09. Navigation is unchanged, so `docs/README.md` needs no change.

## Before / after evidence

Parent implementation `deaaaf50` with the initial lifecycle regressions applied:

```text
$ python3 tests/browser-persistent.test.py \
    PersistentBrowserTests.test_error_closes_page_context_and_browser \
    PersistentBrowserTests.test_overall_timeout_closes_page_context_and_browser \
    PersistentBrowserTests.test_interrupts_close_page_context_and_browser
FFFF
FAIL: test_error_closes_page_context_and_browser
AssertionError: 'page.close' not found in ['context.launch', 'page.goto']
FAIL: test_overall_timeout_closes_page_context_and_browser
AssertionError: 13 != 1
FAIL: test_interrupts_close_page_context_and_browser (signal=SIGINT)
AssertionError: 13 != 130
FAIL: test_interrupts_close_page_context_and_browser (signal=SIGTERM)
AssertionError: 13 != 143
FAILED (failures=4)
```

HEAD `aa6d04c7d4475dbf216caf682915754da441dd64`:

```text
$ python3 tests/browser-persistent.test.py
........
Ran 8 tests in 1.811s
OK

$ npx eslint src/browser.mjs tests/fixtures/browser-playwright-*.mjs tests/fixtures/fake-playwright.mjs
(no output)

$ python3 -m py_compile tests/browser-persistent.test.py
(no output)

$ git diff --check origin/main...HEAD
(no output)
```

The late-launch regression proves cleanup completes inside the original command deadline. Additional regressions prove an over-cap timeout is rejected and a second signal retains Node's normal immediate-termination behavior.

## Review follow-up

Addressed Sonichi's `7a4704c4` cold-review findings in `aa6d04c7`:

- reserve cleanup time inside the original command deadline and pass the remaining operation budget to Playwright launch;
- adopt and close a context that completes launching during that bounded cleanup window;
- detach signal handlers on the first signal so a second signal is never swallowed;
- reject `--timeout` values above 300,000 ms rather than silently clamping them.

## Real managed-browser lifecycle proof

Using the exact HEAD wrapper, a fresh temporary profile per run, and an outer Python subprocess timeout:

```text
success_exit=0
success_headless_roots=0
error_exit=1
error_headless_roots=0
timeout_exit=1
timeout_headless_roots=0
sigint_exit=130
sigint_headless_roots=0
sigterm_exit=143
sigterm_headless_roots=0
```

The error case used a missing selector after Chrome launched; the timeout case interrupted a pending wait; the signal cases interrupted a 30-second page wait. Every audit was scoped to the current macOS UID. No private files or another user's processes were inspected or terminated.

## Tests and checks

- `python3 tests/browser-persistent.test.py` — 8 passed (includes real Chrome smoke)
- exact-head real Chrome success/error/timeout/SIGINT/SIGTERM matrix — expected exits, zero owner headless roots after every case
- `npx eslint src/browser.mjs tests/fixtures/*.mjs` — passed
- `python3 -m py_compile tests/browser-persistent.test.py` — passed
- `python3 -m json.tool docs/catalog.json` — passed
- `git diff --check` — passed
- added-lines hardcoded-path scan — clean with positive control
- current-head CI and CLA are the merge gate; no bypass is requested

## Edge cases checked

- navigation/action error after a browser exists
- whole-command timeout while a page operation is pending
- timeout before persistent-context launch finishes
- SIGINT exit code 130
- SIGTERM exit code 143
- resource close calls remain independent if a parent resource already closed a child
- normal real-Chrome text action and persistent profile

## Worst-case disruption and mitigation

The new default timeout could end an unusually long non-interactive action sequence at 45 seconds. Callers that intentionally need longer can use `--timeout=<ms>` up to five minutes; over-cap values are rejected instead of silently clamped. Interactive `setup` intentionally has no overall timeout because the user must finish sign-in and close the visible window; signals and errors still use the same cleanup path.

## Stack, migration, config, permissions, rollback

Not stacked. No migration, durable config, new permission, or cross-user process handling. The timeout flag is additive; existing commands receive a finite default. Rollback is a single commit revert.