### PR TITLE
docs(release): the tag does not wait on the changelog PR

### DIFF
--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -49,7 +49,9 @@ an approved release PR.
    upgrade guidance, and `CHANGELOG.md`. Do not copy canonical text into a
    second document.
 7. Prepare one release PR containing only release artifacts and documentation.
-   Do not mix product fixes into it; list unresolved fixes as blockers.
+   Do not mix product fixes into it; list unresolved fixes as blockers. It
+   records the entry **after** the tag (see Publish step 2) and is not a
+   precondition for publishing.
 8. Run every applicable hard gate from `docs/release-process.md`, including the
    fresh-clone health check, headline-feature smoke, migration idempotency, and
    prior-release-to-candidate upgrade smoke. Record exact commands, candidate
@@ -73,9 +75,15 @@ Proceed only when the owner explicitly confirms the exact version and candidate
 SHA in the current conversation.
 
 1. Re-read the proposal and `docs/release-process.md`.
-2. Verify the candidate SHA is still the intended commit, the release PR is
-   merged, required checks are green, the worktree is clean, the tag does not
-   exist, and every blocker is resolved.
+2. Verify the candidate SHA is still the intended commit, required checks are
+   green, the worktree is clean, the tag does not exist, and every blocker is
+   resolved.
+
+   **Do not gate the tag on the release PR being merged.** This repo tags the
+   candidate commit and records the CHANGELOG entry afterwards — v0.7.0 through
+   v0.10.0 were each tagged on a tree containing no entry for themselves, and
+   v0.10.0's entry landed two days later in #2826. Holding the tag for the
+   changelog PR blocks the release on review latency for no benefit.
 3. If any evidence is stale or the SHA changed, return to **Prepare**.
 4. Create the annotated tag. Use a signed tag only when the owner is performing
    the signing with their configured key; never impersonate an owner signature.


### PR DESCRIPTION
## What

`skills/release/SKILL.md` Publish step 2 required *"the release PR is merged"* before tagging. **No release in this repo has ever met that precondition.**

## Evidence

```
tag       tagged      own CHANGELOG entry present in the tagged tree
v0.10.0   2026-08-11  0
v0.9.0    2026-07-29  0
v0.8.0    2026-07-20  0
v0.7.0    2026-07-07  0

v0.10.0's entry landed 2026-08-13 in d4da2ee34
  "chore(changelog): record v0.10.0 ..."   — two days AFTER the tag
```

Four consecutive releases tag the candidate commit and record the changelog afterwards. The doc describes an order the project does not use.

## Why it matters

Following it as written blocks a release on review latency for no benefit — the tag is the thing people pin; the changelog entry is a record that can land after.

It cost a real round trip on **v0.11.0**: I opened a changelog PR, told the owner a tag "shouldn't ship without its notes," and made him wait on approvals. He replied *"Why the hell you create a PR? you just create a release. Take a look at history release"* — and the history settled it in one command. This PR makes the next reader (agent or human) not repeat that.

## Change

- Publish step 2: drop `the release PR is merged` from the precondition list, and say explicitly not to gate the tag on it, with the evidence inline so the claim is checkable.
- Prepare step 7: note that the release PR records the entry *after* the tag and is not a publish precondition.

Everything else is untouched — in particular **the owner-confirmation requirement stays exactly as it was**. That part was right: publishing is an irreversible external write. The error was an extra prerequisite layered on top of it, not the confirmation gate itself.

## Not claimed

I'm not asserting tag-then-changelog is better in the abstract — only that it is what this repo does, consistently, and that the doc should describe it. If the intent was to change practice rather than record it, say so and I'll close this instead.