### PR TITLE
fix(team-guard): [no-send] means no send to the channel, not a notice in its place

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
+++ b/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
@@ -367,9 +367,8 @@ def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
     verdict = classify_result_for_tier(
         body, tier, repo, secret_filter, scan_sensitive_data)
     if suppress_journal is not None:
-        # The stub is the module's existing policy for what a guarded
-        # suppression may say; this only adds the record that lets a
-        # non-journaled transport use it. Do not re-derive the body here.
+        # The stub is this module's existing policy; the journal only adds
+        # the record. Never mint a body here.
         stub = suppression_stub_for_tier(body, tier)
         if stub is not None:
             state_dir, task_id = suppress_journal

--- a/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
+++ b/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
@@ -193,6 +193,7 @@ VERDICT_DELIVER = "deliver"
 VERDICT_LEAK = "leak"
 VERDICT_SUPPRESS = "suppress"
 WITHHELD_RESULT_DIR = "withheld-team-results"
+SUPPRESSED_RESULT_DIR = "suppressed-team-results"
 
 
 class TeamResultVerdict(NamedTuple):
@@ -279,6 +280,50 @@ def materialize_withheld_verdict(verdict: TeamResultVerdict, body: str,
         VERDICT_SUPPRESS, "[no-send]", f"{verdict.reason}; pending private owner review")
 
 
+def suppressed_record_path(state_dir: Path, task_id: str) -> Path:
+    return Path(state_dir) / SUPPRESSED_RESULT_DIR / f"{withheld_review_id(task_id)}.json"
+
+
+def materialize_suppressed_verdict(verdict: TeamResultVerdict, body: str,
+                                   state_dir: Path, task_id: str, context=None,
+                                   agent_id: str = "", now=None) -> TeamResultVerdict:
+    """Realise a notice-bearing SUPPRESS as a journaled silent close.
+
+    The record requirement is the policy, not the notice: once the suppression
+    is durably journaled, posting prose about marker mechanics into a human
+    channel is noise. Fail-CLOSED -- if the journal cannot be written the
+    notice stands, so the record is never silently dropped.
+    """
+    if verdict.kind != VERDICT_SUPPRESS or verdict.body != TEAM_SUPPRESS_RESULT:
+        return verdict                     # already silent, or not a suppress
+    timestamp = float(time.time() if now is None else now)
+    directory = Path(state_dir) / SUPPRESSED_RESULT_DIR
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+    except OSError:
+        return verdict
+    payload = {
+        "schema_version": 1,
+        "record_id": withheld_review_id(task_id),
+        "status": "suppressed_silent_close",
+        "created_at": datetime.fromtimestamp(timestamp, timezone.utc).isoformat(),
+        "task_id": task_id,
+        "agent_id": agent_id,
+        "reason": verdict.reason,
+        "context": _bounded_context(context),
+        "suppressed_body": body,
+    }
+    try:
+        saved = _write_artifact(suppressed_record_path(state_dir, task_id), payload)
+    except Exception:  # noqa: BLE001 -- storage failure must remain fail-closed
+        saved = False
+    if not saved:
+        return verdict
+    return TeamResultVerdict(
+        VERDICT_SUPPRESS, "[no-send]", f"{verdict.reason}; journaled silent close")
+
+
 def classify_result_for_tier(body: str, tier, repo: Path,
                              secret_filter=None,
                              scan_sensitive_data: bool = True) -> TeamResultVerdict:
@@ -304,13 +349,21 @@ def classify_result_for_tier(body: str, tier, repo: Path,
 
 
 def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
-                          scan_sensitive_data: bool = True):
+                          scan_sensitive_data: bool = True, *,
+                          suppress_journal=None):
     """Consumer-facing gate: returns (safe_body, withheld_reason).
 
     Returns a body rather than raising, so a caller cannot deliver the raw text
     by catching an exception -- the safe body is the only one it is handed.
     Derived from classify_result_for_tier so the verdict has exactly one owner.
+
+    suppress_journal: `(state_dir, task_id)` from an adapter whose surface is a
+    human channel. The notice becomes a journaled silent close there; adapters
+    that omit it keep the posted notice.
     """
     verdict = classify_result_for_tier(
         body, tier, repo, secret_filter, scan_sensitive_data)
