### PR TITLE
fix(agent-api): a workspace dir that does not exist yet must not brick import

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -143,8 +143,8 @@ def _emit_task_processed(content: str) -> None:
 API_TOKEN = os.environ.get("SUTANDO_API_TOKEN", "")
 
 RESULT_DIR = WORKSPACE_DIR / "results"
-TASK_DIR.mkdir(exist_ok=True)
-RESULT_DIR.mkdir(exist_ok=True)
+TASK_DIR.mkdir(parents=True, exist_ok=True)
+RESULT_DIR.mkdir(parents=True, exist_ok=True)
 
 # In-memory task history (survives file cleanup, lost on restart)
 # {task_id: {status, text, time, result}}

--- a/src/github-webhook.py
+++ b/src/github-webhook.py
@@ -187,7 +187,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 f"access_tier: other\n"
                 f"task: {safe_task}\n"
             )
-            TASKS_DIR.mkdir(exist_ok=True)
+            TASKS_DIR.mkdir(parents=True, exist_ok=True)
             (TASKS_DIR / f"{task_id}.txt").write_text(task_content)
             _emit_github_telemetry()
             print(f"[{time.strftime('%H:%M:%S')}] {event_type}/{payload.get('action', '')} → {task_id}")

--- a/tests/workspace-dirs-created-when-parent-absent.test.py
+++ b/tests/workspace-dirs-created-when-parent-absent.test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Guard: import-time workspace dir creation must tolerate an absent parent.
+
+`WORKSPACE_DIR` comes from `resolve_workspace()`; if that path does not exist yet,
+`mkdir(exist_ok=True)` raises FileNotFoundError because it will not create parents.
+"""
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Patch resolve_workspace BEFORE importing the module under test, then report what happened.
+PROBE = r"""
+import sys, json
+from pathlib import Path
+sys.path.insert(0, {src!r})
+import workspace_default
+target = Path({target!r})
+workspace_default.resolve_workspace = lambda *a, **k: target
+import importlib.util
+spec = importlib.util.spec_from_file_location("_mut", {module!r})
+mod = importlib.util.module_from_spec(spec)
+try:
+    spec.loader.exec_module(mod)
+except FileNotFoundError as exc:
+    print(json.dumps({{"error": "FileNotFoundError", "detail": str(exc)}})); raise SystemExit(0)
+except Exception as exc:  # unrelated import failure — report, don't mask
+    print(json.dumps({{"error": type(exc).__name__, "detail": str(exc)}})); raise SystemExit(0)
+print(json.dumps({{
+    "error": None,
+    "tasks": (target / "tasks").is_dir(),
+    "results": (target / "results").is_dir(),
+    "resolved": str(target),
+}}))
+"""
+
+
+def run_probe(module: Path, target: Path):
+    code = PROBE.format(src=str(REPO / "src"), target=str(target), module=str(module))
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True,
+                         cwd=str(REPO), timeout=120)
+    import json
+    for line in reversed(out.stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            return json.loads(line)
+    raise AssertionError(f"probe produced no JSON.\nstdout={out.stdout[-800:]}\nstderr={out.stderr[-800:]}")
+
+
+class WorkspaceDirsCreatedWhenParentAbsent(unittest.TestCase):
+    def test_agent_api_imports_when_workspace_parent_is_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            # two levels absent: neither <td>/absent nor its child exists
+            target = Path(td) / "absent" / "workspace"
+            self.assertFalse(target.parent.exists(), "fixture must start with the parent missing")
+            res = run_probe(REPO / "src" / "agent-api.py", target)
+            self.assertIsNone(res["error"], f"import raised {res['error']}: {res.get('detail')}")
+            # isolation check: the dirs must land under the tmp target, not the live workspace
+            self.assertEqual(res["resolved"], str(target))
+            self.assertTrue(res["tasks"], "tasks/ not created under the absent parent")
+            self.assertTrue(res["results"], "results/ not created under the absent parent")
+
+    def test_every_workspace_relative_mkdir_passes_parents(self):
+        """Sites whose parent can be absent must not rely on exist_ok alone."""
+        import re
+        offenders = []
+        for rel in ("src/agent-api.py", "src/github-webhook.py"):
+            text = (REPO / rel).read_text()
+            for var in re.findall(r"^\s*([A-Z_]+)\s*=\s*WORKSPACE_DIR\s*/", text, re.M):
+                for m in re.finditer(rf"^\s*{var}\.mkdir\(([^)]*)\)", text, re.M):
+                    if "parents=True" not in m.group(1):
+                        offenders.append(f"{rel}: {var}.mkdir({m.group(1)})")
+        self.assertEqual(offenders, [], f"workspace-relative mkdir without parents=True: {offenders}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/workspace-dirs-created-when-parent-absent.test.py
+++ b/tests/workspace-dirs-created-when-parent-absent.test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-"""Guard: import-time workspace dir creation must tolerate an absent parent.
-
-`WORKSPACE_DIR` comes from `resolve_workspace()`; if that path does not exist yet,
-`mkdir(exist_ok=True)` raises FileNotFoundError because it will not create parents.
+"""Guard: import-time workspace dir creation must tolerate an absent resolved parent —
+workspace-relative mkdirs need parents=True, not exist_ok alone.
 """
 import subprocess
 import sys


