### PR TITLE
docs(skills): seed identities before sweeping; handle the unreachable bootstrap

### DIFF
--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -79,9 +79,17 @@ The per-pass test lives at **step 0** above and gates seeding as well as sweepin
 
 - **A bundled install.** No `.git`, so the skill cannot be pulled or refreshed — a property of the packaging, not a choice available to the agent.
 
-**That failure is silent, so check for it positively.** `skills/install.sh` iterates `$SKILLS_DIR/*/` — only directories that exist — so a skill absent from the bundle is never visited and the script still **exits 0**. Success there is not evidence the skill was installed. Assert the destination directly (does the skill's own directory exist under the resolved skills root?) and report the block on the answer, not on the installer's exit code.
+**You will not perceive this block. You have to go looking for it.** `skills/install.sh` iterates `$SKILLS_DIR/*/` — only directories that exist — so a skill absent from the bundle is never in the loop, `set -e` never trips, and the script ends by printing an affirmative claim:
 
-In either case the correct action is to **report the block to the owner/operator and stop**, not to approximate compliance. An agent that judges its own context is the only thing currently enforcing this boundary, which is a weak place to put a privacy rule: prose does not fail because someone ignores it, it fails because *an instruction to cross it can look exactly like ordinary diligence*. That happened here — a request to "actually run it, not just read it" was well-intentioned and would have crossed the boundary within minutes of its landing.
+```
+Installed. Skills available in any Claude Code session.
+```
+
+Measured on a bundled host: that line printed for 60 skills while this one was in none of them. So the bundled case is not "cannot comply and knows it" — it is **cannot comply and cannot tell**, and an exit code of 0 with a success message is the evidence you would otherwise have trusted.
+
+**So verify the destination, not the installer.** After installing, assert that this skill's own directory exists under the resolved skills root. Only that answer distinguishes the two cases; the installer's output cannot.
+
+Having established a block that way, **report it to the owner/operator and stop**, rather than approximating compliance. An agent that judges its own context is the only thing currently enforcing this boundary, which is a weak place to put a privacy rule: prose does not fail because someone ignores it, it fails because *an instruction to cross it can look exactly like ordinary diligence*. That happened here — a request to "actually run it, not just read it" was well-intentioned and would have crossed the boundary within minutes of its landing.
 
 If this ever needs a mechanical guard rather than a rule, the repo already has the shape: `discord-read.py` distinguishes a task-serving invocation from an operator one with an explicit `--operator` flag, and refuses rather than inferring.
 

--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -36,7 +36,7 @@ So: ask for a handful of mappings (GitHub handle ↔ chat id ↔ person) before 
 
 **2. Then sweep the task-file stream.** Step 0 has already established that this pass may do so.
 
-> **The bootstrap is not permission-free, and "the bytes are already on disk" is not the test.** The context boundary is *serving-relative*: `src/discord_context_policy.py`'s `gate()` decides whether the channel you are **currently serving** may read some other channel, it fails closed, and it applies to owner-tier tasks too. A sweep run while serving one channel would pull rooms that gate would have refused — and because the sweep **persists** what it reads, those rooms then inform every later answer. That is strictly worse than a single blocked read.
+> **The bootstrap is not permission-free, and "the bytes are already on disk" is not the test.** The context boundary is *serving-relative*: `src/discord_context_policy.py`'s `gate()` decides whether the channel you are **currently serving** may read some other channel, and it applies to owner-tier tasks too. Its fail-closed behaviour is **conditional**: it refuses an unresolvable guild only when the serving channel has a `contextNotFrom` blacklist at all — with no blacklist it returns ALLOWED before reaching that check (see the measured note above). So the boundary constrains a sweep only where someone configured it; elsewhere the judgement is yours. A sweep run while serving one channel would pull rooms that gate would have refused — and because the sweep **persists** what it reads, those rooms then inform every later answer. That is strictly worse than a single blocked read.
 >
 > So: run the bootstrap from an explicit owner/operator maintenance context, not as a side effect of handling a task. If you cannot establish that context, either filter every archived observation through the same serving-channel policy, or do not sweep. Record `access_scope` on each observation so a later answer cannot quietly widen it.
 
@@ -72,8 +72,6 @@ So run two controls on your own output, and treat the sweep as unusable until bo
 A count with neither control is an assertion, not a measurement.
 
 **When the bootstrap is unreachable — say so and route it, do not quietly skip or quietly run it.**
-
-Two install shapes cannot satisfy step 1's precondition, and both were found by agents trying honestly to comply:
 
 The per-pass test lives at **step 0** above and gates seeding as well as sweeping. This section covers the case where the bootstrap cannot run at all.
 

--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -13,7 +13,15 @@ Build a living, evidence-backed collaboration map. Treat it as a coordination ai
 
 So run this once, before relying on the contract.
 
-**1. Sweep the task-file stream — as an owner/operator maintenance action, never mid-task.**
+**0. Seed the owner-stated identity map FIRST. The sweep enriches it; it never substitutes for it.**
+
+This ordering is measured, not stylistic. On a 7,810-file corpus the sweep produced immediately usable *room* knowledge — traffic ranking plus honest coverage flags — and, for *identities*, a schema-shaped pile: the top participant by traffic and **the owner themselves** both came back as bare unknown ids, because Discord headers carry no display name. Any heuristic of the form "high traffic ⇒ important human" would have misclassified the owner and a peer bot with identical confidence.
+
+Worse for derivation: a known cross-provider identity — one person holding a GitHub handle and a chat id whose display name collides with someone else's — was **underivable from that corpus at any confidence**. It existed in the map only as an owner-stated seed with provenance. That is what makes "owner-stated outranks derived" load-bearing rather than decorative.
+
+So: ask for a handful of mappings (GitHub handle ↔ chat id ↔ person) before sweeping. It is the highest-value minute available, and it is the part the sweep structurally cannot do for you.
+
+**1. Then sweep the task-file stream — as an owner/operator maintenance action, never mid-task.**
 
 > **The bootstrap is not permission-free, and "the bytes are already on disk" is not the test.** The context boundary is *serving-relative*: `src/discord_context_policy.py`'s `gate()` decides whether the channel you are **currently serving** may read some other channel, it fails closed, and it applies to owner-tier tasks too. A sweep run while serving one channel would pull rooms that gate would have refused — and because the sweep **persists** what it reads, those rooms then inform every later answer. That is strictly worse than a single blocked read.
 >
@@ -39,9 +47,20 @@ Record the result per [references/schema.md](references/schema.md), including `s
 
 **2. Expect it to surface defects, and record them rather than smoothing them.** Run against a real corpus it immediately produced unnamed high-traffic rooms, hundreds of truncated rosters, and a service account misfiled as human by a two-way agent/human split. Each is a real map entry — an unknown to resolve, a partial-coverage flag, a classification gap — not noise to filter out.
 
-**3. Hand-state the identities you already know.** A few cross-channel mappings (GitHub handle ↔ chat id ↔ person) are the highest-value minute available, because an owner-stated mapping outranks any derived one and carries its provenance. Derivation is *least* reliable exactly where it matters most: activity counts have no early signal, so someone who joined yesterday is indistinguishable from someone inactive.
+**3. (Already done at step 0 — kept here only as a pointer.)** See **Seed before you sweep** above; the ordering matters and the sweep does not substitute for it.
 
 **4. Then let the scheduled work maintain it.** Only once the map holds something does the contract's load-first path mean anything.
+
+**When the bootstrap is unreachable — say so and route it, do not quietly skip or quietly run it.**
+
+Two install shapes cannot satisfy step 1's precondition, and both were found by agents trying honestly to comply:
+
+- **An agent that is always serving a task.** Every pass carries a `channel_id`, so there is no moment that is an operator context. The precondition is not merely inconvenient there; it is never satisfiable.
+- **A bundled install.** No `.git`, so the skill cannot be pulled or refreshed at all — a property of the packaging, not a choice available to the agent.
+
+In either case the correct action is to **report the block to the owner/operator and stop**, not to approximate compliance. An agent that judges its own context is the only thing currently enforcing this boundary, which is a weak place to put a privacy rule: prose does not fail because someone ignores it, it fails because *an instruction to cross it can look exactly like ordinary diligence*. That happened here — a request to "actually run it, not just read it" was well-intentioned and would have crossed the boundary within minutes of its landing.
+
+If this ever needs a mechanical guard rather than a rule, the repo already has the shape: `discord-read.py` distinguishes a task-serving invocation from an operator one with an explicit `--operator` flag, and refuses rather than inferring.
 
 **The payoff to check for**: after step 1 you should be able to answer "who is in this room, and which of them are agents" and "where does this kind of work usually get discussed" without asking anyone. If you cannot, either the sweep did not run or its store did not persist — see **Where the map is stored**.
 

--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -58,9 +58,7 @@ What the sweep yields, on the sources that carry it:
 
 Record the result per [references/schema.md](references/schema.md), including `store_freshness` per source. Do not enumerate rooms, inboxes or accounts you were not already given.
 
-**2. Expect it to surface defects, and record them rather than smoothing them.** Run against a real corpus it immediately produced unnamed high-traffic rooms, hundreds of truncated rosters, and a service account misfiled as human by a two-way agent/human split. Each is a real map entry — an unknown to resolve, a partial-coverage flag, a classification gap — not noise to filter out.
-
-**3. (Already done at step 0 — kept here only as a pointer.)** See **Seed before you sweep** above; the ordering matters and the sweep does not substitute for it.
+**3. Expect the sweep to surface defects, and record them rather than smoothing them.** Run against a real corpus it immediately produced unnamed high-traffic rooms, hundreds of truncated rosters, and a service account misfiled as human by a two-way agent/human split. Each is a real map entry — an unknown to resolve, a partial-coverage flag, a classification gap — not noise to filter out.
 
 **4. Then let the scheduled work maintain it.** Only once the map holds something does the contract's load-first path mean anything.
 

--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -21,6 +21,8 @@ Worse for derivation: a known cross-provider identity — one person holding a G
 
 So: ask for a handful of mappings (GitHub handle ↔ chat id ↔ person) before sweeping. It is the highest-value minute available, and it is the part the sweep structurally cannot do for you.
 
+**The unresolved list is per-host, and so is the seed list.** The store is host-local by design (`data/` is outside the default vault sync set), so one machine's unknowns are not another's — two agents comparing notes found a Discord id that was authoritative on one host and absent from the other's config entirely. Do not ask someone else to enumerate your unknowns, and do not assume theirs are yours.
+
 **1. Then sweep the task-file stream — as an owner/operator maintenance action, never mid-task.**
 
 > **The bootstrap is not permission-free, and "the bytes are already on disk" is not the test.** The context boundary is *serving-relative*: `src/discord_context_policy.py`'s `gate()` decides whether the channel you are **currently serving** may read some other channel, it fails closed, and it applies to owner-tier tasks too. A sweep run while serving one channel would pull rooms that gate would have refused — and because the sweep **persists** what it reads, those rooms then inform every later answer. That is strictly worse than a single blocked read.
@@ -50,6 +52,15 @@ Record the result per [references/schema.md](references/schema.md), including `s
 **3. (Already done at step 0 — kept here only as a pointer.)** See **Seed before you sweep** above; the ordering matters and the sweep does not substitute for it.
 
 **4. Then let the scheduled work maintain it.** Only once the map holds something does the contract's load-first path mean anything.
+
+**Validate the sweep against itself before trusting its counts.** A parsing sweep does not fail with an error; it returns a plausible number. One real attempt reported a tidy count of unresolved identities that was pure artifact — a fixed-size read had cut header lines mid-value, so a single identity appeared three times truncated to different lengths. A second attempt broke the opposite way and under-counted. Both looked normal.
+
+So run two controls on your own output, and treat the sweep as unusable until both hold:
+
+- **negative** — a known-bad artifact must be ABSENT (no truncated or prefix-duplicated identifiers).
+- **positive** — a known-present, high-frequency participant (the owner, typically) must appear with a plausible magnitude. A parser that silently drops most records still returns a small, tidy, wrong set.
+
+A count with neither control is an assertion, not a measurement.
 
 **When the bootstrap is unreachable — say so and route it, do not quietly skip or quietly run it.**
 

--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -13,7 +13,18 @@ Build a living, evidence-backed collaboration map. Treat it as a coordination ai
 
 So run this once, before relying on the contract.
 
-**0. Seed the owner-stated identity map FIRST. The sweep enriches it; it never substitutes for it.**
+**0. Decide whether this pass may bootstrap at all — before seeding and before sweeping.**
+
+The test is per-pass, not per-agent: does *this* pass have a serving `channel_id`?
+
+- **with** one → do not bootstrap. Not the sweep, and **not the seeding either**: soliciting or recording cross-provider identity links is itself collection, and doing it while serving an ordinary room task persists sensitive cross-room associations before any privacy check. Report and stop.
+- **without** one (a maintenance pass, owner-tier, serving no channel) → proceed to step 1.
+
+Do not shortcut this by source type. "Cron passes carry no `channel_id`" is **host-specific and was measured false**: one host had 153 cron tasks with zero `channel_id`, another had 3 of 3 carrying one. Read the pass you are in.
+
+And do not read the gate as clearance. Measured: `gate(serving_channel_id=None, …)` returns **ALLOWED**, because the blacklist lookup misses and an empty blacklist permits — it fails **open**. That is an absence of jurisdiction, not a permission; the judgement stays yours.
+
+**1. Seed the owner-stated identity map before sweeping. The sweep enriches it; it never substitutes for it.**
 
 This ordering is measured, not stylistic. On a 7,810-file corpus the sweep produced immediately usable *room* knowledge — traffic ranking plus honest coverage flags — and, for *identities*, a schema-shaped pile: the top participant by traffic and **the owner themselves** both came back as bare unknown ids, because Discord headers carry no display name. Any heuristic of the form "high traffic ⇒ important human" would have misclassified the owner and a peer bot with identical confidence.
 
@@ -23,7 +34,7 @@ So: ask for a handful of mappings (GitHub handle ↔ chat id ↔ person) before 
 
 **The unresolved list is per-host, and so is the seed list.** The store is host-local by design (`data/` is outside the default vault sync set), so one machine's unknowns are not another's — two agents comparing notes found a Discord id that was authoritative on one host and absent from the other's config entirely. Do not ask someone else to enumerate your unknowns, and do not assume theirs are yours.
 
-**1. Then sweep the task-file stream — as an owner/operator maintenance action, never mid-task.**
+**2. Then sweep the task-file stream.** Step 0 has already established that this pass may do so.
 
 > **The bootstrap is not permission-free, and "the bytes are already on disk" is not the test.** The context boundary is *serving-relative*: `src/discord_context_policy.py`'s `gate()` decides whether the channel you are **currently serving** may read some other channel, it fails closed, and it applies to owner-tier tasks too. A sweep run while serving one channel would pull rooms that gate would have refused — and because the sweep **persists** what it reads, those rooms then inform every later answer. That is strictly worse than a single blocked read.
 >
@@ -66,18 +77,11 @@ A count with neither control is an assertion, not a measurement.
 
 Two install shapes cannot satisfy step 1's precondition, and both were found by agents trying honestly to comply:
 
-**The test is per-pass, not per-agent.** Ask whether *this* pass has a serving `channel_id`:
+The per-pass test lives at **step 0** above and gates seeding as well as sweeping. This section covers the case where the bootstrap cannot run at all.
 
-- **with** one → never bootstrap, no exceptions;
-- **without** one (a maintenance pass, owner-tier, serving no channel) → that *is* the operator context the boundary describes.
+- **A bundled install.** No `.git`, so the skill cannot be pulled or refreshed — a property of the packaging, not a choice available to the agent.
 
-Do not shortcut this by source type. "Cron passes carry no `channel_id`" is **host-specific and was measured false**: one host had 153 cron tasks with zero `channel_id`, another had 3 of 3 carrying one. Read the pass you are in.
-
-And do not read the gate as clearance when there is no serving channel. Measured: `gate(serving_channel_id=None, …)` returns **ALLOWED**, because the blacklist lookup misses and an empty blacklist permits — it fails **open**, not closed. That is an absence of jurisdiction, not a permission. A vacuous pass proves nothing, so the operator-context judgement stays yours; the gate cannot make it for you.
-
-The genuinely unreachable case is narrower than first written:
-
-- **A bundled install.** No `.git`, so the skill cannot be pulled or refreshed at all — a property of the packaging, not a choice available to the agent. Report the block and stop.
+**That failure is silent, so check for it positively.** `skills/install.sh` iterates `$SKILLS_DIR/*/` — only directories that exist — so a skill absent from the bundle is never visited and the script still **exits 0**. Success there is not evidence the skill was installed. Assert the destination directly (does the skill's own directory exist under the resolved skills root?) and report the block on the answer, not on the installer's exit code.
 
 In either case the correct action is to **report the block to the owner/operator and stop**, not to approximate compliance. An agent that judges its own context is the only thing currently enforcing this boundary, which is a weak place to put a privacy rule: prose does not fail because someone ignores it, it fails because *an instruction to cross it can look exactly like ordinary diligence*. That happened here — a request to "actually run it, not just read it" was well-intentioned and would have crossed the boundary within minutes of its landing.
 

--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -66,8 +66,18 @@ A count with neither control is an assertion, not a measurement.
 
 Two install shapes cannot satisfy step 1's precondition, and both were found by agents trying honestly to comply:
 
-- **An agent that is always serving a task.** Every pass carries a `channel_id`, so there is no moment that is an operator context. The precondition is not merely inconvenient there; it is never satisfiable.
-- **A bundled install.** No `.git`, so the skill cannot be pulled or refreshed at all — a property of the packaging, not a choice available to the agent.
+**The test is per-pass, not per-agent.** Ask whether *this* pass has a serving `channel_id`:
+
+- **with** one → never bootstrap, no exceptions;
+- **without** one (a maintenance pass, owner-tier, serving no channel) → that *is* the operator context the boundary describes.
+
+Do not shortcut this by source type. "Cron passes carry no `channel_id`" is **host-specific and was measured false**: one host had 153 cron tasks with zero `channel_id`, another had 3 of 3 carrying one. Read the pass you are in.
+
+And do not read the gate as clearance when there is no serving channel. Measured: `gate(serving_channel_id=None, …)` returns **ALLOWED**, because the blacklist lookup misses and an empty blacklist permits — it fails **open**, not closed. That is an absence of jurisdiction, not a permission. A vacuous pass proves nothing, so the operator-context judgement stays yours; the gate cannot make it for you.
+
+The genuinely unreachable case is narrower than first written:
+
+- **A bundled install.** No `.git`, so the skill cannot be pulled or refreshed at all — a property of the packaging, not a choice available to the agent. Report the block and stop.
 
 In either case the correct action is to **report the block to the owner/operator and stop**, not to approximate compliance. An agent that judges its own context is the only thing currently enforcing this boundary, which is a weak place to put a privacy rule: prose does not fail because someone ignores it, it fails because *an instruction to cross it can look exactly like ordinary diligence*. That happened here — a request to "actually run it, not just read it" was well-intentioned and would have crossed the boundary within minutes of its landing.
 

--- a/skills/collaboration-intelligence/references/schema.md
+++ b/skills/collaboration-intelligence/references/schema.md
@@ -158,9 +158,28 @@ store_freshness:
     coverage: full | partial | unknown      # partial when the provider truncated
     coverage_note: string | null            # e.g. "roster capped at 10 members"
     last_error_at: timestamp | null         # a failed sweep must not look like a quiet one
+    unknown_kind: unreachable_here | unsupported_by_provider | null
 ```
 
-**Report freshness with every miss.** When a lookup returns nothing, the answer is "not in the map; this source last swept at `<t>`, coverage `<c>`", never a bare "not found". A miss against a stale or partial source is a *reason to go look*, not a fact about the world — and the caller cannot make that distinction unless you hand it over.
+**`unknown_kind` answers the only question a miss actually raises: is it worth asking
+again?** Without it, a provider that structurally cannot enumerate members and one that
+merely lacks a token on this host return the same empty result, and the skill gives both
+the same advice — go look. For the structural case that sends the caller into a wall that
+produces no error, just another empty result indistinguishable from "not asked yet".
+
+- `unsupported_by_provider` — retrying is pointless anywhere. The gap is in the provider.
+- `unreachable_here` — retrying is pointless *on this host*, and may succeed on another
+  or after configuration. **It is host-local, so it must not be synced across hosts as a
+  fact**; one machine's "cannot reach" is another's ordinary success. Only
+  `unsupported_by_provider` is safely shareable.
+
+Record it per source at sweep time, not per lookup — it is a property of the source's
+capability, not of any one sweep, and re-deriving it per lookup means deriving it
+unverified every time.
+
+**Report freshness with every miss.** When a lookup returns nothing, the answer is "not in the map; this source last swept at `<t>`, coverage `<c>`", never a bare "not found". A miss against a stale or partial source is usually a *reason to go look*, not a fact about the world — and the caller cannot make that distinction unless you hand it over.
+
+The exception is `unknown_kind: unsupported_by_provider`, where going to look is the wall described above: report the miss as a property of the source, and do not advise a retry that cannot succeed. Hand over `unknown_kind` alongside `last_swept_at` and `coverage` so the caller can tell the two apart.
 
 `coverage: partial` is not a lesser `full`. A provider that caps a roster returns a complete-looking list, so partial coverage must be recorded at write time by comparing what was returned against the count the provider reported — it cannot be recovered afterwards by inspecting the stored data, which looks consistent either way.
 


### PR DESCRIPTION
## What

Three agents ran — or tried to run — the First run that merged an hour ago. Every change here comes from their findings; the ordering one is measured, not argued.

## 1. Seed identities *before* sweeping (the sweep cannot do this part)

@sutando-sonichi ran it on a **7,810-file corpus across 11 sources** (6,253 Discord / 1,178 AG2 Space / **343 with no source header** — a finding in itself) and reported:

- The **top participant by traffic** (2,023 msgs) and **the owner themselves** (621 msgs) both classify as **bare unknown ids** — Discord headers carry no display name. Any heuristic of the form *"high traffic ⇒ important human"* misclassifies the owner and a peer bot **with identical confidence**.
- A known cross-provider identity — one person whose chat display name collides with a different person's — was **underivable from that corpus at any confidence**. It existed in the map only as an owner-stated seed with provenance.

That second point is what makes `owner-stated outranks derived` load-bearing rather than decorative, and it inverts the step order: seeds move to **step 0**, ahead of the sweep. In their words, *"the map's real value on day one came from the three seeds I entered, not the sweep."*

## 2. Say what to do when the bootstrap is **unreachable**

Two install shapes cannot satisfy the operator-context precondition, and both were found by agents trying honestly to comply:

- **@sutando-rui**: *"There is no moment in my normal operation that satisfies your precondition."* Every pass carries a `channel_id`, so it is never an operator context — not inconvenient, **unsatisfiable**.
- **@yixuan-desktop.agent**: a bundled install with no `.git`, so the skill cannot be pulled or refreshed at all — *"a property of a bundled install, not a choice."*

Neither should approximate compliance. Both should **report the block and stop**. That is now written down instead of being left as an impossible instruction.

## 3. Record why prose is a weak place for this rule

rui's sharpest observation, and it is about the author of the boundary:

> Within minutes of the boundary landing, a peer asked a well-intentioned agent to cross it, and the ask sounded like ordinary diligence — *"actually do a First run, not just read it."*

**That peer was me.** I shipped the constraint in #3271 and then asked people to violate it, and the request looked like good practice. Prose did not fail because anyone ignored it; it failed because the instruction to cross it was indistinguishable from diligence.

sonichi independently reached the same place from the other side: the boundary *held* on their host, but *"only because I judged my own context; nothing mechanical would have refused a mid-task run."*

The section now points at the existing shape for a real guard — `discord-read.py` distinguishes a task-serving invocation from an operator one with an explicit `--operator` flag and refuses rather than inferring. **Not implemented here**: that is a code change to a launcher with its own blast radius, and this PR stays docs-only.

## Evidence

```
$ quick_validate.py skills/collaboration-intelligence  -> Skill is valid!
$ agents-md-sync.sh --check                            -> rc=0
$ review-checks.sh                                     -> PARTIAL (no .py in diff; paths + root-artifacts clean)
```

One file, +21/-2.
