### PR TITLE
fix(health-check): task-watcher went green on a premise it never checked

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6664,8 +6664,12 @@ def check_task_watcher() -> dict:
                     "detail": f"no live core heartbeat, but {len(idle_trees)} watcher tree(s) "
                               f"alive (pids {', '.join(sorted(idle_trees))}) — watcher health is "
                               "NOT asserted while the core signal is stale"}
+        # Say only what was established: a false _any_core_alive() means no
+        # FRESH heartbeat, and an empty _watcher_trees() can also be a failed ps.
         return {"name": name, "status": "ok",
-                "detail": "no core running and no watcher process — watcher not expected"}
+                "detail": "no live core heartbeat and no watcher tree observed — "
+                          "watcher health is NOT asserted (neither the core's "
+                          "absence nor the probe's success was established)"}
     trees = _watcher_trees()
     roots = sorted(trees)
     if not pid_file.exists():

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6656,7 +6656,16 @@ def check_task_watcher() -> dict:
     name = "task-watcher"
     pid_file = WORKSPACE_DIR / "state" / "watch-tasks-stream.pid"
     if not _any_core_alive():
-        return {"name": name, "status": "ok", "detail": "no core running — watcher not expected"}
+        # Stay green (an always-red check informs nothing), but measure before
+        # claiming: a live watcher here makes "not expected" a false premise.
+        idle_trees = _watcher_trees()
+        if idle_trees:
+            return {"name": name, "status": "ok",
+                    "detail": f"no live core heartbeat, but {len(idle_trees)} watcher tree(s) "
+                              f"alive (pids {', '.join(sorted(idle_trees))}) — watcher health is "
+                              "NOT asserted while the core signal is stale"}
+        return {"name": name, "status": "ok",
+                "detail": "no core running and no watcher process — watcher not expected"}
     trees = _watcher_trees()
     roots = sorted(trees)
     if not pid_file.exists():

--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -496,6 +496,35 @@ def case_a2_no_core_but_live_watcher_is_not_called_unexpected() -> list[str]:
     return out
 
 
+UNMEASURED = ("no core running", "no watcher process", "not expected")
+
+
+def case_a3_stale_heartbeat_no_trees_claims_only_what_it_measured() -> list[str]:
+    # A false _any_core_alive() means no FRESH heartbeat, not an absent core;
+    # an empty _watcher_trees() can equally be a failed ps probe.
+    r = run_check(core_alive=False, pid_text=None, trees={})
+    out = []
+    if r["status"] != "ok":
+        out.append(f"a3) must stay ok (anti-latch), got {r['status']}")
+    for claim in UNMEASURED:
+        if claim in r["detail"]:
+            out.append(f"a3) asserts unestablished {claim!r}: {r['detail']}")
+    return out
+
+
+def case_a4_unavailable_process_probe_is_not_an_absent_watcher() -> list[str]:
+    # _watcher_trees() collapses a failed probe into {} — indistinguishable
+    # from "no watcher", so the row must not report the outage as expected.
+    r = run_check(core_alive=False, pid_text=None, trees={})
+    out = []
+    for claim in UNMEASURED:
+        if claim in r["detail"]:
+            out.append(f"a4) a failed ps probe reads as {claim!r}: {r['detail']}")
+    if "NOT asserted" not in r["detail"]:
+        out.append(f"a4) does not say watcher health is unasserted: {r['detail']}")
+    return out
+
+
 def case_b_sentinel_absent_warns() -> list[str]:
     r = run_check(core_alive=True, pid_text=None)
     if r["status"] != "warn":
@@ -741,6 +770,8 @@ def main() -> int:
     cases = [
         ("a", case_a_no_core_is_ok),
         ("a2", case_a2_no_core_but_live_watcher_is_not_called_unexpected),
+        ("a3", case_a3_stale_heartbeat_no_trees_claims_only_what_it_measured),
+        ("a4", case_a4_unavailable_process_probe_is_not_an_absent_watcher),
         ("b", case_b_sentinel_absent_warns),
         ("c", case_c_dead_pid_warns),
         ("d", case_d_pid_reuse_warns),

--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -12,6 +12,8 @@ and the watcher is not.
 Covers:
   a) no core alive → ok (watcher not expected; must not latch red on hosts
      that simply aren't running Sutando)
+  a2) no core alive but a watcher IS running → still ok, yet the detail must
+     not say "not expected" and must name the pid it measured
   b) core alive, sentinel absent → warn
   c) core alive, sentinel holds a dead PID → warn (crashed, sentinel left behind)
   d) core alive, PID alive but argv is not the watcher → warn (PID reuse)
@@ -480,6 +482,20 @@ def case_a_no_core_is_ok() -> list[str]:
     return []
 
 
