### PR TITLE
feat(discord): route every hand-rolled Discord POST through DiscordRestClient + injected post-gate

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -57,6 +57,7 @@ One entry per agent-facing module.
 - **`discord_context_policy.py`** — contextNotFrom gate — the single policy deciding whether a serving channel may pull another Discord channel's content into context.
 - **`discord_delivery_provider.py`** — DiscordDeliveryProvider: binds the shared DiscordRestClient into the 3013 delivery-core seam — the first production provider behind it.
 - **`discord_http.py`** — Shared Discord REST helper: urlopen with 429 Retry-After + 5xx backoff.
+- **`discord_post_gate.py`** — Production injection seam for the Discord post-gate.
 - **`discord_proactive_send.py`** — Send-leg of proactive text delivery through the shared DeliveryProvider.
 - **`discord_reader.py`** — Shared Discord message fetch + rendering — the single implementation behind both reader CLIs.
 - **`discord_rest_client.py`** — Outcome-aware Discord REST client — one transport, three request classes.

--- a/docs/sutando-config.schema.json
+++ b/docs/sutando-config.schema.json
@@ -173,6 +173,10 @@
         "progress_stream": {
           "type": "boolean",
           "description": "Emit in-channel '\u23f3 working\u2026 (Ns)' progress placeholders while a task runs."
+        },
+        "discord_post_gate": {
+          "type": "string",
+          "description": "Path to a Python file exporting validate(channel_id, payload) — the Discord post-gate policy src/discord_post_gate.py resolves for every Discord sender. Unset: ungated. A configured path that fails to load refuses all sends (fail-closed). Env override: $SUTANDO_DISCORD_POST_GATE."
         }
       }
     },

--- a/skills/bot2bot-post/post.py
+++ b/skills/bot2bot-post/post.py
@@ -266,12 +266,11 @@ _repo = next(p for p in pathlib.Path(__file__).resolve().parents
 sys.path.insert(0, str(_repo / "src"))
 from body_file import MAX_BODY_BYTES, read_body_file as _read_body_file  # noqa: E402
 from discord_post_gate import make_client  # noqa: E402  — the one Discord POST chokepoint
-from discord_rest_client import DiscordRestClient  # noqa: E402  — for test doubles
 from outbox import DeliveryOutcome  # noqa: E402
 
 
-def _client(token: str) -> DiscordRestClient:
-    """Seam for tests; timeout preserves this script's pre-client 10s cap."""
+def _client(token: str):
+    """Shared-DiscordRestClient seam for tests; keeps the pre-client 10s cap."""
     return make_client(token, timeout=10)
 
 

--- a/skills/bot2bot-post/post.py
+++ b/skills/bot2bot-post/post.py
@@ -48,8 +48,6 @@ import json
 import os
 import pathlib
 import sys
-import urllib.request
-import urllib.error
 from pathlib import Path
 
 # Claude Code per-user home. Mirrors src/util_paths.py `claude_home_path()`
@@ -107,20 +105,9 @@ def resolve_bot2bot_channel(access: dict) -> str:
     sys.exit("ERROR: no bot2bot channel found in access.json.groups")
 
 
-USER_AGENT = "DiscordBot (https://github.com/sonichi/sutando, 1.0)"
-
-
 def get_self_id(token: str) -> str:
-    """Discord GET /users/@me → this bot's user ID."""
-    req = urllib.request.Request(
-        "https://discord.com/api/v10/users/@me",
-        headers={
-            "Authorization": f"Bot {token}",
-            "User-Agent": USER_AGENT,
-        },
-    )
-    with urllib.request.urlopen(req, timeout=10) as r:
-        return json.loads(r.read())["id"]
+    """Discord GET /users/@me → this bot's user ID (via the shared client)."""
+    return str(_client(token).get_json("/users/@me")["id"])
 
 
 def resolve_other_bot(access: dict, self_id: str, channel_id: str):
@@ -230,22 +217,14 @@ def post(channel_id: str, text: str, token: str, overhead: int = 0):
     problem = check_length(text, overhead)
     if problem:
         sys.exit(problem)
-    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
-    body = json.dumps({"content": text}).encode()
-    req = urllib.request.Request(
-        url,
-        data=body,
-        headers={
-            "Authorization": f"Bot {token}",
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
-        },
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=10) as r:
-            return json.loads(r.read())
-    except urllib.error.HTTPError as e:
-        sys.exit(f"ERROR: Discord API {e.code}: {e.read().decode()}")
+    receipt, _status, body = _client(token).send_message_with_response(
+        channel_id, {"content": text})
+    if receipt.outcome is DeliveryOutcome.CONFIRMED and isinstance(body, dict):
+        return body
+    hint = (" The post MAY have landed — check the channel before retrying."
+            if receipt.outcome is DeliveryOutcome.OUTCOME_UNKNOWN
+            else " NOTHING WAS SENT.")
+    sys.exit(f"ERROR: Discord send {receipt.outcome.value}: {receipt.detail}.{hint}")
 
 
 # Peer roster lives in per-host config, NOT hardcoded here: this script is
@@ -286,6 +265,13 @@ _repo = next(p for p in pathlib.Path(__file__).resolve().parents
              if (p / "src" / "body_file.py").is_file())
 sys.path.insert(0, str(_repo / "src"))
 from body_file import MAX_BODY_BYTES, read_body_file as _read_body_file  # noqa: E402
+from discord_rest_client import DiscordRestClient  # noqa: E402  — the one Discord POST chokepoint
+from outbox import DeliveryOutcome  # noqa: E402
+
+
+def _client(token: str) -> DiscordRestClient:
+    """Seam for tests; timeout preserves this script's pre-client 10s cap."""
+    return DiscordRestClient(token, timeout=10)
 
 
 def main():

--- a/skills/bot2bot-post/post.py
+++ b/skills/bot2bot-post/post.py
@@ -265,13 +265,14 @@ _repo = next(p for p in pathlib.Path(__file__).resolve().parents
              if (p / "src" / "body_file.py").is_file())
 sys.path.insert(0, str(_repo / "src"))
 from body_file import MAX_BODY_BYTES, read_body_file as _read_body_file  # noqa: E402
-from discord_rest_client import DiscordRestClient  # noqa: E402  — the one Discord POST chokepoint
+from discord_post_gate import make_client  # noqa: E402  — the one Discord POST chokepoint
+from discord_rest_client import DiscordRestClient  # noqa: E402  — for test doubles
 from outbox import DeliveryOutcome  # noqa: E402
 
 
 def _client(token: str) -> DiscordRestClient:
     """Seam for tests; timeout preserves this script's pre-client 10s cap."""
-    return DiscordRestClient(token, timeout=10)
+    return make_client(token, timeout=10)
 
 
 def main():

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -98,15 +98,15 @@ def _post(url: str, payload: dict, headers: dict) -> bool:
 
 
 def _rest_client(token: str):
-    """The shared Discord chokepoint (src/discord_rest_client.py). Resolved and
+    """The shared Discord chokepoint + injected post-gate. Resolved and
     imported lazily so non-Discord sources never touch the Discord stack."""
     repo = next(p for p in Path(__file__).resolve().parents
                 if (p / "src" / "discord_rest_client.py").is_file())
     src = str(repo / "src")
     if src not in sys.path:
         sys.path.insert(0, src)
-    from discord_rest_client import DiscordRestClient
-    return DiscordRestClient(token, timeout=10)
+    from discord_post_gate import make_client
+    return make_client(token, timeout=10)
 
 
 def _discord_mentions(message: str):

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -26,7 +26,6 @@ import re
 import sys
 import urllib.request
 from pathlib import Path
-from typing import Optional
 
 
 MAX_PROGRESS_CHARS = 280
@@ -98,22 +97,16 @@ def _post(url: str, payload: dict, headers: dict) -> bool:
         return False
 
 
-def _discord_request(url: str, token: str, payload: Optional[dict] = None):
-    """Make a Discord JSON request and return its response body, or None."""
-    try:
-        data = json.dumps(payload).encode() if payload is not None else None
-        headers = {
-            "Authorization": f"Bot {token}",
-            "User-Agent": "DiscordBot (https://github.com/sonichi/sutando, 1.0)",
-        }
-        if data is not None:
-            headers["Content-Type"] = "application/json"
-        req = urllib.request.Request(url, data=data, headers=headers)
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            return json.loads(resp.read())
-    except Exception as e:
-        print(f"[task-progress] Discord request failed: {e}", file=sys.stderr)
-        return None
+def _rest_client(token: str):
+    """The shared Discord chokepoint (src/discord_rest_client.py). Resolved and
+    imported lazily so non-Discord sources never touch the Discord stack."""
+    repo = next(p for p in Path(__file__).resolve().parents
+                if (p / "src" / "discord_rest_client.py").is_file())
+    src = str(repo / "src")
+    if src not in sys.path:
+        sys.path.insert(0, src)
+    from discord_rest_client import DiscordRestClient
+    return DiscordRestClient(token, timeout=10)
 
 
 def _discord_mentions(message: str):
@@ -155,11 +148,16 @@ def send_discord(channel_id: str, message: str, validate_mentions: bool = True) 
         )
         return False
 
+    client = _rest_client(token)
+    from outbox import DeliveryOutcome  # importable once _rest_client set the path
+
     if validate_mentions:
         for user_id in user_ids:
-            resolved = _discord_request(
-                f"https://discord.com/api/v10/users/{user_id}", token
-            )
+            try:
+                resolved = client.get_user(user_id)
+            except Exception as e:
+                print(f"[task-progress] Discord request failed: {e}", file=sys.stderr)
+                resolved = None
             if not isinstance(resolved, dict) or str(resolved.get("id")) != user_id:
                 print(
                     f"[task-progress] Discord mention <@{user_id}> did not resolve; "
@@ -176,12 +174,13 @@ def send_discord(channel_id: str, message: str, validate_mentions: bool = True) 
             "replied_user": False,
         },
     }
-    posted = _discord_request(
-        f"https://discord.com/api/v10/channels/{channel_id}/messages",
-        token,
-        payload,
-    )
-    if not isinstance(posted, dict):
+    receipt, _status, posted = client.send_message_with_response(channel_id, payload)
+    if receipt.outcome is not DeliveryOutcome.CONFIRMED or not isinstance(posted, dict):
+        print(
+            f"[task-progress] Discord send not confirmed "
+            f"({receipt.outcome.value}: {receipt.detail})",
+            file=sys.stderr,
+        )
         return False
 
     if validate_mentions:

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5867,25 +5867,28 @@ def _parse_send_argv(argv):
     return reply_to, argv
 
 
+def _rest_client(timeout: int = 10):
+    """The shared Discord REST chokepoint for the CLI send/edit paths. A test
+    binds a scripted transport through here so the PRODUCTION client stays in
+    the loop; hand-rolled urlopen in this file is the drift this seam removed."""
+    from discord_rest_client import DiscordRestClient
+    return DiscordRestClient(TOKEN, timeout=timeout)
+
+
 def _send_via_rest(channel_id: str, message: str, reply_to: str = ""):
-    """Send a message via Discord REST API (no gateway connection).
+    """Send a message via the shared DiscordRestClient (no gateway connection).
 
     Chunks via `_chunk_for_discord` so messages over Discord's 2000-char
     limit render correctly without allowing one oversized payload to monopolize
     the bridge. Without chunking the API returns 400; without the delivery budget,
     a malformed result can produce hundreds of sequential POSTs.
     """
-    import urllib.request
-    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
-    headers = {
-        "Authorization": f"Bot {TOKEN}",
-        "Content-Type": "application/json",
-        "User-Agent": "DiscordBot (sutando, 1.0)",
-    }
+    from outbox import DeliveryOutcome
     chunks = list(_chunk_for_discord(message))
     if not chunks:
         # Empty message — nothing to send. Treat as no-op rather than error.
         return
+    client = _rest_client()
     for i, chunk in enumerate(chunks, 1):
         payload = {"content": chunk}
         # First chunk only: on every chunk it renders N reply-headers for one
@@ -5893,26 +5896,20 @@ def _send_via_rest(channel_id: str, message: str, reply_to: str = ""):
         if reply_to and i == 1:
             payload["message_reference"] = {"message_id": str(reply_to),
                                             "fail_if_not_exists": False}
-        data = json.dumps(payload).encode()
-        req = urllib.request.Request(url, data=data, headers=headers)
-        # Transport only: once urlopen returns, the message is committed, so
-        # read() belongs below. Not a `with` — doubles are plain objects.
-        try:
-            resp = urllib.request.urlopen(req, timeout=10)
-        except Exception as e:
-            print(f"Send failed (chunk {i}/{len(chunks)}): {e}")
+        receipt, status, _body = client.send_message_with_response(channel_id, payload)
+        committed = status is not None and 200 <= status < 300
+        if receipt.outcome is not DeliveryOutcome.CONFIRMED and not committed:
+            # No 2xx reached us: refused, or genuinely unknown. Exiting nonzero
+            # matches the pre-client behavior for these transport failures.
+            print(f"Send failed (chunk {i}/{len(chunks)}): {receipt.detail}")
             sys.exit(1)
         # Best-effort, and emitted per chunk: buffering until every chunk lands
         # leaves an earlier delivered chunk unaddressable when a later one fails.
-        try:
-            body = json.loads(resp.read().decode())
-            mid = body.get("id") if isinstance(body, dict) else None
-            mid = str(mid) if isinstance(mid, (str, int)) and str(mid) else None
-        except Exception:
-            mid = None
-        if mid:
-            print(f"message_id {mid}")
+        if receipt.receipt_id:
+            print(f"message_id {receipt.receipt_id}")
         else:
+            # 2xx without a readable id: COMMITTED, so this must not report a
+            # failure — that invites the retry that duplicates the message.
             print(f"message_id unavailable (chunk {i}/{len(chunks)}) — sent, not addressable")
     suffix = "..." if len(message) > 80 else ""
     chunk_note = f" ({len(chunks)} chunks)" if len(chunks) > 1 else ""
@@ -5925,7 +5922,6 @@ def _edit_via_rest(channel_id: str, message_id: str, message: str):
     Refuses a body the chunker would split: an edit addresses ONE message, so a
     multi-chunk body cannot be applied without silently dropping the remainder.
     """
-    import urllib.request
     if not message.strip():
         print("ERROR: refusing to edit to an empty body")
         sys.exit(1)
@@ -5934,17 +5930,12 @@ def _edit_via_rest(channel_id: str, message_id: str, message: str):
         print(f"ERROR: body is {len(message)} chars — too long for one message. "
               "An edit cannot chunk; shorten it or send a new message.")
         sys.exit(1)
-    url = f"https://discord.com/api/v10/channels/{channel_id}/messages/{message_id}"
-    data = json.dumps({"content": message}).encode()
-    req = urllib.request.Request(url, data=data, method="PATCH", headers={
-        "Authorization": f"Bot {TOKEN}",
-        "Content-Type": "application/json",
-        "User-Agent": "DiscordBot (sutando, 1.0)",
-    })
-    try:
-        urllib.request.urlopen(req, timeout=10)
-    except Exception as e:
-        print(f"Edit failed: {e}")
+    from outbox import DeliveryOutcome
+    receipt, status, _body = _rest_client().edit_message_with_response(
+        channel_id, message_id, {"content": message})
+    committed = status is not None and 200 <= status < 300
+    if receipt.outcome is not DeliveryOutcome.CONFIRMED and not committed:
+        print(f"Edit failed: {receipt.detail}")
         sys.exit(1)
     suffix = "..." if len(message) > 80 else ""
     print(f"Edited {channel_id}/{message_id}: {message[:80]}{suffix}")

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5194,10 +5194,10 @@ def _proactive_provider():
     client (and its 30s upload timeout pin)."""
     global _PROACTIVE_PROVIDER
     if _PROACTIVE_PROVIDER is None:
-        from discord_rest_client import DiscordRestClient
+        from discord_post_gate import make_client
         from discord_delivery_provider import DiscordDeliveryProvider
         _PROACTIVE_PROVIDER = DiscordDeliveryProvider(
-            DiscordRestClient(TOKEN, timeout=30))
+            make_client(TOKEN, timeout=30))
     return _PROACTIVE_PROVIDER
 
 
