### PR TITLE
fix(health-check): a broken pyexpat should not make this probe report on itself

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4315,11 +4315,8 @@ def _resolved_credential_service(config_dir: Optional[str]) -> Optional[str]:
 
 
 def _plist_via_plutil(path: "Path") -> "dict | None":
-    """Parse a plist without `plistlib`, for interpreters whose pyexpat is broken.
-
-    Returns None on any failure, which keeps the caller's existing warn as the
-    behaviour everywhere plutil is absent (non-macOS) or unhappy.
-    """
+    """Parse a plist without `plistlib`. None on any failure, which keeps the
+    caller's existing warn wherever plutil is absent or unusable."""
     try:
         out = subprocess.run(["/usr/bin/plutil", "-convert", "json", "-o", "-", str(path)],
                              capture_output=True, text=True, timeout=10)
@@ -4437,9 +4434,8 @@ def check_quota_account_identity(proxy_status: str, core_env_prober=None) -> dic
     try:
         import plistlib
     except ImportError as exc:
-        # #2588 stopped this ImportError killing the run; the probe then warned
-        # about its own interpreter instead of answering. `plutil` ships with
-        # macOS and needs no expat, so the question is still answerable here.
+        # plutil needs no expat, so the comparison stays answerable on exactly
+        # the hosts where this import fails.
         rendered = _plist_via_plutil(plist)
         if rendered is None:
             return {"name": name, "status": "warn",

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4314,6 +4314,26 @@ def _resolved_credential_service(config_dir: Optional[str]) -> Optional[str]:
     return None
 
 
+def _plist_via_plutil(path: "Path") -> "dict | None":
+    """Parse a plist without `plistlib`, for interpreters whose pyexpat is broken.
+
+    Returns None on any failure, which keeps the caller's existing warn as the
+    behaviour everywhere plutil is absent (non-macOS) or unhappy.
+    """
+    try:
+        out = subprocess.run(["/usr/bin/plutil", "-convert", "json", "-o", "-", str(path)],
+                             capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        parsed = json.loads(out.stdout)
+    except ValueError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def check_quota_account_identity(proxy_status: str, core_env_prober=None) -> dict:
     """Does the proxy resolve THIS core's login, or a different account's?
 
@@ -4417,15 +4437,22 @@ def check_quota_account_identity(proxy_status: str, core_env_prober=None) -> dic
     try:
         import plistlib
     except ImportError as exc:
-        return {"name": name, "status": "warn",
-                "detail": (f"cannot parse the credential-proxy plist — this Python "
-                           f"cannot import plistlib ({exc.__class__.__name__}: {exc}). "
-                           f"Every other check is unaffected.")}
-    try:
-        rendered = plistlib.loads(plist.read_bytes())
-    except (OSError, ValueError) as exc:
-        return {"name": name, "status": "warn",
-                "detail": f"cannot read the credential-proxy plist ({exc})"}
+        # #2588 stopped this ImportError killing the run; the probe then warned
+        # about its own interpreter instead of answering. `plutil` ships with
+        # macOS and needs no expat, so the question is still answerable here.
+        rendered = _plist_via_plutil(plist)
+        if rendered is None:
+            return {"name": name, "status": "warn",
+                    "detail": (f"cannot parse the credential-proxy plist — this Python "
+                               f"cannot import plistlib ({exc.__class__.__name__}: {exc}) "
+                               f"and plutil could not read it either. "
+                               f"Every other check is unaffected.")}
+    else:
+        try:
+            rendered = plistlib.loads(plist.read_bytes())
+        except (OSError, ValueError) as exc:
+            return {"name": name, "status": "warn",
+                    "detail": f"cannot read the credential-proxy plist ({exc})"}
     # A plist can PARSE and still be the wrong shape — `EnvironmentVariables`
     # encoded as a string, say. `.get` on that raises AttributeError, which is
     # not caught above and would abort the whole health run, taking every later

--- a/tests/health-check-quota-account-identity.test.py
+++ b/tests/health-check-quota-account-identity.test.py
@@ -17,6 +17,7 @@ Keychain access is stubbed — these tests never touch the real keychain and nev
 read a token. The production code compares keychain ITEM NAMES only.
 """
 import hashlib
+import json
 import importlib.util
 import os
 import plistlib
@@ -394,6 +395,58 @@ class TestQuotaAccountIdentity(unittest.TestCase):
             hc._resolved_credential_service(core)
         for call in run.call_args_list:
             self.assertNotIn("-w", call.args[0], "must not read the secret value")
+
+
+    # ---- an interpreter that cannot import plistlib must still ANSWER -------
+
+    def test_plistlib_unavailable_answers_via_plutil(self):
+        """A broken pyexpat is an interpreter fault, not an unanswerable question.
+
+        #2588 stopped that ImportError killing the whole run; with no fallback the
+        probe then reported on its own interpreter instead of on the two logins,
+        and a live host warned that way for two weeks while the real answer was
+        "same item"."""
+        core = "/Users/x/ws/.claude-sutando"
+        payload = json.dumps({"Label": "com.sutando.credential-proxy",
+                              "EnvironmentVariables": {"CLAUDE_CONFIG_DIR": core}})
+        with mock.patch.dict(sys.modules, {"plistlib": None}), \
+             mock.patch.object(hc.subprocess, "run",
+                               return_value=mock.Mock(returncode=0, stdout=payload)):
+            out = self._run(core_cfg=core, plist_cfg=core,
+                            existing_services={_scoped(core), VANILLA})
+        self.assertEqual(out["status"], "ok", out["detail"])
+        self.assertIn("same keychain item", out["detail"])
+
+    def test_plutil_unusable_keeps_the_original_warning(self):
+        """No plutil (every non-macOS host), a non-zero exit, or JSON whose root
+        is not a mapping must keep the warn — never become a false "ok"."""
+        core = "/Users/x/ws/.claude-sutando"
+        cases = [("side_effect", OSError("no plutil binary")),
+                 ("side_effect", hc.subprocess.SubprocessError("timeout")),
+                 ("return_value", mock.Mock(returncode=1, stdout="")),
+                 ("return_value", mock.Mock(returncode=0, stdout="not json")),
+                 ("return_value", mock.Mock(returncode=0, stdout='["a list"]'))]
+        for kind, outcome in cases:
+            with self.subTest(outcome=repr(outcome)[:40]):
+                with mock.patch.dict(sys.modules, {"plistlib": None}), \
+                     mock.patch.object(hc.subprocess, "run", **{kind: outcome}):
+                    out = self._run(core_cfg=core, plist_cfg=core,
+                                    existing_services={_scoped(core), VANILLA})
+                self.assertEqual(out["status"], "warn", out["detail"])
+                self.assertIn("cannot import plistlib", out["detail"])
+
+    def test_plutil_is_asked_for_the_plist_path_and_json(self):
+        """Pin the invocation: json output, to stdout, for THIS plist."""
+        core = "/Users/x/ws/.claude-sutando"
+        payload = json.dumps({"EnvironmentVariables": {"CLAUDE_CONFIG_DIR": core}})
+        with mock.patch.dict(sys.modules, {"plistlib": None}), \
+             mock.patch.object(hc.subprocess, "run",
+                               return_value=mock.Mock(returncode=0, stdout=payload)) as run:
+            self._run(core_cfg=core, plist_cfg=core,
+                      existing_services={_scoped(core), VANILLA})
+        argv = run.call_args_list[0].args[0]
+        self.assertEqual(argv[:4], ["/usr/bin/plutil", "-convert", "json", "-o"])
+        self.assertTrue(argv[-1].endswith("com.sutando.credential-proxy.plist"), argv)
 
 
 if __name__ == "__main__":

--- a/tests/health-check-quota-account-identity.test.py
+++ b/tests/health-check-quota-account-identity.test.py
@@ -400,12 +400,8 @@ class TestQuotaAccountIdentity(unittest.TestCase):
     # ---- an interpreter that cannot import plistlib must still ANSWER -------
 
     def test_plistlib_unavailable_answers_via_plutil(self):
-        """A broken pyexpat is an interpreter fault, not an unanswerable question.
-
-        #2588 stopped that ImportError killing the whole run; with no fallback the
-        probe then reported on its own interpreter instead of on the two logins,
-        and a live host warned that way for two weeks while the real answer was
-        "same item"."""
+        """A broken pyexpat is an interpreter fault, not an unanswerable
+        question: the two logins must still be compared."""
         core = "/Users/x/ws/.claude-sutando"
         payload = json.dumps({"Label": "com.sutando.credential-proxy",
                               "EnvironmentVariables": {"CLAUDE_CONFIG_DIR": core}})
@@ -418,8 +414,8 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         self.assertIn("same keychain item", out["detail"])
 
     def test_plutil_unusable_keeps_the_original_warning(self):
-        """No plutil (every non-macOS host), a non-zero exit, or JSON whose root
-        is not a mapping must keep the warn — never become a false "ok"."""
+        """No plutil, a bad exit, or a non-mapping root keeps the warn — a
+        fallback must never turn "cannot tell" into "ok"."""
         core = "/Users/x/ws/.claude-sutando"
         cases = [("side_effect", OSError("no plutil binary")),
                  ("side_effect", hc.subprocess.SubprocessError("timeout")),


### PR DESCRIPTION
## Priority

**Level:** low
**Reason:** a probe that has been silently unable to answer on affected hosts since 2026-08-03 — no data loss, but the check it exists to perform has not run there.

## Closes

<!-- not tied to an issue; follows #2588 -->

## Summary

`check_quota_account_identity` imports `plistlib` lazily, because `plistlib` pulls in `pyexpat` and an interpreter whose pyexpat cannot `dlopen` its libexpat raises `ImportError`. #2588 made that import lazy so one optional probe could not take down all 39 checks — that part works and is not changed here.

The residue is that on those hosts the probe now answers a **different question than the one it exists to ask**. Instead of comparing the login the core resolves against the login the credential proxy resolves, it reports that this interpreter cannot import a module. That is true, and it is not the check.

`plutil` is part of macOS, needs no expat, and reads the same file. Since the failing hosts are macOS by construction (the probe only runs when a `~/Library/LaunchAgents/…plist` exists), the question is still answerable exactly where the import fails.

## What changed

- New `_plist_via_plutil(path)` — `plutil -convert json -o -`, returning `None` on a missing binary, a non-zero exit, unparseable output, or a non-mapping root.
- The `except ImportError` branch tries it, and keeps the **existing warn** when it returns `None`. Non-macOS hosts, where there is no `plutil`, are unchanged.

## Evidence

Same file, same commit, one host that has warned this way since 2026-08-03. The fallback is the only difference:

```
before   warn  cannot parse the credential-proxy plist — this Python cannot import
               plistlib (ImportError: dlopen ... pyexpat ... Symbol not found:
               _XML_SetAllocTrackerActivationThreshold)

after    ok    proxy and core resolve the same keychain item
               (Claude Code-credentials-<hash>) — name match only
```

The warning was masking a **clean** result, and nothing on that host could distinguish that from a real account divergence — which is the failure this probe was built to catch.

### Control — the new assertions fail in the broken state

Run against the parent commit's `src/health-check.py`, with the new test file:

```
FAIL  test_plistlib_unavailable_answers_via_plutil
ERROR test_plutil_is_asked_for_the_plist_path_and_json
pass  test_plutil_unusable_keeps_the_original_warning   <- unchanged behaviour, correctly still passes
```

At HEAD:

```
Ran 25 tests in 0.026s
OK
```

All 74 `tests/health-check*.test.py` suites pass (`suites failing: 0 of 74`), including `health-check-import-without-plistlib.test.py`, which pins #2588's contract. `scripts/review-checks.sh --diff` → `PASS (hardcoded-paths + root-artifacts clean)`.

### Why three tests and not one

- `test_plistlib_unavailable_answers_via_plutil` — the fallback answers (`ok`, same item) instead of describing the interpreter.
- `test_plutil_unusable_keeps_the_original_warning` — five ways plutil can be unusable (absent, `SubprocessError`, non-zero exit, non-JSON output, JSON whose root is a list) must each keep the warn. **A fallback that turns "cannot tell" into a false `ok` would be worse than the warning it replaces**, and this is the assertion that would catch it.
- `test_plutil_is_asked_for_the_plist_path_and_json` — pins the invocation, so a future edit cannot quietly point it at another file or format.

`import plistlib` is made to fail with `mock.patch.dict(sys.modules, {"plistlib": None})`, which raises `ImportError` on the *next* import — the fixture builder's already-bound module reference keeps working, so the test needs no broken interpreter to run and passes on Linux CI.

## Checklist

- [x] Confirmed no other open PR covers this (`gh pr list --search "plistlib OR pyexpat OR plutil"` — #2588 and #2590 are the merged lazy-import work; nothing open)
- [x] Single concern
- [x] Control that fails at the parent commit, pasted above as actual output
- [x] No hardcoded host paths in the diff (`review-checks.sh` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
