### PR TITLE
fix(watcher): an unreadable claim answered "optional", the branch that publishes to the unrestricted core

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -157,9 +157,8 @@ claim_is_ours() {
   [ "$owner_id" = "$WATCHER_ID" ]
 }
 
-# 0 = must-handle, 1 = optional, 2 = unknown. Only the two written tokens are
-# recognised: anything else is unknown, because the optional branch publishes to
-# the unrestricted core and must never be reached by default.
+# 0 = must-handle, 1 = fallback, 2 = unknown.
+# Only must-handle/fallback may reach the live-core branches.
 claim_disposition() {
   local filename="$1"
   case "$(sed -n '4p' "$CLAIMS_DIR/$filename" 2>/dev/null)" in

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -157,18 +157,16 @@ claim_is_ours() {
   [ "$owner_id" = "$WATCHER_ID" ]
 }
 
-# 0 = must-handle, 1 = optional, 2 = UNKNOWN (claim vanished or is short).
-# Unknown must be its own answer. Callers reach this after claim_is_ours has
-# already read the same file, so an unreadable claim means a concurrent path
-# released it — and release happens after that path has emitted, so it owns the
-# task. Collapsing unknown into "optional" makes the permissive branch the
-# default on a read failure, and that branch prints TASK_FILE:, which publishes
-# a Team-tier task to the unrestricted core.
+# 0 = must-handle, 1 = optional, 2 = unknown. Only the two written tokens are
+# recognised: anything else is unknown, because the optional branch publishes to
+# the unrestricted core and must never be reached by default.
 claim_disposition() {
-  local filename="$1" disposition
-  disposition="$(sed -n '4p' "$CLAIMS_DIR/$filename" 2>/dev/null)" || return 2
-  [ -n "$disposition" ] || return 2
-  [ "$disposition" = "must-handle" ]
+  local filename="$1"
+  case "$(sed -n '4p' "$CLAIMS_DIR/$filename" 2>/dev/null)" in
+    must-handle) return 0 ;;
+    fallback) return 1 ;;
+    *) return 2 ;;
+  esac
 }
 
 publish_terminal_failure() {
@@ -234,7 +232,7 @@ finish_handler_task() {
           printf 'TASK_FILE: %s\n' "$filename" || true
           ;;
         *)
-          echo "watch-tasks-stream: claim for $filename vanished before its disposition could be read; leaving it to the releasing path" >&2
+          echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
           ;;
       esac
       release_task_claim "$filename" || true
@@ -445,7 +443,7 @@ fallback_outstanding_handlers() {
             printf 'TASK_FILE: %s\n' "$filename" || true
             ;;
           *)
-            echo "watch-tasks-stream: claim for $filename vanished before its disposition could be read; leaving it to the releasing path" >&2
+            echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
             ;;
         esac
         release_task_claim "$filename" || true
@@ -478,7 +476,7 @@ fallback_outstanding_handlers() {
         printf 'TASK_FILE: %s\n' "$filename" || true
         ;;
       *)
-        echo "watch-tasks-stream: claim for $filename vanished before its disposition could be read; leaving it to the releasing path" >&2
+        echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
         ;;
     esac
     release_task_claim "$filename" || true

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -157,9 +157,17 @@ claim_is_ours() {
   [ "$owner_id" = "$WATCHER_ID" ]
 }
 
-claim_must_handle() {
+# 0 = must-handle, 1 = optional, 2 = UNKNOWN (claim vanished or is short).
+# Unknown must be its own answer. Callers reach this after claim_is_ours has
+# already read the same file, so an unreadable claim means a concurrent path
+# released it — and release happens after that path has emitted, so it owns the
+# task. Collapsing unknown into "optional" makes the permissive branch the
+# default on a read failure, and that branch prints TASK_FILE:, which publishes
+# a Team-tier task to the unrestricted core.
+claim_disposition() {
   local filename="$1" disposition
-  disposition="$(sed -n '4p' "$CLAIMS_DIR/$filename" 2>/dev/null)"
+  disposition="$(sed -n '4p' "$CLAIMS_DIR/$filename" 2>/dev/null)" || return 2
+  [ -n "$disposition" ] || return 2
   [ "$disposition" = "must-handle" ]
 }
 
@@ -214,14 +222,21 @@ finish_handler_task() {
   # event during cleanup, but it cannot strand the task without either path.
   if mv "$marker" "$settled" 2>/dev/null; then
     if [ "$rc" -ne 0 ] && claim_is_ours "$filename"; then
-      if claim_must_handle "$filename"; then
-        echo "watch-tasks-stream: required Team handler failed for $filename (exit $rc); publishing safe terminal failure" >&2
-        publish_terminal_failure "$filename" "failed" || true
-      else
-        printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
-        echo "watch-tasks-stream: optional task handler failed for $filename (exit $rc); falling back to live core (possible at-least-once retry)" >&2
-        printf 'TASK_FILE: %s\n' "$filename" || true
-      fi
+      claim_disposition "$filename"
+      case $? in
+        0)
+          echo "watch-tasks-stream: required Team handler failed for $filename (exit $rc); publishing safe terminal failure" >&2
+          publish_terminal_failure "$filename" "failed" || true
+          ;;
+        1)
+          printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
+          echo "watch-tasks-stream: optional task handler failed for $filename (exit $rc); falling back to live core (possible at-least-once retry)" >&2
+          printf 'TASK_FILE: %s\n' "$filename" || true
+          ;;
+        *)
+          echo "watch-tasks-stream: claim for $filename vanished before its disposition could be read; leaving it to the releasing path" >&2
+          ;;
+      esac
       release_task_claim "$filename" || true
     elif [ "$rc" -eq 0 ]; then
       release_task_claim "$filename" || true