@@ -5870,9 +5870,9 @@ def _parse_send_argv(argv):
 def _rest_client(timeout: int = 10):
     """The shared Discord REST chokepoint for the CLI send/edit paths. A test
     binds a scripted transport through here so the PRODUCTION client stays in
-    the loop; hand-rolled urlopen in this file is the drift this seam removed."""
-    from discord_rest_client import DiscordRestClient
-    return DiscordRestClient(TOKEN, timeout=timeout)
+    the loop; make_client resolves the injected post-gate for this process."""
+    from discord_post_gate import make_client
+    return make_client(TOKEN, timeout=timeout)
 
 
 def _send_via_rest(channel_id: str, message: str, reply_to: str = ""):

--- a/src/discord_post_gate.py
+++ b/src/discord_post_gate.py
@@ -1,0 +1,83 @@
+"""Production injection seam for the Discord post-gate.
+
+`DiscordRestClient` accepts an injected `validator`, but each sender is a
+separate process (bridge CLI, dm-result, bot2bot-post, task-progress,
+notify.sh); a wrapper cannot retrofit a constructor argument into them.
+This module is the ONE factory those entrypoints construct through, and it
+resolves the validator from launch wiring the personal layer controls:
+
+  1. `$SUTANDO_DISCORD_POST_GATE` — path to a Python file exporting
+     `validate(channel_id, payload) -> falsy | refusal-reason str`
+     (env override; same pattern as `$SUTANDO_DOWN_BRIDGE_ACTION`).
+  2. `bridges.discord_post_gate` in `sutando.config.json[.local]` —
+     same path, per-clone.
+
+Unconfigured -> None (ungated; the repo ships mechanism only). Configured
+but unloadable -> a validator that REFUSES every send, naming the load
+failure: config selects WHICH ruleset applies, never WHETHER one does, so
+a named-but-broken policy must fail closed, not silently disable the gate.
+The policy itself (e.g. chain-check) lives in the personal layer / skills
+repo — this module never names or imports a concrete skill.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from pathlib import Path
+from discord_rest_client import DiscordRestClient
+
+
+def _configured_path(repo_root=None) -> str:
+    env = os.environ.get("SUTANDO_DISCORD_POST_GATE", "").strip()
+    if env:
+        return env
+    try:
+        from sutando_config import load_config
+        bridges = load_config(repo_root).get("bridges") or {}
+        return str(bridges.get("discord_post_gate") or "").strip()
+    except Exception:
+        # A config layer that cannot load must not decide gating either way;
+        # treat as unconfigured (workspace resolution already warns loudly).
+        return ""
+
+
+def _fail_closed(reason: str):
+    def _refuse(channel_id, payload):
+        return reason
+    return _refuse
+
+
+def resolve_validator(repo_root=None):
+    """The configured validator callable, None (unconfigured), or a
+    fail-closed refuser when a configured policy cannot be loaded."""
+    path = _configured_path(repo_root)
+    if not path:
+        return None
+    file = Path(os.path.expanduser(path))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"sutando_post_gate_{uuid.uuid4().hex}", file)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"not importable: {file}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        validate = getattr(mod, "validate")
+    except Exception as e:  # noqa: BLE001 — a named-but-broken gate fails CLOSED
+        return _fail_closed(
+            f"post-gate policy {path!r} failed to load "
+            f"({type(e).__name__}: {e}); refusing unvalidated sends")
+    if not callable(validate):
+        return _fail_closed(
+            f"post-gate policy {path!r} has a non-callable `validate`; "
+            "refusing unvalidated sends")
+    return validate
+
+
+def make_client(token: str, timeout: int = 10,
+                transport=None, repo_root=None) -> DiscordRestClient:
+    """The production Discord-client factory. Every delivery entrypoint
+    constructs through here so the resolved post-gate covers all of them.
+    A caller needing an explicit validator binds DiscordRestClient directly."""
+    return DiscordRestClient(token, transport=transport, timeout=timeout,
+                             validator=resolve_validator(repo_root))

--- a/src/discord_post_gate.py
+++ b/src/discord_post_gate.py
@@ -32,14 +32,11 @@ def _configured_path(repo_root=None) -> str:
     env = os.environ.get("SUTANDO_DISCORD_POST_GATE", "").strip()
     if env:
         return env
-    try:
-        from sutando_config import load_config
-        bridges = load_config(repo_root).get("bridges") or {}
-        return str(bridges.get("discord_post_gate") or "").strip()
-    except Exception:
-        # A config layer that cannot load must not decide gating either way;
-        # treat as unconfigured (workspace resolution already warns loudly).
-        return ""
+    # May raise: a config layer that cannot load leaves gating state UNKNOWN,
+    # and the caller must fail closed rather than treat it as unconfigured.
+    from sutando_config import load_config
+    bridges = load_config(repo_root).get("bridges") or {}
+    return str(bridges.get("discord_post_gate") or "").strip()
 
 
 def _fail_closed(reason: str):
@@ -51,10 +48,21 @@ def _fail_closed(reason: str):
 def resolve_validator(repo_root=None):
     """The configured validator callable, None (unconfigured), or a
     fail-closed refuser when a configured policy cannot be loaded."""
-    path = _configured_path(repo_root)
+    try:
+        path = _configured_path(repo_root)
+    except Exception as e:  # noqa: BLE001 — unreadable config fails CLOSED
+        return _fail_closed(
+            f"post-gate config unreadable ({type(e).__name__}: {e}); "
+            "refusing unvalidated sends")
     if not path:
         return None
     file = Path(os.path.expanduser(path))
+    if not file.is_absolute():
+        # Anchor to the config's own repo, never the process cwd.
+        from sutando_config import _find_repo_root
+        root = Path(repo_root) if repo_root else _find_repo_root()
+        if root:
+            file = Path(root) / file
     try:
         spec = importlib.util.spec_from_file_location(
             f"sutando_post_gate_{uuid.uuid4().hex}", file)

--- a/src/discord_rest_client.py
+++ b/src/discord_rest_client.py
@@ -17,8 +17,9 @@ why: a private retry is invisible to the core's attempt budget). They return
 the canonical DeliveryReceipt; `edit_message` marks RetrySafety.SAFE because
 the target message id is fixed, so the CALLER's budget may repeat it.
 
-Consumers migrate in follow-up PRs (dm-result first); this PR is the client
-plus its contract tests.
+Every hand-rolled sender now binds this client (census pinned by
+tests/discord-post-census.test.py), which is what makes the injected
+post-gate `validator` structural: covering the client covers every sender.
 """
 from __future__ import annotations
 
@@ -31,7 +32,7 @@ import uuid
 
 from discord_http import request_json
 from outbox_adapter import DeliveryReceipt, classify_response
-from outbox import RetrySafety
+from outbox import DeliveryOutcome, RetrySafety
 
 API = "https://discord.com/api/v10"
 UA = "DiscordBot (https://github.com/sonichi/sutando, 1.0)"
@@ -42,23 +43,57 @@ _DISCORD_ID_KEYS = ("id",)
 
 
 def _default_transport(req, timeout):
-    """One urlopen -> (status, parsed-json-or-text). Raises on transport failure."""
+    """One urlopen -> (status, parsed-json-or-text). Raises on transport failure.
+
+    A read that dies AFTER urlopen returned still yields (status, None): the
+    server committed the write, and reporting "no response" there invites the
+    caller-side retry that duplicates it."""
     with urllib.request.urlopen(req, timeout=timeout) as resp:
-        raw = resp.read().decode("utf-8", "replace")
+        status = resp.status
         try:
-            return resp.status, json.loads(raw) if raw else None
+            raw = resp.read().decode("utf-8", "replace")
+        except Exception:
+            return status, None
+        try:
+            return status, json.loads(raw) if raw else None
         except ValueError:
-            return resp.status, raw
+            return status, raw
 
 
 class DiscordRestClient:
     """`transport` is injectable (callable(req, timeout) -> (status, body)) so
