### PR TITLE
fix(health-check): a commit count across a graft boundary is not a distance

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2553,7 +2553,34 @@ def _commits_behind(repo: "Path", branch: str, git_bin: str = "git") -> "int | N
     the whole run hang on a flaky link. The consequence is honest and stated in
     the warning text: if the local ref is itself stale the count UNDERSTATES the
     drift, so this can only under-report, never cry wolf.
+
+    That "only under-reports" promise holds ONLY where the two refs share
+    history. In a SHALLOW clone whose remote ref was fetched separately the
+    graft boundaries can leave HEAD and origin/<branch> with no common ancestor
+    at all, and `rev-list --count HEAD..origin/<branch>` then degenerates to
+    "commits reachable from the remote tip", which is a small precise-looking
+    number that is not a distance. Measured on a bundled engine checkout
+    2026-08-12: count said **1** while the two refs shared no merge-base and the
+    content gap was **43 files**. The bundled checkout is always shallow, so
+    that is the primary deployment, and the false 1 also pushed the caller onto
+    its under-threshold branch and had it recommend `git pull --ff-only` — which
+    cannot succeed without a common ancestor.
+
+    So require a merge-base first: no shared history means the question is
+    unanswerable, which is what None already means here.
     """
+    try:
+        base = subprocess.run(
+            [git_bin, "-C", str(repo), "merge-base", "HEAD", f"origin/{branch}"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if base.returncode != 0:
+        # No common ancestor (typically shallow graft boundaries). A count here
+        # would be a number without a meaning — worse than no number, because
+        # callers treat a small one as "nearly current".
+        return None
     try:
         out = subprocess.run(
             [git_bin, "-C", str(repo), "rev-list", "--count", f"HEAD..origin/{branch}"],
@@ -2695,16 +2722,34 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
     # disagreed invisibly, and that is true of any content difference.
     stale_skills = _behind_commits_changing(repo, expected, "skills/", git_bin)
     if stale_skills:
+        # `behind` is None when the refs share no history (shallow graft). The
+        # tree diff below is still valid — it compares trees, not ancestry — but
+        # neither a count nor a fast-forward is available, so say that instead of
+        # rendering "None commit(s)" and prescribing a pull that cannot apply.
+        if behind is None:
+            distance = (f"live checkout is on {expected!r} an unknown distance behind "
+                        f"origin/{expected} (no common ancestor — shallow clone, so a commit "
+                        "count is not available)")
+            # "of them" needs a total to refer to; without one it would dangle.
+            share = f"{len(stale_skills)} commit(s) change"
+            refresh = (f"`git -C {repo} fetch --unshallow` first; `pull --ff-only` cannot "
+                       "apply without a shared history")
+        else:
+            distance = (f"live checkout is on {expected!r} and only {behind} commit(s) behind "
+                        f"origin/{expected} — under the {_behind_warn_threshold(repo)}-commit "
+                        "nag threshold")
+            # The count above is the TOTAL; "of them" keeps the skill subset
+            # visibly a subset of it rather than a second, competing number.
+            share = f"{len(stale_skills)} of them change"
+            refresh = f"`git -C {repo} pull --ff-only`"
         return {"name": name, "status": "warn",
-                "detail": f"live checkout is on {expected!r} and only {behind} commit(s) behind "
-                          f"origin/{expected} — under the {_behind_warn_threshold(repo)}-commit "
-                          f"nag threshold — but {len(stale_skills)} of them change `skills/`, "
+                "detail": f"{distance} — but {share} `skills/`, "
                           "which the agent re-reads from this checkout on EVERY invocation. "
                           "Those merged skill fixes are not in effect here, and no "
                           "restart-staleness probe can see it: a skill has no running process "
                           f"to compare against. ({'; '.join(stale_skills[:3])}"
                           f"{'; …' if len(stale_skills) > 3 else ''}) Refresh with "
-                          f"`git -C {repo} pull --ff-only`. Measured against the last-fetched "
+                          f"{refresh}. Measured against the last-fetched "
                           "ref; this probe does not fetch, so it can only under-report."}
     return {"name": name, "status": "ok",
             "detail": f"live checkout on {expected!r}"

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2548,26 +2548,8 @@ def _behind_commits_changing(repo: "Path", branch: str, prefix: str,
 def _commits_behind(repo: "Path", branch: str, git_bin: str = "git") -> "int | None":
     """Commits on origin/<branch> that HEAD lacks, or None if unanswerable.
 
