### PR TITLE
feat(discord-bridge): the send CLI had no way to reply to a message

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5771,9 +5771,8 @@ def _send_via_rest(channel_id: str, message: str, reply_to: str = ""):
         return
     for i, chunk in enumerate(chunks, 1):
         payload = {"content": chunk}
-        # FIRST chunk only, matching the gateway path: a reference on every chunk
-        # renders N reply-headers for one answer. fail_if_not_exists=False so a
-        # deleted target degrades to a plain message instead of losing the send.
+        # First chunk only: on every chunk it renders N reply-headers for one
+        # answer. fail_if_not_exists=False -> deleted target degrades to plain.
         if reply_to and i == 1:
             payload["message_reference"] = {"message_id": str(reply_to),
                                             "fail_if_not_exists": False}

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5734,7 +5734,23 @@ async def poll_dm_fallback():
         await asyncio.sleep(30)
 
 
-def _send_via_rest(channel_id: str, message: str):
+def _parse_send_argv(argv):
+    """Split `send`'s post-channel argv into (reply_to, body_argv).
+
+    `--reply-to <id>` threads the post onto an existing message, giving the CLI
+    the reach the results path already has by default. Leading position only, so
+    a body word that happens to read `--reply-to` cannot be eaten mid-text.
+    """
+    reply_to = ""
+    if len(argv) >= 2 and argv[0] == "--reply-to":
+        reply_to, argv = argv[1], argv[2:]
+    if not argv:
+        raise SystemExit("usage: discord-bridge.py send <channel_id> "
+                         "[--reply-to <message_id>] <body|--body-file PATH>")
+    return reply_to, argv
+
+
+def _send_via_rest(channel_id: str, message: str, reply_to: str = ""):
     """Send a message via Discord REST API (no gateway connection).
 
     Chunks via `_chunk_for_discord` so messages over Discord's 2000-char
@@ -5754,7 +5770,14 @@ def _send_via_rest(channel_id: str, message: str):
         # Empty message — nothing to send. Treat as no-op rather than error.
         return
     for i, chunk in enumerate(chunks, 1):
-        data = json.dumps({"content": chunk}).encode()
+        payload = {"content": chunk}
+        # FIRST chunk only, matching the gateway path: a reference on every chunk
+        # renders N reply-headers for one answer. fail_if_not_exists=False so a
+        # deleted target degrades to a plain message instead of losing the send.
+        if reply_to and i == 1:
+            payload["message_reference"] = {"message_id": str(reply_to),
+                                            "fail_if_not_exists": False}
+        data = json.dumps(payload).encode()
         req = urllib.request.Request(url, data=data, headers=headers)
         # Transport only: once urlopen returns, the message is committed, so
         # read() belongs below. Not a `with` — doubles are plain objects.
@@ -5831,7 +5854,8 @@ def _send_cli_body(argv: list) -> str:
 
 if __name__ == "__main__":
     if len(sys.argv) >= 4 and sys.argv[1] == "send":
-        _send_via_rest(sys.argv[2], _send_cli_body(sys.argv[3:]))
+        reply_to, body_argv = _parse_send_argv(sys.argv[3:])
+        _send_via_rest(sys.argv[2], _send_cli_body(body_argv), reply_to)
     elif sys.argv[1:2] == ["edit"]:
         # Arity is checked here rather than by the `>= 5` guard the send branch
         # uses: falling through on a short `edit` would boot the whole bridge.

--- a/tests/discord-send-reply-to.test.py
+++ b/tests/discord-send-reply-to.test.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""`discord-bridge.py send --reply-to` threads a CLI post onto an existing message.
+
+The results path already defaults to quoting the triggering message
+(`reply_to_id = source_message_anchor`). The `send` CLI had no reply target at
+all, so every proactive post — digests, corrections, announcements — arrived
+detached from the message it answered. These pin the REST payload shape, which
+is the only place the reference actually reaches Discord.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-reply-to-")
+_cd = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord"
+_cd.mkdir(parents=True, exist_ok=True)
+(_cd / "access.json").write_text('{"allowFrom": []}')
+(_cd / ".env").write_text("DISCORD_BOT_TOKEN=test-token-not-real\n")
+
+REPO = Path(__file__).resolve().parent.parent
+
+try:
+    import discord  # noqa: F401
+except ImportError:
+    stub = types.ModuleType("discord")
+    stub.Intents = type("Intents", (), {"default": staticmethod(
+        lambda: type("I", (), {"message_content": False})())})
+    stub.Client = type("Client", (), {"__init__": lambda self, **kw: None,
+                                      "event": staticmethod(lambda fn: fn)})
+    stub.File = type("File", (), {})
+    stub.Message = type("Message", (), {})
+    sys.modules["discord"] = stub
+
+_spec = importlib.util.spec_from_file_location("dbridge", REPO / "src" / "discord-bridge.py")
+bridge = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bridge)
+
+failures = []
+
+
+def check(cond, label):
+    print(("PASS  " if cond else "FAIL  ") + label)
+    if not cond:
+        failures.append(label)
+
+
+def capture(message, **kw):
+    """Run _send_via_rest against a stubbed transport; return the POSTed payloads."""
+    import urllib.request as ur
+    posted = []
+
+    class FakeResp:
+        status = 200
+        def read(self): return b"{}"
+
+    real_req, real_open = ur.Request, ur.urlopen
+    ur.Request = lambda url, data=None, headers=None: posted.append(json.loads(data)) or object()
+    ur.urlopen = lambda req, timeout=None: FakeResp()
+    try:
+        bridge._send_via_rest("123", message, **kw)
+    finally:
+        ur.Request, ur.urlopen = real_req, real_open
+    return posted
+
+
+# --- the payload, which is what Discord actually sees -----------------------
+one = capture("hello", reply_to="999888777666555444")
+check(len(one) == 1, "single chunk produces one POST")
+ref = one[0].get("message_reference")
+check(ref is not None, "reply_to sets message_reference on the first chunk")
+check((ref or {}).get("message_id") == "999888777666555444",
+      "message_reference carries the id passed in")
+check((ref or {}).get("fail_if_not_exists") is False,
+      "fail_if_not_exists is False so a deleted target degrades to a plain send")
+
+# The bug this guards: a reference on EVERY chunk renders N reply-headers for
+# one answer. Only the first chunk may carry it.
+multi = capture("y" * 1900 + "\n" + "z" * 1900, reply_to="111222333444555666")
+check(len(multi) > 1, "long body actually chunks (fixture is exercising the path)")
+check("message_reference" in multi[0], "first chunk of a chunked body carries the reference")
+check(all("message_reference" not in c for c in multi[1:]),
+      "later chunks carry NO reference")
+
+# Regression guard: the default must stay byte-identical to pre-change behavior.
+plain = capture("hello")
+check("message_reference" not in plain[0], "no reply_to -> no message_reference (unchanged default)")
+
+# --- argv parsing ------------------------------------------------------------
+check(bridge._parse_send_argv(["--reply-to", "42", "body"]) == ("42", ["body"]),
+      "--reply-to is consumed and the body survives")
+check(bridge._parse_send_argv(["body", "--reply-to", "42"]) == ("", ["body", "--reply-to", "42"]),
+      "leading position only: a body word reading --reply-to is not eaten")
+check(bridge._parse_send_argv(["--body-file", "/tmp/x"]) == ("", ["--body-file", "/tmp/x"]),
+      "--body-file still reaches _send_cli_body untouched")
+try:
+    bridge._parse_send_argv(["--reply-to", "42"])
+    check(False, "a --reply-to with no body raises SystemExit")
+except SystemExit:
+    check(True, "a --reply-to with no body raises SystemExit")
+
+print()
+if failures:
+    print(f"{len(failures)} FAILED: " + "; ".join(failures))
+    sys.exit(1)
+print("all reply-to assertions passed")


### PR DESCRIPTION
## The gap

The **results** path threads by default. `src/discord-bridge.py` resolves a reply target for every task result:

```python
reply_pattern = re.compile(r'\[reply:\s*(\d{17,20})\]')
...
if reply_to_id is None:
    reply_to_id = source_message_anchor   # quote the triggering message
```

The **`send` subcommand** had neither half. On `main`:

```python
def _send_via_rest(channel_id: str, message: str):
    ...
    data = json.dumps({"content": chunk}).encode()
```

No reply parameter, and nothing but `content` in the payload. So every post that does not originate from a task — digests, corrections, announcements, anything a script sends via `discord-bridge.py send` — arrives detached from the message it answers. In a busy channel the reply is the only thing tying a post to its referent.

This is a capability present on one path and structurally absent on its sibling, not a bug in either.

## The change

`send <channel_id> [--reply-to <message_id>] <body|--body-file PATH>`

- The reference goes on the **first chunk only**, matching the gateway path. On every chunk it renders N reply-headers for one answer.
- `fail_if_not_exists: false` — a deleted target degrades to a plain message rather than losing the send.
- `--reply-to` is recognised in **leading position only**, so a body word that happens to read `--reply-to` is not eaten mid-text.
- Argv parsing is `_parse_send_argv()` rather than inline in `__main__`, so the dispatch stays a dispatch and the parse is directly testable (CLAUDE.md: "dispatch methods route only; named endpoint methods own behavior").

Default behavior is byte-identical: with no `--reply-to`, the payload is the same `{"content": chunk}` it was before, pinned by an assertion.

## Evidence

**At `origin/main` — the test fails on the missing feature**, with the module loading cleanly (real worktree, not a hand-assembled fixture):

```
$ git worktree add --detach wt-ctrl origin/main && python3 wt-ctrl/tests/discord-send-reply-to.test.py
Traceback (most recent call last):
  File ".../tests/discord-send-reply-to.test.py", line 65, in capture
    bridge._send_via_rest("123", message, **kw)
TypeError: _send_via_rest() got an unexpected keyword argument 'reply_to'
```

My first control failed at *import* (`ModuleNotFoundError: workspace_default`) because I had copied the file into a bare directory — a broken fixture, which looks exactly like a working detector. The run above is the corrected one.

**At `HEAD` — 12/12 pass:**

```
PASS  single chunk produces one POST
PASS  reply_to sets message_reference on the first chunk
PASS  message_reference carries the id passed in
PASS  fail_if_not_exists is False so a deleted target degrades to a plain send
PASS  long body actually chunks (fixture is exercising the path)
PASS  first chunk of a chunked body carries the reference
PASS  later chunks carry NO reference
PASS  no reply_to -> no message_reference (unchanged default)
PASS  --reply-to is consumed and the body survives
PASS  leading position only: a body word reading --reply-to is not eaten
PASS  --body-file still reaches _send_cli_body untouched
PASS  a --reply-to with no body raises SystemExit
all reply-to assertions passed        (rc=0)
```

The chunked case asserts `len(multi) > 1` first, so a fixture that stopped chunking would fail loudly instead of vacuously passing the "later chunks carry no reference" check.

**review-checks:**

```
$ git diff origin/main...HEAD | bash scripts/review-checks.sh
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Relationship to #2817

#2817 also touches `src/discord-bridge.py`, on the *results* path — it fixes a quote-reply anchor dying with the bridge process. Different concern, and `gh pr diff 2817 | grep -cE '^\+.*(_parse_send_argv|--reply-to|reply_to: str)'` returns **0**, so there is no overlap in added lines. Whichever lands second may need a trivial rebase.

## What this does NOT change

The results path is untouched. Task replies were already threaded and still are; this only gives the CLI the same reach.