### PR TITLE
feat(voice): explicit off-switch for the config seams (null/false = disabled)

### DIFF
--- a/src/voice-config.ts
+++ b/src/voice-config.ts
@@ -53,20 +53,27 @@ export interface VoiceConfig {
 	divergenceCorrection: boolean;
 	/** Per-channel overrides, keyed by voice channel id. */
 	channels: Record<string, VoiceChannelConfig>;
-	/** Phase 0.5 seam (design §2.1): context-window compression. ABSENT = off
-	 *  (today's wire behaviour). `{}` = on with the SERVER's defaults (trigger
-	 *  at 80% of the model limit, target half the trigger). Explicit
+	/** Phase 0.5 seam (design §2.1): context-window compression. ABSENT = take
+	 *  whatever the built-in default says. `{}` = on with the SERVER's defaults
+	 *  (trigger at 80% of the model limit, target half the trigger). Explicit
 	 *  thresholds must be safe positive integers with
-	 *  0 < targetTokens < triggerTokens, both-or-neither. */
-	compressionConfig?: { triggerTokens?: number; targetTokens?: number };
+	 *  0 < targetTokens < triggerTokens, both-or-neither. `null`/`false` =
+	 *  DELIBERATELY DISABLED — the user-side off-switch that survives the value
+	 *  becoming a default (design §Phase 3, step 3e): once a default exists,
+	 *  deleting the key stops meaning "off", so absent and disabled must be
+	 *  distinguishable. */
+	compressionConfig?: { triggerTokens?: number; targetTokens?: number } | null | false;
 	/** Phase 0.5 seam (design §2.2): session-wide media token cost for
 	 *  realtime-input images (LOW = 64 tokens/frame). Session-wide means it
 	 *  reaches one-shot send_vision_frame too — realtime input has no
-	 *  per-send override. ABSENT = unset (server default). */
+	 *  per-send override. ABSENT = built-in default; `null`/`false` =
+	 *  deliberately disabled (same off-switch rule as compressionConfig). */
 	mediaResolution?:
 		| 'MEDIA_RESOLUTION_LOW'
 		| 'MEDIA_RESOLUTION_MEDIUM'
-		| 'MEDIA_RESOLUTION_HIGH';
+		| 'MEDIA_RESOLUTION_HIGH'
+		| null
+		| false;
 }
 
 export const VOICE_CONFIG_DEFAULTS: VoiceConfig = {
@@ -116,7 +123,18 @@ export function resolveOwnerMode(
  *  absent when off — `undefined` is not absent at the provider boundary. */
 export interface VoiceSessionTuning {
 	compressionConfig?: { triggerTokens?: number; targetTokens?: number };
-	mediaResolution?: VoiceConfig['mediaResolution'];
+	/** The RESOLVED value only ever carries a real enum member — a disabled or
+	 *  absent seam is real key absence here, never null. */
+	mediaResolution?: 'MEDIA_RESOLUTION_LOW' | 'MEDIA_RESOLUTION_MEDIUM' | 'MEDIA_RESOLUTION_HIGH';
+}
+
+/** The explicit off-switch: `null` or `false` means the operator disabled the
+ *  seam on purpose. Distinct from ABSENT, which defers to the built-in
+ *  default — a distinction that only starts to matter when a value graduates
+ *  into VOICE_CONFIG_DEFAULTS, and which has to exist BEFORE it does or the
+ *  only user-side rollback is downgrading the app (design Phase 3, step 3e). */
+function isDisabled(v: unknown): v is null | false {
+	return v === null || v === false;
 }
 
 const MEDIA_RESOLUTIONS = [
@@ -197,7 +215,10 @@ export function resolveSessionTuning(
 ): VoiceSessionTuning {
 	const out: VoiceSessionTuning = {};
 
-	if (config.mediaResolution !== undefined) {
+	// `null`/`false` = deliberately disabled: the key stays ABSENT from the
+	// session config, exactly as if unset, but a future built-in default
+	// cannot override the user's choice (design step 3e).
+	if (config.mediaResolution !== undefined && !isDisabled(config.mediaResolution)) {
 		if (!(MEDIA_RESOLUTIONS as readonly string[]).includes(config.mediaResolution as string)) {
 			throw new Error(
 				`[voice-config] mediaResolution must be one of ${MEDIA_RESOLUTIONS.join(' | ')}, ` +
@@ -217,12 +238,12 @@ export function resolveSessionTuning(
 			envTarget,
 			parseEnvThreshold,
 		);
-	} else if (config.compressionConfig !== undefined) {
+	} else if (config.compressionConfig !== undefined && !isDisabled(config.compressionConfig)) {
 		const cc = config.compressionConfig;
-		if (cc === null || typeof cc !== 'object' || Array.isArray(cc)) {
+		if (typeof cc !== 'object' || Array.isArray(cc)) {
 			throw new Error(
-				`[voice-config] compressionConfig must be an object ({} enables server defaults), ` +
-					`got ${JSON.stringify(cc)}`,
+				`[voice-config] compressionConfig must be an object ({} enables server defaults, ` +
+					`null/false disables), got ${JSON.stringify(cc)}`,
 			);
 		}
 		if (cc.triggerTokens === undefined && cc.targetTokens === undefined) {

--- a/tests/voice-config-session-tuning.test.ts
+++ b/tests/voice-config-session-tuning.test.ts
@@ -8,7 +8,11 @@
 //     0 < target < trigger — anything else throws (a half-set or inverted
 //     pair is a silently-degrading misconfiguration and must fail startup);
 //   - env (VOICE_CTX_TRIGGER_TOKENS/VOICE_CTX_TARGET_TOKENS) beats the file
-//     and on its own enables compression.
+//     and on its own enables compression;
+//   - null/false is DELIBERATELY DISABLED, distinct from absent: both resolve
+//     to real key absence today, but only the explicit form survives the value
+//     becoming a built-in default (design Phase 3, step 3e — without it the
+//     user-side rollback after release is downgrading the app).
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
@@ -183,6 +187,51 @@ describe('P7 Phase 0.5 — resolveSessionTuning', () => {
 				),
 			/mediaResolution must be one of/,
 		);
+	});
+
+	it('null/false disables a seam explicitly — resolved as real key absence', () => {
+		for (const off of [null, false] as const) {
+			const out = resolveSessionTuning(
+				cfg({
+					compressionConfig: off as VoiceConfig['compressionConfig'],
+					mediaResolution: off as VoiceConfig['mediaResolution'],
+				}),
+				NO_ENV,
+			);
+			assert.deepEqual(out, {}, `${JSON.stringify(off)} disables both seams`);
+			assert.equal('compressionConfig' in out, false);
+			assert.equal('mediaResolution' in out, false);
+		}
+	});
+
+	it('a disabled seam never throws the shape error meant for garbage', () => {
+		// Before the off-switch, null hit "must be an object" — which would have
+		// left app-downgrade as the only rollback once the value is a default.
+		assert.doesNotThrow(() =>
+			resolveSessionTuning(
+				cfg({ compressionConfig: null as VoiceConfig['compressionConfig'] }),
+				NO_ENV,
+			),
+		);
+		// Garbage still throws, naming both enabling and disabling forms.
+		assert.throws(
+			() =>
+				resolveSessionTuning(
+					cfg({ compressionConfig: 'on' as unknown as VoiceConfig['compressionConfig'] }),
+					NO_ENV,
+				),
+			/null\/false disables/,
+		);
+	});
+
+	it('env thresholds still win over a file-disabled compression seam', () => {
+		// Precedence is unchanged by the off-switch: the env pair is the
+		// operator's most explicit statement and still enables.
+		const out = resolveSessionTuning(
+			cfg({ compressionConfig: null as VoiceConfig['compressionConfig'] }),
+			{ VOICE_CTX_TRIGGER_TOKENS: '4000', VOICE_CTX_TARGET_TOKENS: '2000' },
+		);
+		assert.deepEqual(out.compressionConfig, { triggerTokens: 4000, targetTokens: 2000 });
 	});
 
 	it('the shipped example template stays valid JSON with the seams OFF', async () => {


### PR DESCRIPTION
Prerequisite for the context-budget design's **Phase 3 step 3e** — graduating `compressionConfig` and `mediaResolution` into `VOICE_CONFIG_DEFAULTS` so they reach users' devices instead of one operator's laptop (design PR ag2-space/ag2space-cinny-desktop#387).

**The gap.** Today ABSENT means off, so *absent* and *disabled* are indistinguishable — harmless while the built-in default is `unset`. The moment a value becomes a **default**, that stops being true: deleting the key just falls back to the default, and the validator rejected `null` with `must be an object`. The only user-side rollback after such a release would be downgrading the app.

**The fix.** Both seams accept `null`/`false` as **deliberately disabled** — resolved as real key absence on the wire (identical to unset today), but explicit enough to survive a defaults change. Garbage still throws, and the message now names both forms. Env thresholds keep winning over a file-disabled seam, since the env pair is the operator's most explicit statement.

Kept out of #3140 deliberately — that PR is about to merge and this is a distinct concern with its own tests.

```
full TS suite   1141 pass / 0 fail / 2 skipped
tsc --noEmit    clean
eslint          clean on touched files
```

Stacked on **#3140** (the seams themselves); merge order #3140 → this.