### PR TITLE
feat(pool): digest live session transcripts instead of reading them

### DIFF
--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -101,7 +101,7 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # which predate this --diff lint and are grandfathered. A repo-tooling script has
 # no workspace to go through the wrapper for; the wrapper resolves the workspace,
 # which is the wrong directory here.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/pool-session-digest\.py|scripts/check-python39-compat\.py|scripts/review-preflight\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/check-python39-compat\.py|scripts/review-preflight\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form

--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -91,13 +91,17 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # the contract this lint exists to enforce, so the guard already complies where it
 # counts. Listed here rather than reworded to `parents[1]`, per the note above.
 #
+# scripts/pool-session-digest.py is the same category: it walks to the REPO
+# ROOT solely to import src/util_paths.claude_home_path, the sanctioned resolver
+# for the Claude home. It reads no workspace path at all.
+#
 # scripts/gen-src-map.py uses PATTERN_REPO_WALK to resolve the REPO ROOT
 # (to read tracked files under src/ and write docs/), NOT a workspace — same
 # category as scripts/check-utc-z-strftime.py and scripts/dedup-conversation-store.py,
 # which predate this --diff lint and are grandfathered. A repo-tooling script has
 # no workspace to go through the wrapper for; the wrapper resolves the workspace,
 # which is the wrong directory here.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/check-python39-compat\.py|scripts/review-preflight\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/pool-session-digest\.py|scripts/check-python39-compat\.py|scripts/review-preflight\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -84,24 +84,31 @@ def live_sessions() -> "tuple[list[dict], str | None]":
 _SESSION_ID = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 
 
+class TranscriptLookupError(OSError):
+    """The search root could not be read, so nothing is known about the transcript."""
+
+
 def find_transcript(session_id: str) -> "Path | None":
     """Locate a transcript by LITERAL filename.
 
     The id comes from session metadata, so interpolating it into a glob let
     `*` match an unrelated session's transcript. Validate, then match exactly.
+
+    None means the root was searched and holds no match. An unreadable or
+    missing root raises TranscriptLookupError: it is an unknown, not an absence.
     """
     if not _SESSION_ID.match(session_id or ""):
         return None
     name = f"{session_id}.jsonl"
     projects = config_dir() / "projects"
     try:
-        dirs = sorted(d for d in projects.iterdir() if d.is_dir())
-    except OSError:
-        return None
-    for d in dirs:
-        cand = d / name
-        if cand.is_file():
-            return cand
+        for d in sorted(d for d in projects.iterdir() if d.is_dir()):
+            cand = d / name
+            if cand.is_file():
+                return cand
+    except OSError as exc:
+        raise TranscriptLookupError(
+            f"cannot search {projects}: {exc.strerror or exc}") from exc
     return None
 
 
@@ -252,7 +259,13 @@ def main() -> int:
     for sess in sessions:
         name, sid = sess.get("name", "?"), sess.get("sessionId", "")
         head = _safe(f"{name}  [{sess.get('status','?')}]  pid={sess.get('pid','?')}")
-        path = find_transcript(sid)
+        try:
+            path = find_transcript(sid)
+        except TranscriptLookupError as e:
+            # Rendered apart from no-match: "could not look" is not "looked, none".
+            print(f"\n{head}\n  transcript lookup failed: {_one_line(str(e), 120)}")
+            failed += 1
+            continue
         if path is None:
             print(f"\n{head}\n  no transcript for {_safe(sid)}")
             continue

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -108,6 +108,9 @@ def find_transcript(session_id: str) -> "Path | None":
 # C0, DEL and C1. Whitespace is collapsed before this runs, so anything left is
 # a control the terminal would ACT on (OSC 52 writes the clipboard).
 _CTRL = {c: "\ufffd" for c in [*range(0x00, 0x20), 0x7F, *range(0x80, 0xA0)]}
