### PR TITLE
fix(gateway): a held long poll is an empty poll, not a network outage (#2922)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -585,6 +585,10 @@ URL = (_env_compat("REMOTE_TASK_URL", "AG2_REMOTE_URL")
        or _URL_FROM_TOKEN or _URL_FALLBACK).rstrip("/")
 PROVIDER = os.environ.get("REMOTE_TASK_PROVIDER") or "remote"
 POLL_WAIT = int(os.environ.get("REMOTE_TASK_POLL_WAIT") or "25")
+# A read timeout on the long poll is indistinguishable from the documented
+# `200 {"tasks": []}` hold-window expiry, so it is only an outage once no poll
+# has succeeded for this long.
+POLL_TIMEOUT_GRACE_S = 3 * (POLL_WAIT + 10)
 # Proactive-message drain: when REMOTE_PROACTIVE_ROOM names a room id, every
 # `results/proactive-*.txt` the agent writes is delivered to that room as a
 # gateway message (POST /v1/room op:message) and archived. This is the
@@ -2728,6 +2732,16 @@ def _maybe_start_event_channel() -> None:
         _log(f"event channel start failed (task delivery unaffected): {e}")
 
 
+def _poll_timeout_is_empty(last_ok: float, now: float,
+                           grace: float = POLL_TIMEOUT_GRACE_S) -> bool:
+    """Whether a long-poll read timeout should be read as `{"tasks": []}`.
+
+    False once no poll has succeeded within `grace`, so a wedged relay still
+    reaches the outage path instead of looping quietly forever.
+    """
+    return (now - last_ok) <= grace
+
+
 def main() -> None:
     if not TOKEN:
         sys.exit("FATAL: set REMOTE_TASK_TOKEN (the onboarding string, or a bare secret with REMOTE_TASK_URL).")
@@ -2755,6 +2769,7 @@ def main() -> None:
         _log(f"running unsupervised — output also logged to {_LOG_FILE}; "
              f"prefer launching through startup.sh for full diagnostics")
     backoff = 1
+    last_poll_ok = time.time()
     _emit_gateway_status(False, error="starting — not yet connected")
     _maybe_start_event_channel()  # additive/opt-in/isolated — never blocks the task loop
     while True:
@@ -2767,7 +2782,15 @@ def main() -> None:
                      "— exiting to avoid dual-poll")
                 return
             _post_heartbeat(inflight)
-            resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}", timeout=POLL_WAIT + 10)
+            try:
+                resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}", timeout=POLL_WAIT + 10)
+                last_poll_ok = time.time()
+            except TimeoutError:
+                # Read timeout only — a connect failure arrives as URLError and
+                # still takes the outage path below.
+                if not _poll_timeout_is_empty(last_poll_ok, time.time()):
+                    raise
+                resp = {"tasks": []}
             added = False
             pending_ack = []
             for task in resp.get("tasks", []):

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -1724,6 +1724,71 @@ def main() -> int:
             else:
                 os.environ[_k] = _v
 
