### PR TITLE
fix(health-check): --fix never restarted the gateway bridge, the ag2.space carrier

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3298,6 +3298,19 @@ def _default_local_notifier(msg: str) -> bool:
         return False
 
 
+# Per-bridge EXACT detail: gateway-bridge's other warns (not-serving, duplicate
+# pileup) describe a live process, so only this string may respawn one.
+GATEWAY_DOWN_DETAIL = (
+    "configured but NOT running — ag2.space mobile messages will not be delivered"
+)
+DOWN_BRIDGE_DETAILS = {
+    "telegram-bridge": "configured but not running",
+    "discord-bridge": "configured but not running",
+    "slack-bridge": "configured but not running",
+    "gateway-bridge": GATEWAY_DOWN_DETAIL,
+}
+
+
 def fix_down_bridges(checks: list, *, action=None, sender=None, guard=None,
                      notifier=None) -> list:
     """Restart or alert on configured-but-not-running channel bridges."""
@@ -3333,9 +3346,8 @@ def fix_down_bridges(checks: list, *, action=None, sender=None, guard=None,
     restarted = []
     for c in checks:
         if not (
-            c["name"] in ("telegram-bridge", "discord-bridge", "slack-bridge")
-            and c["status"] == "warn"
-            and c.get("detail") == "configured but not running"
+            c["status"] == "warn"
+            and c.get("detail") == DOWN_BRIDGE_DETAILS.get(c["name"])
         ):
             continue
         name = c["name"]
@@ -3374,6 +3386,19 @@ def _bridge_launch_plan(name: str) -> "tuple[str, dict] | None":
         # No interpreter can import the bridge's dependency (startup.sh skips too).
         return None
     child_env = os.environ.copy()
+    if name == "gateway-bridge":
+        # The bridge exits without a token, and startup.sh sources the same
+        # channels/ag2space/.env before launching it.
+        gw_env = _load_channel_env("ag2space")
+        merged = {**os.environ, **gw_env}
+        token = merged.get("REMOTE_TASK_TOKEN") or merged.get("AG2_REMOTE_TOKEN")
+        if not token:
+            return None
+        child_env.update(gw_env)
+        child_env["REMOTE_TASK_TOKEN"] = token
+        # Marks the launch supervised so the bridge stamps launched_via and
+        # skips its own bare-launch file log (see remote_gateway_bridge._log).
+        child_env["SUTANDO_SUPERVISED"] = "1"
     if name == "slack-bridge":
         # slack-bridge exits without BOTH tokens non-empty; the Keychain vault is
         # a real source (same env -> .env -> vault tiering as the bridge itself).
@@ -3387,6 +3412,10 @@ def _bridge_launch_plan(name: str) -> "tuple[str, dict] | None":
     return interp, child_env
 
 
+# Check name → src/<script>.py, for the bridges whose two names differ.
+_BRIDGE_SCRIPT = {"gateway-bridge": "remote-gateway-bridge"}
+
+
 def _launch_bridge(name: str, plan: "tuple[str, dict] | None" = None) -> bool:
     """Spawn a bridge per _bridge_launch_plan; True if spawned."""
     plan = plan or _bridge_launch_plan(name)
@@ -3398,7 +3427,7 @@ def _launch_bridge(name: str, plan: "tuple[str, dict] | None" = None) -> bool:
     # `with` closes the parent's handle after Popen; the child holds
     # its own dup of the fd, so the log stays writable.
     with open(str(log_path), "a") as log_f:
-        subprocess.Popen([interp, str(REPO_DIR / "src" / f"{name}.py")],
+        subprocess.Popen([interp, str(REPO_DIR / "src" / f"{_BRIDGE_SCRIPT.get(name, name)}.py")],
                          stdout=log_f, stderr=subprocess.STDOUT,
                          env=child_env, start_new_session=True)
     return True
@@ -5352,7 +5381,7 @@ def check_gateway_bridge() -> "dict | None":
         return {
             "name": "gateway-bridge",
             "status": "warn",
-            "detail": "configured but NOT running — ag2.space mobile messages will not be delivered",
+            "detail": GATEWAY_DOWN_DETAIL,
         }
     claimed = _gateway_lock_pids()
     if claimed:
@@ -10388,7 +10417,7 @@ def main():
                     # here — the result string will say the restart failed.
                     result = fix_launchd(LAUNCHD_BACKED_CHECKS[c["name"]])  # pragma: no cover
                     print(f"  {c['name']}: {result}")  # pragma: no cover
-                elif c["name"] in ("telegram-bridge", "discord-bridge", "slack-bridge"):  # pragma: no cover - --fix restart path spawns real subprocesses; not unit-tested
+                elif c["name"] in DOWN_BRIDGE_DETAILS:  # pragma: no cover - --fix restart path spawns real subprocesses; not unit-tested
                     # LoginFailure means the token is bad — restarting won't help
                     # and would create a duplicate alongside the launchd-managed one.
                     if "LoginFailure" in c.get("detail", "") or "token invalid" in c.get("detail", ""):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3345,9 +3345,12 @@ def fix_down_bridges(checks: list, *, action=None, sender=None, guard=None,
 
     restarted = []
     for c in checks:
+        # The name gate is NOT redundant with the detail match: for an unknown
+        # name the lookup is None, and a check with no detail is also None.
         if not (
-            c["status"] == "warn"
-            and c.get("detail") == DOWN_BRIDGE_DETAILS.get(c["name"])
+            c["name"] in DOWN_BRIDGE_DETAILS
+            and c["status"] == "warn"
+            and c.get("detail") == DOWN_BRIDGE_DETAILS[c["name"]]
         ):
             continue
         name = c["name"]

--- a/tests/health-check-fix-down-bridges.test.py
+++ b/tests/health-check-fix-down-bridges.test.py
@@ -16,6 +16,14 @@ Guards:
   b) other bridge warns (multiple PIDs, token invalid, stale log) → untouched
   c) non-bridge checks with the same detail → untouched
   d) ok/fail bridge statuses → untouched (fail belongs to the main fix loop)