+    if suppress_journal is not None:
+        state_dir, task_id = suppress_journal
+        verdict = materialize_suppressed_verdict(verdict, body, state_dir, task_id)
     return verdict.body, verdict.reason

--- a/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
+++ b/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
@@ -286,13 +286,16 @@ def suppressed_record_path(state_dir: Path, task_id: str) -> Path:
 
 def materialize_suppressed_verdict(verdict: TeamResultVerdict, body: str,
                                    state_dir: Path, task_id: str, context=None,
-                                   agent_id: str = "", now=None) -> TeamResultVerdict:
-    """Realise a notice-bearing SUPPRESS as a journaled silent close.
+                                   agent_id: str = "", now=None,
+                                   stub: str = "[no-send]") -> TeamResultVerdict:
+    """Realise a notice-bearing SUPPRESS as a journaled close carrying `stub`.
 
     The record requirement is the policy, not the notice: once the suppression
     is durably journaled, posting prose about marker mechanics into a human
-    channel is noise. Fail-CLOSED -- if the journal cannot be written the
-    notice stands, so the record is never silently dropped.
+    channel is noise. `stub` must come from suppression_stub_for_tier -- it is
+    the canonical, sender-uninfluenced body, and it preserves a dedup target
+    that a flat "[no-send]" would drop. Fail-CLOSED -- if the journal cannot be
+    written the notice stands, so the record is never silently dropped.
     """
     if verdict.kind != VERDICT_SUPPRESS or verdict.body != TEAM_SUPPRESS_RESULT:
         return verdict                     # already silent, or not a suppress
@@ -321,7 +324,7 @@ def materialize_suppressed_verdict(verdict: TeamResultVerdict, body: str,
     if not saved:
         return verdict
     return TeamResultVerdict(
-        VERDICT_SUPPRESS, "[no-send]", f"{verdict.reason}; journaled silent close")
+        VERDICT_SUPPRESS, stub, f"{verdict.reason}; journaled silent close")
 
 
 def classify_result_for_tier(body: str, tier, repo: Path,
@@ -364,6 +367,12 @@ def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
     verdict = classify_result_for_tier(
         body, tier, repo, secret_filter, scan_sensitive_data)
     if suppress_journal is not None:
-        state_dir, task_id = suppress_journal
-        verdict = materialize_suppressed_verdict(verdict, body, state_dir, task_id)
+        # The stub is the module's existing policy for what a guarded
+        # suppression may say; this only adds the record that lets a
+        # non-journaled transport use it. Do not re-derive the body here.
+        stub = suppression_stub_for_tier(body, tier)
+        if stub is not None:
+            state_dir, task_id = suppress_journal
+            verdict = materialize_suppressed_verdict(
+                verdict, body, state_dir, task_id, stub=stub)
     return verdict.body, verdict.reason

--- a/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
+++ b/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
@@ -286,8 +286,8 @@ def suppressed_record_path(state_dir: Path, task_id: str) -> Path:
 
 def materialize_suppressed_verdict(verdict: TeamResultVerdict, body: str,
                                    state_dir: Path, task_id: str, context=None,
-                                   agent_id: str = "", now=None,
-                                   stub: str = "[no-send]") -> TeamResultVerdict:
+                                   agent_id: str = "", now=None, *,
+                                   stub: str) -> TeamResultVerdict:
     """Realise a notice-bearing SUPPRESS as a journaled close carrying `stub`.
 
     The record requirement is the policy, not the notice: once the suppression

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -4730,7 +4730,10 @@ async def poll_results():
                 if _guard_tier == "unknown":
                     _guard_tf = find_task_file(TASKS_DIR, task_id)
                     _guard_tier = _resolve_task_tier(_guard_tf) if _guard_tf else "guest"
