### PR TITLE
fix(sparrow): _unquote_env strips one matched pair only, like channel_token._clean

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -349,12 +349,21 @@ _warned_legacy = set()
 
 
 def _unquote_env(v):
-    """Whitespace and surrounding quotes off a credential value.
+    """Whitespace and ONE layer of matching wrapped quotes off a credential
+    value — the dotenv convention, byte-for-byte the core `channel_token._clean`
+    rule, so the two resolvers can never read the same line differently.
 
     The ONE definition every reader uses, so the env tier cannot disagree with
-    the file tiers about a quoted `.env` line.
+    the file tiers about a quoted `.env` line. Matched-pair only: a secret is
+    opaque, so one that genuinely starts or ends with a quote byte (or wears
+    quotes inside a wrapped pair) is preserved verbatim, not eaten.
     """
-    return v.strip().strip("'\"") if v else v
+    if not v:
+        return v
+    v = v.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
+        v = v[1:-1].strip()
+    return v
 
 
 def _env_compat(new, old):

--- a/packages/ag2-sparrow/tests/test_env_token_quotes.py
+++ b/packages/ag2-sparrow/tests/test_env_token_quotes.py
@@ -84,6 +84,33 @@ class UnquoteEnvTests(unittest.TestCase):
         self.assertEqual(self.m._unquote_env(""), "")
         self.assertIsNone(self.m._unquote_env(None))
 
+    def test_matched_pair_only_unmatched_edge_quotes_are_secret_bytes(self):
+        # A secret is opaque: only a MATCHING wrapped pair is a quoting
+        # artifact. An unmatched edge quote is part of the value and must
+        # survive — .strip("'\"") ate it and silently changed the bearer.
+        for raw in (f"{SECRET}'", f"'{SECRET}", f'"{SECRET}\'', f"{SECRET}\"'"):
+            self.assertEqual(self.m._unquote_env(raw), raw, raw)
+
+    def test_one_layer_only_inner_wrap_is_secret_bytes(self):
+        self.assertEqual(self.m._unquote_env(f"''{SECRET}''"), f"'{SECRET}'")
+        self.assertEqual(self.m._unquote_env(f"\"'{SECRET}'\""), f"'{SECRET}'")
+
+    def test_agrees_with_core_channel_token_clean(self):
+        # One dequote rule repo-wide: sparrow's helper and the core policy
+        # (src/channel_token._clean) must read every value identically, or the
+        # same .env line resolves to two different bearers depending on which
+        # resolver got there first.
+        core_src = pathlib.Path(__file__).resolve().parents[3] / "src"
+        sys.path.insert(0, str(core_src))
+        try:
+            from channel_token import _clean
+        finally:
+            sys.path.remove(str(core_src))
+        for raw in (f"'{COMBINED}'", f'"{COMBINED}"', COMBINED, "",
+                    f"{SECRET}'", f"'{SECRET}", f"''{SECRET}''",
+                    f"\"'{SECRET}'\"", f"  '{COMBINED}'  ", "ab'cd"):
+            self.assertEqual(self.m._unquote_env(raw), _clean(raw), raw)
+
 
 class EnvTierTests(unittest.TestCase):
     """The regression: a quoted credential in the process environment."""
@@ -109,11 +136,14 @@ class EnvTierTests(unittest.TestCase):
         self.assertEqual(m.TOKEN, SECRET)
         self.assertEqual(m.URL, URL)
 
-    def test_trailing_quote_only(self):
-        # Leading quote already eaten upstream: the URL parses, so the request reaches
-        # the gateway and 401s on the bearer alone.
+    def test_unmatched_trailing_quote_is_secret_bytes(self):
+        # A half-quoted value (a writer bug) is NOT healed: under the
+        # matched-pair rule an unmatched edge quote is secret bytes, because
+        # eating it would silently corrupt a legal secret that ends in a
+        # quote. The URL half still parses, so the failure stays a loud 401
+        # at the gateway — never a silent secret mutation on our side.
         m = _load(REMOTE_TASK_TOKEN=f"{COMBINED}'")
-        self.assertEqual(m.TOKEN, SECRET)
+        self.assertEqual(m.TOKEN, f"{SECRET}'")
         self.assertEqual(m.URL, URL)
 
     def test_quoted_split_layout_url(self):


### PR DESCRIPTION
## What changed, and why

Follow-up to #3204, implementing the semantics its review suggested (https://github.com/sonichi/sutando/pull/3204#issuecomment — "one matched wrapping pair"). The shipped `_unquote_env` uses `.strip("'\"")`, which removes **any run** of leading/trailing quote bytes, matched or not. Two problems:

1. **It diverges from the repo's settled dequote policy.** `src/channel_token.py::_clean` (the rule every channel bridge resolves tokens through) strips whitespace plus exactly ONE matching wrapped pair. Two policies for the same convention means the same `.env` line can resolve to two different bearers depending on which resolver reads it.
2. **It violates the parse contract beside it.** `_parse_onboarding_token`'s docstring promises the secret is opaque and "returned verbatim". A legal secret that genuinely starts or ends with a quote byte was silently mutated before auth — presenting as exactly the revoked-key-shaped 401 that #3204 exists to kill.

This aligns `_unquote_env` byte-for-byte with `_clean` and adds a parity sweep so they cannot drift apart again.

## Before/after evidence

Divergence probe (`_unquote_env` vs `channel_token._clean`), **at parent `23c3c94d`**:

```
"s3cret'"    _unquote_env='s3cret'   channel_token._clean="s3cret'"
"'s3cret"    _unquote_env='s3cret'   channel_token._clean="'s3cret"
"''x''"      _unquote_env='x'        channel_token._clean="'x'"
"\"'x'\""    _unquote_env='x'        channel_token._clean="'x'"
```

**At HEAD** (same probe):

```
"'s3cret'"   _unquote_env='s3cret'   _clean='s3cret'    agree=True
"s3cret'"    _unquote_env="s3cret'"  _clean="s3cret'"   agree=True
"'s3cret"    _unquote_env="'s3cret"  _clean="'s3cret"   agree=True
"''x''"      _unquote_env="'x'"      _clean="'x'"       agree=True
"\"'x'\""    _unquote_env="'x'"      _clean="'x'"       agree=True
```

## Deliberate behavior change (one input class)

`#3204`'s `test_trailing_quote_only` pinned healing of a half-quoted value (`url|secret'` → trailing quote eaten). This PR reworks that test: the unmatched quote is now **secret bytes** and the gateway 401s loudly. Rationale: healing lopsided input requires eating edge quotes from valid secrets, and the two failure modes are not symmetric — a broken writer fails visibly either way, while a mutated secret fails invisibly and reads as a revoked key. This is also `_clean`'s long-standing behavior for every other channel.

## Where to look

- `packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py` — `_unquote_env` body (matched-pair, one layer, whitespace inside the wrap trimmed, `None`/`""` pass through). All four reader tiers route through it unchanged.
- `packages/ag2-sparrow/tests/test_env_token_quotes.py` — new: unmatched-edge-quote preservation, one-layer-only on doubled/mixed wraps, and `test_agrees_with_core_channel_token_clean` (parity sweep over the full edge set, importing the real `_clean`). Reworked: `test_unmatched_trailing_quote_is_secret_bytes`.

## Tests run

```
python3 packages/ag2-sparrow/tests/test_env_token_quotes.py     OK (18 tests)
packages/ag2-sparrow/tests/ — all files                         PASS
python3 src/remote-gateway-bridge.test.py                       PASS — all checks green
python3 tests/credential-contract-golden.test.py                37/37 passed
python3 tests/gateway-channel-dir.test.py                       OK
python3 scripts/lint-hermetic-bridge-tests.py                   ok (no new violations)
```

## Live path

Touches the bridge's config parse only on quote-edge values; a normally-quoted or unquoted credential resolves byte-identically to #3204's behavior (pinned by the unchanged happy-path tests), so a live round trip on a correctly-onboarded host exercises an unchanged path. Flagging per CONTRIBUTING rather than claiming coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)