### PR TITLE
feat(room-ops): add `events emit` — the send half of the typed-event surface

### DIFF
--- a/skills/agent-room-ops/SKILL.md
+++ b/skills/agent-room-ops/SKILL.md
@@ -37,6 +37,11 @@ python3 skills/agent-room-ops/room_ops.py doc get '!room:hs' --folder room-todo 
 python3 skills/agent-room-ops/room_ops.py doc put '!room:hs' --folder room-memo --name note.md --file /tmp/note.md --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py doc rm  '!room:hs' --folder room-memo --name note.md --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py grant '!room:hs' --tier '@u:hs=owner' --default-tier guest --agent '@a:hs'
+python3 skills/agent-room-ops/room_ops.py events emit '!room:hs' --type space.ag2.app.card --content '{"k":1}' --agent '@a:hs'
+#   -> one typed space.ag2.* TIMELINE event sent AS this agent. Same
+#   confirmed/unconfirmed receipt as `say`. Which type namespaces are accepted is the
+#   server's rule, not restated here — a refusal arrives as `reason`.
+#   Timeline needs no power-level grant; `op:state` (roomtype/widget) does.
 ```
 
 `grant` makes a room **authoritative** (design-response-policy-v0.2 / #429): it writes

--- a/skills/agent-room-ops/events.py
+++ b/skills/agent-room-ops/events.py
@@ -51,6 +51,8 @@ class StreamDisconnected(ConnectionError):
     decide for themselves."""
 
 
+# emit's fields live HERE, not in a private builder: all seven `_op_call`
+# failure paths return through this one, so a split would KeyError on denial.
 def _result(ok, *, room_id=None, subscription_id=None, subscriptions=None, reason=None,
             event_id=None, state=None):
     return {"ok": bool(ok), "room_id": room_id, "subscription_id": subscription_id,

--- a/skills/agent-room-ops/events.py
+++ b/skills/agent-room-ops/events.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 """room-ops · events — client half of Agent Event Subscription & Delivery (#184).
 
-Three surfaces, all speaking the FIXED #184 contract (the server half is built
+Four surfaces, all speaking the FIXED #184 contract (the server half is built
 separately against the same contract — this code targets the contract, never a
 server implementation):
 
   - subscription management — `events_subscribe` / `events_unsubscribe` /
     `events_subscriptions` ops on the generic `POST {base}/v1/room` envelope
     (one privileged endpoint, many ops — same shape as doc/mention).
+  - typed emit — the `event` op on that same envelope: send one typed
+    `space.ag2.*` TIMELINE event as this agent. The receive half above had no
+    counterpart, so an agent could subscribe to typed events it had no way to
+    produce.
   - long-poll pull — `GET {base}/v1/events?cursor=<int>&wait=<sec>`; one
     bounded round per call; timeout = empty `events` + unchanged cursor.
   - SSE push — `GET {base}/v1/events/stream`; each event is `id: <cursor>` +
@@ -29,6 +33,7 @@ import urllib.request
 
 from _gateway import (HTTP_TIMEOUT, gate_allows, load_gate, gateway, http_json,
                       degrade_reason, urlencode, HTTPError, URLError)
+import receipt as _receipt
 
 DEFAULT_WAIT = 30
 
@@ -46,9 +51,11 @@ class StreamDisconnected(ConnectionError):
     decide for themselves."""
 
 
-def _result(ok, *, room_id=None, subscription_id=None, subscriptions=None, reason=None):
+def _result(ok, *, room_id=None, subscription_id=None, subscriptions=None, reason=None,
+            event_id=None, state=None):
     return {"ok": bool(ok), "room_id": room_id, "subscription_id": subscription_id,
-            "subscriptions": subscriptions, "reason": reason}
+            "subscriptions": subscriptions, "reason": reason,
+            "event_id": event_id, "state": state}
 
 
 # --------------------------------------------------------------------------- #
@@ -118,6 +125,22 @@ def subscriptions(agent_mxid=None):
     if res.get("ok") is False:
         return res
     return _result(True, subscriptions=res.get("subscriptions") or [])
+
+
+def emit(room_id, event_type, content, agent_mxid=None, *, gate=None):
+    """op `event` → one typed TIMELINE event sent as this agent.
+
+    The accepted type namespace is the SERVER's rule, not re-encoded here — a
+    client copy would drift, and its refusal already arrives as `reason`.
+    """
+    res = _op_call("event", room_id, agent_mxid, gate,
+                   {"type": event_type, "content": content})
+    if res.get("ok") is False:
+        return res
+    # Same three-state receipt as say/mention: UNCONFIRMED stays ok:true so a
+    # caller cannot re-send an event that already landed.
+    state, event_id, reason = _receipt.classify(res)
+    return _result(True, room_id=room_id, event_id=event_id, reason=reason, state=state)
 
 
 # --------------------------------------------------------------------------- #

--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -14,6 +14,7 @@ graceful-degrade); this file is the unified CLI that dispatches to them.
     python3 room_ops.py join   <room> [--agent mxid]                 # accept own invite
     python3 room_ops.py rooms  [--agent mxid]                        # joined-rooms list
     python3 room_ops.py members <room_id> [--agent mxid]             # room member list
+    python3 room_ops.py events emit <room> --type space.ag2.app.x --content '{"k":1}'
     python3 room_ops.py events subscribe <room> --types a,b [--filters json]
     python3 room_ops.py events unsubscribe <room>
     python3 room_ops.py events list
@@ -74,6 +75,16 @@ def _events_stream(a):
 
 
 def _dispatch_events(a):
+    if a.events_cmd == "emit":
+        try:
+            content = json.loads(a.content)
+        except ValueError as e:
+            return {"ok": False, "reason": f"--content is not valid JSON: {e}"}
+        # The wire contract is a JSON object; a bare scalar or list would be
+        # rejected server-side, so name it here rather than spend a round trip.
+        if not isinstance(content, dict):
+            return {"ok": False, "reason": "--content must be a JSON object"}
+        return _events.emit(a.room_id, a.type, content, agent_mxid=a.agent_mxid)
     if a.events_cmd == "subscribe":
         types = [t.strip() for t in (a.types or "").split(",") if t.strip()]
         filters = None
@@ -144,6 +155,11 @@ def _main(argv):
 
     p = sub.add_parser("events", help="event subscriptions + delivery (#184 client half)")
     esub = p.add_subparsers(dest="events_cmd", required=True)
+    e = esub.add_parser("emit", help="send one typed space.ag2.* timeline event as this agent")
+    e.add_argument("room_id")
+    e.add_argument("--type", required=True, help="event type (e.g. space.ag2.app.card)")
+    e.add_argument("--content", required=True, help="JSON object body")
+    e.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
     e = esub.add_parser("subscribe", help="subscribe this agent to a room's events")
     e.add_argument("room_id")
     e.add_argument("--types", required=True,

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -738,6 +738,54 @@ class EventsSubscribeTests(EnvCase):
                           ev.subscribe(ROOM, ["message.created"], agent_mxid=HS, gate=None)["reason"])
 
 
+# ----- events: typed emit (op:event) ----- #
+class EventsEmitTests(EnvCase):
+    def test_no_gateway(self):
+        res = ev.emit(ROOM, "space.ag2.app.card", {"k": 1}, agent_mxid=HS, gate=None)
+        self.assertIn("no gateway", res["reason"])
+
+    def test_gate_deny(self):
+        os.environ["RELAY_URL"] = "https://r"
+        res = ev.emit(ROOM, "space.ag2.app.card", {"k": 1}, agent_mxid=HS, gate={})
+        self.assertIn("gate denied", res["reason"])
+
+    def test_emit_envelope_and_event_id(self):
+        os.environ["RELAY_URL"] = "https://r"
+        cap = {}
+        fake = {"event_id": "$abc"}
+        with mock.patch.object(ev, "http_json",
+                               side_effect=lambda m, u, h, p: (cap.update(url=u, payload=p), (200, fake))[1]):
+            res = ev.emit(ROOM, "space.ag2.app.card", {"k": 1}, agent_mxid=HS, gate=None)
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["event_id"], "$abc")
+        self.assertEqual(res["state"], "confirmed")
+        self.assertTrue(cap["url"].endswith("/v1/room"))
+        self.assertEqual(cap["payload"], {"op": "event", "room_id": ROOM,
+                                          "type": "space.ag2.app.card",
+                                          "content": {"k": 1}})
+
+    def test_missing_event_id_is_unconfirmed_but_ok(self):
+        # Same fail-open receipt as say/mention — a caller must not re-send an
+        # event the gateway may already have landed.
+        os.environ["RELAY_URL"] = "https://r"
+        with mock.patch.object(ev, "http_json",
+                               side_effect=lambda m, u, h, p: (200, {"ok": True})):
+            res = ev.emit(ROOM, "space.ag2.app.card", {"k": 1}, agent_mxid=HS, gate=None)
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["state"], "unconfirmed")
+        self.assertIsNone(res["event_id"])
+
+    def test_server_type_refusal_surfaces_verbatim(self):
+        # The namespace rule lives server-side and is deliberately NOT copied
+        # into the client; its refusal must reach the caller as `reason`.
+        os.environ["RELAY_URL"] = "https://r"
+        err = {"error": "event type must be under space.ag2.*"}
+        with mock.patch.object(ev, "http_json", side_effect=lambda m, u, h, p: (200, err)):
+            res = ev.emit(ROOM, "not.ag2.thing", {"k": 1}, agent_mxid=HS, gate=None)
+        self.assertFalse(res["ok"])
+        self.assertEqual(res["reason"], "event type must be under space.ag2.*")
+
+
 # ----- events: long-poll pull ----- #
 class EventsPullTests(EnvCase):
     def test_no_gateway(self):

--- a/tests/room-ops-events-emit.test.py
+++ b/tests/room-ops-events-emit.test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""room-ops `events emit` — send one typed space.ag2.* TIMELINE event as this agent.
+
+Lives in `tests/` rather than beside the module because the diff-coverage gate
+discovers only `tests/*.test.py` (`scripts/coverage-gate.sh` -> `find tests -name
+'*.test.py'`), the same reachability note `tests/room-ops-say.test.py` carries.
+The skill-local suite covers the same behaviour; this file is what the gate sees.
+
+Two load-bearing assertions:
+
+  1. The accepted TYPE NAMESPACE is the server's rule and is not re-encoded in
+     the client — a copy would drift silently. `test_server_refusal_verbatim`
+     fails if someone adds a client-side namespace check that shortcuts the
+     round trip, because the server's wording would stop reaching the caller.
+  2. `emit` reads its receipt through `receipt.classify`, the same three-state
+     reading `say` and `mention` share. UNCONFIRMED must stay `ok:true` so a
+     caller cannot re-send an event the gateway already landed.
+
+Run: python3 tests/room-ops-events-emit.test.py
+"""
+import json
+import os
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+_ROOM_OPS = pathlib.Path(__file__).resolve().parents[1] / "skills" / "agent-room-ops"
+sys.path.insert(0, str(_ROOM_OPS))
+import events as ev  # noqa: E402
+import room_ops as ro  # noqa: E402
+
+ROOM = "!r:ag2.space"
+AGENT = "@a:ag2.space"
+ETYPE = "space.ag2.app.card"
+
+
+class _EnvCase(unittest.TestCase):
+    """Pins the gateway POSITIVELY instead of unsetting env names. The resolver
+    reads several vars plus a vault fallback, so name-scrubbing can leave a live
+    path and a "no gateway" test then makes a real network call."""
+
+    def setUp(self):
+        self._g = mock.patch.object(ev, "gateway", return_value=("https://r", {}))
+        self._g.start()
+        self.addCleanup(self._g.stop)
+        self._saved = os.environ.get("ROOM_OPS_GATE")
+        os.environ.pop("ROOM_OPS_GATE", None)
+
+    def tearDown(self):
+        if self._saved is not None:
+            os.environ["ROOM_OPS_GATE"] = self._saved
+
+
+class EmitTests(_EnvCase):
+    def test_no_gateway_configured(self):
+        with mock.patch.object(ev, "gateway", return_value=(None, {})):
+            res = ev.emit(ROOM, ETYPE, {"k": 1}, agent_mxid=AGENT, gate=None)
+        self.assertFalse(res["ok"])
+        self.assertIn("no gateway", res["reason"])
+
+    def test_gate_denial_is_key_complete(self):
+        # A denial returns through the SHARED _result builder, so an emit
+        # caller reading res["event_id"] gets None rather than a KeyError.
+        res = ev.emit(ROOM, ETYPE, {"k": 1}, agent_mxid=AGENT, gate={})
+        self.assertFalse(res["ok"])
+        self.assertIn("gate denied", res["reason"])
+        self.assertIsNone(res["event_id"])
+        self.assertIsNone(res["state"])
+
+    def test_envelope_and_confirmed_receipt(self):
+        cap = {}
+        with mock.patch.object(
+            ev, "http_json",
+            side_effect=lambda m, u, h, p: (cap.update(url=u, payload=p), (200, {"event_id": "$e1"}))[1],
+        ):
+            res = ev.emit(ROOM, ETYPE, {"k": 1}, agent_mxid=AGENT, gate=None)
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["event_id"], "$e1")
+        self.assertEqual(res["state"], "confirmed")
+        self.assertTrue(cap["url"].endswith("/v1/room"))
+        self.assertEqual(cap["payload"],
+                         {"op": "event", "room_id": ROOM, "type": ETYPE, "content": {"k": 1}})
+
+    def test_unconfirmed_stays_ok(self):
+        with mock.patch.object(ev, "http_json", side_effect=lambda m, u, h, p: (200, {"ok": True})):
+            res = ev.emit(ROOM, ETYPE, {"k": 1}, agent_mxid=AGENT, gate=None)
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["state"], "unconfirmed")
+        self.assertIsNone(res["event_id"])
+
+    def test_server_refusal_verbatim(self):
+        refusal = {"error": "event type must be under space.ag2.*"}
+        with mock.patch.object(ev, "http_json", side_effect=lambda m, u, h, p: (200, refusal)):
+            res = ev.emit(ROOM, "not.ag2.thing", {"k": 1}, agent_mxid=AGENT, gate=None)
+        self.assertFalse(res["ok"])
+        self.assertEqual(res["reason"], refusal["error"])
+
+
+class _Args:
+    def __init__(self, **kw):
+        self.events_cmd = "emit"
+        self.room_id = ROOM
+        self.type = ETYPE
+        self.content = json.dumps({"k": 1})
+        self.agent_mxid = AGENT
+        self.__dict__.update(kw)
+
+
+class DispatchTests(_EnvCase):
+    def test_bad_json_is_structured_not_raised(self):
+        res = ro._dispatch_events(_Args(content="not-json"))
+        self.assertFalse(res["ok"])
+        self.assertIn("not valid JSON", res["reason"])
+
+    def test_non_object_content_rejected(self):
+        for body in ("[1,2]", '"str"', "7"):
+            res = ro._dispatch_events(_Args(content=body))
+            self.assertFalse(res["ok"], body)
+            self.assertIn("must be a JSON object", res["reason"])
+
+    def test_delegates_to_events_emit(self):
+        with mock.patch.object(ro._events, "emit", return_value={"ok": True}) as m:
+            ro._dispatch_events(_Args())
+        m.assert_called_once_with(ROOM, ETYPE, {"k": 1}, agent_mxid=AGENT)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `events emit` to the room-ops skill: send one typed `space.ag2.*` **timeline** event as this agent, via the `event` op on the gateway's `/v1/room` envelope.

## Why

The skill had the **receive** half of the typed-event surface (subscribe / unsubscribe / list / long-poll / SSE) and no way to **produce** one. `events.py` passed exactly three ops through its envelope — `events_subscribe`, `events_unsubscribe`, `events_subscriptions` — so an agent could subscribe to a typed event stream it had no verb to write into.

`event` is on the gateway's public accept-list (`services/agent-message-broker/api/v1.py` `_ROOM_OPS`, checked before dispatch), and its handler sends as the requesting agent with no power-level branch — unlike `op:state`, which requires a grant. So the capability was reachable from the server and simply unreachable from this client.

## How

- `events.emit()` uses the module's **existing** `_op_call`, so no second copy of the op-envelope / degrade-mapping policy is introduced.
- Delivery is read through `receipt.classify` — the same three-state receipt `say` and `mention` already share. `UNCONFIRMED` stays `ok:true` so a caller cannot re-send an event that already landed.
- **The accepted type *namespace* is not re-encoded client-side.** The server owns that rule; a client copy would drift. Its refusal arrives as `reason`, and a test pins that.
- **Shape is checked locally; policy is not.** `--content` must parse and must be an object — that is the wire format, stable and cheap to fail fast on. *Which* types are accepted is policy and can change server-side without notice, so it is never mirrored here. The distinction is the line, not "no client-side validation at all."
- CLI parse/shape guards for `--content` are reported as structured `ok:false` (same convention as `--filters`).

## Evidence

**Before** (parent `890a2af5`) — the verb does not exist:

```
$ python3 room_ops.py events emit '!r:x' --type space.ag2.app.card --content '{"k":1}'
usage: room_ops events [-h] {subscribe,unsubscribe,list,pull,stream} ...
room_ops events: error: argument events_cmd: invalid choice: 'emit'
  (choose from subscribe, unsubscribe, list, pull, stream)
$ python3 test_room_ops.py
Ran 117 tests in 0.132s
OK
```

**After** (`69b5d6b6`) — reaches the live gateway and surfaces its real answer for a room this agent is not in:

```
$ python3 room_ops.py events emit '!r:x' --type space.ag2.app.card --content '{"k":1}'
{
  "ok": false,
  "room_id": "!r:x",
  "reason": "denied — agent not a joined member (403)",
  "event_id": null,
  "state": null
}
$ python3 test_room_ops.py
Ran 122 tests in 0.137s
OK
```

Input guards:

```
$ ... --content 'not-json'   -> {"ok": false, "reason": "--content is not valid JSON: Expecting value: line 1 column 1 (char 0)"}
$ ... --content '[1,2]'      -> {"ok": false, "reason": "--content must be a JSON object"}
```

**Red control** — the 122-test pass is meaningful: flipping one expected `event_id` in the new tests makes the suite report `FAILED` (rc=1), then reverted.

`scripts/review-checks.sh` on the diff: `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`.

## Not in scope

No live emit into a real room — that is an outward-facing send and stays the owner's call. The 403 above is the reachability proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNTJu2gT77tcdRJ3TYn83s