### PR TITLE
fix(gateway): a lead-assigned task is custody, not completion

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2197,6 +2197,15 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
         _log(f"owner-activity write failed: {e}")
 
 
+def _task_pending_locally(tid: str) -> bool:
+    """True while the task still sits in tasks/ under ANY pool state. A pool
+    lead renames a task to .assigned-<core> before the follower renames it to
+    .claimed-<core>; both are custody handoffs, never completions."""
+    return ((TASKS_DIR / f"{tid}.txt").exists()
+            or any(TASKS_DIR.glob(f"{tid}.assigned-*"))
+            or any(TASKS_DIR.glob(f"{tid}.claimed-*")))
+
+
 def _write_task(task: dict) -> str | None:
     """Serialize a gateway task into tasks/task-<id>.txt (same schema as bridges).
     Returns the task id, or None if it has no id / already present."""
@@ -2213,7 +2222,7 @@ def _write_task(task: dict) -> str | None:
     task = {**task, "id": tid}
     dest = TASKS_DIR / f"{tid}.txt"
     # Idempotent: don't re-write a task already queued, claimed, or archived.
-    if dest.exists() or any(TASKS_DIR.glob(f"{tid}.claimed-*")):
+    if _task_pending_locally(tid):
         return tid
     # Relay redelivery of already-handled work: on reconnect the gateway replays
     # its unacked pool, including tasks this node long since processed (the
@@ -3106,8 +3115,7 @@ def _reconcile_abandoned(inflight: set[str], suspects: set[str]) -> set[str]:
     instead of being raced. Returns the new suspects set for the next pass."""
     gone = {tid for tid in inflight
             if _valid_local_tid(tid)
-            and not (TASKS_DIR / f"{tid}.txt").exists()
-            and not any(TASKS_DIR.glob(f"{tid}.claimed-*"))
+            and not _task_pending_locally(tid)
             and not (RESULTS_DIR / f"{tid}.txt").exists()
             and not _task_archived_recently(tid)}
     confirmed = gone & suspects

--- a/tests/gateway-assigned-task-not-abandoned.test.py
+++ b/tests/gateway-assigned-task-not-abandoned.test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""A lead-assigned task must not be reconciled away as abandoned.
+
+`_reconcile_abandoned` recognised the follower's `.claimed-<core>` rename but
+not the lead's earlier `.assigned-<core>` rename. In the window between the two,
+no `task-<id>.txt`, no `.claimed-*` and no result file existed, so the id looked
+completed-elsewhere and was dropped from the in-flight ledger. `_post_ready_results`
+only ever iterates in-flight ids, so the reply the follower wrote seconds later was
+never posted and stranded in results/ with no dead-letter and no alert.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_PKG = _REPO / "packages" / "ag2-sparrow"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+TID = "task-9a153e2032e6cabe5a"
+
+
+def _load_gateway():
+    from ag2_sparrow import remote_gateway_bridge as gw  # noqa: WPS433
+    return gw
+
+
+class _Dirs:
+    """Point the module's tasks/results dirs at a temp tree, then restore."""
+
+    _PATCH = ("TASKS_DIR", "RESULTS_DIR")
+
+    def __init__(self, gw, tmp: Path):
+        self.gw, self.tmp = gw, tmp
+        self._saved = {}
+
+    def __enter__(self):
+        for name in self._PATCH:
+            self._saved[name] = getattr(self.gw, name)
+        self.tasks = self.tmp / "tasks"
+        self.results = self.tmp / "results"
+        self.tasks.mkdir(parents=True)
+        self.results.mkdir(parents=True)
+        self.gw.TASKS_DIR = self.tasks
+        self.gw.RESULTS_DIR = self.results
+        return self
+
+    def __exit__(self, *exc):
+        for name, value in self._saved.items():
+            setattr(self.gw, name, value)
+        return False
+
+
+class AssignedTaskNotAbandoned(unittest.TestCase):
+    def setUp(self):
+        self.gw = _load_gateway()
+
+    def _reconcile_twice(self, dirs):
+        """Two consecutive sightings are what actually drops an id."""
+        inflight = {TID}
+        suspects = self.gw._reconcile_abandoned(inflight, set())
+        self.gw._reconcile_abandoned(inflight, suspects)
+        return inflight
+
+    def test_assigned_task_survives_reconcile(self):
+        with tempfile.TemporaryDirectory() as td, _Dirs(self.gw, Path(td)) as d:
+            (d.tasks / f"{TID}.assigned-core-3.txt").write_text("task: hi\n")
+            self.assertIn(TID, self._reconcile_twice(d),
+                          "lead-assigned task was dropped as abandoned")
+
+    def test_claimed_task_survives_reconcile(self):
+        with tempfile.TemporaryDirectory() as td, _Dirs(self.gw, Path(td)) as d:
+            (d.tasks / f"{TID}.claimed-core-3.txt").write_text("task: hi\n")
+            self.assertIn(TID, self._reconcile_twice(d))
+
+    def test_genuinely_gone_task_is_still_dropped(self):
+        """The reconciler must keep doing its job — this is the positive control."""
+        with tempfile.TemporaryDirectory() as td, _Dirs(self.gw, Path(td)) as d:
+            self.assertNotIn(TID, self._reconcile_twice(d),
+                             "reconciler no longer drops truly abandoned ids")
+
+    def test_pending_predicate_covers_every_custody_state(self):
+        with tempfile.TemporaryDirectory() as td, _Dirs(self.gw, Path(td)) as d:
+            self.assertFalse(self.gw._task_pending_locally(TID))
+            for name in (f"{TID}.txt", f"{TID}.assigned-core-2.txt",
+                         f"{TID}.claimed-core-2.txt"):
+                path = d.tasks / name
+                path.write_text("task: hi\n")
+                self.assertTrue(self.gw._task_pending_locally(TID), name)
+                path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

