### PR TITLE
fix(dm-result): refuse a [channel:] redirect instead of silently DMing the body

### DIFF
--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -168,8 +168,7 @@ def _open_dm_channel(owner_id: str, token: str) -> str:
 def send_dm(text: str) -> bool:
     """Send text to the resolved owner's Discord DM."""
     # This sender only ever opens the owner's DM, so a [channel:] redirect names a
-    # destination it cannot reach. Refuse before sending; delivering the body to the
-    # DM anyway would misroute it silently.
+    # destination it cannot reach; refusing beats misrouting the body silently.
     redirects = [a.value for a in parse_markers(text).actions if a.kind == "redirect"]
     if redirects:
         print(

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -167,6 +167,18 @@ def _open_dm_channel(owner_id: str, token: str) -> str:
 
 def send_dm(text: str) -> bool:
     """Send text to the resolved owner's Discord DM."""
+    # This sender only ever opens the owner's DM, so a [channel:] redirect names a
+    # destination it cannot reach. Refuse before sending; delivering the body to the
+    # DM anyway would misroute it silently.
+    redirects = [a.value for a in parse_markers(text).actions if a.kind == "redirect"]
+    if redirects:
+        print(
+            f"dm-result: body carries a [channel: {redirects[0]}] redirect, "
+            "which this sender cannot honor (owner DM only). Not sending.",
+            file=sys.stderr,
+        )
+        return False
+
     token = _load_token()
     if not token:
         print("dm-result: DISCORD_BOT_TOKEN not found in .env", file=sys.stderr)

--- a/tests/dm-result-redirect-refusal.test.py
+++ b/tests/dm-result-redirect-refusal.test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""dm-result must refuse a [channel:] redirect instead of silently DMing the body.
+
+parse_markers() STRIPS the marker, so a dropped redirect is invisible downstream:
+the body arrives in the owner DM looking well-formed, addressed to nobody in particular.
+"""
+
+from contextlib import redirect_stderr
+import importlib.util
+import io
+import os
+from pathlib import Path
+import tempfile
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "dm-result.py"
+
+_TD = tempfile.mkdtemp()
+os.environ["CLAUDE_CONFIG_DIR"] = _TD
+os.environ["DISCORD_BOT_TOKEN"] = ""
+os.environ["SUTANDO_DM_OWNER_ID"] = ""
+
+spec = importlib.util.spec_from_file_location("dm_result_redirect", SCRIPT)
+dm = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(dm)
+
+CHAN = "1538218588937134170"
+
+
+def _send(text):
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        rc = dm.send_dm(text)
+    return rc, buf.getvalue()
+
+
+def test_redirect_is_refused_by_name():
+    rc, err = _send(f"[channel: {CHAN}]\nbody meant for a channel")
+    assert rc is False, "a body it cannot route must not report success"
+    # The RETURN VALUE cannot discriminate: with no token the pre-fix code also
+    # returns False. Only the reason names the redirect, so assert on that.
+    assert CHAN in err, f"refusal must name the channel it could not reach; got: {err!r}"
+    assert "redirect" in err.lower(), f"refusal must name the cause; got: {err!r}"
+
+
+def test_control_no_redirect_fails_for_a_different_reason():
+    """Without a redirect the guard must not fire — otherwise it refuses everything."""
+    rc, err = _send("an ordinary body with no markers at all")
+    assert rc is False, "no token in this env, so it still fails"
+    assert "redirect" not in err.lower(), f"guard fired on a body with no redirect: {err!r}"
+    assert CHAN not in err
+
+
+def test_marker_below_the_first_line_is_not_a_redirect():
+    """CLAUDE.md scopes [channel:] to the FIRST non-empty line; the guard must match.
+
+    Refusing on a marker mentioned mid-prose would block ordinary bodies that merely
+    quote one -- over-refusal is the failure mode on this side.
+    """
+    rc, err = _send(f"leading line\n[channel: {CHAN}]\ntrailing")
+    assert rc is False, "no token in this env, so it still fails"
+    assert "redirect" not in err.lower(), (
+        f"guard fired on a non-first-line marker, which the bridge does not treat "
+        f"as a redirect; got: {err!r}"
+    )
+
+
+if __name__ == "__main__":
+    test_redirect_is_refused_by_name()
+    test_control_no_redirect_fails_for_a_different_reason()
+    test_marker_below_the_first_line_is_not_a_redirect()
+    print("PASS: 3/3")


### PR DESCRIPTION
## The defect

`parse_markers()` returns `Action(kind="redirect", …)` for a leading `[channel: <id>]` and strips the
marker from the body. `send_dm()` consumed only `kind == "attach"` actions, so the redirect was
**parsed, removed, and dropped** — the body went to the owner DM, marker-free and looking well-formed,
while the caller's stated destination was discarded and the command reported success.

Measured at this branch's parent (`f8d13a76`):

```
parse_markers('[channel: 1538218588937134170]\nbody text')
  -> ParseResult(body='body text', actions=[Action(kind='redirect', value='1538218588937134170')])

src/dm-result.py  imports parse_markers (:38), filters to kind == "attach",
                  destination always _open_dm_channel(owner_id) (:159, :181)
```

Hit live before it was diagnosed: a correction addressed to the channel where the original claim was
made landed in the owner DM instead — **1810 chars in, 1778 delivered**, the 31-char marker line
stripped. No error, no warning. Reading the tool's output cannot catch it, because the output says the
send succeeded.

## The fix

This sender can only ever open the owner's DM, so honoring the redirect would widen its contract.
It **refuses** instead, naming the channel it could not reach.

The guard sits at the top of `send_dm()`, ahead of token resolution — so it costs no API call and,
more importantly, stays reachable without credentials. My first draft placed it after the token gate,
where no hermetic test could ever reach it.

## Evidence

**The test asserts on the refusal REASON, not the return value.** With no token the pre-fix code also
returns `False`, so the boolean cannot discriminate. Against the unfixed file:

```
AssertionError: refusal must name the channel it could not reach;
  got: 'dm-result: DISCORD_BOT_TOKEN not found in .env\n'
```

With the fix: `PASS: 3/3`.

Existing suites, all green at HEAD:

```
tests/dm-result-cli.test.py               ok: missing arguments print usage and exit 1
tests/dm-result-adoption-gap.test.py      ok
tests/dm-result-multipart-upload.test.py  All dm-result multipart-upload tests passed.
tests/bridge-marker-no-leak.test.py       PASS
```

## The control, and what it caught

A `[channel:]` **below** the first line is not a redirect per CLAUDE.md, and the guard must not fire on
it — over-refusal is the failure mode on this side. That case caught my own first draft of the test,
which asserted the marker was detected anywhere in the body. The code was right and the test was wrong.

## Scope

`dm-result.py` only. `discord-bridge.py` may share this shape — CLAUDE.md names both as prior private-
parser copies — but I have not measured it and am not touching it here.
