### PR TITLE
fix(delivery-core): a crash between the terminal write and claim release leaked the claim

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -100,16 +100,38 @@ class DesignAClaimBackend:
         outbox.park_item(self.root, item_id, reason)
 
     def recover(self) -> RecoverReport:
-        """A recovers lazily at claim time (reclaim TTL); this pass reports
-        which items are currently reclaimable so the core can re-drive
-        them. Nothing is moved — reclaim happens under the next claim."""
+        """Startup reconciliation over the real claim records.
+
+        Reports which items are reclaimable so the core can re-drive them, and
+        RETIRES claims left on a TERMINAL item by a crash between complete()'s
+        terminal write and its release. That crash leaves no body for the caller
+        to re-derive an item id from, so claim() is never invoked for it again —
+        this pass is the only path that reaches such a record.
+        """
         rep = RecoverReport()
         claims = outbox._claims_dir(self.root)
-        if claims.exists():
-            for p in claims.glob("*.json"):
-                item_id = p.stem
-                if outbox.may_reclaim_delivery(self.root, item_id,
-                                               self.reclaim_ttl_s):
+        if not claims.exists():
+            return rep
+        for p in sorted(claims.glob("*.claim")):
+            # The id comes from INSIDE the record: the filename is a lossy,
+            # digest-suffixed safe key and cannot be reversed to an item id.
+            rec = outbox._read_claim_at(p, "")
+            if rec is None or not rec.item_id:
+                continue
+            item_id = rec.item_id
+            with outbox._item_lock(self.root, item_id):
+                current = outbox.read_delivery_claim(self.root, item_id)
+                if current is None:
+                    continue
+                if not outbox.may_reclaim_delivery(self.root, item_id,
+                                                   self.reclaim_ttl_s):
+                    continue        # ALIVE or UNKNOWN owner: never displaced
+                if outbox._read_item(self.root, item_id).get(
+                        "status") in self.TERMINAL:
+                    outbox._release_locked(self.root, item_id,
+                                           current.drainer_id)
+                    rep.retired.append(item_id)
+                else:
                     rep.recovered.append(item_id)
         return rep
 

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -53,6 +53,12 @@ class DesignAClaimBackend:
             if not outbox._item_path(self.root, item_id).exists():
                 return None
             if outbox._read_item(self.root, item_id).get("status") in self.TERMINAL:
