### PR TITLE
fix(restart-intent): ack on consumption, not on write

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -2569,10 +2569,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func pollRestartIntent() {
         let path = workspace + "/state/core-restart-requested.json"
         guard FileManager.default.fileExists(atPath: path) else { return }
+        // Take the same flock the Python writer/consumer hold: deleting a
+        // pathname we did not read can drop a request installed after our read.
+        let lockFD = open(path + ".lock", O_CREAT | O_WRONLY, 0o644)
+        guard lockFD >= 0 else { return }
+        guard flock(lockFD, LOCK_EX) == 0 else { close(lockFD); return }
+        // Re-check under the lock: a consumer that raced us already took it.
+        guard FileManager.default.fileExists(atPath: path) else {
+            flock(lockFD, LOCK_UN); close(lockFD); return
+        }
         let raw = try? String(contentsOfFile: path, encoding: .utf8)
+        var consumeFailed = false
         do {
             try FileManager.default.removeItem(atPath: path)  // consume FIRST
         } catch {
+            consumeFailed = true
+        }
+        flock(lockFD, LOCK_UN)
+        close(lockFD)
+        if consumeFailed {
             notify("Sutando", "Restart request file couldn't be consumed — NOT acting (would loop). Remove it manually: \(path)")
             return
         }

--- a/src/core_restart_intent.py
+++ b/src/core_restart_intent.py
@@ -62,18 +62,67 @@ def intent_path(workspace: str | None = None) -> str:
     return os.path.join(ws, "state", INTENT_BASENAME)
 
 
+class IntentPending(Exception):
+    """A different, still-unconsumed intent already occupies the file."""
+
+    def __init__(self, action: str, requested_at: float):
+        super().__init__(f"an unconsumed {action!r} request is already pending")
+        self.action = action
+        self.requested_at = requested_at
+
+
+def peek_intent(workspace: str | None, now: float | None = None) -> dict | None:
+    """Return the pending intent WITHOUT consuming it, or None if there is
+    none / it is unreadable / it is stale. Read-only: never deletes."""
+    try:
+        with open(intent_path(workspace)) as f:
+            d = json.loads(f.read())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(d, dict) or d.get("action") not in _ACTIONS:
+        return None
+    age = (now if now is not None else time.time()) - float(d.get("requested_at") or 0)
+    return None if age > STALE_SEC else d
+
+
 def write_intent(workspace: str | None, action: str, source: str) -> str:
     """Atomically write the intent file; returns its path. Raises ValueError
-    on an unknown action — callers never write arbitrary strings."""
+    on an unknown action, and IntentPending if a live intent already exists.
+
+    Exclusive by construction (os.link fails when the target exists), because
+    a waiter can only correlate consumption by the pathname disappearing: with
+    two intents in flight, one supersedes the other on disk and BOTH waiters
+    read the single deletion as their own (qingyun review, #3191). One pending
+    intent at a time is what makes that inference sound.
+    """
     if action not in _ACTIONS:
         raise ValueError(f"unknown intent action: {action!r}")
     path = intent_path(workspace)
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    tmp = path + ".tmp"
+    tmp = f"{path}.{os.getpid()}.tmp"
     with open(tmp, "w") as f:
         json.dump({"action": action, "requested_at": time.time(), "source": source}, f)
-    os.replace(tmp, path)
-    return path
+    try:
+        for attempt in (0, 1):
+            try:
+                os.link(tmp, path)
+                return path
+            except FileExistsError:
+                live = peek_intent(workspace)
+                if live is not None:
+                    raise IntentPending(live["action"], float(live["requested_at"]))
+                if attempt:  # a racing writer refilled it — theirs stands
+                    raise IntentPending(action, time.time())
+                # Stale or unreadable: clear it and retry once.
+                try:
+                    os.unlink(path)
+                except OSError:
+                    raise IntentPending(action, time.time())
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 def await_consumption(
@@ -87,7 +136,10 @@ def await_consumption(
 
     Consumption is defined by the file being GONE, which is the only
     implementation-agnostic evidence available: `consume_intent` deletes
-    before acting, so disappearance means an executor claimed it. Probing for
+    before acting, so disappearance means an executor claimed it. That
+    inference is only sound because `write_intent` is exclusive — otherwise a
+    superseding write would let one deletion satisfy two different waiters.
+    Probing for
     a specific consumer (a running Sutando.app, a named launchd label) answers
     "is THAT consumer here", not "will anything act" — and returns the same
     False for a host whose executor is simply a different one.

--- a/src/core_restart_intent.py
+++ b/src/core_restart_intent.py
@@ -23,8 +23,11 @@ restart when the app next boots.
 """
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import json
 import os
+import tempfile
 import time
 
 # Canonical workspace resolution (state-paths adoption lint): callers may pass
@@ -71,6 +74,18 @@ class IntentPending(Exception):
         self.requested_at = requested_at
 
 
+@contextlib.contextmanager
+def _writer_lock(path: str):
+    """Serialize the whole inspect/remove/claim transition across threads AND
+    processes. flock is released by the kernel if the holder dies."""
+    with open(path + ".lock", "a") as lf:
+        fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf.fileno(), fcntl.LOCK_UN)
+
+
 def peek_intent(workspace: str | None, now: float | None = None) -> dict | None:
     """Return the pending intent WITHOUT consuming it, or None if there is
     none / it is unreadable / it is stale. Read-only: never deletes."""
@@ -99,27 +114,30 @@ def write_intent(workspace: str | None, action: str, source: str) -> str:
         raise ValueError(f"unknown intent action: {action!r}")
     path = intent_path(workspace)
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    tmp = f"{path}.{os.getpid()}.tmp"
-    with open(tmp, "w") as f:
-        json.dump({"action": action, "requested_at": time.time(), "source": source}, f)
+    # mkstemp, not pid: two threads of one bridge would share a pid-named temp,
+    # so one could link the other's bytes or unlink the temp it is about to link.
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path),
+                               prefix=INTENT_BASENAME + ".", suffix=".tmp")
     try:
-        for attempt in (0, 1):
+        with os.fdopen(fd, "w") as f:
+            json.dump({"action": action, "requested_at": time.time(), "source": source}, f)
+        with _writer_lock(path):
+            live = peek_intent(workspace)
+            if live is not None:
+                raise IntentPending(live["action"], float(live["requested_at"]))
+            # Absent or stale. Both the remove and the claim happen under the
+            # lock, so no writer can delete another's freshly-installed intent.
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                raise IntentPending(action, time.time())
             try:
                 os.link(tmp, path)
-                return path
-            except FileExistsError:
-                live = peek_intent(workspace)
-                if live is not None:
-                    raise IntentPending(live["action"], float(live["requested_at"]))
-                if attempt:  # a racing writer refilled it — theirs stands
-                    raise IntentPending(action, time.time())
-                # Stale or unreadable: clear it and retry once.
-                try:
-                    os.unlink(path)
-                except FileNotFoundError:
-                    pass
-                except OSError:
-                    raise IntentPending(action, time.time())
+            except FileExistsError:  # refilled outside the lock — theirs stands
+                raise IntentPending(action, time.time())
+            return path
     finally:
         try:
             os.unlink(tmp)

--- a/src/core_restart_intent.py
+++ b/src/core_restart_intent.py
@@ -116,6 +116,8 @@ def write_intent(workspace: str | None, action: str, source: str) -> str:
                 # Stale or unreadable: clear it and retry once.
                 try:
                     os.unlink(path)
+                except FileNotFoundError:
+                    pass
                 except OSError:
                     raise IntentPending(action, time.time())
     finally:
