### PR TITLE
docs(built-in-tools): /capture requires the X-Sutando-Capture-Token header

### DIFF
--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -15,6 +15,7 @@ TOKEN="$(cat ~/.config/sutando/screen-capture-token)"
 curl -s -H "X-Sutando-Capture-Token: $TOKEN" http://localhost:7845/capture \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["path"])'
 # Multi-display: add ?all=true to capture every display, or ?display=N for a specific one.
+# /capture-video takes the same header — it is the other capture route, gated identically.
 ```
 Then use the Read tool on the returned path to view the screenshot. Use this for any screen-related question: "what am I looking at", "help me with this", "what's on my screen", etc.
 

--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -9,12 +9,16 @@ gws calendar +agenda --week              # this week
 gws calendar +agenda --days 7 --format json   # next 7 days, JSON for parsing
 ```
 
-**Screen capture** — see what's on the user's screen. The screen-capture server runs on port 7845 (started by `src/startup.sh`):
+**Screen capture** — see what's on the user's screen. The screen-capture server runs on port 7845 (started by `src/startup.sh`). Every capture route requires the startup token in `X-Sutando-Capture-Token` — without it the server answers `403 {"status":"error","error":"forbidden"}`:
 ```bash
-curl -s http://localhost:7845/capture | python3 -c 'import json,sys; print(json.load(sys.stdin)["path"])'
+TOKEN="$(cat ~/.config/sutando/screen-capture-token)"
+curl -s -H "X-Sutando-Capture-Token: $TOKEN" http://localhost:7845/capture \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["path"])'
 # Multi-display: add ?all=true to capture every display, or ?display=N for a specific one.
 ```
 Then use the Read tool on the returned path to view the screenshot. Use this for any screen-related question: "what am I looking at", "help me with this", "what's on my screen", etc.
+
+A `forbidden` response means the header was missing or stale, **not** that capture is unavailable — re-read the token file rather than restarting the server.
 
 `/capture` returns the display's native resolution — on a Retina screen that is
 megabyte-class per frame. Frames entering a live voice session (the Watch/vision


### PR DESCRIPTION
## What

`docs/built-in-tools.md` documents the `/capture` recipe without the `X-Sutando-Capture-Token` header the server has required since #1859 (2026-07-01). Following the documented command verbatim returns `403 forbidden`.

## Why it matters

`CLAUDE.md` names this file the authoritative catalog — *"check `docs/built-in-tools.md` BEFORE refusing or trying to invent a tool"* — so this is the recipe an agent actually runs when the user asks "what's on my screen". The failure is not self-describing: `{"status": "error", "error": "forbidden"}` reads as *the capture server is broken / permission is denied at the OS level*, not *you forgot a header*. I hit exactly that on a live host today and went looking at macOS TCC before reading `_require_capture_token` at `src/screen-capture-server.py:186`.

No doc in the tree mentions the header — `grep -rn "X-Sutando-Capture-Token" docs/ *.md` returns nothing on `origin/main`.

## Evidence

Both commands run against a live screen-capture server on the same host, back to back.

**Before** — the recipe exactly as `origin/main` documents it:

```
$ curl -s http://localhost:7845/capture
{"status": "error", "error": "forbidden"}
```

**After** — the recipe as this branch documents it:

```
$ TOKEN="$(cat ~/.config/sutando/screen-capture-token)"
$ curl -s -H "X-Sutando-Capture-Token: $TOKEN" http://localhost:7845/capture \
    | python3 -c 'import json,sys; print(json.load(sys.stdin)["path"])'
/var/folders/bs/0nw4fhvs4599_zcgpk3fbcnh0000gn/T/sutando-screenshots/screen-20260816-000802.png
```

The token path is the server's own: `_CAPTURE_TOKEN_PATH = ~/.config/sutando/screen-capture-token` (`src/screen-capture-server.py:40`), created or loaded at startup by `_load_or_create_capture_token()` (`:65`).

## Scope

Docs only — 6 insertions, 2 deletions, one file. No code change, no behavior change.
