### PR TITLE
fix(pr-flag): fetch the peer half the cron asks for, stop firing on mergeable churn

### DIFF
--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -202,6 +202,30 @@ def raw_state(prs: list, owner_login: str, stand: str = None) -> list:
     return out
 
 
+def carry_unknown_mergeable(state: list, previous: dict) -> list:
+    """Replace UNKNOWN mergeable with the last value seen for that PR.
+
+    GitHub's lazy recomputation parks the field at UNKNOWN; carrying the previous
+    value keeps that churn out of the hash while leaving a real
+    CONFLICTING/MERGEABLE transition fully visible.
+    """
+    out = []
+    for s in state:
+        row = dict(s)
+        if row.get("mergeable") == "UNKNOWN":
+            prior = (previous or {}).get(str(row.get("number")))
+            if prior:
+                row["mergeable"] = prior
+        out.append(row)
+    return out
+
+
+def mergeable_map(state: list) -> dict:
+    """Per-PR mergeable, for the next run to carry forward."""
+    return {str(s.get("number")): s.get("mergeable") for s in state
+            if s.get("mergeable") and s.get("mergeable") != "UNKNOWN"}
+
+
 def state_hash(state: list) -> str:
     """Stable hash of the objective set. Changes when a PR appears/disappears or
     any actionable field (base/head/ci/review/approvals/
@@ -213,20 +237,14 @@ def state_hash(state: list) -> str:
     this it did not refire and the agent was never woken for a PR that had just
     become mergeable.
 
-    `mergeable` is DELIBERATELY EXCLUDED. GitHub computes it lazily and parks it
-    at `UNKNOWN` while recomputing, so it churns without any PR changing. Measured
-    2026-08-14 19:21Z: all 13 rows flipped to UNKNOWN simultaneously, the hash
-    moved, and the cron emitted a digest whose composition was identical to the
-    previous fire — waking the owner for GitHub's cache, not for his repo. Twelve
-    PRs do not change state in the same second; that signature IS the tell.
-
-    Dropping it loses nothing a digest acts on: a real merge-state change is
-    already carried by `head` (a push), `base` (a retarget), `ci`, `review`, or
-    the approval fields. `mergeable` stays in the emitted payload for the agent
-    to read — it is only untrustworthy as a CHANGE signal.
+    `mergeable` is included but must be normalized by `carry_unknown_mergeable`
+    first: GitHub parks it at UNKNOWN while recomputing, and that churn is not a
+    state change. A real CONFLICTING/MERGEABLE flip has no other carrier -- the
+    target branch can advance with head, base name, ci, reviews and approvals all
+    unchanged -- so excluding the field entirely would drop actionable news.
     """
     key = [[s["number"], s["principal"], s["base"], s["head"], s["ci"],
-            s["review"], s["approvals"], s["approvals_standing"]]
+            s["mergeable"], s["review"], s["approvals"], s["approvals_standing"]]
            for s in state]
     return hashlib.sha1(json.dumps(key, sort_keys=True).encode()).hexdigest()[:12]
 
@@ -239,18 +257,8 @@ def fetch_argv(repo: str, owner_login: str) -> list:
     the thing it is describing plus a chance to be wrong: widen the fetch, forget
     the string, and the payload now asserts a filter the code no longer applies.
     """
-    # This is STAGE 2 of a two-stage fetch (#2643). It stays `--author`-scoped on
-    # purpose: the heavy fields below cannot be fetched repo-wide. Measured
-    # 2026-08-14 on sonichi/sutando, 70 open non-draft PRs:
-    #
-    #   --author sonichi + statusCheckRollup + reviews  ->  16 rows, 3.6s, rc=0
-    #   same fields, --author dropped                   ->  HTTP 504 after 11.2s
-    #
-    # GitHub times out computing those fields across the full open set, so simply
-    # removing the flag does not widen the digest -- it EMPTIES it, and a fetch
-    # that fails every fire is worse than one that under-answers because the
-    # failure is silent at the consumer. `peer_candidates()` + `_fetch_peer_pr()`
-    # cover the rest of the population; `scope_descriptor()` reads both.
+    # Stage 2 of two. Stays --author-scoped because these heavy fields 504 when
+    # requested repo-wide; discovery_argv covers the rest of the population.
     return [
         "gh", "pr", "list", "--repo", repo, "--state", "open",
         "--author", owner_login, "--limit", "1000",
@@ -259,13 +267,8 @@ def fetch_argv(repo: str, owner_login: str) -> list:
 
 
 def discovery_argv(repo: str) -> list:
-    """STAGE 1: every open PR, light fields only, NO author filter.
-
-    Cheap enough to run repo-wide because it omits `statusCheckRollup` and
-    `reviews` -- the two fields that 504 at that scale. Measured: 78 rows, 20 KB,
-    1.44s. Its job is only to reveal which PRs exist and who owns them, so the
-    expensive stage can be pointed at the ones that matter.
-    """
+    """Stage 1: every open PR, light fields only, no author filter.
+    Omits statusCheckRollup and reviews -- the two fields that 504 repo-wide."""
     return [
         "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "1000",
         "--json", "number,author,isDraft,mergeable,reviewDecision,baseRefName,headRefOid",
@@ -273,20 +276,11 @@ def discovery_argv(repo: str) -> list:
 
 
 def peer_candidates(discovered: list, owner_login: str) -> list:
-    """Peer PRs where the owner's review could still matter — the category the
-    cron prompt names and the `--author` fetch structurally cannot contain.
+    """Peer PRs whose merge the owner could still unblock -- stage 2's input.
 
-    Prunes two ways, and both are about not paying for the expensive stage:
-
-    - drafts: never actionable.
-    - peer PRs already carrying CHANGES_REQUESTED: the author has to clear the
-      review before anyone's approval can matter, so it is their problem, not the
-      owner's. Measured 2026-08-14: this drops 43 of 70, leaving 27 heavy calls.
-
-    Deliberately does NOT prune on `reviewDecision == APPROVED`. An approved peer
-    PR is precisely the one whose merge may be one owner action away, and an
-    APPROVED-based filter is the exact scope that once reported 32 owner-needing
-    PRs as 1.
+    Prunes drafts and peers already carrying CHANGES_REQUESTED (their author must
+    clear the review first). Never prunes on APPROVED: that is the case an owner
+    action most often unblocks.
     """
     out = []
     for pr in discovered:
@@ -294,7 +288,7 @@ def peer_candidates(discovered: list, owner_login: str) -> list:
             continue
         author = ((pr.get("author") or {}).get("login") or "")
         if author == owner_login:
-            continue                       # stage 2's own fetch already has these
+            continue                       # fetch_argv already covers these
         if pr.get("reviewDecision") == "CHANGES_REQUESTED":
             continue
         out.append(pr["number"])
@@ -339,18 +333,27 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
     except (TypeError, ValueError):
         limit = None
 
+    # A peer stage that could not run is NOT a widened population. Treat it as
+    # owner-only so the payload never claims coverage it does not have.
+    peer_ok = bool(peer_stage) and peer_stage.get("discovery_ok", True)
     excludes = ["draft PRs (dropped by raw_state, always)"]
-    if author and not peer_stage:
+    if peer_stage and not peer_ok:
+        excludes.append(
+            "peer PRs -- the stage-1 discovery fetch FAILED, so the peer half is "
+            "UNKNOWN this fire, not empty"
+        )
+    if peer_stage and not peer_stage.get("owner_ok", True):
+        excludes.append(
+            "the owner-authored fetch FAILED -- owner rows are UNKNOWN, not absent"
+        )
+    if author and not peer_ok:
         excludes.append(
             f"PRs not authored by {author!r} -- including peer PRs where the "
             "owner's approval is the only thing blocking a merge"
         )
