### PR TITLE
fix(tests): gateway fixtures isolate CLAUDE_CONFIG_DIR but not AG2_DEVICE_ENV

### DIFF
--- a/tests/gateway-channel-dir.test.py
+++ b/tests/gateway-channel-dir.test.py
@@ -47,7 +47,10 @@ def _load(env: dict, name: str):
 class TestChannelDir(unittest.TestCase):
     def test_default_is_ag2space(self):
         with tempfile.TemporaryDirectory() as cfg, _load(
-            {"CLAUDE_CONFIG_DIR": cfg, "REMOTE_TASK_TOKEN": "https://gw|s"},
+            # AG2_DEVICE_ENV outranks CLAUDE_CONFIG_DIR in _ag2space_access_path,
+            # so leaving it ambient points this at the operator's real install.
+            {"CLAUDE_CONFIG_DIR": cfg, "REMOTE_TASK_TOKEN": "https://gw|s",
+             "AG2_DEVICE_ENV": ""},
             "rgb_chandir_default",
         ) as mod:
             self.assertEqual(mod.CHANNEL_DIR, "ag2space")

--- a/tests/gateway-task-telemetry.test.py
+++ b/tests/gateway-task-telemetry.test.py
@@ -28,14 +28,16 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 
-# Isolate the channel config BEFORE the bridge import: _ag2space_access_path()
-# resolves under $CLAUDE_CONFIG_DIR (falling back to the real ~/.claude), and
-# _write_task() reads the tierMap from it at write time — without this, the
-# suite depends on the operator's REAL AG2 Space tier map (qingyun-wu CR on
-# #2432 round 2, P1-2: a controlled tierMap mapping the fixture sender to
-# "team" made the owner-activity assertion fail on an operator box).
+# Isolate the channel config BEFORE the bridge import: _write_task() reads the
+# tierMap from _ag2space_access_path() at write time — without this, the suite
+# depends on the operator's REAL AG2 Space tier map (qingyun-wu CR on #2432
+# round 2, P1-2: a controlled tierMap mapping the fixture sender to "team"
+# made the owner-activity assertion fail on an operator box).
 _CFG_ROOT = Path(tempfile.mkdtemp(prefix="rgb-telem-cfg-"))
+# AG2_DEVICE_ENV outranks CLAUDE_CONFIG_DIR in _ag2space_access_path, so setting
+# only the latter still resolves to the operator's install on a configured host.
 os.environ["CLAUDE_CONFIG_DIR"] = str(_CFG_ROOT)
+os.environ["AG2_DEVICE_ENV"] = ""
 _ACCESS = _CFG_ROOT / "channels" / "ag2space" / "access.json"
 _ACCESS.parent.mkdir(parents=True, exist_ok=True)
 _ACCESS.write_text('{"allowFrom": [], "tierMap": {}}')

--- a/tests/owner-activity-channel-id.test.py
+++ b/tests/owner-activity-channel-id.test.py
@@ -42,6 +42,9 @@ _TMP_HOME = tempfile.mkdtemp(prefix="owner-activity-test-home-")
 atexit.register(lambda: shutil.rmtree(_TMP_HOME, ignore_errors=True))
 os.environ["HOME"] = _TMP_HOME
 os.environ["CLAUDE_CONFIG_DIR"] = str(Path(_TMP_HOME) / ".claude")
+# AG2_DEVICE_ENV outranks CLAUDE_CONFIG_DIR in _ag2space_access_path; this suite
+# passes without it only while the operator's real map omits its fixture sender.
+os.environ["AG2_DEVICE_ENV"] = ""
 _ch_env = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord" / ".env"
 _ch_env.parent.mkdir(parents=True, exist_ok=True)
 _ch_env.write_text("DISCORD_BOT_TOKEN=test-token-not-real\n")


### PR DESCRIPTION
Closes #2919.

## The defect

`_ag2space_access_path()` (`remote_gateway_bridge.py`) resolves the per-sender tier map from **`AG2_DEVICE_ENV` first**, and only falls back to `CLAUDE_CONFIG_DIR`:

```python
device_env = os.environ.get("AG2_DEVICE_ENV")
config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
if device_env:   ...        # wins
elif config_dir: ...
```

Three gateway fixtures isolate the *second* variable and leave the first ambient. On any host with AG2 Space configured, they therefore read the operator's real `access.json` rather than the temp one they just wrote. The bridge says so itself, in a fixture that had set `CLAUDE_CONFIG_DIR` to a temp dir:

```
[remote-gateway-bridge] access tier map path:
  /Users/…/space.ag2.app/channels/ag2space/access.json      <-- the operator's install
```

## Why it matters more than a flaky fixture

The casualty is `gateway-task-telemetry`'s hostile-tier pair — the **P1-2 regression pin** added in #2432 round 2. It hands `_write_task` a broker-claimed `access_tier: owner` against a controlled map that down-tiers that sender to `team`, and asserts the write lands as `team`. With the fixture's map bypassed the sender is unmapped, `_tier_for` falls back to `LOCAL_TIER`, and the task is written `owner`.

It passes in CI, where `AG2_DEVICE_ENV` is unset. So the pin is green everywhere it is cheap to check and inert on exactly the hosts whose behaviour it describes.

**To be explicit: this is not a live authorization hole.** `_tier_for` implements the documented cap correctly — "the lower of broker-attested access and the local sender cap" — and it does consult the map. Only the fixture's map was the wrong one.

## Before / after — same commands, this host (`AG2_DEVICE_ENV` set)

Parent (`a8d0ac53`):

```
gateway-task-telemetry     2 FAILURE(S): ['hostile tier: task written with access_tier team',
                                          'hostile tier: owner-activity stamp suppressed for non-owner']
gateway-channel-dir        FAILED (failures=1)
```

At HEAD:

```
gateway-task-telemetry     All gateway task-telemetry checks passed.
gateway-channel-dir        OK
owner-activity-channel-id  OK
```

And with `AG2_DEVICE_ENV` unset — the CI condition, which must not regress — all three pass at HEAD too. The resolver now lands where the fixture put it:

```
[remote-gateway-bridge] access tier map path: /var/folders/…/T/tmp7qpohs8y/channels/ag2space/access.json
```

The isolating variable is what discriminates: at the parent, `env -u AG2_DEVICE_ENV python3 tests/gateway-task-telemetry.test.py` already passed while the plain invocation failed. That is the whole diagnosis in one command pair.

## The class, not the instance

`tests/gateway-channel-dir.test.py` already passed `"AG2_DEVICE_ENV": ""` in `test_override_moves_both_paths` and omitted it in `test_default_is_ag2space` — the knowledge was present and applied to one of two cases. I swept for the rest:

```
$ for f in $(grep -rl CLAUDE_CONFIG_DIR tests/*.py); do
    grep -q remote_gateway_bridge "$f" && ! grep -q AG2_DEVICE_ENV "$f" && echo "$f"; done
tests/owner-activity-channel-id.test.py        # before
(empty)                                        # after
```

`owner-activity-channel-id` passes today under both conditions — but only because the operator's real map happens not to contain its fixture sender. That is luck, not isolation, so it is pinned here rather than left for the next sweep to rediscover.

## Not in scope

`tests/remote-gateway-bridge.test.py` also fails on clean `main`, and it fails with `AG2_DEVICE_ENV` unset too — a different cause. Reported in #2919; deliberately untouched here.

Also unanswered, and worth someone's attention separately: if these files ran in CI, `main` would not be green. Either they are outside the CI selection — which would explain how a pin stayed inert — or the selection needs a look.

## Scope

Three test files, +15/-7. No production code, no behaviour change.

```
review-checks: PASS (hardcoded-paths + root-artifacts clean)
neighbours: gateway-per-sender-tier 30/30, gateway-owner-presence-peer-gate 6/6,
            gateway-access-path-resolution 10/10
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vgb1qDtz7gmqJ5BgypwiZ
