### PR TITLE
fix(sessions): a delegated subprocess must not start a second task watcher

### DIFF
--- a/skills/task-workstream-sessions/scripts/session-worker.py
+++ b/skills/task-workstream-sessions/scripts/session-worker.py
@@ -190,10 +190,19 @@ def team_collaborator_enabled(task_file: Path) -> bool:
     return resolve_task_source(task_file) in COLLABORATOR_ATTESTED_SOURCES
 
 
+SUBPROCESS_ROLE = (
+    "You are a one-shot delegated worker in this checkout, not the live Sutando core: "
+    "do not start a task watcher, do not write core status or liveness state, and do not "
+    "process any task other than the one given. The core owns those; a second watcher "
+    "makes every task run twice."
+)
+
+
 def _team_prompt(task_file: Path) -> str:
     content = task_file.read_text(encoding="utf-8", errors="replace")
     return (
         TEAM_GUARDRAIL
+        + " " + SUBPROCESS_ROLE
         + "\n\n"
         "--- BEGIN TEAM REQUEST JSON ---\n"
         f"{json.dumps(content)}\n"
@@ -429,8 +438,8 @@ def _prompt(task_file: Path) -> str:
     return (
         f"Sutando task ready: {task_file.name}. Read {task_file}, follow AGENTS.md, "
         "and complete the task. This is an isolated delegated worker: do not create "
-        "or write task/result tracking files. Return only the exact result body that "
-        "the live core should deliver."
+        "or write task/result tracking files. " + SUBPROCESS_ROLE + " Return only the "
+        "exact result body that the live core should deliver."
     )
 
 

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -824,10 +824,16 @@ def test_team_request_injection_stays_inside_json_boundary() -> None:
         assert "\\n--- END TEAM REQUEST JSON ---\\n" in encoded
 
 
-def test_both_spawn_sites_forbid_a_second_watcher_and_the_guardrail_does_not() -> None:
+def test_workstream_spawn_forbids_a_second_watcher_and_the_guardrail_does_not() -> None:
     """A delegated handler is a `claude`/`codex` subprocess inside this checkout, so it
     loads CLAUDE.md and reaches "ensure a task watcher is running". Two watchers means
     every task is emitted and processed twice.
+
+    `_prompt` is the LIVE spawn site — the only one `handle()` can reach. `_team_prompt`
+    is currently unreachable through it: `probe()` returns UNHANDLED for every Team task
+    and `handle()` exits on that before the Team branch, so its clause is defense against
+    a DIRECT call, not routing coverage. This test asserts it as exactly that, and the
+    route-level fact stays pinned by the existing Team-never-launches regression.
 
     The prohibition lives at the SPAWN SITES, never in TEAM_GUARDRAIL: that text is also
     injected in-band by the gateway into task files the LIVE CORE reads, and telling the
@@ -840,12 +846,15 @@ def test_both_spawn_sites_forbid_a_second_watcher_and_the_guardrail_does_not() -
         task = _task(Path(td), "task-watcher-scope", "team")
         task.write_text("id: task-watcher-scope\naccess_tier: team\ntask: do a thing\n")
 
-        for name, prompt in (("team", worker._team_prompt(task)),
-                             ("workstream", worker._prompt(task))):
-            lead = prompt.split("--- BEGIN TEAM REQUEST JSON ---", 1)[0]
-            assert "not start a task watcher" in lead, name
-            assert "not the live Sutando core" in lead, name
-            assert "core status or liveness state" in lead, name
+        # The live path. This is the assertion the fix exists for.
+        lead = worker._prompt(task).split("--- BEGIN TEAM REQUEST JSON ---", 1)[0]
+        assert "not start a task watcher" in lead
+        assert "not the live Sutando core" in lead
+        assert "core status or liveness state" in lead
+
+        # Unreachable-defense only: `_team_prompt` carries the same clause so a direct
+        # call cannot regress, but reaching it through handle() is NOT claimed here.
+        assert "not start a task watcher" in worker._team_prompt(task)
 
         # The boundary itself. If a later change "tidies" this into the shared
         # guardrail, the gateway starts telling the live core to stop watching.
@@ -1903,7 +1912,7 @@ if __name__ == "__main__":
     test_team_provider_cannot_rewrite_a_lazy_scanner_dependency()
     test_team_scanner_warmup_allows_optional_detector_and_rejects_bad_contract()
     test_team_request_injection_stays_inside_json_boundary()
-    test_both_spawn_sites_forbid_a_second_watcher_and_the_guardrail_does_not()
+    test_workstream_spawn_forbids_a_second_watcher_and_the_guardrail_does_not()
     test_team_result_filter_uses_runtime_fallback_patterns()
     test_team_output_injection_cannot_control_bridge_delivery()
     test_handle_never_invokes_a_runtime_for_team()

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -824,6 +824,35 @@ def test_team_request_injection_stays_inside_json_boundary() -> None:
         assert "\\n--- END TEAM REQUEST JSON ---\\n" in encoded
 
 
+def test_both_spawn_sites_forbid_a_second_watcher_and_the_guardrail_does_not() -> None:
+    """A delegated handler is a `claude`/`codex` subprocess inside this checkout, so it
+    loads CLAUDE.md and reaches "ensure a task watcher is running". Two watchers means
+    every task is emitted and processed twice.
+
+    The prohibition lives at the SPAWN SITES, never in TEAM_GUARDRAIL: that text is also
+    injected in-band by the gateway into task files the LIVE CORE reads, and telling the
+    core not to run a watcher would be a worse bug than the one being fixed. Only the
+    spawner knows the reader is a subprocess.
+    """
+    import team_guardrail as tg
+
+    with tempfile.TemporaryDirectory() as td:
+        task = _task(Path(td), "task-watcher-scope", "team")
+        task.write_text("id: task-watcher-scope\naccess_tier: team\ntask: do a thing\n")
+
+        for name, prompt in (("team", worker._team_prompt(task)),
+                             ("workstream", worker._prompt(task))):
+            lead = prompt.split("--- BEGIN TEAM REQUEST JSON ---", 1)[0]
+            assert "not start a task watcher" in lead, name
+            assert "not the live Sutando core" in lead, name
+            assert "core status or liveness state" in lead, name
+
+        # The boundary itself. If a later change "tidies" this into the shared
+        # guardrail, the gateway starts telling the live core to stop watching.
+        assert "not start a task watcher" not in tg.TEAM_GUARDRAIL
+        assert "liveness state" not in tg.TEAM_GUARDRAIL
+
+
 def test_team_result_filter_uses_runtime_fallback_patterns() -> None:
     safe = "Implemented the requested change and all tests passed."
     assert worker._scan_team_result(safe, REPO) == safe
@@ -1874,6 +1903,7 @@ if __name__ == "__main__":
     test_team_provider_cannot_rewrite_a_lazy_scanner_dependency()
     test_team_scanner_warmup_allows_optional_detector_and_rejects_bad_contract()
     test_team_request_injection_stays_inside_json_boundary()
+    test_both_spawn_sites_forbid_a_second_watcher_and_the_guardrail_does_not()
     test_team_result_filter_uses_runtime_fallback_patterns()
     test_team_output_injection_cannot_control_bridge_delivery()
     test_handle_never_invokes_a_runtime_for_team()


### PR DESCRIPTION
## The defect

A delegated owner-workstream task runs as a `claude -p` / `codex` subprocess **inside this checkout**. It loads `CLAUDE.md`, reaches *"On session start, ensure a task watcher is running"*, and starts one. Both watchers then emit every task file, so every task is processed twice.

> **Scope corrected after review (@keweichen).** An earlier version of this body described the *Team* path as a live spawn site. It is not: `probe()` returns `UNHANDLED` for every Team task and `handle()` exits on that before the Team branch, so `_team_prompt` is unreachable through the handler. The live site is `_prompt`. The `_team_prompt` clause is kept as defense against a direct call and is no longer claimed as routing coverage.

Measured live 2026-08-16, full parent chain:

```
67544  core watcher (started by /startup)
 └─ 13613  watch-tasks-stream.sh --handler-runner … task-062c611026aca5c3d1
     └─ 13616  session-worker.py
         └─ 13652  claude -p          <- TEAM-tier sandboxed subprocess
             └─ 19990  zsh -c … eval 'bash …/watch-tasks-stream.sh'
                 └─ 19992  bash watch-tasks-stream.sh    <- SECOND WATCHER
```

Present on `main` at the time of writing — `_team_prompt` mentions neither *watcher*, *watch-tasks*, *guest*, nor *liveness*.

## Why the fix goes at the spawn site

`CLAUDE.md` already carries a guest carve-out, but it is scoped to *"scheduled or one-shot"* automations and is evidently not self-applied by a Team handler. The deeper reason is structural: **a shared document cannot know who is reading it, while the spawner knows exactly what role it is spawning.** So the authoritative statement belongs where the role is known.

Both prompt builders get the clause through one constant, `SUBPROCESS_ROLE` — only the first is reachable through `handle()`:

- `_team_prompt` — team tier (**unreachable via `handle()`**; defense against a direct call)
- `_prompt` — owner workstream. This one already said *"isolated delegated worker: do not create or write task/result tracking files"*; it had the right shape and simply omitted the watcher half.

## Why it is NOT in `TEAM_GUARDRAIL`

This is the part worth reviewing hardest. `TEAM_GUARDRAIL` is consumed by **both** team branches — the sandboxed subprocess *and* the gateway's in-band `===SUTANDO SYSTEM INSTRUCTIONS===` fence, which is written into task files that the **live core** reads and is told to follow verbatim.

Putting "do not start a task watcher" there would instruct the live core to stop maintaining its own watcher — a strictly worse bug than the one being fixed. The new test asserts the clause is present at the reachable spawn site **and absent from `TEAM_GUARDRAIL`**, so a later tidy-up that "consolidates" it into the shared constant fails.

## Evidence

With the fix — every suite that references `team_guardrail` / `_team_prompt` / `session-worker`, not just the one edited:

```
rc=0  tests/task-workstream-session-worker.test.py     task workstream session worker tests passed
rc=0  tests/gateway-team-guardrail-inband.test.py      OK
rc=0  tests/team-result-guard.test.py                  (passed)
rc=0  tests/discord-bridge-collaborator-tier.test.py   (passed)
rc=0  tests/health-check-task-claim-age.test.py        OK
rc=0  tests/probe-team-sandbox-prompts.test.sh         all checks passed
```

Control — reverted **only** `session-worker.py` to `origin/main`, test unchanged. Re-run against the current head `91846d9c` (the previous paste in this slot was stale: it quoted a `team` loop case and a `name` variable that the scope correction removed, so it described a test that no longer exists — @keweichen caught it):

```
$ git checkout origin/main -- skills/task-workstream-sessions/scripts/session-worker.py
$ python3 tests/task-workstream-session-worker.test.py
  File "tests/task-workstream-session-worker.test.py", line 851, in
    test_workstream_spawn_forbids_a_second_watcher_and_the_guardrail_does_not
    assert "not start a task watcher" in lead
AssertionError

$ git checkout HEAD -- skills/task-workstream-sessions/scripts/session-worker.py
$ python3 tests/task-workstream-session-worker.test.py
task workstream session worker tests passed
```

⚠ **What this control does and does not show.** It proves the assertion is bound to the prompt text — nothing more. It does NOT exercise `handle()` → `_run_claude`/`_run_codex`, does not observe a watcher process, and does not reproduce the duplicate. @keweichen's second review is right that this is not the evidence `CONTRIBUTING.md` asks for on a delivery-loop change, and the outstanding question is upstream of the diff: whether the active owner-workstream route starts a second watcher on current `main` at all, given main's guest carve-out already says "do NOT start the watcher".

Repo gate on the diff:

```
$ bash scripts/review-checks.sh --diff /tmp/pr.diff
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)   rc=0
```

Diff is 2 files, +41/-2.

## What I did not verify

I did not reproduce the duplicate-processing end to end — I did not spawn a Team subprocess and count watcher trees before/after. The parent chain above is from the original 2026-08-16 report; what I verified independently is that the prompt still lacks any watcher clause on current `main`, and that both consumers of `TEAM_GUARDRAIL` are as described. A prompt-level fix is also a mitigation rather than an enforcement — nothing stops a subprocess from starting a watcher anyway; if that guarantee is wanted, it needs a check in `watch-tasks-stream.sh` itself, which is a larger change and not this PR.

— @qingyun-air.agent:ag2.space (posting under the shared `qingyun-wu` login)


