### PR TITLE
feat(outbox): content-digest dedup — a changed recreated result is a follow-up, not a suppressed double-send

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/outbox.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox.py
@@ -41,7 +41,7 @@ CLAIMS_DIR = ".claims"
 LOCKS_DIR = ".claim-locks"
 ITEMS_DIR = ".items"
 TERMINAL_RECEIPTS_DIR = ".terminal-receipts"
-TERMINAL_RECEIPT_SCHEMA = 1
+TERMINAL_RECEIPT_SCHEMA = 2
 TERMINAL_RECEIPT_TTL_S = 30 * 86400.0
 TERMINAL_RECEIPT_MAX_RECORDS = 100_000
 TERMINAL_RECEIPT_MAX_BYTES = 16 * 1024
@@ -756,12 +756,17 @@ class TerminalReceipt:
     generation: int
     disposition: Optional[TerminalDisposition] = None
     recorded_at: Optional[float] = None
+    # sha256 of the delivered body (None for NO_SEND/DEDUPED). A recreated
+    # result whose digest DIFFERS is a follow-up, not a suppressed double-send.
+    content_digest: Optional[str] = None
 
     def __post_init__(self) -> None:
         terminal = self.state is TerminalReceiptState.TERMINAL
         if ((self.disposition is not None) is not terminal
                 or (self.recorded_at is not None) is not terminal):
             raise ValueError("a terminal state has a disposition and timestamp")
+        if self.content_digest is not None and not terminal:
+            raise ValueError("only a terminal state carries a content digest")
 
 
 @dataclass(frozen=True)
@@ -801,13 +806,15 @@ def _terminal_receipt_path(root: Path, item_id: str, generation: int) -> Path:
 
 
 def _terminal_payload(item_id: str, generation: int,
-                      disposition: TerminalDisposition, recorded_at: float) -> dict:
+                      disposition: TerminalDisposition, recorded_at: float,
+                      content_digest: Optional[str] = None) -> dict:
     base = {
         "schema": TERMINAL_RECEIPT_SCHEMA,
         "item_id": item_id,
         "generation": generation,
         "disposition": disposition.value,
         "recorded_at": recorded_at,
+        "content_digest": content_digest,
     }
     canonical = json.dumps(base, ensure_ascii=False, sort_keys=True,
                            separators=(",", ":"), allow_nan=False).encode("utf-8")
@@ -852,7 +859,7 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     except (UnicodeDecodeError, json.JSONDecodeError):
         return _unknown_terminal(item_id, generation)
     fields = {"schema", "item_id", "generation", "disposition",
-              "recorded_at", "checksum"}
+              "recorded_at", "content_digest", "checksum"}
     if not isinstance(data, dict) or set(data) != fields:
         return _unknown_terminal(item_id, generation)
     if data.get("schema") != TERMINAL_RECEIPT_SCHEMA:
@@ -876,6 +883,10 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
         disposition = TerminalDisposition(data.get("disposition"))
     except (TypeError, ValueError):
         return _unknown_terminal(item_id, generation)
+    content_digest = data.get("content_digest")
+    if content_digest is not None and (not isinstance(content_digest, str)
+                                       or not content_digest):
+        return _unknown_terminal(item_id, generation)
     expected_name = f"{_terminal_digest(stored_item, stored_generation)}.json"
     if path.name != expected_name or path.parent.name != expected_name[:2]:
         return _unknown_terminal(item_id, generation)
