### PR TITLE
fix(startup): the Accessibility probe blocks boot forever on a headless session

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -14,6 +14,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 
 ## `src/`
 
+- **`accessibility_probe.sh`** — Unbounded, this probe blocks forever on a session with nobody to answer the AppleScript prompt, and startup never reaches the services after it.
 - **`agent-api.py`** — Sutando agent API — simple HTTP endpoint for agent-to-agent communication.
 - **`agent_endpoint.py`** — Agent Endpoint resolver — resolve(endpoint, mode) → a transport route.
 - **`archive-stale-results.py`** — Archive stale `results/*.txt` files to `results/archive-YYYY-MM-DD/`.

--- a/src/accessibility_probe.sh
+++ b/src/accessibility_probe.sh
@@ -4,10 +4,21 @@
 
 ACCESSIBILITY_PROBE_TIMEOUT_S="${ACCESSIBILITY_PROBE_TIMEOUT_S:-5}"
 
-# 0 granted, 124 TIMED OUT, other non-zero denied. Timeout is a fact about the
-# session and denial one about the grant; only denial means System Settings.
+# 0 granted, 124 TIMED OUT, 125 COULD NOT CHECK, other non-zero denied. Timeout
+# and absence are facts about the session; only denial means System Settings.
 accessibility_probe() {
   local secs="${1:-$ACCESSIBILITY_PROBE_TIMEOUT_S}"
+  # Fail CLOSED on a bad bound: perl reads `alarm 0` — and anything coercing to
+  # 0 — as "cancel", which silently restores the unbounded call this exists for.
+  case "$secs" in ''|*[!0-9]*|0) secs=5 ;; esac
+  # Overridable so the bound itself is testable; production never sets it.
+  # Keyed on SET, not on length: a one-element override is a real override.
+  local -a cmd
+  if [ "${ACCESSIBILITY_PROBE_CMD+set}" = set ]; then
+    cmd=("${ACCESSIBILITY_PROBE_CMD[@]}")
+  else
+    cmd=(osascript -e 'tell application "System Events" to get name of first process whose frontmost is true')
+  fi
   # perl must FORK, not exec: after exec the ALRM handler is gone and the child
   # dies as signal 14, reporting 142 for something that is not a denial.
   perl -e '
@@ -20,7 +31,5 @@ accessibility_probe() {
     waitpid $pid, 0;
     alarm 0;
     exit($? >> 8 ? $? >> 8 : ($? ? 1 : 0));
-  ' "$secs" osascript -e \
-    'tell application "System Events" to get name of first process whose frontmost is true' \
-    > /dev/null 2>&1
+  ' "$secs" "${cmd[@]}" > /dev/null 2>&1
 }

--- a/src/accessibility_probe.sh
+++ b/src/accessibility_probe.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Unbounded, this probe blocks forever on a session with nobody to answer the
+# AppleScript prompt, and startup never reaches the services after it.
+
+ACCESSIBILITY_PROBE_TIMEOUT_S="${ACCESSIBILITY_PROBE_TIMEOUT_S:-5}"
+
+# 0 granted, 124 TIMED OUT, other non-zero denied. Timeout is a fact about the
+# session and denial one about the grant; only denial means System Settings.
+accessibility_probe() {
+  local secs="${1:-$ACCESSIBILITY_PROBE_TIMEOUT_S}"
+  # perl must FORK, not exec: after exec the ALRM handler is gone and the child
+  # dies as signal 14, reporting 142 for something that is not a denial.
+  perl -e '
+    my $secs = shift;
+    my $pid = fork();
+    die "fork failed\n" unless defined $pid;
+    if (!$pid) { exec @ARGV; exit 127; }
+    $SIG{ALRM} = sub { kill "KILL", $pid; waitpid $pid, 0; exit 124 };
+    alarm $secs;
+    waitpid $pid, 0;
+    alarm 0;
+    exit($? >> 8 ? $? >> 8 : ($? ? 1 : 0));
+  ' "$secs" osascript -e \
+    'tell application "System Events" to get name of first process whose frontmost is true' \
+    > /dev/null 2>&1
+}

