### PR TITLE
fix(dashboard): absent quota must not render as 0% behind a green check

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -228,6 +228,11 @@ def _quota_has_data(quota: dict) -> bool:
     return bool(quota.get("headers")) or quota.get("age_h") is not None
 
 
+# Glyph is a THREE-way split, not two: no reading -> "—", a reading the API
+# refused -> "✗", a good reading -> "✓". Collapsing the last two hides a real
+# rate-limit behind a check.
+
+
 def _quota_age_label(quota: dict) -> str:
     """One short string for the panel: how old this reading is.
 
@@ -559,7 +564,7 @@ def render_dashboard() -> str:
 <div class="stat"><div class="stat-val">{stats['battery']}{charge}</div><div class="stat-label">Battery</div></div>
 <div class="stat"><div class="stat-val">{ok_count}/{total_count}</div><div class="stat-label">Services OK</div></div>
 <div class="stat"><div class="stat-val">{pending['open']}</div><div class="stat-label">Pending</div></div>
-<div class="stat"><div class="stat-val">{"⚠" if stats["quota"].get("stale") else ("✓" if _quota_has_data(stats["quota"]) else "—")}</div><div class="stat-label">Quota<br><span style="font-size:9px;color:{"#b45309" if stats["quota"].get("stale") else "#444"}">{_quota_age_label(stats["quota"])}</span></div></div>
+<div class="stat"><div class="stat-val">{"⚠" if stats["quota"].get("stale") else ("—" if not _quota_has_data(stats["quota"]) else ("✓" if stats["quota"].get("available", True) else "✗"))}</div><div class="stat-label">Quota<br><span style="font-size:9px;color:{"#b45309" if stats["quota"].get("stale") else "#444"}">{_quota_age_label(stats["quota"])}</span></div></div>
 <div class="stat"><div class="stat-val">{(str(int(float(stats["quota"].get("utilization_5h", 0) or stats["quota"].get("headers", {}).get("anthropic-ratelimit-unified-5h-utilization", 0)) * 100)) + "%") if _quota_has_data(stats["quota"]) else "—"}</div><div class="stat-label">5h Used<br><span style="font-size:9px;color:#444">↻ {stats["quota"].get("reset_5h", "?")}</span></div></div>
 <div class="stat"><div class="stat-val">{(str(int(float(stats["quota"].get("utilization_7d", 0) or stats["quota"].get("headers", {}).get("anthropic-ratelimit-unified-7d-utilization", 0)) * 100)) + "%") if _quota_has_data(stats["quota"]) else "—"}</div><div class="stat-label">7d Used<br><span style="font-size:9px;color:#444">↻ {stats["quota"].get("reset_7d", "?")}</span></div></div>
 </div></div>""")

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -217,6 +217,17 @@ def _quota_freshness(data: dict, quota_file) -> dict:
 
 
 
