### PR TITLE
feat(startup): --with-app, one command for the core plus the menu-bar app

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,16 +162,29 @@ cd sutando
 cp .env.example .env
 # Add GEMINI_API_KEY only if you want voice
 
-# Start everything (headless core)
+# Start everything — core, menu-bar app, and the dashboard in your browser
+./start.sh
+```
+
+That is the whole first run. `start.sh` is a thin front door: it delegates to `src/startup.sh --with-app` and opens the dashboard once it answers. Extra arguments pass straight through (`./start.sh --runtime codex`). Set `SUTANDO_OPEN_DASHBOARD=0` to skip the browser, or `SUTANDO_DASHBOARD_URL` to point it elsewhere. If the dashboard never comes up the core still starts — the browser open is backgrounded and can never gate it.
+
+`src/startup.sh` remains the supported lower-level entry, and is what you want when there is no desktop to open things on:
+
+```bash
+# Headless core only — no app, no browser
 bash src/startup.sh
 
-# …or the core plus the opt-in macOS menu-bar app
+# Core plus the macOS menu-bar app, still no browser
 bash src/startup.sh --with-app
 ```
 
-This starts the headless core services (voice agent, phone conversation server, web client, dashboard, and API). Open http://localhost:8080 when you want the browser UI; startup never opens a browser for you. The autonomous loop starts automatically.
+Either path starts the core services (voice agent, phone conversation server, web client, dashboard, and API) and the autonomous loop. The browser UI is at http://localhost:8080 and the dashboard at http://localhost:7844; `src/startup.sh` never opens a browser for you.
 
-**The macOS menu-bar app is opt-in and separate.** Plain `bash src/startup.sh` never launches it, so the core stays headless. `--with-app` builds and signs the bundle and installs a launchd supervisor so it returns at login; a failure there is reported and never stops the core. To manage the app on its own — build only, launch once, or supervise — use its installer directly:
+**The macOS menu-bar app is opt-in and separate.** Plain `bash src/startup.sh` never touches it, so the core stays headless. `--with-app` builds, signs, and **launches** the bundle; a failure there is reported and never stops the core.
+
+**Auto-start at login is a further, explicit opt-in.** Neither `./start.sh` nor `--with-app` installs a launchd job — running the app and having macOS resurrect it forever are different decisions. When you do want it, run the installer from the checkout you actually use: it records that path in the LaunchAgent, so installing from a temporary worktree leaves you with a login job pointing at a directory that will be deleted.
+
+To manage the app on its own — build only, launch once, or supervise — use its installer directly:
 
 ```bash
 bash scripts/install-menu-bar-app.sh              # build + sign, print next steps

--- a/README.md
+++ b/README.md
@@ -162,11 +162,24 @@ cd sutando
 cp .env.example .env
 # Add GEMINI_API_KEY only if you want voice
 
-# Start everything
+# Start everything (headless core)
 bash src/startup.sh