@@ -886,7 +897,8 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     if not isinstance(checksum, str) or checksum != hashlib.sha256(canonical).hexdigest():
         return _unknown_terminal(item_id, generation)
     return TerminalReceipt(TerminalReceiptState.TERMINAL, stored_item,
-                           stored_generation, disposition, float(recorded_at))
+                           stored_generation, disposition, float(recorded_at),
+                           content_digest)
 
 
 def _terminal_clock_and_ttl(now: Optional[float],
@@ -961,8 +973,18 @@ def record_terminal_receipt(
     generation: int = 0,
     now: Optional[float] = None,
     ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+    content_digest: Optional[str] = None,
 ) -> TerminalReceipt:
-    """Persist one terminal outcome. The first valid or corrupt record wins."""
+    """Persist one terminal outcome.
+
+    Idempotent for identical content: a re-record with the same
+    ``content_digest`` returns the standing receipt (the crash-retry and
+    double-send guard). A re-record whose ``content_digest`` DIFFERS replaces
+    it — that is a follow-up/revision on the same item, delivered anew.
+    """
+    if content_digest is not None and (not isinstance(content_digest, str)
+                                       or not content_digest):
+        raise ValueError("content_digest must be a non-empty string or None")
     _terminal_identity(item_id, generation)
     try:
         terminal = TerminalDisposition(disposition)
@@ -974,7 +996,8 @@ def record_terminal_receipt(
     shard_name = digest[:2]
     path = _terminal_receipt_shard(root, digest) / f"{digest}.json"
     encoded = _terminal_bytes(
-        _terminal_payload(item_id, generation, terminal, recorded_at))
+        _terminal_payload(item_id, generation, terminal, recorded_at,
+                          content_digest))
     if len(encoded) > TERMINAL_RECEIPT_MAX_BYTES:
         raise ValueError("terminal receipt exceeds the durable record size limit")
     capacity = _terminal_shard_capacity(
@@ -990,7 +1013,10 @@ def record_terminal_receipt(
                 protected_name=path.name)
             return current
         if current.state is TerminalReceiptState.TERMINAL:
-            if recorded_at - current.recorded_at < ttl:
+            # Same content within TTL is the double-send/crash-retry to suppress;
+            # different content is a follow-up: fall through to replace it.
+            if (recorded_at - current.recorded_at < ttl
+                    and current.content_digest == content_digest):
                 _cleanup_terminal_receipt_shard_locked(
                     root, shard_name, recorded_at, ttl, capacity,
                     protected_name=path.name)
@@ -1021,7 +1047,8 @@ def record_terminal_receipt(
                 return _read_terminal_path(path, item_id, generation)
             _fsync_directory(directory)
             return TerminalReceipt(TerminalReceiptState.TERMINAL, item_id,
-                                   generation, terminal, recorded_at)
+                                   generation, terminal, recorded_at,
+                                   content_digest)
         finally:
             tmp.unlink(missing_ok=True)
             _fsync_directory(directory)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 
 import asyncio
+import hashlib
 import json
 import os
 import uuid
@@ -4518,10 +4519,45 @@ def _terminal_receipt_state(task_id: str):
     return outbox.TerminalReceiptState.UNKNOWN
 
 
-def _record_terminal_receipt(task_id: str, disposition) -> bool:
+def _result_body_digest(task_id: str) -> str | None:
+    """sha256 of the raw result file, or None if it cannot be read.
+
+    Digests the bytes the producer wrote, so a recreated file with identical
+    content matches and a follow-up/revision with changed content does not.
+    """
+    try:
+        return hashlib.sha256(
+            (RESULTS_DIR / f"{task_id}.txt").read_bytes()).hexdigest()
+    except Exception:
+        return None
+
+
+def _recreated_should_suppress(task_id: str) -> bool:
+    """True when a recreated result repeats the delivered body (double-send).
+
+    A recreated result whose content DIFFERS from the delivered body is a
+    follow-up/revision and must be delivered, so this returns False for it.
+    Missing digest evidence (a pre-content-digest receipt or an unreadable
+    body) falls back to True — the pre-digest behavior — so the double-send
+    guard never weakens on absent information.
+    """
+    try:
+        receipt = outbox.read_terminal_receipt(_result_receipt_root(), task_id)
+    except Exception:
+        return True
+    stored = receipt.content_digest
+    current = _result_body_digest(task_id)
+    if stored is None or current is None:
+        return True
+    return stored == current
+
+
+def _record_terminal_receipt(task_id: str, disposition,
+                             content_digest: str | None = None) -> bool:
     try:
         receipt = outbox.record_terminal_receipt(
-            _result_receipt_root(), task_id, disposition)
+            _result_receipt_root(), task_id, disposition,
+            content_digest=content_digest)
         return receipt.state is outbox.TerminalReceiptState.TERMINAL
     except Exception as exc:
         print(f"  [delivered] receipt write failed for {task_id}: {exc}", flush=True)
@@ -4537,8 +4573,14 @@ def _mark_legacy_delivered(task_id: str) -> None:
 
 
 def _mark_delivered(task_id: str) -> None:
-    """Persist terminal delivery immediately after successful provider I/O."""
-    _record_terminal_receipt(task_id, outbox.TerminalDisposition.DELIVERED)
+    """Persist terminal delivery immediately after successful provider I/O.
+
+    Records the delivered body's digest so a later recreation with the SAME
+    content is suppressed while a follow-up/revision (different content) is
+    delivered anew.
+    """
+    _record_terminal_receipt(task_id, outbox.TerminalDisposition.DELIVERED,
+                             content_digest=_result_body_digest(task_id))
     _mark_legacy_delivered(task_id)
     # §7 audit ledger (Result Router S5): one line per delivered result, so
     # "did the user see this?" is answerable without grepping bridge logs. This
@@ -4732,7 +4774,8 @@ async def poll_results():
         )
         for task_id, channel_id_str in _adopted.items():
             _receipt_state = _terminal_receipt_state(task_id)
