### PR TITLE
feat(discord): proactive text send-leg through the shared DeliveryProvider (5b stage 1)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -331,6 +331,7 @@ if channels_env.exists():
         print(f"  [startup] warning: could not chmod 0600 {channels_env}: {e}", flush=True)
 # env -> channel .env -> vault; shared policy so quoting rules cannot drift.
 from channel_token import resolve_channel_token  # noqa: E402
+import discord_proactive_send  # noqa: E402  — proactive text send-leg (5b stage 1)
 TOKEN = resolve_channel_token("DISCORD_BOT_TOKEN", env_file=channels_env)
 
 if not TOKEN:
@@ -5109,6 +5110,22 @@ async def poll_progress():
         await asyncio.sleep(3)
 
 
+_PROACTIVE_PROVIDER = None
+
+
+def _proactive_provider():
+    """Shared DeliveryProvider for the proactive text send-leg (5b stage 1).
+    Lazy so import cost lands on first use, single so receipts share one
+    client (and its 30s upload timeout pin)."""
+    global _PROACTIVE_PROVIDER
+    if _PROACTIVE_PROVIDER is None:
+        from discord_rest_client import DiscordRestClient
+        from discord_delivery_provider import DiscordDeliveryProvider
+        _PROACTIVE_PROVIDER = DiscordDeliveryProvider(
+            DiscordRestClient(TOKEN, timeout=30))
+    return _PROACTIVE_PROVIDER
+
+
 async def poll_proactive():
     """Poll results/ for proactive messages and send to owner's DM.
 
@@ -5273,8 +5290,11 @@ async def poll_proactive():
                             if _target_ch is not None and hasattr(_target_ch, 'send'):
                                 try:
                                     if _redirect_text:
-                                        for chunk in _chunk_for_discord(_redirect_text):
-                                            await _target_ch.send(chunk)
+                                        await asyncio.to_thread(
+                                            discord_proactive_send.deliver_text,
+                                            _proactive_provider(), _target_id,
+                                            _redirect_text, f.stem,
+                                            _chunk_for_discord)
                                     for fpath in files:
                                         fpath = os.path.expanduser(fpath.strip())
                                         if _is_path_sendable(fpath):
@@ -5314,9 +5334,11 @@ async def poll_proactive():
                             # Fall through to DM with the marker INTACT: the visible `[channel: <id>]` is
                             # the loud-failure signal. This except wraps the chunk AND attachment loops.
                         if clean_text:
-                            for chunk in _chunk_for_discord(clean_text):
-                                await dm.send(chunk)
-                                _sent_any = True  # pragma: no cover
+                            _n = await asyncio.to_thread(
+                                discord_proactive_send.deliver_text,
+                                _proactive_provider(), dm.id, clean_text,
+                                f.stem, _chunk_for_discord)
+                            _sent_any = _sent_any or _n > 0  # pragma: no cover
                             try:
                                 import outbox_log
                                 _user_name = getattr(user, "name", None)
@@ -5351,7 +5373,8 @@ async def poll_proactive():
                         # Glue only: the decision AND the file move are one unit in
                         # send_failure_policy.resolve_failed_send.
                         _outcome = send_failure_policy.resolve_failed_send(  # pragma: no cover
-                            f, e, _transient_send_attempts, progressed=_sent_any)
+                            f, e, _transient_send_attempts,
+                            progressed=_sent_any or bool(getattr(e, "sent_chunks", 0)))
                         print(f"  [proactive] send failure -> {_outcome}: "  # pragma: no cover
                               f"{f.with_suffix('.txt').name}", flush=True)
                         if _outcome == "retried":  # pragma: no cover

--- a/src/discord_proactive_send.py
+++ b/src/discord_proactive_send.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Send-leg of proactive text delivery through the shared DeliveryProvider.
+
+Stage 1 of the poll_proactive migration (5b): the bridge KEEPS claim/retry
+orchestration — the cross-bridge `.sending` protocol needs a migration fence
+before claiming moves — and only the outbound text send goes behind the
+provider, so every chunk earns a canonical receipt and an OUTCOME_UNKNOWN
+is never blindly resent as if it had cleanly failed.
+
+Receipt -> exception mapping (send_failure_policy speaks exceptions):
+
+  OUTCOME_UNKNOWN -> send_failure_policy.UnconfirmedDelivery — transient
+                     WITH CAP: the retry stays visible to the bridge's
+                     attempt budget, bounded, then parks loudly.
+  NOT_DELIVERED   -> ProviderSendFailed (permanent by default): Discord
+                     answered and said no; a retry does not change a 4xx.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from send_failure_policy import UnconfirmedDelivery  # noqa: E402
+
+
+class ProviderSendFailed(RuntimeError):
+    """Discord refused a chunk (NOT_DELIVERED). `sent_chunks` counts the
+    chunks confirmed before the refusal — the caller's progressed signal."""
+
+    def __init__(self, detail: str, sent_chunks: int):
+        self.sent_chunks = sent_chunks
+        super().__init__(f"{detail} (after {sent_chunks} confirmed chunk(s))")
+
+
+def deliver_text(provider, channel_id, text: str, item_id: str, chunker) -> int:
+    """Deliver `text` to `channel_id` chunk-by-chunk through `provider`.
+
+    Returns the number of chunks confirmed. Raises on the first chunk that
+    is not CONFIRMED; the idempotency key is per-chunk so a caller's bounded
+    retry re-offers the same chunk identity, never a new one."""
+    from ag2_sparrow.delivery_core.contract import DeliveryOutcome as CO
+
+    sent = 0
+    for i, chunk in enumerate(chunker(text)):
+        payload = json.dumps(
+            {"channel_id": str(channel_id), "content": chunk}).encode()
+        receipt = provider.deliver(item_id, payload, f"{item_id}#{i}")
+        if receipt.outcome is CO.OUTCOME_UNKNOWN:
+            raise UnconfirmedDelivery(
+                f"chunk {i + 1} unconfirmed: {receipt.detail} "
+                f"(after {sent} confirmed chunk(s))")
+        if receipt.outcome is not CO.CONFIRMED:
+            raise ProviderSendFailed(
+                f"chunk {i + 1} refused: {receipt.detail}", sent)
+        sent += 1
+    return sent

