### PR TITLE
fix(start-cli): honor SUTANDO_TMUX_SESSION and forward it into the core env

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -49,7 +49,7 @@ TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
 # A tmux server inherits its GLOBAL environment from whichever process starts it,
 # and `start-server` on a serverless socket is a no-op — so unset before any tmux.
 unset SUTANDO_CORE_MODEL
-SESSION="sutando-core"
+SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 
 # Marker identifying THIS process as the long-lived sutando-core session (as
 # opposed to an ad-hoc `claude` in the same checkout — PR review, codex, etc.).
@@ -62,6 +62,8 @@ SESSION="sutando-core"
 export SUTANDO_CORE_SESSION=1
 export SUTANDO_CORE_RUNTIME=claude
 CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=claude)
+[ -n "${SUTANDO_TMUX_SOCKET:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TMUX_SOCKET=$SUTANDO_TMUX_SOCKET")
+[ -n "${SUTANDO_TMUX_SESSION:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TMUX_SESSION=$SUTANDO_TMUX_SESSION")
 # Forward the embedder-provided default workspace into the core session for the
 # SAME reason as above (tmux takes the server env, not this shell's). Without
 # this the core's own resolve_workspace() (proactive-loop, task scripts) misses

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -115,10 +115,10 @@ def _socket_path() -> str:
 
 def core_session() -> str:
     """The tmux session the core runs in, per the env/default contract.
-    NOT authoritative: the Claude launcher hardcodes SESSION="sutando-core"
-    (claude/cli/start-cli.sh:52) and never forwards SUTANDO_TMUX_SESSION, so an
-    exported value can name a session that does not exist. Prefer
-    _observed_session() for anything recorded."""
+    NOT authoritative: this is an unverified claim from the environment, not a
+    confirmed live session (the Claude launcher honors SUTANDO_TMUX_SESSION as
+    of claude/cli/start-cli.sh, but an exported value can still name a session
+    that never started). Prefer _observed_session() for anything recorded."""
     return os.environ.get("SUTANDO_TMUX_SESSION", "sutando-core")
 
 


### PR DESCRIPTION
## Priority

**Level:** low
**Reason:** cleanup with no urgency — currently-dormant wiring gap, not a live incident

## Closes

<!-- not tied to an issue -->

## Summary

`SESSION` in `start-cli.sh` was hardcoded to `"sutando-core"` even though the script already reads its sibling env var `SUTANDO_TMUX_SOCKET` via `${SUTANDO_TMUX_SOCKET:-default}`. An embedder that runs multiple checkouts on one host (each given its own `SUTANDO_TMUX_SESSION` + `SUTANDO_TMUX_SOCKET`) has that session name silently ignored, and neither var was forwarded into the tmux server's own environment for child processes under it to see.

## Checklist

- [x] Confirmed no other open PR closes the same issue (`gh pr list --repo sonichi/sutando --search "SUTANDO_TMUX_SESSION OR start-cli tmux session"` — no match)
- [x] Git author email matches my CLA-signed email (`git log -1 --format='%ae'` → `755598698@qq.com`, not `*.local` or `noreply@anthropic.com`)
- [x] Single concern per PR — no bundled refactors / drive-by feature additions
- [x] Confirmed bug exists on `upstream/main` (built the branch directly off current `origin/main`)
- [x] Test added (or N/A explained below) — N/A: exercised via the file's existing `--print-core-env` test probe + the existing `start-cli-proxy-routing` suite, which already asserts `CORE_ENV_ARGS` contents; no new probe needed since the two added lines follow the exact same pattern the proxy-routing suite already covers for `ANTHROPIC_BASE_URL`
- [x] **Before/after evidence pasted below**
- [x] Every claim in this PR body is verifiable from the diff or the pasted output
- [x] **Live path?** N/A — this only changes env defaulting/forwarding read at process start; did not exercise a real tmux launch (would risk the sandbox's own live core session), verified instead via the script's dedicated `--print-core-env` test-only exit path (see evidence)
- [x] **Stacked PR?** No
- [x] Scanned added lines for host-specific hardcoded paths and inline home/workspace fallbacks — none added
- [x] N/A — no CI workflow changes
- [x] N/A — no workspace/home-path resolution touched

## Before / after evidence

Before (`git show HEAD~1:src/agent/claude/cli/start-cli.sh`, i.e. current `main`):
```
SESSION="sutando-core"
...
CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=claude)
# (SUTANDO_TMUX_SOCKET / SUTANDO_TMUX_SESSION not forwarded)
```

After — real command run against this branch:
```
$ SUTANDO_TMUX_SESSION=probe-session SUTANDO_TMUX_SOCKET=/tmp/probe.sock \
    bash src/agent/claude/cli/start-cli.sh --print-core-env
-e
SUTANDO_CORE_SESSION=1
-e
SUTANDO_CORE_RUNTIME=claude
-e
SUTANDO_TMUX_SOCKET=/tmp/probe.sock
-e
SUTANDO_TMUX_SESSION=probe-session
```

`SESSION` itself (unset case still defaults correctly):
```
$ bash -c 'SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"; echo "$SESSION"'
sutando-core
$ SUTANDO_TMUX_SESSION=probe-session bash -c 'SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"; echo "$SESSION"'
probe-session
```

## Test plan

```
$ bash tests/start-cli-proxy-routing.test.sh
...
PASS — 13 checks green

$ python3 tests/start-cli-model-pin.test.py
✓ case default
✓ case env-ignored
✓ case tmux-clear
✓ case tmux-launch
✓ case fresh-socket
✓ case pinned-attach
start-cli.sh ignores the model pin and clears it.
```