-                reply_text, _withheld = guard_result_for_tier(reply_text, _guard_tier, REPO)
+                # A Discord channel is a human surface: the suppression is journaled
+                # under STATE_DIR and closed silently rather than posted as prose.
+                reply_text, _withheld = guard_result_for_tier(reply_text, _guard_tier, REPO,
+                                                             suppress_journal=(STATE_DIR, task_id))
                 if _withheld:
                     print(f"  [team-guard] withheld result for {task_id} "
                           f"(tier={_guard_tier}): {_withheld}", flush=True)

--- a/src/team_result_guard.py
+++ b/src/team_result_guard.py
@@ -367,9 +367,8 @@ def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
     verdict = classify_result_for_tier(
         body, tier, repo, secret_filter, scan_sensitive_data)
     if suppress_journal is not None:
-        # The stub is the module's existing policy for what a guarded
-        # suppression may say; this only adds the record that lets a
-        # non-journaled transport use it. Do not re-derive the body here.
+        # The stub is this module's existing policy; the journal only adds
+        # the record. Never mint a body here.
         stub = suppression_stub_for_tier(body, tier)
         if stub is not None:
             state_dir, task_id = suppress_journal

--- a/src/team_result_guard.py
+++ b/src/team_result_guard.py
@@ -193,6 +193,7 @@ VERDICT_DELIVER = "deliver"
 VERDICT_LEAK = "leak"
 VERDICT_SUPPRESS = "suppress"
 WITHHELD_RESULT_DIR = "withheld-team-results"
+SUPPRESSED_RESULT_DIR = "suppressed-team-results"
 
 
 class TeamResultVerdict(NamedTuple):
@@ -279,6 +280,50 @@ def materialize_withheld_verdict(verdict: TeamResultVerdict, body: str,
         VERDICT_SUPPRESS, "[no-send]", f"{verdict.reason}; pending private owner review")
 
 
+def suppressed_record_path(state_dir: Path, task_id: str) -> Path:
+    return Path(state_dir) / SUPPRESSED_RESULT_DIR / f"{withheld_review_id(task_id)}.json"
+
+
+def materialize_suppressed_verdict(verdict: TeamResultVerdict, body: str,
+                                   state_dir: Path, task_id: str, context=None,
+                                   agent_id: str = "", now=None) -> TeamResultVerdict:
+    """Realise a notice-bearing SUPPRESS as a journaled silent close.
+
+    The record requirement is the policy, not the notice: once the suppression
+    is durably journaled, posting prose about marker mechanics into a human
+    channel is noise. Fail-CLOSED -- if the journal cannot be written the
+    notice stands, so the record is never silently dropped.
+    """
+    if verdict.kind != VERDICT_SUPPRESS or verdict.body != TEAM_SUPPRESS_RESULT:
+        return verdict                     # already silent, or not a suppress
+    timestamp = float(time.time() if now is None else now)
+    directory = Path(state_dir) / SUPPRESSED_RESULT_DIR
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+    except OSError:
+        return verdict
+    payload = {
+        "schema_version": 1,
+        "record_id": withheld_review_id(task_id),
+        "status": "suppressed_silent_close",
+        "created_at": datetime.fromtimestamp(timestamp, timezone.utc).isoformat(),
+        "task_id": task_id,
+        "agent_id": agent_id,
+        "reason": verdict.reason,
+        "context": _bounded_context(context),
+        "suppressed_body": body,
+    }
+    try:
+        saved = _write_artifact(suppressed_record_path(state_dir, task_id), payload)
+    except Exception:  # noqa: BLE001 -- storage failure must remain fail-closed
+        saved = False
+    if not saved:
+        return verdict
+    return TeamResultVerdict(
+        VERDICT_SUPPRESS, "[no-send]", f"{verdict.reason}; journaled silent close")
+
+
 def classify_result_for_tier(body: str, tier, repo: Path,
                              secret_filter=None,
                              scan_sensitive_data: bool = True) -> TeamResultVerdict:
