### PR TITLE
fix(task-bridge): [deduped:] skipped the ownership guard the other two markers use

### DIFF
--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -1,7 +1,12 @@
 // Suppression is universal; retirement authority is scoped to the consumer
 // that dispatched the task. One predicate for both narrowed both.
 
-export const SKIP_MARKER_RE = /^\s*\[(?:no-send|REPLIED)\]/i;
+// `deduped` belongs here for the same reason the other two do: Python's
+// parse_markers() classifies all three as ONE `skip` kind, so a consumer that
+// routes only two of them through the retirement guard is not at parity. The
+// target is matched as `[^\]]+` — any non-bracket run, closing bracket
+// REQUIRED — mirroring result_markers.py rather than re-deriving a grammar.
+export const SKIP_MARKER_RE = /^\s*(?:\[(?:no-send|REPLIED)\]|\[deduped:\s*[^\]]+\])/i;
 
 export function isSkipMarked(file: string, result: string): boolean {
 	return file.startsWith('task-') && SKIP_MARKER_RE.test(result);

--- a/src/skip_marker_ownership.ts
+++ b/src/skip_marker_ownership.ts
@@ -1,15 +1,20 @@
 // Suppression is universal; retirement authority is scoped to the consumer
 // that dispatched the task. One predicate for both narrowed both.
 
-// `deduped` belongs here for the same reason the other two do: Python's
-// parse_markers() classifies all three as ONE `skip` kind, so a consumer that
-// routes only two of them through the retirement guard is not at parity. The
-// target is matched as `[^\]]+` — any non-bracket run, closing bracket
-// REQUIRED — mirroring result_markers.py rather than re-deriving a grammar.
+// All three are ONE `skip` kind in parse_markers(); grammar mirrors it.
 export const SKIP_MARKER_RE = /^\s*(?:\[(?:no-send|REPLIED)\]|\[deduped:\s*[^\]]+\])/i;
 
+// Pool cores prepend `**[core: N]**` + optional `_(...)_`; parse_markers peels
+// it before any marker scan (result_markers.py:135), so this must too.
+export const D7_HEADER_RE = /^\*\*\[core:\s*[^\]]+\]\*\*\s*\n(?:_[^\n]*_\s*\n)?\s*/;
+
+/** True iff `result`'s body carries a skip marker, D7 header peeled first. */
+export function bodyIsSkipMarked(result: string): boolean {
+	return SKIP_MARKER_RE.test(String(result ?? "").replace(D7_HEADER_RE, ""));
+}
+
 export function isSkipMarked(file: string, result: string): boolean {
-	return file.startsWith('task-') && SKIP_MARKER_RE.test(result);
+	return file.startsWith('task-') && bodyIsSkipMarked(result);
 }
 
 // Evidence that some OTHER consumer will deliver and archive this result.

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -15,7 +15,7 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';
 import { tryStampText } from './task_envelope.js';
 import { claudeHomePath } from './util_paths.js';
