### PR TITLE
fix(health-check): the memory-index probe reads a compacted index

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2190,8 +2190,24 @@ def check_memory_index_integrity() -> "dict | None":
     loaded_text, loaded_bytes, loaded_lines = _index_loaded_prefix(effective_text)
     truncated = len(loaded_text) < len(effective_text)
 
+    # An index that outgrows the load budget compacts its entries to prefix
+    # abbreviations (`f:` for feedback_, `r:` for reference_, `p:` for project_).
+    _INDEX_ABBREV = {"feedback_": "f:", "reference_": "r:", "project_": "p:"}
+
     def _referenced_in(hay: str, name: str) -> bool:
-        return name in hay or name[:-3] in hay
+        stem = name[:-3] if name.endswith(".md") else name
+        if name in hay or stem in hay:
+            return True
+        # Without this the probe calls an indexed file unindexed, and the
+        # "fix" it invites — expanding the index — is what blows the read limit.
+        for full, short in _INDEX_ABBREV.items():
+            if not stem.startswith(full):
+                continue
+            token = short + stem[len(full):]
+            # Trailing boundary so `f:foo` is not satisfied by `f:foobar`.
+            if re.search(re.escape(token) + r"(?![\w-])", hay):
+                return True
+        return False
 
     # MEMORY.md is not the only index. Once a corpus outgrows the load budget the
     # overflow moves to sibling HUB indexes (MEMORY-reference.md, MEMORY-wire.md,

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -393,6 +393,46 @@ with tempfile.TemporaryDirectory() as t:
     check("beyond-the-cut entry still FAILS (scope unchanged)",
           r and r["status"] == "fail", str(r))
 
+# 7) A COMPACTED index (`f:`/`r:`/`p:` prefixes) still counts as indexed. The
+#    corpus large enough to abbreviate is the one this probe most needs to read.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text(
+        "# Index\nExpand `f:`->`feedback_`, `r:`->`reference_`, `p:`->`project_`.\n"
+        "- f:pronoun_she_her - r:discord_channels - p:room_apps_platform\n")
+    for n in ("feedback_pronoun_she_her.md", "reference_discord_channels.md",
+              "project_room_apps_platform.md"):
+        (mem / n).write_text("body")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("abbreviated index → ok (not 3 false orphans)",
+          r and r["status"] == "ok", str(r))
+
+# 7b) The fix must not blind the probe: a file absent from an abbreviated index
+#     is still reported, and reported BY NAME.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n- f:pronoun_she_her\n")
+    (mem / "feedback_pronoun_she_her.md").write_text("body")
+    (mem / "feedback_never_written_down.md").write_text("genuinely stranded")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("genuinely-missing file still warns", r and r["status"] == "warn", str(r))
+    check("and is named", r and "feedback_never_written_down.md" in r["detail"], str(r))
+
+# 7c) The abbreviation is matched at a boundary: `f:foo` in the index must not
+#     satisfy `feedback_foo_bar.md`, or one entry laundered a whole family.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n- f:pronoun\n")
+    (mem / "feedback_pronoun.md").write_text("body")
+    (mem / "feedback_pronoun_she_her.md").write_text("distinct memory, NOT indexed")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("prefix does not launder a longer sibling",
+          r and r["status"] == "warn"
+          and "feedback_pronoun_she_her.md" in r["detail"], str(r))
+
 print()
 if _failed:
     print(f"FAIL — {_failed} check(s) failed"); sys.exit(1)


### PR DESCRIPTION
## The defect

`check_memory_index_integrity`'s `_referenced_in` matches only a full filename:

```python
return name in hay or name[:-3] in hay
```

An index that has outgrown the session load budget compacts its entries to prefix abbreviations — `f:` for `feedback_`, `r:` for `reference_`, `p:` for `project_`, with the expansion rule stated in the index's own header. Every such entry reads as **"in NO index"**.

That makes the probe least correct exactly where it matters most: a corpus only abbreviates *because* it is large, and large is the case this probe exists for.

## Evidence — before/after on two real corpora

Reported "memory file(s) in NO index", `origin/main` vs this branch:

| corpus | files | before | after |
|---|---|---|---|
| `~/.claude/projects/<slug>/memory` — what the probe reads on this host today | 231 | 127 | **127** |
| `workspace/.claude-sutando/projects/<slug>/memory` — the live corpus | 609 | 600 | **0** |

**Nothing changes on the path the probe reads today.** Those 127 are genuinely missing from that index — abbreviated or not — and the probe should keep saying so.

The 600 is the trap. This host has an open decision to retire a `SUTANDO_MEMORY_DIR` override, which is a one-line change that repoints the probe at the 609-file corpus. On `main` that would produce a 600-file false alarm, and the repair it invites — expanding the index to full filenames — is precisely what breaks the **25KB / 200-line session read limit** the same probe warns about in its other half. The two halves would be pulling against each other.

## Scope

- Abbreviated match requires a **trailing boundary**, so `f:foo` does not credit `feedback_foo_bar.md`.
- Only the new branch is anchored; the pre-existing full-name substring match is untouched, to keep this a single concern. (Measured: anchoring that one too gives the same 0 / 127, so it is available as a separate change if wanted.)
- No threshold, no status semantics, no other probe touched.

## Tests

Three cases added to `tests/memory-index-integrity.test.py`:
1. compacted index → `ok`, not three false orphans;
2. a file genuinely absent from an abbreviated index → still `warn`, and named;
3. `f:pronoun` does not launder `feedback_pronoun_she_her.md`.

Mutation: replacing the new branch with `if False` turns case 7 red — `3 memory file(s) in NO index: feedback_pronoun_she_her.md, project_room_apps_platform.md, reference_discord_channels.md`, exit 1. The pre-existing suite (including the `#2449` beyond-the-cut scope control) stays green, as does `health-check-memory-index-trend.test.py`.

`scripts/review-checks.sh --diff` PASS.

---
@sutando-qingyun-001:ag2.space