### PR TITLE
fix(health-check): a [no-send] result is not an undelivered reply

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5244,6 +5244,17 @@ def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
             # pair past the threshold is stranded rather than in flight.
             if task_age < threshold_age_sec:
                 continue
+        # A body that declares a skip was never going to be delivered, so it
+        # is not a stranded reply. `[deduped:]` stays reported: it PROMISES
+        # delivery via another task, and a broken promise is a real lost reply.
+        try:
+            from result_markers import parse_markers  # noqa: PLC0415
+            skips = {a.value for a in parse_markers(path.read_text()).actions
+                     if a.kind == "skip"}
+        except (OSError, ValueError, ImportError):
+            skips = set()          # unreadable -> judge it as before, never silently clear
+        if skips & {"no-send", "REPLIED"}:
+            continue
         orphans.append((path.name, int(age)))
     # Coverage is part of the verdict: say what could not be measured rather
     # than let it round down into a clean result.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5244,9 +5244,8 @@ def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
             # pair past the threshold is stranded rather than in flight.
             if task_age < threshold_age_sec:
                 continue
-        # A body that declares a skip was never going to be delivered, so it
-        # is not a stranded reply. `[deduped:]` stays reported: it PROMISES
-        # delivery via another task, and a broken promise is a real lost reply.
+        # A declared skip was never going to be delivered. `[deduped:]` stays
+        # reported: it PROMISES delivery elsewhere, so stranding it loses a reply.
         try:
             from result_markers import parse_markers  # noqa: PLC0415
             skips = {a.value for a in parse_markers(path.read_text()).actions

--- a/tests/health-check-orphaned-results-skip-markers.test.py
+++ b/tests/health-check-orphaned-results-skip-markers.test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""A result that declares a skip marker is not a stranded reply.
+
+Run: python3 tests/health-check-orphaned-results-skip-markers.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(workspace: Path):
+    os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+    spec = importlib.util.spec_from_file_location(
+        "hc_orphan_markers", REPO / "src" / "health-check.py")
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+class OrphanSkipMarkerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="orphan-markers-"))
+        self._env = dict(os.environ)
+        (self.tmp / "results").mkdir(parents=True)
+        (self.tmp / "tasks").mkdir(parents=True)
+        self.mod = _load(self.tmp)
+        self.mod.WORKSPACE_DIR = self.tmp
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _result(self, task_id: str, body: str, age_s: int = 3600) -> Path:
+        """A result with NO matching task — the orphan precondition."""
+        p = self.tmp / "results" / f"{task_id}.txt"
+        p.write_text(body)
+        old = time.time() - age_s
+        os.utime(p, (old, old))
+        return p
+
+    def _run(self):
+        return self.mod.check_orphaned_results()
+
+    # --- the control, first: without it a pass proves only that nothing is
+    #     ever reported.
+    def test_a_plain_undelivered_result_is_still_an_orphan(self) -> None:
+        self._result("task-plain-1", "Here is the answer you asked for.")
+        r = self._run()
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("task-plain-1", r["detail"])
+
+    # --- the fix ------------------------------------------------------------
+    def test_no_send_is_not_an_orphan(self) -> None:
+        self._result("task-nosend-1", "[no-send]\nWorkstream grouping: 15 assigned.")
+        r = self._run()
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertNotIn("task-nosend-1", r["detail"])
+
+    def test_replied_is_not_an_orphan(self) -> None:
+        self._result("task-replied-1", "[REPLIED]\nalready sent via the other path")
+        r = self._run()
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    # --- the deliberate NON-exemption ---------------------------------------
+    def test_deduped_is_still_reported(self) -> None:
+        """`[deduped:]` promises delivery elsewhere; a broken promise is a lost reply."""
+        self._result("task-dedup-1", "[deduped: task-other-9]")
+        r = self._run()
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("task-dedup-1", r["detail"])
+
+    # --- the exemption must not swallow a real one beside it ----------------
+    def test_a_skip_does_not_hide_a_real_orphan_in_the_same_scan(self) -> None:
+        self._result("task-nosend-2", "[no-send]\nbookkeeping")
+        self._result("task-plain-2", "a real undelivered reply")
+        r = self._run()
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("task-plain-2", r["detail"])
+        self.assertNotIn("task-nosend-2", r["detail"])
+
+    # --- unreadable must not silently clear ---------------------------------
+    def test_unreadable_body_is_judged_as_before(self) -> None:
+        """A body we cannot read is not evidence of a skip marker."""
+        p = self._result("task-unreadable-1", "whatever")
+        os.chmod(p, 0o000)
+        try:
+            r = self._run()
+            self.assertEqual(r["status"], "warn", r["detail"])
+        finally:
+            os.chmod(p, 0o644)
+
+    # --- the marker grammar is not re-declared here --------------------------
+    def test_probe_does_not_declare_the_marker_grammar_itself(self) -> None:
+        """CLAUDE.md: consumers must obtain grammar from result_markers."""
+        src = (REPO / "src" / "health-check.py").read_text()
+        i = src.index("def check_orphaned_results")
+        seg = src[i:i + 8000]
+        self.assertIn("parse_markers", seg)
+        for literal in ('r"\\[no-send\\]"', "[REPLIED]\\", "re.compile(r\"^\\s*\\[no-send"):
+            self.assertNotIn(literal, seg)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The bug

