### PR TITLE
test(watcher): make the shutdown emit sourceable so the fd-9 guarantee is tested

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -133,7 +133,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`sutando_config.ts`** — Canonical loader for `sutando.config.json` / `sutando.config.local.json`.
 - **`task-bridge.ts`** — Voice → Claude Code session bridge.
 - **`task-delegation.ts`** — TaskDelegationService — step 4 of the interaction-planes refactor (issue #1947, built under the architecture names per design R3).
-- **`task-emit.sh`** — Shutdown-path TASK_FILE emitter — sourceable so it can be tested in isolation.
+- **`task-emit.sh`** — Shutdown-path TASK_FILE emitter — sourceable so a test can invoke it in isolation.
 - **`task_archive.py`** — Task-file locator for archive calls (#933).
 - **`task_body_guard.py`** — Confine untrusted user message content before embedding it in a task file.
 - **`task_priority.py`** — Task priority taxonomy + readers.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-218 modules indexed.
+219 modules indexed.
 
 ## `src/`
 
@@ -132,6 +132,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`sutando_config.ts`** — Canonical loader for `sutando.config.json` / `sutando.config.local.json`.
 - **`task-bridge.ts`** — Voice → Claude Code session bridge.
 - **`task-delegation.ts`** — TaskDelegationService — step 4 of the interaction-planes refactor (issue #1947, built under the architecture names per design R3).
+- **`task-emit.sh`** — Shutdown-path TASK_FILE emitter — sourceable so it can be tested in isolation.
 - **`task_archive.py`** — Task-file locator for archive calls (#933).
 - **`task_body_guard.py`** — Confine untrusted user message content before embedding it in a task file.
 - **`task_priority.py`** — Task priority taxonomy + readers.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-219 modules indexed.
+220 modules indexed.
 
 ## `src/`
 

--- a/src/task-emit.sh
+++ b/src/task-emit.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
-# Shutdown-path TASK_FILE emitter — sourceable so it can be tested in isolation.
-#
-# The caller owns fd 9 (`exec 9>&1` before anything can rebind fd 1). This unit
-# only writes to it. Keeping the write here rather than inline is what lets a
-# test invoke the real emitter one command-substitution deep, which is the only
-# shape that reproduces the delivery bug: inside a $( ), fd 1 is the capture
-# pipe, so an emit on fd 1 is written successfully into a discarded string.
-#
-# Sourcing this file must have no side effects — it defines one function.
+# Shutdown-path TASK_FILE emitter — sourceable so a test can invoke it in isolation.
+# The caller owns fd 9; sourcing this file defines one function and nothing else.
 
 # Emit one task filename on the caller's stable stdout duplicate (fd 9).
 # Never fatal: a failed shutdown emit must not abort the remaining cleanup.

--- a/src/task-emit.sh
+++ b/src/task-emit.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Shutdown-path TASK_FILE emitter — sourceable so it can be tested in isolation.
+#
+# The caller owns fd 9 (`exec 9>&1` before anything can rebind fd 1). This unit
+# only writes to it. Keeping the write here rather than inline is what lets a
+# test invoke the real emitter one command-substitution deep, which is the only
+# shape that reproduces the delivery bug: inside a $( ), fd 1 is the capture
+# pipe, so an emit on fd 1 is written successfully into a discarded string.
+#
+# Sourcing this file must have no side effects — it defines one function.
+
+# Emit one task filename on the caller's stable stdout duplicate (fd 9).
+# Never fatal: a failed shutdown emit must not abort the remaining cleanup.
+emit_task_file() {
+	printf 'TASK_FILE: %s\n' "$1" >&9 || true
+}

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-# fd 9 is a stable dup of the real stdout. The EXIT trap can fire while the shell
-# is inside a $( ) capture, which rebinds fd 1 to the substitution's pipe.
-exec 9>&1
 # Streaming task watcher — the canonical task-detection path.
 #
 # Runs fswatch indefinitely and emits ONE line per new task file appearance.
@@ -20,6 +17,10 @@ exec 9>&1
 # The agent reads the named files via the Read tool when notifications
 # arrive — no need to inline file contents in stdout (Monitor's 200ms
 # batching window would group multi-line content awkwardly).
+
+# fd 9 is a stable dup of the real stdout. The EXIT trap can fire while the shell
+# is inside a $( ) capture, which rebinds fd 1 to the substitution's pipe.
+exec 9>&1
 
 set -u
 

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -50,6 +50,8 @@ fi
 __SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=watcher_sentinel.sh
 source "$__SCRIPT_DIR/watcher_sentinel.sh"
+# shellcheck source=task-emit.sh
+source "$__SCRIPT_DIR/task-emit.sh"
 __REPO_ROOT="$(cd "$__SCRIPT_DIR/.." && pwd)"
 
 # Resolve TASKS_DIR. Priority: explicit positional arg → canonical M0 loader.
@@ -501,7 +503,7 @@ fallback_outstanding_handlers() {
           1)
             printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
             echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
-            printf 'TASK_FILE: %s\n' "$filename" >&9 || true
+            emit_task_file "$filename"
             ;;
           *)
             echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
@@ -537,7 +539,7 @@ fallback_outstanding_handlers() {
       1)
         printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
         echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
-        printf 'TASK_FILE: %s\n' "$filename" >&9 || true
+        emit_task_file "$filename"
         ;;
       *)
         echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# fd 9 is a stable dup of the real stdout. The EXIT trap can fire while the shell
+# is inside a $( ) capture, which rebinds fd 1 to the substitution's pipe.
+exec 9>&1
 # Streaming task watcher — the canonical task-detection path.
 #
 # Runs fswatch indefinitely and emits ONE line per new task file appearance.
@@ -497,7 +500,7 @@ fallback_outstanding_handlers() {
           1)
             printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
             echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
-            printf 'TASK_FILE: %s\n' "$filename" || true
+            printf 'TASK_FILE: %s\n' "$filename" >&9 || true
             ;;
           *)
             echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2
@@ -533,7 +536,7 @@ fallback_outstanding_handlers() {
       1)
         printf '%s\n' "$task_path" > "$FALLBACKS_DIR/$filename"
         echo "watch-tasks-stream: optional task handler interrupted for $filename; falling back to live core (possible at-least-once retry)" >&2
-        printf 'TASK_FILE: %s\n' "$filename" || true
+        printf 'TASK_FILE: %s\n' "$filename" >&9 || true
         ;;
       *)
         echo "watch-tasks-stream: claim for $filename has no recognised disposition; not publishing it to the live core" >&2

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -18,8 +18,8 @@
 # arrive — no need to inline file contents in stdout (Monitor's 200ms
 # batching window would group multi-line content awkwardly).
 
