### PR TITLE
fix(health-check): the summary said "No failures" with two services down

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8808,7 +8808,18 @@ def summary_line(checks) -> str:
     Pure and importable on purpose, so a regression test exercises THIS code
     rather than a copy of it.
     """
+    # Anything not ok/warn/stale renders as ✗ above, so it is a failure here.
+    # Naming the states to exclude keeps a new failure status reported, not lost.
+    fails = [c for c in checks
+             if c.get("status") not in ("ok", "warn", "stale")]
     warns = [c for c in checks if c.get("status") == "warn"]
+    if fails:
+        line = (f"{len(fails)} FAILURE(S): "
+                + ", ".join(c["name"] for c in fails))
+        if warns:
+            line += (f" — plus {len(warns)} warning(s): "
+                     + ", ".join(c["name"] for c in warns))
+        return line
     if not warns:
         return "All systems operational."
     return (f"No failures — {len(warns)} warning(s): "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8765,7 +8765,7 @@ def community_support_line() -> str:
 
 
 #: Statuses that are NOT problems. Everything else is, by the same rule the
-#: issue list uses: `issues = [c for c in checks if c["status"] not in ("ok", "warn")]`.
+#: issue list uses: `issues = [c for c in checks if is_issue(c)]`.
 #: `stale` is an issue but gets its own glyph because it names a specific remedy.
 _BENIGN_STATUSES = ("ok", "warn")
 
@@ -8797,6 +8797,12 @@ def status_icon(status: str) -> str:
     return "✗"
 
 
+def is_issue(check) -> bool:
+    """The single definition of "not healthy". `summary_line` and the exit-code
+    list must use this one, or a run exits non-zero while printing an all-clear."""
+    return check.get("status") not in _BENIGN_STATUSES
+
+
 def summary_line(checks) -> str:
     """The no-failures summary. Warnings are deliberately NOT issues — they must
     not fail the exit code or wake the launchd notifier, and that is unchanged.
