### PR TITLE
fix(refresh-skill): --all serialised a fixed wait, blowing the cron budget

### DIFF
--- a/skills/refresh-skill.sh
+++ b/skills/refresh-skill.sh
@@ -30,6 +30,9 @@ if [ -z "$SKILLS_DST" ]; then
   SKILLS_DST="${SKILLS_DST:-$HOME/.claude/skills}"
 fi
 SETTLE_S="${REFRESH_SKILL_SETTLE_S:-1}"
+# --all concurrency. The settle is a fixed per-skill wait, so serialising it made
+# --all cost SETTLE_S x skill-count — 97s at 97 skills, past a 120s cron budget.
+JOBS="${REFRESH_SKILL_JOBS:-8}"
 EXCLUDES=(--exclude='workspace' --exclude='node_modules' --exclude='generated'
           --exclude='__pycache__' --exclude='.git' --exclude='*.mp4' --exclude='*.png'
           --exclude='*.wav' --exclude='.venv')
@@ -57,11 +60,17 @@ main() {
   mkdir -p "$SKILLS_DST"
   [ "$#" -ge 1 ] || { echo "usage: refresh-skill.sh <name> [<name> ...] | --all" >&2; exit 2; }
   if [ "$1" = "--all" ]; then
-    local any=0
+    # Each skill's settle is WAITING, not work, so --all runs them concurrently.
+    # Chunked, not unbounded: a crash strands at most $REFRESH_SKILL_JOBS as copies,
+    # which refresh_one then refuses to touch ("not a symlink").
+    local any=0 running=0
     for link in "$SKILLS_DST"/*; do
       [ -L "$link" ] || continue
-      refresh_one "$(basename "$link")"; any=1
+      refresh_one "$(basename "$link")" &
+      any=1; running=$((running + 1))
+      if [ "$running" -ge "$JOBS" ]; then wait; running=0; fi
     done
+    wait
     [ "$any" = 1 ] || echo "  (no symlinked skills under $SKILLS_DST)"
   else
     for name in "$@"; do refresh_one "$name"; done


### PR DESCRIPTION
## The bug

`refresh-skill.sh --all` cannot finish inside the 120s budget of the `sync-skills` cron that calls it. It is not a hang — it is a linear cost that crossed the budget as the skill count grew.

`refresh_one` ends with `sync; sleep "$SETTLE_S"`. That settle exists to hold a real directory in place long enough for Claude Code's watcher to fire an fs-event (the watcher does not follow symlinks — the whole reason this script exists). It is a **fixed wait, not work**, and `--all` serialised it:

```
SETTLE_S default          1s
symlinked skills          97
floor from sleeps alone   97s        + 97 whole-filesystem sync() calls
cron budget               120s
```

## Before / after — actual output, not a description

Measured on an isolated fixture (12 symlinks + one deliberately non-symlink local install), `SETTLE_S=1` both runs:

```
parent commit (serial)    17.2s  rc=0  refreshed=12  errors=0
this branch  (JOBS=8)      4.9s  rc=0  refreshed=12  errors=0
```

Live, against the real 97-skill directory, **default `SETTLE_S=1` unchanged**:

```
parent commit    bash skills/refresh-skill.sh --all   ->  TIMEOUT at 120s
this branch      bash skills/refresh-skill.sh --all   ->  33.3s  rc=0
                                                          refreshed=91  skip=0  ERROR=0
```

Directory state after the live run — nothing stranded as a copy:

```
entries 97   symlinks 91   non-symlink 6   (the 6 are pre-existing local installs)
```

## Why chunked and not unbounded

A crash between materialising the copy and restoring the symlink leaves that skill as a real directory — and `refresh_one` then **deliberately refuses to touch it** ("not a symlink — won't clobber a local/copy install"), so it would silently stop updating. Serial exposure is 1 skill; unbounded parallelism would be all 97. `JOBS=8` bounds it to 8, which is why this is chunked with a `wait` per chunk rather than a single `wait` at the end.

Fixture also confirms the non-symlink guard still holds: the local install was present and unmodified after both runs.

## What is NOT changed

- `SETTLE_S` default stays `1`. I did not tune the timing constant — I don't know the watcher's event latency, and guessing it would trade a slow path for an unreliable one.
- `refresh_one` is untouched. Per-skill semantics (materialise → settle → restore) are identical; only the loop around it changes.
- The single-name path (`refresh-skill.sh <name>`) is unchanged and still serial.

`REFRESH_SKILL_JOBS` is env-overridable; `=1` restores the previous behaviour exactly.

## Scope

One file, one loop. `bash -n` clean.
