### PR TITLE
fix(proactive): the [channel:] body marker implies a bridge — give it one owner

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5242,7 +5242,8 @@ async def poll_proactive():
             # decision rule (last-active channel from
             # state/last-owner-activity.json; default discord on missing
             # state).
-            from proactive_routing import should_claim_proactive_file  # noqa: E402
+            from proactive_routing import (  # noqa: E402
+                redirect_target_is_foreign, should_claim_proactive_file)
             for f in RESULTS_DIR.iterdir():
                 # Per-FILE decision: an explicit .to-<channel> destination
                 # outranks activity routing (see proactive_routing).
@@ -5275,8 +5276,8 @@ async def poll_proactive():
                     _pp = parse_markers(text)
                     _early_redirect = next(
                         (a for a in _pp.actions if a.kind == "redirect"), None)
-                    if _early_redirect is not None and not re.fullmatch(
-                            r"\d{17,20}", str(_early_redirect.value).strip()):
+                    if _early_redirect is not None and redirect_target_is_foreign(
+                            _early_redirect.value, "discord"):
                         print(f"  [proactive] {f.name} targets "
                               f"{str(_early_redirect.value).strip()!r} — not a Discord "
                               f"channel id; releasing for its own bridge", flush=True)

--- a/src/proactive_routing.py
+++ b/src/proactive_routing.py
@@ -170,6 +170,10 @@ def target_channel_kind(target) -> "str | None":
 
     None means "not recognised as any bridge's address" — deliberately NOT
     "foreign". See body_claimable_by for why that distinction is load-bearing.
+
+    Telegram is absent by decision, not omission: its bridge DROPS a `[channel:]`
+    redirect outright, so classifying a telegram chat id would route the file to
+    a bridge guaranteed never to deliver it — the strand this module prevents.
     """
     value = str(target or "").strip()
     for kind, pattern in _TARGET_KINDS:

--- a/src/proactive_routing.py
+++ b/src/proactive_routing.py
@@ -156,7 +156,6 @@ def fallback_claims_name(name, this_channel: str) -> bool:
 # The [channel:] BODY marker names a channel but IMPLIES a bridge, and that
 # implication is what each adapter re-derived — two of them Discord-only.
 
-_BODY_TARGET_RE = re.compile(r"\A\s*\[channel:\s*([^\]\n]*)\]")
 # Discord snowflake / Matrix room-or-alias / Slack channel id. Anchored whole:
 # a substring match would classify `#room:server` off its leading character.
 _TARGET_KINDS = (
@@ -180,13 +179,18 @@ def target_channel_kind(target) -> "str | None":
 
 
 def body_target_channel(body) -> "str | None":
-    """The bridge the body's LEADING `[channel:]` marker addresses, or None.
+    """The bridge the body addresses, or None when no redirect will EXECUTE.
 
-    Only the leading marker routes — the same rule result_markers applies when
-    it decides whether a redirect is an executable action or inert prose.
+    Reads the shared parser's redirect action rather than matching the text: a
+    private regex sees `[channel:]` that `[dm-only]` has already disarmed, and
+    routing on a disarmed address strands the file at a bridge that will not
+    deliver it. Re-deriving the grammar here is the defect this module fixes.
     """
-    match = _BODY_TARGET_RE.match(str(body or ""))
-    return target_channel_kind(match.group(1)) if match else None
+    from result_markers import parse_markers  # noqa: PLC0415 — see module note
+    redirect = next(
+        (a for a in parse_markers(str(body or "")).actions if a.kind == "redirect"),
+        None)
+    return target_channel_kind(redirect.value) if redirect is not None else None
 
 
 def body_claimable_by(body, this_channel: str) -> bool:

