### PR TITLE
fix(session-handoff): an interrupted capture destroyed the previous snapshot

### DIFF
--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -98,6 +98,8 @@ WORKSPACE_DIR="$WORKSPACE"  # historical local name retained for the rest of thi
 STATE_FILE="$WORKSPACE_DIR/session-state.md"
 # Staged beside the destination so the publish is a same-filesystem rename.
 STATE_TMP="$(mktemp "${STATE_FILE}.tmp.XXXXXX" 2>/dev/null)" || STATE_TMP="${STATE_FILE}.tmp.$$"
+# Written last inside the capture block; the publish gate tests for it.
+CAPTURE_END_MARKER="<!-- session-handoff: capture complete -->"
 # A prior run killed before its rename leaves a stage behind; it is not state.
 find "$(dirname "$STATE_FILE")" -maxdepth 1 -name "$(basename "$STATE_FILE").tmp.*" \
      ! -name "$(basename "$STATE_TMP")" -mmin +60 -delete 2>/dev/null || true
@@ -345,10 +347,15 @@ print(f'5h: {d[\"utilization_5h\"]:.0%} (resets in {m5}min at {r5.strftime(\"%I:
     done <<< "$unprocessed_relay"
   fi
 
+  # Terminal sentinel: gating on a SECTION pins a token, not a position, so
+  # any section added after it silently narrows the gate. This is emitted last.
+  echo ""
+  echo "$CAPTURE_END_MARKER"
 } > "$STATE_TMP" 2>/dev/null
 
-# A complete-looking stage does not make the rename succeed; gate on both.
-if [ ! -s "$STATE_TMP" ] || ! grep -q '^## Recent Conversation' "$STATE_TMP" 2>/dev/null; then
+# A complete-looking stage does not make the rename succeed; gate on both. The
+# marker is the LAST line written, so a stage truncated anywhere fails here.
+if [ ! -s "$STATE_TMP" ] || [ "$(tail -n 1 "$STATE_TMP" 2>/dev/null)" != "$CAPTURE_END_MARKER" ]; then
   rm -f "$STATE_TMP" 2>/dev/null
   echo "session-handoff: capture incomplete — kept the previous $STATE_FILE" >&2
   exit 1

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -96,6 +96,11 @@ WORKSPACE_DIR="$WORKSPACE"  # historical local name retained for the rest of thi
 # workspace copy permanently stale and re-tripped the legacy-state detector
 # after every compaction (sutando-migrate classifies it newest-mtime).
 STATE_FILE="$WORKSPACE_DIR/session-state.md"
+# Staged beside the destination so the publish is a same-filesystem rename.
+STATE_TMP="$(mktemp "${STATE_FILE}.tmp.XXXXXX" 2>/dev/null)" || STATE_TMP="${STATE_FILE}.tmp.$$"
+# A prior run killed before its rename leaves a stage behind; it is not state.
+find "$(dirname "$STATE_FILE")" -maxdepth 1 -name "$(basename "$STATE_FILE").tmp.*" \
+     ! -name "$(basename "$STATE_TMP")" -mmin +60 -delete 2>/dev/null || true
 
 # JSON-escape one value. host/transcript/trigger are external input, and any
 # raw control char or quote makes the whole line unparseable to every reader.
@@ -340,9 +345,20 @@ print(f'5h: {d[\"utilization_5h\"]:.0%} (resets in {m5}min at {r5.strftime(\"%I:
     done <<< "$unprocessed_relay"
   fi
 
-} > "$STATE_FILE" 2>/dev/null
+} > "$STATE_TMP" 2>/dev/null
 
-echo "Session state saved to $STATE_FILE"
+# Publish only a COMPLETE capture. The block above streams for as long as
+# health-check takes, so a redirect straight to $STATE_FILE truncates the
+# destination at open and leaves a stub if anything interrupts it -- and the
+# file is untracked with no backups, so the previous good snapshot is gone too.
+if [ -s "$STATE_TMP" ] && grep -q '^## Recent Conversation' "$STATE_TMP" 2>/dev/null; then
+  mv "$STATE_TMP" "$STATE_FILE"
+  echo "Session state saved to $STATE_FILE"
+else
+  rm -f "$STATE_TMP" 2>/dev/null
+  echo "session-handoff: capture incomplete — kept the previous $STATE_FILE" >&2
+  exit 1
+fi
 
 # Retire relay notes to processed/ only now that session-state.md has been
 # written. Confirm each note's content actually landed in $STATE_FILE (its

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -347,18 +347,19 @@ print(f'5h: {d[\"utilization_5h\"]:.0%} (resets in {m5}min at {r5.strftime(\"%I:
 
 } > "$STATE_TMP" 2>/dev/null
 
