### PR TITLE
fix(health-check): quota-account-identity went silent on every non-launchd proxy

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4228,6 +4228,69 @@ def _keychain_service_exists(service: str) -> bool:
         return False
 
 
+# Distinct from None and from "": the proxy's environment could not be read at
+# all. "" means "read it, there is no CLAUDE_CONFIG_DIR" (the proxy then resolves
+# the vanilla item), which is a comparable answer; unreadable is not.
+_PROXY_ENV_UNREADABLE = object()
+
+
+def _proxy_config_dir_from_process(pid_finder=None, ps_runner=None):
+    """CLAUDE_CONFIG_DIR of the RUNNING proxy, read from its process environment.
+
+    The launchd plist answers this only for a launchd-managed proxy. One started
+    any other way (startup.sh, the desktop supervisor, a hand-run node) inherits
+    its env from whatever spawned it, and that env can name a different
+    CLAUDE_CONFIG_DIR than the core's just as easily — the plist is one source of
+    the mismatch, not the definition of it.
+
+    Returns the value, "" when the proxy has no such variable, or
+    _PROXY_ENV_UNREADABLE when the environment cannot be read.
+    """
+    finder = pid_finder or _proxy_pids
+    runner = ps_runner or (lambda pid: subprocess.run(
+        ["ps", "eww", "-p", pid], capture_output=True, text=True, timeout=5))
+    try:
+        pids = finder()
+    except Exception:                     # noqa: BLE001 — a probe failure is "unknown"
+        return _PROXY_ENV_UNREADABLE
+    # Zero: nothing to read. More than one: ambiguous, and an ambiguous proxy is
+    # not evidence about which account any single request billed.
+    if len(pids) != 1:
+        return _PROXY_ENV_UNREADABLE
+    try:
+        proc = runner(pids[0])
+    except Exception:                     # noqa: BLE001
+        return _PROXY_ENV_UNREADABLE
+    if proc is None or getattr(proc, "returncode", 1) != 0:
+        return _PROXY_ENV_UNREADABLE
+    out = proc.stdout or ""
+    # `ps eww` prints argv THEN the environment, space-separated, and prints argv
+    # ALONE for a process whose env we may not read. Requiring one KEY=VALUE pair
+    # is what keeps that case UNREADABLE instead of "no CLAUDE_CONFIG_DIR".
+    if not re.search(r"(?:^| )[A-Za-z_][A-Za-z0-9_]*=", out):
+        return _PROXY_ENV_UNREADABLE
+    # Capture to the next ` KEY=` rather than the next space: this value is a path
+    # under "~/Library/Application Support", so a whitespace split truncates it at
+    # "…/Library/Application" and silently hashes the wrong directory.
+    m = re.search(
+        r"(?:^| )CLAUDE_CONFIG_DIR=(.*?)(?= [A-Za-z_][A-Za-z0-9_]*=|$)", out, re.S)
+    return m.group(1) if m else ""
+
+
+def _proxy_pids() -> "list[str]":
+    """PIDs LISTENING on the credential proxy's port (7846).
+
+    `-sTCP:LISTEN` is load-bearing: bare `-ti:7846` also matches every client with
+    an open connection to the port, and the routed core is always one of them. That
+    returns two pids on a healthy host, which an "exactly one" guard reads as
+    ambiguous — disabling the check precisely where it applies.
+    """
+    out = subprocess.run(
+        ["/usr/sbin/lsof", "-ti:7846", "-sTCP:LISTEN"],
+        capture_output=True, text=True, timeout=5)
+    return [p for p in (out.stdout or "").split() if p.isdigit()]
+
+
 def _resolved_credential_service(config_dir: Optional[str]) -> Optional[str]:
     """First EXISTING item of [scoped(config_dir), vanilla] — the proxy's order."""
     for service in (_scoped_keychain_service(config_dir), "Claude Code-credentials"):
@@ -4313,9 +4376,20 @@ def check_quota_account_identity(proxy_status: str, core_env_prober=None) -> dic
                 "detail": "core has no CLAUDE_CONFIG_DIR — both sides resolve the vanilla item"}
 
     plist = Path.home() / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
+    cfg_source = "plist"
     if not plist.is_file():
