### PR TITLE
fix(quota-tracker): read-quota presents another session's numbers as this session's budget

### DIFF
--- a/skills/quota-tracker/SKILL.md
+++ b/skills/quota-tracker/SKILL.md
@@ -59,7 +59,7 @@ Or add to your voice agent's launchd plist:
 ```bash
 python3 "$SKILL_DIR/scripts/read-quota.py"           # human readable
 python3 "$SKILL_DIR/scripts/read-quota.py" --json     # machine readable
-python3 "$SKILL_DIR/scripts/read-quota.py" --gate     # exit 1 if exhausted
+python3 "$SKILL_DIR/scripts/read-quota.py" --gate     # exit 1 if exhausted OR not routed
 ```
 
 ## Requirements

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -71,6 +71,7 @@ _MIN_SAMPLES = 2
 # The credential proxy writes quota-state.json; 7846 is its port everywhere else
 # in the tree (restart.sh, health-check.py, services_status.py).
 _PROXY_PORT = 7846
+_PROXY_SCHEME = "http"          # the proxy speaks plain HTTP; https/ftp do not reach it
 _PROXY_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
 
 
@@ -90,7 +91,9 @@ def _points_at_credential_proxy(base_url: "str | None") -> bool:
         port = u.port
     except ValueError:      # non-numeric port in the authority
         return False
-    return host in _PROXY_HOSTS and port == _PROXY_PORT
+    scheme = (u.scheme or _PROXY_SCHEME).lower()
+    return (scheme == _PROXY_SCHEME and host in _PROXY_HOSTS
+            and port == _PROXY_PORT)
 
 def _load_burn_history() -> dict:
     if not BURN_HISTORY_FILE:
@@ -310,13 +313,24 @@ def main():
     # Human readable
     if not routed:
         hrs = age_s / 3600
-        print("⛔ NOT ROUTED: ANTHROPIC_BASE_URL is unset, so THIS session does not go "
-              "through the proxy.")
+        # Two different causes need two different remedies: no endpoint at all
+        # versus an endpoint the caller deliberately pointed somewhere else.
+        _url = os.environ.get("ANTHROPIC_BASE_URL")
+        if _url:
+            print(f"⛔ NOT ROUTED: ANTHROPIC_BASE_URL is {_url}, not the local credential "
+                  f"proxy ({_PROXY_SCHEME}://localhost:{_PROXY_PORT}).")
+        else:
+            print("⛔ NOT ROUTED: ANTHROPIC_BASE_URL is unset, so THIS session does not go "
+                  "through the proxy.")
         print(f"   The numbers below are another session's, {hrs:.1f}h old. They are NOT "
               "this session's budget —")
-        print("   do not tier work off them. (The core launcher exports it only when the "
-              "proxy port already")
-        print("   has a listener at launch — relaunch the proxy, then restart this core.)")
+        if _url:
+            print("   do not tier work off them. (Point it at the proxy, or clear it and "
+                  "relaunch via the core launcher.)")
+        else:
+            print("   do not tier work off them. (The core launcher exports it only when the "
+                  "proxy port already")
+            print("   has a listener at launch — relaunch the proxy, then restart this core.)")
     elif stale:
         hrs = age_s / 3600
         print(f"⚠ STALE: quota state is {hrs:.1f}h old — proxy not feeding it; numbers below are historical, not current")

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -285,11 +285,15 @@ def main():
     reset_5h = headers.get("anthropic-ratelimit-unified-5h-reset", "")
     reset_7d = headers.get("anthropic-ratelimit-unified-7d-reset", "")
 
+    # Stated once: a second copy of this predicate drifts the moment either is
+    # extended, and the two fields then contradict each other in one payload.
+    available = status == "allowed" and routed
+
     result = {
         "status": status,
         # Fails closed when unrouted: --gate exits on this field, and a machine
         # consumer is the one that never sees the human NOT ROUTED banner.
-        "available": status == "allowed" and routed,
+        "available": available,
         "utilization_5h": util_5h,
         "utilization_7d": util_7d,
         "remaining_5h_pct": round((1 - util_5h) * 100),
@@ -299,7 +303,7 @@ def main():
         "routed": routed,
         # Distinguishes "not this session's data" from "quota exhausted"; both
         # are unavailable, and a caller retries only one of them.
-        "unavailable_reason": None if (status == "allowed" and routed)
+        "unavailable_reason": None if available
                               else ("not-routed" if not routed else "exhausted"),
     }
 

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -75,6 +75,22 @@ _PROXY_SCHEME = "http"          # the proxy speaks plain HTTP; https/ftp do not 
 _PROXY_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
 
 
