### PR TITLE
fix(health-check): an unrunnable sutando-app probe emitted nothing, not a row

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -7532,6 +7532,13 @@ def run_all_checks() -> list[dict]:
             # actually couldn't determine state. Surface as a transient warn
             # with the cause so it's debuggable, not a routine "app is down."
             checks.append({"name": "sutando-app", "status": "warn", "detail": f"detection failed (pgrep: {pgrep_err or 'unknown error'}) — actual app state unknown"})
+    else:
+        # Neither path exists, so the probe never ran. Emitting nothing here
+        # made "not checked" indistinguishable from "checked and fine".
+        checks.append({"name": "sutando-app", "status": "warn", "detail": (
+            "not checked — no binary at either path, so app state is UNKNOWN, not ok. "
+            f"Looked for: {dev_bin} (dev build) and {app_bin} (installed bundle). "
+            "Build the dev binary or install the bundle to make this probe meaningful.")})
 
     # Battery and memory health checks
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -7117,8 +7117,7 @@ MENUBAR_RECENT_S = 7 * 86400
 
 
 def menubar_app_state(dev_bin, app_bin, plist, chips, is_macos: bool,
-                      now: float | None = None,
-                      recent_s: int = MENUBAR_RECENT_S) -> str:
+                      now=None, recent_s: int = MENUBAR_RECENT_S) -> str:
     """installed | expected-missing | not-applicable for the optional menu-bar app.
 
     Only a host that asked for the app can be MISSING it — a headless install

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -7113,30 +7113,16 @@ def check_core_model_pin() -> dict:
 
 MENUBAR_LABEL = "com.sutando.menubar"
 MENUBAR_PLIST = Path.home() / "Library" / "LaunchAgents" / f"{MENUBAR_LABEL}.plist"
-MENUBAR_RECENT_S = 7 * 86400
 
 
-def menubar_app_state(dev_bin, app_bin, plist, chips, is_macos: bool,
-                      now=None, recent_s: int = MENUBAR_RECENT_S) -> str:
+def menubar_app_state(dev_bin, app_bin, plist, is_macos: bool) -> str:
     """installed | expected-missing | not-applicable for the optional menu-bar app.
-
-    Only a host that asked for the app can be MISSING it — a headless install
-    has neither signal, so absence there is a configuration, not a fault.
-    """
+    The launchd plist is the only durable signal a host ASKED for the app."""
     if dev_bin.exists() or app_bin.exists():
         return "installed"
     if not is_macos:
         return "not-applicable"
-    if plist.exists():
-        return "expected-missing"
-    # The app is the sole writer of contextual-chips.json, so a RECENT one means
-    # it ran here; ageing it out stops a deliberate uninstall nagging forever.
-    try:
-        if (now or time.time()) - chips.stat().st_mtime < recent_s:
-            return "expected-missing"
-    except OSError:
-        pass
-    return "not-applicable"
+    return "expected-missing" if plist.exists() else "not-applicable"
 
 
 def run_all_checks() -> list[dict]:
@@ -7505,9 +7491,7 @@ def run_all_checks() -> list[dict]:
     dev_bin = REPO_DIR / "src" / "Sutando" / "Sutando"
     app_bin = Path("/Applications/Sutando.app/Contents/MacOS/Sutando")
     _menubar = menubar_app_state(
-        dev_bin, app_bin, MENUBAR_PLIST,
-        status_read_path("contextual-chips.json", WORKSPACE_DIR),
-        sys.platform == "darwin")
+        dev_bin, app_bin, MENUBAR_PLIST, sys.platform == "darwin")
     if _menubar == "installed":
         # Distinguish pgrep failures (exit code != 0 and != 1) from a real
         # no-match (exit code 1). Pre-fix the bare try/except swallowed

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -7111,6 +7111,35 @@ def check_core_model_pin() -> dict:
     return _interpret_core_model_pin(pinned, socket, _core_argv_pins(socket, sessions))
 
 