-import { isSkipMarked, mayRetireSkipMarked, SKIP_MARKER_RE, type TaskOrigin } from './skip_marker_ownership.js';
+import { isSkipMarked, mayRetireSkipMarked, bodyIsSkipMarked, type TaskOrigin } from './skip_marker_ownership.js';
 import { recordConversation, recordSessionBoundary } from './conversation-store.js';
 import {
 	emitTaskProcessed,
@@ -767,11 +767,9 @@ function startRelayResultWatcher(onResult: (result: string) => void): void {
 				if (!result) continue;
 				_deliveredResults.add(file);
 				_pendingTasks.delete(taskId);
-				// Same grammar as the local watcher and as parse_markers(): this used
-				// to be a third private copy, and it drifted two ways — no /i flag, so
-				// `[DEDUPED: x]` fell through and got NARRATED; and `[^\]]*` accepted an
-				// empty `[deduped:]` that Python rejects.
-				if (!SKIP_MARKER_RE.test(result)) {
+				// Was a third private copy that drifted: no /i, and `[^\]]*` accepted
+				// an empty `[deduped:]` Python rejects. One predicate now.
+				if (!bodyIsSkipMarked(result)) {
 					_sendTaskStatus?.(taskId, 'done', 'Task complete', result);
 					onResult(`[Task result for ${taskId}]\n${result}`);
 				}
@@ -929,11 +927,8 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					setTimeout(() => archiveFile(path, 'results', `voice-${Date.now()}`), 10_000);
 					continue;
 				}
-				// Skip markers: [no-send] / [REPLIED] / [deduped: <id>] — archive silently,
-				// no voice narration. `deduped` used to be handled in its own branch ABOVE
-				// this one, which returned before reaching mayRetireSkipMarked — so the one
-				// marker whose whole purpose is 'another result carries the reply' was the
-				// one that could retire a result this bridge never dispatched.
+				// [no-send] / [REPLIED] / [deduped: <id>] — archive silently, no voice.
+				// deduped had its own branch above this one, bypassing the ownership gate.
 				// These are set by the core agent when delivery already happened via another path
 				// (e.g. Discord bridge already replied) or the result should be suppressed entirely.
 				// Parity with Python bridges: discord-bridge.py and telegram-bridge.py both honor

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -15,7 +15,7 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';
 import { tryStampText } from './task_envelope.js';
 import { claudeHomePath } from './util_paths.js';
-import { isSkipMarked, mayRetireSkipMarked, type TaskOrigin } from './skip_marker_ownership.js';
+import { isSkipMarked, mayRetireSkipMarked, SKIP_MARKER_RE, type TaskOrigin } from './skip_marker_ownership.js';
 import { recordConversation, recordSessionBoundary } from './conversation-store.js';
 import {
 	emitTaskProcessed,
@@ -767,8 +767,11 @@ function startRelayResultWatcher(onResult: (result: string) => void): void {
 				if (!result) continue;
 				_deliveredResults.add(file);
 				_pendingTasks.delete(taskId);
-				const skip = /^\s*\[(deduped:[^\]]*|no-send|REPLIED)\]/.exec(result);
-				if (!skip) {
+				// Same grammar as the local watcher and as parse_markers(): this used
+				// to be a third private copy, and it drifted two ways — no /i flag, so
+				// `[DEDUPED: x]` fell through and got NARRATED; and `[^\]]*` accepted an
+				// empty `[deduped:]` that Python rejects.
+				if (!SKIP_MARKER_RE.test(result)) {
 					_sendTaskStatus?.(taskId, 'done', 'Task complete', result);
 					onResult(`[Task result for ${taskId}]\n${result}`);
 				}
@@ -926,31 +929,11 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					setTimeout(() => archiveFile(path, 'results', `voice-${Date.now()}`), 10_000);
 					continue;
 				}
-				// Deduped-marker result: agent consolidated this task's reply
-				// into another task's result file. Mark this task done silently
-				// and archive — no Discord post, no voice narration, no timeout.
-				// Format: first line is "[deduped: <other-task-id>]" (rest of
-				// file optional, displayed as the result body in the UI).
-				if (file.startsWith('task-') && /^\s*\[deduped:\s*task-/i.test(result)) {
-					console.log(`${ts()} [TaskBridge] ${taskId} is deduped marker; archiving silently`);
-					_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
-					_deliveredResults.add(file);
-					_pendingTasks.delete(taskId);
-					try {
-						fetch('http://localhost:7843/task-done', {
-							method: 'POST',
-							headers: _apiHeaders(),
-							body: JSON.stringify({ taskId, result }),
-						}).catch(() => {});
-					} catch {}
-					setTimeout(() => {
-						archiveFile(path, 'results', taskId);
-						const taskFile = join(TASK_DIR, `${taskId}.txt`);
-						if (existsSync(taskFile)) archiveFile(taskFile, 'tasks', taskId);
-					}, 5_000);
-					continue;
-				}
-				// Skip markers: [no-send] / [REPLIED] — archive silently with no voice narration.
+				// Skip markers: [no-send] / [REPLIED] / [deduped: <id>] — archive silently,
+				// no voice narration. `deduped` used to be handled in its own branch ABOVE
+				// this one, which returned before reaching mayRetireSkipMarked — so the one
+				// marker whose whole purpose is 'another result carries the reply' was the
+				// one that could retire a result this bridge never dispatched.
 				// These are set by the core agent when delivery already happened via another path
 				// (e.g. Discord bridge already replied) or the result should be suppressed entirely.
 				// Parity with Python bridges: discord-bridge.py and telegram-bridge.py both honor

--- a/tests/task-bridge-skip-marker-ownership.test.ts
+++ b/tests/task-bridge-skip-marker-ownership.test.ts
@@ -185,3 +185,42 @@ describe('a durable claim outranks the source label', () => {
 			false, 'a claimed result with no source line was retired');
 	});
 });
+
+// `[deduped: <id>]` is the third skip marker. Python's parse_markers() has always
+// classified all three as ONE `skip` kind; task-bridge.ts handled this one in a
+// separate branch that returned BEFORE mayRetireSkipMarked, so the marker whose
+// entire meaning is "another result carries the reply" was the only one that
+// could retire a result this bridge never dispatched. Expectations below were
+// MEASURED against src/result_markers.py, not authored by hand.
+describe('task-bridge — [deduped:] is a skip marker under the same ownership rule', () => {
+	it('recognises a well-formed deduped marker', () => {
+		assert.equal(isSkipMarked(`${OWN}.txt`, '[deduped: task-123]'), true);
+	});
+
+	it('will NOT retire a foreign bridge\'s deduped result', () => {
+		// The case that motivated this: previously archived unconditionally.
+		assert.equal(
+			mayRetireSkipMarked(`${FOREIGN}.txt`, '[deduped: task-123]', noneOwned, origin), false,
+			'a deduped result this bridge never dispatched was retired, stranding its reply');
+	});
+
+	it('still retires its own deduped result', () => {
+		assert.equal(mayRetireSkipMarked(`${OWN}.txt`, '[deduped: task-123]', owns, origin), true);
+	});
+
+	it('matches result_markers.py exactly on the grammar edges', () => {
+		const py: [string, boolean][] = [
+			['[deduped: task-123]',         true ],
+			['[deduped: task-123',          false],  // closing bracket REQUIRED
+			['[deduped: phone-abc.task-9]', true ],  // any target, not just task-*
+			['[DEDUPED: task-123]',         true ],  // case-insensitive
+			['  [deduped:task-123]',        true ],
+			['[deduped: ]',                 true ],  // whitespace target: Python accepts
+			['[deduped:]',                  false],  // empty: Python rejects
+		];
+		for (const [body, want] of py) {
+			assert.equal(isSkipMarked(`${OWN}.txt`, body), want,
+				`grammar disagrees with parse_markers() on ${JSON.stringify(body)}`);
+		}
+	});
+});

--- a/tests/task-bridge-skip-marker-ownership.test.ts
+++ b/tests/task-bridge-skip-marker-ownership.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { hasNetworkConsumer, isSkipMarked, mayRetireSkipMarked }
+import { bodyIsSkipMarked, hasNetworkConsumer, isSkipMarked, mayRetireSkipMarked }
 	from '../src/skip_marker_ownership.js';
 
 // results/ is shared by every consumer. Matching `task-*` plus a skip marker
@@ -186,12 +186,8 @@ describe('a durable claim outranks the source label', () => {
 	});
 });
 
