### PR TITLE
test(claim-machine): pin hypothesis — nightly engine changes only by deliberate PR

### DIFF
--- a/.github/workflows/claim-machine-nightly.yml
+++ b/.github/workflows/claim-machine-nightly.yml
@@ -21,8 +21,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install hypothesis (required — absence fails the run)
-        run: python3 -m pip install hypothesis
+      - name: Install hypothesis (required — absence fails the run; exact pin
+              so the nightly engine only changes by deliberate PR)
+        run: python3 -m pip install -r requirements-claim-machine.txt
       - name: Deterministic frozen-schedule regressions (sanity)
         run: python3 tests/outbox-claim-regressions.test.py
       - name: ClaimMachine exploration

--- a/requirements-claim-machine.txt
+++ b/requirements-claim-machine.txt
@@ -1,0 +1,4 @@
+# ClaimMachine nightly ONLY — test-scope dependency, never in the production
+# dependency graph. Exact pin: the nightly must not silently test a different
+# search/shrink engine each day; upgrades are deliberate PRs, not drift.
+hypothesis==6.165.10


### PR DESCRIPTION
## What

Owner dependency-policy conclusion on #3006, applied: the nightly bare-installed `hypothesis` latest, silently testing a different search/shrink engine each day. Now: `requirements-claim-machine.txt` with an exact pin (`hypothesis==6.165.10`, current latest), installed by the workflow. Upgrades become deliberate PRs (Dependabot/manual), never drift.

The sharpest consequence of not pinning is about the artifact this suite exists to produce: **an unpinned shrinker can emit a DIFFERENT minimal counterexample for the same defect on consecutive days, and the second reads as a new finding** — shrinking behavior carries no compatibility promise across hypothesis versions. The pinned version is also the exact engine (6.165.10) under which tonight's Design C evaluation runs were recorded, so the explorer and those recorded results share one search/shrink implementation; future divergence between them is a real signal, not a version artifact.

Transitive dependencies (attrs, sortedcontainers) deliberately stay floating: shrinking is implemented in hypothesis itself, so a full lockfile adds upgrade friction without protecting the artifact. Hypothesis remains test-scope only — nothing enters the production dependency graph.

## Stacked PR

**Parent: #3006** (`exp/claim-machine`), this PR is based on it — merge order: #3006 first, then rebase/retarget this onto main and rerun checks per the stacked-PR rules. Kept separate deliberately: #3006 is armed with three current approvals, and a content push would dismiss them; the policy lands minutes behind instead of costing a re-approval cycle. Worst case before this lands is one nightly run on bare latest.

— Sutando (qingyun-001) · owner-identifier: @sutando-qingyun-001:ag2.space
