### PR TITLE
fix(friction-detector): the stale-issue probe read gh's newest-first default window

### DIFF
--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -150,13 +150,26 @@ def check_stale_tasks():
     return issues
 
 
+# `gh issue list` defaults to 30 rows, newest-first. A staleness probe reading
+# that window sees the LEAST stale issues by construction, so it must page past
+# the default. Report is capped separately — the query must be complete even
+# when the output is not.
+_GH_QUERY_LIMIT = 500
+_GH_REPORT_CAP = 10
+
+
 def check_github_issues():
-    """Find open issues/PRs that haven't been updated in >7 days."""
+    """Find open issues that haven't been updated in >7 days.
+
+    Issues only: open PRs are `pr_flag.py`'s domain, and duplicating them here
+    would report the same backlog twice under two different names.
+    """
     issues = []
     try:
         result = subprocess.run(
-            ["gh", "issue", "list", "--state", "open", "--json", "number,title,updatedAt"],
-            capture_output=True, text=True, timeout=10
+            ["gh", "issue", "list", "--state", "open", "--limit", str(_GH_QUERY_LIMIT),
+             "--json", "number,title,updatedAt"],
+            capture_output=True, text=True, timeout=30
         )
         if result.returncode != 0:
             # A failed probe is not an absence of stale issues. Saying nothing
@@ -165,12 +178,24 @@ def check_github_issues():
             return [UNCHECKED + "GitHub issues (gh exited "
                     f"{result.returncode})"]
         items = json.loads(result.stdout)
+        if len(items) >= _GH_QUERY_LIMIT:
+            # Hit the cap we passed: the read is truncated and the oldest issues
+            # are the ones most likely missing. Say so rather than under-report.
+            return [UNCHECKED + f"GitHub issues (returned {len(items)} == the "
+                    f"{_GH_QUERY_LIMIT} cap, so the list is truncated)"]
         now = datetime.now(timezone.utc)
+        stale = []
         for item in items:
             updated = datetime.fromisoformat(item["updatedAt"].replace("Z", "+00:00"))
             age_days = (now - updated).days
             if age_days > 7:
-                issues.append(f"GitHub issue #{item['number']} stale ({age_days}d): {item['title'][:60]}")
+                stale.append((age_days, item))
+        stale.sort(key=lambda p: p[0], reverse=True)
+        for age_days, item in stale[:_GH_REPORT_CAP]:
+            issues.append(f"GitHub issue #{item['number']} stale ({age_days}d): {item['title'][:60]}")
+        if len(stale) > _GH_REPORT_CAP:
+            issues.append(f"...and {len(stale) - _GH_REPORT_CAP} more stale issue(s) "
+                          f"beyond the {_GH_REPORT_CAP} oldest shown")
     except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError) as e:
         return [UNCHECKED + f"GitHub issues ({type(e).__name__})"]
     return issues

--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -150,20 +150,15 @@ def check_stale_tasks():
     return issues
 
 
-# `gh issue list` defaults to 30 rows, newest-first. A staleness probe reading
-# that window sees the LEAST stale issues by construction, so it must page past
-# the default. Report is capped separately — the query must be complete even
-# when the output is not.
+# `gh issue list` defaults to 30 rows newest-first, so a staleness probe must
+# page past it. Query and report bounds are separate on purpose.
 _GH_QUERY_LIMIT = 500
 _GH_REPORT_CAP = 10
 
 
 def check_github_issues():
