### PR TITLE
fix(ag2space): intercept vault set commands before task-write

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-204 modules indexed.
+205 modules indexed.
 
 ## `src/`
 
@@ -137,6 +137,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`util_paths.py`** — Resolve personal-asset paths with private-dir-first lookup.
 - **`util_paths.ts`** — TypeScript twin of src/util_paths.py — personal-asset path resolution.
 - **`vault_intercept.py`** — Bridge-level vault secret interception.
+- **`vault_set_grammar.py`** — Pure, dependency-free `vault set KEY VALUE` grammar — regex + redact-only.
 - **`verify-gemini-31.sh`** — Sutando Gemini 3.1 rollout verification
 - **`verify-setup.sh`** — Sutando setup verification — checks everything a new user needs
 - **`vision-tools.ts`** — Vision pipeline — pipe JPEG frames from a source (screen, webcam) into the Gemini Live voice session.

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -514,19 +514,8 @@ _VAULT_INTERCEPT_FNS: "tuple | None" = None
 
 
 def _vault_intercept_fns():
-    """Lazily locate + import `intercept_vault_commands`/`redact_vault_commands`
-    from the monorepo `src/vault_intercept.py`, same discovery pattern as
-    `_token_from_vault_ag2space` above (sparrow ships standalone, so `src/` may
-    be absent). Memoized; returns (None, None) on any failure so a caller can
-    degrade to `filter_chat_secrets`-only behavior rather than crash.
-
-    Closes the write-side half of #2638 for ag2space: discord/slack/telegram
-    bridges intercept an owner's `vault set KEY VALUE` before task-write so the
-    secret reaches Keychain and never the task file; this bridge only ever read
-    FROM the vault (`_token_from_vault_ag2space`, its own bootstrap token) and
-    never intercepted an inbound `vault set`, so a room-typed `vault set` here
-    silently stored nothing — same class of gap #2638 fixed for the other three.
-    """
+    """Lazily locate the monorepo `src/vault_intercept.py` helpers; memoized.
+    Returns (None, None) on failure so a caller can fall back to `_local_redact_vault_set`."""
     global _VAULT_INTERCEPT_FNS
     if _VAULT_INTERCEPT_FNS is not None:
         return _VAULT_INTERCEPT_FNS

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -553,6 +553,35 @@ def _vault_intercept_fns():
     return _VAULT_INTERCEPT_FNS
 
 
+# Self-contained fallback for when _vault_intercept_fns() returns (None, None) —
+# a standalone `ag2-sparrow` package install never ships the monorepo
+# src/vault_intercept.py, so that's not a rare edge case for shipped installs.
+# Mirrors src/vault_intercept.py's own _VAULT_SET_RE/redact_vault_commands
+# closely enough to catch the same shapes, deliberately duplicated rather than
+# imported: this path exists PRECISELY for when that import is unavailable, so
+# it cannot depend on it. review finding (qingyun-wu, 2026-08-11): without
+# this, an owner-tier `vault set KEY "value"` with no interceptor available
+# fell through untouched to filter_chat_secrets(), which doesn't recognize
+# vault-set syntax, and the plaintext value was persisted verbatim.
+_LOCAL_VAULT_SET_RE = re.compile(
+    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))'
+    r'(?=\s|$|[.,!?;])',
+    re.IGNORECASE,
+)
+
+
+def _local_redact_vault_set(text: str) -> str:
+    """Scrub vault-set patterns WITHOUT storing anything — last-resort, no
+    external dependency. Used only when _vault_intercept_fns() found neither
+    the real interceptor nor the real redactor."""
+    if not text:
+        return text
+    return _LOCAL_VAULT_SET_RE.sub(
+        lambda m: f"vault set {m.group(1)} [VAULT-SET-REDACTED: interceptor unavailable]",
+        text,
+    )
+
+
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""
 _URL_FALLBACK = ""
 _TOKEN_FILE_FALLBACK = ""
@@ -1498,12 +1527,17 @@ def _write_task(task: dict) -> str | None:
             # owner-tier only — write-side #2638 parity with discord/slack/
             # telegram (see _vault_intercept_fns docstring). Non-owner senders
             # never get Keychain writes; `filter_chat_secrets` below still
-            # catches an unnamed pasted token either way. Any interception
-            # failure (missing src/vault_intercept.py, or an exception inside
-            # it) falls back to `redact_vault_commands` if available, else the
-            # existing filter_chat_secrets call is simply unchanged — a value
-            # is never both left unredacted AND unstored.
+            # catches an unnamed pasted token either way. A value is never both
+            # left unredacted AND unstored: every path below that doesn't
+            # successfully intercept-and-store falls through to SOME redactor —
+            # the real one if `_vault_intercept_fns()` found it, else the
+            # dependency-free `_local_redact_vault_set` (review finding,
+            # qingyun-wu 2026-08-11: the old `elif sender_tier != "owner"` guard
+            # meant an owner-tier sender with no interceptor available — the
+            # standalone `ag2-sparrow` package case — skipped redaction
+            # entirely and the plaintext value reached disk).
             _intercept_fn, _redact_fn = _vault_intercept_fns()
+            _redact_fallback = _redact_fn or _local_redact_vault_set
             if sender_tier == "owner" and _intercept_fn is not None:
                 try:
                     _vault_result = _intercept_fn(_fetched)
@@ -1513,13 +1547,12 @@ def _write_task(task: dict) -> str | None:
                     if _vault_result.failed:
                         _log(f"[vault] store failed (still redacted): {_vault_result.failed}")
                 except Exception as _vault_exc:
-                    if _redact_fn is not None:
-                        _fetched = _redact_fn(_fetched)
+                    _fetched = _redact_fallback(_fetched)
                     _log(f"[vault] intercept errored "
                          f"({type(_vault_exc).__name__}: {_vault_exc}) — "
-                         f"redacted if possible, NOT stored")
-            elif sender_tier != "owner" and _redact_fn is not None:
-                _fetched = _redact_fn(_fetched)
+                         f"redacted, NOT stored")
+            else:
+                _fetched = _redact_fallback(_fetched)
             # Redact pasted secrets BEFORE the body is persisted (#2267 parity
             # with the discord/slack/telegram bridges): a token pasted into a
             # room message must never land on disk. Runs AFTER media
@@ -1532,6 +1565,16 @@ def _write_task(task: dict) -> str | None:
                 _log(f"redacted pasted secret(s) in {tid} body: "
                      f"{', '.join(sorted(_secret_types))}")
             lines.append(f"task: {_one_line(_filtered.text)}")
