### PR TITLE
fix(room-ops): an attempted op that failed exited 0, so callers recorded success

### DIFF
--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -192,6 +192,12 @@ def _main(argv):
     p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
 
     a = ap.parse_args(argv)
+
+    # Set where _main REJECTS INPUT before any op runs: nothing was attempted,
+
+    # so no caller can have believed it succeeded.
+
+    rejected_before_attempt = False
     if a.cmd == "read":
         res = _read.read_room(a.room_id, a.agent_mxid, a.limit, before=a.before)
     elif a.cmd == "fetch":
@@ -209,6 +215,7 @@ def _main(argv):
             except (OSError, UnicodeDecodeError) as e:
                 content = None
                 res = {"ok": False, "reason": f"cannot read --file {a.file}: {e}"}
+                rejected_before_attempt = True
             if content is not None:
                 res = _doc.doc_put(a.room, content, folder=a.folder,
                                    name=a.name or "CONTEXT.md", message=a.message,
@@ -240,6 +247,7 @@ def _main(argv):
             tiers = _grant.parse_tier_pairs(a.tiers)
         except ValueError as e:
             res = {"ok": False, "reason": str(e)}
+            rejected_before_attempt = True
         else:
             res = _grant.grant_room(a.room_id, tiers=tiers, default_tier=a.default_tier,
                                     revoke=a.revoke, agent_mxid=a.agent_mxid)
@@ -248,7 +256,11 @@ def _main(argv):
         fn = _react.react if a.cmd == "react" else _react.unreact
         res = fn(a.room_id, a.event_id, key, a.agent_mxid)
     print(json.dumps(res, indent=2))
-    return 0
+    # An ATTEMPTED op that failed exited 0, so a caller checking $? recorded a
+    # success it never got. `ok is False` is doc.py/events.py's own discriminator.
+    if rejected_before_attempt:
+        return 0
+    return 1 if isinstance(res, dict) and res.get("ok") is False else 0
 
 
 if __name__ == "__main__":

--- a/tests/room-ops-say.test.py
+++ b/tests/room-ops-say.test.py
@@ -163,6 +163,58 @@ class SayCliDispatchTests(unittest.TestCase):
         # say() takes (message, room_id); the CLI takes (room_id, message).
         m.assert_called_once_with("hi there", ROOM, None)
 
+    def test_a_failed_say_exits_nonzero(self):
+        """The CLI exited 0 on failure, so `$?` reported a post that never happened.
+
+        Measured live on 2026-08-20: a room with no gateway returned rc=0 carrying
+        {"ok": false, "reason": "no gateway configured"} and the caller recorded a
+        successful post. The JSON was right; only the exit code lied.
+        """
+        import io
+        import room_ops
+        from contextlib import redirect_stdout
+        with mock.patch.object(room_ops._say, "say",
+                               return_value={"ok": False, "room_id": ROOM,
+                                             "event_id": None,
+                                             "reason": "no gateway configured"}):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = room_ops._main(["say", ROOM, "hi there"])
+        self.assertEqual(rc, 1, "a failed say must not report success to the shell")
+        self.assertIn("no gateway configured", buf.getvalue(),
+                      "the reason must still reach stdout")
+
+    def test_unreadable_doc_file_is_rejected_before_any_attempt_and_exits_zero(self):
+        """The second pre-attempt branch, pinned so the exemption stays deliberate.
+
+        `doc put --file <unreadable>` is rejected by _main before doc_put runs, so
+        no caller can have believed a write happened -- the same reason
+        room-ops-grant.test.py pins rc=0 for a bad --tier.
+        """
+        import io
+        import room_ops
+        from contextlib import redirect_stdout
+        import doc as _doc_mod   # room_ops imports it lazily inside the branch
+        with mock.patch.object(_doc_mod, "doc_put") as put:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = room_ops._main(["doc", "put", ROOM,
+                                     "--file", "/nonexistent/nope.md"])
+        self.assertEqual(rc, 0, "input rejected before any attempt is not an op failure")
+        self.assertEqual(put.call_count, 0, "never reached the write")
+        self.assertIn("cannot read --file", buf.getvalue())
+
+    def test_a_result_without_an_ok_key_still_exits_zero(self):
+        """Only an EXPLICIT ok:false fails. Commands that report no `ok` are unchanged."""
+        import io
+        import room_ops
+        from contextlib import redirect_stdout
+        with mock.patch.object(room_ops._say, "say",
+                               return_value={"room_id": ROOM, "event_id": "$e"}):
+            with redirect_stdout(io.StringIO()):
+                rc = room_ops._main(["say", ROOM, "hi there"])
+        self.assertEqual(rc, 0)
+
 
 class SayNetworkFailureTests(unittest.TestCase):
     def test_http_error_degrades_and_does_not_raise(self):


### PR DESCRIPTION
@sonichi — found this while running the news-briefing cron tonight.

## What

`room_ops.py`'s `_main` ended with an unconditional `return 0`, so **every** subcommand reported success to the shell regardless of the result it printed.

## Why it matters

The news briefing posts its sublist to a Discord channel *and* an ag2space room. The room half failed and told me it had worked:

```
$ room_ops.py say '!PrxhizfLysTYrYDcnw:ag2.space' "<sublist #73>"
rc=0
{"ok": false, "event_id": null, "reason": "no gateway configured", "state": "failed"}
```

The JSON was correct. Only the exit code lied. A caller checking `$?` — the normal thing to do — records a post that never happened, and the briefing silently reaches one of its two destinations.

`ok is False` is the discriminator `doc.py` and `events.py` already use internally, so this reuses it rather than inventing one.

## Scoped to ATTEMPTED operations — and that scoping is the interesting part

My first cut was a blanket `ok is False -> 1`, and **it broke `room-ops-grant.test.py`**, which pins `rc == 0` for a bad `--tier` with the comment *"bad input is a clean result, not a crash."*

The test was right. There are two branches where `_main` itself rejects input **before any op runs**, and nothing was attempted, so no caller can have believed it succeeded:

- `grant --tier <bad>` — already pinned.
- `doc put --file <unreadable>` — the same shape, previously **unpinned**. Now pinned, so the exemption stays deliberate rather than incidental.

## Before / after — the live command

| case | parent | HEAD |
|---|---|---|
| `say`, no gateway | `rc=0` | **`rc=1`** (same JSON body) |
| `grant`, bad `--tier` | `rc=0` | `rc=0` (unchanged) |

## Controls

Removing the pre-attempt exemption fails **both** tests, including the pre-existing one:

```
FAIL: test_unreadable_doc_file_is_rejected_before_any_attempt_and_exits_zero
FAIL: test_grant_dispatch_bad_tier_never_calls_grant_room
```

All **8** room-ops suites pass at HEAD. `scripts/review-checks.sh --diff` passes.

## Blast radius

The only in-repo caller — `skills/engine-conflict-resolve/scripts/deliver.py` — imports `_gateway.py` directly and never shells out, so it never observes the exit code. Verified by grep across `src/`, `scripts/`, `skills/` and the workspace skill-repos.

## What this does NOT fix

The underlying "no gateway configured" on this host is separate and already filed as an owner question. This change only stops that failure from being reported as a success — worth having independently, since it converts a silent wrong claim into a loud one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
