### PR TITLE
feat(voice): F5 — event-driven redial with exponential backoff

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -179,6 +179,7 @@ One entry per agent-facing module.
 - **`voice-key.ts`** — Shared Gemini API-key resolution for voice surfaces (voice-agent, phone-conversation, and any plugin voice surface).
 - **`voice-lock.ts`** — voice-lock.ts — TS caller of the guarded PID-lock helper (`scripts/voice-lock.py`), used by voice-agent's `acquirePidLock` (impl plan WS1 Step 4, amendments R1/R3/R4).
 - **`voice-mode-resolver.ts`** — Unified base-mode resolver for the voice agent (issue #1410, supersedes partial fixes #1412 + #1413).
+- **`voice-redial-scheduler.ts`** — Event-driven redial scheduler with exponential backoff (F5).
 - **`watch-tasks-stream.sh`** — Streaming task watcher — the canonical task-detection path.
 - **`watcher_sentinel.sh`** — Ownership protocol for state/watch-tasks-stream.pid — the ONE writer contract.
 - **`web-client.ts`** — Web Audio Client for Sutando

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -75,6 +75,9 @@ import {
 
 import { sharedPersonalPath, claudeHomePath, claudeProjectSlug } from './util_paths.js';
 import { nextConnectingTick } from './voice-connect-watchdog.js';
+import {
+	initialRedialState, noteLifecycle, noteDialed, shouldEventDial, tickMayDial,
+} from './voice-redial-scheduler.js';
 
 // Cartesia is loaded dynamically at the bottom of the config section so
 // the `@cartesia/cartesia-js` package is only required when the user has
@@ -866,6 +869,47 @@ async function main() {
 	// it — Step 12's `backoff` upstream mapping.)
 	let voiceFatalBackoffUntil = 0;
 
+	// F5: event-driven redial with exponential backoff (voice-redial-scheduler.ts).
+	// The 30s tick below remains the safety net; these fire on bodhi's
+	// connection-lifecycle events instead of waiting up to 60s of dead air.
+	// Declared before the VoiceSession constructor because the constructor's
+	// onConnectionLifecycle option feeds them; session access is late-bound
+	// via sessionRef (assigned right after construction, before any event).
+	let redialState = initialRedialState();
+	let redialTimer: ReturnType<typeof setTimeout> | null = null;
+	// Shared with the 30s tick's throttle + the CONNECTING watchdog below.
+	let lastReconnectAt = 0;
+	const fireEventRedial = (): void => {
+		redialTimer = null;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const s = sessionRef as any;
+		if (!s) return;
+		const now = Date.now();
+		const state = String(s.sessionManager?.state ?? 'unknown');
+		const clientConnected = Boolean(s.clientConnected);
+		if (!shouldEventDial({ state, clientConnected, now, nextDialAt: redialState.nextDialAt, fatalBackoffUntil: voiceFatalBackoffUntil })) {
+			// Blocked by the fatal gate alone → re-arm for when it lifts.
+			// Any other veto drops the dial: the next lifecycle event or the
+			// 30s tick takes over.
+			if (redialState.nextDialAt > 0 && now <= voiceFatalBackoffUntil && state === 'CLOSED' && clientConnected) {
+				armRedialTimer(voiceFatalBackoffUntil - now + 100);
+			}
+			return;
+		}
+		redialState = noteDialed(redialState);
+		lastReconnectAt = now;
+		console.log(`${ts()} [Redial] event-driven reconnect (failures=${redialState.failures})`);
+		try {
+			s.handleClientConnected();
+		} catch (err) {
+			console.error(`${ts()} [Redial] reconnect trigger failed:`, (err as Error)?.message ?? err);
+		}
+	};
+	const armRedialTimer = (delayMs: number): void => {
+		if (redialTimer) clearTimeout(redialTimer);
+		redialTimer = setTimeout(fireEventRedial, delayMs);
+	};
+
 	// Declared outside the classifier IIFE below so the recovery hook can read it
 	// too; a banner already shown is what makes a recovery notice owed.
 	const voiceNotifiedCategories = new Set<string>();
@@ -972,7 +1016,20 @@ async function main() {
 				(u as { promptTokensDetails?: Array<{ modality?: string; tokenCount?: number }> })
 					.promptTokensDetails,
 			),
-		onConnectionLifecycle: (e) => audioHealth.noteLifecycleEvent(e),
+		// One lifecycle stream, two consumers: the ledger derives lineage/context
+		// facts (design §1.1/§1.4); F5's redial scheduler reacts to terminal
+		// losses — a remote generation-close or setup-failed schedules a
+		// backed-off dial; setup-ok/attempt clear it; local disconnect is a
+		// no-op (see voice-redial-scheduler.ts for the contract).
+		onConnectionLifecycle: (ev) => {
+			audioHealth.noteLifecycleEvent(ev);
+			const r = noteLifecycle(redialState, ev, { now: Date.now(), fatalBackoffUntil: voiceFatalBackoffUntil });
+			redialState = r.state;
+			if (r.scheduleDelayMs !== null) {
+				console.log(`${ts()} [Redial] ${ev.kind}${'code' in ev && ev.code !== undefined ? ` code=${ev.code}` : ''} — dial in ${r.scheduleDelayMs}ms (failures=${redialState.failures})`);
+				armRedialTimer(r.scheduleDelayMs);
+			}
+		},
 		// Phase 0.5 seams — spread for REAL key absence (design §2.1: an absent
 		// key lets the server default apply; `undefined` is not absent).
 		...(VOICE_SESSION_TUNING.compressionConfig !== undefined
@@ -1637,8 +1694,8 @@ async function main() {
 	// CLOSED→CONNECTING inline before kicking off the async connect. So the next
 	// 30s tick sees state=CONNECTING (not CLOSED) and skips the guard. If the
 	// connect fails fast and bodhi flips back to CLOSED, the 60s lastReconnectAt
-	// throttle prevents a tight retry loop.
-	let lastReconnectAt = 0;
+	// throttle prevents a tight retry loop. (lastReconnectAt is declared with
+	// the F5 redial machinery above — the event-driven path shares it.)
 	let connectingSince = 0;
 	let lastLoggedStatus = '';
 	let matrixBaseline: MatrixBaseline | null = null;
@@ -1765,9 +1822,14 @@ async function main() {
 		// Recover when session is CLOSED and a client is waiting. handleClientConnected
 		// is bodhi's internal entry point for this exact scenario (CLOSED + client
 		// present → transition to CONNECTING, reconnect fire-and-forget).
+		// F5: this is now the SAFETY NET behind the event-driven redial —
+		// tickMayDial defers to a pending scheduled dial so the tick cannot
+		// preempt the backoff.
 		// TODO: drop the (session as any) cast once bodhi exposes a public API.
-		if (state === 'CLOSED' && clientConnected && Date.now() - lastReconnectAt > 60_000 && Date.now() > voiceFatalBackoffUntil) {
+		if (state === 'CLOSED' && clientConnected && Date.now() - lastReconnectAt > 60_000 && Date.now() > voiceFatalBackoffUntil
+			&& tickMayDial({ now: Date.now(), nextDialAt: redialState.nextDialAt })) {
 			lastReconnectAt = Date.now();
+			redialState = noteDialed(redialState);
 			console.log(`${ts()} [Health] Dead session — triggering reconnect`);
 			try {
 				(session as any).handleClientConnected();

--- a/src/voice-redial-scheduler.ts
+++ b/src/voice-redial-scheduler.ts
@@ -1,0 +1,124 @@
+/**
+ * Event-driven redial scheduler with exponential backoff (F5).
+ *
+ * The health monitor's redial was blind: a 30s tick + 60s throttle that
+ * ignored HOW the last attempt died — up to 60s of dead air after a clean
+ * single failure, and a fixed cadence forever after fast re-kills (the
+ * 2026-08-17 incident log shows fresh lineages dying in 9s and 11s, where
+ * churn may itself be worsening the incident). This module turns bodhi's
+ * connection-lifecycle facts (pin 0d506ead) into a dial schedule:
+ *
+ *  - terminal loss (remote `generation-close`, or `setup-failed`) schedules
+ *    a dial after 1s, 2s, 4s, ... capped at 60s, jittered ±20%;
+ *  - a `setup-ok` resets the ladder ONLY once the connection has proven
+ *    stable (no close for 30s) — otherwise the 9s-death loop would reset
+ *    the backoff every cycle and defeat it. The proof is evaluated lazily
+ *    at the NEXT close, so no timer is needed;
+ *  - bodhi's own `disconnect()` close (1000 "local disconnect") never
+ *    schedules — it is the reconnect path working, not a loss;
+ *  - the fatal-backoff gate (voiceFatalBackoffUntil) is honoured both when
+ *    computing nextDialAt and again at fire time.
+ *
+ * Pure over injected now()/random() so tests are deterministic. Its own
+ * module because voice-agent.ts calls main() at import time (same reason as
+ * voice-connect-watchdog.ts). The 30s tick REMAINS as the safety net for
+ * states these events miss; it defers to nextDialAt via tickMayDial().
+ */
+
+export const REDIAL_BASE_MS = 1_000;
+export const REDIAL_CAP_MS = 60_000;
+/** How long a connection must survive after setup-ok to reset the ladder. */
+export const REDIAL_STABLE_MS = 30_000;
+export const REDIAL_JITTER_FRAC = 0.2;
+
+/** Structural subset of bodhi's ConnectionLifecycleEvent — keeps this
+ *  module dependency-free while accepting the real union unchanged. */
+export interface RedialLifecycleEvent {
+	kind: 'attempt' | 'setup-ok' | 'setup-failed' | 'attempt-close' | 'generation-close';
+	code?: number;
+	reason?: string;
+}
+
+export interface RedialState {
+	/** Consecutive unstable/failed connection cycles — the ladder index. */
+	failures: number;
+	/** Epoch ms the next event-driven dial may fire; 0 = none pending. */
+	nextDialAt: number;
+	/** Epoch ms of the current connection's setup-ok; 0 = none/consumed. */
+	setupOkAt: number;
+}
+
+export function initialRedialState(): RedialState {
+	return { failures: 0, nextDialAt: 0, setupOkAt: 0 };
+}
+
+/** bodhi's disconnect() emits exactly this close; it is never a loss. */
+export function isLocalDisconnect(ev: RedialLifecycleEvent): boolean {
+	return ev.kind === 'generation-close' && ev.code === 1000 && ev.reason === 'local disconnect';
+}
+
+/** Ladder delay for the Nth consecutive failure (1-based), jittered ±20%.
+ *  The cap applies to the base so jitter stays symmetric at the top. */
+export function backoffDelayMs(failures: number, random: () => number = Math.random): number {
+	const base = Math.min(REDIAL_CAP_MS, REDIAL_BASE_MS * 2 ** Math.max(0, failures - 1));
+	return Math.round(base * (1 + REDIAL_JITTER_FRAC * (2 * random() - 1)));
+}
+
+/** One lifecycle event folded into the state. `scheduleDelayMs` is non-null
+ *  exactly when the caller should (re)arm its dial timer. */
+export function noteLifecycle(
+	state: RedialState,
+	ev: RedialLifecycleEvent,
+	o: { now: number; fatalBackoffUntil?: number; random?: () => number },
+): { state: RedialState; scheduleDelayMs: number | null } {
+	switch (ev.kind) {
+		case 'attempt':
+			// A dial is in flight — a stale pending dial must not fire under it.
+			return { state: { ...state, nextDialAt: 0 }, scheduleDelayMs: null };
+		case 'setup-ok':
+			return { state: { ...state, setupOkAt: o.now, nextDialAt: 0 }, scheduleDelayMs: null };
+		case 'attempt-close':
+			// The failed-dial verdict is `setup-failed` on the same attempt
+			// (bodhi may emit both); acting here would double-schedule. The
+			// 30s tick is the net for an attempt-close nothing follows.
+			return { state, scheduleDelayMs: null };
+		case 'setup-failed':
+		case 'generation-close': {
+			// The connection is over either way: consume the stability proof.
+			const stable = state.setupOkAt > 0 && o.now - state.setupOkAt >= REDIAL_STABLE_MS;
+			const priorFailures = stable ? 0 : state.failures;
+			if (isLocalDisconnect(ev)) {
+				return { state: { ...state, failures: priorFailures, setupOkAt: 0 }, scheduleDelayMs: null };
+			}
+			const failures = priorFailures + 1;
+			const delay = backoffDelayMs(failures, o.random ?? Math.random);
+			const nextDialAt = Math.max(o.now + delay, o.fatalBackoffUntil ?? 0);
+			return {
+				state: { failures, setupOkAt: 0, nextDialAt },
+				scheduleDelayMs: nextDialAt - o.now,
+			};
+		}
+	}
+}
+
+/** Fire-time gate for the event-driven dial — same preconditions as the
+ *  tick's CLOSED guard, minus its 60s throttle (fast redial is the point). */
+export function shouldEventDial(o: {
+	state: string; clientConnected: boolean; now: number;
+	nextDialAt: number; fatalBackoffUntil: number;
+}): boolean {
+	if (o.nextDialAt === 0 || o.now < o.nextDialAt) return false;
+	if (o.state !== 'CLOSED' || !o.clientConnected) return false;
+	return o.now > o.fatalBackoffUntil;
+}
+
+/** The 30s tick's deference to the scheduler: never dial before a pending
+ *  nextDialAt (0 = nothing pending, tick behaves as before). */
+export function tickMayDial(o: { now: number; nextDialAt: number }): boolean {
+	return o.now >= o.nextDialAt;
+}
+
+/** A dial was triggered (either path) — consume the pending schedule. */
+export function noteDialed(state: RedialState): RedialState {
+	return { ...state, nextDialAt: 0 };
+}

--- a/src/voice-redial-scheduler.ts
+++ b/src/voice-redial-scheduler.ts
@@ -74,7 +74,10 @@ export function noteLifecycle(
 	switch (ev.kind) {
 		case 'attempt':
 			// A dial is in flight — a stale pending dial must not fire under it.
-			return { state: { ...state, nextDialAt: 0 }, scheduleDelayMs: null };
+			// setupOkAt is cleared too: stability credit belongs to the connection
+			// that earned it, and the tick's safety-net dial reaches here with the
+			// previous setupOkAt still set (no close was observed to consume it).
+			return { state: { ...state, nextDialAt: 0, setupOkAt: 0 }, scheduleDelayMs: null };
 		case 'setup-ok':
 			return { state: { ...state, setupOkAt: o.now, nextDialAt: 0 }, scheduleDelayMs: null };
 		case 'attempt-close':

--- a/tests/voice-redial-scheduler.test.ts
+++ b/tests/voice-redial-scheduler.test.ts
@@ -164,6 +164,20 @@ describe('noteLifecycle — pending-dial hygiene', () => {
 		assert.equal(r.state.failures, 1); // ladder survives the attempt
 	});
 
+	it('an attempt clears the stability credit — a new dial cannot inherit the old connection\'s', () => {
+		// The tick's safety-net dial reaches `attempt` with the PREVIOUS
+		// setupOkAt still set, because no close was observed to consume it.
+		// Preserving it made the next setup-failed look like a stable
+		// connection ending, resetting a 5-deep ladder to 1 (1s, not 32s) —
+		// exactly the churn the backoff exists to prevent.
+		let s: RedialState = { failures: 5, nextDialAt: 0, setupOkAt: 100_000 };
+		s = noteLifecycle(s, { kind: 'attempt' }, { now: 200_000, random: mid }).state;
+		assert.equal(s.setupOkAt, 0, 'credit from the dead connection must not carry');
+		const r = loss(s, 201_000, { kind: 'setup-failed' });
+		assert.equal(r.state.failures, 6, 'the ladder escalates, it does not reset');
+		assert.equal(r.scheduleDelayMs, 32_000);
+	});
+
 	it('setup-ok clears the pending dial', () => {
 		const s = loss(initialRedialState(), 100_000).state;
 		const r = noteLifecycle(s, { kind: 'setup-ok' }, { now: 100_500, random: mid });

--- a/tests/voice-redial-scheduler.test.ts
+++ b/tests/voice-redial-scheduler.test.ts
@@ -1,0 +1,222 @@
+/**
+ * F5 — event-driven redial scheduler with exponential backoff.
+ *
+ * The blind 30s-tick/60s-throttle redial gave up to 60s of dead air after a
+ * clean single failure, and after fast re-kills (2026-08-17 incident: fresh
+ * lineages dying in 9s/11s) it redialed at a fixed cadence forever. These
+ * tests pin the scheduler contract:
+ *  - backoff ladder 1s, 2s, 4s, ... capped at 60s; jitter ±20%;
+ *  - setup-ok resets the ladder only after 30s of stability — a 9s death
+ *    must NOT reset it (the loop that defeats naive reset);
+ *  - local disconnect (bodhi's own disconnect(): 1000 "local disconnect")
+ *    never schedules;
+ *  - the fatal-backoff gate is honoured at schedule AND fire time;
+ *  - the 30s tick fallback defers to a pending scheduled dial.
+ *
+ * Imports the real module rather than restating its rules (repo convention:
+ * a hand-copied reimplementation passes while production drifts).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	REDIAL_BASE_MS, REDIAL_CAP_MS, REDIAL_STABLE_MS, REDIAL_JITTER_FRAC,
+	initialRedialState, isLocalDisconnect, backoffDelayMs, noteLifecycle,
+	shouldEventDial, tickMayDial, noteDialed,
+	type RedialState, type RedialLifecycleEvent,
+} from '../src/voice-redial-scheduler.js';
+
+/** random()=0.5 → jitter factor exactly 1.0 — the deterministic midpoint. */
+const mid = (): number => 0.5;
+
+const remoteClose: RedialLifecycleEvent = { kind: 'generation-close', code: 1011, reason: 'internal error' };
+const localClose: RedialLifecycleEvent = { kind: 'generation-close', code: 1000, reason: 'local disconnect' };
+
+function loss(state: RedialState, now: number, ev: RedialLifecycleEvent = remoteClose, fatalBackoffUntil = 0) {
+	return noteLifecycle(state, ev, { now, fatalBackoffUntil, random: mid });
+}
+
+describe('backoffDelayMs', () => {
+	it('follows the 1s, 2s, 4s, 8s ladder at the jitter midpoint', () => {
+		assert.equal(backoffDelayMs(1, mid), 1_000);
+		assert.equal(backoffDelayMs(2, mid), 2_000);
+		assert.equal(backoffDelayMs(3, mid), 4_000);
+		assert.equal(backoffDelayMs(4, mid), 8_000);
+		assert.equal(backoffDelayMs(6, mid), 32_000);
+	});
+
+	it('caps at 60s (2^6 = 64s would exceed it) and stays capped', () => {
+		assert.equal(backoffDelayMs(7, mid), REDIAL_CAP_MS);
+		assert.equal(backoffDelayMs(8, mid), REDIAL_CAP_MS);
+		assert.equal(backoffDelayMs(50, mid), REDIAL_CAP_MS);
+	});
+
+	it('jitters within ±20% of the capped base, symmetric at the extremes', () => {
+		assert.equal(backoffDelayMs(1, () => 0), REDIAL_BASE_MS * (1 - REDIAL_JITTER_FRAC));
+		assert.equal(backoffDelayMs(1, () => 0.9999999), Math.round(REDIAL_BASE_MS * (1 + REDIAL_JITTER_FRAC * (2 * 0.9999999 - 1))));
+		for (const r of [0, 0.1, 0.25, 0.5, 0.75, 0.9999]) {
+			const d = backoffDelayMs(7, () => r);
+			assert.ok(d >= REDIAL_CAP_MS * 0.8 && d <= REDIAL_CAP_MS * 1.2, `failures=7 r=${r} → ${d}`);
+		}
+	});
+});
+
+describe('noteLifecycle — scheduling', () => {
+	it('a remote generation-close schedules the first dial at ~1s', () => {
+		const r = loss(initialRedialState(), 100_000);
+		assert.equal(r.scheduleDelayMs, 1_000);
+		assert.equal(r.state.failures, 1);
+		assert.equal(r.state.nextDialAt, 101_000);
+	});
+
+	it('setup-failed schedules exactly like a remote close', () => {
+		const r = loss(initialRedialState(), 100_000, { kind: 'setup-failed', reason: 'timeout' });
+		assert.equal(r.scheduleDelayMs, 1_000);
+		assert.equal(r.state.failures, 1);
+	});
+
+	it('consecutive fast losses escalate the ladder', () => {
+		let s = initialRedialState();
+		const delays: number[] = [];
+		let now = 100_000;
+		for (let i = 0; i < 8; i++) {
+			const r = loss(s, now, { kind: 'setup-failed' });
+			s = r.state;
+			delays.push(r.scheduleDelayMs ?? -1);
+			now = s.nextDialAt + 500; // dial fails again shortly after
+		}
+		assert.deepEqual(delays, [1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 60_000, 60_000]);
+	});
+
+	it('attempt-close alone never schedules (setup-failed is the verdict)', () => {
+		const r = noteLifecycle(initialRedialState(), { kind: 'attempt-close', code: 1006 }, { now: 100_000, random: mid });
+		assert.equal(r.scheduleDelayMs, null);
+		assert.deepEqual(r.state, initialRedialState());
+	});
+
+	it('local disconnect never schedules a redial', () => {
+		let s = initialRedialState();
+		s = loss(s, 100_000, { kind: 'setup-failed' }).state; // failures=1
+		const r = loss(s, 101_000, localClose);
+		assert.equal(r.scheduleDelayMs, null);
+		assert.equal(r.state.failures, 1); // 9s-class instability is remembered
+	});
+
+	it('a NON-local 1000 close still schedules (reason is part of the match)', () => {
+		assert.equal(isLocalDisconnect({ kind: 'generation-close', code: 1000, reason: 'bye' }), false);
+		const r = loss(initialRedialState(), 100_000, { kind: 'generation-close', code: 1000, reason: 'bye' });
+		assert.equal(r.scheduleDelayMs, 1_000);
+	});
+});
+
+describe('noteLifecycle — stability-window reset', () => {
+	/** Ladder at failures=3, then a setup-ok at t, then a close at t+dt. */
+	function afterOkThenClose(dt: number) {
+		let s: RedialState = { failures: 3, nextDialAt: 0, setupOkAt: 0 };
+		s = noteLifecycle(s, { kind: 'setup-ok' }, { now: 500_000, random: mid }).state;
+		assert.equal(s.setupOkAt, 500_000);
+		return loss(s, 500_000 + dt);
+	}
+
+	it('a close 9s after setup-ok does NOT reset the ladder (the incident loop)', () => {
+		const r = afterOkThenClose(9_000);
+		assert.equal(r.state.failures, 4);
+		assert.equal(r.scheduleDelayMs, 8_000);
+	});
+
+	it('a close just under the 30s window still escalates', () => {
+		const r = afterOkThenClose(REDIAL_STABLE_MS - 1);
+		assert.equal(r.state.failures, 4);
+	});
+
+	it('a close at exactly 30s counts as stable — ladder resets to 1', () => {
+		const r = afterOkThenClose(REDIAL_STABLE_MS);
+		assert.equal(r.state.failures, 1);
+		assert.equal(r.scheduleDelayMs, 1_000);
+	});
+
+	it('a stable connection ended by LOCAL disconnect clears the ladder without scheduling', () => {
+		let s: RedialState = { failures: 5, nextDialAt: 0, setupOkAt: 0 };
+		s = noteLifecycle(s, { kind: 'setup-ok' }, { now: 500_000, random: mid }).state;
+		const r = loss(s, 500_000 + 600_000, localClose); // GoAway-style cycle 10min in
+		assert.equal(r.scheduleDelayMs, null);
+		assert.equal(r.state.failures, 0);
+	});
+
+	it('the stability proof is consumed: a setup-failed AFTER the reset-earning close starts at failures=2', () => {
+		let s: RedialState = { failures: 3, nextDialAt: 0, setupOkAt: 0 };
+		s = noteLifecycle(s, { kind: 'setup-ok' }, { now: 500_000, random: mid }).state;
+		s = loss(s, 500_000 + 60_000).state; // stable → reset → failures=1
+		assert.equal(s.failures, 1);
+		const r = loss(s, 500_000 + 62_000, { kind: 'setup-failed' });
+		assert.equal(r.state.failures, 2); // no second reset from the same setup-ok
+		assert.equal(r.scheduleDelayMs, 2_000);
+	});
+});
+
+describe('noteLifecycle — pending-dial hygiene', () => {
+	it('an attempt clears the pending dial (a dial is in flight)', () => {
+		const s = loss(initialRedialState(), 100_000).state;
+		assert.ok(s.nextDialAt > 0);
+		const r = noteLifecycle(s, { kind: 'attempt' }, { now: 100_500, random: mid });
+		assert.equal(r.state.nextDialAt, 0);
+		assert.equal(r.state.failures, 1); // ladder survives the attempt
+	});
+
+	it('setup-ok clears the pending dial', () => {
+		const s = loss(initialRedialState(), 100_000).state;
+		const r = noteLifecycle(s, { kind: 'setup-ok' }, { now: 100_500, random: mid });
+		assert.equal(r.state.nextDialAt, 0);
+	});
+
+	it('noteDialed consumes the schedule and keeps the ladder', () => {
+		const s = loss(initialRedialState(), 100_000).state;
+		const d = noteDialed(s);
+		assert.equal(d.nextDialAt, 0);
+		assert.equal(d.failures, 1);
+	});
+});
+
+describe('fatal-backoff gate', () => {
+	it('nextDialAt never lands before fatalBackoffUntil', () => {
+		const fatal = 400_000;
+		const r = loss(initialRedialState(), 100_000, remoteClose, fatal);
+		assert.equal(r.state.nextDialAt, fatal);
+		assert.equal(r.scheduleDelayMs, fatal - 100_000);
+	});
+
+	it('shouldEventDial refuses while the fatal gate is active (strict >, matching the tick)', () => {
+		const base = { state: 'CLOSED', clientConnected: true, now: 200_000, nextDialAt: 150_000, fatalBackoffUntil: 0 };
+		assert.equal(shouldEventDial(base), true);
+		assert.equal(shouldEventDial({ ...base, fatalBackoffUntil: 200_000 }), false);
+		assert.equal(shouldEventDial({ ...base, fatalBackoffUntil: 199_999 }), true);
+	});
+});
+
+describe('shouldEventDial — fire-time preconditions', () => {
+	const base = { state: 'CLOSED', clientConnected: true, now: 200_000, nextDialAt: 200_000, fatalBackoffUntil: 0 };
+
+	it('dials when CLOSED, client attached, due, and no fatal gate', () => {
+		assert.equal(shouldEventDial(base), true);
+	});
+
+	it('each precondition alone vetoes', () => {
+		assert.equal(shouldEventDial({ ...base, nextDialAt: 0 }), false, 'nothing pending');
+		assert.equal(shouldEventDial({ ...base, now: 199_999 }), false, 'not yet due');
+		assert.equal(shouldEventDial({ ...base, state: 'CONNECTING' }), false, 'dial in flight');
+		assert.equal(shouldEventDial({ ...base, state: 'ACTIVE' }), false, 'session healthy');
+		assert.equal(shouldEventDial({ ...base, clientConnected: false }), false, 'nobody listening');
+	});
+});
+
+describe('tick fallback interaction', () => {
+	it('the tick defers to a pending scheduled dial', () => {
+		assert.equal(tickMayDial({ now: 100_000, nextDialAt: 130_000 }), false);
+	});
+
+	it('the tick may dial once the schedule is due or absent', () => {
+		assert.equal(tickMayDial({ now: 130_000, nextDialAt: 130_000 }), true);
+		assert.equal(tickMayDial({ now: 100_000, nextDialAt: 0 }), true, 'no schedule → tick behaves as before');
+	});
+});


### PR DESCRIPTION
## What

F5 from the desktop repo's voice reliability sequence — the "cheapest remaining reliability win": replace the blind fixed-tick redial with an **event-driven redial scheduler with exponential backoff**, keeping the tick as a safety net.

### The problem

The health monitor redialed on a 30 s tick with a 60 s throttle, ignoring HOW the last attempt died:

- a clean single failure meant **up to 60 s of dead air** for an attached client (the incident log shows 19–51 s deaf windows);
- after fast re-kills — the 2026-08-17 incident log shows **fresh lineages dying in 9 s and 11 s** — it redialed at a fixed cadence forever, where the churn may itself have been worsening the incident (investigation finding F5).

### The fix

`src/voice-redial-scheduler.ts` — a pure state machine over injected `now()`/`random()` (same convention as `voice-connect-watchdog.ts`), fed by bodhi's `onConnectionLifecycle` facts (pin `0d506ead`, merged in #3131):

- **Terminal loss** (remote `generation-close`, or `setup-failed`) schedules a dial after **1 s, 2 s, 4 s, ... capped at 60 s**, jittered **±20%** (cap applies to the base so jitter stays symmetric at the top).
- **Stability-window reset**: `setup-ok` resets the ladder **only after the connection survives 30 s** — evaluated lazily at the next close, so the 9 s-death loop cannot reset the backoff every cycle. A stable connection's next loss restarts at 1 s (fast recovery from a clean single failure).
- **Local disconnect** (bodhi `disconnect()`: code 1000 `"local disconnect"`, e.g. the GoAway reconnect path) never schedules — it is the reconnect path working, not a loss. A stable lineage ending this way clears the ladder.
- **Fatal gate honoured twice**: `voiceFatalBackoffUntil` bounds `nextDialAt` at schedule time, and `shouldEventDial` re-checks at fire time (bodhi emits the lifecycle close *before* the classifier bumps the gate, so the fire-time check is the one that actually protects). When the gate is the only veto, the timer re-arms for the gate's lift.
- **Dials only fire while a client is attached and state is CLOSED** — same preconditions as the tick, minus its 60 s throttle (fast redial is the point).
- **The 30 s tick remains** as the safety net for states the events miss (e.g. a watchdog-forced CLOSED with no transport close); its throttle now also defers to the scheduler's `nextDialAt` via `tickMayDial`, so it cannot preempt a pending backoff. Both dial paths consume the schedule (`noteDialed`) and share `lastReconnectAt`.
- An `attempt` event clears any pending dial (a dial is in flight); `attempt-close` alone never schedules (`setup-failed` is the verdict on the same attempt — acting on both would double-schedule).

Timer handling matches the file's existing pattern (plain timers, no `unref` — the process's lifetime is the WS server's).

## Tests

`tests/voice-redial-scheduler.test.ts` (node:test): backoff ladder + cap, jitter bounds at the extremes, first-loss 1 s schedule, escalation across consecutive losses, **9 s-death does NOT reset / exactly-30 s does**, stability proof consumed once, local-disconnect no-op (with and without stability credit), attempt/setup-ok clearing the pending dial, fatal gate at schedule and fire time (strict `>`, matching the tick), each fire-time precondition vetoing alone, tick deference.

```
Full suite: npx tsx --test --test-force-exit 'tests/**/*.test.ts'
tests 1126  suites 199  pass 1124  fail 0  skipped 2   (23 new)
npx tsc --noEmit: clean
npx eslint src/voice-agent.ts src/voice-redial-scheduler.ts tests/voice-redial-scheduler.test.ts: 0 errors, 14 warnings (identical to main's baseline on voice-agent.ts)
```

## Live round-trip evidence (CONTRIBUTING)

Agent booted from a detached worktree at this commit (`a5ddf368`) on `PORT=9901` with the workspace key; one text round trip through the real WS server + Gemini Live transport:

Agent boot:

```
23:50:16.075 [VoiceSession] WS server ready. Connecting to LLM transport...
23:50:16.508 [VoiceSession] Gemini setup complete (clientConnected=false)
23:50:16.509 [Session] Started: session_1787097015838
23:50:16.509 [VoiceSession] LLM transport connected and setup complete
23:50:16.509 [Startup] session.start() succeeded
  Voice agent:   ws://localhost:9901
  Native audio:    gemini-3.1-flash-live-preview (googleSearch=false)
```

Client (`ws-roundtrip.mjs`, `WSPORT=9901`):

```
[client] connected to :9901
[client] sending text_input: "Reply with exactly: pin verified"
[client] first reply AUDIO after 1816ms
[client] transcript assistant (partial): pin verified
[client] transcript assistant: pin verified
[client] turn.end
[client] total reply audio: 42722 bytes
client exit: 0
```

Health tick on the same run (healthy path unchanged; no spurious `[Redial]` lines — `attempt`/`setup-ok` events schedule nothing):

```
23:50:46.512 [Health] state=ACTIVE client=true audioIn={fps:0.0,lastAgo:n/a,coverage:session-only} up=n/a out={fps:0.6,buffered:0,endedLag:n/a} clientHealth=n/a epoch=1787097036275 latency=917ms inputHealth=unknown
```

Agent killed after capture.

## Context

- Incident + finding: desktop repo `docs/investigation-voice-vision-context-2026-08-17.md` (F5: "Redial costs 19–51 s deaf; audio discarded meanwhile; no backoff, and three fresh lineages died in 9 s / 11 s / 24 s").
- Sequencing: desktop repo `docs/design-voice-context-budget-and-upstream-observability.md` ("Event-driven redial with backoff (F5) — ... the cheapest remaining reliability win for the companion").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