+# A lone surrogate survives json.loads but not a UTF-8 stdout; one bad string
+# would end the sweep and hide every later session.
+_CTRL.update({c: "\ufffd" for c in range(0xD800, 0xE000)})
 
 
 def _safe(value) -> str:

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""What is each Claude session actually doing? — a digest of live transcripts.
+
+A pool session's transcript is the only complete record of its reasoning and
+context, but they run 4-13 MB and grow, so reading one to answer "is core-2
+stuck, and on what?" is impractical. `tmux capture-pane` shows only what fits on
+screen and dies with the pane; the heartbeat proves the process is alive, not
+that the agent is progressing.
+
+This streams each transcript once, keeping a bounded tail, and prints the few
+lines that answer the question: what it last said, what it last ran, and how
+long ago.
+
+    python3 scripts/pool-session-digest.py                 # every live session
+    python3 scripts/pool-session-digest.py -s core-2 -n 20 # one, deeper
+    python3 scripts/pool-session-digest.py --thinking      # include reasoning
+
+Read-only. Transcripts are live session state; never write to them.
+"""
+from __future__ import annotations
+
+import argparse
+import calendar
+import collections
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CFG_ENV = "CLAUDE_CONFIG_DIR"
+DEFAULT_CFG = Path.home() / ".claude"
+
+
+def config_dir() -> Path:
+    return Path(os.environ.get(CFG_ENV) or DEFAULT_CFG)
+
+
+def live_sessions() -> "list[dict]":
+    """Sessions from `claude agents --json`. Empty list if the CLI is absent —
+    a digest of nothing beats a traceback in an ops script."""
+    try:
+        out = subprocess.run(["claude", "agents", "--json"],
+                             capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if out.returncode != 0:
+        return []
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def find_transcript(session_id: str) -> "Path | None":
+    hits = sorted(config_dir().glob(f"projects/*/{session_id}.jsonl"))
+    return hits[0] if hits else None
+
+
+def _one_line(text: str, width: int) -> str:
+    flat = " ".join((text or "").split())
+    return flat[:width] + ("…" if len(flat) > width else "")
+
+
+def _event(rec: dict, block: dict, width: int) -> "tuple[str, str, str] | None":
+    """(ts, kind, summary) for a content block worth showing, else None."""
+    ts = (rec.get("timestamp") or "")[11:19]
+    kind = block.get("type")
+    if kind == "text":
+        body = _one_line(block.get("text", ""), width)
+        return (ts, "SAY", body) if body else None
+    if kind == "thinking":
+        body = _one_line(block.get("thinking", ""), width)
+        return (ts, "THINK", body) if body else None
+    if kind == "tool_use":
+        name = block.get("name", "?")
+        inp = block.get("input") or {}
+        detail = inp.get("command") or inp.get("file_path") or inp.get("pattern") or ""
+        if not detail and isinstance(inp, dict) and inp:
+            detail = json.dumps(inp)[:width]
+        return (ts, name.upper()[:6], _one_line(str(detail), width))
+    return None
+
+
+def digest(path: Path, keep: int, width: int, want_thinking: bool) -> dict:
+    records = 0
+    blocks: collections.Counter = collections.Counter()
+    tail: collections.deque = collections.deque(maxlen=keep)
+    last_ts = ""
+    with path.open(errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            records += 1
+            if rec.get("timestamp"):
+                last_ts = rec["timestamp"]
+            content = (rec.get("message") or {}).get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                blocks[block.get("type", "?")] += 1
+                if block.get("type") == "thinking" and not want_thinking:
+                    continue
+                ev = _event(rec, block, width)
+                if ev:
+                    tail.append(ev)
+    return {"records": records, "blocks": blocks, "tail": list(tail), "last_ts": last_ts}
+
+
+def age(iso: str) -> str:
+    if not iso:
+        return "?"
+    try:
+        # timegm, not mktime: transcripts stamp UTC, and mktime reads local —
+        # correcting with time.timezone ignores DST and lands an hour out.
+        t = calendar.timegm(time.strptime(iso[:19], "%Y-%m-%dT%H:%M:%S"))
+    except ValueError:
+        return "?"
+    secs = max(0, int(time.time() - t))
+    if secs < 90:
+        return f"{secs}s ago"
+    if secs < 5400:
+        return f"{secs // 60}m ago"
+    return f"{secs // 3600}h ago"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("-s", "--session", help="name or id substring; default all")
+    ap.add_argument("-n", type=int, default=8, help="events to show (default 8)")
+    ap.add_argument("-w", "--width", type=int, default=110, help="summary width")
+    ap.add_argument("--thinking", action="store_true", help="include reasoning")
+    a = ap.parse_args()
+
+    sessions = live_sessions()
+    if not sessions:
+        print("no live sessions (is `claude` on PATH?)", file=sys.stderr)
+        return 1
+    if a.session:
+        needle = a.session.lower()
+        sessions = [s for s in sessions
+                    if needle in s.get("name", "").lower()
+                    or needle in s.get("sessionId", "").lower()]
+        if not sessions:
+            print(f"no session matching {a.session!r}", file=sys.stderr)
+            return 1
+
+    for sess in sessions:
+        name, sid = sess.get("name", "?"), sess.get("sessionId", "")
+        head = f"{name}  [{sess.get('status','?')}]  pid={sess.get('pid','?')}"
+        path = find_transcript(sid)
+        if path is None:
+            print(f"\n{head}\n  no transcript for {sid}")
+            continue
+        d = digest(path, a.n, a.width, a.thinking)
+        mb = path.stat().st_size / 1048576
+        counts = " · ".join(f"{k} {v}" for k, v in d["blocks"].most_common(5))
+        print(f"\n{head}")
+        print(f"  {mb:.1f}M · {d['records']} records · last {age(d['last_ts'])}")
+        print(f"  {counts}")
+        for ts, kind, body in d["tail"]:
+            print(f"    {ts}  {kind:<6} {body}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -120,27 +120,36 @@ def _safe(value) -> str:
     return str(value if value is not None else "").translate(_CTRL)
 
 
-def _one_line(text: str, width: int) -> str:
-    flat = _safe(" ".join((text or "").split()))
+def _one_line(text, width: int) -> str:
+    # Leaf values are as untrusted as the record: a dict where a string belongs
+    # must render empty, not raise and take the rest of the transcript with it.
+    if not isinstance(text, str):
+        return ""
+    flat = _safe(" ".join(text.split()))
     return flat[:width] + ("…" if len(flat) > width else "")
 
 
 def _event(rec: dict, block: dict, width: int) -> "tuple[str, str, str] | None":
     """(ts, kind, summary) for a content block worth showing, else None."""
-    ts = _safe((rec.get("timestamp") or "")[11:19])
+    raw_ts = rec.get("timestamp")
+    ts = _safe(raw_ts[11:19]) if isinstance(raw_ts, str) else ""
     kind = block.get("type")
     if kind == "text":
-        body = _one_line(block.get("text", ""), width)
+        body = _one_line(block.get("text"), width)
         return (ts, "SAY", body) if body else None
     if kind == "thinking":
-        body = _one_line(block.get("thinking", ""), width)
+        body = _one_line(block.get("thinking"), width)
         return (ts, "THINK", body) if body else None
     if kind == "tool_use":
-        name = _safe(block.get("name", "?"))
-        inp = block.get("input") or {}
-        detail = inp.get("command") or inp.get("file_path") or inp.get("pattern") or ""
-        if not detail and isinstance(inp, dict) and inp:
-            detail = json.dumps(inp)[:width]
+        name = block.get("name")
+        name = _safe(name) if isinstance(name, str) else "?"
+        inp = block.get("input")
+        if isinstance(inp, dict):
+            detail = inp.get("command") or inp.get("file_path") or inp.get("pattern") or ""
+            if not detail and inp:
+                detail = json.dumps(inp, default=str)[:width]
+        else:
+            detail = "" if inp is None else str(inp)[:width]
         return (ts, name.upper()[:6], _one_line(str(detail), width))
     return None
 
@@ -179,7 +188,11 @@ def digest(path: Path, keep: int, width: int, want_thinking: bool) -> dict:
                 blocks[btype] += 1
                 if btype == "thinking" and not want_thinking:
                     continue
-                ev = _event(rec, block, width)
+                try:
+                    ev = _event(rec, block, width)
+                except Exception:  # noqa: BLE001
+                    # Backstop for future _event() edits; no JSON value reaches it today.
+                    ev = None
                 if ev:
                     tail.append(ev)
     return {"records": records, "blocks": blocks, "tail": list(tail), "last_ts": last_ts}

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -40,20 +40,38 @@ def config_dir() -> Path:
     return claude_home_path()
 
 
-def live_sessions() -> "list[dict]":
-    """Sessions from `claude agents --json`. Empty list if the CLI is absent —
-    a digest of nothing beats a traceback in an ops script."""
+def live_sessions() -> "tuple[list[dict], str | None]":
+    """(sessions, reason). `reason` is None ONLY when the CLI answered cleanly.
+
+    Every failure used to return [], so "no sessions running" and "the CLI is
+    gone / hung / unauthenticated / speaking HTML" rendered identically — on a
+    tool whose job is telling an operator whether cores are alive.
+    """
     try:
         out = subprocess.run(["claude", "agents", "--json"],
                              capture_output=True, text=True, timeout=30)
-    except (OSError, subprocess.TimeoutExpired):
-        return []
+    except FileNotFoundError:
+        return [], "`claude` is not on PATH"
+    except subprocess.TimeoutExpired:
+        return [], "`claude agents --json` timed out after 30s"
+    except OSError as exc:
+        return [], f"could not run `claude`: {exc.strerror or exc}"
     if out.returncode != 0:
-        return []
+        detail = _one_line(out.stderr or out.stdout, 120) or "no output"
+        return [], f"`claude agents --json` exited {out.returncode}: {detail}"
     try:
-        return json.loads(out.stdout)
+        data = json.loads(out.stdout)
     except json.JSONDecodeError:
-        return []
+        return [], f"`claude agents --json` was not JSON: {_one_line(out.stdout, 120)!r}"
+    # Shape matters as much as parseability: {"sessions": []} parses fine and
+    # then raises AttributeError on the first .get() downstream.
+    if not isinstance(data, list):
+        return [], f"expected a JSON list of session objects, got {type(data).__name__}"
+    bad = next((d for d in data if not isinstance(d, dict)), None)
+    if bad is not None:
+        return [], ("expected a JSON list of session OBJECTS, got a list "
+                    f"containing {type(bad).__name__}")
+    return data, None
 
 
 _SESSION_ID = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
@@ -182,9 +200,13 @@ def main() -> int:
     ap.add_argument("--thinking", action="store_true", help="include reasoning")
     a = ap.parse_args()
 
-    sessions = live_sessions()
+    sessions, reason = live_sessions()
+    if reason is not None:
+        print(f"could not list sessions: {reason}", file=sys.stderr)
+        return 2                      # distinct from "asked, answered, none"
     if not sessions:
-        print("no live sessions (is `claude` on PATH?)", file=sys.stderr)
+        print("no live sessions (the CLI answered, none are running)",
+              file=sys.stderr)
         return 1
     if a.session:
         needle = a.session.lower()

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -58,14 +58,29 @@ def find_transcript(session_id: str) -> "Path | None":
     return hits[0] if hits else None
 
 
+# C0, DEL and C1. Whitespace is collapsed before this runs, so anything left is
+# a control the terminal would ACT on (OSC 52 writes the clipboard).
+_CTRL = {c: "\ufffd" for c in [*range(0x00, 0x20), 0x7F, *range(0x80, 0xA0)]}
+
+
+def _safe(value) -> str:
+    """Neutralize terminal controls in untrusted transcript/session content.
+
+    This digest prints straight to a TTY, so an escape that survives here can
+    spoof output or drive terminal features. Replaced, not dropped, so a reader
+    can see something was removed.
+    """
+    return str(value if value is not None else "").translate(_CTRL)
+
+
 def _one_line(text: str, width: int) -> str:
-    flat = " ".join((text or "").split())
+    flat = _safe(" ".join((text or "").split()))
     return flat[:width] + ("…" if len(flat) > width else "")
 
 
 def _event(rec: dict, block: dict, width: int) -> "tuple[str, str, str] | None":
     """(ts, kind, summary) for a content block worth showing, else None."""
-    ts = (rec.get("timestamp") or "")[11:19]
+    ts = _safe((rec.get("timestamp") or "")[11:19])
     kind = block.get("type")
     if kind == "text":
         body = _one_line(block.get("text", ""), width)
@@ -74,7 +89,7 @@ def _event(rec: dict, block: dict, width: int) -> "tuple[str, str, str] | None":
         body = _one_line(block.get("thinking", ""), width)
         return (ts, "THINK", body) if body else None
     if kind == "tool_use":
-        name = block.get("name", "?")
+        name = _safe(block.get("name", "?"))
         inp = block.get("input") or {}
         detail = inp.get("command") or inp.get("file_path") or inp.get("pattern") or ""
         if not detail and isinstance(inp, dict) and inp:
@@ -155,14 +170,14 @@ def main() -> int:
 
     for sess in sessions:
         name, sid = sess.get("name", "?"), sess.get("sessionId", "")
-        head = f"{name}  [{sess.get('status','?')}]  pid={sess.get('pid','?')}"
+        head = _safe(f"{name}  [{sess.get('status','?')}]  pid={sess.get('pid','?')}")
         path = find_transcript(sid)
         if path is None:
             print(f"\n{head}\n  no transcript for {sid}")
             continue
         d = digest(path, a.n, a.width, a.thinking)
         mb = path.stat().st_size / 1048576
-        counts = " · ".join(f"{k} {v}" for k, v in d["blocks"].most_common(5))
+        counts = " · ".join(f"{_safe(k)} {v}" for k, v in d["blocks"].most_common(5))
         print(f"\n{head}")
         print(f"  {mb:.1f}M · {d['records']} records · last {age(d['last_ts'])}")
         print(f"  {counts}")

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -30,7 +30,7 @@ import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))  # lint-workspace-resolution: allow-repo-root
 
 from util_paths import claude_home_path  # noqa: E402
 
@@ -67,10 +67,17 @@ def live_sessions() -> "tuple[list[dict], str | None]":
     # then raises AttributeError on the first .get() downstream.
     if not isinstance(data, list):
         return [], f"expected a JSON list of session objects, got {type(data).__name__}"
-    bad = next((d for d in data if not isinstance(d, dict)), None)
-    if bad is not None:
+    if any(not isinstance(d, dict) for d in data):
+        # `next(..., None)` cannot work here: None is itself an invalid member,
+        # so a [null] list would report "no bad member found".
+        kinds = sorted({type(d).__name__ for d in data if not isinstance(d, dict)})
         return [], ("expected a JSON list of session OBJECTS, got a list "
-                    f"containing {type(bad).__name__}")
+                    f"containing {', '.join(kinds)}")
+    for d in data:
+        for field in ("name", "sessionId"):
+            if field in d and not isinstance(d[field], str):
+                return [], (f"session {field!r} must be a string, got "
+                            f"{type(d[field]).__name__}")
     return data, None
 
 
@@ -152,17 +159,25 @@ def digest(path: Path, keep: int, width: int, want_thinking: bool) -> dict:
                 rec = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            # A transcript is an external artifact: every decoded level is
+            # untrusted, and one bad record must not end the whole digest.
+            if not isinstance(rec, dict):
+                continue
             records += 1
-            if rec.get("timestamp"):
+            if isinstance(rec.get("timestamp"), str):
                 last_ts = rec["timestamp"]
-            content = (rec.get("message") or {}).get("content")
+            msg = rec.get("message")
+            content = msg.get("content") if isinstance(msg, dict) else None
             if not isinstance(content, list):
                 continue
             for block in content:
                 if not isinstance(block, dict):
                     continue
-                blocks[block.get("type", "?")] += 1
-                if block.get("type") == "thinking" and not want_thinking:
+                btype = block.get("type", "?")
+                if not isinstance(btype, str):
+                    btype = "?"          # an unhashable type would raise here
+                blocks[btype] += 1
+                if btype == "thinking" and not want_thinking:
                     continue
                 ev = _event(rec, block, width)
                 if ev:
@@ -217,6 +232,7 @@ def main() -> int:
             print(f"no session matching {a.session!r}", file=sys.stderr)
             return 1
 
+    failed = 0
     for sess in sessions:
         name, sid = sess.get("name", "?"), sess.get("sessionId", "")
         head = _safe(f"{name}  [{sess.get('status','?')}]  pid={sess.get('pid','?')}")
@@ -224,14 +240,22 @@ def main() -> int:
         if path is None:
             print(f"\n{head}\n  no transcript for {_safe(sid)}")
             continue
-        d = digest(path, a.n, a.width, a.thinking)
-        mb = path.stat().st_size / 1048576
+        try:
+            d = digest(path, a.n, a.width, a.thinking)
+            mb = path.stat().st_size / 1048576
+        except Exception as e:      # noqa: BLE001 — one session must not end the sweep
+            print(f"\n{head}\n  unreadable transcript: "
+                  f"{_safe(type(e).__name__)}: {_safe(_one_line(str(e), 90))}")
+            failed += 1
+            continue
         counts = " · ".join(f"{_safe(k)} {v}" for k, v in d["blocks"].most_common(5))
         print(f"\n{head}")
         print(f"  {mb:.1f}M · {d['records']} records · last {age(d['last_ts'])}")
         print(f"  {counts}")
         for ts, kind, body in d["tail"]:
             print(f"    {ts}  {kind:<6} {body}")
+    if failed and failed == len(sessions):
+        return 2                  # every session unreadable is a failure, not a report
     return 0
 
 

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -24,6 +24,7 @@ import calendar
 import collections
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -53,9 +54,28 @@ def live_sessions() -> "list[dict]":
         return []
 
 
+_SESSION_ID = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
 def find_transcript(session_id: str) -> "Path | None":
-    hits = sorted(config_dir().glob(f"projects/*/{session_id}.jsonl"))
-    return hits[0] if hits else None
+    """Locate a transcript by LITERAL filename.
+
+    The id comes from session metadata, so interpolating it into a glob let
+    `*` match an unrelated session's transcript. Validate, then match exactly.
+    """
+    if not _SESSION_ID.match(session_id or ""):
+        return None
+    name = f"{session_id}.jsonl"
+    projects = config_dir() / "projects"
+    try:
+        dirs = sorted(d for d in projects.iterdir() if d.is_dir())
+    except OSError:
+        return None
+    for d in dirs:
+        cand = d / name
+        if cand.is_file():
+            return cand
+    return None
 
 
 # C0, DEL and C1. Whitespace is collapsed before this runs, so anything left is
@@ -173,7 +193,7 @@ def main() -> int:
         head = _safe(f"{name}  [{sess.get('status','?')}]  pid={sess.get('pid','?')}")
         path = find_transcript(sid)
         if path is None:
-            print(f"\n{head}\n  no transcript for {sid}")
+            print(f"\n{head}\n  no transcript for {_safe(sid)}")
             continue
         d = digest(path, a.n, a.width, a.thinking)
         mb = path.stat().st_size / 1048576

--- a/scripts/pool-session-digest.py
+++ b/scripts/pool-session-digest.py
@@ -30,12 +30,14 @@ import sys
 import time
 from pathlib import Path
 
-CFG_ENV = "CLAUDE_CONFIG_DIR"
-DEFAULT_CFG = Path.home() / ".claude"
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from util_paths import claude_home_path  # noqa: E402
 
 
 def config_dir() -> Path:
-    return Path(os.environ.get(CFG_ENV) or DEFAULT_CFG)
+    """The Claude home, via the ONE resolver that also honours $CLAUDE_HOME."""
+    return claude_home_path()
 
 
 def live_sessions() -> "list[dict]":
@@ -159,7 +161,12 @@ def age(iso: str) -> str:
         t = calendar.timegm(time.strptime(iso[:19], "%Y-%m-%dT%H:%M:%S"))
     except ValueError:
         return "?"
-    secs = max(0, int(time.time() - t))
+    delta = int(time.time() - t)
+    # Clamping a future stamp to 0 renders skew as "0s ago" — identical to a
+    # genuinely fresh core, on the column operators read as the wedge signal.
+    if delta < -2:
+        return "clock skew"
+    secs = max(0, delta)
     if secs < 90:
         return f"{secs}s ago"
     if secs < 5400:

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -297,6 +297,16 @@ class DiscoveryTest(unittest.TestCase):
             self.assertEqual(digest_mod.find_transcript("sid-1").name, "sid-1.jsonl")
             self.assertIsNone(digest_mod.find_transcript("absent"))
 
+    def test_a_missing_search_root_raises_rather_than_reporting_absence(self):
+        """No projects/ at all is an unknown; only a searched root can say "none"."""
+        with unittest.mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(self.cfg)}):
+            with self.assertRaises(digest_mod.TranscriptLookupError) as cm:
+                digest_mod.find_transcript("sid-1")
+            self.assertIn("cannot search", str(cm.exception))
+            (self.cfg / "projects").mkdir()
+            self.assertIsNone(digest_mod.find_transcript("sid-1"),
+                              "control: an empty readable root is a genuine no-match")
+
 
 class MainTest(unittest.TestCase):
     def setUp(self):
@@ -380,6 +390,46 @@ class MainTest(unittest.TestCase):
         rc, out, _ = self._main([], [self._session(sid="absent")])
         self.assertEqual(rc, 0, "one session without a transcript must not abort the rest")
         self.assertIn("no transcript", out)
+
+    def _deny_projects_iterdir(self, times=None):
+        """Patch the REAL Path.iterdir boundary: PermissionError on projects/,
+        for the first `times` calls (all of them when None), pass-through otherwise."""
+        real = Path.iterdir
+        seen = {"n": 0}
+
+        def deny(path):
+            if path.name == "projects" and (times is None or seen["n"] < times):
+                seen["n"] += 1
+                raise PermissionError(13, "Permission denied")
+            return real(path)
+
+        return unittest.mock.patch.object(Path, "iterdir", deny)
+
+    def test_unreadable_search_root_is_a_failure_not_an_absence(self):
+        """Both arms used to print `no transcript for sid-1` and exit 0."""
+        self.proj.rmdir()                     # projects/ exists, readable, empty
+        rc_empty, out_empty, _ = self._main([], [self._session()])
+        self.assertEqual(rc_empty, 0)
+        self.assertIn("no transcript for sid-1", out_empty)
+
+        with self._deny_projects_iterdir():
+            rc_denied, out_denied, _ = self._main([], [self._session()])
+        self.assertEqual(rc_denied, 2, "every lookup failing is not a successful run")
+        self.assertIn("transcript lookup failed", out_denied)
+        self.assertIn("Permission denied", out_denied)
+        self.assertNotIn("no transcript for", out_denied,
+                         "an unreadable root must not be rendered as a confirmed absence")
+        self.assertNotEqual(out_empty, out_denied)
+
+    def test_a_failed_lookup_does_not_poison_the_next_session(self):
+        self._transcript("sid-ok")
+        with self._deny_projects_iterdir(times=1):
+            rc, out, _ = self._main([], [self._session("core-bad", "sid-bad"),
+                                         self._session("core-ok", "sid-ok")])
+        self.assertEqual(rc, 0, "one failed lookup must not fail a sweep that digested a session")
+        self.assertIn("transcript lookup failed", out)
+        self.assertIn("core-ok", out)
+        self.assertIn("did a thing", out, "the session after the failed lookup was not digested")
 
 
 class TerminalSafety(unittest.TestCase):

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -325,6 +325,28 @@ class MainTest(unittest.TestCase):
             rc = digest_mod.main()
         return rc, out.getvalue(), err.getvalue()
 
+    def test_lone_surrogate_in_a_session_does_not_hide_the_next_one(self):
+        """A JSON-decoded lone surrogate reaches print() through _safe; on a real
+        UTF-8 stdout that raised and ended the sweep before the clean session."""
+        self._transcript("sid-clean")
+        bad = json.loads('{"name": "core-x", "sessionId": "\\ud800", "status": "busy", "pid": 1}')
+        raw = io.BytesIO()
+        with unittest.mock.patch.object(sys, "argv", ["prog"]), \
+             unittest.mock.patch.object(digest_mod, "live_sessions",
+                                        return_value=([bad, self._session(sid="sid-clean")], None)), \
+             unittest.mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(self.cfg)}), \
+             contextlib.redirect_stderr(io.StringIO()):
+            wrapped = io.TextIOWrapper(raw, encoding="utf-8", write_through=True)
+            with contextlib.redirect_stdout(wrapped):
+                rc = digest_mod.main()
+                wrapped.flush()
+                out = raw.getvalue().decode("utf-8")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("core-x", out)
+        self.assertIn("\ufffd", out)
+        self.assertIn("core-1", out)
+        self.assertIn("did a thing", out)
+
     def test_reports_a_session_and_its_last_event(self):
         self._transcript()
         rc, out, _ = self._main([], [self._session()])

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -8,6 +8,7 @@ time.timezone rather than the DST-aware offset lands exactly one hour out, which
 is precisely the shape of "stale" an operator is looking for. The first version
 of this script shipped that bug and reported 3-second-old activity as 60m.
 """