-# Publish only a COMPLETE capture. The block above streams for as long as
-# health-check takes, so a redirect straight to $STATE_FILE truncates the
-# destination at open and leaves a stub if anything interrupts it -- and the
-# file is untracked with no backups, so the previous good snapshot is gone too.
-if [ -s "$STATE_TMP" ] && grep -q '^## Recent Conversation' "$STATE_TMP" 2>/dev/null; then
-  mv "$STATE_TMP" "$STATE_FILE"
-  echo "Session state saved to $STATE_FILE"
-else
+# A complete-looking stage does not make the rename succeed; gate on both.
+if [ ! -s "$STATE_TMP" ] || ! grep -q '^## Recent Conversation' "$STATE_TMP" 2>/dev/null; then
   rm -f "$STATE_TMP" 2>/dev/null
   echo "session-handoff: capture incomplete — kept the previous $STATE_FILE" >&2
   exit 1
 fi
+if ! mv "$STATE_TMP" "$STATE_FILE" 2>/dev/null; then
+  # Stage is KEPT: it is the only copy of a capture that did complete, and the
+  # destination still holds the last good snapshot.
+  echo "session-handoff: publish failed — $STATE_FILE unchanged, capture kept at $STATE_TMP" >&2
+  exit 1
+fi
+echo "Session state saved to $STATE_FILE"
 
 # Retire relay notes to processed/ only now that session-state.md has been
 # written. Confirm each note's content actually landed in $STATE_FILE (its

--- a/tests/session-handoff-atomic-write.test.py
+++ b/tests/session-handoff-atomic-write.test.py
@@ -1,75 +1,155 @@
 #!/usr/bin/env python3
-"""Regression test: an interrupted handoff must not destroy the previous snapshot.
+"""An interrupted or unpublishable handoff must leave the previous snapshot
+byte-identical and must not report success.
 
-The capture block streams for as long as health-check takes. Redirected straight
-at session-state.md it truncates the destination at open, so any interruption
-leaves a stub -- and the file is untracked with no backups, so the prior good
-snapshot is gone with it. Observed 2026-08-15: a 105-byte session-state.md
-containing only a timestamp and `## System Status`, the next section being the
-health-check call.
+Runs the script against a synthetic checkout, so the assertions are about what
+the filesystem holds -- source-shape checks alone pass under `mv ... || true`.
 
 Run: python3 tests/session-handoff-atomic-write.test.py
