### PR TITLE
docs(review): tell reviewers to RUN the preflight, don't describe it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ When you review a PR (including another agent's), you MUST follow `CONTRIBUTING.
 - Once a requested change is verified fixed, dismiss or replace the stale REQUEST_CHANGES state. If it remains, cite the exact unresolved behavior.
 - Merge only when the current head is mergeable, required CI + CLA are green, and two maintainers have recorded formal approvals. Never substitute a comment, bot recommendation, stale approval, or admin bypass.
 
-**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the lessons here — read them from `REVIEW.md`. When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline so you see them on every preflight run; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Codex's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
+**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the lessons here — read them from `REVIEW.md`. **Before reviewing, run `python3 scripts/review-preflight.py <PR>`** — it reads `REVIEW.md` and prints the criteria inline; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Codex's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
 
 ## Workspace contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ When you review a PR (including another agent's), you MUST follow `CONTRIBUTING.
 - Once a requested change is verified fixed, dismiss or replace the stale REQUEST_CHANGES state. If it remains, cite the exact unresolved behavior.
 - Merge only when the current head is mergeable, required CI + CLA are green, and two maintainers have recorded formal approvals. Never substitute a comment, bot recommendation, stale approval, or admin bypass.
 
-**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the lessons here — read them from `REVIEW.md`. When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline so you see them on every preflight run; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Claude Code's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
+**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the lessons here — read them from `REVIEW.md`. **Before reviewing, run `python3 scripts/review-preflight.py <PR>`** — it reads `REVIEW.md` and prints the criteria inline; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Claude Code's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
 
 ## Workspace contract
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -16,7 +16,8 @@ and loads whichever repo it reviews.
 
 > **Single source of truth.** These lessons live here in `REVIEW.md` only — they are
 > **not** duplicated in `CLAUDE.md`. They reach reviewers three ways: `review-preflight.py`
-> reads this file and prints the criteria on every pre-review run (for the core agent);
+> (**run it before reviewing**: `python3 scripts/review-preflight.py <PR>`) reads this file and
+> prints the criteria on every pre-review run (for the core agent);
 > `scripts/review-checks.sh` runs the machine `checks:` block below in CI; and Claude Code's
 > managed GitHub-App reviewer reads this file directly. (The in-session `/code-review` reads
 > only `CLAUDE.md`, not this file — but it is not part of our review flow.) Add or edit a


### PR DESCRIPTION
## What

Both review guides **described** `review-preflight.py` instead of **instructing** it. This makes the sentence imperative and names the command.

## Why — the phrasing, exactly

`CLAUDE.md:100` before:

> When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline **so you see them on every preflight run**

That states what the tool does and assumes a preflight run happens. It never says to make one happen. `REVIEW.md:18` has the same shape ("they reach reviewers three ways"). The only imperative lives in the `pr-triage` skill — which is in a **different repo**, so a reviewer reading only this one is never told to run anything.

## Evidence this is a real gap, not a style nit

Three PR reviews on 2026-08-22 — #3290, #3295, #3296 — went out with **no preflight run**. Running it afterwards on #3290 surfaced REVIEW.md's worst-case-disruption criterion, which named a question that review had not asked: the PR swaps the `state/discord-delivered/` sentinel format for outbox state, so a host upgrading mid-flight could re-deliver every already-delivered result to the owner's DMs. (The author had already mitigated it — `is_delivered()` honors the legacy dir read-only. The point is the criterion made me *ask*.)

## Why the script and not the skill

```
scripts/review-preflight.py   IN this repo  (added #2500/#2818)
skills/pr-triage              NOT in this repo — separate skills repo
```

Naming the skill would point most readers at something they cannot invoke. The preflight's own docstring names that exact failure: *"An instruction naming a tool that does not exist is worse than no instruction — it reads as a completed step."* It exists because `CLAUDE.md` referenced this script for months before it was written; swapping in a skill nobody else has would recreate that from the other side.

## Before / after — actual output, not a description

I edited the file the preflight parses, so the load-bearing check is that parsing is unchanged:

```
$ python3 scripts/review-preflight.py 9999 --guide REVIEW.md        # main
  rc=0  lines=241  criteria=15
$ python3 scripts/review-preflight.py 9999 --guide <branch>/REVIEW.md
  rc=0  lines=241  criteria=15
  -> lesson list byte-identical (the edit is in the preamble, above ## Lessons)

$ bash scripts/review-checks.sh --guide <branch>/REVIEW.md --diff my.diff
  review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)

$ python3 tests/review-preflight.test.py      -> Ran 10 tests OK
$ python3 tests/claude-md-tier-summary.test.py -> Ran 3 tests OK
```

`CLAUDE.md` is **2 bytes smaller** (40713 → 40711), so the always-loaded budget does not grow.

## Scope / worst case

Docs only; no code path changes. Worst case is a reviewer reading a slightly longer sentence. `#3245` also touches `CLAUDE.md` (relocating detail to `docs/`) — different line, but whichever lands second may need a trivial rebase.

@sonichi flagging you — you asked for this one directly.

Stand: Echo Act IV Mini