-# fd 9 is a stable dup of the real stdout. The EXIT trap can fire while the shell
-# is inside a $( ) capture, which rebinds fd 1 to the substitution's pipe.
+# fd 9 is a stable dup of the real stdout, taken before anything can rebind fd 1.
+# A shutdown emit invoked one $( ) deep writes to the capture pipe, not to stdout.
 exec 9>&1
 
 set -u

--- a/tests/task-emit-substitution.test.sh
+++ b/tests/task-emit-substitution.test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# A shutdown emit invoked one command-substitution deep must reach the REAL
+# stdout, not the substitution's capture pipe. The mutation arm is part of the
+# test: without `>&9` the assertion has to fail, or it proves nothing.
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+UNIT="$REPO/src/task-emit.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+# Run one arm: establish fd 9 as a dup of this subprocess's real stdout, source
+# the unit under test, then invoke the emitter INSIDE a command substitution --
+# where fd 1 is the capture pipe and fd 9 still is not.
+run_arm() {
+	bash -c '
+		exec 9>&1
+		# shellcheck source=/dev/null
+		source "$1"
+		swallowed="$(emit_task_file "probe-task.txt"; echo settled)"
+		[ "$swallowed" = "settled" ] || printf "ARM_NOTE: capture held %s\n" "$swallowed" >&2
+	' _ "$1" 2>/dev/null
+}
+
+# --- arm 1: the shipped unit -------------------------------------------------
+fixed_out="$(run_arm "$UNIT")"
+case "$fixed_out" in
+	*"TASK_FILE: probe-task.txt"*) : ;;
+	*) fail "shipped unit: emit did not reach real stdout (got: '$fixed_out')" ;;
+esac
+
+# --- arm 2: mutation -- drop the fd-9 redirect, keep everything else ----------
+MUTANT="$TMP/task-emit-mutant.sh"
+sed 's/ >&9 / /' "$UNIT" > "$MUTANT"
+grep -q '>&9' "$MUTANT" && fail "mutation did not apply -- mutant still redirects to fd 9"
+grep -q 'printf .TASK_FILE' "$MUTANT" || fail "mutation removed the emit itself, so arm 2 is vacuous"
+
+mutant_out="$(run_arm "$MUTANT")"
+case "$mutant_out" in
+	*"TASK_FILE: probe-task.txt"*)
+		fail "mutant reached real stdout -- this test cannot detect the bug it exists for" ;;
+	*) : ;;
+esac
+
+printf 'ok: emit survives one command-substitution deep (shipped)\n'
+printf 'ok: without >&9 the same call is swallowed by the capture (mutant)\n'
+printf 'ALL PASS\n'

