### PR TITLE
test(state-paths): allowlist runtime-api — "state"/"results" are domain fields, not paths

### DIFF
--- a/tests/state-paths-adoption.test.py
+++ b/tests/state-paths-adoption.test.py
@@ -150,6 +150,14 @@ ALLOWLIST = {
     # must run before any other Sutando module is loaded, so it inlines
     # the workspace resolution rather than importing workspace_default.
     "src/core_heartbeat.py",
+    # "state"/"results" here are runtime-status and request fields, not the
+    # workspace dirs; none composes a path. Same case as workspace_layout.py.
+    "src/runtime-api/instance_registry.py",
+    "src/runtime-api/runtime_dispatch.py",
+    "src/runtime-api/runtime_view.py",
+    "src/runtime-api/tasks_view.py",
+    "src/runtime-api/ws_transport.py",
+    "src/runtime-cli/tui.py",
     # task_archive.py is a pure locator helper — it takes tasks_dir as a
     # parameter from the caller and never resolves workspace itself. The
     # flagged token appears only in the module docstring (example usage),


### PR DESCRIPTION
`tests/state-paths-adoption.test.py` is RED on `feat/sutando-server`, GREEN on `main`. All six flagged lines are **false positives** — the guard matches a quoted bare word, not a path:

```
instance_registry.py:232  if health.get("state") not in ("online", "degraded"):
runtime_dispatch.py:165   "version": 1, "state": "active",
runtime_view.py:42        return {"state": "offline"}
tasks_view.py:95          {"taskId": task_id, "state": "pending"}
ws_transport.py:285       if params.get("results", True):
tui.py:102                st = h.get("state")
```

In runtime-api's vocabulary `state` is a **runtime status** and `results` is a request flag. None of the six composes a filesystem path from a workspace token — I grepped all six for `state/`, `join`, `Path`, `workspace`: no hits.

I used the remedy the failure message itself prescribes, with the precedent already in that list — `workspace_layout.py` is exempt because *"its flagged tokens are JSON report field names, not runtime-state paths."* Same situation.

## What I did NOT do, and why it's probably the better fix

The over-broad alternation is the first one:

```
["']\s*(?:tasks|results|state|notes|logs)\s*["']    # quoted bare name
```

It matches **every dict key** of those names. The composed-path shape it exists to catch is already covered explicitly by the third alternation (`(REPO|REPO_DIR|WORKSPACE_DIR|workspace|repo) / "token"`), so alternation 1 is largely redundant with it — minus roots under some other variable name. Narrowing it would fix the class rather than exempting a subsystem, but it trades recall on unnamed root variables, and that's a design call on your guard. Reported, not made.

## Control

My first control was **vacuous** — rc=1 with and without the synthetic violation, because the baseline already failed, so it discriminated nothing. Corrected to check the violation is *named*:

```
synthetic "state" added to entrance_links.py -> named in output: 1
after restore                                -> named in output: 0, rc=0
```

Test-only. Targets `feat/sutando-server`; main is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)