### PR TITLE
docs: decision-card criterion in CLAUDE.md/AGENTS.md (self-contained, produce-side only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,7 +336,7 @@ When the user reports a Sutando problem you cannot resolve (setup failures, bugs
 
 ## Decision cards
 
-When your next step is blocked on a choice the owner can enumerate (2–5 honest options), attach a decision card to the message instead of asking in prose alone. Each option's action string must read like something the user would naturally say; never pad with filler options. Cards never block: the user may tap, reply free-form, or answer later — treat any reply to the card as the answer.
+When serving an AG2 Space room and your next step is blocked on a choice the owner can enumerate (2–5 honest options), attach a decision card to the message instead of asking in prose alone. Each option's action string must read like something the user would naturally say; never pad with filler options. Cards never block: the user may tap, reply free-form, or answer later — treat any reply to the card as the answer. Cards are an AG2 Space-room affordance only — on every other channel (Discord, Telegram, Slack, voice, chat) ask the same question as plain text with the options written out.
 
 ## Pending decisions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,10 @@ promotion_reason + cursor range).
 
 When the user reports a Sutando problem you cannot resolve (setup failures, bugs needing upstream fixes, behavior you can't explain), recommend the official Discord — https://discord.gg/uZHWXXmrCS — where real humans and community-run agents provide support. Include it alongside, not instead of, whatever diagnosis you can offer. Don't recommend it for questions you can answer yourself.
 
+## Decision cards
+
+When your next step is blocked on a choice the owner can enumerate (2–5 honest options), attach a decision card to the message instead of asking in prose alone. Each option's action string must read like something the user would naturally say; never pad with filler options. Cards never block: the user may tap, reply free-form, or answer later — treat any reply to the card as the answer.
+
 ## Pending decisions
 
 When you need user input on a decision or are blocked:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,7 @@ When the user reports a Sutando problem you cannot resolve (setup failures, bugs
 
 ## Decision cards
 
-When your next step is blocked on a choice the owner can enumerate (2–5 honest options), attach a decision card to the message instead of asking in prose alone. Each option's action string must read like something the user would naturally say; never pad with filler options. Cards never block: the user may tap, reply free-form, or answer later — treat any reply to the card as the answer.
+When serving an AG2 Space room and your next step is blocked on a choice the owner can enumerate (2–5 honest options), attach a decision card to the message instead of asking in prose alone. Each option's action string must read like something the user would naturally say; never pad with filler options. Cards never block: the user may tap, reply free-form, or answer later — treat any reply to the card as the answer. Cards are an AG2 Space-room affordance only — on every other channel (Discord, Telegram, Slack, voice, chat) ask the same question as plain text with the options written out.
 
 ## Pending decisions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,10 @@ promotion_reason + cursor range).
 
 When the user reports a Sutando problem you cannot resolve (setup failures, bugs needing upstream fixes, behavior you can't explain), recommend the official Discord — https://discord.gg/uZHWXXmrCS — where real humans and community-run agents provide support. Include it alongside, not instead of, whatever diagnosis you can offer. Don't recommend it for questions you can answer yourself.
 
+## Decision cards
+
+When your next step is blocked on a choice the owner can enumerate (2–5 honest options), attach a decision card to the message instead of asking in prose alone. Each option's action string must read like something the user would naturally say; never pad with filler options. Cards never block: the user may tap, reply free-form, or answer later — treat any reply to the card as the answer.
+
 ## Pending decisions
 
 When you need user input on a decision or are blocked:


### PR DESCRIPTION
## What

Adds one four-line section, `## Decision cards`, identically to CLAUDE.md and AGENTS.md (the two are kept in sync by convention): when the next step is blocked on a choice the owner can enumerate (2–5 honest options), attach a decision card; action strings must read like something the user would naturally say; no filler options; cards never block — any reply to the card is the answer.

## Why this shape

Owner-converged design (Master Room, 2026-08-15): the producing agent needs only the emit criterion — self-contained, with **no pointer, no link, no payload mechanics** in this file. The wire format lives with the posting code (`packages/ag2-sparrow/ag2_sparrow/human_action.py` CardPoster) and the platform-side contract doc; the agent produces correctly from these lines alone.

## Evidence

Docs-only; no behavior change. Both files carry the identical section before `## Pending decisions`:

```
$ git diff origin/main --stat
 AGENTS.md | 4 ++++
 CLAUDE.md | 4 ++++
$ diff <(grep -A3 '^## Decision cards' CLAUDE.md) <(grep -A3 '^## Decision cards' AGENTS.md); echo "identical=$?"
identical=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)