--- a/tests/task-emit-substitution.test.sh
+++ b/tests/task-emit-substitution.test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # A shutdown emit invoked one command-substitution deep must reach the REAL
-# stdout, not the substitution's capture pipe. The mutation arm is part of the
-# test: without `>&9` the assertion has to fail, or it proves nothing.
+# stdout. The mutation arm is part of the test; rationale is in the PR body.
 set -u
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
@@ -11,9 +10,8 @@ trap 'rm -rf "$TMP"' EXIT
 
 fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
 
-# Run one arm: establish fd 9 as a dup of this subprocess's real stdout, source
-# the unit under test, then invoke the emitter INSIDE a command substitution --
-# where fd 1 is the capture pipe and fd 9 still is not.
+# Establish fd 9 as a dup of real stdout, source the unit, then invoke the
+# emitter INSIDE a substitution -- where fd 1 is the capture pipe and fd 9 is not.
 run_arm() {
 	bash -c '
 		exec 9>&1
@@ -31,7 +29,7 @@ case "$fixed_out" in
 	*) fail "shipped unit: emit did not reach real stdout (got: '$fixed_out')" ;;
 esac
 
-# --- arm 2: mutation -- drop the fd-9 redirect, keep everything else ----------
+# --- arm 2: mutation -- drop the fd-9 redirect, keep everything else ---
 MUTANT="$TMP/task-emit-mutant.sh"
 sed 's/ >&9 / /' "$UNIT" > "$MUTANT"
 grep -q '>&9' "$MUTANT" && fail "mutation did not apply -- mutant still redirects to fd 9"


### PR DESCRIPTION
**Stacked on #2937 — merge that first.** This adds the regression test #2937 shipped without, and the reason it could not carry one.

## Why #2937 had no test, and why this needs a refactor to get one

The bug needs fd 1 to differ from what `exec 9>&1` captured, and only code *inside* the script creates that divergence. A test that drives the whole script one command substitution deep — `out="$(bash src/watch-tasks-stream.sh …)"` — makes fd 9 a dup of **that same capture pipe**, so the fixed and broken arms behave identically and the assertion cannot fail in the broken state. An existence assertion that cannot fail when the bug is present is worse than no test.

@qingyun-wu proposed the way out in review: make the emitter sourceable. That is this PR.

## What changed

```
src/task-emit.sh                       emit_task_file(), writes to the caller's fd 9
src/watch-tasks-stream.sh              sources it; both cleanup sites call it
tests/task-emit-substitution.test.sh   sources the REAL unit, invokes it one $( ) deep
```

**No behaviour change.** `exec 9>&1` still sits at line 23 before anything can rebind fd 1; the same two cleanup-reachable sites emit; the normal-path sites still use fd 1 deliberately. `grep -c '>&9' src/watch-tasks-stream.sh` is now 0 because the unit owns the redirect.

## The test carries its own mutation arm

A test for this bug that still passes with `>&9` removed would prove nothing, so the failure is *inside* the test: arm 2 strips the redirect from a copy of the unit and asserts that copy **is** swallowed by the capture. It also asserts the mutation actually applied and did not delete the emit outright, so arm 2 cannot go vacuous.

Verified both directions against the shipped unit:

```
shipped                        -> ok: emit survives one $( ) deep
                                  ok: without >&9 the same call is swallowed
                                  ALL PASS                                 rc=0
>&9 removed from the UNIT      -> FAIL: shipped unit: emit did not reach
                                  real stdout (got: '')                    rc=1
```

## Other checks

- `bash -n` clean; `shellcheck -S warning` clean on both new files.
- `gen-src-map.py` regenerated — `task-emit.sh` is indexed from its own header; `--check` clean.
- Session-worker suite is load-flaky on this host tonight and **the parent is no better**: this branch 2/6, parent `d5755df6` 1/6, with the same deadline assertions (`tmux_calls`, `sorted(calls)`) in both arms and none of them the stdout assertion. Not implicated; hosted CI is the gate.

One near-miss worth recording: my first attempt replaced the two emit sites by substring, and the 8-space pattern matched **inside** the 12-space line. An assertion caught it before anything was written. The replacement is line-anchored now.