+import calendar
 import contextlib
 import importlib.util
 import io
@@ -29,12 +30,43 @@ digest_mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(digest_mod)
 
 
+# A fixed instant inside US daylight saving. The bug this suite pins is a
+# local-time parse, which is invisible whenever the runner's TZ offset is zero.
+FROZEN = calendar.timegm((2026, 7, 1, 12, 0, 0, 0, 0, 0))
+DST_TZ = "America/Los_Angeles"
+
+
 def utc_iso(offset_secs: int = 0) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%S.000Z",
-                         time.gmtime(time.time() - offset_secs))
+                         time.gmtime(FROZEN - offset_secs))
 
 
 class AgeTest(unittest.TestCase):
+    def setUp(self):
+        # Ambient TZ decided whether the regression was detectable at all: the
+        # mutant passed the whole suite under TZ=UTC. Pin the zone and the clock.
+        prior = os.environ.get("TZ")
+        os.environ["TZ"] = DST_TZ
+        time.tzset()
+
+        def restore():
+            if prior is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = prior
+            time.tzset()
+
+        self.addCleanup(restore)
+        patcher = unittest.mock.patch.object(time, "time", lambda: FROZEN)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_the_pinned_zone_actually_has_a_nonzero_dst_offset(self):
+        # Positive control: if the zone resolved to UTC the cases below would
+        # pass against the very bug they exist to catch.
+        self.assertNotEqual(time.localtime(FROZEN).tm_gmtoff, 0)
+        self.assertTrue(time.localtime(FROZEN).tm_isdst)
+
     def test_recent_utc_stamp_reads_as_seconds_not_hours(self):
         """A local-time parse of a UTC stamp is off by the whole UTC offset."""
         self.assertTrue(digest_mod.age(utc_iso(3)).endswith("s ago"),

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -8,8 +8,14 @@ time.timezone rather than the DST-aware offset lands exactly one hour out, which
 is precisely the shape of "stale" an operator is looking for. The first version
 of this script shipped that bug and reported 3-second-old activity as 60m.
 """
+import contextlib
 import importlib.util
+import io
 import json
+import os
+import subprocess
+import sys
+import unittest.mock
 import tempfile
 import time
 import unittest
@@ -94,6 +100,136 @@ class DigestTest(unittest.TestCase):
         self._write([self._rec([{"type": "text", "text": "x" * 500}])])
         d = digest_mod.digest(self.path, keep=5, width=40, want_thinking=False)
         self.assertLessEqual(len(d["tail"][0][2]), 41)
+
+    def test_tool_use_without_a_known_field_falls_back_to_its_input(self):
+        """Not every tool names its argument command/file_path/pattern; those
+        must still show something rather than an empty line."""
+        self._write([self._rec([{"type": "tool_use", "name": "Odd",
+                                 "input": {"unexpected": "value"}}])])
+        d = digest_mod.digest(self.path, keep=5, width=80, want_thinking=False)
+        self.assertIn("unexpected", d["tail"][0][2])
+
+    def test_unknown_block_types_are_counted_but_not_shown(self):
+        self._write([self._rec([{"type": "image", "source": "x"}])])
+        d = digest_mod.digest(self.path, keep=5, width=80, want_thinking=False)
+        self.assertEqual(d["blocks"]["image"], 1)
+        self.assertEqual(d["tail"], [], "an unrenderable block must not emit a blank row")
+
+    def test_malformed_records_are_skipped_without_raising(self):
+        """Content that is not a list, blocks that are not dicts, and records
+        with no timestamp all appear in real transcripts."""
+        self._write([
+            {"type": "user", "message": {"content": "a bare string"}},
+            {"type": "assistant", "message": {"content": ["not-a-dict"]}},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "kept"}]}},
+        ])
+        d = digest_mod.digest(self.path, keep=5, width=80, want_thinking=False)
+        self.assertEqual(d["records"], 3)
+        self.assertEqual([t[2] for t in d["tail"]], ["kept"])
+        self.assertEqual(d["last_ts"], "", "no record carried a timestamp")
+
+
+class DiscoveryTest(unittest.TestCase):
+    """The I/O layer. Every failure path here returns empty rather than raising,
+    which is right for an ops script but means a broken CLI looks identical to
+    an idle machine -- so each path is pinned deliberately."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.cfg = Path(self.tmp.name)
+
+    def test_config_dir_prefers_env_over_default(self):
+        with unittest.mock.patch.dict(os.environ, {digest_mod.CFG_ENV: str(self.cfg)}):
+            self.assertEqual(digest_mod.config_dir(), self.cfg)
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(digest_mod.config_dir(), digest_mod.DEFAULT_CFG)
+
+    def _run_result(self, rc=0, stdout="[]"):
+        return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr="")
+
+    def test_live_sessions_parses_success(self):
+        payload = '[{"name": "core-1", "sessionId": "abc", "status": "busy", "pid": 1}]'
+        with unittest.mock.patch.object(subprocess, "run",
+                                        return_value=self._run_result(stdout=payload)):
+            self.assertEqual(digest_mod.live_sessions()[0]["name"], "core-1")
+
+    def test_live_sessions_empty_on_nonzero_exit(self):
+        with unittest.mock.patch.object(subprocess, "run",
+                                        return_value=self._run_result(rc=1, stdout="")):
+            self.assertEqual(digest_mod.live_sessions(), [])
+
+    def test_live_sessions_empty_on_unparsable_output(self):
+        with unittest.mock.patch.object(subprocess, "run",
+                                        return_value=self._run_result(stdout="not json")):
+            self.assertEqual(digest_mod.live_sessions(), [])
+
+    def test_live_sessions_empty_when_cli_missing_or_hangs(self):
+        for exc in (FileNotFoundError("claude"), subprocess.TimeoutExpired("claude", 30)):
+            with unittest.mock.patch.object(subprocess, "run", side_effect=exc):
+                self.assertEqual(digest_mod.live_sessions(), [],
+                                 f"{type(exc).__name__} must not propagate")
+
+    def test_find_transcript_locates_by_session_id_else_none(self):
+        proj = self.cfg / "projects" / "-some-slug"
+        proj.mkdir(parents=True)
+        (proj / "sid-1.jsonl").write_text("")
+        with unittest.mock.patch.dict(os.environ, {digest_mod.CFG_ENV: str(self.cfg)}):
+            self.assertEqual(digest_mod.find_transcript("sid-1").name, "sid-1.jsonl")
+            self.assertIsNone(digest_mod.find_transcript("absent"))
+
+
+class MainTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.cfg = Path(self.tmp.name)
+        self.proj = self.cfg / "projects" / "-slug"
+        self.proj.mkdir(parents=True)
+
+    def _session(self, name="core-1", sid="sid-1"):
+        return {"name": name, "sessionId": sid, "status": "busy", "pid": 42}
+
+    def _transcript(self, sid="sid-1"):
+        rec = {"type": "assistant", "timestamp": utc_iso(1),
+               "message": {"content": [{"type": "text", "text": "did a thing"}]}}
+        (self.proj / f"{sid}.jsonl").write_text(json.dumps(rec) + "\n")
+
+    def _main(self, argv, sessions):
+        out = io.StringIO()
+        err = io.StringIO()
+        with unittest.mock.patch.object(sys, "argv", ["prog", *argv]), \
+             unittest.mock.patch.object(digest_mod, "live_sessions", return_value=sessions), \
+             unittest.mock.patch.dict(os.environ, {digest_mod.CFG_ENV: str(self.cfg)}), \
+             contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = digest_mod.main()
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_reports_a_session_and_its_last_event(self):
+        self._transcript()
+        rc, out, _ = self._main([], [self._session()])
+        self.assertEqual(rc, 0)
+        self.assertIn("core-1", out)
+        self.assertIn("did a thing", out)
+
+    def test_no_live_sessions_is_a_nonzero_exit(self):
+        rc, _, err = self._main([], [])
+        self.assertEqual(rc, 1)
+        self.assertIn("no live sessions", err)
+
+    def test_session_filter_matches_and_misses(self):
+        self._transcript()
+        rc, out, _ = self._main(["-s", "CORE-1"], [self._session()])
+        self.assertEqual(rc, 0, "filter must be case-insensitive")
+        self.assertIn("core-1", out)
+        rc, _, err = self._main(["-s", "nope"], [self._session()])
+        self.assertEqual(rc, 1)
+        self.assertIn("no session matching", err)
+
+    def test_missing_transcript_is_reported_not_fatal(self):
+        rc, out, _ = self._main([], [self._session(sid="absent")])
+        self.assertEqual(rc, 0, "one session without a transcript must not abort the rest")
+        self.assertIn("no transcript", out)
 
 
 if __name__ == "__main__":

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -363,6 +363,118 @@ class UntrustedSessionIdTest(unittest.TestCase):
                                  "control: a legitimate id must still resolve")
 
 
