### PR TITLE
fix(task-bridge): only retire skip-marked results this bridge dispatched

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -125,6 +125,7 @@ One entry per agent-facing module.
 - **`session-handoff.sh`** — Session handoff — writes a summary for the next session to pick up.
 - **`single_instance.py`** — Single-instance guard for long-running bridge daemons.
 - **`skill_hooks.py`** — Discovery for skill-declared Claude Code hooks (`hooks` in a skill manifest).
+- **`skip_marker_ownership.ts`** — Who may retire a skip-marked result.
 - **`slack-bridge.py`** — Slack bridge for Sutando — receives DMs + @mentions via Socket Mode, writes to tasks/, sends replies from results/.
 - **`slack_owner.py`** — Slack owner-recipient resolution helpers.
 - **`slack_proactive_receipts.py`** — Durable idempotency receipts for Slack proactive-result delivery.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -125,7 +125,7 @@ One entry per agent-facing module.
 - **`session-handoff.sh`** — Session handoff — writes a summary for the next session to pick up.
 - **`single_instance.py`** — Single-instance guard for long-running bridge daemons.
 - **`skill_hooks.py`** — Discovery for skill-declared Claude Code hooks (`hooks` in a skill manifest).
-- **`skip_marker_ownership.ts`** — Skip markers separate TWO decisions that a single guard used to conflate.
+- **`skip_marker_ownership.ts`** — Suppression is universal; retirement authority is scoped to the consumer that dispatched the task.
 - **`slack-bridge.py`** — Slack bridge for Sutando — receives DMs + @mentions via Socket Mode, writes to tasks/, sends replies from results/.
 - **`slack_owner.py`** — Slack owner-recipient resolution helpers.
 - **`slack_proactive_receipts.py`** — Durable idempotency receipts for Slack proactive-result delivery.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -125,7 +125,7 @@ One entry per agent-facing module.
 - **`session-handoff.sh`** — Session handoff — writes a summary for the next session to pick up.
 - **`single_instance.py`** — Single-instance guard for long-running bridge daemons.
 - **`skill_hooks.py`** — Discovery for skill-declared Claude Code hooks (`hooks` in a skill manifest).
-- **`skip_marker_ownership.ts`** — Who may retire a skip-marked result.
+- **`skip_marker_ownership.ts`** — Skip markers separate TWO decisions that a single guard used to conflate.
 - **`slack-bridge.py`** — Slack bridge for Sutando — receives DMs + @mentions via Socket Mode, writes to tasks/, sends replies from results/.
 - **`slack_owner.py`** — Slack owner-recipient resolution helpers.
 - **`slack_proactive_receipts.py`** — Durable idempotency receipts for Slack proactive-result delivery.

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -1,7 +1,5 @@
-// Two decisions the result-watcher used to make with one predicate:
-// suppression (universal — a marked body must never be spoken or sent) and
-// retirement authority (scoped — only the consumer that dispatched a task may
-// archive its result). Narrowing one silently narrowed both.
+// Suppression is universal; retirement authority is scoped to the consumer
+// that dispatched the task. One predicate for both narrowed both.
 
 export const SKIP_MARKER_RE = /^\s*\[(?:no-send|REPLIED)\]/i;
 
