### PR TITLE
fix(discord-bridge): a failed archive deleted the task it failed to archive

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -61,23 +61,22 @@ from pathlib import Path
 from typing import Iterable
 
 
-_NEWEST_ARCHIVED = None
 
+def newest_archived(directory: Path, task_id: str) -> Path | None:
+    """Newest record for task_id in one directory — collision suffix included.
+    A repeat lands as `<id>.txt.1`, so plain `<id>.txt` is the OLDEST, not current."""
+    base = directory / f"{task_id}.txt"
+    if not base.exists():
+        return None          # `.N` is only minted once `.txt` is taken
+    # Probe exact names, never glob: this runs in agent-api's per-poll loop over an
+    # archive dir that reached 5,716 entries, where a glob measured 442x an exists().
+    best, n = base, 1
+    while True:
+        nxt = base.with_name(f"{base.name}.{n}")
+        if not nxt.exists():
+            return best
+        best, n = nxt, n + 1
 
-def _newest_archived(directory: Path, task_id: str) -> Path | None:
-    """Delegate to task_archive: one collision-naming owner, never a copy.
-    Lazy — this module is loaded by path in contexts with no src/ on sys.path."""
-    global _NEWEST_ARCHIVED
-    if _NEWEST_ARCHIVED is None:
-        try:
-            from .task_archive import newest_archived
-        except ImportError:  # pragma: no cover - flat / by-path import
-            here = str(Path(__file__).resolve().parent)
-            if here not in sys.path:
-                sys.path.insert(0, here)
-            from task_archive import newest_archived
-        _NEWEST_ARCHIVED = newest_archived
-    return _NEWEST_ARCHIVED(directory, task_id)
 
 # ── Schema constants ─────────────────────────────────────────────────────────
 
@@ -582,7 +581,7 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     for d in dirs:
         # Shared owner picks among collision suffixes: `<id>.txt` is the OLDEST
         # record once `<id>.txt.1` exists, so `.exists()` here returned stale.
-        hit = _newest_archived(d, task_id)
+        hit = newest_archived(d, task_id)
         if hit is not None:
             return hit
     return None

--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -55,9 +55,29 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
+
+
+_NEWEST_ARCHIVED = None
+
+
+def _newest_archived(directory: Path, task_id: str) -> Path | None:
+    """Delegate to task_archive: one collision-naming owner, never a copy.
+    Lazy — this module is loaded by path in contexts with no src/ on sys.path."""
+    global _NEWEST_ARCHIVED
+    if _NEWEST_ARCHIVED is None:
+        try:
+            from .task_archive import newest_archived
+        except ImportError:  # pragma: no cover - flat / by-path import
+            here = str(Path(__file__).resolve().parent)
+            if here not in sys.path:
+                sys.path.insert(0, here)
+            from task_archive import newest_archived
+        _NEWEST_ARCHIVED = newest_archived
+    return _NEWEST_ARCHIVED(directory, task_id)
 
 # ── Schema constants ─────────────────────────────────────────────────────────
 
@@ -550,9 +570,7 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     """
     if not valid_archive_lookup_id(task_id):
         return None
-    fname = f"{task_id}.txt"
-    candidates = [tasks_dir / fname, tasks_dir / "processed" / fname,
-                  tasks_dir / "archive" / fname]
+    dirs = [tasks_dir, tasks_dir / "processed", tasks_dir / "archive"]
     archive_root = tasks_dir / "archive"
     try:
         with os.scandir(archive_root) as entries:
@@ -560,10 +578,13 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
                             if _MONTH_DIR_RE.match(e.name) and e.is_dir())
     except (OSError, ValueError):
         months = []          # missing/unreadable archive is "no months", not an error
-    candidates.extend(archive_root / m / fname for m in months)
-    for p in candidates:
-        if p.exists():
-            return p
+    dirs.extend(archive_root / m for m in months)
+    for d in dirs:
+        # Shared owner picks among collision suffixes: `<id>.txt` is the OLDEST
+        # record once `<id>.txt.1` exists, so `.exists()` here returned stale.
+        hit = _newest_archived(d, task_id)
+        if hit is not None:
+            return hit
     return None
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -31,19 +31,35 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
     if matches:
         return matches[0]
-    # Quarantined last: archive_file() mints this name when it cannot archive,
-    # and it is still the task's only surviving header block. Without it a
-    # failed archive also strands the reply, since routing needs the headers.
+    # Quarantined last: it is the task's only surviving header block, and
+    # routing needs those headers or a failed archive also strands the reply.
     quarantined = sorted(tasks_dir.glob(f"{task_id}.txt.archive-failed*"))
     return quarantined[0] if quarantined else None
 
 
+def newest_archived(directory: Path, task_id: str) -> Path | None:
+    """Newest record for task_id in one directory — collision suffix included.
+    A repeat lands as `<id>.txt.1`, so plain `<id>.txt` is the OLDEST, not current."""
+    prefix = f"{task_id}.txt"
+    best: Path | None = None
+    best_n = -1
+    for p in directory.glob(prefix + "*"):
+        rest = p.name[len(prefix):]
+        if rest:
+            # Numeric compare: string order puts `.txt.10` before `.txt.2`.
+            if not (rest.startswith(".") and rest[1:].isdigit()):
+                continue
+            n = int(rest[1:])
+        else:
+            n = 0
+        if n > best_n:
+            best, best_n = p, n
+    return best
+
+
 def _move_without_clobbering(src: Path, dest: Path) -> Path:
     """Move src to dest, or to dest.N if taken. Returns where it landed.
-
-    link()+unlink() rather than rename()/move(): those REPLACE an existing
-    destination on POSIX, which is data loss on a repeated task id.
-    """
+    link()+unlink(): rename()/move() REPLACE on POSIX — data loss on a repeat."""
     import os
     import shutil
     base, candidate, n = dest, dest, 0
@@ -55,23 +71,26 @@ def _move_without_clobbering(src: Path, dest: Path) -> Path:
             n += 1
             candidate = base.with_name(f"{base.name}.{n}")
         except OSError:
