### PR TITLE
fix(sparrow): reenroll identity falls back to state/auth/ag2space.json

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -669,7 +669,10 @@ def _reenroll_identity() -> str:
     # appears mid-episode must take effect without a restart.
     try:
         rec = json.loads((_STATE / "auth" / "ag2space.json").read_text())
-        return str(rec.get("agent_id") or "").strip()
+        # Non-string values must read as unknown, not be coerced into a
+        # garbage identity that _reenroll_claim would POST on the cadence.
+        v = rec.get("agent_id")
+        return v.strip() if isinstance(v, str) else ""
     except Exception:  # absent, unreadable, or malformed — identity unknown
         return ""
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -654,8 +654,9 @@ def _provision_base() -> str:
 
 
 def _reenroll_identity() -> str:
-    """Agent mxid: process env first, then the channel .env file — the same
-    fallback the token uses (desktop launchers don't export either)."""
+    """Agent mxid: process env, then the channel .env file — the same fallback
+    the token uses (desktop launchers don't export either) — then the durable
+    per-host identity enrolment wrote to state/auth/ag2space.json."""
     for key in ("AGENT_MXID", "AGENT_ID"):
         v = (os.environ.get(key) or "").strip()
         if v:
@@ -664,7 +665,13 @@ def _reenroll_identity() -> str:
         v = _config_from_channel_env(key).strip()
         if v:
             return v
-    return ""
+    # Re-read per call, like the channel-env candidates: an identity that
+    # appears mid-episode must take effect without a restart.
+    try:
+        rec = json.loads((_STATE / "auth" / "ag2space.json").read_text())
+        return str(rec.get("agent_id") or "").strip()
+    except Exception:  # absent, unreadable, or malformed — identity unknown
+        return ""
 
 
 def _reenroll_claim() -> None:

--- a/tests/gateway-auto-reenroll.test.py
+++ b/tests/gateway-auto-reenroll.test.py
@@ -10,6 +10,7 @@ import tempfile
 import unittest
 import urllib.error
 from pathlib import Path
+from unittest import mock
 
 _REPO = Path(__file__).resolve().parent.parent
 _PKG = _REPO / "packages" / "ag2-sparrow"
@@ -261,6 +262,76 @@ class _Status(unittest.TestCase):
             for n, v in saved.items():
                 setattr(gw, n, v)
             _reset()
