### PR TITLE
feat(sparrow): pin a channel-neutral Delivery Core contract (no migration)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/__init__.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/__init__.py
@@ -1,0 +1,16 @@
+"""Channel-neutral Delivery Core: contract types + protocols (contract),
+the drain loop (core), and the default backend (backend_a). Seam design:
+the master-room doc docs/delivery-core-seam-v0.2.md."""
+from .contract import (BackendCapabilities, ClaimBackend, ClaimToken,
+                       CleanupReport, DeliveryOutcome, DeliveryProvider,
+                       DeliveryReceipt, DrainReport, ProviderCapabilities,
+                       RecoverReport)
+from .core import DeliveryCore, RetryPolicy, idempotency_key
+from .backend_a import DesignAClaimBackend
+
+__all__ = [
+    "BackendCapabilities", "ClaimBackend", "ClaimToken", "CleanupReport",
+    "DeliveryOutcome", "DeliveryProvider", "DeliveryReceipt", "DrainReport",
+    "ProviderCapabilities", "RecoverReport", "DeliveryCore", "RetryPolicy",
+    "idempotency_key", "DesignAClaimBackend",
+]

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/__init__.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/__init__.py
@@ -3,14 +3,16 @@ the drain loop (core), and the default backend (backend_a). Seam design:
 the master-room doc docs/delivery-core-seam-v0.2.md."""
 from .contract import (BackendCapabilities, ClaimBackend, ClaimToken,
                        CleanupReport, DeliveryOutcome, DeliveryProvider,
-                       DeliveryReceipt, DrainReport, ProviderCapabilities,
-                       RecoverReport)
+                       DeliveryReceipt, DrainReport, DrainResult, DrainStatus,
+                       ProviderCapabilities, ProviderIndeterminate,
+                       ProviderRefused, RecoverReport)
 from .core import DeliveryCore, RetryPolicy, idempotency_key
 from .backend_a import DesignAClaimBackend
 
 __all__ = [
     "BackendCapabilities", "ClaimBackend", "ClaimToken", "CleanupReport",
     "DeliveryOutcome", "DeliveryProvider", "DeliveryReceipt", "DrainReport",
-    "ProviderCapabilities", "RecoverReport", "DeliveryCore", "RetryPolicy",
-    "idempotency_key", "DesignAClaimBackend",
+    "DrainResult", "DrainStatus", "ProviderCapabilities",
+    "ProviderIndeterminate", "ProviderRefused", "RecoverReport",
+    "DeliveryCore", "RetryPolicy", "idempotency_key", "DesignAClaimBackend",
 ]

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -35,27 +35,51 @@ class DesignAClaimBackend:
         })
         return True
 
+    def _incarnation_of(self, item_id: str) -> Optional[str]:
+        """The claim record's non-reusable identity: pid + process birth +
+        claim stamp. A restarted worker of the same name cannot reproduce
+        it, which is what makes a stale token detectable."""
+        rec = outbox.read_delivery_claim(self.root, item_id)
+        if rec is None or rec.state == "UNKNOWN":
+            return None
+        return f"{rec.drainer_id}:{rec.pid}:{rec.start_usec}:{rec.claimed_at}"
+
     def claim(self, item_id: str, worker: str) -> Optional[ClaimToken]:
         if not outbox._item_path(self.root, item_id).exists():
             return None
-        if outbox.acquire_delivery_claim(self.root, item_id, worker):
-            return ClaimToken(item_id=item_id, opaque=worker)
-        if outbox.reclaim_delivery_claim(self.root, item_id,
-                                         self.reclaim_ttl_s, worker):
-            return ClaimToken(item_id=item_id, opaque=worker)
-        return None
+        took = (outbox.acquire_delivery_claim(self.root, item_id, worker)
+                or outbox.reclaim_delivery_claim(self.root, item_id,
+                                                 self.reclaim_ttl_s, worker))
+        if not took:
+            return None
+        incarnation = self._incarnation_of(item_id)
+        if incarnation is None:                 # record vanished under us
+            return None
+        return ClaimToken(item_id=item_id, worker=worker,
+                          incarnation=incarnation)
 
     def complete(self, token: ClaimToken, outcome: DeliveryOutcome) -> bool:
-        if outcome is DeliveryOutcome.CONFIRMED:
-            d = outbox._read_item(self.root, token.item_id)
-            d["status"] = "DELIVERED"
-            outbox._write_item(self.root, token.item_id, d)
-        elif outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
-            outbox.park_item(self.root, token.item_id, "outcome-unknown")
-        else:
-            outbox.note_attempt(self.root, token.item_id)
-        return outbox.release_delivery_claim(self.root, token.item_id,
-                                             token.opaque)
+        item_id = token.item_id
+        # Validate -> transition -> retire, all under the item lock: a stale
+        # incarnation must not mutate or park its successor's item.
+        with outbox._item_lock(self.root, item_id):
+            if self._incarnation_of(item_id) != token.incarnation:
+                return False
+            if outcome is DeliveryOutcome.CONFIRMED:
+                d = outbox._read_item(self.root, item_id)
+                d["status"] = "DELIVERED"
+                outbox._write_item(self.root, item_id, d)
+            elif outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
+                outbox.park_item(self.root, item_id, "outcome-unknown")
+            else:
+                outbox.note_attempt(self.root, item_id)
+            return outbox._release_locked(self.root, item_id, token.worker)
+
+    def attempts(self, item_id: str) -> int:
+        return outbox.attempts_for(self.root, item_id)
+
+    def park(self, item_id: str, reason: str) -> None:
+        outbox.park_item(self.root, item_id, reason)
 
     def recover(self) -> RecoverReport:
         """A recovers lazily at claim time (reclaim TTL); this pass reports

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -65,7 +65,8 @@ class DesignAClaimBackend:
             return ClaimToken(item_id=item_id, worker=worker,
                               incarnation=incarnation)
 
-    def complete(self, token: ClaimToken, outcome: DeliveryOutcome) -> bool:
+    def complete(self, token: ClaimToken, outcome: DeliveryOutcome,
+                 park_at_attempts: Optional[int] = None) -> bool:
         item_id = token.item_id
         # Validate -> transition -> retire, all under the item lock: a stale
         # incarnation must not mutate or park its successor's item.
@@ -81,7 +82,9 @@ class DesignAClaimBackend:
             elif outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
                 outbox.park_item(self.root, item_id, "outcome-unknown")
             else:
