### PR TITLE
fix(health-check): the 409 detector switched off once the conflict mattered

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5876,7 +5876,8 @@ def _resolve_menu_bar_pgrep(pgrep_status: Optional[str], pids: list[str]) -> tup
     return pgrep_status, pids
 
 
-def bridge_log_content_status(name: str, status: str, tail: list[str]) -> Optional[tuple[str, str]]:
+def bridge_log_content_status(name: str, status: str, tail: list[str],
+                              detail: str = "") -> Optional[tuple[str, str]]:
     """Check a bridge's recent log lines for known failure-mode signatures.
 
     Returns an (status, detail) override, or None if nothing to override.
@@ -5891,12 +5892,16 @@ def bridge_log_content_status(name: str, status: str, tail: list[str]) -> Option
       it last fired (checked via a subsequent "Wrote task-" line) — otherwise
       Event Subscriptions clearly ARE enabled and it's a stale false alarm.
     telegram-bridge: a 409 Conflict is a competing getUpdates poller splitting
-      updates. Only counts if no message arrived after the last conflict.
+      updates. Only counts if no message arrived after the last conflict. It
+      overrides the heartbeat-stale warn too, because the conflict is that
+      warn's CAUSE — gating on "ok" alone silenced it exactly when the split
+      got bad enough to stall the heartbeat.
     """
     if name == "discord-bridge":
         if any("LoginFailure" in ln or "Improper token" in ln for ln in tail):
             return "fail", "token invalid (LoginFailure) — regenerate at discord.com/developers/applications"
-    elif name == "telegram-bridge" and status == "ok":
+    elif name == "telegram-bridge" and (
+            status == "ok" or (status == "warn" and "heartbeat stale" in detail)):
         conflict_idxs = [i for i, ln in enumerate(tail) if "409" in ln and "Conflict" in ln]
         if conflict_idxs:
             # Telegram hands each update to exactly ONE getUpdates caller, so a
@@ -7126,12 +7131,12 @@ def run_all_checks() -> list[dict]:
         #   events aren't routing (Slack app Event Subscriptions disabled).
         #   Only overrides "ok" — stale/dead-inode are higher priority.
         # telegram-bridge: a 409 Conflict is a second poller taking a share of
-        #   the updates. Only overrides "ok".
+        #   the updates. Overrides "ok" and the heartbeat-stale warn it causes.
         if (log_file.exists() and name in ("discord-bridge", "slack-bridge", "telegram-bridge")
                 and _bridge_log_belongs_to_process(log_file, proc_start)):
             try:
                 tail = log_file.read_text(errors="replace").splitlines()[-60:]
-                override = bridge_log_content_status(name, status, tail)
+                override = bridge_log_content_status(name, status, tail, detail)
                 if override is not None:
                     status, detail = override
             except OSError:

--- a/tests/health-check-bridge-log-content.test.py
+++ b/tests/health-check-bridge-log-content.test.py
@@ -88,6 +88,36 @@ check("discord LoginFailure overrides even non-ok incoming status", result7 is n
 result8 = hc.bridge_log_content_status("discord-bridge", "ok", ["Logged in as SutandoBot#1234"])
 check("discord healthy log → no override", result8 is None)
 
+# ── telegram-bridge: 409 Conflict, incl. the warn it causes ────────────────
+# The 409 branch had no test, which is how a gate on status == "ok" survived:
+# the detector switched OFF once the split stalled the heartbeat.
+
+conflict = ['API error 409: {"ok":false,"error_code":409,"description":"Conflict: '
+            'terminated by other getUpdates request"}']
+
+result9 = hc.bridge_log_content_status("telegram-bridge", "ok", conflict)
+check("telegram 409 on ok → warn override", result9 is not None and result9[0] == "warn")
+
+result10 = hc.bridge_log_content_status("telegram-bridge", "warn", conflict,
+                                       "running but heartbeat stale (3482s old)")
+check("telegram 409 STILL reported when the conflict stalled the heartbeat (the fix)",
+      result10 is not None and "getUpdates" in result10[1], str(result10))
+
+result11 = hc.bridge_log_content_status("telegram-bridge", "warn", conflict,
+                                        "some unrelated warning")
+check("telegram 409 does not hijack an unrelated warn", result11 is None, str(result11))
+
+result12 = hc.bridge_log_content_status("telegram-bridge", "ok",
+                                        conflict + ["@chi: hello"])
+check("telegram message after the last 409 → this host is winning, no override",
+      result12 is None, str(result12))
+
+result13 = hc.bridge_log_content_status("telegram-bridge", "warn",
+                                        conflict + ["@chi: hello"],
+                                        "running but heartbeat stale (10s old)")
+check("telegram heartbeat-stale warn + message after 409 → still no override",
+      result13 is None, str(result13))
+
 # ── run_all_checks() integration: exercise the actual call site ─────────────
 # The unit tests above cover bridge_log_content_status() in isolation, but the
 # call site inside run_all_checks() (fetching `tail`, invoking the function,


### PR DESCRIPTION
## The defect

`bridge_log_content_status` only inspected telegram-bridge logs when the incoming status was already `ok`:

```python
elif name == "telegram-bridge" and status == "ok":
```

A competing `getUpdates` poller splits updates between hosts. Once the split is bad enough the Telegram round-trip stops succeeding — which stalls the heartbeat and moves the status to `warn`. So the detector reported the conflict **only while the bridge still looked healthy, and went silent exactly when it stopped being.**

## Observed live on this host

```
process uptime            1d 14h
last successful round-trip 59 minutes ago
API error 409 lines       7,448   (60 of 60 in the tail the probe reads)
health line               telegram-bridge  warn  running but heartbeat stale (3482s old)
```

That line sends the reader at the process and at code staleness — I went there first. The cause was sitting in the log the probe had **already read and then declined to interpret.**

## The fix

The 409 is not a lower-priority signal competing with the stale heartbeat; it is that heartbeat's **cause**. It now overrides that warn too, gated on the heartbeat-stale detail specifically so an unrelated telegram warn is not hijacked.

`detail` is a new **optional** parameter, so existing 3-arg callers and the slack/discord tests are untouched.

## Why it survived

**The 409 branch had no test.** This file covered slack and discord only. Adds five cases, including the regression and both no-fire directions — a message arriving after the last conflict means this host is winning again, and that must still suppress the warn.

## Evidence

```
with the fix                    PASS (13 checks)
src/health-check.py reverted    exit 1
restored                        PASS
all 60 health-check suites      60/60
```

End-to-end against the real log, which is the part a fixture can't prove:

```
OLD (no detail passed) -> None                      # silent
NEW (detail passed)    -> warn: another getUpdates poller is competing —
                          set SKIP_TELEGRAM=1 on the non-owning host
```

Single concern. No behaviour change for discord-bridge or slack-bridge.

Stand: Echo Act IV Mini
