### PR TITLE
fix(codex): notifier supervisor takes a lease, backs off, and stops on config faults

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -125,6 +125,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`personal-claude-compact-hint.sh`** — SessionStart(compact) hook — re-inject PERSONAL_CLAUDE.md after context compaction.
 - **`pool_delivery.py`** — Delivery-side half of the worker pool: read one recipient's own folder.
 - **`pool_roster.py`** — Bindings the owner writes; a roster the core compiles; the router only reads.
+- **`portable_mtime.sh`** — The ONE portable mtime probe.
 - **`presenter-mode.ts`** — Provider-neutral presenter-mode sentinel policy — TS twin of src/presenter_mode.py (#2501).
 - **`presenter_mode.py`** — Provider-neutral presenter-mode sentinel policy.
 - **`proactive_claim_fence.py`** — Proactive claim lifecycle on the outbox ClaimBackend seam.

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -269,6 +269,8 @@ CLASS_RULES=(
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=src/portable_mtime.sh
+. "$REPO_DIR/src/portable_mtime.sh"
 . "$REPO_DIR/scripts/python-binary.sh"
 HELPER="$REPO_DIR/scripts/sutando-config.sh"
 
@@ -354,7 +356,7 @@ age_safe() {
     local file="$1"
     local now mtime age
     now="$(date +%s)"
-    mtime="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || echo 0)"
+    mtime="$(portable_mtime "$file" || echo 0)"
     age=$((now - mtime))
     [ "$age" -ge "$INFLIGHT_GUARD_SEC" ]
 }
@@ -379,7 +381,7 @@ record_xsrc() {
     # $1=tag, $2=relpath, $3=class, $4=abs-path
     local tag="$1" rel="$2" cls="$3" file="$4"
     local mt sz
-    mt="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || echo 0)"
+    mt="$(portable_mtime "$file" || echo 0)"
     sz="$(stat -f %z "$file" 2>/dev/null || stat -c %s "$file" 2>/dev/null || echo 0)"
     printf '%s\t%s\t%s\t%s\t%s\n' "$rel" "$tag" "$cls" "$mt" "$sz" >> "$XSRC_INDEX"
 }
@@ -1170,9 +1172,9 @@ commit_one() {
                 # Same content (mtime+size) → identical-drop. Different →
                 # keep-both: rename source-incoming to <file>.legacy-<tag>.
                 local src_mt src_sz dst_mt dst_sz
-                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
+                src_mt="$(portable_mtime "$src_file" || echo 0)"
                 src_sz="$(stat -f %z "$src_file" 2>/dev/null || stat -c %s "$src_file")"
-                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                dst_mt="$(portable_mtime "$dst_path" || echo 0)"
                 dst_sz="$(stat -f %z "$dst_path" 2>/dev/null || stat -c %s "$dst_path")"
                 if [ "$src_mt" = "$dst_mt" ] && [ "$src_sz" = "$dst_sz" ]; then
                     echo "identical-drop"
@@ -1213,8 +1215,8 @@ commit_one() {
             dst_path="$DEST_REAL/$rel"
             if [ -e "$dst_path" ]; then
                 local src_mt dst_mt
-                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
-                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                src_mt="$(portable_mtime "$src_file" || echo 0)"
+                dst_mt="$(portable_mtime "$dst_path" || echo 0)"
                 if [ "$src_mt" -gt "$dst_mt" ]; then
                     copy_preserving_mtime "$src_file" "$dst_path"
                     echo "src-newer"
@@ -1255,8 +1257,8 @@ commit_one() {
             # Per-mtime swap, identical-drop, or write-fresh.
             if [ -e "$dst_path" ]; then
                 local src_mt dst_mt
-                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
-                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                src_mt="$(portable_mtime "$src_file" || echo 0)"
+                dst_mt="$(portable_mtime "$dst_path" || echo 0)"
                 if [ "$src_mt" -gt "$dst_mt" ]; then
                     copy_preserving_mtime "$src_file" "$dst_path"
                     echo "rehomed-newer"
@@ -1286,7 +1288,7 @@ commit_one() {
             dst_path="$DEST_REAL/logs/workspace-narrative.log"
             mkdir -p "$(dirname "$dst_path")"
             local src_mt src_sz
-            src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
+            src_mt="$(portable_mtime "$src_file" || echo 0)"
             src_sz="$(stat -f %z "$src_file" 2>/dev/null || stat -c %s "$src_file")"
             # Mini #design 2026-06-02 08:10Z: an `{ ... } > tmp && mv ...`
             # compound on a single line is NOT covered by `set -e` for its

--- a/src/agent/codex/cli/task-notifier-supervisor.sh
+++ b/src/agent/codex/cli/task-notifier-supervisor.sh
@@ -18,10 +18,10 @@ _lease_key() {
   local digest
   digest="$(python3 -c 'import hashlib,sys;print(hashlib.sha256("\0".join(sys.argv[1:]).encode()).hexdigest()[:16])' "$1" "$2" 2>/dev/null)" || digest=""
   # An empty digest aliases every socket onto one key: fail closed, never lease.
-  case "$digest" in
-    ????????????????) ;;
-    *) echo "task-notifier-supervisor: cannot derive the lease key for ($1, $2); refusing to run" >&2; exit 1 ;;
-  esac
+  # Malformed successful output (sixteen non-hex bytes) also aliases sockets.
+  if ! [[ "$digest" =~ ^[0-9a-f]{16}$ ]]; then
+    echo "task-notifier-supervisor: cannot derive the lease key for ($1, $2); refusing to run" >&2; exit 1
+  fi
   printf '%s-%s' "$(printf '%s' "$2" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-40)" "$digest"
 }
 if [ -n "${SUTANDO_NOTIFIER_LOCK_DIR:-}" ]; then
@@ -119,13 +119,16 @@ _lease_rm() { _dir_rm "$LOCK_DIR"; }
 
 # Publish a token into directory $1 whole-or-not-at-all: stage OUTSIDE the
 # directory (a crash mid-publication must not leave a file that blocks rmdir),
-# then rename in. Returns nonzero if the publication did not land.
+# then link in. link(2) is atomic and refuses an existing name, so at most one
+# publication ever lands in a directory: a publisher that lost the race to a
+# post-grace claimant fails here and withdraws. Nonzero = did not land.
 _publish_token() {
   local dir="$1" stage="$1.stage.$$"
-  printf '%s\n' "$$" > "$dir/pid" || return 1
   printf '%s' "$OWNER_TOKEN" > "$stage" || { rm -f "$stage"; return 1; }
-  mv -f "$stage" "$dir/token" || { rm -f "$stage"; return 1; }
-  [ "$(_token_of "$dir")" = "$OWNER_TOKEN" ]
+  ln "$stage" "$dir/token" 2>/dev/null || { rm -f "$stage"; return 1; }
+  rm -f "$stage"
+  [ "$(_token_of "$dir")" = "$OWNER_TOKEN" ] || return 1
+  printf '%s\n' "$$" > "$dir/pid" || return 1
 }
 
 release_lease() {
@@ -146,9 +149,10 @@ _reclaim_release() {
 
 # Take the reclaim lock: mkdir is the atomic test-and-set, but an empty
 # directory is a publication in progress, not an abandoned one — it is judged
-# by the same live/publishing/stale rule as the lease, and a dead or recycled
-# holder is BROKEN by renaming its directory away (only one contender's mv
-# succeeds), never by deleting in place.
+# by the same live/publishing/stale rule as the lease. A stale EMPTY directory
+# is recovered by claiming it in place (the no-clobber link fences its late
+# publisher out); a dead or recycled holder with a token is BROKEN by renaming
+# its directory away (only one contender's mv succeeds), never deleted in place.
 _reclaim_lock() {
   local verdict broken
   if mkdir "$RECLAIM_DIR" 2>/dev/null; then
@@ -160,6 +164,11 @@ _reclaim_lock() {
   verdict="$(_judge_dir "$RECLAIM_DIR")"
   case "$verdict" in
     stale)
+      if [ -z "$(_token_of "$RECLAIM_DIR")" ]; then
+        _publish_token "$RECLAIM_DIR" && return 0
+        _reclaim_release
+        return 1
+      fi
       broken="$RECLAIM_DIR.broken.$$"
       mv "$RECLAIM_DIR" "$broken" 2>/dev/null && _dir_rm "$broken"
       ;;

--- a/src/agent/codex/cli/task-notifier-supervisor.sh
+++ b/src/agent/codex/cli/task-notifier-supervisor.sh
@@ -8,7 +8,10 @@ SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 RESTART_DELAY="${SUTANDO_NOTIFIER_RESTART_DELAY:-1}"
 RESTART_DELAY_MAX="${SUTANDO_NOTIFIER_RESTART_DELAY_MAX:-30}"
 STABLE_AFTER="${SUTANDO_NOTIFIER_STABLE_AFTER:-60}"
-LOCK_DIR="${SUTANDO_NOTIFIER_LOCK_DIR:-${TMPDIR:-/tmp}/sutando-notifier-${SESSION}.lock}"
+# start-cli.sh launches one notifier per (socket, session); keying on SESSION
+# alone makes two cores on different sockets suppress each other.
+_lease_key() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+LOCK_DIR="${SUTANDO_NOTIFIER_LOCK_DIR:-${TMPDIR:-/tmp}/sutando-notifier-$(_lease_key "${TMUX_SOCKET}#${SESSION}").lock}"
 NOTIFIER="${SUTANDO_NOTIFIER_SCRIPT:-$REPO/src/agent/codex/cli/task-notifier.sh}"
 # task-notifier.sh exits 2 only for a usage/configuration fault; respawning
 # re-runs the same broken invocation, so that one is terminal rather than retried.
@@ -26,28 +29,84 @@ stop_child() {
   child_pid=""
 }
 
+# Our token: pid plus this process's start identity, so a recycled pid cannot
+# impersonate us. Read once — /proc is absent on macOS, so ps is the portable source.
+_own_token() {
+  printf '%s:%s' "$$" "$(ps -o lstart= -p "$$" 2>/dev/null | tr -s ' ' '_' || echo unknown)"
+}
+OWNER_TOKEN="$(_own_token)"
+
+_lease_token() { cat "$LOCK_DIR/token" 2>/dev/null || true; }
+
+# Non-recursive by construction: remove the files we know we wrote, then rmdir,
+# which FAILS if anything else is inside. `rm -rf` on a configurable path can
+# delete a pre-existing directory and its contents.
+_lease_rm() {
+  rm -f "$LOCK_DIR/token" "$LOCK_DIR/pid" 2>/dev/null || true
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+
 release_lease() {
   [ -n "$lease_held" ] || return 0
-  rm -rf "$LOCK_DIR" 2>/dev/null || true
+  # Verify the path still holds OUR lease. Without this a former owner whose
+  # lease was already reclaimed deletes its successor's.
+  if [ "$(_lease_token)" = "$OWNER_TOKEN" ]; then
+    _lease_rm
+  fi
   lease_held=""
+}
+
+PUBLISH_GRACE="${SUTANDO_NOTIFIER_PUBLISH_GRACE:-10}"
+
+_pid_token() { printf '%s:%s' "$1" "$(ps -o lstart= -p "$1" 2>/dev/null | tr -s ' ' '_' || echo unknown)"; }
+
+_lease_age() {
+  local now mt
+  now="$(date +%s)"
+  mt="$(stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || echo "$now")"
+  echo $(( now - mt ))
 }
 
 # mkdir is the portable atomic test-and-set; macOS ships no flock(1).
 acquire_lease() {
-  local attempt owner
+  local attempt owner token age
   for attempt in 1 2 3; do
     if mkdir "$LOCK_DIR" 2>/dev/null; then
+      # Publish via rename so a contender sees the token whole or not at all.
       printf '%s\n' "$$" > "$LOCK_DIR/pid"
+      printf '%s' "$OWNER_TOKEN" > "$LOCK_DIR/.token.$$" \
+        && mv -f "$LOCK_DIR/.token.$$" "$LOCK_DIR/token"
       lease_held=1
       return 0
     fi
-    owner="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
-    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+    token="$(_lease_token)"
+    owner="${token%%:*}"
+    if [ -z "$token" ]; then
+      # No token. A `pid` file is still usable identity (a pre-token lease), so
+      # fall through to the liveness check rather than widening the grace window.
+      owner="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    fi
+    if [ -z "$owner" ]; then
+      # Neither token nor pid: the ONLY genuinely ambiguous state — a winner
+      # between mkdir and publication, or a crash inside it. Bounded, and it
+      # defers, because deleting here races a live owner into a double-run.
+      age="$(_lease_age)"
+      if [ "$age" -lt "$PUBLISH_GRACE" ]; then
+        echo "task-notifier-supervisor: lease $LOCK_DIR is publishing (${age}s); exiting" >&2
+        exit 0
+      fi
+      _lease_rm
+      continue
+    fi
+    # A token pins the START identity too, so a recycled pid cannot impersonate
+    # the owner. A pre-token lease has only the pid to go on.
+    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null \
+       && { [ -z "$token" ] || [ "$(_pid_token "$owner")" = "$token" ]; }; then
       echo "task-notifier-supervisor: pid $owner already supervises '$SESSION'; exiting" >&2
       exit 0
     fi
-    # Owner is gone: the lease is stale, not contended. Clear it and retry.
-    rm -rf "$LOCK_DIR" 2>/dev/null || true
+    # Owner is gone (or its pid was recycled by an unrelated process): stale.
+    _lease_rm
   done
   echo "task-notifier-supervisor: could not acquire lease $LOCK_DIR" >&2
   exit 1

--- a/src/agent/codex/cli/task-notifier-supervisor.sh
+++ b/src/agent/codex/cli/task-notifier-supervisor.sh
@@ -84,6 +84,8 @@ while tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null; do
   fi
   echo "task-notifier-supervisor: notifier exited with status $status; restarting in ${delay}s" >&2
   sleep "$delay"
-  delay=$(( delay * 2 ))
-  [ "$delay" -gt "$RESTART_DELAY_MAX" ] && delay="$RESTART_DELAY_MAX"
+  # awk, not $(( )): bash arithmetic is integer-only and the delay is
+  # documented as fractional -- tests drive it at 0.01 to stay fast.
+  delay="$(awk -v d="$delay" -v m="$RESTART_DELAY_MAX" \
+    'BEGIN { d *= 2; if (d > m) d = m; print d }')"
 done

--- a/src/agent/codex/cli/task-notifier-supervisor.sh
+++ b/src/agent/codex/cli/task-notifier-supervisor.sh
@@ -63,7 +63,13 @@ _pid_token() { printf '%s:%s' "$1" "$(ps -o lstart= -p "$1" 2>/dev/null | tr -s 
 _lease_age() {
   local now mt
   now="$(date +%s)"
-  mt="$(stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || echo "$now")"
+  # GNU first and validate: `stat -f` on GNU is --file-system and SUCCEEDS with
+  # non-numeric output, so a BSD-first probe never falls through on Linux.
+  mt="$(stat -c %Y "$LOCK_DIR" 2>/dev/null || true)"
+  case "$mt" in '' | *[!0-9]*) mt="$(stat -f %m "$LOCK_DIR" 2>/dev/null || true)" ;; esac
+  # Unreadable mtime reads as just-published, so the guard defers rather than
+  # reclaiming: an unknown age must never authorise deleting a live lease.
+  case "$mt" in '' | *[!0-9]*) mt="$now" ;; esac
   echo $(( now - mt ))
 }
 

--- a/src/agent/codex/cli/task-notifier-supervisor.sh
+++ b/src/agent/codex/cli/task-notifier-supervisor.sh
@@ -3,6 +3,8 @@
 set -u
 
 REPO="$(cd "$(dirname "$0")/../../../.." && pwd)"
+# shellcheck source=src/portable_mtime.sh
+. "$REPO/src/portable_mtime.sh"
 TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
 SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 RESTART_DELAY="${SUTANDO_NOTIFIER_RESTART_DELAY:-1}"
@@ -13,12 +15,25 @@ STABLE_AFTER="${SUTANDO_NOTIFIER_STABLE_AFTER:-60}"
 # Readable session prefix plus a digest of the exact (socket, session) pair:
 # flattening punctuation to `_` made distinct sockets share one lease.
 _lease_key() {
-  printf '%s-%s' "$(printf '%s' "$2" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-40)" \
-    "$(python3 -c 'import hashlib,sys;print(hashlib.sha256("\0".join(sys.argv[1:]).encode()).hexdigest()[:16])' "$1" "$2")"
+  local digest
+  digest="$(python3 -c 'import hashlib,sys;print(hashlib.sha256("\0".join(sys.argv[1:]).encode()).hexdigest()[:16])' "$1" "$2" 2>/dev/null)" || digest=""
+  # An empty digest aliases every socket onto one key: fail closed, never lease.
+  case "$digest" in
+    ????????????????) ;;
+    *) echo "task-notifier-supervisor: cannot derive the lease key for ($1, $2); refusing to run" >&2; exit 1 ;;
+  esac
+  printf '%s-%s' "$(printf '%s' "$2" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-40)" "$digest"
 }
-LOCK_DIR="${SUTANDO_NOTIFIER_LOCK_DIR:-${TMPDIR:-/tmp}/sutando-notifier-$(_lease_key "$TMUX_SOCKET" "$SESSION").lock}"
+if [ -n "${SUTANDO_NOTIFIER_LOCK_DIR:-}" ]; then
+  LOCK_DIR="$SUTANDO_NOTIFIER_LOCK_DIR"
+else
+  LOCK_KEY="$(_lease_key "$TMUX_SOCKET" "$SESSION")" || exit 1
+  LOCK_DIR="${TMPDIR:-/tmp}/sutando-notifier-$LOCK_KEY.lock"
+fi
 RECLAIM_DIR="$LOCK_DIR.reclaim"
 RECLAIM_HOOK="${SUTANDO_NOTIFIER_RECLAIM_HOOK:-}"
+RECLAIM_PUBLISH_HOOK="${SUTANDO_NOTIFIER_RECLAIM_PUBLISH_HOOK:-}"
+JUDGE_HOOK="${SUTANDO_NOTIFIER_JUDGE_HOOK:-}"
 NOTIFIER="${SUTANDO_NOTIFIER_SCRIPT:-$REPO/src/agent/codex/cli/task-notifier.sh}"
 # task-notifier.sh exits 2 only for a usage/configuration fault; respawning
 # re-runs the same broken invocation, so that one is terminal rather than retried.
@@ -49,14 +64,68 @@ _start_of() {
 _own_token() { printf '%s:%s' "$$" "$(_start_of "$$" || echo unknown)"; }
 OWNER_TOKEN="$(_own_token)"
 
-_lease_token() { cat "$LOCK_DIR/token" 2>/dev/null || true; }
+PUBLISH_GRACE="${SUTANDO_NOTIFIER_PUBLISH_GRACE:-10}"
+
+_token_of() { cat "$1/token" 2>/dev/null || true; }
+_lease_token() { _token_of "$LOCK_DIR"; }
+
+_age_of() {
+  local now mt
+  now="$(date +%s)"
+  # Unreadable mtime reads as just-published, so the guard defers rather than
+  # reclaiming: an unknown age must never authorise deleting a live lease.
+  mt="$(portable_mtime "$1")" || mt="$now"
+  echo $(( now - mt ))
+}
+_lease_age() { _age_of "$LOCK_DIR"; }
+
+# Verdict on the lease directory $1: live | publishing | unknown | stale |
+# absent | error. `unknown` is a live pid whose start identity cannot be
+# compared on either side; it must read as contended, never as pid reuse.
+# `absent` is a directory that vanished between mkdir and this read (retry);
+# `error` is a parent that cannot hold it at all (a real path/config fault).
+_judge_dir() {
+  local dir="$1" token owner age start parent
+  if [ ! -d "$dir" ]; then
+    parent="$(dirname "$dir")"
+    if [ -d "$parent" ] && [ -w "$parent" ]; then echo absent; else echo error; fi
+    return
+  fi
+  token="$(_token_of "$dir")"
+  owner="${token%%:*}"
+  [ -n "$token" ] || owner="$(cat "$dir/pid" 2>/dev/null || true)"
+  if [ -z "$owner" ]; then
+    age="$(_age_of "$dir")"
+    [ "$age" -lt "$PUBLISH_GRACE" ] && { echo publishing; return; }
+    echo stale; return
+  fi
+  kill -0 "$owner" 2>/dev/null || { echo stale; return; }
+  [ -n "$token" ] || { echo live; return; }
+  start="$(_start_of "$owner" || true)"
+  if [ -z "$start" ] || [ "${token#*:}" = unknown ]; then echo unknown; return; fi
+  [ "$start" = "${token#*:}" ] && echo live || echo stale
+}
+_judge() { _judge_dir "$LOCK_DIR"; }
 
 # Non-recursive by construction: remove the files we know we wrote, then rmdir,
 # which FAILS if anything else is inside. `rm -rf` on a configurable path can
-# delete a pre-existing directory and its contents.
-_lease_rm() {
-  rm -f "$LOCK_DIR/token" "$LOCK_DIR/pid" 2>/dev/null || true
-  rmdir "$LOCK_DIR" 2>/dev/null || true
+# delete a pre-existing directory and its contents. `.token.*` is the staging
+# artifact an earlier revision of this script left inside the directory.
+_dir_rm() {
+  rm -f "$1/token" "$1/pid" "$1"/.token.* 2>/dev/null || true
+  rmdir "$1" 2>/dev/null || true
+}
+_lease_rm() { _dir_rm "$LOCK_DIR"; }
+
+# Publish a token into directory $1 whole-or-not-at-all: stage OUTSIDE the
+# directory (a crash mid-publication must not leave a file that blocks rmdir),
+# then rename in. Returns nonzero if the publication did not land.
+_publish_token() {
+  local dir="$1" stage="$1.stage.$$"
+  printf '%s\n' "$$" > "$dir/pid" || return 1
+  printf '%s' "$OWNER_TOKEN" > "$stage" || { rm -f "$stage"; return 1; }
+  mv -f "$stage" "$dir/token" || { rm -f "$stage"; return 1; }
+  [ "$(_token_of "$dir")" = "$OWNER_TOKEN" ]
 }
 
 release_lease() {
@@ -69,62 +138,47 @@ release_lease() {
   lease_held=""
 }
 
-PUBLISH_GRACE="${SUTANDO_NOTIFIER_PUBLISH_GRACE:-10}"
-
-# Verdict on the lease at LOCK_DIR: live | publishing | unknown | stale.
-# `unknown` is a live pid whose start identity cannot be compared on either
-# side; it must read as contended, never as pid reuse.
-_judge() {
-  local token owner age start
-  token="$(_lease_token)"
-  owner="${token%%:*}"
-  [ -n "$token" ] || owner="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
-  if [ -z "$owner" ]; then
-    age="$(_lease_age)"
-    [ "$age" -lt "$PUBLISH_GRACE" ] && { echo publishing; return; }
-    echo stale; return
-  fi
-  kill -0 "$owner" 2>/dev/null || { echo stale; return; }
-  [ -n "$token" ] || { echo live; return; }
-  start="$(_start_of "$owner" || true)"
-  if [ -z "$start" ] || [ "${token#*:}" = unknown ]; then echo unknown; return; fi
-  [ "$start" = "${token#*:}" ] && echo live || echo stale
+# Release the reclaim lock only if it is still OURS by exact token.
+_reclaim_release() {
+  [ "$(_token_of "$RECLAIM_DIR")" = "$OWNER_TOKEN" ] && _dir_rm "$RECLAIM_DIR"
+  return 0
 }
 
-_reclaim_unlock() { rm -f "$RECLAIM_DIR/pid" 2>/dev/null; rmdir "$RECLAIM_DIR" 2>/dev/null || true; }
+# Take the reclaim lock: mkdir is the atomic test-and-set, but an empty
+# directory is a publication in progress, not an abandoned one — it is judged
+# by the same live/publishing/stale rule as the lease, and a dead or recycled
+# holder is BROKEN by renaming its directory away (only one contender's mv
+# succeeds), never by deleting in place.
+_reclaim_lock() {
+  local verdict broken
+  if mkdir "$RECLAIM_DIR" 2>/dev/null; then
+    [ -n "$RECLAIM_PUBLISH_HOOK" ] && bash "$RECLAIM_PUBLISH_HOOK"
+    _publish_token "$RECLAIM_DIR" && return 0
+    _reclaim_release
+    return 1
+  fi
+  verdict="$(_judge_dir "$RECLAIM_DIR")"
+  case "$verdict" in
+    stale)
+      broken="$RECLAIM_DIR.broken.$$"
+      mv "$RECLAIM_DIR" "$broken" 2>/dev/null && _dir_rm "$broken"
+      ;;
+  esac
+  return 1
+}
 
 # Only the holder of RECLAIM_DIR may delete a lease, and only on a verdict taken
 # under that lock: a verdict from before the lock is a read another reclaimer
 # may already have acted on.
 _reclaim_stale() {
-  local rpid
-  if ! mkdir "$RECLAIM_DIR" 2>/dev/null; then
-    rpid="$(cat "$RECLAIM_DIR/pid" 2>/dev/null || true)"
-    if [ -n "$rpid" ] && kill -0 "$rpid" 2>/dev/null; then return 1; fi
-    _reclaim_unlock
-    return 1
-  fi
-  printf '%s\n' "$$" > "$RECLAIM_DIR/pid"
+  _reclaim_lock || return 1
   if [ -d "$LOCK_DIR" ] && [ "$(_judge)" = stale ]; then
     _lease_rm
-    _reclaim_unlock
+    _reclaim_release
     return 0
   fi
-  _reclaim_unlock
+  _reclaim_release
   return 1
-}
-
-_lease_age() {
-  local now mt
-  now="$(date +%s)"
-  # GNU first and validate: `stat -f` on GNU is --file-system and SUCCEEDS with
-  # non-numeric output, so a BSD-first probe never falls through on Linux.
-  mt="$(stat -c %Y "$LOCK_DIR" 2>/dev/null || true)"
-  case "$mt" in '' | *[!0-9]*) mt="$(stat -f %m "$LOCK_DIR" 2>/dev/null || true)" ;; esac
-  # Unreadable mtime reads as just-published, so the guard defers rather than
-  # reclaiming: an unknown age must never authorise deleting a live lease.
-  case "$mt" in '' | *[!0-9]*) mt="$now" ;; esac
-  echo $(( now - mt ))
 }
 
 # mkdir is the portable atomic test-and-set; macOS ships no flock(1).
@@ -132,13 +186,15 @@ acquire_lease() {
   local attempt verdict
   for attempt in 1 2 3 4 5 6; do
     if mkdir "$LOCK_DIR" 2>/dev/null; then
-      # Publish via rename so a contender sees the token whole or not at all.
-      printf '%s\n' "$$" > "$LOCK_DIR/pid"
-      printf '%s' "$OWNER_TOKEN" > "$LOCK_DIR/.token.$$" \
-        && mv -f "$LOCK_DIR/.token.$$" "$LOCK_DIR/token"
-      lease_held=1
-      return 0
+      if _publish_token "$LOCK_DIR"; then
+        lease_held=1
+        return 0
+      fi
+      echo "task-notifier-supervisor: could not publish the lease token in $LOCK_DIR" >&2
+      _lease_rm
+      exit 1
     fi
+    [ -n "$JUDGE_HOOK" ] && bash "$JUDGE_HOOK"
     verdict="$(_judge)"
     case "$verdict" in
       live)
@@ -150,6 +206,12 @@ acquire_lease() {
       unknown)
         echo "task-notifier-supervisor: cannot verify the start identity of lease holder $(_lease_token | cut -d: -f1); assuming live; exiting" >&2
         exit 0 ;;
+      absent)
+        # The holder released between our mkdir and this read: try again.
+        sleep 0.1; continue ;;
+      error)
+        echo "task-notifier-supervisor: cannot create lease $LOCK_DIR (parent missing or unwritable)" >&2
+        exit 1 ;;
     esac
     # Stale by a read outside the lock. The hook is a test seam that lets a
     # control hold this reclaimer exactly here.

--- a/src/agent/codex/cli/task-notifier-supervisor.sh
+++ b/src/agent/codex/cli/task-notifier-supervisor.sh
@@ -10,8 +10,15 @@ RESTART_DELAY_MAX="${SUTANDO_NOTIFIER_RESTART_DELAY_MAX:-30}"
 STABLE_AFTER="${SUTANDO_NOTIFIER_STABLE_AFTER:-60}"
 # start-cli.sh launches one notifier per (socket, session); keying on SESSION
 # alone makes two cores on different sockets suppress each other.
-_lease_key() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
-LOCK_DIR="${SUTANDO_NOTIFIER_LOCK_DIR:-${TMPDIR:-/tmp}/sutando-notifier-$(_lease_key "${TMUX_SOCKET}#${SESSION}").lock}"
+# Readable session prefix plus a digest of the exact (socket, session) pair:
+# flattening punctuation to `_` made distinct sockets share one lease.
+_lease_key() {
+  printf '%s-%s' "$(printf '%s' "$2" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-40)" \
+    "$(python3 -c 'import hashlib,sys;print(hashlib.sha256("\0".join(sys.argv[1:]).encode()).hexdigest()[:16])' "$1" "$2")"
+}
+LOCK_DIR="${SUTANDO_NOTIFIER_LOCK_DIR:-${TMPDIR:-/tmp}/sutando-notifier-$(_lease_key "$TMUX_SOCKET" "$SESSION").lock}"
+RECLAIM_DIR="$LOCK_DIR.reclaim"
+RECLAIM_HOOK="${SUTANDO_NOTIFIER_RECLAIM_HOOK:-}"
 NOTIFIER="${SUTANDO_NOTIFIER_SCRIPT:-$REPO/src/agent/codex/cli/task-notifier.sh}"
 # task-notifier.sh exits 2 only for a usage/configuration fault; respawning
 # re-runs the same broken invocation, so that one is terminal rather than retried.
@@ -31,9 +38,15 @@ stop_child() {
 
 # Our token: pid plus this process's start identity, so a recycled pid cannot
 # impersonate us. Read once — /proc is absent on macOS, so ps is the portable source.
-_own_token() {
-  printf '%s:%s' "$$" "$(ps -o lstart= -p "$$" 2>/dev/null | tr -s ' ' '_' || echo unknown)"
+# Prints the start identity of pid $1; fails when it cannot be measured. An
+# empty `ps` piped through `tr` is not an identity, it is a blind probe.
+_start_of() {
+  local out
+  out="$(ps -o lstart= -p "$1" 2>/dev/null)" || return 1
+  [ -n "$out" ] || return 1
+  printf '%s' "$out" | tr -s ' ' '_'
 }
+_own_token() { printf '%s:%s' "$$" "$(_start_of "$$" || echo unknown)"; }
 OWNER_TOKEN="$(_own_token)"
 
 _lease_token() { cat "$LOCK_DIR/token" 2>/dev/null || true; }
@@ -58,7 +71,48 @@ release_lease() {
 
 PUBLISH_GRACE="${SUTANDO_NOTIFIER_PUBLISH_GRACE:-10}"
 
-_pid_token() { printf '%s:%s' "$1" "$(ps -o lstart= -p "$1" 2>/dev/null | tr -s ' ' '_' || echo unknown)"; }
+# Verdict on the lease at LOCK_DIR: live | publishing | unknown | stale.
+# `unknown` is a live pid whose start identity cannot be compared on either
+# side; it must read as contended, never as pid reuse.
+_judge() {
+  local token owner age start
+  token="$(_lease_token)"
+  owner="${token%%:*}"
+  [ -n "$token" ] || owner="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  if [ -z "$owner" ]; then
+    age="$(_lease_age)"
+    [ "$age" -lt "$PUBLISH_GRACE" ] && { echo publishing; return; }
+    echo stale; return
+  fi
+  kill -0 "$owner" 2>/dev/null || { echo stale; return; }
+  [ -n "$token" ] || { echo live; return; }
+  start="$(_start_of "$owner" || true)"
+  if [ -z "$start" ] || [ "${token#*:}" = unknown ]; then echo unknown; return; fi
+  [ "$start" = "${token#*:}" ] && echo live || echo stale
+}
+
+_reclaim_unlock() { rm -f "$RECLAIM_DIR/pid" 2>/dev/null; rmdir "$RECLAIM_DIR" 2>/dev/null || true; }
+
+# Only the holder of RECLAIM_DIR may delete a lease, and only on a verdict taken
+# under that lock: a verdict from before the lock is a read another reclaimer
+# may already have acted on.
+_reclaim_stale() {
+  local rpid
+  if ! mkdir "$RECLAIM_DIR" 2>/dev/null; then
+    rpid="$(cat "$RECLAIM_DIR/pid" 2>/dev/null || true)"
+    if [ -n "$rpid" ] && kill -0 "$rpid" 2>/dev/null; then return 1; fi
+    _reclaim_unlock
+    return 1
+  fi
+  printf '%s\n' "$$" > "$RECLAIM_DIR/pid"
+  if [ -d "$LOCK_DIR" ] && [ "$(_judge)" = stale ]; then
+    _lease_rm
+    _reclaim_unlock
+    return 0
+  fi
+  _reclaim_unlock
+  return 1
+}
 
 _lease_age() {
   local now mt
@@ -75,8 +129,8 @@ _lease_age() {
 
 # mkdir is the portable atomic test-and-set; macOS ships no flock(1).
 acquire_lease() {
-  local attempt owner token age
-  for attempt in 1 2 3; do
+  local attempt verdict
+  for attempt in 1 2 3 4 5 6; do
     if mkdir "$LOCK_DIR" 2>/dev/null; then
       # Publish via rename so a contender sees the token whole or not at all.
       printf '%s\n' "$$" > "$LOCK_DIR/pid"
@@ -85,34 +139,22 @@ acquire_lease() {
       lease_held=1
       return 0
     fi
-    token="$(_lease_token)"
-    owner="${token%%:*}"
-    if [ -z "$token" ]; then
-      # No token. A `pid` file is still usable identity (a pre-token lease), so
-      # fall through to the liveness check rather than widening the grace window.
-      owner="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
-    fi
-    if [ -z "$owner" ]; then
-      # Neither token nor pid: the ONLY genuinely ambiguous state — a winner
-      # between mkdir and publication, or a crash inside it. Bounded, and it
-      # defers, because deleting here races a live owner into a double-run.
-      age="$(_lease_age)"
-      if [ "$age" -lt "$PUBLISH_GRACE" ]; then
-        echo "task-notifier-supervisor: lease $LOCK_DIR is publishing (${age}s); exiting" >&2
-        exit 0
-      fi
-      _lease_rm
-      continue
-    fi
-    # A token pins the START identity too, so a recycled pid cannot impersonate
-    # the owner. A pre-token lease has only the pid to go on.
-    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null \
-       && { [ -z "$token" ] || [ "$(_pid_token "$owner")" = "$token" ]; }; then
-      echo "task-notifier-supervisor: pid $owner already supervises '$SESSION'; exiting" >&2
-      exit 0
-    fi
-    # Owner is gone (or its pid was recycled by an unrelated process): stale.
-    _lease_rm
+    verdict="$(_judge)"
+    case "$verdict" in
+      live)
+        echo "task-notifier-supervisor: pid $(_lease_token | cut -d: -f1) already supervises '$SESSION'; exiting" >&2
+        exit 0 ;;
+      publishing)
+        echo "task-notifier-supervisor: lease $LOCK_DIR is publishing ($(_lease_age)s); exiting" >&2
+        exit 0 ;;
+      unknown)
+        echo "task-notifier-supervisor: cannot verify the start identity of lease holder $(_lease_token | cut -d: -f1); assuming live; exiting" >&2
+        exit 0 ;;
+    esac
+    # Stale by a read outside the lock. The hook is a test seam that lets a
+    # control hold this reclaimer exactly here.
+    [ -n "$RECLAIM_HOOK" ] && bash "$RECLAIM_HOOK"
+    _reclaim_stale || sleep 0.2
   done
   echo "task-notifier-supervisor: could not acquire lease $LOCK_DIR" >&2
   exit 1

--- a/src/agent/codex/cli/task-notifier-supervisor.sh
+++ b/src/agent/codex/cli/task-notifier-supervisor.sh
@@ -6,8 +6,15 @@ REPO="$(cd "$(dirname "$0")/../../../.." && pwd)"
 TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
 SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 RESTART_DELAY="${SUTANDO_NOTIFIER_RESTART_DELAY:-1}"
+RESTART_DELAY_MAX="${SUTANDO_NOTIFIER_RESTART_DELAY_MAX:-30}"
+STABLE_AFTER="${SUTANDO_NOTIFIER_STABLE_AFTER:-60}"
+LOCK_DIR="${SUTANDO_NOTIFIER_LOCK_DIR:-${TMPDIR:-/tmp}/sutando-notifier-${SESSION}.lock}"
 NOTIFIER="${SUTANDO_NOTIFIER_SCRIPT:-$REPO/src/agent/codex/cli/task-notifier.sh}"
+# task-notifier.sh exits 2 only for a usage/configuration fault; respawning
+# re-runs the same broken invocation, so that one is terminal rather than retried.
+FATAL_STATUS=2
 child_pid=""
+lease_held=""
 
 stop_child() {
   [ -n "$child_pid" ] || return 0
@@ -19,9 +26,41 @@ stop_child() {
   child_pid=""
 }
 
-trap 'stop_child; exit 0' HUP INT TERM
+release_lease() {
+  [ -n "$lease_held" ] || return 0
+  rm -rf "$LOCK_DIR" 2>/dev/null || true
+  lease_held=""
+}
 
+# mkdir is the portable atomic test-and-set; macOS ships no flock(1).
+acquire_lease() {
+  local attempt owner
+  for attempt in 1 2 3; do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      printf '%s\n' "$$" > "$LOCK_DIR/pid"
+      lease_held=1
+      return 0
+    fi
+    owner="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+      echo "task-notifier-supervisor: pid $owner already supervises '$SESSION'; exiting" >&2
+      exit 0
+    fi
+    # Owner is gone: the lease is stale, not contended. Clear it and retry.
+    rm -rf "$LOCK_DIR" 2>/dev/null || true
+  done
+  echo "task-notifier-supervisor: could not acquire lease $LOCK_DIR" >&2
+  exit 1
+}
+
+trap 'stop_child; release_lease; exit 0' HUP INT TERM
+trap 'release_lease' EXIT
+
+acquire_lease
+
+delay="$RESTART_DELAY"
 while tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null; do
+  started_at="$(date +%s)"
   # watch-tasks-stream.sh deliberately uses `kill 0` when its fswatch pipeline
   # ends so no orphan child survives. Run the notifier in a separate process
   # group; otherwise that cleanup signal also kills this supervisor and tmux
@@ -34,6 +73,17 @@ while tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null; do
   status=$?
   child_pid=""
   tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null || exit 0
-  echo "task-notifier-supervisor: notifier exited with status $status; restarting" >&2
-  sleep "$RESTART_DELAY"
+  if [ "$status" -eq "$FATAL_STATUS" ]; then
+    echo "task-notifier-supervisor: notifier exited with status $status (configuration fault); not restarting" >&2
+    exit "$status"
+  fi
+  # A run that lasted proves the fault cleared; a short one is a crash loop, so
+  # only the former resets the backoff.
+  if [ "$(( $(date +%s) - started_at ))" -ge "$STABLE_AFTER" ]; then
+    delay="$RESTART_DELAY"
+  fi
+  echo "task-notifier-supervisor: notifier exited with status $status; restarting in ${delay}s" >&2
+  sleep "$delay"
+  delay=$(( delay * 2 ))
+  [ "$delay" -gt "$RESTART_DELAY_MAX" ] && delay="$RESTART_DELAY_MAX"
 done

--- a/src/portable_mtime.sh
+++ b/src/portable_mtime.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# The ONE portable mtime probe. GNU `stat -f` means --file-system and SUCCEEDS
+# with prose, so a BSD-first `||` chain never falls through on Linux; validate
+# the RESULT. Prints epoch seconds; returns 2 when the mtime is unreadable.
+portable_mtime() {
+  local mt
+  mt="$(stat -c %Y "$1" 2>/dev/null || true)"
+  case "$mt" in '' | *[!0-9]*) mt="$(stat -f %m "$1" 2>/dev/null || true)" ;; esac
+  case "$mt" in '' | *[!0-9]*) return 2 ;; esac
+  printf '%s\n' "$mt"
+}

--- a/src/watcher_sentinel.sh
+++ b/src/watcher_sentinel.sh
@@ -61,6 +61,9 @@ sentinel_paths_in() {
 
 # Seconds of elapsed time for a pid, or empty when it cannot be determined.
 # `etime` is [[DD-]HH:]MM:SS on both BSD and GNU ps.
+# shellcheck source=src/portable_mtime.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/portable_mtime.sh"
+
 sentinel_pid_elapsed() {
   local pid="$1" raw
   raw="$(ps -p "$pid" -o etime= 2>/dev/null | tr -d ' ')" || return 1
@@ -95,16 +98,7 @@ sentinel_pid_wrote_file() {
   elapsed="$(sentinel_pid_elapsed "$pid")" || return 2
   case "$elapsed" in ''|*[!0-9]*) return 2 ;; esac   # non-numeric => UNKNOWN, never "owner"
 
-  # `stat -f %m` is BSD "modification time"; on GNU `-f` means FILESYSTEM status
-  # and SUCCEEDS with a human-readable block, so an `||` chain never reaches the
-  # GNU form and $mtime becomes text. Measured on the ubuntu runner: the value
-  # started with "File:" and `$(( now - mtime ))` died as `File: unbound
-  # variable`. macOS passed because BSD is correct there — the GNU path was
-  # never exercised locally. So validate the RESULT rather than trusting the
-  # exit status: a command that succeeds at a different question is the failure.
-  mtime="$(stat -c %Y "$pid_file" 2>/dev/null || true)"
-  case "$mtime" in ''|*[!0-9]*) mtime="$(stat -f %m "$pid_file" 2>/dev/null || true)" ;; esac
-  case "$mtime" in ''|*[!0-9]*) return 2 ;; esac   # mtime unreadable => UNKNOWN
+  mtime="$(portable_mtime "$pid_file")" || return 2   # mtime unreadable => UNKNOWN
 
   now="$(date +%s)"
   age=$(( now - mtime ))

--- a/tests/codex-notifier-supervisor-lifecycle.test.py
+++ b/tests/codex-notifier-supervisor-lifecycle.test.py
@@ -250,6 +250,22 @@ class LeaseOwnershipTest(unittest.TestCase):
                         "the former owner deleted a lease it no longer held")
         self.assertNotEqual((self.lock / "token").read_text(), successor)
 
+    def test_an_unreadable_mtime_defers_instead_of_reclaiming(self):
+        """The grace check reads mtime through `stat`, whose flags differ by
+        platform. A variant that prints non-numeric text and exits 0 must not
+        turn the guard into the lease-steal it exists to prevent."""
+        _write(self.d / "stat", """
+            #!/bin/bash
+            echo '?'
+            exit 0
+        """, executable=True)
+        self.lock.mkdir()
+        r = self._run("blind", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("publishing", r.stderr)
+        self.assertNotIn("blind", self._ran(), "an unreadable mtime let it steal the lease")
+        self.assertTrue(self.lock.exists())
+
     # --- P2: the lease is keyed per (socket, session), as start-cli launches ---
 
     def test_a_second_socket_does_not_suppress_the_first(self):

--- a/tests/codex-notifier-supervisor-lifecycle.test.py
+++ b/tests/codex-notifier-supervisor-lifecycle.test.py
@@ -330,6 +330,162 @@ class LeaseOwnershipTest(unittest.TestCase):
         self.assertIsNone(r.poll())
         self.assertNotIn("999999", (self.lock / "token").read_text())
 
+    # --- P1: the reclaim lock is publication-, identity- and release-safe ---
+
+    def _hold_hook(self, name):
+        entered, go = self.d / f"{name}-entered", self.d / f"{name}-go"
+        hook = _write(self.d / f"{name}.sh", f"""
+            #!/bin/bash
+            touch "{entered}"
+            while [ ! -f "{go}" ]; do sleep 0.05; done
+        """, executable=True)
+        return hook, entered, go
+
+    def _wait_for(self, path, what, timeout=20):
+        deadline = time.monotonic() + timeout
+        while not path.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        self.assertTrue(path.exists(), what)
+
+    def test_an_empty_reclaim_publication_cannot_be_stolen(self):
+        """A holds RECLAIM_DIR right after mkdir, before its token lands; B must
+        defer, not unlock it and enter the critical section beside A."""
+        self._plant_stale()
+        hook, entered, go = self._hold_hook("publish")
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock),
+                     SUTANDO_NOTIFIER_RECLAIM_PUBLISH_HOOK=str(hook))
+        self._wait_for(entered, "reclaimer A never reached the publication window")
+        b = self._run("B", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self.assertNotEqual(b.returncode, 0, b.stderr)
+        self.assertNotIn("B", self._ran(), "B entered the critical section during A's publication")
+        go.touch()
+        self._await_run("A")
+        self.assertIsNone(a.poll())
+        self.assertEqual(self._ran(), ["A"])
+
+    def test_published_reclaim_control_still_wins(self):
+        """Control: with no contender in the window, the same reclaim runs."""
+        self._plant_stale()
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("A")
+        self.assertEqual(self._ran(), ["A"])
+
+    def _plant_reclaimer(self, token):
+        r = Path(str(self.lock) + ".reclaim")
+        r.mkdir()
+        (r / "token").write_text(token)
+        (r / "pid").write_text(token.split(":")[0] + "\n")
+        old = time.time() - 600
+        os.utime(r, (old, old))
+        return r
+
+    def test_a_recycled_pid_cannot_impersonate_a_dead_reclaimer(self):
+        """The reclaim lock names a pid that is live but belongs to another
+        process (a recycled pid). Its start identity does not match, so the
+        lock is stale and is broken; recovery must not wedge."""
+        self._plant_stale()
+        self._plant_reclaimer(f"{os.getpid()}:Mon_Jan__1_00:00:00_2001")
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("A")
+        self.assertEqual(self._ran(), ["A"])
+
+    def test_a_dead_reclaimer_is_broken(self):
+        self._plant_stale()
+        self._plant_reclaimer("999999:Mon_Jan__1_00:00:00_2001")
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("A")
+        self.assertEqual(self._ran(), ["A"])
+
+    def test_a_live_reclaimer_is_respected(self):
+        """Positive control for the identity check: a lock whose holder is
+        alive AND matches its start identity is contended, never broken."""
+        # Spelled exactly as the script spells its own identity (`tr -s ' ' '_'`
+        # over the raw ps line), or a leading blank alone makes it "recycled".
+        ident = subprocess.run(["bash", "-c", "ps -o lstart= -p $1 | tr -s ' ' '_'", "_",
+                                str(os.getpid())], capture_output=True, text=True).stdout
+        if not ident.strip("_\n"):
+            self.skipTest("ps cannot report this process's start time here")
+        ident = ident.rstrip("\n")
+        self._plant_stale()
+        r = self._plant_reclaimer(f"{os.getpid()}:{ident}")
+        b = self._run("B", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self.assertNotEqual(b.returncode, 0)
+        self.assertNotIn("B", self._ran())
+        self.assertTrue(r.exists(), "a live reclaimer's lock was broken")
+
+    # --- P1: the primary lease has no unrecoverable or false-success state ---
+
+    def test_an_orphaned_staged_token_is_reclaimable(self):
+        """A crash between staging and rename left `.token.<pid>` inside the
+        lease directory; that artifact must not block rmdir forever."""
+        self.lock.mkdir()
+        (self.lock / ".token.999999").write_text("999999:Mon_Jan__1_00:00:00_2001")
+        old = time.time() - 600
+        os.utime(self.lock, (old, old))
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("A")
+        self.assertEqual(self._ran(), ["A"])
+        self.assertFalse((self.lock / ".token.999999").exists())
+
+    def test_staging_happens_outside_the_lease_directory(self):
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("A")
+        self.assertEqual(sorted(p.name for p in self.lock.iterdir()), ["pid", "token"])
+
+    def test_a_lease_that_disappears_after_mkdir_failed_is_retried(self):
+        """mkdir failed, then the holder released before the verdict: absence
+        is a retry, not `publishing` (age 0 of a missing path) and not exit 0."""
+        self.lock.mkdir()
+        (self.lock / "pid").write_text("999999\n")
+        hook = _write(self.d / "vanish.sh", f"""
+            #!/bin/bash
+            rm -rf "{self.lock}"
+        """, executable=True)
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock),
+                     SUTANDO_NOTIFIER_JUDGE_HOOK=str(hook))
+        self._await_run("A")
+        self.assertEqual(self._ran(), ["A"])
+        self.assertTrue(self.lock.exists())
+
+    def test_absent_before_mkdir_control(self):
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("A")
+        self.assertEqual(self._ran(), ["A"])
+
+    def test_an_unwritable_lease_parent_is_an_error_not_contention(self):
+        missing = self.d / "no-such-parent" / "lease.lock"
+        r = self._run("E", SUTANDO_NOTIFIER_LOCK_DIR=str(missing))
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("cannot create lease", r.stderr)
+        self.assertNotIn("publishing", r.stderr)
+        self.assertEqual(self._ran(), [])
+
+    # --- P2: a failed digest must not alias sockets onto one key ---
+
+    def _python_that_fails_hashlib(self):
+        d = self.d / "badpy"
+        d.mkdir(exist_ok=True)
+        real = subprocess.run(["bash", "-c", "command -v python3"], capture_output=True,
+                              text=True).stdout.strip()
+        _write(d / "python3", f"""
+            #!/bin/bash
+            case "$*" in *hashlib*) exit 1 ;; esac
+            exec "{real}" "$@"
+        """, executable=True)
+        return d
+
+    def test_digest_failure_fails_closed_before_any_lease(self):
+        env = self._env("digest", SUTANDO_TMUX_SOCKET="/tmp/team/a.sock",
+                        SUTANDO_TMUX_SESSION="s")
+        env["PATH"] = f"{self._python_that_fails_hashlib()}:{env['PATH']}"
+        r = subprocess.run(["bash", str(SUPERVISOR)], env=env,
+                           capture_output=True, text=True, timeout=60)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("cannot derive the lease key", r.stderr)
+        self.assertEqual(self._ran(), [])
+        self.assertEqual(list(self.d.glob("sutando-notifier-*.lock")), [],
+                         "a lease was taken under a collapsed key")
+
     # --- P1: an unmeasurable start identity is contended, never stale ---
 
     def _blind_ps_dir(self):

--- a/tests/codex-notifier-supervisor-lifecycle.test.py
+++ b/tests/codex-notifier-supervisor-lifecycle.test.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Lifecycle contract for src/agent/codex/cli/task-notifier-supervisor.sh.
+
+The supervisor is the only thing keeping the Codex task notifier alive, so its
+failure handling is load-bearing: a fixed 1s respawn turns a permanent
+configuration fault into a crash loop, and a second supervisor silently doubles
+every wakeup the notifier injects.
+
+Timing is asserted through the supervisor's own "restarting in Ns" log lines
+rather than measured wall-clock gaps -- a sleep-timing assertion is flaky under
+CI load, and a flaky guard is worse than none.
+"""
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SUPERVISOR = REPO / "src" / "agent" / "codex" / "cli" / "task-notifier-supervisor.sh"
+
+
+def _write(path: Path, body: str, executable: bool = False) -> Path:
+    path.write_text(textwrap.dedent(body).lstrip())
+    if executable:
+        path.chmod(0o755)
+    return path
+
+
+class SupervisorLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self.runs = self.d / "runs"
+        self.lock = self.d / "lease.lock"
+
+    def _fake_tmux(self, alive_calls: int) -> Path:
+        """`tmux has-session` succeeds alive_calls times, then reports gone."""
+        return _write(self.d / "tmux", f"""
+            #!/bin/bash
+            C="{self.d}/tmux.calls"
+            n=$(cat "$C" 2>/dev/null || echo 0)
+            echo $((n+1)) > "$C"
+            [ "$n" -lt "{alive_calls}" ]
+        """, executable=True)
+
+    def _notifier(self, exit_code: int) -> Path:
+        """Records which pid owns the lease while the notifier runs. Recording
+        mere directory existence cannot tell a lease this supervisor took from a
+        stale one a test planted, so both lease assertions would pass unfixed."""
+        return _write(self.d / "notifier.sh", f"""
+            #!/bin/bash
+            echo "run:$(cat '{self.lock}/pid' 2>/dev/null || echo none)" >> "{self.runs}"
+            exit {exit_code}
+        """, executable=True)
+
+    def lease_owners_seen(self) -> list:
+        if not self.runs.exists():
+            return []
+        return [ln.split(":", 1)[1] for ln in self.runs.read_text().split() if ln.startswith("run:")]
+
+    def _run(self, alive_calls=6, exit_code=1, env_extra=None):
+        self._fake_tmux(alive_calls)
+        notifier = self._notifier(exit_code)
+        env = dict(os.environ)
+        env.update({
+            "PATH": f"{self.d}:{env['PATH']}",
+            "SUTANDO_NOTIFIER_SCRIPT": str(notifier),
+            "SUTANDO_NOTIFIER_LOCK_DIR": str(self.lock),
+            "SUTANDO_NOTIFIER_RESTART_DELAY": "1",
+            "SUTANDO_NOTIFIER_RESTART_DELAY_MAX": "4",
+            "SUTANDO_NOTIFIER_STABLE_AFTER": "600",
+        })
+        env.update(env_extra or {})
+        return subprocess.run(["bash", str(SUPERVISOR)], env=env,
+                              capture_output=True, text=True, timeout=90)
+
+    def run_count(self) -> int:
+        return len(self.runs.read_text().split()) if self.runs.exists() else 0
+
+    def test_backoff_grows_and_is_capped(self):
+        """A crash-looping notifier must not be respawned at a fixed 1s."""
+        r = self._run(alive_calls=8, exit_code=1)
+        delays = [int(w.rstrip("s.")) for line in r.stderr.splitlines()
+                  if "restarting in" in line
+                  for w in [line.rsplit(" ", 1)[-1]]]
+        self.assertGreaterEqual(len(delays), 3, f"expected several restarts, got {r.stderr}")
+        self.assertEqual(delays[:3], [1, 2, 4], "backoff must double from the base delay")
+        self.assertTrue(all(d <= 4 for d in delays), f"backoff exceeded its cap: {delays}")
+
+    def test_configuration_fault_is_terminal(self):
+        """Exit 2 is a usage fault; respawning re-runs the same broken call."""
+        r = self._run(alive_calls=8, exit_code=2)
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("not restarting", r.stderr)
+        self.assertEqual(self.run_count(), 1, "a configuration fault must not respawn")
+
+    def test_second_supervisor_defers_to_a_live_lease_holder(self):
+        """Two supervisors would double every notification injected into Codex."""
+        self.lock.mkdir()
+        (self.lock / "pid").write_text(f"{os.getpid()}\n")
+        r = self._run(alive_calls=8, exit_code=1)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("already supervises", r.stderr)
+        self.assertEqual(self.run_count(), 0, "the loser must not spawn a notifier")
+
+    def test_stale_lease_is_reclaimed(self):
+        """A lease whose owner died is stale, not contended -- else one crash
+        wedges the notifier permanently."""
+        self.lock.mkdir()
+        dead = subprocess.run(["bash", "-c", "echo $$"], capture_output=True, text=True)
+        dead_pid = dead.stdout.strip()
+        (self.lock / "pid").write_text(dead_pid + "\n")
+        r = self._run(alive_calls=2, exit_code=1)
+        self.assertNotIn("already supervises", r.stderr)
+        owners = self.lease_owners_seen()
+        self.assertGreaterEqual(len(owners), 1, "stale lease must be reclaimed")
+        self.assertNotIn(dead_pid, owners,
+                         "the dead owner's lease was left in place, not retaken")
+        self.assertNotIn("none", owners, "reclaiming must take the lease")
+
+    def test_lease_is_held_during_the_run_and_released_after(self):
+        self._run(alive_calls=1, exit_code=1)
+        owners = self.lease_owners_seen()
+        self.assertTrue(owners and "none" not in owners, f"lease never taken: {owners}")
+        self.assertFalse(self.lock.exists(), "lease outlived the supervisor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/codex-notifier-supervisor-lifecycle.test.py
+++ b/tests/codex-notifier-supervisor-lifecycle.test.py
@@ -11,6 +11,7 @@ rather than measured wall-clock gaps -- a sleep-timing assertion is flaky under
 CI load, and a flaky guard is worse than none.
 """
 import os
+import time
 import subprocess
 import tempfile
 import textwrap
@@ -137,6 +138,148 @@ class SupervisorLifecycleTest(unittest.TestCase):
         owners = self.lease_owners_seen()
         self.assertTrue(owners and "none" not in owners, f"lease never taken: {owners}")
         self.assertFalse(self.lock.exists(), "lease outlived the supervisor")
+
+
+class LeaseOwnershipTest(unittest.TestCase):
+    """Contention controls. Every one drives the production supervisor: a
+    hand-rolled recipe would certify a script the repo does not ship."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self.runs = self.d / "runs"
+        self.lock = self.d / "lease.lock"
+        self.stop = self.d / "stop"
+        # Alive until the test says otherwise, so two supervisors can overlap.
+        _write(self.d / "tmux", f"""
+            #!/bin/bash
+            [ -f "{self.stop}" ] && exit 1
+            exit 0
+        """, executable=True)
+
+    def _notifier(self, tag):
+        n = _write(self.d / f"notifier-{tag}.sh", f"""
+            #!/bin/bash
+            echo "{tag}" >> "{self.runs}"
+            sleep 30
+        """, executable=True)
+        return n
+
+    def _env(self, tag, **extra):
+        env = dict(os.environ)
+        env.update({
+            "PATH": f"{self.d}:{env['PATH']}",
+            "TMPDIR": str(self.d),
+            "SUTANDO_NOTIFIER_SCRIPT": str(self._notifier(tag)),
+            "SUTANDO_NOTIFIER_RESTART_DELAY": "1",
+            "SUTANDO_NOTIFIER_RESTART_DELAY_MAX": "2",
+            "SUTANDO_NOTIFIER_STABLE_AFTER": "600",
+        })
+        env.pop("SUTANDO_NOTIFIER_LOCK_DIR", None)
+        env.update(extra)
+        return env
+
+    def _run(self, tag, **extra):
+        return subprocess.run(["bash", str(SUPERVISOR)], env=self._env(tag, **extra),
+                              capture_output=True, text=True, timeout=60)
+
+    def _bg(self, tag, **extra):
+        proc = subprocess.Popen(["bash", str(SUPERVISOR)], env=self._env(tag, **extra),
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        self.addCleanup(self._reap, proc)
+        return proc
+
+    def _reap(self, proc):
+        self.stop.touch()
+        try:
+            proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    def _ran(self):
+        return self.runs.read_text().split() if self.runs.exists() else []
+
+    def _await_run(self, tag, timeout=25):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if tag in self._ran():
+                return
+            time.sleep(0.2)
+        self.fail(f"supervisor {tag} never started its notifier; ran={self._ran()}")
+
+    # --- incomplete publication (kewei's P1 repro: mkdir before metadata) ---
+
+    def test_incomplete_publication_defers_rather_than_deleting(self):
+        """A directory with no metadata is a winner caught mid-publication.
+        Deleting it hands a second supervisor the lease the first one holds."""
+        self.lock.mkdir()
+        r = self._run("second", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self.assertEqual(r.returncode, 0)
+        self.assertNotIn("second", self._ran(), "ran while a winner was publishing")
+        self.assertTrue(self.lock.exists(), "deleted a publishing winner's lease")
+
+    def test_incomplete_publication_is_reclaimed_once_stale(self):
+        """The defer above is bounded: a crash inside publication must not
+        wedge the notifier off forever."""
+        self.lock.mkdir()
+        old = time.time() - 600
+        os.utime(self.lock, (old, old))
+        self._bg("late", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock),
+                 SUTANDO_NOTIFIER_PUBLISH_GRACE="10")
+        self._await_run("late")
+
+    # --- former owner must not delete its successor ---
+
+    def test_former_owner_leaves_its_successors_lease_alone(self):
+        holder = self._bg("holder", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("holder")
+        successor = (self.lock / "token").read_text()
+
+        # Reclaim it out from under the holder, as a stale-lease sweep would.
+        (self.lock / "token").write_text("999999:elsewhere\n")
+        (self.lock / "pid").write_text("999999\n")
+
+        holder.terminate()   # runs the trap -> release_lease, the path under test
+        holder.wait(timeout=25)
+        self.assertTrue(self.lock.exists(),
+                        "the former owner deleted a lease it no longer held")
+        self.assertNotEqual((self.lock / "token").read_text(), successor)
+
+    # --- P2: the lease is keyed per (socket, session), as start-cli launches ---
+
+    def test_a_second_socket_does_not_suppress_the_first(self):
+        self._bg("A", SUTANDO_TMUX_SOCKET="/tmp/sock-A", SUTANDO_TMUX_SESSION="s")
+        self._await_run("A")
+
+        same = self._run("same", SUTANDO_TMUX_SOCKET="/tmp/sock-A",
+                         SUTANDO_TMUX_SESSION="s")
+        self.assertEqual(same.returncode, 0)
+        self.assertNotIn("same", self._ran(),
+                         "two notifiers on one (socket, session) — the lease failed")
+
+        other = self._bg("B", SUTANDO_TMUX_SOCKET="/tmp/sock-B",
+                         SUTANDO_TMUX_SESSION="s")
+        self._await_run("B")
+        self.assertIsNone(other.poll(), "a second socket was suppressed by the first")
+
+    # --- cleanup must not be recursive on a configurable path ---
+
+    def test_cleanup_never_removes_unrelated_contents(self):
+        self.lock.mkdir()
+        keep = self.lock / "not-ours"
+        keep.write_text("someone else's data\n")
+        old = time.time() - 600
+        os.utime(self.lock, (old, old))
+        r = self._run("recurse", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock),
+                      SUTANDO_NOTIFIER_PUBLISH_GRACE="10")
+        self.assertTrue(keep.exists(),
+                        "supervisor deleted a pre-existing file under the lock path")
+        # Fail closed and say which path: refusing to run beats emptying a
+        # directory that is not ours because it sits at a configurable path.
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn(str(self.lock), r.stderr)
+        self.assertNotIn("recurse", self._ran())
 
 
 if __name__ == "__main__":

--- a/tests/codex-notifier-supervisor-lifecycle.test.py
+++ b/tests/codex-notifier-supervisor-lifecycle.test.py
@@ -283,6 +283,100 @@ class LeaseOwnershipTest(unittest.TestCase):
         self._await_run("B")
         self.assertIsNone(other.poll(), "a second socket was suppressed by the first")
 
+    # --- P1: reclamation is serialized and re-judged under its own lock ---
+
+    def _plant_stale(self):
+        self.lock.mkdir()
+        (self.lock / "token").write_text("999999:Mon_Jan__1_00:00:00_2001\n")
+        (self.lock / "pid").write_text("999999\n")
+        old = time.time() - 600
+        os.utime(self.lock, (old, old))
+
+    def test_two_reclaimers_cannot_both_win(self):
+        """Reclaimer A judges the lease stale and is held there; B reclaims and
+        runs; A resumes. A must not delete B's lease: both alive was the P1."""
+        self._plant_stale()
+        entered, go = self.d / "hook-entered", self.d / "hook-go"
+        hook = _write(self.d / "hook.sh", f"""
+            #!/bin/bash
+            touch "{entered}"
+            while [ ! -f "{go}" ]; do sleep 0.05; done
+        """, executable=True)
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock),
+                     SUTANDO_NOTIFIER_RECLAIM_HOOK=str(hook))
+        deadline = time.monotonic() + 20
+        while not entered.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        self.assertTrue(entered.exists(), "reclaimer A never reached the hook")
+
+        b = self._bg("B", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("B")
+        b_token = (self.lock / "token").read_text()
+
+        go.touch()
+        _, a_err = a.communicate(timeout=20)
+        self.assertEqual(a.returncode, 0, a_err)
+        self.assertIn("already supervises", a_err)
+        self.assertIsNone(b.poll(), "reclaimer A took the lease out from under B")
+        self.assertEqual((self.lock / "token").read_text(), b_token,
+                         "A deleted B's lease; a third contender could now double-run")
+        self.assertEqual(self._ran(), ["B"])
+
+    def test_serial_reclaim_still_works(self):
+        """Control for the race case: one reclaimer, no contention, must win."""
+        self._plant_stale()
+        r = self._bg("solo", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("solo")
+        self.assertIsNone(r.poll())
+        self.assertNotIn("999999", (self.lock / "token").read_text())
+
+    # --- P1: an unmeasurable start identity is contended, never stale ---
+
+    def _blind_ps_dir(self):
+        d = self.d / "blind"
+        d.mkdir(exist_ok=True)
+        _write(d / "ps", """
+            #!/bin/bash
+            exit 1
+        """, executable=True)
+        return d
+
+    def test_unreadable_contender_identity_refuses(self):
+        holder = self._bg("holder", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self._await_run("holder")
+        env = self._env("ps_blind", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        env["PATH"] = f"{self._blind_ps_dir()}:{env['PATH']}"
+        r = subprocess.run(["bash", str(SUPERVISOR)], env=env,
+                           capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("cannot verify", r.stderr)
+        self.assertIsNone(holder.poll(), "a blind contender stole the lease")
+        self.assertEqual(self._ran(), ["holder"])
+
+    def test_unreadable_holder_identity_refuses(self):
+        env = self._env("blind_holder", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        env["PATH"] = f"{self._blind_ps_dir()}:{env['PATH']}"
+        holder = subprocess.Popen(["bash", str(SUPERVISOR)], env=env,
+                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        self.addCleanup(self._reap, holder)
+        self._await_run("blind_holder")
+        self.assertIn(":unknown", (self.lock / "token").read_text())
+        r = self._run("sighted", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock))
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("cannot verify", r.stderr)
+        self.assertIsNone(holder.poll(), "a holder with an unreadable identity was treated as pid reuse")
+        self.assertEqual(self._ran(), ["blind_holder"])
+
+    # --- P2: the lease key must not alias distinct sockets ---
+
+    def test_colliding_flat_keys_do_not_alias(self):
+        """`/tmp/team/a.sock` and `/tmp/team_a.sock` flattened to one key."""
+        self._bg("nested", SUTANDO_TMUX_SOCKET="/tmp/team/a.sock", SUTANDO_TMUX_SESSION="s")
+        self._await_run("nested")
+        flat = self._bg("flat", SUTANDO_TMUX_SOCKET="/tmp/team_a.sock", SUTANDO_TMUX_SESSION="s")
+        self._await_run("flat")
+        self.assertIsNone(flat.poll(), "a distinct socket was suppressed by a colliding key")
+
     # --- cleanup must not be recursive on a configurable path ---
 
     def test_cleanup_never_removes_unrelated_contents(self):

--- a/tests/codex-notifier-supervisor-lifecycle.test.py
+++ b/tests/codex-notifier-supervisor-lifecycle.test.py
@@ -162,7 +162,7 @@ class LeaseOwnershipTest(unittest.TestCase):
         n = _write(self.d / f"notifier-{tag}.sh", f"""
             #!/bin/bash
             echo "{tag}" >> "{self.runs}"
-            sleep 30
+            sleep 10
         """, executable=True)
         return n
 
@@ -191,11 +191,15 @@ class LeaseOwnershipTest(unittest.TestCase):
         return proc
 
     def _reap(self, proc):
+        # SIGTERM, not the tmux stop file: the supervisor is blocked in `wait`
+        # on its child, so polling teardown costs a whole notifier lifetime.
         self.stop.touch()
+        proc.terminate()
         try:
-            proc.wait(timeout=20)
+            proc.wait(timeout=10)
         except subprocess.TimeoutExpired:
             proc.kill()
+            proc.wait(timeout=5)
 
     def _ran(self):
         return self.runs.read_text().split() if self.runs.exists() else []
@@ -241,7 +245,7 @@ class LeaseOwnershipTest(unittest.TestCase):
         (self.lock / "pid").write_text("999999\n")
 
         holder.terminate()   # runs the trap -> release_lease, the path under test
-        holder.wait(timeout=25)
+        holder.wait(timeout=15)
         self.assertTrue(self.lock.exists(),
                         "the former owner deleted a lease it no longer held")
         self.assertNotEqual((self.lock / "token").read_text(), successor)

--- a/tests/codex-notifier-supervisor-lifecycle.test.py
+++ b/tests/codex-notifier-supervisor-lifecycle.test.py
@@ -363,6 +363,62 @@ class LeaseOwnershipTest(unittest.TestCase):
         self.assertIsNone(a.poll())
         self.assertEqual(self._ran(), ["A"])
 
+    def _pause_shim(self, name, tools, pattern):
+        """PATH shim for ONE contender: the named tools pause on a go-file when
+        their arguments match `pattern`, then exec the real binary. Holding a
+        contender at its own filesystem action needs no seam in the script, so
+        the same control drives the pre-fix and post-fix supervisor alike."""
+        d = self.d / f"{name}-shim"
+        d.mkdir(exist_ok=True)
+        entered, go = self.d / f"{name}-shim-entered", self.d / f"{name}-shim-go"
+        for tool in tools:
+            _write(d / tool, f"""
+                #!/bin/bash
+                case "$*" in {pattern}) touch "{entered}"; while [ ! -f "{go}" ]; do sleep 0.05; done ;; esac
+                exec /bin/{tool} "$@"
+            """, executable=True)
+        return d, entered, go
+
+    def _settle(self, cond, timeout=20):
+        deadline = time.monotonic() + timeout
+        while not cond() and time.monotonic() < deadline:
+            time.sleep(0.1)
+        return cond()
+
+    def test_a_late_reclaim_publisher_cannot_proceed_after_its_directory_is_recovered(self):
+        """The reviewer's interleaving. A holds RECLAIM_DIR empty past the
+        publication grace. B judges it stale and is held before acting on that
+        verdict (its mv, or its claim). A then publishes, verifies ownership,
+        judges the lease stale and is held at its lease delete. B resumes and
+        recovers the directory; A resumes. With rename-based recovery both
+        launched: B took a fresh lease and A deleted it and launched too."""
+        self._plant_stale()
+        a_pub, a_pub_entered, a_pub_go = self._hold_hook("publish")
+        a_shim, a_rm_entered, a_rm_go = self._pause_shim("A", ("rm",), "*lease.lock/token*")
+        a = self._bg("A", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock),
+                     SUTANDO_NOTIFIER_PUBLISH_GRACE="1",
+                     SUTANDO_NOTIFIER_RECLAIM_PUBLISH_HOOK=str(a_pub),
+                     PATH=f"{a_shim}:{self.d}:{os.environ['PATH']}")
+        self._wait_for(a_pub_entered, "A never reached the publication window")
+        time.sleep(1.5)  # past the grace: A's empty directory now judges stale
+        b_shim, b_entered, b_go = self._pause_shim("B", ("mv", "ln"), "*.reclaim*")
+        b = self._bg("B", SUTANDO_NOTIFIER_LOCK_DIR=str(self.lock),
+                     SUTANDO_NOTIFIER_PUBLISH_GRACE="1",
+                     PATH=f"{b_shim}:{self.d}:{os.environ['PATH']}")
+        self._wait_for(b_entered, "B never judged the empty directory stale")
+        a_pub_go.touch()
+        self._wait_for(a_rm_entered, "A never published and reached its lease delete")
+        b_go.touch()
+        self._settle(lambda: b.poll() is not None or "B" in self._ran())
+        a_rm_go.touch()
+        self._await_run("A")
+        self._settle(lambda: b.poll() is not None or "B" in self._ran())
+        self.assertIsNone(a.poll(), "A did not keep running")
+        self.assertEqual(self._ran(), ["A"], "B launched beside A: two live supervisors")
+        self.assertEqual((self.lock / "token").read_text().split(":")[0], str(a.pid),
+                         "the lease is not A's")
+        self.assertIsNotNone(b.poll(), "B neither launched nor withdrew")
+
     def test_published_reclaim_control_still_wins(self):
         """Control: with no contender in the window, the same reclaim runs."""
         self._plant_stale()
@@ -485,6 +541,34 @@ class LeaseOwnershipTest(unittest.TestCase):
         self.assertEqual(self._ran(), [])
         self.assertEqual(list(self.d.glob("sutando-notifier-*.lock")), [],
                          "a lease was taken under a collapsed key")
+
+    def _python_with_malformed_digest(self):
+        """hashlib succeeds but prints sixteen non-hex bytes; every other python3
+        invocation is delegated, so only the digest guard is under test."""
+        d = self.d / "zpy"
+        d.mkdir(exist_ok=True)
+        real = subprocess.run(["bash", "-c", "command -v python3"], capture_output=True,
+                              text=True).stdout.strip()
+        _write(d / "python3", f"""
+            #!/bin/bash
+            case "$*" in *hashlib*) echo zzzzzzzzzzzzzzzz; exit 0 ;; esac
+            exec "{real}" "$@"
+        """, executable=True)
+        return d
+
+    def test_a_malformed_successful_digest_refuses(self):
+        """Sixteen bytes that are not hex is not a digest: two sockets would
+        collapse onto one lease exactly as an empty digest would."""
+        env = self._env("zdigest", SUTANDO_TMUX_SOCKET="/tmp/team/a.sock",
+                        SUTANDO_TMUX_SESSION="s")
+        env["PATH"] = f"{self._python_with_malformed_digest()}:{env['PATH']}"
+        r = subprocess.run(["bash", str(SUPERVISOR)], env=env,
+                           capture_output=True, text=True, timeout=60)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("cannot derive the lease key", r.stderr)
+        self.assertEqual(self._ran(), [])
+        self.assertEqual(list(self.d.glob("sutando-notifier-*.lock")), [],
+                         "a lease was taken under a malformed key")
 
     # --- P1: an unmeasurable start identity is contended, never stale ---
 

--- a/tests/codex-notifier-supervisor-lifecycle.test.py
+++ b/tests/codex-notifier-supervisor-lifecycle.test.py
@@ -90,6 +90,17 @@ class SupervisorLifecycleTest(unittest.TestCase):
         self.assertEqual(delays[:3], [1, 2, 4], "backoff must double from the base delay")
         self.assertTrue(all(d <= 4 for d in delays), f"backoff exceeded its cap: {delays}")
 
+    def test_fractional_restart_delay_still_restarts(self):
+        """The delay is documented as fractional and the launcher suite drives it
+        at 0.01. Bash arithmetic is integer-only, so doubling it with $(( )) kills
+        the supervisor after one spawn instead of backing off."""
+        r = self._run(alive_calls=6, exit_code=1,
+                      env_extra={"SUTANDO_NOTIFIER_RESTART_DELAY": "0.01",
+                                 "SUTANDO_NOTIFIER_RESTART_DELAY_MAX": "0.05"})
+        self.assertGreaterEqual(self.run_count(), 2,
+                                f"fractional delay must not stop the loop: {r.stderr}")
+        self.assertNotIn("syntax error", r.stderr)
+
     def test_configuration_fault_is_terminal(self):
         """Exit 2 is a usage fault; respawning re-runs the same broken call."""
         r = self._run(alive_calls=8, exit_code=2)

--- a/tests/shell-ci-known-failures.txt
+++ b/tests/shell-ci-known-failures.txt
@@ -14,5 +14,4 @@
 # quarantining, not an entry here.
 #
 # Burn this list to zero: https://github.com/sonichi/sutando/issues/1934
-tests/sutando-migrate.test.sh
 tests/sync-workspace.test.sh


### PR DESCRIPTION
## What

`src/agent/codex/cli/task-notifier-supervisor.sh` is the only thing keeping the Codex task notifier alive. It ignored every signal the notifier gave it. Three faults, each able to silence task delivery on its own:

| Fault | Effect |
|---|---|
| No singleton ownership | Two supervisors each spawn a notifier → every wakeup injected into the Codex pane twice. The claim primitive prevents double *processing*, not the double *wakeup*. |
| Fixed 1s respawn (`RESTART_DELAY:-1`) | A permanent fault became a once-per-second crash loop instead of something an operator notices. |
| Exit status discarded | The loop restarted on any status — including the usage/config fault the notifier reports as `2`, where re-running is guaranteed to reproduce it. |

## Design notes

- **Lease uses `mkdir`, not `flock(1)`** — macOS does not ship `flock`. A lease whose owner is gone is treated as *stale and reclaimed*, not contended, so one crash cannot wedge the notifier permanently.
- **Backoff** doubles `1→2→4→…→30s` and resets only after a run lasts `STABLE_AFTER` (default 60s). Resetting on every restart would defeat the purpose for a flapping notifier.
- **Exit codes map to what `task-notifier.sh` actually emits** (`0` = session gone / signalled at `:68`,`:218`; `2` = usage fault at `:265`) rather than inventing a scheme nothing emits. **`0` deliberately keeps its current meaning** — the existing `has-session` gate already ends the loop when the core is gone, and a notifier TERM'd on its own should still respawn. Only `2` becomes terminal.

## Evidence — every assertion checked against the pre-change script

Same suite, same command, only the supervisor swapped.

**Against this PR's version:**
```
Ran 28 tests: OK  (lifecycle suite at 802c7fde; was 5 at the first head)
OK
```

**Against `origin/main`'s version (control):**
```
A crash-looping notifier must not be respawned at a fixed 1s. ... FAIL
Exit 2 is a usage fault; respawning re-runs the same broken call. ... FAIL
test_lease_is_held_during_the_run_and_released_after ... FAIL
Two supervisors would double every notification injected into Codex. ... FAIL
A lease whose owner died is stale, not contended ... FAIL
```

All five discriminate. **Two initially passed unfixed** — probing for the lease *directory* could not tell a lease this supervisor took from a stale one the test itself planted — so the probe records the owning **pid** instead. Worth calling out because the first version of this suite would have shipped two assertions that proved nothing.

Timing is asserted through the supervisor's own `restarting in Ns` log lines rather than measured wall-clock gaps; a sleep-timing assertion is flaky under CI load.

## Checks

- `scripts/review-checks.sh --diff` → `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`, RC=0
- `ruff check` on the new test → clean
- `bash -n` → clean (shellcheck not installed locally; CI runs it)
- `tests/ci-covers-every-python-test.test.py` → OK. The new test sits under `tests/**/*.test.py`, which CI's `find` step discovers, so no `ci.yml` entry is owed.

## Scope

Supervisor lifecycle only. Deliberately **not** here: delivery acknowledgement (`tmux send-keys` succeeding is not proof Codex accepted the input — that stays `OUTCOME_UNKNOWN`), and any generalisation into a multi-harness session monitor. Those need a second working runtime before there is evidence to design against.

@sutando-qingyun-001:ag2.space


### Round 4 (802c7fde)
Reclaim lock publication/identity/release safety, lease staging outside the directory, absent-vs-error verdicts, digest fail-closed (exactly 16 hex), the no-clobber-link fence that lets a stale empty reclaim directory be claimed in place without its late publisher proceeding, and the shared `src/portable_mtime.sh` probe — evidence tables in the round-4 and round-5 comments.

**Live witness (pending, owner-run).** This changes the startup/delivery loop, so the merge-record needs one real task flowing end to end after the managed notifier is restarted: one task, one wakeup, one result, no duplicate. The restart replaces the `<session>-watcher` tmux session; task wakeups stop from the moment the old session ends until the new one is up, and task files that arrive in that gap are recovered by `watch-tasks-stream.sh`'s initial sweep. If the supervisor exits with terminal status 2 the watcher session is removed and stays down until the launcher, or `health-check.py --fix`, recreates it. The request to run that restart sits in the owner's pending questions; the round trip will be pasted here when it lands.