+    # ── long-poll read timeout is the documented empty poll, not an outage ──
+    # The relay's contract is `200 {"tasks": []}` when the hold window expires.
+    # When it instead lets the client's read timeout fire, the two are
+    # indistinguishable, and treating the timeout as a network error backed the
+    # bridge off (up to 60s) and flipped gateway-status.json to
+    # `connected: false` while tasks were still arriving and results delivering.
+    grace = rtc.POLL_TIMEOUT_GRACE_S
+    check(grace >= rtc.POLL_WAIT + 10,
+          "poll-timeout: the grace covers at least one whole poll window")
+    check(rtc._poll_timeout_is_empty(1000.0, 1000.0),
+          "poll-timeout: a timeout right after a good poll reads as an empty poll")
+    check(rtc._poll_timeout_is_empty(1000.0, 1000.0 + grace),
+          "poll-timeout: still benign at exactly the grace boundary")
+    check(not rtc._poll_timeout_is_empty(1000.0, 1000.0 + grace + 1),
+          "poll-timeout: past the grace it is a real outage again")
+    check(not rtc._poll_timeout_is_empty(1000.0, 1000.0 + 86400),
+          "poll-timeout: a wedged relay never looks healthy, however long it hangs")
+
+    # The narrow catch must be a READ timeout only: a connect failure arrives as
+    # URLError, which is not a TimeoutError, so it keeps taking the outage path.
+    class _SlowBody(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", "13")
+            self.end_headers()
+            self.wfile.flush()
+            time.sleep(2)
+            self.wfile.write(b'{"tasks": []}')
+
+    slow = ThreadingHTTPServer(("127.0.0.1", 0), _SlowBody)
+    threading.Thread(target=slow.serve_forever, daemon=True).start()
+    try:
+        import urllib.error
+        import urllib.request
+        raised = None
+        try:
+            with urllib.request.urlopen(
+                    f"http://127.0.0.1:{slow.server_address[1]}/v1/tasks?wait=25",
+                    timeout=1) as _r:
+                _r.read()
+        except Exception as e:  # noqa: BLE001 — the type IS the assertion
+            raised = e
+        check(isinstance(raised, TimeoutError),
+              "poll-timeout: a held long poll raises TimeoutError (the type the bridge catches)")
+        check(not isinstance(raised, urllib.error.URLError),
+              "poll-timeout: it is NOT a URLError, so connect failures stay on the outage path")
+    finally:
+        slow.shutdown()
+
+    # Wiring: the policy is only worth anything if the poll call site consults
+    # it. Asserted against the loaded function, not a copy of the file.
+    import inspect
+    _loop = inspect.getsource(rtc.main)
+    _poll_call = _loop.split('"GET", f"/v1/tasks?wait=', 1)[-1][:400]
+    check("_poll_timeout_is_empty" in _poll_call,
+          "poll-timeout: the poll call site consults the policy")
+    check("except TimeoutError" in _poll_call,
+          "poll-timeout: the catch is scoped to the poll, not the whole iteration")
+    check("raise" in _poll_call,
+          "poll-timeout: past the grace it re-raises into the existing outage path")
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/tests/gateway-longpoll-timeout.test.py
+++ b/tests/gateway-longpoll-timeout.test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""A held long poll is the documented empty poll — until the grace expires.
+
+Drives the real poll loop for one iteration. The relay's contract is
+`200 {"tasks": []}` when the hold window expires; when it instead lets the
+client's read timeout fire, the two are indistinguishable, so classifying the
+timeout as a network error backed a healthy bridge off and wrote
+`connected: false` while tasks were still arriving.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_PKG = _REPO / "packages" / "ag2-sparrow"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+
+class _Clock:
+    """Stands in for the module's `time`, so the grace can expire without waiting."""
+
+    def __init__(self):
+        self.now = 1_000_000.0
+        self.slept: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, s: float) -> None:
+        self.slept.append(s)
+        self.now += s
+
+
+class _Loop:
+    """One iteration of the real `main()`: the second singleton check ends it."""
+
+    _PATCH = ("TOKEN", "URL", "time", "_acquire_singleton", "_load_inflight",
+              "_recover_orphan_proactive", "_maybe_start_event_channel",
+              "_heartbeat_singleton", "_post_heartbeat", "_req", "_write_task",
+              "_post_task_ack", "_post_ready_results", "_post_proactive",
+              "_reconcile_abandoned", "_emit_gateway_status", "_save_inflight", "_log")
+
+    def __init__(self, gw, poll_raises=None, advance=0.0):
+        self.gw, self.poll_raises, self.advance = gw, poll_raises, advance
+        self.clock = _Clock()
+        self.status: list[tuple] = []
+        self.logs: list[str] = []
+        self._saved: dict = {}
+        self._alive = [True, False]
+
+    def _poll(self, method, path, payload=None, **kw):
+        if path.startswith("/v1/tasks?wait="):
+            self.clock.now += self.advance
+            if self.poll_raises is not None:
+                raise self.poll_raises
+            return {"tasks": []}
+        return {}
+
+    def __enter__(self):
+        gw = self.gw
+        for n in self._PATCH:
+            self._saved[n] = getattr(gw, n)
+        gw.TOKEN, gw.URL = "secret", "http://relay.invalid"
+        gw.time = self.clock
+        gw._acquire_singleton = lambda *a, **k: True
+        gw._load_inflight = lambda *a, **k: set()
+        gw._heartbeat_singleton = lambda *a, **k: self._alive.pop(0) if self._alive else False
+        for noop in ("_recover_orphan_proactive", "_maybe_start_event_channel",
+                     "_post_heartbeat", "_post_task_ack", "_post_ready_results",
+                     "_post_proactive"):
+            setattr(gw, noop, lambda *a, **k: None)
+        gw._save_inflight = lambda *a, **k: None
+        gw._write_task = lambda *a, **k: None
+        gw._reconcile_abandoned = lambda inflight, s, *a, **k: s
+        gw._req = self._poll
+        gw._emit_gateway_status = lambda connected, **k: self.status.append((connected, k))
+        gw._log = lambda m: self.logs.append(str(m))
+        return self
+
+    def __exit__(self, *exc):
+        for n, v in self._saved.items():
+            setattr(self.gw, n, v)
+        return False
+
+    def run(self):
+        self.gw.main()
+        return self
+
+
+class LongPollTimeoutTest(unittest.TestCase):
+    def setUp(self):
+        try:
+            from ag2_sparrow import remote_gateway_bridge as gw
+        except (Exception, SystemExit) as e:  # noqa: BLE001
+            self.skipTest(f"gateway not importable: {str(e)[:60]}")
+        self.gw = gw
+
+    # ── the policy on its own ────────────────────────────────────────────
+    def test_the_grace_covers_at_least_one_whole_poll_window(self):
+        self.assertGreaterEqual(self.gw.POLL_TIMEOUT_GRACE_S, self.gw.POLL_WAIT + 10)
+
+    def test_benign_from_zero_up_to_and_including_the_boundary(self):
+        g = self.gw.POLL_TIMEOUT_GRACE_S
+        for dt in (0.0, g / 2, g):
+            self.assertTrue(self.gw._poll_timeout_is_empty(1000.0, 1000.0 + dt), dt)
+
+    def test_past_the_boundary_it_is_an_outage_again(self):
+        g = self.gw.POLL_TIMEOUT_GRACE_S
+        for dt in (g + 1, g * 10, 86400):
+            self.assertFalse(self.gw._poll_timeout_is_empty(1000.0, 1000.0 + dt), dt)
+
+    # ── the loop ─────────────────────────────────────────────────────────
+    def test_a_timeout_inside_the_grace_neither_logs_nor_backs_off(self):
+        with _Loop(self.gw, poll_raises=TimeoutError("The read operation timed out"),
+                   advance=1.0) as loop:
+            loop.run()
+        self.assertEqual(loop.clock.slept, [], "a benign empty poll must not back off")
+        self.assertNotIn("poll network error",
+                         " ".join(loop.logs), "and must not log an outage")
+        self.assertIn((True, {}), loop.status,
+                      "the iteration completes, so the bridge reports connected")
+
+    def test_a_timeout_past_the_grace_takes_the_outage_path(self):
+        grace = self.gw.POLL_TIMEOUT_GRACE_S
+        with _Loop(self.gw, poll_raises=TimeoutError("The read operation timed out"),
+                   advance=grace + 1) as loop:
+            loop.run()
+        self.assertEqual(loop.clock.slept, [1], "a real outage still backs off")
+        self.assertIn("poll network error", " ".join(loop.logs))
+        self.assertTrue(any(c is False and "network" in str(k.get("error", ""))
+                            for c, k in loop.status),
+                        "and still reports the gateway as not serving")
+
+    def test_a_connect_failure_is_untouched_by_the_timeout_branch(self):
+        # URLError is not a TimeoutError, so an unreachable relay keeps taking
+        # the outage path however recently a poll succeeded.
+        import urllib.error
+        with _Loop(self.gw, poll_raises=urllib.error.URLError("no route"),
+                   advance=1.0) as loop:
+            loop.run()
+        self.assertEqual(loop.clock.slept, [1])
+        self.assertIn("poll network error", " ".join(loop.logs))
+
+    def test_a_successful_poll_still_reports_connected(self):
+        with _Loop(self.gw, poll_raises=None, advance=1.0) as loop:
+            loop.run()
+        self.assertEqual(loop.clock.slept, [])
+        self.assertIn((True, {}), loop.status)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #2922 (client half — suggested fix 1 in that issue).

