### PR TITLE
ci: point the staging trigger at the branch that exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
+    branches: [main, feat/sutando-server]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main, feat/sutando-server]
 
 # Tests must never emit product telemetry (no PostHog writes from CI).
 env:


### PR DESCRIPTION
CI runs on `[main, staging-interaction-planes]`. **That second branch is gone:**

```
git ls-remote --heads origin staging-interaction-planes   -> (nothing)
git ls-remote --heads origin feat/sutando-server          -> 29547ef6
```

So the staging slot protects a branch nobody can push to, while the live staging branch — **6 open PRs against it right now** — gets nothing.

## The cost is measured, not hypothetical

I swept all **629 test files** against `feat/sutando-server`'s origin tip and discriminated every red against main: **8 true regressions plus 3 branch-only failing tests.** Six are now fixed — #3343, #3344, #3345, #3346, #3348, #3349 — and **one was a security guard**: a task writer interpolating user content with no confinement, i.e. a live structural-injection path.

None of it was visible, because workflows run on PRs *targeting main* and nothing watches a long-lived branch with no PR against it. #3343's reviewer reached the same conclusion independently:

> on the current feature base GitHub has run only `parse-on-the-floor` plus CLA, so those checks are not a substitute for the post-parent full gate

## Scope

A **swap, not an addition** — the concern is "the staging slot names the current staging branch." One line to revert if `staging-interaction-planes` is ever recreated.

## This is not instant, and I would rather say so

For `push` events GitHub reads the workflow from **the pushed branch**, so `feat/sutando-server` picks this up when it next merges main — which it does routinely. Landing it here keeps the CI config canonical on main rather than editing a feature branch's workflow directly. If you want coverage sooner, merging main into that branch is the trigger.

```
yaml parse: {'branches': ['main', 'feat/sutando-server']} for both pull_request and push
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)