### PR TITLE
feat(health-check): a doc that tells an agent to read a memory file that isn't there

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2161,6 +2161,65 @@ def _index_growth_note(index: Path, effective_bytes: int) -> str:
         return _TREND_UNAVAILABLE
 
 
+#: Docs naming memory files an agent must read; `tests/` is excluded because its
+#: memory paths are synthetic fixtures that SHOULD NOT resolve.
+MEMORY_CITATION_SOURCES = ("CLAUDE.md", "AGENTS.md")
+MEMORY_CITATION_GLOBS = ("skills/*/SKILL.md",)
+_MEMORY_CITATION_RE = re.compile(r"memory/([A-Za-z0-9_-]+)\.md")
+
+
+def _cited_memory_names(repo: "Path | None" = None) -> dict:
+    """name -> sorted list of the docs citing it."""
+    repo = REPO_DIR if repo is None else repo
+    sources = [repo / rel for rel in MEMORY_CITATION_SOURCES]
+    for pattern in MEMORY_CITATION_GLOBS:
+        sources.extend(sorted(repo.glob(pattern)))
+    cited: dict = {}
+    for path in sources:
+        try:
+            text = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        try:
+            label = str(path.relative_to(repo))
+        except ValueError:
+            label = path.name
+        for name in _MEMORY_CITATION_RE.findall(text):
+            cited.setdefault(name, set()).add(label)
+    return {k: sorted(v) for k, v in cited.items()}
+
+
+def check_memory_citations() -> "dict | None":
+    """Repo docs that tell an agent to read a memory file that does not exist.
+
+    `CLAUDE.md` loads into every session, so a bullet naming
+    `memory/<name>.md` is an instruction, not a footnote. When the file is
+    absent the reference silently no-ops: nothing errors, no test fails, and
+    the agent simply never gets the rule it was told to load.
+
+    Names the corpus it resolved against, because `SUTANDO_MEMORY_DIR` can
+    point this at a different one than the session loads — a verdict about the
+    wrong corpus is worse than no verdict.
+    """
+    if not MEMORY_DIR.is_dir():
+        return None                      # no corpus here: nothing to resolve against
+    cited = _cited_memory_names()
+    if not cited:
+        return None
+    missing = {n: src for n, src in cited.items()
+               if not (MEMORY_DIR / f"{n}.md").exists()}
+    if not missing:
+        return {"name": "memory-citations", "status": "ok",
+                "detail": f"all {len(cited)} memory file(s) cited by repo docs and "
+                          f"skills resolve in {MEMORY_DIR}"}
+    listed = "; ".join(f"{n}.md (cited by {', '.join(src)})"
+                       for n, src in sorted(missing.items()))
+    return {"name": "memory-citations", "status": "warn",
+            "detail": f"{len(missing)} of {len(cited)} memory file(s) named by repo docs "
+                      f"do not exist in {MEMORY_DIR}, so every agent told to read them "
+                      f"silently gets nothing: {listed}"}
+
+
 def check_memory_index_integrity() -> "dict | None":
     """Catch memories that exist on disk but will never load into a session.
 
@@ -8618,6 +8677,10 @@ def run_all_checks() -> list[dict]:
     _mem_index = check_memory_index_integrity()
     if _mem_index:
         checks.append(_mem_index)
+
+    _mem_cites = check_memory_citations()
+    if _mem_cites:
+        checks.append(_mem_cites)
 
     # Carrier-set enforcement — a stale exclude means the vault is silently not
     # backing up paths the config says it carries (#2565).

--- a/tests/health-check-memory-citations.test.py
+++ b/tests/health-check-memory-citations.test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Repo docs that tell an agent to read a memory file that does not exist.
+
+`CLAUDE.md` loads into every session, so a bullet naming `memory/<name>.md` is
+an instruction rather than a footnote. When the file is absent the reference
+silently no-ops — nothing errors, no test fails, and the agent simply never
+gets the rule it was told to load. Found live on `origin/main`:
+`skills/meeting-scheduler/SKILL.md` cites `memory/reference_identity_map.md`,
+which exists in neither corpus on this fleet.
+
+Run: python3 tests/health-check-memory-citations.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+sys.modules["health_check"] = hc
+spec.loader.exec_module(hc)
+
+
+class MemoryCitationsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="hc-cites-"))
+        self._repo, self._mem = hc.REPO_DIR, hc.MEMORY_DIR
+        self.repo = self.tmp / "repo"
+        (self.repo / "skills" / "demo").mkdir(parents=True)
+        (self.repo / "tests").mkdir()
+        self.mem = self.tmp / "memory"
+        self.mem.mkdir()
+        hc.REPO_DIR, hc.MEMORY_DIR = self.repo, self.mem
+
+    def tearDown(self):
+        hc.REPO_DIR, hc.MEMORY_DIR = self._repo, self._mem
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _cite(self, rel: str, name: str):
+        (self.repo / rel).write_text(f"- Profile: `<ws>/memory/{name}.md`\n")
+
+    def _memory(self, name: str):
+        (self.mem / f"{name}.md").write_text("---\nname: x\n---\nbody\n")
+
+    def test_a_citation_that_resolves_is_ok(self):
+        self._cite("CLAUDE.md", "user_profile")
+        self._memory("user_profile")
+        out = hc.check_memory_citations()
+        self.assertEqual(out["status"], "ok")
+
+    def test_a_citation_to_nothing_warns_and_names_both_sides(self):
+        self._cite("CLAUDE.md", "user_profile")
+        self._memory("user_profile")
+        self._cite("skills/demo/SKILL.md", "reference_identity_map")
+
+        out = hc.check_memory_citations()
+
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("reference_identity_map.md", out["detail"],
+                      "the reader needs the file that does not exist")
+        self.assertIn("skills/demo/SKILL.md", out["detail"],
+                      "and the doc that told them to read it")
+
+    def test_test_fixtures_are_not_flagged(self):
+        """`tests/` memory paths are synthetic and SHOULD NOT exist.
+
+        Flagging them would bury the one real finding under a dozen fixtures,
+        which is how a warning stops being read.
+        """
+        self._cite("CLAUDE.md", "user_profile")
+        self._memory("user_profile")
+        (self.repo / "tests" / "sync.test.sh").write_text(
+            "touch memory/feedback_hostA.md memory/test-1.md\n")
+
+        out = hc.check_memory_citations()
+
+        self.assertEqual(out["status"], "ok")
+        self.assertNotIn("feedback_hostA", out["detail"])
+        self.assertNotIn("test-1", out["detail"])
+
+    def test_the_detail_names_the_corpus_it_resolved_against(self):
+        """SUTANDO_MEMORY_DIR can point this at a corpus the session never loads.
+
+        A verdict about the wrong corpus is worse than no verdict, so the path
+        is stated rather than implied.
+        """
+        self._cite("CLAUDE.md", "user_profile")
+        self._memory("user_profile")
+        out = hc.check_memory_citations()
+        self.assertIn(str(self.mem), out["detail"])
+
+    def test_no_corpus_means_no_opinion(self):
+        """A host without a memory dir has nothing to resolve against."""
+        self._cite("CLAUDE.md", "anything")
+        hc.MEMORY_DIR = self.tmp / "absent"
+        self.assertIsNone(hc.check_memory_citations())
+
+    def test_no_citations_means_no_opinion(self):
+        self.assertIsNone(hc.check_memory_citations())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What's wrong

`CLAUDE.md` loads into every session, so a bullet naming `memory/<name>.md` is an **instruction**, not a footnote. When the file is absent the reference silently no-ops — nothing errors, no test fails, and the agent simply never gets the rule it was told to load. There is no signal for this anywhere today.

## Found live on `origin/main`

```
skills/meeting-scheduler/SKILL.md  ->  memory/reference_identity_map.md
```

That file exists in **neither corpus** on this fleet. Verdict from the new probe, run here:

```
memory-citations   warn   1 of 3 memory file(s) named by repo docs do not exist in
                          <corpus>, so every agent told to read them silently gets
                          nothing: reference_identity_map.md
                          (cited by skills/meeting-scheduler/SKILL.md)
```

**A peer fleet hit the same class from the other direction on the same day** — a memory cited by its own loaded instructions that exists in none of its five corpora, so a lesson it had already written could not be read and got re-learned. Two independent fleets, one defect shape, no detector. That is what moved this from a habit to a check.

## Design decisions worth reviewing

**`tests/` is excluded deliberately.** Its memory paths are synthetic fixtures that *should not* exist — `memory/test-1.md`, `memory/feedback_hostA.md`, `memory/note.md`, and nine more. Including them would bury the one real finding under a dozen expected ones, which is how a warning stops being read. There's a test pinning that exclusion.

**The detail names the corpus it resolved against.** `SUTANDO_MEMORY_DIR` can point the probe at a corpus the session never loads — on this host it does exactly that — and a verdict about the wrong corpus is worse than no verdict.

**Absent corpus or no citations returns `None`.** A host without a memory dir has nothing to resolve against; that is not a finding.

## Verification

```
$ python3 tests/health-check-memory-citations.test.py     # at HEAD
Ran 6 tests   OK

$ same suite at origin/main
AttributeError: module 'health_check' has no attribute 'check_memory_citations'
```

`ruff` clean, `review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)`, CI-coverage guard OK.

**Pre-existing failure, not from this change:** `tests/util-paths-memory-dir.test.py` fails 4 tests on this host — identical failures at `origin/main` with and without this diff, same four names. They are env-var tests and this host has `SUTANDO_MEMORY_DIR` set. Flagging so it isn't attributed here; not fixed in this PR.

## Scope

This reports the drift; it does not decide the remedy. Whether `reference_identity_map.md` should be written or the citation removed is a content call for whoever owns the meeting-scheduler skill.

— @sutando-qingyun-001:ag2.space