+            # Make the fully-sanitized body authoritative for every OTHER
+            # persistence sink too, not just the task file. _write_owner_activity()
+            # below re-reads task["task"] independently and only applies the
+            # generic filter_chat_secrets (not vault-aware), so without this the
+            # vault-intercepted/redacted text above stayed local to _fetched and
+            # the raw value still leaked into last-owner-activity.json (review
+            # finding, qingyun-wu 2026-08-11). `task` is this function's own
+            # shallow copy (`task = {**task, ...}` above), so mutating it here
+            # doesn't touch the caller's dict.
+            task["task"] = _filtered.text
             # interaction-model 4D, step 1.5: if a media marker was fetched,
             # stamp structured attachments[]/content_modalities/media_form
             # alongside the legacy [File attached:] body line (dual-write) via the

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -510,6 +510,49 @@ def _token_from_vault_ag2space(vault_get=None):
     return tok
 
 
+_VAULT_INTERCEPT_FNS: "tuple | None" = None
+
+
+def _vault_intercept_fns():
+    """Lazily locate + import `intercept_vault_commands`/`redact_vault_commands`
+    from the monorepo `src/vault_intercept.py`, same discovery pattern as
+    `_token_from_vault_ag2space` above (sparrow ships standalone, so `src/` may
+    be absent). Memoized; returns (None, None) on any failure so a caller can
+    degrade to `filter_chat_secrets`-only behavior rather than crash.
+
+    Closes the write-side half of #2638 for ag2space: discord/slack/telegram
+    bridges intercept an owner's `vault set KEY VALUE` before task-write so the
+    secret reaches Keychain and never the task file; this bridge only ever read
+    FROM the vault (`_token_from_vault_ag2space`, its own bootstrap token) and
+    never intercepted an inbound `vault set`, so a room-typed `vault set` here
+    silently stored nothing — same class of gap #2638 fixed for the other three.
+    """
+    global _VAULT_INTERCEPT_FNS
+    if _VAULT_INTERCEPT_FNS is not None:
+        return _VAULT_INTERCEPT_FNS
+    try:
+        cur = os.path.dirname(os.path.abspath(__file__))
+        src = ""
+        while True:
+            if os.path.isfile(os.path.join(cur, "src", "vault_intercept.py")):
+                src = os.path.join(cur, "src")
+                break
+            parent = os.path.dirname(cur)
+            if parent == cur:
+                break
+            cur = parent
+        if not src:
+            _VAULT_INTERCEPT_FNS = (None, None)
+            return _VAULT_INTERCEPT_FNS
+        if src not in sys.path:
+            sys.path.insert(0, src)
+        from vault_intercept import intercept_vault_commands, redact_vault_commands
+        _VAULT_INTERCEPT_FNS = (intercept_vault_commands, redact_vault_commands)
+    except Exception:
+        _VAULT_INTERCEPT_FNS = (None, None)
+    return _VAULT_INTERCEPT_FNS
+
+
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""
 _URL_FALLBACK = ""
 _TOKEN_FILE_FALLBACK = ""
@@ -1421,6 +1464,13 @@ def _write_task(task: dict) -> str | None:
     TASKS_DIR.mkdir(parents=True, exist_ok=True)
     lines = []
     _secret_types: tuple = ()
+    # Resolved ONCE, up front, and reused everywhere below (the task-field vault
+    # interception, the access_tier header line, and the guest/owner in-band
+    # branches) so the tier decision can never diverge between them. Moved
+    # ahead of the field loop (2026-08-11): vault interception on the "task"
+    # field needs the tier before that field is processed, but the loop
+    # reaches "task" before the tail of the function used to compute it.
+    sender_tier = _tier_for(task.get("user_id"), task.get("access_tier"))
     for f in _TASK_FIELDS:
         if f == "source":
             lines.append(f"source: {_one_line(task.get('source') or PROVIDER)}")
@@ -1444,11 +1494,38 @@ def _write_task(task: dict) -> str | None:
             # Resolve an inbound media marker to a local file the core can read.
             _media_refs: list = []
             _fetched = _maybe_fetch_media(_raw_task, _media_refs)
+            # Intercept `vault set KEY VALUE` BEFORE ordinary secret redaction,
+            # owner-tier only — write-side #2638 parity with discord/slack/
+            # telegram (see _vault_intercept_fns docstring). Non-owner senders
+            # never get Keychain writes; `filter_chat_secrets` below still
+            # catches an unnamed pasted token either way. Any interception
+            # failure (missing src/vault_intercept.py, or an exception inside
+            # it) falls back to `redact_vault_commands` if available, else the
+            # existing filter_chat_secrets call is simply unchanged — a value
+            # is never both left unredacted AND unstored.
+            _intercept_fn, _redact_fn = _vault_intercept_fns()
+            if sender_tier == "owner" and _intercept_fn is not None:
+                try:
+                    _vault_result = _intercept_fn(_fetched)
+                    _fetched = _vault_result.text
+                    if _vault_result.stored:
+                        _log(f"[vault] stored keys: {_vault_result.stored}")
+                    if _vault_result.failed:
+                        _log(f"[vault] store failed (still redacted): {_vault_result.failed}")
+                except Exception as _vault_exc:
+                    if _redact_fn is not None:
+                        _fetched = _redact_fn(_fetched)
+                    _log(f"[vault] intercept errored "
+                         f"({type(_vault_exc).__name__}: {_vault_exc}) — "
+                         f"redacted if possible, NOT stored")
+            elif sender_tier != "owner" and _redact_fn is not None:
+                _fetched = _redact_fn(_fetched)
             # Redact pasted secrets BEFORE the body is persisted (#2267 parity
             # with the discord/slack/telegram bridges): a token pasted into a
             # room message must never land on disk. Runs AFTER media
-            # resolution so a signed media-proxy URL is consumed intact and
-            # only the resolved text is filtered.
+            # resolution (and after any vault interception above consumed a
+            # `vault set` line) so a signed media-proxy URL is consumed intact
+            # and only the resolved text is filtered.
             _filtered = filter_chat_secrets(_fetched)
             if _filtered.secret_types:
                 _secret_types = tuple(_filtered.secret_types)
@@ -1478,9 +1555,9 @@ def _write_task(task: dict) -> str | None:
                 lines.append(f"platform_card: {json.dumps(card, separators=(',', ':'))}")
         elif f in task and task[f] not in (None, ""):
             lines.append(f"{f}: {_one_line(task[f])}")
