### PR TITLE
fix(census): a file the archiver moves mid-scan is a skip, not an abort

### DIFF
--- a/src/task_envelope_census.py
+++ b/src/task_envelope_census.py
@@ -67,11 +67,14 @@ def census(workspace: Path | None = None, days: float = 7.0) -> dict:
         if not d.is_dir():
             continue
         for p in sorted(d.rglob("task-*.txt")):
+            # One failure boundary for read AND stat: the archiver can move
+            # the file between them, and a vanished file is a skip, not an abort.
             try:
                 text = p.read_text(encoding="utf-8")
+                mtime = p.stat().st_mtime
             except OSError:
                 continue
-            if _task_epoch(p.name, text, p.stat().st_mtime) < cutoff:
+            if _task_epoch(p.name, text, mtime) < cutoff:
                 continue
             scanned += 1
             v = verify_text(text, ws)["verdict"]

--- a/tests/task-envelope-census.test.py
+++ b/tests/task-envelope-census.test.py
@@ -166,6 +166,28 @@ class CensusCliAndFallbacks(unittest.TestCase):
         self.assertEqual(j["verdicts"]["verified"], 1)
         self.assertEqual(j["unsigned_sources"], ["voice"])
 
+    def test_file_vanishing_between_read_and_stat_is_skipped(self):
+        # Archiver interleaving: the file is readable, then moved before
+        # stat(). The census must skip the claimed file, not abort.
+        from unittest import mock
+        signed = E.stamp_text("id: task-s\ntask: t\nsource: gateway\n",
+                              self.ws)
+        _write(self.ws, self._now_id("s"), signed)
+        victim = _write(self.ws, self._now_id("gone"),
+                        "id: task-g\ntask: t\nsource: voice\n")
+        real_read = Path.read_text
+
+        def read_then_archive(p, *a, **kw):
+            text = real_read(p, *a, **kw)
+            if p.name == victim.name:
+                p.unlink()
+            return text
+
+        with mock.patch.object(Path, "read_text", read_then_archive):
+            result = C.census(self.ws)
+        self.assertEqual(result["scanned"], 1)
+        self.assertNotIn("voice", result["by_source"])
+
     def test_main_gate_met_message_when_all_verified(self):
         import contextlib
         import io


### PR DESCRIPTION
## Concern

Follow-up to #3034, which auto-merged at `8915f088` at 19:07:11Z — one minute before the fix for its final review finding reached the branch (`ae802ed5`). So main's census carries the defect Codex's re-review named on #3034: `read_text()` is guarded against OSError, but the `p.stat()` beside it is not. The archiver moves task files into monthly dirs while the census walks the same tree; a move landing between read and stat aborts the whole telemetry run with FileNotFoundError instead of skipping one claimed file.

## Change

Cherry-pick of `c1c15cb3` (already reviewed in the #3034 thread, mutation-verified there):
- `src/task_envelope_census.py`: `stat()` moves inside the same `try/except OSError` as the read — a vanished file is a skip, not an abort.
- `tests/task-envelope-census.test.py`: `test_file_vanishing_between_read_and_stat_is_skipped` pins the exact interleaving (read succeeds → file unlinked → stat).

## Evidence

At parent (main `d623a6e3`), the new test errors:
```
FileNotFoundError: ... task-...gone.txt  (1 error, 10 pass)
```
At HEAD: `Ran 11 tests ... OK`. Mutation check in the #3034 thread: reverting only the fix hunk fails exactly this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)