### PR TITLE
fix(dashboard): anchor the Schedules card so it can be linked

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -666,7 +666,7 @@ def render_dashboard() -> str:
         '</tr>'
     )
     cards.append(
-        '<div class="card full"><h2>Schedules</h2>'
+        '<div class="card full" id="schedules"><h2>Schedules</h2>'
         '<table style="width:100%;font-size:11px;border-collapse:collapse">'
         '<tr style="color:#555;text-align:left"><th>Name</th><th>Cron</th>'
         '<th>Type</th><th>Next run</th><th></th></tr>'


### PR DESCRIPTION
## What / why

The desktop tray gained a **Scheduled Loop** item (ag2space-cinny-desktop#303) that opens the local console at `#schedules`. The Schedules card had no `id`, so the fragment had nothing to scroll to and the link simply landed at the top of the page.

One line: `id="schedules"` on that card.

## Evidence

Before (on `main`) — the anchor genuinely does not exist, so this is not a no-op edit:

```
$ git stash && grep -c 'id="schedules"' src/dashboard.py
0
```

After, at `255f07d`:

```
$ grep -n 'id="schedules"' src/dashboard.py
669:        '<div class="card full" id="schedules"><h2>Schedules</h2>'

$ python3 -m py_compile src/dashboard.py
py_compile OK

$ python3 -B tests/dashboard-editable-schedules.test.py     PASS
$ python3 -B tests/dashboard-battery-fallback.test.py       PASS
$ python3 -B tests/dashboard-schedule-delegation.test.py    PASS
```

## Scope

Presentation-only, single concern. The fragment is inert for anything that doesn't use it, so this is safe to merge independently of the desktop PR — and the desktop side is already inert-safe without it (it opens the console at the top until this lands).

No test added: this is a markup attribute with no branch to exercise, and the three existing dashboard tests above cover that rendering still works.
