### PR TITLE
feat(menu-bar-app): a real OSS install path for the app #2677 removed, and the review lesson behind it

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -144,6 +144,25 @@ and loads whichever repo it reviews.
     The tell that you are in this pattern: your test suite grows by exactly one case per
     round, and each new case is the previous one with a single field changed.
 
+11. **A change that removes a capability must relocate it, not just delete it — and one
+    deployment's requirement is never a global default.** If a PR turns behaviour off for
+    everyone to satisfy one environment, ask for the flag instead: the environment that
+    wants the change carries it, and every other install is untouched. Then check the
+    *teardown* side — code that stops, kills, or cleans up the removed thing usually
+    survives the deletion and becomes a one-way operation. And check whether any existing
+    opt-in path depended on the deleted code to produce its inputs.
+    *Grounded by:* #2677 — "keep the open-source core headless" deleted the menu-bar app's
+    build and launch from `startup.sh` (−100 lines) and shipped no replacement script, so
+    every OSS install silently lost the app and the documented alternative became "run
+    `swiftc` by hand". Three knock-on effects, none visible in the diff: `restart.sh:73`
+    still `pkill`s the app while nothing starts it, making a restart a permanent stop;
+    `install-sutando-app-launchd.sh` (#1294) still points at
+    `src/Sutando/Sutando.app/Contents/MacOS/Sutando`, a bundle `startup.sh` was the only
+    thing that built, so the pre-existing opt-in supervisor was silently disabled; and the
+    PR's own new test asserted the removed strings appear *nowhere* in `startup.sh`, which
+    made the previous default unrestorable without deleting the guard. Pin behaviour under
+    the flag, never the absence of a string.
+
 ## Checks (machine-readable — consumed by scripts/review-checks.sh)
 
 ```yaml

--- a/scripts/install-menu-bar-app.sh
+++ b/scripts/install-menu-bar-app.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Build the optional macOS menu-bar app and its .app bundle, so an OSS install
+# can actually run it. #2677 made core startup headless and removed the only
+# code that produced the bundle, which left install-sutando-app-launchd.sh
+# pointing at a path nothing builds.
+#
+# Usage: bash scripts/install-menu-bar-app.sh [--launch] [--supervise]
+#   (no flags)   build the binary + bundle, sign, print what to do next
+#   --launch     also launch it now
+#   --supervise  also install the launchd KeepAlive supervisor (login auto-start)
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_DIR="$REPO/src/Sutando"
+BIN="$SRC_DIR/Sutando"
+APP="$SRC_DIR/Sutando.app"
+LAUNCH=0
+SUPERVISE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --launch) LAUNCH=1 ;;
+    --supervise) SUPERVISE=1 ;;
+    -h|--help) sed -n '2,10p' "$0"; exit 0 ;;
+    *) echo "unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
+[ "$(uname -s)" = "Darwin" ] || { echo "macOS only — nothing to do."; exit 0; }
+command -v swiftc >/dev/null 2>&1 || {
+  echo "swiftc not found — install Xcode Command Line Tools: xcode-select --install" >&2
+  exit 1
+}
+
+echo "Building menu-bar binary…"
+( cd "$SRC_DIR" && swiftc -O -o Sutando main.swift SutandoConfig.swift \
+    -framework Cocoa -framework Carbon -framework ApplicationServices \
+    -framework AVFoundation )
+echo "  ✓ $BIN"
+
+# LSUIElement keeps it out of the Dock; the bundle id is what the TCC
+# Accessibility grant binds to, so it must stay stable across rebuilds.
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+cat > "$APP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>Sutando</string>
+  <key>CFBundleDisplayName</key><string>Sutando</string>
+  <key>CFBundleExecutable</key><string>Sutando</string>
+  <key>CFBundleIdentifier</key><string>com.sutando.menubar</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>LSMinimumSystemVersion</key><string>13.0</string>
+  <key>LSUIElement</key><true/>
+  <key>NSAppleEventsUsageDescription</key>
+  <string>Sutando reads your Finder selection to drop files into the agent task queue.</string>
+</dict>
+</plist>
+PLIST
+cp "$BIN" "$APP/Contents/MacOS/Sutando"
+echo "  ✓ $APP"
+
+# Prefer a stable identity so the Accessibility grant survives rebuilds (cdhash
+# churn); the designated requirement is identifier-only for the same reason.
+SIGN_ID="$(security find-identity -v -p codesigning 2>/dev/null | awk '/"Sutando Dev"/{print $2; exit}')"
+if [ -n "$SIGN_ID" ]; then
+  codesign --force --sign "$SIGN_ID" --identifier com.sutando.menubar \
+    --requirements '=designated => identifier "com.sutando.menubar"' "$APP" 2>/dev/null \
+    || codesign --force --sign - "$APP" 2>/dev/null || true
+  echo "  ✓ signed (Sutando Dev + identifier-only designated requirement)"
+else
+  codesign --force --sign - "$APP" 2>/dev/null || true
+  echo "  ✓ signed (ad-hoc — install a \"Sutando Dev\" cert for a TCC grant that survives rebuilds)"
+fi
+
+if [ "$SUPERVISE" -eq 1 ]; then
+  bash "$REPO/src/install-sutando-app-launchd.sh"
+elif [ "$LAUNCH" -eq 1 ]; then
+  pkill -x Sutando 2>/dev/null || true
+  open "$APP"
+  echo "  ✓ launched"
+fi
+
+cat <<EOF
+
+Done. The core stays headless — this app is opt-in and separate.
+  launch now        : open "$APP"
+  auto-start at login: bash scripts/install-menu-bar-app.sh --supervise
+  first run         : grant Accessibility in System Settings > Privacy & Security
+EOF

--- a/scripts/install-menu-bar-app.sh
+++ b/scripts/install-menu-bar-app.sh
@@ -86,14 +86,25 @@ fi
 # NAME, so `pkill -x Sutando` would also kill the user's UI (#2038).
 APP_BIN="$APP/Contents/MacOS/Sutando"
 
+# `pgrep -f` matches an EXTENDED REGEX, so metacharacters in the checkout path
+# silently retarget the probe; compare the full argv literally instead.
+app_pids() {
+  ps -axww -o pid=,command= 2>/dev/null | awk -v want="$APP_BIN" '
+    { pid = $1; sub(/^[[:space:]]*[0-9]+[[:space:]]+/, ""); if ($0 == want) print pid }'
+}
+
 stop_unmanaged() {
   # An unmanaged copy left running defeats BOTH callers: --launch stacks a second
   # menu-bar icon, and --supervise leaves launchd's copy to exit under the
   # singleton guard, which KeepAlive does not restart.
-  pgrep -f "^$APP_BIN$" >/dev/null 2>&1 || return 0
-  pkill -f "^$APP_BIN$" 2>/dev/null || true
+  local pids
+  pids="$(app_pids)" || return 1        # a failed probe is UNKNOWN, never "absent"
+  [ -n "$pids" ] || return 0
+  # shellcheck disable=SC2086  # deliberate word-split: one pid per line
+  kill $pids 2>/dev/null || true
   for _ in $(seq 1 50); do
-    pgrep -f "^$APP_BIN$" >/dev/null 2>&1 || return 0
+    pids="$(app_pids)" || return 1
+    [ -n "$pids" ] || return 0
     sleep 0.1
   done
   return 1
@@ -113,10 +124,10 @@ elif [ "$LAUNCH" -eq 1 ]; then
   }
   open "$APP"
   for _ in $(seq 1 50); do
-    pgrep -f "^$APP_BIN$" >/dev/null 2>&1 && break
+    [ -n "$(app_pids)" ] && break
     sleep 0.1
   done
-  if pgrep -f "^$APP_BIN$" >/dev/null 2>&1; then
+  if [ -n "$(app_pids)" ]; then
     echo "  ✓ launched"
   else
     echo "  ✗ open returned but no menu-bar process is running — not launched" >&2

--- a/scripts/install-menu-bar-app.sh
+++ b/scripts/install-menu-bar-app.sh
@@ -82,26 +82,35 @@ else
   echo "  ✓ signed (ad-hoc — install a \"Sutando Dev\" cert for a TCC grant that survives rebuilds)"
 fi
 
+# Scope to THIS bundle's path. The Electron desktop app shares the executable
+# NAME, so `pkill -x Sutando` would also kill the user's UI (#2038).
+APP_BIN="$APP/Contents/MacOS/Sutando"
+
+stop_unmanaged() {
+  # An unmanaged copy left running defeats BOTH callers: --launch stacks a second
+  # menu-bar icon, and --supervise leaves launchd's copy to exit under the
+  # singleton guard, which KeepAlive does not restart.
+  pgrep -f "^$APP_BIN$" >/dev/null 2>&1 || return 0
+  pkill -f "^$APP_BIN$" 2>/dev/null || true
+  for _ in $(seq 1 50); do
+    pgrep -f "^$APP_BIN$" >/dev/null 2>&1 || return 0
+    sleep 0.1
+  done
+  return 1
+}
+
 if [ "$SUPERVISE" -eq 1 ]; then
+  stop_unmanaged || {
+    echo "  ✗ the running menu-bar app did not exit — launchd would install a" >&2
+    echo "    supervisor whose copy exits under the singleton guard" >&2
+    exit 1
+  }
   bash "$REPO/src/install-sutando-app-launchd.sh"
 elif [ "$LAUNCH" -eq 1 ]; then
-  # Scope to THIS bundle's path. The Electron desktop app shares the executable
-  # NAME, so `pkill -x Sutando` would also kill the user's UI (#2038).
-  APP_BIN="$APP/Contents/MacOS/Sutando"
-  if pgrep -f "^$APP_BIN$" >/dev/null 2>&1; then
-    pkill -f "^$APP_BIN$" 2>/dev/null || true
-    gone=0
-    for _ in $(seq 1 50); do
-      pgrep -f "^$APP_BIN$" >/dev/null 2>&1 || { gone=1; break; }
-      sleep 0.1
-    done
-    # Opening a second copy while the first is alive is how you get two menu-bar
-    # icons and a confused TCC grant, so stop rather than stack them.
-    [ "$gone" -eq 1 ] || {
-      echo "  ✗ the running menu-bar app did not exit — not launching another" >&2
-      exit 1
-    }
-  fi
+  stop_unmanaged || {
+    echo "  ✗ the running menu-bar app did not exit — not launching another" >&2
+    exit 1
+  }
   open "$APP"
   for _ in $(seq 1 50); do
     pgrep -f "^$APP_BIN$" >/dev/null 2>&1 && break

--- a/scripts/install-menu-bar-app.sh
+++ b/scripts/install-menu-bar-app.sh
@@ -122,6 +122,14 @@ stop_unmanaged() {
   return 1
 }
 
+# Gate the SIDE EFFECTS, not just the footer: supervising or launching an
+# unsigned bundle is the outcome the signing check exists to prevent.
+if [ "$SIGNED" -eq 0 ] && { [ "$SUPERVISE" -eq 1 ] || [ "$LAUNCH" -eq 1 ]; }; then
+  echo "  ✗ refusing to launch or supervise an UNSIGNED bundle." >&2
+  echo "    bundle: $APP" >&2
+  exit 1
+fi
+
 if [ "$SUPERVISE" -eq 1 ]; then
   stop_unmanaged || {
     echo "  ✗ the running menu-bar app did not exit — launchd would install a" >&2

--- a/scripts/install-menu-bar-app.sh
+++ b/scripts/install-menu-bar-app.sh
@@ -71,16 +71,28 @@ echo "  ✓ $APP"
 
 # Prefer a stable identity so the Accessibility grant survives rebuilds (cdhash
 # churn); the designated requirement is identifier-only for the same reason.
-SIGN_ID="$(security find-identity -v -p codesigning 2>/dev/null | awk '/"Sutando Dev"/{print $2; exit}')"
-if [ -n "$SIGN_ID" ]; then
-  codesign --force --sign "$SIGN_ID" --identifier com.sutando.menubar \
-    --requirements '=designated => identifier "com.sutando.menubar"' "$APP" 2>/dev/null \
-    || codesign --force --sign - "$APP" 2>/dev/null || true
-  echo "  ✓ signed (Sutando Dev + identifier-only designated requirement)"
-else
-  codesign --force --sign - "$APP" 2>/dev/null || true
-  echo "  ✓ signed (ad-hoc — install a \"Sutando Dev\" cert for a TCC grant that survives rebuilds)"
-fi
+# An absent keychain identity is the NORMAL case; without `|| true` its nonzero
+# status reaches set -e through pipefail and kills the install with no message.
+SIGN_ID="$(security find-identity -v -p codesigning 2>/dev/null | awk '/"Sutando Dev"/{print $2; exit}' || true)"
+# Both arms used to end in `|| true` under an unconditional "✓ signed", so a
+# total codesign failure still reported success on a bundle that cannot hold TCC.
+sign_app() {
+  if [ -n "$SIGN_ID" ] && codesign --force --sign "$SIGN_ID" --identifier com.sutando.menubar \
+       --requirements '=designated => identifier "com.sutando.menubar"' "$APP" 2>/dev/null; then
+    echo "  ✓ signed (Sutando Dev + identifier-only designated requirement)"
+  elif codesign --force --sign - "$APP" 2>/dev/null; then
+    [ -n "$SIGN_ID" ] && echo "  ⚠ 'Sutando Dev' signing failed; fell back to ad-hoc — the Accessibility grant will NOT survive rebuilds" >&2
+    echo "  ✓ signed (ad-hoc — install a \"Sutando Dev\" cert for a TCC grant that survives rebuilds)"
+  else
+    echo "  ✗ codesign FAILED — the bundle is UNSIGNED and cannot hold an Accessibility grant" >&2
+    return 1
+  fi
+  codesign --verify --strict "$APP" 2>/dev/null && return 0
+  echo "  ✗ codesign --verify rejected the bundle after signing — treating as unsigned" >&2
+  return 1
+}
+SIGNED=1
+sign_app || SIGNED=0
 
 # Scope to THIS bundle's path. The Electron desktop app shares the executable
 # NAME, so `pkill -x Sutando` would also kill the user's UI (#2038).
@@ -133,6 +145,14 @@ elif [ "$LAUNCH" -eq 1 ]; then
     echo "  ✗ open returned but no menu-bar process is running — not launched" >&2
     exit 1
   fi
+fi
+
+# The footer reads as unqualified success, so it must not follow a failed signing.
+if [ "$SIGNED" -eq 0 ]; then
+  echo "" >&2
+  echo "Built, but UNSIGNED — Accessibility cannot be granted to this bundle." >&2
+  echo "  bundle: $APP" >&2
+  exit 1
 fi
 
 cat <<EOF

--- a/scripts/install-menu-bar-app.sh
+++ b/scripts/install-menu-bar-app.sh
@@ -27,10 +27,16 @@ for arg in "$@"; do
 done
 
 [ "$(uname -s)" = "Darwin" ] || { echo "macOS only — nothing to do."; exit 0; }
-command -v swiftc >/dev/null 2>&1 || {
-  echo "swiftc not found — install Xcode Command Line Tools: xcode-select --install" >&2
+# `command -v swiftc` passes against the Xcode-CLT stub on a clean Mac, and the
+# next bare swiftc then raises the install dialog instead of this diagnostic.
+if ! xcode-select -p >/dev/null 2>&1; then
+  echo "No developer tools — install them first: xcode-select --install" >&2
   exit 1
-}
+fi
+if ! swiftc --version >/dev/null 2>&1; then
+  echo "swiftc is present but not runnable — try: xcode-select --install" >&2
+  exit 1
+fi
 
 echo "Building menu-bar binary…"
 ( cd "$SRC_DIR" && swiftc -O -o Sutando main.swift SutandoConfig.swift \
@@ -79,9 +85,34 @@ fi
 if [ "$SUPERVISE" -eq 1 ]; then
   bash "$REPO/src/install-sutando-app-launchd.sh"
 elif [ "$LAUNCH" -eq 1 ]; then
-  pkill -x Sutando 2>/dev/null || true
+  # Scope to THIS bundle's path. The Electron desktop app shares the executable
+  # NAME, so `pkill -x Sutando` would also kill the user's UI (#2038).
+  APP_BIN="$APP/Contents/MacOS/Sutando"
+  if pgrep -f "^$APP_BIN$" >/dev/null 2>&1; then
+    pkill -f "^$APP_BIN$" 2>/dev/null || true
+    gone=0
+    for _ in $(seq 1 50); do
+      pgrep -f "^$APP_BIN$" >/dev/null 2>&1 || { gone=1; break; }
+      sleep 0.1
+    done
+    # Opening a second copy while the first is alive is how you get two menu-bar
+    # icons and a confused TCC grant, so stop rather than stack them.
+    [ "$gone" -eq 1 ] || {
+      echo "  ✗ the running menu-bar app did not exit — not launching another" >&2
+      exit 1
+    }
+  fi
   open "$APP"
-  echo "  ✓ launched"
+  for _ in $(seq 1 50); do
+    pgrep -f "^$APP_BIN$" >/dev/null 2>&1 && break
+    sleep 0.1
+  done
+  if pgrep -f "^$APP_BIN$" >/dev/null 2>&1; then
+    echo "  ✓ launched"
+  else
+    echo "  ✗ open returned but no menu-bar process is running — not launched" >&2
+    exit 1
+  fi
 fi
 
 cat <<EOF

--- a/src/install-sutando-app-launchd.sh
+++ b/src/install-sutando-app-launchd.sh
@@ -99,7 +99,23 @@ case "$cmd" in
         # instance exits cleanly via singleton-detection; kickstart forces
         # launchd to take ownership so KeepAlive applies. Idempotent.
         launchctl kickstart "$SERVICE" >/dev/null 2>&1 || true
-        echo "  Loaded via $SERVICE"
+        # kickstart's status is swallowed above because it is idempotent-noisy,
+        # so supervision must be proven by a live pid, never assumed from it.
+        _sup_pid=""
+        for _ in $(seq 1 50); do
+            _sup_pid="$(launchctl print "$SERVICE" 2>/dev/null \
+                | awk '/^[[:space:]]*pid[[:space:]]*=/{print $3; exit}')"
+            [ -n "$_sup_pid" ] && [ "$_sup_pid" != "0" ] && break
+            _sup_pid=""
+            sleep 0.1
+        done
+        if [ -z "$_sup_pid" ]; then
+            echo "  ✗ $SERVICE is registered but launchd owns no running process." >&2
+            echo "    Not reporting supervision — KeepAlive cannot restart what never started." >&2
+            echo "    Inspect with: launchctl print $SERVICE" >&2
+            exit 1
+        fi
+        echo "  Loaded via $SERVICE (launchd-owned pid $_sup_pid)"
         echo
         echo "Sutando.app is now launchd-supervised."
         echo "  • Crashes auto-restart within ~10s"

--- a/tests/install-menu-bar-app.test.sh
+++ b/tests/install-menu-bar-app.test.sh
@@ -123,6 +123,36 @@ else
     flunk "one stop_unmanaged definition, called by both (defs=$defs calls=$calls)"
 fi
 
+# ---- 4c. the probe must be LITERAL, not a regex over the checkout path ------
+# `pgrep -f` matches an ERE, so a checkout path holding regex metacharacters
+# makes the probe miss a live process and stop_unmanaged report "nothing to do".
+METADIR="$WORK/ex[re]po.d"
+mkdir -p "$METADIR"
+ln -s /bin/sleep "$METADIR/Sutando" 2>/dev/null
+"$METADIR/Sutando" 400 & META_PID=$!
+sleep 0.5
+if ! kill -0 "$META_PID" 2>/dev/null; then
+    flunk "metacharacter-path fixture did not stay alive (fixture broken, not the probe)"
+else
+    APP_BIN="$METADIR/Sutando 400"
+    # Drive the PRODUCTION function body, not a copy of its recipe.
+    eval "$(sed -n '/^app_pids() {/,/^}/p' "$SCRIPT")"
+    found="$(app_pids | tr -d '[:space:]')"
+    pgrep -f "^$APP_BIN$" >/dev/null 2>&1; pg_rc=$?
+    if [ "$found" = "$META_PID" ]; then
+        pass "the probe finds a live process whose path holds regex metacharacters"
+    else
+        flunk "probe missed a live metacharacter-path process (got '$found', want $META_PID)"
+    fi
+    # Control: the old regex probe must actually FAIL here, or this proves nothing.
+    if [ "$pg_rc" -ne 0 ]; then
+        pass "control: the regex probe does miss it, so the literal compare is load-bearing"
+    else
+        flunk "control failed: pgrep -f also matched, so this fixture cannot detect the bug"
+    fi
+fi
+kill "$META_PID" 2>/dev/null
+
 # The guard must precede the installer call, or it cannot prevent anything.
 gi="$(grep -n '^  stop_unmanaged ||' "$SCRIPT" | head -1 | cut -d: -f1)"
 ii="$(grep -n 'bash "\$REPO/src/install-sutando-app-launchd.sh"' "$SCRIPT" | head -1 | cut -d: -f1)"

--- a/tests/install-menu-bar-app.test.sh
+++ b/tests/install-menu-bar-app.test.sh
@@ -160,6 +160,49 @@ else
     flunk "control failed: succeeding codesign did not report signed (rc=$rc_ok)"
 fi
 
+# ---- 4b-ii. an unsigned bundle must not be launched OR supervised -----------
+# The SIGNED report alone is not enough: the gate has to precede the side effect,
+# or the app is already open / the LaunchAgent already installed when it fires.
+for disp in --launch --supervise; do
+    STUB_D="$WORK/stub-unsigned${disp}"
+    mkstub "$STUB_D" xcode-select 'exit 0'
+    mkstub "$STUB_D" swiftc 'while [ $# -gt 0 ]; do [ "$1" = "-o" ] && { shift; touch "$1"; }; shift; done; exit 0'
+    mkstub "$STUB_D" security 'echo "  1) ABC \"Other\""; exit 0'
+    mkstub "$STUB_D" codesign 'exit 1'
+    mkstub "$STUB_D" open "touch '$WORK/OPENED$disp'; exit 0"
+    mkstub "$STUB_D" launchctl 'exit 0'
+    rm -f "$WORK/OPENED$disp"
+    out_u="$(PATH="$STUB_D:$PATH" HOME="$WORK/home-unsigned" bash "$SCRIPT" "$disp" 2>&1)"; rc_u=$?
+    if [ "$rc_u" -ne 0 ]; then
+        pass "$disp with a failed codesign exits nonzero"
+    else
+        flunk "$disp with a failed codesign exited 0"
+    fi
+    if [ -f "$WORK/OPENED$disp" ]; then
+        flunk "$disp OPENED an unsigned bundle before failing"
+    else
+        pass "$disp never reached the side effect on an unsigned bundle"
+    fi
+    case "$out_u" in
+        *UNSIGNED*) pass "$disp names the unsigned state" ;;
+        *)          flunk "$disp did not name the unsigned state" ;;
+    esac
+done
+# Control: the SAME dispositions must still reach the side effect when signing works.
+STUB_S="$WORK/stub-signed-launch"
+mkstub "$STUB_S" xcode-select 'exit 0'
+mkstub "$STUB_S" swiftc 'while [ $# -gt 0 ]; do [ "$1" = "-o" ] && { shift; touch "$1"; }; shift; done; exit 0'
+mkstub "$STUB_S" security 'echo "  1) ABC \"Other\""; exit 0'
+mkstub "$STUB_S" codesign 'exit 0'
+mkstub "$STUB_S" open "touch '$WORK/OPENED_SIGNED'; exit 0"
+rm -f "$WORK/OPENED_SIGNED"
+PATH="$STUB_S:$PATH" bash "$SCRIPT" --launch >/dev/null 2>&1
+if [ -f "$WORK/OPENED_SIGNED" ]; then
+    pass "control: a SIGNED bundle still reaches --launch (the gate does not over-fire)"
+else
+    flunk "control failed: a signed bundle no longer reaches --launch"
+fi
+
 # ---- 4c. the probe must be LITERAL, not a regex over the checkout path ------
 # `pgrep -f` matches an ERE, so a checkout path holding regex metacharacters
 # makes the probe miss a live process and stop_unmanaged report "nothing to do".

--- a/tests/install-menu-bar-app.test.sh
+++ b/tests/install-menu-bar-app.test.sh
@@ -108,6 +108,30 @@ esac
 if [ "$rc4" -ne 0 ]; then pass "exits nonzero when the launch cannot be confirmed"
 else flunk "exits nonzero when the launch cannot be confirmed (exited $rc4)"; fi
 
+# ---- 4b. --supervise must not install a supervisor over a live unmanaged copy --
+# launchd's copy would exit under the singleton guard, and KeepAlive does not
+# restart a clean exit — so the supervisor supervises nothing.
+# NOTE: do NOT drive --supervise here. It reaches the real
+# src/install-sutando-app-launchd.sh, which writes a live LaunchAgent plist
+# pointing at this worktree's temp paths. Asserted structurally instead.
+# Structural: BOTH dispositions must call it, and the definition must exist once.
+defs="$(grep -c '^stop_unmanaged()' "$SCRIPT")"
+calls="$(grep -c '^  stop_unmanaged ||' "$SCRIPT")"
+if [ "$defs" = "1" ] && [ "$calls" = "2" ]; then
+    pass "one stop_unmanaged definition, called by both --supervise and --launch"
+else
+    flunk "one stop_unmanaged definition, called by both (defs=$defs calls=$calls)"
+fi
+
+# The guard must precede the installer call, or it cannot prevent anything.
+gi="$(grep -n '^  stop_unmanaged ||' "$SCRIPT" | head -1 | cut -d: -f1)"
+ii="$(grep -n 'bash "\$REPO/src/install-sutando-app-launchd.sh"' "$SCRIPT" | head -1 | cut -d: -f1)"
+if [ -n "$gi" ] && [ -n "$ii" ] && [ "$gi" -lt "$ii" ]; then
+    pass "the stop guard runs BEFORE the launchd installer"
+else
+    flunk "the stop guard runs BEFORE the launchd installer (guard=$gi installer=$ii)"
+fi
+
 # ---- 5. the retired probes must not come back -------------------------------
 # Strip comments first: the script explains WHY each probe was retired and names
 # it, so a whole-file grep matches the explanation and reports the bug it fixed.

--- a/tests/install-menu-bar-app.test.sh
+++ b/tests/install-menu-bar-app.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # stub bodies are written verbatim and expand when the
+# stub RUNS, not when this file writes it; single quotes are required throughout.
+# The installer's two dangerous paths, exercised against the real script.
+#
+# 1. Toolchain preflight. `command -v swiftc` passes against the Xcode-CLT stub
+#    on a clean Mac (REVIEW.md lesson 7), so a bare swiftc then raises the system
+#    install dialog instead of a diagnostic. The gate must be `xcode-select -p`,
+#    the one probe that does not prompt, and it must run BEFORE swiftc.
+#
+# 2. Replacement scope. The Electron desktop app shares the executable NAME with
+#    this menu-bar binary (#2038), so a name-scoped kill takes out the user's UI
+#    and then reports success. Replacement must be scoped to this bundle's path.
+#
+# Runs the production script with a stubbed toolchain on PATH — not a copy of
+# its logic — so the assertions bind to what actually ships.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO/scripts/install-menu-bar-app.sh"
+fail=0
+pass() { echo "PASS: $1"; }
+flunk() { echo "FAIL: $1"; fail=1; }
+
+[ "$(uname -s)" = "Darwin" ] || { echo "SKIP: macOS-only installer"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"; [ -n "${DECOY:-}" ] && kill "$DECOY" 2>/dev/null; exit' EXIT
+
+mkstub() {  # dir name body
+    mkdir -p "$1"
+    printf '#!/bin/sh\n%s\n' "$3" > "$1/$2"
+    chmod +x "$1/$2"
+}
+
+# ---- 1. preflight: no developer tools -> refuse, and never reach swiftc ------
+STUB="$WORK/stub-noclt"
+mkstub "$STUB" xcode-select 'exit 1'
+mkstub "$STUB" swiftc "touch '$WORK/SWIFTC_WAS_INVOKED'; exit 0"
+out="$(PATH="$STUB:$PATH" bash "$SCRIPT" 2>&1)"; rc=$?
+
+if [ "$rc" -ne 0 ]; then pass "refuses when xcode-select -p fails"
+else flunk "refuses when xcode-select -p fails (exited $rc)"; fi
+
+case "$out" in
+    *"xcode-select --install"*) pass "names the actual remedy" ;;
+    *) flunk "names the actual remedy (got: $out)" ;;
+esac
+
+# The whole point: the stub must never be invoked, because invoking it is what
+# raises the install dialog on a clean Mac.
+if [ -e "$WORK/SWIFTC_WAS_INVOKED" ]; then
+    flunk "does NOT invoke swiftc when the toolchain is absent"
+else
+    pass "does NOT invoke swiftc when the toolchain is absent"
+fi
+
+# ---- 2. preflight: tools present but swiftc not runnable --------------------
+STUB2="$WORK/stub-badswift"
+mkstub "$STUB2" xcode-select 'exit 0'
+mkstub "$STUB2" swiftc 'exit 1'
+out2="$(PATH="$STUB2:$PATH" bash "$SCRIPT" 2>&1)"; rc2=$?
+if [ "$rc2" -ne 0 ]; then pass "refuses when swiftc is present but not runnable"
+else flunk "refuses when swiftc is present but not runnable (exited $rc2: $out2)"; fi
+
+# ---- 3. replacement is path-scoped: a foreign 'Sutando' must SURVIVE --------
+# Stand in for the Electron desktop app: same executable name, different bundle.
+FOREIGN="$WORK/Applications/Sutando.app/Contents/MacOS"
+mkdir -p "$FOREIGN"
+# A COPY of a system binary is SIGKILLed by macOS (its signature no longer
+# matches), so the stand-in has to be a script we own.
+printf '#!/bin/sh\nexec sleep 600\n' > "$FOREIGN/Sutando"
+chmod +x "$FOREIGN/Sutando"
+"$FOREIGN/Sutando" &
+DECOY=$!
+sleep 0.3
+
+if ! kill -0 "$DECOY" 2>/dev/null; then
+    flunk "decoy setup (foreign Sutando did not start)"
+else
+    STUB3="$WORK/stub-build"
+    mkstub "$STUB3" xcode-select 'exit 0'
+    mkstub "$STUB3" swiftc 'while [ $# -gt 0 ]; do [ "$1" = "-o" ] && { shift; touch "$1"; }; shift; done; exit 0'
+    mkstub "$STUB3" codesign 'exit 0'
+    mkstub "$STUB3" open "touch '$WORK/OPEN_CALLED'; exit 0"
+    PATH="$STUB3:$PATH" bash "$SCRIPT" --launch >/dev/null 2>&1
+
+    if kill -0 "$DECOY" 2>/dev/null; then
+        pass "a foreign Sutando process SURVIVES --launch (not name-scoped)"
+    else
+        flunk "a foreign Sutando process SURVIVES --launch (it was killed)"
+    fi
+    kill "$DECOY" 2>/dev/null
+fi
+
+# ---- 4. success is verified, not assumed -----------------------------------
+# `open` succeeded but nothing is running, so the script must NOT claim launch.
+STUB4="$WORK/stub-noproc"
+mkstub "$STUB4" xcode-select 'exit 0'
+mkstub "$STUB4" swiftc 'while [ $# -gt 0 ]; do [ "$1" = "-o" ] && { shift; touch "$1"; }; shift; done; exit 0'
+mkstub "$STUB4" codesign 'exit 0'
+mkstub "$STUB4" open 'exit 0'
+out4="$(PATH="$STUB4:$PATH" bash "$SCRIPT" --launch 2>&1)"; rc4=$?
+case "$out4" in
+    *"✓ launched"*) flunk "never prints '✓ launched' when no process is running" ;;
+    *) pass "never prints '✓ launched' when no process is running" ;;
+esac
+if [ "$rc4" -ne 0 ]; then pass "exits nonzero when the launch cannot be confirmed"
+else flunk "exits nonzero when the launch cannot be confirmed (exited $rc4)"; fi
+
+# ---- 5. the retired probes must not come back -------------------------------
+# Strip comments first: the script explains WHY each probe was retired and names
+# it, so a whole-file grep matches the explanation and reports the bug it fixed.
+code="$(grep -vE '^[[:space:]]*#' "$SCRIPT")"
+case "$code" in
+    *'pkill -x Sutando'*) flunk "no name-scoped 'pkill -x Sutando' in CODE" ;;
+    *) pass "no name-scoped 'pkill -x Sutando' in CODE" ;;
+esac
+case "$code" in
+    *'command -v swiftc'*) flunk "no 'command -v swiftc' in CODE (passes against the CLT stub)" ;;
+    *) pass "no 'command -v swiftc' in CODE (passes against the CLT stub)" ;;
+esac
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: install-menu-bar-app"
+    exit 1
+fi
+echo "PASS: installer refuses without a real toolchain and replaces only its own app."

--- a/tests/install-menu-bar-app.test.sh
+++ b/tests/install-menu-bar-app.test.sh
@@ -123,6 +123,43 @@ else
     flunk "one stop_unmanaged definition, called by both (defs=$defs calls=$calls)"
 fi
 
+# ---- 4bis. a FAILING codesign must not print a signed checkmark -------------
+# Both signing arms used to end in `|| true` under an unconditional "✓ signed".
+STUB_CS="$WORK/stub-codesign-fails"
+mkstub "$STUB_CS" xcode-select 'exit 0'
+mkstub "$STUB_CS" swiftc 'while [ $# -gt 0 ]; do [ "$1" = "-o" ] && { shift; touch "$1"; }; shift; done; exit 0'
+mkstub "$STUB_CS" security 'exit 1'          # no "Sutando Dev" identity
+mkstub "$STUB_CS" codesign 'exit 1'          # every signing attempt fails
+mkstub "$STUB_CS" open 'exit 0'
+out_cs="$(PATH="$STUB_CS:$PATH" bash "$SCRIPT" 2>&1)"; rc_cs=$?
+case "$out_cs" in
+    *"✓ signed"*) flunk "prints '✓ signed' when every codesign attempt failed" ;;
+    *)            pass "never prints '✓ signed' when every codesign attempt failed" ;;
+esac
+case "$out_cs" in
+    *UNSIGNED*) pass "names the bundle as UNSIGNED so the state is reported, not hidden" ;;
+    *)          flunk "failing codesign did not report the unsigned state (out: ${out_cs%%$'\n'*})" ;;
+esac
+if [ "$rc_cs" -ne 0 ]; then
+    pass "exits nonzero when the bundle could not be signed"
+else
+    flunk "exited 0 with an unsigned bundle (rc=$rc_cs)"
+fi
+# Control: with codesign succeeding, the SAME path must still report success —
+# or the assertions above would pass simply by the script being broken.
+STUB_OK="$WORK/stub-codesign-ok"
+mkstub "$STUB_OK" xcode-select 'exit 0'
+mkstub "$STUB_OK" swiftc 'while [ $# -gt 0 ]; do [ "$1" = "-o" ] && { shift; touch "$1"; }; shift; done; exit 0'
+mkstub "$STUB_OK" security 'exit 1'
+mkstub "$STUB_OK" codesign 'exit 0'
+mkstub "$STUB_OK" open 'exit 0'
+out_ok="$(PATH="$STUB_OK:$PATH" bash "$SCRIPT" 2>&1)"; rc_ok=$?
+if [ "$rc_ok" -eq 0 ] && [ "${out_ok#*✓ signed}" != "$out_ok" ]; then
+    pass "control: a SUCCEEDING codesign still reports signed and exits 0"
+else
+    flunk "control failed: succeeding codesign did not report signed (rc=$rc_ok)"
+fi
+
 # ---- 4c. the probe must be LITERAL, not a regex over the checkout path ------
 # `pgrep -f` matches an ERE, so a checkout path holding regex metacharacters
 # makes the probe miss a live process and stop_unmanaged report "nothing to do".

--- a/tests/install-sutando-app-launchd.test.sh
+++ b/tests/install-sutando-app-launchd.test.sh
@@ -12,6 +12,10 @@
 # worktree got installed on a developer machine.
 set -uo pipefail
 
+# launchctl, ~/Library/LaunchAgents and codesign are macOS-only; the sibling
+# installer test carries this same guard, and omitting it broke CI on ubuntu.
+[ "$(uname -s)" = "Darwin" ] || { echo "SKIP: macOS-only installer"; exit 0; }
+
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO/src/install-sutando-app-launchd.sh"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/launchd-test-XXXXXX")"

--- a/tests/install-sutando-app-launchd.test.sh
+++ b/tests/install-sutando-app-launchd.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# --supervise must prove launchd owns a running process before reporting success.
+#
+# `launchctl kickstart` is invoked with `|| true` (it is idempotent-noisy), so the
+# only thing standing between "registered" and "supervised" is a pid check. Without
+# it the command prints "Sutando.app is now launchd-supervised" over a job launchd
+# never started, and KeepAlive cannot restart what never ran.
+#
+# Isolation is the point of this file: HOME is redirected, so DEST resolves inside
+# the temp tree and the real ~/Library/LaunchAgents is never written. Driving
+# --supervise WITHOUT that redirect is how a live LaunchAgent pointing at a temp
+# worktree got installed on a developer machine.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO/src/install-sutando-app-launchd.sh"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/launchd-test-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+fail=0
+
+pass() { echo "PASS: $1"; }
+flunk() { echo "FAIL: $1"; fail=1; }
+
+mkstub() {  # dir name body
+    mkdir -p "$1"
+    printf '#!/bin/sh\n%s\n' "$3" > "$1/$2"
+    chmod +x "$1/$2"
+}
+
+# A launchctl whose `print` reports a running pid == the healthy case.
+mklaunchctl() {  # dir  pid-line-or-empty
+    mkstub "$1" launchctl "
+case \"\$1\" in
+  print) [ -n \"$2\" ] && printf '\tstate = running\n\tpid = %s\n' \"$2\"; exit 0 ;;
+  bootstrap|bootout|kickstart) exit 0 ;;
+esac
+exit 0"
+}
+
+run_supervise() {  # stubdir -> stdout+stderr, sets RC
+    HOME="$WORK/home" PATH="$1:$PATH" bash "$SCRIPT" 2>&1
+}
+
+mkdir -p "$WORK/home/Library/LaunchAgents"
+REAL_AGENTS="$HOME/Library/LaunchAgents"
+agents_listing() { find "$REAL_AGENTS" -maxdepth 1 -type f 2>/dev/null | sort; }
+BEFORE="$(agents_listing)"
+
+# ---- 1. a job launchd never started must NOT report supervision -------------
+STUB_DEAD="$WORK/stub-nopid"
+mklaunchctl "$STUB_DEAD" ""
+out_dead="$(run_supervise "$STUB_DEAD")"; rc_dead=$?
+case "$out_dead" in
+    *"now launchd-supervised"*) flunk "reports supervision with no launchd-owned pid" ;;
+    *)                          pass "never reports supervision with no launchd-owned pid" ;;
+esac
+if [ "$rc_dead" -ne 0 ]; then pass "exits nonzero when launchd owns no process"
+else flunk "exited 0 with no launchd-owned process (rc=$rc_dead)"; fi
+
+# ---- 2. CONTROL: a running pid must still report success --------------------
+# Without this, assertion 1 would pass simply by the script being broken.
+STUB_LIVE="$WORK/stub-pid"
+mklaunchctl "$STUB_LIVE" "4242"
+out_live="$(run_supervise "$STUB_LIVE")"; rc_live=$?
+case "$out_live" in
+    *"now launchd-supervised"*) pass "control: a live launchd pid DOES report supervision" ;;
+    *) flunk "control failed: live pid did not report supervision (rc=$rc_live)" ;;
+esac
+case "$out_live" in
+    *"pid 4242"*) pass "names the launchd-owned pid it verified" ;;
+    *)            flunk "did not name the verified pid" ;;
+esac
+
+# ---- 3. isolation: the REAL LaunchAgents dir must be untouched --------------
+# The defect this guards is not hypothetical — it happened on a dev machine.
+AFTER="$(agents_listing)"
+if [ "$BEFORE" = "$AFTER" ]; then
+    pass "the real ~/Library/LaunchAgents is unchanged by this test"
+else
+    flunk "this test wrote to the REAL LaunchAgents dir"
+fi
+if [ -f "$WORK/home/Library/LaunchAgents/com.sutando.menubar.plist" ]; then
+    pass "the plist landed in the redirected HOME, proving the seam works"
+else
+    flunk "no plist in the redirected HOME — the run never reached install (seam unproven)"
+fi
+
+[ "$fail" -eq 0 ] || { echo "FAIL: install-sutando-app-launchd"; exit 1; }
+echo "PASS: --supervise proves a live launchd-owned process before claiming it."


### PR DESCRIPTION
## Concern

#2677 made the open-source core headless, which was right. But it deleted the only code that **produced** the menu-bar app's `.app` bundle and shipped no replacement, so an OSS install lost the app entirely and the documented alternative became "run `swiftc` by hand."

This adds the missing build path. It does **not** touch `startup.sh` — the core stays headless.

## Evidence

### Before / after, actually run (not described)

```
$ ls -l src/Sutando/Sutando.app/Contents/MacOS/Sutando
ls: src/Sutando/Sutando.app/Contents/MacOS/Sutando: No such file or directory
exit=1

$ bash scripts/install-menu-bar-app.sh          # no flags = build only
Building menu-bar binary…
  ✓ …/src/Sutando/Sutando
  ✓ …/src/Sutando/Sutando.app
  ✓ signed (ad-hoc — install a "Sutando Dev" cert for a TCC grant that survives rebuilds)

Done. The core stays headless — this app is opt-in and separate.
EXIT=0

$ ls -l src/Sutando/Sutando.app/Contents/MacOS/Sutando
-rwxr-xr-x@ 1 wangchi  wheel  458448 Aug 16 19:32 src/Sutando/Sutando.app/…/Sutando
exit=0
```

**And it satisfies the launchd installer's own expression, not a path I chose to match:**

```
$ grep -n "APP_BINARY=" src/install-sutando-app-launchd.sh
56:APP_BINARY="$REPO/src/Sutando/Sutando.app/Contents/MacOS/Sutando"

$ APP_BINARY="$REPO/src/Sutando/Sutando.app/Contents/MacOS/Sutando"; test -x "$APP_BINARY"
test -x APP_BINARY -> EXIT 0 (satisfied)      # was EXIT 1 before the run above
```

Bundle shape and signature:

```
$ ls src/Sutando/Sutando.app/Contents/
Info.plist   MacOS   Resources   _CodeSignature

$ codesign -dv src/Sutando/Sutando.app
Identifier=com.sutando.menubar
Format=app bundle with Mach-O thin (arm64)
```

`git status` stays clean — both artifacts are already gitignored (`.gitignore:80`, `src/Sutando/.gitignore:1`).

### The rest, checkable on current `main`

**Nothing on `main` builds it.** The four tracked files referencing `Sutando.app/Contents/MacOS` — `dashboard.py`, `health-check.py`, `install-sutando-app-launchd.sh`, `launchd/com.sutando.menubar.plist` — are all *consumers*. No `swiftc` caller on `main` compiles `src/Sutando` (the five `swiftc` hits are `python-binary.sh`, `macos-use`, `pointer-teacher-tracer`, `git_binary.py` — unrelated). `startup.sh`'s three remaining mentions are **comments only** (`:189`, `:1330`, `:1338`).

**And the teardown outlived the thing it tears down:**

```
$ grep -n 'pkill.*Sutando' src/restart.sh
73:pkill -f "src/Sutando/Sutando"
```

Nothing starts it, so a restart is a permanent stop.

`shellcheck scripts/install-menu-bar-app.sh` → clean (exit 0). `review-checks.sh --diff` → PASS.

## What this adds

`scripts/install-menu-bar-app.sh` — builds the binary, assembles and signs the bundle at exactly the path `install-sutando-app-launchd.sh:56` already expects. Flags: none (build + print next steps), `--launch`, `--supervise` (launchd KeepAlive for login auto-start). `shellcheck` clean; `review-checks.sh --diff` PASS.

`REVIEW.md` lesson 11 — *a change that removes a capability must relocate it, not just delete it; check the teardown side, and check whether any opt-in path depended on the deleted code to produce its inputs.* Grounded by #2677, which is the instance above.

## Why this shape rather than restoring auto-launch

An earlier draft made the app opt-**out** via `--headless` in `startup.sh`. That was abandoned: it argues with a merged decision. Relocating the capability keeps #2677 intact and still fixes what it broke — which is what lesson 11 asks for, so the lesson and the fix are consistent by construction.

@sonichi — flagging you as the reviewer.