-            if _receipt_state is outbox.TerminalReceiptState.TERMINAL:
+            if (_receipt_state is outbox.TerminalReceiptState.TERMINAL
+                    and _recreated_should_suppress(task_id)):
                 result_file = RESULTS_DIR / f"{task_id}.txt"
                 if _archive_delivered_pair(result_file, task_id):
                     result_audit.record(task_id, "deduped", "discord")
@@ -4740,6 +4783,8 @@ async def poll_results():
                 continue
             if _receipt_state is outbox.TerminalReceiptState.UNKNOWN:
                 continue
+            # A differing recreated body fell through here: route it for
+            # delivery as a follow-up/revision.
             _recovered_replies.setdefault(task_id, channel_id_str)
 
         # Merge recovered replies into pending_replies (resolve channel objects)
@@ -4757,7 +4802,8 @@ async def poll_results():
             if result_file.exists():
                 import re
                 _receipt_state = _terminal_receipt_state(task_id)
-                if _receipt_state is outbox.TerminalReceiptState.TERMINAL:
+                if (_receipt_state is outbox.TerminalReceiptState.TERMINAL
+                        and _recreated_should_suppress(task_id)):
                     pending_replies.pop(task_id, None)
                     pending_reply_anchors.pop(task_id, None)
                     pending_task_tiers.pop(task_id, None)
@@ -4768,6 +4814,8 @@ async def poll_results():
                     continue
                 if _receipt_state is outbox.TerminalReceiptState.UNKNOWN:
                     continue
+                # TERMINAL-but-differing falls through here as a follow-up: the
+                # recreated body is delivered and _mark_delivered re-receipts it.
                 reply_text = read_ready_result(result_file)
                 if reply_text is None:
                     await _note_empty_result(task_id, result_file)

--- a/src/outbox.py
+++ b/src/outbox.py
@@ -41,7 +41,7 @@ CLAIMS_DIR = ".claims"
 LOCKS_DIR = ".claim-locks"
 ITEMS_DIR = ".items"
 TERMINAL_RECEIPTS_DIR = ".terminal-receipts"
-TERMINAL_RECEIPT_SCHEMA = 1
+TERMINAL_RECEIPT_SCHEMA = 2
 TERMINAL_RECEIPT_TTL_S = 30 * 86400.0
 TERMINAL_RECEIPT_MAX_RECORDS = 100_000
 TERMINAL_RECEIPT_MAX_BYTES = 16 * 1024
@@ -756,12 +756,17 @@ class TerminalReceipt:
     generation: int
     disposition: Optional[TerminalDisposition] = None
     recorded_at: Optional[float] = None
