### PR TITLE
fix(cron-runner): stamp the emit and drop log lines so a skipped slot is datable

### DIFF
--- a/src/cron-runner.py
+++ b/src/cron-runner.py
@@ -500,8 +500,11 @@ def run(now_epoch: Optional[int] = None) -> list:
                         emit_task(name, entry)
                         emitted.append(name)
                     else:
+                        # The drop is the only record a slot was skipped; undated,
+                        # it cannot be tied to a sleep window or counted per day.
+                        _ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
                         print(
-                            f"cron-runner: dropping stale slot for {name} "
+                            f"{_ts} cron-runner: dropping stale slot for {name} "
                             f"({lateness}s late)",
                             file=sys.stderr,
                         )
@@ -515,4 +518,5 @@ def run(now_epoch: Optional[int] = None) -> list:
 if __name__ == "__main__":
     names = run()
     if names:
-        print("cron-runner emitted: " + ", ".join(names))
+        _ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        print(f"{_ts} cron-runner emitted: " + ", ".join(names))

--- a/tests/cron-runner.test.py
+++ b/tests/cron-runner.test.py
@@ -506,6 +506,42 @@ def test_run_drops_stale_catchup_slot():
         check(not cr.TASKS_DIR.exists(), "stale slot leaves no task file")
 
 
+def test_drop_line_is_timestamped():
+    """A drop is the ONLY record that a slot was skipped, so it must be datable.
+
+    The log carried no timestamps, so drops could be counted but never correlated
+    with a sleep window or attributed to a day — the gap #2754 and #3232 both hit.
+    """
+    import contextlib
+    import io
+    import json
+    import re
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        cr.TASKS_DIR = root / "tasks"
+        cr.CRONS_FILE = root / "crons.json"
+        cr.STATE_FILE = root / "state" / "cron-runner-state.json"
+        fire = _epoch(2026, 7, 2, 6, 0)
+        now = fire + cr.MAX_EMIT_LATENESS_SECONDS + 60
+        cr.CRONS_FILE.write_text(json.dumps([
+            {"name": "briefing", "cron": "0 6 * * *", "prompt": "x", "launchd": True},
+        ]))
+        cr.STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        cr.STATE_FILE.write_text(json.dumps({"briefing": fire - 60}))
+        _mark_core_alive(root, now)
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            cr.run(now_epoch=now)
+        line = stderr.getvalue()
+        check(re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z cron-runner: dropping",
+                       line),
+              f"drop line starts with an ISO-8601 UTC stamp, got: {line[:60]!r}")
+        # The stamp is a PREFIX, not a replacement: the existing substring
+        # assertion above must keep passing.
+        check("dropping stale slot for briefing" in line,
+              "stamping preserves the searchable message")
+
+
 def test_run_executes_shell_command_without_core_or_task_file():
     import contextlib
     import io


### PR DESCRIPTION
## The gap

`cron-runner` logs a dropped slot, and nothing else records that it happened:

```
cron-runner: dropping stale slot for daily-insight (4754s late)
cron-runner emitted: morning-briefing
```

The message names the job and the lateness but carries no time, so **a drop can be counted and never dated.** It cannot be correlated with a sleep window, attributed to a day, or turned into a rate.

That is the gap #2754 states directly — *"cannot distinguish a daily job that never ran from one that leaves no dated output"* — and the one #3232 runs into when reconstructing a weekly job's history. Dating a drop on a live host today meant leaving the log entirely and reading `pmset -g log`.

## The change

Both `print` sites get the ISO-8601 UTC prefix **the file already uses** at `:313` and `:372`, so no helper and no dependency is introduced. Nothing else changes — same stream, same wording, same fields.

## Before / after

Actual output, not a description. The new test is present in both runs; only `src/cron-runner.py` differs.

**At the parent commit** (`git stash push src/cron-runner.py`):

```
test_drop_line_is_timestamped:
  FAIL: drop line starts with an ISO-8601 UTC stamp, got:
        'cron-runner: dropping stale slot for briefing (960s late)\n'
FAILED (1)
```

**At this HEAD:**

```
test_drop_line_is_timestamped:
  ok: drop line starts with an ISO-8601 UTC stamp, got:
      '2026-08-21T15:40:39Z cron-runner: dropping stale slot for br…'
ALL PASSED
```

The stash/restore is the mutation control: the test fails on production code without the fix, so it is pinning the behaviour rather than passing vacuously.

Emit line, same shape:

```
-        print("cron-runner emitted: " + ", ".join(names))
+        _ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        print(f"{_ts} cron-runner emitted: " + ", ".join(names))
```

## Why this cannot break a reader

I searched for consumers before changing the format. Exactly one exists — `tests/cron-runner.test.py:504`, a substring assertion:

```python
check("dropping stale slot for briefing" in stderr.getvalue(), "stale drop is observable")
```

**The stamp is a prefix, not a replacement**, so that assertion is untouched and still passes. The new test asserts the substring *as well as* the stamp, so a future change cannot satisfy the stamp by rewording the message. No production code reads this log; the only other matches for `cron-runner-launchd` are installer references in `tests/plist-template-render.test.py` and `docs/src-map.md`.

## Scope

Single concern: log-line timestamps. It does **not** touch `MAX_EMIT_LATENESS_SECONDS`, the drop-vs-run policy #3232 is about, or the watermark write at `:508` that makes emit and drop indistinguishable in `cron-runner-state.json`. Those are separate questions and I have deliberately left them to their issues.
