### PR TITLE
fix(screen-companion): use the shared workspace resolver, not a private one

### DIFF
--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -20,12 +20,7 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { loadConfig, discoverConfigs, renderGoal } from './scripts/load-config.js';
 import { readSelection as defaultReadSelection, type SelectionResult } from './scripts/read-selection.js';
 import { registerVisionOnContributor, registerVisionFrameHook, callUpdateTools, callRestoreTools, captureSendFrame, getFullToolSurface } from '../../src/vision-tools.js';
-
-function resolveWorkspace(): string {
-	const env = process.env.SUTANDO_WORKSPACE;
-	if (env) return env.replace(/^~/, process.env.HOME ?? '');
-	return join(process.env.HOME ?? '', '.sutando', 'workspace');
-}
+import { resolveWorkspace } from '../../src/workspace_default.js';
 
 // Contributor for the screen-share-started system note. Tells Gemini the
 // screen-companion catalog is available AND names the configs the user can


### PR DESCRIPTION
## What changed, and why

`skills/screen-companion/tools.ts` defined its **own** `resolveWorkspace()` instead of importing the shared one. It broke the v0.8 workspace contract twice over:

- it **honored `$SUTANDO_WORKSPACE`**, which v0.8 removed as an override; and
- it fell back to a **hardcoded `~/.sutando/workspace`** — the exact path `CLAUDE.md` names as never-hardcode.

It never called the shared resolver at all. This is not a fallback path; it was the only resolution the file had.

## Before / after — measured, not described

Both implementations run side by side, same process, only the env differing:

```
SUTANDO_WORKSPACE=/tmp/BOGUS-WORKSPACE
  OLD private impl -> /tmp/BOGUS-WORKSPACE
  NEW shared impl  -> <repo>/workspace     + "no longer honored (removed in v0.8)" warning

SUTANDO_WORKSPACE unset
  OLD private impl -> /Users/wangchi/.sutando/workspace
  NEW shared impl  -> <repo>/workspace
```

## User-visible consequence

The single consumer is the save-note tool at `tools.ts:378` — `join(resolveWorkspace(), 'notes')`. On any host where the env var is set, or where the canonical workspace is not `~/.sutando/workspace`, voice-saved notes were written **outside** the resolved workspace: not synced by the vault, not visible to the dashboard, not where any reader looks.

## Verification

- `tsc -p tsconfig.skills.json --noEmit` — clean.
- **Negative control:** repointing the import at a nonexistent module yields `error TS2307` on this exact file, so the clean pass is a real signal rather than a check that never ran.
- `join` remains used at lines 378/380 and three `Array.join` sites, so the existing import is not orphaned.

## A second finding, not fixed here

**`scripts/lint-workspace-resolution.sh` exits 0 at the parent commit with this defect present, and never mentions `screen-companion`.** The guard that exists for exactly this class does not cover `skills/**/*.ts`. That is a separate change with its own blast radius — widening the linter will likely surface other skills — so it is deliberately not bundled into this single-concern fix. Filing it separately.

Minor inconsistency spotted while doing this: the linter's own guidance prints `import { resolveWorkspace } from './sutando_config.js'`, while `CLAUDE.md` prescribes `'./workspace_default.js'`. Both resolve (the latter delegates to the former); I followed CLAUDE.md.

Stand: Echo Act IV Pro
