### PR TITLE
feat(paths): resolve channel secrets from state/auth/, outside the Team capability root

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -74,7 +74,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 import discord_config  # noqa: E402  — Sutando workspace-local discord config (#1147)
-from util_paths import channel_access_path, claude_home_path, personal_path, shared_personal_path, write_private_text  # noqa: E402
+from util_paths import channel_access_path, channel_env_path, claude_home_path, personal_path, shared_personal_path, write_private_text  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
 from optional_script import run_optional_script as _run_optional_script_shared  # noqa: E402
 from presenter_mode import presenter_mode_active  # noqa: E402
@@ -231,7 +231,7 @@ except Exception:  # pragma: no cover
 TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
 # Tighten perms whenever the token file exists — even when the token is already
 # in process env — so a world-readable .env never survives startup.
-channels_env = claude_home_path("channels", "discord", ".env")
+channels_env = channel_env_path("discord")
 if channels_env.exists():
     try:
         os.chmod(channels_env, 0o600)  # token file — enforce owner-only, mirrors access.json treatment

--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -16,7 +16,7 @@ import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from util_paths import claude_home_path  # noqa: E402
+from util_paths import channel_env_path, claude_home_path  # noqa: E402
 from discord_http import request_json  # noqa: E402
 
 # Runaway backstop only (not a depth target — depth is governed by --until):
@@ -144,7 +144,7 @@ def _parse_args(argv):
 
 
 def main(argv=None):
-    env = claude_home_path("channels", "discord", ".env")
+    env = channel_env_path("discord")
     token = _load_token(env)
     if not token:
         print(f"Requires DISCORD_BOT_TOKEN in {env}", file=sys.stderr)

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -32,7 +32,7 @@ import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from util_paths import claude_home_path  # noqa: E402
+from util_paths import channel_env_path, claude_home_path  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 import discord_config  # noqa: E402  — workspace-local Sutando discord config (#1147)
 from result_markers import parse_markers  # noqa: E402  — skip markers ([no-send] etc.)
@@ -84,7 +84,7 @@ def voice_connected() -> bool:
 def _load_token() -> str:
     """Read DISCORD_BOT_TOKEN from the first env file that has it."""
     for env_path in [
-        claude_home_path("channels", "discord", ".env"),
+        channel_env_path("discord"),
         REPO / ".env",
     ]:
         if not env_path.exists():

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -51,7 +51,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 # bends here rather than the guard.
 from git_binary import git_argv  # noqa: E402
 from git_binary import GitUnavailable  # noqa: E402
-from util_paths import _host_label, claude_home_path, claude_project_slug, legacy_dotted_workspace, shared_personal_path  # noqa: E402
+from util_paths import _host_label, channel_env_path, claude_home_path, claude_project_slug, legacy_dotted_workspace, shared_personal_path  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 from sutando_config import resolve_core_runtime  # noqa: E402
 from cron_entry_digest import digest_map, drifted  # noqa: E402
@@ -4632,7 +4632,7 @@ def _gateway_configured() -> bool:
     try:
         if os.environ.get("REMOTE_TASK_TOKEN") or os.environ.get("AG2_REMOTE_TOKEN"):
             return True