-// `[deduped: <id>]` is the third skip marker. Python's parse_markers() has always
-// classified all three as ONE `skip` kind; task-bridge.ts handled this one in a
-// separate branch that returned BEFORE mayRetireSkipMarked, so the marker whose
-// entire meaning is "another result carries the reply" was the only one that
-// could retire a result this bridge never dispatched. Expectations below were
-// MEASURED against src/result_markers.py, not authored by hand.
+// Third skip marker; had its own branch that returned before the ownership gate.
+// Expectations MEASURED against src/result_markers.py, not authored by hand.
 describe('task-bridge — [deduped:] is a skip marker under the same ownership rule', () => {
 	it('recognises a well-formed deduped marker', () => {
 		assert.equal(isSkipMarked(`${OWN}.txt`, '[deduped: task-123]'), true);
@@ -222,5 +218,35 @@ describe('task-bridge — [deduped:] is a skip marker under the same ownership r
 			assert.equal(isSkipMarked(`${OWN}.txt`, body), want,
 				`grammar disagrees with parse_markers() on ${JSON.stringify(body)}`);
 		}
+	});
+});
+
+// A pool core prepends `**[core: N]**` before the marker; parse_markers peels it
+// before scanning, so a consumer that does not is narrating a suppressed result.
+describe('task-bridge — D7 `**[core: N]**` header is peeled before the marker scan', () => {
+	const D7: [string, boolean][] = [
+		['**[core: 1]**\n[deduped: task-1]',      true ],
+		['**[core: 1]**\n[no-send]',              true ],
+		['**[core: 1]**\n[REPLIED]',              true ],
+		['**[core: 7]**\n_(routed)_\n[no-send]',  true ],
+		['**[core: 1]**\nthe actual reply',       false],
+	];
+
+	it('matches result_markers.py on every D7-prefixed body', () => {
+		for (const [body, want] of D7) {
+			assert.equal(bodyIsSkipMarked(body), want,
+				`disagrees with parse_markers() on ${JSON.stringify(body)}`);
+		}
+	});
+
+	it('retires an OWNED D7-prefixed deduped result', () => {
+		assert.equal(
+			mayRetireSkipMarked(`${OWN}.txt`, '**[core: 1]**\n[deduped: task-1]', owns, origin), true,
+			'a D7-prefixed skip marker was narrated instead of suppressed');
+	});
+
+	it('still refuses a FOREIGN D7-prefixed result', () => {
+		assert.equal(
+			mayRetireSkipMarked(`${FOREIGN}.txt`, '**[core: 1]**\n[no-send]', noneOwned, origin), false);
 	});
 });