--- a/src/proactive_routing.py
+++ b/src/proactive_routing.py
@@ -151,3 +151,60 @@ def fallback_claims_name(name, this_channel: str) -> bool:
     destination strands visibly rather than falling into another channel's
     fallback sweep."""
     return proactive_destination(name) in (None, this_channel)
+
+
+# The [channel:] BODY marker names a channel but IMPLIES a bridge, and that
+# implication is what each adapter re-derived — two of them Discord-only.
+
+_BODY_TARGET_RE = re.compile(r"\A\s*\[channel:\s*([^\]\n]*)\]")
+# Discord snowflake / Matrix room-or-alias / Slack channel id. Anchored whole:
+# a substring match would classify `#room:server` off its leading character.
+_TARGET_KINDS = (
+    ("discord", re.compile(r"\d{17,20}\Z")),
+    ("ag2space", re.compile(r"[!#][^\s:]+:[^\s:]+\Z")),
+    ("slack", re.compile(r"[CDG][A-Z0-9]{6,}\Z")),
+)
+
+
+def target_channel_kind(target) -> "str | None":
+    """The bridge a resolved `[channel:]` target belongs to, or None.
+
+    None means "not recognised as any bridge's address" — deliberately NOT
+    "foreign". See body_claimable_by for why that distinction is load-bearing.
+    """
+    value = str(target or "").strip()
+    for kind, pattern in _TARGET_KINDS:
+        if pattern.fullmatch(value):
+            return kind
+    return None
+
+
+def body_target_channel(body) -> "str | None":
+    """The bridge the body's LEADING `[channel:]` marker addresses, or None.
+
+    Only the leading marker routes — the same rule result_markers applies when
+    it decides whether a redirect is an executable action or inert prose.
+    """
+    match = _BODY_TARGET_RE.match(str(body or ""))
+    return target_channel_kind(match.group(1)) if match else None
+
+
+def body_claimable_by(body, this_channel: str) -> bool:
+    """False only when the body names ANOTHER bridge's address.
+
+    An unrecognised target stays claimable, which is the pre-existing behaviour
+    of every body-marker gate and is deliberately not changed here: stranding a
+    briefing on a malformed target is a worse failure than delivering it with a
+    stray marker line, and it is a separate judgement from this one.
+    """
+    kind = body_target_channel(body)
+    return kind is None or kind == this_channel
+
+
+def redirect_target_is_foreign(target, this_channel: str) -> bool:
+    """Strict form: anything not POSITIVELY this bridge's address is foreign.
+
+    The default destination uses this — an unrecognised target must not fall
+    into the default's delivery, or every malformed marker lands in one DM.
+    """
+    return target_channel_kind(target) != this_channel

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -64,7 +64,7 @@ from optional_script import run_optional_script as _run_optional_script_shared  
 from presenter_mode import presenter_mode_active  # noqa: E402
 from proactive_recovery import (claim_for_delivery, recover_orphan_sending_files,  # noqa: E402
                                 release_claim)
-from proactive_routing import fallback_claims_name  # noqa: E402
+from proactive_routing import body_claimable_by, fallback_claims_name  # noqa: E402
 
 
 def _slack_claims_name(name: str) -> bool:
@@ -1606,16 +1606,13 @@ def result_watcher():
                         _record_skip_audit(delivery_id, "deduped")
                         f.unlink(missing_ok=True)
                         continue
-                    # Peek before claiming: skip Discord-targeted proactive files.
-                    # [channel: <17-20 digit snowflake>] is a Discord-only marker;
-                    # claiming it here dumps the literal text to Slack DM instead.
-                    # Leave it for discord-bridge to claim. (#1401)
+                    # Peek before claiming: a body addressed to another bridge
+                    # is delivered by that bridge, not dumped here as literal text.
                     try:
                         peek = f.read_text(errors="ignore").lstrip()
                     except OSError:
                         continue
-                    if peek.startswith("[channel:") and \
-                            re.match(r'\[channel:\s*\d{17,20}\]', peek):
+                    if not body_claimable_by(peek, "slack"):
                         continue
                     # Explicit filename destination outranks the race.
                     if not _slack_claims_name(f.name):

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -1000,7 +1000,8 @@ def main():  # pragma: no cover
         # and telegram-bridge raced for the SAME proactive-*.txt files
         # and whichever ran first delivered, producing cross-channel
         # surprises. See proactive_routing.py for the decision rule.
-        from proactive_routing import should_claim_proactive_file
+        from proactive_routing import (body_claimable_by,
+                                       should_claim_proactive_file)
         try:
             if not presenter_mode_active(REPO):
                 # discord-bridge.poll_dm_fallback handles briefing-/insight-/
@@ -1021,16 +1022,13 @@ def main():  # pragma: no cover
                 for f in RESULTS_DIR.iterdir():
                     if any(f.name.startswith(p) for p in PROACTIVE_PREFIXES) \
                             and f.suffix == ".txt" and _tg_claims(f.name):
-                        # Peek before claiming: skip Discord-targeted proactive files.
-                        # [channel: <17-20 digit snowflake>] is a Discord-only marker;
-                        # claiming it here sends the literal text to Telegram DM instead
-                        # of leaving it for discord-bridge. (#1401)
+                        # Peek before claiming: a body addressed to another bridge
+                        # is delivered by that bridge, not sent here as literal text.
                         try:
                             peek = f.read_text(errors="ignore").lstrip()
                         except OSError:
                             continue
-                        if peek.startswith("[channel:") and \
-                                re.match(r'\[channel:\s*\d{17,20}\]', peek):
+                        if not body_claimable_by(peek, "telegram"):
                             continue
                         # Resolve the recipient BEFORE claiming: the claim renames the
                         # file out of the `*.txt` glob every peer bridge polls.

--- a/tests/discord-proactive-foreign-target.test.py
+++ b/tests/discord-proactive-foreign-target.test.py
@@ -11,9 +11,16 @@ consumer that can deliver it, never sees the file. Observed twice on 2026-08-17:
       invalid literal for int() with base 10: '!PrxhizfLysTYrYDcnw:ag2.space'
     [proactive] send failure -> parked: proactive-1786941735.txt
 
-`slack-bridge.py` and `telegram-bridge.py` already gate on `\\d{17,20}` before
-claiming. This pins the same rule for Discord and the ordering that makes it work:
-the shape check has to run BEFORE the int().
+`slack-bridge.py` and `telegram-bridge.py` already gate before claiming. This pins
+the same rule for Discord and the ordering that makes it work: the shape check has
+to run BEFORE the int().
+
+The `\\d{17,20}` literal this file used to grep for now lives once, in
+`proactive_routing`: three adapters spelling it privately is exactly how two of
+them ended up recognising ONLY Discord, so a Matrix room read as unaddressed. The
+assertions moved to the delegation and every property they protected — existence,
+ordering, three-adapter parity — is still here, plus a behavioural check that the
+delegate is not a no-op and a scan that no private copy survived.
 """
 import pathlib
 import re