@@ -418,14 +433,21 @@ fallback_outstanding_handlers() {
       task_path="$(cat "$settled")"
       filename="$(basename "$task_path")"
       if claim_is_ours "$filename"; then
-        if claim_must_handle "$filename"; then
-          echo "watch-tasks-stream: required Team handler interrupted for $filename; publishing safe terminal failure" >&2
-          publish_terminal_failure "$filename" "was interrupted" || true
-        else
-          printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
-          echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
-          printf 'TASK_FILE: %s\n' "$filename" || true
-        fi
+        claim_disposition "$filename"
+        case $? in
+          0)
+            echo "watch-tasks-stream: required Team handler interrupted for $filename; publishing safe terminal failure" >&2
+            publish_terminal_failure "$filename" "was interrupted" || true
+            ;;
+          1)
+            printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
+            echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
+            printf 'TASK_FILE: %s\n' "$filename" || true
+            ;;
+          *)
+            echo "watch-tasks-stream: claim for $filename vanished before its disposition could be read; leaving it to the releasing path" >&2
+            ;;
+        esac
         release_task_claim "$filename" || true
       fi
       rm -f "$settled"
@@ -444,14 +466,21 @@ fallback_outstanding_handlers() {
     task_path="$(sed -n '3p' "$claim" 2>/dev/null)"
     [ -n "$task_path" ] || continue
     filename="$(basename "$task_path")"
-    if claim_must_handle "$filename"; then
-      echo "watch-tasks-stream: required Team handler interrupted for $filename; publishing safe terminal failure" >&2
-      publish_terminal_failure "$filename" "was interrupted" || true
-    else
-      printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
-      echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
-      printf 'TASK_FILE: %s\n' "$filename" || true
-    fi
+    claim_disposition "$filename"
+    case $? in
+      0)
+        echo "watch-tasks-stream: required Team handler interrupted for $filename; publishing safe terminal failure" >&2
+        publish_terminal_failure "$filename" "was interrupted" || true
+        ;;
+      1)
+        printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
+        echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
+        printf 'TASK_FILE: %s\n' "$filename" || true
+        ;;
+      *)
+        echo "watch-tasks-stream: claim for $filename vanished before its disposition could be read; leaving it to the releasing path" >&2
+        ;;
+    esac
     release_task_claim "$filename" || true
   done
 

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -7,7 +7,6 @@ import importlib.util
 import io
 import json
 import os
-import re
 import shutil
 import signal
 import subprocess
@@ -1289,37 +1288,60 @@ def test_codex_notifier_never_submits_a_watcher_claim_to_live_core() -> None:
             process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
 
 
-def test_unreadable_claim_is_never_classified_as_optional() -> None:
-    """An unreadable claim must not answer "optional".
-
-    The optional branch prints `TASK_FILE:`, which publishes the task to the
-    unrestricted live core. The previous helper read line 4 with a discarded
-    error and compared it to "must-handle", so an absent or short claim yielded
-    "" -> not must-handle -> optional. That makes the permissive answer the
-    default on a read failure, on a privilege boundary.
-    """
-    source = (REPO / "src" / "watch-tasks-stream.sh").read_text()
-    body = re.search(r"^claim_disposition\(\) \{.*?^\}", source, re.M | re.S)
-    assert body, "claim_disposition() must exist: an unreadable claim needs its own answer"
+def test_unrecognised_claim_disposition_is_never_published_to_the_live_core() -> None:
+    """Drives the real watcher: only the two written tokens may mean "optional"."""
     with tempfile.TemporaryDirectory() as td:
-        claims = Path(td)
-        (claims / "must.txt").write_text("task\nWID\n/p/t.txt\nmust-handle\n")
-        (claims / "optional.txt").write_text("task\nWID\n/p/t.txt\nfallback\n")
-        (claims / "short.txt").write_text("task\nWID\n/p/t.txt\n")  # no line 4
-        # "gone.txt" is deliberately never created.
-        for name, expected, label in (
-            ("must.txt", 0, "must-handle"),
-            ("optional.txt", 1, "optional"),
-            ("short.txt", 2, "unknown (claim truncated)"),
-            ("gone.txt", 2, "unknown (claim vanished)"),
-        ):
-            rc = subprocess.run(
-                ["/bin/bash", "-c", f'CLAIMS_DIR="{claims}"\n{body.group(0)}\nclaim_disposition "{name}"'],
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            ).returncode
-            assert rc == expected, f"{name} ({label}): expected rc={expected}, got rc={rc}"
-            if expected == 2:
-                assert rc != 1, f"{name} classified as optional -> would print TASK_FILE:"
+        root = Path(td)
+        workspace = root / "workspace"
+        tasks = workspace / "tasks"
+        results = workspace / "results"
+        tasks.mkdir(parents=True)
+        results.mkdir()
+        task = tasks / "task-team-corrupted.txt"
+        task.write_text("access_tier: team\ntask: protected\n")
+        handler = _executable(
+            root / "handler",
+            "#!/bin/sh\ncase \" $* \" in *\" --probe \"*) exit 4;; esac\nsleep 30\n",
+        )
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        _executable(bin_dir / "fswatch", "#!/bin/sh\nsleep 30\n")
+        process = subprocess.Popen(
+            ["/bin/bash", str(REPO / "src" / "watch-tasks-stream.sh"), str(tasks)],
+            env={
+                **os.environ,
+                "PATH": f"{bin_dir}:/usr/bin:/bin",
+                "SUTANDO_DEFAULT_WORKSPACE": str(workspace),
+                "SUTANDO_TASK_EVENT_HANDLER": str(handler),
+                "SUTANDO_CORE_RUNTIME": "claude",
+                "SUTANDO_RESULTS_DIR": str(results),
+            },
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        claim = workspace / "state" / "task-event-handler-claims" / task.name
+        try:
+            deadline = time.monotonic() + 1
+            while not claim.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert claim.exists()
+            lines = claim.read_text().splitlines()
+            assert lines[3] == "must-handle"
+            # Neither written token: the watcher must not read this as optional.
+            lines[3] = "must-handl"
+            claim.write_text("\n".join(lines) + "\n")
+            os.killpg(process.pid, signal.SIGTERM)
+            stdout, stderr = process.communicate(timeout=3)
+            assert "TASK_FILE:" not in stdout, (
+                "an unrecognised disposition was published to the unrestricted core")
+            assert "no recognised disposition" in stderr
+            assert not (workspace / "state" / "task-event-handler-fallbacks" / task.name).exists()
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.communicate(timeout=2)
 
 
 def test_runtime_wiring_is_optional_and_adapter_injected() -> None:
@@ -1369,6 +1391,6 @@ if __name__ == "__main__":
     test_shutdown_falls_back_without_surviving_workers()
     test_codex_notifier_dispatches_each_isolated_task_once_without_waiting()
     test_codex_notifier_never_submits_a_watcher_claim_to_live_core()
-    test_unreadable_claim_is_never_classified_as_optional()
+    test_unrecognised_claim_disposition_is_never_published_to_the_live_core()
     test_runtime_wiring_is_optional_and_adapter_injected()
     print("task workstream session worker tests passed")

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -7,6 +7,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -1288,6 +1289,39 @@ def test_codex_notifier_never_submits_a_watcher_claim_to_live_core() -> None:
             process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
 
 
+def test_unreadable_claim_is_never_classified_as_optional() -> None:
+    """An unreadable claim must not answer "optional".
+
+    The optional branch prints `TASK_FILE:`, which publishes the task to the
+    unrestricted live core. The previous helper read line 4 with a discarded
+    error and compared it to "must-handle", so an absent or short claim yielded
+    "" -> not must-handle -> optional. That makes the permissive answer the
+    default on a read failure, on a privilege boundary.
+    """
+    source = (REPO / "src" / "watch-tasks-stream.sh").read_text()
+    body = re.search(r"^claim_disposition\(\) \{.*?^\}", source, re.M | re.S)
+    assert body, "claim_disposition() must exist: an unreadable claim needs its own answer"
+    with tempfile.TemporaryDirectory() as td:
+        claims = Path(td)
+        (claims / "must.txt").write_text("task\nWID\n/p/t.txt\nmust-handle\n")
+        (claims / "optional.txt").write_text("task\nWID\n/p/t.txt\nfallback\n")
+        (claims / "short.txt").write_text("task\nWID\n/p/t.txt\n")  # no line 4
+        # "gone.txt" is deliberately never created.
+        for name, expected, label in (
+            ("must.txt", 0, "must-handle"),
+            ("optional.txt", 1, "optional"),
+            ("short.txt", 2, "unknown (claim truncated)"),
+            ("gone.txt", 2, "unknown (claim vanished)"),
+        ):
+            rc = subprocess.run(
+                ["/bin/bash", "-c", f'CLAIMS_DIR="{claims}"\n{body.group(0)}\nclaim_disposition "{name}"'],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            ).returncode
+            assert rc == expected, f"{name} ({label}): expected rc={expected}, got rc={rc}"
+            if expected == 2:
+                assert rc != 1, f"{name} classified as optional -> would print TASK_FILE:"
+
+
 def test_runtime_wiring_is_optional_and_adapter_injected() -> None:
     watcher = (REPO / "src" / "watch-tasks-stream.sh").read_text()
     notifier = (REPO / "src" / "agent" / "codex" / "cli" / "task-notifier.sh").read_text()
@@ -1335,5 +1369,6 @@ if __name__ == "__main__":
     test_shutdown_falls_back_without_surviving_workers()
     test_codex_notifier_dispatches_each_isolated_task_once_without_waiting()
     test_codex_notifier_never_submits_a_watcher_claim_to_live_core()
+    test_unreadable_claim_is_never_classified_as_optional()
     test_runtime_wiring_is_optional_and_adapter_injected()
     print("task workstream session worker tests passed")


### PR DESCRIPTION
## What

`claim_must_handle` decided a privilege question with a read whose failure was indistinguishable from a "no":

```bash
disposition="$(sed -n '4p' "$CLAIMS_DIR/$filename" 2>/dev/null)"
[ "$disposition" = "must-handle" ]
```

An absent or short claim yields `""` → false → all three callers take the `else` branch, which writes a fallback receipt and prints `TASK_FILE:`. That publishes a **Team-tier** task to the unrestricted live core — the exact boundary the `--probe` exit-4 path exists to enforce.

Replaced with a three-valued `claim_disposition`: `0` must-handle, `1` optional, `2` unknown. Unknown logs and does nothing.

## Why unknown is its own answer, not a flipped default

Every caller reaches the disposition read *after* a separate read of the same claim (`claim_is_ours`, or the owner/path lines in cleanup's second loop). A concurrent `release_task_claim` between those reads flips the decision. Release happens *after* the releasing path has emitted, so that path already owns the task — neither branch should fire.

Making unknown mean *must-handle* is not safe either: it would publish a "Team-tier" terminal failure for an optional task and strand its at-least-once retry.

## Evidence

Helper extracted from each revision, same four inputs:

```
origin/main  claim_must_handle   must=0  optional=1  short=1  gone=1
this branch  claim_disposition   must=0  optional=1  short=2  gone=2
                                                     ^^^^^^^^^^^^^^
                        1 = optional = the branch that prints TASK_FILE:
```

Affected tests, run on this branch and on an unmodified `origin/main` worktree:

```
required_team_handler_shutdown_never_falls_through   ok / ok
bounded_runtime_failure_never_falls_back_to_owner    ok / ok
slow_handler_does_not_block_the_next_task_event      ok / ok
runtime_wiring_is_optional_and_adapter_injected      ok / ok
unreadable_claim_is_never_classified_as_optional     ok / ABSENT
```

The new test fails on `main`: `claim_disposition` does not exist there, so its first assert fires. `shellcheck` clean.

## What I am NOT claiming

**This is not established as the cause of the intermittent CI failure** of `test_required_team_handler_shutdown_never_falls_through` (seen on #2779, #2798, #2712 — two PRs, two hosts). I could not reproduce it: **0/30** runs in a worktree at `origin/main` `e7db805a` on an idle Mac, which says little about a contended runner. The fail-open shape above is proven by inspection and worth closing regardless; if it also fixes the intermittent, that is a bonus I have not demonstrated.

## Unrelated, pre-existing

`test_watcher_bounds_provider_backlog_and_drains_every_receipt_once` fails **6/6 on unmodified `origin/main`** on this machine (a 1.0s timing bound). Not touched here, flagged so a reviewer running the file locally is not surprised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
