### PR TITLE
fix(gateway): a logging failure must not kill the poll loop

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -914,6 +914,48 @@ def _redact_url(value: str) -> str:
         return str(value)
 
 
+class _NeverFatalStream:
+    """Logging must never take the poll loop down.
+
+    Mirrors the merged `src/discord-bridge.py` fix (#2856). This package is
+    standalone (`dependencies = []`, imports nothing from sutando's `src/`), so
+    the guard is local by necessity rather than duplicated policy.
+
+    The loop's own `except Exception  # keep the loop alive` cannot help here:
+    every handler calls `_log()` first, so a `BrokenPipeError` from that print
+    is raised *inside* the handler and escapes it. Stdout is a pipe whenever the
+    launcher pipes to `tee`, which is how this bridge runs today.
+
+    Swallow ONLY OSError (the EPIPE/EBADF class); anything else still propagates
+    so real bugs are not masked.
+    """
+
+    __slots__ = ("_stream",)
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def write(self, data):
+        try:
+            return self._stream.write(data)
+        except OSError:
+            # Report the write as accepted: callers must not branch on it.
+            return len(data)
+
+    def flush(self):
+        try:
+            self._stream.flush()
+        except OSError:
+            pass
+
+    def __getattr__(self, name):
+        return getattr(self._stream, name)
+
+
+sys.stdout = _NeverFatalStream(sys.stdout)
+sys.stderr = _NeverFatalStream(sys.stderr)
+
+
 def _log(msg: str) -> None:
     line = f"[remote-gateway-bridge] {msg}"
     print(line, flush=True)

--- a/tests/gateway-bridge-logging-not-fatal.test.py
+++ b/tests/gateway-bridge-logging-not-fatal.test.py
@@ -14,7 +14,8 @@ guard for the standalone ag2-sparrow package.
 
 `test_a_write_to_a_dead_pipe_does_not_raise` fails on the parent commit.
 """
-import importlib.util
+import importlib
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -38,19 +39,29 @@ class _DeadPipe:
 
 
 def _never_fatal():
-    """Return the module's guard class without importing the whole bridge.
+    """Return the module's guard class, importing the module the way the repo's
+    other gateway tests do (`tests/gateway-owner-presence-peer-gate.test.py`).
 
-    Executing the module would start real network/config work, so the class is
-    extracted from source. Returns None when the guard is absent (parent commit).
+    Importing rather than exec-ing a source slice matters twice over: it is the
+    established harness, and it is what makes the guard's lines register as
+    covered — `compile()` on a slice renumbers from 1, so diff-cover would credit
+    the wrong lines of this file entirely.
+
+    Returns None when the guard is absent (parent commit), so the control arms
+    fail on an assertion rather than an ImportError.
     """
-    src = MOD.read_text()
-    if "class _NeverFatalStream" not in src:
-        return None
-    start = src.index("class _NeverFatalStream")
-    end = src.index("sys.stdout = _NeverFatalStream", start)
-    ns: dict = {}
-    exec(compile(src[start:end], str(MOD), "exec"), ns)  # noqa: S102 — pinned slice
-    return ns["_NeverFatalStream"]
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
+    sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
+    # The module installs the guard on the REAL sys.stdout/sys.stderr at import.
+    # Restore them, or every later test in the process writes through the wrapper.
+    saved_out, saved_err = sys.stdout, sys.stderr
+    try:
+        m = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+        m = importlib.reload(m)
+    finally:
+        sys.stdout, sys.stderr = saved_out, saved_err
+    return getattr(m, "_NeverFatalStream", None)
 
 
 class GatewayLoggingNotFatalTest(unittest.TestCase):

