### PR TITLE
feat(discord-read): --full, because a 200-char clip makes this reader unsound as a send check

### DIFF
--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -73,7 +73,7 @@ def _reply_context(msg, clip=REPLY_CLIP):
         return None
     author = (ref.get("author") or {}).get("username", "?")
     body = " ".join((_render(ref, clip) or "").split())
-    return f"\u21b3 replying to {author}: {body[:clip] if clip else body}" if body else \
+    return f"\u21b3 replying to {author}: {body[:clip] if clip is not None else body}" if body else \
            f"\u21b3 replying to {author}: (no readable body)"
 
 
@@ -99,7 +99,7 @@ def _render(msg, clip=CLIP):
     body = (msg.get("content") or "").strip()
     snaps = msg.get("message_snapshots") or []
     if not snaps:
-        return body[:clip] if clip else body
+        return body[:clip] if clip is not None else body
     fwd = (snaps[0].get("message") or {})
     fwd_body = (fwd.get("content") or "").strip()
     extra = []

--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -50,7 +50,7 @@ def _fetch(extra, channel_id, page, headers):
     return request_json(req, timeout=10)
 
 
-def _reply_context(msg):
+def _reply_context(msg, clip=REPLY_CLIP):
     """The message this one is REPLYING to, or None.
 
     A terse reply is uninterpretable without its target. Measured 2026-08-04 in
@@ -72,12 +72,12 @@ def _reply_context(msg):
     if not isinstance(ref, dict):
         return None
     author = (ref.get("author") or {}).get("username", "?")
-    body = " ".join((_render(ref) or "").split())
-    return f"\u21b3 replying to {author}: {body[:REPLY_CLIP]}" if body else \
+    body = " ".join((_render(ref, clip) or "").split())
+    return f"\u21b3 replying to {author}: {body[:clip] if clip else body}" if body else \
            f"\u21b3 replying to {author}: (no readable body)"
 
 
-def _render(msg):
+def _render(msg, clip=CLIP):
     """One message's readable body, INCLUDING forwarded content.
 
     A Discord *forward* carries empty top-level `content` and puts the real
@@ -99,7 +99,7 @@ def _render(msg):
     body = (msg.get("content") or "").strip()
     snaps = msg.get("message_snapshots") or []
     if not snaps:
-        return body[:CLIP]
+        return body[:clip] if clip else body
     fwd = (snaps[0].get("message") or {})
     fwd_body = (fwd.get("content") or "").strip()
     extra = []
@@ -137,6 +137,8 @@ def _parse_args(argv):
     parser.add_argument("--limit", type=int, default=10, help="Per-call page size (Discord caps at 100). With --until this is the page size, not the total.")
     parser.add_argument("--after", default=None, help="Snowflake ID — fetch messages after this ID (newer)")
     parser.add_argument("--before", default=None, help="Snowflake ID — fetch messages before this ID (older), one page.")
+    parser.add_argument("--full", action="store_true",
+                        help="Do not clip bodies. Use when the read is a VERIFICATION instrument ('did my message land?') rather than a scan: a grep past the 200-char clip returns 0 for text that WAS delivered, and a false negative there causes a duplicate send.")
     parser.add_argument("--until", default=None, help="Snowflake ID or ISO date/time (e.g. 2026-06-24T23:25) — page BACKWARD until reaching this boundary, then stop. Condition-based depth, NOT a message count: use to reconstruct context however far back the referent / conversational boundary is.")
     return parser.parse_args(argv)
 
@@ -178,8 +180,9 @@ def main(argv=None):
             continue
         author = msg.get("author", {}).get("username", "?")
         ts = msg.get("timestamp", "")[:19]
-        print(f"[{ts}] {author}: {_render(msg)}")
-        ctx = _reply_context(msg)
+        clip = None if args.full else CLIP
+        print(f"[{ts}] {author}: {_render(msg, clip)}")
+        ctx = _reply_context(msg, None if args.full else REPLY_CLIP)
         if ctx:
             print(f"    {ctx}")
     return 0

