### PR TITLE
fix(skills): First run must not cross the serving-context boundary; headers are source-specific

### DIFF
--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -13,14 +13,29 @@ Build a living, evidence-backed collaboration map. Treat it as a coordination ai
 
 So run this once, before relying on the contract.
 
-**1. Sweep what you already have.** The task-file stream is an observation source readable with no new permissions and no network: every task header carries `channel_id`, `room_name`, `room_members`, `room_member_count`, `user_id`. Sweeping `tasks/` plus `tasks/archive/` yields, on day one:
+**1. Sweep the task-file stream — as an owner/operator maintenance action, never mid-task.**
 
-- **rooms**, ranked by traffic, with provider-native ids and names
+> **The bootstrap is not permission-free, and "the bytes are already on disk" is not the test.** The context boundary is *serving-relative*: `src/discord_context_policy.py`'s `gate()` decides whether the channel you are **currently serving** may read some other channel, it fails closed, and it applies to owner-tier tasks too. A sweep run while serving one channel would pull rooms that gate would have refused — and because the sweep **persists** what it reads, those rooms then inform every later answer. That is strictly worse than a single blocked read.
+>
+> So: run the bootstrap from an explicit owner/operator maintenance context, not as a side effect of handling a task. If you cannot establish that context, either filter every archived observation through the same serving-channel policy, or do not sweep. Record `access_scope` on each observation so a later answer cannot quietly widen it.
+
+**Header fields are source-specific — check, do not assume.** Writers differ, and the richest one is not representative:
+
+| source | provides | consequence |
+|---|---|---|
+| AG2 Space / Matrix | `channel_id`, `room_name`, `room_members`, `room_member_count`, `user_id` | rooms, names and rosters available |
+| Discord | `channel_id`, `channel_name`, `guild_name`, `user_id` | **no roster, no member count** — membership is `unknown`, not empty |
+| Slack | `channel_id`, `user_id` | id and speaker only; name and roster `unknown` |
+
+Treat a field the source never emits as **`unknown`**, never as absent-therefore-zero — a room with no roster field is not a room with no members. Set `coverage: unknown` for those sources and `coverage: partial` only where a roster was truncated (`+N more`), which is recordable **at sweep time** and unrecoverable afterwards.
+
+What the sweep yields, on the sources that carry it:
+
+- **rooms**, ranked by traffic, with provider-native ids and whatever name the source gave
 - **participants**, ranked by messages, classified `human` / `agent` / `service`
-- **coverage flags** — a header showing `+N more` means the roster was truncated, so that room is `coverage: partial` and must be recorded as such *at sweep time*; a truncated list looks complete afterwards
 - **unknowns worth resolving immediately** — rooms with real traffic but no name and no members observed
 
-Record the result per [references/schema.md](references/schema.md), including `store_freshness` per source. Do not enumerate rooms, inboxes or accounts you were not already given: this sweep observes traffic already received, which is what makes it permission-free.
+Record the result per [references/schema.md](references/schema.md), including `store_freshness` per source. Do not enumerate rooms, inboxes or accounts you were not already given.
 
 **2. Expect it to surface defects, and record them rather than smoothing them.** Run against a real corpus it immediately produced unnamed high-traffic rooms, hundreds of truncated rosters, and a service account misfiled as human by a two-way agent/human split. Each is a real map entry — an unknown to resolve, a partial-coverage flag, a classification gap — not noise to filter out.
 


### PR DESCRIPTION
## What

#3269 merged at `04:44:59Z` at head `f7accbe1` — the version **before** its two blocking findings were fixed. This carries the fix onto `main`.

## Why it matters

**[P1] `main` currently instructs an agent to cross the serving-context boundary.** The merged First-run section makes a global `tasks/` + `tasks/archive/` sweep the automatic first step, justified as permission-free because it "observes traffic already received".

That reasoning is wrong. The boundary is *serving-relative*:

```python
# src/discord_context_policy.py
def gate(serving_channel_id, target_channel_id, token, ...):
    """Return None if reading target is ALLOWED for this serving channel, ..."""
    # FAIL-CLOSED: a privacy gate must not fetch what it cannot clear.
```

It decides whether the channel **currently being served** may read another, it fails closed, and it applies to owner-tier tasks. "The bytes are already on disk" says nothing about that.

**And the sweep persists.** A blocked read is a one-off refusal; a sweep writes those rooms into the shared map, where they inform every later answer. One bootstrap run in the wrong context contaminates the store permanently — strictly worse than the read the gate exists to prevent.

Fixed by making the bootstrap an explicit **owner/operator maintenance action, never mid-task**, stating the alternative (filter each archived observation through the same policy), and requiring `access_scope` per observation.

**[P2] A false universal claim.** The merged text says *"every task header carries `channel_id`, `room_name`, `room_members`, `room_member_count`, `user_id`"*. Two of three production writers do not:

```
src/discord-bridge.py:4192-4201 -> channel_id, channel_name, guild_name, user_id      (no roster, no count)
src/slack-bridge.py:1129-1132   -> channel_id, user_id                                 (id and speaker only)
```

That claim came from measuring **this host's corpus**, which is overwhelmingly one source, and stating it as universal. Replaced with a per-source table plus the rule that matters more: **a field a source never emits is `unknown`, not absent-therefore-zero** — a room with no roster field is not a room with no members, and collapsing those writes confident emptiness into the map, the exact failure the skill exists to prevent.

## Evidence

```
parent (origin/main)  grep 'every task header carries'  -> 1     (defect present)
this head             grep 'every task header carries'  -> 0     (claim gone)
this head             grep 'discord_context_policy'     -> 1     (gate named)
quick_validate.py skills/collaboration-intelligence     -> Skill is valid!
agents-md-sync.sh --check                               -> rc=0
```

## Why this is a separate PR

#3269 merged while the fix commit was mid-push — the pre-push check returned `state=open merged=false` seconds before. Nothing can be pushed to a merged PR, so the fix comes forward as its own change against `main`.

Docs only, one file, +19/-4.