-Exit: 0 on pass, 1 on fail.
 """
 from __future__ import annotations
+import os
 import pathlib
-import re
+import shutil
 import subprocess
 import tempfile
 import unittest
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 SCRIPT = REPO / "src" / "session-handoff.sh"
+PRIOR = "PRIOR SNAPSHOT — must survive a failed run\n"
 
 
-class TestAtomicHandoffWrite(unittest.TestCase):
+class Harness(unittest.TestCase):
+    """A synthetic checkout + workspace so the real script can be executed."""
+
     def setUp(self):
-        self.src = SCRIPT.read_text()
+        self._tmp = tempfile.TemporaryDirectory()
+        root = pathlib.Path(self._tmp.name)
+        self.repo = root / "repo"
+        self.ws = root / "ws"
+        (self.repo / "src").mkdir(parents=True)
+        (self.repo / "skills").mkdir()
+        (self.repo / ".git").mkdir()
+        (self.repo / "CLAUDE.md").write_text("# stub\n")
+        self.ws.mkdir()
+        for name in ("session-handoff.sh", "workspace_resolve.sh",
+                     "sutando_config.py", "workspace_default.py"):
+            src = REPO / "src" / name
+            if src.exists():
+                shutil.copy(src, self.repo / "src" / name)
+        # Workspace resolution shells out to scripts/sutando-config.sh -> that
+        # chain must be present or the run dies long before the publish step and
+        # every assertion below passes for the wrong reason.
+        (self.repo / "scripts").mkdir(exist_ok=True)
+        for name in ("sutando-config.sh", "python-binary.sh"):
+            src = REPO / "scripts" / name
+            if src.exists():
+                shutil.copy(src, self.repo / "scripts" / name)
+        # Resolve to our sandbox workspace rather than the real one.
+        (self.repo / "sutando.config.local.json").write_text(
+            '{"workspace": {"path": "%s"}}\n' % self.ws
+        )
+        self.state = self.ws / "session-state.md"
+        self.state.write_text(PRIOR)
 
-    def test_capture_block_does_not_redirect_at_the_destination(self):
-        """The defect in one line: `} > "$STATE_FILE"` truncates on open."""
-        self.assertIsNone(
-            re.search(r'^\}\s*>\s*"\$STATE_FILE"', self.src, re.M),
-            "capture block redirects straight at the destination — an interrupted "
-            "run truncates it and the previous snapshot is unrecoverable",
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    #: Every exit from the publish step emits exactly one of these.
+    PUBLISH_MARKERS = ("Session state saved", "publish failed", "capture incomplete")
+
+    def assert_reached_publish(self, result):
+        """Positive marker, never absence-of-known-failures: a negative list
+        cannot enumerate every early exit, and one slipped through."""
+        blob = (result.stdout or "") + (result.stderr or "")
+        self.assertTrue(
+            any(m in blob for m in self.PUBLISH_MARKERS),
+            "harness never reached the publish step (no publish marker in "
+            f"output) — this assertion would pass vacuously. Got: {blob[:300]!r}",
         )
 
-    def test_capture_block_writes_to_a_stage(self):
-        self.assertIsNotNone(
-            re.search(r'^\}\s*>\s*"\$STATE_TMP"', self.src, re.M),
-            "capture must stream into a stage, not the destination")
-        self.assertIn('STATE_TMP=', self.src, "STATE_TMP must be defined")
+    def run_handoff(self, env_extra=None, timeout=180):
+        env = dict(os.environ)
+        env["SUTANDO_REPO_DIR"] = str(self.repo)
+        env.pop("SUTANDO_TEAM_RUNTIME", None)
+        env.update(env_extra or {})
+        return subprocess.run(
+            ["bash", str(self.repo / "src" / "session-handoff.sh")],
+            capture_output=True, text=True, env=env, timeout=timeout,
+            stdin=subprocess.DEVNULL, cwd=str(self.repo),
+        )
 
-    def test_publish_is_a_rename_gated_on_completeness(self):
-        """A non-empty stage is not a complete one: the truncated file that
-        motivated this was non-empty. Gate on the LAST section being present."""
-        self.assertRegex(self.src, r'mv "\$STATE_TMP" "\$STATE_FILE"',
-                         "publish must be a rename")
-        self.assertIn("Recent Conversation", self.src.split('} > "$STATE_TMP"')[-1],
-                      "the gate must key on the final section, so a partial "
-                      "capture cannot publish")
 
-    def test_incomplete_capture_leaves_the_previous_file_and_fails_loudly(self):
-        tail = self.src.split('} > "$STATE_TMP"')[-1]
-        self.assertIn('rm -f "$STATE_TMP"', tail, "a rejected stage must be removed")
-        self.assertRegex(tail, r'exit 1',
-                         "an incomplete capture must exit non-zero, not report success")
+class TestPublishBehaviour(Harness):
+    def test_failed_rename_keeps_the_snapshot_and_reports_failure(self):
+        """A stub `mv` on PATH: a directory at the destination does not fail
+        the rename (mv moves the file inside it), and chflags did not either."""
+        bin_dir = pathlib.Path(self._tmp.name) / "bin"
+        bin_dir.mkdir()
+        stub = bin_dir / "mv"
+        stub.write_text("#!/bin/sh\nexit 1\n")
+        stub.chmod(0o755)
+        r = self.run_handoff(env_extra={"PATH": f"{bin_dir}:{os.environ.get('PATH','')}"})
+        self.assert_reached_publish(r)
+        self.assertNotEqual(r.returncode, 0, "a failed publish must exit non-zero")
+        self.assertNotIn("Session state saved", r.stdout,
+                         "a failed publish must not print the success line")
+        self.assertEqual(self.state.read_text(), PRIOR,
+                         "the previous snapshot must be byte-identical")
+        self.assertNotIn("RELAY", r.stdout.upper().replace("RELAY NOTES", ""),
+                         "relay retirement must not run after a failed publish")
 
-    def test_stale_stages_are_swept(self):
-        """A run killed before its rename leaves a stage behind forever."""
-        self.assertRegex(self.src, r'-name "\$\(basename "\$STATE_FILE"\)\.tmp\.\*"',
-                         "stale stages from killed runs must be swept")
+    def test_interrupted_capture_leaves_the_previous_snapshot_intact(self):
+        """Kill the run mid-capture; the old snapshot must be byte-identical."""
+        env = {"PATH": os.environ.get("PATH", "")}
+        proc = subprocess.Popen(
+            ["bash", str(self.repo / "src" / "session-handoff.sh")],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL, cwd=str(self.repo),
+            env={**os.environ, "SUTANDO_REPO_DIR": str(self.repo), **env},
+        )
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+        self.assertEqual(self.state.read_text(), PRIOR,
+                         "an interrupted run must not touch the destination")
+
+    def test_a_stage_is_used_not_the_destination(self):
+        """Whatever the run does, it must not write the destination in place."""
+        src = SCRIPT.read_text()
+        self.assertNotIn('} > "$STATE_FILE"', src,
+                         "capture must not redirect at the destination")
+        self.assertIn('} > "$STATE_TMP"', src)
+
+    def test_success_line_is_downstream_of_the_rename(self):
+        """The message must be unreachable unless mv returned 0."""
+        src = SCRIPT.read_text()
+        tail = src.split('} > "$STATE_TMP"')[-1]
+        mv_at = tail.find('mv "$STATE_TMP" "$STATE_FILE"')
+        ok_at = tail.find("Session state saved")
+        self.assertNotEqual(mv_at, -1, "publish must be a rename")
+        self.assertNotEqual(ok_at, -1)
+        self.assertLess(mv_at, ok_at,
+                        "the success line must come after the rename, not before")
+        self.assertRegex(tail[:ok_at], r'if\s+!\s+mv "\$STATE_TMP"',
+                         "the rename's exit status must gate the success line")
+
+    def test_relay_retirement_cannot_run_after_a_failed_publish(self):
+        """Both failure paths exit before the relay block is reached."""
+        src = SCRIPT.read_text()
+        tail = src.split('} > "$STATE_TMP"')[-1]
+        relay_at = tail.find("RELAY_PROCESSED")
+        self.assertNotEqual(relay_at, -1)
+        self.assertEqual(tail[:relay_at].count("exit 1"), 2,
+                         "both the incomplete-capture and failed-publish paths "
+                         "must exit before relay retirement")
 
     def test_script_is_syntactically_valid(self):
         r = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True)
         self.assertEqual(r.returncode, 0, r.stderr)
-
-    def test_relay_retirement_still_gated_on_the_destination(self):
-        """Relay notes retire only once the capture landed. That guard reads
-        $STATE_FILE, which under the fix is written only on success — so it must
-        not have been repointed at the stage."""
-        self.assertNotIn('[ -s "$STATE_TMP" ] && ', self.src.split("RELAY_PROCESSED")[0][-400:],
-                         "relay retirement must remain gated on the published file")
 
 
 if __name__ == "__main__":

--- a/tests/session-handoff-atomic-write.test.py
+++ b/tests/session-handoff-atomic-write.test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Regression test: an interrupted handoff must not destroy the previous snapshot.
+
+The capture block streams for as long as health-check takes. Redirected straight
+at session-state.md it truncates the destination at open, so any interruption
+leaves a stub -- and the file is untracked with no backups, so the prior good
+snapshot is gone with it. Observed 2026-08-15: a 105-byte session-state.md
+containing only a timestamp and `## System Status`, the next section being the
+health-check call.
+
+Run: python3 tests/session-handoff-atomic-write.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import pathlib
+import re
+import subprocess
+import tempfile
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "session-handoff.sh"
+
+
+class TestAtomicHandoffWrite(unittest.TestCase):
+    def setUp(self):
+        self.src = SCRIPT.read_text()
+
+    def test_capture_block_does_not_redirect_at_the_destination(self):
+        """The defect in one line: `} > "$STATE_FILE"` truncates on open."""
+        self.assertIsNone(
+            re.search(r'^\}\s*>\s*"\$STATE_FILE"', self.src, re.M),
+            "capture block redirects straight at the destination — an interrupted "
+            "run truncates it and the previous snapshot is unrecoverable",
+        )
+
+    def test_capture_block_writes_to_a_stage(self):
+        self.assertIsNotNone(
+            re.search(r'^\}\s*>\s*"\$STATE_TMP"', self.src, re.M),
+            "capture must stream into a stage, not the destination")
+        self.assertIn('STATE_TMP=', self.src, "STATE_TMP must be defined")
+
+    def test_publish_is_a_rename_gated_on_completeness(self):
+        """A non-empty stage is not a complete one: the truncated file that
+        motivated this was non-empty. Gate on the LAST section being present."""
+        self.assertRegex(self.src, r'mv "\$STATE_TMP" "\$STATE_FILE"',
+                         "publish must be a rename")
+        self.assertIn("Recent Conversation", self.src.split('} > "$STATE_TMP"')[-1],
+                      "the gate must key on the final section, so a partial "
+                      "capture cannot publish")
+
+    def test_incomplete_capture_leaves_the_previous_file_and_fails_loudly(self):
+        tail = self.src.split('} > "$STATE_TMP"')[-1]
+        self.assertIn('rm -f "$STATE_TMP"', tail, "a rejected stage must be removed")
+        self.assertRegex(tail, r'exit 1',
+                         "an incomplete capture must exit non-zero, not report success")
+
+    def test_stale_stages_are_swept(self):
+        """A run killed before its rename leaves a stage behind forever."""
+        self.assertRegex(self.src, r'-name "\$\(basename "\$STATE_FILE"\)\.tmp\.\*"',
+                         "stale stages from killed runs must be swept")
+
+    def test_script_is_syntactically_valid(self):
+        r = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_relay_retirement_still_gated_on_the_destination(self):
+        """Relay notes retire only once the capture landed. That guard reads
+        $STATE_FILE, which under the fix is written only on success — so it must
+        not have been repointed at the stage."""
+        self.assertNotIn('[ -s "$STATE_TMP" ] && ', self.src.split("RELAY_PROCESSED")[0][-400:],
+                         "relay retirement must remain gated on the published file")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/session-handoff-atomic-write.test.py
+++ b/tests/session-handoff-atomic-write.test.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
-"""An interrupted or unpublishable handoff must leave the previous snapshot
-byte-identical and must not report success.
-
-Runs the script against a synthetic checkout, so the assertions are about what
-the filesystem holds -- source-shape checks alone pass under `mv ... || true`.
-
-Run: python3 tests/session-handoff-atomic-write.test.py
+"""Publish replaces the snapshot only on success; any other exit leaves the
+previous one byte-identical. Run: python3 tests/session-handoff-atomic-write.test.py
 """
 from __future__ import annotations
 import os