@@ -45,13 +52,19 @@ block = text[start:end]
 check("_proactive_fence().release" in block,
       "the proactive block can release a claim back to the polling stream")
 
-shape = re.search(r'fullmatch\(r"\\d\{17,20\}"', block) or re.search(r"\\d\{17,20\}", block)
-check(shape is not None,
-      "a Discord-id shape check exists in the proactive claim block")
+GATE = "redirect_target_is_foreign("
+check(GATE in block,
+      "a foreign-target check exists in the proactive claim block")
+# Behavioural, not merely present: a grep is satisfied by a no-op delegate.
+sys.path.insert(0, str(REPO / "src"))
+from proactive_routing import redirect_target_is_foreign  # noqa: E402
+check(redirect_target_is_foreign("!PrxhizfLysTYrYDcnw:ag2.space", "discord")
+      and not redirect_target_is_foreign("1022910063620390932", "discord"),
+      "and the delegate rejects a Matrix room while accepting a snowflake")
 
 # Ordering IS the fix: a check after owner resolution has already done work
 # for a file this bridge is not handling.
-gi = block.find(r"\d{17,20}")
+gi = block.find(GATE)
 ii = block.find("owner_id is None")
 check(gi != -1 and ii != -1 and gi < ii,
       "the shape check runs BEFORE owner resolution — a foreign file needs no owner")
@@ -62,11 +75,16 @@ foreign = block[gi:ii] if (gi != -1 and ii != -1) else ""
 check("_proactive_fence().release" in foreign and "continue" in foreign,
       "the foreign-target branch releases the claim and stops processing")
 
-# Parity: the rule is not new policy, it is what the sibling bridges already do.
-for sib in ("slack-bridge.py", "telegram-bridge.py"):
-    p = REPO / "src" / sib
-    check(p.is_file() and r"\d{17,20}" in p.read_text(),
-          f"{sib} already gates on the same shape (parity, not new policy)")
+# Parity: not new policy, and now through the SAME module, so the three adapters
+# cannot drift apart again — which is how two of them ended up Discord-only.
+PRIVATE = re.compile(r"\\d\{17,20\}")
+for sib, channel in (("slack-bridge.py", "slack"), ("telegram-bridge.py", "telegram")):
+    q = REPO / "src" / sib
+    src = q.read_text() if q.is_file() else ""
+    check(f'body_claimable_by(peek, "{channel}")' in src,
+          f"{sib} gates through proactive_routing (parity, not new policy)")
+    check(not PRIVATE.search(src),
+          f"{sib} keeps NO private copy of the id grammar")
 
 # release_claim must return the file to .txt — parking or unlinking would still
 # keep it away from the gateway.

--- a/tests/proactive-body-target-routing.test.py
+++ b/tests/proactive-body-target-routing.test.py
@@ -125,9 +125,8 @@ def main() -> int:
     for channel in ("discord", "slack", "telegram"):
         check(body_claimable_by(f"[dm-only]\n[channel: {ROOM}]\nx", channel),
               f"3b) so {channel} may still claim it — the guard routes nothing")
-    # And with the address FIRST, routing applies as usual; [dm-only] then stops
-    # the redirect executing, so it lands in the owner's DM on the bridge that
-    # claimed it — an owner DM either way, which is why this is safe to route.
+    # Address FIRST: routing applies, and [dm-only] still stops the redirect, so
+    # it lands in an owner DM either way — which is why routing it is safe.
     check(not body_claimable_by(f"[channel: {ROOM}]\n[dm-only]\nx", "telegram"),
           "3b) an addressed body carrying [dm-only] still routes by its address")
 

--- a/tests/proactive-body-target-routing.test.py
+++ b/tests/proactive-body-target-routing.test.py
@@ -23,6 +23,8 @@ Two policies, one classifier, because the adapters genuinely differ:
   1) classifier: snowflake / matrix / slack ids, and what is NOT an address
   2) body extraction: leading marker only, whitespace tolerated
   3) the two policies differ exactly on the unrecognised target
+  3b) [dm-only] disarms the address, so nothing routes on it
+  3c) asking the parser peels a D7 header a text match cannot see past
   4) THE DEFECT: the old Discord-only predicate disagrees on a Matrix room
   5) every adapter delegates — no private copy of the grammar survives
 
@@ -73,6 +75,7 @@ def main() -> int:
     from proactive_routing import (  # noqa: PLC0415 — see source_checks
         body_claimable_by, body_target_channel, redirect_target_is_foreign,
         target_channel_kind)
