### PR TITLE
fix(discord): suppress recreated task results after delivery

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -93,7 +93,7 @@ One entry per agent-facing module.
 - **`optional_script.py`** — Dependency-light runner for optional script-backed capabilities.
 - **`orphan_result_routes.py`** — Routes for results whose task a bridge never saw.
 - **`osascript-setup-hint.ts`** — Extract the user-actionable sentence from an osascript failure.
-- **`outbox.py`** — Sparrow Outbox: durable delivery claims for an already-created outbound item.
+- **`outbox.py`** — Sparrow Outbox: durable claims and terminal receipts for outbound items.
 - **`outbox_adapter.py`** — The Outbox's transport seam: turn a provider response into a DeliveryReceipt.
 - **`outbox_log.py`** — Outbox visibility log — single append-only sink for outbound messages.
 - **`overlay-manager-ui.ts`** — Overlay Manager view for the Sutando web UI.

--- a/packages/ag2-sparrow/ag2_sparrow/outbox.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox.py
@@ -1,4 +1,4 @@
-"""Sparrow Outbox: durable delivery claims for an already-created outbound item.
+"""Sparrow Outbox: durable claims and terminal receipts for outbound items.
 
 The production boundary starts at an OutboundItem. Deciding which agents receive
 a room event, and which items therefore exist, is upstream server-side semantics
@@ -26,17 +26,27 @@ import errno
 import fcntl
 import hashlib
 import json
+import math
 import os
+import stat
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 CLAIMS_DIR = ".claims"
 LOCKS_DIR = ".claim-locks"
 ITEMS_DIR = ".items"
+TERMINAL_RECEIPTS_DIR = ".terminal-receipts"
+TERMINAL_RECEIPT_SCHEMA = 1
+TERMINAL_RECEIPT_TTL_S = 30 * 86400.0
+TERMINAL_RECEIPT_MAX_RECORDS = 100_000
+TERMINAL_RECEIPT_MAX_BYTES = 16 * 1024
+TERMINAL_RECEIPT_SHARDS = 256
+TERMINAL_RECEIPT_SWEEP_BATCH = 512
 
 
 # -- three-state process identity ---------------------------------------------
@@ -722,3 +732,478 @@ def requeue_item(root: Path, item_id: str) -> None:
     d["reason"] = None
     _write_item(Path(root), item_id, d)
     release_delivery_claim(Path(root), item_id, force=True)
+
+
+# -- terminal receipts --------------------------------------------------------
+
+class TerminalDisposition(str, Enum):
+    DELIVERED = "delivered"
+    NO_SEND = "no_send"
+    DEDUPED = "deduped"
+    REDIRECTED = "redirected"
+
+
+class TerminalReceiptState(str, Enum):
+    ABSENT = "ABSENT"
+    TERMINAL = "TERMINAL"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class TerminalReceipt:
+    state: TerminalReceiptState
+    item_id: str
+    generation: int
+    disposition: Optional[TerminalDisposition] = None
+    recorded_at: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        terminal = self.state is TerminalReceiptState.TERMINAL
+        if ((self.disposition is not None) is not terminal
+                or (self.recorded_at is not None) is not terminal):
+            raise ValueError("a terminal state has a disposition and timestamp")
+
+
+@dataclass(frozen=True)
+class TerminalReceiptCleanup:
+    expired: int = 0
+    overflow: int = 0
+    stale_temps: int = 0
+    unknown: int = 0
+    kept: int = 0
+    incomplete: bool = False
+
+
+def _terminal_identity(item_id: str, generation: int) -> bytes:
+    if not isinstance(item_id, str) or not item_id:
+        raise ValueError("item_id must be a non-empty string")
+    if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
+        raise ValueError("generation must be a non-negative integer")
+    return json.dumps([item_id, generation], ensure_ascii=False,
+                      separators=(",", ":")).encode("utf-8")
+
+
+def _terminal_digest(item_id: str, generation: int) -> str:
+    return hashlib.sha256(_terminal_identity(item_id, generation)).hexdigest()
+
+
+def _terminal_receipts_dir(root: Path) -> Path:
+    return Path(root) / TERMINAL_RECEIPTS_DIR
+
+
+def _terminal_receipt_shard(root: Path, digest: str) -> Path:
+    return _terminal_receipts_dir(root) / digest[:2]
+
+
+def _terminal_receipt_path(root: Path, item_id: str, generation: int) -> Path:
+    digest = _terminal_digest(item_id, generation)
+    return _terminal_receipt_shard(root, digest) / f"{digest}.json"
+
+
+def _terminal_payload(item_id: str, generation: int,
+                      disposition: TerminalDisposition, recorded_at: float) -> dict:
+    base = {
+        "schema": TERMINAL_RECEIPT_SCHEMA,
+        "item_id": item_id,
+        "generation": generation,
+        "disposition": disposition.value,
+        "recorded_at": recorded_at,
+    }
+    canonical = json.dumps(base, ensure_ascii=False, sort_keys=True,
+                           separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return {**base, "checksum": hashlib.sha256(canonical).hexdigest()}
+
+
+def _terminal_bytes(data: dict) -> bytes:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True,
+                      separators=(",", ":"), allow_nan=False).encode("utf-8")
+
+
+def _unknown_terminal(item_id: Optional[str], generation: Optional[int]) -> TerminalReceipt:
+    return TerminalReceipt(TerminalReceiptState.UNKNOWN, item_id or "",
+                           generation if generation is not None else 0)
+
+
+def _read_terminal_path(path: Path, item_id: Optional[str] = None,
+                        generation: Optional[int] = None) -> TerminalReceipt:
+    try:
+        flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+                 | getattr(os, "O_NONBLOCK", 0))
+        fd = os.open(str(path), flags)
+        with os.fdopen(fd, "rb") as fh:
+            if not stat.S_ISREG(os.fstat(fh.fileno()).st_mode):
+                return _unknown_terminal(item_id, generation)
+            raw = fh.read(TERMINAL_RECEIPT_MAX_BYTES + 1)
+    except FileNotFoundError:
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            return TerminalReceipt(TerminalReceiptState.ABSENT, item_id or "",
+                                   generation if generation is not None else 0)
+        except OSError:
+            return _unknown_terminal(item_id, generation)
+        return _unknown_terminal(item_id, generation)
+    except OSError:
+        return _unknown_terminal(item_id, generation)
+    if len(raw) > TERMINAL_RECEIPT_MAX_BYTES:
+        return _unknown_terminal(item_id, generation)
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _unknown_terminal(item_id, generation)
+    fields = {"schema", "item_id", "generation", "disposition",
+              "recorded_at", "checksum"}
+    if not isinstance(data, dict) or set(data) != fields:
+        return _unknown_terminal(item_id, generation)
+    if data.get("schema") != TERMINAL_RECEIPT_SCHEMA:
+        return _unknown_terminal(item_id, generation)
+    stored_item = data.get("item_id")
+    stored_generation = data.get("generation")
+    recorded_at = data.get("recorded_at")
+    if not isinstance(stored_item, str) or not stored_item:
+        return _unknown_terminal(item_id, generation)
+    if (isinstance(stored_generation, bool)
+            or not isinstance(stored_generation, int) or stored_generation < 0):
+        return _unknown_terminal(item_id, generation)
+    if (isinstance(recorded_at, bool) or not isinstance(recorded_at, (int, float))
+            or not math.isfinite(float(recorded_at))):
+        return _unknown_terminal(item_id, generation)
+    if item_id is not None and stored_item != item_id:
+        return _unknown_terminal(item_id, generation)
+    if generation is not None and stored_generation != generation:
+        return _unknown_terminal(item_id, generation)
+    try:
+        disposition = TerminalDisposition(data.get("disposition"))
+    except (TypeError, ValueError):
+        return _unknown_terminal(item_id, generation)
+    expected_name = f"{_terminal_digest(stored_item, stored_generation)}.json"
+    if path.name != expected_name or path.parent.name != expected_name[:2]:
+        return _unknown_terminal(item_id, generation)
+    base = {k: data[k] for k in fields if k != "checksum"}
+    canonical = json.dumps(base, ensure_ascii=False, sort_keys=True,
+                           separators=(",", ":"), allow_nan=False).encode("utf-8")
+    checksum = data.get("checksum")
+    if not isinstance(checksum, str) or checksum != hashlib.sha256(canonical).hexdigest():
+        return _unknown_terminal(item_id, generation)
+    return TerminalReceipt(TerminalReceiptState.TERMINAL, stored_item,
+                           stored_generation, disposition, float(recorded_at))
+
+
+def _terminal_clock_and_ttl(now: Optional[float],
+                            ttl_seconds: float) -> tuple[float, float]:
+    clock = time.time() if now is None else float(now)
+    ttl = float(ttl_seconds)
+    if not math.isfinite(clock):
+        raise ValueError("now must be finite")
+    if not math.isfinite(ttl) or ttl < 0:
+        raise ValueError("ttl_seconds must be finite and non-negative")
+    return clock, ttl
+
+
+def read_terminal_receipt(
+    root: Path,
+    item_id: str,
+    generation: int = 0,
+    now: Optional[float] = None,
+    ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+) -> TerminalReceipt:
+    """O(1) lookup. Corrupt or unreadable state is UNKNOWN, never ABSENT."""
+    clock, ttl = _terminal_clock_and_ttl(now, ttl_seconds)
+    receipt = _read_terminal_path(
+        _terminal_receipt_path(Path(root), item_id, generation), item_id, generation)
+    if (receipt.state is TerminalReceiptState.TERMINAL
+            and clock - receipt.recorded_at >= ttl):
+        return TerminalReceipt(TerminalReceiptState.ABSENT, item_id, generation)
+    return receipt
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    fd = os.open(str(path), flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _ensure_terminal_root(root: Path) -> Path:
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    _fsync_directory(root.parent)
+    return root
+
+
+def _ensure_terminal_receipts_dir(root: Path, digest: str) -> Path:
+    root = Path(root)
+    directory = _terminal_receipts_dir(root)
+    try:
+        directory.mkdir()
+    except FileExistsError:
+        if not directory.is_dir():
+            raise
+    else:
+        _fsync_directory(root)
+    shard = _terminal_receipt_shard(root, digest)
+    try:
+        shard.mkdir()
+    except FileExistsError:
+        if not shard.is_dir():
+            raise
+    else:
+        _fsync_directory(directory)
+    return shard
+
+
+def record_terminal_receipt(
+    root: Path,
+    item_id: str,
+    disposition: Union[TerminalDisposition, str],
+    generation: int = 0,
+    now: Optional[float] = None,
+    ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+) -> TerminalReceipt:
+    """Persist one terminal outcome. The first valid or corrupt record wins."""
+    _terminal_identity(item_id, generation)
+    try:
+        terminal = TerminalDisposition(disposition)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid terminal disposition: {disposition!r}") from exc
+    recorded_at, ttl = _terminal_clock_and_ttl(now, ttl_seconds)
+    root = Path(root)
+    digest = _terminal_digest(item_id, generation)
+    shard_name = digest[:2]
+    path = _terminal_receipt_shard(root, digest) / f"{digest}.json"
+    encoded = _terminal_bytes(
+        _terminal_payload(item_id, generation, terminal, recorded_at))
+    if len(encoded) > TERMINAL_RECEIPT_MAX_BYTES:
+        raise ValueError("terminal receipt exceeds the durable record size limit")
+    capacity = _terminal_shard_capacity(
+        shard_name, TERMINAL_RECEIPT_MAX_RECORDS)
+    if capacity == 0:
+        return _unknown_terminal(item_id, generation)
+    _ensure_terminal_root(root)
+    with _item_lock(root, _terminal_shard_lock_id(shard_name)):
+        current = _read_terminal_path(path, item_id, generation)
+        if current.state is TerminalReceiptState.UNKNOWN:
+            _cleanup_terminal_receipt_shard_locked(
+                root, shard_name, recorded_at, ttl, capacity,
+                protected_name=path.name)
+            return current
+        if current.state is TerminalReceiptState.TERMINAL:
+            if recorded_at - current.recorded_at < ttl:
+                _cleanup_terminal_receipt_shard_locked(
+                    root, shard_name, recorded_at, ttl, capacity,
+                    protected_name=path.name)
+                return current
+            try:
+                path.unlink()
+                _fsync_directory(path.parent)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                return _unknown_terminal(item_id, generation)
+        cleanup = _cleanup_terminal_receipt_shard_locked(
+            root, shard_name, recorded_at, ttl, max(0, capacity - 1))
+        if cleanup.incomplete or cleanup.kept >= capacity:
+            return _unknown_terminal(item_id, generation)
+        directory = _ensure_terminal_receipts_dir(root, digest)
+        fd, tmp_name = tempfile.mkstemp(dir=str(directory),
+                                        prefix=f".{digest}.", suffix=".tmp")
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(encoded)
+                fh.flush()
+                os.fsync(fh.fileno())
+            try:
+                os.link(str(tmp), str(path))
+            except FileExistsError:
+                return _read_terminal_path(path, item_id, generation)
+            _fsync_directory(directory)
+            return TerminalReceipt(TerminalReceiptState.TERMINAL, item_id,
+                                   generation, terminal, recorded_at)
+        finally:
+            tmp.unlink(missing_ok=True)
+            _fsync_directory(directory)
+
+
+def _terminal_filename_digest(path: Path) -> Optional[str]:
+    name = path.name
+    if len(name) != 69 or not name.endswith(".json"):
+        return None
+    digest = name[:-5]
+    return digest if all(c in "0123456789abcdef" for c in digest) else None
+
+
+def _terminal_temp_digest(path: Path) -> Optional[str]:
+    parts = path.name.split(".")
+    if len(parts) != 4 or parts[0] or parts[-1] != "tmp":
+        return None
+    digest = parts[1]
+    if len(digest) != 64 or not all(c in "0123456789abcdef" for c in digest):
+        return None
+    return digest
+
+
+def _terminal_shard_lock_id(shard_name: str) -> str:
+    return f"terminal-receipt-shard:{shard_name}"
+
+
+def _terminal_shard_capacity(shard_name: str, max_records: int) -> int:
+    quotient, remainder = divmod(max_records, TERMINAL_RECEIPT_SHARDS)
+    return quotient + (int(shard_name, 16) < remainder)
+
+
+def _same_stat(path: Path, observed) -> bool:
+    try:
+        current = path.lstat()
+    except OSError:
+        return False
+    return (current.st_dev, current.st_ino) == (observed.st_dev, observed.st_ino)
+
+
+def _cleanup_terminal_receipt_shard_locked(
+    root: Path,
+    shard_name: str,
+    clock: float,
+    ttl: float,
+    max_records: int,
+    protected_name: Optional[str] = None,
+    scan_all: bool = False,
+) -> TerminalReceiptCleanup:
+    directory = _terminal_receipts_dir(root) / shard_name
+    scan_limit = max_records + TERMINAL_RECEIPT_SWEEP_BATCH
+    paths = []
+    incomplete = False
+    try:
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                if not scan_all and len(paths) >= scan_limit:
+                    incomplete = True
+                    break
+                paths.append(Path(entry.path))
+    except FileNotFoundError:
+        return TerminalReceiptCleanup()
+    except OSError:
+        return TerminalReceiptCleanup(unknown=1, incomplete=True)
+
+    expired = overflow = stale_temps = unknown = 0
+    survivors = []
+    changed = False
+    for path in paths:
+        temp_digest = _terminal_temp_digest(path)
+        if temp_digest is not None and temp_digest[:2] == shard_name:
+            try:
+                observed = path.lstat()
+                if _same_stat(path, observed):
+                    path.unlink()
+                    stale_temps += 1
+                    changed = True
+            except FileNotFoundError:
+                pass
+            except OSError:
+                unknown += 1
+                incomplete = True
+            continue
+        digest = _terminal_filename_digest(path)
+        if digest is None or digest[:2] != shard_name:
+            continue
+        try:
+            observed = path.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            unknown += 1
+            incomplete = True
+            continue
+        result = _read_terminal_path(path)
+        if result.state is TerminalReceiptState.UNKNOWN:
+            unknown += 1
+            recorded_at = observed.st_mtime
+            indeterminate = True
+        elif result.state is TerminalReceiptState.TERMINAL:
+            recorded_at = result.recorded_at
+            indeterminate = False
+        else:
+            continue
+        protected = indeterminate or path.name == protected_name
+        if not protected and clock - recorded_at >= ttl and _same_stat(path, observed):
+            try:
+                path.unlink()
+                expired += 1
+                changed = True
+            except FileNotFoundError:
+                pass
+            except OSError:
+                unknown += 1
+                survivors.append((recorded_at, path.name, path, digest, observed, protected))
+            continue
+        survivors.append((recorded_at, path.name, path, digest, observed, protected))
+
+    remove_count = max(0, len(survivors) - max_records)
+    removable = sorted(entry for entry in survivors if not entry[-1])
+    for _recorded_at, _name, path, _digest, observed, _protected in removable[:remove_count]:
+        if not _same_stat(path, observed):
+            continue
+        try:
+            path.unlink()
+            overflow += 1
+            changed = True
+        except FileNotFoundError:
+            pass
+        except OSError:
+            unknown += 1
+    if changed:
+        _fsync_directory(directory)
+    kept = max(0, len(survivors) - overflow)
+    incomplete = incomplete or kept > max_records
+    return TerminalReceiptCleanup(
+        expired, overflow, stale_temps, unknown, kept, incomplete)
+
+
+def cleanup_terminal_receipts(
+    root: Path,
+    ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+    max_records: int = TERMINAL_RECEIPT_MAX_RECORDS,
+    *,
+    now: Optional[float] = None,
+) -> TerminalReceiptCleanup:
+    """Expire receipts and enforce bounded per-shard quotas conservatively."""
+    clock, ttl = _terminal_clock_and_ttl(now, ttl_seconds)
+    if isinstance(max_records, bool) or not isinstance(max_records, int) or max_records < 0:
+        raise ValueError("max_records must be a non-negative integer")
+    root = Path(root)
+    directory = _terminal_receipts_dir(root)
+    try:
+        directory.lstat()
+    except FileNotFoundError:
+        return TerminalReceiptCleanup()
+    except OSError:
+        return TerminalReceiptCleanup(unknown=1, incomplete=True)
+    if not directory.is_dir():
+        return TerminalReceiptCleanup(unknown=1, incomplete=True)
+    expired = overflow = stale_temps = unknown = kept = 0
+    incomplete = False
+    for index in range(TERMINAL_RECEIPT_SHARDS):
+        shard_name = f"{index:02x}"
+        shard = directory / shard_name
+        try:
+            shard.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            unknown += 1
+            incomplete = True
+            continue
+        capacity = _terminal_shard_capacity(shard_name, max_records)
+        with _item_lock(root, _terminal_shard_lock_id(shard_name)):
+            result = _cleanup_terminal_receipt_shard_locked(
+                root, shard_name, clock, ttl, capacity, scan_all=True)
+        expired += result.expired
+        overflow += result.overflow
+        stale_temps += result.stale_temps
+        unknown += result.unknown
+        kept += result.kept
+        incomplete = incomplete or result.incomplete
+    return TerminalReceiptCleanup(
+        expired, overflow, stale_temps, unknown, kept, incomplete)

--- a/packages/ag2-sparrow/ag2_sparrow/outbox.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox.py
@@ -41,7 +41,7 @@ CLAIMS_DIR = ".claims"
 LOCKS_DIR = ".claim-locks"
 ITEMS_DIR = ".items"
 TERMINAL_RECEIPTS_DIR = ".terminal-receipts"
-TERMINAL_RECEIPT_SCHEMA = 1
+TERMINAL_RECEIPT_SCHEMA = 2
 TERMINAL_RECEIPT_TTL_S = 30 * 86400.0
 TERMINAL_RECEIPT_MAX_RECORDS = 100_000
 TERMINAL_RECEIPT_MAX_BYTES = 16 * 1024
@@ -756,12 +756,14 @@ class TerminalReceipt:
     generation: int
     disposition: Optional[TerminalDisposition] = None
     recorded_at: Optional[float] = None
+    content_digest: Optional[str] = None
 
     def __post_init__(self) -> None:
         terminal = self.state is TerminalReceiptState.TERMINAL
         if ((self.disposition is not None) is not terminal
                 or (self.recorded_at is not None) is not terminal):
             raise ValueError("a terminal state has a disposition and timestamp")
+        _validate_content_digest(self.content_digest)
 
 
 @dataclass(frozen=True)
@@ -800,14 +802,50 @@ def _terminal_receipt_path(root: Path, item_id: str, generation: int) -> Path:
     return _terminal_receipt_shard(root, digest) / f"{digest}.json"
 
 
+def _validate_content_digest(content_digest: Optional[str]) -> None:
+    if content_digest is None:
+        return
+    if (not isinstance(content_digest, str) or len(content_digest) != 64
+            or any(c not in "0123456789abcdef" for c in content_digest)):
+        raise ValueError("content_digest must be a lowercase SHA-256 digest")
+
+
+def terminal_content_digest(content: Union[str, bytes]) -> str:
+    if isinstance(content, str):
+        encoded = content.encode("utf-8")
+    elif isinstance(content, bytes):
+        encoded = content
+    else:
+        raise ValueError("content must be text or bytes")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def terminal_receipt_content_state(
+    receipt: TerminalReceipt,
+    content_digest: str,
+) -> TerminalReceiptState:
+    """Match a candidate body without treating digest-less evidence as absent."""
+    _validate_content_digest(content_digest)
+    if receipt.state is not TerminalReceiptState.TERMINAL:
+        return receipt.state
+    if receipt.content_digest is None:
+        return TerminalReceiptState.UNKNOWN
+    if receipt.content_digest == content_digest:
+        return TerminalReceiptState.TERMINAL
+    return TerminalReceiptState.ABSENT
+
+
 def _terminal_payload(item_id: str, generation: int,
-                      disposition: TerminalDisposition, recorded_at: float) -> dict:
+                      disposition: TerminalDisposition, recorded_at: float,
+                      content_digest: Optional[str] = None) -> dict:
+    _validate_content_digest(content_digest)
     base = {
         "schema": TERMINAL_RECEIPT_SCHEMA,
         "item_id": item_id,
         "generation": generation,
         "disposition": disposition.value,
         "recorded_at": recorded_at,
+        "content_digest": content_digest,
     }
     canonical = json.dumps(base, ensure_ascii=False, sort_keys=True,
                            separators=(",", ":"), allow_nan=False).encode("utf-8")
@@ -852,7 +890,7 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     except (UnicodeDecodeError, json.JSONDecodeError):
         return _unknown_terminal(item_id, generation)
     fields = {"schema", "item_id", "generation", "disposition",
-              "recorded_at", "checksum"}
+              "recorded_at", "content_digest", "checksum"}
     if not isinstance(data, dict) or set(data) != fields:
         return _unknown_terminal(item_id, generation)
     if data.get("schema") != TERMINAL_RECEIPT_SCHEMA:
@@ -860,6 +898,7 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     stored_item = data.get("item_id")
     stored_generation = data.get("generation")
     recorded_at = data.get("recorded_at")
