### PR TITLE
feat(health-check): a held task-handler claim is invisible until it floods on restart

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5746,11 +5746,33 @@ def check_task_watcher() -> dict:
     return {"name": name, "status": "ok", "detail": f"streaming watcher alive (pid {pid})"}
 
 
-#: A task-handler claim covers ONE handler run. `codex-bounded.sh` caps a run at
-#: 240s, so a claim outliving these is held, not working. Generous on purpose:
-#: 30x the cap before warn, 120x before down.
-_TASK_CLAIM_WARN_S = 1800.0
-_TASK_CLAIM_DOWN_S = 7200.0
+#: A claim covers ONE handler run, so the thresholds must track the handler's OWN
+#: configured bound. `session-worker.py` reads `SUTANDO_TIER_HARD_TIMEOUT`
+#: (default 900s) and is explicitly configurable, so a deployment that raises it
+#: has legitimately longer in-flight claims. Anchoring on a constant instead
+#: pages on live work the moment the timeout is raised.
+_TASK_CLAIM_HARD_TIMEOUT_DEFAULT_S = 900.0
+_TASK_CLAIM_WARN_MULTIPLE = 2
+_TASK_CLAIM_DOWN_MULTIPLE = 8
+
+
+def _task_claim_thresholds() -> tuple[float, float]:
+    """(warn, down) seconds, derived from the handler's configured hard timeout.
+
+    Falls back to the handler's own default on anything unparseable or
+    non-positive — `session-worker.py` rejects those too, so a bad value means
+    the handler is not running with it either and the default is the honest
+    assumption. Never returns a threshold that could page on a run still inside
+    its permitted bound.
+    """
+    raw = os.environ.get("SUTANDO_TIER_HARD_TIMEOUT", "")
+    try:
+        hard = float(raw)
+    except (TypeError, ValueError):
+        hard = _TASK_CLAIM_HARD_TIMEOUT_DEFAULT_S
+    if hard <= 0:
+        hard = _TASK_CLAIM_HARD_TIMEOUT_DEFAULT_S
+    return hard * _TASK_CLAIM_WARN_MULTIPLE, hard * _TASK_CLAIM_DOWN_MULTIPLE
 
 
 def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
@@ -5788,6 +5810,7 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
         return {"name": name, "status": "ok",
                 "detail": "no claims directory — task-event handler never dispatched on this host"}
     now = time.time()
+    warn_s, down_s = _task_claim_thresholds()
     held = []
     for entry in base.glob("task-*.txt"):
         try:
@@ -5798,14 +5821,15 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
         return {"name": name, "status": "ok", "detail": "no held task-handler claims"}
     held.sort(reverse=True)
     oldest_age, oldest_name = held[0]
-    detail = f"{len(held)} held claim(s), oldest {oldest_age / 3600:.1f}h ({oldest_name})"
-    if oldest_age > _TASK_CLAIM_DOWN_S:
+    detail = (f"{len(held)} held claim(s), oldest {oldest_age / 3600:.1f}h ({oldest_name}); "
+              f"handler bound {warn_s / _TASK_CLAIM_WARN_MULTIPLE / 60:.0f}m")
+    if oldest_age > down_s:
         return {"name": name, "status": "down",
                 "detail": f"{detail} — leaked; each will publish a user-visible "
                           "failure when the watcher next exits"}
-    if oldest_age > _TASK_CLAIM_WARN_S:
+    if oldest_age > warn_s:
         return {"name": name, "status": "warn",
-                "detail": f"{detail} — longer than any bounded handler run"}
+                "detail": f"{detail} — past {_TASK_CLAIM_WARN_MULTIPLE}x the handler's own bound"}
     return {"name": name, "status": "ok", "detail": detail}
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5754,10 +5754,6 @@ def check_task_watcher() -> dict:
 _TASK_CLAIM_HARD_TIMEOUT_DEFAULT_S = 900.0
 _TASK_CLAIM_WARN_MULTIPLE = 2
 _TASK_CLAIM_DOWN_MULTIPLE = 8
-# The live core drains tasks serially: >1 concurrent unbounded holder is
-# already odd, and a handful is the shape of the 34-claim leak.
-_TASK_CLAIM_CONCURRENT_WARN = 3
-_TASK_CLAIM_CONCURRENT_DOWN = 6
 
 
 def _task_claim_thresholds() -> tuple[float, float]:
@@ -5793,28 +5789,29 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _claim_owner(path: Path):
-    """(owner_pid, disposition) from a claim file, either may be None.
+    """(owner_pid, disposition, task_path) from a claim file; any may be None.
 
     Format is the shell writer's: pid, watcher id, task path, disposition.
     """
     try:
         lines = path.read_text(errors="replace").splitlines()
     except OSError:
-        return None, None
+        return None, None, None
     pid = None
     if lines and lines[0].strip().isdigit():
         pid = int(lines[0].strip())
+    task_path = lines[2].strip() if len(lines) > 2 else None
     disposition = lines[3].strip() if len(lines) > 3 else None
-    return pid, disposition
+    return pid, disposition, task_path
 
 
 def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
     """Held-but-unsettled task-handler claims — a leak no other probe can see.
 