`check_orphaned_results` decides purely on **file presence and age**: a result whose task is no
longer in `tasks/` is reported as a reply that "no consumer will ever claim — never delivered".

That premise is inverted for a body that opens with a **skip marker**. `[no-send]` is the author
stating there is no reply to deliver; the task is archived and nothing is sent, by design. The probe
never reads the body, so it cannot tell "silently lost" from "deliberately not sent".

## Live symptom

On my core right now, from a workstream-grouping cron:

```
$ cat workspace/results/task-workstream-grouping-1786607498675.txt
[no-send]
Workstream grouping: 15 assigned, 0 skipped, 0 new (engine-checkout x8, fluffy-mobile x7).

$ python3 src/health-check.py | grep orphaned-results
⚠ orphaned-results   warn   1 result(s) with no consumer coming — never delivered;
                            oldest task-workstream-grouping-1786607498675.txt (0h51m)
```

Nothing is wrong. The warning has been standing all session and will recur on every such cron —
and this probe's own docstring names that cost, about a different case it already fixed: reporting
an in-flight task as stranded "is how a detector trains its readers to ignore it."

## The fix

Read the body and ask the shared parser. Per AGENTS.md, marker grammar comes from
`result_markers.parse_markers()` — the probe declares none of its own, and a test asserts that.

**`[deduped:]` is deliberately NOT exempted.** `no-send` and `REPLIED` mean no delivery was ever
intended. `[deduped: task-X]` instead *promises* the reply is delivered by X — so a stranded deduped
result is a genuinely lost reply, and silencing it would hide the exact failure the probe exists for.

An unreadable body falls back to the previous judgement rather than clearing the warning: a body we
could not read is not evidence of a skip marker.

## Tests

`tests/health-check-orphaned-results-skip-markers.test.py` — 7 cases, control-first:

```
$ python3 tests/health-check-orphaned-results-skip-markers.test.py
Ran 7 tests in 0.027s
OK

$ git show origin/main:src/health-check.py > src/health-check.py   # baseline
$ python3 tests/health-check-orphaned-results-skip-markers.test.py
FAILED (failures=3)
 : 1 result(s) with no consumer coming — never delivered; oldest task-replied-1.txt (1h0m)
```

The controls pass in **both** directions — a plain undelivered result is still an orphan, `[deduped:]`
is still reported, and a skip sitting beside a real orphan does not hide it.

Every marker/orphan suite in the repo, by exit code (three print no `OK` line, and a missing summary
is not a pass):

```
rc=0  bridge-marker-no-leak            rc=0  bridges-sending-orphan-recovery
rc=0  discord-bridge-prose-marker      rc=0  dm-result-skip-markers
rc=0  health-check-orphaned-results    rc=0  health-check-supervised-watcher-not-orphan
rc=0  orphan-result-routes             rc=0  result-file-marker-guard
rc=0  result-markers-golden            rc=0  result-markers
rc=0  slack-bridge-orphan-recovery     rc=0  telegram-bridge-orphaned-routing-recovery
rc=0  telegram-bridge-send-reply-markers
```
