### PR TITLE
fix(start-cli): no silent ~/.claude fallback — refuse when the config-dir helper is missing

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -30,11 +30,8 @@ cd "$REPO"
 # else system python3.
 # Single-sourced in scripts/python-binary.sh (see there for why the bare-name
 # fallback this replaced was the CLT-dialog trigger).
-# Source OPTIONALLY. tests/start-cli-claude-config-dir.test.sh pins a contract
-# older than this change: a checkout without the M0 helper must still spawn
-# claude ("helper missing -> silent fallback"). A hard exit here broke that, so
-# the guard lives at each call site instead — which is what CR #2599 actually
-# needs (no `"" -c ...`), without turning a missing helper into a launch failure.
+# Source OPTIONALLY: a missing python helper must not abort here — the guard
+# lives at each call site (CR #2599 needs no `"" -c ...`, not a launch failure).
 PY=""
 if [ -r "$REPO/scripts/python-binary.sh" ]; then
   . "$REPO/scripts/python-binary.sh"
@@ -181,7 +178,9 @@ fi
 # into the workspace tree rather than the global ~/.claude/.
 #
 # Defense in depth:
-#   - M0 helper missing → silent fallback (legacy install, extracted tarball).
+#   - M0 helper missing → REFUSE to start (a silent ~/.claude fallback switches
+#     keychain identity + memory + sessions without a trace). Legacy installs
+#     opt in explicitly with SUTANDO_ALLOW_DEFAULT_CONFIG_DIR=1.
 #   - Helper present + config valid → export env for every claude invocation
 #     below (no-tmux fallback at L~75, TTY exec at L~115, no-TTY detached at
 #     L~120 all inherit it).
@@ -328,6 +327,13 @@ PY
     exit 1
   fi
   rm -f "$_ccd_err"
+elif [ "${SUTANDO_ALLOW_DEFAULT_CONFIG_DIR:-0}" = "1" ]; then
+  echo "start-cli: WARNING — M0 helper missing; running with the DEFAULT ~/.claude config dir (explicit legacy opt-in)" >&2
+else
+  echo "start-cli: $REPO/scripts/sutando-config.sh missing or not executable — refusing to start the core." >&2
+  echo "start-cli: a silent fallback to ~/.claude would switch credentials, memory and sessions to a different identity." >&2
+  echo "start-cli: fix the checkout (git checkout scripts/sutando-config.sh; chmod +x) or set SUTANDO_ALLOW_DEFAULT_CONFIG_DIR=1 to accept the default dir." >&2
+  exit 1
 fi
 
 # NO --model flag: the core inherits the user's global model, so 1M stays the

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -2,7 +2,7 @@
 # Integration test for src/agent/claude/cli/start-cli.sh's CLAUDE_CONFIG_DIR export.
 #
 # Covers the 3 states the design doc enumerated:
-#   1. M0 helper missing                              → silent fallback, claude spawns w/o env
+#   1. M0 helper missing                              → refuse (exit 1); opt-in env spawns w/ warning
 #   2. helper present + valid config                  → env exported to claude
 #   3. helper present + invariant-violating config    → exit 1, refuse to start
 #
