### PR TITLE
fix(discord-bridge): a thread-created notice became a task with a bare title

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2987,12 +2987,11 @@ async def _handle_discord_message(message, force=False):
             except Exception as e:
                 print(f"  [dm-checkpoint] self-message update failed: {e}", flush=True)
         return
-    # Discord authors these itself; a THREAD_CREATED notice carries the thread NAME
-    # as its content. Ahead of EVERY content consumer, the mod observer included —
-    # a bare thread title must not be judged or actioned. Checkpoint advances first
-    # for the same reason the self-message branch above advances it: the contract is
-    # "do not re-fetch", which is about having seen the message, not processing it.
+    # Ahead of EVERY content consumer, the mod observer included: a THREAD_CREATED
+    # notice carries the thread NAME as content and must not be judged or actioned.
     if getattr(message, "is_system", None) and message.is_system():
+        # Checkpoint first for the self-message branch's reason: "do not re-fetch"
+        # is about having SEEN the message, not about processing it.
         if isinstance(message.channel, discord.DMChannel) and hasattr(message, "id"):
             try:
                 _update_dm_checkpoint(message.channel.id, message.id)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2987,6 +2987,20 @@ async def _handle_discord_message(message, force=False):
             except Exception as e:
                 print(f"  [dm-checkpoint] self-message update failed: {e}", flush=True)
         return
+    # Discord authors these itself; a THREAD_CREATED notice carries the thread NAME
+    # as its content. Ahead of EVERY content consumer, the mod observer included —
+    # a bare thread title must not be judged or actioned. Checkpoint advances first
+    # for the same reason the self-message branch above advances it: the contract is
+    # "do not re-fetch", which is about having seen the message, not processing it.
+    if getattr(message, "is_system", None) and message.is_system():
+        if isinstance(message.channel, discord.DMChannel) and hasattr(message, "id"):
+            try:
+                _update_dm_checkpoint(message.channel.id, message.id)
+            except Exception as e:
+                print(f"  [dm-checkpoint] system-message update failed: {e}", flush=True)
+        print(f"  [skip] system message type={message.type}", flush=True)
+        return
+
     # Auto-mod LLM-judge observation hook (per-guild opt-in via access.json
     # `mod_active`). Pure observe — never blocks the rest of the function.
     # Action only fires from the periodic flush task, not at receive time.
@@ -3027,11 +3041,6 @@ async def _handle_discord_message(message, force=False):
     if hasattr(message, 'message_snapshots') and message.message_snapshots:
         safe_snapshots = filter_chat_secrets(str(message.message_snapshots)).text  # pragma: no cover
         print(f"  [debug] message_snapshots: {safe_snapshots}", flush=True)  # pragma: no cover
-    # Discord authors these itself; a THREAD_CREATED notice carries the thread NAME
-    # as its content, which became a task whose body was a bare title.
-    if getattr(message, "is_system", None) and message.is_system():
-        print(f"  [skip] system message type={message.type}", flush=True)
-        return
 
     # DMs: bot messages always require explicit @-mention (no channel config path).
     if is_dm and message.author.bot and client.user not in message.mentions:

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -3027,8 +3027,11 @@ async def _handle_discord_message(message, force=False):
     if hasattr(message, 'message_snapshots') and message.message_snapshots:
         safe_snapshots = filter_chat_secrets(str(message.message_snapshots)).text  # pragma: no cover
         print(f"  [debug] message_snapshots: {safe_snapshots}", flush=True)  # pragma: no cover
-    if message.type != discord.MessageType.default and message.type != discord.MessageType.reply:
-        print(f"  [debug] non-default message type: {message.type}", flush=True)
+    # Discord authors these itself; a THREAD_CREATED notice carries the thread NAME
+    # as its content, which became a task whose body was a bare title.
+    if getattr(message, "is_system", None) and message.is_system():
+        print(f"  [skip] system message type={message.type}", flush=True)
+        return
 
     # DMs: bot messages always require explicit @-mention (no channel config path).
     if is_dm and message.author.bot and client.user not in message.mentions:

--- a/tests/discord-bridge-system-messages-are-not-tasks.test.py
+++ b/tests/discord-bridge-system-messages-are-not-tasks.test.py
@@ -1,15 +1,6 @@
 #!/usr/bin/env python3
