### PR TITLE
docs(review): a fix that changes a decision rule needs its adjacent inputs enumerated

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -123,6 +123,27 @@ and loads whichever repo it reviews.
    The tell is that a broken instrument and a clean result are *byte-identical*, so the
    author's confidence carries no information.
 
+10. **A fix that changes a decision rule is itself a decision rule — enumerate the
+    adjacent inputs before pushing.** When a patch changes *how something is judged*
+    (a readiness test, a routing check, a marker classification), the next reviewer will
+    find the input one step to the side of the one you tested. Before pushing, list the
+    other values that reach the same decision and exercise each; and when the repo already
+    owns that judgement, ask the owner rather than restating its knowledge — the shared
+    copy is where the edge cases have already been paid for.
+    *Grounded by:* two PRs on 2026-08-13, five and six rounds each, every round a real
+    finding and every one adjacent to the last. (a) #2867 — the reap's "does a result
+    exist?" rule was rebuilt four times: a hand-rolled archive glob (a prefix collision
+    satisfied the wrong task), then `-s` (accepted whitespace-only, which the shared
+    `result_ready` contract rejects), then an overwrite that destroyed a late answer, then
+    a check-then-`mv` that relocated one out of the delivery path. `local_task_protocol`
+    and `result_ready` already answered the first two correctly. (b) #2868 — "is this
+    session routed?" went display-suppression → durable burn history → any non-empty
+    `ANTHROPIC_BASE_URL` → any scheme on the right host:port → a diagnosis line asserting
+    a cause it had not checked → that same line echoing URL credentials into a shared
+    self-diagnose bundle. Each fix was correct for the case its test named.
+    The tell that you are in this pattern: your test suite grows by exactly one case per
+    round, and each new case is the previous one with a single field changed.
+
 ## Checks (machine-readable — consumed by scripts/review-checks.sh)
 
 ```yaml


### PR DESCRIPTION
## What and why

Adds one lesson to `REVIEW.md`: **a fix that changes a decision rule is itself a decision rule — enumerate the adjacent inputs before pushing.**

Two PRs today took **five and six review rounds each**. Every round found a real defect, and every one was the input one step to the side of the case the previous fix tested. Three reviewers named the shape independently before anyone wrote it down, which is why it belongs in the shared criteria rather than in one PR thread.

**#2867** rebuilt "does a result for this task exist?" four times:

| round | the rule | the adjacent input that broke it |
|---|---|---|
| 1 | hand-rolled archive glob `-name "$base*"` | archived `task-1234.txt` satisfied `task-123.txt` |
| 2 | `-s` on the live result | whitespace-only, which `result_ready` already rejects |
| 3 | overwrite the unready body | destroyed an answer that landed in the window |
| 4 | check-then-`mv` it aside | relocated the answer out of the delivery path |

Rounds 1 and 2 were already answered correctly by `local_task_protocol.find_archived_result` and `result_ready.is_ready_body`.

**#2868** rebuilt "is this session routed?" six times: display suppression → durable burn history → any non-empty `ANTHROPIC_BASE_URL` → any scheme on the right `host:port` → a diagnosis line asserting a cause it had not checked → that same line echoing URL credentials into a shared self-diagnose bundle.

Each fix was correct for the case its test named. That is what makes the pattern expensive: nothing looks wrong at the end of a round.

## The actionable form

The lesson is written so a reviewer can apply it *prospectively* rather than recognise it in hindsight:

- list the other values that reach the same decision and exercise each
- when the repo already owns that judgement, ask the owner rather than restating its knowledge — the shared copy is where the edge cases have already been paid for
- **the tell:** your suite grows by exactly one case per round, and each new case is the previous one with a single field changed

## Evidence this change is safe

`REVIEW.md` is consumed three ways (its own header says so), so I checked each:

```
lesson numbers: ['1','2','3','4','5','6','7','8','9','10']   no duplicates, sequential
yaml checks block found: True                                 (scripts/review-checks.sh parser)
scripts/review-preflight.py                                   still runs
git diff | bash scripts/review-checks.sh -> PASS (hardcoded-paths + root-artifacts clean)
git diff --check -> clean
```

Docs-only, +21 lines, no code touched.

## Disclosure

Both grounding PRs are ones I authored or reviewed today, and in #2867 the repeated defect was **mine** — I wrote the rule in round 4's commit message and violated it in the same commit. I am proposing the lesson because it cost two PRs and five agent-days of review attention between us, not because I diagnosed someone else.
