### PR TITLE
feat(health-check): detect when the source has moved off the BUILT engine revision

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2715,9 +2715,7 @@ def check_engine_revision_drift(repo_dir: "Path | None" = None,
                                 manifest_path: "Path | None" = None) -> dict:
     """Warn when the checked-out source has moved off the BUILT engine revision.
 
-    `dist/` is gitignored, so a checkout cannot bring the compiled half with it:
-    the source can advance while the Node artifacts stay on the older build.
-    Warn, never fail; degrade to ok wherever the question does not apply.
+    `dist/` is gitignored, so source advances while the artifacts stay behind.
     """
     name = "engine-revision-drift"
     repo = Path(repo_dir) if repo_dir is not None else REPO_DIR
@@ -2738,8 +2736,7 @@ def check_engine_revision_drift(repo_dir: "Path | None" = None,
     built = built.strip()
 
     # A resolver failure must degrade like resolve_git() -> None, never to bare
-    # `git`: on a clean Mac that resolves the Xcode-CLT stub and this probe runs
-    # on every background health pass (REVIEW.md lesson 7).
+    # `git`, which can resolve the Xcode-CLT stub and raise the install dialog.
     try:
         from git_binary import resolve_git  # noqa: PLC0415
         git_bin = resolve_git()

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2774,6 +2774,18 @@ def check_engine_revision_drift(repo_dir: "Path | None" = None,
     if head.returncode != 0:
         return {"name": name, "status": "ok", "detail": "not a git checkout — skipping"}
     head_sha = head.stdout.strip()
+    # Resolve the manifest value to a full sha before comparing. A raw string
+    # compare calls an ABBREVIATED sha of the very commit that is checked out a
+    # mismatch, and the abbreviation still satisfies the ancestor test below, so
+    # it lands in the ahead-branch and prints "X != X (0 commits ahead)" — a
+    # probe contradicting itself, which costs more than a missed detection.
+    # Resolving also accepts a tag or any other ref-ish value.
+    try:
+        resolved = _git("rev-parse", f"{built}^{{commit}}")
+        if resolved.returncode == 0 and resolved.stdout.strip():
+            built = resolved.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass  # keep the literal; the comparison below is still correct for it
     if head_sha == built:
         return {"name": name, "status": "ok",
                 "detail": f"source matches built revision {built[:9]}"}
@@ -2785,6 +2797,12 @@ def check_engine_revision_drift(repo_dir: "Path | None" = None,
         if _git("cat-file", "-e", built).returncode == 0 and \
            _git("merge-base", "--is-ancestor", built, "HEAD").returncode == 0:
             ahead = _git("rev-list", "--count", f"{built}..HEAD").stdout.strip()
+            # Zero commits ahead of an ancestor means it IS this commit under
+            # another name. Belt to the normalisation's braces: whatever route
+            # got here, the self-contradicting warn is now unreachable.
+            if ahead == "0":
+                return {"name": name, "status": "ok",
+                        "detail": f"source matches built revision {built[:9]}"}
             if ahead:
                 detail += f" ({ahead} commits ahead)"
         else:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2711,6 +2711,92 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
                       + (f", {behind} commits behind" if behind else "")}
 
 
+def check_engine_revision_drift(repo_dir: "Path | None" = None,
+                                manifest_path: "Path | None" = None) -> dict:
+    """Warn when the checked-out source has moved off the BUILT engine revision.
+
+    Sibling of :func:`check_live_checkout_branch`: that one asks "am I on the
+    right branch", this one asks "is the source I am reading the source I am
+    running". They are different questions and only the second catches a mixed
+    engine — right branch, stale artifacts.
+
+    A bundled install ships ``engine/ENGINE_MANIFEST.json`` (``sha`` = the commit
+    the artifacts were built from) beside the ``engine/sutando`` checkout. The
+    compiled half lives in ``dist/``, which is **gitignored**, so a checkout can
+    never bring it along: moving the source forward silently leaves Node running
+    the older build while Python runs the newer source. Nothing else reports it.
+
+    Measured on a live install 2026-08-12: manifest ``3afc80c3`` (built 08-11),
+    checkout HEAD 27 commits ahead (newest source 08-12). The agent had spent a
+    session reading and editing source it was not running, and no probe existed
+    that could have said so — which is exactly why this one is structural rather
+    than a note telling someone to remember.
+
+    Read-only, and warn rather than fail: a developer who deliberately moved the
+    checkout forward should be told, not paged. Degrades to ok wherever the
+    question does not apply (plain dev clone with no manifest, unreadable
+    manifest, no runnable git) — a probe that cannot answer must not invent one.
+    """
+    name = "engine-revision-drift"
+    repo = Path(repo_dir) if repo_dir is not None else REPO_DIR
+    manifest = Path(manifest_path) if manifest_path is not None else repo.parent / "ENGINE_MANIFEST.json"
+
+    if not manifest.is_file():
+        # A plain source clone has no bundle manifest — nothing to compare.
+        return {"name": name, "status": "ok",
+                "detail": "no ENGINE_MANIFEST.json — not a bundled engine, skipping"}
+    try:
+        built = (json.loads(manifest.read_text()) or {}).get("sha")
+    except (OSError, ValueError) as e:
+        return {"name": name, "status": "ok",
+                "detail": f"unreadable ENGINE_MANIFEST.json ({str(e)[:40]}) — skipping"}
+    if not isinstance(built, str) or not built.strip():
+        return {"name": name, "status": "ok",
+                "detail": "ENGINE_MANIFEST.json has no sha — skipping"}
+    built = built.strip()
+
+    try:
+        from git_binary import resolve_git  # noqa: PLC0415
+        git_bin = resolve_git()
+    except Exception:
+        git_bin = "git"
+    if git_bin is None:
+        return {"name": name, "status": "ok", "detail": "no runnable git (resolver) — skipping"}
+
+    def _git(*args):
+        return subprocess.run([git_bin, "-C", str(repo), *args],
+                              capture_output=True, text=True, timeout=10)
+
+    try:
+        head = _git("rev-parse", "HEAD")
+    except (OSError, subprocess.TimeoutExpired):
+        return {"name": name, "status": "ok", "detail": "git not runnable — skipping"}
+    if head.returncode != 0:
+        return {"name": name, "status": "ok", "detail": "not a git checkout — skipping"}
+    head_sha = head.stdout.strip()
+    if head_sha == built:
+        return {"name": name, "status": "ok",
+                "detail": f"source matches built revision {built[:9]}"}
+
+    # Differs. Say HOW it differs when the shallow clone can answer; the drift
+    # itself is already established, so an unanswerable count must not soften it.
+    detail = f"source HEAD {head_sha[:9]} != built revision {built[:9]}"
+    try:
+        if _git("cat-file", "-e", built).returncode == 0 and \
+           _git("merge-base", "--is-ancestor", built, "HEAD").returncode == 0:
+            ahead = _git("rev-list", "--count", f"{built}..HEAD").stdout.strip()
+            if ahead:
+                detail += f" ({ahead} commits ahead)"
+        else:
+            detail += " (diverged, or the built commit is outside this shallow clone)"
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return {"name": name, "status": "warn",
+            "detail": detail + " — dist/ is gitignored so it did NOT follow the source; "
+                               "the Node half still runs the older build. Rebuild and "
+                               "reactivate the engine rather than trusting the checkout."}
+
+
 def check_migrate_reader_contract() -> dict:
     """Verify migration CLASS_RULES are compatible with reader resolution chains (issue #1543).
 
@@ -7241,6 +7327,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_per_host_config_backup())
     # Live checkout on its expected branch (PR-branch drift, 2026-07-29 incident)
     checks.append(check_live_checkout_branch())
+    checks.append(check_engine_revision_drift())
     onboarding_check = check_onboarding_status()
     if onboarding_check is not None:
         checks.append(onboarding_check)

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2715,27 +2715,9 @@ def check_engine_revision_drift(repo_dir: "Path | None" = None,
                                 manifest_path: "Path | None" = None) -> dict:
     """Warn when the checked-out source has moved off the BUILT engine revision.
 
-    Sibling of :func:`check_live_checkout_branch`: that one asks "am I on the
-    right branch", this one asks "is the source I am reading the source I am
-    running". They are different questions and only the second catches a mixed
-    engine — right branch, stale artifacts.
-
-    A bundled install ships ``engine/ENGINE_MANIFEST.json`` (``sha`` = the commit
-    the artifacts were built from) beside the ``engine/sutando`` checkout. The
-    compiled half lives in ``dist/``, which is **gitignored**, so a checkout can
-    never bring it along: moving the source forward silently leaves Node running
-    the older build while Python runs the newer source. Nothing else reports it.
-
-    Measured on a live install 2026-08-12: manifest ``3afc80c3`` (built 08-11),
-    checkout HEAD 27 commits ahead (newest source 08-12). The agent had spent a
-    session reading and editing source it was not running, and no probe existed
-    that could have said so — which is exactly why this one is structural rather
-    than a note telling someone to remember.
-
-    Read-only, and warn rather than fail: a developer who deliberately moved the
-    checkout forward should be told, not paged. Degrades to ok wherever the
-    question does not apply (plain dev clone with no manifest, unreadable
-    manifest, no runnable git) — a probe that cannot answer must not invent one.
+    `dist/` is gitignored, so a checkout cannot bring the compiled half with it:
+    the source can advance while the Node artifacts stay on the older build.
+    Warn, never fail; degrade to ok wherever the question does not apply.
     """
     name = "engine-revision-drift"
     repo = Path(repo_dir) if repo_dir is not None else REPO_DIR
@@ -2755,13 +2737,16 @@ def check_engine_revision_drift(repo_dir: "Path | None" = None,
                 "detail": "ENGINE_MANIFEST.json has no sha — skipping"}
     built = built.strip()
 
+    # A resolver failure must degrade like resolve_git() -> None, never to bare
+    # `git`: on a clean Mac that resolves the Xcode-CLT stub and this probe runs
+    # on every background health pass (REVIEW.md lesson 7).
     try:
         from git_binary import resolve_git  # noqa: PLC0415
         git_bin = resolve_git()
     except Exception:
-        git_bin = "git"
+        git_bin = None
     if git_bin is None:
-        return {"name": name, "status": "ok", "detail": "no runnable git (resolver) — skipping"}
+        return {"name": name, "status": "ok", "detail": "no runnable git — skipping"}
 
     def _git(*args):
         return subprocess.run([git_bin, "-C", str(repo), *args],
@@ -2774,12 +2759,8 @@ def check_engine_revision_drift(repo_dir: "Path | None" = None,
     if head.returncode != 0:
         return {"name": name, "status": "ok", "detail": "not a git checkout — skipping"}
     head_sha = head.stdout.strip()
-    # Resolve the manifest value to a full sha before comparing. A raw string
-    # compare calls an ABBREVIATED sha of the very commit that is checked out a
-    # mismatch, and the abbreviation still satisfies the ancestor test below, so
-    # it lands in the ahead-branch and prints "X != X (0 commits ahead)" — a
-    # probe contradicting itself, which costs more than a missed detection.
-    # Resolving also accepts a tag or any other ref-ish value.
+    # Normalise first: an abbreviated sha (or a tag) of the checked-out commit
+    # would otherwise compare unequal and print "X != X (0 commits ahead)".
     try:
         resolved = _git("rev-parse", f"{built}^{{commit}}")
         if resolved.returncode == 0 and resolved.stdout.strip():
@@ -2790,16 +2771,13 @@ def check_engine_revision_drift(repo_dir: "Path | None" = None,
         return {"name": name, "status": "ok",
                 "detail": f"source matches built revision {built[:9]}"}
 
-    # Differs. Say HOW it differs when the shallow clone can answer; the drift
-    # itself is already established, so an unanswerable count must not soften it.
+    # An unanswerable count must not soften the drift, which is already established.
     detail = f"source HEAD {head_sha[:9]} != built revision {built[:9]}"
     try:
         if _git("cat-file", "-e", built).returncode == 0 and \
            _git("merge-base", "--is-ancestor", built, "HEAD").returncode == 0:
             ahead = _git("rev-list", "--count", f"{built}..HEAD").stdout.strip()
-            # Zero commits ahead of an ancestor means it IS this commit under
-            # another name. Belt to the normalisation's braces: whatever route
-            # got here, the self-contradicting warn is now unreachable.
+            # Zero ahead of an ancestor means it IS this commit under another name.
             if ahead == "0":
                 return {"name": name, "status": "ok",
                         "detail": f"source matches built revision {built[:9]}"}

--- a/tests/health-check-engine-revision-drift.test.py
+++ b/tests/health-check-engine-revision-drift.test.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python3
 """Regression coverage for the engine source/artifact drift probe.
 
-The bug this guards is invisible by construction: `dist/` is gitignored, so
-moving the checkout forward leaves the compiled half on the older build and
-nothing reports it. Every case below drives the production probe against a real
-git repository rather than a stubbed one, because the discriminator IS the git
-comparison.
-
 Run: python3 tests/health-check-engine-revision-drift.test.py
 """
 

--- a/tests/health-check-engine-revision-drift.test.py
+++ b/tests/health-check-engine-revision-drift.test.py
@@ -226,6 +226,51 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertIn(head[:9], r["detail"])
         self.assertIn("dist/", r["detail"])
 
+    def test_normalisation_failure_falls_back_to_the_literal(self) -> None:
+        """`rev-parse` unrunnable must not break the comparison it feeds."""
+        self._write_manifest(sha=self.first)
+        real_run = hc.subprocess.run
+
+        def _boom_on_revparse_of_manifest(argv, *a, **kw):
+            # Let `rev-parse HEAD` through; only the normalisation call fails.
+            if "rev-parse" in argv and "HEAD" not in argv:
+                raise OSError("rev-parse unavailable")
+            return real_run(argv, *a, **kw)
+
+        hc.subprocess.run = _boom_on_revparse_of_manifest
+        try:
+            r = self._run()
+        finally:
+            hc.subprocess.run = real_run
+        # Full sha still matches by literal comparison.
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("matches built revision", r["detail"])
+
+    def test_zero_ahead_is_the_same_commit_even_without_normalisation(self) -> None:
+        """The belt, exercised on its own.
+
+        Normalisation makes this branch unreachable in practice, which is
+        exactly why it needs a test: an unreachable guard nobody ran is a guess
+        about behaviour. Force the abbreviated value past normalisation and
+        assert the ancestor-count path still refuses to contradict itself.
+        """
+        self._write_manifest(sha=self.first[:12])
+        real_run = hc.subprocess.run
+
+        def _revparse_of_manifest_fails(argv, *a, **kw):
+            if "rev-parse" in argv and "HEAD" not in argv:
+                raise OSError("normalisation disabled for this case")
+            return real_run(argv, *a, **kw)
+
+        hc.subprocess.run = _revparse_of_manifest_fails
+        try:
+            r = self._run()
+        finally:
+            hc.subprocess.run = real_run
+        self.assertEqual(r["status"], "ok", r)
+        self.assertNotIn("!=", r["detail"])
+        self.assertNotIn("0 commits ahead", r["detail"])
+
     # --- wiring ----------------------------------------------------------
 
     def test_probe_is_registered(self) -> None:

--- a/tests/health-check-engine-revision-drift.test.py
+++ b/tests/health-check-engine-revision-drift.test.py
@@ -12,12 +12,16 @@ Run: python3 tests/health-check-engine-revision-drift.test.py
 
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import json
 import subprocess
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -124,6 +128,77 @@ class EngineRevisionDriftTest(unittest.TestCase):
                 repo_dir=Path(plain), manifest_path=self.manifest)
         self.assertEqual(r["status"], "ok", r)
         self.assertIn("skipping", r["detail"])
+
+    # --- the defensive branches -----------------------------------------
+    #
+    # Written deliberately, so tested deliberately. An untested `except` is a
+    # guess about what the failure looks like, and the whole contract of this
+    # probe is that it degrades instead of taking the health run down with it.
+
+    def test_ok_when_git_resolver_reports_no_runnable_git(self) -> None:
+        self._write_manifest(sha=self.first)
+        self._advance()
+        mod = types.ModuleType("git_binary")
+        mod.resolve_git = lambda: None            # resolver: no usable git
+        with mock.patch.dict(sys.modules, {"git_binary": mod}):
+            r = self._run()
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("no runnable git", r["detail"])
+
+    def test_falls_back_to_plain_git_when_resolver_is_absent(self) -> None:
+        """Composes on a tree where `git_binary` does not exist yet."""
+        self._write_manifest(sha=self.first)
+        head = self._advance(2)
+        real_import = builtins.__import__
+
+        def _no_resolver(name, *a, **kw):
+            if name == "git_binary":
+                raise ImportError("no git_binary here")
+            return real_import(name, *a, **kw)
+
+        with mock.patch.object(builtins, "__import__", _no_resolver):
+            r = self._run()
+        # Still answers, via a bare `git`.
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("2 commits ahead", r["detail"])
+        self.assertIn(head[:9], r["detail"])
+
+    def test_ok_when_git_cannot_be_executed(self) -> None:
+        self._write_manifest(sha=self.first)
+        self._advance()
+        real_run = hc.subprocess.run
+
+        def _boom(argv, *a, **kw):
+            raise OSError("git is not executable here")
+
+        hc.subprocess.run = _boom
+        try:
+            r = self._run()
+        finally:
+            hc.subprocess.run = real_run
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("git not runnable", r["detail"])
+
+    def test_drift_still_reported_when_the_ahead_count_cannot_be_taken(self) -> None:
+        """The count is a nicety; the drift is the finding and must survive."""
+        self._write_manifest(sha=self.first)
+        head = self._advance(2)
+        real_run = hc.subprocess.run
+
+        def _boom_after_head(argv, *a, **kw):
+            # Let `rev-parse HEAD` through; fail everything used for counting.
+            if "rev-parse" not in argv:
+                raise OSError("cannot count from here")
+            return real_run(argv, *a, **kw)
+
+        hc.subprocess.run = _boom_after_head
+        try:
+            r = self._run()
+        finally:
+            hc.subprocess.run = real_run
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn(head[:9], r["detail"])
+        self.assertIn("dist/", r["detail"])
 
     # --- wiring ----------------------------------------------------------
 

--- a/tests/health-check-engine-revision-drift.test.py
+++ b/tests/health-check-engine-revision-drift.test.py
@@ -72,10 +72,10 @@ class EngineRevisionDriftTest(unittest.TestCase):
         return hc.check_engine_revision_drift(
             repo_dir=self.repo, manifest_path=self.manifest)
 
-    # --- the case that matters ------------------------------------------
+    # --- drift ------------------------------------------------------------
 
     def test_warns_when_source_moved_past_the_built_revision(self) -> None:
-        """The live failure: source ahead of the artifacts, silently."""
+        """Source ahead of the artifacts, with nothing reporting it."""
         self._write_manifest(sha=self.first)
         head = self._advance(3)
 
@@ -88,7 +88,7 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertIn("dist/", r["detail"])
 
     def test_ok_when_source_is_exactly_the_built_revision(self) -> None:
-        """Control: the same probe must go quiet, or the warn proves nothing."""
+        """Control: the probe must go quiet, or the warn proves nothing."""
         self._write_manifest(sha=self.first)
         r = self._run()
         self.assertEqual(r["status"], "ok", r)
@@ -103,15 +103,7 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertIn("diverged", r["detail"])
 
     def test_abbreviated_sha_of_the_same_commit_is_not_drift(self) -> None:
-        """A probe that prints "X != X (0 commits ahead)" discredits itself.
-
-        The abbreviation satisfies `cat-file -e` and `merge-base --is-ancestor`,
-        so before the fix it reached the ahead-branch with a count of zero
-        instead of being recognised as the same commit. Reported by john-the-dev
-        on #2864 with this repro; it cannot fire against today's manifest
-        producer (it writes a full 40-char sha) but the failure mode is a
-        self-contradiction, so it is closed rather than left latent.
-        """
+        """An abbreviated sha of HEAD must not read as drift."""
         for width in (7, 12, 40):
             with self.subTest(width=width):
                 self._write_manifest(sha=self.first[:width])
@@ -128,7 +120,7 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertEqual(r["status"], "ok", r)
         self.assertNotIn("!=", r["detail"])
 
-    # --- degrade cleanly where the question does not apply ---------------
+    # --- not applicable ---------------------------------------------------
 
     def test_ok_when_no_manifest(self) -> None:
         r = self._run()
@@ -155,11 +147,7 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertEqual(r["status"], "ok", r)
         self.assertIn("skipping", r["detail"])
 
-    # --- the defensive branches -----------------------------------------
-    #
-    # Written deliberately, so tested deliberately. An untested `except` is a
-    # guess about what the failure looks like, and the whole contract of this
-    # probe is that it degrades instead of taking the health run down with it.
+    # --- the degrade branches -------------------------------------------
 
     def test_ok_when_git_resolver_reports_no_runnable_git(self) -> None:
         self._write_manifest(sha=self.first)
@@ -171,10 +159,10 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertEqual(r["status"], "ok", r)
         self.assertIn("no runnable git", r["detail"])
 
-    def test_falls_back_to_plain_git_when_resolver_is_absent(self) -> None:
-        """Composes on a tree where `git_binary` does not exist yet."""
+    def test_resolver_failure_degrades_like_no_git(self) -> None:
+        # A resolver failure must not fall back to bare `git` (Xcode-CLT stub).
         self._write_manifest(sha=self.first)
-        head = self._advance(2)
+        self._advance(2)
         real_import = builtins.__import__
 
         def _no_resolver(name, *a, **kw):
@@ -184,10 +172,8 @@ class EngineRevisionDriftTest(unittest.TestCase):
 
         with mock.patch.object(builtins, "__import__", _no_resolver):
             r = self._run()
-        # Still answers, via a bare `git`.
-        self.assertEqual(r["status"], "warn", r)
-        self.assertIn("2 commits ahead", r["detail"])
-        self.assertIn(head[:9], r["detail"])
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("no runnable git", r["detail"])
 
     def test_ok_when_git_cannot_be_executed(self) -> None:
         self._write_manifest(sha=self.first)
@@ -206,7 +192,7 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertIn("git not runnable", r["detail"])
 
     def test_drift_still_reported_when_the_ahead_count_cannot_be_taken(self) -> None:
-        """The count is a nicety; the drift is the finding and must survive."""
+        """The count is a nicety; the drift must still be reported."""
         self._write_manifest(sha=self.first)
         head = self._advance(2)
         real_run = hc.subprocess.run
@@ -247,13 +233,7 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertIn("matches built revision", r["detail"])
 
     def test_zero_ahead_is_the_same_commit_even_without_normalisation(self) -> None:
-        """The belt, exercised on its own.
-
-        Normalisation makes this branch unreachable in practice, which is
-        exactly why it needs a test: an unreachable guard nobody ran is a guess
-        about behaviour. Force the abbreviated value past normalisation and
-        assert the ancestor-count path still refuses to contradict itself.
-        """
+        """Zero-ahead path, forced past normalisation so the guard is exercised."""
         self._write_manifest(sha=self.first[:12])
         real_run = hc.subprocess.run
 
@@ -274,7 +254,7 @@ class EngineRevisionDriftTest(unittest.TestCase):
     # --- wiring ----------------------------------------------------------
 
     def test_probe_is_registered(self) -> None:
-        """An unregistered probe reports nothing and looks identical to green."""
+        """An unregistered probe is indistinguishable from green."""
         src = (REPO / "src" / "health-check.py").read_text()
         self.assertIn("checks.append(check_engine_revision_drift())", src)
 

--- a/tests/health-check-engine-revision-drift.test.py
+++ b/tests/health-check-engine-revision-drift.test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression coverage for the engine source/artifact drift probe.
+
+The bug this guards is invisible by construction: `dist/` is gitignored, so
+moving the checkout forward leaves the compiled half on the older build and
+nothing reports it. Every case below drives the production probe against a real
+git repository rather than a stubbed one, because the discriminator IS the git
+comparison.
+
+Run: python3 tests/health-check-engine-revision-drift.test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location(
+    "health_check", REPO / "src" / "health-check.py"
+)
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(["git", "-C", str(repo), *args],
+                         capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+class EngineRevisionDriftTest(unittest.TestCase):
+    """`engine/` holds the manifest; `engine/sutando/` is the checkout."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        engine = Path(self._tmp.name) / "engine"
+        self.repo = engine / "sutando"
+        self.repo.mkdir(parents=True)
+        self.manifest = engine / "ENGINE_MANIFEST.json"
+
+        _git(self.repo, "init", "-q")
+        _git(self.repo, "config", "user.email", "t@example.com")
+        _git(self.repo, "config", "user.name", "t")
+        (self.repo / "a.txt").write_text("one\n")
+        _git(self.repo, "add", "-A")
+        _git(self.repo, "commit", "-qm", "first")
+        self.first = _git(self.repo, "rev-parse", "HEAD")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _advance(self, n: int = 1) -> str:
+        for i in range(n):
+            (self.repo / "a.txt").write_text(f"more {i}\n")
+            _git(self.repo, "commit", "-qam", f"advance {i}")
+        return _git(self.repo, "rev-parse", "HEAD")
+
+    def _write_manifest(self, **fields) -> None:
+        self.manifest.write_text(json.dumps(fields))
+
+    def _run(self) -> dict:
+        return hc.check_engine_revision_drift(
+            repo_dir=self.repo, manifest_path=self.manifest)
+
+    # --- the case that matters ------------------------------------------
+
+    def test_warns_when_source_moved_past_the_built_revision(self) -> None:
+        """The live failure: source ahead of the artifacts, silently."""
+        self._write_manifest(sha=self.first)
+        head = self._advance(3)
+
+        r = self._run()
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("3 commits ahead", r["detail"])
+        self.assertIn(head[:9], r["detail"])
+        self.assertIn(self.first[:9], r["detail"])
+        # The reason a checkout cannot fix this must reach the reader.
+        self.assertIn("dist/", r["detail"])
+
+    def test_ok_when_source_is_exactly_the_built_revision(self) -> None:
+        """Control: the same probe must go quiet, or the warn proves nothing."""
+        self._write_manifest(sha=self.first)
+        r = self._run()
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn(self.first[:9], r["detail"])
+
+    def test_warns_when_built_revision_is_not_in_this_clone(self) -> None:
+        """A shallow clone cannot count, but drift is still established."""
+        self._write_manifest(sha="0" * 40)
+        self._advance()
+        r = self._run()
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("diverged", r["detail"])
+
+    # --- degrade cleanly where the question does not apply ---------------
+
+    def test_ok_when_no_manifest(self) -> None:
+        r = self._run()
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("not a bundled engine", r["detail"])
+
+    def test_ok_when_manifest_unreadable(self) -> None:
+        self.manifest.write_text("{not json")
+        r = self._run()
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("unreadable", r["detail"])
+
+    def test_ok_when_manifest_has_no_sha(self) -> None:
+        self._write_manifest(branch="main", builder="ci")
+        r = self._run()
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("no sha", r["detail"])
+
+    def test_ok_when_not_a_git_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as plain:
+            self._write_manifest(sha=self.first)
+            r = hc.check_engine_revision_drift(
+                repo_dir=Path(plain), manifest_path=self.manifest)
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("skipping", r["detail"])
+
+    # --- wiring ----------------------------------------------------------
+
+    def test_probe_is_registered(self) -> None:
+        """An unregistered probe reports nothing and looks identical to green."""
+        src = (REPO / "src" / "health-check.py").read_text()
+        self.assertIn("checks.append(check_engine_revision_drift())", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-engine-revision-drift.test.py
+++ b/tests/health-check-engine-revision-drift.test.py
@@ -102,6 +102,32 @@ class EngineRevisionDriftTest(unittest.TestCase):
         self.assertEqual(r["status"], "warn", r)
         self.assertIn("diverged", r["detail"])
 
+    def test_abbreviated_sha_of_the_same_commit_is_not_drift(self) -> None:
+        """A probe that prints "X != X (0 commits ahead)" discredits itself.
+
+        The abbreviation satisfies `cat-file -e` and `merge-base --is-ancestor`,
+        so before the fix it reached the ahead-branch with a count of zero
+        instead of being recognised as the same commit. Reported by john-the-dev
+        on #2864 with this repro; it cannot fire against today's manifest
+        producer (it writes a full 40-char sha) but the failure mode is a
+        self-contradiction, so it is closed rather than left latent.
+        """
+        for width in (7, 12, 40):
+            with self.subTest(width=width):
+                self._write_manifest(sha=self.first[:width])
+                r = self._run()
+                self.assertEqual(r["status"], "ok", r)
+                self.assertIn("matches built revision", r["detail"])
+                self.assertNotIn("!=", r["detail"])
+
+    def test_a_tag_naming_head_is_not_drift(self) -> None:
+        """Normalising via rev-parse also accepts any other ref-ish value."""
+        _git(self.repo, "tag", "built-here")
+        self._write_manifest(sha="built-here")
+        r = self._run()
+        self.assertEqual(r["status"], "ok", r)
+        self.assertNotIn("!=", r["detail"])
+
     # --- degrade cleanly where the question does not apply ---------------
 
     def test_ok_when_no_manifest(self) -> None:


### PR DESCRIPTION
## The problem

`dist/` is gitignored, so a `git checkout` **cannot** bring the compiled half with it. Move the checkout forward and Python runs the newer source while Node keeps running the older build. Nothing reported this — the failure is silent by construction, not merely unnoticed.

## Evidence — this is live, not hypothetical

Measured on a running install before writing anything:

```
$ python3 -c "import json;print(json.load(open('../ENGINE_MANIFEST.json'))['sha'])"
3afc80c34e820d13492f9b9a73fe5fcf77bbafa8          # built_at 2026-08-11T17:55:06Z

$ git rev-parse HEAD
3e8756eb25d4f6476ab3fd0058941365f9aa14c1          # newest commit 2026-08-12T13:37:55Z

$ git rev-list --count 3afc80c3..HEAD
27

$ git ls-files dist | wc -l
0                                                  # gitignored — it can never follow
```

A full session had been spent reading and editing source that was not the source being run.

## Before / after

Both runs are the new test file, at the parent commit and at HEAD:

```
# parent (probe absent)
$ git stash push -q src/health-check.py && python3 tests/health-check-engine-revision-drift.test.py
Ran 8 tests
FAILED (failures=1, errors=7)

# HEAD
$ python3 tests/health-check-engine-revision-drift.test.py
Ran 8 tests in 0.496s
OK
```

And the probe against the real divergent install above:

```
status: warn
detail: source HEAD 3e8756eb2 != built revision 3afc80c34 (27 commits ahead) —
        dist/ is gitignored so it did NOT follow the source; the Node half still
        runs the older build. Rebuild and reactivate the engine rather than
        trusting the checkout.
```

## What it does

`engine-revision-drift` is a sibling of `live-checkout-branch`. That probe asks *am I on the right branch*; this one asks *is the source I am reading the source I am running*. Only the second catches a mixed engine — right branch, stale artifacts.

Warn, never fail: a developer who deliberately moved the checkout forward should be told, not paged.

Degrades to `ok` wherever the question does not apply — plain clone with no manifest, unreadable manifest, manifest without a sha, no runnable git, not a git checkout. A probe that cannot answer must not invent one. Each of those is a test.

## Scope

Detector only. It reads the `sha` the manifest **already** carries, so it needs no change to the manifest producer (`engine/write-engine-manifest.sh`, which lives in the desktop app repo). Recording artifact and lockfile digests — which would let this also catch a rebuild that never happened — is a separate change in that repo.

This is deliberately the detector before the switcher: it makes the invisible state visible today, and it is what would have caught the divergence above.

## Test plan

```
python3 tests/health-check-engine-revision-drift.test.py     # suite passes
python3 src/health-check.py                                  # probe reports in the normal run
```
