### PR TITLE
fix(health-check): this host's own subtree is not evidence that sync ran

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2331,11 +2331,17 @@ def check_host_subtrees() -> dict:
     """Surface per-host subtrees (hosts/<host>/) that have stopped syncing.
 
     Under the hosts/<hostname>/ convention each host writes only its own
-    subtree, so the newest file mtime in a subtree is that host's last sync. A
-    subtree not updated in SUTANDO_STALE_HOST_DAYS days means that host went
-    quiet (crashed, decommissioned, or sync broke) — surface it rather than
-    letting it silently rot (a gap in both the old machine-<host>/ model and the
-    new one until now). Read-only.
+    subtree, so the newest file mtime in a PEER's subtree is when sync last
+    carried that host's writes here. A peer not updated in
+    SUTANDO_STALE_HOST_DAYS days went quiet (crashed, decommissioned, or sync
+    broke) — surface it rather than letting it silently rot. Read-only.
+
+    THIS host's own subtree is excluded, because its mtime measures local
+    writes, not sync: the core rewrites `hosts/<self>/current-track.md`,
+    `pending-questions.md` and `crons.json` continuously, so it is fresh even
+    where sync has never run once. Counting it made the verdict read
+    "all synced <7d" on a single-machine install with `vault.enabled=false` —
+    an assurance about the one thing the mtime cannot witness.
     """
     name = "host-subtrees"
     hosts_dir = WORKSPACE_DIR / "hosts"
@@ -2349,7 +2355,15 @@ def check_host_subtrees() -> dict:
     if not subtrees:
         return {"name": name, "status": "ok", "detail": "hosts/ present, no host subtrees"}
     now = time.time()
-    stale, fresh = [], 0
+    # Union of every label a launcher here could have written, and on failure the
+    # empty set — which restores the old behaviour rather than excluding a peer we
+    # could not identify. Under-claiming sync evidence beats asserting it.
+    try:
+        local = _local_host_labels()
+        label_known = True
+    except Exception:                     # noqa: BLE001 — a probe must not raise
+        local, label_known = set(), False
+    stale, fresh, own = [], 0, []
     for d in subtrees:
         newest = 0.0
         for f in d.rglob("*"):
@@ -2360,16 +2374,28 @@ def check_host_subtrees() -> dict:
                 continue
         if newest == 0.0:
             continue  # empty subtree — nothing to age
+        if d.name in local:
+            own.append(d.name)
+            continue
         age_d = (now - newest) / 86400
         if age_d > stale_days:
             stale.append(f"{d.name} ({age_d:.0f}d)")
         else:
             fresh += 1
+    suffix = "" if label_known else " (could not identify this host's own label)"
     if stale:
         return {"name": name, "status": "warn",
-                "detail": f"{len(stale)} host subtree(s) stale (>{stale_days:.0f}d): "
-                          f"{', '.join(stale)} — host stopped syncing?"}
-    return {"name": name, "status": "ok", "detail": f"{fresh} host subtree(s), all synced <{stale_days:.0f}d"}
+                "detail": f"{len(stale)} peer subtree(s) stale (>{stale_days:.0f}d): "
+                          f"{', '.join(stale)} — host stopped syncing?{suffix}"}
+    if fresh:
+        return {"name": name, "status": "ok",
+                "detail": f"{fresh} peer subtree(s), all synced <{stale_days:.0f}d"
+                          f"{f'; own subtree {own[0]} not aged (local writes)' if own else ''}{suffix}"}
+    return {"name": name, "status": "ok",
+            "detail": ("no peer subtree(s) to age — "
+                       + (f"only this host's own ({', '.join(own)}), whose mtime is local writes, "
+                          "not sync" if own else "hosts/ holds no datable subtree")
+                       + suffix)}
 
 
 def _durable_access_bytes(raw: bytes) -> "bytes | None":

--- a/tests/health-check-host-subtrees-self.test.py
+++ b/tests/health-check-host-subtrees-self.test.py
@@ -130,6 +130,16 @@ class HostSubtreeSelfTest(unittest.TestCase):
         self.assertEqual(out["status"], "ok")
         self.assertNotIn("Empty-Host", out["detail"])
 
+    def test_only_empty_peer_subtrees_says_so_rather_than_naming_a_host(self):
+        """`fresh`, `stale` and `own` all empty. Reachable on a fresh clone that
+        has a hosts/ dir before any host has written into it, so the sentence
+        must not claim a subtree that is not there."""
+        (self.ws / "hosts" / "Nobody-Yet").mkdir()
+        out = self._run()
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("no datable subtree", out["detail"])
+        self.assertNotIn("local writes", out["detail"])
+
     def test_no_hosts_dir_is_unchanged(self):
         with mock.patch.object(hc, "WORKSPACE_DIR", self.ws / "nope"):
             self.assertEqual(hc.check_host_subtrees()["status"], "ok")