+    from result_markers import parse_markers  # noqa: PLC0415
     # 1) The classifier.
     for target, kind in (
         ("1530802402603700415", "discord"),
@@ -118,17 +121,22 @@ def main() -> int:
     check(redirect_target_is_foreign("garbage", "discord"),
           "3) UNRECOGNISED is foreign to the default (discord releases it)")
 
-    # 3b) [dm-only] is a PRIVACY guard, not an address: it suppresses a redirect
-    #     at delivery and must not decide which bridge may claim.
-    check(body_target_channel(f"[dm-only]\n[channel: {ROOM}]\nx") is None,
-          "3b) a body led by [dm-only] addresses no bridge")
-    for channel in ("discord", "slack", "telegram"):
-        check(body_claimable_by(f"[dm-only]\n[channel: {ROOM}]\nx", channel),
-              f"3b) so {channel} may still claim it — the guard routes nothing")
-    # Address FIRST: routing applies, and [dm-only] still stops the redirect, so
-    # it lands in an owner DM either way — which is why routing it is safe.
-    check(not body_claimable_by(f"[channel: {ROOM}]\n[dm-only]\nx", "telegram"),
-          "3b) an addressed body carrying [dm-only] still routes by its address")
+    # 3b) [dm-only] DISARMS the redirect in EITHER order, so no address is left
+    #     to route on — and matching text instead of asking the parser misses it.
+    for order, label in ((f"[dm-only]\n[channel: {ROOM}]\nx", "dm-only first"),
+                         (f"[channel: {ROOM}]\n[dm-only]\nx", "address first")):
+        check(body_target_channel(order) is None,
+              f"3b) {label}: [dm-only] leaves no executable address")
+        for channel in ("discord", "slack", "telegram", "ag2space"):
+            check(body_claimable_by(order, channel),
+                  f"3b) {label}: {channel} may still claim it")
+        check(not any(a.kind == "redirect" for a in parse_markers(order).actions),
+              f"3b) {label}: and the shared parser issues no redirect")
+
+    # 3c) Asking the PARSER also peels a D7 header for free; a leading-marker
+    #     text match cannot see past one.
+    check(body_target_channel(f"**[core: 1]**\n[channel: {ROOM}]\nx") == "ag2space",
+          "3c) a D7-headed body still routes by its address")
 
     # 4) THE DEFECT, stated as the disagreement it is. This is the predicate the
     #    two bridges carried; it is right about Discord and blind to everything else.

--- a/tests/proactive-body-target-routing.test.py
+++ b/tests/proactive-body-target-routing.test.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""A `[channel:]` body implies a BRIDGE, and three adapters each re-derived it.
+
+The filename layer (`.to-<channel>`) already had one owner in proactive_routing.
+The BODY marker did not: slack-bridge and telegram-bridge each carried
+
+    re.match(r'\[channel:\s*\d{17,20}\]', peek)
+
+which recognises a Discord snowflake and nothing else. A Matrix room id therefore
+read as "addressed to nobody" and the file was claimable — so a proactive aimed at
+an ag2.space room could be delivered to the owner's Telegram or Slack DM instead.
+Measured on this host: discord-bridge logged 19 releases of one such file, all
+`!PrxhizfLysTYrYDcnw:ag2.space`, so the shape is live, not hypothetical.
+
+Two policies, one classifier, because the adapters genuinely differ:
+
+  body_claimable_by         slack/telegram — skip only a RECOGNISED foreign target,
+                            so a malformed one still gets delivered rather than
+                            stranded (their pre-existing behaviour, kept).
+  redirect_target_is_foreign  discord — the default destination, so anything not
+                            positively a snowflake is released (also unchanged).
+
+  1) classifier: snowflake / matrix / slack ids, and what is NOT an address
+  2) body extraction: leading marker only, whitespace tolerated
+  3) the two policies differ exactly on the unrecognised target
+  4) THE DEFECT: the old Discord-only predicate disagrees on a Matrix room
+  5) every adapter delegates — no private copy of the grammar survives
+
+Run: python3 tests/proactive-body-target-routing.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+FAILS: list[str] = []
+ROOM = "!PrxhizfLysTYrYDcnw:ag2.space"
+
+
+def check(cond: bool, msg: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def source_checks() -> None:
+    """Run BEFORE the import so a parent-commit run reports the defect, not an
+    ImportError — a missing symbol says nothing about what the old code did."""
+    private = re.compile(r'channel:\\s\*\\d\{17,20\}')
+    for name, channel in (("slack-bridge.py", "slack"),
+                          ("telegram-bridge.py", "telegram")):
+        src = (REPO / "src" / name).read_text(encoding="utf-8")
+        check(f'body_claimable_by(peek, "{channel}")' in src,
+              f"5) {name} delegates its peek to proactive_routing")
+        check("from proactive_routing import" in src and "body_claimable_by" in src,
+              f"5) {name} imports it")
+        check(not private.search(src),
+              f"5) no private Discord-only body grammar survives in {name}")
+    discord = (REPO / "src" / "discord-bridge.py").read_text(encoding="utf-8")
+    check("redirect_target_is_foreign(" in discord,
+          "5) discord-bridge delegates its redirect fence too")
+    check(not private.search(discord),
+          "5) no private Discord-only body grammar survives in discord-bridge.py")
+
+
+def main() -> int:
+    source_checks()
+    from proactive_routing import (  # noqa: PLC0415 — see source_checks
+        body_claimable_by, body_target_channel, redirect_target_is_foreign,
+        target_channel_kind)
+    # 1) The classifier.
+    for target, kind in (
+        ("1530802402603700415", "discord"),
+        ("1022910063620390932", "discord"),
+        (ROOM, "ag2space"),
+        ("#general:ag2.space", "ag2space"),
+        ("C0123ABCD", "slack"),
+        ("G01ABCDEF", "slack"),
+        ("D01ABCDEF", "slack"),
+        # Not addresses: too short for a snowflake, no server part, empty.
+        ("12345", None), ("!room", None), ("garbage", None),
+        ("", None), (None, None), ("   ", None),
+    ):
+        got = target_channel_kind(target)
+        check(got == kind, f"1) {target!r} -> {kind}, got {got}")
+
+    # 2) Only the LEADING marker routes — the rule result_markers already applies
+    #    when deciding whether a redirect is an action or inert prose.
+    for body, kind in (
+        (f"[channel: {ROOM}]\nbody", "ag2space"),
+        (f"  [channel:{ROOM}]\nbody", "ag2space"),
+        ("[channel: 1530802402603700415]\nbody", "discord"),
+        ("prose first\n[channel: 1530802402603700415]\nbody", None),
+        ("see [channel: 1530802402603700415] inline", None),
+        ("no marker at all", None),
+        ("", None),
+    ):
+        got = body_target_channel(body)
+        check(got == kind, f"2) {body[:34]!r} -> {kind}, got {got}")
+
+    # 3) The two policies agree on every recognised target and differ only on the
+    #    unrecognised one. That difference is the deliberate part.
+    for target in (ROOM, "C0123ABCD", "1530802402603700415"):
+        body = f"[channel: {target}]\nx"
+        kind = target_channel_kind(target)
+        for channel in ("discord", "slack", "telegram", "ag2space"):
+            check(body_claimable_by(body, channel) == (kind == channel),
+                  f"3) recognised {target[:18]!r}: claimable by {channel} iff it is {kind}")
+            check(redirect_target_is_foreign(target, channel) == (kind != channel),
+                  f"3) recognised {target[:18]!r}: foreign to {channel} iff it is not {kind}")
+    check(body_claimable_by("[channel: garbage]\nx", "telegram"),
+          "3) UNRECOGNISED stays claimable (telegram delivers rather than strands)")
+    check(redirect_target_is_foreign("garbage", "discord"),
+          "3) UNRECOGNISED is foreign to the default (discord releases it)")
+
+    # 3b) [dm-only] is a PRIVACY guard, not an address: it suppresses a redirect
+    #     at delivery and must not decide which bridge may claim.
+    check(body_target_channel(f"[dm-only]\n[channel: {ROOM}]\nx") is None,
+          "3b) a body led by [dm-only] addresses no bridge")
+    for channel in ("discord", "slack", "telegram"):
+        check(body_claimable_by(f"[dm-only]\n[channel: {ROOM}]\nx", channel),
+              f"3b) so {channel} may still claim it — the guard routes nothing")
+    # And with the address FIRST, routing applies as usual; [dm-only] then stops
+    # the redirect executing, so it lands in the owner's DM on the bridge that
+    # claimed it — an owner DM either way, which is why this is safe to route.
+    check(not body_claimable_by(f"[channel: {ROOM}]\n[dm-only]\nx", "telegram"),
+          "3b) an addressed body carrying [dm-only] still routes by its address")
+
+    # 4) THE DEFECT, stated as the disagreement it is. This is the predicate the
+    #    two bridges carried; it is right about Discord and blind to everything else.
+    old = re.compile(r"\[channel:\s*\d{17,20}\]")
+
+    def old_skips(peek: str) -> bool:
+        return bool(peek.startswith("[channel:") and old.match(peek))
+
+    for body, kind in ((f"[channel: {ROOM}]\nbriefing", "ag2space"),
+                       ("[channel: C0123ABCD]\nbriefing", "slack")):
+        check(not old_skips(body),
+              f"4) the OLD predicate does not skip a {kind} target — the defect")
+        # Every bridge EXCEPT the one addressed must now decline it.
+        for channel in ("telegram", "slack", "discord"):
+            if channel == kind:
+                check(body_claimable_by(body, channel),
+                      f"4) the addressed bridge ({channel}) still claims its own")
+                continue
+            check(not body_claimable_by(body, channel),
+                  f"4) and the new one does not claim a {kind} target on {channel}")
+    snow = "[channel: 1530802402603700415]\nbriefing"
+    check(old_skips(snow) and not body_claimable_by(snow, "telegram"),
+          "4) and both agree on the Discord case, so nothing regresses there")
+
+    print()
+    if FAILS:
+        print(f"{len(FAILS)} FAILED: " + "; ".join(FAILS[:4]))
+        return 1
+    print("PASS — the body marker's bridge implication has one owner")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/proactive-body-target-routing.test.py
+++ b/tests/proactive-body-target-routing.test.py
@@ -118,6 +118,19 @@ def main() -> int:
                   f"3) recognised {target[:18]!r}: foreign to {channel} iff it is not {kind}")
     check(body_claimable_by("[channel: garbage]\nx", "telegram"),
           "3) UNRECOGNISED stays claimable (telegram delivers rather than strands)")