--- a/tests/gateway-bridge-logging-not-fatal.test.py
+++ b/tests/gateway-bridge-logging-not-fatal.test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""A dead log pipe must not kill the gateway's poll loop.
+
+`remote-gateway-bridge` runs with stdout piped to `tee` (measured on a live
+core: fd1/fd2 are PIPE, unlike telegram/discord/voice-agent which are REG). Its
+`_log()` does an unguarded `print(..., flush=True)`, and the poll loop's last
+resort is `except Exception  # keep the loop alive` — which cannot help, because
+**every handler calls `_log()` first**. A `BrokenPipeError` from that print is
+raised inside the handler and escapes it, so the loop dies silently: stderr is
+the same dead pipe, so nothing is reported.
+
+Same class as #2856 (merged) in `src/discord-bridge.py`; this pins the analogous
+guard for the standalone ag2-sparrow package.
+
+`test_a_write_to_a_dead_pipe_does_not_raise` fails on the parent commit.
+"""
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MOD = REPO / "packages" / "ag2-sparrow" / "ag2_sparrow" / "remote_gateway_bridge.py"
+
+
+class _DeadPipe:
+    """Stands in for a pipe whose reader has gone away."""
+
+    def __init__(self):
+        self.writes = 0
+
+    def write(self, data):
+        self.writes += 1
+        raise BrokenPipeError(32, "Broken pipe")
+
+    def flush(self):
+        raise BrokenPipeError(32, "Broken pipe")
+
+
+def _never_fatal():
+    """Return the module's guard class without importing the whole bridge.
+
+    Executing the module would start real network/config work, so the class is
+    extracted from source. Returns None when the guard is absent (parent commit).
+    """
+    src = MOD.read_text()
+    if "class _NeverFatalStream" not in src:
+        return None
+    start = src.index("class _NeverFatalStream")
+    end = src.index("sys.stdout = _NeverFatalStream", start)
+    ns: dict = {}
+    exec(compile(src[start:end], str(MOD), "exec"), ns)  # noqa: S102 — pinned slice
+    return ns["_NeverFatalStream"]
+
+
+class GatewayLoggingNotFatalTest(unittest.TestCase):
+    # ---- THE regression pin: fails on the parent ---------------------------
+
+    def test_a_write_to_a_dead_pipe_does_not_raise(self):
+        """This is the whole defect: the print inside an except handler."""
+        cls = _never_fatal()
+        if cls is None:
+            self.fail("no _NeverFatalStream guard: a dead pipe still kills the poll loop")
+        stream = cls(_DeadPipe())
+        stream.write("[remote-gateway-bridge] poll network error\n")  # must not raise
+        stream.flush()                                                # must not raise
+
+    def test_the_guard_is_actually_installed_on_stdout_and_stderr(self):
+        """A class nobody installs protects nothing.
+
+        Asserts on booleans, not `assertIn` against the source: a failure there
+        dumps the whole 2400-line module into the report and buries the reason.
+        """
+        src = MOD.read_text()
+        self.assertTrue("sys.stdout = _NeverFatalStream(sys.stdout)" in src,
+                        "stdout is never wrapped, so _log still writes raw")
+        self.assertTrue("sys.stderr = _NeverFatalStream(sys.stderr)" in src,
+                        "stderr is never wrapped, so a crash report dies too")
+
+    def test_it_is_installed_before_log_is_defined(self):
+        """Order matters: _log must emit through the guarded stream.
+
+        Uses find() rather than index() so the parent commit FAILS this with a
+        readable reason instead of raising ValueError — an error proves a string
+        is absent; only a comparison shows the ordering is wrong.
+        """
+        src = MOD.read_text()
+        install, log = src.find("sys.stdout = _NeverFatalStream"), src.find("def _log(msg: str)")
+        self.assertNotEqual(install, -1, "guard is never installed on stdout")
+        self.assertNotEqual(log, -1, "_log not found — module shape changed")
+        self.assertLess(install, log, "_log is defined before the guard is installed")
+
+    # ---- must NOT over-swallow ---------------------------------------------
+
+    def test_only_oserror_is_swallowed(self):
+        """Masking every exception would hide real bugs, not just EPIPE."""
+        cls = _never_fatal()
+        if cls is None:
+            self.skipTest("guard absent on this commit")
+
+        class _Nasty:
+            def write(self, data):
+                raise ValueError("a real bug, not a broken pipe")
+
+            def flush(self):
+                raise ValueError("a real bug, not a broken pipe")
+
+        with self.assertRaises(ValueError):
+            cls(_Nasty()).write("x")
+        with self.assertRaises(ValueError):
+            cls(_Nasty()).flush()
+
+    def test_write_reports_the_full_length_so_callers_do_not_branch(self):
+        cls = _never_fatal()
+        if cls is None:
+            self.skipTest("guard absent on this commit")
+        data = "12345"
+        self.assertEqual(cls(_DeadPipe()).write(data), len(data))
+
+    def test_a_healthy_stream_is_passed_through_untouched(self):
+        cls = _never_fatal()
+        if cls is None:
+            self.skipTest("guard absent on this commit")
+
+        class _Ok:
+            def __init__(self):
+                self.buf = []
+
+            def write(self, data):
+                self.buf.append(data)
+                return len(data)
+
+            def flush(self):
+                self.buf.append("<flush>")
+
+            encoding = "utf-8"
+
+        ok = _Ok()
+        w = cls(ok)
+        w.write("hello")
+        w.flush()
+        self.assertEqual(ok.buf, ["hello", "<flush>"])
+        self.assertEqual(w.encoding, "utf-8")  # __getattr__ passthrough
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`remote-gateway-bridge` runs with stdout piped to `tee`, so its fds are a **pipe**. Measured on a live core — and it is the only bridge in that state:

```
telegram-bridge.py       pid 37900   1w:REG 2w:REG     unaffected
discord-bridge.py        pid 23340   1w:REG 2w:REG     unaffected
voice-agent.js           pid 23342   1w:REG 2w:REG     unaffected
credential-proxy         pid 23294   1w:REG 2w:REG     unaffected
remote-gateway-bridge.py pid 23098   1:PIPE 2:PIPE  <- ARMED
```

`_log()` does an unguarded `print(line, flush=True)`. Because the stream is line-buffered, the flush happens at the newline — so if `tee` goes away, `BrokenPipeError` is raised *inside whatever code was logging*.

**The loop's own safety net cannot catch it**, and that is the part worth reading twice:

```python
except (urllib.error.URLError, TimeoutError) as e:
    _log(f"poll network error: {e} — backing off {backoff}s")   # <- raises here
    ...
except Exception as e:  # noqa: BLE001 — keep the loop alive
    _log(f"unexpected: {e} — backing off {backoff}s")           # <- and here
```

`BrokenPipeError` is an `OSError`, so `except Exception` *would* catch it — except **every handler calls `_log()` as its first action**. The new exception is raised inside the handler and escapes it. The comment promises resilience the code cannot deliver.

**Impact:** the poll loop dies **silently** — stderr is the same dead pipe, so there is no crash message — and `state/gateway-status.json` stops updating. The ag2space channel simply goes quiet.

## The fix

The pattern merged for `src/discord-bridge.py` in #2856, applied here.

This package is standalone — `pyproject.toml` declares `dependencies = []` and it imports nothing from sutando's `src/` — so importing a shared helper is not available. The guard is local **by necessity, not duplicated policy**; if ag2-sparrow ever gains a sutando dependency, these should collapse into one owner.

Swallows **only** `OSError` (the EPIPE/EBADF class), so real bugs still propagate.

## Evidence

```
HEAD    : Ran 6 tests — OK
parent  : FAILED (failures=3, skipped=3)   ERROR arms: 0
```

The three that fail on the parent are the ones that matter, and each fails on a real assertion rather than erroring on a missing symbol:

- `test_a_write_to_a_dead_pipe_does_not_raise` → *"no _NeverFatalStream guard: a dead pipe still kills the poll loop"*
- `test_the_guard_is_actually_installed_on_stdout_and_stderr` — a class nobody installs protects nothing
- `test_it_is_installed_before_log_is_defined` — ordering is the whole contract

The three skips are the over-swallow guards, which have nothing to assert against on a commit with no guard. They pass on HEAD and pin that `ValueError` still propagates, that `write()` reports the full length so callers cannot branch on it, and that a healthy stream passes through untouched (including `__getattr__`).

## Scope

Not fixed here: `backend-supervisor` is also PIPE. It is a different process with a different logging path and belongs in its own change.
