### PR TITLE
feat(coverage-gate): name the changed files coverage never measured (#2948)

### DIFF
--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -159,6 +159,30 @@ if [ "$gate_rc" -eq 0 ]; then
 else
     verdict="❌ **Diff coverage BELOW the ${FAIL_UNDER}% bar** — uncovered changed lines listed below. Whole-tree (informational): **${total}%**."
 fi
-publish_summary "$verdict" diff-cover.md
+
+# diff-cover reports only on files IN coverage.xml, so a changed file outside
+# `[run] source` is neither covered nor uncovered — the gate passes without
+# having looked at it. Report, never fail: this names the silence, it does not
+# move the bar.
+report="diff-cover.md"
+if unmeasured="$(python3 scripts/coverage_unmeasured.py "$BASE" coverage.xml)" \
+   && [ -n "$unmeasured" ]; then
+    echo
+    echo "coverage-gate: NOT MEASURED — changed, but absent from coverage.xml:"
+    printf '  %s\n' $unmeasured
+    echo "coverage-gate: their changed lines are outside the bar, not inside and clean."
+    {
+        cat diff-cover.md
+        echo
+        echo "### ⚠️ Not measured"
+        echo
+        echo "Changed, but absent from \`coverage.xml\` — outside \`[run] source\` in"
+        echo "\`.coveragerc\`, so **diff-cover never examined these lines**:"
+        echo
+        printf '-   `%s`\n' $unmeasured
+    } > coverage-gate-report.md
+    report="coverage-gate-report.md"
+fi
+publish_summary "$verdict" "$report"
 
 exit "$gate_rc"

--- a/scripts/coverage_unmeasured.py
+++ b/scripts/coverage_unmeasured.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Changed Python files that coverage never measured at all.
+
+`diff-cover` reports only on files PRESENT in coverage.xml, so a file outside
+`[run] source` is neither covered nor uncovered — it is invisible, and the gate
+passes without having looked at it. Naming those files is what separates "not
+measured" from "measured and clean".
+
+Usage: coverage_unmeasured.py <base-ref> <coverage.xml> [--rcfile .coveragerc]
+Prints one repo-relative path per line; empty output means nothing was missed.
+"""
+from __future__ import annotations
+
+import configparser
+import fnmatch
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def omit_globs(rcfile: str | Path) -> list[str]:
+    """The `[run] omit` patterns, read from coverage's own config.
+
+    Read rather than restated: a hardcoded copy drifts the moment someone edits
+    .coveragerc, and drifts silently in the direction of false alarms.
+    """
+    cp = configparser.ConfigParser()
+    try:
+        cp.read(rcfile)
+    except (configparser.Error, OSError):
+        return []
+    raw = cp.get("run", "omit", fallback="")
+    return [ln.strip() for ln in raw.splitlines() if ln.strip()]
+
+
+def is_omitted(path: str, globs: "list[str]") -> bool:
+    """Coverage matches an omit pattern against the path as a whole."""
+    return any(fnmatch.fnmatch(path, g) or fnmatch.fnmatch("/" + path, g)
+               for g in globs)
+
+
+def unmeasured(changed: "list[str]", measured: "set[str]",
+               globs: "list[str]") -> "list[str]":
+    """Changed files that are neither omitted on purpose nor present in the report.
+
+    `measured` holds coverage.xml's `filename` values, which are relative to a
+    `<source>` root, so a path is matched by suffix rather than equality.
+    """
+    out = []
+    for path in changed:
+        if is_omitted(path, globs):
+            continue
+        if any(path == m or path.endswith("/" + m) for m in measured):
+            continue
+        out.append(path)
+    return out
+
+
+def measured_files(xml_path: "str | Path") -> "set[str]":
+    try:
+        root = ET.parse(xml_path).getroot()
+    except (ET.ParseError, OSError):
+        return set()
+    return {el.get("filename") for el in root.iter("class") if el.get("filename")}
+
+
+def changed_py(base: str) -> "list[str]":
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=d", f"{base}...HEAD", "--", "*.py"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return []
+    return [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
+
+
+def main(argv: "list[str]") -> int:
+    if len(argv) < 3:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    base, xml_path = argv[1], argv[2]
+    rcfile = argv[4] if len(argv) > 4 and argv[3] == "--rcfile" else ".coveragerc"
+    for path in unmeasured(changed_py(base), measured_files(xml_path), omit_globs(rcfile)):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/coverage-unmeasured.test.py
+++ b/tests/coverage-unmeasured.test.py
@@ -104,5 +104,101 @@ class MeasuredFilesParsing(unittest.TestCase):
             self.assertEqual(self.m.measured_files(Path(td) / "absent.xml"), set())
 
 
+class MalformedConfig(unittest.TestCase):
+    def setUp(self):
+        self.m = _mod()
+
+    def test_an_unparsable_rcfile_yields_no_globs_rather_than_raising(self):
+        # Same fail-open contract as the report: the gate's verdict must never
+        # depend on this helper, so a broken config loses the exemptions rather
+        # than the run.
+        with tempfile.TemporaryDirectory() as td:
+            bad = Path(td) / ".coveragerc"
+            bad.write_text("[run\nomit = tests/*\n")   # unclosed section header
+            self.assertEqual(self.m.omit_globs(bad), [])
+
+
+class ChangedFilesComeFromGit(unittest.TestCase):
+    """`changed_py` runs git in the CWD, so drive it against a real repo."""
+
+    def setUp(self):
+        self.m = _mod()
+
+    def _repo(self, td: Path) -> Path:
+        import os
+        import subprocess
+        r = td / "repo"
+        r.mkdir()
+        env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+        run = lambda *a: subprocess.run(["git", "-C", str(r), *a],  # noqa: E731
+                                        check=True, capture_output=True, env=env)
+        subprocess.run(["git", "init", "-q", "-b", "base", str(r)],
+                       check=True, capture_output=True)
+        (r / "kept.py").write_text("x = 1\n")
+        run("add", "-A"); run("commit", "-qm", "base")
+        run("switch", "-qc", "topic")
+        (r / "added.py").write_text("y = 2\n")
+        (r / "notpython.md").write_text("doc\n")
+        run("add", "-A"); run("commit", "-qm", "topic")
+        return r
+
+    def test_only_changed_python_files_are_returned(self):
+        import os
+        with tempfile.TemporaryDirectory() as td:
+            r = self._repo(Path(td))
+            cwd = os.getcwd()
+            try:
+                os.chdir(r)
+                self.assertEqual(self.m.changed_py("base"), ["added.py"])
+            finally:
+                os.chdir(cwd)
+
+    def test_a_failing_git_yields_no_files_rather_than_raising(self):
+        # An unknown base ref (or a non-repo cwd) must not take the gate down.
+        import os
+        with tempfile.TemporaryDirectory() as td:
+            r = self._repo(Path(td))
+            cwd = os.getcwd()
+            try:
+                os.chdir(r)
+                self.assertEqual(self.m.changed_py("no-such-ref"), [])
+            finally:
+                os.chdir(cwd)
+
+
+class CommandLine(unittest.TestCase):
+    def setUp(self):
+        self.m = _mod()
+
+    def test_too_few_arguments_exits_nonzero_without_printing_paths(self):
+        import io
+        import contextlib
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc = self.m.main(["coverage_unmeasured.py"])
+        self.assertEqual(rc, 2)
+        self.assertIn("Usage", err.getvalue())
+
+    def test_it_prints_one_unmeasured_path_per_line(self):
+        import contextlib
+        import io
+        import os
+        with tempfile.TemporaryDirectory() as td:
+            xml = Path(td) / "coverage.xml"
+            xml.write_text(XML)
+            rc_file = Path(td) / ".coveragerc"
+            rc_file.write_text("[run]\nomit =\n    tests/*\n")
+            self.m.changed_py = lambda base: ["packages/x/bridge.py", "tests/a.test.py",
+                                              "src/health-check.py"]
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = self.m.main(["prog", "origin/main", str(xml), "--rcfile", str(rc_file)])
+        self.assertEqual(rc, 0)
+        # tests/ omitted on purpose; health-check.py is in the report by suffix.
+        self.assertEqual(out.getvalue().split(), ["packages/x/bridge.py"])
+        self.assertNotIn("tests/a.test.py", out.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/coverage-unmeasured.test.py
+++ b/tests/coverage-unmeasured.test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""`coverage_unmeasured`: name the changed files the gate never looked at.
+
+diff-cover reports only on files present in coverage.xml. A changed file
+outside `[run] source` is therefore neither covered nor uncovered — the gate
+reports success without having examined it, which is indistinguishable from
+success on a well-tested file.
+"""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _mod():
+    spec = importlib.util.spec_from_file_location(
+        "cov_unmeasured", REPO / "scripts" / "coverage_unmeasured.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+XML = """<?xml version="1.0" ?>
+<coverage><packages><package><classes>
+  <class filename="health-check.py"/>
+  <class filename="task_priority.py"/>
+</classes></package></packages></coverage>
+"""
+
+
+class UnmeasuredFiles(unittest.TestCase):
+    def setUp(self):
+        self.m = _mod()
+
+    def test_a_file_outside_source_is_reported(self):
+        # The live case: packages/ is not in `[run] source`, so a bridge change
+        # passed the gate without a single one of its lines being examined.
+        out = self.m.unmeasured(
+            ["src/health-check.py", "packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py"],
+            {"health-check.py", "task_priority.py"}, [])
+        self.assertEqual(out, ["packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py"])
+
+    def test_a_measured_file_is_not_reported(self):
+        # coverage.xml filenames are relative to a <source> root, so the match
+        # is by suffix — `src/health-check.py` vs `health-check.py`.
+        self.assertEqual(
+            self.m.unmeasured(["src/health-check.py"], {"health-check.py"}, []), [])
+
+    def test_a_deliberately_omitted_file_is_not_reported(self):
+        # tests/ is in `[run] omit` on purpose; reporting it every run would
+        # train the reader to skip the section that matters.
+        self.assertEqual(
+            self.m.unmeasured(["tests/foo.test.py"], {"health-check.py"}, ["tests/*"]), [])
+
+    def test_a_suffix_collision_does_not_mask_an_unmeasured_file(self):
+        # "endswith" alone would let a measured `a/util.py` vouch for an
+        # unmeasured `elsewhere/xutil.py`; the separator is what prevents it.
+        self.assertEqual(
+            self.m.unmeasured(["pkg/xutil.py"], {"util.py"}, []), ["pkg/xutil.py"])
+
+    def test_nothing_changed_reports_nothing(self):
+        self.assertEqual(self.m.unmeasured([], {"health-check.py"}, []), [])
+
+
+class OmitGlobsComeFromCoveragerc(unittest.TestCase):
+    """Read coverage's own config — a restated copy drifts the moment it is edited."""
+
+    def setUp(self):
+        self.m = _mod()
+
+    def test_the_repo_rcfile_is_parsed(self):
+        globs = self.m.omit_globs(REPO / ".coveragerc")
+        self.assertIn("tests/*", globs)
+
+    def test_a_missing_rcfile_yields_no_globs_rather_than_raising(self):
+        self.assertEqual(self.m.omit_globs(REPO / "does-not-exist.cfg"), [])
+
+    def test_omitted_matching_handles_a_leading_slash_pattern(self):
+        self.assertTrue(self.m.is_omitted("a/node_modules/x.py", ["*/node_modules/*"]))
+        self.assertFalse(self.m.is_omitted("src/x.py", ["*/node_modules/*"]))
+
+
+class MeasuredFilesParsing(unittest.TestCase):
+    def setUp(self):
+        self.m = _mod()
+
+    def test_filenames_are_read_from_the_report(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "coverage.xml"
+            p.write_text(XML)
+            self.assertEqual(self.m.measured_files(p),
+                             {"health-check.py", "task_priority.py"})
+
+    def test_an_unreadable_report_yields_an_empty_set_not_an_exception(self):
+        # Fail-open: the gate's verdict must never depend on this helper.
+        with tempfile.TemporaryDirectory() as td:
+            bad = Path(td) / "coverage.xml"
+            bad.write_text("not xml at all")
+            self.assertEqual(self.m.measured_files(bad), set())
+            self.assertEqual(self.m.measured_files(Path(td) / "absent.xml"), set())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Addresses the **narrow half** of #2948. The other half — adding `packages` to `[run] source` — is a real bar change and stays open there for the maintainers to decide; this does not foreclose it, and the two compose (any future out-of-scope tree gets named the same way).

## The defect

`diff-cover` reports only on files **present in `coverage.xml`**. A changed file outside `[run] source` is therefore neither covered nor uncovered — it is invisible, and the gate reports success without having examined it. That is byte-identical to success on a well-tested file.

Today that tree is `packages/`, which holds the AG2 Space transport: the poll loop, result POST/ack, the lease protocol, the proactive drain.

## Evidence — before

`.coveragerc` scopes measurement to `source = src, scripts, skills`. Running one existing suite that imports and drives the bridge, under the repo's own rcfile:

```
$ SUTANDO_TEST_SUBPROCESS_COVERAGE=1 coverage run --rcfile=.coveragerc tests/gateway-dedup-recovery.test.py
$ coverage combine && coverage xml
files in coverage.xml:            114
packages/ | ag2_sparrow entries:  []
```

And the live consequence, on #2947 (which changes the bridge's poll loop):

```
e4a6f2ae   diff coverage >= 95% (python) | success     <- bridge change, no tests/ test at all
57a57701   diff coverage >= 95% (python) | success
```

Green both times, having looked at none of those lines.

## Evidence — after

Same PR head, the new check run against `origin/main`:

```
changed .py vs origin/main:
  packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
  src/remote-gateway-bridge.test.py
  tests/gateway-longpoll-timeout.test.py

NOT MEASURED:
  packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
  src/remote-gateway-bridge.test.py
```

Both reports are correct, and the second one is a bonus I did not set out to find: **a `*.test.py` living under `src/` is never executed by the gate** (`coverage-gate.sh` discovers `find tests -name '*.test.py'`), so it produces no coverage data. I assumed the opposite earlier today and drew a wrong conclusion from it; naming it is the feature working. `tests/gateway-longpoll-timeout.test.py` is correctly *not* reported — `tests/*` is in `omit` on purpose.

On this PR's own branch the check prints nothing, since it touches only `scripts/` and `tests/`.

## Scope and safety

- **Report, never fail.** `gate_rc` and the verdict line are untouched; nothing that passes today starts failing.
- **Omit patterns are read from `.coveragerc`**, not restated, so the two cannot drift.
- **Fail-open:** an unparsable or absent `coverage.xml`/rcfile yields an empty result rather than raising, so the gate's verdict never depends on this helper. Pinned by tests.

## Tests

`tests/coverage-unmeasured.test.py`, 10 cases, green:

- a file outside `source` is reported; a measured one is not (matched by suffix, since `coverage.xml` filenames are relative to a `<source>` root)
- a deliberately-omitted file is not reported — otherwise the section trains the reader to skip it
- **a suffix collision cannot mask a real miss**: a measured `util.py` must not vouch for an unmeasured `pkg/xutil.py`; the separator is what prevents it
- the repo's real `.coveragerc` parses; a missing one yields no globs rather than raising
- an unparsable and an absent `coverage.xml` both yield an empty set

`bash -n scripts/coverage-gate.sh` parses. `scripts/review-checks.sh` on the diff: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTD5g2LhGVnYmNmn7q2nk8
