### PR TITLE
feat(voice-transport): sendClientCommand — surface-owned protocol commands

### DIFF
--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -888,6 +888,14 @@ export class VoiceTransport {
     return true;
   }
 
+  /** Send a surface-owned protocol command (e.g. voice.retryUpstream), JSON-
+   *  serialized onto the open socket; false when no socket is open. */
+  sendClientCommand(msg: { type: string }): boolean {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false;
+    this.ws.send(JSON.stringify(msg));
+    return true;
+  }
+
   /**
    * User-initiated teardown of mic + WS + playback + audio graph. Idempotent.
    *

--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -889,10 +889,17 @@ export class VoiceTransport {
   }
 
   /** Send a surface-owned protocol command (e.g. voice.retryUpstream), JSON-
-   *  serialized onto the open socket; false when no socket is open. */
+   *  serialized onto the open socket; false when no socket is open or the
+   *  frame did not go out. */
   sendClientCommand(msg: { type: string }): boolean {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false;
-    this.ws.send(JSON.stringify(msg));
+    try {
+      this.ws.send(JSON.stringify(msg));
+    } catch {
+      // readyState is sampled a statement earlier; a close landing in that
+      // window throws, and callers read false — not a throw — as "not sent".
+      return false;
+    }
     return true;
   }
 

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -1329,6 +1329,20 @@ describe('transport public API additions (Steps 15/16/18)', () => {
 		h.t.disconnect();
 	});
 
+	it('sendClientCommand: a close between the readyState check and send() returns false, not a throw', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		// The real race: readyState is still OPEN when the guard samples it, and
+		// the socket closes before send() runs, so send() throws InvalidStateError.
+		const before = s.sent.length;
+		s.send = () => { throw new Error('InvalidStateError: still in CONNECTING state'); };
+		assert.equal(s.readyState, 1, 'guard must pass — otherwise this tests the wrong branch');
+		assert.doesNotThrow(() => h.t.sendClientCommand({ type: 'voice.retryUpstream' }));
+		assert.equal(h.t.sendClientCommand({ type: 'voice.retryUpstream' }), false, 'a frame that did not go out must report false');
+		assert.equal(s.sent.length, before, 'nothing was recorded as sent');
+		h.t.disconnect();
+	});
+
 	it('setPlaybackRate drives subsequent playback scheduling', async () => {
 		const h = harness();
 		const s = await goLive(h);

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -1290,6 +1290,45 @@ describe('transport public API additions (Steps 15/16/18)', () => {
 		h.t.disconnect();
 	});
 
+	it('sendClientCommand: false when not open, JSON-serialized frame when live', async () => {
+		// A NAMED command interface (no index signature) must assign — the
+		// parameter is constrained on `type`, not on Record<string, unknown>.
+		interface RetryUpstreamCmd {
+			type: 'voice.retryUpstream';
+			version: 1;
+			voiceSessionId: string;
+			clientEpoch: number;
+			stalledAttemptEpoch: number;
+			requestId: string;
+		}
+		const h = harness();
+		const probe: RetryUpstreamCmd = {
+			type: 'voice.retryUpstream',
+			version: 1,
+			voiceSessionId: 'vs_0',
+			clientEpoch: 0,
+			stalledAttemptEpoch: 1,
+			requestId: 'req-0',
+		};
+		assert.equal(h.t.sendClientCommand(probe), false);
+		const s = await goLive(h);
+		const before = s.sent.length;
+		const msg: RetryUpstreamCmd = {
+			type: 'voice.retryUpstream',
+			version: 1,
+			voiceSessionId: 'vs_1',
+			clientEpoch: 2,
+			stalledAttemptEpoch: 7,
+			requestId: 'req-1',
+		};
+		assert.equal(h.t.sendClientCommand(msg), true);
+		const sent = s.sent[s.sent.length - 1];
+		assert.equal(typeof sent, 'string');
+		assert.deepEqual(JSON.parse(sent as string), msg);
+		assert.equal(s.sent.length, before + 1);
+		h.t.disconnect();
+	});
+
 	it('setPlaybackRate drives subsequent playback scheduling', async () => {
 		const h = harness();
 		const s = await goLive(h);


### PR DESCRIPTION
+32 lines. The browser voice transport's only JSON sender is `sendTextInput`; the ACTIVE-silence recovery client surface (docs: `design-voice-active-silence-recovery.md` in the desktop repo, approved) needs to send `voice.retryUpstream.v1` from the banner's Retry action.

`sendClientCommand(msg): boolean` sends a surface-owned protocol frame verbatim over the live socket, `false` when not open — the transport stays policy-free (schema, epochs, requestId dedup, and retry semantics are all surface/server concerns, exactly like the existing `sendTextInput` split).

Sequencing: this is the one transport-side prerequisite of the cinny `voice-stalled`/Retry PR — `web-voice-transport.ts` is vendored **verbatim** into the cinny client with a hash gate, so the method must land here first and be re-vendored from the merge SHA. The receive side needs nothing: `voice-stalled` and the retry ack ride the existing `onProtocolMessage` seam.

## Amended at `2402e7f5`: the send is guarded

`readyState` is sampled a statement before `ws.send()` runs; a close landing in that window makes `send()` throw `InvalidStateError`, so a method whose signature promises `boolean` throws instead. `sendClientCommand` now carries the same `try/catch` #3138 puts on `sendTextInput`, so the two methods do not disagree about their own failure contract.

Raised as a non-blocking observation by @liususan091219, then re-weighed as blocking by @john-the-dev — correctly. I had deferred it to a follow-up to avoid invalidating two clean reviews; both are `COMMENTED`, so there was no vote at the gate to protect. The method has no callers yet, and its first caller is a *reconnect* path, where a socket close in that window is the expected case rather than the hypothetical one.

## Tests

`tests/web-voice-transport.test.ts`, both watched fail red first:

- `false` when not open; verbatim JSON frame + `true` when live (frame round-trips through `JSON.parse`, `sent.length` increments by exactly one).
- a close between the `readyState` check and `send()` returns `false`, not a throw.

Control for the guard at the parent (`5dbb5278`, guard reverted, test present) — fails with the throw propagating out of `sendClientCommand` itself, so the case is load-bearing rather than tautological:

```
✖ sendClientCommand: a close between the readyState check and send() returns false, not a throw
  AssertionError [ERR_ASSERTION]: Got unwanted exception.
  Actual message: "InvalidStateError: still in CONNECTING state"
      at VoiceTransport.sendClientCommand (src/web-voice-transport.ts:895:13)
ℹ tests 104
ℹ pass 102
ℹ fail 1
```

At this head:

```
ℹ tests 104
ℹ pass 103
ℹ fail 0
```

`tsc --noEmit` clean; eslint 0 errors on both changed files.

## Relationship to #3138

Independent — disjoint methods, no merge order required. #3138 fixes `sendTextInput`, which exists on `main`; this fixes the same window in the method this PR introduces. Both touch adjacent hunks of `src/web-voice-transport.ts` and insert at the same test anchor, so whichever lands second needs a rebase — that was already true before this amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