+MENUBAR_LABEL = "com.sutando.menubar"
+MENUBAR_PLIST = Path.home() / "Library" / "LaunchAgents" / f"{MENUBAR_LABEL}.plist"
+MENUBAR_RECENT_S = 7 * 86400
+
+
+def menubar_app_state(dev_bin, app_bin, plist, chips, is_macos: bool,
+                      now: float | None = None,
+                      recent_s: int = MENUBAR_RECENT_S) -> str:
+    """installed | expected-missing | not-applicable for the optional menu-bar app.
+
+    Only a host that asked for the app can be MISSING it — a headless install
+    has neither signal, so absence there is a configuration, not a fault.
+    """
+    if dev_bin.exists() or app_bin.exists():
+        return "installed"
+    if not is_macos:
+        return "not-applicable"
+    if plist.exists():
+        return "expected-missing"
+    # The app is the sole writer of contextual-chips.json, so a RECENT one means
+    # it ran here; ageing it out stops a deliberate uninstall nagging forever.
+    try:
+        if (now or time.time()) - chips.stat().st_mtime < recent_s:
+            return "expected-missing"
+    except OSError:
+        pass
+    return "not-applicable"
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -7476,7 +7505,11 @@ def run_all_checks() -> list[dict]:
     # the menu bar check to run so dashboard reports accurate status.
     dev_bin = REPO_DIR / "src" / "Sutando" / "Sutando"
     app_bin = Path("/Applications/Sutando.app/Contents/MacOS/Sutando")
-    if dev_bin.exists() or app_bin.exists():
+    _menubar = menubar_app_state(
+        dev_bin, app_bin, MENUBAR_PLIST,
+        status_read_path("contextual-chips.json", WORKSPACE_DIR),
+        sys.platform == "darwin")
+    if _menubar == "installed":
         # Distinguish pgrep failures (exit code != 0 and != 1) from a real
         # no-match (exit code 1). Pre-fix the bare try/except swallowed
         # subprocess errors AND empty results into a single "no pids" path,
@@ -7532,13 +7565,12 @@ def run_all_checks() -> list[dict]:
             # actually couldn't determine state. Surface as a transient warn
             # with the cause so it's debuggable, not a routine "app is down."
             checks.append({"name": "sutando-app", "status": "warn", "detail": f"detection failed (pgrep: {pgrep_err or 'unknown error'}) — actual app state unknown"})
-    else:
-        # Neither path exists, so the probe never ran. Emitting nothing here
-        # made "not checked" indistinguishable from "checked and fine".
+    elif _menubar == "expected-missing":
+        # Only a host that ASKED for the app can be missing it; a headless
+        # install has no plist and gets no row, like check_gateway_bridge().
         checks.append({"name": "sutando-app", "status": "warn", "detail": (
-            "not checked — no binary at either path, so app state is UNKNOWN, not ok. "
-            f"Looked for: {dev_bin} (dev build) and {app_bin} (installed bundle). "
-            "Build the dev binary or install the bundle to make this probe meaningful.")})
+            f"launchd job {MENUBAR_LABEL} is installed but no binary exists at "
+            f"{dev_bin} or {app_bin} — app state UNKNOWN, not ok")})
 
     # Battery and memory health checks
 