--- a/src/init.sh
+++ b/src/init.sh
@@ -383,8 +383,10 @@ preflight() {
     perms_warn=1
   fi
   source "$REPO/src/accessibility_probe.sh"
-  accessibility_probe
-  case $? in
+  # `|| rc=$?` keeps this exempt from `set -e`; a bare non-zero call aborts
+  # init.sh before it ever emits its [Preflight] summary.
+  local acc_rc=0; accessibility_probe || acc_rc=$?
+  case $acc_rc in
     0)   : ;;
     124) log "  ⚠ Accessibility UNKNOWN — probe timed out (headless session cannot answer)"
          perms_warn=1 ;;

--- a/src/init.sh
+++ b/src/init.sh
@@ -382,10 +382,15 @@ preflight() {
     log "  ⚠ Screen Recording not granted (System Settings → Privacy → Screen Recording → grant the app running this terminal, then quit + relaunch it)"
     perms_warn=1
   fi
-  if ! osascript -e 'tell application "System Events" to get name of first process whose frontmost is true' > /dev/null 2>&1; then
-    log "  ⚠ Accessibility not granted (System Settings → Privacy → Accessibility)"
-    perms_warn=1
-  fi
+  source "$REPO/src/accessibility_probe.sh"
+  accessibility_probe
+  case $? in
+    0)   : ;;
+    124) log "  ⚠ Accessibility UNKNOWN — probe timed out (headless session cannot answer)"
+         perms_warn=1 ;;
+    *)   log "  ⚠ Accessibility not granted (System Settings → Privacy → Accessibility)"
+         perms_warn=1 ;;
+  esac
 
   # One-line summary regardless of mode (this is the value-add)
   local cli_str="all-ok"

--- a/src/init.sh
+++ b/src/init.sh
@@ -382,10 +382,19 @@ preflight() {
     log "  ⚠ Screen Recording not granted (System Settings → Privacy → Screen Recording → grant the app running this terminal, then quit + relaunch it)"
     perms_warn=1
   fi
-  source "$REPO/src/accessibility_probe.sh"
-  # `|| rc=$?` keeps this exempt from `set -e`; a bare non-zero call aborts
-  # init.sh before it ever emits its [Preflight] summary.
-  local acc_rc=0; accessibility_probe || acc_rc=$?
+  # $REPO is overridable (tests point it at a scratch dir), so fall back to
+  # alongside this script — an unguarded source under `set -e` aborts the run.
+  local __probe="$REPO/src/accessibility_probe.sh"
+  [ -f "$__probe" ] || __probe="$(cd "$(dirname "$0")" && pwd)/accessibility_probe.sh"
+  local acc_rc=0
+  if [ -f "$__probe" ]; then
+    # `|| rc=$?` keeps this exempt from `set -e`: a bare non-zero call would
+    # abort init.sh before it ever emits its [Preflight] summary.
+    source "$__probe"
+    accessibility_probe || acc_rc=$?
+  else
+    acc_rc=0   # no probe available: do not invent a permission verdict
+  fi
   case $acc_rc in
     0)   : ;;
     124) log "  ⚠ Accessibility UNKNOWN — probe timed out (headless session cannot answer)"

--- a/src/init.sh
+++ b/src/init.sh
@@ -386,17 +386,19 @@ preflight() {
   # alongside this script — an unguarded source under `set -e` aborts the run.
   local __probe="$REPO/src/accessibility_probe.sh"
   [ -f "$__probe" ] || __probe="$(cd "$(dirname "$0")" && pwd)/accessibility_probe.sh"
-  local acc_rc=0
+  # 125 = could not check. acc_rc=0 here would BE the granted verdict, which
+  # is exactly the invention the old comment claimed to avoid.
+  local acc_rc=125
   if [ -f "$__probe" ]; then
     # `|| rc=$?` keeps this exempt from `set -e`: a bare non-zero call would
     # abort init.sh before it ever emits its [Preflight] summary.
     source "$__probe"
-    accessibility_probe || acc_rc=$?
-  else
-    acc_rc=0   # no probe available: do not invent a permission verdict
+    acc_rc=0; accessibility_probe || acc_rc=$?
   fi
   case $acc_rc in
     0)   : ;;