-                outbox.note_attempt(self.root, item_id)
+                attempts = outbox.note_attempt(self.root, item_id)
+                if park_at_attempts is not None and attempts >= park_at_attempts:
+                    outbox.park_item(self.root, item_id, "max-attempts")
             return outbox._release_locked(self.root, item_id, token.worker)
 
     def attempts(self, item_id: str) -> int:

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -1,0 +1,78 @@
+"""DesignAClaimBackend: the shipped outbox claim protocol behind the
+ClaimBackend seam. Wrapper only — no call-site or disk-format change
+(acceptance criterion 4); production callers keep using outbox.py directly
+until Phase 2 routes an adapter through DeliveryCore."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Optional
+
+from .. import outbox
+from .contract import (BackendCapabilities, ClaimToken, CleanupReport,
+                       DeliveryOutcome, RecoverReport)
+
+
+class DesignAClaimBackend:
+    """A: free-standing claim records + flock-serialized transitions.
+    Reclaim TTL is A's dead-owner recovery window; force-release exists
+    (declared) as the administrative-destruction mechanism."""
+
+    capabilities = BackendCapabilities(supports_force_release=True)
+
+    def __init__(self, root: Path, reclaim_ttl_s: float = 300.0):
+        self.root = Path(root)
+        self.reclaim_ttl_s = reclaim_ttl_s
+
+    def publish(self, item_id: str, payload: bytes) -> bool:
+        if outbox._item_path(self.root, item_id).exists():
+            return False
+        outbox._write_item(self.root, item_id, {
+            "item_id": item_id,
+            "payload": payload.decode("utf-8", "replace"),
+            "status": "READY",
+            "published_at": time.time(),
+        })
+        return True
+
+    def claim(self, item_id: str, worker: str) -> Optional[ClaimToken]:
+        if not outbox._item_path(self.root, item_id).exists():
+            return None
+        if outbox.acquire_delivery_claim(self.root, item_id, worker):
+            return ClaimToken(item_id=item_id, opaque=worker)
+        if outbox.reclaim_delivery_claim(self.root, item_id,
+                                         self.reclaim_ttl_s, worker):
+            return ClaimToken(item_id=item_id, opaque=worker)
+        return None
+
+    def complete(self, token: ClaimToken, outcome: DeliveryOutcome) -> bool:
+        if outcome is DeliveryOutcome.CONFIRMED:
+            d = outbox._read_item(self.root, token.item_id)
+            d["status"] = "DELIVERED"
+            outbox._write_item(self.root, token.item_id, d)
+        elif outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
+            outbox.park_item(self.root, token.item_id, "outcome-unknown")
+        else:
+            outbox.note_attempt(self.root, token.item_id)
+        return outbox.release_delivery_claim(self.root, token.item_id,
+                                             token.opaque)
+
+    def recover(self) -> RecoverReport:
+        """A recovers lazily at claim time (reclaim TTL); this pass reports
+        which items are currently reclaimable so the core can re-drive
+        them. Nothing is moved — reclaim happens under the next claim."""
+        rep = RecoverReport()
+        claims = outbox._claims_dir(self.root)
+        if claims.exists():
+            for p in claims.glob("*.json"):
+                item_id = p.stem
+                if outbox.may_reclaim_delivery(self.root, item_id,
+                                               self.reclaim_ttl_s):
+                    rep.recovered.append(item_id)
+        return rep
+
+    def cleanup(self) -> CleanupReport:
+        return CleanupReport(pruned=0, detail="A: bounded by lock striping")
+
+    def force_release(self, item_id: str) -> bool:
+        return outbox.release_delivery_claim(self.root, item_id, force=True)

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -44,26 +44,35 @@ class DesignAClaimBackend:
             return None
         return f"{rec.drainer_id}:{rec.pid}:{rec.start_usec}:{rec.claimed_at}"
 
+    TERMINAL = {"DELIVERED", "PARKED"}
+
     def claim(self, item_id: str, worker: str) -> Optional[ClaimToken]:
-        if not outbox._item_path(self.root, item_id).exists():
-            return None
-        took = (outbox.acquire_delivery_claim(self.root, item_id, worker)
-                or outbox.reclaim_delivery_claim(self.root, item_id,
-                                                 self.reclaim_ttl_s, worker))
-        if not took:
-            return None
-        incarnation = self._incarnation_of(item_id)
-        if incarnation is None:                 # record vanished under us
-            return None
-        return ClaimToken(item_id=item_id, worker=worker,
-                          incarnation=incarnation)
+        # Eligibility, acquisition and capture in ONE critical section: a
+        # later capture can adopt a successor's incarnation.
+        with outbox._item_lock(self.root, item_id):
+            if not outbox._item_path(self.root, item_id).exists():
+                return None
+            if outbox._read_item(self.root, item_id).get("status") in self.TERMINAL:
+                return None
+            took = (outbox._acquire_locked(self.root, item_id, worker)
+                    or outbox._reclaim_locked(self.root, item_id,
+                                              self.reclaim_ttl_s, worker))
+            if not took:
+                return None
+            incarnation = self._incarnation_of(item_id)
+            if incarnation is None:             # record vanished under us
+                return None
+            return ClaimToken(item_id=item_id, worker=worker,
+                              incarnation=incarnation)
 
     def complete(self, token: ClaimToken, outcome: DeliveryOutcome) -> bool:
         item_id = token.item_id
         # Validate -> transition -> retire, all under the item lock: a stale
         # incarnation must not mutate or park its successor's item.
         with outbox._item_lock(self.root, item_id):
-            if self._incarnation_of(item_id) != token.incarnation:
+            rec = outbox.read_delivery_claim(self.root, item_id)
+            if rec is None or rec.drainer_id != token.worker or \
+                    self._incarnation_of(item_id) != token.incarnation:
                 return False
             if outcome is DeliveryOutcome.CONFIRMED:
                 d = outbox._read_item(self.root, item_id)

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -24,9 +24,44 @@ from typing import Optional, Protocol, runtime_checkable
 
 
 class DeliveryOutcome(str, Enum):
+    """Describes an ATTEMPTED external delivery, and nothing else. A drain
+    that never called the provider has no DeliveryOutcome — see DrainResult
+    — or telemetry and recovery policy read local bookkeeping as external
+    ambiguity."""
     CONFIRMED = "confirmed"
     NOT_DELIVERED = "not_delivered"
     OUTCOME_UNKNOWN = "outcome_unknown"
+
+
+class DrainStatus(str, Enum):
+    """Why a drain attempt ended, locally. NOT_CLAIMED means another worker
+    owns the item: no provider call was made, so nothing external is
+    ambiguous."""
+    NOT_CLAIMED = "not_claimed"
+    ATTEMPTED = "attempted"
+
+
+@dataclass(frozen=True)
+class DrainResult:
+    status: DrainStatus
+    outcome: Optional[DeliveryOutcome] = None   # set iff status is ATTEMPTED
+
+    def __post_init__(self):
+        attempted = self.status is DrainStatus.ATTEMPTED
+        if attempted != (self.outcome is not None):
+            raise ValueError(
+                "an outcome exists exactly when a delivery was attempted")
+
+
+class ProviderIndeterminate(Exception):
+    """The call MAY have crossed the external side-effect boundary (timeout
+    after send, connection reset mid-request, ambiguous 5xx). This is the
+    ONLY exception class that maps to OUTCOME_UNKNOWN."""
+
+
+class ProviderRefused(Exception):
+    """The provider definitely did not perform the side effect (validation
+    rejection, refusal before dispatch). Maps to NOT_DELIVERED."""
 
 
 @dataclass(frozen=True)
@@ -60,10 +95,14 @@ class BackendCapabilities:
 
 @dataclass(frozen=True)
 class ClaimToken:
-    """Opaque above the backend: `opaque` is backend-private claim material.
-    item_id rides along so the core can route outcomes without parsing."""
+    """ONE ownership incarnation, not a drainer identity. `incarnation` is
+    backend-private material that a later incarnation of the same worker
+    cannot reproduce (pid + process birth + claim stamp), so a token that
+    outlived its claim is rejected instead of matching by worker name.
+    Opaque above the backend; item_id rides along for routing only."""
     item_id: str
-    opaque: str
+    worker: str
+    incarnation: str
 
 
 @dataclass
@@ -114,8 +153,20 @@ class ClaimBackend(Protocol):
         ...
 
     def complete(self, token: ClaimToken, outcome: DeliveryOutcome) -> bool:
-        """Retire own ownership with the delivery outcome. Only the token's
-        owner may complete; True = retired."""
+        """Validate the exact incarnation, apply the outcome transition, and
+        retire the claim — ALL inside one backend critical section, in that
+        order. A stale token must change nothing: validating after mutating
+        lets a dead incarnation park or advance its successor's item, which
+        is the concurrency defect this seam exists to stop propagating.
+        True = this incarnation owned the claim and it is now retired."""
+        ...
+
+    def attempts(self, item_id: str) -> int:
+        """Delivery attempts recorded for this item (retry accounting)."""
+        ...
+
+    def park(self, item_id: str, reason: str) -> None:
+        """Remove the item from the drainable set pending operator action."""
         ...
 
     def recover(self) -> RecoverReport:

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -1,0 +1,157 @@
+"""Delivery Core contract: the channel-neutral seam between local ownership
+(ClaimBackend), the external side effect (DeliveryProvider), and the drain
+loop (DeliveryCore in core.py).
+
+Identity model (three types, never conflated):
+- item_id: stable logical message identity, assigned at publish.
+- ClaimToken: one local-ownership incarnation; OPAQUE above the backend and
+  NEVER exported as delivery identity — claim material (worker/pid/birth)
+  changes across incarnations, and a key derived from it turns provider
+  dedup into a fresh send.
+- delivery idempotency key: stable per logical external side effect, minted
+  by DeliveryCore from item_id (+ deliberate re-send epoch), passed to the
+  provider, and REUSED on every retry and across re-claim/restart.
+
+Guarantee wording (normative): effectively-once within the provider's
+idempotency and receipt-retention contract — never unqualified
+"exactly-once".
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Protocol, runtime_checkable
+
+
+class DeliveryOutcome(str, Enum):
+    CONFIRMED = "confirmed"
+    NOT_DELIVERED = "not_delivered"
+    OUTCOME_UNKNOWN = "outcome_unknown"
+
+
+@dataclass(frozen=True)
+class DeliveryReceipt:
+    """Outcome of one deliver/reconcile call. `provider_ref` is the
+    provider's own reference for the side effect; confirmed-by-provider is
+    never inferred from accepted-by-transport, so CONFIRMED without a
+    provider_ref is legal only where the provider's contract says accept
+    IS confirmation."""
+    outcome: DeliveryOutcome
+    provider_ref: Optional[str] = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Declared, suite-read; decides post-UNKNOWN behavior. Channel code
+    never does."""
+    reconcile_capable: bool = False   # receipt queryable after UNKNOWN
+    idempotent_send: bool = False     # key-deduped; safe-resend on UNKNOWN
+
+
+@dataclass(frozen=True)
+class BackendCapabilities:
+    """Declared, suite-read (never hasattr-sniffed). What is optional is
+    the OPERATION, not the liveness guarantee it serves: "a dead owner's
+    claim is eventually recoverable" holds for every backend — force
+    release is one mechanism (A), a requeue-layer path is another (B)."""
+    supports_force_release: bool = False
+
+
+@dataclass(frozen=True)
+class ClaimToken:
+    """Opaque above the backend: `opaque` is backend-private claim material.
+    item_id rides along so the core can route outcomes without parsing."""
+    item_id: str
+    opaque: str
+
+
+@dataclass
+class CleanupReport:
+    pruned: int = 0
+    detail: str = ""
+
+
+@dataclass
+class DrainReport:
+    claimed: int = 0
+    confirmed: int = 0
+    retried: int = 0
+    parked: int = 0
+    errors: list = field(default_factory=list)
+
+
+@dataclass
+class RecoverReport:
+    recovered: list = field(default_factory=list)   # item_ids re-claimable
+    quarantined: list = field(default_factory=list)
+
+
+@runtime_checkable
+class ClaimBackend(Protocol):
+    """Local ownership of published outbound items. Invariants the contract
+    suite enforces on EVERY implementation (see the seam doc for the full
+    instrument mapping):
+      1. at most one local owner per item at any time — including under the
+         publish-during-inflight schedule (CE-1);
+      2. a stale incarnation can never destroy a successful claimant;
+      3. crash at any syscall boundary leaves the item in exactly one
+         deliverable state or with a terminal record;
+      4. protocol metadata is bounded (cleanup);
+      5. a dead owner's claim is eventually recoverable (mechanism per
+         capabilities);
+      6. lost races are protocol outcomes; config errors raise loudly."""
+
+    @property
+    def capabilities(self) -> BackendCapabilities: ...
+
+    def publish(self, item_id: str, payload: bytes) -> bool:
+        """True = newly published; False = this id is already live."""
+        ...
+
+    def claim(self, item_id: str, worker: str) -> Optional[ClaimToken]:
+        """Acquire exclusive local ownership, or None on a lost race."""
+        ...
+
+    def complete(self, token: ClaimToken, outcome: DeliveryOutcome) -> bool:
+        """Retire own ownership with the delivery outcome. Only the token's
+        owner may complete; True = retired."""
+        ...
+
+    def recover(self) -> RecoverReport:
+        """Return DEAD owners' items to claimable. ALIVE/UNKNOWN owners are
+        never touched; a dead token whose key has another live holder is
+        quarantined, never re-armed (CE-2/CE-1 class)."""
+        ...
+
+    def cleanup(self) -> CleanupReport:
+        """Bound on-disk protocol state."""
+        ...
+
+    def force_release(self, item_id: str) -> bool:
+        """ADMINISTRATIVE DESTRUCTION, not a release (contract: #3008).
+        Only for backends declaring supports_force_release; others raise
+        NotImplementedError — never a silent no-op."""
+        ...
+
+
+@runtime_checkable
+class DeliveryProvider(Protocol):
+    """The external side effect. Adapters keep provider-specific mechanics
+    (AG2 Space lease/ACK/finalize, Discord API + rate limits); the core
+    reads only capabilities and receipts. Adapter contract tests must
+    export a finalize-observable where the provider has a server-side
+    finalize, so provider-confirmed and server-finalized stay independently
+    observable (invariant 9)."""
+
+    @property
+    def capabilities(self) -> ProviderCapabilities: ...
+
+    def deliver(self, item_id: str, payload: bytes,
+                idempotency_key: str) -> DeliveryReceipt: ...
+
+    def reconcile(self, item_id: str,
+                  idempotency_key: str) -> Optional[DeliveryReceipt]:
+        """Resolve an OUTCOME_UNKNOWN via the provider's receipt store;
+        None where the provider cannot answer (capability-gated)."""
+        ...

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -15,6 +15,12 @@ Identity model (three types, never conflated):
 Guarantee wording (normative): effectively-once within the provider's
 idempotency and receipt-retention contract — never unqualified
 "exactly-once".
+
+Retirement authority (normative, from the #3018 cross-consumer defect):
+the consumer that DISPATCHED a work item is the only one that may retire
+its result (archive / ack / skip-mark). A consumer sweeping a shared
+results namespace must filter to its own dispatches before acting —
+retiring another consumer's bookkeeping strands the replies behind it.
 """
 from __future__ import annotations
 

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -158,12 +158,17 @@ class ClaimBackend(Protocol):
         """Acquire exclusive local ownership, or None on a lost race."""
         ...
 
-    def complete(self, token: ClaimToken, outcome: DeliveryOutcome) -> bool:
+    def complete(self, token: ClaimToken, outcome: DeliveryOutcome,
+                 park_at_attempts: Optional[int] = None) -> bool:
         """Validate the exact incarnation, apply the outcome transition, and
         retire the claim — ALL inside one backend critical section, in that
         order. A stale token must change nothing: validating after mutating
         lets a dead incarnation park or advance its successor's item, which
         is the concurrency defect this seam exists to stop propagating.
+        `park_at_attempts` makes the retry CEILING part of the same atomic
+        step: recording the attempt and parking at the ceiling must not be
+        two transactions, or a successor can claim and confirm between them
+        and the stale caller's park overwrites its DELIVERED state.
         True = this incarnation owned the claim and it is now retired."""
         ...
 

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
@@ -1,0 +1,72 @@
+"""DeliveryCore: the drain loop. The ONLY component that reads
+DeliveryOutcome semantics and ProviderCapabilities — channel code never
+decides retry/UNKNOWN rules (acceptance criterion 2).
+
+Retry policy (normative):
+- only a confirmed NOT_DELIVERED auto-retries;
+- OUTCOME_UNKNOWN parks unless capabilities license reconcile (resolve,
+  then act on the resolved outcome) or idempotent-send (safe re-send);
+- ambiguous is never auto-relabeled NOT_DELIVERED.
+
+Delivered evidence is written only AFTER the send returns (evidence is
+risk control, not proof — invariant 8)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .contract import (BackendCapabilities, ClaimBackend, DeliveryOutcome,
+                       DeliveryProvider, DrainReport, RecoverReport)
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int = 3
+
+
+def idempotency_key(item_id: str, resend_epoch: int = 0) -> str:
+    """Stable per logical side effect; NEVER derived from claim material.
+    resend_epoch changes only on a DELIBERATE operator re-send."""
+    return f"{item_id}#{resend_epoch}"
+
+
+class DeliveryCore:
+    def __init__(self, backend: ClaimBackend, provider: DeliveryProvider,
+                 policy: RetryPolicy | None = None,
+                 worker: str = "delivery-core"):
+        self.backend = backend
+        self.provider = provider
+        self.policy = policy or RetryPolicy()
+        self.worker = worker
+
+    def deliver_one(self, item_id: str, payload: bytes) -> DeliveryOutcome:
+        """Claim -> deliver -> classify -> complete/park. Returns the final
+        outcome recorded for this pass (OUTCOME_UNKNOWN when parked)."""
+        token = self.backend.claim(item_id, self.worker)
+        if token is None:
+            return DeliveryOutcome.OUTCOME_UNKNOWN     # lost race: not ours
+        key = idempotency_key(item_id)
+        try:
+            receipt = self.provider.deliver(item_id, payload, key)
+        except Exception:
+            # transport indeterminacy: the local call and the remote effect
+            # are never one transaction — UNKNOWN is irreducible locally
+            receipt = None
+        outcome = receipt.outcome if receipt is not None \
+            else DeliveryOutcome.OUTCOME_UNKNOWN
+        if outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
+            caps = self.provider.capabilities
+            if caps.reconcile_capable:
+                resolved = self.provider.reconcile(item_id, key)
+                if resolved is not None:
+                    outcome = resolved.outcome
+            elif caps.idempotent_send:
+                try:
+                    retry = self.provider.deliver(item_id, payload, key)
+                    outcome = retry.outcome
+                except Exception:
+                    outcome = DeliveryOutcome.OUTCOME_UNKNOWN
+        self.backend.complete(token, outcome)
+        return outcome
+
+    def recover(self) -> RecoverReport:
+        return self.backend.recover()

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
@@ -69,10 +69,10 @@ class DeliveryCore:
                     outcome = resolved.outcome
             elif caps.idempotent_send:
                 outcome = self._attempt(item_id, payload, key)
-        self.backend.complete(token, outcome)
-        if (outcome is DeliveryOutcome.NOT_DELIVERED
-                and self.backend.attempts(item_id) >= self.policy.max_attempts):
-            self.backend.park(item_id, "max-attempts")
+        # The ceiling rides WITH the completion: parking after the claim
+        # is released lets a successor confirm in the gap.
+        self.backend.complete(token, outcome,
+                              park_at_attempts=self.policy.max_attempts)
         return DrainResult(status=DrainStatus.ATTEMPTED, outcome=outcome)
 
     def recover(self) -> RecoverReport:

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .contract import (BackendCapabilities, ClaimBackend, DeliveryOutcome,
-                       DeliveryProvider, DrainReport, RecoverReport)
+from .contract import (ClaimBackend, DeliveryOutcome, DeliveryProvider,
+                       DrainResult, DrainStatus, ProviderIndeterminate,
+                       ProviderRefused, RecoverReport)
 
 
 @dataclass(frozen=True)
@@ -38,21 +39,28 @@ class DeliveryCore:
         self.policy = policy or RetryPolicy()
         self.worker = worker
 
-    def deliver_one(self, item_id: str, payload: bytes) -> DeliveryOutcome:
-        """Claim -> deliver -> classify -> complete/park. Returns the final
-        outcome recorded for this pass (OUTCOME_UNKNOWN when parked)."""
+    def _attempt(self, item_id: str, payload: bytes,
+                 key: str) -> DeliveryOutcome:
+        """One provider call, classified by the typed failure taxonomy.
+        Only a boundary-crossing failure is UNKNOWN; a refusal is
+        NOT_DELIVERED; anything else (programming, config, capability
+        violation) propagates rather than masquerading as ambiguity."""
+        try:
+            return self.provider.deliver(item_id, payload, key).outcome
+        except ProviderIndeterminate:
+            return DeliveryOutcome.OUTCOME_UNKNOWN
+        except ProviderRefused:
+            return DeliveryOutcome.NOT_DELIVERED
+
+    def deliver_one(self, item_id: str, payload: bytes) -> DrainResult:
+        """Claim -> deliver -> classify -> complete, with retry accounting."""
         token = self.backend.claim(item_id, self.worker)
         if token is None:
-            return DeliveryOutcome.OUTCOME_UNKNOWN     # lost race: not ours
+            # Another worker owns it. No provider call was made, so there is
+            # no external ambiguity to report — this is not an outcome.
+            return DrainResult(status=DrainStatus.NOT_CLAIMED)
         key = idempotency_key(item_id)
-        try:
-            receipt = self.provider.deliver(item_id, payload, key)
-        except Exception:
-            # transport indeterminacy: the local call and the remote effect
-            # are never one transaction — UNKNOWN is irreducible locally
-            receipt = None
-        outcome = receipt.outcome if receipt is not None \
-            else DeliveryOutcome.OUTCOME_UNKNOWN
+        outcome = self._attempt(item_id, payload, key)
         if outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
             caps = self.provider.capabilities
             if caps.reconcile_capable:
@@ -60,13 +68,12 @@ class DeliveryCore:
                 if resolved is not None:
                     outcome = resolved.outcome
             elif caps.idempotent_send:
-                try:
-                    retry = self.provider.deliver(item_id, payload, key)
-                    outcome = retry.outcome
-                except Exception:
-                    outcome = DeliveryOutcome.OUTCOME_UNKNOWN
+                outcome = self._attempt(item_id, payload, key)
         self.backend.complete(token, outcome)
-        return outcome
+        if (outcome is DeliveryOutcome.NOT_DELIVERED
+                and self.backend.attempts(item_id) >= self.policy.max_attempts):
+            self.backend.park(item_id, "max-attempts")
+        return DrainResult(status=DrainStatus.ATTEMPTED, outcome=outcome)
 
     def recover(self) -> RecoverReport:
         return self.backend.recover()

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/fsutil.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/fsutil.py
@@ -1,0 +1,34 @@
+"""Shared filesystem primitives for the delivery core.
+
+create_exclusive exists because the check-then-act-on-a-create-if-absent
+destination class was found twice in one day (2026-08-17) in independent
+codebases: Design B's recover re-arm (CE-4) and #3011's quarantine writer
+(exists-then-rename). Any site that must create a file ONLY if absent uses
+this primitive instead of re-deriving the pattern — the copy nobody
+remembers is the one that ships the bug.
+
+Contract: atomic on POSIX same-fs; exactly one of N racing creators wins;
+the loser's bytes are never visible at the destination, not even
+transiently; the destination is never truncated or overwritten.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def create_exclusive(path: Path, data: bytes) -> bool:
+    """Write `data` to `path` only if `path` does not exist. True = this
+    caller created it; False = it already existed (loser: no side effect
+    at the destination). Temp is written beside the destination (same fs)
+    and linked in — link(2) refuses to clobber, which IS the exclusivity."""
+    path = Path(path)
+    tmp = path.with_name(f".{path.name}.cx{os.getpid()}.{id(data) & 0xffff}")
+    tmp.write_bytes(data)
+    try:
+        os.link(tmp, path)
+        return True
+    except FileExistsError:
+        return False
+    finally:
+        tmp.unlink(missing_ok=True)

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/fsutil.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/fsutil.py
@@ -14,6 +14,7 @@ transiently; the destination is never truncated or overwritten.
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 
@@ -23,12 +24,18 @@ def create_exclusive(path: Path, data: bytes) -> bool:
     at the destination). Temp is written beside the destination (same fs)
     and linked in — link(2) refuses to clobber, which IS the exclusivity."""
     path = Path(path)
-    tmp = path.with_name(f".{path.name}.cx{os.getpid()}.{id(data) & 0xffff}")
-    tmp.write_bytes(data)
+    # mkstemp: O_EXCL under an unpredictable name. A derived name collides
+    # in-process and the loser writes through the winner's inode.
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent),
+                                    prefix=f".{path.name}.cx")
+    tmp = Path(tmp_name)
     try:
-        os.link(tmp, path)
-        return True
-    except FileExistsError:
-        return False
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+        try:
+            os.link(tmp, path)
+            return True
+        except FileExistsError:
+            return False
     finally:
         tmp.unlink(missing_ok=True)

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/migration.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/migration.py
@@ -1,0 +1,69 @@
+"""Migration fencing: single-protocol-per-epoch (seam doc §4).
+
+One logical item is interpreted by exactly ONE claim protocol within an
+epoch. Migration = lock out drainers -> one-shot convert (each item
+individually atomic) -> write the version fence -> start only the new
+drainer. The fence is written LAST: a crash anywhere mid-conversion leaves
+the fence at the old epoch, so the old protocol stays authoritative and no
+item is ever interpreted by both protocols.
+
+Legacy delivered-sentinels map conservatively: a sentinel written after the
+provider call returned is evidence, not proof (the crash window between
+API-return and sentinel-write means its absence proves nothing and its
+presence only witnesses the call returned). Only a durable provider receipt
+reference upgrades to CONFIRMED; anything else converts to OUTCOME_UNKNOWN
+for park/reconcile — never CONFIRMED (seam doc §4, Discord's sentinel).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from .contract import DeliveryOutcome
+
+EPOCH_FILE = "protocol-epoch"
+DEFAULT_EPOCH = "A"
+
+
+def read_epoch(root: Path) -> str:
+    try:
+        return (Path(root) / EPOCH_FILE).read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return DEFAULT_EPOCH
+
+
+def write_fence(root: Path, epoch: str) -> None:
+    p = Path(root) / EPOCH_FILE
+    tmp = p.with_name(p.name + ".tmp")
+    tmp.write_text(epoch, encoding="utf-8")
+    os.replace(tmp, p)
+
+
+def classify_legacy_sentinel(
+        receipt_ref: Optional[str]) -> DeliveryOutcome:
+    """Sentinel-mapping table (normative). receipt_ref is the provider's
+    durable receipt reference when the legacy record carries one; a bare
+    sentinel (written after the call, no receipt) is OUTCOME_UNKNOWN."""
+    if receipt_ref:
+        return DeliveryOutcome.CONFIRMED
+    return DeliveryOutcome.OUTCOME_UNKNOWN
+
+
+def convert_epoch(root: Path, items: Iterable[str],
+                  convert_one: Callable[[str], None], target_epoch: str,
+                  crash_after: Optional[int] = None) -> int:
+    """One-shot conversion pass. convert_one(item) must be per-item atomic
+    (write-temp + rename); this function sequences items and writes the
+    fence only after ALL converted. crash_after=N simulates a crash before
+    the (N+1)th item for the fault-injection suite: the fence must then
+    still read the OLD epoch and every item be converted or untouched,
+    never both-visible."""
+    done = 0
+    for item in items:
+        if crash_after is not None and done >= crash_after:
+            raise RuntimeError("simulated crash mid-conversion")
+        convert_one(item)
+        done += 1
+    write_fence(root, target_epoch)
+    return done

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/migration.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/migration.py
@@ -50,15 +50,42 @@ def classify_legacy_sentinel(
     return DeliveryOutcome.OUTCOME_UNKNOWN
 
 
+def convert_item_atomic(path: Path, render: Callable[[bytes], bytes],
+                        is_converted: Callable[[bytes], bool],
+                        fault: Optional[Callable[[str], None]] = None) -> bool:
+    """The per-item conversion primitive: read -> write temp -> ONE
+    os.replace over the SAME path. There is no unlink step and no second
+    visible name, so no crash point can leave old and new both visible.
+    Idempotent: an already-converted item is left untouched (False), which
+    is what lets a restarted migrator resume mid-pass. `fault` is the
+    fault-injection hook — called before each internal mutation with a
+    step label; tests raise from it to crash INSIDE the item."""
+    data = path.read_bytes()
+    if is_converted(data):
+        return False
+    tmp = path.with_name(path.name + ".tmp")
+    if fault:
+        fault("pre-write-tmp")
+    tmp.write_bytes(render(data))
+    if fault:
+        fault("pre-replace")
+    os.replace(tmp, path)
+    if fault:
+        fault("post-replace")
+    return True
+
+
 def convert_epoch(root: Path, items: Iterable[str],
                   convert_one: Callable[[str], None], target_epoch: str,
                   crash_after: Optional[int] = None) -> int:
     """One-shot conversion pass. convert_one(item) must be per-item atomic
-    (write-temp + rename); this function sequences items and writes the
-    fence only after ALL converted. crash_after=N simulates a crash before
-    the (N+1)th item for the fault-injection suite: the fence must then
-    still read the OLD epoch and every item be converted or untouched,
-    never both-visible."""
+    over a single path (use convert_item_atomic — one os.replace, no
+    unlink, no second visible name) and idempotent, so a restarted pass
+    resumes over the same item list and completes BEFORE any drainer
+    starts: the fence is written only after ALL items converted, and until
+    then read_epoch still names the old protocol. crash_after=N simulates
+    a crash before the (N+1)th item; intra-item crash points are the
+    convert_item_atomic fault hook."""
     done = 0
     for item in items:
         if crash_after is not None and done >= crash_after:

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -22,7 +22,7 @@ if str(_PKG) not in sys.path:
     sys.path.insert(0, str(_PKG))
 
 from ag2_sparrow.delivery_core import (  # noqa: E402
-    BackendCapabilities, DeliveryCore, DeliveryOutcome, DeliveryReceipt,
+    BackendCapabilities, ClaimToken, DeliveryCore, DeliveryOutcome, DeliveryReceipt,
     DesignAClaimBackend, DrainStatus, ProviderCapabilities,
     ProviderIndeterminate, ProviderRefused, RetryPolicy, idempotency_key)
 
@@ -117,6 +117,21 @@ class ContractCase(unittest.TestCase):
         self.assertTrue(
             self.backend.complete(successor, DeliveryOutcome.CONFIRMED),
             "the live incarnation still owns the claim")
+
+    def test_a_foreign_item_is_never_retired(self):
+        """Retirement authority belongs to the dispatching consumer: a
+        backend must not complete an item it never issued a token for.
+        results/ is shared, so filename shape is not ownership (#3018)."""
+        self.backend.publish(ITEM, b"x")
+        foreign = ClaimToken(item_id=ITEM, worker="another-consumer",
+                             incarnation="another-consumer:1:1:1")
+        self.assertFalse(self.backend.complete(foreign,
+                                               DeliveryOutcome.CONFIRMED),
+                         "a token this backend never issued retired the item")
+        import ag2_sparrow.outbox as outbox
+        self.assertNotEqual(
+            outbox._read_item(self.backend.root, ITEM).get("status"),
+            "DELIVERED", "a foreign token marked the item delivered")
 
     def test_force_release_is_capability_gated(self):
         caps = self.backend.capabilities

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -23,7 +23,8 @@ if str(_PKG) not in sys.path:
 
 from ag2_sparrow.delivery_core import (  # noqa: E402
     BackendCapabilities, DeliveryCore, DeliveryOutcome, DeliveryReceipt,
-    DesignAClaimBackend, ProviderCapabilities, idempotency_key)
+    DesignAClaimBackend, DrainStatus, ProviderCapabilities,
+    ProviderIndeterminate, ProviderRefused, RetryPolicy, idempotency_key)
 
 ITEM = "room-evt-1"
 
@@ -92,6 +93,31 @@ class ContractCase(unittest.TestCase):
         t = self.backend.claim(ITEM, "w1")
         self.assertTrue(self.backend.complete(t, DeliveryOutcome.CONFIRMED))
 
+    def test_stale_incarnation_completes_nothing(self):
+        """Owner review finding 1+2: a token that outlived its claim must
+        change NOTHING. Validating after mutating lets a dead incarnation
+        park or advance its successor's item."""
+        self.backend.publish(ITEM, b"x")
+        stale = self.backend.claim(ITEM, "w1")
+        self.backend.force_release(ITEM)          # w1's claim is gone
+        successor = self.backend.claim(ITEM, "w2")
+        self.assertIsNotNone(successor)
+        self.assertNotEqual(stale.incarnation, successor.incarnation,
+                            "incarnation must not be reproducible by name")
+        import ag2_sparrow.outbox as outbox
+        before = outbox._read_item(self.backend.root, ITEM).get("status")
+        self.assertFalse(
+            self.backend.complete(stale, DeliveryOutcome.OUTCOME_UNKNOWN),
+            "stale token must not complete")
+        # The transition each outcome performs is the observable, not the
+        # return value: parking is what a stale UNKNOWN would inflict.
+        self.assertEqual(
+            outbox._read_item(self.backend.root, ITEM).get("status"), before,
+            "stale token parked the successor's item")
+        self.assertTrue(
+            self.backend.complete(successor, DeliveryOutcome.CONFIRMED),
+            "the live incarnation still owns the claim")
+
     def test_force_release_is_capability_gated(self):
         caps = self.backend.capabilities
         if caps.supports_force_release:
@@ -121,32 +147,72 @@ class CorePolicy(unittest.TestCase):
 
     def test_confirmed_is_terminal(self):
         p = _Recorder([DeliveryOutcome.CONFIRMED])
-        out = self._core(p).deliver_one(ITEM, b"x")
-        self.assertIs(out, DeliveryOutcome.CONFIRMED)
+        r = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(r.outcome, DeliveryOutcome.CONFIRMED)
+        self.assertIs(r.status, DrainStatus.ATTEMPTED)
         self.assertEqual(len(p.deliver_calls), 1)
 
     def test_unknown_parks_without_capabilities(self):
-        p = _Recorder([RuntimeError("wire died")])
-        out = self._core(p).deliver_one(ITEM, b"x")
-        self.assertIs(out, DeliveryOutcome.OUTCOME_UNKNOWN,
+        p = _Recorder([ProviderIndeterminate("timeout after send")])
+        r = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(r.outcome, DeliveryOutcome.OUTCOME_UNKNOWN,
                       "UNKNOWN must never be relabeled NOT_DELIVERED")
         self.assertEqual(len(p.deliver_calls), 1, "no blind resend")
 
     def test_unknown_reconciles_when_capable(self):
-        p = _Recorder([RuntimeError("wire died")],
+        p = _Recorder([ProviderIndeterminate("timeout after send")],
                       ProviderCapabilities(reconcile_capable=True))
-        out = self._core(p).deliver_one(ITEM, b"x")
-        self.assertIs(out, DeliveryOutcome.CONFIRMED)
+        r = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(r.outcome, DeliveryOutcome.CONFIRMED)
         self.assertEqual(len(p.reconcile_calls), 1)
 
     def test_unknown_resends_only_with_idempotent_send(self):
-        p = _Recorder([RuntimeError("wire died"), DeliveryOutcome.CONFIRMED],
+        p = _Recorder([ProviderIndeterminate("timeout after send"),
+                       DeliveryOutcome.CONFIRMED],
                       ProviderCapabilities(idempotent_send=True))
-        out = self._core(p).deliver_one(ITEM, b"x")
-        self.assertIs(out, DeliveryOutcome.CONFIRMED)
+        r = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(r.outcome, DeliveryOutcome.CONFIRMED)
         self.assertEqual(len(p.deliver_calls), 2)
         self.assertEqual(p.deliver_calls[0][1], p.deliver_calls[1][1],
                          "retry must reuse the SAME idempotency key")
+
+    def test_lost_race_is_not_a_delivery_outcome(self):
+        """Owner review finding 3: no provider call was made, so nothing
+        external is ambiguous — reporting UNKNOWN pollutes telemetry and
+        recovery policy."""
+        self.backend.claim(ITEM, "someone-else")   # item already owned
+        p = _Recorder([])
+        r = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(r.status, DrainStatus.NOT_CLAIMED)
+        self.assertIsNone(r.outcome, "a lost race has no delivery outcome")
+        self.assertEqual(p.deliver_calls, [], "provider must not be called")
+
+    def test_refusal_is_not_delivered_not_unknown(self):
+        """Owner review finding 5: only boundary-crossing failures are
+        UNKNOWN. A refusal before dispatch is a definite non-delivery."""
+        p = _Recorder([ProviderRefused("rejected before dispatch")])
+        r = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(r.outcome, DeliveryOutcome.NOT_DELIVERED)
+
+    def test_programming_error_propagates(self):
+        """Owner review finding 5, the other half: a bare Exception is a
+        bug or a config error, not evidence the side effect may have run.
+        Swallowing it as UNKNOWN parks the item and hides the defect."""
+        p = _Recorder([TypeError("payload is not bytes")])
+        with self.assertRaises(TypeError):
+            self._core(p).deliver_one(ITEM, b"x")
+
+    def test_retry_policy_parks_at_the_ceiling(self):
+        """Owner review finding 4: RetryPolicy was declared but unread."""
+        core = DeliveryCore(self.backend, _Recorder([]),
+                            RetryPolicy(max_attempts=2))
+        for _ in range(2):
+            core.provider = _Recorder([DeliveryOutcome.NOT_DELIVERED])
+            core.deliver_one(ITEM, b"x")
+        import ag2_sparrow.outbox as outbox
+        self.assertEqual(
+            outbox._read_item(self.backend.root, ITEM).get("status"), "PARKED",
+            "at max_attempts the core must park, not retry forever")
 
     def test_key_never_contains_claim_material(self):
         self.assertEqual(idempotency_key(ITEM), idempotency_key(ITEM),

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -214,6 +214,72 @@ class CorePolicy(unittest.TestCase):
             outbox._read_item(self.backend.root, ITEM).get("status"), "PARKED",
             "at max_attempts the core must park, not retry forever")
 
+    def _second_drain_calls(self, first_outcome, policy=None):
+        """Drive once to `first_outcome`, then again; return the SECOND
+        drain's provider-call count. Terminal states must make it zero."""
+        core = DeliveryCore(self.backend, _Recorder([first_outcome]),
+                            policy or RetryPolicy())
+        core.deliver_one(ITEM, b"x")
+        second = _Recorder([DeliveryOutcome.CONFIRMED])
+        core.provider = second
+        core.deliver_one(ITEM, b"x")
+        return len(second.deliver_calls)
+
+    def test_delivered_item_is_not_delivered_again(self):
+        self.assertEqual(self._second_drain_calls(DeliveryOutcome.CONFIRMED), 0,
+                         "a DELIVERED item was delivered twice")
+
+    def test_parked_unknown_is_not_redriven(self):
+        p = _Recorder([ProviderIndeterminate("timeout after send")])
+        core = DeliveryCore(self.backend, p)
+        core.deliver_one(ITEM, b"x")
+        second = _Recorder([DeliveryOutcome.CONFIRMED])
+        core.provider = second
+        core.deliver_one(ITEM, b"x")
+        self.assertEqual(len(second.deliver_calls), 0,
+                         "an OUTCOME_UNKNOWN item parked for reconcile was "
+                         "immediately re-driven")
+
+    def test_item_parked_at_the_ceiling_is_not_attempted_again(self):
+        self.assertEqual(
+            self._second_drain_calls(DeliveryOutcome.NOT_DELIVERED,
+                                     RetryPolicy(max_attempts=1)), 0,
+            "an item parked at the retry ceiling was attempted again")
+
+    def test_stale_claimant_cannot_adopt_a_successors_incarnation(self):
+        """Acquisition and capture must be one critical section, or A
+        returns a token carrying B's incarnation."""
+        import ag2_sparrow.outbox as outbox
+        self.backend.publish(ITEM, b"x")
+        # Interleave a successor between acquisition and capture; one
+        # critical section makes this impossible.
+        real_incarnation_of = self.backend._incarnation_of
+        fired = []
+
+        def interleave(item_id):
+            if not fired:
+                fired.append(True)
+                try:
+                    # Blocked under the fix: the lock is still held.
+                    self.backend.force_release(item_id)
+                    self.backend.claim(item_id, "B")
+                except Exception:
+                    pass
+            return real_incarnation_of(item_id)
+
+        self.backend._incarnation_of = interleave
+        try:
+            a = self.backend.claim(ITEM, "A")
+        finally:
+            self.backend._incarnation_of = real_incarnation_of
+        self.assertTrue(fired, "the interleave never ran — test is vacuous")
+        if a is not None:
+            # Discriminator: a token must name its own worker's
+            # incarnation; the racy structure gives A the successor's.
+            self.assertTrue(a.incarnation.startswith(f"{a.worker}:"),
+                            f"claim returned a token for {a.worker!r} carrying "
+                            f"another incarnation: {a.incarnation!r}")
+
     def test_key_never_contains_claim_material(self):
         self.assertEqual(idempotency_key(ITEM), idempotency_key(ITEM),
                          "stable across calls")

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Delivery Core contract suite — backend-agnostic: every registered
+ClaimBackend fixture runs the SAME tests (acceptance criterion 1). A is
+wired; B and Discord-legacy join via their adapters (Phases 3/4) by adding
+a fixture to BACKENDS, changing no test.
+
+Enforcement-suite slots (001, same PR): cross-incarnation key-identity
+machine op; static no-claim-material-in-key scan; lease/local seam oracle;
+fence fault tests.
+
+Run: python3 tests/delivery-core-contract.test.py"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_PKG = _REPO / "packages" / "ag2-sparrow"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from ag2_sparrow.delivery_core import (  # noqa: E402
+    BackendCapabilities, DeliveryCore, DeliveryOutcome, DeliveryReceipt,
+    DesignAClaimBackend, ProviderCapabilities, idempotency_key)
+
+ITEM = "room-evt-1"
+
+
+def _a_backend(tmp: Path):
+    return DesignAClaimBackend(tmp)
+
+
+BACKENDS = {
+    "A": _a_backend,
+    # "B": Phase-4 plug-in (exp/design-b-eval driver shape)
+    # "discord-legacy": Phase-3 adapter over rename claim + sentinels
+}
+
+
+class _Recorder:
+    """Provider double: scripted receipts, recorded calls."""
+
+    def __init__(self, outcomes, caps=ProviderCapabilities()):
+        self.outcomes = list(outcomes)
+        self.capabilities = caps
+        self.deliver_calls = []
+        self.reconcile_calls = []
+
+    def deliver(self, item_id, payload, idempotency_key):
+        self.deliver_calls.append((item_id, idempotency_key))
+        out = self.outcomes.pop(0)
+        if isinstance(out, Exception):
+            raise out
+        return DeliveryReceipt(outcome=out)
+
+    def reconcile(self, item_id, idempotency_key):
+        self.reconcile_calls.append((item_id, idempotency_key))
+        return DeliveryReceipt(outcome=DeliveryOutcome.CONFIRMED,
+                               provider_ref="r-1")
+
+
+class ContractCase(unittest.TestCase):
+    """Runs once per BACKENDS entry (see load_tests)."""
+    backend_name = "A"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="delivery-core-")
+        self.backend = BACKENDS[self.backend_name](Path(self.tmp.name))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_capabilities_are_declared_not_sniffed(self):
+        self.assertIsInstance(self.backend.capabilities, BackendCapabilities)
+
+    def test_single_owner(self):
+        self.backend.publish(ITEM, b"x")
+        t1 = self.backend.claim(ITEM, "w1")
+        self.assertIsNotNone(t1)
+        self.assertIsNone(self.backend.claim(ITEM, "w2"),
+                          "second live claim must lose")
+
+    def test_publish_refuses_live_id(self):
+        self.assertTrue(self.backend.publish(ITEM, b"x"))
+        self.assertFalse(self.backend.publish(ITEM, b"x"),
+                         "same-id publish while live must refuse (CE-1 class)")
+
+    def test_complete_retires_ownership(self):
+        self.backend.publish(ITEM, b"x")
+        t = self.backend.claim(ITEM, "w1")
+        self.assertTrue(self.backend.complete(t, DeliveryOutcome.CONFIRMED))
+
+    def test_force_release_is_capability_gated(self):
+        caps = self.backend.capabilities
+        if caps.supports_force_release:
+            self.backend.publish(ITEM, b"x")
+            self.backend.claim(ITEM, "w1")
+            self.assertTrue(self.backend.force_release(ITEM))
+        else:
+            with self.assertRaises(NotImplementedError,
+                                   msg="non-declaring backend must raise, "
+                                       "never silently no-op"):
+                self.backend.force_release(ITEM)
+
+
+class CorePolicy(unittest.TestCase):
+    """DeliveryCore outcome policy — backend-independent (criterion 2)."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="delivery-core-")
+        self.backend = DesignAClaimBackend(Path(self.tmp.name))
+        self.backend.publish(ITEM, b"x")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _core(self, provider):
+        return DeliveryCore(self.backend, provider)
+
+    def test_confirmed_is_terminal(self):
+        p = _Recorder([DeliveryOutcome.CONFIRMED])
+        out = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(out, DeliveryOutcome.CONFIRMED)
+        self.assertEqual(len(p.deliver_calls), 1)
+
+    def test_unknown_parks_without_capabilities(self):
+        p = _Recorder([RuntimeError("wire died")])
+        out = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(out, DeliveryOutcome.OUTCOME_UNKNOWN,
+                      "UNKNOWN must never be relabeled NOT_DELIVERED")
+        self.assertEqual(len(p.deliver_calls), 1, "no blind resend")
+
+    def test_unknown_reconciles_when_capable(self):
+        p = _Recorder([RuntimeError("wire died")],
+                      ProviderCapabilities(reconcile_capable=True))
+        out = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(out, DeliveryOutcome.CONFIRMED)
+        self.assertEqual(len(p.reconcile_calls), 1)
+
+    def test_unknown_resends_only_with_idempotent_send(self):
+        p = _Recorder([RuntimeError("wire died"), DeliveryOutcome.CONFIRMED],
+                      ProviderCapabilities(idempotent_send=True))
+        out = self._core(p).deliver_one(ITEM, b"x")
+        self.assertIs(out, DeliveryOutcome.CONFIRMED)
+        self.assertEqual(len(p.deliver_calls), 2)
+        self.assertEqual(p.deliver_calls[0][1], p.deliver_calls[1][1],
+                         "retry must reuse the SAME idempotency key")
+
+    def test_key_never_contains_claim_material(self):
+        self.assertEqual(idempotency_key(ITEM), idempotency_key(ITEM),
+                         "stable across calls")
+        self.assertNotIn("delivery-core", idempotency_key(ITEM),
+                         "no worker identity in the key")
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestSuite()
+    for name in BACKENDS:
+        case = type(f"ContractCase_{name}", (ContractCase,),
+                    {"backend_name": name})
+        suite.addTests(loader.loadTestsFromTestCase(case))
+    suite.addTests(loader.loadTestsFromTestCase(CorePolicy))
+    return suite
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -93,6 +93,41 @@ class ContractCase(unittest.TestCase):
         t = self.backend.claim(ITEM, "w1")
         self.assertTrue(self.backend.complete(t, DeliveryOutcome.CONFIRMED))
 
+    def test_incarnation_identifies_its_owner(self):
+        """The owner check in complete() reads as a second, independent
+        validation. It is not: this incarnation format embeds drainer_id,
+        so incarnation equality already implies owner equality, and
+        deleting the owner check leaves the suite green.
+
+        Pin the coupling rather than the check. If a future incarnation
+        stops naming its owner, this fails and says so — at which point
+        the owner check becomes load-bearing instead of redundant."""
+        self.backend.publish(ITEM, b"x")
+        t = self.backend.claim(ITEM, "w1")
+        self.assertIsNotNone(t)
+        self.assertIn("w1", t.incarnation,
+                      "incarnation no longer identifies its owner — the "
+                      "owner check in complete() is now the only thing "
+                      "separating two workers, so give it its own control")
+
+    def test_a_foreign_worker_cannot_complete_a_live_claim(self):
+        """Defense in depth for the branch above: a token naming another
+        worker must be refused even when its incarnation is current. Only
+        constructible by hand — claim() cannot emit an inconsistent token,
+        which is exactly why the branch needs a control of its own."""
+        import ag2_sparrow.outbox as outbox
+        self.backend.publish(ITEM, b"x")
+        live = self.backend.claim(ITEM, "w1")
+        forged = ClaimToken(item_id=live.item_id, worker="w2",
+                            incarnation=live.incarnation)
+        before = outbox._read_item(self.backend.root, ITEM).get("status")
+        self.assertFalse(self.backend.complete(forged, DeliveryOutcome.CONFIRMED),
+                         "a foreign worker completed another worker's claim")
+        self.assertEqual(outbox._read_item(self.backend.root, ITEM).get("status"),
+                         before, "a refused completion must change nothing")
+        self.assertTrue(self.backend.complete(live, DeliveryOutcome.CONFIRMED),
+                        "the real owner must still be able to complete")
+
     def test_stale_incarnation_completes_nothing(self):
         """Owner review finding 1+2: a token that outlived its claim must
         change NOTHING. Validating after mutating lets a dead incarnation

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -295,6 +295,39 @@ class CorePolicy(unittest.TestCase):
                             f"claim returned a token for {a.worker!r} carrying "
                             f"another incarnation: {a.incarnation!r}")
 
+    def test_successor_confirmation_survives_a_stale_ceiling_park(self):
+        """The ceiling transition must ride WITH the completion. Parked
+        after the claim is released, a successor can claim and CONFIRM in
+        the gap and the stale caller's park then overwrites DELIVERED —
+        losing delivery evidence and making a requeue duplicate the send."""
+        import ag2_sparrow.outbox as outbox
+        core = DeliveryCore(self.backend, _Recorder([DeliveryOutcome.NOT_DELIVERED]),
+                            RetryPolicy(max_attempts=1))
+        real_complete, fired, confirmed = self.backend.complete, [], []
+
+        def racing_complete(token, outcome, park_at_attempts=None):
+            ok = real_complete(token, outcome, park_at_attempts)
+            if not fired:                     # the gap: successor gets in
+                fired.append(True)
+                t2 = self.backend.claim(ITEM, "successor")
+                if t2 is not None:
+                    confirmed.append(real_complete(t2, DeliveryOutcome.CONFIRMED))
+            return ok
+
+        self.backend.complete = racing_complete
+        try:
+            core.deliver_one(ITEM, b"x")
+        finally:
+            self.backend.complete = real_complete
+        self.assertTrue(fired, "the interleave never ran — test is vacuous")
+        # Under the fix the ceiling park is atomic, so the successor cannot
+        # claim at all; the defect is a confirmation that is then ERASED.
+        if any(confirmed):
+            self.assertEqual(
+                outbox._read_item(self.backend.root, ITEM).get("status"),
+                "DELIVERED",
+                "a stale ceiling park overwrote the successor's confirmed delivery")
+
     def test_key_never_contains_claim_material(self):
         self.assertEqual(idempotency_key(ITEM), idempotency_key(ITEM),
                          "stable across calls")

--- a/tests/delivery-core-enforcement.test.py
+++ b/tests/delivery-core-enforcement.test.py
@@ -233,45 +233,91 @@ class FenceFaults(unittest.TestCase):
         self.assertIs(migration.classify_legacy_sentinel("rcpt-9"),
                       DeliveryOutcome.CONFIRMED)
 
-    def _convert_one(self, root):
+    OLD = json.dumps({"fmt": "legacy"}).encode()
+
+    @staticmethod
+    def _render(data):
+        return json.dumps({"fmt": "v2", "outcome":
+                           migration.classify_legacy_sentinel(None).value
+                           }).encode()
+
+    @staticmethod
+    def _is_converted(data):
+        return json.loads(data).get("fmt") == "v2"
+
+    def _convert_one(self, root, fault=None):
         def convert(item):
-            src = root / f"{item}.old"
-            dst = root / f"{item}.new"
-            tmp = root / f"{item}.tmp"
-            tmp.write_text(json.dumps(
-                {"item": item,
-                 "outcome": migration.classify_legacy_sentinel(None).value}))
-            tmp.rename(dst)
-            src.unlink()
+            migration.convert_item_atomic(root / item, self._render,
+                                          self._is_converted, fault=fault)
         return convert
 
+    def _states(self, root, items):
+        out = {}
+        for it in items:
+            self.assertFalse((root / (it + ".tmp")).exists() and
+                             self._is_converted(
+                                 (root / it).read_bytes()) is None,
+                             "impossible")
+            out[it] = "new" if self._is_converted(
+                (root / it).read_bytes()) else "old"
+        return out
+
     def test_crash_at_every_step_never_leaves_both_visible(self):
-        items = [f"it-{i}" for i in range(4)]
+        """Between-item AND intra-item crash points: at every one, each
+        item reads back as exactly old-format or new-format (one path, one
+        replace — a both-visible state has no filesystem representation)."""
+        items = [f"it-{i}" for i in range(3)]
+        intra = [None, "pre-write-tmp", "pre-replace", "post-replace"]
         for crash_after in range(len(items) + 1):
-            with tempfile.TemporaryDirectory(prefix="enf-fence-") as td:
-                root = Path(td)
-                for it in items:
-                    (root / f"{it}.old").write_text("{}")
-                try:
-                    migration.convert_epoch(root, items,
-                                            self._convert_one(root), "B",
-                                            crash_after=crash_after)
-                    crashed = False
-                except RuntimeError:
-                    crashed = True
-                self.assertEqual(crashed, crash_after < len(items))
-                for it in items:
-                    old = (root / f"{it}.old").exists()
-                    new = (root / f"{it}.new").exists()
-                    self.assertNotEqual(
-                        old, new, f"{it}: converted XOR untouched violated "
-                                  f"(old={old} new={new})")
-                epoch = migration.read_epoch(root)
-                if crashed:
-                    self.assertEqual(epoch, "A",
-                                     "fence must stay OLD after a crash")
-                else:
-                    self.assertEqual(epoch, "B")
+            for crash_step in intra:
+                with tempfile.TemporaryDirectory(prefix="enf-fence-") as td:
+                    root = Path(td)
+                    for it in items:
+                        (root / it).write_bytes(self.OLD)
+
+                    def fault(step, _cs=crash_step):
+                        if _cs is not None and step == _cs:
+                            raise RuntimeError(f"crash at {step}")
+                    try:
+                        migration.convert_epoch(
+                            root, items, self._convert_one(root, fault),
+                            "B", crash_after=crash_after)
+                        crashed = False
+                    except RuntimeError:
+                        crashed = True
+                    for it, state in self._states(root, items).items():
+                        self.assertIn(state, ("old", "new"),
+                                      f"{it} in mixed state")
+                    if crashed:
+                        self.assertEqual(migration.read_epoch(root), "A",
+                                         "fence must stay OLD after crash")
+                    else:
+                        self.assertEqual(migration.read_epoch(root), "B")
+
+    def test_restarted_migrator_completes_before_any_drainer(self):
+        """Crash mid-pass, then re-run the SAME conversion: idempotent
+        convert skips already-new items, finishes the stragglers, and only
+        then flips the fence — until that instant read_epoch names the old
+        protocol, so no new-epoch drainer may start and old-epoch items
+        were never half-interpreted."""
+        items = [f"it-{i}" for i in range(4)]
+        with tempfile.TemporaryDirectory(prefix="enf-fence-r-") as td:
+            root = Path(td)
+            for it in items:
+                (root / it).write_bytes(self.OLD)
+            with self.assertRaises(RuntimeError):
+                migration.convert_epoch(root, items,
+                                        self._convert_one(root), "B",
+                                        crash_after=2)
+            self.assertEqual(migration.read_epoch(root), "A")
+            states = self._states(root, items)
+            self.assertEqual(sorted(states.values()),
+                             ["new", "new", "old", "old"])
+            migration.convert_epoch(root, items, self._convert_one(root),
+                                    "B")
+            self.assertEqual(migration.read_epoch(root), "B")
+            self.assertEqual(set(self._states(root, items).values()),
+                             {"new"})
 
     def test_fence_write_is_atomic_and_last(self):
         with tempfile.TemporaryDirectory(prefix="enf-fence2-") as td:

--- a/tests/delivery-core-enforcement.test.py
+++ b/tests/delivery-core-enforcement.test.py
@@ -347,5 +347,44 @@ class FenceFaults(unittest.TestCase):
                              "no fence temp file may survive")
 
 
+class CreateExclusive(unittest.TestCase):
+    """Shared no-clobber primitive: the CE-4 / quarantine-writer class.
+    Two racing creators -> exactly one True; the loser's bytes are never
+    visible at the destination at any point."""
+
+    def test_single_winner_and_no_clobber(self):
+        from ag2_sparrow.delivery_core.fsutil import create_exclusive
+        with tempfile.TemporaryDirectory(prefix="enf-cx-") as td:
+            dst = Path(td) / "slot"
+            self.assertTrue(create_exclusive(dst, b"winner"))
+            self.assertFalse(create_exclusive(dst, b"loser"))
+            self.assertEqual(dst.read_bytes(), b"winner")
+            self.assertEqual([p.name for p in Path(td).iterdir()], ["slot"],
+                             "loser must leave no temp debris")
+
+    def test_falsifier_racing_creators_exactly_one_wins(self):
+        import threading
+        from ag2_sparrow.delivery_core.fsutil import create_exclusive
+        for _round in range(20):
+            with tempfile.TemporaryDirectory(prefix="enf-cx-r-") as td:
+                dst = Path(td) / "slot"
+                results = {}
+                gate = threading.Barrier(4)
+
+                def racer(name):
+                    gate.wait()
+                    results[name] = create_exclusive(dst, name.encode())
+                ts = [threading.Thread(target=racer, args=(f"w{i}",))
+                      for i in range(4)]
+                for t in ts:
+                    t.start()
+                for t in ts:
+                    t.join()
+                winners = [n for n, ok in results.items() if ok]
+                self.assertEqual(len(winners), 1, f"winners={winners}")
+                self.assertEqual(dst.read_bytes(), winners[0].encode(),
+                                 "destination must hold the winner's bytes")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/delivery-core-enforcement.test.py
+++ b/tests/delivery-core-enforcement.test.py
@@ -146,9 +146,8 @@ class StaticKeyScan(unittest.TestCase):
                 if isinstance(node, ast.Call) and \
                         isinstance(node.func, ast.Attribute) and \
                         node.func.attr in ("deliver", "reconcile"):
-                    # Keywords count: `deliver(idempotency_key=...)` has no
-                    # positional args, and skipping it exempted exactly the
-                    # call shape a refactor would produce.
+                    # Keywords count: a keyword-only call has no positional
+                    # args, and skipping it exempted that whole call shape.
                     kw = {k.arg: k.value for k in node.keywords if k.arg}
                     key_arg = kw.get("idempotency_key")
                     if key_arg is None and node.args:

--- a/tests/delivery-core-enforcement.test.py
+++ b/tests/delivery-core-enforcement.test.py
@@ -99,6 +99,9 @@ class KeyIdentityAcrossIncarnations(unittest.TestCase):
             DeliveryCore(backend, p1, worker="w1.1.1").deliver_one(ITEM, b"x")
             p2 = _KeyRecorder([DeliveryOutcome.CONFIRMED])
             DeliveryCore(backend, p2, worker="w2.2.2").deliver_one(ITEM, b"x")
+            self.assertTrue(p1.keys and p2.keys,
+                            "neither provider was called — the comparison "
+                            "below would pass on two empty lists")
             self.assertEqual(p1.keys, p2.keys,
                              "park -> re-drive changed the idempotency key")
 
@@ -143,9 +146,17 @@ class StaticKeyScan(unittest.TestCase):
                 if isinstance(node, ast.Call) and \
                         isinstance(node.func, ast.Attribute) and \
                         node.func.attr in ("deliver", "reconcile"):
-                    if len(node.args) < 2:
+                    # Keywords count: `deliver(idempotency_key=...)` has no
+                    # positional args, and skipping it exempted exactly the
+                    # call shape a refactor would produce.
+                    kw = {k.arg: k.value for k in node.keywords if k.arg}
+                    key_arg = kw.get("idempotency_key")
+                    if key_arg is None and node.args:
+                        key_arg = node.args[-1]
+                    if key_arg is None:
+                        # Unrecognised shape: fail closed, never `continue`.
+                        bad.append(f"{src.name}:{node.lineno} (no key arg found)")
                         continue
-                    key_arg = node.args[-1]
                     ok = (isinstance(key_arg, ast.Name)
                           and key_arg.id in derived) or \
                          (isinstance(key_arg, ast.Call)
@@ -251,15 +262,22 @@ class FenceFaults(unittest.TestCase):
                                           self._is_converted, fault=fault)
         return convert
 
-    def _states(self, root, items):
+    def _states(self, root, items, crashed=True):
+        """State per item, asserting the two properties that actually
+        distinguish an atomic replace from a copy: the item path holds one
+        INTACT format (never torn), and on a clean pass no second visible
+        name survives (os.replace consumes the temp; a copy does not)."""
         out = {}
         for it in items:
-            self.assertFalse((root / (it + ".tmp")).exists() and
-                             self._is_converted(
-                                 (root / it).read_bytes()) is None,
-                             "impossible")
-            out[it] = "new" if self._is_converted(
-                (root / it).read_bytes()) else "old"
+            raw = (root / it).read_bytes()
+            self.assertIn(raw, (self.OLD, self._render(self.OLD)),
+                          f"{it}: item path holds torn or foreign content")
+            if not crashed:
+                self.assertFalse(
+                    (root / (it + ".tmp")).exists(),
+                    f"{it}: a second visible name survived a completed "
+                    "conversion — the replace was not atomic")
+            out[it] = "new" if self._is_converted(raw) else "old"
         return out
 
     def test_crash_at_every_step_never_leaves_both_visible(self):
@@ -285,9 +303,10 @@ class FenceFaults(unittest.TestCase):
                         crashed = False
                     except RuntimeError:
                         crashed = True
-                    for it, state in self._states(root, items).items():
-                        self.assertIn(state, ("old", "new"),
-                                      f"{it} in mixed state")
+                    states = self._states(root, items, crashed=crashed)
+                    if not crashed:
+                        self.assertEqual(set(states.values()), {"new"},
+                                         "a completed pass converts every item")
                     if crashed:
                         self.assertEqual(migration.read_epoch(root), "A",
                                          "fence must stay OLD after crash")
@@ -310,13 +329,13 @@ class FenceFaults(unittest.TestCase):
                                         self._convert_one(root), "B",
                                         crash_after=2)
             self.assertEqual(migration.read_epoch(root), "A")
