### PR TITLE
fix(discord): a human's reply to their OWN message is addressed to us

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -3101,6 +3101,7 @@ async def _handle_discord_message(message, force=False):
                 reply_author_id=(getattr(_ref_author, "id", None) if _ref_author is not None else None),
                 self_id=_self_id,
                 other_agent_mentioned=_other_agent_mentioned,
+                author_id=getattr(message.author, "id", None),
             ):
                 print(f"  [skip] shared channel: not addressed to me "
                       f"(author_bot={bool(getattr(message.author, 'bot', False))}, "

--- a/src/discord_addressee.py
+++ b/src/discord_addressee.py
@@ -35,6 +35,7 @@ def is_addressed_in_shared_channel(
     reply_author_id,
     self_id,
     other_agent_mentioned: bool = False,
+    author_id=None,
 ) -> bool:
     """Return True iff this message should be processed as addressed to us.
 
@@ -67,7 +68,14 @@ def is_addressed_in_shared_channel(
     if bot_mentioned or role_mentioned or replying_to_me:
         return True
 
-    replying_to_other = bool(is_reply) and not replying_to_me
+    # A human replying to THEIR OWN message is continuing their thread, not
+    # addressing someone else — treat like a fresh message (owner-caught
+    # 2026-08-11: her self-reply follow-up in her private channel was skipped
+    # as "addressed elsewhere" and went unanswered for 10 minutes).
+    replying_to_self = bool(
+        is_reply and author_id is not None and reply_author_id == author_id
+    )
+    replying_to_other = bool(is_reply) and not replying_to_me and not replying_to_self
     if author_is_bot or replying_to_other:
         return False
 

--- a/tests/discord-bridge-shared-channel-addressee.test.py
+++ b/tests/discord-bridge-shared-channel-addressee.test.py
@@ -128,9 +128,27 @@ def main() -> int:
         "discord-bridge.py does not derive peer mentions from message.mentions"
     print("  ok  bridge derives peer mentions from message.mentions")
 
+    assert is_addressed_in_shared_channel(
+        author_is_bot=False, bot_mentioned=False, role_mentioned=False,
+        is_reply=True, reply_author_id=111, self_id=999,
+        other_agent_mentioned=False, author_id=111,
+    ) is True, "human self-reply must be addressed to us"
+    print("  ok  human replies to their OWN message (self-thread, owner 2026-08-11)")
+    assert is_addressed_in_shared_channel(
+        author_is_bot=False, bot_mentioned=False, role_mentioned=False,
+        is_reply=True, reply_author_id=222, self_id=999,
+        other_agent_mentioned=False, author_id=111,
+    ) is False, "reply to a different human must still skip"
+    print("  ok  human replies to a DIFFERENT human -> still skipped")
+    bridge2 = Path(__file__).resolve().parent.parent.joinpath("src", "discord-bridge.py").read_text()
+    assert "author_id=getattr(message.author" in bridge2, \
+        "discord-bridge.py does not pass author_id to the gate"
+    print("  ok  bridge passes author_id for the self-reply carve-out")
+
     print("\nAll addressee-gate cases pass.")
     return 0
 
 
 if __name__ == "__main__":
     sys.exit(main())
+


### PR DESCRIPTION
## Problem

The shared-channel addressee gate classified ANY reply-to-not-us as "addressed elsewhere" — including the owner replying to her own message to continue her thread. The bridge then skipped the message entirely; on 2026-08-11 her follow-up question sat unanswered for 10 minutes.

Bridge log at the incident (before):
```
[msg] #xueqing_private @susanliu_: 这个为啥 submit 了两个 (… type: MessageType.reply, ref: True)
[skip] shared channel: not addressed to me (author_bot=False, reply=True, other_agent_mentioned=False)
```

## Fix

`is_addressed_in_shared_channel` gains an `author_id` parameter; a reply whose target author is the sender themself (`replying_to_self`) falls through to the fresh-message path instead of being classified as reply-to-other. Replies to a DIFFERENT human still skip. The bridge passes `message.author.id`.

## Evidence

- Unit tests: `python3 tests/discord-bridge-shared-channel-addressee.test.py` — 21 cases pass, including the two new ones (self-reply → addressed; reply to different human → still skipped) and a wiring assertion that the bridge passes `author_id`.
- Live: bridge restarted on this branch at the owner's request 2026-08-11 ~18:4x ET (`Discord bridge ready: Lucy-Studio-Susan#3688`, proc 66232); owner-side messages processed normally since.

Single concern; no bundled changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)