### PR TITLE
feat(outbox): a delivered receipt records the provider and destination

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -18,6 +18,8 @@ class DesignAClaimBackend:
     Reclaim TTL is A's dead-owner recovery window; force-release exists
     (declared) as the administrative-destruction mechanism."""
 
+    persists_receipt_metadata = True   # record_delivered() stores both
+
     capabilities = BackendCapabilities(supports_force_release=True)
 
     def __init__(self, root: Path, reclaim_ttl_s: float = 300.0):

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -78,7 +78,9 @@ class DesignAClaimBackend:
                               incarnation=incarnation)
 
     def complete(self, token: ClaimToken, outcome: DeliveryOutcome,
-                 park_at_attempts: Optional[int] = None) -> bool:
+                 park_at_attempts: Optional[int] = None,
+                 provider: Optional[str] = None,
+                 destination: Optional[str] = None) -> bool:
         item_id = token.item_id
         # Validate -> transition -> retire, all under the item lock: a stale
         # incarnation must not mutate or park its successor's item.
@@ -88,9 +90,8 @@ class DesignAClaimBackend:
                     self._incarnation_of(item_id) != token.incarnation:
                 return False
             if outcome is DeliveryOutcome.CONFIRMED:
-                d = outbox._read_item(self.root, item_id)
-                d["status"] = "DELIVERED"
-                outbox._write_item(self.root, item_id, d)
+                outbox.record_delivered(self.root, item_id,
+                                        provider=provider, destination=destination)
             elif outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
                 outbox.park_item(self.root, item_id, "outcome-unknown")
             else:

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_c.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_c.py
@@ -196,7 +196,9 @@ class DesignCClaimBackend:
                               incarnation=fname)
 
     def complete(self, token: ClaimToken, outcome: DeliveryOutcome,
-                 park_at_attempts: Optional[int] = None) -> bool:
+                 park_at_attempts: Optional[int] = None,
+                 provider: Optional[str] = None,
+                 destination: Optional[str] = None) -> bool:
         parts = token.incarnation.split(SEP)
         if len(parts) != TOKEN_PARTS or parts[1] != _safe_component(token.worker):
             return False                    # forged: worker != the record's

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_c.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_c.py
@@ -91,6 +91,10 @@ class DesignCClaimBackend:
     """C: one live object per item, moved between state directories under a
     striped host-local lock. force-release exists as administrative requeue."""
 
+    # The FILENAME is the record here — an archived rename carries no field
+    # to hold receipt metadata, so complete() accepts and drops it.
+    persists_receipt_metadata = False
+
     capabilities = BackendCapabilities(supports_force_release=True)
 
     def __init__(self, root: Path, activate: bool = False):

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -80,6 +80,9 @@ class DeliveryReceipt:
     outcome: DeliveryOutcome
     provider_ref: Optional[str] = None
     detail: str = ""
+    # Where the side effect landed, in the provider's own address space.
+    # Only the provider knows this; the core must not infer it.
+    destination: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -173,7 +173,9 @@ class ClaimBackend(Protocol):
         ...
 
     def complete(self, token: ClaimToken, outcome: DeliveryOutcome,
-                 park_at_attempts: Optional[int] = None) -> bool:
+                 park_at_attempts: Optional[int] = None,
+                 provider: Optional[str] = None,
+                 destination: Optional[str] = None) -> bool:
         """Validate the exact incarnation, apply the outcome transition, and
         retire the claim — ALL inside one backend critical section, in that
         order. A stale token must change nothing: validating after mutating

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -172,6 +172,10 @@ class ClaimBackend(Protocol):
         """Acquire exclusive local ownership, or None on a lost race."""
         ...
 