+    # sha256 of the delivered body (None for NO_SEND/DEDUPED). A recreated
+    # result whose digest DIFFERS is a follow-up, not a suppressed double-send.
+    content_digest: Optional[str] = None
 
     def __post_init__(self) -> None:
         terminal = self.state is TerminalReceiptState.TERMINAL
         if ((self.disposition is not None) is not terminal
                 or (self.recorded_at is not None) is not terminal):
             raise ValueError("a terminal state has a disposition and timestamp")
+        if self.content_digest is not None and not terminal:
+            raise ValueError("only a terminal state carries a content digest")
 
 
 @dataclass(frozen=True)
@@ -801,13 +806,15 @@ def _terminal_receipt_path(root: Path, item_id: str, generation: int) -> Path:
 
 
 def _terminal_payload(item_id: str, generation: int,
-                      disposition: TerminalDisposition, recorded_at: float) -> dict:
+                      disposition: TerminalDisposition, recorded_at: float,
+                      content_digest: Optional[str] = None) -> dict:
     base = {
         "schema": TERMINAL_RECEIPT_SCHEMA,
         "item_id": item_id,
         "generation": generation,
         "disposition": disposition.value,
         "recorded_at": recorded_at,
+        "content_digest": content_digest,
     }
     canonical = json.dumps(base, ensure_ascii=False, sort_keys=True,
                            separators=(",", ":"), allow_nan=False).encode("utf-8")
@@ -852,7 +859,7 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     except (UnicodeDecodeError, json.JSONDecodeError):
         return _unknown_terminal(item_id, generation)
     fields = {"schema", "item_id", "generation", "disposition",
-              "recorded_at", "checksum"}
+              "recorded_at", "content_digest", "checksum"}
     if not isinstance(data, dict) or set(data) != fields:
         return _unknown_terminal(item_id, generation)
     if data.get("schema") != TERMINAL_RECEIPT_SCHEMA:
@@ -876,6 +883,10 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
         disposition = TerminalDisposition(data.get("disposition"))
     except (TypeError, ValueError):
         return _unknown_terminal(item_id, generation)
+    content_digest = data.get("content_digest")
+    if content_digest is not None and (not isinstance(content_digest, str)
+                                       or not content_digest):
+        return _unknown_terminal(item_id, generation)
     expected_name = f"{_terminal_digest(stored_item, stored_generation)}.json"
     if path.name != expected_name or path.parent.name != expected_name[:2]:
         return _unknown_terminal(item_id, generation)
