### PR TITLE
fix(tests): two start-cli tests wrote to the LIVE workspace and faked a session boundary

### DIFF
--- a/tests/start-cli-model-pin.test.py
+++ b/tests/start-cli-model-pin.test.py
@@ -13,8 +13,8 @@ SCRIPT = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
 
 
 def _isolated_workspace(td: Path) -> str:
-    """A redirected workspace must exist WITH its state/ dir: start-cli.sh writes
-    <ws>/state/core-supervisor-relay-loop.pid and aborts under set -e if it cannot."""
+    """A redirected workspace needs its state/ dir: start-cli.sh writes
+    <ws>/state/core-supervisor-relay-loop.pid and aborts under set -e without it."""
     ws = td / "workspace"
     (ws / "state").mkdir(parents=True, exist_ok=True)
     return str(ws)

--- a/tests/start-cli-model-pin.test.py
+++ b/tests/start-cli-model-pin.test.py
@@ -12,6 +12,14 @@ REPO = Path(__file__).resolve().parent.parent
 SCRIPT = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
 
 
+def _isolated_workspace(td: Path) -> str:
+    """A redirected workspace must exist WITH its state/ dir: start-cli.sh writes
+    <ws>/state/core-supervisor-relay-loop.pid and aborts under set -e if it cannot."""
+    ws = td / "workspace"
+    (ws / "state").mkdir(parents=True, exist_ok=True)
+    return str(ws)
+
+
 def _launch_argv(model_env: "str | None") -> list[str]:
     """Run start-cli.sh through its no-tmux fallback and return claude's argv."""
     with tempfile.TemporaryDirectory() as td:
@@ -38,7 +46,7 @@ def _launch_argv(model_env: "str | None") -> list[str]:
             # start-cli.sh stamps <workspace>/state/session-starts.log; without
             # this redirect the run appends a fake launch to the LIVE workspace.
             "SUTANDO_TEST_MODE": "1",
-            "SUTANDO_WORKSPACE": str(td / "workspace"),
+            "SUTANDO_WORKSPACE": _isolated_workspace(td),
         }
         if model_env is not None:
             env["SUTANDO_CORE_MODEL"] = model_env
@@ -180,7 +188,7 @@ def case_tmux_launch_clears_a_pinned_socket() -> list[str]:
                 "HOME": str(td / "home"),
                 "SUTANDO_TMUX_SOCKET": str(sock),
                 "SUTANDO_TEST_MODE": "1",
-                "SUTANDO_WORKSPACE": str(td / "workspace"),
+                "SUTANDO_WORKSPACE": _isolated_workspace(td),
             }
             # The script may exec `tmux attach` and block; that is fine. Kill the
             # whole group after the clear has had its chance to run.
@@ -239,7 +247,7 @@ def case_fresh_socket_server_is_born_unpinned() -> list[str]:
                 "HOME": str(td / "home"),
                 "SUTANDO_TMUX_SOCKET": str(sock),
                 "SUTANDO_TEST_MODE": "1",
-                "SUTANDO_WORKSPACE": str(td / "workspace"),
+                "SUTANDO_WORKSPACE": _isolated_workspace(td),
                 "SUTANDO_CORE_MODEL": "opus",   # the pin is in the LAUNCHER's env
             }
             out, timed_out = _run_launcher(env, td / "launcher.log")
@@ -313,7 +321,7 @@ def case_bare_invocation_still_warns_on_a_pinned_live_core() -> list[str]:
                 "HOME": str(td / "home"),
                 "SUTANDO_TMUX_SOCKET": str(sock),
                 "SUTANDO_TEST_MODE": "1",
-                "SUTANDO_WORKSPACE": str(td / "workspace"),
+                "SUTANDO_WORKSPACE": _isolated_workspace(td),
             }
             out, timed_out = _run_launcher(env, td / "launcher.log")
             if timed_out:

--- a/tests/start-cli-model-pin.test.py
+++ b/tests/start-cli-model-pin.test.py
@@ -35,6 +35,10 @@ def _launch_argv(model_env: "str | None") -> list[str]:
             "PATH": f"{bind}:/bin",
             "HOME": str(td),
             "ARGS_FILE": str(args_file),
+            # start-cli.sh stamps <workspace>/state/session-starts.log; without
+            # this redirect the run appends a fake launch to the LIVE workspace.
+            "SUTANDO_TEST_MODE": "1",
+            "SUTANDO_WORKSPACE": str(td / "workspace"),
         }
         if model_env is not None:
             env["SUTANDO_CORE_MODEL"] = model_env
@@ -175,6 +179,8 @@ def case_tmux_launch_clears_a_pinned_socket() -> list[str]:
                 "PATH": f"{bind}:{Path(tmux).parent}:/usr/bin:/bin:/usr/sbin",
                 "HOME": str(td / "home"),
                 "SUTANDO_TMUX_SOCKET": str(sock),
