### PR TITLE
fix(task-progress): notify.py never consulted the vault, so vault-only tokens failed silently

### DIFF
--- a/skills/task-progress/SKILL.md
+++ b/skills/task-progress/SKILL.md
@@ -112,9 +112,13 @@ Optional for Slack @mentions: `reply_thread_ts:` → `--thread-ts`
 
 ## Supported channels
 
-- **Slack** — `chat.postMessage`, token from `$CLAUDE_CONFIG_DIR/channels/slack/.env` (`SLACK_BOT_TOKEN`)
-- **Discord** — REST v10 messages, token from `$CLAUDE_CONFIG_DIR/channels/discord/.env` (`DISCORD_BOT_TOKEN`)
-- **Telegram** — `sendMessage`, token from `$CLAUDE_CONFIG_DIR/channels/telegram/.env` (`TELEGRAM_BOT_TOKEN`)
+- **Slack** — `chat.postMessage`, `SLACK_BOT_TOKEN` resolved **process env → `$CLAUDE_CONFIG_DIR/channels/slack/.env` → vault**
+- **Discord** — REST v10 messages, `DISCORD_BOT_TOKEN` resolved **process env → `$CLAUDE_CONFIG_DIR/channels/discord/.env` → vault**
+- **Telegram** — `sendMessage`, `TELEGRAM_BOT_TOKEN` resolved **process env → `$CLAUDE_CONFIG_DIR/channels/telegram/.env` → vault**
+
+All three share one resolver (`src/channel_token.resolve_channel_token`), the same one the bridges
+use, so a token stored only via `vault set` resolves here too. If `src/` is not importable the
+vault tier is skipped rather than raising — a progress notification never fails a task.
 
 ### Discord mentions
 

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -66,16 +66,37 @@ def _env_file(path: str) -> dict[str, str]:
     return result
 
 
-def _token(source: str, var: str) -> str:
-    """Resolve a token from env, then the channel .env file."""
-    val = os.environ.get(var, "").strip()
-    if val:
-        return val
+def _channel_env_path(source: str) -> Path:
     # Mirrors util_paths.claude_home_path ($CLAUDE_CONFIG_DIR -> $CLAUDE_HOME -> ~/.claude).
     _base = os.environ.get("CLAUDE_CONFIG_DIR") or os.environ.get("CLAUDE_HOME")
     _claude_config = Path(_base) if _base else Path.home() / ".claude"
-    env_path = _claude_config / "channels" / source / ".env"
-    return _env_file(str(env_path)).get(var, "")
+    return _claude_config / "channels" / source / ".env"
+
+
+def _load_resolver():
+    """The bridges' own resolver, or None when src/ is not importable."""
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+        from channel_token import resolve_channel_token  # type: ignore
+        return resolve_channel_token
+    except Exception:
+        return None
+
+
+_resolve_channel_token = _load_resolver()
+
+
+def _token(source: str, var: str) -> str:
+    """Resolve a token: process env -> channel `.env` -> vault.
+
+    Delegates to channel_token so these tiers cannot drift from the bridges'.
+    Degrades to the first two tiers alone rather than failing a notification.
+    """
+    env_path = _channel_env_path(source)
+    if _resolve_channel_token is not None:
+        return _resolve_channel_token(var, env_file=env_path)
+    val = os.environ.get(var, "").strip()
+    return val or _env_file(str(env_path)).get(var, "")
 
 
 def _post(url: str, payload: dict, headers: dict) -> bool:

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -96,6 +96,24 @@ class TestTokenResolution(unittest.TestCase):
                 got = self.mod._token("telegram", "TELEGRAM_BOT_TOKEN")
         self.assertEqual(got, "tg-vault-only")
 
+    def test_load_resolver_returns_none_when_import_fails(self):
+        """The degraded path itself, not just its result.
+
+        The sibling test patches `_resolve_channel_token` to None, which
+        exercises `_token`'s fallback but never `_load_resolver`. This drives
+        the import failure so the `except` branch is actually executed.
+        """
+        import builtins
+        real_import = builtins.__import__
+
+        def boom(name, *a, **kw):
+            if name == "channel_token":
+                raise ImportError("simulated: src/ not importable")
+            return real_import(name, *a, **kw)
+
+        with patch.object(builtins, "__import__", boom):
+            self.assertIsNone(self.mod._load_resolver())
+
     def test_env_still_wins_over_vault(self):
         """An exported value must keep winning, so working hosts are unaffected."""
         import channel_token

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 REPO = Path(__file__).parent.parent
 SCRIPT = REPO / "skills" / "task-progress" / "scripts" / "notify.py"
+sys.path.insert(0, str(REPO / "src"))
 
 
 def _load() -> types.ModuleType:
@@ -46,6 +47,74 @@ class TestTokenResolution(unittest.TestCase):
             result = self.mod._token("slack", "SLACK_BOT_TOKEN")
             # May be non-empty if the real file exists — just check it's a string
             self.assertIsInstance(result, str)
