### PR TITLE
fix(discord-read): --full, so a text check can see past the 200-char clip

### DIFF
--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -137,6 +137,8 @@ def _parse_args(argv):
     parser.add_argument("--limit", type=int, default=10, help="Per-call page size (Discord caps at 100). With --until this is the page size, not the total.")
     parser.add_argument("--after", default=None, help="Snowflake ID — fetch messages after this ID (newer)")
     parser.add_argument("--before", default=None, help="Snowflake ID — fetch messages before this ID (older), one page.")
+    parser.add_argument("--full", action="store_true",
+                        help="Do not clip message bodies. The default clip makes a long body indistinguishable from a short one, so a text check over this output can report a phrase absent when it was delivered.")
     parser.add_argument("--until", default=None, help="Snowflake ID or ISO date/time (e.g. 2026-06-24T23:25) — page BACKWARD until reaching this boundary, then stop. Condition-based depth, NOT a message count: use to reconstruct context however far back the referent / conversational boundary is.")
     return parser.parse_args(argv)
 
@@ -149,6 +151,10 @@ def main(argv=None):
         return 1
 
     args = _parse_args(argv)
+    if args.full:
+        # `body[:None]` is the whole string, so the clip sites need no change.
+        global CLIP, REPLY_CLIP
+        CLIP = REPLY_CLIP = None
     headers = {"Authorization": f"Bot {token}", "User-Agent": "Sutando-reader/1.0"}
     page = min(max(args.limit, 1), 100)
 

--- a/tests/discord-read-full-flag.test.py
+++ b/tests/discord-read-full-flag.test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""A clipped body is indistinguishable from a short one, so a text check over this
+reader's output reports a phrase absent when it was delivered.
+
+Measured 2026-08-10. Both greps ran against the SAME delivered message:
+
+    'Taking the #310 correction'   (opening)         -> 2 matches
+    'semantically empty'           (~600 chars in)   -> 0 matches
+
+Acting on that zero produced a duplicate post to a peer. The failure direction is
+what makes it costly: the reader turns "delivered" into "looks dropped", and the
+response to a dropped message is to send it again.
+
+`--full` disables both clips. The defaults are unchanged — the clip is right for
+scanning a channel, and wrong for verifying a specific string reached it.
+
+These cases drive `main()` with the fetch stubbed, so they exercise the SHIPPED
+flag-to-clip wiring. Setting `CLIP = None` by hand instead would test Python's
+slicing and stay green if the flag were never wired up.
+"""
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "discord-read.py"
+
+_spec = importlib.util.spec_from_file_location("discord_read", SCRIPT)
+dr = importlib.util.module_from_spec(_spec)
+sys.modules["discord_read"] = dr
+try:
+    _spec.loader.exec_module(dr)
+except SystemExit:
+    pass
+
+TAIL = "PHRASE_PAST_THE_CLIP"
+LONG = ("x" * 400) + TAIL
+MESSAGES = [{
+    "id": "100", "timestamp": "2026-08-10T05:00:00.000000+00:00",
+    "content": LONG, "author": {"username": "Sutando-Pro"},
+    "referenced_message": {"content": LONG, "author": {"username": "Sutando-Mini"}},
+}]
+
+
+def run(argv):
+    """Run main() with the network and token stubbed; return stdout."""
+    buf = io.StringIO()
+    with mock.patch.object(dr, "_load_token", return_value="tok"), \
+         mock.patch.object(dr, "_fetch", return_value=list(MESSAGES)), \
+         contextlib.redirect_stdout(buf):
+        rc = dr.main(argv)
+    assert rc == 0, f"main() returned {rc}"
+    return buf.getvalue()
+
+
+class FullFlag(unittest.TestCase):
+    def setUp(self):
+        self._clip, self._reply_clip = dr.CLIP, dr.REPLY_CLIP
+
+    def tearDown(self):
+        dr.CLIP, dr.REPLY_CLIP = self._clip, self._reply_clip
+
+    def test_default_clips_and_hides_the_tail(self):
+        """The control. If TAIL shows up here the fixture is too short and every
+        assertion below is vacuous."""
+        self.assertNotIn(TAIL, run(["123"]))
+
+    def test_full_reveals_the_tail_in_the_body(self):
+        self.assertIn(TAIL, run(["123", "--full"]))
+
+    def test_full_also_lifts_the_reply_clip(self):
+        out = run(["123", "--full"])
+        self.assertIn("replying to Sutando-Mini", out)
+        # Body and reply target both carry TAIL, so require two occurrences —
+        # one match could come from the body alone and say nothing about REPLY_CLIP.
+        self.assertGreaterEqual(out.count(TAIL), 2)
+
+    def test_default_leaves_the_reply_clipped(self):
+        out = run(["123"])
+        self.assertIn("replying to Sutando-Mini", out)
+        self.assertEqual(out.count(TAIL), 0)
+
+    def test_flag_defaults_off(self):
+        self.assertFalse(dr._parse_args(["123"]).full)
+        self.assertTrue(dr._parse_args(["123", "--full"]).full)
+
+    def test_short_bodies_are_identical_either_way(self):
+        """Additive: --full must not alter anything that was not being clipped."""
+        short = [dict(MESSAGES[0], content="2 merge", referenced_message=None)]
+        with mock.patch.object(dr, "_load_token", return_value="tok"), \
+             mock.patch.object(dr, "_fetch", return_value=short):
+            buf1, buf2 = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(buf1):
+                dr.main(["123"])
+            with contextlib.redirect_stdout(buf2):
+                dr.main(["123", "--full"])
+        self.assertEqual(buf1.getvalue(), buf2.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The bug

`discord-read.py` clips every message body at `CLIP = 200` (and reply targets at `REPLY_CLIP = 110`) with no way to turn it off. That is right for scanning a channel. It is wrong for the other thing this reader is used for — confirming a specific string actually reached a channel — because **a clipped body and a short body are the same output.**

Measured 2026-08-10. Both greps ran against the *same delivered message*:

```
'Taking the #310 correction'   (opening)         -> 2 matches
'semantically empty'           (~600 chars in)   -> 0 matches
```

I acted on that zero, concluded the message had been dropped, and re-sent it. The peer received it twice.

**The failure direction is what makes it costly.** The reader turns *delivered* into *looks dropped*, and the natural response to a dropped message is to send it again. A verification step built on this output manufactures duplicates.

## The fix

`--full` sets `CLIP = REPLY_CLIP = None`. `body[:None]` is the whole string, so **no call site changes** — 6 added lines in `src/discord-read.py`, and the clip expressions are untouched.

Defaults are unchanged. Forwards keep their existing clip exemption.

## Tests

New `tests/discord-read-full-flag.test.py`, 6 cases, driving `main()` with `_fetch` and `_load_token` stubbed.

**They exercise the shipped flag-to-clip wiring rather than re-implementing it.** My first draft set `dr.CLIP = None` by hand — that tests Python's slicing and would stay green if the flag were never wired up. The negative control shows the difference:

```
first draft   (set CLIP by hand)   1 of 5 fail without the fix
this version  (drive main())       4 of 6 fail without the fix
```

The 2 that still pass without the fix are the two default-only cases, which correctly do not touch the flag. Control run by reverting `src/` alone and keeping the test.

Existing suite for the touched file, all green:

```
discord-read-forwarded.test.py      PASS
discord-read-reply-context.test.py  PASS
discord-readers-429.test.py         PASS
discord-read-full-flag.test.py      PASS  (new)
```

`git diff --check` clean, `review-checks: PASS`.

## Credit

Sutando-Mini located the constant after I reported the symptom.