-    elif author and peer_stage:
-        # The author filter still binds STAGE 2, but stage 1 + the peer fetch put
-        # the peer half back. Naming what the widened population still drops is
-        # the whole job of this descriptor: peers with an open CHANGES_REQUESTED
-        # are pruned before the expensive call, and that is a real exclusion even
-        # though it is a defensible one.
+    elif author and peer_ok:
+        # The peer stage restores the peer half, but its own prune is still a
+        # real exclusion and must be declared.
         excludes.append(
             "peer PRs already carrying CHANGES_REQUESTED (pruned before stage 2: "
             "the author must clear the review before any approval can matter)"
@@ -389,13 +392,17 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
         complete = True
         why = f"fetch returned {ceiling_count}, below the {limit} ceiling"
 
+    if peer_stage and (not peer_ok or peer_stage.get("failed")
+                       or not peer_stage.get("owner_ok", True)):
+        complete = False
+        why = "a fetch failed; population is uncertified"
     return {
-        "filter": ("author:{} + peer stage".format(author) if (author and peer_stage)
+        "filter": ("author:{} + peer stage".format(author) if (author and peer_ok)
                    else (f"author:{author}" if author else "none")),
         "population": (
             (f"open, non-draft PRs authored by {author!r}, PLUS open non-draft peer "
              "PRs without an open CHANGES_REQUESTED")
-            if (author and peer_stage)
+            if (author and peer_ok)
             else (f"open, non-draft PRs authored by {author!r}"
                   if author else "open, non-draft PRs (all authors)")
         ),
@@ -408,15 +415,18 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
     }
 
 
-def _fetch_discovered(repo: str) -> list:  # pragma: no cover — subprocess/gh glue
+def _fetch_discovered(repo: str):  # pragma: no cover — subprocess/gh glue
+    """(ok, rows). `ok` is False on ANY failure so an outage can never be
+    serialized as a genuinely empty repository."""
     res = subprocess.run(discovery_argv(repo), capture_output=True, text=True, timeout=60)
     if res.returncode != 0:
         print(f"pr-flag: discovery gh failed: {res.stderr[:200]}", file=sys.stderr)
-        return []
+        return False, []
     try:
-        return json.loads(res.stdout)
+        return True, json.loads(res.stdout)
     except json.JSONDecodeError:
-        return []
+        print("pr-flag: discovery returned unparseable JSON", file=sys.stderr)
+        return False, []
 
 
 def _fetch_peer_pr(repo: str, number: int) -> dict:  # pragma: no cover — subprocess/gh glue
@@ -435,16 +445,18 @@ def _fetch_peer_pr(repo: str, number: int) -> dict:  # pragma: no cover — subp
         return {}
 
 
-def _fetch_prs(repo: str, owner_login: str) -> list:  # pragma: no cover — subprocess/gh glue
+def _fetch_prs(repo: str, owner_login: str):  # pragma: no cover — subprocess/gh glue
+    """(ok, rows) — same contract as _fetch_discovered."""
     cmd = fetch_argv(repo, owner_login)
     res = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
     if res.returncode != 0:
         print(f"pr-flag: gh failed: {res.stderr[:200]}", file=sys.stderr)
-        return []
+        return False, []
     try:
-        return json.loads(res.stdout)
+        return True, json.loads(res.stdout)
     except json.JSONDecodeError:
-        return []
+        print("pr-flag: owner fetch returned unparseable JSON", file=sys.stderr)
+        return False, []
 
 
 
@@ -536,24 +548,21 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
 
     # Bound separately so the PRE-filter size is available to scope_descriptor:
     # the `--limit` ceiling applies here, before raw_state() drops drafts.
-    own = _fetch_prs(args.repo, args.owner)
-    # Stage 1 reveals the peer half the owner-scoped fetch cannot contain (#2643).
-    # A discovery failure must NOT silently shrink the population back to
-    # owner-only and read as normal, so it is reported and counted.
-    discovered = _fetch_discovered(args.repo)
+    own_ok, own = _fetch_prs(args.repo, args.owner)
+    disc_ok, discovered = _fetch_discovered(args.repo)
+    candidates = peer_candidates(discovered, args.owner)
     peers, peer_failures = [], 0
-    for number in peer_candidates(discovered, args.owner):
+    for number in candidates:
         pr = _fetch_peer_pr(args.repo, number)
         if pr:
             peers.append(pr)
         else:
             peer_failures += 1
-    if discovered and not peers and peer_candidates(discovered, args.owner):
-        print("pr-flag: every peer fetch failed — peer half of the population is "
-              "MISSING from this emit, not empty", file=sys.stderr)
+    if not disc_ok:
+        print("pr-flag: discovery FAILED — the peer half is unknown, not empty; "
+              "population is uncertified this fire", file=sys.stderr)
     fetched = _attach_commits(args.repo, own + peers)
     state = raw_state(fetched, args.owner, args.stand)
-    h = state_hash(state)
 
     # dedup: resolve the stored-hash file the same way every reader does
     sf = Path(args.state_file) if args.state_file else None
@@ -565,6 +574,19 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
         except Exception:
             ws = ""
         sf = Path(ws) / "state" / "pr-flag-state.json" if ws else Path("state/pr-flag-state.json")
+
+    prior = {}
+    if sf is not None and sf.exists():
+        try:
+            prior = json.loads(sf.read_text()).get("mergeable", {}) or {}
+        except (json.JSONDecodeError, OSError):
+            prior = {}
+    state = carry_unknown_mergeable(state, prior)
+    h = state_hash(state)
+    # A population we could not certify must not overwrite the last good hash:
+    # doing so lets the next healthy fire read as NO_CHANGE and stay silent.
+    certified = own_ok and disc_ok and peer_failures == 0
+
     prev = ""
     try:
         prev = json.loads(sf.read_text()).get("hash", "")
@@ -583,15 +605,22 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
         # not to what survives raw_state(). See scope_descriptor().
         "scope": scope_descriptor(args.repo, args.owner, record_count=len(state),
                                   peer_stage={"discovered": len(discovered),
-                                              "candidates": len(peer_candidates(discovered, args.owner)),
+                                              "candidates": len(candidates),
                                               "fetched": len(peers),
-                                              "failed": peer_failures},
+                                              "failed": peer_failures,
+                                              "discovery_ok": disc_ok,
+                                              "owner_ok": own_ok},
                                   fetched_count=len(fetched)),
         "prs": state,
     }, indent=2))
     try:
         sf.parent.mkdir(parents=True, exist_ok=True)
-        sf.write_text(json.dumps({"hash": h, "count": len(state)}))
+        if certified:
+            sf.write_text(json.dumps({"hash": h, "count": len(state),
+                                      "mergeable": mergeable_map(state)}))
+        else:
+            print("pr-flag: population uncertified — hash NOT recorded, so the "
+                  "next healthy fire still emits", file=sys.stderr)
     except Exception as e:
         print(f"pr-flag: state write failed: {e}", file=sys.stderr)
     return 0

--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -209,12 +209,8 @@ def _mergeable_key(row: dict) -> str:
 
 
 def carry_unknown_mergeable(state: list, previous: dict) -> list:
-    """Replace UNKNOWN mergeable with the last value seen for THIS revision.
-
-    GitHub's lazy recomputation parks the field at UNKNOWN; carrying the previous
-    value keeps that churn out of the hash while leaving a real
-    CONFLICTING/MERGEABLE transition fully visible.
-    """
+    """Carry the last value seen for THIS revision over an UNKNOWN, so GitHub's
+    lazy recompute stays out of the hash while a real transition still shows."""
     out = []
     for s in state:
         row = dict(s)
@@ -234,22 +230,10 @@ def mergeable_map(state: list) -> dict:
 
 
 def state_hash(state: list) -> str:
-    """Stable hash of the objective set. Changes when a PR appears/disappears or
-    any actionable field (base/head/ci/review/approvals/
-    approvals_standing) flips; a title edit does not refire.
+    """Stable hash of the objective set; a title edit does not refire.
 
-    `approvals_standing` is in the key for a reason the head-anchored count
-    cannot cover: a reviewer converting CHANGES_REQUESTED to APPROVED at an
-    OLDER commit moves the enforced gate without moving `approvals`, so before
-    this it did not refire and the agent was never woken for a PR that had just
-    become mergeable.
-
-    `mergeable` is included but must be normalized by `carry_unknown_mergeable`
-    first: GitHub parks it at UNKNOWN while recomputing, and that churn is not a
-    state change. A real CONFLICTING/MERGEABLE flip has no other carrier -- the
-    target branch can advance with head, base name, ci, reviews and approvals all
-    unchanged -- so excluding the field entirely would drop actionable news.
-    """
+    `approvals_standing` and (normalized) `mergeable` are in the key because
+    each carries a gate change no other field does -- see the PR body."""
     key = [[s["number"], s["principal"], s["base"], s["head"], s["ci"],
             s["mergeable"], s["review"], s["approvals"], s["approvals_standing"]]
            for s in state]
@@ -284,11 +268,7 @@ def discovery_argv(repo: str) -> list:
 
 def peer_candidates(discovered: list, owner_login: str) -> list:
     """Peer PRs whose merge the owner could still unblock -- stage 2's input.
-
-    Prunes drafts and peers already carrying CHANGES_REQUESTED (their author must
-    clear the review first). Never prunes on APPROVED: that is the case an owner
-    action most often unblocks.
-    """
+    Prunes drafts and CHANGES_REQUESTED; never prunes on APPROVED."""
     out = []
     for pr in discovered:
         if pr.get("isDraft"):

--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -204,15 +204,28 @@ def raw_state(prs: list, owner_login: str, stand: str = None) -> list:
 
 def state_hash(state: list) -> str:
     """Stable hash of the objective set. Changes when a PR appears/disappears or
