### PR TITLE
fix(gateway): guarded tiers may SUPPRESS — skip markers honored, wire carries the marker line alone

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -189,6 +189,7 @@ from .local_task_protocol import find_archived_task
 from . import local_task_protocol
 from .result_markers import parse_markers
 from .team_guardrail import team_guardrail_lines, engage_rulebook, AG2SPACE_PROVENANCE
+from . import team_result_guard
 from .outbox import DeliveryOutcome
 from .outbox_adapter import classify_response
 from .send_failure_policy import MAX_TRANSIENT_ATTEMPTS, resolve_failed_send
@@ -2930,6 +2931,16 @@ def _dedup_plan(tid: str, holder_id: str | None):
     return action, payload, room
 
 
+def _result_tier(tid: str) -> "str | None":
+    """Resolve the task tier; unknown provenance stays on the guarded path."""
+    try:
+        tfile = find_task_file(TASKS_DIR, tid) or find_archived_task(TASKS_DIR, tid)
+        return (team_result_guard.resolve_access_tier(tfile)
+                if tfile is not None else "guest")
+    except Exception:
+        return None
+
+
 def _post_ready_results(inflight: set[str]) -> None:
     """For each in-flight task, if its result file exists, POST it + archive."""
     changed = False
@@ -2938,13 +2949,18 @@ def _post_ready_results(inflight: set[str]) -> None:
             inflight.discard(tid); changed = True
             continue
         rfile = RESULTS_DIR / f"{tid}.txt"
-        body = read_ready_result(rfile)
-        if body is None:
+        raw = read_ready_result(rfile)
+        if raw is None:
             continue
-        # Non-owner output is scanned BEFORE any marker is interpreted:
-        # redirect/attach below are side effects on collaborator text.
-
-        body, _withheld = _guarded_result_body(tid, body)
+        # The guard owns the suppression verdict; this journaled transport
+        # applies it as a canonical stub with no collaborator-controlled bytes.
+        _tier = _result_tier(tid)
+        stub = (team_result_guard.suppression_stub_for_tier(raw, _tier)
+                if _tier is not None else None)
+        if stub is not None:
+            body, _withheld = stub, None
+        else:
+            body, _withheld = _guarded_result_body(tid, raw)
         if body is None:
             _log(f"result guard unavailable for {tid} — leaving for retry")
             continue
@@ -2995,7 +3011,8 @@ def _post_ready_results(inflight: set[str]) -> None:
                     _log(f"delivery deferred for {tid} — alias ledger unreadable")
                     continue
                 _req("POST", "/v1/results",
-                     {"id": _broker_tid(_delivery), "body": body})
+                     {"id": _broker_tid(_delivery), "body": body,
+                      "no_send": True})
             except urllib.error.HTTPError as e:
                 _log(f"result POST failed for {tid}: HTTP {e.code} — will retry")
                 continue

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -547,6 +547,52 @@ def main() -> int:
           "[no-send] marker POSTed (closes the lease) and archived")
     check(bool(_posted) and "[no-send]" in (_posted[0].get("body") or ""),
           "[no-send] body keeps its marker so the server suppresses delivery")
+    check(bool(_posted) and _posted[0].get("no_send") is True,
+          "skip result also uses the broker's structured no_send field")
+
+    # Guarded-tier suppression: only the canonical marker crosses the wire;
+    # collaborator prose is discarded before the lease-closing POST.
+    _before = len(STATE["results"])
+    (rtc.TASKS_DIR / "task-TSKIP.txt").write_text(
+        "id: task-TSKIP\naccess_tier: team\ntask: fixture\n")
+    (rtc.RESULTS_DIR / "task-TSKIP.txt").write_text(
+        "[no-send] internal bookkeeping note that must not reach the wire\n")
+    rtc._post_ready_results({"task-TSKIP"})
+    _posted = STATE["results"][_before:]
+    check(len(_posted) == 1 and not (rtc.RESULTS_DIR / "task-TSKIP.txt").exists(),
+          "team [no-send] POSTs (closes lease) and archives")
+    check(bool(_posted) and (_posted[0].get("body") or "").strip() == "[no-send]",
+          "team skip wire body is the marker line ALONE — remainder withheld")
+    check(bool(_posted) and _posted[0].get("no_send") is True,
+          "team skip carries structured no_send")
+
+    # Side-effectful controls remain behind the Team result guard.
+    _before = len(STATE["results"])
+    (rtc.TASKS_DIR / "task-TREDIR.txt").write_text(
+        "id: task-TREDIR\naccess_tier: team\ntask: fixture\n")
+    (rtc.RESULTS_DIR / "task-TREDIR.txt").write_text(
+        "[channel: 12345678901234567] exfil attempt\n")
+    _real_route_withheld_review = rtc._route_withheld_review
+    rtc._route_withheld_review = lambda _path: True
+    try:
+        rtc._post_ready_results({"task-TREDIR"})
+    finally:
+        rtc._route_withheld_review = _real_route_withheld_review
+    _posted = STATE["results"][_before:]
+    check(bool(_posted) and "[channel:" not in (_posted[0].get("body") or ""),
+          "team redirect marker still withheld (canned body, no redirect)")
+
+    # A dedup target is inert only inside the canonical task-id grammar.
+    _hostile = "[deduped: task-123\nSECRET sk-live-abcdef0123456789\nstolen]"
+    _before = len(STATE["results"])
+    (rtc.TASKS_DIR / "task-TDEXF.txt").write_text(
+        "id: task-TDEXF\naccess_tier: team\ntask: fixture\n")
+    (rtc.RESULTS_DIR / "task-TDEXF.txt").write_text(_hostile + "\n")
+    rtc._post_ready_results({"task-TDEXF"})
+    _posted = STATE["results"][_before:]
+    check(bool(_posted) and "SECRET" not in (_posted[0].get("body") or "")
+          and "sk-live" not in (_posted[0].get("body") or ""),
+          "team deduped with out-of-grammar extra is withheld, not re-posted")
 
     # 2. idempotent: re-writing the same task doesn't duplicate / error
     before = content