-    the contract tests drive every outcome without a network."""
+    the contract tests drive every outcome without a network.
 
-    def __init__(self, token: str, transport=None, timeout: int = 15):
+    `validator` is the post-gate injection point: callable(channel_id, payload)
+    returning a falsy value to allow or a refusal reason (str) to block. The
+    repo ships the MECHANISM only — the policy (e.g. a chain-check ruleset) is
+    injected by the personal layer, and its config may select WHICH ruleset
+    applies to a channel, never WHETHER one does. A validator that raises
+    fails CLOSED: an unvalidated post is the thing the gate exists to stop."""
+
+    def __init__(self, token: str, transport=None, timeout: int = 15,
+                 validator=None):
         self._token = token
         self._transport = transport or _default_transport
         self._timeout = timeout
+        self._validator = validator
+
+    def _gate_refusal(self, channel_id, payload: dict):
+        """The refusing DeliveryReceipt when the injected validator blocks this
+        (channel_id, payload), else None. No validator -> no refusal."""
+        if self._validator is None:
+            return None
+        try:
+            reason = self._validator(str(channel_id), payload)
+        except Exception as e:  # noqa: BLE001 — a broken gate must not fail open
+            return DeliveryReceipt(
+                DeliveryOutcome.NOT_DELIVERED,
+                detail=f"validator crashed ({type(e).__name__}: {e}) — "
+                       "refusing the unvalidated send")
+        if reason:
+            return DeliveryReceipt(DeliveryOutcome.NOT_DELIVERED,
+                                   detail=f"refused by validator: {reason}")
+        return None
 
     def _headers(self, content_type: str | None = "application/json"):
         h = {"Authorization": f"Bot {self._token}", "User-Agent": UA}
@@ -107,13 +142,30 @@ class DiscordRestClient:
             return None, None
 
     def send_message(self, channel_id, payload: dict) -> DeliveryReceipt:
+        return self.send_message_with_response(channel_id, payload)[0]
+
+    def send_message_with_response(self, channel_id, payload: dict):
+        """-> (receipt, http_status_or_None, parsed_body). For senders that must
+        inspect the created message (mention resolution) or report commitment
+        honestly (a 2xx without an id is committed, not failed). The receipt is
+        the same canonical one `send_message` returns."""
+        refused = self._gate_refusal(channel_id, payload)
+        if refused:
+            return refused, None, None
         req = urllib.request.Request(
             f"{API}/channels/{channel_id}/messages",
             data=json.dumps(payload).encode(), headers=self._headers(), method="POST")
         status, body = self._deliver(req)
-        return classify_response(status, body, id_keys=_DISCORD_ID_KEYS)
+        return classify_response(status, body, id_keys=_DISCORD_ID_KEYS), status, body
 
     def edit_message(self, channel_id, message_id, payload: dict) -> DeliveryReceipt:
+        return self.edit_message_with_response(channel_id, message_id, payload)[0]
+
+    def edit_message_with_response(self, channel_id, message_id, payload: dict):
+        """Edit-shaped `send_message_with_response` (same tuple contract)."""
+        refused = self._gate_refusal(channel_id, payload)
+        if refused:
+            return refused, None, None
         req = urllib.request.Request(
             f"{API}/channels/{channel_id}/messages/{message_id}",
             data=json.dumps(payload).encode(), headers=self._headers(), method="PATCH")
@@ -121,10 +173,13 @@ class DiscordRestClient:
         receipt = classify_response(status, body, id_keys=_DISCORD_ID_KEYS)
         # The target id is fixed: a repeat cannot create a second message, so
         # the caller's budget MAY retry. The attempt itself is still single.
-        return dataclasses.replace(receipt, safety=RetrySafety.SAFE)
+        return dataclasses.replace(receipt, safety=RetrySafety.SAFE), status, body
 
     def upload_files(self, channel_id, payload: dict, files) -> DeliveryReceipt:
         """`files` = [(filename, bytes)]. Multipart per Discord's files[n] form."""