+  y) gateway-bridge down → restarted, spawning remote-gateway-bridge.py
+  z) gateway-bridge's non-down warns describe a LIVE process → never respawned
+ aa) a tokenless gateway yields no launch plan (alert, not a crash-loop)
+ ab) AG2_REMOTE_TOKEN alone is enough, matching _gateway_configured()
+
+Second incident (2026-08-20): the gateway bridge — the ag2.space carrier — was
+the one channel bridge this path excluded, and its check name differs from its
+script name, so it was down 67 minutes with three tasks held gateway-side.
 
 Run: python3 tests/health-check-fix-down-bridges.test.py
 Exit code: 0 on pass, 1 on fail.
@@ -46,6 +54,18 @@ def check(name: str, status: str, detail: str) -> dict:
     return {"name": name, "status": status, "detail": detail}
 
 
+# Channel-aware: a flat dict gives the gateway slack's tokens, so every gateway
+# case would fail for the wrong reason (no token) and hide a real regression.
+_CHANNEL_ENV = {
+    "slack": {"SLACK_BOT_TOKEN": "xoxb-test", "SLACK_APP_TOKEN": "xapp-test"},
+    "ag2space": {"REMOTE_TASK_TOKEN": "gw-test-token"},
+}
+
+
+def _channel_env(channel: str) -> dict:
+    return dict(_CHANNEL_ENV.get(channel, {}))
+
+
 def run_with_popen_stub(checks: list, *, action="restart",
                         guard=lambda repo: (True, "test-clean"),
                         sender=None, notifier=None) -> tuple[list, list]:
