### PR TITLE
test(workstream): stop the suite reading the live ag2space token

### DIFF
--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -343,7 +343,11 @@ def test_ag2space_team_room_setting_runs_bridge_to_guarded_runtime_end_to_end() 
         package_root = REPO / "packages" / "ag2-sparrow"
         sys.path.insert(0, str(package_root))
         try:
-            import ag2_sparrow.remote_gateway_bridge as gateway
+            # The gateway resolves its token AT IMPORT: env -> channel .env -> Keychain.
+            # A dummy short-circuits that chain so the suite never reads live credentials.
+            with mock.patch.dict(os.environ, {"REMOTE_TASK_TOKEN": "test-dummy-token"},
+                                 clear=False):
+                import ag2_sparrow.remote_gateway_bridge as gateway
         finally:
             sys.path.remove(str(package_root))
 


### PR DESCRIPTION
## What

`tests/task-workstream-session-worker.test.py` reads the owner's **live ag2space gateway token** when it runs. This sets a dummy token before the import so it can't.

## Why it happens

`ag2_sparrow.remote_gateway_bridge` resolves its token **at import time** (`remote_gateway_bridge.py:575-581`), and the chain has three rungs:

```
_RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN")
if not _RAW:  _RAW, ... = _token_from_ag2space_env()      # AG2_DEVICE_ENV, then $CLAUDE_CONFIG_DIR/channels/ag2space/.env
if not _RAW:  _RAW = _token_from_vault_ag2space()         # macOS Keychain
```

The test monkeypatches `TASKS_DIR`, `LOCAL_TIER` and `_load_tier_map` — but only *after* the import, so the credential read has already happened. The Keychain rung is the part I'd most like closed: a test that misses the first two rungs reaches for the credential store.

## Evidence

Same command, before and after — the control fails, which is the point:

```
BEFORE (origin/main)
  [remote-gateway-bridge] token not in env; loaded from
      /Users/<me>/.sutando/repo/workspace/.claude-sutando/channels/ag2space/.env
  'loaded from' lines: 1

AFTER (this branch)
  'loaded from' lines: 0
  task workstream session worker tests passed   (rc=0)
```

I also confirmed the short-circuit directly rather than inferring it — importing the module with `REMOTE_TASK_TOKEN` set produces no `.env` read at all, while importing it without one against the real config dir reproduces the line above verbatim.

## Scope

One test file, three lines. No production change, no behaviour change to the gateway.

## Not claimed

Nothing leaked. The suite writes only into `tempfile.TemporaryDirectory()`, and I verified the live queue was untouched after running it (`tasks/` empty, no `*-e2e` files). This is about a test reaching for credentials it has no need for — found while diagnosing an unrelated CI flake on #2270, and raised separately rather than folded into that PR.