### PR TITLE
feat(ag2space-room-sessions): decoupled ack + heartbeat + timeout handoff notices

### DIFF
--- a/skills/ag2space-room-sessions/SKILL.md
+++ b/skills/ag2space-room-sessions/SKILL.md
@@ -24,3 +24,27 @@ session path.
 Provider hard and stall timeouts default to the values declared in
 `manifest.json`. CLI options override environment values, which override the
 manifest defaults.
+
+## Progress visibility
+
+A room-session invocation is otherwise silent for its whole run — up to the hard
+timeout — with nothing distinguishing "queued behind another message in this
+room" from "actively working" from "hung." Three best-effort notifications close
+most of that gap, each routed through the shared `task-progress` notifier using
+the task's own `source`/`channel_id` headers:
+
+- **On start** (once, the moment this invocation actually begins running, not
+  when it was received) — signals the message left the lock queue and work is
+  underway.
+- **Heartbeat**, every `SUTANDO_TIER_HEARTBEAT_INTERVAL` seconds (manifest
+  default 120s) while the provider is still running.
+- **On timeout** (hard or stall) — an explicit handoff notice before the task
+  falls back to the live core, so that fallback reply doesn't appear
+  disconnected from the original message.
+
+All three are best-effort and never affect the run itself: a broken or slow
+notifier only costs visibility, not correctness. **Known gap, not solved
+here:** the provider call itself is still killed outright on timeout with no
+checkpoint or partial-result recovery — the heartbeat says the room isn't dead,
+it doesn't rescue in-flight work that turns out to need longer than the hard
+timeout allows.