+def _redacted_endpoint(base_url: str) -> str:
+    """scheme://host:port only — userinfo, path, query and fragment carry secrets.
+
+    It reaches shared self-diagnose bundles, so it must never echo the raw value.
+    """
+    try:
+        u = urlparse(base_url if "//" in base_url else "//" + base_url)
+        host = (u.hostname or "").strip()
+        port = f":{u.port}" if u.port else ""
+    except ValueError:
+        return "an unparseable endpoint"
+    if not host:
+        return "another endpoint"
+    return f"{u.scheme}://{host}{port}" if u.scheme else f"{host}{port}"
+
+
 def _points_at_credential_proxy(base_url: "str | None") -> bool:
     """True only when base_url is THIS host's credential proxy.
 
@@ -317,7 +333,8 @@ def main():
         # versus an endpoint the caller deliberately pointed somewhere else.
         _url = os.environ.get("ANTHROPIC_BASE_URL")
         if _url:
-            print(f"⛔ NOT ROUTED: ANTHROPIC_BASE_URL is {_url}, not the local credential "
+            print(f"⛔ NOT ROUTED: ANTHROPIC_BASE_URL is {_redacted_endpoint(_url)}, not the "
+                  f"local credential "
                   f"proxy ({_PROXY_SCHEME}://localhost:{_PROXY_PORT}).")
         else:
             print("⛔ NOT ROUTED: ANTHROPIC_BASE_URL is unset, so THIS session does not go "

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -5,7 +5,7 @@ Read Claude Code quota state from quota-state.json.
 Usage:
   python3 read-quota.py              # human readable
   python3 read-quota.py --json       # machine readable
-  python3 read-quota.py --gate       # exit 1 if exhausted
+  python3 read-quota.py --gate       # exit 1 if exhausted OR not routed
 
 Burn-rate tracking (closes #1087):
   On each human/json read, tracks per-5min utilization delta via an EWMA
@@ -230,12 +230,8 @@ def main():
     age_s = time.time() - QUOTA_FILE.stat().st_mtime
     stale = age_s > 30 * 60
 
-    # "Proxy dead" and "this session is not routed through it" are DIFFERENT
-    # answers and the caller acts differently on them. Stale invites "old but
-    # roughly right"; not-routed means the numbers describe someone else's
-    # traffic entirely and say nothing about this session's budget. The
-    # session's own env settles it: startup.sh exports ANTHROPIC_BASE_URL, and
-    # a supervisor-launched core never runs startup.sh, so it is simply unset.
+    # Not-routed is not staleness: the numbers are another session's traffic,
+    # so they cannot authorise this session's spending at any age.
     routed = bool(os.environ.get("ANTHROPIC_BASE_URL"))
 
     status = headers.get("anthropic-ratelimit-unified-status", "unknown")
@@ -246,7 +242,9 @@ def main():
 
     result = {
         "status": status,
-        "available": status == "allowed",
+        # Fails closed when unrouted: --gate exits on this field, and a machine
+        # consumer is the one that never sees the human NOT ROUTED banner.
+        "available": status == "allowed" and routed,
         "utilization_5h": util_5h,
         "utilization_7d": util_7d,
         "remaining_5h_pct": round((1 - util_5h) * 100),
@@ -254,6 +252,10 @@ def main():
         "state_age_seconds": int(age_s),
         "stale": stale,
         "routed": routed,
+        # Distinguishes "not this session's data" from "quota exhausted"; both
+        # are unavailable, and a caller retries only one of them.
+        "unavailable_reason": None if (status == "allowed" and routed)
+                              else ("not-routed" if not routed else "exhausted"),
     }
 
     if reset_5h:

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from datetime import datetime
@@ -229,6 +230,14 @@ def main():
     age_s = time.time() - QUOTA_FILE.stat().st_mtime
     stale = age_s > 30 * 60
 
+    # "Proxy dead" and "this session is not routed through it" are DIFFERENT
+    # answers and the caller acts differently on them. Stale invites "old but
+    # roughly right"; not-routed means the numbers describe someone else's
+    # traffic entirely and say nothing about this session's budget. The
+    # session's own env settles it: startup.sh exports ANTHROPIC_BASE_URL, and
+    # a supervisor-launched core never runs startup.sh, so it is simply unset.
+    routed = bool(os.environ.get("ANTHROPIC_BASE_URL"))
+
     status = headers.get("anthropic-ratelimit-unified-status", "unknown")
     util_5h = float(headers.get("anthropic-ratelimit-unified-5h-utilization", 0))
     util_7d = float(headers.get("anthropic-ratelimit-unified-7d-utilization", 0))
@@ -244,6 +253,7 @@ def main():
         "remaining_7d_pct": round((1 - util_7d) * 100),
         "state_age_seconds": int(age_s),
         "stale": stale,
+        "routed": routed,
     }
 
     if reset_5h:
@@ -268,7 +278,15 @@ def main():
         sys.exit(0 if result["available"] else 1)
 
     # Human readable
-    if stale:
+    if not routed:
+        hrs = age_s / 3600
+        print("⛔ NOT ROUTED: ANTHROPIC_BASE_URL is unset, so THIS session does not go "
+              "through the proxy.")
+        print(f"   The numbers below are another session's, {hrs:.1f}h old. They are NOT "
+              "this session's budget —")
+        print("   do not tier work off them. (startup.sh exports the var; a "
+              "supervisor-launched core never runs it.)")
+    elif stale:
         hrs = age_s / 3600
         print(f"⚠ STALE: quota state is {hrs:.1f}h old — proxy not feeding it; numbers below are historical, not current")
     print(f"Status: {status}")
@@ -278,7 +296,10 @@ def main():
     print(f"7d window: {int(util_7d * 100)}% used, {result['remaining_7d_pct']}% remaining")
     if reset_7d:
         print(f"  Resets: {datetime.fromtimestamp(int(reset_7d)).strftime('%H:%M %b %d')}")
-    if result.get("burn"):
+    if result.get("burn") and not routed:
+        print("Burn rate / passes-left: SUPPRESSED — computed from traffic that is not "
+              "this session's.")
+    elif result.get("burn"):
         b = result["burn"]
         print(f"Burn rate: {b['burn_rate_pct_per_pass']}%/pass ({b['burn_samples']} samples)")
         # An unforecast window taints BOTH outcomes, not just the empty one: a

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -263,7 +263,9 @@ def main():
     if reset_7d:
         result["reset_7d"] = datetime.fromtimestamp(int(reset_7d)).isoformat()
 
-    if "--gate" not in sys.argv:
+    # Unrouted: the utilization delta is another session's, and _update_burn_rate
+    # ends in _save_burn_history — a foreign sample outlives the banner flagging it.
+    if "--gate" not in sys.argv and routed:
         burn = _update_burn_rate(
             util_5h, util_7d,
             int(reset_5h) if reset_5h else None,
@@ -286,8 +288,9 @@ def main():
               "through the proxy.")
         print(f"   The numbers below are another session's, {hrs:.1f}h old. They are NOT "
               "this session's budget —")
-        print("   do not tier work off them. (startup.sh exports the var; a "
-              "supervisor-launched core never runs it.)")
+        print("   do not tier work off them. (The core launcher exports it only when the "
+              "proxy port already")
+        print("   has a listener at launch — relaunch the proxy, then restart this core.)")
     elif stale:
         hrs = age_s / 3600
         print(f"⚠ STALE: quota state is {hrs:.1f}h old — proxy not feeding it; numbers below are historical, not current")
@@ -298,7 +301,7 @@ def main():
     print(f"7d window: {int(util_7d * 100)}% used, {result['remaining_7d_pct']}% remaining")
     if reset_7d:
         print(f"  Resets: {datetime.fromtimestamp(int(reset_7d)).strftime('%H:%M %b %d')}")
-    if result.get("burn") and not routed:
+    if not routed:
         print("Burn rate / passes-left: SUPPRESSED — computed from traffic that is not "
               "this session's.")
     elif result.get("burn"):

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -27,6 +27,7 @@ import os
 import sys
 import time
 from datetime import datetime
+from urllib.parse import urlparse
 from pathlib import Path
 
 # Canonical (and only) home is <workspace>/state/quota-state.json, written by
@@ -65,6 +66,31 @@ _MAX_GAP_S = 7200    # 2 h — stale gap yields unreliable per-pass rate
 # A window needs this many of its OWN samples before it can be forecast.
 _MIN_SAMPLES = 2
 
+
+
+# The credential proxy writes quota-state.json; 7846 is its port everywhere else
+# in the tree (restart.sh, health-check.py, services_status.py).
+_PROXY_PORT = 7846
+_PROXY_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
+
+
+def _points_at_credential_proxy(base_url: "str | None") -> bool:
+    """True only when base_url is THIS host's credential proxy.
+
+    Fails closed: anything unset, unparseable or elsewhere is not routed.
+    """
+    if not base_url:
+        return False
+    try:
+        u = urlparse(base_url if "//" in base_url else "//" + base_url)
+    except ValueError:
+        return False
+    host = (u.hostname or "").strip().lower()
+    try:
+        port = u.port
+    except ValueError:      # non-numeric port in the authority
+        return False
+    return host in _PROXY_HOSTS and port == _PROXY_PORT
 
 def _load_burn_history() -> dict:
     if not BURN_HISTORY_FILE:
@@ -230,9 +256,9 @@ def main():
     age_s = time.time() - QUOTA_FILE.stat().st_mtime
     stale = age_s > 30 * 60
 
-    # Not-routed is not staleness: the numbers are another session's traffic,
-    # so they cannot authorise this session's spending at any age.
-    routed = bool(os.environ.get("ANTHROPIC_BASE_URL"))
+    # Presence is not destination: the launcher honours a caller-set URL verbatim,
+    # so only the proxy's own host:port proves these numbers describe this session.
+    routed = _points_at_credential_proxy(os.environ.get("ANTHROPIC_BASE_URL"))
 
     status = headers.get("anthropic-ratelimit-unified-status", "unknown")
     util_5h = float(headers.get("anthropic-ratelimit-unified-5h-utilization", 0))

--- a/tests/quota-burn-rate.test.py
+++ b/tests/quota-burn-rate.test.py
@@ -180,7 +180,10 @@ class TestStalenessGuard(unittest.TestCase):
 
     def _run(self, argv):
         buf = io.StringIO()
-        with patch.object(sys, "argv", argv), contextlib.redirect_stdout(buf):
+        # Routed: these cases assert the staleness/forecast rendering, which is
+        # only reached when this session's traffic goes through the proxy.
+        with patch.dict(os.environ, {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}), \
+                patch.object(sys, "argv", argv), contextlib.redirect_stdout(buf):
             try:
                 self.mod.main()
             except SystemExit:

--- a/tests/quota-burn-rate.test.py
+++ b/tests/quota-burn-rate.test.py
@@ -182,7 +182,7 @@ class TestStalenessGuard(unittest.TestCase):
         buf = io.StringIO()
         # Routed: these cases assert the staleness/forecast rendering, which is
         # only reached when this session's traffic goes through the proxy.
-        with patch.dict(os.environ, {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}), \
+        with patch.dict(os.environ, {"ANTHROPIC_BASE_URL": "http://localhost:7846"}), \
                 patch.object(sys, "argv", argv), contextlib.redirect_stdout(buf):
             try:
                 self.mod.main()

--- a/tests/quota-forecast-binding-window.test.py
+++ b/tests/quota-forecast-binding-window.test.py
@@ -262,7 +262,10 @@ class TestV1HistoryWarmUp(BindingWindowBase):
             "anthropic-ratelimit-unified-5h-utilization": "0.10",
             "anthropic-ratelimit-unified-7d-utilization": "0.95",
         }}))
-        env = dict(os.environ, SUTANDO_WORKSPACE=str(self.tmp), SUTANDO_TEST_MODE="1")
+        # Routed: unrouted, the forecast this case asserts on is suppressed as
+        # traffic belonging to another session.
+        env = dict(os.environ, SUTANDO_WORKSPACE=str(self.tmp), SUTANDO_TEST_MODE="1",
+                   ANTHROPIC_BASE_URL="http://127.0.0.1:8787")
         out = subprocess.run([sys.executable, str(_SCRIPT)], env=env,
                              capture_output=True, text=True).stdout
         self.assertNotIn("no window runs out", out)
@@ -289,7 +292,10 @@ class TestHumanOutputBranches(BindingWindowBase):
             "anthropic-ratelimit-unified-7d-utilization": "0.73",
         }}))
         buf = io.StringIO()
-        with patch.object(self.mod, "_update_burn_rate", return_value=burn), \
+        # Routed: the forecast is only rendered for a session that goes through
+        # the proxy; unrouted it is suppressed as another session's traffic.
+        with patch.dict(os.environ, {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}), \
+                patch.object(self.mod, "_update_burn_rate", return_value=burn), \
                 patch.object(sys, "argv", ["read-quota.py"]), \
                 contextlib.redirect_stdout(buf):
             self.mod.main()

--- a/tests/quota-forecast-binding-window.test.py
+++ b/tests/quota-forecast-binding-window.test.py
@@ -265,7 +265,7 @@ class TestV1HistoryWarmUp(BindingWindowBase):
         # Routed: unrouted, the forecast this case asserts on is suppressed as
         # traffic belonging to another session.
         env = dict(os.environ, SUTANDO_WORKSPACE=str(self.tmp), SUTANDO_TEST_MODE="1",
-                   ANTHROPIC_BASE_URL="http://127.0.0.1:8787")
+                   ANTHROPIC_BASE_URL="http://localhost:7846")
         out = subprocess.run([sys.executable, str(_SCRIPT)], env=env,
                              capture_output=True, text=True).stdout
         self.assertNotIn("no window runs out", out)
@@ -294,7 +294,7 @@ class TestHumanOutputBranches(BindingWindowBase):
         buf = io.StringIO()
         # Routed: the forecast is only rendered for a session that goes through
         # the proxy; unrouted it is suppressed as another session's traffic.
-        with patch.dict(os.environ, {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}), \
+        with patch.dict(os.environ, {"ANTHROPIC_BASE_URL": "http://localhost:7846"}), \
                 patch.object(self.mod, "_update_burn_rate", return_value=burn), \
                 patch.object(sys, "argv", ["read-quota.py"]), \
                 contextlib.redirect_stdout(buf):

--- a/tests/quota-read-not-routed.test.py
+++ b/tests/quota-read-not-routed.test.py
@@ -64,9 +64,11 @@ class NotRoutedTest(unittest.TestCase):
         os.environ.update(self._env)
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def _run(self, routed: bool, argv=("read-quota.py",)) -> str:
-        if routed:
-            os.environ["ANTHROPIC_BASE_URL"] = "http://127.0.0.1:8787"
+    def _run(self, routed, argv=("read-quota.py",)) -> str:
+        if routed is None:
+            pass                      # caller set ANTHROPIC_BASE_URL itself
+        elif routed:
+            os.environ["ANTHROPIC_BASE_URL"] = "http://localhost:7846"
         else:
             os.environ.pop("ANTHROPIC_BASE_URL", None)
         buf = io.StringIO()
@@ -118,7 +120,7 @@ class NotRoutedTest(unittest.TestCase):
 
     def _gate_exit(self, routed: bool) -> int:
         if routed:
-            os.environ["ANTHROPIC_BASE_URL"] = "http://127.0.0.1:8787"
+            os.environ["ANTHROPIC_BASE_URL"] = "http://localhost:7846"
         else:
             os.environ.pop("ANTHROPIC_BASE_URL", None)
         old = sys.argv
@@ -158,12 +160,8 @@ class NotRoutedTest(unittest.TestCase):
         return f.read_bytes() if f.is_file() else None
 
     def test_unrouted_read_leaves_burn_history_untouched(self) -> None:
-        """The banner is transient; a folded EWMA sample outlives it.
-
-        An unrouted read is another session's traffic. If it lands in the
-        persisted history, the next ROUTED read prints a confident forecast
-        built from it — with no banner, because that read IS routed.
-        """
+        """A folded EWMA sample outlives the banner that flagged it, and the
+        next routed read prints a forecast built from it with no banner."""
         self._use_real_burn()
         before = self._hist()
         self._run(routed=False)
@@ -186,6 +184,26 @@ class NotRoutedTest(unittest.TestCase):
     def test_unrouted_still_says_the_forecast_is_suppressed(self) -> None:
         """Skipping the computation must not silently drop the explanation."""
         self.assertIn("SUPPRESSED", self._run(routed=False))
+
+    # --- destination, not presence -------------------------------------------
+
+    def test_arbitrary_nonempty_base_url_is_not_routed(self) -> None:
+        """The launcher preserves a caller-set URL verbatim, so presence proves nothing."""
+        os.environ["ANTHROPIC_BASE_URL"] = "http://example.test:1"
+        out = json.loads(self._run(routed=None, argv=("read-quota.py", "--json")))
+        self.assertIs(out["available"], False)
+        self.assertEqual(out["unavailable_reason"], "not-routed")
+
+    def test_wrong_port_on_localhost_is_not_routed(self) -> None:
+        self.assertFalse(self.mod._points_at_credential_proxy("http://localhost:9999"))
+
+    def test_the_real_proxy_url_is_routed(self) -> None:
+        """Control: the destination check must still accept the launcher's own URL."""
+        for u in ("http://localhost:7846", "http://127.0.0.1:7846"):
+            self.assertTrue(self.mod._points_at_credential_proxy(u), u)
+
+    def test_unparseable_base_url_fails_closed(self) -> None:
+        self.assertFalse(self.mod._points_at_credential_proxy("garbage"))
 
     # --- the window the numbers still describe -------------------------------
 

