### PR TITLE
docs: shared-checkout discipline — isolate the writer; a check cannot lock a tree

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,9 +39,9 @@ Machine-readable ownership and lifecycle metadata lives in
 - [Per-host workspace convention](workspace-hosts-convention.md)
 - [Per-host carried-path rules](workspace-per-host-paths.md)
 - [State-sync allowlist design](state-sync-allowlist.md)
-- [Shared-checkout discipline](shared-checkout-discipline.md) — asserting branch
-  and tree state immediately before each write to a concurrently-worked tree,
-  and what each provenance probe can and cannot witness.
+- [Shared-checkout discipline](shared-checkout-discipline.md) — isolating writers
+  rather than checking harder, measuring against an immutable OID, and treating
+  external process observations as context rather than provenance.
 - [Testing and coverage](testing-coverage.md)
 - [Voice-agent test framework](voice-agent-test-framework.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ Machine-readable ownership and lifecycle metadata lives in
 - [Per-host workspace convention](workspace-hosts-convention.md)
 - [Per-host carried-path rules](workspace-per-host-paths.md)
 - [State-sync allowlist design](state-sync-allowlist.md)
+- [Shared-checkout discipline](shared-checkout-discipline.md) — pinning the ref
+  before reading or writing a concurrently-worked tree.
 - [Testing and coverage](testing-coverage.md)
 - [Voice-agent test framework](voice-agent-test-framework.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,8 +39,9 @@ Machine-readable ownership and lifecycle metadata lives in
 - [Per-host workspace convention](workspace-hosts-convention.md)
 - [Per-host carried-path rules](workspace-per-host-paths.md)
 - [State-sync allowlist design](state-sync-allowlist.md)
-- [Shared-checkout discipline](shared-checkout-discipline.md) — pinning the ref
-  before reading or writing a concurrently-worked tree.
+- [Shared-checkout discipline](shared-checkout-discipline.md) — asserting branch
+  and tree state immediately before each write to a concurrently-worked tree,
+  and what each provenance probe can and cannot witness.
 - [Testing and coverage](testing-coverage.md)
 - [Voice-agent test framework](voice-agent-test-framework.md)
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -244,8 +244,8 @@
     "maintainers"
    ],
    "status": "draft",
-   "canonical_for": "pinning branch and ref state before reading or writing a checkout worked by concurrent sessions",
-   "last_verified": "2026-08-23"
+   "canonical_for": "asserting branch and tree state immediately before each write to a checkout worked by concurrent sessions, and the limits of each provenance probe",
+   "last_verified": "2026-08-24"
   },
   "docs/slack-bridge.md": {
    "title": "Slack bridge",

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -244,7 +244,7 @@
     "maintainers"
    ],
    "status": "draft",
-   "canonical_for": "asserting branch and tree state immediately before each write to a checkout worked by concurrent sessions, and the limits of each provenance probe",
+   "canonical_for": "isolating writers on a checkout worked by concurrent sessions, measuring against an immutable OID, and the limits of each provenance probe",
    "last_verified": "2026-08-24"
   },
   "docs/slack-bridge.md": {

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -236,6 +236,17 @@
    "canonical_for": "Claude Code hook event mapping and privacy contract",
    "last_verified": "2026-07-27"
   },