@@ -304,13 +349,21 @@ def classify_result_for_tier(body: str, tier, repo: Path,
 
 
 def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
-                          scan_sensitive_data: bool = True):
+                          scan_sensitive_data: bool = True, *,
+                          suppress_journal=None):
     """Consumer-facing gate: returns (safe_body, withheld_reason).
 
     Returns a body rather than raising, so a caller cannot deliver the raw text
     by catching an exception -- the safe body is the only one it is handed.
     Derived from classify_result_for_tier so the verdict has exactly one owner.
+
+    suppress_journal: `(state_dir, task_id)` from an adapter whose surface is a
+    human channel. The notice becomes a journaled silent close there; adapters
+    that omit it keep the posted notice.
     """
     verdict = classify_result_for_tier(
         body, tier, repo, secret_filter, scan_sensitive_data)
+    if suppress_journal is not None:
+        state_dir, task_id = suppress_journal
+        verdict = materialize_suppressed_verdict(verdict, body, state_dir, task_id)
     return verdict.body, verdict.reason

--- a/src/team_result_guard.py
+++ b/src/team_result_guard.py
@@ -286,13 +286,16 @@ def suppressed_record_path(state_dir: Path, task_id: str) -> Path:
 
 def materialize_suppressed_verdict(verdict: TeamResultVerdict, body: str,
                                    state_dir: Path, task_id: str, context=None,
-                                   agent_id: str = "", now=None) -> TeamResultVerdict:
-    """Realise a notice-bearing SUPPRESS as a journaled silent close.
+                                   agent_id: str = "", now=None,
+                                   stub: str = "[no-send]") -> TeamResultVerdict:
+    """Realise a notice-bearing SUPPRESS as a journaled close carrying `stub`.
 
     The record requirement is the policy, not the notice: once the suppression
     is durably journaled, posting prose about marker mechanics into a human
-    channel is noise. Fail-CLOSED -- if the journal cannot be written the
-    notice stands, so the record is never silently dropped.
+    channel is noise. `stub` must come from suppression_stub_for_tier -- it is
+    the canonical, sender-uninfluenced body, and it preserves a dedup target
+    that a flat "[no-send]" would drop. Fail-CLOSED -- if the journal cannot be
+    written the notice stands, so the record is never silently dropped.
     """
     if verdict.kind != VERDICT_SUPPRESS or verdict.body != TEAM_SUPPRESS_RESULT:
         return verdict                     # already silent, or not a suppress
@@ -321,7 +324,7 @@ def materialize_suppressed_verdict(verdict: TeamResultVerdict, body: str,
     if not saved:
         return verdict
     return TeamResultVerdict(
-        VERDICT_SUPPRESS, "[no-send]", f"{verdict.reason}; journaled silent close")
+        VERDICT_SUPPRESS, stub, f"{verdict.reason}; journaled silent close")
 
 
 def classify_result_for_tier(body: str, tier, repo: Path,
@@ -364,6 +367,12 @@ def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
     verdict = classify_result_for_tier(
         body, tier, repo, secret_filter, scan_sensitive_data)
     if suppress_journal is not None:
-        state_dir, task_id = suppress_journal
-        verdict = materialize_suppressed_verdict(verdict, body, state_dir, task_id)
+        # The stub is the module's existing policy for what a guarded
+        # suppression may say; this only adds the record that lets a
+        # non-journaled transport use it. Do not re-derive the body here.
+        stub = suppression_stub_for_tier(body, tier)
+        if stub is not None:
+            state_dir, task_id = suppress_journal
+            verdict = materialize_suppressed_verdict(
+                verdict, body, state_dir, task_id, stub=stub)
     return verdict.body, verdict.reason

--- a/src/team_result_guard.py
+++ b/src/team_result_guard.py
@@ -286,8 +286,8 @@ def suppressed_record_path(state_dir: Path, task_id: str) -> Path:
 
 def materialize_suppressed_verdict(verdict: TeamResultVerdict, body: str,
                                    state_dir: Path, task_id: str, context=None,
-                                   agent_id: str = "", now=None,
-                                   stub: str = "[no-send]") -> TeamResultVerdict:
+                                   agent_id: str = "", now=None, *,
+                                   stub: str) -> TeamResultVerdict:
     """Realise a notice-bearing SUPPRESS as a journaled close carrying `stub`.
 
     The record requirement is the policy, not the notice: once the suppression