-            states = self._states(root, items)
+            states = self._states(root, items, crashed=True)
             self.assertEqual(sorted(states.values()),
                              ["new", "new", "old", "old"])
             migration.convert_epoch(root, items, self._convert_one(root),
                                     "B")
             self.assertEqual(migration.read_epoch(root), "B")
-            self.assertEqual(set(self._states(root, items).values()),
+            self.assertEqual(set(self._states(root, items, crashed=False).values()),
                              {"new"})
 
     def test_fence_write_is_atomic_and_last(self):

--- a/tests/delivery-core-enforcement.test.py
+++ b/tests/delivery-core-enforcement.test.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Delivery Core enforcement suite (001's four same-PR deliverables;
+seam doc v0.2.1 riders):
+
+1. Cross-incarnation key identity — recovery/re-claim must not mint a new
+   delivery idempotency key: the provider sees the SAME key from a second
+   incarnation (different worker/pid) as from the first.
+2. Static no-claim-material-in-key scan — AST over delivery_core: the
+   idempotency_key function may reference only item_id + resend_epoch, and
+   every provider.deliver call site passes a key derived from it.
+3. Lease/local seam oracle (invariant 9) — the four booleans lease-acked /
+   locally-claimed / provider-confirmed / server-finalized are independent
+   observables: the reference lease provider exports a finalize-observable
+   and CONFIRMED never implies finalized (nor vice versa), and while the
+   lease is held at most one local claim exists.
+4. Fence fault tests (§4) — legacy sentinel maps conservatively (bare
+   sentinel -> OUTCOME_UNKNOWN, never CONFIRMED); crash at every step of a
+   conversion leaves each item converted or untouched, never both-visible,
+   with the fence still naming the OLD epoch.
+
+Run: python3 tests/delivery-core-enforcement.test.py
+"""
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_PKG = _REPO / "packages" / "ag2-sparrow"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from ag2_sparrow.delivery_core import (  # noqa: E402
+    DeliveryCore, DeliveryOutcome, DeliveryReceipt, DesignAClaimBackend,
+    ProviderCapabilities, idempotency_key)
+from ag2_sparrow.delivery_core import migration  # noqa: E402
+
+ITEM = "room-evt-1"
+CORE_DIR = _PKG / "ag2_sparrow" / "delivery_core"
+
+
+class _KeyRecorder:
+    """Provider double that records every idempotency key it is handed."""
+
+    def __init__(self, outcomes, caps=ProviderCapabilities()):
+        self.outcomes = list(outcomes)
+        self.capabilities = caps
+        self.keys = []
+
+    def deliver(self, item_id, payload, idempotency_key):
+        self.keys.append(idempotency_key)
+        out = self.outcomes.pop(0)
+        if isinstance(out, Exception):
+            raise out
+        return DeliveryReceipt(outcome=out)
+
+    def reconcile(self, item_id, idempotency_key):
+        return None
+
+
+class KeyIdentityAcrossIncarnations(unittest.TestCase):
+    """Deliverable 1: the machine op — claim, die without completing, let a
+    second incarnation reclaim and deliver; the wire must see one key."""
+
+    def test_reclaim_reuses_the_same_key(self):
+        with tempfile.TemporaryDirectory(prefix="enf-key-") as td:
+            backend = DesignAClaimBackend(Path(td), reclaim_ttl_s=0.0)
+            backend.publish(ITEM, b"x")
+            # incarnation 1 claims in a child process and CRASHES (exits
+            # without complete()), leaving a claim whose owner pid is dead
+            code = (f"import sys; sys.path.insert(0, {str(_PKG)!r}); "
+                    f"from ag2_sparrow.delivery_core import "
+                    f"DesignAClaimBackend; from pathlib import Path; "
+                    f"b = DesignAClaimBackend(Path({td!r})); "
+                    f"t = b.claim({ITEM!r}, 'w1.111.b1'); "
+                    f"sys.exit(0 if t else 3)")
+            rc = subprocess.run([sys.executable, "-c", code]).returncode
+            self.assertEqual(rc, 0, "first incarnation must claim")
+            provider = _KeyRecorder([DeliveryOutcome.CONFIRMED])
+            core2 = DeliveryCore(backend, provider, worker="w2.222.b2")
+            out = core2.deliver_one(ITEM, b"x")
+            self.assertIs(out, DeliveryOutcome.CONFIRMED)
+            self.assertEqual(provider.keys, [idempotency_key(ITEM)],
+                             "second incarnation must reuse the item key")
+            for material in ("w1", "w2", "111", "222", "b1", "b2"):
+                self.assertNotIn(material, provider.keys[0],
+                                 "claim material leaked into the key")
+
+    def test_key_stable_across_park_and_redrive(self):
+        with tempfile.TemporaryDirectory(prefix="enf-key2-") as td:
+            backend = DesignAClaimBackend(Path(td), reclaim_ttl_s=0.0)
+            backend.publish(ITEM, b"x")
+            p1 = _KeyRecorder([RuntimeError("wire died")])
+            DeliveryCore(backend, p1, worker="w1.1.1").deliver_one(ITEM, b"x")
+            p2 = _KeyRecorder([DeliveryOutcome.CONFIRMED])
+            DeliveryCore(backend, p2, worker="w2.2.2").deliver_one(ITEM, b"x")
+            self.assertEqual(p1.keys, p2.keys,
+                             "park -> re-drive changed the idempotency key")
+
+
+class StaticKeyScan(unittest.TestCase):
+    """Deliverable 2: structural pin — no claim material can reach the key,
+    by construction, verified over the shipped source (not a copy)."""
+
+    FORBIDDEN = {"worker", "opaque", "pid", "token", "birth", "start_usec"}
+
+    def _fn(self, tree, name):
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                return node
+        return None
+
+    def test_key_fn_signature_and_body_are_claim_free(self):
+        tree = ast.parse((CORE_DIR / "core.py").read_text(encoding="utf-8"))
+        fn = self._fn(tree, "idempotency_key")
+        self.assertIsNotNone(fn, "idempotency_key must exist in core.py")
+        params = {a.arg for a in fn.args.args}
+        self.assertEqual(params, {"item_id", "resend_epoch"},
+                         "key derives from item identity + resend epoch ONLY")
+        names = {n.id for n in ast.walk(fn) if isinstance(n, ast.Name)}
+        attrs = {n.attr for n in ast.walk(fn) if isinstance(n, ast.Attribute)}
+        leaked = (names | attrs) & self.FORBIDDEN
+        self.assertFalse(leaked, f"claim material in key fn: {sorted(leaked)}")
+
+    def test_every_deliver_call_passes_a_derived_key(self):
+        derived = set()
+        bad = []
+        for src in CORE_DIR.glob("*.py"):
+            tree = ast.parse(src.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Assign) and \
+                        isinstance(node.value, ast.Call) and \
+                        isinstance(node.value.func, ast.Name) and \
+                        node.value.func.id == "idempotency_key":
+                    derived |= {t.id for t in node.targets
+                                if isinstance(t, ast.Name)}
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and \
+                        isinstance(node.func, ast.Attribute) and \
+                        node.func.attr in ("deliver", "reconcile"):
+                    if len(node.args) < 2:
+                        continue
+                    key_arg = node.args[-1]
+                    ok = (isinstance(key_arg, ast.Name)
+                          and key_arg.id in derived) or \
+                         (isinstance(key_arg, ast.Call)
+                          and isinstance(key_arg.func, ast.Name)
+                          and key_arg.func.id == "idempotency_key")
+                    if not ok:
+                        bad.append(f"{src.name}:{node.lineno}")
+        self.assertFalse(bad, f"deliver/reconcile call passes a key not "
+                              f"derived from idempotency_key(): {bad}")
+
+
+class _LeaseProvider:
+    """Reference AG2-Space-shaped provider: server lease + finalize as
+    INDEPENDENT observables (the invariant-9 shape Phase-2's real adapter
+    tests must export)."""
+
+    capabilities = ProviderCapabilities(reconcile_capable=True)
+
+    def __init__(self):
+        self.lease_held = False
+        self.provider_confirmed = False
+        self.server_finalized = False
+
+    def deliver(self, item_id, payload, idempotency_key):
+        self.provider_confirmed = True
+        return DeliveryReceipt(outcome=DeliveryOutcome.CONFIRMED,
+                               provider_ref="rcpt-1")
+
+    def reconcile(self, item_id, idempotency_key):
+        return DeliveryReceipt(
+            outcome=DeliveryOutcome.CONFIRMED if self.provider_confirmed
+            else DeliveryOutcome.NOT_DELIVERED, provider_ref="rcpt-1")
+
+    def finalize(self, item_id):
+        self.server_finalized = True
+
+
+class LeaseLocalSeamOracle(unittest.TestCase):
+    """Deliverable 3: four independent booleans; lease held -> at most one
+    local claim."""
+
+    def test_lease_held_admits_exactly_one_local_claim(self):
+        with tempfile.TemporaryDirectory(prefix="enf-lease-") as td:
+            backend = DesignAClaimBackend(Path(td))
+            provider = _LeaseProvider()
+            provider.lease_held = True
+            backend.publish(ITEM, b"x")
+            t1 = backend.claim(ITEM, "w1")
+            self.assertIsNotNone(t1)
+            self.assertIsNone(backend.claim(ITEM, "w2"),
+                              "two local claims under one server lease")
+            oracle = (provider.lease_held, t1 is not None,
+                      provider.provider_confirmed, provider.server_finalized)
+            self.assertEqual(oracle, (True, True, False, False),
+                             "claim alone must not move provider booleans")
+
+    def test_confirmed_and_finalized_are_independent(self):
+        with tempfile.TemporaryDirectory(prefix="enf-lease2-") as td:
+            backend = DesignAClaimBackend(Path(td))
+            provider = _LeaseProvider()
+            backend.publish(ITEM, b"x")
+            out = DeliveryCore(backend, provider).deliver_one(ITEM, b"x")
+            self.assertIs(out, DeliveryOutcome.CONFIRMED)
+            self.assertTrue(provider.provider_confirmed)
+            self.assertFalse(provider.server_finalized,
+                             "CONFIRMED must not imply server-finalized")
+            provider.finalize(ITEM)
+            self.assertTrue(provider.server_finalized)
+
+    def test_reference_provider_exports_finalize_observable(self):
+        p = _LeaseProvider()
+        self.assertTrue(hasattr(p, "finalize") and
+                        hasattr(p, "server_finalized"),
+                        "invariant-9 adapters must export finalize state")
+
+
+class FenceFaults(unittest.TestCase):
+    """Deliverable 4: sentinel mapping table + crash-at-every-step
+    conversion pass."""
+
+    def test_sentinel_mapping_is_conservative(self):
+        self.assertIs(migration.classify_legacy_sentinel(None),
+                      DeliveryOutcome.OUTCOME_UNKNOWN,
+                      "bare delivered-sentinel must NEVER map to CONFIRMED")
+        self.assertIs(migration.classify_legacy_sentinel("rcpt-9"),
+                      DeliveryOutcome.CONFIRMED)
+
+    def _convert_one(self, root):
+        def convert(item):
+            src = root / f"{item}.old"
+            dst = root / f"{item}.new"
+            tmp = root / f"{item}.tmp"
+            tmp.write_text(json.dumps(
+                {"item": item,
+                 "outcome": migration.classify_legacy_sentinel(None).value}))
+            tmp.rename(dst)
+            src.unlink()
+        return convert
+
+    def test_crash_at_every_step_never_leaves_both_visible(self):
+        items = [f"it-{i}" for i in range(4)]
+        for crash_after in range(len(items) + 1):
+            with tempfile.TemporaryDirectory(prefix="enf-fence-") as td:
+                root = Path(td)
+                for it in items:
+                    (root / f"{it}.old").write_text("{}")
+                try:
+                    migration.convert_epoch(root, items,
+                                            self._convert_one(root), "B",
+                                            crash_after=crash_after)
+                    crashed = False
+                except RuntimeError:
+                    crashed = True
+                self.assertEqual(crashed, crash_after < len(items))
+                for it in items:
+                    old = (root / f"{it}.old").exists()
+                    new = (root / f"{it}.new").exists()
+                    self.assertNotEqual(
+                        old, new, f"{it}: converted XOR untouched violated "
+                                  f"(old={old} new={new})")
+                epoch = migration.read_epoch(root)
+                if crashed:
+                    self.assertEqual(epoch, "A",
+                                     "fence must stay OLD after a crash")
+                else:
+                    self.assertEqual(epoch, "B")
+
+    def test_fence_write_is_atomic_and_last(self):
+        with tempfile.TemporaryDirectory(prefix="enf-fence2-") as td:
+            root = Path(td)
+            self.assertEqual(migration.read_epoch(root), "A")
+            migration.convert_epoch(root, [], lambda i: None, "B")
+            self.assertEqual(migration.read_epoch(root), "B")
+            self.assertFalse(list(root.glob("*.tmp")),
+                             "no fence temp file may survive")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/delivery-core-enforcement.test.py
+++ b/tests/delivery-core-enforcement.test.py
@@ -39,6 +39,7 @@ from ag2_sparrow.delivery_core import (  # noqa: E402
     DeliveryCore, DeliveryOutcome, DeliveryReceipt, DesignAClaimBackend,
     ProviderCapabilities, ProviderIndeterminate, idempotency_key)
 from ag2_sparrow.delivery_core import migration  # noqa: E402
+from ag2_sparrow import outbox  # noqa: E402
 
 ITEM = "room-evt-1"
 CORE_DIR = _PKG / "ag2_sparrow" / "delivery_core"
@@ -97,6 +98,13 @@ class KeyIdentityAcrossIncarnations(unittest.TestCase):
             backend.publish(ITEM, b"x")
             p1 = _KeyRecorder([ProviderIndeterminate("timeout after send")])
             DeliveryCore(backend, p1, worker="w1.1.1").deliver_one(ITEM, b"x")
+            # A parked item is not automatically re-drivable: requeue is
+            # an explicit act.
+            p_auto = _KeyRecorder([DeliveryOutcome.CONFIRMED])
+            DeliveryCore(backend, p_auto, worker="w2.2.2").deliver_one(ITEM, b"x")
+            self.assertEqual(p_auto.keys, [],
+                             "a PARKED item must not be claimed automatically")
+            outbox.requeue_item(Path(td), ITEM)
             p2 = _KeyRecorder([DeliveryOutcome.CONFIRMED])
             DeliveryCore(backend, p2, worker="w2.2.2").deliver_one(ITEM, b"x")
             self.assertTrue(p1.keys and p2.keys,
@@ -361,6 +369,33 @@ class CreateExclusive(unittest.TestCase):
             self.assertEqual(dst.read_bytes(), b"winner")
             self.assertEqual([p.name for p in Path(td).iterdir()], ["slot"],
                              "loser must leave no temp debris")
+
+    def test_same_bytes_object_callers_do_not_share_a_staging_inode(self):
+        """A staging name derived from (pid, id(data)) collides in-process,
+        letting the loser write through the winner's inode."""
+        from ag2_sparrow.delivery_core import fsutil
+        with tempfile.TemporaryDirectory(prefix="enf-cx3-") as td:
+            dst = Path(td) / "slot"
+            shared = b"AAAA"
+            # Observe the staging path: a thread race only sometimes hits
+            # the window, so racing and passing proves nothing.
+            staged, real_link = [], fsutil.os.link
+
+            def spy(src, dst_):
+                staged.append(str(src))
+                return real_link(src, dst_)
+
+            fsutil.os.link = spy
+            try:
+                fsutil.create_exclusive(dst, shared)
+                fsutil.create_exclusive(dst, shared)
+            finally:
+                fsutil.os.link = real_link
+            self.assertEqual(len(staged), 2, "both calls must stage")
+            self.assertNotEqual(staged[0], staged[1],
+                                "two callers shared one staging inode — the "
+                                "loser can write through the winner's file")
+            self.assertEqual(dst.read_bytes(), b"AAAA")
 
     def test_falsifier_racing_creators_exactly_one_wins(self):
         import threading

--- a/tests/delivery-core-enforcement.test.py
+++ b/tests/delivery-core-enforcement.test.py
@@ -37,7 +37,7 @@ if str(_PKG) not in sys.path:
 
 from ag2_sparrow.delivery_core import (  # noqa: E402
     DeliveryCore, DeliveryOutcome, DeliveryReceipt, DesignAClaimBackend,
-    ProviderCapabilities, idempotency_key)
+    ProviderCapabilities, ProviderIndeterminate, idempotency_key)
 from ag2_sparrow.delivery_core import migration  # noqa: E402
 
 ITEM = "room-evt-1"
