### PR TITLE
docs(skills): add Work with customers — owner, venue, and boundary

### DIFF
--- a/skills/collaboration-intelligence/SKILL.md
+++ b/skills/collaboration-intelligence/SKILL.md
@@ -225,6 +225,56 @@ Keep stable team relationships separate from short-lived work-item collaboration
 
 Never convert one interaction into a stable behavior claim. Require repeated observations or an explicit statement. Use neutral, operational wording such as “usually reviews backend delivery changes” rather than personality judgments.
 
+## Work with customers
+
+Customer collaboration needs a clear owner, a shared working surface, and a durable record. Track,
+per customer:
+
+- the customer organization and its key contacts
+- each contact's role: decision-maker, champion, technical owner, user, or procurement
+- the internal owner and the responsible agent
+- active scope, commitments, blockers, deadlines, and the next action
+- preferred channels, response expectations, and VIP/priority status
+
+### Use each venue for the right purpose
+
+| Venue | Purpose |
+|---|---|
+| Slack Connect, AG2 Space, WhatsApp | day-to-day coordination |
+| GitHub or issue tracker | technical work and delivery status |
+| Email, documents, contracts, CRM | formal decisions and commitments |
+| Meetings | synchronous discussion — record the outcome in a durable venue afterward |
+
+**Always identify the source of truth, and do not let an important decision exist only in chat.** A
+decision that lives in a message thread has no owner, no version, and no reader after scrollback.
+
+### Keep the work moving
+
+1. Acknowledge customer requests promptly.
+2. Clarify the desired outcome, the urgency, and who the decision-maker is.
+3. Assign one internal owner and one clear next action.
+4. Give progress updates **when the state changes**, and before an agreed update deadline **even if
+   the work is not finished** — an update whose content is "still working" is still a state report.
+5. Surface blockers with options and a recommendation, not only a problem statement.
+6. Close the loop: record the outcome and confirm completion with the customer.
+
+⇒ **A customer request must never remain "waiting on nobody."** If ownership is unclear, establish an
+internal owner *before* promising a result. An unowned internal item stalls quietly; an unowned
+customer item stalls while someone outside is waiting on an answer they were led to expect.
+
+### Protect the boundary
+
+- Treat customer-facing rooms as **external or mixed-audience** spaces.
+- Do not carry internal discussion, blame, private incidents, credentials, or personnel context into
+  them.
+- **Distinguish a customer request from an accepted commitment.** The two look alike in a chat log and
+  differ entirely in what they oblige.
+- Do not promise scope, dates, pricing, or policy exceptions without the appropriate authority.
+- Keep an internal backchannel for private coordination, **and keep the customer-facing status
+  accurate and consistent with it** — a backchannel that diverges from what the customer has been told
+  is worse than no backchannel.
+
+
 ## Handle VIP and priority participants
 
 - Apply VIP status only from an explicit owner/organization designation or an authoritative configured source. Record who designated it, why, its scope, and any expiry.


### PR DESCRIPTION
## What & why

Adds a `## Work with customers` section to the collaboration-intelligence skill: how to record who owns a customer relationship, which venue a given conversation belongs in, and where the boundary sits between collaborating with someone and representing the org to them.

Placed after **Maintain identity and relationship records** and before **Handle VIP and priority participants** — the position requested by the owner, and the one the surrounding text implies: it needs the identity/affiliation vocabulary that precedes it, and VIP handling reads as a specialisation on top of it.

## What files / sections should reviewers look at first?

`skills/collaboration-intelligence/SKILL.md`, the new section only. **+50/-0, one file, no existing line changed.**

## Relationship to #3291

**Not stacked, and no merge order is required.** #3291 touches the same file but a different region; a `git merge-tree` dry-run against its head reports **0 conflict hunks**. Either can land first. Both branch from `main`, not from each other.

## Evidence

Placement, from the built file at this head:

```
207:## Maintain identity and relationship records
228:## Work with customers            <- new
278:## Handle VIP and priority participants
```

Scope and conflict check:

```
$ git diff --stat origin/main...HEAD
 skills/collaboration-intelligence/SKILL.md | 50 ++++++++++++++++++++++++++++++
 1 file changed, 50 insertions(+)

$ git merge-tree $(git merge-base HEAD <#3291-head>) HEAD <#3291-head> | grep -c '^<<<<<<<'
0
```

Repository checks:

```
$ git diff origin/main...HEAD | bash scripts/review-checks.sh
prose-cap: no in-scope files (exts .py); nothing was scanned
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
```

**`PARTIAL` here is the markdown-only case, not a skipped check** — `prose-cap` scans `.py` and this diff has none. The two checks that do apply to a docs change, hardcoded-paths and root-artifacts, both ran and are clean.

## Risk

Documentation only. No code path, no test, no runtime behaviour. Reverting is deleting the section.