+
+class UntrustedInputTest(unittest.TestCase):
+    """A transcript and the CLI's JSON are external artifacts. Every decoded
+    level is untrusted, and one bad one must not hide the rest."""
+
+    def _fresh(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "dg_fresh", Path(__file__).resolve().parent.parent
+            / "scripts" / "pool-session-digest.py")
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+
+    def _discovery(self, payload):
+        """`m.subprocess` is the SHARED module object — assigning to its .run
+        mutates it for every test. Patch inside a scope instead."""
+        m = self._fresh()
+
+        class R:
+            returncode, stdout, stderr = 0, payload, ""
+
+        return m, unittest.mock.patch.object(
+            m.subprocess, "run", lambda *a, **k: R())
+
+    def test_a_malformed_record_does_not_suppress_a_later_session(self):
+        m = self._fresh()
+        with tempfile.TemporaryDirectory() as td:
+            good = json.dumps({"timestamp": "2026-08-24T19:00:00Z",
+                               "message": {"content": [{"type": "text",
+                                                        "text": "hi"}]}})
+            (Path(td) / "s1.jsonl").write_text("[]\n" + good + "\n")
+            (Path(td) / "s2.jsonl").write_text(good + "\n")
+            m.live_sessions = lambda: (
+                [{"name": "one", "sessionId": "s1", "status": "r", "pid": 1},
+                 {"name": "two", "sessionId": "s2", "status": "r", "pid": 2}], None)
+            m.find_transcript = lambda sid: Path(td) / f"{sid}.jsonl"
+            buf = io.StringIO()
+            with unittest.mock.patch.object(sys, "argv", ["d"]), \
+                 contextlib.redirect_stdout(buf):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("two", buf.getvalue(),
+                      "a bad record in session one hid session two entirely")
+
+    def test_an_unreadable_session_does_not_end_the_sweep(self):
+        """Record validation cannot cover a session that fails at the FILE
+        level (vanished, permissions, IO). That is what the wrapper is for."""
+        m = self._fresh()
+        with tempfile.TemporaryDirectory() as td:
+            good = json.dumps({"timestamp": "2026-08-24T19:00:00Z",
+                               "message": {"content": [{"type": "text",
+                                                        "text": "hi"}]}})
+            (Path(td) / "s2.jsonl").write_text(good + "\n")
+            (Path(td) / "s1.jsonl").write_text(good + "\n")
+            real = m.digest
+
+            def boom(path, *a, **k):
+                if path.name == "s1.jsonl":
+                    raise OSError("Input/output error")
+                return real(path, *a, **k)
+
+            m.digest = boom
+            m.live_sessions = lambda: (
+                [{"name": "one", "sessionId": "s1", "status": "r", "pid": 1},
+                 {"name": "two", "sessionId": "s2", "status": "r", "pid": 2}], None)
+            m.find_transcript = lambda sid: Path(td) / f"{sid}.jsonl"
+            buf = io.StringIO()
+            with unittest.mock.patch.object(sys, "argv", ["d"]), \
+                 contextlib.redirect_stdout(buf):
+                rc = m.main()
+        out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("unreadable transcript", out, "the failure was not reported")
+        self.assertIn("two", out, "one unreadable session ended the sweep")
+
+    def test_a_string_message_or_unhashable_type_is_survivable(self):
+        m = self._fresh()
+        with tempfile.TemporaryDirectory() as td:
+            t = Path(td) / "t.jsonl"
+            t.write_text('"just a string"\n'
+                         '{"message": "not-an-object"}\n'
+                         '{"message": {"content": [{"type": ["un", "hashable"]}]}}\n')
+            d = m.digest(t, 5, 80, False)
+        self.assertEqual(d["blocks"]["?"], 1, "unhashable type was not coerced")
+
+    def test_null_member_is_rejected_rather_than_passed_through(self):
+        # `next(..., None)` cannot express this: None IS the invalid member.
+        m, patched = self._discovery("[null]")
+        with patched:
+            sessions, reason = m.live_sessions()
+        self.assertEqual(sessions, [])
+        self.assertIn("NoneType", reason)
+
+    def test_non_string_identity_fields_are_rejected(self):
+        for payload, kind in (('[{"name": "a", "sessionId": 5}]', "int"),
+                              ('[{"name": null, "sessionId": "x"}]', "NoneType")):
+            m, patched = self._discovery(payload)
+            with patched:
+                sessions, reason = m.live_sessions()
+            self.assertEqual(sessions, [], payload)
+            self.assertIn(kind, reason, payload)
+
+    def test_a_rejected_discovery_exits_two_not_a_traceback(self):
+        m, patched = self._discovery("[null]")
+        buf = io.StringIO()
+        with patched, unittest.mock.patch.object(sys, "argv", ["d"]), \
+             contextlib.redirect_stderr(buf):
+            rc = m.main()
+        self.assertEqual(rc, 2, "malformed discovery must take the diagnostic path")
+        self.assertIn("could not list sessions", buf.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -44,9 +44,18 @@ class AgeTest(unittest.TestCase):
         self.assertTrue(digest_mod.age(utc_iso(600)).endswith("m ago"))
         self.assertTrue(digest_mod.age(utc_iso(3 * 3600)).endswith("h ago"))
 
-    def test_age_is_never_negative(self):
-        """Clock skew must not render a future stamp as a huge negative age."""
-        self.assertEqual(digest_mod.age(utc_iso(-120)), "0s ago")
+    def test_future_stamp_is_skew_not_freshness(self):
+        """A future stamp must not be indistinguishable from a live core.
+
+        This previously asserted "0s ago" — pinning the clamp. The age column
+        IS the wedge signal, so rendering skew as fresh hides the thing it
+        exists to show.
+        """
+        self.assertEqual(digest_mod.age(utc_iso(-120)), "clock skew")
+        self.assertNotEqual(digest_mod.age(utc_iso(-120)),
+                            digest_mod.age(utc_iso(0)))
+        # Sub-second jitter is not skew; the tolerance must survive.
+        self.assertEqual(digest_mod.age(utc_iso(-1)), "0s ago")
 
     def test_unparsable_stamp_is_reported_not_raised(self):
         self.assertEqual(digest_mod.age("not-a-timestamp"), "?")
@@ -139,11 +148,21 @@ class DiscoveryTest(unittest.TestCase):
         self.addCleanup(self.tmp.cleanup)
         self.cfg = Path(self.tmp.name)
 
-    def test_config_dir_prefers_env_over_default(self):
-        with unittest.mock.patch.dict(os.environ, {digest_mod.CFG_ENV: str(self.cfg)}):
+    def test_config_dir_delegates_to_the_shared_claude_home_resolver(self):
+        """No private copy of the resolution rule — including $CLAUDE_HOME.
+
+        The script used to hand-roll $CLAUDE_CONFIG_DIR or ~/.claude, which
+        silently ignored the $CLAUDE_HOME override the shared contract honours.
+        """
+        with unittest.mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(self.cfg)}):
             self.assertEqual(digest_mod.config_dir(), self.cfg)
