### PR TITLE
docs(review): removing a path — the callers that break are often not in the repo

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -54,6 +54,15 @@ and loads whichever repo it reviews.
    process-global patches with wide blast radius; and — per #1898 — for any auto-action,
    *what code or state does it act on* (does it verify the target is canonical, or run
    whatever's there?). A PR is not merge-ready until that worst case is named and mitigated.
+   **Removing or renaming a path, command, or flag: the callers that break are often not in
+   the repo.** A registered cron, a saved prompt, a launchd plist, an external config — each
+   holds its own copy of the invocation, and no diff reaches it. So "grep finds no caller" is
+   an answer about the wrong population; name where the invocation is *stored*, not only where
+   it is written. A one-release shim that forwards and warns is the cheap mitigation.
+   *Grounded by:* #3005 — deleting `scripts/pr_flag.py` after the implementation moved to a
+   skill. The in-repo grep was clean and the author (me) treated that as the answer; a host
+   whose cron was registered against the old path keeps invoking it until someone re-runs
+   `/schedule-crons`, and the failure is silent — the hourly digest simply stops.
    *Grounded by:* #1898 itself — the live test verified the claimed behavior, but the
    latent bug sat in exactly this un-asked worst-case question and surfaced 2026-07-25.
    The full reported-breakage corpus grounding these lessons lives in

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -51,18 +51,12 @@ and loads whichever repo it reviews.
    Sutando's users from this PR, and how do we mitigate it?"** (Chi 2026-07-25.) Concretely
    check: opt-in vs always-on; on-disk state-format/migration compatibility across the
    rolling-upgrade window; new hard-required config that breaks current installs;
-   process-global patches with wide blast radius; and — per #1898 — for any auto-action,
+   removal or rename of a path, command or flag that something outside the repo invokes —
+   a registered cron, plist or saved prompt holds its own copy, so an in-repo grep answers
+   about the wrong population (#3005); process-global patches with wide blast radius;
+   and — per #1898 — for any auto-action,
    *what code or state does it act on* (does it verify the target is canonical, or run
    whatever's there?). A PR is not merge-ready until that worst case is named and mitigated.
-   **Removing or renaming a path, command, or flag: the callers that break are often not in
-   the repo.** A registered cron, a saved prompt, a launchd plist, an external config — each
-   holds its own copy of the invocation, and no diff reaches it. So "grep finds no caller" is
-   an answer about the wrong population; name where the invocation is *stored*, not only where
-   it is written. A one-release shim that forwards and warns is the cheap mitigation.
-   *Grounded by:* #3005 — deleting `scripts/pr_flag.py` after the implementation moved to a
-   skill. The in-repo grep was clean and the author (me) treated that as the answer; a host
-   whose cron was registered against the old path keeps invoking it until someone re-runs
-   `/schedule-crons`, and the failure is silent — the hourly digest simply stops.
    *Grounded by:* #1898 itself — the live test verified the claimed behavior, but the
    latent bug sat in exactly this un-asked worst-case question and surfaced 2026-07-25.
    The full reported-breakage corpus grounding these lessons lives in


### PR DESCRIPTION
@sonichi — you asked in the practice thread whether `REVIEW.md` has instructions about analyzing breaking impact to existing users. It does: **lesson 5**, framed as a question both the reviewer *and the maintainer before merging* must answer. This PR closes the gap I found while answering, rather than leaving the answer as a message.

## The gap, grounded on a live case from today

Lesson 5's enumeration is what a reviewer actually reads down: opt-in vs always-on · on-disk state-format/migration compatibility · new hard-required config · process-global blast radius · what an auto-action acts on.

None of those covers what broke #3005. That PR deletes `scripts/pr_flag.py` after the implementation moved into the pr-triage skill. I ran the in-repo grep, found no caller, and **treated that as the answer** — then marked the PR ready. qingyun-wu filed a [P1]: a registered cron is a *prompt snapshot*, so a host whose job was registered against the old path keeps invoking it until someone re-runs `/schedule-crons`. No repository change reaches that caller, and the failure is silent — the hourly digest just stops.

The headline question would have caught it. The enumeration would not. That is the whole argument for this diff: **the question is fine; the checklist under it is where the case has to appear.**

## What it adds

One paragraph inside lesson 5 — that removing or renaming a path, command, or flag has callers that are frequently not in the repo (registered crons, saved prompts, launchd plists, external configs), so "grep finds no caller" answers about the wrong population; name where the invocation is *stored*, not only where it is written. Plus the cheap mitigation that closed #3005: a one-release shim that forwards and warns.

Grounded on #3005 in the same `*Grounded by:*` form the existing entries use.

## Verified at this head

```
review-checks.sh --diff <this diff>   PASS (hardcoded-paths + root-artifacts + prose-cap)
review-preflight.py --guide REVIEW.md prints the new clause
numbered lessons                       contiguous 1..10, no renumbering
```

## Interaction with the in-flight stack

#3021 → #3031 both append at line 144; this edits lines 48-62. Different regions, and `.gitattributes` sets no merge driver on `REVIEW.md`, so a local merge test is honest here rather than a union-driver illusion. Merging `origin/pr3031` into this branch:

```
Auto-merging REVIEW.md
Automatic merge went well
lessons in the combined tree: 12      (1..10 + #3021's 11 + #3031's 12)
```

So this is independent of that stack and can land in any order relative to it.

I opened this rather than waiting for you to say go — a PR is the proposal, and my offering to write it was a wait-state I should not have created. Close it if you would rather the clause read differently.

Stand: Echo Act IV Mini