+    content_digest = data.get("content_digest")
     if not isinstance(stored_item, str) or not stored_item:
         return _unknown_terminal(item_id, generation)
     if (isinstance(stored_generation, bool)
@@ -867,6 +906,10 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
         return _unknown_terminal(item_id, generation)
     if (isinstance(recorded_at, bool) or not isinstance(recorded_at, (int, float))
             or not math.isfinite(float(recorded_at))):
+        return _unknown_terminal(item_id, generation)
+    try:
+        _validate_content_digest(content_digest)
+    except ValueError:
         return _unknown_terminal(item_id, generation)
     if item_id is not None and stored_item != item_id:
         return _unknown_terminal(item_id, generation)
@@ -886,7 +929,8 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     if not isinstance(checksum, str) or checksum != hashlib.sha256(canonical).hexdigest():
         return _unknown_terminal(item_id, generation)
     return TerminalReceipt(TerminalReceiptState.TERMINAL, stored_item,
-                           stored_generation, disposition, float(recorded_at))
+                           stored_generation, disposition, float(recorded_at),
+                           content_digest)
 
 
 def _terminal_clock_and_ttl(now: Optional[float],
@@ -961,9 +1005,11 @@ def record_terminal_receipt(
     generation: int = 0,
     now: Optional[float] = None,
     ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+    content_digest: Optional[str] = None,
 ) -> TerminalReceipt:
-    """Persist one terminal outcome. The first valid or corrupt record wins."""
+    """Persist one terminal outcome, replacing it for newly delivered content."""
     _terminal_identity(item_id, generation)
+    _validate_content_digest(content_digest)
     try:
         terminal = TerminalDisposition(disposition)
     except (TypeError, ValueError) as exc:
@@ -974,7 +1020,7 @@ def record_terminal_receipt(
     shard_name = digest[:2]
     path = _terminal_receipt_shard(root, digest) / f"{digest}.json"
     encoded = _terminal_bytes(
-        _terminal_payload(item_id, generation, terminal, recorded_at))
+        _terminal_payload(item_id, generation, terminal, recorded_at, content_digest))
     if len(encoded) > TERMINAL_RECEIPT_MAX_BYTES:
         raise ValueError("terminal receipt exceeds the durable record size limit")
     capacity = _terminal_shard_capacity(
@@ -983,6 +1029,7 @@ def record_terminal_receipt(
         return _unknown_terminal(item_id, generation)
     _ensure_terminal_root(root)
     with _item_lock(root, _terminal_shard_lock_id(shard_name)):
+        replace_existing = False
         current = _read_terminal_path(path, item_id, generation)
         if current.state is TerminalReceiptState.UNKNOWN:
             _cleanup_terminal_receipt_shard_locked(
@@ -994,18 +1041,23 @@ def record_terminal_receipt(
                 _cleanup_terminal_receipt_shard_locked(
                     root, shard_name, recorded_at, ttl, capacity,
                     protected_name=path.name)
-                return current
-            try:
-                path.unlink()
-                _fsync_directory(path.parent)
-            except FileNotFoundError:
-                pass
-            except OSError:
+                if (content_digest is None
+                        or current.content_digest == content_digest):
+                    return current
+                replace_existing = True
+            else:
+                try:
+                    path.unlink()
+                    _fsync_directory(path.parent)
+                except FileNotFoundError:
+                    pass
+                except OSError:
+                    return _unknown_terminal(item_id, generation)
+        if not replace_existing:
+            cleanup = _cleanup_terminal_receipt_shard_locked(
+                root, shard_name, recorded_at, ttl, max(0, capacity - 1))
+            if cleanup.incomplete or cleanup.kept >= capacity:
                 return _unknown_terminal(item_id, generation)
-        cleanup = _cleanup_terminal_receipt_shard_locked(
-            root, shard_name, recorded_at, ttl, max(0, capacity - 1))
-        if cleanup.incomplete or cleanup.kept >= capacity:
-            return _unknown_terminal(item_id, generation)
         directory = _ensure_terminal_receipts_dir(root, digest)
         fd, tmp_name = tempfile.mkstemp(dir=str(directory),
                                         prefix=f".{digest}.", suffix=".tmp")
@@ -1015,13 +1067,17 @@ def record_terminal_receipt(
                 fh.write(encoded)
                 fh.flush()
                 os.fsync(fh.fileno())
-            try:
-                os.link(str(tmp), str(path))
-            except FileExistsError:
-                return _read_terminal_path(path, item_id, generation)
+            if replace_existing:
+                os.replace(str(tmp), str(path))
+            else:
+                try:
+                    os.link(str(tmp), str(path))
+                except FileExistsError:
+                    return _read_terminal_path(path, item_id, generation)
             _fsync_directory(directory)
             return TerminalReceipt(TerminalReceiptState.TERMINAL, item_id,
-                                   generation, terminal, recorded_at)
+                                   generation, terminal, recorded_at,
+                                   content_digest)
         finally:
             tmp.unlink(missing_ok=True)
             _fsync_directory(directory)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -505,7 +505,8 @@ def archive_file(src: "Path", kind: str, task_id: str) -> bool:
         log=lambda m: print(m, flush=True))
 
 
-def _archive_delivered_pair(result_file: "Path", task_id: str) -> bool:
+def _archive_delivered_pair(result_file: "Path", task_id: str,
+                            result_body=None) -> bool:
     """Archive a delivered result + task, then retire its legacy sentinel only
     after the result leaves the live queue and its shared receipt is durable."""
     gone = archive_file(result_file, "results", task_id)
@@ -513,8 +514,12 @@ def _archive_delivered_pair(result_file: "Path", task_id: str) -> bool:
     # `<id>.claimed-core-N.txt` and would strand forever.
     task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
     archive_file(task_file, "tasks", task_id)
-    if gone and _has_durable_terminal_receipt(task_id):
-        _clear_delivered(task_id)
+    if gone:
+        durable = (_has_durable_terminal_receipt(task_id)
+                   if result_body is None
+                   else _has_durable_terminal_receipt(task_id, result_body))
+        if durable:
+            _clear_delivered(task_id)
     return gone
 
 
@@ -4469,10 +4474,15 @@ def _result_receipt_root() -> Path:
     return RESULTS_DIR / ".outbox-discord-task-results"
 
 
-def _has_durable_terminal_receipt(task_id: str) -> bool:
+def _has_durable_terminal_receipt(task_id: str,
+                                  result_body=None) -> bool:
     try:
         receipt = outbox.read_terminal_receipt(_result_receipt_root(), task_id)
-        return receipt.state is outbox.TerminalReceiptState.TERMINAL
+        state = receipt.state
+        if result_body is not None:
+            state = outbox.terminal_receipt_content_state(
+                receipt, outbox.terminal_content_digest(result_body))
+        return state is outbox.TerminalReceiptState.TERMINAL
     except Exception:
         return False
 
@@ -4492,7 +4502,7 @@ def _note_ambiguous_receipt(task_id: str) -> None:
           flush=True)
 
 
-def _terminal_receipt_state(task_id: str):
+def _terminal_receipt_state(task_id: str, result_body=None):
     """Return shared receipt state; legacy-only evidence stays ambiguous."""
     try:
         receipt = outbox.read_terminal_receipt(_result_receipt_root(), task_id)
@@ -4500,17 +4510,21 @@ def _terminal_receipt_state(task_id: str):
         print(f"  [delivered] receipt read failed for {task_id}: {exc}", flush=True)
         _note_ambiguous_receipt(task_id)
         return outbox.TerminalReceiptState.UNKNOWN
-    if receipt.state is outbox.TerminalReceiptState.UNKNOWN:
+    receipt_state = receipt.state
+    if result_body is not None:
+        receipt_state = outbox.terminal_receipt_content_state(
+            receipt, outbox.terminal_content_digest(result_body))
+    if receipt_state is outbox.TerminalReceiptState.UNKNOWN:
         _note_ambiguous_receipt(task_id)
-        return receipt.state
-    if receipt.state is outbox.TerminalReceiptState.TERMINAL:
+        return receipt_state
+    if receipt_state is outbox.TerminalReceiptState.TERMINAL:
         _ambiguous_receipt_notices.discard(task_id)
-        return receipt.state
+        return receipt_state
     try:
         _delivered_sentinel_path(task_id).lstat()
     except FileNotFoundError:
         _ambiguous_receipt_notices.discard(task_id)
-        return receipt.state
+        return receipt_state
     except OSError:
         _note_ambiguous_receipt(task_id)
         return outbox.TerminalReceiptState.UNKNOWN
@@ -4518,11 +4532,15 @@ def _terminal_receipt_state(task_id: str):
     return outbox.TerminalReceiptState.UNKNOWN
 
 
-def _record_terminal_receipt(task_id: str, disposition) -> bool:
+def _record_terminal_receipt(task_id: str, disposition,
+                             result_body: str = "") -> bool:
+    content_digest = outbox.terminal_content_digest(result_body)
     try:
         receipt = outbox.record_terminal_receipt(
-            _result_receipt_root(), task_id, disposition)
-        return receipt.state is outbox.TerminalReceiptState.TERMINAL
+            _result_receipt_root(), task_id, disposition,
+            content_digest=content_digest)
+        return (receipt.state is outbox.TerminalReceiptState.TERMINAL
+                and receipt.content_digest == content_digest)
     except Exception as exc:
         print(f"  [delivered] receipt write failed for {task_id}: {exc}", flush=True)
         return False
@@ -4536,9 +4554,10 @@ def _mark_legacy_delivered(task_id: str) -> None:
         print(f"  [delivered] sentinel write failed for {task_id}: {exc}", flush=True)
 
 
-def _mark_delivered(task_id: str) -> None:
+def _mark_delivered(task_id: str, result_body: str = "") -> None:
     """Persist terminal delivery immediately after successful provider I/O."""
-    _record_terminal_receipt(task_id, outbox.TerminalDisposition.DELIVERED)
+    _record_terminal_receipt(
+        task_id, outbox.TerminalDisposition.DELIVERED, result_body)
     _mark_legacy_delivered(task_id)
     # §7 audit ledger (Result Router S5): one line per delivered result, so
     # "did the user see this?" is answerable without grepping bridge logs. This
@@ -4547,12 +4566,13 @@ def _mark_delivered(task_id: str) -> None:
     result_audit.record(task_id, "delivered", "discord")
 
 
-def _record_skip_audit(task_id: str, skip_value: str) -> None:
+def _record_skip_audit(task_id: str, skip_value: str,
+                       result_body: str = "") -> None:
     """Record §7 audit disposition for a skip-marked result (no_send / deduped)."""
     _disp = "deduped" if skip_value == "deduped" else "no_send"
     terminal = (outbox.TerminalDisposition.DEDUPED if _disp == "deduped"
                 else outbox.TerminalDisposition.NO_SEND)
-    if not _record_terminal_receipt(task_id, terminal):
+    if not _record_terminal_receipt(task_id, terminal, result_body):
         _mark_legacy_delivered(task_id)
     result_audit.record(task_id, _disp, "discord")
 
@@ -4731,10 +4751,16 @@ async def poll_results():
             cursor=_orphan_route_cursor,
         )
         for task_id, channel_id_str in _adopted.items():
-            _receipt_state = _terminal_receipt_state(task_id)
+            if (_terminal_receipt_state(task_id)
+                    is outbox.TerminalReceiptState.UNKNOWN):
+                continue
+            result_file = RESULTS_DIR / f"{task_id}.txt"
+            reply_text = read_ready_result(result_file)
+            if reply_text is None:
+                continue
+            _receipt_state = _terminal_receipt_state(task_id, reply_text)
             if _receipt_state is outbox.TerminalReceiptState.TERMINAL:
-                result_file = RESULTS_DIR / f"{task_id}.txt"
-                if _archive_delivered_pair(result_file, task_id):
+                if _archive_delivered_pair(result_file, task_id, reply_text):
                     result_audit.record(task_id, "deduped", "discord")
                     print(f"  Skipped recreated terminal result: {task_id}", flush=True)
                 continue
@@ -4756,21 +4782,25 @@ async def poll_results():
             result_file = RESULTS_DIR / f"{task_id}.txt"
             if result_file.exists():
                 import re
-                _receipt_state = _terminal_receipt_state(task_id)
+                if (_terminal_receipt_state(task_id)
+                        is outbox.TerminalReceiptState.UNKNOWN):
+                    continue
+                reply_text = read_ready_result(result_file)
+                if reply_text is None:
+                    await _note_empty_result(task_id, result_file)
+                    continue
+                _receipt_body = reply_text
+                _receipt_state = _terminal_receipt_state(task_id, _receipt_body)
                 if _receipt_state is outbox.TerminalReceiptState.TERMINAL:
                     pending_replies.pop(task_id, None)
                     pending_reply_anchors.pop(task_id, None)
                     pending_task_tiers.pop(task_id, None)
                     save_pending_replies()
-                    if _archive_delivered_pair(result_file, task_id):
+                    if _archive_delivered_pair(result_file, task_id, _receipt_body):
                         result_audit.record(task_id, "deduped", "discord")
                         print(f"  Skipped terminal result: {task_id}", flush=True)
                     continue
                 if _receipt_state is outbox.TerminalReceiptState.UNKNOWN:
-                    continue
-                reply_text = read_ready_result(result_file)
-                if reply_text is None:
-                    await _note_empty_result(task_id, result_file)
                     continue
                 _empty_result_polls.pop(task_id, None)
                 channel = pending_replies.pop(task_id)
@@ -4873,8 +4903,8 @@ async def poll_results():
                     print(f"  Skipped (already replied or deduped): {task_id}")
                     # §7 audit: skip-marked results are resolved deliveries, not
                     # silent voids — one line per resolved result per spec.
-                    _record_skip_audit(task_id, _skip.value)
-                    _archive_delivered_pair(result_file, task_id)
+                    _record_skip_audit(task_id, _skip.value, _receipt_body)
+                    _archive_delivered_pair(result_file, task_id, _receipt_body)
                     continue
                 # Strip all protocol markers from working text (channel, file,
                 # etc.) so downstream handling operates on clean content.
@@ -5046,7 +5076,7 @@ async def poll_results():
 
                     # Persist success before archival; a restart can then
                     # retire the live result without another provider call.
-                    _mark_delivered(task_id)
+                    _mark_delivered(task_id, _receipt_body)
                     print(f"  Replied: {reply_text[:80]}...", flush=True)
                     # Observability: one delivered-reply event.
                     _emit_channel(
@@ -5062,7 +5092,7 @@ async def poll_results():
                     print(f"  Reply failed: {e}", flush=True)
                     await _report_delivery_failure(channel, task_id, _task_tier, e)
                 # Archive (not delete) so we can mine patterns later.
-                _archive_delivered_pair(result_file, task_id)
+                _archive_delivered_pair(result_file, task_id, _receipt_body)
             else:
                 # CONSECUTIVE means consecutive: an absent file breaks the run, or a
                 # writer that retries accumulates counts across separate appearances.

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -138,6 +138,7 @@ except Exception:  # pragma: no cover — best-effort telemetry
 from task_archive import find_task_file  # noqa: E402
 from task_archive import archive_file as _shared_archive_file  # noqa: E402
 from orphan_result_routes import orphan_result_routes  # noqa: E402
+import outbox  # noqa: E402
 
 
 # Round-robin position for the orphan-route scan, so a large unroutable
@@ -504,21 +505,17 @@ def archive_file(src: "Path", kind: str, task_id: str) -> bool:
         log=lambda m: print(m, flush=True))
 
 
-def _archive_delivered_pair(result_file: "Path", task_id: str) -> None:
-    """Archive a delivered task's result + task file, then retire its sentinel.
-
-    One owner for a policy both delivery paths need: the sentinel may only be
-    cleared once the result has actually left the live queue, because a
-    surviving result re-enters the poll loop and the sentinel is the only thing
-    standing between it and a second send.
-    """
+def _archive_delivered_pair(result_file: "Path", task_id: str) -> bool:
+    """Archive a delivered result + task, then retire its legacy sentinel only
+    after the result leaves the live queue and its shared receipt is durable."""
     gone = archive_file(result_file, "results", task_id)
     # find_task_file, not a reconstructed bare name: a claimed task is
     # `<id>.claimed-core-N.txt` and would strand forever.
     task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
     archive_file(task_file, "tasks", task_id)
-    if gone:
+    if gone and _has_durable_terminal_receipt(task_id):
         _clear_delivered(task_id)
+    return gone
 
 
 def notify_agent_api_task_done(task_id: str, result: str) -> None:
@@ -4456,41 +4453,93 @@ async def _catchup_missed_dms():
             print(f"  [dm-catchup] channel {channel_id_str} failed: {e}", flush=True)
 
 
-# Delivery-idempotency sentinels. Pre-fix: if the bridge crashed
-# BETWEEN `channel.send(reply_text)` returning success and the
-# subsequent `archive_file(result_file, ...)` call, on restart the
-# result file still exists in `results/` and would be re-sent —
-# producing a duplicate. With these sentinels:
-#
-#   1. Right BEFORE the per-task send block, `_is_delivered(task_id)`
-#      checks the sentinel. If present → skip send, run archive,
-#      clear sentinel.
-#   2. Right AFTER channel.send succeeds, `_mark_delivered(task_id)`
-#      touches the sentinel.
-#   3. After archive completes, `_clear_delivered(task_id)` removes
-#      the sentinel (bounded dir growth).
-#
-# The crash-between-send-and-sentinel window remains a narrow
-# double-send vector (Discord nonce-based dedup would close that
-# tighter; deferred to follow-up).
-#
-# Scope of THIS PR: poll_results main-path only. Channel-redirect,
-# proactive, and dm-fallback paths are scoped follow-ups.
+# Existing sentinels are ambiguous during migration; new sends dual-write them
+# across the send-to-archive crash window. Shared receipts persist afterward.
 DELIVERED_DIR = REPO / "state" / "discord-delivered"
+_AMBIGUOUS_RECEIPT_NOTICE_LIMIT = 1024
+_ambiguous_receipt_notices: set = set()
+_ambiguous_receipt_notice_overflow = False
 
 
 def _delivered_sentinel_path(task_id: str) -> Path:
     return DELIVERED_DIR / f"{task_id}.sentinel"
 
 
-def _mark_delivered(task_id: str) -> None:
-    """Touch the delivery sentinel for `task_id`. Called immediately
-    after a successful `channel.send`."""
+def _result_receipt_root() -> Path:
+    return RESULTS_DIR / ".outbox-discord-task-results"
+
+
+def _has_durable_terminal_receipt(task_id: str) -> bool:
+    try:
+        receipt = outbox.read_terminal_receipt(_result_receipt_root(), task_id)
+        return receipt.state is outbox.TerminalReceiptState.TERMINAL
+    except Exception:
+        return False
+
+
+def _note_ambiguous_receipt(task_id: str) -> None:
+    global _ambiguous_receipt_notice_overflow
+    if task_id in _ambiguous_receipt_notices:
+        return
+    if len(_ambiguous_receipt_notices) >= _AMBIGUOUS_RECEIPT_NOTICE_LIMIT:
+        if not _ambiguous_receipt_notice_overflow:
+            print("  [delivered] additional ambiguous receipt notices suppressed",
+                  flush=True)
+            _ambiguous_receipt_notice_overflow = True
+        return
+    _ambiguous_receipt_notices.add(task_id)
+    print(f"  [delivered] holding {task_id}: terminal outcome needs reconciliation",
+          flush=True)
+
+
+def _terminal_receipt_state(task_id: str):
+    """Return shared receipt state; legacy-only evidence stays ambiguous."""
+    try:
+        receipt = outbox.read_terminal_receipt(_result_receipt_root(), task_id)
+    except Exception as exc:
+        print(f"  [delivered] receipt read failed for {task_id}: {exc}", flush=True)
+        _note_ambiguous_receipt(task_id)
+        return outbox.TerminalReceiptState.UNKNOWN
+    if receipt.state is outbox.TerminalReceiptState.UNKNOWN:
+        _note_ambiguous_receipt(task_id)
+        return receipt.state
+    if receipt.state is outbox.TerminalReceiptState.TERMINAL:
+        _ambiguous_receipt_notices.discard(task_id)
+        return receipt.state
+    try:
+        _delivered_sentinel_path(task_id).lstat()
+    except FileNotFoundError:
+        _ambiguous_receipt_notices.discard(task_id)
+        return receipt.state
+    except OSError:
+        _note_ambiguous_receipt(task_id)
+        return outbox.TerminalReceiptState.UNKNOWN
+    _note_ambiguous_receipt(task_id)
+    return outbox.TerminalReceiptState.UNKNOWN
+
+
+def _record_terminal_receipt(task_id: str, disposition) -> bool:
+    try:
+        receipt = outbox.record_terminal_receipt(
+            _result_receipt_root(), task_id, disposition)
+        return receipt.state is outbox.TerminalReceiptState.TERMINAL
+    except Exception as exc:
+        print(f"  [delivered] receipt write failed for {task_id}: {exc}", flush=True)
+        return False
+
+
+def _mark_legacy_delivered(task_id: str) -> None:
     try:
         DELIVERED_DIR.mkdir(parents=True, exist_ok=True)
         _delivered_sentinel_path(task_id).touch()
-    except Exception as e:
-        print(f"  [delivered] sentinel write failed for {task_id}: {e}", flush=True)
+    except Exception as exc:
+        print(f"  [delivered] sentinel write failed for {task_id}: {exc}", flush=True)
+
+
+def _mark_delivered(task_id: str) -> None:
+    """Persist terminal delivery immediately after successful provider I/O."""
+    _record_terminal_receipt(task_id, outbox.TerminalDisposition.DELIVERED)
+    _mark_legacy_delivered(task_id)
     # §7 audit ledger (Result Router S5): one line per delivered result, so
     # "did the user see this?" is answerable without grepping bridge logs. This
     # is the single post-successful-send choke point in the Discord result path.
@@ -4501,15 +4550,16 @@ def _mark_delivered(task_id: str) -> None:
 def _record_skip_audit(task_id: str, skip_value: str) -> None:
     """Record §7 audit disposition for a skip-marked result (no_send / deduped)."""
     _disp = "deduped" if skip_value == "deduped" else "no_send"
+    terminal = (outbox.TerminalDisposition.DEDUPED if _disp == "deduped"
+                else outbox.TerminalDisposition.NO_SEND)
+    if not _record_terminal_receipt(task_id, terminal):
+        _mark_legacy_delivered(task_id)
     result_audit.record(task_id, _disp, "discord")
 
 
 def _is_delivered(task_id: str) -> bool:
-    """True iff the sentinel for `task_id` exists."""
-    try:
-        return _delivered_sentinel_path(task_id).exists()
-    except Exception:
-        return False
+    """True when the task is terminal or its receipt cannot be read safely."""
+    return _terminal_receipt_state(task_id) is not outbox.TerminalReceiptState.ABSENT
 
 
 def _clear_delivered(task_id: str) -> None:
@@ -4681,6 +4731,15 @@ async def poll_results():
             cursor=_orphan_route_cursor,
         )
         for task_id, channel_id_str in _adopted.items():
+            _receipt_state = _terminal_receipt_state(task_id)
+            if _receipt_state is outbox.TerminalReceiptState.TERMINAL:
+                result_file = RESULTS_DIR / f"{task_id}.txt"
+                if _archive_delivered_pair(result_file, task_id):
+                    result_audit.record(task_id, "deduped", "discord")
+                    print(f"  Skipped recreated terminal result: {task_id}", flush=True)
+                continue
+            if _receipt_state is outbox.TerminalReceiptState.UNKNOWN:
+                continue
             _recovered_replies.setdefault(task_id, channel_id_str)
 
         # Merge recovered replies into pending_replies (resolve channel objects)
@@ -4697,6 +4756,18 @@ async def poll_results():
             result_file = RESULTS_DIR / f"{task_id}.txt"
             if result_file.exists():
                 import re
