### PR TITLE
obs(scroll): log the Accessibility probe where the scroll is unconfirmed

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -35,6 +35,19 @@ export function injectText(session: any, text: string) {
 // Vision model — override via .env (default: flash-lite for this trivial 20-word task)
 const VISION_MODEL = process.env.VISION_MODEL || 'gemini-3.1-flash-lite';
 
+/** Accessibility trust as System Events reports it, memoized per process.
+ *  OBSERVATION ONLY — nothing branches on this; see the call site's comment. */
+let _axTrustedCache: boolean | null | undefined;
+function axTrusted(): boolean | null {
+	if (_axTrustedCache !== undefined) return _axTrustedCache;
+	try {
+		const out = execSync(`osascript -e 'tell application "System Events" to return UI elements enabled'`,
+			{ timeout: 3_000 }).toString().trim();
+		_axTrustedCache = out === 'true' ? true : out === 'false' ? false : null;
+	} catch { _axTrustedCache = null; }
+	return _axTrustedCache;
+}
+
 // --- Scroll ---
 
 export const scrollTool: ToolDefinition = {
@@ -143,6 +156,12 @@ export const scrollTool: ToolDefinition = {
 			} catch (e) { _noteHint(e); _keyDenied = true; }
 
 			console.log(`${ts()} [Scroll] ${direction} (app: ${frontApp})`);
+			// Record the probe wherever the scroll was NOT positively confirmed: on a host
+			// with Accessibility off, `axTrusted=false moved=null denied=false` is the
+			// observation this bug cannot be fixed without.
+			if (_scrollMoved !== true) {
+				console.log(`${ts()} [Scroll] probe: axTrusted=${axTrusted()} moved=${_scrollMoved} denied=${_keyDenied} hints=${_hints.length}`);
+			}
 			return { ...scrollOutcome({ scrollMoved: _scrollMoved, keyDenied: _keyDenied, hints: _hints, direction }),
 			         direction, app: frontApp };
 		} catch (err) {

--- a/tests/browser-tools-ax-probe-is-observation-only.test.ts
+++ b/tests/browser-tools-ax-probe-is-observation-only.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The Accessibility probe is recorded, never consulted.
+ *
+ * Case A of the scroll bug (Accessibility off while `osascript` exits 0) cannot
+ * be fixed until someone observes it, and it cannot be observed on a host where
+ * the grant is on. So the probe is logged to earn that observation — but if it
+ * ever starts steering behaviour, an unvalidated discriminator becomes policy,
+ * which is the exact thing #3164 declined to ship.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const SRC = readFileSync(
+	join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'browser-tools.ts'),
+	'utf8',
+);
+
+describe('axTrusted is observation-only', () => {
+	it('is called exactly once, inside the log line', () => {
+		// `function axTrusted()` contains the same token, so exclude the declaration —
+		// counting it made this pin fail against correct code on first run.
+		const calls = SRC.match(/(?<!function\s)axTrusted\(\)/g) ?? [];
+		assert.equal(calls.length, 1, `axTrusted() should have one call site, found ${calls.length}`);
+		const line = SRC.split('\n').find(l => /(?<!function\s)axTrusted\(\)/.test(l));
+		assert.match(line!, /console\.log/, 'its only call site must be a log statement');
+	});
+
+	it('never reaches scrollOutcome — the verdict cannot depend on it', () => {
+		const call = SRC.slice(SRC.indexOf('scrollOutcome({'), SRC.indexOf('scrollOutcome({') + 200);
+		assert.doesNotMatch(call, /axTrusted|_axTrustedCache/,
+			'the probe must not be passed into the policy function');
+	});
+
+	it('never appears in a conditional', () => {
+		for (const l of SRC.split('\n')) {
+			if (!/(?<!function\s)axTrusted\(\)/.test(l)) continue;
+			assert.doesNotMatch(l, /\bif\s*\(|\?|&&|\|\|/,
+				`the probe must not steer control flow: ${l.trim()}`);
+		}
+	});
+
+	it('is memoized, so the extra osascript is once per process, not per scroll', () => {
+		assert.match(SRC, /if \(_axTrustedCache !== undefined\) return _axTrustedCache;/,
+			'must short-circuit on the cached value');
+		// `undefined` is the only "not yet probed" sentinel — null is a real result
+		// (probe unavailable) and must stay cached rather than re-running every call.
+		assert.match(SRC, /_axTrustedCache: boolean \| null \| undefined/);
+	});
+
+	it('an unreadable probe is null, not a silent true', () => {
+		assert.match(SRC, /catch \{ _axTrustedCache = null; \}/,
+			'a failed probe must not be recorded as trusted');
+	});
+});


### PR DESCRIPTION
## Why this is logging and not a fix

#3164 declined to fix the case @yixuan actually reported — Accessibility off while `osascript` exits 0, so scroll reports success and nothing moved. The reason was that the candidate discriminator (System Events `UI elements enabled`) returns `true` on every host I can reach, so I could only ever observe one side of it. An always-true probe would ship a dead branch that nothing can detect.

@qingyun-wu's review of #3164 proposed the way out, and it is better than either option I had: **log the probe now**, so any host that ever hits a real denial produces the missing observation for free. No behaviour changes, nothing is gated on an unvalidated value, and if the probe *is* legacy-and-always-true the logs say so.

## What lands

```
[Scroll] probe: axTrusted=false moved=null denied=false hints=0
```

Emitted only where the scroll was **not positively confirmed** (`_scrollMoved !== true`) — the population the question is about. On a host with the grant off, that exact line is the evidence case A needs; on this host it reads `axTrusted=true`.

The probe is memoized per process, so the extra `osascript` is once per process rather than once per scroll. A grant change requires an app restart anyway (the existing hint copy says so), so a cached value cannot go stale in a way that matters.

## The invariant, and proof it is enforced

The whole point is that this observation must never quietly become policy. `tests/browser-tools-ax-probe-is-observation-only.test.ts` pins that, and I mutation-tested each pin against this commit rather than trusting that the assertions bite:

| mutation | result |
|---|---|
| baseline | 5 pass / 0 fail |
| let the probe steer the verdict (`keyDenied: axTrusted() === false \|\| _keyDenied`) | **2 pass / 3 fail** |
| a failed probe records as trusted (`catch { … = true }`) | **4 pass / 1 fail** |
| drop the memoization short-circuit | **4 pass / 1 fail** |

Neighbour suite unaffected: `browser-tools-scroll-setup-hint.test.ts` 11/11.

## Honest limits

- `UI elements enabled` returns `true` here and I have **not** seen it return `false`. That is the entire reason this PR exists rather than a fix — do not read the probe's presence as validation of it.
- I did not revoke Accessibility on the owner's machine to observe the other side; it would break his live automation mid-session.
- One test pin failed on first run against correct code because `function axTrusted()` contains the same token as a call site. Fixed with a lookbehind; noting it because a source-regex pin that matches its own declaration is an easy way to write an assertion that never means what you think.

## Relationship to #3164

Independent — different file (`browser-tools.ts` vs `osascript-setup-hint.ts`), no overlap. Either can merge first.