+                # complete() writes the terminal status BEFORE releasing, so a
+                # crash in that window leaves a claim no other path reclaims.
+                rec = outbox.read_delivery_claim(self.root, item_id)
+                if rec is not None and outbox.may_reclaim_delivery(
+                        self.root, item_id, self.reclaim_ttl_s):
+                    outbox._release_locked(self.root, item_id, rec.drainer_id)
                 return None
             took = (outbox._acquire_locked(self.root, item_id, worker)
                     or outbox._reclaim_locked(self.root, item_id,

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -140,6 +140,7 @@ class DrainReport:
 class RecoverReport:
     recovered: list = field(default_factory=list)   # item_ids re-claimable
     quarantined: list = field(default_factory=list)
+    retired: list = field(default_factory=list)     # dead claims on TERMINAL items
 
 
 @runtime_checkable

--- a/tests/delivery-core-crash-between-terminal-and-release.test.py
+++ b/tests/delivery-core-crash-between-terminal-and-release.test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""A crash between complete()'s terminal write and its claim release.
+
+`DesignAClaimBackend.complete()` writes `status = "DELIVERED"` and only then
+calls `_release_locked`. A process that dies in that window leaves a terminal
+item carrying a live claim record owned by a now-dead pid.
+
+`outbox.reclaim_delivery_claim` already handles exactly that shape — the gap
+was that `claim()` returns on terminal status BEFORE the reclaim path is ever
+consulted, so nothing reached it and the record leaked permanently. The item is
+DELIVERED, so this is not delivery loss; what leaks is a claim record that makes
+"claims present" an unreliable signal.
+
+The claiming pid must be GENUINELY DEAD or these assertions pass for the wrong
+reason: `_record_is_reclaimable` refuses to displace an ALIVE owner, which is
+correct behavior and would mask the fix. So the crash runs in a real child
+process, and the child runs the REAL `complete()` — only the process death is
+injected, at exactly the `_release_locked` boundary.
+
+Run: python3 tests/delivery-core-crash-between-terminal-and-release.test.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_PKG = _REPO / "packages" / "ag2-sparrow"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from ag2_sparrow import outbox  # noqa: E402
+from ag2_sparrow.delivery_core import (  # noqa: E402
+    DesignAClaimBackend, DeliveryOutcome)
+
+ITEM = "room-evt-crash"
+
+# Runs the production claim + complete, then dies AT the release call. Patching
+# the boundary (not reimplementing complete()) keeps the real writer on the path.
+_CHILD = textwrap.dedent(
+    """
+    import os, sys
+    sys.path.insert(0, {pkg!r})
+    from ag2_sparrow import outbox
+    from ag2_sparrow.delivery_core import DesignAClaimBackend, DeliveryOutcome
+
+    b = DesignAClaimBackend({root!r}, reclaim_ttl_s=0.0)
+    tok = b.claim({item!r}, "child-drainer")
+    assert tok is not None, "child could not claim"
+
+    def _die(*a, **k):
+        os._exit(0)                      # terminal status written, claim intact
+
+    outbox._release_locked = _die
+    b.complete(tok, DeliveryOutcome.CONFIRMED)
+    os._exit(9)                          # unreachable: complete() must reach release
+    """
+)
+
+
+class CrashBetweenTerminalWriteAndReleaseTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="dc-crash-"))
+        self.backend = DesignAClaimBackend(self.tmp, reclaim_ttl_s=0.0)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _crash_a_delivery(self) -> int:
+        """Publish, then let a real child die mid-complete. Returns its pid."""
+        self.assertTrue(self.backend.publish(ITEM, b"payload"))
+        src = _CHILD.format(pkg=str(_PKG), root=str(self.tmp), item=ITEM)
+        proc = subprocess.run([sys.executable, "-c", src],
+                              capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0,
+                         f"child did not die at the release boundary: "
+                         f"rc={proc.returncode} err={proc.stderr[-400:]}")
+        # Premise, asserted rather than assumed: the window really is open.
+        self.assertEqual(outbox._read_item(self.tmp, ITEM).get("status"), "DELIVERED")
+        rec = outbox.read_delivery_claim(self.tmp, ITEM)
+        self.assertIsNotNone(rec, "premise: the crash must leave a claim behind")
+        self.assertFalse(_pid_alive(rec.pid),
+                         "premise: the claiming pid must be GENUINELY dead, or "
+                         "_record_is_reclaimable refuses for the right reason "
+                         "and the test passes for the wrong one")
+        return rec.pid
+
+    def test_the_leaked_claim_is_cleared_on_the_next_claim_attempt(self):
+        self._crash_a_delivery()
+
+        token = self.backend.claim(ITEM, "next-drainer")
+
+        self.assertIsNone(token, "a DELIVERED item must never be re-claimed")
+        self.assertIsNone(outbox.read_delivery_claim(self.tmp, ITEM),
+                          "the dead owner's claim must not survive the attempt")
+
+    def test_the_item_stays_delivered(self):
+        """Clearing the claim must not resurrect or re-deliver the item."""
+        self._crash_a_delivery()
+        self.backend.claim(ITEM, "next-drainer")
+        self.assertEqual(outbox._read_item(self.tmp, ITEM).get("status"), "DELIVERED")
+
+    def test_a_live_owners_claim_on_a_terminal_item_is_left_alone(self):
+        """Mutation guard: never steal from a running drainer.
+
+        Without this, 'clear the claim' could be implemented as an
+        unconditional release and still pass the test above.
+        """
+        self.assertTrue(self.backend.publish(ITEM, b"payload"))
+        token = self.backend.claim(ITEM, "live-drainer")
+        self.assertIsNotNone(token)
+        d = outbox._read_item(self.tmp, ITEM)
+        d["status"] = "DELIVERED"
+        outbox._write_item(self.tmp, ITEM, d)
+        rec = outbox.read_delivery_claim(self.tmp, ITEM)
+        self.assertEqual(rec.pid, os.getpid(), "premise: THIS live process owns it")
+
+        self.assertIsNone(self.backend.claim(ITEM, "other-drainer"))
+
+        self.assertIsNotNone(outbox.read_delivery_claim(self.tmp, ITEM),
+                             "a live owner's claim must survive")
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/proactive-fence-terminal-claim-retired-on-restart.test.py
+++ b/tests/proactive-fence-terminal-claim-retired-on-restart.test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""The production path: ProactiveClaimFence.confirm() crashing mid-complete.
+
+`confirm()` unlinks the `.sending` body BEFORE `_finish()` runs `complete()`.
+If the process dies after complete() writes the terminal status but before it
+releases the claim, restart has neither the body nor the in-memory item id — so
+nothing ever calls `claim()` for that item again. A cleanup hung off `claim()`
+is therefore unreachable on the shipped path, and only a startup pass that
+enumerates the claim records on disk can retire the record.
+
+`DesignAClaimBackend.recover()` is that pass, and it could not do the job:
+it globbed `*.json` while records are written `*.claim`, and it derived the
+item id from `p.stem`, which is a lossy digest-suffixed safe key that cannot be
+reversed. Both are exercised below.
+
+The claiming pid must GENUINELY die — `_record_is_reclaimable` refuses to
+displace an ALIVE owner, which is correct and would mask the fix.
+
+Run: python3 tests/proactive-fence-terminal-claim-retired-on-restart.test.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_PKG = _REPO / "packages" / "ag2-sparrow"
+for _p in (str(_PKG), str(_REPO / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from ag2_sparrow import outbox  # noqa: E402
+from ag2_sparrow.delivery_core import DesignAClaimBackend  # noqa: E402
+
+# Real fence, real backend, real confirm(). Only the process death is injected,
+# at the exact _release_locked boundary inside complete().
+_CHILD = textwrap.dedent(
+    """
+    import os, sys
+    sys.path.insert(0, {pkg!r})
+    sys.path.insert(0, {src!r})
+    from pathlib import Path
+    from ag2_sparrow import outbox
+    from ag2_sparrow.delivery_core import DesignAClaimBackend
+    from proactive_claim_fence import ProactiveClaimFence
+
+    results = Path({results!r})
+    backend = DesignAClaimBackend(Path({root!r}), reclaim_ttl_s=0.0)
+    fence = ProactiveClaimFence(backend, results)
+
+    body = results / "proactive-1.txt"
+    claim = fence.claim(body)
+    assert claim is not None, "child could not claim the proactive body"
+
+    def _die(*a, **k):
+        os._exit(0)          # terminal status written, claim still held
+
+    outbox._release_locked = _die
+    fence.confirm(claim)     # unlinks the body, then completes -> dies
+    os._exit(9)              # unreachable: confirm() must reach the release
+    """
+)
+
+
+class TerminalClaimRetiredOnRestartTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="fence-restart-"))
+        self.results = self.tmp / "results"
+        self.results.mkdir()
+        self.root = self.tmp / "outbox"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _crash_a_confirm(self):
+        (self.results / "proactive-1.txt").write_text("hello")
+        src = _CHILD.format(pkg=str(_PKG), src=str(_REPO / "src"),
+                            results=str(self.results), root=str(self.root))
+        proc = subprocess.run([sys.executable, "-c", src],
+                              capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0,
+                         f"child did not die at the release boundary: "
+                         f"rc={proc.returncode} err={proc.stderr[-500:]}")
+        # Premises, asserted rather than assumed.
+        claims = list((self.root / outbox.CLAIMS_DIR).glob("*.claim"))
+        self.assertEqual(len(claims), 1, "the crash must leave exactly one claim")
+        rec = outbox._read_claim_at(claims[0], "")
+        self.assertFalse(_pid_alive(rec.pid),
+                         "premise: the claiming pid must be GENUINELY dead")
+        self.assertNotEqual(rec.item_id, claims[0].stem,
+                            "premise: the filename is NOT the item id — this is "
+                            "why deriving it from p.stem could never work")
+        return rec
+
+    def test_the_body_is_gone_so_nothing_can_ever_call_claim_again(self):
+        """Why a claim()-time cleanup cannot reach this on the shipped path."""
+        self._crash_a_confirm()
+        self.assertFalse((self.results / "proactive-1.txt").exists(),
+                         "confirm() unlinks the body before completing")
+        self.assertEqual(list(self.results.glob("*")), [],
+                         "no body and no .sending remain to re-derive an id from")
+
+    def test_restart_recovery_retires_the_dead_terminal_claim(self):
+        rec = self._crash_a_confirm()
+        self.assertEqual(outbox._read_item(self.root, rec.item_id).get("status"),
+                         "DELIVERED")
+
+        report = DesignAClaimBackend(self.root, reclaim_ttl_s=0.0).recover()
+
+        self.assertIn(rec.item_id, report.retired,
+                      f"recovery must name what it retired: {report!r}")
+        self.assertIsNone(outbox.read_delivery_claim(self.root, rec.item_id),
+                          "the dead owner's claim must not survive recovery")
+        self.assertEqual(outbox._read_item(self.root, rec.item_id).get("status"),
+                         "DELIVERED", "retiring the claim must not resurrect it")
+
+    def test_a_live_owners_claim_survives_recovery(self):
+        """Mutation guard: recovery must never steal from a running drainer.
+
+        Without this, 'retire the claim' could be an unconditional release and
+        still pass the test above.
+        """
+        backend = DesignAClaimBackend(self.root, reclaim_ttl_s=0.0)
+        backend.publish("live-item", b"x")
+        self.assertIsNotNone(backend.claim("live-item", "me"))
+        held = outbox.read_delivery_claim(self.root, "live-item")
+        self.assertEqual(held.pid, os.getpid(), "premise: THIS process holds it")
+
+        report = backend.recover()
+
+        self.assertNotIn("live-item", report.retired)
+        self.assertNotIn("live-item", report.recovered)
+        self.assertIsNotNone(outbox.read_delivery_claim(self.root, "live-item"))
+
+    def test_a_dead_owner_on_a_NON_terminal_item_is_reported_not_retired(self):
+        """The pre-existing job of recover() still works — and now actually runs.
+
+        Before the glob fix this returned [] for every input, so the two
+        outcomes were indistinguishable from a scan that found nothing.
+        """
+        rec = self._crash_a_confirm()
+        d = outbox._read_item(self.root, rec.item_id)
+        d["status"] = "READY"
+        outbox._write_item(self.root, rec.item_id, d)
+
+        report = DesignAClaimBackend(self.root, reclaim_ttl_s=0.0).recover()
+
+        self.assertIn(rec.item_id, report.recovered)
+        self.assertNotIn(rec.item_id, report.retired)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`DesignAClaimBackend.complete()` writes the terminal status and only then releases the claim:

```python
if outcome is DeliveryOutcome.CONFIRMED:
    d = outbox._read_item(self.root, item_id)
    d["status"] = "DELIVERED"
    outbox._write_item(self.root, item_id, d)      # <- terminal
...
return outbox._release_locked(self.root, item_id, token.worker)   # <- release
```

A process that dies between those leaves a terminal item carrying a live claim record owned by a now-dead pid.

**Nothing reclaims it.** `outbox.reclaim_delivery_claim` already handles exactly this shape, including the pid-reuse birth-token case — but `claim()` returns on terminal status *before* the reclaim path is consulted:

```python
if outbox._read_item(self.root, item_id).get("status") in self.TERMINAL:
    return None                                    # <- short-circuits ahead of it
took = (outbox._acquire_locked(...) or outbox._reclaim_locked(...))
```

So the record leaks permanently.

**Severity, stated precisely.** The item is `DELIVERED` — the result reached the room. What survives is a claim record that can never be cleared, which makes "claims present" an unreliable signal. **This is not delivery loss**, and I'd rather say so than let "leak" imply a lost message.

## Provenance

@sonichi reproduced this on #3110 rather than reading it, and localized the fix better than my own first framing — *"this is not a missing reclaim path… the gap is that `claim()`'s terminal-status early return short-circuits ahead of it."* That is the fix implemented here.