-    Uses the LAST-FETCHED remote ref — deliberately does not fetch. A health
-    probe must stay fast and work offline, and a network call here would make
-    the whole run hang on a flaky link. The consequence is honest and stated in
-    the warning text: if the local ref is itself stale the count UNDERSTATES the
-    drift, so this can only under-report, never cry wolf.
-
-    That "only under-reports" promise holds ONLY where the two refs share
-    history. In a SHALLOW clone whose remote ref was fetched separately the
-    graft boundaries can leave HEAD and origin/<branch> with no common ancestor
-    at all, and `rev-list --count HEAD..origin/<branch>` then degenerates to
-    "commits reachable from the remote tip", which is a small precise-looking
-    number that is not a distance. Measured on a bundled engine checkout
-    2026-08-12: count said **1** while the two refs shared no merge-base and the
-    content gap was **43 files**. The bundled checkout is always shallow, so
-    that is the primary deployment, and the false 1 also pushed the caller onto
-    its under-threshold branch and had it recommend `git pull --ff-only` — which
-    cannot succeed without a common ancestor.
-
-    So require a merge-base first: no shared history means the question is
-    unanswerable, which is what None already means here.
+    Uses the last-fetched remote ref and never fetches. Requires a merge-base:
+    without shared history the count is not a distance (shallow graft boundary).
     """
     try:
         base = subprocess.run(
@@ -2577,9 +2559,7 @@ def _commits_behind(repo: "Path", branch: str, git_bin: str = "git") -> "int | N
     except (OSError, subprocess.TimeoutExpired):
         return None
     if base.returncode != 0:
-        # No common ancestor (typically shallow graft boundaries). A count here
-        # would be a number without a meaning — worse than no number, because
-        # callers treat a small one as "nearly current".
+        # No shared history: a count here would be a number without a meaning.
         return None
     try:
         out = subprocess.run(
@@ -2722,15 +2702,13 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
     # disagreed invisibly, and that is true of any content difference.
     stale_skills = _behind_commits_changing(repo, expected, "skills/", git_bin)
     if stale_skills:
-        # `behind` is None when the refs share no history (shallow graft). The
-        # tree diff below is still valid — it compares trees, not ancestry — but
-        # neither a count nor a fast-forward is available, so say that instead of
-        # rendering "None commit(s)" and prescribing a pull that cannot apply.
+        # No shared history: the tree diff is still valid, but no count and no
+        # fast-forward are, so say that rather than render "None commit(s)".
         if behind is None:
             distance = (f"live checkout is on {expected!r} an unknown distance behind "
                         f"origin/{expected} (no common ancestor — shallow clone, so a commit "
                         "count is not available)")
-            # "of them" needs a total to refer to; without one it would dangle.
+            # "of them" needs a total to refer to.
             share = f"{len(stale_skills)} commit(s) change"
             refresh = (f"`git -C {repo} fetch --unshallow` first; `pull --ff-only` cannot "
                        "apply without a shared history")
@@ -2738,8 +2716,7 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
             distance = (f"live checkout is on {expected!r} and only {behind} commit(s) behind "
                         f"origin/{expected} — under the {_behind_warn_threshold(repo)}-commit "
                         "nag threshold")
-            # The count above is the TOTAL; "of them" keeps the skill subset
-            # visibly a subset of it rather than a second, competing number.
+            # The count above is the TOTAL, so "of them" keeps the subset a subset.
             share = f"{len(stale_skills)} of them change"
             refresh = f"`git -C {repo} pull --ff-only`"
         return {"name": name, "status": "warn",

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2548,8 +2548,7 @@ def _behind_commits_changing(repo: "Path", branch: str, prefix: str,
 def _commits_behind(repo: "Path", branch: str, git_bin: str = "git") -> "int | None":
     """Commits on origin/<branch> that HEAD lacks, or None if unanswerable.
 
