### PR TITLE
fix(start-cli): scope core adoption to this install's tmux socket

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -15,6 +15,7 @@ Format: `- Brief description of what changed. ([#NNN])`
 ## Fixed
 
 <!-- fix() PRs go here -->
+- start-cli.sh no longer adopts (or restarts/kills) a coexisting install's `sutando-core` claude: core-process matching is scoped to the launcher's own tmux socket via exec-time env markers (`TMUX=`, `SUTANDO_TMUX_SOCKET=`) with a parent-tmux-server fallback, and a refused adoption now names the foreign pid instead of silently exiting 0. ([#2884])
 
 ## Changed
 

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -143,7 +143,11 @@ tmux_core_session_running() {
   core_claude_running
 }
 
-core_claude_pids() {
+# Machine-global `--name $SESSION` match. Diagnostics only — never a basis for
+# adopting or killing: two installs (OSS checkout + desktop bundle) legitimately
+# run cores with the same session name on different sockets (#2884), so a
+# name-only match cannot tell ours from theirs. Use core_claude_pids for that.
+any_session_named_core_pids() {
   # -a: BSD/macOS pgrep excludes the caller's ANCESTORS by default, so when this
   # script runs from inside the core (startup.sh via the core's own Bash tool)
   # the live core is invisible → "core Claude is gone" → heal spawns a duplicate
@@ -153,6 +157,113 @@ core_claude_pids() {
     case "$args" in
       *"--name $SESSION"*|*"--name=$SESSION"*) echo "$pid" ;;
     esac
+  done
+}
+
+# On macOS /tmp, /var and /etc are symlinks into /private, and env markers
+# record whichever spelling their writer was handed — compare against both.
+# Prints the twin spelling, or nothing when the path has none.
+sock_twin() {
+  case "$1" in
+    /private/*) printf '%s' "${1#/private}" ;;
+    /tmp/*|/var/*|/etc/*) printf '/private%s' "$1" ;;
+  esac
+}
+
+# The candidate's exec-time environment, best-effort ("" when unreadable —
+# e.g. another user's process). Linux exposes it at /proc/<pid>/environ
+# (NUL-separated); macOS appends it to `ps -E` output, space-separated and
+# unquoted, in the same blob as argv. Both are snapshots from exec time,
+# which is the point: they still name the socket after the tmux server that
+# stamped them has died.
+core_pid_env_blob() {
+  if [ -r "/proc/$1/environ" ]; then
+    tr '\0' '\n' < "/proc/$1/environ" 2>/dev/null
+  else
+    ps -Ewwo command= -p "$1" 2>/dev/null
+  fi
+}
+
+# Match SUTANDO_TMUX_SOCKET=$2 in blob $1 with a hard right boundary (newline
+# from /proc, space from the ps blob, or end-of-blob) so a socket that is a
+# prefix of another path can never false-match. The value itself may contain
+# spaces (app-support paths do); searching for the full value + boundary is
+# still exact because the boundary only has to terminate the TRUE value.
+_sock_env_match() {
+  local nl='
+'
+  [ -n "$2" ] || return 1
+  case "$1" in
+    *"SUTANDO_TMUX_SOCKET=$2"|*"SUTANDO_TMUX_SOCKET=$2 "*|*"SUTANDO_TMUX_SOCKET=$2$nl"*) return 0 ;;
+  esac
+  return 1
+}
+
+# Does this pid's core belong to THIS launcher's socket? Judged from env
+# markers, strongest first:
+#   TMUX=<socket>,<pid>,<idx> — stamped by tmux into every pane child; the
+#     comma is a natural delimiter, and the snapshot survives the server's
+#     death — exactly the legitimate-orphan case adoption must keep serving.
+#   SUTANDO_TMUX_SOCKET=…     — this launcher's own forwarding (CORE_ENV_ARGS).
+# A marker naming a DIFFERENT socket → not ours. No marker at all → the core
+# was launched outside tmux, which only the default-socket install does:
+# treat it as /tmp/sutando-tmux.sock's.
+core_pid_owned_here() {
+  local blob twin
+  blob="$(core_pid_env_blob "$1")"
+  twin="$(sock_twin "$TMUX_SOCKET")"
+  case "$blob" in
+    *"TMUX=$TMUX_SOCKET,"*) return 0 ;;
+  esac
+  if [ -n "$twin" ]; then
+    case "$blob" in
+      *"TMUX=$twin,"*) return 0 ;;
+    esac
+  fi
+  case "$blob" in
+    *"TMUX="*) return 1 ;;
+  esac
+  if _sock_env_match "$blob" "$TMUX_SOCKET" || _sock_env_match "$blob" "$twin"; then
+    return 0
+  fi
+  case "$blob" in
+    *"SUTANDO_TMUX_SOCKET="*) return 1 ;;
+  esac
+  # Env told us nothing (SIP hides procargs for platform-binary processes, and
+  # another user's env is never readable). Ask the parent instead: a LIVE pane
+  # child's parent is the tmux server itself, whose argv names its socket
+  # (`tmux -S <socket> …`). An orphan's parent is init/launchd — no tmux
+  # there, fall through to the default rule.
+  local ppid pargs
+  ppid="$(ps -p "$1" -o ppid= 2>/dev/null || true)"
+  ppid="${ppid//[[:space:]]/}"
+  if [ -n "$ppid" ] && [ "$ppid" -gt 1 ] 2>/dev/null; then
+    pargs="$(ps -p "$ppid" -o args= 2>/dev/null || true)"
+    case "$pargs" in
+      *tmux*"-S $TMUX_SOCKET "*|*tmux*"-S $TMUX_SOCKET") return 0 ;;
+    esac
+    if [ -n "$twin" ]; then
+      case "$pargs" in
+        *tmux*"-S $twin "*|*tmux*"-S $twin") return 0 ;;
+      esac
+    fi
+    case "$pargs" in
+      *tmux*" -S "*) return 1 ;;
+    esac
+  fi
+  [ "$TMUX_SOCKET" = /tmp/sutando-tmux.sock ] || [ "$TMUX_SOCKET" = /private/tmp/sutando-tmux.sock ]
+}
+
+# Cores that verifiably belong to THIS install's socket. Everything that
+# adopts, attaches to, or kills "the core" must go through this — a global
+# name match falsely adopted a coexisting install's core (#2884: launcher
+# exits 0, its own socket never gets a server, every tmux consumer downstream
+# fails with "no server running").
+core_claude_pids() {
+  any_session_named_core_pids | while read -r pid; do
+    if core_pid_owned_here "$pid"; then
+      echo "$pid"
+    fi
   done
 }
 
@@ -645,10 +756,23 @@ fi
 # claude seen here is either still dying (the SIGKILL escalation above should
 # have reaped it) or one a competing launcher spawned in the race window.
 # Reusing it would defeat the restart and re-introduce the false-success path.
-if [ -z "$RESTART_REQUESTED" ] && core_claude_running; then
-  echo "$SESSION claude process already running (no tmux session) — reusing it." >&2
-  echo "To recycle it cleanly: bash $0 --restart"
-  exit 0
+if [ -z "$RESTART_REQUESTED" ]; then
+  if core_claude_running; then
+    echo "$SESSION claude process already running (no tmux session) — reusing it." >&2
+    echo "To recycle it cleanly: bash $0 --restart"
+    exit 0
+  fi
+  # A '--name $SESSION' claude exists but is NOT ours (its env names a
+  # different socket, or none while we manage a private one). Adopting it was
+  # the #2884 failure: exit 0 with no server ever created on our socket. Say
+  # whose it is and fall through to launch our own core — the two installs
+  # watch different workspaces, so they do not race each other's tasks.
+  _foreign_pid="$(any_session_named_core_pids)"
+  _foreign_pid="${_foreign_pid%%$'\n'*}"
+  if [ -n "$_foreign_pid" ]; then
+    echo "  ⚠ a '$SESSION' claude (pid $_foreign_pid) is running but belongs to another install (different tmux socket) — not adopting it; launching this install's core on $TMUX_SOCKET" >&2
+    echo "    To stop the other core instead: run ITS checkout's start-cli.sh --restart, or kill $_foreign_pid" >&2
+  fi
 fi
 
 if tmux_session_exists; then

--- a/tests/start-cli-foreign-core-adopt.test.py
+++ b/tests/start-cli-foreign-core-adopt.test.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""start-cli.sh orphan-adopt must only adopt a core that belongs to THIS
+install's tmux socket (sonichi/sutando#2884).
+
+The adopt branch fires when no tmux session exists but a `claude --name
+sutando-core` process does. Today the process match is machine-global, so a
+DIFFERENT install's core (OSS checkout vs desktop bundle, distinct sockets)
+gets falsely adopted: the launcher exits 0 without creating its own session
+and every downstream tmux consumer fails with "no server running".
+
+Ownership is judged from the candidate's exec-time environment: tmux stamps
+TMUX=<socket>,<pid>,<idx> into every pane child, and the snapshot survives the
+tmux server's death — which is exactly the legitimate-orphan case adoption
+must keep serving. A core with no socket marker at all is treated as the
+default-socket (/tmp) install's, because the no-tmux launch path is the only
+way to produce one.
+"""
+from __future__ import annotations
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
+
+FAKE_PID = "99999999"  # above pid_max on macOS and default Linux: /proc/<pid> never exists
+
+
+def _isolated_workspace(td: Path) -> str:
+    ws = td / "workspace"
+    (ws / "state").mkdir(parents=True, exist_ok=True)
+    return str(ws)
+
+
+def _run(td: Path, *, args_line: str, env_blob: str, socket: "str | None",
+         ppid: str = "", parent_args: str = "") -> "tuple[str, bool]":
+    """Run start-cli.sh with a staged phantom core and no tmux on PATH.
+
+    Returns (combined output, claude_was_execd). pgrep reports FAKE_PID for the
+    core scan and "running" (exit 0, no output) for every -f guard so no
+    monitor/relay loops are spawned. ps serves the argv line for plain queries
+    and the argv+env blob when the caller asks for the environment (-E / -e).
+    """
+    bind = td / "bin"
+    bind.mkdir(exist_ok=True)
+    argv_file = td / "claude-argv.txt"
+    argv_file.unlink(missing_ok=True)  # cases share a tempdir across sub-runs
+
+    (bind / "claude").write_text('#!/bin/bash\nprintf "%s\\n" "$@" > "$CLAUDE_ARGV_FILE"\n')
+    (bind / "pgrep").write_text(
+        "#!/bin/bash\n"
+        'case "$*" in\n'
+        f'  *"claude"*) echo "{FAKE_PID} claude" ;;\n'
+        "  *) exit 0 ;;\n"  # -f guards: pretend running so nothing else spawns
+        "esac\n"
+    )
+    (bind / "ps").write_text(
+        "#!/bin/bash\n"
+        # Order matters: the env query (-E) also carries command=, and the ppid
+        # query carries -p — match the most specific form first. PS_PPID /
+        # PS_PARENT_ARGS are only set by the parent-fallback case.
+        'case "$*" in\n'
+        '  *-E*|*-e\\ *) printf "%s\\n" "$PS_ENV_BLOB" ;;\n'
+        '  *ppid=*) printf "%s\\n" "${PS_PPID:-}" ;;\n'
+        f'  *"-p {FAKE_PID}"*) printf "%s\\n" "$PS_ARGS_LINE" ;;\n'
+        '  *args=*|*command=*) printf "%s\\n" "${PS_PARENT_ARGS:-}" ;;\n'
+        "  *) exit 0 ;;\n"
+        "esac\n"
+    )
+    for f in ("claude", "pgrep", "ps"):
+        (bind / f).chmod(0o755)
+
+    env = {
+        # /usr/bin excluded: no real tmux, so the flow reaches the adopt branch
+        # and, when adoption is refused, the no-tmux `exec claude` fallback.
+        "PATH": f"{bind}:/bin",
+        "HOME": str(td),
+        "CLAUDE_ARGV_FILE": str(argv_file),
+        "PS_ARGS_LINE": args_line,
+        "PS_ENV_BLOB": env_blob,
+        "PS_PPID": ppid,
+        "PS_PARENT_ARGS": parent_args,
+        "SUTANDO_TEST_MODE": "1",
+        "SUTANDO_WORKSPACE": _isolated_workspace(td),
+    }
+    if socket is not None:
+        env["SUTANDO_TMUX_SOCKET"] = socket
+
+    proc = subprocess.run(
+        ["/bin/bash", str(SCRIPT)],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+    return proc.stdout + proc.stderr, argv_file.exists()
+
+
+CORE_ARGV = "claude --name sutando-core --remote-control Sutando --dangerously-skip-permissions"
+
+
+def case_foreign_socket_core_is_not_adopted() -> list[str]:
+    """A core whose env names ANOTHER install's socket must not be adopted;
+    the launcher must say whose it is and launch its own core."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        out, launched = _run(
+            td,
+            args_line=CORE_ARGV,
+            env_blob=(CORE_ARGV
+                      + " TMUX=/tmp/foreign-install-tmux.sock,4242,0"
+                      + " SUTANDO_TMUX_SOCKET=/tmp/foreign-install-tmux.sock"),
+            socket=str(td / "private" / "tmux.sock"),
+        )
+        if "reusing it" in out:
+            fails.append(f"foreign) adopted a different install's core: {out.strip()[:200]!r}")
+        if "another install" not in out:
+            fails.append("foreign) refusal must name the cause (expected 'another install' in output)")
+        if not launched:
+            fails.append("foreign) launcher never started its own core after refusing the foreign one")
+    return fails
+
+
+def case_own_orphan_is_still_adopted() -> list[str]:
+    """The legitimate case: OUR socket's core whose tmux server died. The env
+    snapshot still names our socket; adoption must keep working."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        sock = str(td / "private" / "tmux.sock")
+        out, launched = _run(
+            td,
+            args_line=CORE_ARGV,
+            env_blob=CORE_ARGV + f" TMUX={sock},4242,0",
+            socket=sock,
+        )
+        if "reusing it" not in out:
+            fails.append(f"own-orphan) our own orphan was not adopted: {out.strip()[:200]!r}")
+        if launched:
+            fails.append("own-orphan) a second core was launched next to our adoptable orphan")
+    return fails
+
+
+def case_markerless_stray_not_adopted_on_private_socket() -> list[str]:
+    """A core with no socket marker (legacy / launched outside tmux) belongs to
+    the default-socket install; a private-socket launcher must not adopt it
+    (issue #2884 fix shape, point 2)."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        out, launched = _run(
+            td,
+            args_line=CORE_ARGV,
+            env_blob=CORE_ARGV,  # argv only: no TMUX=, no SUTANDO_TMUX_SOCKET=
+            socket=str(td / "private" / "tmux.sock"),
+        )
+        if "reusing it" in out:
+            fails.append(f"markerless-private) adopted a default-socket stray: {out.strip()[:200]!r}")
+        if not launched:
+            fails.append("markerless-private) launcher never started its own core")
+    return fails
+
+
+def case_markerless_stray_adopted_on_default_socket() -> list[str]:
+    """Same stray, but the launcher IS the default-socket install: this is the
+    pre-existing single-install contract and must keep adopting."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        out, launched = _run(
+            td,
+            args_line=CORE_ARGV,
+            env_blob=CORE_ARGV,
+            socket=None,  # default /tmp/sutando-tmux.sock
+        )
+        if "reusing it" not in out:
+            fails.append(f"markerless-default) default-socket stray no longer adopted: {out.strip()[:200]!r}")
+        if launched:
+            fails.append("markerless-default) a second core was launched next to the adoptable stray")
+    return fails
+
+
+def case_private_twin_spelling_still_matches() -> list[str]:
+    """macOS spells /tmp paths as /private/tmp in env markers; a socket that
+    differs only by the /private prefix is the SAME socket. Also exercises a
+    marker whose value contains spaces (app-support paths do)."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        out, launched = _run(
+            td,
+            args_line=CORE_ARGV,
+            env_blob=CORE_ARGV + " TMUX=/private/tmp/twin-test-tmux.sock,7,0",
+            socket="/tmp/twin-test-tmux.sock",
+        )
+        if "reusing it" not in out:
+            fails.append(f"twin) /private twin spelling not recognized as ours: {out.strip()[:200]!r}")
+        if launched:
+            fails.append("twin) launched a second core over our own twin-spelled orphan")
+
+        spaced = str(td / "App Support" / "run" / "tmux.sock")
+        out, launched = _run(
+            td,
+            args_line=CORE_ARGV,
+            env_blob=CORE_ARGV + f" TMUX={spaced},7,0 NEXT_VAR=1",
+            socket=spaced,
+        )
+        if "reusing it" not in out:
+            fails.append(f"twin) spaces-in-path socket not recognized as ours: {out.strip()[:200]!r}")
+    return fails
+
+
+def case_parent_tmux_server_decides_when_env_is_hidden() -> list[str]:
+    """SIP hides procargs for some processes: a markerless blob must fall back
+    to the parent — a live pane child's parent is the tmux server whose argv
+    names its socket."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        sock = str(td / "private" / "tmux.sock")
+        out, launched = _run(
+            td,
+            args_line=CORE_ARGV,
+            env_blob=CORE_ARGV,  # markerless: env unreadable / hidden
+            socket=sock,
+            ppid="424242",
+            parent_args="tmux -S /tmp/foreign-install-tmux.sock new-session -d -s sutando-core claude",
+        )
+        if "reusing it" in out:
+            fails.append(f"parent) adopted a pane of a FOREIGN tmux server: {out.strip()[:200]!r}")
+        if not launched:
+            fails.append("parent) launcher never started its own core after refusing the foreign pane")
+
+        out, launched = _run(
+            td,
+            args_line=CORE_ARGV,
+            env_blob=CORE_ARGV,
+            socket=sock,
+            ppid="424242",
+            parent_args=f"tmux -S {sock} new-session -d -s sutando-core claude",
+        )
+        if "reusing it" not in out:
+            fails.append(f"parent) our own tmux server's pane was not adopted: {out.strip()[:200]!r}")
+        if launched:
+            fails.append("parent) launched a second core over our own live pane")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("foreign-not-adopted", case_foreign_socket_core_is_not_adopted),
+        ("own-orphan-adopted", case_own_orphan_is_still_adopted),
+        ("markerless-private", case_markerless_stray_not_adopted_on_private_socket),
+        ("markerless-default", case_markerless_stray_adopted_on_default_socket),
+        ("private-twin", case_private_twin_spelling_still_matches),
+        ("parent-fallback", case_parent_tmux_server_decides_when_env_is_hidden),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if all_failures:
+        print(f"\n{len(all_failures)} failure(s)")
+        return 1
+    print("\nstart-cli.sh adopts only cores that belong to its own socket.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/start-cli-restart-verify.test.py
+++ b/tests/start-cli-restart-verify.test.py
@@ -67,8 +67,11 @@ exit 1
 """ % FAKEPID
 
 PS_STUB = r"""#!/bin/bash
-# core_claude_pids does: ps -p <pid> -o args=
-# Report the matching cmdline only for our fake pid while CORE_MARK exists.
+# core_claude_pids does: ps -p <pid> -o args=; the ownership gate additionally
+# asks for the env blob (-E). The staged core models THIS launcher's own core,
+# so the env response must stamp the launcher's socket (TMUX=<socket>,) — a
+# markerless core on a private socket is now correctly treated as foreign
+# (sonichi/sutando#2884) and would be invisible to the restart flow.
 want=""
 prev=""
 for a in "$@"; do
@@ -76,7 +79,10 @@ for a in "$@"; do
   prev="$a"
 done
 if [ "$want" = "%s" ] && [ -f "$CORE_MARK" ]; then
-  echo "claude --name sutando-core"
+  case "$*" in
+    *-E*) echo "claude --name sutando-core TMUX=${SUTANDO_TMUX_SOCKET},1,0" ;;
+    *) echo "claude --name sutando-core" ;;
+  esac
 fi
 exit 0
 """ % FAKEPID


### PR DESCRIPTION
Closes #2884.

## What changed and why

`core_claude_pids()` matched **any** claude process on the machine whose args contain `--name sutando-core`. With two installs coexisting (OSS checkout on `/tmp/sutando-tmux.sock` + a desktop bundle on a private socket), the orphan-adopt branch falsely adopted the *other* install's core and exited 0: the launcher's own socket never got a tmux server, and every downstream consumer (gateway window, attach/verify, desktop supervisor) failed with `no server running` — 25 supervisor revive attempts, all identical, on the 2026-08-21 live repro that motivated #2884.

Ownership is now judged per candidate pid, strongest signal first:

1. **Exec-time env markers** — `TMUX=<socket>,` (comma-delimited by tmux itself) and `SUTANDO_TMUX_SOCKET=<socket>` (boundary-checked), read from `/proc/<pid>/environ` on Linux and `ps -E` on macOS. Env is a snapshot from exec time, so it still names the socket after the tmux server that stamped it died — exactly the legitimate-orphan case adoption must keep serving.
2. **Parent process** — a live pane child's parent is the tmux server itself, whose argv names its socket (`tmux -S <socket> …`). Covers processes whose procargs SIP hides (platform-binary images).
3. **No marker at all** — the core was launched outside tmux, which only the default-socket install does: treat it as `/tmp/sutando-tmux.sock`'s (pre-existing single-install contract preserved).

A refused adoption now names the foreign pid and why, then launches this install's own core instead of silently exiting 0 (#2884 fix shape, points 1–3). `--restart` is scoped by the same gate: it can no longer SIGTERM/SIGKILL a coexisting install's core.

## Files to look at first

- `src/agent/claude/cli/start-cli.sh` — `core_pid_owned_here()` and the reworked adopt branch
- `tests/start-cli-foreign-core-adopt.test.py` — the six behavior cases

## Tests run

```
python3 tests/start-cli-foreign-core-adopt.test.py     # 6/6 pass
python3 tests/start-cli-model-pin.test.py              # pass
python3 tests/start-cli-restart-verify.test.py         # pass
python3 tests/start-cli-chrome-seed-bundled-python.test.py  # pass
python3 tests/start-cli-dangerous-mode-seed.test.py    # pass
python3 tests/codex-core-launcher.test.py              # OK
bash tests/start-cli-claude-config-dir.test.sh         # pass (macOS)
```

**Fails-before evidence** (on `b048bb40`, the merge-base): the new test's `foreign-not-adopted` and `markerless-private` cases fail —

```
✗ case foreign-not-adopted
    foreign) adopted a different install's core: 'To recycle it cleanly: …'
✗ case markerless-private
    markerless-private) adopted a default-socket stray: …
```

All six pass at this branch's HEAD.

`tests/start-cli-restart-verify.test.py`'s ps stub now stamps the launcher's socket into its env response: the staged core models *this* launcher's own core, and a markerless core on a private socket is treated as foreign by design.

## Edge cases handled

- macOS `/private` twin spellings (`/tmp`, `/var`, `/etc` symlinks) — covered by test `private-twin`
- Socket paths containing spaces (app-support paths) — boundary-checked matching, covered in `private-twin`
- SIP-hidden procargs → parent-tmux-argv fallback — covered by test `parent-fallback`
- Another user's core (env and parent both unreadable) → default-socket rule, i.e. pre-existing behavior

## Risk / rollback

One script + its tests; reverts cleanly. The only behavior change for single-install setups is none: every marker path resolves to "owned" when only one install exists.

## Known gaps

- The test's "launched" assertion means the `claude` stub was exec'd — adequate for the adoption/refusal concern; full launch mechanics stay covered by the existing start-cli suites.
- A same-name core owned by a *different user* on the default socket is still treated as the default install's (its env is unreadable by design); same as before this change.

Reviewed by Codex CLI before submission: LGTM, no must-fix items; its two test-gap notes (parent-fallback coverage, twin/spaces coverage) are addressed in this revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)