### PR TITLE
feat: allow Team result filter opt-out

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -60,8 +60,12 @@ downgrades retain the restricted path. A Discord channel's `collaborators` list 
 
 Opted-in AG2 Space Team can use the normal configured workspace, tools,
 integrations, environment, and network. It is an owner-capability trust boundary
-with a cautious prompt and final-response secret/delivery-marker scan, not hard
-isolation. Team can read owner-accessible credentials, mutate the host, and cause
+with a cautious prompt and final-response delivery-marker guard, not hard
+isolation. The owner can disable only the secret-detection half per room and agent;
+the gateway honors that setting only for an exact Team + Collaborator attestation,
+while missing, malformed, duplicated, or body-authored controls keep scanning on.
+Redirect, attachment, and suppression markers remain guarded in either setting.
+Team can read owner-accessible credentials, mutate the host, and cause
 external side effects before the output scan. Grant it only to rooms whose Team
 members are trusted with that environment. Future AG2 Space monitoring can add
 telemetry, injection/anomaly detection, alerts, and revocation as defense in

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -154,7 +154,7 @@
       ],
       "status": "canonical",
       "canonical_for": "remote gateway wire protocol",
-      "last_verified": null
+      "last_verified": "2026-08-18"
     },
     "docs/runtime/claude-hook-contract-v1.md": {
       "title": "Claude Code Hook Contract — v1",

--- a/docs/remote-gateway-protocol.md
+++ b/docs/remote-gateway-protocol.md
@@ -157,6 +157,10 @@ gateway-controlled URL can never bounce a bearer to another host.
   `collaborator: true` line before the task body. A local owner-to-Team cap does
   not opt a room in; missing/malformed controls fail closed. This setting is
   controlled per room and per agent rather than by a host-wide environment flag.
+- Collaborator result secret scanning defaults on. An exact broker boolean
+  `sensitive_data_filter: false` adds one trusted pre-body opt-out stamp; missing,
+  malformed, duplicated, or body-authored values keep scanning enabled. The
+  delivery-control-marker guard remains active even when secret scanning is off.
 - The default local cap remains `owner` for the personal-agent model. A shared /
   multi-user gateway SHOULD set a lower local cap as defense in depth. Invalid
   local cap values fail closed to Guest.

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -564,10 +564,12 @@ def _team_guard_fns():
         classify_result_for_tier,
         materialize_withheld_verdict,
         resolve_access_tier,
+        sensitive_data_filter_enabled,
         withheld_review_path,
     )
     return (classify_result_for_tier, materialize_withheld_verdict,
-            resolve_access_tier, withheld_review_path)
+            resolve_access_tier, sensitive_data_filter_enabled,
+            withheld_review_path)
 
 
 def _atomic_private_json(path: Path, payload: dict) -> None:
@@ -950,7 +952,7 @@ def _guarded_result_body(tid: str, body: str):
     if tid in _WITHHELD_TASK_OUTPUT:
         return _WITHHELD_TASK_OUTPUT[tid]
     try:
-        classify, materialize, resolve, review_path = _team_guard_fns()
+        classify, materialize, resolve, filter_enabled, review_path = _team_guard_fns()
         from .chat_secret_filter import filter_chat_secrets
     except Exception as exc:
         return None, f"team_result_guard unavailable: {exc}"
@@ -958,6 +960,7 @@ def _guarded_result_body(tid: str, body: str):
     # Absence is not owner provenance: a month-archived Team task is exactly the
     # case that would otherwise fall open.
     tier = resolve(tfile) if tfile is not None else "guest"
+    scan_sensitive_data = filter_enabled(tfile, tier) if tfile is not None else True
     context = {}
     if tfile is not None:
         try:
@@ -967,7 +970,9 @@ def _guarded_result_body(tid: str, body: str):
                 "source", "channel_id", "reply_to_event", "source_message_id", "user_id")}
         except OSError:
             pass