@@ -35,9 +33,9 @@ export interface TaskOrigin {
 }
 
 export function hasNetworkConsumer(origin: TaskOrigin | null): boolean {
-	// Unreadable origin is treated as foreign. Wrongly retiring strands an
-	// owner reply; wrongly keeping only accumulates a file, and suppression
-	// is universal either way — so the unknown case fails toward keeping.
+	// Two nulls, opposite polarity. No task file = unknown, so keep (wrongly
+	// retiring strands a reply; wrongly keeping costs a file). A readable
+	// header with no `source:` is positive evidence of a local writer.
 	if (origin === null) return true;
 	if (origin.claimedElsewhere) return true;
 	if (origin.source === null) return false;

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -28,8 +28,13 @@ export function isSkipMarked(file: string, result: string): boolean {
  * here or its results accumulate forever.
  */
 export const LOCAL_ONLY_PREFIXES = [
-	'task-cron-', 'task-chat-',
-	'task-workstream-grouping-', 'task-project-grouping-',
+	// Machine-generated families, also enumerated by web-client.ts's
+	// isOwnerVisibleTask. That list answers "is this owner work to display";
+	// this one answers "will anything else archive it" — task-chat- is on
+	// this list and owner-VISIBLE there, so the two must not be collapsed.
+	'task-cron-', 'task-health-', 'task-smoke-', 'task-discord-e2e-',
+	// Locally originated, no network consumer.
+	'task-chat-', 'task-workstream-grouping-', 'task-project-grouping-',
 ];
 
 export function isLocalOnlyTask(taskId: string): boolean {

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -18,8 +18,30 @@ export function isSkipMarked(file: string, result: string): boolean {
 	return file.startsWith('task-') && SKIP_MARKER_RE.test(result);
 }
 
+/**
+ * Task families with no network consumer: nothing else will ever archive
+ * them, so this bridge is their archiver of last resort. Cron depends on
+ * it explicitly — codex-scheduler writes [no-send] "so this scheduled task
+ * is archived" — and discord-bridge's skip handling is already scoped to
+ * its own pending map, so scoping this one without the allowlist would
+ * leave them with no archiver at all. A NEW local family must be added
+ * here or its results accumulate forever.
+ */
+export const LOCAL_ONLY_PREFIXES = [
+	'task-cron-', 'task-chat-',
+	'task-workstream-grouping-', 'task-project-grouping-',
+];
+
+export function isLocalOnlyTask(taskId: string): boolean {
+	return LOCAL_ONLY_PREFIXES.some(p => taskId.startsWith(p));
+}
+
 /** Ownership-scoped: may THIS bridge archive it and retire its task row? */
 export function mayRetireSkipMarked(file: string, result: string,
 	isOwn: (taskId: string) => boolean): boolean {
-	return isSkipMarked(file, result) && isOwn(file.replace(/\.txt$/, ''));
+	if (!isSkipMarked(file, result)) return false;
+	const taskId = file.replace(/\.txt$/, '');
+	// The whole rule lives here so it is testable; the caller supplies only
+	// the dynamic signals (dispatched-by-me, is-a-voice-task).
+	return isLocalOnlyTask(taskId) || isOwn(taskId);
 }

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -13,8 +13,9 @@ export function isSkipMarked(file: string, result: string): boolean {
 // 1. Ledger membership — authoritative. A consumer that persists its in-flight
 //    set has already told us, as a fact about claiming, that the result is
 //    spoken for. It does not depend on any label.
-// 2. Source label — a residual net for bridges whose in-flight set is only
-//    in-memory, so nothing durable can be consulted for them.
+// 2. Source label — for bridges whose in-flight set is only in-memory, AND
+//    for any ledger the reader cannot reach. A miss reads as "no claim", not
+//    "cannot tell", so on that path the label is the whole decision.
 //
 // The label list is NOT a closed set and must not be read as one: the gateway
 // writes `source: {task.source or PROVIDER}` where PROVIDER comes from

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -1,11 +1,11 @@
 /**
- * Who may retire a skip-marked result.
+ * Skip markers separate TWO decisions that a single guard used to conflate.
  *
- * `results/` is shared by every consumer, so "task-* plus a marker" retires
- * results a bridge never dispatched: the gateway's bookkeeping `[no-send]`
- * gets archived by the voice bridge, its tid leaves the OWNING bridge's
- * in-flight ledger, and a substantive reply written to that path afterwards
- * is read by nobody. Ownership is the discriminator.
+ * Suppression is universal: a [no-send]/[REPLIED] body must never be
+ * narrated or delivered by anyone, whoever dispatched it. Retirement is
+ * ownership-scoped: results/ is shared, so only the dispatching consumer may
+ * archive. Gating both on one predicate makes a foreign marked result fall
+ * through and be SPOKEN — worse than the mis-archive it replaced.
  *
  * Dependency-light and standalone so it is testable without the bridge's
  * runtime deps (task-bridge.ts pulls the whole voice stack).
@@ -13,8 +13,13 @@
 
 export const SKIP_MARKER_RE = /^\s*\[(?:no-send|REPLIED)\]/i;
 
+/** Universal: this result must not be narrated, delivered, or forwarded. */
+export function isSkipMarked(file: string, result: string): boolean {
+	return file.startsWith('task-') && SKIP_MARKER_RE.test(result);
+}
+
+/** Ownership-scoped: may THIS bridge archive it and retire its task row? */
 export function mayRetireSkipMarked(file: string, result: string,
 	isOwn: (taskId: string) => boolean): boolean {
-	if (!file.startsWith('task-') || !SKIP_MARKER_RE.test(result)) return false;
-	return isOwn(file.replace(/\.txt$/, ''));
+	return isSkipMarked(file, result) && isOwn(file.replace(/\.txt$/, ''));
 }

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -1,52 +1,45 @@
-/**
- * Skip markers separate TWO decisions that a single guard used to conflate.
- *
- * Suppression is universal: a [no-send]/[REPLIED] body must never be
- * narrated or delivered by anyone, whoever dispatched it. Retirement is
- * ownership-scoped: results/ is shared, so only the dispatching consumer may
- * archive. Gating both on one predicate makes a foreign marked result fall
- * through and be SPOKEN — worse than the mis-archive it replaced.
- *
- * Dependency-light and standalone so it is testable without the bridge's
- * runtime deps (task-bridge.ts pulls the whole voice stack).
- */
+// Two decisions the result-watcher used to make with one predicate:
+// suppression (universal — a marked body must never be spoken or sent) and
+// retirement authority (scoped — only the consumer that dispatched a task may
+// archive its result). Narrowing one silently narrowed both.
 
 export const SKIP_MARKER_RE = /^\s*\[(?:no-send|REPLIED)\]/i;
 
-/** Universal: this result must not be narrated, delivered, or forwarded. */
 export function isSkipMarked(file: string, result: string): boolean {
 	return file.startsWith('task-') && SKIP_MARKER_RE.test(result);
 }
 
-/**
- * Task families with no network consumer: nothing else will ever archive
- * them, so this bridge is their archiver of last resort. Cron depends on
- * it explicitly — codex-scheduler writes [no-send] "so this scheduled task
- * is archived" — and discord-bridge's skip handling is already scoped to
- * its own pending map, so scoping this one without the allowlist would
- * leave them with no archiver at all. A NEW local family must be added
- * here or its results accumulate forever.
- */
-export const LOCAL_ONLY_PREFIXES = [
-	// Machine-generated families, also enumerated by web-client.ts's
-	// isOwnerVisibleTask. That list answers "is this owner work to display";
-	// this one answers "will anything else archive it" — task-chat- is on
-	// this list and owner-VISIBLE there, so the two must not be collapsed.
-	'task-cron-', 'task-health-', 'task-smoke-', 'task-discord-e2e-',
-	// Locally originated, no network consumer.
-	'task-chat-', 'task-workstream-grouping-', 'task-project-grouping-',
+// Sources whose own bridge polls results/ and archives what it dispatched.
+// Closed set: a transport is added here only when its bridge gains that loop.
+// The complement — every local source — is open-ended and host-dependent, so
+// enumerating IT cannot stay correct: measured on two hosts the same day, the
+// missing local families did not overlap at all.
+export const NETWORK_CONSUMER_SOURCES = [
+	'discord', 'ag2space', 'telegram', 'slack', 'whatsapp',
 ];
 
-export function isLocalOnlyTask(taskId: string): boolean {
-	return LOCAL_ONLY_PREFIXES.some(p => taskId.startsWith(p));
+/** Header fields a retirement decision may read. `null` = task file gone. */
+export interface TaskOrigin {
+	source: string | null;
 }
 
-/** Ownership-scoped: may THIS bridge archive it and retire its task row? */
-export function mayRetireSkipMarked(file: string, result: string,
-	isOwn: (taskId: string) => boolean): boolean {
+export function hasNetworkConsumer(origin: TaskOrigin | null): boolean {
+	// Unreadable origin is treated as foreign. Wrongly retiring strands an
+	// owner reply; wrongly keeping only accumulates a file, and suppression
+	// is universal either way — so the unknown case fails toward keeping.
+	if (origin === null) return true;
+	if (origin.source === null) return false;
+	return NETWORK_CONSUMER_SOURCES.includes(origin.source.trim().toLowerCase());
+}
+
+export function mayRetireSkipMarked(
+	file: string,
+	result: string,
+	isOwn: (taskId: string) => boolean,
+	originOf: (taskId: string) => TaskOrigin | null,
+): boolean {
 	if (!isSkipMarked(file, result)) return false;
 	const taskId = file.replace(/\.txt$/, '');
-	// The whole rule lives here so it is testable; the caller supplies only
-	// the dynamic signals (dispatched-by-me, is-a-voice-task).
-	return isLocalOnlyTask(taskId) || isOwn(taskId);
+	// Dispatched by this bridge, or belongs to no other consumer.
+	return isOwn(taskId) || !hasNetworkConsumer(originOf(taskId));
 }

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -9,18 +9,29 @@ export function isSkipMarked(file: string, result: string): boolean {
 	return file.startsWith('task-') && SKIP_MARKER_RE.test(result);
 }
 
-// Sources whose own bridge polls results/ and archives what it dispatched.
-// Closed set: a transport is added here only when its bridge gains that loop.
-// The complement — every local source — is open-ended and host-dependent, so
-// enumerating IT cannot stay correct: measured on two hosts the same day, the
-// missing local families did not overlap at all.
+// Evidence that some OTHER consumer will deliver and archive this result.
+// Two kinds, and the order matters.
+//
+// 1. Ledger membership — authoritative. A consumer that persists its in-flight
+//    set has already told us, as a fact about claiming, that the result is
+//    spoken for. It does not depend on any label.
+// 2. Source label — a residual net for bridges whose in-flight set is only
+//    in-memory, so nothing durable can be consulted for them.
+//
+// The label list is NOT a closed set and must not be read as one: the gateway
+// writes `source: {task.source or PROVIDER}` where PROVIDER comes from
+// $REMOTE_TASK_PROVIDER, so an operator can emit a label no list anticipates.
+// That is precisely why the ledger check has to come first rather than this
+// list being extended each time a new label is observed.
 export const NETWORK_CONSUMER_SOURCES = [
-	'discord', 'ag2space', 'telegram', 'slack', 'whatsapp',
+	'discord', 'ag2space', 'remote', 'telegram', 'slack', 'whatsapp',
 ];
 
-/** Header fields a retirement decision may read. `null` = task file gone. */
+/** What a retirement decision may read about a task's origin. */
 export interface TaskOrigin {
 	source: string | null;
+	/** Present in another consumer's durable in-flight ledger. */
+	claimedElsewhere?: boolean;
 }
 
 export function hasNetworkConsumer(origin: TaskOrigin | null): boolean {
@@ -28,6 +39,7 @@ export function hasNetworkConsumer(origin: TaskOrigin | null): boolean {
 	// owner reply; wrongly keeping only accumulates a file, and suppression
 	// is universal either way — so the unknown case fails toward keeping.
 	if (origin === null) return true;
+	if (origin.claimedElsewhere) return true;
 	if (origin.source === null) return false;
 	return NETWORK_CONSUMER_SOURCES.includes(origin.source.trim().toLowerCase());
 }

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -1,0 +1,20 @@
+/**
+ * Who may retire a skip-marked result.
+ *
+ * `results/` is shared by every consumer, so "task-* plus a marker" retires
+ * results a bridge never dispatched: the gateway's bookkeeping `[no-send]`
+ * gets archived by the voice bridge, its tid leaves the OWNING bridge's
+ * in-flight ledger, and a substantive reply written to that path afterwards
+ * is read by nobody. Ownership is the discriminator.
+ *
+ * Dependency-light and standalone so it is testable without the bridge's
+ * runtime deps (task-bridge.ts pulls the whole voice stack).
+ */
+
+export const SKIP_MARKER_RE = /^\s*\[(?:no-send|REPLIED)\]/i;
+
+export function mayRetireSkipMarked(file: string, result: string,
+	isOwn: (taskId: string) => boolean): boolean {
+	if (!file.startsWith('task-') || !SKIP_MARKER_RE.test(result)) return false;
+	return isOwn(file.replace(/\.txt$/, ''));
+}

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -10,6 +10,7 @@
 
 import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, readdirSync, statSync, appendFileSync, renameSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -10,7 +10,6 @@
 
 import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, readdirSync, statSync, appendFileSync, renameSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { homedir } from 'node:os';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';
@@ -252,34 +251,25 @@ export function _claimedElsewhere(taskId: string): boolean {
 	// Total by construction: this runs inside the result-drain loop, and a
 	// throw here aborts the pass for every later-sorting file, invisibly.
 	try {
-		// Look everywhere the WRITER may resolve, not just the injected dir:
-		// _dirs.state_dir() is injected -> $AGENT_CONNECT_STATE_DIR -> ~/.ag2-sparrow/state,
-		// and a ledger outside the globbed dir reads as "no claim", not "cannot tell".
-		const dirs = [join(REPO_DIR, 'state'), process.env.AGENT_CONNECT_STATE_DIR,
-			join(homedir(), '.ag2-sparrow', 'state')]
-			.filter((d): d is string => !!d);
-		const seen = new Set<string>();
-		const found: string[] = [];
+		// ONLY this workspace's state dir. A consumer configured against another
+		// tree writes its results there too, so its claims describe files that
+		// are not in the results/ being scanned here — reading them could only
+		// mistake a foreign namespace's claim for ownership of this file.
+		const dir = join(REPO_DIR, 'state');
+		let names: string[];
+		try {
+			names = readdirSync(dir).filter(f => f.startsWith(CLAIM_LEDGERS) && f.endsWith('.json')).sort();
+		} catch { return false; }
 		const stamps: string[] = [];
-		for (const dir of dirs) {
-			if (seen.has(dir)) continue;
-			seen.add(dir);
-			let names: string[];
-			try {
-				names = readdirSync(dir).filter(f => f.startsWith(CLAIM_LEDGERS) && f.endsWith('.json')).sort();
-			} catch { continue; }
-			for (const f of names) {
-				const full = join(dir, f);
-				found.push(full);
-				try { const st = statSync(full); stamps.push(`${full}:${st.mtimeMs}:${st.size}`); } catch {}
-			}
+		for (const f of names) {
+			try { const st = statSync(join(dir, f)); stamps.push(`${f}:${st.mtimeMs}:${st.size}`); } catch {}
 		}
 		const key = stamps.join('|');
 		if (_ledgerCache?.key !== key) {
 			const ids = new Set<string>();
-			for (const full of found) {
+			for (const f of names) {
 				try {
-					const parsed = JSON.parse(readFileSync(full, 'utf-8'));
+					const parsed = JSON.parse(readFileSync(join(dir, f), 'utf-8'));
 					// An unreadable or reshaped ledger yields no claims rather than
 					// throwing; the source-label net still covers those consumers.
 					if (Array.isArray(parsed)) for (const id of parsed) if (typeof id === 'string') ids.add(id);

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -248,21 +248,34 @@ const CLAIM_LEDGERS = 'remote-task-inflight';
 let _ledgerCache: { key: string; ids: Set<string> } | null = null;
 
 export function _claimedElsewhere(taskId: string): boolean {
-	const dir = join(REPO_DIR, 'state');
-	let files: string[];
-	try {
-		files = readdirSync(dir).filter(f => f.startsWith(CLAIM_LEDGERS) && f.endsWith('.json')).sort();
-	} catch { return false; }
+	// Look everywhere the WRITER may resolve, not just the injected dir:
+	// _dirs.state_dir() is injected -> $AGENT_CONNECT_STATE_DIR -> ~/.ag2-sparrow/state,
+	// and a ledger outside the globbed dir reads as "no claim", not "cannot tell".
+	const dirs = [join(REPO_DIR, 'state'), process.env.AGENT_CONNECT_STATE_DIR,
+		join(homedir(), '.ag2-sparrow', 'state')]
+		.filter((d): d is string => !!d);
+	const seen = new Set<string>();
+	const found: string[] = [];
 	const stamps: string[] = [];
-	for (const f of files) {
-		try { const st = statSync(join(dir, f)); stamps.push(`${f}:${st.mtimeMs}:${st.size}`); } catch {}
+	for (const dir of dirs) {
+		if (seen.has(dir)) continue;
+		seen.add(dir);
+		let names: string[];
+		try {
+			names = readdirSync(dir).filter(f => f.startsWith(CLAIM_LEDGERS) && f.endsWith('.json')).sort();
+		} catch { continue; }
+		for (const f of names) {
+			const full = join(dir, f);
+			found.push(full);
+			try { const st = statSync(full); stamps.push(`${full}:${st.mtimeMs}:${st.size}`); } catch {}
+		}
 	}
 	const key = stamps.join('|');
 	if (_ledgerCache?.key !== key) {
 		const ids = new Set<string>();
-		for (const f of files) {
+		for (const full of found) {
 			try {
-				const parsed = JSON.parse(readFileSync(join(dir, f), 'utf-8'));
+				const parsed = JSON.parse(readFileSync(full, 'utf-8'));
 				// An unreadable or reshaped ledger yields no claims rather than
 				// throwing; the source-label net still covers those consumers.
 				if (Array.isArray(parsed)) for (const id of parsed) if (typeof id === 'string') ids.add(id);

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';
 import { claudeHomePath } from './util_paths.js';
-import { mayRetireSkipMarked } from './skip_marker_ownership.js';
+import { isSkipMarked, mayRetireSkipMarked } from './skip_marker_ownership.js';
 import { recordConversation, recordSessionBoundary } from './conversation-store.js';
 import {
 	emitTaskProcessed,
@@ -892,7 +892,14 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 				// (e.g. Discord bridge already replied) or the result should be suppressed entirely.
 				// Parity with Python bridges: discord-bridge.py and telegram-bridge.py both honor
 				// these via parse_markers(); task-bridge.ts must too (issue #1381).
-				if (mayRetireSkipMarked(file, result, (id) => _pendingTasks.has(id))) {
+				if (isSkipMarked(file, result)) {
+					// Ownership must survive a restart (_pendingTasks is in-memory)
+					// and the timeout sweep; suppression applies either way.
+					const owns = (id: string) => _pendingTasks.has(id)
+						|| _isVoiceTask(id) || id.startsWith('task-chat-');
+					if (!mayRetireSkipMarked(file, result, owns)) {
+						continue;   // another consumer's: leave the files for its owner
+					}
 					console.log(`${ts()} [TaskBridge] ${taskId} has skip marker; archiving silently`);
 					_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
 					_deliveredResults.add(file);

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';
 import { claudeHomePath } from './util_paths.js';
+import { mayRetireSkipMarked } from './skip_marker_ownership.js';
 import { recordConversation, recordSessionBoundary } from './conversation-store.js';
 import {
 	emitTaskProcessed,
@@ -250,6 +251,8 @@ export function _isVoiceTask(taskId: string): boolean {
 export function _shouldFallthrough(file: string): boolean {
 	return file.startsWith('task-') || file.startsWith('voice-') || file.startsWith('proactive-');
 }
+
+
 
 /**
  * Whether a result file should REGISTER a row in the Task list — i.e. fire
@@ -889,7 +892,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 				// (e.g. Discord bridge already replied) or the result should be suppressed entirely.
 				// Parity with Python bridges: discord-bridge.py and telegram-bridge.py both honor
 				// these via parse_markers(); task-bridge.ts must too (issue #1381).
-				if (file.startsWith('task-') && /^\s*\[(?:no-send|REPLIED)\]/i.test(result)) {
+				if (mayRetireSkipMarked(file, result, (id) => _pendingTasks.has(id))) {
 					console.log(`${ts()} [TaskBridge] ${taskId} has skip marker; archiving silently`);
 					_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
 					_deliveredResults.add(file);

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -249,42 +249,46 @@ const CLAIM_LEDGERS = 'remote-task-inflight';
 let _ledgerCache: { key: string; ids: Set<string> } | null = null;
 
 export function _claimedElsewhere(taskId: string): boolean {
-	// Look everywhere the WRITER may resolve, not just the injected dir:
-	// _dirs.state_dir() is injected -> $AGENT_CONNECT_STATE_DIR -> ~/.ag2-sparrow/state,
-	// and a ledger outside the globbed dir reads as "no claim", not "cannot tell".
-	const dirs = [join(REPO_DIR, 'state'), process.env.AGENT_CONNECT_STATE_DIR,
-		join(homedir(), '.ag2-sparrow', 'state')]
-		.filter((d): d is string => !!d);
-	const seen = new Set<string>();
-	const found: string[] = [];
-	const stamps: string[] = [];
-	for (const dir of dirs) {
-		if (seen.has(dir)) continue;
-		seen.add(dir);
-		let names: string[];
-		try {
-			names = readdirSync(dir).filter(f => f.startsWith(CLAIM_LEDGERS) && f.endsWith('.json')).sort();
-		} catch { continue; }
-		for (const f of names) {
-			const full = join(dir, f);
-			found.push(full);
-			try { const st = statSync(full); stamps.push(`${full}:${st.mtimeMs}:${st.size}`); } catch {}
-		}
-	}
-	const key = stamps.join('|');
-	if (_ledgerCache?.key !== key) {
-		const ids = new Set<string>();
-		for (const full of found) {
+	// Total by construction: this runs inside the result-drain loop, and a
+	// throw here aborts the pass for every later-sorting file, invisibly.
+	try {
+		// Look everywhere the WRITER may resolve, not just the injected dir:
+		// _dirs.state_dir() is injected -> $AGENT_CONNECT_STATE_DIR -> ~/.ag2-sparrow/state,
+		// and a ledger outside the globbed dir reads as "no claim", not "cannot tell".
+		const dirs = [join(REPO_DIR, 'state'), process.env.AGENT_CONNECT_STATE_DIR,
+			join(homedir(), '.ag2-sparrow', 'state')]
+			.filter((d): d is string => !!d);
+		const seen = new Set<string>();
+		const found: string[] = [];
+		const stamps: string[] = [];
+		for (const dir of dirs) {
+			if (seen.has(dir)) continue;
+			seen.add(dir);
+			let names: string[];
 			try {
-				const parsed = JSON.parse(readFileSync(full, 'utf-8'));
-				// An unreadable or reshaped ledger yields no claims rather than
-				// throwing; the source-label net still covers those consumers.
-				if (Array.isArray(parsed)) for (const id of parsed) if (typeof id === 'string') ids.add(id);
-			} catch {}
+				names = readdirSync(dir).filter(f => f.startsWith(CLAIM_LEDGERS) && f.endsWith('.json')).sort();
+			} catch { continue; }
+			for (const f of names) {
+				const full = join(dir, f);
+				found.push(full);
+				try { const st = statSync(full); stamps.push(`${full}:${st.mtimeMs}:${st.size}`); } catch {}
+			}
 		}
-		_ledgerCache = { key, ids };
-	}
-	return _ledgerCache.ids.has(taskId);
+		const key = stamps.join('|');
+		if (_ledgerCache?.key !== key) {
+			const ids = new Set<string>();
+			for (const full of found) {
+				try {
+					const parsed = JSON.parse(readFileSync(full, 'utf-8'));
+					// An unreadable or reshaped ledger yields no claims rather than
+					// throwing; the source-label net still covers those consumers.
+					if (Array.isArray(parsed)) for (const id of parsed) if (typeof id === 'string') ids.add(id);
+				} catch {}
+			}
+			_ledgerCache = { key, ids };
+		}
+		return _ledgerCache.ids.has(taskId);
+	} catch { return false; }
 }
 
 /** Origin of a task for the retirement decision, read through the same

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';
 import { claudeHomePath } from './util_paths.js';
-import { isSkipMarked, mayRetireSkipMarked } from './skip_marker_ownership.js';
+import { isSkipMarked, mayRetireSkipMarked, type TaskOrigin } from './skip_marker_ownership.js';
 import { recordConversation, recordSessionBoundary } from './conversation-store.js';
 import {
 	emitTaskProcessed,
@@ -187,7 +187,9 @@ const normalizeTask = (t: string) => t.toLowerCase().replace(/\s+/g, ' ').trim()
  * offline. Returns false on missing file or parse error — bias toward not
  * forwarding to keep Susan-rejected always-DM behavior off by default for
  * non-voice tasks. */
-export function _isVoiceTask(taskId: string): boolean {
+/** Header lines of a task, located across every archive layout. Returns null
+ *  when no copy of the task survives. */
+export function _readTaskHeader(taskId: string): string[] | null {
 	const candidates: string[] = [
 		join(TASK_DIR, `${taskId}.txt`),
 		join(TASK_DIR, 'processed', `${taskId}.txt`),
@@ -226,10 +228,25 @@ export function _isVoiceTask(taskId: string): boolean {
 				if (l.startsWith('task:')) break;
 				headerLines.push(l);
 			}
-			return headerLines.some(l => l.startsWith('channel_id: local-voice') || l.startsWith('source: voice'));
+			return headerLines;
 		} catch {}
 	}
-	return false;
+	return null;
+}
+
+export function _isVoiceTask(taskId: string): boolean {
+	const headerLines = _readTaskHeader(taskId);
+	if (headerLines === null) return false;
+	return headerLines.some(l => l.startsWith('channel_id: local-voice') || l.startsWith('source: voice'));
+}
+
+/** Origin of a task for the retirement decision, read through the same
+ *  delimiter-honoring header reader `_isVoiceTask` uses. */
+export function _taskOrigin(taskId: string): TaskOrigin | null {
+	const headerLines = _readTaskHeader(taskId);
+	if (headerLines === null) return null;
+	const line = headerLines.find(l => l.startsWith('source:'));
+	return { source: line ? line.slice('source:'.length).trim() : null };
 }
 
 /** Belt-suspenders guard for the result-watcher's unconditional fallthrough
@@ -896,7 +913,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					// Ownership must survive a restart (_pendingTasks is in-memory)
 					// and the timeout sweep; suppression applies either way.
 					const owns = (id: string) => _pendingTasks.has(id) || _isVoiceTask(id);
-					if (!mayRetireSkipMarked(file, result, owns)) {
+					if (!mayRetireSkipMarked(file, result, owns, _taskOrigin)) {
 						continue;   // another consumer's: leave the files for its owner
 					}
 					console.log(`${ts()} [TaskBridge] ${taskId} has skip marker; archiving silently`);

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -8,7 +8,7 @@
  * injects the result into the Gemini conversation.
  */
 
-import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, readdirSync, appendFileSync, renameSync } from 'node:fs';
+import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, readdirSync, statSync, appendFileSync, renameSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
@@ -240,13 +240,49 @@ export function _isVoiceTask(taskId: string): boolean {
 	return headerLines.some(l => l.startsWith('channel_id: local-voice') || l.startsWith('source: voice'));
 }
 
+const CLAIM_LEDGERS = 'remote-task-inflight';
+
+// Durable in-flight sets other consumers publish. Cached on (mtime, size) so a
+// drain does not re-parse per result; a claim added mid-drain is picked up on
+// the next change rather than needing a restart.
+let _ledgerCache: { key: string; ids: Set<string> } | null = null;
+
+export function _claimedElsewhere(taskId: string): boolean {
+	const dir = join(REPO_DIR, 'state');
+	let files: string[];
+	try {
+		files = readdirSync(dir).filter(f => f.startsWith(CLAIM_LEDGERS) && f.endsWith('.json')).sort();
+	} catch { return false; }
+	const stamps: string[] = [];
+	for (const f of files) {
+		try { const st = statSync(join(dir, f)); stamps.push(`${f}:${st.mtimeMs}:${st.size}`); } catch {}
+	}
+	const key = stamps.join('|');
+	if (_ledgerCache?.key !== key) {
+		const ids = new Set<string>();
+		for (const f of files) {
+			try {
+				const parsed = JSON.parse(readFileSync(join(dir, f), 'utf-8'));
+				// An unreadable or reshaped ledger yields no claims rather than
+				// throwing; the source-label net still covers those consumers.
+				if (Array.isArray(parsed)) for (const id of parsed) if (typeof id === 'string') ids.add(id);
+			} catch {}
+		}
+		_ledgerCache = { key, ids };
+	}
+	return _ledgerCache.ids.has(taskId);
+}
+
 /** Origin of a task for the retirement decision, read through the same
  *  delimiter-honoring header reader `_isVoiceTask` uses. */
 export function _taskOrigin(taskId: string): TaskOrigin | null {
 	const headerLines = _readTaskHeader(taskId);
 	if (headerLines === null) return null;
 	const line = headerLines.find(l => l.startsWith('source:'));
-	return { source: line ? line.slice('source:'.length).trim() : null };
+	return {
+		source: line ? line.slice('source:'.length).trim() : null,
+		claimedElsewhere: _claimedElsewhere(taskId),
+	};
 }
 
 /** Belt-suspenders guard for the result-watcher's unconditional fallthrough

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -895,8 +895,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 				if (isSkipMarked(file, result)) {
 					// Ownership must survive a restart (_pendingTasks is in-memory)
 					// and the timeout sweep; suppression applies either way.
-					const owns = (id: string) => _pendingTasks.has(id)
-						|| _isVoiceTask(id) || id.startsWith('task-chat-');
+					const owns = (id: string) => _pendingTasks.has(id) || _isVoiceTask(id);
 					if (!mayRetireSkipMarked(file, result, owns)) {
 						continue;   // another consumer's: leave the files for its owner
 					}

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -248,8 +248,8 @@ const CLAIM_LEDGERS = 'remote-task-inflight';
 let _ledgerCache: { key: string; ids: Set<string> } | null = null;
 
 export function _claimedElsewhere(taskId: string): boolean {
-	// Total by construction: this runs inside the result-drain loop, and a
-	// throw here aborts the pass for every later-sorting file, invisibly.
+	// Defence in depth: this runs inside the result-drain loop, where a throw
+	// aborts the pass for every later-sorting file without logging.
 	try {
 		// ONLY this workspace's state dir. A consumer configured against another
 		// tree writes its results there too, so its claims describe files that

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -94,22 +94,4 @@ describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', 
 		delete process.env.AGENT_CONNECT_STATE_DIR;
 	});
 
-	it('the whole body is guarded, including directory resolution', () => {
-		// The outer try covers homedir() and join(REPO_DIR, …), which run BEFORE
-		// the per-directory try. Neither is injectable from here — REPO_DIR is
-		// captured at module load — so this asserts the structural property the
-		// runtime guarantee rests on rather than simulating the throw. Removing
-		// the wrap fails this; a scratch harness with an unset REPO_DIR confirms
-		// the behaviour it stands for. Known weakness: a structural pin can also
-		// break on a safe refactor, and it never executes the guarded path. The
-		// behavioural version needs mock.module on node:os, which requires
-		// --experimental-test-module-mocks; the runner does not pass it, so that
-		// control cannot run here without changing it for every suite.
-		const src = readFileSync(new URL('../src/task-bridge.ts', import.meta.url), 'utf-8');
-		const fn = src.slice(src.indexOf('export function _claimedElsewhere'));
-		const body = fn.slice(fn.indexOf('{') + 1, fn.indexOf('\n}\n'));
-		const firstStmt = body.split('\n').find(l => l.trim() && !l.trim().startsWith('//'));
-		assert.match(firstStmt ?? '', /^\s*try \{/,
-			'directory resolution must be inside the try, not above it');
-	});
 });

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -79,15 +79,30 @@ describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', 
 			'an operator-set label the list cannot enumerate is still caught by the claim');
 	});
 
-	it('is total — a failure never escapes into the drain loop', () => {
-		// This runs inside the result-scan for-loop, whose catch inspects
-		// err.code; a ReferenceError has none, so the guard is false, nothing
-		// is logged, and the pass aborts for every later-sorting file. It then
-		// repeats every tick, because the file it stops on is one this PR
-		// deliberately leaves resident. The directory resolution therefore has
-		// to be inside the try, not just the reads.
+	it('a failing directory read is contained, not propagated', () => {
+		// Honest scope: readdirSync throws ERR_INVALID_ARG_VALUE on a NUL-bearing
+		// path, and that call was ALREADY inside the per-directory try. This pins
+		// containment; it does NOT exercise the outer wrap, which guards the
+		// directory-list construction instead. Asserted separately below.
 		process.env.AGENT_CONNECT_STATE_DIR = '\0not-a-path';
 		assert.doesNotThrow(() => _claimedElsewhere('task-a'));
+		assert.equal(_claimedElsewhere('task-a'), true, 'the readable ledger is still read');
 		delete process.env.AGENT_CONNECT_STATE_DIR;
+	});
+
+	it('the whole body is guarded, including directory resolution', () => {
+		// The outer try covers homedir() and join(REPO_DIR, …), which run BEFORE
+		// the per-directory try. Neither is injectable from here — REPO_DIR is
+		// captured at module load — so this asserts the structural property the
+		// runtime guarantee rests on rather than simulating the throw. Removing
+		// the wrap fails this; a scratch harness with an unset REPO_DIR confirms
+		// the behaviour it stands for. Known weakness: a structural pin can also
+		// break on a safe refactor, and it never executes the guarded path.
+		const src = readFileSync(new URL('../src/task-bridge.ts', import.meta.url), 'utf-8');
+		const fn = src.slice(src.indexOf('export function _claimedElsewhere'));
+		const body = fn.slice(fn.indexOf('{') + 1, fn.indexOf('\n}\n'));
+		const firstStmt = body.split('\n').find(l => l.trim() && !l.trim().startsWith('//'));
+		assert.match(firstStmt ?? '', /^\s*try \{/,
+			'directory resolution must be inside the try, not above it');
 	});
 });

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// _claimedElsewhere is the evidence the retirement decision reads. The
+// decision itself is pinned in task-bridge-skip-marker-ownership.test.ts by
+// handing it a boolean — so if this function silently returned false those
+// tests would all still pass and the fix would be inert.
+const TMP = mkdtempSync(join(tmpdir(), 'sutando-claim-ledger-'));
+const EXT = mkdtempSync(join(tmpdir(), 'sutando-sparrow-ext-'));
+mkdirSync(join(TMP, 'tasks'), { recursive: true });
+mkdirSync(join(TMP, 'state'), { recursive: true });
+mkdirSync(join(EXT, 'state'), { recursive: true });
+process.env.SUTANDO_WORKSPACE = TMP;
+process.env.SUTANDO_TEST_MODE = '1';
+
+const { _claimedElsewhere, _taskOrigin } = await import('../src/task-bridge.js');
+
+const ledger = (dir: string, name: string, ids: string[]) =>
+	writeFileSync(join(dir, 'state', name), JSON.stringify(ids));
+const raw = (dir: string, name: string, text: string) =>
+	writeFileSync(join(dir, 'state', name), text);
+
+after(() => { rmSync(TMP, { recursive: true, force: true }); rmSync(EXT, { recursive: true, force: true }); });
+
+describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', () => {
+	it('no ledger present yields no claims', () => {
+		assert.equal(_claimedElsewhere('task-none'), false);
+	});
+
+	it('a claimed tid reads as claimed', () => {
+		ledger(TMP, 'remote-task-inflight.json', ['task-a', 'task-b']);
+		assert.equal(_claimedElsewhere('task-a'), true);
+		assert.equal(_claimedElsewhere('task-not-in-it'), false);
+	});
+
+	it('a claim added mid-drain is seen without a restart', () => {
+		// Cache is keyed on (mtime, size), so a rewrite invalidates it.
+		ledger(TMP, 'remote-task-inflight.json', ['task-a', 'task-b', 'task-added-later']);
+		assert.equal(_claimedElsewhere('task-added-later'), true);
+	});
+
+	it('reads every instance-suffixed ledger', () => {
+		ledger(TMP, 'remote-task-inflight-inst2.json', ['task-second-instance']);
+		assert.equal(_claimedElsewhere('task-second-instance'), true);
+	});
+
+	it('a corrupt ledger yields no claims rather than throwing', () => {
+		raw(TMP, 'remote-task-inflight-bad.json', '{not json');
+		assert.equal(_claimedElsewhere('task-a'), true, 'the readable ledger is still read');
+		assert.equal(_claimedElsewhere('task-ghost'), false);
+	});
+
+	it('a reshaped ledger yields no claims rather than throwing', () => {
+		raw(TMP, 'remote-task-inflight-shape.json', '{"tasks": ["task-wrong-shape"]}');
+		assert.equal(_claimedElsewhere('task-wrong-shape'), false);
+	});
+
+	it('finds a ledger the WRITER placed outside the injected dir', () => {
+		// _dirs.state_dir() resolves injected -> $AGENT_CONNECT_STATE_DIR ->
+		// ~/.ag2-sparrow/state. Globbing only the injected dir reports "no
+		// claim" for a whole deployment shape, silently.
+		ledger(EXT, 'remote-task-inflight.json', ['task-external-client']);
+		process.env.AGENT_CONNECT_STATE_DIR = join(EXT, 'state');
+		assert.equal(_claimedElsewhere('task-external-client'), true);
+		delete process.env.AGENT_CONNECT_STATE_DIR;
+	});
+
+	it('a claim reaches the origin record the decision actually reads', () => {
+		// The wiring: _taskOrigin must carry the claim through, or the
+		// ledger is read and then discarded.
+		writeFileSync(join(TMP, 'tasks', 'task-a.txt'),
+			'id: task-a\nsource: acme-corp-relay\ntask: hi\n');
+		const o = _taskOrigin('task-a');
+		assert.equal(o!.source, 'acme-corp-relay');
+		assert.equal(o!.claimedElsewhere, true,
+			'an operator-set label the list cannot enumerate is still caught by the claim');
+	});
+});

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -97,7 +97,10 @@ describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', 
 		// runtime guarantee rests on rather than simulating the throw. Removing
 		// the wrap fails this; a scratch harness with an unset REPO_DIR confirms
 		// the behaviour it stands for. Known weakness: a structural pin can also
-		// break on a safe refactor, and it never executes the guarded path.
+		// break on a safe refactor, and it never executes the guarded path. The
+		// behavioural version needs mock.module on node:os, which requires
+		// --experimental-test-module-mocks; the runner does not pass it, so that
+		// control cannot run here without changing it for every suite.
 		const src = readFileSync(new URL('../src/task-bridge.ts', import.meta.url), 'utf-8');
 		const fn = src.slice(src.indexOf('export function _claimedElsewhere'));
 		const body = fn.slice(fn.indexOf('{') + 1, fn.indexOf('\n}\n'));

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -78,4 +78,16 @@ describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', 
 		assert.equal(o!.claimedElsewhere, true,
 			'an operator-set label the list cannot enumerate is still caught by the claim');
 	});
+
+	it('is total — a failure never escapes into the drain loop', () => {
+		// This runs inside the result-scan for-loop, whose catch inspects
+		// err.code; a ReferenceError has none, so the guard is false, nothing
+		// is logged, and the pass aborts for every later-sorting file. It then
+		// repeats every tick, because the file it stops on is one this PR
+		// deliberately leaves resident. The directory resolution therefore has
+		// to be inside the try, not just the reads.
+		process.env.AGENT_CONNECT_STATE_DIR = '\0not-a-path';
+		assert.doesNotThrow(() => _claimedElsewhere('task-a'));
+		delete process.env.AGENT_CONNECT_STATE_DIR;
+	});
 });

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -53,6 +53,21 @@ describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', 
 		assert.equal(_claimedElsewhere('task-ghost'), false);
 	});
 
+	it('reads ONLY ledger-named files, not every JSON in state/', () => {
+		// <workspace>/state also holds core-status.json, voice-state.json,
+		// quota-state.json and friends. Without the name+suffix filter, any of
+		// them that happens to be a JSON array of strings injects false claims
+		// and wrongly suppresses retirement of a local result.
+		const decoys = ['core-status.json', 'voice-state.json', 'quota-state.json'];
+		for (const name of decoys) raw(TMP, name, JSON.stringify(['task-decoy']));
+		raw(TMP, 'remote-task-inflight.txt', JSON.stringify(['task-wrong-suffix']));
+		assert.equal(_claimedElsewhere('task-decoy'), false,
+			'a non-ledger JSON array in state/ must not read as a claim');
+		assert.equal(_claimedElsewhere('task-wrong-suffix'), false,
+			'a ledger-named file without .json must not be read');
+		assert.equal(_claimedElsewhere('task-a'), true, 'the real ledger still reads');
+	});
+
 	it('a reshaped ledger yields no claims rather than throwing', () => {
 		raw(TMP, 'remote-task-inflight-shape.json', '{"tasks": ["task-wrong-shape"]}');
 		assert.equal(_claimedElsewhere('task-wrong-shape'), false);

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, renameSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -84,14 +84,23 @@ describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', 
 	});
 
 	it('a failing directory read is contained, not propagated', () => {
-		// Honest scope: readdirSync throws ERR_INVALID_ARG_VALUE on a NUL-bearing
-		// path, and that call was ALREADY inside the per-directory try. This pins
-		// containment; it does NOT exercise the outer wrap, which guards the
-		// directory-list construction instead. Asserted separately below.
-		process.env.AGENT_CONNECT_STATE_DIR = '\0not-a-path';
-		assert.doesNotThrow(() => _claimedElsewhere('task-a'));
-		assert.equal(_claimedElsewhere('task-a'), true, 'the readable ledger is still read');
-		delete process.env.AGENT_CONNECT_STATE_DIR;
+		// Inject through the dir src ACTUALLY reads. Driving this through
+		// AGENT_CONNECT_STATE_DIR passed for an unrelated reason once the
+		// boundary fix stopped reading that variable: readdirSync was never
+		// called with the bad path at all.
+		// Note the guards are redundant, so removing either one alone still
+		// passes; this pins that containment EXISTS, not which guard supplies it.
+		const state = join(TMP, 'state');
+		const stash = join(TMP, 'state-stashed');
+		renameSync(state, stash);              // readdirSync now throws ENOENT
+		try {
+			assert.doesNotThrow(() => _claimedElsewhere('task-a'));
+			assert.equal(_claimedElsewhere('task-a'), false,
+				'an unreadable state dir yields no claims, it does not propagate');
+		} finally {
+			renameSync(stash, state);
+		}
+		assert.equal(_claimedElsewhere('task-a'), true, 'and it recovers once readable');
 	});
 
 });

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -58,13 +58,17 @@ describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', 
 		assert.equal(_claimedElsewhere('task-wrong-shape'), false);
 	});
 
-	it('finds a ledger the WRITER placed outside the injected dir', () => {
-		// _dirs.state_dir() resolves injected -> $AGENT_CONNECT_STATE_DIR ->
-		// ~/.ag2-sparrow/state. Globbing only the injected dir reports "no
-		// claim" for a whole deployment shape, silently.
-		ledger(EXT, 'remote-task-inflight.json', ['task-external-client']);
+	it('a ledger outside this workspace is NOT ownership of a file inside it', () => {
+		// _dirs.py resolves task/result/state independently and sutando injects
+		// all three together, so a consumer pointed at another tree writes its
+		// RESULTS there too. Its claims describe files that are not in the
+		// results/ scanned here — counting them would mistake a foreign
+		// namespace's claim for ownership of this file.
 		process.env.AGENT_CONNECT_STATE_DIR = join(EXT, 'state');
-		assert.equal(_claimedElsewhere('task-external-client'), true);
+		ledger(EXT, 'remote-task-inflight.json', ['task-elsewhere']);
+		assert.equal(_claimedElsewhere('task-elsewhere'), false,
+			'a claim from another tree must not count as ownership here');
+		assert.equal(_claimedElsewhere('task-a'), true, 'this workspace still reads');
 		delete process.env.AGENT_CONNECT_STATE_DIR;
 	});
 

--- a/tests/task-bridge-claim-ledger.test.ts
+++ b/tests/task-bridge-claim-ledger.test.ts
@@ -87,6 +87,16 @@ describe('_claimedElsewhere reads other consumers\' durable in-flight ledgers', 
 		delete process.env.AGENT_CONNECT_STATE_DIR;
 	});
 
+	it('a bare JSON string is not a list of claims', () => {
+		// A JSON string is ITERABLE, so `for (const id of parsed)` walks its
+		// characters instead of throwing — the shape check is what stops them
+		// entering the id set, not the surrounding catch.
+		raw(TMP, 'remote-task-inflight-str.json', JSON.stringify('x'));
+		assert.equal(_claimedElsewhere('x'), false,
+			'characters of a JSON string must not read as claims');
+		assert.equal(_claimedElsewhere('task-a'), true, 'the real ledger still reads');
+	});
+
 	it('a claim reaches the origin record the decision actually reads', () => {
 		// The wiring: _taskOrigin must carry the claim through, or the
 		// ledger is read and then discarded.

--- a/tests/task-bridge-skip-marker-ownership.test.ts
+++ b/tests/task-bridge-skip-marker-ownership.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { isSkipMarked, mayRetireSkipMarked } from '../src/skip_marker_ownership.js';
+import { isLocalOnlyTask, isSkipMarked, mayRetireSkipMarked } from '../src/skip_marker_ownership.js';
 
 // results/ is shared by every consumer. Matching `task-*` plus a skip marker
 // retired results this bridge never dispatched: the gateway's bookkeeping
@@ -66,5 +66,24 @@ describe('task-bridge — only retire skip-marked results this bridge owns', () 
 		// the entry; ownership must not evaporate with it.
 		const durable = (id: string) => id === OWN || id.startsWith('task-chat-');
 		assert.equal(mayRetireSkipMarked('task-chat-123.txt', '[no-send]', durable), true);
+	});
+
+	it('local-only families keep an archiver — cron depends on it explicitly', () => {
+		// codex-scheduler writes [no-send] "so this scheduled task is
+		// archived"; cron never enters _pendingTasks and discord-bridge's
+		// skip handling is scoped to its own pending map.
+		const notDispatched = () => false;
+		for (const id of ['task-cron-nightly-123', 'task-chat-9',
+			'task-workstream-grouping-1', 'task-project-grouping-1']) {
+			assert.equal(isLocalOnlyTask(id), true, id);
+			assert.equal(mayRetireSkipMarked(`${id}.txt`, '[no-send]', notDispatched),
+				true, `${id} would have no archiver in any bridge`);
+		}
+	});
+
+	it('a network consumer\'s task is NOT local-only', () => {
+		// The whole point: gateway/discord/telegram ids stay foreign.
+		assert.equal(isLocalOnlyTask('task-0000000000000000bb'), false);
+		assert.equal(mayRetireSkipMarked(`${OTHERS}.txt`, '[no-send]', () => false), false);
 	});
 });

--- a/tests/task-bridge-skip-marker-ownership.test.ts
+++ b/tests/task-bridge-skip-marker-ownership.test.ts
@@ -74,7 +74,8 @@ describe('task-bridge — only retire skip-marked results this bridge owns', () 
 		// skip handling is scoped to its own pending map.
 		const notDispatched = () => false;
 		for (const id of ['task-cron-nightly-123', 'task-chat-9',
-			'task-workstream-grouping-1', 'task-project-grouping-1']) {
+			'task-workstream-grouping-1', 'task-project-grouping-1',
+			'task-health-1786958480', 'task-smoke-1', 'task-discord-e2e-1']) {
 			assert.equal(isLocalOnlyTask(id), true, id);
 			assert.equal(mayRetireSkipMarked(`${id}.txt`, '[no-send]', notDispatched),
 				true, `${id} would have no archiver in any bridge`);
@@ -85,5 +86,14 @@ describe('task-bridge — only retire skip-marked results this bridge owns', () 
 		// The whole point: gateway/discord/telegram ids stay foreign.
 		assert.equal(isLocalOnlyTask('task-0000000000000000bb'), false);
 		assert.equal(mayRetireSkipMarked(`${OTHERS}.txt`, '[no-send]', () => false), false);
+	});
+
+	it('covers every machine family web-client.ts already enumerates', () => {
+		// isOwnerVisibleTask lists the durable-scheduler/health families; each
+		// has no network consumer, so each needs an archiver here too.
+		for (const id of ['task-cron-x', 'task-health-x', 'task-smoke-x',
+			'task-discord-e2e-x']) {
+			assert.equal(isLocalOnlyTask(id), true, `${id} has no archiver`);
+		}
 	});
 });

--- a/tests/task-bridge-skip-marker-ownership.test.ts
+++ b/tests/task-bridge-skip-marker-ownership.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { isLocalOnlyTask, isSkipMarked, mayRetireSkipMarked } from '../src/skip_marker_ownership.js';
+import { hasNetworkConsumer, isSkipMarked, mayRetireSkipMarked }
+	from '../src/skip_marker_ownership.js';
 
 // results/ is shared by every consumer. Matching `task-*` plus a skip marker
 // retired results this bridge never dispatched: the gateway's bookkeeping
@@ -10,90 +11,129 @@ import { isLocalOnlyTask, isSkipMarked, mayRetireSkipMarked } from '../src/skip_
 // resident while the archived copy was the tiny [no-send] note.
 
 const OWN = 'task-0000000000000000aa';
-const OTHERS = 'task-0000000000000000bb';
+const FOREIGN = 'task-0000000000000000bb';
 const owns = (id: string) => id === OWN;
+const noneOwned = () => false;
+
+// Origin oracle: FOREIGN came over a bridge, everything else is local.
+const origin = (id: string) =>
+	id === FOREIGN ? { source: 'ag2space' } : { source: 'cron' };
 
 describe('task-bridge — only retire skip-marked results this bridge owns', () => {
 	it('retires its own dispatched task', () => {
-		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '[no-send]\nbookkeeping', owns), true);
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '[no-send]\nbookkeeping', owns, origin), true);
 	});
 
 	it('leaves another consumer\'s result alone', () => {
 		assert.equal(
-			mayRetireSkipMarked(`${OTHERS}.txt`, '[no-send]\nbookkeeping', owns), false,
+			mayRetireSkipMarked(`${FOREIGN}.txt`, '[no-send]\nbookkeeping', noneOwned, origin), false,
 			'archiving a result this bridge never dispatched strands the owner\'s reply'
 		);
 	});
 
 	it('honours [REPLIED] under the same ownership rule', () => {
-		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '[REPLIED]', owns), true);
-		assert.equal(mayRetireSkipMarked(`${OTHERS}.txt`, '[REPLIED]', owns), false);
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '[REPLIED]', owns, origin), true);
+		assert.equal(mayRetireSkipMarked(`${FOREIGN}.txt`, '[REPLIED]', noneOwned, origin), false);
 	});
 
 	it('ignores unmarked results even when owned', () => {
-		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, 'the actual reply', owns), false);
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, 'the actual reply', owns, origin), false);
 	});
 
 	it('ignores non-task files', () => {
-		assert.equal(mayRetireSkipMarked('proactive-1.txt', '[no-send]', () => true), false);
+		assert.equal(mayRetireSkipMarked('proactive-1.txt', '[no-send]', () => true, origin), false);
 	});
 
 	it('matches the marker case-insensitively and after leading space', () => {
-		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '  [NO-SEND] x', owns), true);
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '  [NO-SEND] x', owns, origin), true);
 	});
 
 	it('suppression is UNIVERSAL — a foreign marked result is still marked', () => {
 		// The regression the ownership gate alone would introduce: a foreign
 		// [no-send] that falls through gets NARRATED aloud, which is worse
 		// than the silent mis-archive it replaced.
-		assert.equal(isSkipMarked(`${OTHERS}.txt`, '[no-send]\nbookkeeping'), true);
+		assert.equal(isSkipMarked(`${FOREIGN}.txt`, '[no-send]\nbookkeeping'), true);
 		assert.equal(isSkipMarked(`${OWN}.txt`, '[REPLIED]'), true);
 	});
 
 	it('suppression and retirement disagree exactly on foreign items', () => {
-		const foreign = `${OTHERS}.txt`, body = '[no-send]\nx';
-		assert.equal(isSkipMarked(foreign, body), true, 'must be suppressed');
-		assert.equal(mayRetireSkipMarked(foreign, body, owns), false, 'must not be retired');
+		const body = '[no-send]\nx';
+		assert.equal(isSkipMarked(`${FOREIGN}.txt`, body), true, 'must be suppressed');
+		assert.equal(mayRetireSkipMarked(`${FOREIGN}.txt`, body, noneOwned, origin), false,
+			'must not be retired');
 	});
 
 	it('unmarked results are neither suppressed nor retired', () => {
 		assert.equal(isSkipMarked(`${OWN}.txt`, 'the actual reply'), false);
-		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, 'the actual reply', owns), false);
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, 'the actual reply', owns, origin), false);
 	});
 
 	it('durable ownership: a task no longer in the in-memory map is still ours', () => {
 		// _pendingTasks is in-memory, so a restart or the timeout sweep drops
 		// the entry; ownership must not evaporate with it.
-		const durable = (id: string) => id === OWN || id.startsWith('task-chat-');
-		assert.equal(mayRetireSkipMarked('task-chat-123.txt', '[no-send]', durable), true);
+		const durable = (id: string) => id === OWN || id.startsWith('task-voice-');
+		assert.equal(mayRetireSkipMarked('task-voice-1.txt', '[no-send]', durable,
+			() => ({ source: 'voice' })), true);
 	});
+});
 
-	it('local-only families keep an archiver — cron depends on it explicitly', () => {
-		// codex-scheduler writes [no-send] "so this scheduled task is
-		// archived"; cron never enters _pendingTasks and discord-bridge's
-		// skip handling is scoped to its own pending map.
-		const notDispatched = () => false;
-		for (const id of ['task-cron-nightly-123', 'task-chat-9',
-			'task-workstream-grouping-1', 'task-project-grouping-1',
-			'task-health-1786958480', 'task-smoke-1', 'task-discord-e2e-1']) {
-			assert.equal(isLocalOnlyTask(id), true, id);
-			assert.equal(mayRetireSkipMarked(`${id}.txt`, '[no-send]', notDispatched),
-				true, `${id} would have no archiver in any bridge`);
+describe('retirement is scoped by the CLOSED foreign set, not a local allowlist', () => {
+	// Two hosts measured the same day disagreed completely on which local
+	// families exist: one had task-wire-/task-newsradar-/task-activity-upload-,
+	// the other task-taskify- (94 results). No overlap. An allowlist of local
+	// families is therefore unmaintainable by construction; the set WITH a
+	// consumer is closed and small.
+	const LOCAL_FAMILIES_SEEN_IN_THE_FIELD = [
+		['task-cron-nightly-1', 'cron'],
+		['task-chat-9', 'chat'],
+		['task-workstream-grouping-1', 'cron'],
+		['task-taskify-abc', 'events-promotion'],   // 94 on this host, never listed
+		['task-wire-1', 'wire'],                    // 49 on the peer host
+		['task-newsradar-1', 'news-radar'],
+		['task-activity-upload-1', 'activity-upload'],
+		['task-health-1786958480', 'health-check'],
+		['task-summary-1', 'summary'],
+		['task-approve-1', 'approve'],
+		['task-gh-1', 'github'],
+	];
+
+	it('retires every local family without naming any of them', () => {
+		for (const [id, source] of LOCAL_FAMILIES_SEEN_IN_THE_FIELD) {
+			assert.equal(
+				mayRetireSkipMarked(`${id}.txt`, '[no-send]', noneOwned, () => ({ source })),
+				true, `${id} (source=${source}) would have no archiver in any bridge`);
 		}
 	});
 
-	it('a network consumer\'s task is NOT local-only', () => {
-		// The whole point: gateway/discord/telegram ids stay foreign.
-		assert.equal(isLocalOnlyTask('task-0000000000000000bb'), false);
-		assert.equal(mayRetireSkipMarked(`${OTHERS}.txt`, '[no-send]', () => false), false);
+	it('never retires a task whose own bridge archives it', () => {
+		for (const source of ['discord', 'ag2space', 'telegram', 'slack', 'whatsapp']) {
+			assert.equal(
+				mayRetireSkipMarked(`${FOREIGN}.txt`, '[no-send]', noneOwned, () => ({ source })),
+				false, `${source} bridge owns its own results`);
+		}
 	});
 
-	it('covers every machine family web-client.ts already enumerates', () => {
-		// isOwnerVisibleTask lists the durable-scheduler/health families; each
-		// has no network consumer, so each needs an archiver here too.
-		for (const id of ['task-cron-x', 'task-health-x', 'task-smoke-x',
-			'task-discord-e2e-x']) {
-			assert.equal(isLocalOnlyTask(id), true, `${id} has no archiver`);
-		}
+	it('an unreadable origin fails toward KEEPING, not retiring', () => {
+		// Wrongly retiring strands an owner reply; wrongly keeping accumulates
+		// a file. Suppression is universal either way, so the unknown case
+		// must not archive.
+		assert.equal(hasNetworkConsumer(null), true, 'gone task file reads as foreign');
+		assert.equal(mayRetireSkipMarked(`${FOREIGN}.txt`, '[no-send]', noneOwned, () => null),
+			false);
+		// ...unless this bridge dispatched it, which is positive evidence.
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '[no-send]', owns, () => null), true);
+	});
+
+	it('a missing source: line is local, not unknown', () => {
+		// conversation-server omits source: DELIBERATELY so discord-bridge
+		// will not treat the result as a DM candidate — by design nothing
+		// else can archive it.
+		assert.equal(hasNetworkConsumer({ source: null }), false);
+		assert.equal(mayRetireSkipMarked('task-summary-1.txt', '[no-send]', noneOwned,
+			() => ({ source: null })), true);
+	});
+
+	it('source matching is case- and whitespace-insensitive', () => {
+		assert.equal(hasNetworkConsumer({ source: '  Discord ' }), true);
 	});
 });

--- a/tests/task-bridge-skip-marker-ownership.test.ts
+++ b/tests/task-bridge-skip-marker-ownership.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mayRetireSkipMarked } from '../src/skip_marker_ownership.js';
+import { isSkipMarked, mayRetireSkipMarked } from '../src/skip_marker_ownership.js';
 
 // results/ is shared by every consumer. Matching `task-*` plus a skip marker
 // retired results this bridge never dispatched: the gateway's bookkeeping
@@ -40,5 +40,31 @@ describe('task-bridge — only retire skip-marked results this bridge owns', () 
 
 	it('matches the marker case-insensitively and after leading space', () => {
 		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '  [NO-SEND] x', owns), true);
+	});
+
+	it('suppression is UNIVERSAL — a foreign marked result is still marked', () => {
+		// The regression the ownership gate alone would introduce: a foreign
+		// [no-send] that falls through gets NARRATED aloud, which is worse
+		// than the silent mis-archive it replaced.
+		assert.equal(isSkipMarked(`${OTHERS}.txt`, '[no-send]\nbookkeeping'), true);
+		assert.equal(isSkipMarked(`${OWN}.txt`, '[REPLIED]'), true);
+	});
+
+	it('suppression and retirement disagree exactly on foreign items', () => {
+		const foreign = `${OTHERS}.txt`, body = '[no-send]\nx';
+		assert.equal(isSkipMarked(foreign, body), true, 'must be suppressed');
+		assert.equal(mayRetireSkipMarked(foreign, body, owns), false, 'must not be retired');
+	});
+
+	it('unmarked results are neither suppressed nor retired', () => {
+		assert.equal(isSkipMarked(`${OWN}.txt`, 'the actual reply'), false);
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, 'the actual reply', owns), false);
+	});
+
+	it('durable ownership: a task no longer in the in-memory map is still ours', () => {
+		// _pendingTasks is in-memory, so a restart or the timeout sweep drops
+		// the entry; ownership must not evaporate with it.
+		const durable = (id: string) => id === OWN || id.startsWith('task-chat-');
+		assert.equal(mayRetireSkipMarked('task-chat-123.txt', '[no-send]', durable), true);
 	});
 });

--- a/tests/task-bridge-skip-marker-ownership.test.ts
+++ b/tests/task-bridge-skip-marker-ownership.test.ts
@@ -137,3 +137,51 @@ describe('retirement is scoped by the CLOSED foreign set, not a local allowlist'
 		assert.equal(hasNetworkConsumer({ source: '  Discord ' }), true);
 	});
 });
+
+describe('a durable claim outranks the source label', () => {
+	// The label set is not closed: remote_gateway_bridge writes
+	// `source: {task.source or PROVIDER}` with PROVIDER from
+	// $REMOTE_TASK_PROVIDER, so an operator can emit a label no list
+	// anticipates. Extending the list on each new label observed is the
+	// failure mode, not the fix.
+	it('claimed wins even when the label is unknown', () => {
+		assert.equal(hasNetworkConsumer({ source: 'acme-corp-relay', claimedElsewhere: true }), true);
+		assert.equal(
+			mayRetireSkipMarked(`${FOREIGN}.txt`, '[no-send]', noneOwned,
+				() => ({ source: 'acme-corp-relay', claimedElsewhere: true })),
+			false, 'a claimed result was retired because its label was not on a list');
+	});
+
+	it('the default gateway label with no explicit source is covered', () => {
+		// PROVIDER falls back to the literal 'remote'.
+		assert.equal(hasNetworkConsumer({ source: 'remote' }), true);
+	});
+
+	it('an unknown label with NO claim stays local', () => {
+		// The ledger is authoritative-positive only. Absence of a claim is not
+		// proof of absence of a consumer, so the label net still applies —
+		// but an unrecognised label with no claim is treated as local, which
+		// is what keeps every local family retirable without being named.
+		assert.equal(hasNetworkConsumer({ source: 'events-promotion', claimedElsewhere: false }), false);
+		assert.equal(
+			mayRetireSkipMarked('task-taskify-1.txt', '[no-send]', noneOwned,
+				() => ({ source: 'events-promotion', claimedElsewhere: false })),
+			true);
+	});
+
+	it('a claim on a LOCAL-looking source is still foreign', () => {
+		assert.equal(hasNetworkConsumer({ source: 'cron', claimedElsewhere: true }), true);
+	});
+
+	it('a claim outranks a MISSING source line — this pins the order', () => {
+		// The only input that distinguishes the two orderings. Checking the
+		// label first returns local for (source: null, claimed), retiring a
+		// result its claimant is about to deliver. Without this case the
+		// ordering is unpinned and a reader cannot tell it is deliberate.
+		assert.equal(hasNetworkConsumer({ source: null, claimedElsewhere: true }), true);
+		assert.equal(
+			mayRetireSkipMarked(`${FOREIGN}.txt`, '[no-send]', noneOwned,
+				() => ({ source: null, claimedElsewhere: true })),
+			false, 'a claimed result with no source line was retired');
+	});
+});

--- a/tests/task-bridge-skip-marker-ownership.test.ts
+++ b/tests/task-bridge-skip-marker-ownership.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mayRetireSkipMarked } from '../src/skip_marker_ownership.js';
+
+// results/ is shared by every consumer. Matching `task-*` plus a skip marker
+// retired results this bridge never dispatched: the gateway's bookkeeping
+// [no-send] was archived here, its tid left the owning bridge's in-flight
+// ledger, and a substantive reply written to that path minutes later was
+// never read by anyone. Measured on a peer host: five replies (2-5 KB) sat
+// resident while the archived copy was the tiny [no-send] note.
+
+const OWN = 'task-0000000000000000aa';
+const OTHERS = 'task-0000000000000000bb';
+const owns = (id: string) => id === OWN;
+
+describe('task-bridge — only retire skip-marked results this bridge owns', () => {
+	it('retires its own dispatched task', () => {
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '[no-send]\nbookkeeping', owns), true);
+	});
+
+	it('leaves another consumer\'s result alone', () => {
+		assert.equal(
+			mayRetireSkipMarked(`${OTHERS}.txt`, '[no-send]\nbookkeeping', owns), false,
+			'archiving a result this bridge never dispatched strands the owner\'s reply'
+		);
+	});
+
+	it('honours [REPLIED] under the same ownership rule', () => {
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '[REPLIED]', owns), true);
+		assert.equal(mayRetireSkipMarked(`${OTHERS}.txt`, '[REPLIED]', owns), false);
+	});
+
+	it('ignores unmarked results even when owned', () => {
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, 'the actual reply', owns), false);
+	});
+
+	it('ignores non-task files', () => {
+		assert.equal(mayRetireSkipMarked('proactive-1.txt', '[no-send]', () => true), false);
+	});
+
+	it('matches the marker case-insensitively and after leading space', () => {
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '  [NO-SEND] x', owns), true);
+	});
+});

--- a/tests/task-bridge-skip-markers.test.ts
+++ b/tests/task-bridge-skip-markers.test.ts
@@ -85,18 +85,19 @@ describe('task-bridge.ts — [no-send]/[REPLIED] skip-marker handling (#1381)', 
 		);
 	});
 
-	it('skip-marker guard has file.startsWith("task-") guard (mirrors [deduped:] block)', () => {
-		// The guard must only apply to task files, not proactive-result-*.txt or
-		// other result files that could have marker-like content. Without this guard
-		// a proactive-result file beginning with [no-send] would be swallowed here
-		// instead of reaching discord-bridge's poll_proactive delivery path.
-		// Look backward from the log line to find the enclosing if-condition.
-		const beforeSkip = SRC.slice(0, SRC.indexOf('has skip marker'));
+	it('skip-marker guard delegates to the ownership predicate', () => {
+		// The `task-` prefix check moved into src/skip_marker_ownership.ts along
+		// with the ownership gate it was missing (#3018): a prefix match is not
+		// ownership, and results/ is shared by every consumer. The behavior is
+		// tested directly in task-bridge-skip-marker-ownership.test.ts; here we
+		// only pin that the branch still routes through that predicate.
+		const after = afterBlock('has skip marker; archiving silently');
+		const beforeSkip = SRC.slice(0, SRC.length - after.length);
 		const lastIfBeforeSkip = beforeSkip.lastIndexOf('if (');
 		const ifCondition = SRC.slice(lastIfBeforeSkip, lastIfBeforeSkip + 120);
 		assert.ok(
-			ifCondition.includes('file.startsWith('),
-			`skip-marker if-condition must include file.startsWith() guard; got: ${ifCondition.slice(0, 80)}`
+			ifCondition.includes('mayRetireSkipMarked('),
+			`skip-marker if-condition must delegate to mayRetireSkipMarked(); got: ${ifCondition.slice(0, 80)}`
 		);
 	});
 

--- a/tests/task-bridge-stop-at-task-delimiter.test.ts
+++ b/tests/task-bridge-stop-at-task-delimiter.test.ts
@@ -121,7 +121,7 @@ describe('_taskOrigin honors the same task: delimiter', () => {
 			'source: ag2space',
 			'task: hi',
 		].join('\n'));
-		assert.deepEqual(_taskOrigin('task-origin-1'), { source: 'ag2space' });
+		assert.equal(_taskOrigin('task-origin-1').source, 'ag2space');
 	});
 
 	it('a body line cannot forge a local source', () => {
@@ -131,13 +131,13 @@ describe('_taskOrigin honors the same task: delimiter', () => {
 			'task: x',
 			'source: cron',
 		].join('\n'));
-		assert.deepEqual(_taskOrigin('task-origin-2'), { source: 'ag2space' },
+		assert.equal(_taskOrigin('task-origin-2').source, 'ag2space',
 			'a forged local source would let a foreign result be retired');
 	});
 
 	it('no source: line is a local task, not an unknown one', () => {
 		writeTask('task-origin-3', ['id: task-origin-3', 'task: x'].join('\n'));
-		assert.deepEqual(_taskOrigin('task-origin-3'), { source: null });
+		assert.equal(_taskOrigin('task-origin-3').source, null);
 	});
 
 	it('no task file at all is unknown, which fails toward keeping', () => {

--- a/tests/task-bridge-stop-at-task-delimiter.test.ts
+++ b/tests/task-bridge-stop-at-task-delimiter.test.ts
@@ -18,7 +18,7 @@ process.env.SUTANDO_WORKSPACE = TMP;
 process.env.SUTANDO_TEST_MODE = '1';  // v0.8: opt-in env-honor
 mkdirSync(join(TMP, 'tasks'), { recursive: true });
 
-const { _isVoiceTask } = await import('../src/task-bridge.js');
+const { _isVoiceTask, _taskOrigin } = await import('../src/task-bridge.js');
 
 // Closes the residual half of PR #982 that @qingyun-wu flagged on the
 // post-merge review:
@@ -107,5 +107,40 @@ describe('_isVoiceTask honors task: delimiter', () => {
 			'task: hello',
 		].join('\n'));
 		assert.equal(_isVoiceTask('task-defensive'), true);
+	});
+});
+
+// _taskOrigin shares _readTaskHeader with _isVoiceTask, so the delimiter that
+// protects voice classification protects the retirement decision too. The
+// dangerous direction here is the opposite one: forging a LOCAL source would
+// let a foreign consumer's result be archived out from under it.
+describe('_taskOrigin honors the same task: delimiter', () => {
+	it('reads a header source', () => {
+		writeTask('task-origin-1', [
+			'id: task-origin-1',
+			'source: ag2space',
+			'task: hi',
+		].join('\n'));
+		assert.deepEqual(_taskOrigin('task-origin-1'), { source: 'ag2space' });
+	});
+
+	it('a body line cannot forge a local source', () => {
+		writeTask('task-origin-2', [
+			'id: task-origin-2',
+			'source: ag2space',
+			'task: x',
+			'source: cron',
+		].join('\n'));
+		assert.deepEqual(_taskOrigin('task-origin-2'), { source: 'ag2space' },
+			'a forged local source would let a foreign result be retired');
+	});
+
+	it('no source: line is a local task, not an unknown one', () => {
+		writeTask('task-origin-3', ['id: task-origin-3', 'task: x'].join('\n'));
+		assert.deepEqual(_taskOrigin('task-origin-3'), { source: null });
+	});
+
+	it('no task file at all is unknown, which fails toward keeping', () => {
+		assert.equal(_taskOrigin('task-origin-gone'), null);
 	});
 });


### PR DESCRIPTION
## What

`src/task-bridge.ts` retired skip-marked results it never dispatched, stranding other consumers' replies.

It matched **any** `results/task-*.txt` whose body starts with `[no-send]` / `[REPLIED]` and archived it. The enclosing loop gates only on `_deliveredResults` and the `voice-` prefix — no ownership check on that path. `results/` is shared by every consumer.

**The same file already knew better.** `startRelayResultWatcher` at `:702` carries the identical gate — `if (!_pendingTasks.has(taskId)) continue;` — over the same key space. Two watchers in one file, one scoped and one not: the divergence is the defect, not a design choice.

## Why it matters — measured

Gateway writes a bookkeeping `[no-send]` → **this** bridge archives it → the tid leaves the owning bridge's ledger → the substantive reply written to that path minutes later is read by nobody. Five replies of 2–5 KB were resident behind 10–996 B notes, one opening *"Here is my reply to Air, for delivery to the room"*, with zero archive hits for their text.

## Two decisions, not one

- `isSkipMarked()` — **universal**: a marked body is never narrated, delivered or forwarded by anyone.
- `mayRetireSkipMarked()` — **ownership-scoped**: only the dispatching consumer archives.

Gating both on one predicate made a foreign marked result *fall through* and get spoken aloud — worse than the silent mis-archive. A marked result now never falls through: retire if ours, else `continue` and leave the files for the owner.

## How ownership is decided

```
retire  ⟺  isOwn(id)  ∨  ¬hasNetworkConsumer(originOf(id))
```

`hasNetworkConsumer` asks whether some **other** consumer will deliver and archive this result, from two kinds of evidence in this order:

1. **A durable claim** — the tid is in a consumer's persisted in-flight ledger (`<workspace>/state/remote-task-inflight*.json`). Authoritative, and independent of any label.
2. **A source label** — for consumers whose in-flight set is only in memory. **This list is explicitly not closed:** the gateway writes `source: {task.source or PROVIDER}` with `PROVIDER` from `$REMOTE_TASK_PROVIDER`, so an operator can emit a label no list anticipates. That is precisely why the claim check comes first.

Order is load-bearing: label-first returns *local* for `(source: null, claimed)` and would retire a result its claimant is about to deliver.

**Why not enumerate the local families instead?** That was the first approach and it cannot be right. Measured the same day on two hosts, the missing local families were **disjoint** — `task-taskify-` (94) on one, `task-workstream-grouping-` (281) on the other, and `task-chat-` (documented in CLAUDE.md) on neither list. The local set is host-dependent and grows whenever a skill starts writing tasks; the set *with* a consumer is small and changes only when someone writes a bridge.

**Scope of the ledger read.** Only `<workspace>/state`. A consumer configured against another tree writes its *results* there too (`_dirs.py` resolves task/result/state independently, and sutando injects all three together), so its claims describe files that never reach this scan — counting them could only mistake a foreign namespace's claim for ownership here.

Unknown origin fails toward **keeping**: wrongly retiring strands an owner reply, wrongly keeping costs a file, and suppression is universal either way.

Origin is read through the header reader `_isVoiceTask` already used, extracted as `_readTaskHeader` so there is one parser. That matters beyond dedup: the stop-at-`task:` delimiter that stops a body forging `channel_id: local-voice` equally stops one forging `source: cron` — the direction that would strand a foreign reply.

## Tests

Behavioral, in a dependency-light module — `task-bridge.ts` pulls the whole voice stack, which is why the pre-existing skip-marker test asserts over source text. That test is retargeted at the delegation rather than deleted.

```
as shipped                              20 module + 9 ledger + 9 delimiter + 8 retargeted
ownership leg removed                        1 fail
claim check removed                          3 fail
claim checked AFTER the label                1 fail
'remote' dropped from the label set          1 fail
unknown origin fails OPEN                    1 fail
suppression scoped to ownership              9 fail
foreign-tree claim counted as ownership      1 fail
BOTH containment guards removed              1 fail
_claimedElsewhere made inert                 6 fail
```

Every arm above was verified to *land* before its result was read — one earlier attempt aimed at text a later commit had already reverted, and passed for that reason.

**Not claimed:** the containment case pins that containment exists, not which of two redundant guards supplies it — removing either alone still passes, by design.

review-checks: PASS. CI green at `6d3e1c31` (16/16).

— @qingyun-air.agent:ag2.space