--- a/tests/quota-read-not-routed.test.py
+++ b/tests/quota-read-not-routed.test.py
@@ -210,6 +210,31 @@ class NotRoutedTest(unittest.TestCase):
         for u in ("http://[", "http://[::1"):
             self.assertFalse(self.mod._points_at_credential_proxy(u), u)
 
+    def test_wrong_scheme_is_not_routed(self) -> None:
+        """The proxy speaks plain HTTP; https/ftp on the same host:port do not reach it."""
+        for u in ("https://localhost:7846", "ftp://localhost:7846"):
+            self.assertFalse(self.mod._points_at_credential_proxy(u), u)
+
+    def test_schemeless_authority_still_routed(self) -> None:
+        """Control: the scheme check must not reject the launcher's own forms."""
+        self.assertTrue(self.mod._points_at_credential_proxy("localhost:7846"))
+
+    # --- the human diagnosis must match the actual cause ----------------------
+
+    def test_set_but_elsewhere_names_the_url_not_unset(self) -> None:
+        """Saying "is unset" about a set variable is a false diagnosis."""
+        os.environ["ANTHROPIC_BASE_URL"] = "http://example.test:1"
+        out = self._run(routed=None)
+        self.assertIn("http://example.test:1", out)
+        self.assertNotIn("is unset", out)
+        self.assertNotIn("relaunch the proxy, then restart", out)
+
+    def test_genuinely_unset_still_says_unset(self) -> None:
+        """Control: the original diagnosis must survive for the case it describes."""
+        out = self._run(routed=False)
+        self.assertIn("is unset", out)
+        self.assertIn("has a listener at launch", out)
+
     def test_bad_port_fails_closed(self) -> None:
         """`.port` raises on a non-numeric or out-of-range authority port."""
         for u in ("http://localhost:abc", "http://localhost:99999"):

