### PR TITLE
fix(skill-hooks): a vanished hook script must fail OPEN, not block every tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1325,7 +1325,6 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -1526,7 +1525,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1881,7 +1879,6 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2655,7 +2652,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3433,7 +3429,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3593,7 +3588,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6827,7 +6827,9 @@ def check_claude_hook_registration(
     try:
         sys.path.insert(0, str(repo / "src"))
         from skill_hooks import discover as _discover_skill_hooks
-        owned.extend(_discover_skill_hooks(repo))
+        # [:3] — the 4th field is the prior command, which only the installer's
+        # migration sweep uses; `owned` also holds 3-tuples parsed from the script.
+        owned.extend(r[:3] for r in _discover_skill_hooks(repo))
     except Exception as exc:
         return {"name": name, "status": "warn",
                 "detail": f"skill-hook discovery failed ({exc}) — "

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -104,9 +104,8 @@ HOOKS=(
 HOOK_PRIOR=()
 for _i in "${!HOOKS[@]}"; do HOOK_PRIOR+=(""); done
 
-# Skill-declared hooks. A skill owns its hook the way it owns its `tools`;
-# src/skill_hooks.py is the single discovery the health probe also reads.
-# NUL-framed (`-d ''`) because two of the four fields embed the repo path.
+# Skill-declared hooks via src/skill_hooks.py (the same discovery the health probe reads).
+# NUL-framed (-d '') because two of the four fields embed the repo path.
 while IFS= read -r -d '' _ev && IFS= read -r -d '' _tok \
    && IFS= read -r -d '' _cmd && IFS= read -r -d '' _prior; do
   [ -n "${_ev:-}" ] || continue

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -99,13 +99,23 @@ HOOKS=(
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
 )
 
+# The unguarded command an earlier installer wrote, parallel to HOOKS by index.
+# Carried alongside rather than as another `|` field: HOOKS entries already rely
+# on CMD being last to hold a `|`, and a second path-bearing field cannot also be
+# last. Empty for the static entries above, which were never emitted guarded; sized
+# from HOOKS rather than written out, so adding a static entry cannot shift indices.
+HOOK_PRIOR=()
+for _i in "${!HOOKS[@]}"; do HOOK_PRIOR+=(""); done
+
 # Skill-declared hooks. A skill owns its hook the way it owns its `tools`;
 # src/skill_hooks.py is the single discovery the health probe also reads.
-while IFS='|' read -r _ev _tok _cmd; do
-  [ -n "${_ev:-}" ] && HOOKS+=("$_ev|$_tok|$_cmd")
-done <<EOF
-$(python3 "$REPO_DIR/src/skill_hooks.py" "$REPO_DIR" 2>/dev/null)
-EOF
+# NUL-framed (`-d ''`) because two of the four fields embed the repo path.
+while IFS= read -r -d '' _ev && IFS= read -r -d '' _tok \
+   && IFS= read -r -d '' _cmd && IFS= read -r -d '' _prior; do
+  [ -n "${_ev:-}" ] || continue
+  HOOKS+=("$_ev|$_tok|$_cmd")
+  HOOK_PRIOR+=("$_prior")
+done < <(python3 "$REPO_DIR/src/skill_hooks.py" "$REPO_DIR" 2>/dev/null)
 
 # Deprecated hooks to uninstall on re-run.  Each line: "<event>|<substring>".
 # Matching uses `.command | contains(substring)` so we don't need to track
@@ -166,7 +176,8 @@ re_escape() { printf '%s' "$1" | sed 's/[][\\^$.*+?(){}|]/\\&/g'; }
 #
 # Sweeping a *different clone's* entry is intended — that shape is
 # installer-generated, just not by this checkout.
-for entry in "${HOOKS[@]}"; do
+for i in "${!HOOKS[@]}"; do
+  entry="${HOOKS[$i]}"
   EVENT="${entry%%|*}"
   REST="${entry#*|}"
   MARKER="${REST%%|*}"
@@ -237,10 +248,12 @@ for entry in "${HOOKS[@]}"; do
   # runner-first entry an earlier installer wrote; without this the old one
   # survives beside the new and still blocks the tool it gates.
   # Exact string only — the narrowest form that cannot touch operator variants.
+  #
+  # Taken from the emitter, not re-derived here. `${CMD#*exec }` strips through the
+  # FIRST `exec ` in the string, which on a repo path containing `exec ` is inside
+  # the path — the shape then matches nothing and the blocking entry survives.
   LEGACY_SHAPE=""
-  case "$CMD" in
-    "[ -f "*" ] || exit 0; exec "*) LEGACY_SHAPE="^$(re_escape "${CMD#*exec }")\$" ;;
-  esac
+  [ -n "${HOOK_PRIOR[$i]:-}" ] && LEGACY_SHAPE="^$(re_escape "${HOOK_PRIOR[$i]}")\$"
 
   if ! jq -e --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" \
            --arg shape "$SHAPE" --arg legacy "$LEGACY_SHAPE" \

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -233,22 +233,35 @@ for entry in "${HOOKS[@]}"; do
   CMD_TAIL="${CMD_TAIL#[\"\']}"       # drop shq's closing quote, if present
   SHAPE="^$(re_escape "$CMD_WORD") [\"']?[^ -].*$(re_escape "$MARKER")[\"']?$(re_escape "$CMD_TAIL")\$"
 
-  if ! jq -e --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" --arg shape "$SHAPE" \
+  # A guarded command changes the FIRST WORD to `[`, so SHAPE cannot match the
+  # runner-first entry an earlier installer wrote; without this the old one
+  # survives beside the new and still blocks the tool it gates.
+  # Exact string only — the narrowest form that cannot touch operator variants.
+  LEGACY_SHAPE=""
+  case "$CMD" in
+    "[ -f "*" ] || exit 0; exec "*) LEGACY_SHAPE="^$(re_escape "${CMD#*exec }")\$" ;;
+  esac
+
+  if ! jq -e --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" \
+           --arg shape "$SHAPE" --arg legacy "$LEGACY_SHAPE" \
       '(.hooks // {})[$event] // [] | map(.hooks // []) | flatten | map(.command // "")
-       | map(contains($marker) and (. != $cmd) and test($shape))
+       | map(contains($marker) and (. != $cmd)
+             and (test($shape) or ($legacy != "" and test($legacy))))
        | any' \
       "$SETTINGS" >/dev/null 2>&1; then
     continue
   fi
 
   TMP="$(mktemp "${SETTINGS}.XXXXXX")"
-  jq --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" --arg shape "$SHAPE" '
+  jq --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" \
+     --arg shape "$SHAPE" --arg legacy "$LEGACY_SHAPE" '
     if (.hooks // {})[$event] then
       .hooks[$event] |= map(
         .hooks |= map(select(
           ((.command // "") | contains($marker))
           and ((.command // "") != $cmd)
-          and ((.command // "") | test($shape))
+          and ((.command // "")
+               | test($shape) or ($legacy != "" and test($legacy)))
           | not
         ))
       )

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -99,11 +99,8 @@ HOOKS=(
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
 )
 
-# The unguarded command an earlier installer wrote, parallel to HOOKS by index.
-# Carried alongside rather than as another `|` field: HOOKS entries already rely
-# on CMD being last to hold a `|`, and a second path-bearing field cannot also be
-# last. Empty for the static entries above, which were never emitted guarded; sized
-# from HOOKS rather than written out, so adding a static entry cannot shift indices.
+# Parallel to HOOKS by index, not another `|` field: CMD must stay last to hold a
+# `|`, and a second path-bearing field cannot also be last. Sized from HOOKS.
 HOOK_PRIOR=()
 for _i in "${!HOOKS[@]}"; do HOOK_PRIOR+=(""); done
 
@@ -244,14 +241,8 @@ for i in "${!HOOKS[@]}"; do
   CMD_TAIL="${CMD_TAIL#[\"\']}"       # drop shq's closing quote, if present
   SHAPE="^$(re_escape "$CMD_WORD") [\"']?[^ -].*$(re_escape "$MARKER")[\"']?$(re_escape "$CMD_TAIL")\$"
 
-  # A guarded command changes the FIRST WORD to `[`, so SHAPE cannot match the
-  # runner-first entry an earlier installer wrote; without this the old one
-  # survives beside the new and still blocks the tool it gates.
-  # Exact string only — the narrowest form that cannot touch operator variants.
-  #
-  # Taken from the emitter, not re-derived here. `${CMD#*exec }` strips through the
-  # FIRST `exec ` in the string, which on a repo path containing `exec ` is inside
-  # the path — the shape then matches nothing and the blocking entry survives.
+  # SHAPE cannot match the runner-first entry (its first word is `[`), so match the
+  # prior command exactly, taken from the emitter — `${CMD#*exec }` splits on a path.
   LEGACY_SHAPE=""
   [ -n "${HOOK_PRIOR[$i]:-}" ] && LEGACY_SHAPE="^$(re_escape "${HOOK_PRIOR[$i]}")\$"
 

--- a/src/skill_hooks.py
+++ b/src/skill_hooks.py
@@ -53,7 +53,17 @@ def discover(repo_dir: Path) -> list[tuple[str, str, str]]:
             if target is None or not target.is_file():
                 continue
             runner = RUNNERS.get(target.suffix, "bash")
-            out.append((event, target.name, f"{runner} {shlex.quote(str(target))}"))
+            q = shlex.quote(str(target))
+            # Skip when the script is absent AT FIRE TIME, not just at install time.
+            # The path points into the working tree, so `git checkout` of any branch
+            # predating the skill deletes it while the registration survives — and a
+            # hook whose command cannot start is an error, which BLOCKS the tool. On
+            # 2026-08-14 that took a core fully dark: this guard registers under an
+            # empty matcher, so a missing file blocked Bash, Read, Write and tool
+            # search at once, including every route that could restore the file.
+            # Absent must fail OPEN; a present guard keeps its own exit code, so a
+            # real block still blocks.
+            out.append((event, target.name, f"[ -f {q} ] || exit 0; exec {runner} {q}"))
     return out
 
 

--- a/src/skill_hooks.py
+++ b/src/skill_hooks.py
@@ -54,15 +54,8 @@ def discover(repo_dir: Path) -> list[tuple[str, str, str]]:
                 continue
             runner = RUNNERS.get(target.suffix, "bash")
             q = shlex.quote(str(target))
-            # Skip when the script is absent AT FIRE TIME, not just at install time.
-            # The path points into the working tree, so `git checkout` of any branch
-            # predating the skill deletes it while the registration survives — and a
-            # hook whose command cannot start is an error, which BLOCKS the tool. On
-            # 2026-08-14 that took a core fully dark: this guard registers under an
-            # empty matcher, so a missing file blocked Bash, Read, Write and tool
-            # search at once, including every route that could restore the file.
-            # Absent must fail OPEN; a present guard keeps its own exit code, so a
-            # real block still blocks.
+            # The path is in the working tree, so a checkout can delete it while the
+            # registration survives; a hook that cannot start blocks the tool it gates.
             out.append((event, target.name, f"[ -f {q} ] || exit 0; exec {runner} {q}"))
     return out
 

--- a/src/skill_hooks.py
+++ b/src/skill_hooks.py
@@ -28,13 +28,7 @@ def resolve_hook_command(skill_dir: Path, command: str) -> Path | None:
 
 def discover(repo_dir: Path) -> list[tuple[str, str, str, str]]:
     """(event, token, command, prior_command) per declared, present, enabled hook.
-
-    Skips rather than raises on anything malformed: a broken manifest must not
-    abort a whole install, and a hook declared but absent is not registrable.
-
-    `prior_command` is the unguarded form an earlier installer wrote, emitted here
-    because deriving it by splitting on `exec ` breaks on a path containing `exec `.
-    """
+    Skips malformed entries; prior_command is emitted (not derived by splitting on `exec `)."""
     out: list[tuple[str, str, str, str]] = []
     for manifest in sorted(Path(repo_dir).glob("skills/*/manifest.json")):
         try:

--- a/src/skill_hooks.py
+++ b/src/skill_hooks.py
@@ -32,10 +32,8 @@ def discover(repo_dir: Path) -> list[tuple[str, str, str, str]]:
     Skips rather than raises on anything malformed: a broken manifest must not
     abort a whole install, and a hook declared but absent is not registrable.
 
-    `prior_command` is the unguarded form an earlier installer wrote. It is emitted
-    here, where `runner` and the quoted path are already in hand, because deriving
-    it by splitting the assembled command on `exec ` breaks on a repo path that
-    itself contains `exec `.
+    `prior_command` is the unguarded form an earlier installer wrote, emitted here
+    because deriving it by splitting on `exec ` breaks on a path containing `exec `.
     """
     out: list[tuple[str, str, str, str]] = []
     for manifest in sorted(Path(repo_dir).glob("skills/*/manifest.json")):

--- a/src/skill_hooks.py
+++ b/src/skill_hooks.py
@@ -26,13 +26,18 @@ def resolve_hook_command(skill_dir: Path, command: str) -> Path | None:
     return target if root in target.parents else None
 
 
-def discover(repo_dir: Path) -> list[tuple[str, str, str]]:
-    """(event, token, command) for every declared, present, enabled skill hook.
+def discover(repo_dir: Path) -> list[tuple[str, str, str, str]]:
+    """(event, token, command, prior_command) per declared, present, enabled hook.
 
     Skips rather than raises on anything malformed: a broken manifest must not
     abort a whole install, and a hook declared but absent is not registrable.
+
+    `prior_command` is the unguarded form an earlier installer wrote. It is emitted
+    here, where `runner` and the quoted path are already in hand, because deriving
+    it by splitting the assembled command on `exec ` breaks on a repo path that
+    itself contains `exec `.
     """
-    out: list[tuple[str, str, str]] = []
+    out: list[tuple[str, str, str, str]] = []
     for manifest in sorted(Path(repo_dir).glob("skills/*/manifest.json")):
         try:
             data = json.loads(manifest.read_text())
@@ -56,11 +61,17 @@ def discover(repo_dir: Path) -> list[tuple[str, str, str]]:
             q = shlex.quote(str(target))
             # The path is in the working tree, so a checkout can delete it while the
             # registration survives; a hook that cannot start blocks the tool it gates.
-            out.append((event, target.name, f"[ -f {q} ] || exit 0; exec {runner} {q}"))
+            prior = f"{runner} {q}"
+            out.append((event, target.name, f"[ -f {q} ] || exit 0; exec {prior}", prior))
     return out
 
 
 if __name__ == "__main__":
     import sys
+    # NUL-framed: two fields carry a repo path, and a path may contain any byte
+    # except NUL — including the `|` the reader would otherwise split on.
+    out = sys.stdout.buffer
     for row in discover(Path(sys.argv[1])):
-        print("|".join(row))
+        for field in row:
+            out.write(field.encode() + b"\0")
+    out.flush()

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -366,11 +366,8 @@ ok "with the script deleted the guarded hook exits 0 (tool not blocked)" "$?"
 rm -rf "$UROOT"
 
 # ---- same upgrade, on a repo path containing `exec ` and `|` ----
-# The migration above passes on any ordinary path, which is why this defect
-# shipped. `${CMD#*exec }` is a SHORTEST-match strip, so it cuts at the first
-# `exec ` in the string — inside the path, not at the shell keyword — and the
-# derived shape then matches nothing, leaving the blocking entry in place. The
-# `|` additionally exercises the field framing between skill_hooks and the reader.
+# An ordinary path cannot catch this: `${CMD#*exec }` splits inside the path, and
+# the `|` exercises the field framing between skill_hooks and the reader.
 EROOT="$(mktemp -d)"; EREPO="$EROOT/exec repo|x/repo"
 mkdir -p "$EREPO/.claude" "$EREPO/src" "$EREPO/skills/demo/hooks"
 cp "$HERE/../src/install-claude-hooks.sh" "$EREPO/src/"

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -365,6 +365,48 @@ bash -c "$UGUARD" >/dev/null 2>&1
 ok "with the script deleted the guarded hook exits 0 (tool not blocked)" "$?"
 rm -rf "$UROOT"
 
+# ---- same upgrade, on a repo path containing `exec ` and `|` ----
+# The migration above passes on any ordinary path, which is why this defect
+# shipped. `${CMD#*exec }` is a SHORTEST-match strip, so it cuts at the first
+# `exec ` in the string — inside the path, not at the shell keyword — and the
+# derived shape then matches nothing, leaving the blocking entry in place. The
+# `|` additionally exercises the field framing between skill_hooks and the reader.
+EROOT="$(mktemp -d)"; EREPO="$EROOT/exec repo|x/repo"
+mkdir -p "$EREPO/.claude" "$EREPO/src" "$EREPO/skills/demo/hooks"
+cp "$HERE/../src/install-claude-hooks.sh" "$EREPO/src/"
+cp "$HERE/../src/skill_hooks.py" "$EREPO/src/"
+printf '#!/bin/bash\n:\n' > "$EREPO/src/session-handoff.sh"
+printf '#!/bin/bash\n:\n' > "$EREPO/src/check-pending-tasks.sh"
+chmod +x "$EREPO/src/"*.sh
+printf '{"name":"demo","hooks":[{"event":"PreToolUse","command":"./hooks/g.py"}]}\n' \
+    > "$EREPO/skills/demo/manifest.json"
+printf 'import sys; sys.exit(2)\n' > "$EREPO/skills/demo/hooks/g.py"
+EPATH="$(python3 -c "import pathlib,sys;print(pathlib.Path(sys.argv[1]).resolve())" "$EREPO/skills/demo/hooks/g.py")"
+export E_SETTINGS="$EREPO/.claude/settings.json"
+# shq quotes the path, so the seeded legacy entry must be quoted the same way an
+# installer would have written it — otherwise the fixture is not what it claims.
+E_OLD="python3 $(python3 -c "import shlex,sys;print(shlex.quote(sys.argv[1]))" "$EPATH")"
+export E_OLD
+python3 - <<'PY'
+import json, os
+json.dump({"hooks": {"PreToolUse": [{"matcher": "", "hooks": [
+    {"type": "command", "command": os.environ["E_OLD"]},
+]}]}}, open(os.environ["E_SETTINGS"], "w"), indent=2)
+PY
+bash "$EREPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+ECMDS="$(python3 -c "
+import json, os
+d = json.load(open(os.environ['E_SETTINGS']))
+print(chr(10).join(h['command'] for g in d['hooks'].get('PreToolUse', []) for h in g['hooks']))
+")"
+ok "path containing 'exec ': legacy entry is REMOVED, not left blocking" \
+   "$(echo "$ECMDS" | grep -qxF "$E_OLD" && echo 1 || echo 0)"
+# No trailing space in the pattern: this path needs quoting, so shq emits `g.py'`
+# where an ordinary path emits a bare `g.py `.
+ok "path containing 'exec ': guarded hook registered exactly once" \
+   "$([ "$(echo "$ECMDS" | grep -c "^\[ -f .*g\.py")" = 1 ] && echo 0 || echo 1)"
+rm -rf "$EROOT"
+
 rm -rf "$ROOT"
 echo "---"
 if [ "$fail" -gt 0 ]; then

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -319,6 +319,52 @@ ok "and the repo-path hook is still installed on the same event" \
    "$(echo "$CCMDS" | grep -q 'session-handoff' && echo 0 || echo 1)"
 rm -rf "$CROOT"
 
+# ---- upgrade path: a pre-existing runner-first skill hook must be MIGRATED ----
+# The outage case. An affected install already carries `python3 <path>`; if a
+# re-run only ADDS the guarded entry, the old one still fires and still blocks.
+UROOT="$(mktemp -d)"; UREPO="$UROOT/repo"
+mkdir -p "$UREPO/.claude" "$UREPO/src" "$UREPO/skills/demo/hooks"
+cp "$HERE/../src/install-claude-hooks.sh" "$UREPO/src/"
+cp "$HERE/../src/skill_hooks.py" "$UREPO/src/"
+printf '#!/bin/bash\n:\n' > "$UREPO/src/session-handoff.sh"
+printf '#!/bin/bash\n:\n' > "$UREPO/src/check-pending-tasks.sh"
+chmod +x "$UREPO/src/"*.sh
+printf '{"name":"demo","hooks":[{"event":"PreToolUse","command":"./hooks/g.py"}]}\n' \
+    > "$UREPO/skills/demo/manifest.json"
+printf 'import sys; sys.exit(2)\n' > "$UREPO/skills/demo/hooks/g.py"
+# Resolve it: skill_hooks writes the RESOLVED path, and on macOS mktemp hands
+# back /var/... for /private/var/..., so an unresolved fixture seeds a string no
+# installer ever wrote and the migration would look broken when it is not.
+GPATH="$(python3 -c "import pathlib,sys;print(pathlib.Path(sys.argv[1]).resolve())" "$UREPO/skills/demo/hooks/g.py")"
+export U_SETTINGS="$UREPO/.claude/settings.json"
+# Seed EXACTLY what a previous installer wrote, plus an operator variant that
+# invokes the same script — the negative control the sweep must not eat.
+U_OLD="python3 $GPATH" python3 - <<'PY'
+import json, os
+json.dump({"hooks": {"PreToolUse": [{"matcher": "", "hooks": [
+    {"type": "command", "command": os.environ["U_OLD"]},
+    {"type": "command", "command": "bash -x " + os.environ["U_OLD"].split(" ", 1)[1]},
+]}]}}, open(os.environ["U_SETTINGS"], "w"), indent=2)
+PY
+bash "$UREPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+UCMDS="$(python3 -c "
+import json, os
+d = json.load(open(os.environ['U_SETTINGS']))
+print(chr(10).join(h['command'] for g in d['hooks'].get('PreToolUse', []) for h in g['hooks']))
+")"
+ok "old runner-first skill hook is REMOVED on re-run (not left beside the new one)" \
+   "$(echo "$UCMDS" | grep -qx "python3 $GPATH" && echo 1 || echo 0)"
+ok "guarded skill hook is registered exactly once" \
+   "$([ "$(echo "$UCMDS" | grep -c '^\[ -f .*g\.py ')" = 1 ] && echo 0 || echo 1)"
+ok "operator's own variant on the same script survives (negative control)" \
+   "$(echo "$UCMDS" | grep -q 'bash -x ' && echo 0 || echo 1)"
+# The point of the whole change: with the script gone, nothing blocks.
+rm -f "$GPATH"
+UGUARD="$(echo "$UCMDS" | grep '^\[ -f .*g\.py ' | head -1)"
+bash -c "$UGUARD" >/dev/null 2>&1
+ok "with the script deleted the guarded hook exits 0 (tool not blocked)" "$?"
+rm -rf "$UROOT"
+
 rm -rf "$ROOT"
 echo "---"
 if [ "$fail" -gt 0 ]; then

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -320,8 +320,7 @@ ok "and the repo-path hook is still installed on the same event" \
 rm -rf "$CROOT"
 
 # ---- upgrade path: a pre-existing runner-first skill hook must be MIGRATED ----
-# The outage case. An affected install already carries `python3 <path>`; if a
-# re-run only ADDS the guarded entry, the old one still fires and still blocks.
+# The outage case: a re-run must replace the old `python3 <path>` entry, not add beside it.
 UROOT="$(mktemp -d)"; UREPO="$UROOT/repo"
 mkdir -p "$UREPO/.claude" "$UREPO/src" "$UREPO/skills/demo/hooks"
 cp "$HERE/../src/install-claude-hooks.sh" "$UREPO/src/"
@@ -332,9 +331,8 @@ chmod +x "$UREPO/src/"*.sh
 printf '{"name":"demo","hooks":[{"event":"PreToolUse","command":"./hooks/g.py"}]}\n' \
     > "$UREPO/skills/demo/manifest.json"
 printf 'import sys; sys.exit(2)\n' > "$UREPO/skills/demo/hooks/g.py"
-# Resolve it: skill_hooks writes the RESOLVED path, and on macOS mktemp hands
-# back /var/... for /private/var/..., so an unresolved fixture seeds a string no
-# installer ever wrote and the migration would look broken when it is not.
+# Resolve the fixture path: skill_hooks writes RESOLVED paths, and macOS mktemp's
+# /var/... alias would seed a string no installer ever wrote (false migration failure).
 GPATH="$(python3 -c "import pathlib,sys;print(pathlib.Path(sys.argv[1]).resolve())" "$UREPO/skills/demo/hooks/g.py")"
 export U_SETTINGS="$UREPO/.claude/settings.json"
 # Seed EXACTLY what a previous installer wrote, plus an operator variant that
@@ -366,8 +364,7 @@ ok "with the script deleted the guarded hook exits 0 (tool not blocked)" "$?"
 rm -rf "$UROOT"
 
 # ---- same upgrade, on a repo path containing `exec ` and `|` ----
-# An ordinary path cannot catch this: `${CMD#*exec }` splits inside the path, and
-# the `|` exercises the field framing between skill_hooks and the reader.
+# `${CMD#*exec }` splits inside such a path; the `|` exercises the NUL field framing.
 EROOT="$(mktemp -d)"; EREPO="$EROOT/exec repo|x/repo"
 mkdir -p "$EREPO/.claude" "$EREPO/src" "$EREPO/skills/demo/hooks"
 cp "$HERE/../src/install-claude-hooks.sh" "$EREPO/src/"

--- a/tests/skill-hooks-discovery.test.py
+++ b/tests/skill-hooks-discovery.test.py
@@ -37,8 +37,23 @@ class SkillHookDiscovery(unittest.TestCase):
         event, token, cmd = rows[0]
         self.assertEqual(event, "PreToolUse")
         self.assertEqual(token, "g.py")
-        self.assertTrue(cmd.startswith("python3 "), cmd)
+        # The runner still has to be the one the suffix selects; it just no longer
+        # leads the command, because an existence guard runs first.
+        self.assertIn("exec python3 ", cmd)
         self.assertIn("skills/demo/hooks/g.py", cmd)
+
+    def test_a_vanished_script_allows_the_tool_instead_of_blocking_it(self):
+        """The registration outlives the file: `git checkout` of a branch predating
+        the skill deletes it, and a hook that cannot start blocks the tool it gates.
+
+        Fires the emitted command with the script deleted and requires exit 0 — an
+        absent guard must not be able to take the agent's tools away."""
+        d = self._skill("demo", {"name": "demo", "hooks": [
+            {"event": "PreToolUse", "command": "./hooks/g.py"}]}, hook_body="import sys; sys.exit(2)")
+        cmd = discover(self.repo)[0][2]
+        self.assertEqual(subprocess.run(cmd, shell=True).returncode, 2, "present guard must still block")
+        (d / "hooks" / "g.py").unlink()
+        self.assertEqual(subprocess.run(cmd, shell=True).returncode, 0, "absent guard must fail OPEN")
 
     def test_discovery_refuses_a_command_outside_the_declaring_skill(self):
         """A manifest must not be able to point core at a host executable."""

--- a/tests/skill-hooks-discovery.test.py
+++ b/tests/skill-hooks-discovery.test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 import subprocess
 import sys
@@ -34,13 +35,36 @@ class SkillHookDiscovery(unittest.TestCase):
             {"event": "PreToolUse", "command": "./hooks/g.py"}]})
         rows = discover(self.repo)
         self.assertEqual(len(rows), 1)
-        event, token, cmd = rows[0]
+        event, token, cmd, prior = rows[0]
         self.assertEqual(event, "PreToolUse")
         self.assertEqual(token, "g.py")
         # The runner still has to be the one the suffix selects; it just no longer
         # leads the command, because an existence guard runs first.
         self.assertIn("exec python3 ", cmd)
         self.assertIn("skills/demo/hooks/g.py", cmd)
+        # The unguarded form an earlier installer wrote, so the sweep can match and
+        # replace it without re-deriving it from `cmd`.
+        self.assertTrue(cmd.endswith(prior), f"{cmd!r} does not end with {prior!r}")
+        self.assertEqual(cmd, f"[ -f {shlex.quote(str(self.repo.resolve() / 'skills/demo/hooks/g.py'))} ]"
+                              f" || exit 0; exec {prior}")
+
+    def test_prior_command_survives_a_repo_path_containing_exec_and_pipe(self):
+        """`${CMD#*exec }` strips at the FIRST `exec ` — inside the path, not the
+        shell keyword — so the derived shape matched nothing and the blocking
+        registration survived the upgrade. Emitting it structurally is immune."""
+        self._td.cleanup()
+        self._td = tempfile.TemporaryDirectory(prefix="exec repo|x ")
+        self.addCleanup(self._td.cleanup)
+        self.repo = Path(self._td.name)
+        self._skill("demo", {"name": "demo", "hooks": [
+            {"event": "PreToolUse", "command": "./hooks/g.py"}]})
+        _event, _token, cmd, prior = discover(self.repo)[0]
+
+        self.assertEqual(prior, f"python3 {shlex.quote(str(self.repo.resolve() / 'skills/demo/hooks/g.py'))}")
+        self.assertTrue(cmd.endswith(prior))
+        # What the installer used to compute. It is wrong here, and that is the bug.
+        self.assertNotEqual(cmd.split("exec ", 1)[1], prior,
+                            "fixture must actually exercise the bad derivation")
 
     def test_a_vanished_script_allows_the_tool_instead_of_blocking_it(self):
         """The registration outlives the file, and a hook that cannot start blocks

--- a/tests/skill-hooks-discovery.test.py
+++ b/tests/skill-hooks-discovery.test.py
@@ -43,11 +43,8 @@ class SkillHookDiscovery(unittest.TestCase):
         self.assertIn("skills/demo/hooks/g.py", cmd)
 
     def test_a_vanished_script_allows_the_tool_instead_of_blocking_it(self):
-        """The registration outlives the file: `git checkout` of a branch predating
-        the skill deletes it, and a hook that cannot start blocks the tool it gates.
-
-        Fires the emitted command with the script deleted and requires exit 0 — an
-        absent guard must not be able to take the agent's tools away."""
+        """The registration outlives the file, and a hook that cannot start blocks
+        the tool it gates, so an absent script must exit 0."""
         d = self._skill("demo", {"name": "demo", "hooks": [
             {"event": "PreToolUse", "command": "./hooks/g.py"}]}, hook_body="import sys; sys.exit(2)")
         cmd = discover(self.repo)[0][2]

--- a/tests/skill-hooks-discovery.test.py
+++ b/tests/skill-hooks-discovery.test.py
@@ -49,9 +49,8 @@ class SkillHookDiscovery(unittest.TestCase):
                               f" || exit 0; exec {prior}")
 
     def test_prior_command_survives_a_repo_path_containing_exec_and_pipe(self):
-        """`${CMD#*exec }` strips at the FIRST `exec ` — inside the path, not the
-        shell keyword — so the derived shape matched nothing and the blocking
-        registration survived the upgrade. Emitting it structurally is immune."""
+        """`${CMD#*exec }` splits at the first `exec ` — inside the path, not the
+        keyword — so the derived shape matched nothing. Emitting it is immune."""
         self._td.cleanup()
         self._td = tempfile.TemporaryDirectory(prefix="exec repo|x ")
         self.addCleanup(self._td.cleanup)


### PR DESCRIPTION
## What

A skill-declared hook is registered by absolute path into the working tree, but `skill_hooks.discover()` only verified the file at **install** time. `git checkout` of any branch predating the skill deletes the script while the registration survives — and a hook whose command cannot start is an *error*, which **blocks** the tool it gates.

The emitted command now skips when the script is absent at **fire** time, and still `exec`s it when present so a genuine block still blocks.

```
[ -f <script> ] || exit 0; exec python3 <script>
```

## Why this is a availability bug, not a corner case

Measured on a live core, 2026-08-14. Checking out PR branch #2148 removed `skills/gws-gmail-voice/hooks/reply-orphan-guard.py` (added to main that morning by #2882). That guard registers under an **empty matcher**, so the missing file blocked `Bash`, `Read`, `Write` and tool-search simultaneously — including every route that could have restored the file or fetched its contents. There was no in-session recovery; a human had to run `git switch main`.

The core was dark ~90 minutes and queued 17 tasks behind it, including the morning briefing and several owner messages. Any branch without the file reproduces it: every open PR branch, every worktree, any `git bisect`.

## Evidence

New regression `test_a_vanished_script_allows_the_tool_instead_of_blocking_it` executes the emitted command for real, both ways:

- script present and exiting 2 → command returns **2** (a real block still blocks)
- script deleted → command returns **0** (fails open)

It fails without the change (the old shape returns non-zero on the deleted case).

Consumer suites (`grep -rl skill_hooks`), all green:

| suite | result |
|---|---|
| `tests/skill-hooks-discovery.test.py` | 21 passed |
| `tests/health-check-claude-hook-registration.test.py` | 26 passed |
| `tests/install-claude-hooks.test.sh` | PASS (33 checks) |

`_hook_command_targets` in the health probe compares against the installer's own command string, so probe and installer move together by design — no drift.

## Deliberate test change

`test_a_declared_present_hook_is_discovered` asserted `cmd.startswith("python3 ")`. The runner is no longer the leading token, so it now asserts `"exec python3 "` — same intent (the suffix still selects the runner), updated for the guard that precedes it.

## Known gap, not fixed here

`install-claude-hooks.sh`'s stale-variant sweep anchors `SHAPE` on the command's first word. That word changes from `python3` to `[`, so a re-run **adds** the guarded hook without removing a previously-registered unguarded one, leaving both. Migrating the sweep across a command-word change is a separate concern with its own ownership-test risk (the sweep is deliberately conservative to avoid deleting operator customizations), so it is not bundled here. Until then a re-run needs the old entry dropped by hand; new installs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MK5AeA7sHrCk8tZv5sTrt8