+    # False = complete() accepts provider/destination and DROPS them.
+    # Check this; a signature does not imply durable storage.
+    persists_receipt_metadata: bool = False
+
     def complete(self, token: ClaimToken, outcome: DeliveryOutcome,
                  park_at_attempts: Optional[int] = None,
                  provider: Optional[str] = None,

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
@@ -56,12 +56,11 @@ class DeliveryCore:
         violation) propagates rather than masquerading as ambiguity."""
         try:
             receipt = self.provider.deliver(item_id, payload, key)
-            self._last_destination = getattr(receipt, "destination", None)
-            return receipt.outcome
+            return receipt.outcome, getattr(receipt, "destination", None)
         except ProviderIndeterminate:
-            return DeliveryOutcome.OUTCOME_UNKNOWN
+            return DeliveryOutcome.OUTCOME_UNKNOWN, None
         except ProviderRefused:
-            return DeliveryOutcome.NOT_DELIVERED
+            return DeliveryOutcome.NOT_DELIVERED, None
 
     def _reconcile(self, item_id: str, payload: bytes, key: str):
         """Resolve a prior ambiguity, or None when reconciliation resolved
@@ -79,7 +78,9 @@ class DeliveryCore:
                 DeliveryAttempt(item_id, payload, key))
         except (ProviderIndeterminate, ProviderRefused):
             return None
-        return None if resolved is None else resolved.outcome
+        if resolved is None:
+            return None
+        return resolved.outcome, getattr(resolved, "destination", None)
 
     def deliver_one(self, item_id: str, payload: bytes) -> DrainResult:
         """Claim -> deliver -> classify -> complete, with retry accounting."""
@@ -89,15 +90,17 @@ class DeliveryCore:
             # no external ambiguity to report — this is not an outcome.
             return DrainResult(status=DrainStatus.NOT_CLAIMED)
         key = idempotency_key(item_id)
-        outcome = self._attempt(item_id, payload, key)
+        outcome, destination = self._attempt(item_id, payload, key)
         if outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
             caps = self.provider.capabilities
             if caps.reconcile_capable:
                 resolved = self._reconcile(item_id, payload, key)
                 if resolved is not None:
-                    outcome = resolved
+                    # The reconciliation receipt is the statement about THIS
+                    # item; its destination replaces the ambiguous attempt's.
+                    outcome, destination = resolved
             elif caps.idempotent_send:
-                outcome = self._attempt(item_id, payload, key)
+                outcome, destination = self._attempt(item_id, payload, key)
                 if outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
                     # Retryable by license: parking would strand an item a
                     # later safe re-send could still deliver.