+def _quota_has_data(quota: dict) -> bool:
+    """Whether a reading actually exists, as opposed to defaulting to zero.
+
+    The tiles below format utilization with `.get(..., 0)`, so an ABSENT file
+    rendered as "0% used" plus a green check — absence shown as "healthy,
+    nothing consumed", which is the confidently-wrong failure get_quota_status
+    exists to avoid. Same discriminator as the age label.
+    """
+    return bool(quota.get("headers")) or quota.get("age_h") is not None
+
+
 def _quota_age_label(quota: dict) -> str:
     """One short string for the panel: how old this reading is.
 
@@ -548,9 +559,9 @@ def render_dashboard() -> str:
 <div class="stat"><div class="stat-val">{stats['battery']}{charge}</div><div class="stat-label">Battery</div></div>
 <div class="stat"><div class="stat-val">{ok_count}/{total_count}</div><div class="stat-label">Services OK</div></div>
 <div class="stat"><div class="stat-val">{pending['open']}</div><div class="stat-label">Pending</div></div>
-<div class="stat"><div class="stat-val">{"⚠" if stats["quota"].get("stale") else ("✓" if stats["quota"].get("available", True) else "✗")}</div><div class="stat-label">Quota<br><span style="font-size:9px;color:{"#b45309" if stats["quota"].get("stale") else "#444"}">{_quota_age_label(stats["quota"])}</span></div></div>
-<div class="stat"><div class="stat-val">{int(float(stats["quota"].get("utilization_5h", 0) or stats["quota"].get("headers", {}).get("anthropic-ratelimit-unified-5h-utilization", 0)) * 100)}%</div><div class="stat-label">5h Used<br><span style="font-size:9px;color:#444">↻ {stats["quota"].get("reset_5h", "?")}</span></div></div>
-<div class="stat"><div class="stat-val">{int(float(stats["quota"].get("utilization_7d", 0) or stats["quota"].get("headers", {}).get("anthropic-ratelimit-unified-7d-utilization", 0)) * 100)}%</div><div class="stat-label">7d Used<br><span style="font-size:9px;color:#444">↻ {stats["quota"].get("reset_7d", "?")}</span></div></div>
+<div class="stat"><div class="stat-val">{"⚠" if stats["quota"].get("stale") else ("✓" if _quota_has_data(stats["quota"]) else "—")}</div><div class="stat-label">Quota<br><span style="font-size:9px;color:{"#b45309" if stats["quota"].get("stale") else "#444"}">{_quota_age_label(stats["quota"])}</span></div></div>
+<div class="stat"><div class="stat-val">{(str(int(float(stats["quota"].get("utilization_5h", 0) or stats["quota"].get("headers", {}).get("anthropic-ratelimit-unified-5h-utilization", 0)) * 100)) + "%") if _quota_has_data(stats["quota"]) else "—"}</div><div class="stat-label">5h Used<br><span style="font-size:9px;color:#444">↻ {stats["quota"].get("reset_5h", "?")}</span></div></div>
+<div class="stat"><div class="stat-val">{(str(int(float(stats["quota"].get("utilization_7d", 0) or stats["quota"].get("headers", {}).get("anthropic-ratelimit-unified-7d-utilization", 0)) * 100)) + "%") if _quota_has_data(stats["quota"]) else "—"}</div><div class="stat-label">7d Used<br><span style="font-size:9px;color:#444">↻ {stats["quota"].get("reset_7d", "?")}</span></div></div>
 </div></div>""")
 
     # Services (ports + daemons only)