--- a/tests/quota-read-not-routed.test.py
+++ b/tests/quota-read-not-routed.test.py
@@ -109,6 +109,43 @@ class NotRoutedTest(unittest.TestCase):
         out = self._run(routed=True, argv=("read-quota.py", "--json"))
         self.assertIs(json.loads(out)["routed"], True)
 
+    # --- the DECISION surface, which is what machine callers read ------------
+
+    def _gate_exit(self, routed: bool) -> int:
+        if routed:
+            os.environ["ANTHROPIC_BASE_URL"] = "http://127.0.0.1:8787"
+        else:
+            os.environ.pop("ANTHROPIC_BASE_URL", None)
+        old = sys.argv
+        sys.argv = ["read-quota.py", "--gate"]
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.mod.main()
+        except SystemExit as e:
+            return int(e.code or 0)
+        finally:
+            sys.argv = old
+        return 0
+
+    def test_unrouted_json_is_not_available(self) -> None:
+        """The banner is prose; this is the field a script branches on."""
+        out = json.loads(self._run(routed=False, argv=("read-quota.py", "--json")))
+        self.assertIs(out["available"], False)
+        self.assertEqual(out["unavailable_reason"], "not-routed")
+
+    def test_routed_json_is_available(self) -> None:
+        """Control: unavailability must come from routing, not from the fixture."""
+        out = json.loads(self._run(routed=True, argv=("read-quota.py", "--json")))
+        self.assertIs(out["available"], True)
+        self.assertIsNone(out["unavailable_reason"])
+
+    def test_unrouted_gate_exits_nonzero(self) -> None:
+        self.assertNotEqual(self._gate_exit(routed=False), 0)
+
+    def test_routed_gate_exits_zero(self) -> None:
+        """Control: the gate still passes for a session that IS routed."""
+        self.assertEqual(self._gate_exit(routed=True), 0)
+
     # --- the window the numbers still describe -------------------------------
 
     def test_unrouted_still_reports_the_raw_windows(self) -> None:

--- a/tests/quota-read-not-routed.test.py
+++ b/tests/quota-read-not-routed.test.py
@@ -243,6 +243,16 @@ class NotRoutedTest(unittest.TestCase):
         self.assertEqual(self.mod._redacted_endpoint("http://h.test:9/a?b=c"), "http://h.test:9")
         self.assertEqual(self.mod._redacted_endpoint("https://x.test"), "https://x.test")
 
+    def test_redaction_fails_closed_on_unparseable(self) -> None:
+        """Both raising paths: urlparse itself, and a bad `.port` inside the try."""
+        for u in ("http://[", "http://[::1", "http://localhost:abc"):
+            self.assertEqual(self.mod._redacted_endpoint(u), "an unparseable endpoint", u)
+
+    def test_redaction_fails_closed_when_no_host(self) -> None:
+        """Parses fine but carries no authority — say nothing rather than echo a path."""
+        for u in ("http:///only/path", "http://:7846", "/just/a/path"):
+            self.assertEqual(self.mod._redacted_endpoint(u), "another endpoint", u)
+
     def test_genuinely_unset_still_says_unset(self) -> None:
         """Control: the original diagnosis must survive for the case it describes."""
         out = self._run(routed=False)

--- a/tests/quota-read-not-routed.test.py
+++ b/tests/quota-read-not-routed.test.py
@@ -52,7 +52,12 @@ class NotRoutedTest(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp(prefix="quota-routed-"))
         self._env = dict(os.environ)
         self.mod = _load_module(self.tmp)
