### PR TITLE
fix(sparrow): strip quotes on the env token tier, as the file tiers do

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_human_action.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_launch_diagnostics.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_vault_token_tier.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_env_token_quotes.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tools/test_no_drift.py
           timeout -k 5 120 python3 skills/agent-room-ops/test_room_ops.py
           timeout -k 5 120 python3 skills/make-viral-video/scripts/test_source_tag.py

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -346,16 +346,27 @@ _EVENT_CHANNEL = None
 # aliases for one release (remove next), with a one-line migration nudge, so the
 # bridge keeps connecting under any launcher. New onboards use REMOTE_TASK_*.
 _warned_legacy = set()
+
+
+def _unquote_env(v):
+    """Whitespace and surrounding quotes off a credential value.
+
+    The ONE definition every reader uses, so the env tier cannot disagree with
+    the file tiers about a quoted `.env` line.
+    """
+    return v.strip().strip("'\"") if v else v
+
+
 def _env_compat(new, old):
     v = os.environ.get(new)
     if v:
-        return v
+        return _unquote_env(v)
     v = os.environ.get(old)
     if v and old not in _warned_legacy:
         _warned_legacy.add(old)
         print(f"[remote-gateway-bridge] {old} is deprecated — rename to {new} in your .env",
               file=sys.stderr, flush=True)
-    return v
+    return _unquote_env(v)
 
 # One-token onboarding: REMOTE_TASK_TOKEN alone is enough. The onboarding
 # string may be the combined "https://<gateway>|<secret>" form (the URL travels
@@ -427,7 +438,7 @@ def _channel_env_candidates():
             if not ln or ln.startswith("#") or "=" not in ln:
                 continue
             key, _, val = ln.partition("=")
-            vals[key.strip()] = val.strip().strip('"').strip("'")
+            vals[key.strip()] = _unquote_env(val)
         out.append((path, vals))
     return out
 
@@ -1617,7 +1628,7 @@ def _read_token_file(path: str) -> str:
             line = line[len("export "):].lstrip()
         for key in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN"):
             if line.startswith(key + "="):
-                found[key] = line[len(key) + 1:].strip().strip("'\"")
+                found[key] = _unquote_env(line[len(key) + 1:])
     for key in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN"):
         if found.get(key):
             return found[key]
@@ -1649,7 +1660,7 @@ def _read_token_file_url(path: str) -> str:
             line = line[len("export "):].lstrip()
         for key in ("REMOTE_TASK_URL", "AG2_REMOTE_URL"):
             if line.startswith(key + "="):
-                found[key] = line[len(key) + 1:].strip().strip("'\"")
+                found[key] = _unquote_env(line[len(key) + 1:])
     return found.get("REMOTE_TASK_URL") or found.get("AG2_REMOTE_URL") or ""
 
 

--- a/packages/ag2-sparrow/tests/test_env_token_quotes.py
+++ b/packages/ag2-sparrow/tests/test_env_token_quotes.py
@@ -28,10 +28,8 @@ import tempfile
 import types
 import unittest
 
-# --------------------------------------------------------------------------- #
-# Hermeticity, both boundaries, BEFORE the bridge can be imported (module init
-# resolves the token during exec_module — see lint-hermetic-bridge-tests).
-# --------------------------------------------------------------------------- #
+# Module init resolves the token during exec_module, so both boundaries must be
+# hermetic before the bridge is imported.
 os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-env-token-quotes-")
 
 _FAKE_VI = types.ModuleType("vault_intercept")
@@ -112,9 +110,8 @@ class EnvTierTests(unittest.TestCase):
         self.assertEqual(m.URL, URL)
 
     def test_trailing_quote_only(self):
-        # The shape observed in production 2026-08-20: the leading quote had
-        # already been eaten somewhere upstream, so the URL parsed and the
-        # request reached the gateway — and 401'd on the bearer alone.
+        # Leading quote already eaten upstream: the URL parses, so the request reaches
+        # the gateway and 401s on the bearer alone.
         m = _load(REMOTE_TASK_TOKEN=f"{COMBINED}'")
         self.assertEqual(m.TOKEN, SECRET)
         self.assertEqual(m.URL, URL)