--- a/tests/sparrow-result-guard.test.py
+++ b/tests/sparrow-result-guard.test.py
@@ -282,20 +282,25 @@ def drain_once(tids, provenance=()):
         m._req = real_req
 
 
-# THE security property. A Team runtime controls its own result bytes, so an
-# unprovenanced control must NOT buy a silent close — it stays withheld.
+# THE security property, post-#3108: a guarded tier may suppress its own
+# reply, but its bytes never move — the wire body is the bare marker alone.
 posted, inflight = drain_once(["task-forged"])
 bodies = [p.get("body", "") for p in posted]
-check(all("[no-send]" not in b for b in bodies),
-      "a collaborator-producible control body does NOT close the lease silently")
-check(any("withheld" in b for b in bodies),
-      "it takes the guard's withheld notice instead — the safe failure")
+check(len(bodies) == 1 and bodies[0].strip() == "[no-send]",
+      "a team skip-only result closes the lease with the bare marker ONLY")
+check(all("redelivery" not in b for b in bodies),
+      "the collaborator's surrounding prose never reaches the wire")
+check(len(posted) == 1 and posted[0].get("no_send") is True,
+      "the lease close uses the structured broker suppression field")
+check(inflight == set(), "and that lease is retired")
 
 # The PROVENANCED path is this process's own record, which a collaborator cannot
 # forge, so it still closes silently. Same bytes, opposite verdict.
 posted2, inflight2 = drain_once(["task-real"], provenance=["task-real"])
 check(len(posted2) == 1 and "[no-send]" in posted2[0]["body"],
       "the same bytes WITH this process's record still close the lease silently")
+check(posted2[0].get("no_send") is True,
+      "the provenance-backed close also carries structured suppression")
 check(inflight2 == set(), "and that lease is retired")
 
 # The reviewer's P1: a transient POST failure must not burn the provenance.


### PR DESCRIPTION


## The gap, precisely

The canonical gateway bridge already routes markers through the unified parser (#873) — for OWNER results, `[deduped:]`/`[no-send]` work exactly like Discord. The asymmetry was tier-specific: `_guarded_result_body` scans **before** any marker is interpreted, and the team-result guard treats any bracketed control marker as a leak — so a **team-tier** result whose only marker was suppression-class got replaced with the canned withheld notice and posted. Per-thread bookkeeping stubs became "response was withheld" spam: exactly the fuel of today's agent reply loop (owner screenshots).

## The fix

Suppression-class markers only REDUCE output, so a guarded tier may use them. When a result's markers are ALL skip-kind (`no-send` / `REPLIED` / `deduped`) and the task resolves to a guarded tier:
- the wire body is the **reconstructed marker line alone** (the server's suppression keys on the marker; the fixture pins that), and
- the remainder **never leaves the host** — strictly less egress than today's canned-notice path.

Side-effectful markers (`[channel:]` redirect, `[file:]` attach): the verdict keys off the FIRST marker (`parse_markers` short-circuits). A guarded body whose first marker is a redirect/attach is withheld; one whose first marker is skip-kind reduces to that stub, and any TRAILING side-effect marker is discarded with the body — never honored, so no exfiltration surface either way. An unresolvable tier (None/unknown) is treated as GUARDED and takes the stub path — stricter than the withhold notice, still zero content egress. Both properties are pinned as fixtures (per Sutando-Pro's execution probe, which measured the code stricter than this body's earlier wording).

## Evidence

New checks in the mock-gateway harness (`src/remote-gateway-bridge.test.py`), all green with the full suite:
```
ok  team [no-send] POSTs (closes lease) and archives
ok  team skip wire body is the marker line ALONE — remainder withheld
ok  team redirect marker still withheld (canned body, no redirect)
ok  [no-send] body keeps its marker so the server suppresses delivery   (owner regression, unchanged)
PASS — all checks green
```
Canonical module patched; `packages/ag2-sparrow/tools/sync_from_src.py` reports in sync. review-checks PASS on the diff.

Live-path note: the running bridge picks this up on its next restart; until then the behavioral rule from #3106 covers the gap.

Signed: @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
