### PR TITLE
docs(review): cut the diff against the merge-base, not against main

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -144,6 +144,20 @@ and loads whichever repo it reviews.
     The tell that you are in this pattern: your test suite grows by exactly one case per
     round, and each new case is the previous one with a single field changed.
 
+11. **Cut the diff against the merge-base, not against `main`.** `git diff origin/main <pr>`
+    on a branch that is behind renders `main`'s own newer commits as *removals* by the PR,
+    so a reviewer reads deletions the author never wrote. Use
+    `git diff $(git merge-base origin/main <pr>) <pr>`, and for a stacked PR review the
+    child-only commit as well as the cumulative result — the child layer is what this PR
+    is being asked to add.
+    *Grounded by:* #3020 (2026-08-17). Diffing it against `main` showed ~20 removed lines
+    in `check_cron_runner`, a function the PR does not touch; the topic diff against its
+    merge-base is 2 files, +105/-4. Verify a stated stack rather than trusting the body:
+    `git merge-base --is-ancestor <parent-head> <child>` confirmed #2995's head really is
+    an ancestor, which is what makes "merge the parent first" load-bearing rather than
+    a courtesy — and what makes `--delete-branch` on the parent dangerous while the child
+    is open.
+
 ## Checks (machine-readable — consumed by scripts/review-checks.sh)
 
 ```yaml


### PR DESCRIPTION
REVIEW.md-only, per CLAUDE.md's rule that a review lesson is a PR to
REVIEW.md and nowhere else.

Measured on #3020 today. `git diff origin/main <pr>` on a branch that is
behind renders main's own newer commits as REMOVALS by the PR: it showed
~20 deleted lines in `check_cron_runner`, a function #3020 does not touch,
while the topic diff against its merge-base is 2 files, +105/-4. A reviewer
reading that is reviewing main's history as if the author had written it.

The stacked half is the same mistake one level up. #3020's body says
"merge #2995 first"; `git merge-base --is-ancestor <2995-head> <3020>`
confirms it rather than trusting the body, and that is what makes the
ordering load-bearing — merging the child first carries the parent's
commits in under the child's title, and `--delete-branch` on the parent
while the child is open drops the child's base.

Verified the edit does not break REVIEW.md's consumers:

    scripts/review-checks.sh (fed this diff)  -> rc=0, PASS
    yaml `checks:` block still parses          -> True
    review-preflight.py --guide REVIEW.md      -> prints it (4 hits on "merge-base")

Note review-checks.sh exits 2 on empty input rather than passing — worth
knowing when running it by hand; it must be fed a diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)