+
+    def test_falls_back_to_vault_when_env_and_env_file_are_empty(self):
+        """The vault is the third tier — a token that lives ONLY there must resolve.
+
+        Measured 2026-08-23 on a live host: TELEGRAM_BOT_TOKEN was in the vault,
+        absent from the process env, and absent from channels/telegram/.env, so
+        every Telegram progress notification failed with "not found" while the
+        bridge — which already consults the vault — worked. This asserts the
+        delegation, not a reimplementation of it.
+
+        Hermetic: the vault reader is injected, never the real Keychain.
+        """
+        import channel_token
+
+        empty = Path(tempfile.mkdtemp()) / "absent.env"
+        seen = []
+
+        def fake_vault(key):
+            seen.append(key)
+            return "tg-from-vault"
+
+        def resolver(var, env_file=None, environ=None, vault_get=None):
+            return channel_token.resolve_channel_token(
+                var, env_file=empty, environ={}, vault_get=fake_vault)
+
+        with patch.object(self.mod, "_resolve_channel_token", resolver):
+            got = self.mod._token("telegram", "TELEGRAM_BOT_TOKEN")
+
+        self.assertEqual(got, "tg-from-vault")
+        self.assertEqual(seen, ["TELEGRAM_BOT_TOKEN"])
+
+    def test_vault_only_token_resolves_end_to_end(self):
+        """The behavioural regression: env empty, `.env` absent, token only in the vault.
+
+        This one does NOT patch notify's own seam — it patches the vault reader
+        underneath, so it fails the way the live bug failed (returns "") against
+        any build that does not consult the vault at all.
+        """
+        import vault_intercept
+
+        empty_home = Path(tempfile.mkdtemp())          # no channels/telegram/.env under it
+        with patch.dict("os.environ",
+                        {"CLAUDE_CONFIG_DIR": str(empty_home)}, clear=False):
+            os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+            with patch.object(vault_intercept, "get_vault_key",
+                              lambda k: "tg-vault-only" if k == "TELEGRAM_BOT_TOKEN" else ""):
+                got = self.mod._token("telegram", "TELEGRAM_BOT_TOKEN")
+        self.assertEqual(got, "tg-vault-only")
+
+    def test_env_still_wins_over_vault(self):
+        """An exported value must keep winning, so working hosts are unaffected."""
+        import channel_token
+
+        def resolver(var, env_file=None, environ=None, vault_get=None):
+            return channel_token.resolve_channel_token(
+                var, env_file=None, environ={"TELEGRAM_BOT_TOKEN": "tg-from-env"},
+                vault_get=lambda k: "tg-from-vault")
+
+        with patch.object(self.mod, "_resolve_channel_token", resolver):
+            self.assertEqual(
+                self.mod._token("telegram", "TELEGRAM_BOT_TOKEN"), "tg-from-env")
+
+    def test_degrades_to_env_when_resolver_unavailable(self):
+        """A missing src/ must not fail the notification — fail-open by design."""
+        with patch.object(self.mod, "_resolve_channel_token", None), \
+             patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-degraded"}):
+            self.assertEqual(
+                self.mod._token("slack", "SLACK_BOT_TOKEN"), "xoxb-degraded")
 
 
 class TestProgressMessageGuard(unittest.TestCase):


### PR DESCRIPTION
## What

`skills/task-progress/scripts/notify.py`'s `_token()` resolved a channel token from the process env
and the channel `.env` file only. `src/channel_token.resolve_channel_token()` already implements the
three-tier chain the bridges use — **env → `.env` → vault** — so `_token` was a copy of that helper
with its last tier missing.

## The defect, measured on a live host (2026-08-23)

```
channels/telegram/.env      0 lines matching ^TELEGRAM_BOT_TOKEN=
process env                 unset
vault list                  TELEGRAM_BOT_TOKEN  present
```

Both sources `notify.py` consults were empty and the only one holding the token was never asked. Every
Telegram progress notification exited with `[task-progress] TELEGRAM_BOT_TOKEN not found` — while
`src/telegram-bridge.py`, which already falls back to `token_from_vault`, worked from the same host on
the same token.

**It fails silently by construction.** The message goes to stderr and the caller is documented
fail-open ("always continue the task regardless of exit code"), so the owner simply never receives a
progress line on that surface and nothing reports it. I found it only because I read stderr on an
unrelated call.

Discord and Slack are unaffected **here** only because their tokens are not vault-only. The defect is
in the resolver, not the surface — any host that stores a bot token via `vault set` hits it.

## Fix

Delegate to `resolve_channel_token`. No new policy: the tiers, the precedence, and the "never surface
the value in an exception" behaviour all stay owned by `channel_token`. If `src/` is not importable the
function degrades to the previous two tiers rather than raising, because a progress notification must
never fail a task.

## Evidence

The regression fails the way the live bug failed — an empty token, not a missing attribute:

```
pre-fix    test_vault_only_token_resolves_end_to_end
           AssertionError: '' != 'tg-vault-only'

post-fix   tests/task-progress-skill.test.py            50/50 OK
           tests/channel-token-vault-fallback.test.py   OK
           scripts/review-checks.sh (on this diff)      PASS
```

It patches `vault_intercept.get_vault_key` **underneath** rather than notify's own seam, so it fails
against any build that does not consult the vault at all — not merely one lacking the new attribute.
Hermetic: no real Keychain read, matching the discipline `tests/channel-token-vault-fallback.test.py`
documents (a live-Keychain test there once flipped a credential probe to a false green).

Three supporting cases: env still wins over the vault (working hosts unaffected), and the resolver
being unavailable degrades to env rather than raising.

Not a live path — this is token resolution inside a fail-open notifier, so no restart witness is owed.

## Interaction with #1889

**#1889** (`task-progress: reply in-thread (Slack/Telegram)`) edits the same two files and is currently
`DIRTY`. It does **not** touch `_token`'s definition — it only `patch.object(...,"_token")` in tests —
so this is not a duplicate, but whoever rebases #1889 will meet this in
`tests/task-progress-skill.test.py`. Flagging so it is expected rather than discovered. Either order
works; this PR is 2 files and self-contained.

@sonichi — flagging you since this changes a notifier on your own comms path.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)
