### PR TITLE
docs(proactive-loop): a counted pending question can still render nowhere

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -200,6 +200,24 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    it away as a stale count, and only a title-level check showed the zero. The count is the
    discriminator; the substring cannot fail the way this actually fails.
 
+   **⚠ A COUNTED question can still be INVISIBLE — assert POSITION too (2026-08-20).** The count
+   rising proves membership, not visibility. Waiting order is FILE order, so "insert above the
+   `# Resolved` divider" — the rule that makes a question counted at all — lands it at the BOTTOM of
+   the visible list. The two rules pull opposite ways. Only two consumers render anything, and both
+   take an ordered prefix: `notify_macos` shows `titles[:3]` and the proactive DM body shows
+   `questions[:5]` (hence `VISIBLE_PREFIX = 5` in `src/check-pending-questions.py`). **Positions 6+
+   render nowhere** — they exist only in the file and the web UI's Questions tab. Measured on a live
+   host: `VISIBLE_PREFIX=5; waiting=34; rendered nowhere = 29 of 34`, and the question filed that
+   pass sat at **34/34** while the assertion documented above printed `34 1` — a pass. Extend the
+   proof to position:
+   ```bash
+   python3 -c "import importlib.util;s=importlib.util.spec_from_file_location('c','src/check-pending-questions.py');m=importlib.util.module_from_spec(s);s.loader.exec_module(m);q=m.get_waiting_questions();i=next(k for k,x in enumerate(q,1) if '<distinctive phrase from your TITLE>' in (x.get('title') or ''));assert i <= m.VISIBLE_PREFIX, f'filed at {i}/{len(q)} - below the fold, renders nowhere'"
+   ```
+   If it lands below the fold and it genuinely needs the owner, **move it up** — do not file a second
+   question about the first one being unread. Promotion is self-announcing: `notify_key` hashes the
+   visible-ordered prefix (#3004), so changing the top 5 defeats the cooldown by construction and the
+   next fire notifies.
+
 9. **Ensure the streaming watcher is running.** **Read the `task-watcher` probe from the `health-check.py` run you already did in step 3 — do not re-derive liveness here.** That probe is the authoritative signal: it enumerates real watcher process trees (`_watcher_trees()` in `src/health-check.py`) and reports which of four states holds. Act on the state it names:
 
    | probe says | action |


### PR DESCRIPTION
## The defect

The filing assertion in `skills/proactive-loop/SKILL.md` step 8 proves a question is **counted**, not that it is **seen**.

Waiting order is file order. The rule that makes a question counted at all — insert above the `# Resolved` divider (#2539) — therefore lands it at the *bottom* of the visible list. The two rules pull opposite ways, and nothing said so.

Only two consumers render anything, and both take an ordered prefix:

```
258:    msg = f"{count} pending question{'s' if count > 1 else ''}: {', '.join(titles[:3])}"
277:# Deepest ordered prefix any consumer renders: notify_macos shows titles[:3],
278:# the proactive DM body shows questions[:5]. Covering 5 covers both.
279:VISIBLE_PREFIX = 5
```

Positions 6+ reach no consumer.

## Evidence (live host, `cwd` = the install whose workspace holds the real file)

**Before — the recipe SKILL.md documents today, run against a question filed that same pass:**

```
$ python3 -c "...;q=m.get_waiting_questions();print(len(q), sum('unfiled-findings-backlog' in (x.get('title') or '') for x in q))"
34 1
```

34 waiting, 1 title matched — reads as a pass. The question was at **34/34** and rendered nowhere.

**After — the position assertion this PR adds:**

```
AssertionError: filed at 34/34 - below the fold, renders nowhere
```

**Scale of the blind spot on that host:**

```
VISIBLE_PREFIX=5; waiting=34; rendered nowhere = 29 of 34
```

**Corroborated on a second host** (@qingyun-wu, reviewing this PR): `waiting=97`, **92 below the fold** — a 10x worse ratio than mine, and the same shape. 34 was the conservative case, not the alarming one.

## What changed

Docs only — 18 added lines, 0 removed, one file. Adds the position half of the proof, plus the remedy: if it lands below the fold and genuinely needs the owner, move it up rather than filing a second question about the first being unread. Promotion is self-announcing because `notify_key` hashes the visible-ordered prefix (#3004), so changing the top 5 defeats the cooldown by construction.

## Series

Third iteration on this assertion, all previous merged:

- #2539 — a question appended at EOF is never counted
- #2876 — the assertion could not detect a swallowed entry
- #3004 — the cooldown could not see a promotion into the top

This is the below-the-fold case: counted, unswallowed, and still invisible.

No code paths touched, so no runtime evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNTJu2gT77tcdRJ3TYn83s
