### PR TITLE
test(graceful-restart): case 14 fails AS case 14 when the gate hangs

### DIFF
--- a/tests/graceful-restart.test.sh
+++ b/tests/graceful-restart.test.sh
@@ -414,11 +414,14 @@ GR_WS="$WS13c" GR_SYNC_CMD="true" GR_POLL_S=1 GR_RETAIN_LOCK_ON_DECISION=1 bash 
 echo "14. an EMPTY core-status.json is the truncate WINDOW, not idle — re-read, do not kill through it"
 # Every writer is a `>` truncate-then-write, so a poll can land between the two.
 # Modelled deterministically: empty now, "running" well inside the re-read budget.
+# Write well inside the 5x50ms re-read budget. A loaded runner can stretch
+# either side, so keep the margin visible and overridable rather than implicit.
+GR_T14_WRITE_DELAY="${GR_T14_WRITE_DELAY:-0.10}"
 WS14="$TMP/ws14"; mkws "$WS14"
 : > "$WS14/state/core-status.json"          # the window: readable, empty
 ( for _ in $(seq 1 40); do touch "$WS14/state/cores/$HOST.alive"; sleep 0.5; done ) &
 keeper14=$!
-( sleep 0.15
+( sleep "$GR_T14_WRITE_DELAY"
   printf '{"status":"running","ts":%s}\n' "$(date +%s)" > "$WS14/state/core-status.json" ) &
 writer14=$!
 ( GR_WS="$WS14" GR_SYNC_CMD="true" GR_POLL_S=1 GR_STATUS_REREADS=5 bash "$GR" --dry-run \
@@ -432,6 +435,17 @@ else
   say FAIL "the gate decided through the truncate window: $(grep -h 'would exec' "$TMP/ws14.out" | head -1)"
 fi
 printf '{"status":"idle","ts":%s}\n' "$(date +%s)" > "$WS14/state/core-status.json"
+# Bounded, not `wait`: a gate that never returns must fail AS case 14, not as an
+# anonymous job timeout — the attribution defect case 10 exists to prevent.
+gr14_done=0
+for _ in $(seq 1 60); do
+  kill -0 "$gr14" 2>/dev/null || { gr14_done=1; break; }
+  sleep 0.5
+done
+if [ "$gr14_done" = 0 ]; then
+  kill -9 "$gr14" 2>/dev/null || true
+  say FAIL "case 14: the gate never returned within 30s of a readable idle status — hung, not merely slow"
+fi
 wait "$gr14" 2>/dev/null
 kill "$keeper14" 2>/dev/null || true; wait "$keeper14" 2>/dev/null || true
 grep -q "would exec" "$TMP/ws14.out" \


### PR DESCRIPTION
Follow-up to #3156, from review findings on the merged PR.

## The defect

Case 14 ended in a bare `wait "$gr14"`. If the gate never returns, that blocks forever — the
run dies as an anonymous job timeout and CI attributes it to the job rather than the case.
That is the **same attribution defect #3154's case 10 exists to prevent**, reproduced one file
over, in the case written to demonstrate the principle.

A reviewer sharpened *why* the existing assertion pair is not enough, and the sharpening is
better than the one in #3156's body. Assertion 2's own failure text — `over-corrected into a
hang` — names a state in which that assertion **cannot execute**: if the gate hangs, `wait`
never returns and the `grep` never runs. A message describing a state it cannot reach is the
tell.

## The fix, and its evidence

Bounded poll with a named failure in place of the bare `wait`. Mutation-checked by removing
the idle write so the gate can never proceed:

```
14. an EMPTY core-status.json is the truncate WINDOW, not idle
  ok: the gate re-read the window and stayed in the busy wait
  FAIL: case 14: the gate never returned within 30s of a readable idle status
        — hung, not merely slow
  FAIL: the gate never proceeded on a readable idle status — over-corrected into a hang
15. an ABSENT core-status.json still reads as not-busy (no regression)
```

The run **continues to case 15** instead of wedging, and the failure names the case. Unmodified
at HEAD: `ALL PASS`.

Also: the writer delay becomes `GR_T14_WRITE_DELAY` (0.10s, was a literal 0.15s against a
~0.25s re-read budget), so a loaded runner has margin and the knob is visible rather than
implicit — raised as a close-but-workable timing margin in review.

## Scope — stated because a narrow fix can retire a wide concern

This makes **one** case attributable. A second reviewer mutated `busy()` to always-true and ran
the suite under a guard: it stalled at **case 2**, long before 14. So
wedge-instead-of-attributable-failure is **pre-existing and suite-wide**, not introduced by
#3156 and not fixed here. Shipping only this and calling the concern closed would be worse than
not shipping it, so: it needs its own change, and this PR does not claim otherwise.

## Not in this PR, recorded so it isn't lost

Two further review findings on #3156 that belong to other changes:

1. **The re-read budget covers only the EMPTY window.** A torn read is non-empty, so it exits
   the retry loop immediately, fails the `running` grep, and returns not-busy. Coverage of the
   torn window rests entirely on a ~60-byte redirect being a single `write()` — a property of
   today's writers, not of the code. Falsifiable form: if any writer's status payload grows or
   buffers past one `write()`, that window goes live and `busy()` has no defense.
2. **The pre-#3156 code read the status file twice** (once to grep `running`, once to extract
   `ts`), so a rewrite between the two could pair an old status with a fresh timestamp. Reading
   once into `raw` closes that as well — worth a line in the source, since it reads as a
   stylistic tidy-up and could be optimised back apart by someone who never knew.

Test-only; no production code changes.

---
@sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)