### PR TITLE
fix(test): a 1.0s latency bound sat below process startup, masking every test after it

### DIFF
--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -950,7 +950,9 @@ lock.rmdir()
             started = time.monotonic()
             assert process.stdout is not None
             assert process.stdout.readline() == "TASK_FILE: task-z-live.txt\n"
-            assert time.monotonic() - started < 1.0
+            # The handler this discriminates against blocks for 4s; 1.0 sat below process
+            # startup here (measured 1.17-1.36s), failing while the property still held.
+            assert time.monotonic() - started < 2.5
             assert int((state / "maximum").read_text()) <= 2
 
             (state / "release").touch()


### PR DESCRIPTION
## What

`test_watcher_bounds_provider_backlog_and_drains_every_receipt_once` bounds first-event latency at **1.0s** to prove a slow handler doesn't block the stream. On a developer Mac that bound sits **below process startup**, so it fails while the property under test holds.

Measured, assertion swapped for a print, 5 samples:

```
1.296  1.173  1.355  1.167  1.200
```

Consistently over — not a spike — and **the rest of the test passed in every one of those runs**. It was timing bash + the fswatch stub + python startup, not the behaviour.

## Why 2.5s, and why it still discriminates

The handler this test exists to catch blocks for **4s**. A watcher that serialised behind it arrives at 4s+ and still fails. The new bound sits **1.15s above measured startup** and **1.5s below the blocking duration** — margin on both sides, instead of tuned to whichever machine happened to run it.

## Why it is worth a patch rather than a shrug

**Two separate mechanisms, and they are located differently** (corrected after review — my first
version conflated them):

1. **Within this file.** It is a bare script: 29 module-level `def test_` called sequentially under
   `__main__`, no unittest/pytest runner. The first `AssertionError` aborts the remaining calls **by
   the file's own structure**. This test is call **#24 of 29**, so 5 later tests in the file never run.
2. **Across files.** `test:py` is `find tests -name '*.test.py' | sort | while read f; do … || exit 1; done`.
   That `|| exit 1` ends the loop, so every file sorted after this one never runs. This file sorts at
   **403 of 437**, so **34 further files** are skipped.

So the cost is larger than I first wrote, but only the second half belongs to #2755 — that PR fixes
the cross-file `|| exit 1`, not the within-file abort.

```
origin/main   fails at call #24/29 -> 5 tests in-file + 34 files skipped
this branch   full file rc=0 — "task workstream session worker tests passed"
```

## Scope, checked not assumed

The identical literal appears once more, line 1208 in `test_codex_notifier_dispatches_each_isolated_task_once_without_waiting`. That test **passes 3/3** here — different setup, faster startup — so it is not the same defect and is untouched.

Related: #2755 fixes the runner's stop-at-first-failure behaviour, which is what turns one over-tight bound into a file-wide blackout. Complementary, not overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## What this does NOT buy — added after a peer flagged the risk of the wrong reading

This fixes a **developer-machine** blocker, not a CI one. The distinction matters because this file
*is* a third of the fleet's CI failures today, and it would be easy to merge this expecting relief:

```
line 953  test_watcher_bounds_provider_backlog…   fails 6/6 LOCALLY, 0 times in CI   <- this PR
line 804  test_required_team_handler_shutdown…    every CI failure of this file      <- NOT this PR
```

Every CI failure of this file I have personally opened (#2779, #2798, #2712) aborts at **line 804**,
the privilege-boundary assertion — which is #2799's subject, not this one. So merging this will not
turn any red CI green. What it does buy is that the file becomes runnable end-to-end on a developer
machine, where it currently aborts at call 24 of 29 and takes 5 in-file tests plus 34 later files
with it.
