### PR TITLE
fix(results): pair every result write to the task it answers (both single-core entries)

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -128,6 +128,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`result_markers.py`** — Unified parsing for the result-body protocol markers used by every delivery consumer (discord, slack, telegram, remote-gateway, voice/task-bridge, and the `src/dm-result.py` REST fallback).
 - **`result_ready.py`** — Alias of `delivery.readiness` (phase-1a restructure); one transition window.
 - **`result_router.py`** — Alias of `delivery.router` (phase-1a restructure); one transition window.
+- **`result_write.py`** — Paired result write — the one validating writer for `results/task-<id>.txt`.
 - **`runtime-health.py`** — runtime-health.py — derive this Sutando core's live health as one JSON object.
 - **`scan-call-logs.py`** — Proactive call log scanner — detects issues and classifies by actionability.
 - **`schedule-crons-session-hint.sh`** — SessionStart hook — reminds the core agent to run /startup at the start of every session (including post-compaction restarts).

--- a/packages/ag2-sparrow/ag2_sparrow/result_ready.py
+++ b/packages/ag2-sparrow/ag2_sparrow/result_ready.py
@@ -27,12 +27,18 @@ def is_ready_body(text: str | None) -> bool:
     return bool(text and text.strip())
 
 
-def read_ready_result(path: str | Path) -> str | None:
+def read_ready_result(path: str | Path, attests=None) -> str | None:
     """Return the stripped body of `path`, or None when it is not ready.
 
     None covers missing, unreadable and empty-or-whitespace-only files. Callers
     skip on None and retry on a later pass — the file is not consumed, so a
     result that lands between passes is still delivered.
+
+    `attests` is an optional predicate the caller injects to verify the body is
+    the one written for its task. It receives the RAW published bytes, before
+    stripping: a receipt covers what was written, so verifying the stripped form
+    would reject every body that ends in a newline. This module stays free of
+    the digest itself — the adapter binds it.
     """
     p = Path(path)
     try:
@@ -40,6 +46,8 @@ def read_ready_result(path: str | Path) -> str | None:
     except (OSError, UnicodeDecodeError):
         # Missing, unreadable, or a partial write mid-character. Never
         # deliverable, and readable again on a later pass.
+        return None
+    if attests is not None and not attests(body):
         return None
     body = body.strip()
     return body if body else None

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -111,7 +111,17 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
 ## The numbered loop
 
-1. **Check for tasks.** Look in `tasks/` for voice / Discord / Telegram / phone tasks. Look at `context-drop.txt` for context drops. Process anything found — execute the task, write results to `results/`.
+1. **Check for tasks.** Look in `tasks/` for voice / Discord / Telegram / phone tasks. Look at `context-drop.txt` for context drops. Process anything found — execute the task, then complete it via the completion step below.
+   - **Completion step (required):** the helper is the ONLY sanctioned way to write a result. Compose every result body starting with the line `task: <id>` (the id from the task file's name — `tasks/task-<id>.txt`), then:
+
+     ```bash
+     python3 src/result_write.py write task-<id>.txt <<'EOF'
+     task: <id>
+     <result body>
+     EOF
+     ```
+
+     The `task: <id>` first line is a pairing check: the helper refuses (exit 2, zero writes) if it names a different task — this is what prevents a session holding two tasks at once from writing each reply into the other task's result file, which sends both to the wrong user. The helper strips that line before writing, so users never see it, then writes `results/task-<id>.txt` atomically. Never hand-write that file. Marker-only bodies (`[deduped: …]`, `[no-send]`) go through the helper too — echo line first, marker on the next line.
    - **Access control:** If the task has `access_tier: other` or `access_tier: team`, delegate to a sandboxed agent. Do NOT process non-owner tasks with your full capabilities. Write the sandboxed output to results.
    - Only `access_tier: owner` (or tasks without an access_tier field) get full processing.
    - **Thread consolidation:** when several tasks in a short window are the same continuation thought (e.g. voice over-delegating "yes, right, this is useful…" as 3 separate tasks), put the FULL reply in the latest task's result and put `[deduped: task-<latest-id>]` in each earlier task's result. The bridge silently archives the deduped ones — no voice cascade, no DM duplicates. See CLAUDE.md "Result-body protocol markers" for the full marker list.

--- a/src/agent/codex/cli/task-notifier.sh
+++ b/src/agent/codex/cli/task-notifier.sh
@@ -13,6 +13,8 @@ fi
 RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$(dirname "$TASKS_DIR")/results}"
 TASK_HANDLER_CLAIMS_DIR="$(dirname "$TASKS_DIR")/state/task-event-handler-claims"
 TASK_HANDLER_FALLBACKS_DIR="$(dirname "$TASKS_DIR")/state/task-event-handler-fallbacks"
+RESULT_PAIRING_DIR="${SUTANDO_RESULT_PAIRING_DIR:-$(dirname "$TASKS_DIR")/state/result-pairing}"
+RESULT_WRITER="$REPO/src/result_write.py"
 POLL_INTERVAL="${SUTANDO_NOTIFIER_POLL_INTERVAL:-0.5}"
 COMPLETION_TIMEOUT="${SUTANDO_NOTIFIER_COMPLETION_TIMEOUT:-3600}"
 CORE_READY_TIMEOUT="${SUTANDO_NOTIFIER_CORE_READY_TIMEOUT:-300}"
@@ -121,6 +123,27 @@ has_result() {
   return 1
 }
 