-    verdict = classify(body, tier, None, secret_filter=filter_chat_secrets)
+    verdict = classify(
+        body, tier, None, secret_filter=filter_chat_secrets,
+        scan_sensitive_data=scan_sensitive_data)
     is_leak = verdict.kind == "leak"
     agent_id = _reenroll_identity()
     verdict = materialize(
@@ -2240,6 +2245,8 @@ def _write_task(task: dict) -> str | None:
             # trusted execution-policy header before all untrusted body text.
             if collaborator_enabled:
                 lines.append("collaborator: true")
+                if task.get("sensitive_data_filter") is False:
+                    lines.append("sensitive_data_filter: false")
             # Quarantine the untrusted `[room-ops metadata: …]` block BEFORE it
             # reaches the agent as body content (owner directive 2026-07-16) —
             # see _strip_room_ops_meta. Runs first so the stripped body is what

--- a/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
+++ b/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
@@ -93,6 +93,28 @@ def resolve_access_tier(task_file) -> str:
     return tier if tier in {"owner", "team", "guest"} else "guest"
 
 
+def sensitive_data_filter_enabled(task_file, tier=None) -> bool:
+    """Disable only for paired Team collaborator and filter-off stamps."""
+    if tier != "team":
+        return True
+    try:
+        content = Path(task_file).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return True
+    before_task = content.split("\ntask:", 1)[0]
+    filter_values = [
+        line.partition(":")[2].strip()
+        for line in before_task.splitlines()
+        if line.startswith("sensitive_data_filter:")
+    ]
+    collaborator_values = [
+        line.partition(":")[2].strip()
+        for line in before_task.splitlines()
+        if line.startswith("collaborator:")
+    ]
+    return filter_values != ["false"] or collaborator_values != ["true"]
+
+
 def load_team_result_scanner(repo: Path):
     """Load and warm the full scanner graph before Team-controlled execution."""
     source_dir = str((Path(repo) / "src").resolve())
@@ -118,7 +140,8 @@ def load_team_result_scanner(repo: Path):
     return filter_chat_secrets
 
 
-def scan_team_result(body: str, repo: Path, secret_filter=None) -> str:
+def scan_team_result(body: str, repo: Path, secret_filter=None,
+                     scan_sensitive_data: bool = True) -> str:
     """Return `body` unchanged, or raise TeamResultLeakError if it must be withheld."""
     kinds = {action.kind for action in parse_markers(body or "").actions}
     # dm-only only suppresses a redirect the guard already withholds, and a
@@ -127,6 +150,9 @@ def scan_team_result(body: str, repo: Path, secret_filter=None) -> str:
         raise TeamResultLeakError("result delivery control marker")
     if "skip" in kinds:
         raise TeamResultLeakError("suppressive delivery marker")
+    # Marker checks stay above this narrow scanner opt-out.
+    if not scan_sensitive_data:
+        return body
     filter_chat_secrets = secret_filter or load_team_result_scanner(repo)
     try:
         result = filter_chat_secrets(body)
@@ -254,7 +280,8 @@ def materialize_withheld_verdict(verdict: TeamResultVerdict, body: str,
 
 
 def classify_result_for_tier(body: str, tier, repo: Path,
-                             secret_filter=None) -> TeamResultVerdict:
+                             secret_filter=None,
+                             scan_sensitive_data: bool = True) -> TeamResultVerdict:
     """The guard-owned policy verdict. Adapters apply transport mechanics only;
     re-deciding (or bypassing) this classification in a bridge is a boundary
     violation, not an implementation choice."""
@@ -262,7 +289,9 @@ def classify_result_for_tier(body: str, tier, repo: Path,
         return TeamResultVerdict(VERDICT_DELIVER, body, None)
     try:
         return TeamResultVerdict(
-            VERDICT_DELIVER, scan_team_result(body, repo, secret_filter), None)
+            VERDICT_DELIVER,
+            scan_team_result(body, repo, secret_filter, scan_sensitive_data),
+            None)
     except TeamResultLeakError as exc:
         if str(exc) == "suppressive delivery marker":
             return TeamResultVerdict(VERDICT_SUPPRESS, TEAM_SUPPRESS_RESULT, str(exc))
@@ -274,12 +303,14 @@ def classify_result_for_tier(body: str, tier, repo: Path,
                                  f"scanner unavailable: {exc}")
 
 
-def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None):
+def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
+                          scan_sensitive_data: bool = True):
     """Consumer-facing gate: returns (safe_body, withheld_reason).
 
     Returns a body rather than raising, so a caller cannot deliver the raw text
     by catching an exception -- the safe body is the only one it is handed.
     Derived from classify_result_for_tier so the verdict has exactly one owner.
     """
