### PR TITLE
fix(refresh-skill): hardcoded repo path made it a no-op that reports success

### DIFF
--- a/skills/refresh-skill.sh
+++ b/skills/refresh-skill.sh
@@ -25,8 +25,13 @@ set -uo pipefail   # NOT -e: one skill's hiccup must not strand a half-swapped s
 # Precedence: SKILLS_DST env > sutando-config helper (if reachable) > ~/.claude/skills.
 SKILLS_DST="${SKILLS_DST:-}"
 if [ -z "$SKILLS_DST" ]; then
-  _cfg="${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}/scripts/sutando-config.sh"
-  [ -x "$_cfg" ] && SKILLS_DST="$(bash "$_cfg" claude-home-path skills 2>/dev/null || true)"
+  # The helper lives in THIS script's own repo — a hardcoded path resolves to an
+  # empty dir on any clone elsewhere, and every skill then reads as absent.
+  _repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+  _cfg="${SUTANDO_REPO_DIR:-$_repo}/scripts/sutando-config.sh"
+  # -f, not -x: it is invoked via `bash`, so a missing exec bit must not
+  # silently disable resolution and fall through to the wrong directory.
+  [ -f "$_cfg" ] && SKILLS_DST="$(bash "$_cfg" claude-home-path skills 2>/dev/null || true)"
   SKILLS_DST="${SKILLS_DST:-$HOME/.claude/skills}"
 fi
 SETTLE_S="${REFRESH_SKILL_SETTLE_S:-1}"
@@ -40,6 +45,9 @@ EXCLUDES=(--exclude='workspace' --exclude='node_modules' --exclude='generated'
 refresh_one() {
   local name="$1"
   local link="$SKILLS_DST/$name"
+  if [ ! -e "$link" ] && [ ! -L "$link" ]; then
+    echo "  skip $name (NOT INSTALLED at $SKILLS_DST — nothing to refresh)"; return 0
+  fi
   if [ ! -L "$link" ]; then
     echo "  skip $name (not a symlink — won't clobber a local/copy install)"; return 0
   fi

--- a/tests/refresh-skill-resolves-its-own-repo.test.sh
+++ b/tests/refresh-skill-resolves-its-own-repo.test.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
-# refresh-skill.sh must resolve its config helper from ITS OWN repo.
-#
-# It used to hardcode `${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}`. On a clone
-# anywhere else that path does not exist, `-x` fails, and SKILLS_DST silently
-# falls back to ~/.claude/skills — an empty directory on such a host. Every
-# skill then reads as absent, and because the guard was `[ ! -L "$link" ]`
-# (true for a MISSING path as well as a real directory) each one printed
-# "skip <name> (not a symlink — won't clobber a local/copy install)" before the
-# script announced "done". A no-op that reports success, on all 99 skills.
-#
-# Discriminator: the fake repo's helper emits a UNIQUE temp dir. Only a script
-# that resolves from its own location can find it, so this passes on a machine
-# that happens to have ~/Desktop/sutando too.
+# The fake repo's helper emits a UNIQUE temp dir, so this still discriminates on
+# a host that happens to have ~/Desktop/sutando.
 set -eu
 
 TMP="$(mktemp -d)"

--- a/tests/refresh-skill-resolves-its-own-repo.test.sh
+++ b/tests/refresh-skill-resolves-its-own-repo.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# refresh-skill.sh must resolve its config helper from ITS OWN repo.
+#
+# It used to hardcode `${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}`. On a clone
+# anywhere else that path does not exist, `-x` fails, and SKILLS_DST silently
+# falls back to ~/.claude/skills — an empty directory on such a host. Every
+# skill then reads as absent, and because the guard was `[ ! -L "$link" ]`
+# (true for a MISSING path as well as a real directory) each one printed
+# "skip <name> (not a symlink — won't clobber a local/copy install)" before the
+# script announced "done". A no-op that reports success, on all 99 skills.
+#
+# Discriminator: the fake repo's helper emits a UNIQUE temp dir. Only a script
+# that resolves from its own location can find it, so this passes on a machine
+# that happens to have ~/Desktop/sutando too.
+set -eu
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+ok()   { echo "  ok  $1"; }
+fail() { echo "FAIL: $1"; fails=$((fails+1)); }
+
+REAL_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)/skills/refresh-skill.sh"
+[ -f "$REAL_SCRIPT" ] || { echo "cannot find refresh-skill.sh"; exit 1; }
+
+# --- a fake repo at a path that is NOT ~/Desktop/sutando ----------------------
+REPO="$TMP/some/other/place/sutando"
+mkdir -p "$REPO/scripts" "$REPO/skills"
+cp "$REAL_SCRIPT" "$REPO/skills/refresh-skill.sh"
+
+DST="$TMP/unique-skills-dst"        # only reachable via the fake repo's helper
+mkdir -p "$DST"
+cat > "$REPO/scripts/sutando-config.sh" <<EOF
+#!/usr/bin/env bash
+[ "\${1:-}" = "claude-home-path" ] && { echo "$DST"; exit 0; }
+exit 1
+EOF
+# deliberately NOT chmod +x: it is invoked via \`bash\`, so a missing exec bit
+# must not silently disable resolution.
+
+SRC="$TMP/skill-src/demo"
+mkdir -p "$SRC"; echo "# demo" > "$SRC/SKILL.md"
+ln -s "$SRC" "$DST/demo"
+
+out="$(cd "$TMP" && REFRESH_SKILL_SETTLE_S=0 bash "$REPO/skills/refresh-skill.sh" demo 2>&1 || true)"
+
+case "$out" in
+  *"refreshed demo"*) ok "resolves the helper from its own repo, not a hardcoded path" ;;
+  *"not a symlink"*|*"NOT INSTALLED"*)
+      fail "fell back to the wrong skills dir — a symlinked skill read as absent. Got: $out" ;;
+  *)  fail "unexpected output: $out" ;;
+esac
+
+[ -L "$DST/demo" ] || fail "the symlink must survive a refresh"
+[ "$(readlink "$DST/demo")" = "$SRC" ] || fail "symlink must still point at its source"
+ok "symlink restored and still points at its source"
+
+# --- an ABSENT skill must not be reported as a protective refusal -------------
+out2="$(cd "$TMP" && REFRESH_SKILL_SETTLE_S=0 bash "$REPO/skills/refresh-skill.sh" nosuchskill 2>&1 || true)"
+case "$out2" in
+  *"NOT INSTALLED"*) ok "an absent skill says NOT INSTALLED, not 'won't clobber a local install'" ;;
+  *"not a symlink"*) fail "absent skill misreported as a copy-install refusal: $out2" ;;
+  *) fail "unexpected output for absent skill: $out2" ;;
+esac
+
+# --- a REAL directory is still protected -------------------------------------
+mkdir -p "$DST/copyinstall"
+out3="$(cd "$TMP" && REFRESH_SKILL_SETTLE_S=0 bash "$REPO/skills/refresh-skill.sh" copyinstall 2>&1 || true)"
+case "$out3" in
+  *"not a symlink"*) ok "a real directory is still refused (copy install protected)" ;;
+  *) fail "a real dir must still be refused, got: $out3" ;;
+esac
+[ -d "$DST/copyinstall" ] || fail "copy install must not be removed"
+
+if [ "$fails" -eq 0 ]; then echo "OK — refresh-skill resolution tests passed"; else
+  echo "$fails failure(s)"; exit 1; fi


