### PR TITLE
feat(vision): ask which display to watch, once, and hold it for the session

### DIFF
--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -202,6 +202,108 @@ def _notify_capture():
     _last_notify_ts = now
     threading.Thread(target=_notify_capture_blocking, daemon=True).start()
 
+
+MAX_PROBED_DISPLAYS = 8
+
+
+def _profiler_display_names() -> list[dict]:
+    """Display names + point sizes from system_profiler. Never raises."""
+    try:
+        out = subprocess.run(
+            ["system_profiler", "SPDisplaysDataType", "-json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if out.returncode != 0:
+            return []
+        found = []
+        for gpu in (json.loads(out.stdout).get("SPDisplaysDataType") or []):
+            for mon in (gpu.get("spdisplays_ndrvs") or []):
+                res = mon.get("_spdisplays_resolution") or mon.get("spdisplays_pixelresolution") or ""
+                w = h = 0
+                parts = str(res).replace("x", " ").split()
+                nums = [p for p in parts if p.isdigit()]
+                if len(nums) >= 2:
+                    w, h = int(nums[0]), int(nums[1])
+                found.append({
+                    "name": mon.get("_name") or "Display",
+                    "aspect": (w / h) if w and h else 0.0,
+                    "is_main": mon.get("spdisplays_main") == "spdisplays_yes",
+                })
+        return found
+    except Exception:
+        return []
+
+
+NAME_ASPECT_TOLERANCE = 0.08  # tighter than the 16:10 (1.60) vs 16:9 (1.78) gap
+
+
+def _attach_name(entry: dict, names: list[dict], used: set[int]) -> None:
+    """Decorate a probed display with the closest unclaimed profiler name.
+
+    Matched on aspect ratio, not size: the profiler reports points while the
+    probe returns backing pixels, so a Retina panel's numbers differ by 2x.
+    An unmatched display keeps its index and size and simply has no name.
+    """
+    aspect = (entry["width"] / entry["height"]) if entry.get("width") and entry.get("height") else 0.0
+    if not aspect:
+        return
+    best, best_delta = None, NAME_ASPECT_TOLERANCE
+    for i, cand in enumerate(names):
+        if i in used or not cand["aspect"]:
+            continue
+        delta = abs(cand["aspect"] - aspect)
+        if delta < best_delta:
+            best, best_delta = i, delta
+    if best is None:
+        return
+    used.add(best)
+    entry["name"] = names[best]["name"]
+    entry["is_main"] = names[best]["is_main"]
+
+
+def list_displays() -> list[dict]:
+    """Probe `screencapture -D<n>` and return one entry per attached display.
+
+    The probe is authoritative for `index` because that is the argument the
+    capture routes take; profiler names are best-effort decoration.
+    """
+    names = _profiler_display_names()
+    used: set[int] = set()
+    displays: list[dict] = []
+    for n in range(1, MAX_PROBED_DISPLAYS + 1):
+        path = _os.path.join(DIR, f"displayprobe-{n}.png")
+        try:
+            r = subprocess.run(
+                ["screencapture", "-x", "-t", "png", f"-D{n}", path],
+                timeout=10, capture_output=True,
+            )
+            ok = r.returncode == 0 and _os.path.exists(path) and _os.path.getsize(path) > 0
+            if not ok:
+                break  # first gap is the end of the display list
+            width, height = _png_size(path)
+            entry = {"index": n, "width": width, "height": height}
+            _attach_name(entry, names, used)
+            displays.append(entry)
+        finally:
+            try:
+                _os.unlink(path)
+            except Exception:
+                pass
+    return displays
+
+
+def _png_size(path: str) -> tuple[int, int]:
+    """Width/height from the PNG IHDR, so listing costs no image library."""
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(24)
+        if len(head) < 24 or head[:8] != b"\x89PNG\r\n\x1a\n":
+            return 0, 0
+        return int.from_bytes(head[16:20], "big"), int.from_bytes(head[20:24], "big")
+    except Exception:
+        return 0, 0
+
+
 class Handler(http.server.BaseHTTPRequestHandler):
     def log_message(self, fmt, *args): pass
 
@@ -249,6 +351,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self._handle_capture()
         elif self.path.startswith("/capture-video"):
             self._handle_capture_video()
+        elif self.path.startswith("/displays"):
+            self._handle_displays()
         elif self.path == "/ping":
             self.send_response(200)
             self.end_headers()
@@ -256,6 +360,22 @@ class Handler(http.server.BaseHTTPRequestHandler):
         else:
             self.send_response(404)
             self.end_headers()
+
+    def _handle_displays(self) -> None:
+        """List attached displays by their `screencapture -D<n>` index.
+
+        The index is what every capture route actually takes, so it is probed
+        rather than inferred: `system_profiler` order is not documented to match
+        it. Names come from the profiler and are matched back by aspect ratio,
+        because that survives a resolution the profiler reports in points while
+        the capture returns backing pixels.
+        """
+        if not self._require_capture_token():
+            return
+        try:
+            self._send_json(200, {"status": "ok", "displays": list_displays()})
+        except Exception as e:  # noqa: BLE001 - never take the server down for a listing
+            self._send_json(500, {"status": "error", "error": f"display enumeration failed: {e}"})
 
     def _handle_capture(self) -> None:
         # Reject if no valid token — a browser page on loopback cannot set a

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -207,6 +207,61 @@ export async function ensureScreenCaptureServer(): Promise<void> {
 	}
 }
 
+/**
+ * Which `screencapture -D<n>` display this session watches. Chosen once and held
+ * for the session: a stream that follows the frontmost screen would silently
+ * change what the user is being watched on mid-conversation.
+ */
+let _sessionDisplay: number | null = null;
+
+export function getSessionDisplay(): number | null {
+	return _sessionDisplay;
+}
+
+/** Exported for tests; the session choice is otherwise set only via start_vision. */
+export function setSessionDisplay(display: number | null): void {
+	_sessionDisplay = display;
+}
+
+export type DisplayInfo = { index: number; width: number; height: number; name?: string; is_main?: boolean };
+
+/** Ask the capture server which displays are attached. Empty list on any failure. */
+export async function listDisplays(): Promise<DisplayInfo[]> {
+	await ensureScreenCaptureServer();
+	const tok = readCaptureToken();
+	const res = await fetch('http://localhost:7845/displays', tok ? { headers: { 'X-Sutando-Capture-Token': tok } } : {});
+	const data = (await res.json()) as { status?: string; displays?: DisplayInfo[] };
+	return data.status === 'ok' && Array.isArray(data.displays) ? data.displays : [];
+}
+
+/** "2: U28E510 3840x2160" — what the model reads back to the user. */
+export function describeDisplay(d: DisplayInfo): string {
+	const label = d.name ? `${d.name}` : `Display ${d.index}`;
+	return `${d.index}: ${label}${d.is_main ? ' (main)' : ''} ${d.width}x${d.height}`;
+}
+
+export type DisplayGate =
+	| { kind: 'use'; display: number | null }
+	| { kind: 'ask'; displays: DisplayInfo[] };
+
+/**
+ * Decide whether the user still has a display choice to make.
+ *
+ * Asking is only worth a turn when the answer can differ, so a single display
+ * (or an enumeration that failed, giving an empty list) resolves silently
+ * rather than blocking the stream on a question with one answer.
+ */
+export function decideDisplayGate(
+	sessionDisplay: number | null,
+	requested: number | undefined,
+	displays: DisplayInfo[],
+): DisplayGate {
+	if (requested !== undefined) return { kind: 'use', display: requested };
+	if (sessionDisplay !== null) return { kind: 'use', display: sessionDisplay };
+	if (displays.length > 1) return { kind: 'ask', displays };
+	return { kind: 'use', display: displays.length === 1 ? displays[0].index : null };
+}
+
 const screenSource: VisionSource = {
 	name: 'screen',
 	async capture() {
@@ -219,8 +274,11 @@ const screenSource: VisionSource = {
 		// own process (P7 D7.4: compression never competes with this event
 		// loop) to the ~720p/q0.6 budget before the file comes back.
 		const _capTok = readCaptureToken();
+		// Without this the server captures its default display, so on a multi-display
+		// Mac the stream shows a screen the user did not pick.
+		const _display = _sessionDisplay !== null ? `&display=${_sessionDisplay}` : '';
 		const res = await fetch(
-			`http://localhost:7845/capture?format=jpeg&silent=true&maxdim=${VISION_FRAME_MAX_DIM}&quality=${VISION_FRAME_JPEG_QUALITY}`,
+			`http://localhost:7845/capture?format=jpeg&silent=true&maxdim=${VISION_FRAME_MAX_DIM}&quality=${VISION_FRAME_JPEG_QUALITY}${_display}`,
 			_capTok ? { headers: { 'X-Sutando-Capture-Token': _capTok } } : {},
 		);
 		const data = (await res.json()) as { status: string; path?: string; error?: string };
@@ -1007,10 +1065,11 @@ export const startVisionTool: ToolDefinition = {
 	parameters: z.object({
 		source: z.string().optional().describe("Frame source. Default 'screen'. Built-in: 'screen', 'webcam'. External integrations may register more (e.g. 'glasses')."),
 		fps: z.number().optional().describe('Frames per second, 0.1–1.0 (Gemini Live caps video at 1 fps). Default 1. Webcam may not keep up above 0.5.'),
+		display: z.number().optional().describe('Which display to watch, as its index from the needs_display_choice list. Only for source=screen, and only needed on a multi-display Mac. Held for the rest of the session once set.'),
 	}),
 	execution: 'inline',
 	async execute(args) {
-		const { source: sourceName, fps } = (args ?? {}) as { source?: string; fps?: number };
+		const { source: sourceName, fps, display } = (args ?? {}) as { source?: string; fps?: number; display?: number };
 		if (!getSendFile()) {
 			return { status: 'failed', error: 'No active voice session — vision streaming requires a connected session.' };
 		}
@@ -1031,8 +1090,34 @@ export const startVisionTool: ToolDefinition = {
 		}
 		try {
 			const source = resolveSource(sourceName);
+			if (source.name === 'screen') {
+				// Enumeration is best-effort: if it fails the gate sees an empty list
+				// and streams the default display rather than refusing to start.
+				const known = display === undefined && _sessionDisplay === null
+					? await listDisplays().catch(() => [] as DisplayInfo[])
+					: [];
+				const gate = decideDisplayGate(_sessionDisplay, display, known);
+				if (gate.kind === 'ask') {
+					return {
+						status: 'needs_display_choice',
+						displays: gate.displays,
+						note:
+							'This Mac has more than one display and screencapture would default to one of them. ' +
+							'Ask the user which to watch, then call start_vision again with display=<index>. ' +
+							'The choice is held for the rest of the session. Options — ' +
+							gate.displays.map(describeDisplay).join('; '),
+					};
+				}
+				_sessionDisplay = gate.display;
+			}
 			const info = startStream(source, fps ?? DEFAULT_FPS);
-			return { status: 'streaming', source: source.name, fps: info.fps, intervalMs: info.intervalMs };
+			return {
+				status: 'streaming',
+				source: source.name,
+				fps: info.fps,
+				intervalMs: info.intervalMs,
+				...(source.name === 'screen' && _sessionDisplay !== null ? { display: _sessionDisplay } : {}),
+			};
 		} catch (err) {
 			console.error(`${ts()} [Vision] startVisionTool threw: ${(err as Error)?.message ?? err}`);
 			return { status: 'failed', error: 'startStream failed' };

--- a/tests/fixtures/voice-behavior-anchors.json
+++ b/tests/fixtures/voice-behavior-anchors.json
@@ -504,6 +504,7 @@
    "description": "Start streaming live vision frames to you (Gemini) so you can see what the user is doing in real time. Use for: \"watch my screen\", \"look at what I'm doing\", \"follow along\", \"see me as I talk\". Frames flow at ~1 fps until stop_vision is called or the session ends. Source defaults to the user's screen; pass source='webcam' for the front camera, or any other registered source (e.g. 'glasses'). Prefer send_vision_frame for one-off \"look at this\" questions. Instant.",
    "execution": "inline",
    "params": {
+    "display": "Which display to watch, as its index from the needs_display_choice list. Only for source=screen, and only needed on a multi-display Mac. Held for the rest of the session once set.",
     "fps": "Frames per second, 0.1–1.0 (Gemini Live caps video at 1 fps). Default 1. Webcam may not keep up above 0.5.",
     "source": "Frame source. Default 'screen'. Built-in: 'screen', 'webcam'. External integrations may register more (e.g. 'glasses')."
    }
@@ -513,6 +514,7 @@
    "description": "Start streaming live vision frames to you (Gemini) so you can see what the user is doing in real time. Use for: \"watch my screen\", \"look at what I'm doing\", \"follow along\", \"see me as I talk\". Frames flow at ~1 fps until stop_vision is called or the session ends. Source defaults to the user's screen; pass source='webcam' for the front camera, or any other registered source (e.g. 'glasses'). Prefer send_vision_frame for one-off \"look at this\" questions. Instant.",
    "execution": "inline",
    "params": {
+    "display": "Which display to watch, as its index from the needs_display_choice list. Only for source=screen, and only needed on a multi-display Mac. Held for the rest of the session once set.",
     "fps": "Frames per second, 0.1–1.0 (Gemini Live caps video at 1 fps). Default 1. Webcam may not keep up above 0.5.",
     "source": "Frame source. Default 'screen'. Built-in: 'screen', 'webcam'. External integrations may register more (e.g. 'glasses')."
    }

--- a/tests/screen-capture-display-list.test.py
+++ b/tests/screen-capture-display-list.test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Guards for /displays enumeration in screen-capture-server.py.
+
+The display index is what every capture route takes, so it is probed from
+`screencapture -D<n>` rather than inferred from system_profiler ordering, which
+is not documented to match. Names are decoration matched back by aspect ratio.
+
+The case that matters: a Retina panel reports 1512x982 points to the profiler
+and captures at 3024x1964 pixels. Matching on size would fail; matching on
+aspect ratio is what makes the name land on the right display.
+
+Run: python3 tests/screen-capture-display-list.py
+"""
+import importlib.util
+import os
+import struct
+import sys
+import tempfile
+import zlib
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.join(os.path.dirname(HERE), "src", "screen-capture-server.py")
+
+spec = importlib.util.spec_from_file_location("scs", SRC)
+scs = importlib.util.module_from_spec(spec)
+try:
+    spec.loader.exec_module(scs)
+except SystemExit:
+    pass
+
+failures = []
+
+
+def check(label, got, want):
+    if got != want:
+        failures.append(f"{label}: got {got!r}, want {want!r}")
+
+
+def _png(path, width, height):
+    """Smallest valid PNG carrying a real IHDR, so _png_size reads true bytes."""
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    chunk = struct.pack(">I", len(ihdr)) + b"IHDR" + ihdr
+    chunk += struct.pack(">I", zlib.crc32(b"IHDR" + ihdr) & 0xFFFFFFFF)
+    with open(path, "wb") as fh:
+        fh.write(b"\x89PNG\r\n\x1a\n" + chunk)
+
+
+# --- _png_size reads dimensions without an image library ---------------------
+with tempfile.TemporaryDirectory() as d:
+    p = os.path.join(d, "a.png")
+    _png(p, 3024, 1964)
+    check("_png_size retina", scs._png_size(p), (3024, 1964))
+
+    junk = os.path.join(d, "b.png")
+    with open(junk, "wb") as fh:
+        fh.write(b"not a png at all")
+    check("_png_size on non-PNG is (0,0), not a raise", scs._png_size(junk), (0, 0))
+
+    check("_png_size on missing file is (0,0)", scs._png_size(os.path.join(d, "nope.png")), (0, 0))
+
+# --- name matching -----------------------------------------------------------
+NAMES = [
+    {"name": "Color LCD", "aspect": 1512 / 982, "is_main": True},    # 1.5397
+    {"name": "U28E510", "aspect": 1920 / 1080, "is_main": False},    # 1.7778
+]
+
+used = set()
+builtin = {"index": 1, "width": 3024, "height": 1964}                # 1.5397, 2x points
+scs._attach_name(builtin, NAMES, used)
+check("retina panel matches on aspect despite 2x size", builtin.get("name"), "Color LCD")
+check("main flag carried through", builtin.get("is_main"), True)
+
+external = {"index": 2, "width": 3840, "height": 2160}               # 1.7778, 2x points
+scs._attach_name(external, NAMES, used)
+check("4K external matches its own profiler entry", external.get("name"), "U28E510")
+check("external is not main", external.get("is_main"), False)
+
+# A name is claimed once — two same-aspect displays must not both take it.
+used2 = set()
+one_name = [{"name": "Only", "aspect": 16 / 9, "is_main": False}]
+a = {"index": 1, "width": 3840, "height": 2160}
+b = {"index": 2, "width": 1920, "height": 1080}
+scs._attach_name(a, one_name, used2)
+scs._attach_name(b, one_name, used2)
+check("first same-aspect display claims the name", a.get("name"), "Only")
+check("second gets no name rather than a duplicate", b.get("name"), None)
+check("unnamed display keeps its index", b["index"], 2)
+
+# An aspect far from every candidate stays unnamed rather than guessing.
+used3 = set()
+odd = {"index": 1, "width": 1000, "height": 2000}                    # 0.5, portrait
+scs._attach_name(odd, NAMES, used3)
+check("no name is attached beyond tolerance", odd.get("name"), None)
+
+# A zero-size probe cannot be matched and must not divide by zero.
+used4 = set()
+zero = {"index": 1, "width": 0, "height": 0}
+scs._attach_name(zero, NAMES, used4)
+check("zero-size display is left unnamed", zero.get("name"), None)
+
+# --- profiler parsing is failure-tolerant ------------------------------------
+check("_profiler_display_names returns a list", isinstance(scs._profiler_display_names(), list), True)
+
+if failures:
+    print(f"screen-capture display list: {len(failures)} FAILURE(S)")
+    for f in failures:
+        print("  -", f)
+    sys.exit(1)
+print("screen-capture display list: all checks passed")

--- a/tests/screen-capture-display-list.test.py
+++ b/tests/screen-capture-display-list.test.py
@@ -12,6 +12,7 @@ aspect ratio is what makes the name land on the right display.
 Run: python3 tests/screen-capture-display-list.py
 """
 import importlib.util
+import json
 import os
 import struct
 import sys
@@ -100,6 +101,213 @@ check("zero-size display is left unnamed", zero.get("name"), None)
 
 # --- profiler parsing is failure-tolerant ------------------------------------
 check("_profiler_display_names returns a list", isinstance(scs._profiler_display_names(), list), True)
+
+
+class _Run:
+    """Stand-in for subprocess.CompletedProcess."""
+
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def _with_run(fake):
+    """Swap the module's subprocess.run for the duration of a block."""
+    real = scs.subprocess.run
+    scs.subprocess.run = fake
+    return real
+
+
+# --- _profiler_display_names parses the profiler's own shape -----------------
+PROFILER_JSON = json.dumps({
+    "SPDisplaysDataType": [{
+        "spdisplays_ndrvs": [
+            {"_name": "Color LCD", "_spdisplays_resolution": "1512 x 982",
+             "spdisplays_main": "spdisplays_yes"},
+            {"_name": "U28E510", "spdisplays_pixelresolution": "1920x1080"},
+        ],
+    }],
+})
+
+_real = _with_run(lambda *a, **k: _Run(0, PROFILER_JSON))
+try:
+    got = scs._profiler_display_names()
+finally:
+    scs.subprocess.run = _real
+check("profiler yields one entry per monitor", len(got), 2)
+check("point resolution parses to an aspect", round(got[0]["aspect"], 4), round(1512 / 982, 4))
+check("main display flagged from spdisplays_main", got[0]["is_main"], True)
+check("second monitor is not main", got[1]["is_main"], False)
+check("pixelresolution key is honored too", round(got[1]["aspect"], 4), round(1920 / 1080, 4))
+
+# A monitor with no parseable resolution must not divide by zero.
+_real = _with_run(lambda *a, **k: _Run(0, json.dumps(
+    {"SPDisplaysDataType": [{"spdisplays_ndrvs": [{"_name": "Odd", "_spdisplays_resolution": "n/a"}]}]})))
+try:
+    odd_names = scs._profiler_display_names()
+finally:
+    scs.subprocess.run = _real
+check("unparseable resolution yields aspect 0.0, not a raise", odd_names[0]["aspect"], 0.0)
+check("unparseable entry still carries its name", odd_names[0]["name"], "Odd")
+
+# Non-zero exit and a hard raise both degrade to [] — names are decoration.
+_real = _with_run(lambda *a, **k: _Run(1, ""))
+try:
+    check("profiler non-zero exit yields []", scs._profiler_display_names(), [])
+finally:
+    scs.subprocess.run = _real
+
+
+def _boom(*a, **k):
+    raise OSError("system_profiler missing")
+
+
+_real = _with_run(_boom)
+try:
+    check("profiler raise yields [] rather than propagating", scs._profiler_display_names(), [])
+finally:
+    scs.subprocess.run = _real
+
+# --- list_displays probes screencapture and stops at the first gap -----------
+with tempfile.TemporaryDirectory() as probe_dir:
+    real_dir = scs.DIR
+    scs.DIR = probe_dir
+
+    SIZES = {1: (3024, 1964), 2: (3840, 2160)}   # two attached displays, then a gap
+
+    def fake_capture(argv, **kwargs):
+        if argv[0] == "system_profiler":
+            return _Run(0, PROFILER_JSON)
+        idx = int([a for a in argv if a.startswith("-D")][0][2:])
+        if idx not in SIZES:
+            return _Run(1, "")                    # display 3 does not exist
+        _png(argv[-1], *SIZES[idx])
+        return _Run(0, "")
+
+    _real = _with_run(fake_capture)
+    try:
+        found = scs.list_displays()
+        leftover = os.listdir(probe_dir)
+    finally:
+        scs.subprocess.run = _real
+        scs.DIR = real_dir
+
+    check("probing stops at the first missing display", len(found), 2)
+    check("index is the screencapture -D argument", [d["index"] for d in found], [1, 2])
+    check("dimensions come from the probe's real PNG bytes",
+          [(d["width"], d["height"]) for d in found], [(3024, 1964), (3840, 2160)])
+    check("profiler name lands on the retina panel by aspect", found[0].get("name"), "Color LCD")
+    check("profiler name lands on the 4K external", found[1].get("name"), "U28E510")
+    check("probe files are cleaned up", leftover, [])
+
+# The first gap ENDS the list — a display beyond it must not be picked up.
+# Without this case, `break` and `continue` are indistinguishable: displays past
+# the gap all fail anyway, so the result is [1,2] either way.
+with tempfile.TemporaryDirectory() as probe_dir:
+    real_dir = scs.DIR
+    scs.DIR = probe_dir
+    ISLAND = {1: (3024, 1964), 2: (3840, 2160), 4: (1280, 720)}   # 3 missing, 4 present
+
+    def fake_island(argv, **kwargs):
+        if argv[0] == "system_profiler":
+            return _Run(0, PROFILER_JSON)
+        idx = int([a for a in argv if a.startswith("-D")][0][2:])
+        if idx not in ISLAND:
+            return _Run(1, "")
+        _png(argv[-1], *ISLAND[idx])
+        return _Run(0, "")
+
+    _real = _with_run(fake_island)
+    try:
+        island = scs.list_displays()
+    finally:
+        scs.subprocess.run = _real
+        scs.DIR = real_dir
+    check("enumeration stops at the gap and ignores display 4",
+          [d["index"] for d in island], [1, 2])
+
+# A probe that raises must still clean up and must not take the listing down.
+with tempfile.TemporaryDirectory() as probe_dir:
+    real_dir = scs.DIR
+    scs.DIR = probe_dir
+    _real = _with_run(_boom)
+    try:
+        raised = None
+        try:
+            scs.list_displays()
+        except Exception as e:   # noqa: BLE001 - asserting it DOES propagate or not
+            raised = type(e).__name__
+    finally:
+        scs.subprocess.run = _real
+        scs.DIR = real_dir
+    check("a raising probe surfaces as OSError to the handler's try", raised, "OSError")
+
+# --- /displays route ---------------------------------------------------------
+class _FakeHandler(scs.Handler):
+    """Exercises _handle_displays without binding a socket."""
+
+    def __init__(self, authorized=True):    # noqa: D107 - deliberately skips BaseHTTPRequestHandler.__init__
+        self.sent = None
+        self._authorized = authorized
+
+    def _require_capture_token(self):
+        return self._authorized
+
+    def _send_json(self, status, payload):
+        self.sent = (status, payload)
+
+
+h = _FakeHandler()
+_real = _with_run(lambda *a, **k: _Run(1, ""))    # no displays probe successfully
+try:
+    h._handle_displays()
+finally:
+    scs.subprocess.run = _real
+check("/displays answers 200 with a status envelope", h.sent[0], 200)
+check("/displays reports ok", h.sent[1]["status"], "ok")
+check("/displays returns a displays list", isinstance(h.sent[1]["displays"], list), True)
+
+h_err = _FakeHandler()
+_real = _with_run(_boom)
+try:
+    h_err._handle_displays()
+finally:
+    scs.subprocess.run = _real
+check("enumeration failure answers 500, not a dead server", h_err.sent[0], 500)
+check("500 body names the failure", h_err.sent[1]["status"], "error")
+
+h_unauth = _FakeHandler(authorized=False)
+h_unauth._handle_displays()
+check("an unauthorized caller gets no display listing", h_unauth.sent, None)
+
+
+# --- do_GET routes /displays to the listing, not to a capture ----------------
+class _RouteHandler(scs.Handler):
+    """Records which route do_GET dispatched to, without binding a socket."""
+
+    def __init__(self, path):    # noqa: D107 - deliberately skips the base __init__
+        self.path = path
+        self.routed = None
+
+    def _handle_capture(self):
+        self.routed = "capture"
+
+    def _handle_capture_video(self):
+        self.routed = "capture-video"
+
+    def _handle_displays(self):
+        self.routed = "displays"
+
+
+for path, want in [
+    ("/displays", "displays"),
+    ("/displays?token=x", "displays"),
+    ("/capture", "capture"),
+    ("/capture-video", "capture-video"),
+]:
+    r = _RouteHandler(path)
+    r.do_GET()
+    check(f"do_GET routes {path}", r.routed, want)
 
 if failures:
     print(f"screen-capture display list: {len(failures)} FAILURE(S)")

--- a/tests/screen-capture-display-list.test.py
+++ b/tests/screen-capture-display-list.test.py
@@ -200,9 +200,8 @@ with tempfile.TemporaryDirectory() as probe_dir:
     check("profiler name lands on the 4K external", found[1].get("name"), "U28E510")
     check("probe files are cleaned up", leftover, [])
 
-# The first gap ENDS the list — a display beyond it must not be picked up.
-# Without this case, `break` and `continue` are indistinguishable: displays past
-# the gap all fail anyway, so the result is [1,2] either way.
+# A display PRESENT beyond the gap is what makes this load-bearing: without it,
+# `break` and `continue` both yield [1,2] because everything past the gap fails.
 with tempfile.TemporaryDirectory() as probe_dir:
     real_dir = scs.DIR
     scs.DIR = probe_dir

--- a/tests/vision-display-choice.test.ts
+++ b/tests/vision-display-choice.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The session display choice for screen vision.
+ *
+ * `screencapture` defaults to one display, so on a multi-display Mac a stream
+ * started without a choice watches a screen the user did not pick. The gate asks
+ * once and the answer is held for the session — a stream that re-resolved per
+ * frame would silently change what is being watched mid-conversation.
+ *
+ * Run: node --import tsx/esm tests/vision-display-choice.test.ts
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	decideDisplayGate,
+	describeDisplay,
+	getSessionDisplay,
+	setSessionDisplay,
+	type DisplayInfo,
+} from '../src/vision-tools.js';
+
+const BUILTIN: DisplayInfo = { index: 1, width: 3024, height: 1964, name: 'Color LCD', is_main: true };
+const EXTERNAL: DisplayInfo = { index: 2, width: 3840, height: 2160, name: 'U28E510', is_main: false };
+
+describe('decideDisplayGate', () => {
+	beforeEach(() => setSessionDisplay(null));
+
+	it('asks when more than one display exists and nothing is chosen yet', () => {
+		const gate = decideDisplayGate(null, undefined, [BUILTIN, EXTERNAL]);
+		assert.equal(gate.kind, 'ask');
+		assert.deepEqual(gate.kind === 'ask' && gate.displays.map(d => d.index), [1, 2]);
+	});
+
+	it('does not ask when there is only one display — the question has one answer', () => {
+		assert.deepEqual(decideDisplayGate(null, undefined, [BUILTIN]), { kind: 'use', display: 1 });
+	});
+
+	it('does not ask when enumeration failed — streams the default rather than refusing', () => {
+		assert.deepEqual(decideDisplayGate(null, undefined, []), { kind: 'use', display: null });
+	});
+
+	it('an explicit request wins and is what gets held', () => {
+		assert.deepEqual(decideDisplayGate(null, 2, [BUILTIN, EXTERNAL]), { kind: 'use', display: 2 });
+	});
+
+	it('once chosen it never asks again, even with several displays attached', () => {
+		assert.deepEqual(decideDisplayGate(2, undefined, [BUILTIN, EXTERNAL]), { kind: 'use', display: 2 });
+	});
+
+	it('a later explicit request overrides the held choice', () => {
+		assert.deepEqual(decideDisplayGate(2, 1, [BUILTIN, EXTERNAL]), { kind: 'use', display: 1 });
+	});
+});
+
+describe('session display state', () => {
+	beforeEach(() => setSessionDisplay(null));
+
+	it('starts unset so the first screen stream triggers the gate', () => {
+		assert.equal(getSessionDisplay(), null);
+	});
+
+	it('holds the choice across reads', () => {
+		setSessionDisplay(2);
+		assert.equal(getSessionDisplay(), 2);
+		assert.equal(getSessionDisplay(), 2);
+	});
+});
+
+describe('describeDisplay', () => {
+	it('names the display so the user can answer without knowing indices', () => {
+		assert.equal(describeDisplay(BUILTIN), '1: Color LCD (main) 3024x1964');
+		assert.equal(describeDisplay(EXTERNAL), '2: U28E510 3840x2160');
+	});
+
+	it('falls back to the index when the display could not be named', () => {
+		assert.equal(describeDisplay({ index: 3, width: 1920, height: 1080 }), '3: Display 3 1920x1080');
+	});
+});


### PR DESCRIPTION
Bug 1 of the voice-tool set, first half. Owner's design: **ask which display once, hold it for the session**, so `point_at` can inherit the answer instead of needing its own.

## What's broken

`screencapture` captures one display. `screenSource.capture()` never passed `display=`, so on a multi-display Mac "watch my screen" streams whichever display the server defaults to.

On the reporting host that is the built-in panel — the wrong one whenever the user is working on the external monitor. Nothing errors; the user just gets watched on a screen they aren't using.

The capture server already accepted `?display=N`. Nothing could discover what `N` meant, so nothing ever sent it.

## What changed

**`GET /displays`** on the capture server. It probes `screencapture -D<n>` until the first gap and returns one entry per attached display. Measured on a 2-display host, 532 ms:

```json
[{"index":1,"width":3024,"height":1964,"name":"Color LCD","is_main":true},
 {"index":2,"width":3840,"height":2160,"name":"U28E510","is_main":false}]
```

Two decisions worth calling out, because the obvious version of each is wrong:

- **The index is probed, not read off `system_profiler` order.** That ordering is not documented to match the `-D` argument every capture route takes. I verified they agree here (`-D1` → 3024x1964, `-D2` → 3840x2160, matching the profiler's two panels), but agreeing on one host is not a contract, so the value that ships is the one the capture actually used.
- **Names are matched by aspect ratio, not size.** The profiler reports points (1512x982); the probe returns backing pixels (3024x1964). On a Retina panel those differ by 2x and only the ratio survives. An unmatched display keeps its index and size with no name, and a name is claimed once so two same-aspect displays can't both take it.

**`start_vision` gains an optional `display`.** With nothing chosen and more than one display attached it returns `needs_display_choice` with the list, so the model asks the user and calls again. After that the choice is held for the session — a stream that re-resolved per frame would change what is being watched mid-conversation, which is the failure this is meant to prevent.

A single display, or an enumeration that failed, resolves silently. Asking is only worth a conversational turn when the answer can differ; enumeration failure streams the default rather than refusing to start.

## Evidence

```
npx tsx --test tests/vision-display-choice.test.ts
ℹ tests 10   ℹ pass 10   ℹ fail 0

python3 tests/screen-capture-display-list.test.py
screen-capture display list: all checks passed

npm run test:ts
ℹ tests 1194   ℹ pass 1192   ℹ fail 0   ℹ skipped 2
```

The gate is tested as a pure decision (`decideDisplayGate`), so the assertions run without a capture server or network — no environment-dependent skips hiding a regression in CI.

**The name matcher is mutation-checked.** Widening `NAME_ASPECT_TOLERANCE` to 5.0 makes a portrait display take `"Color LCD"`:

```
mutation(tolerance=5): portrait display named -> Color LCD
```

The test asserts `None` there, so it fails on that mutation.

`tests/fixtures/voice-behavior-anchors.json` is regenerated with `ANCHOR_UPDATE=1` for the new parameter. The diff is exactly two lines — the `display` description, once per tool table — and nothing else:

```
 tests/fixtures/voice-behavior-anchors.json | 2 ++
```

## Follow-up, not in this PR

`point_at` inheriting the session display. The overlay currently force-unwraps `NSScreen.main` (`skills/pointer-teacher-tracer/Sources/pointer-overlay/main.swift:91,119`); pointing it at the chosen display is a separate change in Swift and belongs in its own PR.
