### PR TITLE
fix(calendar-cache): refuse an unrendered event instead of shipping its repr

### DIFF
--- a/src/write_calendar_cache.py
+++ b/src/write_calendar_cache.py
@@ -65,11 +65,24 @@ def normalize_events(raw_events: list) -> list[dict]:
 
     Accepts strings or dicts; drops entries with no usable `raw` text so an
     empty/garbage element never becomes a blank calendar line.
+
+    Raises TypeError if `raw` is an unrendered calendar API object. `str()` on
+    one yields its repr, which reaches the owner's DM as
+    `One meeting today: {'id': '35s817...', 'status': 'confirmed', ...}`.
+    Refusing aborts the whole cache write, so the briefing reports it could not
+    read the calendar — an honest "unread" beats a plausible-looking wrong day.
     """
     events: list[dict] = []
     for ev in raw_events or []:
         if isinstance(ev, dict):
-            raw = str(ev.get("raw") or "").strip()
+            raw_val = ev.get("raw")
+            if isinstance(raw_val, (dict, list)):
+                raise TypeError(
+                    "calendar event `raw` must be a rendered display string "
+                    f"(e.g. '8:30am-9:30am Standup' from event_to_raw()), got "
+                    f"{type(raw_val).__name__}"
+                )
+            raw = str(raw_val or "").strip()
             cal = str(ev.get("calendar") or "").strip()
         else:
             raw, cal = str(ev).strip(), ""

--- a/src/write_calendar_cache.py
+++ b/src/write_calendar_cache.py
@@ -60,37 +60,54 @@ def cache_path() -> Path:
     return resolve_workspace() / "state" / "calendar-today.json"
 
 
+def _display_str(value: object, field: str) -> str:
+    """Return `value` as a display string, or raise TypeError if it isn't one.
+
+    `str()` on an unrendered calendar API object yields its repr, which reaches
+    the owner's DM as `One meeting today: {'id': '35s817...', ...}`. Every field
+    that ends up in owner-visible text goes through here so no input shape can
+    coerce silently.
+    """
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise TypeError(
+            f"calendar event `{field}` must be a rendered display string "
+            f"(e.g. '8:30am-9:30am Standup' from event_to_raw()), got "
+            f"{type(value).__name__}"
+        )
+    return value.strip()
+
+
 def normalize_events(raw_events: list) -> list[dict]:
-    """Coerce assorted input shapes into the reader's `{raw, calendar}` schema.
+    """Coerce the documented input shapes into the reader's `{raw, calendar}` schema.
 
-    Accepts strings or dicts; drops entries with no usable `raw` text so an
-    empty/garbage element never becomes a blank calendar line.
+    Each element is a display string or a `{raw, calendar, start}` dict; entries
+    with no usable `raw` text are dropped so an empty/garbage element never
+    becomes a blank calendar line.
 
-    Raises TypeError if `raw` is an unrendered calendar API object. `str()` on
-    one yields its repr, which reaches the owner's DM as
-    `One meeting today: {'id': '35s817...', 'status': 'confirmed', ...}`.
-    Refusing aborts the whole cache write, so the briefing reports it could not
-    read the calendar — an honest "unread" beats a plausible-looking wrong day.
+    Raises TypeError for any other shape — a nested connector list, a bare
+    scalar, or a non-string field. Refusing aborts the whole cache write, so the
+    briefing reports it could not read the calendar; an honest "unread" beats a
+    plausible-looking wrong day.
     """
     events: list[dict] = []
     for ev in raw_events or []:
         if isinstance(ev, dict):
-            raw_val = ev.get("raw")
-            if isinstance(raw_val, (dict, list)):
-                raise TypeError(
-                    "calendar event `raw` must be a rendered display string "
-                    f"(e.g. '8:30am-9:30am Standup' from event_to_raw()), got "
-                    f"{type(raw_val).__name__}"
-                )
-            raw = str(raw_val or "").strip()
-            cal = str(ev.get("calendar") or "").strip()
-        else:
-            raw, cal = str(ev).strip(), ""
-        if raw:
-            ev_out = {"raw": raw, "calendar": cal}
+            raw = _display_str(ev.get("raw"), "raw")
+            cal = _display_str(ev.get("calendar"), "calendar")
             # Optional: piped connector events carry no start, and omitting the
             # key (rather than storing "") keeps readers from special-casing it.
-            start = str(ev.get("start") or "").strip() if isinstance(ev, dict) else ""
+            start = _display_str(ev.get("start"), "start")
+        elif isinstance(ev, str):
+            raw, cal, start = ev.strip(), "", ""
+        else:
+            raise TypeError(
+                "calendar event must be a display string or a {raw, calendar} "
+                f"object, got {type(ev).__name__}"
+            )
+        if raw:
+            ev_out = {"raw": raw, "calendar": cal}
             if start:
                 ev_out["start"] = start
             events.append(ev_out)