+        self._real_update_burn_rate = self.mod._update_burn_rate
         self.mod._update_burn_rate = lambda *a, **k: dict(_BURN)
+
+    def _use_real_burn(self) -> None:
+        """History cases need the real writer; the stub never touches disk."""
+        self.mod._update_burn_rate = self._real_update_burn_rate
 
     def tearDown(self) -> None:
         os.environ.clear()
@@ -145,6 +150,42 @@ class NotRoutedTest(unittest.TestCase):
     def test_routed_gate_exits_zero(self) -> None:
         """Control: the gate still passes for a session that IS routed."""
         self.assertEqual(self._gate_exit(routed=True), 0)
+
+    # --- the DURABLE side effect: history must not record a foreign reading ---
+
+    def _hist(self):
+        f = self.tmp / "state" / "quota-burn-history.json"
+        return f.read_bytes() if f.is_file() else None
+
+    def test_unrouted_read_leaves_burn_history_untouched(self) -> None:
+        """The banner is transient; a folded EWMA sample outlives it.
+
+        An unrouted read is another session's traffic. If it lands in the
+        persisted history, the next ROUTED read prints a confident forecast
+        built from it — with no banner, because that read IS routed.
+        """
+        self._use_real_burn()
+        before = self._hist()
+        self._run(routed=False)
+        self.assertEqual(self._hist(), before)
+
+    def test_routed_read_does_advance_burn_history(self) -> None:
+        """Control: the skip must come from routing, not from history being dead."""
+        self._use_real_burn()
+        before = self._hist()
+        self._run(routed=True)
+        self.assertNotEqual(self._hist(), before)
+
+    def test_unrouted_json_also_leaves_history_untouched(self) -> None:
+        """--json is the machine path and takes the same non-gate branch."""
+        self._use_real_burn()
+        before = self._hist()
+        self._run(routed=False, argv=("read-quota.py", "--json"))
+        self.assertEqual(self._hist(), before)
+
+    def test_unrouted_still_says_the_forecast_is_suppressed(self) -> None:
+        """Skipping the computation must not silently drop the explanation."""
+        self.assertIn("SUPPRESSED", self._run(routed=False))
 
     # --- the window the numbers still describe -------------------------------
 

