### PR TITLE
fix(scroll): an unparseable denial is still a denial, not a scroll

### DIFF
--- a/src/osascript-setup-hint.ts
+++ b/src/osascript-setup-hint.ts
@@ -30,6 +30,12 @@ export type ScrollOutcome =
  * Decide what a scroll attempt reports. Extracted so the decision is reachable
  * by a test — in-place it could be disabled without any assertion failing.
  */
+/** Fallback step when macOS refuses a keystroke without text setupHint can parse.
+ *  Deliberately hedged: the throw proves refusal, not which grant is missing. */
+const UNEXPLAINED_DENIAL_STEP =
+	'macOS refused the keystroke without saying why. Check System Settings > Privacy & Security '
+	+ '> Accessibility for AG2 Space, turn it on if it is off, then quit and reopen AG2 Space.';
+
 export function scrollOutcome(o: {
 	scrollMoved: boolean | null; keyDenied: boolean; hints: string[]; direction: string;
 }): ScrollOutcome {
@@ -41,8 +47,11 @@ export function scrollOutcome(o: {
 	}
 	// keyDenied is load-bearing: `osascript key code` exits 0 whether or not
 	// anything handled the key, so only a THROW proves the fallback never ran.
-	if (o.scrollMoved === null && o.keyDenied && o.hints.length > 0) {
-		return { status: 'setup_required', moved: false, steps: o.hints,
+	if (o.scrollMoved === null && o.keyDenied) {
+		// An unparseable denial is still a denial: the JS gave no answer and the
+		// keystroke threw, so reporting `scrolled` would assert a move nothing saw.
+		return { status: 'setup_required', moved: false,
+		         steps: o.hints.length > 0 ? o.hints : [UNEXPLAINED_DENIAL_STEP],
 		         message: 'The scroll did not go through — a one-time setup step is needed. Tell the user that, then read the "steps" to them verbatim, in order. Do not add steps of your own.' };
 	}
 	return { status: 'scrolled', moved: o.scrollMoved };

--- a/tests/browser-tools-scroll-setup-hint.test.ts
+++ b/tests/browser-tools-scroll-setup-hint.test.ts
@@ -79,6 +79,28 @@ describe('scroll reporting', () => {
 		assert.doesNotMatch(JSON.stringify(r), /did not go through/);
 	});
 
+	it('a denial whose text setupHint cannot parse is STILL a denial, not a scroll', () => {
+		// The adjacent input to the case above: both paths failed, but the OS error
+		// carried no parseable sentence, so `hints` is empty. Reporting `scrolled`
+		// there asserts a move nothing observed.
+		const r = scrollOutcome({ scrollMoved: null, keyDenied: true, hints: [], direction: 'down' });
+		assert.equal(r.status, 'setup_required');
+		assert.equal(r.moved, false);
+		const steps = (r as { steps: string[] }).steps;
+		assert.equal(steps.length, 1, 'a hedged step still has to be actionable');
+		assert.match(steps[0], /Privacy & Security/);
+		assert.match(steps[0], /without saying why/, 'the copy must not claim to know which grant is missing');
+	});
+
+	it('the deliberate case stays untouched: keystroke SUCCEEDED is still not setup_required', () => {
+		// Guards the regression this change could plausibly cause. Chrome ships
+		// "Allow JavaScript from Apple Events" off, so null/false is the normal machine.
+		for (const hints of [[], ['some step']]) {
+			const r = scrollOutcome({ scrollMoved: null, keyDenied: false, hints, direction: 'down' });
+			assert.equal(r.status, 'scrolled', `keyDenied:false must never be setup_required (hints=${hints.length})`);
+		}
+	});
+
 	it('JS says at-limit and the keystroke was DENIED -> at_limit, not setup_required', () => {
 		// JS is authoritative: it ran and reported the page did not move. A keystroke
 		// denial says nothing about the page, so it must not override that answer.


### PR DESCRIPTION
## The gap

Found while diagnosing @yixuan's report that a failed scroll gave no setup instructions. `scrollOutcome()` required **three** conditions for `setup_required`:

```ts
if (o.scrollMoved === null && o.keyDenied && o.hints.length > 0)
```

The third is the problem. If both paths failed but the OS error carried no sentence `setupHint` could parse, `hints` is empty and the function falls through to `{status:'scrolled', moved:null}` — asserting a move that nothing observed, while holding positive evidence of a refusal.

## Before / after

```
$ npx tsx --test tests/browser-tools-scroll-setup-hint.test.ts   # at origin/main
✖ a denial whose text setupHint cannot parse is STILL a denial, not a scroll
  AssertionError: actual: 'scrolled', expected: 'setup_required'
  pass 12  fail 1

# at HEAD
  pass 13  fail 0
```

## What is deliberately NOT changed

`keyDenied` still gates the branch, so the case pinned by *"JS denied but the keystroke SUCCEEDED -> not setup_required"* is untouched. That behaviour is correct and load-bearing: Chrome ships "Allow JavaScript from Apple Events" off, so `null / false` is the **normal** machine and firing setup steps there would cry wolf on every stock install. A second new test pins it in both hint states so this change cannot erode it later.

The fallback step is hedged on purpose — the throw proves refusal, not *which* grant is missing, so the copy says "macOS refused the keystroke without saying why" and points at the most likely pane rather than asserting a diagnosis.

## What this PR does NOT do — and why

@yixuan's original report is **case A**: Accessibility missing while `osascript` exits 0, so `keyDenied` is false and nothing fires. That needs a positive permission probe rather than inference from a throw.

I did not ship one. The obvious candidate is System Events' `UI elements enabled`, which returns `true` on my host — but Accessibility is **granted** here, so I can only ever observe one side of that discriminator. If the property is legacy and always returns true, the fix would be inert and its inertness invisible. Per REVIEW.md lesson 9 I am not building on an instrument I have not seen produce both values, and I will not revoke a grant on the owner's machine to find out.

So this PR takes only the part that needs no probe: case D is provably wrong on evidence already in hand. Case A stays open and wants either a host with the grant revoked, or a native `AXIsProcessTrusted()` call whose semantics are documented rather than inferred.