### PR TITLE
fix(voice): move the pid metadata file under state/locks/ (#2722, option a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,8 @@ done/
 # Runtime state file written by the voice client. Pure cruft, no commit value.
 voice-state.json
 
-# Single-instance lock written by src/voice-agent.ts (acquirePidLock).
+# Legacy pre-#2722 voice-agent lock path; canonical is workspace/state/locks/
+# (already covered by workspace/*). Keep through the transition window.
 .voice-agent.pid
 
 # Per-clone Sutando config overrides — workspace path, vault remote, etc.

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/wangchi/stando-ui/sutando/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/wangchi/stando-ui/sutando/node_modules

--- a/scripts/restart-voice-agent.sh
+++ b/scripts/restart-voice-agent.sh
@@ -79,7 +79,7 @@ if [ -z "${OLD_PID}" ]; then
 fi
 
 # --- 1a. guarded lock takeover (design 1b; impl plan WS1 Step 5 + S4) ---
-# The voice-agent holds a structured JSON lock (`.voice-agent.pid`) created by
+# The voice-agent holds a structured JSON lock (state/locks/voice-agent.pid) created by
 # the guarded bundled-Python helper scripts/voice-lock.py. If a previous
 # kickstart killed the LaunchAgent wrapper but left the node worker alive
 # (orphaned), the new instance sees the lock and exits 7 — a silent no-op from
@@ -95,7 +95,7 @@ fi
 # below catches a resulting silent no-op.
 SCRIPT_PARENT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 WORKSPACE="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" workspace)"
-PID_FILE="${WORKSPACE}/.voice-agent.pid"
+PID_FILE="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" voice-pidfile "$WORKSPACE")"
 GUARD_FILE="${WORKSPACE}/.voice-agent.lock.guard"
 if [ -f "${PID_FILE}" ]; then
   # Interpreter per amendment R4/T1: sutando-config.sh python-bin (smoke-tested,

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -81,6 +81,22 @@ from src.sutando_config import resolve_workspace
 print(resolve_workspace(), end='')
 "
     ;;
+  voice-pidfile)
+    # Single resolver for the voice-agent pid metadata file (#2722). Canonical
+    # lives under state/locks/; the root path is a ~30-day reader fallback so an
+    # agent started under pre-move code stays stoppable (docs/migration-transition-window.md).
+    # $2 (optional): an already-resolved workspace root — callers that hold one
+    # inject it so this cannot disagree with the tree they operate on.
+    if [ -n "${2:-}" ]; then _ws="$2"; else _ws="$(bash "$0" workspace)" || exit 1; fi
+    _canon="$_ws/state/locks/voice-agent.pid"
+    _legacy="$_ws/.voice-agent.pid"
+    if [ ! -f "$_canon" ] && [ -f "$_legacy" ]; then
+      echo "sutando-config: voice-pidfile using legacy $_legacy (pre-move agent; transition window per #2722)" >&2
+      printf '%s' "$_legacy"
+    else
+      printf '%s' "$_canon"
+    fi
+    ;;
 
   vault-enabled)
     py -c "

--- a/scripts/voice-lock.py
+++ b/scripts/voice-lock.py
@@ -324,6 +324,18 @@ def cmd_acquire(args):
                 os.unlink(args.pidfile)
             except FileNotFoundError:
                 pass
+        # A live legacy record (#2722 pre-move owner) holds this acquisition;
+        # stale-retire and the held-verdict both stay inside THIS transaction.
+        legacy_path = getattr(args, "legacy_pidfile", None)
+        if legacy_path:
+            legacy = read_lock(legacy_path)
+            if legacy["kind"] != "absent":
+                if _owner_liveness(legacy) == "live":
+                    _emit({"code": "held", "holder": legacy, "at": "legacy"}, 7)
+                try:
+                    os.unlink(legacy_path)
+                except FileNotFoundError:
+                    pass
         try:
             record = _create_lock(args.pidfile, args.pid, args.entry, args.workspace)
         except OSError as e:
@@ -667,6 +679,7 @@ def main(argv=None):
     sp.add_argument("--pid", type=int, required=True)
     sp.add_argument("--entry", required=True)
     sp.add_argument("--workspace", required=True)
+    sp.add_argument("--legacy-pidfile", default=None)
     sp.set_defaults(fn=cmd_acquire)
 
     sp = sub.add_parser("read")

