### PR TITLE
fix(tests): session-worker deadlines were set at the median of what they time

### DIFF
--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -33,6 +33,9 @@ NO_WAIT_GAP_S = 2.0
 # Sits between watcher startup (measured max 1.255s) and the slow handler's 5s
 # sleep, so it discriminates on blocking rather than on host speed.
 NOT_BLOCKED_S = 3.0
+# Teardown is the one place the bound IS the assertion: a worker that outlives
+# shutdown must fail, so this stays short and separate from the settling polls.
+WORKER_EXIT_S = 2.0
 WORKER = REPO / "skills" / "task-workstream-sessions" / "scripts" / "session-worker.py"
 spec = importlib.util.spec_from_file_location("workstream_session_worker", WORKER)
 worker = importlib.util.module_from_spec(spec)
@@ -1548,7 +1551,7 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
             assert not remaining_claims
             assert fallback_names == names
             assert len(calls.read_text().splitlines()) <= 2
-            deadline = time.monotonic() + EVENT_SETTLE_TIMEOUT_S
+            deadline = time.monotonic() + WORKER_EXIT_S
             while time.monotonic() < deadline:
                 try:
                     os.killpg(watcher_pgid, 0)

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -24,6 +24,12 @@ REPO = Path(__file__).resolve().parents[1]
 # Guards a hang, not promptness — a leaked worker holds stdout open forever, so any
 # bound catches it. Every timing claim here is a separate assert; keep this generous.
 SHUTDOWN_DRAIN_TIMEOUT_S = 30
+# These are early-exit polls, so a generous bound costs a passing run nothing and
+# only stops a slow-but-correct one being reported as a failure.
+EVENT_SETTLE_TIMEOUT_S = 15
+# The second dispatch must follow the first promptly; a serialized notifier would
+# wait out the first task's whole run, which is orders of magnitude longer.
+NO_WAIT_GAP_S = 2.0
 WORKER = REPO / "skills" / "task-workstream-sessions" / "scripts" / "session-worker.py"
 spec = importlib.util.spec_from_file_location("workstream_session_worker", WORKER)
 worker = importlib.util.module_from_spec(spec)
@@ -1205,7 +1211,7 @@ def test_required_team_handler_shutdown_never_falls_through() -> None:
         )
         claim = workspace / "state" / "task-event-handler-claims" / task.name
         try:
-            deadline = time.monotonic() + 1
+            deadline = time.monotonic() + EVENT_SETTLE_TIMEOUT_S
             while not claim.exists() and time.monotonic() < deadline:
                 time.sleep(0.01)
             assert claim.exists()
@@ -1431,7 +1437,7 @@ def test_overlapping_watcher_preserves_live_claim_and_owner_shutdown_falls_back(
         overlap = None
         try:
             claim = workspace / "state" / "task-event-handler-claims" / task.name
-            deadline = time.monotonic() + 1
+            deadline = time.monotonic() + EVENT_SETTLE_TIMEOUT_S
             while time.monotonic() < deadline:
                 if claim.is_file() and calls.exists():
                     break
@@ -1516,7 +1522,7 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
         watcher_pgid = process.pid
         try:
             claims = workspace / "state" / "task-event-handler-claims"
-            deadline = time.monotonic() + 1
+            deadline = time.monotonic() + EVENT_SETTLE_TIMEOUT_S
             while time.monotonic() < deadline and len(list(claims.glob("task-*.txt"))) < 4:
                 time.sleep(0.01)
             assert sorted(path.name for path in claims.glob("task-*.txt")) == names
@@ -1539,7 +1545,7 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
             assert not remaining_claims
             assert fallback_names == names
             assert len(calls.read_text().splitlines()) <= 2
-            deadline = time.monotonic() + 1
+            deadline = time.monotonic() + EVENT_SETTLE_TIMEOUT_S
             while time.monotonic() < deadline:
                 try:
                     os.killpg(watcher_pgid, 0)
@@ -1609,14 +1615,18 @@ def test_codex_notifier_dispatches_each_isolated_task_once_without_waiting() -> 
         )
         try:
             started = time.monotonic()
-            calls = []
-            while time.monotonic() - started < 1.0:
+            calls, first_at = [], None
+            while time.monotonic() - started < EVENT_SETTLE_TIMEOUT_S:
                 calls = log.read_text().splitlines() if log.exists() else []
+                if calls and first_at is None:
+                    first_at = time.monotonic()
                 if len(calls) == 2:
                     break
                 time.sleep(0.01)
             assert sorted(calls) == ["task-one.txt", "task-two.txt"]
-            assert time.monotonic() - started < 1.0
+            # "without waiting" is the GAP between the two dispatches; timing from
+            # spawn instead folds in subprocess startup, which alone exceeded 1s.
+            assert time.monotonic() - first_at < NO_WAIT_GAP_S, time.monotonic() - first_at
         finally:
             os.killpg(process.pid, signal.SIGTERM)
             process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
@@ -1683,7 +1693,7 @@ def test_codex_notifier_never_submits_a_watcher_claim_to_live_core() -> None:
             start_new_session=True,
         )
         try:
-            deadline = time.monotonic() + 1.5
+            deadline = time.monotonic() + EVENT_SETTLE_TIMEOUT_S
             tmux_calls = ""
             while time.monotonic() < deadline:
                 tmux_calls = tmux_log.read_text() if tmux_log.exists() else ""
