### PR TITLE
fix(routing): a bridge claims a destination it cannot address, then quarantines it

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5166,9 +5166,8 @@ async def poll_proactive():
                 continue
             for f in RESULTS_DIR.iterdir():
                 if f.name.startswith("proactive-") and f.suffix == ".txt":
-                    # Decline a destination this bridge cannot address, BEFORE
-                    # claiming it: claiming then failing quarantines the file out
-                    # of results/, where the gateway's takeover can never see it.
+                    # Decline BEFORE claiming: claiming then failing quarantines
+                    # the file out of results/, where no takeover can see it.
                     try:
                         _target = explicit_target(f.read_text(encoding="utf-8"))
                     except OSError:

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -348,6 +348,10 @@ if not TOKEN:
 
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+
+# Discord snowflakes. A body addressed to anything else belongs to another
+# bridge, and taking it is what strands it in results/undelivered/.
+DISCORD_CHANNEL_ID_RE = r"\d{17,20}"
 STATE_DIR = REPO / "state"
 ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
 ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
@@ -5150,7 +5154,11 @@ async def poll_proactive():
             # decision rule (last-active channel from
             # state/last-owner-activity.json; default discord on missing
             # state).
-            from proactive_routing import should_claim_proactive  # noqa: E402
+            from proactive_routing import (  # noqa: E402
+                can_route,
+                explicit_target,
+                should_claim_proactive,
+            )
             if not should_claim_proactive(
                 STATE_DIR / "last-owner-activity.json", "discord"
             ):
@@ -5158,6 +5166,15 @@ async def poll_proactive():
                 continue
             for f in RESULTS_DIR.iterdir():
                 if f.name.startswith("proactive-") and f.suffix == ".txt":
+                    # Decline a destination this bridge cannot address, BEFORE
+                    # claiming it: claiming then failing quarantines the file out
+                    # of results/, where the gateway's takeover can never see it.
+                    try:
+                        _target = explicit_target(f.read_text(encoding="utf-8"))
+                    except OSError:
+                        continue  # racing consumer already claimed it
+                    if not can_route(_target, DISCORD_CHANNEL_ID_RE):
+                        continue
                     # Claim-by-rename: atomically move the file to a
                     # `.sending` suffix so a concurrent poll iteration
                     # (this coroutine, a race with the same-node telegram

--- a/src/proactive_routing.py
+++ b/src/proactive_routing.py
@@ -30,6 +30,7 @@ duplicate to every configured bridge.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 # Channels whose bridges actually deliver `proactive-*.txt` files.
@@ -103,3 +104,32 @@ def should_claim_proactive(state_file_path: Path, this_channel: str) -> bool:
     # most recently interacted on a surface that doesn't deliver DMs.
     # Default Discord rather than strand the proactive file.
     return this_channel == "discord"
+
+
+# Discord ids are 17-20 digits; Slack's are [CDG][A-Z0-9]+; ag2.space rooms are
+# !opaque:domain. A bridge passes its own grammar — this module names none.
+def explicit_target(body: str) -> "str | None":
+    """The destination the body addresses, or None when it addresses none.
+
+    Grammar comes from result_markers, never a local regex (CLAUDE.md: a result
+    consumer must not re-declare marker syntax).
+    """
+    try:
+        from result_markers import parse_markers
+    except ImportError:  # pragma: no cover - flat src/ import path
+        from .result_markers import parse_markers  # type: ignore[no-redef]
+    for action in parse_markers(body).actions:
+        if action.kind == "redirect":
+            return action.value
+    return None
+
+
+def can_route(target: "str | None", id_pattern: str) -> bool:
+    """Whether a bridge whose ids match `id_pattern` can address `target`.
+
+    A body with no explicit target is routable by whoever routing picks, so
+    None is True: this narrows nothing that worked before.
+    """
+    if target is None:
+        return True
+    return re.fullmatch(id_pattern, target) is not None