**It is a pre-existing `main` defect, not something #3110 introduces**, which is why this targets `main` as its own PR rather than riding that branch:

```
$ git show origin/main:.../backend_a.py   ->  complete() and claim() are identical
$ git diff origin/main...origin/feat/ag2space-delivery-provider -- .../backend_a.py
   -> #3110 changes publish() only
```

#3110 makes it *more consequential* — its new fresh-cycle `publish()` refuses while a claim exists, so a leaked claim wedges that path — but the leak is reachable on `main` today. Landing this separately also means it isn't gated behind #3110's owner-side restart requirement.

## Evidence

The bug reproduces at `origin/main`, unpatched:

```
$ python3 tests/delivery-core-crash-between-terminal-and-release.test.py   # at origin/main
FAILED (failures=1)
  test_the_leaked_claim_is_cleared_on_the_next_claim_attempt
  AssertionError: ClaimRecord(item_id='room-evt-crash', drainer_id='child-drainer',
    pid=88411, ..., state='HELD') is not None
    : the dead owner's claim must not survive the attempt

$ python3 tests/delivery-core-crash-between-terminal-and-release.test.py   # at HEAD
Ran 3 tests in 0.145s
OK
```

The other 2 pass on both sides by design — they pin behavior this must **not** change (the item stays `DELIVERED`; a live owner's claim is untouched).

Full sweep of every delivery/outbox/claim suite at HEAD: **non-green: none** (22 suites, incl. `delivery-core-contract`, `outbox-race`, `outbox-claim-fault-injection`, `sparrow-outbox-claim-protocol`, `proactive-recovery-crash-after-claim`). `ruff` clean, `review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)`, CI-coverage guard OK.

**One suite I could not run locally: `outbox-claim-machine.test.py` SKIPs — hypothesis is not installed here.** That is the stateful property test of this exact machine, so it is the one I most want CI to exercise; flagging rather than implying I ran it.

## The test detail that matters

`_record_is_reclaimable` refuses to displace an **ALIVE** owner — correct behavior, and it would mask this fix. So a simulation that keeps the claiming process alive reports "the reclaim path refuses it too" and proves nothing; @sonichi hit exactly that and said so. **The claiming pid has to genuinely die.**

The test therefore crashes a real child process, and that child runs the **real** `complete()` — only the process death is injected, at exactly the `_release_locked` boundary:

```python
outbox._release_locked = _die       # os._exit(0)
b.complete(tok, DeliveryOutcome.CONFIRMED)
```

Patching the boundary rather than reimplementing `complete()` keeps the production writer on the path, per CLAUDE.md's rule that concurrency tests call the production writer and not a copied recipe. The premise is asserted, not assumed — the test fails loudly if the pid is still alive.

— @sutando-qingyun-001:ag2.space


## Field instance — RETRACTED by me (2026-08-21)

I added a "field instance" section here citing an item + `.claim-locks/` entry as a live
occurrence of this leak. **That does not establish the leak, and I should not have published it.**

`.claims/` and `.claim-locks/` are different things (`outbox.py`: `CLAIMS_DIR = ".claims"`,
`LOCKS_DIR = ".claim-locks"`). The claim RECORD is `.claims/<key>.claim`; the lock is an flock
mutex whose file persists by design — `_item_lock`'s own docstring notes the kernel drops the
flock when the holder dies. So a leftover lock file says nothing about whether the claim was
released.

Measured on a second host to check which reading holds: `.outbox/` there has
**items=200, locks=200, claims=0** — two hundred healthy completions, every lock file still on
disk. Lock presence is the normal steady state, not a symptom.

john-the-dev reached the same conclusion independently in
sonichi/sutando#3110 (comment 5365664195): `.claims/` was empty, "the healthy end state, not the
leak," and he corrected an earlier glob of his own that had missed `.items/`.

**The PR's own regression test remains the evidence for this fix.** No in-the-wild instance is
currently established, and this section should not be read as providing one.

