### PR TITLE
fix(pointer-overlay): point at the display the caller measured, not the focused one

### DIFF
--- a/skills/pointer-teacher-tracer/Sources/pointer-overlay/main.swift
+++ b/skills/pointer-teacher-tracer/Sources/pointer-overlay/main.swift
@@ -87,8 +87,35 @@ final class Overlay: NSObject {
     var holdTimer: Timer?
     var fadeTimer: Timer?
 
+    /// The screen the overlay is currently covering, so poll() can tell when a
+    /// command targets a different one.
+    var currentScreen: NSScreen?
+
+    /// Find the screen whose BACKING PIXELS match, falling back to the main one.
+    ///
+    /// Matched on pixels rather than on an index: the capture side numbers
+    /// displays with `screencapture -D<n>` and nothing documents that ordering as
+    /// NSScreen.screens ordering. Pixel size is the one quantity both sides
+    /// measure the same way (verified on a 2-display host: NSScreen 1512x982@2x
+    /// = 3024x1964 = `-D1`, and 1920x1080@2x = 3840x2160 = `-D2`).
+    static func screenFor(pixelW: Double, pixelH: Double) -> NSScreen? {
+        if pixelW > 0 && pixelH > 0 {
+            for s in NSScreen.screens {
+                let w = Double(s.frame.width * s.backingScaleFactor)
+                let h = Double(s.frame.height * s.backingScaleFactor)
+                if abs(w - pixelW) < 1.0 && abs(h - pixelH) < 1.0 { return s }
+            }
+        }
+        // An unknown display must not drop the command — point at the main screen
+        // and still show something, rather than flying nowhere.
+        return NSScreen.main ?? NSScreen.screens.first
+    }
+
     override init() {
-        let f = NSScreen.main!.frame
+        // No force-unwrap: a headless or mid-reconfiguration session has no main
+        // screen, and crashing the overlay there takes point_at down with it.
+        let f = (NSScreen.main ?? NSScreen.screens.first)?.frame
+            ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         win = NSWindow(contentRect: f, styleMask: .borderless, backing: .buffered, defer: false)
         super.init()
         win.level = .screenSaver
@@ -112,7 +139,19 @@ final class Overlay: NSObject {
         if let d = try? Data(contentsOf: URL(fileURLWithPath: CMD)),
            let o = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
            let t = o["ts"] as? Double { lastTS = t }
+        currentScreen = NSScreen.main ?? NSScreen.screens.first
         NSLog("pointer-overlay up on \(Int(f.width))x\(Int(f.height)) — watching \(CMD)")
+    }
+
+    /// Re-cover a different display. The window frame is in global coordinates,
+    /// so it takes the screen's own origin; the view stays window-local.
+    func moveTo(_ screen: NSScreen) {
+        let f = screen.frame
+        win.setFrame(f, display: true)
+        view.frame = NSRect(origin: .zero, size: f.size)
+        win.orderFrontRegardless()
+        currentScreen = screen
+        NSLog("pointer-overlay moved to \(Int(f.width))x\(Int(f.height)) at (\(Int(f.origin.x)),\(Int(f.origin.y)))")
     }
 
     func poll() {
@@ -122,8 +161,16 @@ final class Overlay: NSObject {
               let nx = o["nx"] as? Double, let ny = o["ny"] as? Double else { return }
         lastTS = ts
         NSLog("pointer-overlay accepted ts=\(ts) nx=\(nx) ny=\(ny)")
-        let f = NSScreen.main!.frame
-        // nx,ny = fraction of main display, top-left origin -> view coords (bottom-left)
+        // sw/sh name the display the caller measured against, in backing pixels.
+        // Absent (older writers) = the main screen, which is the previous behaviour.
+        let sw = o["sw"] as? Double ?? 0
+        let sh = o["sh"] as? Double ?? 0
+        guard let screen = Overlay.screenFor(pixelW: sw, pixelH: sh) else { return }
+        if screen != currentScreen {
+            moveTo(screen)
+        }
+        let f = screen.frame
+        // nx,ny = fraction of THAT display, top-left origin -> view coords (bottom-left)
         let target = CGPoint(x: CGFloat(nx) * f.width,
                              y: f.height - CGFloat(ny) * f.height)
         fly(to: target, label: o["label"] as? String ?? "")


### PR DESCRIPTION
Bug 1's overlay half. Independent of the vision-side PR — nothing writes the new field yet, so this is behaviour-preserving on its own.

## What's broken

The overlay resolved `nx,ny` against `NSScreen.main` on every poll, and force-unwrapped it.

**`NSScreen.main` is the screen with keyboard focus, not a fixed display.** It moves with the user, so the same `nx,ny` lands on a different monitor depending on which window happened to be focused when the command arrived. `point_at` therefore has no stable target on a multi-display Mac.

The live run below caught this in the first line: the overlay came up **"on 1920x1080" — the external monitor** — purely because focus was there. If you assumed `NSScreen.main` meant the built-in panel, that assumption is wrong, and it is the assumption the old code encoded.

## What changed

A command may now carry **`sw`/`sh`** — the backing-pixel size of the display the caller measured against — and the overlay covers that screen. Absent (which is every writer today) it uses the main screen, so nothing changes until a writer opts in.

**Matched on pixels, not on an index.** The capture side numbers displays with `screencapture -D<n>`, and nothing documents that ordering as `NSScreen.screens` ordering. Pixel size is the one quantity both sides measure the same way. Verified on a 2-display host:

| | NSScreen | backing pixels | screencapture |
|---|---|---|---|
| built-in | 1512x982 @2x | 3024x1964 | `-D1` |
| external | 1920x1080 @2x | 3840x2160 | `-D2` |

An **unknown** size falls back to the main screen rather than dropping the command — pointing at the wrong place is recoverable, pointing at nothing just looks broken.

**The force-unwrap goes with it.** A headless or mid-reconfiguration session has no main screen, and crashing there takes `point_at` down along with the overlay.

## Evidence

Four commands written into a running overlay, reading its own log:

```
pointer-overlay up on 1920x1080 — watching …/ptr-cmd.json     <- main == EXTERNAL
(no sw/sh)                -> no move          legacy behaviour, unchanged
sw=3840 sh=2160 external  -> no move          already covering that screen
sw=3024 sh=1964 built-in  -> moved to 1512x982 at (0,0)
sw=9999 sh=9999 unknown   -> moved to 1920x1080 at (1512,-98)   fallback to main
```

Each of the four paths is exercised: no-hint, already-there, real switch, and unknown-fallback. The third line is the one that matters — the overlay moved to the display named by pixel size, not the focused one.

```
swift build → Build of product 'pointer-overlay' complete! (1.31s)
```

## Scope

No writer sets `sw`/`sh` yet, so this ships inert and cannot regress `point_at`. Wiring `point_at` to pass the session's chosen display is the next change and depends on the vision-side session choice (#3168).
