### PR TITLE
docs(cla): a PENDING license/cla is a third case — name the unsigned identity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,16 +215,27 @@ The goal of this phase is to provide evidence the maintainer can verify quickly.
      --jq '.[] | "\(.sha[0:8]) \(.commit.author.email) -> \(.author.login // "NULL — maps to no account")"'
    ```
 
-   Two shapes turn up. An email mapping to **no account** (`author: null`) is yours to fix by re-authoring. An email mapping to a **real account that has not signed** needs that account to sign — and you find it by differencing against the rest of the queue, because one PR alone cannot tell you which of its contributors is the unsigned one:
+   Two shapes turn up: an email mapping to **no account** (`author: null`), and an email mapping to a **real account that has not signed**.
+
+   Neither is identifiable from a single PR — every login on it looks equally plausible. The unsigned one is the login that appears on CLA-**pending** PRs and on **no green** one, which takes a comparison across the open queue:
 
    ```bash
-   # the login that appears on CLA-pending PRs and on no green one
-   gh api repos/<owner>/<repo>/pulls/<N>/commits --jq '[.[].author.login // "NULL"] | unique | join(",")'
+   for n in $(gh pr list --state open --limit 100 --json number --jq '.[].number'); do
+     h=$(gh pr view "$n" --json headRefOid --jq .headRefOid)
+     state=$(gh api "repos/<owner>/<repo>/commits/$h/status" \
+               --jq '[.statuses[]|select(.context=="license/cla")]
+                     | if length==0 then "absent" else (sort_by(.updated_at)|last|.state) end')
+     logins=$(gh api "repos/<owner>/<repo>/pulls/$n/commits" --jq '[.[].author.login // "NULL"]|unique|join(" ")')
+     echo "$state $logins"
+   done | awk '$1=="pending"{for(i=2;i<=NF;i++) p[$i]=1} $1=="success"{for(i=2;i<=NF;i++) g[$i]=1}
+                END{for(k in p) if(!(k in g)) print "unsigned candidate:", k}'
    ```
+
+   Treat the output as a **candidate list, not a verdict**: confirm against the PR's CLA-Assistant page before attributing the pending status to a person.
 
    **Do not guess from the shape of the email.** One contributor here commits under two addresses that map to two different accounts, and it is the personal-looking one that is unsigned while the institutional one is signed — the opposite of the natural assumption. A suspect that also appears on a CLA-**green** PR is disproved, which is the cheap check to run before naming anyone.
 
-   **Only offer "re-author the commits" for commits that belong to the person you are telling.** Rewriting the author of someone else's commit misattributes their work; where the unsigned identity is a third party, the only correct remedy is that account signing.
+   **`author: null` does not mean the commit is yours.** It proves only that GitHub could not map that email to an account. Before recommending `git commit --amend --reset-author` — or running it — establish that the commit is the current contributor's own work: the author NAME, the branch it arrived on, and where there is any doubt, their confirmation. Rewriting the author of someone else's commit misattributes it, and where the unsigned identity is a third party the only correct remedy is that account signing.
 
    Note the corollary of the status being SHA-bound: **pushing to the branch after this drops the status again.** If you reopen to fix the CLA and then push a review fix, expect to be back where you started.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,24 @@ The goal of this phase is to provide evidence the maintainer can verify quickly.
 
    **Give it a minute or two before concluding it failed.** The status is posted asynchronously: on one PR it was still `total=0` immediately after reopening and `license/cla=success` on the next check. Re-running the command above is the way to tell; an immediate zero means nothing yet.
 
+   **If the status is PRESENT and `pending`, that is a third case with its own cause.** `state=pending` with the description *"Contributor License Agreement is not signed yet."* means CLA-Assistant ran and is waiting on a signature — so close+reopen does nothing, and the `--reset-author` fix above only applies if the identity is your own. Ask GitHub which commit identities it cannot vouch for:
+
+   ```bash
+   gh api repos/<owner>/<repo>/pulls/<N>/commits \
+     --jq '.[] | "\(.sha[0:8]) \(.commit.author.email) -> \(.author.login // "NULL — maps to no account")"'
+   ```
+
+   Two shapes turn up. An email mapping to **no account** (`author: null`) is yours to fix by re-authoring. An email mapping to a **real account that has not signed** needs that account to sign — and you find it by differencing against the rest of the queue, because one PR alone cannot tell you which of its contributors is the unsigned one:
+
+   ```bash
+   # the login that appears on CLA-pending PRs and on no green one
+   gh api repos/<owner>/<repo>/pulls/<N>/commits --jq '[.[].author.login // "NULL"] | unique | join(",")'
+   ```
+
+   **Do not guess from the shape of the email.** One contributor here commits under two addresses that map to two different accounts, and it is the personal-looking one that is unsigned while the institutional one is signed — the opposite of the natural assumption. A suspect that also appears on a CLA-**green** PR is disproved, which is the cheap check to run before naming anyone.
+
+   **Only offer "re-author the commits" for commits that belong to the person you are telling.** Rewriting the author of someone else's commit misattributes their work; where the unsigned identity is a third party, the only correct remedy is that account signing.
+
    Note the corollary of the status being SHA-bound: **pushing to the branch after this drops the status again.** If you reopen to fix the CLA and then push a review fix, expect to be back where you started.
 
    **When to expect it.** `license/cla` is a *commit status*, so it binds to one SHA. **Every push gives the PR a new head SHA that carries no CLA status**, which is what [`.github/workflows/cla-recheck-on-push.yml`](.github/workflows/cla-recheck-on-push.yml) exists to repair — it comments the `@cla-assistant check` trigger on each `synchronize`. That repair is not reliable, so a PR you have pushed to can end up permanently short of a required check.


### PR DESCRIPTION
## What

`CONTRIBUTING.md`'s CLA triage covers **FAILING** and **ABSENT**. A third state occurs in this queue and had no entry: the status is *present* with `state=pending` and the description *"Contributor License Agreement is not signed yet."*

It matters because the two documented remedies are both wrong for it — close+reopen does nothing (the status was written), and `--reset-author` only applies if the unsigned identity is your own.

## Evidence (measured across all 89 open PRs, 2026-08-14)

10 PRs non-green: **5 ABSENT, 5 pending.** All five pendings now have a named cause:

| PR | cause |
|----|-------|
| #2431, #2436 | one commit each authored under an email mapping to **no** GitHub account (`author: null`) |
| #2270, #2276 | commits authored under `Susan09` — a real account that has not signed |
| #1414 | one commit authored under `allanturner1234` — same shape |

The unsigned account is **not visible from a single PR** — every login on it looks equally plausible. It falls out of differencing commit logins against the CLA-green PRs: `Susan09` appears on exactly the two pending PRs and no green one; `allanturner1234` on exactly one. Three named causes, **zero false positives across 89 PRs**.

I fixed my own two by re-authoring (tree verified identical to the old head, force-pushed with a lease); both went `license/cla: success`, which is the before/after for the `author: null` half.

## Two traps the section now records, because both cost me time today

1. **The mapping direction is not guessable from the address.** One contributor commits under two addresses that map to two different accounts, and the *personal-looking* one is the unsigned account while the *institutional* one is signed. I suspected the institutional address first and disproved it by finding it on four CLA-green PRs — a cheap check that has to happen before naming anyone.
2. **"Re-author the commits" is only safe advice for commits belonging to the person you are telling.** On #1414 the unsigned commit is a third party's; recommending a re-author there would misattribute their work, so the only correct remedy is that account signing. The section says so explicitly.

## Verification

Both commands in the added text were run **as written** against a live PR before committing, not composed and left untested.

## Relationship to #2863

Adjacent but disjoint. #2863 changes the one-line pointer in `CLAUDE.md`/`AGENTS.md` toward close+reopen for the **ABSENT** case; this changes `CONTRIBUTING.md`'s triage to cover the **pending** case, which #2863 does not mention. No file overlap, no merge-order dependency.

Kept as a separate PR deliberately rather than pushed onto #2863's branch: `license/cla` is SHA-bound, so a push would drop that PR's currently-green status and strand it in the very ABSENT state it documents — whose remedy needs an owner-side close+reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MK5AeA7sHrCk8tZv5sTrt8