@@ -84,7 +84,7 @@ class KeyIdentityAcrossIncarnations(unittest.TestCase):
             provider = _KeyRecorder([DeliveryOutcome.CONFIRMED])
             core2 = DeliveryCore(backend, provider, worker="w2.222.b2")
             out = core2.deliver_one(ITEM, b"x")
-            self.assertIs(out, DeliveryOutcome.CONFIRMED)
+            self.assertIs(out.outcome, DeliveryOutcome.CONFIRMED)
             self.assertEqual(provider.keys, [idempotency_key(ITEM)],
                              "second incarnation must reuse the item key")
             for material in ("w1", "w2", "111", "222", "b1", "b2"):
@@ -95,7 +95,7 @@ class KeyIdentityAcrossIncarnations(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="enf-key2-") as td:
             backend = DesignAClaimBackend(Path(td), reclaim_ttl_s=0.0)
             backend.publish(ITEM, b"x")
-            p1 = _KeyRecorder([RuntimeError("wire died")])
+            p1 = _KeyRecorder([ProviderIndeterminate("timeout after send")])
             DeliveryCore(backend, p1, worker="w1.1.1").deliver_one(ITEM, b"x")
             p2 = _KeyRecorder([DeliveryOutcome.CONFIRMED])
             DeliveryCore(backend, p2, worker="w2.2.2").deliver_one(ITEM, b"x")