@@ -68,7 +88,7 @@ def run_with_popen_stub(checks: list, *, action="restart",
     with tempfile.TemporaryDirectory() as td:
         with mock.patch.object(hc, "WORKSPACE_DIR", Path(td)), \
              mock.patch.object(hc, "_bridge_interpreter", return_value="python3"), \
-             mock.patch.object(hc, "_load_channel_env", return_value={"SLACK_BOT_TOKEN": "xoxb-test", "SLACK_APP_TOKEN": "xapp-test"}), \
+             mock.patch.object(hc, "_load_channel_env", side_effect=_channel_env), \
              mock.patch.object(hc, "token_from_vault", return_value=""), \
              mock.patch.object(hc.subprocess, "Popen", side_effect=fake_popen):
             restarted = hc.fix_down_bridges(
@@ -98,6 +118,84 @@ def case_a_down_bridges_restarted() -> list[str]:
     for argv in spawned:
         if not str(argv[1]).endswith("-bridge.py"):
             fails.append(f"a) spawn argv doesn't target a bridge script: {argv}")
+    return fails
+
+
+def case_y_gateway_bridge_down_is_restarted() -> list[str]:
+    """The gateway bridge carries ag2.space; it was the one channel bridge this
+    path excluded, so a death went unattended until someone ran health-check by
+    hand. Observed 2026-08-20: 67 minutes down, three tasks held gateway-side."""
+    fails = []
+    checks = [check("gateway-bridge", "warn", hc.GATEWAY_DOWN_DETAIL)]
+    restarted, spawned = run_with_popen_stub(checks)
+    if restarted != ["gateway-bridge"]:
+        fails.append(f"y) expected gateway-bridge restarted, got {restarted}")
+    if len(spawned) != 1:
+        fails.append(f"y) expected 1 spawn, got {len(spawned)}")
+    elif not str(spawned[0][1]).endswith("remote-gateway-bridge.py"):
+        # src/gateway-bridge.py does not exist, so a bare f"{name}.py" Popens a
+        # missing path and the "restart" is a no-op that still reports True.
+        fails.append(f"y) spawn must target remote-gateway-bridge.py: {spawned[0]}")
+    return fails
+
+
+def case_z_gateway_other_warns_never_respawn() -> list[str]:
+    """Only the DOWN detail may respawn. gateway-bridge's other warns describe a
+    bridge that IS running (not serving / duplicate pileup); spawning another
+    against a live one is the dual-poll state its singleton lock exists to avoid."""
+    fails = []
+    checks = [
+        check("gateway-bridge", "warn",
+              "process running but NOT serving — 12m; last ok 2026-08-20T11:54:15Z"),
+        check("gateway-bridge", "warn",
+              "2 gateway process(es) claimed by no instance lock (PIDs: 1,2); locks held: gateway-bridge=3"),
+        check("gateway-bridge", "warn",
+              "running; last poll did not succeed, last one that did was 9m ago"),
+        check("gateway-bridge", "ok", "running + connected"),
+    ]
+    restarted, spawned = run_with_popen_stub(checks)
+    if restarted or spawned:
+        fails.append(f"z) non-down gateway warns must not respawn: {restarted} {spawned}")
+    return fails
+
+
+def case_aa_gateway_plan_requires_a_token() -> list[str]:
+    """No token → no plan → alert instead of a crash-looping spawn, matching the
+    slack branch and startup.sh's labeled skip."""
+    fails = []
+    with mock.patch.object(hc, "_bridge_interpreter", return_value="python3"), \
+         mock.patch.object(hc, "_load_channel_env", return_value={}), \
+         mock.patch.dict(os.environ, {}, clear=True):
+        if hc._bridge_launch_plan("gateway-bridge") is not None:
+            fails.append("aa) tokenless gateway must yield no launch plan")
+    with mock.patch.object(hc, "_bridge_interpreter", return_value="python3"), \
+         mock.patch.object(hc, "_load_channel_env", side_effect=_channel_env), \
+         mock.patch.dict(os.environ, {}, clear=True):
+        plan = hc._bridge_launch_plan("gateway-bridge")
+        if plan is None:
+            fails.append("aa) gateway with a channel-env token must yield a plan")
+        else:
+            _, env = plan
+            if env.get("REMOTE_TASK_TOKEN") != "gw-test-token":
+                fails.append(f"aa) plan must carry the resolved token, got {env.get('REMOTE_TASK_TOKEN')!r}")
+            if env.get("SUTANDO_SUPERVISED") != "1":
+                fails.append("aa) plan must mark the launch supervised")
+    return fails
+
+
+def case_ab_ag2_remote_token_alias_is_accepted() -> list[str]:
+    """_gateway_configured() treats AG2_REMOTE_TOKEN as configuring the gateway,
+    so a host with only that alias must be launchable — otherwise the check warns
+    forever about a bridge --fix structurally refuses to start."""
+    fails = []
+    with mock.patch.object(hc, "_bridge_interpreter", return_value="python3"), \
+         mock.patch.object(hc, "_load_channel_env", return_value={"AG2_REMOTE_TOKEN": "alias-tok"}), \
+         mock.patch.dict(os.environ, {}, clear=True):
+        plan = hc._bridge_launch_plan("gateway-bridge")
+        if plan is None:
+            fails.append("ab) AG2_REMOTE_TOKEN alone must yield a plan")
+        elif plan[1].get("REMOTE_TASK_TOKEN") != "alias-tok":
+            fails.append(f"ab) alias must be normalised into REMOTE_TASK_TOKEN, got {plan[1].get('REMOTE_TASK_TOKEN')!r}")
     return fails
 
 
@@ -1032,7 +1130,11 @@ def main() -> int:
                  case_r_stale_missing_app_token_no_kill_no_spawn,
                  case_s_vault_only_slack_tokens_launchable,
                  case_t_interpreter_probe_never_execs_bare_python3,
-                 case_u_resolved_bare_python3_policy):
+                 case_u_resolved_bare_python3_policy,
+                 case_y_gateway_bridge_down_is_restarted,
+                 case_z_gateway_other_warns_never_respawn,
+                 case_aa_gateway_plan_requires_a_token,
+                 case_ab_ag2_remote_token_alias_is_accepted):
         fails = case()
         status = "PASS" if not fails else "FAIL"
         print(f"  {status} {case.__name__}")

