### PR TITLE
docs(cla): the recheck comment is inert here, and the write fails after a 200

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,11 +212,30 @@ The goal of this phase is to provide evidence the maintainer can verify quickly.
 
    **When to expect it.** `license/cla` is a *commit status*, so it binds to one SHA. **Every push gives the PR a new head SHA that carries no CLA status**, which is what [`.github/workflows/cla-recheck-on-push.yml`](.github/workflows/cla-recheck-on-push.yml) exists to repair — it comments the `@cla-assistant check` trigger on each `synchronize`. That repair is not reliable, so a PR you have pushed to can end up permanently short of a required check.
 
-   **The model the evidence supports: the status is SHA-bound, and its delivery can fail on `opened` just as it can on the `synchronize` repair.** A push guarantees you need a *fresh* delivery, so pushed PRs are over-represented among the missing — but a push is not required for the status to be absent, and **close+reopen is a retry of a flaky delivery, not a push-specific fix.**
+   **The model the evidence supports: the status is SHA-bound, and the write can fail *after* CLA-Assistant has received and acknowledged the event.** A push guarantees you need a *fresh* delivery, so pushed PRs are over-represented among the missing — but a push is not required for the status to be absent, and **close+reopen is a retry, not a push-specific fix.**
+
+   The webhook delivery log distinguishes "the event never arrived" from "it arrived and nothing was written", and it is the second one. Twelve `pull_request/synchronize` deliveries on 2026-08-11, each mapped to its PR through the delivery payload and cross-referenced against whether the head carries a status:
+
+   ```
+   all 12:  HTTP 200,  body 'OK - Will be working on it'
+     9 -> license/cla written        3 -> never written   (#2342, #2785, #2790)
+   ```
+
+   Identical request, identical acknowledgement, different outcome — so nothing observable on the GitHub side predicts it, which is why author email, committer identity, push recency and update-branch-button-vs-local all fail as explanations when tested against the full population. Read the log yourself with `gh api "repos/<owner>/<repo>/hooks/<id>/deliveries?per_page=60"`, then `.../deliveries/<delivery-id>` for the payload (`.number`, `.pull_request.head.sha`). Note `&page=N` is silently ignored there — the endpoint is cursor-paginated and returns an empty list, which reads exactly like an empty log.
 
    Three PRs on 2026-08-04 — `#2605`, `#2606`, `#2607` — were opened directly on their final head, had no push before the status went missing, and still had no `license/cla`. `#2607` is the sharpest case and is easy to measure wrong: it *was* pushed later, at `05:07`, but its close+reopen recovery happened at `04:50`, so the absence pre-dated any push. Comparing the head commit's date to the PR's creation date reports it as "pushed after open" and hides that entirely — read the issue **timeline** (`committed` / `closed` / `reopened` events in order), not the current head.
 
-   **Do not rely on the `@cla-assistant check` comment**, even though it is the documented recheck trigger. Of the 99 open non-draft PRs on 2026-08-04, **91 had the status and 8 did not**; all 8 had been pushed since opening, and they span eight days (2026-07-27 to 2026-08-04), so this is not a time window. Read that 8 as a *snapshot of what was still broken*, not as a population of causes: PRs recovered earlier the same day had already left the set, and those are exactly the ones that show `opened`-side failure.
+   **The `@cla-assistant check` comment cannot work on this repo — it is inert, not merely unreliable.** The CLA webhook subscribes to exactly two events, and `issue_comment` is not one of them, so a comment never reaches the service at all:
+
+   ```
+   $ gh api repos/<owner>/<repo>/hooks/<id> --jq '.config.url, (.events|join(", "))'
+   https://cla-assistant.io/github/webhook/sutando
+   merge_group, pull_request
+   ```
+
+   The distinction matters because "unreliable" invites a retry and "inert" ends it: no number of trigger comments, from a workflow or a human, can produce a status. Use a fresh head or close+reopen instead — `pull_request/reopened` acknowledges at 200, while `closed` returns 204 and is discarded, so the reopen is the half that does the work. (`.github/workflows/cla-recheck-on-push.yml` posts that comment on every `synchronize` and reports success every run; it is tracked separately as an open issue, since removing versus reworking it is a maintainer call.)
+
+   This section previously said only "do not rely on" the comment, which was right about the behaviour and silent about the cause. Of the 99 open non-draft PRs on 2026-08-04, **91 had the status and 8 did not**; all 8 had been pushed since opening, and they span eight days (2026-07-27 to 2026-08-04), so this is not a time window. Read that 8 as a *snapshot of what was still broken*, not as a population of causes: PRs recovered earlier the same day had already left the set, and those are exactly the ones that show `opened`-side failure.
 
    The practical consequence is the same either way: the trigger comment is neither sufficient nor necessary, and the check below is what tells you where you actually stand. A manual trigger comment on `#2605` did not restore it; close+reopen did, and its two approvals survived. Four PRs were recovered this way across two authors.
 3. Address every substantive review-thread comment before merge: fixed in a subsequent commit, replied with rationale for declining, or explicitly deferred to a follow-up issue.