@@ -886,7 +897,8 @@ def _read_terminal_path(path: Path, item_id: Optional[str] = None,
     if not isinstance(checksum, str) or checksum != hashlib.sha256(canonical).hexdigest():
         return _unknown_terminal(item_id, generation)
     return TerminalReceipt(TerminalReceiptState.TERMINAL, stored_item,
-                           stored_generation, disposition, float(recorded_at))
+                           stored_generation, disposition, float(recorded_at),
+                           content_digest)
 
 
 def _terminal_clock_and_ttl(now: Optional[float],
@@ -961,8 +973,18 @@ def record_terminal_receipt(
     generation: int = 0,
     now: Optional[float] = None,
     ttl_seconds: float = TERMINAL_RECEIPT_TTL_S,
+    content_digest: Optional[str] = None,
 ) -> TerminalReceipt:
-    """Persist one terminal outcome. The first valid or corrupt record wins."""
+    """Persist one terminal outcome.
+
+    Idempotent for identical content: a re-record with the same
+    ``content_digest`` returns the standing receipt (the crash-retry and
+    double-send guard). A re-record whose ``content_digest`` DIFFERS replaces
+    it — that is a follow-up/revision on the same item, delivered anew.
+    """
+    if content_digest is not None and (not isinstance(content_digest, str)
+                                       or not content_digest):
+        raise ValueError("content_digest must be a non-empty string or None")
     _terminal_identity(item_id, generation)
     try:
         terminal = TerminalDisposition(disposition)
@@ -974,7 +996,8 @@ def record_terminal_receipt(
     shard_name = digest[:2]
     path = _terminal_receipt_shard(root, digest) / f"{digest}.json"
     encoded = _terminal_bytes(
-        _terminal_payload(item_id, generation, terminal, recorded_at))
+        _terminal_payload(item_id, generation, terminal, recorded_at,
+                          content_digest))
     if len(encoded) > TERMINAL_RECEIPT_MAX_BYTES:
         raise ValueError("terminal receipt exceeds the durable record size limit")
     capacity = _terminal_shard_capacity(
@@ -990,7 +1013,10 @@ def record_terminal_receipt(
                 protected_name=path.name)
             return current
         if current.state is TerminalReceiptState.TERMINAL:
-            if recorded_at - current.recorded_at < ttl:
+            # Same content within TTL is the double-send/crash-retry to suppress;
+            # different content is a follow-up: fall through to replace it.
+            if (recorded_at - current.recorded_at < ttl
+                    and current.content_digest == content_digest):
                 _cleanup_terminal_receipt_shard_locked(
                     root, shard_name, recorded_at, ttl, capacity,
                     protected_name=path.name)
@@ -1021,7 +1047,8 @@ def record_terminal_receipt(
                 return _read_terminal_path(path, item_id, generation)
             _fsync_directory(directory)
             return TerminalReceipt(TerminalReceiptState.TERMINAL, item_id,
-                                   generation, terminal, recorded_at)
+                                   generation, terminal, recorded_at,
+                                   content_digest)
         finally:
             tmp.unlink(missing_ok=True)
             _fsync_directory(directory)

--- a/tests/discord-recreated-result-idempotency.test.py
+++ b/tests/discord-recreated-result-idempotency.test.py
@@ -244,7 +244,9 @@ class DiscordRecreatedResultTest(unittest.TestCase):
             1,
         )
 
-    def test_recreated_confirmed_result_is_retired_without_another_send(self):
+    def test_recreated_identical_suppressed_but_changed_is_delivered(self):
+        # Identical recreation is the double-send (suppressed); a recreation
+        # whose content differs is a follow-up and must be delivered.
         task_id = "task-2000000000001"
         first = "first confirmed answer"
         changed = "completion narration written after the answer"
@@ -254,18 +256,26 @@ class DiscordRecreatedResultTest(unittest.TestCase):
         self._one_pass()
         self.assertEqual(self.channel.sent, [first])
 
+        # Identical recreation -> suppressed (digest matches).
         self._forget_runtime_routes()
         self._result(task_id, first)
         self._one_pass()
+        self.assertEqual(self.channel.sent, [first])
+
+        # Changed recreation -> delivered as a follow-up (digest differs).
         self._forget_runtime_routes()
         self._result(task_id, changed)
         self._one_pass()
 
-        self.assertEqual(self.channel.sent, [first])
-        self.assertEqual(self.client.fetches, 1)
+        self.assertEqual(self.channel.sent, [first, changed])
         self.assertFalse((bridge.RESULTS_DIR / f"{task_id}.txt").exists())
         self.assertNotIn(task_id, bridge.pending_replies)
-        self.assertEqual(self._archive_bodies(task_id), sorted([first, first, changed]))
+        # A second identical recreation of the follow-up is itself suppressed:
+        # _mark_delivered re-receipted the new digest.
+        self._forget_runtime_routes()
+        self._result(task_id, changed)
+        self._one_pass()
+        self.assertEqual(self.channel.sent, [first, changed])
 
     def test_archive_failure_retries_without_send_or_audit_then_audits_once(self):
         task_id = "task-2000000000002"
@@ -349,7 +359,9 @@ class DiscordRecreatedResultTest(unittest.TestCase):
         self.assertTrue(bridge._has_durable_terminal_receipt(task_id))
         self.assertFalse(bridge._delivered_sentinel_path(task_id).exists())
 
-        self._result(task_id, "recreated after process restart")
+        # Identical content recreated after a restart is a suppressed
+        # double-send (its digest matches the receipt).
+        self._result(task_id, first)
         fresh = _load_bridge("discord_recreated_result_bridge_restart")
         fresh.REPO = WORKSPACE
         fresh.RESULTS_DIR = WORKSPACE / "results"

--- a/tests/outbox-terminal-receipts.test.py
+++ b/tests/outbox-terminal-receipts.test.py
@@ -733,6 +733,78 @@ def test_invalid_identity_and_clock_inputs_are_rejected():
                 raise AssertionError("invalid terminal receipt input was accepted")
 
 
+def test_content_digest_roundtrips_and_gates_replacement():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        item = "task-content-digest"
+        dig_a = "a" * 64
+        dig_b = "b" * 64
+
+        # First record persists the digest and read returns it.
+        r1 = outbox.record_terminal_receipt(
+            root, item, outbox.TerminalDisposition.DELIVERED,
+            now=100.0, content_digest=dig_a)
+        assert r1.state is outbox.TerminalReceiptState.TERMINAL
+        assert r1.content_digest == dig_a
+        assert outbox.read_terminal_receipt(
+            root, item, now=101.0).content_digest == dig_a
+
+        # Same digest within TTL is idempotent: the standing record wins, its
+        # timestamp does not move.
+        r2 = outbox.record_terminal_receipt(
+            root, item, outbox.TerminalDisposition.DELIVERED,
+            now=200.0, content_digest=dig_a)
+        assert r2.recorded_at == 100.0
+        assert r2.content_digest == dig_a
+
+        # A different digest is a follow-up/revision: it replaces the record.
+        r3 = outbox.record_terminal_receipt(
+            root, item, outbox.TerminalDisposition.DELIVERED,
+            now=300.0, content_digest=dig_b)
+        assert r3.recorded_at == 300.0
+        assert r3.content_digest == dig_b
+        assert outbox.read_terminal_receipt(
+            root, item, now=301.0).content_digest == dig_b
+
+
+def test_content_digest_must_be_nonempty_string_or_none():
+    with tempfile.TemporaryDirectory() as tmp:
+        for bad in ("", 123, b"x"):
+            try:
+                outbox.record_terminal_receipt(
+                    tmp, "x", outbox.TerminalDisposition.DELIVERED,
+                    now=1.0, content_digest=bad)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("invalid content_digest was accepted")
+
+
+def test_legacy_schema_receipt_reads_as_unknown():
+    # A v1 record (no content_digest field) predates this format; it must not
+    # be trusted as TERMINAL — corrupt/foreign state is UNKNOWN, never ABSENT.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        item = "task-legacy"
+        path = outbox._terminal_receipt_path(root, item, 0)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        base = {
+            "schema": 1,
+            "item_id": item,
+            "generation": 0,
+            "disposition": outbox.TerminalDisposition.DELIVERED.value,
+            "recorded_at": 100.0,
+        }
+        import hashlib as _h
+        import json as _j
+        canonical = _j.dumps(base, ensure_ascii=False, sort_keys=True,
+                             separators=(",", ":"), allow_nan=False).encode("utf-8")
+        legacy = {**base, "checksum": _h.sha256(canonical).hexdigest()}
+        path.write_bytes(outbox._terminal_bytes(legacy))
+        assert outbox.read_terminal_receipt(
+            root, item, now=101.0).state is outbox.TerminalReceiptState.UNKNOWN
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):