-"""A Discord-authored system message must not enter the task pipeline.
-
-Creating a thread posts a THREAD_CREATED notice in the parent channel whose
-`content` is the thread NAME and whose body is empty. The bridge logged the
-non-default type and kept going, so that notice became a task file whose whole
-body was a bare title. Observed 2026-08-15 as task-1786810290354.
-
-`Message.is_system()` is the library's own answer to "does this carry user
-content" — it deliberately keeps `thread_starter_message` and the slash-command
-types, which do. Enumerating types here instead would drift from that list.
-"""
+"""A Discord-authored system message must not reach ANY content consumer — the
+guard sits ahead of the mod observer, so a bare thread title is never judged."""
 from __future__ import annotations
 
 import asyncio
@@ -97,32 +88,50 @@ def _guild_message(system: bool, mtype=0, content="PR practice — runs, reflect
 
 
 def _run(msg):
-    """Drive on_message with the first post-guard call recorded."""
-    seen = []
-    orig = bridge._load_welcome_config
-    bridge._load_welcome_config = lambda gid: (seen.append(gid) or (None, None))
+    """Drive on_message, recording the mod observer and the first post-guard call.
+
+    Returns (observed, reached). `observed` is the moderation hook — the consumer
+    the guard used to sit BEHIND, which stores content/author/channel for later
+    judge and action dispatch.
+    """
+    observed, reached = [], []
+
+    async def _spy_observe(m):
+        observed.append(getattr(m, "id", None))
+
+    orig_obs, orig_wel = bridge._observe_for_mod, bridge._load_welcome_config
+    bridge._observe_for_mod = _spy_observe
+    bridge._load_welcome_config = lambda gid: (reached.append(gid) or (None, None))
     try:
         asyncio.run(bridge.on_message(msg))
     except Exception as exc:                      # a later gate may raise on a stub
-        seen.append(("raised", type(exc).__name__))
+        reached.append(("raised", type(exc).__name__))
     finally:
-        bridge._load_welcome_config = orig
-    return seen
+        bridge._observe_for_mod, bridge._load_welcome_config = orig_obs, orig_wel
+    return observed, reached
 
 
-# POSITIVE CONTROL FIRST. Without it, "nothing downstream ran" is satisfied by a
+# POSITIVE CONTROLS FIRST. Without them, "nothing downstream ran" is satisfied by a
 # harness that never reaches the guard at all.
-reached = _run(_guild_message(system=False))
+obs, reached = _run(_guild_message(system=False))
 check(bool(reached), "CONTROL: a non-system message reaches the code after the guard")
+check(bool(obs), "CONTROL: a non-system message DOES reach the moderation observer")
 
-blocked = _run(_guild_message(system=True))
+obs, blocked = _run(_guild_message(system=True))
 check(not blocked, "a system message stops at the guard")
+check(not obs, "a system message never reaches the moderation observer")
 
 # The real shape, against the library's own enum rather than a hand-written int.
 if HAVE_DISCORD:
     import discord as _real
-    real_notice = _guild_message(system=True, mtype=_real.MessageType.thread_created)
-    check(not _run(real_notice), "a real THREAD_CREATED notice stops at the guard")
+    obs, reached = _run(_guild_message(system=True, mtype=_real.MessageType.thread_created))
+    check(not reached, "a real THREAD_CREATED notice stops at the guard")
+    check(not obs, "a real THREAD_CREATED notice is never observed for moderation")
+
+    # thread_starter_message is the dangerous direction: it IS user content.
+    obs, reached = _run(_guild_message(system=False,
+                                       mtype=_real.MessageType.thread_starter_message))
+    check(bool(obs), "a thread_starter_message still reaches the moderation observer")
 
     # And the library must still treat the types that DO carry content as ours.
     check(not _real.Message.is_system(types.SimpleNamespace(

--- a/tests/discord-bridge-system-messages-are-not-tasks.test.py
+++ b/tests/discord-bridge-system-messages-are-not-tasks.test.py
@@ -103,12 +103,8 @@ def _dm_message(system: bool, mtype=0):
 
 
 def _run(msg, checkpoint_raises=False):
-    """Drive on_message, recording the mod observer and the first post-guard call.
-
-    Returns (observed, reached). `observed` is the moderation hook — the consumer
-    the guard used to sit BEHIND, which stores content/author/channel for later
-    judge and action dispatch.
-    """
+    """Drive on_message; returns (observed, reached).
+    `observed` is the moderation hook the guard used to sit BEHIND."""
     observed, reached = [], []
     checkpoints.clear()
 

--- a/tests/discord-bridge-system-messages-are-not-tasks.test.py
+++ b/tests/discord-bridge-system-messages-are-not-tasks.test.py
@@ -146,9 +146,8 @@ obs, blocked = _run(_guild_message(system=True))
 check(not blocked, "a system message stops at the guard")
 check(not obs, "a system message never reaches the moderation observer")
 
-# A system message in a DM must ALSO advance the checkpoint before returning. The
-# contract is "do not re-fetch", so a guard that returns without it re-creates the
-# frozen-checkpoint starvation path the self-message branch documents.
+# A system DM must ALSO advance the checkpoint: returning without it re-creates
+# the frozen-checkpoint starvation path the self-message branch documents.
 obs, reached = _run(_dm_message(system=True))
 check(not reached and not obs, "a system DM stops at the guard")
 check(len(checkpoints) == 1, f"a system DM still advances the checkpoint (got {len(checkpoints)})")

--- a/tests/discord-bridge-system-messages-are-not-tasks.test.py
+++ b/tests/discord-bridge-system-messages-are-not-tasks.test.py
@@ -54,6 +54,7 @@ def load_bridge():
 
 bridge = load_bridge()
 
+checkpoints = []
 pass_n = 0
 fail_n = 0
 
@@ -87,7 +88,21 @@ def _guild_message(system: bool, mtype=0, content="PR practice — runs, reflect
     )
 
 
-def _run(msg):
+class _FakeDM:
+    """isinstance target for the DM branch: the real DMChannel cannot be built here."""
+    def __init__(self, cid):
+        self.id = cid
+        self.name = "dm"
+
+
+def _dm_message(system: bool, mtype=0):
+    m = _guild_message(system=system, mtype=mtype)
+    m.guild = None
+    m.channel = _FakeDM(999000111222333444)
+    return m
+
+
+def _run(msg, checkpoint_raises=False):
     """Drive on_message, recording the mod observer and the first post-guard call.
 
     Returns (observed, reached). `observed` is the moderation hook — the consumer
@@ -95,19 +110,29 @@ def _run(msg):
     judge and action dispatch.
     """
     observed, reached = [], []
+    checkpoints.clear()
 
     async def _spy_observe(m):
         observed.append(getattr(m, "id", None))
 
     orig_obs, orig_wel = bridge._observe_for_mod, bridge._load_welcome_config
+    orig_ck, orig_dm = bridge._update_dm_checkpoint, bridge.discord.DMChannel
     bridge._observe_for_mod = _spy_observe
     bridge._load_welcome_config = lambda gid: (reached.append(gid) or (None, None))
+    def _spy_checkpoint(cid, mid):
+        checkpoints.append((cid, mid))
+        if checkpoint_raises:
+            raise OSError("checkpoint store unwritable")
+
+    bridge._update_dm_checkpoint = _spy_checkpoint
+    bridge.discord.DMChannel = _FakeDM
     try:
         asyncio.run(bridge.on_message(msg))
     except Exception as exc:                      # a later gate may raise on a stub
         reached.append(("raised", type(exc).__name__))
     finally:
         bridge._observe_for_mod, bridge._load_welcome_config = orig_obs, orig_wel
+        bridge._update_dm_checkpoint, bridge.discord.DMChannel = orig_ck, orig_dm
     return observed, reached
 
 
@@ -120,6 +145,24 @@ check(bool(obs), "CONTROL: a non-system message DOES reach the moderation observ
 obs, blocked = _run(_guild_message(system=True))
 check(not blocked, "a system message stops at the guard")
 check(not obs, "a system message never reaches the moderation observer")
+
+# A system message in a DM must ALSO advance the checkpoint before returning. The
+# contract is "do not re-fetch", so a guard that returns without it re-creates the
+# frozen-checkpoint starvation path the self-message branch documents.
+obs, reached = _run(_dm_message(system=True))
+check(not reached and not obs, "a system DM stops at the guard")
+check(len(checkpoints) == 1, f"a system DM still advances the checkpoint (got {len(checkpoints)})")
+
+obs, reached = _run(_dm_message(system=False))
+check(not checkpoints or checkpoints[-1][0] == 999000111222333444,
+      "CONTROL: the checkpoint spy is wired to the same channel id")
+
+# A failing checkpoint store must not break the drop: the guard exists to keep the
+# notice out of the pipeline, and that must not depend on a write succeeding.
+obs, reached = _run(_dm_message(system=True), checkpoint_raises=True)
+check(len(checkpoints) == 1, "the failing checkpoint write was actually attempted")
+check(not reached and not obs,
+      "a system DM is still dropped when the checkpoint write raises")
 
 # The real shape, against the library's own enum rather than a hand-written int.
 if HAVE_DISCORD:

--- a/tests/discord-bridge-system-messages-are-not-tasks.test.py
+++ b/tests/discord-bridge-system-messages-are-not-tasks.test.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""A Discord-authored system message must not enter the task pipeline.
+
+Creating a thread posts a THREAD_CREATED notice in the parent channel whose
+`content` is the thread NAME and whose body is empty. The bridge logged the
+non-default type and kept going, so that notice became a task file whose whole
+body was a bare title. Observed 2026-08-15 as task-1786810290354.
+
+`Message.is_system()` is the library's own answer to "does this carry user
+content" — it deliberately keeps `thread_starter_message` and the slash-command
+types, which do. Enumerating types here instead would drift from that list.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Isolate BEFORE importing the bridge: it resolves channel config at module scope.
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-sysmsg-")
+os.environ.pop("CLAUDE_HOME", None)
+os.environ["SUTANDO_TEST_MODE"] = "1"
+_cfg = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord"
+_cfg.mkdir(parents=True, exist_ok=True)
+(_cfg / ".env").write_text("DISCORD_BOT_TOKEN=test-stub-token\n", encoding="utf-8")
+(_cfg / "access.json").write_text('{"allowFrom": []}', encoding="utf-8")
+
+sys.path.insert(0, str(REPO / "src"))
+
+try:
+    import discord  # noqa: F401
+    HAVE_DISCORD = True
+except ImportError:  # pragma: no cover - depends on the runner's site-packages
+    HAVE_DISCORD = False
+    _d = types.ModuleType("discord")
+    _d.Intents = type("I", (), {"default": staticmethod(
+        lambda: type("X", (), {"message_content": False, "members": False})())})
+    _d.Client = type("C", (), {
+        "__init__": lambda self, **k: setattr(self, "user", None),
+        "event": staticmethod(lambda fn: fn)})
+    _d.File = type("F", (), {})
+    _d.Message = type("M", (), {})
+    _d.DMChannel = type("DM", (), {})
+    _d.AllowedMentions = type("AM", (), {"__init__": lambda self, **k: None})
+    _d.MessageType = types.SimpleNamespace(default=0, reply=19, thread_created=18)
+    sys.modules["discord"] = _d
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(compile(src, bridge.__file__, "exec"), bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+pass_n = 0
+fail_n = 0
+
+
+def check(ok, label):
+    global pass_n, fail_n
+    if ok:
+        print(f"  ok  {label}")
+        pass_n += 1
+    else:
+        print(f"  FAIL {label}")
+        fail_n += 1
+
+
+def _guild_message(system: bool, mtype=0, content="PR practice — runs, reflections, changes"):
+    """A channel message shaped like the real THREAD_CREATED notice."""
+    return types.SimpleNamespace(
+        id=1538218588937134170,
+        type=mtype,
+        content=content,
+        clean_content=content,
+        attachments=[],
+        embeds=[],
+        mentions=[],
+        reference=None,
+        guild=types.SimpleNamespace(id=1153072414184452236, name="Sutando-private"),
+        channel=types.SimpleNamespace(id=1490415515502383137, name="bot2bot"),
+        author=types.SimpleNamespace(id=1490412828065267872, bot=True,
+                                     name="Sutando-Mini", display_name="Sutando-Mini"),
+        is_system=lambda: system,
+    )
+
+
+def _run(msg):
+    """Drive on_message with the first post-guard call recorded."""
+    seen = []
+    orig = bridge._load_welcome_config
+    bridge._load_welcome_config = lambda gid: (seen.append(gid) or (None, None))
+    try:
+        asyncio.run(bridge.on_message(msg))
+    except Exception as exc:                      # a later gate may raise on a stub
+        seen.append(("raised", type(exc).__name__))
+    finally:
+        bridge._load_welcome_config = orig
+    return seen
+
+
+# POSITIVE CONTROL FIRST. Without it, "nothing downstream ran" is satisfied by a
+# harness that never reaches the guard at all.
+reached = _run(_guild_message(system=False))
+check(bool(reached), "CONTROL: a non-system message reaches the code after the guard")
+
+blocked = _run(_guild_message(system=True))
+check(not blocked, "a system message stops at the guard")
+
+# The real shape, against the library's own enum rather than a hand-written int.
+if HAVE_DISCORD:
+    import discord as _real
+    real_notice = _guild_message(system=True, mtype=_real.MessageType.thread_created)
+    check(not _run(real_notice), "a real THREAD_CREATED notice stops at the guard")
+
+    # And the library must still treat the types that DO carry content as ours.
+    check(not _real.Message.is_system(types.SimpleNamespace(
+        type=_real.MessageType.thread_starter_message)),
+        "PREMISE: thread_starter_message is NOT a system message (it carries the post)")
+    check(_real.Message.is_system(types.SimpleNamespace(
+        type=_real.MessageType.thread_created)),
+        "PREMISE: thread_created IS a system message")
+else:                                             # pragma: no cover
+    print("  skip real-enum cases (discord.py not installed)")
+
+print()
+if fail_n == 0:
+    print(f"PASS — {pass_n} checks green")
+else:
+    print(f"FAIL — {fail_n} failed, {pass_n} passed")
+sys.exit(1 if fail_n else 0)


### PR DESCRIPTION
## The bug, with the artifact

Creating a Discord thread posts a **system message in the parent channel** whose `content` is the thread NAME and whose body is empty. `on_message` logged the non-default type and kept going, so that notice entered the task pipeline.

Observed on a live bridge at 2026-08-15T16:11:30Z — the whole task body was a title:

```
id: task-1786810290354
channel_name: bot2bot
access_tier: team
task: [Discord @Sutando-Mini#2994] PR practice — runs, reflections, changes
```

Nothing after it. The consumer then has to decide what a request with no request means; in this instance the sandboxed path would have been handed a heading and asked to answer it.

## Before / after, at the parent commit and at HEAD

The shipped code only printed:

```python
if message.type != discord.MessageType.default and message.type != discord.MessageType.reply:
    print(f"  [debug] non-default message type: {message.type}", flush=True)
```

Now it returns. The gate is `Message.is_system()` rather than a type list, because that is the library's own answer to "does this carry user content" — and it deliberately keeps `thread_starter_message`, `chat_input_command`, `context_menu_command` and `poll_result`, all of which do. A hand-written enumeration here would drift from that list the next time discord.py adds a type; this cannot.

Forwarded messages are unaffected: they arrive as `default` with `message_snapshots`.

## Test, and the control

`tests/discord-bridge-system-messages-are-not-tasks.test.py` drives the real `on_message` (imported from the real module, not a copied block) and records whether the first call *after* the guard runs.

At HEAD:

```
  ok  CONTROL: a non-system message reaches the code after the guard
  ok  a system message stops at the guard
  ok  a real THREAD_CREATED notice stops at the guard
  ok  PREMISE: thread_starter_message is NOT a system message (it carries the post)
  ok  PREMISE: thread_created IS a system message
PASS — 5 checks green
```

Reverting `src/discord-bridge.py` to the parent commit's two lines, same test file:

```
  ok  CONTROL: a non-system message reaches the code after the guard
  FAIL a system message stops at the guard
  FAIL a real THREAD_CREATED notice stops at the guard
  ok  PREMISE: thread_starter_message is NOT a system message (it carries the post)
  ok  PREMISE: thread_created IS a system message
FAIL — 2 failed, 3 passed
```

The positive control and both premises still pass in the reverted run, so the two failures are the defect and not a broken harness. The premises assert against `discord.MessageType` itself, so if the library's classification changes they fail loudly rather than silently protecting the wrong set.

## Checks run locally at this head

```
tests/discord-bridge-system-messages-are-not-tasks.test.py   5/5
scripts/review-checks.sh                                     PASS
scripts/lint-hermetic-bridge-tests.py --diff                 ok
ruff check (both changed files)                              All checks passed!
```

## Scope

Discord only. One guard, one test. No behaviour change for `default` or `reply` messages, which is every message a human or bot actually writes.

**Live-path note:** this is a receive-path change, so the round trip that matters is a real thread creation on a live bridge producing no task file. I have the *before* half as a live artifact (the task ID above, from the running bridge). The *after* half needs a restart of the live bridge onto this head, which is queued for the owner with the other live-path items; I will attach it when that window opens rather than claim it now.

Stand: Echo Act IV Pro
