### PR TITLE
fix(tests): a failing git fixture must report git's reason, not just 128

### DIFF
--- a/tests/daily-insight-landed-under-squash.test.py
+++ b/tests/daily-insight-landed-under-squash.test.py
@@ -19,8 +19,14 @@ def _load():
 
 def _git(repo):
     def g(*a):
-        subprocess.run(["git", "-C", str(repo), *a], check=True,
-                       capture_output=True, text=True)
+        # check=True raises with the exit code only, so a failing fixture reports
+        # "returned non-zero exit status 128" and discards git's reason for it.
+        p = subprocess.run(["git", "-C", str(repo), *a], capture_output=True, text=True)
+        if p.returncode != 0:
+            raise AssertionError(
+                f"git {' '.join(a)} exited {p.returncode} in {repo}\n"
+                f"  stderr: {(p.stderr or '').strip() or '(empty)'}\n"
+                f"  stdout: {(p.stdout or '').strip() or '(empty)'}")
     return g
 
 
@@ -137,8 +143,11 @@ class TestLandedUnderSquash(unittest.TestCase):
             for i in range(30):
                 g("commit", "-q", "--allow-empty", "-m", f"c{i}")
             dst = pathlib.Path(td) / "shallow"
-            subprocess.run(["git", "clone", "-q", "--depth", "1",
-                            f"file://{src}", str(dst)], check=True, capture_output=True)
+            c = subprocess.run(["git", "clone", "-q", "--depth", "1",
+                                f"file://{src}", str(dst)], capture_output=True, text=True)
+            if c.returncode != 0:
+                raise AssertionError(f"git clone exited {c.returncode}\n"
+                                     f"  stderr: {(c.stderr or '').strip() or '(empty)'}")
             d = _git(dst)
             d("config", "user.email", "t@example.com")
             d("config", "user.name", "t")


### PR DESCRIPTION
## The problem, with both occurrences

`tests/daily-insight-landed-under-squash.test.py` fails intermittently on CI, and when it does the report is unusable:

```
2026-08-15T17:12:35Z  python: 498 file(s) ran, failed: tests/daily-insight-landed-under-squash.test.py

  File "tests/daily-insight-landed-under-squash.test.py", line 37, in _repo
    g("commit", "-q", "--allow-empty", "-m", f"c{i}")
subprocess.CalledProcessError: Command '['git', '-C', '/tmp/tmpiaz9fp85/r', 'commit',
  '-q', '--allow-empty', '-m', 'c22']' returned non-zero exit status 128.
```

Twice today on two unrelated branches (#1686 at 15:31Z, #2927 at 17:06Z), both cleared by a rerun. Exit 128 covers a dozen distinct git failures — identity unresolved, index lock held, repo vanished, disk — and `check=True` raises with the code only, so git's one-line explanation is captured into `CalledProcessError.stderr` and never printed. Each occurrence therefore costs a rerun and produces no information, which is why the fixture already carries a comment about a *previous* round of CI fragility ("30 rapid write+add+commit cycles proved fragile on CI") that was worked around rather than diagnosed.

**This PR does not fix the flake.** I could not reproduce it — 3/3 pass on clean `origin/main` locally at ~14.6s per run — and I am not going to guess at a cause and call it fixed. It makes the next occurrence diagnosable.

## The change

Both git call sites in the file now raise with git's own output. Two sites: the shared `_git()` helper and the one direct `git clone`.

## Before / after on the same forced failure

Running each helper against a directory that is not a git repo:

```
NEW helper
  git commit -q --allow-empty -m c0 exited 128 in /var/folders/.../tmp8_ls5fol
    stderr: fatal: not a git repository (or any of the parent directories): .git
    stdout: (empty)

OLD helper (check=True)
  Command '['git', '-C', '/var/folders/.../tmpnwmdi8sk', 'commit', '-q',
    '--allow-empty', '-m', 'c0']' returned non-zero exit status 128.
```

Same failure, same exit code. One names the cause; the other is what CI has printed twice.

## Verification

```
tests/daily-insight-landed-under-squash.test.py   3 runs, rc=0 each, 10 tests
scripts/review-checks.sh                          PASS
ruff check (changed file)                         All checks passed!
```

## Scope

One test file, both of its git call sites. No production code, no behaviour change, no assertion changed — a failing run fails identically, it just says why. 68 other test files use the same `capture_output=True` shape; **deliberately not swept**, since bundling that would make this un-reviewable and none of them are currently costing reruns.

Stand: Echo Act IV Pro