-    any actionable field (base/head/ci/mergeable/review/approvals/
+    any actionable field (base/head/ci/review/approvals/
     approvals_standing) flips; a title edit does not refire.
 
     `approvals_standing` is in the key for a reason the head-anchored count
     cannot cover: a reviewer converting CHANGES_REQUESTED to APPROVED at an
     OLDER commit moves the enforced gate without moving `approvals`, so before
     this it did not refire and the agent was never woken for a PR that had just
-    become mergeable."""
-    key = [[s["number"], s["principal"], s["base"], s["head"], s["ci"], s["mergeable"],
+    become mergeable.
+
+    `mergeable` is DELIBERATELY EXCLUDED. GitHub computes it lazily and parks it
+    at `UNKNOWN` while recomputing, so it churns without any PR changing. Measured
+    2026-08-14 19:21Z: all 13 rows flipped to UNKNOWN simultaneously, the hash
+    moved, and the cron emitted a digest whose composition was identical to the
+    previous fire — waking the owner for GitHub's cache, not for his repo. Twelve
+    PRs do not change state in the same second; that signature IS the tell.
+
+    Dropping it loses nothing a digest acts on: a real merge-state change is
+    already carried by `head` (a push), `base` (a retarget), `ci`, `review`, or
+    the approval fields. `mergeable` stays in the emitted payload for the agent
+    to read — it is only untrustworthy as a CHANGE signal.
+    """
+    key = [[s["number"], s["principal"], s["base"], s["head"], s["ci"],
             s["review"], s["approvals"], s["approvals_standing"]]
            for s in state]
     return hashlib.sha1(json.dumps(key, sort_keys=True).encode()).hexdigest()[:12]
@@ -226,12 +239,18 @@ def fetch_argv(repo: str, owner_login: str) -> list:
     the thing it is describing plus a chance to be wrong: widen the fetch, forget
     the string, and the payload now asserts a filter the code no longer applies.
     """
-    # SCOPE NOTE: `--author owner_login` means this only ever sees the owner's OWN
-    # PRs (24 of 116 open on 2026-08-02). Peer PRs where the owner's approval is
-    # the thing unblocking a merge are not fetched at all, so they cannot appear
-    # in any digest built from this state. Left alone deliberately -- widening the
-    # fetch is a scope decision, not a field-completeness fix, and belongs in its
-    # own change (issue #2643).
+    # This is STAGE 2 of a two-stage fetch (#2643). It stays `--author`-scoped on
+    # purpose: the heavy fields below cannot be fetched repo-wide. Measured
+    # 2026-08-14 on sonichi/sutando, 70 open non-draft PRs:
+    #
+    #   --author sonichi + statusCheckRollup + reviews  ->  16 rows, 3.6s, rc=0
+    #   same fields, --author dropped                   ->  HTTP 504 after 11.2s
+    #
+    # GitHub times out computing those fields across the full open set, so simply
+    # removing the flag does not widen the digest -- it EMPTIES it, and a fetch
+    # that fails every fire is worse than one that under-answers because the
+    # failure is silent at the consumer. `peer_candidates()` + `_fetch_peer_pr()`
+    # cover the rest of the population; `scope_descriptor()` reads both.
     return [
         "gh", "pr", "list", "--repo", repo, "--state", "open",
         "--author", owner_login, "--limit", "1000",
@@ -239,8 +258,51 @@ def fetch_argv(repo: str, owner_login: str) -> list:
     ]
 
 
+def discovery_argv(repo: str) -> list:
+    """STAGE 1: every open PR, light fields only, NO author filter.
+
+    Cheap enough to run repo-wide because it omits `statusCheckRollup` and
+    `reviews` -- the two fields that 504 at that scale. Measured: 78 rows, 20 KB,
+    1.44s. Its job is only to reveal which PRs exist and who owns them, so the
+    expensive stage can be pointed at the ones that matter.
+    """
+    return [
+        "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "1000",
+        "--json", "number,author,isDraft,mergeable,reviewDecision,baseRefName,headRefOid",
+    ]
+
+
+def peer_candidates(discovered: list, owner_login: str) -> list:
+    """Peer PRs where the owner's review could still matter — the category the
+    cron prompt names and the `--author` fetch structurally cannot contain.
+
+    Prunes two ways, and both are about not paying for the expensive stage:
+
+    - drafts: never actionable.
+    - peer PRs already carrying CHANGES_REQUESTED: the author has to clear the
+      review before anyone's approval can matter, so it is their problem, not the
+      owner's. Measured 2026-08-14: this drops 43 of 70, leaving 27 heavy calls.
+
+    Deliberately does NOT prune on `reviewDecision == APPROVED`. An approved peer
+    PR is precisely the one whose merge may be one owner action away, and an
+    APPROVED-based filter is the exact scope that once reported 32 owner-needing
+    PRs as 1.
+    """
+    out = []
+    for pr in discovered:
+        if pr.get("isDraft"):
+            continue
+        author = ((pr.get("author") or {}).get("login") or "")
+        if author == owner_login:
+            continue                       # stage 2's own fetch already has these
+        if pr.get("reviewDecision") == "CHANGES_REQUESTED":
+            continue
+        out.append(pr["number"])
+    return out
+
+
 def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
-                     fetched_count: int = None) -> dict:
+                     fetched_count: int = None, peer_stage: dict = None) -> dict:
     """Name the emitted population precisely, from the WHOLE pipeline.
 
     Why this exists: the payload carries counts, per-PR CI, approvals and merge
@@ -278,11 +340,26 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
         limit = None
 
     excludes = ["draft PRs (dropped by raw_state, always)"]
-    if author:
+    if author and not peer_stage:
         excludes.append(
             f"PRs not authored by {author!r} -- including peer PRs where the "
             "owner's approval is the only thing blocking a merge"
         )
+    elif author and peer_stage:
+        # The author filter still binds STAGE 2, but stage 1 + the peer fetch put
+        # the peer half back. Naming what the widened population still drops is
+        # the whole job of this descriptor: peers with an open CHANGES_REQUESTED
+        # are pruned before the expensive call, and that is a real exclusion even
+        # though it is a defensible one.
+        excludes.append(
+            "peer PRs already carrying CHANGES_REQUESTED (pruned before stage 2: "
+            "the author must clear the review before any approval can matter)"
+        )
+        if peer_stage.get("failed"):
+            excludes.append(
+                f"{peer_stage['failed']} peer PR(s) whose stage-2 fetch FAILED -- "
+                "absent from this payload but NOT known to be uninteresting"
+            )
 
     # complete==True is a CERTIFICATION, so it is only ever granted on evidence:
     # a count strictly below the ceiling. Unknown count -> None, never True.
@@ -313,10 +390,14 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
         why = f"fetch returned {ceiling_count}, below the {limit} ceiling"
 
     return {
-        "filter": f"author:{author}" if author else "none",
+        "filter": ("author:{} + peer stage".format(author) if (author and peer_stage)
+                   else (f"author:{author}" if author else "none")),
         "population": (
-            f"open, non-draft PRs authored by {author!r}"
-            if author else "open, non-draft PRs (all authors)"
+            (f"open, non-draft PRs authored by {author!r}, PLUS open non-draft peer "
+             "PRs without an open CHANGES_REQUESTED")
+            if (author and peer_stage)
+            else (f"open, non-draft PRs authored by {author!r}"
+                  if author else "open, non-draft PRs (all authors)")
         ),
         "excludes": excludes,
         "complete": complete,
@@ -325,6 +406,33 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
         "fetched_count": ceiling_count,
         "limit": limit,
     }
+
+
+def _fetch_discovered(repo: str) -> list:  # pragma: no cover — subprocess/gh glue
+    res = subprocess.run(discovery_argv(repo), capture_output=True, text=True, timeout=60)
+    if res.returncode != 0:
+        print(f"pr-flag: discovery gh failed: {res.stderr[:200]}", file=sys.stderr)
+        return []
+    try:
+        return json.loads(res.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def _fetch_peer_pr(repo: str, number: int) -> dict:  # pragma: no cover — subprocess/gh glue
+    """Heavy fields for ONE peer PR. Per-PR because the repo-wide form 504s."""
+    res = subprocess.run(
+        ["gh", "pr", "view", str(number), "--repo", repo, "--json",
+         "number,title,author,baseRefName,headRefOid,mergeable,reviewDecision,"
+         "statusCheckRollup,isDraft,reviews"],
+        capture_output=True, text=True, timeout=60)
+    if res.returncode != 0:
+        print(f"pr-flag: peer #{number} gh failed: {res.stderr[:120]}", file=sys.stderr)
+        return {}
+    try:
+        return json.loads(res.stdout)
+    except json.JSONDecodeError:
+        return {}
 
 
 def _fetch_prs(repo: str, owner_login: str) -> list:  # pragma: no cover — subprocess/gh glue
@@ -428,7 +536,22 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
 
     # Bound separately so the PRE-filter size is available to scope_descriptor:
     # the `--limit` ceiling applies here, before raw_state() drops drafts.
-    fetched = _attach_commits(args.repo, _fetch_prs(args.repo, args.owner))
+    own = _fetch_prs(args.repo, args.owner)
+    # Stage 1 reveals the peer half the owner-scoped fetch cannot contain (#2643).
+    # A discovery failure must NOT silently shrink the population back to
+    # owner-only and read as normal, so it is reported and counted.
+    discovered = _fetch_discovered(args.repo)
+    peers, peer_failures = [], 0
+    for number in peer_candidates(discovered, args.owner):
+        pr = _fetch_peer_pr(args.repo, number)
+        if pr:
+            peers.append(pr)
+        else:
+            peer_failures += 1
+    if discovered and not peers and peer_candidates(discovered, args.owner):
+        print("pr-flag: every peer fetch failed — peer half of the population is "
+              "MISSING from this emit, not empty", file=sys.stderr)
+    fetched = _attach_commits(args.repo, own + peers)
     state = raw_state(fetched, args.owner, args.stand)
     h = state_hash(state)
 
@@ -459,6 +582,10 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
         # fetched_count is the PRE-filter size: the ceiling applies to the fetch,
         # not to what survives raw_state(). See scope_descriptor().
         "scope": scope_descriptor(args.repo, args.owner, record_count=len(state),
+                                  peer_stage={"discovered": len(discovered),
+                                              "candidates": len(peer_candidates(discovered, args.owner)),
+                                              "fetched": len(peers),
+                                              "failed": peer_failures},
                                   fetched_count=len(fetched)),
         "prs": state,
     }, indent=2))

