### PR TITLE
fix(envelope): corrupt key file yields a loud error or 'unverifiable', never a zero-length key

### DIFF
--- a/src/task_envelope.py
+++ b/src/task_envelope.py
@@ -52,13 +52,26 @@ def key_path(workspace: Path | None = None) -> Path:
     return (workspace or resolve_workspace()) / _KEY_RELPATH
 
 
+def _parse_key(text: str, p: Path) -> bytes:
+    """Exactly 64 hex chars / 32 bytes, or ValueError. bytes.fromhex('')
+    returns b'' without raising, so an EMPTY key file otherwise stamps and
+    verifies under a zero-length key — mirrored guard in task_envelope.ts."""
+    key = bytes.fromhex(text)
+    if len(text) != 64 or len(key) != 32:
+        raise ValueError(
+            f"invalid task-hmac key at {p} (want 64 hex chars, got {len(text)})")
+    return key
+
+
 def load_key(workspace: Path | None = None) -> "bytes | None":
     """Read-only: None when no key exists. Verification MUST use this —
     minting a key from a verify path turns a fresh/restored host's first
-    verification of a good file into a false `invalid` (review finding)."""
+    verification of a good file into a false `invalid` (review finding).
+    A PRESENT-but-corrupt key raises ValueError (verify_text maps it to
+    'unverifiable' — the key is at fault, not the file being judged)."""
+    p = key_path(workspace)
     try:
-        return bytes.fromhex(
-            key_path(workspace).read_text(encoding="utf-8").strip())
+        return _parse_key(p.read_text(encoding="utf-8").strip(), p)
     except FileNotFoundError:
         return None
 
@@ -66,7 +79,7 @@ def load_key(workspace: Path | None = None) -> "bytes | None":
 def load_or_create_key(workspace: Path | None = None) -> bytes:
     p = key_path(workspace)
     try:
-        return bytes.fromhex(p.read_text(encoding="utf-8").strip())
+        return _parse_key(p.read_text(encoding="utf-8").strip(), p)
     except FileNotFoundError:
         pass
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -83,7 +96,7 @@ def load_or_create_key(workspace: Path | None = None) -> bytes:
         pass
     finally:
         tmp.unlink(missing_ok=True)
-    return bytes.fromhex(p.read_text(encoding="utf-8").strip())
+    return _parse_key(p.read_text(encoding="utf-8").strip(), p)
 
 
 def _strip_stamp(text: str) -> tuple[str, str | None]:
@@ -127,7 +140,11 @@ def verify_text(text: str, workspace: Path | None = None) -> dict:
     stripped, mac = _strip_stamp(text)
     if mac is None:
         return {"verdict": "unsigned", "reason": "no stamp line"}
-    key = load_key(workspace)
+    try:
+        key = load_key(workspace)
+    except ValueError:
+        return {"verdict": "unverifiable",
+                "reason": "corrupt local key — cannot judge; treat as warn"}
     if key is None:
         return {"verdict": "unverifiable",
                 "reason": "no local key — cannot judge; treat as warn"}

--- a/tests/task-envelope.test.py
+++ b/tests/task-envelope.test.py
@@ -267,6 +267,46 @@ class FailOpenArms(unittest.TestCase):
         self.assertIsNotNone(m, "stamp call must be fail-open wrapped")
 
 
+class CorruptKeyFile(unittest.TestCase):
+    """bytes.fromhex('') returns b'' without raising, so before the
+    _parse_key guard an EMPTY key file stamped and verified under a
+    zero-length key; a malformed one crashed verify callers instead of
+    yielding a verdict. Mirrored guard in task_envelope.ts (#3058)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory(prefix="env-ck-")
+        self.ws = Path(self._tmp.name)
+        (self.ws / "state" / "auth").mkdir(parents=True)
+        self.keyfile = self.ws / "state" / "auth" / "task-hmac.key"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_stamping_rejects_corrupt_key_content(self):
+        for bad in ("", "zzzz", "deadbeef", "a" * 63):
+            self.keyfile.write_text(bad)
+            with self.assertRaises(ValueError, msg=f"key file {bad!r}"):
+                E.load_or_create_key(self.ws)
+            with self.assertRaises(ValueError, msg=f"key file {bad!r}"):
+                E.stamp_text("id: task-x\ntask: t\n", self.ws)
+
+    def test_verify_maps_corrupt_key_to_unverifiable(self):
+        good = E.stamp_text("id: task-x\ntask: t\n", self.ws)
+        for bad in ("", "zzzz"):
+            self.keyfile.write_text(bad)
+            v = E.verify_text(good, self.ws)
+            self.assertEqual(v["verdict"], "unverifiable",
+                             f"key file {bad!r} must not crash or blame content")
+            self.assertIn("corrupt local key", v["reason"])
+
+    def test_missing_key_still_distinct_from_corrupt(self):
+        self.keyfile.parent.mkdir(parents=True, exist_ok=True)
+        v = E.verify_text("id: task-x\nenvelope_hmac: v1:" + "a" * 64 + "\ntask: t\n",
+                           self.ws)
+        self.assertEqual(v["verdict"], "unverifiable")
+        self.assertIn("no local key", v["reason"])
+
+
 class WriterWiring(unittest.TestCase):
     """The two phase-1 writers must import and call stamp_task on the text
     they persist; a regex pin so the call cannot silently vanish."""


### PR DESCRIPTION
## What

Python half of the corrupt-key-file finding air raised on #3058 (fixed there for TS at 0914e8ba). `bytes.fromhex('')` returns `b''` without raising, so a present-but-EMPTY `state/auth/task-hmac.key`:

- **stamped** under a zero-length key (`load_or_create_key` returned `b''`), emitting well-formed envelopes no correctly-keyed verifier accepts, and
- **verified** with the wrong blame: `verify_text` computed with the `b''` key and returned `invalid` — accusing the *file* of tampering when the *key* was corrupt.

A malformed key (`'zzzz'`) had the opposite failure: `fromhex` raised out of `load_key`, so verify callers crashed instead of getting a verdict.

## Fix

Both loaders parse through a new `_parse_key` (exactly 64 hex chars / 32 bytes, `ValueError` otherwise). `verify_text` maps a corrupt key to `unverifiable` with reason `corrupt local key — cannot judge; treat as warn`, distinct from the keyless-host reason. Stamp-side writers keep their existing fail-open wrappers → an unstamped task, counted `unsigned` by the census (visible, not wrong).

## Evidence

Before (at 1fc015ca, parent of this branch):
```
>>> bytes.fromhex('')
b''                      # no raise — stamps under zero-length key
>>> verify_text(stamped_good_file, ws_with_empty_keyfile)
{'verdict': 'invalid', ...}   # blames the file, key is at fault
>>> load_key(ws_with_zzzz_keyfile)
ValueError               # crashes verify callers
```

After (this head): `tests/task-envelope.test.py` 26/26 — new `CorruptKeyFile` class drives `''`/`'zzzz'`/`'deadbeef'`/63-hex-chars through both loaders (raise), `verify_text` → `unverifiable`+`corrupt local key` for `''`/`'zzzz'`, and pins missing-key vs corrupt-key as distinct reasons. Mutation-verified: neutralizing the `_parse_key` length check fails 5 assertions; restored → 26/26. `tests/task-envelope-census.test.py` also green (load_key consumer).

## Scope

Single concern: the key-loader guard. TS mirror already on #3058; not stacked — both merge independently.

— Sutando (qingyun-001) · owner-identifier: @sutando-qingyun-001:ag2.space