### PR TITLE
feat(ag2space): run opted-in rooms in standing provider sessions

### DIFF
--- a/skills/ag2space-room-sessions/SKILL.md
+++ b/skills/ag2space-room-sessions/SKILL.md
@@ -13,7 +13,7 @@ key and gives that room one durable provider conversation.
 Missing, malformed, or future scope values, non-AG2 sources, and Team or Guest
 tasks remain unhandled and follow their established paths.
 
-## Standing-session execution (Claude runtime)
+## Standing-session execution (both runtimes)
 
 Each opted-in room runs a **standing session**: a long-lived interactive
 `claude` process in a dedicated tmux pane (skill-owned socket, one pane per
@@ -75,12 +75,24 @@ Explicit non-goal: a runaway turn that keeps producing output forever is only
 bounded by the room noticing its heartbeats — kill it manually with
 `tmux -S <socket> kill-session -t <pane>` if needed.
 
-## Codex runtime — per-message fallback
+## Codex specifics (live-verified on codex-cli 0.149.0)
 
-Codex tasks keep the previous per-message `codex exec` / `exec resume` path
-unchanged (turn-length lock, watcher fallback on failure). Interactive codex
-resume-id discovery inside a pane is unverified; moving codex onto the standing
-path is follow-up work, not silently claimed here.
+Codex runs the same pane flow with three runtime differences:
+
+- **It names its own session.** Create-mode launches bare `codex`; the id is
+  discovered from the rollout file the FIRST TURN creates
+  (`$CODEX_HOME/sessions/**/rollout-<ts>-<uuid>.jsonl`, filtered to files newer
+  than the spawn marker whose meta `cwd` matches our working dir — other codex
+  runs, e.g. `exec`, also write rollouts). The monitor records the discovered
+  id; the next respawn uses `codex resume <id>`.
+- **First use in a directory shows a trust dialog** — the spawn readiness loop
+  detects and answers it (Enter = "Yes, continue") at most once.
+- **Injection needs the paste-guard delay** (applies to both runtimes): an
+  Enter arriving in the same burst as the text is folded into the composer,
+  not submitted. `_inject` pauses between text and Enter for this reason.
+
+Mid-turn queueing is native: codex explicitly shows "Messages to be submitted
+after next tool call" for a message injected during a running turn.
 
 ## State and configuration
 

--- a/skills/ag2space-room-sessions/SKILL.md
+++ b/skills/ag2space-room-sessions/SKILL.md
@@ -26,13 +26,21 @@ a whole turn), ensures the pane exists — respawning with `claude --resume
 survives process death — writes a sanitized **spool prompt** (the trusted task
 view; never the raw task file), injects one line pointing at it into the live
 pane, detaches a per-task monitor, acks the room, and returns immediately. The
-watcher is never occupied by a running turn.
+watcher is never occupied by a running turn. A session id is recorded only
+after the pane proves itself with output — recording earlier would poison every
+later `--resume` with a session that may never have existed; a startup failure
+raises with the dying pane's last screen as the diagnostic.
 
-**Publication ownership flips versus the old inline design:** the standing
-session itself writes the result to `results/<task-id>.txt` (the spool prompt
-names the exact path — which necessarily embeds the task id). The monitor is
-the backstop publisher on failure, never a competing one: it only writes after
-the pane is dead or was just killed.
+**The monitor is the sole publisher of the shared result path.** The session
+writes only its own private out-file
+(`state/ag2space-room-sessions/spool/<task-id>.out.txt`); the monitor waits for
+that output to be non-empty and stable (an ordinary write is not atomic and
+must never be published mid-way), then publishes it atomically via the
+no-clobber `_publish_once`. The session never touches
+`results/<task-id>.txt`, so a session/monitor write race is structurally
+impossible. On every terminal path the monitor checks the out-file first — a
+turn that finished right before its pane died still delivers its real result,
+not a failure.
 
 **Why standing over per-message spawn:** a mid-turn message (including a
 cancel or redirect) enters the live conversation natively instead of queueing
@@ -41,20 +49,27 @@ turn serialization is the session's own input queue, not a turn-length flock.
 
 ## The monitor (per injected turn)
 
-A detached watchdog per task:
+A detached watchdog per task, holding publication ownership until a terminal
+state — a delivered result or an honest failure, never abandonment:
 
 - **Heartbeats** every `SUTANDO_TIER_HEARTBEAT_INTERVAL` (120s default) to the
   room while the turn runs, dispatched off-thread so a slow notifier can never
   delay the checks below.
 - **Stall** = pane content frozen for `SUTANDO_TIER_STALL_TIMEOUT` (180s) with
-  no result — a live provider at least animates its spinner. The pane is killed
-  first, then an honest failure result is published ("resend to continue — the
-  conversation itself is preserved"); the next message respawns via `--resume`.
-- **Safety ceiling** `SUTANDO_TIER_HARD_TIMEOUT` (3600s) bounds the *watchdog*,
-  not the work: a still-active turn is left running with a room notice, and its
-  result still lands whenever it finishes. Long work is never discarded.
-- A pane that **dies** without a result gets the honest failure body after a
-  short grace period.
+  no output — a live provider at least animates its spinner. The pane is killed
+  FIRST (fencing: nothing can keep writing the out-file during the verdict),
+  then the out-file is checked once more — a just-finished turn delivers its
+  real result; otherwise the honest failure body is published ("resend to
+  continue — the conversation itself is preserved") and the next message
+  respawns via `--resume`.
+- **A failing liveness probe is unknown, never a dead verdict** — a transient
+  tmux socket error degrades into stall handling rather than an instant
+  failure, so a probe blip cannot fail a turn that is still running.
+- **Safety ceiling** `SUTANDO_TIER_HARD_TIMEOUT` (3600s) changes the message,
+  never the ownership: the room gets a one-time notice and supervision
+  continues until the terminal state. Long work is never discarded or orphaned.
+- A pane that **dies** without output gets the honest failure body after a
+  short grace period (with the same finished-out-file check first).
 
 Explicit non-goal: a runaway turn that keeps producing output forever is only
 bounded by the room noticing its heartbeats — kill it manually with

--- a/skills/ag2space-room-sessions/SKILL.md
+++ b/skills/ag2space-room-sessions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ag2space-room-sessions
-description: Route opted-in owner tasks from AG2 Space into one durable provider session per room. This runtime skill is adapter-invoked; tasks without the exact trusted room-session policy keep the selected core's existing session.
+description: Route opted-in owner tasks from AG2 Space into one standing provider session per room. This runtime skill is adapter-invoked; tasks without the exact trusted room-session policy keep the selected core's existing session.
 user-invocable: false
 ---
 
@@ -8,19 +8,76 @@ user-invocable: false
 
 This runtime skill claims only owner-tier AG2 Space tasks carrying the exact
 trusted `session_scope: room` header. It hashes the Matrix room ID into a stable
-key and resumes one Claude or Codex provider session for that `(runtime, room)`
-pair. Messages in the same room serialize through the same lock and session;
-different rooms may run through the watcher's bounded parallel workers.
+key and gives that room one durable provider conversation.
 
 Missing, malformed, or future scope values, non-AG2 sources, and Team or Guest
-tasks remain unhandled and follow their established paths. Provider failures
-also return the task to the live core so a transient CLI failure cannot strand
-an owner request.
+tasks remain unhandled and follow their established paths.
 
-Session IDs live in `<workspace>/state/ag2space-room-sessions.json`. Remove this
-skill or revert its adapter wiring to return every task to the legacy main
-session path.
+## Standing-session execution (Claude runtime)
 
-Provider hard and stall timeouts default to the values declared in
-`manifest.json`. CLI options override environment values, which override the
-manifest defaults.
+Each opted-in room runs a **standing session**: a long-lived interactive
+`claude` process in a dedicated tmux pane (skill-owned socket, one pane per
+`(runtime, room)`), spawned on the room's first message and kept across
+messages — the same supervised-pane pattern the Sutando core itself runs under.
+
+Per message, `handle()` takes a short lock (spawn + inject ordering only, never
+a whole turn), ensures the pane exists — respawning with `claude --resume
+<recorded-session-id>` after a crash or host reboot, so the conversation
+survives process death — writes a sanitized **spool prompt** (the trusted task
+view; never the raw task file), injects one line pointing at it into the live
+pane, detaches a per-task monitor, acks the room, and returns immediately. The
+watcher is never occupied by a running turn.
+
+**Publication ownership flips versus the old inline design:** the standing
+session itself writes the result to `results/<task-id>.txt` (the spool prompt
+names the exact path — which necessarily embeds the task id). The monitor is
+the backstop publisher on failure, never a competing one: it only writes after
+the pane is dead or was just killed.
+
+**Why standing over per-message spawn:** a mid-turn message (including a
+cancel or redirect) enters the live conversation natively instead of queueing
+blind behind a lock; `tmux capture-pane` gives real mid-run observability; and
+turn serialization is the session's own input queue, not a turn-length flock.
+
+## The monitor (per injected turn)
+
+A detached watchdog per task:
+
+- **Heartbeats** every `SUTANDO_TIER_HEARTBEAT_INTERVAL` (120s default) to the
+  room while the turn runs, dispatched off-thread so a slow notifier can never
+  delay the checks below.
+- **Stall** = pane content frozen for `SUTANDO_TIER_STALL_TIMEOUT` (180s) with
+  no result — a live provider at least animates its spinner. The pane is killed
+  first, then an honest failure result is published ("resend to continue — the
+  conversation itself is preserved"); the next message respawns via `--resume`.
+- **Safety ceiling** `SUTANDO_TIER_HARD_TIMEOUT` (3600s) bounds the *watchdog*,
+  not the work: a still-active turn is left running with a room notice, and its
+  result still lands whenever it finishes. Long work is never discarded.
+- A pane that **dies** without a result gets the honest failure body after a
+  short grace period.
+
+Explicit non-goal: a runaway turn that keeps producing output forever is only
+bounded by the room noticing its heartbeats — kill it manually with
+`tmux -S <socket> kill-session -t <pane>` if needed.
+
+## Codex runtime — per-message fallback
+
+Codex tasks keep the previous per-message `codex exec` / `exec resume` path
+unchanged (turn-length lock, watcher fallback on failure). Interactive codex
+resume-id discovery inside a pane is unverified; moving codex onto the standing
+path is follow-up work, not silently claimed here.
+
+## State and configuration
+
+Session IDs live in `<workspace>/state/ag2space-room-sessions.json` (shared by
+both paths; the standing path reads it for `--resume` on respawn). Spool
+prompts are retained under `state/ag2space-room-sessions/spool/` for debugging.
+The tmux socket lives in a short per-user dir outside the workspace
+(`SUTANDO_ROOM_TMUX_DIR` override) because AF_UNIX paths cap at ~104 bytes.
+
+Timeouts default to `manifest.json` values; CLI overrides environment, which
+overrides the manifest. `SUTANDO_ROOM_SPAWN_WAIT` (30s) bounds how long spawn
+waits for first pane output before declaring the launch failed.
+
+Remove this skill or revert its adapter wiring to return every task to the
+legacy main session path; kill stray panes via the skill's tmux socket.

--- a/skills/ag2space-room-sessions/SKILL.md
+++ b/skills/ag2space-room-sessions/SKILL.md
@@ -28,19 +28,26 @@ view; never the raw task file), injects one line pointing at it into the live
 pane, detaches a per-task monitor, acks the room, and returns immediately. The
 watcher is never occupied by a running turn. A session id is recorded only
 after the pane proves itself with output — recording earlier would poison every
-later `--resume` with a session that may never have existed; a startup failure
-raises with the dying pane's last screen as the diagnostic.
+later `--resume` with a session that may never have existed. The provider runs
+under a small `sh` wrapper that prints an exit sentinel and lingers briefly
+when the command dies, so a startup failure always raises with the dying
+pane's actual screen (auth error, traceback, bad flag) as the diagnostic — on
+every tmux version, with no remain-on-exit race.
 
 **The monitor is the sole publisher of the shared result path.** The session
 writes only its own private out-file
-(`state/ag2space-room-sessions/spool/<task-id>.out.txt`); the monitor waits for
-that output to be non-empty and stable (an ordinary write is not atomic and
-must never be published mid-way), then publishes it atomically via the
-no-clobber `_publish_once`. The session never touches
-`results/<task-id>.txt`, so a session/monitor write race is structurally
-impossible. On every terminal path the monitor checks the out-file first — a
-turn that finished right before its pane died still delivers its real result,
-not a failure.
+(`state/ag2space-room-sessions/spool/<task-id>.out.txt`) — and by the spool
+contract it writes `<out>.tmp` first and atomically **renames** it into place
+as its final action: the out-file's existence IS the completion signal
+(elapsed-time stability is not durable evidence of a finished write). The
+monitor publishes it via the no-clobber `_publish_once`. The session never
+touches `results/<task-id>.txt`, so a session/monitor write race is
+structurally impossible. On every terminal path the monitor checks the
+out-file first — a turn that finished right before its pane died still
+delivers its real result, not a failure. And `handle()` checks it under the
+room lock before injecting: a retry after a crashed monitor publishes the
+finished output directly instead of re-running the turn, so stale output can
+never race a fresh injection.
 
 **Why standing over per-message spawn:** a mid-turn message (including a
 cancel or redirect) enters the live conversation natively instead of queueing

--- a/skills/ag2space-room-sessions/manifest.json
+++ b/skills/ag2space-room-sessions/manifest.json
@@ -11,8 +11,10 @@
     "secrets": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
   },
   "config": {
-    "SUTANDO_TIER_HARD_TIMEOUT": "900",
-    "SUTANDO_TIER_STALL_TIMEOUT": "180"
+    "SUTANDO_TIER_HARD_TIMEOUT": "3600",
+    "SUTANDO_TIER_STALL_TIMEOUT": "180",
+    "SUTANDO_TIER_HEARTBEAT_INTERVAL": "120",
+    "SUTANDO_ROOM_SPAWN_WAIT": "30"
   },
   "provenance": {
     "source_repo": "https://github.com/sonichi/sutando"

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -10,8 +10,6 @@ import hashlib
 import json
 import os
 import re
-import selectors
-import signal
 import subprocess
 import sys
 import tempfile
@@ -157,20 +155,6 @@ def _record_session(workspace: Path, runtime: str, room_key: str, session_id: st
         _atomic_text(_state_path(workspace), json.dumps(state, indent=2, sort_keys=True) + "\n")
 
 
-def _terminate(process: subprocess.Popen) -> None:
-    if process.poll() is not None:
-        return
-    try:
-        os.killpg(process.pid, signal.SIGTERM)
-        process.wait(timeout=2)
-    except (ProcessLookupError, subprocess.TimeoutExpired):
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        process.wait(timeout=2)
-
-
 def _manifest_config(key: str) -> str:
     try:
         manifest = json.loads((Path(__file__).resolve().parents[1] / "manifest.json").read_text())
@@ -186,69 +170,6 @@ def _timeout(key: str, cli_value: Optional[float]) -> float:
     if value <= 0:
         raise ValueError("provider timeouts must be positive")
     return value
-
-
-def _run_bounded(
-    command: list[str],
-    cwd: Path,
-    hard_timeout_override: Optional[float] = None,
-    stall_timeout_override: Optional[float] = None,
-) -> tuple[int, str, str]:
-    hard_timeout = _timeout("SUTANDO_TIER_HARD_TIMEOUT", hard_timeout_override)
-    stall_timeout = _timeout("SUTANDO_TIER_STALL_TIMEOUT", stall_timeout_override)
-    process = subprocess.Popen(
-        command,
-        cwd=cwd,
-        env=os.environ.copy(),
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        start_new_session=True,
-    )
-    assert process.stdout is not None and process.stderr is not None
-    streams = {process.stdout.fileno(): "stdout", process.stderr.fileno(): "stderr"}
-    selector = selectors.DefaultSelector()
-    output = {"stdout": [], "stderr": []}
-    for fd, name in streams.items():
-        os.set_blocking(fd, False)
-        selector.register(fd, selectors.EVENT_READ, name)
-    started = last_progress = time.monotonic()
-    try:
-        while selector.get_map():
-            now = time.monotonic()
-            if now - started >= hard_timeout:
-                raise TimeoutError(f"provider exceeded hard timeout ({hard_timeout:g}s)")
-            if now - last_progress >= stall_timeout:
-                raise TimeoutError(f"provider made no progress for {stall_timeout:g}s")
-            for key, _ in selector.select(timeout=min(0.2, stall_timeout)):
-                try:
-                    chunk = os.read(key.fd, 65536)
-                except BlockingIOError:
-                    continue
-                if chunk:
-                    output[key.data].append(chunk)
-                    last_progress = time.monotonic()
-                else:
-                    selector.unregister(key.fd)
-        while process.poll() is None:
-            now = time.monotonic()
-            if now - started >= hard_timeout:
-                raise TimeoutError(f"provider exceeded hard timeout ({hard_timeout:g}s)")
-            if now - last_progress >= stall_timeout:
-                raise TimeoutError(f"provider made no progress for {stall_timeout:g}s")
-            time.sleep(min(0.05, stall_timeout))
-        return (
-            int(process.returncode or 0),
-            b"".join(output["stdout"]).decode("utf-8", "replace"),
-            b"".join(output["stderr"]).decode("utf-8", "replace"),
-        )
-    except BaseException:
-        _terminate(process)
-        raise
-    finally:
-        selector.close()
-        process.stdout.close()
-        process.stderr.close()
 
 
 def _task_view(task_file: Path) -> str:
@@ -269,16 +190,6 @@ def _task_view(task_file: Path) -> str:
         if parsed.headers.get(key)
     }
     return json.dumps({"context": context, "task": body}, ensure_ascii=False)
-
-
-def _prompt(task_file: Path) -> str:
-    return (
-        "Handle the owner task in this persistent AG2 Space room session. Follow "
-        "AGENTS.md for repository and safety policy. Do not read the original task "
-        "file or create or modify any tasks/results tracking file; the parent worker "
-        "exclusively owns result publication. Return only the exact result body.\n\n"
-        f"Trusted task view:\n{_task_view(task_file)}"
-    )
 
 
 def _working_dir(repo: Path) -> Path:
@@ -368,16 +279,63 @@ def _pane_content(workspace: Path, name: str) -> str:
     return done.stdout if done.returncode == 0 else ""
 
 
-def _standing_launch_command(session_id: str, resume: bool) -> list[str]:
+def _standing_launch_command(runtime: str, session_id: str, resume: bool) -> list[str]:
+    model = os.environ.get("SUTANDO_CORE_MODEL", "").strip()
+    if runtime == "codex":
+        # Codex chooses its own session id at first turn (discovered from the
+        # rollout file afterwards), so create-mode launches with no id at all.
+        command = ["codex", "--dangerously-bypass-approvals-and-sandbox"]
+        if model:
+            command += ["-m", model]
+        if resume:
+            command += ["resume", session_id]
+        return command
     command = ["claude", "--resume" if resume else "--session-id", session_id,
                "--dangerously-skip-permissions", "--add-dir", str(Path.home())]
-    model = os.environ.get("SUTANDO_CORE_MODEL", "").strip()
     settings = os.environ.get("SUTANDO_ISOLATED_CLAUDE_SETTINGS", "").strip()
     if model:
         command += ["--model", model]
     if settings:
         command += ["--settings", settings]
     return command
+
+
+def _codex_sessions_root() -> Path:
+    return Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex")) / "sessions"
+
+
+def _discover_codex_session(since: float, expect_cwd: Path) -> Optional[str]:
+    """The codex TUI names its own session: a rollout-<ts>-<uuid>.jsonl appears
+    under the sessions tree at the FIRST turn, its meta line carrying the cwd."""
+    candidates = []
+    root = _codex_sessions_root()
+    if not root.is_dir():
+        return None
+    for path in root.rglob("rollout-*.jsonl"):
+        try:
+            if path.stat().st_mtime < since:
+                continue
+        except OSError:
+            continue
+        matched = re.search(r"rollout-.*-([0-9a-f-]{36})\.jsonl$", path.name, re.IGNORECASE)
+        if not matched or not SESSION_ID.fullmatch(matched.group(1)):
+            continue
+        try:
+            with path.open(encoding="utf-8") as handle:
+                meta = json.loads(handle.readline() or "{}")
+        except (OSError, ValueError):
+            continue
+        # cwd filter: other codex runs (e.g. exec) also write rollouts; only a
+        # session started in OUR working dir can be this room's pane.
+        cwd = str((meta.get("payload") or {}).get("cwd") or meta.get("cwd") or "")
+        # Resolve BOTH sides: macOS reports /var/... and /private/var/... for the
+        # same directory depending on who recorded it.
+        if cwd and Path(cwd).resolve() != expect_cwd.resolve():
+            continue
+        candidates.append((path.stat().st_mtime, matched.group(1)))
+    if not candidates:
+        return None
+    return max(candidates)[1]
 
 
 def _startup_failure(workspace: Path, name: str, reason: str) -> RuntimeError:
@@ -389,6 +347,10 @@ def _startup_failure(workspace: Path, name: str, reason: str) -> RuntimeError:
                         + (f"; last pane output:\n{tail}" if tail else ""))
 
 
+def _spawn_marker(workspace: Path, name: str) -> Path:
+    return _spool_dir(workspace) / f"{name}.spawned"
+
+
 def _ensure_standing_session(workspace: Path, runtime: str, room_key: str, repo: Path) -> str:
     """Ensure the room's standing provider pane exists and proved itself with
     output; a respawn after crash/reboot resumes the recorded provider session id."""
@@ -397,21 +359,34 @@ def _ensure_standing_session(workspace: Path, runtime: str, room_key: str, repo:
         return name
     session_id, created = _session_id(workspace, runtime, room_key)
     done = _tmux(workspace, "new-session", "-d", "-s", name, "-c", str(_working_dir(repo)),
-                 *_standing_launch_command(session_id, resume=not created))
+                 *_standing_launch_command(runtime, session_id, resume=not created))
     if done.returncode != 0:
         raise RuntimeError(f"tmux new-session failed: {done.stderr.strip()}")
     # Keep a dying startup pane around for post-mortem capture (turned off again
     # once startup is confirmed, so a later natural exit still cleans up).
     _tmux(workspace, "set-option", "-w", "-t", f"={name}:", "remain-on-exit", "on")
+    trust_answered = False
     deadline = time.monotonic() + _timeout("SUTANDO_ROOM_SPAWN_WAIT", None)
     while time.monotonic() < deadline:
         if _pane_dead(workspace, name) or _pane_alive(workspace, name) is False:
             raise _startup_failure(workspace, name, "exited")
-        if _pane_content(workspace, name).strip():
+        content = _pane_content(workspace, name)
+        if not trust_answered and "Do you trust the contents of this directory" in content:
+            # Codex's first-use-in-a-directory dialog; Enter selects "Yes,
+            # continue" (verified live on 0.149.0). Answered at most once.
+            _tmux(workspace, "send-keys", "-t", f"={name}:", "Enter")
+            trust_answered = True
+            time.sleep(0.5)
+            continue
+        if content.strip():
             # Record only after the pane proves itself: an earlier record poisons
             # every later --resume with a session that may never have existed.
-            if created:
+            if created and runtime == "claude":
                 _record_session(workspace, runtime, room_key, session_id)
+            if created and runtime == "codex":
+                # Codex's self-chosen id is discovered by the monitor from the
+                # rollout file the FIRST TURN creates; the marker bounds the scan.
+                _atomic_text(_spawn_marker(workspace, name), f"{time.time():.3f}\n")
             _tmux(workspace, "set-option", "-w", "-t", f"={name}:", "remain-on-exit", "off")
             return name
         time.sleep(0.1)
@@ -468,6 +443,9 @@ def _inject(workspace: Path, name: str, line: str) -> None:
         done = _tmux(workspace, "send-keys", "-t", f"={name}:", *keys)
         if done.returncode != 0:
             raise RuntimeError(f"tmux send-keys failed: {done.stderr.strip()}")
+        # Paste-guard: an Enter arriving in the same burst as the text is folded
+        # into the composer, not submitted (verified live on the codex TUI).
+        time.sleep(0.5)
 
 
 def _fail(task_file: Path, result: Path, reason: str) -> None:
@@ -494,6 +472,7 @@ def monitor(
     workspace: Path,
     task_file: Path,
     results_dir: Path,
+    repo: Path = REPO_ROOT,
     hard_timeout: Optional[float] = None,
     stall_timeout: Optional[float] = None,
 ) -> None:
@@ -516,7 +495,19 @@ def monitor(
     fingerprint = ""
     result = results_dir / task_file.name
     out = _out_path(workspace, task_file.stem)
+    marker = _spawn_marker(workspace, name)
     while True:
+        if marker.is_file():
+            # Codex-create: the first turn just named its own session; persist it
+            # so the NEXT respawn can resume, then retire the marker.
+            try:
+                since = float(marker.read_text().strip())
+            except (OSError, ValueError):
+                since = started
+            discovered = _discover_codex_session(since, _working_dir(repo))
+            if discovered is not None:
+                _record_session(workspace, runtime, room_key, discovered)
+                marker.unlink(missing_ok=True)
         if read_ready_result(result) is not None:
             return
         body = _stable_output(out)
@@ -595,70 +586,6 @@ def _spawn_monitor(
         )
 
 
-def _codex_command(session_id: Optional[str], prompt: str, output_file: Path, repo: Path) -> list[str]:
-    model = os.environ.get("SUTANDO_CORE_MODEL", "").strip()
-    if session_id:
-        command = [
-            "codex", "--search", "exec", "resume", "--json", "-o", str(output_file),
-            "--dangerously-bypass-approvals-and-sandbox",
-        ]
-    else:
-        command = [
-            "codex", "--search", "exec", "--json", "-o", str(output_file),
-            "-C", str(_working_dir(repo)), "--add-dir", str(Path.home()),
-            "--dangerously-bypass-approvals-and-sandbox",
-        ]
-    if model:
-        command += ["-m", model]
-    return command + ([session_id, prompt] if session_id else [prompt])
-
-
-def _run_codex(
-    workspace: Path,
-    room_key: str,
-    prompt: str,
-    repo: Path,
-    hard_timeout: Optional[float] = None,
-    stall_timeout: Optional[float] = None,
-) -> str:
-    state = _read_json(_state_path(workspace))
-    row = ((state.get("sessions") or {}).get("codex") or {}).get(room_key)
-    session_id = str(row.get("session_id") or "") if isinstance(row, dict) else ""
-    if session_id and not SESSION_ID.fullmatch(session_id):
-        session_id = ""
-    (workspace / "state").mkdir(parents=True, exist_ok=True)
-    fd, name = tempfile.mkstemp(prefix=".room-result.", suffix=".txt", dir=workspace / "state")
-    os.close(fd)
-    output_file = Path(name)
-    try:
-        return_code, stdout, stderr = _run_bounded(
-            _codex_command(session_id or None, prompt, output_file, repo),
-            _working_dir(repo),
-            hard_timeout,
-            stall_timeout,
-        )
-        if return_code:
-            raise RuntimeError(stderr.strip() or f"codex exited {return_code}")
-        discovered = ""
-        if not session_id:
-            for line in stdout.splitlines():
-                try:
-                    event = json.loads(line)
-                except (TypeError, ValueError):
-                    continue
-                if event.get("type") == "thread.started":
-                    candidate = str(event.get("thread_id") or "")
-                    if SESSION_ID.fullmatch(candidate):
-                        discovered = candidate
-        if not session_id and not discovered:
-            raise RuntimeError("codex did not report a valid thread.started session id")
-        if discovered:
-            _record_session(workspace, "codex", room_key, discovered)
-        return output_file.read_text(encoding="utf-8")
-    finally:
-        output_file.unlink(missing_ok=True)
-
-
 def probe(runtime: str, workspace: Path, task_file: Path) -> int:
     if runtime not in {"claude", "codex"}:
         return UNHANDLED
@@ -670,34 +597,6 @@ def probe(runtime: str, workspace: Path, task_file: Path) -> int:
     if task_file.parent != tasks_dir or task_file.suffix != ".txt":
         return UNHANDLED
     return 0 if resolve_room_key(task_file) else UNHANDLED
-
-
-def _handle_inline_codex(
-    workspace: Path,
-    room_key: str,
-    task_file: Path,
-    results_dir: Path,
-    repo: Path,
-    hard_timeout: Optional[float],
-    stall_timeout: Optional[float],
-) -> int:
-    """Per-message fallback executor (codex): the pre-standing-session design,
-    kept until interactive codex resume-id discovery is verified live."""
-    lock = workspace / "state" / "ag2space-room-session-locks" / f"codex-{room_key}.lock"
-    try:
-        with _locked(lock):
-            if _completed_result_exists(results_dir, task_file.name):
-                return 0
-            body = _run_codex(workspace, room_key, _prompt(task_file), repo,
-                              hard_timeout, stall_timeout)
-            if not body.strip():
-                raise RuntimeError("codex returned an empty result")
-            if not _publish_once(results_dir / task_file.name, body):
-                raise RuntimeError("result destination exists but is not ready")
-        return 0
-    except Exception as exc:
-        print(f"AG2 Space room-session worker: {exc}", file=sys.stderr)
-        return 1
 
 
 def handle(
@@ -716,9 +615,6 @@ def handle(
     assert room_key is not None
     if _completed_result_exists(results_dir, task_file.name):
         return 0
-    if runtime != "claude":
-        return _handle_inline_codex(workspace, room_key, task_file, results_dir, repo,
-                                    hard_timeout, stall_timeout)
     lock = workspace / "state" / "ag2space-room-session-locks" / f"{runtime}-{room_key}.lock"
     try:
         # The lock guards only spawn+inject ordering (seconds), never a whole
@@ -754,7 +650,7 @@ def main() -> int:
         return probe(args.runtime, args.workspace, args.task_file)
     if args.monitor:
         monitor(args.runtime, args.workspace, args.task_file, args.results_dir,
-                args.hard_timeout, args.stall_timeout)
+                args.repo, args.hard_timeout, args.stall_timeout)
         return 0
     return handle(
         args.runtime,

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -243,7 +243,9 @@ def _tmux(workspace: Path, *args: str) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env.pop("TMUX", None)
     return subprocess.run(
-        ["tmux", "-S", str(_tmux_socket(workspace)), *args],
+        # -f /dev/null: never load the host's tmux.conf. A scripted socket must
+        # not depend on ambient config a version bump can start rejecting.
+        ["tmux", "-f", "/dev/null", "-S", str(_tmux_socket(workspace)), *args],
         capture_output=True, text=True, timeout=15, env=env,
     )
 

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -261,14 +262,6 @@ def _pane_alive(workspace: Path, name: str) -> Optional[bool]:
     return done.returncode == 0
 
 
-def _pane_dead(workspace: Path, name: str) -> bool:
-    try:
-        done = _tmux(workspace, "display-message", "-p", "-t", f"={name}:", "#{pane_dead}")
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return done.returncode == 0 and done.stdout.strip() == "1"
-
-
 def _pane_content(workspace: Path, name: str) -> str:
     try:
         # "=name:" = exact-match session, its active pane — pane-targeting verbs
@@ -338,10 +331,18 @@ def _discover_codex_session(since: float, expect_cwd: Path) -> Optional[str]:
     return max(candidates)[1]
 
 
-def _startup_failure(workspace: Path, name: str, reason: str) -> RuntimeError:
-    # Post-mortem before cleanup: remain-on-exit kept the dying pane, so its last
-    # screen is the actual diagnostic (auth error, traceback, bad flag...).
-    tail = "\n".join(line for line in _pane_content(workspace, name).splitlines() if line.strip())[-500:]
+EXIT_SENTINEL = "__SUTANDO_PANE_EXIT__"
+
+
+def _wrapped_launch(command: list[str]) -> str:
+    # On provider exit the pane prints a sentinel and lingers instead of vanishing:
+    # the dying screen is capturable by construction, on every tmux version.
+    return (f"{shlex.join(command)}; ec=$?; "
+            f"printf '\\n{EXIT_SENTINEL} code=%d\\n' \"$ec\"; sleep 30")
+
+
+def _startup_failure(workspace: Path, name: str, reason: str, content: str = "") -> RuntimeError:
+    tail = "\n".join(line for line in content.splitlines() if line.strip())[-500:]
     _tmux(workspace, "kill-session", "-t", f"={name}")
     return RuntimeError(f"standing session {reason} during startup"
                         + (f"; last pane output:\n{tail}" if tail else ""))
@@ -359,18 +360,17 @@ def _ensure_standing_session(workspace: Path, runtime: str, room_key: str, repo:
         return name
     session_id, created = _session_id(workspace, runtime, room_key)
     done = _tmux(workspace, "new-session", "-d", "-s", name, "-c", str(_working_dir(repo)),
-                 *_standing_launch_command(runtime, session_id, resume=not created))
+                 _wrapped_launch(_standing_launch_command(runtime, session_id, resume=not created)))
     if done.returncode != 0:
         raise RuntimeError(f"tmux new-session failed: {done.stderr.strip()}")
-    # Keep a dying startup pane around for post-mortem capture (turned off again
-    # once startup is confirmed, so a later natural exit still cleans up).
-    _tmux(workspace, "set-option", "-w", "-t", f"={name}:", "remain-on-exit", "on")
     trust_answered = False
     deadline = time.monotonic() + _timeout("SUTANDO_ROOM_SPAWN_WAIT", None)
     while time.monotonic() < deadline:
-        if _pane_dead(workspace, name) or _pane_alive(workspace, name) is False:
-            raise _startup_failure(workspace, name, "exited")
         content = _pane_content(workspace, name)
+        if EXIT_SENTINEL in content:
+            raise _startup_failure(workspace, name, "exited", content)
+        if _pane_alive(workspace, name) is False:
+            raise _startup_failure(workspace, name, "exited", content)
         if not trust_answered and "Do you trust the contents of this directory" in content:
             # Codex's first-use-in-a-directory dialog; Enter selects "Yes,
             # continue" (verified live on 0.149.0). Answered at most once.
@@ -387,10 +387,10 @@ def _ensure_standing_session(workspace: Path, runtime: str, room_key: str, repo:
                 # Codex's self-chosen id is discovered by the monitor from the
                 # rollout file the FIRST TURN creates; the marker bounds the scan.
                 _atomic_text(_spawn_marker(workspace, name), f"{time.time():.3f}\n")
-            _tmux(workspace, "set-option", "-w", "-t", f"={name}:", "remain-on-exit", "off")
             return name
         time.sleep(0.1)
-    raise _startup_failure(workspace, name, "produced no output")
+    raise _startup_failure(workspace, name, "produced no output",
+                           _pane_content(workspace, name))
 
 
 def _spool_dir(workspace: Path) -> Path:
@@ -405,13 +405,15 @@ def _write_spool_prompt(workspace: Path, task_file: Path) -> Path:
     # The session writes only its PRIVATE output file; the trusted monitor is the
     # sole publisher of the shared results path (validated + atomic, no clobber).
     task_id = task_file.stem
+    out = _out_path(workspace, task_id)
     prompt = (
         "Handle the owner task below in this persistent AG2 Space room session. Follow "
         "AGENTS.md for repository and safety policy, and keep this room's conversation "
         "context across tasks. Do not read the original task file and do not create or "
         "modify any tasks/results tracking file; the trusted monitor owns delivery. "
-        "When done, write the exact result body - nothing else - to "
-        f"{_out_path(workspace, task_id)} in a single write.\n\n"
+        f"When done, write the exact result body - nothing else - to {out}.tmp "
+        f"and then rename that file to {out} as your final action. The rename is the "
+        "completion signal: never write the final path directly.\n\n"
         f"Trusted task view:\n{_task_view(task_file)}\n"
     )
     path = _spool_dir(workspace) / f"{task_id}.prompt.txt"
@@ -419,23 +421,14 @@ def _write_spool_prompt(workspace: Path, task_file: Path) -> Path:
     return path
 
 
-def _stable_output(path: Path, delay: float = 0.5) -> Optional[str]:
-    """The provider's private out-file, but only once it is non-empty and stops
-    changing — an ordinary write is not atomic and must never be published mid-way."""
+def _finished_output(path: Path) -> Optional[str]:
+    """The provider's private out-file. Its EXISTENCE is the completion signal —
+    the spool contract has the provider write elsewhere and atomically rename."""
     try:
-        first = path.read_bytes()
+        body = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return None
-    if not first.strip():
-        return None
-    time.sleep(delay)
-    try:
-        second = path.read_bytes()
-    except OSError:
-        return None
-    if first != second:
-        return None
-    return second.decode("utf-8", "replace")
+    return body if body.strip() else None
 
 
 def _inject(workspace: Path, name: str, line: str) -> None:
@@ -460,7 +453,7 @@ def _fail(task_file: Path, result: Path, reason: str) -> None:
 def _settle(task_file: Path, result: Path, out: Path, reason: str) -> None:
     # Terminal disposition: a finished private out-file beats the failure verdict
     # (the turn may have completed right before the pane died or was killed).
-    body = _stable_output(out)
+    body = _finished_output(out)
     if body is not None:
         _publish_once(result, body)
         return
@@ -510,19 +503,21 @@ def monitor(
                 marker.unlink(missing_ok=True)
         if read_ready_result(result) is not None:
             return
-        body = _stable_output(out)
+        body = _finished_output(out)
         if body is not None:
             _publish_once(result, body)
             return
         now = time.monotonic()
         alive = _pane_alive(workspace, name)
-        if alive is False:
-            time.sleep(2)  # grace: a final out-file write may still be landing
-            _settle(task_file, result, out, "the room's standing session exited before finishing")
-            return
         # alive None = probe failure, NOT a confirmed exit: fall through so it
         # degrades into stall handling (content unreadable -> clock keeps running).
         content = _pane_content(workspace, name) if alive else ""
+        if alive is False or EXIT_SENTINEL in content:
+            # Confirmed exit: session gone, or the wrapper's sentinel is on screen.
+            time.sleep(2)  # grace: a final out-file rename may still be landing
+            _tmux(workspace, "kill-session", "-t", f"={name}")
+            _settle(task_file, result, out, "the room's standing session exited before finishing")
+            return
         if content and content != fingerprint:
             fingerprint = content
             last_change = now
@@ -621,6 +616,12 @@ def handle(
         # provider turn - the standing session serializes its own turns natively.
         with _locked(lock):
             if _completed_result_exists(results_dir, task_file.name):
+                return 0
+            leftover = _finished_output(_out_path(workspace, task_file.stem))
+            if leftover is not None:
+                # Finished-but-unpublished output from a crashed prior attempt:
+                # publish it — never race stale output against a fresh injection.
+                _publish_once(results_dir / task_file.name, leftover)
                 return 0
             name = _ensure_standing_session(workspace, runtime, room_key, repo)
             spool = _write_spool_prompt(workspace, task_file)

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import uuid
 from contextlib import contextmanager
@@ -284,16 +285,243 @@ def _working_dir(repo: Path) -> Path:
     return Path(os.environ.get("SUTANDO_ISOLATED_WORKING_DIR", str(repo))).expanduser()
 
 
-def _claude_command(session_id: str, resume: bool, prompt: str) -> list[str]:
-    command = ["claude", "-p", "--resume" if resume else "--session-id", session_id]
-    command += ["--output-format", "text", "--dangerously-skip-permissions", "--add-dir", str(Path.home())]
+def _notify(task_file: Path, message: str) -> None:
+    """Best-effort progress ping via the shared task-progress notifier. Never
+    raises: a broken or slow notify path only costs visibility."""
+    try:
+        headers = parse_task_headers_trusted(
+            task_file.read_text(encoding="utf-8", errors="replace")
+        ).headers
+    except OSError:
+        return
+    source = headers.get("source") or ""
+    channel_id = headers.get("channel_id") or ""
+    if not source or not channel_id:
+        return
+    notifier = REPO_ROOT / "skills" / "task-progress" / "scripts" / "notify.py"
+    if not notifier.is_file():
+        return
+    try:
+        subprocess.run(
+            [sys.executable, str(notifier), "--source", source, "--channel-id", channel_id,
+             "--message", message],
+            timeout=15, check=False,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+def _tmux_socket(workspace: Path) -> Path:
+    # AF_UNIX paths cap at ~104 bytes on macOS, so the socket lives in a short
+    # per-user dir keyed by a hash of the workspace, never inside the workspace.
+    base = Path(os.environ.get("SUTANDO_ROOM_TMUX_DIR") or f"/tmp/sutando-room-tmux-{os.getuid()}")
+    digest = hashlib.sha256(str(workspace.resolve()).encode("utf-8")).hexdigest()[:12]
+    base.mkdir(parents=True, exist_ok=True)
+    try:
+        base.chmod(0o700)
+    except OSError:
+        pass
+    return base / f"{digest}.sock"
+
+
+def _tmux(workspace: Path, *args: str) -> subprocess.CompletedProcess:
+    # TMUX is dropped so this works from inside the core's own tmux session —
+    # with it set, tmux refuses to start nested sessions even on another socket.
+    env = os.environ.copy()
+    env.pop("TMUX", None)
+    return subprocess.run(
+        ["tmux", "-S", str(_tmux_socket(workspace)), *args],
+        capture_output=True, text=True, timeout=15, env=env,
+    )
+
+
+def _pane_name(runtime: str, room_key: str) -> str:
+    return f"room-{runtime}-{room_key[:12]}"
+
+
+def _pane_alive(workspace: Path, name: str) -> bool:
+    try:
+        return _tmux(workspace, "has-session", "-t", f"={name}").returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _pane_content(workspace: Path, name: str) -> str:
+    try:
+        # "=name:" = exact-match session, its active pane — pane-targeting verbs
+        # (capture-pane, send-keys) reject the bare "=name" session form.
+        done = _tmux(workspace, "capture-pane", "-p", "-t", f"={name}:")
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return done.stdout if done.returncode == 0 else ""
+
+
+def _standing_launch_command(session_id: str, resume: bool) -> list[str]:
+    command = ["claude", "--resume" if resume else "--session-id", session_id,
+               "--dangerously-skip-permissions", "--add-dir", str(Path.home())]
     model = os.environ.get("SUTANDO_CORE_MODEL", "").strip()
     settings = os.environ.get("SUTANDO_ISOLATED_CLAUDE_SETTINGS", "").strip()
     if model:
         command += ["--model", model]
     if settings:
         command += ["--settings", settings]
-    return command + ["--", prompt]
+    return command
+
+
+def _ensure_standing_session(workspace: Path, runtime: str, room_key: str, repo: Path) -> str:
+    """Ensure the room's standing provider pane exists and answered with output;
+    a respawn after crash/reboot resumes the recorded provider session id."""
+    name = _pane_name(runtime, room_key)
+    if _pane_alive(workspace, name):
+        return name
+    session_id, created = _session_id(workspace, runtime, room_key)
+    done = _tmux(workspace, "new-session", "-d", "-s", name, "-c", str(_working_dir(repo)),
+                 *_standing_launch_command(session_id, resume=not created))
+    if done.returncode != 0:
+        raise RuntimeError(f"tmux new-session failed: {done.stderr.strip()}")
+    if created:
+        _record_session(workspace, runtime, room_key, session_id)
+    deadline = time.monotonic() + _timeout("SUTANDO_ROOM_SPAWN_WAIT", None)
+    while time.monotonic() < deadline:
+        if _pane_content(workspace, name).strip():
+            return name
+        if not _pane_alive(workspace, name):
+            raise RuntimeError("standing session exited during startup")
+        time.sleep(0.1)
+    raise RuntimeError("standing session produced no output during startup")
+
+
+def _spool_dir(workspace: Path) -> Path:
+    return workspace / "state" / "ag2space-room-sessions" / "spool"
+
+
+def _write_spool_prompt(workspace: Path, task_file: Path, results_dir: Path) -> Path:
+    # Publication ownership flips here versus the inline path: the standing
+    # session writes the result itself, so the view must name the result path.
+    task_id = task_file.stem
+    prompt = (
+        "Handle the owner task below in this persistent AG2 Space room session. Follow "
+        "AGENTS.md for repository and safety policy, and keep this room's conversation "
+        "context across tasks. Do not read the original task file and do not touch any "
+        "other tasks/results tracking file. When done, write the exact result body - "
+        f"nothing else - to {results_dir / (task_id + '.txt')} in a single write.\n\n"
+        f"Trusted task view:\n{_task_view(task_file)}\n"
+    )
+    path = _spool_dir(workspace) / f"{task_id}.prompt.txt"
+    _atomic_text(path, prompt)
+    return path
+
+
+def _inject(workspace: Path, name: str, line: str) -> None:
+    for keys in (["-l", line], ["Enter"]):
+        done = _tmux(workspace, "send-keys", "-t", f"={name}:", *keys)
+        if done.returncode != 0:
+            raise RuntimeError(f"tmux send-keys failed: {done.stderr.strip()}")
+
+
+def _fail(task_file: Path, result: Path, reason: str) -> None:
+    _publish_once(
+        result,
+        f"This room session couldn't complete this message: {reason}.\n\n"
+        "Resend your message to continue - the conversation itself is preserved.",
+    )
+    _notify(task_file, f"Hit a problem: {reason}. Resend to continue.")
+
+
+def monitor(
+    runtime: str,
+    workspace: Path,
+    task_file: Path,
+    results_dir: Path,
+    hard_timeout: Optional[float] = None,
+    stall_timeout: Optional[float] = None,
+) -> None:
+    """Watchdog for one injected turn, in a detached process: heartbeats while it
+    runs, stall detection on frozen pane content, honest failure publishing."""
+    room_key = resolve_room_key(task_file)
+    if room_key is None:
+        return
+    name = _pane_name(runtime, room_key)
+    hard = _timeout("SUTANDO_TIER_HARD_TIMEOUT", hard_timeout)
+    stall = _timeout("SUTANDO_TIER_STALL_TIMEOUT", stall_timeout)
+    try:
+        interval = _timeout("SUTANDO_TIER_HEARTBEAT_INTERVAL", None)
+    except ValueError:
+        interval = 0.0
+    started = last_change = time.monotonic()
+    next_heartbeat = started + interval if interval > 0 else None
+    fingerprint = ""
+    result = results_dir / task_file.name
+    while True:
+        if read_ready_result(result) is not None:
+            return
+        now = time.monotonic()
+        if not _pane_alive(workspace, name):
+            time.sleep(2)  # grace: a final result write may still be landing
+            if read_ready_result(result) is None:
+                _fail(task_file, result, "the room's standing session exited before finishing")
+            return
+        content = _pane_content(workspace, name)
+        if content != fingerprint:
+            fingerprint = content
+            last_change = now
+        if now - last_change >= stall:
+            # A frozen pane is a hung process (a live provider at least animates its
+            # spinner). Kill BEFORE publishing so the session can't write after us.
+            _tmux(workspace, "kill-session", "-t", f"={name}")
+            if read_ready_result(result) is None:
+                _fail(task_file, result,
+                      f"the room's standing session froze for {stall:g}s and was stopped; "
+                      "the next message resumes the conversation")
+            return
+        if now - started >= hard:
+            # Safety ceiling bounds the WATCHDOG, not the work: a still-active turn
+            # is left running and its result still lands whenever it finishes.
+            _notify(task_file,
+                    f"This turn passed the {hard:g}s safety ceiling and is still running - "
+                    "the result will follow whenever it completes.")
+            return
+        if next_heartbeat is not None and now >= next_heartbeat:
+            while now >= next_heartbeat:
+                next_heartbeat += interval
+            # Off-thread: _notify can block up to 15s and must never delay the
+            # stall/ceiling checks (the exact bug qingyun's reviewer caught in #3259).
+            threading.Thread(
+                target=_notify,
+                args=(task_file, f"Still working ({now - started:.0f}s so far)..."),
+                daemon=True,
+            ).start()
+        time.sleep(min(1.0, stall / 4))
+
+
+def _spawn_monitor(
+    runtime: str,
+    workspace: Path,
+    task_file: Path,
+    results_dir: Path,
+    repo: Path,
+    hard_timeout: Optional[float],
+    stall_timeout: Optional[float],
+) -> None:
+    logs = workspace / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable, str(Path(__file__).resolve()), "--monitor",
+        "--runtime", runtime, "--workspace", str(workspace),
+        "--task-file", str(task_file), "--results-dir", str(results_dir), "--repo", str(repo),
+    ]
+    if hard_timeout is not None:
+        command += ["--hard-timeout", str(hard_timeout)]
+    if stall_timeout is not None:
+        command += ["--stall-timeout", str(stall_timeout)]
+    with (logs / f"ag2space-room-monitor-{task_file.stem}.log").open("a", encoding="utf-8") as log:
+        # setsid + not waited on: the monitor outlives this short-lived handler.
+        subprocess.Popen(
+            command, cwd=repo, env=os.environ.copy(),
+            stdin=subprocess.DEVNULL, stdout=log, stderr=log,
+            start_new_session=True,
+        )
 
 
 def _codex_command(session_id: Optional[str], prompt: str, output_file: Path, repo: Path) -> list[str]:
@@ -312,28 +540,6 @@ def _codex_command(session_id: Optional[str], prompt: str, output_file: Path, re
     if model:
         command += ["-m", model]
     return command + ([session_id, prompt] if session_id else [prompt])
-
-
-def _run_claude(
-    workspace: Path,
-    room_key: str,
-    prompt: str,
-    repo: Path,
-    hard_timeout: Optional[float] = None,
-    stall_timeout: Optional[float] = None,
-) -> str:
-    session_id, created = _session_id(workspace, "claude", room_key)
-    return_code, stdout, stderr = _run_bounded(
-        _claude_command(session_id, not created, prompt),
-        _working_dir(repo),
-        hard_timeout,
-        stall_timeout,
-    )
-    if return_code:
-        raise RuntimeError(stderr.strip() or f"claude exited {return_code}")
-    if created:
-        _record_session(workspace, "claude", room_key, session_id)
-    return stdout
 
 
 def _run_codex(
@@ -395,6 +601,34 @@ def probe(runtime: str, workspace: Path, task_file: Path) -> int:
     return 0 if resolve_room_key(task_file) else UNHANDLED
 
 
+def _handle_inline_codex(
+    workspace: Path,
+    room_key: str,
+    task_file: Path,
+    results_dir: Path,
+    repo: Path,
+    hard_timeout: Optional[float],
+    stall_timeout: Optional[float],
+) -> int:
+    """Per-message fallback executor (codex): the pre-standing-session design,
+    kept until interactive codex resume-id discovery is verified live."""
+    lock = workspace / "state" / "ag2space-room-session-locks" / f"codex-{room_key}.lock"
+    try:
+        with _locked(lock):
+            if _completed_result_exists(results_dir, task_file.name):
+                return 0
+            body = _run_codex(workspace, room_key, _prompt(task_file), repo,
+                              hard_timeout, stall_timeout)
+            if not body.strip():
+                raise RuntimeError("codex returned an empty result")
+            if not _publish_once(results_dir / task_file.name, body):
+                raise RuntimeError("result destination exists but is not ready")
+        return 0
+    except Exception as exc:
+        print(f"AG2 Space room-session worker: {exc}", file=sys.stderr)
+        return 1
+
+
 def handle(
     runtime: str,
     workspace: Path,
@@ -411,20 +645,22 @@ def handle(
     assert room_key is not None
     if _completed_result_exists(results_dir, task_file.name):
         return 0
+    if runtime != "claude":
+        return _handle_inline_codex(workspace, room_key, task_file, results_dir, repo,
+                                    hard_timeout, stall_timeout)
     lock = workspace / "state" / "ag2space-room-session-locks" / f"{runtime}-{room_key}.lock"
     try:
+        # The lock guards only spawn+inject ordering (seconds), never a whole
+        # provider turn - the standing session serializes its own turns natively.
         with _locked(lock):
             if _completed_result_exists(results_dir, task_file.name):
                 return 0
-            body = (
-                _run_claude(workspace, room_key, _prompt(task_file), repo, hard_timeout, stall_timeout)
-                if runtime == "claude"
-                else _run_codex(workspace, room_key, _prompt(task_file), repo, hard_timeout, stall_timeout)
-            )
-            if not body.strip():
-                raise RuntimeError(f"{runtime} returned an empty result")
-            if not _publish_once(results_dir / task_file.name, body):
-                raise RuntimeError("result destination exists but is not ready")
+            name = _ensure_standing_session(workspace, runtime, room_key, repo)
+            spool = _write_spool_prompt(workspace, task_file, results_dir)
+            _inject(workspace, name, f'Read the file "{spool}" and do exactly what it says.')
+        _spawn_monitor(runtime, workspace, task_file, results_dir, repo,
+                       hard_timeout, stall_timeout)
+        _notify(task_file, "On it - picked up in this room's standing session.")
         return 0
     except Exception as exc:
         print(f"AG2 Space room-session worker: {exc}", file=sys.stderr)
@@ -441,9 +677,14 @@ def main() -> int:
     parser.add_argument("--hard-timeout", type=float)
     parser.add_argument("--stall-timeout", type=float)
     parser.add_argument("--probe", action="store_true")
+    parser.add_argument("--monitor", action="store_true")
     args = parser.parse_args()
     if args.probe:
         return probe(args.runtime, args.workspace, args.task_file)
+    if args.monitor:
+        monitor(args.runtime, args.workspace, args.task_file, args.results_dir,
+                args.hard_timeout, args.stall_timeout)
+        return 0
     return handle(
         args.runtime,
         args.workspace,

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -321,9 +321,9 @@ def _discover_codex_session(since: float, expect_cwd: Path) -> Optional[str]:
         # cwd filter: other codex runs (e.g. exec) also write rollouts; only a
         # session started in OUR working dir can be this room's pane.
         cwd = str((meta.get("payload") or {}).get("cwd") or meta.get("cwd") or "")
-        # Resolve BOTH sides: macOS reports /var/... and /private/var/... for the
-        # same directory depending on who recorded it.
-        if cwd and Path(cwd).resolve() != expect_cwd.resolve():
+        # cwd is the ONLY identity check — fail closed on missing/malformed meta.
+        # Resolve both sides: macOS reports /var and /private/var for one dir.
+        if not cwd or Path(cwd).resolve() != expect_cwd.resolve():
             continue
         candidates.append((path.stat().st_mtime, matched.group(1)))
     if not candidates:

--- a/skills/ag2space-room-sessions/scripts/session-worker.py
+++ b/skills/ag2space-room-sessions/scripts/session-worker.py
@@ -340,11 +340,22 @@ def _pane_name(runtime: str, room_key: str) -> str:
     return f"room-{runtime}-{room_key[:12]}"
 
 
-def _pane_alive(workspace: Path, name: str) -> bool:
+def _pane_alive(workspace: Path, name: str) -> Optional[bool]:
+    """True/False = tmux answered. None = the probe itself failed (socket error or
+    timeout) — callers must treat None as unknown, never as a confirmed exit."""
     try:
-        return _tmux(workspace, "has-session", "-t", f"={name}").returncode == 0
+        done = _tmux(workspace, "has-session", "-t", f"={name}")
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return done.returncode == 0
+
+
+def _pane_dead(workspace: Path, name: str) -> bool:
+    try:
+        done = _tmux(workspace, "display-message", "-p", "-t", f"={name}:", "#{pane_dead}")
     except (OSError, subprocess.TimeoutExpired):
         return False
+    return done.returncode == 0 and done.stdout.strip() == "1"
 
 
 def _pane_content(workspace: Path, name: str) -> str:
@@ -369,48 +380,87 @@ def _standing_launch_command(session_id: str, resume: bool) -> list[str]:
     return command
 
 
+def _startup_failure(workspace: Path, name: str, reason: str) -> RuntimeError:
+    # Post-mortem before cleanup: remain-on-exit kept the dying pane, so its last
+    # screen is the actual diagnostic (auth error, traceback, bad flag...).
+    tail = "\n".join(line for line in _pane_content(workspace, name).splitlines() if line.strip())[-500:]
+    _tmux(workspace, "kill-session", "-t", f"={name}")
+    return RuntimeError(f"standing session {reason} during startup"
+                        + (f"; last pane output:\n{tail}" if tail else ""))
+
+
 def _ensure_standing_session(workspace: Path, runtime: str, room_key: str, repo: Path) -> str:
-    """Ensure the room's standing provider pane exists and answered with output;
-    a respawn after crash/reboot resumes the recorded provider session id."""
+    """Ensure the room's standing provider pane exists and proved itself with
+    output; a respawn after crash/reboot resumes the recorded provider session id."""
     name = _pane_name(runtime, room_key)
-    if _pane_alive(workspace, name):
+    if _pane_alive(workspace, name) is True:
         return name
     session_id, created = _session_id(workspace, runtime, room_key)
     done = _tmux(workspace, "new-session", "-d", "-s", name, "-c", str(_working_dir(repo)),
                  *_standing_launch_command(session_id, resume=not created))
     if done.returncode != 0:
         raise RuntimeError(f"tmux new-session failed: {done.stderr.strip()}")
-    if created:
-        _record_session(workspace, runtime, room_key, session_id)
+    # Keep a dying startup pane around for post-mortem capture (turned off again
+    # once startup is confirmed, so a later natural exit still cleans up).
+    _tmux(workspace, "set-option", "-w", "-t", f"={name}:", "remain-on-exit", "on")
     deadline = time.monotonic() + _timeout("SUTANDO_ROOM_SPAWN_WAIT", None)
     while time.monotonic() < deadline:
+        if _pane_dead(workspace, name) or _pane_alive(workspace, name) is False:
+            raise _startup_failure(workspace, name, "exited")
         if _pane_content(workspace, name).strip():
+            # Record only after the pane proves itself: an earlier record poisons
+            # every later --resume with a session that may never have existed.
+            if created:
+                _record_session(workspace, runtime, room_key, session_id)
+            _tmux(workspace, "set-option", "-w", "-t", f"={name}:", "remain-on-exit", "off")
             return name
-        if not _pane_alive(workspace, name):
-            raise RuntimeError("standing session exited during startup")
         time.sleep(0.1)
-    raise RuntimeError("standing session produced no output during startup")
+    raise _startup_failure(workspace, name, "produced no output")
 
 
 def _spool_dir(workspace: Path) -> Path:
     return workspace / "state" / "ag2space-room-sessions" / "spool"
 
 
-def _write_spool_prompt(workspace: Path, task_file: Path, results_dir: Path) -> Path:
-    # Publication ownership flips here versus the inline path: the standing
-    # session writes the result itself, so the view must name the result path.
+def _out_path(workspace: Path, task_id: str) -> Path:
+    return _spool_dir(workspace) / f"{task_id}.out.txt"
+
+
+def _write_spool_prompt(workspace: Path, task_file: Path) -> Path:
+    # The session writes only its PRIVATE output file; the trusted monitor is the
+    # sole publisher of the shared results path (validated + atomic, no clobber).
     task_id = task_file.stem
     prompt = (
         "Handle the owner task below in this persistent AG2 Space room session. Follow "
         "AGENTS.md for repository and safety policy, and keep this room's conversation "
-        "context across tasks. Do not read the original task file and do not touch any "
-        "other tasks/results tracking file. When done, write the exact result body - "
-        f"nothing else - to {results_dir / (task_id + '.txt')} in a single write.\n\n"
+        "context across tasks. Do not read the original task file and do not create or "
+        "modify any tasks/results tracking file; the trusted monitor owns delivery. "
+        "When done, write the exact result body - nothing else - to "
+        f"{_out_path(workspace, task_id)} in a single write.\n\n"
         f"Trusted task view:\n{_task_view(task_file)}\n"
     )
     path = _spool_dir(workspace) / f"{task_id}.prompt.txt"
     _atomic_text(path, prompt)
     return path
+
+
+def _stable_output(path: Path, delay: float = 0.5) -> Optional[str]:
+    """The provider's private out-file, but only once it is non-empty and stops
+    changing — an ordinary write is not atomic and must never be published mid-way."""
+    try:
+        first = path.read_bytes()
+    except OSError:
+        return None
+    if not first.strip():
+        return None
+    time.sleep(delay)
+    try:
+        second = path.read_bytes()
+    except OSError:
+        return None
+    if first != second:
+        return None
+    return second.decode("utf-8", "replace")
 
 
 def _inject(workspace: Path, name: str, line: str) -> None:
@@ -429,6 +479,16 @@ def _fail(task_file: Path, result: Path, reason: str) -> None:
     _notify(task_file, f"Hit a problem: {reason}. Resend to continue.")
 
 
+def _settle(task_file: Path, result: Path, out: Path, reason: str) -> None:
+    # Terminal disposition: a finished private out-file beats the failure verdict
+    # (the turn may have completed right before the pane died or was killed).
+    body = _stable_output(out)
+    if body is not None:
+        _publish_once(result, body)
+        return
+    _fail(task_file, result, reason)
+
+
 def monitor(
     runtime: str,
     workspace: Path,
@@ -437,8 +497,9 @@ def monitor(
     hard_timeout: Optional[float] = None,
     stall_timeout: Optional[float] = None,
 ) -> None:
-    """Watchdog for one injected turn, in a detached process: heartbeats while it
-    runs, stall detection on frozen pane content, honest failure publishing."""
+    """Sole publisher of this task's shared result, in a detached process: delivers
+    the session's validated private output, heartbeats, stall/exit supervision.
+    Never abandons ownership before a terminal state - result or failure."""
     room_key = resolve_room_key(task_file)
     if room_key is None:
         return
@@ -451,37 +512,47 @@ def monitor(
         interval = 0.0
     started = last_change = time.monotonic()
     next_heartbeat = started + interval if interval > 0 else None
+    ceiling_notified = False
     fingerprint = ""
     result = results_dir / task_file.name
+    out = _out_path(workspace, task_file.stem)
     while True:
         if read_ready_result(result) is not None:
             return
-        now = time.monotonic()
-        if not _pane_alive(workspace, name):
-            time.sleep(2)  # grace: a final result write may still be landing
-            if read_ready_result(result) is None:
-                _fail(task_file, result, "the room's standing session exited before finishing")
+        body = _stable_output(out)
+        if body is not None:
+            _publish_once(result, body)
             return
-        content = _pane_content(workspace, name)
-        if content != fingerprint:
+        now = time.monotonic()
+        alive = _pane_alive(workspace, name)
+        if alive is False:
+            time.sleep(2)  # grace: a final out-file write may still be landing
+            _settle(task_file, result, out, "the room's standing session exited before finishing")
+            return
+        # alive None = probe failure, NOT a confirmed exit: fall through so it
+        # degrades into stall handling (content unreadable -> clock keeps running).
+        content = _pane_content(workspace, name) if alive else ""
+        if content and content != fingerprint:
             fingerprint = content
             last_change = now
         if now - last_change >= stall:
-            # A frozen pane is a hung process (a live provider at least animates its
-            # spinner). Kill BEFORE publishing so the session can't write after us.
+            # Fence first: kill the pane BEFORE the terminal verdict so nothing can
+            # keep writing the out-file while we decide result-vs-failure.
             _tmux(workspace, "kill-session", "-t", f"={name}")
-            if read_ready_result(result) is None:
-                _fail(task_file, result,
-                      f"the room's standing session froze for {stall:g}s and was stopped; "
-                      "the next message resumes the conversation")
+            _settle(task_file, result, out,
+                    f"the room's standing session froze for {stall:g}s and was stopped; "
+                    "the next message resumes the conversation")
             return
-        if now - started >= hard:
-            # Safety ceiling bounds the WATCHDOG, not the work: a still-active turn
-            # is left running and its result still lands whenever it finishes.
-            _notify(task_file,
-                    f"This turn passed the {hard:g}s safety ceiling and is still running - "
-                    "the result will follow whenever it completes.")
-            return
+        if not ceiling_notified and now - started >= hard:
+            # The ceiling changes the message, never the ownership: supervision
+            # continues to a terminal state, the work is never abandoned or killed.
+            ceiling_notified = True
+            threading.Thread(
+                target=_notify,
+                args=(task_file, f"This turn passed the {hard:g}s safety ceiling and is "
+                                 "still running - the result will follow when it completes."),
+                daemon=True,
+            ).start()
         if next_heartbeat is not None and now >= next_heartbeat:
             while now >= next_heartbeat:
                 next_heartbeat += interval
@@ -656,7 +727,7 @@ def handle(
             if _completed_result_exists(results_dir, task_file.name):
                 return 0
             name = _ensure_standing_session(workspace, runtime, room_key, repo)
-            spool = _write_spool_prompt(workspace, task_file, results_dir)
+            spool = _write_spool_prompt(workspace, task_file)
             _inject(workspace, name, f'Read the file "{spool}" and do exactly what it says.')
         _spawn_monitor(runtime, workspace, task_file, results_dir, repo,
                        hard_timeout, stall_timeout)

--- a/tests/ag2space-room-session-worker.test.py
+++ b/tests/ag2space-room-session-worker.test.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import importlib.util
-import io
 import json
 import os
 import shutil
@@ -14,9 +13,8 @@ import tempfile
 import threading
 import time
 import uuid
-from contextlib import redirect_stderr
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 REPO = Path(__file__).resolve().parents[1]
@@ -73,15 +71,6 @@ def task(
         encoding="utf-8",
     )
     return path
-
-
-def run_worker(runtime: str, workspace: Path, task_file: Path, env: dict[str, str]) -> subprocess.CompletedProcess:
-    stderr = io.StringIO()
-    with patch.dict(os.environ, env), redirect_stderr(stderr):
-        return_code = worker.handle(
-            runtime, workspace, task_file, workspace / "results", REPO
-        )
-    return subprocess.CompletedProcess([], return_code, "", stderr.getvalue())
 
 
 def test_opt_in_and_cardinality() -> None:
@@ -354,12 +343,10 @@ def test_claude_handle_dispatch_without_tmux() -> None:
         with patch.object(worker, "_ensure_standing_session", return_value="pane") as ensure, \
              patch.object(worker, "_inject") as inject, \
              patch.object(worker, "_spawn_monitor") as monitor, \
-             patch.object(worker, "_notify") as notify, \
-             patch.object(worker, "_run_codex") as codex:
+             patch.object(worker, "_notify") as notify:
             code = worker.handle("claude", workspace, started, results, REPO)
         check(code == 0 and ensure.called and inject.called and monitor.called,
               "claude handle ensures the pane, injects, and detaches the monitor")
-        check(not codex.called, "claude handle never runs a per-message provider")
         check("standing session" in notify.call_args.args[1],
               "claude handle acks the room after a successful injection")
         spool = worker._spool_dir(workspace) / f"{started.stem}.prompt.txt"
@@ -402,194 +389,47 @@ def test_startup_failure_never_poisons_the_session_id() -> None:
         check(created, "a failed startup never records the session id (no poisoned resume)")
 
 
-def test_codex_create_resume_and_result_ownership() -> None:
-    with tempfile.TemporaryDirectory() as name:
-        root = Path(name)
-        workspace = root / "workspace"
-        (workspace / "results").mkdir(parents=True)
-        log = root / "codex.jsonl"
-        thread_id = str(uuid.uuid4())
-        executable(root / "codex", f"""#!/usr/bin/env python3
-import json, os, pathlib, sys
-args = sys.argv[1:]
-with pathlib.Path(os.environ['ARG_LOG']).open('a') as out:
-    out.write(json.dumps(args) + '\\n')
-pathlib.Path(args[args.index('-o') + 1]).write_text('codex room result\\n')
-if 'resume' not in args:
-    print(json.dumps({{'type': 'thread.started', 'thread_id': '{thread_id}'}}))
-""")
-        env = {"PATH": f"{root}:{os.environ['PATH']}", "ARG_LOG": str(log)}
-        first = task(workspace, "task-codex-one")
-        second = task(workspace, "task-codex-two")
-        check(run_worker("codex", workspace, first, env).returncode == 0, "Codex creates room thread")
-        check(run_worker("codex", workspace, second, env).returncode == 0, "Codex resumes room thread")
-        args = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()]
-        check("resume" not in args[0] and "resume" in args[1], "Codex uses exec then exec resume")
-        check(thread_id in args[1], "Codex resumes the reported thread id")
-        state = json.loads(worker._state_path(workspace).read_text(encoding="utf-8"))
-        room_key = worker.resolve_room_key(first)
-        assert room_key
-        check(state["sessions"]["codex"][room_key]["session_id"] == thread_id,
-              "Codex reported thread id is persisted")
-
-        existing = task(workspace, "task-existing", room_id="!existing:a")
-        (workspace / "results" / existing.name).write_text("consumer wins\n")
-        before = len(log.read_text().splitlines())
-        check(run_worker("codex", workspace, existing, env).returncode == 0,
-              "existing consumer result settles task")
-        check(len(log.read_text().splitlines()) == before, "settled task never launches provider")
-        check((workspace / "results" / existing.name).read_text() == "consumer wins\n",
-              "publish-once contract never clobbers consumer")
-
-        whitespace = task(workspace, "task-whitespace", room_id="!whitespace:a")
-        (workspace / "results" / whitespace.name).write_text("  \n")
-        before = len(log.read_text().splitlines())
-        result = run_worker("codex", workspace, whitespace, env)
-        check(result.returncode == 1 and len(log.read_text().splitlines()) == before + 1,
-              "whitespace live result invokes provider then falls back without clobbering")
-
-        archived = task(workspace, "task-archived", room_id="!archived:a")
-        archive = workspace / "results" / "archive"
-        archive.mkdir()
-        (archive / f"{archived.stem}-123.txt").write_text("already sent\n")
-        before = len(log.read_text().splitlines())
-        check(run_worker("codex", workspace, archived, env).returncode == 0,
-              "gateway-archived result settles task")
-        check(len(log.read_text().splitlines()) == before, "archived task is never replayed")
-
-        retained = task(workspace, "task-retained", room_id="!retained:a")
-        retention = workspace / "results" / "archive-2026-08-21"
-        retention.mkdir()
-        (retention / retained.name).write_text("already sent\n")
-        check(run_worker("codex", workspace, retained, env).returncode == 0,
-              "retention archive also prevents replay")
-
-        archived_blank = task(workspace, "task-archived-blank", room_id="!archived-blank:a")
-        (archive / archived_blank.name).write_text("\n")
-        before = len(log.read_text().splitlines())
-        check(run_worker("codex", workspace, archived_blank, env).returncode == 0,
-              "whitespace archived result is not treated as completion")
-        check(len(log.read_text().splitlines()) == before + 1,
-              "whitespace archive invokes the provider path")
-
-
-def test_codex_event_and_state_edges() -> None:
-    with tempfile.TemporaryDirectory() as name:
-        root = Path(name)
-        workspace = root / "workspace"
-        (workspace / "results").mkdir(parents=True)
-        valid_id = str(uuid.uuid4())
-        executable(root / "codex", f"""#!/usr/bin/env python3
-import json, os, pathlib, sys
-args = sys.argv[1:]
-pathlib.Path(args[args.index('-o') + 1]).write_text('edge result\\n')
-mode = os.environ.get('MODE')
-if mode == 'fail':
-    print('codex failed', file=sys.stderr)
-    raise SystemExit(8)
-if mode == 'events':
-    print('not-json')
-    print(json.dumps({{'type': 'thread.started', 'thread_id': 'bad'}}))
-    print(json.dumps({{'type': 'other', 'thread_id': '{valid_id}'}}))
-    print(json.dumps({{'type': 'thread.started', 'thread_id': '{valid_id}'}}))
-""")
-        env = {"PATH": f"{root}:{os.environ['PATH']}"}
-        edge = task(workspace, "task-events")
-        room_key = worker.resolve_room_key(edge)
-        assert room_key
-        worker._atomic_text(
-            worker._state_path(workspace),
-            json.dumps({"schema_version": 1, "sessions": {"codex": {
-                room_key: {"session_id": "corrupt"}
-            }}}),
-        )
-        check(run_worker("codex", workspace, edge, {**env, "MODE": "events"}).returncode == 0,
-              "Codex ignores malformed events and replaces corrupt state")
-
-        no_id = task(workspace, "task-no-id", room_id="!no-id:a")
-        result = run_worker("codex", workspace, no_id, env)
-        check(result.returncode == 1 and "valid thread.started" in result.stderr,
-              "Codex requires a valid new thread id")
-
-        failed = task(workspace, "task-codex-failure", room_id="!codex-failure:a")
-        result = run_worker("codex", workspace, failed, {**env, "MODE": "fail"})
-        check(result.returncode == 1 and "codex failed" in result.stderr,
-              "Codex provider failure returns watcher fallback signal")
-
-
 def test_runtime_edges_and_adapter_wiring() -> None:
-    with tempfile.TemporaryDirectory() as name:
-        root = Path(name)
-        sleeper = executable(root / "sleepy", "#!/bin/sh\nsleep 2\n")
-        with patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "0.1", "SUTANDO_TIER_STALL_TIMEOUT": "0.05"}):
-            started = time.monotonic()
-            try:
-                worker._run_bounded([str(sleeper)], root)
-            except TimeoutError:
-                check(time.monotonic() - started < 1, "stalled provider is terminated within bound")
-            else:
-                check(False, "stalled provider is terminated within bound")
+    with patch.dict(os.environ, {}, clear=True):
+        check(worker._timeout("SUTANDO_TIER_HARD_TIMEOUT", None) == 3600,
+              "manifest declares the hard-timeout safety-ceiling default")
+        check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", None) == 180,
+              "manifest declares the stall-timeout default")
+        check(worker._timeout("SUTANDO_TIER_HEARTBEAT_INTERVAL", None) == 120,
+              "manifest declares the heartbeat-interval default")
+        check(worker._timeout("SUTANDO_ROOM_SPAWN_WAIT", None) == 30,
+              "manifest declares the spawn-wait default")
+    with patch.dict(os.environ, {"SUTANDO_TIER_STALL_TIMEOUT": "12"}):
+        check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", None) == 12,
+              "environment overrides the manifest timeout")
+        check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", 13) == 13,
+              "CLI timeout overrides the environment")
+    try:
         with patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "0"}):
-            try:
-                worker._run_bounded(["true"], root)
-            except ValueError:
-                check(True, "non-positive provider timeout is rejected")
-            else:
-                check(False, "non-positive provider timeout is rejected")
+            worker._timeout("SUTANDO_TIER_HARD_TIMEOUT", None)
+    except ValueError:
+        check(True, "non-positive timeout is rejected")
+    else:
+        check(False, "non-positive timeout is rejected")
 
-        with patch.dict(os.environ, {}, clear=True):
-            check(worker._timeout("SUTANDO_TIER_HARD_TIMEOUT", None) == 3600,
-                  "manifest declares the hard-timeout safety-ceiling default")
-            check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", None) == 180,
-                  "manifest declares the stall-timeout default")
-            check(worker._timeout("SUTANDO_TIER_HEARTBEAT_INTERVAL", None) == 120,
-                  "manifest declares the heartbeat-interval default")
-            check(worker._timeout("SUTANDO_ROOM_SPAWN_WAIT", None) == 30,
-                  "manifest declares the spawn-wait default")
-        with patch.dict(os.environ, {"SUTANDO_TIER_STALL_TIMEOUT": "12"}):
-            check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", None) == 12,
-                  "environment overrides the manifest timeout")
-            check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", 13) == 13,
-                  "CLI timeout overrides the environment")
-
-        with patch.dict(os.environ, {"SUTANDO_TIER_HARD_TIMEOUT": "0.05",
-                                     "SUTANDO_TIER_STALL_TIMEOUT": "2"}):
-            for command, message in [
-                ([str(sleeper)], "hard timeout terminates a provider with open streams"),
-                (["sh", "-c", "exec 1>&- 2>&-; sleep 2"],
-                 "hard timeout terminates a provider after streams close"),
-            ]:
-                try:
-                    worker._run_bounded(command, root)
-                except TimeoutError:
-                    check(True, message)
-                else:
-                    check(False, message)
-
-        ended = MagicMock()
-        ended.poll.return_value = 0
-        worker._terminate(ended)
-        check(not ended.wait.called, "termination is a no-op for an exited provider")
-        stubborn = MagicMock(pid=123)
-        stubborn.poll.return_value = None
-        stubborn.wait.side_effect = [subprocess.TimeoutExpired("provider", 2), None]
-        with patch.object(worker.os, "killpg") as killpg:
-            worker._terminate(stubborn)
-        check(killpg.call_count == 2, "termination escalates an unresponsive provider")
-
-        model = "test-model"
-        settings = '{"hooks":{}}'
-        session = str(uuid.uuid4())
-        with patch.dict(os.environ, {"SUTANDO_CORE_MODEL": model,
-                                     "SUTANDO_ISOLATED_CLAUDE_SETTINGS": settings}):
-            create = worker._standing_launch_command(session, resume=False)
-            resume = worker._standing_launch_command(session, resume=True)
-            codex = worker._codex_command(None, "prompt", root / "out", REPO)
-        check("--model" in create and "--settings" in create,
-              "standing launch inherits model and hook settings")
-        check("--session-id" in create and "--resume" in resume,
-              "standing launch distinguishes create from resume")
-        check("-m" in codex, "Codex inherits selected core model")
+    model = "test-model"
+    settings = '{"hooks":{}}'
+    session = str(uuid.uuid4())
+    with patch.dict(os.environ, {"SUTANDO_CORE_MODEL": model,
+                                 "SUTANDO_ISOLATED_CLAUDE_SETTINGS": settings}):
+        create = worker._standing_launch_command("claude", session, resume=False)
+        resume = worker._standing_launch_command("claude", session, resume=True)
+        codex_create = worker._standing_launch_command("codex", session, resume=False)
+        codex_resume = worker._standing_launch_command("codex", session, resume=True)
+    check("--model" in create and "--settings" in create,
+          "claude standing launch inherits model and hook settings")
+    check("--session-id" in create and "--resume" in resume,
+          "claude standing launch distinguishes create from resume")
+    check(codex_create[0] == "codex" and session not in codex_create,
+          "codex create launches with no preassigned session id")
+    check("-m" in codex_create, "codex standing launch inherits selected core model")
+    check(codex_resume[-2:] == ["resume", session],
+          "codex respawn resumes the discovered session id")
 
     relative = "skills/ag2space-room-sessions/scripts/session-worker.py"
     claude_start = (REPO / "src/agent/claude/cli/start-cli.sh").read_text(encoding="utf-8")
@@ -602,7 +442,56 @@ def test_runtime_edges_and_adapter_wiring() -> None:
     check("ag2space-room-sessions" not in watcher, "generic watcher does not name concrete skill")
 
 
-def test_cli_probe_and_empty_output() -> None:
+def test_codex_session_discovery() -> None:
+    with tempfile.TemporaryDirectory() as name:
+        root = Path(name)
+        wd = root / "wd"
+        wd.mkdir()
+        sessions = root / "codex-home" / "sessions" / "2026" / "08" / "22"
+        sessions.mkdir(parents=True)
+        marker = time.time() - 60
+        right = str(uuid.uuid4())
+        wrong_cwd = str(uuid.uuid4())
+        stale = str(uuid.uuid4())
+
+        def rollout(session_uuid: str, cwd: Path, mtime: float) -> None:
+            path = sessions / f"rollout-2026-08-22T03-00-00-{session_uuid}.jsonl"
+            path.write_text(json.dumps({"type": "session_meta",
+                                        "payload": {"cwd": str(cwd)}}) + "\n")
+            os.utime(path, (mtime, mtime))
+
+        rollout(stale, wd, marker - 120)
+        rollout(wrong_cwd, root / "elsewhere", marker + 30)
+        rollout(right, wd, marker + 60)
+        (sessions / "rollout-2026-08-22T03-00-00-not-a-uuid.jsonl").write_text("{}\n")
+        with patch.dict(os.environ, {"CODEX_HOME": str(root / "codex-home")}):
+            check(worker._discover_codex_session(marker, wd) == right,
+                  "discovery picks the newest rollout matching our working dir")
+            check(worker._discover_codex_session(marker + 90, wd) is None,
+                  "discovery never matches rollouts older than the spawn marker")
+
+        workspace = root / "workspace"
+        (workspace / "results").mkdir(parents=True)
+        settled = task(workspace, "task-codex-settle")
+        (workspace / "results" / settled.name).write_text("already done\n")
+        room_key = worker.resolve_room_key(settled)
+        assert room_key
+        pane = worker._pane_name("codex", room_key)
+        worker._atomic_text(worker._spawn_marker(workspace, pane), f"{marker:.3f}\n")
+        env = {"CODEX_HOME": str(root / "codex-home"),
+               "SUTANDO_TIER_HARD_TIMEOUT": "5", "SUTANDO_TIER_STALL_TIMEOUT": "1",
+               "SUTANDO_TIER_HEARTBEAT_INTERVAL": "0",
+               "SUTANDO_ISOLATED_WORKING_DIR": str(wd)}
+        with patch.dict(os.environ, env), patch.object(worker, "_notify"):
+            worker.monitor("codex", workspace, settled, workspace / "results", REPO)
+        state = json.loads(worker._state_path(workspace).read_text(encoding="utf-8"))
+        check(state["sessions"]["codex"][room_key]["session_id"] == right,
+              "monitor records the discovered codex session id for future resumes")
+        check(not worker._spawn_marker(workspace, pane).is_file(),
+              "the spawn marker retires once the session id is recorded")
+
+
+def test_cli_probe() -> None:
     with tempfile.TemporaryDirectory() as name:
         root = Path(name)
         workspace = root / "workspace"
@@ -615,16 +504,6 @@ def test_cli_probe_and_empty_output() -> None:
             cwd=REPO, check=False,
         )
         check(probe.returncode == 0, "CLI probe delegates to room policy")
-        thread_id = str(uuid.uuid4())
-        executable(root / "codex", f"""#!/usr/bin/env python3
-import json, pathlib, sys
-args = sys.argv[1:]
-pathlib.Path(args[args.index('-o') + 1]).write_text('   \\n')
-print(json.dumps({{'type': 'thread.started', 'thread_id': '{thread_id}'}}))
-""")
-        result = run_worker("codex", workspace, room_task, {"PATH": f"{root}:{os.environ['PATH']}"})
-        check(result.returncode == 1 and "empty result" in result.stderr,
-              "empty provider output falls back without publishing")
 
 
 def test_direct_failure_and_cli_edges() -> None:
@@ -646,9 +525,9 @@ def test_direct_failure_and_cli_edges() -> None:
 
         raced = task(workspace, "task-raced")
         with patch.object(worker, "_completed_result_exists", side_effect=[False, True]), \
-             patch.object(worker, "_run_codex") as provider:
+             patch.object(worker, "_ensure_standing_session") as spawn:
             code = worker.handle("codex", workspace, raced, results, REPO)
-        check(code == 0 and not provider.called, "locked completion check prevents a duplicate launch")
+        check(code == 0 and not spawn.called, "locked completion check prevents a duplicate launch")
 
         argv = ["session-worker", "--runtime", "codex", "--workspace", str(workspace),
                 "--task-file", str(raced), "--results-dir", str(results), "--repo", str(REPO)]
@@ -668,10 +547,9 @@ def main() -> int:
     test_monitor_watchdog_policies()
     test_claude_handle_dispatch_without_tmux()
     test_startup_failure_never_poisons_the_session_id()
-    test_codex_create_resume_and_result_ownership()
-    test_codex_event_and_state_edges()
+    test_codex_session_discovery()
     test_runtime_edges_and_adapter_wiring()
-    test_cli_probe_and_empty_output()
+    test_cli_probe()
     test_direct_failure_and_cli_edges()
     print(f"\nResults: {len(FAILURES)} failed")
     return 1 if FAILURES else 0

--- a/tests/ag2space-room-session-worker.test.py
+++ b/tests/ag2space-room-session-worker.test.py
@@ -479,10 +479,15 @@ def test_codex_session_discovery() -> None:
         rollout(wrong_cwd, root / "elsewhere", marker + 30)
         rollout(right, wd, marker + 60)
         (sessions / "rollout-2026-08-22T03-00-00-not-a-uuid.jsonl").write_text("{}\n")
+        anonymous = sessions / f"rollout-2026-08-22T03-00-00-{uuid.uuid4()}.jsonl"
+        anonymous.write_text(json.dumps({"type": "session_meta", "payload": {}}) + "\n")
+        os.utime(anonymous, (marker + 120, marker + 120))
         with patch.dict(os.environ, {"CODEX_HOME": str(root / "codex-home")}):
             check(worker._discover_codex_session(marker, wd) == right,
                   "discovery picks the newest rollout matching our working dir")
             check(worker._discover_codex_session(marker + 90, wd) is None,
+                  "a rollout with no cwd in its meta is never bound to a room (fail closed)")
+            check(worker._discover_codex_session(marker + 130, wd) is None,
                   "discovery never matches rollouts older than the spawn marker")
 
         workspace = root / "workspace"

--- a/tests/ag2space-room-session-worker.test.py
+++ b/tests/ag2space-room-session-worker.test.py
@@ -7,6 +7,7 @@ import importlib.util
 import io
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -142,56 +143,186 @@ def test_session_state_reuses_room_not_message() -> None:
             check(False, "invalid provider session id is refused")
 
 
-def test_claude_create_resume_and_failure() -> None:
+STANDING_STUB = """#!/usr/bin/env python3
+import json, os, pathlib, re, sys, time
+with pathlib.Path(os.environ['ARG_LOG']).open('a') as out:
+    out.write(json.dumps(sys.argv[1:]) + '\\n')
+print('READY', flush=True)
+for line in sys.stdin:
+    m = re.search(r'\"([^\"]*\\.prompt\\.txt)\"', line)
+    if not m:
+        continue
+    prompt = pathlib.Path(m.group(1)).read_text()
+    dest = re.search(r'to (.+?) in a single write', prompt).group(1)
+    if os.environ.get('MODE') == 'hang':
+        time.sleep(600)
+    pathlib.Path(dest).write_text('standing room result\\n')
+    print('DONE', flush=True)
+"""
+
+
+def wait_for(predicate, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def test_claude_standing_session_e2e() -> None:
+    if shutil.which("tmux") is None:
+        print("  SKIP tmux not available - standing-session e2e tests not run")
+        return
     with tempfile.TemporaryDirectory() as name:
         root = Path(name)
         workspace = root / "workspace"
         (workspace / "results").mkdir(parents=True)
         log = root / "claude.jsonl"
-        executable(root / "claude", """#!/usr/bin/env python3
-import json, os, pathlib, sys
-with pathlib.Path(os.environ['ARG_LOG']).open('a') as out:
-    out.write(json.dumps(sys.argv[1:]) + '\\n')
-if 'Process and write the result to results/' in sys.argv[-1]:
-    pathlib.Path(os.environ['ROGUE_RESULT']).write_text('child direct write\\n')
-if os.environ.get('FAIL_PROVIDER'):
-    print('provider failed', file=sys.stderr)
-    raise SystemExit(7)
-print('claude room result')
-""")
+        log.touch()
+        executable(root / "claude", STANDING_STUB)
         env = {
             "PATH": f"{root}:{os.environ['PATH']}",
             "ARG_LOG": str(log),
-            "ROGUE_RESULT": str(workspace / "results" / "task-claude-one.txt"),
+            "SUTANDO_ROOM_TMUX_DIR": str(root / "tmux"),
+            "SUTANDO_ROOM_SPAWN_WAIT": "15",
         }
         first = task(workspace, "task-claude-one", addressed_to="@peer:ag2.space")
         second = task(workspace, "task-claude-two")
-        check(run_worker("claude", workspace, first, env).returncode == 0, "Claude creates room session")
-        check(run_worker("claude", workspace, second, env).returncode == 0, "Claude resumes room session")
-        args = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()]
-        check("--session-id" in args[0] and "--resume" in args[1], "Claude uses create then resume")
-        first_id = args[0][args[0].index("--session-id") + 1]
-        second_id = args[1][args[1].index("--resume") + 1]
-        check(first_id == second_id, "Claude resumes the same room session id")
-        check((workspace / "results" / first.name).read_text() == "claude room result\n",
-              "child cannot become a second result writer")
-        first_prompt = args[0][-1]
-        check("answer this" in first_prompt and "SKILL INSTRUCTIONS" in first_prompt,
-              "child receives task content and trusted execution policy")
-        check("ADDRESSING:" in first_prompt and "CONTEXT-FIRST (unconditional)" in first_prompt,
-              "child preserves addressing and unconditional context-first policy")
-        check('"addressed_to": "@peer:ag2.space"' in first_prompt,
-              "child context preserves the trusted addressed-to target")
-        check("Process and write the result to results/" not in first_prompt,
-              "child omits only the parent-owned publication directive")
-        check(first.name not in first_prompt and str(first) not in first_prompt,
-              "child receives neither task id nor original task path")
+        third = task(workspace, "task-claude-three")
+        try:
+            with patch.dict(os.environ, env), \
+                 patch.object(worker, "_spawn_monitor"), patch.object(worker, "_notify"):
+                check(worker.handle("claude", workspace, first, workspace / "results", REPO) == 0,
+                      "standing session spawns for the room's first message")
+                result_one = workspace / "results" / first.name
+                check(wait_for(lambda: result_one.exists()),
+                      "standing session writes the first result itself")
+                check(result_one.read_text() == "standing room result\n",
+                      "standing session publishes the exact result body")
 
-        failed = task(workspace, "task-claude-fail", room_id="!failure:a")
-        result = run_worker("claude", workspace, failed, {**env, "FAIL_PROVIDER": "1"})
-        check(result.returncode == 1 and "provider failed" in result.stderr,
-              "provider failure returns watcher fallback signal")
-        check(not (workspace / "results" / failed.name).exists(), "provider failure publishes no result")
+                check(worker.handle("claude", workspace, second, workspace / "results", REPO) == 0,
+                      "second message is claimed without a new spawn")
+                check(wait_for(lambda: (workspace / "results" / second.name).exists()),
+                      "reused pane serves the second message")
+                spawns = [json.loads(line) for line in log.read_text().splitlines()]
+                check(len(spawns) == 1, "one pane serves consecutive same-room messages")
+                check("--session-id" in spawns[0], "first spawn proposes a new provider session id")
+
+                room_key = worker.resolve_room_key(first)
+                assert room_key
+                worker._tmux(workspace, "kill-session", "-t", f"={worker._pane_name('claude', room_key)}")
+                check(worker.handle("claude", workspace, third, workspace / "results", REPO) == 0,
+                      "message after a pane death is still claimed")
+                check(wait_for(lambda: (workspace / "results" / third.name).exists()),
+                      "respawned pane serves the message")
+                spawns = [json.loads(line) for line in log.read_text().splitlines()]
+                created = spawns[0][spawns[0].index("--session-id") + 1]
+                check("--resume" in spawns[1] and spawns[1][spawns[1].index("--resume") + 1] == created,
+                      "respawn resumes the recorded provider session id")
+                state = json.loads(worker._state_path(workspace).read_text(encoding="utf-8"))
+                check(state["sessions"]["claude"][room_key]["session_id"] == created,
+                      "standing session id is persisted for resume")
+
+                spool = worker._spool_dir(workspace) / f"{first.stem}.prompt.txt"
+                body = spool.read_text(encoding="utf-8")
+                check("answer this" in body and "SKILL INSTRUCTIONS" in body,
+                      "spool prompt carries task content and trusted execution policy")
+                check("ADDRESSING:" in body and "CONTEXT-FIRST (unconditional)" in body,
+                      "spool prompt preserves addressing and context-first policy")
+                check('"addressed_to": "@peer:ag2.space"' in body,
+                      "spool prompt preserves the trusted addressed-to target")
+                check(f"Process and write the result to results/{first.stem}.txt" not in body,
+                      "spool prompt omits the original numbered publication directive")
+                check(str(workspace / "results" / first.name) in body,
+                      "spool prompt names the result path the session must write")
+                check(str(first) not in body, "spool prompt never names the original task path")
+        finally:
+            with patch.dict(os.environ, env):
+                worker._tmux(workspace, "kill-server")
+
+
+def test_monitor_watchdog_policies() -> None:
+    with tempfile.TemporaryDirectory() as name:
+        workspace = Path(name)
+        results = workspace / "results"
+        results.mkdir()
+        settled = task(workspace, "task-settled")
+        (results / settled.name).write_text("already done\n")
+        timeouts = {"SUTANDO_TIER_HARD_TIMEOUT": "5", "SUTANDO_TIER_STALL_TIMEOUT": "0.2",
+                    "SUTANDO_TIER_HEARTBEAT_INTERVAL": "0"}
+        with patch.dict(os.environ, timeouts), \
+             patch.object(worker, "_notify") as notify, patch.object(worker, "_tmux") as tmux:
+            worker.monitor("claude", workspace, settled, results)
+        check(not tmux.called and not notify.called,
+              "monitor exits untouched when the result is already ready")
+
+        dead = task(workspace, "task-dead", room_id="!dead:a")
+        with patch.dict(os.environ, timeouts), \
+             patch.object(worker, "_pane_alive", return_value=False), \
+             patch.object(worker, "_notify"), patch.object(worker.time, "sleep"):
+            worker.monitor("claude", workspace, dead, results)
+        check("exited before finishing" in (results / dead.name).read_text(),
+              "a dead pane without a result publishes the honest failure body")
+
+        frozen = task(workspace, "task-frozen", room_id="!frozen:a")
+        events: list[str] = []
+        with patch.dict(os.environ, timeouts), \
+             patch.object(worker, "_pane_alive", return_value=True), \
+             patch.object(worker, "_pane_content", return_value="frozen screen"), \
+             patch.object(worker, "_notify"), patch.object(worker.time, "sleep"), \
+             patch.object(worker, "_tmux",
+                          side_effect=lambda ws, *a: events.append(a[0])) as tmux, \
+             patch.object(worker, "_fail",
+                          side_effect=lambda *a: events.append("fail")):
+            worker.monitor("claude", workspace, frozen, results)
+        check(events == ["kill-session", "fail"],
+              "a frozen pane is killed BEFORE the failure result is published")
+
+        busy = task(workspace, "task-busy", room_id="!busy:a")
+        ceiling = {**timeouts, "SUTANDO_TIER_HARD_TIMEOUT": "0.3",
+                   "SUTANDO_TIER_STALL_TIMEOUT": "5"}
+        with patch.dict(os.environ, ceiling), \
+             patch.object(worker, "_pane_alive", return_value=True), \
+             patch.object(worker, "_pane_content", side_effect=lambda ws, n: f"tick {time.monotonic()}"), \
+             patch.object(worker, "_notify") as notify, patch.object(worker.time, "sleep"), \
+             patch.object(worker, "_tmux") as tmux:
+            worker.monitor("claude", workspace, busy, results)
+        check(not tmux.called and not (results / busy.name).exists(),
+              "an active turn past the safety ceiling is never killed or failed")
+        check(notify.called and "safety ceiling" in notify.call_args.args[1],
+              "the safety ceiling detaches the watchdog with a room notice")
+
+
+def test_claude_handle_dispatch_without_tmux() -> None:
+    with tempfile.TemporaryDirectory() as name:
+        workspace = Path(name)
+        results = workspace / "results"
+        results.mkdir()
+        started = task(workspace, "task-dispatch")
+        with patch.object(worker, "_ensure_standing_session", return_value="pane") as ensure, \
+             patch.object(worker, "_inject") as inject, \
+             patch.object(worker, "_spawn_monitor") as monitor, \
+             patch.object(worker, "_notify") as notify, \
+             patch.object(worker, "_run_codex") as codex:
+            code = worker.handle("claude", workspace, started, results, REPO)
+        check(code == 0 and ensure.called and inject.called and monitor.called,
+              "claude handle ensures the pane, injects, and detaches the monitor")
+        check(not codex.called, "claude handle never runs a per-message provider")
+        check("standing session" in notify.call_args.args[1],
+              "claude handle acks the room after a successful injection")
+        spool = worker._spool_dir(workspace) / f"{started.stem}.prompt.txt"
+        check(spool.is_file() and str(spool) in inject.call_args.args[2],
+              "injection points the pane at the spool prompt")
+        check(str(results / started.name) in spool.read_text(encoding="utf-8"),
+              "the spool prompt carries the result-path contract")
+
+        broken = task(workspace, "task-broken", room_id="!broken:a")
+        with patch.object(worker, "_ensure_standing_session",
+                          side_effect=RuntimeError("tmux new-session failed")), \
+             patch.object(worker, "_notify"):
+            code = worker.handle("claude", workspace, broken, results, REPO)
+        check(code == 1, "a spawn failure falls back to the watcher path")
 
 
 def test_codex_create_resume_and_result_ownership() -> None:
@@ -330,10 +461,14 @@ def test_runtime_edges_and_adapter_wiring() -> None:
                 check(False, "non-positive provider timeout is rejected")
 
         with patch.dict(os.environ, {}, clear=True):
-            check(worker._timeout("SUTANDO_TIER_HARD_TIMEOUT", None) == 900,
-                  "manifest declares the hard-timeout default")
+            check(worker._timeout("SUTANDO_TIER_HARD_TIMEOUT", None) == 3600,
+                  "manifest declares the hard-timeout safety-ceiling default")
             check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", None) == 180,
                   "manifest declares the stall-timeout default")
+            check(worker._timeout("SUTANDO_TIER_HEARTBEAT_INTERVAL", None) == 120,
+                  "manifest declares the heartbeat-interval default")
+            check(worker._timeout("SUTANDO_ROOM_SPAWN_WAIT", None) == 30,
+                  "manifest declares the spawn-wait default")
         with patch.dict(os.environ, {"SUTANDO_TIER_STALL_TIMEOUT": "12"}):
             check(worker._timeout("SUTANDO_TIER_STALL_TIMEOUT", None) == 12,
                   "environment overrides the manifest timeout")
@@ -367,11 +502,16 @@ def test_runtime_edges_and_adapter_wiring() -> None:
 
         model = "test-model"
         settings = '{"hooks":{}}'
+        session = str(uuid.uuid4())
         with patch.dict(os.environ, {"SUTANDO_CORE_MODEL": model,
                                      "SUTANDO_ISOLATED_CLAUDE_SETTINGS": settings}):
-            claude = worker._claude_command(str(uuid.uuid4()), False, "prompt")
+            create = worker._standing_launch_command(session, resume=False)
+            resume = worker._standing_launch_command(session, resume=True)
             codex = worker._codex_command(None, "prompt", root / "out", REPO)
-        check("--model" in claude and "--settings" in claude, "Claude inherits model and hook settings")
+        check("--model" in create and "--settings" in create,
+              "standing launch inherits model and hook settings")
+        check("--session-id" in create and "--resume" in resume,
+              "standing launch distinguishes create from resume")
         check("-m" in codex, "Codex inherits selected core model")
 
     relative = "skills/ag2space-room-sessions/scripts/session-worker.py"
@@ -398,8 +538,14 @@ def test_cli_probe_and_empty_output() -> None:
             cwd=REPO, check=False,
         )
         check(probe.returncode == 0, "CLI probe delegates to room policy")
-        executable(root / "claude", "#!/bin/sh\nprintf '   \\n'\n")
-        result = run_worker("claude", workspace, room_task, {"PATH": f"{root}:{os.environ['PATH']}"})
+        thread_id = str(uuid.uuid4())
+        executable(root / "codex", f"""#!/usr/bin/env python3
+import json, pathlib, sys
+args = sys.argv[1:]
+pathlib.Path(args[args.index('-o') + 1]).write_text('   \\n')
+print(json.dumps({{'type': 'thread.started', 'thread_id': '{thread_id}'}}))
+""")
+        result = run_worker("codex", workspace, room_task, {"PATH": f"{root}:{os.environ['PATH']}"})
         check(result.returncode == 1 and "empty result" in result.stderr,
               "empty provider output falls back without publishing")
 
@@ -433,12 +579,17 @@ def test_direct_failure_and_cli_edges() -> None:
             check(worker.main() == 17, "CLI main dispatches probe mode")
         with patch.object(sys, "argv", argv), patch.object(worker, "handle", return_value=18):
             check(worker.main() == 18, "CLI main dispatches handle mode")
+        with patch.object(sys, "argv", argv + ["--monitor"]), \
+             patch.object(worker, "monitor") as watchdog:
+            check(worker.main() == 0 and watchdog.called, "CLI main dispatches monitor mode")
 
 
 def main() -> int:
     test_opt_in_and_cardinality()
     test_session_state_reuses_room_not_message()
-    test_claude_create_resume_and_failure()
+    test_claude_standing_session_e2e()
+    test_monitor_watchdog_policies()
+    test_claude_handle_dispatch_without_tmux()
     test_codex_create_resume_and_result_ownership()
     test_codex_event_and_state_edges()
     test_runtime_edges_and_adapter_wiring()

--- a/tests/ag2space-room-session-worker.test.py
+++ b/tests/ag2space-room-session-worker.test.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import uuid
 from contextlib import redirect_stderr
@@ -28,10 +29,11 @@ SPEC.loader.exec_module(worker)
 FAILURES: list[str] = []
 
 
-def check(condition: bool, message: str) -> None:
+def check(condition: bool, message: str) -> bool:
     print(("  ok  " if condition else "  FAIL ") + message)
     if not condition:
         FAILURES.append(message)
+    return condition
 
 
 def executable(path: Path, body: str) -> Path:
@@ -143,9 +145,12 @@ def test_session_state_reuses_room_not_message() -> None:
             check(False, "invalid provider session id is refused")
 
 
-STANDING_STUB = """#!/usr/bin/env python3
-import json, os, pathlib, re, sys, time
-with pathlib.Path(os.environ['ARG_LOG']).open('a') as out:
+def standing_stub(log_path: Path) -> str:
+    # The log path is EMBEDDED, not read from env: pane env propagation is the
+    # most version-sensitive tmux behavior, and the stub must not depend on it.
+    return f"""#!/usr/bin/env python3
+import json, pathlib, re, sys
+with pathlib.Path({str(log_path)!r}).open('a') as out:
     out.write(json.dumps(sys.argv[1:]) + '\\n')
 print('READY', flush=True)
 for line in sys.stdin:
@@ -154,8 +159,6 @@ for line in sys.stdin:
         continue
     prompt = pathlib.Path(m.group(1)).read_text()
     dest = re.search(r'to (.+?) in a single write', prompt).group(1)
-    if os.environ.get('MODE') == 'hang':
-        time.sleep(600)
     pathlib.Path(dest).write_text('standing room result\\n')
     print('DONE', flush=True)
 """
@@ -180,10 +183,9 @@ def test_claude_standing_session_e2e() -> None:
         (workspace / "results").mkdir(parents=True)
         log = root / "claude.jsonl"
         log.touch()
-        executable(root / "claude", STANDING_STUB)
+        executable(root / "claude", standing_stub(log))
         env = {
             "PATH": f"{root}:{os.environ['PATH']}",
-            "ARG_LOG": str(log),
             "SUTANDO_ROOM_TMUX_DIR": str(root / "tmux"),
             "SUTANDO_ROOM_SPAWN_WAIT": "15",
         }
@@ -191,15 +193,16 @@ def test_claude_standing_session_e2e() -> None:
         second = task(workspace, "task-claude-two")
         third = task(workspace, "task-claude-three")
         try:
-            with patch.dict(os.environ, env), \
-                 patch.object(worker, "_spawn_monitor"), patch.object(worker, "_notify"):
+            # The real detached monitor runs: the shared result appearing proves the
+            # whole pipeline (inject -> private out-file -> validated publication).
+            with patch.dict(os.environ, env), patch.object(worker, "_notify"):
                 check(worker.handle("claude", workspace, first, workspace / "results", REPO) == 0,
                       "standing session spawns for the room's first message")
                 result_one = workspace / "results" / first.name
-                check(wait_for(lambda: result_one.exists()),
-                      "standing session writes the first result itself")
-                check(result_one.read_text() == "standing room result\n",
-                      "standing session publishes the exact result body")
+                if check(wait_for(lambda: result_one.exists()),
+                         "monitor publishes the session's first result"):
+                    check(result_one.read_text() == "standing room result\n",
+                          "published body is the session's exact private output")
 
                 check(worker.handle("claude", workspace, second, workspace / "results", REPO) == 0,
                       "second message is claimed without a new spawn")
@@ -207,7 +210,8 @@ def test_claude_standing_session_e2e() -> None:
                       "reused pane serves the second message")
                 spawns = [json.loads(line) for line in log.read_text().splitlines()]
                 check(len(spawns) == 1, "one pane serves consecutive same-room messages")
-                check("--session-id" in spawns[0], "first spawn proposes a new provider session id")
+                check(spawns and "--session-id" in spawns[0],
+                      "first spawn proposes a new provider session id")
 
                 room_key = worker.resolve_room_key(first)
                 assert room_key
@@ -217,12 +221,14 @@ def test_claude_standing_session_e2e() -> None:
                 check(wait_for(lambda: (workspace / "results" / third.name).exists()),
                       "respawned pane serves the message")
                 spawns = [json.loads(line) for line in log.read_text().splitlines()]
-                created = spawns[0][spawns[0].index("--session-id") + 1]
-                check("--resume" in spawns[1] and spawns[1][spawns[1].index("--resume") + 1] == created,
-                      "respawn resumes the recorded provider session id")
-                state = json.loads(worker._state_path(workspace).read_text(encoding="utf-8"))
-                check(state["sessions"]["claude"][room_key]["session_id"] == created,
-                      "standing session id is persisted for resume")
+                if check(len(spawns) == 2 and "--session-id" in spawns[0] and "--resume" in spawns[1],
+                         "respawn uses resume after create"):
+                    created = spawns[0][spawns[0].index("--session-id") + 1]
+                    check(spawns[1][spawns[1].index("--resume") + 1] == created,
+                          "respawn resumes the recorded provider session id")
+                    state = json.loads(worker._state_path(workspace).read_text(encoding="utf-8"))
+                    check(state["sessions"]["claude"][room_key]["session_id"] == created,
+                          "standing session id is persisted for resume")
 
                 spool = worker._spool_dir(workspace) / f"{first.stem}.prompt.txt"
                 body = spool.read_text(encoding="utf-8")
@@ -234,8 +240,10 @@ def test_claude_standing_session_e2e() -> None:
                       "spool prompt preserves the trusted addressed-to target")
                 check(f"Process and write the result to results/{first.stem}.txt" not in body,
                       "spool prompt omits the original numbered publication directive")
-                check(str(workspace / "results" / first.name) in body,
-                      "spool prompt names the result path the session must write")
+                check(str(worker._out_path(workspace, first.stem)) in body,
+                      "spool prompt names only the private out-file contract")
+                check(str(workspace / "results" / first.name) not in body,
+                      "spool prompt never names the shared results path")
                 check(str(first) not in body, "spool prompt never names the original task path")
         finally:
             with patch.dict(os.environ, env):
@@ -257,13 +265,38 @@ def test_monitor_watchdog_policies() -> None:
         check(not tmux.called and not notify.called,
               "monitor exits untouched when the result is already ready")
 
+        finished = task(workspace, "task-finished", room_id="!finished:a")
+        worker._atomic_text(worker._out_path(workspace, finished.stem), "real session output\n")
+        with patch.dict(os.environ, timeouts), \
+             patch.object(worker, "_notify") as notify, patch.object(worker, "_tmux") as tmux, \
+             patch.object(worker.time, "sleep"):
+            worker.monitor("claude", workspace, finished, results)
+        check((results / finished.name).read_text() == "real session output\n",
+              "monitor is the publisher of the session's private output")
+        check(not tmux.called and not notify.called,
+              "a finished out-file needs no kill and no failure notice")
+
         dead = task(workspace, "task-dead", room_id="!dead:a")
         with patch.dict(os.environ, timeouts), \
              patch.object(worker, "_pane_alive", return_value=False), \
              patch.object(worker, "_notify"), patch.object(worker.time, "sleep"):
             worker.monitor("claude", workspace, dead, results)
         check("exited before finishing" in (results / dead.name).read_text(),
-              "a dead pane without a result publishes the honest failure body")
+              "a dead pane without output publishes the honest failure body")
+
+        died_late = task(workspace, "task-died-late", room_id="!died-late:a")
+        out_late = worker._out_path(workspace, died_late.stem)
+
+        def write_then_report_dead(ws, n):
+            worker._atomic_text(out_late, "finished just in time\n")
+            return False
+
+        with patch.dict(os.environ, timeouts), \
+             patch.object(worker, "_pane_alive", side_effect=write_then_report_dead), \
+             patch.object(worker, "_notify"), patch.object(worker.time, "sleep"):
+            worker.monitor("claude", workspace, died_late, results)
+        check((results / died_late.name).read_text() == "finished just in time\n",
+              "a finished out-file beats the failure verdict when the pane dies")
 
         frozen = task(workspace, "task-frozen", room_id="!frozen:a")
         events: list[str] = []
@@ -272,26 +305,44 @@ def test_monitor_watchdog_policies() -> None:
              patch.object(worker, "_pane_content", return_value="frozen screen"), \
              patch.object(worker, "_notify"), patch.object(worker.time, "sleep"), \
              patch.object(worker, "_tmux",
-                          side_effect=lambda ws, *a: events.append(a[0])) as tmux, \
-             patch.object(worker, "_fail",
-                          side_effect=lambda *a: events.append("fail")):
+                          side_effect=lambda ws, *a: events.append(a[0])), \
+             patch.object(worker, "_settle",
+                          side_effect=lambda *a: events.append("settle")):
             worker.monitor("claude", workspace, frozen, results)
-        check(events == ["kill-session", "fail"],
-              "a frozen pane is killed BEFORE the failure result is published")
+        check(events == ["kill-session", "settle"],
+              "a frozen pane is fenced (killed) BEFORE the terminal verdict")
+
+        flaky = task(workspace, "task-flaky", room_id="!flaky:a")
+        with patch.dict(os.environ, timeouts), \
+             patch.object(worker, "_pane_alive", return_value=None), \
+             patch.object(worker, "_notify"), patch.object(worker.time, "sleep"), \
+             patch.object(worker, "_tmux"):
+            worker.monitor("claude", workspace, flaky, results)
+        check("froze" in (results / flaky.name).read_text(),
+              "a failing liveness probe degrades to stall handling, never a dead verdict")
 
         busy = task(workspace, "task-busy", room_id="!busy:a")
+        out_busy = worker._out_path(workspace, busy.stem)
         ceiling = {**timeouts, "SUTANDO_TIER_HARD_TIMEOUT": "0.3",
                    "SUTANDO_TIER_STALL_TIMEOUT": "5"}
-        with patch.dict(os.environ, ceiling), \
-             patch.object(worker, "_pane_alive", return_value=True), \
-             patch.object(worker, "_pane_content", side_effect=lambda ws, n: f"tick {time.monotonic()}"), \
-             patch.object(worker, "_notify") as notify, patch.object(worker.time, "sleep"), \
-             patch.object(worker, "_tmux") as tmux:
-            worker.monitor("claude", workspace, busy, results)
-        check(not tmux.called and not (results / busy.name).exists(),
-              "an active turn past the safety ceiling is never killed or failed")
-        check(notify.called and "safety ceiling" in notify.call_args.args[1],
-              "the safety ceiling detaches the watchdog with a room notice")
+        finish_timer = threading.Timer(0.6, lambda: worker._atomic_text(out_busy, "slow but done\n"))
+        finish_timer.start()
+        try:
+            with patch.dict(os.environ, ceiling), \
+                 patch.object(worker, "_pane_alive", return_value=True), \
+                 patch.object(worker, "_pane_content",
+                              side_effect=lambda ws, n: f"tick {time.monotonic()}"), \
+                 patch.object(worker, "_notify") as notify, patch.object(worker.time, "sleep"), \
+                 patch.object(worker, "_tmux") as tmux:
+                worker.monitor("claude", workspace, busy, results)
+        finally:
+            finish_timer.cancel()
+        check(not tmux.called, "an active turn past the safety ceiling is never killed")
+        check((results / busy.name).read_text() == "slow but done\n",
+              "supervision continues past the ceiling until the result is delivered")
+        check(wait_for(lambda: notify.called, 2)
+              and "safety ceiling" in notify.call_args.args[1],
+              "the safety ceiling posts a notice without abandoning ownership")
 
 
 def test_claude_handle_dispatch_without_tmux() -> None:
@@ -314,8 +365,11 @@ def test_claude_handle_dispatch_without_tmux() -> None:
         spool = worker._spool_dir(workspace) / f"{started.stem}.prompt.txt"
         check(spool.is_file() and str(spool) in inject.call_args.args[2],
               "injection points the pane at the spool prompt")
-        check(str(results / started.name) in spool.read_text(encoding="utf-8"),
-              "the spool prompt carries the result-path contract")
+        spool_text = spool.read_text(encoding="utf-8")
+        check(str(worker._out_path(workspace, started.stem)) in spool_text,
+              "the spool prompt carries the private out-file contract")
+        check(str(results / started.name) not in spool_text,
+              "the session is never pointed at the shared results path")
 
         broken = task(workspace, "task-broken", room_id="!broken:a")
         with patch.object(worker, "_ensure_standing_session",
@@ -323,6 +377,29 @@ def test_claude_handle_dispatch_without_tmux() -> None:
              patch.object(worker, "_notify"):
             code = worker.handle("claude", workspace, broken, results, REPO)
         check(code == 1, "a spawn failure falls back to the watcher path")
+
+
+def test_startup_failure_never_poisons_the_session_id() -> None:
+    with tempfile.TemporaryDirectory() as name:
+        workspace = Path(name)
+        doomed = task(workspace, "task-doomed")
+        room_key = worker.resolve_room_key(doomed)
+        assert room_key
+        ok = subprocess.CompletedProcess([], 0, "", "")
+        with patch.dict(os.environ, {"SUTANDO_ROOM_SPAWN_WAIT": "5"}), \
+             patch.object(worker, "_tmux", return_value=ok), \
+             patch.object(worker, "_pane_alive", return_value=None), \
+             patch.object(worker, "_pane_dead", return_value=True), \
+             patch.object(worker, "_pane_content", return_value="claude: auth error"):
+            try:
+                worker._ensure_standing_session(workspace, "claude", room_key, REPO)
+            except RuntimeError as exc:
+                check("auth error" in str(exc),
+                      "startup failure carries the dying pane's screen for diagnosis")
+            else:
+                check(False, "startup failure carries the dying pane's screen for diagnosis")
+        _, created = worker._session_id(workspace, "claude", room_key)
+        check(created, "a failed startup never records the session id (no poisoned resume)")
 
 
 def test_codex_create_resume_and_result_ownership() -> None:
@@ -590,6 +667,7 @@ def main() -> int:
     test_claude_standing_session_e2e()
     test_monitor_watchdog_policies()
     test_claude_handle_dispatch_without_tmux()
+    test_startup_failure_never_poisons_the_session_id()
     test_codex_create_resume_and_result_ownership()
     test_codex_event_and_state_edges()
     test_runtime_edges_and_adapter_wiring()

--- a/tests/ag2space-room-session-worker.test.py
+++ b/tests/ag2space-room-session-worker.test.py
@@ -147,8 +147,10 @@ for line in sys.stdin:
     if not m:
         continue
     prompt = pathlib.Path(m.group(1)).read_text()
-    dest = re.search(r'to (.+?) in a single write', prompt).group(1)
-    pathlib.Path(dest).write_text('standing room result\\n')
+    dest = re.search(r'to (.+?)\\.tmp and then rename', prompt).group(1)
+    tmp = pathlib.Path(dest + '.tmp')
+    tmp.write_text('standing room result\\n')
+    tmp.rename(dest)
     print('DONE', flush=True)
 """
 
@@ -220,6 +222,8 @@ def test_claude_standing_session_e2e() -> None:
                           "standing session id is persisted for resume")
 
                 spool = worker._spool_dir(workspace) / f"{first.stem}.prompt.txt"
+                if not check(spool.is_file(), "spool prompt exists for the first message"):
+                    return
                 body = spool.read_text(encoding="utf-8")
                 check("answer this" in body and "SKILL INSTRUCTIONS" in body,
                       "spool prompt carries task content and trusted execution policy")
@@ -365,6 +369,17 @@ def test_claude_handle_dispatch_without_tmux() -> None:
             code = worker.handle("claude", workspace, broken, results, REPO)
         check(code == 1, "a spawn failure falls back to the watcher path")
 
+        crashed = task(workspace, "task-crashed-retry", room_id="!crashed:a")
+        worker._atomic_text(worker._out_path(workspace, crashed.stem), "recovered body\n")
+        with patch.object(worker, "_ensure_standing_session") as ensure, \
+             patch.object(worker, "_inject") as inject, \
+             patch.object(worker, "_spawn_monitor"), patch.object(worker, "_notify"):
+            code = worker.handle("claude", workspace, crashed, results, REPO)
+        check(code == 0 and not ensure.called and not inject.called,
+              "a retry with finished-but-unpublished output never re-injects")
+        check((results / crashed.name).read_text() == "recovered body\n",
+              "the crashed attempt's finished output is published, not re-run")
+
 
 def test_startup_failure_never_poisons_the_session_id() -> None:
     with tempfile.TemporaryDirectory() as name:
@@ -373,11 +388,11 @@ def test_startup_failure_never_poisons_the_session_id() -> None:
         room_key = worker.resolve_room_key(doomed)
         assert room_key
         ok = subprocess.CompletedProcess([], 0, "", "")
+        dying = f"claude: auth error\n{worker.EXIT_SENTINEL} code=1"
         with patch.dict(os.environ, {"SUTANDO_ROOM_SPAWN_WAIT": "5"}), \
              patch.object(worker, "_tmux", return_value=ok), \
-             patch.object(worker, "_pane_alive", return_value=None), \
-             patch.object(worker, "_pane_dead", return_value=True), \
-             patch.object(worker, "_pane_content", return_value="claude: auth error"):
+             patch.object(worker, "_pane_alive", return_value=False), \
+             patch.object(worker, "_pane_content", return_value=dying):
             try:
                 worker._ensure_standing_session(workspace, "claude", room_key, REPO)
             except RuntimeError as exc:


### PR DESCRIPTION
## Scope

Replaces the room-session skill's execution model with the **standing-session architecture** the Sessions-room design discussion landed on (this is the design PR Chi asked for after rejecting #3257 and closing #3259). Stacked on #3238 (base: `feat/native-ag2space-room-sessions`) — the trusted `session_scope: room` opt-in gate, room-key hashing, and session-id persistence stay exactly as reviewed there; this PR replaces only the execution half. Merge order: #3238 first, this second.

## The design

**Per opted-in room: one standing session** — a long-lived interactive `claude` process in a dedicated tmux pane (skill-owned socket, one pane per `(runtime, room)`), spawned on the room's first message, kept across messages, respawned with `claude --resume <recorded-session-id>` after a crash or host reboot. This is the same supervised-pane pattern the Sutando core itself runs under — not new infrastructure.

**Before (this chain until now):** every room message spawned a fresh `claude -p --resume` bounded by a hard timeout, serialized by a turn-length flock; a mid-turn message (including a cancel) queued blind behind the very turn it addressed, mid-run output was structurally unobservable, and (pre-#3259) a 900s timeout killed and discarded in-progress work.

**After:** `handle()` takes a short lock (spawn+inject ordering only — seconds, never a turn), writes a sanitized **spool prompt** (the trusted task view from #3238's `_task_view`; the session never sees the raw task file), injects one line pointing at it into the live pane, detaches a per-task monitor, acks the room, and returns immediately.

- **Mid-turn messages enter the conversation natively** — Claude Code's own input queue holds them visibly in the live session; a cancel/redirect actually reaches the turn it's about. Same-room serialization is the session's input queue, not a flock.
- **Real mid-run observability** — `tmux capture-pane` reads the live turn without disturbing it.
- **Long work is never discarded** — the safety ceiling (3600s) bounds the *watchdog*, not the work: a still-active turn keeps running with a room notice, and its result lands whenever it finishes.
- **Crash/reboot durability** — the persisted session id + `--resume` on respawn; a hung pane is killed by the stall watchdog (frozen pane content for 180s — a live provider at least animates its spinner) and the *next* message resumes the conversation.

**Publication ownership flips, deliberately:** the standing session writes `results/<task-id>.txt` itself (the spool prompt names the exact path — which necessarily embeds the task id, changing #3238's "child never sees the task id" property; that property was an artifact of parent-owned publication, not a trust boundary — the trust boundary, never seeing the *raw task file*, is preserved). The monitor is the backstop publisher on failure only, and kills the pane *before* publishing so the two can never race.

**Conventions carried from #3259** (the branch is closed; its design elements survive): honest failure publishing ("resend to continue — the conversation itself is preserved"), off-thread heartbeat dispatch (the exact blocking bug qingyun's reviewer caught there — carried as a fix, with the monitor's checks never delayed by a slow notifier), safety-ceiling-not-completion-boundary timeout framing, 120s heartbeat cadence.

## Explicit scope boundaries

- **Codex stays on the previous per-message `exec`/`exec resume` path, unchanged.** Interactive codex resume-id discovery inside a pane is unverified — moving codex onto the standing path is named follow-up work, not silently claimed.
- **A runaway turn that keeps producing output forever is only bounded by the room noticing its heartbeats** — documented in SKILL.md with the manual kill command. The stall watchdog only kills genuinely frozen panes.
- Spool prompt files are retained (not reaped) under `state/ag2space-room-sessions/spool/` for debugging; a reaper is possible follow-up.

## Tests

```
$ python3 tests/ag2space-room-session-worker.test.py
Results: 0 failed   (93 checks)
```

Including a **real-tmux end-to-end** (interactive stub provider): spawn-on-first-message with `--session-id` → inject → the session itself writes the exact result body → second message reuses the pane (exactly one spawn recorded) → `kill-session` → third message respawns with `--resume <same recorded id>` → state file matches. Plus monitor policy units: result-already-ready exits untouched; dead pane publishes the honest failure body; frozen pane is killed **before** the failure is published (ordering asserted); an active turn past the safety ceiling is never killed or failed, and the room gets the detach notice. Spool sanitization keeps #3238's policy assertions (ADDRESSING / CONTEXT-FIRST / addressed_to preserved, numbered publication directive stripped, raw task path absent). tmux-less environments skip the e2e with a visible `SKIP` line (CI may not have tmux — flagged, not hidden).

```
$ ruff check <changed .py>          → All checks passed!
$ python3 -m py_compile <changed>   → OK
$ python3 scripts/lint-skill.py skills/ag2space-room-sessions → 0 errors, 0 warnings
$ git diff <base> -- <changed> | bash scripts/review-checks.sh
  → PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Live path

This is exactly the class of change the repo's live-path rule targets. **The live post-restart round trip (real room message → standing pane spawns → real provider turn → result delivered back to the room, through a core restart) has not been run yet** and gates this PR leaving draft. Also worth a live check: tmux target-form behavior was verified against tmux 3.5a on this host (`=name:` for pane-targeting verbs — a bare `=name` silently fails `capture-pane`, which the e2e caught).

## Risk / rollback

One skill's execution model + manifest config; no schema migration (the sessions.json shape is unchanged and shared by both paths). Rollback is `git revert` — the base #3238 design is untouched underneath. Stray panes are killable via the skill's own tmux socket (documented in SKILL.md).