--- a/tests/proactive-routability.test.py
+++ b/tests/proactive-routability.test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""A bridge must decline a destination it cannot address.
+
+Five proactive messages addressed to ag2.space rooms were claimed by the Discord
+bridge, failed to send, and were quarantined into results/undelivered/. The
+gateway bridge has a takeover path for abandoned proactives, but it scans
+results/ root only — so quarantining removes the file from the one directory
+that could have recovered it. Declining before claiming is what keeps the
+takeover reachable.
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+from proactive_routing import can_route, explicit_target  # noqa: E402
+
+DISCORD = r"\d{17,20}"
+SLACK = r"[CDG][A-Z0-9]+"
+AG2SPACE = r"![A-Za-z0-9]+:[a-z0-9.]+"
+
+failures = []
+
+
+def check(cond, label):
+    print(("PASS  " if cond else "FAIL  ") + label)
+    if not cond:
+        failures.append(label)
+
+
+# The actual body that was lost, verbatim in shape.
+LOST = "[channel: !PrxhizfLysTYrYDcnw:ag2.space]\n**Sublist #54** — 13 new / 3 carried"
+
+check(explicit_target(LOST) == "!PrxhizfLysTYrYDcnw:ag2.space",
+      "the ag2.space room id is extracted as the explicit target")
+check(not can_route(explicit_target(LOST), DISCORD),
+      "Discord DECLINES the ag2.space target (the whole point)")
+check(can_route(explicit_target(LOST), AG2SPACE),
+      "the gateway's grammar DOES accept it, so declining strands nothing")
+check(not can_route(explicit_target(LOST), SLACK),
+      "Slack declines it too")
+
+# A Discord-addressed body must still be claimed — this must narrow nothing.
+D = "[channel: 1530802402603700415]\nreply goes to #dev"
+check(explicit_target(D) == "1530802402603700415", "a Discord id is extracted")
+check(can_route(explicit_target(D), DISCORD), "Discord still claims its own targets")
+
+# No marker at all is the common case: routing picks, unchanged.
+check(explicit_target("plain proactive body, no marker") is None,
+      "a body with no redirect has no explicit target")
+check(can_route(None, DISCORD) and can_route(None, SLACK) and can_route(None, AG2SPACE),
+      "no target -> every bridge still routable (behavior unchanged)")
+
+# The dm-only privacy guard suppresses the redirect entirely. A suppressed
+# redirect must read as 'no explicit target', never as an unroutable one --
+# otherwise the guard would make every bridge decline and strand the body.
+DM = "[dm-only]\n[channel: !PrxhizfLysTYrYDcnw:ag2.space]\nprivate calendar contents"
+check(explicit_target(DM) is None,
+      "dm-only suppresses the redirect, so no target is reported")
+check(can_route(explicit_target(DM), DISCORD),
+      "a dm-only body stays claimable — the guard must not strand it")
+
+# Anchoring: a target that merely CONTAINS digits must not pass as a snowflake.
+check(not can_route("!abc1530802402603700415:ag2.space", DISCORD),
+      "match is anchored — an embedded snowflake does not make it Discord's")
+
+# --- WIRING: the helper passing proves nothing if Discord never calls it ------
+# ORDER is the invariant. Declining AFTER the claim-by-rename would still
+# quarantine, which is the defect; the check must precede the rename.
+_src = (REPO / "src" / "discord-bridge.py").read_text()
+check("can_route" in _src and "explicit_target" in _src,
+      "discord-bridge imports the shared routability policy")
+check("DISCORD_CHANNEL_ID_RE" in _src,
+      "discord-bridge declares its own id grammar (the module names none)")
+
+_decline = _src.find("if not can_route(_target, DISCORD_CHANNEL_ID_RE)")
+_claim = _src.find('claim = f.with_suffix(".sending")')
+check(_decline != -1, "the decline branch is present")
+check(_claim != -1, "the claim-by-rename is present")
+check(_decline != -1 and _claim != -1 and _decline < _claim,
+      f"decline precedes claim-by-rename (decline@{_decline} < claim@{_claim})")
+
+# It must LEAVE the file, not quarantine it -- the gateway's takeover scans
+# results/ root, so a rename anywhere makes recovery impossible.
+_between = _src[_decline:_claim] if (_decline != -1 and _claim != -1) else ""
+check("continue" in _between and "undelivered" not in _between,
+      "declining leaves the file in results/ (no rename, no quarantine)")
+
+# The regex must not be re-declared anywhere else in the bridge.
+check(_src.count('r"\\d{17,20}"') <= 1,
+      "the snowflake grammar is declared once, not copied")
+
+print()
+if failures:
+    print(f"{len(failures)} FAILED: " + "; ".join(failures))
+    sys.exit(1)
+print("all routability assertions passed")