### PR DESCRIPTION
## The defect

```sh
_cfg="${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}/scripts/sutando-config.sh"
[ -x "$_cfg" ] && SKILLS_DST="$(bash "$_cfg" claude-home-path skills 2>/dev/null || true)"
SKILLS_DST="${SKILLS_DST:-$HOME/.claude/skills}"
```

On any clone not at `~/Desktop/sutando`, that path does not exist, `-x` fails, and `SKILLS_DST` falls through to `~/.claude/skills` — which is **empty** on such a host. Every skill then reads as absent, and the guard

```sh
if [ ! -L "$link" ]; then
  echo "  skip $name (not a symlink — won't clobber a local/copy install)"
```

is true for a **missing** path exactly as for a real directory. So the script prints a protective-sounding refusal for each skill and then announces `done — updated skills are live in the running session (no restart)`.

It is a no-op that reports success. `--all` prints 99 of these.

## Measured on this host

Repo is at `/Users/wangchi/stando-ui/sutando`; the real skills dir holds **99 symlinks**.

```
$ bash skills/refresh-skill.sh zzz-does-not-exist          # current main
  skip zzz-does-not-exist (not a symlink — won't clobber a local/copy install)
  done — updated skills are live in the running session (no restart).

$ bash skills/refresh-skill.sh zzz-does-not-exist          # this branch
  skip zzz-does-not-exist (NOT INSTALLED at /Users/.../.claude-sutando/skills — nothing to refresh)
```

The second names the directory that actually holds the 99 symlinks.

## Three fixes, one failure

1. **Resolve the helper from the script's own location.** It lives at `<repo>/skills/refresh-skill.sh`, so the repo is one level up. This removes the hardcoded `$HOME/Desktop/...`, which is the banned-host-path class `scripts/review-checks.sh` scans for.
2. **`-f`, not `-x`.** The helper is invoked as `bash "$_cfg"`, so the exec bit is irrelevant to running it — but requiring it silently disabled resolution.
3. **Distinguish absent from copy-installed.** `! -L` conflated them. An absent skill now says `NOT INSTALLED`; a path that genuinely exists and is not a symlink still gets the original refusal, and is still never removed.

## Before / after

New test, run against the **parent** commit:

```
FAIL: fell back to the wrong skills dir — a symlinked skill read as absent.
      Got:   skip demo (not a symlink — won't clobber a local/copy install)
  ok  symlink restored and still points at its source
FAIL: absent skill misreported as a copy-install refusal:
        skip nosuchskill (not a symlink — won't clobber a local/copy install)
  ok  a real directory is still refused (copy install protected)
2 failure(s)
```

At HEAD:

```
  ok  resolves the helper from its own repo, not a hardcoded path
  ok  symlink restored and still points at its source
  ok  an absent skill says NOT INSTALLED, not 'won't clobber a local install'
  ok  a real directory is still refused (copy install protected)
OK — refresh-skill resolution tests passed
```

The test builds a fake repo at a temp path whose helper emits a **unique** temp dir, so only a script resolving from its own location can find it — it therefore still discriminates on a machine that happens to have `~/Desktop/sutando`. It touches nothing outside `mktemp -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)