@@ -173,32 +173,49 @@ cleanup_sandbox() {
 REAL_REPO="$(cd "$(dirname "$0")/.." && pwd)"
 
 # ----------------------------------------------------------------------
-# 1. M0 helper MISSING → silent fallback, start-cli still launches claude,
-#    CLAUDE_CONFIG_DIR is NOT set (or set to default from the parent env).
+# 1. M0 helper MISSING → refuse to start (a silent ~/.claude fallback would
+#    switch identity); 1b. explicit opt-in env spawns with a warning, no CCD.
 # ----------------------------------------------------------------------
-test_helper_missing_silent_fallback() {
+test_helper_missing_refuses() {
   setup_sandbox "no" "(unused)"
-  # Run start-cli; should reach claude stub without erroring on missing helper.
-  bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
+  _err="$(bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null 2>&1 >/dev/null)"
   rc=$?
-  if [ "$rc" != "0" ]; then
-    echo "  FAIL: start-cli exit $rc (expected 0 — helper-missing should be silent fallback)"
+  if [ "$rc" = "0" ]; then
+    echo "  FAIL: exit 0 (expected refusal — helper missing must not silently fall back)"
     cleanup_sandbox; return 1
   fi
-  if [ ! -f "$ENV_DUMP" ]; then
-    echo "  FAIL: claude stub never ran — start-cli didn't reach the spawn"
+  if [ -f "$ENV_DUMP" ]; then
+    echo "  FAIL: claude stub ran despite the refusal"
     cleanup_sandbox; return 1
   fi
-  # CLAUDE_CONFIG_DIR should NOT be set by start-cli (the helper-present
-  # block was skipped). If the parent env had one, it'd pass through, but
-  # we cleared the test env.
-  if grep -q "^CLAUDE_CONFIG_DIR=" "$ENV_DUMP"; then
-    echo "  FAIL: CLAUDE_CONFIG_DIR was set even though helper is absent"
-    grep "^CLAUDE_CONFIG_DIR=" "$ENV_DUMP"
+  if ! printf '%s' "$_err" | grep -q "refusing to start the core"; then
+    echo "  FAIL: refusal message missing from stderr"
     cleanup_sandbox; return 1
   fi
   cleanup_sandbox
-  return 0
+}
+
+test_helper_missing_optin_spawns_with_warning() {
+  setup_sandbox "no" "(unused)"
+  _err="$(SUTANDO_ALLOW_DEFAULT_CONFIG_DIR=1 bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null 2>&1 >/dev/null)"
+  rc=$?
+  if [ "$rc" != "0" ]; then
+    echo "  FAIL: exit $rc (opt-in should spawn)"
+    cleanup_sandbox; return 1
+  fi
+  if [ ! -f "$ENV_DUMP" ]; then
+    echo "  FAIL: claude stub never ran under the opt-in"
+    cleanup_sandbox; return 1
+  fi
+  if grep -q "^CLAUDE_CONFIG_DIR=" "$ENV_DUMP"; then
+    echo "  FAIL: CLAUDE_CONFIG_DIR set even though helper is absent"
+    cleanup_sandbox; return 1
+  fi
+  if ! printf '%s' "$_err" | grep -q "WARNING"; then
+    echo "  FAIL: opt-in fallback did not warn"
+    cleanup_sandbox; return 1
+  fi
+  cleanup_sandbox
 }
 
 # ----------------------------------------------------------------------
@@ -281,7 +298,8 @@ test_block_present_in_start_cli() {
 echo "tests/start-cli-claude-config-dir.test.sh — running"
 echo
 
-run_test "1. helper missing → silent fallback"              test_helper_missing_silent_fallback
+run_test "1. helper missing → refuses to start"             test_helper_missing_refuses
+run_test "1b. helper missing + opt-in → spawns w/ warning"   test_helper_missing_optin_spawns_with_warning
 run_test "2. helper + valid config → env exported"          test_valid_config_exports_env
 run_test "3. helper + invalid config → refuses to start"    test_invalid_config_refuses_to_start
 run_test "4. source-tied guard: block present in script"    test_block_present_in_start_cli


### PR DESCRIPTION
## Why (owner-raised, Master Room 2026-08-11)

start-cli resolves the workspace-scoped `CLAUDE_CONFIG_DIR` via `scripts/sutando-config.sh`. When that helper is missing or not executable, the block silently falls through and the core launches against the DEFAULT `~/.claude` — which silently switches the keychain credential item (they're namespaced by config dir), the memory tree, sessions, and onboarding state to a different identity. Tonight's dual-keychain-item credential incident showed exactly how much damage divergent config-dir identities can do. The invalid-config case already refuses; the missing-helper case was the remaining silent path.

## What

- Missing/non-executable helper → **refuse to start** with a three-line error naming the file, the danger, and both remedies.
- Explicit legacy escape: `SUTANDO_ALLOW_DEFAULT_CONFIG_DIR=1` accepts the default dir with a loud WARNING (extracted-tarball installs keep a path forward; matches this script's existing env-opt-in idiom, e.g. `SUTANDO_ACCEPT_BYPASS_PERMISSIONS`).
- The valid/invalid-config branches are unchanged.
- Stale comment referencing the retired silent-fallback contract updated (python-binary sourcing rationale stands on its own).

## Tests

`tests/start-cli-claude-config-dir.test.sh` contract flipped and extended: case 1 now asserts refusal (exit ≠0, claude never spawns, message on stderr); new case 1b asserts the opt-in spawns with a warning and still no forced CCD. Before/after: at the parent commit the new case 1 FAILS (the script exits 0 and spawns — the silent fallback); at HEAD 5/5 green. Also green at HEAD: start-cli-proxy-routing (5), compat-shim, --visible contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)