### PR TITLE
fix(health-check): report how long the gateway has been down

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4906,10 +4906,15 @@ def check_gateway_bridge() -> "dict | None":
     # opinion, keep the previous process-only verdict.
     verdict = _gateway_serving()
     if verdict is False:
+        # WITHOUT the duration this line is byte-identical at minute one and at
+        # hour thirteen, so a reader cannot tell a blip from a standing outage.
+        age_h = _gateway_last_ok_age_h()
+        since = ("last successful poll UNKNOWN" if age_h is None
+                 else f"last successful poll {age_h:.1f}h ago")
         return {
             "name": "gateway-bridge",
             "status": "warn",
-            "detail": "process running but NOT serving — no successful poll; "
+            "detail": f"process running but NOT serving — {since}; "
                       "ag2.space mobile messages are not being delivered",
         }
     if verdict is True:
@@ -4918,6 +4923,23 @@ def check_gateway_bridge() -> "dict | None":
 
 
 GATEWAY_STATUS_MAX_AGE_S = 180.0
+
+
+def _gateway_last_ok_age_h(path: "Path | None" = None,
+                           now: "float | None" = None) -> "float | None":
+    """Hours since the bridge's last SUCCESSFUL poll, per the sidecar's
+    `last_ok_ts`. None when that field is absent or unusable — an outage of
+    unknown start is reported as unknown, never as a fresh one."""
+    import time as _time
+    p = path or (status_read_path("gateway-status.json", WORKSPACE_DIR))
+    now = _time.time() if now is None else now
+    try:
+        last = json.loads(Path(p).read_text()).get("last_ok_ts")
+    except (OSError, ValueError, AttributeError, TypeError):
+        return None
+    if not isinstance(last, (int, float)) or isinstance(last, bool):
+        return None
+    return max(0.0, (now - float(last)) / 3600.0)
 
 
 def _gateway_serving(path: "Path | None" = None, now: "float | None" = None) -> "bool | None":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4927,9 +4927,8 @@ GATEWAY_STATUS_MAX_AGE_S = 180.0
 
 def _gateway_last_ok_age_h(path: "Path | None" = None,
                            now: "float | None" = None) -> "float | None":
-    """Hours since the bridge's last SUCCESSFUL poll, per the sidecar's
-    `last_ok_ts`. None when that field is absent or unusable — an outage of
-    unknown start is reported as unknown, never as a fresh one."""
+    """Hours since the sidecar's `last_ok_ts`; None when it is absent or
+    unusable, so an unknown start is never reported as a fresh one."""
     import time as _time
     p = path or (status_read_path("gateway-status.json", WORKSPACE_DIR))
     now = _time.time() if now is None else now

