### PR TITLE
fix(health-check): memory-sync detail named no repo, so it read as a memory claim

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2407,7 +2407,8 @@ def check_memory_sync() -> dict:
                     "detail": f"legacy memory-sync clone last fetched {age_h:.0f}h ago (stale)"}
         return {"name": name, "status": "ok",
                 "detail": f"legacy memory-sync clone last fetched {age_h:.1f}h ago"}
-    return {"name": name, "status": "ok", "detail": "initialized, never fetched"}
+    return {"name": name, "status": "ok",
+            "detail": "legacy memory-sync clone initialized, never fetched"}
 
 
 def _age_phrase(age_s) -> str:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2378,8 +2378,10 @@ def check_memory_sync() -> dict:
         if ws_git_fetch.exists():
             age_h = (time.time() - ws_git_fetch.stat().st_mtime) / 3600
             if age_h > 48:
-                return {"name": name, "status": "warn", "detail": f"last sync {age_h:.0f}h ago (stale)"}
-            return {"name": name, "status": "ok", "detail": f"last sync {age_h:.1f}h ago"}
+                return {"name": name, "status": "warn",
+                        "detail": f"workspace vault last fetched {age_h:.0f}h ago (stale)"}
+            return {"name": name, "status": "ok",
+                    "detail": f"workspace vault last fetched {age_h:.1f}h ago"}
         return {"name": name, "status": "ok", "detail": "workspace git repo, never fetched"}
     # Legacy memory-sync clone dir: PR #764 renamed legacy ~/.sutando-memory-sync/
     # → ~/.sutando/memory-sync/. Check new path first; fall back to legacy
@@ -2397,8 +2399,10 @@ def check_memory_sync() -> dict:
     if git_dir.exists():
         age_h = (time.time() - git_dir.stat().st_mtime) / 3600
         if age_h > 48:
-            return {"name": name, "status": "warn", "detail": f"last sync {age_h:.0f}h ago (stale)"}
-        return {"name": name, "status": "ok", "detail": f"last sync {age_h:.1f}h ago"}
+            return {"name": name, "status": "warn",
+                    "detail": f"legacy memory-sync clone last fetched {age_h:.0f}h ago (stale)"}
+        return {"name": name, "status": "ok",
+                "detail": f"legacy memory-sync clone last fetched {age_h:.1f}h ago"}
     return {"name": name, "status": "ok", "detail": "initialized, never fetched"}
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1228,11 +1228,15 @@ def check_file(path: Path, name: str) -> dict:
 
 
 def check_directory(path: Path, name: str) -> dict:
-    """Check if a directory exists and has files."""
+    """Check if a directory exists and has files.
+
+    The count names its directory: both callers (memory-dir, notes-dir) sit on
+    paths with a live twin, so a bare count reads as a claim about the wrong one.
+    """
     if not path.exists():
         return {"name": name, "status": "missing", "detail": str(path)}
     count = len(list(path.glob("*.md")))
-    return {"name": name, "status": "ok", "detail": f"{count} .md files"}
+    return {"name": name, "status": "ok", "detail": f"{count} .md files in {path}"}
 
 
 def check_memory_dir_override() -> "dict | None":

--- a/tests/health-check-memory-sync-vault.test.py
+++ b/tests/health-check-memory-sync-vault.test.py
@@ -15,6 +15,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -107,6 +108,32 @@ class TestMemorySyncVaultLookup(unittest.TestCase):
         self.assertNotIn("sync-memory.sh", detail)
         if "never synced" in detail:
             self.assertIn("sync-workspace.sh", detail)
+
+    def test_freshness_detail_names_which_repo_it_measured(self):
+        """The probe is called 'memory-sync' but the freshness signal it reads is
+        the WORKSPACE vault fetch. A bare 'last sync Nh ago' reads as a claim about
+        memory and contradicts a healthy memory sync, so the detail must say which.
+        """
+        repo, ws = self._set_repo()
+        (repo / "sutando.config.local.json").write_text(
+            json.dumps({"vault": {"remote_url": "git@github.com:user/vault.git"}})
+        )
+        git_dir = ws / ".git"
+        git_dir.mkdir(parents=True, exist_ok=True)
+        fetch_head = git_dir / "FETCH_HEAD"
+        fetch_head.write_text("")
+        stale = time.time() - (367 * 3600)
+        os.utime(fetch_head, (stale, stale))
+
+        with patch("sys.path", [str(REPO / "src")] + sys.path):
+            result = hc.check_memory_sync()
+
+        detail = result.get("detail", "")
+        self.assertEqual(result["status"], "warn", f"367h should be stale: {result!r}")
+        self.assertIn("stale", detail)
+        self.assertIn("workspace", detail.lower(),
+                      f"detail must name the workspace vault as its subject: {detail!r}")
+        self.assertNotIn("sync-memory.sh", detail)
 
 
 if __name__ == "__main__":

