### PR TITLE
docs(cla): lead with close+reopen for an ABSENT license/cla, not the comment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ and "After opening the PR" sections. The short checklist:
 - **Live path (bridge / network / delivery loop / startup)?** Include a real post-restart round trip, not just unit tests — reviewers reject harness-only proof for these.
 - **Stacked PR?** Name the parent and merge order; after the parent lands, rebase/update the child and rerun its full checks.
 - Scan added lines for hardcoded host paths and inline path fallbacks; production code must use the repo's path helpers.
-- After `update-branch`, CLA-Assistant may not auto-rerun — try `@cla-assistant check` comment or close+reopen if stuck
+- After `update-branch`, CLA-Assistant often does not re-post. `license/cla` is SHA-bound, so the new head carries no status, and a *required* context that never posts reads as pending forever. **Close+reopen the PR** — it is a retry, and `pull_request.reopened` is acted on. Do **not** reach for an `@cla-assistant check` comment first: that is exactly what `.github/workflows/cla-recheck-on-push.yml` already posts on every push, and it is unreliable. Full ABSENT-vs-FAILING triage, with the `gh api .../commits/{sha}/status` invocation: `CONTRIBUTING.md` → "Check the CLA status"
 
 ### Reviewing a PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ and "After opening the PR" sections. The short checklist:
 - **Live path (bridge / network / delivery loop / startup)?** Include a real post-restart round trip, not just unit tests — reviewers reject harness-only proof for these.
 - **Stacked PR?** Name the parent and merge order; after the parent lands, rebase/update the child and rerun its full checks.
 - Scan added lines for hardcoded host paths and inline path fallbacks; production code must use the repo's path helpers.
-- After `update-branch`, CLA-Assistant may not auto-rerun — try `@cla-assistant check` comment or close+reopen if stuck
+- After `update-branch`, CLA-Assistant often does not re-post. `license/cla` is SHA-bound, so the new head carries no status, and a *required* context that never posts reads as pending forever. **Close+reopen the PR** — it is a retry, and `pull_request.reopened` is acted on. Do **not** reach for an `@cla-assistant check` comment first: that is exactly what `.github/workflows/cla-recheck-on-push.yml` already posts on every push, and it is unreliable. Full ABSENT-vs-FAILING triage, with the `gh api .../commits/{sha}/status` invocation: `CONTRIBUTING.md` → "Check the CLA status"
 
 ### Reviewing a PR
 


### PR DESCRIPTION
## What

One line in `CLAUDE.md` (and its generated `AGENTS.md` twin). For an **ABSENT** `license/cla`, lead with **close+reopen** instead of an `@cla-assistant check` comment, and point at the fuller triage already written in `CONTRIBUTING.md`.

```diff
-- After `update-branch`, CLA-Assistant may not auto-rerun — try `@cla-assistant check` comment or close+reopen if stuck
+- After `update-branch`, CLA-Assistant often does not re-post. `license/cla` is SHA-bound, so the new head
+  carries no status, and a *required* context that never posts reads as pending forever. **Close+reopen the
+  PR** — it is a retry, and `pull_request.reopened` is acted on. Do **not** reach for an `@cla-assistant
+  check` comment first: that is exactly what `.github/workflows/cla-recheck-on-push.yml` already posts on
+  every push, and it is unreliable. Full ABSENT-vs-FAILING triage, with the `gh api .../commits/{sha}/status`
+  invocation: `CONTRIBUTING.md` → "Check the CLA status"
```

## Why — measured on two live PRs today, not reasoned

I found six open PRs sitting on a missing required `license/cla` and used my own two to test the remedy CLAUDE.md recommends.

**The comment does nothing.**

| PR | what I did | result |
|---|---|---|
| #2158 | force-push, then `@cla-assistant check` comment | `license/cla: success` |
| #1858 | `@cla-assistant check` comment **only**, no push | **no status appeared** |
| #1858 | then close + reopen | ABSENT → `license/cla: success` in ~1 min |

#2158 is the trap: the status went green seconds after my comment, so the comment looks like the cause. It was not — `github-actions[bot]` had posted its own recheck **7 seconds earlier**, fired by my push:

```
2026-08-13T05:58:08Z  github-actions[bot]: @cla-assistant check   <- triggered by the push
2026-08-13T05:58:15Z  john-the-dev:        @cla-assistant check   <- mine, 7s later
```

#1858 isolates the variable: comment with no push, nothing happens; close+reopen, immediate success.

## This agrees with what CONTRIBUTING.md already says

`CONTRIBUTING.md` "Check the CLA status" already documents the correct model, in more depth than the above — the status is SHA-bound; `cla-recheck-on-push.yml` is the thing that posts that comment on each `synchronize`; "**that repair is not reliable**"; and close+reopen is a **retry**, not a push-specific fix, because the write can fail *after* CLA-Assistant acknowledged the event.

So the comment is not a remedy — it is the mechanism that already failed. CLAUDE.md offering it first sends you to re-try the failing path.

**Why bother with one line:** `CLAUDE.md`/`AGENTS.md` are auto-loaded into every agent session; `CONTRIBUTING.md` is not. The weaker guidance is the one that actually gets acted on — I acted on it myself this morning and wasted a round trip before reading CONTRIBUTING. This deliberately points at that section rather than restating it, so there is one source of truth.

## Evidence

```
$ bash scripts/agents-md-sync.sh
agents-md-sync: AGENTS.md regenerated from CLAUDE.md (540 lines)

$ bash scripts/agents-md-sync.sh --check
agents-md-sync: AGENTS.md is up to date          # rc=0

$ git diff origin/main...HEAD | bash scripts/review-checks.sh --diff /dev/stdin
review-checks: PASS (hardcoded-paths + root-artifacts clean)

$ git show --stat HEAD
 AGENTS.md | 2 +-
 CLAUDE.md | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

Docs-only, single concern, no behaviour change. `AGENTS.md` is generated — regenerated via the script, never hand-edited.