@@ -107,7 +110,7 @@ class DeliveryCore:
         self.backend.complete(token, outcome,
                               park_at_attempts=self.policy.max_attempts,
                               provider=type(self.provider).__name__,
-                              destination=getattr(self, "_last_destination", None))
+                              destination=destination)
         return DrainResult(status=DrainStatus.ATTEMPTED, outcome=outcome)
 
     def recover(self) -> RecoverReport:

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
@@ -55,7 +55,9 @@ class DeliveryCore:
         NOT_DELIVERED; anything else (programming, config, capability
         violation) propagates rather than masquerading as ambiguity."""
         try:
-            return self.provider.deliver(item_id, payload, key).outcome
+            receipt = self.provider.deliver(item_id, payload, key)
+            self._last_destination = getattr(receipt, "destination", None)
+            return receipt.outcome
         except ProviderIndeterminate:
             return DeliveryOutcome.OUTCOME_UNKNOWN
         except ProviderRefused:
@@ -103,7 +105,9 @@ class DeliveryCore:
         # The ceiling rides WITH the completion: parking after the claim
         # is released lets a successor confirm in the gap.
         self.backend.complete(token, outcome,
-                              park_at_attempts=self.policy.max_attempts)
+                              park_at_attempts=self.policy.max_attempts,
+                              provider=type(self.provider).__name__,
+                              destination=getattr(self, "_last_destination", None))
         return DrainResult(status=DrainStatus.ATTEMPTED, outcome=outcome)
 
     def recover(self) -> RecoverReport:

--- a/packages/ag2-sparrow/ag2_sparrow/outbox.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox.py
@@ -686,6 +686,24 @@ def _write_item(root: Path, item_id: str, data: dict) -> None:
     os.replace(tmp, p)
 
 
+def record_delivered(root: Path, item_id: str, *, provider: Optional[str] = None,
+                     destination: Optional[str] = None) -> None:
+    """Mark an item delivered and persist WHERE it went.
+
+    The log line naming provider/destination rotates; a receipt that omits them
+    cannot answer "delivered to where" after that. Absent values are not stored,
+    so items written before this existed read back as None rather than as a
+    destination nobody observed.
+    """
+    d = _read_item(Path(root), item_id)
+    d["status"] = "DELIVERED"
+    if provider:
+        d["provider"] = provider
+    if destination:
+        d["destination"] = destination
+    _write_item(Path(root), item_id, d)
+
+
 def attempts_for(root: Path, item_id: str) -> int:
     return int(_read_item(Path(root), item_id).get("attempts", 0))
 

--- a/src/outbox.py
+++ b/src/outbox.py
@@ -686,6 +686,24 @@ def _write_item(root: Path, item_id: str, data: dict) -> None:
     os.replace(tmp, p)
 
 
+def record_delivered(root: Path, item_id: str, *, provider: Optional[str] = None,
+                     destination: Optional[str] = None) -> None:
+    """Mark an item delivered and persist WHERE it went.
+
+    The log line naming provider/destination rotates; a receipt that omits them
+    cannot answer "delivered to where" after that. Absent values are not stored,
+    so items written before this existed read back as None rather than as a
+    destination nobody observed.
+    """
+    d = _read_item(Path(root), item_id)
+    d["status"] = "DELIVERED"
+    if provider:
+        d["provider"] = provider
+    if destination:
+        d["destination"] = destination
+    _write_item(Path(root), item_id, d)
+
+
 def attempts_for(root: Path, item_id: str) -> int:
     return int(_read_item(Path(root), item_id).get("attempts", 0))
 

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -471,8 +471,8 @@ class CorePolicy(unittest.TestCase):
                             RetryPolicy(max_attempts=1))
         real_complete, fired, confirmed = self.backend.complete, [], []
 
-        def racing_complete(token, outcome, park_at_attempts=None):
-            ok = real_complete(token, outcome, park_at_attempts)
+        def racing_complete(token, outcome, park_at_attempts=None, **kw):
+            ok = real_complete(token, outcome, park_at_attempts, **kw)
             if not fired:                     # the gap: successor gets in
                 fired.append(True)
                 t2 = self.backend.claim(ITEM, "successor")

--- a/tests/outbox-receipt-destination.test.py
+++ b/tests/outbox-receipt-destination.test.py
@@ -61,6 +61,53 @@ def main() -> int:
         check(DeliveryReceipt(outcome=DeliveryOutcome.CONFIRMED).destination is None,
               "destination defaults to None so existing providers keep working")
 
+        # --- receipt metadata must stay LOCAL to the delivery it came from ---
+        from ag2_sparrow.delivery_core import (DeliveryCore, DesignAClaimBackend,
+                                               RetryPolicy)
+        from ag2_sparrow.delivery_core.contract import (DeliveryReceipt,
+                                                        DeliveryOutcome,
+                                                        ProviderCapabilities,
+                                                        ProviderIndeterminate)
+
+        class TwoItemProvider:
+            """A confirms with X; B is ambiguous then confirmed by reconcile
+            with Y. B must never inherit A's destination."""
+            capabilities = ProviderCapabilities(reconcile_capable=True,
+                                                idempotent_send=False)
+
+            def deliver(self, item_id, payload, key):
+                if item_id == "A":
+                    return DeliveryReceipt(outcome=DeliveryOutcome.CONFIRMED,
+                                           destination="room-X")
+                # RAISING is the leak vector: an except-path return never
+                # touches a stale field, so A's value would survive into B.
+                raise ProviderIndeterminate("boundary crossed, outcome unknown")
+
+            def reconcile(self, attempt):
+                return DeliveryReceipt(outcome=DeliveryOutcome.CONFIRMED,
+                                       destination="room-Y")
+
+        root = Path(td) / "ob"
+        backend = DesignAClaimBackend(root)
+        core = DeliveryCore(backend, TwoItemProvider(),
+                            policy=RetryPolicy(max_attempts=3), worker="w")
+        for iid in ("A", "B"):
+            backend.publish(iid, b"{}")     # claim() needs a published item
+            core.deliver_one(iid, b"{}")
+        a = outbox._read_item(root, "A"); b = outbox._read_item(root, "B")
+        check(a.get("destination") == "room-X", f"A keeps its own destination, got {a.get('destination')}")
+        check(b.get("destination") == "room-Y",
+              f"B confirmed via reconcile carries the RECONCILE receipt's destination, got {b.get('destination')}")
+        check(b.get("destination") != "room-X",
+              "B did NOT inherit A's destination (cross-item metadata leak)")
+
+        # --- an accepted argument must not be mistaken for durable storage ---
+        from ag2_sparrow.delivery_core.backend_c import DesignCClaimBackend
+        check(DesignAClaimBackend.persists_receipt_metadata is True,
+              "Design A declares it persists receipt metadata")
+        check(DesignCClaimBackend.persists_receipt_metadata is False,
+              "Design C declares it does NOT — it accepts and drops")
+
     print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
     return 1 if failures else 0
 

