### PR TITLE
test: unbreak lint-hermetic-bridge-tests on main (isolate CLAUDE_CONFIG_DIR in the heartbeat-offload test)

### DIFF
--- a/tests/discord-bridge-heartbeat-offload.test.py
+++ b/tests/discord-bridge-heartbeat-offload.test.py
@@ -18,10 +18,25 @@ Run: python3 tests/discord-bridge-heartbeat-offload.test.py  (exit 0/1)
 from __future__ import annotations
 
 import asyncio
+import atexit
+import os
 import re
+import shutil
 import sys
+import tempfile
 import time
 from pathlib import Path
+
+# Isolate host config BEFORE touching the bridge. This file only reads the
+# source text today, but `channel_access_path()` falls back to the real
+# `~/.claude/channels/<ch>/access.json`, so the isolation has to be in place
+# for any future edit that imports the module rather than reading it.
+_CFG = tempfile.mkdtemp(prefix="ccd-heartbeat-offload-")
+atexit.register(lambda: shutil.rmtree(_CFG, ignore_errors=True))
+os.environ["CLAUDE_CONFIG_DIR"] = _CFG
+_CHAN = Path(_CFG) / "channels" / "discord"
+_CHAN.mkdir(parents=True, exist_ok=True)
+(_CHAN / "access.json").write_text('{"allowFrom": []}')
 
 REPO = Path(__file__).resolve().parent.parent
 SRC = (REPO / "src" / "discord-bridge.py").read_text()


### PR DESCRIPTION
## Problem

`lint-hermetic-bridge-tests` is **red on `main`**, and has been since 90c168b7 (#2159). Every commit before it is green on that workflow:

```
$ gh run list --branch main --workflow lint-hermetic-bridge-tests --limit 6
failure  90c168b7  2026-08-12T20:37:44Z
success  7a505429  2026-08-12T20:26:16Z
success  8ed8ac7b  2026-08-12T20:21:49Z
success  94dfb649  2026-08-12T20:08:41Z
success  8956660b  2026-08-12T19:21:55Z
success  bd76167b  2026-08-12T19:11:41Z
```

```
$ python3 scripts/lint-hermetic-bridge-tests.py
lint-hermetic-bridge-tests: FAIL — test imports a bridge without isolating CLAUDE_CONFIG_DIR
  tests/discord-bridge-heartbeat-offload.test.py
```

Every PR rebased onto `main` since then inherits the red — I hit it on #2856 and had to explain the failure there rather than fix it inline, since it isn't that PR's concern.

## Solution

The file resolves `src/discord-bridge.py` by path, which the guard treats as importing a bridge. It only reads the source *text* today, so nothing was actually reaching `channel_access_path()` — but the guard's stated point is that the property is one edit away from being false, and its own recipe is four lines. Cheaper to satisfy it than to argue the exemption.

Seed `CLAUDE_CONFIG_DIR` with a temp dir and an empty `allowFrom` before anything touches the bridge source, with `atexit` cleanup.

## Evidence

Before (on `main`) — shown above.

After, on this branch:

```
$ python3 scripts/lint-hermetic-bridge-tests.py
lint-hermetic-bridge-tests: ok (75 bridge-importing tests scanned, 47 grandfathered, 0 mitigated; 461 scanned for resolver stubs, 1 grandfathered)

$ python3 tests/discord-bridge-heartbeat-offload.test.py
  ok  on_ready executed + bumped session counter (presence_raises=True)

PASS — heartbeat-offload guards
```

One file, +16/-0. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WLZp6rZgNrxHmG5RqS234
