### PR TITLE
feat(envelope): soak census — the measurement behind the enforcement-flip gate

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -139,6 +139,7 @@ One entry per agent-facing module.
 - **`task_archive.py`** — Task-file locator for archive calls (#933).
 - **`task_body_guard.py`** — Confine untrusted user message content before embedding it in a task file.
 - **`task_envelope.py`** — Task-envelope authentication: an HMAC stamp that makes access_tier a verified claim instead of an honor-system header.
+- **`task_envelope_census.py`** — Soak census for HMAC task envelopes: the read-only measurement behind the "writer census reaches zero" gate.
 - **`task_priority.py`** — Task priority taxonomy + readers.
 - **`task_workstreams.py`** — Durable inferred-workstream index and archive-backed task history.
 - **`telegram-bridge.py`** — Telegram bridge for Sutando — polls bot messages, writes to tasks/, sends replies from results/.

--- a/src/task_envelope_census.py
+++ b/src/task_envelope_census.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Soak census for HMAC task envelopes: the read-only measurement behind the
+"writer census reaches zero" gate.
+
+The #3014 rollout is soak-first: consumers warn on `unsigned` and only flip
+to enforcement once every live writer stamps. This tool produces that
+evidence — it verifies every task file in `tasks/` and `tasks/archive/`
+(bounded by --days against the id/header timestamp) and reports verdict
+counts plus a per-`source:` breakdown, so the remaining unsigned writers are
+named by source instead of guessed. Verification-only: uses `verify_text`
+(read-only `load_key`), never creates the key, never modifies a file.
+
+CLI: `task_envelope_census.py [--days N] [--json]`
+Exit 0 always (telemetry, not a gate); `--json` for machine readers.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from task_envelope import verify_text  # noqa: E402
+from workspace_default import resolve_workspace  # noqa: E402
+
+_ID_MS = re.compile(r"task-(\d{13})")
+
+
+def _task_epoch(name: str, text: str, mtime: float) -> float:
+    m = _ID_MS.search(name)
+    if m:
+        return int(m.group(1)) / 1000.0
+    for line in text.split("\n")[:6]:
+        if line.startswith("timestamp:"):
+            try:
+                from datetime import datetime, timezone
+                return datetime.fromisoformat(
+                    line.split(":", 1)[1].strip().replace("Z", "+00:00")
+                ).astimezone(timezone.utc).timestamp()
+            except ValueError:
+                break
+    return mtime
+
+
+def _source_of(text: str) -> str:
+    for line in text.split("\n")[:12]:
+        if line.startswith("source:"):
+            return line.split(":", 1)[1].strip() or "(empty)"
+    return "(none)"
+
+
+def census(workspace: Path | None = None, days: float = 7.0) -> dict:
+    ws = workspace or resolve_workspace()
+    cutoff = time.time() - days * 86400
+    verdicts: Counter = Counter()
+    by_source: dict = defaultdict(Counter)
+    scanned = 0
+    for d in (ws / "tasks", ws / "tasks" / "archive"):
+        if not d.is_dir():
+            continue
+        for p in d.glob("task-*.txt"):
+            try:
+                text = p.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            if _task_epoch(p.name, text, p.stat().st_mtime) < cutoff:
+                continue
+            scanned += 1
+            v = verify_text(text, ws)["verdict"]
+            verdicts[v] += 1
+            by_source[_source_of(text)][v] += 1
+    return {
+        "scanned": scanned,
+        "days": days,
+        "verdicts": dict(verdicts),
+        "by_source": {s: dict(c) for s, c in sorted(by_source.items())},
+        "unsigned_sources": sorted(
+            s for s, c in by_source.items() if c.get("unsigned", 0) > 0),
+    }
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--days", type=float, default=7.0)
+    ap.add_argument("--json", action="store_true")
+    # Explicit workspace: the default resolver is checkout-relative, which is
+    # wrong when this file is invoked from a worktree/bundle copy.
+    ap.add_argument("--workspace", type=Path, default=None)
+    args = ap.parse_args(argv[1:])
+    r = census(workspace=args.workspace, days=args.days)
+    if args.json:
+        print(json.dumps(r, indent=1))
+        return 0
+    print(f"envelope census — {r['scanned']} task file(s), last {r['days']:g}d")
+    for v in ("verified", "unsigned", "invalid", "unverifiable"):
+        if r["verdicts"].get(v):
+            print(f"  {v:12} {r['verdicts'][v]}")
+    for s, c in r["by_source"].items():
+        print(f"  source {s}: " + ", ".join(
+            f"{k}={n}" for k, n in sorted(c.items())))
+    if r["unsigned_sources"]:
+        print("  UNSIGNED writers still live (census gate not met): "
+              + ", ".join(r["unsigned_sources"]))
+    else:
+        print("  census gate MET within window — no unsigned writers")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/task_envelope_census.py
+++ b/src/task_envelope_census.py
@@ -59,10 +59,12 @@ def census(workspace: Path | None = None, days: float = 7.0) -> dict:
     verdicts: Counter = Counter()
     by_source: dict = defaultdict(Counter)
     scanned = 0
-    for d in (ws / "tasks", ws / "tasks" / "archive"):
+    # rglob: the archiver nests monthly dirs (tasks/archive/YYYY-MM/) — a
+    # flat glob silently drops those writers from the census (review blocker).
+    for d in (ws / "tasks",):
         if not d.is_dir():
             continue
-        for p in d.glob("task-*.txt"):
+        for p in sorted(d.rglob("task-*.txt")):
             try:
                 text = p.read_text(encoding="utf-8")
             except OSError:

--- a/src/task_envelope_census.py
+++ b/src/task_envelope_census.py
@@ -27,7 +27,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from task_envelope import verify_text  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 
-_ID_MS = re.compile(r"task-(\d{13})")
+# (?!\d): an id with MORE digits (e.g. an 18-digit gateway id) is not an
+# epoch — its first 13 digits parse as a far-future date, pinning it in-window.
+_ID_MS = re.compile(r"task-(\d{13})(?!\d)")
 
 
 def _task_epoch(name: str, text: str, mtime: float) -> float:

--- a/tests/task-envelope-census.test.py
+++ b/tests/task-envelope-census.test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Census contract: counts every verdict class, names unsigned writers by
+source, honors the day window against the immutable id timestamp (not
+mtime), and never mints a key (verification-only on keyless hosts)."""
+from __future__ import annotations
+
+import sys
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+import task_envelope as E  # noqa: E402
+import task_envelope_census as C  # noqa: E402
+
+
+def _write(ws: Path, name: str, body: str, sub: str = "tasks") -> Path:
+    d = ws / sub
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+class CensusContract(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory(prefix="census-ws-")
+        self.ws = Path(self._tmp.name)
+        (self.ws / "state" / "auth").mkdir(parents=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _now_id(self, suffix: str) -> str:
+        return f"task-{int(time.time()*1000)}{suffix}.txt"
+
+    def test_counts_and_unsigned_sources(self):
+        signed = E.stamp_text(
+            "id: task-1\ntask: t\nsource: ag2space\naccess_tier: owner\n",
+            self.ws)
+        _write(self.ws, self._now_id("1"), signed)
+        _write(self.ws, self._now_id("2"),
+               "id: task-2\ntask: t\nsource: discord\n")
+        tampered = signed.replace("task: t", "task: EVIL")
+        _write(self.ws, self._now_id("3"), tampered, sub="tasks/archive")
+        r = C.census(self.ws)
+        self.assertEqual(r["scanned"], 3)
+        self.assertEqual(r["verdicts"].get("verified"), 1)
+        self.assertEqual(r["verdicts"].get("unsigned"), 1)
+        self.assertEqual(r["verdicts"].get("invalid"), 1)
+        self.assertEqual(r["unsigned_sources"], ["discord"])
+
+    def test_window_uses_id_epoch_not_mtime(self):
+        old_ms = int((time.time() - 30 * 86400) * 1000)
+        _write(self.ws, f"task-{old_ms}.txt",
+               "id: task-old\ntask: t\nsource: voice\n")
+        r = C.census(self.ws, days=7)
+        self.assertEqual(r["scanned"], 0,
+                         "fresh mtime must not resurrect an old task id")
+
+    def test_keyless_host_reports_unverifiable_and_mints_nothing(self):
+        signed = E.stamp_text("id: task-9\ntask: t\nsource: x\n", self.ws)
+        key = E.key_path(self.ws)
+        key.unlink()
+        _write(self.ws, self._now_id("9"), signed)
+        r = C.census(self.ws)
+        self.assertEqual(r["verdicts"].get("unverifiable"), 1)
+        self.assertFalse(key.exists(), "census must never create the key")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/task-envelope-census.test.py
+++ b/tests/task-envelope-census.test.py
@@ -106,6 +106,18 @@ class CensusCliAndFallbacks(unittest.TestCase):
         r = C.census(self.ws, days=10 * 365)
         self.assertEqual(r["scanned"], 1)
 
+    def test_long_digit_id_is_not_an_epoch(self):
+        """Live bug (2026-08-17 census run): an 18-digit gateway id's first 13
+        digits parse as a 2057 epoch, pinning July archive files in-window."""
+        old_iso = "2026-01-01T00:00:00Z"
+        _write(self.ws, "task-274606259064310678.txt",
+               f"id: task-274606259064310678\ntimestamp: {old_iso}\n"
+               "task: t\nsource: ag2space\n", sub="tasks/archive/2026-01")
+        r = C.census(self.ws, days=7)
+        self.assertEqual(r["scanned"], 0,
+                         "an over-long digit id must fall back to the "
+                         "timestamp header, not parse a future epoch")
+
     def test_bad_timestamp_header_falls_back_to_mtime(self):
         _write(self.ws, "task-cafebabe.txt",
                "id: task-cafebabe\ntimestamp: not-a-date\ntask: t\n")

--- a/tests/task-envelope-census.test.py
+++ b/tests/task-envelope-census.test.py
@@ -71,5 +71,93 @@ class CensusContract(unittest.TestCase):
         self.assertFalse(key.exists(), "census must never create the key")
 
 
+class CensusCliAndFallbacks(unittest.TestCase):
+    """In-process CLI + parser-fallback coverage (subprocess runs are
+    invisible to the coverage gate — same lesson as the envelope CLI)."""
+
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory(prefix="census-cli-")
+        self.ws = Path(self._tmp.name)
+        (self.ws / "state" / "auth").mkdir(parents=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_timestamp_header_fallback_for_hex_ids(self):
+        old_iso = "2026-01-01T00:00:00Z"
+        _write(self.ws, "task-deadbeefcafe.txt",
+               f"id: task-deadbeefcafe\ntimestamp: {old_iso}\ntask: t\n"
+               "source: slack\n")
+        r = C.census(self.ws, days=7)
+        self.assertEqual(r["scanned"], 0,
+                         "hex id must fall back to the timestamp header, "
+                         "which is far outside the window")
+        r = C.census(self.ws, days=10 * 365)
+        self.assertEqual(r["scanned"], 1)
+
+    def test_bad_timestamp_header_falls_back_to_mtime(self):
+        _write(self.ws, "task-cafebabe.txt",
+               "id: task-cafebabe\ntimestamp: not-a-date\ntask: t\n")
+        r = C.census(self.ws, days=7)
+        self.assertEqual(r["scanned"], 1, "fresh mtime keeps it in-window")
+        self.assertEqual(r["unsigned_sources"], ["(none)"])
+
+    def test_unreadable_file_is_skipped(self):
+        p = _write(self.ws, f"task-{int(time.time()*1000)}u.txt",
+                   "id: task-u\ntask: t\nsource: x\n")
+        real_read = Path.read_text
+
+        def deny(self_p, *a, **kw):
+            if self_p == p:
+                raise OSError("denied")
+            return real_read(self_p, *a, **kw)
+        Path.read_text = deny
+        try:
+            r = C.census(self.ws)
+        finally:
+            Path.read_text = real_read
+        self.assertEqual(r["scanned"], 0)
+
+    def test_main_text_and_json_paths(self):
+        import contextlib
+        import io
+        import json as _json
+        signed = E.stamp_text(
+            "id: task-1\ntask: t\nsource: gateway\naccess_tier: owner\n",
+            self.ws)
+        _write(self.ws, self._now_id("m"), signed)
+        _write(self.ws, self._now_id("n"),
+               "id: task-2\ntask: t\nsource: voice\n")
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = C.main(["x", "--workspace", str(self.ws)])
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("UNSIGNED writers still live", text)
+        self.assertIn("voice", text)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = C.main(["x", "--json", "--workspace", str(self.ws)])
+        self.assertEqual(rc, 0)
+        j = _json.loads(out.getvalue())
+        self.assertEqual(j["verdicts"]["verified"], 1)
+        self.assertEqual(j["unsigned_sources"], ["voice"])
+
+    def test_main_gate_met_message_when_all_verified(self):
+        import contextlib
+        import io
+        signed = E.stamp_text("id: task-3\ntask: t\nsource: gateway\n",
+                              self.ws)
+        _write(self.ws, self._now_id("v"), signed)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.assertEqual(C.main(["x", "--workspace", str(self.ws)]), 0)
+        self.assertIn("census gate MET", out.getvalue())
+
+    def _now_id(self, suffix: str) -> str:
+        return f"task-{int(time.time()*1000)}{suffix}.txt"
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/task-envelope-census.test.py
+++ b/tests/task-envelope-census.test.py
@@ -61,6 +61,16 @@ class CensusContract(unittest.TestCase):
         self.assertEqual(r["scanned"], 0,
                          "fresh mtime must not resurrect an old task id")
 
+    def test_monthly_archive_subdirs_are_counted(self):
+        """Review blocker: task_archive.py nests tasks/archive/YYYY-MM/ —
+        a writer whose tasks were archived there must still be named."""
+        _write(self.ws, self._now_id("a"),
+               "id: task-m\ntask: t\nsource: voice\n",
+               sub="tasks/archive/2026-08")
+        r = C.census(self.ws)
+        self.assertEqual(r["scanned"], 1)
+        self.assertEqual(r["unsigned_sources"], ["voice"])
+
     def test_keyless_host_reports_unverifiable_and_mints_nothing(self):
         signed = E.stamp_text("id: task-9\ntask: t\nsource: x\n", self.ws)
         key = E.key_path(self.ws)


### PR DESCRIPTION
## What

`src/task_envelope_census.py` — the read-only measurement behind #3014's "writer census reaches zero" enforcement gate. Verifies every task file in `tasks/` + `tasks/archive/` within a `--days` window and reports verdict counts plus a per-`source:` breakdown, naming any source that still produces `unsigned` files. Verification-only by construction: it calls `verify_text` (read-only `load_key`) and can never mint the key. `--workspace` overrides the checkout-relative resolver (the historic worktree/bundle wrong-workspace class).

## Why

#3014's soak plan flips consumer enforcement "once the writer census reaches zero" — but nothing measured that census. Without this, the flip decision would be taken on faith.

## Evidence

Test suite (3 tests, hermetic temp workspace): counts all four verdict classes and names unsigned sources; the day window keys off the immutable id epoch, not mtime (a `touch`ed old task cannot re-enter the window); a keyless host reports `unverifiable` and the test asserts the key file still does not exist afterward.

```
Ran 3 tests ... OK
```

First live datapoint (this host, ~40 min after the soak went live):

```
envelope census — 188 task file(s), last 1d
  verified     1
  unsigned     187
  source ag2space: unsigned=187, verified=1
  UNSIGNED writers still live (census gate not met): ag2space
```

The 187 unsigned are the pre-restart backlog (stamping activated at the 12:2x bridge restart); the 1 verified is the first post-restart task. The window design means the backlog ages out rather than blocking the gate forever — the census converges on what writers do *now*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