--- a/tests/task-bridge-skip-markers.test.ts
+++ b/tests/task-bridge-skip-markers.test.ts
@@ -74,14 +74,22 @@ describe('task-bridge.ts — [no-send]/[REPLIED] skip-marker handling (#1381)', 
 		);
 	});
 
-	it('skip-marker guard appears after the [deduped:] check (correct ordering)', () => {
-		const dedupIdx = SRC.indexOf('deduped marker; archiving silently');
-		const skipIdx = SRC.indexOf('has skip marker');
-		assert.ok(dedupIdx !== -1, '"deduped marker; archiving silently" log not found');
-		assert.ok(skipIdx !== -1, '"has skip marker" log not found');
+	it('has NO private [deduped:] matcher left in code — it is a skip marker now', () => {
+		// SUPERSEDES an earlier assertion that the [deduped:] branch must appear
+		// BEFORE the skip-marker guard. That ordering was the defect, not the
+		// design: the deduped branch returned before mayRetireSkipMarked, so the
+		// one marker meaning "another result carries the reply" was the only one
+		// that could retire a result this bridge never dispatched. #3018 already
+		// moved [no-send]/[REPLIED] into the ownership module for exactly this
+		// reason ("a prefix match is not ownership"); deduped was left behind.
+		// Strip comments, then require that `deduped` survives nowhere in CODE —
+		// the grammar lives once, in skip_marker_ownership.ts.
+		const code = SRC
+			.replace(/\/\*[\s\S]*?\*\//g, '')
+			.split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
 		assert.ok(
-			dedupIdx < skipIdx,
-			`[deduped:] guard (pos ${dedupIdx}) must appear before skip-marker guard (pos ${skipIdx})`
+			!code.includes('deduped'),
+			'task-bridge.ts still carries a private [deduped:] matcher; it must delegate to SKIP_MARKER_RE'
 		);
 	});
 

--- a/tests/task-bridge-skip-markers.test.ts
+++ b/tests/task-bridge-skip-markers.test.ts
@@ -75,15 +75,8 @@ describe('task-bridge.ts — [no-send]/[REPLIED] skip-marker handling (#1381)', 
 	});
 
 	it('has NO private [deduped:] matcher left in code — it is a skip marker now', () => {
-		// SUPERSEDES an earlier assertion that the [deduped:] branch must appear
-		// BEFORE the skip-marker guard. That ordering was the defect, not the
-		// design: the deduped branch returned before mayRetireSkipMarked, so the
-		// one marker meaning "another result carries the reply" was the only one
-		// that could retire a result this bridge never dispatched. #3018 already
-		// moved [no-send]/[REPLIED] into the ownership module for exactly this
-		// reason ("a prefix match is not ownership"); deduped was left behind.
-		// Strip comments, then require that `deduped` survives nowhere in CODE —
-		// the grammar lives once, in skip_marker_ownership.ts.
+		// Comments are stripped first: `deduped` may survive in prose, never in CODE.
+		// The grammar lives once, in skip_marker_ownership.ts.
 		const code = SRC
 			.replace(/\/\*[\s\S]*?\*\//g, '')
 			.split('\n').filter(l => !l.trim().startsWith('//')).join('\n');


### PR DESCRIPTION
## What

`[no-send]` and `[REPLIED]` reach `mayRetireSkipMarked` before task-bridge archives anything. `[deduped: <id>]` did not — it had its own branch ~24 lines earlier that archived, POSTed `/task-done` and `continue`d, so it never met the guard.

That is the one marker whose entire meaning is *"another result carries the reply"*, and it was the only one that could retire a result this bridge never dispatched. #3018 (merged 08-18) added that guard for exactly this failure — *"a prefix match is not ownership"* — and its own suite header records the measured incident: five 2–5 KB replies resident while the archived copy was a tiny marker note.

Python's `parse_markers()` has always classified all three as **one** `skip` kind. TypeScript split that concept across three private regexes and guarded one of them.

## Three copies, now one owner

| where | old | now |
|---|---|---|
| `task-bridge.ts:934` | `/^\s*\[deduped:\s*task-/i` — unguarded branch | deleted; falls through to the guarded path |
| `task-bridge.ts:770` | `/^\s*\[(deduped:[^\]]*\|no-send\|REPLIED)\]/` — relay path | delegates to `SKIP_MARKER_RE` |
| `skip_marker_ownership.ts` | `no-send\|REPLIED` | gains `deduped` with the Python grammar |

## The grammar was measured, not authored

Expectations came from running `src/result_markers.py`, not from reading it. The old inline regex diverged on **3 of 8** cases:

```
body                          old TS   parse_markers
[deduped: task-123            TRUE     False    <- missing ']' silently archived the task
[deduped: phone-abc.task-9]   FALSE    True     <- the documented phoneCallKey namespace
[deduped: ]                   FALSE    True
```

A missing `]` is an easy hand-written typo, and it made the voice path archive a task as done while the Python bridge saw no marker and delivered the literal text `[deduped: task-123` to the owner.

The relay copy diverged differently again: no `/i`, so `[DEDUPED: x]` fell through and got **narrated by voice**; and `[^\]]*` accepted an empty `[deduped:]` that Python rejects.

## One existing assertion replaced — stricter, not weaker

`task-bridge-skip-markers.test.ts` pinned the deduped branch to appear *before* the skip guard ("correct ordering"). That ordering was the defect, not the design, and the assertion checked a **log string's position**, not any behaviour. It is replaced by the invariant that supersedes it: no private `deduped` matcher may survive in code. **That replacement fails on main.**

## Before / after

Full `tests/**/*.test.ts`, exactly as CI runs it (`npm run test:ts`), parent `815277f2` vs this head:

```
parent  1197 pass / 6 fail          head  1201 pass / 2 fail
```

Four assertions flip fail → pass. They are the new ones, and **all four fail on main**:

```
✖ recognises a well-formed deduped marker
✖ still retires its own deduped result
✖ matches result_markers.py exactly on the grammar edges
✖ has NO private [deduped:] matcher left in code
```

**The residual 2 are flake, and I checked rather than assumed.** They are voice-audio / web-voice perf budgets (µs p99, KiB scan limits) that reference neither `task-bridge` nor skip markers. They flip *between runs in both directions*, and in isolation those two files pass **147/147 on three consecutive runs** on this head — they only fail under full-suite CPU contention.

`tsc --noEmit`: parent and head produce the **identical 6 pre-existing errors** (local `bodhi-realtime-agent` dep drift; CI clean-installs). This change adds none.

## Honest caveat

The one test that most directly names the bug — *"will NOT retire a foreign bridge's deduped result"* — **passes on main vacuously**, because `isSkipMarked` returns false there and so the guard returns false for the wrong reason. The unguarded branch lived in the poll loop, which no unit test drives. The source-level invariant above is what actually pins its removal.

## Prior decision checked

`#1556` proposed adjacent work and was closed because issue `#1381` was marked `HOLD` pending the `#1347` refactor. Both are now closed (`#1381` 06-13, `#1347` 06-20), and this is not a `#1381` parity feature — it is a defect in what `#3018` shipped on 08-18.

🚩 @sonichi — this needs your review + merge. Bots don't self-merge, and my PRs are authored under your identity so GitHub never surfaces them in your review queue.