--- a/scripts/voice-lock.py
+++ b/scripts/voice-lock.py
@@ -4,7 +4,7 @@ transaction (design 1b; impl plan WS1 Step 3, amendments R3/S4/U1/Z1).
 
 Serialization is an advisory ``fcntl.flock(LOCK_EX)`` on a *guard* file held
 across each whole transaction; the JSON lock file
-(``<workspace>/.voice-agent.pid``) is owner *metadata* only. Every creator AND
+(``<workspace>/state/locks/voice-agent.pid``; root path pre-#2722) is owner *metadata* only. Every creator AND
 replacer of the lock must hold the guard for the whole
 stale-owner-resolution + acquisition sequence — delete-then-create without it
 is racy (two contenders can both validate the stale lock; one creates a fresh

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1314,8 +1314,8 @@ WORKSPACE_ROOT_ALLOWED = frozenset({
 #: `.backend-supervisor.lock.guard` is written by the desktop app, whose source
 #: is not in this repo (`backend-supervisor.lock.guard`: 0 hits here).
 #:
-#: `.voice-agent.pid` is deliberately NOT exempt: state/locks/ is a real
-#: destination that exists in-tree, so its warn names somewhere to go (#2722).
+#: `.voice-agent.pid` stays NOT exempt after the #2722 move: the writer now
+#: uses state/locks/, so a root copy is a pre-move straggler worth flagging.
 
 #: Migration sentinels are production-owned and DELIBERATELY retained at the
 #: workspace root — `workspace_default.py` writes `.notes-migrated`,

--- a/src/restart.sh
+++ b/src/restart.sh
@@ -17,9 +17,10 @@ echo "Stopping Sutando services..."
 # never signal without validation.
 if _VOICE_PY="$(bash "$REPO/scripts/sutando-config.sh" python-bin 2>/dev/null)"; then
     _VOICE_WS="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
-    if [ -n "$_VOICE_WS" ] && [ -f "$_VOICE_WS/.voice-agent.pid" ]; then
+    _VOICE_PIDFILE="$(bash "$REPO/scripts/sutando-config.sh" voice-pidfile "$_VOICE_WS" 2>/dev/null || true)"
+    if [ -n "$_VOICE_WS" ] && [ -n "$_VOICE_PIDFILE" ] && [ -f "$_VOICE_PIDFILE" ]; then
         "$_VOICE_PY" "$REPO/scripts/voice-lock.py" takeover \
-            --pidfile "$_VOICE_WS/.voice-agent.pid" \
+            --pidfile "$_VOICE_PIDFILE" \
             --guard "$_VOICE_WS/.voice-agent.lock.guard" \
             --workspace "$_VOICE_WS" \
             --mode adopted --port 9900 \

--- a/src/startup-runtime.sh
+++ b/src/startup-runtime.sh
@@ -319,7 +319,7 @@ reap_wedged_voice_agent() {
     return 0
   fi
   if out="$("$PY" "$REPO/scripts/voice-lock.py" takeover \
-      --pidfile "$WORKSPACE/.voice-agent.pid" \
+      --pidfile "$(bash "$REPO/scripts/sutando-config.sh" voice-pidfile "$WORKSPACE")" \
       --guard "$WORKSPACE/.voice-agent.lock.guard" \
       --workspace "$WORKSPACE" \
       --mode adopted --port "$port" \

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -157,7 +157,10 @@ const HOST = process.env.HOST || '127.0.0.1';
 // the file pipeline); the dual-use rationale is obsolete.
 import { resolveWorkspace, statusPath } from './workspace_default.js';
 const WORKSPACE_DIR = resolveWorkspace();
-const PIDFILE = join(WORKSPACE_DIR, '.voice-agent.pid');
+// Canonical since #2722; the root `.voice-agent.pid` is the pre-move legacy
+// location, read by the shell side only via `sutando-config.sh voice-pidfile`.
+const PIDFILE = join(WORKSPACE_DIR, 'state', 'locks', 'voice-agent.pid');
+const LEGACY_PIDFILE = join(WORKSPACE_DIR, '.voice-agent.pid');
 
 /** Bounded primitive-only crash record — shared by BOTH fatal paths (the
  * uncaught handler and `main().catch`), which obey identical crash-only
@@ -241,6 +244,7 @@ function acquirePidLock(): void {
 		console.error(`${ts()} [Startup] Lock operations fail closed. Fix: install python3 (brew install python), set SUTANDO_PY to a working interpreter, or run xcode-select --install. Exiting.`);
 		process.exit(1);
 	}
+	try { mkdirSync(join(WORKSPACE_DIR, 'state', 'locks'), { recursive: true }); } catch { /* acquire fails closed below */ }
 	const res = acquireVoiceLock({
 		pidfile: PIDFILE,
 		guard,
@@ -259,6 +263,9 @@ function acquirePidLock(): void {
 		console.error(`${ts()} [Startup] Fix the lock helper (scripts/voice-lock.py + its python3), then restart. Exiting.`);
 		process.exit(1);
 	}
+	// Self-healing migration (#2722): holding the guard proves any root-path
+	// copy is stale metadata, so retire it the way check-pending-questions.py does.
+	try { unlinkSync(LEGACY_PIDFILE); } catch { /* absent on post-transition hosts */ }
 	// Capability-marker binding token: a stale marker can never match a later
 	// acquisition, even one that reuses this pid.
 	voiceLockId = res.lockId;

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -247,6 +247,7 @@ function acquirePidLock(): void {
 	try { mkdirSync(join(WORKSPACE_DIR, 'state', 'locks'), { recursive: true }); } catch { /* acquire fails closed below */ }
 	const res = acquireVoiceLock({
 		pidfile: PIDFILE,
+		legacyPidfile: LEGACY_PIDFILE,
 		guard,
 		pid: myPid,
 		entry,
@@ -263,9 +264,6 @@ function acquirePidLock(): void {
 		console.error(`${ts()} [Startup] Fix the lock helper (scripts/voice-lock.py + its python3), then restart. Exiting.`);
 		process.exit(1);
 	}
-	// Self-healing migration (#2722): holding the guard proves any root-path
-	// copy is stale metadata, so retire it the way check-pending-questions.py does.
-	try { unlinkSync(LEGACY_PIDFILE); } catch { /* absent on post-transition hosts */ }
 	// Capability-marker binding token: a stale marker can never match a later
 	// acquisition, even one that reuses this pid.
 	voiceLockId = res.lockId;

--- a/src/voice-lock.ts
+++ b/src/voice-lock.ts
@@ -81,6 +81,8 @@ export type AcquireResult =
 
 export interface LockCallOpts {
 	pidfile: string;
+	/** Pre-move root path (#2722): a live record there holds acquisition. */
+	legacyPidfile?: string;
 	guard: string;
 	pid: number;
 	pythonBin: string;
@@ -106,6 +108,7 @@ export function acquireVoiceLock(
 				'--pid', String(opts.pid),
 				'--entry', opts.entry,
 				'--workspace', opts.workspace,
+				...(opts.legacyPidfile ? ['--legacy-pidfile', opts.legacyPidfile] : []),
 			],
 			{ encoding: 'utf-8' },
 		);

--- a/tests/agent-state-protocol.test.ts
+++ b/tests/agent-state-protocol.test.ts
@@ -689,7 +689,7 @@ describe('agent.state emission (integration, spawned agent)', () => {
 			// acquisition — pid and lockId equal the structured lock's.
 			const marker = JSON.parse(readFileSync(voiceCapabilitiesPath(ws), 'utf-8'));
 			assert.equal(marker.probeIsolation, true);
-			const lock = JSON.parse(readFileSync(join(ws, '.voice-agent.pid'), 'utf-8'));
+			const lock = JSON.parse(readFileSync(join(ws, 'state', 'locks', 'voice-agent.pid'), 'utf-8'));
 			assert.equal(marker.pid, lock.pid, 'marker.pid = lock holder pid');
 			assert.equal(marker.lockId, lock.lockId, 'marker.lockId = lock acquisition token');
 		} finally {

--- a/tests/restart-voice-agent-lock.test.py
+++ b/tests/restart-voice-agent-lock.test.py
@@ -107,7 +107,10 @@ class Lab:
             "exit 0\n"
         )
         (self.bin / "lsof").chmod(0o755)
-        self.pidfile = self.ws / ".voice-agent.pid"
+        locks = self.ws / "state" / "locks"
+        locks.mkdir(parents=True)
+        self.pidfile = locks / "voice-agent.pid"
+        self.legacy_pidfile = self.ws / ".voice-agent.pid"
         self.procs = []
 
     def run_script(self, old_pid="", fresh=True, no_job=False):
@@ -183,6 +186,33 @@ def main():
         check("script succeeds", p.returncode == 0, p.stdout + p.stderr)
         check("packaged-shape owner killed", agent.poll() is not None)
         check("packaged-shape lock stolen", not lab.pidfile.exists())
+
+        # --- transition fallback (#2722): a pre-move agent's root lock must
+        # stay reachable, or the restart path silently cannot stop it.
+        print("legacy-root fallback (pre-move agent):")
+        agent = spawn_dummy(entry_dev)
+        lab.procs.append(agent)
+        structured_lock(lab.legacy_pidfile, agent.pid, my_start_time_ms(agent.pid), entry_dev, lab.ws)
+        p = lab.run_script(old_pid=agent.pid)
+        check("script succeeds", p.returncode == 0, p.stdout + p.stderr)
+        check("pre-move owner killed via fallback", agent.poll() is not None)
+        check("legacy lock stolen", not lab.legacy_pidfile.exists())
+        check("fallback announced on stderr", "transition window" in p.stderr, p.stderr)
+        check("canonical path untouched", not lab.pidfile.exists())
+
+        # --- canonical wins when BOTH exist: without this control the rows
+        # above are consistent with a resolver that always answers legacy.
+        print("canonical-first when both exist:")
+        agent = spawn_dummy(entry_dev)
+        lab.procs.append(agent)
+        structured_lock(lab.pidfile, agent.pid, my_start_time_ms(agent.pid), entry_dev, lab.ws)
+        lab.legacy_pidfile.write_text("{stale legacy junk")
+        p = lab.run_script(old_pid=agent.pid)
+        check("script succeeds", p.returncode == 0, p.stdout + p.stderr)
+        check("canonical owner killed", agent.poll() is not None)
+        check("canonical lock stolen", not lab.pidfile.exists())
+        check("no fallback line when canonical exists", "transition window" not in p.stderr, p.stderr)
+        lab.legacy_pidfile.unlink()
 
         # --- malformed lock → left in place, WARN, no rm -f ---
         print("malformed lock:")

--- a/tests/startup-voice-wedge-reap.test.py
+++ b/tests/startup-voice-wedge-reap.test.py
@@ -114,7 +114,8 @@ def main():
     tmp = Path(tempfile.mkdtemp(prefix="startup-wedge-"))
     ws = tmp / "workspace"
     ws.mkdir()
-    pidfile = ws / ".voice-agent.pid"
+    pidfile = ws / "state" / "locks" / "voice-agent.pid"
+    pidfile.parent.mkdir(parents=True)
     shim_bin = tmp / "bin"
     shim_bin.mkdir()
     (shim_bin / "curl").write_text('#!/bin/bash\nexit "${SHIM_CURL_RC:-28}"\n')

--- a/tests/voice-agent-crash-only.test.ts
+++ b/tests/voice-agent-crash-only.test.ts
@@ -264,12 +264,19 @@ describe('voice-agent duplicate-instance + fail-closed lock (integration)', () =
 
 	it('duplicate spawn: loser exits 7 with the FATAL line; winner keeps a structured lock', async () => {
 		const ws = makeWorkspace('dup');
-		const pidfile = join(ws, '.voice-agent.pid');
+		const pidfile = join(ws, 'state', 'locks', 'voice-agent.pid');
+		// #2722 self-healing migration: a pre-move root copy is retired on acquisition.
+		writeFileSync(join(ws, '.voice-agent.pid'), '{"stale":"pre-move"}');
 		const winner = spawnAgent(ws, 19931, 19932);
 		// The lock is written before any side effect — poll for it, then race
 		// the loser against the SAME workspace (different ports: the loser must
 		// die at the LOCK, not at the port bind).
 		await waitFor(() => existsSync(pidfile), 90_000, 'winner lock file');
+		assert.equal(
+			existsSync(join(ws, '.voice-agent.pid')),
+			false,
+			'legacy root copy retired on acquisition (#2722 shim)',
+		);
 		const lock = JSON.parse(readFileSync(pidfile, 'utf-8'));
 		assert.equal(lock.v, 1, 'lock is structured schema v1');
 		// `npx tsx` spawns a worker: the lock names the WORKER (the process
@@ -312,7 +319,7 @@ describe('voice-agent duplicate-instance + fail-closed lock (integration)', () =
 		// the loser's own (now stale) lock stays for the supervisor to replace
 		// under the guard — identical crash-only rules on both fatal paths.
 		assert.equal(
-			existsSync(join(wsB, '.voice-agent.pid')),
+			existsSync(join(wsB, 'state', 'locks', 'voice-agent.pid')),
 			true,
 			'main().catch fatal must NOT release the lock (amendment R1)',
 		);
@@ -336,7 +343,7 @@ describe('voice-agent duplicate-instance + fail-closed lock (integration)', () =
 		assert.equal(typeof rec.pid, 'number');
 		// R1: the acquired lock is left in place (release helper suppressed).
 		assert.equal(
-			existsSync(join(ws, '.voice-agent.pid')),
+			existsSync(join(ws, 'state', 'locks', 'voice-agent.pid')),
 			true,
 			'fatal main() exit must NOT release the lock (amendment R1)',
 		);
@@ -354,7 +361,7 @@ describe('voice-agent duplicate-instance + fail-closed lock (integration)', () =
 		assert.equal(existsSync(join(ws, 'logs', 'voice-agent.crash.json')), false, 'duplicate-instance exit writes no crash record');
 		// And the fatal flag suppresses the exit-time release here too (R1).
 		assert.equal(
-			existsSync(join(ws, '.voice-agent.pid')),
+			existsSync(join(ws, 'state', 'locks', 'voice-agent.pid')),
 			true,
 			'uncaught fatal must NOT release the lock (amendment R1)',
 		);
@@ -374,6 +381,6 @@ describe('voice-agent duplicate-instance + fail-closed lock (integration)', () =
 		assert.equal(code, 1, `fail-closed exit is 1, got ${code}; stderr: ${agent.stderr()}`);
 		assert.match(agent.stderr(), /fail closed/i);
 		assert.match(agent.stderr(), /python/i);
-		assert.equal(existsSync(join(ws, '.voice-agent.pid')), false, 'no unguarded legacy lock writer (amendment R3)');
+		assert.equal(existsSync(join(ws, 'state', 'locks', 'voice-agent.pid')), false, 'no unguarded legacy lock writer (amendment R3)');
 	});
 });

--- a/tests/voice-lock.test.py
+++ b/tests/voice-lock.test.py
@@ -137,7 +137,8 @@ def main():
     tmp = Path(tempfile.mkdtemp(prefix="voice-lock-test-"))
     ws = tmp / "workspace"
     ws.mkdir()
-    pidfile = ws / ".voice-agent.pid"
+    pidfile = ws / "state" / "locks" / "voice-agent.pid"
+    pidfile.parent.mkdir(parents=True)
     guard = ws / ".voice-agent.lock.guard"
     entry = tmp / "src" / "voice-agent.ts"
     entry.parent.mkdir()

--- a/tests/voice-lock.test.py
+++ b/tests/voice-lock.test.py
@@ -188,6 +188,43 @@ def main():
         p = run_helper(base("acquire") + ["--pid", os.getpid(), "--entry", entry, "--workspace", ws])
         check("acquire blocks on live legacy pid", p.returncode == 7, str(p.returncode))
 
+        # --- #2722 transition: a LIVE pre-move owner at the legacy path must
+        # hold canonical acquisition inside the same guarded transaction.
+        print("legacy-path transition (#2722):")
+        pidfile.unlink()
+        legacy_pidfile = ws / ".voice-agent.pid"
+        oldowner = spawn_sleeper()
+        structured_lock(legacy_pidfile, oldowner.pid, my_start_time_ms(oldowner.pid), entry, ws)
+        p = run_helper(base("acquire") + ["--pid", os.getpid(), "--entry", entry,
+                                          "--workspace", ws, "--legacy-pidfile", legacy_pidfile])
+        check("live legacy owner holds canonical acquire (7)", p.returncode == 7, p.stdout + p.stderr)
+        check("held payload marks the legacy location", out_json(p).get("at") == "legacy", p.stdout)
+        check("live legacy record left intact",
+              json.loads(legacy_pidfile.read_text())["pid"] == oldowner.pid)
+        check("no canonical record created", not pidfile.exists())
+        check("pre-move owner never signaled", oldowner.poll() is None)
+
+        # Stale pre-move record → retired in-transaction, canonical created.
+        oldowner.kill()
+        oldowner.wait()
+        p = run_helper(base("acquire") + ["--pid", os.getpid(), "--entry", entry,
+                                          "--workspace", ws, "--legacy-pidfile", legacy_pidfile])
+        check("stale legacy retired and canonical acquired", p.returncode == 0, p.stdout + p.stderr)
+        check("legacy record gone", not legacy_pidfile.exists())
+        check("canonical names acquirer", json.loads(pidfile.read_text())["pid"] == os.getpid())
+
+        # Control: without --legacy-pidfile a legacy record is invisible —
+        # proves the flag, not coincidence, gates the new branch.
+        pidfile.unlink()
+        legacy_pidfile.write_text("{junk")
+        p = run_helper(base("acquire") + ["--pid", os.getpid(), "--entry", entry, "--workspace", ws])
+        check("without the flag, legacy path is not consulted",
+              p.returncode == 0 and legacy_pidfile.exists(), p.stdout + p.stderr)
+        legacy_pidfile.unlink()
+        pidfile.unlink()
+        # Restore the state the later sections expect (sleeper bare-pid lock).
+        pidfile.write_text(f"{sleeper.pid}\n")
+
         # --- read normalization ---
         print("read:")
         p = run_helper(["read", "--pidfile", pidfile])


### PR DESCRIPTION
Closes #2722 — **option (a)** exactly as scoped in the issue thread (sonichi 2026-08-20): the pid metadata file moves; the flock guard's six-site root exemption is untouched (that is option (b), separate issue).

## What

- **One resolver**: `sutando-config.sh voice-pidfile [workspace]` — canonical `state/locks/voice-agent.pid` first, legacy root fallback for the ~30-day transition window (`docs/migration-transition-window.md`), stderr deprecation line only when the fallback fires. The optional workspace argument lets callers inject the root they already resolved — without it the resolver re-derives, and a harness-resolved tree and a resolver-derived tree can be different objects (measured below).
- **Readers delegate**: `src/restart.sh`, `src/startup-runtime.sh`, `scripts/restart-voice-agent.sh` all call the resolver with their resolved workspace. Per the issue inventory refresh (yixuan-ag2), `src/restart.sh` is the reader that would bite hardest — a stale path there means restart silently loses the ability to stop the agent — and it is in the fallback list.
- **Writer**: `voice-agent.ts` writes canonical (mkdir first) and unlinks a pre-move root copy after acquisition — holding the guard proves the root copy is stale. Same shim shape as `check-pending-questions.py:45`.
- `workspace-root-tidy` still flags a root `.voice-agent.pid` — after this move that is a pre-move straggler, which is what the probe should say (comment updated; probe behavior unchanged, suite green).

## Before/after (real output)

Resolver, three states (scratch workspace):
```
empty:    <ws>/state/locks/voice-agent.pid
legacy:   <ws>/.voice-agent.pid
          stderr: sutando-config: voice-pidfile using legacy <ws>/.voice-agent.pid (pre-move agent; transition window per #2722)
both:     <ws>/state/locks/voice-agent.pid
```

At parent `5cb9795a` the transition case does not exist: `src/restart.sh:20` reads only `"$_VOICE_WS/.voice-agent.pid"`, so a new-code agent (canonical) would be unstoppable by old restart.sh, and conversely. At head, `tests/restart-voice-agent-lock.test.py` pins both directions:
```
legacy-root fallback (pre-move agent):
  [ok] script succeeds / pre-move owner killed via fallback / legacy lock stolen
  [ok] fallback announced on stderr / canonical path untouched
canonical-first when both exist:
  [ok] canonical owner killed / canonical lock stolen / no fallback line
All restart-voice-agent lock-migration tests passed.
```

Real agent round trip (worktree, scratch workspace, planted pre-move root copy):
```
$ echo '{"stale":"pre-move"}' > $S/.voice-agent.pid && npx tsx src/voice-agent.ts
LOCK at t=27s; legacy still exists: no        <- canonical written, root copy retired
... [VoiceSession] WS server ready
```

## Test evidence at head

- `tests/restart-voice-agent-lock.test.py`, `tests/voice-lock.test.py`, `tests/startup-voice-wedge-reap.test.py`, `tests/health-check-workspace-root-tidy.test.py`: **all pass**.
- `tests/voice-agent-crash-only.test.ts`: 14/16 in my worktree; the 2 failures are the two 90s-budget spawn cases timing out in that environment. **Control: the identical two cases fail identically at the unmodified merge-base in the same worktree** (stash → run → pop), while 120s-budget spawn cases pass at ~121s — the environment boots agents ~30–60s slower than a live checkout (symlinked node_modules). Full suite is green at main on the live checkout on the same host. Not a product of this diff; hosted CI is the clean arbiter.

## Live path note

This touches the restart path, so per repo standards it needs a real post-restart round trip on a live host. Deliberately staged rather than run at the tail of an autonomous pass (my own caveat in the issue body): the live agent on this host currently holds the root-path lock, which is **exactly the transition case** — the first supervised restart after merge exercises fallback-stop → canonical-write → legacy-retire in one shot, same protocol as #3287's witness. @sonichi say "g" whenever convenient and I'll run it and post the transcript here.

Stand: Echo Act IV Mini
🤖 Generated with [Claude Code](https://claude.com/claude-code)