--- a/tests/team-guard-suppress-journaled-silent-close.test.py
+++ b/tests/team-guard-suppress-journaled-silent-close.test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""A Team-tier suppression is journaled and closed silently, not posted as prose.
+
+The guard withholds `[no-send]` on a guarded tier so a sender cannot close its
+own delivery lease silently -- the record requirement is the policy. It used to
+discharge that by posting TEAM_SUPPRESS_RESULT, which on a human channel is
+marker mechanics addressed to someone who has never heard of a marker.
+
+An adapter that can journal now binds `suppress_journal=(state_dir, task_id)`:
+the record lands on disk and the body becomes `[no-send]`, which the bridge
+already routes to its silent-archive path. Adapters that omit it are unchanged.
+
+  a) journal bound     -> body is [no-send], record written, original body kept
+  b) journal omitted   -> the notice still stands (ag2space/gateway unchanged)
+  c) owner tier        -> never touched
+  d) journal UNWRITABLE -> notice stands (fail-closed; record never dropped)
+  e) redirect/attach   -> still LEAK, never silently closed
+  f) already-silent suppress -> not re-journaled, body unchanged
+
+Run: python3 tests/team-guard-suppress-journaled-silent-close.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+import team_result_guard as guard  # noqa: E402
+
+FAILS: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def main() -> int:
+    body = "[no-send]\nAddressed to another agent; nothing owed here."
+
+    # a) THE FIX.
+    state = pathlib.Path(tempfile.mkdtemp(prefix="tg-suppress-"))
+    got, reason = guard.guard_result_for_tier(
+        body, "team", REPO, suppress_journal=(state, "task-42"))
+    check(got == "[no-send]", f"a) body is [no-send], got {got!r}")
+    check(guard.TEAM_SUPPRESS_RESULT not in got, "a) the notice is NOT in the body")
+    rec = guard.suppressed_record_path(state, "task-42")
+    check(rec.is_file(), f"a) journal record written at {rec.name}")
+    if rec.is_file():
+        payload = json.loads(rec.read_text())
+        check(payload["suppressed_body"] == body, "a) the ORIGINAL body is preserved in the record")
+        check(payload["task_id"] == "task-42", "a) record carries the task id")
+        check(payload["status"] == "suppressed_silent_close", "a) record states the disposition")
+        check(oct(rec.parent.stat().st_mode)[-3:] == "700", "a) journal dir is owner-only")
+    check(reason and "journaled silent close" in reason, f"a) reason names it, got {reason!r}")
+
+    # b) An adapter that does not bind the journal is UNCHANGED.
+    got_b, _ = guard.guard_result_for_tier(body, "team", REPO)
+    check(got_b == guard.TEAM_SUPPRESS_RESULT,
+          "b) without a journal the notice still stands (gateway unchanged)")
+
+    # c) Owner is exempt end to end.
+    got_c, reason_c = guard.guard_result_for_tier(
+        body, "owner", REPO, suppress_journal=(state, "task-owner"))
+    check(got_c == body and reason_c is None, "c) owner body delivered verbatim")
+    check(not guard.suppressed_record_path(state, "task-owner").exists(),
+          "c) and nothing is journaled for owner")
+
+    # d) FAIL-CLOSED. A journal that cannot be written must not lose the record.
+    blocked = pathlib.Path(tempfile.mkdtemp(prefix="tg-suppress-ro-"))
+    (blocked / guard.SUPPRESSED_RESULT_DIR).write_text("not a directory", encoding="utf-8")
+    got_d, _ = guard.guard_result_for_tier(
+        body, "team", REPO, suppress_journal=(blocked, "task-99"))
+    check(got_d == guard.TEAM_SUPPRESS_RESULT,
+          f"d) unwritable journal -> notice STANDS, got {got_d[:40]!r}")
+
+    # e) The capability markers are a different class and must not be softened.
+    for marker in ("[channel: 1530802402603700415]\nhi", "[file: /etc/passwd]\nhi"):
+        got_e, _ = guard.guard_result_for_tier(
+            marker, "team", REPO, suppress_journal=(state, "task-leak"))
+        check(got_e == guard.TEAM_LEAK_RESULT,
+              f"e) {marker.split(chr(10))[0]} still LEAK, got {got_e[:34]!r}")
+    check(not guard.suppressed_record_path(state, "task-leak").exists(),
+          "e) and a leak is never journaled as a silent close")
+
+    # f) An already-silent suppress is returned untouched.
+    silent = guard.TeamResultVerdict(guard.VERDICT_SUPPRESS, "[no-send]", "prior")
+    out = guard.materialize_suppressed_verdict(silent, body, state, "task-77")
+    check(out == silent, "f) an already-silent suppress is not re-journaled")
+
+    print()
+    if FAILS:
+        print(f"{len(FAILS)} FAILED: " + "; ".join(FAILS))
+        return 1
+    print("PASS -- suppression is journaled and closed silently on a bound adapter")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/team-guard-suppress-journaled-silent-close.test.py
+++ b/tests/team-guard-suppress-journaled-silent-close.test.py
@@ -92,7 +92,8 @@ def main() -> int:
 
     # f) An already-silent suppress is returned untouched.
     silent = guard.TeamResultVerdict(guard.VERDICT_SUPPRESS, "[no-send]", "prior")