-        return {"name": name, "status": "ok",
-                "detail": "credential proxy is not launchd-managed on this host"}
+        # Not launchd-managed. This used to return ok here, which reads as "the
+        # accounts agree" but only means "the file this check knows how to read is
+        # absent" — the probe going silent on every host whose proxy is started by
+        # startup.sh or the desktop supervisor. Those proxies still carry a
+        # CLAUDE_CONFIG_DIR; read it from the process instead of giving up.
+        from_proc = _proxy_config_dir_from_process()
+        if from_proc is _PROXY_ENV_UNREADABLE:
+            return {"name": name, "status": "ok",
+                    "detail": ("credential proxy is not launchd-managed and its "
+                               "environment could not be read — identity comparison "
+                               "inactive here (not evidence either way)")}
+        return _quota_identity_verdict(name, core_cfg, from_proc, "process")
     # Imported HERE, not at module scope, and this placement is the whole point.
     # `plistlib` pulls in `xml.parsers.expat` -> the `pyexpat` C extension, which
     # is the single most fragile import in the stdlib: it dlopens libexpat, so a
@@ -4368,6 +4442,17 @@ def check_quota_account_identity(proxy_status: str, core_env_prober=None) -> dic
                 "detail": (f"credential-proxy plist has CLAUDE_CONFIG_DIR as "
                            f"{type(proxy_cfg).__name__}, not a string — cannot resolve its keychain item")}
 
+    return _quota_identity_verdict(name, core_cfg, proxy_cfg, cfg_source)
+
+
+def _quota_identity_verdict(name: str, core_cfg: Optional[str],
+                            proxy_cfg: Optional[str], source: str) -> dict:
+    """Compare the two resolved keychain ITEM NAMES and report.
+
+    `source` names where the proxy's CLAUDE_CONFIG_DIR came from ("plist" or
+    "process") and selects the remediation — telling someone to edit a plist that
+    does not exist on their host is worse than saying nothing.
+    """
     core_service = _resolved_credential_service(core_cfg)
     proxy_service = _resolved_credential_service(proxy_cfg)
 
@@ -4396,11 +4481,20 @@ def check_quota_account_identity(proxy_status: str, core_env_prober=None) -> dic
             f"unusable the proxy engages pass-through, forwarding whatever credential the "
             f"client supplied and billing that account instead, or answering 401 when the "
             f"client supplied none. Either way "
-            f"the cause is almost always the launchd plist omitting CLAUDE_CONFIG_DIR "
-            f"(launchd inherits no shell env): "
-            f"proxy plist has {'no' if not proxy_cfg else repr(proxy_cfg)} value. "
-            f"Fix: pin CLAUDE_CONFIG_DIR in "
-            f"~/Library/LaunchAgents/com.sutando.credential-proxy.plist, then reload it."
+            + (
+                f"the cause is almost always the launchd plist omitting CLAUDE_CONFIG_DIR "
+                f"(launchd inherits no shell env): "
+                f"proxy plist has {'no' if not proxy_cfg else repr(proxy_cfg)} value. "
+                f"Fix: pin CLAUDE_CONFIG_DIR in "
+                f"~/Library/LaunchAgents/com.sutando.credential-proxy.plist, then reload it."
+                if source == "plist" else
+                f"this proxy is NOT launchd-managed — it inherited "
+                f"{'no CLAUDE_CONFIG_DIR' if not proxy_cfg else repr(proxy_cfg)} from whatever "
+                f"started it, so there is no plist to correct. Fix: restart the proxy with "
+                f"CLAUDE_CONFIG_DIR set to this core's ({core_cfg!r}). Restarting it changes "
+                f"which account subsequent requests bill, so confirm that is the intended "
+                f"login first."
+            )
         ),
     }
 

--- a/tests/health-check-quota-account-identity.test.py
+++ b/tests/health-check-quota-account-identity.test.py
@@ -340,15 +340,29 @@ class TestQuotaAccountIdentity(unittest.TestCase):
 
     def test_missing_plist_is_ok_not_an_error(self):
         """Proxy running but not launchd-managed (dev host, manual launch).
-        There is no plist to compare against; that is not a fault."""
+
+        A missing plist is not a fault. It is no longer the END of the check
+        either: the proxy's own environment is consulted instead, so this case
+        now pins only the degraded corner — env unreadable too, therefore
+        inactive rather than an error. The comparing behaviour lives in
+        TestNonLaunchdProxyIdentity.
+
+        `_proxy_config_dir_from_process` is STUBBED deliberately. Left real it
+        reads the developer's live proxy, and this case then passes or fails on
+        whatever that host happens to be running — the same escape the module
+        docstring records for `core_env_has_proxy_url`.
+        """
         core = "/Users/x/ws/.claude-sutando"
         with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_proxy_config_dir_from_process",
+                               return_value=hc._PROXY_ENV_UNREADABLE), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
             out = hc.check_quota_account_identity(
                 "ok", core_env_prober=lambda: True)   # no plist written
         self.assertEqual(out["status"], "ok")
         self.assertIn("launchd", out["detail"])
+        self.assertIn("not evidence either way", out["detail"])
 
     def test_corrupt_plist_warns_rather_than_raising(self):
         """A truncated/garbage plist must degrade to a warn, not propagate an
