### PR TITLE
fix(graceful-restart): an empty core-status.json is the truncate window, not idle

### DIFF
--- a/src/agent/graceful-restart.sh
+++ b/src/agent/graceful-restart.sh
@@ -17,6 +17,7 @@ ALIVE="$WS/state/cores/$HOST.alive"
 STATUS="$WS/state/core-status.json"
 STALE_S=90                                     # matches core_heartbeat's documented liveness threshold
 STATUS_TTL_S="${GR_STATUS_TTL_S:-900}"         # "running" older than this = wedged, not busy (test override)
+STATUS_REREADS="${GR_STATUS_REREADS:-5}"       # empty-read retries before treating the status as absent
 POLL_S="${GR_POLL_S:-2}"                       # test override
 
 log() { echo "graceful-restart[$RID]: $*"; }
@@ -110,9 +111,20 @@ alive_age() {
 # Busy = core-status.json claims "running" AND its self-reported ts is fresh.
 busy() {
   [ -f "$STATUS" ] || return 1
-  grep -q '"status"[[:space:]]*:[[:space:]]*"running"' "$STATUS" 2>/dev/null || return 1
+  # Every writer is a `>` truncate-then-write, so a read can land on an EMPTY
+  # file. Empty is unknown, not idle — re-read instead of authorising the kill.
+  local raw="" i=0
+  while :; do
+    raw="$(cat "$STATUS" 2>/dev/null || true)"
+    [ -n "$raw" ] && break
+    i=$((i + 1))
+    [ "$i" -ge "$STATUS_REREADS" ] && return 1
+    sleep 0.05
+  done
+  printf '%s' "$raw" | grep -q '"status"[[:space:]]*:[[:space:]]*"running"' || return 1
   local ts
-  ts="$(grep -o '"ts"[[:space:]]*:[[:space:]]*[0-9][0-9]*' "$STATUS" 2>/dev/null | grep -o '[0-9][0-9]*$' || true)"
+  ts="$(printf '%s' "$raw" | grep -o '"ts"[[:space:]]*:[[:space:]]*[0-9][0-9]*' \
+        | grep -o '[0-9][0-9]*$' || true)"
   [ -n "$ts" ] || return 1
   [ "$(( $(date +%s) - ts ))" -le "$STATUS_TTL_S" ]
 }

--- a/tests/graceful-restart.test.sh
+++ b/tests/graceful-restart.test.sh
@@ -411,6 +411,45 @@ GR_WS="$WS13c" GR_SYNC_CMD="true" GR_POLL_S=1 GR_RETAIN_LOCK_ON_DECISION=1 bash 
   && say ok "GR_RETAIN_LOCK_ON_DECISION=1 still retains (models production exec)" \
   || say FAIL "retain mode did not retain — the concurrency test no longer models production"
 
+echo "14. an EMPTY core-status.json is the truncate WINDOW, not idle — re-read, do not kill through it"
+# Every writer is a `>` truncate-then-write, so a poll can land between the two.
+# Modelled deterministically: empty now, "running" well inside the re-read budget.
+WS14="$TMP/ws14"; mkws "$WS14"
+: > "$WS14/state/core-status.json"          # the window: readable, empty
+( for _ in $(seq 1 40); do touch "$WS14/state/cores/$HOST.alive"; sleep 0.5; done ) &
+keeper14=$!
+( sleep 0.15
+  printf '{"status":"running","ts":%s}\n' "$(date +%s)" > "$WS14/state/core-status.json" ) &
+writer14=$!
+( GR_WS="$WS14" GR_SYNC_CMD="true" GR_POLL_S=1 GR_STATUS_REREADS=5 bash "$GR" --dry-run \
+    > "$TMP/ws14.out" 2>&1 ) &
+gr14=$!
+wait "$writer14" 2>/dev/null
+sleep 3
+if kill -0 "$gr14" 2>/dev/null; then
+  say ok "the gate re-read the window and stayed in the busy wait"
+else
+  say FAIL "the gate decided through the truncate window: $(grep -h 'would exec' "$TMP/ws14.out" | head -1)"
+fi
+printf '{"status":"idle","ts":%s}\n' "$(date +%s)" > "$WS14/state/core-status.json"
+wait "$gr14" 2>/dev/null
+kill "$keeper14" 2>/dev/null || true; wait "$keeper14" 2>/dev/null || true
+grep -q "would exec" "$TMP/ws14.out" \
+  && say ok "and it proceeded once the core reported idle" \
+  || say FAIL "the gate never proceeded on a readable idle status — over-corrected into a hang"
+
+echo "15. an ABSENT core-status.json still reads as not-busy (no regression)"
+WS15="$TMP/ws15"; mkws "$WS15"
+rm -f "$WS15/state/core-status.json"
+touch "$WS15/state/cores/$HOST.alive"
+( for _ in $(seq 1 20); do touch "$WS15/state/cores/$HOST.alive"; sleep 0.5; done ) &
+k15=$!
+GR_WS="$WS15" GR_SYNC_CMD="true" GR_POLL_S=1 bash "$GR" --dry-run > "$TMP/ws15.out" 2>&1 || true
+kill "$k15" 2>/dev/null || true; wait "$k15" 2>/dev/null || true
+grep -q "would exec" "$TMP/ws15.out" \
+  && say ok "absent status = nothing running = proceed" \
+  || say FAIL "absent status now blocks the restart — the empty-read fix over-reached"
+
 if [ "$fails" = 0 ]; then
   echo "ALL PASS"
 else


### PR DESCRIPTION
Intended for #3154 at the owner's direction ("塞进 #3154"), but #3154 merged at
08:56:50Z (02308a62) before the change was ready, and its branch was deleted. Same
branch name, fresh PR — the fix still has to land somewhere.

## The defect

`busy()` is the quiet gate's only question: is the core mid-work? It read the status
file with `grep` and treated **any** non-match as not-busy:

```sh
[ -f "$STATUS" ] || return 1
grep -q '"status"[[:space:]]*:[[:space:]]*"running"' "$STATUS" 2>/dev/null || return 1
```

Every writer of `core-status.json` is a `>` truncate-then-write — that is what CLAUDE.md
and the proactive-loop skill both instruct, and there is no atomic-write helper on that
path. So a poll can land between the truncate and the write, read a zero-length file, and
conclude the core is idle. The gate then authorises the kill, through the one gate whose
entire job is not killing a busy core.

## Evidence

Measured on the parent commit, with a writer emitting nothing but `"running"` and a reader
running `busy()`'s exact grep:

```
reads=19  zero-length=4  busy()-would-say-NOT-busy=3
```

**Sizing it honestly:** that writer is pathological — thousands of writes back to back. The
real core writes `core-status.json` a handful of times per pass, so the per-poll probability
in production is far lower, proportional to write-duration over poll-interval. The claim is
that the window is real and observable, not that it fires often.

How it was found: a reviewer asked on #3154 whether the new barrier proved *gate entry* as
well as lease acquisition. It does not need to — gate entry there is enforced by state, not
by the sleep the barrier replaced — but answering the question meant reading `busy()`, which
is where this was.

## The fix

Read once into a variable; re-read an empty result up to `GR_STATUS_REREADS` (default 5,
50 ms apart) before giving up. **Empty is unknown, not idle.** An **absent** file still reads
as not-busy — nothing is running — which is a different case and stays unchanged.

## Tests

- **case 14** models the window deterministically: empty now, `"running"` written well inside
  the re-read budget. Asserts the gate stays in the busy wait, then that it still proceeds
  once the core reports idle (so the fix cannot pass by hanging).
- **case 15** pins the no-regression half: an absent status file still proceeds.

Mutation-checked at HEAD — `busy()` reverted to the parent version:

```
14. an EMPTY core-status.json is the truncate WINDOW, not idle
  FAIL: the gate decided through the truncate window: ... DRY-RUN — would exec ...
15. an ABSENT core-status.json still reads as not-busy (no regression)
  ok: absent status = nothing running = proceed
```

Case 15 is green either way, so **14 is the discriminator**. Restored → `ALL PASS`.

At HEAD, on top of current main:

```
$ bash tests/graceful-restart.test.sh
ALL PASS
$ bash scripts/review-checks.sh --diff <pr diff>
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
```

No live restart was exercised — that would kill the running core. The gate is driven in
`--dry-run`, which is how every other case in this suite drives it.

---
@sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)