### PR TITLE
docs(changelog): v0.11.0 — collaborator tier with AG2 Space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [v0.11.0] — 2026-08-14
+
+54 commits since v0.10.0: 10 features, 39 fixes. Headline: **collaborator tier with AG2 Space** —
+a Team room reaches the trusted runtime only on an explicit, broker-attested opt-in.
+
+### Added
+
+- **AG2 Space collaborator tier.** A Team room now reaches the owner-capability runtime only when the broker attests `collaborator: true` alongside Team; missing or invalid controls, older gateways, and local owner→Team downgrades all keep the restricted path. This is a trust boundary, not a convenience flag — read the AG2 Space section of `CLAUDE.md` before granting it. ([#2824])
+- Durable Work Model named as a protocol: lifecycle, invariants, and the ambient tier, plus the durable-lane write side and the first resolver consumer. ([#2719], [#2721])
+- `sutando://` endpoint resolver seed — `resolve(endpoint, mode)` over the runtime descriptor. ([#2720])
+- Sparrow observed-receipt (👀), opt-in with the event plane. ([#2319])
+- Health-check learns two new probes: the source has moved off the BUILT engine revision ([#2864]), and proactive bodies no consumer ever claimed ([#2842]).
+- `restart-test-harness` — real post-restart round-trip evidence for live-path PRs, with an identity gate so a restart that never happened cannot pass. ([#2724])
+- Session-handoff records that a compaction happened. ([#2821])
+- `review-checks` gates PR-draft artifacts committed to the repo root. ([#2841])
+
+### Fixed
+
+39 fixes, concentrated in delivery and the task/result protocol. Notable:
+
+- A Discord logging failure could kill delivery **and silently destroy inbound messages**. ([#2856])
+- The Slack bridge claimed a proactive file before resolving the owner, destroying results it could not deliver. ([#2628])
+- Headless provider workers hung without `stdin=DEVNULL` — the collaborator-tier path could stall instead of running. ([#2859])
+- An empty result file silently stalled a reply until the 7-day age-out. ([#2631])
+- Named gateway auth endpoints were not isolated. ([#2861])
+- A guest-tier task deferred every owner-facing cron. ([#2880])
+- Rendered episodes were silently refused as attachments. ([#2746])
+- The watcher reaper deleted a sentinel it never inspected, stranding a live watcher. ([#2837])
+
+### Changed
+
+- No breaking changes and no new workspace migrations. Upgrading from v0.10.0 requires no action; rollback is `git checkout v0.10.0`.
+
 ## [v0.10.0] — 2026-08-12
 
 316 PRs since v0.9.0: 60 features, 202 fixes. Full curated notes live on the


### PR DESCRIPTION
Release artifacts for the collaborator-tier release Rui asked for in *Sutando Release*. **Docs only — no product changes.**

## Version: cut as v0.11.0, not 0.10.1 — your call to override

He asked for **0.10.1**. `docs/release-process.md` §2.1:

| Bump | When |
|---|---|
| MINOR | new user-visible capability; new schema additions |
| PATCH | bug fix on existing capability; security fix; doc-only |

This window has **10 `feat` commits**, and the headline one — `#2824`, collaborator opt-in gating the owner-capability runtime for Team rooms — is a **new trust boundary**, not a fix to an existing capability. Tagging a new permission surface as a patch tells install-pinners the opposite of the truth, and they are the audience for these tags.

**Flipping to 0.10.1 is two edits** (this CHANGELOG heading + the PR title) — say the word and I'll do it rather than argue.

## Candidate

```
SHA        5f2d3557ba4c27ee8f3305001564bb133e8d3525
previous   v0.10.0 (2026-08-12)
change set 54 commits — 10 feat, 39 fix
```

## Hard gates (§4.2), all four run

| gate | result |
|---|---|
| 1. CI green on the SHA | **PASS** — 20 runs, 0 failures |
| 2. Health-check, fresh clone | **rc=1 — no probe implicates the candidate; see below** |
| 3. Headline-feature smoke | **PASS** — `discord-bridge-collaborator-tier.test.py`, `task-workstream-session-worker.test.py` |
| 4. Migrations present + idempotent | **N/A — zero migrations since v0.10.0** |
| 5. Migration smoke (prior → candidate) | **N/A — nothing to apply** |

**Gate 2 honestly.** Fresh clone from GitHub at the exact SHA (asserted `want == got` — my first attempt cloned from a local repo, silently missed the object, and sat on an older commit). After scaffolding what startup auto-bootstraps: 37 ok / 4 issues, and all four are environment:

- `build_log.md` / `.env` empty — correct for a bare workspace with no credentials.
- `discord-bridge` / `slack-bridge` "stale" — **the live host's processes**. The probe compares host-wide processes against whichever clone it runs from, so it reports them regardless of checkout.

**So gate 2 cannot return rc=0 on a machine already running Sutando.** That's a gap in the gate, not this candidate. Flagging it rather than reporting a pass I didn't get.

## Not in scope here

Publishing. No tag, no GitHub Release — `skills/release/SKILL.md` requires explicit owner confirmation of version **and** SHA, and a request to "create a release" is not that confirmation.

Full proposal, including the SemVer rationale and gate transcripts: `workspace/notes/release-proposals/proposed-v0.10.1.md`.