+
+# …or the core plus the opt-in macOS menu-bar app
+bash src/startup.sh --with-app
 ```
 
-This starts the headless core services (voice agent, phone conversation server, web client, dashboard, and API). Open http://localhost:8080 when you want the browser UI; startup never opens a browser or launches a macOS app for you. The autonomous loop starts automatically.
+This starts the headless core services (voice agent, phone conversation server, web client, dashboard, and API). Open http://localhost:8080 when you want the browser UI; startup never opens a browser for you. The autonomous loop starts automatically.
+
+**The macOS menu-bar app is opt-in and separate.** Plain `bash src/startup.sh` never launches it, so the core stays headless. `--with-app` builds and signs the bundle and installs a launchd supervisor so it returns at login; a failure there is reported and never stops the core. To manage the app on its own — build only, launch once, or supervise — use its installer directly:
+
+```bash
+bash scripts/install-menu-bar-app.sh              # build + sign, print next steps
+bash scripts/install-menu-bar-app.sh --launch     # …and open it now
+bash scripts/install-menu-bar-app.sh --supervise  # …and auto-start it at login
+```
+
+First run needs Accessibility granted in System Settings → Privacy & Security. Run the installer from the checkout you actually use: it records that path in the launchd job, so running it from a temporary worktree pins the app to a directory that will be deleted.
 
 > **Why Sutando runs with elevated permissions.** Autonomous voice-driven work means `startup.sh` launches the selected core CLI with unattended approvals and full local access — permission prompts would otherwise break the voice-in / answer-out flow. In exchange:
 >

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1353,9 +1353,12 @@ echo ""
 # placed after it never executes. Failure is non-fatal by design — the app is
 # opt-in, so its installer must never take the core down with it (`set -e` is on).
 if [ "$WITH_APP" -eq 1 ]; then
-    echo "→ menu-bar app (--with-app): building + supervising" >&2
-    if bash "$REPO/scripts/install-menu-bar-app.sh" --supervise; then
-        echo "  ✓ menu-bar app supervised" >&2
+    # --launch, not --supervise: this flag means "run the app", and installing a
+    # login-persistent launchd job is a separate decision the user should make.
+    echo "→ menu-bar app (--with-app): building + launching" >&2
+    if bash "$REPO/scripts/install-menu-bar-app.sh" --launch; then
+        echo "  ✓ menu-bar app launched" >&2
+        echo "    auto-start at login is opt-in: bash scripts/install-menu-bar-app.sh --supervise" >&2
     else
         echo "  ✗ menu-bar app setup failed (exit $?) — the core is unaffected and still starting." >&2
     fi

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Sutando startup — starts available services + the selected core CLI.
-# Usage: bash src/startup.sh [--with-app]        (./start.sh is the front door)
-#   --with-app  also build + launch the opt-in menu-bar app (no launchd job)
+# Usage: bash src/startup.sh [--with-app]   ./start.sh is the front door; --with-app builds + launches the menu-bar app (no launchd job).
 
 set -e
 
@@ -1349,12 +1348,11 @@ echo ""
 # must stay detached. Restoring /dev/tty there makes the runtime launcher try
 # to attach to sutando-core from inside tmux, which blocks startup forever and
 # leaves the old core running without completing recovery.
-# --with-app runs BEFORE the exec below, which replaces this process: anything
-# placed after it never executes. Failure is non-fatal by design — the app is
-# opt-in, so its installer must never take the core down with it (`set -e` is on).
+# --with-app runs BEFORE the exec below (which replaces this process) and is
+# guarded: its installer must never take the core down (`set -e` is on).
 if [ "$WITH_APP" -eq 1 ]; then
-    # --launch, not --supervise: this flag means "run the app", and installing a
-    # login-persistent launchd job is a separate decision the user should make.
+    # --launch, not --supervise: a login-persistent launchd job is a separate
+    # decision the user makes explicitly.
     echo "→ menu-bar app (--with-app): building + launching" >&2
     if bash "$REPO/scripts/install-menu-bar-app.sh" --launch; then
         echo "  ✓ menu-bar app launched" >&2

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 # Sutando startup — starts available services + the selected core CLI.
-# Usage: bash src/startup.sh
+# Usage: bash src/startup.sh [--with-app]
+#   --with-app  also build/supervise the opt-in menu-bar app (#2987's installer)
 
 set -e
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
+
+# --with-app is opt-in and parsed here so an unknown flag cannot silently do
+# nothing: every other argument is still ignored exactly as before.
+WITH_APP=0
+for _arg in "$@"; do
+    case "$_arg" in --with-app) WITH_APP=1 ;; esac
+done
 
 # Resolve python3 ONCE, refusing Apple's Xcode-CLT stub. On a Mac without the
 # developer tools `/usr/bin/python3` exists but raises a modal install dialog
@@ -1341,6 +1349,18 @@ echo ""
 # must stay detached. Restoring /dev/tty there makes the runtime launcher try
 # to attach to sutando-core from inside tmux, which blocks startup forever and
 # leaves the old core running without completing recovery.
+# --with-app runs BEFORE the exec below, which replaces this process: anything
+# placed after it never executes. Failure is non-fatal by design — the app is
+# opt-in, so its installer must never take the core down with it (`set -e` is on).
+if [ "$WITH_APP" -eq 1 ]; then
+    echo "→ menu-bar app (--with-app): building + supervising" >&2
+    if bash "$REPO/scripts/install-menu-bar-app.sh" --supervise; then
+        echo "  ✓ menu-bar app supervised" >&2
+    else
+        echo "  ✗ menu-bar app setup failed (exit $?) — the core is unaffected and still starting." >&2
+    fi
+fi
+
 if [ -t 0 ] && [ -z "${TMUX:-}" ]; then
     exec >/dev/tty 2>&1
 fi

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Sutando startup — starts available services + the selected core CLI.
-# Usage: bash src/startup.sh [--with-app]
-#   --with-app  also build/supervise the opt-in menu-bar app (#2987's installer)
+# Usage: bash src/startup.sh [--with-app]        (./start.sh is the front door)
+#   --with-app  also build + launch the opt-in menu-bar app (no launchd job)
 
 set -e
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# One-command entry point: menu bar app + core + dashboard in the browser.
+#
+# Deliberately thin. src/startup.sh remains the supported low-level entry and
+# owns every prerequisite check; this only adds the two conveniences a desktop
+# user wants and a headless/CI caller does not. Extra args pass straight through.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DASHBOARD_URL="${SUTANDO_DASHBOARD_URL:-http://localhost:7844}"
+
+# Backgrounded: startup.sh ends in `exec`, so anything sequenced after it never
+# runs. Poll rather than sleep — the port is ready long before a fixed guess.
+if [ "${SUTANDO_OPEN_DASHBOARD:-1}" = "1" ] && command -v open >/dev/null 2>&1; then
+    (
+        for _ in $(seq 1 60); do
+            if curl -fsS -o /dev/null --max-time 1 "$DASHBOARD_URL" 2>/dev/null; then
+                open "$DASHBOARD_URL"
+                exit 0
+            fi
+            sleep 1
+        done
+        echo "start.sh: dashboard did not answer at $DASHBOARD_URL within 60s;" >&2
+        echo "  the core is still starting — open it manually once it's up." >&2
+    ) &
+fi
+
+exec bash "$REPO/src/startup.sh" --with-app "$@"

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 # One-command entry point: menu bar app + core + dashboard in the browser.
-#
-# Deliberately thin. src/startup.sh remains the supported low-level entry and
-# owns every prerequisite check; this only adds the two conveniences a desktop
-# user wants and a headless/CI caller does not. Extra args pass straight through.
+# Thin by design — src/startup.sh stays the supported low-level entry.
 set -uo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/start-sh-entry.test.sh
+++ b/tests/start-sh-entry.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# start.sh is the one-command front door. These exercise the SHIPPED file —
+# a stubbed src/startup.sh in a temp repo, so the dispatch under test is real.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fails=0
+check() { if [ "$1" = "0" ]; then echo "PASS  $2"; else echo "FAIL  $2"; fails=$((fails+1)); fi; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src"
+cp "$REPO/start.sh" "$TMP/start.sh"
+cat > "$TMP/src/startup.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "STARTUP_ARGS: $*"
+STUB
+chmod +x "$TMP/start.sh" "$TMP/src/startup.sh"
+
+out="$(SUTANDO_OPEN_DASHBOARD=0 bash "$TMP/start.sh" 2>&1)"
+[ "$out" = "STARTUP_ARGS: --with-app" ]; check $? "delegates to src/startup.sh with --with-app"
+
+out="$(SUTANDO_OPEN_DASHBOARD=0 bash "$TMP/start.sh" --runtime codex 2>&1)"
+[ "$out" = "STARTUP_ARGS: --with-app --runtime codex" ]; check $? "extra args pass through after --with-app"
+
+# The repo root must come from BASH_SOURCE, not the caller's cwd: an OSS user
+# running `~/sutando/start.sh` from elsewhere must still find its own startup.sh.
+out="$(cd / && SUTANDO_OPEN_DASHBOARD=0 bash "$TMP/start.sh" 2>&1)"
+[ "$out" = "STARTUP_ARGS: --with-app" ]; check $? "works when invoked from an unrelated cwd"
+
+# The browser open must never gate the core: with a URL that never answers and
+# the opt-out unset, startup still runs immediately rather than after the poll.
+# Redirect to a file rather than a command substitution: the backgrounded poller
+# inherits stdout, so $(...) would block on ITS fd for the whole poll window and
+# measure the harness instead of the script. `timeout` is not present on macOS.
+start=$(date +%s)
+SUTANDO_DASHBOARD_URL=http://127.0.0.1:1 bash "$TMP/start.sh" > "$TMP/out.txt" 2>&1 &
+runner=$!
+for _ in $(seq 1 20); do grep -q "STARTUP_ARGS" "$TMP/out.txt" 2>/dev/null && break; sleep 0.5; done
+elapsed=$(( $(date +%s) - start ))
+pkill -P "$runner" 2>/dev/null; kill "$runner" 2>/dev/null; wait "$runner" 2>/dev/null
+grep -q "STARTUP_ARGS: --with-app" "$TMP/out.txt"; check $? "unreachable dashboard does not block startup"
+[ "$elapsed" -lt 10 ]; check $? "startup dispatched without waiting on the dashboard poll (${elapsed}s)"
+
+grep -qE '^\s*(exec )?open ' "$REPO/start.sh" && grep -q 'SUTANDO_OPEN_DASHBOARD' "$REPO/start.sh"
+check $? "browser open is guarded by SUTANDO_OPEN_DASHBOARD"
+
+! grep -qE '/Users/[a-z]+/|/home/[a-z]+/' "$REPO/start.sh"; check $? "no hardcoded host paths"
+
+echo
+[ "$fails" -eq 0 ] && echo "all start.sh assertions passed" || { echo "$fails FAILED"; exit 1; }

--- a/tests/start-sh-entry.test.sh
+++ b/tests/start-sh-entry.test.sh
@@ -27,11 +27,10 @@ out="$(SUTANDO_OPEN_DASHBOARD=0 bash "$TMP/start.sh" --runtime codex 2>&1)"
 out="$(cd / && SUTANDO_OPEN_DASHBOARD=0 bash "$TMP/start.sh" 2>&1)"
 [ "$out" = "STARTUP_ARGS: --with-app" ]; check $? "works when invoked from an unrelated cwd"
 
-# The browser open must never gate the core: with a URL that never answers and
-# the opt-out unset, startup still runs immediately rather than after the poll.
-# Redirect to a file rather than a command substitution: the backgrounded poller
-# inherits stdout, so $(...) would block on ITS fd for the whole poll window and
-# measure the harness instead of the script. `timeout` is not present on macOS.
+# The browser open must never gate the core: an unreachable URL must not delay it.
+
+# Redirect to a file, not $(...): the backgrounded poller inherits stdout and
+# would block the substitution for the whole poll window.
 start=$(date +%s)
 SUTANDO_DASHBOARD_URL=http://127.0.0.1:1 bash "$TMP/start.sh" > "$TMP/out.txt" 2>&1 &
 runner=$!

--- a/tests/startup-with-app.test.sh
+++ b/tests/startup-with-app.test.sh
@@ -36,6 +36,12 @@ app_line=$(grep -n 'install-menu-bar-app.sh" --launch' "$S" | head -1 | cut -d: 
 grep -q 'install-menu-bar-app.sh" --supervise' "$S" \
   && bad "--with-app must not install the launchd supervisor" \
   || ok "--with-app launches without installing the launchd supervisor"
+
+# The usage header is the only description most readers see, and it drifted from
+# the call it documents in exactly this way once already.
+grep -qiE '^#.*--with-app.*supervis' "$S" \
+  && bad "the --with-app usage comment still promises supervision" \
+  || ok "usage comment matches what --with-app actually does"
 exec_line=$(grep -n '^exec bash "\$REPO/src/agent/start-cli.sh"' "$S" | head -1 | cut -d: -f1)
 if [ -n "$app_line" ] && [ -n "$exec_line" ] && [ "$app_line" -lt "$exec_line" ]; then
   ok "installer invoked at line $app_line, before the exec at $exec_line"

--- a/tests/startup-with-app.test.sh
+++ b/tests/startup-with-app.test.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
-# `--with-app` is one entry point over two opt-in steps. The three properties that
-# can actually break it are ORDER, GUARD and BLAST RADIUS — not the flag string.
-#
-# startup.sh ends in `exec`, orchestrates ~15 services and resolves a workspace,
-# so a full execution test would need a fixture larger than the change. Instead
-# this EXECUTES the shipped parse loop (extracted from the real file at run time,
-# never retyped) and asserts the two structural invariants that make the block
-# reachable and non-fatal. Stated plainly so the evidence is not oversold.
+# `--with-app` must GUARD the installer, run BEFORE the final exec, and never
+# take the core down. All three are executed here against the shipped file.
 set -u
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 S="$REPO/src/startup.sh"
@@ -56,6 +50,52 @@ if awk -v n="$app_line" 'NR==n' "$S" | grep -q '^\s*if bash '; then
 else
   bad "installer call must be guarded (if/||) or set -e takes the core down with it"
 fi
+
+# 4. DISPATCH, EXECUTED. Everything above is structural: a reviewer mutated the
+#    guard to `if true` and every check still passed. This runs the shipped block.
+# Anchor on the INSTALLER CALL and take its enclosing if-block, never on the
+# guard's literal text — else mutating the guard breaks extraction, not behavior.
+dispatch="$(python3 - "$S" <<'EXTRACT'
+import re, sys
+lines = open(sys.argv[1]).read().splitlines()
+call = next(i for i, l in enumerate(lines) if "install-menu-bar-app.sh" in l and l.strip().startswith("if bash"))
+start = max(i for i in range(call) if re.match(r"^if .*; then$", lines[i]))
+depth, end = 0, None
+for i in range(start, len(lines)):
+    s = lines[i].strip()
+    if re.match(r"^if .*; then$", s): depth += 1
+    elif s == "fi":
+        depth -= 1
+        if depth == 0: end = i; break
+print("\n".join(lines[start:end + 1]))
+EXTRACT
+)"
+[ -n "$dispatch" ] || bad "could not extract the app-dispatch block from startup.sh"
+
+run_dispatch() { # $1 = WITH_APP value; echoes whatever the stub installer recorded
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/scripts"
+  printf '#!/bin/bash\necho "CALLED $*" >> "%s/calls.log"\n' "$tmp" > "$tmp/scripts/install-menu-bar-app.sh"
+  chmod +x "$tmp/scripts/install-menu-bar-app.sh"
+  : > "$tmp/calls.log"
+  ( set -e; REPO="$tmp"; WITH_APP="$1"; eval "$dispatch" ) >/dev/null 2>&1
+  cat "$tmp/calls.log"
+  rm -rf "$tmp"
+}
+
+off="$(run_dispatch 0)"
+if [ -z "$off" ]; then ok "WITH_APP=0 -> installer called ZERO times"
+else bad "WITH_APP=0 must not call the installer, got: $off"; fi
+
+on="$(run_dispatch 1)"
+if [ "$(printf '%s' "$on" | grep -c CALLED)" = "1" ]; then ok "WITH_APP=1 -> installer called exactly once"
+else bad "WITH_APP=1 must call the installer exactly once, got: $on"; fi
+
+if printf '%s' "$on" | grep -q -- '--launch'; then ok "the single call passes --launch"
+else bad "the call must pass --launch, got: $on"; fi
+
+if printf '%s' "$on" | grep -q -- '--supervise'; then bad "the call must NOT pass --supervise, got: $on"
+else ok "the call does not pass --supervise"; fi
 
 [ "$fail" -eq 0 ] && echo "startup-with-app: PASS" || echo "startup-with-app: FAIL"
 exit "$fail"

--- a/tests/startup-with-app.test.sh
+++ b/tests/startup-with-app.test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# `--with-app` is one entry point over two opt-in steps. The three properties that
+# can actually break it are ORDER, GUARD and BLAST RADIUS — not the flag string.
+#
+# startup.sh ends in `exec`, orchestrates ~15 services and resolves a workspace,
+# so a full execution test would need a fixture larger than the change. Instead
+# this EXECUTES the shipped parse loop (extracted from the real file at run time,
+# never retyped) and asserts the two structural invariants that make the block
+# reachable and non-fatal. Stated plainly so the evidence is not oversold.
+set -u
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+S="$REPO/src/startup.sh"
+fail=0
+ok()   { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1"; fail=1; }
+
+# 1. The shipped parse loop, executed — not a copy of it.
+parse="$(awk '/^WITH_APP=0$/,/^done$/' "$S")"
+[ -n "$parse" ] || { bad "could not extract the parse loop from startup.sh"; exit 1; }
+
+probe() { # args... -> prints resulting WITH_APP
+  ( set -- "$@"; eval "$parse"; echo "$WITH_APP" )
+}
+[ "$(probe)" = "0" ]                        && ok "no args -> WITH_APP=0"            || bad "no args should leave WITH_APP=0"
+[ "$(probe --with-app)" = "1" ]             && ok "--with-app -> WITH_APP=1"         || bad "--with-app should set WITH_APP=1"
+[ "$(probe --other --with-app)" = "1" ]     && ok "flag found in any position"       || bad "flag must be found in any position"
+[ "$(probe --withapp)" = "0" ]              && ok "--withapp (typo) -> 0"            || bad "a near-miss flag must not enable it"
+[ "$(probe --with-app=1)" = "0" ]           && ok "--with-app=1 -> 0 (exact match)"  || bad "only the exact token enables it"
+
+# 2. ORDER: the block must precede the final exec. After `exec` the process is
+#    replaced, so a block moved below it is dead code that still reads as present.
+app_line=$(grep -n 'install-menu-bar-app.sh" --supervise' "$S" | head -1 | cut -d: -f1)
+exec_line=$(grep -n '^exec bash "\$REPO/src/agent/start-cli.sh"' "$S" | head -1 | cut -d: -f1)
+if [ -n "$app_line" ] && [ -n "$exec_line" ] && [ "$app_line" -lt "$exec_line" ]; then
+  ok "installer invoked at line $app_line, before the exec at $exec_line"
+else
+  bad "installer must be invoked BEFORE the final exec (app=$app_line exec=$exec_line)"
+fi
+
+# 3. BLAST RADIUS: `set -e` is on, so an unguarded call would abort the core.
+#    The invocation must sit in an if-condition, which suppresses errexit.
+if awk -v n="$app_line" 'NR==n' "$S" | grep -q '^\s*if bash '; then
+  ok "invocation is in an if-condition — installer failure cannot abort the core"
+else
+  bad "installer call must be guarded (if/||) or set -e takes the core down with it"
+fi
+
+[ "$fail" -eq 0 ] && echo "startup-with-app: PASS" || echo "startup-with-app: FAIL"
+exit "$fail"

--- a/tests/startup-with-app.test.sh
+++ b/tests/startup-with-app.test.sh
@@ -51,10 +51,8 @@ else
   bad "installer call must be guarded (if/||) or set -e takes the core down with it"
 fi
 
-# 4. DISPATCH, EXECUTED. Everything above is structural: a reviewer mutated the
-#    guard to `if true` and every check still passed. This runs the shipped block.
-# Anchor on the INSTALLER CALL and take its enclosing if-block, never on the
-# guard's literal text — else mutating the guard breaks extraction, not behavior.
+# 4. DISPATCH, EXECUTED — the structural checks above all survived an `if true`
+# mutation. Anchored on the installer CALL, so mutating the guard breaks behavior.
 dispatch="$(python3 - "$S" <<'EXTRACT'
 import re, sys
 lines = open(sys.argv[1]).read().splitlines()

--- a/tests/startup-with-app.test.sh
+++ b/tests/startup-with-app.test.sh
@@ -29,7 +29,13 @@ probe() { # args... -> prints resulting WITH_APP
 
 # 2. ORDER: the block must precede the final exec. After `exec` the process is
 #    replaced, so a block moved below it is dead code that still reads as present.
-app_line=$(grep -n 'install-menu-bar-app.sh" --supervise' "$S" | head -1 | cut -d: -f1)
+app_line=$(grep -n 'install-menu-bar-app.sh" --launch' "$S" | head -1 | cut -d: -f1)
+
+# --with-app means "run the app". Installing a login-persistent launchd job is a
+# separate decision, and it is what bakes an install-time path into a LaunchAgent.
+grep -q 'install-menu-bar-app.sh" --supervise' "$S" \
+  && bad "--with-app must not install the launchd supervisor" \
+  || ok "--with-app launches without installing the launchd supervisor"
 exec_line=$(grep -n '^exec bash "\$REPO/src/agent/start-cli.sh"' "$S" | head -1 | cut -d: -f1)
 if [ -n "$app_line" ] && [ -n "$exec_line" ] && [ "$app_line" -lt "$exec_line" ]; then
   ok "installer invoked at line $app_line, before the exec at $exec_line"


### PR DESCRIPTION
## Concern

#2987 restored the menu-bar app's build path, but left starting everything as **two** commands. The owner asked for one, and was right that it belonged in #2987 — I split it off arguing it re-introduced the coupling #2677 removed. It doesn't, and that's the point of this diff: the default run is unchanged, so nothing is re-coupled.

```bash
bash src/startup.sh              # unchanged: headless core, app untouched
bash src/startup.sh --with-app   # core + build/sign/supervise the app
```

## The three things that can actually break it

Not the flag string — ORDER, GUARD, and BLAST RADIUS.

**Order.** `startup.sh` ends in `exec bash src/agent/start-cli.sh`, which replaces the process. A block placed below it is dead code that still reads as present in review. The invocation sits at 1357, the exec at 1367.

**Blast radius.** `set -e` is on. An unguarded call means a failed *opt-in* app install aborts the *core*. The call is an `if` condition, which suppresses errexit, and the failure branch says so:

```
✗ menu-bar app setup failed (exit N) — the core is unaffected and still starting.
```

**Parse.** Exact-token match only, so `--withapp` and `--with-app=1` do nothing rather than half-working.

## Evidence

`tests/startup-with-app.test.sh` — 7 assertions, all passing. It **executes the shipped parse loop**, extracted from `src/startup.sh` at run time rather than retyped, so a change to the real parse fails the test.

Mutation controls, all three fail as named and restore to PASS:

```
drop the if-guard (bare call under set -e)  -> FAIL "installer call must be guarded"
move the block below the exec (dead code)   -> FAIL "must be invoked BEFORE the final exec (app=1361 exec=1358)"
break the parse token                       -> FAIL "--with-app should set WITH_APP=1" (+1)
restore                                     -> PASS
```

`bash -n` clean. `shellcheck -S warning` reports one SC1090 at line 1060 — **pre-existing**, on a `. "$_RELAY_ENV"` line this diff does not touch.

## Scope I deliberately did not take

No `--with-app` in any launchd plist or installer default. Auto-start for the app is already `install-menu-bar-app.sh --supervise`; adding a second path to the same outcome is how two supervisors end up fighting over one bundle, which #2987's `stop_unmanaged()` exists to prevent.

@sonichi — flagging you as the reviewer.