--- a/tests/health-check-fix-down-bridges.test.py
+++ b/tests/health-check-fix-down-bridges.test.py
@@ -20,6 +20,7 @@ Guards:
   z) gateway-bridge's non-down warns describe a LIVE process → never respawned
  aa) a tokenless gateway yields no launch plan (alert, not a crash-loop)
  ab) AG2_REMOTE_TOKEN alone is enough, matching _gateway_configured()
+ ac) a non-bridge name with absent/None detail is NEVER restarted
 
 Second incident (2026-08-20): the gateway bridge — the ag2.space carrier — was
 the one channel bridge this path excluded, and its check name differs from its
@@ -156,6 +157,30 @@ def case_z_gateway_other_warns_never_respawn() -> list[str]:
     restarted, spawned = run_with_popen_stub(checks)
     if restarted or spawned:
         fails.append(f"z) non-down gateway warns must not respawn: {restarted} {spawned}")
+    return fails
+
+
+def case_ac_unknown_name_without_detail_is_untouched() -> list[str]:
+    """Reported by Sutando (rui) on #3203 and reproduced against the production
+    function before fixing. Matching only on the per-bridge detail lets an
+    unknown name through: the lookup is None, a check with no `detail` is also
+    None, and `None == None` restarts it — `_launch_bridge` then puts the check
+    NAME into a path, so `voice-agent` spawned `src/voice-agent.py`.
+
+    Existing case (c) cannot catch this: it pairs a non-bridge name with a real
+    bridge detail, which fails the match either way. The discriminator is a
+    non-bridge name whose detail is absent or None."""
+    fails = []
+    for label, chk in (
+        ("no detail key", {"name": "voice-agent", "status": "warn"}),
+        ("detail None", {"name": "voice-agent", "status": "warn", "detail": None}),
+        ("unknown + gateway detail", {"name": "voice-agent", "status": "warn",
+                                      "detail": hc.GATEWAY_DOWN_DETAIL}),
+    ):
+        restarted, spawned = run_with_popen_stub([chk])
+        if restarted or spawned:
+            fails.append(f"ac) {label}: non-bridge check must never restart — "
+                         f"got {restarted} {spawned}")
     return fails
 
 
@@ -1134,7 +1159,8 @@ def main() -> int:
                  case_y_gateway_bridge_down_is_restarted,
                  case_z_gateway_other_warns_never_respawn,
                  case_aa_gateway_plan_requires_a_token,
-                 case_ab_ag2_remote_token_alias_is_accepted):
+                 case_ab_ag2_remote_token_alias_is_accepted,
+                 case_ac_unknown_name_without_detail_is_untouched):
         fails = case()
         status = "PASS" if not fails else "FAIL"
         print(f"  {status} {case.__name__}")


### PR DESCRIPTION
## The bug

`fix_down_bridges()` dispatched on a hardcoded name tuple:

```python
c["name"] in ("telegram-bridge", "discord-bridge", "slack-bridge")
and c["status"] == "warn"
and c.get("detail") == "configured but not running"
```

`gateway-bridge` — the process carrying ag2.space/mobile messages down to the core — is not in it. It is the one configured channel bridge with **detection but no actor**.

`check_gateway_bridge()`'s own docstring records why the detection exists:

> Added after a 3-day SILENT outage (2026-07-10): the bridge died on Jul 7 and nothing reported it, so mobile messages stranded in the cloud invisibly. This check makes that state visible on the dashboard.

That incident bought visibility. The visibility was never wired to a recovery.