--- a/tests/health-check-host-subtrees-self.test.py
+++ b/tests/health-check-host-subtrees-self.test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""This host's own subtree is not evidence that sync ran.
+
+`check_host_subtrees` ages each `hosts/<label>/` by its newest file mtime and
+reports the result as sync freshness. That reading holds for a PEER — its files
+arrive here only by sync — and fails for the local host, whose core rewrites
+`current-track.md`, `pending-questions.md` and `crons.json` continuously. The
+local subtree is therefore always fresh, including where sync has never run.
+
+The load-bearing case is `test_only_own_subtree_does_not_claim_sync`: it FAILS on
+the parent commit, which answers "1 host subtree(s), all synced <7d" for a
+single-machine workspace with `vault.enabled=false`. The peer cases would pass
+against an implementation that changed nothing, so they prove nothing alone —
+they are here to pin that peer behaviour is untouched.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("hc_host_subtrees", REPO / "src" / "health-check.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["hc_host_subtrees"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+hc = _load()
+SELF = "This-Very-Host"
+
+
+class HostSubtreeSelfTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        (self.ws / "hosts").mkdir(parents=True)
+        self.addCleanup(self._tmp.cleanup)
+        # WORKSPACE_DIR is module state, and the label probe must be stated by
+        # each case rather than inherited — left real it reads the developer's
+        # own hostname and the fixtures stop meaning anything.
+        ws = mock.patch.object(hc, "WORKSPACE_DIR", self.ws)
+        ws.start(); self.addCleanup(ws.stop)
+
+    def _subtree(self, label, age_days):
+        d = self.ws / "hosts" / label
+        d.mkdir(parents=True, exist_ok=True)
+        f = d / "current-track.md"
+        f.write_text("x")
+        when = time.time() - age_days * 86400
+        os.utime(f, (when, when))
+        return d
+
+    def _run(self, labels=(SELF,), stale_days=None):
+        env = {"SUTANDO_STALE_HOST_DAYS": str(stale_days)} if stale_days else {}
+        with mock.patch.object(hc, "_local_host_labels", return_value=set(labels)), \
+             mock.patch.dict(os.environ, env, clear=False):
+            return hc.check_host_subtrees()
+
+    # ---- THE regression pin: fails on the parent commit ---------------------
+
+    def test_only_own_subtree_does_not_claim_sync(self):
+        """A single-machine workspace. The subtree is fresh because the core
+        writes it, and the parent commit reports that as 'all synced <7d'."""
+        self._subtree(SELF, age_days=0)
+        out = self._run()
+        self.assertEqual(out["status"], "ok")
+        self.assertNotIn("all synced", out["detail"])
+        self.assertIn("local writes", out["detail"])
+        self.assertIn(SELF, out["detail"])
+
+    def test_own_subtree_is_not_counted_among_fresh_peers(self):
+        """With one real peer, the count must be 1 — not 2."""
+        self._subtree(SELF, age_days=0)
+        self._subtree("Peer-Laptop", age_days=1)
+        out = self._run()
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("1 peer subtree(s)", out["detail"])
+        self.assertIn("all synced", out["detail"])
+
+    def test_a_stale_own_subtree_is_never_reported_as_stopped_syncing(self):
+        """'host stopped syncing?' is the wrong sentence about the machine
+        reading it — a core that stopped writing is other probes' business."""
+        self._subtree(SELF, age_days=99)
+        out = self._run()
+        self.assertEqual(out["status"], "ok")
+        self.assertNotIn("stopped syncing", out["detail"])
+
+    # ---- peer behaviour must be untouched (passes on the parent too) --------
+
+    def test_a_stale_peer_still_warns(self):
+        self._subtree(SELF, age_days=0)
+        self._subtree("Dead-Peer", age_days=30)
+        out = self._run()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("Dead-Peer", out["detail"])
+        self.assertIn("stopped syncing", out["detail"])
+
+    def test_stale_threshold_still_honours_the_env_override(self):
+        self._subtree("Peer-Laptop", age_days=3)
+        self.assertEqual(self._run(stale_days=2)["status"], "warn")
+        self.assertEqual(self._run(stale_days=10)["status"], "ok")
+
+    # ---- degraded paths -----------------------------------------------------
+
+    def test_unknown_local_label_falls_back_instead_of_excluding_a_peer(self):
+        """If the label cannot be resolved, excluding a subtree would discard a
+        real peer's staleness. Restore the old counting and SAY the label is
+        unknown, rather than silently guessing which subtree is ours."""
+        self._subtree("Some-Host", age_days=0)
+        with mock.patch.object(hc, "_local_host_labels", side_effect=OSError("no hostname")):
+            out = hc.check_host_subtrees()
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("could not identify", out["detail"])
+
+    def test_an_empty_subtree_is_not_aged(self):
+        (self.ws / "hosts" / "Empty-Host").mkdir()
+        self._subtree(SELF, age_days=0)
+        out = self._run()
+        self.assertEqual(out["status"], "ok")
+        self.assertNotIn("Empty-Host", out["detail"])
+
+    def test_no_hosts_dir_is_unchanged(self):
+        with mock.patch.object(hc, "WORKSPACE_DIR", self.ws / "nope"):
+            self.assertEqual(hc.check_host_subtrees()["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`check_host_subtrees` ages every `hosts/<label>/` by its newest file mtime and reports the answer as **sync** freshness. Its docstring states the premise:

> each host writes only its own subtree, so the newest file mtime in a subtree is that host's last sync

That holds for a **peer** — a peer's files reach this workspace only by sync, so their mtime really does date the last one. It does not hold for **this** host. The core rewrites `hosts/<self>/current-track.md`, `pending-questions.md`, `crons.json` and `schedule-crons-stamp.json` continuously, so the local subtree is fresh whether or not sync has ever run.

The local subtree is therefore counted as evidence for the one thing its mtime cannot witness.

## Evidence — same probe, same live workspace, parent vs HEAD

A single-machine install with `vault.enabled = false` (the **shipped default** in `sutando.config.json`, no local override present), where sync has never run once:

```
BEFORE (origin/main)   ok    1 host subtree(s), all synced <7d
AFTER  (this branch)   ok    no peer subtree(s) to age — only this host's own
                             (Yixuans-MacBook-Pro), whose mtime is local writes, not sync
```

The newest file behind that "all synced <7d" was `current-track.md`, written by the core **three minutes before the probe ran**. Nothing had synced; something had been *saved*.

Worth stating plainly, because it decides how much this matters: on a single-host install the verdict is not merely unproven, it is **unfalsifiable**. The local core writes its own subtree every few minutes, so the age can never exceed the threshold, so this probe can never report anything but "all synced" no matter what happens to sync.

## The fix

Exclude the local labels from aging; count and describe **peers** only.

```python
try:
    local = _local_host_labels()
    label_known = True
except Exception:
    local, label_known = set(), False
...
    if d.name in local:
        own.append(d.name)
        continue
```

`_local_host_labels()` already exists in this file and is the right instrument: it returns the *union* of `util_paths._host_label()` and the short hostname, because the reader and the launchers do not share a label contract and this repo's own vault already carries both `Chis-MacBook-Pro` and `Chis-MBP` branches. Its conservative direction suits this use too — if a label *might* be ours, not counting it as sync evidence is the safe side.

**The unresolvable-label case goes the other way, deliberately.** If `_local_host_labels()` raises we keep the old counting and say the label is unknown, rather than excluding a subtree we cannot identify. Under-claiming sync evidence is safe; silently discarding a real peer's staleness is not — that would convert a false assurance into a missing alarm, which is worse.

## Scope

- **Peer behaviour is untouched:** a stale peer still warns, with the same threshold and the same `SUTANDO_STALE_HOST_DAYS` override. Two tests pin this and they pass on the parent as well — they are there to prove nothing moved, not to prove the fix.
- **No new warn.** Every path here returns `ok` unless a *peer* is stale, exactly as before. This deliberately does not become a nag about unconfigured sync: `check_memory_sync` already answers that question and was made informational-only by explicit owner ask (2026-07-10, #2069). Whether to configure a vault is a decision; this PR only stops the probe from asserting the decision was already made.
- Wording changes from "host subtree(s)" to "peer subtree(s)" so the noun matches what is actually being aged.

## Tests

New `tests/health-check-host-subtrees-self.test.py` — **8 pass on this head, 4 fail with `src/health-check.py` restored to `origin/main`** and the test file kept:

```
FAIL test_only_own_subtree_does_not_claim_sync
FAIL test_own_subtree_is_not_counted_among_fresh_peers
FAIL test_a_stale_own_subtree_is_never_reported_as_stopped_syncing
FAIL test_unknown_local_label_falls_back_instead_of_excluding_a_peer
Ran 8 tests — FAILED (failures=4)
```

`_local_host_labels` is stubbed in every case. Left real it reads the developer's own hostname, and a fixture named after some other machine then exercises the peer path on one host and the self path on another — green locally, meaningless everywhere.

The third failing case is the one I would have left out: a *stale* local subtree currently reports `host stopped syncing?`, which is the wrong sentence about the machine reading it. A core that stopped writing is `core-proactive-loop` and `task-watcher`'s business, not this probe's.

`tests/health-check-quota-account-identity.test.py` (21) still passes; `ruff` clean.