-    Uses the last-fetched remote ref and never fetches. Requires a merge-base:
-    without shared history the count is not a distance (shallow graft boundary).
+    Never fetches. Without a merge-base the count is not a distance, so returns None.
     """
     try:
         base = subprocess.run(

--- a/tests/health-check-commits-behind-shallow.test.py
+++ b/tests/health-check-commits-behind-shallow.test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""`_commits_behind` must refuse to answer when the refs share no history.
+
+The bundled engine checkout is always shallow, so this is the primary
+deployment, not an edge case. Every case drives real git repositories: the
+defect IS git's behaviour across a graft boundary, so a stub would only test
+the stub.
+
+Run: python3 tests/health-check-commits-behind-shallow.test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location(
+    "health_check", REPO / "src" / "health-check.py"
+)
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(["git", "-C", str(repo), *args],
+                         capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+def _init(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+
+
+def _commit(repo: Path, text: str, msg: str, path: str = "a.txt") -> str:
+    f = repo / path
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(text)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", msg)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+class CommitsBehindTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.upstream = self.root / "upstream"
+        _init(self.upstream)
+        _commit(self.upstream, "one\n", "first")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _clone(self, shallow: bool) -> Path:
+        clone = self.root / ("shallow" if shallow else "full")
+        args = ["clone", "-q", str(self.upstream), str(clone)]
+        if shallow:
+            args[2:2] = ["--depth", "1"]
+        subprocess.run(["git", *args], capture_output=True, text=True, check=True)
+        _git(clone, "config", "user.email", "t@example.com")
+        _git(clone, "config", "user.name", "t")
+        return clone
+
+    # --- shared history: the count is real and must still be produced --------
+
+    def test_counts_normally_when_history_is_shared(self) -> None:
+        """Control. Without this the None-return below proves nothing."""
+        clone = self._clone(shallow=False)
+        _commit(self.upstream, "two\n", "second")
+        _commit(self.upstream, "three\n", "third")
+        _git(clone, "fetch", "-q", "origin")
+        self.assertEqual(hc._commits_behind(clone, "main"), 2)
+
+    def test_zero_when_current(self) -> None:
+        clone = self._clone(shallow=False)
+        self.assertEqual(hc._commits_behind(clone, "main"), 0)
+
+    # --- the bug -------------------------------------------------------------
+
+    def test_returns_none_when_no_common_ancestor(self) -> None:
+        """No common ancestor: a count would be a number without a meaning.
+
+        The fixture reaches that state by rebuilding upstream history rather than
+        by depth (git ignores --depth for local clones). Disconnection is the
+        CONDITION under test; shallowness is how production reaches it.
+        """
+        clone = self._clone(shallow=True)
+        # Rebuild upstream history so nothing the clone holds is reachable from
+        # it — the shape a shallow bundled checkout reaches after the upstream
+        # commits it grafted at fall outside its depth.
+        orphan = self.upstream / "orphan.txt"
+        _git(self.upstream, "checkout", "-q", "--orphan", "rebuilt")
+        orphan.write_text("rebuilt\n")
+        _git(self.upstream, "add", "-A")
+        _git(self.upstream, "commit", "-qm", "rebuilt root")
+        _git(self.upstream, "branch", "-qM", "rebuilt", "main")
+        _git(clone, "fetch", "-q", "origin", "main")
+        _git(clone, "update-ref", "refs/remotes/origin/main", "FETCH_HEAD")
+
+        # Precondition: git itself says there is no merge-base.
+        base = subprocess.run(["git", "-C", str(clone), "merge-base",
+                               "HEAD", "origin/main"], capture_output=True, text=True)
+        self.assertNotEqual(base.returncode, 0,
+                            "fixture failed to create disconnected histories")
+
+        self.assertIsNone(hc._commits_behind(clone, "main"),
+                          "a count across a graft boundary is not a distance")
+
+    def test_probe_says_unknown_distance_not_none(self) -> None:
+        """The caller must not render 'None commit(s)' nor prescribe ff-only."""
+        clone = self._clone(shallow=True)
+        _commit(self.upstream, "x\n", "skill change", path="skills/demo/SKILL.md")
+        _git(self.upstream, "checkout", "-q", "--orphan", "rebuilt")
+        (self.upstream / "skills" / "demo" / "SKILL.md").write_text("different\n")
+        _git(self.upstream, "add", "-A")
+        _git(self.upstream, "commit", "-qm", "rebuilt with skills")
+        _git(self.upstream, "branch", "-qM", "rebuilt", "main")
+        _git(clone, "fetch", "-q", "origin", "main")
+        _git(clone, "update-ref", "refs/remotes/origin/main", "FETCH_HEAD")
+
+        r = hc.check_live_checkout_branch(repo_dir=clone)
+        detail = r["detail"]
+        # Asserted unconditionally on purpose. Guarding these behind an
+        # `if r["status"] == "warn"` would let the test pass silently on the day
+        # the fixture stops reaching this branch, which is the failure mode this
+        # file exists to catch one level down.
+        self.assertEqual(r["status"], "warn", detail)
+        self.assertIn("skills/", detail)
+        self.assertNotIn("None commit", detail)
+        self.assertIn("unknown distance", detail)
+        self.assertIn("no common ancestor", detail)
+        # The PRESCRIPTION must become unshallow. The text may still name
+        # ff-only — it does, to say it cannot apply — so asserting the string is
+        # absent would be asserting against a true sentence.
+        self.assertIn("fetch --unshallow", detail)
+        self.assertIn("cannot apply without a shared history", detail)
+
+    def test_returns_none_when_remote_ref_absent(self) -> None:
+        """Pre-existing contract preserved: unanswerable stays None."""
+        clone = self._clone(shallow=False)
+        _git(clone, "update-ref", "-d", "refs/remotes/origin/main")
+        self.assertIsNone(hc._commits_behind(clone, "main"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-commits-behind-shallow.test.py
+++ b/tests/health-check-commits-behind-shallow.test.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 """`_commits_behind` must refuse to answer when the refs share no history.
 
