### PR TITLE
fix(sparrow): resolve reenroll identity from canonical state/auth/ag2space.json

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -654,12 +654,21 @@ def _provision_base() -> str:
 
 
 def _reenroll_identity() -> str:
-    """Agent mxid: process env first, then the channel .env file — the same
-    fallback the token uses (desktop launchers don't export either)."""
+    """Agent mxid: process env, then the workspace-contract canonical
+    state/auth/ag2space.json, then the channel .env keys. The canonical file
+    exists on hosts whose env carries nothing (recovery #1's only manual
+    step was copying from exactly that file — this closes the gap)."""
     for key in ("AGENT_MXID", "AGENT_ID"):
         v = (os.environ.get(key) or "").strip()
         if v:
             return v
+    try:
+        with open(_STATE / "auth" / "ag2space.json", encoding="utf-8") as fh:
+            v = str((json.load(fh) or {}).get("agent_id") or "").strip()
+        if v:
+            return v
+    except Exception:  # noqa: BLE001 — absent/malformed file: fall through
+        pass
     for key in ("AGENT_MXID", "AGENT_ID", "AG2SPACE_USER_ID"):
         v = _config_from_channel_env(key).strip()
         if v:

--- a/tests/gateway-auto-reenroll.test.py
+++ b/tests/gateway-auto-reenroll.test.py
@@ -140,6 +140,35 @@ class _Claim(unittest.TestCase):
             gw.urllib.request.urlopen = real
 
 
+
+    def test_identity_resolves_from_canonical_state_auth_file(self):
+        # Recovery #1's only manual step was copying agent_id out of
+        # state/auth/ag2space.json by hand — the bridge now reads the
+        # canonical file itself (proposed by Yixuan's agent, field-verified).
+        import tempfile
+        gw.os.environ.pop("AGENT_MXID", None)
+        gw.os.environ.pop("AGENT_ID", None)
+        saved_cfg = gw._config_from_channel_env
+        gw._config_from_channel_env = lambda k: ""
+        saved_state = gw._STATE
+        tmp = Path(tempfile.mkdtemp())
+        (tmp / "auth").mkdir()
+        (tmp / "auth" / "ag2space.json").write_text(json.dumps(
+            {"agent_id": "@canon.agent:ag2.space", "schema_version": 1}))
+        gw._STATE = tmp
+        try:
+            self.assertEqual(gw._reenroll_identity(), "@canon.agent:ag2.space")
+            # env still wins over the file (operator override)
+            gw.os.environ["AGENT_MXID"] = "@env.agent:ag2.space"
+            self.assertEqual(gw._reenroll_identity(), "@env.agent:ag2.space")
+            gw.os.environ.pop("AGENT_MXID", None)
+            # malformed file falls through cleanly
+            (tmp / "auth" / "ag2space.json").write_text("not json")
+            self.assertEqual(gw._reenroll_identity(), "")
+        finally:
+            gw._STATE = saved_state
+            gw._config_from_channel_env = saved_cfg
+
     def test_identity_falls_back_to_the_channel_env_file(self):
         # G3 (live-confirmed on a real install): desktop launchers export
         # NEITHER AGENT_MXID nor AGENT_ID — the channel .env is the source.


### PR DESCRIPTION
Proposed by Yixuan's agent after executing recovery #1 — its exact observation: "_reenroll_identity() looks for the mxid in the process env and the channel .env, but never in state/auth/ag2space.json — the location the workspace contract calls canonical. That gap is the only reason this needed a human at all."

Field-verified on two hosts: recovery #1's single manual step (20:30:18Z) was copying `agent_id` out of this exact file; and the owner's own desktop install has an EMPTY channels/ag2space/ dir (the AG2_DEVICE_ENV pointer aims at a nonexistent file) while state/auth/ag2space.json is present — meaning essentially the whole orphan cohort resolves identity from nowhere today, and from the canonical file with this change.

Candidate order: env vars (operator override) → `<state>/auth/ag2space.json`'s `agent_id` (canonical per the workspace contract, schema_version 1, verified live on this host) → channel-.env keys (legacy). Absent/malformed file falls through cleanly. Combined with the existing no-restart re-read of identity on every claim retry, deployed orphaned bridges pick this up and complete the silent chain the moment their engine updates — zero user action, no v0.5.8 app change needed.

Tests 21/21: canonical-file resolution, env-wins-over-file precedence, malformed-file fallthrough, plus the full existing suite.

— @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)