-    out = guard.materialize_suppressed_verdict(silent, body, state, "task-77")
+    out = guard.materialize_suppressed_verdict(
+        silent, body, state, "task-77", stub="[no-send]")
     check(out == silent, "f) an already-silent suppress is not re-journaled")
 
     # g) The WRITE raises after the directory exists. Case (d) fails at mkdir and
@@ -129,6 +130,19 @@ def main() -> int:
         check(got_i == want, f"i) {src_body.splitlines()[0]} -> {want!r}, got {got_i!r}")
         check(got_i == guard.suppression_stub_for_tier(src_body, "team"),
               "i) and it equals suppression_stub_for_tier (one policy, not two)")
+
+    # j) A default stub would let a future caller silently reinstate the
+    #    flattening. The signature, not the docstring, has to refuse.
+    try:
+        guard.materialize_suppressed_verdict(
+            guard.TeamResultVerdict(guard.VERDICT_SUPPRESS,
+                                    guard.TEAM_SUPPRESS_RESULT, "r"),
+            "[REPLIED]\nx", pathlib.Path(tempfile.mkdtemp(prefix="tg-suppress-j-")),
+            "task-j")
+    except TypeError:
+        check(True, "j) omitting stub is a TypeError, not a silent [no-send]")
+    else:
+        check(False, "j) omitting stub was ACCEPTED -- the default is back")
 
     print()
     if FAILS:

--- a/tests/team-guard-suppress-journaled-silent-close.test.py
+++ b/tests/team-guard-suppress-journaled-silent-close.test.py
@@ -118,6 +118,21 @@ def main() -> int:
     check(got_h == guard.TEAM_SUPPRESS_RESULT,
           f"h) an UNSUCCESSFUL journal write -> notice stands, got {got_h[:40]!r}")
 
+    # i) THE STUB IS PRESERVED, not flattened. An earlier revision of this change
+    #    returned a hardcoded "[no-send]", which drops the dedup target that
+    #    discord-bridge needs to validate the holder's CHANNEL and re-queue a
+    #    cross-channel dedup. The body must be whatever suppression_stub_for_tier
+    #    says -- the module's existing policy -- never a fresh literal.
+    for src_body, want in (("[no-send]\nx", "[no-send]"),
+                           ("[REPLIED]\nx", "[REPLIED]"),
+                           ("[deduped: task-abc123]\nx", "[deduped: task-abc123]")):
+        st = pathlib.Path(tempfile.mkdtemp(prefix="tg-suppress-stub-"))
+        got_i, _ = guard.guard_result_for_tier(
+            src_body, "team", REPO, suppress_journal=(st, "task-stub"))
+        check(got_i == want, f"i) {src_body.splitlines()[0]} -> {want!r}, got {got_i!r}")
+        check(got_i == guard.suppression_stub_for_tier(src_body, "team"),
+              "i) and it equals suppression_stub_for_tier (one policy, not two)")
+
     print()
     if FAILS:
         print(f"{len(FAILS)} FAILED: " + "; ".join(FAILS))

