### PR TITLE
fix(health-check): a 2-minute-old poll success is a retry, not "not being delivered"

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5067,7 +5067,8 @@ def check_gateway_bridge() -> "dict | None":
         # WITHOUT the duration this line is byte-identical at minute one and at
         # hour thirteen, so a reader cannot tell a blip from a standing outage.
         age_h = _gateway_last_ok_age_h()
-        if age_h is not None and age_h * 3600 < GATEWAY_TRANSIENT_OUTAGE_S:
+        # A negative age means a clock step or a bad sidecar write, not freshness.
+        if age_h is not None and 0 <= age_h * 3600 < GATEWAY_TRANSIENT_OUTAGE_S:
             return {
                 "name": "gateway-bridge",
                 "status": "ok",
@@ -5088,9 +5089,9 @@ def check_gateway_bridge() -> "dict | None":
 
 
 GATEWAY_STATUS_MAX_AGE_S = 180.0
-# The bridge only drops `connected` after ~3 missed hold windows, so a fresher
-# last-success is a retry in progress — not evidence that delivery has stopped.
-GATEWAY_TRANSIENT_OUTAGE_S = 300.0
+# Mirrors POLL_TIMEOUT_GRACE_S in ag2_sparrow/remote_gateway_bridge.py — the same
+# env read, so a host that retunes POLL_WAIT moves both together.
+GATEWAY_TRANSIENT_OUTAGE_S = 3 * (float(os.environ.get("REMOTE_TASK_POLL_WAIT") or 25) + 10)
 
 
 def _gateway_last_ok_age_h(path: "Path | None" = None,

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5067,6 +5067,13 @@ def check_gateway_bridge() -> "dict | None":
         # WITHOUT the duration this line is byte-identical at minute one and at
         # hour thirteen, so a reader cannot tell a blip from a standing outage.
         age_h = _gateway_last_ok_age_h()
+        if age_h is not None and age_h * 3600 < GATEWAY_TRANSIENT_OUTAGE_S:
+            return {
+                "name": "gateway-bridge",
+                "status": "ok",
+                "detail": f"running; last poll did not succeed, last one that did "
+                          f"was {age_h * 3600:.0f}s ago (transient)",
+            }
         since = ("last successful poll UNKNOWN" if age_h is None
                  else f"last successful poll {age_h:.1f}h ago")
         return {
@@ -5081,6 +5088,9 @@ def check_gateway_bridge() -> "dict | None":
 
 
 GATEWAY_STATUS_MAX_AGE_S = 180.0
+# The bridge only drops `connected` after ~3 missed hold windows, so a fresher
+# last-success is a retry in progress — not evidence that delivery has stopped.
+GATEWAY_TRANSIENT_OUTAGE_S = 300.0
 
 
 def _gateway_last_ok_age_h(path: "Path | None" = None,

--- a/tests/health-check-gateway-transient-outage.test.py
+++ b/tests/health-check-gateway-transient-outage.test.py
@@ -4,6 +4,7 @@ Run: python3 tests/health-check-gateway-transient-outage.test.py"""
 from __future__ import annotations
 import importlib.util
 import json
+import os
 import pathlib
 import tempfile
 import unittest
@@ -44,12 +45,31 @@ def _probe(age_s, *, last_ok=True):
 
 class TestTransientIsNotAnOutage(unittest.TestCase):
     def test_the_line_no_longer_contradicts_itself(self):
-        # Measured live 2026-08-16: connected:false with a 148s-old last success,
-        # and the next poll succeeded 39s later.
-        res = _probe(148)
+        # Measured live 2026-08-16: connected:false while last_ok_age never
+        # exceeded 35s across three samples, and the flag returned to True.
+        res = _probe(35)
         self.assertEqual(res["status"], "ok", res["detail"])
-        self.assertIn("148s ago", res["detail"])
+        self.assertIn("35s ago", res["detail"])
         self.assertNotIn("not being delivered", res["detail"])
+
+    def test_the_bound_is_the_bridge_s_own_grace_not_a_local_guess(self):
+        """Review finding: a literal cannot track an env-tuned bridge constant."""
+        self.assertEqual(HC.GATEWAY_TRANSIENT_OUTAGE_S, 3 * (25 + 10))
+        with mock.patch.dict(os.environ, {"REMOTE_TASK_POLL_WAIT": "50"}):
+            reloaded = _load()
+        self.assertEqual(reloaded.GATEWAY_TRANSIENT_OUTAGE_S, 3 * (50 + 10))
+
+    def test_past_the_grace_the_bridge_and_the_probe_agree_it_is_an_outage(self):
+        # Between the old 300s literal and the bridge's 105s the two disagreed:
+        # the bridge called it an outage and this probe still said "transient".
+        self.assertEqual(_probe(106)["status"], "warn")
+        self.assertEqual(_probe(299)["status"], "warn")
+
+    def test_a_negative_age_is_not_freshness(self):
+        """Review finding: a clock step must not read as a 'transient' ok."""
+        res = _probe(-600)
+        self.assertEqual(res["status"], "warn", res["detail"])
+        self.assertNotIn("-600s", res["detail"])
 
     def test_a_real_outage_still_warns(self):
         res = _probe(13.5 * 3600)

--- a/tests/health-check-gateway-transient-outage.test.py
+++ b/tests/health-check-gateway-transient-outage.test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""A minutes-old last successful poll is a retry, not proof of non-delivery.
+Run: python3 tests/health-check-gateway-transient-outage.test.py"""
+from __future__ import annotations
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+HC = _load()
+NOW = 1_800_000_000.0
+
+
+class _Pgrep:
+    """Stand-in for the pgrep subprocess: one live bridge instance."""
+    returncode = 0
+    stdout = "4242\n"
+
+
+def _probe(age_s, *, last_ok=True):
+    """check_gateway_bridge with `connected: false` and a last good poll `age_s` old."""
+    with mock.patch.object(HC, "_gateway_configured", return_value=True), \
+         mock.patch.object(HC.subprocess, "run", return_value=_Pgrep()), \
+         mock.patch.object(HC, "_gateway_serving", return_value=False), \
+         mock.patch.object(HC, "_gateway_last_ok_age_h",
+                           return_value=(age_s / 3600.0 if last_ok else None)):
+        return HC.check_gateway_bridge()
+
+
+class TestTransientIsNotAnOutage(unittest.TestCase):
+    def test_the_line_no_longer_contradicts_itself(self):
+        # Measured live 2026-08-16: connected:false with a 148s-old last success,
+        # and the next poll succeeded 39s later.
+        res = _probe(148)
+        self.assertEqual(res["status"], "ok", res["detail"])
+        self.assertIn("148s ago", res["detail"])
+        self.assertNotIn("not being delivered", res["detail"])
+
+    def test_a_real_outage_still_warns(self):
+        res = _probe(13.5 * 3600)
+        self.assertEqual(res["status"], "warn")
+        self.assertIn("not being delivered", res["detail"])
+        self.assertIn("13.5h ago", res["detail"])
+
+    def test_the_boundary_belongs_to_the_warn_side(self):
+        self.assertEqual(_probe(HC.GATEWAY_TRANSIENT_OUTAGE_S)["status"], "warn")
+        self.assertEqual(_probe(HC.GATEWAY_TRANSIENT_OUTAGE_S - 1)["status"], "ok")
+
+    def test_an_unknown_last_ok_stays_a_warning(self):
+        # Nothing proves it transient, so it must not be downgraded on a guess.
+        res = _probe(0, last_ok=False)
+        self.assertEqual(res["status"], "warn")
+        self.assertIn("UNKNOWN", res["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`check_gateway_bridge` decides "serving" from the sidecar's `connected` boolean alone. It already computes how long ago the last poll succeeded — but only to *narrate* the duration, never to weigh the verdict. So a bridge whose last successful poll was seconds ago is reported as a delivery outage.

## The bug, on `main`, unmodified

Reproduced against `main` with sidecar values measured live on my host:

```
$ python3 -c '<load src/health-check.py; sidecar {connected:false, ts:NOW, last_ok_ts:NOW-90}>'
_gateway_serving        -> False
_gateway_last_ok_age_h  -> 0.025  (= 90s)
probe emits -> warn: "process running but NOT serving — last successful poll 0.0h ago;
                      ag2.space mobile messages are not being delivered"
```

**That line contradicts itself in one breath**: the last successful poll was 0.0 hours ago, and delivery has stopped. The output is self-refuting on its face.

Sampled live on one host, 40s apart, while messages were arriving and proactive results were being delivered through that same bridge:

```
connected=False  last_ok_age= 35s
connected=True   last_ok_age=  0s
connected=True   last_ok_age=  0s
```

## Why the boolean is the wrong signal here

The bridge is deliberate about this: a long-poll read timeout is indistinguishable from the documented `200 {"tasks": []}` hold-window expiry, so `#2947` made it an outage only once no poll has succeeded for `POLL_TIMEOUT_GRACE_S = 3 * (POLL_WAIT + 10)` = **105s**. `connected: false` therefore means "no success recently" — a retry in flight, not proof that delivery stopped. The probe converts that soft, recent signal into the strongest claim on the health surface.

## Change

Below `GATEWAY_TRANSIENT_OUTAGE_S`, report `ok` with the duration in seconds:

```
running; last poll did not succeed, last one that did was 90s ago (transient)
```

At or beyond it, the existing warn is untouched. An **unknown** `last_ok_ts` stays a warning — nothing proves it transient, so it must not be downgraded on a guess. A **negative** age (clock step, bad sidecar write) is likewise not freshness.

The bound is not a local number. It mirrors the bridge's own grace, from the same env read, so the probe's ok-window ends exactly where the bridge declares an outage:

```
GATEWAY_TRANSIENT_OUTAGE_S = 3 * (float(os.environ.get("REMOTE_TASK_POLL_WAIT") or 25) + 10)

default POLL_WAIT -> 105.0     (bridge: 3*(25+10) = 105)
POLL_WAIT=50      -> 180.0     (bridge: 3*(50+10) = 180)
```

## What this does NOT fix — stated plainly

The incident that sent me here was a **148s**-old success, and **148s still warns** under the shipped bound, correctly: the bridge itself calls anything past 105s an outage, so the probe agreeing with it is the right answer. What the warn line still says at that age is `0.0h ago`, because the branch formats sub-hour ages as `{age_h:.1f}h`. @qingyun-wu named this; it is a display fix in the warn branch, tracked as a follow-up rather than smuggled into an approved head.

An earlier revision of this body described a 300s literal and showed `148s ago (transient)` as an `ok` line. That was the pre-review design and it is **not** what ships here; the tests pin 106s and 299s as `warn`.

## Evidence the tests bite

New `tests/health-check-gateway-transient-outage.test.py` — **7 cases**, all passing at HEAD:

```
test_the_line_no_longer_contradicts_itself
test_the_bound_is_the_bridge_s_own_grace_not_a_local_guess
test_past_the_grace_the_bridge_and_the_probe_agree_it_is_an_outage
test_a_negative_age_is_not_freshness
test_a_real_outage_still_warns
test_the_boundary_belongs_to_the_warn_side
test_an_unknown_last_ok_stays_a_warning
```

Control run with `src/health-check.py` stashed back to the parent commit:

```
FAILED (failures=1, errors=1)
  - ok
  + warn
  : process running but NOT serving — last successful poll 0.0h ago;
    ag2.space mobile messages are not being delivered
```

The test fails against unfixed source with exactly the string this PR exists to remove.

## How the bound got here

The first draft used 600s and broke `tests/health-check-gateway-outage-duration.test.py`, which asserts a 360s outage and a 13.5h one produce different lines. I lowered it to a 300s literal. @sonichi then measured that 300s is ~2.9x the bridge's own `POLL_TIMEOUT_GRACE_S`, so between 105s and 300s the bridge called itself in outage while this probe still said "transient" — and a literal cannot track an env-configurable `POLL_WAIT` in either direction. Deriving it from the same expression fixed both, and the env-retune case is pinned by test 2. The 360s case in the neighbouring suite warns under 105s, so that interaction is resolved rather than balanced against.

Full local run:

```
tests/health-check-gateway-transient-outage.test.py      PASS
tests/health-check-gateway-bridge.test.py                PASS
tests/health-check-gateway-outage-duration.test.py       PASS
tests/core-input-watch-gateway-probe.test.py             PASS

review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
gen-src-map:   docs/src-map.md is up to date
```

## Scope

`src/health-check.py` only — the probe's verdict. No change to the bridge, to `_gateway_serving`'s own sidecar-staleness rule, or to the long-outage path `#2947`'s sibling work added.

Field note for whoever merges: on this host the 105s bound is exceeded by ~15% of failure runs (46 of 304 measured over 12h), so this reduces the false outage claim rather than eliminating it. Measurement and a `backoff_s`-based alternative are in the thread; not proposed as part of this PR.
