### PR TITLE
chore(deps): bump bodhi pin ca0f61de → 0d506ead (B1–B5 observability surfaces)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@google/genai": "^1.49.0",
         "@types/ws": "^8.18.1",
         "ai": "^6.0.149",
-        "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent#ca0f61de2ee5156502096a1d0b90bea99ba77b59",
+        "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent#0d506ead47c73f664b174274b7bb622a420c8a18",
         "dotenv": "^17.4.1",
         "playwright": "^1.58.2",
         "ws": "^8.20.0",
@@ -1656,8 +1656,8 @@
     },
     "node_modules/bodhi-realtime-agent": {
       "version": "0.1.5",
-      "resolved": "git+ssh://git@github.com/sonichi/bodhi_realtime_agent.git#ca0f61de2ee5156502096a1d0b90bea99ba77b59",
-      "integrity": "sha512-JNvb/7ta6FYr/nYyLYtB+9itAVFRVL9eGkK97wGTuBA944GgCAjdA1Th3UrDOZL+MhYRDUWSMcNNFYpMMJmmmg==",
+      "resolved": "git+ssh://git@github.com/sonichi/bodhi_realtime_agent.git#0d506ead47c73f664b174274b7bb622a420c8a18",
+      "integrity": "sha512-SfGN+Hfu/d19MWfd7J/E8uIjRthKSEIxjKMYOqgcJOslNOxTdk7tI69n9aJ+mEhy84NYuG8rpLT5ADT1aZVIWg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@google/genai": "^1.49.0",
     "@types/ws": "^8.18.1",
     "ai": "^6.0.149",
-    "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent#ca0f61de2ee5156502096a1d0b90bea99ba77b59",
+    "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent#0d506ead47c73f664b174274b7bb622a420c8a18",
     "dotenv": "^17.4.1",
     "playwright": "^1.58.2",
     "ws": "^8.20.0",


### PR DESCRIPTION
Pin only; no sutando code change. Single concern per CONTRIBUTING.

## What this picks up

The five merged bodhi observability PRs the voice context-budget design depends
on ([#33](https://github.com/sonichi/bodhi_realtime_agent/pull/33),
[#34](https://github.com/sonichi/bodhi_realtime_agent/pull/34),
[#31](https://github.com/sonichi/bodhi_realtime_agent/pull/31),
[#30](https://github.com/sonichi/bodhi_realtime_agent/pull/30),
[#32](https://github.com/sonichi/bodhi_realtime_agent/pull/32)):

- **Upstream send counters + `getDiagnostics()`** — attempted/queued/skipped/threw
  per slot, split raw/wire bytes, per-outcome timestamps; reset per transport
  generation. This is what finally distinguishes "the agent stopped sending
  audio" from "audio was sent and nothing came back".
- **Typed connection-lifecycle events** — attempt / setup-ok / setup-failed /
  attempt-close / generation-close, correlated by `connectAttemptId`, with
  `handleSupplied` on the attempt (lineage tracking without log-line inference).
- **`onUsageMetadata`** — `promptTokenCount` et al, reachable from `VoiceSession`.
- **`mediaResolution` passthrough** — session-wide media token cost.
- **Optional `compressionConfig` thresholds** — `{}` = server defaults; values
  sent as the int64-over-JSON strings the API expects.

Plus review hardening from the merge train: observer isolation on both new
callback surfaces, reconnect replay counted AND moved off the deprecated `media`
field onto the supported video/audio slots, and superseded-dial `setup-failed`
fenced like every other stale-dial signal.

Consumers land separately (Phase 1: ledger sampling, `logicalSessionId`,
`up=`/`ctx=` health segments, shadow matrix).

## Before/after evidence

**Before (parent commit, pin `ca0f61de`):**

```
$ node -e "const {GeminiLiveTransport}=require('bodhi-realtime-agent');
  const t=new GeminiLiveTransport({apiKey:'x'},{});
  console.log(typeof t.getDiagnostics)"
undefined
```

**After (this commit, pin `0d506ead`):**

```
installed version: 0.1.5
getDiagnostics present: true
diag shape: ["upstream","transportGeneration"]
```

**Full TS suite at this pin:** 1096 pass / 0 fail / 2 skipped.

**Python suite:** 551 files; 7 fail — the identical 7 fail at the parent pin on
this host (core-input-watch, core-model-pin-probe, discord-readers-429,
discord-token-delegation, remote-gateway-bridge, runtime-health,
start-cli-model-pin): environment/service-dependent, unrelated to the bump.

## Live round trip (live-path rule)

Through the **pinned artifact** (not the SDK directly) against
`gemini-2.5-flash-native-audio-preview-12-2025` — connect with
`mediaResolution: LOW` + `compressionConfig: {}` accepted by the server; text
in → model audio out; every new surface read while doing it:

```
connected in 304ms; lifecycle so far: attempt -> setup-ok
text slot     : {"attempted":1,"queued":1,"queuedRawBytes":26}
generation    : 1
audio chunks  : 1 (first after 1442ms)
usage samples : 1 promptTokenCount 375 -> 375
lifecycle full: attempt -> setup-ok -> generation-close
LIVE ROUND TRIP: PASS
```
