### PR TITLE
fix(voice): a frame that did not go out reports false, not a throw

### DIFF
--- a/src/web-voice-transport.ts
+++ b/src/web-voice-transport.ts
@@ -881,10 +881,16 @@ export class VoiceTransport {
   }
 
   /** Send a typed text input over the live session (the surface's text box
-   *  during voice). Returns false when no socket is open. */
+   *  during voice). False when no socket is open or the frame did not go out. */
   sendTextInput(text: string): boolean {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false;
-    this.ws.send(JSON.stringify({ type: 'text_input', text }));
+    try {
+      this.ws.send(JSON.stringify({ type: 'text_input', text }));
+    } catch {
+      // readyState is sampled a statement earlier; a close landing in that
+      // window throws, and callers read false — not a throw — as "not sent".
+      return false;
+    }
     return true;
   }
 

--- a/tests/web-voice-transport.test.ts
+++ b/tests/web-voice-transport.test.ts
@@ -1290,6 +1290,20 @@ describe('transport public API additions (Steps 15/16/18)', () => {
 		h.t.disconnect();
 	});
 
+	it('sendTextInput: a close between the readyState check and send() returns false, not a throw', async () => {
+		const h = harness();
+		const s = await goLive(h);
+		// The real race: readyState is still OPEN when the guard samples it, and
+		// the socket closes before send() runs, so send() throws InvalidStateError.
+		const before = s.sent.length;
+		s.send = () => { throw new Error('InvalidStateError: still in CONNECTING state'); };
+		assert.equal(s.readyState, 1, 'guard must pass — otherwise this tests the wrong branch');
+		assert.doesNotThrow(() => h.t.sendTextInput('lost frame'));
+		assert.equal(h.t.sendTextInput('lost frame'), false, 'a frame that did not go out must report false');
+		assert.equal(s.sent.length, before, 'nothing was recorded as sent');
+		h.t.disconnect();
+	});
+
 	it('setPlaybackRate drives subsequent playback scheduling', async () => {
 		const h = harness();
 		const s = await goLive(h);


### PR DESCRIPTION
## What

`sendTextInput` samples `readyState` one statement before calling `ws.send()`. A close landing in that window makes `send()` throw `InvalidStateError`, so the caller gets an exception where the signature promises `boolean` — and every caller treats `false`, not a throw, as "not sent".

```ts
 sendTextInput(text: string): boolean {
   if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false;
-  this.ws.send(JSON.stringify({ type: 'text_input', text }));
+  try {
+    this.ws.send(JSON.stringify({ type: 'text_input', text }));
+  } catch {
+    return false;
+  }
   return true;
 }
```

+10/-2 in the transport, +14 test. No other behaviour changes.

## Why now

@liususan091219 raised this reviewing #3134, as a non-blocking observation that applies to `sendTextInput` too. I verified it against the code rather than taking it on report: `WebSocket.send()` throws when `readyState` is CLOSING or CLOSED, and the guard cannot see a transition that happens after it runs.

It is worth fixing rather than noting because the failure is silent in the shape that matters — a caller checking the boolean sees success semantics never returned at all, and an unhandled rejection surfaces instead.

## Evidence

Test at the parent (`2fac7e9a`), with the fix reverted and the new test present — it fails for the right reason, so the case is load-bearing rather than tautological:

```
✖ sendTextInput: a close between the readyState check and send() returns false, not a throw
ℹ tests 103
ℹ pass 101
ℹ fail 1
```

At this head:

```
ℹ tests 103
ℹ pass 102
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
```

The test asserts the guard branch is *not* the one under test (`assert.equal(s.readyState, 1)`) before forcing `send()` to throw — otherwise it would pass by taking the already-covered not-open path.

## Scope

Deliberately only `sendTextInput`, because that is the method that exists on `main`. `sendClientCommand` is identical in shape and has the same window, and it arrives in #3134 — **which now carries the same guard, amended there at `2402e7f5`.**

~~amending it now would invalidate two independent clean reviews of that exact shape~~ — struck, because it was wrong: both of those reviews are `COMMENTED`, not `APPROVED`, so there was no vote at the gate to protect. @john-the-dev caught that the deferral was landing a known race on a recovery path for no gain. Correcting it here rather than leaving a stale reason a reviewer of *this* PR would read as current.

The two PRs are independent — disjoint methods, no merge order required. They touch adjacent hunks of `src/web-voice-transport.ts` and insert at the same test anchor, so whichever lands second needs a rebase.