+        # The override the private copy could not see.
+        alt = self.cfg / "alt-home"
+        alt.mkdir()
+        with unittest.mock.patch.dict(os.environ, {"CLAUDE_HOME": str(alt)}, clear=True):
+            self.assertEqual(digest_mod.config_dir(), alt)
         with unittest.mock.patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(digest_mod.config_dir(), digest_mod.DEFAULT_CFG)
+            self.assertEqual(digest_mod.config_dir(), Path.home() / ".claude")
 
     def _run_result(self, rc=0, stdout="[]"):
         return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr="")
@@ -174,7 +193,7 @@ class DiscoveryTest(unittest.TestCase):
         proj = self.cfg / "projects" / "-some-slug"
         proj.mkdir(parents=True)
         (proj / "sid-1.jsonl").write_text("")
-        with unittest.mock.patch.dict(os.environ, {digest_mod.CFG_ENV: str(self.cfg)}):
+        with unittest.mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(self.cfg)}):
             self.assertEqual(digest_mod.find_transcript("sid-1").name, "sid-1.jsonl")
             self.assertIsNone(digest_mod.find_transcript("absent"))
 
@@ -200,7 +219,7 @@ class MainTest(unittest.TestCase):
         err = io.StringIO()
         with unittest.mock.patch.object(sys, "argv", ["prog", *argv]), \
              unittest.mock.patch.object(digest_mod, "live_sessions", return_value=sessions), \