--- a/tests/health-check-sutando-app-absent.test.py
+++ b/tests/health-check-sutando-app-absent.test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""A probe that emits nothing when it cannot run is indistinguishable from a pass.
+
+`run_all_checks()` guards the sutando-app probe on `dev_bin.exists() or
+app_bin.exists()`. When neither exists the block was skipped with no `else`, so
+no `sutando-app` row reached the report — and the summary line reads
+"No failures", which is what a healthy probe also produces.
+
+Structural rather than behavioural on purpose: exercising the branch means
+calling `run_all_checks()`, which runs ~100 probes with subprocesses and
+network. So this parses the guard's `else` out of the source and asserts what it
+emits. Validated against the parent — see the negative-control note in the PR.
+
+Run: python3 tests/health-check-sutando-app-absent.test.py
+"""
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "health-check.py"
+
+
+def _guard_node() -> ast.If:
+    """The `if dev_bin.exists() or app_bin.exists():` statement."""
+    tree = ast.parse(SRC.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        names = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)}
+        if {"dev_bin", "app_bin"} <= names:
+            return node
+    raise AssertionError("guard `dev_bin.exists() or app_bin.exists()` not found")
+
+
+def _appended_check_names(body: list[ast.stmt]) -> list[str]:
+    """Literal `name` values of every `checks.append({...})` dict in `body`."""
+    out: list[str] = []
+    for node in ast.walk(ast.Module(body=body, type_ignores=[])):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "append":
+            continue
+        for arg in node.args:
+            if not isinstance(arg, ast.Dict):
+                continue
+            for k, v in zip(arg.keys, arg.values):
+                if isinstance(k, ast.Constant) and k.value == "name" and isinstance(v, ast.Constant):
+                    out.append(v.value)
+    return out
+
+
+def _statuses(body: list[ast.stmt], for_name: str) -> list[str]:
+    out: list[str] = []
+    for node in ast.walk(ast.Module(body=body, type_ignores=[])):
+        if not isinstance(node, ast.Dict):
+            continue
+        pairs = {k.value: v for k, v in zip(node.keys, node.values)
+                 if isinstance(k, ast.Constant)}
+        nm, st = pairs.get("name"), pairs.get("status")
+        if isinstance(nm, ast.Constant) and nm.value == for_name and isinstance(st, ast.Constant):
+            out.append(st.value)
+    return out
+
+
+class SutandoAppAbsentTest(unittest.TestCase):
+    def test_the_guard_has_an_else_branch(self):
+        # Without it the probe is simply absent from the report, and absence
+        # is the one outcome a "No failures" summary cannot distinguish.
+        self.assertTrue(_guard_node().orelse,
+                        "no else on the sutando-app guard: when neither binary "
+                        "exists the report omits the row entirely")
+
+    def test_the_else_emits_a_sutando_app_row(self):
+        names = _appended_check_names(_guard_node().orelse)
+        self.assertIn("sutando-app", names,
+                      f"else branch appends {names or 'nothing'} — the row must exist "
+                      "so 'not checked' is visible")
+
+    def test_that_row_is_NOT_ok(self):
+        # An 'ok' here would be worse than silence: it asserts health for a
+        # thing that was never looked at.
+        sts = _statuses(_guard_node().orelse, "sutando-app")
+        self.assertTrue(sts, "no status literal for the sutando-app row")
+        for s in sts:
+            self.assertNotEqual(s, "ok", "unchecked state must not report ok")
+
+    def test_the_detail_names_both_paths_it_looked_for(self):
+        # A warn that doesn't say where it looked sends the reader to grep.
+        body = ast.get_source_segment(SRC.read_text(encoding="utf-8"),
+                                      _guard_node()) or ""
+        _, _, tail = body.partition("\n    else:")
+        self.assertIn("dev_bin", tail, "detail should name the dev-build path")
+        self.assertIn("app_bin", tail, "detail should name the installed-bundle path")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-sutando-app-absent.test.py
+++ b/tests/health-check-sutando-app-absent.test.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-"""A headless install must stay healthy; a host that asked for the app must not
-go quiet when the binary is gone.
-
-Run: python3 tests/health-check-sutando-app-absent.test.py
-"""
+"""A headless install must stay healthy; a host that asked for the app via
+launchd must not go quiet when the binary is gone."""
 from __future__ import annotations
 
 import ast
+import inspect
 import importlib.util
 import tempfile
 import unittest
@@ -50,13 +48,13 @@ class MenubarAppStateTest(unittest.TestCase):
         # Linux/cloud core: no binaries, no plist, not macOS. The OSS core is
         # deliberately headless, so this is a supported install, not a fault.
         self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=False),
+            hc.menubar_app_state(self.dev, self.app, self.plist, is_macos=False),
             "not-applicable")
 
     def test_macos_without_the_optional_app_is_not_unhealthy(self):
         # An operator who simply never installed the menu-bar app.
         self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=True),
+            hc.menubar_app_state(self.dev, self.app, self.plist, is_macos=True),
             "not-applicable")
 
     # --- but a configured host must stay visible --------------------------
@@ -66,13 +64,13 @@ class MenubarAppStateTest(unittest.TestCase):
         # bug this file exists for is that it used to emit no row at all.
         self._touch(self.plist)
         self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=True),
+            hc.menubar_app_state(self.dev, self.app, self.plist, is_macos=True),
             "expected-missing")
 
     def test_a_plist_on_a_non_macos_host_is_still_not_applicable(self):
         self._touch(self.plist)
         self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=False),
+            hc.menubar_app_state(self.dev, self.app, self.plist, is_macos=False),
             "not-applicable")
 
     # --- present in either location -> the existing probe runs -------------
@@ -80,51 +78,39 @@ class MenubarAppStateTest(unittest.TestCase):
     def test_dev_build_present_is_installed(self):
         self._touch(self.dev)
         self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=True),
+            hc.menubar_app_state(self.dev, self.app, self.plist, is_macos=True),
             "installed")
 
     def test_installed_bundle_present_is_installed(self):
         self._touch(self.app)
         self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=False),
+            hc.menubar_app_state(self.dev, self.app, self.plist, is_macos=False),
             "installed")
 
     def test_installed_wins_over_a_stale_plist(self):
         self._touch(self.plist)
         self._touch(self.dev)
         self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=True),
+            hc.menubar_app_state(self.dev, self.app, self.plist, is_macos=True),
             "installed")
 
 
-    # --- the OTHER install path: app run without launchd ------------------
+    # --- the control: a FRESHLY INITIALIZED workspace ---------------------
 
-    def test_a_RECENT_chips_file_means_the_app_ran_here(self):
-        # This host runs the app with no launchd plist, so plist-only would
-        # leave exactly this configuration silent.
+    def test_an_initialized_workspace_with_seeded_chips_stays_silent(self):
+        # src/init.sh seeds state/contextual-chips.json with a CURRENT
+        # timestamp, so chips recency cannot mean "the app ran here".
         self._touch(self.chips)
         self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips,
-                                 is_macos=True),
-            "expected-missing")
-
-    def test_a_STALE_chips_file_stops_nagging(self):
-        # Deliberate uninstall: the marker ages out instead of warning forever.
-        self._touch(self.chips)
-        import os
-        old = self.chips.stat().st_mtime - (30 * 86400)
-        os.utime(self.chips, (old, old))
-        self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips,
-                                 is_macos=True),
+            hc.menubar_app_state(self.dev, self.app, self.plist, is_macos=True),
             "not-applicable")
 
-    def test_chips_on_a_non_macos_host_is_still_not_applicable(self):
-        self._touch(self.chips)
-        self.assertEqual(
-            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips,
-                                 is_macos=False),
-            "not-applicable")
+    def test_the_probe_never_consults_contextual_chips(self):
+        # Guards the reintroduction, not just the current return value: any
+        # chips-derived signal warns on every newly initialized macOS install.
+        body = inspect.getsource(hc.menubar_app_state)
+        self.assertNotIn("chips", body)
+        self.assertNotIn("contextual", body)
 
 
 class CallSiteTest(unittest.TestCase):

--- a/tests/health-check-sutando-app-absent.test.py
+++ b/tests/health-check-sutando-app-absent.test.py
@@ -9,6 +9,7 @@ import importlib.util
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 SRC = Path(__file__).resolve().parent.parent / "src" / "health-check.py"
 
@@ -141,6 +142,31 @@ class CallSiteTest(unittest.TestCase):
         seg = self.src.split('elif _menubar == "expected-missing":')[1][:600]
         self.assertIn('"sutando-app"', seg)
         self.assertIn('"warn"', seg)
+
+
+class RunAllChecksActuallyEmitsTheAbsentRow(unittest.TestCase):
+    """The AST guard above proves run_all_checks BRANCHES on _menubar; it cannot
+    prove the branch emits anything. This drives run_all_checks for real."""
+
+    def _rows(self, state):
+        with patch.object(hc, "menubar_app_state", return_value=state):
+            checks = hc.run_all_checks()
+        return [c for c in checks if isinstance(c, dict) and c.get("name") == "sutando-app"]
+
+    def test_expected_missing_emits_a_warn_row_naming_both_paths(self):
+        rows = self._rows("expected-missing")
+        self.assertEqual(len(rows), 1, "a host that ASKED for the app must get exactly one row")
+        self.assertEqual(rows[0]["status"], "warn")
+        detail = rows[0]["detail"]
+        self.assertIn("no binary exists", detail)
+        self.assertIn(hc.MENUBAR_LABEL, detail, "the row must name the launchd job that asked")
+        self.assertIn("UNKNOWN", detail, "silence and 'ok' are the two things this must not say")
+
+    def test_CONTROL_not_applicable_emits_NO_row(self):
+        """Without this the assertion above passes for a probe that emits a row
+        unconditionally — the headless case is the whole point of the PR."""
+        self.assertEqual(self._rows("not-applicable"), [],
+                         "a headless host must get no sutando-app row at all")
 
 
 if __name__ == "__main__":

--- a/tests/health-check-sutando-app-absent.test.py
+++ b/tests/health-check-sutando-app-absent.test.py
@@ -1,98 +1,160 @@
 #!/usr/bin/env python3
-"""A probe that emits nothing when it cannot run is indistinguishable from a pass.
-
-`run_all_checks()` guards the sutando-app probe on `dev_bin.exists() or
-app_bin.exists()`. When neither exists the block was skipped with no `else`, so
-no `sutando-app` row reached the report — and the summary line reads
-"No failures", which is what a healthy probe also produces.
-
-Structural rather than behavioural on purpose: exercising the branch means
-calling `run_all_checks()`, which runs ~100 probes with subprocesses and
-network. So this parses the guard's `else` out of the source and asserts what it
-emits. Validated against the parent — see the negative-control note in the PR.
+"""A headless install must stay healthy; a host that asked for the app must not
+go quiet when the binary is gone.
 
 Run: python3 tests/health-check-sutando-app-absent.test.py
 """
 from __future__ import annotations
 
 import ast