-    verdict = classify_result_for_tier(body, tier, repo, secret_filter)
+    verdict = classify_result_for_tier(
+        body, tier, repo, secret_filter, scan_sensitive_data)
     return verdict.body, verdict.reason

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -345,6 +345,20 @@ def main() -> int:
           "broker collaborator control safely promotes legacy Team metadata")
     rtc._write_task({
         **TASK,
+        "id": "task-ROOMTEAMNOFILTER",
+        "access_tier": "guest",
+        "requested_access_tier": "team",
+        "collaborator": True,
+        "sensitive_data_filter": False,
+    })
+    room_team_no_filter = (
+        rtc.TASKS_DIR / "task-ROOMTEAMNOFILTER.txt").read_text()
+    check(room_team_no_filter.count("sensitive_data_filter: false") == 1
+          and room_team_no_filter.index("sensitive_data_filter: false")
+          < room_team_no_filter.index("task:"),
+          "explicit filter opt-out is stamped before untrusted task text")
+    rtc._write_task({
+        **TASK,
         "id": "task-PLAINTEAM",
         "access_tier": "guest",
         "requested_access_tier": "team",

--- a/src/team_result_guard.py
+++ b/src/team_result_guard.py
@@ -93,6 +93,28 @@ def resolve_access_tier(task_file) -> str:
     return tier if tier in {"owner", "team", "guest"} else "guest"
 
 
+def sensitive_data_filter_enabled(task_file, tier=None) -> bool:
+    """Disable only for paired Team collaborator and filter-off stamps."""
+    if tier != "team":
+        return True
+    try:
+        content = Path(task_file).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return True
+    before_task = content.split("\ntask:", 1)[0]
+    filter_values = [
+        line.partition(":")[2].strip()
+        for line in before_task.splitlines()
+        if line.startswith("sensitive_data_filter:")
+    ]
+    collaborator_values = [
+        line.partition(":")[2].strip()
+        for line in before_task.splitlines()
+        if line.startswith("collaborator:")
+    ]
+    return filter_values != ["false"] or collaborator_values != ["true"]
+
+
 def load_team_result_scanner(repo: Path):
     """Load and warm the full scanner graph before Team-controlled execution."""
     source_dir = str((Path(repo) / "src").resolve())
@@ -118,7 +140,8 @@ def load_team_result_scanner(repo: Path):
     return filter_chat_secrets
 
 
-def scan_team_result(body: str, repo: Path, secret_filter=None) -> str:
+def scan_team_result(body: str, repo: Path, secret_filter=None,
+                     scan_sensitive_data: bool = True) -> str:
     """Return `body` unchanged, or raise TeamResultLeakError if it must be withheld."""
     kinds = {action.kind for action in parse_markers(body or "").actions}
     # dm-only only suppresses a redirect the guard already withholds, and a
@@ -127,6 +150,9 @@ def scan_team_result(body: str, repo: Path, secret_filter=None) -> str:
         raise TeamResultLeakError("result delivery control marker")
     if "skip" in kinds:
         raise TeamResultLeakError("suppressive delivery marker")
+    # Marker checks stay above this narrow scanner opt-out.
+    if not scan_sensitive_data:
+        return body
     filter_chat_secrets = secret_filter or load_team_result_scanner(repo)
     try:
         result = filter_chat_secrets(body)
@@ -254,7 +280,8 @@ def materialize_withheld_verdict(verdict: TeamResultVerdict, body: str,
 
 
 def classify_result_for_tier(body: str, tier, repo: Path,
-                             secret_filter=None) -> TeamResultVerdict:
+                             secret_filter=None,
+                             scan_sensitive_data: bool = True) -> TeamResultVerdict:
     """The guard-owned policy verdict. Adapters apply transport mechanics only;
     re-deciding (or bypassing) this classification in a bridge is a boundary
     violation, not an implementation choice."""
@@ -262,7 +289,9 @@ def classify_result_for_tier(body: str, tier, repo: Path,
         return TeamResultVerdict(VERDICT_DELIVER, body, None)
     try:
         return TeamResultVerdict(
-            VERDICT_DELIVER, scan_team_result(body, repo, secret_filter), None)
+            VERDICT_DELIVER,
+            scan_team_result(body, repo, secret_filter, scan_sensitive_data),
+            None)
     except TeamResultLeakError as exc:
         if str(exc) == "suppressive delivery marker":
             return TeamResultVerdict(VERDICT_SUPPRESS, TEAM_SUPPRESS_RESULT, str(exc))
@@ -274,12 +303,14 @@ def classify_result_for_tier(body: str, tier, repo: Path,
                                  f"scanner unavailable: {exc}")
 
 
-def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None):
+def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
+                          scan_sensitive_data: bool = True):
     """Consumer-facing gate: returns (safe_body, withheld_reason).
 
     Returns a body rather than raising, so a caller cannot deliver the raw text
     by catching an exception -- the safe body is the only one it is handed.
     Derived from classify_result_for_tier so the verdict has exactly one owner.
     """