--- a/tests/team-guard-suppress-journaled-silent-close.test.py
+++ b/tests/team-guard-suppress-journaled-silent-close.test.py
@@ -118,11 +118,8 @@ def main() -> int:
     check(got_h == guard.TEAM_SUPPRESS_RESULT,
           f"h) an UNSUCCESSFUL journal write -> notice stands, got {got_h[:40]!r}")
 
-    # i) THE STUB IS PRESERVED, not flattened. An earlier revision of this change
-    #    returned a hardcoded "[no-send]", which drops the dedup target that
-    #    discord-bridge needs to validate the holder's CHANNEL and re-queue a
-    #    cross-channel dedup. The body must be whatever suppression_stub_for_tier
-    #    says -- the module's existing policy -- never a fresh literal.
+    # i) A flat "[no-send]" would drop the dedup target discord-bridge needs to
+    #    validate the holder's channel. The body must equal the stub function's.
     for src_body, want in (("[no-send]\nx", "[no-send]"),
                            ("[REPLIED]\nx", "[REPLIED]"),
                            ("[deduped: task-abc123]\nx", "[deduped: task-abc123]")):

--- a/tests/team-guard-suppress-journaled-silent-close.test.py
+++ b/tests/team-guard-suppress-journaled-silent-close.test.py
@@ -95,6 +95,29 @@ def main() -> int:
     out = guard.materialize_suppressed_verdict(silent, body, state, "task-77")
     check(out == silent, "f) an already-silent suppress is not re-journaled")
 
+    # g) The WRITE raises after the directory exists. Case (d) fails at mkdir and
+    #    takes the earlier OSError guard, so this branch was untested.
+    ok_dir = pathlib.Path(tempfile.mkdtemp(prefix="tg-suppress-raise-"))
+    saved_writer = guard._write_artifact
+    guard._write_artifact = lambda *a, **k: (_ for _ in ()).throw(OSError("disk gone"))
+    try:
+        got_g, _ = guard.guard_result_for_tier(
+            body, "team", REPO, suppress_journal=(ok_dir, "task-raise"))
+    finally:
+        guard._write_artifact = saved_writer
+    check(got_g == guard.TEAM_SUPPRESS_RESULT,
+          f"g) a RAISING journal write -> notice stands, got {got_g[:40]!r}")
+
+    # h) The write reports failure without raising -- same requirement, different path.
+    guard._write_artifact = lambda *a, **k: False
+    try:
+        got_h, _ = guard.guard_result_for_tier(
+            body, "team", REPO, suppress_journal=(ok_dir, "task-false"))
+    finally:
+        guard._write_artifact = saved_writer
+    check(got_h == guard.TEAM_SUPPRESS_RESULT,
+          f"h) an UNSUCCESSFUL journal write -> notice stands, got {got_h[:40]!r}")
+
     print()
     if FAILS:
         print(f"{len(FAILS)} FAILED: " + "; ".join(FAILS))