+import importlib.util
+import tempfile
 import unittest
 from pathlib import Path
 
 SRC = Path(__file__).resolve().parent.parent / "src" / "health-check.py"
 
 
-def _guard_node() -> ast.If:
-    """The `if dev_bin.exists() or app_bin.exists():` statement."""
-    tree = ast.parse(SRC.read_text(encoding="utf-8"))
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.If):
-            continue
-        names = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)}
-        if {"dev_bin", "app_bin"} <= names:
-            return node
-    raise AssertionError("guard `dev_bin.exists() or app_bin.exists()` not found")
+def _load():
+    spec = importlib.util.spec_from_file_location("hc", SRC)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
 
 
-def _appended_check_names(body: list[ast.stmt]) -> list[str]:
-    """Literal `name` values of every `checks.append({...})` dict in `body`."""
-    out: list[str] = []
-    for node in ast.walk(ast.Module(body=body, type_ignores=[])):
-        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
-            continue
-        if node.func.attr != "append":
-            continue
-        for arg in node.args:
-            if not isinstance(arg, ast.Dict):
-                continue
-            for k, v in zip(arg.keys, arg.values):
-                if isinstance(k, ast.Constant) and k.value == "name" and isinstance(v, ast.Constant):
-                    out.append(v.value)
-    return out
+hc = _load()
 
 
-def _statuses(body: list[ast.stmt], for_name: str) -> list[str]:
-    out: list[str] = []
-    for node in ast.walk(ast.Module(body=body, type_ignores=[])):
-        if not isinstance(node, ast.Dict):
-            continue
-        pairs = {k.value: v for k, v in zip(node.keys, node.values)
-                 if isinstance(k, ast.Constant)}
-        nm, st = pairs.get("name"), pairs.get("status")
-        if isinstance(nm, ast.Constant) and nm.value == for_name and isinstance(st, ast.Constant):
-            out.append(st.value)
-    return out
+class MenubarAppStateTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.dev = root / "dev" / "Sutando"
+        self.app = root / "app" / "Sutando"
+        self.plist = root / "com.sutando.menubar.plist"
+        self.chips = root / "contextual-chips.json"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _touch(self, p: Path):
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x")
+
+    # --- the control the review asked for --------------------------------
+
+    def test_a_HEADLESS_host_is_not_unhealthy(self):
+        # Linux/cloud core: no binaries, no plist, not macOS. The OSS core is
+        # deliberately headless, so this is a supported install, not a fault.
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=False),
+            "not-applicable")
+
+    def test_macos_without_the_optional_app_is_not_unhealthy(self):
+        # An operator who simply never installed the menu-bar app.
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=True),
+            "not-applicable")
+
+    # --- but a configured host must stay visible --------------------------
+
+    def test_a_host_that_ASKED_for_the_app_and_lacks_it_is_flagged(self):
+        # launchd job installed, binary gone: that is a broken install, and the
+        # bug this file exists for is that it used to emit no row at all.
+        self._touch(self.plist)
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=True),
+            "expected-missing")
+
+    def test_a_plist_on_a_non_macos_host_is_still_not_applicable(self):
+        self._touch(self.plist)
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=False),
+            "not-applicable")
+
+    # --- present in either location -> the existing probe runs -------------
+
+    def test_dev_build_present_is_installed(self):
+        self._touch(self.dev)
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=True),
+            "installed")
+
+    def test_installed_bundle_present_is_installed(self):
+        self._touch(self.app)
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=False),
+            "installed")
+
+    def test_installed_wins_over_a_stale_plist(self):
+        self._touch(self.plist)
+        self._touch(self.dev)
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips, is_macos=True),
+            "installed")
 
 
-class SutandoAppAbsentTest(unittest.TestCase):
-    def test_the_guard_has_an_else_branch(self):
-        # Without it the probe is simply absent from the report, and absence
-        # is the one outcome a "No failures" summary cannot distinguish.
-        self.assertTrue(_guard_node().orelse,
-                        "no else on the sutando-app guard: when neither binary "
-                        "exists the report omits the row entirely")
+    # --- the OTHER install path: app run without launchd ------------------
 
