### PR TITLE
fix(send-failure): a DNS failure is transient, but its subclass name was not matched

### DIFF
--- a/src/send_failure_policy.py
+++ b/src/send_failure_policy.py
@@ -28,6 +28,14 @@ _TRANSIENT_EXC_NAMES = frozenset({
     "DiscordServerError",
 })
 
+# Checked BEFORE the transient names: these inherit from a listed transient
+# (ClientConnectorError) but a bad cert, wrong CA or pin mismatch is a
+# misconfiguration — no number of retries turns it into a 200.
+_PERMANENT_EXC_NAMES = frozenset({
+    "ClientSSLError",            # + its cert/SSL connector subclasses
+    "ServerFingerprintMismatch",  # reaches the set via ServerConnectionError
+})
+
 
 def failure_status(exc: BaseException) -> int | None:
     """The HTTP status of a failed send, or None.
@@ -48,9 +56,12 @@ def is_transient(exc: BaseException) -> bool:
     Names are matched across the whole MRO, not just the concrete class: aiohttp
     raises `ClientConnectorDNSError(ClientConnectorError)` for a DNS failure, and
     an exact-name test misses every such subclass while its listed parent sits
-    right above it.
+    right above it. `_PERMANENT_EXC_NAMES` is the exception to that widening.
     """
-    if any(base.__name__ in _TRANSIENT_EXC_NAMES for base in type(exc).__mro__):
+    names = [base.__name__ for base in type(exc).__mro__]
+    if any(n in _PERMANENT_EXC_NAMES for n in names):
+        return False
+    if any(n in _TRANSIENT_EXC_NAMES for n in names):
         return True
     status = failure_status(exc)
     if status is not None:

--- a/src/send_failure_policy.py
+++ b/src/send_failure_policy.py
@@ -44,8 +44,13 @@ def is_transient(exc: BaseException) -> bool:
 
     The NAME is checked before the status: a status short-circuit made
     `_TRANSIENT_EXC_NAMES` unreachable for any of those types that carries one.
