### PR TITLE
feat(discord): proactive claim lifecycle on the outbox ClaimBackend (5b fence) [reopen of #3122]

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/send_failure_policy.py
+++ b/packages/ag2-sparrow/ag2_sparrow/send_failure_policy.py
@@ -103,6 +103,16 @@ def should_retry(exc: BaseException, attempts: int,
     return is_transient(exc) and attempts < cap
 
 
+def decide_failed_send(exc: BaseException, tried: int,
+                       progressed: bool = False) -> str:
+    """The decision alone: "retry" or "park". Executors carry it out.
+
+    `progressed` means part of the body already reached the recipient; a
+    re-send from the start would repeat it, so partial delivery always parks.
+    """
+    return "retry" if (not progressed and should_retry(exc, tried)) else "park"
+
+
 def resolve_failed_send(claim: Path, exc: BaseException,
                         attempts: "dict[str, int]", progressed: bool = False,
                         *, body: "Path | None" = None,
@@ -118,9 +128,7 @@ def resolve_failed_send(claim: Path, exc: BaseException,
         body = claim.with_suffix(".txt")
     key = body.name
     tried = attempts.get(key, 0)
-    # `progressed` means part of the body already reached the recipient. Re-sending
-    # from the start would repeat it, so a partial delivery parks instead.
-    if not progressed and should_retry(exc, tried):
+    if decide_failed_send(exc, tried, progressed) == "retry":
         # release_claim refuses to clobber a `.txt` written since the claim, so a
         # False here means a newer body exists — park this one rather than drop it.
         # Bundled verbatim into ag2_sparrow, where siblings are package

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -121,11 +121,10 @@ from util_paths import channel_access_path, claude_home_path, personal_path, sha
 from task_priority import default_priority_for_source  # noqa: E402
 from optional_script import run_optional_script as _run_optional_script_shared  # noqa: E402
 from presenter_mode import presenter_mode_active  # noqa: E402
-from proactive_recovery import recover_orphan_sending_files, release_claim  # noqa: E402
 import send_failure_policy  # noqa: E402  # pragma: no cover — bridge not unit-imported; policy is covered in send_failure_policy.py
 
-# Transient send failures per result body, keyed by its `.txt` name. In-memory on
-# purpose: a bridge restart re-polls the file anyway, so a fresh count is correct.
+# poll_approved's transient counter only. The proactive leg's attempts are
+# durable in the fence's outbox (5b); this stays in-memory for the marker leg.
 _transient_send_attempts: dict = {}  # pragma: no cover — bridge not unit-imported
 from owner_activity import write_owner_activity as _write_owner_activity_shared  # noqa: E402
 
@@ -2543,8 +2542,9 @@ async def list_channel_members(channel_id: int) -> list[dict]:
 
 
 def _recover_orphan_sending_files() -> int:
-    """Recover this adapter's stranded proactive delivery claims."""
-    return recover_orphan_sending_files(RESULTS_DIR)
+    """Recover this adapter's stranded proactive delivery claims.
+    Via the fence: backend recover (dead-incarnation re-arm) + file sweep."""
+    return _proactive_fence().recover()
 
 
 # Guards the once-only startup of the long-lived poll loops below. `on_ready`
@@ -5130,6 +5130,23 @@ def _proactive_provider():
     return _PROACTIVE_PROVIDER
 
 
+_PROACTIVE_FENCE = None
+
+
+def _proactive_fence():
+    """Claim fence for the proactive leg (5b): outbox-backed lifecycle.
+    Lazy like the provider; the root is RESULTS_DIR-scoped so tests binding
+    RESULTS_DIR get a hermetic outbox for free."""
+    global _PROACTIVE_FENCE
+    if _PROACTIVE_FENCE is None:
+        from proactive_claim_fence import ProactiveClaimFence
+        from ag2_sparrow.delivery_core import DesignAClaimBackend
+        _PROACTIVE_FENCE = ProactiveClaimFence(
+            DesignAClaimBackend(RESULTS_DIR / ".outbox-discord-proactive"),
+            RESULTS_DIR, worker="discord-proactive")
+    return _PROACTIVE_FENCE
+
+
 async def poll_proactive():
     """Poll results/ for proactive messages and send to owner's DM.
 
@@ -5181,15 +5198,15 @@ async def poll_proactive():
                     # had no exclusive claim. Rename is atomic on POSIX
                     # same-filesystem; FileNotFoundError from the rename
                     # means another iteration already claimed it.
-                    claim = f.with_suffix(".sending")
-                    try:
-                        f.rename(claim)
-                    except FileNotFoundError:
+                    # 5b fence: file move keeps peers' globs blind; the
+                    # outbox record makes attempts durable across restarts.
+                    claim = _proactive_fence().claim(f)
+                    if claim is None:
                         continue
                     f = claim  # subsequent reads + unlink operate on the claim path
                     text = read_ready_result(f)
                     if text is None:
-                        release_claim(f)
+                        _proactive_fence().release(f)
                         continue
                     # Parse ONCE, here, and reuse below: a second grammar would
                     # miss what parse_markers peels (D7 `**[core: N]**` headers).
@@ -5201,7 +5218,7 @@ async def poll_proactive():
                         print(f"  [proactive] {f.name} targets "
                               f"{str(_early_redirect.value).strip()!r} — not a Discord "
                               f"channel id; releasing for its own bridge", flush=True)
-                        release_claim(f)
+                        _proactive_fence().release(f)
                         continue
                     # Resolve the DM recipient via discord_config.resolve_owner_id
                     # (#1147). The helper consults — in order — the env override,
@@ -5238,7 +5255,7 @@ async def poll_proactive():
                                 continue
                     if owner_id is None:
                         print(f"  [proactive] no human user in allowFrom, skipping {f.name}")
-                        f.unlink(missing_ok=True)
+                        _proactive_fence().drop(f, "no human user in allowFrom")
                         continue
                     # Bound BEFORE the try: the handler reads it, so a failure in
                     # fetch_user/create_dm would raise UnboundLocalError instead.
@@ -5327,7 +5344,7 @@ async def poll_proactive():
                                         f"to channel {_target_id}",
                                         flush=True,
                                     )
-                                    f.unlink(missing_ok=True)
+                                    _proactive_fence().confirm(f)
                                     continue
                                 except Exception as _exc:
                                     print(
@@ -5369,15 +5386,14 @@ async def poll_proactive():
                                 _sent_any = True  # pragma: no cover
                                 print(f"  [proactive] REJECTED file: {fpath}", flush=True)
                         print(f"  [proactive] sent to {owner_id}: {clean_text[:80]}")
-                        f.unlink(missing_ok=True)
+                        _proactive_fence().confirm(f)
                     except Exception as e:  # pragma: no cover — live send path
                         # Quarantine rather than retry, and ONLY for a failure a retry cannot fix: a
                         # 413 never becomes a 200, a 503 does on the very next poll.
                         print(f"  [proactive] failed to DM {owner_id}: {e}")  # pragma: no cover — live send path
-                        # Glue only: the decision AND the file move are one unit in
-                        # send_failure_policy.resolve_failed_send.
-                        _outcome = send_failure_policy.resolve_failed_send(  # pragma: no cover
-                            f, e, _transient_send_attempts,
+                        # decide_failed_send decides; the fence moves + records.
+                        _outcome = _proactive_fence().fail(  # pragma: no cover
+                            f, e,
                             progressed=_sent_any or bool(getattr(e, "sent_chunks", 0)))
                         print(f"  [proactive] send failure -> {_outcome}: "  # pragma: no cover
                               f"{f.with_suffix('.txt').name}", flush=True)

--- a/src/proactive_claim_fence.py
+++ b/src/proactive_claim_fence.py
@@ -1,0 +1,161 @@
+"""Proactive claim lifecycle on the outbox ClaimBackend seam.
+
+File renames stay the inter-bridge visibility mechanism (a claimed file leaves
+every ``*.txt`` glob peers poll); the backend replaces the in-memory transient
+attempt counter and pid-scoped orphan recovery with durable, incarnation-fenced
+records. Ordering per operation: file move first, backend second — ``recover()``
+reconciles a crash between the two.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+try:  # pragma: no cover - package context (ag2-sparrow bundles the siblings)
+    from .proactive_recovery import recover_orphan_sending_files, release_claim
+    from .send_failure_policy import decide_failed_send
+except ImportError:  # pragma: no cover - flat src/ import path
+    from proactive_recovery import recover_orphan_sending_files, release_claim
+    from send_failure_policy import decide_failed_send
+
+from ag2_sparrow.delivery_core import DeliveryOutcome
+
+
+class ProactiveClaimFence:
+    """Claim/confirm/retry/park for one bridge's proactive files.
+
+    Every transition pairs one file move with one backend record transition.
+    The fence never blocks delivery: a backend refusal degrades that cycle to
+    file-only claiming (logged), because losing durability for one item is
+    recoverable and losing the owner's message is not.
+    """
+
+    def __init__(self, backend, results_dir: Path, worker: str = "proactive"):
+        self._backend = backend
+        self._results_dir = results_dir
+        self._worker = worker
+        self._tokens: dict = {}  # claim path -> (item_id, ClaimToken|None)
+
+    @staticmethod
+    def _item_id(path: Path) -> str:
+        # mtime-scoped identity: a re-written body is a fresh delivery cycle,
+        # never a continuation of the consumed one's attempt history.
+        return f"{path.name}#{path.stat().st_mtime_ns}"
+
+    def claim(self, path: Path) -> Optional[Path]:
+        """Claim ``path`` for delivery; returns the ``.sending`` claim path."""
+        # Only the proactive family is ever claimed by rename — a task result
+        # renamed here would vanish from its own consumer's glob.
+        if not path.name.startswith("proactive-"):
+            return None
+        try:
+            item = self._item_id(path)
+        except FileNotFoundError:
+            return None
+        claim = path.with_suffix(".sending")
+        try:
+            path.rename(claim)
+        except FileNotFoundError:
+            return None
+        token = None
+        try:
+            self._backend.publish(item, b"")  # False = record exists; claim decides
+            token = self._backend.claim(item, self._worker)
+            if token is None:
+                self._backend.recover()
+                token = self._backend.claim(item, self._worker)
+        except Exception as exc:  # pragma: no cover - defensive: never lose the body
+            print(f"  [fence] backend claim degraded for {claim.name}: {exc}",
+                  flush=True)
+        if token is None:
+            print(f"  [fence] {claim.name}: no backend claim this cycle "
+                  "(file-only)", flush=True)
+        self._tokens[claim] = (item, token)
+        return claim
+
+    def confirm(self, claim: Path) -> None:
+        """Delivery confirmed: consume the file, archive the record."""
+        claim.unlink(missing_ok=True)
+        self._finish(claim, DeliveryOutcome.CONFIRMED)
+
+    def drop(self, claim: Path, reason: str) -> None:
+        """Terminal non-delivery discard (e.g. no resolvable recipient)."""
+        print(f"  [fence] dropping {claim.name}: {reason}", flush=True)
+        self.confirm(claim)
+
+    def release(self, claim: Path) -> bool:
+        """Non-attempt release (body unready / destined for another bridge).
+
+        The record completes NOT_DELIVERED; if nothing here ever re-claims it
+        (a peer bridge delivers the file), backend cleanup ages the stale
+        ready record out. attempts() inflation is confined to this item's
+        mtime identity, which a re-written body replaces.
+        """
+        released = release_claim(claim)
+        self._finish(claim, DeliveryOutcome.NOT_DELIVERED)
+        return released
+
+    def attempts(self, claim: Path) -> int:
+        item, _token = self._tokens.get(claim, (None, None))
+        if item is None:
+            return 0
+        try:
+            return self._backend.attempts(item)
+        except Exception:  # pragma: no cover - degraded cycle
+            return 0
+
+    def fail(self, claim: Path, exc: BaseException, progressed: bool,
+             undelivered_dir: Optional[Path] = None) -> str:
+        """Execute the send-failure decision. Returns retried/parked/stuck."""
+        decision = decide_failed_send(exc, self.attempts(claim), progressed)
+        if decision == "retry":
+            if release_claim(claim):
+                # NOT_DELIVERED both re-arms the record and durably counts the
+                # attempt — the counter the old in-memory dict lost on restart.
+                self._finish(claim, DeliveryOutcome.NOT_DELIVERED)
+                return "retried"
+            # A newer .txt body exists; park this one rather than clobber it.
+        item, token = self._tokens.pop(claim, (None, None))
+        body_name = claim.with_suffix(".txt").name
+        try:
+            undelivered = undelivered_dir if undelivered_dir is not None \
+                else claim.parent / "undelivered"
+            undelivered.mkdir(parents=True, exist_ok=True)
+            claim.rename(undelivered / body_name)
+        except Exception:
+            self._tokens[claim] = (item, token)
+            return "stuck"
+        if token is not None:
+            try:
+                self._backend.complete(token, DeliveryOutcome.NOT_DELIVERED)
+                self._backend.park(item, "partial-delivery" if progressed
+                                   else "permanent-failure")
+            except Exception as e:  # pragma: no cover - defensive
+                print(f"  [fence] park record failed for {body_name}: {e}",
+                      flush=True)
+        return "parked"
+
+    def recover(self) -> int:
+        """Startup reconciliation: backend half then file half.
+
+        backend.recover() re-arms records whose claimant incarnation died and
+        quarantines ghosts; the file sweep restores ``.sending`` orphans to the
+        polling stream. A record with no file (crash between confirm-unlink and
+        complete) goes stale-ready and is aged out by backend cleanup.
+        """
+        try:
+            self._backend.recover()
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"  [fence] backend recover failed: {exc}", flush=True)
+        return recover_orphan_sending_files(self._results_dir)
+
+    def _finish(self, claim: Path, outcome) -> None:
+        _item, token = self._tokens.pop(claim, (None, None))
+        if token is None:
+            return
+        try:
+            self._backend.complete(token, outcome)
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"  [fence] backend complete failed for {claim.name}: {exc}",
+                  flush=True)

--- a/src/send_failure_policy.py
+++ b/src/send_failure_policy.py
@@ -103,6 +103,16 @@ def should_retry(exc: BaseException, attempts: int,
     return is_transient(exc) and attempts < cap
 
 
+def decide_failed_send(exc: BaseException, tried: int,
+                       progressed: bool = False) -> str:
+    """The decision alone: "retry" or "park". Executors carry it out.
+
+    `progressed` means part of the body already reached the recipient; a
+    re-send from the start would repeat it, so partial delivery always parks.
+    """
+    return "retry" if (not progressed and should_retry(exc, tried)) else "park"
+
+
 def resolve_failed_send(claim: Path, exc: BaseException,
                         attempts: "dict[str, int]", progressed: bool = False,
                         *, body: "Path | None" = None,
@@ -118,9 +128,7 @@ def resolve_failed_send(claim: Path, exc: BaseException,
         body = claim.with_suffix(".txt")
     key = body.name
     tried = attempts.get(key, 0)
-    # `progressed` means part of the body already reached the recipient. Re-sending
-    # from the start would repeat it, so a partial delivery parks instead.
-    if not progressed and should_retry(exc, tried):
+    if decide_failed_send(exc, tried, progressed) == "retry":
         # release_claim refuses to clobber a `.txt` written since the claim, so a
         # False here means a newer body exists — park this one rather than drop it.
         # Bundled verbatim into ag2_sparrow, where siblings are package

--- a/tests/discord-proactive-foreign-target.test.py
+++ b/tests/discord-proactive-foreign-target.test.py
@@ -40,7 +40,9 @@ end = text.find("[proactive] send failure", start)
 check(start != -1 and end > start, "proactive claim block is locatable")
 block = text[start:end]
 
-check("release_claim" in block,
+# Post-5b the release goes through the claim fence, whose release() is
+# behaviorally pinned (fence suite: "release restores the .txt").
+check("_proactive_fence().release" in block,
       "the proactive block can release a claim back to the polling stream")
 
 shape = re.search(r'fullmatch\(r"\\d\{17,20\}"', block) or re.search(r"\\d\{17,20\}", block)
@@ -57,7 +59,7 @@ check(gi != -1 and ii != -1 and gi < ii,
 # The release must be reached by the foreign branch, not only by the empty-text
 # branch that already existed.
 foreign = block[gi:ii] if (gi != -1 and ii != -1) else ""
-check("release_claim" in foreign and "continue" in foreign,
+check("_proactive_fence().release" in foreign and "continue" in foreign,
       "the foreign-target branch releases the claim and stops processing")
 
 # Parity: the rule is not new policy, it is what the sibling bridges already do.

--- a/tests/proactive-claim-fence.test.py
+++ b/tests/proactive-claim-fence.test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""ProactiveClaimFence — the 5b claim-substrate swap, driven on a REAL
+ClaimBackend (Design A; the suite is contract-shaped, so Design C slots in
+when it ships):
+
+  FILE    every transition pairs the documented file move (peer-glob
+          visibility is unchanged from the private .sending machinery).
+  DURABLE transient attempt counts survive a fence/process restart — the
+          in-memory dict the fence replaces lost them (real defect).
+  PARK    partial delivery parks (never re-sends confirmed chunks); the
+          backend record parks with it.
+  RECOVER a crash between file move and backend transition reconciles.
+
+Run: python3 tests/proactive-claim-fence.test.py"""
+# ruff: noqa: E402 — imports follow the sys.path inserts below
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
+
+from ag2_sparrow.delivery_core import DesignAClaimBackend
+from proactive_claim_fence import ProactiveClaimFence
+from send_failure_policy import UnconfirmedDelivery, MAX_TRANSIENT_ATTEMPTS
+
+FAILS = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"  ok: {name}")
+    else:
+        FAILS.append(name)
+        print(f"  FAIL: {name} {detail}", file=sys.stderr)
+
+
+def _fence(root: Path) -> ProactiveClaimFence:
+    return ProactiveClaimFence(
+        DesignAClaimBackend(root / ".outbox-test"), root, worker="t")
+
+
+class _Boom(Exception):
+    status = 413  # permanent: a payload too large never becomes a 200
+
+
+def main() -> int:
+    # FILE + confirm: claim moves .txt aside; confirm consumes it.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        body = root / "proactive-a.txt"
+        body.write_text("hello")
+        fence = _fence(root)
+        claim = fence.claim(body)
+        check("claim returns the .sending path",
+              claim == root / "proactive-a.sending")
+        check("claim moves the body out of the .txt glob",
+              not body.exists() and claim.exists())
+        check("second claim of a gone file is None", fence.claim(body) is None)
+        fence.confirm(claim)
+        check("confirm consumes the claim file", not claim.exists())
+
+    # release: unready body returns to the polling stream.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        body = root / "proactive-b.txt"
+        body.write_text("x")
+        fence = _fence(root)
+        claim = fence.claim(body)
+        check("release restores the .txt", fence.release(claim) and body.exists())
+
+    # DURABLE: transient attempts survive a new fence over the same root —
+    # the cap is enforceable across restarts, unlike the in-memory dict.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        body = root / "proactive-c.txt"
+        body.write_text("x")
+        transient = UnconfirmedDelivery("no event id")
+        outcomes = []
+        for _ in range(MAX_TRANSIENT_ATTEMPTS + 1):
+            fence = _fence(root)          # fresh instance = simulated restart
+            claim = fence.claim(body)
+            outcomes.append(fence.fail(claim, transient, progressed=False))
+        check("transient failures retry up to the cap",
+              outcomes[:MAX_TRANSIENT_ATTEMPTS] == ["retried"] * MAX_TRANSIENT_ATTEMPTS,
+              str(outcomes))
+        check("attempt count survives restarts: capped run parks",
+              outcomes[-1] == "parked", str(outcomes))
+        check("parked body is byte-preserved in undelivered/",
+              (root / "undelivered" / "proactive-c.txt").read_text() == "x")
+
+    # PARK: progressed=True parks even a transient failure (chunk 1 landed).
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        body = root / "proactive-d.txt"
+        body.write_text("y")
+        fence = _fence(root)
+        claim = fence.claim(body)
+        out = fence.fail(claim, UnconfirmedDelivery("after 1 chunk"),
+                         progressed=True)
+        check("partial delivery parks, never retries", out == "parked")
+
+    # PARK: permanent failure parks on the first attempt.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        body = root / "proactive-e.txt"
+        body.write_text("z")
+        fence = _fence(root)
+        claim = fence.claim(body)
+        check("permanent failure parks first time",
+              fence.fail(claim, _Boom(), progressed=False) == "parked")
+
+    # RECOVER: crash after the file move, before/instead of a clean cycle —
+    # a stranded .sending returns to the polling stream on the next start.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        body = root / "proactive-f.txt"
+        body.write_text("w")
+        fence = _fence(root)
+        fence.claim(body)  # token dropped on the floor = crashed process
+        fence2 = _fence(root)
+        recovered = fence2.recover()
+        check("recover restores the stranded .sending", recovered == 1
+              and body.exists(), f"recovered={recovered}")
+        claim = fence2.claim(body)
+        check("recovered body is claimable again", claim is not None)
+        fence2.confirm(claim)
+
+    # re-written body is a fresh cycle: attempts do not carry across mtimes.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        body = root / "proactive-g.txt"
+        body.write_text("v1")
+        fence = _fence(root)
+        claim = fence.claim(body)
+        fence.fail(claim, UnconfirmedDelivery("x"), progressed=False)  # retried
+        import os
+        os.utime(body, ns=(1, 1))  # force a distinct mtime identity
+        fence2 = _fence(root)
+        claim = fence2.claim(body)
+        check("re-written body starts with zero attempts",
+              fence2.attempts(claim) == 0)
+
+    if FAILS:
+        print(f"\nFAILED {len(FAILS)}: {FAILS}", file=sys.stderr)
+        return 1
+    print("\nPASS: proactive claim fence — file semantics unchanged, "
+          "attempts durable, partial delivery parks, recovery reconciles")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/proactive-claim-release.test.py
+++ b/tests/proactive-claim-release.test.py
@@ -106,12 +106,20 @@ class DelegationTest(unittest.TestCase):
                 )
 
     def test_every_bridge_imports_release_claim(self):
+        # discord reaches release_claim through the 5b claim fence, which is
+        # itself pinned to delegate (fence source + its behavioral suite).
         for name, path in CONSUMERS.items():
             with self.subTest(consumer=name):
-                self.assertIn(
-                    "release_claim", path.read_text(),
-                    f"{name}: does not delegate to proactive_recovery.release_claim",
-                )
+                text = path.read_text()
+                if name == "discord-bridge":
+                    self.assertIn("_proactive_fence().release", text)
+                    fence = (REPO / "src" / "proactive_claim_fence.py").read_text()
+                    self.assertIn("release_claim", fence)
+                else:
+                    self.assertIn(
+                        "release_claim", text,
+                        f"{name}: does not delegate to proactive_recovery.release_claim",
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/proactive-dm-failure-preserves-file.test.py
+++ b/tests/proactive-dm-failure-preserves-file.test.py
@@ -98,7 +98,11 @@ def main() -> int:
           f"unconditional unlink at line(s) {bad_after}")
     check("no unlink inside an exception handler", not bad_handler,
           f"unlink at line(s) {bad_handler}")
-    check("at least one unlink remains on a SUCCESS path", bool(good),
+    # Post-5b the success-path cleanup is the fence's confirm() (behaviorally
+    # pinned in its suite); the bad_* checks still guard any raw unlinks.
+    confirms = [n.lineno for n in ast.walk(fn) if isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute) and n.func.attr == "confirm"]
+    check("at least one success-path cleanup remains", bool(good or confirms),
           "the file is never cleaned up — every proactive message would re-send forever")
 
     # The failure path must actively preserve the file, not merely skip the

--- a/tests/proactive-progress-flag-bound-before-try.test.py
+++ b/tests/proactive-progress-flag-bound-before-try.test.py
@@ -82,7 +82,9 @@ class TestProgressFlagBinding(unittest.TestCase):
     def test_the_handler_still_passes_progress_to_the_policy(self):
         handlers = _target_trys()[0].handlers
         self.assertTrue(any(_reads_flag(h) for h in handlers))
-        self.assertTrue(any("resolve_failed_send" in _calls(h) for h in handlers),
+        # Post-5b the handler delegates through the fence's fail(), whose own
+        # consult of decide_failed_send is pinned in send-failure-delegation.
+        self.assertTrue(any("fail" in _calls(h) for h in handlers),
                         "the handler no longer delegates to the policy")
 
 

--- a/tests/proactive-recovery.test.py
+++ b/tests/proactive-recovery.test.py
@@ -89,9 +89,21 @@ for adapter in ("discord-bridge.py", "slack-bridge.py", "telegram-bridge.py"):
         if isinstance(node, ast.ImportFrom) and node.module == "proactive_recovery"
         for alias in node.names
     }
-    check(f"{adapter} imports shared recovery",
-          "recover_orphan_sending_files" in imported)
-    check(f"{adapter} wrapper delegates to shared recovery", delegates)
+    # discord delegates through the 5b fence, whose recover() calls the shared
+    # sweep (pinned here at source + behaviorally in the fence suite).
+    if adapter == "discord-bridge.py":
+        fence_src = (REPO / "src" / "proactive_claim_fence.py").read_text()
+        fence_delegates = (
+            ".recover()" in source
+            and "recover_orphan_sending_files" in fence_src
+        )
+        check(f"{adapter} imports shared recovery", fence_delegates)
+        check(f"{adapter} wrapper delegates to shared recovery",
+              delegates or fence_delegates)
+    else:
+        check(f"{adapter} imports shared recovery",
+              "recover_orphan_sending_files" in imported)
+        check(f"{adapter} wrapper delegates to shared recovery", delegates)
 
 
 if failures:

--- a/tests/send-failure-delegation.test.py
+++ b/tests/send-failure-delegation.test.py
@@ -34,8 +34,12 @@ class TestDelegation(unittest.TestCase):
     def test_both_quarantine_sites_consult_the_policy(self):
         # The approval site keeps its own file (the marker IS the obligation) but must
         # still take the CAP from the policy, or it is an unbounded 3s hot loop.
-        self.assertIn("send_failure_policy.resolve_failed_send", BRIDGE)
+        # The proactive site consults it through the fence (5b), whose own
+        # consult is pinned below and behaviorally by its unit suite.
+        self.assertIn("_proactive_fence().fail", BRIDGE)
         self.assertIn("send_failure_policy.should_retry", BRIDGE)
+        fence = (REPO / "src" / "proactive_claim_fence.py").read_text()
+        self.assertIn("decide_failed_send(", fence)
 
     def test_no_site_retries_without_a_cap(self):
         # `is_transient` alone answers "could a retry work", never "how many times".
@@ -61,8 +65,8 @@ class TestDelegation(unittest.TestCase):
         # rename-to-undelivered, which is how the two copies drifted apart.
         window = BRIDGE.split("failed to DM", 1)[1][:1400]
         self.assertNotIn('/ "undelivered"', window,
-                         "the file move belongs to resolve_failed_send")
-        self.assertIn("resolve_failed_send", window)
+                         "the file move belongs to the fence executor")
+        self.assertIn("_proactive_fence().fail", window)
         self.assertIn("continue", window)
 
     def test_the_policy_module_owns_the_move(self):

--- a/tests/sending-suffix-is-proactive-only.test.py
+++ b/tests/sending-suffix-is-proactive-only.test.py
@@ -61,18 +61,30 @@ def resolve_prefix_tuples(text: str) -> dict:
     return out
 
 
+def _gates_in(block, prefixes_by_name) -> list:
+    found = [m.group(2) for m in
+             re.finditer(r'startswith\((["\'])([^"\']+)\1\)', block)]
+    for name, vals in prefixes_by_name.items():
+        if re.search(rf"startswith\(.*\b{re.escape(name)}\b", block) or \
+                re.search(rf"\bin\s+{re.escape(name)}\b", block):
+            found.extend(vals)
+    return found
+
+
 def gates_before(lines, claim_idx, prefixes_by_name) -> "list | None":
     """Prefix strings gating the nearest enclosing results-dir loop, or None."""
     for i in range(claim_idx, max(0, claim_idx - 80), -1):
         if re.search(r"for\s+\w+\s+in\s+.*(RESULTS_DIR|results_dir)", lines[i]):
-            block = "\n".join(lines[i:claim_idx + 1])
-            found = [m.group(2) for m in
-                     re.finditer(r'startswith\((["\'])([^"\']+)\1\)', block)]
-            for name, vals in prefixes_by_name.items():
-                if re.search(rf"startswith\(.*\b{re.escape(name)}\b", block) or \
-                        re.search(rf"\bin\s+{re.escape(name)}\b", block):
-                    found.extend(vals)
-            return found
+            return _gates_in("\n".join(lines[i:claim_idx + 1]), prefixes_by_name)
+    return None
+
+
+def func_body_gates(lines, claim_idx, prefixes_by_name) -> "list | None":
+    """Inline gate inside the enclosing function (a method claim site like the
+    5b fence, called via attribute so caller resolution cannot see it)."""
+    for i in range(claim_idx, max(0, claim_idx - 80), -1):
+        if re.match(r"\s*def\s+\w+", lines[i]):
+            return _gates_in("\n".join(lines[i:claim_idx + 1]), prefixes_by_name)
     return None
 
 
@@ -157,6 +169,10 @@ for py in sorted(SRC.glob("*.py")):
                 gates = [g for c in callers for g in c[2]]
                 label = f"{py.name} (via {len(callers)} caller(s) of {fn}())"
                 delegating_callers += len(callers)
+            elif not callers:
+                # Method claim sites are invoked via attribute calls, which the
+                # Name-based caller scan cannot see; their gate must be inline.
+                gates = func_body_gates(lines, lineno - 1, prefixes)
         claim_sites.append((label, lineno, gates))
 
 # A zero-site run would make every assertion below vacuously true. Centralising


### PR DESCRIPTION
Reopen of #3122, which was accidentally squash-merged into its PARENT branch (`feat/discord-delivery-provider`, #3095) before receiving any review — the base branch has been reset to its reviewed head `d51d4088` so #3095 keeps exactly the scope john's re-pass covers, and the fence gets its own review pass here. Content identical to #3122 (commit `fc894dae`).

Original description, evidence, and stacking notes: see #3122. Summary:
- `src/proactive_claim_fence.py`: claim/confirm/release/fail/recover — one file move + one durable backend record per transition, on the ClaimBackend contract (Design A now, C-swap at #3104).
- Replaces two real defects: restart-lost transient attempt counts (now durable, cap enforced across restarts) and pid-scoped orphan recovery (now incarnation-based).
- `decide_failed_send` extracted as single decision owner; vendored copy synced.
- 13-check fence suite on a real backend; `sending-suffix` guard extended for method claim sites, mutation-tested; 6 delegation-pin suites followed one hop; 119-suite sweep green; review-checks PASS.

Merge order: #3092 → #3094 → #3095 → this. Rebases over #3113 at its merge.

Signed: @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)