### PR TITLE
feat(room-ops): topic op — a room's declared name/topic/alias

### DIFF
--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -153,6 +153,10 @@ def _main(argv):
     p.add_argument("room_id")
     p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
 
+    p = sub.add_parser("topic", help="a room's declared name/topic/alias (needs backend #735 for non-null fields)")
+    p.add_argument("room_id")
+    p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
+
     p = sub.add_parser("events", help="event subscriptions + delivery (#184 client half)")
     esub = p.add_subparsers(dest="events_cmd", required=True)
     e = esub.add_parser("emit", help="send one typed space.ag2.* timeline event as this agent")
@@ -240,6 +244,9 @@ def _main(argv):
         res = _rooms.joined_rooms(a.agent_mxid)
     elif a.cmd == "members":
         res = _members.room_members(a.room_id, a.agent_mxid)
+    elif a.cmd == "topic":
+        import topic as _topic
+        res = _topic.room_topic(a.room_id, a.agent_mxid)
     elif a.cmd == "events":
         if a.events_cmd == "stream":
             return _events_stream(a)  # prints JSONL itself; summary is one line

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -434,6 +434,9 @@ class CliTests(EnvCase):
     def test_read_exits_zero(self):
         self.assertEqual(room_ops._main(["read", ROOM, "--agent", HS]), 0)
 
+    def test_topic_dispatch_exits_zero(self):
+        self.assertEqual(room_ops._main(["topic", ROOM, "--agent", HS]), 0)
+
     def test_send_exits_zero_on_no_context(self):
         self.assertEqual(room_ops._main(["send", ROOM, "/nope/x.png", "--agent", HS]), 0)
 

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -201,6 +201,37 @@ class ReadTests(EnvCase):
 
 
 # ----- media ----- #
+class TopicTests(EnvCase):
+    def test_extracts_meta_and_reports_served(self):
+        import topic
+        from unittest import mock
+        res_events = {"events": [
+            {"type": "space.ag2.memo", "state_key": "k", "content": {}},
+            {"type": "m.room.name", "state_key": "", "content": {"name": "N"}},
+            {"type": "m.room.topic", "state_key": "", "content": {"topic": "T"}},
+        ]}
+        with mock.patch.object(topic, "gateway", return_value=("http://g", {})), \
+             mock.patch.object(topic, "http_json", return_value=(200, res_events)):
+            r = topic.room_topic("!r:x")
+        self.assertEqual((r["ok"], r["name"], r["topic"], r["alias"]),
+                         (True, "N", "T", None))
+        self.assertTrue(r["served_by_gateway"])
+
+    def test_pre_735_gateway_omits_meta_is_honest_degrade(self):
+        import topic
+        from unittest import mock
+        with mock.patch.object(topic, "gateway", return_value=("http://g", {})), \
+             mock.patch.object(topic, "http_json",
+                               return_value=(200, {"events": [
+                                   {"type": "space.ag2.memo", "content": {}}]})):
+            r = topic.room_topic("!r:x")
+        # ok:true with served_by_gateway:false — "not returned" is distinct
+        # from "the room has none", which would be served:true + nulls.
+        self.assertTrue(r["ok"])
+        self.assertFalse(r["served_by_gateway"])
+        self.assertIsNone(r["name"])
+
+
 class MediaTests(EnvCase):
     def setUp(self):
         super().setUp()