### PR DESCRIPTION
## What

`WORKSPACE_DIR = resolve_workspace()` can point at a path that does not exist yet. `mkdir(exist_ok=True)` tolerates an existing directory but **will not create a missing parent**, so import raises `FileNotFoundError` at module scope.

Three sites are workspace-relative and can hit an absent parent:

| site | scope | var |
|---|---|---|
| `src/agent-api.py:146` | module → **import-time** | `TASK_DIR` |
| `src/agent-api.py:147` | module → **import-time** | `RESULT_DIR` |
| `src/github-webhook.py:190` | function | `TASKS_DIR` |

## Scope: two other bare `exist_ok=True` calls are NOT affected

I checked each call's target rather than grepping the pattern, because the pattern alone over-reports. Resolving every bare `mkdir(exist_ok=True)` to its definition:

```
src/agent-api.py:146      TASK_DIR   = WORKSPACE_DIR / "tasks"          parent can be MISSING -> vulnerable
src/agent-api.py:147      RESULT_DIR = WORKSPACE_DIR / "results"        parent can be MISSING -> vulnerable
src/github-webhook.py:190 TASKS_DIR  = WORKSPACE_DIR / "tasks"          parent can be MISSING -> vulnerable
src/discord-bridge.py:432 INBOX_DIR  = Path("/tmp/discord-inbox")       parent always exists  -> not affected
src/telegram-bridge.py:316 INBOX_DIR = REPO / "telegram-inbox"          parent always exists  -> not affected
```

`discord-bridge`'s workspace-relative dirs already pass `parents=True`. So this is 3 sites in 2 files, not a sweep.

## How it was found

While fixing #2757, whose red `diff coverage >= 95% (python)` had nothing to do with coverage: that PR deleted the tracked `workspace/.gitkeep`, so `workspace/` was absent on a clean CI checkout, `agent-api` raised `FileNotFoundError` at import, every test importing it died, and `coverage-gate.sh` printed "suite must be green before coverage is meaningful" and exited 1 under a coverage-named check. Restoring `.gitkeep` fixed that PR. **This PR fixes the fragility that made a single deleted empty file able to do that.** Root cause credit: Sutando-Pro.

## Evidence

Both new tests fail at the parent commit and pass at HEAD.

**Broken state (parent commit):**
```
FAILED (failures=2)
- ['src/agent-api.py: TASK_DIR.mkdir(exist_ok=True)',
   'src/agent-api.py: RESULT_DIR.mkdir(exist_ok=True)',
   'src/github-webhook.py: TASKS_DIR.mkdir(exist_ok=True)'] : workspace-relative mkdir without parents=True
```

**At HEAD:**
```
Ran 2 tests in 0.056s
OK
```

The behavioural test patches `workspace_default.resolve_workspace` (the mocking point that module's own docstring names) to a path **two levels** absent, imports `agent-api.py` in a subprocess, and asserts no `FileNotFoundError` plus that `tasks/` and `results/` were created. It also asserts the resolved path equals the tmp target, so a test that silently fell back to the live workspace would fail rather than pass.

**Existing suites for the changed files, at HEAD:**
```
existing suites: PASS=13 FAIL=0     (tests/agent-api-*.test.py, tests/github-webhook*.test.py)
```

## Worst-case disruption

Minimal and in the safe direction: `parents=True` only widens what `mkdir` will create. Any call that succeeded before still succeeds; the only behaviour change is that a previously-raising call now creates the missing parent. No new config, no migration, no default flipped.

@sonichi flagging you as usual.
