### PR TITLE
docs(review): end a review with an explicit recommendation

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -94,6 +94,13 @@ and loads whichever repo it reviews.
    "changes requested: …" / "LGTM, non-blocking". And it is only honest if you actually
    ran these criteria on *this* PR — a readiness claim with no evidence attached
    (no test run, no failure-mode named, no blast-radius call) is an over-claim.
+   **Findings are not a verdict.** A review that ends on analysis leaves the author unable
+   to tell "these are blockers" from "these are notes and I would merge it", so say which,
+   and for anything short of ready, name the one thing that would change it.
+   The verdict is a **recommendation, never a gate**: it does not substitute for the merge
+   conditions in `CONTRIBUTING.md` (mergeable head, green required CI + CLA, two recorded
+   approvals). *Grounded by:* a #2824 review that listed one clarity question and two minor
+   notes and never said it was ready; the owner had to ask "do you recommend approval?".
 
 9. **A negative result is not evidence until the instrument is shown able to produce a
    positive.** Much of a PR's evidence is a *zero*: "no other call sites", "no conflicts",


### PR DESCRIPTION
## The gap

`REVIEW.md` tells reviewers what to look for and says nothing about how to close. So a review can be thorough, correct, and still leave the author unable to tell whether the findings are blockers or notes.

**Grounded, not hypothetical.** On #2824 I posted a review with one clarity question and two minor notes, ended on scope, and never wrote the sentence "this is ready". The owner had to ask:

> do you recommend approval? does your instruction contain "recommend for approval" when they are ready?

He was right that it doesn't. `grep -i recommend REVIEW.md CONTRIBUTING.md` returns **one** hit, and it points the other way — `CONTRIBUTING.md:236`, *"a bot recommendation … is not a substitute for any gate"*. That correctly says a recommendation is not authority; nothing anywhere says to give one.

## The change

One lesson appended to the `## Lessons` list, in the same shape as its neighbours (statement, why, `*Grounded by:*`). Asks for *approve* / *not yet* / *needs the owner*, plus the one thing that would change a non-approve.

**Deliberately worded so it cannot be read as widening the merge gate.** The lesson repeats CONTRIBUTING's rule in its own body — "a recommendation, not a gate" — and names the four merge conditions inline. A reader who takes only this paragraph away still cannot conclude that a recommendation merges anything.

## Scope

`REVIEW.md` only, per the repo's own rule that adding or editing a lesson is a PR to `REVIEW.md` alone. No code, no scripts, no `checks:` block change — `scripts/review-checks.sh --diff` passes on this diff (`PASS (hardcoded-paths clean)`).

`docs/src-map.md` is unaffected (no `src/` module added or changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)