--- a/tests/health-check-gateway-outage-duration.test.py
+++ b/tests/health-check-gateway-outage-duration.test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""The gateway warn line must carry HOW LONG the outage has run.
+
+Without it the line is byte-identical at minute one and hour thirteen, so a
+reader cannot tell a blip from a standing outage — and an alert that reads the
+same when ignored as when new is one nobody can act on.
+
+Run: python3 tests/health-check-gateway-outage-duration.test.py
+"""
+from __future__ import annotations
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+HC = _load()
+NOW = 1_800_000_000.0
+
+
+def _sidecar(tmp, **fields):
+    p = pathlib.Path(tmp) / "gateway-status.json"
+    p.write_text(json.dumps(fields))
+    return p
+
+
+class TestLastOkAge(unittest.TestCase):
+    def test_reports_hours_since_the_last_successful_poll(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = _sidecar(td, connected=False, ts=NOW, last_ok_ts=NOW - 48_600)
+            self.assertAlmostEqual(HC._gateway_last_ok_age_h(p, NOW), 13.5, places=2)
+
+    def test_a_missing_last_ok_ts_is_UNKNOWN_not_zero(self):
+        # Zero would read as "just now" — the most misleading possible default.
+        with tempfile.TemporaryDirectory() as td:
+            p = _sidecar(td, connected=False, ts=NOW)
+            self.assertIsNone(HC._gateway_last_ok_age_h(p, NOW))
+
+    def test_a_bool_is_not_a_timestamp(self):
+        # isinstance(True, int) is True in Python, so bools reach the arithmetic
+        # unless excluded explicitly.
+        with tempfile.TemporaryDirectory() as td:
+            p = _sidecar(td, connected=False, ts=NOW, last_ok_ts=True)
+            self.assertIsNone(HC._gateway_last_ok_age_h(p, NOW))
+
+    def test_a_future_last_ok_ts_clamps_to_zero_rather_than_going_negative(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = _sidecar(td, connected=False, ts=NOW, last_ok_ts=NOW + 10_000)
+            self.assertEqual(HC._gateway_last_ok_age_h(p, NOW), 0.0)
+
+    def test_an_absent_or_corrupt_sidecar_is_UNKNOWN(self):
+        with tempfile.TemporaryDirectory() as td:
+            missing = pathlib.Path(td) / "nope.json"
+            self.assertIsNone(HC._gateway_last_ok_age_h(missing, NOW))
+            bad = pathlib.Path(td) / "bad.json"
+            bad.write_text("{not json")
+            self.assertIsNone(HC._gateway_last_ok_age_h(bad, NOW))
+
+
+class TestWarnDetail(unittest.TestCase):
+    """The probe's own output, not just the helper."""
+
+    def _detail(self, age_h):
+        with mock.patch.object(HC, "_gateway_serving", return_value=False), \
+             mock.patch.object(HC, "_gateway_last_ok_age_h", return_value=age_h), \
+             mock.patch.object(HC, "_gateway_configured", return_value=True, create=True):
+            r = HC.check_gateway_bridge()
+        return r["detail"] if r else ""
+
+    def test_two_different_outage_lengths_produce_DIFFERENT_lines(self):
+        # The control. This is the whole point: if these two match, the fix is
+        # inert no matter what the other assertions say.
+        short, long = self._detail(0.1), self._detail(13.5)
+        if not short or not long:
+            self.skipTest("probe short-circuited before the warn branch")
+        self.assertNotEqual(short, long,
+                            "a 6-minute and a 13-hour outage produced identical text")
+        self.assertIn("0.1h", short)
+        self.assertIn("13.5h", long)
+
+    def test_an_unknown_start_says_so_rather_than_implying_freshness(self):
+        d = self._detail(None)
+        if not d:
+            self.skipTest("probe short-circuited before the warn branch")
+        self.assertIn("UNKNOWN", d)
+        self.assertNotIn("0.0h", d)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-gateway-outage-duration.test.py
+++ b/tests/health-check-gateway-outage-duration.test.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python3
 """The gateway warn line must carry HOW LONG the outage has run.
-
-Without it the line is byte-identical at minute one and hour thirteen, so a
-reader cannot tell a blip from a standing outage — and an alert that reads the
-same when ignored as when new is one nobody can act on.
-
-Run: python3 tests/health-check-gateway-outage-duration.test.py
-"""
+Run: python3 tests/health-check-gateway-outage-duration.test.py"""
 from __future__ import annotations
 import importlib.util
 import json
@@ -71,22 +65,34 @@ class TestLastOkAge(unittest.TestCase):
             self.assertIsNone(HC._gateway_last_ok_age_h(bad, NOW))
 
 
+class _Pgrep:
+    """One running bridge, so the probe reaches the serving check."""
+    returncode = 0
+    stdout = "4242\n"
+
+
 class TestWarnDetail(unittest.TestCase):
     """The probe's own output, not just the helper."""
 
     def _detail(self, age_h):