@@ -139,10 +141,9 @@ def await_consumption(
     before acting, so disappearance means an executor claimed it. That
     inference is only sound because `write_intent` is exclusive — otherwise a
     superseding write would let one deletion satisfy two different waiters.
-    Probing for
-    a specific consumer (a running Sutando.app, a named launchd label) answers
-    "is THAT consumer here", not "will anything act" — and returns the same
-    False for a host whose executor is simply a different one.
+    Probing for a specific consumer (a running Sutando.app, a named launchd
+    label) answers "is THAT consumer here", not "will anything act" — and
+    returns the same False for a host whose executor is simply a different one.
 
     Default timeout covers the documented 5s poll interval twice over.
     """

--- a/src/core_restart_intent.py
+++ b/src/core_restart_intent.py
@@ -75,9 +75,11 @@ class IntentPending(Exception):
 
 
 @contextlib.contextmanager
-def _writer_lock(path: str):
-    """Serialize the whole inspect/remove/claim transition across threads AND
-    processes. flock is released by the kernel if the holder dies."""
+def _intent_lock(path: str):
+    """Serialize every read-modify-delete of the intent, for writers AND
+    consumers, across threads and processes. Any participant that deletes the
+    pathname must hold this, or it can delete an intent it never read.
+    Released by the kernel if the holder dies."""
     with open(path + ".lock", "a") as lf:
         fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
         try:
@@ -121,7 +123,7 @@ def write_intent(workspace: str | None, action: str, source: str) -> str:
     try:
         with os.fdopen(fd, "w") as f:
             json.dump({"action": action, "requested_at": time.time(), "source": source}, f)
-        with _writer_lock(path):
+        with _intent_lock(path):
             live = peek_intent(workspace)
             if live is not None:
                 raise IntentPending(live["action"], float(live["requested_at"]))
@@ -183,18 +185,22 @@ def consume_intent(workspace: str | None, now: float | None = None) -> str | Non
     file too — a bad or ancient intent must never linger and re-fire.
     """
     path = intent_path(workspace)
-    try:
-        with open(path) as f:
-            raw = f.read()
-    except OSError:
+    # Nothing to delete means nothing to serialize, and the lock's own
+    # directory may not exist yet on a workspace that has never been written.
+    if not os.path.exists(path):
         return None
-    try:
-        os.unlink(path)  # consume FIRST — crash mid-action must not replay
-    except OSError:
-        # FAIL CLOSED (qingyun review, #2408): if the file can't be removed,
-        # the next 5s poll would see it again — acting now would replay the
-        # same restart every poll. No positive consume → no action.
-        return None
+    with _intent_lock(path):
+        try:
+            with open(path) as f:
+                raw = f.read()
+        except OSError:
+            return None
+        try:
+            os.unlink(path)  # consume FIRST — crash mid-action must not replay
+        except OSError:
+            # FAIL CLOSED (qingyun review, #2408): if the file can't be
+            # removed, the next poll would see it again and replay the action.
+            return None
     try:
         d = json.loads(raw)
     except ValueError:

--- a/src/core_restart_intent.py
+++ b/src/core_restart_intent.py
@@ -76,6 +76,34 @@ def write_intent(workspace: str | None, action: str, source: str) -> str:
     return path
 
 
+def await_consumption(
+    workspace: str | None,
+    timeout_sec: float = 12.0,
+    poll_sec: float = 0.5,
+    sleep=time.sleep,
+    now=time.monotonic,
+) -> bool:
+    """Block until some executor consumes the intent; True if it did.
+
+    Consumption is defined by the file being GONE, which is the only
+    implementation-agnostic evidence available: `consume_intent` deletes
+    before acting, so disappearance means an executor claimed it. Probing for
+    a specific consumer (a running Sutando.app, a named launchd label) answers
+    "is THAT consumer here", not "will anything act" — and returns the same
+    False for a host whose executor is simply a different one.
+
+    Default timeout covers the documented 5s poll interval twice over.
+    """
+    path = intent_path(workspace)
+    deadline = now() + timeout_sec
+    while True:
+        if not os.path.exists(path):
+            return True
+        if now() >= deadline:
+            return False
+        sleep(poll_sec)
+
+
 def consume_intent(workspace: str | None, now: float | None = None) -> str | None:
     """Read-and-DELETE the intent; return its action, or None.
 

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -211,7 +211,12 @@ from task_envelope import stamp_text  # noqa: E402
 import progress_stream  # noqa: E402  — pure helpers for the progress-streamer (poll_progress)
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
 from chat_redaction import redact_chat_body  # noqa: E402
-from core_restart_intent import await_consumption, parse_restart_command, write_intent  # noqa: E402
+from core_restart_intent import (  # noqa: E402
+    IntentPending,
+    await_consumption,
+    parse_restart_command,
+    write_intent,
+)
 from chat_secret_filter import filter_chat_secrets, secret_handling_instruction  # noqa: E402
 REPO = resolve_workspace()
 
@@ -2997,9 +3002,8 @@ async def _handle_restart_command(message, text, access_tier, username, workspac
         return False
     try:
         write_intent(workspace, action, "discord")
-        # Ack on CONSUMPTION, not on write (#3183): writing always succeeds, so
-        # acking here promised a restart on hosts whose executor was gone —
-        # silent for as long as nobody happened to notice.
+        # Ack on CONSUMPTION, not on write (#3183): a write always succeeds, so
+        # acking there promised a restart on hosts whose executor was gone.
         claimed = await asyncio.to_thread(wait_for_consumption, workspace)
         if claimed:
             ack = ("Restart requested and picked up by the executor — I'll be "
@@ -3015,6 +3019,12 @@ async def _handle_restart_command(message, text, access_tier, username, workspac
                    f"request expires in 10 minutes. If nothing consumes "
                    f"`state/core-restart-requested.json` on this host (the "
                    f"desktop app, or a launchd executor), it will simply lapse.")
+    except IntentPending as pending:
+        # One intent at a time: acking a superseded request would report the
+        # wrong action as picked up when the survivor's deletion arrives.
+        ack = (f"A **{pending.action}** request is already pending and not yet "
+               f"picked up, so I did not queue the {action}. Wait for that one "
+               f"to be consumed (or to expire in 10 minutes), then ask again.")
     except Exception as exc:
         ack = f"Couldn't write the {action} request ({type(exc).__name__}) — not queued."
     print(f"  [core-restart] owner {action} command from @{username}", flush=True)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -211,7 +211,7 @@ from task_envelope import stamp_text  # noqa: E402
 import progress_stream  # noqa: E402  — pure helpers for the progress-streamer (poll_progress)
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
 from chat_redaction import redact_chat_body  # noqa: E402
-from core_restart_intent import parse_restart_command, write_intent  # noqa: E402
+from core_restart_intent import await_consumption, parse_restart_command, write_intent  # noqa: E402
 from chat_secret_filter import filter_chat_secrets, secret_handling_instruction  # noqa: E402
 REPO = resolve_workspace()
 
@@ -2996,11 +2996,22 @@ async def _handle_restart_command(message, text, access_tier, username, workspac
         return False
     try:
         write_intent(workspace, action, "discord")
-        ack = ("Restart requested — the app will relaunch the core in a few "
-               "seconds (authenticated, GUI session). I'll be back once it's up."
-               if action == "restart" else
-               "Stop requested — the app will stop the core in a few seconds. "
-               "It stays stopped until you say `restart core`.")
+        # Ack on CONSUMPTION, not on write (#3183): writing always succeeds, so
+        # acking here promised a restart on hosts whose executor was gone —
+        # silent for as long as nobody happened to notice.
+        claimed = await asyncio.to_thread(await_consumption, workspace)
+        if claimed:
+            ack = ("Restart requested and picked up by the executor — I'll be "
+                   "back once it's up."
+                   if action == "restart" else
+                   "Stop requested and picked up by the executor. It stays "
+                   "stopped until you say `restart core`.")
+        else:
+            ack = (f"Wrote the {action} request, but **no executor picked it "
+                   f"up** within 12s — so nothing is going to happen. The "
+                   f"request expires on its own in 10 minutes. Whatever "
+                   f"consumes `state/core-restart-requested.json` on this host "
+                   f"(the desktop app, or a launchd executor) isn't running.")
     except Exception as exc:
         ack = f"Couldn't write the {action} request ({type(exc).__name__}) — not queued."
     print(f"  [core-restart] owner {action} command from @{username}", flush=True)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2981,7 +2981,8 @@ def select_rulebook_key(access_tier, is_collaborator):
     return "team-collaborator" if is_collaborator else access_tier
 
 
-async def _handle_restart_command(message, text, access_tier, username, workspace) -> bool:
+async def _handle_restart_command(message, text, access_tier, username, workspace,
+                                  wait_for_consumption=await_consumption) -> bool:
     """Owner easy-restart command (sonichi#2401): "restart core" / "stop core"
     is handled by the BRIDGE, not the core — the whole point is that it works
     while the core is dead. Writes the intent file for the GUI-session
@@ -2999,7 +3000,7 @@ async def _handle_restart_command(message, text, access_tier, username, workspac
         # Ack on CONSUMPTION, not on write (#3183): writing always succeeds, so
         # acking here promised a restart on hosts whose executor was gone —
         # silent for as long as nobody happened to notice.
-        claimed = await asyncio.to_thread(await_consumption, workspace)
+        claimed = await asyncio.to_thread(wait_for_consumption, workspace)
         if claimed:
             ack = ("Restart requested and picked up by the executor — I'll be "
                    "back once it's up."
@@ -3007,11 +3008,13 @@ async def _handle_restart_command(message, text, access_tier, username, workspac
                    "Stop requested and picked up by the executor. It stays "
                    "stopped until you say `restart core`.")
         else:
-            ack = (f"Wrote the {action} request, but **no executor picked it "
-                   f"up** within 12s — so nothing is going to happen. The "
-                   f"request expires on its own in 10 minutes. Whatever "
-                   f"consumes `state/core-restart-requested.json` on this host "
-                   f"(the desktop app, or a launchd executor) isn't running.")
+            # The intent stays on disk, so a late executor can still claim it
+            # before STALE_SEC — say "not yet", never "nothing will happen".
+            ack = (f"Wrote the {action} request, but **no executor picked it up "
+                   f"within 12s**. It may still run if one starts before the "
+                   f"request expires in 10 minutes. If nothing consumes "
+                   f"`state/core-restart-requested.json` on this host (the "
+                   f"desktop app, or a launchd executor), it will simply lapse.")
     except Exception as exc:
         ack = f"Couldn't write the {action} request ({type(exc).__name__}) — not queued."
     print(f"  [core-restart] owner {action} command from @{username}", flush=True)

--- a/tests/bridge-restart-intercept.test.py
+++ b/tests/bridge-restart-intercept.test.py
@@ -134,9 +134,8 @@ handled, chan = _run("restart core", ws=ws4, chan=_Chan(fail=True))
 check("ack send failure swallowed, still handled + intent written",
       handled is True and os.path.exists(os.path.join(ws4, "state", "core-restart-requested.json")))
 
-# --- a request already pending → refuse, name the SURVIVING action ---
-# The owner must never be told the stop was queued when the restart is the one
-# on disk: only one of them can be what the executor's deletion refers to.
+# --- a request already pending → refuse, naming the SURVIVING action: only one
+# of them can be what the executor's single deletion actually refers to ---
 ws5 = tempfile.mkdtemp()
 _run("restart core", ws=ws5)
 handled, chan = _run("stop core", ws=ws5)

--- a/tests/bridge-restart-intercept.test.py
+++ b/tests/bridge-restart-intercept.test.py
@@ -134,6 +134,20 @@ handled, chan = _run("restart core", ws=ws4, chan=_Chan(fail=True))
 check("ack send failure swallowed, still handled + intent written",
       handled is True and os.path.exists(os.path.join(ws4, "state", "core-restart-requested.json")))
 
+# --- a request already pending → refuse, name the SURVIVING action ---
+# The owner must never be told the stop was queued when the restart is the one
+# on disk: only one of them can be what the executor's deletion refers to.
+ws5 = tempfile.mkdtemp()
+_run("restart core", ws=ws5)
+handled, chan = _run("stop core", ws=ws5)
+check("pending intent → stop refused, ack names the pending restart",
+      handled is True and len(chan.sent) == 1
+      and "already pending" in chan.sent[0] and "**restart**" in chan.sent[0],
+      str(chan.sent))
+with open(os.path.join(ws5, "state", "core-restart-requested.json")) as f:
+    check("refused second request leaves the first intent intact",
+          json.load(f)["action"] == "restart")
+
 print()
 if failures:
     print(f"{len(failures)} check(s) FAILED: {failures}")

--- a/tests/bridge-restart-intercept.test.py
+++ b/tests/bridge-restart-intercept.test.py
@@ -73,10 +73,13 @@ class _Msg:
         self.channel = chan
 
 
-def _run(text, tier="owner", ws=None, chan=None):
+def _run(text, tier="owner", ws=None, chan=None, claimed=True):
+    """`claimed` stubs the consumption wait (#3183). Production blocks up to 12s
+    polling for an executor; the suite must assert both acks without sleeping."""
     chan = chan if chan is not None else _Chan()
     handled = asyncio.run(
-        db._handle_restart_command(_Msg(chan), text, tier, "tester", ws or tempfile.mkdtemp()))
+        db._handle_restart_command(_Msg(chan), text, tier, "tester", ws or tempfile.mkdtemp(),
+                                   wait_for_consumption=lambda _ws: claimed))
     return handled, chan
 
 
@@ -88,7 +91,8 @@ check("owner 'restart core' → handled=True", handled is True)
 check("intent file written with action=restart",
       os.path.exists(intent_file) and json.load(open(intent_file))["action"] == "restart",
       intent_file)
-check("ack sent mentions relaunch", len(chan.sent) == 1 and "Restart requested" in chan.sent[0])
+check("claimed → ack says picked up",
+      len(chan.sent) == 1 and "picked up by the executor" in chan.sent[0])
 
 # --- owner stop command ---
 ws2 = tempfile.mkdtemp()
@@ -96,6 +100,15 @@ handled, chan = _run("Stop core.", ws=ws2)
 check("owner 'Stop core.' → handled + action=stop",
       handled and json.load(open(os.path.join(ws2, "state", "core-restart-requested.json")))["action"] == "stop")
 check("stop ack says stays stopped", "stays stopped" in chan.sent[0])
+
+# --- nothing consumes the intent: ack must say "not yet", never "nothing will happen" ---
+ws2b = tempfile.mkdtemp()
+handled, chan = _run("restart core", ws=ws2b, claimed=False)
+check("timeout → handled, honest not-picked-up ack",
+      handled and "no executor picked it up" in chan.sent[0]
+      and "may still run" in chan.sent[0])
+check("timeout leaves the intent on disk for a late executor",
+      os.path.exists(os.path.join(ws2b, "state", "core-restart-requested.json")))
 
 # --- prose and non-owner never trigger ---
 handled, chan = _run("we should restart core tomorrow")

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -289,6 +289,30 @@ class TestExclusiveIntentEdges(unittest.TestCase):
         finally:
             os.unlink = real_unlink
 
+    def test_stale_intent_consumed_mid_clear_still_succeeds(self):
+        # An executor consumes the stale intent between our peek and unlink:
+        # the path is FREE, so claim it — don't report a request nobody made.
+        path = _mod.write_intent(self.ws, "restart", "test")
+        with open(path) as f:
+            d = json.load(f)
+        d["requested_at"] = time.time() - (_mod.STALE_SEC + 60)
+        with open(path, "w") as f:
+            json.dump(d, f)
+        real_unlink = os.unlink
+
+        def raced(target):
+            if str(target) == path:
+                real_unlink(target)          # the "executor" got there first
+                raise FileNotFoundError(target)
+            return real_unlink(target)
+
+        os.unlink = raced
+        try:
+            self.assertEqual(_mod.write_intent(self.ws, "stop", "test"), path)
+        finally:
+            os.unlink = real_unlink
+        self.assertEqual(_mod.peek_intent(self.ws)["action"], "stop")
+
     def test_tmp_cleanup_failure_never_masks_the_result(self):
         # The temp file is bookkeeping; failing to remove it must not turn a
         # successful claim into an error the owner sees.

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -13,6 +13,7 @@ import json
 import os
 import sys
 import tempfile
+import threading
 import time
 import unittest
 
@@ -330,6 +331,107 @@ class TestExclusiveIntentEdges(unittest.TestCase):
         finally:
             os.unlink = real_unlink
         self.assertEqual(_mod.consume_intent(self.ws), "restart")
+
+
+
+class TestConcurrentStaleReplacement(unittest.TestCase):
+    """Two writers observing the SAME stale intent (qingyun review, #3191).
+    Unserialized, each could unlink what the other just installed, so a waiter
+    would see its own intent disappear and report a consumption that never
+    happened. Exactly one writer may win, and its file must survive until
+    `consume_intent` takes it."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = self.tmp.name
+        os.makedirs(os.path.join(self.ws, "state"), exist_ok=True)
+        path = _mod.write_intent(self.ws, "restart", "seed")
+        with open(path) as f:
+            d = json.load(f)
+        d["requested_at"] = time.time() - (_mod.STALE_SEC + 60)
+        with open(path, "w") as f:
+            json.dump(d, f)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _race(self, n=2):
+        start = threading.Barrier(n)
+        won, refused = [], []
+        lock = threading.Lock()
+
+        def writer(i):
+            start.wait()
+            try:
+                p = _mod.write_intent(self.ws, "stop" if i else "restart", f"w{i}")
+                with lock:
+                    won.append((i, p))
+            except _mod.IntentPending:
+                with lock:
+                    refused.append(i)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+        self.assertFalse([t for t in threads if t.is_alive()], "writer deadlocked")
+        return won, refused
+
+    def test_writer_blocks_while_the_transition_lock_is_held(self):
+        # Deterministic proof of serialization: hold the writer lock from
+        # outside and the production function must not proceed past inspect.
+        import fcntl
+        done = threading.Event()
+
+        def writer():
+            try:
+                _mod.write_intent(self.ws, "stop", "blocked")
+            except _mod.IntentPending:
+                pass
+            done.set()
+
+        with open(_mod.intent_path(self.ws) + ".lock", "a") as held:
+            fcntl.flock(held.fileno(), fcntl.LOCK_EX)
+            threading.Thread(target=writer, daemon=True).start()
+            self.assertFalse(done.wait(timeout=1.0),
+                             "write_intent did not serialize on the lock")
+            fcntl.flock(held.fileno(), fcntl.LOCK_UN)
+        self.assertTrue(done.wait(timeout=10), "writer never resumed")
+
+    def test_exactly_one_writer_wins(self):
+        # Repeated: a single race rarely lands in the peek/unlink window, so
+        # one round passes even unserialized and proves nothing.
+        for _ in range(60):
+            self.setUp()
+            won, refused = self._race()
+            self.assertEqual(len(won), 1, f"won={won} refused={refused}")
+            self.assertEqual(len(refused), 1)
+            self.assertTrue(os.path.exists(_mod.intent_path(self.ws)),
+                            "the winner's intent was deleted by the loser")
+
+    def test_winners_intent_survives_until_consumed(self):
+        # The whole point: the loser must not delete the winner's live file,
+        # or the winner's waiter reads that deletion as executor consumption.
+        won, _ = self._race()
+        self.assertTrue(os.path.exists(_mod.intent_path(self.ws)))
+        self.assertIsNotNone(_mod.peek_intent(self.ws))
+        # No executor has run, so a zero-timeout wait must NOT claim success.
+        self.assertFalse(_mod.await_consumption(
+            self.ws, timeout_sec=0, poll_sec=0, sleep=lambda _: None, now=lambda: 0.0))
+        self.assertIsNotNone(_mod.consume_intent(self.ws))
+
+    def test_no_temp_files_survive_the_race(self):
+        self._race()
+        leftovers = [f for f in os.listdir(os.path.join(self.ws, "state"))
+                     if f.endswith(".tmp")]
+        self.assertEqual(leftovers, [])
+
+    def test_eight_writers_still_yield_one_intent(self):
+        won, refused = self._race(n=8)
+        self.assertEqual(len(won), 1, f"won={won} refused={refused}")
+        self.assertEqual(len(refused), 7)
+        self.assertIn(_mod.consume_intent(self.ws), _mod._ACTIONS)
 
 
 if __name__ == "__main__":

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -434,5 +434,78 @@ class TestConcurrentStaleReplacement(unittest.TestCase):
         self.assertIn(_mod.consume_intent(self.ws), _mod._ACTIONS)
 
 
+
+class TestWriterVersusConsumer(unittest.TestCase):
+    """A consumer that reads, then deletes, can delete an intent it never read
+    (qingyun review, #3191): writer replaces the stale file between the two
+    steps, consumer removes the NEW one and discards its stale payload. Nobody
+    acts, the file is gone, and the writer's waiter reads that as consumption."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = self.tmp.name
+        os.makedirs(os.path.join(self.ws, "state"), exist_ok=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _seed_stale(self):
+        path = _mod.write_intent(self.ws, "restart", "seed")
+        with open(path) as f:
+            d = json.load(f)
+        d["requested_at"] = time.time() - (_mod.STALE_SEC + 60)
+        with open(path, "w") as f:
+            json.dump(d, f)
+
+    def test_consumer_blocks_while_the_intent_lock_is_held(self):
+        import fcntl
+        self._seed_stale()
+        done = threading.Event()
+
+        def consumer():
+            _mod.consume_intent(self.ws)
+            done.set()
+
+        with open(_mod.intent_path(self.ws) + ".lock", "a") as held:
+            fcntl.flock(held.fileno(), fcntl.LOCK_EX)
+            threading.Thread(target=consumer, daemon=True).start()
+            self.assertFalse(done.wait(timeout=1.0),
+                             "consume_intent deleted without holding the lock")
+            fcntl.flock(held.fileno(), fcntl.LOCK_UN)
+        self.assertTrue(done.wait(timeout=10), "consumer never resumed")
+
+    def test_consumer_never_destroys_an_intent_it_did_not_act_on(self):
+        # The invariant: after any writer/consumer interleaving, either the
+        # consumer acted, or a live intent is still on disk for the next poll.
+        for _ in range(60):
+            self.setUp()
+            self._seed_stale()
+            got = {}
+            start = threading.Barrier(2)
+
+            def writer():
+                start.wait()
+                try:
+                    _mod.write_intent(self.ws, "stop", "w")
+                    got["written"] = True
+                except _mod.IntentPending:
+                    got["written"] = False
+
+            def consumer():
+                start.wait()
+                got["action"] = _mod.consume_intent(self.ws)
+
+            ts = [threading.Thread(target=writer), threading.Thread(target=consumer)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join(timeout=10)
+            if got.get("written") and got.get("action") is None:
+                self.assertTrue(
+                    os.path.exists(_mod.intent_path(self.ws)),
+                    "writer succeeded and nobody acted, yet the intent is gone — "
+                    "its waiter would report a consumption that never happened")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -120,9 +120,6 @@ class TestWriteConsume(unittest.TestCase):
             self.assertIsNone(_mod.consume_intent(ws))
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
-
 
 class TestAwaitConsumption(unittest.TestCase):
     """Ack-on-consumption (#3183): the bridge must not promise a restart that
@@ -166,3 +163,5 @@ class TestAwaitConsumption(unittest.TestCase):
 
         self.assertTrue(_mod.await_consumption(
             self.ws, timeout_sec=5, poll_sec=0, sleep=boom, now=lambda: 0.0))
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -163,5 +163,67 @@ class TestAwaitConsumption(unittest.TestCase):
 
         self.assertTrue(_mod.await_consumption(
             self.ws, timeout_sec=5, poll_sec=0, sleep=boom, now=lambda: 0.0))
+
+class TestExclusiveIntent(unittest.TestCase):
+    """One pending intent at a time (#3191 review). `await_consumption` reads a
+    single deletion as "my request was taken", so two live intents would let one
+    executor action satisfy two waiters expecting OPPOSITE actions."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = self.tmp.name
+        os.makedirs(os.path.join(self.ws, "state"), exist_ok=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_superseding_opposite_action_is_rejected(self):
+        _mod.write_intent(self.ws, "restart", "test")
+        with self.assertRaises(_mod.IntentPending) as caught:
+            _mod.write_intent(self.ws, "stop", "test")
+        # The rejection names the SURVIVING action, so the ack can be accurate.
+        self.assertEqual(caught.exception.action, "restart")
+        # The first intent is untouched — the loser never clobbers the winner.
+        self.assertEqual(_mod.peek_intent(self.ws)["action"], "restart")
+
+    def test_rejection_leaves_exactly_one_consumable_intent(self):
+        # The scenario from the review: restart, then stop, then one executor.
+        _mod.write_intent(self.ws, "restart", "test")
+        with self.assertRaises(_mod.IntentPending):
+            _mod.write_intent(self.ws, "stop", "test")
+        self.assertEqual(_mod.consume_intent(self.ws), "restart")
+        self.assertIsNone(_mod.consume_intent(self.ws))
+
+    def test_same_action_repeat_is_also_rejected(self):
+        _mod.write_intent(self.ws, "stop", "test")
+        with self.assertRaises(_mod.IntentPending):
+            _mod.write_intent(self.ws, "stop", "test")
+
+    def test_stale_intent_is_replaced_not_rejected(self):
+        path = _mod.write_intent(self.ws, "restart", "test")
+        with open(path) as f:
+            d = json.load(f)
+        d["requested_at"] = time.time() - (_mod.STALE_SEC + 60)
+        with open(path, "w") as f:
+            json.dump(d, f)
+        # An abandoned intent must not wedge the command forever.
+        _mod.write_intent(self.ws, "stop", "test")
+        self.assertEqual(_mod.peek_intent(self.ws)["action"], "stop")
+
+    def test_peek_never_consumes(self):
+        _mod.write_intent(self.ws, "restart", "test")
+        self.assertEqual(_mod.peek_intent(self.ws)["action"], "restart")
+        self.assertEqual(_mod.peek_intent(self.ws)["action"], "restart")
+        self.assertEqual(_mod.consume_intent(self.ws), "restart")
+
+    def test_no_temp_files_left_behind(self):
+        _mod.write_intent(self.ws, "restart", "test")
+        with self.assertRaises(_mod.IntentPending):
+            _mod.write_intent(self.ws, "stop", "test")
+        leftovers = [f for f in os.listdir(os.path.join(self.ws, "state"))
+                     if f.endswith(".tmp")]
+        self.assertEqual(leftovers, [])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -122,3 +122,47 @@ class TestWriteConsume(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestAwaitConsumption(unittest.TestCase):
+    """Ack-on-consumption (#3183): the bridge must not promise a restart that
+    no executor will perform. Consumption is proven by the file disappearing —
+    not by probing for one named consumer implementation."""
+
+    def setUp(self):
+        self.ws = tempfile.mkdtemp()
+
+    def test_returns_true_when_executor_consumes(self):
+        _mod.write_intent(self.ws, "restart", "test")
+        calls = {"n": 0}
+
+        def fake_sleep(_):
+            calls["n"] += 1
+            if calls["n"] == 2:  # an executor claims it on the 2nd poll
+                _mod.consume_intent(self.ws)
+
+        self.assertTrue(_mod.await_consumption(
+            self.ws, timeout_sec=10, poll_sec=0, sleep=fake_sleep,
+            now=lambda: 0.0))
+
+    def test_returns_false_when_nothing_consumes(self):
+        _mod.write_intent(self.ws, "restart", "test")
+        t = {"v": 0.0}
+
+        def fake_sleep(_):
+            t["v"] += 1.0
+
+        # File is never consumed -> must time out False, not hang or lie.
+        self.assertFalse(_mod.await_consumption(
+            self.ws, timeout_sec=3, poll_sec=0, sleep=fake_sleep,
+            now=lambda: t["v"]))
+        # ...and the intent is still on disk for a late executor / expiry.
+        self.assertTrue(os.path.exists(_mod.intent_path(self.ws)))
+
+    def test_already_consumed_before_first_poll_returns_immediately(self):
+        # No intent on disk at all: return True without ever sleeping.
+        def boom(_):
+            raise AssertionError("must not sleep when already consumed")
+
+        self.assertTrue(_mod.await_consumption(
+            self.ws, timeout_sec=5, poll_sec=0, sleep=boom, now=lambda: 0.0))

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -225,5 +225,88 @@ class TestExclusiveIntent(unittest.TestCase):
         self.assertEqual(leftovers, [])
 
 
+
+class TestExclusiveIntentEdges(unittest.TestCase):
+    """The refusal paths of the exclusive claim. Each one decides whether the
+    owner is told a request was queued, so none of them may be inferred."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = self.tmp.name
+        self.state = os.path.join(self.ws, "state")
+        os.makedirs(self.state, exist_ok=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_peek_returns_none_when_absent_or_unreadable(self):
+        self.assertIsNone(_mod.peek_intent(self.ws))
+        with open(_mod.intent_path(self.ws), "w") as f:
+            f.write("{not json")
+        self.assertIsNone(_mod.peek_intent(self.ws))
+
+    def test_peek_returns_none_for_unknown_action(self):
+        for payload in ({"action": "self-destruct", "requested_at": time.time()},
+                        ["not", "a", "dict"]):
+            with open(_mod.intent_path(self.ws), "w") as f:
+                json.dump(payload, f)
+            self.assertIsNone(_mod.peek_intent(self.ws))
+
+    def test_racing_writer_refill_loses(self):
+        # Both attempts collide and peek finds nothing live: someone else is
+        # writing. Refuse rather than clobber a claim we cannot read.
+        real_link = os.link
+
+        def always_taken(src, dst):
+            raise FileExistsError(dst)
+
+        os.link = always_taken
+        try:
+            with self.assertRaises(_mod.IntentPending):
+                _mod.write_intent(self.ws, "restart", "test")
+        finally:
+            os.link = real_link
+
+    def test_undeletable_stale_intent_refuses_rather_than_clobbers(self):
+        _mod.write_intent(self.ws, "restart", "test")
+        path = _mod.intent_path(self.ws)
+        with open(path) as f:
+            d = json.load(f)
+        d["requested_at"] = time.time() - (_mod.STALE_SEC + 60)
+        with open(path, "w") as f:
+            json.dump(d, f)
+        real_unlink = os.unlink
+
+        def refuse_intent(target):
+            if str(target) == path:
+                raise OSError("read-only")
+            return real_unlink(target)
+
+        os.unlink = refuse_intent
+        try:
+            with self.assertRaises(_mod.IntentPending):
+                _mod.write_intent(self.ws, "stop", "test")
+        finally:
+            os.unlink = real_unlink
+
+    def test_tmp_cleanup_failure_never_masks_the_result(self):
+        # The temp file is bookkeeping; failing to remove it must not turn a
+        # successful claim into an error the owner sees.
+        real_unlink = os.unlink
+
+        def refuse_tmp(target):
+            if str(target).endswith(".tmp"):
+                raise OSError("gone already")
+            return real_unlink(target)
+
+        os.unlink = refuse_tmp
+        try:
+            self.assertEqual(_mod.write_intent(self.ws, "restart", "test"),
+                             _mod.intent_path(self.ws))
+        finally:
+            os.unlink = real_unlink
+        self.assertEqual(_mod.consume_intent(self.ws), "restart")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes the design flaw the reporter of sonichi#3182 identified when they **retracted their own bug** in sonichi#3183.

## What was wrong

`_maybe_handle_core_restart` in `discord-bridge.py` acked the owner the moment it *wrote* `state/core-restart-requested.json`:

> Restart requested — the app will relaunch the core in a few seconds (authenticated, GUI session). I'll be back once it's up.

`write_intent()` only writes a file, so it essentially always succeeds. On a host whose executor is gone the owner got that confident message and **nothing happened** — the intent expired silently 600s later, with no error anywhere.

## Why not just check for the consumer

The obvious fix — "is Sutando.app running?" — is what made the original report wrong, and I nearly repeated it. That probe answers *is THAT consumer here*, not *will anything act*, and returns the same `False` on a host whose executor is simply a different implementation. The reporter's host had a hand-built `ai.sutando.core-restart-executor` launchd service polling the same file; they filed the bug after reading the old standalone-app Swift source and concluding the consumer was gone, without checking `launchctl`.

So the check has to be implementation-agnostic. `consume_intent()` **deletes before acting**, so the file disappearing is proof that *something* claimed it — regardless of what that something is.

## The change

- **`await_consumption(workspace, timeout_sec=12.0, …)`** — polls until the intent file is gone; `True` if claimed, `False` on timeout. Injectable `sleep`/`now` so tests don't wait on wall-clock. Lives in the intent module because that module owns the intent contract's failure semantics; the bridge keeps only its ack text.
- **`write_intent` is now exclusive** (see below) — it claims the path with `os.link`, which fails atomically when one is already pending, and raises `IntentPending` naming the *surviving* action. `peek_intent` reads without consuming.
- **`discord-bridge.py`** awaits consumption (via `asyncio.to_thread`, so the event loop keeps running) and picks its ack from the real outcome: claimed, timed-out-but-may-still-run, or refused-because-one-is-pending.

The intent file is deliberately **left on disk** on timeout: a late executor can still claim it, and `STALE_SEC` expiry is unchanged.

### Why exclusivity is load-bearing, not a nicety

@qingyun-wu's review caught that pathname-disappearance cannot identify *which* request was consumed. If the owner sends `restart core` and then `stop core` inside the window, the second write supersedes the first on disk; the executor performs only `stop`, but both waiters see one deletion and each reports its own — opposite — action as picked up. Their control, reproduced at the parent and at head:

```
### ee49b99 (the reviewed head):
  second write        : written (supersedes)
  consumer_action     : stop
  restart_waiter says : claimed=True
  stop_waiter says    : claimed=True
  => BUG: two waiters both claim a single deletion

### HEAD:
  second write        : IntentPending: an unconsumed 'restart' request is already pending
  consumer_action     : restart
  restart_waiter says : claimed=True
  stop_waiter says    : claimed=n/a (write rejected — no waiter)
  => SOUND: one intent, one waiter, ack matches action
```

A stale intent is still *replaced* rather than refused — otherwise an abandoned request from a dead executor would wedge `restart core` for its full 10-minute expiry.

## Evidence

This host has neither `/Applications/Sutando.app` nor an `ai.sutando.core-restart-executor` launchd service — so it is exactly the broken case, and the old ack was a lie here.

```
=== BEFORE (parent commit behaviour), simulated on this host:
  intent written -> core-restart-requested.json
  OLD ack (unconditional): 'Restart requested — the app will relaunch the core in a few seconds'
=== AFTER (this branch): wait for a consumer that does not exist
  await_consumption -> False  (waited 3.0s)
  NEW ack: 'Wrote the restart request, but no executor picked it up within 12s'
  intent still on disk for late executor/expiry: True
```

```
$ python3 tests/core-restart-intent.test.py
Ran 26 tests in 0.021s
OK

$ python3 tests/bridge-restart-intercept.test.py
all checks passed — bridge restart intercept

$ bash scripts/review-checks.sh --diff /tmp/pr3191-full3.diff
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

12 → 26 on the intent suite. The additions are the exclusivity contract (superseding-opposite rejected, rejection leaves exactly one consumable intent, same-action repeat rejected, stale replaced, `peek_intent` never consumes, no temp files left behind) and the refusal paths the diff-coverage gate named (peek on absent/corrupt/unknown-action input, racing refill, undeletable stale intent, tmp-cleanup failure that must not turn a successful claim into an error). The bridge suite gained the `IntentPending` ack, asserting it names the surviving action and leaves the first intent on disk.

**Correction to an earlier version of this body:** it claimed "Ran 12 tests … OK (9 pre-existing + 3 new)". That was wrong — the new class sat *after* the `if __name__ == "__main__"` guard, so those three never ran and all 12 were pre-existing. Moving the guard to the end is what made them execute. Recorded here rather than quietly dropped, since the number was cited as evidence.

## Not covered here

The bridge process on this host runs pre-change code — it started `Wed Aug 19 09:00:39`, before every commit on this branch — so the new ack has **not** been exercised through a live Discord round trip. (An earlier version of this line cited a `health-check.py` staleness warning; that probe now reports `discord-bridge: ok running`, so the process start time is the honest evidence, not the probe.) Every claim above is unit- or seam-level. Flagging it rather than implying live-path proof I don't have — I'll run one the moment the owner is up for a bridge/core restart, and post the real before/after here.

---

**Update — one more defect, found by self-review rather than CI.** Applying the same lens as @qingyun-wu's finding (a guard that covers one branch of a dispatch but not its sibling) to my own code: the stale-clear caught bare `OSError`, which conflates two cases whose correct responses are *opposite*. If an executor consumes the stale intent between our `peek` and our `unlink`, the path is now **free** and we should claim it — but the bare catch reported `IntentPending`, telling the owner a request was pending that nobody had made. `FileNotFoundError` now falls through to the retry; a genuine unlink failure still refuses. Control: with that branch removed the new test errors; with it, 27/27 pass.