### PR DESCRIPTION
> **REVISED 21:5xZ after self-review — read this before the sections below.**
> The first pass added a **second** suppression mechanism when `suppression_stub_for_tier`
> already existed (#3109, same commit as the notice) and the ag2 space gateway already called it.
> Its comment states the split outright: *"one policy here, transport mechanics at the edges
> (stub-alone where the server suppresses; notice where it delivers)"* — Discord simply never
> bound it. It also **regressed** behaviour: flattening to a hardcoded `[no-send]` dropped the
> dedup target that discord-bridge needs to validate the holder's channel.
>
> ```
> team body                before revision   after (existing policy)
> [no-send]                [no-send]         [no-send]
> [REPLIED]                [no-send]         [REPLIED]
> [deduped: task-abc123]   [no-send]         [deduped: task-abc123]
> ```
>
> The journal now supplies only the missing **record**; the body comes from
> `suppression_stub_for_tier`. Test case (i) asserts each stub round-trips *and* equals that
> function, so "one policy, not two" is pinned rather than described.

## What

A Team-tier `[no-send]` is withheld so a guarded sender cannot close its own delivery lease silently — the record requirement is the policy (#3109, `1a5e0c76`). The guard discharged that by **posting** `TEAM_SUPPRESS_RESULT`. On a Discord channel that is marker mechanics addressed to a human who has never heard of a marker.

The owner saw one, asked what it was, and then specified the fix: *"the no-send msg means no send to the channel. It's ok to deliver to ag2 space server when the target is ag2 space and the server should not deliver to the end user."*

`TeamResultVerdict` already sanctions this in its own docstring — *"an adapter with a durable transport journal may realise SUPPRESS as a journaled silent close instead"*. Nothing bound it.

## Before / after — run at the parent commit and at HEAD

```
BEFORE (origin/main)
  body delivered to the Discord channel:
    Task handled. The agent marked this reply as not-for-delivery; suppression
    markers are not honoured on Team-tier results, so this notice is delivered …

AFTER (HEAD)
  body delivered to the Discord channel:  '[no-send]'
  journal record: wr_3a3b6e433787a5fc.json | status: suppressed_silent_close
                  | body preserved: '[no-send]\nAddressed to anoth'…
  unbound adapter (ag2 space gateway) is unchanged:
    Task handled. The agent marked this reply as not-for-delivery; suppression marke…
```

`[no-send]` is the body the bridge already routes to its silent-archive path, so no new delivery logic is introduced.

## How

- `materialize_suppressed_verdict` journals the suppression under `state/suppressed-team-results/` (0700 dir, atomic-link write, **original body preserved**) and returns `[no-send]`. Same shape as the existing `materialize_withheld_verdict`.
- `guard_result_for_tier` grows `suppress_journal=(state_dir, task_id)`. **Adapters that omit it are unchanged**, which is what keeps the ag2 space gateway delivering to the server.
- **Fail-CLOSED**: an unwritable journal leaves the notice standing, so the record is never silently dropped.
- Both copies move together (`src/` + vendored `packages/ag2-sparrow/`).

## Scope — one part is deliberately NOT done here

The owner's requirement has three parts. This PR is the first two:

| part | status |
|---|---|
| `[no-send]` must not post into the channel | **done** (Discord binds the journal) |
| delivering to the ag2 space server is fine | **done** (gateway unchanged, by omission) |
| the server must not deliver to the end user | **not in this repo** — broker-side |

I have not touched the third and am not treating it as covered. @qingyun-wu — you own this module (`1a5e0c76`); the server-side half is the part I can't see from here, and I'd rather you say where it belongs than guess.

## Tests

`tests/team-guard-suppress-journaled-silent-close.test.py` — journal-bound, journal-omitted, owner-exempt, unwritable-journal fail-closed, redirect/attach still `LEAK`, already-silent suppress not re-journaled. **16/16.**

Against the pre-fix guard it raises `TypeError: guard_result_for_tier() got an unexpected keyword argument 'suppress_journal'` — an honest fail, though a signature one; the *behavioural* discriminator is case (b), which pins that the unbound path still returns the notice.

Adjacent suites, all green: `team-result-guard`, `sparrow-result-guard`, `gateway-team-guardrail-inband`. The first of them **caught a real mistake in this PR** — I line-wrapped the bridge call and broke its `guard_result_for_tier(reply_text` structural assertion. I kept the call contiguous rather than loosening the check.

## Related, not duplicate

#2431 (DRAFT) is the same family — "keep internal notices out of public channels" — but covers the thread-seed and sandbox-fallback notices and contains **zero** references to `team_result_guard` or `TEAM_SUPPRESS`. Both touch `src/discord-bridge.py`, in different regions.

cc @sonichi — this is your directive from #game; flagging so you can see whether the scope split matches what you meant.

