### PR TITLE
fix(watcher): shutdown emits went into a $( ) capture, not stdout

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-# fd 9 is a stable dup of the real stdout. The EXIT trap can fire while the shell
-# is inside a $( ) capture, which rebinds fd 1 to the substitution's pipe.
-exec 9>&1
 # Streaming task watcher — the canonical task-detection path.
 #
 # Runs fswatch indefinitely and emits ONE line per new task file appearance.
@@ -20,6 +17,10 @@ exec 9>&1
 # The agent reads the named files via the Read tool when notifications
 # arrive — no need to inline file contents in stdout (Monitor's 200ms
 # batching window would group multi-line content awkwardly).
+
+# fd 9 is a stable dup of the real stdout. The EXIT trap can fire while the shell
+# is inside a $( ) capture, which rebinds fd 1 to the substitution's pipe.
+exec 9>&1
 
 set -u
 

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# fd 9 is a stable dup of the real stdout. The EXIT trap can fire while the shell
+# is inside a $( ) capture, which rebinds fd 1 to the substitution's pipe.
+exec 9>&1
 # Streaming task watcher — the canonical task-detection path.
 #
 # Runs fswatch indefinitely and emits ONE line per new task file appearance.
@@ -497,7 +500,7 @@ fallback_outstanding_handlers() {
           1)
             printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
             echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
-            printf 'TASK_FILE: %s\n' "$filename" || true
+            printf 'TASK_FILE: %s\n' "$filename" >&9 || true
             ;;
           *)
             echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
@@ -533,7 +536,7 @@ fallback_outstanding_handlers() {
       1)
         printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
         echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
-        printf 'TASK_FILE: %s\n' "$filename" || true
+        printf 'TASK_FILE: %s\n' "$filename" >&9 || true
         ;;
       *)
         echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -18,8 +18,8 @@
 # arrive — no need to inline file contents in stdout (Monitor's 200ms
 # batching window would group multi-line content awkwardly).
 
-# fd 9 is a stable dup of the real stdout. The EXIT trap can fire while the shell
-# is inside a $( ) capture, which rebinds fd 1 to the substitution's pipe.
+# fd 9 is a stable dup of the real stdout, taken before anything can rebind fd 1.
+# A shutdown emit invoked one $( ) deep writes to the capture pipe, not to stdout.
 exec 9>&1
 
 set -u


### PR DESCRIPTION
## What broke

`watch-tasks-stream.sh` emits `TASK_FILE: <name>` on stdout. The two shutdown emits reached by
`cleanup` were succeeding — `printf` returned 0, stderr was complete, the artifact was complete —
and yet never appeared on stdout.

The EXIT trap can fire while the shell is inside a command substitution. `task_path="$(cat "$settled")"`
sits in the same loop, so at that moment **fd 1 is the substitution's capture pipe**: every emit was
written successfully into a string that is then discarded. That single mechanism explains all of it
at once — rc=0, complete stderr, empty stdout.

## The fix

`exec 9>&1` before anything can rebind fd 1, and emit `>&9` on the two sites reachable from `cleanup`.
6 insertions / 2 deletions, one file.

## Scope — why only two of the emit sites (answering the review question)

Deliberate, and checkable from the call graph rather than by eye:

| sites | function | callers | fd |
|---|---|---|---|
| `:503`, `:539` | `fallback_outstanding_handlers` | **exactly one — line 610, inside `cleanup()`** | `>&9` |
| `:371`–`:399` | `dispatch_task` | `:636` initial sweep, `:688` main loop | fd 1 |
| `:252` | `finish_handler_task` | `:309`, `:311`, `:682` | fd 1 |

Only the first row is reachable from the EXIT trap, which is what makes it able to run mid-substitution.
The others execute as ordinary statements on the normal path, where fd 1 is the real stdout — including
`finish_handler_task "$marker" "$(cat "$marker")"`, whose `$( )` is an *argument* and has completed
before the callee runs.

The two failure contracts (`|| exit 0` on the dispatch path, `|| true` in the fallback) are therefore
**left as they are, on purpose**: unifying them would change error handling on paths this bug never
touched, which is a separate concern from a delivery fix.

## Evidence

Failures attributed **by assertion line** — 1535 is the stdout assertion, 1522 the 1s startup deadline:

```
main             25 runs   line 1522 x1,  line 1535 x1
this fix         65 runs   line 1522 only  —  ZERO at 1535
this fix + #2931 30 runs   NONE
```

A bare pass/fail count would have buried this: the first run with the fix still showed failures, and
only the line attribution separates "stdout stopped failing" from "the deadline still is" (#2931's subject).

## What I could not do

No deterministic regression test. The race is ~4% per run and cannot be forced from outside the
process, and a source-regex assertion would be the surrogate this repo's guidance rejects. I would
rather say so than ship a test that passes for the wrong reason.

The live post-restart witness stays owner-gated and is not claimed here.
