### PR TITLE
fix(dedup): a delivered-but-unarchived holder read as "never delivered"

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/dedup_recovery.py
+++ b/packages/ag2-sparrow/ag2_sparrow/dedup_recovery.py
@@ -16,7 +16,7 @@ from pathlib import Path
 # This file is bundled verbatim into ag2_sparrow, where its siblings are
 # package submodules; in src/ they are flat modules. Support both.
 try:  # pragma: no cover - exercised by whichever context imports it
-    from .local_task_protocol import find_archived_result
+    from .local_task_protocol import find_result
     from .result_markers import (
         build_requeued_task,
         dedup_decision,
@@ -24,7 +24,7 @@ try:  # pragma: no cover - exercised by whichever context imports it
     )
     from .task_archive import find_task_file
 except ImportError:  # pragma: no cover - flat src/ import path
-    from local_task_protocol import find_archived_result
+    from local_task_protocol import find_result
     from result_markers import (
         build_requeued_task,
         dedup_decision,
@@ -73,7 +73,7 @@ def plan_dedup_recovery(
     """
     holder = (holder_id or "").strip()
     orig_text = _read(find_task_file(Path(tasks_dir), task_id))
-    holder_text = _read(find_archived_result(Path(results_dir), holder)) if holder else None
+    holder_text = _read(find_result(Path(results_dir), holder)) if holder else None
 
     decision = dedup_decision(holder_text, orig_text)
     if decision == "honour":

--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -520,6 +520,20 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
     return flat[-1] if flat else None
 
 
+def find_result(results_dir: Path, task_id: str) -> Path | None:
+    """Locate a task's result wherever it currently is: live dir, then archive.
+
+    Archival trails delivery, so a result can be delivered and not yet moved;
+    an archive-only lookup reads that window as "never delivered".
+    """
+    if not valid_archive_lookup_id(task_id):
+        return None
+    live = Path(results_dir) / f"{task_id}.txt"
+    if live.is_file():
+        return live
+    return find_archived_result(results_dir, task_id)
+
+
 def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     """Locate a task file across the live dir, the legacy flat archive, and
     the month-partitioned archive — the same candidate set task-bridge's

--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -521,11 +521,8 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
 
 
 def find_result(results_dir: Path, task_id: str) -> Path | None:
-    """Locate a task's result wherever it currently is: live dir, then archive.
-
-    Archival trails delivery, so a result can be delivered and not yet moved;
-    an archive-only lookup reads that window as "never delivered".
-    """
+    """Locate a task's result: live dir first, then archive. Archival trails
+    delivery, so an archive-only lookup reads a fresh result as never delivered."""
     if not valid_archive_lookup_id(task_id):
         return None
     live = Path(results_dir) / f"{task_id}.txt"

--- a/src/dedup_recovery.py
+++ b/src/dedup_recovery.py
@@ -16,7 +16,7 @@ from pathlib import Path
 # This file is bundled verbatim into ag2_sparrow, where its siblings are
 # package submodules; in src/ they are flat modules. Support both.
 try:  # pragma: no cover - exercised by whichever context imports it
-    from .local_task_protocol import find_archived_result
+    from .local_task_protocol import find_result
     from .result_markers import (
         build_requeued_task,
         dedup_decision,
@@ -24,7 +24,7 @@ try:  # pragma: no cover - exercised by whichever context imports it
     )
     from .task_archive import find_task_file
 except ImportError:  # pragma: no cover - flat src/ import path
-    from local_task_protocol import find_archived_result
+    from local_task_protocol import find_result
     from result_markers import (
         build_requeued_task,
         dedup_decision,
@@ -73,7 +73,7 @@ def plan_dedup_recovery(
     """
     holder = (holder_id or "").strip()
     orig_text = _read(find_task_file(Path(tasks_dir), task_id))
-    holder_text = _read(find_archived_result(Path(results_dir), holder)) if holder else None
+    holder_text = _read(find_result(Path(results_dir), holder)) if holder else None
 
     decision = dedup_decision(holder_text, orig_text)
     if decision == "honour":

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -520,6 +520,20 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
     return flat[-1] if flat else None
 
 
+def find_result(results_dir: Path, task_id: str) -> Path | None:
+    """Locate a task's result wherever it currently is: live dir, then archive.
+
+    Archival trails delivery, so a result can be delivered and not yet moved;
+    an archive-only lookup reads that window as "never delivered".
+    """
+    if not valid_archive_lookup_id(task_id):
+        return None
+    live = Path(results_dir) / f"{task_id}.txt"
+    if live.is_file():
+        return live
+    return find_archived_result(results_dir, task_id)
+
+
 def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     """Locate a task file across the live dir, the legacy flat archive, and
     the month-partitioned archive — the same candidate set task-bridge's

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -521,11 +521,8 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
 
 
 def find_result(results_dir: Path, task_id: str) -> Path | None:
-    """Locate a task's result wherever it currently is: live dir, then archive.
-
-    Archival trails delivery, so a result can be delivered and not yet moved;
-    an archive-only lookup reads that window as "never delivered".
-    """
+    """Locate a task's result: live dir first, then archive. Archival trails
+    delivery, so an archive-only lookup reads a fresh result as never delivered."""
     if not valid_archive_lookup_id(task_id):
         return None
     live = Path(results_dir) / f"{task_id}.txt"

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -264,18 +264,15 @@ finish_handler_task() {
 
 handler_result_exists() {
   # Readiness is result_ready's contract (rejects whitespace-only too) and the
-  # archive lookup is local_task_protocol's; this must not re-decide either.
+  # live-then-archive lookup is local_task_protocol's; this must not re-decide either.
   local filename="$1" task_id="${filename%.txt}"
   [ -n "$SUTANDO_PY_BIN" ] || return 1
-  "$SUTANDO_PY_BIN" - "$__REPO_ROOT" "$RESULTS_DIR" "$task_id" "$filename" <<'PYEOF' 2>/dev/null
+  "$SUTANDO_PY_BIN" - "$__REPO_ROOT" "$RESULTS_DIR" "$task_id" <<'PYEOF' 2>/dev/null
 import pathlib, sys
 sys.path.insert(0, str(pathlib.Path(sys.argv[1]) / "src"))
-from local_task_protocol import find_archived_result
+from local_task_protocol import find_result
 from result_ready import read_ready_result
-results = pathlib.Path(sys.argv[2])
-if read_ready_result(results / sys.argv[4]) is not None:
-    raise SystemExit(0)
-found = find_archived_result(results, sys.argv[3])
+found = find_result(pathlib.Path(sys.argv[2]), sys.argv[3])
 raise SystemExit(0 if found is not None and read_ready_result(found) is not None else 1)
 PYEOF
 }

--- a/tests/dedup-recovery-plan.test.py
+++ b/tests/dedup-recovery-plan.test.py
@@ -80,12 +80,8 @@ class PlanTest(unittest.TestCase):
             self.assertIn("dedup_requeue_count: 1", body, "loop guard missing")
 
     def test_live_unarchived_holder_is_found(self):
-        """A holder that answered moments ago is still in results/, not archive/.
-
-        Archival trails delivery, so a same-pass dedup is decided while the
-        holder's result is live. Reading only archive/ calls that "never
-        delivered" and re-asks a question that was already answered.
-        """
+        """Archival trails delivery, so a same-pass dedup is decided while the
+        holder's result is still live in results/ rather than archive/."""
         with tempfile.TemporaryDirectory() as td:
             sp = _Space(td); sp.orig()
             (sp.results / f"{HOLDER}.txt").write_text("the full answer")
@@ -236,11 +232,8 @@ class DelegationTest(unittest.TestCase):
                 )
 
     def test_result_lookup_is_not_reimplemented(self):
-        """Live-then-archive is one policy with one owner.
-
-        An archive-only copy reads a delivered-but-not-yet-archived result as
-        "never delivered", which re-asks a question that was already answered.
-        """
+        """Live-then-archive is one policy: an archive-only copy reads a
+        delivered-but-unarchived result as never delivered."""
         for name, path in LOOKUP_CONSUMERS.items():
             with self.subTest(consumer=name):
                 src = path.read_text()

--- a/tests/dedup-recovery-plan.test.py
+++ b/tests/dedup-recovery-plan.test.py
@@ -30,6 +30,12 @@ CONSUMERS = {
 }
 
 
+LOOKUP_CONSUMERS = {
+    "dedup_recovery": REPO / "src" / "dedup_recovery.py",
+    "watch-tasks-stream": REPO / "src" / "watch-tasks-stream.sh",
+}
+
+
 class _Space:
     def __init__(self, td: str):
         self.results = Path(td) / "results"
@@ -72,6 +78,20 @@ class PlanTest(unittest.TestCase):
             self.assertIn("What is AG2Space?", body, "re-ask lost the question")
             self.assertIn("delivered nothing", body, "re-ask does not say why")
             self.assertIn("dedup_requeue_count: 1", body, "loop guard missing")
+
+    def test_live_unarchived_holder_is_found(self):
+        """A holder that answered moments ago is still in results/, not archive/.
+
+        Archival trails delivery, so a same-pass dedup is decided while the
+        holder's result is live. Reading only archive/ calls that "never
+        delivered" and re-asks a question that was already answered.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            sp = _Space(td); sp.orig()
+            (sp.results / f"{HOLDER}.txt").write_text("the full answer")
+            self.assertEqual(sp.plan(), ("honour", None))
+            self.assertFalse((sp.tasks / f"{NEW}.txt").exists(),
+                             "a holder that delivered must not be re-asked")
 
     def test_month_partitioned_holder_is_found(self):
         """The bridges archive as archive/<YYYY-MM>/<id>.txt, not flat."""
@@ -213,6 +233,24 @@ class DelegationTest(unittest.TestCase):
                 self.assertNotIn(
                     "dedup_decision(", src,
                     f"{name}: calls dedup_decision directly — the plan owns that",
+                )
+
+    def test_result_lookup_is_not_reimplemented(self):
+        """Live-then-archive is one policy with one owner.
+
+        An archive-only copy reads a delivered-but-not-yet-archived result as
+        "never delivered", which re-asks a question that was already answered.
+        """
+        for name, path in LOOKUP_CONSUMERS.items():
+            with self.subTest(consumer=name):
+                src = path.read_text()
+                self.assertIn(
+                    "find_result", src,
+                    f"{name}: must use local_task_protocol.find_result",
+                )
+                self.assertNotIn(
+                    "find_archived_result", src,
+                    f"{name}: archive-only lookup cannot see a live result",
                 )
 
     def test_sparrow_bundle_matches_src(self):


### PR DESCRIPTION
@sonichi flagging you — this is a live delivery-path defect that has already fired on a running host.

## The defect

`plan_dedup_recovery` resolves a `[deduped: task-X]` holder with `find_archived_result`, which searches **only** `results/archive/` (direct, then `<YYYY-MM>/`, then the flat glob). It never looks in the live `results/` dir.

Archival trails delivery. A dedup decided in the same pass as its holder therefore finds no archived file, `dedup_holder_delivered` returns False, and the task is re-queued under a new id — re-asking a question that was already answered in full.

`src/watch-tasks-stream.sh` already had the complete policy (live dir first, then archive). So this was **one policy in two places with one copy missing half** — the duplication is the defect, per CLAUDE.md.

## Evidence it fires in production

On a live host, `tasks/archive/` holds 1,799 files carrying a `source_message_id`; 6 message ids appear twice. Classifying each second delivery by the reason `build_requeued_task` renders:

```
deliberate re-queues (dedup_requeue_count: 1):  6
  by reason:  holder-empty 6   cross-channel 0
unexplained (gateway replay):                   0
```

Opening one — `task-1786600113856`, the holder for re-queue `task-1786600172395` — shows it had delivered a full prose reply. It was archived to `results/archive/2026-08/`, so the holder answered and the lookup still returned None at decision time.

Ruled out first: the monthly-archive gap. #2696 added that month scan on 2026-08-11; these re-queues are 08-12 and 08-13, so it was already fixed and does not explain them.

## Before / after — same tests, same command

Parent commit (`src/` reverted, new tests kept):

```
$ python3 tests/dedup-recovery-plan.test.py PlanTest.test_live_unarchived_holder_is_found
FAILED (failures=1)
  - ('requeue', 'task-newid00000001')
  + ('honour', None)

$ python3 tests/dedup-recovery-plan.test.py DelegationTest.test_result_lookup_is_not_reimplemented
FAILED (failures=2)
```

At HEAD:

```
$ python3 tests/dedup-recovery-plan.test.py
Ran 21 tests in 0.018s
OK
```

Both new tests fail in the broken state, so neither passes vacuously.

## The change

- `local_task_protocol.find_result(results_dir, task_id)` — new single owner: live dir, then archive. Applies the same `valid_archive_lookup_id` traversal gate.
- `dedup_recovery` and `watch-tasks-stream.sh` both call it; the watcher's hand-rolled live-check/archive-check pair collapses into one call.
- `find_archived_result` is unchanged and keeps its archive-only contract and name — callers that genuinely mean "archived" are unaffected.
- `DelegationTest.test_result_lookup_is_not_reimplemented` pins that neither consumer re-derives the split.
- ag2-sparrow bundle re-synced via `tools/sync_from_src.py` (its drift guard fails otherwise).

## What I did not verify

No post-restart round trip. The observable failure is filesystem-level and the production evidence above is the defect having already fired 6 times, which I judged stronger than a synthetic restart — but if you want the live round trip before merging, say so and I will record one.

Scope check: `find_archived_result` has exactly two non-test callers, both updated. #2505 (`tidy: centralize task archive policy`) is open and adjacent but touches neither symbol (0 matching lines in its diff).