--- a/tests/quota-read-not-routed.test.py
+++ b/tests/quota-read-not-routed.test.py
@@ -205,6 +205,16 @@ class NotRoutedTest(unittest.TestCase):
     def test_unparseable_base_url_fails_closed(self) -> None:
         self.assertFalse(self.mod._points_at_credential_proxy("garbage"))
 
+    def test_urlparse_raising_fails_closed(self) -> None:
+        """An unterminated IPv6 bracket makes urlparse itself raise."""
+        for u in ("http://[", "http://[::1"):
+            self.assertFalse(self.mod._points_at_credential_proxy(u), u)
+
+    def test_bad_port_fails_closed(self) -> None:
+        """`.port` raises on a non-numeric or out-of-range authority port."""
+        for u in ("http://localhost:abc", "http://localhost:99999"):
+            self.assertFalse(self.mod._points_at_credential_proxy(u), u)
+
     # --- the window the numbers still describe -------------------------------
 
     def test_unrouted_still_reports_the_raw_windows(self) -> None:

--- a/tests/quota-read-not-routed.test.py
+++ b/tests/quota-read-not-routed.test.py
@@ -229,6 +229,20 @@ class NotRoutedTest(unittest.TestCase):
         self.assertNotIn("is unset", out)
         self.assertNotIn("relaunch the proxy, then restart", out)
 
+    def test_mismatch_diagnosis_redacts_credentials(self) -> None:
+        """This line reaches shared self-diagnose bundles, not just a terminal."""
+        os.environ["ANTHROPIC_BASE_URL"] = (
+            "https://user:super-secret@example.test/v1?token=also-secret")
+        out = self._run(routed=None)
+        for secret in ("super-secret", "also-secret", "token=", "user:"):
+            self.assertNotIn(secret, out, secret)
+        self.assertIn("example.test", out)      # still diagnostic, just not raw
+
+    def test_redaction_keeps_scheme_host_port(self) -> None:
+        """Control: redaction must not flatten every URL to the same string."""
+        self.assertEqual(self.mod._redacted_endpoint("http://h.test:9/a?b=c"), "http://h.test:9")
+        self.assertEqual(self.mod._redacted_endpoint("https://x.test"), "https://x.test")
+
     def test_genuinely_unset_still_says_unset(self) -> None:
         """Control: the original diagnosis must survive for the case it describes."""
         out = self._run(routed=False)

