### PR TITLE
docs(context-reconstruct): a reader can return a plausible PARTIAL result

### DIFF
--- a/skills/context-reconstruct/SKILL.md
+++ b/skills/context-reconstruct/SKILL.md
@@ -58,3 +58,49 @@ When the thing in front of you isn't self-contained — terse ("y", "no", "?", a
   **The guidance is unchanged — do not re-add the flat path — but the reason is cross-host CONTENT DELIVERY on a shared path, NOT data loss.** Keeping the wrong reason here mattered: this file is loaded on every proactive-loop pass via step 0.7, so it re-taught a claim the owner had already retracted, and on 2026-08-04 I repeated "destroyed a 1056-line anchor" back to Chi from it. A retraction has to reach the file that gets *read*, not only the file that learned it.
 
   Note the 2026-06-25 entry above is left as written — it was true then.
+
+- **2026-08-13 — the first entry here that is NOT "I did not read." I read, and the reader returned a
+  plausible partial result.** Every entry above assumes the agent is the unreliable part, and the fix
+  is always *go read the durable record*. This one is about the record's **reader** being unreliable,
+  and it defeats the whole step silently.
+
+  A history read returned only messages from a recent cutoff onward — at every limit up to 1000 —
+  while a local archive held months of earlier traffic from the same source. Probed with known ids
+  from before the cutoff: **0 returned**, with a positive control confirming the id field was
+  populated on every message it *did* return, so the zero was absence rather than an empty field.
+
+  **The property to carry: an agent cannot distinguish a plausible partial result from a complete
+  one.** A windowed read and a genuinely short thread are the same object from inside. So step 0.7's
+  "reconstruct the live thread" can report success while returning almost nothing, and felt
+  compliance is exactly as unreliable here as felt confidence is everywhere else in this file.
+
+  **What to do instead.** When a reconstruction returns fewer items than the situation implies, treat
+  the shortfall as *unexplained* until something **outside that reader** accounts for it. Three cheap
+  discriminating probes, in order:
+
+  1. **Ask for FEWER items than certainly exist.** This pins what any "complete" flag means. If the
+     flag is just `returned == requested`, it is not a truncation signal at all.
+  2. **Ask again after new activity.** Does the count grow, or does the window slide? A *wider*
+     window returning *fewer* results proves the reader is not enumerating.
+  3. **Check against an independent record of what arrived** — and verify that record measures the
+     thing you are about to name.
+
+  **Probe 3 is where the second mistake lives.** An outside record is not automatically trustworthy:
+
+  - **Match on the field, never a bare substring.** A substring search over a message corpus also
+    matches items that merely *quote* the identifier, which silently widens the population.
+  - **A file mtime is a proxy that is `>=` the event time, and its tail is brutal.** Calibrated over
+    2678 files carrying both a declared timestamp and an mtime: median lag **+1s**, maximum lag
+    **8.1 days**. An excellent proxy almost always and catastrophically wrong occasionally — the worst
+    possible shape, because a small sample lands in the well-behaved majority and reads as
+    confirmation. **Quote a max, never a rate**: measured across three populations the tail frequency
+    spans two orders of magnitude (0.1% / 5.5% / 20%), so the rate is a property of the corpus, not of
+    the archive. Name the corpus and the filter with any such number.
+  - Look for **an era or subset where ground truth was recorded for a different reason** — here, older
+    files still carried a declared timestamp that the current schema had dropped. That is usually
+    where calibration data hides when the present has none.
+
+  **And "two independent methods" must mean methods with different FAILURE MODES**, not two
+  invocations. Two calls that share a cutoff, a corpus, or a path convention can agree perfectly while
+  omitting the same thing. Independence is semantic, and the only way to establish it is to have seen
+  the two disagree on a case where you know the answer.


### PR DESCRIPTION
## What

`skills/context-reconstruct/SKILL.md` gains one practice-log entry. Every entry in that log so far assumes **the agent** is the unreliable part, and the fix is always *go read the durable record*. This one is about the record's **reader**.

A history read returned only messages from a recent cutoff onward — at every limit up to 1000 — while a local archive held months of earlier traffic from the same source. Probed with known ids from before the cutoff: **0 returned**, with a positive control confirming the id field was populated on every message it *did* return, so the zero was absence rather than an empty field.

## Why it belongs in this skill specifically

Step 0.7 of the proactive loop invokes this skill to "reconstruct the live thread." **An agent cannot distinguish a plausible partial result from a complete one** — a windowed read and a genuinely short thread are the same object from inside. So that step can report success having returned almost nothing, and felt compliance is exactly as unreliable here as felt confidence is everywhere else in the file.

## What it adds

Three discriminating probes, ordered by cost:

1. ask for **fewer** items than certainly exist — this pins what any "complete" flag means;
2. ask again after new activity — a **wider** window returning **fewer** results proves the reader is not enumerating;
3. check against an independent record — **and verify that record measures the thing you are about to name.**

Probe 3 is where the second mistake lives, so the entry carries its traps: match on the field rather than a bare substring (a substring search also matches items that merely *quote* the identifier), and treat a file mtime as a proxy that is `>=` the event time. Calibrated over 2678 files carrying both a declared timestamp and an mtime: **median lag +1s, maximum 8.1 days**. Excellent almost always, catastrophic occasionally — the worst shape, because a small sample lands in the well-behaved majority and reads as confirmation. Hence: **quote a max, never a rate.** Across three populations the tail frequency spanned two orders of magnitude (0.1% / 5.5% / 20%), so a rate describes the corpus, not the archive.

It closes with the sharpest part: **"two independent methods" must mean methods with different failure modes**, not two invocations. Two calls sharing a cutoff, a corpus, or a path convention can agree perfectly while omitting the same thing.

## Scope

Documentation only — one appended section, no code, no behaviour change.

```
skills/context-reconstruct/SKILL.md | +46 -0
```

The specifics of the incident (which reader, which source) are deliberately generalised out; the transferable property is the reader-completeness one, and naming the instrument would date the lesson without strengthening it.
