### PR TITLE
fix(pointer-overlay): don't replay a stale command on launch

### DIFF
--- a/skills/pointer-teacher-tracer/Sources/pointer-overlay/main.swift
+++ b/skills/pointer-teacher-tracer/Sources/pointer-overlay/main.swift
@@ -107,6 +107,11 @@ final class Overlay: NSObject {
         if !FileManager.default.fileExists(atPath: CMD) {
             FileManager.default.createFile(atPath: CMD, contents: Data("{}".utf8))
         }
+        // Prime lastTS so a stale command from a previous run doesn't fire on launch
+        // (same policy as setupPointerOverlay in src/Sutando/main.swift).
+        if let d = try? Data(contentsOf: URL(fileURLWithPath: CMD)),
+           let o = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
+           let t = o["ts"] as? Double { lastTS = t }
         NSLog("pointer-overlay up on \(Int(f.width))x\(Int(f.height)) — watching \(CMD)")
     }
 
@@ -116,6 +121,7 @@ final class Overlay: NSObject {
               let ts = o["ts"] as? Double, ts > lastTS,
               let nx = o["nx"] as? Double, let ny = o["ny"] as? Double else { return }
         lastTS = ts
+        NSLog("pointer-overlay accepted ts=\(ts) nx=\(nx) ny=\(ny)")
         let f = NSScreen.main!.frame
         // nx,ny = fraction of main display, top-left origin -> view coords (bottom-left)
         let target = CGPoint(x: CGFloat(nx) * f.width,


### PR DESCRIPTION
Field-reported: the pointer appeared on the owner's screen with no request behind it.

## What's broken

`lastTS` starts at **0**, and `poll()` accepts any command with `ts > lastTS`. So the first poll after launch — 0.25s in — draws whatever is already sitting in `pointer-cmd.json`, however old. `point_at` writes that file and never clears it, so the last target persists indefinitely.

This was harmless while `point_at` spawned the overlay itself: the only command in the file was the one that had just triggered the spawn. **cinny-desktop#398 moved overlay ownership to the app** (launch, reap, backoff), so it now starts at app startup — and replays the leftover on every launch.

Measured on a live machine:

```
overlay pid 18921   started Wed Aug 19 10:28:58   parent = AG2 Space (pid 18916, same second)
last real point_at  15:05:58 UTC                  2h 23m earlier
voice-agent.js      started 10:31:00              2 min AFTER the overlay
```

Voice was not running when the pointer was drawn, so `point_at` could not have been the caller.

## The fix

`src/Sutando/main.swift:2216` already primes `lastTS` from the file at startup, with the comment *"Prime lastTS so a stale command from a previous run doesn't fire on launch."* The standalone overlay — the binary the app actually ships and runs — never got that policy. This applies it there.

It compares only the file's own `ts` values, so it carries no wall-clock assumption (an earlier draft seeded from `Date()` and did).

## Evidence

Both sides instrumented identically — the before-control is `origin/main` **plus the accept log only**, so the single differing variable is the `lastTS` seed. A 2h-old command is placed in the file, then the overlay starts.

**Before** (`origin/main` + log probe):

```
10:42:23.117 pointer-overlay up on 1920x1080 — watching .../b-cmd.json
10:42:23.368 pointer-overlay accepted ts=1787154143.0 nx=0.5 ny=0.5
```

Accepted the 2h-old command 251 ms after launch.

**After** (this branch):

```
== AFTER-A) 2h-old command present at launch, 3s: accepts=0 ==
== AFTER-B) fresh command written: accepts=1 ==
10:43:23.271 pointer-overlay up on 1920x1080 — watching .../t-cmd.json
10:43:26.272 pointer-overlay accepted ts=1787161406.5 nx=0.25 ny=0.25
```

Stale ignored, fresh still delivered.

The accept log is part of the fix's testability, not incidental: `fly()` was silent, so a run that ignored a command and a run that drew one produced identical output. My first attempt at this evidence was inconclusive for exactly that reason.

## Scope

Touches `skills/pointer-teacher-tracer/Sources/pointer-overlay/main.swift` only.

**Stacked-file note:** #3169 edits the same file (`NSScreen.main` target-display fix). The two changes are independent — different defects, non-overlapping hunks — but they will need a rebase depending on merge order. Whichever lands second, I'll update and re-run its checks.
