### PR TITLE
docs(src-map): regenerate — the branch added a module without updating the index

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -65,6 +65,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`discord_rest_client.py`** — Alias of `channels.discord.client` (phase-1a restructure); one transition window.
 - **`dm-result.py`** — Send a task result to Discord DM if voice client is disconnected.
 - **`emit-call-tiers.ts`** — Emit the core's advertisable *direct* call tiers to `state/call-tiers.json` — the runtime-authored half of the availability-driven call-tier menu (Track 9).
+- **`entrance_links.py`** — EntranceLink records — verified provider-identity ↔ Stand bindings (I2).
 - **`event_log.py`** — Structured event log for Sutando — JSONL events for post-mortem debugging.
 - **`fix-setup.sh`** — One-shot fix for Mac Mini after migration bundle setup
 - **`friction-detector.py`** — Proactive friction detector for Sutando.


### PR DESCRIPTION
`tests/src-map.test.py` is RED on `feat/sutando-server`, GREEN on `main`:

```
gen-src-map: docs/src-map.md is stale — run 'python3 scripts/gen-src-map.py' and commit the result
FAIL docs/src-map.md matches generated output
```

Purely mechanical — I ran the generator the failure names. One module was missing from the index; `src-map` is the lookup CLAUDE.md tells agents to consult *before* grepping the tree, so a stale index quietly sends readers to grep instead.

After: `tests/src-map.test.py` rc=0.

Found by sweeping all 629 test files against this branch's origin tip (`29547ef6`) and discriminating every red against main. That branch receives no CI of its own, which is why these accumulate unseen — full tally in the PR-Shepherd room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)