--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -372,24 +372,8 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
                 "absent from this payload but NOT known to be uninteresting"
             )
 
-    # complete==True is a CERTIFICATION, so it is only ever granted on evidence:
-    # a count strictly below the ceiling. Unknown count -> None, never True.
-    #
-    # The count compared against the ceiling must be the PRE-filter FETCHED count
-    # (@john-the-dev's second blocker on #2645). The ceiling applies to
-    # `_fetch_prs()`; `raw_state()` then drops drafts, so the emitted count is
-    # strictly smaller. Certifying off the emitted count means one dropped draft
-    # at a truncated fetch reads as complete:
-    #
-    #     fetched=1000 (== ceiling, truncated)  ->  emitted=999  ->  "below the
-    #     1000 ceiling"  ->  complete=True, on a population GitHub had cut off.
-    #
-    # Exactly the defect this descriptor exists to remove, reintroduced by
-    # measuring the wrong side of the filter. `record_count` stays in the payload
-    # as the emitted size — it is what the consumer actually received — but it
-    # never decides completeness.
-    # Two fetches, two ceilings: each stage must clear its OWN limit, since a
-    # combined count under the owner's hides discovery sitting at its own.
+    # Certify against the PRE-filter FETCHED count, per fetch: raw_state() drops
+    # drafts, so an emitted count can sit below a ceiling its own fetch hit.
     stages = [("owner fetch", fetched_count if fetched_count is not None
                else record_count, limit)]
     if peer_ok and peer_stage is not None:

--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -295,6 +295,31 @@ def peer_candidates(discovered: list, owner_login: str) -> list:
     return out
 
 
+def read_prior_mergeable(sf) -> dict:
+    """Prior mergeable map, fail-open. Inline, this swallowed only decode/OS
+    errors: valid JSON that is not an object reached .get and raised."""
+    if sf is None or not sf.exists():
+        return {}
+    try:
+        doc = json.loads(sf.read_text())
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+    if not isinstance(doc, dict):
+        return {}
+    got = doc.get("mergeable") or {}
+    return got if isinstance(got, dict) else {}
+
+
+def _argv_limit(argv: list):
+    """The `--limit` ceiling an argv carries, or None."""
+    if "--limit" not in argv:
+        return None
+    try:
+        return int(argv[argv.index("--limit") + 1])
+    except (IndexError, TypeError, ValueError):
+        return None
+
+
 def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
                      fetched_count: int = None, peer_stage: dict = None) -> dict:
     """Name the emitted population precisely, from the WHOLE pipeline.
@@ -327,11 +352,7 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
     """
     argv = fetch_argv(repo, owner_login)
     author = argv[argv.index("--author") + 1] if "--author" in argv else None
-    limit_s = argv[argv.index("--limit") + 1] if "--limit" in argv else None
-    try:
-        limit = int(limit_s) if limit_s is not None else None
-    except (TypeError, ValueError):
-        limit = None
+    limit = _argv_limit(argv)
 
     # A peer stage that could not run is NOT a widened population. Treat it as
     # owner-only so the payload never claims coverage it does not have.
@@ -380,17 +401,32 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
     # measuring the wrong side of the filter. `record_count` stays in the payload
     # as the emitted size — it is what the consumer actually received — but it
     # never decides completeness.
-    ceiling_count = fetched_count if fetched_count is not None else record_count
-    if ceiling_count is None or limit is None:
+    # TWO fetches, TWO ceilings. Comparing a combined count to the owner limit
+    # certifies neither: discovery can sit at its own ceiling while the sum stays
+    # under the owner's. Every stage that ran must clear its OWN limit.
+    stages = [("owner fetch", fetched_count if fetched_count is not None
+               else record_count, limit)]
+    if peer_ok and peer_stage is not None:
+        stages.append(("discovery", peer_stage.get("discovered"),
+                       _argv_limit(discovery_argv(repo))))
+
+    unknown = [n for n, c, l in stages if c is None or l is None]
+    at_ceiling = [(n, c, l) for n, c, l in stages
+                  if c is not None and l is not None and c >= l]
+    if unknown:
         complete = None
-        why = "fetched count or fetch ceiling unknown — completeness not certified"
-    elif ceiling_count >= limit:
+        why = (f"{', '.join(unknown)} count or ceiling unknown — completeness "
+               "not certified")
+    elif at_ceiling:
         complete = False
-        why = (f"fetch returned {ceiling_count} at a {limit} ceiling — complete "
-               "and truncated are indistinguishable here")
+        why = "; ".join(f"{n} returned {c} at a {l} ceiling — complete and "
+                        f"truncated are indistinguishable here"
+                        for n, c, l in at_ceiling)
     else:
         complete = True
-        why = f"fetch returned {ceiling_count}, below the {limit} ceiling"
+        why = "; ".join(f"{n} returned {c}, below the {l} ceiling"
+                        for n, c, l in stages)
+    ceiling_count = stages[0][1]
 
     if peer_stage and (not peer_ok or peer_stage.get("failed")
                        or not peer_stage.get("owner_ok", True)):
@@ -575,12 +611,7 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
             ws = ""
         sf = Path(ws) / "state" / "pr-flag-state.json" if ws else Path("state/pr-flag-state.json")
 
-    prior = {}
-    if sf is not None and sf.exists():
-        try:
-            prior = json.loads(sf.read_text()).get("mergeable", {}) or {}
-        except (json.JSONDecodeError, OSError):
-            prior = {}
+    prior = read_prior_mergeable(sf)
     state = carry_unknown_mergeable(state, prior)
     h = state_hash(state)
     # A population we could not certify must not overwrite the last good hash:
@@ -610,7 +641,9 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
                                               "failed": peer_failures,
                                               "discovery_ok": disc_ok,
                                               "owner_ok": own_ok},
-                                  fetched_count=len(fetched)),
+                                  # OWNER-stage size: the owner ceiling applies
+                                  # here. Discovery certifies its own, above.
+                                  fetched_count=len(own)),
         "prs": state,
     }, indent=2))
     try:

--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -202,8 +202,18 @@ def raw_state(prs: list, owner_login: str, stand: str = None) -> list:
     return out
 
 
+def _mergeable_key(row: dict) -> str:
+    """Cache key for a carried mergeable value.
+
+    Scoped to the REVISION, not the PR: a force-push or retarget parks the field
+    at UNKNOWN, and a number-only key would attach the old revision's MERGEABLE
+    to the new one -- suppressing exactly the wake-up that re-evaluation needs.
+    """
+    return f"{row.get('number')}@{row.get('head') or ''}#{row.get('base') or ''}"
+
+
 def carry_unknown_mergeable(state: list, previous: dict) -> list:
-    """Replace UNKNOWN mergeable with the last value seen for that PR.
+    """Replace UNKNOWN mergeable with the last value seen for THIS revision.
 
     GitHub's lazy recomputation parks the field at UNKNOWN; carrying the previous
     value keeps that churn out of the hash while leaving a real
@@ -213,7 +223,9 @@ def carry_unknown_mergeable(state: list, previous: dict) -> list:
     for s in state:
         row = dict(s)
         if row.get("mergeable") == "UNKNOWN":
-            prior = (previous or {}).get(str(row.get("number")))
+            # A miss (new revision, or a pre-scoping number-keyed state file)
+            # leaves UNKNOWN in place -- the conservative direction.
+            prior = (previous or {}).get(_mergeable_key(row))
             if prior:
                 row["mergeable"] = prior
         out.append(row)