+
+    # 3a) Telegram is NOT a target kind BY DECISION: its bridge drops [channel:]
+    #     redirects, so classifying one would route a file to a non-delivery.
+    tg_src = (REPO / "src" / "telegram-bridge.py").read_text(encoding="utf-8")
+    check("silently drops [channel:] redirects" in tg_src,
+          "3a) telegram-bridge still documents that it DROPS a [channel:] redirect")
+    check("parse_markers(reply_text)" in tg_src,
+          "3a) and the drop happens at its parse_markers call, not a private branch")
+    for tg_id in ("12345", "-1001234567890", "987654321"):
+        check(target_channel_kind(tg_id) is None,
+              f"3a) {tg_id} classifies as NO bridge, so nothing routes to telegram")
+        check(body_claimable_by(f"[channel: {tg_id}]\nx", "telegram"),
+              f"3a) and {tg_id} stays claimable by every bridge — delivered, not stranded")
     check(redirect_target_is_foreign("garbage", "discord"),
           "3) UNRECOGNISED is foreign to the default (discord releases it)")
 

--- a/tests/proactive-dm-failure-keeps-file-behaviour.test.py
+++ b/tests/proactive-dm-failure-keeps-file-behaviour.test.py
@@ -37,6 +37,9 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src"))
 
+# Imported before the stub replaces sys.modules: it hands back the real gate.
+from proactive_routing import redirect_target_is_foreign as _real_redirect_target_is_foreign  # noqa: E402
+
 FAILURES: list[str] = []
 
 
