### PR TITLE
fix(coverage-gate): the "Not measured" report aborts the gate instead of rendering

### DIFF
--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -179,7 +179,9 @@ if unmeasured="$(python3 scripts/coverage_unmeasured.py "$BASE" coverage.xml)" \
         echo "Changed, but absent from \`coverage.xml\` — outside \`[run] source\` in"
         echo "\`.coveragerc\`, so **diff-cover never examined these lines**:"
         echo
-        printf '-   `%s`\n' $unmeasured
+        # `--` ends option parsing: a format starting with `-` is otherwise
+        # read as a flag, and the report aborts the gate instead of rendering.
+        printf -- '-   `%s`\n' $unmeasured
     } > coverage-gate-report.md
     report="coverage-gate-report.md"
 fi

--- a/tests/coverage-gate-unmeasured-report.test.sh
+++ b/tests/coverage-gate-unmeasured-report.test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# The "Not measured" report must RENDER, not abort the gate.
+#
+# Its bullet format begins with "-", which bash's printf builtin parses as an
+# option unless "--" ends option parsing. The formats are read out of the
+# shipping script and executed, so this fails on the real source rather than on
+# a copy of it.
+set -u
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$REPO/scripts/coverage-gate.sh"
+fails=0
+
+check() {  # name, expected, actual
+  if [ "$2" = "$3" ]; then echo "  ok   $1"; else
+    echo "  FAIL $1: expected '$2', got '$3'"; fails=$((fails + 1)); fi
+}
+
+[ -f "$GATE" ] || { echo "FAIL: $GATE missing"; exit 1; }
+
+# Every printf in the gate, executed exactly as written, with one argument.
+n=0
+while IFS= read -r line; do
+  n=$((n + 1))
+  err=$(eval "${line} probe" 2>&1 >/dev/null)
+  check "printf #$n renders without a bash option error" "" "$err"
+done < <(grep -oE "printf (--[[:space:]])?'[^']*'" "$GATE" | grep -v '%s'"'"' |' )
+
+check "at least one printf was exercised" "yes" "$([ "$n" -gt 0 ] && echo yes || echo no)"
+
+# The bullet-list format specifically: it is the one that starts with a dash.
+bullet=$(grep -oE "printf (--[[:space:]])?'-[^']*'" "$GATE" | head -1)
+check "the unmeasured bullet format exists" "yes" "$([ -n "$bullet" ] && echo yes || echo no)"
+if [ -n "$bullet" ]; then
+  out=$(eval "$bullet alpha beta" 2>/dev/null)
+  check "it renders both arguments as bullets" "2" "$(printf '%s\n' "$out" | grep -c '^-')"
+fi
+
+if [ "$fails" -eq 0 ]; then echo "coverage-gate report: all checks passed"; else
+  echo "FAILED ($fails)"; exit 1; fi


### PR DESCRIPTION
## Priority

**Level:** normal
**Reason:** the branch that reports *why* coverage could not be measured crashes while reporting it, and turns a coverage verdict into exit 2. It fires exactly when someone needs the message.

## The defect

`scripts/coverage-gate.sh:182`:

```sh
printf '-   `%s`\n' $unmeasured
```

Bash's `printf` builtin parses a format that begins with `-` as an option. So the "Not measured" report — the branch whose whole job is to name the files absent from `coverage.xml` — dies at the moment it names them.

Observed on a real run (#2967, where `src/runtime-cli/sutando-runtime.py` is absent from `coverage.xml`):

```
coverage-gate: NOT MEASURED — changed, but absent from coverage.xml:
  src/runtime-cli/sutando-runtime.py
coverage-gate: their changed lines are outside the bar, not inside and clean.
scripts/coverage-gate.sh: line 182: printf: - : invalid option
printf: usage: printf [-v var] format [arguments]
##[error]Process completed with exit code 2.
```

Two costs, and the second is the one that misleads. The markdown report loses its file list, so the summary a reviewer reads no longer says which file to add to `.coveragerc`. And the job exits **2** rather than 1, so a legitimate coverage verdict presents as a broken gate.

## The fix

`printf --` ends option parsing. One line, plus a two-line comment saying why.

## Evidence

Reproduced directly, both ways:

```
$ bash -c "printf '-   \`%s\`\n' alpha beta"
bash: line 0: printf: - : invalid option

$ bash -c "printf -- '-   \`%s\`\n' alpha beta"
-   `alpha`
-   `beta`
```

**Control — the new test fails at the parent commit:**

```
FAIL printf #4 renders without a bash option error: expected '', got
     'printf: - : invalid option'
FAIL it renders both arguments as bullets: expected '2', got '0'
FAILED (2)
```

At HEAD:

```
coverage-gate report: all checks passed
```

`scripts/review-checks.sh --diff` → `PASS (hardcoded-paths + root-artifacts clean)`.

### Why the test reads the script instead of restating it

It greps the `printf` formats **out of the shipping file and executes them**, so a future edit that reintroduces a bare `-` format fails here. A test carrying its own copy of the format would keep passing while the script broke — which is the same class of defect as the one being fixed.

Line 172's `printf '  %s\n'` is unaffected: its format starts with a space. That is the only other `printf` with a literal-prefixed format, and the test exercises every one of them rather than just the changed line.

## Checklist

- [x] Confirmed no other open PR covers this
- [x] Single concern
- [x] Control that fails at the parent commit, pasted as actual output
- [x] No hardcoded host paths in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
