### PR TITLE
chore(sparrow): bump version to 0.3.1 (release cut)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/__init__.py
+++ b/packages/ag2-sparrow/ag2_sparrow/__init__.py
@@ -14,4 +14,4 @@ The shared utility modules are kept in lockstep with sonichi/sutando `src/`
 via tools/sync_from_src.py (a drift-check test fails CI if they diverge —
 single source of truth, no hand-maintained fork).
 """
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
## What

Bump `ag2_sparrow.__version__` 0.3.0 → 0.3.1 to cut a release, per owner request (2026-08-18).

## Why

`packages/ag2-sparrow/` changes on main since `sparrow-v0.3.0`:
- #3073 fix(gateway): an explicitly addressed proactive should not need a default room
- #3067 chore(session-worker): remove the Team execution path that probe() made unreachable
- #3012 / #3080 docs: drift-guard scope corrections (MAP is the authority)

Release mechanics (per `.github/workflows/publish-sparrow.yml`): after this merges, the merge commit is tagged `sparrow-v0.3.1`; the workflow verifies tag == packaged `__version__`, runs the package suites + src-drift guard, and publishes via Trusted Publishing (no token).

## Evidence

Before (origin/main):
```
$ git show origin/main:packages/ag2-sparrow/ag2_sparrow/__init__.py | grep __version__
__version__ = "0.3.0"
```
After (HEAD):
```
$ python3 -c "import sys; sys.path.insert(0,'packages/ag2-sparrow'); import ag2_sparrow; print(ag2_sparrow.__version__)"
0.3.1
$ python3 src/remote-gateway-bridge.test.py | tail -1
PASS — all checks green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