@@ -100,6 +103,8 @@ def _run_one_pass(results: Path, send):
     routing.should_claim_proactive = lambda *_a, **_k: True
     routing.should_claim_proactive_file = lambda *_a, **_k: True
     routing.proactive_destination = lambda *_a, **_k: None
+    # Stubbed routing claims every file; redirect_target_is_foreign stays REAL.
+    routing.redirect_target_is_foreign = _real_redirect_target_is_foreign
     sys.modules["proactive_routing"] = routing
 
     class _DM:

--- a/tests/slack-bridge-channel-redirect-guard.test.py
+++ b/tests/slack-bridge-channel-redirect-guard.test.py
@@ -67,17 +67,33 @@ class TestSlackBridgeChannelRedirectGuard(unittest.TestCase):
             "the file before checking its content.",
         )
 
-    def test_snowflake_regex_present(self):
-        """The guard must use a Discord snowflake regex (17-20 digits) to avoid
-        false-positive matches on Slack channel IDs (which start with C/D prefix,
-        not pure digits).
+    def test_guard_delegates_to_the_shared_classifier(self):
+        """The distinction this test has always been about — a Discord id is not a
+        Slack id — now lives in proactive_routing instead of a literal here.
+
+        The `\\d{17,20}` spelling recognised Discord and NOTHING else, so a Matrix
+        room id read as unaddressed and the file was claimable. Asserting the
+        literal pinned the implementation; asserting the delegate plus its
+        behaviour pins what the literal was for.
         """
         self.assertIn(
-            r"\d{17,20}",
-            SRC,
-            "Snowflake regex (\\d{17,20}) must be present to distinguish Discord "
-            "channel IDs from Slack channel IDs",
-        )
+            'body_claimable_by(peek, "slack")', SRC,
+            "the peek must delegate to proactive_routing, not spell its own grammar")
+        self.assertNotRegex(
+            SRC, r"\\d\{17,20\}",
+            "no private copy of the id grammar may survive in this adapter")
+
+        sys.path.insert(0, str(REPO / "src"))
+        from proactive_routing import body_claimable_by
+
+        # A grep is satisfied by a no-op; these are the discriminations the
+        # docstring above has always named, now actually exercised.
+        self.assertTrue(body_claimable_by("[channel: C0123ABCD]\nx", "slack"),
+                        "a Slack channel id is this bridge's own address")
+        self.assertFalse(body_claimable_by("[channel: 1530802402603700415]\nx", "slack"),
+                         "a Discord snowflake belongs to discord-bridge")
+        self.assertFalse(body_claimable_by("[channel: !Room:ag2.space]\nx", "slack"),
+                         "and a Matrix room to the gateway — the case the literal missed")
 
 
 if __name__ == "__main__":

--- a/tests/telegram-bridge-channel-redirect-guard.test.py
+++ b/tests/telegram-bridge-channel-redirect-guard.test.py
@@ -54,15 +54,32 @@ class TestTelegramBridgeChannelRedirectGuard(unittest.TestCase):
             "telegram-bridge.py must contain a [channel:] guard — see #1401",
         )
 
-    def test_snowflake_pattern_present(self):
-        """The guard must use a Discord snowflake pattern (17-20 digits) to avoid
-        false-positives on Slack channel IDs (which use letter prefixes like C, D, G).
+    def test_guard_delegates_to_the_shared_classifier(self):
+        """The distinction this test is about — a Discord id is not a Slack id —
+        now lives in proactive_routing rather than as a literal here.
+
+        `\\d{17,20}` recognised Discord and NOTHING else, so a Matrix room id read
+        as unaddressed and the file was claimable by this bridge. The literal
+        pinned an implementation; the delegate plus its behaviour pins the point.
         """
         self.assertIn(
-            r"\d{17,20}",
-            SRC,
-            r"telegram-bridge.py must include snowflake regex \d{17,20} in the [channel:] guard",
-        )
+            'body_claimable_by(peek, "telegram")', SRC,
+            "the peek must delegate to proactive_routing, not spell its own grammar")
+        self.assertNotRegex(
+            SRC, r"\\d\{17,20\}",
+            "no private copy of the id grammar may survive in this adapter")
+
+        sys.path.insert(0, str(REPO / "src"))
+        from proactive_routing import body_claimable_by
+
+        self.assertFalse(body_claimable_by("[channel: 1530802402603700415]\nx", "telegram"),
+                         "a Discord snowflake belongs to discord-bridge")
+        self.assertFalse(body_claimable_by("[channel: C0123ABCD]\nx", "telegram"),
+                         "a Slack channel id belongs to slack-bridge")
+        self.assertFalse(body_claimable_by("[channel: !Room:ag2.space]\nx", "telegram"),
+                         "and a Matrix room to the gateway — the case the literal missed")
+        self.assertTrue(body_claimable_by("an ordinary proactive body", "telegram"),
+                        "an unaddressed body is still this bridge's to claim")
 
     def test_peek_occurs_before_rename(self):
         """The peek (read_text) must appear before the rename call in the
@@ -90,8 +107,11 @@ class TestTelegramBridgeChannelRedirectGuard(unittest.TestCase):
         proactive_block_start = SRC.find("PROACTIVE_PREFIXES")
         self.assertGreater(proactive_block_start, 0)
 
-        # The guard should appear before rename(claim) in source order
-        guard_continue_pos = SRC.find("continue", SRC.find("[channel:", proactive_block_start))
+        # Anchor on the gate CALL, not on the string "[channel:" — that literal
+        # appears elsewhere in a 3k-line file and silently moved this assertion.
+        gate_pos = SRC.find('body_claimable_by(peek, "telegram")', proactive_block_start)
+        self.assertGreater(gate_pos, 0, "delegated peek gate not found in the proactive block")
+        guard_continue_pos = SRC.find("continue", gate_pos)
         rename_pos = _claim_pos(SRC, proactive_block_start)
         self.assertGreater(guard_continue_pos, 0, "continue not found in guard block")
         self.assertLess(

--- a/tests/telegram-proactive-release-on-refusal.test.py
+++ b/tests/telegram-proactive-release-on-refusal.test.py
@@ -37,6 +37,11 @@ def check(name: str, cond: bool, detail: str = "") -> None:
         print(f"  FAIL {name} {detail}")
 
 
+sys.path.insert(0, str(REPO / "src"))
+# Imported before the stub replaces sys.modules: it hands back the real gate.
+from proactive_routing import body_claimable_by as _real_body_claimable_by  # noqa: E402
+
+
 class _Stop(Exception):
     """Breaks main()'s poll loop after the drain has run."""
 
