### PR TITLE
fix(discord-bridge): honor suppression markers in poll_proactive

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/result_markers.py
+++ b/packages/ag2-sparrow/ag2_sparrow/result_markers.py
@@ -439,3 +439,9 @@ def first_action(result: ParseResult, kind: ActionKind) -> Action | None:
         if a.kind == kind:
             return a
     return None
+
+
+def has_skip_action(actions) -> bool:
+    """True if `actions` (a ParseResult.actions list) carries a skip-kind
+    marker (`[no-send]`/`[REPLIED]`/`[deduped:...]`) — the body must never be sent."""
+    return any(a.kind == "skip" for a in actions)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -149,7 +149,7 @@ def _is_discord_channel_id(value: str) -> bool:
     """A snowflake, so a Telegram chat id or a Matrix room id can never be
     mistaken for one. Shape only — resolution stays with fetch_channel."""
     return value.isdigit() and 17 <= len(value) <= 20
-from result_markers import parse_markers, dedup_cross_channel_target, dedup_requeue_count, build_requeued_task  # noqa: E402
+from result_markers import parse_markers, dedup_cross_channel_target, dedup_requeue_count, build_requeued_task, has_skip_action  # noqa: E402
 from policy.guardrail import engage_rulebook, DISCORD_PROVENANCE  # noqa: E402
 from policy.egress.result import guard_result_for_tier, resolve_access_tier as _resolve_task_tier  # noqa: E402
 
@@ -5329,7 +5329,7 @@ async def poll_proactive():
                     _pp = parse_markers(text)
                     # Honor suppression markers, same as poll_dm_fallback —
                     # else a skip-marked file still gets DM-attempted here.
-                    if any(a.kind == "skip" for a in _pp.actions):
+                    if has_skip_action(_pp.actions):
                         print(f"  [proactive] skipped (suppression marker): {f.name}", flush=True)
                         _proactive_fence().drop(f, "suppression marker (no-send/deduped/REPLIED)")
                         continue
@@ -5735,7 +5735,7 @@ async def poll_dm_fallback():
                 except OSError:
                     _peek = ""
                 _parsed_fb = parse_markers(_peek)
-                if any(a.kind == "skip" for a in _parsed_fb.actions):
+                if has_skip_action(_parsed_fb.actions):
                     print(f"  [dm-fallback] skipped (suppression marker): {f.name}", flush=True)
                     _task_id = f.stem
                     _task_file = find_task_file(TASKS_DIR, _task_id)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5327,6 +5327,12 @@ async def poll_proactive():
                     # Parse ONCE, here, and reuse below: a second grammar would
                     # miss what parse_markers peels (D7 `**[core: N]**` headers).
                     _pp = parse_markers(text)