-        with mock.patch.object(HC, "_gateway_serving", return_value=False), \
-             mock.patch.object(HC, "_gateway_last_ok_age_h", return_value=age_h), \
-             mock.patch.object(HC, "_gateway_configured", return_value=True, create=True):
+        # Process discovery is mocked too: without it a checkout with no bridge
+        # running returns "configured but NOT running" and never reaches this.
+        with mock.patch.object(HC, "_gateway_configured", return_value=True, create=True), \
+             mock.patch.object(HC, "subprocess") as sp, \
+             mock.patch.object(HC, "_gateway_lock_pids", return_value={}, create=True), \
+             mock.patch.object(HC, "_gateway_serving", return_value=False), \
+             mock.patch.object(HC, "_gateway_last_ok_age_h", return_value=age_h):
+            sp.run.return_value = _Pgrep()
             r = HC.check_gateway_bridge()
-        return r["detail"] if r else ""
+        self.assertIsNotNone(r, "probe returned None — the warn branch was never reached")
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("NOT serving", r["detail"],
+                      f"probe short-circuited before the serving branch: {r['detail']!r}")
+        return r["detail"]
 
     def test_two_different_outage_lengths_produce_DIFFERENT_lines(self):
-        # The control. This is the whole point: if these two match, the fix is
-        # inert no matter what the other assertions say.
+        # The control: if these two match, the fix is inert whatever else passes.
         short, long = self._detail(0.1), self._detail(13.5)
-        if not short or not long:
-            self.skipTest("probe short-circuited before the warn branch")
         self.assertNotEqual(short, long,
                             "a 6-minute and a 13-hour outage produced identical text")
         self.assertIn("0.1h", short)
@@ -94,8 +100,6 @@ class TestWarnDetail(unittest.TestCase):
 
     def test_an_unknown_start_says_so_rather_than_implying_freshness(self):
         d = self._detail(None)
-        if not d:
-            self.skipTest("probe short-circuited before the warn branch")
         self.assertIn("UNKNOWN", d)
         self.assertNotIn("0.0h", d)
 


### PR DESCRIPTION
## What

`health-check.py`'s `gateway-bridge` warn line reported *that* the gateway was not serving but never *how long*, so it was byte-identical at minute one and at hour thirteen.

## Why it matters

An alert that reads the same when ignored as when new cannot be triaged. This host is currently 13.5h into a gateway outage and the line looked exactly as it did at the start.

## The correction behind it

I had previously written that this required a sidecar **schema** change — that the sidecar carried `ts` and `connected` but no last-success field. That was wrong. I asserted the schema from memory instead of opening the file. `last_ok_ts` has been there all along; the probe simply never read it. So this is a reporting change in the probe, and no writer changes.

## Evidence — live sidecar on this host, identical input both sides

```
{"connected": false, "ts": 1786787252, "last_ok_ts": 1786738602}

before (parent a8d0ac53)
  gateway-bridge  warn  process running but NOT serving — no successful poll; ag2.space mobile messages are not being delivered

after (this branch)
  gateway-bridge  warn  process running but NOT serving — last successful poll 13.5h ago; ag2.space mobile messages are not being delivered
```

## Control — the fix reverted, tests unchanged

```
AssertionError: '…no successful poll…' == '…no successful poll…'
  : a 6-minute and a 13-hour outage produced identical text
FAILED (failures=2)
```

The discriminating test asserts two different outage lengths produce *different* lines. That is the property the fix adds, and it fails in the broken state rather than only passing in the fixed one.

## Edge cases pinned

| input | reported |
|---|---|
| `last_ok_ts` absent | `UNKNOWN` — never `0.0h`, which would read as "just now" |
| `last_ok_ts: true` | `UNKNOWN` — `isinstance(True, int)` is True, so bools otherwise reach the arithmetic |
| `last_ok_ts` in the future | clamps to `0.0`, not negative |
| sidecar missing / corrupt | `UNKNOWN` |

## Scope

One probe branch plus a helper; no writer, no schema, no other probe touched. 7/7 new tests, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