--- a/skills/agent-room-ops/topic.py
+++ b/skills/agent-room-ops/topic.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""room-ops · topic — a room's declared name/topic/alias (op `topic`).
+
+Reads via the gateway's `get_state` and extracts the three descriptive
+m.room.* types. Until backend #735 deploys, get_state filters those types
+out and every field is null — that is the honest degrade, not an error:
+"the gateway did not return it" and "the room has none" are reported
+distinctly via `served_by_gateway`.
+
+The map stores DECLARED purpose (this) separately from INFERRED purpose
+(traffic): divergence between them is itself a signal.
+"""
+from __future__ import annotations
+
+from _gateway import gateway, http_json, degrade_reason, HTTPError, URLError
+
+_META = ("m.room.topic", "m.room.name", "m.room.canonical_alias")
+
+
+def _result(ok, *, name=None, topic=None, alias=None, served=False, reason=None):
+    return {"ok": bool(ok), "name": name, "topic": topic, "alias": alias,
+            "served_by_gateway": served, "reason": reason}
+
+
+def room_topic(room_id: str, agent_mxid=None):
+    """→ {ok, name, topic, alias, served_by_gateway, reason}."""
+    base, headers = gateway()
+    if not base:
+        return _result(False, reason="no gateway configured")
+    try:
+        _status, res = http_json("POST", f"{base}/v1/room", headers,
+                                 {"op": "get_state", "room_id": room_id})
+    except HTTPError as e:
+        return _result(False, reason=degrade_reason(e.code))
+    except (URLError, TimeoutError) as e:
+        return _result(False, reason=f"network error: {e}")
+    if not isinstance(res, dict) or res.get("error"):
+        return _result(False, reason=str((res or {}).get("error") or
+                                         "malformed gateway response"))
+    fields = {}
+    served = False
+    for ev in res.get("events") or []:
+        if ev.get("type") in _META:
+            served = True
+            fields[ev["type"]] = ev.get("content") or {}
+    return _result(True, served=served,
+                   name=fields.get("m.room.name", {}).get("name"),
+                   topic=fields.get("m.room.topic", {}).get("topic"),
+                   alias=fields.get("m.room.canonical_alias", {}).get("alias"))

--- a/tests/room-ops-topic.test.py
+++ b/tests/room-ops-topic.test.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""room-ops `topic` — a room's declared name/topic/alias via get_state.
+
+Lives in `tests/` rather than beside the module because the diff-coverage gate
+discovers only `tests/*.test.py` (`scripts/coverage-gate.sh` -> `find tests
+-name '*.test.py'`), the same reachability note `tests/room-ops-say.test.py`
+carries. The in-skill suite (`skills/agent-room-ops/test_room_ops.py`) runs the
+same behavior for developers; this wrapper is what CI measures.
+
+The load-bearing distinction: `served_by_gateway` separates "the gateway did
+not return the m.room.* types" (pre-backend-#735 filter) from "the room has
+none declared" — both render as null fields, and collapsing them would make
+the honest degrade unreadable.
+
+Run: python3 tests/room-ops-topic.test.py
+"""
+import io
+import pathlib
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+_SKILL = pathlib.Path(__file__).resolve().parents[1] / "skills" / "agent-room-ops"
+sys.path.insert(0, str(_SKILL))
+import topic  # noqa: E402
+
+ROOM = "!r:ag2.space"
+HS = "@me:ag2.space"
+
+
+def _served(events):
+    ctx = mock.patch.multiple(
+        topic,
+        gateway=mock.Mock(return_value=("https://gw", {"h": "1"})),
+        http_json=mock.Mock(return_value=(200, {"events": events})),
+    )
+    return ctx
+
+
+class TopicExtractionTests(unittest.TestCase):
+    def test_extracts_meta_and_reports_served(self):
+        events = [
+            {"type": "space.ag2.memo", "state_key": "k", "content": {}},
+            {"type": "m.room.name", "state_key": "", "content": {"name": "N"}},
+            {"type": "m.room.topic", "state_key": "", "content": {"topic": "T"}},
+        ]
+        with _served(events):
+            r = topic.room_topic(ROOM)
+        self.assertEqual((r["ok"], r["name"], r["topic"], r["alias"]),
+                         (True, "N", "T", None))
+        self.assertTrue(r["served_by_gateway"])
+
+    def test_alias_and_null_content_are_tolerated(self):
+        events = [
+            {"type": "m.room.canonical_alias", "content": {"alias": "#a:x"}},
+            {"type": "m.room.name", "content": None},
+        ]
+        with _served(events):
+            r = topic.room_topic(ROOM)
+        self.assertEqual((r["ok"], r["alias"], r["name"]), (True, "#a:x", None))
+
+    def test_pre_735_gateway_omits_meta_is_honest_degrade(self):
+        with _served([{"type": "space.ag2.memo", "content": {}}]):
+            r = topic.room_topic(ROOM)
+        # ok:true with served_by_gateway:false — "not returned" is distinct
+        # from "the room has none", which would be served:true + nulls.
+        self.assertTrue(r["ok"])
+        self.assertFalse(r["served_by_gateway"])
+        self.assertIsNone(r["name"])
+
+
+class TopicDegradeTests(unittest.TestCase):
+    def test_no_gateway_configured(self):
+        with mock.patch.object(topic, "gateway", return_value=(None, {})):
+            r = topic.room_topic(ROOM)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["reason"], "no gateway configured")
+
+    def test_http_error_maps_to_degrade_reason(self):
+        err = topic.HTTPError("u", 403, "forbidden", None, None)
+        with mock.patch.object(topic, "gateway", return_value=("https://gw", {})), \
+             mock.patch.object(topic, "http_json", side_effect=err):
+            r = topic.room_topic(ROOM)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["reason"], topic.degrade_reason(403))
+
+    def test_network_error_degrades_without_raising(self):
+        with mock.patch.object(topic, "gateway", return_value=("https://gw", {})), \
+             mock.patch.object(topic, "http_json",
+                               side_effect=topic.URLError("boom")):
+            r = topic.room_topic(ROOM)
+        self.assertFalse(r["ok"])
+        self.assertIn("network error", r["reason"])
+
+    def test_error_payload_and_malformed_response(self):
+        with mock.patch.object(topic, "gateway", return_value=("https://gw", {})), \
+             mock.patch.object(topic, "http_json",
+                               return_value=(200, {"error": "nope"})):
+            self.assertEqual(topic.room_topic(ROOM)["reason"], "nope")
+        with mock.patch.object(topic, "gateway", return_value=("https://gw", {})), \
+             mock.patch.object(topic, "http_json", return_value=(200, None)):
+            r = topic.room_topic(ROOM)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["reason"], "malformed gateway response")
+
+
+class TopicCliDispatchTests(unittest.TestCase):
+    def test_room_ops_topic_routes_to_room_topic(self):
+        """Pins the CLI wiring: `room_ops topic <room>` reaches topic.room_topic.
+
+        room_ops imports topic lazily inside the dispatch arm; patching the
+        already-imported module object covers it via sys.modules identity.
+        """
+        import room_ops
+        with mock.patch.object(topic, "room_topic",
+                               return_value=topic._result(True, served=True)) as m:
+            with redirect_stdout(io.StringIO()):
+                rc = room_ops._main(["topic", ROOM, "--agent", HS])
+        self.assertEqual(rc, 0)
+        m.assert_called_once_with(ROOM, HS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
## What

The collaboration-intelligence map stores a room's **declared** purpose (owner rule 2026-08-22: name+topic are reference fields) separately from its traffic-**inferred** purpose — divergence between them is itself a signal. But no room_ops op could read the declared half. This adds `room_ops topic <room_id>`: extracts `m.room.name` / `m.room.topic` / `m.room.canonical_alias` from the gateway's `get_state`.

**Pairs with backend ag2-space/ag2space-backend#735** (base=dev): today's gateway filters all `m.room.*` out of get_state, so until #735 deploys the op returns `ok:true, served_by_gateway:false` with null fields — **"the gateway did not return it" stays distinct from "the room has none"** (which would be `served:true` + nulls). Merge order is free: this degrades honestly before #735 and lights up after.

## Evidence

Live run at HEAD against a real member room (pre-#735 gateway):
```
$ python3 room_ops.py topic '!GIdEPVXSWgPicGScYW:ag2.space'
{"ok": true, "name": null, "topic": null, "alias": null, "served_by_gateway": false, "reason": null}
```
Suite at HEAD: `python3 -m unittest test_room_ops` → **Ran 124 tests, OK** — including the extraction pin (name/topic served → fields populated) and the pre-#735 degrade pin. At parent, `room_ops topic` is an unknown subcommand (op absent — before/after is existence).

Measurement that motivated the pair: get_state on a NAMED room returned 20 events, zero carrying the name (documented in #735).

Shepherd: @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)