### PR TITLE
fix(quota-tracker): credential proxy must never inject a known-expired token — pass through or fail loud, reload on 401

### DIFF
--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -124,12 +124,30 @@ function readCredFromService(service: string): StoredClaudeOAuth | null {
 	}
 }
 
+// All keychain candidates that currently hold a credential, scoped item first.
+function readCredCandidates(): StoredClaudeOAuth[] {
+	return keychainServiceCandidates()
+		.map(readCredFromService)
+		.filter((s): s is StoredClaudeOAuth => s !== null);
+}
+
 function readCred(): StoredClaudeOAuth | null {
-	for (const service of keychainServiceCandidates()) {
-		const stored = readCredFromService(service);
-		if (stored) return stored;
+	return readCredCandidates()[0] ?? null;
+}
+
+// Pure: pick the credential to serve. First candidate whose token is usable
+// wins (scoped-first preference preserved); if none is usable, fall back to
+// the first present so degraded handling (pass-through / fail-fast) sees it.
+// A dead scoped item must not eclipse a fresh /login in the default item.
+export function selectCred(
+	candidates: StoredClaudeOAuth[],
+	now: number,
+	rejectedToken: string | null,
+): StoredClaudeOAuth | null {
+	for (const c of candidates) {
+		if (classifyCredential(c.oauth, now, rejectedToken) === 'ok') return c;
 	}
-	return null;
+	return candidates[0] ?? null;
 }
 
 // Atomically write the cred back to the keychain. Returns true ONLY after a
@@ -285,7 +303,7 @@ export function authUnavailableBody(verdict: 'expired' | 'rejected'): string {
 // Injectable seams (keychain, refresh, upstream, clock) so the proxy's failure
 // semantics are testable hermetically; defaults are the production bindings.
 export interface ProxyDeps {
-	readCred: () => StoredClaudeOAuth | null;
+	readCredCandidates: () => StoredClaudeOAuth[];
 	writeCred: (service: string, oauth: ClaudeOAuth) => boolean;
 	refreshAccessToken: (oauth: ClaudeOAuth) => Promise<ClaudeOAuth | null>;
 	request: typeof httpsRequest;
@@ -297,7 +315,7 @@ export interface ProxyDeps {
 
 export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 	const deps: ProxyDeps = {
-		readCred,
+		readCredCandidates,
 		writeCred,
 		refreshAccessToken,
 		request: httpsRequest,
@@ -344,8 +362,10 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 
 	// Re-read the keychain (every call — no cache, so /login lands within one
 	// request) and refresh first when at/near expiry or upstream-rejected.
+	// selectCred scans ALL candidate items: a fresh /login in the default item
+	// must be found even while a dead scoped item exists.
 	async function resolveCredential(): Promise<StoredClaudeOAuth | null> {
-		const stored = deps.readCred();
+		const stored = selectCred(deps.readCredCandidates(), deps.now(), rejectedToken);
 		if (!stored) return null;
 		const { service, oauth: cred } = stored;
 		const nearExpiry =
@@ -357,7 +377,7 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 		if (shouldAttemptRefresh(needsRefresh, deps.now(), nextRefreshAllowedAt)) {
 			if (nearExpiry) console.log(`${ts()} [Proxy] stored token at/near expiry — attempting refresh`);
 			await runSingleFlightRefresh(service, cred);
-			return deps.readCred() ?? stored;
+			return selectCred(deps.readCredCandidates(), deps.now(), rejectedToken) ?? stored;
 		}
 		return stored;
 	}
@@ -366,7 +386,7 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 	// backoff window allows) → rebuild → retry once. Null = give up loud.
 	async function recoverAfter401(failedToken: string): Promise<string | null> {
 		rejectedToken = failedToken;
-		const stored = deps.readCred();
+		const stored = selectCred(deps.readCredCandidates(), deps.now(), rejectedToken);
 		console.log(`${ts()} [Proxy] keychain re-read after 401: ${stored ? 'credential present' : 'no credential'}`);
 		if (!stored) return null;
 		if (
@@ -377,7 +397,7 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 		}
 		if (stored.oauth.refreshToken && shouldAttemptRefresh(true, deps.now(), nextRefreshAllowedAt)) {
 			await runSingleFlightRefresh(stored.service, stored.oauth);
-			const after = deps.readCred();
+			const after = selectCred(deps.readCredCandidates(), deps.now(), rejectedToken);
 			if (
 				after &&
 				after.oauth.accessToken !== failedToken &&

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -253,6 +253,35 @@ function refreshAccessToken(oauth: ClaudeOAuth): Promise<ClaudeOAuth | null> {
 	});
 }
 
+// Pure: is this credential safe to inject? 'expired' = hard expiry (the 5-min
+// REFRESH_SKEW only triggers refresh attempts — a not-yet-expired token still
+// works upstream). 'rejected' = upstream already 401'd this exact token, so it
+// is known-dead regardless of its expiry metadata.
+export function classifyCredential(
+	oauth: ClaudeOAuth,
+	now: number,
+	rejectedToken: string | null,
+): 'ok' | 'expired' | 'rejected' {
+	if (rejectedToken !== null && oauth.accessToken === rejectedToken) return 'rejected';
+	if (typeof oauth.expiresAt === 'number' && oauth.expiresAt <= now) return 'expired';
+	return 'ok';
+}
+
+// Distinct fail-fast body: name the proxy and the remedy so a 401 from HERE is
+// never mistaken for an upstream auth failure.
+export function authUnavailableBody(verdict: 'expired' | 'rejected'): string {
+	return JSON.stringify({
+		type: 'error',
+		error: {
+			type: 'authentication_error',
+			message:
+				`sutando credential-proxy: stored OAuth token is ${verdict} and self-refresh is unavailable ` +
+				'(OAuth endpoint failing; backing off). Run /login in Claude Code — the proxy re-reads the ' +
+				'keychain on every request and will pick the new token up immediately.',
+		},
+	});
+}
+
 // Injectable seams (keychain, refresh, upstream, clock) so the proxy's failure
 // semantics are testable hermetically; defaults are the production bindings.
 export interface ProxyDeps {
@@ -289,36 +318,75 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 	let refreshFailCount = 0;
 	let nextRefreshAllowedAt = 0;
 
-	// Return a usable accessToken, refreshing first if the stored one is at/near
-	// expiry. Fail-safe at every step: any problem → return the existing token.
-	async function getFreshOAuthToken(): Promise<string | null> {
+	// Last token an upstream 401 proved dead — never injected again until a
+	// refresh or /login replaces it (cleared on refresh success).
+	let rejectedToken: string | null = null;
+
+	function runSingleFlightRefresh(service: string, cred: ClaudeOAuth): Promise<void> {
+		if (!refreshInFlight) {
+			refreshInFlight = (async () => {
+				const fresh = await deps.refreshAccessToken(cred);
+				if (fresh && deps.writeCred(service, fresh)) {
+					refreshFailCount = 0;
+					nextRefreshAllowedAt = 0;
+					rejectedToken = null;
+					console.log(`${ts()} [Proxy] OAuth token refreshed (new expiry ${new Date(fresh.expiresAt ?? 0).toISOString()})`);
+				} else {
+					refreshFailCount += 1;
+					const backoff = nextRefreshBackoffMs(refreshFailCount);
+					nextRefreshAllowedAt = deps.now() + backoff;
+					console.error(`${ts()} [Proxy] refresh failed (failure ${refreshFailCount}, next attempt allowed in ${Math.round(backoff / 1000)}s)`);
+				}
+			})().finally(() => { refreshInFlight = null; });
+		}
+		return refreshInFlight;
+	}
+
+	// Re-read the keychain (every call — no cache, so /login lands within one
+	// request) and refresh first when at/near expiry or upstream-rejected.
+	async function resolveCredential(): Promise<StoredClaudeOAuth | null> {
 		const stored = deps.readCred();
 		if (!stored) return null;
 		const { service, oauth: cred } = stored;
-		const needsRefresh =
+		const nearExpiry =
 			typeof cred.expiresAt === 'number' &&
-			cred.expiresAt - deps.now() <= REFRESH_SKEW_MS &&
+			cred.expiresAt - deps.now() <= REFRESH_SKEW_MS;
+		const needsRefresh =
+			(nearExpiry || classifyCredential(cred, deps.now(), rejectedToken) !== 'ok') &&
 			!!cred.refreshToken;
 		if (shouldAttemptRefresh(needsRefresh, deps.now(), nextRefreshAllowedAt)) {
-			if (!refreshInFlight) {
-				refreshInFlight = (async () => {
-					const fresh = await deps.refreshAccessToken(cred);
-					if (fresh && deps.writeCred(service, fresh)) {
-						refreshFailCount = 0;
-						nextRefreshAllowedAt = 0;
-						console.log(`${ts()} [Proxy] OAuth token refreshed (new expiry ${new Date(fresh.expiresAt ?? 0).toISOString()})`);
-					} else {
-						refreshFailCount += 1;
-						const backoff = nextRefreshBackoffMs(refreshFailCount);
-						nextRefreshAllowedAt = deps.now() + backoff;
-						console.error(`${ts()} [Proxy] refresh did not persist — keeping existing token (failure ${refreshFailCount}, backing off ${Math.round(backoff / 1000)}s)`);
-					}
-				})().finally(() => { refreshInFlight = null; });
-			}
-			await refreshInFlight;
-			return deps.readCred()?.oauth.accessToken ?? cred.accessToken;
+			if (nearExpiry) console.log(`${ts()} [Proxy] stored token at/near expiry — attempting refresh`);
+			await runSingleFlightRefresh(service, cred);
+			return deps.readCred() ?? stored;
 		}
-		return cred.accessToken;
+		return stored;
+	}
+
+	// Owner's 401 state machine: reload (keychain re-read) → refresh (if the
+	// backoff window allows) → rebuild → retry once. Null = give up loud.
+	async function recoverAfter401(failedToken: string): Promise<string | null> {
+		rejectedToken = failedToken;
+		const stored = deps.readCred();
+		console.log(`${ts()} [Proxy] keychain re-read after 401: ${stored ? 'credential present' : 'no credential'}`);
+		if (!stored) return null;
+		if (
+			stored.oauth.accessToken !== failedToken &&
+			classifyCredential(stored.oauth, deps.now(), rejectedToken) === 'ok'
+		) {
+			return stored.oauth.accessToken; // a fresh /login already landed
+		}
+		if (stored.oauth.refreshToken && shouldAttemptRefresh(true, deps.now(), nextRefreshAllowedAt)) {
+			await runSingleFlightRefresh(stored.service, stored.oauth);
+			const after = deps.readCred();
+			if (
+				after &&
+				after.oauth.accessToken !== failedToken &&
+				classifyCredential(after.oauth, deps.now(), rejectedToken) === 'ok'
+			) {
+				return after.oauth.accessToken;
+			}
+		}
+		return null;
 	}
 
 	return createServer((req, res) => {
@@ -326,15 +394,6 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 		req.on('data', (c) => chunks.push(c));
 		req.on('end', async () => {
 			const body = Buffer.concat(chunks);
-
-			// Read token fresh from keychain each request, refreshing it first if it
-			// is at/near expiry (self-refresh covers headless nodes).
-			const oauthToken = await getFreshOAuthToken();
-			if (!oauthToken) {
-				res.writeHead(502);
-				res.end('No OAuth token in keychain');
-				return;
-			}
 
 			const headers: Record<string, string | number | string[] | undefined> = {
 				...(req.headers as Record<string, string>),
@@ -347,70 +406,132 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 			delete headers['keep-alive'];
 			delete headers['transfer-encoding'];
 
-			// Inject OAuth token for auth requests
-			if (headers['authorization']) {
-				delete headers['authorization'];
-				headers['authorization'] = `Bearer ${oauthToken}`;
+			const hasClientAuth = !!headers['authorization'] || !!headers['x-api-key'];
+
+			// Read token fresh from keychain each request, refreshing it first if it
+			// is at/near expiry (self-refresh covers headless nodes).
+			const stored = await resolveCredential();
+			// The token this proxy injected, if any — non-null means WE authored the
+			// request's auth and own the 401-recovery duty for it.
+			let injectedToken: string | null = null;
+			if (!stored) {
+				if (!hasClientAuth) {
+					res.writeHead(502);
+					res.end('No OAuth token in keychain');
+					return;
+				}
+				console.log(`${ts()} [Proxy] no keychain credential — passing client credential through`);
+			} else {
+				const verdict = classifyCredential(stored.oauth, deps.now(), rejectedToken);
+				if (verdict === 'ok') {
+					// Inject OAuth token for auth requests
+					if (headers['authorization']) {
+						headers['authorization'] = `Bearer ${stored.oauth.accessToken}`;
+						injectedToken = stored.oauth.accessToken;
+					}
+				} else if (hasClientAuth) {
+					// Never inject a known-dead token over a client credential that may
+					// be fresher (the /login case) — pass it through untouched.
+					console.log(`${ts()} [Proxy] stored token ${verdict}, refresh unavailable — pass-through engaged (client credential forwarded untouched)`);
+				} else {
+					console.error(`${ts()} [Proxy] stored token ${verdict}, refresh unavailable, no client credential — failing fast (401)`);
+					res.writeHead(401, { 'content-type': 'application/json' });
+					res.end(authUnavailableBody(verdict));
+					return;
+				}
 			}
 
-			let timedOut = false;
+			const forward = (attempt: number): void => {
+				let timedOut = false;
 
-			const upstream = deps.request(
-				{
-					hostname: deps.upstreamUrl.hostname,
-					port: upstreamPort,
-					path: req.url,
-					method: req.method,
-					headers,
-					timeout: deps.idleTimeoutMs,
-				} as RequestOptions,
-				(upRes) => {
-					// Extract rate limit headers
-					const quotaHeaders: Record<string, string> = {};
-					for (const [key, val] of Object.entries(upRes.headers)) {
-						if (key.startsWith('anthropic-ratelimit')) {
-							quotaHeaders[key] = String(val);
+				const upstream = deps.request(
+					{
+						hostname: deps.upstreamUrl.hostname,
+						port: upstreamPort,
+						path: req.url,
+						method: req.method,
+						headers,
+						timeout: deps.idleTimeoutMs,
+					} as RequestOptions,
+					(upRes) => {
+						// Extract rate limit headers
+						const quotaHeaders: Record<string, string> = {};
+						for (const [key, val] of Object.entries(upRes.headers)) {
+							if (key.startsWith('anthropic-ratelimit')) {
+								quotaHeaders[key] = String(val);
+							}
 						}
+						if (Object.keys(quotaHeaders).length > 0) {
+							console.log(`${ts()} [Quota]`, quotaHeaders);
+							deps.updateQuotaState(quotaHeaders);
+						}
+
+						if (upRes.statusCode === 401 && injectedToken && attempt === 0) {
+							// 401 on proxy-authored auth is an auth-state transition, not a
+							// generic failure: reload → refresh → retry once → give up loud.
+							console.error(`${ts()} [Proxy] upstream 401 on injected token — invalidating it and re-reading keychain`);
+							const buf: Buffer[] = [];
+							upRes.on('data', (c) => buf.push(c));
+							upRes.on('end', async () => {
+								const recovered = await recoverAfter401(injectedToken as string);
+								if (recovered) {
+									console.log(`${ts()} [Proxy] retrying once with reloaded credential`);
+									headers['authorization'] = `Bearer ${recovered}`;
+									injectedToken = recovered;
+									forward(1);
+									return;
+								}
+								console.error(`${ts()} [Proxy] credential recovery failed — forwarding the upstream 401 (re-auth with /login)`);
+								const h = { ...upRes.headers };
+								delete h['content-length'];
+								delete h['transfer-encoding'];
+								res.writeHead(401, h);
+								res.end(Buffer.concat(buf));
+							});
+							return;
+						}
+						if (upRes.statusCode === 401 && injectedToken && attempt > 0) {
+							console.error(`${ts()} [Proxy] reloaded credential also rejected (401) — giving up`);
+							rejectedToken = injectedToken;
+						}
+
+						res.writeHead(upRes.statusCode!, upRes.headers);
+						upRes.pipe(res);
+					},
+				);
+
+				// 'timeout' fires on socket inactivity but does NOT auto-abort — destroy the
+				// request so it surfaces through the 'error' handler below as a clean failure
+				// (and Claude Code's own retry kicks in) instead of hanging indefinitely.
+				upstream.on('timeout', () => {
+					timedOut = true;
+					console.error(`${ts()} [Proxy] Upstream idle >${deps.idleTimeoutMs}ms — aborting`);
+					upstream.destroy(new Error('upstream idle timeout'));
+				});
+
+				upstream.on('error', (err) => {
+					console.error(`${ts()} [Proxy] Upstream error:`, err.message);
+					if (!res.headersSent) {
+						res.writeHead(timedOut ? 504 : 502);
+						res.end(timedOut ? 'Gateway Timeout' : 'Bad Gateway');
+					} else {
+						// Headers already streamed — can't change status. Tear down the client
+						// connection so the agent sees a broken stream and retries rather than
+						// waiting forever on a dead upstream.
+						res.destroy(err);
 					}
-					if (Object.keys(quotaHeaders).length > 0) {
-						console.log(`${ts()} [Quota]`, quotaHeaders);
-						deps.updateQuotaState(quotaHeaders);
-					}
+				});
 
-					res.writeHead(upRes.statusCode!, upRes.headers);
-					upRes.pipe(res);
-				},
-			);
+				// If the agent hangs up first, don't leak the in-flight upstream request.
+				res.on('close', () => {
+					if (!res.writableEnded) upstream.destroy();
+				});
 
-			// 'timeout' fires on socket inactivity but does NOT auto-abort — destroy the
-			// request so it surfaces through the 'error' handler below as a clean failure
-			// (and Claude Code's own retry kicks in) instead of hanging indefinitely.
-			upstream.on('timeout', () => {
-				timedOut = true;
-				console.error(`${ts()} [Proxy] Upstream idle >${deps.idleTimeoutMs}ms — aborting`);
-				upstream.destroy(new Error('upstream idle timeout'));
-			});
+				upstream.write(body);
+				upstream.end();
+			};
 
-			upstream.on('error', (err) => {
-				console.error(`${ts()} [Proxy] Upstream error:`, err.message);
-				if (!res.headersSent) {
-					res.writeHead(timedOut ? 504 : 502);
-					res.end(timedOut ? 'Gateway Timeout' : 'Bad Gateway');
-				} else {
-					// Headers already streamed — can't change status. Tear down the client
-					// connection so the agent sees a broken stream and retries rather than
-					// waiting forever on a dead upstream.
-					res.destroy(err);
-				}
-			});
-
-			// If the agent hangs up first, don't leak the in-flight upstream request.
-			res.on('close', () => {
-				if (!res.writableEnded) upstream.destroy();
-			});
-
-			upstream.write(body);
-			upstream.end();
+			forward(0);
 		});
 	});
 }

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -253,46 +253,166 @@ function refreshAccessToken(oauth: ClaudeOAuth): Promise<ClaudeOAuth | null> {
 	});
 }
 
-// Single-flight guard: at most one refresh in progress, so concurrent requests
-// never race to consume/rotate the refresh token twice.
-let refreshInFlight: Promise<void> | null = null;
+// Injectable seams (keychain, refresh, upstream, clock) so the proxy's failure
+// semantics are testable hermetically; defaults are the production bindings.
+export interface ProxyDeps {
+	readCred: () => StoredClaudeOAuth | null;
+	writeCred: (service: string, oauth: ClaudeOAuth) => boolean;
+	refreshAccessToken: (oauth: ClaudeOAuth) => Promise<ClaudeOAuth | null>;
+	request: typeof httpsRequest;
+	upstreamUrl: URL;
+	updateQuotaState: (headers: Record<string, string>) => void;
+	now: () => number;
+	idleTimeoutMs: number;
+}
 
-// Failure-backoff state (see nextRefreshBackoffMs / shouldAttemptRefresh).
-// `nextRefreshAllowedAt` is an epoch-ms gate: while now < it, we skip the
-// refresh and fall through to the existing (stale) token instead of hammering.
-let refreshFailCount = 0;
-let nextRefreshAllowedAt = 0;
+export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
+	const deps: ProxyDeps = {
+		readCred,
+		writeCred,
+		refreshAccessToken,
+		request: httpsRequest,
+		upstreamUrl: new URL(UPSTREAM),
+		updateQuotaState,
+		now: Date.now,
+		idleTimeoutMs: UPSTREAM_IDLE_TIMEOUT_MS,
+		...overrides,
+	};
+	const upstreamPort = deps.upstreamUrl.port ? Number(deps.upstreamUrl.port) : 443;
 
-// Return a usable accessToken, refreshing first if the stored one is at/near
-// expiry. Fail-safe at every step: any problem → return the existing token.
-async function getFreshOAuthToken(): Promise<string | null> {
-	const stored = readCred();
-	if (!stored) return null;
-	const { service, oauth: cred } = stored;
-	const needsRefresh =
-		typeof cred.expiresAt === 'number' &&
-		cred.expiresAt - Date.now() <= REFRESH_SKEW_MS &&
-		!!cred.refreshToken;
-	if (shouldAttemptRefresh(needsRefresh, Date.now(), nextRefreshAllowedAt)) {
-		if (!refreshInFlight) {
-			refreshInFlight = (async () => {
-				const fresh = await refreshAccessToken(cred);
-				if (fresh && writeCred(service, fresh)) {
-					refreshFailCount = 0;
-					nextRefreshAllowedAt = 0;
-					console.log(`${ts()} [Proxy] OAuth token refreshed (new expiry ${new Date(fresh.expiresAt ?? 0).toISOString()})`);
-				} else {
-					refreshFailCount += 1;
-					const backoff = nextRefreshBackoffMs(refreshFailCount);
-					nextRefreshAllowedAt = Date.now() + backoff;
-					console.error(`${ts()} [Proxy] refresh did not persist — keeping existing token (failure ${refreshFailCount}, backing off ${Math.round(backoff / 1000)}s)`);
-				}
-			})().finally(() => { refreshInFlight = null; });
+	// Single-flight guard: at most one refresh in progress, so concurrent requests
+	// never race to consume/rotate the refresh token twice.
+	let refreshInFlight: Promise<void> | null = null;
+
+	// Failure-backoff state (see nextRefreshBackoffMs / shouldAttemptRefresh).
+	// While now < nextRefreshAllowedAt, skip the refresh instead of hammering.
+	let refreshFailCount = 0;
+	let nextRefreshAllowedAt = 0;
+
+	// Return a usable accessToken, refreshing first if the stored one is at/near
+	// expiry. Fail-safe at every step: any problem → return the existing token.
+	async function getFreshOAuthToken(): Promise<string | null> {
+		const stored = deps.readCred();
+		if (!stored) return null;
+		const { service, oauth: cred } = stored;
+		const needsRefresh =
+			typeof cred.expiresAt === 'number' &&
+			cred.expiresAt - deps.now() <= REFRESH_SKEW_MS &&
+			!!cred.refreshToken;
+		if (shouldAttemptRefresh(needsRefresh, deps.now(), nextRefreshAllowedAt)) {
+			if (!refreshInFlight) {
+				refreshInFlight = (async () => {
+					const fresh = await deps.refreshAccessToken(cred);
+					if (fresh && deps.writeCred(service, fresh)) {
+						refreshFailCount = 0;
+						nextRefreshAllowedAt = 0;
+						console.log(`${ts()} [Proxy] OAuth token refreshed (new expiry ${new Date(fresh.expiresAt ?? 0).toISOString()})`);
+					} else {
+						refreshFailCount += 1;
+						const backoff = nextRefreshBackoffMs(refreshFailCount);
+						nextRefreshAllowedAt = deps.now() + backoff;
+						console.error(`${ts()} [Proxy] refresh did not persist — keeping existing token (failure ${refreshFailCount}, backing off ${Math.round(backoff / 1000)}s)`);
+					}
+				})().finally(() => { refreshInFlight = null; });
+			}
+			await refreshInFlight;
+			return deps.readCred()?.oauth.accessToken ?? cred.accessToken;
 		}
-		await refreshInFlight;
-		return readCredFromService(service)?.oauth.accessToken ?? cred.accessToken;
+		return cred.accessToken;
 	}
-	return cred.accessToken;
+
+	return createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (c) => chunks.push(c));
+		req.on('end', async () => {
+			const body = Buffer.concat(chunks);
+
+			// Read token fresh from keychain each request, refreshing it first if it
+			// is at/near expiry (self-refresh covers headless nodes).
+			const oauthToken = await getFreshOAuthToken();
+			if (!oauthToken) {
+				res.writeHead(502);
+				res.end('No OAuth token in keychain');
+				return;
+			}
+
+			const headers: Record<string, string | number | string[] | undefined> = {
+				...(req.headers as Record<string, string>),
+				host: deps.upstreamUrl.host,
+				'content-length': body.length,
+			};
+
+			// Strip hop-by-hop headers
+			delete headers['connection'];
+			delete headers['keep-alive'];
+			delete headers['transfer-encoding'];
+
+			// Inject OAuth token for auth requests
+			if (headers['authorization']) {
+				delete headers['authorization'];
+				headers['authorization'] = `Bearer ${oauthToken}`;
+			}
+
+			let timedOut = false;
+
+			const upstream = deps.request(
+				{
+					hostname: deps.upstreamUrl.hostname,
+					port: upstreamPort,
+					path: req.url,
+					method: req.method,
+					headers,
+					timeout: deps.idleTimeoutMs,
+				} as RequestOptions,
+				(upRes) => {
+					// Extract rate limit headers
+					const quotaHeaders: Record<string, string> = {};
+					for (const [key, val] of Object.entries(upRes.headers)) {
+						if (key.startsWith('anthropic-ratelimit')) {
+							quotaHeaders[key] = String(val);
+						}
+					}
+					if (Object.keys(quotaHeaders).length > 0) {
+						console.log(`${ts()} [Quota]`, quotaHeaders);
+						deps.updateQuotaState(quotaHeaders);
+					}
+
+					res.writeHead(upRes.statusCode!, upRes.headers);
+					upRes.pipe(res);
+				},
+			);
+
+			// 'timeout' fires on socket inactivity but does NOT auto-abort — destroy the
+			// request so it surfaces through the 'error' handler below as a clean failure
+			// (and Claude Code's own retry kicks in) instead of hanging indefinitely.
+			upstream.on('timeout', () => {
+				timedOut = true;
+				console.error(`${ts()} [Proxy] Upstream idle >${deps.idleTimeoutMs}ms — aborting`);
+				upstream.destroy(new Error('upstream idle timeout'));
+			});
+
+			upstream.on('error', (err) => {
+				console.error(`${ts()} [Proxy] Upstream error:`, err.message);
+				if (!res.headersSent) {
+					res.writeHead(timedOut ? 504 : 502);
+					res.end(timedOut ? 'Gateway Timeout' : 'Bad Gateway');
+				} else {
+					// Headers already streamed — can't change status. Tear down the client
+					// connection so the agent sees a broken stream and retries rather than
+					// waiting forever on a dead upstream.
+					res.destroy(err);
+				}
+			});
+
+			// If the agent hangs up first, don't leak the in-flight upstream request.
+			res.on('close', () => {
+				if (!res.writableEnded) upstream.destroy();
+			});
+
+			upstream.write(body);
+			upstream.end();
+		});
+	});
 }
 
 // Back-compat sync reader (startup probe only — does not refresh).
@@ -332,15 +452,10 @@ function updateQuotaState(headers: Record<string, string>): void {
 }
 
 // Only start the server when run directly. Importing this module (e.g. from the
-// offline parse test) must NOT bind the port, touch the keychain, or exit.
-// Match the exact script name, NOT a substring — the offline test file is named
-// `credential-proxy-refresh.test.ts`, which contains "credential-proxy" but must
-// NOT be treated as the entry point (else importing it tries to bind the port).
+// offline tests) must NOT bind the port, touch the keychain, or exit.
 // Match the exact basename — works for BOTH the dev entry (`credential-proxy.ts`
-// run via tsx) AND the bundled artifact (`dist/credential-proxy.js`), while still
-// excluding `credential-proxy-refresh.test.{ts,js}` (different basename). Using
-// endsWith('.ts') alone silently no-ops the bundle: argv[1] ends in `.js` there,
-// isMain is false, and the proxy never binds the port.
+// run via tsx) AND the bundled artifact (`dist/credential-proxy.js`), while
+// excluding the `credential-proxy-*.test.{ts,js}` files (different basenames).
 const _entryName = (process.argv[1] ?? '').split(/[\\/]/).pop() ?? '';
 const isMain = _entryName === 'credential-proxy.ts' || _entryName === 'credential-proxy.js';
 
@@ -352,106 +467,8 @@ if (isMain) {
 		process.exit(1);
 	}
 	console.log(`${ts()} [Proxy] OAuth token loaded from keychain (will re-read on each request)`);
-}
 
-const upstreamUrl = new URL(UPSTREAM);
-
-const server = createServer((req, res) => {
-	const chunks: Buffer[] = [];
-	req.on('data', (c) => chunks.push(c));
-	req.on('end', async () => {
-		const body = Buffer.concat(chunks);
-
-		// Read token fresh from keychain each request, refreshing it first if it
-		// is at/near expiry (tokens are also refreshed by active interactive
-		// sessions; this self-refresh covers headless nodes where they aren't).
-		const oauthToken = await getFreshOAuthToken();
-		if (!oauthToken) {
-			res.writeHead(502);
-			res.end('No OAuth token in keychain');
-			return;
-		}
-
-		const headers: Record<string, string | number | string[] | undefined> = {
-			...(req.headers as Record<string, string>),
-			host: upstreamUrl.host,
-			'content-length': body.length,
-		};
-
-		// Strip hop-by-hop headers
-		delete headers['connection'];
-		delete headers['keep-alive'];
-		delete headers['transfer-encoding'];
-
-		// Inject OAuth token for auth requests
-		if (headers['authorization']) {
-			delete headers['authorization'];
-			headers['authorization'] = `Bearer ${oauthToken}`;
-		}
-
-		let timedOut = false;
-
-		const upstream = httpsRequest(
-			{
-				hostname: upstreamUrl.hostname,
-				port: 443,
-				path: req.url,
-				method: req.method,
-				headers,
-				timeout: UPSTREAM_IDLE_TIMEOUT_MS,
-			} as RequestOptions,
-			(upRes) => {
-				// Extract rate limit headers
-				const quotaHeaders: Record<string, string> = {};
-				for (const [key, val] of Object.entries(upRes.headers)) {
-					if (key.startsWith('anthropic-ratelimit')) {
-						quotaHeaders[key] = String(val);
-					}
-				}
-				if (Object.keys(quotaHeaders).length > 0) {
-					console.log(`${ts()} [Quota]`, quotaHeaders);
-					updateQuotaState(quotaHeaders);
-				}
-
-				res.writeHead(upRes.statusCode!, upRes.headers);
-				upRes.pipe(res);
-			},
-		);
-
-		// 'timeout' fires on socket inactivity but does NOT auto-abort — destroy the
-		// request so it surfaces through the 'error' handler below as a clean failure
-		// (and Claude Code's own retry kicks in) instead of hanging indefinitely.
-		upstream.on('timeout', () => {
-			timedOut = true;
-			console.error(`${ts()} [Proxy] Upstream idle >${UPSTREAM_IDLE_TIMEOUT_MS}ms — aborting`);
-			upstream.destroy(new Error('upstream idle timeout'));
-		});
-
-		upstream.on('error', (err) => {
-			console.error(`${ts()} [Proxy] Upstream error:`, err.message);
-			if (!res.headersSent) {
-				res.writeHead(timedOut ? 504 : 502);
-				res.end(timedOut ? 'Gateway Timeout' : 'Bad Gateway');
-			} else {
-				// Headers already streamed — can't change status. Tear down the client
-				// connection so the agent sees a broken stream and retries rather than
-				// waiting forever on a dead upstream.
-				res.destroy(err);
-			}
-		});
-
-		// If the agent hangs up first, don't leak the in-flight upstream request.
-		res.on('close', () => {
-			if (!res.writableEnded) upstream.destroy();
-		});
-
-		upstream.write(body);
-		upstream.end();
-	});
-});
-
-if (isMain) {
-	server.listen(PORT, '127.0.0.1', () => {
+	createProxyServer().listen(PORT, '127.0.0.1', () => {
 		console.log(`${ts()} [Proxy] Credential proxy → http://localhost:${PORT}`);
 		console.log(`${ts()} [Proxy] Upstream: ${UPSTREAM}`);
 		console.log(`${ts()} [Proxy] Set ANTHROPIC_BASE_URL=http://localhost:${PORT} to route through proxy`);

--- a/tests/credential-proxy-failure-semantics.test.ts
+++ b/tests/credential-proxy-failure-semantics.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Hermetic tests for the credential proxy's failure semantics: never inject a
+ * known-dead token (pass the client's credential through, or fail fast with a
+ * legible 401), reload + retry once on an upstream 401 the proxy authored, and
+ * keep the OAuth-endpoint failure backoff. Keychain, OAuth refresh, clock, and
+ * the upstream are all injected — no network, no real keychain.
+ */
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createServer as createHttpServer, request as httpRequest, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { request as httpsRequest } from 'node:https';
+import { createProxyServer, type ProxyDeps } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+
+type Cred = { accessToken: string; refreshToken?: string; expiresAt?: number };
+type Stored = { service: string; oauth: Cred } | null;
+
+const HOUR = 3600_000;
+let now = 1_700_000_000_000;
+let keychain: Stored = null;
+let refreshCalls = 0;
+let refreshResult: Cred | null = null;
+let upstreamHits: Array<{ auth?: string; apiKey?: string; path?: string }> = [];
+let upstreamHandler: (req: IncomingMessage, res: ServerResponse) => void = () => {};
+let quotaWrites: Array<Record<string, string>> = [];
+const servers: Server[] = [];
+
+beforeEach(() => {
+	now = 1_700_000_000_000;
+	keychain = null;
+	refreshCalls = 0;
+	refreshResult = null;
+	upstreamHits = [];
+	quotaWrites = [];
+});
+
+afterEach(async () => {
+	await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
+});
+
+function listen(s: Server): Promise<number> {
+	servers.push(s);
+	return new Promise((resolve) =>
+		s.listen(0, '127.0.0.1', () => resolve((s.address() as { port: number }).port)));
+}
+
+async function startUpstream(): Promise<number> {
+	return listen(createHttpServer((req, res) => {
+		upstreamHits.push({
+			auth: req.headers['authorization'] as string | undefined,
+			apiKey: req.headers['x-api-key'] as string | undefined,
+			path: req.url,
+		});
+		upstreamHandler(req, res);
+	}));
+}
+
+async function startProxy(upstreamPort: number, extra: Partial<ProxyDeps> = {}): Promise<number> {
+	return listen(createProxyServer({
+		readCred: () => (keychain ? { service: keychain.service, oauth: { ...keychain.oauth } } : null),
+		writeCred: (service, oauth) => { keychain = { service, oauth: oauth as Cred }; return true; },
+		refreshAccessToken: async () => { refreshCalls += 1; return refreshResult; },
+		request: httpRequest as unknown as typeof httpsRequest,
+		upstreamUrl: new URL(`http://127.0.0.1:${upstreamPort}`),
+		updateQuotaState: (h) => { quotaWrites.push(h); },
+		now: () => now,
+		idleTimeoutMs: 5000,
+		...extra,
+	}));
+}
+
+function call(port: number, headers: Record<string, string> = {}): Promise<{ status: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const req = httpRequest(
+			{ hostname: '127.0.0.1', port, path: '/v1/messages', method: 'POST', headers },
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on('data', (c) => chunks.push(c));
+				res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }));
+			},
+		);
+		req.on('error', reject);
+		req.end('{"model":"x"}');
+	});
+}
+
+const respond = (res: ServerResponse, status: number, body: string, headers: Record<string, string> = {}) => {
+	res.writeHead(status, { 'content-type': 'application/json', ...headers });
+	res.end(body);
+};
+
+test('expired token + refresh in fail-backoff + client Authorization → client credential passes through untouched', async () => {
+	keychain = { service: 's', oauth: { accessToken: 'dead-stored-token-aaaaaaaa', refreshToken: 'rt', expiresAt: now - 1000 } };
+	refreshResult = null; // refresh endpoint failing (revoked/rotated refresh token)
+	upstreamHandler = (_req, res) => respond(res, 200, '{"ok":true}');
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r = await call(proxyPort, { authorization: 'Bearer client-fresh-login-token' });
+	assert.equal(r.status, 200);
+	assert.equal(upstreamHits.length, 1);
+	// The /login cure: the client's own (fresher) credential must survive.
+	assert.equal(upstreamHits[0].auth, 'Bearer client-fresh-login-token');
+	assert.equal(refreshCalls, 1);
+});
+
+test('expired token + refresh in fail-backoff + no client credential → fast distinct 401, upstream never contacted', async () => {
+	keychain = { service: 's', oauth: { accessToken: 'dead-stored-token-aaaaaaaa', refreshToken: 'rt', expiresAt: now - 1000 } };
+	refreshResult = null;
+	upstreamHandler = (_req, res) => respond(res, 200, '{"ok":true}');
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r = await call(proxyPort);
+	assert.equal(r.status, 401);
+	const parsed = JSON.parse(r.body);
+	assert.equal(parsed.error?.type, 'authentication_error');
+	assert.match(parsed.error?.message ?? '', /credential-proxy/);
+	assert.match(parsed.error?.message ?? '', /\/login/);
+	assert.equal(upstreamHits.length, 0, 'a known-dead token must never be forwarded pretending normality');
+});
+
+test('upstream 401 on injected token → keychain re-read finds fresh /login token → retry once succeeds', async () => {
+	keychain = { service: 's', oauth: { accessToken: 'stale-but-unexpired-token-aa', expiresAt: now + HOUR } };
+	upstreamHandler = (req, res) => {
+		if (req.headers['authorization'] === 'Bearer stale-but-unexpired-token-aa') {
+			// Simulate /login landing while the 401 is in flight.
+			keychain = { service: 's', oauth: { accessToken: 'fresh-relogin-token-bbbbbbbb', expiresAt: now + HOUR } };
+			respond(res, 401, '{"error":{"type":"authentication_error","message":"OAuth access token has expired"}}');
+			return;
+		}
+		respond(res, 200, '{"recovered":true}');
+	};
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r = await call(proxyPort, { authorization: 'Bearer client-token' });
+	assert.equal(r.status, 200);
+	assert.equal(JSON.parse(r.body).recovered, true);
+	assert.equal(upstreamHits.length, 2, 'exactly one retry');
+	assert.equal(upstreamHits[1].auth, 'Bearer fresh-relogin-token-bbbbbbbb');
+	assert.equal(refreshCalls, 0, 'keychain re-read sufficed; no OAuth-endpoint call needed');
+});
+
+test('upstream 401, keychain unchanged, refresh fails → 401 surfaces once, then the rejected token is never re-injected', async () => {
+	// Revoked-but-unexpired token: expiry metadata says valid, upstream says no.
+	keychain = { service: 's', oauth: { accessToken: 'revoked-unexpired-token-aaaa', refreshToken: 'rt', expiresAt: now + HOUR } };
+	refreshResult = null;
+	upstreamHandler = (req, res) => {
+		if (req.headers['authorization'] === 'Bearer revoked-unexpired-token-aaaa') {
+			respond(res, 401, '{"error":{"type":"authentication_error","message":"revoked"}}');
+			return;
+		}
+		respond(res, 200, '{"ok":true}');
+	};
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r1 = await call(proxyPort, { authorization: 'Bearer client-own-token' });
+	assert.equal(r1.status, 401, 'give up loud: the upstream 401 reaches the client');
+	assert.equal(upstreamHits[0].auth, 'Bearer revoked-unexpired-token-aaaa');
+	assert.equal(refreshCalls, 1);
+
+	// Next request: the 401'd token is invalidated → client credential passes through.
+	const r2 = await call(proxyPort, { authorization: 'Bearer client-own-token' });
+	assert.equal(r2.status, 200);
+	assert.equal(upstreamHits.at(-1)?.auth, 'Bearer client-own-token');
+});
+
+test('/login between requests: next request injects the new keychain token without a proxy restart', async () => {
+	keychain = { service: 's', oauth: { accessToken: 'first-session-token-aaaaaaaa', expiresAt: now + HOUR } };
+	upstreamHandler = (_req, res) => respond(res, 200, '{}');
+	const proxyPort = await startProxy(await startUpstream());
+
+	await call(proxyPort, { authorization: 'Bearer client-token' });
+	assert.equal(upstreamHits[0].auth, 'Bearer first-session-token-aaaaaaaa');
+
+	keychain = { service: 's', oauth: { accessToken: 'relogin-session-token-bbbbbb', expiresAt: now + HOUR } };
+	await call(proxyPort, { authorization: 'Bearer client-token' });
+	assert.equal(upstreamHits[1].auth, 'Bearer relogin-session-token-bbbbbb');
+});
+
+test('refresh failure keeps the anti-hammer backoff: one OAuth attempt per window, next attempt after it elapses', async () => {
+	keychain = { service: 's', oauth: { accessToken: 'dead-stored-token-aaaaaaaa', refreshToken: 'rt', expiresAt: now - 1000 } };
+	refreshResult = null;
+	upstreamHandler = (_req, res) => respond(res, 200, '{}');
+	const proxyPort = await startProxy(await startUpstream());
+
+	for (let i = 0; i < 3; i++) await call(proxyPort, { authorization: 'Bearer client-token' });
+	assert.equal(refreshCalls, 1, 'requests inside the backoff window must not re-hit the OAuth endpoint');
+
+	now += 30_001; // past the first 30s backoff window
+	await call(proxyPort, { authorization: 'Bearer client-token' });
+	assert.equal(refreshCalls, 2);
+});
+
+test('successful refresh of a near-expiry token is injected (healthy path) and quota telemetry still captured', async () => {
+	keychain = { service: 's', oauth: { accessToken: 'nearly-expired-token-aaaaaaa', refreshToken: 'rt', expiresAt: now + 60_000 } };
+	refreshResult = { accessToken: 'refreshed-token-bbbbbbbbbbbb', refreshToken: 'rt2', expiresAt: now + 8 * HOUR };
+	upstreamHandler = (_req, res) =>
+		respond(res, 200, '{"ok":true}', { 'anthropic-ratelimit-unified-5h-utilization': '42' });
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r = await call(proxyPort, { authorization: 'Bearer client-token' });
+	assert.equal(r.status, 200);
+	assert.equal(refreshCalls, 1);
+	assert.equal(upstreamHits[0].auth, 'Bearer refreshed-token-bbbbbbbbbbbb');
+	assert.equal(keychain?.oauth.accessToken, 'refreshed-token-bbbbbbbbbbbb', 'refreshed cred written back');
+	assert.deepEqual(quotaWrites, [{ 'anthropic-ratelimit-unified-5h-utilization': '42' }]);
+});
+
+test('requests without Authorization (x-api-key auth) are forwarded untouched when the stored token is healthy', async () => {
+	keychain = { service: 's', oauth: { accessToken: 'healthy-stored-token-aaaaaaa', expiresAt: now + HOUR } };
+	upstreamHandler = (_req, res) => respond(res, 200, '{}');
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r = await call(proxyPort, { 'x-api-key': 'sk-ant-user-key' });
+	assert.equal(r.status, 200);
+	assert.equal(upstreamHits[0].auth, undefined, 'no injection without a client Authorization header');
+	assert.equal(upstreamHits[0].apiKey, 'sk-ant-user-key');
+});
+
+test('expired token + x-api-key request → passes through (the client credential is not an Authorization header)', async () => {
+	keychain = { service: 's', oauth: { accessToken: 'dead-stored-token-aaaaaaaa', refreshToken: 'rt', expiresAt: now - 1000 } };
+	refreshResult = null;
+	upstreamHandler = (_req, res) => respond(res, 200, '{}');
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r = await call(proxyPort, { 'x-api-key': 'sk-ant-user-key' });
+	assert.equal(r.status, 200);
+	assert.equal(upstreamHits.length, 1);
+	assert.equal(upstreamHits[0].apiKey, 'sk-ant-user-key');
+});

--- a/tests/credential-proxy-failure-semantics.test.ts
+++ b/tests/credential-proxy-failure-semantics.test.ts
@@ -9,7 +9,7 @@ import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { createServer as createHttpServer, request as httpRequest, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
 import type { request as httpsRequest } from 'node:https';
-import { createProxyServer, type ProxyDeps } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+import { createProxyServer, selectCred, type ProxyDeps } from '../skills/quota-tracker/scripts/credential-proxy.ts';
 
 type Cred = { accessToken: string; refreshToken?: string; expiresAt?: number };
 type Stored = { service: string; oauth: Cred } | null;
@@ -17,6 +17,8 @@ type Stored = { service: string; oauth: Cred } | null;
 const HOUR = 3600_000;
 let now = 1_700_000_000_000;
 let keychain: Stored = null;
+// Items after the primary — models the scoped/default keychain split.
+let extraKeychainItems: Array<NonNullable<Stored>> = [];
 let refreshCalls = 0;
 let refreshResult: Cred | null = null;
 let upstreamHits: Array<{ auth?: string; apiKey?: string; path?: string }> = [];
@@ -27,6 +29,7 @@ const servers: Server[] = [];
 beforeEach(() => {
 	now = 1_700_000_000_000;
 	keychain = null;
+	extraKeychainItems = [];
 	refreshCalls = 0;
 	refreshResult = null;
 	upstreamHits = [];
@@ -56,7 +59,10 @@ async function startUpstream(): Promise<number> {
 
 async function startProxy(upstreamPort: number, extra: Partial<ProxyDeps> = {}): Promise<number> {
 	return listen(createProxyServer({
-		readCred: () => (keychain ? { service: keychain.service, oauth: { ...keychain.oauth } } : null),
+		readCredCandidates: () =>
+			[keychain, ...extraKeychainItems]
+				.filter((k): k is NonNullable<Stored> => k !== null)
+				.map((k) => ({ service: k.service, oauth: { ...k.oauth } })),
 		writeCred: (service, oauth) => { keychain = { service, oauth: oauth as Cred }; return true; },
 		refreshAccessToken: async () => { refreshCalls += 1; return refreshResult; },
 		request: httpRequest as unknown as typeof httpsRequest,
@@ -225,4 +231,67 @@ test('expired token + x-api-key request → passes through (the client credentia
 	assert.equal(r.status, 200);
 	assert.equal(upstreamHits.length, 1);
 	assert.equal(upstreamHits[0].apiKey, 'sk-ant-user-key');
+});
+
+test('dead scoped item does not eclipse a fresh default-item /login (candidate fallback on read)', async () => {
+	// /login from a vanilla terminal writes the DEFAULT item; the scoped item
+	// still holds a dead cred whose refresh 400s.
+	keychain = { service: 'scoped', oauth: { accessToken: 'dead-scoped-token-aaaaaaaaaa', refreshToken: 'rt', expiresAt: now - 1000 } };
+	extraKeychainItems = [{ service: 'default', oauth: { accessToken: 'fresh-default-login-token-bb', expiresAt: now + HOUR } }];
+	refreshResult = null;
+	upstreamHandler = (_req, res) => respond(res, 200, '{}');
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r = await call(proxyPort, { authorization: 'Bearer client-token' });
+	assert.equal(r.status, 200);
+	assert.equal(upstreamHits[0].auth, 'Bearer fresh-default-login-token-bb');
+	assert.equal(refreshCalls, 0, 'a usable candidate needs no OAuth-endpoint call');
+});
+
+test('upstream 401 on scoped token → recovery finds a fresh token in the default item → retry succeeds', async () => {
+	keychain = { service: 'scoped', oauth: { accessToken: 'revoked-scoped-token-aaaaaaa', expiresAt: now + HOUR } };
+	upstreamHandler = (req, res) => {
+		if (req.headers['authorization'] === 'Bearer revoked-scoped-token-aaaaaaa') {
+			// /login (vanilla terminal) lands in the DEFAULT item mid-incident.
+			extraKeychainItems = [{ service: 'default', oauth: { accessToken: 'fresh-default-login-token-bb', expiresAt: now + HOUR } }];
+			respond(res, 401, '{"error":{"type":"authentication_error","message":"OAuth access token has expired"}}');
+			return;
+		}
+		respond(res, 200, '{"recovered":true}');
+	};
+	const proxyPort = await startProxy(await startUpstream());
+
+	const r = await call(proxyPort, { authorization: 'Bearer client-token' });
+	assert.equal(r.status, 200);
+	assert.equal(upstreamHits.length, 2);
+	assert.equal(upstreamHits[1].auth, 'Bearer fresh-default-login-token-bb');
+	assert.equal(refreshCalls, 0);
+});
+
+// --- selectCred: pure candidate-selection policy ---------------------------
+
+const at = (service: string, accessToken: string, expiresAt?: number) => ({ service, oauth: { accessToken, expiresAt } });
+
+test('selectCred prefers the scoped item when it is usable', () => {
+	const picked = selectCred([at('scoped', 'scoped-token', now + HOUR), at('default', 'default-token', now + HOUR)], now, null);
+	assert.equal(picked?.service, 'scoped');
+});
+
+test('selectCred skips an expired scoped item for a usable default item', () => {
+	const picked = selectCred([at('scoped', 'scoped-token', now - 1), at('default', 'default-token', now + HOUR)], now, null);
+	assert.equal(picked?.service, 'default');
+});
+
+test('selectCred skips an upstream-rejected token for a usable candidate', () => {
+	const picked = selectCred([at('scoped', 'rejected-token', now + HOUR), at('default', 'default-token', now + HOUR)], now, 'rejected-token');
+	assert.equal(picked?.service, 'default');
+});
+
+test('selectCred with no usable candidate falls back to the first present (degraded handling sees it)', () => {
+	const picked = selectCred([at('scoped', 'scoped-token', now - 1), at('default', 'default-token', now - 1)], now, null);
+	assert.equal(picked?.service, 'scoped');
+});
+
+test('selectCred with no candidates → null', () => {
+	assert.equal(selectCred([], now, null), null);
 });


### PR DESCRIPTION
## What changed, and why?

Live owner-blocking incident (2026-08-10 night): the desktop app looped on `401 OAuth access token has expired` for extended stretches, and `/login` could not cure it. Root causes, verified against the source:

1. **The proxy overrides the client's own credentials with a token it knows is dead.** `credential-proxy.ts` replaces every incoming `Authorization` header with the keychain token. When that token is expired and its refresh keeps failing (HTTP 400 — revoked/rotated refresh token, e.g. rotated by the user's own repeated `/login`), the refresh fail-backoff (30s→15min, added in #2102) means the proxy **keeps injecting the known-expired token for up to 15 minutes per window**. The client's fresh `/login` token is stripped off every request — an unexplainable, uncurable 401 loop.
2. **A dead scoped keychain item eclipses a fresh `/login` in the default item.** `readCred()` is first-present-wins across `[scoped, default]`, regardless of expiry. A `/login` from a vanilla terminal writes the *default* item; the namespaced core's proxy kept reading the dead *scoped* corpse. (On the incident host right now: scoped item valid, default item expired 8h ago — the split is real in both directions.)

Fix, per the credential-lifecycle principle (credentials are a runtime-mutable dependency; **401 is an auth-state transition, not a generic retry**):

- **Never inject a known-dead token** (hard-expired, or one upstream already 401'd). If the request carries its own client credential (`Authorization` / `x-api-key`), it is **passed through untouched** — the `/login` case. If it carries none, **fail fast** with a distinct 401 JSON naming the proxy and the `/login` remedy — never forward a dead token pretending normality.
- **On an upstream 401 for auth the proxy authored**: invalidate that token, re-read the keychain (a fresh `/login` may be there), refresh if the backoff window allows, **retry exactly once** with the new credential, then surface the 401 loud. Reload → refresh → rebuild → retry-once — not sleep-and-replay.
- **Credential reload scans all keychain candidates** (`selectCred`): first *usable* candidate wins (scoped-first preference intact); if none is usable, first-present is returned so degraded handling engages. A dead scoped item can no longer hide a fresh default-item login.
- **Anti-hammer backoff for the OAuth endpoint is preserved** — the change is what happens to *requests* during the window, not the refresh cadence.
- **Every auth-state transition is logged** with timestamps to the existing log (`<workspace>/logs/credential-proxy.log` via launchd): expiry detected, refresh ok/fail, pass-through engaged, fail-fast, 401 invalidation, keychain re-read result, retry outcome. The incident took hours to diagnose partly because these decisions were invisible.

## Keychain-read timing (what I found)

The proxy already re-reads the keychain **on every request** (`readCred()` at the top of the per-request token resolution — there is no cross-request cache), so spec item "keychain re-read on every refresh decision" was already satisfied. The reasons `/login` couldn't cure the incident were (a) the injected override of the client's own header and (b) the scoped-vs-default item split above — both fixed here, no TTL cache needed.

**Known-dead is hard expiry (`expiresAt <= now`) or upstream-rejected — deliberately not the 5-min refresh skew.** A token inside the skew window but not yet expired still works upstream; failing fast on it during an OAuth-endpoint outage would drop working service. The skew still triggers refresh attempts exactly as before, and the 401-retry path is the backstop if expiry metadata lies.

## What files / sections should reviewers look at first?

- `skills/quota-tracker/scripts/credential-proxy.ts` — `classifyCredential`, `selectCred`, `resolveCredential`, `recoverAfter401`, and the `forward(attempt)` 401 branch in the request handler.
- `tests/credential-proxy-failure-semantics.test.ts` — hermetic (mock keychain, mock OAuth, local mock upstream; the real keychain is never touched).
- Commit structure: `6076c93` is a **no-behavior-change refactor** (injectable deps seam) so the semantics are hermetically testable; `18b6f16` is the failure-semantics fix; `986b2a8` is the candidate-selection fix.

## Before/after evidence

New suite at the refactor-only commit `6076c93` (= old semantics, injectable): **4/9 fail, reproducing the incident**:

```
✖ expired token + refresh in fail-backoff + client Authorization → client credential passes through untouched
    actual: 'Bearer dead-stored-token-aaaaaaaa',
    expected: 'Bearer client-fresh-login-token',   ← the /login override, verbatim
✖ expired token + refresh in fail-backoff + no client credential → fast distinct 401, upstream never contacted
    actual: 200, expected: 401                      ← dead-token forward pretending normality
✖ upstream 401 on injected token → keychain re-read finds fresh /login token → retry once succeeds
    actual: 401, expected: 200                      ← 401 passed to client, no reload/retry
✖ upstream 401, keychain unchanged, refresh fails → 401 surfaces once, then the rejected token is never re-injected
ℹ tests 9  ℹ pass 5  ℹ fail 4
```

At HEAD:

```
$ npx tsx --test --test-force-exit tests/credential-proxy-failure-semantics.test.ts tests/credential-proxy-refresh.test.ts
ℹ tests 37  ℹ pass 37  ℹ fail 0
```

## What tests did you run?

- `npm run typecheck:skills` — clean.
- `npx eslint skills/quota-tracker/scripts/credential-proxy.ts tests/credential-proxy-failure-semantics.test.ts` — clean.
- `bash tests/credential-proxy-bundled-install.test.sh` — `PASS — 3 checks green`.
- Full TS suite `npx tsx --test --test-force-exit 'tests/**/*.test.ts'`: 765 tests, 1 failure — `tests/agent-state-protocol.test.ts` "?probe=1 gets one frame + close(1000)…", which fails **identically at the refactor-only commit** on this host (it spawns its own services; it imports nothing from quota-tracker) — pre-existing local-environment flake, unrelated.
- `git diff | bash scripts/review-checks.sh` — `PASS (hardcoded-paths clean)`.

## Live-path round trip (real keychain, real upstream)

Ran this branch's proxy with **default (production) deps** on an ephemeral port — the live launchd proxy on 7846 was never touched, and the stored token had ~300 min of validity so the probe could not trigger a refresh/rotation race:

```
$ npx tsx live-probe.ts            # createProxyServer() with no overrides
PROBE_PORT=59135
$ curl -s -D - -X POST http://127.0.0.1:59135/v1/messages \
    -H "authorization: Bearer dummy-client-token-proves-injection-happened" \
    -H "anthropic-beta: oauth-2025-04-20" ... -d '{"model":"claude-haiku-4-5","max_tokens":1,...}'
HTTP/1.1 200 OK                    ← dummy client token would 401; keychain token was injected
anthropic-ratelimit-unified-status: allowed
anthropic-ratelimit-unified-5h-status: allowed    (12 ratelimit headers total)
```

Proxy log: `10:36:27.247 [Quota] { 'anthropic-ratelimit-unified-5h-utilization': '0.13', … }` and `quota-state.json` written with `utilization_5h: 0.13, utilization_7d: 0.27` — quota telemetry intact end to end through the real keychain→inject→upstream→capture path.

## Deliberately preserved behavior

- Port 7846, launchd contract, `start-cli.sh` wiring, `isMain` bundled-entry detection — untouched.
- Injection still happens **only when the client sent an `Authorization` header**; `x-api-key` and unauthenticated requests are forwarded untouched when the stored token is healthy (API-key users are unaffected), pinned by tests.
- Refresh fail-backoff cadence (30s→15min, single-flight) and its env overrides — unchanged, pinned by a test (3 requests in-window → exactly 1 OAuth attempt).
- `502 No OAuth token in keychain` when the keychain is empty **and** the request carries no client credential; with a client credential it now passes through instead.
- Quota-header capture runs on every upstream response, including 401s and the retry.
- Idle-timeout (504/502 mapping) and client-hangup teardown — unchanged.

## Feature/documentation consistency

N/A — no canonical doc under `docs/` describes the proxy's injection/failure semantics (`docs/catalog.json` has no credential-proxy entry; the skill README lists the script one line, still accurate). Behavior is documented in the module header and tests.

## Prior art / related work

- **#2106** (open, john-the-dev) attacks the candidate-eclipse half via `firstUsableCandidate`/`tokenHardExpired`. This PR's `selectCred` covers that case at the same `readCred` seam and additionally latches upstream-rejected tokens; it does **not** include #2106's other aspects. Whichever lands second has a contained conflict in the candidate-read block — happy to rebase either direction.
- **Branch `fix/credential-proxy-config-dir-keychain`** (`5802bd39`, Susan Xueqing Liu) diagnosed the same scoped-vs-default split and mirrored default→scoped at startup. Startup-time mirroring can't catch a mid-session `/login` and an unconditional mirror can overwrite a fresher scoped credential with a stale default one; read-time selection avoids both. Credited as prior art for the diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
