### PR TITLE
fix(watch-tasks-stream): a dead handler worker must not hold its dispatch slot

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -244,17 +244,54 @@ finish_handler_task() {
   drain_dispatch_queue
 }
 
+handler_result_exists() {
+  # Delivery CONSUMES the live result file, so a task that already answered may
+  # survive only in the archive. Missing that would make the reap below publish
+  # a terminal failure for a task that succeeded — and an id delivers once, so
+  # that reply could never be sent and would strand as an orphan result.
+  local filename="$1" base
+  [ -f "$RESULTS_DIR/$filename" ] && return 0
+  base="${filename%.txt}"
+  [ -d "$RESULTS_DIR/archive" ] || return 1
+  [ -n "$(find "$RESULTS_DIR/archive" -type f -name "$base*" -print -quit 2>/dev/null)" ]
+}
+
 drain_dispatch_queue() {
   local marker candidate task_path running_marker worker_receipt running_count=0
+  local filename worker_pid
+  # Re-entrancy guard. The reap below calls finish_handler_task, which ends by
+  # calling this function again — and acquire_dispatch_lock is a mkdir spinlock
+  # with NO timeout, so a nested call would spin forever against the lock this
+  # frame already holds. The nested drain is redundant anyway: this frame
+  # dispatches everything pending before it returns.
+  [ -n "${DRAIN_ACTIVE:-}" ] && return
   [ -n "$DISPATCH_DIR" ] && [ ! -e "$DISPATCH_DIR/shutting-down" ] || return
   acquire_dispatch_lock || return
   if [ -e "$DISPATCH_DIR/shutting-down" ]; then
     release_dispatch_lock
     return
   fi
+  DRAIN_ACTIVE=1
   shopt -s nullglob
+  # Count LIVE workers, not marker files. A worker killed or crashed before it
+  # emitted HANDLER_DONE leaves its marker behind; counting files then retires a
+  # slot permanently, and TASK_HANDLER_WORKERS such deaths stall the lane for the
+  # life of the watcher with no error anywhere.
   for marker in "$DISPATCH_DIR/running/"*; do
-    running_count=$((running_count + 1))
+    filename="$(basename "$marker")"
+    worker_pid="$(cat "$DISPATCH_DIR/workers/$filename" 2>/dev/null)"
+    if [ -n "$worker_pid" ] && kill -0 "$worker_pid" 2>/dev/null; then
+      running_count=$((running_count + 1))
+      continue
+    fi
+    # rc decides whether the sender gets a terminal-failure reply: only when the
+    # worker died before producing anything. finish_handler_task does not take
+    # the dispatch lock, so calling it here is safe.
+    if handler_result_exists "$filename"; then
+      finish_handler_task "$marker" "$(cat "$marker" 2>/dev/null)" 0
+    else
+      finish_handler_task "$marker" "$(cat "$marker" 2>/dev/null)" 1
+    fi
   done
   while [ "$running_count" -lt "$TASK_HANDLER_WORKERS" ]; do
     marker=""
@@ -286,6 +323,7 @@ drain_dispatch_queue() {
   done
   shopt -u nullglob
   release_dispatch_lock
+  DRAIN_ACTIVE=""
 }
 
 queue_handler_task() {

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -169,8 +169,10 @@ claim_disposition() {
   esac
 }
 
+# 0 = the task is settled (failure published, or a real answer already exists).
+# 1 = NOT settled: another writer may own the destination, so nothing was touched.
 publish_terminal_failure() {
-  local filename="$1" reason="$2" result temporary quarantine rc
+  local filename="$1" reason="$2" result temporary rc
   result="$RESULTS_DIR/$filename"
   # The shared readiness contract, not -f/-s: an empty OR whitespace-only body
   # is the undeliverable placeholder state and must not suppress this failure.
@@ -179,31 +181,15 @@ publish_terminal_failure() {
   temporary="$(mktemp "$RESULTS_DIR/.$filename.XXXXXX.tmp")" || return 1
   chmod 600 "$temporary" 2>/dev/null || true
   printf '%s\n' "I could not safely process this Team-tier task because the restricted runtime $reason. No unrestricted fallback was used." > "$temporary"
-  # A dead wrapper pid does not prove its writer stopped, so an unready body is
-  # moved aside and kept rather than overwritten; `ln` only ever creates.
+  # `ln` is the only write to the destination: it establishes ownership or fails.
+  # Reading then mutating a path a provider can still claim has no safe ordering.
   if ln "$temporary" "$result" 2>/dev/null; then
     rc=0
   elif handler_result_exists "$filename"; then
     rc=0
   else
-    quarantine="$(mktemp "$RESULTS_DIR/.$filename.superseded.XXXXXX")" || {
-      rm -f "$temporary"
-      return 1
-    }
-    if mv -f "$result" "$quarantine" 2>/dev/null; then
-      # A writer that raced us to the destination wins it; ours is dropped.
-      ln "$temporary" "$result" 2>/dev/null || true
-      if [ -s "$quarantine" ]; then
-        echo "watch-tasks-stream: $filename held an unready body when the terminal failure was published; kept it at $quarantine rather than destroying it" >&2
-      else
-        rm -f "$quarantine"
-      fi
-      rc=0
-    else
-      rm -f "$quarantine"
-      echo "watch-tasks-stream: could not set aside the unready result for $filename; left it untouched and published nothing" >&2
-      rc=1
-    fi
+    echo "watch-tasks-stream: $filename holds an unready result this watcher does not own; leaving it and the claim unsettled rather than publishing a failure over a provider that may still be writing" >&2
+    rc=1
   fi
   rm -f "$temporary"
   return "$rc"
@@ -236,7 +222,7 @@ release_dispatch_lock() {
 }
 
 finish_handler_task() {
-  local marker="$1" task_path="$2" rc="$3" filename settled worker_receipt
+  local marker="$1" task_path="$2" rc="$3" filename settled worker_receipt claim_settled
   filename="$(basename "$task_path")"
   worker_receipt="$DISPATCH_DIR/workers/$filename"
   settled="$DISPATCH_DIR/settled/$filename.worker"
@@ -246,11 +232,14 @@ finish_handler_task() {
   # event during cleanup, but it cannot strand the task without either path.
   if mv "$marker" "$settled" 2>/dev/null; then
     if [ "$rc" -ne 0 ] && claim_is_ours "$filename"; then
+      claim_settled=1
       claim_disposition "$filename"
       case $? in
         0)
           echo "watch-tasks-stream: required Team handler failed for $filename (exit $rc); publishing safe terminal failure" >&2
-          publish_terminal_failure "$filename" "failed" || true
+          # An unsettled failure means a provider may still own the destination;
+          # keeping the claim lets a later sweep retry instead of faking success.
+          publish_terminal_failure "$filename" "failed" || claim_settled=0
           ;;
         1)
           printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
@@ -261,7 +250,7 @@ finish_handler_task() {
           echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
           ;;
       esac
-      release_task_claim "$filename" || true
+      [ "$claim_settled" -eq 1 ] && { release_task_claim "$filename" || true; }
     elif [ "$rc" -eq 0 ]; then
       release_task_claim "$filename" || true
     fi

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -172,16 +172,16 @@ claim_disposition() {
 publish_terminal_failure() {
   local filename="$1" reason="$2" result temporary rc
   result="$RESULTS_DIR/$filename"
-  # -s not -f: a zero-byte result is the undeliverable placeholder state, so it
-  # must not read as "already answered" and suppress this failure.
-  [ -s "$result" ] && return 0
+  # The shared readiness contract, not -f/-s: an empty OR whitespace-only body
+  # is the undeliverable placeholder state and must not suppress this failure.
+  handler_result_exists "$filename" && return 0
   mkdir -p "$RESULTS_DIR"
   temporary="$(mktemp "$RESULTS_DIR/.$filename.XXXXXX.tmp")" || return 1
   chmod 600 "$temporary" 2>/dev/null || true
   printf '%s\n' "I could not safely process this Team-tier task because the restricted runtime $reason. No unrestricted fallback was used." > "$temporary"
   if ln "$temporary" "$result" 2>/dev/null; then
     rc=0
-  elif [ ! -s "$result" ]; then
+  elif ! handler_result_exists "$filename"; then
     mv -f "$temporary" "$result" 2>/dev/null
     rc=$?
   else
@@ -254,17 +254,20 @@ finish_handler_task() {
 }
 
 handler_result_exists() {
-  # Deliverable means EXACT id and NON-EMPTY: a prefix match or a zero-byte
-  # placeholder would release the claim and suppress the terminal failure.
+  # Readiness is result_ready's contract (rejects whitespace-only too) and the
+  # archive lookup is local_task_protocol's; this must not re-decide either.
   local filename="$1" task_id="${filename%.txt}"
-  [ -s "$RESULTS_DIR/$filename" ] && return 0
   [ -n "$SUTANDO_PY_BIN" ] || return 1
-  "$SUTANDO_PY_BIN" - "$__REPO_ROOT" "$RESULTS_DIR" "$task_id" <<'PYEOF' 2>/dev/null
+  "$SUTANDO_PY_BIN" - "$__REPO_ROOT" "$RESULTS_DIR" "$task_id" "$filename" <<'PYEOF' 2>/dev/null
 import pathlib, sys
 sys.path.insert(0, str(pathlib.Path(sys.argv[1]) / "src"))
 from local_task_protocol import find_archived_result
-found = find_archived_result(pathlib.Path(sys.argv[2]), sys.argv[3])
-raise SystemExit(0 if found and found.stat().st_size > 0 else 1)
+from result_ready import read_ready_result
+results = pathlib.Path(sys.argv[2])
+if read_ready_result(results / sys.argv[4]) is not None:
+    raise SystemExit(0)
+found = find_archived_result(results, sys.argv[3])
+raise SystemExit(0 if found is not None and read_ready_result(found) is not None else 1)
 PYEOF
 }
 

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -509,11 +509,17 @@ fallback_outstanding_handlers() {
       task_path="$(cat "$settled")"
       filename="$(basename "$task_path")"
       if claim_is_ours "$filename"; then
+        claim_settled=1
         claim_disposition "$filename"
         case $? in
           0)
             echo "watch-tasks-stream: required Team handler interrupted for $filename; publishing safe terminal failure" >&2
-            publish_terminal_failure "$filename" "was interrupted" || true
+            # This loop owns the receipt, so the later claim sweep never sees the
+            # task: an unsettled publish must record its own durable receipt here.
+            if ! publish_terminal_failure "$filename" "was interrupted"; then
+              claim_settled=0
+              printf '%s\n' "$task_path" > "$UNSETTLED_DIR/$filename"
+            fi
             ;;
           1)
             printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
@@ -524,7 +530,7 @@ fallback_outstanding_handlers() {
             echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
             ;;
         esac
-        release_task_claim "$filename" || true
+        [ "$claim_settled" -eq 1 ] && { release_task_claim "$filename" || true; }
       fi
       rm -f "$settled"
       made_progress=1

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -198,7 +198,7 @@ publish_terminal_failure() {
 if [ -n "${SUTANDO_TASK_EVENT_HANDLER:-}" ] && [ -x "$SUTANDO_TASK_EVENT_HANDLER" ]; then
   DISPATCH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sutando-task-dispatch.XXXXXX")"
   mkdir "$DISPATCH_DIR/pending" "$DISPATCH_DIR/running" "$DISPATCH_DIR/settled" \
-    "$DISPATCH_DIR/workers"
+    "$DISPATCH_DIR/workers" "$DISPATCH_DIR/unsettled"
   mkdir -p "$CLAIMS_DIR" "$FALLBACKS_DIR"
   shopt -s nullglob
   for claim in "$CLAIMS_DIR"/task-*.txt; do
@@ -237,9 +237,12 @@ finish_handler_task() {
       case $? in
         0)
           echo "watch-tasks-stream: required Team handler failed for $filename (exit $rc); publishing safe terminal failure" >&2
-          # An unsettled failure means a provider may still own the destination;
-          # keeping the claim lets a later sweep retry instead of faking success.
-          publish_terminal_failure "$filename" "failed" || claim_settled=0
+          # The dispatch receipt is about to be removed, so an unsettled publish
+          # needs its own artifact or later drains cannot see the task at all.
+          if ! publish_terminal_failure "$filename" "failed"; then
+            claim_settled=0
+            printf '%s\n' "$task_path" > "$DISPATCH_DIR/unsettled/$filename"
+          fi
           ;;
         1)
           printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
@@ -292,6 +295,16 @@ drain_dispatch_queue() {
   fi
   DRAIN_ACTIVE=1
   shopt -s nullglob
+  # Retry publishes that could not settle: the destination was owned by someone
+  # else then, and this is the only path that revisits them before a restart.
+  for marker in "$DISPATCH_DIR/unsettled/"*; do
+    filename="$(basename "$marker")"
+    claim_is_ours "$filename" || { rm -f "$marker"; continue; }
+    if publish_terminal_failure "$filename" "failed"; then
+      release_task_claim "$filename" || true
+      rm -f "$marker"
+    fi
+  done
   # Count LIVE workers, not marker files: a worker that died before emitting
   # HANDLER_DONE leaves its marker and would retire the slot permanently.
   for marker in "$DISPATCH_DIR/running/"*; do

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -79,6 +79,7 @@ RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$WORKSPACE_DIR/results}"
 # of spawning an unbounded process fanout. Unhandled work still emits its
 # TASK_FILE event immediately, even while the provider queue is full.
 TASK_HANDLER_WORKERS=2
+SUTANDO_PY_BIN="$(bash "$__REPO_ROOT/scripts/sutando-config.sh" python-bin 2>/dev/null || true)"
 DISPATCH_DIR=""
 WATCH_RUNTIME_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sutando-task-watch.XXXXXX")"
 mkfifo "$WATCH_RUNTIME_DIR/events"
@@ -171,13 +172,21 @@ claim_disposition() {
 publish_terminal_failure() {
   local filename="$1" reason="$2" result temporary rc
   result="$RESULTS_DIR/$filename"
-  [ -f "$result" ] && return 0
+  # -s not -f: a zero-byte result is the undeliverable placeholder state, so it
+  # must not read as "already answered" and suppress this failure.
+  [ -s "$result" ] && return 0
   mkdir -p "$RESULTS_DIR"
   temporary="$(mktemp "$RESULTS_DIR/.$filename.XXXXXX.tmp")" || return 1
   chmod 600 "$temporary" 2>/dev/null || true
   printf '%s\n' "I could not safely process this Team-tier task because the restricted runtime $reason. No unrestricted fallback was used." > "$temporary"
-  ln "$temporary" "$result" 2>/dev/null || [ -f "$result" ]
-  rc=$?
+  if ln "$temporary" "$result" 2>/dev/null; then
+    rc=0
+  elif [ ! -s "$result" ]; then
+    mv -f "$temporary" "$result" 2>/dev/null
+    rc=$?
+  else
+    rc=0
+  fi
   rm -f "$temporary"
   return "$rc"
 }
@@ -245,25 +254,25 @@ finish_handler_task() {
 }
 
 handler_result_exists() {
-  # Delivery CONSUMES the live result file, so a task that already answered may
-  # survive only in the archive. Missing that would make the reap below publish
-  # a terminal failure for a task that succeeded — and an id delivers once, so
-  # that reply could never be sent and would strand as an orphan result.
-  local filename="$1" base
-  [ -f "$RESULTS_DIR/$filename" ] && return 0
-  base="${filename%.txt}"
-  [ -d "$RESULTS_DIR/archive" ] || return 1
-  [ -n "$(find "$RESULTS_DIR/archive" -type f -name "$base*" -print -quit 2>/dev/null)" ]
+  # Deliverable means EXACT id and NON-EMPTY: a prefix match or a zero-byte
+  # placeholder would release the claim and suppress the terminal failure.
+  local filename="$1" task_id="${filename%.txt}"
+  [ -s "$RESULTS_DIR/$filename" ] && return 0
+  [ -n "$SUTANDO_PY_BIN" ] || return 1
+  "$SUTANDO_PY_BIN" - "$__REPO_ROOT" "$RESULTS_DIR" "$task_id" <<'PYEOF' 2>/dev/null
+import pathlib, sys
+sys.path.insert(0, str(pathlib.Path(sys.argv[1]) / "src"))
+from local_task_protocol import find_archived_result
+found = find_archived_result(pathlib.Path(sys.argv[2]), sys.argv[3])
+raise SystemExit(0 if found and found.stat().st_size > 0 else 1)
+PYEOF
 }
 
 drain_dispatch_queue() {
   local marker candidate task_path running_marker worker_receipt running_count=0
   local filename worker_pid
-  # Re-entrancy guard. The reap below calls finish_handler_task, which ends by
-  # calling this function again — and acquire_dispatch_lock is a mkdir spinlock
-  # with NO timeout, so a nested call would spin forever against the lock this
-  # frame already holds. The nested drain is redundant anyway: this frame
-  # dispatches everything pending before it returns.
+  # finish_handler_task ends by calling this function, and the dispatch lock is
+  # a mkdir spinlock with no timeout — a nested call would deadlock on it.
   [ -n "${DRAIN_ACTIVE:-}" ] && return
   [ -n "$DISPATCH_DIR" ] && [ ! -e "$DISPATCH_DIR/shutting-down" ] || return
   acquire_dispatch_lock || return
@@ -273,10 +282,8 @@ drain_dispatch_queue() {
   fi
   DRAIN_ACTIVE=1
   shopt -s nullglob
-  # Count LIVE workers, not marker files. A worker killed or crashed before it
-  # emitted HANDLER_DONE leaves its marker behind; counting files then retires a
-  # slot permanently, and TASK_HANDLER_WORKERS such deaths stall the lane for the
-  # life of the watcher with no error anywhere.
+  # Count LIVE workers, not marker files: a worker that died before emitting
+  # HANDLER_DONE leaves its marker and would retire the slot permanently.
   for marker in "$DISPATCH_DIR/running/"*; do
     filename="$(basename "$marker")"
     worker_pid="$(cat "$DISPATCH_DIR/workers/$filename" 2>/dev/null)"
@@ -284,9 +291,8 @@ drain_dispatch_queue() {
       running_count=$((running_count + 1))
       continue
     fi
-    # rc decides whether the sender gets a terminal-failure reply: only when the
-    # worker died before producing anything. finish_handler_task does not take
-    # the dispatch lock, so calling it here is safe.
+    # rc decides whether the sender gets a terminal-failure reply — only when
+    # the worker died before producing a deliverable result.
     if handler_result_exists "$filename"; then
       finish_handler_task "$marker" "$(cat "$marker" 2>/dev/null)" 0
     else

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -88,6 +88,9 @@ CLEANING_UP=0
 GROUP_TERM_SENT=0
 CLAIMS_DIR="$WORKSPACE_DIR/state/task-event-handler-claims"
 FALLBACKS_DIR="$WORKSPACE_DIR/state/task-event-handler-fallbacks"
+# Durable, NOT under DISPATCH_DIR: a retry receipt that dies with the process
+# leaves an unready destination no later watcher knows to settle.
+UNSETTLED_DIR="$WORKSPACE_DIR/state/task-event-handler-unsettled"
 WATCHER_ID="$$-${RANDOM:-0}"
 
 claim_is_live() {
@@ -198,13 +201,22 @@ publish_terminal_failure() {
 if [ -n "${SUTANDO_TASK_EVENT_HANDLER:-}" ] && [ -x "$SUTANDO_TASK_EVENT_HANDLER" ]; then
   DISPATCH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sutando-task-dispatch.XXXXXX")"
   mkdir "$DISPATCH_DIR/pending" "$DISPATCH_DIR/running" "$DISPATCH_DIR/settled" \
-    "$DISPATCH_DIR/workers" "$DISPATCH_DIR/unsettled"
-  mkdir -p "$CLAIMS_DIR" "$FALLBACKS_DIR"
+    "$DISPATCH_DIR/workers"
+  mkdir -p "$CLAIMS_DIR" "$FALLBACKS_DIR" "$UNSETTLED_DIR"
   shopt -s nullglob
   for claim in "$CLAIMS_DIR"/task-*.txt; do
     # Overlapping watchers preserve a live owner's claim. A dead owner's
     # record is atomically quarantined before the new sweep retries it.
     claim_is_live "$claim" || retire_stale_claim "$claim" || true
+  done
+  # A previous watcher left these unsettled. Retry the publish first: the task
+  # is already done, and re-dispatching it would repeat the handler's effects.
+  for marker in "$UNSETTLED_DIR"/*; do
+    filename="$(basename "$marker")"
+    if publish_terminal_failure "$filename" "failed"; then
+      release_task_claim "$filename" 2>/dev/null || rm -f "$CLAIMS_DIR/$filename"
+      rm -f "$marker"
+    fi
   done
   shopt -u nullglob
 fi
@@ -241,7 +253,7 @@ finish_handler_task() {
           # needs its own artifact or later drains cannot see the task at all.
           if ! publish_terminal_failure "$filename" "failed"; then
             claim_settled=0
-            printf '%s\n' "$task_path" > "$DISPATCH_DIR/unsettled/$filename"
+            printf '%s\n' "$task_path" > "$UNSETTLED_DIR/$filename"
           fi
           ;;
         1)
@@ -297,9 +309,9 @@ drain_dispatch_queue() {
   shopt -s nullglob
   # Retry publishes that could not settle: the destination was owned by someone
   # else then, and this is the only path that revisits them before a restart.
-  for marker in "$DISPATCH_DIR/unsettled/"*; do
+  for marker in "$UNSETTLED_DIR"/*; do
     filename="$(basename "$marker")"
-    claim_is_ours "$filename" || { rm -f "$marker"; continue; }
+    claim_is_ours "$filename" || continue
     if publish_terminal_failure "$filename" "failed"; then
       release_task_claim "$filename" || true
       rm -f "$marker"
@@ -479,7 +491,7 @@ _tmux_wake() {
 #   to re-send to ourselves closes that window; the process is exiting
 #   either way so nothing downstream needs to observe them again.
 fallback_outstanding_handlers() {
-  local marker task_path filename settled made_progress found claim owner_id cleanup_ready
+  local marker task_path filename settled made_progress found claim owner_id cleanup_ready claim_settled
   local worker_receipt worker_pid job_pid
   [ -n "$DISPATCH_DIR" ] && [ -d "$DISPATCH_DIR" ] || return
   : > "$DISPATCH_DIR/shutting-down"
@@ -530,11 +542,17 @@ fallback_outstanding_handlers() {
     task_path="$(sed -n '3p' "$claim" 2>/dev/null)"
     [ -n "$task_path" ] || continue
     filename="$(basename "$task_path")"
+    claim_settled=1
     claim_disposition "$filename"
     case $? in
       0)
         echo "watch-tasks-stream: required Team handler interrupted for $filename; publishing safe terminal failure" >&2
-        publish_terminal_failure "$filename" "was interrupted" || true
+        # Releasing here would drop the last record of a task that is neither
+        # delivered nor failed; the durable receipt is what a later watcher retries.
+        if ! publish_terminal_failure "$filename" "was interrupted"; then
+          claim_settled=0
+          printf '%s\n' "$task_path" > "$UNSETTLED_DIR/$filename"
+        fi
         ;;
       1)
         printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
@@ -545,7 +563,7 @@ fallback_outstanding_handlers() {
         echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
         ;;
     esac
-    release_task_claim "$filename" || true
+    [ "$claim_settled" -eq 1 ] && { release_task_claim "$filename" || true; }
   done
 
   # Claims and fallback events are durable now. TERM the whole process group,
@@ -580,11 +598,6 @@ fallback_outstanding_handlers() {
       "$DISPATCH_DIR/settled/claim-"*; do
     rm -f "$settled"
   done
-  # The claims loop above already settled or released every one of these, so the
-  # retry receipts are spent; leaving any would keep the tempdir undeletable.
-  for marker in "$DISPATCH_DIR/unsettled/"*; do
-    rm -f "$marker"
-  done
   rmdir "$DISPATCH_DIR/lock" 2>/dev/null || true
   shopt -u nullglob
   cleanup_ready=1
@@ -593,7 +606,6 @@ fallback_outstanding_handlers() {
   rmdir "$DISPATCH_DIR/running" 2>/dev/null || cleanup_ready=0
   rmdir "$DISPATCH_DIR/settled" 2>/dev/null || cleanup_ready=0
   rmdir "$DISPATCH_DIR/workers" 2>/dev/null || cleanup_ready=0
-  rmdir "$DISPATCH_DIR/unsettled" 2>/dev/null || cleanup_ready=0
   if [ "$cleanup_ready" -eq 1 ]; then
     rm -f "$DISPATCH_DIR/shutting-down"
     rmdir "$DISPATCH_DIR" 2>/dev/null || true

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -580,6 +580,11 @@ fallback_outstanding_handlers() {
       "$DISPATCH_DIR/settled/claim-"*; do
     rm -f "$settled"
   done
+  # The claims loop above already settled or released every one of these, so the
+  # retry receipts are spent; leaving any would keep the tempdir undeletable.
+  for marker in "$DISPATCH_DIR/unsettled/"*; do
+    rm -f "$marker"
+  done
   rmdir "$DISPATCH_DIR/lock" 2>/dev/null || true
   shopt -u nullglob
   cleanup_ready=1
@@ -588,6 +593,7 @@ fallback_outstanding_handlers() {
   rmdir "$DISPATCH_DIR/running" 2>/dev/null || cleanup_ready=0
   rmdir "$DISPATCH_DIR/settled" 2>/dev/null || cleanup_ready=0
   rmdir "$DISPATCH_DIR/workers" 2>/dev/null || cleanup_ready=0
+  rmdir "$DISPATCH_DIR/unsettled" 2>/dev/null || cleanup_ready=0
   if [ "$cleanup_ready" -eq 1 ]; then
     rm -f "$DISPATCH_DIR/shutting-down"
     rmdir "$DISPATCH_DIR" 2>/dev/null || true

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -170,7 +170,7 @@ claim_disposition() {
 }
 
 publish_terminal_failure() {
-  local filename="$1" reason="$2" result temporary rc
+  local filename="$1" reason="$2" result temporary quarantine rc
   result="$RESULTS_DIR/$filename"
   # The shared readiness contract, not -f/-s: an empty OR whitespace-only body
   # is the undeliverable placeholder state and must not suppress this failure.
@@ -179,13 +179,31 @@ publish_terminal_failure() {
   temporary="$(mktemp "$RESULTS_DIR/.$filename.XXXXXX.tmp")" || return 1
   chmod 600 "$temporary" 2>/dev/null || true
   printf '%s\n' "I could not safely process this Team-tier task because the restricted runtime $reason. No unrestricted fallback was used." > "$temporary"
+  # A dead wrapper pid does not prove its writer stopped, so an unready body is
+  # moved aside and kept rather than overwritten; `ln` only ever creates.
   if ln "$temporary" "$result" 2>/dev/null; then
     rc=0
-  elif ! handler_result_exists "$filename"; then
-    mv -f "$temporary" "$result" 2>/dev/null
-    rc=$?
-  else
+  elif handler_result_exists "$filename"; then
     rc=0
+  else
+    quarantine="$(mktemp "$RESULTS_DIR/.$filename.superseded.XXXXXX")" || {
+      rm -f "$temporary"
+      return 1
+    }
+    if mv -f "$result" "$quarantine" 2>/dev/null; then
+      # A writer that raced us to the destination wins it; ours is dropped.
+      ln "$temporary" "$result" 2>/dev/null || true
+      if [ -s "$quarantine" ]; then
+        echo "watch-tasks-stream: $filename held an unready body when the terminal failure was published; kept it at $quarantine rather than destroying it" >&2
+      else
+        rm -f "$quarantine"
+      fi
+      rc=0
+    else
+      rm -f "$quarantine"
+      echo "watch-tasks-stream: could not set aside the unready result for $filename; left it untouched and published nothing" >&2
+      rc=1
+    fi
   fi
   rm -f "$temporary"
   return "$rc"

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -88,9 +88,6 @@ CLEANING_UP=0
 GROUP_TERM_SENT=0
 CLAIMS_DIR="$WORKSPACE_DIR/state/task-event-handler-claims"
 FALLBACKS_DIR="$WORKSPACE_DIR/state/task-event-handler-fallbacks"
-# Durable, NOT under DISPATCH_DIR: a retry receipt that dies with the process
-# leaves an unready destination no later watcher knows to settle.
-UNSETTLED_DIR="$WORKSPACE_DIR/state/task-event-handler-unsettled"
 WATCHER_ID="$$-${RANDOM:-0}"
 
 claim_is_live() {
@@ -202,21 +199,12 @@ if [ -n "${SUTANDO_TASK_EVENT_HANDLER:-}" ] && [ -x "$SUTANDO_TASK_EVENT_HANDLER
   DISPATCH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sutando-task-dispatch.XXXXXX")"
   mkdir "$DISPATCH_DIR/pending" "$DISPATCH_DIR/running" "$DISPATCH_DIR/settled" \
     "$DISPATCH_DIR/workers"
-  mkdir -p "$CLAIMS_DIR" "$FALLBACKS_DIR" "$UNSETTLED_DIR"
+  mkdir -p "$CLAIMS_DIR" "$FALLBACKS_DIR"
   shopt -s nullglob
   for claim in "$CLAIMS_DIR"/task-*.txt; do
     # Overlapping watchers preserve a live owner's claim. A dead owner's
     # record is atomically quarantined before the new sweep retries it.
     claim_is_live "$claim" || retire_stale_claim "$claim" || true
-  done
-  # A previous watcher left these unsettled. Retry the publish first: the task
-  # is already done, and re-dispatching it would repeat the handler's effects.
-  for marker in "$UNSETTLED_DIR"/*; do
-    filename="$(basename "$marker")"
-    if publish_terminal_failure "$filename" "failed"; then
-      release_task_claim "$filename" 2>/dev/null || rm -f "$CLAIMS_DIR/$filename"
-      rm -f "$marker"
-    fi
   done
   shopt -u nullglob
 fi
@@ -249,12 +237,9 @@ finish_handler_task() {
       case $? in
         0)
           echo "watch-tasks-stream: required Team handler failed for $filename (exit $rc); publishing safe terminal failure" >&2
-          # The dispatch receipt is about to be removed, so an unsettled publish
-          # needs its own artifact or later drains cannot see the task at all.
-          if ! publish_terminal_failure "$filename" "failed"; then
-            claim_settled=0
-            printf '%s\n' "$task_path" > "$UNSETTLED_DIR/$filename"
-          fi
+          # An unsettled publish leaves the claim held rather than clobbering a
+          # destination this watcher does not own; cross-restart retry is separate.
+          publish_terminal_failure "$filename" "failed" || claim_settled=0
           ;;
         1)
           printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
@@ -307,16 +292,6 @@ drain_dispatch_queue() {
   fi
   DRAIN_ACTIVE=1
   shopt -s nullglob
-  # Retry publishes that could not settle: the destination was owned by someone
-  # else then, and this is the only path that revisits them before a restart.
-  for marker in "$UNSETTLED_DIR"/*; do
-    filename="$(basename "$marker")"
-    claim_is_ours "$filename" || continue
-    if publish_terminal_failure "$filename" "failed"; then
-      release_task_claim "$filename" || true
-      rm -f "$marker"
-    fi
-  done
   # Count LIVE workers, not marker files: a worker that died before emitting
   # HANDLER_DONE leaves its marker and would retire the slot permanently.
   for marker in "$DISPATCH_DIR/running/"*; do
@@ -514,12 +489,9 @@ fallback_outstanding_handlers() {
         case $? in
           0)
             echo "watch-tasks-stream: required Team handler interrupted for $filename; publishing safe terminal failure" >&2
-            # This loop owns the receipt, so the later claim sweep never sees the
-            # task: an unsettled publish must record its own durable receipt here.
-            if ! publish_terminal_failure "$filename" "was interrupted"; then
-              claim_settled=0
-              printf '%s\n' "$task_path" > "$UNSETTLED_DIR/$filename"
-            fi
+            # As above: hold the claim rather than publish over a destination this
+            # watcher does not own.
+            publish_terminal_failure "$filename" "was interrupted" || claim_settled=0
             ;;
           1)
             printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
@@ -553,12 +525,9 @@ fallback_outstanding_handlers() {
     case $? in
       0)
         echo "watch-tasks-stream: required Team handler interrupted for $filename; publishing safe terminal failure" >&2
-        # Releasing here would drop the last record of a task that is neither
-        # delivered nor failed; the durable receipt is what a later watcher retries.
-        if ! publish_terminal_failure "$filename" "was interrupted"; then
-          claim_settled=0
-          printf '%s\n' "$task_path" > "$UNSETTLED_DIR/$filename"
-        fi
+        # Hold the claim rather than release: a task that is neither delivered nor
+        # failed must keep its last record. Cross-restart retry is separate work.
+        publish_terminal_failure "$filename" "was interrupted" || claim_settled=0
         ;;
       1)
         printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -74,6 +74,18 @@ class Harness:
         self.handler.chmod(0o755)
         self.proc: subprocess.Popen | None = None
 
+    @classmethod
+    def attach(cls, ws: Path, tmp: Path) -> "Harness":
+        """A second watcher over an existing workspace — the restart half of a
+        durability check, which one process cannot demonstrate about itself."""
+        h = cls.__new__(cls)
+        h.tmp, h.ws, h.feed = tmp, ws, tmp / "feed2"
+        h.feed.write_text("")
+        (tmp / "bin" / "fswatch").write_text(f"#!/bin/sh\nexec tail -n +1 -f {h.feed}\n")
+        (tmp / "bin" / "fswatch").chmod(0o755)
+        h.handler, h.proc = tmp / "handler.sh", None
+        return h
+
     def task(self, name: str) -> Path:
         p = self.ws / "tasks" / name
         p.write_text(f"id: {name[:-4]}\naccess_tier: team\ntask: probe\n")
@@ -321,10 +333,10 @@ def scenario_unsettled_task_is_retried_on_a_later_sweep() -> None:
         claims = h.ws / "state" / "task-event-handler-claims" / "task-stuck.txt"
         h.kill_workers()
         h.deliver("task-rrr.txt")
-        got = wait_for(lambda: (h.dispatch() / "unsettled" / "task-stuck.txt").is_file(),
+        got = wait_for(lambda: (h.ws / "state" / "task-event-handler-unsettled" / "task-stuck.txt").is_file(),
                        nudge=lambda n: h.deliver(f"task-nudge-stuck-{n}.txt"))
         check("an unsettled task keeps a dispatch artifact a later drain can see", got,
-              f"unsettled={names(h.dispatch() / 'unsettled')}")
+              f"unsettled={names(h.ws / 'state' / 'task-event-handler-unsettled')}")
         check("and its claim is still held", claims.is_file())
         # Clear the obstruction the way a provider finishing would, then prove a
         # later sweep settles it rather than waiting for a restart.
@@ -336,33 +348,48 @@ def scenario_unsettled_task_is_retried_on_a_later_sweep() -> None:
         check("the claim is released once it settles",
               wait_for(lambda: not claims.is_file(), timeout=8.0))
         check("and the retry artifact is cleaned up",
-              wait_for(lambda: not (h.dispatch() / "unsettled" / "task-stuck.txt").is_file(),
+              wait_for(lambda: not (h.ws / "state" / "task-event-handler-unsettled" / "task-stuck.txt").is_file(),
                        timeout=8.0))
     finally:
         h.stop()
 
 
-def scenario_dispatch_tempdir_is_removed_on_shutdown() -> None:
-    """Every dispatch subdir must be swept, or the tempdir survives the watcher.
-    An unswept `unsettled/` kept the whole `sutando-task-dispatch.*` tree alive."""
+def scenario_unsettled_state_survives_shutdown_and_a_later_watcher_settles_it() -> None:
+    """The retry receipt must outlive the process. In the per-process tempdir it
+    died at shutdown, leaving a whitespace result no later watcher could settle."""
     h = Harness()
-    h.task("task-leak.txt")
+    h.task("task-durable.txt")
     h.start()
     try:
         if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
-            check("tempdir scenario: slot filled", False)
+            check("durable scenario: slot filled", False)
             return
-        (h.ws / "results" / "task-leak.txt").write_text("  \n")
+        res = h.ws / "results" / "task-durable.txt"
+        res.write_text("  \n")
+        unsettled = h.ws / "state" / "task-event-handler-unsettled" / "task-durable.txt"
         h.kill_workers()
-        h.deliver("task-lll.txt")
-        wait_for(lambda: (h.dispatch() / "unsettled" / "task-leak.txt").is_file(),
-                 nudge=lambda n: h.deliver(f"task-nudge-leak-{n}.txt"))
-        d = h.dispatch()
-        check("an unsettled receipt exists before shutdown", (d / "unsettled").is_dir())
+        h.deliver("task-ddd.txt")
+        wait_for(lambda: unsettled.is_file(),
+                 nudge=lambda n: h.deliver(f"task-nudge-dur-{n}.txt"))
+        check("the retry receipt is written outside the dispatch tempdir", unsettled.is_file())
         h.stop(graceful=True)
-        check("the dispatch tempdir is removed on shutdown",
-              wait_for(lambda: not d.exists(), timeout=15.0),
-              f"survived with {[p.name for p in d.iterdir()] if d.exists() else '-'}")
+        check("it survives shutdown", unsettled.is_file(),
+              "receipt died with the process")
+        check("and the claim is NOT released as settled",
+              (h.ws / "state" / "task-event-handler-claims" / "task-durable.txt").is_file())
+        # The provider is gone for good; a fresh watcher must settle it.
+        res.unlink()
+        h2 = Harness.attach(h.ws, h.tmp)
+        try:
+            h2.start()
+            check("a later watcher settles it with no operator action",
+                  wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text(),
+                           nudge=lambda n: h2.deliver(f"task-nudge-dur2-{n}.txt")),
+                  f"body={res.read_text()[:50]!r}" if res.exists() else "still absent")
+            check("and the receipt is cleaned up",
+                  wait_for(lambda: not unsettled.is_file(), timeout=10.0))
+        finally:
+            h2.stop()
     finally:
         h.stop()
 
@@ -375,7 +402,7 @@ def main() -> int:
     scenario_unready_destination_is_left_untouched_and_unsettled()
     scenario_answer_landing_during_the_reap_stays_deliverable()
     scenario_unsettled_task_is_retried_on_a_later_sweep()
-    scenario_dispatch_tempdir_is_removed_on_shutdown()
+    scenario_unsettled_state_survives_shutdown_and_a_later_watcher_settles_it()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -21,7 +21,7 @@ def check(name: str, cond: bool, detail: str = "") -> None:
         FAILURES.append(name)
 
 
-def wait_for(pred, timeout: float = 12.0, step: float = 0.25) -> bool:
+def wait_for(pred, timeout: float = 30.0, step: float = 0.25) -> bool:
     end = time.time() + timeout
     while time.time() < end:
         if pred():
@@ -45,12 +45,8 @@ def names(d: Path | None) -> set[str]:
 
 
 class Harness:
-    """One isolated watcher: own workspace, own TMPDIR, own session.
-
-    start_new_session because cleanup() ends in `kill 0`, which would otherwise
-    signal this test's process group. Only pids recorded here are ever killed —
-    never `pkill -f watch-tasks-stream`, which matches the operator's watcher.
-    """
+    """One isolated watcher: own workspace, TMPDIR and session (cleanup() ends in
+    `kill 0`). Only pids recorded here are killed — never a pattern match."""
 
     def __init__(self) -> None:
         self.tmp = Path(tempfile.mkdtemp(prefix="reap-test-"))
@@ -126,7 +122,7 @@ class Harness:
 
 
 def scenario_slot_recovery() -> None:
-    """The defect: dead workers held both slots, so nothing dispatched again."""
+    """Dead workers held both slots, so nothing dispatched again."""
     h = Harness()
     h.task("task-aaa.txt")
     h.task("task-bbb.txt")
@@ -147,11 +143,8 @@ def scenario_slot_recovery() -> None:
 
 
 def scenario_reap_publishes_only_without_an_exact_result() -> None:
-    """Controls for both false positives, driven through the production reap.
-
-    A prefix-colliding archive entry and a zero-byte live result must each still
-    yield the terminal failure; a genuine archived result must still suppress it.
-    """
+    """A prefix-colliding archive must not satisfy the id; a genuine archived
+    result must still suppress the failure (so the fix is not "always publish")."""
     h = Harness()
     arch = h.ws / "results" / "archive"
     # `task-1234` must not satisfy `task-123` (prefix collision).
@@ -184,22 +177,46 @@ def scenario_reap_publishes_only_without_an_exact_result() -> None:
 
 
 def scenario_empty_live_result_is_not_delivered() -> None:
-    """A zero-byte result is the undeliverable placeholder state, not an answer."""
+    """Empty AND whitespace-only bodies are undeliverable placeholders, per the
+    shared result_ready contract — neither may suppress the terminal failure."""
     h = Harness()
     h.task("task-456.txt")
+    h.task("task-space.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 2):
+            check("placeholder scenario: both slots filled", False)
+            return
+        (h.ws / "results" / "task-456.txt").write_text("")
+        (h.ws / "results" / "task-space.txt").write_text("   \n\t\n")
+        h.kill_workers()
+        h.deliver("task-yyy.txt")
+        for tid, label in (("task-456.txt", "a zero-byte"), ("task-space.txt", "a whitespace-only")):
+            res = h.ws / "results" / tid
+            check(f"{label} live result does NOT suppress the terminal failure",
+                  wait_for(lambda r=res: r.is_file() and FAILURE_TEXT in r.read_text()),
+                  f"body={res.read_text()[:40]!r}" if res.exists() else "missing")
+    finally:
+        h.stop()
+
+
+def scenario_whitespace_archived_result_is_not_delivered() -> None:
+    """An archived body that is whitespace-only never delivered an answer, so the
+    reap must still publish rather than release the claim as success."""
+    h = Harness()
+    (h.ws / "results" / "archive" / "task-wsa-999.txt").write_text("  \n \n")
+    h.task("task-wsa.txt")
     h.start()
     try:
         if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
-            check("empty-result scenario: slot filled", False)
+            check("archived-whitespace scenario: slot filled", False)
             return
-        (h.ws / "results" / "task-456.txt").write_text("")
         h.kill_workers()
-        h.deliver("task-yyy.txt")
-        res = h.ws / "results" / "task-456.txt"
-        check("a zero-byte live result does NOT suppress the terminal failure",
-              wait_for(lambda: res.is_file() and res.stat().st_size > 0)
-              and FAILURE_TEXT in res.read_text(),
-              f"size={res.stat().st_size if res.exists() else 'missing'}")
+        h.deliver("task-www.txt")
+        res = h.ws / "results" / "task-wsa.txt"
+        check("a whitespace-only ARCHIVED result does NOT suppress the failure",
+              wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text()),
+              f"exists={res.exists()}")
     finally:
         h.stop()
 
@@ -208,6 +225,7 @@ def main() -> int:
     scenario_slot_recovery()
     scenario_reap_publishes_only_without_an_exact_result()
     scenario_empty_live_result_is_not_delivered()
+    scenario_whitespace_archived_result_is_not_delivered()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -225,7 +225,8 @@ def scenario_whitespace_archived_result_is_not_delivered() -> None:
         h.deliver("task-www.txt")
         res = h.ws / "results" / "task-wsa.txt"
         check("a whitespace-only ARCHIVED result does NOT suppress the failure",
-              wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text()),
+              wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text(),
+                       nudge=lambda n: h.deliver(f"task-nudge-wsa-{n}.txt")),
               f"exists={res.exists()}")
     finally:
         h.stop()
@@ -294,6 +295,42 @@ def scenario_answer_landing_during_the_reap_stays_deliverable() -> None:
         h.stop()
 
 
+def scenario_unsettled_task_is_retried_on_a_later_sweep() -> None:
+    """An unsettled publish keeps a retry artifact: once the destination clears,
+    a later drain settles it, without a watcher restart."""
+    h = Harness()
+    h.task("task-stuck.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
+            check("retry scenario: slot filled", False)
+            return
+        res = h.ws / "results" / "task-stuck.txt"
+        res.write_text("   \n")
+        claims = h.ws / "state" / "task-event-handler-claims" / "task-stuck.txt"
+        h.kill_workers()
+        h.deliver("task-rrr.txt")
+        got = wait_for(lambda: (h.dispatch() / "unsettled" / "task-stuck.txt").is_file(),
+                       nudge=lambda n: h.deliver(f"task-nudge-stuck-{n}.txt"))
+        check("an unsettled task keeps a dispatch artifact a later drain can see", got,
+              f"unsettled={names(h.dispatch() / 'unsettled')}")
+        check("and its claim is still held", claims.is_file())
+        # Clear the obstruction the way a provider finishing would, then prove a
+        # later sweep settles it rather than waiting for a restart.
+        res.unlink()
+        settled = wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text(),
+                           nudge=lambda n: h.deliver(f"task-nudge-clear-{n}.txt"))
+        check("a later sweep settles it once the destination is free", settled,
+              f"body={res.read_text()[:50]!r}" if res.exists() else "still absent")
+        check("the claim is released once it settles",
+              wait_for(lambda: not claims.is_file(), timeout=8.0))
+        check("and the retry artifact is cleaned up",
+              wait_for(lambda: not (h.dispatch() / "unsettled" / "task-stuck.txt").is_file(),
+                       timeout=8.0))
+    finally:
+        h.stop()
+
+
 def main() -> int:
     scenario_slot_recovery()
     scenario_reap_publishes_only_without_an_exact_result()
@@ -301,6 +338,7 @@ def main() -> int:
     scenario_whitespace_archived_result_is_not_delivered()
     scenario_unready_destination_is_left_untouched_and_unsettled()
     scenario_answer_landing_during_the_reap_stays_deliverable()
+    scenario_unsettled_task_is_retried_on_a_later_sweep()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""A handler worker that dies without emitting HANDLER_DONE must not hold its slot.
+
+`drain_dispatch_queue()` counted FILES in `running/` rather than live workers, so
+a worker killed (or reaped) before it emitted `HANDLER_DONE` left its marker
+forever. With TASK_HANDLER_WORKERS=2, two such deaths stall the required-handler
+lane for the life of the watcher: every later Team-tier task queues in `pending/`
+and is never processed, while health-check still reports the watcher healthy.
+
+Observed live 2026-08-13 — 2 running markers, both worker pids dead, one task
+pending 10+ minutes, zero dispatches.
+
+WHY A REAL-PROCESS TEST: the defect lives in the interaction between the drain
+loop, the worker receipts and the FIFO, and `watch-tasks-stream.sh` has no
+BASH_SOURCE guard, so its functions cannot be sourced in isolation.
+
+CLEANUP DISCIPLINE (from tests/watch-tasks-stream-sentinel-ownership.test.py):
+`cleanup()` ends in `kill 0`, which signals the whole process group — every
+watcher here is started with start_new_session=True or the code under test kills
+this test. Never `pkill -f watch-tasks-stream`: that pattern matches the
+operator's own live watcher. Only pids this test recorded are killed.
+
+Run: python3 tests/watch-tasks-stream-dead-worker-reap.test.py
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    print(("  ok   " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        FAILURES.append(name)
+
+
+def wait_for(pred, timeout: float = 12.0, step: float = 0.25) -> bool:
+    end = time.time() + timeout
+    while time.time() < end:
+        if pred():
+            return True
+        time.sleep(step)
+    return False
+
+
+def write_stub_fswatch(bin_dir: Path, feed: Path) -> None:
+    """Emitting stub: holds stdout open AND replays paths the test appends.
+
+    The blocking `exec sleep` stub used by the sentinel test is not enough here —
+    the stall only becomes observable when a NEW task arrives and finds no free
+    slot, and arrival is what triggers a drain. `tail -f` gives both properties
+    in one process whose death closes the fd.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "fswatch"
+    stub.write_text("#!/bin/sh\nexec tail -n +1 -f " + str(feed) + "\n")
+    stub.chmod(0o755)
+
+
+def write_stub_handler(path: Path) -> None:
+    """--probe exits 4 (required handler); a real run blocks so it can be killed."""
+    path.write_text(
+        "#!/bin/sh\n"
+        'for a in "$@"; do [ "$a" = "--probe" ] && exit 4; done\n'
+        "exec sleep 100000\n"
+    )
+    path.chmod(0o755)
+
+
+def dispatch_dir(tmp: Path) -> Path | None:
+    cands = sorted(tmp.glob("sutando-task-dispatch.*"), key=lambda p: p.stat().st_mtime)
+    return cands[-1] if cands else None
+
+
+def names(d: Path | None) -> set[str]:
+    if d is None or not d.is_dir():
+        return set()
+    return {p.name for p in d.iterdir() if p.is_file()}
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="reap-test-"))
+    ws = tmp / "ws"
+    (ws / "tasks").mkdir(parents=True)
+    (ws / "results").mkdir()
+    (ws / "state").mkdir()
+    feed = tmp / "feed"
+    feed.write_text("")
+    handler = tmp / "handler.sh"
+    write_stub_handler(handler)
+    write_stub_fswatch(tmp / "bin", feed)
+
+    def task(name: str) -> Path:
+        p = ws / "tasks" / name
+        p.write_text(f"id: {name[:-4]}\naccess_tier: team\ntask: probe\n")
+        return p
+
+    # A and B fill both worker slots via the startup sweep; C arrives later.
+    a, b = task("task-aaa.txt"), task("task-bbb.txt")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{tmp/'bin'}:{env['PATH']}"
+    env["TMPDIR"] = str(tmp)                      # makes the watcher's mktemp dirs findable
+    env["SUTANDO_WORKSPACE_DIR"] = str(ws)
+    env["SUTANDO_RESULTS_DIR"] = str(ws / "results")
+    env["SUTANDO_TASK_EVENT_HANDLER"] = str(handler)
+
+    # The watched dir is $1, NOT an env var — passing it as an env var would
+    # silently fall through to the resolver and watch the REAL workspace.
+    proc = subprocess.Popen(
+        ["bash", "src/watch-tasks-stream.sh", str(ws / "tasks")], cwd=str(REPO), env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+    )
+    try:
+        got = wait_for(lambda: len(names(dispatch_dir(tmp) and dispatch_dir(tmp) / "running")) >= 2)
+        d = dispatch_dir(tmp)
+        check("both worker slots filled by the startup sweep", got,
+              f"running={names(d and d/'running')} dispatch_dir={d}")
+        if not got:
+            return 1
+
+        # Record the worker pids, then kill them WITHOUT letting them emit
+        # HANDLER_DONE — exactly what a crashed/reaped worker leaves behind.
+        pids = []
+        for r in (d / "workers").iterdir():
+            try:
+                pids.append(int(r.read_text().strip()))
+            except (ValueError, OSError):
+                pass
+        check("worker receipts recorded pids", len(pids) >= 2, str(pids))
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        check("both workers are dead",
+              wait_for(lambda: all(not _alive(p) for p in pids), 8.0), str(pids))
+
+        # C arrives. Its arrival triggers a drain; with both markers orphaned the
+        # buggy drain sees running_count == TASK_HANDLER_WORKERS and never spawns.
+        c = task("task-ccc.txt")
+        with feed.open("a") as fh:
+            fh.write(str(c.resolve()) + "\n")
+
+        dispatched = wait_for(lambda: "task-ccc.txt" in names(dispatch_dir(tmp) / "running"), 12.0)
+        d = dispatch_dir(tmp)
+        check("a task arriving after both workers died still gets dispatched",
+              dispatched,
+              f"pending={names(d/'pending')} running={names(d/'running')} "
+              "— dead workers still hold both slots (the defect)")
+    finally:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        proc.wait(timeout=5)
+
+    if FAILURES:
+        print(f"\n{len(FAILURES)} failure(s)")
+        return 1
+    print("\nPASS — dead handler workers do not hold dispatch slots")
+    return 0
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -394,6 +394,32 @@ def scenario_unsettled_state_survives_shutdown_and_a_later_watcher_settles_it() 
         h.stop()
 
 
+def scenario_shutdown_while_the_receipt_is_still_running() -> None:
+    """SIGTERM before any reap: cleanup's FIRST loop owns the running receipt, so
+    the later claim sweep never sees the task and this loop must record it."""
+    h = Harness()
+    h.task("task-early.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: "task-early.txt" in names(h.dispatch() and h.dispatch() / "running")):
+            check("early-shutdown scenario: receipt is in running/", False)
+            return
+        res = h.ws / "results" / "task-early.txt"
+        res.write_text("  \n")
+        # No kill_workers() and no drain: the worker is alive and the receipt has
+        # never been reaped, which is the ordering the other scenarios skip past.
+        h.stop(graceful=True)
+        unsettled = h.ws / "state" / "task-event-handler-unsettled" / "task-early.txt"
+        claim = h.ws / "state" / "task-event-handler-claims" / "task-early.txt"
+        check("a direct shutdown still records a durable retry receipt", unsettled.is_file(),
+              f"unsettled={names(h.ws / 'state' / 'task-event-handler-unsettled')}")
+        check("and does not release the claim as settled", claim.is_file())
+        check("and leaves the unready body untouched", res.read_text() == "  \n",
+              f"body={res.read_text()[:40]!r}")
+    finally:
+        h.stop()
+
+
 def main() -> int:
     scenario_slot_recovery()
     scenario_reap_publishes_only_without_an_exact_result()
@@ -403,6 +429,7 @@ def main() -> int:
     scenario_answer_landing_during_the_reap_stays_deliverable()
     scenario_unsettled_task_is_retried_on_a_later_sweep()
     scenario_unsettled_state_survives_shutdown_and_a_later_watcher_settles_it()
+    scenario_shutdown_while_the_receipt_is_still_running()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -182,9 +182,9 @@ def scenario_reap_publishes_only_without_an_exact_result() -> None:
         h.stop()
 
 
-def scenario_empty_live_result_is_not_delivered() -> None:
-    """Empty AND whitespace-only bodies are undeliverable placeholders, per the
-    shared result_ready contract — neither may suppress the terminal failure."""
+def scenario_placeholder_never_settles_the_task_as_success() -> None:
+    """Empty and whitespace-only bodies are undeliverable, so neither may settle
+    the task — the claim is held rather than released as if an answer existed."""
     h = Harness()
     h.task("task-456.txt")
     h.task("task-space.txt")
@@ -195,14 +195,17 @@ def scenario_empty_live_result_is_not_delivered() -> None:
             return
         (h.ws / "results" / "task-456.txt").write_text("")
         (h.ws / "results" / "task-space.txt").write_text("   \n\t\n")
+        claims = h.ws / "state" / "task-event-handler-claims"
         h.kill_workers()
         h.deliver("task-yyy.txt")
+        wait_for(lambda: False, timeout=6.0,
+                 nudge=lambda n: h.deliver(f"task-nudge-ph-{n}.txt"))
         for tid, label in (("task-456.txt", "a zero-byte"), ("task-space.txt", "a whitespace-only")):
             res = h.ws / "results" / tid
-            check(f"{label} live result does NOT suppress the terminal failure",
-                  wait_for(lambda r=res: r.is_file() and FAILURE_TEXT in r.read_text(),
-                           nudge=lambda n, t=tid: h.deliver(f"task-nudge-{t[:-4]}-{n}.txt")),
-                  f"body={res.read_text()[:40]!r}" if res.exists() else "missing")
+            check(f"{label} live result is not overwritten by the failure",
+                  FAILURE_TEXT not in res.read_text(), f"body={res.read_text()[:40]!r}")
+            check(f"{label} live result does NOT settle the claim as success",
+                  (claims / tid).is_file(), "claim was released despite no answer")
     finally:
         h.stop()
 
@@ -228,30 +231,65 @@ def scenario_whitespace_archived_result_is_not_delivered() -> None:
         h.stop()
 
 
-def scenario_unready_body_is_preserved_not_overwritten() -> None:
-    """The bytes of an unready destination survive the terminal failure. A dead
-    wrapper pid does not prove its writer stopped, so nothing may be clobbered."""
+def scenario_unready_destination_is_left_untouched_and_unsettled() -> None:
+    """A destination a provider may still own is neither read-then-moved nor
+    replaced: no publish, no `.superseded.*`, and the claim stays held."""
     h = Harness()
     h.task("task-keep.txt")
     h.start()
     try:
         if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
-            check("preserve scenario: slot filled", False)
+            check("untouched scenario: slot filled", False)
             return
-        # Unready by the shared contract but carrying bytes: any body that
-        # strips to text is a real answer and must be left alone entirely.
         placeholder = "   \n\t\n"
-        (h.ws / "results" / "task-keep.txt").write_text(placeholder)
+        res = h.ws / "results" / "task-keep.txt"
+        res.write_text(placeholder)
+        claims = h.ws / "state" / "task-event-handler-claims" / "task-keep.txt"
+        held_before = claims.is_file()
         h.kill_workers()
         h.deliver("task-zzz.txt")
-        res = h.ws / "results" / "task-keep.txt"
-        check("the terminal failure is still published over an unready body",
-              wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text()),
-              f"body={res.read_text()[:40]!r}" if res.exists() else "missing")
-        kept = [p for p in (h.ws / "results").glob(".task-keep.txt.superseded.*")
-                if p.read_text() == placeholder]
-        check("the unready bytes are preserved, not destroyed", bool(kept),
-              f"superseded files={[p.name for p in (h.ws / 'results').glob('.task-keep.txt.superseded.*')]}")
+        # Give the reap the same room the publishing scenarios get, then assert
+        # the invariant: it must NOT have acted on a destination it cannot own.
+        wait_for(lambda: False, timeout=6.0,
+                 nudge=lambda n: h.deliver(f"task-nudge-keep-{n}.txt"))
+        check("an unready destination is left byte-for-byte untouched",
+              res.read_text() == placeholder, f"body={res.read_text()[:60]!r}")
+        check("no terminal failure is published over it",
+              FAILURE_TEXT not in res.read_text())
+        check("it is not moved aside to a hidden sibling either",
+              not list((h.ws / "results").glob(".task-keep.txt.superseded.*")),
+              f"found={[p.name for p in (h.ws / 'results').glob('.task-keep.txt.superseded.*')]}")
+        check("the claim is left held, so the task is unsettled not falsely done",
+              held_before and claims.is_file(),
+              f"held_before={held_before} still_held={claims.is_file()}")
+    finally:
+        h.stop()
+
+
+def scenario_answer_landing_during_the_reap_stays_deliverable() -> None:
+    """The control qingyun-wu asked for: an answer arriving after the readiness
+    check must remain at the DELIVERY path, not a hidden sibling."""
+    h = Harness()
+    h.task("task-late.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
+            check("late-answer scenario: slot filled", False)
+            return
+        res = h.ws / "results" / "task-late.txt"
+        res.write_text("  \n")
+        h.kill_workers()
+        h.deliver("task-qqq.txt")
+        answer = "the answer the provider finished writing\n"
+        tmp = h.ws / "results" / ".late-writer.tmp"
+        tmp.write_text(answer)
+        os.replace(tmp, res)
+        wait_for(lambda: False, timeout=6.0,
+                 nudge=lambda n: h.deliver(f"task-nudge-late-{n}.txt"))
+        check("an answer that lands during the reap is still at the delivery path",
+              res.read_text() == answer, f"delivery path holds {res.read_text()[:60]!r}")
+        check("and was not relocated to a hidden sibling",
+              not list((h.ws / "results").glob(".task-late.txt.superseded.*")))
     finally:
         h.stop()
 
@@ -259,9 +297,10 @@ def scenario_unready_body_is_preserved_not_overwritten() -> None:
 def main() -> int:
     scenario_slot_recovery()
     scenario_reap_publishes_only_without_an_exact_result()
-    scenario_empty_live_result_is_not_delivered()
+    scenario_placeholder_never_settles_the_task_as_success()
     scenario_whitespace_archived_result_is_not_delivered()
-    scenario_unready_body_is_preserved_not_overwritten()
+    scenario_unready_destination_is_left_untouched_and_unsettled()
+    scenario_answer_landing_during_the_reap_stays_deliverable()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -318,106 +318,7 @@ def scenario_answer_landing_during_the_reap_stays_deliverable() -> None:
         h.stop()
 
 
-def scenario_unsettled_task_is_retried_on_a_later_sweep() -> None:
-    """An unsettled publish keeps a retry artifact: once the destination clears,
-    a later drain settles it, without a watcher restart."""
-    h = Harness()
-    h.task("task-stuck.txt")
-    h.start()
-    try:
-        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
-            check("retry scenario: slot filled", False)
-            return
-        res = h.ws / "results" / "task-stuck.txt"
-        res.write_text("   \n")
-        claims = h.ws / "state" / "task-event-handler-claims" / "task-stuck.txt"
-        h.kill_workers()
-        h.deliver("task-rrr.txt")
-        got = wait_for(lambda: (h.ws / "state" / "task-event-handler-unsettled" / "task-stuck.txt").is_file(),
-                       nudge=lambda n: h.deliver(f"task-nudge-stuck-{n}.txt"))
-        check("an unsettled task keeps a dispatch artifact a later drain can see", got,
-              f"unsettled={names(h.ws / 'state' / 'task-event-handler-unsettled')}")
-        check("and its claim is still held", claims.is_file())
-        # Clear the obstruction the way a provider finishing would, then prove a
-        # later sweep settles it rather than waiting for a restart.
-        res.unlink()
-        settled = wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text(),
-                           nudge=lambda n: h.deliver(f"task-nudge-clear-{n}.txt"))
-        check("a later sweep settles it once the destination is free", settled,
-              f"body={res.read_text()[:50]!r}" if res.exists() else "still absent")
-        check("the claim is released once it settles",
-              wait_for(lambda: not claims.is_file(), timeout=8.0))
-        check("and the retry artifact is cleaned up",
-              wait_for(lambda: not (h.ws / "state" / "task-event-handler-unsettled" / "task-stuck.txt").is_file(),
-                       timeout=8.0))
-    finally:
-        h.stop()
 
-
-def scenario_unsettled_state_survives_shutdown_and_a_later_watcher_settles_it() -> None:
-    """The retry receipt must outlive the process. In the per-process tempdir it
-    died at shutdown, leaving a whitespace result no later watcher could settle."""
-    h = Harness()
-    h.task("task-durable.txt")
-    h.start()
-    try:
-        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
-            check("durable scenario: slot filled", False)
-            return
-        res = h.ws / "results" / "task-durable.txt"
-        res.write_text("  \n")
-        unsettled = h.ws / "state" / "task-event-handler-unsettled" / "task-durable.txt"
-        h.kill_workers()
-        h.deliver("task-ddd.txt")
-        wait_for(lambda: unsettled.is_file(),
-                 nudge=lambda n: h.deliver(f"task-nudge-dur-{n}.txt"))
-        check("the retry receipt is written outside the dispatch tempdir", unsettled.is_file())
-        h.stop(graceful=True)
-        check("it survives shutdown", unsettled.is_file(),
-              "receipt died with the process")
-        check("and the claim is NOT released as settled",
-              (h.ws / "state" / "task-event-handler-claims" / "task-durable.txt").is_file())
-        # The provider is gone for good; a fresh watcher must settle it.
-        res.unlink()
-        h2 = Harness.attach(h.ws, h.tmp)
-        try:
-            h2.start()
-            check("a later watcher settles it with no operator action",
-                  wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text(),
-                           nudge=lambda n: h2.deliver(f"task-nudge-dur2-{n}.txt")),
-                  f"body={res.read_text()[:50]!r}" if res.exists() else "still absent")
-            check("and the receipt is cleaned up",
-                  wait_for(lambda: not unsettled.is_file(), timeout=10.0))
-        finally:
-            h2.stop()
-    finally:
-        h.stop()
-
-
-def scenario_shutdown_while_the_receipt_is_still_running() -> None:
-    """SIGTERM before any reap: cleanup's FIRST loop owns the running receipt, so
-    the later claim sweep never sees the task and this loop must record it."""
-    h = Harness()
-    h.task("task-early.txt")
-    h.start()
-    try:
-        if not wait_for(lambda: "task-early.txt" in names(h.dispatch() and h.dispatch() / "running")):
-            check("early-shutdown scenario: receipt is in running/", False)
-            return
-        res = h.ws / "results" / "task-early.txt"
-        res.write_text("  \n")
-        # No kill_workers() and no drain: the worker is alive and the receipt has
-        # never been reaped, which is the ordering the other scenarios skip past.
-        h.stop(graceful=True)
-        unsettled = h.ws / "state" / "task-event-handler-unsettled" / "task-early.txt"
-        claim = h.ws / "state" / "task-event-handler-claims" / "task-early.txt"
-        check("a direct shutdown still records a durable retry receipt", unsettled.is_file(),
-              f"unsettled={names(h.ws / 'state' / 'task-event-handler-unsettled')}")
-        check("and does not release the claim as settled", claim.is_file())
-        check("and leaves the unready body untouched", res.read_text() == "  \n",
-              f"body={res.read_text()[:40]!r}")
-    finally:
-        h.stop()
 
 
 def main() -> int:
@@ -427,9 +328,6 @@ def main() -> int:
     scenario_whitespace_archived_result_is_not_delivered()
     scenario_unready_destination_is_left_untouched_and_unsettled()
     scenario_answer_landing_during_the_reap_stays_deliverable()
-    scenario_unsettled_task_is_retried_on_a_later_sweep()
-    scenario_unsettled_state_survives_shutdown_and_a_later_watcher_settles_it()
-    scenario_shutdown_while_the_receipt_is_still_running()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -117,14 +117,25 @@ class Harness:
         wait_for(lambda: all(not alive(p) for p in pids), 8.0)
         return pids
 
-    def stop(self) -> None:
+    def stop(self, graceful: bool = False) -> None:
+        """SIGKILL by default — fast and certain. `graceful` sends TERM to the
+        watcher so its trap runs, which is the only way to observe teardown."""
         if self.proc is None:
             return
+        if graceful:
+            try:
+                self.proc.send_signal(signal.SIGTERM)
+                self.proc.wait(timeout=15)
+            except (ProcessLookupError, subprocess.TimeoutExpired):
+                pass
         try:
             os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
             pass
-        self.proc.wait(timeout=5)
+        try:
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
 
 
 def scenario_slot_recovery() -> None:
@@ -331,6 +342,31 @@ def scenario_unsettled_task_is_retried_on_a_later_sweep() -> None:
         h.stop()
 
 
+def scenario_dispatch_tempdir_is_removed_on_shutdown() -> None:
+    """Every dispatch subdir must be swept, or the tempdir survives the watcher.
+    An unswept `unsettled/` kept the whole `sutando-task-dispatch.*` tree alive."""
+    h = Harness()
+    h.task("task-leak.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
+            check("tempdir scenario: slot filled", False)
+            return
+        (h.ws / "results" / "task-leak.txt").write_text("  \n")
+        h.kill_workers()
+        h.deliver("task-lll.txt")
+        wait_for(lambda: (h.dispatch() / "unsettled" / "task-leak.txt").is_file(),
+                 nudge=lambda n: h.deliver(f"task-nudge-leak-{n}.txt"))
+        d = h.dispatch()
+        check("an unsettled receipt exists before shutdown", (d / "unsettled").is_dir())
+        h.stop(graceful=True)
+        check("the dispatch tempdir is removed on shutdown",
+              wait_for(lambda: not d.exists(), timeout=15.0),
+              f"survived with {[p.name for p in d.iterdir()] if d.exists() else '-'}")
+    finally:
+        h.stop()
+
+
 def main() -> int:
     scenario_slot_recovery()
     scenario_reap_publishes_only_without_an_exact_result()
@@ -339,6 +375,7 @@ def main() -> int:
     scenario_unready_destination_is_left_untouched_and_unsettled()
     scenario_answer_landing_during_the_reap_stays_deliverable()
     scenario_unsettled_task_is_retried_on_a_later_sweep()
+    scenario_dispatch_tempdir_is_removed_on_shutdown()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -1,27 +1,6 @@
 #!/usr/bin/env python3
-"""A handler worker that dies without emitting HANDLER_DONE must not hold its slot.
-
-`drain_dispatch_queue()` counted FILES in `running/` rather than live workers, so
-a worker killed (or reaped) before it emitted `HANDLER_DONE` left its marker
-forever. With TASK_HANDLER_WORKERS=2, two such deaths stall the required-handler
-lane for the life of the watcher: every later Team-tier task queues in `pending/`
-and is never processed, while health-check still reports the watcher healthy.
-
-Observed live 2026-08-13 — 2 running markers, both worker pids dead, one task
-pending 10+ minutes, zero dispatches.
-
-WHY A REAL-PROCESS TEST: the defect lives in the interaction between the drain
-loop, the worker receipts and the FIFO, and `watch-tasks-stream.sh` has no
-BASH_SOURCE guard, so its functions cannot be sourced in isolation.
-
-CLEANUP DISCIPLINE (from tests/watch-tasks-stream-sentinel-ownership.test.py):
-`cleanup()` ends in `kill 0`, which signals the whole process group — every
-watcher here is started with start_new_session=True or the code under test kills
-this test. Never `pkill -f watch-tasks-stream`: that pattern matches the
-operator's own live watcher. Only pids this test recorded are killed.
-
-Run: python3 tests/watch-tasks-stream-dead-worker-reap.test.py
-"""
+"""A dead handler worker must not hold its dispatch slot, and the reap must publish
+a terminal failure unless an EXACT, non-empty result for that task already exists."""
 from __future__ import annotations
 
 import os
@@ -33,6 +12,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 FAILURES: list[str] = []
+FAILURE_TEXT = "could not safely process"
 
 
 def check(name: str, cond: bool, detail: str = "") -> None:
@@ -50,33 +30,12 @@ def wait_for(pred, timeout: float = 12.0, step: float = 0.25) -> bool:
     return False
 
 
-def write_stub_fswatch(bin_dir: Path, feed: Path) -> None:
-    """Emitting stub: holds stdout open AND replays paths the test appends.
-
-    The blocking `exec sleep` stub used by the sentinel test is not enough here —
-    the stall only becomes observable when a NEW task arrives and finds no free
-    slot, and arrival is what triggers a drain. `tail -f` gives both properties
-    in one process whose death closes the fd.
-    """
-    bin_dir.mkdir(parents=True, exist_ok=True)
-    stub = bin_dir / "fswatch"
-    stub.write_text("#!/bin/sh\nexec tail -n +1 -f " + str(feed) + "\n")
-    stub.chmod(0o755)
-
-
-def write_stub_handler(path: Path) -> None:
-    """--probe exits 4 (required handler); a real run blocks so it can be killed."""
-    path.write_text(
-        "#!/bin/sh\n"
-        'for a in "$@"; do [ "$a" = "--probe" ] && exit 4; done\n'
-        "exec sleep 100000\n"
-    )
-    path.chmod(0o755)
-
-
-def dispatch_dir(tmp: Path) -> Path | None:
-    cands = sorted(tmp.glob("sutando-task-dispatch.*"), key=lambda p: p.stat().st_mtime)
-    return cands[-1] if cands else None
+def alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
 
 
 def names(d: Path | None) -> set[str]:
@@ -85,96 +44,175 @@ def names(d: Path | None) -> set[str]:
     return {p.name for p in d.iterdir() if p.is_file()}
 
 
-def main() -> int:
-    tmp = Path(tempfile.mkdtemp(prefix="reap-test-"))
-    ws = tmp / "ws"
-    (ws / "tasks").mkdir(parents=True)
-    (ws / "results").mkdir()
-    (ws / "state").mkdir()
-    feed = tmp / "feed"
-    feed.write_text("")
-    handler = tmp / "handler.sh"
-    write_stub_handler(handler)
-    write_stub_fswatch(tmp / "bin", feed)
+class Harness:
+    """One isolated watcher: own workspace, own TMPDIR, own session.
 
-    def task(name: str) -> Path:
-        p = ws / "tasks" / name
+    start_new_session because cleanup() ends in `kill 0`, which would otherwise
+    signal this test's process group. Only pids recorded here are ever killed —
+    never `pkill -f watch-tasks-stream`, which matches the operator's watcher.
+    """
+
+    def __init__(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="reap-test-"))
+        self.ws = self.tmp / "ws"
+        (self.ws / "tasks").mkdir(parents=True)
+        (self.ws / "results" / "archive").mkdir(parents=True)
+        (self.ws / "state").mkdir()
+        self.feed = self.tmp / "feed"
+        self.feed.write_text("")
+        # `tail -f` holds stdout open AND emits on demand: the stall is only
+        # observable when a NEW task arrives, and arrival is what drains.
+        stub_dir = self.tmp / "bin"
+        stub_dir.mkdir()
+        (stub_dir / "fswatch").write_text(f"#!/bin/sh\nexec tail -n +1 -f {self.feed}\n")
+        (stub_dir / "fswatch").chmod(0o755)
+        self.handler = self.tmp / "handler.sh"
+        self.handler.write_text(
+            '#!/bin/sh\nfor a in "$@"; do [ "$a" = "--probe" ] && exit 4; done\nexec sleep 100000\n')
+        self.handler.chmod(0o755)
+        self.proc: subprocess.Popen | None = None
+
+    def task(self, name: str) -> Path:
+        p = self.ws / "tasks" / name
         p.write_text(f"id: {name[:-4]}\naccess_tier: team\ntask: probe\n")
         return p
 
-    # A and B fill both worker slots via the startup sweep; C arrives later.
-    a, b = task("task-aaa.txt"), task("task-bbb.txt")
+    def start(self) -> None:
+        env = dict(os.environ)
+        env["PATH"] = f"{self.tmp/'bin'}:{env['PATH']}"
+        env["TMPDIR"] = str(self.tmp)
+        env["SUTANDO_RESULTS_DIR"] = str(self.ws / "results")
+        env["SUTANDO_TASK_EVENT_HANDLER"] = str(self.handler)
+        # The watched dir is $1, NOT an env var — passing it as one would fall
+        # through to the resolver and watch the REAL workspace.
+        self.proc = subprocess.Popen(
+            ["bash", "src/watch-tasks-stream.sh", str(self.ws / "tasks")],
+            cwd=str(REPO), env=env, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, start_new_session=True)
 
-    env = dict(os.environ)
-    env["PATH"] = f"{tmp/'bin'}:{env['PATH']}"
-    env["TMPDIR"] = str(tmp)                      # makes the watcher's mktemp dirs findable
-    env["SUTANDO_WORKSPACE_DIR"] = str(ws)
-    env["SUTANDO_RESULTS_DIR"] = str(ws / "results")
-    env["SUTANDO_TASK_EVENT_HANDLER"] = str(handler)
+    def dispatch(self) -> Path | None:
+        c = sorted(self.tmp.glob("sutando-task-dispatch.*"), key=lambda p: p.stat().st_mtime)
+        return c[-1] if c else None
 
-    # The watched dir is $1, NOT an env var — passing it as an env var would
-    # silently fall through to the resolver and watch the REAL workspace.
-    proc = subprocess.Popen(
-        ["bash", "src/watch-tasks-stream.sh", str(ws / "tasks")], cwd=str(REPO), env=env,
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
-    )
-    try:
-        got = wait_for(lambda: len(names(dispatch_dir(tmp) and dispatch_dir(tmp) / "running")) >= 2)
-        d = dispatch_dir(tmp)
-        check("both worker slots filled by the startup sweep", got,
-              f"running={names(d and d/'running')} dispatch_dir={d}")
-        if not got:
-            return 1
+    def deliver(self, name: str) -> None:
+        p = self.task(name)
+        with self.feed.open("a") as fh:
+            fh.write(str(p.resolve()) + "\n")
 
-        # Record the worker pids, then kill them WITHOUT letting them emit
-        # HANDLER_DONE — exactly what a crashed/reaped worker leaves behind.
+    def kill_workers(self) -> list[int]:
         pids = []
+        d = self.dispatch()
         for r in (d / "workers").iterdir():
             try:
                 pids.append(int(r.read_text().strip()))
             except (ValueError, OSError):
                 pass
-        check("worker receipts recorded pids", len(pids) >= 2, str(pids))
         for pid in pids:
             try:
                 os.kill(pid, signal.SIGKILL)
             except ProcessLookupError:
                 pass
-        check("both workers are dead",
-              wait_for(lambda: all(not _alive(p) for p in pids), 8.0), str(pids))
+        wait_for(lambda: all(not alive(p) for p in pids), 8.0)
+        return pids
 
-        # C arrives. Its arrival triggers a drain; with both markers orphaned the
-        # buggy drain sees running_count == TASK_HANDLER_WORKERS and never spawns.
-        c = task("task-ccc.txt")
-        with feed.open("a") as fh:
-            fh.write(str(c.resolve()) + "\n")
-
-        dispatched = wait_for(lambda: "task-ccc.txt" in names(dispatch_dir(tmp) / "running"), 12.0)
-        d = dispatch_dir(tmp)
-        check("a task arriving after both workers died still gets dispatched",
-              dispatched,
-              f"pending={names(d/'pending')} running={names(d/'running')} "
-              "— dead workers still hold both slots (the defect)")
-    finally:
+    def stop(self) -> None:
+        if self.proc is None:
+            return
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
             pass
-        proc.wait(timeout=5)
+        self.proc.wait(timeout=5)
 
+
+def scenario_slot_recovery() -> None:
+    """The defect: dead workers held both slots, so nothing dispatched again."""
+    h = Harness()
+    h.task("task-aaa.txt")
+    h.task("task-bbb.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 2):
+            check("both worker slots filled by the startup sweep", False, str(h.dispatch()))
+            return
+        check("both worker slots filled by the startup sweep", True)
+        check("worker pids recorded and killed", len(h.kill_workers()) >= 2)
+        h.deliver("task-ccc.txt")
+        got = wait_for(lambda: "task-ccc.txt" in names(h.dispatch() / "running"))
+        d = h.dispatch()
+        check("a task arriving after both workers died still gets dispatched", got,
+              f"pending={names(d/'pending')} running={names(d/'running')}")
+    finally:
+        h.stop()
+
+
+def scenario_reap_publishes_only_without_an_exact_result() -> None:
+    """Controls for both false positives, driven through the production reap.
+
+    A prefix-colliding archive entry and a zero-byte live result must each still
+    yield the terminal failure; a genuine archived result must still suppress it.
+    """
+    h = Harness()
+    arch = h.ws / "results" / "archive"
+    # `task-1234` must not satisfy `task-123` (prefix collision).
+    (arch / "task-1234-999.txt").write_text("a different task's answer\n")
+    # A genuine archived result for task-abc — the reap must stay silent here.
+    (arch / "task-abc-999.txt").write_text("the real answer\n")
+    h.task("task-123.txt")
+    h.task("task-abc.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 2):
+            check("collision scenario: both slots filled", False)
+            return
+        h.kill_workers()
+        h.deliver("task-zzz.txt")
+
+        res = h.ws / "results"
+        published = wait_for(lambda: (res / "task-123.txt").is_file()
+                             and (res / "task-123.txt").stat().st_size > 0)
+        check("prefix-colliding archive does NOT count as this task's result",
+              published and FAILURE_TEXT in (res / "task-123.txt").read_text(),
+              "no terminal failure published for task-123")
+        # Negative control: the fix must not become "always publish".
+        time.sleep(1.0)
+        check("a genuine archived result still suppresses the terminal failure",
+              not (res / "task-abc.txt").exists(),
+              f"spurious failure written: {(res/'task-abc.txt').read_text()[:60] if (res/'task-abc.txt').exists() else ''}")
+    finally:
+        h.stop()
+
+
+def scenario_empty_live_result_is_not_delivered() -> None:
+    """A zero-byte result is the undeliverable placeholder state, not an answer."""
+    h = Harness()
+    h.task("task-456.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
+            check("empty-result scenario: slot filled", False)
+            return
+        (h.ws / "results" / "task-456.txt").write_text("")
+        h.kill_workers()
+        h.deliver("task-yyy.txt")
+        res = h.ws / "results" / "task-456.txt"
+        check("a zero-byte live result does NOT suppress the terminal failure",
+              wait_for(lambda: res.is_file() and res.stat().st_size > 0)
+              and FAILURE_TEXT in res.read_text(),
+              f"size={res.stat().st_size if res.exists() else 'missing'}")
+    finally:
+        h.stop()
+
+
+def main() -> int:
+    scenario_slot_recovery()
+    scenario_reap_publishes_only_without_an_exact_result()
+    scenario_empty_live_result_is_not_delivered()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1
-    print("\nPASS — dead handler workers do not hold dispatch slots")
+    print("\nPASS — dead workers free their slot; the reap publishes unless an exact result exists")
     return 0
-
-
-def _alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
 
 
 if __name__ == "__main__":

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -21,11 +21,17 @@ def check(name: str, cond: bool, detail: str = "") -> None:
         FAILURES.append(name)
 
 
-def wait_for(pred, timeout: float = 30.0, step: float = 0.25) -> bool:
+def wait_for(pred, timeout: float = 30.0, step: float = 0.25, nudge=None) -> bool:
+    """`nudge` re-arms the event that drives the drain. The reap runs on task
+    ARRIVAL, so one delivery racing the loop's readiness can be consumed early."""
     end = time.time() + timeout
+    ticks = 0
     while time.time() < end:
         if pred():
             return True
+        ticks += 1
+        if nudge is not None and ticks % 8 == 0:
+            nudge(ticks)
         time.sleep(step)
     return False
 
@@ -194,7 +200,8 @@ def scenario_empty_live_result_is_not_delivered() -> None:
         for tid, label in (("task-456.txt", "a zero-byte"), ("task-space.txt", "a whitespace-only")):
             res = h.ws / "results" / tid
             check(f"{label} live result does NOT suppress the terminal failure",
-                  wait_for(lambda r=res: r.is_file() and FAILURE_TEXT in r.read_text()),
+                  wait_for(lambda r=res: r.is_file() and FAILURE_TEXT in r.read_text(),
+                           nudge=lambda n, t=tid: h.deliver(f"task-nudge-{t[:-4]}-{n}.txt")),
                   f"body={res.read_text()[:40]!r}" if res.exists() else "missing")
     finally:
         h.stop()
@@ -221,11 +228,40 @@ def scenario_whitespace_archived_result_is_not_delivered() -> None:
         h.stop()
 
 
+def scenario_unready_body_is_preserved_not_overwritten() -> None:
+    """The bytes of an unready destination survive the terminal failure. A dead
+    wrapper pid does not prove its writer stopped, so nothing may be clobbered."""
+    h = Harness()
+    h.task("task-keep.txt")
+    h.start()
+    try:
+        if not wait_for(lambda: len(names(h.dispatch() and h.dispatch() / "running")) >= 1):
+            check("preserve scenario: slot filled", False)
+            return
+        # Unready by the shared contract but carrying bytes: any body that
+        # strips to text is a real answer and must be left alone entirely.
+        placeholder = "   \n\t\n"
+        (h.ws / "results" / "task-keep.txt").write_text(placeholder)
+        h.kill_workers()
+        h.deliver("task-zzz.txt")
+        res = h.ws / "results" / "task-keep.txt"
+        check("the terminal failure is still published over an unready body",
+              wait_for(lambda: res.is_file() and FAILURE_TEXT in res.read_text()),
+              f"body={res.read_text()[:40]!r}" if res.exists() else "missing")
+        kept = [p for p in (h.ws / "results").glob(".task-keep.txt.superseded.*")
+                if p.read_text() == placeholder]
+        check("the unready bytes are preserved, not destroyed", bool(kept),
+              f"superseded files={[p.name for p in (h.ws / 'results').glob('.task-keep.txt.superseded.*')]}")
+    finally:
+        h.stop()
+
+
 def main() -> int:
     scenario_slot_recovery()
     scenario_reap_publishes_only_without_an_exact_result()
     scenario_empty_live_result_is_not_delivered()
     scenario_whitespace_archived_result_is_not_delivered()
+    scenario_unready_body_is_preserved_not_overwritten()
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1


### PR DESCRIPTION
Fixes #2866.

## The defect

`drain_dispatch_queue` counted **files in `running/`**, not live workers:

```bash
for marker in "$DISPATCH_DIR/running/"*; do running_count=$((running_count + 1)); done
while [ "$running_count" -lt "$TASK_HANDLER_WORKERS" ]; do   # =2
```

The only thing that removes a marker is `finish_handler_task`, reached via a `HANDLER_DONE` event on the runtime FIFO. A worker killed or crashed before it emits that event leaves the marker orphaned and retires the slot permanently. **Two such deaths stall the required-handler lane for the life of the watcher** — every later Team-tier task queues in `pending/` and is never answered, while `health-check` still reports `task-watcher ok`. Silent by construction.

Measured live before writing anything: 2 `running/` markers, worker pids 58226 and 36241 both dead, one task pending 10+ minutes, zero dispatches. Both "running" tasks had in fact completed and delivered.

## The fix

Count live workers using the PID receipts already written to `$DISPATCH_DIR/workers/<filename>`, and reap a dead worker's marker so the slot returns.

**Two things the reap had to get right — both found by the test, not by reading the code.** I proposed a simpler version on the issue and it was wrong on both counts:

**1. rc must not be a blanket `1`.** `publish_terminal_failure` guards only the *live* results file:

```bash
result="$RESULTS_DIR/$filename"
[ -f "$result" ] && return 0
```

Delivery **consumes** that file. So reaping a worker that had already answered would write *"I could not safely process this Team-tier task"* for a task that succeeded — and since the id delivers once, that reply can never be sent and strands as an orphan result. That exact shape was observed on this host (a second result written at 00:05 for a task delivered at 00:03, later surfacing as `orphaned-results`). `handler_result_exists` therefore checks `results/archive/**` as well, and the reap only publishes a failure when nothing was ever produced.

**2. Reaping from inside the drain deadlocked.** `finish_handler_task` ends by calling `drain_dispatch_queue`, and `acquire_dispatch_lock` is a `mkdir` spinlock with **no timeout**:

```bash
while ! mkdir "$DISPATCH_DIR/lock" 2>/dev/null; do sleep 0.01; done
```

So the nested call spins forever against the lock the outer frame already holds. I had claimed on the issue that this call was safe because `finish_handler_task` does not take the lock *directly*; the test showed otherwise — one marker reaped, then the watcher hung. A `DRAIN_ACTIVE` re-entrancy guard makes the nested call a no-op. It is redundant regardless: the outer frame dispatches everything pending before it returns.

## Evidence — the test discriminates

Real-process reproduction. `watch-tasks-stream.sh` has no `BASH_SOURCE` guard, so its functions cannot be sourced in isolation; the test drives a real watcher with a stub `fswatch` (a `tail -f` on a feed file, so it both holds stdout open **and** emits on demand — the stall only becomes observable when a *new* task arrives to trigger a drain) and a stub handler whose `--probe` exits 4.

It fills both slots via the startup sweep, `SIGKILL`s both workers so neither emits `HANDLER_DONE`, then delivers a third task:

```
$ python3 tests/watch-tasks-stream-dead-worker-reap.test.py     # at the parent commit
  ok   both worker slots filled by the startup sweep
  ok   worker receipts recorded pids
  ok   both workers are dead
  FAIL a task arriving after both workers died still gets dispatched
       — pending={'task-ccc.txt'} running={'task-bbb.txt', 'task-aaa.txt'}

$ python3 tests/watch-tasks-stream-dead-worker-reap.test.py     # at HEAD
  ok   a task arriving after both workers died still gets dispatched
PASS — dead handler workers do not hold dispatch slots
```

Regression + hygiene at HEAD:

```
tests/watch-tasks-stream-sentinel-ownership.test.py   All sentinel-ownership checks passed
tests/watch-tasks-stream-trap-exit.test.sh            PASSED
bash -n src/watch-tasks-stream.sh                     parses
git diff --check                                      clean
scripts/review-checks.sh --diff                       PASS (hardcoded-paths + root-artifacts clean)
```

## Safety of the test itself

Following the discipline documented in `tests/watch-tasks-stream-sentinel-ownership.test.py`: every watcher is started with `start_new_session=True` (`cleanup()` ends in `kill 0`, which would otherwise signal the test's own group), the workspace and `TMPDIR` are per-run temp dirs, and **only pids the test recorded are killed** — never `pkill -f watch-tasks-stream`, which matches the operator's live watcher. I verified the host's real watcher (pid 89762) was present and unchanged before and after each run.

## Scope

One function plus a small helper, and a new test. No change to the handler contract, the claim protocol, or the `HANDLER_DONE` path — a worker that emits normally still settles exactly as before; the reap only touches markers whose worker is already gone.