A pool lead renames a task `task-<id>.txt` → `task-<id>.assigned-core-N.txt` before the follower
renames it again to `.claimed-core-N.txt`. `_reconcile_abandoned` knew about `.claimed-*` but not
`.assigned-*`, so during the assigned-but-not-yet-claimed window its predicate saw:

- no `tasks/task-<id>.txt` (renamed away)
- no `tasks/task-<id>.claimed-*` (not claimed yet)
- no `results/task-<id>.txt` (not answered yet)
- not recently archived

…which is exactly its definition of "completed elsewhere". After two sightings the id was dropped
from the in-flight ledger. `_post_ready_results` iterates **only** in-flight ids, so the reply the
follower wrote seconds later was never posted. It stranded in `results/` — no dead-letter, no
`results/undelivered/` entry, no health-check warning. Silent loss.

The same missing shape sat in `_write_task`'s idempotency guard: a gateway replay of an assigned
task would not match `.assigned-*` either, and would write a **second** pending copy alongside the
assigned one.

## Evidence — production, not a harness

Live `remote-gateway-bridge.log` from 2026-08-23, four collaborator replies in AG2 Space Triage:

```
queued task-3a29d9f88e72783ce7
queued task-9a153e2032e6cabe5a
queued task-0f6313e81d6b06df20
queued task-317b14f03a312ffbde
dropped abandoned in-flight id task-0f6313e81d6b06df20 (no task/result file — completed elsewhere)
dropped abandoned in-flight id task-9a153e2032e6cabe5a (no task/result file — completed elsewhere)
dropped abandoned in-flight id task-317b14f03a312ffbde (no task/result file — completed elsewhere)
result task-3a29d9f88e72783ce7 delivered via DeliveryCore (...)
delivered result for task-3a29d9f88e72783ce7
```

One survived — the one claimed immediately, so it reached `.claimed-*` before the reconciler ran.
The three that sat in `.assigned-*` while the follower worked through them one at a time were all
dropped. Their result files are still on disk and their room mappings are still intact:

```
remote-task-rooms.json -> all three -> '!cAAaogVSFcIYaNmohw:ag2.space'
remote-task-inflight.json -> list, present: all three False, size 0
```

## The fix

Both call sites now share one `_task_pending_locally()` predicate covering all three custody
states (plain / assigned / claimed) instead of each carrying its own glob list — the duplication
is what let the two sites drift apart in the first place.

## Verification

`tests/gateway-assigned-task-not-abandoned.test.py` — 4 tests, including a positive control that
the reconciler still drops genuinely-abandoned ids (a fix that simply disabled the reconciler would
pass the other three).

Mutation control — removing only the `.assigned-*` line:

```
MUTATED: assigned glob removed
AssertionError: False is not true : task-9a153e2032e6cabe5a.assigned-core-2.txt
Ran 4 tests ... FAILED (failures=2)
```

Restored:

```
Ran 4 tests in 0.125s
OK
```

Regression sweep: 28/28 `tests/gateway-*.test.py` + `tests/*sparrow*.test.py` pass, 0 failures.
`ag2-sparrow-drift`, `ci-covers-every-python-test`, and `scripts/review-checks.sh --diff` all green.

## Not yet proven, and why

This is a delivery-loop change, so it wants a real post-restart round trip and I have not run one:
restarting the live bridge is owner-gated. The same restart is also what would recover the three
stranded replies (re-add the ids to `state/remote-task-inflight.json`, then restart so the loop
reloads the ledger — `_load_inflight()` is called once at loop setup, so an edit alone is
overwritten by the next save). Both are queued for the owner rather than done unilaterally.

## Stacking

Base is `feat/pool-operability` (#3319). The defect is not reachable on `main` — `.assigned-*`
only exists once the lead-follower assignment layer lands (#3314), so this belongs in that train.
Merge order: #3314 → #3319 → this.
