### PR TITLE
fix(team): keep ephemeral runtime out of owner handoff

### DIFF
--- a/skills/task-workstream-sessions/scripts/session-worker.py
+++ b/skills/task-workstream-sessions/scripts/session-worker.py
@@ -247,13 +247,17 @@ def _terminate_process_group(process: subprocess.Popen) -> None:
         process.wait(timeout=2)
 
 
-def _run_process_bounded(command: list[str], cwd: Path) -> tuple[int, str, str]:
+def _run_process_bounded(
+    command: list[str], cwd: Path, environment_overrides: Optional[dict[str, str]] = None,
+) -> tuple[int, str, str]:
     """Run a streaming CLI with hard and no-progress deadlines."""
     hard_timeout = float(os.environ.get("SUTANDO_TIER_HARD_TIMEOUT", "900"))
     stall_timeout = float(os.environ.get("SUTANDO_TIER_STALL_TIMEOUT", "180"))
     if hard_timeout <= 0 or stall_timeout <= 0:
         raise ValueError("tier runtime timeouts must be positive")
     environment = os.environ.copy()
+    if environment_overrides:
+        environment.update(environment_overrides)
     # Binary pipes read with nonblocking os.read: a text-mode readline() blocks on
     # a partial line even after select() reports readable, so a provider that emits
     # bytes without a newline then stalls would wedge the timeout loop forever
@@ -377,7 +381,7 @@ def _run_team(runtime: str, prompt: str, repo: Path, workspace: Path) -> str:
     secret_filter = _load_team_result_scanner(repo)
     if runtime == "claude":
         return_code, stdout, stderr = _run_process_bounded(
-            _claude_team_command(prompt), cwd)
+            _claude_team_command(prompt), cwd, {"SUTANDO_TEAM_RUNTIME": "1"})
         if return_code:
             raise RuntimeError(stderr.strip() or f"claude exited {return_code}")
         body = _claude_stream_result(stdout)

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -6,6 +6,9 @@
 # <workspace>/session-state.md. The incoming session reads this in CLAUDE.md
 # or as part of the proactive loop.
 
+# Ephemeral Team children do not own the live core's continuity snapshot.
+[ "${SUTANDO_TEAM_RUNTIME:-}" = "1" ] && exit 0
+
 # REPO resolves to: (1) $SUTANDO_REPO_DIR if set AND valid, (2) auto-detect
 # from the script's own resolved location (symlink-safe), (3) common layout
 # probes — each validated by _repo_ok. If nothing validates, the script exits

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -8,6 +8,7 @@ import io
 import json
 import os
 import signal
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -236,7 +237,7 @@ def test_team_runtime_skips_the_owner_session_handoff() -> None:
             "SUTANDO_TEAM_RUNTIME": "1",
         }
         result = subprocess.run(
-            ["bash", str(REPO / "src" / "session-handoff.sh")],
+            ["bash", str(_staged_handoff(root))],
             cwd=root, env=environment, capture_output=True, text=True, timeout=5,
         )
         assert result.returncode == 0
@@ -244,17 +245,28 @@ def test_team_runtime_skips_the_owner_session_handoff() -> None:
         assert not (root / "session-state.md").exists()
 
 
+def _staged_handoff(root: Path) -> Path:
+    """Copy the script somewhere whose parent is NOT a checkout. Run from the repo
+    its own parent passes _repo_ok, so the no-checkout path is unreachable."""
+    staged = root / "stage" / "src"
+    staged.mkdir(parents=True)
+    shutil.copy(REPO / "src" / "session-handoff.sh", staged / "session-handoff.sh")
+    return staged / "session-handoff.sh"
+
+
 def test_owner_session_handoff_does_not_accept_the_team_bypass_by_default() -> None:
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         result = subprocess.run(
-            ["bash", str(REPO / "src" / "session-handoff.sh")],
+            ["bash", str(_staged_handoff(root))],
             cwd=root,
             env={"HOME": str(root), "PATH": os.environ["PATH"],
                  "SUTANDO_REPO_DIR": str(root / "missing-repo")},
             capture_output=True, text=True, timeout=5,
         )
