### PR TITLE
test(session-worker): a shutdown cap breach could not say when the extra handler started

### DIFF
--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -1504,8 +1504,11 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
             "done\n"
             "[ \"$probe\" = 1 ] && exit 0\n"
             "basename \"$task_file\" >> \"$HANDLER_CALLS\"\n"
+            ": > \"$HANDLER_STARTS/$(basename \"$task_file\")\"\n"
             "sleep 10\n",
         )
+        starts = root / "starts"
+        starts.mkdir()
         bin_dir = root / "bin"
         bin_dir.mkdir()
         _executable(bin_dir / "fswatch", "#!/bin/sh\nsleep 10\n")
@@ -1515,6 +1518,7 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
                 **os.environ,
                 "PATH": f"{bin_dir}:/usr/bin:/bin",
                 "HANDLER_CALLS": str(calls),
+                "HANDLER_STARTS": str(starts),
                 "SUTANDO_DEFAULT_WORKSPACE": str(workspace),
                 "SUTANDO_TASK_EVENT_HANDLER": str(handler),
                 "SUTANDO_CORE_RUNTIME": "claude",
@@ -1533,6 +1537,7 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
                 time.sleep(0.01)
             assert sorted(path.name for path in claims.glob("task-*.txt")) == names
 
+            terminated_at = time.time()
             os.killpg(process.pid, signal.SIGTERM)
             stdout, stderr = process.communicate(timeout=SHUTDOWN_DRAIN_TIMEOUT_S)
             process = None
@@ -1551,9 +1556,17 @@ def _assert_shutdown_falls_back_without_surviving_workers() -> None:
             assert not remaining_claims
             assert fallback_names == names
             handler_calls = calls.read_text().splitlines()
-            # The cap is a concurrency bound; without the contents a breach
-            # reports a bare AssertionError and says nothing about which ran.
-            assert len(handler_calls) <= 2, handler_calls
+            started_at = {
+                path.name: path.stat().st_mtime for path in starts.iterdir()
+            }
+            # Contents alone cannot say whether the cap over-dispatched or
+            # shutdown failed to stop dispatching; the signal instant can.
+            after_signal = sorted(
+                name for name, at in started_at.items() if at > terminated_at
+            )
+            assert len(handler_calls) <= 2, (
+                handler_calls, started_at, terminated_at, after_signal, repr(stderr)
+            )
             deadline = time.monotonic() + WORKER_EXIT_S
             while time.monotonic() < deadline:
                 try:


### PR DESCRIPTION
@sonichi

## What

`_assert_shutdown_falls_back_without_surviving_workers` asserts that at most two handlers ran when the watcher is SIGTERMed with four tasks claimed. #2941 gave that assertion its contents. The contents name *which* handlers ran, but not *when* — and the two failure modes it can catch are indistinguishable from a list of names:

- the dispatcher over-dispatched while the cap was still in force, or
- shutdown failed to stop dispatching, and the extra handler started after the signal.

## Change

The stub handler stamps a start marker per task, the test records `terminated_at` immediately before `killpg`, and the breach reports `started_at`, `terminated_at`, and the handlers whose start postdates the signal.

## Before / after

Forced by tightening the cap to `<= 1` at this branch's head (a fixture to exercise the report — not a reproduction of the flake).

At the parent commit (`8e1a5650`), the same forced breach reports:

```
AssertionError: ['task-shutdown-0.txt', 'task-shutdown-1.txt']
```

At this head:

```
AssertionError: (['task-shutdown-0.txt', 'task-shutdown-1.txt'],
 {'task-shutdown-1.txt': 1786920509.7669387, 'task-shutdown-0.txt': 1786920509.7411227},
 1786920509.795192,
 [],
 "'watch-tasks-stream: optional task handler interrupted for task-shutdown-2.txt; falling back to live core ...'")
```

Both handlers started 28 ms and 54 ms *before* the signal, and `after_signal` is empty — so that run was cap-side, not shutdown-side. A run where the extra handler postdates the signal names it in the fourth element.

The margin is the finding the old message could not carry: the window is tens of milliseconds wide.

## Test evidence

- `python3 tests/task-workstream-session-worker.test.py` → `task workstream session worker tests passed`, exit 0.
- The shutdown test alone, 8 invocations x 10 iterations = 80 attempts, all pass. **The flake did not reproduce locally**; the numbers above come from the forced fixture, not from a natural breach. This PR does not claim to fix the flake — it makes the next CI occurrence readable.

## Why it matters

That assertion fired on three unrelated PRs on 2026-08-16 (#2967, #2969) and is why #2160 has read broken for 29 days. Each occurrence cost a manual re-run and produced no information about which mode fired.

## Scope

One test file, 16 insertions. No production code.

Stand: Sutando-Mini (Echo Act IV Mini)