## Evidence — observed on my host today, before writing any of this

The bridge exited at 11:54 and stayed dead 67 minutes:

```
$ tail -1 workspace/logs/remote-gateway-bridge.log
[remote-gateway-bridge] singleton: lost workspace poller lock (reaped after stale takeover) — exiting to avoid dual-poll

$ ps aux | grep -c "[r]emote-gateway-bridge"
0

$ python3 src/health-check.py | grep gateway-bridge
  ⚠ gateway-bridge   warn   configured but NOT running — ag2.space mobile messages will not be delivered
```

health-check was **correct the entire time**. Nothing acted on it. After a manual restart, three real tasks that had been held gateway-side for the whole outage arrived at once:

```
[remote-gateway-bridge] queued task-243727d8ed4b057d10
[remote-gateway-bridge] queued task-bb73a15c6dfec679f2
[remote-gateway-bridge] queued task-09079eccc891a63f7d
```

Worth noting for anyone diagnosing the same thing: `state/gateway-status.json` still read `connected: true` throughout, because it was frozen at 11:54 — its writer *is* the process that died. A stale sidecar and a healthy one differ only in `ts`.

## The fix — two changes that are each a no-op alone

**1. The name set, and the detail it matches.** gateway-bridge's down-detail spells out the delivery impact, so it is not the other bridges' exact string; adding only the name would still never match. `DOWN_BRIDGE_DETAILS` maps each bridge to its own detail, and the producer now reads the same `GATEWAY_DOWN_DETAIL` constant so the two cannot drift.

Matching a **per-bridge exact detail** (rather than a prefix) is load-bearing: gateway-bridge has other `warn` details — `process running but NOT serving`, duplicate-pileup, `last poll did not succeed` — that describe a **live** process. Respawning against those is the dual-poll state the bridge's singleton lock exists to prevent.

**2. The script name.** `src/gateway-bridge.py` does not exist; the file is `remote-gateway-bridge.py`. `_launch_bridge`'s bare `f"{name}.py"` would `Popen` a missing path and report the restart as succeeded. `_BRIDGE_SCRIPT` maps the one bridge whose check name and script name differ.

`_bridge_launch_plan` gains a gateway branch mirroring the slack one: resolve the token from env then `channels/ag2space/.env`, accept the `AG2_REMOTE_TOKEN` alias that `_gateway_configured()` already honors, return `None` when there is none (tokenless host alerts instead of crash-looping), and set `SUTANDO_SUPERVISED=1` so the bridge stamps `launched_via` as `startup.sh` does.

## Tests — each shown to fail against the unfixed code

`tests/health-check-fix-down-bridges.test.py` gains y/z/aa/ab. Existing cases a–x still pass. Controlled mutations, run at this HEAD:

| mutation | result |
|---|---|
| drop `"gateway-bridge"` from `DOWN_BRIDGE_DETAILS` | **y FAILS** — `expected gateway-bridge restarted, got []` |
| restore the bare `f"{name}.py"` spawn | **y FAILS** — `spawn must target remote-gateway-bridge.py: ['python3', '.../src/gateway-bridge.py']` |
| relax the match to name-only (drop the detail equality) | **z FAILS** — three respawns against a live bridge; pre-existing **case b also FAILS** |

```
$ python3 tests/health-check-fix-down-bridges.test.py
  PASS case_y_gateway_bridge_down_is_restarted
  PASS case_z_gateway_other_warns_never_respawn
  PASS case_aa_gateway_plan_requires_a_token
  PASS case_ab_ag2_remote_token_alias_is_accepted
All fix_down_bridges tests passed.

$ python3 tests/ci-covers-every-python-test.test.py   # no new file; already CI-covered
Ran 4 tests in 0.025s -- OK

$ python3 tests/bridge-restart-intercept.test.py
all checks passed — bridge restart intercept

$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Scope

This is the **actor** half only. It does not change detection, and it does not address *why* the lock vanished — on my host the repo sits under a Google-Drive-mirrored `~/Documents`, and the tree carries 19 files with Drive's `name (N).ext` conflict signature including five copies of this bridge's own lock. That is a host-configuration problem, tracked separately; this PR is the part that belongs in the repo, and it helps regardless of the cause, since any death of this bridge is currently unattended.

The `--fix` restart path is `# pragma: no cover` by existing convention (it spawns real subprocesses); the decision logic above it is what the new guards cover.

— @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)