### PR TITLE
ci: bounded retry on review-checks' diff fetch (one 503 = dead lane, 5x today)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,13 @@ jobs:
         # a PR whose diff is genuinely empty fails here rather than passing unscanned.
         run: |
           set -euo pipefail
-          gh pr diff ${{ github.event.pull_request.number }} > /tmp/review-pr.diff
+          # Bounded retry on the fetch only (#3048): one transient GraphQL 503
+          # killed this lane 5x on 2026-08-17; three failures still fail closed.
+          for i in 1 2 3; do
+            gh pr diff ${{ github.event.pull_request.number }} > /tmp/review-pr.diff && break
+            if [ "$i" = 3 ]; then echo "gh pr diff failed after 3 attempts"; exit 1; fi
+            sleep $((i * 15))
+          done
           bash scripts/review-checks.sh --diff /tmp/review-pr.diff
 
       - name: Setup Node


### PR DESCRIPTION
## What

Bounded retry (3 attempts, 15s/30s backoff) around `gh pr diff` in the Review-checks step. Fetch only — the fail-closed contract is untouched.

## Why

`gh pr diff` resolves via GraphQL and the step deliberately fails closed (#2281: a failed fetch must fail the job, or an empty diff passes the scan vacuously). With no retry, a one-second platform 503 converts directly into a dead clean-install lane — and with auto-merge armed, a stalled merge train. Issue #3048 documents **five identical failures today** (`HTTP 503 ... api.github.com/graphql` one second into the step), every one green on rerun with zero code change; two of my PRs each burned 2-3 manual/looped reruns to land through it.

## Before / after — actual behavior

Before (parent, from today's runs): single 503 → `##[error]Process completed with exit code 1` → lane dead.

At HEAD, verified by simulation of the extracted step (stubbed `gh` failing N times):

```
--- succeed on attempt 3:
proceeded with diff: DIFF        rc=0
--- never succeed:
gh pr diff failed after 3 attempts   rc=1
```

Three consecutive failures still fail the job loudly — #2281's no-unscanned-merge guarantee is preserved; only the transient-blip path changes. YAML parses (`yaml.safe_load` on the workflow), step body passes `bash -n`.

Note: this being a workflow change, the modified step exercises itself on this very PR's run.

Closes #3048

— Sutando (qingyun-001)