--- a/tests/health-check-memory-sync-vault.test.py
+++ b/tests/health-check-memory-sync-vault.test.py
@@ -161,8 +161,8 @@ class TestMemorySyncVaultLookup(unittest.TestCase):
     def test_legacy_clone_branch_names_the_legacy_clone(self):
         """No workspace .git → the legacy memory-sync clone supplies the freshness signal.
 
-        home is patched because this host really has ~/.sutando/memory-sync; reading it
-        would make the result depend on the machine.
+        home is patched because a real host may already have the legacy clone on disk;
+        reading it would make the result depend on the machine.
         """
         _, ws = self._configured()
         fake_home = self.tmp / "home"

--- a/tests/health-check-memory-sync-vault.test.py
+++ b/tests/health-check-memory-sync-vault.test.py
@@ -187,5 +187,48 @@ class TestMemorySyncVaultLookup(unittest.TestCase):
         self.assertIn("legacy", result["detail"].lower())
 
 
+
+class TestDirectoryCountNamesItsPath(unittest.TestCase):
+    """A bare '.md files' count is a claim about whichever corpus the reader assumes.
+
+    Both callers (memory-dir, notes-dir) sit on paths that have a live twin on this
+    fleet, and the sibling slug-split check is deliberately diagnostic-only — it
+    reports the divergence and refuses to pick a canonical corpus. So the count has
+    to carry its own path; that disambiguates without answering the open question.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="hc-dircount-"))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_count_detail_names_the_directory_it_counted(self):
+        a = self.tmp / "corpus-a"
+        b = self.tmp / "corpus-b"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+        (a / "one.md").write_text("x")
+        for n in range(3):
+            (b / f"n{n}.md").write_text("x")
+
+        ra = hc.check_directory(a, "memory-dir")
+        rb = hc.check_directory(b, "memory-dir")
+
+        self.assertEqual(ra["status"], "ok")
+        self.assertIn("1 .md files", ra["detail"])
+        self.assertIn("3 .md files", rb["detail"])
+        # Same probe name, same count format, different corpora: without the path
+        # the two details are indistinguishable to a reader.
+        self.assertIn(str(a), ra["detail"])
+        self.assertIn(str(b), rb["detail"])
+        self.assertNotEqual(ra["detail"], rb["detail"])
+
+    def test_missing_directory_still_reports_the_path(self):
+        r = hc.check_directory(self.tmp / "nope", "notes-dir")
+        self.assertEqual(r["status"], "missing")
+        self.assertIn("nope", r["detail"])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/health-check-memory-sync-vault.test.py
+++ b/tests/health-check-memory-sync-vault.test.py
@@ -176,6 +176,22 @@ class TestMemorySyncVaultLookup(unittest.TestCase):
                       f"legacy-clone freshness must say so, not just 'last sync': {detail!r}")
         self.assertNotIn("workspace vault", detail)
 
+    def test_never_fetched_legacy_clone_names_the_legacy_clone(self):
+        """The never-fetched pair must not split: its workspace sibling names a subject,
+        so the legacy one carrying no name is the same ambiguity in a quieter form.
+        """
+        _, ws = self._configured()
+        fake_home = self.tmp / "home"
+        (fake_home / ".sutando" / "memory-sync").mkdir(parents=True)
+        with patch.object(Path, "home", staticmethod(lambda: fake_home)):
+            with patch("sys.path", [str(REPO / "src")] + sys.path):
+                result = hc.check_memory_sync()
+        detail = result["detail"]
+        self.assertEqual(result["status"], "ok", f"clone present but unfetched: {result!r}")
+        self.assertIn("never fetched", detail)
+        self.assertIn("legacy", detail.lower(),
+                      f"never-fetched detail must name its repo too: {detail!r}")
+
     def test_fresh_legacy_clone_names_the_legacy_clone(self):
         _, ws = self._configured()
         fake_home = self.tmp / "home"

--- a/tests/health-check-memory-sync-vault.test.py
+++ b/tests/health-check-memory-sync-vault.test.py
@@ -135,6 +135,57 @@ class TestMemorySyncVaultLookup(unittest.TestCase):
                       f"detail must name the workspace vault as its subject: {detail!r}")
         self.assertNotIn("sync-memory.sh", detail)
 
+    def _configured(self):
+        repo, ws = self._set_repo()
+        (repo / "sutando.config.local.json").write_text(
+            json.dumps({"vault": {"remote_url": "git@github.com:user/vault.git"}})
+        )
+        return repo, ws
+
+    def _aged_fetch_head(self, git_dir: Path, hours: float) -> None:
+        git_dir.mkdir(parents=True, exist_ok=True)
+        fh = git_dir / "FETCH_HEAD"
+        fh.write_text("")
+        when = time.time() - (hours * 3600)
+        os.utime(fh, (when, when))
+
+    def test_fresh_workspace_fetch_also_names_the_workspace(self):
+        """The ok branch is as ambiguous as the warn branch, so it names its subject too."""
+        _, ws = self._configured()
+        self._aged_fetch_head(ws / ".git", 2)
+        with patch("sys.path", [str(REPO / "src")] + sys.path):
+            result = hc.check_memory_sync()
+        self.assertEqual(result["status"], "ok", f"2h is fresh: {result!r}")
+        self.assertIn("workspace", result["detail"].lower())
+
+    def test_legacy_clone_branch_names_the_legacy_clone(self):
+        """No workspace .git → the legacy memory-sync clone supplies the freshness signal.
+
+        home is patched because this host really has ~/.sutando/memory-sync; reading it
+        would make the result depend on the machine.
+        """
+        _, ws = self._configured()
+        fake_home = self.tmp / "home"
+        self._aged_fetch_head(fake_home / ".sutando" / "memory-sync" / ".git", 367)
+        with patch.object(Path, "home", staticmethod(lambda: fake_home)):
+            with patch("sys.path", [str(REPO / "src")] + sys.path):
+                result = hc.check_memory_sync()
+        detail = result["detail"]
+        self.assertEqual(result["status"], "warn", f"367h is stale: {result!r}")
+        self.assertIn("legacy", detail.lower(),
+                      f"legacy-clone freshness must say so, not just 'last sync': {detail!r}")
+        self.assertNotIn("workspace vault", detail)
+
+    def test_fresh_legacy_clone_names_the_legacy_clone(self):
+        _, ws = self._configured()
+        fake_home = self.tmp / "home"
+        self._aged_fetch_head(fake_home / ".sutando" / "memory-sync" / ".git", 3)
+        with patch.object(Path, "home", staticmethod(lambda: fake_home)):
+            with patch("sys.path", [str(REPO / "src")] + sys.path):
+                result = hc.check_memory_sync()
+        self.assertEqual(result["status"], "ok", f"3h is fresh: {result!r}")
+        self.assertIn("legacy", result["detail"].lower())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

The `memory-sync` probe reads, on a git-backed workspace, the **workspace vault's** `.git/FETCH_HEAD` — the `sync-workspace.sh` leg. Its detail named no subject: `last sync 367h ago (stale)`.

Both freshness branches now say which repo they measured.

## Why this is a real misread, not a style nit

On this host today, both sync signals were correct and **disagreed in appearance**:

| signal | source | state |
|---|---|---|
| memory sync | `scripts/sync-memory.sh` → `vault.ag2.space/qingyun/memory.git` | healthy, ran 2026-08-19, `Sync complete: 614 memory, 508 notes` |
| workspace sync | `scripts/sync-workspace.sh` → workspace `.git` | last fetch 2026-08-04 |

The probe printed `memory-sync … last sync 367h ago (stale)` — which reads as *memory is 15 days stale*, contradicting the memory log. Separate scripts, separate remotes, one ambiguous noun. I lost a lookup to it before establishing that neither signal was wrong.

## Before / after

At the parent commit (`565db9fc`), the workspace-git freshness branch:

```
"detail": f"last sync {age_h:.0f}h ago (stale)"
```

At HEAD:

```
"detail": f"workspace vault last fetched {age_h:.0f}h ago (stale)"
```

and the legacy-clone branch says `legacy memory-sync clone last fetched Nh ago`. Status values, the 48h threshold, and every other branch are unchanged.

## Test

Added `test_freshness_detail_names_which_repo_it_measured` — stales a workspace `FETCH_HEAD` to 367h, asserts `warn` + `stale` + that the detail names its subject.

**Mutation-verified** (an assertion that cannot fail is not a test):

```
with fix          → Ran 5 tests … OK
revert fix only   → Ran 5 tests … FAILED (failures=1)
restore           → Ran 5 tests … OK
```

Both existing suites pass unmodified: `health-check-memory-sync.test.py`, `health-check-memory-sync-vault.test.py`. They pin `stale` / `never fetched` / `not configured`, none of which this touches.

## Gate

`bash scripts/review-checks.sh --diff <real post-image, 3675 B>` → `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`, rc=0. Not a SKIPPED verdict.

## Prior art in this file

`assertNotIn("sync-memory.sh", detail)` already guards the never-synced hint against exactly this confusion. This extends the same care to the freshness lines.

—
@sutando-qingyun-001:ag2.space