@@ -8808,13 +8814,10 @@ def summary_line(checks) -> str:
     Pure and importable on purpose, so a regression test exercises THIS code
     rather than a copy of it.
     """
-    # Anything not ok/warn/stale renders as ✗ above, so it is a failure here.
-    # Naming the states to exclude keeps a new failure status reported, not lost.
-    fails = [c for c in checks
-             if c.get("status") not in ("ok", "warn", "stale")]
+    fails = [c for c in checks if is_issue(c)]
     warns = [c for c in checks if c.get("status") == "warn"]
     if fails:
-        line = (f"{len(fails)} FAILURE(S): "
+        line = (f"{len(fails)} ISSUE(S): "
                 + ", ".join(c["name"] for c in fails))
         if warns:
             line += (f" — plus {len(warns)} warning(s): "
@@ -8835,7 +8838,7 @@ def main():
     quiet = "--quiet" in sys.argv or "-q" in sys.argv
 
     checks = run_all_checks()
-    issues = [c for c in checks if c["status"] not in ("ok", "warn")]
+    issues = [c for c in checks if is_issue(c)]
     codex_notifier = (
         next(
             (

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8956,7 +8956,9 @@ def main():
         if not quiet:
             print(summary_line(checks))
     else:
-        print(f"{len(issues)} issue(s) found:")
+        # One summary for both outcomes: a separate issue-count header here is how
+        # the exit code and the printed summary drifted apart in the first place.
+        print(summary_line(checks))
         for c in issues:
             print(f"  - {c['name']}: {c['status']} ({c['detail']})")
         print(community_support_line())  # pragma: no cover — main() summary glue; the line's content is unit-tested via community_support_line()

--- a/tests/health-check-community-support.test.py
+++ b/tests/health-check-community-support.test.py
@@ -62,7 +62,7 @@ check("BEFORE (clean run): summary shows NO Discord support line",
 # AFTER: an issue present → the Discord line appears under the issue list.
 out_issue = _run_main_capture([{"name": "voice-agent", "status": "down", "detail": "not running"}])
 check("AFTER (issue present): summary shows the Discord support line",
-      "discord.gg/uZHWXXmrCS" in out_issue and "issue(s) found" in out_issue)
+      "discord.gg/uZHWXXmrCS" in out_issue and "ISSUE(S): voice-agent" in out_issue)
 
 print()
 if failures:

--- a/tests/health-check-summary-warnings.test.py
+++ b/tests/health-check-summary-warnings.test.py
@@ -70,7 +70,7 @@ class FailureTests(unittest.TestCase):
         out = summarise([OK, DOWN1])
         self.assertNotIn("All systems operational", out)
         self.assertIn("voice-agent", out)
-        self.assertIn("FAILURE", out)
+        self.assertIn("ISSUE", out)
 
     def test_down_with_warns_does_not_claim_no_failures(self):
         out = summarise([OK, DOWN1, WARN1])
@@ -80,13 +80,38 @@ class FailureTests(unittest.TestCase):
 
     def test_every_failure_is_named(self):
         out = summarise([DOWN1, DOWN2])
-        self.assertIn("2 FAILURE(S)", out)
+        self.assertIn("2 ISSUE(S)", out)
         self.assertIn("voice-agent", out)
         self.assertIn("web-client", out)
 
-    def test_stale_is_not_counted_as_a_failure(self):
-        """`stale` renders as ♻, not ✗ — it must not become a failure here."""
-        self.assertEqual(summarise([OK, STALE]), "All systems operational.")
+    def test_stale_is_reported_because_it_exits_non_zero(self):
+        """`stale` renders ♻ rather than ✗, which is why I first excluded it —
+        but the exit-code list counts it, so an all-clear here would contradict."""
+        out = summarise([OK, STALE])
+        self.assertNotIn("All systems operational", out)
+        self.assertIn("bodhi-dist", out)
+
+    def test_summary_and_exit_code_cannot_disagree(self):
+        """Both must read the same predicate; this is the regression that
+        matters, not the wording."""
+        for combo in ([OK, STALE], [OK, DOWN1], [OK, WARN1], [OK],
+                      [OK, STALE, WARN1], [DOWN1, STALE]):
+            issues = [c for c in combo if hc.is_issue(c)]
+            says_clear = summarise(combo) == "All systems operational."
+            # One direction only: a warning yields a non-clear summary with no
+            # issues, which is correct. What must never happen is exit!=0 + clear.
+            if issues:
+                self.assertFalse(says_clear,
+                                 f"exits 1 on {[c['name'] for c in issues]} "
+                                 f"but summary reads {summarise(combo)!r}")
+
+    def test_is_issue_reads_the_shared_benign_constant(self):
+        """_BENIGN_STATUSES existed and nothing used it; that is how the two
+        rules drifted in the first place."""
+        self.assertEqual(hc._BENIGN_STATUSES, ("ok", "warn"))
+        self.assertFalse(hc.is_issue({"status": "ok"}))
+        self.assertFalse(hc.is_issue({"status": "warn"}))
+        self.assertTrue(hc.is_issue({"status": "stale"}))
 
     def test_an_unknown_future_status_is_reported_not_swallowed(self):
         odd = {"name": "new-probe", "status": "erupted", "detail": ""}

--- a/tests/health-check-summary-warnings.test.py
+++ b/tests/health-check-summary-warnings.test.py
@@ -60,11 +60,8 @@ class SummaryTests(unittest.TestCase):
 
 
 class FailureTests(unittest.TestCase):
-    """The same defect one state over: a ✗ row and the summary said health.
-
-    Observed on a live core 2026-08-13 — voice-agent and web-client both down,
-    summary read "No failures — 8 warning(s)".
-    """
+    """A down row must never be summarised as health: a ✗ present with
+    "All systems operational" is the failure this class exists to reject."""
 
     def test_down_alone_is_not_operational(self):
         out = summarise([OK, DOWN1])

--- a/tests/health-check-summary-warnings.test.py
+++ b/tests/health-check-summary-warnings.test.py
@@ -31,6 +31,9 @@ def summarise(checks):
 OK = {"name": "task-queue", "status": "ok", "detail": ""}
 WARN1 = {"name": "core-supervisor", "status": "warn", "detail": "core degraded"}
 WARN2 = {"name": "screen-capture", "status": "warn", "detail": "not running"}
+DOWN1 = {"name": "voice-agent", "status": "down", "detail": "port 9900"}
+DOWN2 = {"name": "web-client", "status": "down", "detail": "port 8080"}
+STALE = {"name": "bodhi-dist", "status": "stale", "detail": "rebuilt"}
 
 
 class SummaryTests(unittest.TestCase):
@@ -54,6 +57,41 @@ class SummaryTests(unittest.TestCase):
         """Guard the property we deliberately did NOT change."""
         issues = [c for c in [OK, WARN1, WARN2] if c["status"] not in ("ok", "warn")]
         self.assertEqual(issues, [])
+
+
+class FailureTests(unittest.TestCase):
+    """The same defect one state over: a ✗ row and the summary said health.
+
+    Observed on a live core 2026-08-13 — voice-agent and web-client both down,
+    summary read "No failures — 8 warning(s)".
+    """
+
+    def test_down_alone_is_not_operational(self):
+        out = summarise([OK, DOWN1])
+        self.assertNotIn("All systems operational", out)
+        self.assertIn("voice-agent", out)
+        self.assertIn("FAILURE", out)
+
+    def test_down_with_warns_does_not_claim_no_failures(self):
+        out = summarise([OK, DOWN1, WARN1])
+        self.assertNotIn("No failures", out)
+        self.assertIn("voice-agent", out)
+        self.assertIn("core-supervisor", out)
+
+    def test_every_failure_is_named(self):
+        out = summarise([DOWN1, DOWN2])
+        self.assertIn("2 FAILURE(S)", out)
+        self.assertIn("voice-agent", out)
+        self.assertIn("web-client", out)
+
+    def test_stale_is_not_counted_as_a_failure(self):
+        """`stale` renders as ♻, not ✗ — it must not become a failure here."""
+        self.assertEqual(summarise([OK, STALE]), "All systems operational.")
+
+    def test_an_unknown_future_status_is_reported_not_swallowed(self):
+        odd = {"name": "new-probe", "status": "erupted", "detail": ""}
+        out = summarise([OK, odd])
+        self.assertIn("new-probe", out)
 
 
 class SourceTests(unittest.TestCase):


### PR DESCRIPTION
## The defect

`health-check.py`'s summary line reported health while the rows above it said otherwise. Observed on a live core: `voice-agent` and `web-client` both showing `✗`, and the summary read **"No failures — 8 warning(s)"**.

The summary counted only a subset of non-benign statuses, so a row the operator could see was not a row the summary counted.

## What this head does

`_BENIGN_STATUSES = ("ok", "warn")` — **everything else is an issue**, including `stale`, and the summary says `ISSUE(S)` rather than `FAILURE(S)` so the noun matches what is actually counted.

That is deliberately stricter than an earlier revision of this branch, which treated `stale` as benign. A `stale` row means a service is running code older than the checkout — the operator can see it and it is not health, so the summary should not absorb it.

## Evidence (this head, `e8fbb688e`)

```
$ python3 tests/health-check-summary-warnings.test.py
Ran 12 tests — OK

$ git checkout origin/main -- src/health-check.py   # control: parent source, same suite
Ran 12 tests — FAILED (failures=5, errors=2)
```

**Seven of the twelve cases fail without the source change** (five assertion failures, two errors), so the suite genuinely depends on it rather than characterising whatever exists.

Verified at this head:

```
_BENIGN_STATUSES = ('ok', 'warn')
```

## Review history

- The unreachable-production-branch finding from an earlier review is fixed.
- @qingyun-wu confirmed the merge itself is mechanically sound: all three topic commits unchanged, stable topic patch ID `cab51be7`, and the overlapping incoming `src/health-check.py` changes did not alter the topic patch.
- **[P1] body-vs-patch mismatch** — this body previously described the older behaviour (`stale` benign, `FAILURE(S)`, 10 tests / four control failures). Rewritten above to the current patch and its measured output. That was a real defect in the PR, not a wording nit: the body was evidence for a version that no longer existed.
- **[P2] source prose** — the five-line class docstring with dated incident history is collapsed to its invariant at `e8fbb688e`; the incident stays here in the body where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MK5AeA7sHrCk8tZv5sTrt8