### PR TITLE
fix(health-check): the quarantine probe tells you nobody has been told

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6338,8 +6338,9 @@ def check_proactive_quarantine() -> dict:
         "name": name,
         "status": "warn",
         "detail": (f"{len(kept)} proactive message(s) kept in results/undelivered/ that Discord "
-                   f"refused — preserved, but nothing reads this directory, so nobody has been "
-                   f"told; oldest {oldest_name} ({oldest_age // 3600}h{oldest_age % 3600 // 60}m)"
+                   f"refused — preserved, but no consumer drains this directory, so they stay "
+                   f"until someone acts; oldest {oldest_name} "
+                   f"({oldest_age // 3600}h{oldest_age % 3600 // 60}m)"
                    f"{partial}"),
     }
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6285,15 +6285,17 @@ def check_proactive_quarantine() -> dict:
     the owner never saw was also destroyed — observed live here as
     `413 Payload Too Large (error code: 40005)`. The fix (#2626) moves the body
     to `results/undelivered/` instead of deleting it, which is strictly better
-    and still ends with nobody being told: a scan of the whole tree at that
+    but left the body with no consumer: a scan of the whole tree at that
     change's head finds the writer and **no reader at all**. The nearest
     candidate, `friction-detector.check_stale_results()`, is a stub that returns
     `[]` and is never called.
 
-    That is the shape this probe exists to close. Preservation without a reader
-    is a message that exists on disk and reaches no one — the same failure as
-    deletion from the owner's side, minus the recoverability. Losing it loudly
-    at least surfaces; losing it quietly does not.
+    That is the shape this probe exists to close, which makes it the reader —
+    so "nobody has been told" stopped being true the moment this shipped, and
+    saying it here or in what this probe emits invites the output to be quoted
+    back as independent evidence that no reader exists. What stays true is
+    narrower: nothing drains or re-drives the directory, so a preserved body
+    reaches no one until someone acts. Warning is not delivering.
 
     Deliberately NOT a failure: quarantine is the correct end state for a body
     Discord will never accept (a 413 never becomes a 200). The action is for a

--- a/tests/health-check-proactive-quarantine.test.py
+++ b/tests/health-check-proactive-quarantine.test.py
@@ -63,7 +63,10 @@ class TestProactiveQuarantine(unittest.TestCase):
             self.assertIn("proactive-1785870055.txt", r["detail"])
             self.assertIn("2h15m", r["detail"])
             # The verdict must say WHY it matters, not just that a file exists.
-            self.assertIn("nothing reads this directory", r["detail"])
+            self.assertIn("no consumer drains this directory", r["detail"])
+            # ...and must not say nobody was told. Emitting this line IS telling;
+            # the claim was quoted as an independent finding twice.
+            self.assertNotIn("nobody has been told", r["detail"])
 
     def test_every_kept_body_is_counted(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/health-check-proactive-quarantine.test.py
+++ b/tests/health-check-proactive-quarantine.test.py
@@ -3,8 +3,9 @@
 
 #2626 stops `poll_proactive` from deleting a proactive DM that Discord refused,
 moving the body to `results/undelivered/` instead. That is strictly better than
-destroying it and still leaves nobody informed: at that change's head the only
-code touching the directory is the writer. This probe is the reader.
+destroying it, but left the body with no consumer: at that change's head the only
+code touching the directory is the writer. This probe is the reader — so what it
+reports is that nothing drains the directory, never that nobody has been told.
 
 The controls that matter here are the ones that would let the probe report a
 clean host while a message sits unread:


### PR DESCRIPTION
## The defect

`proactive-quarantine` (src/health-check.py) reports parked proactive bodies like this:

```
⚠ proactive-quarantine   19 proactive message(s) kept in results/undelivered/ that Discord
                         refused — preserved, but nothing reads this directory, so nobody
                         has been told; oldest proactive-arcade-revision-… (249h42m)
```

**"so nobody has been told" is false at the instant it prints.** Emitting that line is telling. The probe is the reader it says does not exist — and the test pinned the claim verbatim (`assertIn("nothing reads this directory", …)`), so the repo guaranteed it kept saying so.

## Why it is not cosmetic

The sentence has been quoted as an independent finding twice:

- **#2910** ("results/undelivered/ is write-only", open since 08-15) cites it under *Why nothing picks it up* — harmless there, because the surrounding `git grep` does the real work.
- **#3186, today**, a review used it to conclude no reader exists and that something should be built to watch the directory. That shipped on **2026-08-04 as #2649 — which is this probe**, five days before the oldest file in the population being examined.

A claim a probe makes about itself stops looking self-referential the moment it is quoted somewhere else.

## The change

One clause. The first half stays, reworded — #2910's grep of `origin/main` establishes every reference to `results/undelivered/` is a writer or a log line, so *no consumer drains it* is true and is the part worth saying.

```
- refused — preserved, but nothing reads this directory, so nobody has been
- told; oldest {oldest_name} ({...}h{...}m)
+ refused — preserved, but no consumer drains this directory, so they stay
+ until someone acts; oldest {oldest_name}
+ ({...}h{...}m)
```

## Evidence

Parent (`origin/main` @ `ce171bf4`) with this branch's test — the assertion bites:

```
$ /usr/bin/python3 tests/health-check-proactive-quarantine.test.py
  File "tests/health-check-proactive-quarantine.test.py", line 66, in test_a_kept_body_warns_and_is_named
    self.assertIn("no consumer drains this directory", r["detail"])
AssertionError: 'no consumer drains this directory' not found in '1 proactive message(s) kept in
results/undelivered/ that Discord refused — preserved, but nothing reads this directory, so nobody
has been told; oldest proactive-1785870055.txt (2h15m)'
Ran 8 tests — FAILED (failures=1)
```

HEAD (`3bdc0358`):

```
$ /usr/bin/python3 tests/health-check-proactive-quarantine.test.py
Ran 8 tests in 0.034s — OK

$ /usr/bin/python3 tests/health-check-stale-proactive-backlog.test.py
OK

$ bash scripts/review-checks.sh --diff /tmp/q.diff
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)

$ git diff --cached --check      # clean
```

The old phrasing survives on this branch in exactly one place — the new `assertNotIn` guarding against its return.

## Scope — what this does NOT do

**It does not close #2910.** The stranded bodies still need the classification-aware re-drive that issue describes; a blanket retry would be wrong, because park time discards the transient/permanent verdict `resolve_failed_send()` had just computed, leaving a DNS outage and a permanent 403 indistinguishable on disk. This PR changes what the operator is told, not what happens to the files.

Not a live path (probe detail string, no bridge/network/delivery behaviour), so unit evidence is the appropriate proof and no restart round trip applies. I did not run the full suite — five failures are pre-existing on `origin/main` here (codex-core-launcher, gateway-owner-presence-peer-gate, 3× screen-capture) and are unrelated to this diff.

@sonichi flagging you — this is a two-file, one-clause change; the interesting part is item 2 above, not the diff.