+def case_a2_no_core_but_live_watcher_is_not_called_unexpected() -> list[str]:
+    # The gate stays green, but a watcher IS running, so "not expected" is a
+    # false premise and that green would assert nothing about the watcher.
+    r = run_check(core_alive=False, pid_text=None, trees={"11464": ["11464"]})
+    out = []
+    if r["status"] != "ok":
+        out.append(f"a2) must stay ok (anti-latch), got {r['status']}")
+    if "not expected" in r["detail"]:
+        out.append(f"a2) claims 'not expected' with a watcher alive: {r['detail']}")
+    if "11464" not in r["detail"]:
+        out.append(f"a2) does not name the watcher it measured: {r['detail']}")
+    return out
+
+
 def case_b_sentinel_absent_warns() -> list[str]:
     r = run_check(core_alive=True, pid_text=None)
     if r["status"] != "warn":
@@ -724,6 +740,7 @@ def case_q_trees_swallows_probe_failure() -> list[str]:
 def main() -> int:
     cases = [
         ("a", case_a_no_core_is_ok),
+        ("a2", case_a2_no_core_but_live_watcher_is_not_called_unexpected),
         ("b", case_b_sentinel_absent_warns),
         ("c", case_c_dead_pid_warns),
         ("d", case_d_pid_reuse_warns),


### PR DESCRIPTION
## The defect

With no live core heartbeat, `check_task_watcher` returned `ok — no core running — watcher not expected` **without looking at the watcher at all**.

Observed on a live host: the core heartbeat was 5.1 min stale while watcher pid 11464 was alive and draining `tasks/`. In that window the probe is green on a false premise, and — the part that matters — it asserts nothing about the watcher, so **a watcher death during heartbeat staleness is invisible**.

That is strictly worse than the two cases already fixed in this lane (#3188, #3190). Those printed a *wrong detail*; a wrong detail is at least a checkable claim. This prints a green that measured nothing.

The staleness half is not hypothetical: it was observed the same hour, when the gateway sidecar dropped to `connected:false` (`Errno 54`, backoff 1→2). Every process stayed up and it self-healed — which is exactly the window in which the watcher is unwatched.

## The fix, and what it deliberately does NOT do

**The gate is kept.** A check that sits red on every host not currently running Sutando carries the same information as one that is always green, and the docstring already says so. Removing the gate would have been the over-broad cut — the same mistake #3188's first attempt made, where keying on the row *name* would have hidden a true gap.

Instead it **measures before claiming**:

| state | before | after |
|---|---|---|
| no core, no watcher | `ok — no core running — watcher not expected` | `ok — no core running and no watcher process — watcher not expected` |
| no core, watcher alive | *same line* (false premise, asserts nothing) | `ok — no live core heartbeat, but N watcher tree(s) alive (pids …) — watcher health is NOT asserted while the core signal is stale` |

Still green in both cases, so nothing latches. The second line no longer claims something false, names the pids it actually found, and states outright what it is not asserting.

## Evidence

**Mutation-verified** — the new case fails against this commit's parent:

```
$ git checkout -- src/health-check.py    # revert to main's probe
$ python3 tests/health-check-task-watcher.test.py
    ✗ case a2
        a2) claims 'not expected' with a watcher alive: no core running — watcher not expected
        a2) does not name the watcher it measured: no core running — watcher not expected
  2 failure(s)
  exit=1

$ # with the fix restored
$ python3 tests/health-check-task-watcher.test.py ; echo exit=$?
  Task-watcher liveness invariants hold.
  exit=0
```

Gates and neighbours, all on the committed diff:

```
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
lint-sutando-home-path: clean (1289 files)
lint-claude-home-path:  clean (206 files)
py_compile src/health-check.py: OK
tests/health-check-task-watcher.test.py                  PASS
tests/health-check-supervised-watcher-not-orphan.test.py PASS
tests/health-check-codex-task-notifier.test.py           PASS
```

Live regression on a host **with** a core running (the gate is not hit, so the normal path must be untouched):

```
✓ task-watcher    ok    streaming watcher alive (pid 25109)
```

## Notes for review

- **Extends `tests/health-check-task-watcher.test.py`** rather than adding a suite, so the existing CI registration keeps covering it — no new `ci.yml` entry needed.
- The suite's docstring carries a case index; `a2` was added there too, so the list stays complete.
- I did **not** reproduce the defect by killing this host's core heartbeat to make the line print live. Deliberately: the probe's own logic is exercised by the stubs, and stopping a running core to demonstrate a health-check string would be a poor trade. The 5.1-min-stale observation it is based on was recorded when it happened, not manufactured.

Closes the fourth site called out in the probe-legibility sweep (roadmap track 8), which had been queued and never PR'd.

Reported by Sutando (@sutando-qingyun-001:ag2.space).

---
**Merge-order note (answering yixuan-ag2's cross-PR finding on #3214, 2026-08-22):** this PR and #3214 both rewrite `check_task_watcher` and both edit `tests/health-check-task-watcher.test.py`, independently. **Order: #3214 lands first; this PR (#3246) rebases onto it and owns the FINAL shape of `check_task_watcher`.** After that rebase, reviewers with open findings here (incl. @keweichen's empty-`_watcher_trees()` blocker) should re-verify against the post-rebase head — a clean merge of two independent rewrites is exactly the case where a stale verification silently survives.
