### PR TITLE
fix(session-handoff): an interrupted hook must not leak its atomic-write stage

### DIFF
--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -98,6 +98,10 @@ WORKSPACE_DIR="$WORKSPACE"  # historical local name retained for the rest of thi
 STATE_FILE="$WORKSPACE_DIR/session-state.md"
 # Staged beside the destination so the publish is a same-filesystem rename.
 STATE_TMP="$(mktemp "${STATE_FILE}.tmp.XXXXXX" 2>/dev/null)" || STATE_TMP="${STATE_FILE}.tmp.$$"
+# An interrupted hook must not leave its stage behind. Opt-out, not blanket rm:
+# the publish-failure path below keeps the stage on purpose.
+_handoff_keep_stage=0
+trap '[ "$_handoff_keep_stage" = 1 ] || rm -f "$STATE_TMP" 2>/dev/null' EXIT INT TERM
 # Written last inside the capture block; the publish gate tests for it.
 CAPTURE_END_MARKER="<!-- session-handoff: capture complete -->"
 # A prior run killed before its rename leaves a stage behind; it is not state.
@@ -363,6 +367,7 @@ fi
 if ! mv "$STATE_TMP" "$STATE_FILE" 2>/dev/null; then
   # Stage is KEPT: it is the only copy of a capture that did complete, and the
   # destination still holds the last good snapshot.
+  _handoff_keep_stage=1
   echo "session-handoff: publish failed — $STATE_FILE unchanged, capture kept at $STATE_TMP" >&2
   exit 1
 fi

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -101,7 +101,14 @@ STATE_TMP="$(mktemp "${STATE_FILE}.tmp.XXXXXX" 2>/dev/null)" || STATE_TMP="${STA
 # An interrupted hook must not leave its stage behind. Opt-out, not blanket rm:
 # the publish-failure path below keeps the stage on purpose.
 _handoff_keep_stage=0
-trap '[ "$_handoff_keep_stage" = 1 ] || rm -f "$STATE_TMP" 2>/dev/null' EXIT INT TERM
+_handoff_drop_stage() {
+  [ "$_handoff_keep_stage" = 1 ] || rm -f "$STATE_TMP" 2>/dev/null
+}
+# A signal trap REPLACES the default action, so cleaning up and returning would
+# let a cancelled hook run on; restore the default and re-raise to die correctly.
+trap '_handoff_drop_stage' EXIT
+trap '_handoff_drop_stage; trap - INT;  kill -INT  $$' INT
+trap '_handoff_drop_stage; trap - TERM; kill -TERM $$' TERM
 # Written last inside the capture block; the publish gate tests for it.
 CAPTURE_END_MARKER="<!-- session-handoff: capture complete -->"
 # A prior run killed before its rename leaves a stage behind; it is not state.

--- a/tests/session-handoff-stage-cleanup.test.py
+++ b/tests/session-handoff-stage-cleanup.test.py
@@ -18,25 +18,33 @@ BASH = shutil.which("bash") or "/bin/bash"
 
 def _trap_snippet() -> str:
     src = SCRIPT.read_text(encoding="utf-8")
-    m = re.search(r"(_handoff_keep_stage=0\ntrap .*?EXIT INT TERM)", src, re.DOTALL)
+    m = re.search(r"(_handoff_keep_stage=0\n.*?kill -TERM \$\$' TERM)", src, re.DOTALL)
     assert m, "stage-cleanup trap not found in session-handoff.sh"
     return m.group(1)
 
 
 class StageCleanup(unittest.TestCase):
-    def test_an_interrupted_run_leaves_no_stage(self):
+    def test_a_cancelled_run_dies_and_leaves_no_stage(self):
+        """Cleanup is not enough: a trap replaces the default action, so a handler
+        that returns lets the cancelled hook run on through the rest of capture."""
         with tempfile.TemporaryDirectory() as tmp:
+            after = Path(tmp) / "downstream-ran"
             harness = (
                 f'STATE_FILE="{tmp}/session-state.md"\n'
                 'STATE_TMP="$(mktemp "${STATE_FILE}.tmp.XXXXXX")"\n'
                 'echo staged > "$STATE_TMP"\n'
                 + _trap_snippet() + "\n"
                 'kill -TERM $$\n'
+                f'touch "{after}"\n'          # must never run
                 'sleep 5\n'
             )
-            subprocess.run([BASH, "-c", harness], capture_output=True, timeout=30)
-            leaked = list(Path(tmp).glob("session-state.md.tmp.*"))
-            self.assertEqual(leaked, [], f"interrupted run leaked {leaked}")
+            r = subprocess.run([BASH, "-c", harness], capture_output=True, timeout=30)
+            self.assertEqual(r.returncode, -15,
+                             f"cancelled hook must die on SIGTERM, got rc={r.returncode}")
+            self.assertFalse(after.exists(),
+                             "work downstream of the signal ran — the trap swallowed it")
+            self.assertEqual(list(Path(tmp).glob("session-state.md.tmp.*")), [],
+                             "cancelled run leaked its stage")
 
     def test_the_publish_failure_path_keeps_the_stage(self):
         """The stage is the only copy of a completed capture — a blanket rm loses it."""

