### PR TITLE
fix(team): close stdin for headless provider workers

### DIFF
--- a/skills/task-workstream-sessions/scripts/session-worker.py
+++ b/skills/task-workstream-sessions/scripts/session-worker.py
@@ -261,7 +261,7 @@ def _run_process_bounded(command: list[str], cwd: Path) -> tuple[int, str, str]:
     # returns whatever is available immediately, so the loop always makes it back
     # to the deadline checks and can fail closed.
     process = subprocess.Popen(
-        command, cwd=cwd, env=environment, stdout=subprocess.PIPE,
+        command, cwd=cwd, env=environment, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
         stderr=subprocess.PIPE, start_new_session=True,
     )
     assert process.stdout is not None and process.stderr is not None
@@ -518,7 +518,7 @@ def _run_claude(workspace: Path, workstream_id: str, prompt: str, repo: Path) ->
     result = subprocess.run(
         _claude_command(session_id, not created, prompt, repo),
         cwd=os.environ.get("SUTANDO_ISOLATED_WORKING_DIR", str(repo)),
-        text=True,
+        text=True, stdin=subprocess.DEVNULL,
         capture_output=True,
         check=False,
     )
@@ -544,7 +544,7 @@ def _run_codex(workspace: Path, workstream_id: str, prompt: str, repo: Path) -> 
             process = subprocess.Popen(
                 _codex_command(session_id or None, prompt, repo, output_file),
                 cwd=os.environ.get("SUTANDO_ISOLATED_WORKING_DIR", str(repo)),
-                text=True,
+                text=True, stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=stderr_file,
             )

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -261,6 +261,61 @@ pathlib.Path(args[args.index('-o') + 1]).write_text('safe codex result\\n')
         assert (workspace / "results" / team.name).read_text() == "safe codex result\n"
 
 