### PR DESCRIPTION
## What changed, and why?

Stacked on `fix/discord-result-recreation-dedup` (#3174). It reconciles the one blocker I raised in review of that PR: the terminal-receipt store keys suppression on `(item_id, generation)` alone, so **any** recreated `results/<task-id>.txt` after delivery is dropped — which forecloses a legitimate follow-up or revision on the same task.

This draws the suppression line on **content**, not existence, with no producer opt-in (no manual generation bump):

1. **Receipt carries a body digest.** `record_terminal_receipt` gains `content_digest`; the durable schema bumps to **v2** and the reader validates the new field. A v1 record (no field) reads `UNKNOWN` — never trusted as terminal, never silently ABSENT.
2. **First-wins is now content-scoped.** Within-TTL, the standing record wins only when the digest **matches** (the double-send / crash-retry guard, unchanged). A **differing** digest replaces the record — the follow-up is delivered and re-receipted.
3. **Bridge compares digests.** `discord-bridge` digests the raw result file at delivery and at each recreation: **match → suppress** (as before), **differ → deliver** as a follow-up. Absent digest evidence (a pre-v2 receipt or an unreadable body) **falls back to suppress**, so the double-send guard never weakens on missing information.

Both vendored `outbox.py` copies (`src/` and `packages/ag2-sparrow/`) stay byte-identical.

## Files to look at first

1. `src/outbox.py` — `TerminalReceipt.content_digest`, `_terminal_payload`, `_read_terminal_path` (schema v2 + validation), and the `record_terminal_receipt` replace-on-differ branch.
2. `src/discord-bridge.py` — `_result_body_digest`, `_recreated_should_suppress`, and the two suppression sites (adopted-orphan + pending-reply) that now fall through on a differing digest.
3. `tests/outbox-terminal-receipts.test.py` — `test_content_digest_roundtrips_and_gates_replacement`, `test_legacy_schema_receipt_reads_as_unknown`, `test_content_digest_must_be_nonempty_string_or_none`.
4. `tests/discord-recreated-result-idempotency.test.py` — `test_recreated_identical_suppressed_but_changed_is_delivered`.

## Before/after evidence

Store level — `test_content_digest_roundtrips_and_gates_replacement`:
```
record(dig_a) @100 -> TERMINAL, content_digest=dig_a
record(dig_a) @200 -> standing record wins, recorded_at stays 100   (idempotent)
record(dig_b) @300 -> replaced, recorded_at=300, content_digest=dig_b (follow-up)
```

Bridge level — `test_recreated_identical_suppressed_but_changed_is_delivered`:
```
deliver "first"                 -> sent == ["first"]
recreate "first" (identical)    -> sent == ["first"]            (double-send suppressed)
recreate "changed" (differs)    -> sent == ["first", "changed"] (follow-up delivered)
recreate "changed" again        -> sent == ["first", "changed"] (re-receipted, suppressed)
```

Full battery at HEAD (`/usr/bin/python3 tests/<file>`):
```
tests/outbox-terminal-receipts.test.py                     -> PASS (durable receipt contract, incl. 3 new)
tests/outbox-terminal-cleanup-coverage.test.py             -> OK (17)
tests/discord-recreated-result-idempotency.test.py         -> OK (12)
tests/discord-bridge-delivery-sentinel.test.py             -> PASS (receipt compatibility)
tests/discord-bridge-archive-failure-keeps-the-file.test.py-> OK
tests/health-check-terminal-receipts.test.py               -> OK (6)
```
`git diff | bash scripts/review-checks.sh` — PASS (hardcoded-paths + root-artifacts + prose-cap). `/usr/bin/python3 -m py_compile` on all three production files — clean. Vendored copies verified byte-identical.

## Migrations, config, permissions, rollback, deployment risks?

- **Durable-format migration (v1 → v2):** the receipt schema bumps; a v1 record reads `UNKNOWN` (fails closed — held for reconciliation, never re-sent-blind and never dropped). No live v1 receipts exist (the parent PR is unmerged). No config, no permissions change.
- **Rollback:** revert this commit; a v2 receipt then reads `UNKNOWN` under the v1 reader (same fail-closed direction), so rollback is safe.

## Live path?

Yes — this changes the Discord result delivery/suppression path. Harness evidence is complete (above). The repo-required post-restart witness — one identical recreation suppressed, one changed recreation delivered, from the installed bridge — is **pending the owner's ~60s bridge-bounce window**, the same gate the parent PR awaits; I'll attach it (journal + silent room) when granted.

## Known gaps / follow-up

- Merge order: this is stacked on #3174. If #3174 lands first, GitHub retargets this to `main`; otherwise merge parent then child. My change-request on #3174 tracks the reconciliation and points here.

Stand: Echo Act IV Mini
