### PR TITLE
fix(watch-tasks-stream): close the post-signal promotion window (#2934)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -598,6 +598,11 @@ fallback_outstanding_handlers() {
 cleanup() {
   [ "${CLEANING_UP:-0}" -eq 0 ] || return
   CLEANING_UP=1
+  # FIRST, before any release/kill/sweep work: the drain and queue guards read
+  # this file, so anything they do before it exists can still promote a worker.
+  if [ -n "${DISPATCH_DIR:-}" ] && [ -d "$DISPATCH_DIR" ]; then
+    : > "$DISPATCH_DIR/shutting-down"
+  fi
   # EXIT and signal traps share this function. Disarm EXIT before spawning
   # cleanup helpers so a subshell cannot recursively re-enter the trap.
   trap - EXIT


### PR DESCRIPTION
Implements @sonichi's diagnosis and safety inventory from #2934 — the ordering candidate, not the
parsing one. The credit for the root cause and for establishing that nothing in `cleanup` depends on
`shutting-down` being absent is entirely theirs; what I add is the before/after measurement they said
they could not produce.

## The window

`shutting-down` is written at `:479`, inside `fallback_outstanding_handlers`, which `cleanup` calls
after disarming traps, releasing the PID sentinel and killing fswatch. The drain guards (`:292`,
`:294`) and the queue guard (`:354`) all read that file, so every drain between signal delivery and
`:479` sees no sentinel and promotes normally. On the Linux failure that is a third worker starting
75 ms into teardown against `TASK_HANDLER_WORKERS=2`.

## The change

```bash
 cleanup() {
   [ "${CLEANING_UP:-0}" -eq 0 ] || return
   CLEANING_UP=1
+  # FIRST, before any release/kill/sweep work: the drain and queue guards read
+  # this file, so anything they do before it exists can still promote a worker.
+  if [ -n "${DISPATCH_DIR:-}" ] && [ -d "$DISPATCH_DIR" ]; then
+    : > "$DISPATCH_DIR/shutting-down"
+  fi
```

Same guard `fallback_outstanding_handlers` already applies at `:478`. The `:479` write stays — an
idempotent truncate, per the inventory.

## Before / after — measured, n=8 each

Time from SIGTERM delivery to `shutting-down` existing, polled at 1 ms from outside the watcher:

```
with fix   n=8  min 1.8  median 1.8  max 2.0    ms
without    n=8  min 7.8  median 17.3 max 20.1   ms
overlap: NONE — max(with) < min(without)
```

The "without" set is visibly **bimodal** (7.8 twice, 15.8–20.1 six times), so the median is a
property of this host's scheduling, not a constant — I am quoting the range, not a single number.
The point is the separation, and that 7.8–20.1 ms is the same order as the 75 ms window measured on
the failing Linux run.

## What this is NOT: a race reproduction

Stated plainly because it is the weakest part. The race does not fire on macOS (100 clean trials on
`test_shutdown_falls_back_without_surviving_workers` per #2934), and I have no Linux vantage point
here — docker/colima/podman/lima/orb are all absent. So the measurement above shows the **window
narrowing**, not a failing-to-passing test. The mutation control lives in the Linux CI lane.

**Two test designs I tried and abandoned, so the next person doesn't repeat them:**

1. **Fake `fswatch` whose TERM handler checks for the sentinel.** Fails when the test signals the
   process *group* — fswatch receives the signal directly at delivery time, before `cleanup` has done
   anything, so it reports `absent` on fixed and unfixed alike.
2. **Same probe, signalling only the watcher** (`os.kill(pid)` not `killpg`). Now reports `present`
   on both, because the fswatch child ends up observing the end-of-cleanup group TERM — which is
   after `:479` — rather than `cleanup`'s targeted kill.

Both are the probe changing what it measures. The latency poll above is the only seam I found that
needs no cooperation from inside the script. A timing-bound assertion could be written from it, but
#2931 already tried widening a deadline and the flake survived, so I did not add one — a bound would
be green on both sides on any host where the race doesn't fire, i.e. exactly the hosts developers use.

## Regression checks

```
tests/task-workstream-session-worker.test.py          OK
tests/watch-tasks-stream-dead-worker-reap.test.py     OK
tests/watch-tasks-stream-sentinel-ownership.test.py   OK

$ git diff | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

Companion, independent of this one: **#3024** instruments the *hang* leg of #2934, which is a
different failure from the `<= 2` breach this fixes. Neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wqEvhuA4hY4casgMzHzNm