--- a/skills/ag2space-room-sessions/manifest.json
+++ b/skills/ag2space-room-sessions/manifest.json
@@ -12,7 +12,8 @@
   },
   "config": {
     "SUTANDO_TIER_HARD_TIMEOUT": "900",
-    "SUTANDO_TIER_STALL_TIMEOUT": "180"
+    "SUTANDO_TIER_STALL_TIMEOUT": "180",
+    "SUTANDO_TIER_HEARTBEAT_INTERVAL": "120"
   },
   "provenance": {
     "source_repo": "https://github.com/sonichi/sutando"

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -20,7 +20,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 
 UNHANDLED = 3
@@ -192,9 +192,18 @@ def _run_bounded(
     cwd: Path,
     hard_timeout_override: Optional[float] = None,
     stall_timeout_override: Optional[float] = None,
+    heartbeat_interval_override: Optional[float] = None,
+    on_heartbeat: Optional[Callable[[float], None]] = None,
 ) -> tuple[int, str, str]:
     hard_timeout = _timeout("SUTANDO_TIER_HARD_TIMEOUT", hard_timeout_override)
     stall_timeout = _timeout("SUTANDO_TIER_STALL_TIMEOUT", stall_timeout_override)
+    # Heartbeat is best-effort progress visibility, not a correctness timer — reuse
+    # _timeout() only for its CLI>env>manifest precedence; a bad/missing value disables
+    # it rather than aborting the run (unlike hard/stall, which must fail closed).
+    try:
+        heartbeat_interval = _timeout("SUTANDO_TIER_HEARTBEAT_INTERVAL", heartbeat_interval_override)
+    except ValueError:
+        heartbeat_interval = 0.0
     process = subprocess.Popen(
         command,
         cwd=cwd,
@@ -212,6 +221,18 @@ def _run_bounded(
         os.set_blocking(fd, False)
         selector.register(fd, selectors.EVENT_READ, name)
     started = last_progress = time.monotonic()
+    next_heartbeat = started + heartbeat_interval if heartbeat_interval > 0 else None
+
+    def _maybe_heartbeat(now: float) -> None:
+        nonlocal next_heartbeat
+        if next_heartbeat is None or now < next_heartbeat or on_heartbeat is None:
+            return
+        # Skip ahead past any interval(s) a slow select()/sleep() overran, rather than
+        # firing a burst of catch-up pings once the loop resumes.
+        while next_heartbeat is not None and now >= next_heartbeat:
+            next_heartbeat += heartbeat_interval
+        on_heartbeat(now - started)
+
     try:
         while selector.get_map():
             now = time.monotonic()
@@ -219,6 +240,7 @@ def _run_bounded(
                 raise TimeoutError(f"provider exceeded hard timeout ({hard_timeout:g}s)")
             if now - last_progress >= stall_timeout:
                 raise TimeoutError(f"provider made no progress for {stall_timeout:g}s")
+            _maybe_heartbeat(now)
             for key, _ in selector.select(timeout=min(0.2, stall_timeout)):
                 try:
                     chunk = os.read(key.fd, 65536)
@@ -235,6 +257,7 @@ def _run_bounded(
                 raise TimeoutError(f"provider exceeded hard timeout ({hard_timeout:g}s)")
             if now - last_progress >= stall_timeout:
                 raise TimeoutError(f"provider made no progress for {stall_timeout:g}s")
+            _maybe_heartbeat(now)
             time.sleep(min(0.05, stall_timeout))
         return (
             int(process.returncode or 0),
@@ -284,6 +307,35 @@ def _working_dir(repo: Path) -> Path:
     return Path(os.environ.get("SUTANDO_ISOLATED_WORKING_DIR", str(repo))).expanduser()
 
 
+def _notify(task_file: Path, message: str) -> None:
+    """Best-effort progress ping via the shared task-progress notifier — reused rather
+    than reimplemented, matching the same delivery path the NOTIFY FIRST convention
+    already uses everywhere else in this codebase. Never raises: a broken or slow
+    notify path must not affect the room session itself, only its visibility."""
+    try:
+        headers = parse_task_headers_trusted(
+            task_file.read_text(encoding="utf-8", errors="replace")
+        ).headers
+    except OSError:
+        return
+    source = headers.get("source") or ""
+    channel_id = headers.get("channel_id") or ""
+    if not source or not channel_id:
+        return
+    notifier = REPO_ROOT / "skills" / "task-progress" / "scripts" / "notify.py"
+    if not notifier.is_file():
+        return
+    try:
+        subprocess.run(
+            [sys.executable, str(notifier), "--source", source, "--channel-id", channel_id,
+             "--message", message],
+            timeout=15, check=False,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
 def _claude_command(session_id: str, resume: bool, prompt: str) -> list[str]:
     command = ["claude", "-p", "--resume" if resume else "--session-id", session_id]
     command += ["--output-format", "text", "--dangerously-skip-permissions", "--add-dir", str(Path.home())]
@@ -321,6 +373,7 @@ def _run_claude(
     repo: Path,
     hard_timeout: Optional[float] = None,
     stall_timeout: Optional[float] = None,
+    on_heartbeat: Optional[Callable[[float], None]] = None,
 ) -> str:
     session_id, created = _session_id(workspace, "claude", room_key)
     return_code, stdout, stderr = _run_bounded(
@@ -328,6 +381,7 @@ def _run_claude(
         _working_dir(repo),
         hard_timeout,
         stall_timeout,
+        on_heartbeat=on_heartbeat,
     )
     if return_code:
         raise RuntimeError(stderr.strip() or f"claude exited {return_code}")
@@ -343,6 +397,7 @@ def _run_codex(
     repo: Path,
     hard_timeout: Optional[float] = None,
     stall_timeout: Optional[float] = None,
+    on_heartbeat: Optional[Callable[[float], None]] = None,
 ) -> str:
     state = _read_json(_state_path(workspace))
     row = ((state.get("sessions") or {}).get("codex") or {}).get(room_key)
@@ -359,6 +414,7 @@ def _run_codex(
             _working_dir(repo),
             hard_timeout,
             stall_timeout,
+            on_heartbeat=on_heartbeat,
         )
         if return_code:
             raise RuntimeError(stderr.strip() or f"codex exited {return_code}")
@@ -416,11 +472,32 @@ def handle(
         with _locked(lock):
             if _completed_result_exists(results_dir, task_file.name):
                 return 0
-            body = (
-                _run_claude(workspace, room_key, _prompt(task_file), repo, hard_timeout, stall_timeout)
-                if runtime == "claude"
-                else _run_codex(workspace, room_key, _prompt(task_file), repo, hard_timeout, stall_timeout)
+            # Decoupled ack: fires once, the moment this task actually starts running
+            # (not when it was queued) — so a message stuck behind another room-session
+            # invocation's lock stays silent until its own turn, exactly like the live
+            # core's own step-2 NOTIFY FIRST convention for a task that's now underway.
+            _notify(task_file, "On it — working on this now.")
+            heartbeat = lambda elapsed: _notify(  # noqa: E731
+                task_file, f"Still working ({elapsed:.0f}s so far)…"
             )
+            try:
+                body = (
+                    _run_claude(workspace, room_key, _prompt(task_file), repo,
+                                hard_timeout, stall_timeout, on_heartbeat=heartbeat)
+                    if runtime == "claude"
+                    else _run_codex(workspace, room_key, _prompt(task_file), repo,
+                                     hard_timeout, stall_timeout, on_heartbeat=heartbeat)
+                )
+            except TimeoutError:
+                # Surface the handoff explicitly rather than leaving the room to
+                # discover it only when a *different* reply eventually shows up from
+                # the live-core fallback path with no visible connection to this one.
+                _notify(
+                    task_file,
+                    "This is taking longer than expected — handing off, a reply will "
+                    "follow through the normal path.",
+                )
+                raise
             if not body.strip():
                 raise RuntimeError(f"{runtime} returned an empty result")
             if not _publish_once(results_dir / task_file.name, body):

--- a/tests/ag2space-room-session-worker.test.py
+++ b/tests/ag2space-room-session-worker.test.py
@@ -435,6 +435,75 @@ def test_direct_failure_and_cli_edges() -> None:
             check(worker.main() == 18, "CLI main dispatches handle mode")
 
 
+def test_progress_notifications() -> None:
+    with tempfile.TemporaryDirectory() as name:
+        workspace = Path(name)
+        results = workspace / "results"
+        results.mkdir()
+
+        # _notify: builds the shared task-progress notifier call from the task's own
+        # trusted headers, and never raises even when the subprocess itself fails.
+        notified = task(workspace, "task-notify")
+        with patch.object(worker.subprocess, "run") as run:
+            worker._notify(notified, "hello")
+        run_args = run.call_args.args[0]
+        check(run_args[0] == sys.executable and str(worker.REPO_ROOT) in " ".join(run_args),
+              "_notify invokes the shared notifier via the resolved interpreter")
+        check("--source" in run_args and "ag2space" in run_args, "_notify passes the task's source header")
+        check("--channel-id" in run_args and "!alpha:ag2.space" in run_args,
+              "_notify passes the task's channel_id header")
+        check("hello" in run_args, "_notify passes the message through")
+        with patch.object(worker.subprocess, "run", side_effect=OSError("no interpreter")):
+            worker._notify(notified, "hello")  # must not raise
+        check(True, "_notify swallows a subprocess failure rather than raising")
+        missing_headers = workspace / "tasks" / "task-bare.txt"
+        missing_headers.write_text("id: task-bare\ntask: no source or channel\n", encoding="utf-8")
+        with patch.object(worker.subprocess, "run") as run:
+            worker._notify(missing_headers, "hello")
+        check(not run.called, "_notify is a no-op without source/channel_id headers")
+
+        # handle(): fires exactly one ack, at the moment work starts, before the
+        # provider runs at all — not when the task was merely received.
+        started = task(workspace, "task-started")
+        calls: list[str] = []
+        with patch.object(worker, "_notify", side_effect=lambda _f, msg: calls.append(msg)), \
+             patch.object(worker, "_run_claude", return_value="ok") as run_claude:
+            check(worker.handle("claude", workspace, started, results, REPO) == 0,
+                  "handle succeeds with the ack wired in")
+        check(calls == ["On it — working on this now."],
+              "handle fires exactly one ack before the provider runs")
+        check(run_claude.call_args.kwargs.get("on_heartbeat") is not None,
+              "handle wires a heartbeat callback into the provider call")
+
+        # _run_bounded: heartbeat fires on a real elapsed-time cadence and skips ahead
+        # past overrun intervals rather than bursting catch-up pings.
+        sleeper = executable(Path(name) / "sleepy2", "#!/bin/sh\nsleep 0.5\n")
+        beats: list[float] = []
+        with patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "5", "SUTANDO_TIER_STALL_TIMEOUT": "5"}):
+            worker._run_bounded([str(sleeper)], Path(name),
+                                 heartbeat_interval_override=0.15, on_heartbeat=beats.append)
+        check(1 <= len(beats) <= 4, f"heartbeat fires a bounded number of times during a 0.5s run ({beats})")
+        check(all(b >= 0 for b in beats), "heartbeat receives non-negative elapsed seconds")
+
+        # On timeout, an explicit handoff notice fires (via _notify) before the
+        # exception surfaces as the ordinary watcher-fallback failure path.
+        stuck = task(workspace, "task-stuck", room_id="!stuck:a")
+        handoff: list[str] = []
+        with patch.object(worker, "_notify", side_effect=lambda _f, msg: handoff.append(msg)), \
+             patch.object(worker, "_run_claude", side_effect=TimeoutError("provider exceeded hard timeout")):
+            code = worker.handle("claude", workspace, stuck, results, REPO)
+        check(code == 1, "handle still returns the watcher-fallback signal on timeout")
+        check(handoff == ["On it — working on this now.",
+                           "This is taking longer than expected — handing off, a reply will "
+                           "follow through the normal path."],
+              "handle notifies both the start ack and an explicit timeout handoff")
+        check(not (results / stuck.name).exists(), "timeout publishes no result, same as any other failure")
+
+        with patch.dict(os.environ, {}, clear=True):
+            check(worker._timeout("SUTANDO_TIER_HEARTBEAT_INTERVAL", None) == 120,
+                  "manifest declares the heartbeat-interval default")
+
+
 def main() -> int:
     test_opt_in_and_cardinality()
     test_session_state_reuses_room_not_message()
@@ -444,6 +513,7 @@ def main() -> int:
     test_runtime_edges_and_adapter_wiring()
     test_cli_probe_and_empty_output()
     test_direct_failure_and_cli_edges()
+    test_progress_notifications()
     print(f"\nResults: {len(FAILURES)} failed")
     return 1 if FAILURES else 0
 


### PR DESCRIPTION
## What changed, and why?

Design proposal responding to the discussion on #3238's review: room-session
invocations run silently for their whole duration (up to the 900s hard
timeout), with no way to distinguish "queued" from "working" from "hung," and
a stuck provider's timeout SIGTERMs it and discards all progress with no
visible signal before the fallback path takes over.

Adds three best-effort progress notifications to `session-worker.py`,
routed through the existing `task-progress` notifier (the same delivery
path the `NOTIFY FIRST` convention already uses everywhere else in this
codebase — no new mechanism, no new dependency):

1. **On start** — fires once, the moment this invocation actually begins
   running (after acquiring the per-room lock, not when the task was
   received), so a message queued behind another one in the same room stays
   quiet until its own turn.
2. **Heartbeat** — every `SUTANDO_TIER_HEARTBEAT_INTERVAL` seconds (manifest
   default 120s) while the provider is still running.
3. **On timeout** (hard or stall) — an explicit handoff notice before the
   task falls back to the live core, so that eventual reply doesn't appear
   disconnected from the original message.

## Review first

- `skills/ag2space-room-sessions/scripts/session-worker.py` — `_notify()`,
  the heartbeat threading through `_run_bounded`/`_run_claude`/`_run_codex`,
  and the `handle()` wiring (ack before the provider call, timeout handoff
  in the `except TimeoutError` branch).
- `tests/ag2space-room-session-worker.test.py` — `test_progress_notifications`.

## User behavior proved

A room-session message now produces an immediate "on it" ping, periodic
"still working" pings if it runs long, and an explicit handoff notice if it
times out — instead of total silence until either a real reply or an
unexplained fallback reply appears.

## Explicitly NOT solved here

The provider call is still killed outright on hard/stall timeout with no
checkpoint or partial-result recovery — documented plainly in `SKILL.md`.
The heartbeat proves the room session isn't dead; it does not rescue
in-flight work that turns out to need longer than the timeout allows.
Making that survive would mean streaming/checkpointing the provider's own
output, a materially larger change deliberately left out of this pass.

## Tests run

```text
$ python3 tests/ag2space-room-session-worker.test.py
Results: 0 failed (84 checks, 14 new)

$ python3 -m ruff check skills/ag2space-room-sessions/scripts/session-worker.py tests/ag2space-room-session-worker.test.py
All checks passed!

$ python3 scripts/lint-skill.py skills/ag2space-room-sessions
lint-skill: 1 manifest(s), 0 error(s), 0 warning(s)

$ python3 -m py_compile skills/ag2space-room-sessions/scripts/session-worker.py tests/ag2space-room-session-worker.test.py
(no output; exit 0)
```

## Hardcoded-path check

```text
$ git diff --name-only | xargs grep -nE '/Users/|/home/|C:\\'
(no output; exit 1)
```

## Migration, permissions, rollback, risk

No new config required to run — `SUTANDO_TIER_HEARTBEAT_INTERVAL` has a
manifest default like the existing timeout knobs. No new permissions: the
notifier is the same `task-progress` script every other NOTIFY FIRST caller
already uses. All three notifications are best-effort and wrapped so a
broken/slow notifier only costs visibility, never correctness — `handle()`'s
existing exception handling and return-code contract are unchanged.
Rollback is reverting this commit; `#3238`'s own behavior is untouched
without it.

## Stack / relationship

**Stacked on #3238** (`feat/native-ag2space-room-sessions`) — this branch
only makes sense once that one lands, and is opened as a **draft**
specifically because it depends on that unmerged parent. Merge order: #3238
first, then rebase this onto `main` and take it out of draft.

## Known gaps / follow-up

- No checkpoint/partial-result recovery on timeout (see above — explicitly
  out of scope for this pass).
- No visible queue position for a message stuck behind another one's lock —
  the "on it" ack tells you when your turn *started*, not how long you
  waited first.
