### PR TITLE
fix(health-check): a single undrained task was unreachable by the queue probe

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5079,7 +5079,8 @@ def _bridge_log_belongs_to_process(log_file: Path, process_started_at: "float | 
         return True
 
 
-def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300) -> dict:
+def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300,
+                     stuck_age_sec: int = 900) -> dict:
     """Detect a task-queue pileup — tasks/ directory growing without
     being drained. Independent of which watcher / loop is dying: the queue
     backs up either way. Fires when BOTH count and age cross thresholds so
@@ -5103,6 +5104,14 @@ def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300) -> 
             "name": name,
             "status": "warn",
             "detail": f"{len(files)} tasks queued, oldest {oldest_age}s — watcher or core may be stuck",
+        }
+    # ANDing count with age left a single stuck task unreachable, so one owner
+    # message could sit indefinitely while this probe printed its age under "ok".
+    if oldest_age > stuck_age_sec:
+        return {
+            "name": name,
+            "status": "warn",
+            "detail": f"{len(files)} task(s) queued, oldest {oldest_age}s — undrained past {stuck_age_sec}s",
         }
     return {"name": name, "status": "ok", "detail": f"{len(files)} task(s), oldest {oldest_age}s"}
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5081,12 +5081,8 @@ def _bridge_log_belongs_to_process(log_file: Path, process_started_at: "float | 
 
 def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300,
                      stuck_age_sec: int = 900) -> dict:
-    """Detect a task-queue pileup — tasks/ directory growing without
-    being drained. Independent of which watcher / loop is dying: the queue
-    backs up either way. Fires when BOTH count and age cross thresholds so
-    a transient spike of fresh tasks (normal during heavy use) doesn't
-    alert.
-    """
+    """Detect a task-queue pileup, independent of which watcher or loop is dying.
+    Two branches: count AND age together, or age alone past stuck_age_sec."""
     name = "task-queue"
     tasks_dir = WORKSPACE_DIR / "tasks"
     if not tasks_dir.exists():

--- a/tests/health-check-stuck-loop.test.py
+++ b/tests/health-check-stuck-loop.test.py
@@ -239,8 +239,8 @@ def case_j_large_fresh_queue() -> list[str]:
 
 def case_k_small_old_queue() -> list[str]:
     fails = []
-    # Small queue but old — age alone shouldn't alarm. The user might have
-    # 1-2 long-tail tasks that take a while; not stuck.
+    # Age alone shouldn't alarm BELOW the bar: 600s is under stuck_age_sec
+    # (900), which is what separates this from j0 where age alone must warn.
     def setup(d):
         for i in range(2):
             write_task(d, f"task-{i}.txt", age_sec=600)

--- a/tests/health-check-stuck-loop.test.py
+++ b/tests/health-check-stuck-loop.test.py
@@ -212,6 +212,19 @@ def case_i_small_fresh_queue() -> list[str]:
     return fails
 
 
+def case_j0_one_task_stuck_long() -> list[str]:
+    """A SINGLE task stuck far past the age threshold must warn. The count and
+    age conditions were ANDed, so 1-3 aged tasks were unreachable and green."""
+    fails = []
+    def setup(d):
+        write_task(d, "task-stuck.txt", age_sec=3600)
+    r = with_tasks_override(setup)
+    if r["status"] != "warn":
+        fails.append(
+            f"j0) 1 task aged 3600s should warn, got {r['status']} ({r['detail']})")
+    return fails
+
+
 def case_j_large_fresh_queue() -> list[str]:
     fails = []
     # Many tasks but all fresh — count alone shouldn't alarm.
@@ -502,6 +515,7 @@ def main() -> int:
         ("i", case_i_small_fresh_queue),
         ("j", case_j_large_fresh_queue),
         ("k", case_k_small_old_queue),
+        ("j0", case_j0_one_task_stuck_long),
         ("l", case_l_pileup),
         ("m", case_m_archive_excluded),
         ("m2", case_m2_completed_tasks_excluded),


### PR DESCRIPTION
## What changed

`check_task_queue` ANDed its count and age conditions, so **1–3 tasks stuck for any length of time returned `ok`** — while printing the age in the green detail line. Adds a count-independent `stuck_age_sec` (900s) branch. The existing burst rule is untouched.

## Why

Two live incidents on this host today. Both were **one** owner Discord message sitting undrained — I had done the work and replied on another surface without writing `results/`. Each blocked every `cron-gate`d cron behind it (pending-questions, sync-workspace, sync-skills, pr-flag all deferred), and the probe reported `ok` throughout.

The green line carried the number that should have alarmed:

```
1 task(s), oldest 1234s     <- status: ok
```

## Before / after — the probe exercised directly, not described

Against `origin/main`, one task aged 3600s:

```
  1 task(s) aged 3600s -> status=ok    | 1 task(s), oldest 3600s
  2 task(s) aged 3600s -> status=ok    | 2 task(s), oldest 3600s
  3 task(s) aged 3600s -> status=ok    | 3 task(s), oldest 3600s
  4 task(s) aged 3600s -> status=warn  | 4 tasks queued, oldest 3600s — watcher or core may be stuck
```

New regression `case_j0_one_task_stuck_long`, run on **unfixed** main:

```
✗ case j0
    j0) 1 task aged 3600s should warn, got ok (1 task(s), oldest 3600s)
1 failure(s)                                   <- exactly one, so nothing else was disturbed
```

After the fix:

```
python3 tests/health-check-stuck-loop.test.py     -> All stuck-loop / queue-pileup invariants hold (rc 0)
python3 tests/health-check-orphaned-results.test.py -> OK
python3 tests/health-check-task-watcher.test.py   -> Task-watcher liveness invariants hold
python3 -m py_compile src/health-check.py         -> ok
git diff origin/main...HEAD | bash scripts/review-checks.sh -> PASS
```

## Threshold choice

900s matches `check_orphaned_results`'s existing `threshold_age_sec`, and the bridge normally drains in seconds — so 15 minutes is well clear of routine traffic. The burst rule keeps its 3/300 so a transient spike of fresh tasks still doesn't alert.

## Scope

One concern. No behaviour change to the burst path, no threshold changes to existing conditions.