+                _receipt_state = _terminal_receipt_state(task_id)
+                if _receipt_state is outbox.TerminalReceiptState.TERMINAL:
+                    pending_replies.pop(task_id, None)
+                    pending_reply_anchors.pop(task_id, None)
+                    pending_task_tiers.pop(task_id, None)
+                    save_pending_replies()
+                    if _archive_delivered_pair(result_file, task_id):
+                        result_audit.record(task_id, "deduped", "discord")
+                        print(f"  Skipped terminal result: {task_id}", flush=True)
+                    continue
+                if _receipt_state is outbox.TerminalReceiptState.UNKNOWN:
+                    continue
                 reply_text = read_ready_result(result_file)
                 if reply_text is None:
                     await _note_empty_result(task_id, result_file)
@@ -4803,24 +4874,11 @@ async def poll_results():
                     # §7 audit: skip-marked results are resolved deliveries, not
                     # silent voids — one line per resolved result per spec.
                     _record_skip_audit(task_id, _skip.value)
-                    archive_file(result_file, "results", task_id)
-                    task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"
-                    archive_file(task_file, "tasks", task_id)
+                    _archive_delivered_pair(result_file, task_id)
                     continue
                 # Strip all protocol markers from working text (channel, file,
                 # etc.) so downstream handling operates on clean content.
                 reply_text = _parsed.body
-
-                # Idempotency check: if the previous run already sent
-                # this reply (sentinel present) but crashed BEFORE the
-                # archive completed, skip the send + archive normally.
-                # Avoids the double-delivery vector when the bridge
-                # restarts between channel.send() returning and
-                # archive_file() finishing. See DELIVERED_DIR docstring.
-                if _is_delivered(task_id):
-                    print(f"  Skipped (already delivered per sentinel): {task_id}", flush=True)
-                    _archive_delivered_pair(result_file, task_id)
-                    continue
 
                 try:
                     # Extract optional [reply: <message_id>] directive — the
@@ -4986,12 +5044,8 @@ async def poll_results():
                             await channel.send(f"(file not allowed: {fpath})")
                             print(f"  REJECTED file (not in allowlist): {fpath}", flush=True)
 
-                    # Mark delivered BEFORE the archive runs. If we
-                    # crash between channel.send returning and archive,
-                    # on restart the sentinel + result-file combo
-                    # triggers the skip-block above (archive + clear,
-                    # no re-send). Without this, the result file
-                    # would re-send on restart producing a duplicate.
+                    # Persist success before archival; a restart can then
+                    # retire the live result without another provider call.
                     _mark_delivered(task_id)
                     print(f"  Replied: {reply_text[:80]}...", flush=True)
                     # Observability: one delivered-reply event.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6337,7 +6337,7 @@ def check_proactive_quarantine() -> dict:
 
 
 def check_terminal_receipts() -> dict:
-    """Surface terminal receipts that require a human delivery decision."""
+    """Drive periodic receipt retention and surface human reconciliation needs."""
     name = "terminal-receipts"
     root = WORKSPACE_DIR / "results" / ".outbox-discord-task-results"
     try:
@@ -6358,8 +6358,18 @@ def check_terminal_receipts() -> dict:
                        "fail-closed; confirm the delivery outcome, then remove only "
                        "the affected receipt under results/.outbox-discord-task-results/"),
         }
+    before_cleanup = report.kept + report.expired + report.overflow
+    removals = []
+    if report.expired:
+        removals.append(f"{report.expired} expired")
+    if report.overflow:
+        removals.append(f"{report.overflow} over quota")
+    if report.stale_temps:
+        removals.append(f"{report.stale_temps} stale temporary")
+    cleanup = f"removed {', '.join(removals)}" if removals else "removed nothing"
     return {"name": name, "status": "ok",
-            "detail": f"{report.kept} terminal receipt(s) retained; no reconciliation needed"}
+            "detail": (f"{before_cleanup} terminal receipt(s) before periodic retention; "
+                       f"{cleanup}; {report.kept} retained; no reconciliation needed")}
 
 
 def _ps_snapshot() -> "str | None":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -61,6 +61,7 @@ from workspace_layout import inspect_layout  # noqa: E402
 from sutando_config import resolve_core_runtime, resolve_down_bridge_action  # noqa: E402
 from cron_entry_digest import digest_map, drifted  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
+import outbox  # noqa: E402
 
 # Workspace = runtime-state root (tasks/, results/, state/). REPO_DIR stays the
 # source-code root (src/, skills/, logs/, .env, build_log.md). Before PR #762's
@@ -6335,6 +6336,32 @@ def check_proactive_quarantine() -> dict:
     }
 
 
+def check_terminal_receipts() -> dict:
+    """Surface terminal receipts that require a human delivery decision."""
+    name = "terminal-receipts"
+    root = WORKSPACE_DIR / "results" / ".outbox-discord-task-results"
+    try:
+        report = outbox.cleanup_terminal_receipts(root)
+    except Exception as exc:  # noqa: BLE001 — a blind probe must warn, not abort health
+        return {"name": name, "status": "warn",
+                "detail": f"could not inspect Discord terminal receipts: {exc}"}
+    if report.unknown or report.incomplete:
+        findings = []
+        if report.unknown:
+            findings.append(f"{report.unknown} unreadable or corrupt receipt entr{'y' if report.unknown == 1 else 'ies'}")
+        if report.incomplete:
+            findings.append("receipt inspection incomplete")
+        return {
+            "name": name,
+            "status": "warn",
+            "detail": (f"{'; '.join(findings)} — Discord task results remain held "
+                       "fail-closed; confirm the delivery outcome, then remove only "
+                       "the affected receipt under results/.outbox-discord-task-results/"),
+        }
+    return {"name": name, "status": "ok",
+            "detail": f"{report.kept} terminal receipt(s) retained; no reconciliation needed"}
+
+
 def _ps_snapshot() -> "str | None":
     """One `ps -Ao pid,ppid,args` for callers classifying several pids at once."""
     try:
@@ -8956,6 +8983,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_core_supervisor())
     checks.append(check_task_queue(threshold_count=queue_count, threshold_age_sec=queue_age_sec))
     checks.append(check_orphaned_results())
+    checks.append(check_terminal_receipts())
     checks.append(check_proactive_quarantine())
     checks.append(check_stranded_destined_proactive())
     checks.append(check_stale_proactive_backlog())

--- a/src/outbox.py
+++ b/src/outbox.py
@@ -1,4 +1,4 @@
-"""Sparrow Outbox: durable delivery claims for an already-created outbound item.
+"""Sparrow Outbox: durable claims and terminal receipts for outbound items.
 
 The production boundary starts at an OutboundItem. Deciding which agents receive
 a room event, and which items therefore exist, is upstream server-side semantics
@@ -26,17 +26,27 @@ import errno
 import fcntl
 import hashlib
 import json
+import math
 import os
+import stat
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 CLAIMS_DIR = ".claims"
 LOCKS_DIR = ".claim-locks"
 ITEMS_DIR = ".items"
+TERMINAL_RECEIPTS_DIR = ".terminal-receipts"
+TERMINAL_RECEIPT_SCHEMA = 1
+TERMINAL_RECEIPT_TTL_S = 30 * 86400.0
+TERMINAL_RECEIPT_MAX_RECORDS = 100_000
+TERMINAL_RECEIPT_MAX_BYTES = 16 * 1024
+TERMINAL_RECEIPT_SHARDS = 256
+TERMINAL_RECEIPT_SWEEP_BATCH = 512
 
 
 # -- three-state process identity ---------------------------------------------
@@ -722,3 +732,478 @@ def requeue_item(root: Path, item_id: str) -> None:
     d["reason"] = None
     _write_item(Path(root), item_id, d)
     release_delivery_claim(Path(root), item_id, force=True)
+
+
+# -- terminal receipts --------------------------------------------------------
+
+class TerminalDisposition(str, Enum):
+    DELIVERED = "delivered"
+    NO_SEND = "no_send"
+    DEDUPED = "deduped"
+    REDIRECTED = "redirected"
+
+
+class TerminalReceiptState(str, Enum):
+    ABSENT = "ABSENT"
+    TERMINAL = "TERMINAL"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class TerminalReceipt:
+    state: TerminalReceiptState
+    item_id: str
+    generation: int
+    disposition: Optional[TerminalDisposition] = None
+    recorded_at: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        terminal = self.state is TerminalReceiptState.TERMINAL
+        if ((self.disposition is not None) is not terminal
+                or (self.recorded_at is not None) is not terminal):
+            raise ValueError("a terminal state has a disposition and timestamp")
+
+
+@dataclass(frozen=True)
+class TerminalReceiptCleanup:
+    expired: int = 0
+    overflow: int = 0
+    stale_temps: int = 0
+    unknown: int = 0
+    kept: int = 0
+    incomplete: bool = False
+
+
+def _terminal_identity(item_id: str, generation: int) -> bytes:
+    if not isinstance(item_id, str) or not item_id:
+        raise ValueError("item_id must be a non-empty string")
+    if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
+        raise ValueError("generation must be a non-negative integer")
+    return json.dumps([item_id, generation], ensure_ascii=False,
+                      separators=(",", ":")).encode("utf-8")
+
+
+def _terminal_digest(item_id: str, generation: int) -> str:
+    return hashlib.sha256(_terminal_identity(item_id, generation)).hexdigest()
+
+
+def _terminal_receipts_dir(root: Path) -> Path:
+    return Path(root) / TERMINAL_RECEIPTS_DIR
+
+
+def _terminal_receipt_shard(root: Path, digest: str) -> Path:
+    return _terminal_receipts_dir(root) / digest[:2]
+
+
+def _terminal_receipt_path(root: Path, item_id: str, generation: int) -> Path:
+    digest = _terminal_digest(item_id, generation)
+    return _terminal_receipt_shard(root, digest) / f"{digest}.json"
+
+
+def _terminal_payload(item_id: str, generation: int,
+                      disposition: TerminalDisposition, recorded_at: float) -> dict:
+    base = {
+        "schema": TERMINAL_RECEIPT_SCHEMA,
+        "item_id": item_id,
+        "generation": generation,
+        "disposition": disposition.value,
+        "recorded_at": recorded_at,
+    }
+    canonical = json.dumps(base, ensure_ascii=False, sort_keys=True,
+                           separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return {**base, "checksum": hashlib.sha256(canonical).hexdigest()}
+
+
+def _terminal_bytes(data: dict) -> bytes:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True,
+                      separators=(",", ":"), allow_nan=False).encode("utf-8")
+
+
+def _unknown_terminal(item_id: Optional[str], generation: Optional[int]) -> TerminalReceipt:
+    return TerminalReceipt(TerminalReceiptState.UNKNOWN, item_id or "",
+                           generation if generation is not None else 0)
+
+
+def _read_terminal_path(path: Path, item_id: Optional[str] = None,
+                        generation: Optional[int] = None) -> TerminalReceipt:
+    try:
+        flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+                 | getattr(os, "O_NONBLOCK", 0))
+        fd = os.open(str(path), flags)
+        with os.fdopen(fd, "rb") as fh:
+            if not stat.S_ISREG(os.fstat(fh.fileno()).st_mode):
+                return _unknown_terminal(item_id, generation)
+            raw = fh.read(TERMINAL_RECEIPT_MAX_BYTES + 1)
+    except FileNotFoundError:
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            return TerminalReceipt(TerminalReceiptState.ABSENT, item_id or "",
+                                   generation if generation is not None else 0)
+        except OSError:
+            return _unknown_terminal(item_id, generation)
+        return _unknown_terminal(item_id, generation)
+    except OSError:
+        return _unknown_terminal(item_id, generation)
+    if len(raw) > TERMINAL_RECEIPT_MAX_BYTES:
+        return _unknown_terminal(item_id, generation)
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _unknown_terminal(item_id, generation)
+    fields = {"schema", "item_id", "generation", "disposition",
+              "recorded_at", "checksum"}
+    if not isinstance(data, dict) or set(data) != fields:
+        return _unknown_terminal(item_id, generation)
+    if data.get("schema") != TERMINAL_RECEIPT_SCHEMA:
+        return _unknown_terminal(item_id, generation)
+    stored_item = data.get("item_id")
+    stored_generation = data.get("generation")
+    recorded_at = data.get("recorded_at")
+    if not isinstance(stored_item, str) or not stored_item:
+        return _unknown_terminal(item_id, generation)
+    if (isinstance(stored_generation, bool)
+            or not isinstance(stored_generation, int) or stored_generation < 0):
+        return _unknown_terminal(item_id, generation)
+    if (isinstance(recorded_at, bool) or not isinstance(recorded_at, (int, float))
+            or not math.isfinite(float(recorded_at))):
+        return _unknown_terminal(item_id, generation)
+    if item_id is not None and stored_item != item_id:
+        return _unknown_terminal(item_id, generation)
+    if generation is not None and stored_generation != generation:
+        return _unknown_terminal(item_id, generation)
+    try:
+        disposition = TerminalDisposition(data.get("disposition"))
+    except (TypeError, ValueError):
+        return _unknown_terminal(item_id, generation)
+    expected_name = f"{_terminal_digest(stored_item, stored_generation)}.json"
+    if path.name != expected_name or path.parent.name != expected_name[:2]:
+        return _unknown_terminal(item_id, generation)
+    base = {k: data[k] for k in fields if k != "checksum"}
+    canonical = json.dumps(base, ensure_ascii=False, sort_keys=True,
+                           separators=(",", ":"), allow_nan=False).encode("utf-8")
+    checksum = data.get("checksum")
+    if not isinstance(checksum, str) or checksum != hashlib.sha256(canonical).hexdigest():
+        return _unknown_terminal(item_id, generation)
+    return TerminalReceipt(TerminalReceiptState.TERMINAL, stored_item,
+                           stored_generation, disposition, float(recorded_at))
+
+
+def _terminal_clock_and_ttl(now: Optional[float],
+                            ttl_seconds: float) -> tuple[float, float]:
+    clock = time.time() if now is None else float(now)
+    ttl = float(ttl_seconds)
+    if not math.isfinite(clock):
+        raise ValueError("now must be finite")
+    if not math.isfinite(ttl) or ttl < 0:
+        raise ValueError("ttl_seconds must be finite and non-negative")
+    return clock, ttl
+
+
+def read_terminal_receipt(
+    root: Path,
+    item_id: str,
+    generation: int = 0,
+    now: Optional[float] = None,
+    ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+) -> TerminalReceipt:
+    """O(1) lookup. Corrupt or unreadable state is UNKNOWN, never ABSENT."""
+    clock, ttl = _terminal_clock_and_ttl(now, ttl_seconds)
+    receipt = _read_terminal_path(
+        _terminal_receipt_path(Path(root), item_id, generation), item_id, generation)
+    if (receipt.state is TerminalReceiptState.TERMINAL
+            and clock - receipt.recorded_at >= ttl):
+        return TerminalReceipt(TerminalReceiptState.ABSENT, item_id, generation)
+    return receipt
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    fd = os.open(str(path), flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _ensure_terminal_root(root: Path) -> Path:
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    _fsync_directory(root.parent)
+    return root
+
+
+def _ensure_terminal_receipts_dir(root: Path, digest: str) -> Path:
+    root = Path(root)
+    directory = _terminal_receipts_dir(root)
+    try:
+        directory.mkdir()
+    except FileExistsError:
+        if not directory.is_dir():
+            raise
+    else:
+        _fsync_directory(root)
+    shard = _terminal_receipt_shard(root, digest)
+    try:
+        shard.mkdir()
+    except FileExistsError:
+        if not shard.is_dir():
+            raise
+    else:
+        _fsync_directory(directory)
+    return shard
+
+
+def record_terminal_receipt(
+    root: Path,
+    item_id: str,
+    disposition: Union[TerminalDisposition, str],
+    generation: int = 0,
+    now: Optional[float] = None,
+    ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+) -> TerminalReceipt:
+    """Persist one terminal outcome. The first valid or corrupt record wins."""
+    _terminal_identity(item_id, generation)
+    try:
+        terminal = TerminalDisposition(disposition)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid terminal disposition: {disposition!r}") from exc
+    recorded_at, ttl = _terminal_clock_and_ttl(now, ttl_seconds)
+    root = Path(root)
+    digest = _terminal_digest(item_id, generation)
+    shard_name = digest[:2]
+    path = _terminal_receipt_shard(root, digest) / f"{digest}.json"
+    encoded = _terminal_bytes(
+        _terminal_payload(item_id, generation, terminal, recorded_at))
+    if len(encoded) > TERMINAL_RECEIPT_MAX_BYTES:
+        raise ValueError("terminal receipt exceeds the durable record size limit")
+    capacity = _terminal_shard_capacity(
+        shard_name, TERMINAL_RECEIPT_MAX_RECORDS)
+    if capacity == 0:
+        return _unknown_terminal(item_id, generation)
+    _ensure_terminal_root(root)
+    with _item_lock(root, _terminal_shard_lock_id(shard_name)):
+        current = _read_terminal_path(path, item_id, generation)
+        if current.state is TerminalReceiptState.UNKNOWN:
+            _cleanup_terminal_receipt_shard_locked(
+                root, shard_name, recorded_at, ttl, capacity,
+                protected_name=path.name)
+            return current
+        if current.state is TerminalReceiptState.TERMINAL:
+            if recorded_at - current.recorded_at < ttl:
+                _cleanup_terminal_receipt_shard_locked(
+                    root, shard_name, recorded_at, ttl, capacity,
+                    protected_name=path.name)
+                return current
+            try:
+                path.unlink()
+                _fsync_directory(path.parent)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                return _unknown_terminal(item_id, generation)
+        cleanup = _cleanup_terminal_receipt_shard_locked(
+            root, shard_name, recorded_at, ttl, max(0, capacity - 1))
+        if cleanup.incomplete or cleanup.kept >= capacity:
+            return _unknown_terminal(item_id, generation)
+        directory = _ensure_terminal_receipts_dir(root, digest)
+        fd, tmp_name = tempfile.mkstemp(dir=str(directory),
+                                        prefix=f".{digest}.", suffix=".tmp")
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(encoded)
+                fh.flush()
+                os.fsync(fh.fileno())
+            try:
+                os.link(str(tmp), str(path))
+            except FileExistsError:
+                return _read_terminal_path(path, item_id, generation)
+            _fsync_directory(directory)
+            return TerminalReceipt(TerminalReceiptState.TERMINAL, item_id,
+                                   generation, terminal, recorded_at)
+        finally:
+            tmp.unlink(missing_ok=True)
+            _fsync_directory(directory)
+
+
+def _terminal_filename_digest(path: Path) -> Optional[str]:
+    name = path.name
+    if len(name) != 69 or not name.endswith(".json"):
+        return None
+    digest = name[:-5]
+    return digest if all(c in "0123456789abcdef" for c in digest) else None
+
+
+def _terminal_temp_digest(path: Path) -> Optional[str]:
+    parts = path.name.split(".")
+    if len(parts) != 4 or parts[0] or parts[-1] != "tmp":
+        return None
+    digest = parts[1]
+    if len(digest) != 64 or not all(c in "0123456789abcdef" for c in digest):
+        return None
+    return digest
+
+
+def _terminal_shard_lock_id(shard_name: str) -> str:
+    return f"terminal-receipt-shard:{shard_name}"
+
+
+def _terminal_shard_capacity(shard_name: str, max_records: int) -> int:
+    quotient, remainder = divmod(max_records, TERMINAL_RECEIPT_SHARDS)
+    return quotient + (int(shard_name, 16) < remainder)
+
+
+def _same_stat(path: Path, observed) -> bool:
+    try:
+        current = path.lstat()
+    except OSError:
+        return False
+    return (current.st_dev, current.st_ino) == (observed.st_dev, observed.st_ino)
+
+
+def _cleanup_terminal_receipt_shard_locked(
+    root: Path,
+    shard_name: str,
+    clock: float,
+    ttl: float,
+    max_records: int,
+    protected_name: Optional[str] = None,
+    scan_all: bool = False,
+) -> TerminalReceiptCleanup:
+    directory = _terminal_receipts_dir(root) / shard_name
+    scan_limit = max_records + TERMINAL_RECEIPT_SWEEP_BATCH
+    paths = []
+    incomplete = False
+    try:
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                if not scan_all and len(paths) >= scan_limit:
+                    incomplete = True
+                    break
+                paths.append(Path(entry.path))
+    except FileNotFoundError:
+        return TerminalReceiptCleanup()
+    except OSError:
+        return TerminalReceiptCleanup(unknown=1, incomplete=True)
+
+    expired = overflow = stale_temps = unknown = 0
+    survivors = []
+    changed = False
+    for path in paths:
+        temp_digest = _terminal_temp_digest(path)
+        if temp_digest is not None and temp_digest[:2] == shard_name:
+            try:
+                observed = path.lstat()
+                if _same_stat(path, observed):
+                    path.unlink()
+                    stale_temps += 1
+                    changed = True
+            except FileNotFoundError:
+                pass
+            except OSError:
+                unknown += 1
+                incomplete = True
+            continue
+        digest = _terminal_filename_digest(path)
+        if digest is None or digest[:2] != shard_name:
+            continue
+        try:
+            observed = path.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            unknown += 1
+            incomplete = True
+            continue
+        result = _read_terminal_path(path)
+        if result.state is TerminalReceiptState.UNKNOWN:
+            unknown += 1
+            recorded_at = observed.st_mtime
+            indeterminate = True
+        elif result.state is TerminalReceiptState.TERMINAL:
+            recorded_at = result.recorded_at
+            indeterminate = False
+        else:
+            continue
+        protected = indeterminate or path.name == protected_name
+        if not protected and clock - recorded_at >= ttl and _same_stat(path, observed):
+            try:
+                path.unlink()
+                expired += 1
+                changed = True
+            except FileNotFoundError:
+                pass
+            except OSError:
+                unknown += 1
+                survivors.append((recorded_at, path.name, path, digest, observed, protected))
+            continue
+        survivors.append((recorded_at, path.name, path, digest, observed, protected))
+
+    remove_count = max(0, len(survivors) - max_records)
+    removable = sorted(entry for entry in survivors if not entry[-1])
+    for _recorded_at, _name, path, _digest, observed, _protected in removable[:remove_count]:
+        if not _same_stat(path, observed):
+            continue
+        try:
+            path.unlink()
+            overflow += 1
+            changed = True
+        except FileNotFoundError:
+            pass
+        except OSError:
+            unknown += 1
+    if changed:
+        _fsync_directory(directory)
+    kept = max(0, len(survivors) - overflow)
+    incomplete = incomplete or kept > max_records
+    return TerminalReceiptCleanup(
+        expired, overflow, stale_temps, unknown, kept, incomplete)
+
+
+def cleanup_terminal_receipts(
+    root: Path,
+    ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+    max_records: int = TERMINAL_RECEIPT_MAX_RECORDS,
+    *,
+    now: Optional[float] = None,
+) -> TerminalReceiptCleanup:
+    """Expire receipts and enforce bounded per-shard quotas conservatively."""
+    clock, ttl = _terminal_clock_and_ttl(now, ttl_seconds)
+    if isinstance(max_records, bool) or not isinstance(max_records, int) or max_records < 0:
+        raise ValueError("max_records must be a non-negative integer")
+    root = Path(root)
+    directory = _terminal_receipts_dir(root)
+    try:
+        directory.lstat()
+    except FileNotFoundError:
+        return TerminalReceiptCleanup()
+    except OSError:
+        return TerminalReceiptCleanup(unknown=1, incomplete=True)
+    if not directory.is_dir():
+        return TerminalReceiptCleanup(unknown=1, incomplete=True)
+    expired = overflow = stale_temps = unknown = kept = 0
+    incomplete = False
+    for index in range(TERMINAL_RECEIPT_SHARDS):
+        shard_name = f"{index:02x}"
+        shard = directory / shard_name
+        try:
+            shard.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            unknown += 1
+            incomplete = True
+            continue
+        capacity = _terminal_shard_capacity(shard_name, max_records)
+        with _item_lock(root, _terminal_shard_lock_id(shard_name)):
+            result = _cleanup_terminal_receipt_shard_locked(
+                root, shard_name, clock, ttl, capacity, scan_all=True)
+        expired += result.expired
+        overflow += result.overflow
+        stale_temps += result.stale_temps
+        unknown += result.unknown
+        kept += result.kept
+        incomplete = incomplete or result.incomplete
+    return TerminalReceiptCleanup(
+        expired, overflow, stale_temps, unknown, kept, incomplete)

--- a/src/outbox.py
+++ b/src/outbox.py
@@ -41,7 +41,7 @@ CLAIMS_DIR = ".claims"
 LOCKS_DIR = ".claim-locks"
 ITEMS_DIR = ".items"
 TERMINAL_RECEIPTS_DIR = ".terminal-receipts"
-TERMINAL_RECEIPT_SCHEMA = 1
+TERMINAL_RECEIPT_SCHEMA = 2
 TERMINAL_RECEIPT_TTL_S = 30 * 86400.0
 TERMINAL_RECEIPT_MAX_RECORDS = 100_000
 TERMINAL_RECEIPT_MAX_BYTES = 16 * 1024
@@ -756,12 +756,14 @@ class TerminalReceipt:
     generation: int
     disposition: Optional[TerminalDisposition] = None
     recorded_at: Optional[float] = None
+    content_digest: Optional[str] = None
 
     def __post_init__(self) -> None:
         terminal = self.state is TerminalReceiptState.TERMINAL
         if ((self.disposition is not None) is not terminal
                 or (self.recorded_at is not None) is not terminal):
             raise ValueError("a terminal state has a disposition and timestamp")
+        _validate_content_digest(self.content_digest)
 
 
 @dataclass(frozen=True)
@@ -800,14 +802,50 @@ def _terminal_receipt_path(root: Path, item_id: str, generation: int) -> Path:
     return _terminal_receipt_shard(root, digest) / f"{digest}.json"
 
 
+def _validate_content_digest(content_digest: Optional[str]) -> None:
+    if content_digest is None:
+        return
+    if (not isinstance(content_digest, str) or len(content_digest) != 64
+            or any(c not in "0123456789abcdef" for c in content_digest)):
+        raise ValueError("content_digest must be a lowercase SHA-256 digest")
+
+
+def terminal_content_digest(content: Union[str, bytes]) -> str:
+    if isinstance(content, str):
+        encoded = content.encode("utf-8")
+    elif isinstance(content, bytes):
+        encoded = content
+    else:
+        raise ValueError("content must be text or bytes")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def terminal_receipt_content_state(
+    receipt: TerminalReceipt,
+    content_digest: str,
+) -> TerminalReceiptState:
+    """Match a candidate body without treating digest-less evidence as absent."""
+    _validate_content_digest(content_digest)
+    if receipt.state is not TerminalReceiptState.TERMINAL:
+        return receipt.state
+    if receipt.content_digest is None:
+        return TerminalReceiptState.UNKNOWN
+    if receipt.content_digest == content_digest:
+        return TerminalReceiptState.TERMINAL
+    return TerminalReceiptState.ABSENT
+
+
 def _terminal_payload(item_id: str, generation: int,
-                      disposition: TerminalDisposition, recorded_at: float) -> dict:
+                      disposition: TerminalDisposition, recorded_at: float,
+                      content_digest: Optional[str] = None) -> dict:
+    _validate_content_digest(content_digest)
     base = {
         "schema": TERMINAL_RECEIPT_SCHEMA,
         "item_id": item_id,
         "generation": generation,
         "disposition": disposition.value,
         "recorded_at": recorded_at,
+        "content_digest": content_digest,
     }
     canonical = json.dumps(base, ensure_ascii=False, sort_keys=True,
                            separators=(",", ":"), allow_nan=False).encode("utf-8")