-    # Resolve the broker tier and local cap once for both task authority and presence.
+    # sender_tier is resolved once, ahead of the field loop above (needed there
+    # for the "task" field's vault interception), and reused here unchanged.
     # All preceding fields are newline-stripped, so none can forge a tier header.
-    sender_tier = _tier_for(task.get("user_id"), task.get("access_tier"))
     lines.append(f"access_tier: {sender_tier}")
     # The fixed prose notice follows access_tier without introducing recognized headers.
     if _secret_types:

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -553,33 +553,17 @@ def _vault_intercept_fns():
     return _VAULT_INTERCEPT_FNS
 
 
-# Self-contained fallback for when _vault_intercept_fns() returns (None, None) —
-# a standalone `ag2-sparrow` package install never ships the monorepo
-# src/vault_intercept.py, so that's not a rare edge case for shipped installs.
-# Mirrors src/vault_intercept.py's own _VAULT_SET_RE/redact_vault_commands
-# closely enough to catch the same shapes, deliberately duplicated rather than
-# imported: this path exists PRECISELY for when that import is unavailable, so
-# it cannot depend on it. review finding (qingyun-wu, 2026-08-11): without
-# this, an owner-tier `vault set KEY "value"` with no interceptor available
-# fell through untouched to filter_chat_secrets(), which doesn't recognize
-# vault-set syntax, and the plaintext value was persisted verbatim.
-_LOCAL_VAULT_SET_RE = re.compile(
-    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))'
-    r'(?=\s|$|[.,!?;])',
-    re.IGNORECASE,
-)
-
-
 def _local_redact_vault_set(text: str) -> str:
-    """Scrub vault-set patterns WITHOUT storing anything — last-resort, no
-    external dependency. Used only when _vault_intercept_fns() found neither
-    the real interceptor nor the real redactor."""
-    if not text:
-        return text
-    return _LOCAL_VAULT_SET_RE.sub(
-        lambda m: f"vault set {m.group(1)} [VAULT-SET-REDACTED: interceptor unavailable]",
-        text,
-    )
+    """Last-resort redaction when _vault_intercept_fns() found neither the
+    real interceptor nor the real redactor (standalone package install with
+    no monorepo src/vault_intercept.py). Delegates to vault_set_grammar,
+    which THIS PACKAGE vendors verbatim from src/ (tools/sync_from_src.py,
+    drift-checked) — a plain in-package import, no runtime search needed,
+    and no hand-copied regex to diverge from the canonical shape (review
+    finding, qingyun-wu 2026-08-11: a duplicated grammar silently drifts the
+    moment the canonical one changes)."""
+    from .vault_set_grammar import redact_vault_commands as _grammar_redact
+    return _grammar_redact(text, placeholder="[VAULT-SET-REDACTED: interceptor unavailable]")
 
 
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -554,14 +554,8 @@ def _vault_intercept_fns():
 
 
 def _local_redact_vault_set(text: str) -> str:
-    """Last-resort redaction when _vault_intercept_fns() found neither the
-    real interceptor nor the real redactor (standalone package install with
-    no monorepo src/vault_intercept.py). Delegates to vault_set_grammar,
-    which THIS PACKAGE vendors verbatim from src/ (tools/sync_from_src.py,
-    drift-checked) — a plain in-package import, no runtime search needed,
-    and no hand-copied regex to diverge from the canonical shape (review
-    finding, qingyun-wu 2026-08-11: a duplicated grammar silently drifts the
-    moment the canonical one changes)."""
+    """Last-resort redaction when no monorepo `vault_intercept.py` is found.
+    Delegates to this package's own vendored `vault_set_grammar`, not a hand-copied regex."""
     from .vault_set_grammar import redact_vault_commands as _grammar_redact
     return _grammar_redact(text, placeholder="[VAULT-SET-REDACTED: interceptor unavailable]")
 
@@ -1477,12 +1471,8 @@ def _write_task(task: dict) -> str | None:
     TASKS_DIR.mkdir(parents=True, exist_ok=True)
     lines = []
     _secret_types: tuple = ()
-    # Resolved ONCE, up front, and reused everywhere below (the task-field vault
-    # interception, the access_tier header line, and the guest/owner in-band
-    # branches) so the tier decision can never diverge between them. Moved
-    # ahead of the field loop (2026-08-11): vault interception on the "task"
-    # field needs the tier before that field is processed, but the loop
-    # reaches "task" before the tail of the function used to compute it.
+    # Resolved once, reused everywhere below so the tier decision can never diverge;
+    # must run before the "task" field is reached in the loop below.
     sender_tier = _tier_for(task.get("user_id"), task.get("access_tier"))
     for f in _TASK_FIELDS:
         if f == "source":
@@ -1507,19 +1497,8 @@ def _write_task(task: dict) -> str | None:
             # Resolve an inbound media marker to a local file the core can read.
             _media_refs: list = []
             _fetched = _maybe_fetch_media(_raw_task, _media_refs)
-            # Intercept `vault set KEY VALUE` BEFORE ordinary secret redaction,
-            # owner-tier only — write-side #2638 parity with discord/slack/
-            # telegram (see _vault_intercept_fns docstring). Non-owner senders
-            # never get Keychain writes; `filter_chat_secrets` below still
-            # catches an unnamed pasted token either way. A value is never both
-            # left unredacted AND unstored: every path below that doesn't
-            # successfully intercept-and-store falls through to SOME redactor —
-            # the real one if `_vault_intercept_fns()` found it, else the
-            # dependency-free `_local_redact_vault_set` (review finding,
-            # qingyun-wu 2026-08-11: the old `elif sender_tier != "owner"` guard
-            # meant an owner-tier sender with no interceptor available — the
-            # standalone `ag2-sparrow` package case — skipped redaction
-            # entirely and the plaintext value reached disk).
+            # Intercept `vault set KEY VALUE` before ordinary redaction, owner-tier only.
+            # Every path below intercepts-and-stores or falls through to a redactor — never neither.
             _intercept_fn, _redact_fn = _vault_intercept_fns()
             _redact_fallback = _redact_fn or _local_redact_vault_set
             if sender_tier == "owner" and _intercept_fn is not None:
@@ -1549,15 +1528,8 @@ def _write_task(task: dict) -> str | None:
                 _log(f"redacted pasted secret(s) in {tid} body: "
                      f"{', '.join(sorted(_secret_types))}")
             lines.append(f"task: {_one_line(_filtered.text)}")
