### PR TITLE
fix(health-check): a killed cron-runner invocation with fresh state is degraded, not down

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -846,6 +846,10 @@ def check_cron_runner(
     try:
         age = (float(time.time() if now is None else now) - state_file.stat().st_mtime)
         age_err = None
+        # A negative age is a clock step or a bad write, never freshness. Discard
+        # it here so no branch below can read it as proof that work is happening.
+        if age < 0:
+            age, age_err = None, f"state is future-dated by {int(-age)}s"
     except FileNotFoundError:
         age, age_err = None, "state file is missing"
     except OSError as exc:
@@ -860,13 +864,16 @@ def check_cron_runner(
                 "status": "warn",
                 "detail": (f"{launchd_count} schedule(s); launchd reports {probe['status']} "
                            f"({probe.get('detail', '')}) but the runner wrote state "
-                           f"{int(max(age, 0))}s ago — invocations are being killed and "
+                           f"{int(age)}s ago — invocations are being killed and "
                            "relaunched, schedules still fire"),
             }
+        # Name why freshness could not vouch for it; a clock step here is exactly
+        # the neighbour of whatever else has gone wrong.
         return {
             "name": name,
             "status": "down",
-            "detail": f"{launchd_count} schedule(s) configured but launchd is {probe['status']}",
+            "detail": (f"{launchd_count} schedule(s) configured but launchd is "
+                       f"{probe['status']}" + (f"; {age_err}" if age_err else "")),
         }
 
     if age_err is not None:
@@ -880,7 +887,7 @@ def check_cron_runner(
     return {
         "name": name,
         "status": "ok",
-        "detail": f"{launchd_count} durable schedule(s), state {int(max(age, 0))}s old",
+        "detail": f"{launchd_count} durable schedule(s), state {int(age)}s old",
     }
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -842,20 +842,35 @@ def check_cron_runner(
         return {"name": name, "status": "ok", "detail": "no launchd-owned schedules"}
 
     probe = (launchd_check or check_launchd)("com.sutando.cron-runner")
+    state_file = workspace / "state" / "cron-runner-state.json"
+    try:
+        age = (float(time.time() if now is None else now) - state_file.stat().st_mtime)
+        age_err = None
+    except FileNotFoundError:
+        age, age_err = None, "state file is missing"
+    except OSError as exc:
+        age, age_err = None, f"state unreadable ({exc})"
+
     if probe["status"] != "ok":
+        # `check_launchd` reports the LAST invocation. A killed one with a fresh
+        # state file means later ones complete, so the schedules still fire.
+        if age is not None and age <= 180:
+            return {
+                "name": name,
+                "status": "warn",
+                "detail": (f"{launchd_count} schedule(s); launchd reports {probe['status']} "
+                           f"({probe.get('detail', '')}) but the runner wrote state "
+                           f"{int(max(age, 0))}s ago — invocations are being killed and "
+                           "relaunched, schedules still fire"),
+            }
         return {
             "name": name,
             "status": "down",
             "detail": f"{launchd_count} schedule(s) configured but launchd is {probe['status']}",
         }
 
-    state_file = workspace / "state" / "cron-runner-state.json"
-    try:
-        age = (float(time.time() if now is None else now) - state_file.stat().st_mtime)
-    except FileNotFoundError:
-        return {"name": name, "status": "down", "detail": "runner loaded but state file is missing"}
-    except OSError as exc:
-        return {"name": name, "status": "down", "detail": f"runner state unreadable ({exc})"}
+    if age_err is not None:
+        return {"name": name, "status": "down", "detail": f"runner loaded but {age_err}"}
     if age > 180:
         return {
             "name": name,

--- a/tests/health-check-cron-runner.test.py
+++ b/tests/health-check-cron-runner.test.py
@@ -180,6 +180,46 @@ class CronRunnerHealthTest(unittest.TestCase):
             self.assertIn("launchd is not_loaded", res["detail"])
             self.assertNotIn("runner loaded", res["detail"])
 
+    def test_a_future_dated_state_file_never_buys_a_downgrade(self):
+        """A clock step must not read as freshness — on EITHER branch.
+
+        Guarding only the render (`int(max(age, 0))`) turned a day-old file into
+        the literal text "wrote state 0s ago ... schedules still fire", which is
+        worse than a missing warning because it reads as freshly measured.
+        """
+        killed = lambda _: {"status": "stopped", "detail": "pid=- exit=-9"}
+        loaded = lambda _: {"status": "ok", "detail": "pid=123"}
+        with tempfile.TemporaryDirectory() as td:
+            workspace = self._workspace(Path(td), [
+                {"name": "digest", "cron": "2 6 * * *", "launchd": True},
+            ])
+            state = workspace / "state" / "cron-runner-state.json"
+            state.parent.mkdir(parents=True)
+            state.write_text("{}")
+            mtime = state.stat().st_mtime
+
+            for label, probe in (("killed", killed), ("loaded", loaded)):
+                res = health.check_cron_runner(
+                    workspace, "test-host", "codex", probe, now=mtime - 86400
+                )
+                self.assertEqual(res["status"], "down", f"{label}: {res['detail']}")
+                self.assertIn("future-dated", res["detail"], label)
+                # The exact regression: a day-old file rendered as a fresh write.
+                self.assertNotIn("wrote state", res["detail"], label)
+                self.assertNotIn("schedules still fire", res["detail"], label)
+
+            # One second in the future is still a clock step, not a fresh write.
+            edge = health.check_cron_runner(
+                workspace, "test-host", "codex", killed, now=mtime - 1
+            )
+            self.assertEqual(edge["status"], "down", edge["detail"])
+            # ...and the bound itself is unchanged: 0s is fresh, 180s is fresh.
+            for offset in (0, 180):
+                ok = health.check_cron_runner(
+                    workspace, "test-host", "codex", killed, now=mtime + offset
+                )
+                self.assertEqual(ok["status"], "warn", f"{offset}s: {ok['detail']}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/health-check-cron-runner.test.py
+++ b/tests/health-check-cron-runner.test.py
@@ -134,6 +134,52 @@ class CronRunnerHealthTest(unittest.TestCase):
             self.assertEqual(unreadable["status"], "down")
             self.assertIn("unreadable", unreadable["detail"])
 
+    def test_a_killed_invocation_with_fresh_state_is_degraded_not_down(self):
+        """`check_launchd` reports the LAST invocation, not whether work happens.
+
+        Measured on a live host: launchd showed `exit=-9` (SIGKILL, code signing)
+        while the runner wrote state every ~120s and that morning's briefing was
+        emitted on the minute. The old early return called that `down`.
+        """
+        killed = lambda _: {"status": "stopped", "detail": "pid=- exit=-9"}
+        with tempfile.TemporaryDirectory() as td:
+            workspace = self._workspace(Path(td), [
+                {"name": "digest", "cron": "2 6 * * *", "launchd": True},
+            ])
+            state = workspace / "state" / "cron-runner-state.json"
+            state.parent.mkdir(parents=True)
+            state.write_text("{}")
+            mtime = state.stat().st_mtime
+
+            fresh = health.check_cron_runner(
+                workspace, "test-host", "codex", killed, now=mtime + 120
+            )
+            self.assertEqual(fresh["status"], "warn", fresh["detail"])
+            self.assertIn("120s ago", fresh["detail"])
+            self.assertIn("schedules still fire", fresh["detail"])
+            self.assertIn("exit=-9", fresh["detail"])
+
+            # Past the freshness bound nothing proves work is happening, so the
+            # original verdict must survive.
+            stale = health.check_cron_runner(
+                workspace, "test-host", "codex", killed, now=mtime + 181
+            )
+            self.assertEqual(stale["status"], "down")
+            self.assertIn("launchd is stopped", stale["detail"])
+
+    def test_a_killed_invocation_with_no_state_file_stays_down(self):
+        """Regression guard: the freshness read moved ABOVE the launchd branch,
+        so a missing file must not be described as if the runner were loaded."""
+        killed = lambda _: {"status": "not_loaded", "detail": "not found"}
+        with tempfile.TemporaryDirectory() as td:
+            workspace = self._workspace(Path(td), [
+                {"name": "digest", "cron": "2 6 * * *", "launchd": True},
+            ])
+            res = health.check_cron_runner(workspace, "test-host", "codex", killed)
+            self.assertEqual(res["status"], "down")
+            self.assertIn("launchd is not_loaded", res["detail"])
+            self.assertNotIn("runner loaded", res["detail"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

`check_cron_runner` asked launchd whether the job is running, and returned `down` before ever reading the state file that says whether the runner is *doing anything*.

## The bug

`check_launchd` reports the **last invocation**: `status = "ok" if running or exit_code == "0" else "stopped"`. A periodic `StartInterval` job is "not running" almost always, so the exit code decides — and if that last invocation was SIGKILLed, the probe returned immediately:

```python
probe = (launchd_check or check_launchd)("com.sutando.cron-runner")
if probe["status"] != "ok":
    return {..., "status": "down",
            "detail": f"{launchd_count} schedule(s) configured but launchd is {probe['status']}"}

state_file = workspace / "state" / "cron-runner-state.json"   # <- never reached
```

The freshness check below it is the only evidence about whether work is happening, and the early return skipped it.

## Measured on a live host, not hypothesised

macOS code signing kills this job repeatedly (`OS_REASON_CODESIGNING`), so `launchctl print` shows:

```
state = not running
runs = 1025
last exit reason = OS_REASON_CODESIGNING     # launchctl list: pid=-  exit=-9
```

Health said `✗ cron-runner: down — 3 schedule(s) configured but launchd is stopped`. Meanwhile the runner was demonstrably working:

```
# state file mtime, sampled every 3s across a 240s window
23:29:01Z   23:31:01Z   23:33:02Z          -> a write every ~120s

# and that morning, end to end:
tasks/archive/2026-08/task-cron-morning-briefing-1786888677259.txt    emitted 13:57:57Z = 06:57 local
results/archive/2026-08/task-cron-morning-briefing-1786888677259.txt  result present
logs/cron-runner-launchd.log: 10x "cron-runner emitted: morning-briefing"
```

Killed invocations and delivered schedules are both real. `down` describes only the first.

## Change

Read the state file first, then branch:

- launchd not-ok **and** state younger than the existing 180s bound → `warn`, naming both facts (`launchd reports stopped (pid=- exit=-9) but the runner wrote state 120s ago — invocations are being killed and relaunched, schedules still fire`).
- launchd not-ok **and** state stale / missing / unreadable → `down`, with the original launchd wording unchanged.
- launchd ok → every existing branch and message is byte-identical.

No new threshold: 180s is the constant already used two lines down, and the measured 120s tick sits inside it.

## Tests

Two cases added to `tests/health-check-cron-runner.test.py` (7 total, all passing). The second is a regression guard for the reordering — moving the freshness read above the launchd branch must not let a *missing* state file be described as "runner loaded".

Control against the parent commit:

```
FAILED (failures=1)
 : 1 schedule(s) configured but launchd is stopped
```

The suite fails on unfixed source with exactly the string this PR is about. Restored → 7/7 OK. Siblings `tests/cron-runner.test.py` and `tests/health-check-gateway-bridge.test.py` both pass.

`review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)`, `gen-src-map: up to date`.

## Relationship to #2978

Same file, same failure family — a status field read as a behavioural verdict — but independent regions (`check_gateway_bridge` vs `check_cron_runner`) and no dependency. Either can merge first.