-    Classified by the claim's own execution contract, not by age alone:
-    `must-handle` is bounded by SUTANDO_TIER_HARD_TIMEOUT; `fallback` runs on
-    the live core and has no deadline, so only a dead owner or many concurrent
-    holders condemn it. Not a --fix: releasing a claim may drop a running task.
+    The task file is the progress signal: while it exists the work is queued or
+    running, so neither count nor age can condemn the claim. A claim whose task
+    is already archived is leaked at any age. Not a --fix: releasing a claim may
+    drop a running task.
     """
     name = "task-claims"
     base = Path(workspace_dir or WORKSPACE_DIR) / "state" / "task-event-handler-claims"
@@ -5823,51 +5820,40 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
                 "detail": "no claims directory — task-event handler never dispatched on this host"}
     now = time.time()
     warn_s, down_s = _task_claim_thresholds()
-    bounded, unbounded, live_unbounded, held = [], [], [], 0
+    bounded, leaked, in_flight, held = [], [], 0, 0
     for entry in base.glob("task-*.txt"):
         try:
             age = now - entry.stat().st_mtime
         except OSError:
             continue          # raced with a release; the next run sees the truth
         held += 1
-        pid, disposition = _claim_owner(entry)
-        if disposition == "must-handle":
+        pid, disposition, task_path = _claim_owner(entry)
+        # The task file is the progress signal. While it exists the work is
+        # queued or running -- with 2 handler workers a burst legitimately holds
+        # several claims -- so neither count nor age can condemn it.
+        task_live = bool(task_path) and Path(task_path).exists()
+        if not task_live:
+            # The task was archived, so the work finished and nothing released
+            # the claim. That is the leak, at any age and any count.
+            leaked.append((age, entry.name, "task already archived"))
+        elif pid is not None and not _pid_alive(pid):
+            leaked.append((age, entry.name, "owner process gone"))
+        elif disposition == "must-handle":
             bounded.append((age, entry.name))
         else:
-            # No deadline to exceed, so age is not evidence; only an owner
-            # that can no longer release it is.
-            if pid is not None and not _pid_alive(pid):
-                unbounded.append((age, entry.name))
-            else:
-                live_unbounded.append((age, entry.name))
+            in_flight += 1
+
     if not held:
         return {"name": name, "status": "ok", "detail": "no held task-handler claims"}
 
-    if unbounded:
-        unbounded.sort(reverse=True)
-        age, who = unbounded[0]
+    if leaked:
+        leaked.sort(reverse=True)
+        age, who, why = leaked[0]
         return {"name": name, "status": "down",
-                "detail": f"{len(unbounded)} of {held} held claim(s) are orphaned — "
-                          f"owner process gone, oldest {age / 3600:.1f}h ({who}); "
-                          "nothing will release them, and each publishes a "
-                          "user-visible failure when the watcher next exits"}
-    # Age cannot condemn a live unbounded claim, but concurrency can: the core
-    # drains serially, and the founding leak was 34 held at once under a healthy watcher.
-    if len(live_unbounded) >= _TASK_CLAIM_CONCURRENT_DOWN:
-        live_unbounded.sort(reverse=True)
-        age, who = live_unbounded[0]
-        return {"name": name, "status": "down",
-                "detail": f"{len(live_unbounded)} unbounded claim(s) held at once "
-                          f"(oldest {age / 3600:.1f}h, {who}) — the live core drains "
-                          "serially, so this many concurrent holders is a leak, not "
-                          "a long session"}
-    if len(live_unbounded) >= _TASK_CLAIM_CONCURRENT_WARN:
-        live_unbounded.sort(reverse=True)
-        age, who = live_unbounded[0]
-        return {"name": name, "status": "warn",
-                "detail": f"{len(live_unbounded)} unbounded claim(s) held at once "
-                          f"(oldest {age / 3600:.1f}h, {who}) — more than one live "
-                          "session should hold"}
+                "detail": f"{len(leaked)} of {held} held claim(s) leaked — {why}, "
+                          f"oldest {age / 3600:.1f}h ({who}); nothing will release "
+                          "them, and each publishes a user-visible failure when the "
+                          "watcher next exits"}
     if bounded:
         bounded.sort(reverse=True)
         age, who = bounded[0]
@@ -5880,7 +5866,8 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
             return {"name": name, "status": "warn",
                     "detail": f"{detail} — past {_TASK_CLAIM_WARN_MULTIPLE}x the handler's own bound"}
     return {"name": name, "status": "ok",
-            "detail": f"{held} held claim(s), none past its own execution contract"}
+            "detail": f"{held} held claim(s), {in_flight} still queued or running; "
+                      "none leaked and none past its own execution contract"}
 
 
 def fix_task_watcher_sentinel(check: dict) -> str:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5810,52 +5810,88 @@ def _claim_owner(path: Path):
 _TASK_CLAIM_ARCHIVE_GRACE_S = 300
 
 
-def _claim_observations_path(workspace_dir: Path) -> Path:
-    """Under the git dir on purpose: `state/` is carryable by a supported
-    vault.sync include, but nothing under the git dir is ever tracked (#2476)."""
+def _claim_observations_path(workspace_dir: Path) -> Optional[Path]:
+    """Unsynced store for first-sightings, or None when none exists.
+
+    Anchored on the ENGINE checkout (this file's repo), never the workspace: a
+    deployed layout can keep the workspace beside the checkout, and `state/` is
+    carryable, so a workspace-relative store is refreshable by the same sync
+    that refreshes claim mtime.
+    """
+    engine = Path(__file__).resolve().parent.parent
     try:
-        out = subprocess.run(["git", "rev-parse", "--git-dir"], cwd=str(workspace_dir),
+        # rev-parse, not `engine/".git"`: in a WORKTREE .git is a file.
+        out = subprocess.run(["git", "rev-parse", "--git-dir"], cwd=str(engine),
                              capture_output=True, text=True, timeout=5)
-        if out.returncode == 0 and out.stdout.strip():
-            git_dir = (workspace_dir / out.stdout.strip()).resolve()
-            return git_dir / "sutando-claim-observations.json"
+        if out.returncode != 0 or not out.stdout.strip():
+            return None
+        git_dir = (engine / out.stdout.strip()).resolve()
     except Exception:
-        pass
-    # No git dir (a bare workspace): fall back beside the claims, and say so by
-    # name so a reader knows this copy is only as durable as state/ itself.
-    return workspace_dir / "state" / ".claim-observations-local.json"
+        return None
+    if not git_dir.is_dir():
+        return None
+    # Keyed by workspace identity so two workspaces on one host cannot share
+    # (and cross-contaminate) a ledger.
+    key = hashlib.sha1(str(Path(workspace_dir).resolve()).encode()).hexdigest()[:12]
+    return git_dir / "sutando-claim-observations" / f"{key}.json"
 
 
-def _claim_ages(entries: list, workspace_dir: Path, now: float) -> dict:
-    """{name: seconds since THIS host first observed the claim}. mtime is
-    sync-mutable, so a refresh must not push a stale claim under its threshold."""
+def _claim_ages(entries: list, workspace_dir: Path, now: float) -> tuple:
+    """({name: seconds since first local sighting}, trusted).
+
+    `trusted` is False when no structurally-unsynced store exists -- the caller
+    must then treat age as unavailable rather than trust a syncable mtime.
+    """
     path = _claim_observations_path(workspace_dir)
-    try:
-        seen = json.loads(path.read_text())
-        if not isinstance(seen, dict):
-            seen = {}
-    except Exception:
-        seen = {}          # unreadable/corrupt -> re-observe, never crash the probe
-    live = {e.name for e in entries}
-    seen = {k: v for k, v in seen.items() if k in live and isinstance(v, (int, float))}
-    ages = {}
-    for e in entries:
-        first = seen.get(e.name)
-        if first is None:
-            # First sighting: seed from mtime, the only evidence there is, but
-            # record it so a later sync refresh cannot move it.
-            try:
-                first = e.stat().st_mtime
-            except OSError:
-                continue      # raced with a release; no age, caller skips it
-            seen[e.name] = first
-        ages[e.name] = max(0.0, now - first)
+    if path is None:
+        return {}, False
+    lock = path.with_suffix(".lock")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(seen))
     except Exception:
-        pass               # read-only fs: degrade to per-run observation
-    return ages
+        return {}, False
+    fd = None
+    try:
+        fd = os.open(str(lock), os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            seen = json.loads(path.read_text())
+            if not isinstance(seen, dict):
+                seen = {}
+        except FileNotFoundError:
+            seen = {}
+        except Exception:
+            # Corrupt: a reset would reseed every claim from sync-mutable mtime
+            # and suppress exactly what this exists to catch.
+            return {}, False
+        live = {e.name for e in entries}
+        seen = {k: v for k, v in seen.items() if k in live and isinstance(v, (int, float))}
+        ages = {}
+        for e in entries:
+            first = seen.get(e.name)
+            if first is None:
+                try:
+                    first = e.stat().st_mtime
+                except OSError:
+                    continue
+                seen[e.name] = first
+            ages[e.name] = max(0.0, now - first)
+        tmp = path.with_suffix(".tmp")
+        with open(tmp, "w") as fh:
+            json.dump(seen, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+        return ages, True
+    except Exception:
+        return {}, False
+    finally:
+        if fd is not None:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+            except Exception:
+                pass
 
 
 def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
@@ -5876,7 +5912,14 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
     bounded, leaked, in_flight, held = [], [], 0, 0
     entries = list(base.glob("task-*.txt"))
     # Ages come from a LOCAL first-sighting, not mtime: mtime is sync-mutable.
-    ages = _claim_ages(entries, Path(workspace_dir or WORKSPACE_DIR), now)
+    ages, age_trusted = _claim_ages(entries, Path(workspace_dir or WORKSPACE_DIR), now)
+    if entries and not age_trusted:
+        # No structurally-unsynced store: mtime is the only signal and it is
+        # refreshable, so report the gap rather than a number we cannot trust.
+        return {"name": name, "status": "warn",
+                "detail": f"{len(entries)} held claim(s); claim AGE is unavailable "
+                          "(no unsynced observation store), so a stale claim cannot "
+                          "be distinguished from a fresh one"}
     for entry in entries:
         age = ages.get(entry.name)
         if age is None:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5746,6 +5746,69 @@ def check_task_watcher() -> dict:
     return {"name": name, "status": "ok", "detail": f"streaming watcher alive (pid {pid})"}
 
 
+#: A task-handler claim covers ONE handler run. `codex-bounded.sh` caps a run at
+#: 240s, so a claim outliving these is held, not working. Generous on purpose:
+#: 30x the cap before warn, 120x before down.
+_TASK_CLAIM_WARN_S = 1800.0
+_TASK_CLAIM_DOWN_S = 7200.0
+
+
+def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
+    """Held-but-unsettled task-handler claims — the leak nothing else can see.
+
+    `watch-tasks-stream.sh` takes a claim in `state/task-event-handler-claims/`
+    before dispatching a task to `$SUTANDO_TASK_EVENT_HANDLER`, and releases it
+    on completion. A claim that is never released is invisible: no error path
+    runs, so nothing is logged, and every other probe here reads healthy. The
+    task queue drains, the watcher is alive, results are delivered.
+
+    It stays invisible until the watcher EXITS, because `fallback_outstanding_
+    handlers()` settles each still-held claim by publishing a terminal failure —
+    one user-visible message per claim. So the first and only symptom of a slow
+    leak is a flood at restart, sized by however long the leak ran.
+
+    Measured 2026-08-14: 34 claims accumulated over 21h of task arrivals, oldest
+    31.2h, and drained as 34 Discord messages in two seconds when the watcher was
+    restarted. The retired watcher's whole captured stderr was 228 lines — 194
+    task events plus those 34 shutdown lines, and NOTHING else. Zero handler
+    failures. Nothing in the system could have reported the leak while it grew.
+
+    Age comes from mtime, not a payload: the claim file's format is owned by the
+    shell writer, and a probe that parsed it would break when that changed. mtime
+    is safe here for the reason it is NOT safe for `state/cores/*.alive` — claims
+    are local-only and never synced, so no remote write can refresh one.
+
+    Deliberately NOT a `--fix`: deleting a held claim would drop a task that may
+    still be running, and publishing its failure early is the watcher's call, not
+    a health probe's.
+    """
+    name = "task-claims"
+    base = Path(workspace_dir or WORKSPACE_DIR) / "state" / "task-event-handler-claims"
+    if not base.is_dir():
+        return {"name": name, "status": "ok",
+                "detail": "no claims directory — task-event handler never dispatched on this host"}
+    now = time.time()
+    held = []
+    for entry in base.glob("task-*.txt"):
+        try:
+            held.append((now - entry.stat().st_mtime, entry.name))
+        except OSError:
+            continue          # raced with a release; the next run sees the truth
+    if not held:
+        return {"name": name, "status": "ok", "detail": "no held task-handler claims"}
+    held.sort(reverse=True)
+    oldest_age, oldest_name = held[0]
+    detail = f"{len(held)} held claim(s), oldest {oldest_age / 3600:.1f}h ({oldest_name})"
+    if oldest_age > _TASK_CLAIM_DOWN_S:
+        return {"name": name, "status": "down",
+                "detail": f"{detail} — leaked; each will publish a user-visible "
+                          "failure when the watcher next exits"}
+    if oldest_age > _TASK_CLAIM_WARN_S:
+        return {"name": name, "status": "warn",
+                "detail": f"{detail} — longer than any bounded handler run"}
+    return {"name": name, "status": "ok", "detail": detail}
+
+
 def fix_task_watcher_sentinel(check: dict) -> str:
     """Re-stamp the PID sentinel for a supervised watcher that lost it (--fix).
 
@@ -7840,6 +7903,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_proactive_quarantine())
     checks.append(check_stale_proactive_backlog())
     checks.append(check_task_watcher())
+    checks.append(check_task_claim_age())
     checks.append(check_codex_task_notifier())
     checks.append(check_skill_symlinks())
     checks.append(check_core_model_pin())

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5810,6 +5810,54 @@ def _claim_owner(path: Path):
 _TASK_CLAIM_ARCHIVE_GRACE_S = 300
 
 
+def _claim_observations_path(workspace_dir: Path) -> Path:
+    """Under the git dir on purpose: `state/` is carryable by a supported
+    vault.sync include, but nothing under the git dir is ever tracked (#2476)."""
+    try:
+        out = subprocess.run(["git", "rev-parse", "--git-dir"], cwd=str(workspace_dir),
+                             capture_output=True, text=True, timeout=5)
+        if out.returncode == 0 and out.stdout.strip():
+            git_dir = (workspace_dir / out.stdout.strip()).resolve()
+            return git_dir / "sutando-claim-observations.json"
+    except Exception:
+        pass
+    # No git dir (a bare workspace): fall back beside the claims, and say so by
+    # name so a reader knows this copy is only as durable as state/ itself.
+    return workspace_dir / "state" / ".claim-observations-local.json"
+
+
+def _claim_ages(entries: list, workspace_dir: Path, now: float) -> dict:
+    """{name: seconds since THIS host first observed the claim}. mtime is
+    sync-mutable, so a refresh must not push a stale claim under its threshold."""
+    path = _claim_observations_path(workspace_dir)
+    try:
+        seen = json.loads(path.read_text())
+        if not isinstance(seen, dict):
+            seen = {}
+    except Exception:
+        seen = {}          # unreadable/corrupt -> re-observe, never crash the probe
+    live = {e.name for e in entries}
+    seen = {k: v for k, v in seen.items() if k in live and isinstance(v, (int, float))}
+    ages = {}
+    for e in entries:
+        first = seen.get(e.name)
+        if first is None:
+            # First sighting: seed from mtime, the only evidence there is, but
+            # record it so a later sync refresh cannot move it.
+            try:
+                first = e.stat().st_mtime
+            except OSError:
+                continue      # raced with a release; no age, caller skips it
+            seen[e.name] = first
+        ages[e.name] = max(0.0, now - first)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(seen))
+    except Exception:
+        pass               # read-only fs: degrade to per-run observation
+    return ages
+
+
 def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
     """Held-but-unsettled task-handler claims — a leak no other probe can see.
 
@@ -5826,10 +5874,12 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
     now = time.time()
     warn_s, down_s = _task_claim_thresholds()
     bounded, leaked, in_flight, held = [], [], 0, 0
-    for entry in base.glob("task-*.txt"):
-        try:
-            age = now - entry.stat().st_mtime
-        except OSError:
+    entries = list(base.glob("task-*.txt"))
+    # Ages come from a LOCAL first-sighting, not mtime: mtime is sync-mutable.
+    ages = _claim_ages(entries, Path(workspace_dir or WORKSPACE_DIR), now)
+    for entry in entries:
+        age = ages.get(entry.name)
+        if age is None:
             continue          # raced with a release; the next run sees the truth
         held += 1
         pid, disposition, task_path = _claim_owner(entry)

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5746,11 +5746,8 @@ def check_task_watcher() -> dict:
     return {"name": name, "status": "ok", "detail": f"streaming watcher alive (pid {pid})"}
 
 
-#: A claim covers ONE handler run, so the thresholds must track the handler's OWN
-#: configured bound. `session-worker.py` reads `SUTANDO_TIER_HARD_TIMEOUT`
-#: (default 900s) and is explicitly configurable, so a deployment that raises it
-#: has legitimately longer in-flight claims. Anchoring on a constant instead
-#: pages on live work the moment the timeout is raised.
+#: Track session-worker.py's own SUTANDO_TIER_HARD_TIMEOUT (default 900s,
+#: configurable): a constant pages on live work the moment a deploy raises it.
 _TASK_CLAIM_HARD_TIMEOUT_DEFAULT_S = 900.0
 _TASK_CLAIM_WARN_MULTIPLE = 2
 _TASK_CLAIM_DOWN_MULTIPLE = 8
@@ -5911,9 +5908,8 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
     warn_s, down_s = _task_claim_thresholds()
     bounded, leaked, in_flight, held = [], [], 0, 0
     entries = list(base.glob("task-*.txt"))
-    # Ages come from a LOCAL first-sighting, not mtime: mtime is sync-mutable.
-    # An untrusted ledger degrades only the AGE-DEPENDENT decisions. A dead owner
-    # is knowable without any age, so keep scanning rather than returning here.
+    # Ages come from a LOCAL first-sighting; mtime is sync-mutable. An untrusted
+    # ledger degrades only the AGE-DEPENDENT decisions, so keep scanning.
     ages, age_trusted = _claim_ages(entries, Path(workspace_dir or WORKSPACE_DIR), now)
     age_unknown = 0
     for entry in entries:
@@ -5922,19 +5918,16 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
             continue          # raced with a release; the next run sees the truth
         held += 1
         pid, disposition, task_path = _claim_owner(entry)
-        # The task file is the progress signal. While it exists the work is
-        # queued or running -- with 2 handler workers a burst legitimately holds
-        # several claims -- so neither count nor age can condemn it.
+        # The task file is the progress signal: while it exists the work is queued
+        # or running, and 2 workers legitimately hold several claims in a burst.
         task_live = bool(task_path) and Path(task_path).exists()
         # Age-INDEPENDENT and definitive, so it is checked FIRST: nothing can
         # release a claim whose owner is gone, whatever the ledger says.
         if pid is not None and not _pid_alive(pid):
             leaked.append((age or 0.0, entry.name, "owner process gone"))
         elif not task_live:
-            # Archival and claim release are ASYNCHRONOUS: the handler can
-            # publish, the bridge archive the task, and finish_handler_task
-            # still be processing HANDLER_DONE. Only past that window is an
-            # absent task evidence that nothing will release the claim.
+            # Archival and claim release are ASYNCHRONOUS; only past that window
+            # is an absent task evidence that nothing will release the claim.
             if age is None:
                 age_unknown += 1          # grace needs an age we do not have
             elif age >= _TASK_CLAIM_ARCHIVE_GRACE_S:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5754,6 +5754,10 @@ def check_task_watcher() -> dict:
 _TASK_CLAIM_HARD_TIMEOUT_DEFAULT_S = 900.0
 _TASK_CLAIM_WARN_MULTIPLE = 2
 _TASK_CLAIM_DOWN_MULTIPLE = 8
+# The live core drains tasks serially: >1 concurrent unbounded holder is
+# already odd, and a handful is the shape of the 34-claim leak.
+_TASK_CLAIM_CONCURRENT_WARN = 3
+_TASK_CLAIM_CONCURRENT_DOWN = 6
 
 
 def _task_claim_thresholds() -> tuple[float, float]:
@@ -5775,34 +5779,42 @@ def _task_claim_thresholds() -> tuple[float, float]:
     return hard * _TASK_CLAIM_WARN_MULTIPLE, hard * _TASK_CLAIM_DOWN_MULTIPLE
 
 
+def _pid_alive(pid: int) -> bool:
+    """Signal 0 probes existence without delivering anything."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True           # exists, owned by someone else
+    except (OverflowError, ValueError, OSError):
+        return False
+    return True
+
+
+def _claim_owner(path: Path):
+    """(owner_pid, disposition) from a claim file, either may be None.
+
+    Format is the shell writer's: pid, watcher id, task path, disposition.
+    """
+    try:
+        lines = path.read_text(errors="replace").splitlines()
+    except OSError:
+        return None, None
+    pid = None
+    if lines and lines[0].strip().isdigit():
+        pid = int(lines[0].strip())
+    disposition = lines[3].strip() if len(lines) > 3 else None
+    return pid, disposition
+
+
 def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
-    """Held-but-unsettled task-handler claims — the leak nothing else can see.
+    """Held-but-unsettled task-handler claims — a leak no other probe can see.
 
-    `watch-tasks-stream.sh` takes a claim in `state/task-event-handler-claims/`
-    before dispatching a task to `$SUTANDO_TASK_EVENT_HANDLER`, and releases it
-    on completion. A claim that is never released is invisible: no error path
-    runs, so nothing is logged, and every other probe here reads healthy. The
-    task queue drains, the watcher is alive, results are delivered.
-
-    It stays invisible until the watcher EXITS, because `fallback_outstanding_
-    handlers()` settles each still-held claim by publishing a terminal failure —
-    one user-visible message per claim. So the first and only symptom of a slow
-    leak is a flood at restart, sized by however long the leak ran.
-
-    Measured 2026-08-14: 34 claims accumulated over 21h of task arrivals, oldest
-    31.2h, and drained as 34 Discord messages in two seconds when the watcher was
-    restarted. The retired watcher's whole captured stderr was 228 lines — 194
-    task events plus those 34 shutdown lines, and NOTHING else. Zero handler
-    failures. Nothing in the system could have reported the leak while it grew.
-
-    Age comes from mtime, not a payload: the claim file's format is owned by the
-    shell writer, and a probe that parsed it would break when that changed. mtime
-    is safe here for the reason it is NOT safe for `state/cores/*.alive` — claims
-    are local-only and never synced, so no remote write can refresh one.
-
-    Deliberately NOT a `--fix`: deleting a held claim would drop a task that may
-    still be running, and publishing its failure early is the watcher's call, not
-    a health probe's.
+    Classified by the claim's own execution contract, not by age alone:
+    `must-handle` is bounded by SUTANDO_TIER_HARD_TIMEOUT; `fallback` runs on
+    the live core and has no deadline, so only a dead owner or many concurrent
+    holders condemn it. Not a --fix: releasing a claim may drop a running task.
     """
     name = "task-claims"
     base = Path(workspace_dir or WORKSPACE_DIR) / "state" / "task-event-handler-claims"
@@ -5811,26 +5823,64 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
                 "detail": "no claims directory — task-event handler never dispatched on this host"}
     now = time.time()
     warn_s, down_s = _task_claim_thresholds()
-    held = []
+    bounded, unbounded, live_unbounded, held = [], [], [], 0
     for entry in base.glob("task-*.txt"):
         try:
-            held.append((now - entry.stat().st_mtime, entry.name))
+            age = now - entry.stat().st_mtime
         except OSError:
             continue          # raced with a release; the next run sees the truth
+        held += 1
+        pid, disposition = _claim_owner(entry)
+        if disposition == "must-handle":
+            bounded.append((age, entry.name))
+        else:
+            # No deadline to exceed, so age is not evidence; only an owner
+            # that can no longer release it is.
+            if pid is not None and not _pid_alive(pid):
+                unbounded.append((age, entry.name))
+            else:
+                live_unbounded.append((age, entry.name))
     if not held:
         return {"name": name, "status": "ok", "detail": "no held task-handler claims"}
-    held.sort(reverse=True)
-    oldest_age, oldest_name = held[0]
-    detail = (f"{len(held)} held claim(s), oldest {oldest_age / 3600:.1f}h ({oldest_name}); "
-              f"handler bound {warn_s / _TASK_CLAIM_WARN_MULTIPLE / 60:.0f}m")
-    if oldest_age > down_s:
+
+    if unbounded:
+        unbounded.sort(reverse=True)
+        age, who = unbounded[0]
         return {"name": name, "status": "down",
-                "detail": f"{detail} — leaked; each will publish a user-visible "
-                          "failure when the watcher next exits"}
-    if oldest_age > warn_s:
+                "detail": f"{len(unbounded)} of {held} held claim(s) are orphaned — "
+                          f"owner process gone, oldest {age / 3600:.1f}h ({who}); "
+                          "nothing will release them, and each publishes a "
+                          "user-visible failure when the watcher next exits"}
+    # Age cannot condemn a live unbounded claim, but concurrency can: the core
+    # drains serially, and the founding leak was 34 held at once under a healthy watcher.
+    if len(live_unbounded) >= _TASK_CLAIM_CONCURRENT_DOWN:
+        live_unbounded.sort(reverse=True)
+        age, who = live_unbounded[0]
+        return {"name": name, "status": "down",
+                "detail": f"{len(live_unbounded)} unbounded claim(s) held at once "
+                          f"(oldest {age / 3600:.1f}h, {who}) — the live core drains "
+                          "serially, so this many concurrent holders is a leak, not "
+                          "a long session"}
+    if len(live_unbounded) >= _TASK_CLAIM_CONCURRENT_WARN:
+        live_unbounded.sort(reverse=True)
+        age, who = live_unbounded[0]
         return {"name": name, "status": "warn",
-                "detail": f"{detail} — past {_TASK_CLAIM_WARN_MULTIPLE}x the handler's own bound"}
-    return {"name": name, "status": "ok", "detail": detail}
+                "detail": f"{len(live_unbounded)} unbounded claim(s) held at once "
+                          f"(oldest {age / 3600:.1f}h, {who}) — more than one live "
+                          "session should hold"}
+    if bounded:
+        bounded.sort(reverse=True)
+        age, who = bounded[0]
+        detail = (f"{held} held claim(s); oldest bounded {age / 3600:.1f}h ({who}); "
+                  f"handler bound {warn_s / _TASK_CLAIM_WARN_MULTIPLE / 60:.0f}m")
+        if age > down_s:
+            return {"name": name, "status": "down",
+                    "detail": f"{detail} — past its own hard timeout; leaked"}
+        if age > warn_s:
+            return {"name": name, "status": "warn",
+                    "detail": f"{detail} — past {_TASK_CLAIM_WARN_MULTIPLE}x the handler's own bound"}
+    return {"name": name, "status": "ok",
+            "detail": f"{held} held claim(s), none past its own execution contract"}
 
 
 def fix_task_watcher_sentinel(check: dict) -> str:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5754,14 +5754,8 @@ _TASK_CLAIM_DOWN_MULTIPLE = 8
 
 
 def _task_claim_thresholds() -> tuple[float, float]:
-    """(warn, down) seconds, derived from the handler's configured hard timeout.
-
-    Falls back to the handler's own default on anything unparseable or
-    non-positive — `session-worker.py` rejects those too, so a bad value means
-    the handler is not running with it either and the default is the honest
-    assumption. Never returns a threshold that could page on a run still inside
-    its permitted bound.
-    """
+    """(warn, down) seconds from the handler's configured hard timeout, falling back to
+    its default on anything unparseable so a threshold never pages a permitted run."""
     raw = os.environ.get("SUTANDO_TIER_HARD_TIMEOUT", "")
     try:
         hard = float(raw)
@@ -5808,13 +5802,8 @@ _TASK_CLAIM_ARCHIVE_GRACE_S = 300
 
 
 def _claim_observations_path(workspace_dir: Path) -> Optional[Path]:
-    """Unsynced store for first-sightings, or None when none exists.
-
-    Anchored on the ENGINE checkout (this file's repo), never the workspace: a
-    deployed layout can keep the workspace beside the checkout, and `state/` is
-    carryable, so a workspace-relative store is refreshable by the same sync
-    that refreshes claim mtime.
-    """
+    """Unsynced first-sighting store, or None. Anchored on the ENGINE checkout, never the
+    workspace, whose state/ is refreshed by the same sync that refreshes claim mtime."""
     engine = REPO_DIR.resolve()          # the module already resolves its own repo
     try:
         # rev-parse, not `engine/".git"`: in a WORKTREE .git is a file.
@@ -5834,11 +5823,8 @@ def _claim_observations_path(workspace_dir: Path) -> Optional[Path]:
 
 
 def _claim_ages(entries: list, workspace_dir: Path, now: float) -> tuple:
-    """({name: seconds since first local sighting}, trusted).
-
-    `trusted` is False when no structurally-unsynced store exists -- the caller
-    must then treat age as unavailable rather than trust a syncable mtime.
-    """
+    """({name: seconds since first local sighting}, trusted). trusted=False means no
+    unsynced store exists, so the caller must treat age as unavailable, not as mtime."""
     path = _claim_observations_path(workspace_dir)
     if path is None:
         return {}, False
@@ -5892,13 +5878,8 @@ def _claim_ages(entries: list, workspace_dir: Path, now: float) -> tuple:
 
 
 def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
-    """Held-but-unsettled task-handler claims — a leak no other probe can see.
-
-    The task file is the progress signal: while it exists the work is queued or
-    running, so neither count nor age can condemn the claim. A claim whose task
-    is already archived is leaked at any age. Not a --fix: releasing a claim may
-    drop a running task.
-    """
+    """A claim whose task file still exists is queued or running, so no age condemns it;
+    one whose task is archived is leaked at any age. Not a --fix: release may drop work."""
     name = "task-claims"
     base = Path(workspace_dir or WORKSPACE_DIR) / "state" / "task-event-handler-claims"
     if not base.is_dir():

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5805,6 +5805,11 @@ def _claim_owner(path: Path):
     return pid, disposition, task_path
 
 
+# Archive-then-release is a normal asynchronous transition, so an absent task
+# only condemns a claim once it is older than the slowest such handoff.
+_TASK_CLAIM_ARCHIVE_GRACE_S = 300
+
+
 def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
     """Held-but-unsettled task-handler claims — a leak no other probe can see.
 
@@ -5833,9 +5838,14 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
         # several claims -- so neither count nor age can condemn it.
         task_live = bool(task_path) and Path(task_path).exists()
         if not task_live:
-            # The task was archived, so the work finished and nothing released
-            # the claim. That is the leak, at any age and any count.
-            leaked.append((age, entry.name, "task already archived"))
+            # Archival and claim release are ASYNCHRONOUS: the handler can
+            # publish, the bridge archive the task, and finish_handler_task
+            # still be processing HANDLER_DONE. Only past that window is an
+            # absent task evidence that nothing will release the claim.
+            if age >= _TASK_CLAIM_ARCHIVE_GRACE_S:
+                leaked.append((age, entry.name, "task already archived"))
+            else:
+                in_flight += 1
         elif pid is not None and not _pid_alive(pid):
             leaked.append((age, entry.name, "owner process gone"))
         elif disposition == "must-handle":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5821,7 +5821,7 @@ def _claim_observations_path(workspace_dir: Path) -> Optional[Path]:
     engine = REPO_DIR.resolve()          # the module already resolves its own repo
     try:
         # rev-parse, not `engine/".git"`: in a WORKTREE .git is a file.
-        out = subprocess.run(["git", "rev-parse", "--git-dir"], cwd=str(engine),
+        out = subprocess.run(git_argv("rev-parse", "--git-dir"), cwd=str(engine),
                              capture_output=True, text=True, timeout=5)
         if out.returncode != 0 or not out.stdout.strip():
             return None
@@ -5912,17 +5912,13 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
     bounded, leaked, in_flight, held = [], [], 0, 0
     entries = list(base.glob("task-*.txt"))
     # Ages come from a LOCAL first-sighting, not mtime: mtime is sync-mutable.
+    # An untrusted ledger degrades only the AGE-DEPENDENT decisions. A dead owner
+    # is knowable without any age, so keep scanning rather than returning here.
     ages, age_trusted = _claim_ages(entries, Path(workspace_dir or WORKSPACE_DIR), now)
-    if entries and not age_trusted:
-        # No structurally-unsynced store: mtime is the only signal and it is
-        # refreshable, so report the gap rather than a number we cannot trust.
-        return {"name": name, "status": "warn",
-                "detail": f"{len(entries)} held claim(s); claim AGE is unavailable "
-                          "(no unsynced observation store), so a stale claim cannot "
-                          "be distinguished from a fresh one"}
+    age_unknown = 0
     for entry in entries:
         age = ages.get(entry.name)
-        if age is None:
+        if age is None and age_trusted:
             continue          # raced with a release; the next run sees the truth
         held += 1
         pid, disposition, task_path = _claim_owner(entry)
@@ -5930,19 +5926,26 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
         # queued or running -- with 2 handler workers a burst legitimately holds
         # several claims -- so neither count nor age can condemn it.
         task_live = bool(task_path) and Path(task_path).exists()
-        if not task_live:
+        # Age-INDEPENDENT and definitive, so it is checked FIRST: nothing can
+        # release a claim whose owner is gone, whatever the ledger says.
+        if pid is not None and not _pid_alive(pid):
+            leaked.append((age or 0.0, entry.name, "owner process gone"))
+        elif not task_live:
             # Archival and claim release are ASYNCHRONOUS: the handler can
             # publish, the bridge archive the task, and finish_handler_task
             # still be processing HANDLER_DONE. Only past that window is an
             # absent task evidence that nothing will release the claim.
-            if age >= _TASK_CLAIM_ARCHIVE_GRACE_S:
+            if age is None:
+                age_unknown += 1          # grace needs an age we do not have
+            elif age >= _TASK_CLAIM_ARCHIVE_GRACE_S:
                 leaked.append((age, entry.name, "task already archived"))
             else:
                 in_flight += 1
-        elif pid is not None and not _pid_alive(pid):
-            leaked.append((age, entry.name, "owner process gone"))
         elif disposition == "must-handle":
-            bounded.append((age, entry.name))
+            if age is None:
+                age_unknown += 1          # the bound is an age comparison
+            else:
+                bounded.append((age, entry.name))
         else:
             in_flight += 1
 
@@ -5968,6 +5971,12 @@ def check_task_claim_age(workspace_dir: Optional[Path] = None) -> dict:
         if age > warn_s:
             return {"name": name, "status": "warn",
                     "detail": f"{detail} — past {_TASK_CLAIM_WARN_MULTIPLE}x the handler's own bound"}
+    if age_unknown:
+        return {"name": name, "status": "warn",
+                "detail": f"{held} held claim(s); no leak or dead owner found, but "
+                          f"claim AGE is unavailable for {age_unknown} of them (no "
+                          "trusted observation store), so stale cannot be told from "
+                          "fresh for those"}
     return {"name": name, "status": "ok",
             "detail": f"{held} held claim(s), {in_flight} still queued or running; "
                       "none leaked and none past its own execution contract"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5818,7 +5818,7 @@ def _claim_observations_path(workspace_dir: Path) -> Optional[Path]:
     carryable, so a workspace-relative store is refreshable by the same sync
     that refreshes claim mtime.
     """
-    engine = Path(__file__).resolve().parent.parent
+    engine = REPO_DIR.resolve()          # the module already resolves its own repo
     try:
         # rev-parse, not `engine/".git"`: in a WORKTREE .git is a file.
         out = subprocess.run(["git", "rev-parse", "--git-dir"], cwd=str(engine),

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -132,10 +132,8 @@ class TestTaskClaimAge(unittest.TestCase):
         source = (REPO / "src" / "health-check.py").read_text()
         self.assertIn("checks.append(check_task_claim_age())", source)
 
-    # --- thresholds track the HANDLER's configured bound, not a constant -----
-    # Claims wrap session-worker.py, whose hard limit is SUTANDO_TIER_HARD_TIMEOUT
-    # (default 900s, explicitly configurable). A fixed threshold pages on live work
-    # the moment a deployment raises that timeout.
+    # Thresholds track SUTANDO_TIER_HARD_TIMEOUT (configurable), not a constant:
+    # a fixed threshold pages on live work as soon as a deployment raises it.
 
     def test_raised_hard_timeout_does_not_page_on_an_in_flight_handler(self):
         """The reviewer's control on #2906: hard timeout 7200s, a 1900s live claim.

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -395,6 +395,25 @@ class TestClaimExecutionContract(unittest.TestCase):
                 r = self.hc.check_task_claim_age(ws)
             self.assertEqual(r["status"], "warn", r["detail"])
 
+    def test_untrusted_age_still_reports_a_DEAD_OWNER_as_down(self):
+        # The reviewer's P1: a dead owner is knowable without any age, so an
+        # unusable ledger must not downgrade it to warn.
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            self._claim_in(ws, "task-1.txt", 999999, "fallback", 0.1, True)
+            with mock.patch.object(self.hc, "_claim_ages", return_value=({}, False)):
+                r = self.hc.check_task_claim_age(ws)
+            self.assertEqual(r["status"], "down", r["detail"])
+            self.assertIn("owner process gone", r["detail"])
+
+    def test_the_probe_resolves_git_through_git_argv_not_a_bare_binary(self):
+        # A bare `git` can raise the Xcode CLT dialog on a clean macOS box.
+        src = (REPO / "src" / "health-check.py").read_text()
+        i = src.index("def _claim_observations_path")
+        body = src[i:src.index("def _claim_ages")]
+        self.assertIn("git_argv(", body)
+        self.assertNotIn('["git"', body)
+
     def test_archive_before_claim_release_is_not_an_outage(self):
         # The reviewer's case: handler published, bridge archived the task,
         # and finish_handler_task has not processed HANDLER_DONE yet.

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -262,6 +262,20 @@ class TestClaimExecutionContract(unittest.TestCase):
         self.assertEqual(r["status"], "down", r["detail"])
         self.assertIn("task already archived", r["detail"])
 
+    def test_archive_before_claim_release_is_not_an_outage(self):
+        # The reviewer's case: handler published, bridge archived the task,
+        # and finish_handler_task has not processed HANDLER_DONE yet.
+        r = self._run([(os.getpid(), "fallback", 0.01, False)])
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_a_stranded_old_claim_with_no_task_is_still_caught(self):
+        r = self._run([(os.getpid(), "fallback", 2.0, False)])
+        self.assertEqual(r["status"], "down", r["detail"])
+        self.assertIn("task already archived", r["detail"])
+
+    def test_the_grace_is_a_deliberate_interval_not_zero(self):
+        self.assertGreaterEqual(self.hc._TASK_CLAIM_ARCHIVE_GRACE_S, 60)
+
     def test_a_single_leaked_claim_is_caught_at_any_age(self):
         # Strictly better than the count rule this replaced, which needed six.
         r = self._run([(os.getpid(), "fallback", 0.2, False)])

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -189,9 +189,24 @@ class TestTaskClaimAge(unittest.TestCase):
 
     def test_all_claims_unreadable_reads_as_empty_not_broken(self):
         """Every entry racing at once is indistinguishable from an empty dir, and
-        an empty dir is the honest report — the next run sees the truth."""
+        an empty dir is the honest report — the next run sees the truth.
+
+        Raises only for claim FILES, never blanket-on-Path.stat: CPython 3.12's
+        `Path.is_dir()` calls stat(), so a global raise breaks the probe's own
+        directory check and the test exercises the wrong failure. It passed on
+        3.14 locally and errored on 3.12 in CI for exactly that reason. The
+        suffix matters too — the claims DIRECTORY is `task-event-handler-claims`,
+        which also starts with `task-`.
+        """
         self._claim("task-gone.txt", 10)
-        with mock.patch.object(Path, "stat", lambda *a, **kw: (_ for _ in ()).throw(OSError())):
+        real_stat = Path.stat
+
+        def flaky(self_path, *a, **kw):
+            if self_path.name.startswith("task-") and self_path.name.endswith(".txt"):
+                raise OSError(2, "No such file or directory")
+            return real_stat(self_path, *a, **kw)
+
+        with mock.patch.object(Path, "stat", flaky):
             out = self.hc.check_task_claim_age(workspace_dir=self.ws)
         self.assertEqual(out["status"], "ok")
 

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -51,8 +51,14 @@ class TestTaskClaimAge(unittest.TestCase):
 
     def _claim(self, name: str, age_s: float) -> Path:
         self.claims.mkdir(parents=True, exist_ok=True)
+        # The task must EXIST: these cases are about a bounded handler running
+        # too long, not about a claim whose task was already archived.
+        tasks = self.ws / "tasks"
+        tasks.mkdir(parents=True, exist_ok=True)
+        task = tasks / name
+        task.write_text("task\n")
         path = self.claims / name
-        path.write_text("claim\nwatcher-id\n/tasks/x.txt\nmust-handle\n")
+        path.write_text("%d\nwatcher-id\n%s\nmust-handle\n" % (os.getpid(), task))
         stamp = time.time() - age_s
         os.utime(path, (stamp, stamp))
         return path
@@ -214,61 +220,70 @@ class TestTaskClaimAge(unittest.TestCase):
 
 
 class TestClaimExecutionContract(unittest.TestCase):
-    """Age alone condemned every claim, including ones with no deadline."""
+    """The task file is the progress signal; count and age cannot condemn."""
 
     def setUp(self):
         self.hc = _load_health_check()
 
-    def _claim(self, ws, name, pid, disposition, age_h):
-        d = ws / "state" / "task-event-handler-claims"
-        d.mkdir(parents=True, exist_ok=True)
-        f = d / name
-        f.write_text("%s\nWID\n/tmp/t.txt\n%s\n" % (pid, disposition))
+    def _claim(self, ws, name, pid, disposition, age_h, task_exists):
+        cd = ws / "state" / "task-event-handler-claims"
+        cd.mkdir(parents=True, exist_ok=True)
+        td = ws / "tasks"
+        td.mkdir(parents=True, exist_ok=True)
+        tp = td / name
+        if task_exists:
+            tp.write_text("task\n")
+        f = cd / name
+        f.write_text("%s\nWID\n%s\n%s\n" % (pid, tp, disposition))
         t = time.time() - age_h * 3600
         os.utime(f, (t, t))
-        return f
 
     def _run(self, spec):
         with tempfile.TemporaryDirectory() as td:
             ws = Path(td)
-            for i, (pid, disp, age) in enumerate(spec):
-                self._claim(ws, "task-%d.txt" % i, pid, disp, age)
+            for i, (pid, disp, age, exists) in enumerate(spec):
+                self._claim(ws, "task-%d.txt" % i, pid, disp, age, exists)
             return self.hc.check_task_claim_age(ws)
 
-    def test_a_live_unbounded_claim_is_not_leaked_however_old(self):
-        # The reviewer's case: a fallback claim runs on the live core, which has
-        # no hard deadline, so a long owner session must not read as a leak.
-        r = self._run([(os.getpid(), "fallback", 31.2)])
+    def test_a_burst_of_queued_claims_never_alarms(self):
+        # Six fresh fallback claims with their tasks still present. The watcher
+        # claims before queueing and runs 2 workers, so this is a normal burst.
+        r = self._run([(os.getpid(), "fallback", 0.01, True)] * 6)
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_queued_claims_do_not_alarm_on_age_either(self):
+        r = self._run([(os.getpid(), "fallback", 5.0, True)] * 6)
         self.assertEqual(r["status"], "ok", r["detail"])
 
     def test_the_founding_leak_is_still_caught(self):
-        # 34 concurrent fallback claims under a HEALTHY watcher — the incident
-        # this probe exists for. Age cannot see it; concurrency can.
-        r = self._run([(os.getpid(), "fallback", 31.2 - i * 0.5) for i in range(34)])
+        # 34 claims whose tasks are already archived: the work finished and
+        # nothing released them.
+        r = self._run([(os.getpid(), "fallback", 31.0 - i * 0.5, False) for i in range(34)])
         self.assertEqual(r["status"], "down", r["detail"])
-        self.assertIn("held at once", r["detail"])
+        self.assertIn("task already archived", r["detail"])
 
-    def test_an_orphaned_claim_is_down_at_any_age(self):
-        r = self._run([(999999, "fallback", 0.2)])
+    def test_a_single_leaked_claim_is_caught_at_any_age(self):
+        # Strictly better than the count rule this replaced, which needed six.
+        r = self._run([(os.getpid(), "fallback", 0.2, False)])
         self.assertEqual(r["status"], "down", r["detail"])
-        self.assertIn("orphaned", r["detail"])
+
+    def test_a_long_owner_session_is_not_leaked(self):
+        r = self._run([(os.getpid(), "fallback", 31.2, True)])
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_a_dead_owner_is_leaked_even_with_the_task_present(self):
+        r = self._run([(999999, "fallback", 0.1, True)])
+        self.assertEqual(r["status"], "down", r["detail"])
+        self.assertIn("owner process gone", r["detail"])
 
     def test_a_bounded_claim_past_its_hard_timeout_is_down(self):
-        r = self._run([(os.getpid(), "must-handle", 31.2)])
+        r = self._run([(os.getpid(), "must-handle", 31.2, True)])
         self.assertEqual(r["status"], "down", r["detail"])
 
     def test_a_young_bounded_claim_is_ok(self):
-        self.assertEqual(self._run([(os.getpid(), "must-handle", 0.05)])["status"], "ok")
-
-
-    def test_the_warn_tier_of_the_concurrency_signal(self):
-        # down was covered, warn was not — the middle band of my own threshold.
-        r = self._run([(os.getpid(), "fallback", 2.0)] * 3)
-        self.assertEqual(r["status"], "warn", r["detail"])
-        self.assertIn("held at once", r["detail"])
+        self.assertEqual(self._run([(os.getpid(), "must-handle", 0.05, True)])["status"], "ok")
 
     def test_pid_liveness_edge_cases(self):
-        # PermissionError means the process EXISTS under another uid.
         with mock.patch.object(self.hc.os, "kill", side_effect=PermissionError):
             self.assertTrue(self.hc._pid_alive(1))
         for exc in (OverflowError, ValueError, OSError):
@@ -280,7 +295,7 @@ class TestClaimExecutionContract(unittest.TestCase):
             f = Path(td) / "task-x.txt"
             f.write_text("1\nWID\n/tmp/t\nfallback\n")
             with mock.patch.object(Path, "read_text", side_effect=OSError):
-                self.assertEqual(self.hc._claim_owner(f), (None, None))
+                self.assertEqual(self.hc._claim_owner(f), (None, None, None))
 
 
 if __name__ == "__main__":

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Regression test: check_task_claim_age must make a LEAKED task-handler claim
+loud while it is leaking, instead of only at watcher exit.
+
+The gap it covers: `watch-tasks-stream.sh` takes a claim in
+state/task-event-handler-claims/ before dispatching a task to
+$SUTANDO_TASK_EVENT_HANDLER and releases it on completion. A claim that is
+never released takes NO error path, so nothing is logged and every other probe
+reads healthy. It surfaces only when the watcher exits, where
+fallback_outstanding_handlers() publishes one user-visible terminal failure per
+held claim — so a slow leak's first and only symptom is a flood at restart.
+
+Measured 2026-08-14: 34 claims accumulated over 21h, oldest 31.2h, and drained
+as 34 Discord messages in two seconds on restart. The retired watcher's entire
+captured stderr was 228 lines — 194 task events plus those 34 shutdown lines,
+and nothing else. Zero handler failures. Nothing could have reported the leak.
+
+Run: python3 tests/health-check-task-claim-age.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_health_check():
+    spec = importlib.util.spec_from_file_location(
+        "health_check_claim_age_test", REPO / "src" / "health-check.py"
+    )
+    hc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hc)
+    return hc
+
+
+class TestTaskClaimAge(unittest.TestCase):
+    def setUp(self):
+        self.hc = _load_health_check()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        self.claims = self.ws / "state" / "task-event-handler-claims"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _claim(self, name: str, age_s: float) -> Path:
+        self.claims.mkdir(parents=True, exist_ok=True)
+        path = self.claims / name
+        path.write_text("claim\nwatcher-id\n/tasks/x.txt\nmust-handle\n")
+        stamp = time.time() - age_s
+        os.utime(path, (stamp, stamp))
+        return path
+
+    # --- the assertions that must FAIL in the broken state -------------------
+
+    def test_leaked_claim_reports_down(self):
+        """A 31h claim — the measured 2026-08-14 case — must read `down`."""
+        self._claim("task-1786641305509.txt", 31.2 * 3600)
+        out = self.hc.check_task_claim_age(workspace_dir=self.ws)
+        self.assertEqual(out["status"], "down")
+        self.assertIn("31.2h", out["detail"])
+
+    def test_aging_claim_reports_warn(self):
+        """Past any bounded handler run (codex-bounded caps at 240s) but not yet
+        `down`: the window where the leak is still cheap to catch."""
+        self._claim("task-1786641305509.txt", 45 * 60)
+        self.assertEqual(
+            self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "warn"
+        )
+
+    def test_oldest_claim_decides_not_the_count(self):
+        """Many fresh claims must not average away one old one — a busy handler
+        would otherwise mask the leak exactly when it is worst."""
+        for i in range(12):
+            self._claim(f"task-fresh-{i}.txt", 5)
+        self._claim("task-old.txt", 9 * 3600)
+        out = self.hc.check_task_claim_age(workspace_dir=self.ws)
+        self.assertEqual(out["status"], "down")
+        self.assertIn("13 held claim(s)", out["detail"])
+        self.assertIn("task-old.txt", out["detail"])
+
+    # --- and the clean states, so the probe cannot be trivially always-down ---
+
+    def test_in_flight_claim_is_ok(self):
+        """A claim younger than one handler run is normal operation."""
+        self._claim("task-1786641305509.txt", 30)
+        self.assertEqual(
+            self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "ok"
+        )
+
+    def test_empty_claims_dir_is_ok(self):
+        self.claims.mkdir(parents=True, exist_ok=True)
+        self.assertEqual(
+            self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "ok"
+        )
+
+    def test_absent_claims_dir_is_ok(self):
+        """A host that never dispatched to the handler has no directory, and
+        that is not a fault — an absent-is-warn probe warns forever and gets
+        ignored, which is how the alarm this exists to raise would be lost."""
+        self.assertEqual(
+            self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "ok"
+        )
+
+    def test_non_claim_files_are_ignored(self):
+        """Release/retire use `.stale-*` and `.claim-*` temporaries in the same
+        directory; only published `task-*.txt` claims are held work."""
+        self.claims.mkdir(parents=True, exist_ok=True)
+        stale = self.claims / ".stale-watcher-task-1.txt"
+        stale.write_text("x")
+        old = time.time() - 40 * 3600
+        os.utime(stale, (old, old))
+        self.assertEqual(
+            self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "ok"
+        )
+
+    def test_probe_is_registered_in_the_report(self):
+        """A probe that exists but is never appended to `checks` cannot fail."""
+        source = (REPO / "src" / "health-check.py").read_text()
+        self.assertIn("checks.append(check_task_claim_age())", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -1,23 +1,6 @@
 #!/usr/bin/env python3
-"""Regression test: check_task_claim_age must make a LEAKED task-handler claim
-loud while it is leaking, instead of only at watcher exit.
-
-The gap it covers: `watch-tasks-stream.sh` takes a claim in
-state/task-event-handler-claims/ before dispatching a task to
-$SUTANDO_TASK_EVENT_HANDLER and releases it on completion. A claim that is
-never released takes NO error path, so nothing is logged and every other probe
-reads healthy. It surfaces only when the watcher exits, where
-fallback_outstanding_handlers() publishes one user-visible terminal failure per
-held claim — so a slow leak's first and only symptom is a flood at restart.
-
-Measured 2026-08-14: 34 claims accumulated over 21h, oldest 31.2h, and drained
-as 34 Discord messages in two seconds on restart. The retired watcher's entire
-captured stderr was 228 lines — 194 task events plus those 34 shutdown lines,
-and nothing else. Zero handler failures. Nothing could have reported the leak.
-
-Run: python3 tests/health-check-task-claim-age.test.py
-Exit: 0 on pass, 1 on fail.
-"""
+"""check_task_claim_age must make a LEAKED handler claim loud while it is leaking,
+    not only at watcher exit. Run: python3 tests/health-check-task-claim-age.test.py"""
 from __future__ import annotations
 import importlib.util
 import json
@@ -108,9 +91,8 @@ class TestTaskClaimAge(unittest.TestCase):
         )
 
     def test_absent_claims_dir_is_ok(self):
-        """A host that never dispatched to the handler has no directory, and
-        that is not a fault — an absent-is-warn probe warns forever and gets
-        ignored, which is how the alarm this exists to raise would be lost."""
+        """A host that never dispatched has no directory; an absent-is-warn probe warns
+        forever and gets ignored, losing the alarm this exists to raise."""
         self.assertEqual(
             self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "ok"
         )
@@ -136,10 +118,8 @@ class TestTaskClaimAge(unittest.TestCase):
     # a fixed threshold pages on live work as soon as a deployment raises it.
 
     def test_raised_hard_timeout_does_not_page_on_an_in_flight_handler(self):
-        """The reviewer's control on #2906: hard timeout 7200s, a 1900s live claim.
-
-        Against a fixed 1800s warn this returned `warn` for a handler still well
-        inside its permitted run. It must stay `ok`."""
+        """Hard timeout 7200s with a 1900s live claim returned warn against a fixed 1800s
+        bound. A handler still inside its permitted run must stay ok."""
         self._claim("task-live.txt", 1900)
         with mock.patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "7200"}):
             out = self.hc.check_task_claim_age(workspace_dir=self.ws)
@@ -163,9 +143,8 @@ class TestTaskClaimAge(unittest.TestCase):
             )
 
     def test_unusable_hard_timeout_falls_back_to_the_handler_default(self):
-        """session-worker rejects non-positive/unparseable values too, so the
-        handler is not running with them either — 900s is the honest assumption.
-        Never fail toward a threshold that pages on a permitted run."""
+        """session-worker rejects the same values, so the handler is not running with them
+        either — never fail toward a threshold that pages on a permitted run."""
         self._claim("task-x.txt", 1000)          # < 2*900 warn, > 2*60 if misparsed as small
         for bad in ("", "abc", "0", "-5"):
             with mock.patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": bad}):
@@ -175,9 +154,8 @@ class TestTaskClaimAge(unittest.TestCase):
                 )
 
     def test_unreadable_claim_is_skipped_not_fatal(self):
-        """A claim released mid-scan makes stat() raise. The probe must skip that
-        entry and still judge the rest — a release racing the health check is
-        normal operation, not an error."""
+        """A release racing the scan makes stat() raise; that is normal operation, so the
+        probe must skip the entry and still judge the rest."""
         self._claim("task-old.txt", 9 * 3600)
         real_stat = Path.stat
 
@@ -193,16 +171,8 @@ class TestTaskClaimAge(unittest.TestCase):
         self.assertIn("1 held claim(s)", out["detail"])   # the vanished one is not counted
 
     def test_all_claims_unreadable_reads_as_empty_not_broken(self):
-        """Every entry racing at once is indistinguishable from an empty dir, and
-        an empty dir is the honest report — the next run sees the truth.
-
-        Raises only for claim FILES, never blanket-on-Path.stat: CPython 3.12's
-        `Path.is_dir()` calls stat(), so a global raise breaks the probe's own
-        directory check and the test exercises the wrong failure. It passed on
-        3.14 locally and errored on 3.12 in CI for exactly that reason. The
-        suffix matters too — the claims DIRECTORY is `task-event-handler-claims`,
-        which also starts with `task-`.
-        """
+        """Raises only for claim FILES: Path.is_dir() calls stat(), so a blanket raise breaks
+        the probe's own directory check and exercises the wrong failure."""
         self._claim("task-gone.txt", 10)
         real_stat = Path.stat
 

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -25,6 +25,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -123,6 +124,76 @@ class TestTaskClaimAge(unittest.TestCase):
         """A probe that exists but is never appended to `checks` cannot fail."""
         source = (REPO / "src" / "health-check.py").read_text()
         self.assertIn("checks.append(check_task_claim_age())", source)
+
+    # --- thresholds track the HANDLER's configured bound, not a constant -----
+    # Claims wrap session-worker.py, whose hard limit is SUTANDO_TIER_HARD_TIMEOUT
+    # (default 900s, explicitly configurable). A fixed threshold pages on live work
+    # the moment a deployment raises that timeout.
+
+    def test_raised_hard_timeout_does_not_page_on_an_in_flight_handler(self):
+        """The reviewer's control on #2906: hard timeout 7200s, a 1900s live claim.
+
+        Against a fixed 1800s warn this returned `warn` for a handler still well
+        inside its permitted run. It must stay `ok`."""
+        self._claim("task-live.txt", 1900)
+        with mock.patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "7200"}):
+            out = self.hc.check_task_claim_age(workspace_dir=self.ws)
+        self.assertEqual(out["status"], "ok")
+
+    def test_raised_hard_timeout_still_pages_past_its_own_multiple(self):
+        """Deriving from the bound must not disable the probe — 7200s bound still
+        warns past 2x and goes down past 8x."""
+        self._claim("task-stuck.txt", 7200 * 3)
+        with mock.patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "7200"}):
+            self.assertEqual(
+                self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "warn"
+            )
+
+    def test_lowered_hard_timeout_tightens_the_threshold(self):
+        """A 60s bound makes a 300s claim (5x) late — a fixed 1800s would miss it."""
+        self._claim("task-late.txt", 300)
+        with mock.patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "60"}):
+            self.assertEqual(
+                self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "warn"
+            )
+
+    def test_unusable_hard_timeout_falls_back_to_the_handler_default(self):
+        """session-worker rejects non-positive/unparseable values too, so the
+        handler is not running with them either — 900s is the honest assumption.
+        Never fail toward a threshold that pages on a permitted run."""
+        self._claim("task-x.txt", 1000)          # < 2*900 warn, > 2*60 if misparsed as small
+        for bad in ("", "abc", "0", "-5"):
+            with mock.patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": bad}):
+                self.assertEqual(
+                    self.hc.check_task_claim_age(workspace_dir=self.ws)["status"], "ok",
+                    f"unusable value {bad!r} must fall back to the 900s default",
+                )
+
+    def test_unreadable_claim_is_skipped_not_fatal(self):
+        """A claim released mid-scan makes stat() raise. The probe must skip that
+        entry and still judge the rest — a release racing the health check is
+        normal operation, not an error."""
+        self._claim("task-old.txt", 9 * 3600)
+        real_stat = Path.stat
+
+        def flaky(self_path, *a, **kw):
+            if self_path.name == "task-gone.txt":
+                raise OSError(2, "No such file or directory")
+            return real_stat(self_path, *a, **kw)
+
+        self._claim("task-gone.txt", 10)
+        with mock.patch.object(Path, "stat", flaky):
+            out = self.hc.check_task_claim_age(workspace_dir=self.ws)
+        self.assertEqual(out["status"], "down")
+        self.assertIn("1 held claim(s)", out["detail"])   # the vanished one is not counted
+
+    def test_all_claims_unreadable_reads_as_empty_not_broken(self):
+        """Every entry racing at once is indistinguishable from an empty dir, and
+        an empty dir is the honest report — the next run sees the truth."""
+        self._claim("task-gone.txt", 10)
+        with mock.patch.object(Path, "stat", lambda *a, **kw: (_ for _ in ()).throw(OSError())):
+            out = self.hc.check_task_claim_age(workspace_dir=self.ws)
+        self.assertEqual(out["status"], "ok")
 
 
 if __name__ == "__main__":

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -211,5 +211,55 @@ class TestTaskClaimAge(unittest.TestCase):
         self.assertEqual(out["status"], "ok")
 
 