## The defect

The relay's contract, quoted at the top of `remote_gateway_bridge.py`, is `200 {"tasks": []}` when the hold window expires. When the relay instead lets the client's read timeout fire, the two outcomes are **indistinguishable from the client** — but the poll loop classified the timeout as a network error: one error log, exponential backoff (up to 60s), and `connected: false` written to `state/gateway-status.json`.

That flap is what makes `health-check.py` report

```
⚠ gateway-bridge  warn  process running but NOT serving — ag2.space mobile messages are not being delivered
⚠ core-supervisor warn  core degraded: gateway-down
```

while tasks are arriving and results are delivering through that same bridge. #2922 documents the live host: a fresh `GET /v1/tasks` returned 200 in 0.1s during the "outage", short requests never failed, and restarting the bridge did not stop the timeouts.

## The change

Scoped to the poll request alone:

```python
try:
    resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}", timeout=POLL_WAIT + 10)
    last_poll_ok = time.time()
except TimeoutError:
    if not _poll_timeout_is_empty(last_poll_ok, time.time()):
        raise
    resp = {"tasks": []}
```

- **Benign only while a poll has recently succeeded.** `POLL_TIMEOUT_GRACE_S = 3 * (POLL_WAIT + 10)`. Past it the timeout re-raises into the existing handler, so a genuinely wedged relay still logs, backs off and reports `connected: false`. This is the half that keeps #2345/#2253's silent-outage detection intact.
- **Read timeouts only.** A connect failure arrives as `URLError`, which is not a `TimeoutError` (verified below), so unreachable-relay behaviour is unchanged.
- **The catch does not span the iteration.** `_post_ready_results` / `_post_task_ack` / `_post_heartbeat` run inside the same outer `try`; widening the catch would let a failed *result POST* look like a quiet poll. Pinned by a test.

