### PR TITLE
test(session-worker): the shutdown cap breach reported a bare AssertionError

### DIFF
--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -1550,7 +1550,10 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
             assert all(1 <= events[name] <= 2 for name in names), events
             assert not remaining_claims
             assert fallback_names == names
-            assert len(calls.read_text().splitlines()) <= 2
+            handler_calls = calls.read_text().splitlines()
+            # The cap is a concurrency bound; without the contents a breach
+            # reports a bare AssertionError and says nothing about which ran.
+            assert len(handler_calls) <= 2, handler_calls
             deadline = time.monotonic() + WORKER_EXIT_S
             while time.monotonic() < deadline:
                 try:


### PR DESCRIPTION
## The problem

`_assert_shutdown_falls_back_without_surviving_workers` ends with a bare assertion:

```python
assert len(calls.read_text().splitlines()) <= 2
```

When it fires, the entire failure output is the word `AssertionError`. Its two neighbours in the same block already attach context — `(repr(stdout), repr(stderr), remaining_claims, fallback_names)` and `events` — so this line is the outlier, and it is the one that keeps firing.

That cap counts handlers that **started**: the handler script appends its task name to `$HANDLER_CALLS` and then `sleep 10`s. A breach therefore means a handler was dispatched that should not have been — and *which* one, and how many, is exactly what the failure does not say. The enclosing `test_shutdown_falls_back_without_surviving_workers` calls the helper **10 times**, so a per-iteration race `p` surfaces as `1-(1-p)^10`: intermittent enough that it is usually read out of a CI log rather than reproduced locally, which is where a bare `AssertionError` costs the most.

## Before / after

Same forced breach (`<= -1`), run at the parent commit and at this HEAD:

```
--- PARENT origin/main (bare assert): rc=1
    final line: AssertionError
--- HEAD (assert carries contents): rc=1
    final line: AssertionError: ['task-shutdown-0.txt', 'task-shutdown-1.txt']
```

The control fails in the broken state by construction — it is the same assertion forced negative — and the only difference is what the failure tells you.

Unmodified, at this HEAD:

```
unforced run 1: rc=0
unforced run 2: rc=0
unforced run 3: rc=0
```

## Scope — read this before reviewing it as a fix

**This does not fix the race.** The condition is byte-identical (`<= 2`); only the failure message changes. I could not reproduce the breach locally — 12 consecutive runs on macOS all passed — and I am explicitly not reporting that as a rate, because it is a negative from an instrument that never fired. It says this host does not reproduce it, nothing more.

**Correction to this body (I verified the four PRs after writing it, and two were wrong).** I originally wrote that this assertion blocked #2160, #2928, #2738 and #2757. I had read the traceback for exactly one of them. Verified now, per PR:

| PR | actually failed on |
|---|---|
| #2738 | **this assertion** — `line 1553 … assert len(calls…) <= 2` → `AssertionError` |
| #2757 | **this assertion** — same frame, same bare `AssertionError` |
| #2160 | a **different** assertion in the same function: `assert set(events) == set(names)` |
| #2928 | nothing in this file — its terminal check is a CANCELLED job that never mentions it |

So this assertion is on record for **two** PRs, not four.

The #2160 failure is worth reading, because it argues this change rather than against it. That assertion already carries context, and the failure prints it:

```
AssertionError: ("'TASK_FILE: task-shutdown-0.txt\nTASK_FILE: task-shutdown-1.txt\nTASK_FILE: task-shutdown-3.txt\n'", …)
```

Three of four events, and it names the missing one — diagnosable on sight. The neighbouring line reports `AssertionError` and nothing else. Same function, same shutdown path, two failures minutes apart, and only one of them told anyone anything.

There is at least a third distinct failure mode in this area — `subprocess.TimeoutExpired` on `watch-tasks-stream.sh` at `SHUTDOWN_DRAIN_TIMEOUT_S`, reported by a peer against other PRs. This PR does not address that one either.

The cap may itself be wrong — nobody has established that 2 is the correct bound under concurrent drain entry. Widening it would hide a real concurrency violation, so this PR deliberately does not touch it. The next occurrence will simply say which handlers ran, and that is the input a real diagnosis needs.

No open PR touches this file (`gh pr list --json files` over all open PRs → no hits), so this does not collide with in-flight work.