+def test_team_codex_does_not_inherit_an_open_parent_fifo() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        workspace = root / "workspace"
+        project = root / "project"
+        results = workspace / "results"
+        project.mkdir()
+        results.mkdir(parents=True)
+        team = _task(workspace, "task-team-open-fifo", "team")
+        marker = root / "provider-started"
+        _executable(root / "codex", """#!/usr/bin/env python3
+import os, pathlib, sys
+assert sys.stdin.read() == ''
+pathlib.Path(os.environ['PROVIDER_MARKER']).write_text('started\\n')
+args = sys.argv[1:]
+pathlib.Path(args[args.index('-o') + 1]).write_text('safe fifo result\\n')
+""")
+        fifo = root / "notifier-events"
+        os.mkfifo(fifo)
+        fifo_fd = os.open(fifo, os.O_RDWR)
+        process = subprocess.Popen(
+            [
+                sys.executable, str(WORKER), "--runtime", "codex",
+                "--workspace", str(workspace), "--task-file", str(team),
+                "--results-dir", str(results), "--repo", str(REPO),
+            ],
+            cwd=REPO,
+            env={
+                **os.environ,
+                "PATH": f"{root}:{os.environ['PATH']}",
+                "PROVIDER_MARKER": str(marker),
+                "SUTANDO_ISOLATED_WORKING_DIR": str(project),
+                "SUTANDO_TIER_HARD_TIMEOUT": "5",
+                "SUTANDO_TIER_STALL_TIMEOUT": "3",
+            },
+            stdin=fifo_fd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = process.communicate(timeout=2)
+        finally:
+            os.close(fifo_fd)
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.communicate(timeout=2)
+        assert process.returncode == 0, (stdout, stderr)
+        result = (results / team.name).read_text()
+        assert marker.is_file(), (stdout, stderr, result)
+        assert marker.read_text() == "started\n"
+        assert result == "safe fifo result\n"
+
+
 def test_ag2space_team_room_setting_runs_bridge_to_guarded_runtime_end_to_end() -> None:
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
@@ -1664,6 +1719,7 @@ if __name__ == "__main__":
     test_tier_parser_prevents_task_body_escalation_and_fails_closed()
     test_team_claude_uses_normal_workspace_with_guardrail_and_output_scan()
     test_team_codex_uses_normal_workspace_and_owner_configuration()
+    test_team_codex_does_not_inherit_an_open_parent_fifo()
     test_ag2space_team_room_setting_runs_bridge_to_guarded_runtime_end_to_end()
     test_bounded_runtime_failure_never_falls_back_to_owner_core()
     test_stalled_team_runtime_is_killed_and_publishes_safe_result()

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -261,7 +261,7 @@ pathlib.Path(args[args.index('-o') + 1]).write_text('safe codex result\\n')
         assert (workspace / "results" / team.name).read_text() == "safe codex result\n"
 
 
-def test_team_codex_does_not_inherit_an_open_parent_fifo() -> None:
+def test_provider_launches_do_not_inherit_an_open_parent_fifo() -> None:
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         workspace = root / "workspace"
@@ -270,50 +270,63 @@ def test_team_codex_does_not_inherit_an_open_parent_fifo() -> None:
         project.mkdir()
         results.mkdir(parents=True)
         team = _task(workspace, "task-team-open-fifo", "team")
-        marker = root / "provider-started"
+        claude_owner = _task(workspace, "task-claude-open-fifo")
+        codex_owner = _task(workspace, "task-codex-open-fifo")
+        _store(workspace, {
+            claude_owner.stem: {"workstream_id": "workstream-a"},
+            codex_owner.stem: {"workstream_id": "workstream-a"},
+        })
         _executable(root / "codex", """#!/usr/bin/env python3
-import os, pathlib, sys
+import json, os, pathlib, sys
 assert sys.stdin.read() == ''
-pathlib.Path(os.environ['PROVIDER_MARKER']).write_text('started\\n')
 args = sys.argv[1:]
-pathlib.Path(args[args.index('-o') + 1]).write_text('safe fifo result\\n')
+pathlib.Path(args[args.index('-o') + 1]).write_text('safe codex fifo result\\n')
+print(json.dumps({'type': 'thread.started',
+                  'thread_id': '12345678-1234-1234-8234-123456789abc'}))
 """)
-        fifo = root / "notifier-events"
-        os.mkfifo(fifo)
-        fifo_fd = os.open(fifo, os.O_RDWR)
-        process = subprocess.Popen(
-            [
-                sys.executable, str(WORKER), "--runtime", "codex",
-                "--workspace", str(workspace), "--task-file", str(team),
-                "--results-dir", str(results), "--repo", str(REPO),
-            ],
-            cwd=REPO,
-            env={
-                **os.environ,
-                "PATH": f"{root}:{os.environ['PATH']}",
-                "PROVIDER_MARKER": str(marker),
-                "SUTANDO_ISOLATED_WORKING_DIR": str(project),
-                "SUTANDO_TIER_HARD_TIMEOUT": "5",
-                "SUTANDO_TIER_STALL_TIMEOUT": "3",
-            },
-            stdin=fifo_fd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-        )
-        try:
-            stdout, stderr = process.communicate(timeout=2)
-        finally:
-            os.close(fifo_fd)
-            if process.poll() is None:
-                os.killpg(process.pid, signal.SIGKILL)
-                process.communicate(timeout=2)
-        assert process.returncode == 0, (stdout, stderr)
-        result = (results / team.name).read_text()
-        assert marker.is_file(), (stdout, stderr, result)
-        assert marker.read_text() == "started\n"
-        assert result == "safe fifo result\n"
+        _executable(root / "claude", """#!/usr/bin/env python3
+import sys
+assert sys.stdin.read() == ''
+print('safe claude fifo result')
+""")
+
+        for runtime, task, expected in (
+            ("codex", team, "safe codex fifo result\n"),
+            ("claude", claude_owner, "safe claude fifo result\n"),
+            ("codex", codex_owner, "safe codex fifo result\n"),
+        ):
+            fifo = root / f"{task.stem}-events"
+            os.mkfifo(fifo)
+            fifo_fd = os.open(fifo, os.O_RDWR)
+            process = subprocess.Popen(
+                [
+                    sys.executable, str(WORKER), "--runtime", runtime,
+                    "--workspace", str(workspace), "--task-file", str(task),
+                    "--results-dir", str(results), "--repo", str(REPO),
+                ],
+                cwd=REPO,
+                env={
+                    **os.environ,
+                    "PATH": f"{root}:{os.environ['PATH']}",
+                    "SUTANDO_ISOLATED_WORKING_DIR": str(project),
+                    "SUTANDO_TIER_HARD_TIMEOUT": "5",
+                    "SUTANDO_TIER_STALL_TIMEOUT": "3",
+                },
+                stdin=fifo_fd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+            try:
+                stdout, stderr = process.communicate(timeout=10)
+            finally:
+                os.close(fifo_fd)
+                if process.poll() is None:
+                    os.killpg(process.pid, signal.SIGKILL)
+                    process.communicate(timeout=2)
+            assert process.returncode == 0, (runtime, task.name, stdout, stderr)
+            assert (results / task.name).read_text() == expected
 
 
 def test_ag2space_team_room_setting_runs_bridge_to_guarded_runtime_end_to_end() -> None:
@@ -1719,7 +1732,7 @@ if __name__ == "__main__":
     test_tier_parser_prevents_task_body_escalation_and_fails_closed()
     test_team_claude_uses_normal_workspace_with_guardrail_and_output_scan()
     test_team_codex_uses_normal_workspace_and_owner_configuration()
-    test_team_codex_does_not_inherit_an_open_parent_fifo()
+    test_provider_launches_do_not_inherit_an_open_parent_fifo()
     test_ag2space_team_room_setting_runs_bridge_to_guarded_runtime_end_to_end()
     test_bounded_runtime_failure_never_falls_back_to_owner_core()
     test_stalled_team_runtime_is_killed_and_publishes_safe_result()


### PR DESCRIPTION
## What changed, and why?

The Codex task notifier reads its event stream from a long-lived FIFO, so the collaborator worker inherited that FIFO as stdin. Codex interpreted it as additional prompt input, waited for EOF, emitted no JSON, and hit the 180-second no-progress deadline.

This change binds `stdin=subprocess.DEVNULL` at every headless provider launch in `session-worker.py`:

- bounded Team Claude/Codex execution;
- durable owner-workstream Claude execution;
- durable owner-workstream Codex execution.

It also adds an end-to-end regression that launches the worker CLI while the worker's own stdin is an open FIFO. The fake Codex must read EOF before it can publish a result, proving the provider does not inherit the FIFO.

## Review first

1. `skills/task-workstream-sessions/scripts/session-worker.py` — the three provider launch contracts.
2. `tests/task-workstream-session-worker.test.py` — `test_team_codex_does_not_inherit_an_open_parent_fifo`.

## User behavior proved

A collaborator-enabled AG2 Space Team request now starts its separate headless Codex worker immediately even though the notifier's stdin remains an open events FIFO. It no longer falls back with “configured runtime was unavailable” after a 180-second stall.

## Feature/documentation consistency

N/A — this is a reliability fix for the existing collaborator worker contract; it does not change user-facing configuration, permissions, or capability semantics.

## Before/after evidence

Same standalone repro against the parent commit and HEAD. It launches the real worker CLI with parent stdin attached to an open FIFO; the provider cannot start until its stdin reaches EOF.

Parent `90c168b7`:

```text
$ python3 /tmp/sutando-fifo-pr-repro.py /tmp/sutando-parent.<id>
exit=0 elapsed=0.666s provider_started=False
stderr=tier task worker: provider made no progress for 0.5s
result=I could not process this team-tier task because the configured runtime was unavailable. No owner-core fallback was used.
```

HEAD `2f08ade7`:

```text
$ python3 /tmp/sutando-fifo-pr-repro.py /tmp/sutando-head.<id>
exit=0 elapsed=0.294s provider_started=True
stderr=<empty>
result=safe fifo result
```

The bug is also present on current `origin/main`: all three provider subprocess sites omit `stdin`; this branch is based directly on that commit.

## Tests

```text
$ python3 tests/task-workstream-session-worker.test.py
[remote-gateway-bridge] queued task-room-team-e2e
[remote-gateway-bridge] queued task-local-team-cap-e2e
task workstream session worker tests passed

$ python3 -m py_compile skills/task-workstream-sessions/scripts/session-worker.py tests/task-workstream-session-worker.test.py
(no output; exit 0)

$ git diff --check origin/main...HEAD
(no output; exit 0)

$ git diff --unified=0 origin/main...HEAD | rg '^\+.*(/Users/[^ <]+|/home/[^ <]+)'
hardcoded-host-path scan: no matches
```

## Live post-reload round trip

Reloaded the managed notifier on this head without restarting the interactive core:

```text
watcher PID:      63248 -> 60651
notifier version: 1914004589-523 -> 2456224695-523
core runtime:     codex (remained running)
notifier FD 0:    .../sutando-task-notifier.C3Svqt/events
```

Then a real AG2 Space collaborator sent task `task-d256e4dabd9e841779`:

```text
collaborator: true
source: ag2space
source_message_id: $Y3D2koa1upCky2lv4RjkvYyIMmoMIgu7jivF_AT91sQ
access_tier: team
task: ... are you in collaborator tier and be able to perform work?
```

The headless Team worker produced and the bridge delivered:

```text
Yes. I’m operating in collaborator-enabled Team tier and can use the configured workspace, tools, integrations, and network to perform requested work. I’ll stay within the request’s scope, protect owner-private data and credentials, and avoid irreversible or external actions unless explicitly requested and verified.
```

Room event timestamps were `1786571116396` input -> `1786571142544` reply: **26.148 seconds end to end**. The archived result was written at `2026-08-12T14:45:24-0700`. No fallback or worker error appeared.

## Duplicate search

No open or recent PR/issue covers this worker path. Closed PR #1701 documented the same Codex stdin behavior in the old Discord bridge, but touched only `src/discord-bridge.py`; this PR fixes the newer task-workstream session worker.

## Edge cases and risks

- Covered bounded Team execution and both durable Claude/Codex workstream launch sites.
- The regression keeps the parent FIFO open for the entire worker run and fails if the provider inherits it.
- No migrations, config changes, permission changes, or new dependencies.
- Rollback is a normal revert of this commit.
- Stdin-delivered provider prompts are not used here; prompts are already passed in argv, so closing stdin preserves intended behavior.

## Stacking / known gaps

N/A — not stacked. No known follow-up required.
