### PR TITLE
fix(voice): switch_voice_config must preserve the config file, not replace it

### DIFF
--- a/src/voice-config-switch.ts
+++ b/src/voice-config-switch.ts
@@ -22,7 +22,7 @@
  */
 
 import { z } from 'zod';
-import { writeFileSync, renameSync, mkdirSync } from 'node:fs';
+import { writeFileSync, renameSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
@@ -68,6 +68,38 @@ const PRESETS: Record<'search' | 'no-search', VoiceConfigPreset> = {
 
 const ts = () => new Date().toISOString().slice(11, 23);
 
+/** Read the live config as raw JSON. An absent, unreadable, or corrupt file
+ *  is not a reason to refuse a switch — the caller falls back to defaults. */
+export function readConfigRaw(path: string): unknown {
+	try {
+		return existsSync(path) ? JSON.parse(readFileSync(path, 'utf-8')) : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * What the switch writes: defaults fill gaps, **the user's own file is
+ * preserved**, and only the preset's keys are overlaid.
+ *
+ * The previous form was `{...VOICE_CONFIG_DEFAULTS, ...preset}` — it never
+ * read the file, so every switch REPLACED it. That silently deleted session
+ * tuning (`compressionConfig`, `mediaResolution`), their explicit
+ * `null`/`false` off-switches, and any future key, with a restart right
+ * behind it so the loss left no trace. Preserving raw is also what makes a
+ * fleet-wide defaults revert reach devices whose user has used the switch.
+ */
+export function nextSwitchConfig(
+	existingRaw: unknown,
+	preset: Pick<VoiceConfig, 'model' | 'googleSearch'>,
+): VoiceConfig {
+	const existing =
+		existingRaw && typeof existingRaw === 'object' && !Array.isArray(existingRaw)
+			? (existingRaw as Partial<VoiceConfig>)
+			: {};
+	return { ...VOICE_CONFIG_DEFAULTS, ...existing, ...preset };
+}
+
 export const switchVoiceConfigTool: ToolDefinition = {
 	name: 'switch_voice_config',
 	description:
@@ -102,8 +134,7 @@ export const switchVoiceConfigTool: ToolDefinition = {
 		const tmpPath = `${configPath}.tmp-${process.pid}`;
 		try {
 			mkdirSync(join(resolveWorkspace(), 'config'), { recursive: true });
-			// Merge with defaults so the on-disk file is complete + auditable.
-			const next: VoiceConfig = { ...VOICE_CONFIG_DEFAULTS, ...cfg };
+			const next = nextSwitchConfig(readConfigRaw(configPath), cfg);
 			writeFileSync(tmpPath, JSON.stringify(next, null, 2) + '\n');
 			renameSync(tmpPath, configPath);
 			console.log(`${ts()} [SwitchVoiceConfig] wrote ${configPath} → preset=${preset} (model=${cfg.model}, search=${cfg.googleSearch})`);

--- a/tests/voice-config-switch-preserves-file.test.ts
+++ b/tests/voice-config-switch-preserves-file.test.ts
@@ -1,0 +1,102 @@
+/**
+ * switch_voice_config must PRESERVE the user's config file and overlay only
+ * the two keys it owns.
+ *
+ * The previous form wrote `{...VOICE_CONFIG_DEFAULTS, ...preset}` without
+ * ever reading the file, so every switch replaced it — silently deleting
+ * session tuning (`compressionConfig`, `mediaResolution`), their explicit
+ * `null`/`false` off-switches, and any future key, with a restart right
+ * behind it so the loss left no trace. Two consequences this file pins
+ * against: a canary soak cannot be reverted mid-measurement, and a
+ * fleet-wide defaults revert still reaches devices whose user has used the
+ * switch.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { nextSwitchConfig, readConfigRaw } from '../src/voice-config-switch.js';
+import { VOICE_CONFIG_DEFAULTS, type VoiceConfig } from '../src/voice-config.js';
+
+const SEARCH: Pick<VoiceConfig, 'model' | 'googleSearch'> = {
+	model: 'gemini-2.5-flash-native-audio-preview-12-2025',
+	googleSearch: true,
+};
+
+test('the preset overlays model + googleSearch and nothing else', () => {
+	const existing = {
+		model: 'gemini-3.1-flash-live-preview',
+		googleSearch: false,
+		shadowStt: true,
+		channels: { c1: { owner_mode: true } },
+	};
+	const next = nextSwitchConfig(existing, SEARCH);
+	assert.equal(next.model, SEARCH.model);
+	assert.equal(next.googleSearch, true);
+	assert.equal(next.shadowStt, true, 'unrelated user settings survive');
+	assert.deepEqual(next.channels, { c1: { owner_mode: true } });
+});
+
+test('session tuning survives a switch — a canary soak is not silently reverted', () => {
+	const existing = {
+		compressionConfig: {},
+		mediaResolution: 'MEDIA_RESOLUTION_LOW',
+	};
+	const next = nextSwitchConfig(existing, SEARCH) as VoiceConfig;
+	assert.deepEqual(next.compressionConfig, {}, 'canary 3b key retained');
+	assert.equal(next.mediaResolution, 'MEDIA_RESOLUTION_LOW', 'canary 3c key retained');
+});
+
+test('an explicit off-switch survives — a defaults revert cannot be undone by a switch', () => {
+	for (const off of [null, false] as const) {
+		const next = nextSwitchConfig(
+			{ compressionConfig: off, mediaResolution: off },
+			SEARCH,
+		) as VoiceConfig;
+		assert.equal(next.compressionConfig, off, `${JSON.stringify(off)} preserved`);
+		assert.equal(next.mediaResolution, off);
+	}
+});
+
+test('unknown future keys are preserved verbatim', () => {
+	const next = nextSwitchConfig({ someFutureKnob: 42 }, SEARCH) as VoiceConfig &
+		Record<string, unknown>;
+	assert.equal(next.someFutureKnob, 42);
+});
+
+test('a missing, corrupt, or non-object file falls back to defaults, never refuses', () => {
+	const dir = mkdtempSync(join(tmpdir(), 'switchcfg-'));
+	try {
+		const missing = join(dir, 'nope.json');
+		assert.equal(readConfigRaw(missing), null);
+
+		const corrupt = join(dir, 'corrupt.json');
+		writeFileSync(corrupt, '{ not json');
+		assert.equal(readConfigRaw(corrupt), null);
+
+		const arrayFile = join(dir, 'array.json');
+		writeFileSync(arrayFile, '[1,2,3]');
+		const next = nextSwitchConfig(readConfigRaw(arrayFile), SEARCH);
+		assert.equal(next.shadowStt, VOICE_CONFIG_DEFAULTS.shadowStt, 'defaults fill in');
+		assert.equal(next.model, SEARCH.model);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('a real file round-trips through readConfigRaw', () => {
+	const dir = mkdtempSync(join(tmpdir(), 'switchcfg-'));
+	try {
+		const p = join(dir, 'voice-agent.json');
+		writeFileSync(p, JSON.stringify({ shadowStt: true, compressionConfig: {} }, null, 2));
+		const next = nextSwitchConfig(readConfigRaw(p), SEARCH) as VoiceConfig;
+		assert.equal(next.shadowStt, true);
+		assert.deepEqual(next.compressionConfig, {});
+		assert.equal(next.googleSearch, true, 'preset still wins on its own keys');
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
`switch_voice_config` writes `{...VOICE_CONFIG_DEFAULTS, ...preset}` and **never reads the existing file**, so every invocation *replaces* it — and fires a restart immediately after, so the loss leaves no trace.

**What it silently deletes:** session tuning (`compressionConfig`, `mediaResolution`), their explicit `null`/`false` off-switches, per-channel `owner_mode` entries, and any future key.

**Two concrete failures:**
1. A canary soak reverts mid-measurement the moment the user says "switch to search mode" — the session under test quietly goes back to uncompressed and the acceptance-gate result is invalid, with nothing in the log to say so.
2. After those values become built-in defaults, a fleet-wide revert **cannot reach any device whose user has ever used the switch**: the materialized copy sits in the per-user file, and `raw` outranks defaults.

**The fix:** `nextSwitchConfig(existingRaw, preset)` — pure and exported — merges defaults → **the user's actual file** → preset, so only `model` and `googleSearch` are overlaid and every other key survives. A missing, corrupt, or non-object file still falls back to defaults rather than refusing the switch (the pre-change behaviour).

An earlier draft of this fix proposed *stripping* the tuning keys instead; that would have deleted explicit off-switches too, re-enabling a default on exactly the devices that opted out. Preserving raw is the only form that gets both cases right.

6 tests pin it: unrelated settings survive, canary keys survive, `null`/`false` off-switches survive, unknown future keys survive, corrupt/missing/array files fall back, and a real file round-trips.

```
full TS suite   1147 pass / 0 fail / 2 skipped
tsc --noEmit    clean
eslint          clean on touched files
```

Found by a Codex review of the design doc's graduation step (ag2-space/ag2space-cinny-desktop#387). Independent of #3140/#3144 — it fixes existing behaviour and blocks the first canary flip.