### PR TITLE
fix(cron-notify): a delivered room post reported as failed, so the cron re-sent it

### DIFF
--- a/skills/schedule-crons/cron-notify.py
+++ b/skills/schedule-crons/cron-notify.py
@@ -227,9 +227,13 @@ def _post_to_room(room_id, body, repo=None):
                  "User-Agent": "sutando-core/1.0"})
     try:
         r = urllib.request.urlopen(req, timeout=30)
-        return (json.loads(r.read().decode() or "{}")).get("event_id")
+        body_json = json.loads(r.read().decode() or "{}")
     except (urllib.error.URLError, urllib.error.HTTPError):
         return None
+    # A 2xx IS delivery. The live gateway answers {"ok": true} with no
+    # event_id, so keying on that field reports every success as a failure —
+    # and the caller rolls back its cooldown and re-sends on a falsy return.
+    return body_json.get("event_id") or body_json.get("ok") or True
 
 
 def _default_state_file():

--- a/skills/schedule-crons/cron-notify.py
+++ b/skills/schedule-crons/cron-notify.py
@@ -230,9 +230,8 @@ def _post_to_room(room_id, body, repo=None):
         body_json = json.loads(r.read().decode() or "{}")
     except (urllib.error.URLError, urllib.error.HTTPError):
         return None
-    # A 2xx IS delivery. The live gateway answers {"ok": true} with no
-    # event_id, so keying on that field reports every success as a failure —
-    # and the caller rolls back its cooldown and re-sends on a falsy return.
+    # A 2xx IS delivery: the gateway may answer {"ok": true} with no event_id,
+    # so keying the return on that field reports every success as a failure.
     return body_json.get("event_id") or body_json.get("ok") or True
 
 

--- a/tests/cron-notify.test.py
+++ b/tests/cron-notify.test.py
@@ -142,9 +142,8 @@ def main() -> int:
             req = uo.call_args[0][0]
             check("_post_to_room targets <base>/v1/room",
                   req.full_url == "https://x.example/relay/v1/room", req.full_url)
-        # The LIVE gateway answers {"ok": true} with no event_id. Keying the
-        # return on event_id reported every real success as a failure, and the
-        # caller rolls back its cooldown and re-sends on a falsy return.
+        # The gateway can answer {"ok": true} with no event_id; the return must
+        # still be truthy or the caller re-sends.
         resp_ok = um.MagicMock()
         resp_ok.read.return_value = json.dumps({"ok": True}).encode()
         with um.patch.object(cn, "_load_gateway", return_value=("https://x.example/relay", "sekret")), \

--- a/tests/cron-notify.test.py
+++ b/tests/cron-notify.test.py
@@ -142,6 +142,21 @@ def main() -> int:
             req = uo.call_args[0][0]
             check("_post_to_room targets <base>/v1/room",
                   req.full_url == "https://x.example/relay/v1/room", req.full_url)
+        # The LIVE gateway answers {"ok": true} with no event_id. Keying the
+        # return on event_id reported every real success as a failure, and the
+        # caller rolls back its cooldown and re-sends on a falsy return.
+        resp_ok = um.MagicMock()
+        resp_ok.read.return_value = json.dumps({"ok": True}).encode()
+        with um.patch.object(cn, "_load_gateway", return_value=("https://x.example/relay", "sekret")), \
+             um.patch("urllib.request.urlopen", return_value=resp_ok):
+            r_ok = cn._post_to_room("!r:x", "hello", str(env))
+            check("_post_to_room {\"ok\":true} → truthy (live gateway shape)", bool(r_ok), r_ok)
+        resp_bare = um.MagicMock()
+        resp_bare.read.return_value = b""
+        with um.patch.object(cn, "_load_gateway", return_value=("https://x.example/relay", "sekret")), \
+             um.patch("urllib.request.urlopen", return_value=resp_bare):
+            r_bare = cn._post_to_room("!r:x", "hello", str(env))
+            check("_post_to_room empty 2xx body → truthy (a 2xx IS delivery)", bool(r_bare), r_bare)
         import urllib.error as ue
         with um.patch.object(cn, "_load_gateway", return_value=("https://x.example/relay", "s")), \
              um.patch("urllib.request.urlopen", side_effect=ue.URLError("down")):


### PR DESCRIPTION
## The defect

`_post_to_room` ended with:

```python
return (json.loads(r.read().decode() or "{}")).get("event_id")
```

The live gateway answers **`{"ok": true}`** — no `event_id`. So every successful post returns `None`.

That would be cosmetic if nothing read the return. `cron-notify.py:431` does:

```python
eid = _post_to_room(args.room, body)
if not eid:
    # Delivery failed, so the reservation is a lie — release it, or a
    # transient send error would silently mute this cron for the whole
    # cooldown window.
```

The rollback logic is correct; it is being fed a wrong signal. **A delivered post releases its own cooldown reservation, so the next fire re-sends the same body.** Every `--room` cron schedules its own duplicate, repeatedly.

## Observed

Posting a news sublist to `!PrxhizfLysTYrYDcnw:ag2.space`:

```
_post_to_room(...)                     -> None        ("failed")
same request, same moment, by hand     -> HTTP 200 {"ok": true}
```

The room has that sublist twice as a direct result. I could not confirm by reading it back — the gateway serves no history op (`read`/`messages`/`history` all HTTP 400), which is why the false failure went unnoticed: the one surface that would show the duplicate is unreadable.

## The change

Return `event_id` when present, else truthy. A 2xx is delivery; the response body's shape is the gateway's business, not the caller's.

## Why the test never caught it

`tests/cron-notify.test.py:137` builds its fixture as:

```python
resp.read.return_value = json.dumps({"event_id": "$evt"}).encode()
```

It asserts the function returns `event_id` when the server sends `event_id`. The server does not send `event_id`. The fixture encodes a response shape that does not exist in production, so the test passed for as long as the bug did.

Two cases added for the shapes the gateway actually produces:

```
PRE-FIX {'ok':true}   -> None   FAILS (reports success as failure)
PRE-FIX empty body    -> None   FAILS
```

Full `tests/cron-notify.test.py` green after the change, including the pre-existing `event_id` case — the fix is additive, not a replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