+    125) log "  ⚠ Accessibility UNKNOWN — probe unavailable, nothing was checked"
+         perms_warn=1 ;;
     124) log "  ⚠ Accessibility UNKNOWN — probe timed out (headless session cannot answer)"
          perms_warn=1 ;;
     *)   log "  ⚠ Accessibility not granted (System Settings → Privacy → Accessibility)"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -599,13 +599,16 @@ else
 fi
 
 # Check Accessibility (needed for context drop shortcut)
-if ! osascript -e 'tell application "System Events" to get name of first process whose frontmost is true' > /dev/null 2>&1; then
-  echo "  ⚠ Accessibility not granted"
-  echo "    → System Settings → Privacy & Security → Accessibility"
-  echo "    → Add Terminal.app or Shortcuts.app"
-else
-  echo "  ✓ Accessibility"
-fi
+source "$REPO/src/accessibility_probe.sh"
+accessibility_probe
+case $? in
+  0)   echo "  ✓ Accessibility" ;;
+  124) echo "  ⚠ Accessibility UNKNOWN — probe timed out after ${ACCESSIBILITY_PROBE_TIMEOUT_S}s"
+       echo "    This session cannot answer the prompt (headless/SSH); the grant may be fine." ;;
+  *)   echo "  ⚠ Accessibility not granted"
+       echo "    → System Settings → Privacy & Security → Accessibility"
+       echo "    → Add Terminal.app or Shortcuts.app" ;;
+esac
 echo ""
 
 # Install Claude Code skills (runs every startup, idempotent)

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -603,14 +603,17 @@ fi
 # source under `set -e` aborts the whole run.
 __probe="$REPO/src/accessibility_probe.sh"
 [ -f "$__probe" ] || __probe="$(cd "$(dirname "$0")" && pwd)/accessibility_probe.sh"
-acc_rc=0
+# 125 = could not check. NOT 0: a missing probe would otherwise print
+# "✓ Accessibility", asserting a grant on a run where nothing was probed.
+acc_rc=125
 if [ -f "$__probe" ]; then
   # `|| rc=$?` keeps this exempt from `set -e`; a bare non-zero call aborts.
   source "$__probe"
-  accessibility_probe || acc_rc=$?
+  acc_rc=0; accessibility_probe || acc_rc=$?
 fi
 case $acc_rc in
   0)   echo "  ✓ Accessibility" ;;
+  125) echo "  ⚠ Accessibility UNKNOWN — probe unavailable, nothing was checked" ;;
   124) echo "  ⚠ Accessibility UNKNOWN — probe timed out after ${ACCESSIBILITY_PROBE_TIMEOUT_S}s"
        echo "    This session cannot answer the prompt (headless/SSH); the grant may be fine." ;;
   *)   echo "  ⚠ Accessibility not granted"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -600,8 +600,10 @@ fi
 
 # Check Accessibility (needed for context drop shortcut)
 source "$REPO/src/accessibility_probe.sh"
-accessibility_probe
-case $? in
+# `|| rc=$?` keeps this exempt from `set -e`: a bare non-zero call aborts the
+# whole script, and the probe returns non-zero on every host without the grant.
+acc_rc=0; accessibility_probe || acc_rc=$?
+case $acc_rc in
   0)   echo "  ✓ Accessibility" ;;
   124) echo "  ⚠ Accessibility UNKNOWN — probe timed out after ${ACCESSIBILITY_PROBE_TIMEOUT_S}s"
        echo "    This session cannot answer the prompt (headless/SSH); the grant may be fine." ;;

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -599,10 +599,16 @@ else
 fi
 
 # Check Accessibility (needed for context drop shortcut)