@@ -221,8 +233,8 @@ def carry_unknown_mergeable(state: list, previous: dict) -> list:
 
 
 def mergeable_map(state: list) -> dict:
-    """Per-PR mergeable, for the next run to carry forward."""
-    return {str(s.get("number")): s.get("mergeable") for s in state
+    """Per-REVISION mergeable, for the next run to carry forward."""
+    return {_mergeable_key(s): s.get("mergeable") for s in state
             if s.get("mergeable") and s.get("mergeable") != "UNKNOWN"}
 
 
@@ -624,7 +636,9 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
     except Exception:
         prev = ""
 
-    if h == prev and not args.force:
+    # `certified` gates the fast path: an uncertified run whose surviving rows
+    # happen to hash to the last healthy state would otherwise exit silently.
+    if h == prev and certified and not args.force:
         print("NO_CHANGE")
         return 0
 

--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -203,12 +203,8 @@ def raw_state(prs: list, owner_login: str, stand: str = None) -> list:
 
 
 def _mergeable_key(row: dict) -> str:
-    """Cache key for a carried mergeable value.
-
-    Scoped to the REVISION, not the PR: a force-push or retarget parks the field
-    at UNKNOWN, and a number-only key would attach the old revision's MERGEABLE
-    to the new one -- suppressing exactly the wake-up that re-evaluation needs.
-    """
+    """Revision-scoped key: a number-only one attaches the old head/base's
+    MERGEABLE to a new revision, suppressing the needed wake-up."""
     return f"{row.get('number')}@{row.get('head') or ''}#{row.get('base') or ''}"
 
 
@@ -223,8 +219,7 @@ def carry_unknown_mergeable(state: list, previous: dict) -> list:
     for s in state:
         row = dict(s)
         if row.get("mergeable") == "UNKNOWN":
-            # A miss (new revision, or a pre-scoping number-keyed state file)
-            # leaves UNKNOWN in place -- the conservative direction.
+            # A miss (new revision, or a legacy number-keyed file) keeps UNKNOWN.
             prior = (previous or {}).get(_mergeable_key(row))
             if prior:
                 row["mergeable"] = prior
@@ -413,9 +408,8 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
     # measuring the wrong side of the filter. `record_count` stays in the payload
     # as the emitted size — it is what the consumer actually received — but it
     # never decides completeness.
-    # TWO fetches, TWO ceilings. Comparing a combined count to the owner limit
-    # certifies neither: discovery can sit at its own ceiling while the sum stays
-    # under the owner's. Every stage that ran must clear its OWN limit.
+    # Two fetches, two ceilings: each stage must clear its OWN limit, since a
+    # combined count under the owner's hides discovery sitting at its own.
     stages = [("owner fetch", fetched_count if fetched_count is not None
                else record_count, limit)]
     if peer_ok and peer_stage is not None:
@@ -626,9 +620,19 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
     prior = read_prior_mergeable(sf)
     state = carry_unknown_mergeable(state, prior)
     h = state_hash(state)
-    # A population we could not certify must not overwrite the last good hash:
-    # doing so lets the next healthy fire read as NO_CHANGE and stay silent.
-    certified = own_ok and disc_ok and peer_failures == 0
+    # Fetch success is not completeness: a stage on its ceiling is truncated,
+    # and certifying it persists a partial hash the next such run reads as NO_CHANGE.
+    scope = scope_descriptor(args.repo, args.owner, record_count=len(state),
+                             peer_stage={"discovered": len(discovered),
+                                         "candidates": len(candidates),
+                                         "fetched": len(peers),
+                                         "failed": peer_failures,
+                                         "discovery_ok": disc_ok,
+                                         "owner_ok": own_ok},
+                             # OWNER-stage size: the owner ceiling applies here.
+                             fetched_count=len(own))
+    certified = (own_ok and disc_ok and peer_failures == 0
+                 and scope.get("complete") is True)
 
     prev = ""
     try:
@@ -636,8 +640,8 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
     except Exception:
         prev = ""
 
-    # `certified` gates the fast path: an uncertified run whose surviving rows
-    # happen to hash to the last healthy state would otherwise exit silently.
+    # Gated on `certified`: an uncertified or TRUNCATED run whose surviving rows
+    # hash to the last healthy state would otherwise exit silently.
     if h == prev and certified and not args.force:
         print("NO_CHANGE")
         return 0
@@ -646,18 +650,7 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
     print(json.dumps({
         "hash": h,
         "changed": True,
-        # fetched_count is the PRE-filter size: the ceiling applies to the fetch,
-        # not to what survives raw_state(). See scope_descriptor().
-        "scope": scope_descriptor(args.repo, args.owner, record_count=len(state),
-                                  peer_stage={"discovered": len(discovered),
-                                              "candidates": len(candidates),
-                                              "fetched": len(peers),
-                                              "failed": peer_failures,
-                                              "discovery_ok": disc_ok,
-                                              "owner_ok": own_ok},
-                                  # OWNER-stage size: the owner ceiling applies
-                                  # here. Discovery certifies its own, above.
-                                  fetched_count=len(own)),
+        "scope": scope,
         "prs": state,
     }, indent=2))
     try:
@@ -666,8 +659,9 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
             sf.write_text(json.dumps({"hash": h, "count": len(state),
                                       "mergeable": mergeable_map(state)}))
         else:
-            print("pr-flag: population uncertified — hash NOT recorded, so the "
-                  "next healthy fire still emits", file=sys.stderr)
+            print("pr-flag: population uncertified or truncated — hash NOT "
+                  "recorded, so the next healthy fire still emits",
+                  file=sys.stderr)
     except Exception as e:
         print(f"pr-flag: state write failed: {e}", file=sys.stderr)
     return 0

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -109,9 +109,8 @@ def _mergeable_churn_does_not_refire():
     assert pf.state_hash(base) == pf.state_hash(churn), "UNKNOWN churn must NOT move the hash"
     assert pf.mergeable_map(churn) == {key: "MERGEABLE"}, "carried value must persist for the next fire"
 
-    # The control the reviewer asked for: a real transition MUST wake the cron.
-    # The target branch advancing changes nothing else -- not head, base name, ci,
-    # reviews or approvals -- so this is the only carrier.
+    # A real transition MUST wake the cron; nothing else here changes, so
+    # mergeable is the only carrier.
     conflict = pf.carry_unknown_mergeable([dict(base[0], mergeable="CONFLICTING")], prior)
     assert pf.state_hash(base) != pf.state_hash(conflict), "CONFLICTING must move the hash"
     back = pf.carry_unknown_mergeable([dict(base[0], mergeable="MERGEABLE")],
@@ -619,10 +618,66 @@ def main() -> int:
     _prior_read_fails_open_on_any_shape()
     _no_change_gate_is_present_in_source()
     _uncertified_run_is_never_silent()
+    _a_truncated_population_is_never_certified()
     _mergeable_carry_is_revision_scoped()
     print("  ok  #2643 peer-scope + mergeable-churn cases")
     print("\nAll pr-flag core cases pass.")
     return 0
+
+
+def _a_truncated_population_is_never_certified():
+    """P1: a stage landing exactly on its ceiling is complete-looking but partial.
+
+    Two fires, production main(): the first must not persist, the second must
+    not read NO_CHANGE.
+    """
+    import contextlib
+    import io
+    import json
+    import pathlib as _pl
+    import tempfile
+
+    real_prs, real_disc, real_argv, real_dargv = (
+        pf._fetch_prs, pf._fetch_discovered, pf.fetch_argv, pf.discovery_argv)
+    try:
+        for stage in ("owner", "discovery"):
+            rows = [_pr(i, "sonichi") for i in range(1, 4)]
+            pf._fetch_prs = lambda *a, **k: (True, rows)
+            pf._fetch_discovered = lambda *a, **k: (True, [])
+            # Land the stage under test EXACTLY on its declared ceiling.
+            if stage == "owner":
+                pf.fetch_argv = lambda *a, **k: ["gh", "pr", "list", "--limit", "3"]
+                pf.discovery_argv = lambda *a, **k: ["gh", "pr", "list", "--limit", "900"]
+            else:
+                pf.fetch_argv = lambda *a, **k: ["gh", "pr", "list", "--limit", "900"]
+                pf.discovery_argv = lambda *a, **k: ["gh", "pr", "list", "--limit", "0"]
+            with tempfile.TemporaryDirectory() as td:
+                sf = _pl.Path(td) / "state.json"
+                outs = []
+                for _ in range(2):
+                    buf = io.StringIO()
+                    keep = sys.argv
+                    try:
+                        sys.argv = ["pr_flag.py", "--emit", "--repo", "o/r",
+                                    "--owner", "sonichi", "--state-file", str(sf)]
+                        with contextlib.redirect_stdout(buf):
+                            pf.main()
+                    except SystemExit:
+                        pass
+                    finally:
+                        sys.argv = keep
+                    outs.append(buf.getvalue().strip())
+                first, second = outs
+                if first.startswith("{"):
+                    assert json.loads(first)["scope"]["complete"] is not True, \
+                        f"{stage}: a ceiling-bound fetch reported complete"
+                assert second != "NO_CHANGE", \
+                    f"{stage}: the second truncated fire exited NO_CHANGE -- the " \
+                    "partial population was certified and persisted"
+    finally:
+        (pf._fetch_prs, pf._fetch_discovered,
+         pf.fetch_argv, pf.discovery_argv) = (real_prs, real_disc, real_argv, real_dargv)
+    print("  ok  a ceiling-truncated population is never certified or persisted")
 
 
 def _no_change_gate_is_present_in_source():
@@ -647,9 +702,8 @@ def _uncertified_run_is_never_silent():
     import pathlib
     real_prs, real_disc = pf._fetch_prs, pf._fetch_discovered
     try:
-        # Owner fetch survives and yields the same (empty) population as last
-        # run; discovery FAILS. The hash is therefore unchanged while the
-        # population is incomplete -- precisely the silent-outage case.
+        # Owner fetch survives with the same population; discovery FAILS. Hash
+        # unchanged while incomplete -- the silent-outage case.
         pf._fetch_prs = lambda *a, **k: (True, [])
         pf._fetch_discovered = lambda *a, **k: (False, [])
         h = pf.state_hash([])
@@ -706,5 +760,3 @@ def _mergeable_carry_is_revision_scoped():
 
 if __name__ == "__main__":
     sys.exit(main())
-
-

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -95,14 +95,60 @@ def _descriptor_tracks_the_widened_population():
 
 
 def _mergeable_churn_does_not_refire():
-    """GitHub parks mergeable at UNKNOWN while recomputing; that is not a change."""
+    """UNKNOWN churn must not refire; a REAL mergeability flip must."""
     base = [{"number": 1, "principal": "p", "base": "main", "head": "abc", "ci": "green",
              "mergeable": "MERGEABLE", "review": "APPROVED", "approvals": 2,
              "approvals_standing": 2}]
-    churn = [dict(base[0], mergeable="UNKNOWN")]
-    assert pf.state_hash(base) == pf.state_hash(churn), "a mergeable-only flip must NOT move the hash"
+    prior = pf.mergeable_map(base)
+    assert prior == {"1": "MERGEABLE"}, f"map should carry the known value, got {prior}"
+
+    # GitHub parks the field at UNKNOWN mid-recompute: carried forward, no refire.
+    churn = pf.carry_unknown_mergeable([dict(base[0], mergeable="UNKNOWN")], prior)
+    assert pf.state_hash(base) == pf.state_hash(churn), "UNKNOWN churn must NOT move the hash"
+    assert pf.mergeable_map(churn) == {"1": "MERGEABLE"}, "carried value must persist for the next fire"
+
+    # The control the reviewer asked for: a real transition MUST wake the cron.
+    # The target branch advancing changes nothing else -- not head, base name, ci,
+    # reviews or approvals -- so this is the only carrier.
+    conflict = pf.carry_unknown_mergeable([dict(base[0], mergeable="CONFLICTING")], prior)
+    assert pf.state_hash(base) != pf.state_hash(conflict), "CONFLICTING must move the hash"
+    back = pf.carry_unknown_mergeable([dict(base[0], mergeable="MERGEABLE")],
+                                      pf.mergeable_map(conflict))
+    assert pf.state_hash(conflict) != pf.state_hash(back), "recovering to MERGEABLE must move it too"
+
+    # With no prior (first ever fire) UNKNOWN cannot be carried and stays UNKNOWN.
+    fresh = pf.carry_unknown_mergeable([dict(base[0], mergeable="UNKNOWN")], {})
+    assert fresh[0]["mergeable"] == "UNKNOWN", "nothing to carry -> value is left alone"
+
     assert pf.state_hash(base) != pf.state_hash([dict(base[0], head="def")]), "a new head MUST still move the hash"
     assert pf.state_hash(base) != pf.state_hash([dict(base[0], approvals=1)]), "an approval change MUST still move the hash"
+
+
+def _failed_fetch_is_never_an_empty_population():
+    """A discovery outage must not be serialized as a widened, empty population."""
+    ok = {"discovered": 70, "candidates": 13, "fetched": 13, "failed": 0,
+          "discovery_ok": True, "owner_ok": True}
+    good = pf.scope_descriptor("o/r", "sonichi", record_count=3, fetched_count=3, peer_stage=ok)
+    assert "peer" in good["population"], "a healthy peer stage must claim the widened population"
+
+    dead = {"discovered": 0, "candidates": 0, "fetched": 0, "failed": 0,
+            "discovery_ok": False, "owner_ok": True}
+    bad = pf.scope_descriptor("o/r", "sonichi", record_count=3, fetched_count=3, peer_stage=dead)
+    assert any("not authored by" in e for e in bad["excludes"]), "a failed discovery must fall back to declaring owner-only"
+    assert any("UNKNOWN this fire" in e for e in bad["excludes"]), "the failure itself must be declared"
+    assert bad["complete"] is False, "an uncertified population must never certify complete"
+    assert "peer" not in bad["population"], "must not claim a peer half it could not fetch"
+
+    partial = {"discovered": 70, "candidates": 13, "fetched": 11, "failed": 2,
+               "discovery_ok": True, "owner_ok": True}
+    part = pf.scope_descriptor("o/r", "sonichi", record_count=3, fetched_count=3, peer_stage=partial)
+    assert part["complete"] is False, "partial peer fetch must not certify complete"
+
+    ownfail = {"discovered": 70, "candidates": 13, "fetched": 13, "failed": 0,
+               "discovery_ok": True, "owner_ok": False}
+    of = pf.scope_descriptor("o/r", "sonichi", record_count=3, fetched_count=3, peer_stage=ownfail)
+    assert any("owner-authored fetch FAILED" in e for e in of["excludes"]), "an owner fetch failure must be declared too"
+    assert of["complete"] is False, "owner fetch failure must not certify complete"
 
 
 def main() -> int:
@@ -531,6 +577,7 @@ def main() -> int:
     _discovery_is_light()
     _descriptor_tracks_the_widened_population()
     _mergeable_churn_does_not_refire()
+    _failed_fetch_is_never_an_empty_population()
     print("  ok  #2643 peer-scope + mergeable-churn cases")
     print("\nAll pr-flag core cases pass.")
     return 0

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Unit tests for the pure core of scripts/pr_flag.py.
+Unit tests for the pure core of scripts/pf.py.
 
 After the 2026-07-27 refactor (Chi: "are you using a script to do judgement that
 should be done by an agent?"), the script does ONLY mechanical state-gathering +
@@ -48,6 +48,61 @@ def _pr(number, author, review="", ci="green", mergeable="MERGEABLE", draft=Fals
             *extra_reviews,
         ],
     }
+
+
+# --- #2643: the peer half the owner-scoped fetch structurally cannot contain ---
+
+def _peer_cases():
+    disc = [
+        {"number": 1, "author": {"login": "sonichi"}, "isDraft": False, "reviewDecision": "APPROVED"},
+        {"number": 2, "author": {"login": "peer"}, "isDraft": False, "reviewDecision": "APPROVED"},
+        {"number": 3, "author": {"login": "peer"}, "isDraft": False, "reviewDecision": "CHANGES_REQUESTED"},
+        {"number": 4, "author": {"login": "peer"}, "isDraft": True, "reviewDecision": "APPROVED"},
+        {"number": 5, "author": {"login": "peer2"}, "isDraft": False, "reviewDecision": None},
+        {"number": 6, "author": {"login": "peer2"}, "isDraft": False, "reviewDecision": "REVIEW_REQUIRED"},
+    ]
+    got = pf.peer_candidates(disc, "sonichi")
+    # own PR excluded (stage 2 already has it); CR pruned; draft pruned;
+    # APPROVED kept -- that is the one an owner action may unblock.
+    assert got == [2, 5, 6], f"peer candidates should be [2,5,6], got {got}"
+    assert pf.peer_candidates([], "sonichi") == [], "no discovery -> no candidates, not a crash"
+    # An APPROVED-based filter is the scope that once reported 32 owner-needing
+    # PRs as 1. Assert we did not reintroduce it.
+    assert 2 in got, "an APPROVED peer PR must survive pruning"
+
+
+def _discovery_is_light():
+    """Stage 1 must omit the two fields that 504 repo-wide, or it IS stage 2."""
+    argv = pf.discovery_argv("o/r")
+    fields = argv[argv.index("--json") + 1]
+    assert "statusCheckRollup" not in fields, "discovery must not request statusCheckRollup"
+    assert "reviews" not in fields, "discovery must not request reviews"
+    assert "--author" not in argv, "discovery must NOT be author-scoped -- that is the point"
+
+
+def _descriptor_tracks_the_widened_population():
+    """Metadata must not claim peers are excluded once they are fetched."""
+    narrow = pf.scope_descriptor("o/r", "sonichi", record_count=3, fetched_count=3)
+    assert any("not authored by" in e for e in narrow["excludes"]), "author exclusion must still be declared without a peer stage"
+    stage = {"discovered": 70, "candidates": 13, "fetched": 13, "failed": 0}
+    wide = pf.scope_descriptor("o/r", "sonichi", record_count=3, fetched_count=3, peer_stage=stage)
+    assert not any("not authored by" in e for e in wide["excludes"]), "must not still claim peers are excluded once fetched"
+    assert any("CHANGES_REQUESTED" in e for e in wide["excludes"]), "the CR prune is a real exclusion and must be declared"
+    assert "peer" in wide["population"], "population string must name the peer half"
+    bad = {"discovered": 70, "candidates": 13, "fetched": 11, "failed": 2}
+    failed = pf.scope_descriptor("o/r", "sonichi", record_count=3, fetched_count=3, peer_stage=bad)
+    assert any("FAILED" in e for e in failed["excludes"]), "a failed peer fetch must be declared, not read as 'no peers'"
+
+
+def _mergeable_churn_does_not_refire():
+    """GitHub parks mergeable at UNKNOWN while recomputing; that is not a change."""
+    base = [{"number": 1, "principal": "p", "base": "main", "head": "abc", "ci": "green",
+             "mergeable": "MERGEABLE", "review": "APPROVED", "approvals": 2,
+             "approvals_standing": 2}]
+    churn = [dict(base[0], mergeable="UNKNOWN")]
+    assert pf.state_hash(base) == pf.state_hash(churn), "a mergeable-only flip must NOT move the hash"
+    assert pf.state_hash(base) != pf.state_hash([dict(base[0], head="def")]), "a new head MUST still move the hash"
+    assert pf.state_hash(base) != pf.state_hash([dict(base[0], approvals=1)]), "an approval change MUST still move the hash"
 
 
 def main() -> int:
@@ -472,9 +527,16 @@ def main() -> int:
     assert "--author" in argv and argv[argv.index("--author") + 1] == "someowner", argv
     print("  ok  fetch_argv is the real gh command the descriptor reads")
 
+    _peer_cases()
+    _discovery_is_light()
+    _descriptor_tracks_the_widened_population()
+    _mergeable_churn_does_not_refire()
+    print("  ok  #2643 peer-scope + mergeable-churn cases")
     print("\nAll pr-flag core cases pass.")
     return 0
 
 
 if __name__ == "__main__":
     sys.exit(main())
+
+

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -100,12 +100,14 @@ def _mergeable_churn_does_not_refire():
              "mergeable": "MERGEABLE", "review": "APPROVED", "approvals": 2,
              "approvals_standing": 2}]
     prior = pf.mergeable_map(base)
