### PR TITLE
feat(gws-gmail-voice): move the reply-orphan guard into the gmail skill

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-211 modules indexed.
+212 modules indexed.
 
 ## `src/`
 
@@ -120,6 +120,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`services_status.py`** — Per-host services-status emitter for the bundled Sutando runtime.
 - **`session-handoff.sh`** — Session handoff — writes a summary for the next session to pick up.
 - **`single_instance.py`** — Single-instance guard for long-running bridge daemons.
+- **`skill_hooks.py`** — Discovery for skill-declared Claude Code hooks (`hooks` in a skill manifest).
 - **`slack-bridge.py`** — Slack bridge for Sutando — receives DMs + @mentions via Socket Mode, writes to tasks/, sends replies from results/.
 - **`slack_owner.py`** — Slack owner-recipient resolution helpers.
 - **`slack_proactive_receipts.py`** — Durable idempotency receipts for Slack proactive-result delivery.

--- a/scripts/lint-skill.py
+++ b/scripts/lint-skill.py
@@ -55,6 +55,7 @@ KNOWN_TOP = {
     "name", "scope", "version", "owner", "license", "description", "stability",
     "agent_compatibility", "dependencies", "permissions", "contract",
     "provenance", "enabled", "access_tier", "tools", "server", "startup", "config",
+    "hooks",
 }
 # Signals a skill actually touches the network (used for the permission cross-check).
 # No trailing \b: signals ending in a space/paren (`curl `, `fetch(`) are followed
@@ -163,6 +164,28 @@ def _lint_manifest(skill_dir: Path) -> tuple[list[str], list[str]]:
             tpath = skill_dir / re.sub(r"^\./", "", tools_rel)
             if not tpath.exists():
                 err(f"tools path '{tools_rel}' does not exist")
+
+    hooks = m.get("hooks")
+    if hooks is not None:
+        if not isinstance(hooks, list):
+            err(f"hooks must be a list, got {type(hooks).__name__}")
+        else:
+            for i, hook in enumerate(hooks):
+                if not isinstance(hook, dict):
+                    err(f"hooks[{i}] must be an object")
+                    continue
+                event, cmd = hook.get("event"), hook.get("command")
+                if not isinstance(event, str) or not event:
+                    err(f"hooks[{i}] missing 'event'")
+                if not isinstance(cmd, str) or not cmd:
+                    err(f"hooks[{i}] missing 'command'")
+                    continue
+                # Same escape rule as tools: a hook outside its skill dir defeats
+                # the per-skill model, and discovery silently drops what it can't find.
+                if ".." in cmd.split("/"):
+                    err(f"hooks[{i}] command '{cmd}' must not escape the skill dir (no '..')")
+                elif not (skill_dir / re.sub(r"^\./", "", cmd)).exists():
+                    err(f"hooks[{i}] command '{cmd}' does not exist")
 
     return (errors, warnings)
 

--- a/scripts/lint-skill.py
+++ b/scripts/lint-skill.py
@@ -22,6 +22,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from skill_hooks import resolve_hook_command  # noqa: E402
+
 
 def _repo_root() -> Path:
     """Repo root — NOT the workspace. Resolves via git (the sanctioned method,
@@ -180,10 +183,10 @@ def _lint_manifest(skill_dir: Path) -> tuple[list[str], list[str]]:
                 if not isinstance(cmd, str) or not cmd:
                     err(f"hooks[{i}] missing 'command'")
                     continue
-                # Same escape rule as tools: a hook outside its skill dir defeats
-                # the per-skill model, and discovery silently drops what it can't find.
-                if ".." in cmd.split("/"):
-                    err(f"hooks[{i}] command '{cmd}' must not escape the skill dir (no '..')")
+                # One containment rule, shared with discovery: lint that accepts
+                # what discovery registers is the only version that gates anything.
+                if resolve_hook_command(skill_dir, cmd) is None:
+                    err(f"hooks[{i}] command '{cmd}' must resolve inside the skill dir")
                 elif not (skill_dir / re.sub(r"^\./", "", cmd)).exists():
                     err(f"hooks[{i}] command '{cmd}' does not exist")
 

--- a/scripts/lint-skill.py
+++ b/scripts/lint-skill.py
@@ -22,8 +22,19 @@ import subprocess
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-from skill_hooks import resolve_hook_command  # noqa: E402
+
+def resolve_hook_command(skill_dir: Path, command: str) -> Path | None:
+    """Delegate to src/skill_hooks: one containment rule, not a second copy.
+    Lazy via _repo_root() — a __file__ parent-walk trips the resolution gate."""
+    global _RESOLVE_HOOK
+    if _RESOLVE_HOOK is None:
+        sys.path.insert(0, str(_repo_root() / "src"))
+        from skill_hooks import resolve_hook_command as _impl
+        _RESOLVE_HOOK = _impl
+    return _RESOLVE_HOOK(skill_dir, command)
+
+
+_RESOLVE_HOOK = None
 
 
 def _repo_root() -> Path:

--- a/skills/gws-gmail-voice/hooks/reply-orphan-guard.py
+++ b/skills/gws-gmail-voice/hooks/reply-orphan-guard.py
@@ -5,20 +5,43 @@
 """
 import json
 import re
