### PR TITLE
fix(entrance-links): verify_discord bypassed the Discord REST chokepoint

### DIFF
--- a/src/entrance_links.py
+++ b/src/entrance_links.py
@@ -14,7 +14,6 @@ import json
 import os
 import secrets
 import tempfile
-import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -298,12 +297,10 @@ def _revoke_link_locked(state_dir, stand_id, provider, revoked_by, reason):
 
 
 def verify_discord(state_dir: str | Path, token: str) -> dict:
-    req = urllib.request.Request(
-        "https://discord.com/api/v10/users/@me",
-        headers={"Authorization": f"Bot {token}",
-                 "User-Agent": "sutando-entrance-verify (https://ag2.ai, v0)"})
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        me = json.loads(resp.read().decode())
+    # Through the REST chokepoint, not a hand-rolled request: one HTTP stack
+    # means one place that owns retries, UA and the post-gate.
+    from channels.discord.client import DiscordRestClient
+    me = DiscordRestClient(token).get_json("/users/@me")
     subject = {"type": "bot_user", "id": str(me["id"])}
     display = {}
     name = me.get("global_name") or me.get("username")


### PR DESCRIPTION
`tests/discord-post-census.test.py` is RED on `feat/sutando-server`, GREEN on `main`:

```
FAIL  no discord.com/api literal outside the chokepoint+readers (scanned 501 production files)
      [src/entrance_links.py]
```

`verify_discord()` hand-rolled its own request to `https://discord.com/api/v10/users/@me`. The census exists precisely because *"a chokepoint is only as good as its coverage — one hand-rolled sender outside it and an injected post-gate validator silently misses that path."*

## Routed, not allowlisted

The allowlist has a **READERS** category and this call is a GET, so exempting it would have been defensible. I didn't, because the client already exposes `get_json()` and takes a token per-instance — so the read needs no exemption at all. **Fewer exemptions beats a well-justified one.**

```python
from channels.discord.client import DiscordRestClient
me = DiscordRestClient(token).get_json("/users/@me")
```

Three things come free by routing:

- reads pick up the client's 429 `Retry-After` + transient-5xx handling;
- one User-Agent for every Sutando→Discord REST call, in Discord's documented `DiscordBot (url, version)` form rather than a bespoke string;
- `transport` is injectable, so this path is now testable without a network.

## Behaviour

`verify_discord` has **no callers yet** — the I2 EntranceLink feature hasn't wired it — so nothing live changes. Error shapes do differ (the client raises through `request_json` rather than letting `urllib` escape), which is the same contract every other REST caller already has. Also dropped the now-dead `import urllib.request`; ruff's config here doesn't flag F401, so it would have lingered.

## Verification

```
discord-post-census        rc=0     discord-rest-client        rc=0
runtime-api-identity-view  rc=0     discord-rest-client-gate   rc=0
ruff / review-checks       pass     discord-post-gate-wiring   rc=0
```

Mutation — restoring the literal makes the census fail again (rc=1), so the guard still fires and this isn't a scanner that quietly stopped looking.

Targets `feat/sutando-server`; main is unaffected. This was the last *real* regression from the 629-test branch sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)