-The bundled engine checkout is always shallow, so this is the primary
-deployment, not an edge case. Every case drives real git repositories: the
-defect IS git's behaviour across a graft boundary, so a stub would only test
-the stub.
-
 Run: python3 tests/health-check-commits-behind-shallow.test.py
 """
 
@@ -72,7 +67,7 @@ class CommitsBehindTest(unittest.TestCase):
     # --- shared history: the count is real and must still be produced --------
 
     def test_counts_normally_when_history_is_shared(self) -> None:
-        """Control. Without this the None-return below proves nothing."""
+        """Control: without this the None-return proves nothing."""
         clone = self._clone(shallow=False)
         _commit(self.upstream, "two\n", "second")
         _commit(self.upstream, "three\n", "third")
@@ -86,16 +81,9 @@ class CommitsBehindTest(unittest.TestCase):
     # --- the bug -------------------------------------------------------------
 
     def test_returns_none_when_no_common_ancestor(self) -> None:
-        """No common ancestor: a count would be a number without a meaning.
-
-        The fixture reaches that state by rebuilding upstream history rather than
-        by depth (git ignores --depth for local clones). Disconnection is the
-        CONDITION under test; shallowness is how production reaches it.
-        """
+        """No common ancestor: the count would be a number without a meaning."""
         clone = self._clone(shallow=True)
-        # Rebuild upstream history so nothing the clone holds is reachable from
-        # it — the shape a shallow bundled checkout reaches after the upstream
-        # commits it grafted at fall outside its depth.
+        # Rebuild upstream history so nothing the clone holds is reachable.
         orphan = self.upstream / "orphan.txt"
         _git(self.upstream, "checkout", "-q", "--orphan", "rebuilt")
         orphan.write_text("rebuilt\n")
@@ -128,18 +116,13 @@ class CommitsBehindTest(unittest.TestCase):
 
         r = hc.check_live_checkout_branch(repo_dir=clone)
         detail = r["detail"]
-        # Asserted unconditionally on purpose. Guarding these behind an
-        # `if r["status"] == "warn"` would let the test pass silently on the day
-        # the fixture stops reaching this branch, which is the failure mode this
-        # file exists to catch one level down.
+        # Asserted unconditionally: a guarded assert can pass without running.
         self.assertEqual(r["status"], "warn", detail)
         self.assertIn("skills/", detail)
         self.assertNotIn("None commit", detail)
         self.assertIn("unknown distance", detail)
         self.assertIn("no common ancestor", detail)
-        # The PRESCRIPTION must become unshallow. The text may still name
-        # ff-only — it does, to say it cannot apply — so asserting the string is
-        # absent would be asserting against a true sentence.
+        # The PRESCRIPTION must become unshallow; the text may still name ff-only.
         self.assertIn("fetch --unshallow", detail)
         self.assertIn("cannot apply without a shared history", detail)
 


### PR DESCRIPTION
## The bug

`_commits_behind()` runs `rev-list --count HEAD..origin/<branch>` without checking that the two refs share history. Across a shallow clone's graft boundary they may not, and the count then degenerates to "commits reachable from the remote tip" — a small, precise-looking number that is not a distance.

**The bundled engine checkout is always shallow, so this is the primary deployment, not an edge case.**

## Measured on a live bundled checkout

```
$ git rev-parse --is-shallow-repository
true
$ git merge-base HEAD origin/main ; echo "exit: $?"
exit: 1                                   # no common ancestor
$ git rev-list --count HEAD..origin/main
1                                         # <-- reported as "1 commit behind"
$ git diff --name-only HEAD..origin/main | wc -l
43                                        # actual content gap
```

Two consequences, both worse than under-reporting:

1. `1` is under the 10-commit nag threshold, so the caller took its *quiet* branch. The probe's own docstring promises it "can only under-report, never cry wolf" — true where history is shared, and this is the case where it isn't.
2. It prescribed `git pull --ff-only`, which **cannot apply** without a common ancestor.

## Before / after

Both runs are the new test file, at the parent commit and at HEAD:

```
# parent
$ git stash push -q src/health-check.py && python3 tests/health-check-commits-behind-shallow.test.py
FAIL: test_returns_none_when_no_common_ancestor
  AssertionError: 1 is not None : a count across a graft boundary is not a distance
FAIL: test_probe_says_unknown_distance_not_none
  AssertionError: 'unknown distance' not found in "live checkout is on 'main' and only 1
  commit(s) behind origin/main — under the 10-commit nag threshold — ... Refresh with
  `git -C ... pull --ff-only`."
FAILED (failures=2)

# HEAD
$ python3 tests/health-check-commits-behind-shallow.test.py
Ran 5 tests in 0.75s
OK
```

The baseline failure text *is* the bug, verbatim.

Against the same live checkout, after:

```
_commits_behind -> None
warn: live checkout is on 'main' an unknown distance behind origin/main (no common
      ancestor — shallow clone, so a commit count is not available) — but 1 commit(s)
      change `skills/` ... Refresh with `git -C ... fetch --unshallow` first;
      `pull --ff-only` cannot apply without a shared history.
```

## The fix

Require a `merge-base` before counting. No shared history → return `None`, which is what the function already documents as "unanswerable". The caller reports an unknown distance and prescribes `fetch --unshallow`.

`_behind_commits_changing` needs **no** change: it gates on a tree diff, which stays valid across disconnected histories. Only the count was unsound.

## No regression to the existing probe test

`v4` asserts the message says `"1 of them change"` — deliberately, because the count is the TOTAL and "of them" keeps the skill subset visibly a subset. My first cut flattened that to `"1 commit(s) change"` and broke it. Fixed by varying only the unknown-count path, where "of them" would dangle for lack of an antecedent:

```
$ python3 tests/health-check-live-checkout-branch.test.py
live-checkout-branch probe invariants hold.
```

## Test plan

```
python3 tests/health-check-commits-behind-shallow.test.py   # 5 passed
python3 tests/health-check-live-checkout-branch.test.py     # invariants hold
```

Independent of #2864 (different probe, different defect); both touch `src/health-check.py` in separate regions.
