### PR TITLE
fix(supervisor-relay): a login blocker's spinner line must not key the debounce

### DIFF
--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -52,8 +52,18 @@ HARD_ESCALATE = {"blocked-human", "logged-out"}
 
 
 def _sig_hash(signal: dict) -> str:
-    """Stable hash of the escalation-relevant fields (state + prompt)."""
-    key = f"{signal.get('state')}\x00{signal.get('prompt') or ''}"
+    """Stable hash of the escalation-relevant fields.
+
+    For a login-class blocker the prompt excerpt is the live terminal's
+    SPINNER line, which churns while the blocker itself is unchanged —
+    hashing it re-fires one stuck login on every cosmetic repaint (3 alerts
+    for one blocker, observed 2026-08-21). The remedy is identical whatever
+    the spinner says, so state alone keys the debounce there; a genuine
+    awaiting-user question keeps prompt identity so a NEW question still
+    escalates.
+    """
+    prompt = "" if _is_login_class(signal) else (signal.get("prompt") or "")
+    key = f"{signal.get('state')}\x00{prompt}"
     return hashlib.sha1(key.encode()).hexdigest()
 
 

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -97,6 +97,23 @@ class TestShouldEscalate(unittest.TestCase):
         self.assertFalse(esc2)
         self.assertEqual(h1, h2)
 
+    def test_login_spinner_churn_fires_once(self):
+        """One stuck login, three spinner repaints -> ONE alert (2026-08-21:
+        the spinner text was in the hash, so it fired three times)."""
+        spin1 = dict(_LOGIN, prompt="\u273b Running scheduled task (Aug 21 5:10pm)")
+        spin2 = dict(_LOGIN, prompt="\u273b Cooked for 0s \u00b7 1 shell, 1 monitor still running")
+        esc1, h1 = should_escalate(spin1, None)
+        self.assertTrue(esc1)
+        esc2, h2 = should_escalate(spin2, h1)
+        self.assertFalse(esc2, "a cosmetic spinner repaint re-fired the same login blocker")
+        self.assertEqual(h1, h2)
+        # logged-out is the other login-class shape; same invariant.
+        lo2 = dict(_LOGGED_OUT, prompt="some transient console text")
+        _, h3 = should_escalate(_LOGGED_OUT, None)
+        esc4, h4 = should_escalate(lo2, h3)
+        self.assertFalse(esc4)
+        self.assertEqual(h3, h4)
+
     def test_new_prompt_reescalates(self):
         _, h1 = should_escalate(_LOGIN, None)
         other = {"state": "blocked-human", "detail": "awaiting user: permission",


### PR DESCRIPTION
## What changed, and why?

`should_escalate` debounces owner escalations on `hash(state, prompt)`. For a **login-class blocker**, the "prompt" field is the live terminal's **spinner line** — `✻ Running scheduled task (Aug 21 5:10pm)`, `✻ Cooked for 0s · 1 shell, 1 monitor still running` — which repaints while the blocker itself is unchanged. Each cosmetic repaint minted a new hash, so **one stuck login escalated three times** into the owner's Pro-Main room tonight (2026-08-21, observed live; the owner replied "Room Ops cleanup" to the pile).

The function's own docstring promises *"a persistent prompt fires exactly once"* — which holds only when the prompt is stable, and a spinner is not. For login-class signals the excerpt also carries no information: the remedy line appended by `compose_message` is identical whatever the spinner says.

## Fix

`_sig_hash` excludes the prompt **only for login-class signals** (`_is_login_class`: `state == "logged-out"` or `kind == "login"`) — state alone keys the debounce there. A genuine awaiting-user question keeps prompt identity, so a **new** question still escalates (the existing `test_new_prompt_reescalates` pins that and still passes).

## Evidence

At HEAD, the suite (53 tests) passes, including the new case:

```
test_login_spinner_churn_fires_once — one stuck login, three spinner repaints -> ONE alert
```

Mutation-verified rather than assumed — putting the prompt back in the hash for login-class:

```
FAIL: test_login_spinner_churn_fires_once
  "a cosmetic spinner repaint re-fired the same login blocker"
```

Restored → `Ran 53 tests ... OK`. Both login-class shapes are covered (`blocked-human`+`kind=login`, and `logged-out`), and the healthy-tick hash-preservation behavior is untouched.

`scripts/review-checks.sh --diff` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