--- a/tests/outbox-receipt-destination.test.py
+++ b/tests/outbox-receipt-destination.test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""A delivered item must record WHERE it went, durably.
+
+The provider/destination line is logged, and logs rotate; after that the
+receipt is the only thing that can answer "delivered to where". Absent values
+must stay absent rather than becoming a destination nobody observed.
+"""
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
+
+spec = importlib.util.spec_from_file_location("outbox", REPO / "src" / "outbox.py")
+outbox = importlib.util.module_from_spec(spec)
+# Register before exec: @dataclass resolves annotations via sys.modules[__module__].
+sys.modules["outbox"] = outbox
+spec.loader.exec_module(outbox)
+
+failures = []
+
+
+def check(cond, label):
+    print(("PASS: " if cond else "FAIL: ") + label)
+    if not cond:
+        failures.append(label)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+
+        outbox.record_delivered(root, "task-A", provider="AG2SpaceResultProvider",
+                                destination="!room:ag2.space")
+        a = outbox._read_item(root, "task-A")
+        check(a.get("status") == "DELIVERED", "records the DELIVERED status")
+        check(a.get("provider") == "AG2SpaceResultProvider", "persists the provider")
+        check(a.get("destination") == "!room:ag2.space", "persists the destination")
+
+        # Back-compat: a caller with nothing to assert must not invent one.
+        outbox.record_delivered(root, "task-B")
+        b = outbox._read_item(root, "task-B")
+        check(b.get("status") == "DELIVERED", "still marks delivered without a destination")
+        check("destination" not in b, "absent destination is OMITTED, not stored as null")
+        check("provider" not in b, "absent provider is OMITTED, not stored as null")
+
+        # An item written before this existed reads back as None, not as a guess.
+        outbox._write_item(root, "task-legacy", {"item_id": "task-legacy",
+                                                 "status": "DELIVERED", "attempts": 1})
+        legacy = outbox._read_item(root, "task-legacy")
+        check(legacy.get("destination") is None,
+              "a pre-existing item reports destination None rather than a fabricated value")
+
+        # The receipt type must be able to carry it, or the provider cannot report it.
+        from ag2_sparrow.delivery_core.contract import DeliveryReceipt, DeliveryOutcome
+        r = DeliveryReceipt(outcome=DeliveryOutcome.CONFIRMED, destination="!x:y")
+        check(r.destination == "!x:y", "DeliveryReceipt carries a destination")
+        check(DeliveryReceipt(outcome=DeliveryOutcome.CONFIRMED).destination is None,
+              "destination defaults to None so existing providers keep working")
+
+    print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed, and why?

A delivered outbox item recorded **that** it was delivered, never **where**. Measured on two live AG2 Space round trips today:

```
$ python3 -c "...json.load(item)"   # after a real, confirmed delivery
keys: ['item_id', 'payload', 'published_at', 'status']
  status: "DELIVERED"
```

The provider/backend/worker line exists only in a rotating log:

```
[remote-gateway-bridge] result task-cb05… delivered via DeliveryCore
  (provider=AG2SpaceResultProvider, backend=DesignAClaimBackend, worker=gateway-result-drain)
```

So once that log rotates, nothing durable can answer "delivered to where" — which is the question the whole outbound-convergence effort exists to make answerable.

## Shape

Per the repo's shared-record rule, the dependency-light owner defines the schema and adapters inject values:

- **`src/outbox.py`** gains `record_delivered(root, item_id, *, provider=None, destination=None)` — the one writer of the DELIVERED transition and of these fields.
- **`DeliveryReceipt`** gains an optional `destination` — the provider's own address space; the core must not infer it.
- **`DeliveryCore`** keeps the receipt it already built (`_attempt` previously discarded everything but `.outcome`) and threads `provider` + `destination` into `backend.complete()`.
- **`DesignAClaimBackend.complete()`** records through the owner API instead of hand-writing `d["status"]`.

`outbox.py` is MAP-canonical, so it was re-synced into `packages/ag2-sparrow/`; `tests/ag2-sparrow-drift.test.py` passes.

## Back-compat is the point, not a footnote

Absent values are **omitted**, never stored as null. 256 items already exist without these fields; a backfill would assert a destination nobody observed, which is precisely the failure this PR exists to prevent.

```
PASS: absent destination is OMITTED, not stored as null
PASS: a pre-existing item reports destination None rather than a fabricated value
PASS: destination defaults to None so existing providers keep working
```

Mutation-verified rather than assumed — changing the writer to store unconditionally:

```
FAIL: absent destination is OMITTED, not stored as null
FAIL: absent provider is OMITTED, not stored as null
FAILED — 2 failure(s)
```

## A finding this surfaced, stated because it bounds the PR

**`AG2SpaceResultProvider` cannot supply a room id, by design.** It is transport-only — it holds an *injected* `self._request` callable and no base URL (`URL/token/User-Agent conventions live in ONE place, the bridge's _req`), and it POSTs `{"id", "body"}` while the **gateway resolves the room server-side from the task id**.

I initially wrote `destination=f"{self.base}{RESULTS_PATH}"` and reverted it: `self.base` does not exist, so that would have raised `AttributeError` on every delivery. Recording a room there would also have been asserting a destination the client never determined.

So this PR lands the mechanism and leaves that provider's `destination` as `None` until the **bridge injects it** — the bridge is what reads `channel_id` from the task envelope. That injection is the next slice, not a gap this PR papers over.

Regression at HEAD: `ag2space-provider`, `sparrow-result-guard`, `ag2-sparrow-drift`, `discord-delivery-provider` all pass. `review-checks.sh --diff` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Which field is load-bearing (added after cross-host review)

**`destination` is the field that cannot be reconstructed; `provider` is cheap redundancy.** On a host using activity routing, the delivered room is not derivable from the item, not derivable from the producing task, and not equal to the origin — once the log rotates, nothing can answer "delivered where" without this field. `provider` is often encoded in the outbox directory name and is stored because a merely-redundant field is cheap, not because it is irreplaceable. (Asymmetry surfaced by yixuan-ag2's second-host walk: 8 delivered items on a desktop-bundle install, byte-identical key set to the two measured here — the gap is structural, not incidental to my round trips.)
