### PR TITLE
fix(health-check): quota-telemetry names the wrong mechanism for an unrouted core

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3863,11 +3863,8 @@ def check_quota_telemetry(proxy_status: str, core_env_prober=None) -> dict:
     the proxy. Only the core launcher (`src/agent/claude/cli/start-cli.sh`)
     exports ANTHROPIC_BASE_URL=http://localhost:7846, and only when the proxy
     port already has a listener at launch — so a core started outside the
-    launcher, or started before the proxy bound, stays unrouted for its whole
-    session. Result on such a host: the proxy is healthy and listening, every
-    check is green, and quota telemetry is silently absent forever. The
-    proactive loop's per-pass budget check reads "unknown" on every pass and
-    nobody is told why.
+    launcher, or started before it bound, stays unrouted and every other check
+    still reads green.
 
     The existing credential-proxy check can't catch this: it is a plain
     TCP-listening probe (correctly so — a forwarding proxy has no liveness

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3860,12 +3860,14 @@ def check_quota_telemetry(proxy_status: str, core_env_prober=None) -> dict:
 
     quota-state.json is written by the proxy from the quota headers on
     upstream responses, so it only appears if a core actually ROUTES through
-    the proxy. `src/startup.sh` is the only thing that exports
-    ANTHROPIC_BASE_URL=http://localhost:7846 — and a core launched by the
-    desktop supervisor never runs startup.sh. Result on such a host: the
-    proxy is healthy and listening, every check is green, and quota
-    telemetry is silently absent forever. The proactive loop's per-pass
-    budget check reads "unknown" on every pass and nobody is told why.
+    the proxy. Only the core launcher (`src/agent/claude/cli/start-cli.sh`)
+    exports ANTHROPIC_BASE_URL=http://localhost:7846, and only when the proxy
+    port already has a listener at launch — so a core started outside the
+    launcher, or started before the proxy bound, stays unrouted for its whole
+    session. Result on such a host: the proxy is healthy and listening, every
+    check is green, and quota telemetry is silently absent forever. The
+    proactive loop's per-pass budget check reads "unknown" on every pass and
+    nobody is told why.
 
     The existing credential-proxy check can't catch this: it is a plain
     TCP-listening probe (correctly so — a forwarding proxy has no liveness
@@ -3962,19 +3964,22 @@ def check_quota_telemetry(proxy_status: str, core_env_prober=None) -> dict:
                 f"working ({int(agent_age / 60)}m since the last loop pass) — the proxy "
                 "is up but nothing is routing through it any more, so the file on disk "
                 "is a leftover from when it was. Quota-based budgeting is quoting stale "
-                "numbers as current. Check ANTHROPIC_BASE_URL on the running core; the "
-                "core launcher (src/agent/claude/cli/start-cli.sh) exports it only when "
-                "the proxy port already has a listener at launch."
+                "numbers as current. Check ANTHROPIC_BASE_URL on the running core: only "
+                "the core launcher (src/agent/claude/cli/start-cli.sh) exports it, and "
+                "only when the proxy port already has a listener at launch — so a core "
+                "started outside the launcher, or started before the proxy bound, stays "
+                "unrouted for its whole session."
             )
         return check
     check["status"] = "warn"
     check["detail"] = (
-        "credential proxy is up but has never written quota-state.json — "
-        "nothing is routing through it (ANTHROPIC_BASE_URL unset). The core "
-        "launcher (src/agent/claude/cli/start-cli.sh) exports it only when the "
-        "proxy port already has a listener at the moment the core starts, so a "
-        "proxy that binds after the core leaves this host unrouted for the whole "
-        "session. Quota-based budgeting is blind on this host."
+        "credential proxy is up but has never written quota-state.json — nothing "
+        "is routing through it (ANTHROPIC_BASE_URL unset on the running core). "
+        "Only the core launcher (src/agent/claude/cli/start-cli.sh) exports it, "
+        "and only when the proxy port already has a listener at launch — so a "
+        "core started outside the launcher, or started before the proxy bound, "
+        "stays unrouted for its whole session. Quota-based budgeting is blind "
+        "on this host."
     )
     return check
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3962,16 +3962,19 @@ def check_quota_telemetry(proxy_status: str, core_env_prober=None) -> dict:
                 f"working ({int(agent_age / 60)}m since the last loop pass) — the proxy "
                 "is up but nothing is routing through it any more, so the file on disk "
                 "is a leftover from when it was. Quota-based budgeting is quoting stale "
-                "numbers as current. Check ANTHROPIC_BASE_URL on the running core "
-                "(exported by src/startup.sh; a supervisor-launched core never runs it)."
+                "numbers as current. Check ANTHROPIC_BASE_URL on the running core; the "
+                "core launcher (src/agent/claude/cli/start-cli.sh) exports it only when "
+                "the proxy port already has a listener at launch."
             )
         return check
     check["status"] = "warn"
     check["detail"] = (
         "credential proxy is up but has never written quota-state.json — "
-        "nothing is routing through it (ANTHROPIC_BASE_URL unset; set by "
-        "src/startup.sh, which a supervisor-launched core never runs). "
-        "Quota-based budgeting is blind on this host."
+        "nothing is routing through it (ANTHROPIC_BASE_URL unset). The core "
+        "launcher (src/agent/claude/cli/start-cli.sh) exports it only when the "
+        "proxy port already has a listener at the moment the core starts, so a "
+        "proxy that binds after the core leaves this host unrouted for the whole "
+        "session. Quota-based budgeting is blind on this host."
     )
     return check
 