-            # Make the fully-sanitized body authoritative for every OTHER
-            # persistence sink too, not just the task file. _write_owner_activity()
-            # below re-reads task["task"] independently and only applies the
-            # generic filter_chat_secrets (not vault-aware), so without this the
-            # vault-intercepted/redacted text above stayed local to _fetched and
-            # the raw value still leaked into last-owner-activity.json (review
-            # finding, qingyun-wu 2026-08-11). `task` is this function's own
-            # shallow copy (`task = {**task, ...}` above), so mutating it here
-            # doesn't touch the caller's dict.
+            # Make the sanitized body authoritative everywhere, not just this task file —
+            # _write_owner_activity() re-reads task["task"] independently and isn't vault-aware.
             task["task"] = _filtered.text
             # interaction-model 4D, step 1.5: if a media marker was fetched,
             # stamp structured attachments[]/content_modalities/media_form

--- a/packages/ag2-sparrow/ag2_sparrow/vault_set_grammar.py
+++ b/packages/ag2-sparrow/ag2_sparrow/vault_set_grammar.py
@@ -1,0 +1,42 @@
+"""Pure, dependency-free `vault set KEY VALUE` grammar — regex + redact-only.
+
+Extracted from `vault_intercept.py` (2026-08-11) so the pattern has one canonical
+source. `vault_intercept.py`'s own `intercept_vault_commands`/`redact_vault_commands`
+import from here rather than duplicating the regex, and this module is also the one
+`packages/ag2-sparrow` vendors verbatim (see `tools/sync_from_src.py`) — the standalone
+package needs the redaction shape but never the Keychain-writing storage path, which
+stays monorepo-only in `vault_intercept.py` (system Keychain access, not a pure utility).
+
+No imports beyond `re`. Any change to the accepted `vault set` syntax belongs here,
+not in a copy — a hand-copied grammar silently diverges the moment this file changes.
+"""
+from __future__ import annotations
+
+import re
+
+# Key/value separator is whitespace OR `=` (with optional surrounding spaces), so
+# `vault set KEY VALUE`, `vault set KEY=VALUE`, and `vault set KEY = VALUE` all
+# intercept. The KEY group stops at the first space or `=` (`[^\s=]+`) so the `=`
+# form isn't swallowed whole. Group numbering: key=group(1), value alternatives=
+# groups 2-5 (separator is non-capturing). See vault_intercept.py's own history
+# for the FP/FN incidents this exact shape was tuned against.
+VAULT_SET_RE = re.compile(
+    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))'
+    r'(?=\s|$|[.,!?;])',
+    re.IGNORECASE,
+)
+
+
+def redact_vault_commands(text: str, *, placeholder: str = "[vault: non-owner tier — ignored]") -> str:
+    """Scrub vault-set patterns from `text` WITHOUT touching any store.
+
+    Pure string transform, no I/O, no external dependency — safe for any caller
+    that only needs "don't let this reach disk," not "actually store it."
+    `placeholder` lets callers customize the reason without re-deriving the regex.
+    """
+    if not text:
+        return text
+    return VAULT_SET_RE.sub(
+        lambda m: f"vault set {m.group(1)} {placeholder}",
+        text,
+    )

--- a/packages/ag2-sparrow/ag2_sparrow/vault_set_grammar.py
+++ b/packages/ag2-sparrow/ag2_sparrow/vault_set_grammar.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 import re
 
-# Separator is whitespace or `=`; KEY stops at the first space/`=` so `=` isn't swallowed.
-# Group numbering: key=group(1), value alternatives=groups 2-5 (separator non-capturing).
+# Separator is whitespace or `=`; KEY stops at the first space/`=` so `=` isn't swallowed. Unquoted
+# value is lazy with an optional trailing-punctuation lookahead so `.,!?;` isn't captured into the secret.
 VAULT_SET_RE = re.compile(
-    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))'
-    r'(?=\s|$|[.,!?;])',
+    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+?))'
+    r'(?=[.,!?;]?(?:\s|$))',
     re.IGNORECASE,
 )
 

--- a/packages/ag2-sparrow/ag2_sparrow/vault_set_grammar.py
+++ b/packages/ag2-sparrow/ag2_sparrow/vault_set_grammar.py
@@ -1,25 +1,13 @@
 """Pure, dependency-free `vault set KEY VALUE` grammar — regex + redact-only.
 
-Extracted from `vault_intercept.py` (2026-08-11) so the pattern has one canonical
-source. `vault_intercept.py`'s own `intercept_vault_commands`/`redact_vault_commands`
-import from here rather than duplicating the regex, and this module is also the one
-`packages/ag2-sparrow` vendors verbatim (see `tools/sync_from_src.py`) — the standalone
-package needs the redaction shape but never the Keychain-writing storage path, which
-stays monorepo-only in `vault_intercept.py` (system Keychain access, not a pure utility).
-
-No imports beyond `re`. Any change to the accepted `vault set` syntax belongs here,
-not in a copy — a hand-copied grammar silently diverges the moment this file changes.
+Canonical source for `vault_intercept.py` and the vendored ag2-sparrow copy; no imports beyond `re`.
 """
 from __future__ import annotations
 
 import re
 
-# Key/value separator is whitespace OR `=` (with optional surrounding spaces), so
-# `vault set KEY VALUE`, `vault set KEY=VALUE`, and `vault set KEY = VALUE` all
-# intercept. The KEY group stops at the first space or `=` (`[^\s=]+`) so the `=`
-# form isn't swallowed whole. Group numbering: key=group(1), value alternatives=
-# groups 2-5 (separator is non-capturing). See vault_intercept.py's own history
-# for the FP/FN incidents this exact shape was tuned against.
+# Separator is whitespace or `=`; KEY stops at the first space/`=` so `=` isn't swallowed.
+# Group numbering: key=group(1), value alternatives=groups 2-5 (separator non-capturing).
 VAULT_SET_RE = re.compile(
     r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))'
     r'(?=\s|$|[.,!?;])',
