### PR TITLE
fix(discord): stop restarting the progress loop that opted out

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2545,6 +2545,10 @@ _poll_loops_started = False
 # failing loop can't spin, short enough that delivery resumes on its own.
 POLL_LOOP_RESTART_SEC = 5
 
+# Returned by a poll loop that declined to run because its feature is off.
+# Not a failure, so the supervisor must stop rather than restart it forever.
+LOOP_DISABLED = object()
+
 
 async def _supervise_loop(coro_fn, name):
     """Keep a poll loop alive across crashes.
@@ -2564,7 +2568,10 @@ async def _supervise_loop(coro_fn, name):
     """
     while True:
         try:
-            await coro_fn()
+            if await coro_fn() is LOOP_DISABLED:
+                # Opted out on purpose (feature flag off) — supervising it would
+                # re-enter and re-return every POLL_LOOP_RESTART_SEC forever.
+                return
             # A poll loop returning is itself unexpected (they never exit).
             print(f"  [{name}] loop returned unexpectedly — restarting in {POLL_LOOP_RESTART_SEC}s", flush=True)
         except asyncio.CancelledError:
@@ -5009,7 +5016,7 @@ async def poll_progress():
     must never break the loop or leak an exception into the gateway.
     """
     if not progress_stream.stream_enabled():
-        return  # feature off → never loops; zero overhead, zero risk
+        return LOOP_DISABLED  # feature off → never loops; zero overhead, zero risk
     while True:
         try:
             now = time.time()

--- a/tests/discord-progress-loop-disabled-no-restart.test.py
+++ b/tests/discord-progress-loop-disabled-no-restart.test.py
@@ -63,10 +63,15 @@ os.environ["HOME"] = _CFG
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-test-not-real")
 os.environ.setdefault("SLACK_APP_TOKEN", "xapp-test-not-real")
-for _ch in ("discord", "slack"):
-    _p = Path(_CFG) / "channels" / _ch
-    _p.mkdir(parents=True, exist_ok=True)
-    (_p / "access.json").write_text(json.dumps({"allowFrom": []}))
+# Seeded with literal channel names, not a loop variable: the hermetic-bridge lint
+# traces the path-segment chain statically and cannot prove a computed segment.
+_cfg_discord = Path(_CFG) / "channels" / "discord"
+_cfg_discord.mkdir(parents=True, exist_ok=True)
+(_cfg_discord / "access.json").write_text(json.dumps({"allowFrom": []}))
+
+_cfg_slack = Path(_CFG) / "channels" / "slack"
+_cfg_slack.mkdir(parents=True, exist_ok=True)
+(_cfg_slack / "access.json").write_text(json.dumps({"allowFrom": []}))
 
 # The defect only reproduces with the feature OFF, which is the shipped default.
 os.environ["SUTANDO_PROGRESS_STREAM"] = "0"

--- a/tests/discord-progress-loop-disabled-no-restart.test.py
+++ b/tests/discord-progress-loop-disabled-no-restart.test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""BEHAVIOURAL: `_supervise_loop` must not restart a loop that opted out.
+
+`poll_progress` returns immediately when `SUTANDO_PROGRESS_STREAM` is off — its
+docstring promises "never loops; zero overhead, zero risk". But `_supervise_loop`
+treats *any* return as a crash ("a poll loop returning is itself unexpected"), so
+on the DEFAULT configuration it re-entered and re-returned every
+POLL_LOOP_RESTART_SEC forever: ~17k log lines/day and a needless task, on the
+live owner-facing bridge.
+
+Two arms, because the fix must be narrow:
+  - disabled loop  -> supervisor stops, silently.
+  - loop that returns for any OTHER reason -> still restarted (real failures must
+    keep being supervised).
+"""
+from __future__ import annotations
+
+import asyncio
+import atexit
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+try:
+    import discord  # noqa: F401
+except ImportError:
+    _d = types.ModuleType("discord")
+    _d.Intents = type("I", (), {"default": staticmethod(
+        lambda: type("X", (), {"message_content": False})())})
+    _d.Client = type("C", (), {"__init__": lambda self, **k: None,
+                               "event": staticmethod(lambda fn: fn)})
+    _d.File = type("F", (), {})
+    _d.Message = type("M", (), {})
+    _d.DMChannel = type("DM", (), {})
+    sys.modules["discord"] = _d
+
+# The real App() performs a live auth.test at import.
+_sb = types.ModuleType("slack_bolt")
+_sb.App = type("App", (), {"__init__": lambda self, **kw: None,
+                           "event": lambda self, name: (lambda fn: fn),
+                           "client": None})
+sys.modules["slack_bolt"] = _sb
+sys.modules["slack_bolt.adapter"] = types.ModuleType("slack_bolt.adapter")
+_sm = types.ModuleType("slack_bolt.adapter.socket_mode")
+_sm.SocketModeHandler = type("SocketModeHandler", (), {"__init__": lambda self, *a, **k: None})
+sys.modules["slack_bolt.adapter.socket_mode"] = _sm
+
+_CFG = tempfile.mkdtemp(prefix="ccd-progress-supervise-")
+atexit.register(lambda: shutil.rmtree(_CFG, ignore_errors=True))
+os.environ["CLAUDE_CONFIG_DIR"] = _CFG
+os.environ["HOME"] = _CFG
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
+os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-test-not-real")
+os.environ.setdefault("SLACK_APP_TOKEN", "xapp-test-not-real")
+for _ch in ("discord", "slack"):
+    _p = Path(_CFG) / "channels" / _ch
+    _p.mkdir(parents=True, exist_ok=True)
+    (_p / "access.json").write_text(json.dumps({"allowFrom": []}))
+
+# The defect only reproduces with the feature OFF, which is the shipped default.
+os.environ["SUTANDO_PROGRESS_STREAM"] = "0"
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, REPO / "src" / filename)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _SleptTwice(Exception):
+    """Escape hatch: proves the supervisor entered its restart cycle."""
+
+
+class ProgressLoopDisabledTest(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load("discord_bridge_supervise", "discord-bridge.py")
+        self.sleeps = 0
+
+        async def _counting_sleep(_secs):
+            self.sleeps += 1
+            # One restart is already the bug; a second guarantees we never hang.
+            if self.sleeps >= 2:
+                raise _SleptTwice
+        self._orig_sleep = self.mod.asyncio.sleep
+        self.mod.asyncio.sleep = _counting_sleep
+
+    def tearDown(self):
+        self.mod.asyncio.sleep = self._orig_sleep
+
+    def _run(self, coro_fn, name):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with contextlib.suppress(_SleptTwice):
+                asyncio.run(self.mod._supervise_loop(coro_fn, name))
+        return buf.getvalue()
+
+    def test_disabled_progress_loop_is_not_restarted(self):
+        """The shipped default must not spin the supervisor."""
+        self.assertFalse(
+            self.mod.progress_stream.stream_enabled(),
+            "precondition: the flag must be off for this defect to reproduce")
+
+        out = self._run(self.mod.poll_progress, "poll_progress")
+
+        self.assertEqual(
+            self.sleeps, 0,
+            f"supervisor restarted a deliberately-disabled loop {self.sleeps}x")
+        self.assertNotIn("returned unexpectedly", out)
+
+    def test_other_returns_are_still_supervised(self):
+        """Control: the fix must not stop supervising genuine early returns."""
+        async def _returns_none():
+            return None
+
+        out = self._run(_returns_none, "poll_other")
+
+        self.assertGreater(self.sleeps, 0, "a real early return must be restarted")
+        self.assertIn("returned unexpectedly", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`poll_progress` returns immediately when `SUTANDO_PROGRESS_STREAM` is off — which is **the shipped default**. Its docstring promises exactly that:

> Fully self-contained and side-effect-free when the flag is off: the loop returns immediately, touching nothing.

But `_supervise_loop` treats *any* return as a crash:

```python
await coro_fn()
# A poll loop returning is itself unexpected (they never exit).
print(f"  [{name}] loop returned unexpectedly — restarting in {POLL_LOOP_RESTART_SEC}s", flush=True)
```

So on the default configuration the supervisor re-enters and re-returns every 5s, forever. The one loop that is *documented* to return is the one the supervisor punishes.

## Evidence it is live, not theoretical

Measured on a running core (`SUTANDO_PROGRESS_STREAM` absent from the bridge process env, so the flag resolves to its default):

```
$ grep -c "poll_progress.*returned unexpectedly" workspace/logs/discord-bridge.log
184     # bridge up ~15 min
261     # same log, ~9 min later
```

~17k log lines/day and a permanently respawning task, on the owner-facing bridge, out of the box.

## Before / after

Same test file, unchanged, against both sources:

```
########## BEFORE (origin/main source) ##########
test_disabled_progress_loop_is_not_restarted ... FAIL
test_other_returns_are_still_supervised ... ok

AssertionError: 2 != 0 : supervisor restarted a deliberately-disabled loop 2x

Ran 2 tests in 0.057s
FAILED (failures=1)

########## AFTER (this branch) ##########
test_disabled_progress_loop_is_not_restarted ... ok
test_other_returns_are_still_supervised ... ok

Ran 2 tests in 0.106s
OK
```

The control arm passes in **both** — so the gate discriminates rather than just being red.

## The fix

A `LOOP_DISABLED` sentinel, so a loop can say "I declined to run" rather than "I fell over". Any other early return is still restarted; that is the control arm above, and it is the reason the change is narrow rather than "stop supervising returns".

## Scope — checked, not assumed

Discord-only. Telegram's `poll_progress` (`src/telegram-bridge.py:603`) is a **synchronous per-tick call** with no supervisor, so its early return is harmless; Slack has no progress loop at all. There is no duplicated policy to extract into `src/`, so this is not an instance of the shared-policy rule in CLAUDE.md.

## Behaviour change worth naming

Today, with the flag off, the loop re-checks `stream_enabled()` every 5s, so flipping the flag **on** at runtime would start streaming within 5s. After this change the supervisor exits, so enabling it needs a bridge restart.

I judged that worth losing: it was never a documented capability, it is the direct cause of the spin, and the reverse direction (on -> off at runtime) already does not work — once the flag is on at boot the loop enters `while True` and never re-checks. Happy to keep the task alive on a long sleep instead if you would rather preserve live-enable.

## Regression runs

```
bridge-dedup-poll-loop                        OK
progress-stream                               OK
proactive-progress-flag-bound-before-try      OK
telegram-bridge-progress-stream               OK
discord-bridge-progress-placeholder-ingest    SKIP — discord.py not importable (pre-existing)
```

`scripts/review-checks.sh` on the staged diff: `PASS (hardcoded-paths + root-artifacts clean)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vgb1qDtz7gmqJ5BgypwiZ