+task_id_of() {
+  local stem="${1%.txt}"
+  printf '%s\n' "${stem#task-}"
+}
+
+# The notifier holds the correct task id; the core holds the body. Nothing else
+# can tell whether the body that landed answers THIS task, so require a receipt.
+assert_result_paired() {
+  local filename="$1" task_id
+  if ! has_result "$filename"; then
+    echo "task-notifier: no result for $filename after ${COMPLETION_TIMEOUT}s; the task turn produced nothing" >&2
+    return 1
+  fi
+  task_id="$(task_id_of "$filename")"
+  if [ ! -f "$RESULT_PAIRING_DIR/task-$task_id.ok" ]; then
+    echo "task-notifier: result for $filename has no pairing receipt in $RESULT_PAIRING_DIR; it was not written through src/result_write.py, so it may answer a different task" >&2
+    return 1
+  fi
+  return 0
+}
+
 core_pane_is_busy() {
   local pane
   pane="$(tmux -S "$TMUX_SOCKET" capture-pane -p -t "$SESSION:0" 2>/dev/null)" || return 0
@@ -205,21 +228,22 @@ PY
 }
 
 submit_task() {
-  local filename="$1" wait_for_result="${2:-0}" prompt started
+  local filename="$1" wait_for_result="${2:-0}" prompt started task_id
   case "$filename" in
     ""|*/*|*..*) return 0 ;;
   esac
+  task_id="$(task_id_of "$filename")"
   # The stream watcher deliberately sweeps pre-existing task files after a
   # restart. Completed tasks remain in tasks/ for dashboard history, so do not
   # replay any task whose bridge result already exists.
   has_result "$filename" && return 0
-  prompt="Sutando task ready: $filename. Read $TASKS_DIR/$filename, follow AGENTS.md, complete the task, and write the result to $RESULTS_DIR/$filename."
+  prompt="Sutando task ready: $filename. Read $TASKS_DIR/$filename, follow AGENTS.md, complete the task, then write the result ONLY with: python3 $RESULT_WRITER write $filename --results-dir $RESULTS_DIR --receipts-dir $RESULT_PAIRING_DIR — result body on stdin, its FIRST line exactly 'task: $task_id'. That line is a pairing check: the helper refuses with zero writes if it names a different task, which is what stops a reply reaching the wrong user; it strips the line and writes $RESULTS_DIR/$filename atomically. Never hand-write that file."
   if ! tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null; then
     exit 0
   fi
   # The managed queue path waits for completion, so a private temp file can
-  # safely live for exactly the task turn.  The diagnostic --event path keeps
-  # its original byte-for-byte prompt and remains fire-and-forget.
+  # safely live for exactly the task turn.  The diagnostic --event path takes
+  # the base prompt with no context suffix, and remains fire-and-forget.
   if [ "$wait_for_result" = "1" ]; then
     prepare_workstream_context "$filename"
     if [ -n "$workstream_context_file" ]; then
@@ -252,12 +276,14 @@ submit_task() {
       fi
       if [ $(( $(date +%s) - started )) -ge "$COMPLETION_TIMEOUT" ]; then
         echo "task-notifier: timed out waiting for result: $filename" >&2
-        clear_workstream_context
-        return 0
+        break
       fi
       sleep "$POLL_INTERVAL"
     done
     clear_workstream_context
+    # A waited turn that produced no result, or one whose result nobody can pair
+    # to this task, is a failure — never report it as a completed delivery.
+    assert_result_paired "$filename" || return 1
   fi
 }
 
@@ -274,6 +300,7 @@ python3 -c \
   "$REPO/src/watch-tasks-stream.sh" "$TASKS_DIR" > "$event_dir/events" &
 watcher_pid=$!
 
+notifier_rc=0
 while IFS= read -r event; do
   case "$event" in
     "TASK_FILE: "*)
@@ -284,7 +311,10 @@ while IFS= read -r event; do
       next_pending_task >/dev/null || continue
       wait_for_core_idle || exit 1
       filename="$(next_pending_task)" || continue
-      submit_task "$filename" 1
+      # Keep draining on a post-condition failure — the task stays durable on
+      # disk — but never exit 0 and let the supervisor log a clean restart.
+      submit_task "$filename" 1 || notifier_rc=1
       ;;
   esac
 done < "$event_dir/events"
+exit "$notifier_rc"

--- a/src/agent/codex/cli/task-notifier.sh
+++ b/src/agent/codex/cli/task-notifier.sh
@@ -137,8 +137,11 @@ assert_result_paired() {
     return 1
   fi
   task_id="$(task_id_of "$filename")"
-  if [ ! -f "$RESULT_PAIRING_DIR/task-$task_id.ok" ]; then
-    echo "task-notifier: result for $filename has no pairing receipt in $RESULT_PAIRING_DIR; it was not written through src/result_write.py, so it may answer a different task" >&2
+  # Attestation, not presence: an empty or stale receipt is exactly what a
+  # presence check cannot tell apart from a matching one.
+  if ! python3 "$REPO/src/result_write.py" attests "$task_id" \
+      --results-dir "$RESULTS_DIR" --receipts-dir "$RESULT_PAIRING_DIR" >/dev/null 2>&1; then
+    echo "task-notifier: the pairing receipt in $RESULT_PAIRING_DIR does not attest the bytes now in $filename; it was not written through src/result_write.py, or it was overwritten, so it may answer a different task" >&2
     return 1
   fi
   return 0

--- a/src/agent/codex/cli/task-notifier.sh
+++ b/src/agent/codex/cli/task-notifier.sh
@@ -237,7 +237,14 @@ submit_task() {
   # restart. Completed tasks remain in tasks/ for dashboard history, so do not
   # replay any task whose bridge result already exists.
   has_result "$filename" && return 0
-  prompt="Sutando task ready: $filename. Read $TASKS_DIR/$filename, follow AGENTS.md, complete the task, then write the result ONLY with: python3 $RESULT_WRITER write $filename --results-dir $RESULTS_DIR --receipts-dir $RESULT_PAIRING_DIR — result body on stdin, its FIRST line exactly 'task: $task_id'. That line is a pairing check: the helper refuses with zero writes if it names a different task, which is what stops a reply reaching the wrong user; it strips the line and writes $RESULTS_DIR/$filename atomically. Never hand-write that file."
+  # The prompt embeds a command Codex will RUN, so every path must survive a
+  # shell: an unquoted workspace containing spaces breaks every completion.
+  local q_writer q_file q_results q_receipts
+  printf -v q_writer   '%q' "$RESULT_WRITER"
+  printf -v q_file     '%q' "$filename"
+  printf -v q_results  '%q' "$RESULTS_DIR"
+  printf -v q_receipts '%q' "$RESULT_PAIRING_DIR"
+  prompt="Sutando task ready: $filename. Read $TASKS_DIR/$filename, follow AGENTS.md, complete the task, then write the result ONLY with: python3 $q_writer write $q_file --results-dir $q_results --receipts-dir $q_receipts — result body on stdin, its FIRST line exactly 'task: $task_id'. That line is a pairing check: the helper refuses with zero writes if it names a different task, which is what stops a reply reaching the wrong user; it strips the line and writes $RESULTS_DIR/$filename atomically. Never hand-write that file."
   if ! tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null; then
     exit 0
   fi

--- a/src/delivery/readiness.py
+++ b/src/delivery/readiness.py
@@ -27,12 +27,18 @@ def is_ready_body(text: str | None) -> bool:
     return bool(text and text.strip())
 
 
-def read_ready_result(path: str | Path) -> str | None:
+def read_ready_result(path: str | Path, attests=None) -> str | None:
     """Return the stripped body of `path`, or None when it is not ready.
 
     None covers missing, unreadable and empty-or-whitespace-only files. Callers
     skip on None and retry on a later pass — the file is not consumed, so a
     result that lands between passes is still delivered.
+
+    `attests` is an optional predicate the caller injects to verify the body is
+    the one written for its task. It receives the RAW published bytes, before
+    stripping: a receipt covers what was written, so verifying the stripped form
+    would reject every body that ends in a newline. This module stays free of
+    the digest itself — the adapter binds it.
     """
     p = Path(path)
     try:
@@ -40,6 +46,8 @@ def read_ready_result(path: str | Path) -> str | None:
     except (OSError, UnicodeDecodeError):
         # Missing, unreadable, or a partial write mid-character. Never
         # deliverable, and readable again on a later pass.
+        return None
+    if attests is not None and not attests(body):
         return None
     body = body.strip()
     return body if body else None

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -154,6 +154,7 @@ from policy.guardrail import engage_rulebook, DISCORD_PROVENANCE  # noqa: E402
 from policy.egress.result import guard_result_for_tier, resolve_access_tier as _resolve_task_tier  # noqa: E402
 
 from delivery.readiness import read_ready_result  # noqa: E402
+from result_write import receipt_verifier, receipts_dir_for  # noqa: E402
 from dedup_recovery import plan_dedup_recovery  # noqa: E402
 from discord_addressee import is_addressed_in_shared_channel, reference_is_reply  # noqa: E402  # pragma: no cover — bridge not unit-imported; addressee logic is covered in discord_addressee.py
 from reply_chain import format_parent_reference, format_reply_chain, format_reply_chain_ids, format_reply_chain_truncation, should_fetch_reply_context, walk_reply_chain  # noqa: E402  # pragma: no cover — bridge not unit-imported; chain formatting is covered in reply_chain.py
@@ -346,6 +347,7 @@ if not TOKEN:
 
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+RECEIPTS_DIR = receipts_dir_for(REPO)
 STATE_DIR = REPO / "state"
 ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
 ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
@@ -4725,7 +4727,9 @@ async def poll_results():
             result_file = RESULTS_DIR / f"{task_id}.txt"
             if result_file.exists():
                 import re
-                reply_text = read_ready_result(result_file)
+                reply_text = read_ready_result(
+                    result_file,
+                    attests=receipt_verifier(RECEIPTS_DIR, task_id))
                 if reply_text is None:
                     await _note_empty_result(task_id, result_file)
                     continue

--- a/src/result_write.py
+++ b/src/result_write.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Paired result write — the one validating writer for `results/task-<id>.txt`.
+
+A session holding two tasks at once can compose a reply for A and write it into
+B's result file; nothing downstream can tell, because a result file carries no
+statement of which task it answers. Both replies then reach the wrong user. The
+fix is to make the writer refuse a body that does not name its task: the body's
+FIRST line must be exactly `task: <id>`, matching the id the caller was told to
+answer. On mismatch nothing is written at all — not a partial file, not a temp
+file. On success the echo line is stripped (users never see it) and the result
+lands atomically under the canonical `task-<id>.txt` name.
+
+This is the protocol layer, shared by every runtime's completion step: the
+Claude entry (`skills/proactive-loop/SKILL.md`), the Codex entry
+(`src/agent/codex/cli/task-notifier.sh`), and the pool follower. Runtimes differ
+in how they learn about a task and what else completion entails (done-flags,
+archiving); the pairing rule and the atomic write do not, so they live here once.
+
+`write_paired_result` also drops a pairing receipt under
+`state/result-pairing/`. That receipt is what lets an EXTERNAL process — one
+holding the correct task id but not the body — distinguish "the agent completed
+this task through the sanctioned path" from "a file with the right name
+appeared". Without it, an after-the-fact reader cannot recover the pairing,
+because the echo line is stripped before the body is written.
+
+Task-file (read-side) schema lives in `src/local_task_protocol.py`; result-body
+markers live in `src/result_markers.py`. Stdlib only, no network, no daemon.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+RECEIPTS_SUBPATH = ("state", "result-pairing")
+
+
+def task_id_from(name: str) -> str:
+    """Accept a task id, a task filename, or a result filename; return the id.
+
+    Callers hold different spellings of the same thing — the notifier knows
+    `task-123.txt`, the pool knows `123`. Normalizing here keeps ONE accepted
+    spelling in the body (`task: 123`), so laxity about the argument never
+    becomes laxity about the check.
+    """
+    value = str(name).strip()
+    if not value:
+        raise ValueError("empty task id")
+    value = Path(value).name
+    if value.endswith(".txt"):
+        value = value[:-len(".txt")]
+    if value.startswith("task-"):
+        value = value[len("task-"):]
+    if not value or "/" in value or value in (".", ".."):
+        raise ValueError(f"unusable task id: {name!r}")
+    return value
+
+
+def strip_pairing_echo(task_id: str, body: str) -> str:
+    """Return the body minus its `task: <id>` first line, or raise ValueError.
+
+    Pure — it decides, it does not write. The caller must not write anything
+    until this has returned.
+    """
+    if not body or not body.strip():
+        raise ValueError("empty result body")
+    first, _, rest = body.partition("\n")
+    if first.rstrip("\r") != f"task: {task_id}":
+        raise ValueError(
+            f"pairing echo mismatch: need 'task: {task_id}' "
+            f"as first line, got {first!r}")
+    if not rest.strip():
+        raise ValueError("result body is only the pairing echo line")
+    return rest
+
+
+def receipts_dir_for(workspace) -> Path:
+    return Path(workspace).joinpath(*RECEIPTS_SUBPATH)
+
+
+def receipt_path(receipts_dir, task_id: str) -> Path:
+    return Path(receipts_dir) / f"task-{task_id}.ok"
+
+
+def has_pairing_receipt(receipts_dir, task_id: str) -> bool:
+    try:
+        return receipt_path(receipts_dir, task_id).is_file()
+    except OSError:
+        return False
+
+
+def write_paired_result(results_dir, task_id: str, body: str,
+                        receipts_dir=None, tmp_tag: str = "") -> Path:
+    """Validate the pairing echo, then write `results/task-<id>.txt` atomically.
+
+    Refuses with ValueError and ZERO writes when the echo does not match.
+    `tmp_tag` disambiguates the temp file when several writers share a results
+    directory. The receipt is best-effort: a result already durable on disk must
+    never be rolled back because a diagnostic sidecar could not be written.
+    """
+    task_id = task_id_from(task_id)
+    rest = strip_pairing_echo(task_id, body)
+
+    results = Path(results_dir)
+    results.mkdir(parents=True, exist_ok=True)
+    result = results / f"task-{task_id}.txt"
+    suffix = f"-{tmp_tag}" if tmp_tag else ""
+    tmp = results / f".task-{task_id}.txt.tmp{suffix}"
+    tmp.write_text(rest)
+    os.replace(tmp, result)
+
+    if receipts_dir is not None:
+        try:
+            d = Path(receipts_dir)
+            d.mkdir(parents=True, exist_ok=True)
+            receipt_path(d, task_id).write_text("")
+        except OSError as e:
+            print(f"result_write: pairing receipt not written: {e}",
+                  file=sys.stderr)
+    return result
+
+
+def _resolve_dirs(args):
+    """(results_dir, receipts_dir) from explicit flags, else the workspace."""
+    results = args.get("results-dir")
+    receipts = args.get("receipts-dir")
+    if results is None or receipts is None:
+        workspace = args.get("workspace")
+        if workspace is None:
+            sys.path.insert(0, str(Path(__file__).resolve().parent))
+            from workspace_default import resolve_workspace
+            workspace = str(resolve_workspace())
+        if results is None:
+            results = str(Path(workspace) / "results")
+        if receipts is None:
+            receipts = str(receipts_dir_for(workspace))
+    return Path(results), Path(receipts)
+
+
+USAGE = ("usage: result_write.py write <task-id> "
+         "[--workspace DIR] [--results-dir DIR] [--receipts-dir DIR] "
+         "[--tmp-tag TAG]   # result body on stdin")
+
+
+def _write_cli(argv: "list[str]") -> int:
+    if not argv:
+        print(USAGE, file=sys.stderr)
+        return 2
+    task_id, rest = argv[0], argv[1:]
+    opts: "dict[str, str]" = {}
+    while rest:
+        flag = rest.pop(0)
+        if not flag.startswith("--") or not rest:
+            print(USAGE, file=sys.stderr)
+            return 2
+        opts[flag[2:]] = rest.pop(0)
+    if set(opts) - {"workspace", "results-dir", "receipts-dir", "tmp-tag"}:
+        print(USAGE, file=sys.stderr)
+        return 2
+    try:
+        results, receipts = _resolve_dirs(opts)
+        result = write_paired_result(results, task_id, sys.stdin.read(),
+                                     receipts_dir=receipts,
+                                     tmp_tag=opts.get("tmp-tag", ""))
+    except ValueError as e:
+        print(f"result write refused: {e}", file=sys.stderr)
+        return 2
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 2 and sys.argv[1] == "write":
+        sys.exit(_write_cli(sys.argv[2:]))
+    print(USAGE, file=sys.stderr)
+    sys.exit(2)

--- a/src/result_write.py
+++ b/src/result_write.py
@@ -28,6 +28,8 @@ markers live in `src/result_markers.py`. Stdlib only, no network, no daemon.
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import secrets
 import sys
@@ -83,6 +85,27 @@ def receipt_path(receipts_dir, task_id: str) -> Path:
     return Path(receipts_dir) / f"task-{task_id}.ok"
 
 
+def receipt_body(task_id: str, body: str) -> str:
+    """What a receipt attests: which task, and the exact bytes published for it.
+    An empty receipt (every pre-upgrade one) attests neither."""
+    return json.dumps({"task_id": task_id,
+                       "sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+                       "bytes": len(body.encode("utf-8"))}, sort_keys=True) + "\n"
+
+
+def receipt_attests(receipts_dir, task_id: str, body: str) -> bool:
+    """True only when the receipt names THIS task and THESE bytes. Presence is
+    not attestation: an empty or stale receipt answers False."""
+    try:
+        raw = receipt_path(receipts_dir, task_id).read_text()
+        rec = json.loads(raw)
+    except (OSError, ValueError):
+        return False
+    if not isinstance(rec, dict) or rec.get("task_id") != task_id:
+        return False
+    return rec.get("sha256") == hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
 def has_pairing_receipt(receipts_dir, task_id: str) -> bool:
     try:
         return receipt_path(receipts_dir, task_id).is_file()
@@ -116,7 +139,7 @@ def write_paired_result(results_dir, task_id: str, body: str,
         try:
             d = Path(receipts_dir)
             d.mkdir(parents=True, exist_ok=True)
-            receipt_path(d, task_id).write_text("")
+            receipt_path(d, task_id).write_text(receipt_body(task_id, rest))
         except OSError as e:
             print(f"result_write: pairing receipt not written: {e}",
                   file=sys.stderr)

--- a/src/result_write.py
+++ b/src/result_write.py
@@ -106,6 +106,23 @@ def receipt_attests(receipts_dir, task_id: str, body: str) -> bool:
     return rec.get("sha256") == hashlib.sha256(body.encode("utf-8")).hexdigest()
 
 
+def receipt_verifier(receipts_dir, task_id: str):
+    """A readiness predicate for delivery: enforce the digest once a receipt
+    exists, and only then.
+
+    A MISSING receipt is a pre-upgrade result, not a forgery. Requiring one
+    unconditionally would strand every reply written before this shipped — an
+    outage, in the name of a check. That makes this a transition window, not a
+    permanent exemption: once no unreceipted results remain, the caller can
+    drop straight to `receipt_attests`.
+    """
+    def _attests(raw_body: str) -> bool:
+        if not has_pairing_receipt(receipts_dir, task_id):
+            return True
+        return receipt_attests(receipts_dir, task_id, raw_body)
+    return _attests
+
+
 def has_pairing_receipt(receipts_dir, task_id: str) -> bool:
     try:
         return receipt_path(receipts_dir, task_id).is_file()

--- a/src/result_write.py
+++ b/src/result_write.py
@@ -82,7 +82,9 @@ def receipts_dir_for(workspace) -> Path:
 
 
 def receipt_path(receipts_dir, task_id: str) -> Path:
-    return Path(receipts_dir) / f"task-{task_id}.ok"
+    """Accepts `abc` or `task-abc`. Writers hold the bare id; delivery consumers
+    hold the prefixed one, and a lookup that misses fails OPEN — silently."""
+    return Path(receipts_dir) / f"task-{str(task_id).removeprefix('task-')}.ok"
 
 
 def receipt_body(task_id: str, body: str) -> str:
@@ -116,10 +118,12 @@ def receipt_verifier(receipts_dir, task_id: str):
     permanent exemption: once no unreceipted results remain, the caller can
     drop straight to `receipt_attests`.
     """
+    bare = str(task_id).removeprefix("task-")
+
     def _attests(raw_body: str) -> bool:
-        if not has_pairing_receipt(receipts_dir, task_id):
+        if not has_pairing_receipt(receipts_dir, bare):
             return True
-        return receipt_attests(receipts_dir, task_id, raw_body)
+        return receipt_attests(receipts_dir, bare, raw_body)
     return _attests
 
 

--- a/src/result_write.py
+++ b/src/result_write.py
@@ -212,8 +212,40 @@ def _write_cli(argv: "list[str]") -> int:
     return 0
 
 
+def _attests_cli(argv) -> int:
+    """`attests <task_id> [--results-dir X --receipts-dir Y]` -> 0 when the
+    receipt names this task AND the bytes currently in the result file.
+
+    Exists so a shell caller can check ATTESTATION rather than presence: an
+    empty or stale receipt is exactly what presence cannot tell apart.
+    """
+    if not argv:
+        print(USAGE, file=sys.stderr)
+        return 2
+    task_id, rest = argv[0], argv[1:]
+    opts: "dict[str, str]" = {}
+    while rest:
+        flag = rest.pop(0)
+        if not flag.startswith("--") or not rest:
+            print(USAGE, file=sys.stderr)
+            return 2
+        opts[flag[2:]] = rest.pop(0)
+    if set(opts) - {"workspace", "results-dir", "receipts-dir"}:
+        print(USAGE, file=sys.stderr)
+        return 2
+    try:
+        results, receipts = _resolve_dirs(opts)
+        body = (Path(results) / f"task-{task_id}.txt").read_text()
+    except (OSError, ValueError) as e:
+        print(f"result unreadable: {e}", file=sys.stderr)
+        return 1
+    return 0 if receipt_attests(receipts, task_id, body) else 1
+
+
 if __name__ == "__main__":
     if len(sys.argv) >= 2 and sys.argv[1] == "write":
         sys.exit(_write_cli(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "attests":
+        sys.exit(_attests_cli(sys.argv[2:]))
     print(USAGE, file=sys.stderr)
     sys.exit(2)

--- a/src/result_write.py
+++ b/src/result_write.py
@@ -29,6 +29,7 @@ markers live in `src/result_markers.py`. Stdlib only, no network, no daemon.
 from __future__ import annotations
 
 import os
+import secrets
 import sys
 from pathlib import Path
 
@@ -95,8 +96,10 @@ def write_paired_result(results_dir, task_id: str, body: str,
 
     Refuses with ValueError and ZERO writes when the echo does not match.
     `tmp_tag` disambiguates the temp file when several writers share a results
-    directory. The receipt is best-effort: a result already durable on disk must
-    never be rolled back because a diagnostic sidecar could not be written.
+    directory; it defaults to a unique token, because a SHARED temp name lets
+    one writer's os.replace move the file the other is about to replace. The
+    receipt is best-effort: a result already durable on disk must never be
+    rolled back because a diagnostic sidecar could not be written.
     """
     task_id = task_id_from(task_id)
     rest = strip_pairing_echo(task_id, body)
@@ -104,7 +107,7 @@ def write_paired_result(results_dir, task_id: str, body: str,
     results = Path(results_dir)
     results.mkdir(parents=True, exist_ok=True)
     result = results / f"task-{task_id}.txt"
-    suffix = f"-{tmp_tag}" if tmp_tag else ""
+    suffix = f"-{tmp_tag}" if tmp_tag else f"-{os.getpid()}-{secrets.token_hex(8)}"
     tmp = results / f".task-{task_id}.txt.tmp{suffix}"
     tmp.write_text(rest)
     os.replace(tmp, result)

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -83,6 +83,7 @@ except Exception:  # pragma: no cover — best-effort telemetry
         return None
 from result_markers import parse_markers  # noqa: E402
 from delivery.readiness import read_ready_result  # noqa: E402
+from result_write import receipt_verifier, receipts_dir_for  # noqa: E402
 from dedup_recovery import plan_dedup_recovery  # noqa: E402
 from message_chunking import chunk_message  # noqa: E402  (Result Router S3 — shared fence-aware chunker)
 import local_task_protocol  # noqa: E402
@@ -108,6 +109,7 @@ except ImportError:
 REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+RECEIPTS_DIR = receipts_dir_for(REPO)
 STATE_DIR = REPO / "state"
 INBOX_DIR = REPO / "slack-inbox"
 ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
@@ -1551,7 +1553,9 @@ def result_watcher():
                 result_file = RESULTS_DIR / f"{task_id}.txt"
                 if not result_file.exists():
                     continue
-                reply_text = read_ready_result(result_file)
+                reply_text = read_ready_result(
+                    result_file,
+                    attests=receipt_verifier(RECEIPTS_DIR, task_id))
                 if reply_text is None:
                     continue
                 with pending_replies_lock:

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -59,6 +59,7 @@ import local_task_protocol  # noqa: E402
 from result_markers import parse_markers
 from message_chunking import chunk_plain_text  # plain transport: byte-identical chunking  # noqa: E402
 from delivery.readiness import read_ready_result  # noqa: E402
+from result_write import receipt_verifier, receipts_dir_for  # noqa: E402
 from dedup_recovery import plan_dedup_recovery  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 from util_paths import channel_access_path, claude_home_path, write_private_text  # noqa: E402
@@ -74,6 +75,7 @@ from chat_secret_filter import filter_chat_secrets, secret_handling_instruction 
 REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+RECEIPTS_DIR = receipts_dir_for(REPO)
 
 # Allowlist for paths that may be sent via Telegram [file: /path] markers.
 # Mirrors _is_path_sendable() in discord-bridge.py.
@@ -1097,7 +1099,9 @@ def main():  # pragma: no cover
         for task_id in _gather_pending_task_ids(pending_replies, RESULTS_DIR, TASKS_DIR):
             result_file = RESULTS_DIR / f"{task_id}.txt"
             if result_file.exists():
-                reply_text = read_ready_result(result_file)
+                reply_text = read_ready_result(
+                    result_file,
+                    attests=receipt_verifier(RECEIPTS_DIR, task_id))
                 if reply_text is None:
                     continue
                 chat_id = pending_replies.pop(task_id)

--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -17,6 +17,20 @@ REAL_REPO = Path(os.environ.get(
 )).resolve()
 
 
+# tmux stubs stand in for the live core, so they must complete a task the way the
+# core is now told to: through the real writer, which is what mints the receipt.
+STUB_HEADER = r'''#!/bin/bash
+paired_result() {
+  local name="$1" id
+  id="${name%.txt}"; id="${id#task-}"
+  printf 'task: %s\nack\n' "$id" \
+    | python3 "$RESULT_WRITER" write "$name" \
+        --results-dir "$SUTANDO_RESULTS_DIR" \
+        --receipts-dir "$SUTANDO_RESULT_PAIRING_DIR" >/dev/null
+}
+'''
+
+
 def _read_count(path):
     """Read the supervisor's counter file, tolerating a mid-write empty read.
 
@@ -47,6 +61,7 @@ class CodexCoreLauncherTests(unittest.TestCase):
             "src/agent/start-cli.sh",
             "src/local_task_protocol.py",
             "src/result_markers.py",
+            "src/result_write.py",
             "src/task_priority.py",
             "src/task_workstreams.py",
             "src/util_paths.py",
@@ -141,6 +156,13 @@ exit 0
 
     def tearDown(self):
         self.tmp.cleanup()
+
+    def _pairing_env(self, workspace):
+        return {
+            "RESULT_WRITER": str(self.root / "src" / "result_write.py"),
+            "SUTANDO_RESULT_PAIRING_DIR": str(
+                Path(workspace) / "state" / "result-pairing"),
+        }
 
     def _write_exe(self, name, body):
         path = self.bin / name
@@ -802,12 +824,12 @@ exit 0
         watcher.chmod(0o755)
         capture = Path(self.tmp.name) / "context.json"
         context_path = Path(self.tmp.name) / "context-path.txt"
-        self._write_exe("tmux", '''#!/bin/bash
+        self._write_exe("tmux", STUB_HEADER + '''
 printf '%s\n' "$*" >> "$TMUX_LOG"
 [ "${1:-}" = -S ] && shift 2
 if [ "${1:-}" = has-session ]; then exit 0; fi
 if [ "${1:-}" = send-keys ] && [ "${*: -1}" = C-m ]; then
-  touch "$SUTANDO_RESULTS_DIR/task-owner.txt"
+  paired_result task-owner.txt
   exit 0
 fi
 if [ "${1:-}" = send-keys ]; then
@@ -835,6 +857,7 @@ exit 0
             SUTANDO_RESULTS_DIR=str(results),
             SUTANDO_NOTIFIER_POLL_INTERVAL="0.02",
             SUTANDO_NOTIFIER_COMPLETION_TIMEOUT="2",
+            **self._pairing_env(workspace),
         )
         script = self.root / "src/agent/codex/cli/task-notifier.sh"
 
@@ -882,12 +905,12 @@ exit 0
         watcher = self.root / "src/watch-tasks-stream.sh"
         watcher.write_text("#!/bin/bash\nprintf 'TASK_FILE: task-unassigned.txt\\n'\n")
         watcher.chmod(0o755)
-        self._write_exe("tmux", '''#!/bin/bash
+        self._write_exe("tmux", STUB_HEADER + '''
 printf '%s\n' "$*" >> "$TMUX_LOG"
 [ "${1:-}" = -S ] && shift 2
 if [ "${1:-}" = has-session ]; then exit 0; fi
 if [ "${1:-}" = send-keys ] && [ "${*: -1}" = C-m ]; then
-  touch "$SUTANDO_RESULTS_DIR/task-unassigned.txt"
+  paired_result task-unassigned.txt
 fi
 exit 0
 ''')
@@ -901,6 +924,7 @@ exit 0
             SUTANDO_RESULTS_DIR=str(results),
             SUTANDO_NOTIFIER_POLL_INTERVAL="0.02",
             SUTANDO_NOTIFIER_COMPLETION_TIMEOUT="2",
+            **self._pairing_env(workspace),
         )
         script = self.root / "src/agent/codex/cli/task-notifier.sh"
         started = time.monotonic()
@@ -914,6 +938,96 @@ exit 0
         calls = self.log.read_text()
         self.assertIn("task-unassigned.txt", calls)
         self.assertNotIn("Related prior workstream context", calls)
+
+    def _managed_post_condition_run(self, stub_body, timeout="1"):
+        """One managed turn against a stub core; returns the finished process."""
+        workspace = self.root / "workspace"
+        tasks = workspace / "tasks"
+        results = workspace / "results"
+        tasks.mkdir(exist_ok=True)
+        results.mkdir(exist_ok=True)
+        (workspace / "state" / "core-status.json").write_text(
+            '{"status":"idle","ts":1}\n'
+        )
+        (tasks / "task-owner.txt").write_text("priority: normal\ntask: do it\n")
+        watcher = self.root / "src/watch-tasks-stream.sh"
+        watcher.write_text("#!/bin/bash\nprintf 'TASK_FILE: task-owner.txt\\n'\n")
+        watcher.chmod(0o755)
+        self._write_exe("tmux", STUB_HEADER + stub_body)
+        env = dict(
+            os.environ,
+            PATH=f"{self.bin}:/usr/bin:/bin",
+            TMUX_LOG=str(self.log),
+            SUTANDO_TMUX_SOCKET="/tmp/test.sock",
+            SUTANDO_TMUX_SESSION="sutando-core",
+            SUTANDO_TASKS_DIR=str(tasks),
+            SUTANDO_RESULTS_DIR=str(results),
+            SUTANDO_NOTIFIER_POLL_INTERVAL="0.02",
+            SUTANDO_NOTIFIER_COMPLETION_TIMEOUT=timeout,
+            **self._pairing_env(workspace),
+        )
+        script = self.root / "src/agent/codex/cli/task-notifier.sh"
+        return subprocess.run(["/bin/bash", str(script)], env=env,
+                              capture_output=True, text=True, timeout=10)
+
+    def test_managed_notifier_fails_loudly_when_the_turn_produces_no_result(self):
+        """A silent turn used to return success; the queue then looked drained."""
+        result = self._managed_post_condition_run('''
+printf '%s\\n' "$*" >> "$TMUX_LOG"
+[ "${1:-}" = -S ] && shift 2
+if [ "${1:-}" = has-session ]; then exit 0; fi
+exit 0
+''')
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("no result for task-owner.txt", result.stderr)
+
+    def test_managed_notifier_fails_loudly_on_a_result_it_cannot_pair(self):
+        """A file with the right NAME is not evidence it answers this task."""
+        result = self._managed_post_condition_run('''
+printf '%s\\n' "$*" >> "$TMUX_LOG"
+[ "${1:-}" = -S ] && shift 2
+if [ "${1:-}" = has-session ]; then exit 0; fi
+if [ "${1:-}" = send-keys ] && [ "${*: -1}" = C-m ]; then
+  printf 'hand-written, pairing unknown\\n' > "$SUTANDO_RESULTS_DIR/task-owner.txt"
+fi
+exit 0
+''', timeout="5")
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("no pairing receipt", result.stderr)
+        self.assertNotIn("no result for", result.stderr)
+
+    def test_managed_notifier_accepts_a_result_written_through_the_helper(self):
+        """Positive control: the same harness passes when pairing is satisfied."""
+        result = self._managed_post_condition_run('''
+printf '%s\\n' "$*" >> "$TMUX_LOG"
+[ "${1:-}" = -S ] && shift 2
+if [ "${1:-}" = has-session ]; then exit 0; fi
+if [ "${1:-}" = send-keys ] && [ "${*: -1}" = C-m ]; then
+  paired_result task-owner.txt
+fi
+exit 0
+''', timeout="5")
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertNotIn("pairing receipt", result.stderr)
+        self.assertEqual(
+            (self.root / "workspace/results/task-owner.txt").read_text(), "ack\n")
+
+    def test_notifier_prompt_states_the_pairing_requirement(self):
+        env = dict(os.environ, PATH=f"{self.bin}:/usr/bin:/bin", TMUX_LOG=str(self.log),
+                   SUTANDO_TMUX_SOCKET="/tmp/test.sock", SUTANDO_TMUX_SESSION="sutando-core")
+        self._write_exe("tmux", '''#!/bin/bash
+printf '%s\\n' "$*" >> "$TMUX_LOG"
+[ "$3" = has-session ] && exit 0
+exit 0
+''')
+        script = self.root / "src/agent/codex/cli/task-notifier.sh"
+        result = subprocess.run(["/bin/bash", str(script), "--event", "task-123.txt"],
+                                env=env, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text()
+        self.assertIn("src/result_write.py write task-123.txt", calls)
+        self.assertIn("FIRST line exactly 'task: 123'", calls)
+        self.assertIn("Never hand-write that file", calls)
 
     def test_managed_notifier_waits_for_each_result_before_next_task(self):
         workspace = self.root / "workspace"
@@ -930,7 +1044,7 @@ exit 0
         watcher.write_text("#!/bin/bash\nprintf 'TASK_FILE: task-one.txt\\nTASK_FILE: task-two.txt\\n'\n")
         watcher.chmod(0o755)
         count = Path(self.tmp.name) / "submit-count"
-        self._write_exe("tmux", '''#!/bin/bash
+        self._write_exe("tmux", STUB_HEADER + '''
 printf '%s\\n' "$*" >> "$TMUX_LOG"
 [ "${1:-}" = -S ] && shift 2
 if [ "${1:-}" = has-session ]; then exit 0; fi
@@ -938,7 +1052,7 @@ if [ "${1:-}" = send-keys ] && [ "${*: -1}" = C-m ]; then
   n=0; [ -f "$SUBMIT_COUNT" ] && n=$(cat "$SUBMIT_COUNT")
   n=$((n + 1)); printf '%s' "$n" > "$SUBMIT_COUNT"
   if [ "$n" = 1 ]; then name=task-one.txt; else name=task-two.txt; fi
-  (sleep 0.12; touch "$SUTANDO_RESULTS_DIR/$name") >/dev/null 2>&1 &
+  (sleep 0.12; paired_result "$name") >/dev/null 2>&1 &
 fi
 exit 0
 ''')
@@ -946,7 +1060,8 @@ exit 0
                    SUBMIT_COUNT=str(count), SUTANDO_TMUX_SOCKET="/tmp/test.sock",
                    SUTANDO_TMUX_SESSION="sutando-core", SUTANDO_TASKS_DIR=str(tasks),
                    SUTANDO_RESULTS_DIR=str(results), SUTANDO_NOTIFIER_POLL_INTERVAL="0.02",
-                   SUTANDO_NOTIFIER_COMPLETION_TIMEOUT="5")
+                   SUTANDO_NOTIFIER_COMPLETION_TIMEOUT="5",
+                   **self._pairing_env(workspace))
         script = self.root / "src/agent/codex/cli/task-notifier.sh"
         started = time.monotonic()
         result = subprocess.run(["/bin/bash", str(script)], env=env,
@@ -983,7 +1098,7 @@ exit 0
         early = Path(self.tmp.name) / "submitted-while-busy"
         busy = Path(self.tmp.name) / "pane-busy"
         busy.touch()
-        self._write_exe("tmux", '''#!/bin/bash
+        self._write_exe("tmux", STUB_HEADER + '''
 printf '%s\\n' "$*" >> "$TMUX_LOG"
 [ "${1:-}" = -S ] && shift 2
 if [ "${1:-}" = has-session ]; then exit 0; fi
@@ -996,7 +1111,7 @@ if [ "${1:-}" = send-keys ] && [ "${*: -1}" = C-m ]; then
   prompt=$(grep 'Sutando task ready:' "$TMUX_LOG" | tail -1)
   name=${prompt#*Sutando task ready: }
   name=${name%%.*}.txt
-  touch "$SUTANDO_RESULTS_DIR/$name"
+  paired_result "$name"
 fi
 exit 0
 ''')
@@ -1006,7 +1121,8 @@ exit 0
                    SUTANDO_TMUX_SESSION="sutando-core", SUTANDO_TASKS_DIR=str(tasks),
                    SUTANDO_RESULTS_DIR=str(results), SUTANDO_CORE_STATUS_FILE=str(status),
                    SUTANDO_NOTIFIER_POLL_INTERVAL="0.02",
-                   SUTANDO_NOTIFIER_COMPLETION_TIMEOUT="2")
+                   SUTANDO_NOTIFIER_COMPLETION_TIMEOUT="2",
+                   **self._pairing_env(workspace))
         script = self.root / "src/agent/codex/cli/task-notifier.sh"
         process = subprocess.Popen(["/bin/bash", str(script)], env=env,
                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
@@ -1042,7 +1158,7 @@ exit 0
         watcher = self.root / "src/watch-tasks-stream.sh"
         watcher.write_text("#!/bin/bash\nprintf 'TASK_FILE: task-owner.txt\\n'\n")
         watcher.chmod(0o755)
-        self._write_exe("tmux", '''#!/bin/bash
+        self._write_exe("tmux", STUB_HEADER + '''
 printf '%s\\n' "$*" >> "$TMUX_LOG"
 [ "${1:-}" = -S ] && shift 2
 if [ "${1:-}" = has-session ]; then exit 0; fi
@@ -1051,7 +1167,7 @@ if [ "${1:-}" = capture-pane ]; then
   exit 0
 fi
 if [ "${1:-}" = send-keys ] && [ "${*: -1}" = C-m ]; then
-  touch "$SUTANDO_RESULTS_DIR/task-owner.txt"
+  paired_result task-owner.txt
 fi
 exit 0
 ''')
@@ -1066,6 +1182,7 @@ exit 0
             SUTANDO_CORE_STATUS_FILE=str(status),
             SUTANDO_NOTIFIER_POLL_INTERVAL="0.02",
             SUTANDO_NOTIFIER_COMPLETION_TIMEOUT="2",
+            **self._pairing_env(workspace),
         )
         script = self.root / "src/agent/codex/cli/task-notifier.sh"
         result = subprocess.run(

--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -993,8 +993,26 @@ fi
 exit 0
 ''', timeout="5")
         self.assertNotEqual(result.returncode, 0, result.stdout)
-        self.assertIn("no pairing receipt", result.stderr)
+        # The gate moved from presence to attestation; re-pointed rather than
+        # loosened, because a stale receipt also has to fail here.
+        self.assertIn("does not attest the bytes", result.stderr)
         self.assertNotIn("no result for", result.stderr)
+
+    def test_managed_notifier_rejects_a_receipt_that_no_longer_matches(self):
+        """The case presence cannot see: the receipt IS there, minted by the
+        real writer, and the result was overwritten afterwards."""
+        result = self._managed_post_condition_run("""
+printf '%s\\n' "$*" >> "$TMUX_LOG"
+[ "${1:-}" = -S ] && shift 2
+if [ "${1:-}" = has-session ]; then exit 0; fi
+if [ "${1:-}" = send-keys ] && [ "${*: -1}" = C-m ]; then
+  paired_result task-owner.txt
+  printf 'a different answer\\n' > "$SUTANDO_RESULTS_DIR/task-owner.txt"
+fi
+exit 0
+""", timeout="5")
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("does not attest the bytes", result.stderr)
 
     def test_managed_notifier_accepts_a_result_written_through_the_helper(self):
         """Positive control: the same harness passes when pairing is satisfied."""

--- a/tests/codex-notifier-emitted-command-quoting.test.py
+++ b/tests/codex-notifier-emitted-command-quoting.test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""The notifier's prompt embeds a command Codex will RUN. Every interpolated
+path must survive a shell, or an install whose repo or workspace contains a
+space loses every managed completion."""
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+NOTIFIER = REPO / "src" / "agent" / "codex" / "cli" / "task-notifier.sh"
+
+
+class EmittedCommandQuotingTest(unittest.TestCase):
+    def _emit_and_run(self, repo_dir: Path, ws: Path):
+        """Drive the real --event path, take the command it told Codex to run,
+        and actually run it. Returns (rc, stderr, result_exists)."""
+        (ws / "tasks").mkdir(parents=True)
+        (ws / "results").mkdir()
+        (ws / "tasks" / "task-probe.txt").write_text("id: task-probe\n")
+        binp = ws.parent / "bin"
+        binp.mkdir(exist_ok=True)
+        log = ws.parent / "tmux.log"
+        (binp / "tmux").write_text(
+            f'#!/bin/bash\nprintf "%s\\n" "$*" >> {log!s}\nexit 0\n')
+        os.chmod(binp / "tmux", 0o755)
+
+        env = dict(os.environ)
+        env.update({
+            "PATH": f"{binp}:{env['PATH']}",
+            "SUTANDO_TASKS_DIR": str(ws / "tasks"),
+            "SUTANDO_RESULTS_DIR": str(ws / "results"),
+            "SUTANDO_RESULT_PAIRING_DIR": str(ws / "state" / "result-pairing"),
+            "SUTANDO_TMUX_SOCKET": str(ws.parent / "s.sock"),
+        })
+        script = repo_dir / "src" / "agent" / "codex" / "cli" / "task-notifier.sh"
+        subprocess.run(["bash", str(script), "--event", "task-probe.txt"],
+                       env=env, capture_output=True, text=True, timeout=60)
+
+        txt = log.read_text() if log.exists() else ""
+        # A correctly-quoted path contains `\ `, which \S+ cannot cross —
+        # the naive pattern reports "no command" on exactly the fixed case.
+        tok = r"(?:\\.|\S)+"
+        cmd = re.search(
+            rf"(python3 {tok}result_write\.py write .*?--receipts-dir {tok})", txt)
+        self.assertIsNotNone(cmd, "the notifier emitted no write command")
+        # Take the required first line from the prompt itself rather than
+        # re-deriving the id — a re-typed probe drifts from what is instructed.
+        first = re.search(r"FIRST line exactly '([^']+)'", txt)
+        self.assertIsNotNone(first, "prompt no longer states the pairing line")
+        run = subprocess.run(["bash", "-c", cmd.group(1)],
+                             input=first.group(1) + "\nthe answer\n",
+                             capture_output=True, text=True)
+        return run.returncode, run.stderr, (ws / "results" / "task-probe.txt").exists()
+
+    def test_workspace_path_with_spaces(self):
+        with tempfile.TemporaryDirectory() as td:
+            rc, err, wrote = self._emit_and_run(
+                REPO, Path(td) / "workspace with spaces")
+        self.assertEqual(rc, 0, f"emitted command failed: {err.strip()[:120]}")
+        self.assertNotIn("usage:", err, "arguments were split by the shell")
+        self.assertTrue(wrote, "no result written")
+
+    def test_repo_path_with_spaces(self):
+        """$RESULT_WRITER is derived from $REPO, so a spaced repo breaks the
+        same command through a different variable."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "repo with spaces"
+            cli = repo / "src" / "agent" / "codex" / "cli"
+            cli.mkdir(parents=True)
+            shutil.copy2(NOTIFIER, cli / "task-notifier.sh")
+            shutil.copy2(REPO / "src" / "result_write.py",
+                         repo / "src" / "result_write.py")
+            (repo / "scripts").mkdir()
+            shutil.copy2(REPO / "scripts" / "sutando-config.sh",
+                         repo / "scripts" / "sutando-config.sh")
+            rc, err, wrote = self._emit_and_run(repo, Path(td) / "ws")
+        self.assertEqual(rc, 0, f"emitted command failed: {err.strip()[:120]}")
+        self.assertTrue(wrote, "no result written")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/injection-guard-sweep.test.py
+++ b/tests/injection-guard-sweep.test.py
@@ -361,7 +361,21 @@ _GUARDED_PY_WRITERS = {
     "src/cron-runner.py",
 }
 
+# Membership asserts "does not write task files" — NOT "is guarded". A file
+# listed here that gains a task writer must move to _GUARDED_PY_WRITERS above.
+_NON_WRITER_TASK_FIELD_USES = {
+    # Writes results/task-<id>.txt, never tasks/; both matches are in
+    # strip_pairing_echo() and the id is normalized by task_id_from() first.
+    "src/result_write.py",
+}
+
 _TASK_FIELD_PATTERN = 'f"task: {'
+_check(
+    "exhaustive-scan: guarded-writer and non-writer sets are disjoint",
+    not (_GUARDED_PY_WRITERS & _NON_WRITER_TASK_FIELD_USES),
+    f"a path claims both guarded-writer and non-writer status: "
+    f"{sorted(_GUARDED_PY_WRITERS & _NON_WRITER_TASK_FIELD_USES)}",
+)
 for _pyf in sorted(
     list((REPO / "src").glob("*.py")) + list((REPO / "skills").rglob("*.py"))
 ):
@@ -374,7 +388,7 @@ for _pyf in sorted(
         continue
     _check(
         f"exhaustive-scan: {_rel} is a known-guarded task writer",
-        _rel in _GUARDED_PY_WRITERS,
+        _rel in _GUARDED_PY_WRITERS or _rel in _NON_WRITER_TASK_FIELD_USES,
         f"{_rel} contains an interpolated task: f-string but is not in "
         f"_GUARDED_PY_WRITERS.  Add confine_user_content() to its task body, "
         f"then add the path to _GUARDED_PY_WRITERS so future passes catch regressions.",

--- a/tests/result-ready-contract.test.py
+++ b/tests/result-ready-contract.test.py
@@ -34,6 +34,51 @@ class ContractTest(unittest.TestCase):
             p.write_text(text)
         return p
 
+    # Readiness owns "is there a body"; the caller owns "is it THIS task's".
+    # The predicate sees RAW bytes, before stripping.
+
+    def test_a_body_the_predicate_rejects_is_not_ready(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, "answer composed for B\n")
+            self.assertIsNone(read_ready_result(p, attests=lambda raw: False))
+            self.assertEqual(read_ready_result(p), "answer composed for B",
+                             "positive control: without the predicate it delivers")
+
+    def test_the_predicate_sees_raw_bytes_not_the_stripped_body(self):
+        """A receipt covers what was WRITTEN. Verifying the stripped form would
+        reject every body ending in a newline — i.e. all of them."""
+        seen = []
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, "body\n")
+            read_ready_result(p, attests=lambda raw: seen.append(raw) or True)
+        self.assertEqual(seen, ["body\n"])
+
+    def test_no_predicate_keeps_the_previous_behaviour(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(read_ready_result(self._write(td, "hi\n")), "hi")
+
+    def test_the_predicate_is_not_consulted_for_an_unreadable_file(self):
+        """Order matters: an absent file is not-ready on its own, and calling a
+        caller-supplied predicate on bytes we never read would be a lie."""
+        calls = []
+        with tempfile.TemporaryDirectory() as td:
+            read_ready_result(self._write(td, None), attests=lambda raw: calls.append(raw))
+        self.assertEqual(calls, [])
+
+    def test_every_delivery_consumer_passes_an_attestation(self):
+        """The digest is worthless if no live path consults it — the exact gap
+        this change closes. Each src/ bridge must bind `attests=` on the call
+        that decides delivery."""
+        for name, path in CONSUMERS.items():
+            if "ag2-sparrow" in str(path):
+                continue  # vendored; carries no pairing digest yet
+            with self.subTest(name):
+                src = path.read_text()
+                self.assertIn("receipt_verifier", src,
+                              f"{name}: does not bind the attestation predicate")
+                self.assertIn("attests=receipt_verifier(RECEIPTS_DIR", src,
+                               f"{name}: delivery read is not attested")
+
     def test_missing_file_is_not_ready(self):
         with tempfile.TemporaryDirectory() as td:
             self.assertIsNone(read_ready_result(self._write(td, None)))

--- a/tests/result-ready-contract.test.py
+++ b/tests/result-ready-contract.test.py
@@ -65,41 +65,6 @@ class ContractTest(unittest.TestCase):
             read_ready_result(self._write(td, None), attests=lambda raw: calls.append(raw))
         self.assertEqual(calls, [])
 
-    def test_the_id_form_a_bridge_actually_holds_still_verifies(self):
-        """The source scan below proves the call EXISTS; this proves it BITES.
-
-        Writers hold `abc`, delivery consumers hold `task-abc`, and a receipt
-        lookup that misses fails OPEN — so a wrong id form is enforcement that
-        silently does nothing and looks wired in every grep.
-        """
-        import importlib.util
-        spec = importlib.util.spec_from_file_location(
-            "rw", REPO / "src" / "result_write.py")
-        rw = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(rw)
-        with tempfile.TemporaryDirectory() as td:
-            ws = Path(td)
-            results = ws / "results"
-            results.mkdir()
-            receipts = rw.receipts_dir_for(ws)
-            receipts.mkdir(parents=True)
-            rw.write_paired_result(results, "abc", "task: abc\nthe answer\n",
-                                   receipts_dir=receipts)
-            published = results / "task-abc.txt"
-            published.write_text("someone else's answer\n")
-            for form in ("abc", "task-abc"):
-                with self.subTest(form):
-                    self.assertIsNone(
-                        read_ready_result(
-                            published,
-                            attests=rw.receipt_verifier(receipts, form)),
-                        f"{form}: a crossed body was delivered")
-            published.write_text("the answer\n")
-            self.assertEqual(
-                read_ready_result(published,
-                                  attests=rw.receipt_verifier(receipts, "task-abc")),
-                "the answer", "positive control: the intact body must pass")
-
     def test_every_delivery_consumer_passes_an_attestation(self):
         """The digest is worthless if no live path consults it — the exact gap
         this change closes. Each src/ bridge must bind `attests=` on the call

--- a/tests/result-ready-contract.test.py
+++ b/tests/result-ready-contract.test.py
@@ -65,6 +65,41 @@ class ContractTest(unittest.TestCase):
             read_ready_result(self._write(td, None), attests=lambda raw: calls.append(raw))
         self.assertEqual(calls, [])
 
+    def test_the_id_form_a_bridge_actually_holds_still_verifies(self):
+        """The source scan below proves the call EXISTS; this proves it BITES.
+
+        Writers hold `abc`, delivery consumers hold `task-abc`, and a receipt
+        lookup that misses fails OPEN — so a wrong id form is enforcement that
+        silently does nothing and looks wired in every grep.
+        """
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "rw", REPO / "src" / "result_write.py")
+        rw = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(rw)
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            results = ws / "results"
+            results.mkdir()
+            receipts = rw.receipts_dir_for(ws)
+            receipts.mkdir(parents=True)
+            rw.write_paired_result(results, "abc", "task: abc\nthe answer\n",
+                                   receipts_dir=receipts)
+            published = results / "task-abc.txt"
+            published.write_text("someone else's answer\n")
+            for form in ("abc", "task-abc"):
+                with self.subTest(form):
+                    self.assertIsNone(
+                        read_ready_result(
+                            published,
+                            attests=rw.receipt_verifier(receipts, form)),
+                        f"{form}: a crossed body was delivered")
+            published.write_text("the answer\n")
+            self.assertEqual(
+                read_ready_result(published,
+                                  attests=rw.receipt_verifier(receipts, "task-abc")),
+                "the answer", "positive control: the intact body must pass")
+
     def test_every_delivery_consumer_passes_an_attestation(self):
         """The digest is worthless if no live path consults it — the exact gap
         this change closes. Each src/ bridge must bind `attests=` on the call

--- a/tests/result-router-empty-result-bound.test.py
+++ b/tests/result-router-empty-result-bound.test.py
@@ -115,7 +115,8 @@ def main() -> int:
         # Emptiness lives in the shared read_ready_result owner, so assert that
         # spelling: the contract moved, and the assertion follows it rather than loosening.
         check(f"  ...{bridge} still SKIPS rather than delivering the empty body",
-              "read_ready_result(result_file)" in src
+              "read_ready_result(" in src
+              and "attests=receipt_verifier(RECEIPTS_DIR, task_id)" in src
               and "if reply_text is None:" in src and src.count("continue") > 0,
               "the partial-write guard was removed")
 

--- a/tests/result-write-pairing.test.py
+++ b/tests/result-write-pairing.test.py
@@ -386,5 +386,47 @@ class ConcurrentDefaultWritersTest(unittest.TestCase):
                       "harness cannot produce the collision it claims to prevent")
 
 
+class ReceiptAttestsTheBytesItPublished(unittest.TestCase):
+    """A receipt that only proves a file EXISTS cannot tell a correct pairing
+    from a reply composed for another task. It must name the bytes."""
+
+    def _write(self, td, task="task-A", body="task: A\nthe answer for A\n"):
+        res, rec = Path(td) / "results", Path(td) / "receipts"
+        out = result_write.write_paired_result(res, task, body, receipts_dir=rec)
+        return rec, out.read_text()
+
+    def test_receipt_names_the_task_and_the_published_bytes(self):
+        with tempfile.TemporaryDirectory() as td:
+            rec, published = self._write(td)
+            self.assertTrue(result_write.receipt_attests(rec, "A", published))
+
+    def test_a_body_composed_for_another_task_is_not_attested(self):
+        with tempfile.TemporaryDirectory() as td:
+            rec, _ = self._write(td)
+            self.assertFalse(
+                result_write.receipt_attests(rec, "A", "answer composed for B"),
+                "the receipt attested bytes it never saw")
+
+    def test_a_receipt_does_not_attest_a_different_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            rec, published = self._write(td)
+            self.assertFalse(result_write.receipt_attests(rec, "B", published))
+
+    def test_a_pre_upgrade_empty_receipt_attests_nothing_but_still_exists(self):
+        # Additive by design: the presence gate keeps its current answer, so
+        # results already pending at upgrade cannot be stranded by this change.
+        with tempfile.TemporaryDirectory() as td:
+            rec, published = self._write(td)
+            result_write.receipt_path(rec, "A").write_text("")
+            self.assertFalse(result_write.receipt_attests(rec, "A", published))
+            self.assertTrue(result_write.has_pairing_receipt(rec, "A"))
+
+    def test_a_corrupt_receipt_is_not_attestation(self):
+        with tempfile.TemporaryDirectory() as td:
+            rec, published = self._write(td)
+            result_write.receipt_path(rec, "A").write_text("{not json")
+            self.assertFalse(result_write.receipt_attests(rec, "A", published))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/result-write-pairing.test.py
+++ b/tests/result-write-pairing.test.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""The result writer must refuse a body composed for a different task.
+
+The incident these tests exist for: a session holding two claimed tasks wrote
+each reply into the OTHER task's result file. Nothing downstream could notice,
+because a result file states nothing about which task it answers. So the check
+has to happen at the write, and it has to be all-or-nothing — a refused write
+that still leaves a temp file behind is the same bug with extra steps.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+import result_write  # noqa: E402
+
+
+class PairedResultWriteTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name)
+        self.results = self.ws / "results"
+        self.receipts = result_write.receipts_dir_for(self.ws)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write(self, task_id, body, **kw):
+        return result_write.write_paired_result(
+            self.results, task_id, body, receipts_dir=self.receipts, **kw)
+
+    def files_under(self, directory):
+        d = Path(directory)
+        if not d.is_dir():
+            return []
+        return sorted(p.name for p in d.iterdir())
+
+    def test_interleaved_body_of_a_against_id_of_b_is_refused(self):
+        """Two tasks in flight; A's body submitted against B's id."""
+        body_a = "task: a1\nthe answer for A\n"
+        with self.assertRaises(ValueError) as cm:
+            self.write("b2", body_a)
+        self.assertIn("pairing echo mismatch", str(cm.exception))
+        self.assertIn("task: b2", str(cm.exception))
+
+    def test_a_refused_write_leaves_zero_files(self):
+        with self.assertRaises(ValueError):
+            self.write("b2", "task: a1\nthe answer for A\n")
+        self.assertEqual(self.files_under(self.results), [])
+        self.assertEqual(self.files_under(self.receipts), [])
+        self.assertFalse(self.results.exists(),
+                         "a refused write must not even create results/")
+
+    def test_neither_task_is_corrupted_by_the_crossed_submission(self):
+        """The correct pairing for each still lands, untouched by the refusal."""
+        self.write("a1", "task: a1\nthe answer for A\n")
+        with self.assertRaises(ValueError):
+            self.write("b2", "task: a1\nthe answer for A\n")
+        self.write("b2", "task: b2\nthe answer for B\n")
+        self.assertEqual((self.results / "task-a1.txt").read_text(),
+                         "the answer for A\n")
+        self.assertEqual((self.results / "task-b2.txt").read_text(),
+                         "the answer for B\n")
+
+    def test_happy_path_strips_the_echo_and_writes_the_canonical_name(self):
+        out = self.write("a1", "task: a1\nline one\nline two\n")
+        self.assertEqual(out, self.results / "task-a1.txt")
+        self.assertEqual(out.read_text(), "line one\nline two\n")
+
+    def test_success_leaves_no_temp_residue(self):
+        self.write("a1", "task: a1\nbody\n", tmp_tag="core-2")
+        self.assertEqual(self.files_under(self.results), ["task-a1.txt"])
+
+    def test_success_records_a_pairing_receipt(self):
+        self.write("a1", "task: a1\nbody\n")
+        self.assertTrue(result_write.has_pairing_receipt(self.receipts, "a1"))
+        self.assertFalse(result_write.has_pairing_receipt(self.receipts, "b2"))
+
+    def test_write_is_atomic_via_replace(self):
+        """No reader may ever observe a partially written result file."""
+        calls = []
+        real_replace = os.replace
+        original = "the original body\n"
+        self.results.mkdir(parents=True)
+        (self.results / "task-a1.txt").write_text(original)
+
+        def spy(src, dst):
+            calls.append((str(src), str(dst)))
+            self.assertEqual((self.results / "task-a1.txt").read_text(), original,
+                             "destination changed before the atomic swap")
+            return real_replace(src, dst)
+
+        result_write.os.replace = spy
+        try:
+            self.write("a1", "task: a1\nreplacement\n")
+        finally:
+            result_write.os.replace = real_replace
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(calls[0][0].endswith(".tmp"), calls[0][0])
+        self.assertEqual((self.results / "task-a1.txt").read_text(), "replacement\n")
+
+    def test_empty_body_refused(self):
+        for body in ("", "   \n\n"):
+            with self.subTest(body=body):
+                with self.assertRaises(ValueError):
+                    self.write("a1", body)
+                self.assertEqual(self.files_under(self.results), [])
+
+    def test_missing_echo_line_refused(self):
+        with self.assertRaises(ValueError):
+            self.write("a1", "just an answer, no echo line\n")
+        self.assertEqual(self.files_under(self.results), [])
+
+    def test_echo_only_body_refused(self):
+        for body in ("task: a1", "task: a1\n", "task: a1\n   \n"):
+            with self.subTest(body=body):
+                with self.assertRaises(ValueError) as cm:
+                    self.write("a1", body)
+                self.assertIn("only the pairing echo", str(cm.exception))
+                self.assertEqual(self.files_under(self.results), [])
+
+    def test_echo_must_be_the_first_line_not_merely_present(self):
+        with self.assertRaises(ValueError):
+            self.write("a1", "preamble\ntask: a1\nbody\n")
+
+    def test_prefix_ids_do_not_satisfy_each_other(self):
+        """`task: a1` must not pair a task whose id merely starts with it."""
+        with self.assertRaises(ValueError):
+            self.write("a12", "task: a1\nbody\n")
+
+    def test_crlf_echo_accepted(self):
+        out = self.write("a1", "task: a1\r\nbody\r\n")
+        self.assertEqual(out.read_bytes(), b"body\r\n")
+
+    def test_task_id_accepts_the_spellings_callers_hold(self):
+        for spelling in ("a1", "task-a1", "task-a1.txt", "/w/tasks/task-a1.txt"):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(result_write.task_id_from(spelling), "a1")
+
+    def test_body_must_echo_the_bare_id_whatever_spelling_was_passed(self):
+        """Laxity about the argument must not become laxity about the check."""
+        with self.assertRaises(ValueError):
+            self.write("task-a1.txt", "task: task-a1.txt\nbody\n")
+        out = self.write("task-a1.txt", "task: a1\nbody\n")
+        self.assertEqual(out.name, "task-a1.txt")
+
+    def test_unusable_task_id_refused(self):
+        for bad in ("", "   ", "task-.txt", ".."):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    result_write.task_id_from(bad)
+
+
+class PairedResultWriteCliTests(unittest.TestCase):
+    """The shell entries reach this module only through the CLI."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name)
+        self.results = self.ws / "results"
+        self.receipts = result_write.receipts_dir_for(self.ws)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_cli(self, task_id, body, *extra):
+        return subprocess.run(
+            [sys.executable, str(REPO / "src" / "result_write.py"), "write",
+             task_id, "--workspace", str(self.ws), *extra],
+            input=body, capture_output=True, text=True)
+
+    def test_cli_happy_path_exits_zero_and_prints_the_path(self):
+        p = self.run_cli("a1", "task: a1\nbody\n")
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertEqual(p.stdout.strip(), str(self.results / "task-a1.txt"))
+        self.assertEqual((self.results / "task-a1.txt").read_text(), "body\n")
+        self.assertTrue(result_write.has_pairing_receipt(self.receipts, "a1"))
+
+    def test_cli_refuses_crossed_body_with_exit_2_and_zero_writes(self):
+        p = self.run_cli("b2", "task: a1\nthe answer for A\n")
+        self.assertEqual(p.returncode, 2, p.stdout)
+        self.assertIn("pairing echo mismatch", p.stderr)
+        self.assertFalse(self.results.exists())
+        self.assertFalse(self.receipts.exists())
+
+    def test_cli_refuses_empty_stdin(self):
+        p = self.run_cli("a1", "")
+        self.assertEqual(p.returncode, 2)
+        self.assertIn("empty result body", p.stderr)
+
+    def test_cli_honours_explicit_directories(self):
+        results = self.ws / "elsewhere" / "results"
+        receipts = self.ws / "elsewhere" / "receipts"
+        p = self.run_cli("a1", "task: a1\nbody\n",
+                         "--results-dir", str(results),
+                         "--receipts-dir", str(receipts))
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertEqual((results / "task-a1.txt").read_text(), "body\n")
+        self.assertTrue(result_write.has_pairing_receipt(receipts, "a1"))
+
+    def test_cli_rejects_unknown_flags_rather_than_ignoring_them(self):
+        p = self.run_cli("a1", "task: a1\nbody\n", "--nope", "x")
+        self.assertEqual(p.returncode, 2)
+        self.assertFalse(self.results.exists())
+
+    def test_bare_invocation_is_a_usage_error(self):
+        p = subprocess.run(
+            [sys.executable, str(REPO / "src" / "result_write.py")],
+            capture_output=True, text=True)
+        self.assertEqual(p.returncode, 2)
+        self.assertIn("usage:", p.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/result-write-pairing.test.py
+++ b/tests/result-write-pairing.test.py
@@ -7,6 +7,7 @@ because a result file states nothing about which task it answers. So the check
 has to happen at the write, and it has to be all-or-nothing — a refused write
 that still leaves a temp file behind is the same bug with extra steps.
 """
+import io
 import os
 import subprocess
 import sys
@@ -214,6 +215,88 @@ class PairedResultWriteCliTests(unittest.TestCase):
             capture_output=True, text=True)
         self.assertEqual(p.returncode, 2)
         self.assertIn("usage:", p.stderr)
+
+
+class CliInProcessTests(unittest.TestCase):
+    """Same CLI, called in-process so the coverage gate can see the lines.
+
+    PairedResultWriteCliTests above spawns a subprocess: it proves the real shell
+    entry works, but the gate instruments only this process, so those lines read
+    as uncovered.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name)
+        self.results = self.ws / "results"
+        self._stdin = sys.stdin
+
+    def tearDown(self):
+        sys.stdin = self._stdin
+        self.tmp.cleanup()
+
+    def cli(self, argv, body=""):
+        sys.stdin = io.StringIO(body)
+        return result_write._write_cli(argv)
+
+    def test_happy_path_returns_zero_and_writes(self):
+        rc = self.cli(["a1", "--workspace", str(self.ws)], "task: a1\nbody\n")
+        self.assertEqual(rc, 0)
+        self.assertEqual((self.results / "task-a1.txt").read_text(), "body\n")
+
+    def test_explicit_dirs_bypass_workspace_resolution(self):
+        r = self.ws / "R"; k = self.ws / "K"
+        rc = self.cli(["a2", "--results-dir", str(r), "--receipts-dir", str(k)],
+                      "task: a2\nbody\n")
+        self.assertEqual(rc, 0)
+        self.assertTrue((r / "task-a2.txt").is_file())
+        self.assertTrue(result_write.has_pairing_receipt(k, "a2"))
+
+    def test_crossed_body_returns_two_and_writes_nothing(self):
+        rc = self.cli(["b2", "--workspace", str(self.ws)], "task: a1\nwrong\n")
+        self.assertEqual(rc, 2)
+        self.assertFalse(self.results.exists() and any(self.results.iterdir()))
+
+    def test_usage_errors_return_two(self):
+        for argv in ([], ["x", "novalue"], ["x", "--results-dir"],
+                     ["x", "--bogus", "v"]):
+            with self.subTest(argv=argv):
+                self.assertEqual(self.cli(argv, "task: x\nb\n"), 2)
+
+
+class ReceiptFailuresDoNotLoseTheResult(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_unwritable_receipts_dir_still_returns_the_result(self):
+        """A durable result must never be rolled back for a diagnostic sidecar."""
+        blocker = self.ws / "blocker"
+        blocker.write_text("")
+        out = result_write.write_paired_result(
+            self.ws / "results", "c3", "task: c3\nbody\n",
+            receipts_dir=blocker / "under-a-file")
+        self.assertEqual(out.read_text(), "body\n")
+
+    def test_has_pairing_receipt_is_false_when_the_path_raises(self):
+        """pathlib swallows most of these, so raise at the seam the guard wraps."""
+        orig = result_write.receipt_path
+        def boom(*a, **k):
+            raise OSError("unreadable")
+        result_write.receipt_path = boom
+        try:
+            self.assertFalse(result_write.has_pairing_receipt(self.ws, "c3"))
+        finally:
+            result_write.receipt_path = orig
+
+    def test_resolve_dirs_falls_back_to_the_workspace_helper(self):
+        """No explicit dirs and no --workspace: the module must resolve one."""
+        results, receipts = result_write._resolve_dirs({})
+        self.assertEqual(results.name, "results")
+        self.assertEqual(receipts.parts[-2:], result_write.RECEIPTS_SUBPATH)
 
 
 if __name__ == "__main__":

--- a/tests/result-write-pairing.test.py
+++ b/tests/result-write-pairing.test.py
@@ -102,7 +102,12 @@ class PairedResultWriteTests(unittest.TestCase):
         finally:
             result_write.os.replace = real_replace
         self.assertEqual(len(calls), 1)
-        self.assertTrue(calls[0][0].endswith(".tmp"), calls[0][0])
+        # Assert the PROPERTY, not the spelling — `.endswith(".tmp")` also
+        # failed for any caller passing tmp_tag, so it never held generally.
+        src = Path(calls[0][0])
+        self.assertEqual(src.parent, self.results, calls[0][0])
+        self.assertTrue(src.name.startswith(".task-a1.txt.tmp"), calls[0][0])
+        self.assertNotEqual(src, self.results / "task-a1.txt")
         self.assertEqual((self.results / "task-a1.txt").read_text(), "replacement\n")
 
     def test_empty_body_refused(self):
@@ -297,6 +302,88 @@ class ReceiptFailuresDoNotLoseTheResult(unittest.TestCase):
         results, receipts = result_write._resolve_dirs({})
         self.assertEqual(results.name, "results")
         self.assertEqual(receipts.parts[-2:], result_write.RECEIPTS_SUBPATH)
+
+
+
+class ConcurrentDefaultWritersTest(unittest.TestCase):
+    """Two writers with no explicit tmp_tag must not share a temp path: the
+    first os.replace would move the file the second is about to replace."""
+
+    def _race(self, tags):
+        import threading
+        with tempfile.TemporaryDirectory() as td:
+            results = Path(td)
+            barrier = threading.Barrier(2)
+            real = result_write.os.replace
+
+            def synced(src, dst):
+                # Hold both writers until each has created its temp file, so
+                # the collision is deterministic rather than timing-dependent.
+                barrier.wait(timeout=10)
+                return real(src, dst)
+
+            out, errs = [], []
+
+            def go(tag):
+                try:
+                    out.append(result_write.write_paired_result(
+                        results, "race", "task: race\nbody\n", tmp_tag=tag))
+                except Exception as e:      # noqa: BLE001 — recorded, not raised
+                    errs.append(type(e).__name__)
+
+            result_write.os.replace = synced
+            try:
+                ts = [threading.Thread(target=go, args=(t,)) for t in tags]
+                for t in ts:
+                    t.start()
+                for t in ts:
+                    t.join(timeout=20)
+            finally:
+                result_write.os.replace = real
+            return len(out), errs
+
+    def test_default_tags_do_not_collide(self):
+        returned, errs = self._race(["", ""])
+        self.assertEqual(errs, [], "concurrent default writers lost a write")
+        self.assertEqual(returned, 2)
+
+    def test_explicit_tags_still_work(self):
+        returned, errs = self._race(["core-1", "core-2"])
+        self.assertEqual(errs, [])
+        self.assertEqual(returned, 2)
+
+    def test_the_race_harness_can_actually_fail(self):
+        """Control: force the pre-fix shared name and the collision appears."""
+        import threading
+        with tempfile.TemporaryDirectory() as td:
+            results = Path(td)
+            barrier = threading.Barrier(2)
+            real = result_write.os.replace
+            errs = []
+
+            def synced(src, dst):
+                barrier.wait(timeout=10)
+                return real(src, dst)
+
+            def go():
+                try:
+                    # the shared name the default used to produce
+                    result_write.write_paired_result(results, "race",
+                                           "task: race\nbody\n", tmp_tag="shared")
+                except Exception as e:      # noqa: BLE001
+                    errs.append(type(e).__name__)
+
+            result_write.os.replace = synced
+            try:
+                ts = [threading.Thread(target=go) for _ in range(2)]
+                for t in ts:
+                    t.start()
+                for t in ts:
+                    t.join(timeout=20)
+            finally:
+                result_write.os.replace = real
+        self.assertIn("FileNotFoundError", errs,
+                      "harness cannot produce the collision it claims to prevent")
 
 
 if __name__ == "__main__":

--- a/tests/result-write-pairing.test.py
+++ b/tests/result-write-pairing.test.py
@@ -469,5 +469,58 @@ class AttestationBitesAtTheIdFormBridgesHold(unittest.TestCase):
             "the answer")
 
 
+class AttestsCliAndCrossTaskReceipt(unittest.TestCase):
+    """The `attests` subcommand exists so a SHELL caller can check attestation
+    rather than presence; it is only reachable through the CLI entry."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        ws = Path(self.tmp.name)
+        self.results = ws / "results"
+        self.results.mkdir()
+        self.receipts = result_write.receipts_dir_for(ws)
+        self.receipts.mkdir(parents=True)
+        result_write.write_paired_result(
+            self.results, "abc", "task: abc\nthe answer\n",
+            receipts_dir=self.receipts)
+
+    def _cli(self, *argv):
+        return result_write._attests_cli(
+            [*argv, "--results-dir", str(self.results),
+             "--receipts-dir", str(self.receipts)])
+
+    def test_a_receipt_naming_a_different_task_does_not_attest(self):
+        """A receipt is only evidence for the task it names. Copying one over
+        another id must not launder the body it never covered."""
+        other = result_write.receipt_path(self.receipts, "abc").read_text()
+        result_write.receipt_path(self.receipts, "zzz").write_text(other)
+        (self.results / "task-zzz.txt").write_text("the answer\n")
+        self.assertFalse(
+            result_write.receipt_attests(self.receipts, "zzz", "the answer\n"))
+
+    def test_cli_exits_0_when_the_receipt_attests_the_current_bytes(self):
+        self.assertEqual(self._cli("abc"), 0)
+
+    def test_cli_exits_1_after_the_result_is_overwritten(self):
+        (self.results / "task-abc.txt").write_text("someone else's answer\n")
+        self.assertEqual(self._cli("abc"), 1)
+
+    def test_cli_exits_1_for_an_empty_receipt(self):
+        """Presence is not attestation — the case the old shell gate missed."""
+        result_write.receipt_path(self.receipts, "abc").write_text("")
+        self.assertEqual(self._cli("abc"), 1)
+
+    def test_cli_exits_1_when_there_is_no_result_file(self):
+        self.assertEqual(self._cli("nosuch"), 1)
+
+    def test_cli_rejects_a_missing_task_id(self):
+        self.assertEqual(result_write._attests_cli([]), 2)
+
+    def test_cli_rejects_a_dangling_or_unknown_flag(self):
+        self.assertEqual(result_write._attests_cli(["abc", "--results-dir"]), 2)
+        self.assertEqual(result_write._attests_cli(["abc", "--nope", "x"]), 2)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/result-write-pairing.test.py
+++ b/tests/result-write-pairing.test.py
@@ -19,6 +19,7 @@ REPO = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO / "src"))
 
 import result_write  # noqa: E402
+from delivery.readiness import read_ready_result  # noqa: E402
 
 
 class PairedResultWriteTests(unittest.TestCase):
@@ -428,5 +429,45 @@ class ReceiptAttestsTheBytesItPublished(unittest.TestCase):
             self.assertFalse(result_write.receipt_attests(rec, "A", published))
 
 
+class AttestationBitesAtTheIdFormBridgesHold(unittest.TestCase):
+    """A source scan proves the delivery call EXISTS; only this proves it BITES.
+
+    Writers hold `abc`, delivery consumers hold `task-abc`, and a receipt lookup
+    that misses fails OPEN — so a wrong id form is enforcement that does nothing
+    and still greps as wired.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        ws = Path(self.tmp.name)
+        self.results = ws / "results"
+        self.results.mkdir()
+        self.receipts = result_write.receipts_dir_for(ws)
+        self.receipts.mkdir(parents=True)
+        result_write.write_paired_result(
+            self.results, "abc", "task: abc\nthe answer\n",
+            receipts_dir=self.receipts)
+        self.published = self.results / "task-abc.txt"
+
+    def test_a_crossed_body_is_refused_in_either_id_form(self):
+        self.published.write_text("someone else's answer\n")
+        for form in ("abc", "task-abc"):
+            with self.subTest(form):
+                self.assertIsNone(
+                    read_ready_result(
+                        self.published,
+                        attests=result_write.receipt_verifier(self.receipts, form)),
+                    f"{form}: a crossed body was delivered")
+
+    def test_the_intact_body_still_passes(self):
+        """Positive control: a gate that refuses everything is not a gate."""
+        self.assertEqual(
+            read_ready_result(
+                self.published,
+                attests=result_write.receipt_verifier(self.receipts, "task-abc")),
+            "the answer")
+
+
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changed, and why

Today a pool follower holding two claimed tasks wrote each reply into the **other** task's result file. Both replies reached the wrong user. Nothing downstream could notice, because a result file states nothing about which task it answers — so the only party that can check the pairing is the writer, at the moment of writing.

The pool follower was fixed at the time (`finish_task` in `src/pool_follower.py`, PR #3314). **The two single-core paths have the same defect and no such check**, and are in fact weaker:

- **Codex** — `src/agent/codex/cli/task-notifier.sh` asserted the pairing in prose only: the prompt said *"write the result to `$RESULTS_DIR/$filename`"*, and the wait loop then treated the mere appearance of that filename as a completed delivery. Its existing guards (`has_result` replay guard, the `""|*/*|*..*` traversal case) check neither pairing nor completion.
- **Claude** — `src/agent/claude/cli/` has no notifier at all. The agent learns about tasks in-session from the stream watcher (`skills/proactive-loop/SKILL.md:22`) and writes `results/` itself. There is no external holder of the correct filename.

The pool skill already states the architecture: the claim → finish protocol is runtime-neutral, the entry is not. **So the pairing check belongs to the protocol layer, not to either entry** — this PR adds it there once and points both single-core entries at it, rather than copying the pool's logic twice.

### The shared writer — `src/result_write.py`

Given an intended task id and a body, it **refuses (`ValueError` / exit 2) with zero writes** — not even a temp file — unless the body's first line is exactly `task: <id>` matching. On success it strips that line (users never see it) and writes `results/task-<id>.txt` atomically (temp + `os.replace`). Stdlib only; callable from Python and, via a `write` subcommand with the body on stdin, from bash — the same shape as `pool_follower.py finish`.

It also records a **pairing receipt** under `state/result-pairing/`. That is what lets an external process holding the id but *not* the body distinguish "completed through the sanctioned path" from "a file with the right name appeared" — after the write the echo line is gone, so the pairing is otherwise unrecoverable after the fact.

### The two entries are NOT equally strong — please don't read them as such

This asymmetry is structural, not an implementation shortcut:

| | who holds the correct id | check strength |
|---|---|---|
| **Codex** | an external process (`task-notifier.sh`, kept alive by `task-notifier-supervisor.sh`); the body lives in the agent, so the pairing crosses a process boundary | **enforceable** — an external party can verify |
| **Claude** | nobody but the agent itself (in-session `TASK_FILE:` notifications) | **voluntary** — the helper only refuses if the agent calls it |

- **Codex** (`task-notifier.sh`): the prompt now names the helper and the required `task: <id>` first line, and the managed `wait_for_result=1` path gained a **post-condition**: after the wait, a missing result *or* a result with no pairing receipt logs loudly and fails, instead of being reported as success. A timed-out turn no longer `return 0`s. The loop keeps draining (the task stays durable on disk, so nothing is lost) but the notifier exits non-zero, which the supervisor already logs as `notifier exited with status 1`.
- **Claude** (`skills/proactive-loop/SKILL.md`): the completion step is now worded as the **only sanctioned way to write a result**, matching how the pool skill phrases it ("Never hand-write the result/flag/archive steps yourself"). This is a **self-imposed guard**: an agent that hand-writes the file bypasses it entirely and nothing outside can notice. Its value is that skipping it is visibly non-compliant with the documented step — not that it is enforced. See "Follow-ups" for the honest way to close that gap.

## What to look at first

1. `src/result_write.py` — the contract (`strip_pairing_echo`, `write_paired_result`).
2. `src/agent/codex/cli/task-notifier.sh` — `assert_result_paired()`, the changed prompt, and the wait-loop `break`→post-condition.
3. `skills/proactive-loop/SKILL.md` — the new **Completion step (required)** bullet under step 1.
4. `tests/result-write-pairing.test.py`, and the four new tests in `tests/codex-core-launcher.test.py`.

## What bug does this prove

A result written for task A landing under task B's name, silently, exit status 0.

## Feature/documentation consistency

`docs/src-map.md` regenerated (`python3 scripts/gen-src-map.py`) — CI's `lint-src-map` requires it for any new `src/` module. No other canonical doc describes result-write mechanics; the two runtime entries are themselves the documentation and both are updated here.

`CLAUDE.md` / `AGENTS.md` deliberately **not** touched. Note for the owner: `CLAUDE.md`'s "Task bridge" section still says *"writes results to `results/task-{ts}.txt`"*, which now understates the contract — a one-line follow-up if you want it aligned.

## Before/after evidence

### A. The defect (what both single-core entries did before this PR)

```
$ printf 'the answer for A\n' > "$W/results/task-b2.txt"
$ printf 'the answer for B\n' > "$W/results/task-a1.txt"
results/task-a1.txt -> the answer for B
results/task-b2.txt -> the answer for A
exit status of both writes: 0   <- nothing refused, nothing logged
```

### B. The same crossed submission through the new writer

```
$ printf 'task: a1\nthe answer for A\n' | python3 src/result_write.py write b2 --workspace "$W"
result write refused: pairing echo mismatch: need 'task: b2' as first line, got 'task: a1'
RC=2
files created:
       0
```

### C. Mutation control — disable the pairing check, the interleave test goes RED

Mutation: `if first.rstrip("\r") != f"task: {task_id}":` → `if False:` in `src/result_write.py`, applied and reverted by exact reverse string-replace (never `git checkout --`).

```
m1 apply: ok (src/result_write.py)
FAIL: test_cli_refuses_crossed_body_with_exit_2_and_zero_writes
FAIL: test_a_refused_write_leaves_zero_files
FAIL: test_body_must_echo_the_bare_id_whatever_spelling_was_passed
FAIL: test_echo_must_be_the_first_line_not_merely_present
FAIL: test_interleaved_body_of_a_against_id_of_b_is_refused
FAIL: test_neither_task_is_corrupted_by_the_crossed_submission
FAIL: test_prefix_ids_do_not_satisfy_each_other
Ran 22 tests in 0.293s
FAILED (failures=7)
m1 revert: ok (src/result_write.py)
--- restored:
Ran 22 tests in 0.311s

OK
```

### D. Mutation control — disable the codex post-condition, the unpaired-result test goes RED

Mutation: `if [ ! -f "$RESULT_PAIRING_DIR/task-$task_id.ok" ]; then` → `if false; then` in `task-notifier.sh`.

```
m2 apply: ok (src/agent/codex/cli/task-notifier.sh)
FAIL: test_managed_notifier_fails_loudly_on_a_result_it_cannot_pair
AssertionError: 0 == 0 :
Ran 1 test in 1.046s
FAILED (failures=1)
m2 revert: ok (src/agent/codex/cli/task-notifier.sh)
--- restored:
Ran 1 test in 1.001s

OK
```

## Tests

New — `tests/result-write-pairing.test.py` (22 tests), including the interleaving repro (`test_interleaved_body_of_a_against_id_of_b_is_refused`), zero-writes-on-refusal (`test_a_refused_write_leaves_zero_files`), no temp residue on success, `os.replace` atomicity with a spy that asserts the destination is untouched until the swap, empty/blank/echo-only/missing-echo refusals, and prefix-id non-collision.

New in `tests/codex-core-launcher.test.py` — the post-condition, driven end-to-end through the managed notifier with a stub core:
- `test_managed_notifier_fails_loudly_when_the_turn_produces_no_result` (agent writes nothing)
- `test_managed_notifier_fails_loudly_on_a_result_it_cannot_pair` (agent hand-writes an unpaired file)
- `test_managed_notifier_accepts_a_result_written_through_the_helper` (positive control — same harness, passes)
- `test_notifier_prompt_states_the_pairing_requirement`

The five existing tmux stubs in that suite that stood in for the live core were changed from `touch`ing a result to calling the **real** helper (`paired_result` in `STUB_HEADER`), so they exercise the shipped writer rather than a copied recipe.

```
tests/pending-questions-body-field.test.py           OK
tests/proactive-loop-self-development.test.py        all tests passed
tests/bot2bot-post.test.py                           all tests passed — bot2bot-channel scope guard + kind vocabulary
tests/src-map.test.py                                Results: 27 passed
tests/health-check-codex-task-notifier.test.py       OK
tests/ci-covers-every-python-test.test.py            OK
tests/result-write-pairing.test.py                   OK   (22 tests)
tests/codex-core-launcher.test.py                    OK   (35 tests)
```

Repo gate:

```
$ bash scripts/review-checks.sh --diff <diff>
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
RC=0
```

Shell: `bash -n` clean on `task-notifier.sh` and `task-notifier-supervisor.sh`. **shellcheck is not installed on this host**, so the `shellcheck -S error` workflow was not run locally — it will run in CI.

## Live path — no post-restart round trip

**Stated plainly: no live post-restart round trip was performed.** The single-core paths edited here are the ones running on this host right now, and restarting them is the owner's to trigger. The changes take effect on the next core launch. What is proven instead is the managed notifier driven end-to-end as a real process (real fifo, real watcher stub, real tmux stub, real helper) in `tests/codex-core-launcher.test.py` — including the two failure modes and a positive control — plus the evidence above.

## Follow-ups (deliberately not in this PR — one concern per PR)

1. **`pool_follower.finish_task` is not refactored to call the shared writer.** It cannot be: the entire pool feature is unmerged, living only on `feat/lead-follower-pool` (#3314), so `src/pool_follower.py` does not exist on `main`. `write_paired_result(results_dir, task_id, body, tmp_tag=instance)` is deliberately shaped to be a drop-in for the validate+write half of `finish_task`, preserving its temp-file naming and error strings; the done-flag and archive steps stay pool-specific. Whichever of the two lands second should make that one-line change — leaving two copies of the pairing rule is a defect in its own right.
2. **A reconciliation sweep over `results/`** — periodically flag bodies whose pairing cannot be established — is the honest way to close Claude's voluntary-guard gap, catching a hand-written bypass after the fact. Today taught us silent failures are the expensive kind, so this deserves its own issue rather than being smuggled in here.
3. **`src/remote-gateway-bridge.py`'s `===SKILL INSTRUCTIONS===` block** (task-body instructions for ag2space room tasks) also tells the agent to "write the result to `results/task-<id>.txt`". It is a third instruction site and should be pointed at the helper too — out of scope here.

4. **Anything that later *latches* this guard closed is downstream of this PR, not just of its behaviour.** A per-producer exemption is only safe if it keys on a positive, statically-readable fact — "this producer's write path mints a receipt" — continuously asserted in CI, rather than on a runtime count of how often the guard failed open. A residue counter cannot serve: it reads zero both when producers have started minting and when nothing produced work, and no denominator separates those, because an un-enumerated producer that is merely quiet is invisible at any volume. The relevant point for whoever picks this up: **that CI assertion has no subject on `main` today.** `src/result_write.py` does not exist there, so the property to assert is not yet present in the tree CI runs on — the enumeration and the assertion must be one artifact (the test iterating the manifest) so that deleting a producer's assertion is the same edit as deleting the producer.

Author: @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)