--- a/tests/dashboard-quota-no-data.test.py
+++ b/tests/dashboard-quota-no-data.test.py
@@ -47,14 +47,21 @@ HAS_DATA = {                                        # a real reading, for the co
 
 
 def _render_with(quota: dict) -> str:
+    """Render with a fully synthetic stats dict — never the real collector.
+
+    `get_system_stats()` shells out to `/usr/bin/pmset`, which does not exist on
+    the Linux CI runner, so calling it and patching only `quota` raised
+    FileNotFoundError before any assertion ran. `render_dashboard()` reads
+    exactly four keys off stats, so a complete fake is cheap and keeps this
+    hermetic on every platform.
+    """
     real = dashboard.get_system_stats
-
-    def fake():
-        stats = real()
-        stats["quota"] = quota
-        return stats
-
-    dashboard.get_system_stats = fake
+    dashboard.get_system_stats = lambda: {
+        "disk_free": "53GB",
+        "battery": "42%",
+        "charging": False,
+        "quota": quota,
+    }
     try:
         return dashboard.render_dashboard()
     finally:

--- a/tests/dashboard-quota-no-data.test.py
+++ b/tests/dashboard-quota-no-data.test.py
@@ -24,6 +24,7 @@ Plain-python self-runner (no pytest — CI runs these files directly).
 """
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -33,6 +34,24 @@ sys.path.insert(0, str(REPO / "src"))
 spec = importlib.util.spec_from_file_location("dashboard", REPO / "src" / "dashboard.py")
 dashboard = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(dashboard)
+
+def _tile(html: str, label: str) -> str:
+    """The stat-val of ONE named tile.
+
+    Page-wide substring checks are useless here: "✓" also appears in the
+    Services tile and "0%" can appear anywhere, so an assertion like
+    `">✓<" not in html` fails on an unrelated tile and reads as a real defect.
+    Anchor on the tile's own label instead.
+    """
+    # [^<]* — not (.*?): a dot-any capture starts at the FIRST stat-val on the
+    # page and swallows every tile until it reaches this label, so every tile
+    # "contains" every value and the assertion means nothing.
+    m = re.search(
+        r'<div class="stat-val">([^<]*)</div><div class="stat-label">' + re.escape(label),
+        html)
+    assert m, f"tile {label!r} not found in rendered page"
+    return m.group(1)
+
 
 NO_DATA = {"available": True}                      # exactly what a missing file yields
 HAS_DATA = {                                        # a real reading, for the control
@@ -71,6 +90,7 @@ def _render_with(quota: dict) -> str:
 def test_missing_reading_renders_as_absent_not_zero() -> None:
     html = _render_with(NO_DATA)
     assert "no data" in html, "the age label should still say so"
+    assert _tile(html, "Quota") == "—", "absent reading must render — in the Quota tile"
     # The bug: both utilization tiles fell back to 0 and printed "0%".
     assert ">0%<" not in html, 'absent quota rendered as "0%" — the zero default is back'
     assert html.count(">—<") >= 3, (
@@ -79,9 +99,36 @@ def test_missing_reading_renders_as_absent_not_zero() -> None:
     )
 
 
+UNAVAILABLE = {                                     # a REAL reading the API refused
+    "headers": {
+        "anthropic-ratelimit-unified-5h-utilization": 0.91,
+        "anthropic-ratelimit-unified-7d-utilization": 0.88,
+    },
+    "age_h": 0.1,
+    "stale": False,
+    "available": False,
+}
+
+
+def test_unavailable_reading_still_shows_the_cross() -> None:
+    """Regression for the review P1: `—` is for NO reading, not for a bad one.
+
+    The first cut of this fix swapped `available` for `_quota_has_data()` in the
+    glyph, so a fresh reading with `available: False` — which the writer sets
+    whenever `anthropic-ratelimit-unified-status != "allowed"` — rendered as a
+    green check. That is the same confidently-wrong class the whole fix exists
+    to remove, just pointed at rate-limiting instead of absence.
+    """
+    html = _render_with(UNAVAILABLE)
+    glyph = _tile(html, "Quota")
+    assert glyph == "✗", f"an unavailable reading must render ✗, got {glyph!r}"
+    assert _tile(html, "5h Used") == "91%", "utilization from a real reading should still show"
+
+
 def test_a_real_reading_still_shows_numbers() -> None:
     """Control: the fix must not blank out a genuine reading."""
     html = _render_with(HAS_DATA)
+    assert _tile(html, "Quota") == "✓", "a fresh available reading should render ✓"
     assert ">42%<" in html, "5h utilization should render from a real reading"
     assert ">13%<" in html, "7d utilization should render from a real reading"
     assert ">✓<" in html, "a fresh real reading should still show the check"
@@ -90,4 +137,5 @@ def test_a_real_reading_still_shows_numbers() -> None:
 if __name__ == "__main__":
     test_missing_reading_renders_as_absent_not_zero()
     test_a_real_reading_still_shows_numbers()
+    test_unavailable_reading_still_shows_the_cross()
     print("dashboard-quota-no-data: PASS")

--- a/tests/dashboard-quota-no-data.test.py
+++ b/tests/dashboard-quota-no-data.test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""A missing quota reading must not render as "0% used" behind a green check.
+
+## Why this test exists
+
+`get_quota_status()` already degrades honestly: no `quota-state.json` returns
+`{"available": True}` with **no numbers**, precisely so the panel cannot imply
+freshness it can't vouch for. The tiles in `render_dashboard()` then undid
+that — they formatted utilization with `.get("utilization_5h", 0)` and picked
+the glyph off `available`, so an ABSENT file rendered as:
+
+    ✓ QUOTA (no data)      0% 5H USED      0% 7D USED
+
+which reads as "quota healthy, nothing consumed" — the opposite of the truth.
+Observed on a live host 2026-08-11, where nothing had written the file for the
+whole session because the core runs without ANTHROPIC_BASE_URL (sonichi#2417):
+the owner reasonably read the tile as "quota is fine" and separately as "the
+quota is not showing the right info".
+
+Absence must look like absence. This pins the em-dash rendering so the zero
+default cannot come back.
+
+Plain-python self-runner (no pytest — CI runs these files directly).
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+spec = importlib.util.spec_from_file_location("dashboard", REPO / "src" / "dashboard.py")
+dashboard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(dashboard)
+
+NO_DATA = {"available": True}                      # exactly what a missing file yields
+HAS_DATA = {                                        # a real reading, for the control
+    "headers": {
+        "anthropic-ratelimit-unified-5h-utilization": 0.42,
+        "anthropic-ratelimit-unified-7d-utilization": 0.13,
+    },
+    "age_h": 0.2,
+    "stale": False,
+    "available": True,
+}
+
+
+def _render_with(quota: dict) -> str:
+    real = dashboard.get_system_stats
+
+    def fake():
+        stats = real()
+        stats["quota"] = quota
+        return stats
+
+    dashboard.get_system_stats = fake
+    try:
+        return dashboard.render_dashboard()
+    finally:
+        dashboard.get_system_stats = real
+
+
+def test_missing_reading_renders_as_absent_not_zero() -> None:
+    html = _render_with(NO_DATA)
+    assert "no data" in html, "the age label should still say so"
+    # The bug: both utilization tiles fell back to 0 and printed "0%".
+    assert ">0%<" not in html, 'absent quota rendered as "0%" — the zero default is back'
+    assert html.count(">—<") >= 3, (
+        "expected em-dashes for the glyph and both utilization tiles, got "
+        f"{html.count('>—<')}"
+    )
+
+
+def test_a_real_reading_still_shows_numbers() -> None:
+    """Control: the fix must not blank out a genuine reading."""
+    html = _render_with(HAS_DATA)
+    assert ">42%<" in html, "5h utilization should render from a real reading"
+    assert ">13%<" in html, "7d utilization should render from a real reading"
+    assert ">✓<" in html, "a fresh real reading should still show the check"
+
+
+if __name__ == "__main__":
+    test_missing_reading_renders_as_absent_not_zero()
+    test_a_real_reading_still_shows_numbers()
+    print("dashboard-quota-no-data: PASS")


### PR DESCRIPTION
## What / why

`get_quota_status()` already degrades honestly: a missing `quota-state.json` returns `{"available": True}` with **no numbers**, specifically so the panel cannot imply freshness it can't vouch for. Its docstring is explicit that a stale reading is "confidently wrong, which is the worse failure".

The tiles in `render_dashboard()` undid that. They formatted utilization with `.get("utilization_5h", 0)` and picked the glyph off `available` — which is `True` for a *missing* file — so an absent reading rendered as:

```
✓ QUOTA (no data)      0% 5H USED      0% 7D USED
```

"Quota healthy, nothing consumed" — the opposite of the truth, from the same class of failure the reader was written to avoid.

**Found on a live host**, where nothing had written the file for an entire session because the core runs without `ANTHROPIC_BASE_URL` (#2417). The owner read that tile two ways in the same minute — as "quota is fine", and as "the quota is not showing the right info". Both are the tile's fault.

## Fix

`_quota_has_data()` — the same discriminator `_quota_age_label()` already uses — gates the three tiles. Absent reading → em-dash for the glyph and both utilization values. A real reading is untouched, and `⚠`/stale behaviour is unchanged.

## Evidence

The regression test fails on the parent commit and passes on the fix:

```
# parent (fix reverted, grep -c '_quota_has_data' -> 0)
$ python3 -B tests/dashboard-quota-no-data.test.py
AssertionError: absent quota rendered as "0%" — the zero default is back

# at b6b0416
$ python3 -B tests/dashboard-quota-no-data.test.py
dashboard-quota-no-data: PASS        (rc=0)
```

The test carries its own control so it can't pass vacuously — a genuine reading must still render numbers:

```
test_a_real_reading_still_shows_numbers:  >42%<  >13%<  >✓<
```

Existing dashboard tests at `b6b0416`:

```
dashboard-battery-fallback               PASS
dashboard-editable-schedules             PASS
dashboard-schedule-delegation            PASS
```

## Scope

Presentation-only, single concern. Does **not** attempt to fix why the file is missing — that's #2417, separate and not mine. This only stops the dashboard lying while it is.