-    assert prior == {"1": "MERGEABLE"}, f"map should carry the known value, got {prior}"
+    key = pf._mergeable_key(base[0])
+    assert prior == {key: "MERGEABLE"}, f"map should carry the known value, got {prior}"
+    assert key != "1", "the key must be revision-scoped, not the bare PR number"
 
     # GitHub parks the field at UNKNOWN mid-recompute: carried forward, no refire.
     churn = pf.carry_unknown_mergeable([dict(base[0], mergeable="UNKNOWN")], prior)
     assert pf.state_hash(base) == pf.state_hash(churn), "UNKNOWN churn must NOT move the hash"
-    assert pf.mergeable_map(churn) == {"1": "MERGEABLE"}, "carried value must persist for the next fire"
+    assert pf.mergeable_map(churn) == {key: "MERGEABLE"}, "carried value must persist for the next fire"
 
     # The control the reviewer asked for: a real transition MUST wake the cron.
     # The target branch advancing changes nothing else -- not head, base name, ci,
@@ -615,9 +617,81 @@ def main() -> int:
     _failed_fetch_is_never_an_empty_population()
     _each_stage_certifies_its_own_ceiling()
     _prior_read_fails_open_on_any_shape()
+    _uncertified_run_is_never_silent()
+    _mergeable_carry_is_revision_scoped()
     print("  ok  #2643 peer-scope + mergeable-churn cases")
     print("\nAll pr-flag core cases pass.")
     return 0
