### PR TITLE
docs(friction-detector): the divider docstring said the opposite of the code

### DIFF
--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -48,7 +48,8 @@ def check_pending_questions():
     pending-questions.md is free-form: sections start with ## Title and
     may or may not carry **Status:** markers. Per the #1265 / #1404
     convention: a section is open unless it is explicitly resolved.
-    Sections above a `# Resolved` divider are ignored entirely.
+    Only text ABOVE a `# Resolved` divider is scanned; the archive below it
+    is ignored (this calls active_region(), which returns text up to the divider).
     """
     pq = Path(personal_path("pending-questions.md", WORKSPACE))
     if not pq.exists():


### PR DESCRIPTION
## The defect

`check_pending_questions`'s docstring claims:

> Sections above a `# Resolved` divider are ignored entirely.

**Above is what is KEPT.** The docstring states the inverse of the behaviour.

The contradiction sits eight lines apart inside the same function on `main`:

| line | says |
|---|---|
| 51 (docstring) | "Sections **above** a `# Resolved` divider are **ignored** entirely" |
| 59 (comment) | "Discard resolved section (**below** a `# Resolved` / `# Done` divider)" |
| 60 (code) | `content = active_region(content, DIVIDER_OR_DONE_RE)` |

and `active_region()`'s own docstring is *"`text` up to the first real (non-quoted) archive divider"* — i.e. it **returns** the text above.

## Measured, not reasoned

Fixture with one section on each side of the divider:

```
active_region keeps ABOVE : True
active_region drops BELOW : True
old docstring's claim     : False
```

## Why this is worth a PR rather than a nit

Following the docstring puts questions **below** the divider — where `check-pending-questions.py`, the morning briefing, `agent-api`, this detector and the dashboard all stop counting them.

That failure is silent in every cheap way: the bytes land, the path is right, nothing errors, and the file grows. Only calling a reader shows the zero. This repo has hit it before — it is why `proactive-loop`'s step 8 carries a a multi-paragraph warning and an assertion snippet telling the agent to re-read the count after writing.

I hit a cousin of it myself today: I resolved a question by replacing it with a `## RESOLVED …` heading left **above** the divider, and the count stayed at 14 because the reader counts sections, not titles. Moving it below took it to 13. The divider semantics are easy to get backwards, which is exactly why the docstring should not model them backwards.

## Scope

Docs-only — 2 insertions, 1 deletion, no code lines touched. Verified by filtering the diff for non-comment changes (none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)