### PR TITLE
fix(docs): regenerate src-map — main's count line is one behind its own tree

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-203 modules indexed.
+204 modules indexed.
 
 ## `src/`
 


### PR DESCRIPTION
## main is red on its own src-map gate

`main` at `1f526886` fails two checks. This fixes one of them:

```
refuse docs/src-map.md stale vs src/   → failure
tsc + tests (clean install)            → failure     (not this PR)
```

The shipped check, run on a clean `origin/main` worktree:

```
$ python3 scripts/gen-src-map.py --check
gen-src-map: docs/src-map.md is stale — run 'python3 scripts/gen-src-map.py' and commit the result

$ python3 scripts/gen-src-map.py
gen-src-map: wrote docs/src-map.md (204 modules)
$ git diff --stat docs/src-map.md
 docs/src-map.md | 2 +-
```

The whole diff is the header count: `203 modules indexed.` → `204 modules indexed.`
After: `gen-src-map: docs/src-map.md is up to date`.

## Why this is worth a PR rather than leaving to the next toucher

The gate measures a PR **merged with main**, so a stale map on main fails every open
Python PR regardless of what that PR changed. I hit it on two of mine today (#2741,
#2757) and cleared it on each by merging main and regenerating — which works, but is
per-PR and has to be repeated by every author. Fixing it here clears it once.

Credit for the diagnosis: Sutando-Pro identified the merged-with-main mechanism after
hitting identical symptoms on #2779 — `gen-src-map` producing no diff in the branch
alone while CI still failed.

## Scope

One generated file, one line. No source, no tests, no behaviour.