-             unittest.mock.patch.dict(os.environ, {digest_mod.CFG_ENV: str(self.cfg)}), \
+             unittest.mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(self.cfg)}), \
              contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
             rc = digest_mod.main()
         return rc, out.getvalue(), err.getvalue()

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -171,23 +171,49 @@ class DiscoveryTest(unittest.TestCase):
         payload = '[{"name": "core-1", "sessionId": "abc", "status": "busy", "pid": 1}]'
         with unittest.mock.patch.object(subprocess, "run",
                                         return_value=self._run_result(stdout=payload)):
-            self.assertEqual(digest_mod.live_sessions()[0]["name"], "core-1")
+            sessions, reason = digest_mod.live_sessions()
+            self.assertIsNone(reason)
+            self.assertEqual(sessions[0]["name"], "core-1")
 
-    def test_live_sessions_empty_on_nonzero_exit(self):
-        with unittest.mock.patch.object(subprocess, "run",
-                                        return_value=self._run_result(rc=1, stdout="")):
-            self.assertEqual(digest_mod.live_sessions(), [])
-
-    def test_live_sessions_empty_on_unparsable_output(self):
-        with unittest.mock.patch.object(subprocess, "run",
-                                        return_value=self._run_result(stdout="not json")):
-            self.assertEqual(digest_mod.live_sessions(), [])
-
-    def test_live_sessions_empty_when_cli_missing_or_hangs(self):
-        for exc in (FileNotFoundError("claude"), subprocess.TimeoutExpired("claude", 30)):
+    def test_every_discovery_failure_is_distinguishable(self):
+        """These all used to return [] — so "none running" and "the CLI is
+        gone/hung/unauthenticated" rendered identically on a liveness tool."""
+        run_cases = {
+            "empty":     self._run_result(stdout="[]"),
+            "auth":      self._run_result(rc=2, stdout=""),
+            "not json":  self._run_result(stdout="<html>502</html>"),
+            "dict":      self._run_result(stdout='{"sessions": []}'),
+            "non-dicts": self._run_result(stdout='["core-1"]'),
+        }
+        raise_cases = {
+            "missing":   FileNotFoundError(2, "No such file"),
+            "denied":    PermissionError(13, "Permission denied"),
+            "timeout":   subprocess.TimeoutExpired("claude", 30),
+        }
+        reasons = {}
+        for label, result in run_cases.items():
+            with unittest.mock.patch.object(subprocess, "run", return_value=result):
+                sessions, reasons[label] = digest_mod.live_sessions()
+                self.assertEqual(sessions, [], label)
+        for label, exc in raise_cases.items():
             with unittest.mock.patch.object(subprocess, "run", side_effect=exc):
