### PR TITLE
test(health-check): the watcher cases read the HOST pid table, not their fixture

### DIFF
--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -83,21 +83,31 @@ def make_workspace(td: Path, *, core_alive: bool, pid_text: str | None) -> Path:
 
 
 def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None,
-              trees: dict | None = None) -> dict:
+              trees: dict | None = None, parents: dict | None = None) -> dict:
     """Call check_task_watcher against a temp WORKSPACE_DIR. `argv` patches
     the _proc_argv probe: None = leave the real one (only used where no PID
-    is read), "" = process gone, any string = that process's argv."""
+    is read), "" = process gone, any string = that process's argv.
+
+    `parents` maps a fabricated tree root to its parent pid; a root absent from
+    it has unknown parentage. The parent probes are stubbed unconditionally —
+    `trees` invents pids, and an unstubbed probe reads the HOST's process table,
+    where a fabricated pid may really exist and carry a real parent.
+    """
     with tempfile.TemporaryDirectory() as td:
         make_workspace(Path(td), core_alive=core_alive, pid_text=pid_text)
-        orig_ws, orig_probe, orig_trees = hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees
+        saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
+                 hc._ps_snapshot, hc._pid_parent)
         try:
             hc.WORKSPACE_DIR = Path(td)
             if argv is not None:
                 hc._proc_argv = lambda pid: argv
             hc._watcher_trees = lambda *a, **k: (trees or {})
+            hc._ps_snapshot = lambda *a, **k: ""
+            hc._pid_parent = lambda pid, ps=None: (parents or {}).get(pid)
             return hc.check_task_watcher()
         finally:
-            hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees = orig_ws, orig_probe, orig_trees
+            (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
+             hc._ps_snapshot, hc._pid_parent) = saved
 
 
 @contextlib.contextmanager
@@ -616,6 +626,22 @@ def case_m_absent_sentinel_with_live_orphan() -> list[str]:
     return fails
 
 
+def case_m2_fabricated_pid_ignores_the_host_process_table() -> list[str]:
+    """`trees` invents pids; the verdict must not depend on whether the host
+    happens to be running one. Unstubbed, the parent probe read the real table,
+    so on a runner where 9000 existed under kthreadd case m flipped to the
+    supervised branch — a green suite elsewhere and a red one there."""
+    saved = hc._pid_parent
+    try:
+        hc._pid_parent = lambda pid, ps=None: "2"   # host really runs pid 9000
+        r = run_check(core_alive=True, pid_text=None, trees={"9000": {"9000"}})
+    finally:
+        hc._pid_parent = saved
+    if "orphaned" not in r["detail"]:
+        return [f"m2) host pid table leaked into the verdict, got {r['detail']!r}"]
+    return []
+
+
 def case_n_trees_group_a_process_chain() -> list[str]:
     """The grouping algorithm: script + subshell is ONE watcher, not two.
     Counting matching processes would double it."""
@@ -710,6 +736,7 @@ def main() -> int:
         ("k", case_k_sentinels_own_tree_is_not_an_extra),
         ("l", case_l_dead_sentinel_with_live_orphan),
         ("m", case_m_absent_sentinel_with_live_orphan),
+        ("m2", case_m2_fabricated_pid_ignores_the_host_process_table),
         ("n", case_n_trees_group_a_process_chain),
         ("n2", case_n2_mentioning_the_script_is_not_running_it),
         ("o", case_o_trees_excludes_our_own_pid),


### PR DESCRIPTION
## The defect

`run_check` in `tests/health-check-task-watcher.test.py` fabricates process trees
(`trees={"9000": {"9000"}}`) but stubs only `_watcher_trees` and `_proc_argv`.
`check_task_watcher`'s absent-sentinel branch then calls `_pid_parent(root, ps_out)`,
which reads the **machine's real `ps` output**. So the verdict for an invented pid
depends on whether that pid happens to exist on the runner.

`supervised_watcher`, in the same file, already stubs `_ps_snapshot` **and**
`_pid_parent` — the omission in `run_check` is a slip, not a design choice.

## Evidence — the failure, and the same failure reproduced on demand

Observed on the coverage job of an unrelated PR (#3113, which does not touch this
probe). `scripts/coverage-gate.sh` aborts before measuring anything:

```
coverage-gate: running Python suite under instrumentation...
✖ test failed under instrumentation: tests/health-check-task-watcher.test.py
  ✗ case m
      m) detail should name the orphan, got 'watcher pid 9000 runs under a live
      session (ppid 2) but wrote no PID sentinel, so health-check cannot track it.
      Do NOT stop it — it IS draining ta...
coverage-gate: suite must be green before coverage is meaningful.
```

`ppid 2` is the tell: on that runner pid 9000 really existed, parented by kthreadd,
so `supervised = [r for r, pp in parents.items() if pp and pp != "1"]` was non-empty
and the check took the supervised branch.

Reproduced at the **parent commit** by changing one variable — the host's answer for
pid 9000 — and nothing else:

```
$ python3 -c "... hc._pid_parent = lambda p, ps=None: '2' ; print(case_m())"
["m) detail should name the orphan, got 'watcher pid 9000 runs under a live session
  (ppid 2) but wrote no PID sentinel, so health-check cannot track it. ...'"]
$ python3 tests/health-check-task-watcher.test.py     # same commit, unpatched
Task-watcher liveness invariants hold.                # rc=0
```

Byte-identical detail string to CI, from a local host where the test otherwise passes.

## The fix

`run_check` stubs `_ps_snapshot`/`_pid_parent` like `supervised_watcher` does, with an
optional `parents` map so a case can still state the parentage it means. Default is
unknown parentage — which is what cases j/l/m already assert on ("Unknown parentage
cannot support that claim, so it stays an orphan"). No production code changes; no
existing case changes its expectation.

## New case m2, and why it is not redundant with m

Case m only fails on a host where pid 9000 exists — that is the whole bug. m2 pins the
property directly: it makes the host claim the fabricated pid is parented by a live
session, and requires the orphan verdict not to move.

Mutation check — stub reverted to `pass`, at HEAD:

```
m  : PASS(host pid 9000 absent — env-dependent, as diagnosed)
m2 : m2) host pid table leaked into the verdict, got 'watcher pid 9000 runs under
     a live session (ppid 2) but wrote ...
```

m2 is red on **any** host when the stub is removed; m is red only on an unlucky one.

## At HEAD

```
$ python3 tests/health-check-task-watcher.test.py
Task-watcher liveness invariants hold.                                    # rc=0
$ SUTANDO_TEST_SUBPROCESS_COVERAGE=1 python3 -m coverage run --rcfile=.coveragerc \
    tests/health-check-task-watcher.test.py
Task-watcher liveness invariants hold.                                    # rc=0
```

Single concern: test hermeticity in one file. No production behavior is touched, so
there is no live path to exercise.

---
@sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)