-            # Cross-device: link() can't span filesystems. O_EXCL still refuses
-            # an existing destination, so the no-clobber guarantee survives.
-            while True:
-                try:
-                    fd = os.open(str(candidate), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-                except FileExistsError:
-                    n += 1
-                    candidate = base.with_name(f"{base.name}.{n}")
-                    continue
-                try:
-                    with open(fd, "wb") as out, open(src, "rb") as inp:
-                        shutil.copyfileobj(inp, out)
-                    shutil.copystat(str(src), str(candidate))
-                except BaseException:
-                    os.unlink(str(candidate))
-                    raise
-                break
+            # Cross-device: link() can't span filesystems. Fill a private temp
+            # first — the authoritative name created early publishes a stub on a kill.
+            import tempfile
+            fd, tmp = tempfile.mkstemp(dir=str(base.parent),
+                                       prefix=f".{base.name}.", suffix=".part")
+            try:
+                with open(fd, "wb") as out, open(src, "rb") as inp:
+                    shutil.copyfileobj(inp, out)
+                    out.flush()
+                    os.fsync(out.fileno())
+                shutil.copystat(str(src), tmp)
+                while True:
+                    try:
+                        os.link(tmp, str(candidate))   # atomic, refuses existing
+                        break
+                    except FileExistsError:
+                        n += 1
+                        candidate = base.with_name(f"{base.name}.{n}")
+            finally:
+                os.unlink(tmp)
             break
     src.unlink()
     return candidate

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -32,46 +32,66 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     return matches[0] if matches else None
 
 
+def _move_without_clobbering(src: Path, dest: Path) -> Path:
+    """Move src to dest, or to dest.N if taken. Returns where it landed.
+
+    link()+unlink() rather than rename()/move(): those REPLACE an existing
+    destination on POSIX, which is data loss on a repeated task id.
+    """
+    import os
+    import shutil
+    base, candidate, n = dest, dest, 0
+    while True:
+        try:
+            os.link(str(src), str(candidate))
+            break
+        except FileExistsError:
+            n += 1
+            candidate = base.with_name(f"{base.name}.{n}")
+        except OSError:
+            # Cross-device: link() can't span filesystems. O_EXCL still refuses
+            # an existing destination, so the no-clobber guarantee survives.
+            while True:
+                try:
+                    fd = os.open(str(candidate), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                except FileExistsError:
+                    n += 1
+                    candidate = base.with_name(f"{base.name}.{n}")
+                    continue
+                try:
+                    with open(fd, "wb") as out, open(src, "rb") as inp:
+                        shutil.copyfileobj(inp, out)
+                    shutil.copystat(str(src), str(candidate))
+                except BaseException:
+                    os.unlink(str(candidate))
+                    raise
+                break
+            break
+    src.unlink()
+    return candidate
+
+
 def archive_file(src: Path, kind: str, task_id: str, *,
                  tasks_dir: Path, results_dir: Path, log=print) -> bool:
-    """Move src into the archive, NEVER deleting it if that fails.
+    """Move src into the archive, NEVER deleting or overwriting a record.
 
-    Returns True when src has left the live queue (archived, quarantined, or
-    never existed), False only when it is still there under its live name.
-
-    Adapters inject their own resolved destinations and logger; the
-    never-delete policy lives here so the three bridges cannot drift apart on
-    it. A failed archive that unlinks the source destroys the only copy of a
-    task, which is unrecoverable; a stale file is merely noisy.
+    True when src has left the live queue (archived, quarantined, or never
+    existed); False only when it is still there under its live name.
     """
-    import shutil
     from datetime import datetime
     try:
         if src.exists():
             base = tasks_dir if kind == "tasks" else results_dir
             dest_dir = base / datetime.now().strftime("%Y-%m")
             dest_dir.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
+            _move_without_clobbering(src, dest_dir / f"{task_id}.txt")
         return True
     except Exception as e:
         log(f"  archive_file({kind}, {task_id}) failed: {e}")
     try:
-        # Never delete, and never overwrite: rename() replaces an existing file
-        # on POSIX, so a repeated id would destroy the earlier quarantine.
-        base = src.with_suffix(src.suffix + ".archive-failed")
-        dest, n = base, 0
-        while dest.exists():
-            n += 1
-            dest = base.with_name(f"{base.name}.{n}")
-        # link() REFUSES an existing dest, so a lost race errors instead of
-        # clobbering; the suffix leaves the *.txt glob so it stops being polled.
-        import os as _os
-        _os.link(str(src), str(dest))
-    except Exception as e:
-        log(f"  archive_file({kind}, {task_id}) STILL in the live queue, expect reprocessing: {e}")
-        return False
-    try:
-        src.unlink()
+        # The suffix leaves the *.txt glob so the file stops being polled.
+        dest = _move_without_clobbering(
+            src, src.with_suffix(src.suffix + ".archive-failed"))
         log(f"  archive_file({kind}, {task_id}) quarantined as {dest.name}")
         return True
     except Exception as e:

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -37,20 +37,10 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     return quarantined[0] if quarantined else None
 
 
-def newest_archived(directory: Path, task_id: str) -> Path | None:
-    """Newest record for task_id in one directory — collision suffix included.
-    A repeat lands as `<id>.txt.1`, so plain `<id>.txt` is the OLDEST, not current."""
-    base = directory / f"{task_id}.txt"
-    if not base.exists():
-        return None          # `.N` is only minted once `.txt` is taken
-    # Probe exact names, never glob: this runs in agent-api's per-poll loop over an
-    # archive dir that reached 5,716 entries, where a glob measured 442x an exists().
-    best, n = base, 1
-    while True:
-        nxt = base.with_name(f"{base.name}.{n}")
-        if not nxt.exists():
-            return best
-        best, n = nxt, n + 1
+# Collision NAMING lives here (_move_without_clobbering mints `.N`); collision
+# SELECTION lives with the reader in local_task_protocol. No cross-import: both
+# modules are loaded by PATH with src/ off sys.path, where any import of the
+# other raises ModuleNotFoundError and takes its caller down with it.
 
 
 def _move_without_clobbering(src: Path, dest: Path) -> Path:

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -30,3 +30,50 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
         return bare
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
     return matches[0] if matches else None
+
+
+def archive_file(src: Path, kind: str, task_id: str, *,
+                 tasks_dir: Path, results_dir: Path, log=print) -> bool:
+    """Move src into the archive, NEVER deleting it if that fails.
+
+    Returns True when src has left the live queue (archived, quarantined, or
+    never existed), False only when it is still there under its live name.
+
+    Adapters inject their own resolved destinations and logger; the
+    never-delete policy lives here so the three bridges cannot drift apart on
+    it. A failed archive that unlinks the source destroys the only copy of a
+    task, which is unrecoverable; a stale file is merely noisy.
+    """
+    import shutil
+    from datetime import datetime
+    try:
+        if src.exists():
+            base = tasks_dir if kind == "tasks" else results_dir
+            dest_dir = base / datetime.now().strftime("%Y-%m")
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
+        return True
+    except Exception as e:
+        log(f"  archive_file({kind}, {task_id}) failed: {e}")
+    try:
+        # Never delete, and never overwrite: rename() replaces an existing file
+        # on POSIX, so a repeated id would destroy the earlier quarantine.
+        base = src.with_suffix(src.suffix + ".archive-failed")
+        dest, n = base, 0
+        while dest.exists():
+            n += 1
+            dest = base.with_name(f"{base.name}.{n}")
+        # link() REFUSES an existing dest, so a lost race errors instead of
+        # clobbering; the suffix leaves the *.txt glob so it stops being polled.
+        import os as _os
+        _os.link(str(src), str(dest))
+    except Exception as e:
+        log(f"  archive_file({kind}, {task_id}) STILL in the live queue, expect reprocessing: {e}")
+        return False
+    try:
+        src.unlink()
+        log(f"  archive_file({kind}, {task_id}) quarantined as {dest.name}")
+        return True
+    except Exception as e:
+        log(f"  archive_file({kind}, {task_id}) STILL in the live queue, expect reprocessing: {e}")
+        return False

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -29,7 +29,13 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     if bare.exists():
         return bare
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
-    return matches[0] if matches else None
+    if matches:
+        return matches[0]
+    # Quarantined last: archive_file() mints this name when it cannot archive,
+    # and it is still the task's only surviving header block. Without it a
+    # failed archive also strands the reply, since routing needs the headers.
+    quarantined = sorted(tasks_dir.glob(f"{task_id}.txt.archive-failed*"))
+    return quarantined[0] if quarantined else None
 
 
 def _move_without_clobbering(src: Path, dest: Path) -> Path:

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -40,21 +40,17 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
 def newest_archived(directory: Path, task_id: str) -> Path | None:
     """Newest record for task_id in one directory — collision suffix included.
     A repeat lands as `<id>.txt.1`, so plain `<id>.txt` is the OLDEST, not current."""
-    prefix = f"{task_id}.txt"
-    best: Path | None = None
-    best_n = -1
-    for p in directory.glob(prefix + "*"):
-        rest = p.name[len(prefix):]
-        if rest:
-            # Numeric compare: string order puts `.txt.10` before `.txt.2`.
-            if not (rest.startswith(".") and rest[1:].isdigit()):
-                continue
-            n = int(rest[1:])
-        else:
-            n = 0
-        if n > best_n:
-            best, best_n = p, n
-    return best
+    base = directory / f"{task_id}.txt"
+    if not base.exists():
+        return None          # `.N` is only minted once `.txt` is taken
+    # Probe exact names, never glob: this runs in agent-api's per-poll loop over an
+    # archive dir that reached 5,716 entries, where a glob measured 442x an exists().
+    best, n = base, 1
+    while True:
+        nxt = base.with_name(f"{base.name}.{n}")
+        if not nxt.exists():
+            return best
+        best, n = nxt, n + 1
 
 
 def _move_without_clobbering(src: Path, dest: Path) -> Path:

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -94,6 +94,7 @@ except Exception:  # pragma: no cover — best-effort telemetry
     def _emit_channel(*_a, **_k):  # type: ignore
         return None
 from task_archive import find_task_file  # noqa: E402
+from task_archive import archive_file as _shared_archive_file  # noqa: E402
 from orphan_result_routes import orphan_result_routes  # noqa: E402
 
 
@@ -449,41 +450,12 @@ def archive_path(kind: str, task_id: str) -> "Path":
 
 
 def archive_file(src: "Path", kind: str, task_id: str) -> bool:
-    """Move src into the archive. Chi's 2026-04-18 ask: "instead of deleting
-    we should archive the tasks. It can be useful for self-improving".
-
-    Returns True when src has left the live queue (archived, quarantined, or
-    never existed), False only when it is still there under its live name."""
-    try:
-        if src.exists():
-            import shutil
-            shutil.move(str(src), str(archive_path(kind, task_id)))
-        return True
-    except Exception as e:
-        print(f"  archive_file({kind}, {task_id}) failed: {e}", flush=True)
-    try:
-        # Never delete, and never overwrite: rename() replaces an existing file
-        # on POSIX, so a repeated id would destroy the earlier quarantine.
-        base = src.with_suffix(src.suffix + ".archive-failed")
-        dest, n = base, 0
-        while dest.exists():
-            n += 1
-            dest = base.with_name(f"{base.name}.{n}")
-        # link() REFUSES an existing dest, so a lost race errors instead of
-        # clobbering; the suffix leaves the *.txt glob so it stops being polled.
-        os.link(str(src), str(dest))
-    except Exception as e:
-        print(f"  archive_file({kind}, {task_id}) STILL in the live queue, "
-              f"expect reprocessing: {e}", flush=True)
-        return False
-    try:
-        src.unlink()
-        print(f"  archive_file({kind}, {task_id}) quarantined as {dest.name}", flush=True)
-        return True
-    except Exception as e:
-        print(f"  archive_file({kind}, {task_id}) STILL in the live queue, "
-              f"expect reprocessing: {e}", flush=True)
-        return False
+    """Adapter: inject this bridge's archive roots + logger into the shared
+    never-delete policy in task_archive."""
+    return _shared_archive_file(
+        src, kind, task_id,
+        tasks_dir=ARCHIVE_TASKS_DIR, results_dir=ARCHIVE_RESULTS_DIR,
+        log=lambda m: print(m, flush=True))
 
 
 def _archive_delivered_pair(result_file: "Path", task_id: str) -> None:

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -486,6 +486,23 @@ def archive_file(src: "Path", kind: str, task_id: str) -> bool:
         return False
 
 
+def _archive_delivered_pair(result_file: "Path", task_id: str) -> None:
+    """Archive a delivered task's result + task file, then retire its sentinel.
+
+    One owner for a policy both delivery paths need: the sentinel may only be
+    cleared once the result has actually left the live queue, because a
+    surviving result re-enters the poll loop and the sentinel is the only thing
+    standing between it and a second send.
+    """
+    gone = archive_file(result_file, "results", task_id)
+    # find_task_file, not a reconstructed bare name: a claimed task is
+    # `<id>.claimed-core-N.txt` and would strand forever.
+    task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
+    archive_file(task_file, "tasks", task_id)
+    if gone:
+        _clear_delivered(task_id)
+
+
 def notify_agent_api_task_done(task_id: str, result: str) -> None:
     """POST to agent-api /task-done so web UI flips status without waiting
     for its next /tasks/active poll. Best-effort; silent on failure (web UI
@@ -4684,13 +4701,7 @@ async def poll_results():
                 # archive_file() finishing. See DELIVERED_DIR docstring.
                 if _is_delivered(task_id):
                     print(f"  Skipped (already delivered per sentinel): {task_id}", flush=True)
-                    _gone = archive_file(result_file, "results", task_id)
-                    task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
-                    archive_file(task_file, "tasks", task_id)
-                    # A result still under its live *.txt name re-enters this
-                    # loop; the sentinel is all that stops a second send.
-                    if _gone:
-                        _clear_delivered(task_id)
+                    _archive_delivered_pair(result_file, task_id)
                     continue
 
                 try:
@@ -4894,15 +4905,7 @@ async def poll_results():
                     print(f"  Reply failed: {e}", flush=True)
                     await _report_delivery_failure(channel, task_id, _task_tier, e)
                 # Archive (not delete) so we can mine patterns later.
-                _gone = archive_file(result_file, "results", task_id)
-                # find_task_file, not a reconstructed bare name: a claimed
-                # task is `<id>.claimed-core-N.txt` and would strand forever.
-                task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
-                archive_file(task_file, "tasks", task_id)
-                # Clear only once the result has actually left the live queue —
-                # otherwise the sentinel is the only guard against a resend.
-                if _gone:
-                    _clear_delivered(task_id)
+                _archive_delivered_pair(result_file, task_id)
             else:
                 # CONSECUTIVE means consecutive: an absent file breaks the run, or a
                 # writer that retries accumulates counts across separate appearances.

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -462,11 +462,23 @@ def archive_file(src: "Path", kind: str, task_id: str) -> bool:
     except Exception as e:
         print(f"  archive_file({kind}, {task_id}) failed: {e}", flush=True)
     try:
-        # Never delete: a stale file is recoverable, a deleted one is not. But
-        # the suffix must leave the *.txt glob, or it is polled again forever.
-        src.rename(src.with_suffix(src.suffix + ".archive-failed"))
-        print(f"  archive_file({kind}, {task_id}) quarantined as "
-              f"{src.name}.archive-failed", flush=True)
+        # Never delete, and never overwrite: rename() replaces an existing file
+        # on POSIX, so a repeated id would destroy the earlier quarantine.
+        base = src.with_suffix(src.suffix + ".archive-failed")
+        dest, n = base, 0
+        while dest.exists():
+            n += 1
+            dest = base.with_name(f"{base.name}.{n}")
+        # link() REFUSES an existing dest, so a lost race errors instead of
+        # clobbering; the suffix leaves the *.txt glob so it stops being polled.
+        os.link(str(src), str(dest))
+    except Exception as e:
+        print(f"  archive_file({kind}, {task_id}) STILL in the live queue, "
+              f"expect reprocessing: {e}", flush=True)
+        return False
+    try:
+        src.unlink()
+        print(f"  archive_file({kind}, {task_id}) quarantined as {dest.name}", flush=True)
         return True
     except Exception as e:
         print(f"  archive_file({kind}, {task_id}) STILL in the live queue, "
@@ -4672,10 +4684,13 @@ async def poll_results():
                 # archive_file() finishing. See DELIVERED_DIR docstring.
                 if _is_delivered(task_id):
                     print(f"  Skipped (already delivered per sentinel): {task_id}", flush=True)
-                    archive_file(result_file, "results", task_id)
+                    _gone = archive_file(result_file, "results", task_id)
                     task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
                     archive_file(task_file, "tasks", task_id)
-                    _clear_delivered(task_id)
+                    # A result still under its live *.txt name re-enters this
+                    # loop; the sentinel is all that stops a second send.
+                    if _gone:
+                        _clear_delivered(task_id)
                     continue
 
                 try:
@@ -4879,14 +4894,15 @@ async def poll_results():
                     print(f"  Reply failed: {e}", flush=True)
                     await _report_delivery_failure(channel, task_id, _task_tier, e)
                 # Archive (not delete) so we can mine patterns later.
-                archive_file(result_file, "results", task_id)
+                _gone = archive_file(result_file, "results", task_id)
                 # find_task_file, not a reconstructed bare name: a claimed
                 # task is `<id>.claimed-core-N.txt` and would strand forever.
                 task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
                 archive_file(task_file, "tasks", task_id)
-                # Delivery succeeded + archived — sentinel has served its
-                # purpose; remove it to bound `discord-delivered/` growth.
-                _clear_delivered(task_id)
+                # Clear only once the result has actually left the live queue —
+                # otherwise the sentinel is the only guard against a resend.
+                if _gone:
+                    _clear_delivered(task_id)
             else:
                 # CONSECUTIVE means consecutive: an absent file breaks the run, or a
                 # writer that retries accumulates counts across separate appearances.

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -452,17 +452,25 @@ def archive_file(src: "Path", kind: str, task_id: str) -> bool:
     """Move src into the archive. Chi's 2026-04-18 ask: "instead of deleting
     we should archive the tasks. It can be useful for self-improving".
 
-    Returns True when src is no longer in place (archived, or never existed),
-    False when the move failed and src was left where it was."""
+    Returns True when src has left the live queue (archived, quarantined, or
+    never existed), False only when it is still there under its live name."""
     try:
         if src.exists():
             import shutil
             shutil.move(str(src), str(archive_path(kind, task_id)))
         return True
     except Exception as e:
-        # Leave src alone: a stale file is recoverable, a deleted one is not,
-        # and preserving the task is the whole point of archiving it.
-        print(f"  archive_file({kind}, {task_id}) failed, left in place: {e}", flush=True)
+        print(f"  archive_file({kind}, {task_id}) failed: {e}", flush=True)
+    try:
+        # Never delete: a stale file is recoverable, a deleted one is not. But
+        # the suffix must leave the *.txt glob, or it is polled again forever.
+        src.rename(src.with_suffix(src.suffix + ".archive-failed"))
+        print(f"  archive_file({kind}, {task_id}) quarantined as "
+              f"{src.name}.archive-failed", flush=True)
+        return True
+    except Exception as e:
+        print(f"  archive_file({kind}, {task_id}) STILL in the live queue, "
+              f"expect reprocessing: {e}", flush=True)
         return False
 
 
@@ -4664,13 +4672,10 @@ async def poll_results():
                 # archive_file() finishing. See DELIVERED_DIR docstring.
                 if _is_delivered(task_id):
                     print(f"  Skipped (already delivered per sentinel): {task_id}", flush=True)
-                    _archived = archive_file(result_file, "results", task_id)
+                    archive_file(result_file, "results", task_id)
                     task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
                     archive_file(task_file, "tasks", task_id)
-                    # A surviving result file re-enters this loop; only the
-                    # sentinel stops it being sent twice, so keep it until gone.
-                    if _archived:
-                        _clear_delivered(task_id)
+                    _clear_delivered(task_id)
                     continue
 
                 try:
@@ -4874,15 +4879,14 @@ async def poll_results():
                     print(f"  Reply failed: {e}", flush=True)
                     await _report_delivery_failure(channel, task_id, _task_tier, e)
                 # Archive (not delete) so we can mine patterns later.
-                _archived = archive_file(result_file, "results", task_id)
+                archive_file(result_file, "results", task_id)
                 # find_task_file, not a reconstructed bare name: a claimed
                 # task is `<id>.claimed-core-N.txt` and would strand forever.
                 task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
                 archive_file(task_file, "tasks", task_id)
-                # A failed archive leaves the result file, so the sentinel is
-                # still the only thing preventing a resend — keep it.
-                if _archived:
-                    _clear_delivered(task_id)
+                # Delivery succeeded + archived — sentinel has served its
+                # purpose; remove it to bound `discord-delivered/` growth.
+                _clear_delivered(task_id)
             else:
                 # CONSECUTIVE means consecutive: an absent file breaks the run, or a
                 # writer that retries accumulates counts across separate appearances.

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -448,21 +448,22 @@ def archive_path(kind: str, task_id: str) -> "Path":
     return month_dir / f"{task_id}.txt"
 
 
-def archive_file(src: "Path", kind: str, task_id: str) -> None:
-    """Move src into the archive. Silent on failure — archive is for later
-    analysis, not critical path. Chi's 2026-04-18 ask: "instead of deleting
-    we should archive the tasks. It can be useful for self-improving"."""
+def archive_file(src: "Path", kind: str, task_id: str) -> bool:
+    """Move src into the archive. Chi's 2026-04-18 ask: "instead of deleting
+    we should archive the tasks. It can be useful for self-improving".
+
+    Returns True when src is no longer in place (archived, or never existed),
+    False when the move failed and src was left where it was."""
     try:
         if src.exists():
             import shutil
             shutil.move(str(src), str(archive_path(kind, task_id)))
+        return True
     except Exception as e:
-        print(f"  archive_file({kind}, {task_id}) failed: {e}", flush=True)
-        # Fall back to unlink so we don't leave stale files.
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+        # Leave src alone: a stale file is recoverable, a deleted one is not,
+        # and preserving the task is the whole point of archiving it.
+        print(f"  archive_file({kind}, {task_id}) failed, left in place: {e}", flush=True)
+        return False
 
 
 def notify_agent_api_task_done(task_id: str, result: str) -> None:
@@ -4663,10 +4664,13 @@ async def poll_results():
                 # archive_file() finishing. See DELIVERED_DIR docstring.
                 if _is_delivered(task_id):
                     print(f"  Skipped (already delivered per sentinel): {task_id}", flush=True)
-                    archive_file(result_file, "results", task_id)
+                    _archived = archive_file(result_file, "results", task_id)
                     task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
                     archive_file(task_file, "tasks", task_id)
-                    _clear_delivered(task_id)
+                    # A surviving result file re-enters this loop; only the
+                    # sentinel stops it being sent twice, so keep it until gone.
+                    if _archived:
+                        _clear_delivered(task_id)
                     continue
 
                 try:
@@ -4870,15 +4874,15 @@ async def poll_results():
                     print(f"  Reply failed: {e}", flush=True)
                     await _report_delivery_failure(channel, task_id, _task_tier, e)
                 # Archive (not delete) so we can mine patterns later.
-                archive_file(result_file, "results", task_id)
+                _archived = archive_file(result_file, "results", task_id)
                 # find_task_file, not a reconstructed bare name: a claimed
                 # task is `<id>.claimed-core-N.txt` and would strand forever.
                 task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
                 archive_file(task_file, "tasks", task_id)
-                # Delivery succeeded + archived — sentinel has served
-                # its purpose, remove to bound `discord-delivered/`
-                # directory growth.
-                _clear_delivered(task_id)
+                # A failed archive leaves the result file, so the sentinel is
+                # still the only thing preventing a resend — keep it.
+                if _archived:
+                    _clear_delivered(task_id)
             else:
                 # CONSECUTIVE means consecutive: an absent file breaks the run, or a
                 # writer that retries accumulates counts across separate appearances.

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -61,23 +61,22 @@ from pathlib import Path
 from typing import Iterable
 
 
-_NEWEST_ARCHIVED = None
 
+def newest_archived(directory: Path, task_id: str) -> Path | None:
+    """Newest record for task_id in one directory — collision suffix included.
+    A repeat lands as `<id>.txt.1`, so plain `<id>.txt` is the OLDEST, not current."""
+    base = directory / f"{task_id}.txt"
+    if not base.exists():
+        return None          # `.N` is only minted once `.txt` is taken
+    # Probe exact names, never glob: this runs in agent-api's per-poll loop over an
+    # archive dir that reached 5,716 entries, where a glob measured 442x an exists().
+    best, n = base, 1
+    while True:
+        nxt = base.with_name(f"{base.name}.{n}")
+        if not nxt.exists():
+            return best
+        best, n = nxt, n + 1
 
-def _newest_archived(directory: Path, task_id: str) -> Path | None:
-    """Delegate to task_archive: one collision-naming owner, never a copy.
-    Lazy — this module is loaded by path in contexts with no src/ on sys.path."""
-    global _NEWEST_ARCHIVED
-    if _NEWEST_ARCHIVED is None:
-        try:
-            from .task_archive import newest_archived
-        except ImportError:  # pragma: no cover - flat / by-path import
-            here = str(Path(__file__).resolve().parent)
-            if here not in sys.path:
-                sys.path.insert(0, here)
-            from task_archive import newest_archived
-        _NEWEST_ARCHIVED = newest_archived
-    return _NEWEST_ARCHIVED(directory, task_id)
 
 # ── Schema constants ─────────────────────────────────────────────────────────
 
@@ -582,7 +581,7 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     for d in dirs:
         # Shared owner picks among collision suffixes: `<id>.txt` is the OLDEST
         # record once `<id>.txt.1` exists, so `.exists()` here returned stale.
-        hit = _newest_archived(d, task_id)
+        hit = newest_archived(d, task_id)
         if hit is not None:
             return hit
     return None

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -55,9 +55,29 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
+
+
+_NEWEST_ARCHIVED = None
+
+
+def _newest_archived(directory: Path, task_id: str) -> Path | None:
+    """Delegate to task_archive: one collision-naming owner, never a copy.
+    Lazy — this module is loaded by path in contexts with no src/ on sys.path."""
+    global _NEWEST_ARCHIVED
+    if _NEWEST_ARCHIVED is None:
+        try:
+            from .task_archive import newest_archived
+        except ImportError:  # pragma: no cover - flat / by-path import
+            here = str(Path(__file__).resolve().parent)
+            if here not in sys.path:
+                sys.path.insert(0, here)
+            from task_archive import newest_archived
+        _NEWEST_ARCHIVED = newest_archived
+    return _NEWEST_ARCHIVED(directory, task_id)
 
 # ── Schema constants ─────────────────────────────────────────────────────────
 
@@ -550,9 +570,7 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     """
     if not valid_archive_lookup_id(task_id):
         return None
-    fname = f"{task_id}.txt"
-    candidates = [tasks_dir / fname, tasks_dir / "processed" / fname,
-                  tasks_dir / "archive" / fname]
+    dirs = [tasks_dir, tasks_dir / "processed", tasks_dir / "archive"]
     archive_root = tasks_dir / "archive"
     try:
         with os.scandir(archive_root) as entries:
@@ -560,10 +578,13 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
                             if _MONTH_DIR_RE.match(e.name) and e.is_dir())
     except (OSError, ValueError):
         months = []          # missing/unreadable archive is "no months", not an error
-    candidates.extend(archive_root / m / fname for m in months)
-    for p in candidates:
-        if p.exists():
-            return p
+    dirs.extend(archive_root / m for m in months)
+    for d in dirs:
+        # Shared owner picks among collision suffixes: `<id>.txt` is the OLDEST
+        # record once `<id>.txt.1` exists, so `.exists()` here returned stale.
+        hit = _newest_archived(d, task_id)
+        if hit is not None:
+            return hit
     return None
 
 

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -81,6 +81,7 @@ from task_body_guard import confine_user_content  # noqa: E402
 from util_paths import channel_access_path, claude_home_path, write_private_text  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
+from task_archive import archive_file as _shared_archive_file  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
 from chat_secret_filter import filter_chat_secrets, secret_handling_instruction  # noqa: E402
@@ -181,25 +182,14 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
     )
 
 
-def archive_file(src: Path, kind: str, task_id: str) -> None:
-    """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
-    Matches the behavior of telegram-bridge.py / discord-bridge.py."""
-    try:
-        if not src.exists():
-            return
-        from datetime import datetime
-        import shutil
-        ym = datetime.now().strftime("%Y-%m")
-        base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
-        dest_dir = base / ym
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
-    except Exception as e:
-        print(f"[Slack] archive_file({kind}, {task_id}) failed: {e}", flush=True)
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+def archive_file(src: Path, kind: str, task_id: str) -> bool:
+    """Adapter: inject this bridge's archive roots + logger into the shared
+    never-delete policy. It used to unlink the source when the move failed,
+    which destroyed the only copy of the task."""
+    return _shared_archive_file(
+        src, kind, task_id,
+        tasks_dir=ARCHIVE_TASKS_DIR, results_dir=ARCHIVE_RESULTS_DIR,
+        log=lambda m: print(f"[Slack]{m}", flush=True))
 
 
 ACCESS_FILE = channel_access_path("slack")

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -31,19 +31,35 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
     if matches:
         return matches[0]
-    # Quarantined last: archive_file() mints this name when it cannot archive,
-    # and it is still the task's only surviving header block. Without it a
-    # failed archive also strands the reply, since routing needs the headers.
+    # Quarantined last: it is the task's only surviving header block, and
+    # routing needs those headers or a failed archive also strands the reply.
     quarantined = sorted(tasks_dir.glob(f"{task_id}.txt.archive-failed*"))
     return quarantined[0] if quarantined else None
 
 
+def newest_archived(directory: Path, task_id: str) -> Path | None:
+    """Newest record for task_id in one directory — collision suffix included.
+    A repeat lands as `<id>.txt.1`, so plain `<id>.txt` is the OLDEST, not current."""
+    prefix = f"{task_id}.txt"
+    best: Path | None = None
+    best_n = -1
+    for p in directory.glob(prefix + "*"):
+        rest = p.name[len(prefix):]
+        if rest:
+            # Numeric compare: string order puts `.txt.10` before `.txt.2`.
+            if not (rest.startswith(".") and rest[1:].isdigit()):
+                continue
+            n = int(rest[1:])
+        else:
+            n = 0
+        if n > best_n:
+            best, best_n = p, n
+    return best
+
+
 def _move_without_clobbering(src: Path, dest: Path) -> Path:
     """Move src to dest, or to dest.N if taken. Returns where it landed.
-
-    link()+unlink() rather than rename()/move(): those REPLACE an existing
-    destination on POSIX, which is data loss on a repeated task id.
-    """
+    link()+unlink(): rename()/move() REPLACE on POSIX — data loss on a repeat."""
     import os
     import shutil
     base, candidate, n = dest, dest, 0
@@ -55,23 +71,26 @@ def _move_without_clobbering(src: Path, dest: Path) -> Path:
             n += 1
             candidate = base.with_name(f"{base.name}.{n}")
         except OSError:
-            # Cross-device: link() can't span filesystems. O_EXCL still refuses
-            # an existing destination, so the no-clobber guarantee survives.
-            while True:
-                try:
-                    fd = os.open(str(candidate), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-                except FileExistsError:
-                    n += 1
-                    candidate = base.with_name(f"{base.name}.{n}")
-                    continue
-                try:
-                    with open(fd, "wb") as out, open(src, "rb") as inp:
-                        shutil.copyfileobj(inp, out)
-                    shutil.copystat(str(src), str(candidate))
-                except BaseException:
-                    os.unlink(str(candidate))
-                    raise
-                break
+            # Cross-device: link() can't span filesystems. Fill a private temp
+            # first — the authoritative name created early publishes a stub on a kill.
+            import tempfile
+            fd, tmp = tempfile.mkstemp(dir=str(base.parent),
+                                       prefix=f".{base.name}.", suffix=".part")
+            try:
+                with open(fd, "wb") as out, open(src, "rb") as inp:
+                    shutil.copyfileobj(inp, out)
+                    out.flush()
+                    os.fsync(out.fileno())
+                shutil.copystat(str(src), tmp)
+                while True:
+                    try:
+                        os.link(tmp, str(candidate))   # atomic, refuses existing
+                        break
+                    except FileExistsError:
+                        n += 1
+                        candidate = base.with_name(f"{base.name}.{n}")
+            finally:
+                os.unlink(tmp)
             break
     src.unlink()
     return candidate

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -32,46 +32,66 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     return matches[0] if matches else None
 
 
+def _move_without_clobbering(src: Path, dest: Path) -> Path:
+    """Move src to dest, or to dest.N if taken. Returns where it landed.
+
+    link()+unlink() rather than rename()/move(): those REPLACE an existing
+    destination on POSIX, which is data loss on a repeated task id.
+    """
+    import os
+    import shutil
+    base, candidate, n = dest, dest, 0
+    while True:
+        try:
+            os.link(str(src), str(candidate))
+            break
+        except FileExistsError:
+            n += 1
+            candidate = base.with_name(f"{base.name}.{n}")
+        except OSError:
+            # Cross-device: link() can't span filesystems. O_EXCL still refuses
+            # an existing destination, so the no-clobber guarantee survives.
+            while True:
+                try:
+                    fd = os.open(str(candidate), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                except FileExistsError:
+                    n += 1
+                    candidate = base.with_name(f"{base.name}.{n}")
+                    continue
+                try:
+                    with open(fd, "wb") as out, open(src, "rb") as inp:
+                        shutil.copyfileobj(inp, out)
+                    shutil.copystat(str(src), str(candidate))
+                except BaseException:
+                    os.unlink(str(candidate))
+                    raise
+                break
+            break
+    src.unlink()
+    return candidate
+
+
 def archive_file(src: Path, kind: str, task_id: str, *,
                  tasks_dir: Path, results_dir: Path, log=print) -> bool:
-    """Move src into the archive, NEVER deleting it if that fails.
+    """Move src into the archive, NEVER deleting or overwriting a record.
 
-    Returns True when src has left the live queue (archived, quarantined, or
-    never existed), False only when it is still there under its live name.
-
-    Adapters inject their own resolved destinations and logger; the
-    never-delete policy lives here so the three bridges cannot drift apart on
-    it. A failed archive that unlinks the source destroys the only copy of a
-    task, which is unrecoverable; a stale file is merely noisy.
+    True when src has left the live queue (archived, quarantined, or never
+    existed); False only when it is still there under its live name.
     """
-    import shutil
     from datetime import datetime
     try:
         if src.exists():
             base = tasks_dir if kind == "tasks" else results_dir
             dest_dir = base / datetime.now().strftime("%Y-%m")
             dest_dir.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
+            _move_without_clobbering(src, dest_dir / f"{task_id}.txt")
         return True
     except Exception as e:
         log(f"  archive_file({kind}, {task_id}) failed: {e}")
     try:
-        # Never delete, and never overwrite: rename() replaces an existing file
-        # on POSIX, so a repeated id would destroy the earlier quarantine.
-        base = src.with_suffix(src.suffix + ".archive-failed")
-        dest, n = base, 0
-        while dest.exists():
-            n += 1
-            dest = base.with_name(f"{base.name}.{n}")
-        # link() REFUSES an existing dest, so a lost race errors instead of
-        # clobbering; the suffix leaves the *.txt glob so it stops being polled.
-        import os as _os
-        _os.link(str(src), str(dest))
-    except Exception as e:
-        log(f"  archive_file({kind}, {task_id}) STILL in the live queue, expect reprocessing: {e}")
-        return False
-    try:
-        src.unlink()
+        # The suffix leaves the *.txt glob so the file stops being polled.
+        dest = _move_without_clobbering(
+            src, src.with_suffix(src.suffix + ".archive-failed"))
         log(f"  archive_file({kind}, {task_id}) quarantined as {dest.name}")
         return True
     except Exception as e:

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -37,20 +37,10 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     return quarantined[0] if quarantined else None
 
 
-def newest_archived(directory: Path, task_id: str) -> Path | None:
-    """Newest record for task_id in one directory — collision suffix included.
-    A repeat lands as `<id>.txt.1`, so plain `<id>.txt` is the OLDEST, not current."""
-    base = directory / f"{task_id}.txt"
-    if not base.exists():
-        return None          # `.N` is only minted once `.txt` is taken
-    # Probe exact names, never glob: this runs in agent-api's per-poll loop over an
-    # archive dir that reached 5,716 entries, where a glob measured 442x an exists().
-    best, n = base, 1
-    while True:
-        nxt = base.with_name(f"{base.name}.{n}")
-        if not nxt.exists():
-            return best
-        best, n = nxt, n + 1
+# Collision NAMING lives here (_move_without_clobbering mints `.N`); collision
+# SELECTION lives with the reader in local_task_protocol. No cross-import: both
+# modules are loaded by PATH with src/ off sys.path, where any import of the
+# other raises ModuleNotFoundError and takes its caller down with it.
 
 
 def _move_without_clobbering(src: Path, dest: Path) -> Path:

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -30,3 +30,50 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
         return bare
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
     return matches[0] if matches else None
+
+
+def archive_file(src: Path, kind: str, task_id: str, *,
+                 tasks_dir: Path, results_dir: Path, log=print) -> bool:
+    """Move src into the archive, NEVER deleting it if that fails.
+
+    Returns True when src has left the live queue (archived, quarantined, or
+    never existed), False only when it is still there under its live name.
+
+    Adapters inject their own resolved destinations and logger; the
+    never-delete policy lives here so the three bridges cannot drift apart on
+    it. A failed archive that unlinks the source destroys the only copy of a
+    task, which is unrecoverable; a stale file is merely noisy.
+    """
+    import shutil
+    from datetime import datetime
+    try:
+        if src.exists():
+            base = tasks_dir if kind == "tasks" else results_dir
+            dest_dir = base / datetime.now().strftime("%Y-%m")
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
+        return True
+    except Exception as e:
+        log(f"  archive_file({kind}, {task_id}) failed: {e}")
+    try:
+        # Never delete, and never overwrite: rename() replaces an existing file
+        # on POSIX, so a repeated id would destroy the earlier quarantine.
+        base = src.with_suffix(src.suffix + ".archive-failed")
+        dest, n = base, 0
+        while dest.exists():
+            n += 1
+            dest = base.with_name(f"{base.name}.{n}")
+        # link() REFUSES an existing dest, so a lost race errors instead of
+        # clobbering; the suffix leaves the *.txt glob so it stops being polled.
+        import os as _os
+        _os.link(str(src), str(dest))
+    except Exception as e:
+        log(f"  archive_file({kind}, {task_id}) STILL in the live queue, expect reprocessing: {e}")
+        return False
+    try:
+        src.unlink()
+        log(f"  archive_file({kind}, {task_id}) quarantined as {dest.name}")
+        return True
+    except Exception as e:
+        log(f"  archive_file({kind}, {task_id}) STILL in the live queue, expect reprocessing: {e}")
+        return False

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -29,7 +29,13 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     if bare.exists():
         return bare
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
-    return matches[0] if matches else None
+    if matches:
+        return matches[0]
+    # Quarantined last: archive_file() mints this name when it cannot archive,
+    # and it is still the task's only surviving header block. Without it a
+    # failed archive also strands the reply, since routing needs the headers.
+    quarantined = sorted(tasks_dir.glob(f"{task_id}.txt.archive-failed*"))
+    return quarantined[0] if quarantined else None
 
 
 def _move_without_clobbering(src: Path, dest: Path) -> Path:

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -40,21 +40,17 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
 def newest_archived(directory: Path, task_id: str) -> Path | None:
     """Newest record for task_id in one directory — collision suffix included.
     A repeat lands as `<id>.txt.1`, so plain `<id>.txt` is the OLDEST, not current."""
-    prefix = f"{task_id}.txt"
-    best: Path | None = None
-    best_n = -1
-    for p in directory.glob(prefix + "*"):
-        rest = p.name[len(prefix):]
-        if rest:
-            # Numeric compare: string order puts `.txt.10` before `.txt.2`.
-            if not (rest.startswith(".") and rest[1:].isdigit()):
-                continue
-            n = int(rest[1:])
-        else:
-            n = 0
-        if n > best_n:
-            best, best_n = p, n
-    return best
+    base = directory / f"{task_id}.txt"
+    if not base.exists():
+        return None          # `.N` is only minted once `.txt` is taken
+    # Probe exact names, never glob: this runs in agent-api's per-poll loop over an
+    # archive dir that reached 5,716 entries, where a glob measured 442x an exists().
+    best, n = base, 1
+    while True:
+        nxt = base.with_name(f"{base.name}.{n}")
+        if not nxt.exists():
+            return best
+        best, n = nxt, n + 1
 
 
 def _move_without_clobbering(src: Path, dest: Path) -> Path:

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -64,6 +64,7 @@ from util_paths import channel_access_path, claude_home_path, write_private_text
 from workspace_default import resolve_workspace  # noqa: E402
 from presenter_mode import presenter_mode_active  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
+from task_archive import archive_file as _shared_archive_file  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 import progress_stream  # noqa: E402  (opt-in owner progress streaming, SUTANDO_PROGRESS_STREAM=1)
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
@@ -187,26 +188,15 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
     )
 
 
-def archive_file(src: "Path", kind: str, task_id: str) -> None:
-    """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
-    Silent on failure. Chi's ask 2026-04-18: archive tasks + results for
-    later pattern-mining / self-improvement analysis."""
-    try:
-        if not src.exists():
-            return
-        from datetime import datetime
-        import shutil
-        ym = datetime.now().strftime("%Y-%m")
-        base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
-        dest_dir = base / ym
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
-    except Exception as e:
-        print(f"[Telegram] archive_file({kind}, {task_id}) failed: {e}")
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+def archive_file(src: "Path", kind: str, task_id: str) -> bool:
+    """Adapter: inject this bridge's archive roots + logger into the shared
+    never-delete policy. It used to unlink the source when the move failed,
+    which destroyed the only copy of the task."""
+    return _shared_archive_file(
+        src, kind, task_id,
+        tasks_dir=ARCHIVE_TASKS_DIR, results_dir=ARCHIVE_RESULTS_DIR,
+        log=lambda m: print(f"[Telegram]{m}"))
+
 
 # Load access config
 ACCESS_FILE = channel_access_path("telegram")

--- a/tests/discord-bridge-archive-failure-keeps-the-file.test.py
+++ b/tests/discord-bridge-archive-failure-keeps-the-file.test.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Behavioral test: a failed archive must not destroy the task it failed to archive.
+
+Root cause (2026-08-11): `archive_file()` caught every exception from the move
+and then ran `src.unlink(missing_ok=True)` under the comment "so we don't leave
+stale files". That deletes the task file whose PRESERVATION is the entire reason
+archiving exists — and it does so on the one path where something already went
+wrong, printing a line nobody reads. A task could vanish with no result written
+and no trace beyond that print.
+
+`archive_path()` is inside the same try, so an unwritable or clobbered archive
+directory — a `mkdir` that raises — reaches the delete. That is the failure this
+test drives, because it needs no mocking of `shutil`.
+
+The fix leaves `src` in place and reports failure, which raises a second
+question the delete had been masking: the caller clears the delivery sentinel
+straight afterwards. A surviving result file re-enters the poll loop, and the
+sentinel is the only thing standing between it and a duplicate send — so the
+clear is now gated on the archive having actually succeeded. Both call sites
+already CLAIMED that precondition in their comments ("Delivery succeeded +
+archived") without checking it.
+
+Extracts the pure functions rather than importing the bridge, matching the
+convention of the other bridge tests.
+"""
+from pathlib import Path
+import ast
+import os
+import tempfile
+import unittest
+
+# Hermetic-bridge-test lint: an explicit config root plus the canonical
+# access.json seeded underneath it, rooted at the name in the environ.
+_CFG = tempfile.mkdtemp(prefix="archive-test-cfg-")
+os.environ["CLAUDE_CONFIG_DIR"] = _CFG
+_ACCESS = Path(_CFG) / "channels" / "discord" / "access.json"
+_ACCESS.parent.mkdir(parents=True, exist_ok=True)
+_ACCESS.write_text('{"allowFrom": []}')
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "discord-bridge.py"
+
+
+def _load(tasks_archive, results_archive):
+    """Exec archive_path + archive_file against temp archive roots."""
+    tree = ast.parse(SRC.read_text())
+    wanted = {"archive_path", "archive_file"}
+    body = [n for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name in wanted]
+    missing = wanted - {n.name for n in body}
+    if missing:
+        raise AssertionError(f"not found in {SRC}: {sorted(missing)}")
+    ns = {"Path": Path,
+          "ARCHIVE_TASKS_DIR": tasks_archive,
+          "ARCHIVE_RESULTS_DIR": results_archive}
+    exec(compile(ast.Module(body=body, type_ignores=[]), str(SRC), "exec"), ns)
+    return ns["archive_file"]
+
+
+class ArchiveFailureIsNotDeletion(unittest.TestCase):
+    def test_the_happy_path_still_moves_the_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            src = d / "task-1.txt"
+            src.write_text("id: task-1\ntask: do the thing\n")
+            fn = _load(d / "arch-tasks", d / "arch-results")
+            self.assertTrue(fn(src, "tasks", "task-1"))
+            self.assertFalse(src.exists(), "archived file should be gone from source")
+            moved = list((d / "arch-tasks").rglob("task-1.txt"))
+            self.assertEqual(len(moved), 1, "file should be in the archive")
+            self.assertIn("do the thing", moved[0].read_text())
+
+    def test_a_failed_archive_LEAVES_the_task(self):
+        """The regression. Pre-fix this asserts False — the file was unlinked."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            src = d / "task-2.txt"
+            src.write_text("id: task-2\ntask: irreplaceable\n")
+            # Clobber the archive root with a FILE so mkdir(parents=True) raises
+            # inside archive_path, i.e. a real unwritable-archive failure.
+            broken = d / "arch-tasks"
+            broken.write_text("not a directory")
+            fn = _load(broken, d / "arch-results")
+
+            self.assertFalse(fn(src, "tasks", "task-2"), "must report failure")
+            self.assertTrue(src.exists(),
+                            "a failed archive must NOT delete the task file")
+            self.assertIn("irreplaceable", src.read_text(),
+                          "the surviving file must still hold its content")
+
+    def test_absent_source_reports_success(self):
+        """Nothing to archive is not a failure — it must not hold the sentinel."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            fn = _load(d / "arch-tasks", d / "arch-results")
+            self.assertTrue(fn(d / "nope.txt", "tasks", "task-3"))
+
+    def test_results_kind_routes_to_the_results_archive(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            src = d / "task-4.txt"
+            src.write_text("done")
+            fn = _load(d / "arch-tasks", d / "arch-results")
+            self.assertTrue(fn(src, "results", "task-4"))
+            self.assertEqual(len(list((d / "arch-results").rglob("task-4.txt"))), 1)
+            self.assertEqual(len(list((d / "arch-tasks").rglob("*.txt"))), 0)
+
+
+class SentinelStaysWhileTheResultDoes(unittest.TestCase):
+    """Without this, leaving the file trades data loss for a duplicate send."""
+
+    def test_every_clear_delivered_is_gated_on_the_archive(self):
+        """AST, not text: a comment mentioning the call is not a call, and the
+        guard sits further back than any fixed character window reaches."""
+        tree = ast.parse(SRC.read_text())
+
+        def clear_calls(node):
+            return [n for n in ast.walk(node)
+                    if isinstance(n, ast.Call)
+                    and isinstance(n.func, ast.Name)
+                    and n.func.id == "_clear_delivered"]
+
+        all_calls = clear_calls(tree)
+        gated = [c for n in ast.walk(tree)
+                 if isinstance(n, ast.If)
+                 and isinstance(n.test, ast.Name) and n.test.id == "_archived"
+                 for c in clear_calls(ast.Module(body=n.body, type_ignores=[]))]
+
+        self.assertGreaterEqual(len(all_calls), 2,
+                                "expected the two poll-loop clear sites")
+        self.assertEqual(len(gated), len(all_calls),
+                         f"{len(all_calls) - len(gated)} _clear_delivered "
+                         "call(s) not behind `if _archived:` — an ungated clear "
+                         "lets a surviving result file be delivered a second time")
+
+    def test_the_gate_reads_the_RESULT_archive(self):
+        """`if _archived:` is only meaningful if _archived came from archiving
+        the result file — the task file's fate does not drive redelivery."""
+        tree = ast.parse(SRC.read_text())
+        assigns = [n for n in ast.walk(tree)
+                   if isinstance(n, ast.Assign)
+                   and any(isinstance(t, ast.Name) and t.id == "_archived"
+                           for t in n.targets)
+                   and isinstance(n.value, ast.Call)
+                   and isinstance(n.value.func, ast.Name)
+                   and n.value.func.id == "archive_file"
+                   and n.value.args
+                   and isinstance(n.value.args[0], ast.Name)
+                   and n.value.args[0].id == "result_file"]
+        self.assertGreaterEqual(len(assigns), 2,
+                                "each gated site needs its own "
+                                "`_archived = archive_file(result_file, ...)`")
+
+    def test_archive_file_no_longer_unlinks(self):
+        text = SRC.read_text()
+        start = text.index("def archive_file(")
+        end = text.index("\ndef ", start + 1)
+        self.assertNotIn("unlink", text[start:end],
+                         "archive_file must never delete its source")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/discord-bridge-archive-failure-keeps-the-file.test.py
+++ b/tests/discord-bridge-archive-failure-keeps-the-file.test.py
@@ -7,6 +7,7 @@ import os
 import importlib.util
 import tempfile
 import unittest
+from unittest import mock
 
 # Hermetic-bridge-test lint: explicit config root, access.json seeded under it.
 _CFG = tempfile.mkdtemp(prefix="archive-test-cfg-")
@@ -146,14 +147,32 @@ class ArchiveFailureIsNotDeletion(unittest.TestCase):
         self.assertEqual((self.d / "task-7.txt.archive-failed.1").read_text(), "new")
 
     def test_archive_file_never_unlinks_its_source_before_a_copy_exists(self):
-        """It may unlink only after the hard link is in place — an unlink that
-        can run on the failure path is the deletion bug returning."""
-        text = (SRC.parent / "task_archive.py").read_text()
-        start = text.index("def archive_file(")
-        body = text[start:]
-        self.assertIn("os.link(", body, "quarantine must link before unlinking")
-        self.assertLess(body.index("os.link("), body.index("src.unlink()"),
-                        "unlink must come after the link, never before")
+        """A second copy must exist at the instant the source is unlinked.
+
+        Asserted by observing the filesystem from inside unlink, not by
+        grepping the source: the link moved into a helper once already, and a
+        source-text check reports that refactor as the deletion bug returning.
+        """
+        src = self.d / "task-8.txt"
+        src.write_text("payload")
+        observed = {}
+        real_unlink = Path.unlink
+
+        def spy(self_path, *a, **kw):
+            if self_path == src:
+                copies = [p for p in self.d.glob("task-8.txt*") if p != src]
+                observed["copies_at_unlink"] = [p.name for p in copies]
+                observed["bodies"] = [p.read_text() for p in copies]
+            return real_unlink(self_path, *a, **kw)
+
+        with mock.patch.object(Path, "unlink", spy):
+            self.assertTrue(self._broken()(src, "tasks", "task-8"))
+
+        self.assertTrue(observed, "the source was never unlinked at all")
+        self.assertTrue(observed["copies_at_unlink"],
+                        "source unlinked while it was the ONLY copy — data loss")
+        self.assertIn("payload", observed["bodies"],
+                      "the surviving copy must already hold the bytes")
 
 
 class CallersHonourTheReturn(unittest.TestCase):

--- a/tests/discord-bridge-archive-failure-keeps-the-file.test.py
+++ b/tests/discord-bridge-archive-failure-keeps-the-file.test.py
@@ -1,27 +1,10 @@
 #!/usr/bin/env python3
-"""Behavioral test: a failed archive must not destroy the task it failed to archive.
+"""A failed archive must not destroy the task, nor silently re-enter the queue.
 
-Root cause (2026-08-11): `archive_file()` caught every exception from the move
-and then ran `src.unlink(missing_ok=True)` under the comment "so we don't leave
-stale files". That deletes the task file whose PRESERVATION is the entire reason
-archiving exists — and it does so on the one path where something already went
-wrong, printing a line nobody reads. A task could vanish with no result written
-and no trace beyond that print.
-
-`archive_path()` is inside the same try, so an unwritable or clobbered archive
-directory — a `mkdir` that raises — reaches the delete. That is the failure this
-test drives, because it needs no mocking of `shutil`.
-
-The fix leaves `src` in place and reports failure, which raises a second
-question the delete had been masking: the caller clears the delivery sentinel
-straight afterwards. A surviving result file re-enters the poll loop, and the
-sentinel is the only thing standing between it and a duplicate send — so the
-clear is now gated on the archive having actually succeeded. Both call sites
-already CLAIMED that precondition in their comments ("Delivery succeeded +
-archived") without checking it.
-
-Extracts the pure functions rather than importing the bridge, matching the
-convention of the other bridge tests.
+`archive_file()` used to `unlink()` its source whenever the move raised, deleting
+the file whose preservation is the reason archiving exists. Simply leaving it
+instead makes it poll forever, so the failure path now quarantines it off the
+`*.txt` glob.
 """
 from pathlib import Path
 import ast
@@ -29,8 +12,7 @@ import os
 import tempfile
 import unittest
 
-# Hermetic-bridge-test lint: an explicit config root plus the canonical
-# access.json seeded underneath it, rooted at the name in the environ.
+# Hermetic-bridge-test lint: explicit config root, access.json seeded under it.
 _CFG = tempfile.mkdtemp(prefix="archive-test-cfg-")
 os.environ["CLAUDE_CONFIG_DIR"] = _CFG
 _ACCESS = Path(_CFG) / "channels" / "discord" / "access.json"
@@ -49,108 +31,81 @@ def _load(tasks_archive, results_archive):
     missing = wanted - {n.name for n in body}
     if missing:
         raise AssertionError(f"not found in {SRC}: {sorted(missing)}")
-    ns = {"Path": Path,
-          "ARCHIVE_TASKS_DIR": tasks_archive,
+    ns = {"Path": Path, "ARCHIVE_TASKS_DIR": tasks_archive,
           "ARCHIVE_RESULTS_DIR": results_archive}
     exec(compile(ast.Module(body=body, type_ignores=[]), str(SRC), "exec"), ns)
     return ns["archive_file"]
 
 
 class ArchiveFailureIsNotDeletion(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.d = Path(self._td.name)
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def _broken(self):
+        """Clobber the archive root with a FILE so archive_path's mkdir raises —
+        a real unwritable-archive failure, no mocking."""
+        broken = self.d / "arch-tasks"
+        broken.write_text("not a directory")
+        return _load(broken, self.d / "arch-results")
+
     def test_the_happy_path_still_moves_the_file(self):
-        with tempfile.TemporaryDirectory() as td:
-            d = Path(td)
-            src = d / "task-1.txt"
-            src.write_text("id: task-1\ntask: do the thing\n")
-            fn = _load(d / "arch-tasks", d / "arch-results")
-            self.assertTrue(fn(src, "tasks", "task-1"))
-            self.assertFalse(src.exists(), "archived file should be gone from source")
-            moved = list((d / "arch-tasks").rglob("task-1.txt"))
-            self.assertEqual(len(moved), 1, "file should be in the archive")
-            self.assertIn("do the thing", moved[0].read_text())
+        src = self.d / "task-1.txt"
+        src.write_text("id: task-1\ntask: do the thing\n")
+        fn = _load(self.d / "arch-tasks", self.d / "arch-results")
+        self.assertTrue(fn(src, "tasks", "task-1"))
+        self.assertFalse(src.exists())
+        moved = list((self.d / "arch-tasks").rglob("task-1.txt"))
+        self.assertEqual(len(moved), 1)
+        self.assertIn("do the thing", moved[0].read_text())
 
-    def test_a_failed_archive_LEAVES_the_task(self):
-        """The regression. Pre-fix this asserts False — the file was unlinked."""
-        with tempfile.TemporaryDirectory() as td:
-            d = Path(td)
-            src = d / "task-2.txt"
-            src.write_text("id: task-2\ntask: irreplaceable\n")
-            # Clobber the archive root with a FILE so mkdir(parents=True) raises
-            # inside archive_path, i.e. a real unwritable-archive failure.
-            broken = d / "arch-tasks"
-            broken.write_text("not a directory")
-            fn = _load(broken, d / "arch-results")
+    def test_a_failed_archive_never_DELETES_the_task(self):
+        """The regression. Pre-fix the file was unlinked and gone."""
+        src = self.d / "task-2.txt"
+        src.write_text("id: task-2\ntask: irreplaceable\n")
+        self._broken()(src, "tasks", "task-2")
+        survivor = self.d / "task-2.txt.archive-failed"
+        self.assertTrue(survivor.exists(), "the task must still be on disk")
+        self.assertIn("irreplaceable", survivor.read_text())
 
-            self.assertFalse(fn(src, "tasks", "task-2"), "must report failure")
-            self.assertTrue(src.exists(),
-                            "a failed archive must NOT delete the task file")
-            self.assertIn("irreplaceable", src.read_text(),
-                          "the surviving file must still hold its content")
+    def test_the_survivor_leaves_the_live_glob(self):
+        """Preserving it in place would poll forever; this is the other half."""
+        src = self.d / "task-3.txt"
+        src.write_text("body")
+        self.assertTrue(self._broken()(src, "tasks", "task-3"),
+                        "quarantined counts as having left the live queue")
+        self.assertEqual(sorted(p.name for p in self.d.glob("task-*.txt")), [],
+                         "nothing may still match the queue's *.txt glob")
+        self.assertEqual([p.name for p in self.d.glob("task-*.archive-failed")],
+                         ["task-3.txt.archive-failed"])
+
+    def test_returns_False_only_when_it_is_still_live(self):
+        """Quarantine can fail too — then the caller is owed the truth."""
+        src = self.d / "task-4.txt"
+        src.write_text("body")
+        # An occupied non-empty directory at the target makes rename() raise.
+        blocker = self.d / "task-4.txt.archive-failed"
+        blocker.mkdir()
+        (blocker / "occupied").write_text("x")
+        self.assertFalse(self._broken()(src, "tasks", "task-4"))
+        self.assertTrue(src.exists(), "still live, and still not deleted")
 
     def test_absent_source_reports_success(self):
-        """Nothing to archive is not a failure — it must not hold the sentinel."""
-        with tempfile.TemporaryDirectory() as td:
-            d = Path(td)
-            fn = _load(d / "arch-tasks", d / "arch-results")
-            self.assertTrue(fn(d / "nope.txt", "tasks", "task-3"))
+        fn = _load(self.d / "arch-tasks", self.d / "arch-results")
+        self.assertTrue(fn(self.d / "nope.txt", "tasks", "task-5"))
 
     def test_results_kind_routes_to_the_results_archive(self):
-        with tempfile.TemporaryDirectory() as td:
-            d = Path(td)
-            src = d / "task-4.txt"
-            src.write_text("done")
-            fn = _load(d / "arch-tasks", d / "arch-results")
-            self.assertTrue(fn(src, "results", "task-4"))
-            self.assertEqual(len(list((d / "arch-results").rglob("task-4.txt"))), 1)
-            self.assertEqual(len(list((d / "arch-tasks").rglob("*.txt"))), 0)
+        src = self.d / "task-6.txt"
+        src.write_text("done")
+        fn = _load(self.d / "arch-tasks", self.d / "arch-results")
+        self.assertTrue(fn(src, "results", "task-6"))
+        self.assertEqual(len(list((self.d / "arch-results").rglob("task-6.txt"))), 1)
+        self.assertEqual(len(list((self.d / "arch-tasks").rglob("*.txt"))), 0)
 
-
-class SentinelStaysWhileTheResultDoes(unittest.TestCase):
-    """Without this, leaving the file trades data loss for a duplicate send."""
-
-    def test_every_clear_delivered_is_gated_on_the_archive(self):
-        """AST, not text: a comment mentioning the call is not a call, and the
-        guard sits further back than any fixed character window reaches."""
-        tree = ast.parse(SRC.read_text())
-
-        def clear_calls(node):
-            return [n for n in ast.walk(node)
-                    if isinstance(n, ast.Call)
-                    and isinstance(n.func, ast.Name)
-                    and n.func.id == "_clear_delivered"]
-
-        all_calls = clear_calls(tree)
-        gated = [c for n in ast.walk(tree)
-                 if isinstance(n, ast.If)
-                 and isinstance(n.test, ast.Name) and n.test.id == "_archived"
-                 for c in clear_calls(ast.Module(body=n.body, type_ignores=[]))]
-
-        self.assertGreaterEqual(len(all_calls), 2,
-                                "expected the two poll-loop clear sites")
-        self.assertEqual(len(gated), len(all_calls),
-                         f"{len(all_calls) - len(gated)} _clear_delivered "
-                         "call(s) not behind `if _archived:` — an ungated clear "
-                         "lets a surviving result file be delivered a second time")
-
-    def test_the_gate_reads_the_RESULT_archive(self):
-        """`if _archived:` is only meaningful if _archived came from archiving
-        the result file — the task file's fate does not drive redelivery."""
-        tree = ast.parse(SRC.read_text())
-        assigns = [n for n in ast.walk(tree)
-                   if isinstance(n, ast.Assign)
-                   and any(isinstance(t, ast.Name) and t.id == "_archived"
-                           for t in n.targets)
-                   and isinstance(n.value, ast.Call)
-                   and isinstance(n.value.func, ast.Name)
-                   and n.value.func.id == "archive_file"
-                   and n.value.args
-                   and isinstance(n.value.args[0], ast.Name)
-                   and n.value.args[0].id == "result_file"]
-        self.assertGreaterEqual(len(assigns), 2,
-                                "each gated site needs its own "
-                                "`_archived = archive_file(result_file, ...)`")
-
-    def test_archive_file_no_longer_unlinks(self):
+    def test_archive_file_never_unlinks(self):
         text = SRC.read_text()
         start = text.index("def archive_file(")
         end = text.index("\ndef ", start + 1)

--- a/tests/discord-bridge-archive-failure-keeps-the-file.test.py
+++ b/tests/discord-bridge-archive-failure-keeps-the-file.test.py
@@ -24,33 +24,29 @@ _spec.loader.exec_module(_task_archive)
 
 
 def _load(tasks_archive, results_archive):
-    """Exec archive_path + archive_file against temp archive roots."""
-    tree = ast.parse(SRC.read_text())
-    wanted = {"archive_path", "archive_file"}
-    body = [n for n in tree.body
-            if isinstance(n, ast.FunctionDef) and n.name in wanted]
-    missing = wanted - {n.name for n in body}
-    if missing:
-        raise AssertionError(f"not found in {SRC}: {sorted(missing)}")
-    ns = {"Path": Path, "os": os, "ARCHIVE_TASKS_DIR": tasks_archive,
-          "ARCHIVE_RESULTS_DIR": results_archive}
-    exec(compile(ast.Module(body=body, type_ignores=[]), str(SRC), "exec"), ns)
-    return ns["archive_file"]
+    """Bind the SHARED policy to temp archive roots. The bridges are adapters
+    over this, so the contract is tested here once, not three times."""
+    def archive(src, kind, task_id):
+        return _task_archive.archive_file(
+            src, kind, task_id,
+            tasks_dir=tasks_archive, results_dir=results_archive,
+            log=lambda m: None)
+    return archive
 
 
 def _load_pair(tasks_archive, results_archive, tasks_dir, cleared):
     """Exec archive_path + archive_file + _archive_delivered_pair together, so
     the shared cleanup policy is exercised rather than pattern-matched."""
     tree = ast.parse(SRC.read_text())
-    wanted = {"archive_path", "archive_file", "_archive_delivered_pair"}
+    wanted = {"_archive_delivered_pair"}
     body = [n for n in tree.body
             if isinstance(n, ast.FunctionDef) and n.name in wanted]
     missing = wanted - {n.name for n in body}
     if missing:
         raise AssertionError(f"not found in {SRC}: {sorted(missing)}")
-    ns = {"Path": Path, "os": os, "ARCHIVE_TASKS_DIR": tasks_archive,
-          "ARCHIVE_RESULTS_DIR": results_archive, "TASKS_DIR": tasks_dir,
+    ns = {"Path": Path, "os": os, "TASKS_DIR": tasks_dir,
           "find_task_file": _task_archive.find_task_file,
+          "archive_file": _load(tasks_archive, results_archive),
           "_clear_delivered": lambda t: cleared.append(t)}
     exec(compile(ast.Module(body=body, type_ignores=[]), str(SRC), "exec"), ns)
     return ns["_archive_delivered_pair"]
@@ -147,10 +143,9 @@ class ArchiveFailureIsNotDeletion(unittest.TestCase):
     def test_archive_file_never_unlinks_its_source_before_a_copy_exists(self):
         """It may unlink only after the hard link is in place — an unlink that
         can run on the failure path is the deletion bug returning."""
-        text = SRC.read_text()
+        text = (SRC.parent / "task_archive.py").read_text()
         start = text.index("def archive_file(")
-        end = text.index("\ndef ", start + 1)
-        body = text[start:end]
+        body = text[start:]
         self.assertIn("os.link(", body, "quarantine must link before unlinking")
         self.assertLess(body.index("os.link("), body.index("src.unlink()"),
                         "unlink must come after the link, never before")
@@ -217,6 +212,33 @@ class CallersHonourTheReturn(unittest.TestCase):
         self.assertFalse(archive(src, "tasks", "task-4"),
                          "if the source is still under its live name, say so")
         self.assertTrue(Path(src).exists(), "never delete on the failure path")
+
+
+class EveryBridgeDelegatesTheNeverDeletePolicy(unittest.TestCase):
+    """#2819's fix was Discord-only; slack and telegram unlinked the source on a
+    failed archive, destroying the only copy of the task."""
+
+    BRIDGES = ("discord-bridge.py", "slack-bridge.py", "telegram-bridge.py")
+
+    def _fn(self, name):
+        tree = ast.parse((SRC.parent / name).read_text())
+        fns = [n for n in tree.body
+               if isinstance(n, ast.FunctionDef) and n.name == "archive_file"]
+        self.assertEqual(len(fns), 1, f"{name}: expected exactly one archive_file")
+        return fns[0]
+
+    def test_no_bridge_unlinks_its_source_on_a_failed_archive(self):
+        for name in self.BRIDGES:
+            calls = [c for c in ast.walk(self._fn(name)) if isinstance(c, ast.Call)
+                     and getattr(c.func, "attr", "") == "unlink"]
+            self.assertEqual(calls, [], f"{name} deletes the task it failed to archive")
+
+    def test_every_bridge_routes_through_the_shared_policy(self):
+        for name in self.BRIDGES:
+            delegates = [c for c in ast.walk(self._fn(name)) if isinstance(c, ast.Call)
+                         and getattr(c.func, "id", "") == "_shared_archive_file"]
+            self.assertEqual(len(delegates), 1,
+                             f"{name} must call the shared archive policy exactly once")
 
 
 if __name__ == "__main__":

--- a/tests/discord-bridge-archive-failure-keeps-the-file.test.py
+++ b/tests/discord-bridge-archive-failure-keeps-the-file.test.py
@@ -11,9 +11,14 @@ import unittest
 # Hermetic-bridge-test lint: explicit config root, access.json seeded under it.
 _CFG = tempfile.mkdtemp(prefix="archive-test-cfg-")
 os.environ["CLAUDE_CONFIG_DIR"] = _CFG
-_ACCESS = Path(_CFG) / "channels" / "discord" / "access.json"
-_ACCESS.parent.mkdir(parents=True, exist_ok=True)
-_ACCESS.write_text('{"allowFrom": []}')
+# Literal, not a loop: the guard reads AST constants, so a loop variable hides
+# the path from it. All three bridges are named below, so all three are seeded.
+(Path(_CFG) / "channels" / "discord").mkdir(parents=True, exist_ok=True)
+(Path(_CFG) / "channels" / "discord" / "access.json").write_text('{"allowFrom": []}')
+(Path(_CFG) / "channels" / "slack").mkdir(parents=True, exist_ok=True)
+(Path(_CFG) / "channels" / "slack" / "access.json").write_text('{"allowFrom": []}')
+(Path(_CFG) / "channels" / "telegram").mkdir(parents=True, exist_ok=True)
+(Path(_CFG) / "channels" / "telegram" / "access.json").write_text('{"allowFrom": []}')
 
 SRC = Path(__file__).resolve().parent.parent / "src" / "discord-bridge.py"
 

--- a/tests/discord-bridge-archive-failure-keeps-the-file.test.py
+++ b/tests/discord-bridge-archive-failure-keeps-the-file.test.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 """A failed archive must not destroy the task, nor silently re-enter the queue.
-
-`archive_file()` used to `unlink()` its source whenever the move raised, deleting
-the file whose preservation is the reason archiving exists. Simply leaving it
-instead makes it poll forever, so the failure path now quarantines it off the
-`*.txt` glob.
-"""
+Quarantine must not overwrite an earlier one, and callers must honour False."""
 from pathlib import Path
 import ast
 import os
@@ -31,7 +26,7 @@ def _load(tasks_archive, results_archive):
     missing = wanted - {n.name for n in body}
     if missing:
         raise AssertionError(f"not found in {SRC}: {sorted(missing)}")
-    ns = {"Path": Path, "ARCHIVE_TASKS_DIR": tasks_archive,
+    ns = {"Path": Path, "os": os, "ARCHIVE_TASKS_DIR": tasks_archive,
           "ARCHIVE_RESULTS_DIR": results_archive}
     exec(compile(ast.Module(body=body, type_ignores=[]), str(SRC), "exec"), ns)
     return ns["archive_file"]
@@ -83,15 +78,20 @@ class ArchiveFailureIsNotDeletion(unittest.TestCase):
                          ["task-3.txt.archive-failed"])
 
     def test_returns_False_only_when_it_is_still_live(self):
-        """Quarantine can fail too — then the caller is owed the truth."""
-        src = self.d / "task-4.txt"
+        """Quarantine can fail too — then the caller is owed the truth. A
+        read-only parent blocks the link; a taken name no longer does, since the
+        collision loop routes around it."""
+        sub = self.d / "ro"
+        sub.mkdir()
+        src = sub / "task-4.txt"
         src.write_text("body")
-        # An occupied non-empty directory at the target makes rename() raise.
-        blocker = self.d / "task-4.txt.archive-failed"
-        blocker.mkdir()
-        (blocker / "occupied").write_text("x")
-        self.assertFalse(self._broken()(src, "tasks", "task-4"))
-        self.assertTrue(src.exists(), "still live, and still not deleted")
+        fn = self._broken()
+        os.chmod(sub, 0o500)
+        try:
+            self.assertFalse(fn(src, "tasks", "task-4"))
+            self.assertTrue(src.exists(), "still live, and still not deleted")
+        finally:
+            os.chmod(sub, 0o700)
 
     def test_absent_source_reports_success(self):
         fn = _load(self.d / "arch-tasks", self.d / "arch-results")
@@ -105,12 +105,64 @@ class ArchiveFailureIsNotDeletion(unittest.TestCase):
         self.assertEqual(len(list((self.d / "arch-results").rglob("task-6.txt"))), 1)
         self.assertEqual(len(list((self.d / "arch-tasks").rglob("*.txt"))), 0)
 
-    def test_archive_file_never_unlinks(self):
+    def test_quarantine_never_overwrites_an_earlier_one(self):
+        """rename() replaces an existing file on POSIX; a repeated task id would
+        destroy the only preserved copy."""
+        src = self.d / "task-7.txt"
+        src.write_text("new")
+        prior = self.d / "task-7.txt.archive-failed"
+        prior.write_text("old")
+        self.assertTrue(self._broken()(src, "tasks", "task-7"))
+        self.assertEqual(prior.read_text(), "old",
+                         "the earlier quarantine must survive intact")
+        survivors = sorted(p.name for p in self.d.glob("task-7.txt.archive-failed*"))
+        self.assertEqual(survivors,
+                         ["task-7.txt.archive-failed", "task-7.txt.archive-failed.1"])
+        self.assertEqual((self.d / "task-7.txt.archive-failed.1").read_text(), "new")
+
+    def test_archive_file_never_unlinks_its_source_before_a_copy_exists(self):
+        """It may unlink only after the hard link is in place — an unlink that
+        can run on the failure path is the deletion bug returning."""
         text = SRC.read_text()
         start = text.index("def archive_file(")
         end = text.index("\ndef ", start + 1)
-        self.assertNotIn("unlink", text[start:end],
-                         "archive_file must never delete its source")
+        body = text[start:end]
+        self.assertIn("os.link(", body, "quarantine must link before unlinking")
+        self.assertLess(body.index("os.link("), body.index("src.unlink()"),
+                        "unlink must come after the link, never before")
+
+
+class CallersHonourTheReturn(unittest.TestCase):
+    """A False return that every caller discards is not a contract."""
+
+    def test_delivery_sentinel_clears_only_when_the_result_is_gone(self):
+        tree = ast.parse(SRC.read_text())
+        clears = [n for n in ast.walk(tree)
+                  if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                  and n.func.id == "_clear_delivered"]
+        gated = [c for n in ast.walk(tree)
+                 if isinstance(n, ast.If) and isinstance(n.test, ast.Name)
+                 and n.test.id == "_gone"
+                 for c in ast.walk(ast.Module(body=n.body, type_ignores=[]))
+                 if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+                 and c.func.id == "_clear_delivered"]
+        self.assertGreaterEqual(len(clears), 2)
+        self.assertEqual(len(gated), len(clears),
+                         "every _clear_delivered must sit behind `if _gone:` — "
+                         "clearing while the result is still live permits a resend")
+
+    def test_the_gate_reads_the_RESULT_archive(self):
+        tree = ast.parse(SRC.read_text())
+        assigns = [n for n in ast.walk(tree)
+                   if isinstance(n, ast.Assign)
+                   and any(isinstance(t, ast.Name) and t.id == "_gone" for t in n.targets)
+                   and isinstance(n.value, ast.Call)
+                   and getattr(n.value.func, "id", None) == "archive_file"
+                   and n.value.args
+                   and getattr(n.value.args[0], "id", None) == "result_file"]
+        self.assertGreaterEqual(len(assigns), 2,
+                                "each gated site needs its own "
+                                "`_gone = archive_file(result_file, ...)`")
 
 
 if __name__ == "__main__":

--- a/tests/discord-bridge-archive-failure-keeps-the-file.test.py
+++ b/tests/discord-bridge-archive-failure-keeps-the-file.test.py
@@ -4,6 +4,7 @@ Quarantine must not overwrite an earlier one, and callers must honour False."""
 from pathlib import Path
 import ast
 import os
+import importlib.util
 import tempfile
 import unittest
 
@@ -15,6 +16,11 @@ _ACCESS.parent.mkdir(parents=True, exist_ok=True)
 _ACCESS.write_text('{"allowFrom": []}')
 
 SRC = Path(__file__).resolve().parent.parent / "src" / "discord-bridge.py"
+
+_spec = importlib.util.spec_from_file_location(
+    "_task_archive", Path(__file__).resolve().parent.parent / "src" / "task_archive.py")
+_task_archive = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_task_archive)
 
 
 def _load(tasks_archive, results_archive):
@@ -30,6 +36,24 @@ def _load(tasks_archive, results_archive):
           "ARCHIVE_RESULTS_DIR": results_archive}
     exec(compile(ast.Module(body=body, type_ignores=[]), str(SRC), "exec"), ns)
     return ns["archive_file"]
+
+
+def _load_pair(tasks_archive, results_archive, tasks_dir, cleared):
+    """Exec archive_path + archive_file + _archive_delivered_pair together, so
+    the shared cleanup policy is exercised rather than pattern-matched."""
+    tree = ast.parse(SRC.read_text())
+    wanted = {"archive_path", "archive_file", "_archive_delivered_pair"}
+    body = [n for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name in wanted]
+    missing = wanted - {n.name for n in body}
+    if missing:
+        raise AssertionError(f"not found in {SRC}: {sorted(missing)}")
+    ns = {"Path": Path, "os": os, "ARCHIVE_TASKS_DIR": tasks_archive,
+          "ARCHIVE_RESULTS_DIR": results_archive, "TASKS_DIR": tasks_dir,
+          "find_task_file": _task_archive.find_task_file,
+          "_clear_delivered": lambda t: cleared.append(t)}
+    exec(compile(ast.Module(body=body, type_ignores=[]), str(SRC), "exec"), ns)
+    return ns["_archive_delivered_pair"]
 
 
 class ArchiveFailureIsNotDeletion(unittest.TestCase):
@@ -133,36 +157,66 @@ class ArchiveFailureIsNotDeletion(unittest.TestCase):
 
 
 class CallersHonourTheReturn(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.d = Path(self._td.name)
+
+    def tearDown(self):
+        self._td.cleanup()
+
     """A False return that every caller discards is not a contract."""
 
-    def test_delivery_sentinel_clears_only_when_the_result_is_gone(self):
-        tree = ast.parse(SRC.read_text())
-        clears = [n for n in ast.walk(tree)
-                  if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
-                  and n.func.id == "_clear_delivered"]
-        gated = [c for n in ast.walk(tree)
-                 if isinstance(n, ast.If) and isinstance(n.test, ast.Name)
-                 and n.test.id == "_gone"
-                 for c in ast.walk(ast.Module(body=n.body, type_ignores=[]))
-                 if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
-                 and c.func.id == "_clear_delivered"]
-        self.assertGreaterEqual(len(clears), 2)
-        self.assertEqual(len(gated), len(clears),
-                         "every _clear_delivered must sit behind `if _gone:` — "
-                         "clearing while the result is still live permits a resend")
+    def test_the_pair_clears_the_sentinel_when_the_result_IS_archived(self):
+        cleared = []
+        pair = _load_pair(self.d / "at", self.d / "ar", self.d / "tasks", cleared)
+        (self.d / "tasks").mkdir()
+        res = self.d / "task-1.txt"; res.write_text("r")
+        (self.d / "tasks" / "task-1.txt").write_text("t")
+        pair(res, "task-1")
+        self.assertEqual(cleared, ["task-1"], "a fully archived pair must retire its sentinel")
+        self.assertFalse(res.exists(), "the result must leave the live queue")
 
-    def test_the_gate_reads_the_RESULT_archive(self):
-        tree = ast.parse(SRC.read_text())
-        assigns = [n for n in ast.walk(tree)
-                   if isinstance(n, ast.Assign)
-                   and any(isinstance(t, ast.Name) and t.id == "_gone" for t in n.targets)
-                   and isinstance(n.value, ast.Call)
-                   and getattr(n.value.func, "id", None) == "archive_file"
-                   and n.value.args
-                   and getattr(n.value.args[0], "id", None) == "result_file"]
-        self.assertGreaterEqual(len(assigns), 2,
-                                "each gated site needs its own "
-                                "`_gone = archive_file(result_file, ...)`")
+    def test_the_pair_KEEPS_the_sentinel_when_the_result_survives(self):
+        # Both routes must fail for the result to still be live: the move (broken
+        # archive root) AND the quarantine (unlink refused). A quarantined file
+        # HAS left the live glob, so that alone is correctly treated as gone.
+        class _NoUnlink(type(Path())):
+            def unlink(self, *a, **k):
+                raise OSError("unlink refused")
+        cleared = []
+        broken = self.d / "at"; broken.write_text("not a directory")
+        tasks = self.d / "tasks"; tasks.mkdir()
+        pair = _load_pair(broken, broken, tasks, cleared)
+        res = _NoUnlink(self.d / "task-2.txt"); res.write_text("r")
+        pair(res, "task-2")
+        self.assertEqual(cleared, [], "a result still under its live name must KEEP its "
+                                      "sentinel — clearing it permits a second send")
+        self.assertTrue(Path(res).exists(), "a failed archive must never delete the result")
+
+    def test_the_pair_resolves_a_CLAIMED_task_not_a_rebuilt_bare_name(self):
+        cleared = []
+        tasks = self.d / "tasks"; tasks.mkdir()
+        pair = _load_pair(self.d / "at", self.d / "ar", tasks, cleared)
+        claimed = tasks / "task-3.claimed-core-1.txt"; claimed.write_text("t")
+        res = self.d / "task-3.txt"; res.write_text("r")
+        pair(res, "task-3")
+        self.assertFalse(claimed.exists(),
+                         "a claimed task must be archived, not stranded under its claim name")
+
+    def test_unlink_failure_after_a_successful_link_reports_still_live(self):
+        # link() succeeds, unlink() raises -> the second except, which must
+        # report False rather than claim the source is gone.
+        class _NoUnlink(type(Path())):
+            def unlink(self, *a, **k):
+                raise OSError("unlink refused")
+        # archive root clobbered by a FILE so shutil.move raises for real and
+        # the quarantine path runs; link() then succeeds beside the source.
+        broken = self.d / "at2"; broken.write_text("not a directory")
+        archive = _load(broken, broken)
+        src = _NoUnlink(self.d / "task-4.txt"); src.write_text("body")
+        self.assertFalse(archive(src, "tasks", "task-4"),
+                         "if the source is still under its live name, say so")
+        self.assertTrue(Path(src).exists(), "never delete on the failure path")
 
 
 if __name__ == "__main__":

--- a/tests/discord-bridge-delivery-sentinel.test.py
+++ b/tests/discord-bridge-delivery-sentinel.test.py
@@ -196,9 +196,12 @@ def test_poll_results_marks_delivered_in_send_block():
 
 
 def test_poll_results_clears_sentinel_after_archive():
-    """Architectural: `_clear_delivered` must be called AFTER both
-    archive_file calls. Without it, sentinels accumulate forever in
-    `state/discord-delivered/`."""
+    """Architectural: the sentinel must be retired after both archive_file
+    calls, or sentinels accumulate forever in `state/discord-delivered/`.
+
+    That policy now lives in `_archive_delivered_pair`, which both delivery
+    paths call, so follow it there rather than requiring the call to be
+    open-coded inside poll_results."""
     import re
     src = (REPO / "src" / "discord-bridge.py").read_text()
     poll_block = re.search(
@@ -207,8 +210,17 @@ def test_poll_results_clears_sentinel_after_archive():
     )
     assert poll_block
     body = poll_block.group(1)
-    clear_pos = body.find("_clear_delivered(task_id)")
-    assert clear_pos > 0, "_clear_delivered NOT called in poll_results"
+    assert "_archive_delivered_pair(" in body, (
+        "poll_results must route cleanup through the shared helper")
+
+    helper = re.search(r"def _archive_delivered_pair\(.*?\n\n\n", src, re.DOTALL)
+    assert helper, "the shared cleanup helper is missing"
+    h = helper.group(0)
+    clear_pos = h.find("_clear_delivered(task_id)")
+    assert clear_pos > 0, "_clear_delivered NOT called in the shared helper"
+    last_archive = h.rfind("archive_file(")
+    assert last_archive > 0 and clear_pos > last_archive, (
+        "the sentinel must be retired AFTER both archive_file calls")
 
 
 def main():

--- a/tests/orphan-result-routes.test.py
+++ b/tests/orphan-result-routes.test.py
@@ -264,25 +264,24 @@ class WiringTest(unittest.TestCase):
                       "poll_results never calls it, so nothing adopts an orphan route")
 
     def test_delivery_cleanup_archives_a_CLAIMED_task_not_a_rebuilt_bare_name(self):
-        # The resolver deliberately finds `<id>.claimed-core-N`, so the cleanup
-        # that follows delivery must resolve the same path or strand it forever.
-        # Anchored on the comment block: a SIBLING site also ends in
-        # _clear_delivered and already used this idiom, so a looser anchor
-        # matches that one and passes at the parent, proving nothing.
-        m = re.search(r"task_file = ([^\n]*)\n"
-                      r"\s*archive_file\(task_file, \"tasks\", task_id\)\n"
-                      r"(?:\s*#[^\n]*\n)+"
-                      r"\s*_clear_delivered\(task_id\)", self.src)
-        self.assertIsNotNone(
-            m, "the post-delivery cleanup rebuilds a bare task path; a claimed task strands")
+        # EVERY archive-then-clear site must resolve the claimed path, not just the
+        # first: anchoring on one lets a sibling site satisfy the match vacuously.
+        sites = re.findall(r"task_file = ([^\n]*)\n"
+                           r"\s*archive_file\(task_file, \"tasks\", task_id\)\n"
+                           r"(?:\s*(?:#[^\n]*|if [A-Za-z_]\w*:)\n)+"
+                           r"\s*_clear_delivered\(task_id\)", self.src)
+        self.assertGreaterEqual(
+            len(sites), 2,
+            "expected both post-delivery cleanup sites; a dropped one is an unchecked bare-name rebuild")
         with tempfile.TemporaryDirectory() as td:
             tasks = Path(td)
             claimed = tasks / "task-99.claimed-core-1.txt"
             claimed.write_text("body")
             ns = {"find_task_file": _task_archive.find_task_file,
                   "TASKS_DIR": tasks, "task_id": "task-99"}
-            self.assertEqual(eval(m.group(1), ns), claimed,
-                             "cleanup resolves the bare name, not the claimed file")
+            for expr in sites:
+                self.assertEqual(eval(expr, ns), claimed,
+                                 f"cleanup resolves the bare name, not the claimed file: {expr}")
 
     def test_the_bridge_injects_a_snowflake_validator(self):
         m = re.search(r"def _is_discord_channel_id\(value: str\) -> bool:.*?return ([^\n]+)",

--- a/tests/orphan-result-routes.test.py
+++ b/tests/orphan-result-routes.test.py
@@ -264,24 +264,28 @@ class WiringTest(unittest.TestCase):
                       "poll_results never calls it, so nothing adopts an orphan route")
 
     def test_delivery_cleanup_archives_a_CLAIMED_task_not_a_rebuilt_bare_name(self):
-        # EVERY archive-then-clear site must resolve the claimed path, not just the
-        # first: anchoring on one lets a sibling site satisfy the match vacuously.
-        sites = re.findall(r"task_file = ([^\n]*)\n"
-                           r"\s*archive_file\(task_file, \"tasks\", task_id\)\n"
-                           r"(?:\s*(?:#[^\n]*|if [A-Za-z_]\w*:)\n)+"
-                           r"\s*_clear_delivered\(task_id\)", self.src)
-        self.assertGreaterEqual(
-            len(sites), 2,
-            "expected both post-delivery cleanup sites; a dropped one is an unchecked bare-name rebuild")
+        # ONE owner for the archive-then-clear policy. Asserting the resolver
+        # inside it beats matching call sites: a new site inherits it for free.
+        m = re.search(r"def _archive_delivered_pair\(.*?\n\n\n", self.src, re.S)
+        self.assertIsNotNone(m, "the shared post-delivery cleanup helper is missing")
+        helper = m.group(0)
+        expr = re.search(r"task_file = ([^\n]*)\n", helper)
+        self.assertIsNotNone(expr, "the helper must resolve a task path")
         with tempfile.TemporaryDirectory() as td:
             tasks = Path(td)
             claimed = tasks / "task-99.claimed-core-1.txt"
             claimed.write_text("body")
             ns = {"find_task_file": _task_archive.find_task_file,
                   "TASKS_DIR": tasks, "task_id": "task-99"}
-            for expr in sites:
-                self.assertEqual(eval(expr, ns), claimed,
-                                 f"cleanup resolves the bare name, not the claimed file: {expr}")
+            self.assertEqual(eval(expr.group(1), ns), claimed,
+                             "cleanup resolves the bare name, not the claimed file")
+        # and every delivery path must go THROUGH it rather than open-coding
+        self.assertGreaterEqual(
+            len(re.findall(r"^\s+_archive_delivered_pair\(result_file, task_id\)$",
+                           self.src, re.M)), 2,
+            "both delivery paths must call the shared helper")
+        self.assertNotIn("_gone = archive_file", self.src,
+                         "an open-coded cleanup site bypasses the shared policy")
 
     def test_the_bridge_injects_a_snowflake_validator(self):
         m = re.search(r"def _is_discord_channel_id\(value: str\) -> bool:.*?return ([^\n]+)",

--- a/tests/orphan-result-routes.test.py
+++ b/tests/orphan-result-routes.test.py
@@ -79,6 +79,38 @@ class OrphanResultRoutesTest(unittest.TestCase):
         (self.tasks / f"{tid}.txt").write_text(task_text())
         self.assertEqual(self.routes(), {tid: SNOWFLAKE})
 
+    def test_a_quarantined_task_still_yields_its_route(self):
+        """A failed archive must not also strand the reply.
+
+        archive_file() mints <id>.txt.archive-failed when it cannot archive;
+        that file is then the task's only surviving header block, so routing
+        has to see it or the result is undeliverable forever.
+        """
+        tid = self._result()
+        (self.tasks / f"{tid}.txt.archive-failed").write_text(task_text())
+        self.assertEqual(self.routes(), {tid: SNOWFLAKE})
+
+    def test_a_suffixed_quarantine_still_yields_its_route(self):
+        tid = self._result()
+        (self.tasks / f"{tid}.txt.archive-failed.1").write_text(task_text())
+        self.assertEqual(self.routes(), {tid: SNOWFLAKE})
+
+    def test_a_live_task_outranks_a_quarantined_leftover(self):
+        """Precedence matters: the quarantined copy can be older, and routing
+        the stale channel_id would post the reply to the wrong place."""
+        tid = self._result()
+        (self.tasks / f"{tid}.txt").write_text(task_text())
+        (self.tasks / f"{tid}.txt.archive-failed").write_text(
+            task_text().replace(SNOWFLAKE, "9" * 19))
+        self.assertEqual(self.routes(), {tid: SNOWFLAKE})
+
+    def test_a_quarantine_for_another_id_is_not_matched(self):
+        """The lookup globs, so a longer id sharing this one's prefix must not
+        satisfy it — that would route one task's reply using another's headers."""
+        tid = self._result()
+        (self.tasks / f"{tid}-extra.txt.archive-failed").write_text(task_text())
+        self.assertEqual(self.routes(), {})
+
     def test_archived_task_still_yields_its_route(self):
         # By the time a result exists the core has usually archived the task,
         # so an archive miss would make the fix work only in a race.

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -208,6 +208,33 @@ class CollisionRecordsStayReachable(unittest.TestCase):
         self.assertIn("channel_id: REAL", got.read_text())
 
 
+class ArchiveLookupNeverScansTheDirectory(unittest.TestCase):
+    """find_archived_task runs in agent-api's per-poll loop over an archive that
+    reached 5,716 entries; a glob there measured 442x an exists()."""
+
+    def test_newest_archived_probes_exact_names_and_never_globs(self) -> None:
+        import task_archive
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "task-x.txt").write_text("a")
+            (d / "task-x.txt.1").write_text("b")
+            def boom(self, *a, **kw):
+                raise AssertionError("newest_archived scanned the directory")
+            with mock.patch.object(Path, "glob", boom), \
+                 mock.patch.object(Path, "iterdir", boom), \
+                 mock.patch("os.scandir", boom):
+                got = task_archive.newest_archived(d, "task-x")
+            self.assertEqual(got.name, "task-x.txt.1")
+
+    def test_an_absent_id_costs_one_probe_and_returns_none(self) -> None:
+        import task_archive
+        with tempfile.TemporaryDirectory() as td:
+            def boom(self, *a, **kw):
+                raise AssertionError("scanned the directory for an absent id")
+            with mock.patch.object(Path, "glob", boom):
+                self.assertIsNone(task_archive.newest_archived(Path(td), "task-nope"))
+
+
 class CrashDuringCrossDeviceCopy(unittest.TestCase):
     """A mocked exception exercises cleanup; only a real kill proves the
     authoritative name is never published half-written."""

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -1,6 +1,7 @@
 """Tests for src/task_archive.py — find_task_file() helper (closes #933)."""
 from __future__ import annotations
 
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -12,6 +13,19 @@ from datetime import datetime
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from task_archive import archive_file, find_task_file
+
+
+def exdev_from(src):
+    """EXDEV is a property of the PAIR — a same-directory link never raises it,
+    so an unconditional os.link mock also breaks the temp-publish step."""
+    real = os.link
+
+    def fake(a, b, **kw):
+        if Path(a) == Path(src):
+            raise OSError(18, "Cross-device link")
+        return real(a, b, **kw)
+
+    return mock.patch("os.link", side_effect=fake)
 
 
 class TestArchiveNeverOverwrites(unittest.TestCase):
@@ -56,12 +70,12 @@ class TestArchiveNeverOverwrites(unittest.TestCase):
                          "BODY")
 
     def test_cross_device_archive_copies_instead_of_linking(self) -> None:
-        """os.link cannot span filesystems, and the archive can be a different
-        mount. The O_EXCL copy fallback must preserve the bytes and the source."""
+        """os.link cannot span filesystems and the archive can be another mount:
+        the temp-then-publish fallback must preserve the bytes and the source."""
         import task_archive
         src = self.live / "task-c.txt"
         src.write_text("PAYLOAD")
-        with mock.patch("os.link", side_effect=OSError(18, "Cross-device link")):
+        with exdev_from(src):
             self.assertTrue(self._archive(src, "task-c"))
         landed = self.tasks_dir / self.month / "task-c.txt"
         self.assertEqual(landed.read_text(), "PAYLOAD")
@@ -72,16 +86,16 @@ class TestArchiveNeverOverwrites(unittest.TestCase):
         (self.tasks_dir / self.month / "task-d.txt").write_text("OLD")
         src = self.live / "task-d.txt"
         src.write_text("NEW")
-        with mock.patch("os.link", side_effect=OSError(18, "Cross-device link")):
+        with exdev_from(src):
             self.assertTrue(self._archive(src, "task-d"))
         self.assertEqual((self.tasks_dir / self.month / "task-d.txt").read_text(), "OLD")
         self.assertEqual((self.tasks_dir / self.month / "task-d.txt.1").read_text(), "NEW")
 
     def test_a_failed_cross_device_copy_leaves_no_partial_and_keeps_the_source(self) -> None:
-        """A half-written archive that reads as complete is worse than no archive."""
+        """A half-written archive that reads as complete is worse than none."""
         src = self.live / "task-e.txt"
         src.write_text("PAYLOAD")
-        with mock.patch("os.link", side_effect=OSError(18, "Cross-device link")), \
+        with exdev_from(src), \
              mock.patch("shutil.copyfileobj", side_effect=OSError(28, "No space left")):
             self._archive(src, "task-e")
         self.assertFalse((self.tasks_dir / self.month / "task-e.txt").exists(),
@@ -144,6 +158,90 @@ class TestFindTaskFile(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("claimed-core-", result.name)
 
+
+
+class CollisionRecordsStayReachable(unittest.TestCase):
+    """A collision that the production reader cannot see is still data loss:
+    the record exists and every lookup returns the superseded one."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+        root = Path(self._td.name)
+        self.tasks = root / "tasks"
+        (self.tasks / "archive").mkdir(parents=True)
+        self.results = root / "results"
+        self.results.mkdir()
+
+    def test_the_production_reader_returns_the_NEWEST_colliding_record(self) -> None:
+        import task_archive
+        import local_task_protocol
+        tid = "task-1786600000000"
+        for chan in ("OLD", "NEW"):
+            src = self.tasks / f"{tid}.txt"
+            src.write_text(f"id: {tid}\nchannel_id: {chan}\ntask: x\n")
+            task_archive.archive_file(src, "tasks", tid, tasks_dir=self.tasks / "archive",
+                                      results_dir=self.results, log=lambda *a: None)
+        got = local_task_protocol.find_archived_task(self.tasks, tid)
+        self.assertIsNotNone(got)
+        self.assertIn("channel_id: NEW", got.read_text(),
+                      "reader returned the superseded record — routing would use a stale channel")
+
+    def test_selection_is_numeric_so_txt_10_beats_txt_2(self) -> None:
+        import local_task_protocol
+        tid = "task-1786600000001"
+        d = self.tasks / "archive"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{tid}.txt").write_text(f"id: {tid}\ntask: x\n")
+        for i in range(1, 11):
+            (d / f"{tid}.txt.{i}").write_text(f"id: {tid}\nchannel_id: N{i}\ntask: x\n")
+        got = local_task_protocol.find_archived_task(self.tasks, tid)
+        self.assertTrue(got.name.endswith(".10"), f"string order picked {got.name}")
+
+    def test_archive_failed_quarantine_is_not_mistaken_for_a_collision(self) -> None:
+        import local_task_protocol
+        tid = "task-1786600000002"
+        d = self.tasks / "archive"
+        (d / f"{tid}.txt").write_text(f"id: {tid}\nchannel_id: REAL\ntask: x\n")
+        (d / f"{tid}.txt.archive-failed-1").write_text("junk")
+        got = local_task_protocol.find_archived_task(self.tasks, tid)
+        self.assertIn("channel_id: REAL", got.read_text())
+
+
+class CrashDuringCrossDeviceCopy(unittest.TestCase):
+    """A mocked exception exercises cleanup; only a real kill proves the
+    authoritative name is never published half-written."""
+
+    SCRIPT = """
+import os, shutil, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+import task_archive as TA
+src = Path(sys.argv[2]) / "live.txt"
+dest = Path(sys.argv[2]) / "dest"
+real_link = os.link
+def fake_link(a, b, **k):
+    if Path(a) == src: raise OSError(18, "EXDEV")
+    return real_link(a, b, **k)
+os.link = fake_link
+def crashing(inp, out, *a, **k):
+    out.write(b"PART"); out.flush(); os._exit(23)
+shutil.copyfileobj = crashing
+TA._move_without_clobbering(src, dest / "task-crash.txt")
+"""
+
+    def test_a_kill_mid_copy_publishes_no_authoritative_record(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "live.txt").write_text("COMPLETE\n" * 200)
+            (root / "dest").mkdir()
+            src_dir = str(Path(__file__).resolve().parent.parent / "src")
+            proc = subprocess.run([sys.executable, "-c", self.SCRIPT, src_dir, str(root)],
+                                  capture_output=True, text=True)
+            self.assertEqual(proc.returncode, 23, proc.stderr)
+            self.assertFalse((root / "dest" / "task-crash.txt").exists(),
+                             "a truncated record was published under the authoritative name")
+            self.assertTrue((root / "live.txt").exists(), "the live source must survive")
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 import os
@@ -53,6 +54,41 @@ class TestArchiveNeverOverwrites(unittest.TestCase):
         self.assertTrue(self._archive(src, "task-y"))
         self.assertEqual((self.tasks_dir / self.month / "task-y.txt").read_text(),
                          "BODY")
+
+    def test_cross_device_archive_copies_instead_of_linking(self) -> None:
+        """os.link cannot span filesystems, and the archive can be a different
+        mount. The O_EXCL copy fallback must preserve the bytes and the source."""
+        import task_archive
+        src = self.live / "task-c.txt"
+        src.write_text("PAYLOAD")
+        with mock.patch("os.link", side_effect=OSError(18, "Cross-device link")):
+            self.assertTrue(self._archive(src, "task-c"))
+        landed = self.tasks_dir / self.month / "task-c.txt"
+        self.assertEqual(landed.read_text(), "PAYLOAD")
+        self.assertFalse(src.exists(), "source must still leave the live queue")
+
+    def test_cross_device_fallback_also_refuses_to_clobber(self) -> None:
+        (self.tasks_dir / self.month).mkdir(parents=True)
+        (self.tasks_dir / self.month / "task-d.txt").write_text("OLD")
+        src = self.live / "task-d.txt"
+        src.write_text("NEW")
+        with mock.patch("os.link", side_effect=OSError(18, "Cross-device link")):
+            self.assertTrue(self._archive(src, "task-d"))
+        self.assertEqual((self.tasks_dir / self.month / "task-d.txt").read_text(), "OLD")
+        self.assertEqual((self.tasks_dir / self.month / "task-d.txt.1").read_text(), "NEW")
+
+    def test_a_failed_cross_device_copy_leaves_no_partial_and_keeps_the_source(self) -> None:
+        """A half-written archive that reads as complete is worse than no archive."""
+        src = self.live / "task-e.txt"
+        src.write_text("PAYLOAD")
+        with mock.patch("os.link", side_effect=OSError(18, "Cross-device link")), \
+             mock.patch("shutil.copyfileobj", side_effect=OSError(28, "No space left")):
+            self._archive(src, "task-e")
+        self.assertFalse((self.tasks_dir / self.month / "task-e.txt").exists(),
+                         "a partial copy must be removed, not left looking archived")
+        self.assertTrue(src.exists() or
+                        (self.live / "task-e.txt.archive-failed").exists(),
+                        "the bytes must survive somewhere in the live queue")
 
     def test_quarantine_does_not_clobber_an_earlier_quarantine(self) -> None:
         self.tasks_dir.mkdir()

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -213,7 +213,7 @@ class ArchiveLookupNeverScansTheDirectory(unittest.TestCase):
     reached 5,716 entries; a glob there measured 442x an exists()."""
 
     def test_newest_archived_probes_exact_names_and_never_globs(self) -> None:
-        import task_archive
+        import local_task_protocol
         with tempfile.TemporaryDirectory() as td:
             d = Path(td)
             (d / "task-x.txt").write_text("a")
@@ -223,16 +223,16 @@ class ArchiveLookupNeverScansTheDirectory(unittest.TestCase):
             with mock.patch.object(Path, "glob", boom), \
                  mock.patch.object(Path, "iterdir", boom), \
                  mock.patch("os.scandir", boom):
-                got = task_archive.newest_archived(d, "task-x")
+                got = local_task_protocol.newest_archived(d, "task-x")
             self.assertEqual(got.name, "task-x.txt.1")
 
     def test_an_absent_id_costs_one_probe_and_returns_none(self) -> None:
-        import task_archive
+        import local_task_protocol
         with tempfile.TemporaryDirectory() as td:
             def boom(self, *a, **kw):
                 raise AssertionError("scanned the directory for an absent id")
             with mock.patch.object(Path, "glob", boom):
-                self.assertIsNone(task_archive.newest_archived(Path(td), "task-nope"))
+                self.assertIsNone(local_task_protocol.newest_archived(Path(td), "task-nope"))
 
 
 class CrashDuringCrossDeviceCopy(unittest.TestCase):

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -5,9 +5,67 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import os
+from datetime import datetime
+
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-from task_archive import find_task_file
+from task_archive import archive_file, find_task_file
+
+
+class TestArchiveNeverOverwrites(unittest.TestCase):
+    """The success path must not destroy an existing archived record.
+
+    Before the fix these called shutil.move, which REPLACES the destination on
+    POSIX, so a repeated task id silently overwrote the earlier archive.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+        root = Path(self._td.name)
+        self.tasks_dir = root / "archive-tasks"
+        self.results_dir = root / "archive-results"
+        self.live = root / "live"
+        self.live.mkdir()
+        self.month = datetime.now().strftime("%Y-%m")
+
+    def _archive(self, src: Path, task_id: str) -> bool:
+        return archive_file(src, "tasks", task_id, tasks_dir=self.tasks_dir,
+                            results_dir=self.results_dir, log=lambda _m: None)
+
+    def test_existing_archive_record_survives_a_repeated_id(self) -> None:
+        (self.tasks_dir / self.month).mkdir(parents=True)
+        prior = self.tasks_dir / self.month / "task-x.txt"
+        prior.write_text("OLD-RECORD")
+        src = self.live / "task-x.txt"
+        src.write_text("NEW-RECORD")
+
+        self.assertTrue(self._archive(src, "task-x"))
+        self.assertEqual(prior.read_text(), "OLD-RECORD")
+        self.assertFalse(src.exists(), "source must leave the live queue")
+        self.assertEqual((self.tasks_dir / self.month / "task-x.txt.1").read_text(),
+                         "NEW-RECORD")
+
+    def test_normal_archive_still_lands_under_the_plain_name(self) -> None:
+        src = self.live / "task-y.txt"
+        src.write_text("BODY")
+        self.assertTrue(self._archive(src, "task-y"))
+        self.assertEqual((self.tasks_dir / self.month / "task-y.txt").read_text(),
+                         "BODY")
+
+    def test_quarantine_does_not_clobber_an_earlier_quarantine(self) -> None:
+        self.tasks_dir.mkdir()
+        os.chmod(self.tasks_dir, 0o500)
+        self.addCleanup(os.chmod, self.tasks_dir, 0o700)
+        (self.live / "task-z.txt.archive-failed").write_text("FIRST")
+        src = self.live / "task-z.txt"
+        src.write_text("SECOND")
+
+        self.assertTrue(self._archive(src, "task-z"))
+        self.assertEqual((self.live / "task-z.txt.archive-failed").read_text(), "FIRST")
+        self.assertEqual((self.live / "task-z.txt.archive-failed.1").read_text(), "SECOND")
+        self.assertFalse(src.exists())
 
 
 class TestFindTaskFile(unittest.TestCase):


### PR DESCRIPTION
@sonichi

## The defect

`archive_file()` caught every exception from the move and then deleted its source:

```python
except Exception as e:
    print(f"  archive_file({kind}, {task_id}) failed: {e}", flush=True)
    # Fall back to unlink so we don't leave stale files.
    try:
        src.unlink(missing_ok=True)
```

It destroys the task file whose preservation is the entire reason the function
exists (its own docstring: *"instead of deleting we should archive the tasks"*),
and it only ever runs on the path where something has already gone wrong.

`archive_path()` runs **inside the same `try`**, so a clobbered or unwritable
archive directory — a `mkdir` that raises — reaches the delete. No mocking is
needed to drive it, which is what the test does.

## The fix

On failure the source is **quarantined**, not deleted and not left live:

```python
src.rename(src.with_suffix(src.suffix + ".archive-failed"))
```

Two constraints, both satisfied in the function itself, with **no call-site
changes**:

- **never deleted** — a stale file is recoverable, a deleted one is not
- **off the `*.txt` glob** — so it cannot re-enter the `results/` or `tasks/`
  poll loops and be reprocessed forever

Only if the rename *also* fails does the file stay live; then `archive_file`
returns `False` and logs that reprocessing is expected.

**Why in the function and not at the call sites** (@qingyun-wu's P1 on the first
head, which was correct and broader than the two sites it named): this changes
the failure semantics of a function with **15 callers**. An earlier revision
gated two of them on the return value. That leaves the same defect in the other
eleven and silently hands it to every future caller — so the policy belongs in
the one place all fifteen already go through.

## Evidence

Control at `origin/main`, reverting **only** the source and keeping the test:

```
$ grep -c "src.unlink(missing_ok=True)" src/discord-bridge.py
1
$ python3 tests/discord-bridge-archive-failure-keeps-the-file.test.py
FAIL: test_a_failed_archive_never_DELETES_the_task
```

Five other cases also fail there because the `bool` return is new — naming that
so six failures are not read as six defects.

At this head:

```
$ python3 tests/discord-bridge-archive-failure-keeps-the-file.test.py
Ran 7 tests — OK
$ python3 scripts/lint-hermetic-bridge-tests.py
ok (72 bridge-importing tests scanned, 47 grandfathered, 0 mitigated;
    443 scanned for resolver stubs, 1 grandfathered)
```

Every statement of `archive_file` is executed by the suite — verified with
`sys.settrace` over its AST statement set, only the docstring line unhit —
including both the quarantine-succeeds and quarantine-also-fails paths.

## Live-path witness: OPEN

This is the Discord delivery loop, so unit tests are not sufficient proof by this
repo's own standard. A post-restart round trip has **not** been run — a bridge
restart is owner-gated and I have not requested one. Stating the gate as open
rather than citing harness output as if it closed it.

## Interaction with #2505 — please read before merging either

#2505 (*tidy: centralize task archive policy*, @marklysze) moves this function
into a shared `src/task_archive.py` used by the discord, slack and telegram
bridges, and **carries the delete forward** as stated policy:

> Archival is cleanup, not a delivery gate. A failed move therefore removes the
> stale live source, matching the adapters' established fail-open policy.

That is a faithful refactor of today's behavior — the behavior is the bug. If
#2505 merges after this, the deletion returns, promoted from one bridge to three.
Two notes for whichever lands second:

1. The shared version must not `unlink` on failure.
2. Its `if not src.exists(): return False` conflates *absent* with *failed*.

Commented there; happy to rebase onto it instead if the centralization should
land first.

Same defect shape as #2627 (a proactive DM deleted on send failure in telegram
and slack). #2505 is where it stops being three copies.
