### PR TITLE
fix(coverage-gate): a suite failure could not say which environment it failed in

### DIFF
--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -130,6 +130,9 @@ if [ "${#fully_skipped[@]}" -gt 0 ]; then
     echo "coverage-gate: but a fully-skipped file is not a passing file. Verify that is intended."
 fi
 if [ "$failed" -ne 0 ]; then
+    # A suite that fails here but passes locally is usually an environment gap.
+    # /bin/bash is what the watcher suites spawn, so name it rather than $SHELL.
+    echo "coverage-gate: env — $(/bin/bash --version | head -1) · $(python3 -V 2>&1) · $(uname -sr)" >&2
     publish_summary "❌ **Test suite failed under instrumentation** — coverage not measurable. See the job log."
     echo "coverage-gate: suite must be green before coverage is meaningful." >&2
     exit 1


### PR DESCRIPTION
## What

When the Python suite fails under instrumentation, `coverage-gate.sh` prints the failing file and
its output and exits. It never says *which environment* it failed in. This adds one line to that
failure path: the `/bin/bash` version, the Python version, and `uname -sr`.

## Why now

This is not a speculative diagnostic. #2934 is a 14-comment investigation into a flake in
`tests/task-workstream-session-worker.test.py`, and its leading mechanism is **bash-version
specific** — the bash 5.2 CHANGES entry about parser state being corrupted when a trap is taken
while parsing a command substitution.

**No comment in that issue states the bash version the failure occurs on**, because nothing in the
job prints one. I tried to settle it from outside and could not: the runner-image release notes for
`20260810.271` do not list bash. I measured what I could — 100 trials clean on macOS `/bin/bash`
3.2.57 ([issuecomment-5314041553](https://github.com/sonichi/sutando/issues/2934#issuecomment-5314041553))
— but the version that actually matters is the runner's, and only the job can report it.

This also follows the file's own established reasoning. It already names skipped files so that
"a macOS-vs-Linux difference [is] visible in the log instead of requiring a local re-run to guess
at" (`:119-123`). Failures had no equivalent.

## Evidence

Real script, real failure branch, driven in a minimal repo whose one test fails. Same command,
same input, only the script version differs.

**BEFORE** (`origin/main`):

```
coverage-gate: running Python suite under instrumentation...
✖ test failed under instrumentation: tests/one.test.py
coverage-gate: suite must be green before coverage is meaningful.
```

**AFTER** (this branch):

```
coverage-gate: running Python suite under instrumentation...
✖ test failed under instrumentation: tests/one.test.py
coverage-gate: env — GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25) · Python 3.14.6 · Darwin 25.5.0
coverage-gate: suite must be green before coverage is meaningful.
```

On a runner that same line reports the runner's bash, which is the input #2934 is missing.

Behavior is otherwise unchanged — the gate still exits 1 on a failed suite:

```
BEFORE exit code: 1
AFTER  exit code: 1
```

`bash -n` clean. `shellcheck` reports two info-level findings, both pre-existing on `main`
(`:175`, `:185`) and neither on the added line.

## Scope

One line plus a two-line comment, on the failure path only. It cannot fire on a green run, so it
adds nothing to passing logs.

## Why `/bin/bash` and not `$SHELL`

The watcher suites spawn `/bin/bash` explicitly
(`tests/task-workstream-session-worker.test.py` → `["/bin/bash", ".../watch-tasks-stream.sh"]`),
so that is the interpreter whose version bears on the failure being investigated. `$SHELL` would
report something else.

@sonichi flagging you since this is mine — it is diagnostic-only, but it touches a required-check
script, so it should not land on my say-so.
