### PR TITLE
test(chunker): the suite could not detect deletion of the primitive it covers

### DIFF
--- a/tests/discord-chunker.test.py
+++ b/tests/discord-chunker.test.py
@@ -79,6 +79,20 @@ def _run_against(mod, label):
     # reassembly; dm-result.py still exposes only its lossless alias.
     chunk = getattr(mod, "_chunk_for_discord_unbounded", mod._chunk_for_discord)
 
+    # The fallback above is deliberate (dm-result names its lossless alias
+    # differently), but it made this suite BLIND: renaming the bridge's primitive
+    # away left every assertion below satisfied by the bounded path, which caps at
+    # DISCORD_DELIVERY_MAX_CHUNKS. Assert the PROPERTY, not the name — a lossless
+    # chunker must exceed that cap on input that needs more.
+    _long = ("x" * 1800 + "\n") * 8
+    _n = len(list(chunk(_long)))
+    _cap = getattr(mod, "DISCORD_DELIVERY_MAX_CHUNKS", None)
+    if _cap is not None:
+        assert _n > _cap, (
+            f"{label}: resolved chunker produced {_n} chunks on ~14k chars, at or under the "
+            f"{_cap}-chunk delivery cap — the lossless primitive is missing and the bounded "
+            f"path was substituted silently")
+
     # Test 1: empty/short
     assert list(chunk("")) == []
     assert list(chunk("hi")) == ["hi"]


### PR DESCRIPTION
## The suite could not detect deletion of the primitive it covers

`tests/discord-chunker.test.py:80` resolves the lossless chunker as:

```python
chunk = getattr(mod, "_chunk_for_discord_unbounded", mod._chunk_for_discord)
```

The fallback is **deliberate** — `dm-result.py` names its lossless alias differently and
these golden checks are shared across both modules. But it made the suite blind: if the
bridge's primitive is ever removed, `getattr` silently substitutes the **bounded** path,
which caps at `DISCORD_DELIVERY_MAX_CHUNKS = 4` — and Test 2 asks only for `> 1` chunk
while Test 3 asks for `>= 3`. Both are satisfied by 4.

## Verified by exercising it, not by reading it

Renamed the primitive away in a scratch copy and ran the suite unchanged:

```
suite WITHOUT _chunk_for_discord_unbounded:  rc=0
"All chunker tests passed."
```

So the one thing this file exists to protect is the one thing it cannot notice.

## The fix asserts the property, not the name

A lossless chunker must exceed the delivery cap on input that needs more. Measured on
~14k chars:

```
_chunk_for_discord_unbounded : 8 chunks
_chunk_for_discord (bounded) : 4 chunks   <- cap
```

So the added assertion requires `> DISCORD_DELIVERY_MAX_CHUNKS`, read from the module
rather than hardcoded, and skips entirely for modules exposing no cap. **The fallback is
untouched**, so `dm-result.py` coverage is unchanged — which matters, because removing the
fallback would have been the obvious fix and the wrong one.

**Control** — same scratch deletion, patched test:

```
rc=1
AssertionError: discord-bridge.py: resolved chunker produced 4 chunks on ~14k chars,
at or under the 4-chunk delivery cap — the lossless primitive is missing and the
bounded path was substituted silently
```

Green at HEAD: `[dm-result.py] all 7 cases OK`, `[discord delivery budget] all 3 cases OK`,
`All chunker tests passed.`

## Note on the src-map check

If `refuse docs/src-map.md stale vs src/` fails here, it is inherited: `main` itself is red
on that gate (header says 203 modules, the tree has 204) and `#2782` fixes it. This PR
touches no file under `src/`.

## Credit

Found by Sutando-Pro while correcting an earlier claim of their own. Verified independently
here, including the deletion experiment.
