### PR TITLE
feat(ag2space): detach room-session provider runs from the watcher's clock

### DIFF
--- a/skills/ag2space-room-sessions/SKILL.md
+++ b/skills/ag2space-room-sessions/SKILL.md
@@ -9,18 +9,61 @@ user-invocable: false
 This runtime skill claims only owner-tier AG2 Space tasks carrying the exact
 trusted `session_scope: room` header. It hashes the Matrix room ID into a stable
 key and resumes one Claude or Codex provider session for that `(runtime, room)`
-pair. Messages in the same room serialize through the same lock and session;
-different rooms may run through the watcher's bounded parallel workers.
+pair. Messages in the same room serialize through the same session; different
+rooms may run through the watcher's bounded parallel workers.
 
 Missing, malformed, or future scope values, non-AG2 sources, and Team or Guest
-tasks remain unhandled and follow their established paths. Provider failures
-also return the task to the live core so a transient CLI failure cannot strand
-an owner request.
+tasks remain unhandled and follow their established paths.
 
 Session IDs live in `<workspace>/state/ag2space-room-sessions.json`. Remove this
 skill or revert its adapter wiring to return every task to the legacy main
 session path.
 
+## Detached execution — the provider run is never on the watcher's clock
+
+`handle()` (what the generic watcher calls) only validates, sends an ack, spawns
+a fully detached worker (`--run-detached`, `start_new_session=True`, not waited
+on), and returns — it never runs the provider inline. The actual run happens in
+`run_detached()`, in a process that outlives `handle()`'s own return, so a long
+room turn never occupies a watcher worker slot or blocks other tasks.
+
+Same-room messages still serialize strictly (each detached worker blocks on the
+same `fcntl` lock before touching the provider session) — that hasn't changed.
+What changed is *where* the wait happens: a message queued behind an earlier one
+in the same room gets an explicit "queued, your turn is coming" ack instead of
+the watcher silently sitting on it.
+
 Provider hard and stall timeouts default to the values declared in
 `manifest.json`. CLI options override environment values, which override the
-manifest defaults.
+manifest defaults. `SUTANDO_TIER_HARD_TIMEOUT` is now a safety ceiling against a
+genuinely runaway process (manifest default 3600s) rather than a normal
+completion boundary — since the run is off the watcher's request/response
+cycle, a long-but-progressing turn is expected and not itself a problem.
+`SUTANDO_TIER_STALL_TIMEOUT` (180s, unchanged) is the practical "this is
+actually stuck" signal: a working provider streams some output periodically.
+
+## Progress visibility
+
+Three best-effort notifications, all through the shared `task-progress`
+notifier (the same delivery path the `NOTIFY FIRST` convention already uses
+everywhere else in this codebase):
+
+- **On receipt** (from `handle()`, immediately) — "queued behind an earlier
+  message" if another detached worker already holds this room's claim, "on it"
+  otherwise.
+- **Heartbeat**, every `SUTANDO_TIER_HEARTBEAT_INTERVAL` seconds (120s default)
+  while the provider is actually running.
+- **On failure** (provider error, hard/stall timeout) — `run_detached()`
+  publishes an explicit failure result directly. This is a real behavior change
+  from the old design, not just messaging: once `handle()` has told the watcher
+  "0, handled," there is no synchronous caller left to fall back to the live
+  core, so a detached failure is reported by publishing a plain, honest failure
+  body ("...couldn't complete: `<reason>`. Resend for a fresh attempt.") rather
+  than silently discarding the attempt or leaving the room with no reply at
+  all. A crashed detached worker's `fcntl` lock releases automatically when the
+  OS closes its file descriptors on process death — the *next* message for that
+  room proceeds normally without any special recovery logic; the small
+  `<runtime>-<room-key>.active` claim file is purely informational (drives the
+  queued-vs-working ack), never load-bearing for correctness.
+
+All three are best-effort: a broken or slow notifier costs only visibility.

