### PR TITLE
docs(workspace): document skill-repos/ as the home for skill source checkouts

### DIFF
--- a/docs/workspace-design.md
+++ b/docs/workspace-design.md
@@ -74,9 +74,24 @@ Per-user runtime + content. Lives at `<repo>/workspace/` by default (post-M0). S
 | `state/auth/`, `state/cloud-auth.json`, `state/device.json` | ❌ no | Per-host durable | Install/identity state, per-host |
 | `logs/conversation.log` | ❌ no | Per-host runtime | Voice/phone/discord log; large + per-host |
 | `data/conversation.sqlite` | ❌ no | Per-host runtime | SQLite mirror of conversation log |
+| `skill-repos/<repo-name>/` | ❌ no | Per-host clone | Git checkouts of skill **source** repos that `skills/install.sh` symlinks from |
 | `.env` | ❌ no | Per-host secret | Tokens, API keys — must NOT sync |
 
 The sync default is "synced unless excluded"; per-host runtime sub-paths are excluded via the carrier-set gitignore (per PR #1447) + `vault.sync.exclude` user overrides.
+
+### `skill-repos/` — where skill source repos are cloned
+
+A skill's *installed* form is a symlink under `$CLAUDE_CONFIG_DIR/skills/<name>`. The repo it points **at** is a normal git checkout, and that checkout belongs at `<workspace>/skill-repos/<repo-name>/`.
+
+Clone skill repos there rather than into `$HOME`. A checkout outside the workspace is invisible to every workspace-level tool — it is not in the sync carrier set, not in a workspace audit, and not where anyone looks for it — so it drifts on its own schedule and nothing notices. The failure is quiet by construction: the symlinks keep resolving, so the only signal is that a pull cron names a path no convention would predict.
+
+`skill-repos/` is **not** synced. The blanket `*` in the carrier-set gitignore already excludes it, which is what you want: these are independent git repos with their own remotes and history, some of them large, and the vault should not be carrying a nested checkout.
+
+Relocating an existing clone is a three-step change, and the second and third steps are the ones that get missed:
+
+1. `mv` the checkout to `<workspace>/skill-repos/<repo-name>/`.
+2. Re-run the repo's `install.sh`, **then verify each link individually** — a conservative installer refuses to overwrite symlinks pointing outside itself, so it will report `0 linked` and change nothing while every link is still dangling. Clear the dead links first.
+3. Update any cron that names the old path **and re-register it**. A registered job holds the prompt text it was created with; editing the config file alone leaves the old path firing.
 
 ## Decisions (preserved as historical record)
 

--- a/docs/workspace-design.md
+++ b/docs/workspace-design.md
@@ -74,7 +74,7 @@ Per-user runtime + content. Lives at `<repo>/workspace/` by default (post-M0). S
 | `state/auth/`, `state/cloud-auth.json`, `state/device.json` | ❌ no | Per-host durable | Install/identity state, per-host |
 | `logs/conversation.log` | ❌ no | Per-host runtime | Voice/phone/discord log; large + per-host |
 | `data/conversation.sqlite` | ❌ no | Per-host runtime | SQLite mirror of conversation log |
-| `skill-repos/<repo-name>/` | ❌ no | Per-host clone | Git checkouts of skill **source** repos that `skills/install.sh` symlinks from |
+| `skill-repos/<repo-name>/` | ❌ no | Per-host clone | Git checkouts of skill **source** repos; each is linked by its OWN installer, not by `skills/install.sh` |
 | `.env` | ❌ no | Per-host secret | Tokens, API keys — must NOT sync |
 
 The sync default is "synced unless excluded"; per-host runtime sub-paths are excluded via the carrier-set gitignore (per PR #1447) + `vault.sync.exclude` user overrides.
@@ -87,11 +87,16 @@ Clone skill repos there rather than into `$HOME`. A checkout outside the workspa
 
 `skill-repos/` is **not** synced. The blanket `*` in the carrier-set gitignore already excludes it, which is what you want: these are independent git repos with their own remotes and history, some of them large, and the vault should not be carrying a nested checkout.
 
-Relocating an existing clone is a three-step change, and the second and third steps are the ones that get missed:
+**`skills/install.sh` does not manage these.** It iterates only its own directory — `for skill_dir in "$SKILLS_DIR"/*/` — so it links the built-in `skills/*/` of this repo and nothing else; the string `skill-repos` does not appear in it. Each external checkout is linked by **its own** installer, at `skill-repos/<repo-name>/scripts/install.sh`. Measured on this host: 58 links point into this repo, 35 into `skill-repos/`, 3 elsewhere.
+
+Relocating a clone therefore depends on which installer owns it, because they differ on the one step that matters:
 
 1. `mv` the checkout to `<workspace>/skill-repos/<repo-name>/`.
-2. Re-run the repo's `install.sh`, **then verify each link individually** — a conservative installer refuses to overwrite symlinks pointing outside itself, so it will report `0 linked` and change nothing while every link is still dangling. Clear the dead links first.
-3. Update any cron that names the old path **and re-register it**. A registered job holds the prompt text it was created with; editing the config file alone leaves the old path firing.
+2. **Check how that repo's installer treats an existing symlink**, then act accordingly:
+   - `ln -sfn` (e.g. `sutando-personal`) — force-relinks in place. Re-run it; nothing to clear.
+   - skip-if-points-elsewhere (e.g. `sutando-skills`, which prints `⚠ <name> (symlink points elsewhere … skipping)`) — re-running it after a move changes **nothing**, because every link still names the old path. Remove those links first, then re-run.
+3. Verify each resulting link resolves, rather than trusting the installer's own count.
+4. Update any cron that names the old path **and re-register it**. A registered job holds the prompt text it was created with; editing the config file alone leaves the old path firing.
 
 ## Decisions (preserved as historical record)
 


### PR DESCRIPTION
## Why

The workspace contract enumerates `tasks/`, `results/`, `state/`, `data/`, `logs/`, `notes/`, `build_log.md`, `pending-questions.md` — and stops. `skill-repos/` was a de-facto convention, held up only by the clones that happened to be sitting in it.

Measured on one host: **5 of 6 skill source repos were under `<workspace>/skill-repos/`. The sixth was in `$HOME`.** Nothing was misconfigured and nothing was broken — there was simply no written rule for the outlier to violate.

The failure mode is quiet by construction. The installed form of a skill is a symlink, and a symlink into `$HOME` resolves exactly as well as one into the workspace. So:

- it is not in the sync carrier set,
- it is not in any workspace-level audit,
- it is not where anyone looks for it,

and the only visible trace is a pull cron naming a path no convention would predict. On the host above, that repo held **12 live skills** and a stale "this install is inert by design" note in the cron that had already caused it to be nearly ruled out as a skill home.

## What

One table row plus a short section in `docs/workspace-design.md`:

- what belongs in `skill-repos/` (the git checkout a skill symlink points **at**);
- why it is **not** synced — these are independent repos with their own remotes and history, some large, and the carrier-set blanket `*` already excludes them, which is the desired behaviour;
- the relocation steps, including the two that get missed.

Those two are worth calling out because both were hit doing this for real:

1. **A conservative `install.sh` reports `0 linked` and changes nothing** while every symlink is dangling — it refuses to overwrite links pointing outside itself, so the dead links have to be cleared first. Verify each link individually rather than trusting the summary.
2. **A registered cron keeps firing the path it was registered with.** Editing the config file does not reach it; it needs re-registering.

## Scope

Docs only — no code, no behaviour change.

**Correction to an earlier draft of this body:** I first wrote that nothing in the tree references `skill-repos/` programmatically. That was wrong — I asserted the grep instead of running it. Running it gives **4 hits in 2 files**:

```
hooks/result-file-marker-guard.py:7:  wrote ``[file: …/skill-repos/video-production/…/talk.mp4]`` into a result, and
hooks/result-file-marker-guard.py:8:  reported the task delivered. ``skill-repos/`` is not on the allowlist
tests/result-file-marker-guard.test.py:12: `skill-repos/` attached from a result body. The bridge posted
tests/result-file-marker-guard.test.py:31: OUTSIDE = WS / 'skill-repos' / 'video-production'
```

That strengthens the case rather than weakening it: `skill-repos/` is already load-bearing in a send-allowlist guard, which names it as a path whose contents must **not** be attachable from a result body. A directory a security hook reasons about is exactly one that should be written down in the contract. It also means the convention has a second consumer, so a clone living in `$HOME` sits outside that guard'''s mental model as well.

No code changes here; the guard and its test are untouched.