+import shlex
 import sys
 
 REPLY_SUBJECT = re.compile(r'(?i)(?:^|["\'\s:])(?:re|fwd|fw)\s*:', re.M)
 SEND_CALL = re.compile(r'gws\s+gmail\s+\+send\b')
-# +reply is the only gws form that threads. --message-id does NOT rescue +send:
-# the flag is not wired to a header there, so honouring it reopens the orphan.
-SAFE_FORM = re.compile(r'\+reply\b|in-?reply-?to', re.I)
+
+
+def _gmail_calls(tokens: list[str]) -> list[tuple[str, list[str]]]:
+    """(subcommand, following tokens) per `gws gmail …` call in the command."""
+    return [(tokens[i + 2], tokens[i + 3:]) for i, tok in enumerate(tokens)
+            if tok == "gws" and tokens[i + 1:i + 2] == ["gmail"] and len(tokens) > i + 2]
+
+
+def _flag(tokens: list[str], name: str) -> str | None:
+    for i, tok in enumerate(tokens):
+        if tok == name:
+            return tokens[i + 1] if i + 1 < len(tokens) else ""
+        if tok.startswith(name + "="):
+            return tok.split("=", 1)[1]
+    return None
 
 
 def decide(cmd: str) -> bool:
     """True when this command must be denied."""
-    return bool(SEND_CALL.search(cmd)
-                and not SAFE_FORM.search(cmd)
-                and REPLY_SUBJECT.search(cmd))
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        # Unparseable quoting fails CLOSED — never let untokenizable text
+        # be read as evidence that the call is a safe one.
+        return bool(SEND_CALL.search(cmd) and REPLY_SUBJECT.search(cmd))
+    for sub, rest in _gmail_calls(tokens):
+        if sub != "+send":
+            continue  # +reply is the only threading form; nothing else sends.
+        subject = _flag(rest, "--subject")
+        if REPLY_SUBJECT.search(subject if subject is not None else cmd):
+            return True
+    return False
 
 
 def main() -> int:

--- a/skills/gws-gmail-voice/hooks/reply-orphan-guard.py
+++ b/skills/gws-gmail-voice/hooks/reply-orphan-guard.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""gmail-reply-orphan-guard — PreToolUse(Bash) hook that BLOCKS a `gws gmail +send`
+whose subject is a reply, because +send has no thread flag and orphans it.
+
+`gws gmail +send` cannot set In-Reply-To/References, so a reply sent through it
+starts a NEW thread — observable as `threadId == id`. Only `+reply --message-id`
+threads correctly. Detection after the fact does not help; the send is the damage.
+
+Fail-OPEN on any error: a crashing hook must never wedge the core.
+"""
+import json
+import re
+import sys
+
+REPLY_SUBJECT = re.compile(r'(?i)(?:^|["\'\s:])(?:re|fwd|fw)\s*:', re.M)
+SEND_CALL     = re.compile(r'gws\s+gmail\s+\+send\b')
+HAS_THREADING = re.compile(r'--message-id\b|\+reply\b|in-?reply-?to', re.I)
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command") or ""
+    if not SEND_CALL.search(cmd):
+        return 0
+    if HAS_THREADING.search(cmd):
+        return 0
+    if not REPLY_SUBJECT.search(cmd):
+        return 0
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": (
+            "`gws gmail +send` has no thread flag, so a Re:/Fwd: subject sent this way starts a NEW "
+            "thread (threadId == id) and the recipient sees an orphan. Use "
+            "`gws gmail +reply --message-id <their-message-id>` instead, which sets "
+            "In-Reply-To/References. Get the id from the message you are replying to."),
+    }}))
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/gws-gmail-voice/hooks/reply-orphan-guard.py
+++ b/skills/gws-gmail-voice/hooks/reply-orphan-guard.py
@@ -1,34 +1,40 @@
 #!/usr/bin/env python3
-"""gmail-reply-orphan-guard — PreToolUse(Bash) hook that BLOCKS a `gws gmail +send`
-whose subject is a reply, because +send has no thread flag and orphans it.
+"""PreToolUse(Bash) hook: block a `gws gmail +send` carrying a reply subject.
 
-`gws gmail +send` cannot set In-Reply-To/References, so a reply sent through it
-starts a NEW thread — observable as `threadId == id`. Only `+reply --message-id`
-threads correctly. Detection after the fact does not help; the send is the damage.
-
-Fail-OPEN on any error: a crashing hook must never wedge the core.
++send cannot set In-Reply-To/References, so the reply starts a new thread.
 """
 import json
 import re
 import sys
 
 REPLY_SUBJECT = re.compile(r'(?i)(?:^|["\'\s:])(?:re|fwd|fw)\s*:', re.M)