--- a/skills/ag2space-room-sessions/manifest.json
+++ b/skills/ag2space-room-sessions/manifest.json
@@ -11,8 +11,9 @@
     "secrets": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
   },
   "config": {
-    "SUTANDO_TIER_HARD_TIMEOUT": "900",
-    "SUTANDO_TIER_STALL_TIMEOUT": "180"
+    "SUTANDO_TIER_HARD_TIMEOUT": "3600",
+    "SUTANDO_TIER_STALL_TIMEOUT": "180",
+    "SUTANDO_TIER_HEARTBEAT_INTERVAL": "120"
   },
   "provenance": {
     "source_repo": "https://github.com/sonichi/sutando"

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import uuid
 from contextlib import contextmanager
@@ -195,11 +196,8 @@ def _run_bounded(
     heartbeat_interval_override: Optional[float] = None,
     on_heartbeat: Optional[Callable[[float], None]] = None,
 ) -> tuple[int, str, str]:
-    # hard_timeout is a safety ceiling against a truly runaway process holding the
-    # room lock forever, not a normal completion boundary — the caller (run_detached)
-    # runs off the watcher's own request/response cycle, so a long-but-progressing
-    # run is expected and fine. stall_timeout is the real "this is actually stuck"
-    # signal: a working provider streams SOME output periodically.
+    # hard_timeout is a safety ceiling, not a completion boundary — this runs off the
+    # watcher's clock. stall_timeout (no output at all) is the real "stuck" signal.
     hard_timeout = _timeout("SUTANDO_TIER_HARD_TIMEOUT", hard_timeout_override)
     stall_timeout = _timeout("SUTANDO_TIER_STALL_TIMEOUT", stall_timeout_override)
     try:
@@ -233,7 +231,9 @@ def _run_bounded(
         # firing a burst of catch-up pings once the loop resumes.
         while next_heartbeat is not None and now >= next_heartbeat:
             next_heartbeat += heartbeat_interval
-        on_heartbeat(now - started)
+        # Off-thread: on_heartbeat can block (_notify's subprocess call has its own
+        # 15s timeout) and must never delay this loop's own deadline checks.
+        threading.Thread(target=on_heartbeat, args=(now - started,), daemon=True).start()
 
     try:
         while selector.get_map():
@@ -528,11 +528,8 @@ def run_detached(
                 if not body.strip():
                     raise RuntimeError(f"{runtime} returned an empty result")
             except Exception as exc:
-                # Unlike the old synchronous design, there is no watcher call left to
-                # return 1 to — the watcher was already told "0, handled" the moment
-                # this was spawned. The only honest options are silence (what this
-                # whole design exists to stop) or publishing an explicit failure, so:
-                # publish one, plainly, rather than let the room simply never hear back.
+                # No watcher call left to fall back to (it was already told "0,
+                # handled") — publish an honest failure rather than go silent.
                 print(f"AG2 Space room-session worker (detached): {exc}", file=sys.stderr)
                 _publish_once(
                     results_dir / task_file.name,
@@ -541,9 +538,7 @@ def run_detached(
                 )
                 return
             if not _publish_once(results_dir / task_file.name, body):
-                # Lost the publish race — something already occupies this task's
-                # result path (a genuine winner, or a stale non-ready placeholder).
-                # Never clobber; just make the loss visible instead of silent.
+                # Lost the publish race — never clobber; make the loss visible instead.
                 print(
                     f"AG2 Space room-session worker (detached): {runtime} completed "
                     "but lost the publish race for this task's result path",
@@ -575,10 +570,8 @@ def _spawn_detached(
     if stall_timeout is not None:
         command += ["--stall-timeout", str(stall_timeout)]
     with log_path.open("a", encoding="utf-8") as log_file:
-        # start_new_session=True (setsid) is what makes this survive the parent
-        # session-worker.py process exiting moments from now, the same primitive
-        # _run_bounded already uses for the provider subprocess itself. Deliberately
-        # not waited on: that's the entire point of detaching.
+        # start_new_session=True (setsid) survives the parent exiting; not waited
+        # on — that's the entire point of detaching.
         subprocess.Popen(
             command, cwd=repo, env=os.environ.copy(),
             stdin=subprocess.DEVNULL, stdout=log_file, stderr=log_file,

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -20,7 +20,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 
 UNHANDLED = 3
@@ -192,9 +192,20 @@ def _run_bounded(
     cwd: Path,
     hard_timeout_override: Optional[float] = None,
     stall_timeout_override: Optional[float] = None,
+    heartbeat_interval_override: Optional[float] = None,
+    on_heartbeat: Optional[Callable[[float], None]] = None,
 ) -> tuple[int, str, str]:
+    # hard_timeout is a safety ceiling against a truly runaway process holding the
+    # room lock forever, not a normal completion boundary — the caller (run_detached)
+    # runs off the watcher's own request/response cycle, so a long-but-progressing
+    # run is expected and fine. stall_timeout is the real "this is actually stuck"
+    # signal: a working provider streams SOME output periodically.
     hard_timeout = _timeout("SUTANDO_TIER_HARD_TIMEOUT", hard_timeout_override)
     stall_timeout = _timeout("SUTANDO_TIER_STALL_TIMEOUT", stall_timeout_override)
+    try:
+        heartbeat_interval = _timeout("SUTANDO_TIER_HEARTBEAT_INTERVAL", heartbeat_interval_override)
+    except ValueError:
+        heartbeat_interval = 0.0
     process = subprocess.Popen(
         command,
         cwd=cwd,
@@ -212,6 +223,18 @@ def _run_bounded(
         os.set_blocking(fd, False)
         selector.register(fd, selectors.EVENT_READ, name)
     started = last_progress = time.monotonic()
+    next_heartbeat = started + heartbeat_interval if heartbeat_interval > 0 else None
+
+    def _maybe_heartbeat(now: float) -> None:
+        nonlocal next_heartbeat
+        if next_heartbeat is None or now < next_heartbeat or on_heartbeat is None:
+            return
+        # Skip ahead past any interval(s) a slow select()/sleep() overran, rather than
+        # firing a burst of catch-up pings once the loop resumes.
+        while next_heartbeat is not None and now >= next_heartbeat:
+            next_heartbeat += heartbeat_interval
+        on_heartbeat(now - started)
+
     try:
         while selector.get_map():
             now = time.monotonic()
@@ -219,6 +242,7 @@ def _run_bounded(
                 raise TimeoutError(f"provider exceeded hard timeout ({hard_timeout:g}s)")
             if now - last_progress >= stall_timeout:
                 raise TimeoutError(f"provider made no progress for {stall_timeout:g}s")
+            _maybe_heartbeat(now)
             for key, _ in selector.select(timeout=min(0.2, stall_timeout)):
                 try:
                     chunk = os.read(key.fd, 65536)
@@ -235,6 +259,7 @@ def _run_bounded(
                 raise TimeoutError(f"provider exceeded hard timeout ({hard_timeout:g}s)")
             if now - last_progress >= stall_timeout:
                 raise TimeoutError(f"provider made no progress for {stall_timeout:g}s")
+            _maybe_heartbeat(now)
             time.sleep(min(0.05, stall_timeout))
         return (
             int(process.returncode or 0),
@@ -284,6 +309,72 @@ def _working_dir(repo: Path) -> Path:
     return Path(os.environ.get("SUTANDO_ISOLATED_WORKING_DIR", str(repo))).expanduser()
 
 
+def _notify(task_file: Path, message: str) -> None:
+    """Best-effort progress ping via the shared task-progress notifier — the same
+    delivery path the NOTIFY FIRST convention already uses everywhere else in this
+    codebase. Never raises: a broken or slow notify path only costs visibility."""
+    try:
+        headers = parse_task_headers_trusted(
+            task_file.read_text(encoding="utf-8", errors="replace")
+        ).headers
+    except OSError:
+        return
+    source = headers.get("source") or ""
+    channel_id = headers.get("channel_id") or ""
+    if not source or not channel_id:
+        return
+    notifier = REPO_ROOT / "skills" / "task-progress" / "scripts" / "notify.py"
+    if not notifier.is_file():
+        return
+    try:
+        subprocess.run(
+            [sys.executable, str(notifier), "--source", source, "--channel-id", channel_id,
+             "--message", message],
+            timeout=15, check=False,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+def _claim_path(workspace: Path, runtime: str, room_key: str) -> Path:
+    return workspace / "state" / "ag2space-room-session-locks" / f"{runtime}-{room_key}.active"
+
+
+def _claim_is_live(path: Path) -> bool:
+    """Informational only — the flock in run_detached() is what actually prevents two
+    workers touching the same provider session; a crashed holder's flock releases on
+    its own when the OS closes that process's file descriptors. This just answers
+    'should the ack say queued or working' and 'did the previous attempt crash', so a
+    wrong answer here costs a slightly-off status message, never correctness."""
+    data = _read_json(path)
+    pid = data.get("pid")
+    if not isinstance(pid, int):
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _write_claim(path: Path, task_id: str) -> None:
+    _atomic_text(path, json.dumps({
+        "pid": os.getpid(),
+        "task_id": task_id,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _clear_claim(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
 def _claude_command(session_id: str, resume: bool, prompt: str) -> list[str]:
     command = ["claude", "-p", "--resume" if resume else "--session-id", session_id]
     command += ["--output-format", "text", "--dangerously-skip-permissions", "--add-dir", str(Path.home())]
@@ -321,6 +412,7 @@ def _run_claude(
     repo: Path,
     hard_timeout: Optional[float] = None,
     stall_timeout: Optional[float] = None,
+    on_heartbeat: Optional[Callable[[float], None]] = None,
 ) -> str:
     session_id, created = _session_id(workspace, "claude", room_key)
     return_code, stdout, stderr = _run_bounded(
@@ -328,6 +420,7 @@ def _run_claude(
         _working_dir(repo),
         hard_timeout,
         stall_timeout,
+        on_heartbeat=on_heartbeat,
     )
     if return_code:
         raise RuntimeError(stderr.strip() or f"claude exited {return_code}")
@@ -343,6 +436,7 @@ def _run_codex(
     repo: Path,
     hard_timeout: Optional[float] = None,
     stall_timeout: Optional[float] = None,
+    on_heartbeat: Optional[Callable[[float], None]] = None,
 ) -> str:
     state = _read_json(_state_path(workspace))
     row = ((state.get("sessions") or {}).get("codex") or {}).get(room_key)
@@ -359,6 +453,7 @@ def _run_codex(
             _working_dir(repo),
             hard_timeout,
             stall_timeout,
+            on_heartbeat=on_heartbeat,
         )
         if return_code:
             raise RuntimeError(stderr.strip() or f"codex exited {return_code}")
@@ -395,6 +490,102 @@ def probe(runtime: str, workspace: Path, task_file: Path) -> int:
     return 0 if resolve_room_key(task_file) else UNHANDLED
 
 
+def run_detached(
+    runtime: str,
+    workspace: Path,
+    task_file: Path,
+    results_dir: Path,
+    repo: Path,
+    hard_timeout: Optional[float] = None,
+    stall_timeout: Optional[float] = None,
+) -> None:
+    """The actual provider run, off the watcher's request/response cycle entirely —
+    invoked only via `--run-detached` in a process `handle()` spawned and did not
+    wait for. A long-but-progressing run is expected here; nothing upstream is
+    blocked on this function returning."""
+    room_key = resolve_room_key(task_file)
+    if room_key is None or _completed_result_exists(results_dir, task_file.name):
+        return
+    lock = workspace / "state" / "ag2space-room-session-locks" / f"{runtime}-{room_key}.lock"
+    claim = _claim_path(workspace, runtime, room_key)
+    try:
+        with _locked(lock):
+            if _completed_result_exists(results_dir, task_file.name):
+                return
+            _write_claim(claim, task_file.stem)
+            _notify(task_file, "On it — working on this now.")
+            heartbeat = lambda elapsed: _notify(  # noqa: E731
+                task_file, f"Still working ({elapsed:.0f}s so far)…"
+            )
+            try:
+                body = (
+                    _run_claude(workspace, room_key, _prompt(task_file), repo,
+                                hard_timeout, stall_timeout, on_heartbeat=heartbeat)
+                    if runtime == "claude"
+                    else _run_codex(workspace, room_key, _prompt(task_file), repo,
+                                     hard_timeout, stall_timeout, on_heartbeat=heartbeat)
+                )
+                if not body.strip():
+                    raise RuntimeError(f"{runtime} returned an empty result")
+            except Exception as exc:
+                # Unlike the old synchronous design, there is no watcher call left to
+                # return 1 to — the watcher was already told "0, handled" the moment
+                # this was spawned. The only honest options are silence (what this
+                # whole design exists to stop) or publishing an explicit failure, so:
+                # publish one, plainly, rather than let the room simply never hear back.
+                print(f"AG2 Space room-session worker (detached): {exc}", file=sys.stderr)
+                _publish_once(
+                    results_dir / task_file.name,
+                    "This room session hit an error and couldn't complete: "
+                    f"{exc}\n\nResend your message for a fresh attempt.",
+                )
+                return
+            if not _publish_once(results_dir / task_file.name, body):
+                # Lost the publish race — something already occupies this task's
+                # result path (a genuine winner, or a stale non-ready placeholder).
+                # Never clobber; just make the loss visible instead of silent.
+                print(
+                    f"AG2 Space room-session worker (detached): {runtime} completed "
+                    "but lost the publish race for this task's result path",
+                    file=sys.stderr,
+                )
+    finally:
+        _clear_claim(claim)
+
+
+def _spawn_detached(
+    runtime: str,
+    workspace: Path,
+    task_file: Path,
+    results_dir: Path,
+    repo: Path,
+    hard_timeout: Optional[float],
+    stall_timeout: Optional[float],
+) -> None:
+    logs = workspace / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    log_path = logs / f"ag2space-room-session-{task_file.stem}.log"
+    command = [
+        sys.executable, str(Path(__file__).resolve()), "--run-detached",
+        "--runtime", runtime, "--workspace", str(workspace),
+        "--task-file", str(task_file), "--results-dir", str(results_dir), "--repo", str(repo),
+    ]
+    if hard_timeout is not None:
+        command += ["--hard-timeout", str(hard_timeout)]
+    if stall_timeout is not None:
+        command += ["--stall-timeout", str(stall_timeout)]
+    with log_path.open("a", encoding="utf-8") as log_file:
+        # start_new_session=True (setsid) is what makes this survive the parent
+        # session-worker.py process exiting moments from now, the same primitive
+        # _run_bounded already uses for the provider subprocess itself. Deliberately
+        # not waited on: that's the entire point of detaching.
+        subprocess.Popen(
+            command, cwd=repo, env=os.environ.copy(),
+            stdin=subprocess.DEVNULL, stdout=log_file, stderr=log_file,
+            start_new_session=True,
+        )
+
+
 def handle(
     runtime: str,
     workspace: Path,
@@ -403,7 +594,11 @@ def handle(
     repo: Path,
     hard_timeout: Optional[float] = None,
     stall_timeout: Optional[float] = None,
+    spawn: Optional[Callable[..., None]] = None,
 ) -> int:
+    """Fast foreground path only: validate, ack, hand off, return — never runs the
+    provider inline. The actual work happens in run_detached(), off this call
+    entirely, so a long-running room turn never occupies a watcher worker slot."""
     if probe(runtime, workspace, task_file) != 0:
         return UNHANDLED
     task_file = task_file.resolve()
@@ -411,24 +606,19 @@ def handle(
     assert room_key is not None
     if _completed_result_exists(results_dir, task_file.name):
         return 0
-    lock = workspace / "state" / "ag2space-room-session-locks" / f"{runtime}-{room_key}.lock"
+    claim = _claim_path(workspace, runtime, room_key)
+    if _claim_is_live(claim):
+        _notify(task_file, "Queued behind an earlier message in this room — "
+                            "you'll get a reply as soon as it's your turn.")
+    else:
+        _notify(task_file, "On it — working on this now.")
+    launcher = spawn or _spawn_detached
     try:
-        with _locked(lock):
-            if _completed_result_exists(results_dir, task_file.name):
-                return 0
-            body = (
-                _run_claude(workspace, room_key, _prompt(task_file), repo, hard_timeout, stall_timeout)
-                if runtime == "claude"
-                else _run_codex(workspace, room_key, _prompt(task_file), repo, hard_timeout, stall_timeout)
-            )
-            if not body.strip():
-                raise RuntimeError(f"{runtime} returned an empty result")
-            if not _publish_once(results_dir / task_file.name, body):
-                raise RuntimeError("result destination exists but is not ready")
-        return 0
-    except Exception as exc:
-        print(f"AG2 Space room-session worker: {exc}", file=sys.stderr)
+        launcher(runtime, workspace, task_file, results_dir, repo, hard_timeout, stall_timeout)
+    except OSError as exc:
+        print(f"AG2 Space room-session worker: failed to start detached worker: {exc}", file=sys.stderr)
         return 1
+    return 0
 
 
 def main() -> int:
@@ -441,9 +631,16 @@ def main() -> int:
     parser.add_argument("--hard-timeout", type=float)
     parser.add_argument("--stall-timeout", type=float)
     parser.add_argument("--probe", action="store_true")
+    parser.add_argument("--run-detached", action="store_true")
     args = parser.parse_args()
     if args.probe:
         return probe(args.runtime, args.workspace, args.task_file)
+    if args.run_detached:
+        run_detached(
+            args.runtime, args.workspace, args.task_file, args.results_dir, args.repo,
+            args.hard_timeout, args.stall_timeout,
+        )
+        return 0
     return handle(
         args.runtime,
         args.workspace,

--- a/tests/ag2space-room-session-worker.test.py
+++ b/tests/ag2space-room-session-worker.test.py
@@ -83,9 +83,8 @@ def run_worker(runtime: str, workspace: Path, task_file: Path, env: dict[str, st
             runtime, workspace, task_file, workspace / "results", REPO
         )
     output = stderr.getvalue()
-    # run_detached always publishes SOMETHING on a genuine exception now (an honest
-    # failure body, not silence) — the exception log line, not file presence, is
-    # what distinguishes "failed" from "succeeded" here.
+    # run_detached always publishes something now (even a failure body) — the
+    # exception log line, not file presence, distinguishes failed from succeeded.
     return_code = 1 if "AG2 Space room-session worker (detached):" in output else 0
     return subprocess.CompletedProcess([], return_code, "", output)
 
@@ -340,6 +339,21 @@ def test_runtime_edges_and_adapter_wiring() -> None:
             else:
                 check(False, "non-positive provider timeout is rejected")
 
+        # A slow/blocking heartbeat callback must never delay the deadline check —
+        # it's dispatched off-thread, not called inline in the monitor loop.
+        with patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "0.2",
+                                     "SUTANDO_TIER_STALL_TIMEOUT": "2",
+                                     "SUTANDO_TIER_HEARTBEAT_INTERVAL": "0.01"}):
+            slow_heartbeat = lambda elapsed: time.sleep(1)  # noqa: E731
+            started = time.monotonic()
+            try:
+                worker._run_bounded([str(sleeper)], root, on_heartbeat=slow_heartbeat)
+            except TimeoutError:
+                check(time.monotonic() - started < 0.5,
+                      "a slow heartbeat callback never delays the hard-timeout check")
+            else:
+                check(False, "a slow heartbeat callback never delays the hard-timeout check")
+
         with patch.dict(os.environ, {}, clear=True):
             check(worker._timeout("SUTANDO_TIER_HARD_TIMEOUT", None) == 3600,
                   "manifest declares the hard-timeout safety-ceiling default")
@@ -434,9 +448,8 @@ def test_direct_failure_and_cli_edges() -> None:
         check(accepted and published.read_text() == "first\n",
               "publish-once accepts an already-ready winning writer")
 
-        # Double-checked completion now lives in run_detached, not handle() — this is
-        # what protects against a stale detached worker relaunching provider work a
-        # different one already finished while this one waited on the lock.
+        # Double-checked completion now lives in run_detached, not handle() — guards
+        # against a stale worker relaunching work another one already finished.
         raced = task(workspace, "task-raced")
         with patch.object(worker, "_completed_result_exists", side_effect=[False, True]), \
              patch.object(worker, "_run_codex") as provider:
@@ -479,8 +492,7 @@ def test_handle_spawns_detached_and_never_runs_provider() -> None:
               "handle acks immediately when no other worker is active for this room")
 
         # A second message for the SAME room, while the first's claim is still live,
-        # gets an honest "queued" ack instead of the same "on it" — the whole point
-        # Chi's design push was about: tell the room what's actually happening.
+        # gets an honest "queued" ack instead of the same "on it".
         room_key = worker.resolve_room_key(started)
         assert room_key
         claim = worker._claim_path(workspace, "claude", room_key)

--- a/tests/ag2space-room-session-worker.test.py
+++ b/tests/ag2space-room-session-worker.test.py
@@ -73,12 +73,21 @@ def task(
 
 
 def run_worker(runtime: str, workspace: Path, task_file: Path, env: dict[str, str]) -> subprocess.CompletedProcess:
+    """Drives run_detached() directly — the actual provider-running body, now off
+    handle()'s own call entirely. Named run_worker (not run_detached_worker) to
+    keep the diff against the pre-detachment test suite legible; it exercises the
+    same locked-run-then-publish contract handle() used to run inline."""
     stderr = io.StringIO()
-    with patch.dict(os.environ, env), redirect_stderr(stderr):
-        return_code = worker.handle(
+    with patch.dict(os.environ, env), redirect_stderr(stderr), patch.object(worker, "_notify"):
+        worker.run_detached(
             runtime, workspace, task_file, workspace / "results", REPO
         )
-    return subprocess.CompletedProcess([], return_code, "", stderr.getvalue())
+    output = stderr.getvalue()
+    # run_detached always publishes SOMETHING on a genuine exception now (an honest
+    # failure body, not silence) — the exception log line, not file presence, is
+    # what distinguishes "failed" from "succeeded" here.
+    return_code = 1 if "AG2 Space room-session worker (detached):" in output else 0
+    return subprocess.CompletedProcess([], return_code, "", output)
 
 
 def test_opt_in_and_cardinality() -> None:
@@ -190,8 +199,10 @@ print('claude room result')
         failed = task(workspace, "task-claude-fail", room_id="!failure:a")
         result = run_worker("claude", workspace, failed, {**env, "FAIL_PROVIDER": "1"})
         check(result.returncode == 1 and "provider failed" in result.stderr,
-              "provider failure returns watcher fallback signal")
-        check(not (workspace / "results" / failed.name).exists(), "provider failure publishes no result")
+              "provider failure is logged")
+        failure_body = (workspace / "results" / failed.name).read_text(encoding="utf-8")
+        check("couldn't complete" in failure_body and "provider failed" in failure_body,
+              "provider failure publishes an explicit failure result, not silence")
 
 
 def test_codex_create_resume_and_result_ownership() -> None:
@@ -330,8 +341,10 @@ def test_runtime_edges_and_adapter_wiring() -> None:
                 check(False, "non-positive provider timeout is rejected")
 
         with patch.dict(os.environ, {}, clear=True):
-            check(worker._timeout("SUTANDO_TIER_HARD_TIMEOUT", None) == 900,
-                  "manifest declares the hard-timeout default")
+            check(worker._timeout("SUTANDO_TIER_HARD_TIMEOUT", None) == 3600,
+                  "manifest declares the hard-timeout safety-ceiling default")
+            check(worker._timeout("SUTANDO_TIER_HEARTBEAT_INTERVAL", None) == 120,
+                  "manifest declares the heartbeat-interval default")
             check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", None) == 180,
                   "manifest declares the stall-timeout default")
         with patch.dict(os.environ, {"SUTANDO_TIER_STALL_TIMEOUT": "12"}):
@@ -401,7 +414,7 @@ def test_cli_probe_and_empty_output() -> None:
         executable(root / "claude", "#!/bin/sh\nprintf '   \\n'\n")
         result = run_worker("claude", workspace, room_task, {"PATH": f"{root}:{os.environ['PATH']}"})
         check(result.returncode == 1 and "empty result" in result.stderr,
-              "empty provider output falls back without publishing")
+              "empty provider output is treated as a failure, not a real result")
 
 
 def test_direct_failure_and_cli_edges() -> None:
@@ -421,11 +434,14 @@ def test_direct_failure_and_cli_edges() -> None:
         check(accepted and published.read_text() == "first\n",
               "publish-once accepts an already-ready winning writer")
 
+        # Double-checked completion now lives in run_detached, not handle() — this is
+        # what protects against a stale detached worker relaunching provider work a
+        # different one already finished while this one waited on the lock.
         raced = task(workspace, "task-raced")
         with patch.object(worker, "_completed_result_exists", side_effect=[False, True]), \
              patch.object(worker, "_run_codex") as provider:
-            code = worker.handle("codex", workspace, raced, results, REPO)
-        check(code == 0 and not provider.called, "locked completion check prevents a duplicate launch")
+            worker.run_detached("codex", workspace, raced, results, REPO)
+        check(not provider.called, "locked completion check in run_detached prevents a duplicate launch")
 
         argv = ["session-worker", "--runtime", "codex", "--workspace", str(workspace),
                 "--task-file", str(raced), "--results-dir", str(results), "--repo", str(REPO)]
@@ -433,6 +449,85 @@ def test_direct_failure_and_cli_edges() -> None:
             check(worker.main() == 17, "CLI main dispatches probe mode")
         with patch.object(sys, "argv", argv), patch.object(worker, "handle", return_value=18):
             check(worker.main() == 18, "CLI main dispatches handle mode")
+        with patch.object(sys, "argv", argv + ["--run-detached"]), \
+             patch.object(worker, "run_detached", return_value=None) as detached:
+            check(worker.main() == 0, "CLI main dispatches run-detached mode")
+        check(detached.call_args.args[:5] == ("codex", workspace, raced, results, REPO),
+              "run-detached mode passes the same identifying arguments through")
+
+
+def test_handle_spawns_detached_and_never_runs_provider() -> None:
+    with tempfile.TemporaryDirectory() as name:
+        workspace = Path(name)
+        results = workspace / "results"
+        results.mkdir()
+        started = task(workspace, "task-dispatch")
+        spawned: list = []
+
+        def fake_spawn(runtime, ws, task_file, results_dir, repo, hard_timeout, stall_timeout):
+            spawned.append((runtime, task_file.name))
+
+        with patch.object(worker, "_run_claude") as run_claude, \
+             patch.object(worker, "_run_codex") as run_codex, \
+             patch.object(worker, "_notify") as notify:
+            code = worker.handle("claude", workspace, started, results, REPO, spawn=fake_spawn)
+        check(code == 0, "handle returns 0 (claimed) once the detached worker is spawned")
+        check(not run_claude.called and not run_codex.called,
+              "handle never runs a provider inline — that only happens in run_detached")
+        check(spawned == [("claude", started.name)], "handle hands the task off to the spawn function")
+        check(notify.call_args.args[1] == "On it — working on this now.",
+              "handle acks immediately when no other worker is active for this room")
+
+        # A second message for the SAME room, while the first's claim is still live,
+        # gets an honest "queued" ack instead of the same "on it" — the whole point
+        # Chi's design push was about: tell the room what's actually happening.
+        room_key = worker.resolve_room_key(started)
+        assert room_key
+        claim = worker._claim_path(workspace, "claude", room_key)
+        worker._write_claim(claim, started.stem)
+        second = task(workspace, "task-dispatch-two")
+        with patch.object(worker, "_notify") as notify:
+            worker.handle("claude", workspace, second, results, REPO, spawn=fake_spawn)
+        check(notify.call_args.args[1].startswith("Queued behind an earlier message"),
+              "handle acks 'queued' when a live claim already holds this room")
+
+        def failing_spawn(*_args, **_kwargs):
+            raise OSError("no interpreter")
+        with patch.object(worker, "_notify"):
+            code = worker.handle("claude", workspace, second, results, REPO, spawn=failing_spawn)
+        check(code == 1, "handle surfaces a spawn failure as the ordinary watcher-fallback signal")
+
+
+def test_run_detached_claim_lifecycle_and_failure_reporting() -> None:
+    with tempfile.TemporaryDirectory() as name:
+        root = Path(name)
+        workspace = root / "workspace"
+        (workspace / "results").mkdir(parents=True)
+        crashy = task(workspace, "task-crashy")
+        room_key = worker.resolve_room_key(crashy)
+        assert room_key
+        claim = worker._claim_path(workspace, "claude", room_key)
+
+        def crash(*_args, **_kwargs):
+            check(claim.exists(), "claim file is present for the duration of the locked run")
+            raise RuntimeError("boom")
+
+        with patch.object(worker, "_run_claude", side_effect=crash), patch.object(worker, "_notify") as notify:
+            worker.run_detached("claude", workspace, crashy, workspace / "results", REPO)
+        check(not claim.exists(), "claim is cleared even when the run raises")
+        failure_body = (workspace / "results" / crashy.name).read_text(encoding="utf-8")
+        check("boom" in failure_body, "the explicit failure body names the actual error")
+        acks = [call.args[1] for call in notify.call_args_list]
+        check(acks[0] == "On it — working on this now.", "run_detached itself also acks before running")
+
+        check(not worker._claim_is_live(root / "missing.json"),
+              "a missing claim file is never treated as live")
+        worker._atomic_text(claim, json.dumps({"pid": "not-an-int"}))
+        check(not worker._claim_is_live(claim), "a claim with a non-integer pid is never treated as live")
+        # PID 1 always exists (init/launchd) and this test doesn't own it, so a
+        # permission-denied kill(pid, 0) must still read as live, not absent.
+        worker._atomic_text(claim, json.dumps({"pid": 1}))
+        check(worker._claim_is_live(claim), "a claim naming a real but unowned pid is treated as live")
 
 
 def main() -> int:
@@ -444,6 +539,8 @@ def main() -> int:
     test_runtime_edges_and_adapter_wiring()
     test_cli_probe_and_empty_output()
     test_direct_failure_and_cli_edges()
+    test_handle_spawns_detached_and_never_runs_provider()
+    test_run_detached_claim_lifecycle_and_failure_reporting()
     print(f"\nResults: {len(FAILURES)} failed")
     return 1 if FAILURES else 0
 


### PR DESCRIPTION
## Scope

Redesigns `session-worker.py`'s execution model for the ag2space room-session skill (stacked on #3238 — base branch `feat/native-ag2space-room-sessions`, merge order: #3238 first, this second). Single concern: decouple the provider run from the watcher's synchronous 900s ceiling.

## Why (replaces #3257, which I closed)

#3238's `handle()` runs the provider inline inside the watcher's call, bounded by `_run_bounded()`'s hard timeout. At 900s it kills the subprocess and discards whatever it had produced — a genuinely long room turn (901s+) has no way to ever finish. #3257 only added notifications around that same kill-and-discard behavior; it didn't change it. This PR does:

**Before (this repo, #3238 head):** `handle()` runs `_run_claude`/`_run_codex` inline; `_run_bounded`'s `hard_timeout` (900s) kills the subprocess and `handle()` returns 1 (watcher fallback) — the in-progress work is gone, no result is ever published for that room turn.

**After (this branch):** `handle()` only validates + acks + spawns a fully detached subprocess (`start_new_session=True`, never waited on) and returns 0 immediately. The actual provider run happens in the new `run_detached()`, invoked via `--run-detached` in that detached process — off the watcher's request/response cycle entirely. `hard_timeout` becomes a safety ceiling against a runaway process (manifest default raised 900s → 3600s); a slow-but-progressing turn is no longer killed at 900s. Stall timeout (180s, unchanged) remains the real "stuck" signal — a working provider streams output periodically.

## What changed

- `handle()` / `run_detached()` / `_spawn_detached()` split in `skills/ag2space-room-sessions/scripts/session-worker.py` (see file for the full flow).
- Periodic heartbeat notifications (new `SUTANDO_TIER_HEARTBEAT_INTERVAL`, 120s default) while the provider is actually running, via the existing `task-progress` notifier.
- On genuine provider failure, `run_detached()` publishes an explicit, honest failure body ("...couldn't complete: `<reason>`. Resend for a fresh attempt.") instead of silence — there's no synchronous watcher caller left to fall back to once `handle()` has already returned "0, handled."
- Same-room messages still serialize strictly through the existing `fcntl` lock (unchanged); a message queued behind an earlier one in the same room now gets an explicit "queued, your turn is coming" ack instead of the watcher silently sitting on it.
- Crash safety unchanged: `fcntl.flock` releases automatically on process death (fd close), so a crashed detached worker doesn't need special recovery — the next message for that room proceeds normally. The new per-room `<runtime>-<room-key>.active` claim file is purely informational (drives the queued-vs-working ack), never load-bearing for correctness.
- Fixed a regression the split introduced in review: the pre-existing "existing non-ready result blocks the publish, provider work must not silently vanish" path lost its failure-visibility signal when I moved the final publish out of `handle()`'s old return-1 contract. `run_detached()` now logs explicitly when it loses that publish race, instead of the real body just disappearing.

## What this does NOT solve (explicit scope)

No checkpoint/partial-result recovery mid-run — if a run is still in progress when the room needs an answer *right now*, there's still no way to peek at partial output; the room gets the heartbeat and then the final result. That's a materially bigger change (would need the provider to stream partial state somewhere pollable) and is deliberately out of scope here.

## Tests

```
$ python3 tests/ag2space-room-session-worker.test.py
...
Results: 0 failed
```
88/88 pass — 14 new/updated: `handle()`'s spawn dispatch (never runs a provider inline, acks correctly for on-it vs queued, surfaces a spawn `OSError` as a failure signal), the claim helpers (`_claim_path`/`_claim_is_live`/`_write_claim`/`_clear_claim`, including a claim naming a real-but-unowned pid still reading as live), `run_detached`'s locked double-check-under-lock (duplicate-launch prevention moved here from `handle()`) and claim-lifecycle-on-crash, `--run-detached` CLI dispatch, and the manifest-default checks for the new `3600`/`120` values.

```
$ ruff check skills/ag2space-room-sessions/scripts/session-worker.py tests/ag2space-room-session-worker.test.py
All checks passed!
$ python3 -m py_compile skills/ag2space-room-sessions/scripts/session-worker.py tests/ag2space-room-session-worker.test.py
$ python3 scripts/lint-skill.py skills/ag2space-room-sessions
lint-skill: 1 manifest(s), 0 error(s), 0 warning(s)
```

Hardcoded-path scan on the diff: none found.

## Live-path note

This is a bridge/watcher-adjacent execution-path change, so per repo convention it needs a real post-restart round trip, not just unit tests — I have not yet run one against a live room session on this host. Flagging it explicitly as still-needed before this leaves draft; happy to do it once the design direction itself is confirmed, since a live round trip against a design that then gets reshaped is wasted verification.

## Risk / rollback

Config-only + one file's execution model; no schema migration, no new external permission. Rollback is `git revert` this commit — #3238's synchronous inline design is unaffected as a fallback since it's the base this stacks on.
