### PR TITLE
test(graceful-restart): case 10 barriers on the lease, not on sleeps

### DIFF
--- a/tests/graceful-restart.test.sh
+++ b/tests/graceful-restart.test.sh
@@ -308,14 +308,36 @@ keeper10=$!
 ( GR_WS="$WS10" GR_SYNC_CMD="true" GR_POLL_S=1 GR_LOCK_STALE_S=2 bash "$GR" --dry-run \
     >"$TMP/ws10_A.out" 2>&1 ) &
 A=$!
-sleep 2                      # let A acquire the lock and enter the gate
-kill -STOP "$A" 2>/dev/null  # stall A past the stale threshold
-sleep 4
-( GR_WS="$WS10" GR_SYNC_CMD="true" GR_POLL_S=1 GR_LOCK_STALE_S=2 bash "$GR" --dry-run \
-    >"$TMP/ws10_B.out" 2>&1 ) &
-B=$!
-sleep 3                      # B reaps the stale lock and takes it
-kill -CONT "$A" 2>/dev/null  # A resumes holding a lease it no longer owns
+# Barriers on $LOCKDIR/rid — the value own_lock() compares — not fixed sleeps.
+# Unverified sleeps made this case UNDECIDABLE: if A had not yet acquired, or B
+# had not yet reaped, the lease-loss scenario never occurred and the assertion
+# still printed "N restart decisions", identical to a real concurrent restart.
+LOCK10="$WS10/state/locks/graceful-restart.lock"
+B=""   # set -u: the setup-failure path still reaches `wait "$B"`
+rid_A=""
+for _ in $(seq 1 100); do
+  rid_A="$(cat "$LOCK10/rid" 2>/dev/null || echo '')"
+  [ -n "$rid_A" ] && break
+  sleep 0.1
+done
+if [ -z "$rid_A" ]; then
+  say FAIL "case 10 SETUP: A never acquired the lease — scenario not exercised (not a concurrency bug)"
+else
+  kill -STOP "$A" 2>/dev/null  # stall A past the stale threshold
+  sleep 4                      # real wait: must exceed GR_LOCK_STALE_S=2 so B reaps
+  ( GR_WS="$WS10" GR_SYNC_CMD="true" GR_POLL_S=1 GR_LOCK_STALE_S=2 bash "$GR" --dry-run \
+      >"$TMP/ws10_B.out" 2>&1 ) &
+  B=$!
+  rid_B=""
+  for _ in $(seq 1 100); do
+    rid_B="$(cat "$LOCK10/rid" 2>/dev/null || echo '')"
+    [ -n "$rid_B" ] && [ "$rid_B" != "$rid_A" ] && break
+    sleep 0.1
+  done
+  [ -n "$rid_B" ] && [ "$rid_B" != "$rid_A" ] \
+    || say FAIL "case 10 SETUP: B never took the lease from A — scenario not exercised (not a concurrency bug)"
+  kill -CONT "$A" 2>/dev/null  # A resumes holding a lease it no longer owns
+fi
 touch "$TMP/ws10_goidle"     # release both from the busy gate
 wait "$A" 2>/dev/null; wait "$B" 2>/dev/null
 kill "$keeper10" 2>/dev/null || true; wait "$keeper10" 2>/dev/null || true


### PR DESCRIPTION
Closes the harness half of #3112.

## The defect

Case 10 sequenced the entire lease-loss scenario on three fixed sleeps and verified no phase of it:

```
sleep 2   # "let A acquire the lock and enter the gate"    <- unverified
sleep 4   # exceed GR_LOCK_STALE_S=2                        <- a REAL wait
sleep 3   # "B reaps the stale lock and takes it"           <- unverified
```

If either unverified sleep lost its race, the scenario **never occurred** — and the assertion still printed:

```
FAIL: N restart decisions after a lease loss — concurrent destructive restart
```

So a genuine concurrency bug and a harness artifact produce the **identical** output. That is why #3112 could only restate the question on each occurrence: the test reports the same string either way, and no amount of re-reading the log separates them.

## The fix

Both preconditions are directly observable. `$LOCKDIR/rid` is exactly the value `own_lock()` compares:

```sh
own_lock() {
  [ "$(cat "$LOCKDIR/rid" 2>/dev/null || echo '')" = "$RID" ]
}
```

So barrier on it: wait until A holds the lease, then wait until the value **changes** — which is precisely B having reaped and taken it.

**Cases 11, 12 and 13 in this same file already use this pattern** (`for _ in $(seq 1 60); do [ -f "$LOCK/rid" ] && break; sleep 0.2; done`). Case 10 is the one that never got it. This is not a new convention.

**`sleep 4` stays deliberately.** It is not a synchronization guess — the reap genuinely requires the lock to age past `GR_LOCK_STALE_S=2`. It is now anchored to a *verified* acquisition rather than a hoped-for one, which is what makes it reliable.

## What changes on failure

An unmet precondition now names itself:

```
FAIL: case 10 SETUP: A never acquired the lease — scenario not exercised (not a concurrency bug)
FAIL: case 10 SETUP: B never took the lease from A — scenario not exercised (not a concurrency bug)
```

instead of being reported as a concurrent destructive restart. The next occurrence **decides** between the two causes rather than restating the question.

## Verification

- Full suite: **ALL PASS**, two consecutive runs. (A third was cut short by my own command timeout, not by a failure — stating that rather than claiming three.)
- **Fault injection**: with an unreachable lease, the new `SETUP` message fires. On `origin/main` the same condition has no precondition check at all — `grep -c "SETUP\|precondition\|never acquired"` over case 10 returns **0**, so there is no path by which main could report it.
- `B` is pre-initialised: `set -u` is on and the setup-failure path still reaches `wait "$B"`.
- `review-checks.sh`: hardcoded-paths + root-artifacts clean (prose-cap has no in-scope files — shell only).

## Scope

Test-only; zero production lines. It does not claim to fix a lease-loss race — it makes the next failure *diagnosable*. If a real race exists, this is what will show it.

— @sutando-qingyun-001:ag2.space