### PR TITLE
test(isvoice): fixtures go to a tmp workspace, never the live task queue

### DIFF
--- a/tests/task-bridge-isvoice.test.ts
+++ b/tests/task-bridge-isvoice.test.ts
@@ -14,15 +14,8 @@ import { join, dirname } from 'node:path';
 // archive lookup all surface a voice task; non-voice content stays false; missing
 // task files stay false.
 
-// Fixtures go to a per-run tmp workspace, NEVER the live queue (#3035): the
-// old form wrote owner-tier task files into `resolveWorkspace()/tasks/`, where
-// a running core's watcher claims them — writeFileSync → (watcher emit,
-// dispatcher claim) → unlinkSync is a race the live core can win. Same
-// redirect the delimiter suite uses: SUTANDO_TEST_MODE=1 makes
-// resolveWorkspace() honor SUTANDO_WORKSPACE (sutando_config.ts test-only
-// hatch), and the top-level `await import` below runs in source order —
-// AFTER these lines — where a hoisted static import of task-bridge.js would
-// capture the ambient workspace before the env-set executed.
+// Fixtures use a tmp workspace, never the live queue (#3035): SUTANDO_TEST_MODE=1
+// must be set before the source-ordered `await import` binds the bridge's paths.
 const TMP = mkdtempSync(join(tmpdir(), 'sutando-isvoice-archive-test-'));
 process.env.SUTANDO_WORKSPACE = TMP;
 process.env.SUTANDO_TEST_MODE = '1';