--- a/tests/discord-proactive-send.test.py
+++ b/tests/discord-proactive-send.test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""discord_proactive_send.deliver_text: the proactive text send-leg's contract.
+
+CONFIRMED chunks flow in order with per-chunk idempotency keys; the first
+OUTCOME_UNKNOWN raises send_failure_policy.UnconfirmedDelivery (transient
+WITH CAP — the bounded-retry class, never a silent park, never an unbounded
+resend); the first NOT_DELIVERED raises ProviderSendFailed carrying how many
+chunks were already confirmed (the caller's progressed signal).
+
+Run: python3 tests/discord-proactive-send.test.py
+"""
+# ruff: noqa: E402 — imports follow the sys.path inserts below
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
+
+import json
+
+import discord_proactive_send as ps
+import send_failure_policy
+from ag2_sparrow.delivery_core.contract import (
+    DeliveryOutcome as CO,
+    DeliveryReceipt,
+)
+
+FAILS = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"  ok: {name}")
+    else:
+        FAILS.append(name)
+        print(f"  FAIL: {name} {detail}", file=sys.stderr)
+
+
+class StubProvider:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def deliver(self, item_id, payload, idempotency_key):
+        self.calls.append((item_id, json.loads(payload), idempotency_key))
+        out = self.outcomes.pop(0)
+        return DeliveryReceipt(out, provider_ref="m" if out is CO.CONFIRMED else None,
+                               detail=out.value)
+
+
+def chunker3(text):
+    return [text[i:i + 3] for i in range(0, len(text), 3)]
+
+
+def main() -> int:
+    # 1. All-confirmed: every chunk delivered, ordered keys, right channel.
+    p = StubProvider([CO.CONFIRMED] * 3)
+    n = ps.deliver_text(p, 123, "abcdefgh", "proactive-1", chunker3)
+    check("all chunks confirmed -> count", n == 3)
+    check("chunks in order with content",
+          [c[1]["content"] for c in p.calls] == ["abc", "def", "gh"])
+    check("channel id threaded", all(c[1]["channel_id"] == "123" for c in p.calls))
+    check("per-chunk idempotency keys",
+          [c[2] for c in p.calls] == ["proactive-1#0", "proactive-1#1", "proactive-1#2"])
+
+    # 2. UNKNOWN raises the policy's capped-transient class — the bridge's
+    #    attempt budget sees it; blind unbounded resend is structurally out.
+    p = StubProvider([CO.CONFIRMED, CO.OUTCOME_UNKNOWN])
+    try:
+        ps.deliver_text(p, 1, "abcdef", "i", chunker3)
+        check("UNKNOWN raises UnconfirmedDelivery", False)
+    except send_failure_policy.UnconfirmedDelivery as e:
+        check("UNKNOWN raises UnconfirmedDelivery", True)
+        check("UNKNOWN is transient (capped) per policy",
+              send_failure_policy.is_transient(e))
+    check("UNKNOWN: no chunk sent after the ambiguous one", len(p.calls) == 2)
+
+    # 3. NOT_DELIVERED raises ProviderSendFailed, non-transient, with the
+    #    progressed count.
+    p = StubProvider([CO.CONFIRMED, CO.NOT_DELIVERED])
+    try:
+        ps.deliver_text(p, 1, "abcdef", "i", chunker3)
+        check("NOT_DELIVERED raises ProviderSendFailed", False)
+    except ps.ProviderSendFailed as e:
+        check("NOT_DELIVERED raises ProviderSendFailed", True)
+        check("refusal is permanent per policy",
+              not send_failure_policy.is_transient(e))
+        check("sent_chunks carries progress", e.sent_chunks == 1)
+
+    if FAILS:
+        print(f"\nFAILED {len(FAILS)}: {FAILS}", file=sys.stderr)
+        return 1
+    print("\nPASS: proactive send-leg — ordered confirmed chunks, capped-transient "
+          "UNKNOWN, permanent refusal with progress")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Stacked on #3095 (`feat/discord-delivery-provider`). Merge order: #3091 → #3092 → #3094 → #3095 → this. Child-only layer: `pr3095..HEAD`, 3 files, +187/−6.

## What

Stage 1 of migrating `poll_proactive` behind the delivery-core seam: the **text send-leg only**. The bridge keeps claim/retry orchestration — the `proactive-*.txt` `.sending` claim protocol is shared by the discord/telegram/slack bridges on the same files, so moving *claiming* requires a cross-bridge migration fence (single-protocol-per-epoch); that is deliberately out of this PR. Attachments stay on the WS client (the provider has no file surface yet).

- `src/discord_proactive_send.py` — `deliver_text(provider, channel_id, text, item_id, chunker)`: per-chunk delivery through `DiscordDeliveryProvider`, per-chunk idempotency keys (`{item}#{i}`).
- Receipt → exception mapping, chosen to make duplicate sends structurally hard:
  - `OUTCOME_UNKNOWN` → `send_failure_policy.UnconfirmedDelivery` — the policy's **capped-transient** class (bounded retry visible to the bridge's attempt budget, then park). This replaces the old WS behavior where a timeout looked like a plain failure and was retried on the next poll — the 2026-08-16 12-duplicate incident's shape.
  - `NOT_DELIVERED` → `ProviderSendFailed`, permanent (a 4xx does not become a 200), carrying `sent_chunks` so the bridge's `progressed` signal survives partial sends.
- `poll_proactive` wiring: DM leg and `[channel:]` redirect leg both deliver text via `asyncio.to_thread(deliver_text, ...)`; the redirect's fail-loudly semantics (literal marker kept in DM + WARN on failure) are unchanged — a provider failure raises into the existing except path.

## Evidence

At HEAD:

```
$ python3 tests/discord-proactive-send.test.py
PASS: proactive send-leg — ordered confirmed chunks, capped-transient UNKNOWN, permanent refusal with progress
$ python3 tests/discord-delivery-provider.test.py   # unchanged sibling
PASS: DiscordDeliveryProvider — contract receipts, raising config errors, real core+backend wiring
$ bash scripts/review-checks.sh --diff <(git diff pr3095..HEAD)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
$ bash scripts/lint-workspace-resolution.sh --diff
✓ no new workspace-resolution anti-patterns in this diff.
```

Before (parent): `poll_proactive` sent text via `await dm.send(chunk)` / `await _target_ch.send(chunk)` (WS client, no receipts, timeout = retry-next-poll). After: chunks earn canonical `CONFIRMED / NOT_DELIVERED / OUTCOME_UNKNOWN` receipts with the mapping above.

## Live-path status

This is the live proactive delivery loop, so harness proof is not sufficient for merge-readiness per repo policy. The live round trip (bridge restart on this branch → synthetic `proactive-*.txt` → message observed in the owner DM, including one UNKNOWN injection) is planned as part of the stack's post-merge restart chain, same protocol as #3086's done-chain; happy to run it pre-merge on request instead.

Signed: @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