+
+
+def _uncertified_run_is_never_silent():
+    """P1: a failed fetch whose survivors hash to the LAST HEALTHY state."""
+    src = (REPO / "scripts" / "pr_flag.py").read_text()
+    assert "if h == prev and certified and not args.force:" in src, \
+        "the NO_CHANGE fast path must be gated on `certified`"
+
+    import io
+    import json
+    import contextlib
+    import tempfile
+    import pathlib
+    real_prs, real_disc = pf._fetch_prs, pf._fetch_discovered
+    try:
+        # Owner fetch survives and yields the same (empty) population as last
+        # run; discovery FAILS. The hash is therefore unchanged while the
+        # population is incomplete -- precisely the silent-outage case.
+        pf._fetch_prs = lambda *a, **k: (True, [])
+        pf._fetch_discovered = lambda *a, **k: (False, [])
+        h = pf.state_hash([])
+        with tempfile.TemporaryDirectory() as td:
+            sf = pathlib.Path(td) / "state.json"
+            sf.write_text(json.dumps({"hash": h}))
+            argv = ["pr_flag.py", "--emit", "--repo", "o/r", "--owner", "o",
+                    "--state-file", str(sf)]
+            out = io.StringIO()
+            real_argv = sys.argv
+            try:
+                sys.argv = argv
+                with contextlib.redirect_stdout(out):
+                    pf.main()
+            except SystemExit:
+                pass
+            finally:
+                sys.argv = real_argv
+            printed = out.getvalue().strip()
+            assert printed != "NO_CHANGE", \
+                "an uncertified run exited NO_CHANGE -- the outage is invisible " \
+                "to the monitor and the population was never declared incomplete"
+    finally:
+        pf._fetch_prs, pf._fetch_discovered = real_prs, real_disc
+    print("  ok  an uncertified run never collapses to NO_CHANGE")
+
+
+def _mergeable_carry_is_revision_scoped():
+    """P1: UNKNOWN must not inherit a DIFFERENT revision's mergeability."""
+    prev = pf.mergeable_map(
+        [{"number": 7, "head": "aaa", "base": "main", "mergeable": "MERGEABLE"}])
+
+    same = pf.carry_unknown_mergeable(
+        [{"number": 7, "head": "aaa", "base": "main", "mergeable": "UNKNOWN"}], prev)
+    assert same[0]["mergeable"] == "MERGEABLE", same
+
+    forced = pf.carry_unknown_mergeable(
+        [{"number": 7, "head": "bbb", "base": "main", "mergeable": "UNKNOWN"}], prev)
+    assert forced[0]["mergeable"] == "UNKNOWN", \
+        "a force-pushed head inherited the old revision's MERGEABLE"
+
+    retargeted = pf.carry_unknown_mergeable(
+        [{"number": 7, "head": "aaa", "base": "release", "mergeable": "UNKNOWN"}], prev)
+    assert retargeted[0]["mergeable"] == "UNKNOWN", \
+        "a retargeted base inherited the old revision's MERGEABLE"
+
+    legacy = pf.carry_unknown_mergeable(
+        [{"number": 7, "head": "aaa", "base": "main", "mergeable": "UNKNOWN"}],
+        {"7": "MERGEABLE"})
+    assert legacy[0]["mergeable"] == "UNKNOWN", \
+        "a pre-scoping number-keyed state file must fail open, not carry"
+    print("  ok  carried mergeable is scoped to (number, head, base)")
 
 
 if __name__ == "__main__":

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -626,11 +626,8 @@ def main() -> int:
 
 
 def _a_truncated_population_is_never_certified():
-    """P1: a stage landing exactly on its ceiling is complete-looking but partial.
-
-    Two fires, production main(): the first must not persist, the second must
-    not read NO_CHANGE.
-    """
+    """P1: two fires through production main() -- a ceiling-bound stage must
+    neither persist its hash nor let the second fire read NO_CHANGE."""
     import contextlib
     import io
     import json
@@ -639,7 +636,11 @@ def _a_truncated_population_is_never_certified():
 
     real_prs, real_disc, real_argv, real_dargv = (
         pf._fetch_prs, pf._fetch_discovered, pf.fetch_argv, pf.discovery_argv)
+    real_stands = pf._gh_stands_page
     try:
+        # _attach_commits() is live under main(); without this seam the two-fire
+        # control makes real `gh api graphql` calls at 60s each.
+        pf._gh_stands_page = lambda *a, **k: (True, [], False, None)
         for stage in ("owner", "discovery"):
             rows = [_pr(i, "sonichi") for i in range(1, 4)]
             pf._fetch_prs = lambda *a, **k: (True, rows)
