### PR TITLE
fix(voice-tools): a denied keystroke names the setup step, like a denied scroll

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -39,6 +39,7 @@ const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
 // Re-export recording/screen/browser tools from browser-tools
 export { describeScreenTool, clickTool, scrollAndDescribeTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool, openUrlTool } from './browser-tools.js';
+import { keystrokeOutcome } from './osascript-setup-hint.js';
 import { describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool, openUrlTool } from './browser-tools.js';
 
 // Vision: one-shot frame + start/stop live screen-to-Gemini video.
@@ -215,14 +216,14 @@ export const pressKeyTool: ToolDefinition = {
 			try {
 				execFileSync('osascript', ['-e', `tell application "System Events" to keystroke "${safeKey}"${modStr}`], { timeout: 3_000 });
 			} catch (err) {
-				return { error: `press_key failed: ${err instanceof Error ? err.message : err}` };
+				return keystrokeOutcome('press_key', err instanceof Error ? err.message : String(err));
 			}
 		} else {
 			const modStr = modifiers.length ? ` using {${modifiers.map(m => m + ' down').join(', ')}}` : '';
 			try {
 				execFileSync('osascript', ['-e', `tell application "System Events" to key code ${keyCode}${modStr}`], { timeout: 3_000 });
 			} catch (err) {
-				return { error: `press_key failed: ${err instanceof Error ? err.message : err}` };
+				return keystrokeOutcome('press_key', err instanceof Error ? err.message : String(err));
 			}
 		}
 		console.log(`${ts()} [PressKey] ${app ? `(${app}) ` : ''}${modifiers.length ? modifiers.join('+') + '+' : ''}${key}`);
@@ -379,7 +380,7 @@ export const typeTextTool: ToolDefinition = {
 				console.log(`${ts()} [TypeText] pasted (multi-line, mode=${mode}): ${text.slice(0, 40)}...`);
 				return { status: 'typed', text };
 			} catch (err) {
-				return { error: `Paste failed: ${err instanceof Error ? err.message : err}` };
+				return keystrokeOutcome('Paste', err instanceof Error ? err.message : String(err));
 			}
 		}
 		// Single-line short text: use keystroke
@@ -398,7 +399,7 @@ export const typeTextTool: ToolDefinition = {
 			console.log(`${ts()} [TypeText] typed (mode=${mode}): ${text.slice(0, 40)}`);
 			return { status: 'typed', text };
 		} catch (err) {
-			return { error: `Type failed: ${err instanceof Error ? err.message : err}` };
+			return keystrokeOutcome('Type', err instanceof Error ? err.message : String(err));
 		}
 	},
 };

--- a/src/osascript-setup-hint.ts
+++ b/src/osascript-setup-hint.ts
@@ -21,6 +21,32 @@ export function setupHint(raw: string): string | null {
 	return text;
 }
 
+export type KeystrokeOutcome =
+	| { status: 'setup_required'; steps: string[]; message: string }
+	| { error: string };
+
+/**
+ * Decide what a failed keystroke/paste reports. Same extraction rationale as
+ * scrollOutcome: in-place this could be disabled without a test failing.
+ *
+ * `scroll` already turns an OS denial into steps the model reads aloud; the
+ * keystroke tools returned the raw error, so the user heard "I don't have
+ * permission" with nothing to act on.
+ */
+export function keystrokeOutcome(prefix: string, raw: string): KeystrokeOutcome {
+	const hint = setupHint(raw);
+	// No hint means an ordinary failure — keep the raw text so real errors read
+	// unchanged rather than being dressed up as a setup problem.
+	if (!hint) return { error: `${prefix}: ${raw}` };
+	return {
+		status: 'setup_required',
+		steps: [hint],
+		message: `${prefix} did not go through — a one-time setup step is needed. `
+			+ 'Tell the user that, then read the "steps" to them verbatim, in order. '
+			+ 'Do not add steps of your own.',
+	};
+}
+
 export type ScrollOutcome =
 	| { status: 'setup_required'; moved: false; steps: string[]; message: string }
 	| { status: 'at_limit'; moved: false; message: string }