+                "SUTANDO_TEST_MODE": "1",
+                "SUTANDO_WORKSPACE": str(td / "workspace"),
             }
             # The script may exec `tmux attach` and block; that is fine. Kill the
             # whole group after the clear has had its chance to run.
@@ -232,6 +238,8 @@ def case_fresh_socket_server_is_born_unpinned() -> list[str]:
                 "PATH": f"{bind}:{Path(tmux).parent}:/usr/bin:/bin:/usr/sbin",
                 "HOME": str(td / "home"),
                 "SUTANDO_TMUX_SOCKET": str(sock),
+                "SUTANDO_TEST_MODE": "1",
+                "SUTANDO_WORKSPACE": str(td / "workspace"),
                 "SUTANDO_CORE_MODEL": "opus",   # the pin is in the LAUNCHER's env
             }
             out, timed_out = _run_launcher(env, td / "launcher.log")
@@ -304,6 +312,8 @@ def case_bare_invocation_still_warns_on_a_pinned_live_core() -> list[str]:
                 "PATH": f"{bind}:{Path(tmux).parent}:/usr/bin:/bin:/usr/sbin",
                 "HOME": str(td / "home"),
                 "SUTANDO_TMUX_SOCKET": str(sock),
+                "SUTANDO_TEST_MODE": "1",
+                "SUTANDO_WORKSPACE": str(td / "workspace"),
             }
             out, timed_out = _run_launcher(env, td / "launcher.log")
             if timed_out:

--- a/tests/start-cli-restart-verify.test.py
+++ b/tests/start-cli-restart-verify.test.py
@@ -112,6 +112,10 @@ def _run(restart: bool, session: bool, core: bool, force: bool = False, wedged: 
             "CORE_MARK": str(core_mark),
             # keep the run fast: the fix polls in 0.2s ticks up to a few seconds.
             "SUTANDO_TMUX_SOCKET": str(td / "sock"),
+            # start-cli.sh appends to <workspace>/state/session-starts.log and
+            # logs/restart-attempts.log; unredirected, the run writes LIVE state.
+            "SUTANDO_TEST_MODE": "1",
+            "SUTANDO_WORKSPACE": str(td / "workspace"),
         }
         if wedged:
             env["WEDGED"] = "1"
@@ -191,6 +195,33 @@ def case_force_restart_wedged_escalates_to_sigkill():
     return fails
 
 
+def _live_log_lines() -> "tuple[int, int]":
+    """Line counts of the two logs start-cli.sh appends to in the LIVE workspace."""
+    ws = subprocess.run(["bash", str(REPO / "scripts" / "sutando-config.sh"), "workspace"],
+                        capture_output=True, text=True).stdout.strip()
+    def count(rel: str) -> int:
+        f = Path(ws) / rel
+        return len(f.read_text().splitlines()) if ws and f.exists() else 0
+    return count("state/session-starts.log"), count("logs/restart-attempts.log")
+
+
+def case_run_does_not_touch_the_live_workspace():
+    """The harness must isolate the workspace, not just tmux/claude.
+
+    start-cli.sh stamps `state/session-starts.log` on every session it creates
+    and `logs/restart-attempts.log` on every --restart. A stub run that reaches
+    the live copies fabricates a session boundary newer than the real
+    /schedule-crons stamp, and health-check's `session-crons` probe then reports
+    every still-registered cron as gone with an old session."""
+    before = _live_log_lines()
+    _run(restart=True, session=True, core=True)
+    after = _live_log_lines()
+    if after != before:
+        return [f"a stub run appended to the live workspace: "
+                f"(session-starts, restart-attempts) {before} -> {after}"]
+    return []
+
+
 def main() -> int:
     cases = [
         ("fresh-start-core-down-exits-nonzero", case_fresh_start_core_down_exits_nonzero),
@@ -199,6 +230,7 @@ def main() -> int:
         ("restart-does-not-reuse-orphan", case_restart_does_not_reuse_orphan),
         ("restart-wedged-aborts-not-kills", case_restart_wedged_aborts_not_kills),
         ("force-restart-wedged-escalates-to-sigkill", case_force_restart_wedged_escalates_to_sigkill),
+        ("run-does-not-touch-the-live-workspace", case_run_does_not_touch_the_live_workspace),
     ]
     all_failures = []
     for label, fn in cases:

--- a/tests/start-cli-restart-verify.test.py
+++ b/tests/start-cli-restart-verify.test.py
@@ -206,13 +206,8 @@ def _live_log_lines() -> "tuple[int, int]":
 
 
 def case_run_does_not_touch_the_live_workspace():
-    """The harness must isolate the workspace, not just tmux/claude.
-
-    start-cli.sh stamps `state/session-starts.log` on every session it creates
-    and `logs/restart-attempts.log` on every --restart. A stub run that reaches
-    the live copies fabricates a session boundary newer than the real
-    /schedule-crons stamp, and health-check's `session-crons` probe then reports
-    every still-registered cron as gone with an old session."""
+    """start-cli.sh stamps state/session-starts.log and logs/restart-attempts.log;
+    a stub run reaching the live copies fabricates a real-looking session boundary."""
     before = _live_log_lines()
     _run(restart=True, session=True, core=True)
     after = _live_log_lines()


