### PR TITLE
fix(cron-runner): stamp the HMAC envelope at the writer's edge (#3014)

### DIFF
--- a/src/cron-runner.py
+++ b/src/cron-runner.py
@@ -411,6 +411,13 @@ def emit_task(name: str, entry: dict) -> Path:
             except OSError:
                 pass
     path = TASKS_DIR / f"{task_id}.txt"
+    # HMAC envelope (#3014 writer census): stamp at this writer's edge, fail-open
+    # so a stamping error costs the stamp and never the fire.
+    try:
+        from task_envelope import stamp_text  # sibling module (src/ on sys.path)
+        body = stamp_text(body, WORKSPACE)
+    except Exception:
+        pass
     path.write_text(body)
     _emit_cron_telemetry()
     return path

--- a/tests/cron-runner.test.py
+++ b/tests/cron-runner.test.py
@@ -587,6 +587,63 @@ def test_run_acquires_shared_state_lock():
         check(len(files) == 1, "run() emits the due entry after acquiring the lock")
 
 
+def test_emit_task_stamps_the_hmac_envelope():
+    """#3014's writer census lists cron-runner as unstamped. It writes with a
+    bare `path.write_text`, so it needs an edge stamp, not the injected seam."""
+    import tempfile
+    sys.path.insert(0, str(REPO / "src"))
+    from task_envelope import verify_text
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        orig_ws, orig_tasks = cr.WORKSPACE, cr.TASKS_DIR
+        try:
+            cr.WORKSPACE = root
+            cr.TASKS_DIR = root / "tasks"
+            cr.TASKS_DIR.mkdir(parents=True)
+            path = cr.emit_task("probe", {"prompt": "hello"})
+            text = path.read_text()
+            check(verify_text(text, root)["verdict"] == "verified",
+                  "an emitted cron task verifies against the per-host key")
+            check(text.splitlines()[0].startswith("id:"),
+                  "the stamp is inserted AFTER id:, so task-last readers see a header")
+            check("\ntask:" in text and text.rstrip().endswith("hello"),
+                  "task: stays last and the body is unchanged")
+            # The key must land beside the tasks it signs, not via a second
+            # independent workspace resolution.
+            check((root / "state" / "auth" / "task-hmac.key").is_file(),
+                  "the key is created under the workspace cron-runner writes to")
+        finally:
+            cr.WORKSPACE, cr.TASKS_DIR = orig_ws, orig_tasks
+
+
+def test_emit_task_survives_a_raising_stamper():
+    """Fail-open is the contract: a stamping error must cost the stamp, never
+    the fire. Without the guard this test loses the task entirely."""
+    import tempfile
+    sys.path.insert(0, str(REPO / "src"))
+    import task_envelope
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        orig_ws, orig_tasks = cr.WORKSPACE, cr.TASKS_DIR
+        orig_stamp = task_envelope.stamp_text
+        def boom(*_a, **_k):
+            raise RuntimeError("keychain on fire")
+        try:
+            task_envelope.stamp_text = boom
+            cr.WORKSPACE = root
+            cr.TASKS_DIR = root / "tasks"
+            cr.TASKS_DIR.mkdir(parents=True)
+            path = cr.emit_task("probe", {"prompt": "hello"})
+            check(path.is_file(), "the task is still written when stamping raises")
+            body = path.read_text()
+            check("hello" in body, "the body survives a raising stamper intact")
+            check("envelope_hmac:" not in body,
+                  "no partial stamp is left behind")
+        finally:
+            task_envelope.stamp_text = orig_stamp
+            cr.WORKSPACE, cr.TASKS_DIR = orig_ws, orig_tasks
+
+
 def _run_all():
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):


### PR DESCRIPTION
## What

`src/cron-runner.py` now stamps the HMAC task envelope at its write site. One writer off #3014's census.

## Why this writer needs an edge stamp, not the seam

#3014 added two mechanisms: `set_task_stamper()` injected at the adapter edge (which covers every producer going through sparrow's `write_task_file`), and a direct `stamp_text()` call for writers that don't. cron-runner is the second kind — it writes with a bare `path.write_text(body)` in `emit_task`, so the injection seam never reaches it. Same shape as discord-bridge's call site, per the PR's "each gets its own edge injection".

Two deliberate choices, both worth pushing back on if you disagree:

- **Fail-open, explicitly guarded.** `stamp_text` calls `load_or_create_key`, which does `mkdir` + file I/O and can raise. The guard makes a stamping error cost the stamp and never the fire.
- **`WORKSPACE` passed explicitly** rather than letting `task_envelope` resolve its own. cron-runner already derives `TASKS_DIR = WORKSPACE / "tasks"`, so passing it guarantees the key lands beside the tasks it signs instead of depending on two independent resolutions agreeing. discord-bridge passes nothing; this differs on purpose, and it is also what makes the test hermetic.

## Before / after — actual output

New tests run against the **parent** (`908e4bfd` src, new tests present):

```
FAILED (2): an emitted cron task verifies against the per-host key;
            the key is created under the workspace cron-runner writes to
```

At HEAD:

```
test_emit_task_stamps_the_hmac_envelope:
  ok: an emitted cron task verifies against the per-host key
  ok: the stamp is inserted AFTER id:, so task-last readers see a header
  ok: task: stays last and the body is unchanged
  ok: the key is created under the workspace cron-runner writes to
test_emit_task_survives_a_raising_stamper:
  ok: the task is still written when stamping raises
  ok: the body survives a raising stamper intact
  ok: no partial stamp is left behind

ALL PASSED
```

**The fail-open test needs its own falsifier, because it passes vacuously at the parent** (nothing stamps, so nothing can raise). Keeping the stamp and removing *only* the guard:

```
File ".../tests/cron-runner.test.py", line 636, in test_emit_task_survives_a_raising_stamper
    path = cr.emit_task("probe", {"prompt": "hello"})
RuntimeError: keychain on fire
```

— i.e. without the guard a stamping failure loses the task outright, which is the outcome the contract exists to prevent.

## Other checks

```
bash scripts/review-checks.sh   PASS (hardcoded-paths + root-artifacts + prose-cap clean)
tests/injection-guard-sweep     49/49 passed
tests/task-envelope.test.py     OK
tests/cron-runner.test.py       ALL PASSED (full suite)
```

`review-checks.sh` was also run from a worktree of `origin/main`; note that scanning a diff whose post-image is not in the tree reports `prose-cap: SKIPPED — no post-image`, which is not a pass — the PASS above is from the tree that has the files.

## Scope

One writer. The remaining census entries (`telegram-bridge.py:863`, `agent-api.py:1016,1051`, slack, friction-detector, morning-briefing, codex-scheduler, `task-bridge.ts`, and the chat-path heredoc) are untouched — happy to take more if this shape is right, or to close this if you would rather land them as one batch.

Not verifiable end-to-end on my host: its engine build predates #3014, so nothing local can stamp yet. Everything above is proven through the production `emit_task`, not a surrogate.