-    def test_the_else_emits_a_sutando_app_row(self):
-        names = _appended_check_names(_guard_node().orelse)
-        self.assertIn("sutando-app", names,
-                      f"else branch appends {names or 'nothing'} — the row must exist "
-                      "so 'not checked' is visible")
+    def test_a_RECENT_chips_file_means_the_app_ran_here(self):
+        # This host runs the app with no launchd plist, so plist-only would
+        # leave exactly this configuration silent.
+        self._touch(self.chips)
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips,
+                                 is_macos=True),
+            "expected-missing")
 
-    def test_that_row_is_NOT_ok(self):
-        # An 'ok' here would be worse than silence: it asserts health for a
-        # thing that was never looked at.
-        sts = _statuses(_guard_node().orelse, "sutando-app")
-        self.assertTrue(sts, "no status literal for the sutando-app row")
-        for s in sts:
-            self.assertNotEqual(s, "ok", "unchecked state must not report ok")
+    def test_a_STALE_chips_file_stops_nagging(self):
+        # Deliberate uninstall: the marker ages out instead of warning forever.
+        self._touch(self.chips)
+        import os
+        old = self.chips.stat().st_mtime - (30 * 86400)
+        os.utime(self.chips, (old, old))
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips,
+                                 is_macos=True),
+            "not-applicable")
 