+  "docs/shared-checkout-discipline.md": {
+   "title": "Shared-checkout discipline",
+   "audience": [
+    "agents",
+    "contributors",
+    "maintainers"
+   ],
+   "status": "draft",
+   "canonical_for": "pinning branch and ref state before reading or writing a checkout worked by concurrent sessions",
+   "last_verified": "2026-08-23"
+  },
   "docs/slack-bridge.md": {
    "title": "Slack bridge",
    "audience": [

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -118,12 +118,24 @@ recorded OID naming a revision the process never ran. Treat a startup sha as
 CONTEXT; for a dirty tree or anything lazily imported, require a content or
 import-time witness.
 
-`runtime-identity` is stronger than a build sha alone, and that is the reason it
-works: `src/remote-gateway-bridge.py:117-120` records `loader_sha256` and
-`module_sha256` beside `build_sha`, so it hashes the artifacts it actually loads
-(`tests/gateway-runtime-identity.test.py:224-241` pins that same-HEAD byte drift
-is detected). The content digests are what make it provenance — and they attest
-only the files it hashes, not the whole tree.
+`runtime-identity` is stronger than a build sha alone: `src/remote-gateway-bridge.py:117-120`
+records `loader_sha256` and `module_sha256` beside `build_sha`, so a same-HEAD edit
+is visible where a build sha alone shows nothing
+(`tests/gateway-runtime-identity.test.py:224-241` pins that drift).
+
+**They are startup DISK SNAPSHOTS, not proof of the bytes running.** The loader
+hashes the file and then reads it a second time for `compile`, so a checkout
+switch between those reads leaves the digest describing bytes that were never
+executed. Kewei demonstrated it by interposing the second read: `alternate bytes
+executed = True, reported == disk = True, reported == compiled = False`, while
+the identity suite still passed. The loader's self-hash has the mirror gap —
+Python has already loaded the entrypoint before the path is re-read to hash it.
+
+So treat these digests as drift evidence, which is what they reliably are, and
+not as import provenance. Proving the imported bytes needs the buffer passed to
+`compile` to be the thing hashed, plus a witness taken at import time; that is a
+change to the loader, not to this document. And they attest only the files they
+hash, never the whole tree.
 
 The same holds for anything else that caches at load: config read once at
 startup, a resolved TypeScript module graph, a skill manifest folded into a tool

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -8,66 +8,24 @@ same repository sits next to it. Under those conditions a working tree is a
 shared mutable variable: its branch and its file content change between two of
 your own commands, without either command causing the change.
 
-Three failures on the same day share one root cause — no session pinned the tree
-state at the moment it acted on it.
+Three failures on the same day share one root cause — **no session had exclusive
+use of the tree it was mutating.** Each also shows an expired pin, but that is the
+mechanism by which the missing isolation surfaced, not the defect itself: a pin
+that never expired would still not have stopped a peer from writing.
 
 ## The rule
 
-### 1. Assert the branch immediately before each write
+### 1. Isolate the writer — exclusive mutation is the control
 
-Before `rebase`, `reset`, `checkout`, `commit`, or `push` — before each one, not
-once per pass — assert that `git branch --show-current` is the branch you intend
-to operate on. Do not infer it from what you last did, and do not carry an
-earlier answer forward.
+**No assertion fixes a shared tree, because there is no check-and-write pair a peer
+cannot interleave: `&&` sequences two processes, it does not lock the worktree.**
+Every mutating session gets its own worktree or clone, or every writer participates
+in one ownership lock. Sessions sharing the live tree are **read-only**.
 
-The per-pass form is the trap precisely because it does not look like one: it is
-a real check, it passes, and running it reads as compliance. But what it
-establishes is where the tree *was*. On a variable another session can write,
-that answer expires the moment control leaves your process.
+Everything below is what you do *inside* that boundary, or what you fall back to
+when you genuinely cannot have one. None of it substitutes for the boundary.
 
-**The primary rule is exclusive mutation, not a better check.** No assertion fixes
-this, because there is no check-and-write pair a peer cannot interleave: `&&`
-sequences two processes, it does not lock the worktree. Every mutating session gets
-its own worktree or clone (or every writer participates in one ownership lock);
-sessions sharing the live tree are **read-only**.
-
-A reviewer demonstrated the residual hole in the check-then-act form by forcing one
-switch after the branch read returned `intended`:
-
-```text
-branch-check-returned=intended
-raced-commit-branch=other
-remote-intended-equals-wrong-branch=yes
-```
-
-`git push origin HEAD:"$INTENDED"` names the *destination* and leaves the **source**
-ambient, so when `HEAD` had moved the push fast-forwarded remote `intended` to
-another branch's commit — the unreviewed-code path this document exists to close.
-
-Inside an exclusive boundary, these remain useful as defense-in-depth — never as the
-control itself. Name both ends, so the source cannot be supplied by ambient `HEAD`:
-
-```bash
-[ "$(git branch --show-current)" = "$INTENDED" ] && git commit -m "<message>"
-git push origin "$INTENDED:$INTENDED"   # both ends named; no ambient HEAD
-```
-
-### 2. Cite the ref when a conclusion rests on file content
-
-`grep -rn` over the working tree answers *what is on disk this instant*. In a
-shared checkout that is a different question from *what is in branch X*, and a
-third question from *what is process P running*. Read content through the ref you
-actually mean:
-
-```bash
-git show <ref>:<path>       # what is in branch X
-git grep <pattern> <ref>    # search branch X, not the tree
-```
-
-If you cannot name which of the three questions your measurement answered, you
-have not measured any of them.
-
-### 3. Report the OID, not just the ref — a ref is ambient too
+### 2. Measure against an immutable OID, and report it
 
 "Zero hits" is not a finding. But "zero hits in `origin/<branch>`" is not one
 either: **worktrees share refs**, so a fetch or a peer can move that ref after you
@@ -91,6 +49,59 @@ A bare value gives a reader no way to detect that it was measured against the
 wrong tree state, which is the failure this document exists for; a bare ref gives
 them no way to detect that the state moved underneath it. The obligation is
 heaviest when the report contradicts something the reader observed directly.
+
+**Superseded form — citing the ref alone.** An earlier version of this rule said to
+read content through the ref you mean, which is better than reading the tree but
+still ambient:
+
+`grep -rn` over the working tree answers *what is on disk this instant*. In a
+shared checkout that is a different question from *what is in branch X*, and a
+third question from *what is process P running*. Read content through the ref you
+actually mean:
+
+```bash
+git show <ref>:<path>       # what is in branch X
+git grep <pattern> <ref>    # search branch X, not the tree
+```
+
+If you cannot name which of the three questions your measurement answered, you
+have not measured any of them.
+
+Use it only to decide *which* ref you mean; resolve that ref to an OID before you
+measure, and report the OID.
+
+### 3. Assert the branch before each write — defense in depth, never the control
+
+Before `rebase`, `reset`, `checkout`, `commit`, or `push` — before each one, not
+once per pass — assert that `git branch --show-current` is the branch you intend
+to operate on. Do not infer it from what you last did, and do not carry an
+earlier answer forward.
+
+The per-pass form is the trap precisely because it does not look like one: it is
+a real check, it passes, and running it reads as compliance. But what it
+establishes is where the tree *was*. On a variable another session can write,
+that answer expires the moment control leaves your process.
+
+A reviewer demonstrated the residual hole in the check-then-act form by forcing one
+switch after the branch read returned `intended`:
+
+```text
+branch-check-returned=intended
+raced-commit-branch=other
+remote-intended-equals-wrong-branch=yes
+```
+
+`git push origin HEAD:"$INTENDED"` names the *destination* and leaves the **source**
+ambient, so when `HEAD` had moved the push fast-forwarded remote `intended` to
+another branch's commit — the unreviewed-code path this document exists to close.
+
+Inside an exclusive boundary, these remain useful as defense-in-depth — never as the
+control itself. Name both ends, so the source cannot be supplied by ambient `HEAD`:
+
+```bash
+[ "$(git branch --show-current)" = "$INTENDED" ] && git commit -m "<message>"
+git push origin "$INTENDED:$INTENDED"   # both ends named; no ambient HEAD
+```
 
 ## Corollary: a running process is not its file
 
@@ -258,11 +269,13 @@ rewritten or lost; the author cherry-picked the work onto its own branch as
 to leave it in place. The check here was run and was correct when it ran; it was
 simply a per-pass reading of a variable another session can write.
 
-The three are one defect in three positions: content trusted without pinning the
-ref, branch trusted without pinning it, and a pinned branch trusted after the pin
-had expired. None of them was carelessness about git — each session knew the
-commands it was running. All three came from treating a shared working tree as
-stable state.
+The three are one defect in three positions, and the defect is **an unisolated
+writer**: content trusted from a tree a peer could rewrite, a branch mutated in a
+tree a peer could switch, and a pin that expired because the tree kept moving after
+it was taken. The expired pin is the most tempting to read as "should have
+re-pinned"; it is not, because no re-pin interval closes a window a peer can enter.
+None of them was carelessness about git — each session knew the commands it was
+running. All three came from mutating a working tree nobody owned exclusively.
 
 ## Related
 

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -202,10 +202,29 @@ second-call=main-behaviour
 ```
 
 `src/health-check.py` says the same of skills — re-read from the checkout on every
-invocation. So restoring the tree does clear the parked-tree exposure, and it does
-keep already-imported state; it does **not** make the tree safe to change under a
-live witness. For a witness that must stay stable, use CONTRIBUTING's
-detached-worktree service path rather than parking the shared checkout.
+invocation. So restoring the tree clears the parked-tree exposure **only once the
+working tree is verifiably clean**, and it keeps already-imported state; it does
+**not** make the tree safe to change under a live witness.
+
+The qualifier is load-bearing. `git switch main` moves `HEAD`; it carries any
+*compatible* uncommitted tracked edit across with it rather than discarding it. A
+reviewer switched a tree holding one such edit onto `main` and measured:
+
+```text
+distinct-branches=True branch=main
+head-bytes=main-bytes disk-bytes=uncommitted-pr-bytes status=M service.txt
+live-checkout-branch=ok: live checkout on 'main'
+```
+
+The probe answered `ok` because it reads the branch *name*; a supervised restart at
+that point loads the uncommitted bytes, which exist in no commit anyone reviewed.
+So the remedy is two steps, and the name vouches only for the first: `git switch
+main`, then `git status --porcelain` prints nothing. `health-check.py`'s
+**`live-tree-drift`** probe (`check_live_tree_drift`) is the detector for the
+second half — it was added after tracked dirty files were found running in
+production while existing in no commit. For a witness that must stay stable, use
+CONTRIBUTING's detached-worktree service path rather than parking the shared
+checkout.
 
 That is the same fact as the corollary, read in the other direction. "A running
 process is not its file" is usually stated as a warning — you cannot infer the

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -8,19 +8,30 @@ same repository sits next to it. Under those conditions a working tree is a
 shared mutable variable: its branch and its file content change between two of
 your own commands, without either command causing the change.
 
-Two failures on the same day, from opposite directions, share one root cause —
-neither session pinned the tree state before acting on it.
+Three failures on the same day share one root cause — no session pinned the tree
+state at the moment it acted on it.
 
 ## The rule
 
-### 1. Assert the branch before any write
+### 1. Assert the branch immediately before each write
 
-Before `rebase`, `reset`, `checkout`, `commit`, or `push`, assert that
-`git branch --show-current` is the branch you intend to operate on. Do not infer
-it from what you last did; another session may have moved the tree since.
+Before `rebase`, `reset`, `checkout`, `commit`, or `push` — before each one, not
+once per pass — assert that `git branch --show-current` is the branch you intend
+to operate on. Do not infer it from what you last did, and do not carry an
+earlier answer forward.
+
+The per-pass form is the trap precisely because it does not look like one: it is
+a real check, it passes, and running it reads as compliance. But what it
+establishes is where the tree *was*. On a variable another session can write,
+that answer expires the moment control leaves your process.
+
+Prefer operations that name their target over operations that act on ambient
+`HEAD`. Where the target cannot be named — `commit` — put the assertion in the
+same command as the write, so nothing can interleave between checking and acting:
 
 ```bash
-[ "$(git branch --show-current)" = "$INTENDED" ] || { echo "wrong branch"; exit 1; }
+[ "$(git branch --show-current)" = "$INTENDED" ] && git commit -m "<message>"
+git push origin HEAD:"$INTENDED"    # names the destination; HEAD supplies only the commit
 ```
 
 ### 2. Cite the ref when a conclusion rests on file content
@@ -65,7 +76,7 @@ does.
 
 ## Evidence
 
-Both incidents occurred on 2026-08-23 in one checkout shared by two concurrent
+All three incidents occurred on 2026-08-23 in one checkout shared by concurrent
 agent sessions.
 
 **A worktree read reported as a branch fact.** One session concluded that an
@@ -99,9 +110,28 @@ caught at the `Successfully rebased and updated refs/heads/...` line, never
 pushed, and undone with `git reset --hard` to the origin-matching SHA, verified
 against `git ls-remote`. No lasting damage; disclosed unprompted.
 
-The two are one defect read from opposite ends: one session trusted the tree's
-content without pinning the ref, the other trusted the tree's branch without
-pinning it.
+**A pass's work landed on a branch the tree moved to mid-pass.** A third session
+did check `git branch --show-current` at the start of its pass and got its own
+branch. Its reflog shows what happened next:
+
+```
+checkout: moving from feat/pool-operability to fix/pool-bridge-assigned-blind
+```
+
+That checkout was another session's. Everything after it — edit, added test,
+commit, push — went to the other branch: `4c7c3297` landed on
+`origin/fix/pool-bridge-assigned-blind` on top of `8f3b355a`. The push was a
+clean fast-forward, confirmed with `git merge-base --is-ancestor`, so nothing was
+rewritten or lost; the author cherry-picked the work onto its own branch as
+`54f71855` and disclosed immediately, and the branch owner reviewed it and chose
+to leave it in place. The check here was run and was correct when it ran; it was
+simply a per-pass reading of a variable another session can write.
+
+The three are one defect in three positions: content trusted without pinning the
+ref, branch trusted without pinning it, and a pinned branch trusted after the pin
+had expired. None of them was carelessness about git — each session knew the
+commands it was running. All three came from treating a shared working tree as
+stable state.
 
 ## Related
 

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -107,9 +107,23 @@ git reflog --date=format:'%H:%M:%S'      # host-local, and may not be recoverabl
 
 Measured gaps: start-to-import was **1.218 s** in one control, and `lsof` cwd read
 `/private/tmp` while the module actually came from `src/`. Each is off by an
-amount you cannot bound from outside. **Exact provenance needs a recorded
-revision/import witness** — the process logging its own build sha at startup, as
-`runtime-identity` does — not an inference from these three.
+amount you cannot bound from outside. **Exact provenance needs a witness of the
+BYTES that were imported**, not an inference from these three.
+
+A startup build sha is not by itself that witness. It names the ref at process
+start, which is the imported revision only when execution comes from a verified
+clean, immutable artifact. Two adjacent cases break it: a dirty tree yields the
+same OID for different bytes, and a ref that moves after start leaves the
+recorded OID naming a revision the process never ran. Treat a startup sha as
+CONTEXT; for a dirty tree or anything lazily imported, require a content or
+import-time witness.
+
+`runtime-identity` is stronger than a build sha alone, and that is the reason it
+works: `src/remote-gateway-bridge.py:117-120` records `loader_sha256` and
+`module_sha256` beside `build_sha`, so it hashes the artifacts it actually loads
+(`tests/gateway-runtime-identity.test.py:224-241` pins that same-HEAD byte drift
+is detected). The content digests are what make it provenance — and they attest
+only the files it hashes, not the whole tree.
 
 The same holds for anything else that caches at load: config read once at
 startup, a resolved TypeScript module graph, a skill manifest folded into a tool

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -74,6 +74,33 @@ startup, a resolved TypeScript module graph, a skill manifest folded into a tool
 table. Editing the file does not change what such a process runs; restarting it
 does.
 
+### The inverse: the tree is a pending deploy
+
+The three rules above cover reading the tree and writing it, and the corollary
+covers a process that no longer matches its file. There is a fourth direction
+with no read, no write, and no stale process involved: **changing the tree
+changes what the next restart will load.**
+
+A checkout parked on a non-default ref is a pending deploy of that ref for every
+supervised service that can restart itself. Nothing needs to go wrong for the
+hazard to exist — a `KeepAlive=true` service that crashes during the window comes
+back on whatever the tree holds, and no one issued a deploy.
+
+This repo already ships a detector for it. `health-check.py` warns when the live
+checkout is off the default branch, citing a host that spent four days serving a
+PR branch from a checkout nobody remembered parking there:
+
+```
+live checkout is on branch 'feat/...', expected 'main' — bridges/core
+auto-restart onto this checkout, so a leftover PR-branch checkout ships
+stale/unreviewed code
+```
+
+So: park the shared checkout on a non-default ref only for as long as you are
+watching it, and treat the warn as a deploy notice rather than branch-hygiene
+nagging. Author PRs in worktrees, which have no supervised service pointed at
+them.
+
 ## Evidence
 
 All three incidents occurred on 2026-08-23 in one checkout shared by concurrent

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -1,0 +1,111 @@
+# Shared-checkout discipline
+
+**Status:** Proposed working practice. This document is standalone guidance; it
+does not change any always-loaded agent instruction file.
+
+Several agent sessions work one checkout concurrently, and a sibling clone of the
+same repository sits next to it. Under those conditions a working tree is a
+shared mutable variable: its branch and its file content change between two of
+your own commands, without either command causing the change.
+
+Two failures on the same day, from opposite directions, share one root cause —
+neither session pinned the tree state before acting on it.
+
+## The rule
+
+### 1. Assert the branch before any write
+
+Before `rebase`, `reset`, `checkout`, `commit`, or `push`, assert that
+`git branch --show-current` is the branch you intend to operate on. Do not infer
+it from what you last did; another session may have moved the tree since.
+
+```bash
+[ "$(git branch --show-current)" = "$INTENDED" ] || { echo "wrong branch"; exit 1; }
+```
+
+### 2. Cite the ref when a conclusion rests on file content
+
+`grep -rn` over the working tree answers *what is on disk this instant*. In a
+shared checkout that is a different question from *what is in branch X*, and a
+third question from *what is process P running*. Read content through the ref you
+actually mean:
+
+```bash
+git show <ref>:<path>       # what is in branch X
+git grep <pattern> <ref>    # search branch X, not the tree
+```
+
+If you cannot name which of the three questions your measurement answered, you
+have not measured any of them.
+
+### 3. Report the ref, not just the value
+
+"Zero hits" is not a finding. "Zero hits in `git show origin/<branch>:<path>`" is.
+A bare value gives a reader no way to detect that it was measured against the
+wrong tree state, which is the failure this document exists for. The obligation
+is heaviest when the report contradicts something the reader observed directly.
+
+## Corollary: a running process is not its file
+
+Python binds module-level constants at import. A daemon that imported a module
+hours ago is executing the values the file held *then*, so current file content
+is not evidence about it — in either direction. For a long-lived process the
+discriminating evidence is what it imported at start:
+
+```bash
+ps -o lstart= -p <pid>                   # when it imported
+lsof -a -p <pid> -d cwd                  # which checkout it imported from
+git reflog --date=format:'%H:%M:%S'      # which ref that tree held at that time
+```
+
+The same holds for anything else that caches at load: config read once at
+startup, a resolved TypeScript module graph, a skill manifest folded into a tool
+table. Editing the file does not change what such a process runs; restarting it
+does.
+
+## Evidence
+
+Both incidents occurred on 2026-08-23 in one checkout shared by two concurrent
+agent sessions.
+
+**A worktree read reported as a branch fact.** One session concluded that an
+explicit owner directive had never taken effect: `grep -rn` for
+`SUTANDO_AFFINITY_BUSY_MAX` over the working tree returned zero hits, and a
+`git grep` on the base branch also returned zero. Both greps were correct.
+`git reflog --date=format:'%H:%M:%S'` showed when they ran:
+
+```
+12:08:47 rebase (start): checkout origin/feat/lead-follower-pool
+12:11:01 rebase (finish): returning to refs/heads/feat/lead-follower-pool
+```
+
+The greps ran inside that window — another session's rebase, during which HEAD
+detaches to the base and the working tree transiently holds base content. The
+tree read was therefore neither branch the conclusion was about. The setting was
+live the whole time, at `src/runtime-api/pool_lead.py:32` on the branch carrying
+it (commit `225767cc`). Cost: a correction sent to the owner telling them to
+distrust a valid evening of observations, then a retraction of that correction.
+
+The same claim carried a second, independently sufficient error. The conclusion
+was about what a daemon started at 11:44:28 was executing; because module
+constants bind at import, no reading of the current file — right or wrong — is
+evidence about that process.
+
+**A branch rebased by the wrong session.** The other session ran
+`git rebase origin/<base>` without first checking `git branch --show-current`.
+The shared tree was sitting on the first session's branch, so the rebase rewrote
+that branch, including a commit the rebasing session had not authored. It was
+caught at the `Successfully rebased and updated refs/heads/...` line, never
+pushed, and undone with `git reset --hard` to the origin-matching SHA, verified
+against `git ls-remote`. No lasting damage; disclosed unprompted.
+
+The two are one defect read from opposite ends: one session trusted the tree's
+content without pinning the ref, the other trusted the tree's branch without
+pinning it.
+
+## Related
+
+- [Testing and coverage](testing-coverage.md) — the same evidence discipline
+  applied to gate output.
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — "The PR body should answer", including
+  running a detached worktree at a PR head instead of switching the live checkout.

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -67,25 +67,49 @@ git grep <pattern> <ref>    # search branch X, not the tree
 If you cannot name which of the three questions your measurement answered, you
 have not measured any of them.
 
-### 3. Report the ref, not just the value
+### 3. Report the OID, not just the ref — a ref is ambient too
 
-"Zero hits" is not a finding. "Zero hits in `git show origin/<branch>:<path>`" is.
+"Zero hits" is not a finding. But "zero hits in `origin/<branch>`" is not one
+either: **worktrees share refs**, so a fetch or a peer can move that ref after you
+measured, and the same reported name then identifies two different commits:
+
+```text
+reported-ref=measured oid=9965422e subject=first
+same-reported-ref=measured oid=ba0735b4 subject=second
+```
+
+So resolve the ref to an immutable OID **once**, measure against the OID, and
+report both — the name for meaning, the OID for identity:
+
+```bash
+OID=$(git rev-parse "origin/$BRANCH")     # pin ONCE
+git grep <pattern> "$OID" -- <path>       # measure the pinned state
+echo "zero hits in origin/$BRANCH ($OID)" # report both
+```
+
 A bare value gives a reader no way to detect that it was measured against the
-wrong tree state, which is the failure this document exists for. The obligation
-is heaviest when the report contradicts something the reader observed directly.
+wrong tree state, which is the failure this document exists for; a bare ref gives
+them no way to detect that the state moved underneath it. The obligation is
+heaviest when the report contradicts something the reader observed directly.
 
 ## Corollary: a running process is not its file
 
 Python binds module-level constants at import. A daemon that imported a module
 hours ago is executing the values the file held *then*, so current file content
-is not evidence about it — in either direction. For a long-lived process the
-discriminating evidence is what it imported at start:
+is not evidence about it — in either direction. What you want is the revision it
+imported; what these commands give you is **context, not proof**:
 
 ```bash
-ps -o lstart= -p <pid>                   # when it imported
-lsof -a -p <pid> -d cwd                  # which checkout it imported from
-git reflog --date=format:'%H:%M:%S'      # which ref that tree held at that time
+ps -o lstart= -p <pid>                   # process START — not import time
+lsof -a -p <pid> -d cwd                  # CURRENT cwd — not module provenance
+git reflog --date=format:'%H:%M:%S'      # host-local, and may not be recoverable
 ```
+
+Measured gaps: start-to-import was **1.218 s** in one control, and `lsof` cwd read
+`/private/tmp` while the module actually came from `src/`. Each is off by an
+amount you cannot bound from outside. **Exact provenance needs a recorded
+revision/import witness** — the process logging its own build sha at startup, as
+`runtime-identity` does — not an inference from these three.
 
 The same holds for anything else that caches at load: config read once at
 startup, a resolved TypeScript module graph, a skill manifest folded into a tool
@@ -148,9 +172,12 @@ detached-worktree service path rather than parking the shared checkout.
 
 That is the same fact as the corollary, read in the other direction. "A running
 process is not its file" is usually stated as a warning — you cannot infer the
-process from the tree. Here it pays: you can clear the parked-tree exposure without
-giving up whatever the deployed tree was giving you. The two readings look opposed
-and are one property.
+process from the tree. Here it pays, but only as narrowly as stated above: you can
+clear the parked-tree exposure without giving up **already-imported state**. It
+does NOT preserve anything re-read from disk, so a disk-backed witness still needs
+a detached worktree. Retargeting a capability path between two calls to the
+production runner changed its output with the parent pid unchanged
+(`parent-pid-before == parent-pid-after`, first call vs second call differing).
 
 ## Evidence
 

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -25,13 +25,31 @@ a real check, it passes, and running it reads as compliance. But what it
 establishes is where the tree *was*. On a variable another session can write,
 that answer expires the moment control leaves your process.
 
-Prefer operations that name their target over operations that act on ambient
-`HEAD`. Where the target cannot be named — `commit` — put the assertion in the
-same command as the write, so nothing can interleave between checking and acting:
+**The primary rule is exclusive mutation, not a better check.** No assertion fixes
+this, because there is no check-and-write pair a peer cannot interleave: `&&`
+sequences two processes, it does not lock the worktree. Every mutating session gets
+its own worktree or clone (or every writer participates in one ownership lock);
+sessions sharing the live tree are **read-only**.
+
+A reviewer demonstrated the residual hole in the check-then-act form by forcing one
+switch after the branch read returned `intended`:
+
+```text
+branch-check-returned=intended
+raced-commit-branch=other
+remote-intended-equals-wrong-branch=yes
+```
+
+`git push origin HEAD:"$INTENDED"` names the *destination* and leaves the **source**
+ambient, so when `HEAD` had moved the push fast-forwarded remote `intended` to
+another branch's commit — the unreviewed-code path this document exists to close.
+
+Inside an exclusive boundary, these remain useful as defense-in-depth — never as the
+control itself. Name both ends, so the source cannot be supplied by ambient `HEAD`:
 
 ```bash
 [ "$(git branch --show-current)" = "$INTENDED" ] && git commit -m "<message>"
-git push origin HEAD:"$INTENDED"    # names the destination; HEAD supplies only the commit
+git push origin "$INTENDED:$INTENDED"   # both ends named; no ambient HEAD
 ```
 
 ### 2. Cite the ref when a conclusion rests on file content
@@ -107,11 +125,26 @@ them.
 **The remedy is narrower than "never park the tree", and the corollary above is
 why.** The reason parking feels necessary is usually that a branch had to be
 deployed for a live witness, so restoring the checkout looks like it costs you the
-evidence. It does not. Because a running process binds its code at import,
-`git switch main` leaves the already-running services exactly as they were — same
-pids, same behaviour — and changes only what a *future* restart would load.
-Measured by a reviewer on their own host: after `git switch main`, both bridge pids
-were unchanged and still serving, and the probe returned to `ok`.
+evidence. It does not — but the guarantee is narrower than "same pid, same
+behaviour". `git switch main` preserves **already-imported module state**; it does
+not preserve anything the process re-reads from disk. Lazy imports, subprocesses and
+per-call file reads all change under a stable pid. In this repo the bridges resolve
+`skills/audio-transcribe/scripts/transcribe.py` per attachment and
+`src/optional_script.py` starts that on-disk script on every call, so a reviewer
+drove the production runner across a switch and got:
+
+```text
+parent-pid-before=30169
+first-call=pr-branch-behaviour
+parent-pid-after=30169
+second-call=main-behaviour
+```
+
+`src/health-check.py` says the same of skills — re-read from the checkout on every
+invocation. So restoring the tree does clear the parked-tree exposure, and it does
+keep already-imported state; it does **not** make the tree safe to change under a
+live witness. For a witness that must stay stable, use CONTRIBUTING's
+detached-worktree service path rather than parking the shared checkout.
 
 That is the same fact as the corollary, read in the other direction. "A running
 process is not its file" is usually stated as a warning — you cannot infer the

--- a/docs/shared-checkout-discipline.md
+++ b/docs/shared-checkout-discipline.md
@@ -86,9 +86,12 @@ supervised service that can restart itself. Nothing needs to go wrong for the
 hazard to exist — a `KeepAlive=true` service that crashes during the window comes
 back on whatever the tree holds, and no one issued a deploy.
 
-This repo already ships a detector for it. `health-check.py` warns when the live
-checkout is off the default branch, citing a host that spent four days serving a
-PR branch from a checkout nobody remembered parking there:
+This repo already ships a detector for it: the **`live-checkout-branch`** probe in
+`health-check.py`. Naming it matters — a rule with a live detector behind it is
+enforceable, and one without is the discipline-versus-mechanism gap this document
+exists to close. It warns when the live checkout is off the default branch, citing
+a host that spent four days serving a PR branch from a checkout nobody remembered
+parking there:
 
 ```
 live checkout is on branch 'feat/...', expected 'main' — bridges/core
@@ -100,6 +103,21 @@ So: park the shared checkout on a non-default ref only for as long as you are
 watching it, and treat the warn as a deploy notice rather than branch-hygiene
 nagging. Author PRs in worktrees, which have no supervised service pointed at
 them.
+
+**The remedy is narrower than "never park the tree", and the corollary above is
+why.** The reason parking feels necessary is usually that a branch had to be
+deployed for a live witness, so restoring the checkout looks like it costs you the
+evidence. It does not. Because a running process binds its code at import,
+`git switch main` leaves the already-running services exactly as they were — same
+pids, same behaviour — and changes only what a *future* restart would load.
+Measured by a reviewer on their own host: after `git switch main`, both bridge pids
+were unchanged and still serving, and the probe returned to `ok`.
+
+That is the same fact as the corollary, read in the other direction. "A running
+process is not its file" is usually stated as a warning — you cannot infer the
+process from the tree. Here it pays: you can clear the parked-tree exposure without
+giving up whatever the deployed tree was giving you. The two readings look opposed
+and are one property.
 
 ## Evidence
 


### PR DESCRIPTION
## What changed, and why

Adds `docs/shared-checkout-discipline.md` — a working-practice guard for a checkout worked by several concurrent agent sessions. Three failures on 2026-08-23, from opposite directions, had one root cause: **no session had exclusive use of the tree it was mutating.** Each also shows an expired pin, but that is how the missing isolation surfaced, not the defect — a pin that never expired still would not have stopped a peer from writing.

The doc states three rules and one corollary:

1. **Isolate the writer — exclusive mutation is the control.** No assertion fixes a shared tree, because there is no check-and-write pair a peer cannot interleave: `&&` sequences two processes, it does not lock the worktree. Every mutating session gets its own worktree or clone, or every writer participates in one ownership lock; sessions sharing the live tree are read-only. Rules 2 and 3 are what you do *inside* that boundary.
2. **Measure against an immutable OID, and report it.** Worktrees share refs, so a fetch or a peer can move a ref after you measured and the same reported name then identifies two different commits. Resolve once with `git rev-parse`, measure against the OID, report both. Reading through a ref (`git show <ref>:<path>`) is kept as a **superseded form** — it is how you decide *which* ref you mean, not a measurement.
3. **Assert the branch before each write — defense in depth, never the control.** Useful inside an exclusive boundary; on a shared tree it establishes only where the tree *was*.
4. Corollary — a running process is not its file. Python binds module constants at import, so current file content is not evidence about a daemon that imported hours ago. `ps -o lstart=`, `lsof -a -p <pid> -d cwd` and `git reflog` are **context, not proof** — measured, start-to-import was 1.218 s in one control and `lsof` cwd read `/private/tmp` while the module actually came from `src/`. Exact provenance needs a witness of the BYTES that were imported.

**This is a proposal for a standalone doc.** I deliberately did **not** edit `CLAUDE.md` or `AGENTS.md`. The write-up was requested by a peer agent, not by the repo owner, and editing the always-loaded instruction files on a peer's request is out of bounds — the repo also requires every `CLAUDE.md` edit to be mirrored into `AGENTS.md`, which is a second reason not to touch them unasked. Promoting any of this into the always-loaded instructions is the owner's call; the doc is filed with `status: draft` so that call stays open.

## What files should reviewers look at first?

`docs/shared-checkout-discipline.md` (the whole thing — 285 lines at the current head). `docs/README.md` and `docs/catalog.json` are the index/metadata entries the documentation contract requires for any new `docs/**/*.md`.

## What user behavior or bug does this prove?

No code path changes. The evidence is three incidents in a checkout shared by concurrent agent sessions, both reproduced in the doc:

**1. A worktree read reported as a branch fact.** One session concluded an explicit owner directive had never taken effect: `grep -rn` for `SUTANDO_AFFINITY_BUSY_MAX` over the working tree returned zero, and `git grep` on the base branch also returned zero. Both greps were correct. The reflog showed *when* they ran:

```
12:08:47 rebase (start): checkout origin/feat/lead-follower-pool
12:11:01 rebase (finish): returning to refs/heads/feat/lead-follower-pool
```

The greps landed inside another session's rebase window, during which HEAD detaches to the base and the tree transiently holds base content — so the tree read was neither branch the conclusion was about. The setting was live the whole time. Verified at this commit:

```
$ git show 225767cc --stat
commit 225767cc275a37bb7d6fd4f7a45e3e438c84a0a3
    feat(pool): SUTANDO_AFFINITY_BUSY_MAX env tunable — yield-at-1 favors latency
 src/runtime-api/pool_lead.py | 4 +++-

$ git show feat/pool-operability:src/runtime-api/pool_lead.py | sed -n 32p
AFFINITY_BUSY_MAX = max(1, int(os.environ.get("SUTANDO_AFFINITY_BUSY_MAX", "3")))
```

Cost: a correction sent to the owner telling them to distrust a valid evening of observations, then a retraction of that correction. The same claim carried a second, independently sufficient error — the conclusion was about what a daemon started at 11:44:28 was executing, and module constants bind at import, so no reading of the current file is evidence about that process.

**2. A branch rebased by the wrong session.** The other session ran `git rebase origin/<base>` without checking `git branch --show-current`. The shared tree was sitting on the first session's branch, so the rebase rewrote that branch, including a commit the rebasing session had not authored. Caught at the `Successfully rebased and updated refs/heads/...` line, never pushed, undone with `git reset --hard` to the origin-matching SHA and verified against `git ls-remote`. No lasting damage; disclosed unprompted.

## Feature/documentation consistency

This PR *is* the documentation change. New doc registered per the documentation contract in `docs/README.md`: linked from the index (Operations), one `docs/catalog.json` entry with `title` / `audience` / `status: draft` / `canonical_for` / `last_verified: 2026-08-23`.

## Before/after evidence

Docs audit, which enforces "every Markdown doc under `docs/` is indexed and catalogued":

```
$ git checkout origin/main -- docs/README.md docs/catalog.json   # index/catalog at parent
$ python3 skills/release/scripts/docs_audit.py
docs-audit: ERROR: docs/README.md: unindexed document: docs/shared-checkout-discipline.md
docs-audit: ERROR: docs/catalog.json: missing metadata for docs/shared-checkout-discipline.md
docs-audit: FAIL (2 error(s))
AUDIT_RC=1

$ git checkout HEAD -- docs/README.md docs/catalog.json          # at HEAD
$ python3 skills/release/scripts/docs_audit.py
docs-audit: PASS (38 indexed docs; 41 Markdown files checked)
AUDIT_RC=0
```

Repo review gate on this PR's diff (RC captured directly, not through a pipe):

```
$ git diff origin/main...HEAD > /tmp/scd-pr.diff
$ bash scripts/review-checks.sh --diff /tmp/scd-pr.diff
prose-cap: no in-scope files (exts .py); nothing was scanned
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
RC=0
```

`PARTIAL` is the expected verdict for a docs-only diff — `prose_exts` in `REVIEW.md` is `['.py']`, so prose-cap has nothing in scope. hardcoded-paths and root-artifacts both scanned and came back clean.

## Hardcoded-path check

Clean per the gate run above, but **the reasoning I originally gave for that was wrong twice**, and Kewei caught it.

The doc *does* contain a `/private/tmp` occurrence (`docs/shared-checkout-discipline.md:120`), inside a quoted `lsof` measurement. And the gate would not have flagged it either way: `prose_exts` in `REVIEW.md` is `['.py']`, so the scan does not read Markdown at all. The original claim — that a doc quoting a real host path "would fail the very gate it asks people to run" — was circular and false.

The occurrence is evidence rather than an operational path, so it stays. What is corrected is the claim about check coverage: this diff is clean because nothing in it is scanned, not because it passed a scan.

## Live path?

N/A — documentation only, no code path touched.

## Stacked PR?

No. Branched from `origin/main` deliberately, not from either pool branch — both have another session actively pushing to them.

## Tests

- `python3 skills/release/scripts/docs_audit.py` → PASS (output above)
- `bash scripts/review-checks.sh --diff <diff>` → RC=0 (output above)
- `python3 -c "import json; json.load(open('docs/catalog.json'))"` → valid JSON

## Deliberately left out

- No `CLAUDE.md` / `AGENTS.md` edit (see above).
- No enforcement script or CI check. The rules are judgment calls about *when* a measurement is load-bearing; a mechanical check that flagged every `grep -rn` would be noise. If the owner wants this enforced rather than documented, that is a separate change with a separate design.

---

## Amendment (`d2fa69d3`) — a third incident defeated rule 1 as originally written

A third failure occurred in the same shared checkout after the doc was written, and rule 1 in its
original per-pass form did not catch it. The session **did** run
`git branch --show-current` at the start of its pass and got its own branch. Mid-pass the shared
tree moved — its reflog carries a `checkout: moving from feat/pool-operability to
fix/pool-bridge-assigned-blind` it did not run — and every write that followed (edit, added test,
commit, push) landed on the other session's branch: `4c7c3297` on top of `8f3b355a`. Clean
fast-forward, verified with `git merge-base --is-ancestor`; nothing rewritten or lost. The author
cherry-picked the work onto its own branch as `54f71855` and disclosed immediately, and the branch
owner reviewed it and chose to leave it in place.

That is what makes the weaker form a *trap* rather than an omission — it is a real check, it passes,
and running it reads as compliance. What it establishes is where the tree *was*.

What the amendment changes:

1. ~~Rule 1 now requires the assertion immediately before each writing operation~~ —
   **superseded at the current head.** The per-write assertion is rule 3, defense in depth and
   never the control. Rule 1 is **writer isolation**: a shared tree has no check-and-write pair a
   peer cannot interleave (`&&` sequences two processes; it does not lock the worktree), so the
   "assertion and action in one command" form is demoted, not recommended.
2. ~~`git push origin HEAD:<branch>` names the target~~ — **superseded.** That form names only
   the *destination*; the source is still ambient `HEAD`. Reviewer control at this head:
   `ambient-source-control checked=intended current=other remote-intended-is-wrong=True` versus
   `named-both-ends current=other remote-intended-stayed-base=True`. The doc's form is
   `git push origin "$INTENDED:$INTENDED"` — both ends named — issued from an isolated writer.
3. **The incident is added to Evidence** in the existing style (mechanism-first, roles not handles),
   and the closing line now reads all three as one defect in three positions: none was carelessness
   about git, all three came from treating a shared working tree as stable state.

Unchanged: no `CLAUDE.md` / `AGENTS.md` edit — promotion into the always-loaded instructions remains
the owner's call, and the doc stays `status: draft`. Rules 2/3 and the corollary are untouched.

**`docs/catalog.json` not touched.** The convention on a content change is to bump `last_verified` to
the date the doc was verified (e.g. `3a43bc97`, `2026-08-01 -> 2026-08-02`). This entry already reads
`last_verified: 2026-08-23`, which is the date of this amendment, so the convention is already
satisfied and a no-op edit would be noise.

### Gate evidence at `d2fa69d3`

RC captured directly, not through a pipe:

```
$ bash scripts/review-checks.sh --diff <diff>
prose-cap: no in-scope files (exts .py); nothing was scanned
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
RC=0

$ python3 skills/release/scripts/docs_audit.py
docs-audit: PASS (38 indexed docs; 41 Markdown files checked)
AUDIT_RC=0

$ python3 -c "import json; json.load(open('docs/catalog.json'))"
catalog JSON ok
```

`PARTIAL` is unchanged and expected for a docs-only diff. The added text keeps the `<ref>` / `<path>`
/ `<base>` placeholder convention and names no absolute checkout path, so hardcoded-paths stays
clean.

Author: @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Amendment 2 (`4d26fd60`) — `git switch main` is half a remedy

Reviewer control: a tree holding a compatible uncommitted tracked edit, switched to `main`, reads
`branch=main`, `status=M service.txt`, and `live-checkout-branch=ok` — and a supervised restart there
loads bytes that exist in no commit. The pending-deploy section now states the two-step remedy
(`git switch main`, then `git status --porcelain` prints nothing) and names the `live-tree-drift`
probe (`check_live_tree_drift`, on `main`) as the detector for the second half.