-source "$REPO/src/accessibility_probe.sh"
-# `|| rc=$?` keeps this exempt from `set -e`: a bare non-zero call aborts the
-# whole script, and the probe returns non-zero on every host without the grant.
-acc_rc=0; accessibility_probe || acc_rc=$?
+# $REPO is overridable, so fall back to alongside this script: an unguarded
+# source under `set -e` aborts the whole run.
+__probe="$REPO/src/accessibility_probe.sh"
+[ -f "$__probe" ] || __probe="$(cd "$(dirname "$0")" && pwd)/accessibility_probe.sh"
+acc_rc=0
+if [ -f "$__probe" ]; then
+  # `|| rc=$?` keeps this exempt from `set -e`; a bare non-zero call aborts.
+  source "$__probe"
+  accessibility_probe || acc_rc=$?
+fi
 case $acc_rc in
   0)   echo "  ✓ Accessibility" ;;
   124) echo "  ⚠ Accessibility UNKNOWN — probe timed out after ${ACCESSIBILITY_PROBE_TIMEOUT_S}s"

--- a/tests/accessibility-probe-bounded.test.sh
+++ b/tests/accessibility-probe-bounded.test.sh
@@ -58,6 +58,23 @@ probe_with 3 false;        [ $? -eq 1 ] && ok "a plain failure is 1, not 124" ||
 grep -q 'ACCESSIBILITY_PROBE_TIMEOUT_S' "$REPO/src/accessibility_probe.sh" \
   && ok "the bound is overridable" || bad "the bound is overridable"
 
-total=9
+# Both callers run under `set -e`, where a bare non-zero call aborts the script
+# before its summary — measured: init.sh --preflight emitted 0 summary lines.
+for f in src/startup.sh src/init.sh; do
+  if grep -qE '^\s*accessibility_probe\s*$' "$REPO/$f"; then
+    bad "$f calls the probe set -e safely" "bare call aborts under set -e"
+  else
+    ok "$f calls the probe set -e safely"
+  fi
+done
+
+# And prove the shape, not just its absence.
+if bash -c 'set -e; f(){ return 124; }; rc=0; f || rc=$?; [ "$rc" -eq 124 ]'; then
+  ok "the || rc=\$? form survives set -e and keeps the code"
+else
+  bad "the || rc=\$? form survives set -e and keeps the code"
+fi
+
+total=12
 echo "  Total: $total — pass: $((total-fails)), fail: $fails"
 [ "$fails" -eq 0 ] || exit 1

--- a/tests/accessibility-probe-bounded.test.sh
+++ b/tests/accessibility-probe-bounded.test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Drives the REAL accessibility_probe and the REAL caller blocks. The previous
-# version tested a hand-copied perl invocation, so the bound could be defeated
-# while every case passed.
+# Drives the REAL accessibility_probe, not a copy: the previous version tested a
+# hand-copied perl invocation, so the bound could be defeated while all passed.
 set -uo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fails=0

--- a/tests/accessibility-probe-bounded.test.sh
+++ b/tests/accessibility-probe-bounded.test.sh
@@ -75,6 +75,29 @@ else
   bad "the || rc=\$? form survives set -e and keeps the code"
 fi
 
-total=12
+# $REPO is overridable — tests point it at a scratch dir with no src/. An
+# unguarded `source "$REPO/..."` under `set -e` aborts before any output.
+for f in src/startup.sh src/init.sh; do
+  if grep -qE '^\s*(local )?source "\$REPO/src/accessibility_probe.sh"' "$REPO/$f"; then
+    bad "$f guards the probe source" "sources \$REPO unguarded; a scratch repo aborts it"
+  else
+    ok "$f guards the probe source"
+  fi
+done
+
+S="$(mktemp -d)"; mkdir -p "$S/.fake-home"
+SUTANDO_REPO="$S" SUTANDO_WORKSPACE="$S/.workspace" SUTANDO_TEST_MODE=1 \
+  HOME="$S/.fake-home" CLAUDE_CONFIG_DIR="$S/.fake-home/.claude" \
+  bash "$REPO/src/init.sh" --preflight > "$S/out" 2>&1
+prc=$?
+if [ "$prc" -eq 0 ] && [ "$(grep -c 'Preflight' "$S/out")" -eq 1 ]; then
+  ok "--preflight exits 0 and emits its summary with SUTANDO_REPO on a scratch dir"
+else
+  bad "--preflight exits 0 and emits its summary with SUTANDO_REPO on a scratch dir" \
+      "rc=$prc summary_lines=$(grep -c 'Preflight' "$S/out")"
+fi
+rm -rf "$S"
+
+total=15
 echo "  Total: $total — pass: $((total-fails)), fail: $fails"
 [ "$fails" -eq 0 ] || exit 1

