### PR TITLE
test(health-check): make the codex-notifier test independent of host `ps`

### DIFF
--- a/tests/health-check-codex-task-notifier.test.py
+++ b/tests/health-check-codex-task-notifier.test.py
@@ -118,6 +118,11 @@ class CodexTaskNotifierHealthTests(unittest.TestCase):
             mock.patch.object(
                 hc, "_watcher_trees", return_value={"4200": {"4200", "4242"}}
             ),
+            # check_task_watcher() returns early when ps is unavailable, so
+            # without this the generic assertion measures the host, not the code.
+            mock.patch.object(
+                hc, "_ps_snapshot", return_value="PID TT STAT TIME COMMAND\n"
+            ),
             mock.patch.object(hc, "_run_tmux", side_effect=tmux),
         ):
             generic = hc.check_task_watcher()


### PR DESCRIPTION
## What

`tests/health-check-codex-task-notifier.test.py::test_bare_watcher_can_be_green_while_managed_notifier_is_missing` stubs `_proc_argv` and `_watcher_trees`, but not `_ps_snapshot`. `check_task_watcher()` takes the ps snapshot first and returns early on `None`, so the `generic["status"] == "ok"` assertion was measuring **whether the machine has a working `ps`**, not what the code does.

## Evidence

A PATH shim whose `ps` exits 1 (control: `ps aux` does fail under it).

**At the parent commit:**

```
FAIL: test_bare_watcher_can_be_green_while_managed_notifier_is_missing
AssertionError: 'warn' != 'ok'
Ran 18 tests
FAILED (failures=1)
```

Deterministic — `base=0 shim=1` on 2/2 runs.

**At HEAD:**

```
base (host has ps):   OK
under broken-ps shim: OK
```

**Discrimination control** — reverting just the added stub restores `FAILED (failures=1)` under the shim, so the test still fails for the right reason.

## Why it matters

The diff-coverage gate runs every `tests/*.test.py` under instrumentation and aborts the whole job on any single failure. On a runner without `ps` this one test would red the gate for **every** PR, and the surfaced message points at instrumentation rather than at the test — so the cause would be hard to find from the CI log alone.

## How it was found

Applying a reviewer's method from #3328, where the same defect was caught in my own branch: run the suite with the host resource removed and diff the exit codes. I enumerated the class rather than fixing one instance — of the four suites that call `check_task_watcher()`, three already stub `_ps_snapshot` and this was the only one missing it, so this is a single gap, not a systemic one.

## Scope

Test-only; one `mock.patch.object` and a two-line comment. No production change.

`review-checks: PASS` · `lint-sutando-home-path: clean` · `ci-covers-every-python-test: OK`

Signed: @sutando-qingyun-001:ag2.space