--- a/tests/session-handoff-stage-cleanup.test.py
+++ b/tests/session-handoff-stage-cleanup.test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""An interrupted handoff must not leak its stage, and a failed publish must keep it.
+
+Source-tied: the trap is extracted and executed, because running the real script
+resolves the live workspace and would overwrite session-state.md.
+"""
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "session-handoff.sh"
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+def _trap_snippet() -> str:
+    src = SCRIPT.read_text(encoding="utf-8")
+    m = re.search(r"(_handoff_keep_stage=0\ntrap .*?EXIT INT TERM)", src, re.DOTALL)
+    assert m, "stage-cleanup trap not found in session-handoff.sh"
+    return m.group(1)
+
+
+class StageCleanup(unittest.TestCase):
+    def test_an_interrupted_run_leaves_no_stage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            harness = (
+                f'STATE_FILE="{tmp}/session-state.md"\n'
+                'STATE_TMP="$(mktemp "${STATE_FILE}.tmp.XXXXXX")"\n'
+                'echo staged > "$STATE_TMP"\n'
+                + _trap_snippet() + "\n"
+                'kill -TERM $$\n'
+                'sleep 5\n'
+            )
+            subprocess.run([BASH, "-c", harness], capture_output=True, timeout=30)
+            leaked = list(Path(tmp).glob("session-state.md.tmp.*"))
+            self.assertEqual(leaked, [], f"interrupted run leaked {leaked}")
+
+    def test_the_publish_failure_path_keeps_the_stage(self):
+        """The stage is the only copy of a completed capture — a blanket rm loses it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            harness = (
+                f'STATE_FILE="{tmp}/session-state.md"\n'
+                'STATE_TMP="$(mktemp "${STATE_FILE}.tmp.XXXXXX")"\n'
+                'echo staged > "$STATE_TMP"\n'
+                + _trap_snippet() + "\n"
+                '_handoff_keep_stage=1\n'      # what the publish-failure branch sets
+                'exit 1\n'
+            )
+            subprocess.run([BASH, "-c", harness], capture_output=True, timeout=30)
+            kept = list(Path(tmp).glob("session-state.md.tmp.*"))
+            self.assertEqual(len(kept), 1,
+                             "a failed publish must keep the only copy of the capture")
+
+    def test_the_publish_failure_branch_still_opts_out(self):
+        src = SCRIPT.read_text(encoding="utf-8")
+        i = src.index("publish failed")
+        window = src[max(0, i - 400):i]
+        self.assertIn("_handoff_keep_stage=1", window,
+                      "the publish-failure branch must opt out of stage cleanup")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=0)


### PR DESCRIPTION
## What

Every interrupted `session-handoff.sh` run leaves its atomic-write stage behind. The script `mktemp`s `session-state.md.tmp.XXXXXX`, publishes with `mv`, and has **no trap** — so a hook cancelled between those two points leaks the file until the `-mmin +60` sweep collects it on some later run.

## Evidence (live workspace, tonight)

`health-check.py` reports it as a standing warning, and the leak is not hypothetical:

```
⚠ workspace-root-tidy   6 loose file(s) at the workspace root ...
   session-state.md.tmp.OOVfMq, session-state.md.tmp.SHx2Lo,
   session-state.md.tmp.kY3l0M, session-state.md.tmp.xrLF9k
```

Timestamps: `01:06:00` ×2 and `02:03:22` ×2. Those are the two `people-analysis` worker dispatches, and each worker's log ends with **two** `SessionEnd hook ... failed: Hook cancelled` lines — a 1:1 match between cancellations and leaked stages. Every hourly worker adds two more, and the 60-minute sweep is what keeps the count from growing without bound. That is why this warning is permanent rather than transient.

## The fix, and the fix I deliberately did not make

An unconditional `trap 'rm -f "$STATE_TMP"' EXIT` is the obvious one-liner and it is **wrong**. The publish-failure branch keeps the stage on purpose:

```
  # Stage is KEPT: it is the only copy of a capture that did complete, and the
  # destination still holds the last good snapshot.
```

A blanket cleanup deletes the only copy of a completed capture exactly when the destination could not be updated. So the trap is opt-out: `_handoff_keep_stage=0` by default, set to `1` in that branch before it exits.

After a successful `mv` the stage no longer exists, so the trap's `rm -f` is a no-op. `SIGKILL` remains uncoverable by any trap — the existing 60-minute sweep stays as the backstop for it.

## Tests

`tests/session-handoff-stage-cleanup.test.py`, 3 cases: an interrupted run leaves no stage; a publish failure keeps exactly one; and the publish-failure branch still opts out (structural, so a future blanket `rm` cannot quietly reappear).

**Mutation-checked against both failure modes** — this is the part that matters, since one mutation is the naive fix:

| mutation | result |
|---|---|
| remove the trap entirely (today's behaviour) | 2 failures |
| replace with a blanket `rm -f` (the tempting fix) | 1 failure — the keep case |
| unchanged | 3/3 pass |

`bash -n` clean; `review-checks.sh` PASS over the full diff.

## Scope

Only the stage leak. `.legacy-notice-printed` — another of the six loose files that probe reports — is already handled by #3205; `.voice-agent.pid` is untouched here.