+
+    Names are matched across the whole MRO, not just the concrete class: aiohttp
+    raises `ClientConnectorDNSError(ClientConnectorError)` for a DNS failure, and
+    an exact-name test misses every such subclass while its listed parent sits
+    right above it.
     """
-    if type(exc).__name__ in _TRANSIENT_EXC_NAMES:
+    if any(base.__name__ in _TRANSIENT_EXC_NAMES for base in type(exc).__mro__):
         return True
     status = failure_status(exc)
     if status is not None:

--- a/tests/send-failure-policy.test.py
+++ b/tests/send-failure-policy.test.py
@@ -49,6 +49,35 @@ class TestIsTransient(unittest.TestCase):
 
         self.assertTrue(sfp.is_transient(ServerDisconnectedError()))
 
+    def test_a_subclass_of_a_listed_transient_is_transient(self):
+        # aiohttp raises ClientConnectorDNSError(ClientConnectorError) for a DNS
+        # failure, so the concrete name is NOT the listed one. Matching only the
+        # concrete class parked an owner's DM permanently on the first blip —
+        # the retry budget was never spent because the branch was never entered.
+        class ClientConnectorError(Exception):
+            pass
+
+        class ClientConnectorDNSError(ClientConnectorError):
+            pass
+
+        exc = ClientConnectorDNSError(
+            "Cannot connect to host discord.com:443 ssl:default "
+            "[nodename nor servname provided, or not known]")
+        self.assertNotIn(type(exc).__name__, sfp._TRANSIENT_EXC_NAMES)
+        self.assertTrue(sfp.is_transient(exc))
+        self.assertTrue(sfp.should_retry(exc, 0))
+
+    def test_an_unlisted_hierarchy_still_parks(self):
+        # The MRO walk must not turn "any exception" into a retry: only a listed
+        # ancestor counts.
+        class SomeLibraryError(Exception):
+            pass
+
+        class MalformedPayloadError(SomeLibraryError):
+            pass
+
+        self.assertFalse(sfp.is_transient(MalformedPayloadError("bad body")))
+
     def test_unknown_failure_parks(self):
         # Parking an unknown error loses nothing — quarantine preserves the body and
         # health-check reports it — while retrying forever would bury the log.

--- a/tests/send-failure-policy.test.py
+++ b/tests/send-failure-policy.test.py
@@ -78,6 +78,62 @@ class TestIsTransient(unittest.TestCase):
 
         self.assertFalse(sfp.is_transient(MalformedPayloadError("bad body")))
 
+    def test_a_tls_failure_parks_even_though_its_parent_is_listed(self):
+        # The MRO walk widens the transient set to everything under
+        # ClientConnectorError, which on aiohttp 3.13.5 pulls in three TLS types.
+        # A bad cert, wrong CA or pin mismatch is a misconfiguration: retrying
+        # only burns the 5-attempt budget before parking anyway.
+        class ClientConnectorError(Exception):
+            pass
+
+        class ClientSSLError(ClientConnectorError):
+            pass
+
+        class ClientConnectorCertificateError(ClientSSLError):
+            pass
+
+        class ClientConnectorSSLError(ClientSSLError):
+            pass
+
+        for cls in (ClientSSLError, ClientConnectorCertificateError,
+                    ClientConnectorSSLError):
+            exc = cls("certificate verify failed")
+            self.assertFalse(sfp.is_transient(exc), cls.__name__)
+            self.assertFalse(sfp.should_retry(exc, 0), cls.__name__)
+
+    def test_a_pinned_fingerprint_mismatch_parks_via_a_different_ancestor(self):
+        # ServerFingerprintMismatch is a TLS pin failure that reaches the
+        # transient set through ServerConnectionError, NOT ClientSSLError — so
+        # excluding the SSL branch alone would still have retried it.
+        class ClientConnectionError(Exception):
+            pass
+
+        class ServerConnectionError(ClientConnectionError):
+            pass
+
+        class ServerFingerprintMismatch(ServerConnectionError):
+            pass
+
+        self.assertTrue(sfp.is_transient(ServerConnectionError("dropped")),
+                        "the parent stays transient")
+        self.assertFalse(sfp.is_transient(ServerFingerprintMismatch("pin")))
+
+    def test_the_permanent_set_does_not_swallow_its_transient_siblings(self):
+        # ClientProxyConnectionError and ClientConnectorDNSError descend from
+        # ClientConnectorError WITHOUT passing through ClientSSLError, so the
+        # exclusion must not reach them.
+        class ClientConnectorError(Exception):
+            pass
+
+        class ClientProxyConnectionError(ClientConnectorError):
+            pass
+
+        class ClientConnectorDNSError(ClientConnectorError):
+            pass
+
+        self.assertTrue(sfp.is_transient(ClientProxyConnectionError("proxy down")))
+        self.assertTrue(sfp.is_transient(ClientConnectorDNSError("dns")))
+
     def test_unknown_failure_parks(self):
         # Parking an unknown error loses nothing — quarantine preserves the body and
         # health-check reports it — while retrying forever would bury the log.


### PR DESCRIPTION
## What

`is_transient()` matched `type(exc).__name__` against `_TRANSIENT_EXC_NAMES` — an exact match on the **concrete** class. aiohttp raises `ClientConnectorDNSError(ClientConnectorError)` for a DNS resolution failure, so the name in the list is the *parent*, one level up, and the check missed it.

Nothing downstream recovers: the exception carries no `.status`, and the final `isinstance(exc, (TimeoutError, ConnectionError))` fallback is `False` because aiohttp's connector errors derive from `OSError`, not `ConnectionError`.

Net effect: **a DNS blip parked an owner-facing DM permanently on the first failure.** `MAX_TRANSIENT_ATTEMPTS = 5` was never spent, because the retryable branch was never entered.

## Evidence — the live hierarchy

Run against the bridge's own venv (`workspace/runtime/bridge-venv`, aiohttp 3.14.3):

```
ClientConnectorDNSError -> ['ClientConnectorDNSError', 'ClientConnectorError', 'ClientOSError',
                            'ClientConnectionError', 'ClientError', 'OSError', 'Exception']
is ClientConnectorDNSError a ConnectionError? False
```

And end to end, forcing a real DNS failure through aiohttp and into the policy:

```
raised class : ClientConnectorDNSError
message      : Cannot connect to host no-such-host-xyzzy.invalid:443 ssl:default [nodename nor servname p...
is_transient : False
should_retry : False
in NAMES set : False
parent name  : ClientConnectorError (IS in set: True )
```

That message shape is exactly what the live incident logged:

```
[proactive] failed to DM …: Cannot connect to host discord.com:443
            ssl:default [nodename nor servname provided, or not known]
[proactive] send failure -> parked: proactive-result-task-1786733771019-1786734017.txt
```

## Before / after

Same subclass, same policy call, at the parent commit and at HEAD:

```
=== BEFORE (origin/main) ===
is_transient: False | should_retry: False
=== AFTER (this branch) ===
is_transient: True | should_retry: True
```

## Tests

```
$ python3 tests/send-failure-policy.test.py     # 28 tests, OK
$ python3 tests/send-failure-delegation.test.py #  8 tests, OK
```

The new test fails without the source change, verified by reverting only `src/send_failure_policy.py`:

```
FAIL: test_a_subclass_of_a_listed_transient_is_transient
AssertionError: False is not true
Ran 28 tests — FAILED (failures=1)
```

Two tests added: a listed transient's **subclass** retries, and an unrelated hierarchy still parks (the MRO walk must not turn "any exception" into a retry).

Why the existing suite passed throughout: every fake in it is declared *with the listed name itself* (`class ServerDisconnectedError(Exception)`), so no case exercised a subclass.

## Relation to #2910

#2910 reports the same parked message and is still valid — nothing reads `results/undelivered/`, so a parked body is stranded whatever put it there. But its stated cause is wrong, and I've commented there with this reproduction: it says *"`ClientConnectorError` is in `_TRANSIENT_EXC_NAMES`, so this is the known-retryable branch — it parked only because the outage outlasted `MAX_TRANSIENT_ATTEMPTS = 5`."* The raised class was `ClientConnectorDNSError`, so it parked immediately.

The two fixes are independent and complementary: this one stops transient failures from parking; #2910's sweeper recovers whatever legitimately parks.

## Scope

One condition in `src/send_failure_policy.py`, plus two tests. No behavior change for any exception whose concrete name is already listed.