-    """Find open issues that haven't been updated in >7 days.
-
-    Issues only: open PRs are `pr_flag.py`'s domain, and duplicating them here
-    would report the same backlog twice under two different names.
-    """
+    """Find open issues not updated in >7 days. Issues only — open PRs are
+    `pr_flag.py`'s domain and would otherwise be reported twice."""
     issues = []
     try:
         result = subprocess.run(

--- a/tests/friction-github-probe-is-not-capped.test.py
+++ b/tests/friction-github-probe-is-not-capped.test.py
@@ -1,17 +1,6 @@
 #!/usr/bin/env python3
-"""A staleness probe must not read a newest-first default window.
-
-`gh issue list` returns 30 rows by default, ordered newest-first, so a probe
-looking for the OLDEST issues sees the least stale ones by construction.
-Measured on sonichi/sutando before the fix: 138 open issues, 109 stale >7d,
-and exactly 1 of them inside the default 30 — the probe reported 1 of 109.
-
-Every assertion here fails against the pre-fix source, which passed no
-`--limit` at all and sorted nothing.
-
-Run: python3 tests/friction-github-probe-is-not-capped.test.py
-Exit code: 0 on pass, 1 on fail.
-"""
+"""A staleness probe must not read a newest-first default window: `gh issue list`
+returns 30 rows newest-first, so looking for the OLDEST sees the least stale."""
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import importlib.util

--- a/tests/friction-github-probe-is-not-capped.test.py
+++ b/tests/friction-github-probe-is-not-capped.test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""A staleness probe must not read a newest-first default window.
+
+`gh issue list` returns 30 rows by default, ordered newest-first, so a probe
+looking for the OLDEST issues sees the least stale ones by construction.
+Measured on sonichi/sutando before the fix: 138 open issues, 109 stale >7d,
+and exactly 1 of them inside the default 30 — the probe reported 1 of 109.
+
+Every assertion here fails against the pre-fix source, which passed no
+`--limit` at all and sorted nothing.
+
+Run: python3 tests/friction-github-probe-is-not-capped.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import importlib.util
+import json
+import subprocess
+import types
+import unittest
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "friction-detector.py"
+_spec = importlib.util.spec_from_file_location("fd", SRC)
+fd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fd)
+
+
+def _issue(n, age_days):
+    ts = (datetime.now(timezone.utc) - timedelta(days=age_days)).isoformat().replace("+00:00", "Z")
+    return {"number": n, "title": f"issue {n} aged {age_days}d", "updatedAt": ts}
+
+
+class _FakeGh:
+    """Records argv and returns a canned issue list."""
+
+    def __init__(self, items, returncode=0):
+        self.items = items
+        self.returncode = returncode
+        self.argv = None
+
+    def __call__(self, argv, **kw):
+        self.argv = argv
+        return types.SimpleNamespace(
+            returncode=self.returncode, stdout=json.dumps(self.items), stderr="")
+
+
+class GithubProbeBounds(unittest.TestCase):
+    def setUp(self):
+        self._real = fd.subprocess.run
+
+    def tearDown(self):
+        fd.subprocess.run = self._real
+
+    def _run(self, items, returncode=0):
+        fake = _FakeGh(items, returncode)
+        fd.subprocess.run = fake
+        return fd.check_github_issues(), fake
+
+    def test_the_query_passes_an_explicit_limit(self):
+        """Pre-fix this argv had no --limit, so gh's default 30 applied."""
+        _, fake = self._run([_issue(1, 30)])
+        self.assertIn("--limit", fake.argv,
+                      "no --limit means gh's default 30-row, newest-first window")
+        i = fake.argv.index("--limit")
+        self.assertGreaterEqual(int(fake.argv[i + 1]), 100,
+                                "a limit at or below the default does not widen anything")
+
+    def test_a_truncated_read_is_reported_as_UNCHECKED_not_as_findings(self):
+        """count == the cap we passed means the oldest rows may be missing."""
+        items = [_issue(n, 30) for n in range(fd._GH_QUERY_LIMIT)]
+        out, _ = self._run(items)
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0].startswith(fd.UNCHECKED),
+                        f"a capped read must not render as a clean finding list: {out[0]!r}")
+
+    def test_it_reports_the_OLDEST_first(self):
+        """The pre-fix loop emitted gh's newest-first order verbatim."""
+        out, _ = self._run([_issue(1, 8), _issue(2, 400), _issue(3, 50)])
+        self.assertIn("#2", out[0], f"oldest (400d) must lead, got {out[0]!r}")
+        self.assertIn("#3", out[1])
+
+    def test_fresh_issues_are_not_reported(self):
+        out, _ = self._run([_issue(1, 1), _issue(2, 3)])
+        self.assertEqual(out, [])
+
+    def test_the_report_is_capped_and_says_how_many_it_dropped(self):
+        """109 findings is a nag nobody opens; silence about the rest is worse."""
+        out, _ = self._run([_issue(n, 100 + n) for n in range(40)])
+        self.assertEqual(len(out), fd._GH_REPORT_CAP + 1,
+                         "expected the cap plus one overflow line")
+        self.assertIn(f"{40 - fd._GH_REPORT_CAP} more", out[-1],
+                      f"the dropped count must be stated, got {out[-1]!r}")
+
+    def test_exactly_at_the_report_cap_adds_no_overflow_line(self):
+        out, _ = self._run([_issue(n, 100 + n) for n in range(fd._GH_REPORT_CAP)])
+        self.assertEqual(len(out), fd._GH_REPORT_CAP)
+        self.assertNotIn("more stale", out[-1])
+
+    def test_a_failed_gh_still_reports_UNCHECKED(self):
+        """Pre-existing behaviour that must survive the change."""
+        out, _ = self._run([], returncode=1)
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0].startswith(fd.UNCHECKED))
+
+    def test_it_queries_issues_not_prs(self):
+        """Open PRs are pr_flag.py's domain; querying both double-reports."""
+        _, fake = self._run([_issue(1, 30)])
+        self.assertIn("issue", fake.argv)
+        self.assertNotIn("pr", fake.argv)
+
+
+class DocstringMatchesBehaviour(unittest.TestCase):
+    def test_the_docstring_does_not_promise_PRs(self):
+        """It said 'issues/PRs' while querying only issues."""
+        doc = fd.check_github_issues.__doc__ or ""
+        self.assertNotIn("/PRs", doc,
+                         "docstring claims PRs the query never fetches")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`check_github_issues` looks for open issues not updated in >7 days. It called:

```python
["gh", "issue", "list", "--state", "open", "--json", "number,title,updatedAt"]
```

No `--limit`. `gh issue list` defaults to **30 rows, newest-first** — so a probe whose entire purpose is finding the *oldest* issues reads the window least likely to contain them.

## Evidence, measured on this repo

```
gh issue list --state open                 ->  30   (the default cap)
gh issue list --state open --limit 500     -> 138   (true count)
open issues stale >7d                      -> 106
stale issues inside the default-30 window  ->   1
```

Running both versions against live `gh`, same moment:

```
BEFORE (origin/main):   0 finding(s)
AFTER  (this branch):  11 finding(s)
   GitHub issue #766 stale (87d): Priority interviewer skill — proactive disambiguation…
   GitHub issue #830 stale (85d): docs: build a full docs site…
   GitHub issue #898 stale (84d): telegram-bridge tests: add end-to-end dispatch() coverage
   …and 96 more stale issue(s) beyond the 10 oldest shown
```

The probe reported **zero** while 106 stale issues existed. It is not that it under-counted — it returned nothing, which renders as "checked, found nothing."

## The change

- Pass an explicit `--limit 500`.
- **If the read comes back at that cap, return `UNCHECKED` rather than findings.** A truncated list must not render as a clean result — this is the same invariant the file already applies to a failed `gh` call, extended to a *successful but incomplete* one.
- Sort oldest-first (previously emitted gh's newest-first order verbatim).
- Cap the report at 10 and state how many were dropped. 106 lines is a nag nobody opens; silence about the remainder is worse than a count.
- Docstring said "issues/PRs" while querying only issues. Corrected — open PRs are `pr_flag.py`'s domain and duplicating them here would report one backlog twice under two names.

`timeout` raised 10s → 30s, since 500 rows is a larger fetch than 30.

## Tests

New: `tests/friction-github-probe-is-not-capped.test.py`, 9 cases, hermetic (fake `gh`, no network).

**Negative control — the same file run against the pre-fix source:**

```
Ran 9 tests   FAILED (failures=3, errors=3)
  FAIL  test_the_query_passes_an_explicit_limit
  FAIL  test_it_reports_the_OLDEST_first
  FAIL  test_the_docstring_does_not_promise_PRs
  ERROR test_a_truncated_read_is_reported_as_UNCHECKED_not_as_findings
  ERROR test_the_report_is_capped_and_says_how_many_it_dropped
  ERROR test_exactly_at_the_report_cap_adds_no_overflow_line
```

The 3 that pass pre-fix (`fresh issues not reported`, `failed gh → UNCHECKED`, `queries issues not PRs`) are pre-existing behaviour this change preserves deliberately.

Existing suite, all green: `friction-unchecked-probes`, `friction-detector-every-check-is-registered`, `friction-detector-pending-questions`, `pending-questions-readers-agree`.

## Scope

One concern: the capped query. Deliberately **not** in this PR, and raised separately with the owner — the detector currently has no caller at all (not in `crons.json`, no script or skill invokes it; last output `friction-2026-06-04.txt`, 69 days ago), and 52 of its 60 findings today duplicate `check-pending-questions.py`. Those are a scope question, not a correctness one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## ⚠ CORRECTION (2026-08-12 04:5xZ) — the "no caller" claim above is WRONG

A peer audit caught it. `skills/morning-briefing/SKILL.md:50` reads:

> 4. **Friction check** — Run `python3 src/friction-detector.py`. If friction items found, include as "⚠️ Friction: [count] items need attention" with the top 3.

And `morning-briefing` **is** scheduled on this host (`45 5 * * *`). So the detector has a documented, scheduled caller.

The accurate finding is narrower and more interesting: **a documented caller that does not actually invoke it** — the briefing runs daily, yet the detector has produced no output since `friction-2026-06-04.txt`. Step 4 is being skipped in practice.

How I got it wrong: my grep for callers was piped through `head -12`, and the `skills/` matches fell below the cut. I treated a truncated list as complete — the same capped-read failure this very PR fixes in `gh issue list`. Nothing about the code change is affected; only the framing in the Context section.