--- a/tests/health-check-quota-telemetry.test.py
+++ b/tests/health-check-quota-telemetry.test.py
@@ -4,11 +4,13 @@ producing no quota state.
 
 The gap it covers: quota-state.json is written by the credential proxy from
 upstream response headers, so it only appears if a core actually ROUTES
-through the proxy. The core launcher (src/agent/claude/cli/start-cli.sh)
-exports ANTHROPIC_BASE_URL only when the proxy port already has a listener at
-the moment the core starts, so a proxy that binds seconds AFTER the core --
-routine when both are supervised -- leaves that core unrouted for its whole
-session. On such a host the proxy is healthy and listening,
+through the proxy. Only the core launcher (src/agent/claude/cli/start-cli.sh)
+exports ANTHROPIC_BASE_URL, and only when the proxy port already has a listener
+at launch. TWO conditions leave a core unrouted, and the probe cannot tell them
+apart: the core was started outside the launcher (straight from tmux, no
+startup.sh, no start-cli.sh), or it was started by the launcher before the proxy
+bound -- routine when both are supervised. Both were observed on live hosts, one
+each. On such a host the proxy is healthy and listening,
 every check is green, and quota telemetry is silently absent forever — the
 proactive loop's budget check reads "unknown" every pass with no explanation.
 
@@ -80,6 +82,19 @@ class TestQuotaTelemetryCheck(unittest.TestCase):
         # reader has no idea why an up proxy produces nothing.
         self.assertIn("ANTHROPIC_BASE_URL", r["detail"])
 
+    def test_absent_message_names_the_condition_not_one_cause(self):
+        """The probe sees an unrouted core; it cannot see WHICH way it got there.
+        Two causes were each observed on a live host — launched outside the
+        launcher entirely, and launched by it before the proxy bound — so naming
+        either alone sends the reader on the other host to an absent bug."""
+        d = self.hc.check_quota_telemetry("ok")["detail"]
+        self.assertIn("src/agent/claude/cli/start-cli.sh", d)
+        self.assertIn("outside the launcher", d)
+        self.assertIn("before the proxy bound", d)
+        # startup.sh stopped being the exporter in #2417; pointing at it sends
+        # the reader to "the supervisor bypasses startup.sh", an absent bug.
+        self.assertNotIn("startup.sh", d)
+
     def test_proxy_down_stays_silent(self):
         """Not every host routes through the proxy, and its own check already
         reports it as down. Warning twice would be noise."""
@@ -136,6 +151,17 @@ class TestQuotaTelemetryCheck(unittest.TestCase):
         self.assertIn("ANTHROPIC_BASE_URL", r["detail"])
         self.assertIn("312h", r["detail"])
         self.assertIn("1m", r["detail"])