@@ -78,6 +83,8 @@ def _run_one_drain(mod, results: Path, send_result: dict):
     routing.should_claim_proactive = lambda *_a, **_k: True
     routing.should_claim_proactive_file = lambda *_a, **_k: True
     routing.proactive_destination = lambda *_a, **_k: None
+    # Stubbed routing claims every file; body_claimable_by stays REAL.
+    routing.body_claimable_by = _real_body_claimable_by
     sys.modules["proactive_routing"] = routing
     mod.presenter_mode_active = lambda *_a, **_k: False
     t = threading.Thread(target=lambda: _swallow(mod.main), daemon=True)


### PR DESCRIPTION
## The defect

`results/proactive-*.txt` is polled by every bridge. The **filename** layer (`.to-<channel>`) has had one owner in `proactive_routing` for a while. The **body** layer — a leading `[channel: X]` — did not, and each adapter re-derived it. Two of them wrote the same Discord-only predicate:

```python
# src/slack-bridge.py:1617  and  src/telegram-bridge.py:1032, at 565db9fc
if peek.startswith("[channel:") and re.match(r'\[channel:\s*\d{17,20}\]', peek):
    continue
```

A `[channel:]` marker names a channel, but it **implies a bridge**. That predicate recognises a Discord snowflake and nothing else, so a Matrix room id or a Slack channel id reads as *"addressed to nobody"* and the file becomes claimable — by a bridge that cannot deliver it, which then sends the body to the owner's DM on the wrong surface.

`proactive_routing`'s own docstring already states the principle the filename layer follows: *"a file aimed at a channel this install lacks must strand visibly, never fall into another bridge's race."* The body layer was the half that never got it.

## It is live, and only incidentally protected

Measured on this host — `discord-bridge` correctly released one such file over and over, and every release is the same target:

```
$ grep -c "not a Discord channel id; releasing" logs/discord-bridge.log
19
$ grep -oE "targets '[^']+'" logs/discord-bridge.log | sort | uniq -c
  19 targets '!PrxhizfLysTYrYDcnw:ag2.space'
```