+                    # Honor suppression markers, same as poll_dm_fallback —
+                    # else a skip-marked file still gets DM-attempted here.
+                    if any(a.kind == "skip" for a in _pp.actions):
+                        print(f"  [proactive] skipped (suppression marker): {f.name}", flush=True)
+                        _proactive_fence().drop(f, "suppression marker (no-send/deduped/REPLIED)")
+                        continue
                     _early_redirect = next(
                         (a for a in _pp.actions if a.kind == "redirect"), None)
                     if _early_redirect is not None and redirect_target_is_foreign(

--- a/src/result_markers.py
+++ b/src/result_markers.py
@@ -439,3 +439,9 @@ def first_action(result: ParseResult, kind: ActionKind) -> Action | None:
         if a.kind == kind:
             return a
     return None
+
+
+def has_skip_action(actions) -> bool:
+    """True if `actions` (a ParseResult.actions list) carries a skip-kind
+    marker (`[no-send]`/`[REPLIED]`/`[deduped:...]`) — the body must never be sent."""
+    return any(a.kind == "skip" for a in actions)

--- a/tests/proactive-suppression-marker-behavioral.test.py
+++ b/tests/proactive-suppression-marker-behavioral.test.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""BEHAVIORAL mutation-resistance proof for the suppression-marker skip check
+inside `poll_proactive` and `poll_dm_fallback` (src/discord-bridge.py).
+
+Sibling to `proactive-suppression-marker-honored.test.py`, which pins the
+decision (`has_skip_action()`) behaviorally but only pins each call SITE
+structurally (source-text: "does the function contain this substring, near
+this other substring"). qingyun-wu's second review round showed that is not
+enough: `if False and has_skip_action(_pp.actions):` leaves every guarded
+substring — `parse_markers`, `kind == "skip"`, `.drop(`, `continue`, their
+relative order — intact, so the structural test stays green while a
+suppression-marked file falls through to a live send attempt.
+
+This file closes that gap by actually EXECUTING `poll_proactive` and
+`poll_dm_fallback` (one real pass each, driven the same way
+`proactive-dm-failure-keeps-file-behaviour.test.py` already does — a
+sleep-sentinel that raises after one iteration) against a real `[no-send]`
+file and a real ordinary file side by side, and observing the one signal
+that actually matters: was a send attempted. `check_mutation_makes_it_fail`
+is the permanent guard — it applies qingyun's exact mutation to a COPY of
+the source, executes THAT, and asserts the observable behavior flips. A
+regex over the mutated text would prove nothing; running the mutated code
+is the only thing that can.
+
+`proactive_routing` is captured as a real module reference below, before any
+per-pass stub replaces `sys.modules["proactive_routing"]`, so
+`poll_dm_fallback`'s own runtime `from proactive_routing import ...` still
+sees the real module after a `poll_proactive` pass has stubbed it out.
+
+Run: python3 tests/proactive-suppression-marker-behavioral.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import itertools
+import os
+import sys
+import tempfile
+import time
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BRIDGE = REPO / "src" / "discord-bridge.py"
+sys.path.insert(0, str(REPO / "src"))
+
+import proactive_routing as _real_proactive_routing_module  # noqa: E402
+from proactive_routing import redirect_target_is_foreign as _real_redirect_target_is_foreign  # noqa: E402
+
+_CFG = tempfile.mkdtemp(prefix="suppression-behavioral-ccd-")
+os.environ["CLAUDE_CONFIG_DIR"] = _CFG
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
+_cfg_discord = Path(_CFG) / "channels" / "discord"
+_cfg_discord.mkdir(parents=True, exist_ok=True)
+(_cfg_discord / "access.json").write_text('{"allowFrom": ["4242"]}')
+
+try:  # pragma: no cover - present in dev, absent in clean CI
+    import discord  # noqa: F401
+except Exception:
+    stub = types.ModuleType("discord")
+    stub.Intents = type("Intents", (), {"default": staticmethod(
+        lambda: type("I", (), {"message_content": False})())})
+    stub.Client = type("Client", (), {"__init__": lambda self, **kw: None,
+                                      "event": staticmethod(lambda fn: fn)})
+    stub.File = type("File", (), {"__init__": lambda self, *a, **kw: None})
+    stub.Message = type("Message", (), {})
+    stub.DMChannel = type("DMChannel", (), {})
+    sys.modules["discord"] = stub
+
+_FAILURES: list[str] = []
+_counter = itertools.count()
+
+
+def fail(msg: str) -> None:
+    _FAILURES.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+
+
+class _Sentinel(Exception):
+    """Breaks the poll loop after exactly one pass."""
+
+
+def _load(source_path: Path):
+    """Load a fresh discord-bridge module instance from `source_path`."""
+    name = f"dbridge_suppression_{next(_counter)}"
+    spec = importlib.util.spec_from_file_location(name, source_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _mutated_bridge_source() -> str:
+    """discord-bridge.py source with BOTH skip-check sites disabled — the
+    exact mutation from qingyun-wu's review, applied to a copy, never the
+    real file: `if has_skip_action(...)` -> `if False and has_skip_action(...)`."""
+    src = BRIDGE.read_text()
+    targets = [
+        "if has_skip_action(_pp.actions):",
+        "if has_skip_action(_parsed_fb.actions):",
+    ]
+    for t in targets:
+        assert src.count(t) == 1, f"expected exactly one occurrence of {t!r}"
+        src = src.replace(t, t.replace("if has_skip_action(", "if False and has_skip_action("))
+    return src
+
+
+def _load_mutated():
+    """Write the mutated source to a temp file and load it as a fresh module
+    — this EXECUTES the mutation rather than matching it as text."""
+    tmp = Path(tempfile.mkdtemp(prefix="suppression-mutated-")) / "discord-bridge.py"
+    tmp.write_text(_mutated_bridge_source())
+    return _load(tmp)
+
+
+class _FenceProxy:
+    """Wraps the real ProactiveClaimFence and records which terminal call the
+    production code reached — `.drop()` (suppressed) vs `.confirm()` (treated
+    as sent) — for the ONE file under test.
+
+    `ProactiveClaimFence.drop()` internally calls `self.confirm()` on itself,
+    not on this wrapper, so that internal call is invisible here: only calls
+    poll_proactive itself makes through `_proactive_fence()` are recorded.
+    This is the direct, executable signal for "does the suppression
+    predicate control the terminal drop" (qingyun-wu's own wording) —
+    independent of whether the body also happens to be empty.
+    """
+
+    def __init__(self, real, calls: list[str]):
+        self._real = real
+        self._calls = calls
+
+    def claim(self, path):
+        return self._real.claim(path)
+
+    def confirm(self, claim):
+        self._calls.append("confirm")
+        return self._real.confirm(claim)
+
+    def drop(self, claim, reason):
+        self._calls.append("drop")
+        return self._real.drop(claim, reason)
+
+    def release(self, claim):
+        return self._real.release(claim)
+
+    def attempts(self, claim):
+        return self._real.attempts(claim)
+
+    def fail(self, claim, exc, progressed, undelivered_dir=None):
+        return self._real.fail(claim, exc, progressed, undelivered_dir=undelivered_dir)
+
+    def recover(self):
+        return self._real.recover()
+
+
+def _run_proactive_pass(db, results_dir: Path) -> tuple[list[str], list[str]]:
+    """One real poll_proactive pass over `results_dir` (a [no-send] file, an
+    ordinary file, or both). Returns (delivered_item_ids, fence_terminal_calls)
+    — whether the DeliveryProvider was invoked and which fence call landed."""
+    db.RESULTS_DIR = results_dir
+    db.ACCESS_FILE = Path(_CFG) / "channels" / "discord" / "access.json"
+    db.presenter_mode_active = lambda *_a, **_k: False
+    db._PROACTIVE_FENCE = None
+    fence_calls: list[str] = []
+    real_fence = db._proactive_fence()  # constructs, bound to results_dir
+    db._PROACTIVE_FENCE = _FenceProxy(real_fence, fence_calls)
+
+    routing = types.ModuleType("proactive_routing")
+    routing.should_claim_proactive_file = lambda *_a, **_k: True
+    routing.redirect_target_is_foreign = _real_redirect_target_is_foreign
+    sys.modules["proactive_routing"] = routing
+
+    delivered: list[str] = []
+
+    from ag2_sparrow.delivery_core.contract import (
+        DeliveryOutcome, DeliveryReceipt, ProviderCapabilities)
+
+    class _Provider:
+        capabilities = ProviderCapabilities()
+
+        def deliver(self, item_id, payload, key):
+            delivered.append(item_id)
+            return DeliveryReceipt(outcome=DeliveryOutcome.CONFIRMED, provider_ref="m1")
+
+        def reconcile(self, attempt):
+            return None
+
+    db._PROACTIVE_PROVIDER = _Provider()
+
+    class _DM:
+        id = 4242
+
+        async def send(self, *a, **kw):
+            pass
+
+    class _User:
+        bot = False
+        name = "owner"
+
+        async def create_dm(self):
+            return _DM()
+
+    class _Client:
+        async def fetch_user(self, _uid):
+            return _User()
+
+        def get_channel(self, _cid):
+            return None
+
+        async def fetch_channel(self, _cid):
+            raise RuntimeError("no channel resolvable in this harness")
+
+    db.client = _Client()
+
+    async def _sleep(_secs):
+        raise _Sentinel()
+
+    orig_sleep = db.asyncio.sleep
+    db.asyncio.sleep = _sleep
+    try:
+        asyncio.run(db.poll_proactive())
+    except _Sentinel:
+        pass
+    finally:
+        db.asyncio.sleep = orig_sleep
+
+    return delivered, fence_calls
+
+
+def _run_dm_fallback_pass(db, results_dir: Path, tasks_dir: Path) -> list[list[str]]:
+    """One real poll_dm_fallback pass over `results_dir`/`tasks_dir`. Returns
+    the argv of every dm-result.py subprocess invocation — whichever files
+    were dispatched to it. Restores the real proactive_routing module in case
+    a prior _run_proactive_pass() stubbed it out."""
+    db.RESULTS_DIR = results_dir
+    db.TASKS_DIR = tasks_dir
+    db.ARCHIVE_TASKS_DIR = tasks_dir / "archive"
+    db.ARCHIVE_RESULTS_DIR = results_dir / "archive"
+    db.pending_replies = {}
+    sys.modules["proactive_routing"] = _real_proactive_routing_module
+
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **_kw):
+        calls.append(list(argv))
+        return types.SimpleNamespace(returncode=0, stdout="sent", stderr="")
+
+    orig_run = db.subprocess.run
+    db.subprocess.run = _fake_run
+
+    async def _sleep(_secs):
+        raise _Sentinel()
+
+    orig_sleep = db.asyncio.sleep
+    db.asyncio.sleep = _sleep
+    try:
+        asyncio.run(db.poll_dm_fallback())
+    except _Sentinel:
+        pass
+    finally:
+        db.asyncio.sleep = orig_sleep
+        db.subprocess.run = orig_run
+
+    return calls
+
+
+def _age_past_grace(*paths: Path) -> None:
+    old = time.time() - 100  # > GRACE_SECONDS (90s), < MAX_RETRY_AGE_SECONDS
+    for p in paths:
+        os.utime(p, (old, old))
+
+
+# --------------------------------------------------------------------------
+
+def check_real_code_honors_the_marker() -> None:
+    """The real, unmutated code: [no-send] must never be attempted, and the
+    ordinary sibling MUST be attempted (positive control). Each file runs in
+    its own pass so the fence-call signal is unambiguous per file."""
+    box1 = Path(tempfile.mkdtemp(prefix="proactive-behavioral-nosend-"))
+    nosend = box1 / "proactive-behavioral-nosend.txt"
+    nosend.write_text("[no-send]\nInternal, must never reach a send attempt.")
+    delivered, calls = _run_proactive_pass(_load(BRIDGE), box1)
+    if nosend.stem in delivered:
+        fail(
+            f"poll_proactive: [no-send] file {nosend.name} reached a DM-send "
+            f"attempt (delivered={delivered!r})"
+        )
+    if calls != ["drop"]:
+        fail(
+            f"poll_proactive: [no-send] file {nosend.name} did not take the "
+            f"fence .drop() (suppressed) path — fence calls were {calls!r}, "
+            "expected ['drop']"
+        )
+
+    box2 = Path(tempfile.mkdtemp(prefix="proactive-behavioral-ordinary-"))
+    ordinary = box2 / "proactive-behavioral-ordinary.txt"
+    ordinary.write_text("Good morning! Here is your briefing.")
+    delivered2, calls2 = _run_proactive_pass(_load(BRIDGE), box2)
+    if ordinary.stem not in delivered2:
+        fail(
+            f"poll_proactive: ordinary file {ordinary.name} was NOT delivered — "
+            f"positive control failed (delivered={delivered2!r})"
+        )
+    if calls2 != ["confirm"]:
+        fail(
+            f"poll_proactive: ordinary file {ordinary.name} did not take the "
+            f"fence .confirm() (sent) path — fence calls were {calls2!r}, "
+            "expected ['confirm']"
+        )
+
+    db2 = _load(BRIDGE)
+    results = Path(tempfile.mkdtemp(prefix="dmfallback-behavioral-results-"))
+    tasks = Path(tempfile.mkdtemp(prefix="dmfallback-behavioral-tasks-"))
+    fb_nosend = results / "question-behavioral-nosend.txt"
+    fb_ordinary = results / "question-behavioral-ordinary.txt"
+    fb_nosend.write_text("[no-send]\nInternal, must never reach dm-result.py.")
+    fb_ordinary.write_text("Here is your answer.")
+    _age_past_grace(fb_nosend, fb_ordinary)
+    calls = _run_dm_fallback_pass(db2, results, tasks)
+    argvs = [" ".join(a) for a in calls]
+    if any(str(fb_nosend) in a for a in argvs):
+        fail(
+            f"poll_dm_fallback: [no-send] file {fb_nosend.name} reached the "
+            f"dm-result.py subprocess (calls={calls!r})"
+        )
+    if not any(str(fb_ordinary) in a for a in argvs):
+        fail(
+            f"poll_dm_fallback: ordinary file {fb_ordinary.name} was NOT "
+            f"dispatched to dm-result.py — positive control failed (calls={calls!r})"
+        )
+
+
+def check_mutation_makes_it_fail() -> None:
+    """Permanent guard: qingyun-wu's exact review mutation, applied to a real
+    executed copy, must flip the [no-send] case from held-back to attempted.
+
+    parse_markers() blanks the body for ANY skip-matched marker regardless of
+    has_skip_action, so delivered-content alone can't see this mutation for
+    poll_proactive — the fence call it reaches can: disabling the predicate
+    flips .drop() -> .confirm(), the terminal-drop control under review."""
+    mdb = _load_mutated()
+    box = Path(tempfile.mkdtemp(prefix="proactive-mutated-"))
+    nosend = box / "proactive-mutated-nosend.txt"
+    nosend.write_text("[no-send]\nInternal, must never reach a send attempt.")
+    _delivered, calls = _run_proactive_pass(mdb, box)
+    if calls == ["drop"]:
+        fail(
+            "mutation-resistance: disabling poll_proactive's skip check "
+            "(if False and has_skip_action(...)) did NOT change the "
+            "[no-send] file's fence outcome away from .drop() — this test "
+            f"cannot detect that mutation (fence calls: {calls!r})"
+        )
+
+    mdb2 = _load_mutated()
+    results = Path(tempfile.mkdtemp(prefix="dmfallback-mutated-results-"))
+    tasks = Path(tempfile.mkdtemp(prefix="dmfallback-mutated-tasks-"))
+    fb_nosend = results / "question-mutated-nosend.txt"
+    fb_nosend.write_text("[no-send]\nInternal, must never reach dm-result.py.")
+    _age_past_grace(fb_nosend)
+    calls = _run_dm_fallback_pass(mdb2, results, tasks)
+    argvs = [" ".join(a) for a in calls]
+    if not any(str(fb_nosend) in a for a in argvs):
+        fail(
+            "mutation-resistance: disabling poll_dm_fallback's skip check "
+            "(if False and has_skip_action(...)) did NOT cause a [no-send] "
+            "file to reach the dm-result.py subprocess — this test cannot "
+            "detect that mutation"
+        )
+
+
+def main() -> int:
+    check_real_code_honors_the_marker()
+    check_mutation_makes_it_fail()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} failure(s)", file=sys.stderr)
+        return 1
+    print(
+        "PASS: poll_proactive/poll_dm_fallback behaviorally honor suppression "
+        "markers, and disabling the check (mutation) makes this test fail"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/proactive-suppression-marker-honored.test.py
+++ b/tests/proactive-suppression-marker-honored.test.py
@@ -1,26 +1,42 @@
 #!/usr/bin/env python3
-"""Structural cross-check that `poll_proactive` in `src/discord-bridge.py`
-honors suppression markers (`[no-send]` / `[REPLIED]` / `[deduped:]`) instead
-of DM-attempting a `proactive-*.txt` body that was never meant to be sent.
+"""Behavioral + structural cross-check that `poll_proactive` in
+`src/discord-bridge.py` honors suppression markers (`[no-send]` /
+`[REPLIED]` / `[deduped:]`) instead of DM-attempting a `proactive-*.txt`
+body that was never meant to be sent.
 
 Sibling bug to the `[channel:]` loud-failure fix (see
 `proactive-channel-redirect-loud-failure.test.py`) and to `poll_dm_fallback`,
 which already honors these markers — its own docstring incorrectly assumed
-`poll_proactive` did too: "Proactive files are handled by `poll_proactive()`
-already, so we don't touch those either." It didn't. A suppression-marked
-proactive file fell through to DM-send; when that attempt failed (or the
-recipient/channel resolution had any hiccup), `ProactiveClaimFence.fail()`
-parked it in `results/undelivered/` FOREVER — the exact quarantine backlog
-`health-check-proactive-quarantine.test.py` guards the symptom of. This test
-guards the cause: the file must never reach a send attempt in the first place.
+`poll_proactive` did too. A suppression-marked proactive file fell through
+to DM-send; when that attempt failed (or the recipient/channel resolution
+had any hiccup), `ProactiveClaimFence.fail()` parked it in
+`results/undelivered/` FOREVER — the exact quarantine backlog
+`health-check-proactive-quarantine.test.py` guards the symptom of. This
+test guards the cause: the file must never reach a send attempt.
 
-Why structural and not behavioral: behavioral testing of `poll_proactive`
-requires async discord.py + a mocked client + mocked channel + mocked DM.
-See `proactive-channel-redirect-loud-failure.test.py`'s own note — that
-setup outweighs the fix. The structural test catches the regression that
-matters: "did someone delete the skip-marker check" / "did the check stop
-using the shared `parse_markers()` grammar" / "did the drop stop happening
-before the DM-send block."
+Per REVIEW.md rule #14 ("never assert on source text as a stand-in for a
+behavioral claim"), the actual skip decision now lives in an importable,
+dependency-light unit — `has_skip_action()` in `src/result_markers.py` —
+and is tested BEHAVIORALLY here with real `parse_markers()` output. A
+regex over `poll_proactive`'s source text could stay green with the check
+disabled outright (e.g. `if False and has_skip_action(...)`) or go red on
+a harmless rename; it cannot substitute for exercising the real decision.
+
+What remains structural (and is legitimate per REVIEW.md's structural
+exception — a policy must not be duplicated) is: (a) a delegation pin
+confirming `poll_proactive`/`poll_dm_fallback` call the shared
+`has_skip_action(` helper rather than reimplementing the check inline,
+and (b) a negative scan proving the old inline `kind == "skip"`
+reimplementation is gone from both branches. Both are paired with the
+behavioral test above, never a substitute for it.
+
+Why the discard-behavior guards (`.drop(`, `continue`, ordering vs. the
+first send call) stay structural: behavioral testing of `poll_proactive`
+itself requires async discord.py + a mocked client + mocked channel +
+mocked DM (see `proactive-channel-redirect-loud-failure.test.py`'s own
+note — that setup outweighs the fix). Those guards catch "did the drop
+stop happening before the DM-send block", a property about control flow
+around the (now-verified) decision, not the decision itself.
 
 Run: python3 tests/proactive-suppression-marker-honored.test.py
 Exit: 0 on pass, 1 on fail.
@@ -33,6 +49,11 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 BRIDGE = REPO / "src" / "discord-bridge.py"
+SRC = REPO / "src"
+
+sys.path.insert(0, str(SRC))
+
+from result_markers import parse_markers, has_skip_action  # noqa: E402
 
 _FAILURES: list[str] = []
 
@@ -45,9 +66,9 @@ def fail(msg: str, ctx: str = "") -> None:
         print(ctx[:1500], file=sys.stderr)
 
 
-def extract_poll_proactive(source: str) -> str:
-    """Return the body of `async def poll_proactive(...)` as a single string."""
-    start = source.find("\nasync def poll_proactive(")
+def extract_func(source: str, name: str) -> str:
+    """Return the body of `async def <name>(...)` as a single string."""
+    start = source.find(f"\nasync def {name}(")
     if start == -1:
         return ""
     after = source[start + 1:]
@@ -56,71 +77,111 @@ def extract_poll_proactive(source: str) -> str:
     return source[start:end]
 
 
-def main() -> int:
-    src = BRIDGE.read_text()
-    func = extract_poll_proactive(src)
-    if not func:
-        return fail("couldn't locate `async def poll_proactive(...)` in discord-bridge.py") or 1
+def check_behavioral() -> None:
+    """The actual skip decision, exercised with real parse_markers() output."""
+    skip_bodies = {
+        "no-send": "[no-send]\nInternal note, nothing to deliver.",
+        "REPLIED": "[REPLIED]\nAlready sent via another path.",
+        "deduped": "[deduped: task-1234]\nSuperseded by the other task.",
+    }
+    for label, body in skip_bodies.items():
+        actions = parse_markers(body).actions
+        if not has_skip_action(actions):
+            fail(
+                f"has_skip_action() returned False for a `{label}` marker body — "
+                "this body must never reach a DM-send attempt",
+                body,
+            )
 
-    # Guard 1: markers come from the shared grammar, not a private regex.
-    # CLAUDE.md: "Marker parsing is centralised — do not re-implement it."
-    if "parse_markers(" not in func:
+    # Positive control: ordinary proactive text (no marker) must NOT be
+    # treated as skip, or a real delivery would silently regress to it.
+    ordinary = "Good morning! Here's your briefing for today: ..."
+    if has_skip_action(parse_markers(ordinary).actions):
         fail(
-            "poll_proactive doesn't call parse_markers() — suppression markers "
-            "must come from the shared src/result_markers.py grammar, not a "
-            "private re-implementation",
+            "has_skip_action() returned True for ordinary, unmarked text — "
+            "this would suppress every normal proactive delivery",
+            ordinary,
+        )
+
+
+def check_delegation_and_no_reimplementation(func: str, fn_name: str) -> None:
+    """Structural: the branch calls the shared helper, not an inline reimplementation.
+
+    Legitimate per REVIEW.md's structural exception (policy must not be
+    duplicated), paired with the behavioral test above — never a substitute."""
+    if "has_skip_action(" not in func:
+        fail(
+            f"{fn_name} doesn't call has_skip_action() — suppression markers "
+            "must go through the shared src/result_markers.py decision, not "
+            "a private re-implementation",
+            func,
+        )
+    if "kind == \"skip\"" in func or "kind=='skip'" in func:
+        fail(
+            f"{fn_name} still contains an inline `kind == \"skip\"` check — "
+            "the reimplementation should have been replaced by has_skip_action(), "
+            "not left alongside it",
             func,
         )
 
-    # Guard 2: it actually checks for a skip-kind action.
-    if "kind == \"skip\"" not in func and "kind=='skip'" not in func:
-        fail(
-            "poll_proactive doesn't check for a skip-kind marker action — "
-            "[no-send]/[REPLIED]/[deduped:] bodies would still be DM-attempted",
-            func,
-        )
 
-    # Guard 3: the skip branch itself must call .drop(...), checked in the
-    # post-skip-check window (not "anywhere in func" — a later, unrelated drop() exists).
-    skip_idx = func.find("kind == \"skip\"")
+def check_discard_behavior(func: str, fn_name: str) -> None:
+    """Structural: control flow around the (now behaviorally-verified) decision."""
+    skip_idx = func.find("has_skip_action(")
     if skip_idx == -1:
-        skip_idx = func.find("kind=='skip'")
-    skip_tail = func[skip_idx:skip_idx + 400] if skip_idx != -1 else ""
-    if ".drop(" not in skip_tail:
+        return  # already reported by check_delegation_and_no_reimplementation
+    skip_tail = func[skip_idx:skip_idx + 500]
+
+    if ".drop(" not in skip_tail and "archive_file(" not in skip_tail:
         fail(
-            "poll_proactive's skip-marker branch doesn't call "
-            "_proactive_fence().drop(...) — a suppressed file must be "
-            "cleanly discarded (unlinked, never DM-attempted), not left to "
-            "reach the send/fail path",
+            f"{fn_name}'s skip-marker branch doesn't cleanly discard the file "
+            "(no .drop(...) / archive_file(...) call nearby) — a suppressed "
+            "file must be discarded, never left to reach the send/fail path",
             skip_tail or func,
         )
 
-    # Guard 4: ordering — the skip check must precede the first send call.
-    # Checks both .send( and deliver_text( — the latter is the real text-DM path.
     send_candidates = [i for i in (func.find(".send("), func.find("deliver_text(")) if i != -1]
     send_idx = min(send_candidates) if send_candidates else -1
-    if skip_idx != -1 and send_idx != -1 and skip_idx > send_idx:
+    if send_idx != -1 and skip_idx > send_idx:
         fail(
-            "the skip-marker check appears AFTER the first send call "
-            "(.send(/deliver_text() in poll_proactive — a suppressed body "
-            "could still be sent before the check runs",
+            f"{fn_name}'s skip-marker check appears AFTER the first send call "
+            "(.send(/deliver_text() — a suppressed body could still be sent "
+            "before the check runs",
             func,
         )
 
-    # Guard 5: the skip branch `continue`s past the rest of the loop body
-    # (does not fall through to redirect/DM resolution).
-    if skip_idx != -1:
-        if "continue" not in skip_tail:
+    if "continue" not in skip_tail:
+        fail(
+            f"{fn_name}'s skip-marker branch doesn't `continue` shortly after — "
+            "it may fall through into redirect/DM-send logic anyway",
+            skip_tail,
+        )
+
+
+def main() -> int:
+    check_behavioral()
+
+    src = BRIDGE.read_text()
+    for fn_name in ("poll_proactive", "poll_dm_fallback"):
+        func = extract_func(src, fn_name)
+        if not func:
+            fail(f"couldn't locate `async def {fn_name}(...)` in discord-bridge.py")
+            continue
+        if "parse_markers(" not in func:
             fail(
-                "the skip-marker branch doesn't `continue` shortly after — "
-                "it may fall through into redirect/DM-send logic anyway",
-                skip_tail,
+                f"{fn_name} doesn't call parse_markers() — suppression markers "
+                "must come from the shared src/result_markers.py grammar, not "
+                "a private re-implementation",
+                func,
             )
+        check_delegation_and_no_reimplementation(func, fn_name)
+        check_discard_behavior(func, fn_name)
 
     if _FAILURES:
         print(f"\n{len(_FAILURES)} failure(s)", file=sys.stderr)
         return 1
-    print("PASS: poll_proactive honors suppression markers (no-send/REPLIED/deduped)")
+    print("PASS: has_skip_action() behaves correctly and poll_proactive/"
+          "poll_dm_fallback delegate to it (no inline reimplementation)")
     return 0
 
 

--- a/tests/proactive-suppression-marker-honored.test.py
+++ b/tests/proactive-suppression-marker-honored.test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Structural cross-check that `poll_proactive` in `src/discord-bridge.py`
+honors suppression markers (`[no-send]` / `[REPLIED]` / `[deduped:]`) instead
+of DM-attempting a `proactive-*.txt` body that was never meant to be sent.
+
+Sibling bug to the `[channel:]` loud-failure fix (see
+`proactive-channel-redirect-loud-failure.test.py`) and to `poll_dm_fallback`,
+which already honors these markers — its own docstring incorrectly assumed
+`poll_proactive` did too: "Proactive files are handled by `poll_proactive()`
+already, so we don't touch those either." It didn't. A suppression-marked
+proactive file fell through to DM-send; when that attempt failed (or the
+recipient/channel resolution had any hiccup), `ProactiveClaimFence.fail()`
+parked it in `results/undelivered/` FOREVER — the exact quarantine backlog
+`health-check-proactive-quarantine.test.py` guards the symptom of. This test
+guards the cause: the file must never reach a send attempt in the first place.
+
+Why structural and not behavioral: behavioral testing of `poll_proactive`
+requires async discord.py + a mocked client + mocked channel + mocked DM.
+See `proactive-channel-redirect-loud-failure.test.py`'s own note — that
+setup outweighs the fix. The structural test catches the regression that
+matters: "did someone delete the skip-marker check" / "did the check stop
+using the shared `parse_markers()` grammar" / "did the drop stop happening
+before the DM-send block."
+
+Run: python3 tests/proactive-suppression-marker-honored.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BRIDGE = REPO / "src" / "discord-bridge.py"
+
+_FAILURES: list[str] = []
+
+
+def fail(msg: str, ctx: str = "") -> None:
+    _FAILURES.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+    if ctx:
+        print("---context---", file=sys.stderr)
+        print(ctx[:1500], file=sys.stderr)
+
+
+def extract_poll_proactive(source: str) -> str:
+    """Return the body of `async def poll_proactive(...)` as a single string."""
+    start = source.find("\nasync def poll_proactive(")
+    if start == -1:
+        return ""
+    after = source[start + 1:]
+    nxt = re.search(r"\n(async def|def) [a-zA-Z_]", after)
+    end = start + 1 + (nxt.start() if nxt else len(after))
+    return source[start:end]
+
+
+def main() -> int:
+    src = BRIDGE.read_text()
+    func = extract_poll_proactive(src)
+    if not func:
+        return fail("couldn't locate `async def poll_proactive(...)` in discord-bridge.py") or 1
+
+    # Guard 1: markers come from the shared grammar, not a private regex.
+    # CLAUDE.md: "Marker parsing is centralised — do not re-implement it."
+    if "parse_markers(" not in func:
+        fail(
+            "poll_proactive doesn't call parse_markers() — suppression markers "
+            "must come from the shared src/result_markers.py grammar, not a "
+            "private re-implementation",
+            func,
+        )
+
+    # Guard 2: it actually checks for a skip-kind action.
+    if "kind == \"skip\"" not in func and "kind=='skip'" not in func:
+        fail(
+            "poll_proactive doesn't check for a skip-kind marker action — "
+            "[no-send]/[REPLIED]/[deduped:] bodies would still be DM-attempted",
+            func,
+        )
+
+    # Guard 3: the skip branch discards the file via the fence's terminal-drop
+    # path (never sent, never parked to undelivered/ on a later failure) —
+    # not confirm()/release() directly, which would either skip the print/log
+    # or leave attempts()-inflating state behind.
+    if ".drop(" not in func:
+        fail(
+            "poll_proactive's skip-marker branch doesn't call "
+            "_proactive_fence().drop(...) — a suppressed file must be "
+            "cleanly discarded (unlinked, never DM-attempted), not left to "
+            "reach the send/fail path",
+            func,
+        )
+
+    # Guard 4: ordering — the skip check must appear BEFORE the first DM send
+    # call in the function, or a suppressed body could still be attempted on
+    # some earlier branch.
+    skip_idx = func.find("kind == \"skip\"")
+    if skip_idx == -1:
+        skip_idx = func.find("kind=='skip'")
+    send_idx = func.find(".send(")
+    if skip_idx != -1 and send_idx != -1 and skip_idx > send_idx:
+        fail(
+            "the skip-marker check appears AFTER the first .send( call in "
+            "poll_proactive — a suppressed body could still be sent before "
+            "the check runs",
+            func,
+        )
+
+    # Guard 5: the skip branch `continue`s past the rest of the loop body
+    # (does not fall through to redirect/DM resolution).
+    if skip_idx != -1:
+        tail = func[skip_idx:skip_idx + 400]
+        if "continue" not in tail:
+            fail(
+                "the skip-marker branch doesn't `continue` shortly after — "
+                "it may fall through into redirect/DM-send logic anyway",
+                tail,
+            )
+
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} failure(s)", file=sys.stderr)
+        return 1
+    print("PASS: poll_proactive honors suppression markers (no-send/REPLIED/deduped)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/proactive-suppression-marker-honored.test.py
+++ b/tests/proactive-suppression-marker-honored.test.py
@@ -80,43 +80,41 @@ def main() -> int:
             func,
         )
 
-    # Guard 3: the skip branch discards the file via the fence's terminal-drop
-    # path (never sent, never parked to undelivered/ on a later failure) —
-    # not confirm()/release() directly, which would either skip the print/log
-    # or leave attempts()-inflating state behind.
-    if ".drop(" not in func:
+    # Guard 3: the skip branch itself must call .drop(...), checked in the
+    # post-skip-check window (not "anywhere in func" — a later, unrelated drop() exists).
+    skip_idx = func.find("kind == \"skip\"")
+    if skip_idx == -1:
+        skip_idx = func.find("kind=='skip'")
+    skip_tail = func[skip_idx:skip_idx + 400] if skip_idx != -1 else ""
+    if ".drop(" not in skip_tail:
         fail(
             "poll_proactive's skip-marker branch doesn't call "
             "_proactive_fence().drop(...) — a suppressed file must be "
             "cleanly discarded (unlinked, never DM-attempted), not left to "
             "reach the send/fail path",
-            func,
+            skip_tail or func,
         )
 
-    # Guard 4: ordering — the skip check must appear BEFORE the first DM send
-    # call in the function, or a suppressed body could still be attempted on
-    # some earlier branch.
-    skip_idx = func.find("kind == \"skip\"")
-    if skip_idx == -1:
-        skip_idx = func.find("kind=='skip'")
-    send_idx = func.find(".send(")
+    # Guard 4: ordering — the skip check must precede the first send call.
+    # Checks both .send( and deliver_text( — the latter is the real text-DM path.
+    send_candidates = [i for i in (func.find(".send("), func.find("deliver_text(")) if i != -1]
+    send_idx = min(send_candidates) if send_candidates else -1
     if skip_idx != -1 and send_idx != -1 and skip_idx > send_idx:
         fail(
-            "the skip-marker check appears AFTER the first .send( call in "
-            "poll_proactive — a suppressed body could still be sent before "
-            "the check runs",
+            "the skip-marker check appears AFTER the first send call "
+            "(.send(/deliver_text() in poll_proactive — a suppressed body "
+            "could still be sent before the check runs",
             func,
         )
 
     # Guard 5: the skip branch `continue`s past the rest of the loop body
     # (does not fall through to redirect/DM resolution).
     if skip_idx != -1:
-        tail = func[skip_idx:skip_idx + 400]
-        if "continue" not in tail:
+        if "continue" not in skip_tail:
             fail(
                 "the skip-marker branch doesn't `continue` shortly after — "
                 "it may fall through into redirect/DM-send logic anyway",
-                tail,
+                skip_tail,
             )
 
     if _FAILURES:


### PR DESCRIPTION
## Problem

`discord-bridge.py`'s `poll_dm_fallback()` checks for skip-kind suppression
markers (`[no-send]` / `[REPLIED]` / `[deduped: ...]`) via `parse_markers()`
before attempting delivery — and its own docstring says `poll_proactive()`
already does the same. It doesn't. A `proactive-*.txt` result body written
with a skip marker still gets DM-attempted by `poll_proactive()`, the
attempt fails (no resolvable recipient for a suppressed item), and
`ProactiveClaimFence.fail()` parks it permanently in `results/undelivered/`
instead of being cleanly discarded. 77 files had accumulated in
`results/undelivered/` this way on the running host before this fix.

Draining that existing 77-item backlog is a separate, owner-gated decision
(deletion of files) and is explicitly **out of scope for this PR** — it's
tracked as a pending question awaiting go-ahead. This PR only stops the
leak going forward.

## Fix

Mirrors `poll_dm_fallback`'s own check, reusing markers already parsed for
the adjacent redirect-marker logic: if any parsed action is skip-kind,
drop the claim via the existing `ProactiveClaimFence.drop()` path (already
used elsewhere in this function for unresolvable recipients) instead of
proceeding to delivery.

## Before/after evidence

**Regression test**, stashing the fix to get pre-fix behavior, then restoring:

```
$ git stash push -- src/discord-bridge.py
$ python3 tests/proactive-suppression-marker-honored.test.py; echo "exit: $?"
FAIL: poll_proactive doesn't check for a skip-kind marker action —
[no-send]/[REPLIED]/[deduped:] bodies would still be DM-attempted
exit: 1

$ git stash pop
$ python3 tests/proactive-suppression-marker-honored.test.py; echo "exit: $?"
PASS: poll_proactive honors suppression markers (no-send/REPLIED/deduped)
exit: 0
```

**Adjacent marker/bridge tests, both green at HEAD:**

```
$ python3 tests/bridge-marker-no-leak.test.py
PASS: bridges route marker decisions through parse_markers + parser strips
all markers from body.

$ python3 tests/sending-suffix-is-proactive-only.test.py
sending-suffix-is-proactive-only: 6/6 passed
```

**`review-checks.sh`:**

```
$ git diff origin/main -- src/discord-bridge.py | bash scripts/review-checks.sh
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Live post-restart round trip (bridge / delivery-loop path)

This touches `discord-bridge.py`'s delivery loop, so per CONTRIBUTING.md a
unit test alone isn't sufficient. This exact fix has been hot-patched and
running live on my host's `discord-bridge.py` process since a restart at
`2026-08-23 08:13:11` (after the source edit at `07:48:07`). Verified a real
round trip against the live process just before opening this PR:

```
$ echo -e '[no-send]\nLive round-trip test ...' > \
    "$WORKSPACE/results/proactive-livetest-quarantine-fix-1787512285.txt"

# ~8s later, from the live discord-bridge.log:
  [proactive] skipped (suppression marker): proactive-livetest-quarantine-fix-1787512285.sending
  [fence] dropping proactive-livetest-quarantine-fix-1787512285.sending: suppression marker (no-send/deduped/REPLIED)

# file is gone from results/, and did NOT land in results/undelivered/:
$ ls "$WORKSPACE/results/proactive-livetest-quarantine-fix-"*
no matches found
$ ls "$WORKSPACE/results/undelivered/"*livetest*
no matches found
```

Also confirmed no new items have landed in `results/undelivered/` since
that same restart (`find results/undelivered/ -newermt '2026-08-23 08:13:11'`
→ 0), consistent with the fix holding under real traffic since deploy.

## Scope

Single concern: the suppression-marker gap in `poll_proactive()`. Does
**not** touch the existing `results/undelivered/` backlog (77 files) —
that drain is a separate, owner-gated decision.