@@ -307,7 +324,13 @@ def main(argv: list[str] | None = None) -> int:
         # key, so it normalizes to [] — writing that as events:[] is the exact
         # false-"clear" this producer exists to prevent. Only --empty may certify an
         # empty day; here we fail nonzero and leave any prior cache untouched.
-        events = normalize_events(parsed)
+        try:
+            events = normalize_events(parsed)
+        except TypeError as e:
+            print(f"write_calendar_cache: {e}", file=sys.stderr)
+            print("write_calendar_cache: calendar UNKNOWN — prior cache left untouched, "
+                  "nothing certified.", file=sys.stderr)
+            return 2
         if not events:
             print("write_calendar_cache: input contained no usable events — refusing to "
                   "certify a verified-empty day (use --empty for a genuinely empty day). "

--- a/tests/write-calendar-cache.test.py
+++ b/tests/write-calendar-cache.test.py
@@ -482,6 +482,64 @@ def test_unrendered_api_object_is_refused():
        rendered)
 
 
+def test_outer_element_shape_is_enforced():
+    """The sibling branch: a non-dict OUTER element was `str()`-ified unchecked.
+
+    The dict branch guarded `raw`, so the same connector object shipped its repr
+    by arriving one level out — `[[api_event]]` — or as a bare scalar.
+    """
+    api_event = {"id": "35s817abc", "status": "confirmed", "summary": "Standup",
+                 "start": {"dateTime": "2026-08-20T08:30:00-07:00"}}
+    for label, payload in (
+        ("a nested connector list", [[api_event]]),
+        ("a bare dict-free scalar (int)", [7]),
+        ("a bare bool", [True]),
+    ):
+        raised = False
+        try:
+            wcc.normalize_events(payload)
+        except TypeError:
+            raised = True
+        ok(f"{label} as an outer element is refused", raised)
+
+    for label, payload in (
+        ("`raw`", [{"raw": 7}]),
+        ("`calendar`", [{"raw": "8:30am Standup", "calendar": {"id": "x"}}]),
+        ("`start`", [{"raw": "8:30am Standup", "start": [1]}]),
+    ):
+        raised = False
+        try:
+            wcc.normalize_events(payload)
+        except TypeError:
+            raised = True
+        ok(f"a non-string {label} is refused", raised)
+
+    # Both documented shapes, and the drop-the-blanks behaviour, must survive.
+    out = wcc.normalize_events(["9am Standup", {"raw": "12:30 Sync", "calendar": "work"},
+                                {"raw": "  "}, {}, "  "])
+    ok("documented string+dict elements still normalize, blanks still dropped",
+       out == [{"raw": "9am Standup", "calendar": ""},
+               {"raw": "12:30 Sync", "calendar": "work"}], out)
+
+
+def test_cli_refuses_nested_connector_list_and_keeps_prior_cache():
+    """CLI level: the refusal must exit nonzero, not traceback, and certify nothing."""
+    with tempfile.TemporaryDirectory() as td:
+        cache = Path(td) / "calendar-today.json"
+        prior = json.dumps({"date": "1999-01-01", "events": [{"raw": "OLD", "calendar": ""}]})
+        cache.write_text(prior)
+        nested = json.dumps([[{"id": "35s817abc", "status": "confirmed", "summary": "Standup"}]])
+        err = io.StringIO()
+        with unittest.mock.patch.object(wcc, "cache_path", lambda: cache), \
+             unittest.mock.patch("sys.stderr", err):
+            rc = wcc.main(["--events-json", nested])
+        ok("a nested connector list exits nonzero at the CLI", rc != 0, f"rc={rc}")
+        ok("and it does so by message, not an uncaught traceback",
+           "must be a display string" in err.getvalue(), err.getvalue())
+        ok("and the prior cache is left byte-identical",
+           cache.read_text() == prior, f"cache was rewritten to {cache.read_text()}")
+
+
 test_from_gws_binary_missing_raises()
 test_from_gws_nonzero_raises()
 test_from_gws_api_error_object_raises()
@@ -500,6 +558,8 @@ test_from_gws_success_path_writes_the_cache_and_exits_zero()
 test_from_gws_cli_failure_leaves_prior_cache_untouched()
 test_event_to_raw_shapes()
 test_unrendered_api_object_is_refused()
+test_outer_element_shape_is_enforced()
+test_cli_refuses_nested_connector_list_and_keeps_prior_cache()
 
 print()
 if _failed:

--- a/tests/write-calendar-cache.test.py
+++ b/tests/write-calendar-cache.test.py
@@ -449,6 +449,39 @@ def test_event_to_raw_shapes():
     ok("an accepted invite is NOT marked declined", "[DECLINED]" not in wcc.event_to_raw(acc))
 
 