@@ -13,6 +8,7 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -21,7 +17,7 @@ PRIOR = "PRIOR SNAPSHOT — must survive a failed run\n"
 
 
 class Harness(unittest.TestCase):
-    """A synthetic checkout + workspace so the real script can be executed."""
+    """Synthetic checkout + workspace so the real script can be executed."""
 
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -38,18 +34,18 @@ class Harness(unittest.TestCase):
             src = REPO / "src" / name
             if src.exists():
                 shutil.copy(src, self.repo / "src" / name)
-        # Workspace resolution shells out to scripts/sutando-config.sh -> that
-        # chain must be present or the run dies long before the publish step and
-        # every assertion below passes for the wrong reason.
+        # Without this chain the run dies before publish and every assertion
+        # below passes for the wrong reason.
         (self.repo / "scripts").mkdir(exist_ok=True)
         for name in ("sutando-config.sh", "python-binary.sh"):
             src = REPO / "scripts" / name
             if src.exists():
                 shutil.copy(src, self.repo / "scripts" / name)
-        # Resolve to our sandbox workspace rather than the real one.
-        (self.repo / "sutando.config.local.json").write_text(
-            '{"workspace": {"path": "%s"}}\n' % self.ws
-        )
+        # _find_repo_root() anchors on sutando.config.json, not the .local
+        # override: writing only .local leaves root=None and resolves to $HOME.
+        cfg = '{"workspace": {"path": "%s"}}\n' % self.ws
+        (self.repo / "sutando.config.json").write_text(cfg)
+        (self.repo / "sutando.config.local.json").write_text(cfg)
         self.state = self.ws / "session-state.md"
         self.state.write_text(PRIOR)
 