@@ -852,7 +890,7 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     except (UnicodeDecodeError, json.JSONDecodeError):
         return _unknown_terminal(item_id, generation)
     fields = {"schema", "item_id", "generation", "disposition",
-              "recorded_at", "checksum"}
+              "recorded_at", "content_digest", "checksum"}
     if not isinstance(data, dict) or set(data) != fields:
         return _unknown_terminal(item_id, generation)
     if data.get("schema") != TERMINAL_RECEIPT_SCHEMA:
@@ -860,6 +898,7 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     stored_item = data.get("item_id")
     stored_generation = data.get("generation")
     recorded_at = data.get("recorded_at")
+    content_digest = data.get("content_digest")
     if not isinstance(stored_item, str) or not stored_item:
         return _unknown_terminal(item_id, generation)
     if (isinstance(stored_generation, bool)
@@ -867,6 +906,10 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
         return _unknown_terminal(item_id, generation)
     if (isinstance(recorded_at, bool) or not isinstance(recorded_at, (int, float))
             or not math.isfinite(float(recorded_at))):
+        return _unknown_terminal(item_id, generation)
+    try:
+        _validate_content_digest(content_digest)
+    except ValueError:
         return _unknown_terminal(item_id, generation)
     if item_id is not None and stored_item != item_id:
         return _unknown_terminal(item_id, generation)
@@ -886,7 +929,8 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     if not isinstance(checksum, str) or checksum != hashlib.sha256(canonical).hexdigest():
         return _unknown_terminal(item_id, generation)
     return TerminalReceipt(TerminalReceiptState.TERMINAL, stored_item,
-                           stored_generation, disposition, float(recorded_at))
+                           stored_generation, disposition, float(recorded_at),
+                           content_digest)
 
 
 def _terminal_clock_and_ttl(now: Optional[float],
@@ -961,9 +1005,11 @@ def record_terminal_receipt(
     generation: int = 0,
     now: Optional[float] = None,
     ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+    content_digest: Optional[str] = None,
 ) -> TerminalReceipt:
-    """Persist one terminal outcome. The first valid or corrupt record wins."""
+    """Persist one terminal outcome, replacing it for newly delivered content."""
     _terminal_identity(item_id, generation)
+    _validate_content_digest(content_digest)
     try:
         terminal = TerminalDisposition(disposition)
     except (TypeError, ValueError) as exc:
@@ -974,7 +1020,7 @@ def record_terminal_receipt(
     shard_name = digest[:2]
     path = _terminal_receipt_shard(root, digest) / f"{digest}.json"
     encoded = _terminal_bytes(
-        _terminal_payload(item_id, generation, terminal, recorded_at))
+        _terminal_payload(item_id, generation, terminal, recorded_at, content_digest))
     if len(encoded) > TERMINAL_RECEIPT_MAX_BYTES:
         raise ValueError("terminal receipt exceeds the durable record size limit")
     capacity = _terminal_shard_capacity(
@@ -983,6 +1029,7 @@ def record_terminal_receipt(
         return _unknown_terminal(item_id, generation)
     _ensure_terminal_root(root)
     with _item_lock(root, _terminal_shard_lock_id(shard_name)):
+        replace_existing = False
         current = _read_terminal_path(path, item_id, generation)
         if current.state is TerminalReceiptState.UNKNOWN:
             _cleanup_terminal_receipt_shard_locked(
@@ -994,18 +1041,23 @@ def record_terminal_receipt(
                 _cleanup_terminal_receipt_shard_locked(
                     root, shard_name, recorded_at, ttl, capacity,
                     protected_name=path.name)
-                return current
-            try:
-                path.unlink()
-                _fsync_directory(path.parent)
-            except FileNotFoundError:
-                pass
-            except OSError:
+                if (content_digest is None
+                        or current.content_digest == content_digest):
+                    return current
+                replace_existing = True
+            else:
+                try:
+                    path.unlink()
+                    _fsync_directory(path.parent)
+                except FileNotFoundError:
+                    pass
+                except OSError:
+                    return _unknown_terminal(item_id, generation)
+        if not replace_existing:
+            cleanup = _cleanup_terminal_receipt_shard_locked(
+                root, shard_name, recorded_at, ttl, max(0, capacity - 1))
+            if cleanup.incomplete or cleanup.kept >= capacity:
                 return _unknown_terminal(item_id, generation)
-        cleanup = _cleanup_terminal_receipt_shard_locked(
-            root, shard_name, recorded_at, ttl, max(0, capacity - 1))
-        if cleanup.incomplete or cleanup.kept >= capacity:
-            return _unknown_terminal(item_id, generation)
         directory = _ensure_terminal_receipts_dir(root, digest)
         fd, tmp_name = tempfile.mkstemp(dir=str(directory),
                                         prefix=f".{digest}.", suffix=".tmp")
@@ -1015,13 +1067,17 @@ def record_terminal_receipt(
                 fh.write(encoded)
                 fh.flush()
                 os.fsync(fh.fileno())
-            try:
-                os.link(str(tmp), str(path))
-            except FileExistsError:
-                return _read_terminal_path(path, item_id, generation)
+            if replace_existing:
+                os.replace(str(tmp), str(path))
+            else:
+                try:
+                    os.link(str(tmp), str(path))
+                except FileExistsError:
+                    return _read_terminal_path(path, item_id, generation)
             _fsync_directory(directory)
             return TerminalReceipt(TerminalReceiptState.TERMINAL, item_id,
-                                   generation, terminal, recorded_at)
+                                   generation, terminal, recorded_at,
+                                   content_digest)
         finally:
             tmp.unlink(missing_ok=True)
             _fsync_directory(directory)

--- a/tests/discord-bridge-archive-failure-keeps-the-file.test.py
+++ b/tests/discord-bridge-archive-failure-keeps-the-file.test.py
@@ -40,7 +40,7 @@ def _load(tasks_archive, results_archive):
     return archive
 
 
-def _load_pair(tasks_archive, results_archive, tasks_dir, cleared):
+def _load_pair(tasks_archive, results_archive, tasks_dir, cleared, durable=True):
     """Exec archive_path + archive_file + _archive_delivered_pair together, so
     the shared cleanup policy is exercised rather than pattern-matched."""
     tree = ast.parse(SRC.read_text())
@@ -53,6 +53,7 @@ def _load_pair(tasks_archive, results_archive, tasks_dir, cleared):
     ns = {"Path": Path, "os": os, "TASKS_DIR": tasks_dir,
           "find_task_file": _task_archive.find_task_file,
           "archive_file": _load(tasks_archive, results_archive),
+          "_has_durable_terminal_receipt": lambda _t: durable,
           "_clear_delivered": lambda t: cleared.append(t)}
     exec(compile(ast.Module(body=body, type_ignores=[]), str(SRC), "exec"), ns)
     return ns["_archive_delivered_pair"]
@@ -211,6 +212,17 @@ class CallersHonourTheReturn(unittest.TestCase):
         self.assertEqual(cleared, [], "a result still under its live name must KEEP its "
                                       "sentinel — clearing it permits a second send")
         self.assertTrue(Path(res).exists(), "a failed archive must never delete the result")
+
+    def test_the_pair_keeps_fallback_sentinel_without_a_durable_receipt(self):
+        cleared = []
+        tasks = self.d / "tasks"; tasks.mkdir()
+        pair = _load_pair(self.d / "at", self.d / "ar", tasks, cleared,
+                          durable=False)
+        res = self.d / "task-2b.txt"; res.write_text("r")
+        pair(res, "task-2b")
+        self.assertEqual(cleared, [],
+                         "legacy protection stays until shared persistence succeeds")
+        self.assertFalse(res.exists(), "the archived result must leave the live queue")
 
     def test_the_pair_resolves_a_CLAIMED_task_not_a_rebuilt_bare_name(self):
         cleared = []

--- a/tests/discord-bridge-delivery-sentinel.test.py
+++ b/tests/discord-bridge-delivery-sentinel.test.py
@@ -1,253 +1,260 @@
 #!/usr/bin/env python3
-"""Regression guard for restart-safety #3: result-delivery idempotency
-sentinel.
+"""Discord task-result receipts survive archive and fence legacy sentinels."""
+from __future__ import annotations
 
-## The bug
-
-In `poll_results`, the bridge:
-
-  1. Pops `task_id` from `pending_replies`
-  2. Calls `channel.send(reply_text)` (Discord API)
-  3. Calls `archive_file(result_file, ...)`
-
-If the bridge crashes between step 2 (send returned success) and
-step 3 (archive completes), the result file is still on disk at
-`results/{task_id}.txt`. On restart, `poll_results` re-iterates,
-finds the result file, and re-sends — producing a duplicate
-delivery to the owner.
-
-## The fix
-
-`<DELIVERED_DIR>/<task_id>.sentinel` files mark "send returned
-success but archive not yet complete":
-
-  - Right BEFORE the per-task send block, `_is_delivered(task_id)`
-    checks the sentinel. If present, skip the send, run the archive,
-    clear the sentinel.
-  - Right AFTER `channel.send` succeeds, `_mark_delivered(task_id)`
-    touches the sentinel.
-  - After archive completes, `_clear_delivered(task_id)` removes
-    the sentinel (so the dir doesn't accumulate forever).
-
-The remaining narrow window — crash between send-success and
-sentinel-touch — produces at most one duplicate on restart. Nonce-
-based dedup via Discord's `nonce` parameter would close that
-tighter; deferred to follow-up.
-
-## What this test covers
-
-The sentinel storage (touch / check / clear) is pure file I/O and
-fully testable. The poll_results wiring is asserted via source-grep.
-"""
-
+import contextlib
 import importlib.util
+import io
 import os
+import shutil
 import sys
 import tempfile
 import types
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
-
-_WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-delivery-sentinel-test-")
-os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
-os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
+WORKSPACE = Path(tempfile.mkdtemp(prefix="discord-receipt-test-"))
+CONFIG = WORKSPACE / "config"
+os.environ["SUTANDO_WORKSPACE"] = str(WORKSPACE)
+os.environ["SUTANDO_TEST_MODE"] = "1"
+os.environ["CLAUDE_CONFIG_DIR"] = str(CONFIG)
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
-(Path(_WORKSPACE_TMP) / "state").mkdir(parents=True, exist_ok=True)
+(CONFIG / "channels" / "discord").mkdir(parents=True)
+(CONFIG / "channels" / "discord" / "access.json").write_text(
+    '{"allowFrom": []}', encoding="utf-8")
 
 
-def _load(name: str, path: Path):
-    if "discord" not in sys.modules:
-        stub = types.ModuleType("discord")
-        stub.Intents = type("Intents", (), {"default": staticmethod(lambda: type("I", (), {"message_content": False})())})
-        stub.Client = type("Client", (), {"__init__": lambda self, **kw: None, "event": staticmethod(lambda fn: fn)})
-        stub.File = type("File", (), {})
-        stub.DMChannel = type("DMChannel", (), {})
-        stub.Object = lambda id: type("Object", (), {"id": id})()
-        sys.modules["discord"] = stub
-    spec = importlib.util.spec_from_file_location(name, path)
-    m = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(m)
-    return m
+def _load_bridge():
+    stub = types.ModuleType("discord")
+    stub.Intents = type("Intents", (), {
+        "default": staticmethod(
+            lambda: type("I", (), {"message_content": False, "members": False})())})
+    stub.Client = type("Client", (), {
+        "__init__": lambda self, **_kw: None,
+        "event": staticmethod(lambda fn: fn),
+    })
+    stub.File = type("File", (), {})
+    stub.DMChannel = type("DMChannel", (), {})
+    stub.Object = lambda id: type("Object", (), {"id": id})()
+    sys.modules["discord"] = stub
+    spec = importlib.util.spec_from_file_location(
+        "discord_bridge_receipt_test", REPO / "src" / "discord-bridge.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
-bridge = _load("discord_bridge", REPO / "src" / "discord-bridge.py")
+bridge = _load_bridge()
 
 
-def _clear_sentinels():
-    """Remove any sentinels left from a previous test."""
-    if bridge.DELIVERED_DIR.exists():
-        for p in bridge.DELIVERED_DIR.iterdir():
-            p.unlink()
+def _reset():
+    shutil.rmtree(WORKSPACE / "results", ignore_errors=True)
+    shutil.rmtree(WORKSPACE / "state" / "discord-delivered", ignore_errors=True)
+    (WORKSPACE / "results").mkdir(parents=True)
+    bridge._ambiguous_receipt_notices.clear()
+    bridge._ambiguous_receipt_notice_overflow = False
 
 
-def test_is_delivered_false_when_no_sentinel():
-    """Default: no sentinel → False. Bridge sends normally."""
-    _clear_sentinels()
-    assert bridge._is_delivered("task-123") is False
+def test_default_is_not_terminal():
+    _reset()
+    assert bridge._is_delivered("task-100") is False
 
 
-def test_mark_delivered_creates_sentinel():
-    _clear_sentinels()
-    bridge._mark_delivered("task-456")
-    assert bridge._is_delivered("task-456") is True
-    assert (bridge.DELIVERED_DIR / "task-456.sentinel").exists()
+def test_receipt_read_error_does_not_claim_a_durable_terminal_state():
+    _reset()
+    with mock.patch.object(
+            bridge.outbox, "read_terminal_receipt",
+            side_effect=PermissionError("receipt unreadable")):
+        assert bridge._has_durable_terminal_receipt("task-100b") is False
 
 
-def test_clear_delivered_removes_sentinel():
-    _clear_sentinels()
-    bridge._mark_delivered("task-789")
-    assert bridge._is_delivered("task-789") is True
-    bridge._clear_delivered("task-789")
-    assert bridge._is_delivered("task-789") is False
+def test_success_writes_a_shared_terminal_receipt():
+    _reset()
+    bridge._mark_delivered("task-101")
+    assert bridge._is_delivered("task-101") is True
+    assert bridge._delivered_sentinel_path("task-101").exists()
+    receipt = bridge.outbox.read_terminal_receipt(
+        bridge._result_receipt_root(), "task-101")
+    assert receipt.state is bridge.outbox.TerminalReceiptState.TERMINAL
+    assert receipt.disposition is bridge.outbox.TerminalDisposition.DELIVERED
 
 
-def test_mark_creates_directory_if_missing():
-    """Defensive: DELIVERED_DIR may not exist on first-ever run.
-    `_mark_delivered` must mkdir(parents=True) before touching."""
-    import shutil
-    if bridge.DELIVERED_DIR.exists():
-        shutil.rmtree(bridge.DELIVERED_DIR)
-    bridge._mark_delivered("task-fresh")
-    assert bridge.DELIVERED_DIR.is_dir()
-    assert bridge._is_delivered("task-fresh") is True
+def test_clearing_legacy_state_does_not_erase_the_shared_receipt():
+    _reset()
+    bridge._mark_delivered("task-102")
+    assert bridge._delivered_sentinel_path("task-102").exists()
+    bridge._clear_delivered("task-102")
+    assert not bridge._delivered_sentinel_path("task-102").exists()
+    assert bridge._is_delivered("task-102") is True
 
 
-def test_clear_idempotent():
-    """Clearing a non-existent sentinel is a no-op, not an error."""
-    _clear_sentinels()
-    # Should not raise even though sentinel doesn't exist
-    bridge._clear_delivered("task-never-existed")
-    assert bridge._is_delivered("task-never-existed") is False
+def test_clearing_legacy_state_is_idempotent():
+    _reset()
+    bridge._mark_delivered("task-102b")
+    bridge._clear_delivered("task-102b")
+    bridge._clear_delivered("task-102b")
+    assert not bridge._delivered_sentinel_path("task-102b").exists()
+    assert bridge._is_delivered("task-102b") is True
 
 
-def test_separate_tasks_independent():
-    """Sentinels are per-task; one task's sentinel doesn't affect
-    another. Critical for the case where multiple results are pending
-    and only one was crashed-during-send."""
-    _clear_sentinels()
-    bridge._mark_delivered("task-A")
-    assert bridge._is_delivered("task-A") is True
-    assert bridge._is_delivered("task-B") is False
-    bridge._mark_delivered("task-B")
-    bridge._clear_delivered("task-A")
-    assert bridge._is_delivered("task-A") is False
-    assert bridge._is_delivered("task-B") is True
+def test_legacy_only_sentinel_is_ambiguous_and_not_promoted():
+    _reset()
+    bridge.DELIVERED_DIR.mkdir(parents=True, exist_ok=True)
+    bridge._delivered_sentinel_path("task-103").touch()
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        states = [bridge._terminal_receipt_state("task-103") for _ in range(3)]
+    assert states == [bridge.outbox.TerminalReceiptState.UNKNOWN] * 3
+    assert bridge._delivered_sentinel_path("task-103").exists()
+    assert bridge._has_durable_terminal_receipt("task-103") is False
+    receipt = bridge.outbox.read_terminal_receipt(
+        bridge._result_receipt_root(), "task-103")
+    assert receipt.state is bridge.outbox.TerminalReceiptState.ABSENT
+    assert output.getvalue().count(
+        "holding task-103: terminal outcome needs reconciliation") == 1
 
 
-def test_poll_results_checks_sentinel_before_main_send():
-    """Architectural source-grep: the sentinel check must come BEFORE
-    the first `channel.send` call in poll_results. Pin via textual
-    position so a refactor that re-orders these (e.g. moves the
-    delivered check into the try-block AFTER send) fails loudly.
+def test_ambiguous_notice_capacity_warns_once_then_stays_bounded():
+    _reset()
+    output = io.StringIO()
+    with mock.patch.object(bridge, "_AMBIGUOUS_RECEIPT_NOTICE_LIMIT", 1), \
+            contextlib.redirect_stdout(output):
+        bridge._note_ambiguous_receipt("task-capacity-first")
+        bridge._note_ambiguous_receipt("task-capacity-overflow")
+        bridge._note_ambiguous_receipt("task-capacity-overflow-again")
 
-    Note: poll_results has multiple `try:` blocks (heartbeat retry,
-    channel resolution, send, file-send) — we don't pin against a
-    specific `try:` line; we pin the sentinel check is BEFORE the
-    first send call."""
-    import re
-    src = (REPO / "src" / "discord-bridge.py").read_text()
-    poll_block = re.search(
-        r"async def poll_results\(\):(.*?)(?=^async def )",
-        src, re.MULTILINE | re.DOTALL,
-    )
-    assert poll_block, "could not locate poll_results"
-    body = poll_block.group(1)
-    delivered_pos = body.find("_is_delivered(task_id)")
-    # Find the first channel.send AFTER the skip-block. The skip-block
-    # has `archive_file(result_file, "results", task_id)` followed by
-    # `continue`, then the sentinel check, then the try-block with
-    # the send. The first `await channel.send(` should be after both.
-    skip_continue_pos = body.find("Skipped (already replied or deduped)")
-    first_send_pos = body.find("await channel.send(", skip_continue_pos)
-    assert delivered_pos > 0, "_is_delivered NOT called in poll_results"
-    assert first_send_pos > 0, "could not locate post-skip channel.send"
-    assert delivered_pos < first_send_pos, (
-        "_is_delivered check must come BEFORE the first channel.send — "
-        "otherwise the send fires before the sentinel is checked, "
-        "defeating the fix."
-    )
+    assert bridge._ambiguous_receipt_notices == {"task-capacity-first"}
+    assert bridge._ambiguous_receipt_notice_overflow is True
+    text = output.getvalue()
+    assert text.count("holding task-capacity-first") == 1
+    assert text.count("additional ambiguous receipt notices suppressed") == 1
+    assert "holding task-capacity-overflow" not in text
 
 
-def test_poll_results_marks_delivered_in_send_block():
-    """Architectural: `_mark_delivered` must be called inside the
-    main try-block (after channel.send succeeded). Pin that it
-    appears AFTER the first send call (so it's marking a real
-    delivery, not a pre-send phantom)."""
-    import re
-    src = (REPO / "src" / "discord-bridge.py").read_text()
-    poll_block = re.search(
-        r"async def poll_results\(\):(.*?)(?=^async def )",
-        src, re.MULTILINE | re.DOTALL,
-    )
-    assert poll_block
-    body = poll_block.group(1)
-    mark_pos = body.find("_mark_delivered(task_id)")
-    skip_continue_pos = body.find("Skipped (already replied or deduped)")
-    first_send_pos = body.find("await channel.send(", skip_continue_pos)
-    assert mark_pos > 0, "_mark_delivered NOT called in poll_results"
-    assert first_send_pos > 0
-    assert mark_pos > first_send_pos, (
-        "_mark_delivered must be called AFTER the first channel.send "
-        "(post-success) — otherwise a crash between mark and send "
-        "marks a delivery that never happened, silently dropping the "
-        "message on restart."
-    )
+def test_receipt_read_error_returns_unknown_and_bounds_reconciliation_notice():
+    _reset()
+    output = io.StringIO()
+    with mock.patch.object(
+            bridge.outbox, "read_terminal_receipt",
+            side_effect=PermissionError("receipt unreadable")), \
+            contextlib.redirect_stdout(output):
+        states = [bridge._terminal_receipt_state("task-103a") for _ in range(3)]
+
+    assert states == [bridge.outbox.TerminalReceiptState.UNKNOWN] * 3
+    assert bridge._ambiguous_receipt_notices == {"task-103a"}
+    text = output.getvalue()
+    assert text.count("receipt read failed for task-103a: receipt unreadable") == 3
+    assert text.count(
+        "holding task-103a: terminal outcome needs reconciliation") == 1
 
 
-def test_poll_results_clears_sentinel_after_archive():
-    """Architectural: the sentinel must be retired after both archive_file
-    calls, or sentinels accumulate forever in `state/discord-delivered/`.
+def test_unreadable_legacy_sentinel_is_ambiguous_not_absent():
+    _reset()
 
-    That policy now lives in `_archive_delivered_pair`, which both delivery
-    paths call, so follow it there rather than requiring the call to be
-    open-coded inside poll_results."""
-    import re
-    src = (REPO / "src" / "discord-bridge.py").read_text()
-    poll_block = re.search(
-        r"async def poll_results\(\):(.*?)(?=^async def )",
-        src, re.MULTILINE | re.DOTALL,
-    )
-    assert poll_block
-    body = poll_block.group(1)
-    assert "_archive_delivered_pair(" in body, (
-        "poll_results must route cleanup through the shared helper")
+    class UnreadableSentinel:
+        @staticmethod
+        def lstat():
+            raise PermissionError("injected")
 
-    helper = re.search(r"def _archive_delivered_pair\(.*?\n\n\n", src, re.DOTALL)
-    assert helper, "the shared cleanup helper is missing"
-    h = helper.group(0)
-    clear_pos = h.find("_clear_delivered(task_id)")
-    assert clear_pos > 0, "_clear_delivered NOT called in the shared helper"
-    last_archive = h.rfind("archive_file(")
-    assert last_archive > 0 and clear_pos > last_archive, (
-        "the sentinel must be retired AFTER both archive_file calls")
+    output = io.StringIO()
+    with mock.patch.object(
+            bridge, "_delivered_sentinel_path", return_value=UnreadableSentinel()), \
+            contextlib.redirect_stdout(output):
+        states = [bridge._terminal_receipt_state("task-103b") for _ in range(3)]
+    assert states == [bridge.outbox.TerminalReceiptState.UNKNOWN] * 3
+    assert bridge._has_durable_terminal_receipt("task-103b") is False
+    assert output.getvalue().count(
+        "holding task-103b: terminal outcome needs reconciliation") == 1
+
+
+def test_receipt_write_failure_keeps_the_legacy_fallback():
+    _reset()
+    with mock.patch.object(
+            bridge.outbox, "record_terminal_receipt", side_effect=OSError("disk full")):
+        bridge._mark_delivered("task-104")
+    assert bridge._delivered_sentinel_path("task-104").exists()
+    assert bridge._is_delivered("task-104") is True
+
+
+def test_legacy_sentinel_write_error_preserves_shared_receipt_and_audit():
+    _reset()
+
+    class UnwritableSentinel:
+        @staticmethod
+        def touch():
+            raise PermissionError("sentinel unwritable")
+
+    output = io.StringIO()
+    with mock.patch.object(
+            bridge, "_delivered_sentinel_path",
+            return_value=UnwritableSentinel()), \
+            mock.patch.object(bridge.result_audit, "record") as audit, \
+            contextlib.redirect_stdout(output):
+        bridge._mark_delivered("task-104b")
+
+    receipt = bridge.outbox.read_terminal_receipt(
+        bridge._result_receipt_root(), "task-104b")
+    assert receipt.state is bridge.outbox.TerminalReceiptState.TERMINAL
+    assert receipt.disposition is bridge.outbox.TerminalDisposition.DELIVERED
+    assert not (bridge.DELIVERED_DIR / "task-104b.sentinel").exists()
+    audit.assert_called_once_with("task-104b", "delivered", "discord")
+    assert output.getvalue().count(
+        "sentinel write failed for task-104b: sentinel unwritable") == 1
+
+
+def test_skip_receipt_write_failure_leaves_legacy_fallback_and_audits():
+    _reset()
+    output = io.StringIO()
+    with mock.patch.object(
+            bridge.outbox, "record_terminal_receipt",
+            side_effect=OSError("receipt disk full")), \
+            mock.patch.object(bridge.result_audit, "record") as audit, \
+            contextlib.redirect_stdout(output):
+        bridge._record_skip_audit("task-104c", "deduped")
+
+    assert bridge._delivered_sentinel_path("task-104c").exists()
+    receipt = bridge.outbox.read_terminal_receipt(
+        bridge._result_receipt_root(), "task-104c")
+    assert receipt.state is bridge.outbox.TerminalReceiptState.ABSENT
+    audit.assert_called_once_with("task-104c", "deduped", "discord")
+    assert output.getvalue().count(
+        "receipt write failed for task-104c: receipt disk full") == 1
+
+
+def test_terminal_receipts_are_per_task():
+    _reset()
+    bridge._mark_delivered("task-105")
+    assert bridge._is_delivered("task-105") is True
+    assert bridge._is_delivered("task-106") is False
+
+
+def test_bridge_delegates_terminal_decisions_to_outbox_before_send():
+    src = (REPO / "src" / "discord-bridge.py").read_text(encoding="utf-8")
+    start = src.index("async def poll_results():")
+    end = src.index("\nasync def ", start + 1)
+    body = src[start:end]
+    receipt_pos = body.index("_terminal_receipt_state(task_id)")
+    send_pos = body.index("await channel.send(")
+    mark_pos = body.index("_mark_delivered(task_id)")
+    assert receipt_pos < send_pos < mark_pos
 
 
 def main():
+    tests = [fn for name, fn in sorted(globals().items())
+             if name.startswith("test_") and callable(fn)]
     failures = []
-    for fn in (
-        test_is_delivered_false_when_no_sentinel,
-        test_mark_delivered_creates_sentinel,
-        test_clear_delivered_removes_sentinel,
-        test_mark_creates_directory_if_missing,
-        test_clear_idempotent,
-        test_separate_tasks_independent,
-        test_poll_results_checks_sentinel_before_main_send,
-        test_poll_results_marks_delivered_in_send_block,
-        test_poll_results_clears_sentinel_after_archive,
-    ):
+    for fn in tests:
         try:
             fn()
-            print(f"  ✓ {fn.__name__}")
-        except AssertionError as e:
-            failures.append(f"{fn.__name__}: {e}")
-            print(f"  ✗ {fn.__name__}")
+            print(f"  ok  {fn.__name__}")
+        except Exception as exc:
+            failures.append((fn.__name__, exc))
+            print(f"  FAIL  {fn.__name__}: {exc}")
     if failures:
-        print("\nFailures:")
-        for f in failures:
-            print(f"  {f}")
-        sys.exit(1)
-    print("All delivery-sentinel tests passed.")
+        raise SystemExit(1)
+    print("PASS - Discord terminal receipt compatibility")
 
 
 if __name__ == "__main__":

--- a/tests/discord-bridge-delivery-sentinel.test.py
+++ b/tests/discord-bridge-delivery-sentinel.test.py
@@ -235,9 +235,9 @@ def test_bridge_delegates_terminal_decisions_to_outbox_before_send():
     start = src.index("async def poll_results():")
     end = src.index("\nasync def ", start + 1)
     body = src[start:end]
-    receipt_pos = body.index("_terminal_receipt_state(task_id)")
+    receipt_pos = body.index("_terminal_receipt_state(task_id,")
     send_pos = body.index("await channel.send(")
-    mark_pos = body.index("_mark_delivered(task_id)")
+    mark_pos = body.index("_mark_delivered(task_id,")
     assert receipt_pos < send_pos < mark_pos
 
 

--- a/tests/discord-recreated-result-idempotency.test.py
+++ b/tests/discord-recreated-result-idempotency.test.py
@@ -166,10 +166,11 @@ class DiscordRecreatedResultTest(unittest.TestCase):
         (bridge.RESULTS_DIR / f"{task_id}.txt").write_text(body, encoding="utf-8")
 
     @staticmethod
-    def _terminal(task_id: str, disposition=None) -> None:
+    def _terminal(task_id: str, result_body: str, disposition=None) -> None:
         bridge.outbox.record_terminal_receipt(
             bridge._result_receipt_root(), task_id,
             disposition or bridge.outbox.TerminalDisposition.DELIVERED,
+            content_digest=bridge.outbox.terminal_content_digest(result_body),
         )
 
     @staticmethod
@@ -244,7 +245,7 @@ class DiscordRecreatedResultTest(unittest.TestCase):
             1,
         )
 
-    def test_recreated_confirmed_result_is_retired_without_another_send(self):
+    def test_identical_recreation_is_suppressed_but_changed_body_is_delivered(self):
         task_id = "task-2000000000001"
         first = "first confirmed answer"
         changed = "completion narration written after the answer"
@@ -261,16 +262,22 @@ class DiscordRecreatedResultTest(unittest.TestCase):
         self._result(task_id, changed)
         self._one_pass()
 
-        self.assertEqual(self.channel.sent, [first])
-        self.assertEqual(self.client.fetches, 1)
+        self.assertEqual(self.channel.sent, [first, changed])
+        self.assertEqual(self.client.fetches, 2)
         self.assertFalse((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
         self.assertNotIn(task_id, bridge.pending_replies)
         self.assertEqual(self._archive_bodies(task_id), sorted([first, first, changed]))
+        receipt = bridge.outbox.read_terminal_receipt(
+            bridge._result_receipt_root(), task_id)
+        self.assertEqual(
+            receipt.content_digest,
+            bridge.outbox.terminal_content_digest(changed),
+        )
 
     def test_archive_failure_retries_without_send_or_audit_then_audits_once(self):
         task_id = "task-2000000000002"
         self._live_task(task_id)
-        self._terminal(task_id)
+        self._terminal(task_id, "late copy")
         self._result(task_id, "late copy")
         original = bridge.archive_file
         bridge.archive_file = lambda *_args, **_kwargs: False
@@ -299,7 +306,7 @@ class DiscordRecreatedResultTest(unittest.TestCase):
     def test_pending_terminal_nonempty_result_retires_without_send_or_failure(self):
         task_id = "task-2000000000009"
         self._seed_pending(task_id, "already delivered")
-        self._terminal(task_id)
+        self._terminal(task_id, "already delivered")
 
         self._one_pass()
 
@@ -314,23 +321,35 @@ class DiscordRecreatedResultTest(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0][2:], ["deduped", "discord"])
 
-    def test_pending_terminal_empty_result_retires_without_send_or_failure(self):
+    def test_pending_changed_result_is_delivered_and_updates_receipt(self):
+        task_id = "task-2000000000014"
+        changed = "revised while the route is still pending"
+        self._seed_pending(task_id, changed)
+        self._terminal(task_id, "earlier delivered body")
+
+        self._one_pass()
+
+        self.assertEqual(self.channel.sent, [changed])
+        receipt = bridge.outbox.read_terminal_receipt(
+            bridge._result_receipt_root(), task_id)
+        self.assertEqual(
+            receipt.content_digest,
+            bridge.outbox.terminal_content_digest(changed),
+        )
+
+    def test_pending_terminal_empty_result_stays_live_until_ready(self):
         task_id = "task-2000000000010"
         self._seed_pending(task_id, "")
-        self._terminal(task_id)
+        self._terminal(task_id, "")
 
         self._one_pass()
 
         self.assertEqual(self.channel.sent, [])
-        self.assertFalse((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
-        self.assertFalse((bridge.TASKS_DIR / f"{task_id}.txt").exists())
-        self.assertNotIn(task_id, bridge.pending_replies)
-        self.assertNotIn(task_id, bridge.pending_reply_anchors)
-        self.assertNotIn(task_id, bridge.pending_task_tiers)
-        self.assertNotIn(task_id, bridge._empty_result_polls)
-        rows = self._audit_rows(task_id)
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0][2:], ["deduped", "discord"])
+        self.assertTrue((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertTrue((bridge.TASKS_DIR / f"{task_id}.txt").exists())
+        self.assertIs(bridge.pending_replies.get(task_id), self.channel)
+        self.assertEqual(bridge._empty_result_polls.get(task_id), 1)
+        self.assertEqual(self._audit_rows(task_id), [])
 
     def test_pending_unknown_nonempty_result_stays_live_across_polls(self):
         self._assert_pending_unknown_is_held(
@@ -339,7 +358,7 @@ class DiscordRecreatedResultTest(unittest.TestCase):
     def test_pending_unknown_empty_result_stays_live_without_empty_count(self):
         self._assert_pending_unknown_is_held("task-2000000000012", "")
 
-    def test_fresh_bridge_module_suppresses_a_recreated_result(self):
+    def test_fresh_bridge_suppresses_identical_body_and_delivers_revision(self):
         task_id = "task-2000000000013"
         first = "first process delivered this"
         self._archived_task(task_id)
@@ -349,7 +368,7 @@ class DiscordRecreatedResultTest(unittest.TestCase):
         self.assertTrue(bridge._has_durable_terminal_receipt(task_id))
         self.assertFalse(bridge._delivered_sentinel_path(task_id).exists())
 
-        self._result(task_id, "recreated after process restart")
+        self._result(task_id, first)
         fresh = _load_bridge("discord_recreated_result_bridge_restart")
         fresh.REPO = WORKSPACE
         fresh.RESULTS_DIR = WORKSPACE / "results"
@@ -381,6 +400,19 @@ class DiscordRecreatedResultTest(unittest.TestCase):
         self.assertFalse((fresh.RESULTS_DIR / f"{task_id}.txt").exists())
         self.assertNotIn(task_id, fresh.pending_replies)
         self.assertTrue(fresh._has_durable_terminal_receipt(task_id))
+
+        revision = "revised after process restart"
+        self._result(task_id, revision)
+        self._one_pass(fresh)
+
+        self.assertEqual(fresh_channel.sent, [revision])
+        self.assertEqual(fresh_client.fetches, 1)
+        receipt = fresh.outbox.read_terminal_receipt(
+            fresh._result_receipt_root(), task_id)
+        self.assertEqual(
+            receipt.content_digest,
+            fresh.outbox.terminal_content_digest(revision),
+        )
 
     def test_failed_delivery_record_does_not_suppress_a_recreated_result(self):
         task_id = "task-2000000000003"
@@ -443,7 +475,7 @@ class DiscordRecreatedResultTest(unittest.TestCase):
             1,
         )
 
-    def test_terminal_skip_outcomes_do_not_resurrect_as_plain_replies(self):
+    def test_changed_body_after_terminal_skip_is_a_followup(self):
         for offset, marker, disposition in (
             (6, "[no-send]\nalready handled", bridge.outbox.TerminalDisposition.NO_SEND),
             (7, "[deduped: task-holder]\nalready handled",
@@ -462,7 +494,10 @@ class DiscordRecreatedResultTest(unittest.TestCase):
                 self._result(task_id, "late completion narration")
                 self._one_pass()
 
-        self.assertEqual(self.channel.sent, [])
+        self.assertEqual(
+            self.channel.sent,
+            ["late completion narration", "late completion narration"],
+        )
 
     def test_corrupt_receipt_holds_the_result_instead_of_sending_or_discarding(self):
         task_id = "task-2000000000008"

--- a/tests/discord-recreated-result-idempotency.test.py
+++ b/tests/discord-recreated-result-idempotency.test.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""A confirmed Discord task result stays one logical external delivery."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(os.environ.get("REPO_UNDER_TEST") or Path(__file__).resolve().parent.parent)
+sys.path.insert(0, str(REPO / "src"))
+
+ROOT = Path(tempfile.mkdtemp(prefix="discord-result-idempotency-"))
+CONFIG = tempfile.mkdtemp(prefix="discord-result-idempotency-config-")
+WORKSPACE = ROOT / "workspace"
+os.environ["CLAUDE_CONFIG_DIR"] = CONFIG
+os.environ["SUTANDO_WORKSPACE"] = str(WORKSPACE)
+os.environ["SUTANDO_TEST_MODE"] = "1"
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
+(Path(CONFIG) / "channels" / "discord").mkdir(parents=True)
+(Path(CONFIG) / "channels" / "discord" / "access.json").write_text(
+    json.dumps({"allowFrom": []}), encoding="utf-8")
+
+
+def _install_discord_stub() -> None:
+    discord = types.ModuleType("discord")
+
+    class Intents:
+        @staticmethod
+        def default():
+            return types.SimpleNamespace(message_content=False, members=False)
+
+    class Client:
+        def __init__(self, **_kwargs):
+            self.loop = types.SimpleNamespace(create_task=lambda *_a, **_k: None)
+
+        @staticmethod
+        def event(fn):
+            return fn
+
+    class MessageReference:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    discord.Intents = Intents
+    discord.Client = Client
+    discord.MessageReference = MessageReference
+    discord.AllowedMentions = type("AllowedMentions", (), {})
+    discord.Message = type("Message", (), {})
+    discord.Thread = type("Thread", (), {})
+    discord.DMChannel = type("DMChannel", (), {})
+    discord.File = type("File", (), {"__init__": lambda self, *_a, **_k: None})
+    sys.modules["discord"] = discord
+
+
+_install_discord_stub()
+
+
+def _load_bridge(module_name: str):
+    spec = importlib.util.spec_from_file_location(
+        module_name, REPO / "src" / "discord-bridge.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bridge = _load_bridge("discord_recreated_result_bridge")
+
+CHANNEL_ID = "123456789012345678"
+
+
+class StopPoll(Exception):
+    pass
+
+
+class Channel:
+    def __init__(self):
+        self.id = int(CHANNEL_ID)
+        self.name = "idempotency-test"
+        self.sent: list[str] = []
+
+    async def send(self, content=None, **_kwargs):
+        self.sent.append(str(content))
+        return types.SimpleNamespace(id=len(self.sent))
+
+
+class Client:
+    def __init__(self, channel: Channel):
+        self.channel = channel
+        self.fetches = 0
+
+    @staticmethod
+    def is_ready():
+        return False
+
+    async def fetch_channel(self, channel_id):
+        self.fetches += 1
+        if int(channel_id) != self.channel.id:
+            raise AssertionError(f"unexpected channel {channel_id}")
+        return self.channel
+
+    @staticmethod
+    def get_channel(_channel_id):
+        return None
+
+
+class DiscordRecreatedResultTest(unittest.TestCase):
+    def setUp(self) -> None:
+        shutil.rmtree(WORKSPACE, ignore_errors=True)
+        for rel in ("results", "results/archive", "tasks", "tasks/archive", "state", "logs"):
+            (WORKSPACE / rel).mkdir(parents=True, exist_ok=True)
+        bridge.REPO = WORKSPACE
+        bridge.RESULTS_DIR = WORKSPACE / "results"
+        bridge.TASKS_DIR = WORKSPACE / "tasks"
+        bridge.ARCHIVE_RESULTS_DIR = bridge.RESULTS_DIR / "archive"
+        bridge.ARCHIVE_TASKS_DIR = bridge.TASKS_DIR / "archive"
+        bridge.STATE_DIR = WORKSPACE / "state"
+        bridge.DELIVERED_DIR = bridge.STATE_DIR / "discord-delivered"
+        bridge.PENDING_REPLIES_FILE = bridge.STATE_DIR / "pending-discord-replies.json"
+        bridge.pending_replies.clear()
+        bridge.pending_reply_anchors.clear()
+        bridge.pending_task_tiers.clear()
+        bridge._empty_result_polls.clear()
+        bridge._progress_msgs.clear()
+        bridge._recovered_replies = {}
+        bridge._orphan_route_cursor = ""
+        notices = getattr(bridge, "_ambiguous_receipt_notices", None)
+        if notices is not None:
+            notices.clear()
+            bridge._ambiguous_receipt_notice_overflow = False
+        bridge.save_pending_replies = lambda: None
+        bridge.result_audit._audit_path = lambda: WORKSPACE / "state" / "result-audit.log"
+        self.channel = Channel()
+        self.client = Client(self.channel)
+        bridge.client = self.client
+
+    @staticmethod
+    def _archived_task(task_id: str) -> None:
+        month = bridge.ARCHIVE_TASKS_DIR / "2026-08"
+        month.mkdir(parents=True, exist_ok=True)
+        (month / f"{task_id}.txt").write_text(
+            f"id: {task_id}\nsource: discord\nchannel_id: {CHANNEL_ID}\n"
+            "access_tier: owner\ntask: test\n",
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _live_task(task_id: str) -> None:
+        (bridge.TASKS_DIR / f"{task_id}.txt").write_text(
+            f"id: {task_id}\nsource: discord\nchannel_id: {CHANNEL_ID}\n"
+            "access_tier: owner\ntask: test\n",
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _result(task_id: str, body: str) -> None:
+        (bridge.RESULTS_DIR / f"{task_id}.txt").write_text(body, encoding="utf-8")
+
+    @staticmethod
+    def _terminal(task_id: str, disposition=None) -> None:
+        bridge.outbox.record_terminal_receipt(
+            bridge._result_receipt_root(), task_id,
+            disposition or bridge.outbox.TerminalDisposition.DELIVERED,
+        )
+
+    @staticmethod
+    def _archive_bodies(task_id: str) -> list[str]:
+        return sorted(
+            p.read_text(encoding="utf-8")
+            for p in bridge.ARCHIVE_RESULTS_DIR.glob(f"*/{task_id}.txt*"))
+
+    @staticmethod
+    def _audit_rows(task_id: str) -> list[list[str]]:
+        audit = WORKSPACE / "state" / "result-audit.log"
+        if not audit.exists():
+            return []
+        return [
+            fields
+            for line in audit.read_text(encoding="utf-8").splitlines()
+            if len(fields := line.split("\t")) == 4 and fields[1] == task_id
+        ]
+
+    @staticmethod
+    def _one_pass(module=bridge) -> None:
+        async def stop(_seconds):
+            raise StopPoll()
+
+        original = module.asyncio.sleep
+        module.asyncio.sleep = stop
+        try:
+            with unittest.TestCase().assertRaises(StopPoll):
+                asyncio.run(module.poll_results())
+        finally:
+            module.asyncio.sleep = original
+
+    @staticmethod
+    def _forget_runtime_routes() -> None:
+        bridge.pending_replies.clear()
+        bridge.pending_reply_anchors.clear()
+        bridge.pending_task_tiers.clear()
+        bridge._recovered_replies = {}
+        bridge._orphan_route_cursor = ""
+
+    def _seed_pending(self, task_id: str, body: str) -> None:
+        self._live_task(task_id)
+        self._result(task_id, body)
+        bridge.pending_replies[task_id] = self.channel
+        bridge.pending_reply_anchors[task_id] = 987654321098765432
+        bridge.pending_task_tiers[task_id] = "owner"
+
+    def _assert_pending_unknown_is_held(self, task_id: str, body: str) -> None:
+        self._seed_pending(task_id, body)
+        receipt_path = bridge.outbox._terminal_receipt_path(
+            bridge._result_receipt_root(), task_id, 0)
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text("{torn", encoding="utf-8")
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            for _ in range(3):
+                self._one_pass()
+
+        self.assertEqual(self.channel.sent, [])
+        self.assertTrue((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertTrue((bridge.TASKS_DIR / f"{task_id}.txt").exists())
+        self.assertIs(bridge.pending_replies.get(task_id), self.channel)
+        self.assertEqual(
+            bridge.pending_reply_anchors.get(task_id), 987654321098765432)
+        self.assertEqual(bridge.pending_task_tiers.get(task_id), "owner")
+        self.assertNotIn(task_id, bridge._empty_result_polls)
+        self.assertEqual(self._audit_rows(task_id), [])
+        self.assertEqual(
+            output.getvalue().count(
+                f"holding {task_id}: terminal outcome needs reconciliation"),
+            1,
+        )
+
+    def test_recreated_confirmed_result_is_retired_without_another_send(self):
+        task_id = "task-2000000000001"
+        first = "first confirmed answer"
+        changed = "completion narration written after the answer"
+        self._archived_task(task_id)
+
+        self._result(task_id, first)
+        self._one_pass()
+        self.assertEqual(self.channel.sent, [first])
+
+        self._forget_runtime_routes()
+        self._result(task_id, first)
+        self._one_pass()
+        self._forget_runtime_routes()
+        self._result(task_id, changed)
+        self._one_pass()
+
+        self.assertEqual(self.channel.sent, [first])
+        self.assertEqual(self.client.fetches, 1)
+        self.assertFalse((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertNotIn(task_id, bridge.pending_replies)
+        self.assertEqual(self._archive_bodies(task_id), sorted([first, first, changed]))
+
+    def test_archive_failure_retries_without_send_or_audit_then_audits_once(self):
+        task_id = "task-2000000000002"
+        self._live_task(task_id)
+        self._terminal(task_id)
+        self._result(task_id, "late copy")
+        original = bridge.archive_file
+        bridge.archive_file = lambda *_args, **_kwargs: False
+        try:
+            for _ in range(3):
+                self._one_pass()
+        finally:
+            bridge.archive_file = original
+
+        self.assertEqual(self.channel.sent, [])
+        self.assertTrue((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertTrue((bridge.TASKS_DIR / f"{task_id}.txt").exists())
+        self.assertNotIn(task_id, bridge.pending_replies)
+        self.assertEqual(self._audit_rows(task_id), [])
+
+        self._one_pass()
+        self._one_pass()
+
+        self.assertEqual(self.channel.sent, [])
+        self.assertFalse((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertFalse((bridge.TASKS_DIR / f"{task_id}.txt").exists())
+        rows = self._audit_rows(task_id)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][2:], ["deduped", "discord"])
+
+    def test_pending_terminal_nonempty_result_retires_without_send_or_failure(self):
+        task_id = "task-2000000000009"
+        self._seed_pending(task_id, "already delivered")
+        self._terminal(task_id)
+
+        self._one_pass()
+
+        self.assertEqual(self.channel.sent, [])
+        self.assertFalse((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertFalse((bridge.TASKS_DIR / f"{task_id}.txt").exists())
+        self.assertNotIn(task_id, bridge.pending_replies)
+        self.assertNotIn(task_id, bridge.pending_reply_anchors)
+        self.assertNotIn(task_id, bridge.pending_task_tiers)
+        self.assertNotIn(task_id, bridge._empty_result_polls)
+        rows = self._audit_rows(task_id)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][2:], ["deduped", "discord"])
+
+    def test_pending_terminal_empty_result_retires_without_send_or_failure(self):
+        task_id = "task-2000000000010"
+        self._seed_pending(task_id, "")
+        self._terminal(task_id)
+
+        self._one_pass()
+
+        self.assertEqual(self.channel.sent, [])
+        self.assertFalse((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertFalse((bridge.TASKS_DIR / f"{task_id}.txt").exists())
+        self.assertNotIn(task_id, bridge.pending_replies)
+        self.assertNotIn(task_id, bridge.pending_reply_anchors)
+        self.assertNotIn(task_id, bridge.pending_task_tiers)
+        self.assertNotIn(task_id, bridge._empty_result_polls)
+        rows = self._audit_rows(task_id)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][2:], ["deduped", "discord"])
+
+    def test_pending_unknown_nonempty_result_stays_live_across_polls(self):
+        self._assert_pending_unknown_is_held(
+            "task-2000000000011", "must wait for receipt repair")
+
+    def test_pending_unknown_empty_result_stays_live_without_empty_count(self):
+        self._assert_pending_unknown_is_held("task-2000000000012", "")
+
+    def test_fresh_bridge_module_suppresses_a_recreated_result(self):
+        task_id = "task-2000000000013"
+        first = "first process delivered this"
+        self._archived_task(task_id)
+        self._result(task_id, first)
+        self._one_pass()
+        self.assertEqual(self.channel.sent, [first])
+        self.assertTrue(bridge._has_durable_terminal_receipt(task_id))
+        self.assertFalse(bridge._delivered_sentinel_path(task_id).exists())
+
+        self._result(task_id, "recreated after process restart")
+        fresh = _load_bridge("discord_recreated_result_bridge_restart")
+        fresh.REPO = WORKSPACE
+        fresh.RESULTS_DIR = WORKSPACE / "results"
+        fresh.TASKS_DIR = WORKSPACE / "tasks"
+        fresh.ARCHIVE_RESULTS_DIR = fresh.RESULTS_DIR / "archive"
+        fresh.ARCHIVE_TASKS_DIR = fresh.TASKS_DIR / "archive"
+        fresh.STATE_DIR = WORKSPACE / "state"
+        fresh.DELIVERED_DIR = fresh.STATE_DIR / "discord-delivered"
+        fresh.PENDING_REPLIES_FILE = fresh.STATE_DIR / "pending-discord-replies.json"
+        fresh.pending_replies.clear()
+        fresh.pending_reply_anchors.clear()
+        fresh.pending_task_tiers.clear()
+        fresh._empty_result_polls.clear()
+        fresh._progress_msgs.clear()
+        fresh._recovered_replies = {}
+        fresh._orphan_route_cursor = ""
+        fresh._ambiguous_receipt_notices.clear()
+        fresh._ambiguous_receipt_notice_overflow = False
+        fresh.save_pending_replies = lambda: None
+        fresh.result_audit._audit_path = lambda: WORKSPACE / "state" / "result-audit.log"
+        fresh_channel = Channel()
+        fresh_client = Client(fresh_channel)
+        fresh.client = fresh_client
+
+        self._one_pass(fresh)
+
+        self.assertEqual(fresh_channel.sent, [])
+        self.assertEqual(fresh_client.fetches, 0)
+        self.assertFalse((fresh.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertNotIn(task_id, fresh.pending_replies)
+        self.assertTrue(fresh._has_durable_terminal_receipt(task_id))
+
+    def test_failed_delivery_record_does_not_suppress_a_recreated_result(self):
+        task_id = "task-2000000000003"
+        self._archived_task(task_id)
+        archived = bridge.ARCHIVE_RESULTS_DIR / "2026-08"
+        archived.mkdir(parents=True, exist_ok=True)
+        (archived / f"{task_id}.txt").write_text("failed attempt", encoding="utf-8")
+        bridge.result_audit.record(task_id, "failed", "discord",
+                                   ts="2026-08-19T18:00:00Z")
+
+        self._result(task_id, "retry after failure")
+        self._one_pass()
+
+        self.assertEqual(self.channel.sent, ["retry after failure"])
+
+    def test_other_surface_delivery_does_not_suppress_discord(self):
+        task_id = "task-2000000000004"
+        self._archived_task(task_id)
+        bridge.outbox.record_terminal_receipt(
+            WORKSPACE / "results" / ".outbox-slack-task-results",
+            task_id,
+            bridge.outbox.TerminalDisposition.DELIVERED,
+        )
+        self._result(task_id, "discord answer")
+
+        self._one_pass()
+
+        self.assertEqual(self.channel.sent, ["discord answer"])
+
+    def test_legacy_only_sentinel_holds_live_pair_for_reconciliation(self):
+        task_id = "task-2000000000005"
+        task = bridge.TASKS_DIR / f"{task_id}.txt"
+        task.write_text(
+            f"id: {task_id}\nsource: discord\nchannel_id: {CHANNEL_ID}\n"
+            "access_tier: owner\ntask: test\n",
+            encoding="utf-8",
+        )
+        bridge.DELIVERED_DIR.mkdir(parents=True, exist_ok=True)
+        bridge._delivered_sentinel_path(task_id).touch()
+        self._result(task_id, "already sent before restart")
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            for _ in range(3):
+                self._one_pass()
+
+        self.assertEqual(self.channel.sent, [])
+        self.assertEqual(self.client.fetches, 0)
+        self.assertTrue(task.exists())
+        self.assertTrue((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertTrue(bridge._delivered_sentinel_path(task_id).exists())
+        self.assertFalse(bridge._has_durable_terminal_receipt(task_id))
+        receipt = bridge.outbox.read_terminal_receipt(
+            bridge._result_receipt_root(), task_id)
+        self.assertIs(receipt.state, bridge.outbox.TerminalReceiptState.ABSENT)
+        self.assertEqual(self._audit_rows(task_id), [])
+        self.assertEqual(
+            output.getvalue().count(
+                f"holding {task_id}: terminal outcome needs reconciliation"),
+            1,
+        )
+
+    def test_terminal_skip_outcomes_do_not_resurrect_as_plain_replies(self):
+        for offset, marker, disposition in (
+            (6, "[no-send]\nalready handled", bridge.outbox.TerminalDisposition.NO_SEND),
+            (7, "[deduped: task-holder]\nalready handled",
+             bridge.outbox.TerminalDisposition.DEDUPED),
+        ):
+            with self.subTest(disposition=disposition.value):
+                task_id = f"task-200000000000{offset}"
+                self._live_task(task_id)
+                self._result(task_id, marker)
+                self._one_pass()
+                receipt = bridge.outbox.read_terminal_receipt(
+                    bridge._result_receipt_root(), task_id)
+                self.assertEqual(receipt.disposition, disposition)
+
+                self._forget_runtime_routes()
+                self._result(task_id, "late completion narration")
+                self._one_pass()
+
+        self.assertEqual(self.channel.sent, [])
+
+    def test_corrupt_receipt_holds_the_result_instead_of_sending_or_discarding(self):
+        task_id = "task-2000000000008"
+        self._archived_task(task_id)
+        receipt_path = bridge.outbox._terminal_receipt_path(
+            bridge._result_receipt_root(), task_id, 0)
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text("{torn", encoding="utf-8")
+        self._result(task_id, "must wait for operator repair")
+
+        self._one_pass()
+
+        self.assertEqual(self.channel.sent, [])
+        self.assertEqual(self.client.fetches, 0)
+        self.assertTrue((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
+        self.assertNotIn(task_id, bridge.pending_replies)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-terminal-receipts.test.py
+++ b/tests/health-check-terminal-receipts.test.py
@@ -40,6 +40,25 @@ class TerminalReceiptHealthTest(unittest.TestCase):
             check = self._check(workspace)
         self.assertEqual(check["status"], "ok", check)
         self.assertIn("1 terminal receipt(s)", check["detail"])
+        self.assertIn("removed nothing", check["detail"])
+
+    def test_expired_receipt_reports_pre_cleanup_count_and_removal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            root = self._root(workspace)
+            hc.outbox.record_terminal_receipt(
+                root, "task-expired", hc.outbox.TerminalDisposition.DELIVERED,
+                now=1.0)
+            path = hc.outbox._terminal_receipt_path(root, "task-expired", 0)
+
+            check = self._check(workspace)
+
+            self.assertEqual(check["status"], "ok", check)
+            self.assertIn("1 terminal receipt(s) before periodic retention", check["detail"])
+            self.assertIn("removed 1 expired", check["detail"])
+            self.assertIn("0 retained", check["detail"])
+            self.assertNotIn("removed nothing", check["detail"])
+            self.assertFalse(path.exists())
 
     def test_corrupt_receipt_warns_and_survives_the_probe(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/health-check-terminal-receipts.test.py
+++ b/tests/health-check-terminal-receipts.test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Health visibility for Discord terminal receipts held fail-closed."""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "health_check_terminal_receipts", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(hc)
+
+
+class TerminalReceiptHealthTest(unittest.TestCase):
+    def _check(self, workspace: Path) -> dict:
+        with mock.patch.object(hc, "WORKSPACE_DIR", workspace):
+            return hc.check_terminal_receipts()
+
+    @staticmethod
+    def _root(workspace: Path) -> Path:
+        return workspace / "results" / ".outbox-discord-task-results"
+
+    def test_absent_store_is_healthy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            check = self._check(Path(tmp))
+        self.assertEqual(check["status"], "ok", check)
+        self.assertIn("0 terminal receipt(s)", check["detail"])
+
+    def test_valid_receipt_is_healthy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            hc.outbox.record_terminal_receipt(
+                self._root(workspace), "task-valid",
+                hc.outbox.TerminalDisposition.DELIVERED)
+            check = self._check(workspace)
+        self.assertEqual(check["status"], "ok", check)
+        self.assertIn("1 terminal receipt(s)", check["detail"])
+
+    def test_corrupt_receipt_warns_and_survives_the_probe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            root = self._root(workspace)
+            hc.outbox.record_terminal_receipt(
+                root, "task-corrupt", hc.outbox.TerminalDisposition.DELIVERED)
+            path = hc.outbox._terminal_receipt_path(root, "task-corrupt", 0)
+            path.write_bytes(b"corrupt")
+
+            check = self._check(workspace)
+
+            self.assertEqual(check["status"], "warn", check)
+            self.assertIn("1 unreadable or corrupt receipt entry", check["detail"])
+            self.assertIn("held fail-closed", check["detail"])
+            self.assertIn("confirm the delivery outcome", check["detail"])
+            self.assertTrue(path.exists())
+            self.assertEqual(
+                hc.outbox.read_terminal_receipt(root, "task-corrupt").state,
+                hc.outbox.TerminalReceiptState.UNKNOWN)
+
+    def test_incomplete_or_failed_inspection_warns(self):
+        report = hc.outbox.TerminalReceiptCleanup(incomplete=True)
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(hc.outbox, "cleanup_terminal_receipts",
+                                  return_value=report):
+            check = self._check(Path(tmp))
+        self.assertEqual(check["status"], "warn", check)
+        self.assertIn("inspection incomplete", check["detail"])
+
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(hc.outbox, "cleanup_terminal_receipts",
+                                  side_effect=PermissionError("denied")):
+            check = self._check(Path(tmp))
+        self.assertEqual(check["status"], "warn", check)
+        self.assertIn("could not inspect", check["detail"])
+
+    def test_probe_is_wired_into_run_all_checks(self):
+        tree = ast.parse((REPO / "src" / "health-check.py").read_text())
+        run_all = next(node for node in tree.body
+                       if isinstance(node, ast.FunctionDef)
+                       and node.name == "run_all_checks")
+        calls = [node.func.id for node in ast.walk(run_all)
+                 if isinstance(node, ast.Call)
+                 and isinstance(node.func, ast.Name)]
+        self.assertEqual(calls.count("check_terminal_receipts"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/orphan-result-routes.test.py
+++ b/tests/orphan-result-routes.test.py
@@ -313,7 +313,8 @@ class WiringTest(unittest.TestCase):
                              "cleanup resolves the bare name, not the claimed file")
         # and every delivery path must go THROUGH it rather than open-coding
         self.assertGreaterEqual(
-            len(re.findall(r"^\s+_archive_delivered_pair\(result_file, task_id\)$",
+            len(re.findall(
+                r"^\s+_archive_delivered_pair\(result_file, task_id, _receipt_body\)$",
                            self.src, re.M)), 2,
             "both delivery paths must call the shared helper")
         self.assertNotIn("_gone = archive_file", self.src,

--- a/tests/outbox-terminal-cleanup-coverage.test.py
+++ b/tests/outbox-terminal-cleanup-coverage.test.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Failure-path contracts for bounded terminal-receipt cleanup."""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+import outbox  # noqa: E402
+
+
+def _same_shard_ids(prefix: str) -> tuple[str, str]:
+    first = f"{prefix}-a"
+    shard = outbox._terminal_digest(first, 0)[:2]
+    for index in range(10_000):
+        second = f"{prefix}-b-{index}"
+        if outbox._terminal_digest(second, 0).startswith(shard):
+            return first, second
+    raise AssertionError("could not find a same-shard receipt id")
+
+
+def _write_receipt(root: Path, item_id: str, recorded_at: float = 10.0) -> Path:
+    path = outbox._terminal_receipt_path(root, item_id, 0)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = outbox._terminal_payload(
+        item_id, 0, outbox.TerminalDisposition.DELIVERED, recorded_at)
+    path.write_bytes(outbox._terminal_bytes(payload))
+    return path
+
+
+def _cleanup(root: Path, path: Path, *, clock: float = 20.0,
+             ttl: float = 100.0, max_records: int = 10):
+    shard_name = path.parent.name
+    with outbox._item_lock(root, outbox._terminal_shard_lock_id(shard_name)):
+        return outbox._cleanup_terminal_receipt_shard_locked(
+            root, shard_name, clock, ttl, max_records, scan_all=True)
+
+
+class TestBoundedScan(unittest.TestCase):
+    def test_truncated_scan_refuses_same_shard_publication(self):
+        first, target = _same_shard_ids("scan-bound")
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(outbox, "TERMINAL_RECEIPT_MAX_RECORDS", 256), \
+                mock.patch.object(outbox, "TERMINAL_RECEIPT_SWEEP_BATCH", 1):
+            root = Path(tmp)
+            shard = outbox._terminal_receipt_path(root, first, 0).parent
+            shard.mkdir(parents=True)
+            (shard / "junk-a").write_text("a")
+            (shard / "junk-b").write_text("b")
+
+            refused = outbox.record_terminal_receipt(
+                root, target, outbox.TerminalDisposition.DELIVERED, now=20.0)
+
+            self.assertIs(refused.state, outbox.TerminalReceiptState.UNKNOWN)
+            self.assertFalse(outbox._terminal_receipt_path(root, target, 0).exists())
+            self.assertEqual(sorted(path.name for path in shard.iterdir()),
+                             ["junk-a", "junk-b"])
+
+
+class TestTemporaryEntries(unittest.TestCase):
+    def _temp(self, root: Path, item_id: str) -> Path:
+        digest = outbox._terminal_digest(item_id, 0)
+        shard = outbox._terminal_receipt_shard(root, digest)
+        shard.mkdir(parents=True, exist_ok=True)
+        path = shard / f".{digest}.orphan.tmp"
+        path.write_text("partial")
+        return path
+
+    def test_stale_temp_is_removed_and_counted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = self._temp(root, "temp-removed")
+
+            report = _cleanup(root, path)
+
+            self.assertFalse(path.exists())
+            self.assertEqual(report.stale_temps, 1)
+            self.assertEqual(report.unknown, 0)
+            self.assertFalse(report.incomplete)
+
+    def test_temp_disappearing_before_stat_is_a_clean_race(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = self._temp(root, "temp-vanished")
+            real_lstat = Path.lstat
+
+            def vanished(candidate):
+                if candidate == path:
+                    path.unlink()
+                    raise FileNotFoundError(path)
+                return real_lstat(candidate)
+
+            with mock.patch.object(Path, "lstat", vanished):
+                report = _cleanup(root, path)
+
+            self.assertFalse(path.exists())
+            self.assertEqual(report.stale_temps, 0)
+            self.assertEqual(report.unknown, 0)
+            self.assertFalse(report.incomplete)
+
+    def test_unstatable_temp_is_preserved_and_marks_incomplete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = self._temp(root, "temp-unreadable")
+            real_lstat = Path.lstat
+
+            def unreadable(candidate):
+                if candidate == path:
+                    raise PermissionError("injected")
+                return real_lstat(candidate)
+
+            with mock.patch.object(Path, "lstat", unreadable):
+                report = _cleanup(root, path)
+
+            self.assertTrue(path.exists())
+            self.assertEqual(report.unknown, 1)
+            self.assertTrue(report.incomplete)
+
+
+class TestEntryRaces(unittest.TestCase):
+    def test_unrelated_entries_are_ignored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            shard = outbox._terminal_receipts_dir(root) / "00"
+            shard.mkdir(parents=True)
+            junk = shard / "not-a-receipt"
+            wrong = shard / f"{'f' * 64}.json"
+            junk.write_text("junk")
+            wrong.write_text("wrong shard")
+
+            report = _cleanup(root, junk)
+
+            self.assertEqual(report, outbox.TerminalReceiptCleanup())
+            self.assertTrue(junk.exists())
+            self.assertTrue(wrong.exists())
+
+    def test_receipt_disappearing_before_stat_is_not_counted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = _write_receipt(root, "receipt-before-stat")
+            real_lstat = Path.lstat
+
+            def vanished(candidate):
+                if candidate == path:
+                    path.unlink()
+                    raise FileNotFoundError(path)
+                return real_lstat(candidate)
+
+            with mock.patch.object(Path, "lstat", vanished):
+                report = _cleanup(root, path)
+
+            self.assertFalse(path.exists())
+            self.assertEqual(report, outbox.TerminalReceiptCleanup())
+
+    def test_receipt_disappearing_during_read_is_not_counted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = _write_receipt(root, "receipt-during-read")
+
+            def vanished(*_args, **_kwargs):
+                path.unlink()
+                return outbox.TerminalReceipt(
+                    outbox.TerminalReceiptState.ABSENT, "", 0)
+
+            with mock.patch.object(outbox, "_read_terminal_path", vanished):
+                report = _cleanup(root, path)
+
+            self.assertFalse(path.exists())
+            self.assertEqual(report, outbox.TerminalReceiptCleanup())
+
+
+class TestExpiryRaces(unittest.TestCase):
+    def _run(self, error_type):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = _write_receipt(root, f"expired-{error_type.__name__}", 1.0)
+            real_unlink = Path.unlink
+
+            def fail_unlink(candidate, *args, **kwargs):
+                if candidate != path:
+                    return real_unlink(candidate, *args, **kwargs)
+                if error_type is FileNotFoundError:
+                    real_unlink(candidate)
+                raise error_type("injected")
+
+            with mock.patch.object(Path, "unlink", fail_unlink):
+                report = _cleanup(root, path, clock=20.0, ttl=5.0)
+            return path.exists(), report
+
+    def test_expired_receipt_removed_by_peer_is_not_counted(self):
+        exists, report = self._run(FileNotFoundError)
+        self.assertFalse(exists)
+        self.assertEqual(report.expired, 0)
+        self.assertEqual(report.kept, 0)
+        self.assertEqual(report.unknown, 0)
+
+    def test_unremovable_expired_receipt_is_preserved_and_accounted(self):
+        exists, report = self._run(PermissionError)
+        self.assertTrue(exists)
+        self.assertEqual(report.expired, 0)
+        self.assertEqual(report.kept, 1)
+        self.assertEqual(report.unknown, 1)
+
+
+class TestOverflowRaces(unittest.TestCase):
+    def test_rebound_overflow_entry_is_kept_fail_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = _write_receipt(root, "overflow-rebound")
+
+            with mock.patch.object(outbox, "_same_stat", return_value=False):
+                report = _cleanup(root, path, max_records=0)
+
+            self.assertTrue(path.exists())
+            self.assertEqual(report.overflow, 0)
+            self.assertEqual(report.kept, 1)
+            self.assertTrue(report.incomplete)
+
+    def _run_unlink_error(self, error_type):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = _write_receipt(root, f"overflow-{error_type.__name__}")
+            real_unlink = Path.unlink
+
+            def fail_unlink(candidate, *args, **kwargs):
+                if candidate != path:
+                    return real_unlink(candidate, *args, **kwargs)
+                if error_type is FileNotFoundError:
+                    real_unlink(candidate)
+                raise error_type("injected")
+
+            with mock.patch.object(Path, "unlink", fail_unlink):
+                report = _cleanup(root, path, max_records=0)
+            return path.exists(), report
+
+    def test_overflow_removed_by_peer_is_conservatively_accounted(self):
+        exists, report = self._run_unlink_error(FileNotFoundError)
+        self.assertFalse(exists)
+        self.assertEqual(report.overflow, 0)
+        self.assertEqual(report.kept, 1)
+        self.assertTrue(report.incomplete)
+
+    def test_unremovable_overflow_is_preserved_and_accounted(self):
+        exists, report = self._run_unlink_error(PermissionError)
+        self.assertTrue(exists)
+        self.assertEqual(report.overflow, 0)
+        self.assertEqual(report.kept, 1)
+        self.assertEqual(report.unknown, 1)
+        self.assertTrue(report.incomplete)
+
+
+class TestPublicCleanupErrors(unittest.TestCase):
+    def test_invalid_capacity_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for invalid in (True, -1):
+                with self.subTest(invalid=invalid), self.assertRaises(ValueError):
+                    outbox.cleanup_terminal_receipts(tmp, max_records=invalid)
+
+    def test_missing_receipt_root_is_a_clean_empty_store(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = outbox.cleanup_terminal_receipts(tmp)
+        self.assertEqual(report, outbox.TerminalReceiptCleanup())
+
+    def test_unstatable_receipt_root_is_unknown_and_incomplete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            directory = outbox._terminal_receipts_dir(root)
+            directory.mkdir()
+            real_lstat = Path.lstat
+
+            def unreadable(candidate):
+                if candidate == directory:
+                    raise PermissionError("injected")
+                return real_lstat(candidate)
+
+            with mock.patch.object(Path, "lstat", unreadable):
+                report = outbox.cleanup_terminal_receipts(root)
+
+            self.assertEqual(report.unknown, 1)
+            self.assertTrue(report.incomplete)
+
+    def test_non_directory_receipt_root_is_unknown_and_incomplete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            directory = outbox._terminal_receipts_dir(root)
+            directory.write_text("not a directory")
+
+            report = outbox.cleanup_terminal_receipts(root)
+
+            self.assertEqual(report.unknown, 1)
+            self.assertTrue(report.incomplete)
+
+    def test_unstatable_shard_is_unknown_and_incomplete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            directory = outbox._terminal_receipts_dir(root)
+            directory.mkdir()
+            shard = directory / "7f"
+            real_lstat = Path.lstat
+
+            def unreadable(candidate):
+                if candidate == shard:
+                    raise PermissionError("injected")
+                return real_lstat(candidate)
+
+            with mock.patch.object(Path, "lstat", unreadable):
+                report = outbox.cleanup_terminal_receipts(root)
+
+            self.assertEqual(report.unknown, 1)
+            self.assertTrue(report.incomplete)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/outbox-terminal-receipts.test.py
+++ b/tests/outbox-terminal-receipts.test.py
@@ -79,6 +79,63 @@ def test_states_dispositions_and_first_terminal_wins():
                 raise AssertionError("partial nonterminal receipt was accepted")
 
 
+def test_content_digest_matches_and_changed_content_replaces_receipt():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        first_digest = outbox.terminal_content_digest("first answer")
+        changed_digest = outbox.terminal_content_digest("revised answer")
+        first = outbox.record_terminal_receipt(
+            root, "revision", outbox.TerminalDisposition.DELIVERED,
+            now=10.0, content_digest=first_digest)
+
+        assert outbox.terminal_receipt_content_state(
+            first, first_digest) is outbox.TerminalReceiptState.TERMINAL
+        assert outbox.terminal_receipt_content_state(
+            first, changed_digest) is outbox.TerminalReceiptState.ABSENT
+
+        replacement = outbox.record_terminal_receipt(
+            root, "revision", outbox.TerminalDisposition.DELIVERED,
+            now=11.0, content_digest=changed_digest)
+        assert replacement.content_digest == changed_digest
+        assert replacement.recorded_at == 11.0
+        assert outbox.read_terminal_receipt(
+            root, "revision", now=12.0) == replacement
+        assert len(list((root / outbox.TERMINAL_RECEIPTS_DIR).glob("*/*.json"))) == 1
+
+        digestless = outbox.record_terminal_receipt(
+            root, "legacy-shape", outbox.TerminalDisposition.DELIVERED,
+            now=10.0)
+        assert outbox.terminal_receipt_content_state(
+            digestless, first_digest) is outbox.TerminalReceiptState.UNKNOWN
+
+
+def test_failed_content_update_preserves_the_previous_receipt():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        first_digest = outbox.terminal_content_digest("first answer")
+        changed_digest = outbox.terminal_content_digest("revised answer")
+        original = outbox.record_terminal_receipt(
+            root, "failed-revision", outbox.TerminalDisposition.DELIVERED,
+            now=10.0, content_digest=first_digest)
+        path = outbox._terminal_receipt_path(root, "failed-revision", 0)
+        before = path.read_bytes()
+
+        with mock.patch.object(
+                outbox.os, "replace", side_effect=OSError(errno.EIO, "injected")):
+            try:
+                outbox.record_terminal_receipt(
+                    root, "failed-revision", outbox.TerminalDisposition.DELIVERED,
+                    now=11.0, content_digest=changed_digest)
+            except OSError as exc:
+                assert exc.errno == errno.EIO
+            else:
+                raise AssertionError("failed receipt update reported success")
+
+        assert path.read_bytes() == before
+        assert outbox.read_terminal_receipt(
+            root, "failed-revision", now=12.0) == original
+
+
 def test_concurrent_writers_observe_one_terminal_winner():
     with tempfile.TemporaryDirectory() as tmp:
         ctx = multiprocessing.get_context("fork")
@@ -179,6 +236,12 @@ def test_reader_rejects_every_semantically_invalid_record_shape():
         data = outbox._terminal_payload(
             item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
         data["recorded_at"] = "yesterday"
+        cases.append((item_id, 0, data))
+
+        item_id = "invalid-content-digest"
+        data = outbox._terminal_payload(
+            item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
+        data["content_digest"] = "not-sha256"
         cases.append((item_id, 0, data))
 
         item_id = "mismatched-generation"
@@ -723,6 +786,10 @@ def test_invalid_identity_and_clock_inputs_are_rejected():
             lambda: outbox.read_terminal_receipt(tmp, "x", now=float("nan")),
             lambda: outbox.read_terminal_receipt(tmp, "x", now=1.0, ttl_seconds=-1.0),
             lambda: outbox.record_terminal_receipt(tmp, "x", "bogus", now=1.0),
+            lambda: outbox.record_terminal_receipt(
+                tmp, "x", outbox.TerminalDisposition.DELIVERED,
+                now=1.0, content_digest="not-sha256"),
+            lambda: outbox.terminal_content_digest(1),
         ]
         for call in invalid_calls:
             try:

--- a/tests/outbox-terminal-receipts.test.py
+++ b/tests/outbox-terminal-receipts.test.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+"""Direct contract tests for durable outbox terminal receipts."""
+from __future__ import annotations
+
+import errno
+import json
+import multiprocessing
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+import outbox  # noqa: E402
+
+
+def _race_record(root, disposition, start, results):
+    start.wait()
+    receipt = outbox.record_terminal_receipt(root, "race/item", disposition, now=100.0)
+    results.put((receipt.state.value, receipt.disposition.value, receipt.recorded_at))
+
+
+def _read_receipt_state(root, item_id, results):
+    receipt = outbox.read_terminal_receipt(root, item_id, now=100.0)
+    results.put(receipt.state.value)
+
+
+def _item_id_for_record_size(size):
+    sample = "x"
+    overhead = len(outbox._terminal_bytes(outbox._terminal_payload(
+        sample, 0, outbox.TerminalDisposition.DELIVERED, 100.0))) - len(sample)
+    item_id = "x" * (size - overhead)
+    encoded = outbox._terminal_bytes(outbox._terminal_payload(
+        item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0))
+    assert len(encoded) == size
+    return item_id
+
+
+def test_states_dispositions_and_first_terminal_wins():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        absent = outbox.read_terminal_receipt(root, "missing", now=10.0)
+        assert absent == outbox.TerminalReceipt(
+            outbox.TerminalReceiptState.ABSENT, "missing", 0)
+        for index, disposition in enumerate(outbox.TerminalDisposition):
+            item_id = f"outcome-{index}"
+            receipt = outbox.record_terminal_receipt(
+                root, item_id, disposition, now=10.0 + index)
+            assert receipt.state is outbox.TerminalReceiptState.TERMINAL
+            assert receipt.disposition is disposition
+            assert outbox.read_terminal_receipt(
+                root, item_id, now=20.0) == receipt
+
+        first = outbox.record_terminal_receipt(
+            root, "one-winner", outbox.TerminalDisposition.DELIVERED, now=30.0)
+        second = outbox.record_terminal_receipt(
+            root, "one-winner", outbox.TerminalDisposition.NO_SEND, now=31.0)
+        assert second == first
+
+        invalid = [
+            (outbox.TerminalReceiptState.ABSENT, None, 1.0),
+            (outbox.TerminalReceiptState.ABSENT,
+             outbox.TerminalDisposition.DELIVERED, None),
+            (outbox.TerminalReceiptState.UNKNOWN, None, 1.0),
+            (outbox.TerminalReceiptState.UNKNOWN,
+             outbox.TerminalDisposition.DELIVERED, None),
+        ]
+        for state, disposition, recorded_at in invalid:
+            try:
+                outbox.TerminalReceipt(
+                    state, "invalid", 0, disposition, recorded_at)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("partial nonterminal receipt was accepted")
+
+
+def test_concurrent_writers_observe_one_terminal_winner():
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = multiprocessing.get_context("fork")
+        start = ctx.Event()
+        results = ctx.Queue()
+        dispositions = list(outbox.TerminalDisposition) * 2
+        workers = [ctx.Process(target=_race_record, args=(tmp, value, start, results))
+                   for value in dispositions]
+        for worker in workers:
+            worker.start()
+        start.set()
+        observed = [results.get(timeout=10) for _ in workers]
+        for worker in workers:
+            worker.join(timeout=10)
+            assert worker.exitcode == 0
+        assert len(set(observed)) == 1, observed
+        files = list((Path(tmp) / outbox.TERMINAL_RECEIPTS_DIR).glob("*/*.json"))
+        assert len(files) == 1, files
+
+
+def test_generation_and_path_identity_are_exact():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        ids = ["a/b", "a_b", "../escape", "snowman-☃"]
+        for item_id in ids:
+            outbox.record_terminal_receipt(
+                root, item_id, outbox.TerminalDisposition.DELIVERED, now=100.0)
+        paths = [outbox._terminal_receipt_path(root, item_id, 0) for item_id in ids]
+        assert len(set(paths)) == len(ids)
+        assert all(path.parent.parent == root / outbox.TERMINAL_RECEIPTS_DIR
+                   for path in paths)
+        assert all(len(path.stem) == 64 and path.parent.name == path.stem[:2]
+                   for path in paths)
+
+        zero = outbox.record_terminal_receipt(
+            root, "generation", outbox.TerminalDisposition.DELIVERED,
+            generation=0, now=101.0)
+        one = outbox.record_terminal_receipt(
+            root, "generation", outbox.TerminalDisposition.REDIRECTED,
+            generation=1, now=102.0)
+        assert zero.disposition is outbox.TerminalDisposition.DELIVERED
+        assert one.disposition is outbox.TerminalDisposition.REDIRECTED
+        assert outbox._terminal_receipt_path(root, "generation", 0) != \
+            outbox._terminal_receipt_path(root, "generation", 1)
+
+
+def test_corruption_is_unknown_and_record_never_overwrites_it():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        original = outbox.record_terminal_receipt(
+            root, "corrupt", outbox.TerminalDisposition.DELIVERED, now=100.0)
+        assert original.state is outbox.TerminalReceiptState.TERMINAL
+        path = outbox._terminal_receipt_path(root, "corrupt", 0)
+        path.write_bytes(b'{"schema":1')
+        before = path.read_bytes()
+        unknown = outbox.read_terminal_receipt(root, "corrupt", now=101.0)
+        assert unknown.state is outbox.TerminalReceiptState.UNKNOWN
+        refused = outbox.record_terminal_receipt(
+            root, "corrupt", outbox.TerminalDisposition.NO_SEND, now=102.0)
+        assert refused.state is outbox.TerminalReceiptState.UNKNOWN
+        assert path.read_bytes() == before
+
+        other = outbox.record_terminal_receipt(
+            root, "other", outbox.TerminalDisposition.DEDUPED, now=103.0)
+        assert other.state is outbox.TerminalReceiptState.TERMINAL
+        path.write_bytes(outbox._terminal_receipt_path(root, "other", 0).read_bytes())
+        assert outbox.read_terminal_receipt(
+            root, "corrupt", now=104.0).state is outbox.TerminalReceiptState.UNKNOWN
+
+
+def test_reader_rejects_every_semantically_invalid_record_shape():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        cases = []
+
+        item_id = "missing-fields"
+        cases.append((item_id, 0, {"schema": outbox.TERMINAL_RECEIPT_SCHEMA}))
+
+        item_id = "wrong-schema"
+        data = outbox._terminal_payload(
+            item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
+        data["schema"] += 1
+        cases.append((item_id, 0, data))
+
+        item_id = "empty-stored-item"
+        data = outbox._terminal_payload(
+            item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
+        data["item_id"] = ""
+        cases.append((item_id, 0, data))
+
+        item_id = "invalid-stored-generation"
+        data = outbox._terminal_payload(
+            item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
+        data["generation"] = True
+        cases.append((item_id, 0, data))
+
+        item_id = "invalid-recorded-at"
+        data = outbox._terminal_payload(
+            item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
+        data["recorded_at"] = "yesterday"
+        cases.append((item_id, 0, data))
+
+        item_id = "mismatched-generation"
+        data = outbox._terminal_payload(
+            item_id, 1, outbox.TerminalDisposition.DELIVERED, 100.0)
+        cases.append((item_id, 0, data))
+
+        item_id = "invalid-disposition"
+        data = outbox._terminal_payload(
+            item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
+        data["disposition"] = "maybe"
+        cases.append((item_id, 0, data))
+
+        item_id = "invalid-checksum"
+        data = outbox._terminal_payload(
+            item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
+        data["checksum"] = "0" * 64
+        cases.append((item_id, 0, data))
+
+        for item_id, generation, data in cases:
+            path = outbox._terminal_receipt_path(root, item_id, generation)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(outbox._terminal_bytes(data))
+            receipt = outbox.read_terminal_receipt(
+                root, item_id, generation=generation, now=101.0)
+            assert receipt.state is outbox.TerminalReceiptState.UNKNOWN, item_id
+
+        wrong_path_item = "wrong-path"
+        wrong_path = root / outbox.TERMINAL_RECEIPTS_DIR / "ff" / "wrong.json"
+        wrong_path.parent.mkdir(parents=True, exist_ok=True)
+        wrong_path.write_bytes(outbox._terminal_bytes(outbox._terminal_payload(
+            wrong_path_item, 0, outbox.TerminalDisposition.DELIVERED, 100.0)))
+        assert outbox._read_terminal_path(
+            wrong_path, wrong_path_item, 0).state is outbox.TerminalReceiptState.UNKNOWN
+
+
+def test_reader_open_failures_and_oversized_disk_record_are_unknown():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        item_id = "lstat-denied"
+        with mock.patch.object(outbox.os, "open", side_effect=FileNotFoundError()), \
+                mock.patch.object(Path, "lstat", side_effect=PermissionError()):
+            receipt = outbox.read_terminal_receipt(root, item_id, now=100.0)
+        assert receipt.state is outbox.TerminalReceiptState.UNKNOWN
+
+        item_id = "vanished-open-existing-name"
+        path = outbox._terminal_receipt_path(root, item_id, 0)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"present")
+        with mock.patch.object(outbox.os, "open", side_effect=FileNotFoundError()):
+            receipt = outbox.read_terminal_receipt(root, item_id, now=100.0)
+        assert receipt.state is outbox.TerminalReceiptState.UNKNOWN
+
+        with mock.patch.object(outbox.os, "open", side_effect=PermissionError()):
+            receipt = outbox.read_terminal_receipt(root, "open-denied", now=100.0)
+        assert receipt.state is outbox.TerminalReceiptState.UNKNOWN
+
+        item_id = "oversized-on-disk"
+        path = outbox._terminal_receipt_path(root, item_id, 0)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"x" * (outbox.TERMINAL_RECEIPT_MAX_BYTES + 1))
+        receipt = outbox.read_terminal_receipt(root, item_id, now=100.0)
+        assert receipt.state is outbox.TerminalReceiptState.UNKNOWN
+
+
+def test_fifo_receipt_returns_unknown_without_blocking():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        item_id = "fifo-receipt"
+        path = outbox._terminal_receipt_path(root, item_id, 0)
+        path.parent.mkdir(parents=True)
+        os.mkfifo(path)
+
+        ctx = multiprocessing.get_context("fork")
+        results = ctx.Queue()
+        worker = ctx.Process(target=_read_receipt_state, args=(root, item_id, results))
+        worker.start()
+        worker.join(timeout=2)
+        if worker.is_alive():
+            worker.terminate()
+            worker.join(timeout=2)
+            raise AssertionError("terminal receipt reader blocked on a FIFO")
+        assert worker.exitcode == 0
+        assert results.get(timeout=1) == outbox.TerminalReceiptState.UNKNOWN.value
+        direct = outbox.read_terminal_receipt(root, item_id, now=100.0)
+        assert direct.state is outbox.TerminalReceiptState.UNKNOWN
+
+
+def test_ttl_expiry_and_cleanup_are_conservative():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        outbox.record_terminal_receipt(
+            root, "expired", outbox.TerminalDisposition.DELIVERED,
+            now=10.0, ttl_seconds=5.0)
+        assert outbox.read_terminal_receipt(
+            root, "expired", now=15.0,
+            ttl_seconds=5.0).state is outbox.TerminalReceiptState.ABSENT
+        replacement = outbox.record_terminal_receipt(
+            root, "expired", outbox.TerminalDisposition.DEDUPED,
+            now=15.0, ttl_seconds=5.0)
+        assert replacement.disposition is outbox.TerminalDisposition.DEDUPED
+
+        path = outbox._terminal_receipt_path(root, "bad-old", 0)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"torn")
+        os.utime(path, (1.0, 1.0))
+        assert outbox.read_terminal_receipt(
+            root, "bad-old", now=20.0,
+            ttl_seconds=5.0).state is outbox.TerminalReceiptState.UNKNOWN
+        cleanup = outbox.cleanup_terminal_receipts(root, ttl_seconds=5.0, now=20.0)
+        assert cleanup.expired >= 1
+        assert cleanup.unknown >= 1
+        assert outbox.read_terminal_receipt(
+            root, "bad-old", now=20.0,
+            ttl_seconds=5.0).state is outbox.TerminalReceiptState.UNKNOWN
+
+
+def test_unknown_receipt_survives_ttl_and_overflow_cleanup():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        path = outbox._terminal_receipt_path(root, "protected-unknown", 0)
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"corrupt")
+        os.utime(path, (1.0, 1.0))
+
+        report = outbox.cleanup_terminal_receipts(
+            root, ttl_seconds=1.0, max_records=0, now=100.0)
+
+        assert path.read_bytes() == b"corrupt"
+        assert outbox.read_terminal_receipt(
+            root, "protected-unknown", now=100.0,
+            ttl_seconds=1.0).state is outbox.TerminalReceiptState.UNKNOWN
+        assert report.unknown == 1
+        assert report.kept == 1
+        assert report.incomplete is True
+
+
+def test_explicit_cleanup_finishes_preexisting_overflow():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        shard = root / outbox.TERMINAL_RECEIPTS_DIR / "00"
+        shard.mkdir(parents=True)
+        count = outbox.TERMINAL_RECEIPT_SWEEP_BATCH + 8
+        written = 0
+        candidate = 0
+        while written < count:
+            item_id = f"preexisting-{candidate}"
+            candidate += 1
+            digest = outbox._terminal_digest(item_id, 0)
+            if not digest.startswith("00"):
+                continue
+            payload = outbox._terminal_payload(
+                item_id, 0, outbox.TerminalDisposition.DELIVERED, 100.0)
+            (shard / f"{digest}.json").write_bytes(outbox._terminal_bytes(payload))
+            written += 1
+        report = outbox.cleanup_terminal_receipts(
+            root, max_records=0, now=100.0)
+        assert not list(shard.glob("*.json"))
+        assert report.overflow == count
+        assert report.kept == 0
+        assert report.incomplete is False
+
+
+def test_cleanup_removes_recognized_temps_and_ignores_foreign_names():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        shard_name = "aa"
+        shard = root / outbox.TERMINAL_RECEIPTS_DIR / shard_name
+        shard.mkdir(parents=True)
+        unrelated = shard / "short.json"
+        malformed_temp = shard / ".not-a-digest.token.tmp"
+        digest = shard_name + "0" * 62
+        recognized_temp = shard / f".{digest}.token.tmp"
+        unrelated.write_bytes(b"leave me")
+        malformed_temp.write_bytes(b"leave me too")
+        recognized_temp.write_bytes(b"orphaned publication")
+
+        report = outbox.cleanup_terminal_receipts(root, now=100.0)
+        assert report.stale_temps == 1
+        assert not recognized_temp.exists()
+        assert unrelated.read_bytes() == b"leave me"
+        assert malformed_temp.read_bytes() == b"leave me too"
+
+
+def test_cleanup_keeps_entry_when_identity_recheck_cannot_stat_it():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        item_id = "same-stat-denied"
+        outbox.record_terminal_receipt(
+            root, item_id, outbox.TerminalDisposition.DELIVERED, now=100.0)
+        path = outbox._terminal_receipt_path(root, item_id, 0)
+        real_lstat = Path.lstat
+        target_calls = 0
+
+        def deny_recheck(candidate):
+            nonlocal target_calls
+            if candidate == path:
+                target_calls += 1
+                if target_calls > 1:
+                    raise PermissionError("injected identity recheck denial")
+            return real_lstat(candidate)
+
+        with mock.patch.object(Path, "lstat", deny_recheck):
+            report = outbox.cleanup_terminal_receipts(
+                root, ttl_seconds=0.0, max_records=0, now=101.0)
+        assert target_calls >= 2
+        assert path.exists()
+        assert report.kept == 1
+        assert report.incomplete is True
+
+
+def test_indeterminate_receipt_survives_capacity_pressure_and_blocks_publication():
+    item_a = "indeterminate-a"
+    shard_name = outbox._terminal_digest(item_a, 0)[:2]
+    for candidate in range(10_000):
+        item_b = f"capacity-b-{candidate}"
+        if outbox._terminal_digest(item_b, 0).startswith(shard_name):
+            break
+    else:
+        raise AssertionError("could not find a colliding receipt shard")
+
+    with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(outbox, "TERMINAL_RECEIPT_MAX_RECORDS", 256):
+        root = Path(tmp)
+        path_a = outbox._terminal_receipt_path(root, item_a, 0)
+        path_a.parent.mkdir(parents=True)
+        path_a.write_bytes(b"torn")
+        os.utime(path_a, (1.0, 1.0))
+
+        refused = outbox.record_terminal_receipt(
+            root, item_b, outbox.TerminalDisposition.DELIVERED,
+            now=100.0, ttl_seconds=0.0)
+        assert refused.state is outbox.TerminalReceiptState.UNKNOWN
+        assert outbox.read_terminal_receipt(
+            root, item_a, now=100.0,
+            ttl_seconds=0.0).state is outbox.TerminalReceiptState.UNKNOWN
+        assert not outbox._terminal_receipt_path(root, item_b, 0).exists()
+
+        report = outbox.cleanup_terminal_receipts(
+            root, ttl_seconds=0.0, max_records=0, now=100.0)
+        assert report.incomplete is True
+        assert report.unknown >= 1
+        assert report.kept == 1
+        assert path_a.read_bytes() == b"torn"
+
+
+def test_unreadable_shard_blocks_publication_and_marks_cleanup_incomplete():
+    item_a = "unreadable-shard-a"
+    shard_name = outbox._terminal_digest(item_a, 0)[:2]
+    for candidate in range(10_000):
+        item_b = f"unreadable-shard-b-{candidate}"
+        if outbox._terminal_digest(item_b, 0).startswith(shard_name):
+            break
+    else:
+        raise AssertionError("could not find a colliding receipt shard")
+
+    with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(outbox, "TERMINAL_RECEIPT_MAX_RECORDS", 256):
+        root = Path(tmp)
+        outbox.record_terminal_receipt(
+            root, item_a, outbox.TerminalDisposition.DELIVERED, now=100.0)
+        path_b = outbox._terminal_receipt_path(root, item_b, 0)
+        with mock.patch.object(
+                outbox.os, "scandir", side_effect=PermissionError("injected")):
+            refused = outbox.record_terminal_receipt(
+                root, item_b, outbox.TerminalDisposition.DELIVERED, now=101.0)
+            report = outbox.cleanup_terminal_receipts(
+                root, max_records=256, now=101.0)
+        assert refused.state is outbox.TerminalReceiptState.UNKNOWN
+        assert not path_b.exists()
+        assert report.incomplete is True
+        assert report.unknown >= 1
+
+
+def test_unstatable_receipt_entry_blocks_same_shard_publication():
+    item_a = "unstatable-entry-a"
+    shard_name = outbox._terminal_digest(item_a, 0)[:2]
+    for candidate in range(10_000):
+        item_b = f"unstatable-entry-b-{candidate}"
+        if outbox._terminal_digest(item_b, 0).startswith(shard_name):
+            break
+    else:
+        raise AssertionError("could not find a colliding receipt shard")
+
+    with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(outbox, "TERMINAL_RECEIPT_MAX_RECORDS", 256):
+        root = Path(tmp)
+        outbox.record_terminal_receipt(
+            root, item_a, outbox.TerminalDisposition.DELIVERED, now=100.0)
+        path_a = outbox._terminal_receipt_path(root, item_a, 0)
+        path_b = outbox._terminal_receipt_path(root, item_b, 0)
+        real_lstat = Path.lstat
+
+        def selective_lstat(path):
+            if path == path_a:
+                raise PermissionError("injected")
+            return real_lstat(path)
+
+        with mock.patch.object(Path, "lstat", selective_lstat):
+            refused = outbox.record_terminal_receipt(
+                root, item_b, outbox.TerminalDisposition.DELIVERED, now=101.0)
+        assert refused.state is outbox.TerminalReceiptState.UNKNOWN
+        assert path_a.exists()
+        assert not path_b.exists()
+
+
+def test_production_writer_enforces_shard_bound():
+    buckets = {}
+    for number in range(10_000):
+        item_id = f"bounded-{number}"
+        shard = outbox._terminal_digest(item_id, 0)[:2]
+        buckets.setdefault(shard, []).append(item_id)
+        if len(buckets[shard]) == 3:
+            same_shard = buckets[shard]
+            break
+    else:
+        raise AssertionError("could not find three ids in one receipt shard")
+
+    with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(outbox, "TERMINAL_RECEIPT_MAX_RECORDS", 512):
+        root = Path(tmp)
+        for index, item_id in enumerate(same_shard):
+            outbox.record_terminal_receipt(
+                root, item_id, outbox.TerminalDisposition.DELIVERED,
+                now=100.0 + index)
+        shard_dir = outbox._terminal_receipt_path(root, same_shard[0], 0).parent
+        assert len(list(shard_dir.glob("*.json"))) == 2
+        assert outbox.read_terminal_receipt(
+            root, same_shard[0], now=103.0).state is outbox.TerminalReceiptState.ABSENT
+        for item_id in same_shard[1:]:
+            assert outbox.read_terminal_receipt(
+                root, item_id, now=103.0).state is outbox.TerminalReceiptState.TERMINAL
+
+    with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(outbox, "TERMINAL_RECEIPT_MAX_RECORDS", 0):
+        refused = outbox.record_terminal_receipt(
+            tmp, "zero-capacity", outbox.TerminalDisposition.DELIVERED, now=100.0)
+        assert refused.state is outbox.TerminalReceiptState.UNKNOWN
+        assert not list(Path(tmp).rglob("*.json"))
+
+
+def test_receipt_directory_type_collisions_fail_without_replacement():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        receipt_root = root / outbox.TERMINAL_RECEIPTS_DIR
+        receipt_root.write_bytes(b"not a directory")
+        digest = outbox._terminal_digest("root-collision", 0)
+        try:
+            outbox._ensure_terminal_receipts_dir(root, digest)
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError("receipt-root file was treated as a directory")
+        assert receipt_root.read_bytes() == b"not a directory"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        digest = outbox._terminal_digest("shard-collision", 0)
+        receipt_root = root / outbox.TERMINAL_RECEIPTS_DIR
+        receipt_root.mkdir()
+        shard = outbox._terminal_receipt_shard(root, digest)
+        shard.write_bytes(b"not a directory")
+        try:
+            outbox._ensure_terminal_receipts_dir(root, digest)
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError("receipt-shard file was treated as a directory")
+        assert shard.read_bytes() == b"not a directory"
+
+
+def test_expiry_unlink_races_fail_closed_or_publish_a_replacement():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        item_id = "expiry-vanished"
+        outbox.record_terminal_receipt(
+            root, item_id, outbox.TerminalDisposition.DELIVERED, now=100.0)
+        path = outbox._terminal_receipt_path(root, item_id, 0)
+        real_unlink = Path.unlink
+        injected = False
+
+        def vanish_then_report_missing(candidate, *args, **kwargs):
+            nonlocal injected
+            if candidate == path and not injected:
+                injected = True
+                real_unlink(candidate)
+                raise FileNotFoundError("injected expiry race")
+            return real_unlink(candidate, *args, **kwargs)
+
+        with mock.patch.object(Path, "unlink", vanish_then_report_missing):
+            replacement = outbox.record_terminal_receipt(
+                root, item_id, outbox.TerminalDisposition.DEDUPED,
+                now=101.0, ttl_seconds=0.0)
+        assert injected is True
+        assert replacement.disposition is outbox.TerminalDisposition.DEDUPED
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        item_id = "expiry-unlink-denied"
+        original = outbox.record_terminal_receipt(
+            root, item_id, outbox.TerminalDisposition.DELIVERED, now=100.0)
+        path = outbox._terminal_receipt_path(root, item_id, 0)
+        before = path.read_bytes()
+        real_unlink = Path.unlink
+
+        def deny_target_unlink(candidate, *args, **kwargs):
+            if candidate == path:
+                raise PermissionError("injected expiry denial")
+            return real_unlink(candidate, *args, **kwargs)
+
+        with mock.patch.object(Path, "unlink", deny_target_unlink):
+            refused = outbox.record_terminal_receipt(
+                root, item_id, outbox.TerminalDisposition.DEDUPED,
+                now=101.0, ttl_seconds=0.0)
+        assert original.state is outbox.TerminalReceiptState.TERMINAL
+        assert refused.state is outbox.TerminalReceiptState.UNKNOWN
+        assert path.read_bytes() == before
+
+
+def test_atomic_link_collision_returns_the_published_winner():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        real_link = outbox.os.link
+
+        def publish_then_report_collision(source, destination):
+            real_link(source, destination)
+            raise FileExistsError("injected publication collision")
+
+        with mock.patch.object(outbox.os, "link", publish_then_report_collision):
+            receipt = outbox.record_terminal_receipt(
+                root, "link-collision", outbox.TerminalDisposition.DELIVERED,
+                now=100.0)
+        assert receipt.state is outbox.TerminalReceiptState.TERMINAL
+        assert outbox.read_terminal_receipt(
+            root, "link-collision", now=101.0) == receipt
+
+
+def test_publication_fsyncs_content_before_atomic_link_and_directory_after():
+    with tempfile.TemporaryDirectory() as tmp:
+        events = []
+        real_fsync = outbox.os.fsync
+        real_link = outbox.os.link
+
+        def traced_fsync(fd):
+            events.append(("fsync", stat.S_ISDIR(os.fstat(fd).st_mode)))
+            return real_fsync(fd)
+
+        def traced_link(source, destination):
+            payload = json.loads(Path(source).read_text())
+            assert payload["item_id"] == "durable"
+            assert not Path(destination).exists()
+            assert ("fsync", False) in events
+            events.append(("link", False))
+            return real_link(source, destination)
+
+        with mock.patch.object(outbox.os, "fsync", traced_fsync), \
+                mock.patch.object(outbox.os, "link", traced_link):
+            receipt = outbox.record_terminal_receipt(
+                tmp, "durable", outbox.TerminalDisposition.DELIVERED, now=100.0)
+        assert receipt.state is outbox.TerminalReceiptState.TERMINAL
+        link_index = events.index(("link", False))
+        assert any(event == ("fsync", True) for event in events[link_index + 1:])
+
+        destination = outbox._terminal_receipt_path(Path(tmp), "failed-link", 0)
+        with mock.patch.object(outbox.os, "link",
+                               side_effect=OSError(errno.EIO, "injected")):
+            try:
+                outbox.record_terminal_receipt(
+                    tmp, "failed-link", outbox.TerminalDisposition.DELIVERED,
+                    now=101.0)
+            except OSError as exc:
+                assert exc.errno == errno.EIO
+            else:
+                raise AssertionError("link failure was swallowed")
+        assert not destination.exists()
+        assert not list(destination.parent.glob("*.tmp"))
+
+
+def test_first_root_creation_fsyncs_parent_before_publication():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "new-receipt-root"
+        assert not root.exists()
+        events = []
+        real_fsync_directory = outbox._fsync_directory
+        real_link = outbox.os.link
+
+        def traced_fsync_directory(path):
+            events.append(("fsync-directory", Path(path)))
+            return real_fsync_directory(path)
+
+        def traced_link(source, destination):
+            events.append(("link", Path(destination)))
+            return real_link(source, destination)
+
+        with mock.patch.object(outbox, "_fsync_directory", traced_fsync_directory), \
+                mock.patch.object(outbox.os, "link", traced_link):
+            receipt = outbox.record_terminal_receipt(
+                root, "new-root", outbox.TerminalDisposition.DELIVERED, now=100.0)
+
+        assert receipt.state is outbox.TerminalReceiptState.TERMINAL
+        parent_fsync = events.index(("fsync-directory", root.parent))
+        publication = next(index for index, event in enumerate(events)
+                           if event[0] == "link")
+        assert parent_fsync < publication, events
+
+
+def test_record_at_reader_size_limit_round_trips_as_terminal():
+    item_id = _item_id_for_record_size(outbox.TERMINAL_RECEIPT_MAX_BYTES)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        receipt = outbox.record_terminal_receipt(
+            root, item_id, outbox.TerminalDisposition.DELIVERED, now=100.0)
+        path = outbox._terminal_receipt_path(root, item_id, 0)
+        assert receipt.state is outbox.TerminalReceiptState.TERMINAL
+        assert path.stat().st_size == outbox.TERMINAL_RECEIPT_MAX_BYTES
+        assert outbox.read_terminal_receipt(
+            root, item_id, now=101.0) == receipt
+
+
+def test_record_over_reader_size_limit_is_rejected_before_publication():
+    item_id = _item_id_for_record_size(outbox.TERMINAL_RECEIPT_MAX_BYTES + 1)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        try:
+            outbox.record_terminal_receipt(
+                root, item_id, outbox.TerminalDisposition.DELIVERED, now=100.0)
+        except ValueError as exc:
+            assert "size limit" in str(exc)
+        else:
+            raise AssertionError("oversized terminal receipt was published")
+        assert not outbox._terminal_receipt_path(root, item_id, 0).exists()
+        assert outbox.read_terminal_receipt(
+            root, item_id, now=101.0).state is outbox.TerminalReceiptState.ABSENT
+
+
+def test_invalid_identity_and_clock_inputs_are_rejected():
+    with tempfile.TemporaryDirectory() as tmp:
+        invalid_calls = [
+            lambda: outbox.read_terminal_receipt(tmp, "", now=1.0),
+            lambda: outbox.read_terminal_receipt(tmp, "x", generation=-1, now=1.0),
+            lambda: outbox.read_terminal_receipt(tmp, "x", generation=True, now=1.0),
+            lambda: outbox.read_terminal_receipt(tmp, "x", now=float("nan")),
+            lambda: outbox.read_terminal_receipt(tmp, "x", now=1.0, ttl_seconds=-1.0),
+            lambda: outbox.record_terminal_receipt(tmp, "x", "bogus", now=1.0),
+        ]
+        for call in invalid_calls:
+            try:
+                call()
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("invalid terminal receipt input was accepted")
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"  ok  {name}")
+    print("PASS - durable terminal receipt contract")


### PR DESCRIPTION
Closes #3172.

## What changed and why

Normal Discord task results can be sent again when a producer recreates `results/<task-id>.txt` after the first copy was successfully delivered and archived. The archived task lets orphan routing recover the same channel, while the old crash sentinel has already been cleared.

This adds a shared, bounded terminal-receipt store in `src/outbox.py` and makes both the orphan and already-pending Discord result paths consult it before sending. A retained terminal receipt retires a recreated copy collision-safely without another provider call. Corrupt, unreadable, or legacy one-bit evidence is `UNKNOWN` and fails closed rather than being relabeled as delivered.

Persistent `UNKNOWN` state is intentionally not auto-deleted: doing so would turn uncertainty into `ABSENT` and permit the duplicate send this PR prevents. It is now owner-visible through the `terminal-receipts` health check, which reports a warning and the manual reconciliation action while preserving the held result and receipt.

This is intentionally a staged **post-success result-recreation fence**, not exactly-once delivery or complete DeliveryCore adoption. The PR is ready for review as the narrow fix; the remaining outbound-migration work is listed below.

## Review first

1. `src/discord-bridge.py` — receipt checks on orphan/pending paths and terminal recording.
2. `src/outbox.py` — shared receipt identity, atomic persistence, bounded retention, and fail-closed reads/cleanup.
3. `src/health-check.py` — owner-visible warning for receipt state that needs reconciliation.
4. `tests/discord-recreated-result-idempotency.test.py` — real `poll_results()` regression, restart, pending, corrupt, legacy, and archive-failure cases.
5. The terminal-receipt and health-check suites — persistence, race, corruption, cleanup, capacity, legacy-sentinel, and operator-visibility contracts.

The canonical outbox module is synced verbatim into `packages/ag2-sparrow/ag2_sparrow/outbox.py`.

## Behavior proved

- First normal Discord result: one external send.
- Same task-id result recreated with identical or changed content: no second send while the receipt is retained.
- Late copies remain available in collision-safe archives instead of replacing earlier evidence.
- `NO_SEND` / `DEDUPED` tasks do not resurrect as plain replies.
- Failed delivery remains retryable; corrupt/unreadable/legacy-ambiguous evidence parks instead of guessing.
- Protected `UNKNOWN` state survives both TTL and overflow pressure.
- Persistent `UNKNOWN` state produces a health warning without deleting evidence.
- The decision survives a fresh bridge-module/process restart.
- Legacy sentinel creation, removal, and idempotent removal remain covered.

## Before / after

Same behavioral test against current parent `565db9fc`:

```text
$ REPO_UNDER_TEST=/private/tmp/sutando-pr3174-parent-565db /usr/bin/python3 -u tests/discord-recreated-result-idempotency.test.py DiscordRecreatedResultTest.test_recreated_confirmed_result_is_retired_without_another_send
  Replied: first confirmed answer...
  Replied: first confirmed answer...
  Replied: completion narration written after the answer...
FAIL
AssertionError: ['first confirmed answer', 'first confirmed answer',
'completion narration written after the answer'] != ['first confirmed answer']

Ran 1 test in 0.012s
FAILED (failures=1)
```

At `b194da06`:

```text
$ /usr/bin/python3 -u tests/discord-recreated-result-idempotency.test.py DiscordRecreatedResultTest.test_recreated_confirmed_result_is_retired_without_another_send
  Replied: first confirmed answer...
  Skipped recreated terminal result: task-2000000000001
  Skipped recreated terminal result: task-2000000000001
ok

Ran 1 test in 0.013s
OK
```

## Review-feedback evidence

- The mutation that removes `UNKNOWN` protection from cleanup now fails `test_unknown_receipt_survives_ttl_and_overflow_cleanup`: an expired corrupt receipt is required to survive both TTL and zero-capacity overflow pressure and remain `UNKNOWN`.
- The legacy tests map directly to the prior contracts: successful marking starts from a missing sentinel directory; clearing asserts the sentinel is removed without erasing the shared receipt; a second clear is explicitly idempotent.
- A corrupt receipt now yields an owner-visible `terminal-receipts: warn`, remains on disk, and still reads `UNKNOWN`. Inspection failures also warn rather than aborting the health run.

## Tests

Passed under the repository's macOS system Python 3.9.6 and Python 3.13.5:

```text
outbox-terminal-receipts.test.py                         24 passed
outbox-terminal-cleanup-coverage.test.py                 17 passed
discord-recreated-result-idempotency.test.py            12 passed
discord-bridge-delivery-sentinel.test.py                 14 passed
health-check-terminal-receipts.test.py                    5 passed
discord-bridge-archive-failure-keeps-the-file.test.py    15 passed
orphan-result-routes.test.py                             30 passed
sparrow-outbox-claim-protocol.test.py                    22 passed
delivery-core-contract.test.py                           38 passed
discord-delivery-provider.test.py                        13 checks passed
```

Also passed:

```text
all tests/outbox*.test.py
all 79 tests/health-check*.test.py files
ruff 0.15.22 over changed Python files
lint-hermetic-bridge-tests.test.py --diff
tests/review-checks.test.sh
scripts/gen-src-map.py --check
packages/ag2-sparrow/tools/sync_from_src.py --check
git diff --check
```

`npm run test:py` was also attempted: 578 test files ran, with 13 failures outside the changed paths attributable to this host's unrelated prerequisites/ambient state (default-Python Discord dependency, optional `tmux`, Swift toolchain compilation, unavailable full secret-scanner dependency, and ambient vault/config fixtures). The changed-path and adjacent delivery/health suites above are green.

## Live post-restart check

I ran the bridge from a detached branch worktree against the owner's real workspace at staging commit `4c1faf0a`, then restored the normal live checkout. The successful-send/restart path exercised here is unchanged at current head; later changes hardened fail-closed cleanup/durability, added review coverage and health visibility, and rebased onto current main.

One synthetic normal Discord result was delivered at `2026-08-19T19:25:15Z`. After stopping and starting a fresh bridge process, I recreated the same task-id result with changed content. The fresh process suppressed it at `19:25:51Z`:

```text
2026-08-19T19:25:15Z  task-live-3172-0001  delivered  discord
2026-08-19T19:25:51Z  task-live-3172-0001  deduped    discord

outbox entries for task-live-3172-0001: 1
Discord messages matching the verification text: 1
archive/task-live-3172-0001.txt    sha256 56b0a50933ba5c9abea5f2f5014c2c2d20938028ff55c73c3a78b92236d40ff3
archive/task-live-3172-0001.txt.1  sha256 1bec64dbbc9d6318f757cfee82fd7b4c75f98b455bdd9017c33a185ceb63476d
live result remaining: 0
```

## Documentation / paths / deployment

- User docs: N/A. This repairs internal delivery behavior and adds a self-explanatory health row; it adds no configuration or UI.
- Hardcoded host paths: none added.
- Migration/config/permissions: none. Receipt state is local under the ignored results/outbox root.
- Privacy: receipt filenames are hashes; mode is `0600`; records contain only opaque task id, generation, disposition, timestamp, and checksum—no message content, credentials, channel id, or user id.
- Rollback: reverting the commit restores the previous behavior. Archived results remain ordinary evidence files.
- Stacked PR: N/A.

## Known gaps / follow-up work

- Normal `poll_results` still calls Discord directly instead of binding the full `ClaimBackend` + `DeliveryCore` + `DiscordDeliveryProvider` path required as the target architecture by `AGENTS.md`. This PR only centralizes the durable terminal decision and removes the measured post-archive recreation loop.
- It does not close the concurrent-drainer race, send-success-to-receipt crash window, or partial multi-chunk/file delivery window. Those require the full outbound migration with per-part identities/provider receipts.
- Discord currently uses receipt generation `0`. Task ids must remain immutable and unique; an intentional resend must mint a new task id until `resend_epoch` is wired.
- Suppression is retention-bounded: valid receipts expire after 30 days and are subject to conservative per-shard capacity. Protected `UNKNOWN` state is never evicted merely to make room; it fails closed.
- `UNKNOWN` results stay live and now surface through health-check. Repair remains deliberately manual: confirm the delivery outcome, then remove only the affected receipt. Automated reconciliation is follow-up work because guessing would reintroduce duplicate delivery.
