### PR TITLE
review: token-specific scanner allows for the send-allowlist's own /private/tmp data

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -301,6 +301,13 @@ checks:
       - '/usr/fake'
       - '/tmp/'
       - 'example.com'
+      # The send-allowlist's OWN policy data, not a host path a helper could
+      # resolve: is_path_sendable compares realpaths and macOS resolves /tmp to
+      # /private/tmp, so both spellings must be listed or the prefix never
+      # matches. Token-specific on purpose — a bare '/private/tmp/' allow would
+      # also hide unrelated findings under that root.
+      - '/private/tmp/sutando-'
+      - '/private/tmp/echo-'
     # Tokens allowed ONLY when the SAME added line also carries a companion path
     # for the SAME binary — i.e. the portable candidate-list shape, never a naked
     # literal. Encoded as 'TOKEN_PREFIX :: COMPANION_PREFIX'.

--- a/tests/review-checks.test.sh
+++ b/tests/review-checks.test.sh
@@ -31,6 +31,11 @@ check "# and // comment lines not flagged"            clean $'+++ b/c.js\n@@ -1,
 check "fixture paths (/usr/fake,/nonexistent,/tmp)"   clean $'+++ b/f.js\n@@ -1,0 +1,3 @@\n+a = "/usr/fake/p"\n+b = "/nonexistent/p"\n+c = "/tmp/scratch"'
 check "mixed forbidden+allowed line still flags real" flag  $'+++ b/m.js\n@@ -1,0 +1,1 @@\n+x = "/Users/alice/app"; y = "https://example.com";'
 check "real /Users/tmp/ not masked by /tmp/ allow"    flag  $'+++ b/t.js\n@@ -1,0 +1,1 @@\n+p = "/Users/tmp/keep"'
+# The send-allowlist tokens are exempt, but ONLY those two: a sibling path under
+# the same root must still flag, or the allow would blanket /private/tmp.
+check "allowed /private/tmp/sutando- token"           clean $'+++ b/a.py\n@@ -1,0 +1,1 @@\n+    "/private/tmp/sutando-",'
+check "allowed /private/tmp/echo- token"              clean $'+++ b/a.py\n@@ -1,0 +1,1 @@\n+    "/private/tmp/echo-",'
+check "other /private/tmp/ path still flagged"        flag  $'+++ b/a.py\n@@ -1,0 +1,1 @@\n+    p = "/private/tmp/unrelated-cache"'
 check "~/.claude flagged"                             flag  $'+++ b/g.sh\n@@ -1,0 +1,1 @@\n+cfg=~/.claude/settings.json'
 check "/home/ flagged"                                flag  $'+++ b/i.py\n@@ -1,0 +1,1 @@\n+p = "/home/bob/.config"'
 check "clean diff passes"                             clean $'+++ b/h.js\n@@ -1,0 +1,1 @@\n+const x = resolveWorkspace();'


### PR DESCRIPTION
Split out of #3256 at its reviewer's request — and the reason is the better framing of the two: bundling a scanner exception with the code it exempts **makes the submitted change its own acceptance gate**. This PR is REVIEW.md + its controls only, so the production move in #3256 can be judged against a gate it does not modify.

## What

Two **token-specific** entries in the `hardcoded-paths` `allow` list: `/private/tmp/sutando-` and `/private/tmp/echo-`.

## Why these are policy data, not a host path

`src/send_allowlist.py` (moving to `src/policy/egress/attachment.py` in #3256) defines the deliverable-file prefixes. `is_path_sendable` compares **realpaths**, and macOS resolves `/tmp` → `/private/tmp`, so both spellings must be present or the prefix never matches a real file. `tests/send-allowlist-shared.test.py` asserts all four entries exist, so they cannot be deleted. The existing `/tmp/` allow covers the `/tmp/` pair; only the `/private/tmp/` pair is flagged.

Exempting the **root** `/private/tmp/` was deliberately rejected — it would blanket unrelated findings under that root.

## Controls — both directions

This suite's own comment says an exception that only proves its allow is a half-test, so:

```
ok   allowed /private/tmp/sutando- token
ok   allowed /private/tmp/echo- token
ok   other /private/tmp/ path still flagged
```

And two mutations, to show the controls actually depend on the change:

```
# broaden the allow to the root instead of the tokens:
FAIL other /private/tmp/ path still flagged (rc=0, want=flag)     -> FAILED — 1 of 79 checks
# remove the allows entirely:
FAIL allowed /private/tmp/sutando- token (rc=1, want=clean)
FAIL allowed /private/tmp/echo- token (rc=1, want=clean)
# restored: 79/79 PASS
```

## Merge order

This lands first; #3256 then updates onto it and is re-evaluated against the unmodified gate. #3256 stays blocked until then — expected, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
