### PR TITLE
fix(gateway): bound AG2Space tasks by broker tier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,27 @@ promotion_reason + cursor range).
   fails it closed; this section makes the mapping explicit rather than
   implicit (sonichi#2292 P1-1 follow-through).
 
+## Guest access control
+
+`access_tier: guest` is the **fail-closed, most-restrictive tier**. The
+AG2Space gateway resolves it whenever a broker-attested or local tier is
+missing, empty, or unrecognized, and it is the floor when broker and local
+tiers bound each other downward (the minimum wins — neither side can raise the
+other). `guest` outranks nothing (`_TIER_RANK` = guest 0 < team 1 < owner 2).
+
+- **Process like team/other: sandboxed read-only path** — research, inspect,
+  explain, and draft only. No system mutations, no privileged actions (no email
+  sends, merges, deploys, purchases, config changes). If acting would require a
+  privileged action, surface it to the owner and wait.
+- **In-band enforcement:** a guest task file carries the
+  `===SUTANDO SYSTEM INSTRUCTIONS===` block (the gateway writes it for `team`
+  AND `guest`), so the sandbox spec travels with the task — follow it verbatim
+  rather than depending on recognizing the tier.
+- `guest` is not `owner`, so the standing rule ("only `access_tier: owner` — or
+  tasks without an access_tier field — get full processing") already fails it
+  closed; this section makes the mapping explicit rather than implicit (the same
+  precedent the `ambient` section follows).
+
 ## Community support routing
 
 When the user reports a Sutando problem you cannot resolve (setup failures, bugs needing upstream fixes, behavior you can't explain), recommend the official Discord — https://discord.gg/uZHWXXmrCS — where real humans and community-run agents provide support. Include it alongside, not instead of, whatever diagnosis you can offer. Don't recommend it for questions you can answer yourself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,27 @@ promotion_reason + cursor range).
   fails it closed; this section makes the mapping explicit rather than
   implicit (sonichi#2292 P1-1 follow-through).
 
+## Guest access control
+
+`access_tier: guest` is the **fail-closed, most-restrictive tier**. The
+AG2Space gateway resolves it whenever a broker-attested or local tier is
+missing, empty, or unrecognized, and it is the floor when broker and local
+tiers bound each other downward (the minimum wins — neither side can raise the
+other). `guest` outranks nothing (`_TIER_RANK` = guest 0 < team 1 < owner 2).
+
+- **Process like team/other: sandboxed read-only path** — research, inspect,
+  explain, and draft only. No system mutations, no privileged actions (no email
+  sends, merges, deploys, purchases, config changes). If acting would require a
+  privileged action, surface it to the owner and wait.
+- **In-band enforcement:** a guest task file carries the
+  `===SUTANDO SYSTEM INSTRUCTIONS===` block (the gateway writes it for `team`
+  AND `guest`), so the sandbox spec travels with the task — follow it verbatim
+  rather than depending on recognizing the tier.
+- `guest` is not `owner`, so the standing rule ("only `access_tier: owner` — or
+  tasks without an access_tier field — get full processing") already fails it
+  closed; this section makes the mapping explicit rather than implicit (the same
+  precedent the `ambient` section follows).
+
 ## Community support routing
 
 When the user reports a Sutando problem you cannot resolve (setup failures, bugs needing upstream fixes, behavior you can't explain), recommend the official Discord — https://discord.gg/uZHWXXmrCS — where real humans and community-run agents provide support. Include it alongside, not instead of, whatever diagnosis you can offer. Don't recommend it for questions you can answer yourself.

--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -92,10 +92,8 @@ MEDIA_FORMS = frozenset({"attachment", "live_stream"})
 # the schema names). Consumer semantics: highest first, mtime FIFO tiebreak.
 PRIORITIES = ("urgent", "normal", "low")
 
-# Access tiers (CLAUDE.md access-control sections). `owner` is full processing;
-# team is workspace-write sandboxed; guest/legacy-other are read-only sandboxed.
-# A missing header reads as owner for
-# legacy local files — that default belongs to consumers, not this module.
+# `owner` is full, `team` is workspace-write sandboxed, and `guest`/`other` are read-only.
+# Consumers retain the owner default for legacy files without an access header.
 ACCESS_TIERS = ("owner", "team", "guest", "other")
 
 # The header vocabulary: every key observed in the real archive corpus

--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -92,10 +92,11 @@ MEDIA_FORMS = frozenset({"attachment", "live_stream"})
 # the schema names). Consumer semantics: highest first, mtime FIFO tiebreak.
 PRIORITIES = ("urgent", "normal", "low")
 
-# Access tiers (CLAUDE.md access-control sections). `owner` is full
-# processing; team/other are sandboxed. A missing header reads as owner for
+# Access tiers (CLAUDE.md access-control sections). `owner` is full processing;
+# team is workspace-write sandboxed; guest/legacy-other are read-only sandboxed.
+# A missing header reads as owner for
 # legacy local files — that default belongs to consumers, not this module.
-ACCESS_TIERS = ("owner", "team", "other")
+ACCESS_TIERS = ("owner", "team", "guest", "other")
 
 # The header vocabulary: every key observed in the real archive corpus
 # (3,401 files, 2026-07-06) plus the live writers' full sets. This list is

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -571,47 +571,17 @@ _INTERACTION_TYPES = frozenset({
     "tool_initiated", "system_event", "self_reflective",
 })
 
-# Trust is bounded at both ends. The gateway's access_tier is broker-attested
-# from the Matrix sender and room policy; this machine independently resolves a
-# local cap. The effective tier is the less privileged of those two decisions,
-# so neither side can upgrade the other.
-#
-# Default is "owner" for the personal-agent model (2026-07-08): a user runs
-# their OWN gateway authenticated with their OWN owner bearer, and the broker
-# OWNER-SCOPES every pull (per-agent bearer; caller-owner == target-owner), so
-# this gateway can ONLY ever receive its owner's own tasks — e.g. a voice-call
-# delegation from the user's own cloud agent. The trust therefore derives from
-# the broker's owner-scoping, NOT from trusting the gateway process or the
-# task's claim. The previous "team" default made a user's own voice
-# delegations look untrusted, so a hardened core (correctly, given the signal)
-# refused them.
-# Missing or invalid gateway tiers fail closed to guest.
+# Effective access is the lower of the broker-attested tier and the local cap.
+# Unset local policy defaults to owner; invalid values fail closed to guest.
 LOCAL_TIER = (_env_compat("REMOTE_TASK_TIER", "AG2_REMOTE_TIER") or "owner").strip().lower()
 if LOCAL_TIER == "other":
-    LOCAL_TIER = "guest"  # legacy spelling
+    LOCAL_TIER = "guest"
 if LOCAL_TIER not in ("owner", "team", "guest"):
-    # An INVALID value (e.g. a typo "owenr") fails CLOSED to "guest" — NEVER
-    # silently grant owner on a misconfiguration. Only the UNSET case defaults to
-    # "owner" (the `or "owner"` above — the explicit personal-agent model).
     LOCAL_TIER = "guest"
 
 
-# ── per-sender tier map (owner-controlled, LOCAL) ────────────────────────────
-# LOCAL_TIER above is the gateway-wide default. A SHARED room can carry messages
-# from senders who are NOT the owner (e.g. a teammate invited into a project
-# room). To tier those correctly WITHOUT trusting the task's self-claimed tier,
-# the OWNER declares a per-sender map in a LOCAL, owner-owned file:
-#   $CLAUDE_CONFIG_DIR/channels/ag2space/access.json → {"tierMap": {"@user:hs": "team"}}
-# We key the lookup on the BROKER-attested `user_id` (Matrix sender the broker
-# writes into the task, not a task-body self-claim), so this stays a LOCAL trust
-# decision — same principle as LOCAL_TIER. Only listed senders are re-tiered;
-# everyone else keeps LOCAL_TIER, so an UNLISTED sender can never escalate. A LISTED
-# sender gets exactly the tier the owner mapped them to — including one ABOVE
-# LOCAL_TIER, which is how a least-privilege node names its owner. See the CONTRACT
-# note on _tier_for for why that cannot be driven from the wire.
-# Hot: the cache keys on (st_mtime_ns, st_size, st_ino) and never serves an
-# above-LOCAL_TIER grant without a fresh read, so the owner can add teammates AND
-# revoke them without a restart.
+# A local per-sender map can only cap the broker tier; unlisted senders use LOCAL_TIER.
+# Cache identity includes mtime, size, and inode so revocations take effect promptly.
 def _ag2space_access_path():
     base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
     return os.path.join(base, "channels", CHANNEL_DIR, "access.json")
@@ -638,51 +608,24 @@ def _has_above_local(cached) -> bool:
 
 
 def _stale_safe(cached):
-    """Project a STALE cached map onto the fail-closed side in BOTH directions.
-
-    The cache is deliberately preserved across a read error so a transient
-    mid-write cannot fail-OPEN a down-tiered sender back to LOCAL_TIER. That
-    reasoning holds only for entries at or below LOCAL_TIER. Once the map can
-    also grant a tier ABOVE LOCAL_TIER, replaying the cache verbatim keeps an
-    ESCALATION alive on a file the owner may have just deleted to revoke it —
-    so deleting access.json would not actually revoke anything.
-
-    Drop the above-LOCAL_TIER entries (those senders fall back to LOCAL_TIER)
-    and keep the rest. A legitimately-granted sender is briefly demoted while
-    the file is unreadable and is restored on the next successful read; an
-    unrevoked escalation is not left standing. Transient demotion is the safe
-    direction — the module already fails closed to "team" on a bad LOCAL_TIER."""
+    """Keep stale caps at or below LOCAL_TIER and drop stale privilege grants.
+    Transient demotion is safer than retaining a possibly revoked escalation."""
     local_rank = _TIER_RANK.get(LOCAL_TIER, _TIER_RANK["owner"])
     return {k: v for k, v in cached.items() if _TIER_RANK.get(v, 0) <= local_rank}
 
 
 def _load_tier_map():
-    """Return the owner's {sender_mxid: tier} map, mtime-cached.
-
-    Preserves the last-known-good map on a READ error (stat/open/parse failure)
-    rather than clearing to {}. Clearing would silently up-tier every previously
-    down-tiered sender back to LOCAL_TIER the moment access.json is mid-write,
-    corrupt, or transiently unreadable — a fail-OPEN that is especially bad on a
-    LOCAL_TIER=owner node (a teammate momentarily regains owner). Only a
-    SUCCESSFUL read of a changed file replaces the cache; a fixed file (new mtime)
-    is picked up on the next call. A genuine deletion keeps the last map until the
-    owner writes an empty tierMap or the process restarts (the safe, non-surprising
-    tradeoff — the map floor never drops on a transient fault)."""
+    """Return the cached local sender caps, preserving safe caps on read errors.
+    Only a successful changed-file read replaces the cache."""
     path = _ag2space_access_path()
     try:
         st = os.stat(path)
     except OSError:
         # Absent/unstattable → keep last-known-good (initially {} before any load).
         return _stale_safe(_TIER_MAP_CACHE["map"])
-    # Cache identity is (mtime_ns, size, inode), NOT float mtime. A float mtime
-    # collides under a same-second rewrite and can be restored outright with
-    # os.utime, which would serve a REVOKED grant from cache — reproduced on
-    # #2584 (rewrite to {"tierMap":{}}, restore st_mtime_ns, still resolved owner).
+    # Size and inode supplement nanosecond mtime so same-timestamp rewrites are detected.
     ident = (st.st_mtime_ns, st.st_size, st.st_ino)
-    # Belt-and-braces: never serve an ABOVE-LOCAL grant from cache without a fresh
-    # read. Identity can still be forged deliberately; a revoked escalation must not
-    # survive that. Costs one small read per call only while an escalation is
-    # cached — discord's loader has no cache at all and re-reads every message.
+    # Re-read while an above-default grant is cached so revocation cannot be masked.
     if ident == _TIER_MAP_CACHE["ident"] and not _has_above_local(_TIER_MAP_CACHE["map"]):
         # File present and UNCHANGED — this cache is current, not stale. Return it
         # verbatim: projecting here would drop a legitimate up-tier on every call.
@@ -704,20 +647,8 @@ def _load_tier_map():
 
 
 def _tier_for(user_id, attested_tier=None):
-    """Resolve access without letting the gateway or local config upgrade the other.
-
-    The gateway tier comes from authenticated broker transport, not task-body
-    text. Missing or invalid values are guest. Locally, an explicitly mapped
-    sender uses that tier; everyone else uses LOCAL_TIER. The final result is the
-    lower of the gateway and local decisions. A local map can identify the real
-    owner on a team-default node, but cannot upgrade a backend guest.
-
-    ⚠ CONTRACT — `user_id` MUST stay broker-attested (cold-review note, #2584).
-    `user_id` is a broker-writer-side entry in _TASK_FIELDS, serialized beside
-    room_name/sender_name. It selects only the local CAP; the separately
-    broker-attested tier remains an upper bound even if identity parsing regresses.
-    (Deliberately a contract note, not an assert: provenance cannot be checked
-    at runtime — the value is an ordinary string whichever path produced it.)"""
+    """Return the lower of broker-attested access and the local sender cap.
+    Missing or invalid broker tiers resolve to guest."""
     wire = _normalized_tier(attested_tier)
     local = _normalized_tier(LOCAL_TIER)
     uid = (user_id or "").strip()
@@ -1379,32 +1310,14 @@ def _fleet_agent_ids() -> set[str]:
 
 
 def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
-    """Record that the owner was active on this transport right now — but only
-    when THIS node resolves the SENDER to owner tier. Gated on the sender's
-    resolved tier, NOT the gateway-wide LOCAL_TIER: in a shared room a
-    down-tiered teammate (tierMap[...] = "team"/"other") must not overwrite
-    `state/last-owner-activity.json`, or their message would poison owner-presence
-    routing (the proactive-loop's "owner active N min ago" signal + the core-
-    supervisor escalation target). `sender_tier` is passed in by `_write_task` so
-    the task tier and this gate share a SINGLE resolution (no divergence, no
-    double tierMap read); a direct caller can omit it and we resolve here. A
-    locally named owner registers owner presence only when the broker also
-    attests owner. Every unlisted sender is bounded by the broker-attested access
-    tier. Atomic write via per-PID tmp + os.replace (this file has four
-    concurrent writers; #2222); same schema (`ts`, `channel`, `summary`)
-    as discord-bridge.write_owner_activity so the proactive-loop reader is
-    transport-agnostic. Best-effort — never blocks task intake."""
+    """Record owner activity only for resolved owner-tier human senders.
+    Reuse the task's resolved tier so routing and presence cannot diverge."""
     if sender_tier is None:
         sender_tier = _tier_for(task.get("user_id"), task.get("access_tier"))
     if sender_tier != "owner":
         return
-    # A peer FLEET agent resolves to owner tier on a tierMap-less node (LOCAL_TIER
-    # fallthrough), but it is never the HUMAN owner — recording its post as
-    # owner-presence poisons the proactive-loop's engagement signal and the
-    # core-supervisor escalation target. Gate PRESENCE ONLY here; the task's
-    # access_tier (the other _tier_for consumer) stays owner so peer delegation
-    # is unaffected. Broker-attested user_id only — the /v1/agents directory is
-    # the authoritative peer set (the human owner is not in it).
+    # Agent peers may have owner task authority but must not count as human-owner presence.
+    # The broker-attested directory is authoritative for peer identity.
     _uid = (task.get("user_id") or "").strip()
     if _uid and _uid in _fleet_agent_ids():
         return
@@ -1414,8 +1327,7 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
         body = (task.get("task") or "").lstrip()
         if body.startswith("[") and "]" in body:
             body = body[body.index("]") + 1:].lstrip()
-        # #2267 parity: the presence summary is persisted state too — a pasted
-        # token must not survive in last-owner-activity.json either.
+        # Presence summaries are persisted, so redact secrets before writing them.
         body = filter_chat_secrets(body).text
         payload = {
             "ts": int(time.time()),
@@ -1546,22 +1458,11 @@ def _write_task(task: dict) -> str | None:
                 lines.append(f"platform_card: {json.dumps(card, separators=(',', ':'))}")
         elif f in task and task[f] not in (None, ""):
             lines.append(f"{f}: {_one_line(task[f])}")
-    # (This used to note that a gateway-written trust signal was dropped for
-    # lack of end-to-end support. platform_card above is that signal, done
-    # properly: KNOWN_HEADER_KEYS vocabulary + guard defang + a verifying
-    # consumer in skills/agent-room-ops/verify_platform_card.py.)
-    # access_tier is broker-attested and then clamped by local policy. Every
-    # other field is newline-stripped so none can forge an earlier tier line.
-    # Resolve ONCE and reuse for both the task tier AND the owner-activity gate
-    # below, so the two decisions can never diverge (a single source of truth,
-    # no double read of the tierMap).
-    # user_id and access_tier are broker-attested here — see _tier_for.
+    # Resolve the broker tier and local cap once for both task authority and presence.
+    # All preceding fields are newline-stripped, so none can forge a tier header.
     sender_tier = _tier_for(task.get("user_id"), task.get("access_tier"))
     lines.append(f"access_tier: {sender_tier}")
-    # #2267 parity, second half: the other bridges append the in-band security
-    # notice so the core neither reproduces nor re-requests the redacted value.
-    # Appended AFTER access_tier: the notice is bridge-generated fixed text with
-    # no header-shaped lines, so the access-tier-wins-last invariant holds.
+    # The fixed prose notice follows access_tier without introducing recognized headers.
     if _secret_types:
         lines.append(secret_handling_instruction("AG2Space", _secret_types).strip("\n"))
     if sender_tier in ("team", "guest"):

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -571,9 +571,10 @@ _INTERACTION_TYPES = frozenset({
     "tool_initiated", "system_event", "self_reflective",
 })
 
-# Trust tier is a LOCAL decision (review 2026-06-13): the gateway is outside
-# this machine's trust boundary, so a task's SELF-CLAIMED access_tier is
-# ignored. The tier written to every task file comes from REMOTE_TASK_TIER.
+# Trust is bounded at both ends. The gateway's access_tier is broker-attested
+# from the Matrix sender and room policy; this machine independently resolves a
+# local cap. The effective tier is the less privileged of those two decisions,
+# so neither side can upgrade the other.
 #
 # Default is "owner" for the personal-agent model (2026-07-08): a user runs
 # their OWN gateway authenticated with their OWN owner bearer, and the broker
@@ -584,14 +585,15 @@ _INTERACTION_TYPES = frozenset({
 # task's claim. The previous "team" default made a user's own voice
 # delegations look untrusted, so a hardened core (correctly, given the signal)
 # refused them.
-# ESCAPE HATCH: a SHARED / multi-user gateway — one that could pull tasks NOT
-# scoped to a single owner — MUST set REMOTE_TASK_TIER=team (or other).
+# Missing or invalid gateway tiers fail closed to guest.
 LOCAL_TIER = (_env_compat("REMOTE_TASK_TIER", "AG2_REMOTE_TIER") or "owner").strip().lower()
-if LOCAL_TIER not in ("owner", "team", "other"):
-    # An INVALID value (e.g. a typo "owenr") fails CLOSED to "team" — NEVER
+if LOCAL_TIER == "other":
+    LOCAL_TIER = "guest"  # legacy spelling
+if LOCAL_TIER not in ("owner", "team", "guest"):
+    # An INVALID value (e.g. a typo "owenr") fails CLOSED to "guest" — NEVER
     # silently grant owner on a misconfiguration. Only the UNSET case defaults to
     # "owner" (the `or "owner"` above — the explicit personal-agent model).
-    LOCAL_TIER = "team"
+    LOCAL_TIER = "guest"
 
 
 # ── per-sender tier map (owner-controlled, LOCAL) ────────────────────────────
@@ -615,9 +617,16 @@ def _ag2space_access_path():
     return os.path.join(base, "channels", CHANNEL_DIR, "access.json")
 
 
-# Known tier vocabulary. Also an ordering (higher == more privileged); kept for
-# validating a mapped value. It no longer CLAMPS — see _tier_for.
-_TIER_RANK = {"other": 0, "team": 1, "owner": 2}
+# Known tier vocabulary and privilege ordering. `_tier_for` uses this ordering
+# to choose the lower of the broker-attested tier and the local cap.
+_TIER_RANK = {"guest": 0, "team": 1, "owner": 2}
+
+
+def _normalized_tier(value):
+    tier = str(value or "").strip().lower()
+    if tier == "other":
+        tier = "guest"
+    return tier if tier in _TIER_RANK else "guest"
 
 _TIER_MAP_CACHE = {"ident": None, "map": {}}
 
@@ -684,8 +693,8 @@ def _load_tier_map():
         tm = {}
         for who, tier in raw.items():
             t = str(tier).strip().lower()
-            if isinstance(who, str) and t in ("owner", "team", "other"):
-                tm[who.strip()] = t
+            if isinstance(who, str) and t in ("owner", "team", "guest", "other"):
+                tm[who.strip()] = _normalized_tier(t)
     except Exception:
         # Malformed / mid-write → keep last-known-good; don't advance mtime so a
         # later successful read of the fixed file is still picked up.
@@ -694,42 +703,29 @@ def _load_tier_map():
     return tm
 
 
-def _tier_for(user_id):
-    """Resolve the access_tier for a task's broker-attested sender.
+def _tier_for(user_id, attested_tier=None):
+    """Resolve access without letting the gateway or local config upgrade the other.
 
-    An EXPLICITLY LISTED sender gets exactly the tier the owner mapped them to —
-    including a tier ABOVE this node's LOCAL_TIER. That is the point: it lets a
-    SHARED gateway run a least-privilege default (REMOTE_TASK_TIER=team) and name
-    the one sender who is the owner, instead of the only previously-available
-    shape — a blanket `owner` default that every unlisted sender inherits.
-
-    This mirrors the discord and slack bridges, which have always resolved
-    `access_tier = tierMap[sender_id]` with no clamp. The map is LOCAL,
-    owner-owned config with the same trust standing as REMOTE_TASK_TIER itself,
-    and the lookup key is the BROKER-ATTESTED user_id, never a task-body
-    self-claim — so the WIRE still cannot escalate anyone. Only the owner's own
-    local file can, and only for a sender they named explicitly.
-
-    Everyone else (unlisted / no user_id) gets LOCAL_TIER, unchanged: no existing
-    install is silently demoted, and an unknown sender never gains privilege.
+    The gateway tier comes from authenticated broker transport, not task-body
+    text. Missing or invalid values are guest. Locally, an explicitly mapped
+    sender uses that tier; everyone else uses LOCAL_TIER. The final result is the
+    lower of the gateway and local decisions. A local map can identify the real
+    owner on a team-default node, but cannot upgrade a backend guest.
 
     ⚠ CONTRACT — `user_id` MUST stay broker-attested (cold-review note, #2584).
-    The removed clamp used to be a backstop: even if `user_id` had become
-    body-influenced, a mapped tier was still bounded by LOCAL_TIER. With the
-    clamp gone, "`user_id` is the broker-written Matrix sender, never a
-    task-body self-claim" is SOLELY load-bearing for the no-wire-escalation
-    property. It holds today because `user_id` is a broker-writer-side entry in
-    _TASK_FIELDS, serialized beside room_name/sender_name. Any future change
-    that lets a task body influence `user_id` reintroduces wire-controlled
-    escalation — re-add a bound here if that contract is ever weakened.
+    `user_id` is a broker-writer-side entry in _TASK_FIELDS, serialized beside
+    room_name/sender_name. It selects only the local CAP; the separately
+    broker-attested tier remains an upper bound even if identity parsing regresses.
     (Deliberately a contract note, not an assert: provenance cannot be checked
     at runtime — the value is an ordinary string whichever path produced it.)"""
+    wire = _normalized_tier(attested_tier)
+    local = _normalized_tier(LOCAL_TIER)
     uid = (user_id or "").strip()
     if uid:
         mapped = _load_tier_map().get(uid)
-        if mapped in _TIER_RANK:
-            return mapped
-    return LOCAL_TIER
+        if mapped is not None:
+            local = _normalized_tier(mapped)
+    return wire if _TIER_RANK[wire] <= _TIER_RANK[local] else local
 
 
 # ── inbound media fetch (owner screenshots, file uploads) ────────────────────
@@ -1391,22 +1387,15 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
     routing (the proactive-loop's "owner active N min ago" signal + the core-
     supervisor escalation target). `sender_tier` is passed in by `_write_task` so
     the task tier and this gate share a SINGLE resolution (no divergence, no
-    double tierMap read); a direct caller can omit it and we resolve here. For an
-    Since the map may now grant a tier ABOVE LOCAL_TIER, the mirror case also
-    holds: a sender explicitly mapped to owner on a least-privilege node DOES
-    register owner presence — that is the point of naming them owner. Tests 23/24
-    pin both directions, because a refactor that regated this on LOCAL_TIER would
-    silently stop recording the real owner's activity. For an
-    unlisted sender `_tier_for` returns LOCAL_TIER, so the single-owner case is
-    unchanged. Never trusts the gateway's own claim (it is outside the trust
-    boundary) — only the broker-attested user_id keyed against the owner's LOCAL
-    tierMap. Atomic write via per-PID tmp + os.replace (this file has four
+    double tierMap read); a direct caller can omit it and we resolve here. A
+    locally named owner registers owner presence only when the broker also
+    attests owner. Every unlisted sender is bounded by the broker-attested access
+    tier. Atomic write via per-PID tmp + os.replace (this file has four
     concurrent writers; #2222); same schema (`ts`, `channel`, `summary`)
     as discord-bridge.write_owner_activity so the proactive-loop reader is
     transport-agnostic. Best-effort — never blocks task intake."""
     if sender_tier is None:
-        # user_id is broker-attested here — see the CONTRACT note in _tier_for.
-        sender_tier = _tier_for(task.get("user_id"))
+        sender_tier = _tier_for(task.get("user_id"), task.get("access_tier"))
     if sender_tier != "owner":
         return
     # A peer FLEET agent resolves to owner tier on a tierMap-less node (LOCAL_TIER
@@ -1561,16 +1550,13 @@ def _write_task(task: dict) -> str | None:
     # lack of end-to-end support. platform_card above is that signal, done
     # properly: KNOWN_HEADER_KEYS vocabulary + guard defang + a verifying
     # consumer in skills/agent-room-ops/verify_platform_card.py.)
-    # access_tier is a LOCAL decision and written LAST so it wins even under a
-    # last-occurrence parser; every other field is newline-stripped so none can
-    # forge an earlier one either. Resolved per broker-attested sender via the
-    # owner's tierMap (LOCAL file), falling back to LOCAL_TIER for unlisted
-    # senders — so a named teammate can be down-tiered without trusting the task.
+    # access_tier is broker-attested and then clamped by local policy. Every
+    # other field is newline-stripped so none can forge an earlier tier line.
     # Resolve ONCE and reuse for both the task tier AND the owner-activity gate
     # below, so the two decisions can never diverge (a single source of truth,
     # no double read of the tierMap).
-    # user_id is broker-attested here — see the CONTRACT note in _tier_for.
-    sender_tier = _tier_for(task.get("user_id"))
+    # user_id and access_tier are broker-attested here — see _tier_for.
+    sender_tier = _tier_for(task.get("user_id"), task.get("access_tier"))
     lines.append(f"access_tier: {sender_tier}")
     # #2267 parity, second half: the other bridges append the in-band security
     # notice so the core neither reproduces nor re-requests the redacted value.
@@ -1578,6 +1564,27 @@ def _write_task(task: dict) -> str | None:
     # no header-shaped lines, so the access-tier-wins-last invariant holds.
     if _secret_types:
         lines.append(secret_handling_instruction("AG2Space", _secret_types).strip("\n"))
+    if sender_tier in ("team", "guest"):
+        sandbox = "workspace-write" if sender_tier == "team" else "read-only"
+        purpose = (
+            "You may edit files and run tests inside the current workspace, but must not "
+            "use secrets, contact people, push code, merge, deploy, or mutate external systems."
+            if sender_tier == "team"
+            else (
+                "You may only research, inspect, explain, and draft. Do not "
+                "modify files or external systems."
+            )
+        )
+        lines.extend([
+            "",
+            "===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===",
+            f"This AG2Space task is {sender_tier.upper()} tier, not owner tier.",
+            "Do not execute the request directly with the owner's unrestricted core.",
+            f"Delegate it to Codex using `codex exec --sandbox {sandbox}`.",
+            purpose,
+            f"Write only the sandboxed agent's safe user-facing answer to results/{tid}.txt.",
+            "===END SUTANDO SYSTEM INSTRUCTIONS===",
+        ])
     # ===SKILL INSTRUCTIONS=== (owner-tier only): prose/numbered lines only, no
     # header-shaped lines, so appending after access_tier keeps it the last one.
     if sender_tier == "owner":

--- a/packages/ag2-sparrow/tests/test_write_task_atomic.py
+++ b/packages/ag2-sparrow/tests/test_write_task_atomic.py
@@ -32,6 +32,7 @@ def _task(tid="task-1784500000000"):
         "source": "ag2space",
         "channel_id": "!room:ag2.space",
         "user_id": "@qingyun:ag2.space",
+        "access_tier": "owner",
         "timestamp": "2026-07-20T00:00:00Z",
     }
 

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -92,10 +92,8 @@ MEDIA_FORMS = frozenset({"attachment", "live_stream"})
 # the schema names). Consumer semantics: highest first, mtime FIFO tiebreak.
 PRIORITIES = ("urgent", "normal", "low")
 
-# Access tiers (CLAUDE.md access-control sections). `owner` is full processing;
-# team is workspace-write sandboxed; guest/legacy-other are read-only sandboxed.
-# A missing header reads as owner for
-# legacy local files — that default belongs to consumers, not this module.
+# `owner` is full, `team` is workspace-write sandboxed, and `guest`/`other` are read-only.
+# Consumers retain the owner default for legacy files without an access header.
 ACCESS_TIERS = ("owner", "team", "guest", "other")
 
 # The header vocabulary: every key observed in the real archive corpus

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -92,10 +92,11 @@ MEDIA_FORMS = frozenset({"attachment", "live_stream"})
 # the schema names). Consumer semantics: highest first, mtime FIFO tiebreak.
 PRIORITIES = ("urgent", "normal", "low")
 
-# Access tiers (CLAUDE.md access-control sections). `owner` is full
-# processing; team/other are sandboxed. A missing header reads as owner for
+# Access tiers (CLAUDE.md access-control sections). `owner` is full processing;
+# team is workspace-write sandboxed; guest/legacy-other are read-only sandboxed.
+# A missing header reads as owner for
 # legacy local files — that default belongs to consumers, not this module.
-ACCESS_TIERS = ("owner", "team", "other")
+ACCESS_TIERS = ("owner", "team", "guest", "other")
 
 # The header vocabulary: every key observed in the real archive corpus
 # (3,401 files, 2026-07-06) plus the live writers' full sets. This list is

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -128,14 +128,14 @@ def main() -> int:
     _dspec.loader.exec_module(_drtc)
     check(_drtc.LOCAL_TIER == "owner",
           "default LOCAL_TIER=owner when REMOTE_TASK_TIER unset (personal-agent model)")
-    # An INVALID value must fail CLOSED to "team" — never silently grant owner on
+    # An INVALID value must fail CLOSED to "guest" — never silently grant owner on
     # a typo; only an unset/explicit config grants owner.
     os.environ["REMOTE_TASK_TIER"] = "owenr"  # typo
     _ispec = importlib.util.spec_from_file_location("rtc_invalid", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
     _irtc = importlib.util.module_from_spec(_ispec)
     _ispec.loader.exec_module(_irtc)
-    check(_irtc.LOCAL_TIER == "team",
-          "invalid REMOTE_TASK_TIER fails CLOSED to team (never silently owner)")
+    check(_irtc.LOCAL_TIER == "guest",
+          "invalid REMOTE_TASK_TIER fails CLOSED to guest (never silently owner)")
     os.environ.pop("REMOTE_TASK_TIER", None)
 
     # ── GATEWAY_INSTANCE (multi-gateway): named instance suffixes the per-bridge
@@ -302,7 +302,35 @@ def main() -> int:
     check("task: hello from gateway" in content, "task body serialized")
     check("source: remote-gateway" in content, "source field carried")
     check("access_tier: team" in content and "access_tier: owner" not in content,
-          "access_tier CLAMPED to local default (wire said owner — never trusted)")
+          "owner attestation is clamped to the local team cap")
+    check("--sandbox workspace-write" in content,
+          "team task gets the useful workspace-write sandbox")
+    _load_map = rtc._load_tier_map
+    _local_tier = rtc.LOCAL_TIER
+    rtc._load_tier_map = lambda: {}
+    rtc.LOCAL_TIER = "owner"
+    try:
+        check(rtc._tier_for("@owner:example.org", "owner") == "owner",
+              "backend owner + local owner remains owner")
+        check(rtc._tier_for("@team:example.org", "team") == "team",
+              "backend team is not upgraded by local owner default")
+        check(rtc._tier_for("@guest:example.org", "guest") == "guest",
+              "backend guest is not upgraded by local owner default")
+        check(rtc._tier_for("@missing:example.org", None) == "guest",
+              "missing backend tier fails closed to guest")
+        rtc._load_tier_map = lambda: {"@team:example.org": "team",
+                                      "@guest:example.org": "owner"}
+        check(rtc._tier_for("@team:example.org", "owner") == "team",
+              "local sender map may downgrade backend owner to team")
+        check(rtc._tier_for("@guest:example.org", "guest") == "guest",
+              "local owner mapping cannot upgrade backend guest")
+    finally:
+        rtc._load_tier_map = _load_map
+        rtc.LOCAL_TIER = _local_tier
+    rtc._write_task({**TASK, "id": "task-GUEST", "access_tier": "guest"})
+    guest_body = (rtc.TASKS_DIR / "task-GUEST.txt").read_text()
+    check("access_tier: guest" in guest_body and "--sandbox read-only" in guest_body,
+          "guest task stays guest and gets a read-only sandbox")
     # context enrichment: room_name / sender_name / reply_to_* serialize when
     # present, and a newline in a name can't forge an extra field line.
     rtc._write_task({**TASK, "id": "task-CTX", "room_name": "#design",
@@ -814,15 +842,16 @@ def main() -> int:
           "two same-name media saves get distinct files (no overwrite)")
     rtc._download_bytes = real_download
 
-    # 7. owner-activity gate follows LOCAL_TIER, not the gateway's tier claim
+    # 7. owner-activity gate follows the final resolved sender tier
     act = rtc.OWNER_ACTIVITY_FILE
     act.unlink(missing_ok=True)
     rtc._write_owner_activity({"task": "[X @u] hi there", "source": "remote-gateway",
-                               "access_tier": "owner"})
+                               "access_tier": "owner"}, sender_tier="team")
     check(not act.exists(),
-          "LOCAL_TIER=team → owner-activity NOT written even if wire claims owner")
+          "team task does not write owner activity")
     rtc.LOCAL_TIER = "owner"
-    rtc._write_owner_activity({"task": "[X @u] hi there", "source": "remote-gateway"})
+    rtc._write_owner_activity({"task": "[X @u] hi there", "source": "remote-gateway",
+                               "access_tier": "owner"}, sender_tier="owner")
     data = json.loads(act.read_text()) if act.exists() else {}
     check(data.get("summary") == "hi there" and data.get("channel") == "remote-gateway",
           "LOCAL_TIER=owner → owner-activity written with stripped summary")

--- a/tests/gateway-owner-presence-peer-gate.test.py
+++ b/tests/gateway-owner-presence-peer-gate.test.py
@@ -1,18 +1,15 @@
-"""Presence gate: a peer FLEET agent must not set owner-presence, while its
-task authority (access_tier) stays exactly as today.
+"""Presence gate: a peer FLEET agent must not set owner-presence, and its task
+authority must remain bounded by the broker-attested access tier.
 
 Regression: `_tier_for()` falls through to LOCAL_TIER="owner" for any unlisted
 sender on a tierMap-less node, so a peer agent's room post (a) read as owner-tier
 AND (b) overwrote `last-owner-activity.json`, poisoning the proactive-loop's
 "owner active N min ago" signal (and the core-supervisor escalation target).
 
-The fix gates PRESENCE ONLY (`_write_owner_activity` consults the /v1/agents
-fleet directory and returns early for peers) and deliberately leaves `_tier_for`
-untouched — because `_tier_for` also feeds the task's access_tier, and
-down-tiering peers there would sandbox all peer-to-peer delegation. So this test
-covers BOTH consumers of `_tier_for` (per the review requirement): after the
-change a peer task still resolves access_tier=owner, but no owner-activity is
-written for it.
+The presence gate consults the /v1/agents fleet directory and returns early for
+peers. Independently, `_tier_for` feeds the task's access_tier and must not let a
+local owner default promote a broker-attested team or guest task. Team retains
+bounded workspace-write delegation without receiving unrestricted owner access.
 """
 import importlib
 import json
@@ -88,13 +85,14 @@ def test_owner_sender_still_writes_owner_activity():
     assert json.loads(f.read_text())["channel"] == "ag2space"
 
 
-def test_peer_task_authority_unchanged_access_tier_still_owner():
+def test_peer_task_authority_follows_broker_attestation():
     m = _load()
-    # consumer 2 (task authority): _tier_for is UNTOUCHED — a peer still resolves
-    # to owner tier on this tierMap-less node, so peer-to-peer delegation keeps
-    # working. If this flips to team/other, the fix wrongly sandboxed peers.
-    assert m._tier_for(PEER) == "owner"
-    assert m._tier_for(OWNER) == "owner"
+    # consumer 2 (task authority): local owner is only a cap. The authenticated
+    # broker decides whether a peer has useful team access or read-only guest
+    # access; only an attested owner remains unrestricted.
+    assert m._tier_for(PEER, "team") == "team"
+    assert m._tier_for(PEER, "guest") == "guest"
+    assert m._tier_for(OWNER, "owner") == "owner"
 
 
 def test_fail_open_records_peer_when_directory_unknown():

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Per-sender access_tier resolution in the ag2-sparrow gateway.
+"""Broker-attested access_tier resolution in the ag2-sparrow gateway.
 
-The gateway writes access_tier as a LOCAL decision (never trusting the task's
-self-claim). This test covers the owner-controlled per-sender tierMap layered on
-top of LOCAL_TIER: a named teammate is down-tiered by user_id, everyone else
-keeps LOCAL_TIER, and a malformed/missing map never re-tiers (fail-soft).
+The broker tier and owner-controlled local tierMap are independent upper bounds.
+The effective tier is the lower one: a local map may downgrade an authenticated
+sender, but can never promote a broker-attested team or guest task.
 """
 import json
 import sys
@@ -45,36 +44,36 @@ def _write_map(m):
 
 # 1. named teammate is down-tiered by user_id
 _write_map({"@rick:ag2.space": "team"})
-check("mapped sender → team", rgb._tier_for("@rick:ag2.space") == "team")
+check("mapped sender → team", rgb._tier_for("@rick:ag2.space", "owner") == "team")
 
 # 2. unlisted sender keeps LOCAL_TIER (owner) — no escalation, no accidental downgrade
-check("unlisted sender → LOCAL_TIER", rgb._tier_for("@qingyun:ag2.space") == "owner")
+check("unlisted sender → LOCAL_TIER", rgb._tier_for("@qingyun:ag2.space", "owner") == "owner")
 
 # 3. empty / missing user_id → LOCAL_TIER
-check("empty user_id → LOCAL_TIER", rgb._tier_for("") == "owner")
-check("None user_id → LOCAL_TIER", rgb._tier_for(None) == "owner")
+check("empty user_id → LOCAL_TIER", rgb._tier_for("", "owner") == "owner")
+check("None user_id → LOCAL_TIER", rgb._tier_for(None, "owner") == "owner")
 
 # 4. invalid tier value in the map is ignored → LOCAL_TIER (never a bogus tier)
 _write_map({"@rick:ag2.space": "boss"})
-check("invalid tier value ignored → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") == "owner")
+check("invalid tier value ignored → LOCAL_TIER", rgb._tier_for("@rick:ag2.space", "owner") == "owner")
 
-# 5. 'other' tier is honored
+# 5. legacy 'other' tier is normalized to guest
 _write_map({"@stranger:ag2.space": "other"})
-check("'other' tier honored", rgb._tier_for("@stranger:ag2.space") == "other")
+check("'other' tier normalized to guest", rgb._tier_for("@stranger:ag2.space", "owner") == "guest")
 
 # 6. missing file → LOCAL_TIER (fail-soft, no crash)
 ACCESS.unlink()
 rgb._TIER_MAP_CACHE["ident"] = None
-check("missing access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") == "owner")
+check("missing access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space", "owner") == "owner")
 
 # 7. malformed JSON → LOCAL_TIER (fail-soft)
 ACCESS.write_text("{ not json ]")
 rgb._TIER_MAP_CACHE["ident"] = None
-check("malformed access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") == "owner")
+check("malformed access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space", "owner") == "owner")
 
 # 8. live update: adding a teammate is picked up without reload (mtime cache)
 _write_map({"@rick:ag2.space": "team", "@sam:ag2.space": "team"})
-check("live-added teammate → team", rgb._tier_for("@sam:ag2.space") == "team")
+check("live-added teammate → team", rgb._tier_for("@sam:ag2.space", "owner") == "team")
 
 # --- owner-activity gate (same tier map must gate presence, not just task tier) ---
 # Regression for the blocking finding on a3e24dd: _write_owner_activity() gated on
@@ -87,61 +86,60 @@ _write_map({"@rick:ag2.space": "team"})
 
 # 9. owner sender → owner-activity IS written
 OWNER_ACT.unlink(missing_ok=True)
-rgb._write_owner_activity({"task": "hi", "source": "ag2space", "user_id": "@qingyun:ag2.space", "channel_id": "!r:hs"})
+rgb._write_owner_activity({"task": "hi", "source": "ag2space", "user_id": "@qingyun:ag2.space", "access_tier": "owner", "channel_id": "!r:hs"})
 check("owner sender writes owner-activity", OWNER_ACT.exists())
 
 # 10. team-tier teammate → owner-activity NOT written (the fix)
 OWNER_ACT.unlink(missing_ok=True)
-rgb._write_owner_activity({"task": "hi", "source": "ag2space", "user_id": "@rick:ag2.space", "channel_id": "!r:hs"})
+rgb._write_owner_activity({"task": "hi", "source": "ag2space", "user_id": "@rick:ag2.space", "access_tier": "owner", "channel_id": "!r:hs"})
 check("team teammate does NOT write owner-activity", not OWNER_ACT.exists())
 
 # 11. team teammate cannot OVERWRITE a prior genuine owner-activity record
-rgb._write_owner_activity({"task": "owner here", "source": "ag2space", "user_id": "@qingyun:ag2.space", "channel_id": "!r:hs"})
+rgb._write_owner_activity({"task": "owner here", "source": "ag2space", "user_id": "@qingyun:ag2.space", "access_tier": "owner", "channel_id": "!r:hs"})
 before = OWNER_ACT.read_text()
-rgb._write_owner_activity({"task": "rick here", "source": "ag2space", "user_id": "@rick:ag2.space", "channel_id": "!r:hs"})
+rgb._write_owner_activity({"task": "rick here", "source": "ag2space", "user_id": "@rick:ag2.space", "access_tier": "owner", "channel_id": "!r:hs"})
 check("teammate does not clobber owner's activity record", OWNER_ACT.read_text() == before)
 
 # --- per-sender owner tier on a least-privilege node (the shared-gateway shape) ---
-# 12. BEHAVIOR CHANGE (deliberate, owner-approved): an EXPLICITLY LISTED sender now
-# gets the tier the owner mapped them to, including one ABOVE LOCAL_TIER. This
-# previously clamped to <= LOCAL_TIER, which made the only way to grant owner a
-# BLANKET REMOTE_TASK_TIER=owner that every unlisted sender inherited (fail-OPEN).
-# Mirrors discord/slack, which resolve `tierMap[sender_id]` with no clamp.
-# The lookup key is the broker-attested user_id, so the WIRE still cannot escalate;
-# only the owner's own local access.json can, and only for a sender named in it.
+# 12. An explicitly listed sender may exceed the node default only when the
+# authenticated broker independently attests that same higher tier.
 _prev_local = rgb.LOCAL_TIER
 rgb.LOCAL_TIER = "team"
 _write_map({"@dana:ag2.space": "owner", "@stranger:ag2.space": "other"})
 check("listed sender IS up-tiered above LOCAL_TIER (team node, explicit owner)",
-      rgb._tier_for("@dana:ag2.space") == "owner")
-check("map still down-tiers below LOCAL_TIER (team node, 'other' honored)",
-      rgb._tier_for("@stranger:ag2.space") == "other")
+      rgb._tier_for("@dana:ag2.space", "owner") == "owner")
+check("local owner map cannot promote a broker guest",
+      rgb._tier_for("@dana:ag2.space", "guest") == "guest")
+check("map still down-tiers below LOCAL_TIER (team node, 'other' is guest)",
+      rgb._tier_for("@stranger:ag2.space", "owner") == "guest")
 # 12b. the escalation is EXPLICIT-ONLY: an unlisted sender on the same node keeps
 # the least-privilege default. This is the property that makes the shared-gateway
 # config default-CLOSED, and it is what a blanket owner default cannot give you.
 check("unlisted sender on a team node stays team (no blanket escalation)",
-      rgb._tier_for("@nobody:ag2.space") == "team")
+      rgb._tier_for("@nobody:ag2.space", "owner") == "team")
 # 12c. an invalid mapped value still cannot escalate — it is ignored, not honored.
 _write_map({"@rick:ag2.space": "admin"})
 check("invalid mapped value on a team node does NOT escalate",
-      rgb._tier_for("@rick:ag2.space") == "team")
+      rgb._tier_for("@rick:ag2.space", "owner") == "team")
 rgb.LOCAL_TIER = _prev_local
 
 # 12d. no silent demotion: on an owner-default node an unlisted sender is STILL
 # owner, so existing single-owner installs are untouched by this change.
 _write_map({"@rick:ag2.space": "team"})
 check("owner-default node: unlisted sender still owner (no regression)",
-      rgb._tier_for("@unknown:ag2.space") == "owner")
+      rgb._tier_for("@unknown:ag2.space", "owner") == "owner")
+check("owner-default node: missing broker tier fails closed",
+      rgb._tier_for("@unknown:ag2.space") == "guest")
 
 # --- fail-safe: a transient read error preserves the last-known-good map ---
 # 13. once a teammate is down-tiered, a malformed/mid-write access.json must NOT
 # silently fail-open them back to LOCAL_TIER (owner). Preserve last-known-good.
 _write_map({"@rick:ag2.space": "team"})
-assert rgb._tier_for("@rick:ag2.space") == "team"  # prime the cache with a good read
+assert rgb._tier_for("@rick:ag2.space", "owner") == "team"  # prime the cache with a good read
 ACCESS.write_text("{ corrupt not json ]")           # file now unparseable
 rgb._TIER_MAP_CACHE["ident"] = None                    # force a re-read attempt (hits except)
 check("malformed re-read keeps the down-tier (fail-safe, not fail-open to owner)",
-      rgb._tier_for("@rick:ag2.space") == "team")
+      rgb._tier_for("@rick:ag2.space", "owner") == "team")
 
 # --- stale cache must fail CLOSED in BOTH directions (revocation safety) ---
 # Once the map can grant a tier ABOVE LOCAL_TIER, replaying a STALE cache verbatim
@@ -153,33 +151,33 @@ rgb.LOCAL_TIER = "team"
 
 # 18. revocation-by-deletion actually revokes an ESCALATED sender
 _write_map({"@dana:ag2.space": "owner"})
-assert rgb._tier_for("@dana:ag2.space") == "owner"   # prime cache with the grant
+assert rgb._tier_for("@dana:ag2.space", "owner") == "owner"   # prime cache with the grant
 ACCESS.unlink()
 rgb._TIER_MAP_CACHE["ident"] = None                     # force re-read → OSError path
 check("deleting access.json REVOKES an escalated sender (no stale owner)",
-      rgb._tier_for("@dana:ag2.space") == "team")
+      rgb._tier_for("@dana:ag2.space", "owner") == "team")
 
 # 19. ...while a DOWN-tier still survives the same stale read (original fail-safe intact)
 _write_map({"@rick:ag2.space": "other"})
-assert rgb._tier_for("@rick:ag2.space") == "other"
+assert rgb._tier_for("@rick:ag2.space", "owner") == "guest"
 ACCESS.unlink()
 rgb._TIER_MAP_CACHE["ident"] = None
 check("stale cache still preserves a DOWN-tier (fail-safe not broken)",
-      rgb._tier_for("@rick:ag2.space") == "other")
+      rgb._tier_for("@rick:ag2.space", "owner") == "guest")
 
 # 20. malformed (not deleted) also drops the escalation but keeps the down-tier
 _write_map({"@dana:ag2.space": "owner", "@rick:ag2.space": "other"})
-assert rgb._tier_for("@dana:ag2.space") == "owner"
+assert rgb._tier_for("@dana:ag2.space", "owner") == "owner"
 ACCESS.write_text("{ corrupt ]")
 rgb._TIER_MAP_CACHE["ident"] = None
-check("malformed read drops the escalation", rgb._tier_for("@dana:ag2.space") == "team")
-check("malformed read keeps the down-tier", rgb._tier_for("@rick:ag2.space") == "other")
+check("malformed read drops the escalation", rgb._tier_for("@dana:ag2.space", "owner") == "team")
+check("malformed read keeps the down-tier", rgb._tier_for("@rick:ag2.space", "owner") == "guest")
 
 # 21. HOT PATH REGRESSION GUARD: a present, unchanged file is a VALID cache, not a
 # stale one — a legitimate up-tier must survive repeated reads untouched.
 _write_map({"@dana:ag2.space": "owner"})
 check("valid unchanged cache keeps the up-tier (hot path not projected)",
-      rgb._tier_for("@dana:ag2.space") == "owner" and rgb._tier_for("@dana:ag2.space") == "owner")
+      rgb._tier_for("@dana:ag2.space", "owner") == "owner" and rgb._tier_for("@dana:ag2.space", "owner") == "owner")
 rgb.LOCAL_TIER = _prev_local
 
 # --- the OTHER _tier_for consumer: owner-presence gate, under UP-tiering ---
@@ -196,13 +194,13 @@ _write_map({"@dana:ag2.space": "owner"})
 # 23. an UP-tiered sender on a team node DOES register owner presence
 OWNER_ACT.unlink(missing_ok=True)
 rgb._write_owner_activity({"task": "hi", "source": "ag2space",
-                           "user_id": "@dana:ag2.space", "channel_id": "!r:hs"})
+                           "user_id": "@dana:ag2.space", "access_tier": "owner", "channel_id": "!r:hs"})
 check("up-tiered owner registers owner-presence on a team node", OWNER_ACT.exists())
 
 # 24. ...and an unlisted sender on that same node still does NOT
 OWNER_ACT.unlink(missing_ok=True)
 rgb._write_owner_activity({"task": "hi", "source": "ag2space",
-                           "user_id": "@nobody:ag2.space", "channel_id": "!r:hs"})
+                           "user_id": "@nobody:ag2.space", "access_tier": "owner", "channel_id": "!r:hs"})
 check("unlisted sender does NOT register owner-presence on a team node",
       not OWNER_ACT.exists())
 rgb.LOCAL_TIER = _prev_local
@@ -231,25 +229,25 @@ rgb.LOCAL_TIER = "team"
 # 25. SAME size, SAME mtime_ns, SAME inode -> identity collides exactly; only the
 # above-local re-read can catch the revocation. owner->other keeps byte length.
 _write_map({"@dana:ag2.space": "owner"})
-assert rgb._tier_for("@dana:ag2.space") == "owner"           # prime the grant
+assert rgb._tier_for("@dana:ag2.space", "owner") == "owner"           # prime the grant
 _rewrite_same_identity({"@dana:ag2.space": "other"})
 check("identity-colliding rewrite does NOT serve a revoked owner grant",
-      rgb._tier_for("@dana:ag2.space") == "other")
+      rgb._tier_for("@dana:ag2.space", "owner") == "guest")
 
 # 26. full revocation to an empty map under a restored mtime
 _write_map({"@dana:ag2.space": "owner"})
-assert rgb._tier_for("@dana:ag2.space") == "owner"
+assert rgb._tier_for("@dana:ag2.space", "owner") == "owner"
 _rewrite_same_identity({})
 check("same-mtime revocation to an empty map drops the grant",
-      rgb._tier_for("@dana:ag2.space") == "team")
+      rgb._tier_for("@dana:ag2.space", "owner") == "team")
 
 # 27. a NON-escalating cache still uses the identity shortcut (no perf regression)
 _write_map({"@rick:ag2.space": "team"})
-assert rgb._tier_for("@rick:ag2.space") == "team"
+assert rgb._tier_for("@rick:ag2.space", "owner") == "team"
 check("cache identity shortcut still serves a non-escalating map",
-      rgb._tier_for("@rick:ag2.space") == "team")
+      rgb._tier_for("@rick:ag2.space", "owner") == "team")
 rgb.LOCAL_TIER = _prev_local
 
-_total = 27
+_total = 30
 print(f"\nResults: {_total - len(failures)}/{_total} passed" if not failures else f"\nResults: FAILED {failures}")
 sys.exit(1 if failures else 0)

--- a/tests/gateway-task-telemetry.test.py
+++ b/tests/gateway-task-telemetry.test.py
@@ -83,6 +83,7 @@ def _fresh_dirs():
     # Reset the tierMap to the seeded EMPTY config and drop the mtime cache so
     # no case inherits another case's (or the host's) tier state.
     _ACCESS.write_text('{"allowFrom": [], "tierMap": {}}')
+    rgb._TIER_MAP_CACHE["ident"] = None
     rgb._TIER_MAP_CACHE["mtime"] = None
     rgb._TIER_MAP_CACHE["map"] = {}
     return tmp
@@ -118,21 +119,25 @@ class _FakeTelemetry:
 _fresh_dirs()
 with _FakeTelemetry() as t:
     tid = rgb._write_task({"id": "task-telem1", "task": "hello", "source": "ag2space",
-                           "user_id": "@rui:ag2.space", "channel_id": "!room:ag2.space"})
+                           "user_id": "@rui:ag2.space", "access_tier": "owner",
+                           "channel_id": "!room:ag2.space"})
 check("write returns the task id", tid == "task-telem1")
 check("one task_processed event", t.calls == ["ag2space"], repr(t.calls))
 
 # 2. no source on the task → falls back to PROVIDER (matches the file header)
 _fresh_dirs()
 with _FakeTelemetry() as t:
-    rgb._write_task({"id": "task-telem2", "task": "hi", "user_id": "@rui:ag2.space"})
+    rgb._write_task({"id": "task-telem2", "task": "hi", "user_id": "@rui:ag2.space",
+                     "access_tier": "owner"})
 check("sourceless task tags PROVIDER", t.calls == [rgb.PROVIDER], repr(t.calls))
 
 # 3. idempotent re-write (file already queued) → no second event
 _fresh_dirs()
 with _FakeTelemetry() as t:
-    rgb._write_task({"id": "task-telem3", "task": "x", "source": "ag2space"})
-    rgb._write_task({"id": "task-telem3", "task": "x", "source": "ag2space"})
+    rgb._write_task({"id": "task-telem3", "task": "x", "source": "ag2space",
+                     "access_tier": "owner"})
+    rgb._write_task({"id": "task-telem3", "task": "x", "source": "ag2space",
+                     "access_tier": "owner"})
 check("idempotent re-write counted once", t.calls == ["ag2space"], repr(t.calls))
 
 # 4. gateway redelivery of an archived task → no event (and no task file)
@@ -141,7 +146,8 @@ archive = rgb.TASKS_DIR / "archive"
 archive.mkdir(parents=True, exist_ok=True)
 (archive / "task-telem4.txt").write_text("done long ago\n")
 with _FakeTelemetry() as t:
-    rgb._write_task({"id": "task-telem4", "task": "replay", "source": "ag2space"})
+    rgb._write_task({"id": "task-telem4", "task": "replay", "source": "ag2space",
+                     "access_tier": "owner"})
 check("archived redelivery not counted", t.calls == [], repr(t.calls))
 check("archived redelivery writes no task file",
       not (rgb.TASKS_DIR / "task-telem4.txt").exists())
@@ -150,7 +156,8 @@ check("archived redelivery writes no task file",
 _fresh_dirs()
 _prev = sys.modules.pop("telemetry", None)
 try:
-    tid = rgb._write_task({"id": "task-telem5", "task": "standalone", "source": "ag2space"})
+    tid = rgb._write_task({"id": "task-telem5", "task": "standalone", "source": "ag2space",
+                           "access_tier": "owner"})
 finally:
     if _prev is not None:
         sys.modules["telemetry"] = _prev
@@ -160,7 +167,8 @@ check("missing telemetry module → task still queued",
 # 6. telemetry raising mid-call → write still succeeds (fire-and-forget)
 _fresh_dirs()
 with _FakeTelemetry(raise_on_call=True) as t:
-    tid = rgb._write_task({"id": "task-telem6", "task": "boom", "source": "ag2space"})
+    tid = rgb._write_task({"id": "task-telem6", "task": "boom", "source": "ag2space",
+                           "access_tier": "owner"})
 check("raising telemetry never breaks the write",
       tid == "task-telem6" and (rgb.TASKS_DIR / "task-telem6.txt").exists())
 check("raising telemetry was attempted", t.calls == ["ag2space"], repr(t.calls))
@@ -196,6 +204,7 @@ def _write_with_real_telemetry(task: dict):
     its network sink stubbed to a capture list. Joins sender threads so the
     captured payloads are complete before asserting."""
     tmp = _fresh_dirs()
+    task = {"access_tier": "owner", **task}
     real = _load_real_telemetry(tmp / "telem-state")
     payloads = []
     real._post = lambda payload: payloads.append(payload)  # network boundary stub
@@ -218,7 +227,8 @@ def _write_with_real_telemetry(task: dict):
 #    exact metric the owner reported missing), not "unknown".
 tmp7, payloads = _write_with_real_telemetry(
     {"id": "task-telem7", "task": "hello", "source": "ag2space",
-     "user_id": "@rui:ag2.space", "channel_id": "!room:ag2.space"})
+     "user_id": "@rui:ag2.space", "access_tier": "owner",
+     "channel_id": "!room:ag2.space"})
 tp = [p for p in payloads if p.get("event") == "task_processed"]
 check("real pipeline emits one task_processed", len(tp) == 1, repr(payloads))
 check("real pipeline keeps source=ag2space",
@@ -327,6 +337,7 @@ check("raw secret value never reaches the payload",
 #     proving no assertion secretly depends on the host's ambient tierMap.
 tmp7d = _fresh_dirs()
 _ACCESS.write_text('{"allowFrom": [], "tierMap": {"@rui:ag2.space": "team"}}')
+rgb._TIER_MAP_CACHE["ident"] = None
 rgb._TIER_MAP_CACHE["mtime"] = None  # force re-read of the hostile map
 real = _load_real_telemetry(tmp7d / "telem-state")
 payloads = []
@@ -336,7 +347,8 @@ sys.modules["telemetry"] = real
 try:
     before = set(threading.enumerate())
     rgb._write_task({"id": "task-telem7d", "task": "hi", "source": "ag2space",
-                     "user_id": "@rui:ag2.space", "channel_id": "!room:ag2.space"})
+                     "user_id": "@rui:ag2.space", "access_tier": "owner",
+                     "channel_id": "!room:ag2.space"})
     for th in set(threading.enumerate()) - before:
         th.join(timeout=2)
 finally:

--- a/tests/gateway-writeside-attachments.test.py
+++ b/tests/gateway-writeside-attachments.test.py
@@ -101,15 +101,19 @@ text, h = _write_and_parse({"id": "task-gw-3", "task": "just a text question"})
 check("no marker → no attachments header", "attachments:" not in text)
 check("no marker → no content_modalities header", "content_modalities:" not in text)
 
-# ── 5. access_tier must remain the ONLY header-shaped access_tier line —
-# nothing after it but bridge-authored block text that never carries the key.
+# ── 5. access_tier must remain the ONLY access_tier line, and no recognized
+# task header may appear after it. Security instructions are intentionally prose.
 def _tier_wins_last(txt):
     ls = [l for l in txt.split("\n") if l]
     tier_at = [i for i, l in enumerate(ls) if l.startswith("access_tier:")]
     if len(tier_at) != 1:
         return False
     tail = ls[tier_at[0] + 1:]
-    return not tail or any(l.startswith("===SKILL INSTRUCTIONS") for l in tail)
+    return not any(
+        line.startswith(f"{key}:")
+        for line in tail
+        for key in ltp.KNOWN_HEADER_KEYS
+    )
 check("access_tier still last header", _tier_wins_last(text))
 # and with media present too
 text1 = (rgb.TASKS_DIR / "task-gw-1.txt").read_text()

--- a/tests/owner-activity-channel-id.test.py
+++ b/tests/owner-activity-channel-id.test.py
@@ -127,6 +127,7 @@ class TestGatewayWriterChannelId(unittest.TestCase):
                 # channel_id present → recorded + bracket prefix stripped from summary
                 gw._write_owner_activity({"task": "[AG2 @u] hi there",
                                           "source": "ag2space",
+                                          "access_tier": "owner",
                                           "channel_id": "!room:ag2.space"})
                 data = json.loads(f.read_text())
                 self.assertEqual(data["channel"], "ag2space")
@@ -134,7 +135,8 @@ class TestGatewayWriterChannelId(unittest.TestCase):
                 self.assertEqual(data["summary"], "hi there")
                 # channel_id omitted → key absent (back-compat with older readers)
                 f.unlink()
-                gw._write_owner_activity({"task": "[AG2 @u] no room", "source": "ag2space"})
+                gw._write_owner_activity({"task": "[AG2 @u] no room", "source": "ag2space",
+                                          "access_tier": "owner"})
                 self.assertNotIn("channel_id", json.loads(f.read_text()))
             finally:
                 gw.OWNER_ACTIVITY_FILE, gw.LOCAL_TIER = orig_file, orig_tier

--- a/tests/remote-gateway-interaction-type.test.py
+++ b/tests/remote-gateway-interaction-type.test.py
@@ -72,14 +72,21 @@ for v in sorted(rgb._INTERACTION_TYPES):
     h = _headers({"id": f"task-it-{v}", "task": "x", "interaction_type": v})
     check(f"vocab round-trip: {v}", h.get("interaction_type") == v)
 
-# 5. access_tier must remain the ONLY header-shaped access_tier line — nothing
-# after it but bridge-authored block text that never carries the key.
+# 5. access_tier must remain the ONLY access_tier line and the final recognized
+# task header. Bridge-authored security guidance intentionally follows as prose.
 body = (rgb.TASKS_DIR / "task-it-1.txt").read_text()
 lines = [l for l in body.split("\n") if l]
 _tier_at = [i for i, l in enumerate(lines) if l.startswith("access_tier:")]
 _tail = lines[_tier_at[0] + 1:] if len(_tier_at) == 1 else None
+_known_headers = set(rgb._TASK_FIELDS) | {
+    "interaction_type", "content_modalities", "media_form", "attachments",
+}
 check("access_tier is the last header",
-      _tail is not None and (not _tail or any(l.startswith("===SKILL INSTRUCTIONS") for l in _tail)))
+      _tail is not None and not any(
+          line.startswith(f"{key}:")
+          for line in _tail
+          for key in _known_headers
+      ))
 
 if failures:
     sys.exit(1)


### PR DESCRIPTION
## Summary
- treat the broker access tier as an authenticated upper bound
- keep owner unrestricted, make team workspace-write sandboxed, and make guest read-only
- fail missing or invalid broker tiers closed to guest
- prevent local sender mappings from upgrading a broker-attested team or guest task

## Regression
Before this change, the desktop bridge ignored the broker tier and an owner-default node wrote non-owner tasks as `access_tier: owner`. The focused test now proves broker team/guest tiers survive and local owner defaults cannot promote them.

## Tests
- `python3 src/remote-gateway-bridge.test.py`
- `python3 packages/ag2-sparrow/tests/test_write_task_atomic.py`
- `python3 -m py_compile packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py src/local_task_protocol.py`
- `git diff --check`

Fixes #2460