-    verdict = classify_result_for_tier(body, tier, repo, secret_filter)
+    verdict = classify_result_for_tier(
+        body, tier, repo, secret_filter, scan_sensitive_data)
     return verdict.body, verdict.reason

--- a/tests/sparrow-result-guard.test.py
+++ b/tests/sparrow-result-guard.test.py
@@ -124,6 +124,16 @@ with tempfile.TemporaryDirectory() as td:
     write_task(
         tasks, "task-team-filter-off", "team",
         collaborator="true", sensitive_data_filter="false")
+    bundled_filter_enabled = m._team_guard_fns()[3]
+    missing_task = tasks / "missing-task.txt"
+    task_directory = tasks / "task-directory"
+    task_directory.mkdir()
+    check(bundled_filter_enabled(missing_task, "team"),
+          "a missing bundled task file fails closed to scanning enabled")
+    check(bundled_filter_enabled(task_directory, "team"),
+          "a directory in place of a bundled task file fails closed")
+    check(not bundled_filter_enabled(tasks / "task-team-filter-off.txt", "team"),
+          "a readable paired bundled task still disables scanning")
     plain, plain_withheld = m._guarded_result_body(
         "task-team-filter-off", "intentional ghp_" + "a" * 36)
     check(plain_withheld is None and plain.startswith("intentional ghp_"),

--- a/tests/sparrow-result-guard.test.py
+++ b/tests/sparrow-result-guard.test.py
@@ -120,6 +120,19 @@ with tempfile.TemporaryDirectory() as td:
     check(any(a.kind == "skip" for a in m.parse_markers(other_notice).actions),
           "a different thread is also kept out of the shared room")
 
+    # Explicit opt-out skips secret detection, while marker controls remain guarded.
+    write_task(
+        tasks, "task-team-filter-off", "team",
+        collaborator="true", sensitive_data_filter="false")
+    plain, plain_withheld = m._guarded_result_body(
+        "task-team-filter-off", "intentional ghp_" + "a" * 36)
+    check(plain_withheld is None and plain.startswith("intentional ghp_"),
+          "an explicit filter opt-out passes token-like result text")
+    controlled, controlled_withheld = m._guarded_result_body(
+        "task-team-filter-off", BODY_WITH_MARKERS)
+    check(controlled_withheld is not None and controlled != BODY_WITH_MARKERS,
+          "filter opt-out does not disable delivery-control protection")
+
     # Absence is NOT owner provenance — a month-archived Team task is exactly
     # the case that would otherwise fall open.
     for _baseline in ("owner", "team"):

--- a/tests/team-result-guard.test.py
+++ b/tests/team-result-guard.test.py
@@ -116,6 +116,13 @@ def behavioral() -> list:
 
     with tempfile.TemporaryDirectory() as td:
         task = Path(td) / "task.txt"
+        missing = Path(td) / "missing-task.txt"
+        directory = Path(td) / "task-directory"
+        directory.mkdir()
+        if not guard.sensitive_data_filter_enabled(missing, "team"):
+            fails.append("a missing task file must fail closed to scanning enabled")
+        if not guard.sensitive_data_filter_enabled(directory, "team"):
+            fails.append("a directory in place of a task file must fail closed")
         task.write_text("access_tier: team\ntask: body\n")
         if not guard.sensitive_data_filter_enabled(task, "team"):
             fails.append("a missing filter stamp must default on")

--- a/tests/team-result-guard.test.py
+++ b/tests/team-result-guard.test.py
@@ -103,6 +103,50 @@ def behavioral() -> list:
     if out != guard.TEAM_LEAK_RESULT or not why:
         fails.append("a raising scanner must fail CLOSED and withhold the body")
 
+    out, why = guard.guard_result_for_tier(
+        "intentional secret", "team", REPO, secret_filter=_leaky,
+        scan_sensitive_data=False)
+    if out != "intentional secret" or why is not None:
+        fails.append("an explicit filter opt-out must pass ordinary result text")
+    out, why = guard.guard_result_for_tier(
+        "[attach: /etc/passwd]", "team", REPO, secret_filter=_clean,
+        scan_sensitive_data=False)
+    if out != guard.TEAM_LEAK_RESULT or not why:
+        fails.append("delivery-control markers must stay guarded when scanning is off")
+
+    with tempfile.TemporaryDirectory() as td:
+        task = Path(td) / "task.txt"
+        task.write_text("access_tier: team\ntask: body\n")
+        if not guard.sensitive_data_filter_enabled(task, "team"):
+            fails.append("a missing filter stamp must default on")
+        task.write_text(
+            "collaborator: true\nsensitive_data_filter: false\n"
+            "access_tier: team\ntask: body\n")
+        if guard.sensitive_data_filter_enabled(task, "team"):
+            fails.append("paired Team collaborator and filter-off stamps must disable scanning")
+        if not guard.sensitive_data_filter_enabled(task, "guest"):
+            fails.append("a non-Team tier must keep scanning enabled")
+        task.write_text(
+            "collaborator: true\nsensitive_data_filter: FALSE\n"
+            "access_tier: team\ntask: body\n")
+        if not guard.sensitive_data_filter_enabled(task, "team"):
+            fails.append("a non-canonical filter value must fail closed to enabled")
+        task.write_text(
+            "collaborator: true\nsensitive_data_filter: false\n"
+            "sensitive_data_filter: false\n"
+            "access_tier: team\ntask: body\n")
+        if not guard.sensitive_data_filter_enabled(task, "team"):
+            fails.append("duplicate filter stamps must fail closed to enabled")
+        task.write_text(
+            "collaborator: true\naccess_tier: team\ntask: body\n"
+            "sensitive_data_filter: false\n")
+        if not guard.sensitive_data_filter_enabled(task, "team"):
+            fails.append("a body-authored filter opt-out must not be trusted")
+        task.write_text(
+            "sensitive_data_filter: false\naccess_tier: team\ntask: body\n")
+        if not guard.sensitive_data_filter_enabled(task, "team"):
+            fails.append("filter-off without collaborator opt-in must fail closed")
+
     # The caller is handed only the safe body — it cannot deliver the raw text
     # by swallowing an exception.
     out, _ = guard.guard_result_for_tier("[channel: 5] secret", "team", REPO, secret_filter=_clean)


### PR DESCRIPTION
## Priority

**Level:** medium
**Reason:** Enables an owner-requested per-room workaround for false positives while retaining delivery-control protections.

## Dependency and merge order

#3141 is merged, and this PR is rebased directly onto the resulting `main`. The diff is now only the Team-collaborator filter switch, its fail-closed controls, tests, and canonical access-control documentation.

The AG2Space backend and Agent Native UI support are deployed to production via ag2-space/ag2space-backend#703 and ag2-space/cinny#526.

## Summary

Accepts an exact trusted `sensitive_data_filter: false` task field only when all three trusted header conditions agree:

- `access_tier: team`
- exactly one `collaborator: true`
- exactly one `sensitive_data_filter: false`

It skips only result secret detection. Redirect, attachment, and suppression markers remain guarded. Guest tasks, missing collaborator attestation, missing/malformed/duplicated controls, and body-authored controls all fail closed to filtering enabled.

The marker checks deliberately run before the narrow scanner opt-out, so disabling secret detection cannot bypass delivery-control protections.

## Checklist

- [x] Git author email is GitHub-mapped
- [x] Single concern per PR after #3141
- [x] Confirmed the feature is absent on `origin/main`
- [x] Exact Team + collaborator pairing enforced
- [x] Canonical `docs/access-control.md` policy updated
- [x] Source/package drift synchronized
- [x] Tests added for pass, fail-closed, and marker-protection paths
- [x] #3141 merged and this PR rebased to remove its parent diff
- [x] Record a post-restart two-state deployed-room round trip

## Automated evidence

```text
python3 tests/team-result-guard.test.py
python3 tests/sparrow-result-guard.test.py
python3 tests/withheld-review-dm.test.py
python3 tests/gateway-outbound-characterization.test.py
python3 src/remote-gateway-bridge.test.py
python3 packages/ag2-sparrow/tools/sync_from_src.py --check
git diff --binary origin/main...HEAD | scripts/review-checks.sh
git diff --check
```

All pass locally on the rebased head `5c6696906`. The focused controls verify that the opt-out passes token-like result text only for an exact Team collaborator while the same text remains guarded for guest, missing-collaborator, malformed, duplicate, and body-authored inputs. Marker-like output remains guarded even with the filter off.

## Live verification

Validated against the deployed Agent Native UI and dev broker after a witnessed restart of the gateway at exact head `f13e5fe`.

- Room: `!VttJDsUssvDDvcNBMI:dev.ag2.space` (`Team compatibility E2E 503`)
- Gateway identity: `@rui-rui-dev.agent:dev.ag2.space`
- Switch off: exact trusted pre-body `collaborator: true` + `sensitive_data_filter: false` with `access_tier: team`; `ghp_` plus 36 `a` characters was delivered to the shared room for task `task-a08aa4b9c2aa12a83c`.
- Switch on: paired Team/collaborator task with no opt-out stamp; the same token class was absent from the shared-room result path, archived as `marker no-send`, and routed to canonical owner DM `!HwLMOPwQCDXKSMZZev:dev.ag2.space` as review `wr_6d0bec509f79dc14` with working Yes/No buttons.
- Durable record: `status=awaiting_owner`, `reason=GitHub Token`, exact gateway `agent_id`, origin room, DM room/event, and candidate-body equality all verified on disk.
- Restore: the room switch is back on. The dev gateway remains healthy on the byte-equivalent deployed toggle code; the production gateway was not disturbed.

The browser sender was the registered owner, so the deterministic harness changed only the delivered task's trusted tier/collaborator header before supplying the fake token-shaped result, matching #3141's accepted live-test method without impersonating another Matrix user. The deployed UI/backend path itself was independently verified: the switch is present only for Team-collaborator agent policies and persists both states.

