### PR TITLE
docs(proactive-loop): the filing assertion could not detect a swallowed entry

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -190,9 +190,15 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
    It reports success in every cheap way: bytes land, the path is right, nothing errors, the file grows. **Only calling the reader shows the zero.** So after writing, assert it:
    ```bash
-   python3 -c "import importlib.util;s=importlib.util.spec_from_file_location('c','src/check-pending-questions.py');m=importlib.util.module_from_spec(s);s.loader.exec_module(m);q=[str(x) for x in m.get_waiting_questions()];print(any('<a distinctive phrase from your question>' in x for x in q))"
+   python3 -c "import importlib.util;s=importlib.util.spec_from_file_location('c','src/check-pending-questions.py');m=importlib.util.module_from_spec(s);s.loader.exec_module(m);q=m.get_waiting_questions();print(len(q), sum('<distinctive phrase from your TITLE>' in (x.get('title') or '') for x in q))"
    ```
-   A `True` is the only proof the question exists for anyone but you.
+   **Match on `title`, and check that the COUNT went up — not `str(x)`.** ⚠ 2026-08-13: the
+   substring-anywhere form above this line passed while the entry was **swallowed into the
+   neighbouring section's body**, because a merged section still contains your text. The reader
+   splits on `##` ONLY; a `###` heading is body text, not a new question. Tell: a purely additive
+   edit (`git diff --numstat` = N/0) that leaves the count UNCHANGED. I saw that delta=0, explained
+   it away as a stale count, and only a title-level check showed the zero. The count is the
+   discriminator; the substring cannot fail the way this actually fails.
 
 9. **Ensure the streaming watcher is running.** **Read the `task-watcher` probe from the `health-check.py` run you already did in step 3 — do not re-derive liveness here.** That probe is the authoritative signal: it enumerates real watcher process trees (`_watcher_trees()` in `src/health-check.py`) and reports which of four states holds. Act on the state it names:
 

--- a/tests/pending-questions-h3-is-not-a-question.test.py
+++ b/tests/pending-questions-h3-is-not-a-question.test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""A `###` heading is body text, not a new question.
+
+Documented in the proactive-loop skill because writing one silently folds the
+entry into the preceding question instead of adding one.
+"""
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+BASE = """# Pending questions
+
+## First question
+
+Body of the first.
+
+"""
+DIVIDER = "\n# Resolved\n\n## An old one\n"
+
+
+def _reader(path):
+    spec = importlib.util.spec_from_file_location(
+        "cpq", ROOT / "src" / "check-pending-questions.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.PQ_FILE = path
+    return mod
+
+
+class TestHeadingLevelDecidesWhatCounts(unittest.TestCase):
+    def _count(self, body):
+        with tempfile.TemporaryDirectory() as td:
+            p = pathlib.Path(td) / "pq.md"
+            p.write_text(BASE + body + DIVIDER)
+            return _reader(p).get_waiting_questions()
+
+    def test_h3_does_not_add_a_question(self):
+        q = self._count("### Swallowed by the section above\n\nSome body.\n")
+        self.assertEqual(len(q), 1, [x.get("title") for x in q])
+        self.assertFalse(
+            any("Swallowed" in (x.get("title") or "") for x in q),
+            "an h3 must not surface as its own question title")
+
+    def test_h2_does_add_a_question(self):
+        q = self._count("## Counted as its own question\n\nSome body.\n")
+        self.assertEqual(len(q), 2, [x.get("title") for x in q])
+        self.assertTrue(any("Counted" in (x.get("title") or "") for x in q))
+
+    def test_the_h3_text_is_still_findable_which_is_why_a_substring_check_lies(self):
+        """The failure mode the skill warns about: present, but not a question."""
+        q = self._count("### Swallowed by the section above\n\nSome body.\n")
+        self.assertTrue(any("Swallowed" in str(x) for x in q),
+                        "the text survives inside the previous section...")
+        self.assertFalse(any("Swallowed" in (x.get("title") or "") for x in q),
+                         "...so only a title-level check can tell the two apart")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/pending-questions-h3-is-not-a-question.test.py
+++ b/tests/pending-questions-h3-is-not-a-question.test.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 """A `###` heading is body text, not a new question.
-
-Documented in the proactive-loop skill because writing one silently folds the
-entry into the preceding question instead of adding one.
-"""
+Why it matters is in the PR body."""
 import importlib.util
 import pathlib
 import tempfile


### PR DESCRIPTION
## The bug

Step 8 of the proactive-loop skill tells the agent to prove a pending question actually landed:

```python
q=[str(x) for x in get_waiting_questions()]; any('<my phrase>' in x for x in q)
```

**That check passes in both worlds.** The reader splits on `##` only, so a `###` heading is body text — the entry folds into the *preceding* question rather than becoming its own — and the merged section still contains the phrase being searched for. The assertion has no failing case for the failure it exists to catch.

## Observed

On this host, filing a question with a `###` heading:

```console
$ git diff --numstat -- hosts/<host>/pending-questions.md
23      0                                  # purely additive

$ python3 -c "...get_waiting_questions()..."
waiting: 87        # before the edit
waiting: 87        # after the edit
substring check:   True
```

Additive edit, unchanged count, and the check said success. Promoting the heading to `##` took it to 88 and the title-level match from 0 to 1.

## The change

Step 8 now matches on `title`, checks the count moved, and names both the `##`-only split and the tell (an additive edit that changes no count).

## The test

`tests/pending-questions-h3-is-not-a-question.test.py` — 3 cases:

- `###` does not add a question
- `##` does
- the `###` text is **still findable by substring** while absent from every `title` — which is precisely why the old assertion could not fail

```console
$ python3 tests/pending-questions-h3-is-not-a-question.test.py
Ran 3 tests in 0.023s
OK
```

**Being straight about what this test is:** it passes on current `main` without any source change. It is a *characterization* test, not a regression test for a fix — the behaviour is not new, it was undocumented, and pinning it is what keeps the doc's claim from drifting from the code. There is no "fails without the fix" control to show here because there is no source fix; the defect was in the instructions.

## Neighbours unchanged

```console
  check-pending-questions-bullet.test.py       5/5 pass
  check-pending-questions-collapse.test.py     20 passed, 0 failed
  check-pending-questions-open-status.test.py  11 passed, 0 failed
  check-pending-questions-snippet.test.py      10/10 pass
  pending-questions-body-field.test.py         OK
  pending-questions-divider-anchor.test.py     44/44 passed
  pending-questions-readers-agree.test.py      11/11 passed
  pending-questions-zero-is-explained.test.py  16/16 passed
```

Single concern: the filing assertion and the rule it depends on. Sibling to the `# Resolved` divider guidance already in that step, which fails the same way — success in every cheap check, zero only visible from the reader.