--- a/tests/accessibility-probe-bounded.test.sh
+++ b/tests/accessibility-probe-bounded.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# The probe must be BOUNDED and must distinguish a timeout from a denial:
-# only a denial should send someone to System Settings.
+# Drives the REAL accessibility_probe and the REAL caller blocks. The previous
+# version tested a hand-copied perl invocation, so the bound could be defeated
+# while every case passed.
 set -uo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fails=0
@@ -9,80 +10,63 @@ bad() { printf '  FAIL %s %s\n' "$1" "${2:-}"; fails=$((fails+1)); }
 
 echo "accessibility probe is bounded:"
 
-[ -f "$REPO/src/accessibility_probe.sh" ] \
-  && ok "the shared probe exists" \
-  || { bad "the shared probe exists" "src/accessibility_probe.sh missing"; echo "  Total: 1 — pass: 0, fail: 1"; exit 1; }
+PROBE="$REPO/src/accessibility_probe.sh"
+[ -f "$PROBE" ] && ok "the shared probe exists" \
+  || { bad "the shared probe exists" "missing"; echo "  Total: 1 — pass: 0, fail: 1"; exit 1; }
 
-# The defect existed in two places because the probe was duplicated, so a fix
-# in only one of them is not a fix.
-raw=0
-for f in src/startup.sh src/init.sh; do
-  if grep -q "osascript -e 'tell application \"System Events\" to get name of first process" "$REPO/$f"; then
-    bad "$f goes through the shared probe" "still calls osascript directly"; raw=1
-  fi
-done
-[ "$raw" -eq 0 ] && ok "both callers go through the shared probe"
+# shellcheck source=../src/accessibility_probe.sh
+. "$PROBE"
+type accessibility_probe >/dev/null 2>&1 \
+  && ok "the real function is what this file exercises" \
+  || bad "the real function is what this file exercises" "not defined after sourcing"
 
