### PR TITLE
fix(voice-host): the wearable task writer interpolated user content unguarded

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -12,6 +12,7 @@ import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, readdir
 import { join, resolve } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
+import { confineUserContent } from './task_body_guard.js';
 import { resolveWorkspace } from './workspace_default.js';
 import { tryStampText } from './task_envelope.js';
 import { claudeHomePath } from './util_paths.js';
@@ -81,51 +82,7 @@ const _delegation: TaskDelegationService = selectBackend(TASK_DIR, RESULT_DIR, a
 function ts(): string { return new Date().toISOString().slice(11, 23); }
 
 /** U+200B — zero-width space; not whitespace, so it survives .trimStart(). */
-const _ZWSP = '​';
-// Kept in lockstep with local_task_protocol.KNOWN_HEADER_KEYS (the Python
-// guard's source of truth). TS can't import the Python tuple, so this list is
-// the mirror; injection-guard-sweep asserts parity so drift fails CI. Synced to
-// the full 38-key set on the 2026-07-13 main merge (main widened the Python side
-// from 14 → 38; the TS guard must defang the same keys or forged interaction_type:
-// / attachments: / media_form: lines slip through here).
-const _HEADER_KEYS = [
-	'id', 'timestamp', 'session_scope', 'task', 'source', 'access_tier', 'user_id',
-	'channel_id', 'priority', 'interaction_type', 'source_message_id',
-	'channel_name', 'guild_name', 'attempts', 'sender_name', 'room_name',
-	'parent_message_id', 'reply_chain_ids', 'reminder', 'author_name', 'author_id', 'chat_id',
-	'thread_ts', 'reply_to_event', 'reply_to_me', 'reply_to_sender', 'addressed_to', 'callSid', 'caller',
-	'receiving_instance',
-	'from', 'call_sid', 'hint', 'instructions', 'transcript',
-	'schedule_name', 'schedule_slot',
-	'content_modalities', 'media_form', 'attachments', 'platform_card',
-	'instance_id',
-];
-const _HEADER_RE = new RegExp(`^(?:${_HEADER_KEYS.join('|')})\\s*:`, 'i');
-const _FENCE_RE = /^={3,}/;
-// Every separator str.splitlines() / universal-newline readers treat as a
-// line boundary — fold ALL to '\n' so the guard's line-set matches the
-// reader's (else \v \f \x1c-\x1e \x85 \u2028 \u2029 smuggle a forged line past it).
-const _LINE_SEP_RE = /\r\n|[\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]/g;
 
-/**
- * Defang user-supplied content before embedding in a task file.
- *
- * Prefixes any line that looks like a task-file header field or a
- * ===FENCE=== with U+200B so structural injection (access_tier forge,
- * system-instruction fence) cannot succeed. Idempotent; folds every str.splitlines() separator (not just CR/CRLF).
- * TypeScript mirror of src/task_body_guard.py:confine_user_content().
- */
-function confineUserContent(text: string): string {
-	if (!text) return text;
-	const normalized = text.replace(_LINE_SEP_RE, '\n');
-	return normalized.split('\n').map(line => {
-		const probe = line.trimStart();
-		if ((_HEADER_RE.test(probe) || _FENCE_RE.test(probe)) && !line.startsWith(_ZWSP)) {
-			return _ZWSP + line;
-		}
-		return line;
-	}).join('\n');
-}
 
 /**
  * Write a chat-path task file so the dashboard tracks chat-originated work.

--- a/src/task_body_guard.ts
+++ b/src/task_body_guard.ts
@@ -1,0 +1,56 @@
+/**
+ * confineUserContent — the ONE TypeScript implementation of the task-body
+ * injection guard. TS mirror of src/task_body_guard.py:confine_user_content().
+ *
+ * Extracted because the guard existed as two hand-copies (task-bridge.ts and
+ * the phone skill's conversation-server.ts) and a third writer arrived without
+ * one — src/voice-host.ts interpolated a model-supplied `task:` unguarded.
+ * Copies drift: conversation-server's own comment records that main's version
+ * had already "dropped the wrapping" once.
+ */
+
+const _ZWSP = '​';
+// Kept in lockstep with local_task_protocol.KNOWN_HEADER_KEYS (the Python
+// guard's source of truth). TS can't import the Python tuple, so this list is
+// the mirror; injection-guard-sweep asserts parity so drift fails CI. Synced to
+// the full 38-key set on the 2026-07-13 main merge (main widened the Python side
+// from 14 → 38; the TS guard must defang the same keys or forged interaction_type:
+// / attachments: / media_form: lines slip through here).
+const _HEADER_KEYS = [
+	'id', 'timestamp', 'session_scope', 'task', 'source', 'access_tier', 'user_id',
+	'channel_id', 'priority', 'interaction_type', 'source_message_id',
+	'channel_name', 'guild_name', 'attempts', 'sender_name', 'room_name',
+	'parent_message_id', 'reply_chain_ids', 'reminder', 'author_name', 'author_id', 'chat_id',
+	'thread_ts', 'reply_to_event', 'reply_to_me', 'reply_to_sender', 'addressed_to', 'callSid', 'caller',
+	'receiving_instance',
+	'from', 'call_sid', 'hint', 'instructions', 'transcript',
+	'schedule_name', 'schedule_slot',
+	'content_modalities', 'media_form', 'attachments', 'platform_card',
+	'instance_id',
+];
+const _HEADER_RE = new RegExp(`^(?:${_HEADER_KEYS.join('|')})\\s*:`, 'i');
+const _FENCE_RE = /^={3,}/;
+// Every separator str.splitlines() / universal-newline readers treat as a
+// line boundary — fold ALL to '\n' so the guard's line-set matches the
+// reader's (else \v \f \x1c-\x1e \x85 \u2028 \u2029 smuggle a forged line past it).
+const _LINE_SEP_RE = /\r\n|[\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]/g;
+
+/**
+ * Defang user-supplied content before embedding in a task file.
+ *
+ * Prefixes any line that looks like a task-file header field or a
+ * ===FENCE=== with U+200B so structural injection (access_tier forge,
+ * system-instruction fence) cannot succeed. Idempotent; folds every str.splitlines() separator (not just CR/CRLF).
+ * TypeScript mirror of src/task_body_guard.py:confine_user_content().
+ */
+export function confineUserContent(text: string): string {
+	if (!text) return text;
+	const normalized = text.replace(_LINE_SEP_RE, '\n');
+	return normalized.split('\n').map(line => {
+		const probe = line.trimStart();
+		if ((_HEADER_RE.test(probe) || _FENCE_RE.test(probe)) && !line.startsWith(_ZWSP)) {
+			return _ZWSP + line;
+		}
+		return line;
+	}).join('\n');
+}

--- a/src/voice-host.ts
+++ b/src/voice-host.ts
@@ -29,6 +29,7 @@ import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, renam
 import { join } from 'node:path';
 import { resolveWorkspace } from './workspace_default.js';
 import { tryStampText } from './task_envelope.js';
+import { confineUserContent } from './task_body_guard.js';
 
 const PORT = Number(process.env.SUTANDO_VOICE_HOST_PORT || 8788);
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY || '';
@@ -83,7 +84,7 @@ function buildWorkTool(device: { deviceId?: string; label?: string },
 			const body = [
 				`id: ${id}`,
 				`timestamp: ${new Date().toISOString()}`,
-				`task: ${task.replace(/\n/g, ' ')}`,
+				`task: ${confineUserContent(task).replace(/\n/g, ' ')}`,
 				'source: wearable-voice',
 				'channel_id: voice-host',
 				`user_id: ${device.label || 'wearable'}`,

--- a/tests/injection-guard-sweep.test.py
+++ b/tests/injection-guard-sweep.test.py
@@ -186,9 +186,25 @@ if _ag2_path.exists():
 # ---------------------------------------------------------------------------
 
 _tb = _src("src/task-bridge.ts")
+_guard_mod = _src("src/task_body_guard.ts")
 _check(
-    "task-bridge: confineUserContent defined",
-    "function confineUserContent" in _tb,
+    "task_body_guard.ts: confineUserContent is defined and exported",
+    "export function confineUserContent" in _guard_mod,
+)
+_check(
+    "task-bridge: DELEGATES to the shared guard (no private copy)",
+    "from './task_body_guard.js'" in _tb and "function confineUserContent" not in _tb,
+)
+_vh = _src("src/voice-host.ts")
+_check(
+    "voice-host: DELEGATES to the shared guard",
+    "from './task_body_guard.js'" in _vh and "function confineUserContent" not in _vh,
+)
+_check(
+    # Importing the guard is not applying it: the earlier form of this check
+    # stayed green when the call was deleted from the task body.
+    "voice-host: confineUserContent APPLIED to the task body",
+    "`task: ${confineUserContent(task)" in _vh,
 )
 _check(
     "task-bridge: confineUserContent(task) — voice body",
@@ -394,6 +410,7 @@ for _pyf in sorted(
 
 _GUARDED_TS_WRITERS = {
     "src/task-bridge.ts",
+    "src/voice-host.ts",
     "skills/phone-conversation/scripts/conversation-server.ts",
 }
 
@@ -450,7 +467,9 @@ else:
         )
         _py_header_keys = set(re.findall(r"[\"']([^\"']+)[\"']", _body))
 
-_tb2 = _src("src/task-bridge.ts")
+# The TS key list moved to the shared guard module; task-bridge.ts now
+# imports it, so parity must be checked against its real home.
+_tb2 = _src("src/task_body_guard.ts")
 _ts_keys_m = re.search(r"const _HEADER_KEYS\s*=\s*\[([^\]]+)\]", _tb2, re.DOTALL)
 _ts_header_keys: set[str] = set()
 if _ts_keys_m:
@@ -461,7 +480,7 @@ if _ts_keys_m:
     }
 
 _check(
-    "header-key-parity: task_body_guard.py _HEADER_KEYS matches task-bridge.ts",
+    "header-key-parity: task_body_guard.py _HEADER_KEYS matches task_body_guard.ts",
     bool(_py_header_keys) and _py_header_keys == _ts_header_keys,
     f"key mismatch: py={sorted(_py_header_keys - _ts_header_keys)} "
     f"ts={sorted(_ts_header_keys - _py_header_keys)} — "


### PR DESCRIPTION
## The defect

`src/voice-host.ts` — new on this branch (`cb3a25fb`) — writes a task file with:

```ts
`task: ${task.replace(/\n/g, ' ')}`,
```

Newline-folding only, no `confineUserContent()`. A model- or device-supplied task body can therefore carry a forged header line or a `===FENCE===` into the task file: the structural-injection vector the guard exists to close.

`tests/injection-guard-sweep.test.py` catches it, and the failure names its own remedy. It is **RED on `feat/sutando-server`, GREEN on `main`** — a branch regression, not a pre-existing gap. That branch receives no CI (workflows run on PRs targeting main), which is why it sat unseen.

## Not fixed by adding a third copy

Two hand-copies of the guard already existed — `src/task-bridge.ts` and the phone skill's `conversation-server.ts` — and they had **already drifted once**, recorded in conversation-server's own comment: *"main's version dropped the wrapping."* A third copy is the defect, not the fix.

So this extracts the owner the code had already named (`task-bridge.ts`'s comment calls itself the *"TypeScript mirror of src/task_body_guard.py"*):

| file | change |
|---|---|
| `src/task_body_guard.ts` | **new** — the one TS implementation, exported |
| `src/task-bridge.ts` | drops its private copy, imports the shared one |
| `src/voice-host.ts` | imports it and applies it to the task body |

**The constants were moved verbatim, not retyped** — dropping one of the 41 header keys would be a silent hole, so the block was relocated programmatically.

**`conversation-server.ts` keeps its copy, deliberately.** It is a skill, so importing from `src/` crosses the boundary where this repo has a documented TS symlink-resolution hazard. Copies go **2 → 1**, and the remaining one is named here rather than left silent.

## The sweep's own couplings had to move

Three assertions treated `task-bridge.ts` as "the TS home". Rather than loosen them:

- header-key parity now reads `task_body_guard.ts`;
- *"confineUserContent defined in task-bridge"* → **three** checks: defined+exported in the owner, and each adapter **delegates**.

**49 → 52 guards.**

## Mutation-verified — and the first round caught my own new guard being vacuous

```
voice-host guard removed    -> 51/51 passed   ← my "delegates" check only saw the IMPORT
```

Deleting the confinement call left the suite green, because asserting the import is not asserting the application — the exact class this sweep exists to prevent, in the guard I had just written. Added an explicit call-site assertion. Final:

```
voice-host guard removed    -> 51/52 FAILED
task-bridge import removed  -> 50/51 FAILED
shared export removed       -> 50/51 FAILED
restored                    -> 52/52 passed
```

```
injection-guard-sweep  rc=0     task-body-guard              rc=0
task-body-injection-guard rc=0  local-task-protocol          rc=0
agent-api-task-field-injection rc=0
tsc --noEmit: clean for the touched files
review-checks: PASS
```

Targets `feat/sutando-server`; `main` is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