@@ -208,7 +208,7 @@ class LeaseLocalSeamOracle(unittest.TestCase):
             provider = _LeaseProvider()
             backend.publish(ITEM, b"x")
             out = DeliveryCore(backend, provider).deliver_one(ITEM, b"x")
-            self.assertIs(out, DeliveryOutcome.CONFIRMED)
+            self.assertIs(out.outcome, DeliveryOutcome.CONFIRMED)
             self.assertTrue(provider.provider_confirmed)
             self.assertFalse(provider.server_finalized,
                              "CONFIRMED must not imply server-finalized")

--- a/tests/gateway-outbound-characterization.test.py
+++ b/tests/gateway-outbound-characterization.test.py
@@ -52,10 +52,8 @@ class _Base(unittest.TestCase):
         self.tmp.cleanup()
 
     def _result(self, body: str, tier: str = "owner") -> Path:
-        # The drain's guard resolves tier from the TASK file and fails closed
-        # to guest when it is absent — a result without provenance must never
-        # pass markers through. Owner provenance is therefore part of the
-        # fixture, not an accident of the pre-#2983 gateway.
+        # The drain resolves tier from the TASK file, failing closed to guest —
+        # so owner provenance must be explicit in the fixture, never an accident.
         (gw.TASKS_DIR / f"{TID}.txt").write_text(
             f"id: {TID}\ntask: characterization fixture\naccess_tier: {tier}\n")
         f = gw.RESULTS_DIR / f"{TID}.txt"

