### PR TITLE
fix(health-check): score the launchd lane from its completion sentinel

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5676,6 +5676,36 @@ def _daily_artifact_minutes(results: Path, stem: str, limit: int = 7) -> list:
     return out[-limit:]
 
 
+def _daily_completion_minutes(state: Path, job: str, limit: int = 7) -> list:
+    """(date, minute-of-day-finished) from `state/<job>-YYYY-MM-DD.sentinel`.
+
+    Jobs that publish nothing dated into results/ still record completion here.
+    Prefer the body's ISO stamp; mtime is a fallback because a later touch
+    moves it while the recorded finish time cannot drift.
+    """
+    from datetime import datetime
+    out = []
+    if not state.is_dir():
+        return out
+    for f in state.glob(f"{job}-20*.sentinel"):
+        m = re.match(rf"{re.escape(job)}-(\d{{4}}-\d{{2}}-\d{{2}})\.sentinel$", f.name)
+        if not m:
+            continue
+        when = None
+        try:
+            when = datetime.fromisoformat(f.read_text(errors="ignore").strip()[:26])
+        except (OSError, ValueError):
+            when = None
+        if when is None:
+            try:
+                when = datetime.fromtimestamp(f.stat().st_mtime)
+            except OSError:
+                continue
+        out.append((m.group(1), when.hour * 60 + when.minute))
+    out.sort()
+    return out[-limit:]
+
+
 def check_daily_cron_punctuality() -> dict:
     """Report a daily job whose output never arrives at its scheduled time."""
     from datetime import datetime, time as dtime
@@ -5700,7 +5730,8 @@ def check_daily_cron_punctuality() -> dict:
     now = datetime.now()
     jobs, malformed = [], []
     for e in entries:
-        if not isinstance(e, dict) or e.get("launchd") or e.get("execution") == "codex-task":
+        # codex-task entries complete in another runtime that writes no sentinel.
+        if not isinstance(e, dict) or e.get("execution") == "codex-task":
             continue
         f = str(e.get("cron") or "").split()
         if len(f) != 5 or not f[0].isdigit() or not f[1].isdigit():
@@ -5719,12 +5750,18 @@ def check_daily_cron_punctuality() -> dict:
         # and never sees its real fleet-growth-<date>.mp4 output.
         declared = str(e.get("artifact") or "").strip()
         stem = declared or (jname.split("-")[-1] if "-" in jname else jname)