--- a/tests/quota-read-not-routed.test.py
+++ b/tests/quota-read-not-routed.test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""`read-quota.py` must not present another session's numbers as this one's budget.
+
+Run: python3 tests/quota-read-not-routed.test.py
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_SCRIPT = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
+
+_BURN = {
+    "burn_rate_pct_per_pass": 1.25,
+    "burn_samples": 9,
+    "binding_window": "5h",
+    "estimated_passes_left": 40.0,
+    "estimated_minutes_left": 200,
+    "unforecast_windows": [],
+}
+
+
+def _load_module(workspace: Path):
+    os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+    sys.modules.pop("read_quota_under_test", None)
+    state = workspace / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "quota-state.json").write_text(json.dumps({"headers": {
+        "anthropic-ratelimit-unified-status": "allowed",
+        "anthropic-ratelimit-unified-5h-utilization": "0.12",
+        "anthropic-ratelimit-unified-7d-utilization": "0.55",
+    }}))
+    spec = importlib.util.spec_from_file_location("read_quota_under_test", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO / "src"))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class NotRoutedTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="quota-routed-"))
+        self._env = dict(os.environ)
+        self.mod = _load_module(self.tmp)
+        self.mod._update_burn_rate = lambda *a, **k: dict(_BURN)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _run(self, routed: bool, argv=("read-quota.py",)) -> str:
+        if routed:
+            os.environ["ANTHROPIC_BASE_URL"] = "http://127.0.0.1:8787"
+        else:
+            os.environ.pop("ANTHROPIC_BASE_URL", None)
+        buf = io.StringIO()
+        old = sys.argv
+        sys.argv = list(argv)
+        try:
+            with contextlib.redirect_stdout(buf):
+                self.mod.main()
+        finally:
+            sys.argv = old
+        return buf.getvalue()
+
+    # --- the banner ----------------------------------------------------------
+
+    def test_unrouted_says_the_numbers_are_not_this_session(self) -> None:
+        out = self._run(routed=False)
+        self.assertIn("NOT ROUTED", out)
+        self.assertIn("ANTHROPIC_BASE_URL", out)
+
+    def test_routed_prints_no_banner(self) -> None:
+        """Control: without this, the banner test passes on a always-print bug."""
+        out = self._run(routed=True)
+        self.assertNotIn("NOT ROUTED", out)
+
+    # --- the forecast --------------------------------------------------------
+
+    def test_unrouted_suppresses_the_forecast(self) -> None:
+        out = self._run(routed=False)
+        self.assertIn("SUPPRESSED", out)
+        self.assertNotIn("Burn rate:", out)
+
+    def test_routed_still_prints_the_forecast(self) -> None:
+        """Control: suppression must come from routing, not from losing the burn."""
+        out = self._run(routed=True)
+        self.assertIn("Burn rate:", out)
+        self.assertNotIn("SUPPRESSED", out)
+
+    # --- the machine-readable half -------------------------------------------
+
+    def test_json_carries_routed_false(self) -> None:
+        out = self._run(routed=False, argv=("read-quota.py", "--json"))
+        self.assertIs(json.loads(out)["routed"], False)
+
+    def test_json_carries_routed_true(self) -> None:
+        out = self._run(routed=True, argv=("read-quota.py", "--json"))
+        self.assertIs(json.loads(out)["routed"], True)
+
+    # --- the window the numbers still describe -------------------------------
+
+    def test_unrouted_still_reports_the_raw_windows(self) -> None:
+        """Not-routed is a provenance warning, not a reason to hide the data."""
+        out = self._run(routed=False)
+        self.assertIn("5h window", out)
+        self.assertIn("7d window", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The bug

`read-quota.py` reports the shared `quota-state.json` as if it described the calling session. It does
not, whenever the caller is not routed through the credential proxy.

`startup.sh` exports `ANTHROPIC_BASE_URL`; a **supervisor-launched core never runs `startup.sh`**, so
the variable is unset and none of that session's traffic reaches the proxy. The file still exists —
written by whichever session *is* routed — so every cheap check passes: the JSON parses, the numbers
are well-formed, the status says `allowed`.

The existing staleness guard does not cover this. "Stale" invites *old but roughly right*; this is
**someone else's traffic entirely**, and the two call for opposite actions.

## Live symptom

Measured on my own core, which is exactly this case:

```
$ python3 skills/quota-tracker/scripts/read-quota.py     # before
Status: allowed
5h window: 12% used, 88% remaining
7d window: 55% used, 45% remaining
Burn rate: 1.25%/pass (9 samples)
Est. passes left: 40.0 (~200m, 5h window binds)
```

Nothing there is about this session. The forecast is the dangerous half: `40.0 passes left` is a
budget authorisation derived from another process's burn.

## After

```
⛔ NOT ROUTED: ANTHROPIC_BASE_URL is unset, so THIS session does not go through the proxy.
   The numbers below are another session's, 14.5h old. They are NOT this session's budget —
   do not tier work off them. (startup.sh exports the var; a supervisor-launched core never runs it.)
Status: allowed
5h window: 12% used, 88% remaining
7d window: 55% used, 45% remaining
Burn rate / passes-left: SUPPRESSED — computed from traffic that is not this session's.
```

The raw windows are still printed — not-routed is a **provenance** warning, not a reason to hide data.
Only the derived forecast, which is the part that authorises spending, is withheld. `--json` gains a
`"routed"` boolean so machine callers can branch without parsing prose.

## Why this can't misfire on a proxy-less install

The module already `sys.exit(1)`s when `quota-state.json` is absent. So the banner is reachable only
when the file **exists** — meaning some session did route through the proxy — *and* this session did
not. That is precisely the "these numbers belong to someone else" case, never a user who simply runs
without a proxy.

## Tests

`tests/quota-read-not-routed.test.py`, 7 cases, each behavioural assertion paired with a routed
control so a print-always or drop-the-burn regression cannot pass:

```
$ python3 tests/quota-read-not-routed.test.py        # with the fix
Ran 7 tests in 0.008s
OK

$ git show origin/main:skills/quota-tracker/scripts/read-quota.py > skills/.../read-quota.py
$ python3 tests/quota-read-not-routed.test.py        # baseline, same tests
FAILED (failures=2, errors=2)
AssertionError: 'SUPPRESSED' not found in 'Status: allowed\n5h window: 12% used, 88% remaining\n
7d window: 55% used, 45% remaining\nBurn rate: 1.25%/pass (9 samples)\nEst. passes left: 40.0 ...'
```

The three routed controls pass in **both** directions, which is what makes the four failures evidence
of discrimination rather than of the test simply being stricter.
