### PR TITLE
fix(gateway): long-poll catch includes socket.timeout — py3.9 has no TimeoutError alias

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2825,9 +2825,9 @@ def main() -> None:
             try:
                 resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}", timeout=POLL_WAIT + 10)
                 last_poll_ok = time.time()
-            except TimeoutError:
-                # Read timeout only — a connect failure arrives as URLError and
-                # still takes the outage path below.
+            except (TimeoutError, socket.timeout):
+                # Read timeout only (URLError takes the outage path below).
+                # socket.timeout only aliases TimeoutError on 3.10+, not 3.9.
                 if not _poll_timeout_is_empty(last_poll_ok, time.time()):
                     raise
                 resp = {"tasks": []}

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -1816,8 +1816,26 @@ def main() -> int:
     _poll_call = _loop.split('"GET", f"/v1/tasks?wait=', 1)[-1][:400]
     check("_poll_timeout_is_empty" in _poll_call,
           "poll-timeout: the poll call site consults the policy")
-    check("except TimeoutError" in _poll_call,
+    check("except (TimeoutError, socket.timeout)" in _poll_call,
           "poll-timeout: the catch is scoped to the poll, not the whole iteration")
+    # Py3.9 portability: socket.timeout aliases TimeoutError only on 3.10+.
+    # On stock macOS /usr/bin/python3 (3.9.6, a supported runtime) it is a bare
+    # OSError subclass, so a catch spelled `except TimeoutError` misroutes a
+    # held long poll to the unexpected-error backoff. CI interpreters are all
+    # 3.10+, where an execution probe cannot go red (the alias makes any
+    # socket.timeout injection pass) — so pin the catch tuple itself via AST:
+    # both names must appear in the poll call's except clause.
+    import ast
+    _clause = _poll_call.split("except ", 1)[-1].split(":", 1)[0]
+    _t = ast.parse(_clause, mode="eval").body
+    _caught = {
+        e.id if isinstance(e, ast.Name)
+        else f"{e.value.id}.{e.attr}" if isinstance(e, ast.Attribute)
+        else "?"
+        for e in (_t.elts if isinstance(_t, ast.Tuple) else [_t])}
+    check(_caught >= {"TimeoutError", "socket.timeout"},
+          "poll-timeout: catch tuple names BOTH TimeoutError and socket.timeout "
+          f"(py3.9 shape) — got {sorted(_caught)}")
     check("raise" in _poll_call,
           "poll-timeout: past the grace it re-raises into the existing outage path")
 

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -1818,13 +1818,8 @@ def main() -> int:
           "poll-timeout: the poll call site consults the policy")
     check("except (TimeoutError, socket.timeout)" in _poll_call,
           "poll-timeout: the catch is scoped to the poll, not the whole iteration")
-    # Py3.9 portability: socket.timeout aliases TimeoutError only on 3.10+.
-    # On stock macOS /usr/bin/python3 (3.9.6, a supported runtime) it is a bare
-    # OSError subclass, so a catch spelled `except TimeoutError` misroutes a
-    # held long poll to the unexpected-error backoff. CI interpreters are all
-    # 3.10+, where an execution probe cannot go red (the alias makes any
-    # socket.timeout injection pass) — so pin the catch tuple itself via AST:
-    # both names must appear in the poll call's except clause.
+    # 3.9 has no socket.timeout->TimeoutError alias; CI is 3.10+ where an
+    # execution probe cannot go red, so pin the catch tuple itself via AST.
     import ast
     _clause = _poll_call.split("except ", 1)[-1].split(":", 1)[0]
     _t = ast.parse(_clause, mode="eval").body

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import shutil
+import socket
 import sys
 import tempfile
 import time
@@ -1802,8 +1803,9 @@ def main() -> int:
                 _r.read()
         except Exception as e:  # noqa: BLE001 — the type IS the assertion
             raised = e
-        check(isinstance(raised, TimeoutError),
-              "poll-timeout: a held long poll raises TimeoutError (the type the bridge catches)")
+        check(isinstance(raised, (TimeoutError, socket.timeout)),
+              "poll-timeout: a held long poll raises a caught timeout type "
+              "(socket.timeout on 3.9, TimeoutError via the alias on 3.10+)")
         check(not isinstance(raised, urllib.error.URLError),
               "poll-timeout: it is NOT a URLError, so connect failures stay on the outage path")
     finally:


### PR DESCRIPTION
## What

The gateway long-poll's read-timeout catch now names `socket.timeout` alongside `TimeoutError`. One line in `remote_gateway_bridge.py`, plus the harness pin.

## Why

`socket.timeout` only became an alias of `TimeoutError` in Python 3.10. On stock macOS `/usr/bin/python3` (3.9.6 — a supported runtime for the bridge), it is a bare `OSError` subclass, so a held long poll that times out at the socket layer misses the empty-poll path and takes the unexpected-error 1-second backoff instead — every poll cycle.

Confirmed the bug exists on `upstream/main` (this branch is cut from it; the flagged hunk is untouched by any open PR — notably it is byte-identical on sonichi/sutando#3006, where a reviewer first raised it against the wrong PR).

## Evidence

Interpreter semantics on this host:
```
$ /usr/bin/python3 --version
Python 3.9.6
$ /usr/bin/python3 -c "import socket; print(issubclass(socket.timeout, TimeoutError))"
False
```

Behavior at the parent commit's catch shape vs this head, driven with `socket.timeout('timed out')` under 3.9.6:
```
py3.9  old catch: unexpected/backoff path
py3.9  new catch: empty-poll path
```

Harness (`src/remote-gateway-bridge.test.py`):
- at HEAD: `PASS — all checks green`
- mutant with the old `except TimeoutError:` spelling: `2 × FAIL poll-timeout` (the source pin and the new AST catch-tuple check both go red)

## Test-shape note

CI interpreters are all ≥3.10, where the alias makes any runtime `socket.timeout` injection pass regardless of the catch spelling — an execution probe is structurally green there and proves nothing. The regression therefore pins the catch tuple itself (AST-parsed from the live poll call site, not a file copy): both `TimeoutError` and `socket.timeout` must be named. That check is exactly as strong on 3.14 as on 3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