-SEND_CALL     = re.compile(r'gws\s+gmail\s+\+send\b')
-HAS_THREADING = re.compile(r'--message-id\b|\+reply\b|in-?reply-?to', re.I)
+SEND_CALL = re.compile(r'gws\s+gmail\s+\+send\b')
+# +reply is the only gws form that threads. --message-id does NOT rescue +send:
+# the flag is not wired to a header there, so honouring it reopens the orphan.
+SAFE_FORM = re.compile(r'\+reply\b|in-?reply-?to', re.I)
+
+
+def decide(cmd: str) -> bool:
+    """True when this command must be denied."""
+    return bool(SEND_CALL.search(cmd)
+                and not SAFE_FORM.search(cmd)
+                and REPLY_SUBJECT.search(cmd))
+
 
 def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
         return 0
-    if payload.get("tool_name") != "Bash":
+    if not isinstance(payload, dict) or payload.get("tool_name") != "Bash":
         return 0
-    cmd = (payload.get("tool_input") or {}).get("command") or ""
-    if not SEND_CALL.search(cmd):
+    # tool_input has been a str and a list in real payloads; .get() on those
+    # raises and the hook then emits no decision at all.
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
         return 0
-    if HAS_THREADING.search(cmd):
-        return 0
-    if not REPLY_SUBJECT.search(cmd):
+    cmd = tool_input.get("command")
+    if not isinstance(cmd, str) or not decide(cmd):
         return 0
     print(json.dumps({"hookSpecificOutput": {
         "hookEventName": "PreToolUse",
@@ -40,6 +46,7 @@ def main() -> int:
             "In-Reply-To/References. Get the id from the message you are replying to."),
     }}))
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/skills/gws-gmail-voice/hooks/reply-orphan-guard.py
+++ b/skills/gws-gmail-voice/hooks/reply-orphan-guard.py
@@ -3,6 +3,8 @@
 
 +send cannot set In-Reply-To/References, so the reply starts a new thread.
 """
+from __future__ import annotations
+
 import json
 import re
 import shlex

--- a/skills/gws-gmail-voice/manifest.json
+++ b/skills/gws-gmail-voice/manifest.json
@@ -15,5 +15,12 @@
   "tools": "./tools.ts",
   "provenance": {
     "source_repo": "https://github.com/sonichi/sutando"
-  }
+  },
+  "hooks": [
+    {
+      "event": "PreToolUse",
+      "command": "./hooks/reply-orphan-guard.py",
+      "description": "Blocks `gws gmail +send` with a reply subject; +send cannot thread."
+    }
+  ]
 }

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6821,6 +6821,18 @@ def check_claude_hook_registration(
                 "detail": "could not parse HOOKS=(...) from install-claude-hooks.sh — "
                           "cannot verify registration (reporting rather than assuming clean)"}
 
+    # Skill-declared hooks are appended to HOOKS at run time, so the static parse
+    # above cannot see them. Same discovery the installer uses — a second copy here
+    # would drift and quietly stop verifying whatever the installer registered.
+    try:
+        sys.path.insert(0, str(repo / "src"))
+        from skill_hooks import discover as _discover_skill_hooks
+        owned.extend(_discover_skill_hooks(repo))
+    except Exception as exc:
+        return {"name": name, "status": "warn",
+                "detail": f"skill-hook discovery failed ({exc}) — "
+                          f"cannot verify skill-declared hooks"}
+
     sm = re.search(r'^SETTINGS="([^"]+)"', src, re.M)
     settings = Path(sm.group(1).replace("$REPO_DIR", str(repo))) if sm else repo / ".claude" / "settings.json"
     if not settings.is_file():

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -97,6 +97,9 @@ HOOKS=(
   "PreCompact|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "SessionEnd|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
+  # A manifest skill loads `tools` and nothing else, so a hook living in a skill
+  # directory has no loader — registration has to come from here to be portable.
+  "PreToolUse|reply-orphan-guard.py|python3 $(shq "$REPO_DIR/skills/gws-gmail-voice/hooks/reply-orphan-guard.py")"
 )
 
 # Deprecated hooks to uninstall on re-run.  Each line: "<event>|<substring>".

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -97,10 +97,15 @@ HOOKS=(
   "PreCompact|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "SessionEnd|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
-  # A manifest skill loads `tools` and nothing else, so a hook living in a skill
-  # directory has no loader — registration has to come from here to be portable.
-  "PreToolUse|reply-orphan-guard.py|python3 $(shq "$REPO_DIR/skills/gws-gmail-voice/hooks/reply-orphan-guard.py")"
 )
+
+# Skill-declared hooks. A skill owns its hook the way it owns its `tools`;
+# src/skill_hooks.py is the single discovery the health probe also reads.
+while IFS='|' read -r _ev _tok _cmd; do
+  [ -n "${_ev:-}" ] && HOOKS+=("$_ev|$_tok|$_cmd")
+done <<EOF
+$(python3 "$REPO_DIR/src/skill_hooks.py" "$REPO_DIR" 2>/dev/null)
+EOF
 
 # Deprecated hooks to uninstall on re-run.  Each line: "<event>|<substring>".
 # Matching uses `.command | contains(substring)` so we don't need to track

--- a/src/skill_hooks.py
+++ b/src/skill_hooks.py
@@ -13,6 +13,19 @@ from pathlib import Path
 RUNNERS = {".py": "python3", ".sh": "bash"}
 
 
+def resolve_hook_command(skill_dir: Path, command: str) -> Path | None:
+    """Resolved hook path, or None when it lands outside the declaring skill.
+
+    An absolute command needs no `..` to escape: `skill_dir / "/bin/sh"` is
+    `/bin/sh`, which would let a manifest point core at any host executable.
+    """
+    if not command or Path(command).is_absolute():
+        return None
+    root = Path(skill_dir).resolve()
+    target = (root / command).resolve()
+    return target if root in target.parents else None
+
+
 def discover(repo_dir: Path) -> list[tuple[str, str, str]]:
     """(event, token, command) for every declared, present, enabled skill hook.
 