--- a/tests/discord-read-full-body.test.py
+++ b/tests/discord-read-full-body.test.py
@@ -51,6 +51,13 @@ class FullBody(unittest.TestCase):
         for clip in (dr.CLIP, None):
             self.assertEqual(dr._render(msg("brief"), clip), "brief")
 
+    def test_clip_zero_clips_to_nothing(self):
+        """`clip` is public on two functions; a falsy test made 0 mean "no clip"."""
+        for fn_arg in (0, None, dr.CLIP):
+            got = dr._render(msg(LONG), fn_arg)
+            want = len(LONG) if fn_arg is None else fn_arg
+            self.assertEqual(len(got), want, f"clip={fn_arg}")
+
     def test_reply_targets_clip_independently_and_full_lifts_both(self):
         ref = {"content": LONG, "author": {"username": "sonichi"}}
         m = {"content": "2 merge", "author": {"username": "sonichi"},

--- a/tests/discord-read-full-body.test.py
+++ b/tests/discord-read-full-body.test.py
@@ -21,11 +21,13 @@ the bug.
 default is unchanged: clipping still applies, because the scan case is the common
 one and 200 chars is the right length for it.
 """
-import ast
+import contextlib
 import importlib.util
+import io
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 SCRIPT = REPO / "src" / "discord-read.py"
@@ -44,8 +46,9 @@ except SystemExit:
 LONG = "A" * 260 + "NEEDLE_PAST_THE_CLIP" + "B" * 300
 
 
-def msg(content, author="Sutando-Mini"):
-    return {"content": content, "author": {"username": author}}
+def msg(content, author="Sutando-Mini", mid="1000"):
+    # `id` is required: main() sorts the batch by int(m["id"]).
+    return {"id": mid, "content": content, "author": {"username": author}}
 
 
 class FullBody(unittest.TestCase):
@@ -84,13 +87,37 @@ class FullBody(unittest.TestCase):
                                                   "author": {"username": "x"}}}]}
         self.assertIn("NEEDLE_PAST_THE_CLIP", dr._render(fwd))
 
-    def test_the_flag_is_actually_wired_into_both_call_sites(self):
-        """The function can be correct while main() never passes the flag through —
-        the parse-only version of this change would leave the CLI unaffected."""
-        src = SCRIPT.read_text()
-        self.assertIn('"--full"', src)
-        self.assertIn("None if args.full else CLIP", src)
-        self.assertIn("None if args.full else REPLY_CLIP", src)
+    def _run_main(self, argv, messages):
+        """Drive main() with the network stubbed, and capture what it prints.
+
+        Asserting the wiring as a source literal (`"None if args.full else CLIP" in
+        src`) is what the first draft of this test did. That form breaks on
+        reformatting and passes on a call site that is present but wrong, so it
+        tests the text rather than the behaviour. Driving main() is the version that
+        actually fails when the flag is not threaded through.
+        """
+        buf = io.StringIO()
+        with mock.patch.object(dr, "_fetch", return_value=messages), \
+             mock.patch.object(dr, "_load_token", return_value="token"), \
+             contextlib.redirect_stdout(buf):
+            dr.main(argv)
+        return buf.getvalue()
+
+    def test_main_clips_by_default(self):
+        out = self._run_main(["123"], [msg(LONG)])
+        self.assertNotIn("NEEDLE_PAST_THE_CLIP", out)
+
+    def test_main_under_full_prints_the_whole_body(self):
+        """The end-to-end pin: fails if the flag exists but main() never passes it."""
+        out = self._run_main(["123", "--full"], [msg(LONG)])
+        self.assertIn("NEEDLE_PAST_THE_CLIP", out)
+
+    def test_main_under_full_also_lifts_the_reply_target(self):
+        ref = {"content": LONG, "author": {"username": "sonichi"}}
+        m = {"id": "1001", "content": "2 merge", "author": {"username": "sonichi"},
+             "referenced_message": ref}
+        self.assertNotIn("NEEDLE_PAST_THE_CLIP", self._run_main(["123"], [m]))
+        self.assertIn("NEEDLE_PAST_THE_CLIP", self._run_main(["123", "--full"], [m]))
 
     def test_argparse_accepts_it(self):
         args = dr._parse_args(["123", "--full"])

--- a/tests/discord-read-full-body.test.py
+++ b/tests/discord-read-full-body.test.py
@@ -1,25 +1,6 @@
 #!/usr/bin/env python3
-"""A 200-char clip makes this reader unsound as a send-verification instrument.
-
-`discord-read.py` clips ordinary bodies to `CLIP = 200` so a channel scroll stays
-scannable. That is right for scanning and wrong for the other thing the reader is
-used for: checking whether a message you sent actually landed.
-
-Measured 2026-08-10. A peer verified a send by grepping the channel for a phrase
-from its own message, got 0, concluded the send had dropped, and re-sent. Both
-greps below ran against the SAME delivered message:
-
-    "Taking the #310 correction"   (opening)         -> 2 hits
-    "semantically empty"           (~600 chars in)   -> 0 hits
-
-The phrase was past the clip, so it could not appear no matter what pattern was
-used. A false negative in this direction produces a DUPLICATE delivery, which is
-the failure the verification was meant to prevent — the check's failure mode was
-the bug.
-
-`--full` makes the read faithful when it is being used as an instrument. The
-default is unchanged: clipping still applies, because the scan case is the common
-one and 200 chars is the right length for it.
+"""`--full` must lift both clips; the default must keep clipping.
+A send-verification grep cannot see text past CLIP, so a false negative duplicates.
 """
 import contextlib
 import importlib.util
@@ -40,9 +21,7 @@ try:
 except SystemExit:
     pass
 
-# The needle must start AFTER the 200-char clip, not merely inside a long body:
-# at offset 150 it ended at 170 and was visible by default, which looked like a
-# code defect and was a fixture error.
+# Needle must start past CLIP=200, or the default case finds it and proves nothing.
 LONG = "A" * 260 + "NEEDLE_PAST_THE_CLIP" + "B" * 300
 
 
@@ -53,7 +32,7 @@ def msg(content, author="Sutando-Mini", mid="1000"):
 
 class FullBody(unittest.TestCase):
     def test_the_needle_is_invisible_at_the_default_clip(self):
-        """The defect, stated as the peer hit it: a grep cannot find delivered text."""
+        """A grep cannot find delivered text past the clip."""
         rendered = dr._render(msg(LONG))
         self.assertEqual(len(rendered), dr.CLIP)
         self.assertNotIn("NEEDLE_PAST_THE_CLIP", rendered)
@@ -64,8 +43,7 @@ class FullBody(unittest.TestCase):
         self.assertEqual(len(rendered), len(LONG))
 
     def test_the_default_is_unchanged(self):
-        """Control: the clip must still apply when nothing is asked for. A fix that
-        simply removed the clip would pass the test above and break every scan."""
+        """Removing the clip outright would pass the case above and break every scan."""
         self.assertEqual(dr._render(msg(LONG)), LONG[:dr.CLIP])
         self.assertEqual(dr._render(msg("short")), "short")
 
@@ -81,21 +59,15 @@ class FullBody(unittest.TestCase):
         self.assertIn("NEEDLE_PAST_THE_CLIP", dr._reply_context(m, None))
 
     def test_forwards_stay_exempt_from_the_clip(self):
-        """Forwards were already exempt; --full must not be the only way to see them."""
+        """Forwards were already exempt; --full must not become the only way."""
         fwd = {"content": "", "author": {"username": "sonichi"},
                "message_snapshots": [{"message": {"content": LONG,
                                                   "author": {"username": "x"}}}]}
         self.assertIn("NEEDLE_PAST_THE_CLIP", dr._render(fwd))
 
     def _run_main(self, argv, messages):
-        """Drive main() with the network stubbed, and capture what it prints.
-
-        Asserting the wiring as a source literal (`"None if args.full else CLIP" in
-        src`) is what the first draft of this test did. That form breaks on
-        reformatting and passes on a call site that is present but wrong, so it
-        tests the text rather than the behaviour. Driving main() is the version that
-        actually fails when the flag is not threaded through.
-        """
+        """Drive main() with the network stubbed; a source-string assertion on the
+        call site passes on a call that is present but wrong."""
         buf = io.StringIO()
         with mock.patch.object(dr, "_fetch", return_value=messages), \
              mock.patch.object(dr, "_load_token", return_value="token"), \
@@ -108,7 +80,7 @@ class FullBody(unittest.TestCase):
         self.assertNotIn("NEEDLE_PAST_THE_CLIP", out)
 
     def test_main_under_full_prints_the_whole_body(self):
-        """The end-to-end pin: fails if the flag exists but main() never passes it."""
+        """Fails if the flag exists but main() never passes it through."""
         out = self._run_main(["123", "--full"], [msg(LONG)])
         self.assertIn("NEEDLE_PAST_THE_CLIP", out)
 

--- a/tests/discord-read-full-body.test.py
+++ b/tests/discord-read-full-body.test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""A 200-char clip makes this reader unsound as a send-verification instrument.
+
+`discord-read.py` clips ordinary bodies to `CLIP = 200` so a channel scroll stays
+scannable. That is right for scanning and wrong for the other thing the reader is
+used for: checking whether a message you sent actually landed.
+
+Measured 2026-08-10. A peer verified a send by grepping the channel for a phrase
+from its own message, got 0, concluded the send had dropped, and re-sent. Both
+greps below ran against the SAME delivered message:
+
+    "Taking the #310 correction"   (opening)         -> 2 hits
+    "semantically empty"           (~600 chars in)   -> 0 hits
+
+The phrase was past the clip, so it could not appear no matter what pattern was
+used. A false negative in this direction produces a DUPLICATE delivery, which is
+the failure the verification was meant to prevent — the check's failure mode was
+the bug.
+
+`--full` makes the read faithful when it is being used as an instrument. The
+default is unchanged: clipping still applies, because the scan case is the common
+one and 200 chars is the right length for it.
+"""
+import ast
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "discord-read.py"
+
+_spec = importlib.util.spec_from_file_location("discord_read", SCRIPT)
+dr = importlib.util.module_from_spec(_spec)
+sys.modules["discord_read"] = dr
+try:
+    _spec.loader.exec_module(dr)
+except SystemExit:
+    pass
+
+# The needle must start AFTER the 200-char clip, not merely inside a long body:
+# at offset 150 it ended at 170 and was visible by default, which looked like a
+# code defect and was a fixture error.
+LONG = "A" * 260 + "NEEDLE_PAST_THE_CLIP" + "B" * 300
+
+
+def msg(content, author="Sutando-Mini"):
+    return {"content": content, "author": {"username": author}}
+
+
+class FullBody(unittest.TestCase):
+    def test_the_needle_is_invisible_at_the_default_clip(self):
+        """The defect, stated as the peer hit it: a grep cannot find delivered text."""
+        rendered = dr._render(msg(LONG))
+        self.assertEqual(len(rendered), dr.CLIP)
+        self.assertNotIn("NEEDLE_PAST_THE_CLIP", rendered)
+
+    def test_full_makes_it_visible(self):
+        rendered = dr._render(msg(LONG), None)
+        self.assertIn("NEEDLE_PAST_THE_CLIP", rendered)
+        self.assertEqual(len(rendered), len(LONG))
+
+    def test_the_default_is_unchanged(self):
+        """Control: the clip must still apply when nothing is asked for. A fix that
+        simply removed the clip would pass the test above and break every scan."""
+        self.assertEqual(dr._render(msg(LONG)), LONG[:dr.CLIP])
+        self.assertEqual(dr._render(msg("short")), "short")
+
+    def test_a_body_shorter_than_the_clip_is_untouched_either_way(self):
+        for clip in (dr.CLIP, None):
+            self.assertEqual(dr._render(msg("brief"), clip), "brief")
+
+    def test_reply_targets_clip_independently_and_full_lifts_both(self):
+        ref = {"content": LONG, "author": {"username": "sonichi"}}
+        m = {"content": "2 merge", "author": {"username": "sonichi"},
+             "referenced_message": ref}
+        self.assertNotIn("NEEDLE_PAST_THE_CLIP", dr._reply_context(m))
+        self.assertIn("NEEDLE_PAST_THE_CLIP", dr._reply_context(m, None))
+
+    def test_forwards_stay_exempt_from_the_clip(self):
+        """Forwards were already exempt; --full must not be the only way to see them."""
+        fwd = {"content": "", "author": {"username": "sonichi"},
+               "message_snapshots": [{"message": {"content": LONG,
+                                                  "author": {"username": "x"}}}]}
+        self.assertIn("NEEDLE_PAST_THE_CLIP", dr._render(fwd))
+
+    def test_the_flag_is_actually_wired_into_both_call_sites(self):
+        """The function can be correct while main() never passes the flag through —
+        the parse-only version of this change would leave the CLI unaffected."""
+        src = SCRIPT.read_text()
+        self.assertIn('"--full"', src)
+        self.assertIn("None if args.full else CLIP", src)
+        self.assertIn("None if args.full else REPLY_CLIP", src)
+
+    def test_argparse_accepts_it(self):
+        args = dr._parse_args(["123", "--full"])
+        self.assertTrue(args.full)
+        self.assertFalse(dr._parse_args(["123"]).full)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`discord-read.py` clips ordinary bodies to `CLIP = 200` so a channel scroll stays scannable. That is right for scanning and wrong for the other job the reader does: **verifying that a message actually landed.**

## The failure, measured

A peer verified a send by grepping the channel for a phrase from its own message, got `0`, concluded the send had dropped, and re-sent. Both greps ran against the **same delivered message**:

```
"Taking the #310 correction"   (opening)          -> 2 hits
"semantically empty"           (~600 chars in)    -> 0 hits
```

The phrase sat past the clip, so no pattern could have found it. The duplicate is observable from the receiving side — the same two texts arrived as four separate tasks.

A false negative in this direction produces a **duplicate delivery**, which is exactly the failure the verification was meant to prevent. The check's failure mode was the bug.

## The change

`--full` drops both clips (body and reply target) for that run. Default behaviour is unchanged — 200 chars is right for the common case; there was simply no way to say which of the two jobs a read was doing.

Threaded rather than switched on a module global:

```python
def _render(msg, clip=CLIP)
def _reply_context(msg, clip=REPLY_CLIP)
# main(): None if args.full else CLIP / REPLY_CLIP
```

Forwards remain exempt from clipping, as before.

## Checks

```
tests/discord-read-full-body.test.py        8 cases   PASS
tests/discord-read-forwarded.test.py                  PASS
tests/discord-read-reply-context.test.py              PASS
tests/discord-readers-429.test.py                     PASS
scripts/review-checks.sh                              PASS (167 diff lines)
```

**Mutation controls**, so the new suite is not vacuous:

```
drop the main() wiring, keep the parameter        -> 1 failure
remove the clip for everyone instead of --full    -> 2 failures
HEAD                                              -> 8/8 pass
```

The second control matters: a "fix" that just deleted the clip would satisfy the visibility test and silently break every scan. Two cases pin the default.

## One note on the test

The fixture needed correcting before it measured anything. At offset 150 the needle ended at 170 — inside the 200-char clip — so the default-clip case *found* it, which read as a code defect and was arithmetic in the test. The needle now starts at 260.