@@ -28,12 +16,7 @@ VAULT_SET_RE = re.compile(
 
 
 def redact_vault_commands(text: str, *, placeholder: str = "[vault: non-owner tier — ignored]") -> str:
-    """Scrub vault-set patterns from `text` WITHOUT touching any store.
-
-    Pure string transform, no I/O, no external dependency — safe for any caller
-    that only needs "don't let this reach disk," not "actually store it."
-    `placeholder` lets callers customize the reason without re-deriving the regex.
-    """
+    """Scrub vault-set patterns from `text` without touching any store."""
     if not text:
         return text
     return VAULT_SET_RE.sub(

--- a/packages/ag2-sparrow/tools/sync_from_src.py
+++ b/packages/ag2-sparrow/tools/sync_from_src.py
@@ -26,6 +26,7 @@ MAP = {
     "dedup_recovery.py": "dedup_recovery.py",
     "workspace_lock.py": "workspace_lock.py",
     "chat_secret_filter.py": "chat_secret_filter.py",
+    "vault_set_grammar.py": "vault_set_grammar.py",
 }
 PKG_DIR = Path(__file__).resolve().parent.parent / "ag2_sparrow"
 SRC_DIR = Path(__file__).resolve().parents[3] / "src"

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -1233,12 +1233,8 @@ def main() -> int:
     _hdrs = [ln for ln in _sec_body.split("\n") if ln.startswith("access_tier: ")]
     check(len(_hdrs) == 1, "notice introduces no second access_tier line")
 
-    # Write-side vault interception (#2638 parity): an owner-tier `vault set
-    # KEY VALUE` in the task body must reach `_vault_intercept_fns()` and have
-    # its sanitized `.text` persisted — not the raw redact-only fallback.
-    # Faked, not the real vault_intercept module: this suite covers the NEW
-    # wiring inside _write_task, not vault_intercept.py's own regex/keychain
-    # logic (covered by tests/vault-intercept.test.py).
+    # Faked interceptor: covers `_write_task`'s wiring, not vault_intercept.py's own
+    # regex/keychain logic (tests/vault-intercept.test.py).
     class _FakeInterceptResult:
         def __init__(self, text, stored=(), failed=()):
             self.text = text
@@ -1295,8 +1291,8 @@ def main() -> int:
     rtc._VAULT_INTERCEPT_FNS = (None, None)
     rtc.LOCAL_TIER = _tier_before_vault_block
 
-    # Two P1 findings from review (qingyun-wu, 2026-08-11), both about a
-    # sanitized body not being authoritative for EVERY persistence sink.
+    # Both cases below check the sanitized body is authoritative for every
+    # persistence sink, not just the task file.
 
     # (1) The interceptor is the ONLY store call site — _write_task() must not
     # invoke it a second time when it also updates task["task"] for

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -1294,6 +1294,51 @@ def main() -> int:
           "intercept exception falls back to redaction — never left unredacted AND unstored")
     rtc._VAULT_INTERCEPT_FNS = (None, None)
     rtc.LOCAL_TIER = _tier_before_vault_block
+
+    # Two P1 findings from review (qingyun-wu, 2026-08-11), both about a
+    # sanitized body not being authoritative for EVERY persistence sink.
+
+    # (1) The interceptor is the ONLY store call site — _write_task() must not
+    # invoke it a second time when it also updates task["task"] for
+    # _write_owner_activity()'s benefit, or an owner's `vault set` would be
+    # stored twice (double Keychain write / double-counted "stored" log).
+    rtc.LOCAL_TIER = "owner"
+    _oa = rtc.OWNER_ACTIVITY_FILE
+    _oa.unlink(missing_ok=True)
+    _vault_calls["intercept"] = _vault_calls["redact"] = 0
+    rtc._VAULT_INTERCEPT_FNS = (_fake_intercept, _fake_redact)
+    rtc._write_task({**TASK, "id": "task-VAULTOWNERACTIVITY", "access_tier": "owner",
+                     "task": "[AG2Space @qingyun] vault set MY_KEY hunter2"})
+    _voa_body = (rtc.TASKS_DIR / "task-VAULTOWNERACTIVITY.txt").read_text()
+    check("hunter2" not in _voa_body and "[STORED]" in _voa_body,
+          "owner-activity regression: task file still sanitized")
+    _oa_data = json.loads(_oa.read_text()) if _oa.exists() else {}
+    check("hunter2" not in json.dumps(_oa_data),
+          "owner-activity file does NOT carry the raw vault secret "
+          "(sanitized task[\"task\"] is authoritative for every sink)")
+    check(_vault_calls["intercept"] == 1,
+          "interceptor invoked exactly once — updating task[\"task\"] for "
+          "_write_owner_activity does not re-run the store")
+    rtc._VAULT_INTERCEPT_FNS = (None, None)
+    rtc.LOCAL_TIER = _tier_before_vault_block
+
+    # (2) No-interceptor-available fallback: an owner-tier sender with
+    # _vault_intercept_fns() == (None, None) — the standalone/package-only
+    # ag2-sparrow install, no monorepo src/vault_intercept.py to find — must
+    # still get SOME redaction (the dependency-free local fallback), not pass
+    # through untouched to the generic filter_chat_secrets.
+    rtc.LOCAL_TIER = "owner"
+    rtc._VAULT_INTERCEPT_FNS = (None, None)
+    rtc._write_task({**TASK, "id": "task-VAULTNOHELPER", "access_tier": "owner",
+                     "task": '[AG2Space @qingyun] vault set API_KEY "secret value here"'})
+    _vnh_body = (rtc.TASKS_DIR / "task-VAULTNOHELPER.txt").read_text()
+    check("secret value here" not in _vnh_body,
+          "owner-tier vault set redacted by the local fallback when NO "
+          "interceptor/redactor is available at all (standalone package case)")
+    check("VAULT-SET-REDACTED" in _vnh_body,
+          "local fallback leaves an explicit placeholder, not silent deletion")
+    rtc.LOCAL_TIER = _tier_before_vault_block
+
     # Onboarding-token parse: the combined "url|secret" form, and the %7C-encoded
     # separator the desktop connect flow emits (ag2space-cinny-desktop#231). A
     # %7C token must decode so URL is populated — otherwise it parses as a bare

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -1294,10 +1294,8 @@ def main() -> int:
     # Both cases below check the sanitized body is authoritative for every
     # persistence sink, not just the task file.
 
-    # (1) The interceptor is the ONLY store call site — _write_task() must not
-    # invoke it a second time when it also updates task["task"] for
-    # _write_owner_activity()'s benefit, or an owner's `vault set` would be
-    # stored twice (double Keychain write / double-counted "stored" log).
+    # (1) Updating task["task"] for _write_owner_activity() must not re-invoke
+    # the interceptor — that would double-store the vault key.
     rtc.LOCAL_TIER = "owner"
     _oa = rtc.OWNER_ACTIVITY_FILE
     _oa.unlink(missing_ok=True)
@@ -1318,11 +1316,8 @@ def main() -> int:
     rtc._VAULT_INTERCEPT_FNS = (None, None)
     rtc.LOCAL_TIER = _tier_before_vault_block
 
-    # (2) No-interceptor-available fallback: an owner-tier sender with
-    # _vault_intercept_fns() == (None, None) — the standalone/package-only
-    # ag2-sparrow install, no monorepo src/vault_intercept.py to find — must
-    # still get SOME redaction (the dependency-free local fallback), not pass
-    # through untouched to the generic filter_chat_secrets.
+    # (2) No interceptor available (standalone package, no monorepo src/) must still
+    # redact via the local fallback, not pass through untouched.
     rtc.LOCAL_TIER = "owner"
     rtc._VAULT_INTERCEPT_FNS = (None, None)
     rtc._write_task({**TASK, "id": "task-VAULTNOHELPER", "access_tier": "owner",

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -1232,6 +1232,68 @@ def main() -> int:
           "no security notice on clean tasks")
     _hdrs = [ln for ln in _sec_body.split("\n") if ln.startswith("access_tier: ")]
     check(len(_hdrs) == 1, "notice introduces no second access_tier line")
+
+    # Write-side vault interception (#2638 parity): an owner-tier `vault set
+    # KEY VALUE` in the task body must reach `_vault_intercept_fns()` and have
+    # its sanitized `.text` persisted — not the raw redact-only fallback.
+    # Faked, not the real vault_intercept module: this suite covers the NEW
+    # wiring inside _write_task, not vault_intercept.py's own regex/keychain
+    # logic (covered by tests/vault-intercept.test.py).
+    class _FakeInterceptResult:
+        def __init__(self, text, stored=(), failed=()):
+            self.text = text
+            self.stored = list(stored)
+            self.failed = list(failed)
+
+    _vault_calls = {"intercept": 0, "redact": 0}
+
+    def _fake_intercept(text):
+        _vault_calls["intercept"] += 1
+        return _FakeInterceptResult(
+            text=text.replace("vault set MY_KEY hunter2", "vault set MY_KEY [STORED]"),
+            stored=["MY_KEY"])
+
+    def _fake_redact(text):
+        _vault_calls["redact"] += 1
+        return text.replace("hunter2", "[VAULT-SET-REDACTED]")
+
+    # TASK's own access_tier field is the broker-attested wire value now (2-arg
+    # _tier_for); LOCAL_TIER is the local cap. Pin both explicitly per case so
+    # the resolved sender_tier is deterministic regardless of suite order.
+    _tier_before_vault_block = rtc.LOCAL_TIER
+    rtc.LOCAL_TIER = "owner"
+    rtc._VAULT_INTERCEPT_FNS = (_fake_intercept, _fake_redact)
+    rtc._write_task({**TASK, "id": "task-VAULTOWNER", "access_tier": "owner",
+                     "task": "[AG2Space @qingyun] vault set MY_KEY hunter2"})
+    _vo_body = (rtc.TASKS_DIR / "task-VAULTOWNER.txt").read_text()
+    check("hunter2" not in _vo_body and "[STORED]" in _vo_body,
+          "owner-tier vault set intercepted and sanitized before persist")
+    check(_vault_calls["intercept"] == 1 and _vault_calls["redact"] == 0,
+          "owner-tier vault set calls intercept, not the plain redactor")
+
+    rtc.LOCAL_TIER = "team"
+    _vault_calls["intercept"] = _vault_calls["redact"] = 0
+    rtc._write_task({**TASK, "id": "task-VAULTTEAM", "access_tier": "owner",
+                     "task": "[AG2Space @qingyun] vault set MY_KEY hunter2"})
+    _vt_body = (rtc.TASKS_DIR / "task-VAULTTEAM.txt").read_text()
+    check("hunter2" not in _vt_body and "[VAULT-SET-REDACTED]" in _vt_body,
+          "non-owner vault set redacted, not stored")
+    check(_vault_calls["intercept"] == 0 and _vault_calls["redact"] == 1,
+          "non-owner vault set never reaches the intercept path")
+
+    def _raising_intercept(text):
+        raise RuntimeError("boom")
+
+    rtc.LOCAL_TIER = "owner"
+    rtc._VAULT_INTERCEPT_FNS = (_raising_intercept, _fake_redact)
+    _vault_calls["redact"] = 0
+    rtc._write_task({**TASK, "id": "task-VAULTRAISE", "access_tier": "owner",
+                     "task": "[AG2Space @qingyun] vault set MY_KEY hunter2"})
+    _vr_body = (rtc.TASKS_DIR / "task-VAULTRAISE.txt").read_text()
+    check("hunter2" not in _vr_body and _vault_calls["redact"] == 1,
+          "intercept exception falls back to redaction — never left unredacted AND unstored")
+    rtc._VAULT_INTERCEPT_FNS = (None, None)
+    rtc.LOCAL_TIER = _tier_before_vault_block
     # Onboarding-token parse: the combined "url|secret" form, and the %7C-encoded
     # separator the desktop connect flow emits (ag2space-cinny-desktop#231). A
     # %7C token must decode so URL is populated — otherwise it parses as a bare

--- a/src/vault_intercept.py
+++ b/src/vault_intercept.py
@@ -42,6 +42,9 @@ import sys
 from datetime import datetime, timezone
 from typing import NamedTuple
 
+from vault_set_grammar import VAULT_SET_RE as _VAULT_SET_RE
+from vault_set_grammar import redact_vault_commands as _grammar_redact_vault_commands
+
 _ACCOUNT = "sutando"
 
 # The manifest is the NON-SECRET index of key NAMES (values live in macOS
@@ -105,17 +108,12 @@ def _read_manifest() -> dict:
 #   - FP: "the vault set command works fine" → key="command" (not env-shaped),
 #     value="works" (not a secret) → skip, left as prose
 #   - FN: "hey vault set APOLLO_KEY sk-..." mid-prose → "sk-..." is OpenAI → store
-# Key/value separator is whitespace OR `=` (with optional surrounding spaces),
-# so `vault set KEY VALUE`, `vault set KEY=VALUE`, and `vault set KEY = VALUE`
-# all intercept. The KEY group stops at the first space or `=` (`[^\s=]+`) so
-# the `=` form isn't swallowed whole — that swallowing is what let an owner's
-# `vault set X_BEARER_TOKEN=…` slip past uncaught and land in plaintext on disk
-# (2026-06-22 incident). Group numbering preserved: key=group(1), value
-# alternatives=groups 2-5 (separator is non-capturing).
-_VAULT_SET_RE = re.compile(
-    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))(?=\s|$|[.,!?;])',
-    re.IGNORECASE,
-)
+# Grammar (regex + shape) is canonical in vault_set_grammar.py (2026-08-11
+# extraction) — imported above as _VAULT_SET_RE, not redefined here. That
+# module is also what packages/ag2-sparrow vendors verbatim, so the standalone
+# package and this monorepo interceptor can never diverge on what counts as
+# a `vault set` command. This file adds the STORAGE half (Keychain,
+# detect-secrets validation) on top of that shared shape.
 
 # #2074: an unquoted value the FP guard doesn't recognize isn't proof of
 # prose — it can be a real secret the classifier missed (a 32-char Discord
