### PR TITLE
feat(voice): P7 Tranche A — audio-progress ledger, health matrix, vision egress controls, capture recovery

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-212 modules indexed.
+216 modules indexed.
 
 ## `src/`
 
@@ -149,11 +149,15 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`voice-agent-config.ts`** — Voice agent tuned-prompt configuration — step 5a-1 of the interaction-planes refactor (LiveAgentRuntime extraction, slice 1).
 - **`voice-agent-state.ts`** — `agent.state` v1 protocol provider + lifecycle snapshot publisher (design 1a′; impl plan WS1 Step 12, amendments R8/A9/A10/S3/Z3).
 - **`voice-agent.ts`** — Sutando — Voice Interface
+- **`voice-audio-health-persist.ts`** — voice-audio-health-persist — worker_threads sqlite writer for the P7 voice_audio_health table (D7.1; §D7.0b round-4 #3: node:sqlite is synchronous, so timer-scheduled writes on the voice event loop can still block audio behind disk latency or busy_timeout — the writes live in a worker thread instead, and the main thread only try-enqueues).
+- **`voice-audio-health.ts`** — voice-audio-health — P7 D7.1 engine-side audio-progress ledger (Tranche A interim).
 - **`voice-config-switch.ts`** — Voice tool: switch voice-agent's model + googleSearch preset at runtime.
 - **`voice-config.ts`** — Per-surface voice configuration loader.
 - **`voice-connect-resolver.ts`** — Transparent voice-connection tier resolution — picks the best reachable endpoint for "call your agent" so the user never chooses a tier.
 - **`voice-context.ts`** — Builds a system prompt for the Claude Code subprocess that injects Sutando identity and user context from the memory system.
+- **`voice-continuity.ts`** — voice-continuity — P7 D7.3 continuity helpers (Tranche A engine-side): the stale-repeat goodbye guard and the centralized conversation-clear.
 - **`voice-error-classifier.ts`** — Classify Gemini Live transport close events into actionable categories.
+- **`voice-health-matrix.ts`** — voice-health-matrix — P7 D7.2: the failure-localization matrix.
 - **`voice-key.ts`** — Shared Gemini API-key resolution for voice surfaces (voice-agent, phone-conversation, and any plugin voice surface).
 - **`voice-lock.ts`** — voice-lock.ts — TS caller of the guarded PID-lock helper (`scripts/voice-lock.py`), used by voice-agent's `acquirePidLock` (impl plan WS1 Step 4, amendments R1/R3/R4).
 - **`voice-mode-resolver.ts`** — Unified base-mode resolver for the voice agent (issue #1410, supersedes partial fixes #1412 + #1413).

--- a/skills/screen-companion/scripts/read-selection.ts
+++ b/skills/screen-companion/scripts/read-selection.ts
@@ -9,8 +9,12 @@
 //
 // Timeout budget: 800ms per probe (Mini #1409 review). 3s × 2 = 6s worst-case
 // is too slow for an inline voice tool; 800ms keeps total budget ≤ 1.6s.
+//
+// ASYNC (P7 §D7.0b): the vision frame hook runs on the voice event loop —
+// a synchronous osascript would block audio for the whole probe timeout, so
+// the subprocess is execFile with a callback, never execSync.
 
-import { execSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 
 export type SelectionSource = 'ax_selection' | 'chrome_js_selection';
 
@@ -33,26 +37,35 @@ on error
   return ""
 end try`;
 
-function probe(script: string, label: string, timeoutMs = 800): string {
-	try {
-		return execSync(`osascript -e '${script}'`, { encoding: 'utf-8', timeout: timeoutMs }).trim();
-	} catch (err) {
-		// execSync timeout surfaces as an Error with .signal === 'SIGTERM' AND .code === 'ETIMEDOUT'.
-		const e = err as { signal?: string; code?: string };
-		if (e?.signal === 'SIGTERM' || e?.code === 'ETIMEDOUT') {
-			console.error(`[read-selection] ${label} probe timed out — permission may be denied`);
-		}
-		return '';
-	}
+function probe(script: string, label: string, timeoutMs = 800): Promise<string> {
+	return new Promise((resolve) => {
+		execFile(
+			'osascript',
+			['-e', script],
+			{ encoding: 'utf-8', timeout: timeoutMs },
+			(err, stdout) => {
+				if (err) {
+					// A timeout surfaces with .signal === 'SIGTERM' / .code === 'ETIMEDOUT'.
+					const e = err as { signal?: string; code?: string };
+					if (e?.signal === 'SIGTERM' || e?.code === 'ETIMEDOUT') {
+						console.error(`[read-selection] ${label} probe timed out — permission may be denied`);
+					}
+					resolve('');
+					return;
+				}
+				resolve((stdout ?? '').trim());
+			}
+		);
+	});
 }
 
 /** Read the user's current text selection. Tries AX first (native apps),
  *  then Chrome's window.getSelection() (browser content). Returns null when
  *  nothing is selected anywhere. */
-export function readSelection(timeoutMs = 800): SelectionResult | null {
-	const ax = probe(AX_SCRIPT, 'AX', timeoutMs);
+export async function readSelection(timeoutMs = 800): Promise<SelectionResult | null> {
+	const ax = await probe(AX_SCRIPT, 'AX', timeoutMs);
 	if (ax) return { text: ax, source: 'ax_selection' };
-	const js = probe(CHROME_JS_SCRIPT, 'Chrome JS', timeoutMs);
+	const js = await probe(CHROME_JS_SCRIPT, 'Chrome JS', timeoutMs);
 	if (js) return { text: js, source: 'chrome_js_selection' };
 	return null;
 }

--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -54,10 +54,15 @@ let _lastInjectedSelection = '';
 export function _frameHook(sendUserCtx: (text: string) => void): void {
 	_selectionTickCount++;
 	if (_selectionTickCount % SELECTION_PROBE_INTERVAL_TICKS !== 0) return;
-	const sel = _readSelection(200); // 200ms timeout — must not stall the tick
-	if (!sel || sel.text === _lastInjectedSelection) return;
-	_lastInjectedSelection = sel.text;
-	sendUserCtx(`[Selected text: ${sel.text}]`);
+	// §D7.0b: the probe shells out — fire-and-forget async so the frame-send
+	// path returns immediately; the injection lands when the probe resolves.
+	void Promise.resolve(_readSelection(200))
+		.then((sel) => {
+			if (!sel || sel.text === _lastInjectedSelection) return;
+			_lastInjectedSelection = sel.text;
+			sendUserCtx(`[Selected text: ${sel.text}]`);
+		})
+		.catch(() => {});
 }
 
 /** Reset module-level frame hook state between tests. */
@@ -224,10 +229,15 @@ const deactivateScreenCompanionTool: ToolDefinition = {
 // Gemini Live session. Designed for pull-mode (configs that don't stream).
 
 // Injection seams for tests — production code uses the imported defaults.
-let _readSelection: (timeoutMs?: number) => SelectionResult | null = defaultReadSelection;
+// readSelection is async in production (§D7.0b: the osascript probe must
+// never run synchronously on the voice loop); sync fakes are also accepted.
+type ReadSelectionFn = (
+	timeoutMs?: number
+) => SelectionResult | null | Promise<SelectionResult | null>;
+let _readSelection: ReadSelectionFn = defaultReadSelection;
 let _captureSendFrame: typeof captureSendFrame = captureSendFrame;
 export function _setVisionQueryDeps(deps: {
-	readSelection?: (timeoutMs?: number) => SelectionResult | null;
+	readSelection?: ReadSelectionFn;
 	captureSendFrame?: typeof captureSendFrame;
 }): void {
 	if (deps.readSelection) _readSelection = deps.readSelection;
@@ -267,7 +277,7 @@ const visionQueryTool: ToolDefinition = {
 		const wantSelection = mode === 'selection' || mode === 'both' || mode === 'selection-or-frame';
 		const wantFrame = mode === 'frame' || mode === 'both' || mode === 'selection-or-frame';
 
-		const selection = wantSelection ? _readSelection() : null;
+		const selection = wantSelection ? await _readSelection() : null;
 
 		// mode='selection' — only selection, no frame fallback.
 		if (mode === 'selection') {

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -132,6 +132,25 @@ def _notify_capture_blocking():
         pass  # Best-effort; notification absence is never critical.
 
 
+def _downscale_frame(path: str, maxdim: int | None, quality: int | None) -> None:
+    """P7 D7.4: resize/recompress a captured frame IN THIS PROCESS via sips.
+
+    Runs before the path is returned to the caller, so the voice event loop
+    only ever touches the already-shrunk file. Best-effort: any failure
+    leaves the original in place (the caller's token bucket still bounds
+    egress)."""
+    cmd = ["sips"]
+    if maxdim:
+        cmd += ["--resampleHeightWidthMax", str(maxdim)]
+    if quality:
+        cmd += ["-s", "format", "jpeg", "-s", "formatOptions", str(quality)]
+    cmd.append(path)
+    try:
+        subprocess.run(cmd, timeout=10, capture_output=True, check=True)
+    except Exception:
+        pass
+
+
 def _notify_capture():
     """Debounced fire-and-forget macOS notification."""
     global _last_notify_ts
@@ -206,6 +225,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
             fmt = "png"
         ext = "jpg" if fmt in ("jpg", "jpeg") else "png"
         type_flag = "jpg" if ext == "jpg" else "png"
+        # P7 D7.4: optional downscale/recompress executed HERE, in the capture
+        # server's process (sips subprocess) — vision compression must never
+        # compete with the voice event loop. maxdim bounds the longest edge;
+        # quality is JPEG percent (jpg only). Bounded to sane ranges.
+        maxdim_raw = query.get("maxdim", [None])[0]
+        maxdim = int(maxdim_raw) if maxdim_raw and maxdim_raw.isdigit() and 320 <= int(maxdim_raw) <= 3840 else None
+        quality_raw = query.get("quality", [None])[0]
+        quality = int(quality_raw) if quality_raw and quality_raw.isdigit() and 10 <= int(quality_raw) <= 100 else None
         try:
             if capture_all:
                 # Capture all displays separately
@@ -229,6 +256,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     cmd.append(f"-D{display}")
                 cmd.append(path)
                 subprocess.run(cmd, timeout=5, check=True)
+            if maxdim or (quality and ext == "jpg"):
+                for p in paths:
+                    _downscale_frame(p, maxdim, quality if ext == "jpg" else None)
             resp = {"status": "ok", "path": paths[0] if paths else path}
             if len(paths) > 1:
                 resp["all_paths"] = paths

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -132,13 +132,19 @@ def _notify_capture_blocking():
         pass  # Best-effort; notification absence is never critical.
 
 
-def _downscale_frame(path: str, maxdim: int | None, quality: int | None) -> None:
+# A frame that could not be recompressed may still pass if it is already
+# small; past this it is an error — D7.4 makes the downscale budget
+# MANDATORY, and silently sending a native-res original re-creates FE-1.
+DOWNSCALE_FAIL_MAX_BYTES = 400 * 1024
+
+
+def _downscale_frame(path: str, maxdim: int | None, quality: int | None) -> bool:
     """P7 D7.4: resize/recompress a captured frame IN THIS PROCESS via sips.
 
     Runs before the path is returned to the caller, so the voice event loop
-    only ever touches the already-shrunk file. Best-effort: any failure
-    leaves the original in place (the caller's token bucket still bounds
-    egress)."""
+    only ever touches the already-shrunk file. Returns False when the frame
+    could not be brought under budget (sips failed AND the original exceeds
+    DOWNSCALE_FAIL_MAX_BYTES) — the caller must error, not pass it through."""
     cmd = ["sips"]
     if maxdim:
         cmd += ["--resampleHeightWidthMax", str(maxdim)]
@@ -147,8 +153,12 @@ def _downscale_frame(path: str, maxdim: int | None, quality: int | None) -> None
     cmd.append(path)
     try:
         subprocess.run(cmd, timeout=10, capture_output=True, check=True)
+        return True
     except Exception:
-        pass
+        try:
+            return os.path.getsize(path) <= DOWNSCALE_FAIL_MAX_BYTES
+        except Exception:
+            return False
 
 
 def _notify_capture():
@@ -258,7 +268,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 subprocess.run(cmd, timeout=5, check=True)
             if maxdim or (quality and ext == "jpg"):
                 for p in paths:
-                    _downscale_frame(p, maxdim, quality if ext == "jpg" else None)
+                    if not _downscale_frame(p, maxdim, quality if ext == "jpg" else None):
+                        for cleanup in paths:
+                            try: os.unlink(cleanup)
+                            except Exception: pass
+                        self._send_json(500, {"status": "error", "error": "downscale failed and frame exceeds budget"})
+                        return
             resp = {"status": "ok", "path": paths[0] if paths else path}
             if len(paths) > 1:
                 resp["all_paths"] = paths

--- a/src/task-delegation.ts
+++ b/src/task-delegation.ts
@@ -28,10 +28,11 @@
  * read / archive), so the same watcher semantics run over either backend.
  */
 
-import { writeFileSync, readdirSync, readFileSync, accessSync, constants, mkdirSync } from 'node:fs';
+import { writeFileSync, readdirSync, readFileSync, accessSync, constants, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFile } from 'node:child_process';
+import { findRepoRoot } from './sutando_config.js';
 
 function ts(): string { return new Date().toISOString().slice(11, 23); }
 
@@ -43,7 +44,17 @@ function ts(): string { return new Date().toISOString().slice(11, 23); }
 // cleanly when telemetry is opted out / unconfigured. Fire-and-forget: never
 // blocks or throws into task submission. Source is read from the task file's own
 // `source:` header, so every surface is tagged with exactly what it wrote.
-const _TELEMETRY_PY = join(dirname(fileURLToPath(import.meta.url)), 'telemetry.py');
+// Resolve telemetry.py from the repo root, not the running module's dir: the
+// bundled build runs dist/voice-agent.js and ships no .py files in dist/ —
+// src/*.py travel as a SIBLING of dist/ (same defect class as the
+// screen-capture-server path, field report 2026-08-14). Module-sibling stays
+// as the dev fallback; the fire-and-forget execFile tolerates a miss either way.
+const _TELEMETRY_PY = (() => {
+	const moduleDir = dirname(fileURLToPath(import.meta.url));
+	const root = findRepoRoot(moduleDir);
+	const canonical = root ? join(root, 'src', 'telemetry.py') : null;
+	return canonical && existsSync(canonical) ? canonical : join(moduleDir, 'telemetry.py');
+})();
 /** Read the coarse surface bucket from a task file's own `source:` header —
  * `voice` / `chat` / `context-drop` / … — falling back to `unknown` when the
  * header is absent. Pure + exported so the tag is unit-tested without spawning. */

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -38,7 +38,8 @@ const execFileAsync = promisify(execFile);
 const ts = () => new Date().toISOString().slice(11, 23);
 
 const DEFAULT_FPS = 1;
-const MAX_FPS = 2;
+export const VISION_MIN_SEND_INTERVAL_MS = 900;
+const MAX_FPS = 1000 / VISION_MIN_SEND_INTERVAL_MS;
 const MIN_INTERVAL_MS = 250;
 // TODO(roadmap §5 Now: cost posture): A 720p JPEG q=0.6 ≈ 80–150KB. At 1 fps
 // continuous that's ~6–9MB/min into Gemini Live's video slot, plus context-
@@ -468,8 +469,6 @@ export function isStreaming(): boolean {
  *  ceiling is 2 s of budget; a 720p/q0.6 frame is ~80–150 KB. */
 export const VISION_BUCKET_BYTES_PER_SEC = 300 * 1024;
 export const VISION_BUCKET_MAX_BYTES = 600 * 1024;
-/** ≈1 fps egress cap regardless of the capture cadence. */
-export const VISION_MIN_SEND_INTERVAL_MS = 900;
 const VISION_DRAIN_INTERVAL_MS = 250;
 /** Downscale budget requested from the capture server (which resizes in ITS
  *  process — compression never competes with this event loop). ~720p-class. */
@@ -488,7 +487,7 @@ let bucketRefillAt = Date.now();
 let lastFrameSentAt = 0;
 let deferredSlot: { data: Buffer; mimeType: string; fireHooks: boolean } | null = null;
 let drainTimer: NodeJS.Timeout | null = null;
-const egressStats = { sent: 0, deferredGate: 0, deferredBudget: 0, displaced: 0 };
+const egressStats = { sent: 0, deferredGate: 0, deferredBudget: 0, displaced: 0, droppedOversize: 0 };
 
 /** Read-only egress diagnostics (drop counters are cumulative per process). */
 export function getVisionEgressStats(): {
@@ -496,6 +495,7 @@ export function getVisionEgressStats(): {
 	deferredGate: number;
 	deferredBudget: number;
 	displaced: number;
+	droppedOversize: number;
 	slotOccupied: boolean;
 } {
 	return { ...egressStats, slotOccupied: deferredSlot !== null };
@@ -513,6 +513,7 @@ export function resetVisionEgressForTests(): void {
 	egressStats.deferredGate = 0;
 	egressStats.deferredBudget = 0;
 	egressStats.displaced = 0;
+	egressStats.droppedOversize = 0;
 }
 
 function refillBucket(now: number): void {
@@ -604,14 +605,22 @@ function sendFrameGated(
 	if (!sendFile) return { ok: false, error: 'no active voice session' };
 	const now = Date.now();
 	refillBucket(now);
+	// A frame larger than the bucket burst can never drain; reject it instead.
+	const wireBytes = Math.ceil((data.byteLength * 4) / 3);
+	if (wireBytes > VISION_BUCKET_MAX_BYTES) {
+		egressStats.droppedOversize++;
+		return {
+			ok: false,
+			reason: 'frame-too-large',
+			error: `frame exceeds the ${VISION_BUCKET_MAX_BYTES}-byte vision egress budget`,
+		};
+	}
 	const gate = visionGate();
 	if (!gate.open) {
 		parkFrame(data, mimeType, fireHooks, 'gate', fromDrain);
 		return { ok: true, deferred: true, reason: gate.reason };
 	}
-	// The wire carries base64 — 4/3 of the raw frame — so the bucket charges
-	// encoded bytes, not raw (round-3 #10: raw accounting under-charged 25%).
-	const wireBytes = Math.ceil((data.byteLength * 4) / 3);
+	// The wire carries base64, so the bucket charges encoded bytes rather than raw.
 	if (now - lastFrameSentAt < VISION_MIN_SEND_INTERVAL_MS || wireBytes > bucketBytes) {
 		parkFrame(data, mimeType, fireHooks, 'budget', fromDrain);
 		return { ok: true, deferred: true, reason: 'budget' };
@@ -820,7 +829,7 @@ function stopStream(): { wasRunning: boolean; frames: number; durationMs: number
 /** Inject a frame from an external pusher (the web-client's
  *  getDisplayMedia loop). Push-mode must be active — caller should have
  *  hit /vision/start with source='browser' first. */
-export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok: boolean; deferred?: boolean; error?: string } {
+export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok: boolean; deferred?: boolean; reason?: string; error?: string } {
 	if (!getSendFile()) {
 		console.warn(`${ts()} [Vision] frame dropped: no active voice session (sessionRef=${!!sessionRef}, transport=${!!sessionRef?.transport})`);
 		return { ok: false, error: 'no active voice session' };
@@ -834,7 +843,7 @@ export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok
 	const r = sendFrameGated(data, mimeType, false);
 	if (!r.ok) {
 		console.error(`${ts()} [Vision] sendFile failed: ${r.error}`);
-		return { ok: false, error: 'submitFrame failed' };
+		return { ok: false, reason: r.reason, error: r.error ?? 'submitFrame failed' };
 	}
 	return r;
 }
@@ -1090,7 +1099,7 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 				const buf = Buffer.concat(chunks);
 				const mime = (req.headers['content-type'] as string | undefined) || 'image/jpeg';
 				const r = submitFrame(buf, mime);
-				respond(r.ok ? 200 : 409, r.ok ? { status: 'sent' } : { status: 'failed', error: r.error });
+				respond(r.ok ? 200 : r.reason === 'frame-too-large' ? 413 : 409, r.ok ? { status: 'sent' } : { status: 'failed', error: r.error });
 			});
 			req.on('error', () => respond(500, { status: 'failed', error: 'request error' }));
 			return;

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -136,9 +136,14 @@ const screenSource: VisionSource = {
 		await ensureScreenCaptureServer();
 		// silent=true skips the menu-bar flash + macOS notification, which would
 		// otherwise fire on every frame during a stream. format=jpeg keeps
-		// frames small (~50–150KB).
+		// frames small; maxdim/quality make the CAPTURE SERVER resize in its
+		// own process (P7 D7.4: compression never competes with this event
+		// loop) to the ~720p/q0.6 budget before the file comes back.
 		const _capTok = readCaptureToken();
-		const res = await fetch('http://localhost:7845/capture?format=jpeg&silent=true', _capTok ? { headers: { 'X-Sutando-Capture-Token': _capTok } } : {});
+		const res = await fetch(
+			`http://localhost:7845/capture?format=jpeg&silent=true&maxdim=${VISION_FRAME_MAX_DIM}&quality=${VISION_FRAME_JPEG_QUALITY}`,
+			_capTok ? { headers: { 'X-Sutando-Capture-Token': _capTok } } : {},
+		);
 		const data = (await res.json()) as { status: string; path?: string; error?: string };
 		if (data.status !== 'ok' || !data.path) {
 			throw new Error(`screen-capture-server: ${data.error || 'no path'}`);
@@ -378,6 +383,196 @@ export function isStreaming(): boolean {
 	return ticker !== null || pushMode;
 }
 
+// --- P7 D7.4 vision egress controls ---------------------------------------
+// The FE-1 controls: EVERY frame — pull tick, browser push, external
+// sources — passes one central gate + token bucket before sendFile. Deferral
+// is a latest-frame-only slot, never a backlog: a queued burst draining after
+// speech would re-create FE-1 under a different name.
+
+/** Token bucket for vision egress on the shared upstream socket. The burst
+ *  ceiling is 2 s of budget; a 720p/q0.6 frame is ~80–150 KB. */
+export const VISION_BUCKET_BYTES_PER_SEC = 300 * 1024;
+export const VISION_BUCKET_MAX_BYTES = 600 * 1024;
+/** ≈1 fps egress cap regardless of the capture cadence. */
+export const VISION_MIN_SEND_INTERVAL_MS = 900;
+const VISION_DRAIN_INTERVAL_MS = 250;
+/** Downscale budget requested from the capture server (which resizes in ITS
+ *  process — compression never competes with this event loop). ~720p-class. */
+export const VISION_FRAME_MAX_DIM = 1280;
+export const VISION_FRAME_JPEG_QUALITY = 60;
+
+let speechEvidenceFn: (() => { active: boolean }) | null = null;
+/** Voice-agent injects the engine ledger's getSpeechEvidence — the CANONICAL
+ *  speech signal (D7.1) — so vision defers while the user is speaking. */
+export function setVisionSpeechEvidence(fn: (() => { active: boolean }) | null): void {
+	speechEvidenceFn = fn;
+}
+
+let bucketBytes = VISION_BUCKET_MAX_BYTES;
+let bucketRefillAt = Date.now();
+let lastFrameSentAt = 0;
+let deferredSlot: { data: Buffer; mimeType: string; fireHooks: boolean } | null = null;
+let drainTimer: NodeJS.Timeout | null = null;
+const egressStats = { sent: 0, deferredGate: 0, deferredBudget: 0, displaced: 0 };
+
+/** Read-only egress diagnostics (drop counters are cumulative per process). */
+export function getVisionEgressStats(): {
+	sent: number;
+	deferredGate: number;
+	deferredBudget: number;
+	displaced: number;
+	slotOccupied: boolean;
+} {
+	return { ...egressStats, slotOccupied: deferredSlot !== null };
+}
+
+/** TEST-ONLY: reset the egress gate/bucket/slot state between test cases
+ *  (module state is process-wide; production never calls this). */
+export function resetVisionEgressForTests(): void {
+	deferredSlot = null;
+	stopDrainTimer();
+	bucketBytes = VISION_BUCKET_MAX_BYTES;
+	bucketRefillAt = Date.now();
+	lastFrameSentAt = 0;
+	egressStats.sent = 0;
+	egressStats.deferredGate = 0;
+	egressStats.deferredBudget = 0;
+	egressStats.displaced = 0;
+}
+
+function refillBucket(now: number): void {
+	const elapsed = Math.max(0, now - bucketRefillAt);
+	bucketRefillAt = now;
+	bucketBytes = Math.min(
+		VISION_BUCKET_MAX_BYTES,
+		bucketBytes + (elapsed / 1000) * VISION_BUCKET_BYTES_PER_SEC,
+	);
+}
+
+/**
+ * Tranche-A gate: ACTIVE ∧ ¬speechActive. Bodhi's buffering/replaying flags
+ * are not observable pre-pin — that blind spot is NAMED (D7.4): until the
+ * bodhi tranche, vision can still slip into the window where buffered speech
+ * awaits reconnect replay.
+ */
+function visionGate(): { open: boolean; reason: string } {
+	// Same trust contract as getSendFile's isConnected: if the session
+	// exposes a state and it is not ACTIVE, gate; a session object without a
+	// sessionManager (integration fakes/bridges) is trusted.
+	const sm = (sessionRef as unknown as { sessionManager?: { state?: string } } | null)
+		?.sessionManager;
+	if (sm && sm.state !== 'ACTIVE') return { open: false, reason: `session=${sm.state ?? '?'}` };
+	if (speechEvidenceFn) {
+		try {
+			if (speechEvidenceFn().active) return { open: false, reason: 'speech-active' };
+		} catch {
+			/* evidence source failure never blocks vision */
+		}
+	}
+	return { open: true, reason: '' };
+}
+
+function stopDrainTimer(): void {
+	if (drainTimer) {
+		clearInterval(drainTimer);
+		drainTimer = null;
+	}
+}
+
+function parkFrame(
+	data: Buffer,
+	mimeType: string,
+	fireHooks: boolean,
+	why: 'gate' | 'budget',
+	fromDrain: boolean,
+): void {
+	if (!fromDrain) {
+		// A drain retry re-parks the SAME frame — that is neither a new
+		// deferral nor a displacement.
+		if (deferredSlot) egressStats.displaced++; // the old frame is dropped forever
+		if (why === 'gate') egressStats.deferredGate++;
+		else egressStats.deferredBudget++;
+	}
+	deferredSlot = { data, mimeType, fireHooks };
+	if (!drainTimer) {
+		drainTimer = setInterval(drainDeferredFrame, VISION_DRAIN_INTERVAL_MS);
+		drainTimer.unref?.();
+	}
+}
+
+function drainDeferredFrame(): void {
+	if (!deferredSlot) {
+		stopDrainTimer();
+		return;
+	}
+	const slot = deferredSlot;
+	// Take the frame OUT before retrying — a re-defer re-parks it without a
+	// self-displacement, and a fresh frame arriving mid-retry wins the slot.
+	deferredSlot = null;
+	const r = sendFrameGated(slot.data, slot.mimeType, slot.fireHooks, true);
+	if (!r.ok) {
+		// Session gone — a stale frame must not survive to the next session.
+		stopDrainTimer();
+		return;
+	}
+	if (!r.deferred && !deferredSlot) stopDrainTimer();
+}
+
+/** The ONE vision egress path (gate → bucket → send). All sources call this. */
+function sendFrameGated(
+	data: Buffer,
+	mimeType: string,
+	fireHooks: boolean,
+	fromDrain = false,
+): { ok: boolean; deferred?: boolean; reason?: string; error?: string } {
+	const sendFile = getSendFile();
+	if (!sendFile) return { ok: false, error: 'no active voice session' };
+	const now = Date.now();
+	refillBucket(now);
+	const gate = visionGate();
+	if (!gate.open) {
+		parkFrame(data, mimeType, fireHooks, 'gate', fromDrain);
+		return { ok: true, deferred: true, reason: gate.reason };
+	}
+	if (now - lastFrameSentAt < VISION_MIN_SEND_INTERVAL_MS || data.byteLength > bucketBytes) {
+		parkFrame(data, mimeType, fireHooks, 'budget', fromDrain);
+		return { ok: true, deferred: true, reason: 'budget' };
+	}
+	// The residual voice-loop cost — base64 + the SDK's synchronous
+	// JSON.stringify (~1-3 ms per 720p frame at ≤1 fps) — is named in D7.4,
+	// bounded by the capture-server downscale, and covered by the budget test.
+	try {
+		sendFile(data.toString('base64'), mimeType);
+	} catch (err) {
+		return { ok: false, error: (err as Error)?.message ?? 'sendFile threw' };
+	}
+	bucketBytes = Math.max(0, bucketBytes - data.byteLength);
+	lastFrameSentAt = now;
+	egressStats.sent++;
+	frameCount++;
+	if (frameCount === 1 || frameCount % 10 === 0) {
+		console.log(`${ts()} [Vision] sent frame #${frameCount} (${Math.round(data.byteLength / 1024)}KB ${mimeType})`);
+	}
+	if (fireHooks && visionFrameHooks.length > 0) {
+		const transport = sessionRef?.transport;
+		if (transport && typeof transport.sendContent === 'function') {
+			const sendUserCtx = (text: string): void => {
+				try {
+					transport.sendContent!([{ role: 'user', text }], false);
+				} catch {}
+			};
+			for (const hook of visionFrameHooks) {
+				try {
+					hook(sendUserCtx);
+				} catch (err) {
+					console.warn(`${ts()} [Vision] frame hook threw: ${(err as Error)?.message}`);
+				}
+			}
+		}
+	}
+	return { ok: true };
+}
+
 export interface VisionState {
 	streaming: boolean;
 	source: string | null;
@@ -385,6 +580,15 @@ export interface VisionState {
 	frames: number;
 	durationMs: number;
 	sessionReady: boolean;
+	/** P7 D7.4 egress diagnostics: real sends vs gate/budget deferrals and
+	 *  displaced (dropped) slot frames. */
+	egress: {
+		sent: number;
+		deferredGate: number;
+		deferredBudget: number;
+		displaced: number;
+		slotOccupied: boolean;
+	};
 }
 
 /** Public read-only view of vision streaming state.
@@ -400,6 +604,7 @@ export function getVisionState(): VisionState {
 		frames: frameCount,
 		durationMs: streaming && startedAt ? Date.now() - startedAt : 0,
 		sessionReady: getSendFile() !== null,
+		egress: getVisionEgressStats(),
 	};
 }
 
@@ -502,6 +707,10 @@ function stopStream(): { wasRunning: boolean; frames: number; durationMs: number
 	activeSource = null;
 	frameCount = 0;
 	startedAt = 0;
+	// P7 D7.4: a parked frame must not outlive its stream — a stale deferred
+	// frame draining into a later session is exactly the backlog rule's target.
+	deferredSlot = null;
+	stopDrainTimer();
 	// Push-mode frames accumulate in Gemini Live's conversation context.
 	// Without this hint, "what do you see?" after the user stops sharing
 	// gets answered from the last frame still in context (model recalls
@@ -532,9 +741,8 @@ function stopStream(): { wasRunning: boolean; frames: number; durationMs: number
 /** Inject a frame from an external pusher (the web-client's
  *  getDisplayMedia loop). Push-mode must be active — caller should have
  *  hit /vision/start with source='browser' first. */
-export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok: boolean; error?: string } {
-	const sendFile = getSendFile();
-	if (!sendFile) {
+export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok: boolean; deferred?: boolean; error?: string } {
+	if (!getSendFile()) {
 		console.warn(`${ts()} [Vision] frame dropped: no active voice session (sessionRef=${!!sessionRef}, transport=${!!sessionRef?.transport})`);
 		return { ok: false, error: 'no active voice session' };
 	}
@@ -542,41 +750,23 @@ export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok
 		console.warn(`${ts()} [Vision] frame dropped: push mode inactive — call /vision/start with source=browser first`);
 		return { ok: false, error: 'not in push mode — call /vision/start with source=browser first' };
 	}
-	try {
-		sendFile(data.toString('base64'), mimeType);
-		frameCount++;
-		// Log first frame so the user can confirm vision is wired end-to-end,
-		// and every 10th to keep tail noise low.
-		if (frameCount === 1 || frameCount % 10 === 0) {
-			console.log(`${ts()} [Vision] sent frame #${frameCount} (${Math.round(data.byteLength / 1024)}KB ${mimeType})`);
-		}
-		return { ok: true };
-	} catch (err) {
-		console.error(`${ts()} [Vision] sendFile threw: ${(err as Error)?.message ?? err}`);
+	// P7 D7.4: browser push was the ungated FE-1 hole — it rides the same
+	// central gate + token bucket + latest-frame slot as every other source.
+	const r = sendFrameGated(data, mimeType, false);
+	if (!r.ok) {
+		console.error(`${ts()} [Vision] sendFile failed: ${r.error}`);
 		return { ok: false, error: 'submitFrame failed' };
 	}
+	return r;
 }
 
-async function captureAndSend(source: VisionSource): Promise<{ ok: boolean; error?: string }> {
-	const sendFile = getSendFile();
-	if (!sendFile) return { ok: false, error: 'no active voice session' };
+async function captureAndSend(source: VisionSource): Promise<{ ok: boolean; deferred?: boolean; error?: string }> {
+	if (!getSendFile()) return { ok: false, error: 'no active voice session' };
 	const frame = await source.capture();
-	sendFile(frame.data.toString('base64'), frame.mimeType);
-	// Fire post-send hooks (e.g. screen-companion injects selection text).
-	if (visionFrameHooks.length > 0) {
-		const transport = sessionRef?.transport;
-		if (transport && typeof transport.sendContent === 'function') {
-			const sendUserCtx = (text: string): void => {
-				try { transport.sendContent!([{ role: 'user', text }], false); } catch {}
-			};
-			for (const hook of visionFrameHooks) {
-				try { hook(sendUserCtx); } catch (err) {
-					console.warn(`${ts()} [Vision] frame hook threw: ${(err as Error)?.message}`);
-				}
-			}
-		}
-	}
-	return { ok: true };
+	// P7 D7.4: the central gate + bucket own the egress decision; post-send
+	// hooks (screen-companion selection text) fire only when the frame
+	// actually sends — including a later drain of the deferred slot.
+	return sendFrameGated(frame.data, frame.mimeType, true);
 }
 
 /** Capture a single frame from `sourceName` (default 'screen') and send it to
@@ -599,7 +789,9 @@ async function tick(): Promise<void> {
 	try {
 		const r = await captureAndSend(activeSource);
 		if (r.ok) {
-			frameCount++;
+			// Deferred counts as healthy: the gate/bucket parked the frame
+			// deliberately (frameCount advances only on real sends, inside
+			// sendFrameGated).
 			if (consecutiveFrameErrors > 0) {
 				console.log(`${ts()} [Vision] frame capture recovered after ${consecutiveFrameErrors} failure(s)`);
 				consecutiveFrameErrors = 0;

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -353,6 +353,10 @@ function getSendFile(): ((b64: string, mime: string) => void) | null {
 // --- Streaming controller -------------------------------------------------
 
 let ticker: NodeJS.Timeout | null = null;
+/** Bumped on every stream start/stop: an in-flight pull capture from a
+ *  stopped stream must not send its stale frame after stopStream() (P7
+ *  round-3 #8 — stop semantics beat a slow source.capture()). */
+let streamGen = 0;
 let activeSource: VisionSource | null = null;
 let inFlight = false;
 let frameCount = 0;
@@ -534,7 +538,10 @@ function sendFrameGated(
 		parkFrame(data, mimeType, fireHooks, 'gate', fromDrain);
 		return { ok: true, deferred: true, reason: gate.reason };
 	}
-	if (now - lastFrameSentAt < VISION_MIN_SEND_INTERVAL_MS || data.byteLength > bucketBytes) {
+	// The wire carries base64 — 4/3 of the raw frame — so the bucket charges
+	// encoded bytes, not raw (round-3 #10: raw accounting under-charged 25%).
+	const wireBytes = Math.ceil((data.byteLength * 4) / 3);
+	if (now - lastFrameSentAt < VISION_MIN_SEND_INTERVAL_MS || wireBytes > bucketBytes) {
 		parkFrame(data, mimeType, fireHooks, 'budget', fromDrain);
 		return { ok: true, deferred: true, reason: 'budget' };
 	}
@@ -546,7 +553,7 @@ function sendFrameGated(
 	} catch (err) {
 		return { ok: false, error: (err as Error)?.message ?? 'sendFile threw' };
 	}
-	bucketBytes = Math.max(0, bucketBytes - data.byteLength);
+	bucketBytes = Math.max(0, bucketBytes - wireBytes);
 	lastFrameSentAt = now;
 	egressStats.sent++;
 	frameCount++;
@@ -704,6 +711,7 @@ function stopStream(): { wasRunning: boolean; frames: number; durationMs: number
 	if (wasRunning) {
 		console.log(`${ts()} [Vision] stopped ${sourceName}${wasPush ? ' (push)' : ''} — ${frames} frame(s) in ${(durationMs / 1000).toFixed(1)}s`);
 	}
+	streamGen++; // fence any in-flight pull capture (see captureAndSend)
 	activeSource = null;
 	frameCount = 0;
 	startedAt = 0;
@@ -760,9 +768,17 @@ export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok
 	return r;
 }
 
-async function captureAndSend(source: VisionSource): Promise<{ ok: boolean; deferred?: boolean; error?: string }> {
+async function captureAndSend(
+	source: VisionSource,
+	fenceGen?: number,
+): Promise<{ ok: boolean; deferred?: boolean; error?: string }> {
 	if (!getSendFile()) return { ok: false, error: 'no active voice session' };
 	const frame = await source.capture();
+	if (fenceGen !== undefined && fenceGen !== streamGen) {
+		// The stream this capture belonged to was stopped (or replaced) while
+		// the source was capturing — the stale frame is dropped, not sent.
+		return { ok: true, deferred: false };
+	}
 	// P7 D7.4: the central gate + bucket own the egress decision; post-send
 	// hooks (screen-companion selection text) fire only when the frame
 	// actually sends — including a later drain of the deferred slot.
@@ -787,7 +803,7 @@ async function tick(): Promise<void> {
 	if (inFlight || !activeSource) return; // skip overlap — slow camera or slow disk
 	inFlight = true;
 	try {
-		const r = await captureAndSend(activeSource);
+		const r = await captureAndSend(activeSource, streamGen);
 		if (r.ok) {
 			// Deferred counts as healthy: the gate/bucket parked the frame
 			// deliberately (frameCount advances only on real sends, inside
@@ -840,6 +856,7 @@ function startStream(source: VisionSource, fps: number): { fps: number; interval
 	const clamped = Math.max(0.5, Math.min(MAX_FPS, fps));
 	const intervalMs = Math.max(MIN_INTERVAL_MS, Math.round(1000 / clamped));
 	if (ticker) clearInterval(ticker);
+	streamGen++;
 	activeSource = source;
 	frameCount = 0;
 	startedAt = Date.now();

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -16,10 +16,11 @@
  * realtime_input.video slot accepts single-frame images.
  */
 
-import { readFileSync, writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { readFileSync, writeFileSync, unlinkSync, mkdtempSync, mkdirSync, openSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { readCaptureToken } from './util_paths.js';
+import { findRepoRoot } from './sutando_config.js';
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createServer, type Server } from 'node:http';
@@ -30,7 +31,11 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace, statusPath } from './workspace_default.js';
 
 const execFileAsync = promisify(execFile);
-const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
+// UTC, matching voice-agent's ts() — these logs interleave in the same file,
+// and a local-time subsystem next to UTC subsystems made incident timelines
+// off-by-timezone (field report 2026-08-14: 09:48:04 [Vision] and 16:48:04
+// [VoiceSession] were the same instant).
+const ts = () => new Date().toISOString().slice(11, 23);
 
 const DEFAULT_FPS = 1;
 const MAX_FPS = 2;
@@ -81,15 +86,43 @@ function _portListening(port: number): Promise<boolean> {
 	});
 }
 
+/**
+ * Where screen-capture-server.py actually lives, as candidate paths in
+ * probe order. The old single answer — "next to this module" — was only true
+ * in dev (`tsx src/voice-agent.ts`): the bundled app runs
+ * `dist/voice-agent.js`, and build-bundle.mjs ships no .py files, so the
+ * module-relative path resolved to a nonexistent dist/screen-capture-server.py
+ * and every Watch attempt died as a silent 8s port timeout (field report
+ * 2026-08-14). The bundle DOES ship src/*.py as a sibling of dist/, so the
+ * canonical answer is `<sutando root>/src/…` via findRepoRoot (the same
+ * helper python-binary.ts uses), with the module-sibling kept as the dev/
+ * exotic-layout fallback. Exported for tests.
+ */
+export function _captureServerScriptCandidates(moduleDir: string): string[] {
+	const candidates: string[] = [];
+	const root = findRepoRoot(moduleDir);
+	if (root) candidates.push(join(root, 'src', 'screen-capture-server.py'));
+	const sibling = join(moduleDir, 'screen-capture-server.py');
+	if (!candidates.includes(sibling)) candidates.push(sibling);
+	return candidates;
+}
+
 /** Ensure the screen-capture-server is up on :7845, spawning it if absent.
- *  Reuses a running server (startup.sh's, or a prior lazy spawn); memoizes the
- *  in-flight spawn so concurrent captures don't double-start it. */
+ *  Reuses a running server (startup.sh's, the supervisor's, or a prior lazy
+ *  spawn); memoizes the in-flight spawn so concurrent captures don't
+ *  double-start it. */
 export async function ensureScreenCaptureServer(): Promise<void> {
 	if (await _portListening(SCREEN_CAPTURE_PORT)) return; // reuse a running server
 	if (_screenCaptureStarting) return _screenCaptureStarting; // join an in-flight spawn
 	const start = (async () => {
-		// screen-capture-server.py sits next to this module in src/.
-		const script = join(dirname(fileURLToPath(import.meta.url)), 'screen-capture-server.py');
+		const moduleDir = dirname(fileURLToPath(import.meta.url));
+		const candidates = _captureServerScriptCandidates(moduleDir);
+		const script = candidates.find((c) => existsSync(c));
+		if (!script) {
+			// Fail FAST and say why — the old path burned 8s per attempt on a
+			// port that could never open, with the real cause discarded.
+			throw new Error(`screen-capture-server.py not found (tried: ${candidates.join(', ')})`);
+		}
 		// The bundled .app's voice-agent runs under a MINIMAL launchd PATH (no
 		// /opt/homebrew/bin etc. — same class as the claude-on-PATH gotcha, desktop
 		// PR #50). A bare `python3` would ENOENT there — Watch would still silently
@@ -100,17 +133,55 @@ export async function ensureScreenCaptureServer(): Promise<void> {
 		const augmentedPath = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/usr/sbin', '/bin', process.env.PATH]
 			.filter(Boolean)
 			.join(':');
+		// Observability + process shape (field report 2026-08-14): the old
+		// spawn was detached with stdio 'ignore' and no handlers, so a child
+		// that died instantly (missing script, python error, bind failure) was
+		// indistinguishable from a slow boot. Now: NOT detached — the server
+		// stays a non-disclaimed child of the voice agent, the same shape the
+		// supervisor deliberately uses for screen-capture so TCC attributes the
+		// Screen Recording grant to the app lineage — stderr/stdout go to a log
+		// file, the pid is logged, and an early exit fails the wait immediately
+		// with the code + log path instead of a ghost timeout. unref() still
+		// keeps the child from holding the event loop open.
+		let logPath = '/dev/null';
+		let logfd: number | undefined;
+		try {
+			const logDir = join(resolveWorkspace(), 'logs');
+			mkdirSync(logDir, { recursive: true });
+			logPath = join(logDir, 'screen-capture-server.lazy.log');
+			logfd = openSync(logPath, 'a');
+		} catch {
+			logfd = undefined; // fall back to ignore — logging must not block the spawn
+		}
+		let exited: { code: number | null; signal: string | null } | null = null;
+		let spawnError: Error | null = null;
 		const child = spawn('python3', [script], {
-			detached: true,
-			stdio: 'ignore',
+			detached: false,
+			stdio: logfd !== undefined ? ['ignore', logfd, logfd] : 'ignore',
 			env: { ...process.env, PATH: augmentedPath },
 		});
 		child.unref();
+		child.on('error', (err) => {
+			spawnError = err;
+		});
+		child.on('exit', (code, signal) => {
+			exited = { code, signal };
+		});
+		console.log(`${ts()} [Vision] spawned screen-capture-server pid=${child.pid} script=${script} log=${logPath}`);
 		for (let i = 0; i < 40; i++) {
 			if (await _portListening(SCREEN_CAPTURE_PORT)) return;
+			if (spawnError) {
+				throw new Error(`screen-capture-server spawn failed: ${(spawnError as Error).message}`);
+			}
+			if (exited) {
+				const e = exited as { code: number | null; signal: string | null };
+				throw new Error(
+					`screen-capture-server exited before listening (code=${e.code} signal=${e.signal}) — see ${logPath}`,
+				);
+			}
 			await new Promise((r) => setTimeout(r, 200));
 		}
-		throw new Error('screen-capture-server did not come up on :7845 within 8s');
+		throw new Error(`screen-capture-server did not come up on :7845 within 8s — see ${logPath}`);
 	})();
 	_screenCaptureStarting = start;
 	try {

--- a/src/voice-agent-state.ts
+++ b/src/voice-agent-state.ts
@@ -164,7 +164,7 @@ export function createAgentStateProvider(inputs: AgentStateInputs): AgentStatePr
 // Lifecycle snapshot — state/voice-lifecycle.json (amendment A9)
 // ---------------------------------------------------------------------------
 
-/** On-disk lifecycle snapshot schema (A9 + S3). */
+/** On-disk lifecycle snapshot schema (A9 + S3; P7 D7.1 adds inputHealth). */
 export interface VoiceLifecycleSnapshot {
 	at: number;
 	clientAttached: boolean;
@@ -173,6 +173,9 @@ export interface VoiceLifecycleSnapshot {
 	category?: ProtocolFailureCategory;
 	credentialSource?: 'managed' | 'byok';
 	credentialGeneration?: string;
+	/** P7 D7.1 (additive): audio-input health verdict from the engine ledger —
+	 *  P4's evidence ladder consumes `stalled` for its degraded rows. */
+	inputHealth?: 'ok' | 'degraded' | 'stalled' | 'unknown';
 }
 
 export function voiceLifecyclePath(workspace: string): string {
@@ -226,7 +229,12 @@ let _tmpCounter = 0;
 export function publishLifecycleSnapshot(
 	workspace: string,
 	frame: AgentStateV1,
-	opts?: { now?: () => number; onError?: (err: unknown) => void },
+	opts?: {
+		now?: () => number;
+		onError?: (err: unknown) => void;
+		/** P7 D7.1: additive input-health verdict (see VoiceLifecycleSnapshot). */
+		inputHealth?: 'ok' | 'degraded' | 'stalled' | 'unknown';
+	},
 ): void {
 	const target = voiceLifecyclePath(workspace);
 	const snapshot: VoiceLifecycleSnapshot = {
@@ -238,6 +246,7 @@ export function publishLifecycleSnapshot(
 	if (frame.category !== undefined) snapshot.category = frame.category;
 	if (frame.credentialSource !== undefined) snapshot.credentialSource = frame.credentialSource;
 	if (frame.credentialGeneration !== undefined) snapshot.credentialGeneration = frame.credentialGeneration;
+	if (opts?.inputHealth !== undefined) snapshot.inputHealth = opts.inputHealth;
 	const tmp = `${target}-tmp-${process.pid}-${++_tmpCounter}`;
 	try {
 		mkdirSync(dirname(target), { recursive: true });

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -50,7 +50,7 @@ import { workTool, resetNoteViewingDebounce, logConversation, logSessionBoundary
 import { createAudioHealthLedger } from './voice-audio-health.js';
 import { createHealthPersistence } from './voice-audio-health-persist.js';
 import { evaluateMatrix, type MatrixBaseline } from './voice-health-matrix.js';
-import { initialGoodbyeGuard, shouldFireGoodbye, createConversationClearHelper } from './voice-continuity.js';
+import { initialGoodbyeGuard, shouldFireGoodbye, createConversationClearHelper, clearStaleResumptionHandle } from './voice-continuity.js';
 import { classifyFatalExitCode, isFatalExit, markFatalExit, writeCrashRecordAndExit, EXIT_CODE_DUPLICATE_INSTANCE } from './crash-only.js';
 import { acquireVoiceLock, releaseOnExitUnlessFatal, resolveLockPython, voiceLockGuardPath } from './voice-lock.js';
 import { recordToolCall } from './conversation-store.js';
@@ -1468,6 +1468,12 @@ async function main() {
 	if (origConnect) {
 		(session as any).handleClientConnected = () => {
 			cancelIdleTeardown();
+			// A dead session's resumption handle must not poison the fresh
+			// connect (1008 "Requested entity was not found" staircase — see
+			// clearStaleResumptionHandle). Only the CLOSED path reconnects.
+			if (session.sessionManager.state === 'CLOSED' && clearStaleResumptionHandle(session)) {
+				console.log(`${ts()} [Resume] cleared stale resumption handle from dead session before fresh connect`);
+			}
 			// P7 D7.1: new client connection = new (pending) ledger epoch; the
 			// epoch value is minted on first heartbeat sight (nonce mapping).
 			audioHealth.onClientConnected();

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -33,7 +33,7 @@ import { z } from 'zod';
 import { existsSync, readFileSync, readdirSync, unlinkSync, mkdirSync, copyFileSync, appendFileSync, writeFileSync, realpathSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { inlineTools } from './inline-tools.js';
-import { setVisionSession, startVisionControlServer, stopVisionControlServer, setSessionToolUpdater } from './vision-tools.js';
+import { setVisionSession, startVisionControlServer, stopVisionControlServer, setSessionToolUpdater, setVisionSpeechEvidence } from './vision-tools.js';
 import { clearActiveArtifact } from './artifact-cache-tools.js';
 import { injectText } from './browser-tools.js';
 import { join, dirname } from 'node:path';
@@ -597,8 +597,17 @@ const itemsClear = createConversationClearHelper(
 	() => (voiceSessionRef as any)?.conversationContext?.items,
 	(m) => console.log(`${ts()} ${m}`),
 );
-// P7 D7.3 stale-repeat goodbye guard (Tranche A engine-side).
+// P7 D7.3 stale-repeat goodbye guard (Tranche A engine-side). The guard
+// compares against userTurnCount, which resets per logical session — every
+// reset MUST rebase the guard too, or a legitimate goodbye in the next
+// session (count restarted below the old watermark) would be suppressed.
 let goodbyeGuard = initialGoodbyeGuard();
+function resetSessionGateState(): void {
+	userTurnCount = 0;
+	userHasInterrupted = false;
+	sessionEnding = false;
+	goodbyeGuard = initialGoodbyeGuard();
+}
 
 // Unified base-mode resolver: see src/voice-mode-resolver.ts for the
 // rationale + canonical mode descriptors. Local wrapper threads the in-memory
@@ -618,7 +627,7 @@ const _configCtx: VoiceConfigContext = {
 	resolveCurrentMode,
 	isMeetingActive: () => meetingActive,
 	googleSearch: VOICE_GOOGLE_SEARCH,
-	resetSessionGates: () => { userTurnCount = 0; userHasInterrupted = false; sessionEnding = false; },
+	resetSessionGates: () => { resetSessionGateState(); },
 	resetNoteViewingDebounce,
 	getRecentConversation,
 	getSecondsSinceLastTurn,
@@ -954,7 +963,7 @@ async function main() {
 			: {}),
 		hooks: {
 			onSessionStart: (e) => {
-				userTurnCount = 0; userHasInterrupted = false; sessionEnding = false;
+				resetSessionGateState();
 				recorder.reset();
 				recorder.events.push({ event: 'session_started', timestamp: new Date().toISOString() });
 				recorder.startTicker(VOICE_NATIVE_AUDIO_MODEL);
@@ -1021,6 +1030,9 @@ async function main() {
 	// ingress-RMS speech tracker, audio_health heartbeat intercept, egress
 	// count). Coverage is honestly session-only until the bodhi pin.
 	audioHealth.wrapSession(session);
+	// P7 D7.4: vision defers frames while the canonical speech evidence is
+	// active (pause-during-speech rides the same tracker as the matrix).
+	setVisionSpeechEvidence(() => audioHealth.getSpeechEvidence());
 
 	// =========================================================================
 	// `agent.state` emission + lifecycle snapshot (Step 12 + amendment A9).
@@ -1064,13 +1076,18 @@ async function main() {
 		lastEmittedUpstream = upstreamKey;
 		if (opts.immediate || upstreamChanged) sendAgentStateFrame(frame);
 		// A9: publish the lifecycle snapshot when any relevant field flipped
-		// (attach/detach, initialized, upstream) — atomic temp+rename with
-		// unique temp names inside publishLifecycleSnapshot; NOT the
-		// writeVoiceState plain-writeFileSync pattern.
-		const lifecycleKey = `${frame.clientAttached}|${frame.initialized}|${upstreamKey}`;
+		// (attach/detach, initialized, upstream, and — P7 D7.1 — the additive
+		// inputHealth verdict P4's evidence ladder consumes) — atomic
+		// temp+rename inside publishLifecycleSnapshot.
+		const ledgerHealth = audioHealth.getInputHealth(session.clientConnected);
+		// The lifecycle schema's four values: no-client folds into 'unknown'
+		// (a detached client is absence of evidence for THIS field).
+		const inputHealth = ledgerHealth === 'no-client' ? 'unknown' : ledgerHealth;
+		const lifecycleKey = `${frame.clientAttached}|${frame.initialized}|${upstreamKey}|${inputHealth}`;
 		if (lifecycleKey !== lastLifecycleKey) {
 			lastLifecycleKey = lifecycleKey;
 			publishLifecycleSnapshot(WORKSPACE_DIR, frame, {
+				inputHealth,
 				onError: (err) => console.error(`${ts()} [AgentState] lifecycle snapshot write failed: ${(err as Error)?.message ?? err}`),
 			});
 		}
@@ -1455,7 +1472,7 @@ async function main() {
 			// upstream down under this client.
 			probeIdleRestore.fence();
 			if (recorder.wasFlushed) {
-				userTurnCount = 0; userHasInterrupted = false; sessionEnding = false;
+				resetSessionGateState();
 				recorder.reset();
 				recorder.events.push({ event: 'session_started:client_connect', timestamp: new Date().toISOString() });
 				// bodhi's onSessionStart won't re-fire (#1372 above), so start the
@@ -1561,16 +1578,24 @@ async function main() {
 	let lastLoggedStatus = '';
 	let matrixBaseline: MatrixBaseline | null = null;
 	let lastMatrixVerdict = '';
+	let lastFailedWrites = 0;
 	setInterval(() => {
 		const state = session.sessionManager.state ?? 'unknown';
 		const clientConnected = session.clientConnected;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const serverBufferedAmount = (session as any).clientTransport?.client?.bufferedAmount ?? null;
 		// Log only on state changes or non-ACTIVE states — avoid 2,880 lines/day of
 		// "state=ACTIVE client=true" during healthy operation. P7 D7.1 inverts
 		// the suppression for anomalies: any tick where the ledger latched an
 		// anomaly logs the FULL line even mid-ACTIVE-streak (the suppression
 		// rule was hiding exactly the dead zones we need to see).
 		const status = `state=${state} client=${clientConnected}`;
-		const anomaly = audioHealth.anomalySinceLastTick(clientConnected);
+		// PEEK anomalies; the latches clear only AFTER the anomaly row has
+		// been persisted (clearing first would serialize a snapshot with the
+		// evidence already gone).
+		const anomaly = audioHealth.anomalies(clientConnected);
+		const persistFailed = healthPersistence.failedWrites > lastFailedWrites;
+		lastFailedWrites = healthPersistence.failedWrites;
 		// P7 D7.2: evaluate the localization matrix per tick. lastEgressAt is
 		// the Tranche-A model-event proxy (model audio out = the model spoke);
 		// the native model hop lands with the bodhi pin.
@@ -1580,8 +1605,7 @@ async function main() {
 			clientConnected,
 			snapshot,
 			prev: matrixBaseline,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			serverBufferedAmount: (session as any).clientTransport?.client?.bufferedAmount ?? null,
+			serverBufferedAmount,
 			lastModelEventAt: snapshot.lastEgressAt,
 			now: Date.now(),
 		});
@@ -1591,13 +1615,20 @@ async function main() {
 			console.log(`${ts()} [Matrix] ${matrix.verdict}${matrix.reasons.length ? ' (' + matrix.reasons.join('; ') + ')' : ''}`);
 		}
 		lastMatrixVerdict = matrix.verdict;
+		if (anomaly.anomalous) audioHealth.persistTick('anomaly', clientConnected);
+		// Rate windows advance EVERY tick (a suppressed streak must not turn
+		// the next logged line into a long-window average).
+		const seg = audioHealth.healthSegments(clientConnected, serverBufferedAmount);
 		if (state !== 'ACTIVE' || status !== lastLoggedStatus || anomaly.anomalous) {
-			const seg = clientConnected ? ' ' + audioHealth.healthSegments(clientConnected) : '';
 			const why = anomaly.anomalous ? ` anomaly=${anomaly.reasons.join(',')}` : '';
-			console.log(`${ts()} [Health] ${status}${seg}${why}`);
+			const pf = persistFailed ? ` persistFail=${healthPersistence.failedWrites}` : '';
+			console.log(`${ts()} [Health] ${status}${clientConnected ? ' ' + seg : ''}${why}${pf}`);
 			lastLoggedStatus = status;
 		}
-		if (anomaly.anomalous) audioHealth.persistTick('anomaly', clientConnected);
+		audioHealth.clearTickLatches();
+		// P7 D7.1: an inputHealth flip republishes the lifecycle snapshot
+		// (emitAgentState publishes only when its key changed — cheap).
+		emitAgentState();
 		// Clear any stale fatal-backoff once we observe a healthy session —
 		// otherwise a brief outage that triggered a backoff would suppress
 		// recovery from a later transient close even after the upstream
@@ -1622,9 +1653,11 @@ async function main() {
 
 	// P7 D7.1: periodic ledger persistence — a try-enqueue into the worker's
 	// one-slot mailbox (a busy slot skips the sample; §D7.0b). Anomaly rows
-	// ride the 30 s tick above; this is the once-a-minute baseline.
+	// ride the 30 s tick above; this is the once-a-minute baseline. Gated on
+	// an attached client: idle no-client rows would slowly evict the real
+	// evidence through the per-session row cap.
 	setInterval(() => {
-		audioHealth.persistTick('timer', session.clientConnected);
+		if (session.clientConnected) audioHealth.persistTick('timer', true);
 	}, 60_000);
 
 	// The server bound successfully (EADDRINUSE would have exited via main().catch

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -47,6 +47,9 @@ function assertMacOS() {
 	}
 }
 import { workTool, resetNoteViewingDebounce, logConversation, logSessionBoundary, getRecentConversation, getSecondsSinceLastTurn, setTaskStatusCallback } from './task-bridge.js';
+import { createAudioHealthLedger } from './voice-audio-health.js';
+import { createHealthPersistence } from './voice-audio-health-persist.js';
+import { initialGoodbyeGuard, shouldFireGoodbye, createConversationClearHelper } from './voice-continuity.js';
 import { classifyFatalExitCode, isFatalExit, markFatalExit, writeCrashRecordAndExit, EXIT_CODE_DUPLICATE_INSTANCE } from './crash-only.js';
 import { acquireVoiceLock, releaseOnExitUnlessFatal, resolveLockPython, voiceLockGuardPath } from './voice-lock.js';
 import { recordToolCall } from './conversation-store.js';
@@ -554,22 +557,10 @@ const endSession: ToolDefinition = {
 		// Death spiral observed live 2026-04-09 at 22:57 — 3 self-initiated
 		// end_session calls in 36 seconds. sessionManager.reset() only
 		// clears the state machine; conversationContext persists separately.
-		try {
-			const vs = voiceSessionRef as any;
-			const items = vs?.conversationContext?.items;
-			// `items` is a GETTER returning bodhi's underlying _items array
-			// by reference. We can't reassign to it (TypeError: only has a
-			// getter, hit live at 23:01:09 on 2026-04-09) but we CAN mutate
-			// in place via `length = 0`. Verified against bodhi dist
-			// ConversationContext class around line 945 of index.js.
-			if (Array.isArray(items)) {
-				const count = items.length;
-				items.length = 0;
-				console.log(`${ts()} [end_session] Cleared ${count} conversationContext items`);
-			}
-		} catch (e) {
-			console.log(`${ts()} [end_session] Could not clear conversationContext: ${e}`);
-		}
+		// (`items` is a GETTER returning bodhi's underlying _items array by
+		// reference — mutate in place via length = 0, never reassign. The
+		// helper also rebases the turn.end transcript cursor: P7 D7.3.)
+		itemsClear.clear('end_session');
 		// Also force-close client WS after 4s as fallback
 		setTimeout(() => {
 			console.log(`${ts()} [end_session] Force-closing client WS`);
@@ -594,6 +585,19 @@ const endSession: ToolDefinition = {
 // =============================================================================
 
 let voiceSessionRef: VoiceSession | null = null;
+
+// P7 D7.3: the ONE clear path for bodhi's conversationContext — items and the
+// turn.end transcript cursor move together (G-P7-8: a clear that leaves the
+// cursor pointing past the emptied array makes the logger skip everything
+// that accumulates after it). Used by end_session, the goodbye detector, and
+// the sessionEnding turn.end sweep.
+const itemsClear = createConversationClearHelper(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	() => (voiceSessionRef as any)?.conversationContext?.items,
+	(m) => console.log(`${ts()} ${m}`),
+);
+// P7 D7.3 stale-repeat goodbye guard (Tranche A engine-side).
+let goodbyeGuard = initialGoodbyeGuard();
 
 // Unified base-mode resolver: see src/voice-mode-resolver.ts for the
 // rationale + canonical mode descriptors. Local wrapper threads the in-memory
@@ -696,13 +700,21 @@ const mainAgent: MainAgent = {
 			if (lastText.length === 0 || lastText.length >= 80) return;
 			const FAREWELL_START = /^(goodbye|bye\b|farewell|good\s*bye|see you)/i;
 			if (!FAREWELL_START.test(lastText)) return;
+			// P7 D7.3 stale-repeat guard: a reconnect replay can make the model
+			// repeat the SAME short farewell with no new real user turn — that
+			// repeat must not re-fire session_end.
+			const verdict = shouldFireGoodbye(goodbyeGuard, lastText, userTurnCount);
+			if (!verdict.fire) {
+				console.log(`${ts()} [Agent] Stale-repeat goodbye suppressed (same farewell, no new user turn)`);
+				return;
+			}
+			goodbyeGuard = verdict.next;
 			console.log(`${ts()} [Agent] Strict goodbye detected — closing client in 3s`);
 			logSessionBoundary('voice_goodbye');
 			(ctx as any).sendJsonToClient?.({ type: 'session_end', reason: 'user_goodbye' });
 			setTimeout(() => {
 				try {
-					const vsItems = (voiceSessionRef as any)?.conversationContext?.items;
-					if (Array.isArray(vsItems)) vsItems.length = 0;
+					itemsClear.clear('voice_goodbye');
 					const ct = (voiceSessionRef as any)?.clientTransport;
 					ct?.client?.close(4000, 'goodbye');
 				} catch {}
@@ -889,6 +901,16 @@ async function main() {
 		try { return String(VoiceSession).includes('probeState'); } catch { return false; }
 	})();
 
+	// P7 D7.1: engine-side audio-progress ledger (Tranche A interim, coverage
+	// session-only) + worker-thread persistence. Created before the session so
+	// the hooks below can reference it; the wraps install after construction.
+	const healthPersistence = createHealthPersistence();
+	const audioHealth = createAudioHealthLedger({
+		sessionId: SESSION_ID,
+		persist: (row) => healthPersistence.tryEnqueue(row),
+		log: (m) => console.log(`${ts()} ${m}`),
+	});
+
 	const session = new VoiceSession({
 		sessionId: SESSION_ID,
 		userId: 'user',
@@ -943,6 +965,13 @@ async function main() {
 				clearActiveArtifact();
 				recorder.flush();
 			},
+			// P7 D7.3: bodhi's turn-latency hook was half-blind AND unconsumed
+			// (G-P7-12) — the ledger keeps the last value for [Health] and the
+			// persisted snapshot.
+			onTurnLatency: (e: { turnId?: string; segments?: { totalE2EMs?: number } }) => {
+				audioHealth.noteTurnLatency(e?.segments?.totalE2EMs);
+				console.log(`${ts()} [Latency] ${e?.turnId ?? '?'} e2e=${e?.segments?.totalE2EMs ?? '?'}ms`);
+			},
 			onToolCall: (e) => {
 				voiceToolIdMap.set(e.toolCallId, e.toolName);
 				// tool_call event push removed per #1052 — canonical record
@@ -986,6 +1015,11 @@ async function main() {
 	});
 
 	sessionRef = session;
+
+	// P7 D7.1: install the session-layer ledger wraps (audio ingress count +
+	// ingress-RMS speech tracker, audio_health heartbeat intercept, egress
+	// count). Coverage is honestly session-only until the bodhi pin.
+	audioHealth.wrapSession(session);
 
 	// =========================================================================
 	// `agent.state` emission + lifecycle snapshot (Step 12 + amendment A9).
@@ -1184,7 +1218,8 @@ async function main() {
 	// The Cartesia stuck-session fallback is adapter-provided via opts.
 	wireDurableChannels(session, { cartesiaApiKey: CARTESIA_API_KEY, generateSpeech });
 
-	let lastLoggedIndex = 0;
+	// P7 D7.3: the transcript cursor lives in the clear helper so every clear
+	// path rebases it with the items array (G-P7-8).
 	const liveTranscriptPath = '/tmp/sutando-live-transcript-voice.txt';
 	try { writeFileSync(liveTranscriptPath, `--- Live Transcript: ${new Date().toISOString()} ---\n\n`); } catch {}
 	session.eventBus.subscribe('turn.end', () => {
@@ -1194,12 +1229,10 @@ async function main() {
 		// to inject on the next reconnect. Items re-accumulate during
 		// the post-goodbye "Farewell. Talk to you next time." turns.
 		if (sessionEnding && Array.isArray(items) && items.length > 0) {
-			console.log(`${ts()} [turn.end] Clearing ${items.length} items (sessionEnding=true)`);
-			items.length = 0;
-			lastLoggedIndex = 0;
+			itemsClear.clear('session-ending-turn-end');
 			return;
 		}
-		for (const item of items.slice(lastLoggedIndex)) {
+		for (const item of items.slice(itemsClear.cursor.index)) {
 			if (item.role === 'user' || item.role === 'assistant') {
 				console.log(`${ts()}   [${item.role}] ${item.content}`);
 				logConversation(item.role, item.content, SESSION_ID);
@@ -1221,7 +1254,7 @@ async function main() {
 				}
 			}
 		}
-		lastLoggedIndex = items.length;
+		itemsClear.cursor.index = items.length;
 	});
 
 	// Track user interruption events as a secondary signal for the
@@ -1384,6 +1417,10 @@ async function main() {
 			origDisconnect();
 			recorder.flush();
 			writeVoiceState(false);
+			// P7 D7.1: final ledger row for the departing epoch — written NOW
+			// (the crash-evidence rule: end-of-session-only flushes lose it).
+			audioHealth.onClientDisconnected();
+			audioHealth.persistTick('final', false);
 			scheduleIdleTeardown();
 			// Step 12/A9: client detach is a lifecycle transition (and may
 			// flip upstream backoff→idle now that no client is attached).
@@ -1409,6 +1446,9 @@ async function main() {
 	if (origConnect) {
 		(session as any).handleClientConnected = () => {
 			cancelIdleTeardown();
+			// P7 D7.1: new client connection = new (pending) ledger epoch; the
+			// epoch value is minted on first heartbeat sight (nonce mapping).
+			audioHealth.onClientConnected();
 			// Z3 fence: a REAL connection invalidates any pending
 			// probe/verifier idle-restore — the restore must never tear the
 			// upstream down under this client.
@@ -1522,12 +1562,19 @@ async function main() {
 		const state = session.sessionManager.state ?? 'unknown';
 		const clientConnected = session.clientConnected;
 		// Log only on state changes or non-ACTIVE states — avoid 2,880 lines/day of
-		// "state=ACTIVE client=true" during healthy operation.
+		// "state=ACTIVE client=true" during healthy operation. P7 D7.1 inverts
+		// the suppression for anomalies: any tick where the ledger latched an
+		// anomaly logs the FULL line even mid-ACTIVE-streak (the suppression
+		// rule was hiding exactly the dead zones we need to see).
 		const status = `state=${state} client=${clientConnected}`;
-		if (state !== 'ACTIVE' || status !== lastLoggedStatus) {
-			console.log(`${ts()} [Health] ${status}`);
+		const anomaly = audioHealth.anomalySinceLastTick(clientConnected);
+		if (state !== 'ACTIVE' || status !== lastLoggedStatus || anomaly.anomalous) {
+			const seg = clientConnected ? ' ' + audioHealth.healthSegments(clientConnected) : '';
+			const why = anomaly.anomalous ? ` anomaly=${anomaly.reasons.join(',')}` : '';
+			console.log(`${ts()} [Health] ${status}${seg}${why}`);
 			lastLoggedStatus = status;
 		}
+		if (anomaly.anomalous) audioHealth.persistTick('anomaly', clientConnected);
 		// Clear any stale fatal-backoff once we observe a healthy session —
 		// otherwise a brief outage that triggered a backoff would suppress
 		// recovery from a later transient close even after the upstream
@@ -1549,6 +1596,13 @@ async function main() {
 			}
 		}
 	}, 30_000);
+
+	// P7 D7.1: periodic ledger persistence — a try-enqueue into the worker's
+	// one-slot mailbox (a busy slot skips the sample; §D7.0b). Anomaly rows
+	// ride the 30 s tick above; this is the once-a-minute baseline.
+	setInterval(() => {
+		audioHealth.persistTick('timer', session.clientConnected);
+	}, 60_000);
 
 	// The server bound successfully (EADDRINUSE would have exited via main().catch
 	// before here) — record the actual bound endpoint for the runtime descriptor.

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -49,6 +49,7 @@ function assertMacOS() {
 import { workTool, resetNoteViewingDebounce, logConversation, logSessionBoundary, getRecentConversation, getSecondsSinceLastTurn, setTaskStatusCallback } from './task-bridge.js';
 import { createAudioHealthLedger } from './voice-audio-health.js';
 import { createHealthPersistence } from './voice-audio-health-persist.js';
+import { evaluateMatrix, type MatrixBaseline } from './voice-health-matrix.js';
 import { initialGoodbyeGuard, shouldFireGoodbye, createConversationClearHelper } from './voice-continuity.js';
 import { classifyFatalExitCode, isFatalExit, markFatalExit, writeCrashRecordAndExit, EXIT_CODE_DUPLICATE_INSTANCE } from './crash-only.js';
 import { acquireVoiceLock, releaseOnExitUnlessFatal, resolveLockPython, voiceLockGuardPath } from './voice-lock.js';
@@ -1558,6 +1559,8 @@ async function main() {
 	// throttle prevents a tight retry loop.
 	let lastReconnectAt = 0;
 	let lastLoggedStatus = '';
+	let matrixBaseline: MatrixBaseline | null = null;
+	let lastMatrixVerdict = '';
 	setInterval(() => {
 		const state = session.sessionManager.state ?? 'unknown';
 		const clientConnected = session.clientConnected;
@@ -1568,6 +1571,26 @@ async function main() {
 		// rule was hiding exactly the dead zones we need to see).
 		const status = `state=${state} client=${clientConnected}`;
 		const anomaly = audioHealth.anomalySinceLastTick(clientConnected);
+		// P7 D7.2: evaluate the localization matrix per tick. lastEgressAt is
+		// the Tranche-A model-event proxy (model audio out = the model spoke);
+		// the native model hop lands with the bodhi pin.
+		const snapshot = audioHealth.getSnapshot(clientConnected);
+		const matrix = evaluateMatrix({
+			sessionState: state,
+			clientConnected,
+			snapshot,
+			prev: matrixBaseline,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			serverBufferedAmount: (session as any).clientTransport?.client?.bufferedAmount ?? null,
+			lastModelEventAt: snapshot.lastEgressAt,
+			now: Date.now(),
+		});
+		matrixBaseline = matrix.baseline;
+		audioHealth.noteMatrixVerdict(matrix.verdict);
+		if (matrix.verdict !== lastMatrixVerdict && (matrix.verdict !== 'healthy-idle' || lastMatrixVerdict)) {
+			console.log(`${ts()} [Matrix] ${matrix.verdict}${matrix.reasons.length ? ' (' + matrix.reasons.join('; ') + ')' : ''}`);
+		}
+		lastMatrixVerdict = matrix.verdict;
 		if (state !== 'ACTIVE' || status !== lastLoggedStatus || anomaly.anomalous) {
 			const seg = clientConnected ? ' ' + audioHealth.healthSegments(clientConnected) : '';
 			const why = anomaly.anomalous ? ` anomaly=${anomaly.reasons.join(',')}` : '';

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -983,6 +983,7 @@ async function main() {
 				console.log(`${ts()} [Latency] ${e?.turnId ?? '?'} e2e=${e?.segments?.totalE2EMs ?? '?'}ms`);
 			},
 			onToolCall: (e) => {
+				audioHealth.noteModelEvent(); // P7 D7.1: a tool call is model activity
 				voiceToolIdMap.set(e.toolCallId, e.toolName);
 				// tool_call event push removed per #1052 — canonical record
 				// is the surface-table row written in onToolResult via
@@ -1294,6 +1295,9 @@ async function main() {
 		try { fetch(`http://localhost:7877/speaking/${mode}`, { method: 'POST' }).catch(() => {}); } catch {}
 	};
 	session.eventBus.subscribe('turn.start', () => _duck('on'));
+	// P7 D7.1: the model hop is EVENTS — a text/tool-first turn must count
+	// as model activity even before any audio frame lands.
+	session.eventBus.subscribe('turn.start', () => audioHealth.noteModelEvent());
 	session.eventBus.subscribe('turn.end', () => _duck('off'));
 	session.eventBus.subscribe('turn.interrupted', () => _duck('off'));
 
@@ -1606,7 +1610,7 @@ async function main() {
 			snapshot,
 			prev: matrixBaseline,
 			serverBufferedAmount,
-			lastModelEventAt: snapshot.lastEgressAt,
+			lastModelEventAt: snapshot.lastModelEventAt,
 			now: Date.now(),
 		});
 		matrixBaseline = matrix.baseline;
@@ -1614,12 +1618,17 @@ async function main() {
 		if (matrix.verdict !== lastMatrixVerdict && (matrix.verdict !== 'healthy-idle' || lastMatrixVerdict)) {
 			console.log(`${ts()} [Matrix] ${matrix.verdict}${matrix.reasons.length ? ' (' + matrix.reasons.join('; ') + ')' : ''}`);
 		}
+		const verdictChanged = matrix.verdict !== lastMatrixVerdict;
 		lastMatrixVerdict = matrix.verdict;
-		if (anomaly.anomalous) audioHealth.persistTick('anomaly', clientConnected);
+		// A verdict TRANSITION is itself evidence worth a row — without this a
+		// transient verdict can vanish before the 1-min baseline write.
+		if (anomaly.anomalous || (verdictChanged && matrix.verdict !== 'healthy-idle')) {
+			audioHealth.persistTick('anomaly', clientConnected);
+		}
 		// Rate windows advance EVERY tick (a suppressed streak must not turn
 		// the next logged line into a long-window average).
 		const seg = audioHealth.healthSegments(clientConnected, serverBufferedAmount);
-		if (state !== 'ACTIVE' || status !== lastLoggedStatus || anomaly.anomalous) {
+		if (state !== 'ACTIVE' || status !== lastLoggedStatus || anomaly.anomalous || persistFailed) {
 			const why = anomaly.anomalous ? ` anomaly=${anomaly.reasons.join(',')}` : '';
 			const pf = persistFailed ? ` persistFail=${healthPersistence.failedWrites}` : '';
 			console.log(`${ts()} [Health] ${status}${clientConnected ? ' ' + seg : ''}${why}${pf}`);

--- a/src/voice-audio-health-persist.ts
+++ b/src/voice-audio-health-persist.ts
@@ -1,0 +1,140 @@
+// voice-audio-health-persist — worker_threads sqlite writer for the P7
+// voice_audio_health table (D7.1; §D7.0b round-4 #3: node:sqlite is
+// synchronous, so timer-scheduled writes on the voice event loop can still
+// block audio behind disk latency or busy_timeout — the writes live in a
+// worker thread instead, and the main thread only try-enqueues).
+//
+// One-slot mailbox: at most one row is in flight; while the worker is busy,
+// tryEnqueue() returns false and the caller counts a skipped sample. Rows are
+// written immediately on receipt (G-P7-14: an end-of-session flush loses
+// crash evidence) — once the worker acks, the row is on disk.
+//
+// The worker is spawned from an inline source string (eval: true): the
+// voice agent ships as a single esbuild artifact (scripts/build-bundle.mjs),
+// where a sibling worker FILE would not resolve. The worker uses only node
+// builtins, so the string needs no bundling.
+
+import { Worker } from 'node:worker_threads';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { resolveWorkspace } from './workspace_default.js';
+import type { HealthRow } from './voice-audio-health.js';
+
+/** Hard row cap enforced after every insert (age prune: 30 days). */
+export const HEALTH_MAX_ROWS = 5000;
+
+// CJS worker source — `require` is available under eval:true workers.
+const WORKER_SOURCE = `
+const { parentPort, workerData } = require('node:worker_threads');
+const { DatabaseSync } = require('node:sqlite');
+let db = null;
+function open() {
+  if (db) return db;
+  db = new DatabaseSync(workerData.dbPath);
+  db.exec('PRAGMA journal_mode=WAL');
+  db.exec('PRAGMA synchronous=NORMAL');
+  db.exec('PRAGMA busy_timeout=2000');
+  db.exec('CREATE TABLE IF NOT EXISTS voice_audio_health (' +
+    'id INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    'ts_unix INTEGER NOT NULL,' +
+    'session_id TEXT NOT NULL,' +
+    'epoch INTEGER,' +
+    'nonce TEXT,' +
+    'reason TEXT NOT NULL,' +
+    'payload TEXT NOT NULL)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_vah_ts ON voice_audio_health(ts_unix)');
+  return db;
+}
+parentPort.on('message', (row) => {
+  let ok = true;
+  try {
+    const d = open();
+    d.prepare('INSERT INTO voice_audio_health (ts_unix, session_id, epoch, nonce, reason, payload) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(row.tsUnix, row.sessionId, row.epoch ?? null, row.nonce ?? null, row.reason, row.payload);
+    d.prepare('DELETE FROM voice_audio_health WHERE id NOT IN (SELECT id FROM voice_audio_health ORDER BY id DESC LIMIT ?)')
+      .run(row.maxRows);
+    d.prepare('DELETE FROM voice_audio_health WHERE ts_unix < ?')
+      .run(Math.floor(Date.now() / 1000) - 30 * 24 * 3600);
+  } catch (e) {
+    ok = false;
+  }
+  parentPort.postMessage({ ok });
+});
+`;
+
+export interface HealthPersistence {
+  /** Non-blocking: false when the slot is occupied or the worker is down. */
+  tryEnqueue(row: HealthRow): boolean;
+  /** Test seam: resolves when the in-flight row (if any) has been acked —
+   *  i.e. it is on disk. */
+  drain(): Promise<void>;
+  close(): Promise<void>;
+  readonly broken: boolean;
+  /** Rows the worker acked as failed (disk error) — accepted but not stored. */
+  readonly failedWrites: number;
+}
+
+export function defaultHealthDbPath(): string {
+  return process.env.SUTANDO_VOICE_HEALTH_DB || join(resolveWorkspace(), 'data', 'voice-audio-health.sqlite');
+}
+
+export function createHealthPersistence(opts: { dbPath?: string; maxRows?: number } = {}): HealthPersistence {
+  const dbPath = opts.dbPath ?? defaultHealthDbPath();
+  const maxRows = opts.maxRows ?? HEALTH_MAX_ROWS;
+  try {
+    mkdirSync(dirname(dbPath), { recursive: true });
+  } catch {
+    /* worker open will surface a real failure */
+  }
+  let inFlight = false;
+  let broken = false;
+  let failedWrites = 0;
+  const waiters: Array<() => void> = [];
+  const release = (): void => {
+    inFlight = false;
+    for (const w of waiters.splice(0)) w();
+  };
+  const worker = new Worker(WORKER_SOURCE, { eval: true, workerData: { dbPath } });
+  // The persistence worker must never keep the voice process alive.
+  worker.unref();
+  worker.on('message', (m: { ok?: boolean }) => {
+    if (m?.ok === false) failedWrites++;
+    release();
+  });
+  worker.on('error', () => {
+    broken = true;
+    release();
+  });
+  worker.on('exit', (code) => {
+    if (code !== 0) broken = true;
+    release();
+  });
+  return {
+    tryEnqueue(row: HealthRow): boolean {
+      if (broken || inFlight) return false;
+      inFlight = true;
+      try {
+        worker.postMessage({ ...row, maxRows });
+      } catch {
+        broken = true;
+        release();
+        return false;
+      }
+      return true;
+    },
+    drain(): Promise<void> {
+      if (!inFlight) return Promise.resolve();
+      return new Promise((res) => waiters.push(res));
+    },
+    async close(): Promise<void> {
+      await worker.terminate();
+      release();
+    },
+    get broken(): boolean {
+      return broken;
+    },
+    get failedWrites(): number {
+      return failedWrites;
+    },
+  };
+}

--- a/src/voice-audio-health-persist.ts
+++ b/src/voice-audio-health-persist.ts
@@ -41,18 +41,22 @@ function open() {
     'epoch INTEGER,' +
     'nonce TEXT,' +
     'reason TEXT NOT NULL,' +
-    'payload TEXT NOT NULL)');
+    'payload_json TEXT NOT NULL)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_vah_ts ON voice_audio_health(ts_unix)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_vah_session ON voice_audio_health(session_id)');
   return db;
 }
 parentPort.on('message', (row) => {
   let ok = true;
   try {
     const d = open();
-    d.prepare('INSERT INTO voice_audio_health (ts_unix, session_id, epoch, nonce, reason, payload) VALUES (?, ?, ?, ?, ?, ?)')
+    d.prepare('INSERT INTO voice_audio_health (ts_unix, session_id, epoch, nonce, reason, payload_json) VALUES (?, ?, ?, ?, ?, ?)')
       .run(row.tsUnix, row.sessionId, row.epoch ?? null, row.nonce ?? null, row.reason, row.payload);
-    d.prepare('DELETE FROM voice_audio_health WHERE id NOT IN (SELECT id FROM voice_audio_health ORDER BY id DESC LIMIT ?)')
-      .run(row.maxRows);
+    // Row cap is PER SESSION (a busy new session must not evict another
+    // session's evidence); the 30-day sweep is global.
+    d.prepare('DELETE FROM voice_audio_health WHERE session_id = ? AND id NOT IN ' +
+      '(SELECT id FROM voice_audio_health WHERE session_id = ? ORDER BY id DESC LIMIT ?)')
+      .run(row.sessionId, row.sessionId, row.maxRows);
     d.prepare('DELETE FROM voice_audio_health WHERE ts_unix < ?')
       .run(Math.floor(Date.now() / 1000) - 30 * 24 * 3600);
   } catch (e) {

--- a/src/voice-audio-health-persist.ts
+++ b/src/voice-audio-health-persist.ts
@@ -42,6 +42,12 @@ function open() {
     'nonce TEXT,' +
     'reason TEXT NOT NULL,' +
     'payload_json TEXT NOT NULL)');
+  // Pre-rename databases carry a "payload" column; CREATE IF NOT EXISTS
+  // would leave them as-is and every insert would then fail forever.
+  const cols = db.prepare('PRAGMA table_info(voice_audio_health)').all().map((c) => c.name);
+  if (!cols.includes('payload_json') && cols.includes('payload')) {
+    db.exec('ALTER TABLE voice_audio_health RENAME COLUMN payload TO payload_json');
+  }
   db.exec('CREATE INDEX IF NOT EXISTS idx_vah_ts ON voice_audio_health(ts_unix)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_vah_session ON voice_audio_health(session_id)');
   return db;

--- a/src/voice-audio-health.ts
+++ b/src/voice-audio-health.ts
@@ -1,0 +1,548 @@
+// voice-audio-health — P7 D7.1 engine-side audio-progress ledger (Tranche A
+// interim). Wraps the session-layer seams only, so coverage is honestly
+// 'session-only': frames buffered by bodhi's ClientTransport during a
+// reconnect never pass handleAudioFromClient, and the matrix must downgrade
+// rather than misfire on that blind window.
+//
+// §D7.0b budget: the two frame-path wraps (audio ingress, audio egress) do
+// only O(1) counter/latch writes plus one subsampled RMS pass — no
+// allocation, no I/O, no serialization. Heartbeat ingest is message-rate
+// (~0.5/s); snapshots, [Health] segments, and persistence rows are
+// assembled on the 30 s / 1-min timers, never on a frame path. Persistence
+// itself is a try-enqueue into an injected one-slot mailbox — a busy slot
+// skips the sample (visible in `samplesSkipped`), it never queues.
+
+/** Mirror of the client transport's speech constants: floor above which a
+ *  frame counts as speech, and the offset hangover. */
+export const ENGINE_SPEECH_RMS_FLOOR = 0.02;
+export const ENGINE_SPEECH_HANG_MS = 600;
+
+/** Ingress considered stalled when no frame reached the session for this
+ *  long while a client is attached and its heartbeat says unmuted. */
+export const INGRESS_STALL_MS = 5000;
+
+/** Client heartbeat considered stale past this (expected cadence 2 s). */
+export const HEARTBEAT_STALE_MS = 8000;
+
+/** Bounded payload column (a snapshot serializes ~1 KB; the cap is a
+ *  guard, not a target). */
+export const PERSIST_PAYLOAD_MAX_BYTES = 4096;
+
+/** The engine-owned speech evidence (round-3 #4: ONE owner, one precedence —
+ *  this tracker is canonical; client RMS intervals are corroboration only).
+ *  Computed over PCM as delivered to the session, pre-EchoGuard. */
+export interface SpeechEvidence {
+  active: boolean;
+  onsetAt: number | null;
+  lastAboveFloorAt: number | null;
+}
+
+/** Parsed client audio_health heartbeat (wire schema owned by
+ *  web-voice-transport.ts sendAudioHealth — short keys, ≤300 B). Unknown
+ *  fields are ignored by construction: only the keys below are read.
+ *  The eight counter fields are DELTAS since the client's previous
+ *  successfully-sent heartbeat (the ledger accumulates them into
+ *  `clientTotals`). */
+export interface ClientHeartbeat {
+  nonce: string;
+  seq: number;
+  capCallbacks: number;
+  bytesSent: number;
+  sendSkipped: number;
+  sendFailed: number;
+  chunksRecv: number;
+  chunksScheduled: number;
+  chunksEnded: number;
+  chunksCancelled: number;
+  ctxTimeMs: number | null;
+  scheduledDepth: number | null;
+  lastEndedAgoMs: number | null;
+  ctxState: string | null;
+  captureState: string | null;
+  ctxSuspendCount: number;
+  bufferedAmount: number | null;
+  bufferedHighWater: number | null;
+  muted: boolean;
+  openGap: { startMs: number; ageMs: number } | null;
+  episodeOverflow: number;
+  episodes: Array<{ id: number; kind: string }>;
+  receivedAt: number;
+}
+
+/** One persistence row (the injected mailbox writes it to sqlite). */
+export interface HealthRow {
+  tsUnix: number;
+  sessionId: string;
+  epoch: number | null;
+  nonce: string | null;
+  reason: 'timer' | 'anomaly' | 'final';
+  payload: string;
+}
+
+export interface AudioHealthSnapshot {
+  coverage: 'session-only';
+  epoch: number | null;
+  nonce: string | null;
+  deliveredFrames: number;
+  deliveredBytes: number;
+  lastDeliveredAt: number | null;
+  egressFrames: number;
+  egressBytes: number;
+  lastEgressAt: number | null;
+  speech: SpeechEvidence;
+  ingressRms: number;
+  lastHeartbeat: ClientHeartbeat | null;
+  /** Delta heartbeats accumulated into per-epoch totals. */
+  clientTotals: {
+    capCallbacks: number;
+    bytesSent: number;
+    sendSkipped: number;
+    sendFailed: number;
+    chunksRecv: number;
+    chunksScheduled: number;
+    chunksEnded: number;
+    chunksCancelled: number;
+  };
+  heartbeatCount: number;
+  newEpisodeIds: number[];
+  samplesSkipped: number;
+  lastTurnLatencyMs: number | null;
+  inputHealth: 'ok' | 'stalled' | 'no-client' | 'unknown';
+}
+
+export interface AudioHealthLedger {
+  /** Install the session-layer wraps (monkey-patch, same pattern as the
+   *  narration-tee's handleAudioOutput wrap). Idempotent per session. */
+  wrapSession(session: unknown): void;
+  /** New client connection = new (pending) epoch: reset per-epoch state.
+   *  The epoch value itself is minted on first heartbeat sight. */
+  onClientConnected(): void;
+  onClientDisconnected(): void;
+  noteTurnLatency(totalE2EMs: number | undefined): void;
+  /** Canonical speech evidence — the vision gate and the matrix consume
+   *  THIS (precedence: ingress tracker > client RMS intervals). */
+  getSpeechEvidence(): SpeechEvidence;
+  getInputHealth(clientConnected: boolean): 'ok' | 'stalled' | 'no-client' | 'unknown';
+  getSnapshot(clientConnected: boolean): AudioHealthSnapshot;
+  /** Upgraded [Health] segments (30 s tick). Also advances the per-tick
+   *  rate windows. */
+  healthSegments(clientConnected: boolean): string;
+  /** Anomaly-overrides-suppression (D7.1): true forces a [Health] line even
+   *  during an unchanged-ACTIVE streak. Clears the per-tick latches. */
+  anomalySinceLastTick(clientConnected: boolean): { anomalous: boolean; reasons: string[] };
+  /** Try-enqueue one row into the persistence mailbox; a busy mailbox skips
+   *  the sample (samplesSkipped), never queues (§D7.0b). */
+  persistTick(reason: 'timer' | 'anomaly' | 'final', clientConnected: boolean): void;
+  /** Exposed for tests (the wrap routes here). */
+  ingestHeartbeat(msg: unknown): void;
+}
+
+export interface AudioHealthOptions {
+  sessionId: string;
+  nowFn?: () => number;
+  persist?: (row: HealthRow) => boolean;
+  log?: (line: string) => void;
+  speechRmsFloor?: number;
+  speechHangMs?: number;
+}
+
+/** Parse one wire heartbeat; returns null when the shape is not a plausible
+ *  audio_health frame. Tolerates unknown fields and absent optionals. */
+export function parseHeartbeat(msg: unknown, receivedAt: number): ClientHeartbeat | null {
+  if (!msg || typeof msg !== 'object') return null;
+  const m = msg as Record<string, unknown>;
+  if (m.t !== 'audio_health' || typeof m.n !== 'string') return null;
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+  const numOrNull = (v: unknown): number | null =>
+    typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : null;
+  const c = Array.isArray(m.c) ? (m.c as unknown[]) : [];
+  const x = Array.isArray(m.x) ? (m.x as unknown[]) : [];
+  const ba = Array.isArray(m.ba) ? (m.ba as unknown[]) : null;
+  const og = Array.isArray(m.og) && m.og.length >= 2 ? (m.og as unknown[]) : null;
+  const episodes: Array<{ id: number; kind: string }> = [];
+  if (Array.isArray(m.ep)) {
+    for (const e of m.ep as unknown[]) {
+      if (Array.isArray(e) && typeof e[0] === 'number' && typeof e[1] === 'string') {
+        episodes.push({ id: e[0], kind: e[1] === 'g' ? 'gap' : 'speech' });
+      }
+    }
+  }
+  return {
+    nonce: m.n,
+    seq: num(m.q),
+    capCallbacks: num(c[0]),
+    bytesSent: num(c[1]),
+    sendSkipped: num(c[2]),
+    sendFailed: num(c[3]),
+    chunksRecv: num(c[4]),
+    chunksScheduled: num(c[5]),
+    chunksEnded: num(c[6]),
+    chunksCancelled: num(c[7]),
+    ctxTimeMs: numOrNull(x[0]),
+    scheduledDepth: numOrNull(x[1]),
+    lastEndedAgoMs: numOrNull(x[2]),
+    ctxState: typeof m.cs === 'string' ? m.cs : null,
+    captureState: typeof m.cap === 'string' ? m.cap : null,
+    ctxSuspendCount: num(m.sc),
+    bufferedAmount: ba ? numOrNull(ba[0]) : null,
+    bufferedHighWater: ba ? numOrNull(ba[1]) : null,
+    muted: m.mu === 1,
+    openGap: og ? { startMs: num(og[0]), ageMs: num(og[1]) } : null,
+    episodeOverflow: num(m.eo),
+    episodes,
+    receivedAt,
+  };
+}
+
+export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLedger {
+  const now = opts.nowFn ?? Date.now;
+  const log = opts.log ?? (() => {});
+  const floor = opts.speechRmsFloor ?? ENGINE_SPEECH_RMS_FLOOR;
+  const hangMs = opts.speechHangMs ?? ENGINE_SPEECH_HANG_MS;
+
+  // ── epoch (engine-minted, Tranche A — round-4 #7) ──
+  let epoch: number | null = null;
+  let nonce: string | null = null;
+  let lastMintedEpoch = 0;
+  const nonceToEpoch = new Map<string, number>();
+
+  // ── frame-path counters (session-layer coverage only) ──
+  let deliveredFrames = 0;
+  let deliveredBytes = 0;
+  let lastDeliveredAt: number | null = null;
+  let egressFrames = 0;
+  let egressBytes = 0;
+  let lastEgressAt: number | null = null;
+
+  // ── ingress speech tracker (canonical) ──
+  let ingressRms = 0;
+  let speechEager = false;
+  let onsetAt: number | null = null;
+  let lastAboveFloorAt: number | null = null;
+
+  // ── client heartbeat mirror ──
+  let lastHb: ClientHeartbeat | null = null;
+  let prevHb: ClientHeartbeat | null = null;
+  let heartbeatCount = 0;
+  let seenEpisodeIds = new Set<number>();
+  let newEpisodeIds: number[] = [];
+  let sendSkippedGrew = false;
+  const zeroTotals = () => ({
+    capCallbacks: 0,
+    bytesSent: 0,
+    sendSkipped: 0,
+    sendFailed: 0,
+    chunksRecv: 0,
+    chunksScheduled: 0,
+    chunksEnded: 0,
+    chunksCancelled: 0,
+  });
+  let clientTotals = zeroTotals();
+
+  // ── persistence + latency ──
+  let samplesSkipped = 0;
+  let prevSamplesSkipped = 0;
+  let lastTurnLatencyMs: number | null = null;
+
+  // ── per-tick rate windows ([Health]) ──
+  let prevTickAt = now();
+  let prevDeliveredFrames = 0;
+  let prevEgressFrames = 0;
+
+  const wrapped: WeakSet<object> = new WeakSet();
+
+  function resetEpochState(): void {
+    epoch = null;
+    nonce = null;
+    deliveredFrames = 0;
+    deliveredBytes = 0;
+    lastDeliveredAt = null;
+    egressFrames = 0;
+    egressBytes = 0;
+    lastEgressAt = null;
+    ingressRms = 0;
+    speechEager = false;
+    onsetAt = null;
+    lastAboveFloorAt = null;
+    lastHb = null;
+    prevHb = null;
+    heartbeatCount = 0;
+    seenEpisodeIds = new Set();
+    newEpisodeIds = [];
+    sendSkippedGrew = false;
+    clientTotals = zeroTotals();
+    prevDeliveredFrames = 0;
+    prevEgressFrames = 0;
+  }
+
+  function noteIngress(data: unknown): void {
+    // §D7.0b FRAME PATH: O(1) writes + one subsampled pass. `data` is the
+    // int16le PCM Buffer bodhi hands to handleAudioFromClient.
+    const t = now();
+    deliveredFrames++;
+    const buf = data as { length?: number; readInt16LE?: (o: number) => number };
+    const len = typeof buf?.length === 'number' ? buf.length : 0;
+    deliveredBytes += len;
+    lastDeliveredAt = t;
+    if (len >= 2 && typeof buf.readInt16LE === 'function') {
+      // Every 4th sample (= every 8 bytes), allocation-free.
+      let sum = 0;
+      let n = 0;
+      for (let o = 0; o + 1 < len; o += 8) {
+        const v = buf.readInt16LE(o) / 32768;
+        sum += v * v;
+        n++;
+      }
+      const rms = n > 0 ? Math.sqrt(sum / n) : 0;
+      ingressRms = rms;
+      if (rms >= floor) {
+        if (!speechEager) {
+          speechEager = true;
+          onsetAt = t;
+        }
+        lastAboveFloorAt = t;
+      } else if (speechEager && lastAboveFloorAt !== null && t - lastAboveFloorAt > hangMs) {
+        speechEager = false;
+      }
+    }
+  }
+
+  function noteEgress(base64: unknown): void {
+    // §D7.0b FRAME PATH: O(1). `base64` is the outbound audio string.
+    egressFrames++;
+    const s = base64 as { length?: number };
+    if (typeof s?.length === 'number') egressBytes += Math.floor((s.length * 3) / 4);
+    lastEgressAt = now();
+  }
+
+  function ingestHeartbeat(msg: unknown): void {
+    const hb = parseHeartbeat(msg, now());
+    if (!hb) return;
+    if (hb.nonce !== nonce) {
+      // First sight of a new client connection: mint the engine-owned epoch
+      // (monotonic, collision-free) and key everything to it.
+      const existing = nonceToEpoch.get(hb.nonce);
+      if (existing !== undefined) {
+        epoch = existing;
+      } else {
+        lastMintedEpoch = Math.max(now(), lastMintedEpoch + 1);
+        epoch = lastMintedEpoch;
+        nonceToEpoch.set(hb.nonce, epoch);
+        if (nonceToEpoch.size > 4) {
+          const oldest = nonceToEpoch.keys().next().value;
+          if (oldest !== undefined) nonceToEpoch.delete(oldest);
+        }
+        log(`[AudioHealth] epoch ${epoch} minted for client nonce ${hb.nonce}`);
+      }
+      nonce = hb.nonce;
+      prevHb = null;
+      seenEpisodeIds = new Set();
+      newEpisodeIds = [];
+      clientTotals = zeroTotals();
+    } else {
+      prevHb = lastHb;
+    }
+    for (const e of hb.episodes) {
+      if (!seenEpisodeIds.has(e.id)) {
+        seenEpisodeIds.add(e.id);
+        newEpisodeIds.push(e.id);
+        if (seenEpisodeIds.size > 128) seenEpisodeIds.clear(); // bounded (ids re-add harmlessly)
+      }
+    }
+    // Counter fields are deltas: accumulate into the per-epoch totals.
+    clientTotals.capCallbacks += hb.capCallbacks;
+    clientTotals.bytesSent += hb.bytesSent;
+    clientTotals.sendSkipped += hb.sendSkipped;
+    clientTotals.sendFailed += hb.sendFailed;
+    clientTotals.chunksRecv += hb.chunksRecv;
+    clientTotals.chunksScheduled += hb.chunksScheduled;
+    clientTotals.chunksEnded += hb.chunksEnded;
+    clientTotals.chunksCancelled += hb.chunksCancelled;
+    if (hb.sendSkipped > 0) sendSkippedGrew = true;
+    lastHb = hb;
+    heartbeatCount++;
+  }
+
+  function speechEvidence(): SpeechEvidence {
+    const t = now();
+    // Lazy decay: a stalled client stops delivering frames, so the eager
+    // flag alone would latch active forever — the hangover check here makes
+    // silence (and stalls) end the evidence.
+    const active = lastAboveFloorAt !== null && t - lastAboveFloorAt <= hangMs;
+    return { active, onsetAt: active ? onsetAt : null, lastAboveFloorAt };
+  }
+
+  function inputHealth(clientConnected: boolean): 'ok' | 'stalled' | 'no-client' | 'unknown' {
+    if (!clientConnected) return 'no-client';
+    const t = now();
+    if (lastHb?.openGap) return 'stalled';
+    const muted = lastHb?.muted ?? false;
+    if (!muted && lastDeliveredAt !== null && t - lastDeliveredAt > INGRESS_STALL_MS) return 'stalled';
+    if (lastDeliveredAt === null && heartbeatCount === 0) return 'unknown';
+    return 'ok';
+  }
+
+  return {
+    wrapSession(session: unknown): void {
+      const s = session as Record<string, unknown> & object;
+      if (wrapped.has(s)) return;
+      wrapped.add(s);
+      const origAudio = (s.handleAudioFromClient as ((d: unknown) => void) | undefined)?.bind(s);
+      if (origAudio) {
+        s.handleAudioFromClient = (data: unknown) => {
+          noteIngress(data);
+          origAudio(data);
+        };
+      }
+      const origJson = (s.handleJsonFromClient as ((m: unknown) => void) | undefined)?.bind(s);
+      if (origJson) {
+        s.handleJsonFromClient = (message: unknown) => {
+          const m = message as { t?: unknown } | null;
+          if (m && m.t === 'audio_health') {
+            // Intercepted: health telemetry is engine-consumed, never routed
+            // into bodhi's client-message handling.
+            try {
+              ingestHeartbeat(message);
+            } catch {
+              /* a malformed frame must never break the message path */
+            }
+            return;
+          }
+          origJson(message);
+        };
+      }
+      const origOut = (s.handleAudioOutput as ((d: unknown) => void) | undefined)?.bind(s);
+      if (origOut) {
+        s.handleAudioOutput = (data: unknown) => {
+          noteEgress(data);
+          origOut(data);
+        };
+      }
+    },
+
+    onClientConnected(): void {
+      resetEpochState();
+    },
+
+    onClientDisconnected(): void {
+      // Keep the epoch's evidence for the final persist; eager speech ends.
+      speechEager = false;
+    },
+
+    noteTurnLatency(totalE2EMs: number | undefined): void {
+      if (typeof totalE2EMs === 'number' && Number.isFinite(totalE2EMs)) {
+        lastTurnLatencyMs = totalE2EMs;
+      }
+    },
+
+    getSpeechEvidence: speechEvidence,
+    getInputHealth: inputHealth,
+
+    getSnapshot(clientConnected: boolean): AudioHealthSnapshot {
+      return {
+        coverage: 'session-only',
+        epoch,
+        nonce,
+        deliveredFrames,
+        deliveredBytes,
+        lastDeliveredAt,
+        egressFrames,
+        egressBytes,
+        lastEgressAt,
+        speech: speechEvidence(),
+        ingressRms,
+        lastHeartbeat: lastHb,
+        clientTotals: { ...clientTotals },
+        heartbeatCount,
+        newEpisodeIds: [...newEpisodeIds],
+        samplesSkipped,
+        lastTurnLatencyMs,
+        inputHealth: inputHealth(clientConnected),
+      };
+    },
+
+    healthSegments(clientConnected: boolean): string {
+      const t = now();
+      const dt = Math.max(0.001, (t - prevTickAt) / 1000);
+      const inFps = (deliveredFrames - prevDeliveredFrames) / dt;
+      const outFps = (egressFrames - prevEgressFrames) / dt;
+      prevTickAt = t;
+      prevDeliveredFrames = deliveredFrames;
+      prevEgressFrames = egressFrames;
+      const ago = (v: number | null): string => (v === null ? 'n/a' : ((t - v) / 1000).toFixed(1) + 's');
+      const audioIn = `audioIn={fps:${inFps.toFixed(1)},lastAgo:${ago(lastDeliveredAt)},coverage:session-only}`;
+      // Tranche A cannot see SDK accepts/discards (bodhi-internal) — up is
+      // honestly n/a until the native counters land ([B] step 6).
+      const up = 'up=n/a';
+      const endedLag =
+        lastHb?.lastEndedAgoMs != null ? (lastHb.lastEndedAgoMs / 1000).toFixed(1) + 's' : 'n/a';
+      const out = `out={fps:${outFps.toFixed(1)},buffered:${lastHb?.bufferedAmount ?? 'n/a'},endedLag:${endedLag}}`;
+      let client = 'clientHealth=n/a';
+      if (lastHb) {
+        const hbAge = ((t - lastHb.receivedAt) / 1000).toFixed(1) + 's';
+        let capRate = 'n/a';
+        if (prevHb && lastHb.receivedAt > prevHb.receivedAt) {
+          // Counter fields are deltas — the rate is delta over inter-beat time.
+          capRate = ((lastHb.capCallbacks * 1000) / (lastHb.receivedAt - prevHb.receivedAt)).toFixed(1);
+        }
+        // rms is the ENGINE ingress tracker (canonical evidence) — the
+        // client's own rms travels only as latched episode intervals.
+        client =
+          `clientHealth={age:${hbAge},capCb/s:${capRate},rms:${ingressRms.toFixed(3)},` +
+          `ctx:${lastHb.ctxState ?? '?'},cap:${lastHb.captureState ?? '?'},gaps:${seenEpisodeIds.size},` +
+          `skip:${clientTotals.sendSkipped}${lastHb.muted ? ',muted' : ''}${lastHb.openGap ? ',STALLED' : ''}}`;
+      }
+      const lat = lastTurnLatencyMs != null ? ` latency=${lastTurnLatencyMs}ms` : '';
+      const ep = epoch != null ? ` epoch=${epoch}` : '';
+      const health = clientConnected ? inputHealth(true) : 'no-client';
+      return `${audioIn} ${up} ${out} ${client}${ep}${lat} inputHealth=${health}`;
+    },
+
+    anomalySinceLastTick(clientConnected: boolean): { anomalous: boolean; reasons: string[] } {
+      const t = now();
+      const reasons: string[] = [];
+      if (lastHb?.openGap) reasons.push('capStalled');
+      if (newEpisodeIds.length > 0) reasons.push(`episodes:${newEpisodeIds.length}`);
+      if (clientConnected && lastHb && t - lastHb.receivedAt > HEARTBEAT_STALE_MS) {
+        reasons.push('heartbeat-stale');
+      }
+      if (
+        clientConnected &&
+        !(lastHb?.muted ?? false) &&
+        lastDeliveredAt !== null &&
+        t - lastDeliveredAt > INGRESS_STALL_MS
+      ) {
+        reasons.push('ingress-stalled');
+      }
+      if (sendSkippedGrew) reasons.push('sendSkipped');
+      if (samplesSkipped > prevSamplesSkipped) reasons.push('persistSkipped');
+      // Clear the per-tick latches (counters themselves stay monotonic).
+      newEpisodeIds = [];
+      sendSkippedGrew = false;
+      prevSamplesSkipped = samplesSkipped;
+      return { anomalous: reasons.length > 0, reasons };
+    },
+
+    persistTick(reason: 'timer' | 'anomaly' | 'final', clientConnected: boolean): void {
+      if (!opts.persist) return;
+      const snapshot = this.getSnapshot(clientConnected);
+      let payload = JSON.stringify(snapshot);
+      if (payload.length > PERSIST_PAYLOAD_MAX_BYTES) payload = payload.slice(0, PERSIST_PAYLOAD_MAX_BYTES);
+      const row: HealthRow = {
+        tsUnix: Math.floor(now() / 1000),
+        sessionId: opts.sessionId,
+        epoch,
+        nonce,
+        reason,
+        payload,
+      };
+      if (!opts.persist(row)) {
+        // One-slot mailbox busy (or worker down): the sample is SKIPPED, not
+        // queued — lag is visible in the ledger, never felt in audio.
+        samplesSkipped++;
+      }
+    },
+
+    ingestHeartbeat,
+  };
+}

--- a/src/voice-audio-health.ts
+++ b/src/voice-audio-health.ts
@@ -65,8 +65,22 @@ export interface ClientHeartbeat {
   muted: boolean;
   openGap: { startMs: number; ageMs: number } | null;
   episodeOverflow: number;
-  episodes: Array<{ id: number; kind: string }>;
+  episodes: ClientEpisode[];
   receivedAt: number;
+}
+
+/** One episode interval from the wire window. Gap entries carry
+ *  {startMs, durationMs} (client-epoch-relative); speech entries carry
+ *  {onsetSeq, offsetSeq, maxRmsPm, aboveFloorMs}. */
+export interface ClientEpisode {
+  id: number;
+  kind: 'gap' | 'speech';
+  startMs?: number;
+  durationMs?: number;
+  onsetSeq?: number;
+  offsetSeq?: number;
+  maxRmsPm?: number;
+  aboveFloorMs?: number;
 }
 
 /** One persistence row (the injected mailbox writes it to sqlite). */
@@ -108,6 +122,12 @@ export interface AudioHealthSnapshot {
   samplesSkipped: number;
   lastTurnLatencyMs: number | null;
   inputHealth: 'ok' | 'stalled' | 'no-client' | 'unknown';
+  /** Receipt-time approximation of the client epoch's start on the engine
+   *  clock (null before the first heartbeat). */
+  epochStartApproxMs: number | null;
+  /** Last D7.2 matrix verdict noted via noteMatrixVerdict (persisted with
+   *  every row). */
+  lastMatrixVerdict: string | null;
 }
 
 export interface AudioHealthLedger {
@@ -133,6 +153,8 @@ export interface AudioHealthLedger {
   /** Try-enqueue one row into the persistence mailbox; a busy mailbox skips
    *  the sample (samplesSkipped), never queues (§D7.0b). */
   persistTick(reason: 'timer' | 'anomaly' | 'final', clientConnected: boolean): void;
+  /** D7.2: record the latest matrix verdict so every persisted row carries it. */
+  noteMatrixVerdict(verdict: string): void;
   /** Exposed for tests (the wrap routes here). */
   ingestHeartbeat(msg: unknown): void;
 }
@@ -159,11 +181,22 @@ export function parseHeartbeat(msg: unknown, receivedAt: number): ClientHeartbea
   const x = Array.isArray(m.x) ? (m.x as unknown[]) : [];
   const ba = Array.isArray(m.ba) ? (m.ba as unknown[]) : null;
   const og = Array.isArray(m.og) && m.og.length >= 2 ? (m.og as unknown[]) : null;
-  const episodes: Array<{ id: number; kind: string }> = [];
+  const episodes: ClientEpisode[] = [];
   if (Array.isArray(m.ep)) {
     for (const e of m.ep as unknown[]) {
       if (Array.isArray(e) && typeof e[0] === 'number' && typeof e[1] === 'string') {
-        episodes.push({ id: e[0], kind: e[1] === 'g' ? 'gap' : 'speech' });
+        if (e[1] === 'g') {
+          episodes.push({ id: e[0], kind: 'gap', startMs: num(e[2]), durationMs: num(e[3]) });
+        } else {
+          episodes.push({
+            id: e[0],
+            kind: 'speech',
+            onsetSeq: num(e[2]),
+            offsetSeq: num(e[3]),
+            maxRmsPm: num(e[4]),
+            aboveFloorMs: num(e[5]),
+          });
+        }
       }
     }
   }
@@ -205,6 +238,12 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
   let nonce: string | null = null;
   let lastMintedEpoch = 0;
   const nonceToEpoch = new Map<string, number>();
+  /** Receipt-time approximation of the client's epoch start (first heartbeat
+   *  fires on the client's first 500 ms stats tick) — lets the matrix place
+   *  client-epoch-relative episode intervals on the engine clock, labeled
+   *  approximate. */
+  let epochStartApproxMs: number | null = null;
+  let lastMatrixVerdict: string | null = null;
 
   // ── frame-path counters (session-layer coverage only) ──
   let deliveredFrames = 0;
@@ -254,6 +293,8 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
   function resetEpochState(): void {
     epoch = null;
     nonce = null;
+    epochStartApproxMs = null;
+    lastMatrixVerdict = null;
     deliveredFrames = 0;
     deliveredBytes = 0;
     lastDeliveredAt = null;
@@ -339,6 +380,7 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
       seenEpisodeIds = new Set();
       newEpisodeIds = [];
       clientTotals = zeroTotals();
+      epochStartApproxMs = hb.receivedAt - 500;
     } else {
       prevHb = lastHb;
     }
@@ -458,7 +500,13 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
         samplesSkipped,
         lastTurnLatencyMs,
         inputHealth: inputHealth(clientConnected),
+        epochStartApproxMs,
+        lastMatrixVerdict,
       };
+    },
+
+    noteMatrixVerdict(verdict: string): void {
+      lastMatrixVerdict = verdict;
     },
 
     healthSegments(clientConnected: boolean): string {

--- a/src/voice-audio-health.ts
+++ b/src/voice-audio-health.ts
@@ -46,6 +46,9 @@ export interface SpeechEvidence {
 export interface ClientHeartbeat {
   nonce: string;
   seq: number;
+  /** ms since connect() on the CLIENT clock at assembly (null on frames from
+   *  clients predating the field). epochStartApprox = receivedAt − ea. */
+  epochAgeMs: number | null;
   capCallbacks: number;
   bytesSent: number;
   sendSkipped: number;
@@ -121,9 +124,11 @@ export interface AudioHealthSnapshot {
   newEpisodeIds: number[];
   samplesSkipped: number;
   lastTurnLatencyMs: number | null;
-  /** Server-clock ingress-onset → first model audio (receipt-time
+  /** Server-clock ingress-onset → first model EVENT (receipt-time
    *  approximation — D7.3's user-speech→first-model-event metric). */
   lastSpeechToModelMs: number | null;
+  /** Latest observed model activity (audio out, turn start, tool call). */
+  lastModelEventAt: number | null;
   inputHealth: 'ok' | 'degraded' | 'stalled' | 'no-client' | 'unknown';
   /** Receipt-time approximation of the client epoch's start on the engine
    *  clock (null before the first heartbeat). */
@@ -142,6 +147,9 @@ export interface AudioHealthLedger {
   onClientConnected(): void;
   onClientDisconnected(): void;
   noteTurnLatency(totalE2EMs: number | undefined): void;
+  /** Any observed model activity beyond audio (turn start, tool call) — the
+   *  D7.1 model hop is EVENTS, and audio alone misses text/tool-first turns. */
+  noteModelEvent(): void;
   /** Canonical speech evidence — the vision gate and the matrix consume
    *  THIS (precedence: ingress tracker > client RMS intervals). */
   getSpeechEvidence(): SpeechEvidence;
@@ -214,6 +222,7 @@ export function parseHeartbeat(msg: unknown, receivedAt: number): ClientHeartbea
   return {
     nonce: m.n,
     seq: num(m.q),
+    epochAgeMs: numOrNull(m.ea),
     capCallbacks: num(c[0]),
     bytesSent: num(c[1]),
     sendSkipped: num(c[2]),
@@ -272,9 +281,12 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
   let speechEager = false;
   let onsetAt: number | null = null;
   let lastAboveFloorAt: number | null = null;
-  /** Armed at speech onset, consumed by the next egress frame (D7.3 latency). */
+  /** Armed at speech onset, consumed by the next MODEL EVENT (D7.3 latency). */
   let pendingSpeechOnsetAt: number | null = null;
   let lastSpeechToModelMs: number | null = null;
+  /** Any model activity: first audio out, turn start, tool call — whichever
+   *  the engine observes first (D7.1: model EVENT, not model audio). */
+  let lastModelEventAt: number | null = null;
 
   // ── client heartbeat mirror ──
   let lastHb: ClientHeartbeat | null = null;
@@ -340,6 +352,7 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
     lastTurnLatencyMs = null;
     pendingSpeechOnsetAt = null;
     lastSpeechToModelMs = null;
+    lastModelEventAt = null;
   }
 
   function noteIngress(data: unknown): void {
@@ -385,19 +398,23 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
     }
   }
 
+  function noteModelEventAt(t: number): void {
+    lastModelEventAt = t;
+    if (pendingSpeechOnsetAt !== null) {
+      // Server-clock ingress-onset → FIRST model event (audio, turn start,
+      // or tool call — whichever lands first; receipt-time approximation).
+      lastSpeechToModelMs = t - pendingSpeechOnsetAt;
+      pendingSpeechOnsetAt = null;
+    }
+  }
+
   function noteEgress(base64: unknown): void {
     // §D7.0b FRAME PATH: O(1). `base64` is the outbound audio string.
     egressFrames++;
     const s = base64 as { length?: number };
     if (typeof s?.length === 'number') egressBytes += Math.floor((s.length * 3) / 4);
     lastEgressAt = now();
-    if (pendingSpeechOnsetAt !== null) {
-      // Server-clock ingress-onset → first model audio (receipt-time
-      // approximation, labeled — model audio out is the Tranche-A model
-      // event).
-      lastSpeechToModelMs = lastEgressAt - pendingSpeechOnsetAt;
-      pendingSpeechOnsetAt = null;
-    }
+    noteModelEventAt(lastEgressAt);
   }
 
   function mintEpoch(): number {
@@ -413,22 +430,28 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
         // First heartbeat of the connection: bind the client nonce to the
         // epoch minted at connect.
         log(`[AudioHealth] client nonce ${hb.nonce} bound to epoch ${epoch}`);
+        nonce = hb.nonce;
       } else {
         // Nonce changed without a connect event (or a heartbeat arrived
-        // before any connect) — defensively treat it as a new epoch.
+        // before any connect) — a FULL epoch boundary, not just a client
+        // baseline reset: server counters, heartbeats, latency samples, and
+        // tick windows from the old epoch must not bleed into the new one.
+        resetEpochState();
         epoch = mintEpoch();
+        nonce = hb.nonce;
         log(`[AudioHealth] epoch ${epoch} minted for unexpected client nonce ${hb.nonce}`);
       }
-      nonce = hb.nonce;
-      prevHb = null;
-      seenEpisodeIds = new Set();
-      gapEpisodeCount = 0;
-      newEpisodeIds = [];
-      clientTotals = zeroTotals();
-      epochStartApproxMs = hb.receivedAt - 500;
     } else {
       prevHb = lastHb;
     }
+    // Epoch placement: the client stamps its own epoch age into every beat —
+    // receivedAt − ea places the client's epoch-relative intervals on the
+    // engine clock (accurate to network latency). Refreshed per beat; the
+    // pre-`ea` fallback stays a coarse first-beat guess.
+    epochStartApproxMs =
+      hb.epochAgeMs !== null
+        ? hb.receivedAt - hb.epochAgeMs
+        : (epochStartApproxMs ?? hb.receivedAt - 500);
     for (const e of hb.episodes) {
       if (!seenEpisodeIds.has(e.id)) {
         seenEpisodeIds.add(e.id);
@@ -546,6 +569,10 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
       }
     },
 
+    noteModelEvent(): void {
+      noteModelEventAt(now());
+    },
+
     getSpeechEvidence: speechEvidence,
     getInputHealth: inputHealth,
 
@@ -569,6 +596,7 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
         samplesSkipped,
         lastTurnLatencyMs,
         lastSpeechToModelMs,
+        lastModelEventAt,
         inputHealth: inputHealth(clientConnected),
         epochStartApproxMs,
         lastMatrixVerdict,
@@ -629,7 +657,9 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
       // and FRESH — a detached client's retained open gap is not a live
       // anomaly (codex round-2 #4).
       if (clientConnected && !muted && hbFresh && lastHb?.openGap) reasons.push('capStalled');
-      if (newEpisodeIds.length > 0) reasons.push(`episodes:${newEpisodeIds.length}`);
+      // Episode evidence still latches into the snapshot regardless, but a
+      // detached client re-sending its window is not a LIVE anomaly.
+      if (clientConnected && newEpisodeIds.length > 0) reasons.push(`episodes:${newEpisodeIds.length}`);
       if (clientConnected && lastHb && !hbFresh) reasons.push('heartbeat-stale');
       if (
         clientConnected &&

--- a/src/voice-audio-health.ts
+++ b/src/voice-audio-health.ts
@@ -121,7 +121,10 @@ export interface AudioHealthSnapshot {
   newEpisodeIds: number[];
   samplesSkipped: number;
   lastTurnLatencyMs: number | null;
-  inputHealth: 'ok' | 'stalled' | 'no-client' | 'unknown';
+  /** Server-clock ingress-onset → first model audio (receipt-time
+   *  approximation — D7.3's user-speech→first-model-event metric). */
+  lastSpeechToModelMs: number | null;
+  inputHealth: 'ok' | 'degraded' | 'stalled' | 'no-client' | 'unknown';
   /** Receipt-time approximation of the client epoch's start on the engine
    *  clock (null before the first heartbeat). */
   epochStartApproxMs: number | null;
@@ -142,14 +145,18 @@ export interface AudioHealthLedger {
   /** Canonical speech evidence — the vision gate and the matrix consume
    *  THIS (precedence: ingress tracker > client RMS intervals). */
   getSpeechEvidence(): SpeechEvidence;
-  getInputHealth(clientConnected: boolean): 'ok' | 'stalled' | 'no-client' | 'unknown';
+  getInputHealth(clientConnected: boolean): 'ok' | 'degraded' | 'stalled' | 'no-client' | 'unknown';
   getSnapshot(clientConnected: boolean): AudioHealthSnapshot;
-  /** Upgraded [Health] segments (30 s tick). Also advances the per-tick
-   *  rate windows. */
-  healthSegments(clientConnected: boolean): string;
+  /** Upgraded [Health] segments (30 s tick). Also advances the per-tick rate
+   *  windows — call EVERY tick, even when the line is suppressed, or a later
+   *  line reports a long-window average instead of the last 30 s. */
+  healthSegments(clientConnected: boolean, serverBufferedAmount?: number | null): string;
   /** Anomaly-overrides-suppression (D7.1): true forces a [Health] line even
-   *  during an unchanged-ACTIVE streak. Clears the per-tick latches. */
-  anomalySinceLastTick(clientConnected: boolean): { anomalous: boolean; reasons: string[] };
+   *  during an unchanged-ACTIVE streak. PEEK ONLY — call clearTickLatches()
+   *  after the anomaly row has been logged AND persisted, so the evidence
+   *  cannot be cleared before it is serialized. */
+  anomalies(clientConnected: boolean): { anomalous: boolean; reasons: string[] };
+  clearTickLatches(): void;
   /** Try-enqueue one row into the persistence mailbox; a busy mailbox skips
    *  the sample (samplesSkipped), never queues (§D7.0b). */
   persistTick(reason: 'timer' | 'anomaly' | 'final', clientConnected: boolean): void;
@@ -183,11 +190,13 @@ export function parseHeartbeat(msg: unknown, receivedAt: number): ClientHeartbea
   const og = Array.isArray(m.og) && m.og.length >= 2 ? (m.og as unknown[]) : null;
   const episodes: ClientEpisode[] = [];
   if (Array.isArray(m.ep)) {
-    for (const e of m.ep as unknown[]) {
+    // Cap at 2× the client window: telemetry is bounded by contract, and an
+    // oversized array must not become unbounded ingest work.
+    for (const e of (m.ep as unknown[]).slice(0, 8)) {
       if (Array.isArray(e) && typeof e[0] === 'number' && typeof e[1] === 'string') {
         if (e[1] === 'g') {
           episodes.push({ id: e[0], kind: 'gap', startMs: num(e[2]), durationMs: num(e[3]) });
-        } else {
+        } else if (e[1] === 's') {
           episodes.push({
             id: e[0],
             kind: 'speech',
@@ -197,6 +206,8 @@ export function parseHeartbeat(msg: unknown, receivedAt: number): ClientHeartbea
             aboveFloorMs: num(e[5]),
           });
         }
+        // Unknown kinds are dropped, not misclassified — a future client's
+        // new episode type must not masquerade as speech evidence.
       }
     }
   }
@@ -234,10 +245,13 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
   const hangMs = opts.speechHangMs ?? ENGINE_SPEECH_HANG_MS;
 
   // ── epoch (engine-minted, Tranche A — round-4 #7) ──
+  // Minted in onClientConnected (per the design — a connection that dies
+  // before its first heartbeat still persists a real epoch); the client's
+  // nonce binds to it on first heartbeat sight. A nonce change WITHOUT a
+  // connect event (should not happen at the pin) re-mints defensively.
   let epoch: number | null = null;
   let nonce: string | null = null;
   let lastMintedEpoch = 0;
-  const nonceToEpoch = new Map<string, number>();
   /** Receipt-time approximation of the client's epoch start (first heartbeat
    *  fires on the client's first 500 ms stats tick) — lets the matrix place
    *  client-epoch-relative episode intervals on the engine clock, labeled
@@ -258,12 +272,17 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
   let speechEager = false;
   let onsetAt: number | null = null;
   let lastAboveFloorAt: number | null = null;
+  /** Armed at speech onset, consumed by the next egress frame (D7.3 latency). */
+  let pendingSpeechOnsetAt: number | null = null;
+  let lastSpeechToModelMs: number | null = null;
 
   // ── client heartbeat mirror ──
   let lastHb: ClientHeartbeat | null = null;
   let prevHb: ClientHeartbeat | null = null;
   let heartbeatCount = 0;
   let seenEpisodeIds = new Set<number>();
+  /** Gap episodes only — the [Health] `gaps` field must not count speech. */
+  let gapEpisodeCount = 0;
   let newEpisodeIds: number[] = [];
   let sendSkippedGrew = false;
   const zeroTotals = () => ({
@@ -309,16 +328,26 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
     prevHb = null;
     heartbeatCount = 0;
     seenEpisodeIds = new Set();
+    gapEpisodeCount = 0;
     newEpisodeIds = [];
     sendSkippedGrew = false;
     clientTotals = zeroTotals();
     prevDeliveredFrames = 0;
     prevEgressFrames = 0;
+    prevTickAt = now();
+    samplesSkipped = 0;
+    prevSamplesSkipped = 0;
+    lastTurnLatencyMs = null;
+    pendingSpeechOnsetAt = null;
+    lastSpeechToModelMs = null;
   }
 
   function noteIngress(data: unknown): void {
-    // §D7.0b FRAME PATH: O(1) writes + one subsampled pass. `data` is the
-    // int16le PCM Buffer bodhi hands to handleAudioFromClient.
+    // §D7.0b FRAME PATH: O(1) writes + one BOUNDED subsampled pass. `data`
+    // is the int16le PCM Buffer bodhi hands to handleAudioFromClient — but
+    // its length is client-controlled, so the pass caps at 8 KiB (≥ the
+    // nominal 1364 B frame; a jumbo frame's tail adds nothing to a level
+    // estimate).
     const t = now();
     deliveredFrames++;
     const buf = data as { length?: number; readInt16LE?: (o: number) => number };
@@ -326,24 +355,32 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
     deliveredBytes += len;
     lastDeliveredAt = t;
     if (len >= 2 && typeof buf.readInt16LE === 'function') {
+      const scanLen = Math.min(len, 8192);
       // Every 4th sample (= every 8 bytes), allocation-free.
       let sum = 0;
       let n = 0;
-      for (let o = 0; o + 1 < len; o += 8) {
+      for (let o = 0; o + 1 < scanLen; o += 8) {
         const v = buf.readInt16LE(o) / 32768;
         sum += v * v;
         n++;
       }
       const rms = n > 0 ? Math.sqrt(sum / n) : 0;
       ingressRms = rms;
+      // Decay FIRST: after a silent stall longer than the hangover, the next
+      // above-floor frame is a NEW onset — without this, onsetAt would stay
+      // latched to the first utterance forever (codex round-2 #3).
+      if (speechEager && lastAboveFloorAt !== null && t - lastAboveFloorAt > hangMs) {
+        speechEager = false;
+      }
       if (rms >= floor) {
         if (!speechEager) {
           speechEager = true;
           onsetAt = t;
+          // Arm the speech→first-model-event latency sample (D7.3: the half
+          // FE-1 actually inflated), consumed by the next egress frame.
+          pendingSpeechOnsetAt = t;
         }
         lastAboveFloorAt = t;
-      } else if (speechEager && lastAboveFloorAt !== null && t - lastAboveFloorAt > hangMs) {
-        speechEager = false;
       }
     }
   }
@@ -354,30 +391,38 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
     const s = base64 as { length?: number };
     if (typeof s?.length === 'number') egressBytes += Math.floor((s.length * 3) / 4);
     lastEgressAt = now();
+    if (pendingSpeechOnsetAt !== null) {
+      // Server-clock ingress-onset → first model audio (receipt-time
+      // approximation, labeled — model audio out is the Tranche-A model
+      // event).
+      lastSpeechToModelMs = lastEgressAt - pendingSpeechOnsetAt;
+      pendingSpeechOnsetAt = null;
+    }
+  }
+
+  function mintEpoch(): number {
+    lastMintedEpoch = Math.max(now(), lastMintedEpoch + 1);
+    return lastMintedEpoch;
   }
 
   function ingestHeartbeat(msg: unknown): void {
     const hb = parseHeartbeat(msg, now());
     if (!hb) return;
     if (hb.nonce !== nonce) {
-      // First sight of a new client connection: mint the engine-owned epoch
-      // (monotonic, collision-free) and key everything to it.
-      const existing = nonceToEpoch.get(hb.nonce);
-      if (existing !== undefined) {
-        epoch = existing;
+      if (nonce === null && epoch !== null) {
+        // First heartbeat of the connection: bind the client nonce to the
+        // epoch minted at connect.
+        log(`[AudioHealth] client nonce ${hb.nonce} bound to epoch ${epoch}`);
       } else {
-        lastMintedEpoch = Math.max(now(), lastMintedEpoch + 1);
-        epoch = lastMintedEpoch;
-        nonceToEpoch.set(hb.nonce, epoch);
-        if (nonceToEpoch.size > 4) {
-          const oldest = nonceToEpoch.keys().next().value;
-          if (oldest !== undefined) nonceToEpoch.delete(oldest);
-        }
-        log(`[AudioHealth] epoch ${epoch} minted for client nonce ${hb.nonce}`);
+        // Nonce changed without a connect event (or a heartbeat arrived
+        // before any connect) — defensively treat it as a new epoch.
+        epoch = mintEpoch();
+        log(`[AudioHealth] epoch ${epoch} minted for unexpected client nonce ${hb.nonce}`);
       }
       nonce = hb.nonce;
       prevHb = null;
       seenEpisodeIds = new Set();
+      gapEpisodeCount = 0;
       newEpisodeIds = [];
       clientTotals = zeroTotals();
       epochStartApproxMs = hb.receivedAt - 500;
@@ -388,6 +433,7 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
       if (!seenEpisodeIds.has(e.id)) {
         seenEpisodeIds.add(e.id);
         newEpisodeIds.push(e.id);
+        if (e.kind === 'gap') gapEpisodeCount++;
         if (seenEpisodeIds.size > 128) seenEpisodeIds.clear(); // bounded (ids re-add harmlessly)
       }
     }
@@ -414,13 +460,31 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
     return { active, onsetAt: active ? onsetAt : null, lastAboveFloorAt };
   }
 
-  function inputHealth(clientConnected: boolean): 'ok' | 'stalled' | 'no-client' | 'unknown' {
+  function inputHealth(
+    clientConnected: boolean,
+  ): 'ok' | 'degraded' | 'stalled' | 'no-client' | 'unknown' {
     if (!clientConnected) return 'no-client';
     const t = now();
-    if (lastHb?.openGap) return 'stalled';
+    const hbFresh = lastHb !== null && t - lastHb.receivedAt <= HEARTBEAT_STALE_MS;
     const muted = lastHb?.muted ?? false;
-    if (!muted && lastDeliveredAt !== null && t - lastDeliveredAt > INGRESS_STALL_MS) return 'stalled';
-    if (lastDeliveredAt === null && heartbeatCount === 0) return 'unknown';
+    // A degraded capture (client recovery exhausted) is worth surfacing even
+    // muted — the input will still be dead on unmute.
+    if (hbFresh && lastHb?.captureState === 'd') return 'degraded';
+    // Mute is a user choice, not an input failure — nothing below can
+    // conclude 'stalled' while muted.
+    if (muted && hbFresh) return 'ok';
+    // Client-reported evidence counts only while its heartbeat is FRESH — a
+    // detached client's retained open gap must not report stalled forever.
+    if (hbFresh && lastHb) {
+      if (lastHb.openGap) return 'stalled';
+      if (lastHb.ctxState === 's' || lastHb.ctxState === 'c') return 'stalled';
+    }
+    if (lastDeliveredAt !== null && t - lastDeliveredAt > INGRESS_STALL_MS) return 'stalled';
+    if (lastDeliveredAt === null) {
+      // Heartbeats crossing while NO PCM has ever reached the session is a
+      // stall, not health (codex round-2 #4).
+      return heartbeatCount > 0 ? 'stalled' : 'unknown';
+    }
     return 'ok';
   }
 
@@ -464,6 +528,11 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
 
     onClientConnected(): void {
       resetEpochState();
+      // The design mints the epoch HERE: a connection that dies before its
+      // first heartbeat still persists rows under a real epoch. The client's
+      // nonce binds on first heartbeat sight.
+      epoch = mintEpoch();
+      log(`[AudioHealth] epoch ${epoch} minted (client connected; nonce pending)`);
     },
 
     onClientDisconnected(): void {
@@ -499,6 +568,7 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
         newEpisodeIds: [...newEpisodeIds],
         samplesSkipped,
         lastTurnLatencyMs,
+        lastSpeechToModelMs,
         inputHealth: inputHealth(clientConnected),
         epochStartApproxMs,
         lastMatrixVerdict,
@@ -509,7 +579,7 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
       lastMatrixVerdict = verdict;
     },
 
-    healthSegments(clientConnected: boolean): string {
+    healthSegments(clientConnected: boolean, serverBufferedAmount?: number | null): string {
       const t = now();
       const dt = Math.max(0.001, (t - prevTickAt) / 1000);
       const inFps = (deliveredFrames - prevDeliveredFrames) / dt;
@@ -524,7 +594,9 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
       const up = 'up=n/a';
       const endedLag =
         lastHb?.lastEndedAgoMs != null ? (lastHb.lastEndedAgoMs / 1000).toFixed(1) + 's' : 'n/a';
-      const out = `out={fps:${outFps.toFixed(1)},buffered:${lastHb?.bufferedAmount ?? 'n/a'},endedLag:${endedLag}}`;
+      // out.buffered is the SERVER's egress socket toward the client; the
+      // client's own uplink bufferedAmount lives under clientHealth.upBuf.
+      const out = `out={fps:${outFps.toFixed(1)},buffered:${serverBufferedAmount ?? 'n/a'},endedLag:${endedLag}}`;
       let client = 'clientHealth=n/a';
       if (lastHb) {
         const hbAge = ((t - lastHb.receivedAt) / 1000).toFixed(1) + 's';
@@ -537,26 +609,31 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
         // client's own rms travels only as latched episode intervals.
         client =
           `clientHealth={age:${hbAge},capCb/s:${capRate},rms:${ingressRms.toFixed(3)},` +
-          `ctx:${lastHb.ctxState ?? '?'},cap:${lastHb.captureState ?? '?'},gaps:${seenEpisodeIds.size},` +
-          `skip:${clientTotals.sendSkipped}${lastHb.muted ? ',muted' : ''}${lastHb.openGap ? ',STALLED' : ''}}`;
+          `ctx:${lastHb.ctxState ?? '?'},cap:${lastHb.captureState ?? '?'},gaps:${gapEpisodeCount},` +
+          `upBuf:${lastHb.bufferedAmount ?? 'n/a'},skip:${clientTotals.sendSkipped}` +
+          `${lastHb.muted ? ',muted' : ''}${lastHb.openGap ? ',STALLED' : ''}}`;
       }
       const lat = lastTurnLatencyMs != null ? ` latency=${lastTurnLatencyMs}ms` : '';
+      const s2m = lastSpeechToModelMs != null ? ` speech2model=${lastSpeechToModelMs}ms` : '';
       const ep = epoch != null ? ` epoch=${epoch}` : '';
       const health = clientConnected ? inputHealth(true) : 'no-client';
-      return `${audioIn} ${up} ${out} ${client}${ep}${lat} inputHealth=${health}`;
+      return `${audioIn} ${up} ${out} ${client}${ep}${lat}${s2m} inputHealth=${health}`;
     },
 
-    anomalySinceLastTick(clientConnected: boolean): { anomalous: boolean; reasons: string[] } {
+    anomalies(clientConnected: boolean): { anomalous: boolean; reasons: string[] } {
       const t = now();
       const reasons: string[] = [];
-      if (lastHb?.openGap) reasons.push('capStalled');
+      const hbFresh = lastHb !== null && t - lastHb.receivedAt <= HEARTBEAT_STALE_MS;
+      const muted = lastHb?.muted ?? false;
+      // Client-reported stall evidence only counts while attached, unmuted,
+      // and FRESH — a detached client's retained open gap is not a live
+      // anomaly (codex round-2 #4).
+      if (clientConnected && !muted && hbFresh && lastHb?.openGap) reasons.push('capStalled');
       if (newEpisodeIds.length > 0) reasons.push(`episodes:${newEpisodeIds.length}`);
-      if (clientConnected && lastHb && t - lastHb.receivedAt > HEARTBEAT_STALE_MS) {
-        reasons.push('heartbeat-stale');
-      }
+      if (clientConnected && lastHb && !hbFresh) reasons.push('heartbeat-stale');
       if (
         clientConnected &&
-        !(lastHb?.muted ?? false) &&
+        !muted &&
         lastDeliveredAt !== null &&
         t - lastDeliveredAt > INGRESS_STALL_MS
       ) {
@@ -564,18 +641,34 @@ export function createAudioHealthLedger(opts: AudioHealthOptions): AudioHealthLe
       }
       if (sendSkippedGrew) reasons.push('sendSkipped');
       if (samplesSkipped > prevSamplesSkipped) reasons.push('persistSkipped');
-      // Clear the per-tick latches (counters themselves stay monotonic).
+      return { anomalous: reasons.length > 0, reasons };
+    },
+
+    clearTickLatches(): void {
       newEpisodeIds = [];
       sendSkippedGrew = false;
       prevSamplesSkipped = samplesSkipped;
-      return { anomalous: reasons.length > 0, reasons };
     },
 
     persistTick(reason: 'timer' | 'anomaly' | 'final', clientConnected: boolean): void {
       if (!opts.persist) return;
       const snapshot = this.getSnapshot(clientConnected);
       let payload = JSON.stringify(snapshot);
-      if (payload.length > PERSIST_PAYLOAD_MAX_BYTES) payload = payload.slice(0, PERSIST_PAYLOAD_MAX_BYTES);
+      if (Buffer.byteLength(payload) > PERSIST_PAYLOAD_MAX_BYTES) {
+        // Never slice a JSON document mid-string: over budget, persist a
+        // reduced-but-VALID snapshot with the truncation named.
+        payload = JSON.stringify({
+          truncated: true,
+          coverage: snapshot.coverage,
+          epoch: snapshot.epoch,
+          nonce: snapshot.nonce,
+          inputHealth: snapshot.inputHealth,
+          deliveredFrames: snapshot.deliveredFrames,
+          egressFrames: snapshot.egressFrames,
+          samplesSkipped: snapshot.samplesSkipped,
+          lastMatrixVerdict: snapshot.lastMatrixVerdict,
+        });
+      }
       const row: HealthRow = {
         tsUnix: Math.floor(now() / 1000),
         sessionId: opts.sessionId,

--- a/src/voice-continuity.ts
+++ b/src/voice-continuity.ts
@@ -1,0 +1,74 @@
+// voice-continuity — P7 D7.3 continuity helpers (Tranche A engine-side):
+// the stale-repeat goodbye guard and the centralized conversation-clear.
+// Both are policy the voice agent previously carried inline in three places;
+// centralizing them is the fix for G-P7-8 (a clear path that empties bodhi's
+// conversationContext without rebasing the transcript cursor makes the
+// turn.end logger skip every item that accumulates after the clear).
+
+/** State for the stale-repeat goodbye guard. */
+export interface GoodbyeGuardState {
+  lastText: string | null;
+  userTurnsAtFire: number;
+}
+
+export function initialGoodbyeGuard(): GoodbyeGuardState {
+  return { lastText: null, userTurnsAtFire: -1 };
+}
+
+/**
+ * Should a strict-detected farewell fire session_end? A reconnect replay can
+ * make the model repeat the SAME short farewell with no new real user turn —
+ * that repeat must not re-fire the end-session machinery (the 2026-04-09
+ * replay-contamination class; D7.3 Tranche A interim until bodhi's
+ * epoch-fenced boundary lands). Pure: returns the decision plus next state.
+ */
+export function shouldFireGoodbye(
+  state: GoodbyeGuardState,
+  lastText: string,
+  userTurnCount: number,
+): { fire: boolean; next: GoodbyeGuardState } {
+  if (state.lastText !== null && lastText === state.lastText && userTurnCount <= state.userTurnsAtFire) {
+    return { fire: false, next: state };
+  }
+  return { fire: true, next: { lastText, userTurnsAtFire: userTurnCount } };
+}
+
+export interface ConversationClearHelper {
+  /** The turn.end logger's cursor into conversationContext.items. */
+  cursor: { index: number };
+  /** Empty the items array IN PLACE (it is getter-backed — reassignment
+   *  throws) and rebase the cursor with it. Returns items cleared. */
+  clear(reason: string): number;
+}
+
+/**
+ * The ONE way to empty bodhi's conversationContext (used by end_session, the
+ * goodbye detector, and the sessionEnding turn.end sweep). Items and cursor
+ * move together, always.
+ */
+export function createConversationClearHelper(
+  getItems: () => unknown,
+  log: (line: string) => void = () => {},
+): ConversationClearHelper {
+  const cursor = { index: 0 };
+  return {
+    cursor,
+    clear(reason: string): number {
+      let cleared = 0;
+      try {
+        const items = getItems();
+        if (Array.isArray(items) && items.length > 0) {
+          cleared = items.length;
+          items.length = 0;
+        }
+      } catch (e) {
+        log(`[clear-items] ${reason}: could not clear conversationContext: ${e}`);
+      }
+      // The cursor rebases even when the array was empty or unreadable — a
+      // stale cursor against an emptied array is exactly the G-P7-8 bug.
+      cursor.index = 0;
+      if (cleared > 0) log(`[clear-items] ${reason}: cleared ${cleared} conversationContext items`);
+      return cleared;
+    },
+  };
+}

--- a/src/voice-continuity.ts
+++ b/src/voice-continuity.ts
@@ -33,6 +33,37 @@ export function shouldFireGoodbye(
   return { fire: true, next: { lastText, userTurnsAtFire: userTurnCount } };
 }
 
+/**
+ * Clear a dead session's Gemini resumption handle before a fresh reconnect
+ * (field incident 2026-08-14): when Gemini invalidates a session it closes
+ * 1008 "Requested entity was not found", bodhi transitions ACTIVE→CLOSED —
+ * but nothing clears `transport.config.resumptionHandle`, and the CLOSED→
+ * fresh-connect path replays it in `sessionResumption: { handle }`. Gemini
+ * completes setup, then kills each new connection the same way (observed
+ * survival staircase: 9 min → 18 s → 0.9 s). Clearing costs nothing here:
+ * this path already rebuilds context via text injection, never via resume;
+ * mid-session GoAway resume (the legitimate handle use) does not run
+ * through it. Returns true when a stale handle was actually cleared.
+ * Pin-workaround: belongs in bodhi's handleTransportClose (Tranche B).
+ */
+export function clearStaleResumptionHandle(session: unknown): boolean {
+  let cleared = false;
+  try {
+    const s = session as {
+      transport?: { config?: { resumptionHandle?: string } };
+      sessionManager?: { clearResumptionHandle?: () => void };
+    };
+    if (s?.transport?.config?.resumptionHandle) {
+      s.transport.config.resumptionHandle = undefined;
+      cleared = true;
+    }
+    s?.sessionManager?.clearResumptionHandle?.();
+  } catch {
+    /* a missing seam must never break the reconnect path */
+  }
+  return cleared;
+}
+
 export interface ConversationClearHelper {
   /** The turn.end logger's cursor into conversationContext.items. */
   cursor: { index: number };

--- a/src/voice-health-matrix.ts
+++ b/src/voice-health-matrix.ts
@@ -26,6 +26,10 @@ export type MatrixVerdict =
 /** Counter values the next tick diffs against (returned by every evaluation). */
 export interface MatrixBaseline {
   at: number;
+  /** The epoch the counters belong to — deltas NEVER cross epochs (a
+   *  reconnect resets every counter; a cross-epoch diff would be negative
+   *  garbage that still pattern-matches). */
+  epoch: number | null;
   deliveredFrames: number;
   capCallbacks: number;
   bytesSent: number;
@@ -33,6 +37,7 @@ export interface MatrixBaseline {
   chunksRecv: number;
   chunksScheduled: number;
   chunksEnded: number;
+  chunksCancelled: number;
   ctxTimeMs: number | null;
   bufferedAmount: number | null;
   serverBufferedAmount: number | null;
@@ -73,10 +78,12 @@ export const PLAYBACK_MIN_CHUNKS = 5;
 function makeBaseline(input: MatrixInput): MatrixBaseline {
   const s = input.snapshot;
   const hb = s.lastHeartbeat;
-  let maxEpisodeId = input.prev?.maxEpisodeId ?? 0;
+  const sameEpoch = input.prev?.epoch === s.epoch;
+  let maxEpisodeId = sameEpoch ? (input.prev?.maxEpisodeId ?? 0) : 0;
   for (const e of hb?.episodes ?? []) if (e.id > maxEpisodeId) maxEpisodeId = e.id;
   return {
     at: input.now,
+    epoch: s.epoch,
     deliveredFrames: s.deliveredFrames,
     capCallbacks: s.clientTotals.capCallbacks,
     bytesSent: s.clientTotals.bytesSent,
@@ -84,7 +91,8 @@ function makeBaseline(input: MatrixInput): MatrixBaseline {
     chunksRecv: s.clientTotals.chunksRecv,
     chunksScheduled: s.clientTotals.chunksScheduled,
     chunksEnded: s.clientTotals.chunksEnded,
-    ctxTimeMs: hb?.ctxTimeMs ?? input.prev?.ctxTimeMs ?? null,
+    chunksCancelled: s.clientTotals.chunksCancelled,
+    ctxTimeMs: hb?.ctxTimeMs ?? (sameEpoch ? (input.prev?.ctxTimeMs ?? null) : null),
     bufferedAmount: hb?.bufferedAmount ?? null,
     serverBufferedAmount: input.serverBufferedAmount ?? null,
     maxEpisodeId,
@@ -113,10 +121,14 @@ export function evaluateMatrix(input: MatrixInput): MatrixResult {
   if (!input.clientConnected) {
     return out('healthy-idle', 'no-client-attached');
   }
-  if (!hb || !prev) {
-    // No heartbeat yet (or no prior tick to diff against): nothing below can
-    // be computed as a delta — never guess.
-    return out('insufficient-evidence', !hb ? 'no-client-heartbeat' : 'first-tick-no-baseline');
+  if (!hb || !prev || prev.epoch !== s.epoch) {
+    // No heartbeat yet, no prior tick, or an epoch boundary since the last
+    // tick: nothing below can be computed as a same-epoch delta — never
+    // guess (a cross-epoch diff is negative garbage that still matches).
+    return out(
+      'insufficient-evidence',
+      !hb ? 'no-client-heartbeat' : !prev ? 'first-tick-no-baseline' : 'epoch-boundary',
+    );
   }
   const hbStale = now - hb.receivedAt > 8_000;
 
@@ -127,6 +139,7 @@ export function evaluateMatrix(input: MatrixInput): MatrixResult {
   const dChunksRecv = s.clientTotals.chunksRecv - prev.chunksRecv;
   const dChunksScheduled = s.clientTotals.chunksScheduled - prev.chunksScheduled;
   const dChunksEnded = s.clientTotals.chunksEnded - prev.chunksEnded;
+  const dChunksCancelled = s.clientTotals.chunksCancelled - prev.chunksCancelled;
   const muted = hb.muted;
   const ingressStalled =
     s.lastDeliveredAt === null || now - s.lastDeliveredAt > MATRIX_INGRESS_STALL_MS;
@@ -183,6 +196,32 @@ export function evaluateMatrix(input: MatrixInput): MatrixResult {
     }
   }
 
+  // ── Row 5: model silent (evaluated BEFORE rows 6/7 — the D7.2 table
+  // order; speech with no model response outranks backpressure findings).
+  // Speech evidence is the CANONICAL server-ingress tracker only — a stale
+  // client speech episode idempotently re-sent in the heartbeat window is
+  // NOT current-window evidence.
+  const speech = s.speech;
+  const speechInWindow =
+    speech.active || (speech.lastAboveFloorAt !== null && now - speech.lastAboveFloorAt < 30_000);
+  if (speechInWindow && dDelivered > 0) {
+    const modelSilent =
+      input.lastModelEventAt == null || now - input.lastModelEventAt > 15_000;
+    if (modelSilent) {
+      if (s.coverage !== ('full' as string)) {
+        // Speech reached the session and nothing came back — but the
+        // upstream-send hop is unobserved, so blaming the model would be a
+        // guess (the design's honesty rule).
+        return out(
+          'insufficient-evidence',
+          'speech-without-model-event',
+          'upstream-hop-unobserved(coverage:session-only)',
+        );
+      }
+      return out('model-silent', 'speech-in-window', 'no-model-event');
+    }
+  }
+
   // ── Row 6: client send backpressure (FE-1 class, client side) ──
   const bufferedGrowing =
     hb.bufferedAmount !== null &&
@@ -211,43 +250,41 @@ export function evaluateMatrix(input: MatrixInput): MatrixResult {
 
   // ── Row 7b: client playback failure ──
   // Scheduling proves delivery; NATURAL completion + ctx-clock advancement
-  // prove playback (cancellations excluded by construction — chunksEnded
-  // never counts them). Completion ≠ audibility, stated.
-  if (dChunksScheduled >= PLAYBACK_MIN_CHUNKS && dChunksEnded === 0) {
+  // prove playback. Cancellations are excluded BOTH ways: chunksEnded never
+  // counts them, and a window where (nearly) everything scheduled was
+  // cancelled (barge-in flush) proves nothing about the output path.
+  const dEffectiveScheduled = dChunksScheduled - dChunksCancelled;
+  if (dEffectiveScheduled >= PLAYBACK_MIN_CHUNKS && dChunksEnded === 0) {
     const ctxAdvanced =
       hb.ctxTimeMs !== null && prev.ctxTimeMs !== null && hb.ctxTimeMs > prev.ctxTimeMs;
     if (!ctxAdvanced) {
       return out(
         'client-playback-failure',
         `scheduled+=${dChunksScheduled}`,
+        `cancelled+=${dChunksCancelled}`,
         'no-natural-completions',
         `ctxTime=${hb.ctxTimeMs ?? 'n/a'}`,
       );
     }
   }
 
-  // ── Row 5 / 5′: speech vs idle ──
-  const speech = s.speech;
-  const speechInWindow =
-    speech.active ||
-    (speech.lastAboveFloorAt !== null && now - speech.lastAboveFloorAt < 30_000) ||
-    hb.episodes.some((e) => e.kind === 'speech');
-  if (speechInWindow && dDelivered > 0) {
-    const modelSilent = input.lastModelEventAt == null || now - input.lastModelEventAt > 15_000;
-    if (modelSilent) {
-      if (s.coverage !== ('full' as string)) {
-        // Speech reached the session and nothing came back — but the
-        // upstream-send hop is unobserved, so blaming the model would be a
-        // guess (the design's honesty rule).
-        return out(
-          'insufficient-evidence',
-          'speech-without-model-event',
-          'upstream-hop-unobserved(coverage:session-only)',
-        );
-      }
-      return out('model-silent', 'speech-in-window', 'no-model-event');
-    }
+  // ── Totality before the idle default (round-3 #3): a verdict of
+  // healthy-idle must rest on EVIDENCE of health, not its absence. ──
+  if (hb.episodeOverflow > 0) {
+    // Episode evidence was lost client-side; the window cannot prove the
+    // quiet period was quiet.
+    return out('insufficient-evidence', `episodeOverflow=${hb.episodeOverflow}`);
+  }
+  if (hbStale) {
+    return out('insufficient-evidence', 'heartbeat-stale');
+  }
+  if (!muted && dCapCallbacks === 0 && dDelivered === 0) {
+    // Nothing progressed anywhere this window while unmuted: that is not a
+    // quietly listening user, it is missing telemetry (row 5′ requires the
+    // layers to be ADVANCING).
+    return out('insufficient-evidence', 'no-progress-in-window');
   }
 
+  // ── Row 5′: a quietly listening user is not an incident. ──
   return out('healthy-idle');
 }

--- a/src/voice-health-matrix.ts
+++ b/src/voice-health-matrix.ts
@@ -1,0 +1,253 @@
+// voice-health-matrix — P7 D7.2: the failure-localization matrix. A pure
+// function over the engine ledger snapshot with HONEST outcomes: a partial
+// ledger (coverage 'session-only', missing heartbeats, a reconnect window)
+// can never produce a confident verdict about the layers the partiality
+// obscures. Rows 2–4 (native server dispositions) therefore stay unreachable
+// until the bodhi tranche flips coverage to 'full'; their patterns surface as
+// `insufficient-evidence` with the blind hop named. Evaluated per 30 s health
+// tick; the caller logs the verdict and notes it into the ledger for
+// persistence.
+
+import type { AudioHealthSnapshot } from './voice-audio-health.js';
+
+export type MatrixVerdict =
+  | 'reconnect-window'
+  | 'insufficient-evidence'
+  | 'client-capture-dead' // row 1
+  | 'server-accounting-inconsistency' // row 2 [needs native counters]
+  | 'server-discarding' // row 3 [needs native counters]
+  | 'upstream-send-dead' // row 4 [needs native counters]
+  | 'model-silent' // row 5 (the honest F4 residue)
+  | 'client-send-backpressure' // row 6
+  | 'egress-backpressure' // row 7a
+  | 'client-playback-failure' // row 7b
+  | 'healthy-idle'; // row 5′ + default
+
+/** Counter values the next tick diffs against (returned by every evaluation). */
+export interface MatrixBaseline {
+  at: number;
+  deliveredFrames: number;
+  capCallbacks: number;
+  bytesSent: number;
+  sendSkipped: number;
+  chunksRecv: number;
+  chunksScheduled: number;
+  chunksEnded: number;
+  ctxTimeMs: number | null;
+  bufferedAmount: number | null;
+  serverBufferedAmount: number | null;
+  maxEpisodeId: number;
+}
+
+export interface MatrixInput {
+  /** bodhi sessionManager.state (RECONNECTING/CONNECTING ⇒ row 0). */
+  sessionState: string;
+  clientConnected: boolean;
+  snapshot: AudioHealthSnapshot;
+  /** Previous tick's baseline (null on the first evaluation). */
+  prev: MatrixBaseline | null;
+  /** Server-side ws bufferedAmount toward the client (row 7a); absent ⇒ that
+   *  pattern is insufficient-evidence. */
+  serverBufferedAmount?: number | null;
+  /** Last model event timestamp (row 5); absent ⇒ unknown. */
+  lastModelEventAt?: number | null;
+  now: number;
+}
+
+export interface MatrixResult {
+  verdict: MatrixVerdict;
+  reasons: string[];
+  baseline: MatrixBaseline;
+}
+
+/** An episode (or open gap) is only row-1 evidence while fresh. */
+export const EPISODE_UNEXPIRED_MS = 90_000;
+
+/** Ingress considered stalled for matrix purposes past this. */
+export const MATRIX_INGRESS_STALL_MS = 5_000;
+
+/** Minimum playback chunks scheduled in a window before row 7b can fire
+ *  (turn boundaries legitimately schedule little). */
+export const PLAYBACK_MIN_CHUNKS = 5;
+
+function makeBaseline(input: MatrixInput): MatrixBaseline {
+  const s = input.snapshot;
+  const hb = s.lastHeartbeat;
+  let maxEpisodeId = input.prev?.maxEpisodeId ?? 0;
+  for (const e of hb?.episodes ?? []) if (e.id > maxEpisodeId) maxEpisodeId = e.id;
+  return {
+    at: input.now,
+    deliveredFrames: s.deliveredFrames,
+    capCallbacks: s.clientTotals.capCallbacks,
+    bytesSent: s.clientTotals.bytesSent,
+    sendSkipped: s.clientTotals.sendSkipped,
+    chunksRecv: s.clientTotals.chunksRecv,
+    chunksScheduled: s.clientTotals.chunksScheduled,
+    chunksEnded: s.clientTotals.chunksEnded,
+    ctxTimeMs: hb?.ctxTimeMs ?? input.prev?.ctxTimeMs ?? null,
+    bufferedAmount: hb?.bufferedAmount ?? null,
+    serverBufferedAmount: input.serverBufferedAmount ?? null,
+    maxEpisodeId,
+  };
+}
+
+/**
+ * Evaluate the matrix. First matching row wins, in the design's order; the
+ * default outcome is `healthy-idle` (a quietly listening user is not an
+ * incident — row 5′).
+ */
+export function evaluateMatrix(input: MatrixInput): MatrixResult {
+  const { snapshot: s, prev, now } = input;
+  const hb = s.lastHeartbeat;
+  const baseline = makeBaseline(input);
+  const out = (verdict: MatrixVerdict, ...reasons: string[]): MatrixResult => ({
+    verdict,
+    reasons,
+    baseline,
+  });
+
+  // ── Row 0: reconnect window / structural insufficiency ──
+  if (input.sessionState === 'RECONNECTING' || input.sessionState === 'CONNECTING') {
+    return out('reconnect-window', `session=${input.sessionState}`);
+  }
+  if (!input.clientConnected) {
+    return out('healthy-idle', 'no-client-attached');
+  }
+  if (!hb || !prev) {
+    // No heartbeat yet (or no prior tick to diff against): nothing below can
+    // be computed as a delta — never guess.
+    return out('insufficient-evidence', !hb ? 'no-client-heartbeat' : 'first-tick-no-baseline');
+  }
+  const hbStale = now - hb.receivedAt > 8_000;
+
+  const dDelivered = s.deliveredFrames - prev.deliveredFrames;
+  const dCapCallbacks = s.clientTotals.capCallbacks - prev.capCallbacks;
+  const dBytesSent = s.clientTotals.bytesSent - prev.bytesSent;
+  const dSendSkipped = s.clientTotals.sendSkipped - prev.sendSkipped;
+  const dChunksRecv = s.clientTotals.chunksRecv - prev.chunksRecv;
+  const dChunksScheduled = s.clientTotals.chunksScheduled - prev.chunksScheduled;
+  const dChunksEnded = s.clientTotals.chunksEnded - prev.chunksEnded;
+  const muted = hb.muted;
+  const ingressStalled =
+    s.lastDeliveredAt === null || now - s.lastDeliveredAt > MATRIX_INGRESS_STALL_MS;
+
+  // ── Row 1: client capture dead/suspended ──
+  // A CURRENT-epoch, UNEXPIRED gap (or the open gap itself) whose interval
+  // overlaps the ingress stall, while unmuted + connected. An old latched
+  // gap must never pair with unrelated later silence (round-3 #3).
+  if (!muted && ingressStalled) {
+    const stallStartedAt = s.lastDeliveredAt ?? now - MATRIX_INGRESS_STALL_MS;
+    let evidence: string | null = null;
+    if (hb.openGap && !hbStale) {
+      const gapStartAbs = hb.receivedAt - hb.openGap.ageMs;
+      if (gapStartAbs <= stallStartedAt + 2_000) evidence = `open-gap age=${hb.openGap.ageMs}ms`;
+    }
+    if (!evidence && s.epochStartApproxMs !== null) {
+      for (const e of hb.episodes) {
+        if (e.kind !== 'gap' || e.startMs === undefined || e.durationMs === undefined) continue;
+        const endAbs = s.epochStartApproxMs + e.startMs + e.durationMs;
+        if (now - endAbs > EPISODE_UNEXPIRED_MS) continue; // expired — not current evidence
+        // Overlap (±2 s receipt-time tolerance): the gap must cover part of
+        // the ingress stall, not merely precede it.
+        if (endAbs >= stallStartedAt - 2_000) {
+          evidence = `gap-episode id=${e.id} dur=${e.durationMs}ms`;
+          break;
+        }
+      }
+    }
+    if (evidence) {
+      // Discriminate the S1/S2 shapes from the episode fields that travel.
+      const shape =
+        hb.ctxState === 's'
+          ? 'ctx-suspended'
+          : hb.ctxSuspendCount > 0
+            ? 'post-suspension'
+            : hb.captureState === 'r' || hb.captureState === 'd'
+              ? 'device-recovery'
+              : 'main-thread-gap';
+      return out('client-capture-dead', evidence, `shape=${shape}`, `ctx=${hb.ctxState ?? '?'}`);
+    }
+  }
+
+  // ── Rows 2–4: native server dispositions — unreachable at session-only ──
+  if (s.coverage !== ('full' as string)) {
+    // The patterns these rows need (received/buffered/eligible/sdkSend
+    // counters) do not exist yet; if the observable half of the pattern is
+    // present, say WHY the verdict cannot be issued.
+    if ((dCapCallbacks > 0 || dBytesSent > 0) && dDelivered === 0 && !muted && !hbStale) {
+      return out(
+        'insufficient-evidence',
+        'client-sending-but-session-delivery-stalled',
+        'server-ingress-chain-unobserved(coverage:session-only)',
+      );
+    }
+  }
+
+  // ── Row 6: client send backpressure (FE-1 class, client side) ──
+  const bufferedGrowing =
+    hb.bufferedAmount !== null &&
+    prev.bufferedAmount !== null &&
+    hb.bufferedAmount > prev.bufferedAmount &&
+    hb.bufferedAmount > 0;
+  if (bufferedGrowing || dSendSkipped > 0) {
+    return out(
+      'client-send-backpressure',
+      `bufferedAmount=${hb.bufferedAmount ?? 'n/a'}`,
+      `sendSkipped+=${dSendSkipped}`,
+    );
+  }
+
+  // ── Row 7a: server→client egress backpressure ──
+  if (input.serverBufferedAmount != null && prev.serverBufferedAmount != null) {
+    if (
+      input.serverBufferedAmount > prev.serverBufferedAmount &&
+      input.serverBufferedAmount > 0 &&
+      dChunksRecv === 0 &&
+      s.egressFrames > 0
+    ) {
+      return out('egress-backpressure', `serverBuffered=${input.serverBufferedAmount}`);
+    }
+  }
+
+  // ── Row 7b: client playback failure ──
+  // Scheduling proves delivery; NATURAL completion + ctx-clock advancement
+  // prove playback (cancellations excluded by construction — chunksEnded
+  // never counts them). Completion ≠ audibility, stated.
+  if (dChunksScheduled >= PLAYBACK_MIN_CHUNKS && dChunksEnded === 0) {
+    const ctxAdvanced =
+      hb.ctxTimeMs !== null && prev.ctxTimeMs !== null && hb.ctxTimeMs > prev.ctxTimeMs;
+    if (!ctxAdvanced) {
+      return out(
+        'client-playback-failure',
+        `scheduled+=${dChunksScheduled}`,
+        'no-natural-completions',
+        `ctxTime=${hb.ctxTimeMs ?? 'n/a'}`,
+      );
+    }
+  }
+
+  // ── Row 5 / 5′: speech vs idle ──
+  const speech = s.speech;
+  const speechInWindow =
+    speech.active ||
+    (speech.lastAboveFloorAt !== null && now - speech.lastAboveFloorAt < 30_000) ||
+    hb.episodes.some((e) => e.kind === 'speech');
+  if (speechInWindow && dDelivered > 0) {
+    const modelSilent = input.lastModelEventAt == null || now - input.lastModelEventAt > 15_000;
+    if (modelSilent) {
+      if (s.coverage !== ('full' as string)) {
+        // Speech reached the session and nothing came back — but the
+        // upstream-send hop is unobserved, so blaming the model would be a
+        // guess (the design's honesty rule).
+        return out(
+          'insufficient-evidence',
+          'speech-without-model-event',
+          'upstream-hop-unobserved(coverage:session-only)',
+        );
+      }
+      return out('model-silent', 'speech-in-window', 'no-model-event');
+    }
+  }
+
+  return out('healthy-idle');
+}

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2427,17 +2427,59 @@ function updateVisionPreviewStats() {
   if (stats) stats.textContent = _visionFrameCount + ' frame' + (_visionFrameCount === 1 ? '' : 's');
 }
 
+// P7 D7.4: this page's main thread also runs the voice capture
+// (ScriptProcessor in the vendored transport) — drawImage + JPEG encode
+// there competes with audio. A tiny Blob-URL worker does the draw + encode
+// in an OffscreenCanvas; the main thread only grabs a cheap ImageBitmap.
+// One frame in flight at a time (latest-frame discipline, no backlog).
+var _visionWorker = null;
+var _visionWorkerBusy = false;
+function ensureVisionWorker() {
+  if (_visionWorker !== null) return _visionWorker;
+  if (typeof OffscreenCanvas === 'undefined' || typeof createImageBitmap === 'undefined' || typeof Worker === 'undefined') {
+    _visionWorker = false; // feature-detected once; falsy → main-thread fallback
+    return _visionWorker;
+  }
+  var src = 'onmessage=async function(e){var d=e.data;try{' +
+    'var c=new OffscreenCanvas(d.w,d.h);var x=c.getContext("2d");' +
+    'x.drawImage(d.bmp,0,0,d.w,d.h);d.bmp.close();' +
+    'var b=await c.convertToBlob({type:"image/jpeg",quality:d.q});' +
+    'postMessage({ok:true,blob:b});}catch(err){postMessage({ok:false});}}';
+  try {
+    _visionWorker = new Worker(URL.createObjectURL(new Blob([src], { type: 'text/javascript' })));
+    _visionWorker.onmessage = function(e) {
+      _visionWorkerBusy = false;
+      if (e.data && e.data.ok && e.data.blob) _postVisionBlob(e.data.blob);
+    };
+    _visionWorker.onerror = function() { _visionWorkerBusy = false; };
+  } catch (e) { _visionWorker = false; }
+  return _visionWorker;
+}
+
 function captureAndSendFrame() {
   var preview = document.getElementById('vision-preview');
   if (!preview || !_visionStream) return;
   // Wait for the video to actually have pixels — readyState >= HAVE_CURRENT_DATA (2)
   if (preview.readyState < 2 || !preview.videoWidth || !preview.videoHeight) return;
+  var worker = ensureVisionWorker();
+  if (worker) {
+    if (_visionWorkerBusy) return; // latest-frame: skip, never queue
+    _visionWorkerBusy = true;
+    createImageBitmap(preview).then(function(bmp) {
+      worker.postMessage({ bmp: bmp, w: VISION_FRAME_WIDTH, h: VISION_FRAME_HEIGHT, q: VISION_FRAME_QUALITY }, [bmp]);
+    }).catch(function() { _visionWorkerBusy = false; });
+    return;
+  }
+  // Fallback (no OffscreenCanvas): the original main-thread canvas path.
   if (!_visionCanvas) _visionCanvas = document.createElement('canvas');
   _visionCanvas.width = VISION_FRAME_WIDTH;
   _visionCanvas.height = VISION_FRAME_HEIGHT;
   var ctx = _visionCanvas.getContext('2d');
   ctx.drawImage(preview, 0, 0, VISION_FRAME_WIDTH, VISION_FRAME_HEIGHT);
-  _visionCanvas.toBlob(function(blob) {
+  _visionCanvas.toBlob(function(blob) { _postVisionBlob(blob); }, 'image/jpeg', VISION_FRAME_QUALITY);
+}
+
+function _postVisionBlob(blob) {
     if (!blob) return;
     // Skip blank frames — getDisplayMedia sometimes paints a black frame
     // for the first tick when the user switches surfaces; uploading a
@@ -2467,11 +2509,11 @@ function captureAndSendFrame() {
         }
       }
     }).catch(function() { /* network blip — next tick will retry */ });
-  }, 'image/jpeg', VISION_FRAME_QUALITY);
 }
 
 function teardownPushSession() {
   _visionPushActive = false;
+  _visionWorkerBusy = false; // an in-flight encode must not block the next session's first frame
   if (_visionFrameTimer) { clearInterval(_visionFrameTimer); _visionFrameTimer = null; }
   if (_visionStream) {
     try { _visionStream.getTracks().forEach(function(t) { t.stop(); }); } catch (e) {}

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -446,6 +446,13 @@ export interface VoiceStats {
    *  the engine mints the server epoch and maps this nonce to it on first
    *  sight). */
   epochNonce: string;
+  /** D7.5 lifecycle evidence, epoch-retained (bounded rings; `*Dropped`
+   *  makes truncation visible instead of silent). */
+  ctxLastTransition: { from: string; to: string; at: number } | null;
+  deviceEvents: Array<{ kind: string; at: number }>;
+  deviceEventsDropped: number;
+  recoveryEvents: Array<{ kind: string; result: string; attempt: number; at: number }>;
+  recoveryEventsDropped: number;
 }
 
 /**
@@ -663,6 +670,9 @@ export class VoiceTransport {
   private lastCapAt = 0;
   /** captureBuf / ctx.sampleRate, computed when the graph wires (~43 ms). */
   private expectedFrameMs = 43;
+  /** max(3× expectedFrameMs, CAP_STALL_FLOOR_MS), fixed at graph wire so the
+   *  frame path reads one preallocated field (§D7.0b). */
+  private stallAfterMs = CAP_STALL_FLOOR_MS;
   private capStalled = false;
   /** Absolute ms the open capture gap started at (0 = no open gap). */
   private gapOpenedAt = 0;
@@ -680,8 +690,23 @@ export class VoiceTransport {
   private episodeOverflow = 0;
   private statsTickCount = 0;
   private heartbeatsSent = 0;
+  /** Counter values at the last SUCCESSFULLY SENT heartbeat — the wire
+   *  carries deltas against these (D7.1 compact schema). Advanced only on
+   *  send success, so a failed frame's interval folds into the next one. */
+  private readonly hbPrev = {
+    capCallbacks: 0,
+    bytesSent: 0,
+    sendSkipped: 0,
+    sendFailed: 0,
+    chunksRecv: 0,
+    chunksScheduled: 0,
+    chunksEnded: 0,
+    chunksCancelled: 0,
+  };
   private deviceEvents: Array<{ kind: string; at: number }> = [];
+  private deviceEventsDropped = 0;
   private recoveryEvents: Array<{ kind: string; result: string; attempt: number; at: number }> = [];
+  private recoveryEventsDropped = 0;
 
   // ── P7 D7.5 capture recovery FSM ──
   /** Independent of attemptGen (bumping the attempt would kill the still-live
@@ -689,7 +714,10 @@ export class VoiceTransport {
    *  teardownAudio; every async capture continuation validates BOTH gens. */
   private captureGen = 0;
   private captureState: CaptureState = 'observing';
-  private recoveryActive = false;
+  /** attemptGen that owns the in-flight recovery loop (0 = none). Ownership
+   *  is attempt-scoped: a stale loop (owner ≠ current attempt) is fenced-dead
+   *  and must not swallow the live attempt's triggers. */
+  private recoveryOwner = 0;
   /** A reacquire trigger arrived while a resume-recovery was in flight. */
   private recoveryEscalate = false;
   /** Sorted input-device fingerprint (null = cannot enumerate). */
@@ -1389,6 +1417,11 @@ export class VoiceTransport {
     const ctx = this.audioCtx!;
     this.adoptCtx(ctx);
     this.expectedFrameMs = Math.max(1, Math.round((this.captureBuf / ctx.sampleRate) * 1000));
+    this.stallAfterMs = Math.max(3 * this.expectedFrameMs, CAP_STALL_FLOOR_MS);
+    // Arm the gap clock at wire time: a graph whose FIRST callback never
+    // fires must still produce a gap (baseline = the moment capture should
+    // have started flowing).
+    this.lastCapAt = this.nowFn();
     const source = ctx.createMediaStreamSource(stream);
     const processor = ctx.createScriptProcessor(this.captureBuf, 1, 1);
     this.processor = processor;
@@ -1399,7 +1432,16 @@ export class VoiceTransport {
       // beyond the pinned encode, no I/O beyond the pinned send.
       const now = this.nowFn();
       this.capCallbacks++;
-      if (this.gapOpenedAt > 0) this.closeGapEpisode(now);
+      if (this.gapOpenedAt > 0) {
+        this.closeGapEpisode(now);
+      } else if (this.lastCapAt > 0 && now - this.lastCapAt > this.stallAfterMs) {
+        // Foreground-overwrite (round-1 #7): when the whole thread was
+        // frozen, the watchdog timer froze WITH it — the resumed callback is
+        // the first code to observe the outage, and it must latch the gap
+        // BEFORE overwriting lastCapAt. O(1) preallocated-slot writes.
+        this.gapOpenedAt = this.lastCapAt;
+        this.closeGapEpisode(now);
+      }
       this.lastCapAt = now;
       const raw = e.inputBuffer.getChannelData(0);
       let sum = 0;
@@ -1681,8 +1723,18 @@ export class VoiceTransport {
     this.episodeOverflow = 0;
     this.statsTickCount = 0;
     this.heartbeatsSent = 0;
+    this.hbPrev.capCallbacks = 0;
+    this.hbPrev.bytesSent = 0;
+    this.hbPrev.sendSkipped = 0;
+    this.hbPrev.sendFailed = 0;
+    this.hbPrev.chunksRecv = 0;
+    this.hbPrev.chunksScheduled = 0;
+    this.hbPrev.chunksEnded = 0;
+    this.hbPrev.chunksCancelled = 0;
     this.deviceEvents = [];
+    this.deviceEventsDropped = 0;
     this.recoveryEvents = [];
+    this.recoveryEventsDropped = 0;
     this.captureState = 'observing';
     this.inputDeviceSig = null;
   }
@@ -1751,17 +1803,18 @@ export class VoiceTransport {
     const now = this.nowFn();
     // Watchdog (D7.1): a silent capture past max(3× frame interval, 1 s)
     // while unmuted + connected is a stall. The gap LATCHES as an episode
-    // when capture returns, so a fast resume before the next tick cannot
-    // erase the evidence; a permanent stall travels as the open gap (`og`).
-    const stallAfter = Math.max(3 * this.expectedFrameMs, CAP_STALL_FLOOR_MS);
+    // when capture returns (the frame path also self-latches, for outages
+    // the frozen timer never saw); a permanent stall travels as the open
+    // gap (`og`). Armed while a processor exists OR recovery is in flight —
+    // a reacquire outage (stopMic cleared the processor) is still a gap.
     if (
-      this.processor &&
+      (this.processor || this.captureState !== 'observing') &&
       !this.micMuted &&
       this.ws &&
       this.ws.readyState === WebSocket.OPEN &&
       this.lastCapAt > 0 &&
       this.gapOpenedAt === 0 &&
-      now - this.lastCapAt > stallAfter
+      now - this.lastCapAt > this.stallAfterMs
     ) {
       this.gapOpenedAt = this.lastCapAt;
       this.capStalled = true;
@@ -1795,6 +1848,11 @@ export class VoiceTransport {
       bufferedAmount: this.ws ? this.ws.bufferedAmount || 0 : 0,
       bufferedHighWater: this.bufferedHighWater,
       epochNonce: this.epochNonce,
+      ctxLastTransition: this.ctxLastTransition,
+      deviceEvents: [...this.deviceEvents],
+      deviceEventsDropped: this.deviceEventsDropped,
+      recoveryEvents: [...this.recoveryEvents],
+      recoveryEventsDropped: this.recoveryEventsDropped,
     };
   }
 
@@ -1810,7 +1868,9 @@ export class VoiceTransport {
    *   t   'audio_health'
    *   n   epoch nonce (engine maps nonce→server epoch on first sight)
    *   q   heartbeat seq within the epoch
-   *   c   [capCallbacks, bytesSent, sendSkipped, sendFailed, chunksRecv,
+   *   c   DELTAS since the last successfully-sent heartbeat (lossless: a
+   *       failed/skipped frame's interval folds into the next delta):
+   *       [capCallbacks, bytesSent, sendSkipped, sendFailed, chunksRecv,
    *        chunksScheduled, chunksEnded, chunksCancelled]
    *   x   [ctxTimeMs|-1, scheduledDepth, lastEndedAgoMs|-1]
    *   cs  ctx state initial ('r'unning | 's'uspended | 'c'losed)
@@ -1824,6 +1884,10 @@ export class VoiceTransport {
    *   ep  ≤4 entries, oldest→newest:
    *       gap    [id, 'g', startRelMs, durationMs]
    *       speech [id, 's', onsetSeq, offsetSeq, maxRmsPm, aboveFloorMs]
+   *
+   * The ≤300 B cap holds by construction: episodes trim oldest-first, and if
+   * the episode-free frame still exceeds the cap, diagnostic fields drop in
+   * the order x → ba → sc (never the core evidence: n/q/c/cs/cap/mu/og/eo).
    */
   private sendAudioHealth(now: number): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
@@ -1832,14 +1896,14 @@ export class VoiceTransport {
       n: this.epochNonce,
       q: this.heartbeatsSent,
       c: [
-        this.capCallbacks,
-        this.bytesSent,
-        this.sendSkipped,
-        this.sendFailed,
-        this.audioChunksRecv,
-        this.chunksScheduled,
-        this.chunksEnded,
-        this.chunksCancelled,
+        this.capCallbacks - this.hbPrev.capCallbacks,
+        this.bytesSent - this.hbPrev.bytesSent,
+        this.sendSkipped - this.hbPrev.sendSkipped,
+        this.sendFailed - this.hbPrev.sendFailed,
+        this.audioChunksRecv - this.hbPrev.chunksRecv,
+        this.chunksScheduled - this.hbPrev.chunksScheduled,
+        this.chunksEnded - this.hbPrev.chunksEnded,
+        this.chunksCancelled - this.hbPrev.chunksCancelled,
       ],
       x: [
         this.audioCtx ? Math.round(this.audioCtx.currentTime * 1000) : -1,
@@ -1898,6 +1962,15 @@ export class VoiceTransport {
       if (enc.encode(payload).byteLength <= AUDIO_HEALTH_MAX_BYTES || window.length === 0) break;
       window.shift(); // drop oldest — it re-sends next beat (or surfaces in eo)
     }
+    // Episode-free frame still over the cap (extreme counter widths): drop
+    // diagnostics in fixed order, keeping the core evidence intact.
+    for (const key of ['x', 'ba', 'sc'] as const) {
+      if (enc.encode(payload).byteLength <= AUDIO_HEALTH_MAX_BYTES) break;
+      if (frame[key] !== undefined) {
+        delete frame[key];
+        payload = JSON.stringify(frame);
+      }
+    }
     try {
       this.ws.send(payload);
     } catch {
@@ -1905,6 +1978,15 @@ export class VoiceTransport {
     }
     this.heartbeatsSent++;
     for (const s of window) s.sent = true;
+    // Advance the delta baseline only after a SUCCESSFUL send.
+    this.hbPrev.capCallbacks = this.capCallbacks;
+    this.hbPrev.bytesSent = this.bytesSent;
+    this.hbPrev.sendSkipped = this.sendSkipped;
+    this.hbPrev.sendFailed = this.sendFailed;
+    this.hbPrev.chunksRecv = this.audioChunksRecv;
+    this.hbPrev.chunksScheduled = this.chunksScheduled;
+    this.hbPrev.chunksEnded = this.chunksEnded;
+    this.hbPrev.chunksCancelled = this.chunksCancelled;
   }
 
   // ─── P7 D7.5 capture recovery FSM ───────────────────────────
@@ -1948,24 +2030,32 @@ export class VoiceTransport {
    * from a superseded attempt can never overwrite a newer graph.
    */
   private async startRecovery(kind: 'resume' | 'reacquire'): Promise<void> {
-    if (this.recoveryActive) {
-      // Coalesce: device loss during a resume-recovery upgrades the next
-      // attempt to a full reacquire; a same-kind re-trigger is already
-      // covered by the running loop.
+    if (this.recoveryOwner === this.attemptGen) {
+      // Coalesce into the LIVE attempt's loop: device loss during a
+      // resume-recovery upgrades its next attempt to a full reacquire; a
+      // same-kind re-trigger is already covered.
       if (kind === 'reacquire') this.recoveryEscalate = true;
       return;
     }
-    this.recoveryActive = true;
+    // Any other owner is a stale attempt's loop — it is fenced-dead (its gen
+    // checks make every remaining await a no-op), so the live attempt takes
+    // ownership rather than letting the corpse swallow its trigger.
+    this.recoveryOwner = this.attemptGen;
     this.recoveryEscalate = false;
     const gen = this.attemptGen;
     this.captureState = 'recovering';
     this.ev.onCaptureHealth?.('recovering', kind);
     let effectiveKind = kind;
+    let failures = 0;
+    let iterations = 0;
     try {
-      for (let attempt = 0; attempt < RECOVERY_MAX_ATTEMPTS; attempt++) {
+      // Failure-counted (an escalated retry after a SUCCESSFUL resume must
+      // not burn an attempt); the iteration cap is a belt against a
+      // pathological trigger storm re-arming escalation forever.
+      while (failures < RECOVERY_MAX_ATTEMPTS && ++iterations <= 10) {
         const backoff =
-          this.recoveryBackoffMs[Math.min(attempt, this.recoveryBackoffMs.length - 1)] ?? 0;
-        if (backoff > 0) {
+          this.recoveryBackoffMs[Math.min(failures, this.recoveryBackoffMs.length - 1)] ?? 0;
+        if (backoff > 0 && iterations > 1) {
           await new Promise((r) => setTimeout(r, backoff));
           if (gen !== this.attemptGen) return;
         }
@@ -1980,12 +2070,19 @@ export class VoiceTransport {
             : await this.tryReacquire(gen, capGen);
         if (gen !== this.attemptGen) return;
         if (ok) {
-          this.recordRecoveryEvent(effectiveKind, 'recovered', attempt + 1);
+          if (this.recoveryEscalate) {
+            // A reacquire request landed while this (resume) pass was in
+            // flight: the track it reported on is still dead — keep going,
+            // consuming the escalation on the next iteration.
+            continue;
+          }
+          this.recordRecoveryEvent(effectiveKind, 'recovered', failures + 1);
           this.captureState = 'observing';
           this.ev.onCaptureHealth?.('recovered', effectiveKind);
           return;
         }
-        this.recordRecoveryEvent(effectiveKind, 'failed', attempt + 1);
+        failures++;
+        this.recordRecoveryEvent(effectiveKind, 'failed', failures);
       }
       // Exhausted (failure contract): degraded, NOT terminal — the socket
       // and the voice lease stay live; the surface renders a retry
@@ -1998,7 +2095,7 @@ export class VoiceTransport {
         'Microphone input could not be recovered',
       );
     } finally {
-      this.recoveryActive = false;
+      if (this.recoveryOwner === gen) this.recoveryOwner = 0;
     }
   }
 
@@ -2045,14 +2142,17 @@ export class VoiceTransport {
       try {
         await this.withTimeout(this.audioCtx.resume(), this.recoveryResumeTimeoutMs);
       } catch {
-        /* graph can still run if the ctx resumes later */
+        /* verdict below reads the actual ctx state */
       }
       if (gen !== this.attemptGen || capGen !== this.captureGen) {
         for (const t of stream.getTracks()) t.stop();
         return false;
       }
     }
-    if (!this.audioCtx || this.audioCtx.state === 'closed') {
+    // Honest verdict: a graph wired onto a non-running context captures
+    // nothing — reporting 'recovered' with the ctx still suspended would
+    // tell the UI capture is back while it stays dead.
+    if (!this.audioCtx || this.audioCtx.state !== 'running') {
       for (const t of stream.getTracks()) t.stop();
       return false;
     }
@@ -2078,12 +2178,18 @@ export class VoiceTransport {
 
   private recordDeviceEvent(kind: string): void {
     this.deviceEvents.push({ kind, at: this.nowFn() });
-    if (this.deviceEvents.length > 8) this.deviceEvents.shift();
+    if (this.deviceEvents.length > 8) {
+      this.deviceEvents.shift();
+      this.deviceEventsDropped++; // truncation is evidence loss — count it
+    }
   }
 
   private recordRecoveryEvent(kind: string, result: string, attempt: number): void {
     this.recoveryEvents.push({ kind, result, attempt, at: this.nowFn() });
-    if (this.recoveryEvents.length > 8) this.recoveryEvents.shift();
+    if (this.recoveryEvents.length > 8) {
+      this.recoveryEvents.shift();
+      this.recoveryEventsDropped++;
+    }
   }
 
   private installDeviceChangeListener(): void {
@@ -2144,8 +2250,12 @@ export class VoiceTransport {
   private async handleDeviceChange(): Promise<void> {
     if (!this.attemptActive || this.terminal || !this.processor) return;
     const gen = this.attemptGen;
+    const capGen = this.captureGen;
     const sig = await this.snapshotInputDevices();
-    if (gen !== this.attemptGen) return;
+    // Dual fence (round-1 fix #5): a recovery that replaced the graph while
+    // this enumeration was pending bumped captureGen — acting on the stale
+    // result would tear the fresh capture down again.
+    if (gen !== this.attemptGen || capGen !== this.captureGen) return;
     if (sig === null) return;
     if (this.inputDeviceSig !== null && sig === this.inputDeviceSig) return; // output-only change
     this.inputDeviceSig = sig;

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -1868,6 +1868,10 @@ export class VoiceTransport {
    *   t   'audio_health'
    *   n   epoch nonce (engine maps nonce→server epoch on first sight)
    *   q   heartbeat seq within the epoch
+   *   ea  epoch age: ms since connect() on the CLIENT clock at assembly —
+   *       lets the engine place epoch-relative episode intervals on its own
+   *       clock as receivedAt − ea (accurate to network latency), instead of
+   *       guessing the epoch start from first-heartbeat timing
    *   c   DELTAS since the last successfully-sent heartbeat (lossless: a
    *       failed/skipped frame's interval folds into the next delta):
    *       [capCallbacks, bytesSent, sendSkipped, sendFailed, chunksRecv,
@@ -1895,6 +1899,7 @@ export class VoiceTransport {
       t: 'audio_health',
       n: this.epochNonce,
       q: this.heartbeatsSent,
+      ea: Math.max(0, Math.round(now - this.connectAtMs)),
       c: [
         this.capCallbacks - this.hbPrev.capCallbacks,
         this.bytesSent - this.hbPrev.bytesSent,

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -380,8 +380,97 @@ export interface VoiceTransportEvents {
   onMicError?(name: string, message: string, friendly: string): void;
   /** Optional live-audio AnalyserNode for avatar viz (playback path). */
   onAnalyser?(node: AnalyserNode): void;
-  /** Byte counters, ~2×/s, for a stats panel. */
-  onStats?(stats: { bytesSent: number; bytesRecv: number }): void;
+  /** Byte + audio-health counters, ~2×/s, for a stats panel. Everything beyond
+   *  `bytesSent`/`bytesRecv` is additive (P7 D7.1) — older consumers keep
+   *  reading just the byte totals. */
+  onStats?(stats: VoiceStats): void;
+  /**
+   * Capture-health lifecycle (P7 D7.5 failure contract). 'recovering' when a
+   * suspension / device loss triggers the bounded recovery FSM, 'recovered' on
+   * success, 'degraded' when recovery is exhausted. Degraded is NOT terminal
+   * and deliberately not `onConnectFailure`: the socket and the voice lease
+   * stay live (the call is alive, input is not) — surfaces render a distinct
+   * mic-error state with a retry affordance wired to `retryCapture()`.
+   */
+  onCaptureHealth?(
+    state: 'recovering' | 'recovered' | 'degraded',
+    kind: 'resume' | 'reacquire',
+    detail?: string,
+  ): void;
+}
+
+/** Recovery FSM state (P7 D7.5): recovered collapses back into 'observing'. */
+export type CaptureState = 'observing' | 'recovering' | 'degraded';
+
+/**
+ * Extended stats snapshot assembled on the 500 ms stats tick (never on the
+ * frame path). All counters are scoped to the current connection epoch — they
+ * reset on every `connect()`.
+ */
+export interface VoiceStats {
+  bytesSent: number;
+  bytesRecv: number;
+  /** Capture callbacks seen (counts even while muted — mute must not read as
+   *  a capture gap). */
+  capCallbacks: number;
+  /** Frames skipped because the socket's bufferedAmount exceeded the egress
+   *  watermark (backpressure made visible instead of deepening the stall). */
+  sendSkipped: number;
+  /** Frames whose ws.send threw (socket died mid-callback). */
+  sendFailed: number;
+  chunksRecv: number;
+  /** Chunks handed to the audio graph (schedule-time — NOT proof of playback). */
+  chunksScheduled: number;
+  /** Natural playback completions only (cancellations counted separately). */
+  chunksEnded: number;
+  /** Sources stopped by flushPlayback (barge-in/deafen/teardown) — `onended`
+   *  fires for these too, so they must not masquerade as completions. */
+  chunksCancelled: number;
+  scheduledDepth: number;
+  lastEndedAt: number | null;
+  ctxState: string | null;
+  ctxTimeMs: number | null;
+  ctxSuspendCount: number;
+  captureState: CaptureState;
+  /** Watchdog: capture gap past max(3× frame interval, 1 s) while unmuted +
+   *  connected, still open. */
+  capStalled: boolean;
+  lastCapAgoMs: number | null;
+  /** Latest frame RMS (subsampled). Client-side corroboration only — the
+   *  server's ingress tracker is the canonical speech evidence (D7.1). */
+  rms: number;
+  speechActive: boolean;
+  bufferedAmount: number;
+  bufferedHighWater: number;
+  /** Per-connection nonce echoed in every audio_health heartbeat (Tranche A:
+   *  the engine mints the server epoch and maps this nonce to it on first
+   *  sight). */
+  epochNonce: string;
+}
+
+/**
+ * One latched episode interval (P7 D7.1). Slots are preallocated and mutated
+ * in place — episode latching happens on the frame path, where allocation is
+ * forbidden (§D7.0b). `kind: 'gap'` = capture-callback gap; `'speech'` = an
+ * above-floor RMS interval. Times are ms relative to the connection epoch.
+ */
+interface EpisodeSlot {
+  /** Episode id (1-based, per epoch). 0 = slot never written. */
+  id: number;
+  kind: 'gap' | 'speech';
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  /** Speech only: capCallbacks seq at onset/offset. */
+  onsetSeq: number;
+  offsetSeq: number;
+  /** Speech only: max RMS over the interval, in permille (0–1000). */
+  maxRmsPm: number;
+  aboveFloorMs: number;
+  /** Accounted: included in a transmitted heartbeat, or already counted into
+   *  episodeOverflow (an unsent slot being evicted or aging out of the send
+   *  window is evidence loss). */
+  sent: boolean;
 }
 
 /** Default connect timeout (design 1e): if the WS has not reached `onopen`
@@ -398,6 +487,55 @@ export const AGENT_STATE_LEGACY_MS = 3000;
  *  returned teardown promise resolves anyway — a wedged handshake must not
  *  hang lease release. */
 export const DISCONNECT_CLOSE_TIMEOUT_MS = 1500;
+
+// ─── P7 D7.1/D7.5 audio-health constants ─────────────────────
+
+/** RMS floor above which a capture frame counts as speech evidence
+ *  (client-side corroboration only; the server ingress tracker is canonical). */
+export const SPEECH_RMS_FLOOR = 0.02;
+
+/** A speech interval closes after this long below the floor — the hangover
+ *  keeps word gaps from splitting one utterance into many episodes. */
+export const SPEECH_OFFSET_HANG_MS = 600;
+
+/** Capture-gap watchdog floor: a gap counts as a stall only past
+ *  max(3× expected callback interval, this) while unmuted + connected. */
+export const CAP_STALL_FLOOR_MS = 1000;
+
+/** Egress backpressure watermark: above this bufferedAmount, capture frames
+ *  are skipped (visible in `sendSkipped`) instead of piling more PCM onto a
+ *  stalled socket (FE-1). */
+export const SEND_BUFFER_WATERMARK_BYTES = 256 * 1024;
+
+/** Hard cap on one serialized audio_health frame. Assembly drops the oldest
+ *  window episodes until the frame fits, so the cap holds by construction
+ *  (≤300 B / 2 s = ≤150 B/s average on the shared socket). */
+export const AUDIO_HEALTH_MAX_BYTES = 300;
+
+/** Heartbeat cadence in 500 ms stats ticks (4 → one per 2 s). The first fires
+ *  on the first tick so the engine learns the nonce right after going live. */
+export const AUDIO_HEALTH_INTERVAL_TICKS = 4;
+
+/** Preallocated episode retention ring (per connection epoch). */
+export const EPISODE_RING_SIZE = 8;
+
+/** Newest episodes re-sent idempotently in every heartbeat (server dedups by
+ *  id; ACK-free by design — a server→client ack would queue ahead of PCM). */
+export const AUDIO_HEALTH_EPISODE_WINDOW = 4;
+
+/** Bounded single-flight capture recovery (D7.5). */
+export const RECOVERY_MAX_ATTEMPTS = 3;
+export const RECOVERY_BACKOFF_MS: readonly number[] = [0, 1000, 4000];
+export const RECOVERY_RESUME_TIMEOUT_MS = 2000;
+
+/** 8-char per-connection nonce. Tranche A epoch scheme (D7.1): the engine
+ *  mints the server-issued epoch and maps it to this nonce on first heartbeat
+ *  sight — collision-resistant randomness, no protocol change. */
+function mintNonce(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) return c.randomUUID().replace(/-/g, '').slice(0, 8);
+  return Math.random().toString(36).slice(2, 10).padEnd(8, '0');
+}
 
 export interface VoiceTransportOptions extends VoiceTransportEvents {
   /** Mic capture buffer size (ScriptProcessor). Default 2048, matching web-client. */
@@ -422,6 +560,18 @@ export interface VoiceTransportOptions extends VoiceTransportEvents {
    * cast to WebSocket.
    */
   wsFactory?: (url: string) => WebSocket;
+  /** Speech-evidence RMS floor override (tests). Default SPEECH_RMS_FLOOR. */
+  speechRmsFloor?: number;
+  /** Speech offset hangover override (tests). Default SPEECH_OFFSET_HANG_MS. */
+  speechOffsetHangMs?: number;
+  /** Egress skip watermark override (tests). Default SEND_BUFFER_WATERMARK_BYTES. */
+  sendBufferWatermark?: number;
+  /** Recovery pacing overrides (tests). Defaults RECOVERY_BACKOFF_MS /
+   *  RECOVERY_RESUME_TIMEOUT_MS. */
+  recoveryBackoffMs?: readonly number[];
+  recoveryResumeTimeoutMs?: number;
+  /** Clock seam for deterministic watchdog/episode tests. Default Date.now. */
+  nowFn?: () => number;
 }
 
 /**
@@ -446,7 +596,9 @@ export class VoiceTransport {
   private micStream: MediaStream | null = null;
   private processor: ScriptProcessorNode | null = null;
   private analyserNode: AnalyserNode | null = null;
-  private activeSources: AudioBufferSourceNode[] = [];
+  /** `cancelled` distinguishes flushPlayback stops from natural completions —
+   *  stop() fires `onended` too, and cancellation is not completion (D7.1). */
+  private activeSources: Array<{ src: AudioBufferSourceNode; cancelled: boolean }> = [];
   private nextPlayTime = 0;
 
   private bytesSent = 0;
@@ -484,10 +636,65 @@ export class VoiceTransport {
   private closeCompletion: Promise<void> = Promise.resolve();
 
   // Debug-panel counters. They exist to bound the trace output (first N only),
-  // not as protocol state — the surface reads byte totals from onStats.
+  // not as protocol state — the surface reads byte totals from onStats. Since
+  // P7 they are epoch-scoped (reset per connect), so the traces re-arm per
+  // attempt.
   private audioChunksRecv = 0;
   private micSendCount = 0;
-  private playChunkCount = 0;
+
+  // ── P7 D7.1 audio-progress ledger (all epoch-scoped; resetLedger) ──
+  private speechRmsFloor: number;
+  private speechOffsetHangMs: number;
+  private sendBufferWatermark: number;
+  private recoveryBackoffMs: readonly number[];
+  private recoveryResumeTimeoutMs: number;
+  private nowFn: () => number;
+
+  private epochNonce = '';
+  private connectAtMs = 0;
+  private capCallbacks = 0;
+  private sendSkipped = 0;
+  private sendFailed = 0;
+  private chunksScheduled = 0;
+  private chunksEnded = 0;
+  private chunksCancelled = 0;
+  private lastEndedAt: number | null = null;
+  private bufferedHighWater = 0;
+  private lastCapAt = 0;
+  /** captureBuf / ctx.sampleRate, computed when the graph wires (~43 ms). */
+  private expectedFrameMs = 43;
+  private capStalled = false;
+  /** Absolute ms the open capture gap started at (0 = no open gap). */
+  private gapOpenedAt = 0;
+  private lastRms = 0;
+  private speechActive = false;
+  private speechOnsetSeq = 0;
+  private speechOnsetAtMs = 0;
+  private speechMaxRms = 0;
+  private speechAboveFloorMs = 0;
+  private speechLastAboveAt = 0;
+  private ctxSuspendCount = 0;
+  private ctxLastTransition: { from: string; to: string; at: number } | null = null;
+  private readonly episodeRing: EpisodeSlot[];
+  private episodeSeq = 0;
+  private episodeOverflow = 0;
+  private statsTickCount = 0;
+  private heartbeatsSent = 0;
+  private deviceEvents: Array<{ kind: string; at: number }> = [];
+  private recoveryEvents: Array<{ kind: string; result: string; attempt: number; at: number }> = [];
+
+  // ── P7 D7.5 capture recovery FSM ──
+  /** Independent of attemptGen (bumping the attempt would kill the still-live
+   *  socket's callbacks): bumps on every recovery attempt, on timeout, and in
+   *  teardownAudio; every async capture continuation validates BOTH gens. */
+  private captureGen = 0;
+  private captureState: CaptureState = 'observing';
+  private recoveryActive = false;
+  /** A reacquire trigger arrived while a resume-recovery was in flight. */
+  private recoveryEscalate = false;
+  /** Sorted input-device fingerprint (null = cannot enumerate). */
+  private inputDeviceSig: string | null = null;
+  private deviceChangeHandler: (() => void) | null = null;
 
   constructor(opts: VoiceTransportOptions = {}) {
     this.ev = opts;
@@ -499,6 +706,26 @@ export class VoiceTransport {
     this.agentStateLegacyMs = opts.agentStateLegacyMs ?? AGENT_STATE_LEGACY_MS;
     this.disconnectCloseTimeoutMs = opts.disconnectCloseTimeoutMs ?? DISCONNECT_CLOSE_TIMEOUT_MS;
     this.wsFactory = opts.wsFactory ?? ((url: string) => new WebSocket(url));
+    this.speechRmsFloor = opts.speechRmsFloor ?? SPEECH_RMS_FLOOR;
+    this.speechOffsetHangMs = opts.speechOffsetHangMs ?? SPEECH_OFFSET_HANG_MS;
+    this.sendBufferWatermark = opts.sendBufferWatermark ?? SEND_BUFFER_WATERMARK_BYTES;
+    this.recoveryBackoffMs = opts.recoveryBackoffMs ?? RECOVERY_BACKOFF_MS;
+    this.recoveryResumeTimeoutMs = opts.recoveryResumeTimeoutMs ?? RECOVERY_RESUME_TIMEOUT_MS;
+    this.nowFn = opts.nowFn ?? Date.now;
+    // Preallocated: episode latching happens on the frame path, where
+    // allocation is forbidden (§D7.0b) — slots are mutated in place.
+    this.episodeRing = Array.from({ length: EPISODE_RING_SIZE }, () => ({
+      id: 0,
+      kind: 'gap' as const,
+      startMs: 0,
+      endMs: 0,
+      durationMs: 0,
+      onsetSeq: 0,
+      offsetSeq: 0,
+      maxRmsPm: 0,
+      aboveFloorMs: 0,
+      sent: false,
+    }));
   }
 
   get connected(): boolean {
@@ -556,6 +783,9 @@ export class VoiceTransport {
     // the new attempt — and nextPlayTime must restart from the new clock
     // instead of continuing the old session's schedule.
     this.flushPlayback();
+    // New connection epoch (D7.1): every counter/episode resets and a fresh
+    // nonce is minted, so ledger evidence can never span two calls.
+    this.resetLedger();
 
     this.status('connecting', 'Connecting…');
 
@@ -564,6 +794,7 @@ export class VoiceTransport {
     if (!this.audioCtx || this.audioCtx.state === 'closed') {
       this.audioCtx = new AudioContext();
     }
+    this.adoptCtx(this.audioCtx);
     if (this.audioCtx.state === 'suspended') {
       try {
         await this.audioCtx.resume();
@@ -754,6 +985,13 @@ export class VoiceTransport {
    * web-client's doCleanup(). Idempotent.
    */
   private teardownAudio(): void {
+    // D7.5: fence every in-flight recovery continuation and tear down the
+    // lifecycle listeners BEFORE closing the ctx — close() fires its own
+    // statechange, which must not trigger recovery.
+    this.captureGen++;
+    this.recoveryEscalate = false;
+    this.removeDeviceChangeListener();
+    if (this.audioCtx) this.audioCtx.onstatechange = null;
     this.stopMic();
     this.stopStats();
     this.flushPlayback();
@@ -840,9 +1078,9 @@ export class VoiceTransport {
       // may already belong to a newer attempt).
       if (gen !== this.attemptGen) return;
       this.status('live', 'Live — speak now');
-      this.statsTimer = setInterval(() => {
-        this.ev.onStats?.({ bytesSent: this.bytesSent, bytesRecv: this.bytesRecv });
-      }, 500);
+      // 500 ms cadence, off the frame path (§D7.0b): watchdog + stats +
+      // (every 4th tick) the audio_health heartbeat all ride this timer.
+      this.statsTimer = setInterval(() => this.runStatsTick(), 500);
     } catch (err: any) {
       if (gen !== this.attemptGen) return;
       const name = err?.name ?? 'unknown';
@@ -1124,7 +1362,6 @@ export class VoiceTransport {
       for (const t of stream.getTracks()) t.stop();
       return;
     }
-    this.micStream = stream;
 
     if (!this.audioCtx || this.audioCtx.state === 'closed') {
       this.audioCtx = new AudioContext();
@@ -1135,27 +1372,71 @@ export class VoiceTransport {
         // Stop OUR capture only — this.micStream may already belong to a
         // newer attempt (its connect() re-ran stopMic + startMic).
         for (const t of stream.getTracks()) t.stop();
-        if (this.micStream === stream) this.micStream = null;
         return;
       }
     }
 
-    const ctx = this.audioCtx;
-    const source = ctx.createMediaStreamSource(this.micStream);
+    this.wireCaptureGraph(stream);
+  }
+
+  /**
+   * Wire (or re-wire, on a recovery reacquire) the capture graph over an
+   * acquired stream. Synchronous — callers have already generation-fenced
+   * their awaits.
+   */
+  private wireCaptureGraph(stream: MediaStream): void {
+    this.micStream = stream;
+    const ctx = this.audioCtx!;
+    this.adoptCtx(ctx);
+    this.expectedFrameMs = Math.max(1, Math.round((this.captureBuf / ctx.sampleRate) * 1000));
+    const source = ctx.createMediaStreamSource(stream);
     const processor = ctx.createScriptProcessor(this.captureBuf, 1, 1);
     this.processor = processor;
 
     processor.onaudioprocess = (e: AudioProcessingEvent) => {
+      // §D7.0b FRAME PATH: O(1) counter/latch writes plus one subsampled RMS
+      // pass on top of the pinned downsample+encode+send — no allocation
+      // beyond the pinned encode, no I/O beyond the pinned send.
+      const now = this.nowFn();
+      this.capCallbacks++;
+      if (this.gapOpenedAt > 0) this.closeGapEpisode(now);
+      this.lastCapAt = now;
+      const raw = e.inputBuffer.getChannelData(0);
+      let sum = 0;
+      let n = 0;
+      for (let i = 0; i < raw.length; i += 4) {
+        const v = raw[i];
+        sum += v * v;
+        n++;
+      }
+      const rms = n > 0 ? Math.sqrt(sum / n) : 0;
+      this.lastRms = rms;
+      this.trackSpeech(rms, now);
+      // Capture-health accounting above runs regardless of socket/mute state
+      // (capture health ≠ socket health); the send path gates below.
       if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
       // Muted: keep the processor running (it must stay in the graph) but
       // don't send mic audio to the agent.
       if (this.micMuted) return;
-      const raw = e.inputBuffer.getChannelData(0);
       const down = downsample(raw, ctx.sampleRate, this.inputRate);
       const pcm = float32ToInt16(down);
+      const buffered = this.ws.bufferedAmount || 0;
+      if (buffered > this.bufferedHighWater) this.bufferedHighWater = buffered;
+      if (buffered > this.sendBufferWatermark) {
+        // Backpressure: more PCM onto a stalled socket only deepens the
+        // stall (FE-1) — skip visibly instead.
+        this.sendSkipped++;
+        return;
+      }
       // pcm.buffer is a freshly-allocated ArrayBuffer (float32ToInt16 does
       // `new Int16Array(len)`), so the ArrayBufferLike→ArrayBuffer cast is safe.
-      this.ws.send(pcm.buffer as ArrayBuffer);
+      try {
+        this.ws.send(pcm.buffer as ArrayBuffer);
+      } catch {
+        // A socket dying mid-callback must never throw off the audio graph.
+        this.sendFailed++;
+        return;
+      }
       this.bytesSent += pcm.buffer.byteLength;
       this.micSendCount++;
       if (this.micSendCount <= 3) {
@@ -1174,6 +1455,21 @@ export class VoiceTransport {
     silence.gain.value = 0;
     processor.connect(silence);
     silence.connect(ctx.destination);
+
+    // D7.5: device-loss signals drive the recovery FSM.
+    const track = stream.getAudioTracks()[0];
+    if (track) {
+      track.enabled = !this.micMuted; // a reacquired track must honor the mute
+      track.onended = () => {
+        if (this.micStream !== stream || !this.attemptActive || this.terminal) return;
+        this.recordDeviceEvent('track-ended');
+        void this.startRecovery('reacquire');
+      };
+    }
+    this.installDeviceChangeListener();
+    void this.snapshotInputDevices().then((sig) => {
+      if (this.micStream === stream) this.inputDeviceSig = sig;
+    });
   }
 
   private stopMic(): void {
@@ -1186,7 +1482,12 @@ export class VoiceTransport {
       this.processor = null;
     }
     if (this.micStream) {
-      this.micStream.getTracks().forEach((t) => t.stop());
+      this.micStream.getTracks().forEach((t) => {
+        // Clear the D7.5 listener first — a deliberate stop() must not fire
+        // `ended` into the recovery FSM.
+        t.onended = null;
+        t.stop();
+      });
       this.micStream = null;
     }
     // Don't close audioCtx here — playback may still be draining.
@@ -1251,6 +1552,7 @@ export class VoiceTransport {
       } catch {
         return;
       }
+      this.adoptCtx(this.audioCtx);
     }
     const ctx = this.audioCtx;
     if (ctx.state === 'suspended') ctx.resume();
@@ -1280,15 +1582,22 @@ export class VoiceTransport {
       }
       src.start(this.nextPlayTime);
       this.nextPlayTime += audioBuf.duration / this.playbackRate;
-      this.activeSources.push(src);
+      const entry = { src, cancelled: false };
+      this.activeSources.push(entry);
       src.onended = () => {
-        const idx = this.activeSources.indexOf(src);
+        // Natural completion only — a flushPlayback stop() also fires
+        // onended, but that chunk was cancelled, not played out (D7.1).
+        if (!entry.cancelled) {
+          this.chunksEnded++;
+          this.lastEndedAt = this.nowFn();
+        }
+        const idx = this.activeSources.indexOf(entry);
         if (idx >= 0) this.activeSources.splice(idx, 1);
       };
-      this.playChunkCount++;
-      if (this.playChunkCount <= 5) {
+      this.chunksScheduled++;
+      if (this.chunksScheduled <= 5) {
         this.debug(
-          'Played chunk #' + this.playChunkCount + ': ' + f32.length +
+          'Played chunk #' + this.chunksScheduled + ': ' + f32.length +
             ' samples, scheduled at ' + this.nextPlayTime.toFixed(3) +
             's (ctx.state=' + ctx.state + ')',
           'audio',
@@ -1302,9 +1611,14 @@ export class VoiceTransport {
 
   /** Stop and drop all scheduled playback (barge-in / disconnect). */
   private flushPlayback(): void {
-    for (const s of this.activeSources) {
+    for (const entry of this.activeSources) {
+      // Counted HERE, deterministically — not in onended (which a closed ctx
+      // may never fire). The flag keeps a trailing onended from also counting
+      // the chunk as ended.
+      entry.cancelled = true;
+      this.chunksCancelled++;
       try {
-        s.stop();
+        entry.src.stop();
       } catch {
         /* already stopped */
       }
@@ -1328,5 +1642,514 @@ export class VoiceTransport {
       clearInterval(this.statsTimer);
       this.statsTimer = null;
     }
+  }
+
+  // ─── P7 D7.1 audio-progress ledger ──────────────────────────
+
+  /** New connection epoch: zero every counter, clear the episode ring, mint
+   *  the nonce the engine maps to its server-issued epoch on first heartbeat
+   *  sight. Ledger evidence can never span two calls. */
+  private resetLedger(): void {
+    this.epochNonce = mintNonce();
+    this.connectAtMs = this.nowFn();
+    this.bytesSent = 0;
+    this.bytesRecv = 0;
+    this.audioChunksRecv = 0;
+    this.micSendCount = 0;
+    this.capCallbacks = 0;
+    this.sendSkipped = 0;
+    this.sendFailed = 0;
+    this.chunksScheduled = 0;
+    this.chunksEnded = 0;
+    this.chunksCancelled = 0;
+    this.lastEndedAt = null;
+    this.bufferedHighWater = 0;
+    this.lastCapAt = 0;
+    this.capStalled = false;
+    this.gapOpenedAt = 0;
+    this.lastRms = 0;
+    this.speechActive = false;
+    this.speechMaxRms = 0;
+    this.speechAboveFloorMs = 0;
+    this.ctxSuspendCount = 0;
+    this.ctxLastTransition = null;
+    for (const slot of this.episodeRing) {
+      slot.id = 0;
+      slot.sent = false;
+    }
+    this.episodeSeq = 0;
+    this.episodeOverflow = 0;
+    this.statsTickCount = 0;
+    this.heartbeatsSent = 0;
+    this.deviceEvents = [];
+    this.recoveryEvents = [];
+    this.captureState = 'observing';
+    this.inputDeviceSig = null;
+  }
+
+  /** Latched speech intervals (D7.1): an utterance entirely between
+   *  heartbeats still leaves its record. O(1) — frame-path safe. */
+  private trackSpeech(rms: number, now: number): void {
+    if (rms >= this.speechRmsFloor) {
+      if (!this.speechActive) {
+        this.speechActive = true;
+        this.speechOnsetSeq = this.capCallbacks;
+        this.speechOnsetAtMs = now;
+        this.speechMaxRms = 0;
+        this.speechAboveFloorMs = 0;
+      }
+      if (rms > this.speechMaxRms) this.speechMaxRms = rms;
+      this.speechAboveFloorMs += this.expectedFrameMs;
+      this.speechLastAboveAt = now;
+    } else if (this.speechActive && now - this.speechLastAboveAt >= this.speechOffsetHangMs) {
+      this.speechActive = false;
+      this.latchEpisode('speech', this.speechOnsetAtMs, this.speechLastAboveAt);
+    }
+  }
+
+  /** Write the next preallocated ring slot (frame-path safe: field writes
+   *  only). Evicting a slot that never made a heartbeat is evidence loss —
+   *  it bumps episodeOverflow, which the matrix maps to
+   *  insufficient-evidence. */
+  private latchEpisode(kind: 'gap' | 'speech', startAbsMs: number, endAbsMs: number): void {
+    const slot = this.episodeRing[this.episodeSeq % EPISODE_RING_SIZE];
+    if (slot.id !== 0 && !slot.sent) this.episodeOverflow++;
+    this.episodeSeq++;
+    slot.id = this.episodeSeq;
+    slot.kind = kind;
+    slot.startMs = Math.max(0, Math.round(startAbsMs - this.connectAtMs));
+    slot.endMs = Math.max(0, Math.round(endAbsMs - this.connectAtMs));
+    slot.durationMs = Math.max(0, Math.round(endAbsMs - startAbsMs));
+    slot.sent = false;
+    if (kind === 'speech') {
+      slot.onsetSeq = this.speechOnsetSeq;
+      slot.offsetSeq = this.capCallbacks;
+      slot.maxRmsPm = Math.min(1000, Math.round(this.speechMaxRms * 1000));
+      slot.aboveFloorMs = Math.round(this.speechAboveFloorMs);
+    } else {
+      slot.onsetSeq = 0;
+      slot.offsetSeq = 0;
+      slot.maxRmsPm = 0;
+      slot.aboveFloorMs = 0;
+    }
+  }
+
+  /** Close the open capture gap into a latched episode (frame-path safe). */
+  private closeGapEpisode(now: number): void {
+    this.latchEpisode('gap', this.gapOpenedAt, now);
+    this.gapOpenedAt = 0;
+    this.capStalled = false;
+  }
+
+  /**
+   * 500 ms cadence, off the frame path (§D7.0b): the capture watchdog, the
+   * extended stats publication, and — every AUDIO_HEALTH_INTERVAL_TICKS-th
+   * tick, starting with the first so the engine learns the nonce right after
+   * going live — audio_health assembly + send.
+   */
+  private runStatsTick(): void {
+    const now = this.nowFn();
+    // Watchdog (D7.1): a silent capture past max(3× frame interval, 1 s)
+    // while unmuted + connected is a stall. The gap LATCHES as an episode
+    // when capture returns, so a fast resume before the next tick cannot
+    // erase the evidence; a permanent stall travels as the open gap (`og`).
+    const stallAfter = Math.max(3 * this.expectedFrameMs, CAP_STALL_FLOOR_MS);
+    if (
+      this.processor &&
+      !this.micMuted &&
+      this.ws &&
+      this.ws.readyState === WebSocket.OPEN &&
+      this.lastCapAt > 0 &&
+      this.gapOpenedAt === 0 &&
+      now - this.lastCapAt > stallAfter
+    ) {
+      this.gapOpenedAt = this.lastCapAt;
+      this.capStalled = true;
+    }
+    this.ev.onStats?.(this.buildStats(now));
+    if (this.statsTickCount % AUDIO_HEALTH_INTERVAL_TICKS === 0) this.sendAudioHealth(now);
+    this.statsTickCount++;
+  }
+
+  private buildStats(now: number): VoiceStats {
+    return {
+      bytesSent: this.bytesSent,
+      bytesRecv: this.bytesRecv,
+      capCallbacks: this.capCallbacks,
+      sendSkipped: this.sendSkipped,
+      sendFailed: this.sendFailed,
+      chunksRecv: this.audioChunksRecv,
+      chunksScheduled: this.chunksScheduled,
+      chunksEnded: this.chunksEnded,
+      chunksCancelled: this.chunksCancelled,
+      scheduledDepth: this.activeSources.length,
+      lastEndedAt: this.lastEndedAt,
+      ctxState: this.audioCtx?.state ?? null,
+      ctxTimeMs: this.audioCtx ? Math.round(this.audioCtx.currentTime * 1000) : null,
+      ctxSuspendCount: this.ctxSuspendCount,
+      captureState: this.captureState,
+      capStalled: this.capStalled,
+      lastCapAgoMs: this.lastCapAt > 0 ? now - this.lastCapAt : null,
+      rms: this.lastRms,
+      speechActive: this.speechActive,
+      bufferedAmount: this.ws ? this.ws.bufferedAmount || 0 : 0,
+      bufferedHighWater: this.bufferedHighWater,
+      epochNonce: this.epochNonce,
+    };
+  }
+
+  /**
+   * The 2 s audio_health heartbeat (D7.1). Compact wire schema, hard-capped
+   * at AUDIO_HEALTH_MAX_BYTES by construction: window episodes are dropped
+   * oldest-first until the frame fits (an entry evicted from the ring without
+   * ever being sent surfaces via `eo`). Counters are absolute — idempotent
+   * across skipped heartbeats; episodes re-send idempotently and the server
+   * dedups by id. There are NO server→client telemetry frames (§D7.0b).
+   *
+   * Wire schema (short keys; optional keys omitted when empty):
+   *   t   'audio_health'
+   *   n   epoch nonce (engine maps nonce→server epoch on first sight)
+   *   q   heartbeat seq within the epoch
+   *   c   [capCallbacks, bytesSent, sendSkipped, sendFailed, chunksRecv,
+   *        chunksScheduled, chunksEnded, chunksCancelled]
+   *   x   [ctxTimeMs|-1, scheduledDepth, lastEndedAgoMs|-1]
+   *   cs  ctx state initial ('r'unning | 's'uspended | 'c'losed)
+   *   cap capture state initial ('o'bserving | 'r'ecovering | 'd'egraded)
+   *   sc  ctxSuspendCount
+   *   ba  [bufferedAmount, bufferedHighWater]
+   *   mu  1 while mic muted
+   *   og  [gapStartRelMs, ageMs] while a capture gap is OPEN — a permanent
+   *       stall never closes an episode, so the open gap itself must travel
+   *   eo  episodes evicted unsent (matrix: insufficient-evidence)
+   *   ep  ≤4 entries, oldest→newest:
+   *       gap    [id, 'g', startRelMs, durationMs]
+   *       speech [id, 's', onsetSeq, offsetSeq, maxRmsPm, aboveFloorMs]
+   */
+  private sendAudioHealth(now: number): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    const frame: Record<string, unknown> = {
+      t: 'audio_health',
+      n: this.epochNonce,
+      q: this.heartbeatsSent,
+      c: [
+        this.capCallbacks,
+        this.bytesSent,
+        this.sendSkipped,
+        this.sendFailed,
+        this.audioChunksRecv,
+        this.chunksScheduled,
+        this.chunksEnded,
+        this.chunksCancelled,
+      ],
+      x: [
+        this.audioCtx ? Math.round(this.audioCtx.currentTime * 1000) : -1,
+        this.activeSources.length,
+        this.lastEndedAt != null ? Math.max(0, now - this.lastEndedAt) : -1,
+      ],
+      cs: (this.audioCtx?.state ?? 'x')[0],
+      cap: this.captureState[0],
+    };
+    if (this.ctxSuspendCount > 0) frame.sc = this.ctxSuspendCount;
+    const buffered = this.ws.bufferedAmount || 0;
+    if (buffered > 0 || this.bufferedHighWater > 0) {
+      frame.ba = [buffered, this.bufferedHighWater];
+    }
+    if (this.micMuted) frame.mu = 1;
+    if (this.gapOpenedAt > 0) {
+      frame.og = [
+        Math.max(0, Math.round(this.gapOpenedAt - this.connectAtMs)),
+        Math.max(0, Math.round(now - this.gapOpenedAt)),
+      ];
+    }
+
+    // Newest AUDIO_HEALTH_EPISODE_WINDOW episodes, oldest→newest on the wire.
+    const window: EpisodeSlot[] = [];
+    for (let i = 0; i < AUDIO_HEALTH_EPISODE_WINDOW; i++) {
+      const seq = this.episodeSeq - i;
+      if (seq <= 0) break;
+      const slot = this.episodeRing[(seq - 1) % EPISODE_RING_SIZE];
+      if (slot.id === seq) window.push(slot);
+    }
+    window.reverse();
+    // An unsent episode that has aged OUT of the window can never be sent —
+    // that is overflow now, not at ring eviction (the "5th unsent episode"
+    // rule). Marked accounted so it counts exactly once.
+    for (const slot of this.episodeRing) {
+      if (slot.id > 0 && !slot.sent && slot.id <= this.episodeSeq - AUDIO_HEALTH_EPISODE_WINDOW) {
+        this.episodeOverflow++;
+        slot.sent = true;
+      }
+    }
+    if (this.episodeOverflow > 0) frame.eo = this.episodeOverflow;
+
+    const enc = new TextEncoder();
+    let payload: string;
+    for (;;) {
+      if (window.length > 0) {
+        frame.ep = window.map((s) =>
+          s.kind === 'gap'
+            ? [s.id, 'g', s.startMs, s.durationMs]
+            : [s.id, 's', s.onsetSeq, s.offsetSeq, s.maxRmsPm, s.aboveFloorMs],
+        );
+      } else {
+        delete frame.ep;
+      }
+      payload = JSON.stringify(frame);
+      if (enc.encode(payload).byteLength <= AUDIO_HEALTH_MAX_BYTES || window.length === 0) break;
+      window.shift(); // drop oldest — it re-sends next beat (or surfaces in eo)
+    }
+    try {
+      this.ws.send(payload);
+    } catch {
+      return; // heartbeat loss is itself evidence; never throw off a timer
+    }
+    this.heartbeatsSent++;
+    for (const s of window) s.sent = true;
+  }
+
+  // ─── P7 D7.5 capture recovery FSM ───────────────────────────
+
+  /** Attach lifecycle observation to a (possibly fresh) AudioContext.
+   *  Idempotent; teardownAudio clears it before close so the close's own
+   *  statechange never triggers recovery. */
+  private adoptCtx(ctx: AudioContext): void {
+    ctx.onstatechange = () => this.handleCtxStateChange(ctx);
+  }
+
+  private handleCtxStateChange(ctx: AudioContext): void {
+    if (ctx !== this.audioCtx) return; // stale context
+    const to = ctx.state;
+    const from = this.ctxLastTransition?.to ?? 'running';
+    this.ctxLastTransition = { from, to, at: this.nowFn() };
+    if (to === 'suspended') {
+      this.ctxSuspendCount++;
+      // Unexpected suspension while a live attempt captures → recovery.
+      if (this.attemptActive && !this.terminal && this.processor) {
+        void this.startRecovery('resume');
+      }
+    }
+  }
+
+  /**
+   * Manual retry from the degraded state (the UI affordance in D7.5's
+   * failure contract). Re-arms a full bounded reacquire; no-op while a
+   * recovery is already in flight or the attempt is not live.
+   */
+  retryCapture(): void {
+    if (!this.attemptActive || this.terminal) return;
+    void this.startRecovery('reacquire');
+  }
+
+  /**
+   * Single-flight bounded capture recovery (D7.5). `captureGen` — independent
+   * of `attemptGen`, because bumping the attempt would kill the still-live
+   * socket's callbacks — fences every await: it bumps on each attempt, on
+   * timeout, and in teardownAudio, so a late resume()/getUserMedia completion
+   * from a superseded attempt can never overwrite a newer graph.
+   */
+  private async startRecovery(kind: 'resume' | 'reacquire'): Promise<void> {
+    if (this.recoveryActive) {
+      // Coalesce: device loss during a resume-recovery upgrades the next
+      // attempt to a full reacquire; a same-kind re-trigger is already
+      // covered by the running loop.
+      if (kind === 'reacquire') this.recoveryEscalate = true;
+      return;
+    }
+    this.recoveryActive = true;
+    this.recoveryEscalate = false;
+    const gen = this.attemptGen;
+    this.captureState = 'recovering';
+    this.ev.onCaptureHealth?.('recovering', kind);
+    let effectiveKind = kind;
+    try {
+      for (let attempt = 0; attempt < RECOVERY_MAX_ATTEMPTS; attempt++) {
+        const backoff =
+          this.recoveryBackoffMs[Math.min(attempt, this.recoveryBackoffMs.length - 1)] ?? 0;
+        if (backoff > 0) {
+          await new Promise((r) => setTimeout(r, backoff));
+          if (gen !== this.attemptGen) return;
+        }
+        if (this.recoveryEscalate) {
+          effectiveKind = 'reacquire';
+          this.recoveryEscalate = false;
+        }
+        const capGen = ++this.captureGen;
+        const ok =
+          effectiveKind === 'resume'
+            ? await this.tryResume(gen, capGen)
+            : await this.tryReacquire(gen, capGen);
+        if (gen !== this.attemptGen) return;
+        if (ok) {
+          this.recordRecoveryEvent(effectiveKind, 'recovered', attempt + 1);
+          this.captureState = 'observing';
+          this.ev.onCaptureHealth?.('recovered', effectiveKind);
+          return;
+        }
+        this.recordRecoveryEvent(effectiveKind, 'failed', attempt + 1);
+      }
+      // Exhausted (failure contract): degraded, NOT terminal — the socket
+      // and the voice lease stay live; the surface renders a retry
+      // affordance (retryCapture). P4's evidence ladder sees the stall via
+      // the heartbeat, not via a connection failure.
+      this.captureState = 'degraded';
+      this.ev.onCaptureHealth?.(
+        'degraded',
+        effectiveKind,
+        'Microphone input could not be recovered',
+      );
+    } finally {
+      this.recoveryActive = false;
+    }
+  }
+
+  private async tryResume(gen: number, capGen: number): Promise<boolean> {
+    const ctx = this.audioCtx;
+    if (!ctx || ctx.state === 'closed') return false;
+    try {
+      await this.withTimeout(ctx.resume(), this.recoveryResumeTimeoutMs);
+    } catch {
+      this.captureGen++; // timeout: fence the abandoned resume (D7.5)
+      return false;
+    }
+    if (gen !== this.attemptGen || capGen !== this.captureGen) return false;
+    return this.audioCtx === ctx && ctx.state === 'running';
+  }
+
+  private async tryReacquire(gen: number, capGen: number): Promise<boolean> {
+    // Tear down the dead capture first (keep the ctx — playback drains on it).
+    this.stopMic();
+    let stream: MediaStream;
+    try {
+      const p = navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+      // A timed-out acquisition can still resolve later — the late grant
+      // must not leak a live capture (R10 discipline, captureGen edition;
+      // the timeout below bumps captureGen, so this sees it stale).
+      p.then((s) => {
+        if (gen !== this.attemptGen || capGen !== this.captureGen) {
+          for (const t of s.getTracks()) t.stop();
+        }
+      }).catch(() => {});
+      stream = await this.withTimeout(p, this.recoveryResumeTimeoutMs);
+    } catch {
+      this.captureGen++; // timeout/denial: fence the late completion
+      return false;
+    }
+    if (gen !== this.attemptGen || capGen !== this.captureGen) return false; // tracks stopped above
+    if (this.audioCtx && this.audioCtx.state === 'suspended') {
+      try {
+        await this.withTimeout(this.audioCtx.resume(), this.recoveryResumeTimeoutMs);
+      } catch {
+        /* graph can still run if the ctx resumes later */
+      }
+      if (gen !== this.attemptGen || capGen !== this.captureGen) {
+        for (const t of stream.getTracks()) t.stop();
+        return false;
+      }
+    }
+    if (!this.audioCtx || this.audioCtx.state === 'closed') {
+      for (const t of stream.getTracks()) t.stop();
+      return false;
+    }
+    this.wireCaptureGraph(stream);
+    return true;
+  }
+
+  private withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('recovery timeout')), ms);
+      p.then(
+        (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      );
+    });
+  }
+
+  private recordDeviceEvent(kind: string): void {
+    this.deviceEvents.push({ kind, at: this.nowFn() });
+    if (this.deviceEvents.length > 8) this.deviceEvents.shift();
+  }
+
+  private recordRecoveryEvent(kind: string, result: string, attempt: number): void {
+    this.recoveryEvents.push({ kind, result, attempt, at: this.nowFn() });
+    if (this.recoveryEvents.length > 8) this.recoveryEvents.shift();
+  }
+
+  private installDeviceChangeListener(): void {
+    if (this.deviceChangeHandler) return; // one per transport
+    const md = (navigator as { mediaDevices?: unknown }).mediaDevices as
+      | {
+          addEventListener?: (type: string, h: () => void) => void;
+          ondevicechange?: (() => void) | null;
+        }
+      | undefined;
+    if (!md) return;
+    const handler = (): void => {
+      void this.handleDeviceChange();
+    };
+    this.deviceChangeHandler = handler;
+    if (typeof md.addEventListener === 'function') md.addEventListener('devicechange', handler);
+    else md.ondevicechange = handler;
+  }
+
+  private removeDeviceChangeListener(): void {
+    const handler = this.deviceChangeHandler;
+    this.deviceChangeHandler = null;
+    if (!handler) return;
+    const md = (navigator as { mediaDevices?: unknown }).mediaDevices as
+      | {
+          removeEventListener?: (type: string, h: () => void) => void;
+          ondevicechange?: (() => void) | null;
+        }
+      | undefined;
+    if (!md) return;
+    if (typeof md.removeEventListener === 'function') {
+      md.removeEventListener('devicechange', handler);
+    } else if (md.ondevicechange === handler) {
+      md.ondevicechange = null;
+    }
+  }
+
+  /** Input-device fingerprint — `devicechange` fires for outputs too, and
+   *  only input-set changes justify a reacquire (D7.5). Null = cannot
+   *  enumerate (never reacquire blind). */
+  private async snapshotInputDevices(): Promise<string | null> {
+    const md = (navigator as { mediaDevices?: unknown }).mediaDevices as
+      | { enumerateDevices?: () => Promise<Array<{ kind?: string; deviceId?: string }>> }
+      | undefined;
+    if (!md || typeof md.enumerateDevices !== 'function') return null;
+    try {
+      const devices = await md.enumerateDevices();
+      return devices
+        .filter((d) => d?.kind === 'audioinput')
+        .map((d) => String(d?.deviceId ?? ''))
+        .sort()
+        .join('|');
+    } catch {
+      return null;
+    }
+  }
+
+  private async handleDeviceChange(): Promise<void> {
+    if (!this.attemptActive || this.terminal || !this.processor) return;
+    const gen = this.attemptGen;
+    const sig = await this.snapshotInputDevices();
+    if (gen !== this.attemptGen) return;
+    if (sig === null) return;
+    if (this.inputDeviceSig !== null && sig === this.inputDeviceSig) return; // output-only change
+    this.inputDeviceSig = sig;
+    this.recordDeviceEvent('input-devices-changed');
+    void this.startRecovery('reacquire');
   }
 }

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -714,10 +714,10 @@ export class VoiceTransport {
    *  teardownAudio; every async capture continuation validates BOTH gens. */
   private captureGen = 0;
   private captureState: CaptureState = 'observing';
-  /** attemptGen that owns the in-flight recovery loop (0 = none). Ownership
+  /** attemptGen that owns the in-flight recovery loop (-1 = none). Ownership
    *  is attempt-scoped: a stale loop (owner ≠ current attempt) is fenced-dead
    *  and must not swallow the live attempt's triggers. */
-  private recoveryOwner = 0;
+  private recoveryOwner = -1;
   /** A reacquire trigger arrived while a resume-recovery was in flight. */
   private recoveryEscalate = false;
   /** Sorted input-device fingerprint (null = cannot enumerate). */
@@ -2100,7 +2100,7 @@ export class VoiceTransport {
         'Microphone input could not be recovered',
       );
     } finally {
-      if (this.recoveryOwner === gen) this.recoveryOwner = 0;
+      if (this.recoveryOwner === gen) this.recoveryOwner = -1;
     }
   }
 
@@ -2261,8 +2261,8 @@ export class VoiceTransport {
     // this enumeration was pending bumped captureGen — acting on the stale
     // result would tear the fresh capture down again.
     if (gen !== this.attemptGen || capGen !== this.captureGen) return;
-    if (sig === null) return;
-    if (this.inputDeviceSig !== null && sig === this.inputDeviceSig) return; // output-only change
+    if (sig === null || this.inputDeviceSig === null) return;
+    if (sig === this.inputDeviceSig) return; // output-only change
     this.inputDeviceSig = sig;
     this.recordDeviceEvent('input-devices-changed');
     void this.startRecovery('reacquire');

--- a/tests/agent-state-protocol.test.ts
+++ b/tests/agent-state-protocol.test.ts
@@ -300,6 +300,19 @@ describe('publishLifecycleSnapshot — atomic temp+rename (A9)', () => {
 		} finally { rmSync(ws, { recursive: true, force: true }); }
 	});
 
+	it('P7 D7.1: inputHealth rides the snapshot additively when supplied', () => {
+		const ws = mkdtempSync(join(tmpdir(), 'agent-state-lifecycle-ih-'));
+		try {
+			publishLifecycleSnapshot(ws, frameFixture(), { now: () => 700, inputHealth: 'stalled' });
+			const snap = JSON.parse(readFileSync(voiceLifecyclePath(ws), 'utf-8'));
+			assert.equal(snap.inputHealth, 'stalled', 'P4\'s evidence ladder consumes this');
+			// Omitted → absent (additive field, older readers unaffected).
+			publishLifecycleSnapshot(ws, frameFixture(), { now: () => 701 });
+			const snap2 = JSON.parse(readFileSync(voiceLifecyclePath(ws), 'utf-8'));
+			assert.equal('inputHealth' in snap2, false);
+		} finally { rmSync(ws, { recursive: true, force: true }); }
+	});
+
 	it('category included only for failed frames; write errors go to onError (never throw)', () => {
 		const ws = mkdtempSync(join(tmpdir(), 'agent-state-lifecycle-cat-'));
 		try {

--- a/tests/screen-capture-server-auth.test.py
+++ b/tests/screen-capture-server-auth.test.py
@@ -227,6 +227,9 @@ def test_downscale_failure_only_allows_small_original() -> None:
         with unittest.mock.patch.object(sc.subprocess, "run", side_effect=RuntimeError("sips failed")):
             ok("downscale failure permits a small original", sc._downscale_frame(small.name, 1280, 60))
             ok("downscale failure rejects an over-budget original", not sc._downscale_frame(large.name, 1280, 60))
+    with unittest.mock.patch.object(sc.subprocess, "run", side_effect=RuntimeError("sips failed")), \
+         unittest.mock.patch.object(sc.os.path, "getsize", side_effect=OSError("stat failed")):
+        ok("downscale failure rejects an unreadable original", not sc._downscale_frame("missing.jpg", 1280, 60))
 
 
 def test_capture_downscale_options_and_failure_are_visible() -> None:
@@ -252,6 +255,11 @@ def test_capture_downscale_options_and_failure_are_visible() -> None:
     ok("downscale budget failure has a stable error", json.loads(failed._buf.getvalue()) == {
         "status": "error", "error": "downscale failed and frame exceeds budget"
     }, f"got body={failed._buf.getvalue()!r}")
+
+
+test_downscale_invokes_sips_with_bounds()
+test_downscale_failure_only_allows_small_original()
+test_capture_downscale_options_and_failure_are_visible()
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/screen-capture-server-auth.test.py
+++ b/tests/screen-capture-server-auth.test.py
@@ -204,6 +204,56 @@ test_load_reuses_existing_valid_token()
 test_load_rejects_wrong_permissions()
 
 # ---------------------------------------------------------------------------
+# Downscale budget tests
+# ---------------------------------------------------------------------------
+
+def test_downscale_invokes_sips_with_bounds() -> None:
+    with tempfile.NamedTemporaryFile() as frame:
+        with unittest.mock.patch.object(sc.subprocess, "run") as run:
+            ok_result = sc._downscale_frame(frame.name, 1280, 60)
+        ok("downscale succeeds when sips succeeds", ok_result)
+        ok("downscale bounds reach sips", run.call_args.args[0] == [
+            "sips", "--resampleHeightWidthMax", "1280", "-s", "format",
+            "jpeg", "-s", "formatOptions", "60", frame.name,
+        ], f"got {run.call_args.args[0] if run.call_args else None}")
+
+
+def test_downscale_failure_only_allows_small_original() -> None:
+    with tempfile.NamedTemporaryFile() as small, tempfile.NamedTemporaryFile() as large:
+        small.write(b"x")
+        small.flush()
+        large.write(b"x" * (sc.DOWNSCALE_FAIL_MAX_BYTES + 1))
+        large.flush()
+        with unittest.mock.patch.object(sc.subprocess, "run", side_effect=RuntimeError("sips failed")):
+            ok("downscale failure permits a small original", sc._downscale_frame(small.name, 1280, 60))
+            ok("downscale failure rejects an over-budget original", not sc._downscale_frame(large.name, 1280, 60))
+
+
+def test_capture_downscale_options_and_failure_are_visible() -> None:
+    handler = _FakeHandler("/capture?format=jpeg&maxdim=1280&quality=60&silent=true", "secret-token")
+    with unittest.mock.patch.object(sc, "CAPTURE_TOKEN", "secret-token"), \
+         unittest.mock.patch("os.makedirs"), \
+         unittest.mock.patch("subprocess.run"), \
+         unittest.mock.patch.object(sc, "_downscale_frame", return_value=True) as downscale:
+        handler._handle_capture()
+    ok("capture passes bounded JPEG options to downscale", downscale.call_args.args[1:] == (1280, 60),
+       f"got {downscale.call_args.args if downscale.call_args else None}")
+    ok("capture returns success after downscale", handler._response_code == 200,
+       f"got code={handler._response_code}")
+
+    failed = _FakeHandler("/capture?format=jpeg&maxdim=1280&quality=60&silent=true", "secret-token")
+    with unittest.mock.patch.object(sc, "CAPTURE_TOKEN", "secret-token"), \
+         unittest.mock.patch("os.makedirs"), \
+         unittest.mock.patch("subprocess.run"), \
+         unittest.mock.patch.object(sc, "_downscale_frame", return_value=False):
+        failed._handle_capture()
+    ok("capture rejects a frame that cannot meet the downscale budget", failed._response_code == 500,
+       f"got code={failed._response_code}")
+    ok("downscale budget failure has a stable error", json.loads(failed._buf.getvalue()) == {
+        "status": "error", "error": "downscale failed and frame exceeds budget"
+    }, f"got body={failed._buf.getvalue()!r}")
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/screen-companion-push-selection-e2e.test.ts
+++ b/tests/screen-companion-push-selection-e2e.test.ts
@@ -10,12 +10,23 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { setTimeout as delay } from 'node:timers/promises';
 import {
 	registerSource,
 	setVisionSession,
 	captureSendFrame,
+	resetVisionEgressForTests,
+	VISION_MIN_SEND_INTERVAL_MS,
 	_getVisionFrameHookCount,
 } from '../src/vision-tools.js';
+
+// P7 D7.4: real sends are paced by the egress token bucket (~1 fps) — the
+// e2e drives real sends, so it must respect the designed cadence.
+async function pacedCapture(name: string): Promise<Awaited<ReturnType<typeof captureSendFrame>>> {
+	const r = await captureSendFrame(name);
+	await delay(VISION_MIN_SEND_INTERVAL_MS + 50);
+	return r;
+}
 // Importing the skill registers `_frameHook` into vision-tools' hook registry
 // at module-load time (registerVisionFrameHook(_frameHook)).
 import {
@@ -46,12 +57,14 @@ test('captureAndSend fires the screen-companion hook and injects selection after
 	});
 
 	_resetFrameHookState();
+	resetVisionEgressForTests();
 	_setVisionQueryDeps({ readSelection: () => ({ text: 'HELLO', source: 'ax_selection' }) });
 	try {
-		// _frameHook probes every 3rd frame — drive 3 captures to hit the boundary.
-		await captureSendFrame('testsrc');
-		await captureSendFrame('testsrc');
-		await captureSendFrame('testsrc');
+		// _frameHook probes every 3rd frame — drive 3 PACED captures to hit
+		// the boundary (the P7 egress bucket caps real sends at ~1 fps).
+		await pacedCapture('testsrc');
+		await pacedCapture('testsrc');
+		await pacedCapture('testsrc');
 	} finally {
 		_resetVisionQueryDeps();
 	}
@@ -83,12 +96,13 @@ test('no injection when the session transport has no sendContent (graceful)', as
 	});
 
 	_resetFrameHookState();
+	resetVisionEgressForTests();
 	_setVisionQueryDeps({ readSelection: () => ({ text: 'HELLO', source: 'ax_selection' }) });
 	let r;
 	try {
-		await captureSendFrame('testsrc2');
-		await captureSendFrame('testsrc2');
-		r = await captureSendFrame('testsrc2'); // probe tick — would inject if sendContent existed
+		await pacedCapture('testsrc2');
+		await pacedCapture('testsrc2');
+		r = await pacedCapture('testsrc2'); // probe tick — would inject if sendContent existed
 	} finally {
 		_resetVisionQueryDeps();
 	}

--- a/tests/screen-companion-push-selection.test.ts
+++ b/tests/screen-companion-push-selection.test.ts
@@ -24,30 +24,37 @@ function makeCtx() {
 	return { calls, sendUserCtx };
 }
 
-function withSelection(
+async function withSelection(
 	result: SelectionResult | null,
 	fn: () => void,
-): void {
+): Promise<void> {
 	_setVisionQueryDeps({ readSelection: () => result });
-	try { fn(); } finally { _resetVisionQueryDeps(); }
+	try {
+		fn();
+		// P7: the hook's probe is fire-and-forget async — flush the microtask
+		// queue so injections land before the assertions run.
+		await new Promise((r) => setImmediate(r));
+	} finally {
+		_resetVisionQueryDeps();
+	}
 }
 
 // Each test resets module state first.
 
-test('does not call sendUserCtx on ticks 1 and 2 (below interval)', () => {
+test('does not call sendUserCtx on ticks 1 and 2 (below interval)', async () => {
 	_resetFrameHookState();
 	const { calls, sendUserCtx } = makeCtx();
-	withSelection({ text: 'hello', source: 'ax_selection' }, () => {
+	await withSelection({ text: 'hello', source: 'ax_selection' }, () => {
 		_frameHook(sendUserCtx); // tick 1
 		_frameHook(sendUserCtx); // tick 2
 	});
 	assert.deepEqual(calls, []);
 });
 
-test('injects selection on tick 3 when text is present', () => {
+test('injects selection on tick 3 when text is present', async () => {
 	_resetFrameHookState();
 	const { calls, sendUserCtx } = makeCtx();
-	withSelection({ text: 'hello', source: 'ax_selection' }, () => {
+	await withSelection({ text: 'hello', source: 'ax_selection' }, () => {
 		_frameHook(sendUserCtx); // 1
 		_frameHook(sendUserCtx); // 2
 		_frameHook(sendUserCtx); // 3 — probe fires
@@ -55,34 +62,34 @@ test('injects selection on tick 3 when text is present', () => {
 	assert.deepEqual(calls, ['[Selected text: hello]']);
 });
 
-test('does NOT inject again when selection unchanged on next interval', () => {
+test('does NOT inject again when selection unchanged on next interval', async () => {
 	_resetFrameHookState();
 	const { calls, sendUserCtx } = makeCtx();
-	withSelection({ text: 'hello', source: 'ax_selection' }, () => {
+	await withSelection({ text: 'hello', source: 'ax_selection' }, () => {
 		for (let i = 0; i < 6; i++) _frameHook(sendUserCtx); // ticks 1–6 (probes at 3, 6)
 	});
 	// Both probes return 'hello'; should inject only once (first change: '' → 'hello')
 	assert.deepEqual(calls, ['[Selected text: hello]']);
 });
 
-test('injects again when selection text changes', () => {
+test('injects again when selection text changes', async () => {
 	_resetFrameHookState();
 	const { calls, sendUserCtx } = makeCtx();
 	// First probe: 'hello'
-	withSelection({ text: 'hello', source: 'ax_selection' }, () => {
+	await withSelection({ text: 'hello', source: 'ax_selection' }, () => {
 		for (let i = 0; i < 3; i++) _frameHook(sendUserCtx);
 	});
 	// Second probe interval: 'world'
-	withSelection({ text: 'world', source: 'ax_selection' }, () => {
+	await withSelection({ text: 'world', source: 'ax_selection' }, () => {
 		for (let i = 0; i < 3; i++) _frameHook(sendUserCtx);
 	});
 	assert.deepEqual(calls, ['[Selected text: hello]', '[Selected text: world]']);
 });
 
-test('does not inject when no selection is found', () => {
+test('does not inject when no selection is found', async () => {
 	_resetFrameHookState();
 	const { calls, sendUserCtx } = makeCtx();
-	withSelection(null, () => {
+	await withSelection(null, () => {
 		for (let i = 0; i < 3; i++) _frameHook(sendUserCtx); // probe fires on tick 3, returns null
 	});
 	assert.deepEqual(calls, []);

--- a/tests/vision-capture-server-path.test.ts
+++ b/tests/vision-capture-server-path.test.ts
@@ -1,0 +1,64 @@
+// The bundled-build Watch regression (field report 2026-08-14): the lazy
+// screen-capture-server spawn resolved the .py next to the RUNNING module,
+// which is dist/voice-agent.js in the bundle — and dist/ ships no .py files,
+// so every attempt died as a silent 8s port timeout. The fix resolves from
+// the sutando root (marker: sutando.config.json — the same walk
+// python-binary.ts uses) with the module-sibling kept as the dev fallback.
+// These tests pin the candidate order against both on-disk shapes.
+
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { _captureServerScriptCandidates } from '../src/vision-tools.js';
+
+const scratch = mkdtempSync(join(tmpdir(), 'capture-path-'));
+after(() => {
+	try {
+		rmSync(scratch, { recursive: true, force: true });
+	} catch {
+		/* best effort */
+	}
+});
+
+describe('P7 bundled-build capture-server path resolution', () => {
+	it('bundle shape: module runs from dist/, script ships in the SIBLING src/ — root candidate wins', () => {
+		const root = join(scratch, 'bundle', 'sutando');
+		mkdirSync(join(root, 'dist'), { recursive: true });
+		mkdirSync(join(root, 'src'), { recursive: true });
+		writeFileSync(join(root, 'sutando.config.json'), '{}');
+		writeFileSync(join(root, 'src', 'screen-capture-server.py'), '# server');
+		const candidates = _captureServerScriptCandidates(join(root, 'dist'));
+		assert.equal(candidates[0], join(root, 'src', 'screen-capture-server.py'));
+		const resolved = candidates.find((c) => existsSync(c));
+		assert.equal(resolved, join(root, 'src', 'screen-capture-server.py'), 'the bundle resolves to the shipped copy');
+	});
+
+	it('dev shape: module runs from src/ — root candidate and sibling coincide, deduplicated', () => {
+		const root = join(scratch, 'dev', 'sutando');
+		mkdirSync(join(root, 'src'), { recursive: true });
+		writeFileSync(join(root, 'sutando.config.json'), '{}');
+		writeFileSync(join(root, 'src', 'screen-capture-server.py'), '# server');
+		const candidates = _captureServerScriptCandidates(join(root, 'src'));
+		assert.deepEqual(candidates, [join(root, 'src', 'screen-capture-server.py')], 'one deduplicated candidate');
+	});
+
+	it('no root marker: falls back to the module sibling (pre-fix behavior preserved for exotic layouts)', () => {
+		const bare = join(scratch, 'bare');
+		mkdirSync(bare, { recursive: true });
+		const candidates = _captureServerScriptCandidates(bare);
+		assert.ok(candidates.includes(join(bare, 'screen-capture-server.py')));
+	});
+
+	it('the real repo resolves to an existing script from BOTH src/ and a simulated dist/', () => {
+		// Run against the actual checkout: from src/ (dev truth) and from a
+		// hypothetical sibling dist/ (bundle truth) the walk must land on the
+		// same real file.
+		const realSrc = join(process.cwd(), 'src');
+		const fromSrc = _captureServerScriptCandidates(realSrc).find((c) => existsSync(c));
+		assert.ok(fromSrc && fromSrc.endsWith(join('src', 'screen-capture-server.py')));
+		const fromDist = _captureServerScriptCandidates(join(process.cwd(), 'dist')).find((c) => existsSync(c));
+		assert.equal(fromDist, fromSrc, 'dist-resident module finds the same shipped script');
+	});
+});

--- a/tests/vision-egress-controls.test.ts
+++ b/tests/vision-egress-controls.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { setTimeout as delay } from 'node:timers/promises';
+import {
+	setVisionSession,
+	setVisionSpeechEvidence,
+	submitFrame,
+	startStreaming,
+	stopStreaming,
+	getVisionEgressStats,
+	getVisionState,
+	resetVisionEgressForTests,
+	VISION_MIN_SEND_INTERVAL_MS,
+} from '../src/vision-tools.js';
+
+/** Fake VoiceSession exposing exactly what the vision egress path reads. */
+function fakeSession(state = 'ACTIVE') {
+	const sent: Array<{ b64: string; mime: string }> = [];
+	const session = {
+		sessionManager: { state },
+		transport: {
+			isConnected: true,
+			sendFile(b64: string, mime: string) {
+				sent.push({ b64, mime });
+			},
+			sendContent() {},
+		},
+	};
+	return { session, sent };
+}
+
+function frameBuf(fill: number, size = 10_000): Buffer {
+	return Buffer.alloc(size, fill);
+}
+
+beforeEach(() => {
+	stopStreaming();
+	setVisionSession(null);
+	setVisionSpeechEvidence(null);
+	resetVisionEgressForTests();
+});
+
+describe('P7 D7.4 vision egress controls', () => {
+	it('browser push rides the central gate: ACTIVE sends, non-ACTIVE defers to the latest-frame slot', async () => {
+		const { session, sent } = fakeSession('CONNECTING');
+		setVisionSession(session);
+		startStreaming('browser', undefined, 'push');
+		const before = getVisionEgressStats();
+		const r = submitFrame(frameBuf(1));
+		assert.equal(r.ok, true);
+		assert.equal(r.deferred, true, 'session not ACTIVE — parked, not sent');
+		assert.equal(sent.length, 0);
+		assert.equal(getVisionEgressStats().deferredGate, before.deferredGate + 1);
+		assert.equal(getVisionEgressStats().slotOccupied, true);
+		// The gate opening lets the drain timer deliver the PARKED frame.
+		session.sessionManager.state = 'ACTIVE';
+		await delay(400);
+		assert.equal(sent.length, 1, 'parked frame drained once the gate opened');
+		assert.equal(getVisionEgressStats().slotOccupied, false);
+		stopStreaming();
+	});
+
+	it('pause-during-speech: frames defer while the canonical speech evidence is active', async () => {
+		const { session, sent } = fakeSession();
+		setVisionSession(session);
+		let speaking = true;
+		setVisionSpeechEvidence(() => ({ active: speaking }));
+		startStreaming('browser', undefined, 'push');
+		const r = submitFrame(frameBuf(2));
+		assert.equal(r.deferred, true);
+		assert.equal(sent.length, 0, 'no vision while the user speaks');
+		speaking = false;
+		await delay(400);
+		assert.equal(sent.length, 1, 'deferred frame followed the speech, not preceded it');
+		stopStreaming();
+	});
+
+	it('latest-frame-only slot: a burst while gated keeps ONLY the newest frame (no backlog — FE-1 rule)', async () => {
+		const { session, sent } = fakeSession();
+		setVisionSession(session);
+		let speaking = true;
+		setVisionSpeechEvidence(() => ({ active: speaking }));
+		startStreaming('browser', undefined, 'push');
+		const d0 = getVisionEgressStats().displaced;
+		submitFrame(frameBuf(0x11));
+		submitFrame(frameBuf(0x22));
+		submitFrame(frameBuf(0x33));
+		assert.equal(getVisionEgressStats().displaced, d0 + 2, 'two frames displaced forever');
+		speaking = false;
+		await delay(400);
+		assert.equal(sent.length, 1, 'exactly one frame — never a drained backlog');
+		assert.equal(Buffer.from(sent[0].b64, 'base64')[0], 0x33, 'and it is the NEWEST');
+		stopStreaming();
+	});
+
+	it('fps cap: a second frame inside the send interval defers on budget', () => {
+		const { session, sent } = fakeSession();
+		setVisionSession(session);
+		startStreaming('browser', undefined, 'push');
+		const r1 = submitFrame(frameBuf(1));
+		assert.equal(r1.deferred, undefined, 'first frame sends');
+		const r2 = submitFrame(frameBuf(2));
+		assert.equal(r2.deferred, true, `second frame within ${VISION_MIN_SEND_INTERVAL_MS}ms is over budget`);
+		assert.equal(sent.length, 1);
+		assert.ok(getVisionEgressStats().deferredBudget >= 1);
+		stopStreaming();
+	});
+
+	it('stopStream clears the parked frame — stale vision never leaks into the next session', () => {
+		const { session, sent } = fakeSession('CONNECTING');
+		setVisionSession(session);
+		startStreaming('browser', undefined, 'push');
+		submitFrame(frameBuf(9));
+		assert.equal(getVisionEgressStats().slotOccupied, true);
+		stopStreaming();
+		assert.equal(getVisionEgressStats().slotOccupied, false);
+		assert.equal(sent.length, 0);
+	});
+
+	it('getVisionState exposes the egress diagnostics', () => {
+		const st = getVisionState();
+		assert.equal(typeof st.egress.sent, 'number');
+		assert.equal(typeof st.egress.deferredGate, 'number');
+		assert.equal(typeof st.egress.deferredBudget, 'number');
+		assert.equal(typeof st.egress.displaced, 'number');
+		assert.equal(typeof st.egress.slotOccupied, 'boolean');
+	});
+
+	it('§D7.0b budget guard: the residual voice-loop cost of a worst-case 720p frame is bounded', () => {
+		// The named residual: base64 + the SDK's synchronous stringify of the
+		// frame message. At the downscaled ~150 KB budget this must stay in
+		// the low milliseconds.
+		const frame = Buffer.alloc(150 * 1024, 0xab);
+		const t0 = process.hrtime.bigint();
+		const b64 = frame.toString('base64');
+		const msg = JSON.stringify({ realtime_input: { video: { data: b64, mimeType: 'image/jpeg' } } });
+		const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+		assert.ok(msg.length > frame.length);
+		assert.ok(ms < 25, `base64+stringify took ${ms.toFixed(1)}ms — downscale budget violated`);
+	});
+});

--- a/tests/vision-egress-controls.test.ts
+++ b/tests/vision-egress-controls.test.ts
@@ -7,6 +7,7 @@ import {
 	submitFrame,
 	startStreaming,
 	stopStreaming,
+	registerSource,
 	getVisionEgressStats,
 	getVisionState,
 	resetVisionEgressForTests,
@@ -115,6 +116,37 @@ describe('P7 D7.4 vision egress controls', () => {
 		stopStreaming();
 		assert.equal(getVisionEgressStats().slotOccupied, false);
 		assert.equal(sent.length, 0);
+	});
+
+	it('wire-byte accounting: the bucket charges base64 size (4/3 of raw)', () => {
+		const { session, sent } = fakeSession();
+		setVisionSession(session);
+		startStreaming('browser', undefined, 'push');
+		// 500 KB raw fits the 600 KB burst raw-wise, but its 667 KB wire size
+		// must NOT pass (round-3 #10: raw accounting under-charged by 25%).
+		const r = submitFrame(frameBuf(1, 500 * 1024));
+		assert.equal(r.deferred, true, 'over the encoded-bytes burst → deferred');
+		assert.equal(sent.length, 0);
+		stopStreaming();
+	});
+
+	it('stopStreaming fences an in-flight pull capture — the stale frame never sends', async () => {
+		const { session, sent } = fakeSession();
+		setVisionSession(session);
+		let releaseCapture!: () => void;
+		registerSource({
+			name: 'slowsrc',
+			capture: () =>
+				new Promise((res) => {
+					releaseCapture = () => res({ data: frameBuf(7), mimeType: 'image/jpeg' });
+				}),
+		});
+		startStreaming('slowsrc', 1, 'pull'); // startStream fires an immediate tick
+		await delay(10); // the tick is parked inside capture()
+		stopStreaming();
+		releaseCapture(); // slow source finally returns — AFTER the stop
+		await delay(10);
+		assert.equal(sent.length, 0, 'stop semantics beat a slow source');
 	});
 
 	it('getVisionState exposes the egress diagnostics', () => {

--- a/tests/vision-egress-controls.test.ts
+++ b/tests/vision-egress-controls.test.ts
@@ -118,15 +118,32 @@ describe('P7 D7.4 vision egress controls', () => {
 		assert.equal(sent.length, 0);
 	});
 
-	it('wire-byte accounting: the bucket charges base64 size (4/3 of raw)', () => {
+	it('wire-byte accounting: an over-burst base64 frame is rejected rather than deferred forever', () => {
 		const { session, sent } = fakeSession();
 		setVisionSession(session);
 		startStreaming('browser', undefined, 'push');
 		// 500 KB raw fits the 600 KB burst raw-wise, but its 667 KB wire size
-		// must NOT pass (round-3 #10: raw accounting under-charged by 25%).
+		// cannot ever fit the encoded-byte burst budget.
 		const r = submitFrame(frameBuf(1, 500 * 1024));
-		assert.equal(r.deferred, true, 'over the encoded-bytes burst → deferred');
+		assert.equal(r.ok, false);
+		assert.equal(r.reason, 'frame-too-large');
+		assert.match(r.error ?? '', /vision egress budget/);
 		assert.equal(sent.length, 0);
+		assert.equal(getVisionEgressStats().droppedOversize, 1);
+		assert.equal(getVisionEgressStats().slotOccupied, false);
+		stopStreaming();
+	});
+
+	it('pull cadence is capped by the egress send interval', () => {
+		const { session } = fakeSession();
+		setVisionSession(session);
+		registerSource({ name: 'fps-cap-source', capture: async () => ({ data: frameBuf(1), mimeType: 'image/jpeg' }) });
+		const r = startStreaming('fps-cap-source', 2, 'pull');
+		assert.equal(r.status, 'streaming');
+		if (r.status === 'streaming') {
+			assert.equal(r.intervalMs, VISION_MIN_SEND_INTERVAL_MS);
+			assert.equal(r.fps, 1000 / VISION_MIN_SEND_INTERVAL_MS);
+		}
 		stopStreaming();
 	});
 
@@ -155,6 +172,7 @@ describe('P7 D7.4 vision egress controls', () => {
 		assert.equal(typeof st.egress.deferredGate, 'number');
 		assert.equal(typeof st.egress.deferredBudget, 'number');
 		assert.equal(typeof st.egress.displaced, 'number');
+		assert.equal(typeof st.egress.droppedOversize, 'number');
 		assert.equal(typeof st.egress.slotOccupied, 'boolean');
 	});
 

--- a/tests/voice-audio-health-persist.test.ts
+++ b/tests/voice-audio-health-persist.test.ts
@@ -37,14 +37,14 @@ describe('P7 D7.1 voice_audio_health persistence (worker_threads)', () => {
 		await p.close(); // terminate(): the worker-thread SIGKILL analog — no flush
 		const db = new DatabaseSync(dbPath);
 		const rows = db
-			.prepare('SELECT session_id, epoch, nonce, reason, payload FROM voice_audio_health')
+			.prepare('SELECT session_id, epoch, nonce, reason, payload_json FROM voice_audio_health')
 			.all() as Array<Record<string, unknown>>;
 		db.close();
 		assert.equal(rows.length, 1);
 		assert.equal(rows[0].session_id, 'session_test');
 		assert.equal(rows[0].epoch, 123);
 		assert.equal(rows[0].reason, 'anomaly');
-		assert.equal(rows[0].payload, '{"coverage":"session-only"}');
+		assert.equal(rows[0].payload_json, '{"coverage":"session-only"}');
 	});
 
 	it('one-slot mailbox: a second enqueue while the slot is in flight is refused', async () => {
@@ -59,20 +59,61 @@ describe('P7 D7.1 voice_audio_health persistence (worker_threads)', () => {
 		await p.close();
 	});
 
-	it('row cap retention: only the newest maxRows survive', async () => {
+	it('row cap retention is PER SESSION: one busy session cannot evict another\'s evidence', async () => {
 		const dbPath = join(dir, 'cap.sqlite');
-		const p = createHealthPersistence({ dbPath, maxRows: 3 });
-		for (let i = 0; i < 5; i++) {
-			assert.equal(p.tryEnqueue(row({ epoch: i })), true);
+		const p = createHealthPersistence({ dbPath, maxRows: 2 });
+		for (const [sid, epoch] of [
+			['A', 1],
+			['A', 2],
+			['B', 3],
+			['B', 4],
+			['B', 5],
+		] as Array<[string, number]>) {
+			assert.equal(p.tryEnqueue(row({ sessionId: sid, epoch })), true);
 			await p.drain();
 		}
+		await p.close();
+		const db = new DatabaseSync(dbPath);
+		const rows = (db
+			.prepare('SELECT session_id, epoch FROM voice_audio_health ORDER BY id')
+			.all() as Array<{ session_id: string; epoch: number }>).map((r) => `${r.session_id}:${r.epoch}`);
+		db.close();
+		assert.deepEqual(rows, ['A:1', 'A:2', 'B:4', 'B:5'], 'B capped to 2 without touching A');
+	});
+
+	it('30-day retention sweep prunes ancient rows on the next write', async () => {
+		const dbPath = join(dir, 'age.sqlite');
+		const p = createHealthPersistence({ dbPath });
+		assert.equal(p.tryEnqueue(row({ tsUnix: Math.floor(Date.now() / 1000) - 40 * 24 * 3600, epoch: 1 })), true);
+		await p.drain();
+		assert.equal(p.tryEnqueue(row({ epoch: 2 })), true);
+		await p.drain();
 		await p.close();
 		const db = new DatabaseSync(dbPath);
 		const epochs = (db.prepare('SELECT epoch FROM voice_audio_health ORDER BY id').all() as Array<{ epoch: number }>).map(
 			(r) => r.epoch,
 		);
 		db.close();
-		assert.deepEqual(epochs, [2, 3, 4], 'oldest rows pruned at the cap');
+		assert.deepEqual(epochs, [2], 'the 40-day-old row was swept');
+	});
+
+	it('a busy/locked health DB never blocks the caller: tryEnqueue refuses instead of waiting', async () => {
+		const dbPath = join(dir, 'locked.sqlite');
+		const p = createHealthPersistence({ dbPath });
+		assert.equal(p.tryEnqueue(row({ epoch: 1 })), true);
+		await p.drain();
+		// Hold an exclusive transaction from THIS thread — the worker's next
+		// write will sit in its busy_timeout inside the worker.
+		const locker = new DatabaseSync(dbPath);
+		locker.exec('BEGIN EXCLUSIVE');
+		const t0 = Date.now();
+		assert.equal(p.tryEnqueue(row({ epoch: 2 })), true, 'slot accepts — the WORKER blocks, not us');
+		assert.equal(p.tryEnqueue(row({ epoch: 3 })), false, 'slot busy → skip, zero waiting');
+		assert.ok(Date.now() - t0 < 100, 'the voice loop side never blocked');
+		locker.exec('ROLLBACK');
+		locker.close();
+		await p.drain();
+		await p.close();
 	});
 
 	it('a failing write acks ok:false — visible in failedWrites, worker stays up', async () => {

--- a/tests/voice-audio-health-persist.test.ts
+++ b/tests/voice-audio-health-persist.test.ts
@@ -116,6 +116,32 @@ describe('P7 D7.1 voice_audio_health persistence (worker_threads)', () => {
 		await p.close();
 	});
 
+	it('a legacy database (pre-rename payload column) is migrated, not bricked', async () => {
+		const dbPath = join(dir, 'legacy.sqlite');
+		const legacy = new DatabaseSync(dbPath);
+		legacy.exec('CREATE TABLE voice_audio_health (' +
+			'id INTEGER PRIMARY KEY AUTOINCREMENT,' +
+			'ts_unix INTEGER NOT NULL,' +
+			'session_id TEXT NOT NULL,' +
+			'epoch INTEGER,' +
+			'nonce TEXT,' +
+			'reason TEXT NOT NULL,' +
+			'payload TEXT NOT NULL)');
+		legacy
+			.prepare('INSERT INTO voice_audio_health (ts_unix, session_id, epoch, nonce, reason, payload) VALUES (?, ?, ?, ?, ?, ?)')
+			.run(Math.floor(Date.now() / 1000), 'session_old', 1, 'aaaa', 'timer', '{"old":true}');
+		legacy.close();
+		const p = createHealthPersistence({ dbPath });
+		assert.equal(p.tryEnqueue(row({ epoch: 2 })), true);
+		await p.drain();
+		await p.close();
+		assert.equal(p.failedWrites, 0, 'insert succeeded against the migrated schema');
+		const db = new DatabaseSync(dbPath);
+		const rows = (db.prepare('SELECT payload_json FROM voice_audio_health ORDER BY id').all() as Array<{ payload_json: string }>).map((r) => r.payload_json);
+		db.close();
+		assert.deepEqual(rows, ['{"old":true}', '{"coverage":"session-only"}'], 'old rows preserved under the new column');
+	});
+
 	it('a failing write acks ok:false — visible in failedWrites, worker stays up', async () => {
 		// A file path whose parent is a FILE cannot be opened as a database.
 		const bad = join(dir, 'not-a-dir.sqlite');

--- a/tests/voice-audio-health-persist.test.ts
+++ b/tests/voice-audio-health-persist.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { createHealthPersistence } from '../src/voice-audio-health-persist.js';
+import type { HealthRow } from '../src/voice-audio-health.js';
+
+const dir = mkdtempSync(join(tmpdir(), 'vah-test-'));
+after(() => {
+	try {
+		rmSync(dir, { recursive: true, force: true });
+	} catch {
+		/* best effort */
+	}
+});
+
+function row(over: Partial<HealthRow> = {}): HealthRow {
+	return {
+		tsUnix: Math.floor(Date.now() / 1000),
+		sessionId: 'session_test',
+		epoch: 123,
+		nonce: 'abcd1234',
+		reason: 'timer',
+		payload: '{"coverage":"session-only"}',
+		...over,
+	};
+}
+
+describe('P7 D7.1 voice_audio_health persistence (worker_threads)', () => {
+	it('a drained row is on disk BEFORE the ack — surviving an abrupt worker kill (crash path)', async () => {
+		const dbPath = join(dir, 'crash.sqlite');
+		const p = createHealthPersistence({ dbPath });
+		assert.equal(p.tryEnqueue(row({ reason: 'anomaly' })), true);
+		await p.drain(); // ack ⇒ INSERT committed
+		await p.close(); // terminate(): the worker-thread SIGKILL analog — no flush
+		const db = new DatabaseSync(dbPath);
+		const rows = db
+			.prepare('SELECT session_id, epoch, nonce, reason, payload FROM voice_audio_health')
+			.all() as Array<Record<string, unknown>>;
+		db.close();
+		assert.equal(rows.length, 1);
+		assert.equal(rows[0].session_id, 'session_test');
+		assert.equal(rows[0].epoch, 123);
+		assert.equal(rows[0].reason, 'anomaly');
+		assert.equal(rows[0].payload, '{"coverage":"session-only"}');
+	});
+
+	it('one-slot mailbox: a second enqueue while the slot is in flight is refused', async () => {
+		const dbPath = join(dir, 'slot.sqlite');
+		const p = createHealthPersistence({ dbPath });
+		assert.equal(p.tryEnqueue(row()), true);
+		// Synchronously after the first postMessage the ack cannot have run yet.
+		assert.equal(p.tryEnqueue(row()), false, 'slot busy → skip, never queue');
+		await p.drain();
+		assert.equal(p.tryEnqueue(row()), true, 'slot free again after the ack');
+		await p.drain();
+		await p.close();
+	});
+
+	it('row cap retention: only the newest maxRows survive', async () => {
+		const dbPath = join(dir, 'cap.sqlite');
+		const p = createHealthPersistence({ dbPath, maxRows: 3 });
+		for (let i = 0; i < 5; i++) {
+			assert.equal(p.tryEnqueue(row({ epoch: i })), true);
+			await p.drain();
+		}
+		await p.close();
+		const db = new DatabaseSync(dbPath);
+		const epochs = (db.prepare('SELECT epoch FROM voice_audio_health ORDER BY id').all() as Array<{ epoch: number }>).map(
+			(r) => r.epoch,
+		);
+		db.close();
+		assert.deepEqual(epochs, [2, 3, 4], 'oldest rows pruned at the cap');
+	});
+
+	it('a failing write acks ok:false — visible in failedWrites, worker stays up', async () => {
+		// A file path whose parent is a FILE cannot be opened as a database.
+		const bad = join(dir, 'not-a-dir.sqlite');
+		const p0 = createHealthPersistence({ dbPath: bad });
+		assert.equal(p0.tryEnqueue(row()), true);
+		await p0.drain();
+		await p0.close();
+		const p = createHealthPersistence({ dbPath: join(bad, 'child.sqlite') });
+		assert.equal(p.tryEnqueue(row()), true);
+		await p.drain();
+		assert.equal(p.failedWrites, 1);
+		assert.equal(p.broken, false, 'a write failure is a skipped sample, not a dead worker');
+		assert.equal(p.tryEnqueue(row()), true, 'later samples still accepted');
+		await p.drain();
+		await p.close();
+	});
+});

--- a/tests/voice-audio-health.test.ts
+++ b/tests/voice-audio-health.test.ts
@@ -69,8 +69,8 @@ describe('P7 D7.1 parseHeartbeat', () => {
 		assert.deepEqual(hb.openGap, { startMs: 10, ageMs: 1500 });
 		assert.equal(hb.episodeOverflow, 3);
 		assert.deepEqual(hb.episodes, [
-			{ id: 1, kind: 'gap' },
-			{ id: 2, kind: 'speech' },
+			{ id: 1, kind: 'gap', startMs: 0, durationMs: 1200 },
+			{ id: 2, kind: 'speech', onsetSeq: 5, offsetSeq: 9, maxRmsPm: 300, aboveFloorMs: 172 },
 		]);
 		assert.equal(hb.receivedAt, 5000);
 	});

--- a/tests/voice-audio-health.test.ts
+++ b/tests/voice-audio-health.test.ts
@@ -1,0 +1,291 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	createAudioHealthLedger,
+	parseHeartbeat,
+	type HealthRow,
+} from '../src/voice-audio-health.js';
+
+/** Int16LE PCM buffer at a constant normalized amplitude. */
+function pcm(amplitude: number, samples = 682): Buffer {
+	const buf = Buffer.alloc(samples * 2);
+	const v = Math.round(amplitude * 32767);
+	for (let i = 0; i < samples; i++) buf.writeInt16LE(v, i * 2);
+	return buf;
+}
+
+/** A minimal valid wire heartbeat (delta counters). */
+function wireHb(nonce: string, over: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		t: 'audio_health',
+		n: nonce,
+		q: 0,
+		c: [47, 64000, 0, 0, 100, 100, 98, 2],
+		x: [2000, 3, 120],
+		cs: 'r',
+		cap: 'o',
+		...over,
+	};
+}
+
+function makeLedger(now: { t: number }, persist?: (row: HealthRow) => boolean) {
+	return createAudioHealthLedger({
+		sessionId: 'session_test',
+		nowFn: () => now.t,
+		persist,
+		log: () => {},
+	});
+}
+
+/** Fake session exposing the three wrapped seams. */
+function fakeSession() {
+	const calls = { audio: [] as unknown[], json: [] as unknown[], out: [] as unknown[] };
+	return {
+		calls,
+		handleAudioFromClient(data: unknown) {
+			calls.audio.push(data);
+		},
+		handleJsonFromClient(msg: unknown) {
+			calls.json.push(msg);
+		},
+		handleAudioOutput(data: unknown) {
+			calls.out.push(data);
+		},
+	};
+}
+
+describe('P7 D7.1 parseHeartbeat', () => {
+	it('parses a full frame and tolerates unknown fields', () => {
+		const hb = parseHeartbeat(
+			wireHb('abcd1234', { zz: 'future-field', mu: 1, sc: 2, ba: [100, 900], og: [10, 1500], eo: 3, ep: [[1, 'g', 0, 1200], [2, 's', 5, 9, 300, 172]] }),
+			5000,
+		);
+		assert.ok(hb);
+		assert.equal(hb.nonce, 'abcd1234');
+		assert.equal(hb.capCallbacks, 47);
+		assert.equal(hb.bytesSent, 64000);
+		assert.equal(hb.muted, true);
+		assert.equal(hb.ctxSuspendCount, 2);
+		assert.deepEqual(hb.openGap, { startMs: 10, ageMs: 1500 });
+		assert.equal(hb.episodeOverflow, 3);
+		assert.deepEqual(hb.episodes, [
+			{ id: 1, kind: 'gap' },
+			{ id: 2, kind: 'speech' },
+		]);
+		assert.equal(hb.receivedAt, 5000);
+	});
+
+	it('rejects non-heartbeat shapes', () => {
+		assert.equal(parseHeartbeat(null, 0), null);
+		assert.equal(parseHeartbeat({ t: 'other' }, 0), null);
+		assert.equal(parseHeartbeat({ t: 'audio_health' }, 0), null); // no nonce
+		assert.equal(parseHeartbeat('audio_health', 0), null);
+	});
+
+	it('tolerates missing optionals (absent c/x/ba/og/ep)', () => {
+		const hb = parseHeartbeat({ t: 'audio_health', n: 'x1', q: 4 }, 1);
+		assert.ok(hb);
+		assert.equal(hb.capCallbacks, 0);
+		assert.equal(hb.openGap, null);
+		assert.deepEqual(hb.episodes, []);
+	});
+});
+
+describe('P7 D7.1 engine ledger — wraps', () => {
+	it('audio wrap is transparent (same Buffer through) and counts delivered frames', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		const b = pcm(0.3);
+		s.handleAudioFromClient(b);
+		assert.equal(s.calls.audio.length, 1);
+		assert.equal(s.calls.audio[0], b, 'exact same Buffer delivered');
+		const snap = led.getSnapshot(true);
+		assert.equal(snap.deliveredFrames, 1);
+		assert.equal(snap.deliveredBytes, b.length);
+		assert.equal(snap.coverage, 'session-only');
+	});
+
+	it('audio_health frames are intercepted (never routed into bodhi); other JSON passes through', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleJsonFromClient(wireHb('n0n0n0n0'));
+		s.handleJsonFromClient({ type: 'text_input', text: 'hi' });
+		assert.equal(s.calls.json.length, 1, 'heartbeat swallowed');
+		assert.deepEqual(s.calls.json[0], { type: 'text_input', text: 'hi' });
+		assert.equal(led.getSnapshot(true).heartbeatCount, 1);
+	});
+
+	it('a malformed heartbeat never breaks the message path', () => {
+		const led = makeLedger({ t: 0 });
+		const s = fakeSession();
+		led.wrapSession(s);
+		assert.doesNotThrow(() => s.handleJsonFromClient({ t: 'audio_health', n: 42, c: 'bogus' }));
+	});
+
+	it('egress wrap counts frames/bytes and passes through; wrap is idempotent', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		led.wrapSession(s); // second wrap must be a no-op
+		const b64 = Buffer.from('abcdef').toString('base64');
+		s.handleAudioOutput(b64);
+		assert.equal(s.calls.out.length, 1, 'idempotent wrap: exactly one delivery');
+		const snap = led.getSnapshot(true);
+		assert.equal(snap.egressFrames, 1);
+		assert.equal(snap.egressBytes, 6);
+	});
+});
+
+describe('P7 D7.1 engine ledger — epoch minting (Tranche A nonce scheme)', () => {
+	it('mints on first sight, stays stable per nonce, advances per new nonce, resets baselines', () => {
+		const now = { t: 50_000 };
+		const led = makeLedger(now);
+		led.ingestHeartbeat(wireHb('nonceAAA'));
+		const e1 = led.getSnapshot(true).epoch;
+		assert.ok(e1 && e1 >= 50_000, 'engine-minted epoch');
+		led.ingestHeartbeat(wireHb('nonceAAA', { q: 1 }));
+		assert.equal(led.getSnapshot(true).epoch, e1, 'stable for the same connection');
+		assert.equal(led.getSnapshot(true).clientTotals.capCallbacks, 94, 'deltas accumulate');
+		now.t += 10;
+		led.ingestHeartbeat(wireHb('nonceBBB'));
+		const snap = led.getSnapshot(true);
+		assert.ok(snap.epoch && snap.epoch > e1!, 'new connection = strictly newer epoch');
+		assert.equal(snap.nonce, 'nonceBBB');
+		assert.equal(snap.clientTotals.capCallbacks, 47, 'totals reset at the epoch boundary');
+	});
+
+	it('onClientConnected clears the pending epoch and per-epoch counters', () => {
+		const now = { t: 50_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.1));
+		led.ingestHeartbeat(wireHb('nonceAAA'));
+		led.onClientConnected();
+		const snap = led.getSnapshot(true);
+		assert.equal(snap.epoch, null);
+		assert.equal(snap.deliveredFrames, 0);
+		assert.equal(snap.heartbeatCount, 0);
+	});
+});
+
+describe('P7 D7.1 engine ledger — ingress speech tracker (canonical evidence)', () => {
+	it('latches onset on loud PCM and decays lazily after the hangover', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.3));
+		let ev = led.getSpeechEvidence();
+		assert.equal(ev.active, true);
+		assert.equal(ev.onsetAt, 10_000);
+		now.t += 300;
+		s.handleAudioFromClient(pcm(0.25));
+		now.t += 700; // no frames at all (stall) — lazy decay must end the evidence
+		ev = led.getSpeechEvidence();
+		assert.equal(ev.active, false, 'hangover elapsed with no above-floor frame');
+		assert.equal(ev.lastAboveFloorAt, 10_300);
+	});
+
+	it('quiet PCM is not speech', () => {
+		const led = makeLedger({ t: 10_000 });
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.005));
+		assert.equal(led.getSpeechEvidence().active, false);
+	});
+});
+
+describe('P7 D7.1 engine ledger — inputHealth + anomaly latching', () => {
+	it('inputHealth: no-client / unknown / ok / stalled(og) / stalled(ingress-stale)', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		assert.equal(led.getInputHealth(false), 'no-client');
+		assert.equal(led.getInputHealth(true), 'unknown', 'no evidence yet');
+		s.handleAudioFromClient(pcm(0.1));
+		assert.equal(led.getInputHealth(true), 'ok');
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { og: [0, 1500] }));
+		assert.equal(led.getInputHealth(true), 'stalled', 'client-reported open gap');
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 1 })); // gap closed
+		assert.equal(led.getInputHealth(true), 'ok');
+		now.t += 6000; // ingress silent past the stall bound while unmuted
+		assert.equal(led.getInputHealth(true), 'stalled');
+	});
+
+	it('anomalies latch per tick and clear on read; muted suppresses the ingress-stall reason', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.1));
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { ep: [[1, 'g', 0, 1200]], og: [0, 1500] }));
+		const a1 = led.anomalySinceLastTick(true);
+		assert.equal(a1.anomalous, true);
+		assert.ok(a1.reasons.includes('capStalled'));
+		assert.ok(a1.reasons.some((r) => r.startsWith('episodes:')));
+		// same episode re-sent (idempotent window) → no NEW episode anomaly
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 1, ep: [[1, 'g', 0, 1200]], og: [0, 3500] }));
+		const a2 = led.anomalySinceLastTick(true);
+		assert.ok(!a2.reasons.some((r) => r.startsWith('episodes:')), 'dedup by episode id');
+		now.t += 6000;
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 2, mu: 1 }));
+		const a3 = led.anomalySinceLastTick(true);
+		assert.ok(!a3.reasons.includes('ingress-stalled'), 'muted client is not an ingress stall');
+	});
+
+	it('sendSkipped delta in any heartbeat is an anomaly', () => {
+		const led = makeLedger({ t: 10_000 });
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { c: [47, 64000, 5, 0, 0, 0, 0, 0] }));
+		assert.ok(led.anomalySinceLastTick(true).reasons.includes('sendSkipped'));
+	});
+});
+
+describe('P7 D7.1 engine ledger — persistence tick + [Health] segments', () => {
+	it('persistTick writes a bounded row; a busy mailbox skips the sample visibly', () => {
+		const now = { t: 10_000 };
+		const rows: HealthRow[] = [];
+		let accept = true;
+		const led = makeLedger(now, (row) => {
+			if (accept) rows.push(row);
+			return accept;
+		});
+		led.ingestHeartbeat(wireHb('nnnnnnnn'));
+		led.persistTick('timer', true);
+		assert.equal(rows.length, 1);
+		assert.equal(rows[0].sessionId, 'session_test');
+		assert.equal(rows[0].reason, 'timer');
+		assert.equal(rows[0].nonce, 'nnnnnnnn');
+		const payload = JSON.parse(rows[0].payload);
+		assert.equal(payload.coverage, 'session-only');
+		accept = false;
+		led.persistTick('anomaly', true);
+		assert.equal(led.getSnapshot(true).samplesSkipped, 1, 'busy mailbox → skipped, never queued');
+		assert.ok(led.anomalySinceLastTick(true).reasons.includes('persistSkipped'));
+	});
+
+	it('healthSegments renders the upgraded line fields', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.3));
+		led.ingestHeartbeat(wireHb('nnnnnnnn'));
+		now.t += 2000;
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 1 }));
+		led.noteTurnLatency(1840);
+		const line = led.healthSegments(true);
+		assert.match(line, /audioIn=\{fps:[\d.]+,lastAgo:[\d.]+s,coverage:session-only\}/);
+		assert.match(line, /up=n\/a/);
+		assert.match(line, /out=\{fps:/);
+		assert.match(line, /clientHealth=\{age:[\d.]+s,capCb\/s:23\.5,rms:/);
+		assert.match(line, /latency=1840ms/);
+		assert.match(line, /inputHealth=ok/);
+	});
+});

--- a/tests/voice-audio-health.test.ts
+++ b/tests/voice-audio-health.test.ts
@@ -20,6 +20,7 @@ function wireHb(nonce: string, over: Record<string, unknown> = {}): Record<strin
 		t: 'audio_health',
 		n: nonce,
 		q: 0,
+		ea: 60_000,
 		c: [47, 64000, 0, 0, 100, 100, 98, 2],
 		x: [2000, 3, 120],
 		cs: 'r',
@@ -274,6 +275,7 @@ describe('P7 D7.1 engine ledger — inputHealth + anomaly latching', () => {
 		led.wrapSession(s);
 		assert.equal(led.getInputHealth(false), 'no-client');
 		assert.equal(led.getInputHealth(true), 'unknown', 'no evidence yet');
+		led.onClientConnected();
 		s.handleAudioFromClient(pcm(0.1));
 		assert.equal(led.getInputHealth(true), 'ok');
 		led.ingestHeartbeat(wireHb('nnnnnnnn', { og: [0, 1500] }));
@@ -420,6 +422,7 @@ describe('P7 D7.1 engine ledger — persistence tick + [Health] segments', () =>
 		const led = makeLedger(now);
 		const s = fakeSession();
 		led.wrapSession(s);
+		led.onClientConnected();
 		s.handleAudioFromClient(pcm(0.3));
 		led.ingestHeartbeat(wireHb('nnnnnnnn'));
 		now.t += 2000;
@@ -432,5 +435,70 @@ describe('P7 D7.1 engine ledger — persistence tick + [Health] segments', () =>
 		assert.match(line, /clientHealth=\{age:[\d.]+s,capCb\/s:23\.5,rms:/);
 		assert.match(line, /latency=1840ms/);
 		assert.match(line, /inputHealth=ok/);
+	});
+});
+
+describe('P7 round-3 ledger fixes', () => {
+	it('epoch placement uses the client-stamped epoch age (receivedAt − ea), refreshed per beat', () => {
+		const now = { t: 100_000 };
+		const led = makeLedger(now);
+		led.onClientConnected();
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { ea: 7_500 }));
+		assert.equal(led.getSnapshot(true).epochStartApproxMs, 100_000 - 7_500);
+		now.t = 102_000;
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 1, ea: 9_500 }));
+		assert.equal(led.getSnapshot(true).epochStartApproxMs, 102_000 - 9_500);
+	});
+
+	it('a frame without ea falls back to the coarse first-beat guess', () => {
+		const now = { t: 100_000 };
+		const led = makeLedger(now);
+		led.onClientConnected();
+		const frame = wireHb('nnnnnnnn');
+		delete (frame as Record<string, unknown>).ea;
+		led.ingestHeartbeat(frame);
+		assert.equal(led.getSnapshot(true).epochStartApproxMs, 100_000 - 500);
+	});
+
+	it('an unexpected nonce is a FULL epoch boundary: server counters and latency reset too', () => {
+		const now = { t: 100_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		led.onClientConnected();
+		led.ingestHeartbeat(wireHb('nonceAAA'));
+		s.handleAudioFromClient(pcm(0.1));
+		led.noteTurnLatency(1234);
+		now.t += 10;
+		led.ingestHeartbeat(wireHb('nonceZZZ'));
+		const snap = led.getSnapshot(true);
+		assert.equal(snap.deliveredFrames, 0, 'server-side counters reset at the boundary');
+		assert.equal(snap.lastTurnLatencyMs, null);
+		assert.equal(snap.nonce, 'nonceZZZ');
+	});
+
+	it('noteModelEvent records model activity and consumes the speech→model latency sample', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.3)); // speech onset armed at 10000
+		now.t = 10_900;
+		led.noteModelEvent(); // e.g. turn.start — text/tool-first turn
+		const snap = led.getSnapshot(true);
+		assert.equal(snap.lastModelEventAt, 10_900);
+		assert.equal(snap.lastSpeechToModelMs, 900, 'first EVENT, not first audio');
+		now.t = 11_500;
+		s.handleAudioOutput(Buffer.from('audio').toString('base64'));
+		assert.equal(led.getSnapshot(true).lastSpeechToModelMs, 900, 'already consumed');
+		assert.equal(led.getSnapshot(true).lastModelEventAt, 11_500, 'audio still advances the event clock');
+	});
+
+	it('episode anomalies require an attached client (a detached window re-send is not live)', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { ep: [[1, 'g', 0, 1200]] }));
+		assert.ok(!led.anomalies(false).reasons.some((r) => r.startsWith('episodes:')));
+		assert.ok(led.anomalies(true).reasons.some((r) => r.startsWith('episodes:')));
 	});
 });

--- a/tests/voice-audio-health.test.ts
+++ b/tests/voice-audio-health.test.ts
@@ -142,16 +142,21 @@ describe('P7 D7.1 engine ledger — wraps', () => {
 });
 
 describe('P7 D7.1 engine ledger — epoch minting (Tranche A nonce scheme)', () => {
-	it('mints on first sight, stays stable per nonce, advances per new nonce, resets baselines', () => {
+	it('mints AT CONNECT; the nonce binds on first heartbeat; a connection dying pre-heartbeat still has a real epoch', () => {
 		const now = { t: 50_000 };
 		const led = makeLedger(now);
-		led.ingestHeartbeat(wireHb('nonceAAA'));
+		led.onClientConnected();
 		const e1 = led.getSnapshot(true).epoch;
-		assert.ok(e1 && e1 >= 50_000, 'engine-minted epoch');
+		assert.ok(e1 && e1 >= 50_000, 'epoch minted at connect, before any heartbeat');
+		assert.equal(led.getSnapshot(true).nonce, null, 'nonce pending until first heartbeat');
+		led.ingestHeartbeat(wireHb('nonceAAA'));
+		assert.equal(led.getSnapshot(true).epoch, e1, 'first heartbeat BINDS, does not re-mint');
+		assert.equal(led.getSnapshot(true).nonce, 'nonceAAA');
 		led.ingestHeartbeat(wireHb('nonceAAA', { q: 1 }));
-		assert.equal(led.getSnapshot(true).epoch, e1, 'stable for the same connection');
 		assert.equal(led.getSnapshot(true).clientTotals.capCallbacks, 94, 'deltas accumulate');
+		// Reconnect: connect mints a strictly newer epoch and resets baselines.
 		now.t += 10;
+		led.onClientConnected();
 		led.ingestHeartbeat(wireHb('nonceBBB'));
 		const snap = led.getSnapshot(true);
 		assert.ok(snap.epoch && snap.epoch > e1!, 'new connection = strictly newer epoch');
@@ -159,18 +164,38 @@ describe('P7 D7.1 engine ledger — epoch minting (Tranche A nonce scheme)', () 
 		assert.equal(snap.clientTotals.capCallbacks, 47, 'totals reset at the epoch boundary');
 	});
 
-	it('onClientConnected clears the pending epoch and per-epoch counters', () => {
+	it('a mid-connection nonce change (no connect event) defensively re-mints', () => {
 		const now = { t: 50_000 };
 		const led = makeLedger(now);
+		led.onClientConnected();
+		led.ingestHeartbeat(wireHb('nonceAAA'));
+		const e1 = led.getSnapshot(true).epoch!;
+		now.t += 10;
+		led.ingestHeartbeat(wireHb('nonceZZZ'));
+		assert.ok(led.getSnapshot(true).epoch! > e1, 'unexpected nonce never reuses the old epoch');
+	});
+
+	it('onClientConnected resets per-epoch counters, latency samples, and skip counters', () => {
+		const now = { t: 50_000 };
+		const rows: HealthRow[] = [];
+		let accept = false;
+		const led = makeLedger(now, () => accept);
 		const s = fakeSession();
 		led.wrapSession(s);
 		s.handleAudioFromClient(pcm(0.1));
 		led.ingestHeartbeat(wireHb('nonceAAA'));
+		led.noteTurnLatency(1234);
+		led.persistTick('timer', true); // rejected → samplesSkipped 1
+		assert.equal(led.getSnapshot(true).samplesSkipped, 1);
 		led.onClientConnected();
+		accept = true;
 		const snap = led.getSnapshot(true);
-		assert.equal(snap.epoch, null);
+		assert.ok(snap.epoch, 'fresh epoch minted');
 		assert.equal(snap.deliveredFrames, 0);
 		assert.equal(snap.heartbeatCount, 0);
+		assert.equal(snap.samplesSkipped, 0, 'skip counter is per-epoch');
+		assert.equal(snap.lastTurnLatencyMs, null, 'latency sample is per-epoch');
+		assert.equal(rows.length, 0);
 	});
 });
 
@@ -199,6 +224,46 @@ describe('P7 D7.1 engine ledger — ingress speech tracker (canonical evidence)'
 		s.handleAudioFromClient(pcm(0.005));
 		assert.equal(led.getSpeechEvidence().active, false);
 	});
+
+	it('speech after a silent stall is a NEW onset (eager decay on the frame path)', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.3)); // onset #1 at 10000
+		now.t = 10_700; // hangover elapsed with NO frames (stall)
+		s.handleAudioFromClient(pcm(0.3)); // must re-latch, not extend
+		const ev = led.getSpeechEvidence();
+		assert.equal(ev.active, true);
+		assert.equal(ev.onsetAt, 10_700, 'stale onset would corrupt speech→model latency');
+	});
+
+	it('speech onset → first model audio yields the latency sample (server clock)', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.3)); // onset armed at 10000
+		now.t = 11_840;
+		s.handleAudioOutput(Buffer.from('audio').toString('base64'));
+		assert.equal(led.getSnapshot(true).lastSpeechToModelMs, 1840);
+		// consumed: a second egress frame does not overwrite the sample
+		now.t = 12_000;
+		s.handleAudioOutput(Buffer.from('audio').toString('base64'));
+		assert.equal(led.getSnapshot(true).lastSpeechToModelMs, 1840);
+	});
+
+	it('ingress RMS work is bounded: a jumbo frame scans at most 8 KiB', () => {
+		const led = makeLedger({ t: 10_000 });
+		const s = fakeSession();
+		led.wrapSession(s);
+		const jumbo = Buffer.alloc(4 * 1024 * 1024); // 4 MiB of silence
+		const t0 = process.hrtime.bigint();
+		s.handleAudioFromClient(jumbo);
+		const us = Number(process.hrtime.bigint() - t0) / 1000;
+		assert.ok(us < 5000, `jumbo frame took ${us.toFixed(0)}µs — scan not bounded`);
+		assert.equal(led.getSnapshot(true).deliveredBytes, jumbo.length, 'bytes still fully accounted');
+	});
 });
 
 describe('P7 D7.1 engine ledger — inputHealth + anomaly latching', () => {
@@ -219,31 +284,86 @@ describe('P7 D7.1 engine ledger — inputHealth + anomaly latching', () => {
 		assert.equal(led.getInputHealth(true), 'stalled');
 	});
 
-	it('anomalies latch per tick and clear on read; muted suppresses the ingress-stall reason', () => {
+	it('heartbeats crossing while NO PCM ever reached the session is a stall, not health', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		led.onClientConnected();
+		led.ingestHeartbeat(wireHb('nnnnnnnn'));
+		assert.equal(led.getInputHealth(true), 'stalled');
+	});
+
+	it('a muted client is never stalled; a degraded capture surfaces even muted', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.1));
+		now.t += 6000; // would be an ingress stall if unmuted
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { mu: 1 }));
+		assert.equal(led.getInputHealth(true), 'ok', 'mute is a user choice');
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 1, mu: 1, cap: 'd' }));
+		assert.equal(led.getInputHealth(true), 'degraded', 'exhausted recovery surfaces regardless');
+	});
+
+	it('suspended/closed context reports stalled; STALE heartbeat evidence stops counting', () => {
+		const now = { t: 10_000 };
+		const led = makeLedger(now);
+		const s = fakeSession();
+		led.wrapSession(s);
+		s.handleAudioFromClient(pcm(0.1));
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { cs: 's' }));
+		assert.equal(led.getInputHealth(true), 'stalled', 'suspended ctx = no input');
+		// The same heartbeat 20 s later is stale — a detached client's
+		// retained evidence must not report stalled forever…
+		now.t += 20_000;
+		s.handleAudioFromClient(pcm(0.1)); // …and live PCM proves input works
+		assert.equal(led.getInputHealth(true), 'ok');
+	});
+
+	it('anomalies PEEK until clearTickLatches; muted/stale gates apply', () => {
 		const now = { t: 10_000 };
 		const led = makeLedger(now);
 		const s = fakeSession();
 		led.wrapSession(s);
 		s.handleAudioFromClient(pcm(0.1));
 		led.ingestHeartbeat(wireHb('nnnnnnnn', { ep: [[1, 'g', 0, 1200]], og: [0, 1500] }));
-		const a1 = led.anomalySinceLastTick(true);
+		const a1 = led.anomalies(true);
 		assert.equal(a1.anomalous, true);
 		assert.ok(a1.reasons.includes('capStalled'));
 		assert.ok(a1.reasons.some((r) => r.startsWith('episodes:')));
+		const a1again = led.anomalies(true);
+		assert.ok(a1again.reasons.some((r) => r.startsWith('episodes:')), 'peek does not clear');
+		led.clearTickLatches();
 		// same episode re-sent (idempotent window) → no NEW episode anomaly
 		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 1, ep: [[1, 'g', 0, 1200]], og: [0, 3500] }));
-		const a2 = led.anomalySinceLastTick(true);
+		const a2 = led.anomalies(true);
 		assert.ok(!a2.reasons.some((r) => r.startsWith('episodes:')), 'dedup by episode id');
+		led.clearTickLatches();
 		now.t += 6000;
-		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 2, mu: 1 }));
-		const a3 = led.anomalySinceLastTick(true);
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { q: 2, mu: 1, og: [0, 9000] }));
+		const a3 = led.anomalies(true);
 		assert.ok(!a3.reasons.includes('ingress-stalled'), 'muted client is not an ingress stall');
+		assert.ok(!a3.reasons.includes('capStalled'), 'muted open gap is not a stall');
+		assert.ok(!led.anomalies(false).reasons.includes('capStalled'), 'detached gap is not live');
 	});
 
 	it('sendSkipped delta in any heartbeat is an anomaly', () => {
 		const led = makeLedger({ t: 10_000 });
 		led.ingestHeartbeat(wireHb('nnnnnnnn', { c: [47, 64000, 5, 0, 0, 0, 0, 0] }));
-		assert.ok(led.anomalySinceLastTick(true).reasons.includes('sendSkipped'));
+		assert.ok(led.anomalies(true).reasons.includes('sendSkipped'));
+	});
+
+	it('unknown episode kinds are dropped, never misclassified as speech', () => {
+		const led = makeLedger({ t: 10_000 });
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { ep: [[1, 'z', 0, 1200]] }));
+		assert.equal(led.getSnapshot(true).lastHeartbeat?.episodes.length, 0);
+	});
+
+	it('the ep array ingest is capped at 8 entries', () => {
+		const led = makeLedger({ t: 10_000 });
+		const ep = Array.from({ length: 100 }, (_, i) => [i + 1, 'g', 0, 100]);
+		led.ingestHeartbeat(wireHb('nnnnnnnn', { ep }));
+		assert.equal(led.getSnapshot(true).lastHeartbeat?.episodes.length, 8);
 	});
 });
 
@@ -267,7 +387,32 @@ describe('P7 D7.1 engine ledger — persistence tick + [Health] segments', () =>
 		accept = false;
 		led.persistTick('anomaly', true);
 		assert.equal(led.getSnapshot(true).samplesSkipped, 1, 'busy mailbox → skipped, never queued');
-		assert.ok(led.anomalySinceLastTick(true).reasons.includes('persistSkipped'));
+		assert.ok(led.anomalies(true).reasons.includes('persistSkipped'));
+	});
+
+	it('an oversized snapshot persists as reduced-but-VALID JSON, never a sliced document', () => {
+		const now = { t: 10_000 };
+		const rows: HealthRow[] = [];
+		const led = makeLedger(now, (row) => {
+			rows.push(row);
+			return true;
+		});
+		led.onClientConnected();
+		// Inflate the snapshot past the payload budget: hundreds of un-cleared
+		// new episode ids (a tick that never cleared its latches).
+		for (let k = 0; k < 80; k++) {
+			// 8-digit ids keep every entry wide so the accumulated ids alone
+			// push the snapshot past the payload budget.
+			const ep = Array.from({ length: 8 }, (_, i) => [10_000_000 + k * 8 + i, 'g', 9_999_999, 9_999_999]);
+			led.ingestHeartbeat(wireHb('nnnnnnnn', { q: k, ep }));
+		}
+		led.persistTick('timer', true);
+		assert.equal(rows.length, 1);
+		const parsed = JSON.parse(rows[0].payload); // must not throw — VALID JSON
+		assert.ok(Buffer.byteLength(rows[0].payload) <= 4096);
+		assert.equal(parsed.truncated, true, 'over-budget snapshot takes the reduced form');
+		assert.equal(parsed.coverage, 'session-only');
+		assert.ok(parsed.epoch, 'core evidence survives truncation');
 	});
 
 	it('healthSegments renders the upgraded line fields', () => {

--- a/tests/voice-continuity.test.ts
+++ b/tests/voice-continuity.test.ts
@@ -4,6 +4,7 @@ import {
 	initialGoodbyeGuard,
 	shouldFireGoodbye,
 	createConversationClearHelper,
+	clearStaleResumptionHandle,
 } from '../src/voice-continuity.js';
 
 describe('P7 D7.3 stale-repeat goodbye guard', () => {
@@ -74,5 +75,34 @@ describe('P7 D7.3 centralized conversation clear (G-P7-8)', () => {
 		h.cursor.index = 2;
 		assert.equal(h.clear('none'), 0);
 		assert.equal(h.cursor.index, 0);
+	});
+});
+
+describe('stale resumption-handle clearing (1008 \'Requested entity was not found\' staircase)', () => {
+	it('clears BOTH handle copies before a fresh reconnect and reports it', () => {
+		let smCleared = 0;
+		const session = {
+			transport: { config: { resumptionHandle: 'dead-handle-123' } },
+			sessionManager: { clearResumptionHandle: () => { smCleared += 1; } },
+		};
+		assert.equal(clearStaleResumptionHandle(session), true);
+		assert.equal(session.transport.config.resumptionHandle, undefined, 'transport copy cleared');
+		assert.equal(smCleared, 1, 'sessionManager copy cleared');
+	});
+
+	it('no stale handle → false, still syncs the sessionManager copy', () => {
+		let smCleared = 0;
+		const session = {
+			transport: { config: {} },
+			sessionManager: { clearResumptionHandle: () => { smCleared += 1; } },
+		};
+		assert.equal(clearStaleResumptionHandle(session), false);
+		assert.equal(smCleared, 1);
+	});
+
+	it('missing seams never throw (a broken shape must not break reconnect)', () => {
+		assert.equal(clearStaleResumptionHandle(null), false);
+		assert.equal(clearStaleResumptionHandle({}), false);
+		assert.equal(clearStaleResumptionHandle({ transport: {} }), false);
 	});
 });

--- a/tests/voice-continuity.test.ts
+++ b/tests/voice-continuity.test.ts
@@ -32,6 +32,16 @@ describe('P7 D7.3 stale-repeat goodbye guard', () => {
 		const other = shouldFireGoodbye(first.next, 'Bye for now!', 3);
 		assert.equal(other.fire, true);
 	});
+
+	it('a rebased (fresh) guard fires at ANY count — the per-session reset contract', () => {
+		// voice-agent's resetSessionGateState() replaces the guard whenever
+		// userTurnCount resets; without the rebase, the next session's count
+		// (restarted below the old watermark) would suppress a real goodbye.
+		const first = shouldFireGoodbye(initialGoodbyeGuard(), 'Goodbye!', 3);
+		assert.equal(first.fire, true);
+		const nextSession = shouldFireGoodbye(initialGoodbyeGuard(), 'Goodbye!', 1);
+		assert.equal(nextSession.fire, true);
+	});
 });
 
 describe('P7 D7.3 centralized conversation clear (G-P7-8)', () => {

--- a/tests/voice-continuity.test.ts
+++ b/tests/voice-continuity.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	initialGoodbyeGuard,
+	shouldFireGoodbye,
+	createConversationClearHelper,
+} from '../src/voice-continuity.js';
+
+describe('P7 D7.3 stale-repeat goodbye guard', () => {
+	it('first detection fires and latches text + user-turn watermark', () => {
+		const v = shouldFireGoodbye(initialGoodbyeGuard(), 'Goodbye!', 3);
+		assert.equal(v.fire, true);
+		assert.deepEqual(v.next, { lastText: 'Goodbye!', userTurnsAtFire: 3 });
+	});
+
+	it('the SAME farewell with no new user turn is suppressed (reconnect replay)', () => {
+		const first = shouldFireGoodbye(initialGoodbyeGuard(), 'Goodbye!', 3);
+		const replay = shouldFireGoodbye(first.next, 'Goodbye!', 3);
+		assert.equal(replay.fire, false);
+		assert.equal(replay.next, first.next, 'state unchanged on suppression');
+	});
+
+	it('the same farewell AFTER a new real user turn fires again', () => {
+		const first = shouldFireGoodbye(initialGoodbyeGuard(), 'Goodbye!', 3);
+		const again = shouldFireGoodbye(first.next, 'Goodbye!', 4);
+		assert.equal(again.fire, true);
+		assert.equal(again.next.userTurnsAtFire, 4);
+	});
+
+	it('a different farewell fires regardless of turn count', () => {
+		const first = shouldFireGoodbye(initialGoodbyeGuard(), 'Goodbye!', 3);
+		const other = shouldFireGoodbye(first.next, 'Bye for now!', 3);
+		assert.equal(other.fire, true);
+	});
+});
+
+describe('P7 D7.3 centralized conversation clear (G-P7-8)', () => {
+	it('empties items IN PLACE and rebases the cursor together', () => {
+		const items: string[] = ['a', 'b', 'c'];
+		const logs: string[] = [];
+		const h = createConversationClearHelper(() => items, (m) => logs.push(m));
+		h.cursor.index = 3;
+		const cleared = h.clear('test');
+		assert.equal(cleared, 3);
+		assert.equal(items.length, 0, 'mutated in place (getter-backed array)');
+		assert.equal(h.cursor.index, 0, 'cursor rebased WITH the clear');
+		assert.ok(logs.some((l) => l.includes('cleared 3')));
+	});
+
+	it('rebases the cursor even when items are unreadable — a stale cursor against an emptied array is the bug', () => {
+		const h = createConversationClearHelper(
+			() => {
+				throw new Error('no session yet');
+			},
+			() => {},
+		);
+		h.cursor.index = 7;
+		assert.equal(h.clear('early'), 0);
+		assert.equal(h.cursor.index, 0);
+	});
+
+	it('non-array items: clears nothing, still rebases', () => {
+		const h = createConversationClearHelper(() => undefined, () => {});
+		h.cursor.index = 2;
+		assert.equal(h.clear('none'), 0);
+		assert.equal(h.cursor.index, 0);
+	});
+});

--- a/tests/voice-health-matrix.test.ts
+++ b/tests/voice-health-matrix.test.ts
@@ -1,0 +1,319 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	evaluateMatrix,
+	type MatrixBaseline,
+	type MatrixInput,
+} from '../src/voice-health-matrix.js';
+import type { AudioHealthSnapshot, ClientHeartbeat } from '../src/voice-audio-health.js';
+
+const NOW = 1_000_000;
+
+function hb(over: Partial<ClientHeartbeat> = {}): ClientHeartbeat {
+	return {
+		nonce: 'n0n0n0n0',
+		seq: 10,
+		capCallbacks: 47,
+		bytesSent: 64000,
+		sendSkipped: 0,
+		sendFailed: 0,
+		chunksRecv: 0,
+		chunksScheduled: 0,
+		chunksEnded: 0,
+		chunksCancelled: 0,
+		ctxTimeMs: 30_000,
+		scheduledDepth: 0,
+		lastEndedAgoMs: null,
+		ctxState: 'r',
+		captureState: 'o',
+		ctxSuspendCount: 0,
+		bufferedAmount: 0,
+		bufferedHighWater: 0,
+		muted: false,
+		openGap: null,
+		episodeOverflow: 0,
+		episodes: [],
+		receivedAt: NOW - 1000,
+		...over,
+	};
+}
+
+function snap(over: Partial<AudioHealthSnapshot> = {}): AudioHealthSnapshot {
+	return {
+		coverage: 'session-only',
+		epoch: 12345,
+		nonce: 'n0n0n0n0',
+		deliveredFrames: 1000,
+		deliveredBytes: 1_364_000,
+		lastDeliveredAt: NOW - 100,
+		egressFrames: 500,
+		egressBytes: 100_000,
+		lastEgressAt: NOW - 200,
+		speech: { active: false, onsetAt: null, lastAboveFloorAt: null },
+		ingressRms: 0.001,
+		lastHeartbeat: hb(),
+		clientTotals: {
+			capCallbacks: 1000,
+			bytesSent: 1_364_000,
+			sendSkipped: 0,
+			sendFailed: 0,
+			chunksRecv: 500,
+			chunksScheduled: 500,
+			chunksEnded: 490,
+			chunksCancelled: 10,
+		},
+		heartbeatCount: 20,
+		newEpisodeIds: [],
+		samplesSkipped: 0,
+		lastTurnLatencyMs: null,
+		inputHealth: 'ok',
+		epochStartApproxMs: NOW - 60_000,
+		lastMatrixVerdict: null,
+		...over,
+	};
+}
+
+/** A previous-tick baseline consistent with `snap()` minus the given deltas. */
+function baselineBefore(s: AudioHealthSnapshot, deltas: Partial<MatrixBaseline> = {}): MatrixBaseline {
+	return {
+		at: NOW - 30_000,
+		deliveredFrames: s.deliveredFrames,
+		capCallbacks: s.clientTotals.capCallbacks,
+		bytesSent: s.clientTotals.bytesSent,
+		sendSkipped: s.clientTotals.sendSkipped,
+		chunksRecv: s.clientTotals.chunksRecv,
+		chunksScheduled: s.clientTotals.chunksScheduled,
+		chunksEnded: s.clientTotals.chunksEnded,
+		ctxTimeMs: s.lastHeartbeat?.ctxTimeMs ?? null,
+		bufferedAmount: s.lastHeartbeat?.bufferedAmount ?? null,
+		serverBufferedAmount: null,
+		maxEpisodeId: 0,
+		...deltas,
+	};
+}
+
+function evalWith(s: AudioHealthSnapshot, prev: MatrixBaseline | null, over: Partial<MatrixInput> = {}) {
+	return evaluateMatrix({
+		sessionState: 'ACTIVE',
+		clientConnected: true,
+		snapshot: s,
+		prev,
+		now: NOW,
+		...over,
+	});
+}
+
+describe('P7 D7.2 matrix — structural outcomes (row 0 + honesty)', () => {
+	it('RECONNECTING/CONNECTING → reconnect-window, never a layer verdict', () => {
+		for (const st of ['RECONNECTING', 'CONNECTING']) {
+			const r = evalWith(snap(), baselineBefore(snap()), { sessionState: st });
+			assert.equal(r.verdict, 'reconnect-window');
+		}
+	});
+
+	it('no client attached → healthy-idle (not an incident)', () => {
+		const r = evalWith(snap(), baselineBefore(snap()), { clientConnected: false });
+		assert.equal(r.verdict, 'healthy-idle');
+		assert.ok(r.reasons.includes('no-client-attached'));
+	});
+
+	it('no heartbeat, or no prior baseline → insufficient-evidence (never guess)', () => {
+		const r1 = evalWith(snap({ lastHeartbeat: null }), baselineBefore(snap()));
+		assert.equal(r1.verdict, 'insufficient-evidence');
+		const r2 = evalWith(snap(), null);
+		assert.equal(r2.verdict, 'insufficient-evidence');
+	});
+
+	it('partial coverage NEVER yields a server-layer verdict: client sends but session delivery stalls', () => {
+		// The observable half of rows 2-4's patterns: heartbeats prove PCM
+		// crossed the socket, session delivery is flat. At session-only
+		// coverage the ingress chain is unobserved — the matrix must say so.
+		const s = snap({ lastDeliveredAt: NOW - 20_000 });
+		const prev = baselineBefore(s, { capCallbacks: s.clientTotals.capCallbacks - 700 });
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'insufficient-evidence');
+		assert.ok(r.reasons.some((x) => x.includes('server-ingress-chain-unobserved')));
+		assert.ok(r.reasons.includes('client-sending-but-session-delivery-stalled'));
+	});
+
+	it('speech without a model event at partial coverage → insufficient-evidence naming the blind hop', () => {
+		const s = snap({
+			speech: { active: true, onsetAt: NOW - 3000, lastAboveFloorAt: NOW - 500 },
+		});
+		const prev = baselineBefore(s, { deliveredFrames: s.deliveredFrames - 100 });
+		const r = evalWith(s, prev, { lastModelEventAt: NOW - 60_000 });
+		assert.equal(r.verdict, 'insufficient-evidence');
+		assert.ok(r.reasons.some((x) => x.includes('upstream-hop-unobserved')));
+	});
+
+	it('the same speech-silence pattern at FULL coverage reaches model-silent (the F4 residue)', () => {
+		const s = snap({
+			coverage: 'full' as never,
+			speech: { active: true, onsetAt: NOW - 3000, lastAboveFloorAt: NOW - 500 },
+		});
+		const prev = baselineBefore(s, { deliveredFrames: s.deliveredFrames - 100 });
+		const r = evalWith(s, prev, { lastModelEventAt: NOW - 60_000 });
+		assert.equal(r.verdict, 'model-silent');
+	});
+});
+
+describe('P7 D7.2 matrix — row 1 client capture dead', () => {
+	it('an OPEN gap overlapping the ingress stall while unmuted → client-capture-dead', () => {
+		const s = snap({
+			lastDeliveredAt: NOW - 10_000,
+			lastHeartbeat: hb({ openGap: { startMs: 48_000, ageMs: 11_000 }, ctxState: 's' }),
+		});
+		const r = evalWith(s, baselineBefore(s));
+		assert.equal(r.verdict, 'client-capture-dead');
+		assert.ok(r.reasons.some((x) => x.startsWith('open-gap')));
+		assert.ok(r.reasons.includes('shape=ctx-suspended'), 'S2 discriminator from ctxState');
+	});
+
+	it('a fresh CLOSED gap episode overlapping the stall → client-capture-dead (main-thread shape)', () => {
+		// Gap ended 4 s ago (epoch-relative 55s..56.2s with epoch start NOW-60s),
+		// ingress stalled since 6 s ago — the intervals overlap.
+		const s = snap({
+			lastDeliveredAt: NOW - 6_000,
+			lastHeartbeat: hb({ episodes: [{ id: 3, kind: 'gap', startMs: 55_000, durationMs: 1_200 }] }),
+		});
+		const r = evalWith(s, baselineBefore(s));
+		assert.equal(r.verdict, 'client-capture-dead');
+		assert.ok(r.reasons.includes('shape=main-thread-gap'));
+	});
+
+	it('an OLD latched gap must not pair with unrelated later silence (round-3 #3)', () => {
+		// Episode ended ~55 s ago (expired against the 90 s freshness bound is
+		// not enough — it also ends long before the stall started 3 s ago).
+		const s = snap({
+			lastDeliveredAt: NOW - 5_500,
+			epochStartApproxMs: NOW - 300_000,
+			lastHeartbeat: hb({ episodes: [{ id: 1, kind: 'gap', startMs: 5_000, durationMs: 1_000 }] }),
+		});
+		const r = evalWith(s, baselineBefore(s));
+		assert.notEqual(r.verdict, 'client-capture-dead');
+	});
+
+	it('muted suppresses row 1 (mute is not a capture failure)', () => {
+		const s = snap({
+			lastDeliveredAt: NOW - 10_000,
+			lastHeartbeat: hb({ muted: true, openGap: { startMs: 48_000, ageMs: 11_000 } }),
+		});
+		const r = evalWith(s, baselineBefore(s));
+		assert.notEqual(r.verdict, 'client-capture-dead');
+	});
+});
+
+describe('P7 D7.2 matrix — rows 6/7a/7b', () => {
+	it('row 6: growing client bufferedAmount → client-send-backpressure', () => {
+		const s = snap({ lastHeartbeat: hb({ bufferedAmount: 300_000 }) });
+		const prev = baselineBefore(s, { bufferedAmount: 50_000 });
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'client-send-backpressure');
+	});
+
+	it('row 6: a sendSkipped delta alone is transmitted evidence (round-3 #5)', () => {
+		const s = snap({
+			clientTotals: { ...snap().clientTotals, sendSkipped: 12 },
+		});
+		const prev = baselineBefore(s, { sendSkipped: 0 });
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'client-send-backpressure');
+	});
+
+	it('row 7a: server egress buffered growing while client chunksRecv stalls', () => {
+		const s = snap();
+		const prev = baselineBefore(s, { serverBufferedAmount: 10_000 });
+		const r = evalWith(s, prev, { serverBufferedAmount: 500_000 });
+		assert.equal(r.verdict, 'egress-backpressure');
+	});
+
+	it('row 7a needs the server buffered input — absent ⇒ no verdict from that pattern', () => {
+		const s = snap();
+		const r = evalWith(s, baselineBefore(s), { serverBufferedAmount: null });
+		assert.equal(r.verdict, 'healthy-idle');
+	});
+
+	it('row 7b: chunks scheduled but zero NATURAL completions and a frozen ctx clock → playback failure', () => {
+		const s = snap({ lastHeartbeat: hb({ ctxTimeMs: 30_000 }) });
+		const prev = baselineBefore(s, {
+			chunksScheduled: s.clientTotals.chunksScheduled - 20,
+			ctxTimeMs: 30_000, // clock frozen
+		});
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'client-playback-failure');
+	});
+
+	it('row 7b does not fire while the ctx clock advances (chunks may still be draining)', () => {
+		const s = snap({ lastHeartbeat: hb({ ctxTimeMs: 60_000 }) });
+		const prev = baselineBefore(s, {
+			chunksScheduled: s.clientTotals.chunksScheduled - 20,
+			ctxTimeMs: 30_000,
+		});
+		const r = evalWith(s, prev);
+		assert.notEqual(r.verdict, 'client-playback-failure');
+	});
+
+	it('row 7b: cancellations are excluded by construction (barge-in flush ≠ playback failure)', () => {
+		// 20 scheduled, 20 CANCELLED (chunksEnded unchanged) — but the ctx
+		// clock advanced: a barge-in, not a dead output path.
+		const s = snap({
+			lastHeartbeat: hb({ ctxTimeMs: 45_000 }),
+			clientTotals: { ...snap().clientTotals, chunksCancelled: 30 },
+		});
+		const prev = baselineBefore(s, {
+			chunksScheduled: s.clientTotals.chunksScheduled - 20,
+			ctxTimeMs: 30_000,
+		});
+		assert.notEqual(evalWith(s, prev).verdict, 'client-playback-failure');
+	});
+});
+
+describe('P7 D7.2 matrix — row 5′ healthy-idle', () => {
+	it('quiet user, everything advancing → healthy-idle (not an incident)', () => {
+		const s = snap();
+		const prev = baselineBefore(s, {
+			deliveredFrames: s.deliveredFrames - 700,
+			capCallbacks: s.clientTotals.capCallbacks - 700,
+		});
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'healthy-idle');
+	});
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// HYPOTHESIS FIXTURES (D7.2, round-1 #9): the FE-1/FE-2 incident counters
+// never existed — these encode the *hypothesized* field patterns from
+// docs/investigation-voice-incident-2026-08-09.md and must be validated
+// against captured S1/S2 runs (D7.6) before being treated as ground truth.
+// FE-3 is exercised through D7.6-S3 continuity scenarios, not the matrix.
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('P7 D7.2 hypothesis fixtures (NOT ground truth until S-runs validate)', () => {
+	it('FE-1 [HYPOTHESIS]: vision saturation — client egress backpressure → row 6', () => {
+		// Hypothesized: 557 native-res frames saturate the shared socket;
+		// bufferedAmount climbs and PCM frames start skipping.
+		const s = snap({
+			lastHeartbeat: hb({ bufferedAmount: 2_500_000, bufferedHighWater: 2_500_000 }),
+			clientTotals: { ...snap().clientTotals, sendSkipped: 40 },
+		});
+		const prev = baselineBefore(s, { bufferedAmount: 400_000, sendSkipped: 0 });
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'client-send-backpressure');
+	});
+
+	it('FE-2 [HYPOTHESIS]: shared AudioContext death mid-word — suspension gap → row 1', () => {
+		// Hypothesized: the context suspends mid-utterance; capture callbacks
+		// stop; the open gap travels while ingress goes quiet, socket healthy.
+		const s = snap({
+			lastDeliveredAt: NOW - 12_000,
+			lastHeartbeat: hb({
+				ctxState: 's',
+				ctxSuspendCount: 1,
+				openGap: { startMs: 47_000, ageMs: 12_500 },
+			}),
+		});
+		const r = evalWith(s, baselineBefore(s));
+		assert.equal(r.verdict, 'client-capture-dead');
+		assert.ok(r.reasons.includes('shape=ctx-suspended'));
+	});
+});

--- a/tests/voice-health-matrix.test.ts
+++ b/tests/voice-health-matrix.test.ts
@@ -13,6 +13,7 @@ function hb(over: Partial<ClientHeartbeat> = {}): ClientHeartbeat {
 	return {
 		nonce: 'n0n0n0n0',
 		seq: 10,
+		epochAgeMs: 60_000,
 		capCallbacks: 47,
 		bytesSent: 64000,
 		sendSkipped: 0,
@@ -66,6 +67,8 @@ function snap(over: Partial<AudioHealthSnapshot> = {}): AudioHealthSnapshot {
 		newEpisodeIds: [],
 		samplesSkipped: 0,
 		lastTurnLatencyMs: null,
+		lastSpeechToModelMs: null,
+		lastModelEventAt: null,
 		inputHealth: 'ok',
 		epochStartApproxMs: NOW - 60_000,
 		lastMatrixVerdict: null,
@@ -77,6 +80,7 @@ function snap(over: Partial<AudioHealthSnapshot> = {}): AudioHealthSnapshot {
 function baselineBefore(s: AudioHealthSnapshot, deltas: Partial<MatrixBaseline> = {}): MatrixBaseline {
 	return {
 		at: NOW - 30_000,
+		epoch: s.epoch,
 		deliveredFrames: s.deliveredFrames,
 		capCallbacks: s.clientTotals.capCallbacks,
 		bytesSent: s.clientTotals.bytesSent,
@@ -84,6 +88,7 @@ function baselineBefore(s: AudioHealthSnapshot, deltas: Partial<MatrixBaseline> 
 		chunksRecv: s.clientTotals.chunksRecv,
 		chunksScheduled: s.clientTotals.chunksScheduled,
 		chunksEnded: s.clientTotals.chunksEnded,
+		chunksCancelled: s.clientTotals.chunksCancelled,
 		ctxTimeMs: s.lastHeartbeat?.ctxTimeMs ?? null,
 		bufferedAmount: s.lastHeartbeat?.bufferedAmount ?? null,
 		serverBufferedAmount: null,
@@ -229,7 +234,11 @@ describe('P7 D7.2 matrix — rows 6/7a/7b', () => {
 
 	it('row 7a needs the server buffered input — absent ⇒ no verdict from that pattern', () => {
 		const s = snap();
-		const r = evalWith(s, baselineBefore(s), { serverBufferedAmount: null });
+		const prev = baselineBefore(s, {
+			deliveredFrames: s.deliveredFrames - 700,
+			capCallbacks: s.clientTotals.capCallbacks - 700,
+		});
+		const r = evalWith(s, prev, { serverBufferedAmount: null });
 		assert.equal(r.verdict, 'healthy-idle');
 	});
 
@@ -277,6 +286,87 @@ describe('P7 D7.2 matrix — row 5′ healthy-idle', () => {
 		});
 		const r = evalWith(s, prev);
 		assert.equal(r.verdict, 'healthy-idle');
+	});
+});
+
+describe('P7 D7.2 matrix — round-3 honesty + ordering fixes', () => {
+	it('an epoch boundary between ticks is never diffed — insufficient-evidence', () => {
+		const s = snap();
+		const prev = baselineBefore(s, { epoch: 99, deliveredFrames: s.deliveredFrames + 5000 });
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'insufficient-evidence');
+		assert.ok(r.reasons.includes('epoch-boundary'));
+		assert.equal(r.baseline.epoch, s.epoch, 'fresh baseline adopts the new epoch');
+	});
+
+	it('episode overflow means the quiet window cannot be proven quiet', () => {
+		const s = snap({ lastHeartbeat: hb({ episodeOverflow: 2 }) });
+		const prev = baselineBefore(s, {
+			deliveredFrames: s.deliveredFrames - 700,
+			capCallbacks: s.clientTotals.capCallbacks - 700,
+		});
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'insufficient-evidence');
+		assert.ok(r.reasons.some((x) => x.startsWith('episodeOverflow')));
+	});
+
+	it('a stale heartbeat cannot support healthy-idle', () => {
+		const s = snap({ lastHeartbeat: hb({ receivedAt: NOW - 20_000 }) });
+		const prev = baselineBefore(s, {
+			deliveredFrames: s.deliveredFrames - 700,
+			capCallbacks: s.clientTotals.capCallbacks - 700,
+		});
+		const r = evalWith(s, prev);
+		assert.equal(r.verdict, 'insufficient-evidence');
+		assert.ok(r.reasons.includes('heartbeat-stale'));
+	});
+
+	it('zero progress while unmuted is missing telemetry, not health', () => {
+		const s = snap({ lastDeliveredAt: NOW - 1000 });
+		const r = evalWith(s, baselineBefore(s));
+		assert.equal(r.verdict, 'insufficient-evidence');
+		assert.ok(r.reasons.includes('no-progress-in-window'));
+	});
+
+	it('row 5 outranks row 6: speech with no model event wins over backpressure (D7.2 order)', () => {
+		const s = snap({
+			coverage: 'full' as never,
+			speech: { active: true, onsetAt: NOW - 3000, lastAboveFloorAt: NOW - 500 },
+			lastHeartbeat: hb({ bufferedAmount: 500_000 }),
+		});
+		const prev = baselineBefore(s, {
+			deliveredFrames: s.deliveredFrames - 100,
+			bufferedAmount: 50_000,
+		});
+		const r = evalWith(s, prev, { lastModelEventAt: NOW - 60_000 });
+		assert.equal(r.verdict, 'model-silent');
+	});
+
+	it('a stale client speech EPISODE alone is not current speech evidence (canonical tracker only)', () => {
+		const s = snap({
+			speech: { active: false, onsetAt: null, lastAboveFloorAt: null },
+			lastHeartbeat: hb({ episodes: [{ id: 7, kind: 'speech', onsetSeq: 5, offsetSeq: 9, maxRmsPm: 300, aboveFloorMs: 900 }] }),
+		});
+		const prev = baselineBefore(s, {
+			deliveredFrames: s.deliveredFrames - 700,
+			capCallbacks: s.clientTotals.capCallbacks - 700,
+		});
+		const r = evalWith(s, prev, { lastModelEventAt: NOW - 60_000 });
+		assert.notEqual(r.verdict, 'model-silent');
+		assert.ok(!r.reasons.includes('speech-without-model-event'));
+	});
+
+	it('row 7b: an all-cancelled window (barge-in flush) proves nothing about playback', () => {
+		const s = snap({ lastHeartbeat: hb({ ctxTimeMs: 30_000 }) });
+		const prev = baselineBefore(s, {
+			chunksScheduled: s.clientTotals.chunksScheduled - 20,
+			chunksCancelled: s.clientTotals.chunksCancelled - 20,
+			deliveredFrames: s.deliveredFrames - 700,
+			capCallbacks: s.clientTotals.capCallbacks - 700,
+			ctxTimeMs: 30_000,
+		});
+		const r = evalWith(s, prev);
+		assert.notEqual(r.verdict, 'client-playback-failure');
 	});
 });
 

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -1501,7 +1501,8 @@ describe('P7 D7.1 audio_health heartbeat', () => {
 		assert.equal(hb.length, 3, 'heartbeats at ticks 0/4/8 — 2 s cadence on the 500 ms timer');
 		assert.equal(hb[0].n.length, 8);
 		assert.equal(hb[0].n, hb[2].n, 'nonce stable within the epoch');
-		assert.equal(hb[2].c[0], 2, 'capCallbacks absolute (idempotent across skipped beats)');
+		assert.equal(hb[0].c[0], 2, 'first beat carries the delta since epoch start');
+		assert.equal(hb[1].c[0] + hb[2].c[0], 0, 'quiet beats carry zero deltas');
 		assert.deepEqual([hb[0].q, hb[1].q, hb[2].q], [0, 1, 2]);
 		const enc = new TextEncoder();
 		for (const x of s.sent.filter((v): v is string => typeof v === 'string')) {
@@ -1593,9 +1594,12 @@ describe('P7 D7.1 audio_health heartbeat', () => {
 		assert.ok(new TextEncoder().encode(raw).byteLength <= 300, 'hard cap holds under worst case');
 		const hb = JSON.parse(raw);
 		assert.ok((hb.ep?.length ?? 0) < 4, 'window trimmed to fit');
+		// Core evidence survives trimming/dropping; only diagnostics (x/ba/sc)
+		// may be sacrificed for the cap.
 		assert.equal(hb.mu, 1);
 		assert.ok(hb.og, 'open gap still travels');
-		assert.deepEqual(hb.ba, [99_999_999, 99_999_999]);
+		assert.equal(hb.c.length, 8, 'delta counters intact');
+		assert.equal(hb.n.length, 8, 'nonce intact');
 		h.t.disconnect();
 	});
 
@@ -1872,6 +1876,348 @@ describe('P7 §D7.0b frame-path budget', () => {
 		const addedUs = (p99(tInst) - p99(tBase)) / 1000;
 		assert.ok(addedUs <= 50, `added p99 ${addedUs.toFixed(1)} µs exceeds the 50 µs budget`);
 		assert.ok(baseBytes > 0);
+		h.t.disconnect();
+	});
+
+	it('PCM displacement: heartbeat bytes are <1% of egress while frames flow', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now });
+		const s = await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		for (let i = 0; i < 47; i++) {
+			now += 43;
+			p(frame(LOUD));
+		}
+		tick(h); // one heartbeat within the ~2 s of PCM
+		let stringBytes = 0;
+		let binBytes = 0;
+		for (const x of s.sent) {
+			if (typeof x === 'string') stringBytes += new TextEncoder().encode(x).byteLength;
+			else binBytes += (x as ArrayBuffer).byteLength;
+		}
+		assert.ok(binBytes > 0);
+		assert.ok(
+			stringBytes / (stringBytes + binBytes) < 0.01,
+			`displacement ${((stringBytes / (stringBytes + binBytes)) * 100).toFixed(2)}% ≥ 1%`,
+		);
+		h.t.disconnect();
+	});
+
+	it('zero added frame-path allocation (GC A/B soak — needs --expose-gc, else skips)', async (t) => {
+		const gc = (globalThis as { gc?: () => void }).gc;
+		if (typeof gc !== 'function') {
+			t.skip('run with node --expose-gc to enable');
+			return;
+		}
+		const h = harness();
+		await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		const s = h.sock();
+		const buf = new Float32Array(2048).fill(0.05);
+		const ev = frame(buf);
+		const baseSink: ArrayBuffer[] = [];
+		const baseline = (e: FrameEvent): void => {
+			const raw = e.inputBuffer.getChannelData(0);
+			baseSink.push(float32ToInt16(downsample(raw, 48000, 16000)).buffer as ArrayBuffer);
+		};
+		const measure = (fn: (e: FrameEvent) => void, sink: () => void): number => {
+			for (let i = 0; i < 500; i++) fn(ev); // warm
+			sink();
+			gc();
+			const before = process.memoryUsage().heapUsed;
+			for (let i = 0; i < 3000; i++) {
+				fn(ev);
+				if (i % 250 === 0) sink();
+			}
+			sink();
+			gc();
+			return process.memoryUsage().heapUsed - before;
+		};
+		const baseDelta = measure(baseline, () => {
+			baseSink.length = 0;
+		});
+		const instDelta = measure(p, () => {
+			s.sent.length = 0;
+		});
+		assert.ok(
+			instDelta <= baseDelta + 512 * 1024,
+			`instrumented retained ${instDelta - baseDelta} B more than baseline`,
+		);
+		h.t.disconnect();
+	});
+});
+
+describe('P7 codex round-1 fixes', () => {
+	it('gap that starts AND ends between watchdog ticks still latches (frozen-timer self-latch)', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now });
+		await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		p(frame(QUIET)); // lastCapAt = 10000
+		now += 1200; // whole-thread freeze: no tick ever observed it
+		p(frame(QUIET)); // resumed callback must latch before overwriting
+		const ep = ((h.t as any).episodeRing as any[]).find((sl) => sl.id === 1);
+		assert.ok(ep, 'episode latched without any watchdog tick');
+		assert.equal(ep.kind, 'gap');
+		assert.equal(ep.durationMs, 1200);
+		assert.equal((h.t as any).episodeSeq, 1);
+		h.t.disconnect();
+	});
+
+	it('capture that never fires its first callback still produces a stall (wire-time baseline)', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now });
+		const s = await goLive(h);
+		stopRealStats(h);
+		// no frames at all
+		now += 1500;
+		tick(h);
+		assert.equal((h.t as any).capStalled, true, 'baseline armed at graph wire');
+		const hb = healthFrames(s);
+		assert.ok(hb[0].og, 'open gap travels');
+		h.t.disconnect();
+	});
+
+	it('watchdog stays armed during a reacquire outage (processor torn down)', async () => {
+		let now = 10_000;
+		const streams: FakeMediaStream[] = [];
+		gumImpl = async () => {
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		const h = harness({ nowFn: () => now, recoveryBackoffMs: [0, 0, 0], recoveryResumeTimeoutMs: 5000 });
+		await goLive(h);
+		stopRealStats(h);
+		proc(h)(frame(QUIET));
+		gumImpl = () => new Promise<FakeMediaStream>(() => {}); // park the reacquire
+		(streams[0].tracks[0] as any).onended?.();
+		await delay(5);
+		assert.equal((h.t as any).captureState, 'recovering');
+		assert.equal((h.t as any).processor, null, 'precondition: capture torn down');
+		now += 2000;
+		tick(h);
+		assert.equal((h.t as any).capStalled, true, 'reacquire outage is a gap');
+		h.t.disconnect();
+	});
+
+	it('reacquire requested during an in-flight resume is honored after the resume succeeds', async () => {
+		const events: Array<{ s: string; k: string }> = [];
+		const streams: FakeMediaStream[] = [];
+		let gumCalls = 0;
+		gumImpl = async () => {
+			gumCalls++;
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		const h = harness({
+			recoveryBackoffMs: [0, 0, 0],
+			recoveryResumeTimeoutMs: 500,
+			onCaptureHealth: (s: any, k: any) => events.push({ s, k }),
+		});
+		await goLive(h);
+		const ctx = FakeAudioContext.created[0];
+		let releaseResume!: () => void;
+		ctx.resume = () =>
+			new Promise<void>((res) => {
+				releaseResume = () => {
+					ctx.state = 'running';
+					res();
+				};
+			});
+		ctx.state = 'suspended';
+		ctx.fireStateChange(); // resume-recovery parks inside resume()
+		await delay(5);
+		(streams[0].tracks[0] as any).onended?.(); // dead track during the resume
+		releaseResume(); // resume SUCCEEDS — but the track is still dead
+		await delay(10);
+		assert.equal(gumCalls, 2, 'escalated reacquire ran after the successful resume');
+		assert.equal((h.t as any).micStream, streams[1], 'fresh stream wired');
+		const last = events[events.length - 1];
+		assert.deepEqual(last, { s: 'recovered', k: 'reacquire' });
+		h.t.disconnect();
+	});
+
+	it('reacquire with the context stuck suspended reports failure, not recovery', async () => {
+		const events: Array<{ s: string; k: string }> = [];
+		const streams: FakeMediaStream[] = [];
+		let gumCalls = 0;
+		gumImpl = async () => {
+			gumCalls++;
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		const h = harness({
+			recoveryBackoffMs: [0, 0, 0],
+			recoveryResumeTimeoutMs: 30,
+			onCaptureHealth: (s: any, k: any) => events.push({ s, k }),
+		});
+		await goLive(h);
+		const ctx = FakeAudioContext.created[0];
+		ctx.resume = async () => {
+			/* resolves but the context never runs again */
+		};
+		ctx.state = 'suspended';
+		(streams[0].tracks[0] as any).onended?.();
+		await delay(30);
+		assert.equal((h.t as any).captureState, 'degraded', 'suspended ctx is NOT a recovery');
+		assert.equal(gumCalls, 4, 'initial + 3 bounded attempts');
+		for (const st of streams.slice(1)) {
+			assert.equal(st.tracks[0].stopped, true, 'unused acquisition stopped');
+		}
+		assert.equal(events[events.length - 1].s, 'degraded');
+		h.t.disconnect();
+	});
+
+	it('a stale attempt\'s in-flight recovery cannot swallow the new attempt\'s trigger', async () => {
+		const events: Array<{ s: string; k: string }> = [];
+		const streams: FakeMediaStream[] = [];
+		gumImpl = async () => {
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		const h = harness({
+			recoveryBackoffMs: [0, 0, 0],
+			recoveryResumeTimeoutMs: 5000,
+			onCaptureHealth: (s: any, k: any) => events.push({ s, k }),
+		});
+		await goLive(h);
+		// Park attempt 1's recovery inside getUserMedia.
+		gumImpl = () => new Promise<FakeMediaStream>(() => {});
+		(streams[0].tracks[0] as any).onended?.();
+		await delay(5);
+		assert.equal(events.filter((e) => e.s === 'recovering').length, 1);
+		// New attempt over the same transport.
+		gumImpl = async () => {
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		await h.t.connect('ws://fake:9900/');
+		h.sock().open();
+		await delay(5);
+		const ctx = FakeAudioContext.created[0]; // reused (never closed)
+		ctx.resume = async () => {
+			ctx.state = 'running';
+		};
+		ctx.state = 'suspended';
+		ctx.fireStateChange();
+		await delay(10);
+		assert.equal(
+			events.filter((e) => e.s === 'recovering').length,
+			2,
+			'the live attempt took recovery ownership from the fenced-dead loop',
+		);
+		assert.equal(events[events.length - 1].s, 'recovered');
+		h.t.disconnect();
+	});
+
+	it('a stale device enumeration cannot reacquire over a fresh recovery (captureGen fence)', async () => {
+		const streams: FakeMediaStream[] = [];
+		let gumCalls = 0;
+		gumImpl = async () => {
+			gumCalls++;
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		const enumResolvers: Array<(v: Array<{ kind: string; deviceId: string }>) => void> = [];
+		enumImpl = () => new Promise((res) => enumResolvers.push(res));
+		const h = harness({ recoveryBackoffMs: [0, 0, 0], recoveryResumeTimeoutMs: 100 });
+		await goLive(h);
+		// r0: wireCaptureGraph's initial snapshot — settle it as 'a'.
+		enumResolvers.shift()?.([{ kind: 'audioinput', deviceId: 'a' }]);
+		await delay(5);
+		fireDeviceChange(); // r1 parks (captures captureGen)
+		await delay(2);
+		(streams[0].tracks[0] as any).onended?.(); // recovery replaces the graph (bumps captureGen)
+		await delay(10);
+		assert.equal(gumCalls, 2, 'precondition: track-ended reacquired');
+		// r2: the NEW graph's snapshot; r1 is still the parked devicechange.
+		const afterRecovery = gumCalls;
+		enumResolvers.pop()?.([{ kind: 'audioinput', deviceId: 'b' }]); // settle r2 (fresh graph)
+		enumResolvers.shift()?.([{ kind: 'audioinput', deviceId: 'zzz' }]); // stale r1: changed set!
+		await delay(10);
+		assert.equal(gumCalls, afterRecovery, 'stale enumeration fenced — no spurious reacquire');
+		h.t.disconnect();
+	});
+
+	it('delta heartbeats: a failed send folds its interval into the next beat (lossless)', async () => {
+		const now = 10_000;
+		const h = harness({ nowFn: () => now });
+		const s = await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		p(frame(LOUD));
+		p(frame(LOUD));
+		tick(h); // tick 0 → hb0: delta 2
+		for (let i = 0; i < 3; i++) p(frame(LOUD));
+		let failNext = true;
+		const origSend = s.send.bind(s);
+		s.send = (d: ArrayBuffer | string) => {
+			if (typeof d === 'string' && failNext) {
+				failNext = false;
+				throw new Error('socket hiccup');
+			}
+			origSend(d);
+		};
+		tick(h);
+		tick(h);
+		tick(h);
+		tick(h); // tick 4 → hb send FAILS (baseline not advanced)
+		p(frame(LOUD));
+		tick(h);
+		tick(h);
+		tick(h);
+		tick(h); // tick 8 → next successful hb
+		const hb = healthFrames(s);
+		assert.equal(hb.length, 2, 'failed beat never landed');
+		assert.equal(hb[0].c[0], 2);
+		assert.equal(hb[1].c[0], 4, 'lost interval (3) + new (1) folded into one delta');
+		assert.deepEqual([hb[0].q, hb[1].q], [0, 1], 'q counts SENT beats — contiguous');
+		h.t.disconnect();
+	});
+
+	it('lifecycle evidence rides onStats: ctx transition, device + recovery events, drop counters', async () => {
+		const statsSeen: any[] = [];
+		const streams: FakeMediaStream[] = [];
+		gumImpl = async () => {
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		const h = harness({
+			recoveryBackoffMs: [0, 0, 0],
+			recoveryResumeTimeoutMs: 100,
+			onStats: (st: any) => statsSeen.push(st),
+		});
+		await goLive(h);
+		stopRealStats(h);
+		const ctx = FakeAudioContext.created[0];
+		ctx.state = 'suspended';
+		ctx.fireStateChange(); // resume recovery (fake resume → running)
+		await delay(10);
+		(streams[0].tracks[0] as any).onended?.(); // reacquire
+		await delay(10);
+		tick(h);
+		const st = statsSeen[statsSeen.length - 1];
+		assert.equal(st.ctxLastTransition?.to, 'suspended');
+		assert.ok(
+			st.deviceEvents.some((e: any) => e.kind === 'track-ended'),
+			'device events exposed',
+		);
+		assert.ok(
+			st.recoveryEvents.some((e: any) => e.result === 'recovered'),
+			'recovery events exposed',
+		);
+		assert.equal(st.deviceEventsDropped, 0);
+		assert.equal(st.recoveryEventsDropped, 0);
 		h.t.disconnect();
 	});
 });

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -320,7 +320,7 @@ class FakeAudioContext {
 		return { duration: len / rate, getChannelData: () => new Float32Array(len) };
 	}
 	createBufferSource(): any {
-		return {
+		const src = {
 			buffer: null,
 			playbackRate: { value: 1 },
 			connect() {},
@@ -328,8 +328,19 @@ class FakeAudioContext {
 				this.bufferSourcesStarted++;
 			},
 			stop() {},
-			onended: null,
+			onended: null as (() => void) | null,
 		};
+		this.bufferSources.push(src);
+		return src;
+	}
+	/** Every source created, in order — P7 ended/cancelled split tests fire
+	 *  their onended by hand. */
+	bufferSources: Array<{ onended: (() => void) | null; stop: () => void }> = [];
+	/** P7 D7.5: the transport assigns onstatechange; tests flip `state` and
+	 *  call this to simulate a browser lifecycle transition. */
+	onstatechange: (() => void) | null = null;
+	fireStateChange(): void {
+		this.onstatechange?.();
 	}
 }
 
@@ -340,6 +351,8 @@ class FakeSocket {
 	readyState = 0; // CONNECTING
 	sent: Array<ArrayBuffer | string> = [];
 	closeCalls = 0;
+	/** P7: settable for bufferedAmount-skip tests (real sockets expose this). */
+	bufferedAmount = 0;
 	onopen: (() => void) | null = null;
 	onmessage: ((ev: { data: unknown }) => void) | null = null;
 	onerror: (() => void) | null = null;
@@ -379,13 +392,32 @@ class FakeSocket {
 // Browser globals the class touches. Each test FILE runs in its own process
 // under the node:test runner, so this stubbing cannot leak into other suites.
 let gumImpl: () => Promise<FakeMediaStream>;
+/** P7 D7.5 input-device fingerprinting seam: tests swap the device list to
+ *  drive the devicechange input-filter. */
+let enumImpl: () => Promise<Array<{ kind: string; deviceId: string }>>;
+const mediaDevicesListeners: Array<{ type: string; h: () => void }> = [];
+function fireDeviceChange(): void {
+	for (const l of [...mediaDevicesListeners]) if (l.type === 'devicechange') l.h();
+}
 Object.defineProperty(globalThis, 'AudioContext', {
 	value: FakeAudioContext,
 	configurable: true,
 	writable: true,
 });
 Object.defineProperty(globalThis, 'navigator', {
-	value: { mediaDevices: { getUserMedia: () => gumImpl() } },
+	value: {
+		mediaDevices: {
+			getUserMedia: () => gumImpl(),
+			enumerateDevices: () => enumImpl(),
+			addEventListener: (type: string, h: () => void) => {
+				mediaDevicesListeners.push({ type, h });
+			},
+			removeEventListener: (type: string, h: () => void) => {
+				const i = mediaDevicesListeners.findIndex((l) => l.type === type && l.h === h);
+				if (i >= 0) mediaDevicesListeners.splice(i, 1);
+			},
+		},
+	},
 	configurable: true,
 	writable: true,
 });
@@ -434,6 +466,8 @@ beforeEach(() => {
 	FakeAudioContext.nextState = 'running';
 	FakeAudioContext.resumeHook = null;
 	gumImpl = async () => new FakeMediaStream();
+	enumImpl = async () => [];
+	mediaDevicesListeners.length = 0;
 });
 
 describe('classifyMicErrorCode (Step 15 — machine-readable class)', () => {
@@ -713,7 +747,11 @@ describe('attempt conclusion invalidates the generation (fix round — server-cl
 		FakeAudioContext.resumeHook = () => new Promise((res) => (release = res));
 		await delay(5); // getUserMedia resolved → stream captured → parked in resume()
 		assert.equal(streams.length, 1);
-		assert.equal((h.t as any).micStream, streams[0], 'precondition: captured before the resume await');
+		// P7 (wireCaptureGraph): the captured stream is not published to
+		// micStream until AFTER the resume fence passes — while parked, the
+		// grant is held only by the continuation, so a stale one can't leave
+		// even a transient publication behind.
+		assert.equal((h.t as any).micStream, null, 'precondition: parked in resume, not yet published');
 
 		h.t.disconnect(); // while parked in resume()
 		assert.equal(h.statuses[h.statuses.length - 1].status, 'closed');
@@ -1279,5 +1317,561 @@ describe('transport public API additions (Steps 15/16/18)', () => {
 				k + ' has a remediation hint',
 			);
 		}
+	});
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// P7 step 1 — audio-progress ledger client hop (D7.1): counters, latched
+// episodes, watchdog, audio_health heartbeat; capture recovery FSM (D7.5);
+// §D7.0b frame-path budget guard.
+// ═════════════════════════════════════════════════════════════════════════════
+
+type FrameEvent = { inputBuffer: { getChannelData: () => Float32Array } };
+function frame(samples: Float32Array): FrameEvent {
+	return { inputBuffer: { getChannelData: () => samples } };
+}
+const LOUD = new Float32Array(2048).fill(0.1); // rms 0.1 ≥ 0.02 floor
+const QUIET = new Float32Array(2048); // zeros
+
+function proc(h: ReturnType<typeof harness>): (e: FrameEvent) => void {
+	const p = (h.t as any).processor;
+	assert.ok(p?.onaudioprocess, 'capture processor must be wired');
+	return p.onaudioprocess;
+}
+
+/** Kill the real 500 ms interval so ticks are driven deterministically. */
+function stopRealStats(h: ReturnType<typeof harness>): void {
+	const timer = (h.t as any).statsTimer;
+	if (timer) clearInterval(timer);
+	(h.t as any).statsTimer = null;
+}
+function tick(h: ReturnType<typeof harness>): void {
+	(h.t as any).runStatsTick();
+}
+function healthFrames(s: FakeSocket): any[] {
+	return s.sent
+		.filter((x): x is string => typeof x === 'string')
+		.map((x) => {
+			try {
+				return JSON.parse(x);
+			} catch {
+				return null;
+			}
+		})
+		.filter((m) => m?.t === 'audio_health');
+}
+
+describe('P7 D7.1 ledger counters', () => {
+	it('scheduled/ended/cancelled split: barge-in cancellations never count as completion', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		const ctx = FakeAudioContext.created[0];
+		s.binary(new Int16Array([1000, -1000, 500, -500]).buffer);
+		s.binary(new Int16Array([1000, -1000]).buffer);
+		s.binary(new Int16Array([500]).buffer);
+		assert.equal((h.t as any).chunksScheduled, 3);
+		assert.equal((h.t as any).activeSources.length, 3);
+		ctx.bufferSources[0].onended?.(); // natural completion of the first
+		assert.equal((h.t as any).chunksEnded, 1);
+		assert.ok((h.t as any).lastEndedAt != null);
+		feed(h.t, { type: 'turn.interrupted' }); // flush cancels the remaining two
+		assert.equal((h.t as any).chunksCancelled, 2);
+		assert.equal((h.t as any).activeSources.length, 0);
+		// The browser fires onended for stop()ped sources too — a cancelled
+		// chunk must not later masquerade as a completion.
+		ctx.bufferSources[1].onended?.();
+		assert.equal((h.t as any).chunksEnded, 1, 'cancelled chunk never counts as ended');
+		h.t.disconnect();
+	});
+
+	it('bufferedAmount watermark: skip + sendSkipped + high-water, resumes when drained', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		const p = proc(h);
+		const bin = () => s.sent.filter((x) => typeof x !== 'string').length;
+		const before = bin();
+		s.bufferedAmount = 300 * 1024;
+		p(frame(LOUD));
+		assert.equal((h.t as any).sendSkipped, 1);
+		assert.equal((h.t as any).bufferedHighWater, 300 * 1024);
+		assert.equal(bin(), before, 'no PCM past the watermark');
+		s.bufferedAmount = 0;
+		p(frame(LOUD));
+		assert.equal(bin(), before + 1, 'send resumes when drained');
+		assert.equal((h.t as any).sendSkipped, 1);
+		h.t.disconnect();
+	});
+
+	it('send try/catch: a throwing socket increments sendFailed, never throws off the graph', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		const p = proc(h);
+		s.send = () => {
+			throw new Error('boom');
+		};
+		assert.doesNotThrow(() => p(frame(LOUD)));
+		assert.equal((h.t as any).sendFailed, 1);
+		assert.equal((h.t as any).capCallbacks, 1, 'callback still accounted');
+		assert.equal((h.t as any).bytesSent, 0, 'failed send not counted as sent');
+		h.t.disconnect();
+	});
+});
+
+describe('P7 D7.1 latched episodes + watchdog', () => {
+	it('RMS floor latches a speech interval {onsetSeq, offsetSeq, maxRms, aboveFloorMs}', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now });
+		await goLive(h);
+		const p = proc(h);
+		p(frame(LOUD)); // onset at seq 1
+		now += 43;
+		p(frame(LOUD));
+		now += 700; // past the 600 ms hangover
+		p(frame(QUIET)); // offset
+		const ep = ((h.t as any).episodeRing as any[]).find((sl) => sl.id === 1);
+		assert.ok(ep, 'episode latched');
+		assert.equal(ep.kind, 'speech');
+		assert.equal(ep.onsetSeq, 1);
+		assert.equal(ep.offsetSeq, 3);
+		assert.equal(ep.maxRmsPm, 100); // rms 0.1 → 100‰
+		assert.equal(ep.aboveFloorMs, 86); // 2 loud frames × 43 ms
+		assert.equal((h.t as any).speechActive, false);
+		h.t.disconnect();
+	});
+
+	it('capture stall opens a gap (capStalled + og on the wire); return latches the episode; the latch survives fast resume and re-sends idempotently', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now });
+		const s = await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		p(frame(QUIET)); // lastCapAt = 10000
+		now += 1100; // > max(3×43, 1000)
+		tick(h); // tick 0: gap opens + first heartbeat
+		assert.equal((h.t as any).capStalled, true);
+		let hb = healthFrames(s);
+		assert.equal(hb.length, 1);
+		assert.deepEqual(hb[0].og, [0, 1100], 'open gap travels — a permanent stall never closes an episode');
+		// Fast resume (S2 shape): capture returns before the next tick — the
+		// interval must LATCH, not vanish with the overwritten lastCapAt.
+		p(frame(QUIET));
+		assert.equal((h.t as any).capStalled, false);
+		const ep = ((h.t as any).episodeRing as any[]).find((sl) => sl.id === 1);
+		assert.equal(ep.kind, 'gap');
+		assert.equal(ep.durationMs, 1100);
+		for (let i = 0; i < 4; i++) tick(h); // ticks 1-4 → heartbeat at 4
+		for (let i = 0; i < 4; i++) tick(h); // ticks 5-8 → heartbeat at 8
+		hb = healthFrames(s);
+		assert.equal(hb.length, 3);
+		assert.deepEqual(hb[1].ep.map((e: any[]) => e[0]), [1]);
+		assert.deepEqual(hb[2].ep.map((e: any[]) => e[0]), [1], 'idempotent window re-sends by id');
+		assert.equal(hb[1].og, undefined, 'gap closed — og gone');
+		h.t.disconnect();
+	});
+
+	it('watchdog is gated: no gap while muted', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now });
+		await goLive(h);
+		stopRealStats(h);
+		proc(h)(frame(QUIET));
+		h.t.setMicMuted(true);
+		now += 5000;
+		tick(h);
+		assert.equal((h.t as any).capStalled, false);
+		assert.equal((h.t as any).gapOpenedAt, 0);
+		h.t.disconnect();
+	});
+});
+
+describe('P7 D7.1 audio_health heartbeat', () => {
+	it('cadence (first tick, then every 4th), stable 8-char nonce, absolute counters, seq', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now });
+		const s = await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		p(frame(LOUD));
+		p(frame(LOUD));
+		for (let i = 0; i < 9; i++) {
+			now += 500;
+			tick(h);
+		}
+		const hb = healthFrames(s);
+		assert.equal(hb.length, 3, 'heartbeats at ticks 0/4/8 — 2 s cadence on the 500 ms timer');
+		assert.equal(hb[0].n.length, 8);
+		assert.equal(hb[0].n, hb[2].n, 'nonce stable within the epoch');
+		assert.equal(hb[2].c[0], 2, 'capCallbacks absolute (idempotent across skipped beats)');
+		assert.deepEqual([hb[0].q, hb[1].q, hb[2].q], [0, 1, 2]);
+		const enc = new TextEncoder();
+		for (const x of s.sent.filter((v): v is string => typeof v === 'string')) {
+			assert.ok(enc.encode(x).byteLength <= 300, 'every frame ≤ 300 B (≤150 B/s at 2 s cadence)');
+		}
+		h.t.disconnect();
+	});
+
+	it('episode window: last 4 by id; unsent episodes aging out surface as eo', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now, speechOffsetHangMs: 100 });
+		const s = await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		for (let k = 0; k < 6; k++) {
+			p(frame(LOUD));
+			now += 43;
+			p(frame(LOUD));
+			now += 200; // past the 100 ms hangover
+			p(frame(QUIET));
+			now += 10;
+		}
+		assert.equal((h.t as any).episodeSeq, 6);
+		tick(h);
+		const hb = healthFrames(s);
+		assert.deepEqual(hb[0].ep.map((e: any[]) => e[0]), [3, 4, 5, 6], 'window = newest 4, oldest first');
+		assert.equal(hb[0].eo, 2, 'episodes 1-2 can never be sent — evidence loss is visible');
+		tick(h);
+		tick(h);
+		tick(h);
+		tick(h); // next heartbeat
+		const hb2 = healthFrames(s);
+		assert.deepEqual(hb2[1].ep.map((e: any[]) => e[0]), [3, 4, 5, 6], 'idempotent re-send');
+		assert.equal(hb2[1].eo, 2, 'overflow counted exactly once');
+		h.t.disconnect();
+	});
+
+	it('worst-case serialization: hard ≤300 B by construction — window trims, flags survive', async () => {
+		let now = 10_000;
+		const h = harness({ nowFn: () => now, speechOffsetHangMs: 100 });
+		const s = await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		for (let k = 0; k < 6; k++) {
+			p(frame(LOUD));
+			now += 43;
+			p(frame(LOUD));
+			now += 200;
+			p(frame(QUIET));
+			now += 10;
+		}
+		const t: any = h.t;
+		t.capCallbacks = 9_999_999;
+		t.bytesSent = 9_999_999_999;
+		t.sendSkipped = 99_999;
+		t.sendFailed = 99_999;
+		t.audioChunksRecv = 9_999_999;
+		t.chunksScheduled = 9_999_999;
+		t.chunksEnded = 9_999_999;
+		t.chunksCancelled = 9_999_999;
+		t.ctxSuspendCount = 999;
+		t.bufferedHighWater = 99_999_999;
+		t.lastEndedAt = 1;
+		t.gapOpenedAt = 1; // ancient open gap (worst-width og values)
+		s.bufferedAmount = 99_999_999;
+		h.t.setMicMuted(true);
+		// Model episodes from hour 3 of a call: every numeric field at its
+		// realistic maximum width, so the serialized window genuinely overflows.
+		for (const slot of t.episodeRing as any[]) {
+			if (slot.id === 0) continue;
+			slot.startMs = 9_999_999;
+			slot.endMs = 9_999_999;
+			slot.durationMs = 9_999_999;
+			slot.onsetSeq = 9_999_999;
+			slot.offsetSeq = 9_999_999;
+			slot.maxRmsPm = 1000;
+			slot.aboveFloorMs = 9_999_999;
+		}
+		tick(h);
+		const raw = s.sent
+			.filter((v): v is string => typeof v === 'string')
+			.find((x) => {
+				try {
+					return JSON.parse(x)?.t === 'audio_health';
+				} catch {
+					return false;
+				}
+			})!;
+		assert.ok(new TextEncoder().encode(raw).byteLength <= 300, 'hard cap holds under worst case');
+		const hb = JSON.parse(raw);
+		assert.ok((hb.ep?.length ?? 0) < 4, 'window trimmed to fit');
+		assert.equal(hb.mu, 1);
+		assert.ok(hb.og, 'open gap still travels');
+		assert.deepEqual(hb.ba, [99_999_999, 99_999_999]);
+		h.t.disconnect();
+	});
+
+	it('skipped silently when the socket is not open', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		stopRealStats(h);
+		s.serverClose(4000, 'bye');
+		assert.doesNotThrow(() => tick(h));
+		assert.equal(healthFrames(s).length, 0);
+	});
+
+	it('epoch scoping: reconnect resets counters/episodes and rotates the nonce', async () => {
+		const h = harness();
+		const s1 = await goLive(h);
+		stopRealStats(h);
+		proc(h)(frame(LOUD));
+		tick(h);
+		const n1 = healthFrames(s1)[0].n;
+		assert.equal((h.t as any).capCallbacks, 1);
+		await h.t.connect('ws://fake:9900/');
+		const s2 = h.sock();
+		s2.open();
+		await delay(5);
+		stopRealStats(h);
+		assert.equal((h.t as any).capCallbacks, 0, 'counters reset per epoch');
+		assert.equal((h.t as any).episodeSeq, 0, 'episodes reset per epoch');
+		tick(h);
+		const n2 = healthFrames(s2)[0].n;
+		assert.notEqual(n1, n2, 'fresh nonce per connection epoch');
+		h.t.disconnect();
+	});
+
+	it('demux: heartbeat text rides between binary PCM frames without disturbing egress', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		p(frame(LOUD));
+		tick(h);
+		p(frame(LOUD));
+		const kinds = s.sent.map((x) => (typeof x === 'string' ? 's' : 'b')).join('');
+		assert.ok(kinds.includes('bsb'), 'text heartbeat between binary PCM frames');
+		assert.equal((h.t as any).bytesSent, 2 * 682 * 2, 'PCM byte accounting unaffected');
+		h.t.disconnect();
+	});
+
+	it('onStats: extended payload is additive alongside the byte totals', async () => {
+		const statsSeen: any[] = [];
+		const h = harness({ onStats: (st: any) => statsSeen.push(st) });
+		await goLive(h);
+		stopRealStats(h);
+		proc(h)(frame(LOUD));
+		tick(h);
+		const st = statsSeen[statsSeen.length - 1];
+		assert.equal(typeof st.bytesSent, 'number');
+		assert.equal(typeof st.bytesRecv, 'number');
+		assert.equal(st.capCallbacks, 1);
+		assert.equal(st.captureState, 'observing');
+		assert.equal(st.speechActive, true);
+		assert.equal(st.ctxState, 'running');
+		assert.equal(st.epochNonce.length, 8);
+		h.t.disconnect();
+	});
+});
+
+describe('P7 D7.5 capture recovery FSM', () => {
+	it('suspension → resume recovery succeeds; ctxSuspendCount + transitions recorded', async () => {
+		const events: Array<{ state: string; kind: string }> = [];
+		const h = harness({
+			recoveryBackoffMs: [0, 0, 0],
+			recoveryResumeTimeoutMs: 100,
+			onCaptureHealth: (state: any, kind: any) => events.push({ state, kind }),
+		});
+		await goLive(h);
+		const ctx = FakeAudioContext.created[0];
+		ctx.state = 'suspended';
+		ctx.fireStateChange();
+		await delay(10);
+		assert.deepEqual(events, [
+			{ state: 'recovering', kind: 'resume' },
+			{ state: 'recovered', kind: 'resume' },
+		]);
+		assert.equal((h.t as any).captureState, 'observing');
+		assert.equal((h.t as any).ctxSuspendCount, 1);
+		assert.equal(ctx.state, 'running');
+		h.t.disconnect();
+	});
+
+	it('exhausted recovery → degraded, NOT terminal; single-flight; retryCapture recovers', async () => {
+		const events: Array<{ s: string; k: string }> = [];
+		const h = harness({
+			recoveryBackoffMs: [0, 0, 0],
+			recoveryResumeTimeoutMs: 30,
+			onCaptureHealth: (s: any, k: any) => events.push({ s, k }),
+		});
+		const s = await goLive(h);
+		const ctx = FakeAudioContext.created[0];
+		let resumeCalls = 0;
+		ctx.resume = async () => {
+			resumeCalls++; // resolves but stays suspended — resume ineffective
+		};
+		ctx.state = 'suspended';
+		ctx.fireStateChange();
+		ctx.fireStateChange(); // second signal mid-recovery: no second loop
+		await delay(30);
+		assert.equal((h.t as any).captureState, 'degraded');
+		assert.equal(resumeCalls, 3, 'bounded attempts, single-flight');
+		assert.equal(events.filter((e) => e.s === 'recovering').length, 1, 'one recovering emission');
+		assert.equal(events[events.length - 1].s, 'degraded');
+		assert.equal(h.failures.length, 0, 'degraded is NOT onConnectFailure');
+		assert.equal(s.closeCalls, 0, 'socket stays live — voice lease retained');
+		assert.ok(
+			h.statuses.every((x) => x.status !== 'error' && x.status !== 'closed'),
+			'no terminal status',
+		);
+		// The UI retry affordance: fix the ctx, reacquire from degraded.
+		ctx.resume = async () => {
+			ctx.state = 'running';
+		};
+		let gumCalls = 0;
+		gumImpl = async () => {
+			gumCalls++;
+			return new FakeMediaStream();
+		};
+		h.t.retryCapture();
+		await delay(10);
+		assert.equal(gumCalls, 1, 'retry reacquires');
+		assert.equal((h.t as any).captureState, 'observing');
+		assert.equal(events[events.length - 1].s, 'recovered');
+		h.t.disconnect();
+	});
+
+	it('devicechange filter: output-only change ignored; input-set change reacquires', async () => {
+		let devices = [
+			{ kind: 'audioinput', deviceId: 'a' },
+			{ kind: 'audiooutput', deviceId: 'x' },
+		];
+		enumImpl = async () => devices;
+		let gumCalls = 0;
+		gumImpl = async () => {
+			gumCalls++;
+			return new FakeMediaStream();
+		};
+		const h = harness({ recoveryBackoffMs: [0, 0, 0], recoveryResumeTimeoutMs: 50 });
+		await goLive(h);
+		await delay(5); // initial input-device snapshot settles
+		assert.equal(gumCalls, 1);
+		assert.equal((h.t as any).inputDeviceSig, 'a');
+		devices = [
+			{ kind: 'audioinput', deviceId: 'a' },
+			{ kind: 'audiooutput', deviceId: 'y' },
+		];
+		fireDeviceChange();
+		await delay(10);
+		assert.equal(gumCalls, 1, 'output-only change: no reacquire');
+		devices = [
+			{ kind: 'audioinput', deviceId: 'b' },
+			{ kind: 'audiooutput', deviceId: 'y' },
+		];
+		fireDeviceChange();
+		await delay(10);
+		assert.equal(gumCalls, 2, 'input-set change: reacquire');
+		assert.equal((h.t as any).inputDeviceSig, 'b');
+		h.t.disconnect();
+	});
+
+	it('track ended → reacquire replaces the capture stream', async () => {
+		const streams: FakeMediaStream[] = [];
+		gumImpl = async () => {
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		const h = harness({ recoveryBackoffMs: [0, 0, 0], recoveryResumeTimeoutMs: 50 });
+		await goLive(h);
+		(streams[0].tracks[0] as any).onended?.();
+		await delay(10);
+		assert.equal(streams.length, 2, 'reacquired');
+		assert.equal((h.t as any).micStream, streams[1]);
+		assert.equal(streams[0].tracks[0].stopped, true, 'old track stopped');
+		h.t.disconnect();
+	});
+
+	it('fencing: disconnect during a parked reacquire — the late grant leaks nothing', async () => {
+		const streams: FakeMediaStream[] = [];
+		gumImpl = async () => {
+			const st = new FakeMediaStream();
+			streams.push(st);
+			return st;
+		};
+		const h = harness({ recoveryBackoffMs: [0, 0, 0], recoveryResumeTimeoutMs: 5000 });
+		await goLive(h);
+		let releaseGum!: (s: FakeMediaStream) => void;
+		gumImpl = () =>
+			new Promise<FakeMediaStream>((res) => {
+				releaseGum = (st) => {
+					streams.push(st);
+					res(st);
+				};
+			});
+		(streams[0].tracks[0] as any).onended?.(); // recovery parks in getUserMedia
+		await delay(5);
+		assert.equal((h.t as any).captureState, 'recovering');
+		await h.t.disconnect(); // teardown bumps captureGen
+		const late = new FakeMediaStream();
+		releaseGum(late);
+		await delay(5);
+		assert.equal(late.tracks[0].stopped, true, 'late grant stopped, not leaked');
+		assert.equal((h.t as any).micStream, null);
+		assert.equal((h.t as any).processor, null);
+	});
+
+	it('listener teardown: disconnect removes devicechange + statechange listeners', async () => {
+		const h = harness();
+		await goLive(h);
+		assert.equal(mediaDevicesListeners.length, 1, 'devicechange listener installed');
+		const ctx = FakeAudioContext.created[0];
+		assert.ok(ctx.onstatechange, 'statechange adopted');
+		await h.t.disconnect();
+		assert.equal(mediaDevicesListeners.length, 0, 'devicechange removed');
+		assert.equal(ctx.onstatechange, null, 'statechange cleared before close');
+	});
+});
+
+describe('P7 §D7.0b frame-path budget', () => {
+	it('instrumented frame handler adds ≤50 µs p99 over the pinned-replica baseline', async () => {
+		const h = harness();
+		await goLive(h);
+		stopRealStats(h);
+		const p = proc(h);
+		const s = h.sock();
+		const buf = new Float32Array(2048);
+		for (let i = 0; i < buf.length; i++) buf[i] = Math.sin(i / 10) * 0.05;
+		const ev = frame(buf);
+		// Pinned-replica baseline: the pre-P7 handler body with a same-shape sink.
+		const baseSink: ArrayBuffer[] = [];
+		let baseBytes = 0;
+		const baseline = (e: FrameEvent): void => {
+			const raw = e.inputBuffer.getChannelData(0);
+			const down = downsample(raw, 48000, 16000);
+			const pcm = float32ToInt16(down);
+			baseSink.push(pcm.buffer as ArrayBuffer);
+			baseBytes += pcm.buffer.byteLength;
+		};
+		const N = 2000;
+		const WARM = 300;
+		const tInst = new Float64Array(N);
+		const tBase = new Float64Array(N);
+		for (let i = 0; i < WARM; i++) {
+			p(ev);
+			baseline(ev);
+		}
+		s.sent.length = 0;
+		baseSink.length = 0;
+		for (let i = 0; i < N; i++) {
+			let t0 = process.hrtime.bigint();
+			baseline(ev);
+			let t1 = process.hrtime.bigint();
+			tBase[i] = Number(t1 - t0);
+			t0 = process.hrtime.bigint();
+			p(ev);
+			t1 = process.hrtime.bigint();
+			tInst[i] = Number(t1 - t0);
+			if (i % 250 === 0) {
+				s.sent.length = 0; // keep sink growth from skewing either side
+				baseSink.length = 0;
+			}
+		}
+		const p99 = (a: Float64Array): number => {
+			const c = Array.from(a).sort((x, y) => x - y);
+			return c[Math.floor(c.length * 0.99)];
+		};
+		const addedUs = (p99(tInst) - p99(tBase)) / 1000;
+		assert.ok(addedUs <= 50, `added p99 ${addedUs.toFixed(1)} µs exceeds the 50 µs budget`);
+		assert.ok(baseBytes > 0);
+		h.t.disconnect();
 	});
 });

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -1767,6 +1767,29 @@ describe('P7 D7.5 capture recovery FSM', () => {
 		h.t.disconnect();
 	});
 
+	it('devicechange before the initial input snapshot settles does not reacquire blindly', async () => {
+		const resolvers: Array<(v: Array<{ kind: string; deviceId: string }>) => void> = [];
+		enumImpl = () => new Promise((resolve) => resolvers.push(resolve));
+		let gumCalls = 0;
+		gumImpl = async () => {
+			gumCalls++;
+			return new FakeMediaStream();
+		};
+		const h = harness({ recoveryBackoffMs: [0, 0, 0], recoveryResumeTimeoutMs: 50 });
+		await goLive(h);
+		assert.equal(resolvers.length, 1, 'initial snapshot is pending');
+		fireDeviceChange();
+		await delay(2);
+		assert.equal(resolvers.length, 2, 'change snapshot is pending');
+		resolvers[1]([{ kind: 'audioinput', deviceId: 'a' }]);
+		await delay(5);
+		assert.equal(gumCalls, 1, 'no baseline means no blind reacquire');
+		resolvers[0]([{ kind: 'audioinput', deviceId: 'a' }]);
+		await delay(5);
+		assert.equal((h.t as any).inputDeviceSig, 'a', 'initial snapshot still establishes the baseline');
+		h.t.disconnect();
+	});
+
 	it('track ended → reacquire replaces the capture stream', async () => {
 		const streams: FakeMediaStream[] = [];
 		gumImpl = async () => {


### PR DESCRIPTION
## What

The voice-observability + egress-control tranche of the desktop P7 design (ag2-space/ag2space-cinny-desktop#341 — reviewed there through four Codex rounds; this PR is its sutando half, reconciled with main as of `f22898f8`, zero conflicts):

- **Transport (`src/web-voice-transport.ts`)** — epoch-scoped counters (scheduled/ended/**cancelled** split), frame-path capture-gap **self-latch** (survives frozen timers), latched speech/gap interval episodes, delta-encoded **≤300 B** `audio_health` heartbeat (per-connection nonce + epoch-age stamp, ACK-free idempotent 4-episode window), bufferedAmount skip + send try/catch, and a **captureGen-fenced bounded recovery FSM** (resume/reacquire, single-flight, input-filtered devicechange, degraded-not-terminal contract + `retryCapture()`).
- **Engine ledger (`src/voice-audio-health*.ts`)** — session-layer wraps honestly labeled `coverage: 'session-only'`, engine-minted epochs bound to client nonces, canonical ingress-RMS speech tracker, model-**event** clock, upgraded `[Health]` with anomaly-overrides-suppression, **worker_threads** sqlite persistence (one-slot try-enqueue mailbox, per-session row caps, legacy-column migration, crash-durable writes), additive `inputHealth` in `voice-lifecycle.json`.
- **Localization matrix (`src/voice-health-matrix.ts`)** — pure, honest outcomes: partial coverage never yields a server-layer verdict; epoch boundaries/episode overflow/stale heartbeats/no-progress are `insufficient-evidence`; FE fixtures are hypothesis-labeled.
- **Vision egress (`src/vision-tools.ts`, `src/screen-capture-server.py`)** — ONE central gate (`ACTIVE ∧ ¬speechActive`) + token bucket charging wire bytes + latest-frame-only slot + stream-generation stop fence; impossible-to-ship frames are rejected before occupying the slot; capture-server **in-process downscale** (~720p/q0.6, mandatory budget); async selection probe; OffscreenCanvas browser-push compression.
- **Bundled-build fix** — the lazy capture-server spawn resolved its .py next to the running module (`dist/` in bundles, where no .py ships): now repo-root resolution via `findRepoRoot`, non-detached TCC-lineage spawn with pid + logged stderr + fail-fast on early exit; same fix for `telemetry.py`; `[Vision]` timestamps unified to UTC. **Field-verified on a bundled install: 59 frames streamed in 60 s.**
- **D7.3 continuity (`src/voice-continuity.ts`)** — stale-repeat goodbye guard + the centralized conversation-clear/cursor helper.

## Hot-path budget (normative §D7.0b)

Frame paths do O(1) preallocated-field writes + bounded arithmetic only; heartbeat assembly rides the existing 500 ms stats timer; persistence is try-enqueue to a worker. Enforced by tests: A/B frame-handler p99 ≤ 50 µs, zero-added-allocation GC soak, PCM displacement < 1%, locked-DB isolation proof, worst-case vision-frame cost.

## Evidence

- Full TypeScript suite at this head: **1,026 pass / 0 fail** (2 conditional skips).
- Focused post-rebase regressions: **111 pass / 0 fail** (1 GC-soak skip) plus **23/23** capture-server tests.
- `npm run typecheck` clean.
- Review trail: three adversarial Codex CLI rounds on this code (7 + 10 + 10 findings, every one fixed with a regression test) — recorded on ag2-space/ag2space-cinny-desktop#341.
- Live-path proof (bundled desktop install, 2026-08-14): heartbeats/epochs/matrix verdicts flowing in production logs; Watch streamed 59 real frames end-to-end.

## Merge context

The desktop release train (ag2space-cinny-desktop#341) pins this branch and its `cinny-pin-on-main`-equivalent release gate requires this PR to land on main first; the desktop repins to the merged SHA afterward. cinny-webclient's vendored transport copy byte-locks to this branch's `src/web-voice-transport.ts` — its companion PR re-vendors from this head.

## Coordination

Merge #2902 before #2885: #2902 owns the central vision-egress gate; #2885 is limited to the `/vision/frame` ingress body-size bound and must not add a second compression stage or generation counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
