### PR TITLE
fix(health-check): a Console row the live host contradicts is stale, not a setup gap

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2438,9 +2438,12 @@ def check_onboarding_status() -> "dict | None":
         # running" from a reconnect. `str()` because a separate repo writes this.
         todo_keys = [k for k, v in sorted(rows.items())
                      if isinstance(v, dict) and v.get("state") == "todo"]
-        # A mirror row this host's own heartbeat contradicts is stale, not a
-        # real gap: the Console writes on change and can be hours behind.
-        stale_core = "core" in todo_keys and _fresh_local_core_record() is not None
+        # A heartbeat refutes only the runtime-DOWN row; the writer also emits
+        # "core running, Claude sign-in required", a real gap on a running core.
+        _core = rows.get("core") if isinstance(rows.get("core"), dict) else {}
+        _down = (_core.get("claude_authed") is not False
+                 and "not running" in str(_core.get("detail") or "").lower())
+        stale_core = "core" in todo_keys and _down and _fresh_local_core_record() is not None
         if stale_core:
             todo_keys.remove("core")
         todo = [f"{k} ({d})" if (d := str(rows[k].get("detail") or "").strip()[:120]) else k

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2436,15 +2436,30 @@ def check_onboarding_status() -> "dict | None":
         rows = data["rows"]
         # Carry each row's own detail: "gateway" alone cannot distinguish "not
         # running" from a reconnect. `str()` because a separate repo writes this.
-        todo = [f"{k} ({d})" if (d := str(v.get("detail") or "").strip()[:120]) else k
-                for k, v in sorted(rows.items())
-                if isinstance(v, dict) and v.get("state") == "todo"]
+        todo_keys = [k for k, v in sorted(rows.items())
+                     if isinstance(v, dict) and v.get("state") == "todo"]
+        # A mirror row this host's own heartbeat contradicts is stale, not a
+        # real gap: the Console writes on change and can be hours behind.
+        stale_core = "core" in todo_keys and _fresh_local_core_record() is not None
+        if stale_core:
+            todo_keys.remove("core")
+        todo = [f"{k} ({d})" if (d := str(rows[k].get("detail") or "").strip()[:120]) else k
+                for k in todo_keys]
         # Absent/null/0 updated_at is UNKNOWN, not the epoch — int(None or 0)
         # rendered the whole unix time as an age (~56 years) on both lines.
         _updated = int(data.get("updated_at", 0) or 0)
         age_s = max(0, int(time.time()) - _updated) if _updated > 0 else None
     except (ValueError, OSError, TypeError):
         return {"name": name, "status": "warn", "detail": "onboarding-status.json unreadable"}
+    if stale_core:
+        rest = f"; still todo: {', '.join(todo)}" if todo else ""
+        return {
+            "name": name,
+            "status": "warn",
+            "detail": (f"Console mirror is stale — its core row says 'not running' but this "
+                       f"host's heartbeat is live; mirror last written {_age_phrase(age_s)}"
+                       f"{rest}"),
+        }
     if todo:
         return {
             "name": name,

--- a/tests/onboarding-status-check.test.py
+++ b/tests/onboarding-status-check.test.py
@@ -99,6 +99,30 @@ class OnboardingStatusCheckTest(unittest.TestCase):
         self.assertIn("setup incomplete", out["detail"])
         self.assertIn("core", out["detail"])
 
+    def test_a_peer_hosts_heartbeat_does_not_silence_a_local_gap(self):
+        """The reason this uses _fresh_local_core_record() and not the fleet-wide
+        resolver: that one globs every synced state/cores/*.alive and takes the
+        freshest, which the workspace contract permits to be another machine's.
+        """
+        import time
+        ws = self._with_workspace(
+            {"updated_at": 1, "rows": {"core": {"state": "todo",
+                                                "detail": "core not running"}}}
+        )
+        d = ws / "state" / "cores"
+        d.mkdir(parents=True, exist_ok=True)
+        peer = d / "some-peer-host.alive"
+        peer.write_text(json.dumps({"ts": int(time.time())}))
+        self.assertFalse((d / f"{hc._host_label()}.alive").exists(),
+                         "premise: THIS host has no heartbeat, only the peer does")
+
+        out = hc.check_onboarding_status()
+
+        self.assertEqual(out["status"], "warn",
+                         f"a peer's heartbeat must not clear a local gap: {out!r}")
+        self.assertIn("setup incomplete", out["detail"])
+        self.assertIn("core", out["detail"])
+
     def test_other_todo_rows_survive_a_stale_core_row(self):
         ws = self._with_workspace(
             {"updated_at": 1, "rows": {"core": {"state": "todo",

--- a/tests/onboarding-status-check.test.py
+++ b/tests/onboarding-status-check.test.py
@@ -36,6 +36,56 @@ class OnboardingStatusCheckTest(unittest.TestCase):
         self.addCleanup(lambda: setattr(hc, "WORKSPACE_DIR", orig))
         return ws
 
+    def _core_heartbeat(self, ws, *, fresh: bool):
+        """Write this host's core heartbeat; fresh=False makes it look dead."""
+        import os
+        import time
+        d = ws / "state" / "cores"
+        d.mkdir(parents=True, exist_ok=True)
+        f = d / f"{hc._host_label()}.alive"
+        f.write_text(json.dumps({"ts": int(time.time())}))
+        if not fresh:
+            old = time.time() - 3600
+            os.utime(f, (old, old))
+        return f
+
+    def test_stale_core_row_reported_as_stale_mirror_not_setup_gap(self):
+        """The mirror said 'core not running' while the core's own heartbeat was
+        19s old — the probe reported a 9h-old third-party claim as current fact."""
+        ws = self._with_workspace(
+            {"updated_at": 1, "rows": {"core": {"state": "todo",
+                                                "detail": "core not running"}}}
+        )
+        self._core_heartbeat(ws, fresh=True)
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("stale", out["detail"].lower())
+        # The false claim must NOT survive as user-facing incompleteness.
+        self.assertNotIn("setup incomplete", out["detail"])
+
+    def test_core_row_still_reported_when_heartbeat_is_dead(self):
+        """Mutation guard: with no live heartbeat the row is a REAL gap, so the
+        stale-mirror branch must not swallow it."""
+        ws = self._with_workspace(
+            {"updated_at": 1, "rows": {"core": {"state": "todo",
+                                                "detail": "core not running"}}}
+        )
+        self._core_heartbeat(ws, fresh=False)
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("setup incomplete", out["detail"])
+        self.assertIn("core", out["detail"])
+
+    def test_other_todo_rows_survive_a_stale_core_row(self):
+        ws = self._with_workspace(
+            {"updated_at": 1, "rows": {"core": {"state": "todo"},
+                                       "gateway": {"state": "todo"}}}
+        )
+        self._core_heartbeat(ws, fresh=True)
+        out = hc.check_onboarding_status()
+        self.assertIn("stale", out["detail"].lower())
+        self.assertIn("gateway", out["detail"])
+
     def test_none_when_file_absent(self):
         self._with_workspace(None)
         self.assertIsNone(hc.check_onboarding_status())

--- a/tests/onboarding-status-check.test.py
+++ b/tests/onboarding-status-check.test.py
@@ -63,6 +63,29 @@ class OnboardingStatusCheckTest(unittest.TestCase):
         # The false claim must NOT survive as user-facing incompleteness.
         self.assertNotIn("setup incomplete", out["detail"])
 
+    def test_detail_less_core_row_is_not_assumed_to_be_the_down_state(self):
+        """Fail safe: a todo core row with no detail says nothing about WHY, so a
+        heartbeat cannot refute it — report the gap rather than suppress it."""
+        ws = self._with_workspace({"updated_at": 1, "rows": {"core": {"state": "todo"}}})
+        self._core_heartbeat(ws, fresh=True)
+        out = hc.check_onboarding_status()
+        self.assertIn("setup incomplete", out["detail"])
+
+    def test_fresh_heartbeat_does_not_hide_a_signin_gap_on_a_running_core(self):
+        """Control for the over-broad first cut: the writer emits TWO core todo
+        details, and a heartbeat refutes only 'not running'."""
+        ws = self._with_workspace(
+            {"updated_at": 1, "rows": {"core": {
+                "state": "todo", "detail": "core running, Claude sign-in required",
+                "claude_authed": False}}}
+        )
+        self._core_heartbeat(ws, fresh=True)
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("setup incomplete", out["detail"])
+        self.assertIn("sign-in", out["detail"])
+        self.assertNotIn("stale", out["detail"].lower())
+
     def test_core_row_still_reported_when_heartbeat_is_dead(self):
         """Mutation guard: with no live heartbeat the row is a REAL gap, so the
         stale-mirror branch must not swallow it."""
@@ -78,7 +101,8 @@ class OnboardingStatusCheckTest(unittest.TestCase):
 
     def test_other_todo_rows_survive_a_stale_core_row(self):
         ws = self._with_workspace(
-            {"updated_at": 1, "rows": {"core": {"state": "todo"},
+            {"updated_at": 1, "rows": {"core": {"state": "todo",
+                                                "detail": "core not running"},
                                        "gateway": {"state": "todo"}}}
         )
         self._core_heartbeat(ws, fresh=True)


### PR DESCRIPTION
## The defect, measured on a live core

`onboarding-status` reported the desktop Console's mirrored checklist verbatim. On this host, right now:

```
mirror  state/onboarding-status.json  updated_at age: 33055s   row core: state=todo  detail="core not running"
truth   state/cores/<host>.alive      mtime age:      19s      (core is running; it wrote that file)
```

So the probe warned **"user-facing setup incomplete: core (core not running)"** — a nine-hour-old third-party claim presented as current fact, contradicted by evidence in the same `state/` directory.

Before / after on this machine:

```
before:  ⚠ onboarding-status  user-facing setup incomplete: core (core not running) (33027s ago)
after:   ⚠ onboarding-status  Console mirror is stale — its core row says 'not running' but this
                              host's heartbeat is live; mirror last written 33096s ago
```

Still a warning, because something *is* wrong — but now it names the real thing, and the owner is not sent to fix a core that never stopped.

## Why the age alone is not the test

The Console writes **on change**, so an old file is not evidence of staleness by itself — a mirror can be correct and hours old. What makes this row stale is that a first-party local signal contradicts it. The check is the contradiction, not the age.

`_fresh_local_core_record()` deliberately, not the fleet-wide resolver: that one globs every synced `state/cores/*.alive` and takes the freshest, which the workspace contract permits to be **another machine's** — a peer's heartbeat must never silence a local gap.

## Scope

- Only the `core` row is cross-checked. It is the one with an unambiguous first-party local signal; `gateway` and `voice_creds` have no equivalent here.
- Other `todo` rows still surface, appended to the stale-mirror verdict.
- With **no** live heartbeat the core row is reported exactly as before.

## Tests

Three added to `tests/onboarding-status-check.test.py` (17/17 green). **Mutation-verified**: neutering only the guard (`stale_core = False`) fails exactly the two that assert the new behavior and leaves the dead-heartbeat case green — so they constrain this change rather than passing regardless.

`ruff` clean; `scripts/review-checks.sh --diff` PASS with prose-cap actually scanned (run from the worktree, since running it from another tree reports `prose-cap: SKIPPED`, which is not a pass).

— @sutando-qingyun-001:ag2.space