--- a/tests/gateway-outbound-characterization.test.py
+++ b/tests/gateway-outbound-characterization.test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Characterization of the gateway's CURRENT outbound drain — written
+BEFORE Phase 2 routes it through DeliveryCore, so "production behavior
+unchanged" (acceptance criterion 4) is a measurement rather than a claim.
+
+These tests assert what the shipped code does today, including behavior
+nobody would design on purpose. If Phase 2 changes any of it, that is a
+decision to make deliberately, not a diff to discover afterwards.
+
+Run: python3 tests/gateway-outbound-characterization.test.py
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_PKG = _REPO / "packages" / "ag2-sparrow"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from ag2_sparrow import remote_gateway_bridge as gw  # noqa: E402
+
+TID = "task-0000000000000000ch"
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="gw-char-")
+        root = Path(self.tmp.name)
+        self._saved = {n: getattr(gw, n) for n in (
+            "TASKS_DIR", "RESULTS_DIR", "ARCHIVE_RESULTS_DIR",
+            "UNDELIVERABLE_RESULTS_DIR", "_req", "_delivery_tid", "_log",
+            "_broker_tid")}
+        gw.TASKS_DIR = root / "tasks"
+        gw.RESULTS_DIR = root / "results"
+        gw.ARCHIVE_RESULTS_DIR = gw.RESULTS_DIR / "archive"
+        gw.UNDELIVERABLE_RESULTS_DIR = gw.RESULTS_DIR / "undelivered"
+        for d in (gw.TASKS_DIR, gw.RESULTS_DIR):
+            d.mkdir(parents=True)
+        self.posted = []
+        gw._req = lambda m, path, payload=None: self.posted.append((m, path, payload))
+        gw._delivery_tid = lambda tid: tid
+        gw._broker_tid = lambda tid: tid
+        gw._log = lambda m: None
+
+    def tearDown(self):
+        for n, v in self._saved.items():
+            setattr(gw, n, v)
+        self.tmp.cleanup()
+
+    def _result(self, body: str) -> Path:
+        f = gw.RESULTS_DIR / f"{TID}.txt"
+        f.write_text(body)
+        return f
+
+
+class DrainShape(_Base):
+    """What the drain does with an in-flight result today."""
+
+    def test_plain_result_posts_body_verbatim_and_archives(self):
+        self._result("the reply")
+        inflight = {TID}
+        gw._post_ready_results(inflight)
+        self.assertEqual(len(self.posted), 1)
+        method, path, payload = self.posted[0]
+        self.assertEqual((method, path), ("POST", "/v1/results"))
+        self.assertEqual(payload["body"], "the reply",
+                         "body is posted verbatim — no wrapper, no label")
+        self.assertNotIn(TID, inflight, "delivered tid leaves the ledger")
+        self.assertFalse((gw.RESULTS_DIR / f"{TID}.txt").exists(),
+                         "the result file is consumed, not left behind")
+
+    def test_result_not_in_ledger_is_never_read(self):
+        """The property that produced the orphan class: the drain iterates
+        the LEDGER, so a result whose tid is not tracked is invisible to
+        it — no scan of results/ happens here."""
+        self._result("the reply")
+        gw._post_ready_results(set())
+        self.assertEqual(self.posted, [])
+        self.assertTrue((gw.RESULTS_DIR / f"{TID}.txt").exists())
+
+    def test_absent_result_leaves_the_tid_in_flight(self):
+        inflight = {TID}
+        gw._post_ready_results(inflight)
+        self.assertEqual(self.posted, [])
+        self.assertIn(TID, inflight, "a missing result is retried, not dropped")
+
+    def test_unsafe_tid_is_discarded_without_reading_a_path(self):
+        inflight = {"../../etc/passwd"}
+        gw._post_ready_results(inflight)
+        self.assertEqual(self.posted, [])
+        self.assertEqual(inflight, set(), "unsafe tid is dropped from the ledger")
+
+
+class MarkerHandling(_Base):
+    """Marker semantics the core must preserve when it owns delivery."""
+
+    def test_skip_marker_body_still_reaches_the_server(self):
+        """[no-send] is posted VERBATIM: the server suppresses user-facing
+        delivery and still closes the lease. The core must not 'optimize'
+        this into a local-only completion."""
+        self._result("[no-send]\ninternal only")
+        gw._post_ready_results({TID})
+        self.assertEqual(len(self.posted), 1, "the lease still closes via POST")
+        self.assertIn("[no-send]", self.posted[0][2]["body"])
+
+    def test_redirect_marker_is_posted_intact(self):
+        self._result("[channel: C123ABC]\nthe reply")
+        gw._post_ready_results({TID})
+        self.assertIn("[channel: C123ABC]", self.posted[0][2]["body"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway-outbound-characterization.test.py
+++ b/tests/gateway-outbound-characterization.test.py
@@ -51,7 +51,13 @@ class _Base(unittest.TestCase):
             setattr(gw, n, v)
         self.tmp.cleanup()
 
-    def _result(self, body: str) -> Path:
+    def _result(self, body: str, tier: str = "owner") -> Path:
+        # The drain's guard resolves tier from the TASK file and fails closed
+        # to guest when it is absent — a result without provenance must never
+        # pass markers through. Owner provenance is therefore part of the
+        # fixture, not an accident of the pre-#2983 gateway.
+        (gw.TASKS_DIR / f"{TID}.txt").write_text(
+            f"id: {TID}\ntask: characterization fixture\naccess_tier: {tier}\n")
         f = gw.RESULTS_DIR / f"{TID}.txt"
         f.write_text(body)
         return f
@@ -112,6 +118,15 @@ class MarkerHandling(_Base):
         gw._post_ready_results({TID})
         self.assertIn("[channel: C123ABC]", self.posted[0][2]["body"])
 
+
+    def test_missing_task_provenance_withholds_markers(self):
+        """Absence is not owner provenance: with no task file the guard
+        resolves guest and marker bodies are withheld, not honoured."""
+        f = gw.RESULTS_DIR / f"{TID}.txt"
+        f.write_text("[channel: C123ABC]\nthe reply")
+        gw._post_ready_results({TID})
+        self.assertEqual(len(self.posted), 1)
+        self.assertNotIn("[channel: C123ABC]", self.posted[0][2]["body"])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Pins a channel-neutral **Delivery Core contract** in `ag2-sparrow`, so Discord and the gateway can share one outbound-delivery lifecycle instead of two drifting copies. Contract text only — **no production backend migration**, no call-site change, no disk-format change.

Three layers, per the ratified seam design:

| layer | file | owns |
|---|---|---|
| `ClaimBackend` | `delivery_core/contract.py` | local ownership: publish / claim / complete / recover / cleanup (+ capability-gated force-release) |
| `DeliveryProvider` | `delivery_core/contract.py` | the external side effect: deliver / reconcile, with declared capabilities |
| `DeliveryCore` | `delivery_core/core.py` | the drain loop — **the only reader of outcome semantics** |

`DesignAClaimBackend` wraps today's shipped `outbox.py` protocol, so A remains the default and nothing in production changes behavior.

Explicitly **not** in the core: room lifecycle, lease policy, rate-limit policy, channel routing, agent cognition.

## Why

`_write_task` and the orphan sweep reading one archive directory through two different filters (fixed in #3011) is the same class of defect the repo rule names: *when one defect exists in several places because the policy is duplicated, the duplication is the defect*. Delivery lifecycle is currently duplicated across the Discord bridge and the gateway bridge; this PR creates the shared owner the rule asks for, before any migration.

## Normative decisions pinned here

- **Three identity types, never conflated**: `item_id` (logical), `ClaimToken` (one ownership incarnation, opaque above the backend), and the delivery idempotency key (stable per logical side effect). The key is **never** derived from claim material — worker/pid/birth change across incarnations and would turn provider dedup into a fresh send.
- **Guarantee wording**: *effectively-once within the provider's idempotency and receipt-retention contract* — never unqualified "exactly-once".
- **Retry policy**: only confirmed `NOT_DELIVERED` auto-retries; `OUTCOME_UNKNOWN` parks unless the provider's **declared** capabilities license reconcile or safe-resend; ambiguous is never relabeled as failure.
- **`DeliveryReceipt`** carries the three-state outcome plus an optional provider reference — confirmed-by-provider is never inferred from accepted-by-transport.
- **Capabilities are declared, never sniffed.** A backend that does not declare `force_release` must raise, never silently no-op. What is optional is the *operation*, not the liveness guarantee it serves: "a dead owner's claim is eventually recoverable" is required of every backend.

## Tests — two suites, both green

`tests/delivery-core-contract.test.py` (10) is **backend-parameterized**: every registered fixture runs the same tests, so B and a Discord-legacy adapter join by adding a fixture, changing no test.

`tests/delivery-core-enforcement.test.py` (10) enforces the contract's sharp edges: cross-incarnation key identity (first incarnation dies mid-claim in a real subprocess; the second must present a byte-identical key), an AST scan over the shipped source proving the key derives only from `item_id` + resend epoch, the lease/local seam oracle (four booleans evolve independently), and epoch-fence fault injection where every item is converted XOR untouched at each crash point.

```
$ python3 tests/delivery-core-contract.test.py     → Ran 10 tests … OK
$ python3 tests/delivery-core-enforcement.test.py  → Ran 10 tests … OK
$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

**Mutation control** (a suite that cannot fail proves nothing): blinding the UNKNOWN policy in `core.py` — forcing a resend regardless of declared capabilities — turns 2 contract tests red (`test_unknown_parks_without_capabilities`, `test_unknown_reconciles_when_capable`) and green again on restore. The enforcement suite carries its own XOR and key-leak assertions.

## Next (not this PR)

Phase 2 routes the gateway adapter through `DeliveryCore` behind characterization tests; Phase 3 adds a Discord-legacy backend so both channels' fixtures run this suite; Phase 4 re-parameterizes the claim-machine over `ClaimBackend` and decides A vs B on evidence. Migration fencing (single-protocol-per-epoch, conservative sentinel mapping) is pinned in `delivery_core/migration.py` now so no migration can start without it.

Co-authored under the shared login: the contract skeleton is mine (`qingyun0327@gmail.com`), the enforcement suite is @sutando-qingyun-001's (`qingyun@ag2.ai`). Approval of one half is approval of both, by prior agreement.

— @qingyun-air.agent:ag2.space
