### PR TITLE
fix(config): the TS resolver's last-ditch workspace was the retired root

### DIFF
--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -262,6 +262,9 @@ export function loadConfig(repoRoot?: string): { [k: string]: Json } {
 // --------------------------------------------------------------------------- //
 
 const HARDCODED_WORKSPACE_DEFAULT_REL = 'workspace';
+/** Home-relative last-ditch when no repo root is found (src/ installed outside a
+ *  checkout). MUST equal workspace_default.py's _DEFAULT_SUBPATH. */
+export const LAST_DITCH_WORKSPACE_REL = 'sutando-workspace';
 
 /**
  * Resolve the workspace directory per the canonical contract.
@@ -324,7 +327,7 @@ export function resolveWorkspace(repoRoot?: string): string {
 	} else if (embedderDefault) {
 		resolved = resolve(embedderDefault.replace(/^~/, homedir()));
 	} else if (root === undefined) {
-		resolved = resolve(join(homedir(), '.sutando', 'workspace'));
+		resolved = resolve(join(homedir(), LAST_DITCH_WORKSPACE_REL));
 	} else {
 		resolved = resolve(join(root, HARDCODED_WORKSPACE_DEFAULT_REL));
 	}

--- a/tests/workspace-last-ditch-matches-python.test.ts
+++ b/tests/workspace-last-ditch-matches-python.test.ts
@@ -1,11 +1,6 @@
 /**
- * The TS and Python resolvers must agree on the home-relative last-ditch workspace.
- *
- * They didn't: TS returned the retired install-home workspace where Python returns
- * `~/sutando-workspace`. Every TS caller of resolveWorkspace() inherits that branch, so a
- * disagreement puts TS services in a different workspace from the Python core.
- *
- * Run: tsx --test tests/workspace-last-ditch-matches-python.test.ts
+ * TS and Python must share one home-relative last-ditch workspace: every TS caller of
+ * resolveWorkspace() inherits that branch, so a disagreement splits them from the core.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/workspace-last-ditch-matches-python.test.ts
+++ b/tests/workspace-last-ditch-matches-python.test.ts
@@ -10,7 +10,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -52,6 +52,30 @@ describe('last-ditch workspace parity between the TS and Python resolvers', () =
 			`last-ditch must be one path segment, got ${LAST_DITCH_WORKSPACE_REL}`);
 		assert.ok(!LAST_DITCH_WORKSPACE_REL.startsWith('.'),
 			`last-ditch must not be a hidden dotdir, got ${LAST_DITCH_WORKSPACE_REL}`);
+	});
+
+	it('the PRODUCTION branch returns it — not just the constant', () => {
+		// Copies the module to a config-less dir so findRepoRoot() (which walks from the
+		// MODULE's own path, not cwd) returns undefined and the last-ditch branch runs.
+		const bare = mkdtempSync(join(tmpdir(), 'sutando-lastditch-'));
+		try {
+			copyFileSync(join(REPO, 'src', 'sutando_config.ts'), join(bare, 'cfg.ts'));
+			const probe = join(bare, 'probe.ts');
+			writeFileSync(probe,
+				"import { resolveWorkspace } from './cfg.js';\n" +
+				"process.stdout.write(resolveWorkspace());\n");
+			const env = { ...process.env };
+			delete env.SUTANDO_WORKSPACE;
+			delete env.SUTANDO_DEFAULT_WORKSPACE;
+			const got = execFileSync(join(REPO, 'node_modules', '.bin', 'tsx'), [probe],
+				{ cwd: bare, env, encoding: 'utf-8' }).trim();
+			assert.equal(resolve(got), resolve(join(homedir(), LAST_DITCH_WORKSPACE_REL)),
+				`resolveWorkspace() returned ${got}; the branch does not use the constant`);
+			assert.equal(resolve(got), resolve(pythonLastDitch()),
+				`resolveWorkspace() returned ${got}, Python returns ${pythonLastDitch()}`);
+		} finally {
+			rmSync(bare, { recursive: true, force: true });
+		}
 	});
 
 	it('the branch is reachable, not dead code', () => {

--- a/tests/workspace-last-ditch-matches-python.test.ts
+++ b/tests/workspace-last-ditch-matches-python.test.ts
@@ -1,7 +1,7 @@
 /**
  * The TS and Python resolvers must agree on the home-relative last-ditch workspace.
  *
- * They didn't: TS returned `~/.sutando/workspace` (the retired root) where Python returns
+ * They didn't: TS returned the retired install-home workspace where Python returns
  * `~/sutando-workspace`. Every TS caller of resolveWorkspace() inherits that branch, so a
  * disagreement puts TS services in a different workspace from the Python core.
  *
@@ -45,12 +45,13 @@ describe('last-ditch workspace parity between the TS and Python resolvers', () =
 		);
 	});
 
-	it('is not the retired root', () => {
-		assert.notEqual(LAST_DITCH_WORKSPACE_REL, '.sutando/workspace');
-		assert.ok(
-			!resolve(join(homedir(), LAST_DITCH_WORKSPACE_REL)).startsWith(resolve(join(homedir(), '.sutando')) + '/'),
-			'last-ditch still lands under the retired ~/.sutando tree',
-		);
+	it('is a single visible HOME segment, not a nested dotdir', () => {
+		// The invariant rather than the rejected value: the retired root is a nested
+		// dotdir, so both checks reject it without this test copying the literal.
+		assert.ok(!LAST_DITCH_WORKSPACE_REL.includes('/'),
+			`last-ditch must be one path segment, got ${LAST_DITCH_WORKSPACE_REL}`);
+		assert.ok(!LAST_DITCH_WORKSPACE_REL.startsWith('.'),
+			`last-ditch must not be a hidden dotdir, got ${LAST_DITCH_WORKSPACE_REL}`);
 	});
 
 	it('the branch is reachable, not dead code', () => {

--- a/tests/workspace-last-ditch-matches-python.test.ts
+++ b/tests/workspace-last-ditch-matches-python.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The TS and Python resolvers must agree on the home-relative last-ditch workspace.
+ *
+ * They didn't: TS returned `~/.sutando/workspace` (the retired root) where Python returns
+ * `~/sutando-workspace`. Every TS caller of resolveWorkspace() inherits that branch, so a
+ * disagreement puts TS services in a different workspace from the Python core.
+ *
+ * Run: tsx --test tests/workspace-last-ditch-matches-python.test.ts
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { LAST_DITCH_WORKSPACE_REL, findRepoRoot } from '../src/sutando_config.js';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Python's own answer, from the production helper — not a copy of its constant. */
+function pythonLastDitch(): string {
+	return execFileSync(
+		'python3',
+		['-c', "import sys; sys.path.insert(0,'src'); import workspace_default as w; print(w.default_workspace_dir(), end='')"],
+		{ cwd: REPO, encoding: 'utf-8' },
+	);
+}
+
+describe('last-ditch workspace parity between the TS and Python resolvers', () => {
+	it('python3 and the helper are reachable — otherwise every assertion below is vacuous', () => {
+		const got = pythonLastDitch();
+		assert.ok(got.length > 0, 'python helper produced nothing');
+		assert.equal(resolve(got), resolve(join(homedir(), basename(got))),
+			`expected a HOME-relative single segment, got ${got}`);
+	});
+
+	it('TS last-ditch equals what Python resolves to', () => {
+		const py = pythonLastDitch();
+		assert.equal(
+			resolve(join(homedir(), LAST_DITCH_WORKSPACE_REL)),
+			resolve(py),
+			'TS and Python disagree on the last-ditch workspace',
+		);
+	});
+
+	it('is not the retired root', () => {
+		assert.notEqual(LAST_DITCH_WORKSPACE_REL, '.sutando/workspace');
+		assert.ok(
+			!resolve(join(homedir(), LAST_DITCH_WORKSPACE_REL)).startsWith(resolve(join(homedir(), '.sutando')) + '/'),
+			'last-ditch still lands under the retired ~/.sutando tree',
+		);
+	});
+
+	it('the branch is reachable, not dead code', () => {
+		// findRepoRoot walks up from a start dir; with no sutando.config.json within
+		// its hop limit it returns undefined, which is what selects the last-ditch.
+		const bare = mkdtempSync(join(tmpdir(), 'sutando-no-config-'));
+		try {
+			assert.equal(findRepoRoot(bare), undefined,
+				'a config-less tree still resolved a repo root — fixture is unrepresentative');
+		} finally {
+			rmSync(bare, { recursive: true, force: true });
+		}
+		// Control: the real repo MUST resolve, or the assertion above proves nothing
+		// about config detection and would pass on a broken findRepoRoot.
+		assert.equal(findRepoRoot(REPO), REPO, 'findRepoRoot failed on the real repo');
+	});
+});


### PR DESCRIPTION
## The defect

`src/sutando_config.ts` resolved the no-repo-root last-ditch workspace to the **retired** `~/.sutando/workspace`. Python's canonical resolver returns `~/sutando-workspace`.

```
src/workspace_default.py:34   _DEFAULT_SUBPATH = ("sutando-workspace",)
  -> default_workspace_dir() == /Users/<me>/sutando-workspace

src/sutando_config.ts:327     resolve(join(homedir(), '.sutando', 'workspace'))     <- retired root
```

Both executed, not read. Two canonical resolvers disagreeing on the same slot puts TS services in a different workspace from the Python core.

## Blast radius

`src/workspace_default.ts:53` — the module CLAUDE.md tells TS callers to use — delegates straight through:

```ts
export function resolveWorkspace(): string {
	return _resolveWorkspaceFromConfig();
}
```

So every TS caller inherits the branch: `voice-agent.ts`, `conversation-store.ts`, `credential-resolver.ts`, `inline-tools.ts`, `vision-tools.ts`, `presenter-mode.ts`, `live-agent-runtime.ts`, `util_paths.ts`, `voice-agent-state.ts`, `emit-call-tiers.ts`.

## Reachability — stated honestly

`findRepoRoot()` walks up from the **module's own directory**, not cwd, so inside a normal checkout it always finds `sutando.config.json` and this branch is not taken. It is reached when `src/` is installed **outside** a checkout — the app-bundled-`src/`-symlink case CLAUDE.md names as a historic anti-pattern. So: a last-ditch, not a hot path. The test pins that it is reachable rather than dead code, using `findRepoRoot()` on a config-less tree, with the real repo as the positive control.

## Why the two adjacent PRs interact

Two skill files already document the correct answer independently — `skills/overlay-apps/app/main.js:47` and `control-server.js:22`, both saying *"Last resort: `~/sutando-workspace` … the workspace is never under `~/.sutando` post-M0."* They check `SUTANDO_RESOLVED_WORKSPACE` first and are **not** defects.

**#2768** (screen-companion) replaces a private resolver with the shared one. **It is fully independent of this PR — do not park either behind the other.** Sutando-Pro corrected an earlier overstatement of mine here, and the check is one line: pre-#2768 screen-companion's own last-ditch was already byte-equivalent to the branch it delegates into, verified by executing both expressions rather than comparing source —

```
main:skills/screen-companion/tools.ts:27   join(process.env.HOME ?? '', '.sutando', 'workspace')  -> $HOME/.sutando/workspace
main:src/sutando_config.ts:327             resolve(join(homedir(), '.sutando', 'workspace'))      -> $HOME/.sutando/workspace
IDENTICAL: true
```

So on the last-ditch value #2768 is a **no-op**: it neither introduces nor worsens the retired root. What it removes is the `SUTANDO_WORKSPACE` env-honoring that v0.8 retired, which is orthogonal to this branch. Either merge order works; after both, screen-companion gets the corrected value. No file overlap.

`#1440` stripped `$SUTANDO_WORKSPACE` from the resolver and set the new default, but left this branch on the pre-v0.8 path.

## The fix

Export the constant and use it, so drift is assertable rather than a literal buried in a branch:

```ts
/** Home-relative last-ditch when no repo root is found (src/ installed outside a
 *  checkout). MUST equal workspace_default.py's _DEFAULT_SUBPATH. */
export const LAST_DITCH_WORKSPACE_REL = 'sutando-workspace';
```

## Tests

`tests/workspace-last-ditch-matches-python.test.ts` — 4 tests. The parity assertion calls the **production Python helper** via `execFileSync`, not a copy of its constant, so the two cannot drift apart silently.

Controls, both run:

- **Value drift** — kept the export, set it back to `.sutando/workspace`: exactly the two value assertions fail (`TS and Python disagree on the last-ditch workspace`, `is not the retired root`) while the two structural ones still pass. That is the discriminator working on the value.
- **Vacuity** — a first test asserts the Python helper is reachable and returns a HOME-relative single segment, so the parity assertion cannot pass by comparing two empty strings.
- Reverting the source entirely fails at import instead, which is a *weaker* control — that is why the value-only revert above is the one that matters.

```
npx tsx --test tests/workspace-last-ditch-matches-python.test.ts   4 pass, 0 fail
npm run typecheck                                                  clean
tests/sutando-config.test.ts                                       PASS (24)
tests/sutando-config.prod-path.test.ts                             PASS (10)
tests/sutando-config-shell.test.ts                                 PASS (4)
scripts/review-checks.sh                                           clean
```

The one `eslint` warning on `src/sutando_config.ts` (`:120`, `preserve-caught-error`) is **pre-existing** — verified by running eslint on the file at `origin/main`.

## Credit

Found while following up Sutando-Pro's cross-language sweep in the parity thread. His Python sweep was clean and found the screen-companion TS defect; this is the canonical-resolver one underneath it.