-    def test_the_detail_names_both_paths_it_looked_for(self):
-        # A warn that doesn't say where it looked sends the reader to grep.
-        body = ast.get_source_segment(SRC.read_text(encoding="utf-8"),
-                                      _guard_node()) or ""
-        _, _, tail = body.partition("\n    else:")
-        self.assertIn("dev_bin", tail, "detail should name the dev-build path")
-        self.assertIn("app_bin", tail, "detail should name the installed-bundle path")
+    def test_chips_on_a_non_macos_host_is_still_not_applicable(self):
+        self._touch(self.chips)
+        self.assertEqual(
+            hc.menubar_app_state(self.dev, self.app, self.plist, self.chips,
+                                 is_macos=False),
+            "not-applicable")
+
+
+class CallSiteTest(unittest.TestCase):
+    """The pure function is useless if run_all_checks stops consulting it."""
+
+    src = SRC.read_text(encoding="utf-8")
+
+    def _guard(self) -> ast.If:
+        for node in ast.walk(ast.parse(self.src)):
+            if isinstance(node, ast.If):
+                names = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)}
+                if "_menubar" in names:
+                    return node
+        raise AssertionError("run_all_checks no longer branches on _menubar")
+
+    def test_the_call_site_branches_on_the_state(self):
+        self.assertTrue(self._guard().orelse, "no expected-missing branch")
+
+    def test_not_applicable_emits_NO_row(self):
+        # The whole point of the fix: silence is correct here and only here.
+        tail = self.src.split("_menubar ==")[-1]
+        block = tail.split("# Battery and memory health checks")[0]
+        self.assertNotIn("not-applicable", block,
+                         "not-applicable must fall through without appending a check")
+
+    def test_expected_missing_emits_a_non_ok_row(self):
+        self.assertIn('"expected-missing"', self.src)
+        seg = self.src.split('elif _menubar == "expected-missing":')[1][:600]
+        self.assertIn('"sutando-app"', seg)
+        self.assertIn('"warn"', seg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

`run_all_checks()` guards the menu-bar probe on `dev_bin.exists() or app_bin.exists()`. When **neither** path exists the block is skipped and **no `sutando-app` row is appended at all** — there is no `else`. The report's summary line then reads `No failures — N warning(s)`, which is exactly what a healthy probe produces. A check that was never run and a check that passed are indistinguishable to anyone reading the output.

This is narrower than it first looks, and worth stating precisely because I got it wrong myself before reading the code: the probe does **not** assume `/Applications`. It is an `or` across both paths, and on any host with a dev build it runs and discriminates correctly. The defect is only in the neither-exists case, and the symptom is *absence*, not a false pass.

## What changed

- One `else` on the existing guard, emitting a `sutando-app` row with `status: warn` naming **both** paths it looked for and stating the state is unknown rather than ok.
- `tests/health-check-sutando-app-absent.test.py` — 4 assertions: the `else` exists, it appends a `sutando-app` row, that row's status is not `"ok"`, and the detail names both paths.

A host that genuinely has no menu-bar app now carries a standing warn. That is the intended trade: the previous behaviour was silence that read as coverage.

## Before / after evidence

Same test file against both trees. Parent `8956660b`:

```text
AssertionError: [] is not true : no else on the sutando-app guard: when neither
binary exists the report omits the row entirely
Ran 4 tests in 1.003s
FAILED (failures=4)
```

Head `033a7b56`:

```text
test_the_detail_names_both_paths_it_looked_for ... ok
test_the_else_emits_a_sutando_app_row ... ok
test_the_guard_has_an_else_branch ... ok
test_that_row_is_NOT_ok ... ok
Ran 4 tests in 1.010s
OK
```

All four fail at the parent and pass at head, so this is not a test that can only ever print OK. Restoring the fixed file after the control returns `OK` again.

Also green: `py_compile src/health-check.py`, and the six existing `tests/health-check-*` suites run unchanged.

## Why the test is structural

It parses the guard out of the AST rather than exercising the branch. Reaching that branch behaviourally means calling `run_all_checks()`, which runs ~100 probes with subprocesses and network — too heavy and too flaky for the one line under test. The negative control above is what keeps a structural test honest.

## Scope

`health-check.py`'s sutando-app probe only. No change to the probe's logic when a binary *is* present, no change to any other check, no change to how statuses are summarised.

@sonichi flagging you — this came out of a #bot2bot thread with @Sutando-Mini and echo about which Sutando.app artifact is canonical. Separate finding from that thread, **not** addressed here: nothing in the repo actually *builds* `src/Sutando/Sutando.app` — `install-sutando-app-launchd.sh:56` expects `Sutando.app/Contents/MacOS/Sutando`, its own error hint at `:79` suggests `swiftc -o` into a directory nothing creates, and no `Info.plist` is generated anywhere. That one needs your decision on the canonical artifact before anyone writes it.
