### PR TITLE
feat(gateway): a delivered proactive nudge records a durable receipt with its room

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -162,7 +162,7 @@ from . import local_task_protocol
 from .result_markers import parse_markers
 from .team_guardrail import team_guardrail_lines, engage_rulebook, AG2SPACE_PROVENANCE
 from . import team_result_guard
-from .outbox import DeliveryOutcome
+from .outbox import DeliveryOutcome, record_delivered
 from .outbox_adapter import classify_response
 from .send_failure_policy import MAX_TRANSIENT_ATTEMPTS, resolve_failed_send
 from .delivery_core import (DeliveryCore, DesignAClaimBackend, DrainStatus,
@@ -2487,6 +2487,18 @@ def _proactive_route(body: str) -> "tuple[str, str | None, str]":
     return ("send", None, parsed.body)
 
 
+def _record_proactive_receipt(item_id: str, room: str) -> None:
+    """Durable "delivered where" for the proactive leg. The log line naming the
+    room rotates; this outlives it. Fail-open: a receipt write must never
+    unwind a delivery that already happened."""
+    try:
+        record_delivered(RESULTS_DIR / ".outbox-ag2space-proactive", item_id,
+                         provider="ag2space-proactive", destination=room)
+    except Exception as e:  # noqa: BLE001 — receipt is best-effort by design
+        _log(f"proactive receipt write failed for {item_id}: {e} "
+             "(delivery unaffected)")
+
+
 def _pid_alive(pid: int) -> bool:
     try:
         os.kill(pid, 0)
@@ -2668,10 +2680,11 @@ def _post_proactive() -> None:
                  "— dead-lettering, it can never be delivered")
             _retire_proactive(claim, f, UNDELIVERABLE_RESULTS_DIR)
             continue
+        dest_room = room_override or PROACTIVE_ROOM
         try:
             resp = _req("POST", "/v1/room",
                         {"op": "message",
-                         "room_id": room_override or PROACTIVE_ROOM,
+                         "room_id": dest_room,
                          "body": body},
                         timeout=15)
             # A bare 200 is NOT proof of delivery: the gateway can swallow a
@@ -2703,13 +2716,14 @@ def _post_proactive() -> None:
             outcome = _resolve_send_failure(claim, f, e)
             _log(f"proactive send network error for {f.name}: {e} — {outcome}")
             continue
+        _record_proactive_receipt(f.stem, dest_room)
         ARCHIVE_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
         try:
             claim.rename(ARCHIVE_RESULTS_DIR / f"{f.stem}-{int(time.time())}.txt")
         except OSError:
             claim.unlink(missing_ok=True)
         _PROACTIVE_ATTEMPTS.pop(f.name, None)
-        _log(f"delivered proactive {f.name}")
+        _log(f"delivered proactive {f.name} to {dest_room}")
 
 
 def _load_inflight() -> set[str]:

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -996,6 +996,39 @@ def main() -> int:
                   for p in rtc.ARCHIVE_RESULTS_DIR.glob("*.txt")),
           "[no-send] proactive nudge is archived silently, never posted")
 
+    # Durable delivery receipts (the log line naming the room rotates; the
+    # receipt outlives it — parallel of the reply leg's #3252).
+    import importlib as _il
+    _ob = _il.import_module("ag2_sparrow.outbox")
+    _rroot = rtc.RESULTS_DIR / ".outbox-ag2space-proactive"
+    (rtc.RESULTS_DIR / "proactive-r1.txt").write_text("receipt nudge\n")
+    rtc._post_proactive()
+    _it = _ob._read_item(_rroot, "proactive-r1")
+    check(_it.get("status") == "DELIVERED"
+          and _it.get("provider") == "ag2space-proactive"
+          and _it.get("destination") == "!owner:example.org",
+          "delivered default-room nudge records a durable receipt with the room")
+    (rtc.RESULTS_DIR / "proactive-r2.txt").write_text(
+        "[channel: !other:example.org]\nrouted receipt nudge\n")
+    rtc._post_proactive()
+    _it2 = _ob._read_item(_rroot, "proactive-r2")
+    check(_it2.get("destination") == "!other:example.org",
+          "a routed nudge's receipt records the OVERRIDE room, not the default")
+    # A failed POST must record NOTHING — a receipt is proof of delivery,
+    # never of an attempt.
+    (rtc.RESULTS_DIR / "proactive-r3.txt").write_text("failing nudge\n")
+    STATE["force_room_502"] = True
+    rtc._post_proactive()
+    STATE["force_room_502"] = False
+    _it3 = _ob._read_item(_rroot, "proactive-r3")
+    check(_it3.get("status") != "DELIVERED" and "destination" not in _it3,
+          "a failed POST records no receipt")
+    rtc._post_proactive()
+    _it3b = _ob._read_item(_rroot, "proactive-r3")
+    check(_it3b.get("status") == "DELIVERED"
+          and _it3b.get("destination") == "!owner:example.org",
+          "the successful retry records the receipt")
+
     # 3.6 cross-bridge claim gate (proactive_routing wired by the loader).
     # Hermetic: the gate asks claude_home_path() whether the routed bridge is
     # configured, so an ambient ~/.claude would decide these cases from the


### PR DESCRIPTION
## What changed, and why?

The proactive leg confirmed delivery and then **discarded where it delivered**. The room survived only in a log line:

```
[remote-gateway-bridge] delivered proactive proactive-1787358429.to-ag2space.txt
```

Demonstrated live tonight (2026-08-22), not hypothesized: a nudge with a mis-placed `[channel:]` marker landed in the **wrong room**, and its log line + archive entry were byte-identical to a correct delivery. Only reading the target room back distinguished the two. Once that log rotates, nothing can answer "delivered where".

This is the proactive-leg parallel of #3252 (merged), and uses its owner API rather than a private writer.

## Fix

On the drain's **confirmed** path only, record a durable receipt via `outbox.record_delivered`:

- root `results/.outbox-ag2space-proactive` (per-leg root, same precedent as the discord fence)
- `provider="ag2space-proactive"`, `destination=` the room **actually posted** — the `[channel:]` override when present, else `REMOTE_PROACTIVE_ROOM`
- fail-open: a receipt write failure logs and never unwinds a delivery that happened
- the success log now names the room too

A failed POST records **nothing** — a receipt is proof of delivery, never of an attempt.

## Evidence

Suite at HEAD (`src/remote-gateway-bridge.test.py`): `PASS — all checks green`, including the four new cases:

```
ok  delivered default-room nudge records a durable receipt with the room
ok  a routed nudge's receipt records the OVERRIDE room, not the default
ok  a failed POST records no receipt
ok  the successful retry records the receipt
```

Mutation-verified: removing the single recorder call → **3 receipt failures**; restored → green. `tests/ag2-sparrow-drift.test.py` PASS (the bridge is package-canonical; `outbox.py` untouched). `review-checks.sh --diff` PASS.

## Scope boundary

This is the receipt half of typed-proactive only. Producer migration (briefing → typed destination) and the auditable re-drive of quarantined items are the next slices; the claim-ownership half already exists in `proactive_routing.py` and was live-verified tonight (destined `.to-ag2space` file: discord/telegram/slack claim = False, gateway = True, delivered to the marked room, event read back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