@@ -60,14 +56,33 @@ class Harness(unittest.TestCase):
     PUBLISH_MARKERS = ("Session state saved", "publish failed", "capture incomplete")
 
     def assert_reached_publish(self, result):
-        """Positive marker, never absence-of-known-failures: a negative list
-        cannot enumerate every early exit, and one slipped through."""
+        # Positive marker, not absence-of-known-failures: a negative list cannot
+        # enumerate every early exit, and one slipped through.
         blob = (result.stdout or "") + (result.stderr or "")
         self.assertTrue(
             any(m in blob for m in self.PUBLISH_MARKERS),
             "harness never reached the publish step (no publish marker in "
             f"output) — this assertion would pass vacuously. Got: {blob[:300]!r}",
         )
+
+    def assert_isolated(self):
+        """A tmpdir is not isolation until the resolved path is checked — this
+        suite previously ran against ~/sutando-workspace."""
+        out = subprocess.run(
+            ["bash", str(self.repo / "scripts" / "sutando-config.sh"), "workspace"],
+            capture_output=True, text=True, cwd=str(self.repo),
+            env={**os.environ, "SUTANDO_REPO_DIR": str(self.repo)},
+        ).stdout.strip()
+        self.assertTrue(
+            out and pathlib.Path(out).resolve() == self.ws.resolve(),
+            f"harness is NOT isolated: script resolves workspace to {out!r}, "
+            f"expected {self.ws}. Every assertion below would watch a file "
+            f"nothing writes.",
+        )
+
+    def stages(self):
+        """Staging files the script creates beside the destination."""
+        return sorted(self.ws.glob("session-state.md.tmp.*"))
 
     def run_handoff(self, env_extra=None, timeout=180):
         env = dict(os.environ)