+
+    def test_stale_message_names_the_condition_not_one_cause(self):
+        """Same two causes as the absent branch — this message is read by the
+        same person on the same host, so it must not pick one either."""
+        self._write_quota(mtime_age_sec=60 * 60 * 24 * 13)
+        self._write_core_status(mtime_age_sec=60)
+        d = self.hc.check_quota_telemetry("ok")["detail"]
+        self.assertIn("src/agent/claude/cli/start-cli.sh", d)
+        self.assertIn("outside the launcher", d)
+        self.assertIn("before the proxy bound", d)
+        self.assertNotIn("startup.sh", d)
 
     def test_idle_host_with_stale_quota_stays_silent(self):
         """The false positive the original decision was protecting against,

--- a/tests/health-check-quota-telemetry.test.py
+++ b/tests/health-check-quota-telemetry.test.py
@@ -4,9 +4,11 @@ producing no quota state.
 
 The gap it covers: quota-state.json is written by the credential proxy from
 upstream response headers, so it only appears if a core actually ROUTES
-through the proxy. src/startup.sh is the only thing exporting
-ANTHROPIC_BASE_URL=http://localhost:7846, and a supervisor-launched core
-never runs startup.sh. On such a host the proxy is healthy and listening,
+through the proxy. The core launcher (src/agent/claude/cli/start-cli.sh)
+exports ANTHROPIC_BASE_URL only when the proxy port already has a listener at
+the moment the core starts, so a proxy that binds seconds AFTER the core --
+routine when both are supervised -- leaves that core unrouted for its whole
+session. On such a host the proxy is healthy and listening,
 every check is green, and quota telemetry is silently absent forever — the
 proactive loop's budget check reads "unknown" every pass with no explanation.
 

--- a/tests/health-check-quota-telemetry.test.py
+++ b/tests/health-check-quota-telemetry.test.py
@@ -6,11 +6,8 @@ The gap it covers: quota-state.json is written by the credential proxy from
 upstream response headers, so it only appears if a core actually ROUTES
 through the proxy. Only the core launcher (src/agent/claude/cli/start-cli.sh)
 exports ANTHROPIC_BASE_URL, and only when the proxy port already has a listener
-at launch. TWO conditions leave a core unrouted, and the probe cannot tell them
-apart: the core was started outside the launcher (straight from tmux, no
-startup.sh, no start-cli.sh), or it was started by the launcher before the proxy
-bound -- routine when both are supervised. Both were observed on live hosts, one
-each. On such a host the proxy is healthy and listening,
+at launch — so a core started outside the launcher, or started by it before the
+proxy bound, stays unrouted. On such a host the proxy is healthy and listening,
 every check is green, and quota telemetry is silently absent forever — the
 proactive loop's budget check reads "unknown" every pass with no explanation.
 
@@ -83,16 +80,14 @@ class TestQuotaTelemetryCheck(unittest.TestCase):
         self.assertIn("ANTHROPIC_BASE_URL", r["detail"])
 
     def test_absent_message_names_the_condition_not_one_cause(self):
-        """The probe sees an unrouted core; it cannot see WHICH way it got there.
-        Two causes were each observed on a live host — launched outside the
-        launcher entirely, and launched by it before the proxy bound — so naming
-        either alone sends the reader on the other host to an absent bug."""
+        """The probe sees an unrouted core, not WHICH way it got there, so naming
+        one of the two causes sends the reader on the other host to an absent bug."""
         d = self.hc.check_quota_telemetry("ok")["detail"]
         self.assertIn("src/agent/claude/cli/start-cli.sh", d)
         self.assertIn("outside the launcher", d)
         self.assertIn("before the proxy bound", d)
-        # startup.sh stopped being the exporter in #2417; pointing at it sends
-        # the reader to "the supervisor bypasses startup.sh", an absent bug.
+        # startup.sh is no longer the exporter; naming it would send the reader
+        # to "the supervisor bypasses startup.sh", an absent bug.
         self.assertNotIn("startup.sh", d)
 
     def test_proxy_down_stays_silent(self):


### PR DESCRIPTION
## The bug

Both `quota-telemetry` messages tell the reader to blame `src/startup.sh` and *"a supervisor-launched core never runs it."* Measured on a live host, that is **not** why the core is unrouted.

`#2417` moved the routing decision into the core launcher. On an unrouted host, `src/agent/claude/cli/start-cli.sh` **has** run — it is the core process's own parent — and it exported nothing because its guard is a one-shot `lsof` on the proxy port, evaluated at launch:

```
16:09:53Z   start-cli.sh runs   (guard evaluates — no listener yet)
16:09:58Z   proxy listener binds
```

Five seconds. Both are supervised, so that ordering is routine rather than exceptional, and the core stays unrouted for the whole session.

## Why a message deserves its own PR

The probe fires on **every health run**, which makes it the most-read explanation of this symptom on any affected host — and it points at a file that is no longer the mechanism. Following it leads to *"the supervisor bypasses startup.sh"*, a different and absent bug. I nearly reported exactly that to a peer on this host's evidence before checking the process tree.

The test's docstring carried the same wrong rationale, so it is corrected alongside — that docstring is the explanation a future reader trusts when deciding whether the probe is right.

## Evidence

```
python3 tests/health-check-quota-telemetry.test.py
Ran 43 tests   OK   rc=0
```

**Control — the suite genuinely gates this text**, rather than passing vacuously. Deliberately corrupting the surviving assertion string:

```
rc=1, 7 failure lines
```

and restoring it returns `rc=0`. Worth doing because "43 tests OK" on a message-only change proves nothing unless the suite would have noticed the message changing.

```
bash scripts/review-checks.sh --diff <diff>
review-checks: PASS (hardcoded-paths clean)
```

## Scope

Message and docstring only — no behaviour change. Complements #2800, which fixes the race itself; this makes the diagnostic point at the right place whether or not that lands.