## Evidence

### 1. End-to-end, real bridge process, before vs after

`python3 -m ag2_sparrow.remote_gateway_bridge` against a stub relay that holds the first long poll past the client's read timeout (`REMOTE_TASK_POLL_WAIT=1` → timeout 11s, hold 15s), then serves one task. `gateway-status.json` sampled every 250 ms throughout.

**BEFORE** (`origin/main`, e4a6f2a^):
```
[remote-gateway-bridge] poll network error: timed out — backing off 1s
[remote-gateway-bridge] queued task-E2E1
  task delivered: True
  poll network errors: 1
  gateway-status samples: 78; showing connected:false with a network error: 4  e.g. 'network: timed out'
```

**AFTER** (this branch):
```
[remote-gateway-bridge] queued task-E2E1
  task delivered: True
  poll network errors: 0
  gateway-status samples: 79; showing connected:false with a network error: 0
```

### 2. The outage path still fires — same harness, relay holds *every* poll

```
[remote-gateway-bridge] poll network error: timed out — backing off 1s
[remote-gateway-bridge] poll network error: timed out — backing off 2s
[remote-gateway-bridge] poll network error: timed out — backing off 4s
[remote-gateway-bridge] poll network error: timed out — backing off 8s
  poll network errors: 4
  gateway-status samples: 291; showing connected:false with a network error: 163
  gateway-status.json: {"connected": false, ..., "backoff_s": 8, "error": "network: timed out"}
```

Errors resume once the grace expires; backoff escalates exactly as before.

### 3. The exception type the catch depends on

A held long poll raises a bare `TimeoutError`, not a `URLError` — asserted in the test against a live stub, for both the pre-header and post-header (body read) variants:

```
type: TimeoutError | isinstance TimeoutError: True | isinstance URLError: False
```

### 4. Unit tests — `src/remote-gateway-bridge.test.py`

10 new checks: the grace covers a whole poll window; benign at 0s and at exactly the boundary; an outage again one second past it; never benign after a day; the exception-type discriminators above; and three wiring checks asserted against `inspect.getsource(rtc.main)` (the loaded function, not a copy of the file) that the call site consults the policy, scopes the catch to the poll, and re-raises past the grace.

```
  ok  poll-timeout: the grace covers at least one whole poll window
  ok  poll-timeout: a timeout right after a good poll reads as an empty poll
  ok  poll-timeout: still benign at exactly the grace boundary
  ok  poll-timeout: past the grace it is a real outage again
  ok  poll-timeout: a wedged relay never looks healthy, however long it hangs
  ok  poll-timeout: a held long poll raises TimeoutError (the type the bridge catches)
  ok  poll-timeout: it is NOT a URLError, so connect failures stay on the outage path
  ok  poll-timeout: the poll call site consults the policy
  ok  poll-timeout: the catch is scoped to the poll, not the whole iteration
  ok  poll-timeout: past the grace it re-raises into the existing outage path
```

### 5. Pre-existing failure, unchanged by this branch

`src/remote-gateway-bridge.test.py` ends `FAILED (1)` on **both** `origin/main` (run in a clean worktree) and this branch, with the same single check:

```
FAIL env-fallback: no env token and no file yields empty token (no crash)
```

That is #2929 (green in CI, red on any host with a vault entry), not a regression here.

Sibling suites green: `tests/gateway-dedup-recovery.test.py`, `tests/remote-gateway-file-attach.test.py`, `tests/sparrow-integration-e2e.test.py`. `scripts/review-checks.sh` on the diff: PASS.

## Scope

Client-side only, one call site. The server half of #2922 (return `[]` comfortably before the client's read timeout) remains worth doing independently; this makes the bridge correct regardless of which side is slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTD5g2LhGVnYmNmn7q2nk8