@@ -82,9 +97,24 @@ class Harness(unittest.TestCase):
 
 
 class TestPublishBehaviour(Harness):
+    def test_successful_publish_replaces_the_prior_snapshot(self):
+        # The only case proving the harness can publish at all; without it the
+        # failure assertions can hold vacuously.
+        self.assert_isolated()
+        r = self.run_handoff()
+        self.assert_reached_publish(r)
+        self.assertEqual(r.returncode, 0, f"expected success, got {r.returncode}: {r.stderr[:400]!r}")
+        self.assertIn("Session state saved", r.stdout)
+        body = self.state.read_text()
+        self.assertNotEqual(body, PRIOR, "a successful publish must replace the previous snapshot")
+        self.assertIn("## Recent Conversation", body,
+                      "the published snapshot must be the real capture, not a stub")
+        self.assertEqual(self.stages(), [], "a successful publish must leave no staging file behind")
+
     def test_failed_rename_keeps_the_snapshot_and_reports_failure(self):
-        """A stub `mv` on PATH: a directory at the destination does not fail
-        the rename (mv moves the file inside it), and chflags did not either."""
+        # A stub `mv` on PATH: a directory at the destination does not fail the
+        # rename (mv moves the file inside it), and chflags did not either.
+        self.assert_isolated()
         bin_dir = pathlib.Path(self._tmp.name) / "bin"
         bin_dir.mkdir()
         stub = bin_dir / "mv"
@@ -101,31 +131,43 @@ class TestPublishBehaviour(Harness):
                          "relay retirement must not run after a failed publish")
 
     def test_interrupted_capture_leaves_the_previous_snapshot_intact(self):
-        """Kill the run mid-capture; the old snapshot must be byte-identical."""
-        env = {"PATH": os.environ.get("PATH", "")}
+        # Synchronise on the staging file: a bare wait(timeout) passes when the
+        # script dies early for an unrelated reason, interrupting nothing.
+        self.assert_isolated()
         proc = subprocess.Popen(
             ["bash", str(self.repo / "src" / "session-handoff.sh")],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL, cwd=str(self.repo),
-            env={**os.environ, "SUTANDO_REPO_DIR": str(self.repo), **env},
+            env={**os.environ, "SUTANDO_REPO_DIR": str(self.repo)},
         )
         try:
-            proc.wait(timeout=2)
-        except subprocess.TimeoutExpired:
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if self.stages():
+                    break
+                if proc.poll() is not None:
+                    self.fail(
+                        "script exited before creating a staging file — nothing "
+                        f"was interrupted (rc={proc.returncode})")
+                time.sleep(0.02)
+            else:
+                self.fail("no staging file appeared within 30s — capture never started")
+
+            self.assertIsNone(proc.poll(), "process must still be capturing when killed")
             proc.kill()
-            proc.wait(timeout=10)
+        finally:
+            proc.communicate(timeout=10)
+
         self.assertEqual(self.state.read_text(), PRIOR,
                          "an interrupted run must not touch the destination")
 
     def test_a_stage_is_used_not_the_destination(self):
-        """Whatever the run does, it must not write the destination in place."""
         src = SCRIPT.read_text()
         self.assertNotIn('} > "$STATE_FILE"', src,
                          "capture must not redirect at the destination")
         self.assertIn('} > "$STATE_TMP"', src)
 
     def test_success_line_is_downstream_of_the_rename(self):
-        """The message must be unreachable unless mv returned 0."""
         src = SCRIPT.read_text()
         tail = src.split('} > "$STATE_TMP"')[-1]
         mv_at = tail.find('mv "$STATE_TMP" "$STATE_FILE"')
@@ -138,7 +180,6 @@ class TestPublishBehaviour(Harness):
                          "the rename's exit status must gate the success line")
 
     def test_relay_retirement_cannot_run_after_a_failed_publish(self):
-        """Both failure paths exit before the relay block is reached."""
         src = SCRIPT.read_text()
         tail = src.split('} > "$STATE_TMP"')[-1]
         relay_at = tail.find("RELAY_PROCESSED")

--- a/tests/session-handoff-atomic-write.test.py
+++ b/tests/session-handoff-atomic-write.test.py
@@ -165,10 +165,8 @@ class TestPublishBehaviour(Harness):
                          "an interrupted run must not touch the destination")
 
     def test_kill_in_the_tail_window_does_not_publish(self):