### PR DESCRIPTION
## What

Two tests under `tests/` run `src/start-cli.sh` as a subprocess with a curated env. They stub tmux, pgrep, ps, `claude`, and `HOME` — but they leave the **workspace axis live**, so every run appends to the real workspace's `state/session-starts.log` and `logs/restart-attempts.log`.

This PR adds `SUTANDO_TEST_MODE=1` + `SUTANDO_WORKSPACE=<tmpdir>` to those env dicts, and adds a regression case that fails if a stub run touches the live logs.

## Why it matters (not just tidiness)

`start-cli.sh` appends to both files only on the session-**create** path (the "already running → attach" branch returns first):

- `log_restart_attempt()` → `>> "$ws/logs/restart-attempts.log"`
- the session stamp (`src/start-cli.sh` ~683–691) → `>> "$_ws/state/session-starts.log"`

`state/session-starts.log` is not a log for humans — it is a **load-bearing input**. `_last_core_launch_at()` (`src/health-check.py:3583`) reads the newest entry whose host is in `_local_host_labels()` and returns it as *this core's launch boundary*. `check_session_cron_registration()` (`src/health-check.py:941`) then compares that boundary against `hosts/<host>/schedule-crons-stamp.json`, and warns when the stamp predates the launch.

So a test run fabricates a session boundary newer than the real `/schedule-crons` stamp, and the probe reports that every still-registered cron died with a previous session. That is exactly what happened on this host:

```
⚠ session-crons   warn   stamp predates this session's launch (4745s older)
```

`CronList` showed all 9 crons alive the whole time. The warning's stated remedy is "re-run `/schedule-crons`", which carries the documented inline-fire hazard — a false positive here points the operator at a genuinely risky action.

## Before / after

Run in a clean full clone of `main` whose workspace resolves in-repo (`/Users/.../github/sutando/workspace`), so the measurement is self-contained and does not touch an operational workspace.

**BEFORE — parent commit (`bcc84d45`), both test files at `HEAD~1`:**

```
  start-cli-restart-verify.test.py rc=0
  start-cli-model-pin.test.py rc=0
[BEFORE] <workspace>/state/session-starts.log   : 0 -> 4   (delta +4)
[BEFORE] <workspace>/logs/restart-attempts.log  : 0 -> 10   (delta +10)
```

**AFTER — this commit:**

```
  start-cli-restart-verify.test.py rc=0
  start-cli-model-pin.test.py rc=0
[AFTER] <workspace>/state/session-starts.log   : 0 -> 0   (delta +0)
[AFTER] <workspace>/logs/restart-attempts.log  : 0 -> 0   (delta +0)
```

Both suites still pass; the only change is where they write.

## The new test actually fails without the fix

`case run-does-not-touch-the-live-workspace` counts the two live logs, runs the stub `--restart` path, and re-counts. Mutation check — isolation keys deleted from the harness env, everything else unchanged:

```
  ✓ case restart-wedged-aborts-not-kills
  ✓ case force-restart-wedged-escalates-to-sigkill
  ✗ case run-does-not-touch-the-live-workspace
      a stub run appended to the live workspace: (session-starts, restart-attempts) (3, 10) -> (4, 13)

1 failure(s)
```

Restored:

```
  ✓ case force-restart-wedged-escalates-to-sigkill
  ✓ case run-does-not-touch-the-live-workspace

start-cli.sh --restart verifies liveness and never false-succeeds.
```

## Live effect of clearing the fabricated entries

Removing the 17 test-generated `session-starts.log` entries newer than the real boot (and the 43 test-generated `restart-attempts.log` lines, all of them) cleared the warning on this host:

```
  ✓ session-crons                  ok           9 session cron(s) stamped registered this boot
```

## Why `SUTANDO_TEST_MODE`

`$SUTANDO_WORKSPACE` alone is ignored for workspace resolution post-v0.8 / #1440. `resolve_workspace()` (`src/sutando_config.py:315`) keeps an explicit test hatch:

```python
if env_val and os.environ.get("SUTANDO_TEST_MODE") == "1":
    return Path(env_val).expanduser().resolve()
```

65 test files already use this pair. This adds two more rather than inventing a mechanism.

## Relationship to #2622

#2622 (open, @sonichi) — "a test can be CCD-hermetic and still write to the live workspace" — is the same *class* of bug, and worth landing. It is not the same *mechanism* and does not overlap:

- #2622 changes `scripts/lint-hermetic-bridge-tests.py` and `tests/lint-resolver-stub-arity.test.py` only — an AST lint for zero-arg `_resolve_workspace` lambda stubs in Python tests.
- These two tests leak through a **bash subprocess with a curated env**; there is no Python resolver stub to lint. The AST lint cannot see them.

No file overlap, so no merge-order dependency either way.

## Scope

Test-only. No production code, no prompts, no tool behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