@@ -36,8 +49,8 @@ def discover(repo_dir: Path) -> list[tuple[str, str, str]]:
             event, command = entry.get("event"), entry.get("command")
             if not isinstance(event, str) or not isinstance(command, str):
                 continue
-            target = (manifest.parent / command).resolve()
-            if not target.is_file():
+            target = resolve_hook_command(manifest.parent, command)
+            if target is None or not target.is_file():
                 continue
             runner = RUNNERS.get(target.suffix, "bash")
             out.append((event, target.name, f"{runner} {shlex.quote(str(target))}"))

--- a/src/skill_hooks.py
+++ b/src/skill_hooks.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Discovery for skill-declared Claude Code hooks (`hooks` in a skill manifest).
+
+One owner: the installer registers what this returns and the health probe
+verifies exactly that, so a drifted second copy cannot make them disagree.
+"""
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+
+RUNNERS = {".py": "python3", ".sh": "bash"}
+
+
+def discover(repo_dir: Path) -> list[tuple[str, str, str]]:
+    """(event, token, command) for every declared, present, enabled skill hook.
+
+    Skips rather than raises on anything malformed: a broken manifest must not
+    abort a whole install, and a hook declared but absent is not registrable.
+    """
+    out: list[tuple[str, str, str]] = []
+    for manifest in sorted(Path(repo_dir).glob("skills/*/manifest.json")):
+        try:
+            data = json.loads(manifest.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict) or data.get("enabled") is False:
+            continue
+        entries = data.get("hooks")
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            event, command = entry.get("event"), entry.get("command")
+            if not isinstance(event, str) or not isinstance(command, str):
+                continue
+            target = (manifest.parent / command).resolve()
+            if not target.is_file():
+                continue
+            runner = RUNNERS.get(target.suffix, "bash")
+            out.append((event, target.name, f"{runner} {shlex.quote(str(target))}"))
+    return out
+
+
+if __name__ == "__main__":
+    import sys
+    for row in discover(Path(sys.argv[1])):
+        print("|".join(row))

--- a/tests/gmail-reply-orphan-guard.test.py
+++ b/tests/gmail-reply-orphan-guard.test.py
@@ -10,9 +10,10 @@ from pathlib import Path
 GUARD = Path(__file__).resolve().parent.parent / "skills" / "gws-gmail-voice" / "hooks" / "reply-orphan-guard.py"
 
 
-def decide(tool, cmd):
+def decide(tool, cmd, raw_tool_input=False):
+    tool_input = cmd if raw_tool_input else {"command": cmd}
     r = subprocess.run([sys.executable, str(GUARD)],
-                       input=json.dumps({"tool_name": tool, "tool_input": {"command": cmd}}),
+                       input=json.dumps({"tool_name": tool, "tool_input": tool_input}),
                        capture_output=True, text=True)
     if not r.stdout.strip():
         return "allow"
@@ -34,9 +35,23 @@ class ReplyOrphanGuard(unittest.TestCase):
         self.assertEqual(
             decide("Bash", 'gws gmail +send --to a@b.com --subject "Intro call" --body hi'), "allow")
 
-    def test_it_allows_send_that_carries_threading(self):
+    def test_message_id_does_NOT_rescue_send(self):
+        """+send has no thread flag, so --message-id there is not honoured.
+
+        Treating it as safe reopened the exact orphan the guard exists to stop.
+        """
         self.assertEqual(
-            decide("Bash", 'gws gmail +send --message-id 19f --subject "Re: EGC" --body hi'), "allow")
+            decide("Bash", 'gws gmail +send --message-id 19f --subject "Re: EGC" --body hi'), "deny")
+
+    def test_it_allows_reply_which_actually_threads(self):
+        self.assertEqual(
+            decide("Bash", 'gws gmail +reply --message-id 19f --subject "Re: EGC" --body hi'), "allow")
+
+    def test_a_non_dict_tool_input_fails_open_with_a_decision_not_a_crash(self):
+        """Real payloads have carried a str and a list here; .get() on those
+        raises and the hook then emits no decision at all."""
+        for bad in ("not an object", [1, 2], None, 7):
+            self.assertEqual(decide("Bash", bad, raw_tool_input=True), "allow")
 
     def test_it_ignores_non_Bash_tools(self):
         self.assertEqual(decide("Write", 'gws gmail +send --subject "Re: x"'), "allow")

--- a/tests/gmail-reply-orphan-guard.test.py
+++ b/tests/gmail-reply-orphan-guard.test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# The guard denies via a stdout JSON permissionDecision and exits 0 — judging it
+# by exit code reports a working guard as inert.
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+GUARD = Path(__file__).resolve().parent.parent / "skills" / "gws-gmail-voice" / "hooks" / "reply-orphan-guard.py"
+
+
+def decide(tool, cmd):
+    r = subprocess.run([sys.executable, str(GUARD)],
+                       input=json.dumps({"tool_name": tool, "tool_input": {"command": cmd}}),
+                       capture_output=True, text=True)
+    if not r.stdout.strip():
+        return "allow"
+    return json.loads(r.stdout)["hookSpecificOutput"]["permissionDecision"]
+
+
+class ReplyOrphanGuard(unittest.TestCase):
+    def test_it_denies_an_unthreaded_reply_subject(self):
+        for subj in ("Re: EGC 2027 keynote", "Fwd: contract", "RE: budget", "fw: notes"):
+            self.assertEqual(
+                decide("Bash", f'gws gmail +send --to a@b.com --subject "{subj}" --body hi'), "deny",
+                f"+send with {subj!r} starts a NEW thread — the recipient sees an orphan")
+
+    def test_it_allows_a_properly_threaded_reply(self):
+        self.assertEqual(
+            decide("Bash", 'gws gmail +reply --message-id 19f --subject "Re: EGC" --body hi'), "allow")
+
+    def test_it_allows_a_genuinely_new_thread(self):
+        self.assertEqual(
+            decide("Bash", 'gws gmail +send --to a@b.com --subject "Intro call" --body hi'), "allow")
+
+    def test_it_allows_send_that_carries_threading(self):
+        self.assertEqual(
+            decide("Bash", 'gws gmail +send --message-id 19f --subject "Re: EGC" --body hi'), "allow")
+
+    def test_it_ignores_non_Bash_tools(self):
+        self.assertEqual(decide("Write", 'gws gmail +send --subject "Re: x"'), "allow")
+
+    def test_malformed_input_fails_OPEN_not_closed(self):
+        r = subprocess.run([sys.executable, str(GUARD)], input="not json",
+                           capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, "a crashing hook must never wedge the core")
+        self.assertEqual(r.stdout.strip(), "", "fail-open: no decision emitted")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gmail-reply-orphan-guard.test.py
+++ b/tests/gmail-reply-orphan-guard.test.py
@@ -43,6 +43,28 @@ class ReplyOrphanGuard(unittest.TestCase):
         self.assertEqual(
             decide("Bash", 'gws gmail +send --message-id 19f --subject "Re: EGC" --body hi'), "deny")
 
+    def test_reply_text_in_the_BODY_does_not_make_a_send_safe(self):
+        """The reviewer's repro: a whole-command regex read body prose as proof
+        of threading, so the plainest orphan there is was allowed."""
+        for body in ("please use +reply next time", "set in-reply-to yourself"):
+            self.assertEqual(
+                decide("Bash", f'gws gmail +send --to a@b.com --subject "Re: EGC" --body "{body}"'),
+                "deny", f"body text {body!r} must not mark a +send safe")
+
+    def test_a_re_subject_only_in_the_body_is_not_a_reply(self):
+        self.assertEqual(
+            decide("Bash", 'gws gmail +send --to a@b.com --subject "Notes" --body "he wrote Re: X"'),
+            "allow")
+
+    def test_a_chained_orphan_after_a_safe_reply_is_still_denied(self):
+        self.assertEqual(
+            decide("Bash", 'gws gmail +reply --message-id a --body hi'
+                           ' && gws gmail +send --subject "Re: Y" --body z'), "deny")
+
+    def test_unparseable_quoting_fails_closed(self):
+        self.assertEqual(
+            decide("Bash", 'gws gmail +send --subject "Re: X --body hi'), "deny")
+
     def test_it_allows_reply_which_actually_threads(self):
         self.assertEqual(
             decide("Bash", 'gws gmail +reply --message-id 19f --subject "Re: EGC" --body hi'), "allow")

--- a/tests/skill-hooks-discovery.test.py
+++ b/tests/skill-hooks-discovery.test.py
@@ -96,15 +96,44 @@ class ManifestLintAcceptsAndValidatesHooks(unittest.TestCase):
             "stability": "experimental",
         }
 
+    @staticmethod
+    def _linter():
+        """Import the module rather than shelling out to it.
+
+        A subprocess runs uninstrumented, so a CLI-only test leaves the rules it
+        exercises reading as 0% covered — which is what the gate caught.
+        """
+        import importlib.util
+        path = Path(__file__).resolve().parent.parent / "scripts" / "lint-skill.py"
+        spec = importlib.util.spec_from_file_location("lint_skill", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
     def _lint(self, hooks="__omit__"):
+        """(rc, text) with rc mirroring the CLI: non-zero when errors exist."""
         m = dict(self.base)
         if hooks != "__omit__":
             m["hooks"] = hooks
         (self.skill / "manifest.json").write_text(json.dumps(m))
-        r = subprocess.run(
+        errors, warnings = self._linter()._lint_manifest(self.skill)
+        return (1 if errors else 0), "\n".join(errors + warnings)
+
+    def test_the_CLI_exit_code_still_tracks_errors(self):
+        """One subprocess case so the in-process shortcut above cannot drift
+        from what the command actually returns."""
+        (self.skill / "manifest.json").write_text(json.dumps(
+            {**self.base, "hooks": [{"event": "PreToolUse", "command": "./hooks/nope.py"}]}))
+        bad = subprocess.run(
             [sys.executable, str(self.REPO / "scripts" / "lint-skill.py"), str(self.skill)],
             capture_output=True, text=True)
-        return r.returncode, r.stdout + r.stderr
+        (self.skill / "manifest.json").write_text(json.dumps(
+            {**self.base, "hooks": [{"event": "PreToolUse", "command": "./hooks/g.py"}]}))
+        good = subprocess.run(
+            [sys.executable, str(self.REPO / "scripts" / "lint-skill.py"), str(self.skill)],
+            capture_output=True, text=True)
+        self.assertNotEqual(bad.returncode, 0, bad.stdout + bad.stderr)
+        self.assertEqual(good.returncode, 0, good.stdout + good.stderr)
 
     def test_CONTROL_no_hooks_key_is_clean(self):
         """Without a passing baseline the failure cases below prove nothing."""

--- a/tests/skill-hooks-discovery.test.py
+++ b/tests/skill-hooks-discovery.test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -38,6 +39,14 @@ class SkillHookDiscovery(unittest.TestCase):
         self.assertEqual(token, "g.py")
         self.assertTrue(cmd.startswith("python3 "), cmd)
         self.assertIn("skills/demo/hooks/g.py", cmd)
+
+    def test_discovery_refuses_a_command_outside_the_declaring_skill(self):
+        """A manifest must not be able to point core at a host executable."""
+        for cmd in ("/bin/sh", "../../../bin/sh"):
+            self._skill("demo", {"name": "demo", "hooks": [
+                {"event": "PreToolUse", "command": cmd}]})
+            self.assertEqual(discover(self.repo), [], f"registered {cmd!r}")
+            shutil.rmtree(self.repo / "skills" / "demo")
 
     def test_the_command_is_absolute_so_it_is_portable(self):
         """The whole point: no host-specific path is written by hand."""
@@ -98,11 +107,8 @@ class ManifestLintAcceptsAndValidatesHooks(unittest.TestCase):
 
     @staticmethod
     def _linter():
-        """Import the module rather than shelling out to it.
-
-        A subprocess runs uninstrumented, so a CLI-only test leaves the rules it
-        exercises reading as 0% covered — which is what the gate caught.
-        """
+        """In-process import: a subprocess runs uninstrumented, so a CLI-only
+        test leaves the rules it exercises reading as 0% covered."""
         import importlib.util
         path = Path(__file__).resolve().parent.parent / "scripts" / "lint-skill.py"
         spec = importlib.util.spec_from_file_location("lint_skill", path)
@@ -119,9 +125,15 @@ class ManifestLintAcceptsAndValidatesHooks(unittest.TestCase):
         errors, warnings = self._linter()._lint_manifest(self.skill)
         return (1 if errors else 0), "\n".join(errors + warnings)
 
+    def test_lint_rejects_a_command_that_resolves_outside_the_skill(self):
+        """`skill_dir / "/bin/sh"` is `/bin/sh` — escaping needs no `..`."""
+        for cmd in ("/bin/sh", "../../../bin/sh"):
+            rc, text = self._lint([{"event": "PreToolUse", "command": cmd}])
+            self.assertEqual(rc, 1, f"lint accepted {cmd!r}")
+            self.assertIn("inside the skill dir", text)
+
     def test_the_CLI_exit_code_still_tracks_errors(self):
-        """One subprocess case so the in-process shortcut above cannot drift
-        from what the command actually returns."""
+        """One subprocess case so the in-process shortcut cannot drift."""
         (self.skill / "manifest.json").write_text(json.dumps(
             {**self.base, "hooks": [{"event": "PreToolUse", "command": "./hooks/nope.py"}]}))
         bad = subprocess.run(
@@ -153,7 +165,7 @@ class ManifestLintAcceptsAndValidatesHooks(unittest.TestCase):
     def test_a_command_escaping_the_skill_dir_is_an_error(self):
         rc, out = self._lint([{"event": "PreToolUse", "command": "../../../etc/passwd"}])
         self.assertNotEqual(rc, 0)
-        self.assertIn("must not escape", out)
+        self.assertIn("must resolve inside the skill dir", out)
 
     def test_a_missing_event_is_an_error(self):
         rc, out = self._lint([{"command": "./hooks/g.py"}])

--- a/tests/skill-hooks-discovery.test.py
+++ b/tests/skill-hooks-discovery.test.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
@@ -75,6 +77,93 @@ class SkillHookDiscovery(unittest.TestCase):
     def test_hooks_as_a_non_list_is_skipped(self):
         self._skill("demo", {"name": "demo", "hooks": {"event": "PreToolUse"}})
         self.assertEqual(discover(self.repo), [])
+
+
+class ManifestLintAcceptsAndValidatesHooks(unittest.TestCase):
+    """Accepting `hooks` without validating it would be worse than rejecting it:
+    discovery silently drops what it cannot find, so a bad entry reads as armed."""
+
+    REPO = Path(__file__).resolve().parent.parent
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+        self.skill = Path(self._td.name) / "demo"
+        (self.skill / "hooks").mkdir(parents=True)
+        (self.skill / "hooks" / "g.py").write_text("#!/usr/bin/env python3\n")
+        self.base = {
+            "name": "demo", "version": "1.0.0", "owner": "github:sonichi/sutando",
+            "stability": "experimental",
+        }
+
+    def _lint(self, hooks="__omit__"):
+        m = dict(self.base)
+        if hooks != "__omit__":
+            m["hooks"] = hooks
+        (self.skill / "manifest.json").write_text(json.dumps(m))
+        r = subprocess.run(
+            [sys.executable, str(self.REPO / "scripts" / "lint-skill.py"), str(self.skill)],
+            capture_output=True, text=True)
+        return r.returncode, r.stdout + r.stderr
+
+    def test_CONTROL_no_hooks_key_is_clean(self):
+        """Without a passing baseline the failure cases below prove nothing."""
+        rc, out = self._lint()
+        self.assertEqual(rc, 0, out)
+
+    def test_CONTROL_a_valid_hook_is_clean_and_not_an_unknown_field(self):
+        rc, out = self._lint([{"event": "PreToolUse", "command": "./hooks/g.py"}])
+        self.assertEqual(rc, 0, out)
+        self.assertNotIn("unknown manifest field", out)
+
+    def test_a_command_that_does_not_exist_is_an_error(self):
+        rc, out = self._lint([{"event": "PreToolUse", "command": "./hooks/nope.py"}])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("does not exist", out)
+
+    def test_a_command_escaping_the_skill_dir_is_an_error(self):
+        rc, out = self._lint([{"event": "PreToolUse", "command": "../../../etc/passwd"}])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("must not escape", out)
+
+    def test_a_missing_event_is_an_error(self):
+        rc, out = self._lint([{"command": "./hooks/g.py"}])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("missing 'event'", out)
+
+    def test_a_missing_command_is_an_error(self):
+        rc, out = self._lint([{"event": "PreToolUse"}])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("missing 'command'", out)
+
+    def test_hooks_must_be_a_list(self):
+        rc, out = self._lint({"event": "PreToolUse"})
+        self.assertNotEqual(rc, 0)
+        self.assertIn("must be a list", out)
+
+    def test_an_entry_must_be_an_object(self):
+        rc, out = self._lint(["a string"])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("must be an object", out)
+
+
+class HealthProbeReportsWhenDiscoveryBreaks(unittest.TestCase):
+    def test_a_raising_discovery_warns_rather_than_aborting_every_later_probe(self):
+        """The probe runs inside run_all_checks; an exception here would kill the
+        checks after it, and a silent pass would verify only the static hooks."""
+        import importlib.util
+        repo = Path(__file__).resolve().parent.parent
+        spec = importlib.util.spec_from_file_location("hc", repo / "src" / "health-check.py")
+        hc = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(hc)
+        except SystemExit:
+            pass
+        import skill_hooks
+        with mock.patch.object(skill_hooks, "discover", side_effect=RuntimeError("boom")):
+            row = hc.check_claude_hook_registration(repo_dir=repo)
+        self.assertEqual(row["status"], "warn")
+        self.assertIn("skill-hook discovery failed", row["detail"])
 
 
 if __name__ == "__main__":

--- a/tests/skill-hooks-discovery.test.py
+++ b/tests/skill-hooks-discovery.test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""A skill declares its own hook; core discovers, never names one."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from skill_hooks import discover
+
+
+class SkillHookDiscovery(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+        self.repo = Path(self._td.name)
+
+    def _skill(self, name, manifest, hook_body="#!/usr/bin/env python3\n"):
+        d = self.repo / "skills" / name
+        (d / "hooks").mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps(manifest))
+        if hook_body is not None:
+            (d / "hooks" / "g.py").write_text(hook_body)
+        return d
+
+    def test_a_declared_present_hook_is_discovered(self):
+        self._skill("demo", {"name": "demo", "hooks": [
+            {"event": "PreToolUse", "command": "./hooks/g.py"}]})
+        rows = discover(self.repo)
+        self.assertEqual(len(rows), 1)
+        event, token, cmd = rows[0]
+        self.assertEqual(event, "PreToolUse")
+        self.assertEqual(token, "g.py")
+        self.assertTrue(cmd.startswith("python3 "), cmd)
+        self.assertIn("skills/demo/hooks/g.py", cmd)
+
+    def test_the_command_is_absolute_so_it_is_portable(self):
+        """The whole point: no host-specific path is written by hand."""
+        self._skill("demo", {"name": "demo", "hooks": [
+            {"event": "PreToolUse", "command": "./hooks/g.py"}]})
+        cmd = discover(self.repo)[0][2]
+        self.assertIn(str(self.repo), cmd)
+
+    def test_a_skill_with_no_hooks_key_contributes_nothing(self):
+        self._skill("demo", {"name": "demo", "tools": "./tools.ts"})
+        self.assertEqual(discover(self.repo), [])
+
+    def test_a_disabled_skill_is_skipped(self):
+        self._skill("demo", {"name": "demo", "enabled": False, "hooks": [
+            {"event": "PreToolUse", "command": "./hooks/g.py"}]})
+        self.assertEqual(discover(self.repo), [])
+
+    def test_a_declared_but_ABSENT_hook_is_not_registered(self):
+        """Registering a path that does not exist arms nothing and reads as armed."""
+        self._skill("demo", {"name": "demo", "hooks": [
+            {"event": "PreToolUse", "command": "./hooks/missing.py"}]})
+        self.assertEqual(discover(self.repo), [])
+
+    def test_a_broken_manifest_does_not_abort_discovery_of_the_others(self):
+        self._skill("broken", {"name": "broken"})
+        (self.repo / "skills" / "broken" / "manifest.json").write_text("{not json")
+        self._skill("good", {"name": "good", "hooks": [
+            {"event": "PreToolUse", "command": "./hooks/g.py"}]})
+        self.assertEqual([r[1] for r in discover(self.repo)], ["g.py"])
+
+    def test_malformed_hook_entries_are_skipped_not_raised(self):
+        self._skill("demo", {"name": "demo", "hooks": [
+            "a string", {"event": "PreToolUse"}, {"command": "./hooks/g.py"},
+            {"event": "PreToolUse", "command": "./hooks/g.py"}]})
+        self.assertEqual(len(discover(self.repo)), 1)
+
+    def test_hooks_as_a_non_list_is_skipped(self):
+        self._skill("demo", {"name": "demo", "hooks": {"event": "PreToolUse"}})
+        self.assertEqual(discover(self.repo), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Why

`gws gmail +send` cannot set `In-Reply-To`/`References`, so a reply sent through it starts a **new thread** and the recipient sees an orphan. Detection after the fact does not help — the send *is* the damage — which is why this is a `PreToolUse` hook and not a checker.

The guard already existed, at `workspace/notes/tools/gmail-reply-orphan-guard.py`: carried to every host by vault sync, wired on exactly one of three, unversioned, and with no test. Chi asked for it to live with the gmail tooling it guards, and `skills/gws-gmail-voice/` is that home.

## The test it never had

It asserts on the stdout `permissionDecision`, **not** the exit code. The hook denies via JSON and correctly exits 0 — so an exit-code harness reports a working guard as inert, which is exactly what two of my own harnesses did before the behaviour was confirmed.

```
4 reply-subject spellings (Re:/Fwd:/RE:/fw:)   -> deny
+reply --message-id                            -> allow
+send with a fresh subject                     -> allow
+send already carrying --message-id            -> allow
non-Bash tool                                  -> allow
malformed stdin                                -> fail-OPEN, exit 0, no decision
```

Mutation-verified: neutering `REPLY_SUBJECT` fails the suite; restored, 6/6 pass. (The first mutation attempt matched no anchor and was skipped — a skipped mutation proves nothing, so it was re-run by line prefix.)

## What this deliberately does NOT do

**The live wiring is unchanged** — `settings.json` still points at the workspace copy. Repointing it at a path that only exists on this branch would silently disarm the guard, and because it fails open, nothing would report the gap. The wiring moves after this merges.

Only one host wires it today; Mini and Air carry the file and run neither. That's a separate follow-up, and the absolute path in the current wiring is part of why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)