### PR TITLE
feat(skills): engine-conflict-resolve — ask Sutando to resolve a conflicted update (scratch-worktree merge, confirm-before-apply)

### DIFF
--- a/skills/engine-conflict-resolve/SKILL.md
+++ b/skills/engine-conflict-resolve/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: engine-conflict-resolve
+description: Core-side handler for the desktop app's "Resolve with Sutando" engine-update conflict button. Reproduces the conflicted merge in a scratch git worktree, lets the agent resolve it there, proposes the resolution to the owner, and applies it to the live engine checkout only after explicit confirmation.
+---
+
+# engine-conflict-resolve
+
+When the desktop app's git-aware engine updater hits merge conflicts it aborts
+completely and records `ENGINE_UPDATE_PENDING.json`. "Resolve with Sutando" in
+the app writes a task file `tasks/task-engine-conflict-<epoch>.txt`
+(`source: desktop-app`, `interaction_type: system_event`) whose body names the
+pending file and the engine checkout. This skill is the protocol for that task.
+
+**Iron rule: never modify the live checkout until the owner confirms.** All
+merge work happens in a scratch worktree; only `apply.py` touches the live
+checkout, and only behind the updater's own lock and staleness guards.
+
+## Protocol
+
+### 1. Prepare — reproduce the merge in a scratch worktree
+
+Take `--pending` and `--engine` verbatim from the task body (both paths may
+contain spaces — always double-quote).
+
+```bash
+python3 skills/engine-conflict-resolve/scripts/prepare.py \
+  --pending "<…/ENGINE_UPDATE_PENDING.json>" \
+  --engine "<…/engine/sutando>"
+```
+
+- `{"status": "clean", "merged_sha": …}` — the merge replays cleanly (the
+  recorded conflict no longer reproduces). Skip step 2; the merged_sha IS the
+  proposal — go to step 3 and report "merged cleanly, no conflicts remained".
+- `{"status": "conflicts", "scratch": …, "conflicting_files": […]}` — resolve
+  in the scratch (step 2).
+- `{"status": "error", "reason": "pending-stale", …}` — the checkout moved
+  since the conflict was recorded. Do NOT improvise: report to the owner that
+  the state is stale and that relaunching the app (or re-running the updater)
+  will re-detect. Stop.
+- Re-running prepare is safe: an existing scratch for the same merge is reused.
+
+### 2. Resolve the conflicts IN THE SCRATCH
+
+For each file in `conflicting_files`, read `<scratch>/<file>` — it contains
+standard conflict markers (`<<<<<<< HEAD` = the user's local version,
+`>>>>>>> <sha>` = the new release). Resolve **semantically**: understand what
+the user's change and the release change each intend and produce content that
+preserves both intents (when they are irreconcilable, prefer keeping the
+user's behavior and note it in the proposal). Edit the files in the scratch,
+then stage each one:
+
+```bash
+git -C "<scratch>" add -- "<file>"
+```
+
+Never edit files in the live checkout, and never run `git` in the live
+checkout during this step.
+
+### 3. Propose — commit in the scratch and report to the owner
+
+```bash
+python3 skills/engine-conflict-resolve/scripts/propose.py --scratch "<scratch>"
+```
+
+- Exit 2 `{"status": "unmerged", …}` — you missed a file; go back to step 2.
+- `{"status": "proposed", "merged_sha": …, "files": …, "diffstat": …,
+  "summary_lines": […]}` — write the task's result file
+  (`results/task-engine-conflict-<epoch>.txt`, same id as the task) so the
+  owner sees the proposal in the originating channel. The result must contain:
+  - the `summary_lines` (one line per conflicted file: what was kept), with
+    your own one-line semantic note per file where the mechanical verdict
+    isn't self-explanatory;
+  - the `diffstat`;
+  - the `merged_sha` and the `scratch` path (the follow-up session needs both);
+  - a clear ask: reply **"apply"** to update the live engine, or "discard".
+
+### 4. WAIT for explicit confirmation
+
+Never auto-apply. Confirmation is a follow-up task from the owner saying
+apply / yes / go ahead. If the reply is unclear, ask again. Also record the
+pending action in `state/voice-session-context.json` (`pending_action`:
+`{"kind": "other", "what": "apply engine conflict resolution <merged_sha>",
+"where": "<scratch>"}`) so a later session can pick it up.
+
+### 5. Apply — only after the owner confirmed
+
+```bash
+python3 skills/engine-conflict-resolve/scripts/apply.py \
+  --pending "<…/ENGINE_UPDATE_PENDING.json>" \
+  --engine "<…/engine/sutando>" \
+  --merged-sha "<merged_sha>"
+```
+
+Guards (all enforced by the script, not by you): takes the updater's own
+`ENGINE_UPDATE_LOCK.d` mkdir lock (exit 3 = busy, try again shortly);
+re-asserts HEAD still equals the snapshot tip recorded in pending (exit 4 =
+checkout moved — go back to step 1); verifies the merged sha is a descendant
+of HEAD and contains the release; re-asserts the `!/workspace/` sparse guard;
+then `git merge --ff-only`. On success it clears the pending file, removes the
+scratch worktree, and prints `{"status": "applied", …}` — report that to the
+owner (their work remains on the snapshot branch; the engine restarts on the
+new code at the next app restart).
+
+If the owner says discard: remove the scratch
+(`git -C "<engine>" worktree remove --force "<scratch>"`), leave the pending
+file alone (the app's tray still owns that state), and confirm.
+
+## Notes
+
+- The scratch shares the engine repo's object database (`git worktree`) — no
+  network, no re-fetch, and `apply` is a pure ref fast-forward.
+- Scripts print machine JSON on stdout; human logs go to stderr. Exit 0 covers
+  the `clean`/`conflicts`/`proposed`/`applied` outcomes; treat any other exit
+  as the JSON `reason` says.
+- Tests: `python3 tests/engine-conflict-resolve.test.py` (hermetic, local
+  `file://` upstream, space-containing paths).

--- a/skills/engine-conflict-resolve/SKILL.md
+++ b/skills/engine-conflict-resolve/SKILL.md
@@ -95,18 +95,31 @@ python3 skills/engine-conflict-resolve/scripts/propose.py --scratch "<scratch>"
   file alone is a dead letter the owner never sees:
   1. Write the task's result file (`results/task-engine-conflict-<epoch>.txt`,
      same id as the task) — protocol hygiene: the dashboard, result-watcher,
-     and timeout logic key off it.
-  2. **Actively surface the proposal on the owner's live channel**: post it
-     to the owner's active AG2 Space room via the gateway `op:message` path
-     (the `skills/agent-room-ops/` capabilities — gateway URL + token
-     resolution per `_gateway.py` / `gateway_credentials.py`; the legacy
-     `AG2_REMOTE_TOKEN` in the repo `.env` is an accepted token alias). If no
-     gateway resolves, fall back to the repo's Pending-decisions convention:
-     a macOS notification (`osascript -e 'display notification "Engine
-     conflict resolved — proposal ready" with title "Sutando"'`) **and**
-     append the question to the per-host pending-questions file
-     (`<workspace>/hosts/<hostname>/pending-questions.md`, `<hostname>` =
-     `bash scripts/sutando-config.sh host-label`).
+     and timeout logic key off it. **State in the result which delivery
+     channel step 2 actually used** (the room, or the fallback).
+  2. **Actively surface the proposal via the deterministic deliverer** —
+     write the proposal text to a file, then:
+
+     ```bash
+     python3 skills/engine-conflict-resolve/scripts/deliver.py \
+       --message-file "<proposal.txt>" \
+       --title "Engine update conflict — proposal ready"
+     ```
+
+     The destination is DECLARED, never guessed: `--room` >
+     `$ENGINE_CONFLICT_NOTIFY_ROOM` > this skill's `manifest.json` `config`
+     default (skills/MANIFEST.md precedence). The room must be an
+     **owner-only** room; deliver.py never infers a "last active" room —
+     a merge proposal is owner-only material and a guessed room may be
+     shared. When a room resolves, the post goes through the
+     `agent-room-ops` gateway module (`op:message`). **When no room is
+     configured, or the post fails for any reason**, deliver.py always
+     executes the Pending-decisions fallback: a macOS notification plus a
+     question section inserted into the per-host
+     `<workspace>/hosts/<hostname>/pending-questions.md` (above the
+     `# Resolved` divider, via the shared `src/pending_questions_md.py`
+     locator). Its JSON output tells you which path ran — put that in the
+     result file per point 1.
 
 ### 4. WAIT for explicit confirmation
 
@@ -149,18 +162,23 @@ app's tray still owns that state), and confirm.
 ## Git resolution (installed hosts)
 
 The scripts never assume a usable `git` on PATH — an installed Mac may have a
-sanitized PATH or only the Xcode-CLT stub. Resolution order: `--git` flag >
-`$SUTANDO_GIT` > `PATH`; if nothing usable resolves, they print
-`{"status": "no-git", …}` (exit 6) instead of a traceback. **For a
-desktop-app task, pass the app's own bundled git — the same binary the
-updater/attach scripts use, at `<engine-parent>/bin/git`** (sibling of
-`ENGINE_UPDATE_PENDING.json`):
+sanitized PATH or only the Xcode-CLT stub. Resolution order (config declared
+in this skill's `manifest.json` `config` block, per skills/MANIFEST.md):
 
-```bash
-SUTANDO_GIT="<…/engine>/bin/git" python3 skills/engine-conflict-resolve/scripts/prepare.py …
-```
+1. `--git` CLI flag (explicit override);
+2. `$ENGINE_CONFLICT_GIT` (the manifest-declared env spelling);
+3. the manifest `config` default itself;
+4. **derived from the engine path already passed in**: the desktop bundle
+   ships a runnable `<engine-parent>/bin/git` (desktop #305) — for prepare/
+   apply this comes from `--engine`, for propose from the scratch worktree's
+   `.git` pointer file, so desktop tasks need no configuration at all;
+5. the repo's `src/git_binary.py` contract (first non-stub git on PATH; the
+   system git only when the CLT are verifiably installed — never pops the
+   installer dialog).
 
-(or `--git "<…/engine>/bin/git"` on each script; same for propose/apply).
+If nothing usable resolves, every script prints `{"status": "no-git", …}`
+(exit 6) instead of a traceback. An explicitly configured value (tiers 1–3)
+that is not runnable is an error, not a fall-through.
 
 ## Notes
 

--- a/skills/engine-conflict-resolve/SKILL.md
+++ b/skills/engine-conflict-resolve/SKILL.md
@@ -1,15 +1,26 @@
 ---
 name: engine-conflict-resolve
-description: Core-side handler for the desktop app's "Resolve with Sutando" engine-update conflict button. Reproduces the conflicted merge in a scratch git worktree, lets the agent resolve it there, proposes the resolution to the owner, and applies it to the live engine checkout only after explicit confirmation.
+description: Ask Sutando to resolve a conflicted update of a Sutando checkout. When pulling the latest release/main conflicts with local changes, Sutando reproduces the merge in a scratch git worktree, resolves the conflicts there, proposes the resolution to the owner, and fast-forwards the live checkout only after explicit confirmation. First entry path is the desktop app's "Resolve with Sutando" engine-update button.
 ---
 
 # engine-conflict-resolve
 
-When the desktop app's git-aware engine updater hits merge conflicts it aborts
-completely and records `ENGINE_UPDATE_PENDING.json`. "Resolve with Sutando" in
-the app writes a task file `tasks/task-engine-conflict-<epoch>.txt`
+Anyone running Sutando from a git checkout can ask it to pull the latest
+main/release — and when the update conflicts with their local changes, ask
+Sutando to resolve the merge itself. This skill is that protocol: reproduce
+the merge in a scratch worktree, resolve the conflicts there semantically,
+propose the result, and land it in the live checkout only after the owner
+explicitly confirms.
+
+The first producer of the pending state is the desktop app's git-aware engine
+updater: on a conflicted update it aborts completely and records
+`ENGINE_UPDATE_PENDING.json`; the app's "Resolve with Sutando" button then
+writes a task file `tasks/task-engine-conflict-<epoch>.txt`
 (`source: desktop-app`, `interaction_type: system_event`) whose body names the
-pending file and the engine checkout. This skill is the protocol for that task.
+pending file and the engine checkout. That task is one entry path, not the
+feature: the scripts take the pending-file shape as input from any producer
+(a ref-based entry point — merge any two refs with no pending file — plus a
+chat-facing command are queued follow-ups).
 
 **Iron rule: never modify the live checkout until the owner confirms.** All
 merge work happens in a scratch worktree; only `apply.py` touches the live
@@ -29,8 +40,9 @@ python3 skills/engine-conflict-resolve/scripts/prepare.py \
 ```
 
 - `{"status": "clean", "merged_sha": …}` — the merge replays cleanly (the
-  recorded conflict no longer reproduces). Skip step 2; the merged_sha IS the
-  proposal — go to step 3 and report "merged cleanly, no conflicts remained".
+  recorded conflict no longer reproduces). Skip step 2 but still RUN step 3:
+  only `propose.py` records the proposal `apply.py` will accept. Report
+  "merged cleanly, no conflicts remained".
 - `{"status": "conflicts", "scratch": …, "conflicting_files": […]}` — resolve
   in the scratch (step 2).
 - `{"status": "error", "reason": "pending-stale", …}` — the checkout moved
@@ -64,8 +76,13 @@ python3 skills/engine-conflict-resolve/scripts/propose.py --scratch "<scratch>"
 
 - Exit 2 `{"status": "unmerged", …}` — you missed a file; go back to step 2.
 - `{"status": "proposed", "merged_sha": …, "files": …, "diffstat": …,
-  "summary_lines": […]}` — report the proposal. The proposal text must
-  contain:
+  "summary_lines": […], "proposal_record": …}` — the script has atomically
+  recorded this exact `merged_sha` in `ENGINE_CONFLICT_PROPOSAL.json` next to
+  the pending file; `apply.py` will land ONLY that recorded commit. If you
+  change anything in the scratch afterwards, you MUST re-run propose.py (it
+  overwrites the record) and re-report — the owner confirms a specific
+  proposal, never "whatever is in the scratch now". Report the proposal. The
+  proposal text must contain:
   - the `summary_lines` (one line per conflicted file: what was kept), with
     your own one-line semantic note per file where the mechanical verdict
     isn't self-explanatory;
@@ -113,16 +130,37 @@ python3 skills/engine-conflict-resolve/scripts/apply.py \
 Guards (all enforced by the script, not by you): takes the updater's own
 `ENGINE_UPDATE_LOCK.d` mkdir lock (exit 3 = busy, try again shortly);
 re-asserts HEAD still equals the snapshot tip recorded in pending (exit 4 =
-checkout moved — go back to step 1); verifies the merged sha is a descendant
-of HEAD and contains the release; re-asserts the `!/workspace/` sparse guard;
-then `git merge --ff-only`. On success it clears the pending file, removes the
-scratch worktree, and prints `{"status": "applied", …}` — report that to the
-owner (their work remains on the snapshot branch; the engine restarts on the
-new code at the next app restart).
+checkout moved — go back to step 1); requires the `ENGINE_CONFLICT_PROPOSAL.json`
+record to exist, to match the live pending state, and `--merged-sha` to be
+exactly the recorded commit (exit 5 = proposal missing/mismatched — re-run
+propose.py, re-confirm with the owner); verifies the merged sha is a
+descendant of HEAD and contains the release; re-asserts the `!/workspace/`
+sparse guard; then `git merge --ff-only`. On success it clears the pending
+file and the proposal record, removes the scratch worktree, and prints
+`{"status": "applied", …}` — report that to the owner (their work remains on
+the snapshot branch; the engine restarts on the new code at the next app
+restart).
 
 If the owner says discard: remove the scratch
-(`git -C "<engine>" worktree remove --force "<scratch>"`), leave the pending
-file alone (the app's tray still owns that state), and confirm.
+(`git -C "<engine>" worktree remove --force "<scratch>"`), delete the
+`ENGINE_CONFLICT_PROPOSAL.json` record, leave the pending file alone (the
+app's tray still owns that state), and confirm.
+
+## Git resolution (installed hosts)
+
+The scripts never assume a usable `git` on PATH — an installed Mac may have a
+sanitized PATH or only the Xcode-CLT stub. Resolution order: `--git` flag >
+`$SUTANDO_GIT` > `PATH`; if nothing usable resolves, they print
+`{"status": "no-git", …}` (exit 6) instead of a traceback. **For a
+desktop-app task, pass the app's own bundled git — the same binary the
+updater/attach scripts use, at `<engine-parent>/bin/git`** (sibling of
+`ENGINE_UPDATE_PENDING.json`):
+
+```bash
+SUTANDO_GIT="<…/engine>/bin/git" python3 skills/engine-conflict-resolve/scripts/prepare.py …
+```
+
+(or `--git "<…/engine>/bin/git"` on each script; same for propose/apply).
 
 ## Notes
 

--- a/skills/engine-conflict-resolve/SKILL.md
+++ b/skills/engine-conflict-resolve/SKILL.md
@@ -64,9 +64,8 @@ python3 skills/engine-conflict-resolve/scripts/propose.py --scratch "<scratch>"
 
 - Exit 2 `{"status": "unmerged", …}` — you missed a file; go back to step 2.
 - `{"status": "proposed", "merged_sha": …, "files": …, "diffstat": …,
-  "summary_lines": […]}` — write the task's result file
-  (`results/task-engine-conflict-<epoch>.txt`, same id as the task) so the
-  owner sees the proposal in the originating channel. The result must contain:
+  "summary_lines": […]}` — report the proposal. The proposal text must
+  contain:
   - the `summary_lines` (one line per conflicted file: what was kept), with
     your own one-line semantic note per file where the mechanical verdict
     isn't self-explanatory;
@@ -74,10 +73,30 @@ python3 skills/engine-conflict-resolve/scripts/propose.py --scratch "<scratch>"
   - the `merged_sha` and the `scratch` path (the follow-up session needs both);
   - a clear ask: reply **"apply"** to update the live engine, or "discard".
 
+  **Delivery needs BOTH of the following** — the task's `source` is
+  `desktop-app`, and no bridge polls results for that source, so a result
+  file alone is a dead letter the owner never sees:
+  1. Write the task's result file (`results/task-engine-conflict-<epoch>.txt`,
+     same id as the task) — protocol hygiene: the dashboard, result-watcher,
+     and timeout logic key off it.
+  2. **Actively surface the proposal on the owner's live channel**: post it
+     to the owner's active AG2 Space room via the gateway `op:message` path
+     (the `skills/agent-room-ops/` capabilities — gateway URL + token
+     resolution per `_gateway.py` / `gateway_credentials.py`; the legacy
+     `AG2_REMOTE_TOKEN` in the repo `.env` is an accepted token alias). If no
+     gateway resolves, fall back to the repo's Pending-decisions convention:
+     a macOS notification (`osascript -e 'display notification "Engine
+     conflict resolved — proposal ready" with title "Sutando"'`) **and**
+     append the question to the per-host pending-questions file
+     (`<workspace>/hosts/<hostname>/pending-questions.md`, `<hostname>` =
+     `bash scripts/sutando-config.sh host-label`).
+
 ### 4. WAIT for explicit confirmation
 
-Never auto-apply. Confirmation is a follow-up task from the owner saying
-apply / yes / go ahead. If the reply is unclear, ask again. Also record the
+Never auto-apply. Confirmation is a follow-up task or message from the owner
+saying apply / yes / go ahead — on whatever channel it arrives (the reply
+will NOT come back through the desktop app; that path is one-way). If the
+reply is unclear, ask again. Also record the
 pending action in `state/voice-session-context.json` (`pending_action`:
 `{"kind": "other", "what": "apply engine conflict resolution <merged_sha>",
 "where": "<scratch>"}`) so a later session can pick it up.

--- a/skills/engine-conflict-resolve/manifest.json
+++ b/skills/engine-conflict-resolve/manifest.json
@@ -1,10 +1,22 @@
 {
   "name": "engine-conflict-resolve",
+  "version": "1.0.0",
+  "owner": "github:sonichi/sutando",
+  "license": "MIT",
+  "stability": "experimental",
   "enabled": true,
   "access_tier": "owner",
+  "permissions": {
+    "network": true,
+    "filesystem": "read-write",
+    "secrets": "none"
+  },
   "description": "Config-only manifest — present to DECLARE this skill's config per skills/MANIFEST.md (no runtime tools). ENGINE_CONFLICT_GIT: trusted git executable for the scripts (read precedence: --git CLI > env > this manifest default; unset = derive the desktop bundle's <engine-parent>/bin/git, then the src/git_binary.py contract). ENGINE_CONFLICT_NOTIFY_ROOM: owner-only room id for proposal delivery via deliver.py (unset = never post to any room; deterministic fallback to macOS notification + per-host pending-questions.md).",
   "config": {
     "ENGINE_CONFLICT_GIT": "",
     "ENGINE_CONFLICT_NOTIFY_ROOM": ""
+  },
+  "provenance": {
+    "source_repo": "https://github.com/sonichi/sutando"
   }
 }

--- a/skills/engine-conflict-resolve/manifest.json
+++ b/skills/engine-conflict-resolve/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "engine-conflict-resolve",
+  "enabled": true,
+  "access_tier": "owner",
+  "description": "Config-only manifest — present to DECLARE this skill's config per skills/MANIFEST.md (no runtime tools). ENGINE_CONFLICT_GIT: trusted git executable for the scripts (read precedence: --git CLI > env > this manifest default; unset = derive the desktop bundle's <engine-parent>/bin/git, then the src/git_binary.py contract). ENGINE_CONFLICT_NOTIFY_ROOM: owner-only room id for proposal delivery via deliver.py (unset = never post to any room; deterministic fallback to macOS notification + per-host pending-questions.md).",
+  "config": {
+    "ENGINE_CONFLICT_GIT": "",
+    "ENGINE_CONFLICT_NOTIFY_ROOM": ""
+  }
+}

--- a/skills/engine-conflict-resolve/scripts/_common.py
+++ b/skills/engine-conflict-resolve/scripts/_common.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Shared helpers for the engine-conflict-resolve skill scripts.
+
+Mirrors the contracts of the desktop app's engine/update-engine-git.sh:
+same mkdir lock (ENGINE_UPDATE_LOCK.d + info pid=/ts= file), same
+:(exclude)workspace pathspec, same /* + !/workspace/ sparse guard.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import List, Optional
+
+# The scratch merge commit identity is fixed so proposals are deterministic
+# regardless of the host's git config.
+SUTANDO_IDENT = {
+    "GIT_AUTHOR_NAME": "Sutando",
+    "GIT_AUTHOR_EMAIL": "noreply@local",
+    "GIT_COMMITTER_NAME": "Sutando",
+    "GIT_COMMITTER_EMAIL": "noreply@local",
+}
+
+WS_EXCLUDE = ":(exclude)workspace"
+META_NAME = "sutando-engine-conflict.json"
+LOCK_NAME = "ENGINE_UPDATE_LOCK.d"
+
+
+def run_git(repo, *args: str, check: bool = True, ident: bool = False) -> "subprocess.CompletedProcess[str]":
+    env = dict(os.environ)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    if ident:
+        env.update(SUTANDO_IDENT)
+    proc = subprocess.run(
+        ["git", "-C", str(repo)] + list(args),
+        capture_output=True, text=True, env=env,
+    )
+    if check and proc.returncode != 0:
+        raise GitError(f"git {' '.join(args)} failed in {repo}: {proc.stderr.strip()}")
+    return proc
+
+
+class GitError(RuntimeError):
+    pass
+
+
+def git_out(repo, *args: str) -> str:
+    return run_git(repo, *args).stdout.strip()
+
+
+def emit(payload: dict, exit_code: int = 0) -> "None":
+    print(json.dumps(payload, indent=2))
+    sys.exit(exit_code)
+
+
+def die(error: str, reason: str = "error", exit_code: int = 1, **extra) -> "None":
+    payload = {"status": "error", "reason": reason, "error": error}
+    payload.update(extra)
+    emit(payload, exit_code)
+
+
+def load_pending(path: Path) -> dict:
+    if not path.is_file():
+        die(f"pending file not found: {path}", reason="pending-missing")
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError) as e:
+        die(f"pending file unreadable: {e}", reason="pending-invalid")
+    for key in ("new_sha", "old_sha", "snapshot_branch"):
+        if not isinstance(data.get(key), str) or not data[key]:
+            die(f"pending file missing required field '{key}': {path}", reason="pending-invalid")
+    if not isinstance(data.get("conflicting_files"), list):
+        data["conflicting_files"] = []
+    return data
+
+
+def is_git_checkout(repo: Path) -> bool:
+    return run_git(repo, "rev-parse", "--git-dir", check=False).returncode == 0
+
+
+def tree_dirty(repo: Path) -> str:
+    """Non-empty string = dirty. Same pathspec as the updater's tree_status."""
+    return run_git(repo, "status", "--porcelain", "--", ".", WS_EXCLUDE).stdout.strip()
+
+
+def default_scratch(engine: Path, new_sha: str) -> Path:
+    digest = hashlib.sha256(f"{engine.resolve()}\n{new_sha}".encode()).hexdigest()[:12]
+    return Path(tempfile.gettempdir()) / "sutando-engine-conflict" / digest
+
+
+def git_path(repo: Path, name: str) -> Path:
+    out = git_out(repo, "rev-parse", "--git-path", name)
+    p = Path(out)
+    return p if p.is_absolute() else (Path(repo) / p).resolve()
+
+
+def read_meta(scratch: Path) -> Optional[dict]:
+    p = git_path(scratch, META_NAME)
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def write_meta(scratch: Path, meta: dict) -> None:
+    p = git_path(scratch, META_NAME)
+    tmp = p.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(meta, indent=2))
+    os.replace(tmp, p)
+
+
+def unmerged_paths(repo: Path) -> List[str]:
+    out = run_git(repo, "ls-files", "-u").stdout
+    seen: List[str] = []
+    for line in out.splitlines():
+        path = line.split("\t", 1)[1] if "\t" in line else ""
+        if path and path not in seen:
+            seen.append(path)
+    return seen
+
+
+def merge_in_progress(repo: Path) -> bool:
+    return run_git(repo, "rev-parse", "-q", "--verify", "MERGE_HEAD", check=False).returncode == 0
+
+
+def commit_exists(repo: Path, sha: str) -> bool:
+    return run_git(repo, "cat-file", "-e", f"{sha}^{{commit}}", check=False).returncode == 0
+
+
+def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    return run_git(repo, "merge-base", "--is-ancestor", ancestor, descendant, check=False).returncode == 0
+
+
+def ensure_workspace_guard(repo: Path) -> None:
+    """Same defense the updater re-asserts: sparse-checkout excludes /workspace/."""
+    run_git(repo, "config", "core.sparseCheckout", "true")
+    run_git(repo, "config", "core.sparseCheckoutCone", "false")
+    sparse = git_path(repo, "info/sparse-checkout")
+    sparse.parent.mkdir(parents=True, exist_ok=True)
+    if not sparse.is_file() or "!/workspace/" not in sparse.read_text().splitlines():
+        sparse.write_text("/*\n!/workspace/\n")
+
+
+def log(msg: str) -> None:
+    print(f"engine-conflict-resolve: {msg}", file=sys.stderr)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def acquire_lock(state_dir: Path, busy_exit: int = 3) -> Path:
+    """Take the updater's own mutex. Busy → exit(busy_exit); dead holder → reclaim."""
+    lock_dir = state_dir / LOCK_NAME
+    tries = 0
+    while True:
+        try:
+            lock_dir.mkdir()
+            break
+        except FileExistsError:
+            pass
+        opid: Optional[int] = None
+        try:
+            for line in (lock_dir / "info").read_text().splitlines():
+                if line.startswith("pid="):
+                    opid = int(line[4:].strip())
+                    break
+        except (OSError, ValueError):
+            opid = None
+        if opid is None:
+            # Holder may be between mkdir and info-write: only reclaim an old dir.
+            try:
+                age = time.time() - lock_dir.stat().st_mtime
+            except OSError:
+                age = 0.0
+            if age < 10:
+                die(f"another engine mutator is starting (lock {lock_dir}) — not touching the checkout",
+                    reason="lock-busy", exit_code=busy_exit)
+        elif _pid_alive(opid):
+            die(f"another engine mutator is running (pid {opid}, lock {lock_dir}) — not touching the checkout",
+                reason="lock-busy", exit_code=busy_exit)
+        log(f"reclaiming stale lock (pid {opid if opid is not None else 'unknown'} not running)")
+        _remove_lock(lock_dir)
+        tries += 1
+        if tries >= 3:
+            die(f"could not acquire {lock_dir} after reclaim attempts", reason="lock-error")
+    (lock_dir / "info").write_text(
+        "pid=%d\nts=%s\n" % (os.getpid(), time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
+    )
+    return lock_dir
+
+
+def _remove_lock(lock_dir: Path) -> None:
+    try:
+        for child in lock_dir.iterdir():
+            child.unlink()
+        lock_dir.rmdir()
+    except OSError as e:
+        die(f"could not remove lock {lock_dir}: {e}", reason="lock-error")
+
+
+def release_lock(lock_dir: Path) -> None:
+    if lock_dir.is_dir():
+        _remove_lock(lock_dir)

--- a/skills/engine-conflict-resolve/scripts/_common.py
+++ b/skills/engine-conflict-resolve/scripts/_common.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -34,30 +33,103 @@ PROPOSAL_NAME = "ENGINE_CONFLICT_PROPOSAL.json"
 
 EXIT_NO_GIT = 6
 
+# Declared in this skill's manifest.json config block (skills/MANIFEST.md
+# convention) — read precedence: CLI --git > env > manifest default.
+GIT_CONFIG_KEY = "ENGINE_CONFLICT_GIT"
+
 _GIT: Optional[str] = None
+_CLI_GIT: Optional[str] = None
+_ENGINE_HINT: Optional[Path] = None
 
 
 def set_git(path: Optional[str]) -> None:
-    """CLI --git override; wins over env + PATH resolution."""
-    global _GIT
+    """CLI --git override; the top tier of the declared config precedence."""
+    global _CLI_GIT
     if path:
-        _GIT = path
+        _CLI_GIT = path
+
+
+def set_engine_hint(engine) -> None:
+    """The engine checkout location; lets resolution derive the bundle's git."""
+    global _ENGINE_HINT
+    if engine:
+        _ENGINE_HINT = Path(engine)
+
+
+def engine_hint_from_scratch(scratch: Path) -> None:
+    """A linked worktree's .git is a plain 'gitdir: <engine>/.git/worktrees/<id>'
+    pointer file — readable without git, so the bundle tier works for propose too."""
+    try:
+        text = (Path(scratch) / ".git").read_text().strip()
+    except OSError:
+        return
+    if text.startswith("gitdir:") and "/.git/worktrees/" in text:
+        set_engine_hint(text[len("gitdir:"):].strip().split("/.git/worktrees/")[0])
+
+
+def skill_dir() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def manifest_config(key: str) -> str:
+    try:
+        data = json.loads((skill_dir() / "manifest.json").read_text())
+        val = (data.get("config") or {}).get(key)
+        return val if isinstance(val, str) else ""
+    except (OSError, ValueError):
+        return ""
+
+
+def _runnable(path: str) -> bool:
+    return bool(path) and Path(path).is_file() and os.access(path, os.X_OK)
+
+
+def _repo_src() -> Optional[Path]:
+    for p in Path(__file__).resolve().parents:
+        if (p / "src" / "git_binary.py").is_file():
+            return p / "src"
+    return None
 
 
 def resolve_git() -> str:
-    """Trusted git: --git flag > $SUTANDO_GIT > PATH. Never a traceback if absent."""
+    """Trusted git, never a traceback and never the bare CLT stub:
+    --git > $ENGINE_CONFLICT_GIT > manifest config > <engine-parent>/bin/git
+    (the desktop bundle, #305) > src/git_binary.py contract."""
     global _GIT
     if _GIT:
         return _GIT
-    cand = os.environ.get("SUTANDO_GIT") or shutil.which("git")
-    if not cand or not (Path(cand).is_file() and os.access(cand, os.X_OK)):
-        emit({"status": "no-git", "reason": "no-git",
-              "error": "no usable git executable (checked --git, $SUTANDO_GIT, then PATH) — "
-                       "set SUTANDO_GIT to a trusted git (the desktop bundle ships one at "
-                       "<engine-parent>/bin/git) or pass --git"},
-             exit_code=EXIT_NO_GIT)
-    _GIT = cand
-    return _GIT
+    for tier, cand in (("--git", _CLI_GIT),
+                       ("$" + GIT_CONFIG_KEY, os.environ.get(GIT_CONFIG_KEY)),
+                       ("manifest config " + GIT_CONFIG_KEY, manifest_config(GIT_CONFIG_KEY))):
+        if cand:
+            if not _runnable(cand):
+                emit({"status": "no-git", "reason": "no-git",
+                      "error": f"configured git ({tier}) is not runnable: {cand}"},
+                     exit_code=EXIT_NO_GIT)
+            _GIT = cand
+            return _GIT
+    if _ENGINE_HINT is not None:
+        bundled = Path(_ENGINE_HINT).resolve().parent / "bin" / "git"
+        if _runnable(str(bundled)):
+            _GIT = str(bundled)
+            return _GIT
+    src = _repo_src()
+    if src is not None:
+        if str(src) not in sys.path:
+            sys.path.insert(0, str(src))
+        try:
+            import git_binary
+            cand = git_binary.resolve_git()
+        except Exception:
+            cand = None
+        if cand:
+            _GIT = cand
+            return _GIT
+    emit({"status": "no-git", "reason": "no-git",
+          "error": "no usable git — pass --git, set ENGINE_CONFLICT_GIT (declared in "
+                   "skills/engine-conflict-resolve/manifest.json), or run against a desktop "
+                   "bundle whose engine dir ships bin/git"},
+         exit_code=EXIT_NO_GIT)
 
 
 def run_git(repo, *args: str, check: bool = True, ident: bool = False) -> "subprocess.CompletedProcess[str]":

--- a/skills/engine-conflict-resolve/scripts/_common.py
+++ b/skills/engine-conflict-resolve/scripts/_common.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -29,6 +30,34 @@ SUTANDO_IDENT = {
 WS_EXCLUDE = ":(exclude)workspace"
 META_NAME = "sutando-engine-conflict.json"
 LOCK_NAME = "ENGINE_UPDATE_LOCK.d"
+PROPOSAL_NAME = "ENGINE_CONFLICT_PROPOSAL.json"
+
+EXIT_NO_GIT = 6
+
+_GIT: Optional[str] = None
+
+
+def set_git(path: Optional[str]) -> None:
+    """CLI --git override; wins over env + PATH resolution."""
+    global _GIT
+    if path:
+        _GIT = path
+
+
+def resolve_git() -> str:
+    """Trusted git: --git flag > $SUTANDO_GIT > PATH. Never a traceback if absent."""
+    global _GIT
+    if _GIT:
+        return _GIT
+    cand = os.environ.get("SUTANDO_GIT") or shutil.which("git")
+    if not cand or not (Path(cand).is_file() and os.access(cand, os.X_OK)):
+        emit({"status": "no-git", "reason": "no-git",
+              "error": "no usable git executable (checked --git, $SUTANDO_GIT, then PATH) — "
+                       "set SUTANDO_GIT to a trusted git (the desktop bundle ships one at "
+                       "<engine-parent>/bin/git) or pass --git"},
+             exit_code=EXIT_NO_GIT)
+    _GIT = cand
+    return _GIT
 
 
 def run_git(repo, *args: str, check: bool = True, ident: bool = False) -> "subprocess.CompletedProcess[str]":
@@ -36,10 +65,15 @@ def run_git(repo, *args: str, check: bool = True, ident: bool = False) -> "subpr
     env["GIT_TERMINAL_PROMPT"] = "0"
     if ident:
         env.update(SUTANDO_IDENT)
-    proc = subprocess.run(
-        ["git", "-C", str(repo)] + list(args),
-        capture_output=True, text=True, env=env,
-    )
+    try:
+        proc = subprocess.run(
+            [resolve_git(), "-C", str(repo)] + list(args),
+            capture_output=True, text=True, env=env,
+        )
+    except OSError as e:
+        emit({"status": "no-git", "reason": "no-git",
+              "error": f"git executable failed to launch ({e}) — set SUTANDO_GIT or pass --git"},
+             exit_code=EXIT_NO_GIT)
     if check and proc.returncode != 0:
         raise GitError(f"git {' '.join(args)} failed in {repo}: {proc.stderr.strip()}")
     return proc
@@ -114,6 +148,29 @@ def write_meta(scratch: Path, meta: dict) -> None:
     tmp = p.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(meta, indent=2))
     os.replace(tmp, p)
+
+
+def proposal_path(pending: Path) -> Path:
+    """The confirmed-proposal record lives beside the pending file (state dir)."""
+    return Path(pending).resolve().parent / PROPOSAL_NAME
+
+
+def write_proposal(pending: Path, record: dict) -> None:
+    p = proposal_path(pending)
+    tmp = p.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(record, indent=2))
+    os.replace(tmp, p)
+
+
+def read_proposal(pending: Path) -> Optional[dict]:
+    p = proposal_path(pending)
+    if not p.is_file():
+        return None
+    try:
+        data = json.loads(p.read_text())
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
 
 
 def unmerged_paths(repo: Path) -> List[str]:

--- a/skills/engine-conflict-resolve/scripts/_common.py
+++ b/skills/engine-conflict-resolve/scripts/_common.py
@@ -38,6 +38,7 @@ EXIT_NO_GIT = 6
 GIT_CONFIG_KEY = "ENGINE_CONFLICT_GIT"
 
 _GIT: Optional[str] = None
+_EXEC_PATH: Optional[str] = None  # "" = derivation attempted and failed
 _CLI_GIT: Optional[str] = None
 _ENGINE_HINT: Optional[Path] = None
 
@@ -91,11 +92,23 @@ def _repo_src() -> Optional[Path]:
     return None
 
 
+def _finalize_git(cand: str) -> str:
+    """Cache the binary AND its exec-path: git's merge machinery re-execs
+    itself, and under an empty PATH only GIT_EXEC_PATH lets that resolve."""
+    global _GIT, _EXEC_PATH
+    _GIT = cand
+    try:
+        proc = subprocess.run([cand, "--exec-path"], capture_output=True, text=True, timeout=15)
+        _EXEC_PATH = proc.stdout.strip() if proc.returncode == 0 else ""
+    except (OSError, subprocess.SubprocessError):
+        _EXEC_PATH = ""
+    return _GIT
+
+
 def resolve_git() -> str:
     """Trusted git, never a traceback and never the bare CLT stub:
     --git > $ENGINE_CONFLICT_GIT > manifest config > <engine-parent>/bin/git
     (the desktop bundle, #305) > src/git_binary.py contract."""
-    global _GIT
     if _GIT:
         return _GIT
     for tier, cand in (("--git", _CLI_GIT),
@@ -106,13 +119,11 @@ def resolve_git() -> str:
                 emit({"status": "no-git", "reason": "no-git",
                       "error": f"configured git ({tier}) is not runnable: {cand}"},
                      exit_code=EXIT_NO_GIT)
-            _GIT = cand
-            return _GIT
+            return _finalize_git(cand)
     if _ENGINE_HINT is not None:
         bundled = Path(_ENGINE_HINT).resolve().parent / "bin" / "git"
         if _runnable(str(bundled)):
-            _GIT = str(bundled)
-            return _GIT
+            return _finalize_git(str(bundled))
     src = _repo_src()
     if src is not None:
         if str(src) not in sys.path:
@@ -123,8 +134,7 @@ def resolve_git() -> str:
         except Exception:
             cand = None
         if cand:
-            _GIT = cand
-            return _GIT
+            return _finalize_git(cand)
     emit({"status": "no-git", "reason": "no-git",
           "error": "no usable git — pass --git, set ENGINE_CONFLICT_GIT (declared in "
                    "skills/engine-conflict-resolve/manifest.json), or run against a desktop "
@@ -133,18 +143,23 @@ def resolve_git() -> str:
 
 
 def run_git(repo, *args: str, check: bool = True, ident: bool = False) -> "subprocess.CompletedProcess[str]":
+    git = resolve_git()
     env = dict(os.environ)
     env["GIT_TERMINAL_PROMPT"] = "0"
+    if _EXEC_PATH:
+        env["GIT_EXEC_PATH"] = _EXEC_PATH
     if ident:
         env.update(SUTANDO_IDENT)
     try:
         proc = subprocess.run(
-            [resolve_git(), "-C", str(repo)] + list(args),
+            [git, "-C", str(repo)] + list(args),
             capture_output=True, text=True, env=env,
         )
     except OSError as e:
+        detail = "" if _EXEC_PATH else " (GIT_EXEC_PATH could not be derived via --exec-path)"
         emit({"status": "no-git", "reason": "no-git",
-              "error": f"git executable failed to launch ({e}) — set SUTANDO_GIT or pass --git"},
+              "error": f"git executable failed to launch ({e}){detail} — "
+                       "set ENGINE_CONFLICT_GIT or pass --git"},
              exit_code=EXIT_NO_GIT)
     if check and proc.returncode != 0:
         raise GitError(f"git {' '.join(args)} failed in {repo}: {proc.stderr.strip()}")
@@ -335,10 +350,16 @@ def acquire_lock(state_dir: Path, busy_exit: int = 3) -> Path:
 
 
 def _remove_lock(lock_dir: Path) -> None:
+    """Idempotent like the updater's rm -rf: a concurrent reclaim is not an error."""
     try:
         for child in lock_dir.iterdir():
-            child.unlink()
+            try:
+                child.unlink()
+            except FileNotFoundError:
+                pass
         lock_dir.rmdir()
+    except FileNotFoundError:
+        pass
     except OSError as e:
         die(f"could not remove lock {lock_dir}: {e}", reason="lock-error")
 

--- a/skills/engine-conflict-resolve/scripts/apply.py
+++ b/skills/engine-conflict-resolve/scripts/apply.py
@@ -54,7 +54,7 @@ def main() -> None:
     ap.add_argument("--engine", required=True, type=Path)
     ap.add_argument("--merged-sha", required=True)
     ap.add_argument("--scratch", type=Path, default=None)
-    ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
+    ap.add_argument("--git", default=None, help="trusted git executable (top tier of the declared $ENGINE_CONFLICT_GIT config precedence)")
     args = ap.parse_args()
     set_git(args.git)
     set_engine_hint(args.engine)

--- a/skills/engine-conflict-resolve/scripts/apply.py
+++ b/skills/engine-conflict-resolve/scripts/apply.py
@@ -26,7 +26,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _common import (  # noqa: E402
     acquire_lock, commit_exists, die, emit, ensure_workspace_guard, git_out,
     is_ancestor, is_git_checkout, load_pending, log, proposal_path,
-    read_meta, read_proposal, release_lock, run_git, set_git, tree_dirty,
+    read_meta, read_proposal, release_lock, run_git, set_engine_hint,
+    set_git, tree_dirty,
 )
 
 EXIT_PROPOSAL = 5
@@ -56,6 +57,7 @@ def main() -> None:
     ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
     args = ap.parse_args()
     set_git(args.git)
+    set_engine_hint(args.engine)
 
     pending = load_pending(args.pending)
     engine = args.engine

--- a/skills/engine-conflict-resolve/scripts/apply.py
+++ b/skills/engine-conflict-resolve/scripts/apply.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""apply.py — land a confirmed resolution in the LIVE engine checkout.
+
+Run ONLY after the owner explicitly confirmed the proposal. Takes the desktop
+updater's own mkdir lock, re-asserts the checkout is exactly where the pending
+state recorded it, then fast-forwards to the proposed merge — an ff can only
+move HEAD to a descendant, and the sparse workspace guard is re-asserted first,
+so the live workspace can never be touched.
+
+Exit codes: 0 applied · 3 lock busy · 4 checkout moved/dirty · 1 other error.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (  # noqa: E402
+    acquire_lock, commit_exists, die, emit, ensure_workspace_guard, git_out,
+    is_ancestor, is_git_checkout, load_pending, log, read_meta, release_lock,
+    run_git, tree_dirty,
+)
+
+
+def find_scratch(engine: Path, merged_sha: str) -> Optional[Path]:
+    """Locate the prepare.py worktree that carries the proposed merge."""
+    blocks = run_git(engine, "worktree", "list", "--porcelain").stdout.split("\n\n")
+    for block in blocks[1:]:  # first block is the live checkout itself
+        lines = dict(l.split(" ", 1) for l in block.splitlines() if " " in l)
+        path = lines.get("worktree")
+        if not path:
+            continue
+        wt = Path(path)
+        meta = read_meta(wt) if wt.is_dir() and is_git_checkout(wt) else None
+        if meta and run_git(wt, "rev-parse", "HEAD", check=False).stdout.strip() == merged_sha:
+            return wt
+    return None
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pending", required=True, type=Path)
+    ap.add_argument("--engine", required=True, type=Path)
+    ap.add_argument("--merged-sha", required=True)
+    ap.add_argument("--scratch", type=Path, default=None)
+    args = ap.parse_args()
+
+    pending = load_pending(args.pending)
+    engine = args.engine
+    if not engine.is_dir() or not is_git_checkout(engine):
+        die(f"engine checkout not found or not a git checkout: {engine}", reason="engine-invalid")
+
+    lock_dir = acquire_lock(args.pending.resolve().parent, busy_exit=3)
+    try:
+        branch = pending["snapshot_branch"]
+        head = git_out(engine, "rev-parse", "HEAD")
+        tip_proc = run_git(engine, "rev-parse", "-q", "--verify", f"refs/heads/{branch}", check=False)
+        snapshot_tip = tip_proc.stdout.strip() if tip_proc.returncode == 0 else ""
+        if head != snapshot_tip or head != pending["old_sha"]:
+            die("checkout moved since the conflict was recorded (HEAD %s, snapshot tip %s, pending old_sha %s)"
+                " — NOT applying; re-run prepare.py against fresh state"
+                % (head[:12], (snapshot_tip or "missing")[:12], pending["old_sha"][:12]),
+                reason="checkout-moved", exit_code=4)
+        if tree_dirty(engine):
+            die("checkout has local changes since the conflict was recorded — NOT applying",
+                reason="checkout-moved", exit_code=4)
+
+        merged_sha = args.merged_sha
+        if not commit_exists(engine, merged_sha):
+            die(f"proposed merge commit {merged_sha[:12]} not found in the engine repo", reason="merged-sha-missing")
+        merged_sha = git_out(engine, "rev-parse", f"{merged_sha}^{{commit}}")
+        if not is_ancestor(engine, head, merged_sha):
+            die(f"{merged_sha[:12]} is not a descendant of HEAD {head[:12]} — refusing non-ff apply",
+                reason="not-fast-forward")
+        if not is_ancestor(engine, pending["new_sha"], merged_sha):
+            die(f"{merged_sha[:12]} does not contain the release {pending['new_sha'][:12]} — wrong proposal?",
+                reason="release-missing")
+
+        ensure_workspace_guard(engine)
+        run_git(engine, "merge", "--ff-only", merged_sha)
+        landed = git_out(engine, "rev-parse", "HEAD")
+        if landed != merged_sha:
+            die(f"fast-forward did not land on {merged_sha[:12]} (HEAD is {landed[:12]})", reason="apply-failed")
+
+        os.unlink(args.pending)
+
+        scratch = args.scratch.resolve() if args.scratch else find_scratch(engine, merged_sha)
+        removed = None
+        if scratch and scratch.exists():
+            rm = run_git(engine, "worktree", "remove", "--force", str(scratch), check=False)
+            if rm.returncode == 0:
+                removed = str(scratch)
+            else:
+                log(f"scratch worktree not removed ({rm.stderr.strip()}) — clean up manually: {scratch}")
+            run_git(engine, "worktree", "prune", check=False)
+    finally:
+        release_lock(lock_dir)
+
+    emit({"status": "applied", "head": landed, "snapshot_branch": pending["snapshot_branch"],
+          "pending_cleared": True, "scratch_removed": removed})
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/engine-conflict-resolve/scripts/apply.py
+++ b/skills/engine-conflict-resolve/scripts/apply.py
@@ -7,7 +7,12 @@ state recorded it, then fast-forwards to the proposed merge — an ff can only
 move HEAD to a descendant, and the sparse workspace guard is re-asserted first,
 so the live workspace can never be touched.
 
-Exit codes: 0 applied · 3 lock busy · 4 checkout moved/dirty · 1 other error.
+Only the exact commit propose.py recorded in ENGINE_CONFLICT_PROPOSAL.json can
+land: --merged-sha must equal the recorded proposal, whose identity fields must
+in turn match the live pending file — an unrecorded descendant is refused.
+
+Exit codes: 0 applied · 3 lock busy · 4 checkout moved/dirty ·
+5 proposal missing/mismatched · 6 no usable git · 1 other error.
 """
 from __future__ import annotations
 
@@ -20,9 +25,11 @@ from typing import Optional
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _common import (  # noqa: E402
     acquire_lock, commit_exists, die, emit, ensure_workspace_guard, git_out,
-    is_ancestor, is_git_checkout, load_pending, log, read_meta, release_lock,
-    run_git, tree_dirty,
+    is_ancestor, is_git_checkout, load_pending, log, proposal_path,
+    read_meta, read_proposal, release_lock, run_git, set_git, tree_dirty,
 )
+
+EXIT_PROPOSAL = 5
 
 
 def find_scratch(engine: Path, merged_sha: str) -> Optional[Path]:
@@ -46,7 +53,9 @@ def main() -> None:
     ap.add_argument("--engine", required=True, type=Path)
     ap.add_argument("--merged-sha", required=True)
     ap.add_argument("--scratch", type=Path, default=None)
+    ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
     args = ap.parse_args()
+    set_git(args.git)
 
     pending = load_pending(args.pending)
     engine = args.engine
@@ -68,10 +77,29 @@ def main() -> None:
             die("checkout has local changes since the conflict was recorded — NOT applying",
                 reason="checkout-moved", exit_code=4)
 
+        # The confirmation binds to the recorded proposal, not to whatever sha
+        # was typed: no record, or any field out of step with the live pending
+        # state, or a different sha (even a descendant) → refusal.
+        record = read_proposal(args.pending)
+        if record is None:
+            die(f"no proposal record ({proposal_path(args.pending)}) — run propose.py first; "
+                "only a recorded proposal can be applied",
+                reason="proposal-missing", exit_code=EXIT_PROPOSAL)
+        for key in ("old_sha", "new_sha", "snapshot_branch"):
+            if record.get(key) != pending[key]:
+                die("proposal record does not match the live pending state (%s: recorded %r, pending %r)"
+                    " — re-run prepare.py + propose.py" % (key, record.get(key), pending[key]),
+                    reason="proposal-mismatch", exit_code=EXIT_PROPOSAL)
+
         merged_sha = args.merged_sha
         if not commit_exists(engine, merged_sha):
             die(f"proposed merge commit {merged_sha[:12]} not found in the engine repo", reason="merged-sha-missing")
         merged_sha = git_out(engine, "rev-parse", f"{merged_sha}^{{commit}}")
+        if merged_sha != record.get("merged_sha"):
+            die("--merged-sha %s is not the recorded proposal %s — the owner confirmed the recorded "
+                "commit only; re-run propose.py if the scratch changed"
+                % (merged_sha[:12], str(record.get("merged_sha"))[:12]),
+                reason="proposal-mismatch", exit_code=EXIT_PROPOSAL)
         if not is_ancestor(engine, head, merged_sha):
             die(f"{merged_sha[:12]} is not a descendant of HEAD {head[:12]} — refusing non-ff apply",
                 reason="not-fast-forward")
@@ -86,8 +114,17 @@ def main() -> None:
             die(f"fast-forward did not land on {merged_sha[:12]} (HEAD is {landed[:12]})", reason="apply-failed")
 
         os.unlink(args.pending)
+        try:
+            os.unlink(proposal_path(args.pending))
+        except FileNotFoundError:
+            pass
 
-        scratch = args.scratch.resolve() if args.scratch else find_scratch(engine, merged_sha)
+        if args.scratch:
+            scratch: Optional[Path] = args.scratch.resolve()
+        elif record.get("scratch") and Path(record["scratch"]).is_dir():
+            scratch = Path(record["scratch"])
+        else:
+            scratch = find_scratch(engine, merged_sha)
         removed = None
         if scratch and scratch.exists():
             rm = run_git(engine, "worktree", "remove", "--force", str(scratch), check=False)

--- a/skills/engine-conflict-resolve/scripts/deliver.py
+++ b/skills/engine-conflict-resolve/scripts/deliver.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""deliver.py — deterministic proposal delivery with a fail-safe fallback.
+
+The desktop-app task carries no originating room, so the destination must be
+DECLARED, never inferred: the room comes from --room > $ENGINE_CONFLICT_NOTIFY_ROOM
+> the manifest config default (skills/MANIFEST.md precedence). This script never
+reads activity state to guess a "last active" room — a merge proposal is
+owner-only material and a guessed room may be shared.
+
+No room configured, or the room post fails for ANY reason → the fallback always
+runs: macOS notification (best-effort) + a question section inserted into the
+per-host pending-questions.md ABOVE the '# Resolved' divider (via the shared
+src/pending_questions_md.py locator — never a private regex).
+
+stdout: {"status": "posted", ...} or {"status": "fallback", "reason": ...};
+exit 0 for both (delivery happened on some channel), 1 only when even the
+pending-questions write failed.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import die, emit, manifest_config, skill_dir  # noqa: E402
+
+ROOM_CONFIG_KEY = "ENGINE_CONFLICT_NOTIFY_ROOM"
+
+
+def _repo_root() -> Optional[Path]:
+    for p in Path(__file__).resolve().parents:
+        if (p / "src" / "pending_questions_md.py").is_file():
+            return p
+    return None
+
+
+def resolve_room(cli_room: Optional[str]) -> Optional[str]:
+    """--room > declared env > manifest default. NEVER inferred from activity."""
+    return cli_room or os.environ.get(ROOM_CONFIG_KEY) or manifest_config(ROOM_CONFIG_KEY) or None
+
+
+def post_via_room_ops(room_ops_dir: Path, room_id: str, body: str) -> Tuple[bool, Optional[str]]:
+    """Room posting delegates to the agent-room-ops gateway module (it owns the
+    /v1 credential + HTTP contract). Absent or failing → (False, reason)."""
+    gw = room_ops_dir / "_gateway.py"
+    if not gw.is_file():
+        return False, "room-ops-unavailable"
+    try:
+        spec = importlib.util.spec_from_file_location("ecr_gateway", gw)
+        mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+        if str(room_ops_dir) not in sys.path:
+            sys.path.insert(0, str(room_ops_dir))
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        base, headers = mod.gateway()
+        if not base:
+            return False, "no-gateway-configured"
+        status, _parsed = mod.http_json(
+            "POST", f"{base}/v1/room", headers,
+            {"op": "message", "room_id": room_id, "body": body})
+        if 200 <= int(status) < 300:
+            return True, None
+        return False, f"http-{status}"
+    except Exception as e:  # any failure MUST reach the fallback, never crash
+        return False, f"post-failed: {e.__class__.__name__}: {e}"
+
+
+def notify_macos(title: str) -> bool:
+    try:
+        proc = subprocess.run(
+            ["osascript", "-e",
+             f'display notification "{title}" with title "Sutando"'],
+            capture_output=True, timeout=10)
+        return proc.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def pending_questions_target(override: Optional[Path]) -> Path:
+    if override:
+        return override
+    repo = _repo_root()
+    if repo is None:
+        die("cannot locate the repo (src/pending_questions_md.py) for the pending-questions fallback",
+            reason="no-repo")
+    if str(repo / "src") not in sys.path:
+        sys.path.insert(0, str(repo / "src"))
+    from util_paths import personal_path, _host_label  # noqa: E402
+    p = personal_path("pending-questions.md")
+    if p.exists():
+        return p
+    from workspace_default import resolve_workspace  # noqa: E402
+    return resolve_workspace() / "hosts" / _host_label() / "pending-questions.md"
+
+
+def write_pending_question(path: Path, title: str, body: str) -> None:
+    """Insert the section ABOVE the '# Resolved' divider (shared locator)."""
+    repo = _repo_root()
+    if repo is not None and str(repo / "src") not in sys.path:
+        sys.path.insert(0, str(repo / "src"))
+    section = "## %s\n- asked: %s\n- source: engine-conflict-resolve\n\n%s\n\n" % (
+        title, time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), body.rstrip())
+    text = path.read_text() if path.is_file() else ""
+    insert_at = len(text)
+    try:
+        import pending_questions_md as pq
+        m = pq.DIVIDER_RE.search(pq.mask_markup(text))
+        if m:
+            insert_at = m.start()
+    except Exception:
+        pass  # divider location is best-effort; appending is still a valid file
+    if insert_at == len(text) and text and not text.endswith("\n"):
+        section = "\n" + section
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(text[:insert_at] + section + text[insert_at:])
+    os.replace(tmp, path)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--message-file", required=True, type=Path,
+                    help="file whose content is the proposal text to deliver")
+    ap.add_argument("--title", default="Engine update conflict — proposal ready")
+    ap.add_argument("--room", default=None,
+                    help=f"owner-only room id (else ${ROOM_CONFIG_KEY} / manifest config)")
+    ap.add_argument("--room-ops-dir", type=Path,
+                    default=skill_dir().parent / "agent-room-ops")
+    ap.add_argument("--pending-questions", type=Path, default=None,
+                    help="override the per-host pending-questions.md target")
+    args = ap.parse_args()
+
+    try:
+        body = args.message_file.read_text()
+    except OSError as e:
+        die(f"cannot read --message-file: {e}", reason="message-unreadable")
+
+    room = resolve_room(args.room)
+    reason = "no-room"
+    if room:
+        ok, fail = post_via_room_ops(args.room_ops_dir, room, body)
+        if ok:
+            emit({"status": "posted", "room": room, "via": "agent-room-ops gateway"})
+        reason = fail or "post-failed"
+
+    target = pending_questions_target(args.pending_questions)
+    try:
+        write_pending_question(target, args.title, body)
+    except OSError as e:
+        die(f"fallback failed too — could not write {target}: {e}", reason="fallback-failed")
+    notified = notify_macos(args.title)
+    emit({"status": "fallback", "reason": reason,
+          "pending_questions": str(target), "notified": notified})
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/engine-conflict-resolve/scripts/prepare.py
+++ b/skills/engine-conflict-resolve/scripts/prepare.py
@@ -56,7 +56,7 @@ def main() -> None:
     ap.add_argument("--pending", required=True, type=Path)
     ap.add_argument("--engine", required=True, type=Path)
     ap.add_argument("--scratch", type=Path, default=None)
-    ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
+    ap.add_argument("--git", default=None, help="trusted git executable (top tier of the declared $ENGINE_CONFLICT_GIT config precedence)")
     args = ap.parse_args()
     set_git(args.git)
     set_engine_hint(args.engine)

--- a/skills/engine-conflict-resolve/scripts/prepare.py
+++ b/skills/engine-conflict-resolve/scripts/prepare.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _common import (  # noqa: E402
     commit_exists, default_scratch, die, emit, ensure_workspace_guard, git_out,
     is_ancestor, is_git_checkout, load_pending, merge_in_progress, read_meta,
-    run_git, tree_dirty, unmerged_paths, write_meta,
+    run_git, set_git, tree_dirty, unmerged_paths, write_meta,
 )
 
 
@@ -56,7 +56,9 @@ def main() -> None:
     ap.add_argument("--pending", required=True, type=Path)
     ap.add_argument("--engine", required=True, type=Path)
     ap.add_argument("--scratch", type=Path, default=None)
+    ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
     args = ap.parse_args()
+    set_git(args.git)
 
     pending = load_pending(args.pending)
     engine = args.engine

--- a/skills/engine-conflict-resolve/scripts/prepare.py
+++ b/skills/engine-conflict-resolve/scripts/prepare.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _common import (  # noqa: E402
     commit_exists, default_scratch, die, emit, ensure_workspace_guard, git_out,
     is_ancestor, is_git_checkout, load_pending, merge_in_progress, read_meta,
-    run_git, set_git, tree_dirty, unmerged_paths, write_meta,
+    run_git, set_engine_hint, set_git, tree_dirty, unmerged_paths, write_meta,
 )
 
 
@@ -59,6 +59,7 @@ def main() -> None:
     ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
     args = ap.parse_args()
     set_git(args.git)
+    set_engine_hint(args.engine)
 
     pending = load_pending(args.pending)
     engine = args.engine

--- a/skills/engine-conflict-resolve/scripts/prepare.py
+++ b/skills/engine-conflict-resolve/scripts/prepare.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""prepare.py — reproduce a deferred engine-update merge in a scratch worktree.
+
+Reads the desktop updater's ENGINE_UPDATE_PENDING.json, creates a scratch git
+worktree off the snapshot tip (shared object db — no re-fetch), and re-runs the
+conflicted merge THERE. Never touches the live checkout's index or worktree.
+
+stdout (machine JSON):
+  {"status": "clean",     "scratch": ..., "merged_sha": ..., ...}
+  {"status": "conflicts", "scratch": ..., "conflicting_files": [...], ...}
+  {"status": "error",     "reason": ..., "error": ...}          (exit 1)
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (  # noqa: E402
+    commit_exists, default_scratch, die, emit, ensure_workspace_guard, git_out,
+    is_ancestor, is_git_checkout, load_pending, merge_in_progress, read_meta,
+    run_git, tree_dirty, unmerged_paths, write_meta,
+)
+
+
+def result(status: str, scratch: Path, pending: dict, snapshot_tip: str, **extra) -> None:
+    payload = {
+        "status": status,
+        "scratch": str(scratch),
+        "snapshot_tip": snapshot_tip,
+        "new_sha": pending["new_sha"],
+        "snapshot_branch": pending["snapshot_branch"],
+    }
+    payload.update(extra)
+    emit(payload)
+
+
+def run_merge(scratch: Path, pending: dict, snapshot_tip: str) -> None:
+    new_sha = pending["new_sha"]
+    msg = "merge engine release %s into %s (Sutando conflict resolution)" % (
+        new_sha[:12], pending["snapshot_branch"])
+    proc = run_git(scratch, "merge", "--no-edit", "-m", msg, new_sha, check=False, ident=True)
+    if proc.returncode == 0:
+        result("clean", scratch, pending, snapshot_tip,
+               merged_sha=git_out(scratch, "rev-parse", "HEAD"), conflicting_files=[])
+    if merge_in_progress(scratch):
+        conflicts = unmerged_paths(scratch)
+        write_meta(scratch, dict(read_meta(scratch) or {}, conflicting_files=conflicts))
+        result("conflicts", scratch, pending, snapshot_tip, conflicting_files=conflicts)
+    die(f"merge failed without a conflict state: {proc.stderr.strip()}", reason="merge-failed")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pending", required=True, type=Path)
+    ap.add_argument("--engine", required=True, type=Path)
+    ap.add_argument("--scratch", type=Path, default=None)
+    args = ap.parse_args()
+
+    pending = load_pending(args.pending)
+    engine = args.engine
+    if not engine.is_dir() or not is_git_checkout(engine):
+        die(f"engine checkout not found or not a git checkout: {engine}", reason="engine-invalid")
+
+    branch = pending["snapshot_branch"]
+    if run_git(engine, "rev-parse", "-q", "--verify", f"refs/heads/{branch}", check=False).returncode != 0:
+        die(f"snapshot branch '{branch}' not found in {engine} — pending state is stale",
+            reason="pending-stale")
+    snapshot_tip = git_out(engine, "rev-parse", f"refs/heads/{branch}")
+    head = git_out(engine, "rev-parse", "HEAD")
+
+    # Same validity rule as the updater's own reconciliation: the pending state
+    # describes the checkout only while HEAD == snapshot tip == old_sha, clean.
+    if head != snapshot_tip or snapshot_tip != pending["old_sha"]:
+        die("checkout no longer matches the pending state (HEAD %s, snapshot tip %s, pending old_sha %s)"
+            " — re-run the app's updater to re-detect" % (head[:12], snapshot_tip[:12], pending["old_sha"][:12]),
+            reason="pending-stale")
+    if tree_dirty(engine):
+        die("checkout has local changes newer than the pending snapshot — re-run the app's updater",
+            reason="pending-stale")
+
+    new_sha = pending["new_sha"]
+    if not commit_exists(engine, new_sha):
+        fetched = run_git(engine, "-c", "http.lowSpeedLimit=1", "-c", "http.lowSpeedTime=30",
+                          "fetch", "--depth", "50", "origin", new_sha, check=False)
+        if fetched.returncode != 0 or not commit_exists(engine, new_sha):
+            die(f"release commit {new_sha[:12]} not present and could not be fetched",
+                reason="new-sha-missing")
+
+    scratch = (args.scratch or default_scratch(engine, new_sha)).resolve()
+
+    if scratch.exists():
+        meta = read_meta(scratch) if is_git_checkout(scratch) else None
+        if not meta or meta.get("new_sha") != new_sha or meta.get("snapshot_tip") != snapshot_tip:
+            die(f"scratch {scratch} exists but was made for a different merge — remove it or pass --scratch",
+                reason="scratch-mismatch")
+        if merge_in_progress(scratch):
+            result("conflicts", scratch, pending, snapshot_tip,
+                   conflicting_files=unmerged_paths(scratch), reused=True)
+        scratch_head = git_out(scratch, "rev-parse", "HEAD")
+        if scratch_head != snapshot_tip and is_ancestor(scratch, new_sha, scratch_head):
+            result("clean", scratch, pending, snapshot_tip, merged_sha=scratch_head,
+                   conflicting_files=[], reused=True)
+        if scratch_head != snapshot_tip or tree_dirty(scratch):
+            die(f"scratch {scratch} is in an unexpected state — remove it or pass --scratch",
+                reason="scratch-mismatch")
+        run_merge(scratch, pending, snapshot_tip)  # same base, merge never ran: retry
+
+    scratch.parent.mkdir(parents=True, exist_ok=True)
+    run_git(engine, "worktree", "add", "--no-checkout", "--detach", str(scratch), snapshot_tip)
+    # The engine repo runs sparse (attach's workspace guard is repo config, the
+    # pattern file is per-worktree) — give the scratch the same guard, then populate.
+    if git_out(engine, "config", "--default", "false", "--bool", "core.sparseCheckout") == "true":
+        ensure_workspace_guard(scratch)
+    run_git(scratch, "reset", "--hard", snapshot_tip)
+    write_meta(scratch, {
+        "engine": str(engine.resolve()),
+        "pending": str(args.pending.resolve()),
+        "new_sha": new_sha,
+        "old_sha": pending["old_sha"],
+        "snapshot_tip": snapshot_tip,
+        "snapshot_branch": branch,
+        "conflicting_files": list(pending.get("conflicting_files") or []),
+    })
+    run_merge(scratch, pending, snapshot_tip)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/engine-conflict-resolve/scripts/propose.py
+++ b/skills/engine-conflict-resolve/scripts/propose.py
@@ -19,9 +19,9 @@ from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _common import (  # noqa: E402
-    WS_EXCLUDE, die, emit, git_out, is_ancestor, is_git_checkout,
-    merge_in_progress, proposal_path, read_meta, run_git, set_git,
-    tree_dirty, unmerged_paths, write_proposal,
+    WS_EXCLUDE, die, emit, engine_hint_from_scratch, git_out, is_ancestor,
+    is_git_checkout, merge_in_progress, proposal_path, read_meta, run_git,
+    set_git, tree_dirty, unmerged_paths, write_proposal,
 )
 
 
@@ -53,6 +53,7 @@ def main() -> None:
     ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
     args = ap.parse_args()
     set_git(args.git)
+    engine_hint_from_scratch(args.scratch)
 
     scratch = args.scratch.resolve()
     if not scratch.is_dir() or not is_git_checkout(scratch):

--- a/skills/engine-conflict-resolve/scripts/propose.py
+++ b/skills/engine-conflict-resolve/scripts/propose.py
@@ -13,13 +13,15 @@ from __future__ import annotations
 
 import argparse
 import sys
+import time
 from pathlib import Path
 from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _common import (  # noqa: E402
     WS_EXCLUDE, die, emit, git_out, is_ancestor, is_git_checkout,
-    merge_in_progress, read_meta, run_git, tree_dirty, unmerged_paths,
+    merge_in_progress, proposal_path, read_meta, run_git, set_git,
+    tree_dirty, unmerged_paths, write_proposal,
 )
 
 
@@ -48,7 +50,9 @@ def kept_line(scratch: Path, path: str, merged: str, local: str, update: str) ->
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--scratch", required=True, type=Path)
+    ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
     args = ap.parse_args()
+    set_git(args.git)
 
     scratch = args.scratch.resolve()
     if not scratch.is_dir() or not is_git_checkout(scratch):
@@ -90,6 +94,17 @@ def main() -> None:
                % (new_sha[:12], meta["snapshot_branch"], len(conflicted), len(files))]
     summary += [kept_line(scratch, p, merged_sha, snapshot_tip, new_sha) for p in conflicted]
 
+    # Bind the confirmation to THIS exact commit: apply.py refuses any sha that
+    # is not the recorded one. Re-proposing atomically overwrites the record.
+    write_proposal(Path(meta["pending"]), {
+        "merged_sha": merged_sha,
+        "old_sha": meta["old_sha"],
+        "new_sha": new_sha,
+        "snapshot_branch": meta["snapshot_branch"],
+        "scratch": str(scratch),
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    })
+
     emit({
         "status": "proposed",
         "merged_sha": merged_sha,
@@ -98,6 +113,7 @@ def main() -> None:
         "files": files,
         "diffstat": diffstat,
         "summary_lines": summary,
+        "proposal_record": str(proposal_path(Path(meta["pending"]))),
     })
 
 

--- a/skills/engine-conflict-resolve/scripts/propose.py
+++ b/skills/engine-conflict-resolve/scripts/propose.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""propose.py — commit the resolved merge in the scratch and print the proposal.
+
+Run after the agent has resolved every conflict in the scratch worktree and
+`git add`-ed the resolutions. Refuses (exit 2) while unmerged paths remain.
+
+stdout (machine JSON):
+  {"status": "proposed", "merged_sha": ..., "files": [...], "diffstat": ...,
+   "summary_lines": [...]}
+  {"status": "unmerged", "unmerged_paths": [...]}                (exit 2)
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (  # noqa: E402
+    WS_EXCLUDE, die, emit, git_out, is_ancestor, is_git_checkout,
+    merge_in_progress, read_meta, run_git, tree_dirty, unmerged_paths,
+)
+
+
+def blob(scratch: Path, rev: str, path: str) -> Optional[str]:
+    proc = run_git(scratch, "rev-parse", "-q", "--verify", f"{rev}:{path}", check=False)
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def kept_line(scratch: Path, path: str, merged: str, local: str, update: str) -> str:
+    b_merged = blob(scratch, merged, path)
+    b_local = blob(scratch, local, path)
+    b_update = blob(scratch, update, path)
+    if b_merged is None:
+        verdict = "removed in the resolution"
+    elif b_merged == b_local and b_merged == b_update:
+        verdict = "identical on both sides"
+    elif b_merged == b_local:
+        verdict = "kept your local version"
+    elif b_merged == b_update:
+        verdict = "took the release version"
+    else:
+        verdict = "hand-merged — combines local and release changes"
+    return f"{path}: {verdict}"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--scratch", required=True, type=Path)
+    args = ap.parse_args()
+
+    scratch = args.scratch.resolve()
+    if not scratch.is_dir() or not is_git_checkout(scratch):
+        die(f"scratch worktree not found: {scratch}", reason="scratch-invalid")
+    meta = read_meta(scratch)
+    if not meta:
+        die(f"{scratch} was not created by prepare.py (no merge metadata)", reason="scratch-invalid")
+
+    unmerged = unmerged_paths(scratch)
+    if unmerged:
+        emit({"status": "unmerged", "unmerged_paths": unmerged,
+              "error": "conflicts are not fully resolved+staged — edit the files, `git add` them, re-run"},
+             exit_code=2)
+
+    snapshot_tip = meta["snapshot_tip"]
+    new_sha = meta["new_sha"]
+    if merge_in_progress(scratch) or tree_dirty(scratch):
+        # The whole scratch tree IS the proposal — stage any still-unstaged edits
+        # so a resolution can't silently drop, then conclude the merge.
+        run_git(scratch, "add", "-A", "--", ".", WS_EXCLUDE)
+        msg = "merge: engine release %s resolved by Sutando (%s)" % (
+            new_sha[:12], meta["snapshot_branch"])
+        run_git(scratch, "commit", "--no-verify", "-m", msg, ident=True)
+
+    merged_sha = git_out(scratch, "rev-parse", "HEAD")
+    if merged_sha == snapshot_tip or not is_ancestor(scratch, new_sha, merged_sha):
+        die("scratch has no merge to propose (HEAD does not contain the release) — run prepare.py first",
+            reason="nothing-to-propose")
+
+    files = []
+    for line in run_git(scratch, "diff", "--name-status", snapshot_tip, merged_sha).stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            files.append({"status": parts[0], "path": parts[-1]})
+    diffstat = run_git(scratch, "diff", "--stat", snapshot_tip, merged_sha).stdout.rstrip()
+
+    conflicted = list(meta.get("conflicting_files") or [])
+    summary = ["Merge of release %s into '%s' — %d conflicted file(s) resolved, %d file(s) changed overall"
+               % (new_sha[:12], meta["snapshot_branch"], len(conflicted), len(files))]
+    summary += [kept_line(scratch, p, merged_sha, snapshot_tip, new_sha) for p in conflicted]
+
+    emit({
+        "status": "proposed",
+        "merged_sha": merged_sha,
+        "snapshot_tip": snapshot_tip,
+        "new_sha": new_sha,
+        "files": files,
+        "diffstat": diffstat,
+        "summary_lines": summary,
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/engine-conflict-resolve/scripts/propose.py
+++ b/skills/engine-conflict-resolve/scripts/propose.py
@@ -50,7 +50,7 @@ def kept_line(scratch: Path, path: str, merged: str, local: str, update: str) ->
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--scratch", required=True, type=Path)
-    ap.add_argument("--git", default=None, help="trusted git executable (overrides $SUTANDO_GIT and PATH)")
+    ap.add_argument("--git", default=None, help="trusted git executable (top tier of the declared $ENGINE_CONFLICT_GIT config precedence)")
     args = ap.parse_args()
     set_git(args.git)
     engine_hint_from_scratch(args.scratch)

--- a/tests/engine-conflict-resolve.test.py
+++ b/tests/engine-conflict-resolve.test.py
@@ -40,9 +40,9 @@ def git(repo, *args, check=True):
     return proc
 
 
-def run_script(name, *args):
+def run_script(name, *args, env=None):
     return subprocess.run([sys.executable, str(SCRIPTS / name)] + list(args),
-                          capture_output=True, text=True)
+                          capture_output=True, text=True, env=env)
 
 
 def out_json(proc):
@@ -111,9 +111,14 @@ class EngineFixture:
     def cleanup(self):
         shutil.rmtree(self.root, ignore_errors=True)
 
-    def prepare(self):
+    def prepare(self, env=None):
         return run_script("prepare.py", "--pending", str(self.pending),
-                          "--engine", str(self.engine), "--scratch", str(self.scratch))
+                          "--engine", str(self.engine), "--scratch", str(self.scratch),
+                          env=env)
+
+    @property
+    def proposal(self):
+        return self.engine.parent / "ENGINE_CONFLICT_PROPOSAL.json"
 
     def apply(self, merged_sha):
         return run_script("apply.py", "--pending", str(self.pending),
@@ -145,11 +150,24 @@ class TestCleanMergeFastPath(unittest.TestCase):
         self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), fx.old_sha)
         self.assertTrue(fx.pending.is_file())
 
+        # No proposal record yet — apply must refuse even a valid merged_sha.
+        early = fx.apply(merged)
+        self.assertEqual(early.returncode, 5, early.stdout + early.stderr)
+        self.assertEqual(out_json(early)["reason"], "proposal-missing")
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), fx.old_sha)
+
+        # Clean path still runs propose: that is what records the proposal.
+        pr = run_script("propose.py", "--scratch", str(fx.scratch))
+        self.assertEqual(pr.returncode, 0, pr.stdout + pr.stderr)
+        self.assertEqual(out_json(pr)["merged_sha"], merged)
+        self.assertTrue(fx.proposal.is_file())
+
         a = fx.apply(merged)
         self.assertEqual(a.returncode, 0, a.stdout + a.stderr)
         self.assertEqual(out_json(a)["status"], "applied")
         self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), merged)
         self.assertFalse(fx.pending.exists(), "pending must be cleared")
+        self.assertFalse(fx.proposal.exists(), "proposal record must be cleared")
         self.assertNotIn(str(fx.scratch),
                          git(fx.engine, "worktree", "list", "--porcelain").stdout)
         self.assertFalse(fx.scratch.exists(), "scratch worktree removed")
@@ -250,6 +268,37 @@ class TestConflictEndToEnd(unittest.TestCase):
         self.assertFalse(lock.exists(), "reclaimed lock released after apply")
         fx.assert_invariants(self)
 
+    def test_apply_refuses_unrecorded_descendant(self):
+        """Reviewer P1 repro: a post-proposal scratch commit must not land."""
+        fx = self.fx
+        self.assertEqual(fx.prepare().returncode, 0)
+        self.resolve_in_scratch()
+        merged = out_json(run_script("propose.py", "--scratch", str(fx.scratch)))["merged_sha"]
+
+        # An unreviewed commit on top of the proposal, in the shared object db.
+        (fx.scratch / "sneaky.txt").write_text("never shown to the owner\n")
+        git(fx.scratch, "add", "-A", "--", ".", ":(exclude)workspace")
+        git(fx.scratch, "commit", "-q", "-m", "post-proposal descendant")
+        descendant = git(fx.scratch, "rev-parse", "HEAD").stdout.strip()
+        self.assertNotEqual(descendant, merged)
+
+        a = fx.apply(descendant)
+        self.assertEqual(a.returncode, 5, a.stdout + a.stderr)
+        self.assertEqual(out_json(a)["reason"], "proposal-mismatch")
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), fx.old_sha,
+                         "refused apply must leave the checkout untouched")
+        self.assertTrue(fx.pending.is_file())
+        self.assertTrue(fx.proposal.is_file())
+
+        # The recorded proposal itself still lands.
+        a2 = fx.apply(merged)
+        self.assertEqual(a2.returncode, 0, a2.stdout + a2.stderr)
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), merged)
+        self.assertFalse((fx.engine / "sneaky.txt").exists(),
+                         "the unreviewed descendant's content must not land")
+        self.assertFalse(fx.proposal.exists())
+        fx.assert_invariants(self)
+
     def test_apply_refuses_when_checkout_moved(self):
         fx = self.fx
         self.assertEqual(fx.prepare().returncode, 0)
@@ -279,6 +328,44 @@ class TestConflictEndToEnd(unittest.TestCase):
         self.assertEqual(p.returncode, 1)
         self.assertEqual(out_json(p)["reason"], "pending-stale")
         self.assertFalse(fx.scratch.exists(), "no scratch created for stale state")
+
+
+class TestGitResolution(unittest.TestCase):
+    """Installed-host runtime: sanitized PATH, possibly no system git at all."""
+
+    def setUp(self):
+        self.fx = EngineFixture(conflicting=True)
+        self.addCleanup(self.fx.cleanup)
+        self.real_git = shutil.which("git")
+        self.assertTrue(self.real_git)
+
+    def sanitized_env(self, **extra):
+        env = dict(os.environ)
+        env["PATH"] = ""
+        env.pop("SUTANDO_GIT", None)
+        env.update(extra)
+        return env
+
+    def test_no_git_is_clean_json_not_a_traceback(self):
+        p = self.fx.prepare(env=self.sanitized_env())
+        self.assertEqual(p.returncode, 6, p.stdout + p.stderr)
+        data = out_json(p)
+        self.assertEqual(data["status"], "no-git")
+        self.assertIn("SUTANDO_GIT", data["error"])
+        self.assertNotIn("Traceback", p.stderr)
+        self.assertFalse(self.fx.scratch.exists())
+
+    def test_sutando_git_env_works_without_path(self):
+        p = self.fx.prepare(env=self.sanitized_env(SUTANDO_GIT=self.real_git))
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+        self.assertEqual(out_json(p)["status"], "conflicts")
+
+    def test_git_flag_overrides(self):
+        p = run_script("prepare.py", "--pending", str(self.fx.pending),
+                       "--engine", str(self.fx.engine), "--scratch", str(self.fx.scratch),
+                       "--git", self.real_git, env=self.sanitized_env())
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+        self.assertEqual(out_json(p)["status"], "conflicts")
 
 
 if __name__ == "__main__":

--- a/tests/engine-conflict-resolve.test.py
+++ b/tests/engine-conflict-resolve.test.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Tests for skills/engine-conflict-resolve (prepare/propose/apply).
+
+Hermetic: local file:// upstream, every checkout under a scratch root whose
+path contains a space (mirrors ~/Library/Application Support/...). The engine
+fixture reproduces exactly what the desktop updater leaves behind after a
+conflicted merge: snapshot branch at HEAD, sparse !/workspace/ guard, live
+workspace symlink, ENGINE_UPDATE_PENDING.json in the updater's own shape.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "engine-conflict-resolve" / "scripts"
+
+# Hermetic git: no user/system config, deterministic identity for fixtures.
+os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+os.environ["GIT_CONFIG_SYSTEM"] = os.devnull
+FIXTURE_IDENT = {
+    "GIT_AUTHOR_NAME": "Fixture", "GIT_AUTHOR_EMAIL": "fixture@test",
+    "GIT_COMMITTER_NAME": "Fixture", "GIT_COMMITTER_EMAIL": "fixture@test",
+}
+
+
+def git(repo, *args, check=True):
+    env = dict(os.environ)
+    env.update(FIXTURE_IDENT)
+    proc = subprocess.run(["git", "-C", str(repo)] + list(args),
+                          capture_output=True, text=True, env=env)
+    if check and proc.returncode != 0:
+        raise AssertionError(f"git {args} failed: {proc.stderr}")
+    return proc
+
+
+def run_script(name, *args):
+    return subprocess.run([sys.executable, str(SCRIPTS / name)] + list(args),
+                          capture_output=True, text=True)
+
+
+def out_json(proc):
+    try:
+        return json.loads(proc.stdout)
+    except ValueError:
+        raise AssertionError(f"non-JSON stdout: {proc.stdout!r}\nstderr: {proc.stderr}")
+
+
+class EngineFixture:
+    """Post-conflict engine state, as update-engine-git.sh records it."""
+
+    def __init__(self, conflicting=True):
+        self.root = Path(tempfile.mkdtemp(prefix="engine conflict test "))
+        upstream = self.root / "upstream"
+        upstream.mkdir()
+        git(self.root, "init", "-q", "-b", "main", str(upstream))
+        (upstream / "src").mkdir()
+        (upstream / "src" / "app.txt").write_text("line1\nline2\nline3\nline4\nline5\n")
+        (upstream / "README.md").write_text("readme v1\n")
+        git(upstream, "add", "-A")
+        git(upstream, "commit", "-q", "-m", "V1")
+        self.v1 = git(upstream, "rev-parse", "HEAD").stdout.strip()
+        (upstream / "src" / "app.txt").write_text("line1\nline2\nRELEASE line3\nline4\nline5\n")
+        git(upstream, "commit", "-q", "-am", "V2 release")
+        self.new_sha = git(upstream, "rev-parse", "HEAD").stdout.strip()
+
+        engine_parent = self.root / "engine"
+        self.engine = engine_parent / "sutando"
+        git(self.root, "clone", "-q", f"file://{upstream}", str(self.engine))
+
+        # Local line: branch off V1 with a local change (conflicting or not).
+        # The updater's snapshot branch marks the same commit (named-branch case:
+        # the local line advances on merge, the snapshot ref stays frozen).
+        git(self.engine, "checkout", "-q", "-b", "local-line", self.v1)
+        if conflicting:
+            (self.engine / "src" / "app.txt").write_text("line1\nline2\nLOCAL line3\nline4\nline5\n")
+        else:
+            (self.engine / "README.md").write_text("readme v1\nlocal addition\n")
+        git(self.engine, "commit", "-q", "-am", "local work")
+        self.old_sha = git(self.engine, "rev-parse", "HEAD").stdout.strip()
+        git(self.engine, "branch", "local-changes-2026-08-10", self.old_sha)
+
+        # The attach-installed workspace guard + live workspace symlink.
+        git(self.engine, "config", "core.sparseCheckout", "true")
+        git(self.engine, "config", "core.sparseCheckoutCone", "false")
+        info = self.engine / ".git" / "info"
+        info.mkdir(parents=True, exist_ok=True)
+        (info / "sparse-checkout").write_text("/*\n!/workspace/\n")
+        self.live_ws = self.root / "live workspace"
+        self.live_ws.mkdir()
+        (self.live_ws / "user-state.txt").write_text("precious user state\n")
+        (self.engine / "workspace").symlink_to(self.live_ws)
+
+        self.pending = engine_parent / "ENGINE_UPDATE_PENDING.json"
+        self.pending.write_text(json.dumps({
+            "new_sha": self.new_sha,
+            "old_sha": self.old_sha,
+            "snapshot_branch": "local-changes-2026-08-10",
+            "conflicting_files": ["src/app.txt"] if conflicting else [],
+            "ts": "2026-08-10T00:00:00Z",
+            "deferred": False,
+        }, indent=2))
+        self.scratch = self.root / "scratch dir" / "wt"
+
+    def cleanup(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def prepare(self):
+        return run_script("prepare.py", "--pending", str(self.pending),
+                          "--engine", str(self.engine), "--scratch", str(self.scratch))
+
+    def apply(self, merged_sha):
+        return run_script("apply.py", "--pending", str(self.pending),
+                          "--engine", str(self.engine), "--merged-sha", merged_sha)
+
+    def assert_invariants(self, t):
+        ws = self.engine / "workspace"
+        t.assertTrue(ws.is_symlink(), "workspace symlink must survive")
+        t.assertEqual(os.path.realpath(ws), os.path.realpath(self.live_ws))
+        t.assertEqual((self.live_ws / "user-state.txt").read_text(), "precious user state\n")
+        t.assertEqual(git(self.engine, "rev-parse", "refs/heads/local-changes-2026-08-10").stdout.strip(),
+                      self.old_sha, "snapshot branch must still point at the user's work")
+
+
+class TestCleanMergeFastPath(unittest.TestCase):
+    def setUp(self):
+        self.fx = EngineFixture(conflicting=False)
+        self.addCleanup(self.fx.cleanup)
+
+    def test_clean_merge_prepare_then_apply(self):
+        fx = self.fx
+        p = fx.prepare()
+        self.assertEqual(p.returncode, 0, p.stderr)
+        data = out_json(p)
+        self.assertEqual(data["status"], "clean")
+        merged = data["merged_sha"]
+        self.assertTrue(merged)
+        # prepare never touches the live checkout
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), fx.old_sha)
+        self.assertTrue(fx.pending.is_file())
+
+        a = fx.apply(merged)
+        self.assertEqual(a.returncode, 0, a.stdout + a.stderr)
+        self.assertEqual(out_json(a)["status"], "applied")
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), merged)
+        self.assertFalse(fx.pending.exists(), "pending must be cleared")
+        self.assertNotIn(str(fx.scratch),
+                         git(fx.engine, "worktree", "list", "--porcelain").stdout)
+        self.assertFalse(fx.scratch.exists(), "scratch worktree removed")
+        fx.assert_invariants(self)
+
+
+class TestConflictEndToEnd(unittest.TestCase):
+    def setUp(self):
+        self.fx = EngineFixture(conflicting=True)
+        self.addCleanup(self.fx.cleanup)
+
+    def resolve_in_scratch(self):
+        """Simulate the agent's semantic resolution: keep both intents."""
+        f = self.fx.scratch / "src" / "app.txt"
+        self.assertIn("<<<<<<<", f.read_text(), "conflict markers are the agent's input")
+        f.write_text("line1\nline2\nRESOLVED line3 (local+release)\nline4\nline5\n")
+        git(self.fx.scratch, "add", "--", "src/app.txt")
+
+    def test_conflict_resolve_propose_apply(self):
+        fx = self.fx
+        p = fx.prepare()
+        self.assertEqual(p.returncode, 0, p.stderr)
+        data = out_json(p)
+        self.assertEqual(data["status"], "conflicts")
+        self.assertEqual(data["conflicting_files"], ["src/app.txt"])
+        self.assertEqual(os.path.realpath(data["scratch"]), os.path.realpath(fx.scratch))
+        # live checkout untouched, no merge state there
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), fx.old_sha)
+        self.assertEqual(git(fx.engine, "status", "--porcelain", "--", ".",
+                             ":(exclude)workspace").stdout.strip(), "")
+
+        # prepare re-run while the scratch merge is open: reused, same answer
+        p2 = fx.prepare()
+        self.assertEqual(p2.returncode, 0, p2.stderr)
+        self.assertEqual(out_json(p2)["status"], "conflicts")
+
+        self.resolve_in_scratch()
+        pr = run_script("propose.py", "--scratch", str(fx.scratch))
+        self.assertEqual(pr.returncode, 0, pr.stdout + pr.stderr)
+        prop = out_json(pr)
+        self.assertEqual(prop["status"], "proposed")
+        merged = prop["merged_sha"]
+        self.assertIn("src/app.txt", [f["path"] for f in prop["files"]])
+        self.assertTrue(any("src/app.txt" in l and "hand-merged" in l
+                            for l in prop["summary_lines"]), prop["summary_lines"])
+        self.assertIn("src/app.txt", prop["diffstat"])
+        # merge commit: parents are the snapshot tip and the release
+        parents = git(fx.scratch, "rev-list", "--parents", "-n", "1", merged).stdout.split()
+        self.assertEqual(set(parents[1:]), {fx.old_sha, fx.new_sha})
+        self.assertIn("Sutando <noreply@local>",
+                      git(fx.scratch, "log", "-1", "--format=%an <%ae>", merged).stdout)
+
+        a = fx.apply(merged)
+        self.assertEqual(a.returncode, 0, a.stdout + a.stderr)
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), merged)
+        self.assertEqual((fx.engine / "src" / "app.txt").read_text(),
+                         "line1\nline2\nRESOLVED line3 (local+release)\nline4\nline5\n")
+        self.assertFalse(fx.pending.exists())
+        self.assertFalse(fx.scratch.exists())
+        self.assertFalse((fx.engine.parent / "ENGINE_UPDATE_LOCK.d").exists(),
+                         "apply must release the updater lock")
+        fx.assert_invariants(self)
+
+    def test_propose_refuses_unmerged(self):
+        fx = self.fx
+        self.assertEqual(fx.prepare().returncode, 0)
+        pr = run_script("propose.py", "--scratch", str(fx.scratch))
+        self.assertEqual(pr.returncode, 2)
+        data = out_json(pr)
+        self.assertEqual(data["status"], "unmerged")
+        self.assertEqual(data["unmerged_paths"], ["src/app.txt"])
+
+    def test_apply_refuses_live_lock_then_reclaims_dead(self):
+        fx = self.fx
+        self.assertEqual(fx.prepare().returncode, 0)
+        self.resolve_in_scratch()
+        merged = out_json(run_script("propose.py", "--scratch", str(fx.scratch)))["merged_sha"]
+
+        lock = fx.engine.parent / "ENGINE_UPDATE_LOCK.d"
+        lock.mkdir()
+        (lock / "info").write_text(f"pid={os.getpid()}\nts=2026-08-10T00:00:00Z\n")
+        a = fx.apply(merged)
+        self.assertEqual(a.returncode, 3, a.stdout + a.stderr)
+        self.assertEqual(out_json(a)["reason"], "lock-busy")
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), fx.old_sha,
+                         "busy apply must not touch the checkout")
+        self.assertTrue(fx.pending.is_file())
+        self.assertTrue((lock / "info").is_file(), "holder's lock must be preserved")
+
+        # Same lock, but the recorded pid is dead → reclaimed with a log line.
+        dead = subprocess.Popen(["true"])
+        dead.wait()
+        (lock / "info").write_text(f"pid={dead.pid}\nts=2026-08-10T00:00:00Z\n")
+        a2 = fx.apply(merged)
+        self.assertEqual(a2.returncode, 0, a2.stdout + a2.stderr)
+        self.assertIn("reclaiming stale lock", a2.stderr)
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), merged)
+        self.assertFalse(lock.exists(), "reclaimed lock released after apply")
+        fx.assert_invariants(self)
+
+    def test_apply_refuses_when_checkout_moved(self):
+        fx = self.fx
+        self.assertEqual(fx.prepare().returncode, 0)
+        self.resolve_in_scratch()
+        merged = out_json(run_script("propose.py", "--scratch", str(fx.scratch)))["merged_sha"]
+
+        (fx.engine / "new-note.txt").write_text("moved after prepare\n")
+        git(fx.engine, "add", "-A", "--", ".", ":(exclude)workspace")
+        git(fx.engine, "commit", "-q", "-m", "user kept working")
+        moved_head = git(fx.engine, "rev-parse", "HEAD").stdout.strip()
+
+        a = fx.apply(merged)
+        self.assertEqual(a.returncode, 4, a.stdout + a.stderr)
+        self.assertEqual(out_json(a)["reason"], "checkout-moved")
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), moved_head,
+                         "refusal must leave the checkout exactly as found")
+        self.assertTrue(fx.pending.is_file(), "pending stays for the app to re-detect")
+        self.assertFalse((fx.engine.parent / "ENGINE_UPDATE_LOCK.d").exists(),
+                         "lock released on refusal")
+
+    def test_prepare_reports_stale_pending(self):
+        fx = self.fx
+        (fx.engine / "new-note.txt").write_text("stale\n")
+        git(fx.engine, "add", "-A", "--", ".", ":(exclude)workspace")
+        git(fx.engine, "commit", "-q", "-m", "moved before prepare")
+        p = fx.prepare()
+        self.assertEqual(p.returncode, 1)
+        self.assertEqual(out_json(p)["reason"], "pending-stale")
+        self.assertFalse(fx.scratch.exists(), "no scratch created for stale state")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/engine-conflict-resolve.test.py
+++ b/tests/engine-conflict-resolve.test.py
@@ -361,11 +361,29 @@ class TestGitResolution(unittest.TestCase):
         self.assertFalse(self.fx.scratch.exists())
 
     def test_bundled_engine_git_serves_the_whole_chain_without_path(self):
-        """Reviewer's control: desktop bundle ships engine/bin/git; PATH has none."""
+        """Bundle-derived resolution + GIT_EXEC_PATH propagation, PATH empty.
+
+        The exec-path half is asserted via env capture, not merge survival:
+        this host's git (like CI's apt git) bakes an absolute exec-path at
+        build time, so its internal self-execs survive PATH="" even WITHOUT
+        GIT_EXEC_PATH — a green merge here cannot by itself prove the
+        desktop-bundled git (whose self-execs DO need GIT_EXEC_PATH — the
+        'cannot run stash' failure from review) would work. The wrapper logs
+        every run_git child env; we assert each carries the exec-path derived
+        from the resolved binary.
+        """
         fx = self.fx
         bin_dir = fx.engine.parent / "bin"
         bin_dir.mkdir()
-        (bin_dir / "git").symlink_to(self.real_git)
+        envlog = fx.root / "git-env.log"
+        (bin_dir / "git").write_text(
+            "#!/bin/sh\n"
+            'echo "ARGS=$* EXEC=${GIT_EXEC_PATH:-UNSET}" >> "%s"\n'
+            'exec "%s" "$@"\n' % (envlog, self.real_git))
+        os.chmod(bin_dir / "git", 0o755)
+        expected_exec = subprocess.run([self.real_git, "--exec-path"],
+                                       capture_output=True, text=True).stdout.strip()
+        self.assertTrue(expected_exec)
         env = self.sanitized_env()
 
         p = fx.prepare(env=env)
@@ -386,6 +404,14 @@ class TestGitResolution(unittest.TestCase):
         self.assertEqual(a.returncode, 0, a.stdout + a.stderr)
         self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), merged)
         fx.assert_invariants(self)
+
+        # Every run_git child (all lines except each process's single
+        # --exec-path derivation probe) must carry the derived exec-path.
+        lines = envlog.read_text().splitlines()
+        work = [l for l in lines if l != "ARGS=--exec-path EXEC=UNSET"]
+        self.assertGreater(len(work), 10, lines)
+        bad = [l for l in work if f"EXEC={expected_exec}" not in l]
+        self.assertEqual(bad, [], "run_git child env missing/incorrect GIT_EXEC_PATH")
 
     def test_declared_env_works_without_path(self):
         p = self.fx.prepare(env=self.sanitized_env(ENGINE_CONFLICT_GIT=self.real_git))

--- a/tests/engine-conflict-resolve.test.py
+++ b/tests/engine-conflict-resolve.test.py
@@ -331,7 +331,12 @@ class TestConflictEndToEnd(unittest.TestCase):
 
 
 class TestGitResolution(unittest.TestCase):
-    """Installed-host runtime: sanitized PATH, possibly no system git at all."""
+    """Installed-host runtime: sanitized PATH, possibly no system git at all.
+
+    Contract (declared in the skill's manifest.json per skills/MANIFEST.md):
+    --git > $ENGINE_CONFLICT_GIT > manifest default > <engine-parent>/bin/git
+    (desktop #305 bundle) > src/git_binary.py > clean no-git JSON.
+    """
 
     def setUp(self):
         self.fx = EngineFixture(conflicting=True)
@@ -342,7 +347,7 @@ class TestGitResolution(unittest.TestCase):
     def sanitized_env(self, **extra):
         env = dict(os.environ)
         env["PATH"] = ""
-        env.pop("SUTANDO_GIT", None)
+        env.pop("ENGINE_CONFLICT_GIT", None)
         env.update(extra)
         return env
 
@@ -351,12 +356,39 @@ class TestGitResolution(unittest.TestCase):
         self.assertEqual(p.returncode, 6, p.stdout + p.stderr)
         data = out_json(p)
         self.assertEqual(data["status"], "no-git")
-        self.assertIn("SUTANDO_GIT", data["error"])
+        self.assertIn("ENGINE_CONFLICT_GIT", data["error"])
         self.assertNotIn("Traceback", p.stderr)
         self.assertFalse(self.fx.scratch.exists())
 
-    def test_sutando_git_env_works_without_path(self):
-        p = self.fx.prepare(env=self.sanitized_env(SUTANDO_GIT=self.real_git))
+    def test_bundled_engine_git_serves_the_whole_chain_without_path(self):
+        """Reviewer's control: desktop bundle ships engine/bin/git; PATH has none."""
+        fx = self.fx
+        bin_dir = fx.engine.parent / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "git").symlink_to(self.real_git)
+        env = self.sanitized_env()
+
+        p = fx.prepare(env=env)
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+        self.assertEqual(out_json(p)["status"], "conflicts")
+
+        f = fx.scratch / "src" / "app.txt"
+        f.write_text("line1\nline2\nRESOLVED line3 (local+release)\nline4\nline5\n")
+        git(fx.scratch, "add", "--", "src/app.txt")
+        # propose derives the engine (and thus bin/git) from the scratch's
+        # .git pointer file — no config, no PATH.
+        pr = run_script("propose.py", "--scratch", str(fx.scratch), env=env)
+        self.assertEqual(pr.returncode, 0, pr.stdout + pr.stderr)
+        merged = out_json(pr)["merged_sha"]
+
+        a = run_script("apply.py", "--pending", str(fx.pending),
+                       "--engine", str(fx.engine), "--merged-sha", merged, env=env)
+        self.assertEqual(a.returncode, 0, a.stdout + a.stderr)
+        self.assertEqual(git(fx.engine, "rev-parse", "HEAD").stdout.strip(), merged)
+        fx.assert_invariants(self)
+
+    def test_declared_env_works_without_path(self):
+        p = self.fx.prepare(env=self.sanitized_env(ENGINE_CONFLICT_GIT=self.real_git))
         self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
         self.assertEqual(out_json(p)["status"], "conflicts")
 
@@ -366,6 +398,89 @@ class TestGitResolution(unittest.TestCase):
                        "--git", self.real_git, env=self.sanitized_env())
         self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
         self.assertEqual(out_json(p)["status"], "conflicts")
+
+    def test_configured_but_broken_git_is_an_error_not_a_fallthrough(self):
+        p = self.fx.prepare(env=self.sanitized_env(ENGINE_CONFLICT_GIT="/nonexistent/git"))
+        self.assertEqual(p.returncode, 6, p.stdout + p.stderr)
+        data = out_json(p)
+        self.assertEqual(data["status"], "no-git")
+        self.assertIn("/nonexistent/git", data["error"])
+
+
+class TestProposalDelivery(unittest.TestCase):
+    """deliver.py controls: declared room or deterministic fallback — never a guess."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="engine deliver test "))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.msg = self.root / "proposal.txt"
+        self.msg.write_text("merged_sha abc123\nsrc/app.txt: hand-merged\n")
+        self.record = self.root / "gateway-record.json"
+        self.pq = self.root / "host dir" / "pending-questions.md"
+
+    def stub_room_ops(self, status=200, explode=False):
+        d = self.root / "stub room-ops"
+        d.mkdir(exist_ok=True)
+        body = "raise RuntimeError('gateway down')" if explode else (
+            "with open(%r, 'w') as f:\n"
+            "        json.dump({'url': url, 'payload': payload}, f)\n"
+            "    return (%d, {})" % (str(self.record), status))
+        (d / "_gateway.py").write_text(
+            "import json\n"
+            "def gateway():\n"
+            "    return ('http://stub.local', {'Authorization': 'Bearer x'})\n"
+            "def http_json(method, url, headers, payload):\n"
+            "    %s\n" % body)
+        return d
+
+    def deliver(self, *args, env_room=None):
+        env = dict(os.environ)
+        env["PATH"] = ""  # no osascript: notification tier degrades cleanly
+        env.pop("ENGINE_CONFLICT_NOTIFY_ROOM", None)
+        if env_room is not None:
+            env["ENGINE_CONFLICT_NOTIFY_ROOM"] = env_room
+        return run_script("deliver.py", "--message-file", str(self.msg),
+                          "--pending-questions", str(self.pq), *args, env=env)
+
+    def test_no_room_never_guesses_and_falls_back(self):
+        self.pq.parent.mkdir(parents=True)
+        self.pq.write_text("## Older question\nbody\n\n# Resolved\n## done q\n")
+        d = self.deliver("--room-ops-dir", str(self.stub_room_ops()))
+        self.assertEqual(d.returncode, 0, d.stdout + d.stderr)
+        out = out_json(d)
+        self.assertEqual(out["status"], "fallback")
+        self.assertEqual(out["reason"], "no-room")
+        self.assertFalse(self.record.exists(), "no configured room -> no post, ever")
+        text = self.pq.read_text()
+        self.assertIn("Engine update conflict", text)
+        self.assertLess(text.index("Engine update conflict"), text.index("# Resolved"),
+                        "new question must be inserted ABOVE the Resolved divider")
+
+    def test_post_failure_always_reaches_the_fallback(self):
+        for kwargs, want_reason in (({"status": 500}, "http-500"),
+                                    ({"explode": True}, "post-failed")):
+            if self.pq.exists():
+                self.pq.unlink()
+            d = self.deliver("--room", "!owner-room:stub.local",
+                             "--room-ops-dir", str(self.stub_room_ops(**kwargs)))
+            self.assertEqual(d.returncode, 0, d.stdout + d.stderr)
+            out = out_json(d)
+            self.assertEqual(out["status"], "fallback")
+            self.assertIn(want_reason, out["reason"])
+            self.assertTrue(self.pq.is_file(), "failed send must still reach the owner")
+
+    def test_declared_room_posts_via_gateway(self):
+        d = self.deliver("--room-ops-dir", str(self.stub_room_ops(status=200)),
+                         env_room="!owner-room:stub.local")
+        self.assertEqual(d.returncode, 0, d.stdout + d.stderr)
+        out = out_json(d)
+        self.assertEqual(out["status"], "posted")
+        self.assertEqual(out["room"], "!owner-room:stub.local")
+        rec = json.loads(self.record.read_text())
+        self.assertEqual(rec["payload"]["op"], "message")
+        self.assertEqual(rec["payload"]["room_id"], "!owner-room:stub.local")
+        self.assertIn("merged_sha abc123", rec["payload"]["body"])
+        self.assertFalse(self.pq.exists(), "successful post needs no fallback")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed, and why

**Ask the running Sutando to pull the latest main — and when your local changes conflict with the update, ask Sutando to resolve the merge.** That is the capability this PR adds: any user or developer running Sutando from a git checkout gets a safe conflicted-update path — reproduce the merge in a scratch worktree, let the agent resolve the conflicts there, propose the resolution, and land it in the live checkout only after explicit confirmation. Never the live checkout first, never without a confirmed proposal.

The **first producer** of the pending state (and the first UI entry point) is the desktop app's engine updater: ag2-space/ag2space-cinny-desktop#306 (git-aware updater: snapshot-first merge, conflict → abort + `ENGINE_UPDATE_PENDING.json`) and ag2-space/ag2space-cinny-desktop#307 (tray/dialog "Resolve with Sutando" → writes `tasks/task-engine-conflict-<epoch>.txt` naming the pending file and the engine checkout). Until now that task had no consumer protocol — this PR is it. The scripts take the pending-file shape as input from any producer; a **ref-based entry point** (pull/merge any two refs, no desktop pending file needed) plus a **chat-facing command** for OSS users are the queued follow-up.

## Review round 3 addressed (head `28e28831`)

- **Blocking (bassilkhilo-ag2, formal REQUEST_CHANGES at `96fbb764`) — GIT_EXEC_PATH.** Git's merge machinery re-execs itself as a separate subprocess; under an empty PATH that internal exec fails ("cannot run stash") on the desktop-bundled git — the feature's actual target — while apt/CLT gits mask the gap with a build-time absolute exec-path (why CI stayed green). `resolve_git()` now derives the exec-path from the resolved binary (`<git> --exec-path`, cached alongside it; failed derivation degrades gracefully and is named in the launch-error message), and `run_git()` sets `GIT_EXEC_PATH` in every child env. `test_bundled_engine_git_serves_the_whole_chain_without_path` no longer overclaims: the bundled git is a logging wrapper and the test **asserts via env capture** that every `run_git` child carries the derived exec-path, with the CI-vs-desktop gap stated in its docstring.
- **Nits (both reviewers):** the four stale `SUTANDO_GIT` strings (`--git` help text x3 + the `run_git` launch-error message) now name `ENGINE_CONFLICT_GIT` (and no longer claim PATH participates in resolution); `_remove_lock` tolerates a concurrently-reclaimed lock dir (`FileNotFoundError` == already gone, matching the updater's `rm -rf` semantics).

(The branch also carries a clean merge of current `main`, `69aaebd1` — no skill files touched.)

## Review round 2 addressed (heads `1a554364` + `96fbb764`)

- **Blocker A — deterministic, owner-only proposal delivery.** New `scripts/deliver.py`: the destination room resolves ONLY from declared config — `--room` > `$ENGINE_CONFLICT_NOTIFY_ROOM` > the skill's `manifest.json` `config` default (skills/MANIFEST.md precedence) — and is documented owner-only. It never infers a "last active" room (no activity-state code path exists). A resolved room posts `op:message` through the `agent-room-ops` gateway module; **no room configured, or any failed send** (non-2xx, exception, gateway unconfigured/absent) always executes the Pending-decisions fallback: macOS notification + a question section inserted **above the `# Resolved` divider** of the per-host `pending-questions.md` using the shared `src/pending_questions_md.py` locator (no private regex). SKILL.md step 3 routes delivery through deliver.py and requires the task result file to state which channel ran. Controls: `test_no_room_never_guesses_and_falls_back` (also pins divider-relative insertion and that the gateway stub is never called), `test_post_failure_always_reaches_the_fallback` (http-500 and raising-gateway variants), `test_declared_room_posts_via_gateway` (positive control via stub gateway, asserts the exact `op:message` payload).
- **Blocker B — `$SUTANDO_GIT` removed; git is a declared config contract.** New `manifest.json` (config-only, per skills/MANIFEST.md) declares `ENGINE_CONFLICT_GIT` and `ENGINE_CONFLICT_NOTIFY_ROOM`. Resolution: `--git` CLI > `$ENGINE_CONFLICT_GIT` (the manifest-declared spelling) > manifest default > **derived `<engine-parent>/bin/git`** from the already-required engine path (desktop #305's bundled git; `propose.py` derives the engine from the scratch's `.git` pointer file, so the whole chain needs zero configuration on a desktop host) > the repo's `src/git_binary.py` contract (first non-stub PATH git; system git only when CLT verifiably installed — never pops the installer dialog) > `{"status": "no-git"}` exit 6, never a traceback. A configured-but-broken value is an error, not a fall-through. Tests: `test_bundled_engine_git_serves_the_whole_chain_without_path` (reviewer's control: PATH empty, bundle git only, full prepare→propose→apply), `test_declared_env_works_without_path`, `test_git_flag_overrides`, `test_no_git_is_clean_json_not_a_traceback`, `test_configured_but_broken_git_is_an_error_not_a_fallthrough`.

## Review round 1 addressed (head `46495276`)

Both blocking findings from the first 2026-08-11 review (Qingyun's Personal Codex) were fixed at `46495276` and verified by the reviewer; kept for the record.

- **P1-1 — apply is now bound to the proposal the owner confirmed.** `propose.py` atomically persists `ENGINE_CONFLICT_PROPOSAL.json` (temp+rename, beside the pending file) with `{merged_sha, old_sha, new_sha, snapshot_branch, scratch, ts}`; re-proposing overwrites it atomically. `apply.py` refuses — distinct exit 5, `proposal-missing` / `proposal-mismatch` JSON — unless the record exists, its identity fields match the live pending file, **and** `--merged-sha` resolves to exactly the recorded commit. The reviewer's repro (post-proposal descendant committed in the scratch, handed to apply) is now refused with the checkout untouched; the record is cleared together with the pending file on success. Regression test: `test_apply_refuses_unrecorded_descendant`; the clean-path test additionally pins `proposal-missing` (apply before any propose refuses even a valid sha).
- **P1-2 — no unqualified system git.** `_common.resolve_git()` resolves the trusted git once: `--git` flag > `$SUTANDO_GIT` > `PATH`; nothing usable → `{"status": "no-git", …}` machine JSON on stdout with guidance naming `SUTANDO_GIT`, distinct exit 6, never a traceback (launch failure of a resolved binary is caught the same way). SKILL.md documents passing the desktop bundle's own `<engine-parent>/bin/git` for desktop tasks — the same binary the attach/updater scripts use under the app's hardened PATH. Tests: `test_no_git_is_clean_json_not_a_traceback` (PATH empty, no override → clean JSON), `test_sutando_git_env_works_without_path`, `test_git_flag_overrides`.

New self-contained skill `skills/engine-conflict-resolve/` (nothing wired into `src/` — per the architecture decision guide, a self-contained feature is a skill; the task body already reaches the core through the normal task bridge):

- **`scripts/prepare.py`** — validates the pending JSON against the live checkout (HEAD must equal the snapshot tip == `old_sha`, tree clean with the updater's own `:(exclude)workspace` pathspec; anything else → explicit `pending-stale` error JSON, nothing created). Creates a **scratch git worktree** off the snapshot tip (`git worktree add` — shared object db, no re-fetch) and re-runs the conflicted merge **there**. Clean replay → commits and reports `merged_sha` immediately. Conflicts → reports `conflicting_files` for the agent to resolve in the scratch. Never touches the live checkout's index/worktree. Idempotent: an existing scratch for the same merge is reused; a mismatched one is refused. The scratch gets its own per-worktree `/*` + `!/workspace/` sparse guard (worktrees don't inherit the pattern file).
- **`scripts/propose.py`** — refuses (exit 2, listing them) while unmerged paths remain; commits the resolved merge as `Sutando <noreply@local>`; prints `{merged_sha, files[], diffstat, summary_lines[]}` where each conflicted file gets a mechanical verdict (kept your local version / took the release version / hand-merged) computed by blob comparison against both parents.
- **`scripts/apply.py`** — the guarded landing, run **only after the owner explicitly confirms**:
  1. takes the **same mkdir lock the desktop updater uses** (`<engine-parent>/ENGINE_UPDATE_LOCK.d`, `info` file with `pid=`/`ts=` lines — same shape as `update-engine-git.sh`): live-pid holder → busy exit 3 without touching anything; dead-pid lock reclaimed with a log line; a pid-less lock younger than 10 s treated as busy (holder between mkdir and info-write). The two mutators can never interleave.
  2. re-asserts HEAD still equals the snapshot tip recorded in pending and the tree is clean (else exit 4, checkout untouched, pending left for the app to re-detect);
  3. requires the `ENGINE_CONFLICT_PROPOSAL.json` record: it must exist, match the live pending state's identity fields, and `--merged-sha` must be exactly the recorded commit (else exit 5 — see the P1-1 section);
  4. verifies `merged_sha` is a **descendant of HEAD** (`git merge-base --is-ancestor`) and **contains the release sha** (wrong-proposal guard);
  5. re-asserts the `!/workspace/` sparse guard exactly like the updater's `ensure_workspace_guard`, then `git merge --ff-only <merged_sha>` — a pure ref fast-forward that provably cannot materialize into the excluded workspace path;
  6. unlinks the pending file + proposal record, removes the scratch worktree, releases the lock (finally-guaranteed).
- **`SKILL.md`** — the durable agent protocol: prepare → resolve semantically in the scratch → propose → **write the proposal as the task result** so the owner sees it in the originating channel → **WAIT for an explicit follow-up "apply"** → only then apply. Never auto-apply; a stale pending is reported back, never improvised around.
- **`tests/engine-conflict-resolve.test.py`** — hermetic suite (below).

Every path is passed as a subprocess list argument (no shell), and the whole suite runs under a scratch root **containing spaces** (`…/engine conflict test …/scratch dir/…`), matching the real `~/Library/Application Support/space.ag2.app/engine` install path.

## What to look at first

`skills/engine-conflict-resolve/scripts/apply.py` (the only file that can touch the live checkout — the guard order is the review surface), then `_common.py:acquire_lock` (byte-level mirror of the updater's lock contract), then the test's `EngineFixture` (reproduces exactly what `update-engine-git.sh` leaves behind after an aborted conflicted merge: snapshot branch, sparse guard, live workspace symlink, updater-shaped pending JSON).

## Confirm-before-apply contract

The desktop task body says "Do not modify the live checkout until the user confirms"; this skill enforces it structurally, not just by instruction: `prepare`/`propose` operate exclusively on the scratch worktree, and `apply` is a separate script the agent is directed to run only on an explicit owner follow-up. Even a misbehaving agent running `apply` early cannot corrupt anything — it still lands only a fast-forward to a verified descendant behind the updater's lock and staleness re-asserts, and any drift refuses with the checkout untouched.

## No reply channel on `desktop-app` tasks (answers a review nit on #307)

The desktop handoff task's `source` is `desktop-app` — **no bridge polls results for that source**, so a result file alone would be a dead letter and the confirm loop would never start. SKILL.md step 3 therefore requires BOTH: write the task result file (protocol hygiene — dashboard, result-watcher, and timeout logic key off it) **and** actively surface the proposal via `scripts/deliver.py` — declared owner-only room (`ENGINE_CONFLICT_NOTIFY_ROOM`, see the round-2 section above) or the deterministic notification + per-host `pending-questions.md` fallback, with the channel used named in the result file. Step 4 states explicitly that the owner's reply will arrive on some other channel; the desktop path is one-way.

## Documentation

N/A — skills are self-documenting via `SKILL.md` (the pattern for every existing skill); `docs/catalog.json` has no per-skill canonical documents.

## Before/after evidence

At the parent commit (`fd04a046`, current `origin/main`) the skill does not exist — the desktop's `task-engine-conflict-*` task has no consumer protocol:

```
$ git show origin/main:skills/engine-conflict-resolve/SKILL.md
fatal: path 'skills/engine-conflict-resolve/SKILL.md' exists on disk, but not in 'origin/main'
```

At HEAD (`1a554364`):

```
$ python3 tests/engine-conflict-resolve.test.py
test_clean_merge_prepare_then_apply (__main__.TestCleanMergeFastPath.test_clean_merge_prepare_then_apply) ... ok
test_apply_refuses_live_lock_then_reclaims_dead (__main__.TestConflictEndToEnd.test_apply_refuses_live_lock_then_reclaims_dead) ... ok
test_apply_refuses_unrecorded_descendant (__main__.TestConflictEndToEnd.test_apply_refuses_unrecorded_descendant)
Reviewer P1 repro: a post-proposal scratch commit must not land. ... ok
test_apply_refuses_when_checkout_moved (__main__.TestConflictEndToEnd.test_apply_refuses_when_checkout_moved) ... ok
test_conflict_resolve_propose_apply (__main__.TestConflictEndToEnd.test_conflict_resolve_propose_apply) ... ok
test_prepare_reports_stale_pending (__main__.TestConflictEndToEnd.test_prepare_reports_stale_pending) ... ok
test_propose_refuses_unmerged (__main__.TestConflictEndToEnd.test_propose_refuses_unmerged) ... ok
test_bundled_engine_git_serves_the_whole_chain_without_path (__main__.TestGitResolution.test_bundled_engine_git_serves_the_whole_chain_without_path)
Reviewer's control: desktop bundle ships engine/bin/git; PATH has none. ... ok
test_configured_but_broken_git_is_an_error_not_a_fallthrough (__main__.TestGitResolution.test_configured_but_broken_git_is_an_error_not_a_fallthrough) ... ok
test_declared_env_works_without_path (__main__.TestGitResolution.test_declared_env_works_without_path) ... ok
test_git_flag_overrides (__main__.TestGitResolution.test_git_flag_overrides) ... ok
test_no_git_is_clean_json_not_a_traceback (__main__.TestGitResolution.test_no_git_is_clean_json_not_a_traceback) ... ok
test_declared_room_posts_via_gateway (__main__.TestProposalDelivery.test_declared_room_posts_via_gateway) ... ok
test_no_room_never_guesses_and_falls_back (__main__.TestProposalDelivery.test_no_room_never_guesses_and_falls_back) ... ok
test_post_failure_always_reaches_the_fallback (__main__.TestProposalDelivery.test_post_failure_always_reaches_the_fallback) ... ok

----------------------------------------------------------------------
Ran 15 tests in 30.279s

OK
```

What the cases pin, beyond the happy paths: the conflict end-to-end asserts the merge commit's parents are exactly {snapshot tip, release sha}, the author is `Sutando <noreply@local>`, the resolved content lands byte-exact in the live checkout, the **workspace symlink and its target survive**, the **snapshot branch still points at the user's work**, pending is cleared, the scratch worktree is gone, and the lock is released. The refusal cases assert the checkout is left *exactly* as found (including a live-pid lock holder's `info` file being preserved, and the pending file surviving so the app can re-detect).

`bash scripts/review-checks.sh` over the diff: `PASS (hardcoded-paths clean)`.

## What tests did you run?

- `python3 tests/engine-conflict-resolve.test.py` — 15/15 OK at `1a554364` (output above; hermetic, local `file://` upstream, space-containing paths, no network). Also `python3 -m py_compile` over all seven files, `ruff check` (clean), and `git diff --check origin/main...HEAD` (clean), per the reviewer's validation list.
- `npm run test:py` (run at the initial head) — this suite passed inside the full-suite run; the run then stops at `tests/hostname-resolution-resilience.test.py` (`'Qingyuns-MacBook-Pro-2200' != 'QingyunsMBP2200'`) — that file is byte-identical to `origin/main` (`git diff origin/main HEAD -- tests/hostname-resolution-resilience.test.py` → empty) and fails from this host's scutil LocalHostName, unrelated to this PR (and the stop-at-first-failure runner behavior is #2755's subject). 227 test files ran up to that point with no other failure.
- Not a bridge/network/delivery-loop/startup path — the skill is invoked on demand against paths named in the task file, so there is no resident service to restart; the hermetic suite exercises the shipped scripts end-to-end (subprocess invocations of the real files, not copies).

## Testing with the Air today

The producing desktop side (#306/#307) is not merged yet, so the full tray-button loop needs a #307 build. The skill itself can be exercised on the Air right now against a **manufactured conflict** in the real installed bundle — attach ships in the current app (#304, merged):

```bash
ENG="$HOME/Library/Application Support/space.ag2.app/engine"
bash "$ENG/attach-engine-git.sh"          # no-op if already attached

cd "$ENG/sutando"
NEW="$(git rev-parse HEAD)"               # treat the current release as "the update"
git checkout -q -b conflict-test HEAD~5   # rewind the local line
F="$(git diff --name-only HEAD "$NEW" | grep -v '^workspace/' | head -1)"
printf 'LOCAL CONFLICT TEST\n' > "$F"     # whole-file rewrite guarantees overlap
git add -- "$F" && git commit -m "manufactured local edit"

# Write the pending state in the updater's own shape (the #306 updater would
# normally write this after aborting the merge):
python3 - "$NEW" "$(git rev-parse HEAD)" "$F" > "$ENG/ENGINE_UPDATE_PENDING.json" <<'EOF'
import json, sys, time
print(json.dumps({"new_sha": sys.argv[1], "old_sha": sys.argv[2],
  "snapshot_branch": "conflict-test", "conflicting_files": [sys.argv[3]],
  "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "deferred": False}, indent=2))
EOF
```

Then, from the sutando checkout with this branch:

```bash
python3 skills/engine-conflict-resolve/scripts/prepare.py \
  --pending "$ENG/ENGINE_UPDATE_PENDING.json" --engine "$ENG/sutando"
#   → {"status": "conflicts", "scratch": …, "conflicting_files": […]}
# resolve in the scratch (edit the file, then `git -C "<scratch>" add -- <file>`)
python3 skills/engine-conflict-resolve/scripts/propose.py --scratch "<scratch>"
python3 skills/engine-conflict-resolve/scripts/apply.py \
  --pending "$ENG/ENGINE_UPDATE_PENDING.json" --engine "$ENG/sutando" \
  --merged-sha "<merged_sha from propose>"
```

Cleanup after the experiment: `git -C "$ENG/sutando" checkout -f "$NEW" && git -C "$ENG/sutando" branch -D conflict-test`.

Once #306/#307 land in a build, the same three commands are what SKILL.md directs the core to run when the tray button writes the real `task-engine-conflict-*` task — with `--pending`/`--engine` taken verbatim from the task body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