+
+
+class _Identity(unittest.TestCase):
+    """`_reenroll_identity` must reach the durable per-host identity.
+
+    Enrolment writes the agent mxid to `state/auth/ag2space.json`, which
+    CLAUDE.md designates as the canonical home for per-host install/identity
+    state. Before this the resolver read only the process env and the channel
+    .env — so on a host whose .env carries just the token (the shape `connect`
+    writes), identity was unreachable and the claim could never be issued:
+    `reenroll: agent identity unknown` on every cycle, with the answer sitting
+    on disk one directory away.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.state = Path(self._tmp.name)
+        (self.state / "auth").mkdir(parents=True)
+        self._saved_state = gw._STATE
+        gw._STATE = self.state
+        self.addCleanup(lambda: setattr(gw, "_STATE", self._saved_state))
+        # Neutralise the two earlier candidates so this pins the THIRD one.
+        self._env = mock.patch.dict(
+            gw.os.environ, {"AGENT_MXID": "", "AGENT_ID": ""}, clear=False)
+        self._env.start(); self.addCleanup(self._env.stop)
+        for k in ("AGENT_MXID", "AGENT_ID"):
+            gw.os.environ.pop(k, None)
+        self._chan = mock.patch.object(gw, "_config_from_channel_env", return_value="")
+        self._chan.start(); self.addCleanup(self._chan.stop)
+
+    def _write(self, payload):
+        (self.state / "auth" / "ag2space.json").write_text(json.dumps(payload))
+
+    def test_identity_resolves_from_the_auth_state_file(self):
+        """The load-bearing case: fails before this change, which returns ''."""
+        self._write({"agent_id": "@host.agent:ag2.space", "schema_version": 1})
+        self.assertEqual(gw._reenroll_identity(), "@host.agent:ag2.space")
+
+    def test_env_still_wins_over_the_state_file(self):
+        """Precedence is unchanged — the new source is a LAST resort, so a
+        deliberate override cannot be silently outranked by stale enrolment."""
+        self._write({"agent_id": "@stale.agent:ag2.space"})
+        with mock.patch.dict(gw.os.environ, {"AGENT_MXID": "@live.agent:ag2.space"}):
+            self.assertEqual(gw._reenroll_identity(), "@live.agent:ag2.space")
+
+    def test_channel_env_still_wins_over_the_state_file(self):
+        self._write({"agent_id": "@stale.agent:ag2.space"})
+        with mock.patch.object(gw, "_config_from_channel_env",
+                               side_effect=lambda k: "@chan.agent:ag2.space"
+                               if k == "AGENT_MXID" else ""):
+            self.assertEqual(gw._reenroll_identity(), "@chan.agent:ag2.space")
+
+    def test_absent_unreadable_and_malformed_all_yield_empty(self):
+        """Never raise into the claim path: a missing, corrupt, or
+        wrong-shaped record is an unknown identity, not a crash."""
+        self.assertEqual(gw._reenroll_identity(), "")          # absent
+        (self.state / "auth" / "ag2space.json").write_text("{not json")
+        self.assertEqual(gw._reenroll_identity(), "")          # malformed
+        self._write({"agent_id": None})
+        self.assertEqual(gw._reenroll_identity(), "")          # null field
+        self._write({"agent_id": "   "})
+        self.assertEqual(gw._reenroll_identity(), "")          # whitespace only
+
+    def test_identity_appearing_later_is_picked_up_without_a_restart(self):
+        """Re-read per call, matching the channel-env candidates: an operator
+        (or a re-enrolment) landing the file mid-episode must take effect."""
+        self.assertEqual(gw._reenroll_identity(), "")
+        self._write({"agent_id": "@late.agent:ag2.space"})
+        self.assertEqual(gw._reenroll_identity(), "@late.agent:ag2.space")
 
 
 class _ClaimClock(unittest.TestCase):

--- a/tests/gateway-auto-reenroll.test.py
+++ b/tests/gateway-auto-reenroll.test.py
@@ -315,6 +315,26 @@ class _Identity(unittest.TestCase):
                                if k == "AGENT_MXID" else ""):
             self.assertEqual(gw._reenroll_identity(), "@chan.agent:ag2.space")
 
+    def test_every_earlier_candidate_still_outranks_the_state_file(self):
+        """REVIEW.md lesson 10 — enumerate the adjacent inputs, not just the one
+        you changed. `_reenroll_identity` has SIX inputs; a new last-resort
+        source must not quietly outrank any of the five that precede it, so
+        walk the whole ladder rather than neutralising it wholesale.
+        """
+        self._write({"agent_id": "@stale.agent:ag2.space"})
+        # 1-2: process env, both spellings.
+        for key in ("AGENT_MXID", "AGENT_ID"):
+            with mock.patch.dict(gw.os.environ, {key: f"@env-{key}:ag2.space"}):
+                self.assertEqual(gw._reenroll_identity(), f"@env-{key}:ag2.space",
+                                 f"process env {key} must outrank the state file")
+        # 3-5: channel .env, all three spellings it accepts.
+        for key in ("AGENT_MXID", "AGENT_ID", "AG2SPACE_USER_ID"):
+            with mock.patch.object(gw, "_config_from_channel_env",
+                                   side_effect=lambda k, want=key:
+                                   f"@chan-{want}:ag2.space" if k == want else ""):
+                self.assertEqual(gw._reenroll_identity(), f"@chan-{key}:ag2.space",
+                                 f"channel .env {key} must outrank the state file")
+
     def test_absent_unreadable_and_malformed_all_yield_empty(self):
         """Never raise into the claim path: a missing, corrupt, or
         wrong-shaped record is an unknown identity, not a crash."""

--- a/tests/gateway-auto-reenroll.test.py
+++ b/tests/gateway-auto-reenroll.test.py
@@ -346,6 +346,15 @@ class _Identity(unittest.TestCase):
         self._write({"agent_id": "   "})
         self.assertEqual(gw._reenroll_identity(), "")          # whitespace only
 
+    def test_non_string_agent_id_reads_as_unknown_not_garbage(self):
+        """Review P2: a truthy non-string must not be coerced into a garbage
+        identity — `_reenroll_claim` gates on `if not agent_id`, so '12345'
+        would be POSTed on the cadence and the operator hint never printed."""
+        for bad in (12345, ["@x:ag2.space"], {"v": "@x"}, True, 0.5):
+            self._write({"agent_id": bad})
+            self.assertEqual(gw._reenroll_identity(), "",
+                             f"non-string agent_id {bad!r} must read as unknown")
+
     def test_identity_appearing_later_is_picked_up_without_a_restart(self):
         """Re-read per call, matching the channel-env candidates: an operator
         (or a re-enrolment) landing the file mid-episode must take effect."""


### PR DESCRIPTION
Follow-up to #2925 (merged), as offered in review there.

## The gap #2925 leaves

#2925 correctly stops the crash-loop and retries identity discovery every cycle. Its identity-missing path then terminates in *"write `AGENT_MXID` into the channel .env"* — or, with no pointers, *"RESTART the wrapper"*.

On the desktop shape that step is unnecessary. `connect` writes only the **token** into `channels/ag2space/.env` (its `CONNECT_ENV_KEY`), while the agent mxid is already on disk at `state/auth/ag2space.json`:

```json
{"agent_id": "@…:ag2.space", "enrolled_at": "…", "schema_version": 1}
```

CLAUDE.md designates `state/auth/` as canonical for durable per-host install/identity state that survives upgrades. `_reenroll_identity()` read the process env and the channel .env and stopped — so identity was unreachable, no claim could be issued, and the operator was told to hand-write a value the machine already knew.

**Field evidence:** on the host where this was found, the pre-#2925 bridge logged `AGENT_MXID/AGENT_ID or token unavailable — not claiming` on every cycle. Recovery required POSTing the claim by hand, using exactly the `agent_id` from that file.

## The change

A third, last-resort candidate. **Precedence is unchanged** — process env, then channel .env, then the state file — so a deliberate override still outranks a stale enrolment record. Re-read per call like the channel-env candidates, so an identity landing mid-episode takes effect without a restart (composing with #2925's retry-every-cycle). Any failure — absent, unreadable, malformed, null, whitespace — yields `""`; this runs inside the claim path and must never raise.

## Evidence

Control arm, `tests/gateway-auto-reenroll.test.py` (25 tests):

```
fixed src            : OK
src reverted to head : FAILED (failures=2)
```

The two failures are the load-bearing cases (`…resolves_from_the_auth_state_file`, `…appearing_later_is_picked_up_without_a_restart`). The three precedence/robustness cases pass in **both** arms deliberately — they are fences against a future change inverting precedence or making the read raise, not evidence for this one.

**Live, on a configured host**, with the dir injection `src/remote-gateway-bridge.py:54` performs (`state_dir=WS/"state"`):

```
_STATE       : <workspace>/state
identity now : '@yixuan-desktop.agent:ag2.space'
```

Same value that completed that host's recovery by hand.

## Two things a reviewer should weigh

1. **`_dirs.py` is deliberately sutando-agnostic** ("No 'workspace' concept, no sutando deps"), and this reads a path *shape* (`auth/ag2space.json`) under the injected state dir. I judged that acceptable because it goes through the injected `_STATE` rather than importing anything sutando-side, and degrades to `""` when absent — an external agent with its own state dir simply finds no file. Say the word if you'd rather it were a fourth injected candidate instead.
2. **Nothing in this repo writes that file** — the writer is the desktop `connect` flow, out of tree. So its schema is not pinned here; I read `agent_id` defensively and treat every other shape as unknown-identity.

Sibling suite `src/remote-gateway-bridge.test.py` is unchanged by this diff: it fails one case, `env-fallback: no env token and no file yields empty token`, identically on clean `origin/main` — filed separately as #2929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134RYKn1wSfeDTKcrLApZRX