@@ -80,10 +73,8 @@ describe('_isVoiceTask — archive-path coverage', () => {
 	});
 
 	it('resolves against the redirected tmp workspace, not the live queue (#3035)', () => {
-		// The redirect above is what keeps every fixture in this file out of
-		// the live queue; assert it held, so a future resolver change that
-		// silently drops the test-mode hatch fails HERE instead of leaking
-		// owner-tier fixtures back into a running core's watcher.
+		// If the resolver ever drops the test-mode hatch, fail HERE instead of
+		// silently leaking owner-tier fixtures back into a live core's watcher.
 		const id = 'task-isvoice-test-redirect-aaa';
 		writeTask(join(TASK_DIR, `${id}.txt`), VOICE_BODY);
 		assert.equal(_isVoiceTask(id), true,
@@ -129,9 +120,8 @@ describe('_isVoiceTask — archive-path coverage', () => {
 	});
 
 	it('ignores non-month-shaped subdirs (e.g. "done", "tmp")', () => {
-		// Stray subdirs under tasks/archive/ shouldn't trip the regex; they
-		// won't be scanned. Negative-control: a voice task placed under a
-		// non-month-shaped subdir is NOT found, confirming the regex gate.
+		// Negative-control: a voice task under a non-month-shaped subdir is
+		// NOT found, confirming the YYYY-MM regex gate.
 		const id = 'task-isvoice-test-stray-subdir-aaa';
 		writeTask(join(ARCHIVE_DIR, 'done', `${id}.txt`), VOICE_BODY);
 		assert.equal(_isVoiceTask(id), false);

--- a/tests/task-bridge-isvoice.test.ts
+++ b/tests/task-bridge-isvoice.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, afterEach } from 'node:test';
+import { describe, it, after, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { resolveWorkspace } from '../src/workspace_default.js';
-import { _isVoiceTask } from '../src/task-bridge.js';
 
 // Regression for the archive-path drift bug flagged by VasiliyRad 2026-05-06:
 // `archiveFile()` writes to `tasks/archive/YYYY-MM/<taskId>.txt`, but
@@ -15,10 +14,27 @@ import { _isVoiceTask } from '../src/task-bridge.js';
 // archive lookup all surface a voice task; non-voice content stays false; missing
 // task files stay false.
 
-// Task dir is wherever the bridge looks — `resolveWorkspace()/tasks/`. Was
-// `<REPO_ROOT>/tasks/` pre-#821, when the bridge fell back to repo root.
-const TASK_DIR = join(resolveWorkspace(), 'tasks');
+// Fixtures go to a per-run tmp workspace, NEVER the live queue (#3035): the
+// old form wrote owner-tier task files into `resolveWorkspace()/tasks/`, where
+// a running core's watcher claims them — writeFileSync → (watcher emit,
+// dispatcher claim) → unlinkSync is a race the live core can win. Same
+// redirect the delimiter suite uses: SUTANDO_TEST_MODE=1 makes
+// resolveWorkspace() honor SUTANDO_WORKSPACE (sutando_config.ts test-only
+// hatch), and the top-level `await import` below runs in source order —
+// AFTER these lines — where a hoisted static import of task-bridge.js would
+// capture the ambient workspace before the env-set executed.
+const TMP = mkdtempSync(join(tmpdir(), 'sutando-isvoice-archive-test-'));
+process.env.SUTANDO_WORKSPACE = TMP;
+process.env.SUTANDO_TEST_MODE = '1';
+const TASK_DIR = join(TMP, 'tasks');
 const ARCHIVE_DIR = join(TASK_DIR, 'archive');
+mkdirSync(TASK_DIR, { recursive: true });
+
+const { _isVoiceTask } = await import('../src/task-bridge.js');
+
+after(() => {
+	try { rmSync(TMP, { recursive: true, force: true }); } catch {}
+});
 
 // Field order: `task:` LAST, per the writer convention enforced in PR #1023.
 // `_isVoiceTask` stops scanning at the first `task:` line (closes the body-
@@ -59,8 +75,21 @@ function writeTask(path: string, body: string) {
 describe('_isVoiceTask — archive-path coverage', () => {
 	afterEach(() => {
 		for (const p of created.splice(0)) {
-			try { unlinkSync(p); } catch {}
+			try { rmSync(p, { force: true }); } catch {}
 		}
+	});
+
+	it('resolves against the redirected tmp workspace, not the live queue (#3035)', () => {
+		// The redirect above is what keeps every fixture in this file out of
+		// the live queue; assert it held, so a future resolver change that
+		// silently drops the test-mode hatch fails HERE instead of leaking
+		// owner-tier fixtures back into a running core's watcher.
+		const id = 'task-isvoice-test-redirect-aaa';
+		writeTask(join(TASK_DIR, `${id}.txt`), VOICE_BODY);
+		assert.equal(_isVoiceTask(id), true,
+			'a fixture in the tmp workspace must be visible to _isVoiceTask');
+		assert.ok(TASK_DIR.startsWith(tmpdir()),
+			'fixture dir must live under the OS tmpdir');
 	});
 
 	it('returns true for a voice task in the live tasks/ dir', () => {
@@ -81,22 +110,14 @@ describe('_isVoiceTask — archive-path coverage', () => {
 		assert.equal(_isVoiceTask(id), true);
 	});
 
-	it('returns true for a voice task in legacy flat tasks/archive/', () => {
+	it('returns true for a voice task in the legacy flat archive', () => {
 		const id = 'task-isvoice-test-flat-aaa';
 		writeTask(join(ARCHIVE_DIR, `${id}.txt`), VOICE_BODY);
 		assert.equal(_isVoiceTask(id), true);
 	});
 
-	it('returns true for a voice task in month-partitioned tasks/archive/YYYY-MM/ — the bug fix', () => {
+	it('returns true for a voice task in month-partitioned archive (the drift bug)', () => {
 		const id = 'task-isvoice-test-month-aaa';
-		writeTask(join(ARCHIVE_DIR, '2026-05', `${id}.txt`), VOICE_BODY);
-		assert.equal(_isVoiceTask(id), true);
-	});
-
-	it('finds a voice task across multiple month subdirs', () => {
-		// The taskId may live in any historical month; the function must scan
-		// all month-shaped subdirs, not just the current month.
-		const id = 'task-isvoice-test-old-month-aaa';
 		writeTask(join(ARCHIVE_DIR, '2026-01', `${id}.txt`), VOICE_BODY);
 		assert.equal(_isVoiceTask(id), true);
 	});
@@ -118,5 +139,21 @@ describe('_isVoiceTask — archive-path coverage', () => {
 
 	it('returns false when the task file is missing entirely', () => {
 		assert.equal(_isVoiceTask('task-isvoice-test-no-such-file'), false);
+	});
+
+	it('leaves no fixture behind in the tmp workspace after cleanup', () => {
+		// afterEach already removed this describe-block's fixtures; the tmp
+		// tree should hold only the (possibly empty) dirs the tests created.
+		const leftover: string[] = [];
+		const walk = (d: string) => {
+			if (!existsSync(d)) return;
+			for (const e of readdirSync(d, { withFileTypes: true })) {
+				const p = join(d, e.name);
+				if (e.isDirectory()) walk(p);
+				else leftover.push(p);
+			}
+		};
+		walk(TASK_DIR);
+		assert.deepEqual(leftover, []);
 	});
 });


### PR DESCRIPTION
## What

`tests/task-bridge-isvoice.test.ts` fixtures now go to a per-run `mkdtemp` workspace instead of the live task queue. Test-only change; `src/task-bridge.ts` untouched.

## The correction that shrinks the fix (issue #3035, second comment)

The issue's follow-up concluded the env escape hatch is closed ("$SUTANDO_WORKSPACE was removed as a resolution input in v0.8/#1440 — even setting it before import does not redirect") and that the honest remedy was a source change (lazy resolution in `task-bridge.ts`). That's incomplete: **`SUTANDO_TEST_MODE=1` makes `resolveWorkspace()` honor `SUTANDO_WORKSPACE`** — the deliberate test-only hatch at `src/sutando_config.ts:288-295` ("while letting the test suite redirect workspace to per-test tmp dirs"). The sibling suite `tests/task-bridge-stop-at-task-delimiter.test.ts` has used exactly this pattern all along, including the source-ordered top-level `await import` that defuses the import-hoisting brittleness the issue worried about. So the class fix for this suite is the established pattern, not a live-path source change.

## Before / after — actual output

**Before (parent `50869be5`)** — old suite pointed at a pristine probe workspace; the fixture writes land in the resolver-pointed workspace (on a live core that's the real queue; the issue's watcher log shows the core claiming them):

```
ℹ tests 9 / pass 9
--- leftover tree the old suite created in the workspace it resolved:
<workspace>/tasks
<workspace>/tasks/archive
<workspace>/tasks/processed
<workspace>/tasks/archive/2026-05
<workspace>/tasks/archive/done
<workspace>/tasks/archive/2026-01
```

**At HEAD** — run with NO env from CI's perspective:

```
ℹ tests 10 / pass 10 / fail 0
--- worktree workspace after run:
(no tasks dir created — fixtures stayed in OS tmpdir)
```

**Falsifier for the new guard test** (commenting out only the `SUTANDO_TEST_MODE = '1'` line):

```
✖ resolves against the redirected tmp workspace, not the live queue (#3035)
ℹ pass 0 / fail 3
```

— i.e. if the resolver ever drops the test-mode hatch, this suite fails loudly instead of silently writing owner-tier fixtures back into the live queue.

## Scope

- The issue's severity analysis (no `access_tier` → owner-tier processing; write→claim→unlink race) is unchanged and correct — this removes the writer.
- The issue's separate finding (7 orphaned `fswatch` processes, ppid=1) is untouched — that deserves its own issue as offered.
- Option 2 (lazy resolution of the five module-level constants in `task-bridge.ts`) remains available as a later refactor if wanted; it is not needed to close the live-queue leak.

Closes #3035

— Sutando (qingyun-001)
