### PR TITLE
fix(vision): stop the stream when the voice client disconnects, terminally

### DIFF
--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -487,6 +487,10 @@ export function setVisionSpeechEvidence(fn: (() => { active: boolean }) | null):
 	speechEvidenceFn = fn;
 }
 
+/** Why the last stop happened. 'no-client' is TERMINAL: the browser must tear
+ *  its push session down rather than treat the stop as a server-side glitch. */
+let lastStopReason: string | null = null;
+
 let bucketBytes = VISION_BUCKET_MAX_BYTES;
 let bucketRefillAt = Date.now();
 let lastFrameSentAt = 0;
@@ -672,6 +676,9 @@ export interface VisionState {
 	frames: number;
 	durationMs: number;
 	sessionReady: boolean;
+	/** Why streaming last stopped, when it was stopped deliberately. 'no-client'
+	 *  is terminal — a push driver seeing it must tear down, not re-arm. */
+	stoppedReason: string | null;
 	/** P7 D7.4 egress diagnostics: real sends vs gate/budget deferrals and
 	 *  displaced (dropped) slot frames. */
 	egress: {
@@ -696,6 +703,7 @@ export function getVisionState(): VisionState {
 		frames: frameCount,
 		durationMs: streaming && startedAt ? Date.now() - startedAt : 0,
 		sessionReady: getSendFile() !== null,
+		stoppedReason: streaming ? null : lastStopReason,
 		egress: getVisionEgressStats(),
 	};
 }
@@ -730,6 +738,7 @@ export function startStreaming(
 			// Push mode — caller (web-client, Mentra bridge, glasses webhook,
 			// etc.) captures frames and POSTs them to /vision/frame. No ticker.
 			stopStream();
+			lastStopReason = null; // a new push session supersedes any terminal stop
 			pushMode = true;
 			pushSourceName = lower;
 			frameCount = 0;
@@ -776,8 +785,9 @@ export function startStreaming(
 }
 
 /** Programmatic stop (used by the HTTP control server / button). */
-export function stopStreaming(): { status: 'stopped' | 'idle'; source: string | null; frames: number; durationMs: number } {
+export function stopStreaming(reason?: string): { status: 'stopped' | 'idle'; source: string | null; frames: number; durationMs: number } {
 	const r = stopStream();
+	if (r.wasRunning) lastStopReason = reason ?? null;
 	return { status: r.wasRunning ? 'stopped' : 'idle', source: r.source, frames: r.frames, durationMs: r.durationMs };
 }
 
@@ -933,6 +943,7 @@ function noteFrameFailure(msg: string): void {
 }
 
 function startStream(source: VisionSource, fps: number): { fps: number; intervalMs: number } {
+	lastStopReason = null; // a new stream supersedes any terminal stop
 	const clamped = Math.max(MIN_FPS, Math.min(MAX_FPS, fps));
 	const intervalMs = Math.max(MIN_INTERVAL_MS, Math.round(1000 / clamped));
 	if (ticker) clearInterval(ticker);

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -1111,7 +1111,10 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 				if (!buf) return respond(413, { status: 'failed', error: 'frame body too large' });
 				const mime = (req.headers['content-type'] as string | undefined) || 'image/jpeg';
 				const r = submitFrame(buf, mime);
-				respond(r.ok ? 200 : r.reason === 'frame-too-large' ? 413 : 409, r.ok ? { status: 'sent' } : { status: 'failed', error: r.error });
+				// The 409 carries stoppedReason so the client can distinguish a
+				// terminal stop from a lost flag without awaiting the 2s poll.
+				respond(r.ok ? 200 : r.reason === 'frame-too-large' ? 413 : 409,
+					r.ok ? { status: 'sent' } : { status: 'failed', error: r.error, stoppedReason: lastStopReason });
 			});
 			return;
 		}

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -33,7 +33,7 @@ import { z } from 'zod';
 import { existsSync, readFileSync, readdirSync, unlinkSync, mkdirSync, copyFileSync, appendFileSync, writeFileSync, realpathSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { inlineTools } from './inline-tools.js';
-import { setVisionSession, startVisionControlServer, stopVisionControlServer, setSessionToolUpdater, setVisionSpeechEvidence } from './vision-tools.js';
+import { setVisionSession, startVisionControlServer, stopVisionControlServer, setSessionToolUpdater, setVisionSpeechEvidence, stopStreaming as stopVisionStreaming } from './vision-tools.js';
 import { clearActiveArtifact } from './artifact-cache-tools.js';
 import { injectText } from './browser-tools.js';
 import { join, dirname } from 'node:path';
@@ -1442,6 +1442,12 @@ async function main() {
 	if (origDisconnect) {
 		(session as any).handleClientDisconnected = () => {
 			origDisconnect();
+			// No listener left, so frames only burn capture + quota. Reason is
+			// terminal: a browser push driver must tear down, not re-arm.
+			const stopped = stopVisionStreaming('no-client');
+			if (stopped.status === 'stopped') {
+				console.log(`${ts()} [Vision] stopped on client disconnect (${stopped.frames} frame(s))`);
+			}
 			recorder.flush();
 			writeVoiceState(false);
 			// P7 D7.1: final ledger row for the departing epoch — written NOW

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2340,6 +2340,9 @@ var _visionCanvas = null;            // hidden canvas reused for toBlob
 // Capped to prevent thrashing if recovery genuinely fails.
 var _visionRearmInFlight = false;
 var _visionRearmCount = 0;
+// Latched when the server reports a terminal stop; cleared only by a fresh
+// user-initiated start, so no recovery path can undo that decision.
+var _visionTerminalStop = false;
 var _VISION_REARM_LIMIT = 3;
 
 function applyVisionState(state) {
@@ -2368,6 +2371,7 @@ function applyVisionState(state) {
     // capture the server just stopped, and the voice session it fed is gone.
     if (state.stoppedReason === 'no-client') {
       console.log('[Vision] server stopped push mode: no voice client — tearing down');
+      _visionTerminalStop = true;
       teardownPushSession();
     } else if (_visionStream && _visionStream.active) {
       rearmPushMode();
@@ -2386,6 +2390,9 @@ function applyVisionState(state) {
 // _VISION_REARM_LIMIT consecutive attempts to prevent thrashing if
 // recovery genuinely fails (e.g., voice session is gone).
 function rearmPushMode() {
+  // A terminal stop is a decision. Re-arming would restart the capture the
+  // server just stopped, so it outranks every recovery guard below.
+  if (_visionTerminalStop) return;
   if (_visionRearmInFlight || _visionRearmCount >= _VISION_REARM_LIMIT) return;
   if (!_visionStream || !_visionStream.active) return;
   _visionRearmInFlight = true;
@@ -2506,7 +2513,16 @@ function _postVisionBlob(blob) {
         // 409 means the server's pushMode flag is false (voice-agent
         // restart) — try to re-arm without waiting for the 2s state poll.
         if (r.status === 409 && _visionPushActive) {
-          rearmPushMode();
+          // The 2s poll usually loses this race at >=1fps, so read the reason
+          // off the rejection itself rather than waiting for the next poll.
+          r.clone().json().then(function(d) {
+            if (d && d.stoppedReason === 'no-client') {
+              _visionTerminalStop = true;
+              teardownPushSession();
+            } else {
+              rearmPushMode();
+            }
+          }).catch(function() { rearmPushMode(); });
         }
         // Surface the first rejection so the user sees why Sutando doesn't
         // see frames (e.g. push mode not active because voice isn't ready).
@@ -2584,6 +2600,7 @@ async function startWatch() {
     pollVisionState();
     return;
   }
+  _visionTerminalStop = false;   // a user-initiated start supersedes it
   _visionPushActive = true;
   _visionFrameCount = 0;
   updateVisionPreviewStats();

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2364,7 +2364,12 @@ function applyVisionState(state) {
   // is gone, just tear down our side.
   var ourSideStale = _visionPushActive && (!streaming || state.source !== 'browser');
   if (ourSideStale) {
-    if (_visionStream && _visionStream.active) {
+    // A terminal stop is a decision, not a glitch — re-arming would restart the
+    // capture the server just stopped, and the voice session it fed is gone.
+    if (state.stoppedReason === 'no-client') {
+      console.log('[Vision] server stopped push mode: no voice client — tearing down');
+      teardownPushSession();
+    } else if (_visionStream && _visionStream.active) {
       rearmPushMode();
     } else {
       teardownPushSession();

--- a/tests/vision-egress-controls.test.ts
+++ b/tests/vision-egress-controls.test.ts
@@ -183,6 +183,34 @@ describe('P7 D7.4 vision egress controls', () => {
 		assert.equal(sent.length, 0, 'stop semantics beat a slow source');
 	});
 
+	it('a no-client stop is reported as terminal so a push driver tears down', () => {
+		const { session } = fakeSession();
+		setVisionSession(session);
+		registerSource({ name: 'term-source', capture: async () => ({ data: frameBuf(1), mimeType: 'image/jpeg' }) });
+		startStreaming('term-source', 1, 'pull');
+		assert.equal(getVisionState().stoppedReason, null, 'no reason while streaming');
+		stopStreaming('no-client');
+		assert.equal(getVisionState().stoppedReason, 'no-client');
+		// A user-initiated stop must NOT look terminal — the browser may legitimately
+		// re-arm after one, and conflating the two would break recovery.
+		startStreaming('term-source', 1, 'pull');
+		stopStreaming();
+		assert.equal(getVisionState().stoppedReason, null);
+		stopStreaming();
+	});
+
+	it('starting again clears a terminal stop', () => {
+		const { session } = fakeSession();
+		setVisionSession(session);
+		registerSource({ name: 'clear-source', capture: async () => ({ data: frameBuf(1), mimeType: 'image/jpeg' }) });
+		startStreaming('clear-source', 1, 'pull');
+		stopStreaming('no-client');
+		assert.equal(getVisionState().stoppedReason, 'no-client');
+		startStreaming('clear-source', 1, 'pull');
+		assert.equal(getVisionState().stoppedReason, null, 'a fresh stream supersedes the terminal stop');
+		stopStreaming();
+	});
+
 	it('getVisionState exposes the egress diagnostics', () => {
 		const st = getVisionState();
 		assert.equal(typeof st.egress.sent, 'number');

--- a/tests/vision-egress-controls.test.ts
+++ b/tests/vision-egress-controls.test.ts
@@ -13,7 +13,10 @@ import {
 	resetVisionEgressForTests,
 	VISION_MIN_SEND_INTERVAL_MS,
 	MAX_FPS,
+	startVisionControlServer,
+	stopVisionControlServer,
 } from '../src/vision-tools.js';
+import type { AddressInfo } from 'node:net';
 
 /** Fake VoiceSession exposing exactly what the vision egress path reads. */
 function fakeSession(state = 'ACTIVE') {
@@ -197,6 +200,34 @@ describe('P7 D7.4 vision egress controls', () => {
 		stopStreaming();
 		assert.equal(getVisionState().stoppedReason, null);
 		stopStreaming();
+	});
+
+	it('a frame rejected after a terminal stop carries the reason on the 409', async () => {
+		// The client's 2s state poll loses this race at >=1fps: an in-flight frame
+		// POST returns 409 first, and a rearm on that 409 restarts the capture the
+		// server just stopped. The rejection has to carry the reason itself.
+		const { session } = fakeSession();
+		setVisionSession(session);
+		registerSource({ name: 'r409-source', capture: async () => ({ data: frameBuf(1), mimeType: 'image/jpeg' }) });
+		startStreaming('r409-source', 1, 'push');
+		stopStreaming('no-client');
+
+		const srv = startVisionControlServer(0);
+		await new Promise<void>((r) => (srv.listening ? r() : srv.once('listening', () => r())));
+		const port = (srv.address() as AddressInfo).port;
+		try {
+			const res = await fetch(`http://127.0.0.1:${port}/vision/frame`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'image/jpeg' },
+				body: frameBuf(1),
+			});
+			assert.equal(res.status, 409, 'a frame after a stop is rejected');
+			const body = (await res.json()) as { stoppedReason?: string | null };
+			assert.equal(body.stoppedReason, 'no-client',
+				'the 409 must name the terminal stop, or the client re-arms past it');
+		} finally {
+			stopVisionControlServer();
+		}
 	});
 
 	it('starting again clears a terminal stop', () => {


### PR DESCRIPTION
## The problem

In a 2026-08-17 field session, vision kept capturing and sending for **89 seconds
after the client left** — frames ran on until 30 consecutive "no active voice
session" send failures finally tripped the stop. Nothing was listening to any of
it, and every frame cost a screen capture and Gemini quota.

## Stopping server-side alone does not fix it

It would *look* fixed while still failing. In browser push mode the client still
owns a live `MediaStream`, and the state poller reads "server not streaming" as a
server-side glitch to recover from:

```js
var ourSideStale = _visionPushActive && (!streaming || state.source !== 'browser');
if (ourSideStale) { if (_visionStream.active) rearmPushMode(); ... }
```

So the very next poll restarts the capture we just stopped. Both halves are
needed:

- **`vision-tools`** — `stopStreaming()` takes an optional reason; `getVisionState()`
  reports it as `stoppedReason` while idle. Starting any stream clears it.
- **`voice-agent`** — `handleClientDisconnected` stops with reason `'no-client'`.
- **`web-client`** — the poller treats `'no-client'` as terminal and tears the push
  session down instead of re-arming.

## Only one reason is terminal

A user-initiated stop still reports `null`, so push-mode auto-recovery — which
exists for voice-agent restarts and races — keeps working unchanged. A test pins
that distinction, because conflating the two would silently break recovery rather
than fail loudly.

## Tests

```
tests/vision-egress-controls.test.ts   14/14 pass
full suite                             1070 pass, 0 fail, 2 skipped
tsc --noEmit                           clean
```



Parent: **#3089** (fps cap), which sits on **#3087** (comment corrections).
Merge order: #3087 → #3089 → **this PR**. This branch contains both parents'
commits; after each lands I'll rebase and rerun the full suite.
## Stack

~~Parent: #3089 (fps cap), which sits on #3087 (comment corrections).~~ **Both parents have merged**; this branch is now rebased onto main and carries only the single F8 commit. No ordering constraints remain.