@@ -359,11 +357,8 @@ def redact_vault_commands(text: str) -> str:
     """Scrub vault-set patterns from text WITHOUT touching the Keychain.
 
     Use for non-owner-tier messages: prevents secrets from landing in task files
-    while ensuring the Keychain is never written by an untrusted sender.
+    while ensuring the Keychain is never written by an untrusted sender. Delegates
+    to the canonical vault_set_grammar implementation (single source, see the
+    module-level note above _VAULT_SET_RE) rather than reimplementing it here.
     """
-    if not text:
-        return text
-    return _VAULT_SET_RE.sub(
-        lambda m: f"vault set {m.group(1)} [vault: non-owner tier — ignored]",
-        text,
-    )
+    return _grammar_redact_vault_commands(text, placeholder="[vault: non-owner tier — ignored]")

--- a/src/vault_intercept.py
+++ b/src/vault_intercept.py
@@ -108,12 +108,8 @@ def _read_manifest() -> dict:
 #   - FP: "the vault set command works fine" → key="command" (not env-shaped),
 #     value="works" (not a secret) → skip, left as prose
 #   - FN: "hey vault set APOLLO_KEY sk-..." mid-prose → "sk-..." is OpenAI → store
-# Grammar (regex + shape) is canonical in vault_set_grammar.py (2026-08-11
-# extraction) — imported above as _VAULT_SET_RE, not redefined here. That
-# module is also what packages/ag2-sparrow vendors verbatim, so the standalone
-# package and this monorepo interceptor can never diverge on what counts as
-# a `vault set` command. This file adds the STORAGE half (Keychain,
-# detect-secrets validation) on top of that shared shape.
+# Grammar is canonical in vault_set_grammar.py, imported above as _VAULT_SET_RE — not
+# redefined here. This file adds the storage half (Keychain, detect-secrets) on top.
 
 # #2074: an unquoted value the FP guard doesn't recognize isn't proof of
 # prose — it can be a real secret the classifier missed (a 32-char Discord

