### PR TITLE
fix(health-check): an unclaimed task beside its own result read as "still queued"

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-203 modules indexed.
+204 modules indexed.
 
 ## `src/`
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5178,6 +5178,9 @@ def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
             try:
                 task_age = now - task_path.stat().st_mtime
             except OSError:
+                # Same treatment as an unreadable result entry: a measurement we
+                # could not take is partial coverage, never a silent clean pass.
+                unreadable += 1
                 continue
             # An UNCLAIMED task sitting beside its own finished result, both
             # past the threshold, is not a pair in flight: nothing is coming

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5169,8 +5169,24 @@ def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
         # same signal as a genuinely stranded reply, which is how a detector
         # trains its readers to ignore it. `find_task_file()` is the canonical
         # locator (it is what the bridge archive paths already use).
-        if find_task_file(tasks_dir, path.stem) is not None:
-            continue
+        task_path = find_task_file(tasks_dir, path.stem)
+        if task_path is not None:
+            # A CLAIMED task is owned by a running consumer; its lifetime is
+            # not ours to judge, however long it takes.
+            if ".claimed-core-" in task_path.name:
+                continue
+            try:
+                task_age = now - task_path.stat().st_mtime
+            except OSError:
+                continue
+            # An UNCLAIMED task sitting beside its own finished result, both
+            # past the threshold, is not a pair in flight: nothing is coming
+            # to collect it. Tasks written straight into tasks/ by a script
+            # are never registered with a bridge, so their result is polled by
+            # no one and both files stay on disk forever -- which is exactly
+            # the state this exclusion used to read as "still queued".
+            if task_age < threshold_age_sec:
+                continue
         orphans.append((path.name, int(age)))
     # Coverage is part of the verdict: say what could not be measured rather
     # than let it round down into a clean result.