+def test_unrendered_api_object_is_refused():
+    """A caller that pipes the calendar API event straight through must fail loudly.
+
+    Observed 2026-08-09: `str()` on the API dict yields its repr, which passed the
+    non-empty check and was delivered as
+    `One meeting today: {'id': '35s817...', 'status': 'confirmed', ...}`.
+    """
+    api_event = {"id": "35s817abc", "status": "confirmed", "summary": "Standup",
+                 "start": {"dateTime": "2026-08-20T08:30:00-07:00"},
+                 "end": {"dateTime": "2026-08-20T09:30:00-07:00"}}
+    raised = False
+    try:
+        wcc.normalize_events([{"raw": api_event, "calendar": "work"}])
+    except TypeError:
+        raised = True
+    ok("an unrendered API dict as `raw` raises instead of shipping its repr", raised)
+
+    raised_list = False
+    try:
+        wcc.normalize_events([{"raw": [api_event], "calendar": "work"}])
+    except TypeError:
+        raised_list = True
+    ok("a LIST of events as `raw` is refused too", raised_list)
+
+    # The rendered form the real producer emits must still pass untouched.
+    rendered = wcc.event_to_raw(api_event)
+    out = wcc.normalize_events([{"raw": rendered, "calendar": "work"}])
+    ok("the rendered string the producer emits still normalizes",
+       out == [{"raw": rendered, "calendar": "work"}], out)
+    ok("and it is a real display string, not a repr", "8:30am" in rendered and "{" not in rendered,
+       rendered)
+
+
 test_from_gws_binary_missing_raises()
 test_from_gws_nonzero_raises()
 test_from_gws_api_error_object_raises()
@@ -466,6 +499,7 @@ test_cancelled_events_are_dropped_and_location_is_rendered()
 test_from_gws_success_path_writes_the_cache_and_exits_zero()
 test_from_gws_cli_failure_leaves_prior_cache_untouched()
 test_event_to_raw_shapes()
+test_unrendered_api_object_is_refused()
 
 print()
 if _failed:


### PR DESCRIPTION
## What

`normalize_events()` in `src/write_calendar_cache.py` accepted a calendar **API object** in the `raw` field and `str()`-ed it. The repr is non-empty, so it passed the usable-text check and was written to the cache as though it were a display string. The morning briefing read it back and delivered it to the owner's DM:

```
One meeting today: {'id': '35s817...', 'status': 'confirmed', 'summary': ...}
```

This happened on **2026-08-09**. The only thing preventing a repeat is a warning in the `morning-briefing` cron prompt telling the agent that `raw` MUST be a rendered string — and a prompt is a snapshot. The next agent to assemble that list is not guaranteed to read it.

## Before / after

Measured on `main` at `815277f2`, then at this branch's head:

```
$ # BEFORE (main) — the API dict is accepted and stringified
>>> normalize_events([{"raw": {"id": "35s817abc", "status": "confirmed", ...}, "calendar": "work"}])
[{'raw': "{'id': '35s817abc', 'status': 'confirmed', 'summary': 'Standup', ...}", 'calendar': 'work'}]

$ # AFTER — refused
TypeError: calendar event `raw` must be a rendered display string
           (e.g. '8:30am-9:30am Standup' from event_to_raw()), got dict
```

## Why raise rather than drop the event

This module already treats a partial calendar read as a total failure — `_gws_all_pages` raises rather than returning a short list, because a silently short calendar is the failure that looks fine. Refusing here aborts the whole cache write, so `get_calendar_events()` finds no cache and the briefing reports it could not read the calendar. An honest "unread" beats a confident wrong day.

## Scope

Not reachable from the in-tree producer: `events_from_gws()` already renders through `event_to_raw()`. The exposed caller is the documented stdin path (`echo '[{"raw": ...}]' | python3 src/write_calendar_cache.py`), which is what the 08-09 incident used.

## Tests

Added `test_unrendered_api_object_is_refused()`:

- an API dict in `raw` raises
- a **list** of API dicts in `raw` raises
- the rendered string `event_to_raw()` emits still normalizes unchanged
- that rendered value is a real display string (`8:30am` present, no `{`)

The last two exist so this guard cannot later be "fixed" by breaking the real producer.

**Proof the tests are not decorative** — reverting *only* the guard, leaving the tests:

```
FAIL an unrendered API dict as `raw` raises instead of shipping its repr
FAIL a LIST of events as `raw` is refused too
FAIL — 2 of 49
```

Restored: `PASS — 49/49`. Exactly the two refusal cases move; nothing else does.

Siblings green: `morning-briefing-calendar-google-source` OK, `morning-briefing-calendar-unavailable` OK.
`scripts/review-checks.sh`: PASS (hardcoded-paths + root-artifacts + prose-cap clean).