-        gw_env = claude_home_path("channels", "ag2space", ".env")
+        gw_env = channel_env_path("ag2space")
         if gw_env.exists():
             return any(
                 ln.startswith(("REMOTE_TASK_TOKEN=", "AG2_REMOTE_TOKEN="))
@@ -7743,7 +7743,7 @@ def _slack_token_from_env_file() -> str:
     $REPO/.env for hosts that keep it there instead.
     """
     candidates = [
-        claude_home_path("channels", "slack", ".env"),
+        channel_env_path("slack"),
         REPO_DIR / ".env",
     ]
     for env_path in candidates:

--- a/src/read_discord_channel.py
+++ b/src/read_discord_channel.py
@@ -41,7 +41,7 @@ import urllib.error
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from util_paths import channel_env_path, claude_home_path  # canonical ~/.claude/ resolver (no hand-rolled paths)
+from util_paths import channel_env_path, claude_home_path  # canonical resolvers — no hand-rolled paths
 from discord_http import request_json  # 429 Retry-After + 5xx backoff wrapper
 
 ACCESS_FILE = claude_home_path("channels", "discord", "access.json")

--- a/src/read_discord_channel.py
+++ b/src/read_discord_channel.py
@@ -41,11 +41,11 @@ import urllib.error
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from util_paths import claude_home_path  # canonical ~/.claude/ resolver (no hand-rolled paths)
+from util_paths import channel_env_path, claude_home_path  # canonical ~/.claude/ resolver (no hand-rolled paths)
 from discord_http import request_json  # 429 Retry-After + 5xx backoff wrapper
 
 ACCESS_FILE = claude_home_path("channels", "discord", "access.json")
-ENV_FILE = claude_home_path("channels", "discord", ".env")
+ENV_FILE = channel_env_path("discord")
 API = "https://discord.com/api/v10"
 
 

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -78,7 +78,7 @@ from dedup_recovery import plan_dedup_recovery  # noqa: E402
 from message_chunking import chunk_message  # noqa: E402  (Result Router S3 — shared fence-aware chunker)
 import local_task_protocol  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
-from util_paths import channel_access_path, claude_home_path, write_private_text  # noqa: E402
+from util_paths import channel_access_path, channel_env_path, claude_home_path, write_private_text  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
@@ -128,7 +128,7 @@ APP_TOKEN = os.environ.get("SLACK_APP_TOKEN", "")
 # supervisor-spawned bridge crash-loops on "not set". Mirrors discord-bridge.py.
 # Tighten perms whenever the token file exists — even when the tokens are already
 # in process env — so a world-readable .env never survives startup.
-channels_env = claude_home_path("channels", "slack", ".env")
+channels_env = channel_env_path("slack")
 if channels_env.exists():
     try:
         os.chmod(channels_env, 0o600)  # token file — enforce owner-only, mirrors access.json treatment

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -59,7 +59,7 @@ from result_markers import parse_markers  # noqa: E402
 from result_ready import read_ready_result  # noqa: E402
 from dedup_recovery import plan_dedup_recovery  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
-from util_paths import channel_access_path, claude_home_path, write_private_text  # noqa: E402
+from util_paths import channel_access_path, channel_env_path, claude_home_path, write_private_text  # noqa: E402
 
 from workspace_default import resolve_workspace  # noqa: E402
 from presenter_mode import presenter_mode_active  # noqa: E402
@@ -94,7 +94,7 @@ except ImportError:
 # `setdefault` previously let a stale TELEGRAM_BOT_TOKEN from a prior shell
 # session silently override the freshly-rotated value, same bug class as
 # skills/x-twitter/x-post.py (see PR #416 commit message for full context).
-channels_env = claude_home_path("channels", "telegram", ".env")
+channels_env = channel_env_path("telegram")
 if channels_env.exists():  # pragma: no cover — telegram import path not driven by the perms test
     try:
         os.chmod(channels_env, 0o600)  # token file — enforce owner-only, mirrors access.json treatment

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -382,6 +382,41 @@ def channel_access_path(source: str) -> Path:
     return canonical
 
 
+def channel_env_path(source: str) -> Path:
+    """Resolve `channels/<source>/.env` (bot tokens), preferring state/auth/.
+
+    Same prefer-canonical / fall-back-to-legacy shape as channel_access_path(),
+    for the *secret* half rather than the policy half.
+
+    Why the destination is `state/auth/`: the Team capability root is the owner
+    workspace, so anything under `$CLAUDE_CONFIG_DIR` inside it is readable by a
+    Team task that has Bash. `.claude-sutando/` cannot simply be read-denied —
+    it IS `CLAUDE_CONFIG_DIR`, so denying it stops the sandboxed provider
+    reading its own config. `state/auth/` is already the documented home for
+    per-host credential state, is already covered by the Team deny list, and is
+    exempt from transient-state cleanup, which makes the boundary structural
+    instead of a deny list that has to stay exhaustive.
+
+    The legacy fallback is what makes the move safe: readers keep working off
+    the existing file until it is physically relocated, so bridges do not lose
+    their tokens mid-flight.
+    """
+    canonical = _workspace_root() / "state" / "auth" / "channels" / source / ".env"
+    if canonical.exists():
+        return canonical
+    legacy = claude_home_path("channels", source, ".env")
+    if legacy != canonical and legacy.exists():
+        print(
+            f"[util_paths] DEPRECATION: channel secret for {source!r} still at "
+            f"{legacy} — canonical {canonical} missing. It sits inside the Team "
+            f"capability root; relocate it to state/auth/. This fallback is "
+            f"removed ~30 days post-migration.",
+            file=sys.stderr,
+        )
+        return legacy
+    return canonical
+
+
 # ---------------------------------------------------------------------------
 # Fallback-banner gate — fires ONCE per process when claude_home_path() lands
 # on the ~/.claude/ default because neither $CLAUDE_CONFIG_DIR nor $CLAUDE_HOME

--- a/tests/util-paths-channel-env.test.py
+++ b/tests/util-paths-channel-env.test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""channel_env_path() must prefer state/auth/ but never strand a live token.
+
+The move exists because $CLAUDE_CONFIG_DIR sits INSIDE the Team capability root,
+so a Team task with Bash can read channels/<src>/.env. The risk in fixing it is
+the opposite failure: a resolver that points at the new location before the file
+is physically there would take every bridge offline. So the legacy fallback is
+the load-bearing half, and it is what this pins.
+
+The canonical-preference assertion is only meaningful if the legacy file also
+exists at the same time — otherwise it passes for a resolver that always returns
+the canonical path and never falls back at all.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+
+def _load(workspace: Path, ccd: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("util_paths", REPO / "src" / "util_paths.py")
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    mod._workspace_root = lambda: workspace  # type: ignore[attr-defined]
+    return mod
+
+
+class TestChannelEnvPath(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        root = Path(self._td.name)
+        self.workspace = root / "workspace"
+        self.ccd = root / "ccd"
+        (self.workspace / "state" / "auth" / "channels" / "slack").mkdir(parents=True)
+        (self.ccd / "channels" / "slack").mkdir(parents=True)
+        self._prev = os.environ.get("CLAUDE_CONFIG_DIR")
+        os.environ["CLAUDE_CONFIG_DIR"] = str(self.ccd)
+        os.environ["SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER"] = "1"
+        self.mod = _load(self.workspace, self.ccd)
+        self.canonical = self.workspace / "state" / "auth" / "channels" / "slack" / ".env"
+        self.legacy = self.ccd / "channels" / "slack" / ".env"
+
+    def tearDown(self) -> None:
+        if self._prev is None:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        else:
+            os.environ["CLAUDE_CONFIG_DIR"] = self._prev
+        self._td.cleanup()
+
+    def test_falls_back_to_legacy_so_a_live_bridge_keeps_its_token(self) -> None:
+        """Pre-migration: only the legacy file exists. Losing this strands the bridge."""
+        self.legacy.write_text("SLACK_BOT_TOKEN=live\n")
+        err = io.StringIO()
+        with redirect_stderr(err):
+            got = self.mod.channel_env_path("slack")
+        self.assertEqual(got, self.legacy)
+        self.assertIn("DEPRECATION", err.getvalue())
+        self.assertIn("Team capability root", err.getvalue())
+
+    def test_prefers_canonical_even_while_the_legacy_file_still_exists(self) -> None:
+        """Both present — the post-copy, pre-delete window. Must pick state/auth/."""
+        self.legacy.write_text("SLACK_BOT_TOKEN=stale\n")
+        self.canonical.write_text("SLACK_BOT_TOKEN=migrated\n")
+        err = io.StringIO()
+        with redirect_stderr(err):
+            got = self.mod.channel_env_path("slack")
+        self.assertEqual(got, self.canonical)
+        self.assertNotIn("DEPRECATION", err.getvalue())
+
+    def test_returns_canonical_when_neither_exists_so_writers_land_in_state_auth(self) -> None:
+        got = self.mod.channel_env_path("slack")
+        self.assertEqual(got, self.canonical)
+
+    def test_canonical_is_under_state_auth_not_the_config_dir(self) -> None:
+        """The whole point: the resolved home must be outside $CLAUDE_CONFIG_DIR."""
+        got = self.mod.channel_env_path("slack")
+        self.assertNotIn(str(self.ccd), str(got))
+        self.assertIn(os.path.join("state", "auth"), str(got))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Channel bot tokens (`channels/<src>/.env`) resolve from `state/auth/` instead of `$CLAUDE_CONFIG_DIR`, via one new resolver that every reader now goes through. **Resolver + rewiring only — no files are moved by this PR.**

## Why

`$CLAUDE_CONFIG_DIR` sits **inside** the Team capability root, so `channels/*/.env` — live Discord/Slack/Telegram/AG2Space bot tokens — is readable by a Team task that has Bash. Raised as a [P1] on #2808 by @qingyun-wu.

The obvious fix does not work, and I measured it rather than assuming:

- **Read-denying `.claude-sutando/` breaks the runtime.** That directory *is* `CLAUDE_CONFIG_DIR`, so denying it stops the sandboxed provider reading its own config: `test_installed_claude_enforces_team_credential_and_network_boundary` goes PASS → FAIL. Bisected; narrowing to `channels/` does not rescue it.
- **The glob form does not scale.** `_credential_paths()` *enumerates* matches, and `**/.claude-sutando/**` expands to **3535 files** on a real workspace — into `denyRead`, `denyWrite` and `credentials.files` on every task.
- @liususan091219-susan-s-bot.agent named the deeper shape: the deny list **enumerates rather than bounds**, so a secret written *during* a run is never in it. Appending patterns cannot fix that.

`state/auth/` is already the documented home for per-host credential state, is already covered by the Team deny list, and is exempt from transient-state cleanup — so the boundary becomes structural instead of a list that has to stay exhaustive.

## Why this is safe to land while bridges are running

The legacy fallback is the load-bearing half, mirroring the existing `channel_access_path()` precedent: prefer canonical, fall back to the current location, warn once on stderr.

Verified against the **running install** — with `state/auth/` still empty, every live token resolves exactly where it does today:
```
discord    -> EXISTS  .../workspace/.claude-sutando/channels/discord/.env
slack      -> EXISTS  .../workspace/.claude-sutando/channels/slack/.env
telegram   -> EXISTS  .../workspace/.claude-sutando/channels/telegram/.env
ag2space   -> EXISTS  .../workspace/.claude-sutando/channels/ag2space/.env
ALL live tokens still resolvable: True
```
So behaviour is unchanged until someone physically relocates the files.

## Scope, and what is deliberately NOT here

- 8 call sites across `health-check`, `read_discord_channel`, `discord-read`, `dm-result`, and the slack/telegram/discord bridges now route through `channel_env_path()`.
- **`src/startup.sh` still probes the legacy path** to decide whether to launch each bridge. Harmless today (the files have not moved) but it must be updated *before* the physical move, or startup would skip a bridge whose token had relocated. Calling that out rather than half-doing it.
- The physical move itself is a separate, owner-gated step.

## Checks

`tests/util-paths-channel-env.test.py` 4/4 · `util-paths-ccd-banner` PASS · `channel-token-vault-fallback` PASS · `py_compile` on all 8 touched files · `git diff --check` · `review-checks.sh` PASS.

The new test is mutation-verified: removing the legacy fallback fails it. That assertion is the one that matters — a resolver pointing at the new home before the files arrive would take every bridge offline.

Refs #2808.
