### PR TITLE
fix(test): isolate CLAUDE_CONFIG_DIR in the heartbeat-offload test — main is red

### DIFF
--- a/tests/discord-bridge-heartbeat-offload.test.py
+++ b/tests/discord-bridge-heartbeat-offload.test.py
@@ -18,8 +18,10 @@ Run: python3 tests/discord-bridge-heartbeat-offload.test.py  (exit 0/1)
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -129,6 +131,13 @@ check(
     "gateway session #" in SRC,
 )
 
+# Module-level, before ANY bridge import: the bridge resolves channel config at
+# import and falls back to the operator's real ~/.claude one when it is absent.
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="sutando-hb-test-")
+_ccd = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord"
+_ccd.mkdir(parents=True, exist_ok=True)
+(_ccd / "access.json").write_text('{"allowFrom": []}')
+
 # ── 5. Execution: on_ready runs its presence block (counter + try/except) ──────
 # The structural checks above read source text; this one actually executes
 # on_ready so the counter bump + the change_presence try/except are covered.
@@ -139,11 +148,8 @@ except ImportError:
     print("  skip on_ready exec-coverage — discord.py not importable")
 else:
     import importlib.util
-    import os
-    import tempfile
     from unittest.mock import patch, AsyncMock, MagicMock
 
-    os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="sutando-hb-test-")
     os.environ.setdefault("DISCORD_BOT_TOKEN", "faketoken-for-tests")
     _spec = importlib.util.spec_from_file_location("discordbridge_hb", REPO / "src" / "discord-bridge.py")
     _mod = importlib.util.module_from_spec(_spec)


### PR DESCRIPTION
**main is red right now and this is my fault.** Fixing it takes priority over explaining it, so the fix is above and the account is below.

## What broke

`origin/main@90c168b7` (#2159) has two failing checks. The commit before it, `7a505429` (#2342), was clean — so #2159 turned main red.

```
refuse bridge tests that read host config   FAIL
tsc + tests (clean install)                 FAIL
   python: failed tests/lint-hermetic-bridge-tests.test.py
                  tests/lint-hermetic-discovery-floor.test.py
```

Both are one root cause. `tests/discord-bridge-heartbeat-offload.test.py` sets a temp `CLAUDE_CONFIG_DIR` but never seeds `channels/discord/access.json`, so `channel_access_path()` falls back to the operator's real `~/.claude` one during `exec_module`. That makes it a new violator — which fails the gate directly and breaks the linter's own census tests.

## How I let it merge

I had already found this and fixed it on the PR branch (`7d045c85`). It never landed: GitHub's PR head stayed stale at `a02f173b` while the fork ref had moved, and **auto-merge, which I had armed, fired on the stale head.** The hermetic gate is not a required context — only `license/cla` and `refuse new inline CLAUDE_CONFIG_DIR fallback` are — so nothing stopped for a red non-required check.

The mistake was arming auto-merge on a PR I knew had a failing check, trusting that "not required" meant "not important". A non-required red still reds main.

## The fix

Two parts, and the second is the one that isn't obvious:

1. Seed `channels/discord/access.json` before `exec_module`. A temp `CLAUDE_CONFIG_DIR` alone is **not** isolation — the fallback triggers when the canonical path is *missing*.
2. **Hoist the assignment to module level.** `_isolation_line` scans `tree.body` only, deliberately: *"a body nested in a function, branch or with-block may never run, or may run after the import."* My first attempts set it correctly inside the existing `else:` and the gate kept failing.

## Verification

```
lint-hermetic-bridge-tests.py                  ok (75 bridge-importing tests scanned)
tests/lint-hermetic-bridge-tests.test.py       PASS
tests/lint-hermetic-discovery-floor.test.py    PASS
tests/discord-bridge-heartbeat-offload.test.py PASS   (no DEPRECATION line naming a real home path)
```

Test-only change; no production code touched. The offload fix from #2159 is untouched and still covered — I re-confirmed the suite discriminates (un-wrapping the real `to_thread` call site still produces 2 FAILs).