+
+
+class TestClaimExecutionContract(unittest.TestCase):
+    """Age alone condemned every claim, including ones with no deadline."""
+
+    def setUp(self):
+        self.hc = _load_health_check()
+
+    def _claim(self, ws, name, pid, disposition, age_h):
+        d = ws / "state" / "task-event-handler-claims"
+        d.mkdir(parents=True, exist_ok=True)
+        f = d / name
+        f.write_text("%s\nWID\n/tmp/t.txt\n%s\n" % (pid, disposition))
+        t = time.time() - age_h * 3600
+        os.utime(f, (t, t))
+        return f
+
+    def _run(self, spec):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            for i, (pid, disp, age) in enumerate(spec):
+                self._claim(ws, "task-%d.txt" % i, pid, disp, age)
+            return self.hc.check_task_claim_age(ws)
+
+    def test_a_live_unbounded_claim_is_not_leaked_however_old(self):
+        # The reviewer's case: a fallback claim runs on the live core, which has
+        # no hard deadline, so a long owner session must not read as a leak.
+        r = self._run([(os.getpid(), "fallback", 31.2)])
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_the_founding_leak_is_still_caught(self):
+        # 34 concurrent fallback claims under a HEALTHY watcher — the incident
+        # this probe exists for. Age cannot see it; concurrency can.
+        r = self._run([(os.getpid(), "fallback", 31.2 - i * 0.5) for i in range(34)])
+        self.assertEqual(r["status"], "down", r["detail"])
+        self.assertIn("held at once", r["detail"])
+
+    def test_an_orphaned_claim_is_down_at_any_age(self):
+        r = self._run([(999999, "fallback", 0.2)])
+        self.assertEqual(r["status"], "down", r["detail"])
+        self.assertIn("orphaned", r["detail"])
+
+    def test_a_bounded_claim_past_its_hard_timeout_is_down(self):
+        r = self._run([(os.getpid(), "must-handle", 31.2)])
+        self.assertEqual(r["status"], "down", r["detail"])
+
+    def test_a_young_bounded_claim_is_ok(self):
+        self.assertEqual(self._run([(os.getpid(), "must-handle", 0.05)])["status"], "ok")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -354,6 +354,47 @@ class TestClaimExecutionContract(unittest.TestCase):
             self.assertEqual(before, after,
                              "a first sighting moved forward under an mtime refresh")
 