+        refused = self._gate_refusal(channel_id, payload)
+        if refused:
+            return refused
         boundary = uuid.uuid4().hex
         parts = [f"--{boundary}\r\nContent-Disposition: form-data; "
                  f'name="payload_json"\r\nContent-Type: application/json\r\n\r\n'

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -57,14 +57,14 @@ from send_allowlist import (  # noqa: E402
     SEND_ALLOWED_ROOTS as _SEND_ALLOWED_ROOTS,
 )
 from message_chunking import chunk_message, _is_fence_open_line  # noqa: E402  (Result Router S3 — shared fence-aware chunker; was a 4th private copy)
-from discord_rest_client import DiscordRestClient  # noqa: E402  — shared transport (PR 4)
+from discord_post_gate import make_client  # noqa: E402  — shared transport + injected post-gate
 from outbox import DeliveryOutcome  # noqa: E402
 
 
 def _client(token):
     # Seam for test stubs. timeout=30 preserves the retired multipart cap;
     # on a single-attempt send a longer timeout only delays the verdict.
-    return DiscordRestClient(token, timeout=30)
+    return make_client(token, timeout=30)
 
 
 

--- a/src/notify.sh
+++ b/src/notify.sh
@@ -13,31 +13,28 @@ if [ -z "$MSG" ]; then echo "Usage: bash src/notify.sh 'message'"; exit 1; fi
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TS=$(date +%s%3N)
 
-# Load tokens from channel configs
-CLAUDE_CFG_DIR="$(bash "$REPO_DIR/scripts/sutando-config.sh" claude-home-path)"
-DISCORD_TOKEN=$(grep DISCORD_BOT_TOKEN "$CLAUDE_CFG_DIR/channels/discord/.env" 2>/dev/null | cut -d= -f2-)
-DISCORD_USER_ID=$(python3 -c "import json; print(json.load(open('$CLAUDE_CFG_DIR/channels/discord/access.json')).get('allowFrom',[''])[0])" 2>/dev/null)
-
 # 1. Voice — write proactive message if voice agent is up
 if curl -s -o /dev/null -w "%{http_code}" http://localhost:9900 2>/dev/null | grep -q "426"; then
   echo "$MSG" > "$REPO_DIR/results/proactive-$TS.txt"
 fi
 
-# 2. Discord DM
-if [ -n "$DISCORD_TOKEN" ]; then
-  DM_CHANNEL=$(curl -s -X POST "https://discord.com/api/v10/users/@me/channels" \
-    -H "Authorization: Bot $DISCORD_TOKEN" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: DiscordBot (https://github.com/sonichi/sutando, 1.0)" \
-    -d "{\"recipient_id\":\"$DISCORD_USER_ID\"}" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
-  if [ -n "$DM_CHANNEL" ]; then
-    curl -s -X POST "https://discord.com/api/v10/channels/$DM_CHANNEL/messages" \
-      -H "Authorization: Bot $DISCORD_TOKEN" \
-      -H "Content-Type: application/json" \
-      -H "User-Agent: DiscordBot (https://github.com/sonichi/sutando, 1.0)" \
-      -d "{\"content\":\"$MSG\"}" >/dev/null 2>&1
-  fi
-fi
+# 2. Discord DM — via dm-result.py's send_dm, which owns token/owner
+# resolution, chunking, and the send allowlist, and delivers through the
+# shared DiscordRestClient (the one Discord POST chokepoint). Best-effort:
+# a failed DM must not block the remaining channels.
+SUTANDO_REPO_DIR="$REPO_DIR" python3 - "$MSG" <<'PY' || true
+import importlib.util
+import os
+import sys
+
+repo = os.environ["SUTANDO_REPO_DIR"]
+sys.path.insert(0, os.path.join(repo, "src"))
+spec = importlib.util.spec_from_file_location(
+    "dm_result_notify", os.path.join(repo, "src", "dm-result.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+sys.exit(0 if mod.send_dm(sys.argv[1]) else 1)
+PY
 
 # 3. macOS notification
 osascript -e "display notification \"$MSG\" with title \"Sutando\"" 2>/dev/null

--- a/tests/bot2bot-post-client-delegation.test.py
+++ b/tests/bot2bot-post-client-delegation.test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""bot2bot-post delivers through the shared DiscordRestClient — no private HTTP.
+
+The skill used to hand-roll its own urlopen POST, which sat outside the
+post-gate chokepoint (a validator injected on the client could never see it).
+Pinned here: `post()` routes through the PRODUCTION client (scripted transport
+only), a refusal surfaces as a loud SystemExit that names the tri-state
+outcome, an OUTCOME_UNKNOWN warns the post MAY have landed, and the module
+carries no urllib fallback to drift back to.
+
+Run: python3 tests/bot2bot-post-client-delegation.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+_POST = REPO / "skills" / "bot2bot-post" / "post.py"
+_spec = importlib.util.spec_from_file_location("b2b_post_delegation", _POST)
+b2b = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(b2b)
+
+sys.path.insert(0, str(REPO / "src"))
+from discord_rest_client import DiscordRestClient  # noqa: E402
+
+_fails = []
+
+
+def check(name, cond, detail=""):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        _fails.append(name)
+
+
+def bind(*script):
+    """Point b2b._client at the PRODUCTION client with a scripted transport."""
+    calls = []
+    steps = list(script)
+
+    def transport(req, timeout):
+        calls.append({"url": req.full_url, "method": req.get_method(),
+                      "body": json.loads(req.data.decode()) if req.data else None})
+        step = steps.pop(0) if steps else (200, {"id": "777"})
+        if isinstance(step, Exception):
+            raise step
+        return step
+
+    b2b._client = lambda token: DiscordRestClient(token, transport=transport)
+    return calls
+
+
+# --- the real factory builds the shared client with the pre-client 10s cap ---
+_real = b2b._client("tok")
+check("_client() builds the shared DiscordRestClient",
+      isinstance(_real, DiscordRestClient))
+check("_client() preserves the pre-client 10s timeout", _real._timeout == 10)
+
+# --- happy path: POST built by the client, message object returned -----------
+calls = bind((200, {"id": "424242"}))
+result = b2b.post("chan1", "ping: hi", "tok")
+check("post() returns the created message object", result == {"id": "424242"})
+check("exactly one delivery attempt", len(calls) == 1)
+check("the request is a POST to the channel messages endpoint",
+      calls[0]["method"] == "POST" and calls[0]["url"].endswith("/channels/chan1/messages"))
+check("the payload carries the content", calls[0]["body"] == {"content": "ping: hi"})
+
+# --- 4xx refusal: loud SystemExit naming NOT_DELIVERED, nothing retried ------
+calls = bind(urllib.error.HTTPError("u", 403, "forbidden", {}, io.BytesIO(b"{}")))
+msg = ""
+try:
+    b2b.post("chan1", "ping: hi", "tok")
+    check("4xx raises SystemExit", False)
+except SystemExit as e:
+    msg = str(e)
+    check("4xx raises SystemExit", True)
+check("refusal names NOT_DELIVERED + says nothing was sent",
+      "NOT_DELIVERED" in msg and "NOTHING WAS SENT" in msg, msg)
+check("refusal: single attempt (no private retry)", len(calls) == 1)
+
+# --- timeout: OUTCOME_UNKNOWN warns the post MAY have landed -----------------
+calls = bind(TimeoutError("timed out"))
+msg = ""
+try:
+    b2b.post("chan1", "ping: hi", "tok")
+    check("timeout raises SystemExit", False)
+except SystemExit as e:
+    msg = str(e)
+    check("timeout raises SystemExit", True)
+check("unknown outcome warns it MAY have landed (2026-07-29 double-ping guard)",
+      "OUTCOME_UNKNOWN" in msg and "MAY have landed" in msg, msg)
+check("timeout: single attempt", len(calls) == 1)
+
+# --- get_self_id also rides the shared client (no urllib left anywhere) ------
+class _SelfClient:
+    def get_json(self, path):
+        assert path == "/users/@me"
+        return {"id": 314}
+
+
+b2b._client = lambda token: _SelfClient()
+check("get_self_id resolves via client.get_json('/users/@me') as str",
+      b2b.get_self_id("tok") == "314")
+check("module imports no urllib (nothing to drift back to)",
+      not any(name.startswith("urllib") for name in dir(b2b)))
+
+print()
+if _fails:
+    print(f"{len(_fails)} FAILED: " + "; ".join(_fails))
+    sys.exit(1)
+print("all bot2bot-post client-delegation assertions passed")

--- a/tests/bot2bot-post-length-guard.test.py
+++ b/tests/bot2bot-post-length-guard.test.py
@@ -105,7 +105,8 @@ def main() -> int:
 
     # The PRODUCTION DiscordRestClient stays in the loop; only its transport
     # is scripted, so "did not send" is observed at the real chokepoint.
-    post_mod._client = lambda token: post_mod.DiscordRestClient(
+    from discord_rest_client import DiscordRestClient
+    post_mod._client = lambda token: DiscordRestClient(
         token, transport=_recording_transport)
     try:
         raised = ""

--- a/tests/bot2bot-post-length-guard.test.py
+++ b/tests/bot2bot-post-length-guard.test.py
@@ -97,23 +97,16 @@ def main() -> int:
     # absence of an exception — which would also hold if post() returned early
     # for some unrelated reason.
     calls: list[str] = []
-    _orig_urlopen = post_mod.urllib.request.urlopen
+    _orig_client = post_mod._client
 
-    class _Resp:
-        def read(self):
-            return b'{"id":"STUB"}'
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *a):
-            return False
-
-    def _recording_urlopen(req, timeout=None):
+    def _recording_transport(req, timeout):
         calls.append(getattr(req, "full_url", "?"))
-        return _Resp()
+        return 200, {"id": "STUB"}
 
-    post_mod.urllib.request.urlopen = _recording_urlopen
+    # The PRODUCTION DiscordRestClient stays in the loop; only its transport
+    # is scripted, so "did not send" is observed at the real chokepoint.
+    post_mod._client = lambda token: post_mod.DiscordRestClient(
+        token, transport=_recording_transport)
     try:
         raised = ""
         try:
@@ -140,7 +133,7 @@ def main() -> int:
         check("POSITIVE CONTROL — a normal message DOES reach the network",
               len(calls) == 1, f"calls={calls}")
     finally:
-        post_mod.urllib.request.urlopen = _orig_urlopen
+        post_mod._client = _orig_client
 
     print()
     if FAILURES:

--- a/tests/bridge-timeout-guards.test.py
+++ b/tests/bridge-timeout-guards.test.py
@@ -167,10 +167,9 @@ def test_rescue_probe_bounded_and_skips_wedged():
 # ── 2. discord-bridge _send_via_rest: urlopen bounded with timeout=10 ───────
 
 def test_send_via_rest_bounded():
-    code = _compile_segment(
-        DISCORD_SRC,
-        lambda n: isinstance(n, ast.FunctionDef) and n.name == "_send_via_rest",
-    )
+    # The bound lives in _rest_client (DiscordRestClient timeout=10); the
+    # client's _default_transport is what passes it to urlopen.
+    sys.path.insert(0, str(REPO / "src"))
     g = {
         "TOKEN": "test-token",
         "_chunk_for_discord": lambda m: [m],
@@ -178,16 +177,33 @@ def test_send_via_rest_bounded():
         "sys": sys,
         "print": lambda *a, **k: None,
     }
-    exec(code, g)
+    for name in ("_rest_client", "_send_via_rest"):
+        code = _compile_segment(
+            DISCORD_SRC,
+            lambda n, name=name: isinstance(n, ast.FunctionDef) and n.name == name,
+        )
+        exec(code, g)
     send = g["_send_via_rest"]
 
     seen: dict = {}
     real_urlopen = urllib.request.urlopen
 
+    class _OkResp:
+        status = 200
+
+        def read(self):
+            return b'{"id": "1"}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
     def ok_urlopen(req, timeout=None):
         seen["timeout"] = timeout
         seen["url"] = req.full_url
-        return types.SimpleNamespace(read=lambda: b"{}")
+        return _OkResp()
 
     urllib.request.urlopen = ok_urlopen
     try:

--- a/tests/discord-bridge-edit-verb.test.py
+++ b/tests/discord-bridge-edit-verb.test.py
@@ -48,38 +48,37 @@ def check(cond: bool, msg: str) -> None:
         FAILS += 1
 
 
-class _Resp:
-    def __init__(self, payload):
-        self._p = json.dumps(payload).encode()
-
-    def read(self):
-        return self._p
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        return False
+from discord_rest_client import DiscordRestClient  # noqa: E402
 
 
-def _patch_urlopen(calls, payload=None):
-    import urllib.request
+def _bind_transport(calls, script=None, default=(200, {"id": "9999"})):
+    """Bind a scripted transport through the PRODUCTION DiscordRestClient, so
+    these cases exercise the real chokepoint rather than a copied recipe.
+    `script` steps are (status, body) tuples or Exceptions; when exhausted the
+    `default` step repeats."""
+    steps = list(script or [])
 
-    def fake(req, timeout=None):
+    def transport(req, timeout):
         calls.append({"url": req.full_url, "method": req.get_method(),
                       "body": json.loads(req.data.decode()) if req.data else None})
-        return _Resp(payload if payload is not None else {"id": "9999"})
+        step = steps.pop(0) if steps else default
+        if isinstance(step, Exception):
+            raise step
+        return step
 
-    urllib.request.urlopen = fake
+    _mod._rest_client = lambda timeout=10: DiscordRestClient(
+        "test-stub-token", transport=transport)
 
 
 def main() -> int:
-    import urllib.request
-    real = urllib.request.urlopen
+    real = _mod._rest_client
+    check(isinstance(real(), DiscordRestClient),
+          "_rest_client() builds the shared client (default timeout=10)")
+    check(real()._timeout == 10, "_rest_client() keeps the pre-client 10s bound")
     try:
         # 1. edit issues a PATCH at the message-scoped URL
         calls = []
-        _patch_urlopen(calls)
+        _bind_transport(calls)
         _mod._edit_via_rest("111", "222", "corrected body")
         check(len(calls) == 1, f"edit issues exactly one request (got {len(calls)})")
         check(calls and calls[0]["method"] == "PATCH",
@@ -92,7 +91,7 @@ def main() -> int:
         # 2. THE LOAD-BEARING CASE: a body the chunker would split is refused,
         #    and refused BEFORE any network call — not truncated.
         calls = []
-        _patch_urlopen(calls)
+        _bind_transport(calls)
         try:
             _mod._edit_via_rest("111", "222", "x" * 5000)
             refused = False
@@ -103,7 +102,7 @@ def main() -> int:
 
         # 3. empty body refused — an edit to nothing silently blanks a message
         calls = []
-        _patch_urlopen(calls)
+        _bind_transport(calls)
         try:
             _mod._edit_via_rest("111", "222", "   ")
             blanked = True
@@ -113,7 +112,7 @@ def main() -> int:
 
         # 4. send returns the id an edit needs — the gap that made this necessary
         calls = []
-        _patch_urlopen(calls, payload={"id": "4242"})
+        _bind_transport(calls, default=(200, {"id": "4242"}))
         import io
         from contextlib import redirect_stdout
         buf = io.StringIO()
@@ -124,10 +123,8 @@ def main() -> int:
 
         # 4b. The refusals above short-circuit before the request, so the
         #     failing-request path is otherwise never exercised.
-        def fake_raise(req, timeout=None):
-            raise RuntimeError("403 Forbidden")
-
-        urllib.request.urlopen = fake_raise
+        calls = []
+        _bind_transport(calls, default=RuntimeError("403 Forbidden"))
         buf = io.StringIO()
         rc = None
         try:
@@ -142,16 +139,7 @@ def main() -> int:
         # 5. A COMMITTED send whose response body is unreadable is still a send.
         #    Reporting it as a failure invites the retry that duplicates it.
         calls = []
-
-        class _BadBody(_Resp):
-            def read(self):
-                return b"<html>gateway</html>"
-
-        def fake_bad(req, timeout=None):
-            calls.append(req.full_url)
-            return _BadBody({})
-
-        urllib.request.urlopen = fake_bad
+        _bind_transport(calls, default=(200, "<html>gateway</html>"))
         buf = io.StringIO()
         rc = None
         try:
@@ -164,19 +152,10 @@ def main() -> int:
         check("Send failed" not in out, "...and is not reported as a send failure")
         check("unavailable" in out, f"...but the id is reported unavailable (got {out!r})")
 
-        # 5b. urlopen succeeds, then read() raises: the message is committed,
-        #     so reporting a send failure here invites a duplicate retry.
+        # 5b. Body dies mid-read after a 2xx -> (status, None) per
+        #     _default_transport (gate test pins that); still committed here.
         calls = []
-
-        class _RaisingRead:
-            def read(self):
-                raise ConnectionResetError("peer reset mid-body")
-
-        def fake_read_raises(req, timeout=None):
-            calls.append(req.full_url)
-            return _RaisingRead()
-
-        urllib.request.urlopen = fake_read_raises
+        _bind_transport(calls, default=(200, None))
         buf = io.StringIO()
         rc = None
         try:
@@ -192,16 +171,8 @@ def main() -> int:
         # 6. A later-chunk failure must not swallow the EARLIER chunk's id —
         #    that chunk is delivered and would otherwise be unrevisable.
         calls = []
-        state = {"n": 0}
-
-        def fake_second_fails(req, timeout=None):
-            state["n"] += 1
-            calls.append(req.full_url)
-            if state["n"] == 1:
-                return _Resp({"id": "7001"})
-            raise RuntimeError("boom on chunk 2")
-
-        urllib.request.urlopen = fake_second_fails
+        _bind_transport(calls, script=[(200, {"id": "7001"})],
+                        default=RuntimeError("boom on chunk 2"))
         buf = io.StringIO()
         rc = None
         try:
@@ -210,12 +181,12 @@ def main() -> int:
         except SystemExit as e:
             rc = e.code
         out = buf.getvalue()
-        check(state["n"] >= 2, f"the body really did chunk (requests={state['n']})")
+        check(len(calls) >= 2, f"the body really did chunk (requests={len(calls)})")
         check("message_id 7001" in out,
               f"chunk 1's id is printed BEFORE chunk 2 fails (got {out!r})")
         check(rc == 1, f"and the overall send still fails (exit {rc})")
     finally:
-        urllib.request.urlopen = real
+        _mod._rest_client = real
 
     print(f"\n{'PASS' if FAILS == 0 else str(FAILS) + ' FAILURE(S)'}")
     return 1 if FAILS else 0

--- a/tests/discord-post-census.test.py
+++ b/tests/discord-post-census.test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Census: DiscordRestClient is the only production code that POSTs to Discord.
+
+A chokepoint is only as good as its coverage — one hand-rolled sender outside
+it and an injected post-gate validator silently misses that path (the reason
+this gate is structural, not disciplinary). This walks every production tree
+and pins two invariants:
+
+  1. The API literal `discord.com/api` appears ONLY in the allowlisted
+     modules: the shared client (the chokepoint) and the GET-only reader
+     modules. A new sender pasting its own endpoint fails here by
+     construction. (Bare `discord.com` prose — e.g. health-check's
+     "regenerate at discord.com/developers" hint — is not an endpoint.)
+  2. The reader modules stay read-only: no POST/PATCH/DELETE verbs and no
+     request body construction, so an allowlisted file cannot quietly grow
+     into a second send path.
+
+Scope note: gateway-library sends inside discord-bridge.py (`channel.send`
+via discord.py) ride the library's own HTTP stack and are out of census scope;
+this census governs hand-rolled REST, which is where the drift lived.
+
+Run: python3 tests/discord-post-census.test.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Production trees. tests/ and docs are exempt (fixtures may quote endpoints).
+TREES = ("src", "skills", "scripts", "hooks")
+SUFFIXES = {".py", ".ts", ".sh", ".swift", ".js"}
+
+# The chokepoint plus the GET-only readers (each held read-only by
+# invariant 2 below, so an allowlisted file cannot grow into a sender).
+ALLOWED = {
+    "src/discord_rest_client.py",
+    "src/discord_reader.py",
+    "src/discord_context_policy.py",
+    "src/read_discord_channel.py",
+    "hooks/context-source-guard.py",
+}
+READERS = ALLOWED - {"src/discord_rest_client.py"}
+
+_MUTATING = re.compile(r"""method\s*=\s*["'](POST|PATCH|DELETE|PUT)["']""")
+
+_fails = []
+
+
+def check(name, cond, detail=""):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        _fails.append(name)
+
+
+def production_files():
+    for tree in TREES:
+        root = REPO / tree
+        if not root.is_dir():
+            continue
+        for f in sorted(root.rglob("*")):
+            if not f.is_file() or f.suffix not in SUFFIXES:
+                continue
+            rel = f.relative_to(REPO).as_posix()
+            if ".bak" in rel or "node_modules" in rel:
+                continue
+            yield rel, f
+
+
+# --- invariant 1: the endpoint literal only lives in the allowlist -----------
+offenders = []
+population = 0
+for rel, f in production_files():
+    population += 1
+    try:
+        text = f.read_text(errors="replace")
+    except OSError:
+        continue
+    if "discord.com/api" in text and rel not in ALLOWED:
+        offenders.append(rel)
+
+check(f"no discord.com/api literal outside the chokepoint+readers "
+      f"(scanned {population} production files)", offenders == [], ", ".join(offenders))
+check("the scan population is real (a broken walk would pass vacuously)",
+      population > 100, str(population))
+
+# --- invariant 2: allowlisted readers stay read-only -------------------------
+for rel in sorted(READERS):
+    text = (REPO / rel).read_text(errors="replace")
+    verbs = _MUTATING.findall(text)
+    check(f"{rel} carries no mutating verb", verbs == [], ", ".join(verbs))
+
+# Positive control: the pattern DOES fire on the client itself, so an empty
+# reader result above means "clean", not "pattern never matches anything".
+client_text = (REPO / "src" / "discord_rest_client.py").read_text()
+check("positive control: the mutating-verb pattern fires on the client",
+      bool(_MUTATING.search(client_text)))
+check("positive control: the literal scan fires on the client",
+      "discord.com/api" in client_text)
+
+print()
+if _fails:
+    print(f"{len(_fails)} FAILED: " + "; ".join(_fails))
+    sys.exit(1)
+print("census holds: every hand-rolled Discord POST path routes through DiscordRestClient")

--- a/tests/discord-post-gate-wiring.test.py
+++ b/tests/discord-post-gate-wiring.test.py
@@ -200,6 +200,31 @@ check("policy saw every channel id",
 check("policy saw dict payloads with content",
       all(isinstance(s["payload"], dict) and "content" in s["payload"] for s in seen))
 
+# CR 2026-08-21 regressions: unreadable config fails CLOSED; relative
+# config paths anchor to the repo root, not the process cwd.
+import sutando_config as _sc
+_orig_load = _sc.load_config
+def _boom(repo_root=None):
+    raise ValueError("malformed sutando.config.json")
+_sc.load_config = _boom
+os.environ.pop("SUTANDO_DISCORD_POST_GATE", None)
+_v = dpg.resolve_validator()
+check("unreadable config yields a refuser, not None", _v is not None)
+check("refuser names the closed gate",
+      _v is not None and "refusing unvalidated sends" in str(_v("1", {"content": "x"})))
+_root = Path(tempfile.mkdtemp(prefix="post-gate-root-"))
+(_root / "policy").mkdir()
+(_root / "policy" / "gate_ok.py").write_text("def validate(channel_id, payload):\n    return None\n")
+_sc.load_config = lambda repo_root=None: {"bridges": {"discord_post_gate": "policy/gate_ok.py"}}
+_prev_cwd = os.getcwd(); os.chdir("/")
+try:
+    _v2 = dpg.resolve_validator(repo_root=_root)
+finally:
+    os.chdir(_prev_cwd)
+check("relative config path anchors to repo_root (cwd wrong on purpose)",
+      callable(_v2) and _v2("1", {"content": "x"}) is None)
+_sc.load_config = _orig_load
+
 print()
 if FAILS:
     print(f"{len(FAILS)} FAILURE(S)")

--- a/tests/discord-post-gate-wiring.test.py
+++ b/tests/discord-post-gate-wiring.test.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""A refusing post-gate policy, installed through the REAL launch wiring,
+blocks every migrated production sender with zero transport attempts.
+
+The gate contract test proves a manually built client can refuse; this one
+proves the PRODUCTION entrypoints consult the policy at all. The policy is a
+real file on disk, named by $SUTANDO_DISCORD_POST_GATE (the launch wiring a
+personal layer sets for these separate processes; `bridges.discord_post_gate`
+in sutando.config.json[.local] is the per-clone equivalent), and every path
+below constructs through discord_post_gate.make_client:
+
+  bridge CLI send        discord-bridge.py:_send_via_rest -> _rest_client
+  bridge proactive leg   discord-bridge.py:_proactive_provider
+  dm-result / notify.sh  dm-result.py:_client
+  bot2bot-post           post.py:post -> _client
+  task-progress          notify.py:send_discord -> _rest_client
+
+urlopen is patched with a recorder that WOULD succeed, so a gate that fails
+to refuse shows up as a recorded attempt, not as an unrelated error.
+
+Run: python3 tests/discord-post-gate-wiring.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import types
+import urllib.request
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+os.environ["SUTANDO_TEST_MODE"] = "1"
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-post-gate-")
+_cfg = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord"
+_cfg.mkdir(parents=True, exist_ok=True)
+(_cfg / ".env").write_text("DISCORD_BOT_TOKEN=test-stub-token\n", encoding="utf-8")
+(_cfg / "access.json").write_text('{"allowFrom": []}', encoding="utf-8")
+
+FAILS = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok   " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+import discord_post_gate as dpg  # noqa: E402
+from outbox import DeliveryOutcome  # noqa: E402
+
+_policy_dir = Path(tempfile.mkdtemp(prefix="post-gate-policy-"))
+_seen_file = _policy_dir / "seen.jsonl"
+_policy = _policy_dir / "refuse_all.py"
+_policy.write_text(
+    "import json, pathlib\n"
+    f"_SEEN = pathlib.Path({str(_seen_file)!r})\n"
+    "def validate(channel_id, payload):\n"
+    "    with _SEEN.open('a') as f:\n"
+    "        f.write(json.dumps({'channel_id': channel_id, 'payload': payload}) + '\\n')\n"
+    "    return 'refused by wiring-test policy'\n"
+)
+
+# --- resolver semantics ------------------------------------------------------
+os.environ.pop("SUTANDO_DISCORD_POST_GATE", None)
+with tempfile.TemporaryDirectory() as td:
+    check("unconfigured -> validator is None (repo default, ungated)",
+          dpg.resolve_validator(repo_root=Path(td)) is None)
+    client = dpg.make_client("tok", repo_root=Path(td))
+    check("unconfigured make_client -> ungated client", client._validator is None)
+
+os.environ["SUTANDO_DISCORD_POST_GATE"] = str(_policy_dir / "does-not-exist.py")
+v = dpg.resolve_validator()
+check("configured-but-missing policy -> fail-closed refuser",
+      callable(v) and "failed to load" in (v("c", {}) or ""))
+
+_bad = _policy_dir / "not_callable.py"
+_bad.write_text("validate = 42\n")
+os.environ["SUTANDO_DISCORD_POST_GATE"] = str(_bad)
+v = dpg.resolve_validator()
+check("non-callable validate -> fail-closed refuser",
+      callable(v) and "non-callable" in (v("c", {}) or ""))
+
+# --- install the refusing policy through the real wiring ---------------------
+os.environ["SUTANDO_DISCORD_POST_GATE"] = str(_policy)
+
+attempts = []
+
+
+class _OkResp:
+    status = 200
+
+    def read(self):
+        return b'{"id": "should-never-be-sent"}'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _recording_urlopen(req, timeout=None):
+    attempts.append(getattr(req, "full_url", "?"))
+    return _OkResp()
+
+
+_real_urlopen = urllib.request.urlopen
+urllib.request.urlopen = _recording_urlopen
+try:
+    # 1. dm-result (the same factory notify.sh's delegation rides)
+    _spec = importlib.util.spec_from_file_location("dm_result_gate", REPO / "src" / "dm-result.py")
+    dmr = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(dmr)
+    r = dmr._client("tok").send_message("chan-dm", {"content": "x"})
+    check("dm-result/notify.sh: refused", r.outcome is DeliveryOutcome.NOT_DELIVERED, r.detail)
+    check("dm-result/notify.sh: refusal names the policy",
+          "wiring-test policy" in r.detail, r.detail)
+
+    # 2. bot2bot-post, full post() path
+    _spec = importlib.util.spec_from_file_location("b2b_gate", REPO / "skills" / "bot2bot-post" / "post.py")
+    b2b = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(b2b)
+    msg = ""
+    try:
+        b2b.post("chan-b2b", "ping: hi", "tok")
+        check("bot2bot: refused post exits", False)
+    except SystemExit as e:
+        msg = str(e)
+        check("bot2bot: refused post exits", True)
+    check("bot2bot: exit names NOT_DELIVERED + the policy",
+          "NOT_DELIVERED" in msg and "wiring-test policy" in msg, msg)
+
+    # 3. task-progress send_discord, full path
+    _spec = importlib.util.spec_from_file_location(
+        "notify_gate", REPO / "skills" / "task-progress" / "scripts" / "notify.py")
+    ntf = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(ntf)
+    ntf._token = lambda source, var: "test-stub-token"
+    err = io.StringIO()
+    with redirect_stderr(err):
+        ok = ntf.send_discord("chan-tp", "hello")
+    check("task-progress: send_discord returns False", ok is False)
+    check("task-progress: stderr names the refusal",
+          "wiring-test policy" in err.getvalue(), err.getvalue())
+
+    # 4 + 5. discord-bridge: CLI send and the proactive provider
+    try:
+        import discord  # noqa: F401
+    except ImportError:
+        stub = types.ModuleType("discord")
+        stub.Intents = type("Intents", (), {"default": staticmethod(
+            lambda: type("I", (), {"message_content": False})())})
+        stub.Client = type("Client", (), {"__init__": lambda self, **kw: None,
+                                          "event": staticmethod(lambda fn: fn)})
+        stub.File = type("File", (), {})
+        stub.Message = type("Message", (), {})
+        sys.modules["discord"] = stub
+    _spec = importlib.util.spec_from_file_location("dbridge_gate", REPO / "src" / "discord-bridge.py")
+    bridge = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(bridge)
+
+    out = io.StringIO()
+    rc = None
+    try:
+        with redirect_stdout(out):
+            bridge._send_via_rest("chan-cli", "hello")
+    except SystemExit as e:
+        rc = e.code
+    check("bridge CLI send: refused -> exit 1", rc == 1, out.getvalue())
+    check("bridge CLI send: failure names the policy",
+          "wiring-test policy" in out.getvalue(), out.getvalue())
+
+    bridge._PROACTIVE_PROVIDER = None
+    provider = bridge._proactive_provider()
+    receipt = provider.deliver(
+        "item-1", json.dumps({"channel_id": "chan-pro", "content": "x"}).encode(),
+        "idem-1")
+    check("proactive provider: refused", "NOT_DELIVERED" in str(receipt.outcome),
+          str(receipt.outcome))
+
+    check("ZERO transport attempts across all five paths", attempts == [],
+          str(attempts))
+finally:
+    urllib.request.urlopen = _real_urlopen
+    os.environ.pop("SUTANDO_DISCORD_POST_GATE", None)
+
+# --- the policy really saw (channel_id, payload) from every path -------------
+seen = [json.loads(line) for line in _seen_file.read_text().splitlines()]
+seen_channels = {s["channel_id"] for s in seen}
+check("policy saw every channel id",
+      {"chan-dm", "chan-b2b", "chan-tp", "chan-cli", "chan-pro"} <= seen_channels,
+      str(seen_channels))
+check("policy saw dict payloads with content",
+      all(isinstance(s["payload"], dict) and "content" in s["payload"] for s in seen))
+
+print()
+if FAILS:
+    print(f"{len(FAILS)} FAILURE(S)")
+    sys.exit(1)
+print("post-gate wiring holds: one refusing policy, installed via launch wiring, "
+      "blocks all five production sender paths with zero transport attempts")

--- a/tests/discord-rest-client-gate.test.py
+++ b/tests/discord-rest-client-gate.test.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""DiscordRestClient post-gate contract: the injected validator is structural.
+
+The client is the ONE thing that POSTs messages to Discord, so a validator
+injected here covers every sender by construction. Pinned:
+  * no validator (the repo default) -> no gating, sends proceed;
+  * validator sees (channel_id, payload) and a falsy return allows;
+  * a refusal reason blocks EVERY delivery method (send / send_with_response /
+    edit / edit_with_response / upload_files) with a NOT_DELIVERED receipt and
+    ZERO transport attempts;
+  * a validator that CRASHES fails CLOSED (refuses), never open;
+  * reads and create_dm_channel are not part of the gated delivery class;
+  * send_message/edit_message stay the first element of their _with_response
+    twins (one code path, so the gate cannot be bypassed by method choice);
+  * _default_transport maps a body that dies mid-read AFTER a 2xx to
+    (status, None) — committed, not "no response" (the duplicate-send trap).
+
+Run: python3 tests/discord-rest-client-gate.test.py
+"""
+import io
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+import discord_rest_client as drc  # noqa: E402
+from outbox import DeliveryOutcome, RetrySafety  # noqa: E402
+
+FAILS = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"  ok: {name}")
+    else:
+        FAILS.append(name)
+        print(f"  FAIL: {name} {detail}", file=sys.stderr)
+
+
+class Transport:
+    def __init__(self, *script):
+        self.script = list(script)
+        self.calls = []
+
+    def __call__(self, req, timeout):
+        self.calls.append(req)
+        step = self.script.pop(0) if self.script else (200, {"id": "1"})
+        if isinstance(step, Exception):
+            raise step
+        return step
+
+
+def main() -> int:
+    # 1. Default: no validator -> delivery proceeds untouched.
+    t = Transport((200, {"id": "10"}))
+    r = drc.DiscordRestClient("tok", transport=t).send_message("c1", {"content": "x"})
+    check("no validator -> send proceeds", r.outcome is DeliveryOutcome.CONFIRMED)
+
+    # 2. Allowing validator: called with (channel_id, payload), send proceeds.
+    seen = []
+    t = Transport((200, {"id": "11"}))
+    client = drc.DiscordRestClient(
+        "tok", transport=t,
+        validator=lambda cid, payload: seen.append((cid, payload)) and None)
+    r = client.send_message("chan-9", {"content": "hello"})
+    check("allowing validator -> CONFIRMED", r.outcome is DeliveryOutcome.CONFIRMED)
+    check("validator saw the channel id", seen and seen[0][0] == "chan-9")
+    check("validator saw the payload", seen and seen[0][1] == {"content": "hello"})
+
+    # 3. Refusal blocks every delivery method with zero attempts.
+    def refuse(cid, payload):
+        return "ruleset says no"
+
+    t = Transport()
+    client = drc.DiscordRestClient("tok", transport=t, validator=refuse)
+    receipts = {
+        "send_message": client.send_message("c", {"content": "x"}),
+        "send_message_with_response": client.send_message_with_response(
+            "c", {"content": "x"})[0],
+        "edit_message": client.edit_message("c", "m", {"content": "x"}),
+        "edit_message_with_response": client.edit_message_with_response(
+            "c", "m", {"content": "x"})[0],
+        "upload_files": client.upload_files("c", {"content": ""}, [("f.txt", b"x")]),
+    }
+    for name, receipt in receipts.items():
+        check(f"refusal: {name} -> NOT_DELIVERED",
+              receipt.outcome is DeliveryOutcome.NOT_DELIVERED)
+        check(f"refusal: {name} names the reason",
+              "ruleset says no" in receipt.detail, receipt.detail)
+    check("refusal: ZERO transport attempts across all five", len(t.calls) == 0,
+          f"{len(t.calls)} attempts")
+
+    # 4. A crashing validator fails CLOSED, with zero attempts.
+    def crash(cid, payload):
+        raise RuntimeError("policy module exploded")
+
+    t = Transport()
+    client = drc.DiscordRestClient("tok", transport=t, validator=crash)
+    r = client.send_message("c", {"content": "x"})
+    check("crashing validator -> refused (fail closed)",
+          r.outcome is DeliveryOutcome.NOT_DELIVERED)
+    check("crashing validator: the crash is named", "policy module exploded" in r.detail)
+    check("crashing validator: zero attempts", len(t.calls) == 0)
+
+    # 5. Scope pin: reads and the open-DM control call are NOT the gated
+    #    delivery class (a validator must not break owner-DM resolution).
+    calls = []
+
+    def gate_recorder(cid, payload):
+        calls.append(cid)
+        return None
+
+    client = drc.DiscordRestClient("tok", validator=gate_recorder)
+    orig = drc.request_json
+    drc.request_json = lambda req, timeout=None: {"id": "dm-1"}
+    try:
+        cid = client.create_dm_channel("42")
+        got = client.get_channel("7")
+    finally:
+        drc.request_json = orig
+    check("create_dm_channel still works under a validator", cid == "dm-1")
+    check("get_channel still works under a validator", got == {"id": "dm-1"})
+    check("validator was NOT consulted for reads/control", calls == [])
+
+    # 6. Delegation: the plain methods ARE their _with_response twins' receipt.
+    t = Transport((200, {"id": "77"}), (200, {"id": "77"}))
+    client = drc.DiscordRestClient("tok", transport=t)
+    r1 = client.send_message("c", {"content": "x"})
+    r2, status, body = client.send_message_with_response("c", {"content": "x"})
+    check("send twins agree on receipt", r1 == r2)
+    check("with_response surfaces the status", status == 200)
+    check("with_response surfaces the body", body == {"id": "77"})
+
+    t = Transport(urllib.error.HTTPError("u", 403, "f", {}, io.BytesIO(b"{}")))
+    r, status, _ = drc.DiscordRestClient(
+        "tok", transport=t).send_message_with_response("c", {})
+    check("with_response: 403 -> NOT_DELIVERED with status",
+          r.outcome is DeliveryOutcome.NOT_DELIVERED and status == 403)
+
+    t = Transport((200, {"id": "88"}))
+    r, status, body = drc.DiscordRestClient(
+        "tok", transport=t).edit_message_with_response("c", "m", {"content": "x"})
+    check("edit_with_response keeps RetrySafety.SAFE", r.safety is RetrySafety.SAFE)
+    check("edit_with_response surfaces status+body",
+          status == 200 and body == {"id": "88"})
+
+    # 7. _default_transport: a read dying AFTER the 2xx is (status, None) —
+    #    committed server-side; "no response" would invite a duplicating retry.
+    class _DyingRead:
+        status = 200
+
+        def read(self):
+            raise ConnectionResetError("peer reset mid-body")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    real = urllib.request.urlopen
+    urllib.request.urlopen = lambda req, timeout=None: _DyingRead()
+    try:
+        status, body = drc._default_transport(object(), 5)
+    finally:
+        urllib.request.urlopen = real
+    check("mid-read death -> (200, None), not a raise", status == 200 and body is None)
+    r = drc.classify_response(status, body, id_keys=drc._DISCORD_ID_KEYS)
+    check("...which classifies as accepted-unproven, NOT no-response",
+          r.outcome is DeliveryOutcome.OUTCOME_UNKNOWN and "accepted" in r.detail,
+          r.detail)
+
+    print()
+    if FAILS:
+        print(f"{len(FAILS)} FAILURE(S)")
+        return 1
+    print("PASS: DiscordRestClient post-gate — structural coverage, fail-closed, "
+          "delivery-class scope, committed-read honesty")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/discord-send-reply-to.test.py
+++ b/tests/discord-send-reply-to.test.py
@@ -49,22 +49,26 @@ def check(cond, label):
         failures.append(label)
 
 
+sys.path.insert(0, str(REPO / "src"))
+from discord_rest_client import DiscordRestClient  # noqa: E402
+
+
 def capture(message, **kw):
-    """Run _send_via_rest against a stubbed transport; return the POSTed payloads."""
-    import urllib.request as ur
+    """Run _send_via_rest through the PRODUCTION DiscordRestClient with a
+    scripted transport; return the POSTed payloads the client built."""
     posted = []
 
-    class FakeResp:
-        status = 200
-        def read(self): return b"{}"
+    def transport(req, timeout):
+        posted.append(json.loads(req.data))
+        return 200, {"id": "1"}
 
-    real_req, real_open = ur.Request, ur.urlopen
-    ur.Request = lambda url, data=None, headers=None: posted.append(json.loads(data)) or object()
-    ur.urlopen = lambda req, timeout=None: FakeResp()
+    real = bridge._rest_client
+    bridge._rest_client = lambda timeout=10: DiscordRestClient(
+        "test-token-not-real", transport=transport)
     try:
         bridge._send_via_rest("123", message, **kw)
     finally:
-        ur.Request, ur.urlopen = real_req, real_open
+        bridge._rest_client = real
     return posted
 
 

--- a/tests/notify-sh-dm-delegation.test.py
+++ b/tests/notify-sh-dm-delegation.test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""notify.sh's Discord leg delegates to dm-result.send_dm — no hand-rolled curl.
+
+notify.sh used to open the DM channel and POST the message with raw `curl`,
+which sat outside the DiscordRestClient chokepoint (and outside the send
+allowlist, the chunker, and the shared owner/token resolution that
+dm-result.py carries). Pinned here by EXECUTION, not source-grep alone: the
+current notify.sh is copied into a scratch repo skeleton whose src/dm-result.py
+is a recorder stub, `curl`/`osascript` are PATH-shimmed (so no voice probe, no
+desktop notification, no network), and the script must hand the exact message
+to send_dm and still exit 0 when the DM leg fails (best-effort contract).
+
+Run: python3 tests/notify-sh-dm-delegation.test.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+NOTIFY = REPO / "src" / "notify.sh"
+
+_fails = []
+
+
+def check(name, cond, detail=""):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        _fails.append(name)
+
+
+# --- census half: the raw Discord HTTP is gone from the script itself --------
+src = NOTIFY.read_text()
+check("notify.sh carries no discord.com API URL", "discord.com" not in src)
+check("notify.sh delegates to dm-result", "dm-result.py" in src and "send_dm" in src)
+
+# --- execution half: the copied script really reaches send_dm ----------------
+with tempfile.TemporaryDirectory() as td:
+    scratch = Path(td)
+    (scratch / "src").mkdir()
+    (scratch / "results").mkdir()
+    shutil.copy(NOTIFY, scratch / "src" / "notify.sh")
+
+    marker = scratch / "sent.txt"
+    (scratch / "src" / "dm-result.py").write_text(
+        "import pathlib, sys\n"
+        "def send_dm(text):\n"
+        f"    pathlib.Path({str(marker)!r}).write_text(text)\n"
+        "    return False\n"  # DM leg FAILS -> script must still exit 0
+    )
+
+    shims = scratch / "bin"
+    shims.mkdir()
+    # curl shim: voice probe reports nothing listening -> no proactive file.
+    (shims / "curl").write_text("#!/bin/bash\necho -n 000\nexit 0\n")
+    # osascript shim: no desktop notification from a test run.
+    (shims / "osascript").write_text("#!/bin/bash\nexit 0\n")
+    for f in ("curl", "osascript"):
+        (shims / f).chmod((shims / f).stat().st_mode | stat.S_IEXEC)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{shims}:{env['PATH']}"
+    message = "gate check: it's done — 100% (`quotes` & $vars survive)"
+    proc = subprocess.run(
+        ["bash", str(scratch / "src" / "notify.sh"), message],
+        env=env, capture_output=True, text=True, timeout=60,
+    )
+
+    check("script exits 0 even when the DM leg fails (best-effort contract)",
+          proc.returncode == 0, f"rc={proc.returncode} err={proc.stderr[-300:]}")
+    check("send_dm received the message VERBATIM",
+          marker.exists() and marker.read_text() == message,
+          marker.read_text() if marker.exists() else "never called")
+    check("no proactive file written when voice probe says down",
+          not any((scratch / "results").iterdir()))
+
+print()
+if _fails:
+    print(f"{len(_fails)} FAILED: " + "; ".join(_fails))
+    sys.exit(1)
+print("all notify.sh dm-delegation assertions passed")

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -149,64 +149,116 @@ class TestSendSlack(unittest.TestCase):
 
 
 class TestSendDiscord(unittest.TestCase):
+    """send_discord routes through the shared src/discord_rest_client.py
+    chokepoint. The PRODUCTION client stays in the loop with a scripted
+    delivery transport; `get_user` (a retried read, not part of the gated
+    delivery class) is stubbed at method level."""
+
     def setUp(self):
         self.mod = _load()
 
-    @staticmethod
-    def _response(body):
-        response = MagicMock()
-        response.__enter__ = lambda s: s
-        response.__exit__ = MagicMock(return_value=False)
-        response.read.return_value = json.dumps(body).encode()
-        return response
+    def _bind_client(self, post_steps=None, get_user_steps=None):
+        """Bind a scripted client; returns the recorded delivery requests."""
+        sys.path.insert(0, str(REPO / "src"))
+        from discord_rest_client import DiscordRestClient
+
+        calls = []
+        steps = list(post_steps or [])
+        gets = list(get_user_steps or [])
+
+        def transport(req, timeout):
+            calls.append({"url": req.full_url, "method": req.get_method(),
+                          "body": json.loads(req.data.decode()) if req.data else None})
+            step = steps.pop(0) if steps else (200, {"id": "msg123", "mentions": []})
+            if isinstance(step, Exception):
+                raise step
+            return step
+
+        def fake_get_user(uid):
+            step = gets.pop(0) if gets else {"id": str(uid)}
+            if isinstance(step, Exception):
+                raise step
+            return step
+
+        def factory(token):
+            client = DiscordRestClient(token, transport=transport)
+            client.get_user = fake_get_user
+            return client
+
+        patcher = patch.object(self.mod, "_rest_client", side_effect=factory)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return calls
+
+    def test_rest_client_factory_builds_shared_client(self):
+        sys.path.insert(0, str(REPO / "src"))
+        from discord_rest_client import DiscordRestClient
+        client = self.mod._rest_client("Bot-fake")
+        self.assertIsInstance(client, DiscordRestClient)
+        self.assertEqual(client._timeout, 10)
 
     def test_success(self):
-        mock_resp = self._response({"id": "msg123", "mentions": []})
-        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch("urllib.request.urlopen", return_value=mock_resp):
+        calls = self._bind_client()
+        with patch.object(self.mod, "_token", return_value="Bot-fake"):
             result = self.mod.send_discord("111222333", "hello")
         self.assertTrue(result)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["method"], "POST")
+        self.assertIn("/channels/111222333/messages", calls[0]["url"])
 
     def test_missing_token_returns_false(self):
         with patch.object(self.mod, "_token", return_value=""):
             result = self.mod.send_discord("111", "hello")
         self.assertFalse(result)
 
-    def test_discord_request_api_error_returns_none(self):
-        with patch("urllib.request.urlopen", side_effect=Exception("timeout")), \
+    def test_user_lookup_error_blocks_send(self):
+        # Pre-client this lived in _discord_request ("Discord request failed");
+        # the failure wording and the do-not-send behavior both survive.
+        calls = self._bind_client(get_user_steps=[Exception("timeout")])
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
              patch("sys.stderr", new_callable=io.StringIO) as stderr:
-            result = self.mod._discord_request(
-                "https://discord.com/api/v10/users/123",
-                "Bot-fake",
-            )
-        self.assertIsNone(result)
+            result = self.mod.send_discord("111", "Please review, <@123456789012345678>")
+        self.assertFalse(result)
         self.assertIn("Discord request failed: timeout", stderr.getvalue())
+        self.assertEqual(calls, [])  # the POST never happened
 
     def test_post_failure_returns_false(self):
+        calls = self._bind_client(post_steps=[Exception("timeout")])
         with patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(self.mod, "_discord_request", return_value=None):
+             patch("sys.stderr", new_callable=io.StringIO) as stderr:
             result = self.mod.send_discord("111", "hello")
         self.assertFalse(result)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("Discord send not confirmed", stderr.getvalue())
+
+    def test_refused_post_returns_false(self):
+        # 4xx -> NOT_DELIVERED via the shared receipt classification.
+        import urllib.error
+        err = urllib.error.HTTPError("https://discord.com/x", 403, "forbidden",
+                                     {}, io.BytesIO(b"{}"))
+        calls = self._bind_client(post_steps=[err])
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            result = self.mod.send_discord("111", "hello")
+        self.assertFalse(result)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("NOT_DELIVERED", stderr.getvalue())
 
     def test_plain_at_handle_is_rejected_before_post(self):
         with patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(self.mod, "_discord_request") as request, \
+             patch.object(self.mod, "_rest_client") as factory, \
              patch("sys.stderr", new_callable=io.StringIO) as stderr:
             result = self.mod.send_discord("111", "Please review, @qingyun-wu")
         self.assertFalse(result)
-        request.assert_not_called()
+        factory.assert_not_called()
         self.assertIn("unresolved Discord mention(s): @qingyun-wu", stderr.getvalue())
 
     def test_email_address_is_not_treated_as_a_mention(self):
-        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(
-                 self.mod,
-                 "_discord_request",
-                 return_value={"id": "msg123", "mentions": []},
-             ) as request:
+        calls = self._bind_client()
+        with patch.object(self.mod, "_token", return_value="Bot-fake"):
             result = self.mod.send_discord("111", "Email dev@example.com")
         self.assertTrue(result)
-        self.assertEqual(request.call_count, 1)
+        self.assertEqual(len(calls), 1)
 
     def test_structured_mention_is_preflighted_and_verified(self):
         user_id = "1025828152183885925"
@@ -214,87 +266,70 @@ class TestSendDiscord(unittest.TestCase):
             "id": "msg123",
             "mentions": [{"id": user_id, "username": "qingyunwu"}],
         }
-        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(
-                 self.mod,
-                 "_discord_request",
-                 side_effect=[{"id": user_id}, posted],
-             ) as request:
+        calls = self._bind_client(post_steps=[(200, posted)],
+                                  get_user_steps=[{"id": user_id}])
+        with patch.object(self.mod, "_token", return_value="Bot-fake"):
             result = self.mod.send_discord("111", f"Please review, <@{user_id}>")
         self.assertTrue(result)
-        self.assertEqual(request.call_count, 2)
-        payload = request.call_args_list[1].args[2]
+        self.assertEqual(len(calls), 1)
+        payload = calls[0]["body"]
         self.assertEqual(payload["allowed_mentions"]["parse"], [])
         self.assertEqual(payload["allowed_mentions"]["users"], [user_id])
 
     def test_unresolvable_structured_mention_is_not_posted(self):
         user_id = "999999999999999999"
+        calls = self._bind_client(get_user_steps=[{"id": "different"}])
         with patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(
-                 self.mod,
-                 "_discord_request",
-                 return_value=None,
-             ) as request, \
              patch("sys.stderr", new_callable=io.StringIO) as stderr:
             result = self.mod.send_discord("111", f"Please review, <@{user_id}>")
         self.assertFalse(result)
-        self.assertEqual(request.call_count, 1)
+        self.assertEqual(calls, [])
         self.assertIn("message was not sent", stderr.getvalue())
 
     def test_missing_mention_in_post_response_returns_error(self):
         user_id = "1025828152183885925"
+        calls = self._bind_client(post_steps=[(200, {"id": "msg123", "mentions": []})],
+                                  get_user_steps=[{"id": user_id}])
         with patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(
-                 self.mod,
-                 "_discord_request",
-                 side_effect=[{"id": user_id}, {"id": "msg123", "mentions": []}],
-             ), \
              patch("sys.stderr", new_callable=io.StringIO) as stderr:
             result = self.mod.send_discord("111", f"Please review, <@{user_id}>")
         self.assertFalse(result)
+        self.assertEqual(len(calls), 1)
         self.assertIn("did not resolve expected mention", stderr.getvalue())
 
     def test_validation_can_be_disabled_for_plain_text_handle(self):
-        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(
-                 self.mod,
-                 "_discord_request",
-                 return_value={"id": "msg123", "mentions": []},
-             ) as request:
+        calls = self._bind_client()
+        with patch.object(self.mod, "_token", return_value="Bot-fake"):
             result = self.mod.send_discord(
                 "111",
                 "GitHub author @qingyun-wu",
                 validate_mentions=False,
             )
         self.assertTrue(result)
-        self.assertEqual(request.call_count, 1)
+        self.assertEqual(len(calls), 1)
 
     def test_cli_defaults_to_validation_and_returns_agent_visible_error(self):
         with patch("sys.argv", [
             "notify.py", "--source", "discord", "--channel-id", "111",
             "--message", "Please review, @qingyun-wu",
         ]), patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(self.mod, "_discord_request") as request, \
+             patch.object(self.mod, "_rest_client") as factory, \
              patch("sys.stderr", new_callable=io.StringIO) as stderr:
             result = self.mod.main()
         self.assertEqual(result, 1)
-        request.assert_not_called()
+        factory.assert_not_called()
         self.assertIn("Use <@USER_ID>", stderr.getvalue())
 
     def test_cli_opt_out_allows_intentional_plain_text_handle(self):
+        calls = self._bind_client()
         with patch("sys.argv", [
             "notify.py", "--source", "discord", "--channel-id", "111",
             "--message", "GitHub author @qingyun-wu",
             "--no-validate-mentions",
-        ]), patch.object(self.mod, "_token", return_value="Bot-fake"), \
-             patch.object(
-                 self.mod,
-                 "_discord_request",
-                 return_value={"id": "msg123", "mentions": []},
-             ) as request:
+        ]), patch.object(self.mod, "_token", return_value="Bot-fake"):
             result = self.mod.main()
         self.assertEqual(result, 0)
-        self.assertEqual(request.call_count, 1)
+        self.assertEqual(len(calls), 1)
 
 
 class TestSendTelegram(unittest.TestCase):


### PR DESCRIPTION
## What changed, and why?

`DiscordRestClient` (`src/discord_rest_client.py`) becomes the single chokepoint for every hand-rolled Discord message POST/PATCH in the repo, and gains the post-gate injection point the owner settled in today's #PR-practice thread:

1. **Gate hook on the client (mechanism in repo, policy injected).** `DiscordRestClient(..., validator=None)` — a callable receiving `(channel_id, payload)`; falsy return allows, a reason string refuses with a `NOT_DELIVERED` receipt and **zero transport attempts**. A validator that crashes fails **closed**. The gate itself (chain-check) lives in sutando-skills and is NOT vendored here; a personal-layer wrapper selects WHICH ruleset applies per channel — config never decides WHETHER one applies (no absent-key-means-skip semantics anywhere in this PR).
1b. **Production injection seam (answers qingyun-wu's P1 review, commit ff0c80ec).** `src/discord_post_gate.py` is the ONE factory every delivery entrypoint constructs through — bridge CLI send/edit, the proactive provider, `dm-result.py` (and therefore notify.sh's delegation), bot2bot-post, task-progress. `make_client()` resolves the validator from launch wiring the personal layer controls: `$SUTANDO_DISCORD_POST_GATE` (env; mirrors the `$SUTANDO_DOWN_BRIDGE_ACTION` precedent) else `bridges.discord_post_gate` in `sutando.config.json[.local]` (schema updated) — a path to a Python file exporting `validate(channel_id, payload)`. Unconfigured = ungated (repo default); **a configured policy that fails to load refuses every send** (fail-closed — a named-but-broken gate must not silently disable itself). Behavioral proof: `tests/discord-post-gate-wiring.test.py` installs one refusing policy file through the real env seam and shows ALL FIVE production paths refuse with **zero transport attempts** (urlopen is patched with a recorder that would succeed, so a non-consulted gate surfaces as a recorded attempt, not an error); the policy's recorded inputs prove it saw each path's real `(channel_id, payload)`. Negative control exercised during authoring: reverting any single factory to a bare client fails the test with 4 loud failures including the recorded transport attempt.
2. **Every hand-rolled sender now routes through the client** (census below): `discord-bridge.py send`/`edit` CLI, `skills/bot2bot-post/post.py`, `skills/task-progress/scripts/notify.py`, and `src/notify.sh` (whose Discord leg now delegates to `dm-result.py:send_dm`, which was already on the client — so notify.sh also inherits the shared owner/token resolution, fence-aware chunking, and `send_allowlist` policy instead of raw `curl` with none of them).
3. **New structural census test** (`tests/discord-post-census.test.py`) pins the end state: the `discord.com/api` literal may exist only in the client + the GET-only reader modules, and those readers must stay verb-free — a future hand-rolled sender fails CI by construction.
4. **`send_message_with_response` / `edit_message_with_response`** on the client return `(receipt, status, body)` for senders that must inspect the created message (task-progress mention verification) or report commitment honestly (a 2xx without a readable id is *committed*, not failed — the duplicate-send trap the bridge tests pin). The plain methods delegate to these, so the gate cannot be bypassed by method choice.
5. **`_default_transport` fix:** a response body that dies mid-read AFTER a 2xx now yields `(status, None)` instead of raising into "no response" — the server committed the write; reporting "unknown/no response" invited the caller retry that duplicates it.

Marker/attachment authority is untouched: `result_markers.parse_markers` and `send_allowlist` remain the owners (dm-result path unchanged; notify.sh now *gains* them via delegation).

## POST-site census — the spine of this PR

**Before (origin/main `b63fcde3`), hand-rolled Discord message POST/PATCH sites outside the client:**

| # | Site | Call |
|---|------|------|
| 1 | `src/discord-bridge.py:_send_via_rest` | urlopen POST `/channels/{id}/messages` (chunked) |
| 2 | `src/discord-bridge.py:_edit_via_rest` | urlopen PATCH `/channels/{id}/messages/{mid}` |
| 3 | `skills/bot2bot-post/post.py:post()` | urlopen POST `/channels/{id}/messages` (+ hand-rolled GET `/users/@me`) |
| 4 | `skills/task-progress/scripts/notify.py:send_discord` | `_discord_request` POST `/channels/{id}/messages` (+ hand-rolled GET `/users/{id}`) |
| 5 | `src/notify.sh` | `curl` POST `/users/@me/channels` + `curl` POST `/channels/{id}/messages` — **not in the settled census; found by the completeness sweep** |

Verified NOT a Discord send: `discord-bridge.py:547` urlopen (`timeout=2`) POSTs to `http://localhost:7843/task-done` (agent-api), left alone.

**After: zero.** The census test proves both directions — at the parent commit it FAILS naming exactly the senders above, at HEAD it passes:

```
# at b63fcde3 (origin/main), test file copied in:
FAIL  no discord.com/api literal outside the chokepoint+readers (scanned 452 production files)
      [src/discord-bridge.py, src/notify.sh, skills/bot2bot-post/post.py, skills/task-progress/scripts/notify.py]

# at HEAD:
census holds: every hand-rolled Discord POST path routes through DiscordRestClient
```

**Deliberately out of scope (stated, not hidden):** the live bridge's ~32 `await channel.send(...)` gateway sends ride discord.py's own HTTP stack — the owner-settled census covered hand-rolled REST, which is where the drift lived. Gating the library path means wrapping discord.py's HTTPClient and is a separate concern. The census test documents this scope in its docstring.

## What files / sections should reviewers look at first?

1. `src/discord_rest_client.py` — `validator` + `_gate_refusal` + the `_with_response` pair + `_default_transport` read-death fix.
2. `tests/discord-post-census.test.py` — the structural completeness pin (with positive controls so an empty result can't be a broken scan).
3. `src/discord_post_gate.py` + `tests/discord-post-gate-wiring.test.py` — the production injection seam and its behavioral proof (review P1).
3b. `tests/discord-rest-client-gate.test.py` — the gate contract (all five delivery methods refuse, zero attempts, fail-closed crash, reads/open-DM out of the gated class, twin-method delegation).
4. The four sender conversions + their wiring tests.

## What user behavior or bug does this prove?

No user-visible behavior change on the happy paths (payload shapes are pinned byte-identical by the updated tests — e.g. `message_reference` on first chunk only, PATCH verb, `allowed_mentions`). The structural change: a post-gate validator injected at the client now covers every hand-rolled sender; before, bot2bot-post / task-progress / notify.sh sat entirely outside it.

Known behavioral deltas (all narrow, all named):
- bot2bot `post()`: a timeout previously escaped as a raw traceback; now a loud `SystemExit` saying the post MAY have landed (the 2026-07-29 double-ping guard). A 4xx keeps its loud NOTHING-WAS-SENT exit.
- task-progress GETs/bot2bot `get_self_id` now ride the client's read class, gaining bounded 429/5xx retry (previously single-attempt).
- notify.sh's DM leg gains chunking + allowlist + shared owner resolution; its stderr is no longer swallowed (best-effort exit contract unchanged — pinned by the new test).
- bridge CLI: a 2xx whose body dies mid-read now prints `message_id unavailable … sent, not addressable` (was already the behavior for an unparseable body; the mid-read case previously depended on where the exception fired).

## Feature/documentation consistency

`docs/src-map.md` IS in this diff (regenerated — the earlier claim that it was unchanged predated later commits and was wrong; corrected at head 45b78731 per review). `docs/sutando-config.schema.json` carries the `bridges.discord_post_gate` key this PR reads. N/A for `docs/catalog.json` — no doc files added.

## Before/after evidence

Census: pasted above (FAIL at `b63fcde3` naming all four files → PASS at HEAD).

Test battery at HEAD (all commands `python3 tests/<file>`):

```
tests/discord-rest-client.test.py        -> PASS (pre-existing contract intact)
tests/discord-rest-client-gate.test.py   -> PASS (new gate contract)
tests/discord-post-census.test.py        -> PASS (census holds)
tests/discord-send-reply-to.test.py      -> all reply-to assertions passed
tests/discord-bridge-edit-verb.test.py   -> PASS (incl. committed-but-unproven cases 5/5b)
tests/bot2bot-post.test.py               -> PASS
tests/bot2bot-post-length-guard.test.py  -> PASS (guard still refuses BEFORE the network)
tests/bot2bot-post-client-delegation.test.py -> PASS (new wiring)
tests/task-progress-skill.test.py        -> OK (46 tests)
tests/notify-sh-dm-delegation.test.py    -> PASS (new wiring, by execution not grep)
tests/bridge-timeout-guards.test.py      -> PASS (timeout=10 bound now proven through the client)
tests/dm-result-*.test.py                -> PASS (untouched consumer, still green)
```

Full related battery: 111 discord/bot2bot/task-progress/notify/dm-result/marker/outbox/delivery/rest test files — 109 pass inside a 90s harness cap; the two over-cap files (`outbox-claim-regressions` 88s, `start-cli-restart-verify` 164s, both untouched by this diff) pass when run to completion. 0 failures.

## What tests did you run?

The 111-file related battery above, `git diff | bash scripts/review-checks.sh` (hardcoded-paths + root-artifacts + prose-cap: PASS), plus `ruff check` over every touched file and `/usr/bin/python3 -m py_compile` (3.9.6) over the four production files. Updated-in-place tests (`discord-send-reply-to`, `discord-bridge-edit-verb`, `bot2bot-post-length-guard`, `task-progress-skill`, `bridge-timeout-guards`) keep their original assertions and now drive the PRODUCTION client with a scripted transport rather than patched `urlopen` — per the repo rule that wiring tests must call the production writer, not a copied recipe.

## Live path?

Yes — `discord-bridge.py send/edit` is a live CLI path and CONTRIBUTING requires a real round trip. **Executed 2026-08-21 ~23:10Z from the installed path, post-restart** (owner authorized the bounce), same discipline as the recorded #3184 witness:

- **Allowed send:** with a benign policy configured through the real config seam, `discord-bridge.py send` delivered — `message_id 1540498345552781313` (sentinel `WITNESS-3239-ALLOW 2026-08-21T23:10:25Z`, practice thread).
- **Configured refusal:** with the policy refusing the sentinel, the same CLI exited rc=1 — `Send failed (chunk 1/1): refused by validator: refused by configured post-gate policy (witness sentinel)` — and **zero messages were delivered and zero transport attempts made** (no new message in the channel after the sentinel; the refusal receipt is produced before the transport layer, which the gate contract test pins structurally).
- **Blob attestation binds the witness to THIS head:** `git hash-object` of the three executed files at witness time = `043e1de904ef` (discord-bridge.py), `7dfe1cb73d49` (discord_post_gate.py), `b5896c91609d` (discord_rest_client.py) — each equal to `git rev-parse 6d947056:<file>`, checkable from the diff. (The later rebase for the CLA repair changed authorship only; these blobs are byte-identical.)

## Edge cases / non-happy paths checked

Refusal (4xx), timeout, 5xx, 2xx-without-id, 2xx-with-mid-read-death, crashing validator, refusing validator, empty message no-op, over-long edit refusal, later-chunk failure after a delivered first chunk, missing token, unresolvable mention, mention missing from the posted message, DM-leg failure in notify.sh (script still exits 0).

## Migrations, config, permissions, rollback, deployment risks?

**Config surface (opt-in, added by this head):** `bridges.discord_post_gate` in `sutando.config.json[.local]` (schema key in `docs/sutando-config.schema.json`) or the `SUTANDO_DISCORD_POST_GATE` env var — a path to a policy module exporting `validate(channel_id, payload)`. No migration. **Unconfigured hosts are byte-identical to today** (`validator=None`). **Failure semantics are fail-closed on every configured-but-broken state:** an unreadable/malformed config, a policy that fails to import, or a non-callable `validate` all yield a refuser, never an ungated send (review-driven; parent/head-controlled wiring tests pin each case), and a relative policy path resolves against the repo root, never process cwd. **Rollback:** revert the PR's commits; additionally any host can disable the gate instantly by removing the config key/env var (returns to unconfigured = ungated), with the caveat that a host relying on the gate as a security control loses it on removal — that is the operator's explicit choice, not a silent state. Risk: senders now import `src/` from skills (bot2bot already did via `body_file`; task-progress newly does, lazily and only on the Discord path so Slack/Telegram notifies never touch it).

## Known gaps / follow-up

- discord.py gateway-library sends (see scope note) — follow-up if the owner wants the library path gated too.
- `create_dm_channel` (open-DM control call) is deliberately NOT in the gated delivery class (pinned by test): the gate governs message posts; refusing DM-channel resolution would break owner-DM delivery wholesale.
- discord-bridge's pre-outbox archive/delivered-sentinel machinery remains migration debt per CLAUDE.md — untouched here (single concern).

Stand: Echo Act IV Pro