@@ -381,6 +395,153 @@ class TestQuotaAccountIdentity(unittest.TestCase):
             hc._resolved_credential_service(core)
         for call in run.call_args_list:
             self.assertNotIn("-w", call.args[0], "must not read the secret value")
+
+
+class TestNonLaunchdProxyIdentity(unittest.TestCase):
+    """The same divergence, on a proxy that launchd does not manage.
+
+    Before this, the check returned ok the moment the plist was absent —
+    "credential proxy is not launchd-managed on this host". That reads as the
+    accounts agreeing, but only says the one file the check knew how to read
+    was missing. A proxy started by startup.sh, the desktop supervisor, or by
+    hand carries a CLAUDE_CONFIG_DIR in its process environment and can name a
+    different directory than the core's just as easily.
+
+    `test_divergent_process_config_dirs_warn` is the load-bearing case: it
+    fails on the parent commit, which returns ok on this exact input.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+        (self.home / "Library/LaunchAgents").mkdir(parents=True)   # no plist inside
+        self.addCleanup(self._tmp.cleanup)
+
+    def _run(self, core_cfg, proc_cfg, existing_services, routed=True):
+        """proc_cfg=hc._PROXY_ENV_UNREADABLE models an unreadable environment."""
+        env = {"CLAUDE_CONFIG_DIR": core_cfg, "ANTHROPIC_BASE_URL": "http://localhost:7846"}
+        with mock.patch.dict(os.environ, env, clear=False), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False), \
+             mock.patch.object(hc, "_proxy_config_dir_from_process", return_value=proc_cfg), \
+             mock.patch.object(hc, "_keychain_service_exists",
+                               side_effect=lambda s: s in existing_services):
+            return hc.check_quota_account_identity("ok", core_env_prober=lambda: routed)
+
+    def test_divergent_process_config_dirs_warn(self):
+        """Measured on a live host 2026-08-14: core resolved
+        `…-c225c1ed`, the proxy had inherited the in-repo default workspace and
+        resolved vanilla, and the proxy's log showed injection on every request
+        (no pass-through line ever emitted). The check reported ok throughout."""
+        core = "/Users/x/Library/Application Support/app/workspace/.claude-sutando"
+        proxy = "/Users/x/Library/Application Support/app/engine/sutando/workspace/.claude-sutando"
+        out = self._run(core, proxy, {_scoped(core), VANILLA})
+        self.assertEqual(out["status"], "warn")
+        self.assertIn(_scoped(core), out["detail"])
+        self.assertIn(VANILLA, out["detail"])
+
+    def test_non_launchd_remediation_does_not_name_a_plist(self):
+        """A host with no plist must not be told to edit one. The fix there is
+        to restart the proxy with the right CLAUDE_CONFIG_DIR."""
+        core = "/Users/x/ws/.claude-sutando"
+        proxy = "/Users/x/other/.claude-sutando"
+        out = self._run(core, proxy, {_scoped(core), VANILLA})
+        self.assertEqual(out["status"], "warn")
+        self.assertNotIn("LaunchAgents", out["detail"])
+        self.assertIn("NOT launchd-managed", out["detail"])
+        self.assertIn("confirm that is the intended", out["detail"])
+
+    def test_matching_process_config_dirs_stay_ok(self):
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core, core, {_scoped(core), VANILLA})
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("same keychain item", out["detail"])
+
+    def test_unreadable_process_env_is_inactive_not_agreement(self):
+        """Unreadable must not collapse into "" — that would assert the proxy
+        resolves vanilla on no evidence."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core, hc._PROXY_ENV_UNREADABLE, {_scoped(core), VANILLA})
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("could not be read", out["detail"])
+        self.assertIn("not evidence either way", out["detail"])
+
+    def test_unrouted_core_still_silent_without_a_plist(self):
+        """The routing gate outranks this path: a core that does not route is
+        unaffected by whose login the proxy holds."""
+        core = "/Users/x/ws/.claude-sutando"
+        proxy = "/Users/x/other/.claude-sutando"
+        out = self._run(core, proxy, {_scoped(core), VANILLA}, routed=False)
+        self.assertEqual(out["status"], "ok")
+
+
+class TestProxyConfigDirFromProcess(unittest.TestCase):
+    """Parsing `ps eww` output — where the space in "Application Support" bites."""
+
+    def _ps(self, stdout, returncode=0):
+        return lambda pid: mock.Mock(stdout=stdout, returncode=returncode)
+
+    def test_value_with_spaces_is_captured_whole(self):
+        """A whitespace split truncates this at '…/Library/Application', which
+        hashes a different directory and invents a mismatch (or hides one)."""
+        cfg = "/Users/x/Library/Application Support/app/workspace/.claude-sutando"
+        out = f"  PID TTY\n 1 ?? node /srv/proxy.js HOME=/Users/x CLAUDE_CONFIG_DIR={cfg} PATH=/usr/bin"
+        got = hc._proxy_config_dir_from_process(
+            pid_finder=lambda: ["1"], ps_runner=self._ps(out))
+        self.assertEqual(got, cfg)
+
+    def test_trailing_variable_is_captured_to_end_of_output(self):
+        cfg = "/Users/x/Application Support/ws/.claude-sutando"
+        out = f"node /srv/proxy.js PATH=/usr/bin CLAUDE_CONFIG_DIR={cfg}"
+        got = hc._proxy_config_dir_from_process(
+            pid_finder=lambda: ["1"], ps_runner=self._ps(out))
+        self.assertEqual(got, cfg)
+
+    def test_argv_only_output_is_unreadable_not_absent(self):
+        """`ps eww` prints argv alone for a process whose env we may not read.
+        That is UNKNOWN, not "the proxy has no CLAUDE_CONFIG_DIR"."""
+        got = hc._proxy_config_dir_from_process(
+            pid_finder=lambda: ["1"], ps_runner=self._ps("node /srv/proxy.js --port 7846"))
+        self.assertIs(got, hc._PROXY_ENV_UNREADABLE)
+
+    def test_env_readable_but_variable_absent_is_empty_string(self):
+        """Distinct from unreadable: the proxy really has none, so it resolves
+        the vanilla item — a comparable answer."""
+        got = hc._proxy_config_dir_from_process(
+            pid_finder=lambda: ["1"], ps_runner=self._ps("node /srv/proxy.js HOME=/Users/x PATH=/usr/bin"))
+        self.assertEqual(got, "")
+
+    def test_ambiguous_or_missing_pid_is_unreadable(self):
+        for pids in ([], ["1", "2"]):
+            with self.subTest(pids=pids):
+                self.assertIs(
+                    hc._proxy_config_dir_from_process(
+                        pid_finder=lambda: pids, ps_runner=self._ps("X=1")),
+                    hc._PROXY_ENV_UNREADABLE)
+
+    def test_probe_failures_are_unreadable_not_raises(self):
+        def boom(*a, **k):
+            raise OSError("no lsof")
+        self.assertIs(
+            hc._proxy_config_dir_from_process(pid_finder=boom, ps_runner=self._ps("X=1")),
+            hc._PROXY_ENV_UNREADABLE)
+        self.assertIs(
+            hc._proxy_config_dir_from_process(pid_finder=lambda: ["1"], ps_runner=boom),
+            hc._PROXY_ENV_UNREADABLE)
+        self.assertIs(
+            hc._proxy_config_dir_from_process(
+                pid_finder=lambda: ["1"], ps_runner=self._ps("X=1", returncode=1)),
+            hc._PROXY_ENV_UNREADABLE)
+
+    def test_listener_selector_excludes_connected_clients(self):
+        """`lsof -ti:7846` alone also matches every client holding a connection,
+        and the routed core is always one — two pids on a healthy host, which the
+        exactly-one guard reads as ambiguous. Measured: pids 23294 (proxy) and
+        62679 (claude) on 2026-08-14."""
+        with mock.patch.object(hc.subprocess, "run") as run:
+            run.return_value = mock.Mock(stdout="23294\n", returncode=0)
+            hc._proxy_pids()
+        self.assertIn("-sTCP:LISTEN", run.call_args.args[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

`check_quota_account_identity` compares the keychain item the credential proxy resolves against the one the core resolves. It read the proxy's `CLAUDE_CONFIG_DIR` from the launchd plist **only**, and returned `ok` the moment that file was absent:

```python
plist = Path.home() / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
if not plist.is_file():
    return {"name": name, "status": "ok",
            "detail": "credential proxy is not launchd-managed on this host"}
```

That detail reads as *the accounts agree*. It only means *the one file this check knows how to read is missing*. A proxy started by `startup.sh`, by the desktop supervisor, or by hand still carries a `CLAUDE_CONFIG_DIR` in its **process environment**, and it can name a different directory than the core's just as easily. The plist is one source of the mismatch, not the definition of it.

So the probe written for the 2026-08-03 wrong-account incident is silent on every host whose proxy is not launchd-managed — including the one this was found on.

## Evidence — the same command, parent vs HEAD

Live host, core routed (`ANTHROPIC_BASE_URL` set on this core, and `lsof -ti:7846` showing the core itself holding a connection to the port). No plist on this host.

```
$ git stash push -q src/health-check.py    # revert to origin/main
### PARENT (origin/main):
ok | credential proxy is not launchd-managed on this host

$ git stash pop -q
### HEAD (this branch):
warn | the credential proxy resolves a DIFFERENT login than this core's: proxy
resolves 'Claude Code-credentials', core would resolve 'Claude Code-credentials-c225c1ed'
```

What was actually true while the parent reported `ok`:

| | `CLAUDE_CONFIG_DIR` | scoped item | exists? |
|---|---|---|---|
| core | `<app>/workspace/.claude-sutando` | `…-c225c1ed` | **yes** |
| proxy | `<app>/engine/sutando/workspace/.claude-sutando` | `…-c5063b93` | **no** → falls back to vanilla |

The proxy's directory is the in-repo default workspace — it was started without reading `sutando.config.local.json`. Its scoped item cannot exist, which is the **125** `SecKeychainSearchCopyNext: item could not be found` lines against 35 loads in its log. And the log contains **zero** `pass-through engaged` and zero `failing fast` lines, so every request took the `verdict === 'ok'` inject branch — i.e. requests were billed to the vanilla account, which is exactly the consequence the warning describes.

## The fix

Fall back to the proxy's process environment when there is no plist, and give that path its own remediation — telling someone to edit a plist they do not have is worse than saying nothing.

Two details decide whether this works at all, and both are pinned by tests:

- **`-sTCP:LISTEN` is load-bearing.** Bare `lsof -ti:7846` also matches every client with an open connection, and the routed core is always one of them. That returns two pids on a healthy host (measured: `23294` = proxy, `62679` = `claude`), which an "exactly one" guard reads as ambiguous — disabling the check precisely where it applies. I hit this on the first run.
- **Capture to the next ` KEY=`, not the next space.** The value is a path under `Library/Application Support`; a whitespace split truncates it at `…/Library/Application` and hashes a directory nobody has.

Unreadable stays distinct from absent throughout: `""` means the proxy really has no `CLAUDE_CONFIG_DIR` (it resolves vanilla — a comparable answer), while an unreadable environment reports inactive and says so. Same tri-state discipline the routing gate above it already uses.

## Tests

`tests/health-check-quota-account-identity.test.py` — 33 pass (was 28).

- `TestNonLaunchdProxyIdentity` (5) — the load-bearing class. Divergent dirs with no plist → `warn`; matching → `ok`; unreadable env → inactive, not agreement; unrouted core still silent (the routing gate outranks this path); remediation must not name a plist.
- `TestProxyConfigDirFromProcess` (7) — parsing: value with spaces captured whole, trailing variable captured to end, argv-only output is UNREADABLE rather than absent, env-readable-but-variable-absent is `""`, zero/two pids ambiguous, probe failures never raise, and the listener selector is asserted.

`test_missing_plist_is_ok_not_an_error` keeps its name and narrows to the corner it still owns (no plist **and** no readable env). It now also stubs the process probe — left real it reads the developer's live proxy, the same escape this module's docstring already records for `core_env_has_proxy_url`.

Sibling suite `tests/health-check-quota-telemetry.test.py` still OK.

## Scope / notes

- Single concern: the probe's blind spot. It does **not** change how the proxy is launched — that root cause is #1887 (open, launcher/plist side, no overlap in files).
- #2843 fixed this for launchd-managed proxies by baking `CLAUDE_CONFIG_DIR` into the plist. This is the other half: hosts where there is no plist to bake into.
- **#2809 (open) touches the same file and test, but the two merge cleanly — measured, not assumed:** `git merge-tree --write-tree HEAD pr2809-trial` returns a tree OID with rc=0 and no conflict output. Its `health-check.py` hunk lands earlier in `check_quota_account_identity` (the docstring/gate region) than my first change (the plist branch), and its test hunk lands above both my modified case and my appended classes. Merge order should not matter; if either side moves, re-check rather than trusting this line.
- No token or secret material is read anywhere in this change — keychain **item names** only, and the existing `test_reads_no_secret_material` still asserts `security … -w` is never invoked.