--- a/tests/inline-tools-keystroke-setup-hint.test.ts
+++ b/tests/inline-tools-keystroke-setup-hint.test.ts
@@ -1,0 +1,66 @@
+/**
+ * A denied keystroke names the setup step, the way a denied scroll already does.
+ *
+ * type_text and press_key returned the raw osascript error, so the model told
+ * the user "I don't have permission" with nothing to act on — while `scroll`,
+ * two files away, had been turning the same denials into spoken steps.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { keystrokeOutcome } from '../src/osascript-setup-hint.js';
+
+const SRC = readFileSync(
+	join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'inline-tools.ts'),
+	'utf8',
+);
+
+const ACCESSIBILITY =
+	'36:48: execution error: System Events got an error: osascript is not allowed to send keystrokes. (1002)';
+const AUTOMATION =
+	'0:0: execution error: Not authorized to send Apple events to Google Chrome. (-1743)';
+
+describe('keystrokeOutcome', () => {
+	it('an Accessibility denial becomes steps the model is told to read aloud', () => {
+		const r = keystrokeOutcome('Type', ACCESSIBILITY);
+		assert.equal((r as { status: string }).status, 'setup_required');
+		assert.match((r as { steps: string[] }).steps[0], /Privacy & Security > Accessibility/);
+		assert.match((r as { message: string }).message, /verbatim/);
+	});
+
+	it('an Automation denial does too, and names that pane instead', () => {
+		const r = keystrokeOutcome('press_key', AUTOMATION);
+		assert.equal((r as { status: string }).status, 'setup_required');
+		assert.match((r as { steps: string[] }).steps[0], /Privacy & Security > Automation/);
+	});
+
+	it('an ORDINARY failure stays a raw error — a real bug must not read as setup', () => {
+		const r = keystrokeOutcome('Paste', 'Command failed: pbcopy\nbroken pipe');
+		assert.equal((r as { status?: string }).status, undefined);
+		assert.match((r as { error: string }).error, /^Paste: Command failed: pbcopy/);
+	});
+
+	it('the prefix identifies which tool failed, so the model does not guess', () => {
+		assert.match((keystrokeOutcome('Type', ACCESSIBILITY) as { message: string }).message, /^Type /);
+		assert.match((keystrokeOutcome('press_key', ACCESSIBILITY) as { message: string }).message, /^press_key /);
+	});
+});
+
+describe('the keystroke tools route their failures through it', () => {
+	it('no catch in inline-tools.ts returns a bare `<tool> failed:` string', () => {
+		// The regression this pins: each site formatted its own error and the
+		// hint was never consulted.
+		assert.doesNotMatch(SRC, /error: `press_key failed:/);
+		assert.doesNotMatch(SRC, /error: `Paste failed:/);
+		assert.doesNotMatch(SRC, /error: `Type failed:/);
+	});
+
+	it('all four failure sites call keystrokeOutcome', () => {
+		const calls = SRC.match(/return keystrokeOutcome\(/g) ?? [];
+		assert.equal(calls.length, 4,
+			`expected 4 routed failure sites (2 press_key, 2 type_text), got ${calls.length}`);
+	});
+});


### PR DESCRIPTION
## The bug

Reported by @yixuan: *"I asked it to type and it said it didn't have permission."* His guess was that the cursor wasn't in an editable field. It wasn't that — it was a real permission denial with no remediation attached.

`type_text` and `press_key` returned the raw osascript error, so the model paraphrased it as "I don't have permission" and stopped there. `scroll` had already solved this two files away — but `inline-tools.ts` has **zero references to `setupHint`**.

## Before / after

```
$ git show origin/main:src/inline-tools.ts | grep -cE 'error: `(press_key|Paste|Type) failed:'
4
$ git show origin/main:src/inline-tools.ts | grep -c 'setupHint\|keystrokeOutcome'
0
```

at HEAD: `0` bare returns, `4` routed through `keystrokeOutcome`.

What the model receives now:

```
DENIAL   {"status":"setup_required",
          "steps":["System Events got an error: osascript is not allowed to send keystrokes.
                    Turn on AG2 Space in System Settings > Privacy & Security > Accessibility,
                    then quit and reopen AG2 Space."],
          "message":"Type did not go through — a one-time setup step is needed. Tell the user
                      that, then read the \"steps\" to them verbatim, in order..."}
ORDINARY {"error":"Type: Command failed: pbcopy\nbroken pipe"}
```

Both directions are pinned: an ordinary failure must keep its raw text, so a real bug is never dressed up as a setup problem.

## Where the logic lives

`keystrokeOutcome()` sits beside `scrollOutcome()` in `src/osascript-setup-hint.ts` — the dependency-light policy module — for the same reason its neighbour is extracted: in place, it could be disabled without any assertion failing. The adapter keeps only the I/O.

## Tests

`tests/inline-tools-keystroke-setup-hint.test.ts` — 6 tests: Accessibility denial → steps, Automation denial → the other pane, ordinary error stays raw, the prefix identifies the tool, plus two source-level pins (no bare `<tool> failed:` return survives; exactly 4 sites call the helper).

```
tests/inline-tools-keystroke-setup-hint.test.ts   pass 6  fail 0
tests/browser-tools-scroll-setup-hint.test.ts     pass 11 fail 0   (unchanged neighbour, still green)
```

## Typecheck

`npm run typecheck` reports 6 errors — **the same 6, byte-identical, at `origin/main`**. `comm -13` between the two runs is empty, and none touch `inline-tools.ts` or `osascript-setup-hint.ts`. They are `bodhi-realtime-agent` version skew in `voice-agent.ts` / `voice-audio-health.ts`, pre-existing and out of scope here.

## What I could NOT verify

I could not reproduce the original denial end-to-end: Accessibility is granted on this host, so the failing path never fires. The unit behaviour above is measured; the live "user hears the steps" round trip needs a machine with the grant revoked. Flagging that rather than implying a live test I did not run.

## Not in this PR

The related gap — `setupHint` maps `-1743` and `1002` but not `-1719` — is left alone deliberately. I have not observed `-1719` from this code path on a real denial, and I won't add a mapping for a code I haven't measured. Separate concern, separate PR, once someone can produce one.