### PR TITLE
fix(cron-gate): a guest-tier task defers every owner-facing cron

### DIFF
--- a/scripts/cron-gate.sh
+++ b/scripts/cron-gate.sh
@@ -64,7 +64,7 @@ owner_task_queued() {
     [ -n "$f" ] || continue
     tier="$(sed -n 's/^access_tier:[[:space:]]*//p' "$f" 2>/dev/null | head -1 | tr -d '[:space:]')"
     case "$tier" in
-      team|other|ambient) continue ;;   # explicitly not the owner -> ignore
+      team|other|guest|ambient) continue ;;   # explicitly not the owner -> ignore
       *) return 0 ;;                    # owner, or unstated -> yield
     esac
   done <<EOF

--- a/tests/cron-gate.test.sh
+++ b/tests/cron-gate.test.sh
@@ -144,13 +144,13 @@ out="$(SUTANDO_WORKSPACE="$TMPDIR" SUTANDO_TEST_MODE=1 bash "$GATE" test-team ec
 [ "$out" = "ran-despite-team" ] || fail "team-tier task must NOT defer, got '$out'"
 ok "access_tier: team does not trigger deferral"
 
-for tier in other ambient; do
+for tier in other ambient guest; do
   rm -f "$TMPDIR/tasks/"task-*.txt
   printf 'id: t\naccess_tier: %s\n' "$tier" > "$TMPDIR/tasks/task-$tier-1.txt"
   out="$(SUTANDO_WORKSPACE="$TMPDIR" SUTANDO_TEST_MODE=1 bash "$GATE" test-$tier echo "ran-$tier" 2>&1)"
   [ "$out" = "ran-$tier" ] || fail "access_tier: $tier must NOT defer, got '$out'"
 done
-ok "access_tier: other / ambient do not trigger deferral"
+ok "access_tier: other / ambient / guest do not trigger deferral"
 
 # --- but an OWNER task still defers, even beside non-owner ones ---------------
 printf 'id: t\naccess_tier: owner\ntask: real owner work\n' > "$TMPDIR/tasks/task-owner-1.txt"
@@ -159,7 +159,7 @@ case "$out" in
   *"deferring test-mixed"*) : ;;
   *) fail "owner task beside non-owner ones must still defer, got '$out'" ;;
 esac
-ok "an owner task still defers even alongside team/other/ambient tasks"
+ok "an owner task still defers even alongside team/other/ambient/guest tasks"
 
 # --- a task with NO access_tier line still defers (fails CLOSED) --------------
 # CLAUDE.md: tasks without an access_tier field get full owner processing, so an


### PR DESCRIPTION
## The defect

`cron-gate.sh` skips deferral for explicitly non-owner tiers:

```sh
team|other|ambient) continue ;;   # explicitly not the owner -> ignore
*) return 0 ;;                    # owner, or unstated -> yield
```

`guest` is not on that list, so it hits the catch-all that treats an unrecognised tier as the owner. A peer bot's message therefore silences the owner's own crons — the same starvation #2559 fixed for `team`, still live for `guest`.

Both suppressors exit 0, so this is invisible from outside: `cron-gate` returns 0 whether it deferred or ran, and `pr_flag.py` prints `NO_CHANGE` when its hash is unchanged. "Deferred", "ran and nothing changed", and "ran and found things" are indistinguishable.

## Evidence it is live

Measured on this host, last 24h of archived tasks:

```
owner  164   -> defers crons
team   120      (correctly ignored)
guest   29   -> defers crons   <- this PR
```

And the gate deferring in the moment I checked it:

```
$ bash scripts/cron-gate.sh pr-flag echo "RAN — gate was open"
cron-gate: owner tasks queued — deferring pr-flag (will retry next fire)
```

`pr-flag` fires hourly at `:17`; with ~8 qualifying tasks an hour the queue is rarely empty at that minute.

## Before / after

The test case was added **first** and run against the unfixed gate, so it fails in the broken state:

```
$ bash tests/cron-gate.test.sh     # at the parent commit, test added, fix not applied
FAIL: access_tier: guest must NOT defer, got
  'cron-gate: owner tasks queued — deferring test-guest (will retry next fire)'
```

At HEAD:

```
$ bash tests/cron-gate.test.sh
  ok  access_tier: team does not trigger deferral
  ok  access_tier: other / ambient / guest do not trigger deferral
  ok  an owner task still defers even alongside team/other/ambient/guest tasks
  ok  a task with no access_tier still defers — unknown tier fails closed
OK — 16/16 cron-gate tests passed
```

## Scope

One word in the case pattern, plus the tier added to the existing test loop. The catch-all still fails **closed** for genuinely unknown tiers — that case is asserted and still passes; only the four explicitly-non-owner tiers are ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)