### PR DESCRIPTION
## What

Two statements in `CONTRIBUTING.md`'s CLA section are contradicted by the webhook delivery log. Docs only.

## Why — evidence, not description

### 1. `@cla-assistant check` is inert here, not unreliable

The section said "do not rely on" it, which is right about the behaviour and silent about the cause. The cause is that it cannot arrive:

```
$ gh api repos/sonichi/sutando/hooks/624469452 --jq '.config.url, (.events|join(", "))'
https://cla-assistant.io/github/webhook/sutando
merge_group, pull_request
```

`issue_comment` is not subscribed, and that is the only CLA hook on the repo. The distinction is operational: "unreliable" invites a retry, "inert" ends it. Three separate retries this week — the recheck workflow's automatic comments, a manual one from a human account on #2763, and one on #2785 — could not have reached the service at all.

### 2. Delivery succeeds; the write fails after the acknowledgement

The section's model was that *delivery* can fail. Measured 2026-08-11 — 12 `pull_request/synchronize` deliveries, each mapped to its PR through the delivery payload, cross-referenced against whether that exact head carries a status:

```
    PR   delivered_at                 code  head       outcome          response body
  1789   2026-08-11T07:57:01.901Z      200  67c5ff2a   STATUS-PRESENT   'OK - Will be working on it'
  2324   2026-08-11T02:22:22.043Z      200  3a7a3e77   STATUS-PRESENT   'OK - Will be working on it'
  2342   2026-08-11T07:29:37.763Z      200  8c3b3f38   STATUS-ABSENT    'OK - Will be working on it'
  2417   2026-08-11T04:46:52.622Z      200  dda9de73   STATUS-PRESENT   'OK - Will be working on it'
  2771   2026-08-11T04:11:13.600Z      200  6557631d   STATUS-PRESENT   'OK - Will be working on it'
  2777   2026-08-10T22:57:29.887Z      200  c868b21a   STATUS-PRESENT   'OK - Will be working on it'
  2785   2026-08-11T04:13:20.086Z      200  6895bf03   STATUS-ABSENT    'OK - Will be working on it'
  2786   2026-08-11T04:56:25.250Z      200  082bccd7   STATUS-PRESENT   'OK - Will be working on it'
  2787   2026-08-11T06:07:37.153Z      200  688e62d2   STATUS-PRESENT   'OK - Will be working on it'
  2788   2026-08-11T05:00:24.171Z      200  0d977898   STATUS-PRESENT   'OK - Will be working on it'
  2789   2026-08-11T04:41:59.131Z      200  8aa8cff7   STATUS-PRESENT   'OK - Will be working on it'
  2790   2026-08-11T07:57:22.582Z      200  69aaebd1   STATUS-ABSENT    'OK - Will be working on it'
```

Identical request, identical acknowledgement, different outcome. That also explains why every request-side hypothesis dies against the full population — author email, committer identity, push recency, update-branch-button vs local push were each tested and each has PRs on both sides. The discriminator is not in the request.

Reproduce:

```bash
gh api "repos/sonichi/sutando/hooks/624469452/deliveries?per_page=60"
gh api "repos/sonichi/sutando/hooks/624469452/deliveries/<id>"   # .number, .pull_request.head.sha
```

`&page=N` is silently ignored on that endpoint (cursor-paginated) and returns an empty list that reads exactly like an empty log — that produced a false "0 deliveries" before I probed `per_page` on its own, so the note is in the doc.

## Scope

**Deliberately not touching `:213`'s description of `cla-recheck-on-push.yml`.** That workflow is inert for the same reason, but remove-versus-rework is a maintainer call tracked in #2791, and the doc line should follow whichever is picked. This PR only adds a parenthetical pointing at it.

## What is NOT claimed

- No cause for the missing statuses. The failure is inside cla-assistant.io after a 200; nothing here explains why.
- The remedy guidance is unchanged — `:207`'s close+reopen was already correct. This adds *why* it works (`reopened` acks at 200; `closed` returns 204 and is discarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