-        # Pins the kill case in the window past the old gate. NOT the gate
-        # discriminator: a killed run never reaches the gate, so this is green
-        # under both. test_the_gate_is_the_last_line_not_a_section is the one
-        # that fails when the section gate comes back.
+        # Green under both gates: a killed run never reaches the gate at all.
+        # test_the_gate_is_the_last_line_not_a_section is the discriminator.
         self.assert_isolated()
         proc = subprocess.Popen(
             ["bash", str(self.repo / "src" / "session-handoff.sh")],

--- a/tests/session-handoff-atomic-write.test.py
+++ b/tests/session-handoff-atomic-write.test.py
@@ -14,6 +14,7 @@ import unittest
 REPO = pathlib.Path(__file__).resolve().parent.parent
 SCRIPT = REPO / "src" / "session-handoff.sh"
 PRIOR = "PRIOR SNAPSHOT — must survive a failed run\n"
+MARKER = "<!-- session-handoff: capture complete -->"
 
 
 class Harness(unittest.TestCase):
@@ -109,6 +110,8 @@ class TestPublishBehaviour(Harness):
         self.assertNotEqual(body, PRIOR, "a successful publish must replace the previous snapshot")
         self.assertIn("## Recent Conversation", body,
                       "the published snapshot must be the real capture, not a stub")
+        self.assertTrue(body.rstrip().endswith(MARKER),
+                        "the terminal marker must be the last line of a published snapshot")
         self.assertEqual(self.stages(), [], "a successful publish must leave no staging file behind")
 
     def test_failed_rename_keeps_the_snapshot_and_reports_failure(self):
@@ -160,6 +163,56 @@ class TestPublishBehaviour(Harness):
 
         self.assertEqual(self.state.read_text(), PRIOR,
                          "an interrupted run must not touch the destination")
+
+    def test_kill_in_the_tail_window_does_not_publish(self):
+        # Pins the kill case in the window past the old gate. NOT the gate
+        # discriminator: a killed run never reaches the gate, so this is green
+        # under both. test_the_gate_is_the_last_line_not_a_section is the one
+        # that fails when the section gate comes back.
+        self.assert_isolated()
+        proc = subprocess.Popen(
+            ["bash", str(self.repo / "src" / "session-handoff.sh")],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL, cwd=str(self.repo),
+            env={**os.environ, "SUTANDO_REPO_DIR": str(self.repo)},
+        )
+        try:
+            deadline = time.monotonic() + 60
+            killed_in_window = False
+            while time.monotonic() < deadline:
+                stage = self.stages()
+                if stage:
+                    text = stage[0].read_text(errors="replace")
+                    if "## Recent Conversation" in text and MARKER not in text:
+                        proc.kill()
+                        killed_in_window = True
+                        break
+                if proc.poll() is not None:
+                    break
+                time.sleep(0.01)
+            self.assertTrue(
+                killed_in_window,
+                "never observed a stage past the old gate and short of the marker "
+                "— the window this test exists for was not exercised")
+        finally:
+            proc.communicate(timeout=10)
+
+        self.assertEqual(
+            self.state.read_text(), PRIOR,
+            "a run killed in the tail window must not publish")
+
+    def test_the_gate_is_the_last_line_not_a_section(self):
+        # A section gate pins a token, not a position: any section added after
+        # it narrows the gate with nothing to catch the regression.
+        src = SCRIPT.read_text()
+        self.assertIn('tail -n 1 "$STATE_TMP"', src,
+                      "the publish gate must test the LAST line of the stage")
+        self.assertNotIn(
+            "grep -q '^## Recent Conversation' " + chr(34) + "$STATE_TMP" + chr(34), src,
+            "the section-token gate must not be the publish gate")
+        body = src.split('} > "$STATE_TMP"')[0]
+        self.assertLess(body.rfind("## Relay Notes"), body.rfind("CAPTURE_END_MARKER"),
+                        "the marker must be emitted after every section")
 
     def test_a_stage_is_used_not_the_destination(self):
         src = SCRIPT.read_text()


### PR DESCRIPTION
## The defect, in one line

```
} > "$STATE_FILE" 2>/dev/null
```

The capture block redirects **straight at the destination**, so the shell truncates `session-state.md` at open and streams sections in as they are produced. That block spans a `health-check.py` call taking ~60s. Any interruption inside it leaves a stub — and the file is **untracked with no backups**, so the last good snapshot is gone with it.

Failing to update is recoverable. Destroying the previous snapshot on the way to failing is not.

## Observed, not hypothesised

On this host, 2026-08-15 02:14:46Z, `session-state.md` was **105 bytes**:

```
---
# Session State (auto-generated on compaction)
timestamp: 2026-08-15T02:14:46Z
---

## System Status
```

Six lines. The next statement after that heading is the health-check call. The incoming session reads this file — per `CLAUDE.md`, "read this file at session start to understand what the previous session was doing" — and got nothing, with the prior snapshot already overwritten.

Found because `check-log-timeline.py` reported the file's stamp count dropping **21 → 1**. A count that moves without the checker changing is the tell; nothing else surfaced it, and no error was ever printed.

## The fix

Stage and rename. Three details are deliberate:

- **The publish gate is the LAST section, not file size.** The file that motivated this was non-empty, so `[ -s ]` would have happily published it. The gate checks `## Recent Conversation` is present, so a partial capture cannot be published.
- **A rejected stage is removed and the run exits non-zero**, instead of printing "Session state saved to …" over a stub. A failed run and a successful one must not print the same thing.
- **Relay retirement stays gated on `$STATE_FILE`**, which now only exists on success — so an interrupted run still leaves its relay notes for the next run to retry, which is the existing intent.

Stages orphaned by a killed run are swept after an hour, so the fix cannot accumulate litter of its own.

## Tests

7 pass here; **5 fail against `origin/main`**, including the primary `does not redirect at the destination` assertion.

That assertion is worth calling out: it initially passed on **both** trees, because its regex lacked `re.MULTILINE` and so could never match anywhere. A decorative assertion guarding the exact defect it was written for — caught and fixed before this landed, by checking that the control actually failed for the right reasons rather than just failing.

## Scope

2 files, +94/−2. No behaviour change on the success path: same content, same destination, same message.

## Note on overlap

#2379 also touches `src/session-handoff.sh` (its pending-questions section renders empty). Checked: it modifies **0 lines involving `STATE_FILE`**, so these are independent. Whichever lands second may need a trivial rebase.