-for f in src/startup.sh src/init.sh; do
-  grep -q 'accessibility_probe' "$REPO/$f" \
-    && ok "$f calls accessibility_probe" \
-    || bad "$f calls accessibility_probe" "no call found"
-done
-
-. "$REPO/src/accessibility_probe.sh"
-
-# A hanging command must be killed at the bound, not waited on forever.
-start=$(date +%s)
-( perl -e 'my $s=shift; my $p=fork(); if(!$p){exec @ARGV; exit 127;}
-           $SIG{ALRM}=sub{kill "KILL",$p; waitpid $p,0; exit 124};
-           alarm $s; waitpid $p,0; alarm 0;
-           exit($?>>8 ? $?>>8 : ($? ? 1 : 0));' 2 sleep 30 ) >/dev/null 2>&1
-rc=$?; el=$(( $(date +%s) - start ))
-[ "$rc" -eq 124 ] && [ "$el" -lt 5 ] \
-  && ok "a hanging probe is killed at the bound (rc=124 after ${el}s)" \
-  || bad "a hanging probe is killed at the bound" "rc=$rc elapsed=${el}s"
-
-# Timeout and denial must not collapse: 142 means the ALRM handler was lost to
-# exec, and a caller cannot tell that from a genuine denial.
-probe_with() {
-  perl -e 'my $s=shift; my $p=fork(); if(!$p){exec @ARGV; exit 127;}
-           $SIG{ALRM}=sub{kill "KILL",$p; waitpid $p,0; exit 124};
-           alarm $s; waitpid $p,0; alarm 0;
-           exit($?>>8 ? $?>>8 : ($? ? 1 : 0));' "$@" >/dev/null 2>&1
+run_probe() {
+  local s0 rc
+  s0=$(date +%s)
+  ACCESSIBILITY_PROBE_CMD=(sleep 8)
+  ACCESSIBILITY_PROBE_TIMEOUT_S="$1" accessibility_probe; rc=$?
+  ELAPSED=$(( $(date +%s) - s0 ))
+  return $rc
 }
-probe_with 3 true;         [ $? -eq 0 ] && ok "success returns 0"        || bad "success returns 0"
-probe_with 3 sh -c 'exit 7'; [ $? -eq 7 ] && ok "a denial code survives (7)" || bad "a denial code survives (7)"
-probe_with 3 false;        [ $? -eq 1 ] && ok "a plain failure is 1, not 124" || bad "a plain failure is 1, not 124"
 
-# 5s is a guess and a slow host is not a denial, so the bound is overridable.
-grep -q 'ACCESSIBILITY_PROBE_TIMEOUT_S' "$REPO/src/accessibility_probe.sh" \
-  && ok "the bound is overridable" || bad "the bound is overridable"
+# Valid override HONOURED. Without this control the rows below are equally
+# consistent with a helper that ignores the variable and always waits 5s.
+run_probe 2; rc=$?
+[ "$rc" -eq 124 ] && [ "$ELAPSED" -ge 2 ] && [ "$ELAPSED" -lt 4 ] \
+  && ok "a valid bound is honoured (2s -> 124 in ${ELAPSED}s)" \
+  || bad "a valid bound is honoured" "rc=$rc elapsed=${ELAPSED}s"
 
-# Both callers run under `set -e`, where a bare non-zero call aborts the script
-# before its summary — measured: init.sh --preflight emitted 0 summary lines.
-for f in src/startup.sh src/init.sh; do
-  if grep -qE '^\s*accessibility_probe\s*$' "$REPO/$f"; then
-    bad "$f calls the probe set -e safely" "bare call aborts under set -e"
+# A bad bound must FAIL CLOSED: perl reads `alarm 0`, and anything coercing to
+# 0, as cancel — silently restoring the unbounded call this exists to prevent.
+for badv in 0 abc -1 ''; do
+  run_probe "$badv"; rc=$?
+  if [ "$rc" -eq 124 ] && [ "$ELAPSED" -lt 7 ]; then
+    ok "bound '$badv' fails closed to the default (124 in ${ELAPSED}s)"
   else
-    ok "$f calls the probe set -e safely"
+    bad "bound '$badv' fails closed to the default" "rc=$rc elapsed=${ELAPSED}s — UNBOUNDED"
   fi
 done
 
-# And prove the shape, not just its absence.
-if bash -c 'set -e; f(){ return 124; }; rc=0; f || rc=$?; [ "$rc" -eq 124 ]'; then
-  ok "the || rc=\$? form survives set -e and keeps the code"
-else
-  bad "the || rc=\$? form survives set -e and keeps the code"
-fi
+ACCESSIBILITY_PROBE_CMD=(true);           accessibility_probe; [ $? -eq 0 ] && ok "granted -> 0" || bad "granted -> 0"
+ACCESSIBILITY_PROBE_CMD=(sh -c 'exit 7'); accessibility_probe; [ $? -eq 7 ] && ok "a denial code survives (7)" || bad "a denial code survives (7)"
+ACCESSIBILITY_PROBE_CMD=(false);          accessibility_probe; [ $? -eq 1 ] && ok "a plain denial is 1, not 124" || bad "a plain denial is 1, not 124"
 
-# $REPO is overridable — tests point it at a scratch dir with no src/. An
-# unguarded `source "$REPO/..."` under `set -e` aborts before any output.
+# The defect existed in two files, so a fix in one is not a fix.
 for f in src/startup.sh src/init.sh; do
-  if grep -qE '^\s*(local )?source "\$REPO/src/accessibility_probe.sh"' "$REPO/$f"; then
-    bad "$f guards the probe source" "sources \$REPO unguarded; a scratch repo aborts it"
-  else
-    ok "$f guards the probe source"
-  fi
+  grep -q "osascript -e 'tell application \"System Events\" to get name of first process" "$REPO/$f" \
+    && bad "$f goes through the shared probe" "raw osascript remains" || ok "$f goes through the shared probe"
+  grep -qE '^\s*(local )?source "\$REPO/src/accessibility_probe.sh"' "$REPO/$f" \
+    && bad "$f guards the probe source" "unguarded \$REPO source" || ok "$f guards the probe source"
+  grep -qE '^\s*accessibility_probe\s*$' "$REPO/$f" \
+    && bad "$f keeps the call set -e exempt" "bare call aborts" || ok "$f keeps the call set -e exempt"
+done
+
+# Could-not-check must not read as granted: acc_rc=0 with no probe file would
+# print "✓ Accessibility" for a run where nothing was probed.
+for f in src/startup.sh src/init.sh; do
+  grep -qE '^\s*(local )?acc_rc=125' "$REPO/$f" \
+    && ok "$f defaults to could-not-check, not granted" \
+    || bad "$f defaults to could-not-check, not granted" "acc_rc starts at 0"
 done
 
 S="$(mktemp -d)"; mkdir -p "$S/.fake-home"
@@ -90,14 +74,11 @@ SUTANDO_REPO="$S" SUTANDO_WORKSPACE="$S/.workspace" SUTANDO_TEST_MODE=1 \
   HOME="$S/.fake-home" CLAUDE_CONFIG_DIR="$S/.fake-home/.claude" \
   bash "$REPO/src/init.sh" --preflight > "$S/out" 2>&1
 prc=$?
-if [ "$prc" -eq 0 ] && [ "$(grep -c 'Preflight' "$S/out")" -eq 1 ]; then
-  ok "--preflight exits 0 and emits its summary with SUTANDO_REPO on a scratch dir"
-else
-  bad "--preflight exits 0 and emits its summary with SUTANDO_REPO on a scratch dir" \
-      "rc=$prc summary_lines=$(grep -c 'Preflight' "$S/out")"
-fi
+[ "$prc" -eq 0 ] && [ "$(grep -c 'Preflight' "$S/out")" -eq 1 ] \
+  && ok "--preflight exits 0 and emits its summary under a scratch SUTANDO_REPO" \
+  || bad "--preflight exits 0 and emits its summary under a scratch SUTANDO_REPO" "rc=$prc"
 rm -rf "$S"
 
-total=15
+total=18
 echo "  Total: $total — pass: $((total-fails)), fail: $fails"
 [ "$fails" -eq 0 ] || exit 1

--- a/tests/accessibility-probe-bounded.test.sh
+++ b/tests/accessibility-probe-bounded.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# The probe must be BOUNDED and must distinguish a timeout from a denial:
+# only a denial should send someone to System Settings.
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fails=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s %s\n' "$1" "${2:-}"; fails=$((fails+1)); }
+
+echo "accessibility probe is bounded:"
+
+[ -f "$REPO/src/accessibility_probe.sh" ] \
+  && ok "the shared probe exists" \
+  || { bad "the shared probe exists" "src/accessibility_probe.sh missing"; echo "  Total: 1 — pass: 0, fail: 1"; exit 1; }
+
+# The defect existed in two places because the probe was duplicated, so a fix
+# in only one of them is not a fix.
+raw=0
+for f in src/startup.sh src/init.sh; do
+  if grep -q "osascript -e 'tell application \"System Events\" to get name of first process" "$REPO/$f"; then
+    bad "$f goes through the shared probe" "still calls osascript directly"; raw=1
+  fi
+done
+[ "$raw" -eq 0 ] && ok "both callers go through the shared probe"
+
+for f in src/startup.sh src/init.sh; do
+  grep -q 'accessibility_probe' "$REPO/$f" \
+    && ok "$f calls accessibility_probe" \
+    || bad "$f calls accessibility_probe" "no call found"
+done
+
+. "$REPO/src/accessibility_probe.sh"
+
+# A hanging command must be killed at the bound, not waited on forever.
+start=$(date +%s)
+( perl -e 'my $s=shift; my $p=fork(); if(!$p){exec @ARGV; exit 127;}
+           $SIG{ALRM}=sub{kill "KILL",$p; waitpid $p,0; exit 124};
+           alarm $s; waitpid $p,0; alarm 0;
+           exit($?>>8 ? $?>>8 : ($? ? 1 : 0));' 2 sleep 30 ) >/dev/null 2>&1
+rc=$?; el=$(( $(date +%s) - start ))
+[ "$rc" -eq 124 ] && [ "$el" -lt 5 ] \
+  && ok "a hanging probe is killed at the bound (rc=124 after ${el}s)" \
+  || bad "a hanging probe is killed at the bound" "rc=$rc elapsed=${el}s"
+
+# Timeout and denial must not collapse: 142 means the ALRM handler was lost to
+# exec, and a caller cannot tell that from a genuine denial.
+probe_with() {
+  perl -e 'my $s=shift; my $p=fork(); if(!$p){exec @ARGV; exit 127;}
+           $SIG{ALRM}=sub{kill "KILL",$p; waitpid $p,0; exit 124};
+           alarm $s; waitpid $p,0; alarm 0;
+           exit($?>>8 ? $?>>8 : ($? ? 1 : 0));' "$@" >/dev/null 2>&1
+}
+probe_with 3 true;         [ $? -eq 0 ] && ok "success returns 0"        || bad "success returns 0"
+probe_with 3 sh -c 'exit 7'; [ $? -eq 7 ] && ok "a denial code survives (7)" || bad "a denial code survives (7)"
+probe_with 3 false;        [ $? -eq 1 ] && ok "a plain failure is 1, not 124" || bad "a plain failure is 1, not 124"
+
+# 5s is a guess and a slow host is not a denial, so the bound is overridable.
+grep -q 'ACCESSIBILITY_PROBE_TIMEOUT_S' "$REPO/src/accessibility_probe.sh" \
+  && ok "the bound is overridable" || bad "the bound is overridable"
+
+total=9
+echo "  Total: $total — pass: $((total-fails)), fail: $fails"
+[ "$fails" -eq 0 ] || exit 1


### PR DESCRIPTION
## The defect

`osascript -e 'tell application "System Events" to get name of first process whose frontmost is true'` has **no bound**. On a session with nobody to answer the AppleScript prompt it never returns, and startup stops before every service that follows it.

## Measured, not inferred

The call was still running after 20s on this host and had to be killed. It was reached during a real boot — startup sat at

```
Checking permissions...
  ✓ Screen Recording
```

for **four minutes**, with ngrok and the phone path down, until I stopped it. Screen Recording **passed**; the line after it is the one that hangs.

I found this while attempting an unrelated post-restart witness, and my first explanation was wrong: I read the SSH/keychain banner in auth-preflight and blamed the permission *check*. Measuring it showed Screen Recording had already succeeded and the next statement was the blocker.

## Fixed where the policy lives

The same unbounded call existed in **two** places — `src/startup.sh` and `src/init.sh:385`. Patching the one I hit would have left the other, so both now source `src/accessibility_probe.sh`, and a test asserts neither caller retains a raw `osascript` call.

## Timeout and denial are kept distinct

Not cosmetic. A denial is a fact about the **grant**; a timeout is a fact about the **session**. Only the first should send anyone to System Settings — a headless host whose grant is fine must not be told to go fix it.

```
0     granted
124   timed out  -> reported UNKNOWN, naming the session as the cause
else  denied     -> the existing System Settings guidance, unchanged
```

**perl must fork, not exec.** After `exec` the `ALRM` handler is gone and the child dies as signal 14, so the wrapper returns **142** and a caller cannot tell a timeout from a denial. My first cut did exactly that and measured 142; the fork/waitpid form returns 124. `timeout`/`gtimeout` are absent on stock macOS, which is why this is perl rather than the obvious one-liner.

## Controls

`tests/accessibility-probe-bounded.test.sh` — **9/9** here, **1 fail** on `main` (the shared probe does not exist there).

```
sleep 30 with a 2s bound  -> 124 after 2s, not hung
true                      -> 0
sh -c 'exit 7'            -> 7     a real denial code survives
false                     -> 1     NOT 124 — the collapse this guards
neither caller retains a raw osascript call
```

`startup-core-auth-routing` 15/15, `startup-channel-token-gate` 11/11, `startup-headless` pass. Added comment blocks are within the repository's 2-line cap.

## Scope

Deliberately **not** folded into #3287, which changes the ngrok/verification section of the same file and already carries three concerns under active review. This is a different defect with a different blast radius: #3287 makes a diagnostic honest, this one stops a boot from hanging.

Stand: Echo Act IV Mini