+    def test_rev_parse_raising_yields_no_store(self):
+        # subprocess itself blowing up (git missing) must not crash the probe.
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch.object(self.hc.subprocess, "run",
+                                   side_effect=OSError("no git")):
+                self.assertIsNone(self.hc._claim_observations_path(Path(td)))
+
+    def test_a_nonexistent_git_dir_yields_no_store(self):
+        with tempfile.TemporaryDirectory() as td:
+            ok = type("R", (), {"returncode": 0, "stdout": "definitely-not-here"})()
+            with mock.patch.object(self.hc.subprocess, "run", return_value=ok):
+                self.assertIsNone(self.hc._claim_observations_path(Path(td)))
+
+    def test_an_unwritable_store_degrades_to_untrusted(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            self._claim_in(ws, "task-1.txt", os.getpid(), "must-handle", 40.0, True)
+            with mock.patch.object(Path, "mkdir", side_effect=OSError("read-only")):
+                r = self.hc.check_task_claim_age(ws)
+            self.assertEqual(r["status"], "warn", r["detail"])
+            self.assertIn("unavailable", r["detail"])
+
+    def test_a_registry_holding_a_non_dict_is_ignored_not_fatal(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            self._claim_in(ws, "task-1.txt", os.getpid(), "must-handle", 40.0, True)
+            p = self.hc._claim_observations_path(ws)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text('["a list, not a dict"]')
+            r = self.hc.check_task_claim_age(ws)
+            self.assertEqual(r["status"], "down", r["detail"])
+
+    def test_a_flock_failure_degrades_to_untrusted(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            self._claim_in(ws, "task-1.txt", os.getpid(), "must-handle", 40.0, True)
+            with mock.patch.object(self.hc.fcntl, "flock",
+                                   side_effect=OSError("locking unsupported")):
+                r = self.hc.check_task_claim_age(ws)
+            self.assertEqual(r["status"], "warn", r["detail"])
+
     def test_archive_before_claim_release_is_not_an_outage(self):
         # The reviewer's case: handler published, bridge archived the task,
         # and finish_handler_task has not processed HANDLER_DONE yet.

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -20,6 +20,7 @@ Exit: 0 on pass, 1 on fail.
 """
 from __future__ import annotations
 import importlib.util
+import json
 import os
 import tempfile
 import time
@@ -295,15 +296,63 @@ class TestClaimExecutionContract(unittest.TestCase):
                              "back under its threshold: " + after["detail"])
             self.assertIn("40.0h", after["detail"])
 
-    def test_the_observation_registry_is_outside_the_synced_tree(self):
-        # state/ is carryable by a vault.sync include; the git dir never is.
-        import subprocess
+    def test_the_registry_is_outside_the_workspace_WITHOUT_git_initing_it(self):
+        # The previous version ran `git init` on the temp workspace, so it
+        # CONSTRUCTED the condition it verified. A plain dir is the real case.
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)                      # deliberately NOT a git repo
+            p = self.hc._claim_observations_path(ws)
+            self.assertIsNotNone(p, "engine checkout should supply a store")
+            self.assertNotIn(str(ws.resolve()), str(p),
+                             "registry must not live under the workspace: " + str(p))
+
+    def test_no_engine_git_dir_yields_NONE_never_a_workspace_path(self):
+        # Discriminating: forces the branch the happy path never reaches, so a
+        # reintroduced workspace-relative fallback turns this red.
+        import subprocess as _sp
         with tempfile.TemporaryDirectory() as td:
             ws = Path(td)
-            subprocess.run(["git", "init", "-q", str(ws)], check=False)
+            fail = _sp.CompletedProcess(args=[], returncode=128, stdout="", stderr="")
+            with mock.patch.object(self.hc.subprocess, "run", return_value=fail):
+                p = self.hc._claim_observations_path(ws)
+            self.assertIsNone(
+                p, "with no engine git dir the store must be None, not a "
+                   "workspace path that sync can carry: " + str(p))
+
+    def test_age_is_reported_UNAVAILABLE_when_no_unsynced_store_exists(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            self._claim_in(ws, "task-1.txt", os.getpid(), "must-handle", 40.0, True)
+            with mock.patch.object(self.hc, "_claim_observations_path",
+                                   return_value=None):
+                r = self.hc.check_task_claim_age(ws)
+            self.assertEqual(r["status"], "warn", r["detail"])
+            self.assertIn("unavailable", r["detail"])
+
+    def test_a_corrupt_registry_does_not_reseed_from_mtime(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            self._claim_in(ws, "task-1.txt", os.getpid(), "must-handle", 40.0, True)
             p = self.hc._claim_observations_path(ws)
-            self.assertIn(".git", str(p),
-                          "observations must live under the git dir: " + str(p))
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("{ this is not json")
+            r = self.hc.check_task_claim_age(ws)
+            self.assertEqual(r["status"], "warn", r["detail"])
+            self.assertIn("unavailable", r["detail"])
+
+    def test_a_recorded_first_sighting_is_never_moved_FORWARD(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            f = self._claim_in(ws, "task-1.txt", os.getpid(), "must-handle", 40.0, True)
+            self.hc.check_task_claim_age(ws)           # records the sighting
+            p = self.hc._claim_observations_path(ws)
+            before = json.loads(p.read_text())["task-1.txt"]
+            now = time.time()
+            os.utime(f, (now, now))                    # the sync replay
+            self.hc.check_task_claim_age(ws)
+            after = json.loads(p.read_text())["task-1.txt"]
+            self.assertEqual(before, after,
+                             "a first sighting moved forward under an mtime refresh")
 
     def test_archive_before_claim_release_is_not_an_outage(self):
         # The reviewer's case: handler published, bridge archived the task,

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -238,6 +238,20 @@ class TestClaimExecutionContract(unittest.TestCase):
         t = time.time() - age_h * 3600
         os.utime(f, (t, t))
 
+    def _claim_in(self, ws, name, pid, disposition, age_h, task_exists):
+        cd = ws / "state" / "task-event-handler-claims"
+        cd.mkdir(parents=True, exist_ok=True)
+        td = ws / "tasks"
+        td.mkdir(parents=True, exist_ok=True)
+        tp = td / name
+        if task_exists:
+            tp.write_text("task\n")
+        f = cd / name
+        f.write_text("%s\nWID\n%s\n%s\n" % (pid, tp, disposition))
+        t = time.time() - age_h * 3600
+        os.utime(f, (t, t))
+        return f
+
     def _run(self, spec):
         with tempfile.TemporaryDirectory() as td:
             ws = Path(td)
@@ -261,6 +275,35 @@ class TestClaimExecutionContract(unittest.TestCase):
         r = self._run([(os.getpid(), "fallback", 31.0 - i * 0.5, False) for i in range(34)])
         self.assertEqual(r["status"], "down", r["detail"])
         self.assertIn("task already archived", r["detail"])
+
+    def test_a_sync_refreshed_mtime_cannot_hide_a_stale_bounded_claim(self):
+        # A sync replay rewrites claim mtime; the execution lifetime is
+        # unchanged and must still alarm.
+        import subprocess
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            subprocess.run(["git", "init", "-q", str(ws)], check=False)
+            self._claim_in(ws, "task-1.txt", os.getpid(), "must-handle", 40.0, True)
+            first = self.hc.check_task_claim_age(ws)
+            self.assertEqual(first["status"], "down", first["detail"])
+            f = ws / "state" / "task-event-handler-claims" / "task-1.txt"
+            now = time.time()
+            os.utime(f, (now, now))          # the sync replay
+            after = self.hc.check_task_claim_age(ws)
+            self.assertEqual(after["status"], "down",
+                             "a refreshed mtime pushed a stale bounded claim "
+                             "back under its threshold: " + after["detail"])
+            self.assertIn("40.0h", after["detail"])
+
+    def test_the_observation_registry_is_outside_the_synced_tree(self):
+        # state/ is carryable by a vault.sync include; the git dir never is.
+        import subprocess
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            subprocess.run(["git", "init", "-q", str(ws)], check=False)
+            p = self.hc._claim_observations_path(ws)
+            self.assertIn(".git", str(p),
+                          "observations must live under the git dir: " + str(p))
 
     def test_archive_before_claim_release_is_not_an_outage(self):
         # The reviewer's case: handler published, bridge archived the task,

--- a/tests/health-check-task-claim-age.test.py
+++ b/tests/health-check-task-claim-age.test.py
@@ -261,5 +261,27 @@ class TestClaimExecutionContract(unittest.TestCase):
         self.assertEqual(self._run([(os.getpid(), "must-handle", 0.05)])["status"], "ok")
 
 
+    def test_the_warn_tier_of_the_concurrency_signal(self):
+        # down was covered, warn was not — the middle band of my own threshold.
+        r = self._run([(os.getpid(), "fallback", 2.0)] * 3)
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("held at once", r["detail"])
+
+    def test_pid_liveness_edge_cases(self):
+        # PermissionError means the process EXISTS under another uid.
+        with mock.patch.object(self.hc.os, "kill", side_effect=PermissionError):
+            self.assertTrue(self.hc._pid_alive(1))
+        for exc in (OverflowError, ValueError, OSError):
+            with mock.patch.object(self.hc.os, "kill", side_effect=exc):
+                self.assertFalse(self.hc._pid_alive(1))
+
+    def test_an_unreadable_claim_yields_no_owner(self):
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "task-x.txt"
+            f.write_text("1\nWID\n/tmp/t\nfallback\n")
+            with mock.patch.object(Path, "read_text", side_effect=OSError):
+                self.assertEqual(self.hc._claim_owner(f), (None, None))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `check_task_claim_age` — one probe, `task-claims` — so a **held-but-unsettled task-handler claim is visible while it is leaking**, instead of only when it floods on restart.

## Why

`watch-tasks-stream.sh` takes a claim in `state/task-event-handler-claims/` before dispatching a task to `$SUTANDO_TASK_EVENT_HANDLER`, and releases it on completion. A claim that is never released **takes no error path**: nothing is logged, and every other probe reads healthy — the queue drains, the watcher is alive, results deliver.

It stays invisible until the watcher *exits*, where `fallback_outstanding_handlers()` settles each still-held claim by publishing a terminal failure — **one user-visible message per claim**. So a slow leak has exactly one symptom: a flood at restart, sized by however long the leak ran.

### Measured, 2026-08-14 on a live host

A routine watcher restart produced **34 Discord messages in two seconds** (17:22:09–17:22:11). Those claims carried task IDs spanning Aug 13 10:15 → Aug 14 07:20 — the oldest **31.2h** before the burst — and 33 of the 34 task files had already been deleted, so the claims outlived their tasks.

The retired watcher's entire captured stderr was **228 lines: 194 task events plus those 34 shutdown lines, and nothing else.** Zero `required Team handler failed`, zero `could not be queued`, zero disposition warnings. Nothing in the system could have reported the leak while it grew.

> The root-cause leak is **not** fixed here and is not claimed to be. `release_task_claim` runs only inside `if mv "$marker" "$settled"`, which *looks* like the culprit — but that race is deliberate per the code's own comment (whoever wins the `mv` settles), so asserting it would be a guess. This PR closes the observability gap that let the leak run 31h unseen; the mechanism is separate work.

## Evidence

Probe replayed against the real incident, and against normal operation:

```
2026-08-14 replay (34 claims, oldest 31.2h)
  -> down: 34 held claim(s), oldest 31.2h — leaked; each will publish a
           user-visible failure when the watcher next exits
  -> would have paged ~29h before the flood

normal in-flight dispatch (30s)   -> ok: 1 held claim(s), oldest 0.0h
live workspace, claims dir empty  -> ok: no held task-handler claims
host that never dispatched        -> ok: no claims directory
```

**Probe-name diff — no probe lost:**

```
before (origin/main 5940075c): 49 probes
after                        : 50 probes
LOST : []      ADDED: ['task-claims']
```

That diff is the gate, not the green suite: the failure mode of touching this file is *silence* — a dropped probe does not fail anything, it just makes the run green with fewer checks.

**Suite:** all **71** health-check test files pass (`PASS=71 FAIL=0`).

**New test fails in the broken state** — the same file run against `origin/main` fails with `'checks.append(check_task_claim_age())' not found`, so it is a validated detector rather than one that has only ever printed OK. One case asserts the probe is actually appended to `checks`, since a probe that exists but is never registered cannot fail.

## Thresholds

Warn past 30 min, down past 2h — **30x and 120x** the 240s `codex-bounded.sh` cap, so a legitimately in-flight handler cannot trip it. The **oldest** claim decides, never an average: a busy handler would otherwise mask one stuck claim exactly when it matters most.

## Deliberately not done

- **No `--fix`.** Deleting a held claim would drop a task that may still be running, and publishing its failure early is the watcher's call, not a health probe's.
- Age comes from mtime, not a parsed payload: the claim format is owned by the shell writer. Safe here for the reason it is *not* safe for `state/cores/*.alive` — claims are local-only and never synced, so no remote write can refresh one.

## Scope

2 files, +193/-0. No behaviour change to any existing probe.