-                self.assertEqual(digest_mod.live_sessions(), [],
-                                 f"{type(exc).__name__} must not propagate")
+                sessions, reasons[label] = digest_mod.live_sessions()
+                self.assertEqual(sessions, [], f"{label} must not propagate")
+
+        self.assertIsNone(reasons["empty"],
+                          "a CLEAN answer of zero sessions is not a failure")
+        failures = {k: v for k, v in reasons.items() if k != "empty"}
+        self.assertTrue(all(failures.values()), f"a failure carried no reason: {failures}")
+        self.assertEqual(len(set(failures.values())), len(failures),
+                         f"two failure modes share a message: {failures}")
+
+    def test_wrong_shape_does_not_reach_the_caller(self):
+        """{"sessions": []} parses, then raises AttributeError on the first .get()."""
+        with unittest.mock.patch.object(subprocess, "run",
+                                        return_value=self._run_result(stdout='{"sessions": []}')):
+            sessions, reason = digest_mod.live_sessions()
+        self.assertEqual(sessions, [])
+        self.assertIn("list", reason)
 
     def test_find_transcript_locates_by_session_id_else_none(self):
         proj = self.cfg / "projects" / "-some-slug"
@@ -214,11 +240,12 @@ class MainTest(unittest.TestCase):
                "message": {"content": [{"type": "text", "text": "did a thing"}]}}
         (self.proj / f"{sid}.jsonl").write_text(json.dumps(rec) + "\n")
 
-    def _main(self, argv, sessions):
+    def _main(self, argv, sessions, reason=None):
         out = io.StringIO()
         err = io.StringIO()
         with unittest.mock.patch.object(sys, "argv", ["prog", *argv]), \
-             unittest.mock.patch.object(digest_mod, "live_sessions", return_value=sessions), \
+             unittest.mock.patch.object(digest_mod, "live_sessions",
+                                        return_value=(sessions, reason)), \
              unittest.mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(self.cfg)}), \
              contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
             rc = digest_mod.main()
@@ -235,6 +262,14 @@ class MainTest(unittest.TestCase):
         rc, _, err = self._main([], [])
         self.assertEqual(rc, 1)
         self.assertIn("no live sessions", err)
+
+    def test_broken_discovery_exits_differently_from_an_empty_pool(self):
+        rc_broken, _, err_broken = self._main([], [], reason="`claude` is not on PATH")
+        rc_empty, _, err_empty = self._main([], [])
+        self.assertEqual(rc_broken, 2, "a broken CLI must not look like an idle pool")
+        self.assertNotEqual(rc_broken, rc_empty)
+        self.assertIn("not on PATH", err_broken)
+        self.assertNotEqual(err_broken, err_empty)
 
     def test_session_filter_matches_and_misses(self):
         self._transcript()

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -260,5 +260,55 @@ class TerminalSafety(unittest.TestCase):
         self.assertNotIn("\x1b", ev[1])
 
 