@@ -677,13 +678,13 @@ def _a_truncated_population_is_never_certified():
     finally:
         (pf._fetch_prs, pf._fetch_discovered,
          pf.fetch_argv, pf.discovery_argv) = (real_prs, real_disc, real_argv, real_dargv)
+        pf._gh_stands_page = real_stands
     print("  ok  a ceiling-truncated population is never certified or persisted")
 
 
 def _no_change_gate_is_present_in_source():
-    """Separate function ON PURPOSE: a source-text assert and a behavioural one
-    in the same body are a single assert -- whichever runs first, and the
-    source one is the weaker."""
+    """Separate ON PURPOSE: a source assert and a behavioural one in the same
+    body are one assert -- whichever runs first, and the source one is weaker."""
     src = (REPO / "scripts" / "pr_flag.py").read_text()
     assert "if h == prev and certified and not args.force:" in src, \
         "the NO_CHANGE fast path must be gated on `certified`"
@@ -692,9 +693,7 @@ def _no_change_gate_is_present_in_source():
 
 def _uncertified_run_is_never_silent():
     """P1: a failed fetch whose survivors hash to the LAST HEALTHY state.
-
-    Carries NO source-text assert, so it can fail on its own.
-    """
+    Carries NO source-text assert, so it can fail on its own."""
     import io
     import json
     import contextlib

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -151,6 +151,41 @@ def _failed_fetch_is_never_an_empty_population():
     assert of["complete"] is False, "owner fetch failure must not certify complete"
 
 
+def _each_stage_certifies_its_own_ceiling():
+    """Discovery at ITS ceiling must make the widened population incomplete,
+    even when the owner stage is far below the owner ceiling."""
+    d = pf.scope_descriptor("o/r", "o", record_count=100, fetched_count=110,
+                            peer_stage={"discovered": 1000, "candidates": 100,
+                                        "fetched": 100, "failed": 0,
+                                        "discovery_ok": True, "owner_ok": True})
+    assert d["complete"] is False, (
+        "discovery sat at its 1000 ceiling and the population was certified "
+        "complete — a combined count was compared to the owner limit")
+    assert "discovery" in d["complete_reason"], d["complete_reason"]
+    ok = pf.scope_descriptor("o/r", "o", record_count=20, fetched_count=25,
+                             peer_stage={"discovered": 40, "candidates": 5,
+                                         "fetched": 5, "failed": 0,
+                                         "discovery_ok": True, "owner_ok": True})
+    assert ok["complete"] is True, ok["complete_reason"]
+
+
+def _prior_read_fails_open_on_any_shape():
+    """Valid JSON that is not an object must not crash before the fail-open."""
+    import tempfile
+    import pathlib as _pl
+    for payload in ("[]", '"str"', "null", "123", "{ not json",
+                    '{"mergeable": [1, 2]}'):
+        with tempfile.TemporaryDirectory() as td:
+            sf = _pl.Path(td) / "s.json"
+            sf.write_text(payload)
+            assert pf.read_prior_mergeable(sf) == {}, payload
+    with tempfile.TemporaryDirectory() as td:
+        sf = _pl.Path(td) / "s.json"
+        sf.write_text('{"mergeable": {"1": "MERGEABLE"}}')
+        assert pf.read_prior_mergeable(sf) == {"1": "MERGEABLE"}
+    assert pf.read_prior_mergeable(None) == {}
+
+
 def main() -> int:
     OWNER = "sonichi"
 
@@ -578,6 +613,8 @@ def main() -> int:
     _descriptor_tracks_the_widened_population()
     _mergeable_churn_does_not_refire()
     _failed_fetch_is_never_an_empty_population()
+    _each_stage_certifies_its_own_ceiling()
+    _prior_read_fails_open_on_any_shape()
     print("  ok  #2643 peer-scope + mergeable-churn cases")
     print("\nAll pr-flag core cases pass.")
     return 0

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -617,6 +617,7 @@ def main() -> int:
     _failed_fetch_is_never_an_empty_population()
     _each_stage_certifies_its_own_ceiling()
     _prior_read_fails_open_on_any_shape()
+    _no_change_gate_is_present_in_source()
     _uncertified_run_is_never_silent()
     _mergeable_carry_is_revision_scoped()
     print("  ok  #2643 peer-scope + mergeable-churn cases")
@@ -624,12 +625,21 @@ def main() -> int:
     return 0
 
 
-def _uncertified_run_is_never_silent():
-    """P1: a failed fetch whose survivors hash to the LAST HEALTHY state."""
+def _no_change_gate_is_present_in_source():
+    """Separate function ON PURPOSE: a source-text assert and a behavioural one
+    in the same body are a single assert -- whichever runs first, and the
+    source one is the weaker."""
     src = (REPO / "scripts" / "pr_flag.py").read_text()
     assert "if h == prev and certified and not args.force:" in src, \
         "the NO_CHANGE fast path must be gated on `certified`"
+    print("  ok  the NO_CHANGE gate is present in source")
 
+
+def _uncertified_run_is_never_silent():
+    """P1: a failed fetch whose survivors hash to the LAST HEALTHY state.
+
+    Carries NO source-text assert, so it can fail on its own.
+    """
     import io
     import json
     import contextlib


### PR DESCRIPTION
Closes #2643.

## 1. The scope gap — and why the one-line fix does not work

The `pr-flag` cron prompt asks which PRs need the owner in **two** categories:

> his own truly ready to merge; **peer PRs where his approval unblocks a merge**

`scripts/pr_flag.py` fetches with `--author owner_login`, so the second category was never fetched and could not appear in any digest. The file's own SCOPE NOTE said so, and every digest I wrote restated it as a caveat rather than fixing it.

**Dropping `--author` is not the fix. Measured on this repo, 70 open non-draft PRs:**

```
--author sonichi + statusCheckRollup + reviews   ->  16 rows, 540 KB, 3.6s, rc=0
same fields, --author dropped                    ->  HTTP 504 after 11.2s
```

GitHub times out computing those fields repo-wide, so removing the flag **empties** the digest instead of widening it — and a fetch that fails every fire is worse than one that under-answers, because the failure is silent at the consumer.

### Two-stage instead

```
STAGE 1  discovery_argv() — light fields, no --author
         -> 78 rows, 20 KB, 1.44s

         non-draft            70
         owner-authored       14
         peer without a CR    13   <- the category the prompt names

STAGE 2  heavy fields for 27, not 70
```

Peers already carrying `CHANGES_REQUESTED` are their author's problem — the review must clear before any approval can matter — so they are pruned *before* the expensive call. That prune is what makes the widening affordable.

`peer_candidates()` deliberately does **not** prune on `APPROVED`. An approved peer PR is precisely the one whose merge may be one owner action away, and an APPROVED-based filter is the exact scope that once reported 32 owner-needing PRs as 1. Pinned by a test.

### Live evidence

```
before:  14 emitted (own only)
after :  27 emitted (14 own + 13 peer), rc=0

  #1889 bassilkhilo-ag2  APPROVED  ci=failing  appr=2
  #1973 john-the-dev     APPROVED  ci=green    appr=2
  #2874 john-the-dev     APPROVED  ci=green    appr=1   <- one approval short
```

`#2874` is the whole point: a peer PR one approval from its gate, structurally invisible to every digest before this change.

## 2. Spurious emits — `mergeable` in the change-hash

`state_hash()` included `mergeable`, which GitHub parks at `UNKNOWN` while recomputing lazily. Observed **2026-08-14 19:21Z**: all 13 rows flipped to `UNKNOWN` in the same second, the hash moved, and the cron emitted a digest whose composition was *identical* to the previous fire — waking the owner for GitHub's cache rather than his repo. Twelve PRs do not change state simultaneously; that signature is the tell.

Removed from the key **only**. It is still emitted for the agent to read — it is untrustworthy as a *change* signal, not as data. A real merge-state change is already carried by `head` (a push), `base` (a retarget), `ci`, `review`, or the approval fields, and tests pin that those still refire.

## Metadata honesty

`scope_descriptor()` derives from the real argv, so it follows the widened population automatically — and now declares what the *new* pruning drops (CR'd peers) plus any peer fetch that **FAILED**, so an absent peer can never read as "no peers". That property is the reason this file exists; widening the data path without widening the descriptor would have reintroduced the defect it was built to remove.

## Tests

All existing cases pass, plus four new groups: peer-candidate pruning (including the APPROVED-must-survive assertion), discovery-stays-light (asserts stage 1 omits the two 504-causing fields and is not author-scoped), descriptor-tracks-the-widened-population (including the failed-fetch declaration), and mergeable-churn-does-not-refire (with both positive controls — a new head and an approval change **must** still move the hash).