--- a/src/vault_set_grammar.py
+++ b/src/vault_set_grammar.py
@@ -1,0 +1,42 @@
+"""Pure, dependency-free `vault set KEY VALUE` grammar — regex + redact-only.
+
+Extracted from `vault_intercept.py` (2026-08-11) so the pattern has one canonical
+source. `vault_intercept.py`'s own `intercept_vault_commands`/`redact_vault_commands`
+import from here rather than duplicating the regex, and this module is also the one
+`packages/ag2-sparrow` vendors verbatim (see `tools/sync_from_src.py`) — the standalone
+package needs the redaction shape but never the Keychain-writing storage path, which
+stays monorepo-only in `vault_intercept.py` (system Keychain access, not a pure utility).
+
+No imports beyond `re`. Any change to the accepted `vault set` syntax belongs here,
+not in a copy — a hand-copied grammar silently diverges the moment this file changes.
+"""
+from __future__ import annotations
+
+import re
+
+# Key/value separator is whitespace OR `=` (with optional surrounding spaces), so
+# `vault set KEY VALUE`, `vault set KEY=VALUE`, and `vault set KEY = VALUE` all
+# intercept. The KEY group stops at the first space or `=` (`[^\s=]+`) so the `=`
+# form isn't swallowed whole. Group numbering: key=group(1), value alternatives=
+# groups 2-5 (separator is non-capturing). See vault_intercept.py's own history
+# for the FP/FN incidents this exact shape was tuned against.
+VAULT_SET_RE = re.compile(
+    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))'
+    r'(?=\s|$|[.,!?;])',
+    re.IGNORECASE,
+)
+
+
+def redact_vault_commands(text: str, *, placeholder: str = "[vault: non-owner tier — ignored]") -> str:
+    """Scrub vault-set patterns from `text` WITHOUT touching any store.
+
+    Pure string transform, no I/O, no external dependency — safe for any caller
+    that only needs "don't let this reach disk," not "actually store it."
+    `placeholder` lets callers customize the reason without re-deriving the regex.
+    """
+    if not text:
+        return text
+    return VAULT_SET_RE.sub(
+        lambda m: f"vault set {m.group(1)} {placeholder}",
+        text,
+    )

--- a/src/vault_set_grammar.py
+++ b/src/vault_set_grammar.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 import re
 
-# Separator is whitespace or `=`; KEY stops at the first space/`=` so `=` isn't swallowed.
-# Group numbering: key=group(1), value alternatives=groups 2-5 (separator non-capturing).
+# Separator is whitespace or `=`; KEY stops at the first space/`=` so `=` isn't swallowed. Unquoted
+# value is lazy with an optional trailing-punctuation lookahead so `.,!?;` isn't captured into the secret.
 VAULT_SET_RE = re.compile(
-    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))'
-    r'(?=\s|$|[.,!?;])',
+    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+?))'
+    r'(?=[.,!?;]?(?:\s|$))',
     re.IGNORECASE,
 )
 

--- a/src/vault_set_grammar.py
+++ b/src/vault_set_grammar.py
@@ -1,25 +1,13 @@
 """Pure, dependency-free `vault set KEY VALUE` grammar — regex + redact-only.
 
-Extracted from `vault_intercept.py` (2026-08-11) so the pattern has one canonical
-source. `vault_intercept.py`'s own `intercept_vault_commands`/`redact_vault_commands`
-import from here rather than duplicating the regex, and this module is also the one
-`packages/ag2-sparrow` vendors verbatim (see `tools/sync_from_src.py`) — the standalone
-package needs the redaction shape but never the Keychain-writing storage path, which
-stays monorepo-only in `vault_intercept.py` (system Keychain access, not a pure utility).
-
-No imports beyond `re`. Any change to the accepted `vault set` syntax belongs here,
-not in a copy — a hand-copied grammar silently diverges the moment this file changes.
+Canonical source for `vault_intercept.py` and the vendored ag2-sparrow copy; no imports beyond `re`.
 """
 from __future__ import annotations
 
 import re
 