+ATTACK_SID = "abc\x1b]52;c;YXR0YWNr\x07def"
+
+
+class UntrustedSessionIdTest(unittest.TestCase):
+    """sessionId is metadata, not a name we control: it reaches a TTY and a path."""
+
+    def _main_with(self, session_id):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            cfg = td / "cfg"
+            (cfg / "projects" / "p1").mkdir(parents=True)
+            (cfg / "projects" / "p1" / "real-session.jsonl").write_text(
+                '{"timestamp":"2026-08-24T10:00:00.000Z"}\n')
+            payload = td / "payload.json"
+            payload.write_text(json.dumps(
+                [{"name": "n1", "status": "ok", "pid": 1,
+                  "sessionId": session_id}]))
+            stub = td / "bin"
+            stub.mkdir()
+            (stub / "claude").write_text(f"#!/bin/sh\ncat {payload}\n")
+            (stub / "claude").chmod(0o755)
+            env = dict(os.environ, CLAUDE_CONFIG_DIR=str(cfg),
+                       PATH=f"{stub}:{os.environ['PATH']}")
+            r = subprocess.run([sys.executable, str(SCRIPT)],
+                               capture_output=True, text=True, env=env)
+            return r.stdout + r.stderr
+
+    def test_no_transcript_path_neutralizes_terminal_controls(self):
+        out = self._main_with(ATTACK_SID)
+        self.assertNotIn("\x1b", out, "ESC reached the terminal")
+        self.assertNotIn("\x07", out, "BEL reached the terminal (OSC 52 sets the clipboard)")
+        self.assertIn("\ufffd", out,
+                      "control: the escape was present and REPLACED, not merely absent")
+
+    def test_session_id_is_matched_literally_never_as_a_pattern(self):
+        with tempfile.TemporaryDirectory() as td:
+            cfg = Path(td) / "cfg"
+            (cfg / "projects" / "p1").mkdir(parents=True)
+            real = cfg / "projects" / "p1" / "real-session.jsonl"
+            real.write_text("{}\n")
+            with unittest.mock.patch.dict(os.environ,
+                                          {"CLAUDE_CONFIG_DIR": str(cfg)}):
+                for bad in ("*", "real-*", "../../etc/passwd", ""):
+                    self.assertIsNone(digest_mod.find_transcript(bad),
+                                      f"{bad!r} selected a transcript")
+                self.assertEqual(digest_mod.find_transcript("real-session"), real,
+                                 "control: a legitimate id must still resolve")
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Contract for scripts/pool-session-digest.py.
+
+The age column is the load-bearing part: an operator reads it to decide whether
+a session is wedged. Transcripts stamp UTC, so reading them with a local-time
+parser reports an age that is wrong by the UTC offset -- and correcting with
+time.timezone rather than the DST-aware offset lands exactly one hour out, which
+is precisely the shape of "stale" an operator is looking for. The first version
+of this script shipped that bug and reported 3-second-old activity as 60m.
+"""
+import importlib.util
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "pool-session-digest.py"
+
+_spec = importlib.util.spec_from_file_location("digest_mod", SCRIPT)
+digest_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(digest_mod)
+
+
+def utc_iso(offset_secs: int = 0) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S.000Z",
+                         time.gmtime(time.time() - offset_secs))
+
+
+class AgeTest(unittest.TestCase):
+    def test_recent_utc_stamp_reads_as_seconds_not_hours(self):
+        """A local-time parse of a UTC stamp is off by the whole UTC offset."""
+        self.assertTrue(digest_mod.age(utc_iso(3)).endswith("s ago"),
+                        "a 3s-old event must not read as minutes or hours")
+
+    def test_age_scales(self):
+        self.assertTrue(digest_mod.age(utc_iso(600)).endswith("m ago"))
+        self.assertTrue(digest_mod.age(utc_iso(3 * 3600)).endswith("h ago"))
+
+    def test_age_is_never_negative(self):
+        """Clock skew must not render a future stamp as a huge negative age."""
+        self.assertEqual(digest_mod.age(utc_iso(-120)), "0s ago")
+
+    def test_unparsable_stamp_is_reported_not_raised(self):
+        self.assertEqual(digest_mod.age("not-a-timestamp"), "?")
+        self.assertEqual(digest_mod.age(""), "?")
+
+
+class DigestTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "s.jsonl"
+
+    def _write(self, records):
+        self.path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+    def _rec(self, blocks):
+        return {"type": "assistant", "timestamp": utc_iso(1),
+                "message": {"content": blocks}}
+
+    def test_counts_blocks_and_tolerates_junk_lines(self):
+        self.path.write_text(
+            json.dumps(self._rec([{"type": "text", "text": "hello"}])) + "\n"
+            + "{ not json\n\n"
+            + json.dumps(self._rec([{"type": "thinking", "thinking": "hmm"}])) + "\n")
+        d = digest_mod.digest(self.path, keep=10, width=80, want_thinking=True)
+        self.assertEqual(d["records"], 2, "a malformed line must not abort the scan")
+        self.assertEqual(d["blocks"]["text"], 1)
+        self.assertEqual(d["blocks"]["thinking"], 1)
+
+    def test_thinking_is_counted_but_hidden_unless_requested(self):
+        self._write([self._rec([{"type": "thinking", "thinking": "private"}])])
+        d = digest_mod.digest(self.path, keep=10, width=80, want_thinking=False)
+        self.assertEqual(d["blocks"]["thinking"], 1, "still counted")
+        self.assertEqual(d["tail"], [], "reasoning must not leak without --thinking")
+
+    def test_tail_is_bounded_to_keep(self):
+        self._write([self._rec([{"type": "text", "text": f"m{i}"}]) for i in range(50)])
+        d = digest_mod.digest(self.path, keep=5, width=80, want_thinking=False)
+        self.assertEqual(len(d["tail"]), 5, "tail must stay bounded on huge transcripts")
+        self.assertEqual(d["tail"][-1][2], "m49", "must keep the NEWEST events")
+
+    def test_tool_use_summarises_the_command(self):
+        self._write([self._rec([{"type": "tool_use", "name": "Bash",
+                                 "input": {"command": "git status"}}])])
+        d = digest_mod.digest(self.path, keep=5, width=80, want_thinking=False)
+        _, kind, body = d["tail"][0]
+        self.assertEqual(kind, "BASH")
+        self.assertEqual(body, "git status")
+
+    def test_long_summary_is_truncated_to_width(self):
+        self._write([self._rec([{"type": "text", "text": "x" * 500}])])
+        d = digest_mod.digest(self.path, keep=5, width=40, want_thinking=False)
+        self.assertLessEqual(len(d["tail"][0][2]), 41)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -75,6 +75,48 @@ class DigestTest(unittest.TestCase):
         return {"type": "assistant", "timestamp": utc_iso(1),
                 "message": {"content": blocks}}
 
+    # `rendered` is what the block degrades to; None means dropped is fine.
+    # Isolation alone would pass a before/after check with every guard reverted.
+    MALFORMED_LEAVES = {
+        "tool_input_is_a_string": ({"type": "tool_use", "name": "Bash",
+                                    "input": "not-a-dict"}, "not-a-dict"),
+        "text_is_an_object": ({"type": "text", "text": {"a": 1}}, None),
+        "thinking_is_an_array": ({"type": "thinking",
+                                  "thinking": ["a", "b"]}, None),
+        "tool_name_is_an_int": ({"type": "tool_use", "name": 42,
+                                 "input": {"command": "ls"}}, "ls"),
+        "tool_input_value_nested": ({"type": "tool_use", "name": "Bash",
+                                     "input": {"command": {"deep": 1}}},
+                                    "{'deep': 1}"),
+    }
+
+    def test_a_malformed_leaf_does_not_hide_later_events(self):
+        for name, (bad, rendered) in self.MALFORMED_LEAVES.items():
+            with self.subTest(name):
+                self._write([self._rec([{"type": "text", "text": "before"}]),
+                             self._rec([bad]),
+                             self._rec([{"type": "text", "text": "after"}])])
+                out = digest_mod.digest(self.path, keep=10, width=80,
+                                        want_thinking=True)
+                bodies = [e[2] for e in out["tail"]]
+                self.assertIn("after", bodies,
+                              f"{name}: the malformed record hid every later event")
+                self.assertIn("before", bodies, name)
+                if rendered is not None:
+                    self.assertIn(rendered, bodies,
+                                  f"{name}: degraded to dropped, not rendered")
+
+    def test_a_non_string_timestamp_does_not_hide_later_events(self):
+        """`(rec.get("timestamp") or "")[11:19]` subscripts an int and raises;
+        `or ""` does not catch it, because a non-zero int is truthy."""
+        self._write([self._rec([{"type": "text", "text": "before"}]),
+                     {"type": "assistant", "timestamp": 1234567890,
+                      "message": {"content": [{"type": "text", "text": "mid"}]}},
+                     self._rec([{"type": "text", "text": "after"}])])
+        out = digest_mod.digest(self.path, keep=10, width=80, want_thinking=True)
+        bodies = [e[2] for e in out["tail"]]
+        self.assertEqual(bodies, ["before", "mid", "after"])
+
     def test_counts_blocks_and_tolerates_junk_lines(self):
         self.path.write_text(
             json.dumps(self._rec([{"type": "text", "text": "hello"}])) + "\n"

--- a/tests/pool-session-digest.test.py
+++ b/tests/pool-session-digest.test.py
@@ -232,5 +232,33 @@ class MainTest(unittest.TestCase):
         self.assertIn("no transcript", out)
 
 
+class TerminalSafety(unittest.TestCase):
+    """This digest prints to a TTY, so transcript content must not carry controls."""
+
+    def test_osc52_clipboard_escape_is_neutralized(self):
+        out = digest_mod._one_line("safe\x1b]52;c;YXR0YWNr\x07text", 200)
+        self.assertNotIn("\x1b", out)
+        self.assertNotIn("\x07", out)
+        self.assertIn("safe", out)
+
+    def test_csi_colour_sequence_is_neutralized(self):
+        self.assertNotIn("\x1b", digest_mod._one_line("a\x1b[31mred\x1b[0m", 50))
+
+    def test_c1_and_del_are_neutralized(self):
+        for ch in ("\x7f", "\x9b", "\x00"):
+            with self.subTest(ch=ch):
+                self.assertNotIn(ch, digest_mod._one_line(f"x{ch}y", 50))
+
+    def test_ordinary_text_is_untouched(self):
+        """Positive control: the guard must not mangle normal content."""
+        self.assertEqual(digest_mod._one_line("hello  world", 50), "hello world")
+
+    def test_tool_name_is_sanitized_too(self):
+        ev = digest_mod._event({"timestamp": "2026-08-23T00:00:00Z"},
+                        {"type": "tool_use", "name": "a\x1bb",
+                         "input": {"command": "ls"}}, 50)
+        self.assertNotIn("\x1b", ev[1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

A session transcript is the only complete record of a core's reasoning and context — but they are **4–286 MB** and growing. Reading one to answer *"is core-2 wedged, and on what?"* isn't practical. The alternatives each miss something:

| | limitation |
|---|---|
| `tmux capture-pane` | only what fits on screen; dies with the pane |
| `state/cores/*.alive` | proves the **process** is alive, not that the **agent** is progressing |

That gap is not hypothetical: a core held a claim for 646s and was indistinguishable from a stall until someone captured its pane by hand.

## What

Streams each transcript once with a bounded tail and prints what answers the question:

```
sutando-lead-follower-65  [busy]  pid=3952
  6.9M · 5687 records · last 3s ago
  tool_use 513 · tool_result 513 · text 510 · thinking 280
    21:39:37  BASH   python3 - <<'EOF' import sys, pathlib …
    21:39:45  SAY    Sweep pass: no assignments for core-2 …
    21:42:17  SAY    Core-1 assignment — ignoring.
```

**308 MB across four live sessions digests in 2.4s.** Sessions are discovered via `claude agents --json` (which also supplies `status`), transcripts located by `sessionId`.

Reasoning is **counted but not printed** without `--thinking` — a diagnostic that dumps another session's reasoning by default isn't one you can run casually.

## Evidence

The `age` column is the part an operator acts on, so it's the part under test.

The first working version had a real bug: it parsed UTC stamps with `mktime` and corrected using `time.timezone`, which **ignores DST** and reported 3-second-old activity as **"60m ago"** — indistinguishable from the staleness the tool exists to detect. It was caught because the output was self-evidently absurd, not because a test failed.

So the test now pins it. Same suite, only the parse swapped:

```
fixed  (calendar.timegm)              -> Ran 9 tests  OK
buggy  (mktime - time.timezone)       -> FAILED (failures=2)
   test_recent_utc_stamp_reads_as_seconds_not_hours ... FAIL
```

Other assertions cover: malformed lines don't abort the scan, the tail stays bounded and keeps the *newest* events, `--thinking` gating, negative-age clamping under clock skew, and width truncation.

## Checks

- `ruff check` → clean
- `scripts/review-checks.sh --diff` → `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`, RC=0
- `tests/ci-covers-every-python-test.test.py` → OK (test sits under the auto-discovered `tests/**` glob; no `ci.yml` entry owed)

## Scope

Read-only, and deliberately narrow. It does **not** write to transcripts (live session state), summarise content with a model, or feed scheduling. Pairing `status` from `claude agents --json` into the lead's stall detection is a plausible follow-up but is a separate change to `pool_lead.py`, which is being edited concurrently.

@sutando-qingyun-001:ag2.space