-        assert result.returncode != 0
+        assert result.returncode != 0, (
+            f"expected the no-checkout hard failure; got rc=0 "
+            f"(stdout={result.stdout!r} stderr={result.stderr!r})")
         assert "could not locate a valid Sutando checkout" in result.stderr
 
 
@@ -1697,6 +1709,8 @@ if __name__ == "__main__":
     test_team_collaborator_requires_one_exact_pre_body_stamp()
     test_tier_parser_prevents_task_body_escalation_and_fails_closed()
     test_team_claude_uses_normal_workspace_with_guardrail_and_output_scan()
+    test_team_runtime_skips_the_owner_session_handoff()
+    test_owner_session_handoff_does_not_accept_the_team_bypass_by_default()
     test_team_codex_uses_normal_workspace_and_owner_configuration()
     test_ag2space_team_room_setting_runs_bridge_to_guarded_runtime_end_to_end()
     test_bounded_runtime_failure_never_falls_back_to_owner_core()

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -183,7 +183,8 @@ def test_team_claude_uses_normal_workspace_with_guardrail_and_output_scan() -> N
 import json, os, sys
 with open(os.environ['PROVIDER_LOG'], 'a') as f:
     f.write(json.dumps({'args': sys.argv[1:], 'cwd': os.getcwd(),
-                        'integration': os.environ.get('TEAM_INTEGRATION_TOKEN')}) + '\\n')
+                        'integration': os.environ.get('TEAM_INTEGRATION_TOKEN'),
+                        'team_runtime': os.environ.get('SUTANDO_TEAM_RUNTIME')}) + '\\n')
 open('claude-work.txt', 'w').write('normal work\\n')
 print(json.dumps({'type': 'result', 'result': 'safe claude result'}))
 """)
@@ -208,6 +209,7 @@ print(json.dumps({'type': 'result', 'result': 'safe claude result'}))
         team_args = call["args"]
         assert Path(call["cwd"]).resolve() == project.resolve()
         assert call["integration"] == "available-to-team-runtime"
+        assert call["team_runtime"] == "1"
         assert team_args[:2] == ["-p", "--no-session-persistence"]
         assert "--dangerously-skip-permissions" in team_args
         assert team_args[team_args.index("--add-dir") + 1] == str(Path.home())
@@ -222,6 +224,38 @@ print(json.dumps({'type': 'result', 'result': 'safe claude result'}))
         assert (project / "claude-work.txt").read_text() == "normal work\n"
         assert (workspace / "results" / team.name).read_text() == "safe claude result"
         assert not (workspace / "results" / guest.name).exists()
+
+
+def test_team_runtime_skips_the_owner_session_handoff() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        environment = {
+            "HOME": str(root),
+            "PATH": os.environ["PATH"],
+            "SUTANDO_REPO_DIR": str(root / "missing-repo"),
+            "SUTANDO_TEAM_RUNTIME": "1",
+        }
+        result = subprocess.run(
+            ["bash", str(REPO / "src" / "session-handoff.sh")],
+            cwd=root, env=environment, capture_output=True, text=True, timeout=5,
+        )
+        assert result.returncode == 0
+        assert result.stdout == "" and result.stderr == ""
+        assert not (root / "session-state.md").exists()
+
+
+def test_owner_session_handoff_does_not_accept_the_team_bypass_by_default() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        result = subprocess.run(
+            ["bash", str(REPO / "src" / "session-handoff.sh")],
+            cwd=root,
+            env={"HOME": str(root), "PATH": os.environ["PATH"],
+                 "SUTANDO_REPO_DIR": str(root / "missing-repo")},
+            capture_output=True, text=True, timeout=5,
+        )
+        assert result.returncode != 0
+        assert "could not locate a valid Sutando checkout" in result.stderr
 
 
 def test_team_codex_uses_normal_workspace_and_owner_configuration() -> None:


### PR DESCRIPTION
## What changed, and why?

A trusted Team task launches a fresh Claude child with the owner's normal workspace, tools, integrations, network, and configuration. That child also inherited Sutando's owner-only `SessionEnd -> session-handoff.sh` hook. On the live host this morning the hook was cancelled as the ephemeral child exited, Claude returned nonzero, and `session-worker.py` replaced the otherwise-completed answer with the generic configured-runtime-unavailable result.

The Team launcher now marks only its Claude child with `SUTANDO_TEAM_RUNTIME=1`; `session-handoff.sh` exits immediately for that child. The owner core remains unmarked and retains normal continuity snapshots. This does not remove settings, hooks, tools, integrations, workspace access, or network access from Team work.

## Review first

- `skills/task-workstream-sessions/scripts/session-worker.py`: child-only environment marker
- `src/session-handoff.sh`: owner-handoff ownership guard
- `tests/task-workstream-session-worker.test.py`: marker propagation, Team skip, and owner negative control

## User behavior proved

Trusted AG2 Space Team tasks can finish through the configured Claude runtime even when the owner profile registers Sutando's SessionEnd handoff. Normal owner sessions still run the handoff.

## Feature/documentation consistency

N/A. This restores the behavior documented and shipped by #2824; it does not change the Team capability or access model.

## Before / after evidence

Live host, parent behavior (`96da21ca` code path; exact child runner):

```text
RuntimeError: SessionEnd hook [bash "/Users/ruiwang/Documents/GitHub/sutando/src/session-handoff.sh" "$TRANSCRIPT_PATH"] failed: Hook cancelled
```

The visible AG2 Space result was consequently:

```text
I could not process this team-tier task because the configured runtime was unavailable. No owner-core fallback was used.
```

Live host with this head's launcher and handoff guard, using the live core's authenticated Claude profile and the real Team output scanner:

```text
$ CLAUDE_CONFIG_DIR=<live-profile> ... python3 -c '<load session-worker; _run_team("claude", exact-response prompt, live workspace)>'
live-team-runtime=PASS
```

The same run loaded the normal configured workspace and settings and returned the scanned terminal result. No owner-core fallback was involved.

## Tests

```text
$ python3 tests/task-workstream-session-worker.test.py
[remote-gateway-bridge] queued task-room-team-e2e
[remote-gateway-bridge] queued task-local-team-cap-e2e
task workstream session worker tests passed

$ python3 tests/session-handoff-pending-questions.test.py
PASS

$ bash tests/install-claude-hooks.test.sh
PASS — install-claude-hooks (33 checks)

$ bash tests/sutando-config-hooks.test.sh
Results: 18 passed, 0 failed

$ python3 tests/health-check-claude-hook-registration.test.py
Ran 26 tests in 0.412s
OK

$ bash -n src/session-handoff.sh
$ python3 -m py_compile skills/task-workstream-sessions/scripts/session-worker.py tests/task-workstream-session-worker.test.py
$ git diff --check
$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts clean)
```

## Live path evidence

The affected live watcher was not restarted: it resolves and starts a fresh handler for each task. I first verified both stuck receipts corresponded to already-delivered archived results, released them through the watcher's sanctioned `HANDLER_DONE: 0` FIFO, and confirmed the dispatch/claim directories were empty. I then ran a real authenticated Claude Team child through `_run_team` and the full result scanner; it returned `TEAM_RUNTIME_OK` in 3.4 seconds. A room-originated follow-up can now traverse the cleared lane.

## Edge cases

- Team child is marked and skips only the owner continuity writer.
- Owner invocation without the marker does not bypass handoff validation.
- Existing Team integration environment remains available.
- Guest tasks remain unhandled by this trusted path.
- Claude nonzero exits, scanner failures, timeouts, and leak detections retain their fail-closed behavior.

## Migrations / permissions / rollback

No migration or permission change. Rollback is this single commit. The marker is child-local and inherited only by tools that child launches.

## Known gaps / follow-up

The separate dead-worker receipt leak is tracked in #2866 / #2867. I recovered the live lane safely, but that PR still needs its current review blocker resolved to make receipt reclamation automatic.