-# Key/value separator is whitespace OR `=` (with optional surrounding spaces), so
-# `vault set KEY VALUE`, `vault set KEY=VALUE`, and `vault set KEY = VALUE` all
-# intercept. The KEY group stops at the first space or `=` (`[^\s=]+`) so the `=`
-# form isn't swallowed whole. Group numbering: key=group(1), value alternatives=
-# groups 2-5 (separator is non-capturing). See vault_intercept.py's own history
-# for the FP/FN incidents this exact shape was tuned against.
+# Separator is whitespace or `=`; KEY stops at the first space/`=` so `=` isn't swallowed.
+# Group numbering: key=group(1), value alternatives=groups 2-5 (separator non-capturing).
 VAULT_SET_RE = re.compile(
     r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))'
     r'(?=\s|$|[.,!?;])',
@@ -28,12 +16,7 @@ VAULT_SET_RE = re.compile(
 
 
 def redact_vault_commands(text: str, *, placeholder: str = "[vault: non-owner tier — ignored]") -> str:
-    """Scrub vault-set patterns from `text` WITHOUT touching any store.
-
-    Pure string transform, no I/O, no external dependency — safe for any caller
-    that only needs "don't let this reach disk," not "actually store it."
-    `placeholder` lets callers customize the reason without re-deriving the regex.
-    """
+    """Scrub vault-set patterns from `text` without touching any store."""
     if not text:
         return text
     return VAULT_SET_RE.sub(

--- a/tests/vault-intercept.test.py
+++ b/tests/vault-intercept.test.py
@@ -432,8 +432,7 @@ class TestKeychainInteraction(unittest.TestCase):
         self.assertEqual(args[w_idx + 1], "pa$$word")
 
     def test_bare_value_trailing_sentence_punctuation_not_stored(self):
-        # Reviewer-found (qingyun-wu review of #2786): a sentence-ending `.`/`,`/`!`/`?`/`;`
-        # after a bare (unquoted) value was captured into the stored secret, corrupting it.
+        # Bare sentence punctuation after an unquoted value must not become part of the stored secret.
         value = "sk-" + "a"*20 + "T3BlbkFJ" + "b"*20
         with patch("vault_intercept.subprocess.run", return_value=MagicMock(returncode=0)) as mock_run:
             intercept_vault_commands(f"vault set MY_KEY {value}.")

--- a/tests/vault-intercept.test.py
+++ b/tests/vault-intercept.test.py
@@ -431,6 +431,16 @@ class TestKeychainInteraction(unittest.TestCase):
         self.assertEqual(args[s_idx + 1], "MY_SECRET")
         self.assertEqual(args[w_idx + 1], "pa$$word")
 
+    def test_bare_value_trailing_sentence_punctuation_not_stored(self):
+        # Reviewer-found (qingyun-wu review of #2786): a sentence-ending `.`/`,`/`!`/`?`/`;`
+        # after a bare (unquoted) value was captured into the stored secret, corrupting it.
+        value = "sk-" + "a"*20 + "T3BlbkFJ" + "b"*20
+        with patch("vault_intercept.subprocess.run", return_value=MagicMock(returncode=0)) as mock_run:
+            intercept_vault_commands(f"vault set MY_KEY {value}.")
+        args = mock_run.call_args[0][0]
+        w_idx = args.index("-w")
+        self.assertEqual(args[w_idx + 1], value)
+
 
 class TestRedactVaultCommands(unittest.TestCase):
     """redact_vault_commands — scrubs vault patterns without touching Keychain."""


### PR DESCRIPTION
## Problem

The Discord/Slack/Telegram bridges each intercept an owner's `vault set KEY VALUE` before writing the task file, so the secret reaches Keychain and never touches disk (#2638). The ag2space bridge only ever read FROM the vault (its own bootstrap token) and never intercepted an inbound `vault set` — a room-typed `vault set` here silently redacted the value and stored nothing, so the owner's secret was lost, not saved. Found and confirmed live on `Chis-MacBook-Air-Blue` this session: the owner's `vault set DISCORD_BOT_TOKEN ...` was redacted but never landed in Keychain.

## Fix

Wires the same `intercept_vault_commands()`/`redact_vault_commands()` pair the other three bridges already use into `_write_task()`'s `"task"` field handling, owner-tier only, with a fail-closed fallback to plain redaction on any error (missing `src/vault_intercept.py`, or an exception inside it — a value is never both left unredacted AND unstored). Hoists `sender_tier` resolution ahead of the field loop (previously computed once, late, only for the `access_tier` header and owner-activity gate) since the new interception needs it earlier — and removes the now-duplicate late computation so the two call sites can never diverge.

## Evidence

**Before** (this fix's own new checks, run against unpatched `main`):
```
FAIL owner-tier vault set intercepted and sanitized before persist
FAIL owner-tier vault set calls intercept, not the plain redactor
FAIL non-owner vault set redacted, not stored
FAIL non-owner vault set never reaches the intercept path
FAIL intercept exception falls back to redaction — never left unredacted AND unstored
FAILED (5)
```

**After:**
```
ok  owner-tier vault set intercepted and sanitized before persist
ok  owner-tier vault set calls intercept, not the plain redactor
ok  non-owner vault set redacted, not stored
ok  non-owner vault set never reaches the intercept path
ok  intercept exception falls back to redaction — never left unredacted AND unstored
PASS — all checks green
```

Also ran the full `src/remote-gateway-bridge.test.py` suite (green) plus 25 other tests referencing `remote_gateway_bridge.py` (`gateway-per-sender-tier`, `gateway-dedup-recovery`, `sparrow-integration-e2e`, `health-check-gateway-bridge`, etc.) — all green, no regression against the dedup-recovery/tiering work already merged since I last checked out this file.

## Collision check

Checked #2324 (qingyun-wu, ag2space-gateway, already 2-approved) before opening this, since it touches the same file: it only adds a `PROACTIVE_ROOM` drain loop near line 520 and a ~314-line block starting at line 1772; `_write_task()` where this fix lives is untouched by #2324. No overlap either merge order.

## Known unrelated red check

Per `#bot2bot` coordination with Sutando-Pro: the src-map coverage gate may show red here — `docs/src-map.md` is stale on `main` (fixed by the pending #2782, +1/-1, zero red checks). Not caused by this diff.

Stand: Echo Act IV Blue
