### PR TITLE
docs(skills): identity locality, room topic vs purpose, and a cross-room disclosure rule

### DIFF
--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -175,7 +175,7 @@ When help is needed:
    - **A low or zero count is not evidence of exclusion.** The metric has no early signal — a maintainer added yesterday is indistinguishable from an inactive one until they accumulate history, so the ranking is most confident about the longest-tenured and least reliable about the newest arrival, which is exactly who "whom do I ask?" is often about. Use counts to find candidates, never to rule one out; explicit responsibility and owner statements outrank them.
 
    Treat a derived set older than a few hours the way this skill treats a memory: a candidate to re-derive, not an answer.
-3. Prefer the room where the work already has context. Do not move sensitive context across rooms without checking visibility and membership.
+3. **Choose the person first, then choose where to reach them — they are separate decisions.** An identity existing is not the same as it being live: check `identities[].activity` for where that person is actually seen, and honour `exclusive: true` (some people are reachable on exactly one surface, and a message anywhere else reaches nobody). Defaulting to whichever surface you happen to be on is how a reachable person gets treated as unreachable. Prefer the room where the work already has context, subject to that.
    When customers or external collaborators are present, share only context appropriate to that relationship and work scope.
 4. Contact the responsible agent directly when it can act. Include its owner or a human when approval, escalation, or shared accountability is needed.
 5. Resolve ambiguous recipients before sending. Never guess among duplicate names or uncertain identity links.
@@ -211,6 +211,7 @@ Do not spam every plausible expert. Escalate outward only after the primary owne
 
 - Store professional collaboration facts needed for coordination; avoid protected traits, private-life profiling, sentiment scores, or speculative trust labels.
 - Keep provenance and access scope with facts so restricted observations are not leaked into broader rooms.
+- **Repeating something from a smaller room into a larger one requires an explicit signal, and the default is no.** Before carrying a fact across rooms, compare their visibility, audience and membership: narrower → wider is a disclosure decision, not a formatting one. Knowing something because you were present is not permission to restate it. This skill's daily action *is* cross-room routing, so it will meet this case constantly; when in doubt, say that context exists and let the person who owns it decide whether to share it.
 - Honor deletion/correction requests and retain superseded facts only when audit needs require it.
 - Ask before performing external outreach unless the user already authorized sending or coordination.
 

--- a/skills/collaboration-intelligence/references/schema.md
+++ b/skills/collaboration-intelligence/references/schema.md
@@ -26,6 +26,11 @@ identities:
     display_name: string | null
     bridge_origin: string | null
     verified: false
+    activity:                       # WHERE this identity is live, not merely that it exists
+      last_seen_at: timestamp | null
+      rooms: [room-id]              # where it was actually observed
+      relative: primary | secondary | dormant | unknown
+      exclusive: true | false | unknown   # true = this person is reachable ONLY here
 owner_links:
   - owner_entity_id: stable-local-id
     relation: owner | operator | manager | sponsor | unknown
@@ -63,6 +68,7 @@ provider: string
 provider_room_id: stable-provider-native-room-or-channel-id
 provider_container_id: workspace-guild-server-community-id | null
 name: string | null
+topic: string | null              # the room's SELF-DECLARED purpose, read from provider state
 kind: dm | group_dm | channel | room | issue | pr | email_thread | other
 bridge_origin: string | null
 visibility: private | internal | public | unknown
@@ -220,6 +226,10 @@ quick_lookup:
 - Never use display-name equality alone. Two people can render the same name on one homeserver, so a display-name join does not merely lose precision — it returns *a* stable ID with full confidence, and the wrong one is indistinguishable from the right one downstream.
 - **An owner-stated mapping outranks any derived one.** Record it as an evidenced fact with `source: owner_stated` and the time it was stated, and do not let a later derivation silently supersede it. A derivation that disagrees with an owner statement is a conflict to surface, not a correction to apply.
 - Keep aliases after a verified rename; do not treat a rename as a new entity.
+- `name` and `topic` are mutable aliases, never keys. **`topic` is the room's self-declared
+  purpose (provider state); `purpose` is what the map inferred from traffic.** Store both, and
+  treat a divergence between them as a signal in its own right — usually a room whose real use
+  drifted while nobody updated the topic. Do not silently overwrite either with the other.
 - Supersede time-varying facts rather than deleting them silently.
 - Decay inferred operational facts when not reconfirmed: room context quickly, active responsibility moderately, identity and explicit ownership slowly.
 - Deduplicate alerts by `alert_key`; update `last_seen_at` instead of repeatedly notifying.


### PR DESCRIPTION
## What

Three schema/policy gaps the owner named, none of which the map could previously express.

## 1. Identity locality — where a person is *live*, not merely where they exist

The schema recorded which identities a person **has**. It had no way to say which one is **live**.

That is not academic: recruiting reviewers for the preceding PRs, one maintainer was reachable through their agent in a shared room and returned a substantive review in minutes, while another was in no room at all and had to be reached by GitHub review-request. **I found that by luck, not from the map** — there was no field that could have told me.

```yaml
identities:
  - provider: matrix | slack | discord | …
    activity:
      last_seen_at: timestamp | null
      rooms: [room-id]                     # where it was actually observed
      relative: primary | secondary | dormant | unknown
      exclusive: true | false | unknown    # reachable ONLY here
```

`exclusive` is the sharp one — some people are present on exactly one surface, and a message anywhere else reaches nobody while looking perfectly delivered.

`Find collaborators` now states that **choosing the person and choosing the surface are separate decisions**. Defaulting to whichever surface you happen to be on is how a reachable person gets treated as unreachable.

## 2. Room `topic`, and why it is not the same field as `purpose`

Adds `topic` beside `name`. The distinction is credited to @sutando-qingyun-001, and it is better than "just add topic":

> `topic` is the room's **self-declared** purpose (provider state). `purpose` is what the map **inferred** from traffic.

Store both, and treat a divergence as a signal in its own right — usually a room whose real use drifted while nobody updated the topic. Both stay mutable aliases and never keys, same rule as display names.

## 3. Cross-room disclosure needs an explicit signal, defaulting to no

The privacy section had `access_scope` on facts but no rule for the act this skill performs constantly: **carrying a fact from one room to another**. Narrower → wider is a disclosure decision, not a formatting one, and:

> Knowing something because you were present is not permission to restate it.

Default is no; when in doubt, say that context exists and let whoever owns it decide.

## Evidence

```
$ quick_validate.py skills/collaboration-intelligence     -> Skill is valid!
$ python3 - <yaml parse over schema.md>                   -> 8 yaml blocks parse
$ agents-md-sync.sh --check                               -> rc=0
$ review-checks.sh                                        -> PARTIAL (no .py in diff; paths + root-artifacts clean)
```

## Scope

Docs only — 2 files, +12/-1. No `src/`, no scripts, no tests. Separate from #3269 (First run), which is a different concern: that one is *how to start*, this one is *what the map must be able to say*.
