### PR TITLE
docs: peer-communication termination discipline — break agent reply loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,26 +289,15 @@ Tasks arrive from multiple channels via the same file bridge:
 - Proactive messages: write to `results/proactive-{ts}.txt` to speak to the user
 - To send files in replies, include `[file: /path/to/file]` in the result text
 
-**Peer-communication termination discipline (owner rule 2026-08-18).** Replies
-between duty-bound agents form loops: every reply becomes a task on the peer's
-side, which must produce a reply back. Three rules break the loop:
-
-1. **Pure-ack messages get NO reply.** Acknowledgements, "noted/封版", guard
-   withheld-notices, and restatements carrying no new information are archived
-   locally (move the task file to `tasks/archive/`) with no result written on
-   surfaces that post every result verbatim (e.g. AG2 Space, where dedup
-   markers are unusable — the team-result guard withholds bracketed markers).
-   Silence is the termination signal.
-2. **Parallel same-topic peer threads get ONE consolidated reply** on the most
-   substantive thread; sibling task files are archived locally. Never post the
-   same sentence per-thread.
-3. **A settled topic ends without response hooks** — no "what do you think",
-   no "waiting for your reply". Reply only when there is new information.
-
-On surfaces whose bridge parses markers (voice/Discord), `[deduped:]` remains
-the mechanism; the rules above are for surfaces without one. The structural
-fix (consolidation as a result-envelope field the gateway absorbs silently) is
-tracked at ag2-space/ag2space-backend#678.
+**Peer-communication termination discipline (owner rule 2026-08-18).** Agent
+replies form loops: each becomes a task on the peer's side that must reply
+back. On surfaces that post every result verbatim (AG2 Space — its guard
+withholds bracketed markers, so `[deduped:]` is unusable): (1) pure acks and
+no-new-info messages get NO reply — archive the task file locally; silence is
+the termination signal; (2) parallel same-topic peer threads get ONE
+consolidated reply, siblings archived; (3) a settled topic ends without
+response hooks ("waiting for your reply"). Marker-capable surfaces keep
+`[deduped:]`. Structural fix: ag2-space/ag2space-backend#678.
 
 **Result-body protocol markers** — when the result body STARTS with one of these, the bridge handles delivery specially. Use them when multiple related tasks should produce ONE user-facing reply instead of N separate ones:
 - `[deduped: task-<other-id>]` — both voice (task-bridge) and Discord (discord-bridge) silently archive this task as done, no narration, no DM. Put the full reply in the other task's result file and put this marker in each superseded task's result. The canonical way to handle thread-consolidated replies (e.g. when voice over-delegates 3 tasks for the same continuation utterance — see `src/task-bridge.ts:527`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,27 @@ Tasks arrive from multiple channels via the same file bridge:
 - Proactive messages: write to `results/proactive-{ts}.txt` to speak to the user
 - To send files in replies, include `[file: /path/to/file]` in the result text
 
+**Peer-communication termination discipline (owner rule 2026-08-18).** Replies
+between duty-bound agents form loops: every reply becomes a task on the peer's
+side, which must produce a reply back. Three rules break the loop:
+
+1. **Pure-ack messages get NO reply.** Acknowledgements, "noted/封版", guard
+   withheld-notices, and restatements carrying no new information are archived
+   locally (move the task file to `tasks/archive/`) with no result written on
+   surfaces that post every result verbatim (e.g. AG2 Space, where dedup
+   markers are unusable — the team-result guard withholds bracketed markers).
+   Silence is the termination signal.
+2. **Parallel same-topic peer threads get ONE consolidated reply** on the most
+   substantive thread; sibling task files are archived locally. Never post the
+   same sentence per-thread.
+3. **A settled topic ends without response hooks** — no "what do you think",
+   no "waiting for your reply". Reply only when there is new information.
+
+On surfaces whose bridge parses markers (voice/Discord), `[deduped:]` remains
+the mechanism; the rules above are for surfaces without one. The structural
+fix (consolidation as a result-envelope field the gateway absorbs silently) is
+tracked at ag2-space/ag2space-backend#678.
+
 **Result-body protocol markers** — when the result body STARTS with one of these, the bridge handles delivery specially. Use them when multiple related tasks should produce ONE user-facing reply instead of N separate ones:
 - `[deduped: task-<other-id>]` — both voice (task-bridge) and Discord (discord-bridge) silently archive this task as done, no narration, no DM. Put the full reply in the other task's result file and put this marker in each superseded task's result. The canonical way to handle thread-consolidated replies (e.g. when voice over-delegates 3 tasks for the same continuation utterance — see `src/task-bridge.ts:527`).
 - `[no-send]` — Discord bridge skips delivery for this task (still archives). Use when the task is internally handled but produces no user-visible reply.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,26 +289,15 @@ Tasks arrive from multiple channels via the same file bridge:
 - Proactive messages: write to `results/proactive-{ts}.txt` to speak to the user
 - To send files in replies, include `[file: /path/to/file]` in the result text
 
-**Peer-communication termination discipline (owner rule 2026-08-18).** Replies
-between duty-bound agents form loops: every reply becomes a task on the peer's
-side, which must produce a reply back. Three rules break the loop:
-
-1. **Pure-ack messages get NO reply.** Acknowledgements, "noted/封版", guard
-   withheld-notices, and restatements carrying no new information are archived
-   locally (move the task file to `tasks/archive/`) with no result written on
-   surfaces that post every result verbatim (e.g. AG2 Space, where dedup
-   markers are unusable — the team-result guard withholds bracketed markers).
-   Silence is the termination signal.
-2. **Parallel same-topic peer threads get ONE consolidated reply** on the most
-   substantive thread; sibling task files are archived locally. Never post the
-   same sentence per-thread.
-3. **A settled topic ends without response hooks** — no "what do you think",
-   no "waiting for your reply". Reply only when there is new information.
-
-On surfaces whose bridge parses markers (voice/Discord), `[deduped:]` remains
-the mechanism; the rules above are for surfaces without one. The structural
-fix (consolidation as a result-envelope field the gateway absorbs silently) is
-tracked at ag2-space/ag2space-backend#678.
+**Peer-communication termination discipline (owner rule 2026-08-18).** Agent
+replies form loops: each becomes a task on the peer's side that must reply
+back. On surfaces that post every result verbatim (AG2 Space — its guard
+withholds bracketed markers, so `[deduped:]` is unusable): (1) pure acks and
+no-new-info messages get NO reply — archive the task file locally; silence is
+the termination signal; (2) parallel same-topic peer threads get ONE
+consolidated reply, siblings archived; (3) a settled topic ends without
+response hooks ("waiting for your reply"). Marker-capable surfaces keep
+`[deduped:]`. Structural fix: ag2-space/ag2space-backend#678.
 
 **Result-body protocol markers** — when the result body STARTS with one of these, the bridge handles delivery specially. Use them when multiple related tasks should produce ONE user-facing reply instead of N separate ones:
 - `[deduped: task-<other-id>]` — both voice (task-bridge) and Discord (discord-bridge) silently archive this task as done, no narration, no DM. Put the full reply in the other task's result file and put this marker in each superseded task's result. The canonical way to handle thread-consolidated replies (e.g. when voice over-delegates 3 tasks for the same continuation utterance — see `src/task-bridge.ts:527`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,27 @@ Tasks arrive from multiple channels via the same file bridge:
 - Proactive messages: write to `results/proactive-{ts}.txt` to speak to the user
 - To send files in replies, include `[file: /path/to/file]` in the result text
 
+**Peer-communication termination discipline (owner rule 2026-08-18).** Replies
+between duty-bound agents form loops: every reply becomes a task on the peer's
+side, which must produce a reply back. Three rules break the loop:
+
+1. **Pure-ack messages get NO reply.** Acknowledgements, "noted/封版", guard
+   withheld-notices, and restatements carrying no new information are archived
+   locally (move the task file to `tasks/archive/`) with no result written on
+   surfaces that post every result verbatim (e.g. AG2 Space, where dedup
+   markers are unusable — the team-result guard withholds bracketed markers).
+   Silence is the termination signal.
+2. **Parallel same-topic peer threads get ONE consolidated reply** on the most
+   substantive thread; sibling task files are archived locally. Never post the
+   same sentence per-thread.
+3. **A settled topic ends without response hooks** — no "what do you think",
+   no "waiting for your reply". Reply only when there is new information.
+
+On surfaces whose bridge parses markers (voice/Discord), `[deduped:]` remains
+the mechanism; the rules above are for surfaces without one. The structural
+fix (consolidation as a result-envelope field the gateway absorbs silently) is
+tracked at ag2-space/ag2space-backend#678.
+
 **Result-body protocol markers** — when the result body STARTS with one of these, the bridge handles delivery specially. Use them when multiple related tasks should produce ONE user-facing reply instead of N separate ones:
 - `[deduped: task-<other-id>]` — both voice (task-bridge) and Discord (discord-bridge) silently archive this task as done, no narration, no DM. Put the full reply in the other task's result file and put this marker in each superseded task's result. The canonical way to handle thread-consolidated replies (e.g. when voice over-delegates 3 tasks for the same continuation utterance — see `src/task-bridge.ts:527`).
 - `[no-send]` — Discord bridge skips delivery for this task (still archives). Use when the task is internally handled but produces no user-visible reply.


### PR DESCRIPTION
Owner rule (2026-08-18), made fleet-wide by putting it in the instruction surface every core loads rather than any one agent's memory.

**The problem, observed live today:** replies between duty-bound agents form loops — each reply becomes a task on the peer's side which must produce a reply back. Concrete chain: 7 parallel peer threads → 7 per-thread closers (same sentence posted 7×, owner screenshot) → 7 guard withheld-notices back → 7 new tasks. Two agents are a perpetual-motion machine unless someone's side terminates.

**The rules added (CLAUDE.md + AGENTS.md, kept in sync):** pure-ack messages get NO reply (archive the task locally; silence is the termination signal); parallel same-topic threads get ONE consolidated reply with siblings archived; settled topics end without response hooks. Marker-capable surfaces keep `[deduped:]`; these rules cover the surfaces without one (AG2 Space's guard withholds bracketed markers by design). The structural complement — consolidation as a result-envelope field the gateway absorbs — is tracked at ag2-space/ag2space-backend#678.

Docs-only; both files verified byte-identical on the added section.

Signed: @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)