@@ -5184,7 +5200,7 @@ def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
     return {
         "name": name,
         "status": "warn",
-        "detail": (f"{len(orphans)} result(s) whose task is already archived — never delivered; "
+        "detail": (f"{len(orphans)} result(s) with no consumer coming — never delivered; "
                    f"oldest {oldest_name} ({oldest_age // 3600}h{oldest_age % 3600 // 60}m){partial}"),
     }
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5169,7 +5169,13 @@ def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
         # same signal as a genuinely stranded reply, which is how a detector
         # trains its readers to ignore it. `find_task_file()` is the canonical
         # locator (it is what the bridge archive paths already use).
-        task_path = find_task_file(tasks_dir, path.stem)
+        try:
+            task_path = find_task_file(tasks_dir, path.stem)
+        except OSError:
+            # The locator itself stats the path, so it raises for the same
+            # reasons the age read does; both are partial coverage, not clean.
+            unreadable += 1
+            continue
         if task_path is not None:
             # A CLAIMED task is owned by a running consumer; its lifetime is
             # not ours to judge, however long it takes.
@@ -5182,12 +5188,8 @@ def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
                 # could not take is partial coverage, never a silent clean pass.
                 unreadable += 1
                 continue
-            # An UNCLAIMED task sitting beside its own finished result, both
-            # past the threshold, is not a pair in flight: nothing is coming
-            # to collect it. Tasks written straight into tasks/ by a script
-            # are never registered with a bridge, so their result is polled by
-            # no one and both files stay on disk forever -- which is exactly
-            # the state this exclusion used to read as "still queued".
+            # A task no bridge created is never collected, so an unclaimed
+            # pair past the threshold is stranded rather than in flight.
             if task_age < threshold_age_sec:
                 continue
         orphans.append((path.name, int(age)))

--- a/tests/health-check-orphaned-results.test.py
+++ b/tests/health-check-orphaned-results.test.py
@@ -76,22 +76,13 @@ class OrphanedResultsTest(unittest.TestCase):
     # --- negative: the guards that keep a 'warn' meaningful -------------
 
     def test_task_still_queued_is_not_an_orphan(self):
-        """The consumer simply has not reached this pair yet.
-
-        Scoped to a task younger than the threshold: "not reached yet" is a
-        transient state, not one a pair can hold for hours.
-        """
+        """Not-reached-yet is transient, so this is scoped to a fresh task."""
         self._write("results/task-abc.txt", TWO_HOURS_AGO)
         self._write("tasks/task-abc.txt")
         self.assertEqual(hc.check_orphaned_results()["status"], "ok")
 
     def test_aged_unclaimed_task_beside_its_result_IS_an_orphan(self):
-        """Nothing is coming to collect it, so "still queued" is the wrong read.
-
-        A task written straight into tasks/ by a script is never registered
-        with a bridge, so its result is polled by no one and BOTH files sit
-        past the threshold forever.
-        """
+        """An unclaimed pair past the threshold is stranded, not in flight."""
         self._write("results/task-newsradar-1.txt", TWO_HOURS_AGO)
         self._write("tasks/task-newsradar-1.txt", TWO_HOURS_AGO)
         result = hc.check_orphaned_results()
@@ -99,17 +90,12 @@ class OrphanedResultsTest(unittest.TestCase):
         self.assertIn("task-newsradar-1.txt", result["detail"])
 
     def test_unmeasurable_task_age_warns_rather_than_dropping_the_result(self):
-        """A task whose mtime cannot be read is partial coverage, not a clean pass.
-
-        Same treatment as an unreadable result entry — otherwise a stat failure
-        turns a real orphan into `ok` and nothing says the scan was incomplete.
-        """
+        """An unreadable task age is partial coverage, never a clean pass."""
         self._write("results/task-stat.txt", TWO_HOURS_AGO)
 
         class _UnstatableTask:
-            # Only `.name` and `.stat()` are used by the probe. A stub keeps the
-            # failure on that one call; patching Path.stat globally also breaks
-            # Path.exists(), which calls it internally.
+            # Deterministic counterpart to the real-locator control below:
+            # patching Path.stat globally would also break Path.exists().
             name = "task-stat.txt"
 
             def stat(self, *a, **k):
@@ -119,6 +105,24 @@ class OrphanedResultsTest(unittest.TestCase):
             result = hc.check_orphaned_results()
         self.assertEqual(result["status"], "warn", result)
         self.assertIn("unreadable", result["detail"])
+
+    def test_real_locator_raising_does_not_abort_the_probe(self):
+        """Drives the REAL find_task_file, whose exists() stats the path too."""
+        self._write("results/task-real.txt", TWO_HOURS_AGO)
+        task = self._write("tasks/task-real.txt", TWO_HOURS_AGO)
+        real_stat = pathlib.Path.stat
+
+        def boom(self_p, *a, **k):
+            if self_p == task:
+                raise OSError("EIO")
+            return real_stat(self_p, *a, **k)
+
+        # No stub: the failure must survive the locator, not bypass it.
+        with mock.patch.object(pathlib.Path, "stat", boom):
+            result = hc.check_orphaned_results()
+        # 3.12 raises out of exists(); 3.14 swallows it and the pair reads as
+        # an orphan. Both must warn; only the route differs.
+        self.assertEqual(result["status"], "warn", result)
 
     def test_aged_CLAIMED_task_is_still_not_an_orphan(self):
         """A claimed task is owned by a running consumer, however long it runs."""

--- a/tests/health-check-orphaned-results.test.py
+++ b/tests/health-check-orphaned-results.test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import pathlib
 import tempfile
 import time
 import unittest
@@ -96,6 +97,26 @@ class OrphanedResultsTest(unittest.TestCase):
         result = hc.check_orphaned_results()
         self.assertEqual(result["status"], "warn", result)
         self.assertIn("task-newsradar-1.txt", result["detail"])
+
+    def test_unmeasurable_task_age_warns_rather_than_dropping_the_result(self):
+        """A task whose mtime cannot be read is partial coverage, not a clean pass.
+
+        Same treatment as an unreadable result entry — otherwise a stat failure
+        turns a real orphan into `ok` and nothing says the scan was incomplete.
+        """
+        self._write("results/task-stat.txt", TWO_HOURS_AGO)
+        task = self._write("tasks/task-stat.txt", TWO_HOURS_AGO)
+        real_stat = pathlib.Path.stat
+
+        def boom(self_p, *a, **k):
+            if self_p == task:
+                raise OSError("EIO")
+            return real_stat(self_p, *a, **k)
+
+        with mock.patch.object(pathlib.Path, "stat", boom):
+            result = hc.check_orphaned_results()
+        self.assertEqual(result["status"], "warn", result)
+        self.assertIn("unreadable", result["detail"])
 
     def test_aged_CLAIMED_task_is_still_not_an_orphan(self):
         """A claimed task is owned by a running consumer, however long it runs."""

--- a/tests/health-check-orphaned-results.test.py
+++ b/tests/health-check-orphaned-results.test.py
@@ -75,9 +75,32 @@ class OrphanedResultsTest(unittest.TestCase):
     # --- negative: the guards that keep a 'warn' meaningful -------------
 
     def test_task_still_queued_is_not_an_orphan(self):
-        """The consumer simply has not reached this pair yet."""
+        """The consumer simply has not reached this pair yet.
+
+        Scoped to a task younger than the threshold: "not reached yet" is a
+        transient state, not one a pair can hold for hours.
+        """
         self._write("results/task-abc.txt", TWO_HOURS_AGO)
-        self._write("tasks/task-abc.txt", TWO_HOURS_AGO)
+        self._write("tasks/task-abc.txt")
+        self.assertEqual(hc.check_orphaned_results()["status"], "ok")
+
+    def test_aged_unclaimed_task_beside_its_result_IS_an_orphan(self):
+        """Nothing is coming to collect it, so "still queued" is the wrong read.
+
+        A task written straight into tasks/ by a script is never registered
+        with a bridge, so its result is polled by no one and BOTH files sit
+        past the threshold forever.
+        """
+        self._write("results/task-newsradar-1.txt", TWO_HOURS_AGO)
+        self._write("tasks/task-newsradar-1.txt", TWO_HOURS_AGO)
+        result = hc.check_orphaned_results()
+        self.assertEqual(result["status"], "warn", result)
+        self.assertIn("task-newsradar-1.txt", result["detail"])
+
+    def test_aged_CLAIMED_task_is_still_not_an_orphan(self):
+        """A claimed task is owned by a running consumer, however long it runs."""
+        self._write("results/task-slow.txt", TWO_HOURS_AGO)
+        self._write("tasks/task-slow.claimed-core-2.txt", TWO_HOURS_AGO)
         self.assertEqual(hc.check_orphaned_results()["status"], "ok")
 
     def test_claimed_task_is_still_a_live_task(self):

--- a/tests/health-check-orphaned-results.test.py
+++ b/tests/health-check-orphaned-results.test.py
@@ -105,15 +105,17 @@ class OrphanedResultsTest(unittest.TestCase):
         turns a real orphan into `ok` and nothing says the scan was incomplete.
         """
         self._write("results/task-stat.txt", TWO_HOURS_AGO)
-        task = self._write("tasks/task-stat.txt", TWO_HOURS_AGO)
-        real_stat = pathlib.Path.stat
 
-        def boom(self_p, *a, **k):
-            if self_p == task:
+        class _UnstatableTask:
+            # Only `.name` and `.stat()` are used by the probe. A stub keeps the
+            # failure on that one call; patching Path.stat globally also breaks
+            # Path.exists(), which calls it internally.
+            name = "task-stat.txt"
+
+            def stat(self, *a, **k):
                 raise OSError("EIO")
-            return real_stat(self_p, *a, **k)
 
-        with mock.patch.object(pathlib.Path, "stat", boom):
+        with mock.patch.object(hc, "find_task_file", return_value=_UnstatableTask()):
             result = hc.check_orphaned_results()
         self.assertEqual(result["status"], "warn", result)
         self.assertIn("unreadable", result["detail"])


### PR DESCRIPTION
## What

`check_orphaned_results` skipped any result whose task file still existed, reasoning that "the consumer has not reached this pair yet." That holds for a few seconds and fails permanently after: a task written **straight into `tasks/` by a script** is never registered with a bridge, so nothing polls its result and both files stay on disk forever. The condition that makes such a result stranded is precisely the one the exclusion treated as healthy.

`poll_results()` in `src/discord-bridge.py:4394` iterates `pending_replies` — task IDs the bridge itself registered when it created a task from a Discord message. A script-written task never enters that map.

## Evidence — a real stranded pair on the live workspace

Both files present, unclaimed, 65+ minutes old:

```
task-newsradar-1786379171467.txt   tasks/    age 4058s
task-newsradar-1786379171467.txt   results/  age 3881s
```

Same probe, same workspace, parent commit vs this head:

```
before   ok    no undeliverable results
after    warn  1 result(s) with no consumer coming — never delivered;
               oldest task-newsradar-1786379171467.txt (1h7m)
```

That result was a drafted post awaiting the owner's approval. It sat undelivered for over an hour while the probe reported clean, and was only found because I went looking for something else.

## How

The exclusion is now age-bounded and claim-aware:

| task state | behaviour |
|---|---|
| claimed (`*.claimed-core-N.txt`) | still skipped **at any age** — a running consumer owns it |
| unclaimed, younger than threshold | still skipped — the transient case the guard exists for |
| unclaimed, older than threshold | reported |

The `warn` detail said "whose task is already archived", which is false for this case — the task is present and unclaimed. Corrected to "with no consumer coming".

## A pre-existing test asserted the defect

`test_task_still_queued_is_not_an_orphan` wrote **both** files aged two hours and asserted `ok`. Its own docstring says "the consumer simply has not reached this pair yet" — a transient state that a pair cannot hold for hours. It now uses a fresh task, matching that stated intent, and two new cases cover the aged claimed/unclaimed split.

Calling this out explicitly because changing an existing assertion is a design change, not a bug fix, and it should be reviewed as one.

## Verification

```
tests/health-check-orphaned-results.test.py    16 passed (was 14)
```

Mutation control — the new unclaimed case run against the parent commit:

```
AssertionError: 'ok' != 'warn'
 : {'name': 'orphaned-results', 'status': 'ok', 'detail': 'no undeliverable results'}
Ran 16 tests ... FAILED (failures=1)
```

The other 15 pass unchanged on the parent, so the control isolates the one behaviour this changes.

## Scope

Probe only. It does not give script-written tasks a delivery route — that is a separate and larger question. This makes the strand visible instead of silent.