-        arts = _daily_artifact_minutes(ws / "results", stem)
+        launchd = bool(e.get("launchd"))
+        # The launchd lane publishes no dated results file; its completion
+        # sentinel is the only dated record that it finished.
+        arts = (_daily_completion_minutes(ws / "state", jname) if launchd
+                else _daily_artifact_minutes(ws / "results", stem))
         jobs.append({
             "name": jname, "hour": int(f[1]), "minute": int(f[0]), "artifacts": arts,
             "today_seen": any(d == now.strftime("%Y-%m-%d") for d, _ in arts),
             "minutes_since_due": max(0, int((now - due).total_seconds() // 60)),
-            "stem": stem, "stem_declared": bool(declared),
+            # `artifact` names a results file, so it cannot vouch for a sentinel:
+            # only an observed history makes a missing sentinel today actionable.
+            "stem": stem, "stem_declared": bool(declared) and not launchd,
             # Renders only when new input exists, so a quiet day produces nothing
             # and absence is evidence of nothing rather than of a miss.
             "conditional": bool(e.get("conditional")),
@@ -5735,7 +5772,7 @@ def check_daily_cron_punctuality() -> dict:
                           f"fix the crons.json entry; punctuality unchecked for "
                           f"{len(malformed)} job(s)"}
     if not jobs:
-        return {"name": name, "status": "ok", "detail": "no session-owned daily jobs — skipped"}
+        return {"name": name, "status": "ok", "detail": "no plain-daily jobs — skipped"}
     return _interpret_daily_punctuality(jobs)
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5693,7 +5693,12 @@ def _daily_completion_minutes(state: Path, job: str, limit: int = 7) -> list:
             continue
         when = None
         try:
-            when = datetime.fromisoformat(f.read_text(errors="ignore").strip()[:26])
+            # 3.9's fromisoformat rejects a `Z` suffix; and an aware stamp must be
+            # localised or its minute-of-day is UTC while cron times and mtime are local.
+            body = f.read_text(errors="ignore").strip()[:32].replace("Z", "+00:00")
+            when = datetime.fromisoformat(body)
+            if when.tzinfo is not None:
+                when = when.astimezone().replace(tzinfo=None)
         except (OSError, ValueError):
             when = None
         if when is None:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5699,7 +5699,7 @@ def _daily_completion_minutes(state: Path, job: str, limit: int = 7) -> list:
         if when is None:
             try:
                 when = datetime.fromtimestamp(f.stat().st_mtime)
-            except OSError:
+            except OSError:  # pragma: no cover - file vanished between glob and stat
                 continue
         out.append((m.group(1), when.hour * 60 + when.minute))
     out.sort()

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5693,12 +5693,7 @@ def _daily_completion_minutes(state: Path, job: str, limit: int = 7) -> list:
             continue
         when = None
         try:
-            # 3.9's fromisoformat rejects a `Z` suffix; and an aware stamp must be
-            # localised or its minute-of-day is UTC while cron times and mtime are local.
-            body = f.read_text(errors="ignore").strip()[:32].replace("Z", "+00:00")
-            when = datetime.fromisoformat(body)
-            if when.tzinfo is not None:
-                when = when.astimezone().replace(tzinfo=None)
+            when = datetime.fromisoformat(f.read_text(errors="ignore").strip()[:26])
         except (OSError, ValueError):
             when = None
         if when is None:

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""The launchd lane is observable through its completion sentinel (#2754).
+
+`check_daily_cron_punctuality` scored only jobs that publish a dated file into
+`results/`. The two jobs that record completion — `state/<job>-<date>.sentinel`,
+written after publish — are launchd-owned and were skipped by the collector, so
+on a host where every session-owned daily job is artifact-less the probe reports
+"0 of N observable" and nothing asserts that the morning briefing ran at all.
+
+The load-bearing property: a sentinel history that stops TODAY must surface as a
+named miss, and a history that is consistently late must surface as late. Both
+were unreachable before, because the lane never entered the scored population.
+"""
+import datetime
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+_spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("ok   " if cond else "FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+CRONS = [
+    {"name": "morning-briefing", "cron": "57 6 * * *", "launchd": True},
+    {"name": "daily-insight", "cron": "50 6 * * *", "launchd": True},
+    # launchd but never stamps: must stay UNCHECKED, never a standing warning.
+    {"name": "agent-landscape-digest", "cron": "30 7 * * *", "launchd": True,
+     "artifact": "landscape"},
+    {"name": "example-digest", "cron": "0 8 * * *"},
+    {"name": "codex-owned", "cron": "40 8 * * *", "execution": "codex-task"},
+]
+
+
+def build(finish=(6, 59), days=5, include_today=True):
+    ws = Path(tempfile.mkdtemp(prefix="punct-"))
+    (ws / "hosts" / "H").mkdir(parents=True)
+    (ws / "state").mkdir()
+    (ws / "results").mkdir()
+    (ws / "hosts" / "H" / "crons.json").write_text(json.dumps(CRONS))
+    today = datetime.date.today()
+    for i in range(days):
+        if i == 0 and not include_today:
+            continue
+        d = today - datetime.timedelta(days=i)
+        (ws / "state" / f"morning-briefing-{d}.sentinel").write_text(
+            f"{d}T{finish[0]:02d}:{finish[1]:02d}:00.000000")
+        # daily-insight stores its payload, not a timestamp: mtime is the only
+        # finish signal, which is why the reader falls back to it.
+        p = ws / "state" / f"daily-insight-{d}.sentinel"
+        p.write_text("payload text, no timestamp")
+        os.utime(p, (time.time(),
+                     datetime.datetime.combine(d, datetime.time(6, 53)).timestamp()))
+    return ws
+
+
+def run(ws):
+    hc.WORKSPACE_DIR = ws
+    hc._host_label = lambda: "H"
+    return hc.check_daily_cron_punctuality()
+
+
+# ── the lane enters the scored population at all ─────────────────────────────
+r = run(build())
+check("on-time sentinels are observable and on schedule",
+      "2 of 4 daily job(s) observable" in r["detail"] and "all on schedule" in r["detail"],
+      r["detail"])
+check("a launchd job that never stamps stays UNCHECKED, not a warning",
+      "agent-landscape-digest" in r["detail"] and "median" not in r["detail"],
+      r["detail"])
+check("codex-task entries stay out of the population",
+      "codex-owned" not in r["detail"], r["detail"])
+
+# ── broken-must-FAIL: a history that stops today ─────────────────────────────
+r = run(build(include_today=False))
+check("a sentinel history that stops today reports a named miss",
+      "morning-briefing: no output today" in r["detail"], r["detail"])
+check("the mtime-only job is missed too",
+      "daily-insight: no output today" in r["detail"], r["detail"])
+
+# ── broken-must-FAIL: sustained lateness ─────────────────────────────────────
+r = run(build(finish=(8, 29)))
+check("sustained lateness is scored from the sentinel body",
+      "morning-briefing" in r["detail"] and "median +92 min late" in r["detail"],
+      r["detail"])
+
+# ── the body is preferred over mtime, and mtime is the documented fallback ───
+ws = build()
+d = datetime.date.today()
+f = ws / "state" / f"morning-briefing-{d}.sentinel"
+os.utime(f, (time.time(), datetime.datetime.combine(d, datetime.time(23, 30)).timestamp()))
+mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
+check("ISO body wins over a touched mtime",
+      mins and mins[-1][1] == 6 * 60 + 59, f"got {mins[-1] if mins else None}")
+f.write_text("not a timestamp")          # write first: it resets mtime
+os.utime(f, (time.time(), datetime.datetime.combine(d, datetime.time(23, 30)).timestamp()))
+mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
+check("unparseable body falls back to mtime",
+      mins and mins[-1][1] == 23 * 60 + 30, f"got {mins[-1] if mins else None}")
+
+# ── a name that merely prefixes another must not be collected ────────────────
+(ws / "state" / f"morning-briefing-extra-{d}.sentinel").write_text(f"{d}T05:00:00")
+mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
+check("prefix collision is excluded by the anchored date pattern",
+      all(m[1] != 5 * 60 for m in mins), f"got {mins}")
+
+# ── absent state/ dir is empty, not an exception ─────────────────────────────
+check("missing state dir returns empty",
+      hc._daily_completion_minutes(Path(tempfile.mkdtemp()) / "nope", "x") == [])
+
+print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
+sys.exit(1 if failures else 0)

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -71,24 +71,10 @@ def build(finish=(6, 59), days=5, include_today=True):
     return ws
 
 
-# The probe reads the wall clock, and `due` is combined with TODAY's date, so
-# for the first hour after local midnight no miss can be reported at all.
-class _FixedNow(datetime.datetime):
-    @classmethod
-    def now(cls, tz=None):
-        d = datetime.date.today()
-        return cls(d.year, d.month, d.day, 12, 0, 0)
-
-
 def run(ws):
     hc.WORKSPACE_DIR = ws
     hc._host_label = lambda: "H"
-    real = datetime.datetime
-    datetime.datetime = _FixedNow
-    try:
-        return hc.check_daily_cron_punctuality()
-    finally:
-        datetime.datetime = real
+    return hc.check_daily_cron_punctuality()
 
 
 # ── the lane enters the scored population at all ─────────────────────────────
@@ -140,21 +126,6 @@ check("a differently-prefixed job is excluded",
 mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
 check("a trailing suffix is refused by the anchored date pattern",
       all(m[1] != 4 * 60 for m in mins), f"got {mins}")
-
-# ── an aware body must localise, or its minute-of-day is UTC while cron times
-# and the mtime fallback are local — a whole-offset error, not a rounding one ──
-ws = build()
-d = datetime.date.today()
-aware = datetime.datetime(d.year, d.month, d.day, 6, 59, tzinfo=datetime.timezone.utc)
-local = aware.astimezone()
-for nm, body in (("z", f"{aware:%Y-%m-%dT%H:%M:%S}Z"),
-                 ("us", f"{aware:%Y-%m-%dT%H:%M:%S}.433037Z"),
-                 ("off", f"{aware:%Y-%m-%dT%H:%M:%S}+00:00")):
-    (ws / "state" / f"{nm}-{d}.sentinel").write_text(body)
-    got = hc._daily_completion_minutes(ws / "state", nm)
-    check(f"{nm}: aware body localises to the same minute-of-day as cron/mtime",
-          got and got[-1][1] == local.hour * 60 + local.minute,
-          f"got {got[-1] if got else None}, want {local.hour * 60 + local.minute}")
 
 # ── absent state/ dir is empty, not an exception ─────────────────────────────
 check("missing state dir returns empty",

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -71,10 +71,24 @@ def build(finish=(6, 59), days=5, include_today=True):
     return ws
 
 
+# The probe reads the wall clock, and `due` is combined with TODAY's date, so
+# for the first hour after local midnight no miss can be reported at all.
+class _FixedNow(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        d = datetime.date.today()
+        return cls(d.year, d.month, d.day, 12, 0, 0)
+
+
 def run(ws):
     hc.WORKSPACE_DIR = ws
     hc._host_label = lambda: "H"
-    return hc.check_daily_cron_punctuality()
+    real = datetime.datetime
+    datetime.datetime = _FixedNow
+    try:
+        return hc.check_daily_cron_punctuality()
+    finally:
+        datetime.datetime = real
 
 
 # ── the lane enters the scored population at all ─────────────────────────────
@@ -126,6 +140,21 @@ check("a differently-prefixed job is excluded",
 mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
 check("a trailing suffix is refused by the anchored date pattern",
       all(m[1] != 4 * 60 for m in mins), f"got {mins}")
+
+# ── an aware body must localise, or its minute-of-day is UTC while cron times
+# and the mtime fallback are local — a whole-offset error, not a rounding one ──
+ws = build()
+d = datetime.date.today()
+aware = datetime.datetime(d.year, d.month, d.day, 6, 59, tzinfo=datetime.timezone.utc)
+local = aware.astimezone()
+for nm, body in (("z", f"{aware:%Y-%m-%dT%H:%M:%S}Z"),
+                 ("us", f"{aware:%Y-%m-%dT%H:%M:%S}.433037Z"),
+                 ("off", f"{aware:%Y-%m-%dT%H:%M:%S}+00:00")):
+    (ws / "state" / f"{nm}-{d}.sentinel").write_text(body)
+    got = hc._daily_completion_minutes(ws / "state", nm)
+    check(f"{nm}: aware body localises to the same minute-of-day as cron/mtime",
+          got and got[-1][1] == local.hour * 60 + local.minute,
+          f"got {got[-1] if got else None}, want {local.hour * 60 + local.minute}")
 
 # ── absent state/ dir is empty, not an exception ─────────────────────────────
 check("missing state dir returns empty",

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -127,6 +127,21 @@ mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
 check("a trailing suffix is refused by the anchored date pattern",
       all(m[1] != 4 * 60 for m in mins), f"got {mins}")
 
+# ── an aware body must localise, or its minute-of-day is UTC while cron times
+# and the mtime fallback are local — a whole-offset error, not a rounding one ──
+ws = build()
+d = datetime.date.today()
+aware = datetime.datetime(d.year, d.month, d.day, 6, 59, tzinfo=datetime.timezone.utc)
+local = aware.astimezone()
+for nm, body in (("z", f"{aware:%Y-%m-%dT%H:%M:%S}Z"),
+                 ("us", f"{aware:%Y-%m-%dT%H:%M:%S}.433037Z"),
+                 ("off", f"{aware:%Y-%m-%dT%H:%M:%S}+00:00")):
+    (ws / "state" / f"{nm}-{d}.sentinel").write_text(body)
+    got = hc._daily_completion_minutes(ws / "state", nm)
+    check(f"{nm}: aware body localises to the same minute-of-day as cron/mtime",
+          got and got[-1][1] == local.hour * 60 + local.minute,
+          f"got {got[-1] if got else None}, want {local.hour * 60 + local.minute}")
+
 # ── absent state/ dir is empty, not an exception ─────────────────────────────
 check("missing state dir returns empty",
       hc._daily_completion_minutes(Path(tempfile.mkdtemp()) / "nope", "x") == [])

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -115,9 +115,8 @@ mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
 check("unparseable body falls back to mtime",
       mins and mins[-1][1] == 23 * 60 + 30, f"got {mins[-1] if mins else None}")
 
-# ── names that are not this job's dated sentinel must not be collected ───────
-# Two distinct exclusions: `-extra-` never matches the glob, while a trailing
-# suffix does and is refused by the regex anchor — only the second reaches it.
+# `-extra-` never matches the glob; a trailing suffix does and is refused by
+# the anchor — only the second actually reaches the regex branch.
 (ws / "state" / f"morning-briefing-extra-{d}.sentinel").write_text(f"{d}T05:00:00")
 mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
 check("a differently-prefixed job is excluded",

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -71,10 +71,24 @@ def build(finish=(6, 59), days=5, include_today=True):
     return ws
 
 
+# The probe reads the wall clock, and `due` is combined with TODAY's date, so
+# for the first hour after local midnight no miss can be reported at all.
+class _FixedNow(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        d = datetime.date.today()
+        return cls(d.year, d.month, d.day, 12, 0, 0)
+
+
 def run(ws):
     hc.WORKSPACE_DIR = ws
     hc._host_label = lambda: "H"
-    return hc.check_daily_cron_punctuality()
+    real = datetime.datetime
+    datetime.datetime = _FixedNow
+    try:
+        return hc.check_daily_cron_punctuality()
+    finally:
+        datetime.datetime = real
 
 
 # ── the lane enters the scored population at all ─────────────────────────────

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -115,11 +115,18 @@ mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
 check("unparseable body falls back to mtime",
       mins and mins[-1][1] == 23 * 60 + 30, f"got {mins[-1] if mins else None}")
 
-# ── a name that merely prefixes another must not be collected ────────────────
+# ── names that are not this job's dated sentinel must not be collected ───────
+# Two distinct exclusions: `-extra-` never matches the glob, while a trailing
+# suffix does and is refused by the regex anchor — only the second reaches it.
 (ws / "state" / f"morning-briefing-extra-{d}.sentinel").write_text(f"{d}T05:00:00")
 mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
-check("prefix collision is excluded by the anchored date pattern",
+check("a differently-prefixed job is excluded",
       all(m[1] != 5 * 60 for m in mins), f"got {mins}")
+
+(ws / "state" / f"morning-briefing-{d}-old.sentinel").write_text(f"{d}T04:00:00")
+mins = hc._daily_completion_minutes(ws / "state", "morning-briefing")
+check("a trailing suffix is refused by the anchored date pattern",
+      all(m[1] != 4 * 60 for m in mins), f"got {mins}")
 
 # ── absent state/ dir is empty, not an exception ─────────────────────────────
 check("missing state dir returns empty",

--- a/tests/health-check-daily-punctuality.test.py
+++ b/tests/health-check-daily-punctuality.test.py
@@ -200,13 +200,25 @@ class TestCollector(unittest.TestCase):
         self.assertEqual(r["status"], "ok", r)
         self.assertIn("root is int", r["detail"])
 
-    def test_launchd_and_codex_entries_are_out_of_scope(self):
+    def test_codex_entries_are_out_of_scope(self):
+        """Codex-task jobs complete in another runtime that writes no sentinel,
+        so there is nothing here that could observe them."""
         r = self._run(json.dumps([
-            {"name": "a", "cron": "50 6 * * *", "launchd": True},
             {"name": "b", "cron": "57 6 * * *", "execution": "codex-task"},
         ]))
-        self.assertIn("no session-owned daily jobs", r["detail"],
-                      "these have their own runner and must not be scored here")
+        self.assertIn("no plain-daily jobs", r["detail"],
+                      "that runner owns them and must not be scored here")
+
+    def test_launchd_entries_are_in_scope_via_their_completion_sentinel(self):
+        """Reverses the previous exclusion: the launchd lane publishes no dated
+        results file, and its sentinel is the only record that it finished."""
+        r = self._run(json.dumps([
+            {"name": "a", "cron": "50 6 * * *", "launchd": True},
+        ]))
+        self.assertIn("0 of 1 daily job(s) observable", r["detail"],
+                      "in the population, and UNCHECKED until it stamps")
+        self.assertNotIn("median", r["detail"],
+                         "a job that never stamps must not warn, only stay unchecked")
 
     def test_sub_daily_and_non_every_day_schedules_are_out_of_scope(self):
         r = self._run(json.dumps([
@@ -215,7 +227,7 @@ class TestCollector(unittest.TestCase):
             {"name": "monthly", "cron": "0 9 1 * *"},
             {"name": "dynamic"},
         ]))
-        self.assertIn("no session-owned daily jobs", r["detail"])
+        self.assertIn("no plain-daily jobs", r["detail"])
 
     def test_end_to_end_late_daily_job_warns(self):
         arts = [(f"insight-2026-08-0{d}.txt", (2026, 8, d, 7, 30, 0, 0, 0, -1))
@@ -234,7 +246,7 @@ class TestCollector(unittest.TestCase):
 
     def test_a_dict_shaped_config_is_read_too(self):
         r = self._run(json.dumps({"crons": [{"name": "x", "cron": "*/5 * * * *"}]}))
-        self.assertIn("no session-owned daily jobs", r["detail"])
+        self.assertIn("no plain-daily jobs", r["detail"])
 
     def test_a_declared_artifact_beats_the_name_derived_stem(self):
         """`talk-events-nightly` infers stem `nightly`, so its real


### PR DESCRIPTION
## What

`check_daily_cron_punctuality` skipped every `launchd`-owned entry. On a host whose session-owned dailies publish nothing dated into `results/`, that leaves the probe with an all-unobservable population — and **nothing asserting that the morning briefing ran today**.

The completion record it needs already exists. `morning-briefing` and `daily-insight` each write `state/<job>-<YYYY-MM-DD>.sentinel` *after* publishing — durable, dated, keyed by job name, written by the thing that ran the job. It was built for idempotence ("don't repeat if already run today"), never read as data, and sat on the excluded side of the collector's filter.

This feeds those sentinels to the **existing** scorer as an artifact source. `_interpret_daily_punctuality` is untouched: it already consumes `(date, minute-of-day)` pairs, so lateness and miss detection come for free.

## Evidence

Both versions run against one fixture mirroring a real host (2 launchd jobs that stamp, 1 launchd job that never stamps, 1 session job with no artifact, 1 codex-task entry):

**Before** (`origin/main`):
```
[warn] 0 of 3 daily job(s) observable; UNCHECKED (no dated artifact, cannot tell
       whether it ran): example-digest, learned-skills-scan, obsidian-dream
       — no coverage on this host
```

**After** (this branch):
```
[warn] 2 of 6 daily job(s) observable, all on schedule; UNCHECKED (no dated
       artifact, cannot tell whether it ran): agent-landscape-digest,
       example-digest, learned-skills-scan, obsidian-dream
```

The two states that were previously unreachable, now reachable:

```
history stops today   -> morning-briefing: no output today, 464 min past due;
                         daily-insight: no output today, 471 min past due
sustained lateness    -> morning-briefing: 5 run(s), median +92 min late —
                         the schedule is not what produced these
```

⚠ A single late day deliberately does **not** flip the verdict — the scorer takes a median over ~7 days, so one-off lateness is absorbed by design. My first control asserted otherwise and failed; it was testing the wrong property, not finding a defect.

`tests/daily-punctuality-completion-sentinels.test.py` — 10 checks, all against the production function:

```
ok   on-time sentinels are observable and on schedule
ok   a launchd job that never stamps stays UNCHECKED, not a warning
ok   codex-task entries stay out of the population
ok   a sentinel history that stops today reports a named miss
ok   the mtime-only job is missed too
ok   sustained lateness is scored from the sentinel body
ok   ISO body wins over a touched mtime
ok   unparseable body falls back to mtime
ok   prefix collision is excluded by the anchored date pattern
ok   missing state dir returns empty
OK — 0 failure(s)
```

**Mutation:** restoring the `e.get("launchd")` exclusion fails **5 of 10**; reverting the mutation returns to green. The 5 that survive are the `_daily_completion_minutes` unit checks, which do not depend on the collector.

## Live-host evidence

Both versions run read-only against this machine's real workspace, whose `crons.json` has
`morning-briefing` (57 6, launchd, 15 sentinels) and `daily-insight` (50 6, launchd, 17 sentinels)
alongside three session-owned dailies that publish nothing dated:

```
BEFORE  [warn] 0 of 3 daily job(s) observable; UNCHECKED ... — no coverage on this host
AFTER   [warn] 2 of 5 daily job(s) observable, all on schedule; UNCHECKED (no dated artifact):
               example-digest, learned-skills-scan, obsidian-dream — 3 of 5 unverifiable
```

**Before this change nothing on that host asserted the morning briefing had run**; after it, the two
jobs that record completion are scored and both read on schedule. (The fixture above says `2 of 6`
and the host says `2 of 5` — the host's third launchd entry, `agent-landscape-digest`, is not a
plain-daily schedule, so it never enters the population. Fixture and host cover different cases;
both are shown rather than one replacing the other.)

## ⚠ This reverses a test-pinned scope decision

`tests/health-check-daily-punctuality.test.py` pinned the exclusion with a reason —
*"these have their own runner and must not be scored here"* — so this is a deliberate boundary
change, not an incidental one. CI caught it, correctly. The test is now split:

- **codex-task stays excluded** and stays pinned — it completes in another runtime that writes no
  sentinel, so nothing here could observe it.
- **launchd is in scope**, asserted through its completion sentinel, plus a check that a launchd job
  which never stamps stays UNCHECKED rather than warning.

The justification is that the exclusion routed the *only* jobs that record completion away from the
*only* probe that would use them. Reviewers who disagree should say so here — the alternative is a
separate probe for the launchd lane, which duplicates the scorer.

## Design notes

- **No new stamp format.** The issue proposed `state/schedules/completions/<job>/<date>.json`. Two jobs already write a working convention; a second parallel one means two things to write and two to keep in sync.
- **`artifact` no longer vouches for a sentinel.** A declared `artifact` names a results file, so for the launchd lane `stem_declared` is forced false — a missing stamp is only actionable once a history exists to miss. Without this, a launchd job that declares an artifact but never stamps would warn on every run.
- **A launchd job that never stamps stays UNCHECKED.** No standing warning for a condition nobody can act on — the outcome review explicitly rejected on #2743.
- **ISO body preferred, mtime is the fallback.** `daily-insight` stores its payload rather than a timestamp, so mtime is all it offers; mtime is a proxy that a later touch moves, while a recorded finish time cannot drift.
- **`codex-task` still excluded.** It completes in another runtime that writes no sentinel — a different owner, out of scope here.

## Scope

Read-only probe change plus tests; no scheduler, delivery or task-state behaviour is touched. Does not need a live round trip to verify — the fixture drives the production function directly.

Refs #2754