@@ -1692,7 +1702,7 @@ def test_codex_notifier_never_submits_a_watcher_claim_to_live_core() -> None:
                 time.sleep(0.01)
             assert "task-a-live.txt" in tmux_calls
             assert "task-z-isolated.txt" not in tmux_calls
-            deadline = time.monotonic() + 1
+            deadline = time.monotonic() + EVENT_SETTLE_TIMEOUT_S
             while not handler_log.exists() and time.monotonic() < deadline:
                 time.sleep(0.01)
             assert handler_log.read_text().splitlines() == ["task-z-isolated.txt"]
@@ -1736,7 +1746,7 @@ def test_unrecognised_claim_disposition_is_never_published_to_the_live_core() ->
         )
         claim = workspace / "state" / "task-event-handler-claims" / task.name
         try:
-            deadline = time.monotonic() + 1
+            deadline = time.monotonic() + EVENT_SETTLE_TIMEOUT_S
             while not claim.exists() and time.monotonic() < deadline:
                 time.sleep(0.01)
             assert claim.exists()

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -30,6 +30,9 @@ EVENT_SETTLE_TIMEOUT_S = 15
 # The second dispatch must follow the first promptly; a serialized notifier would
 # wait out the first task's whole run, which is orders of magnitude longer.
 NO_WAIT_GAP_S = 2.0
+# Sits between watcher startup (measured max 1.255s) and the slow handler's 5s
+# sleep, so it discriminates on blocking rather than on host speed.
+NOT_BLOCKED_S = 3.0
 WORKER = REPO / "skills" / "task-workstream-sessions" / "scripts" / "session-worker.py"
 spec = importlib.util.spec_from_file_location("workstream_session_worker", WORKER)
 worker = importlib.util.module_from_spec(spec)
@@ -1279,7 +1282,7 @@ def test_slow_handler_does_not_block_the_next_task_event() -> None:
             line = process.stdout.readline()
             elapsed = time.monotonic() - started
             assert line == "TASK_FILE: task-b-live.txt\n"
-            assert elapsed < 1.0, f"second task event was blocked for {elapsed:.2f}s"
+            assert elapsed < NOT_BLOCKED_S, f"second task event was blocked for {elapsed:.2f}s"
         finally:
             os.killpg(process.pid, signal.SIGTERM)
             process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)


### PR DESCRIPTION
## The defect

`tests/task-workstream-session-worker.test.py` is nondeterministic on `main`, and it has been costing real signal: it is why #2757 read red for hours (a rerun with no code change cleared it), and #2853 has been flapping green/red all evening on a branch that touches only `src/restart.sh` and `src/startup.sh`.

Five runs of the file at one commit, clean `origin/main` worktree, nothing else changed:

```
run 1  FAIL  line 1618  test_codex_notifier_dispatches_each_isolated_task_once_without_waiting
run 2  FAIL  line 1693  test_codex_notifier_never_submits_a_watcher_claim_to_live_core
run 3  FAIL  line 1535  _assert_shutdown_falls_back_without_surviving_workers
run 4  PASS
```

Three different assertions, then a clean pass. @Sutando-Mini reproduced it independently on a second host at a **fourth** site (line 1541).

## Root cause, measured

Seven waits are budgeted **1 second**. I instrumented one and timed the work it bounds, 18 samples across 3 runs:

```
min 0.884s   median ~0.98s   max 1.255s      budget 1.000s
```

**The deadline is set at the median of the operation it is timing**, so roughly half of all runs fail on a perfectly correct system. The 3-fails-then-a-pass pattern is what that looks like.

## The change

`EVENT_SETTLE_TIMEOUT_S = 15` applied to the six `+ 1` and one `+ 1.5` deadlines. These are **early-exit polls** — they break the moment the condition holds — so a generous bound costs a passing run nothing and only stops a slow-but-correct one being reported as a failure. No passing path gets slower.

One site needed more than a number. `test_codex_notifier_dispatches_each_isolated_task_once_without_waiting` asserted `time.monotonic() - started < 1.0` where `started` was set before the poll loop, i.e. immediately after `Popen` — so it was timing subprocess startup, which I measured at 0.88–1.25s *by itself*. It could not have passed reliably regardless of the behaviour under test. It now records when the first dispatch lands and asserts the **gap** to the second (`NO_WAIT_GAP_S = 2.0`), which is the property the test's name claims.

## Evidence

```
before (origin/main)   5 runs -> 3 FAIL at 3 different sites, 1 PASS
after  (this branch)   6 runs -> 5 PASS, 1 FAIL — and NOT at any deadline site
```

Control that the new gap assertion is not vacuous — set `NO_WAIT_GAP_S = 0.0` and it fails at the expected line:

```
line 1629, in test_codex_notifier_dispatches_each_isolated_task_once_without_waiting
```

## What this does NOT fix, stated plainly

The one remaining failure in six runs is a **different defect** at line 1541, and I am not touching it here:

```
assert set(events) == set(names)
AssertionError: ("''", "'watch-tasks-stream: optional task handler interrupted for
                        task-shutdown-2.txt; falling back to live core ...'")
```

stdout came back **empty** while stderr shows the fallback ran — an output-flush race on SIGTERM during shutdown, not a deadline. Fixing it plausibly means touching `watch-tasks-stream.sh`, which is production code and a separate concern from a test-timing fix. Filing it as its own issue rather than smuggling it in here.

So this narrows the file from four rotating flake sites to one, and names the survivor precisely.

Stand: Echo Act IV Pro

---

**Closes #2731.** Does NOT address #2901 (shutdown/stdout-flush race — needs `watch-tasks-stream.sh`, separate concern).