--- a/packages/ag2-sparrow/tests/test_env_token_quotes.py
+++ b/packages/ag2-sparrow/tests/test_env_token_quotes.py
@@ -1,0 +1,173 @@
+"""The env tier must strip quotes, like the three file tiers already do.
+
+A user who writes the credential quoted —
+
+    REMOTE_TASK_TOKEN='https://gw.example/relay|<secret>'
+
+— gets a working bridge when the value is read from the FILE (three readers
+call `.strip().strip("'\\"")`) and a permanently unauthorized one when a launcher
+hands the same value over in the process environment, because `_env_compat` used
+`os.environ.get` raw. The bearer then travels as `<secret>'`, the gateway's
+`Authorization` parse strips whitespace but not quotes, no registry entry
+matches, and every poll answers 401 — which reads as a revoked key rather than a
+parsing bug. Live production diagnosis 2026-08-20 spent a session on it.
+
+Env wins over file (`_RAW = _env_compat(...)` runs first, and only `if not _RAW`
+does the quote-stripping file reader get a turn), so the one tier that did not
+strip was also the tier that decided.
+
+Pins the SHIPPED readers by importing the real bridge module, not a copy.
+
+Run: python3 packages/ag2-sparrow/tests/test_env_token_quotes.py
+"""
+import importlib
+import os
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+
+# --------------------------------------------------------------------------- #
+# Hermeticity, both boundaries, BEFORE the bridge can be imported (module init
+# resolves the token during exec_module — see lint-hermetic-bridge-tests).
+# --------------------------------------------------------------------------- #
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-env-token-quotes-")
+
+_FAKE_VI = types.ModuleType("vault_intercept")
+
+
+def _no_vault(var):
+    raise KeyError(var)             # empty vault: never resolves, never touches Keychain
+
+
+_FAKE_VI.get_vault_key = _no_vault
+sys.modules["vault_intercept"] = _FAKE_VI
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+URL = "https://gw.example/relay"
+SECRET = "s3cr3t-value"
+COMBINED = f"{URL}|{SECRET}"
+TOKEN_VARS = ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL",
+              "AG2_REMOTE_URL", "AG2_DEVICE_ENV", "GATEWAY_INSTANCE",
+              "REMOTE_TASK_TOKEN_FILE")
+
+
+def _load(**env):
+    """Reload the bridge with exactly `env` as its credential environment."""
+    for k in TOKEN_VARS:
+        os.environ.pop(k, None)
+    os.environ.update(env)
+    mod = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+    return importlib.reload(mod)
+
+
+class UnquoteEnvTests(unittest.TestCase):
+    """The shared helper itself."""
+
+    def setUp(self):
+        self.m = _load()
+
+    def test_strips_both_quote_styles_and_whitespace(self):
+        for raw in (f"'{COMBINED}'", f'"{COMBINED}"', f"  {COMBINED}  ",
+                    f"  '{COMBINED}'  "):
+            self.assertEqual(self.m._unquote_env(raw), COMBINED, raw)
+
+    def test_leaves_an_unquoted_value_alone(self):
+        self.assertEqual(self.m._unquote_env(COMBINED), COMBINED)
+
+    def test_preserves_quotes_inside_the_value(self):
+        # Only the surrounding pair is a quoting artifact; a secret that
+        # contains a quote keeps it.
+        self.assertEqual(self.m._unquote_env("ab'cd"), "ab'cd")
+
+    def test_empty_and_none_pass_through(self):
+        self.assertEqual(self.m._unquote_env(""), "")
+        self.assertIsNone(self.m._unquote_env(None))
+
+
+class EnvTierTests(unittest.TestCase):
+    """The regression: a quoted credential in the process environment."""
+
+    def test_quoted_combined_token_yields_a_clean_bearer(self):
+        m = _load(REMOTE_TASK_TOKEN=f"'{COMBINED}'")
+        self.assertEqual(m.TOKEN, SECRET)
+        self.assertEqual(m.URL, URL)
+
+    def test_double_quoted_too(self):
+        m = _load(REMOTE_TASK_TOKEN=f'"{COMBINED}"')
+        self.assertEqual(m.TOKEN, SECRET)
+        self.assertEqual(m.URL, URL)
+
+    def test_unquoted_is_unchanged(self):
+        m = _load(REMOTE_TASK_TOKEN=COMBINED)
+        self.assertEqual(m.TOKEN, SECRET)
+        self.assertEqual(m.URL, URL)
+
+    def test_quoted_legacy_alias_is_cleaned_too(self):
+        # The deprecated name is the one the 2026-08-20 report carried.
+        m = _load(AG2_REMOTE_TOKEN=f"'{COMBINED}'")
+        self.assertEqual(m.TOKEN, SECRET)
+        self.assertEqual(m.URL, URL)
+
+    def test_trailing_quote_only(self):
+        # The shape observed in production 2026-08-20: the leading quote had
+        # already been eaten somewhere upstream, so the URL parsed and the
+        # request reached the gateway — and 401'd on the bearer alone.
+        m = _load(REMOTE_TASK_TOKEN=f"{COMBINED}'")
+        self.assertEqual(m.TOKEN, SECRET)
+        self.assertEqual(m.URL, URL)
+
+    def test_quoted_split_layout_url(self):
+        m = _load(REMOTE_TASK_TOKEN=f"'{SECRET}'", REMOTE_TASK_URL=f"'{URL}'")
+        self.assertEqual(m.TOKEN, SECRET)
+        self.assertEqual(m.URL, URL)
+
+    def test_a_bare_secret_never_gains_a_url(self):
+        # Guard against over-stripping turning an opaque secret into a URL split.
+        m = _load(REMOTE_TASK_TOKEN=f"'{SECRET}'")
+        self.assertEqual(m.TOKEN, SECRET)
+        self.assertEqual(m.URL, "")
+
+
+class TierAgreementTests(unittest.TestCase):
+    """The invariant this change exists to hold: same file, same answer,
+    whichever tier reads it."""
+
+    def _via_file(self, line: str) -> "tuple[str, str]":
+        with tempfile.TemporaryDirectory() as d:
+            env_file = pathlib.Path(d) / ".env"
+            env_file.write_text(line + "\n", encoding="utf-8")
+            m = _load(AG2_DEVICE_ENV=str(env_file))
+            return m.TOKEN, m.URL
+
+    def _via_env(self, value: str) -> "tuple[str, str]":
+        m = _load(REMOTE_TASK_TOKEN=value)
+        return m.TOKEN, m.URL
+
+    def test_quoted_line_reads_the_same_through_both_tiers(self):
+        quoted = f"'{COMBINED}'"
+        self.assertEqual(self._via_file(f"REMOTE_TASK_TOKEN={quoted}"),
+                         self._via_env(quoted))
+
+    def test_and_that_shared_answer_is_the_clean_one(self):
+        self.assertEqual(self._via_file(f"REMOTE_TASK_TOKEN='{COMBINED}'"),
+                         (SECRET, URL))
+
+    def test_unquoted_line_reads_the_same_through_both_tiers(self):
+        self.assertEqual(self._via_file(f"REMOTE_TASK_TOKEN={COMBINED}"),
+                         self._via_env(COMBINED))
+
+
+class BearerShapeTests(unittest.TestCase):
+    """What the gateway actually receives."""
+
+    def test_auth_header_carries_no_quote(self):
+        m = _load(REMOTE_TASK_TOKEN=f"'{COMBINED}'")
+        self.assertEqual(m._AUTH_HEADERS["Authorization"], f"Bearer {SECRET}")
+        self.assertNotIn("'", m._AUTH_HEADERS["Authorization"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changed, and why

`.env` **must** quote the combined onboarding token — an unquoted `|` is a shell pipe when `startup.sh` sources the file:

```
$ printf 'REMOTE_TASK_TOKEN=https://chat.ag2.space/relay|abc123secret\n' > unquoted.env
$ bash -c 'set -a; . ./unquoted.env; set +a; echo "RESULT=[${REMOTE_TASK_TOKEN:-<UNSET>}]"'
./unquoted.env: line 1: abc123secret: command not found
RESULT=[<UNSET>]

$ printf "REMOTE_TASK_TOKEN='https://chat.ag2.space/relay|abc123secret'\n" > quoted.env
$ bash -c 'set -a; . ./quoted.env; set +a; echo "RESULT=[${REMOTE_TASK_TOKEN:-<UNSET>}]"'
RESULT=[https://chat.ag2.space/relay|abc123secret]
```

`docs/remote-gateway-protocol.md:38` says exactly this. Three readers strip those quotes back off — `_token_from_ag2space_env`, `_read_token_file`, `_read_token_file_url`. **`_env_compat` did not**; it returned `os.environ.get()` raw.

So a launcher that hands the value to the process rather than sourcing it (the desktop supervisor's fixed env whitelist is the case that matters) produced a bearer of `<secret>'`. The gateway's `Authorization` parse strips whitespace but not quotes, no registry entry matches, and every poll answers 401 — which reads as a revoked key rather than a parsing bug. A live diagnosis on 2026-08-20 spent a session there before the trailing quote was spotted.

The env tier is also the **deciding** tier:

```python
_RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""
if not _RAW:
    _RAW, _URL_FALLBACK, _TOKEN_FILE_FALLBACK = _token_from_ag2space_env()
```

The one reader that did not strip was the one that won, so the three that do never got a turn.

## Where to look first

- `packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py` — new `_unquote_env` helper; all four readers now route through it, so the tiers cannot drift apart again.
- `packages/ag2-sparrow/tests/test_env_token_quotes.py` — new.

## What user behavior this proves

A user who quotes the credential correctly (as the docs instruct, and as sourcing requires) gets a working bridge under **every** launcher, not only the ones that source the file.

## Feature/documentation consistency

N/A. `docs/remote-gateway-protocol.md:38` already documents the quoted form as correct and its guidance is unchanged — this makes a previously-broken launcher path honour it. No user-visible contract moved.

## Before/after evidence

Test present in both states; only the source fix differs.

**At parent `ce171bf4` (fix reverted):**
```
FAIL: test_auth_header_carries_no_quote (BearerShapeTests)
AssertionError: "Bearer 'https://gw.example/relay|s3cr3t-value'" != 'Bearer s3cr3t-value'
FAIL: test_quoted_combined_token_yields_a_clean_bearer (EnvTierTests)
AssertionError: "'https://gw.example/relay|s3cr3t-value'" != 's3cr3t-value'
FAIL: test_quoted_legacy_alias_is_cleaned_too (EnvTierTests)
AssertionError: "'https://gw.example/relay|s3cr3t-value'" != 's3cr3t-value'
FAIL: test_quoted_line_reads_the_same_through_both_tiers (TierAgreementTests)
AssertionError: Tuples differ: ('s3cr3t-value', 'https://gw.example/relay')
                            != ("'https://gw.example/relay|s3cr3t-value'", '')
Ran 15 tests
FAILED (failures=8, errors=4)
```

That last one is the invariant in one line: the same `.env` read through the file tier gave `(secret, url)` and through the env tier gave `(quoted-everything, no-url)`.

**At HEAD:**
```
Ran 15 tests in 0.033s

OK
```

## Tests run

```
python3 packages/ag2-sparrow/tests/test_env_token_quotes.py     OK (15 tests)
python3 src/remote-gateway-bridge.test.py                       PASS — all checks green
python3 scripts/lint-hermetic-bridge-tests.py                   ok (99 scanned, 0 new violations)

packages/ag2-sparrow/tests/  — all 12 files PASS
tests/health-check-gateway-bridge.test.py                       PASS
tests/room_ops_gateway_vault.test.py                            PASS
tests/task-progress-skill.test.py                               PASS
tests/cron-notify.test.py                                       PASS
```

## Live-path round trip — NOT included

This touches the bridge, so per CONTRIBUTING a real post-restart round trip is expected and I have not run one; the evidence above is unit-level only. Holding for that is reasonable. Note the affected path is only reachable under a non-sourcing launcher, so a round trip on a `startup.sh`-launched host exercises the tier that already worked — the meaningful capture is a desktop-spawned core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)