Nothing was actually misdelivered, and the reason is **not** the peek gate — it is activity routing. The owner has been on Discord, so `should_claim_proactive_file` never let Telegram near the file. Change that one condition and the gate is all that is left:

```
=== PARENT 565db9fc ===
  owner last active on telegram -> telegram claims this file?  True
  peek gate (inline Discord-only regex) lets it through?       True
  => DELIVERED TO TELEGRAM DM: True
=== THIS BRANCH ===
  owner last active on telegram -> telegram claims this file?  True
  peek gate (body_claimable_by) lets it through?               False
  => DELIVERED TO TELEGRAM DM: False
```

That is an ag2.space room briefing landing in a Telegram DM instead of the room it named.

## The fix

One classifier in `proactive_routing`, two policies over it, because the adapters genuinely differ and pretending otherwise would change behaviour:

| helper | used by | unrecognised target |
|---|---|---|
| `body_claimable_by(body, ch)` | slack, telegram | **claimable** — delivered, not stranded (their existing behaviour, kept) |
| `redirect_target_is_foreign(t, ch)` | discord | **foreign** — released (its existing behaviour, kept) |

Discord is the default destination, so it can afford to be strict; a malformed marker must not fall into the default's delivery. Slack and Telegram must not strand a briefing on a typo. Both rules were already in force — this PR moves them next to each other and gives them one grammar, so a fourth surface cannot arrive with a fifth spelling.

Only the **leading** marker routes, matching the rule `result_markers` already applies when deciding whether a redirect is an executable action or inert prose.

## `[dm-only]` is a privacy guard, not an address

**Corrected after opening — see `569993c2` and the first comment.** This section originally claimed that an addressed body carrying `[dm-only]` still routes by its address and lands in an owner DM either way. That was reasoning, not measurement, and it was wrong.

`[dm-only]` **disarms the redirect in either marker order** — `parse_markers` issues no redirect action at all — so there is no executable address to route on. Matching the leading `[channel:]` as text saw one anyway, which would have routed the file to a bridge that will not deliver it (`_proactive_route` returns `("send", None, body)`, needs `PROACTIVE_ROOM`, and with none set skips before claiming at `:2738`) while the bridges that *would* deliver it declined. A strand, on the one body shape the marker grammar treats as sensitive.

`body_target_channel` now reads the shared parser's redirect action rather than matching text — which is what the rest of this PR argues for, and it peels a D7 `**[core: N]**` header for free.

## Tests

New `tests/proactive-body-target-routing.test.py` — 68 checks over the classifier, body extraction, the two policies, the `[dm-only]` interaction, and the delegation of all three adapters.

**Its source-level checks run BEFORE the import on purpose.** A parent-commit run would otherwise report `ImportError: cannot import name 'body_claimable_by'`, which says nothing about what the old code did. As structured, the parent run names the defect:

```
at 565db9fc:
  FAIL 5) no private Discord-only body grammar survives in slack-bridge.py
  FAIL 5) no private Discord-only body grammar survives in telegram-bridge.py
  FAIL 5) slack-bridge.py delegates its peek to proactive_routing
  FAIL 5) telegram-bridge.py delegates its peek to proactive_routing
  FAIL 5) discord-bridge delegates its redirect fence too
```

`tests/discord-proactive-foreign-target.test.py` was updated rather than deleted, and this is the part worth reviewing closely. It pinned the gate by grepping for the `\d{17,20}` literal in all three adapters — i.e. it pinned the *how*, and this PR changes exactly that. Every property it protected is still asserted: the gate exists in the claim block, it runs **before** owner resolution, its branch releases the claim, and all three adapters agree. Added on top: a **behavioural** check that the delegate actually rejects a Matrix room and accepts a snowflake (a grep is satisfied by a no-op), and a scan that no private copy of the grammar survived.

## Verification

Ran the full `tests/*.test.py` population — the same set CI's standalone step globs — at this branch **and** at the parent, so a failure is attributable rather than assumed.

```
PARENT 565db9fc   5 failing of 565
BRANCH            5 failing of 566   <- same five, plus one more test file
```

Parent baseline is `codex-core-launcher` (a 1.34s-vs-1.0s timing budget on a loaded machine), `gateway-owner-presence-peer-gate`, and three `screen-capture` suites.

**That population run is why this PR has a second commit.** My hand-picked sweep of "related" suites was green; the population run found four suites pinned to the `\d{17,20}` literal and two hand-built `proactive_routing` stubs missing the new name. Details in the commit message — the one worth reading here is `telegram-bridge-channel-redirect-guard`, whose before-claim ordering assertion anchored on the **string** `"[channel:"` and therefore kept passing a *different* comparison once the peek stopped spelling it. It now anchors on the gate call.

`ruff` clean. `scripts/review-checks.sh --diff` clean.

## Not verified

No live post-restart round trip. This is a delivery path on three bridges, so if you would rather see it exercised against a real proactive before merging, say so and I will hold it.

cc @sonichi

🤖 Generated with [Claude Code](https://claude.com/claude-code)