--- a/tests/proactive-routability.test.py
+++ b/tests/proactive-routability.test.py
@@ -53,9 +53,8 @@ check(explicit_target("plain proactive body, no marker") is None,
 check(can_route(None, DISCORD) and can_route(None, SLACK) and can_route(None, AG2SPACE),
       "no target -> every bridge still routable (behavior unchanged)")
 
-# The dm-only privacy guard suppresses the redirect entirely. A suppressed
-# redirect must read as 'no explicit target', never as an unroutable one --
-# otherwise the guard would make every bridge decline and strand the body.
+# dm-only suppresses the redirect: it must read as 'no target', never as an
+# unroutable one, or the privacy guard would strand the body everywhere.
 DM = "[dm-only]\n[channel: !PrxhizfLysTYrYDcnw:ag2.space]\nprivate calendar contents"
 check(explicit_target(DM) is None,
       "dm-only suppresses the redirect, so no target is reported")
@@ -67,8 +66,7 @@ check(not can_route("!abc1530802402603700415:ag2.space", DISCORD),
       "match is anchored — an embedded snowflake does not make it Discord's")
 
 # --- WIRING: the helper passing proves nothing if Discord never calls it ------
-# ORDER is the invariant. Declining AFTER the claim-by-rename would still
-# quarantine, which is the defect; the check must precede the rename.
+# ORDER is the invariant: declining after the rename still quarantines.
 _src = (REPO / "src" / "discord-bridge.py").read_text()
 check("can_route" in _src and "explicit_target" in _src,
       "discord-bridge imports the shared routability policy")


### PR DESCRIPTION
## The defect, in two halves

**Half one — the claim ignores the destination.** `proactive_routing.should_claim_proactive` decides ownership entirely from `state/last-owner-activity.json`:

```python
if last_channel in BRIDGE_CHANNELS:
    return last_channel == this_channel
```

No bridge consults the body. So a proactive addressed `[channel: !PrxhizfLysTYrYDcnw:ag2.space]` is claimed by whichever bridge the owner was last active on — Discord — which cannot address a Matrix room id.

**Half two, and this is the one that makes it unrecoverable — the failure path destroys the recovery path.** The gateway bridge already handles exactly this case (`src/remote-gateway-bridge.py:143`), and its docstring says so:

```python
def _ag2space_proactive_claim_gate(path):
    """Claim when routing says the owner lives here; otherwise claim only what
    no other bridge will ever take."""
    ...
    return (now - path.stat().st_mtime) >= _PROACTIVE_GRACE_S   # abandoned -> take it
```

`_PROACTIVE_GRACE_S = 180`, `_PROACTIVE_ABANDONED_S = 6h`. Had Discord simply left the file alone, the gateway would have delivered it. Instead Discord renames it:

```python
f.rename(f.parent / "undelivered" / f.name)
```

and the gateway scans `RESULTS_DIR.glob("proactive-*.txt")` — **results/ root only**. Measured on a live host:

```
results/              0 proactive files
results/undelivered/  4 proactive files, oldest 14h56m, all ag2.space rooms
```

The quarantine was written as the careful option — *"NOT deleted; a confirmation is still owed"* — and it is precisely what makes recovery impossible. Nothing reads that directory, so the loss is silent; `health-check.py` warns, but no one is paged.

## The change

A bridge declines a destination it cannot address, **before** claiming, and leaves the file in place. The existing takeover does the rest, unchanged.

Policy lives in the shared dependency-light module (CLAUDE.md: shared adapter policy is core); **each bridge passes its own id grammar and the module names none**:

```python
def explicit_target(body) -> str | None   # grammar from result_markers, never a local regex
def can_route(target, id_pattern) -> bool # None -> True: narrows nothing that worked
```

`src/discord-bridge.py` declares `DISCORD_CHANNEL_ID_RE = r"\d{17,20}"` and skips what doesn't match.

## Evidence

**Control at `origin/main`** — module loads cleanly (so the fixture is sound), test fails on the missing feature:

```
proactive_routing imports cleanly: True
explicit_target present: False
can_route present: False
ImportError: cannot import name 'can_route' from 'proactive_routing'
```

**At HEAD — 17/17.** The fixture is the body that was actually lost:

```
PASS  the ag2.space room id is extracted as the explicit target
PASS  Discord DECLINES the ag2.space target (the whole point)
PASS  the gateway's grammar DOES accept it, so declining strands nothing
PASS  Discord still claims its own targets
PASS  no target -> every bridge still routable (behavior unchanged)
PASS  dm-only suppresses the redirect, so no target is reported
PASS  a dm-only body stays claimable — the guard must not strand it
PASS  match is anchored — an embedded snowflake does not make it Discord's
PASS  decline precedes claim-by-rename (decline@272560 < claim@273371)
PASS  declining leaves the file in results/ (no rename, no quarantine)
PASS  the snowflake grammar is declared once, not copied
```

**Order control** — the two order assertions are the load-bearing ones, since declining *after* the rename would still quarantine. Moving the block after `f.rename(claim)`:

```
FAIL  decline precedes claim-by-rename (decline@273387 < claim@273055)
FAIL  declining leaves the file in results/ (no rename, no quarantine)
```

`review-checks`: PASS (hardcoded-paths + root-artifacts + prose-cap clean).

## Deliberately not in this PR

- **Claim-by-target**, so delivery is prompt rather than waiting out the 6h abandonment window. This PR converts silent loss into slow delivery; that one makes it fast.
- **A per-bridge `on_down` policy** (hold / presence-fallback / reroute-to-owner) with a bounded hold deadline. A `hold` without a deadline would recreate this failure with better intentions.

Both are being discussed with the owner and want his call on placement and timing.

## Scope note

A target Discord *can* route but that fails for another reason — deleted channel, missing permission — still quarantines, and should: that one is genuinely undeliverable and owed to the owner. The distinction this PR draws is "not mine to route" versus "mine and broken", and only the first is released.