### PR TITLE
fix(gateway): isolate named gateway auth endpoints

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1128,7 +1128,11 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
       # REMOTE_TASK_CHANNEL_DIR_<INST>.
       _gw_chdir_var="REMOTE_TASK_CHANNEL_DIR_${_gw_var#AG2_REMOTE_TOKEN_}"
       _gw_chdir="${!_gw_chdir_var:-${_gw_inst}-ag2space}"
+      _gw_token_file_var="REMOTE_TASK_TOKEN_FILE_${_gw_var#AG2_REMOTE_TOKEN_}"
+      _gw_token_file="${!_gw_token_file_var:-$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels "$_gw_chdir" .env)}"
+      [ -f "$_gw_token_file" ] || _gw_token_file=""
       SUTANDO_SUPERVISED=1 GATEWAY_INSTANCE="$_gw_inst" REMOTE_TASK_TOKEN="${!_gw_var}" \
+        REMOTE_TASK_URL= REMOTE_TASK_TOKEN_FILE="$_gw_token_file" \
         REMOTE_TASK_CHANNEL_DIR="$_gw_chdir" \
         REMOTE_PROACTIVE_ROOM= \
         "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &

--- a/tests/startup-gateway-channel-dir.test.sh
+++ b/tests/startup-gateway-channel-dir.test.sh
@@ -10,7 +10,7 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 # Stub interpreter: dump the env we care about, exit (no real bridge).
 cat > "$TMP/py-stub" <<'STUB'
 #!/usr/bin/env bash
-env | grep -E '^(REMOTE_TASK_CHANNEL_DIR|GATEWAY_INSTANCE|REMOTE_TASK_TOKEN)=' \
+env | grep -E '^(REMOTE_TASK_CHANNEL_DIR|REMOTE_TASK_TOKEN_FILE|REMOTE_TASK_URL|GATEWAY_INSTANCE|REMOTE_TASK_TOKEN)=' \
   >> "$ENV_DUMP"
 STUB
 chmod +x "$TMP/py-stub"
@@ -45,4 +45,13 @@ echo "  ok  per-instance override honored"
 echo "$OUT" | grep -q '^REMOTE_TASK_CHANNEL_DIR=ag2space$' \
   && { echo "FAIL: instance leaked prod channel dir"; exit 1; }
 echo "  ok  prod channel dir never inherited"
+
+# Case 4: named gateways must not inherit the primary gateway URL or token file.
+: > "$TMP/dev.env"
+OUT="$(run_loop 'export AG2_REMOTE_TOKEN_DEV=https://dev.example/relay\|tok-dev REMOTE_TASK_URL=https://prod.example/relay REMOTE_TASK_TOKEN_FILE=/tmp/prod.env REMOTE_TASK_TOKEN_FILE_DEV="$TMP/dev.env"')"
+echo "$OUT" | grep -q '^REMOTE_TASK_URL=$' \
+  || { echo "FAIL: dev instance inherited primary REMOTE_TASK_URL"; echo "$OUT"; exit 1; }
+echo "$OUT" | grep -q "^REMOTE_TASK_TOKEN_FILE=$TMP/dev.env$" \
+  || { echo "FAIL: dev instance did not get its own token file"; echo "$OUT"; exit 1; }
+echo "  ok  primary URL and token file never inherited"
 echo "PASS — launcher threads REMOTE_TASK_CHANNEL_DIR per instance"


### PR DESCRIPTION
## What changed, and why?

Named secondary gateways now clear the primary gateway URL and resolve a per-instance token file before launch. Previously `AG2_REMOTE_TOKEN_DEV` supplied the dev bearer, but the already-exported production `REMOTE_TASK_URL` won URL resolution and the production `REMOTE_TASK_TOKEN_FILE` hot-reloaded the production bearer after the first auth rejection. The `dev` process therefore collapsed onto production.

## Review first

- `src/startup.sh` named-secondary launch environment
- `tests/startup-gateway-channel-dir.test.sh` isolation regression

## User behavior proved

A production and dev gateway can run concurrently from one Sutando checkout. The dev process connects to `https://dev-chat.ag2.space/relay`, uses `channels/dev-ag2space/.env` for rotation, and does not inherit production authentication state.

## Documentation

N/A — this restores the already-documented multi-gateway isolation contract; it does not add or change a user-visible feature.

## Before/after evidence

New regression test against parent `90c168b7`:

```text
before_exit=1
  ok  dev instance defaults to dev-ag2space
  ok  per-instance override honored
  ok  prod channel dir never inherited
FAIL: dev instance inherited primary REMOTE_TASK_URL
REMOTE_TASK_TOKEN_FILE=/tmp/prod.env
REMOTE_TASK_CHANNEL_DIR=dev-ag2space
REMOTE_TASK_URL=https://prod.example/relay
GATEWAY_INSTANCE=dev
REMOTE_TASK_TOKEN=https://dev.example/relay|tok-dev
```

At this PR head:

```text
$ bash tests/startup-gateway-channel-dir.test.sh
  ok  dev instance defaults to dev-ag2space
  ok  per-instance override honored
  ok  prod channel dir never inherited
  ok  primary URL and token file never inherited
PASS — launcher threads REMOTE_TASK_CHANNEL_DIR per instance
```

## Tests

```text
$ git diff --check
$ bash -n src/startup.sh
$ bash tests/startup-gateway-channel-dir.test.sh
PASS — launcher threads REMOTE_TASK_CHANNEL_DIR per instance
```

## Live post-restart evidence

Restarted `src/startup.sh` on the affected macOS host with both production and dev credentials configured. The dev bridge log changed from the failing production bind:

```text
starting — gateway=https://chat.ag2.space/relay
...
auth rejected but token file already rotated
```

to the isolated bind:

```text
starting — gateway=https://dev-chat.ag2.space/relay
access tier map path: .../channels/dev-ag2space/access.json
queued task-dev~task-e469d3afcd316df55c
```

The runtime-authored status then reported:

```json
{"connected":true,"gateway":"https://dev-chat.ag2.space/relay","launched_via":"supervised","error":null}
```

The authenticated dev broker directory returned the exact identity online:

```json
{"id":"@rui-rui-dev.agent:dev.ag2.space","online":true}
```

The AG2 Space public capability endpoint reports `team_collaborator: true` for that identity after its heartbeat.
