### PR TITLE
fix(health-check): an absent onboarding timestamp read as the whole epoch

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2369,7 +2369,11 @@ def check_onboarding_status() -> "dict | None":
         if not isinstance(data, dict) or not isinstance(data.get("rows"), dict):
             return {"name": name, "status": "warn", "detail": "onboarding-status.json unreadable"}
         rows = data["rows"]
-        todo = sorted(k for k, v in rows.items() if isinstance(v, dict) and v.get("state") == "todo")
+        # Carry each row's own detail: "gateway" alone cannot distinguish "not
+        # running" from a reconnect, and the writer populates it to say which.
+        todo = [f"{k} ({d})" if (d := (v.get("detail") or "").strip()) else k
+                for k, v in sorted(rows.items())
+                if isinstance(v, dict) and v.get("state") == "todo"]
         age_s = max(0, int(time.time()) - int(data.get("updated_at", 0) or 0))
     except (ValueError, OSError, TypeError):
         return {"name": name, "status": "warn", "detail": "onboarding-status.json unreadable"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2370,8 +2370,8 @@ def check_onboarding_status() -> "dict | None":
             return {"name": name, "status": "warn", "detail": "onboarding-status.json unreadable"}
         rows = data["rows"]
         # Carry each row's own detail: "gateway" alone cannot distinguish "not
-        # running" from a reconnect, and the writer populates it to say which.
-        todo = [f"{k} ({d})" if (d := (v.get("detail") or "").strip()) else k
+        # running" from a reconnect. `str()` because a separate repo writes this.
+        todo = [f"{k} ({d})" if (d := str(v.get("detail") or "").strip()[:120]) else k
                 for k, v in sorted(rows.items())
                 if isinstance(v, dict) and v.get("state") == "todo"]
         age_s = max(0, int(time.time()) - int(data.get("updated_at", 0) or 0))

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2343,6 +2343,12 @@ def check_memory_sync() -> dict:
     return {"name": name, "status": "ok", "detail": "initialized, never fetched"}
 
 
+def _age_phrase(age_s) -> str:
+    """None means the writer gave no usable timestamp — say so rather than
+    printing a number a reader cannot tell apart from a real age."""
+    return "age unknown" if age_s is None else f"{age_s}s ago"
+
+
 def check_onboarding_status() -> "dict | None":
     """Read the desktop checklist's agent surface (onboarding v2 spec,
     ag2space-cinny-desktop#165 S4).
@@ -2374,16 +2380,20 @@ def check_onboarding_status() -> "dict | None":
         todo = [f"{k} ({d})" if (d := str(v.get("detail") or "").strip()[:120]) else k
                 for k, v in sorted(rows.items())
                 if isinstance(v, dict) and v.get("state") == "todo"]
-        age_s = max(0, int(time.time()) - int(data.get("updated_at", 0) or 0))
+        # Absent/null/0 updated_at is UNKNOWN, not the epoch — int(None or 0)
+        # rendered the whole unix time as an age (~56 years) on both lines.
+        _updated = int(data.get("updated_at", 0) or 0)
+        age_s = max(0, int(time.time()) - _updated) if _updated > 0 else None
     except (ValueError, OSError, TypeError):
         return {"name": name, "status": "warn", "detail": "onboarding-status.json unreadable"}
     if todo:
         return {
             "name": name,
             "status": "warn",
-            "detail": f"user-facing setup incomplete: {', '.join(todo)} (as of {age_s}s ago)",
+            "detail": f"user-facing setup incomplete: {', '.join(todo)} ({_age_phrase(age_s)})",
         }
-    return {"name": name, "status": "ok", "detail": f"all checklist rows satisfied ({age_s}s ago)"}
+    return {"name": name, "status": "ok",
+            "detail": f"all checklist rows satisfied ({_age_phrase(age_s)})"}
 
 
 def check_host_subtrees() -> dict:

--- a/tests/onboarding-status-check.test.py
+++ b/tests/onboarding-status-check.test.py
@@ -132,5 +132,49 @@ class OnboardingStatusCheckTest(unittest.TestCase):
         self.assertIn("core", out["detail"])
         self.assertNotIn("core (", out["detail"])
 
+    # --- age rendering: an unknown timestamp must not read as a number -------
+
+    def test_a_missing_updated_at_is_unknown_not_the_whole_epoch(self):
+        """`int(None or 0)` made the age the unix time itself — the warn line
+        read "as of 1786962010s ago" (~56 years) as though it were measured."""
+        for payload in ({"rows": {"gateway": {"state": "todo"}}},
+                        {"updated_at": None, "rows": {"gateway": {"state": "todo"}}},
+                        {"updated_at": 0, "rows": {"gateway": {"state": "todo"}}}):
+            self._with_workspace(payload)
+            out = hc.check_onboarding_status()
+            self.assertEqual(out["status"], "warn", out)
+            self.assertIn("age unknown", out["detail"], payload)
+            self.assertNotIn("s ago", out["detail"], payload)
+
+    def test_the_ok_line_carries_the_same_guard(self):
+        """The all-satisfied line rendered it too, and that is the line a reader
+        is least likely to question — it says everything is fine."""
+        self._with_workspace({"updated_at": 0, "rows": {"gateway": {"state": "done"}}})
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "ok", out)
+        self.assertIn("age unknown", out["detail"])
+
+    def test_a_real_timestamp_still_renders_as_seconds(self):
+        """Control: without this, returning "age unknown" unconditionally passes
+        both tests above while destroying the age the probe exists to report."""
+        import time
+        for state, want_status in (("todo", "warn"), ("done", "ok")):
+            self._with_workspace({"updated_at": int(time.time()) - 42,
+                                  "rows": {"gateway": {"state": state}}})
+            out = hc.check_onboarding_status()
+            self.assertEqual(out["status"], want_status, out)
+            self.assertIn("s ago", out["detail"])
+            self.assertNotIn("age unknown", out["detail"])
+
+    def test_an_unusable_updated_at_TYPE_still_reads_as_unreadable(self):
+        """Pins what this change does NOT touch: a non-numeric updated_at keeps
+        raising into the existing handler rather than degrading to unknown."""
+        self._with_workspace({"updated_at": {"a": 1},
+                              "rows": {"gateway": {"state": "todo"}}})
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("unreadable", out["detail"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/onboarding-status-check.test.py
+++ b/tests/onboarding-status-check.test.py
@@ -89,5 +89,25 @@ class OnboardingStatusCheckTest(unittest.TestCase):
         self.assertIn("unreadable", out["detail"])
 
 
+    def test_a_todo_row_carries_its_own_detail(self):
+        """`gateway` alone cannot distinguish "not running" from a reconnect —
+        the writer populates `detail` to say which, and it was being dropped."""
+        self._with_workspace(
+            {
+                "updated_at": 0,
+                "rows": {
+                    "gateway": {"state": "todo",
+                                "detail": "gateway process up, relay not connected"},
+                    "core": {"state": "todo"},
+                },
+            }
+        )
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("gateway (gateway process up, relay not connected)", out["detail"])
+        # A row with no detail still renders as the bare name.
+        self.assertIn("core", out["detail"])
+        self.assertNotIn("core (", out["detail"])
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/onboarding-status-check.test.py
+++ b/tests/onboarding-status-check.test.py
@@ -89,6 +89,29 @@ class OnboardingStatusCheckTest(unittest.TestCase):
         self.assertIn("unreadable", out["detail"])
 
 
+    def test_a_non_string_detail_warns_rather_than_raising(self):
+        """The Console (a separate repo) writes this file, which is why every
+        other shape here is guarded. `AttributeError` is not in the except tuple
+        and the call site has ZERO enclosing try blocks, so a raise here loses
+        every other check's result — one bad optional field becomes an outage."""
+        for bad in (3, {"a": 1}, ["x"], True):
+            self._with_workspace(
+                {"updated_at": 0, "rows": {"gateway": {"state": "todo", "detail": bad}}}
+            )
+            out = hc.check_onboarding_status()
+            self.assertEqual(out["status"], "warn", f"detail={bad!r}: {out}")
+            self.assertIn("gateway", out["detail"])
+
+    def test_a_verbose_detail_is_clamped(self):
+        """One chatty row must not dominate the line the owner scans."""
+        self._with_workspace(
+            {"updated_at": 0, "rows": {"gateway": {"state": "todo", "detail": "z" * 400}}}
+        )
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertNotIn("z" * 200, out["detail"])
+        self.assertIn("z" * 120, out["detail"])
+
     def test_a_todo_row_carries_its_own_detail(self):
         """`gateway` alone cannot distinguish "not running" from a reconnect —
         the writer populates `detail` to say which, and it was being dropped."""


### PR DESCRIPTION
**Stacked on #2995 — merge #2995 first.** Same function and same test file; this branch is
#2995's head plus one commit. Found by @sonichi while reviewing #2995, who called it correctly as
adjacent rather than part of it. I'll rebase and rerun checks once the parent lands.

## The defect

`src/health-check.py` (main:2400):

```python
age_s = max(0, int(time.time()) - int(data.get("updated_at", 0) or 0))
```

A missing, null or zero `updated_at` becomes `0`, so the age is the unix time itself.
`max(0, ...)` guards only the negative direction.

## Before — measured at the parent commit (`8a1b718b`)

```
updated_at missing     -> user-facing setup incomplete: gateway (as of 1786962010s ago)
updated_at null        -> user-facing setup incomplete: gateway (as of 1786962010s ago)
updated_at 0           -> user-facing setup incomplete: gateway (as of 1786962010s ago)
all rows ok, ua 0      -> all checklist rows satisfied (1786962010s ago)
updated_at now-42      -> user-facing setup incomplete: gateway (as of 42s ago)
```

1,786,962,010 seconds is ~56 years, rendered in the same slot as the real `42s ago`.

**One thing the review did not cover: the `ok` line carries it too.** That is the line a reader is
least likely to question — it says everything is fine, and the age beside it is the only thing
that could say otherwise.

## After

```
updated_at missing     -> [warn] user-facing setup incomplete: gateway (age unknown)
updated_at null        -> [warn] user-facing setup incomplete: gateway (age unknown)
updated_at 0           -> [warn] user-facing setup incomplete: gateway (age unknown)
all rows ok, ua 0      -> [ok]   all checklist rows satisfied (age unknown)
updated_at now-42      -> [warn] user-facing setup incomplete: gateway (42s ago)
all ok, now-42         -> [ok]   all checklist rows satisfied (42s ago)
garbage type           -> [warn] onboarding-status.json unreadable
```

The last row is deliberate scope: a **non-numeric** `updated_at` still raises into the existing
handler and reads `unreadable`, exactly as before. This changes the value semantics of an
absent/zero field only, and a test pins that.

## Tests — 10 → 14, with a falsifier and a control

```
$ git checkout src/health-check.py     # parent source, new tests
FAILED (failures=2)
  test_a_missing_updated_at_is_unknown_not_the_whole_epoch
  test_the_ok_line_carries_the_same_guard

$ # restore the fix
Ran 14 tests ... OK

$ git diff | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

`test_a_real_timestamp_still_renders_as_seconds` is the control: without it, returning
`"age unknown"` unconditionally would pass both new tests while destroying the age the probe
exists to report.

## Scope, honestly

Like the review, I could **not** establish that a live writer omits the field. On this host
`onboarding-status.json` is present and populated (`all checklist rows satisfied (133s ago)`), and
the writer named in the docstring is in another repo. So this is a demonstrated render on a
defensive path, not a confirmed live miss.

Same family as #2991 (`-0.2h ago`) and #2994 (`oldest 0.0h` for an unknown age): an unknown
quantity printed as a confident number in the slot where a real measurement goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wqEvhuA4hY4casgMzHzNm