### PR TITLE
fix(ci): PRs stacked on a feature branch trigger no workflows and render all-green

### DIFF
--- a/.github/workflows/bundle-smoke.yml
+++ b/.github/workflows/bundle-smoke.yml
@@ -5,7 +5,6 @@ name: bundle-smoke
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
     paths:
       - 'src/**'
       - 'skills/phone-conversation/scripts/conversation-server.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -13,7 +13,6 @@ name: Coverage Gate
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
 
 jobs:
   coverage-gate:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -21,7 +21,6 @@ name: eslint
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-agents-md-sync.yml
+++ b/.github/workflows/lint-agents-md-sync.yml
@@ -19,7 +19,6 @@ name: lint-agents-md-sync
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-claude-home-path.yml
+++ b/.github/workflows/lint-claude-home-path.yml
@@ -14,7 +14,6 @@ name: lint-claude-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-hermetic-bridge-tests.yml
+++ b/.github/workflows/lint-hermetic-bridge-tests.yml
@@ -16,7 +16,6 @@ name: lint-hermetic-bridge-tests
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-host-label.yml
+++ b/.github/workflows/lint-host-label.yml
@@ -17,7 +17,6 @@ name: lint-host-label
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-hotkey-assertions.yml
+++ b/.github/workflows/lint-hotkey-assertions.yml
@@ -14,7 +14,6 @@ name: lint-hotkey-assertions
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-src-map.yml
+++ b/.github/workflows/lint-src-map.yml
@@ -13,7 +13,6 @@ name: lint-src-map
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-sutando-home-path.yml
+++ b/.github/workflows/lint-sutando-home-path.yml
@@ -15,7 +15,6 @@ name: lint-sutando-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-workspace-resolution.yml
+++ b/.github/workflows/lint-workspace-resolution.yml
@@ -15,7 +15,6 @@ name: lint-workspace-resolution
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,6 @@ name: ruff
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,7 +25,6 @@ name: shellcheck
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/workspace-leak-check.yml
+++ b/.github/workflows/workspace-leak-check.yml
@@ -18,7 +18,6 @@ name: workspace-leak-check
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 


### PR DESCRIPTION
Closes #3339.

## The defect

`on: pull_request: branches:` filters the **base** branch, not the head. Fifteen workflows list only `[main, staging-interaction-planes]` or `[main, staging-workspace-revamp]`, so a PR opened against a feature branch matches **none** of them. GitHub renders that as a green PR — not "no checks required", but a checks list with nothing meaningful in it.

## Before / after — measured against the 14 currently-open stacked PRs

Eligible workflows, computed by evaluating each `pull_request` trigger against each PR's real `baseRefName`:

```
    PR  base                                before  after
  3263  feat/native-ag2space-room-sessions       2     17
  3264  feat/c-terminal-record                   2     17
  3314  feat/sutando-server-v0                   2     17
  3316  feat/sparrow-b1-identity-contract        2     17
  3319  feat/lead-follower-pool                  2     17
  3322  feat/pool-operability                    2     17
  3330  feat/pool-operability                    2     17
  3333  feat/pool-runtime-dimension              2     17
  3343  feat/sutando-server                      2     17
  3344  feat/sutando-server                      2     17
  3345  feat/sutando-server                      2     17
  3346  feat/sutando-server                      2     17
  3348  feat/sutando-server                      2     17
  3349  feat/sutando-server                      2     17

CONTROL base=main:                        before=17  after=17   UNCHANGED
CONTROL base=staging-interaction-planes:  before=10  after=17
```

**The `base=main` control is the important row**: this change does not alter what runs on a normal PR. It only stops excluding the stacked ones.

That `before=2` is an independent check on the model — #3339 measured the *actual* rollup on stacked PRs at a median of 2.5, which is what you get from the handful of workflows that were never base-filtered (`python39-compat`, `publish-sparrow`, and the CLA/coverage comment jobs). The prediction and the observation agree without being fitted to each other.

## Incidental: the two staging branches were each getting half the suite

The filters had drifted into two different sets — 8 workflows name `staging-interaction-planes`, 7 name `staging-workspace-revamp`, and no workflow names both. So each staging branch was running roughly half the checks (the `before=10` row above). Removing the base filter repairs that as a side effect rather than by a separate rule.

## The change

One line removed from each of 15 workflows — the `branches:` key under `pull_request:`, nothing else:

```
$ git diff --numstat | awk '{a+=$1;d+=$2} END{print "additions="a" deletions="d" files="NR}'
additions=0 deletions=15 files=15
```

Guards on the edit:

```
changed lines that are `branches`:              15
of those, lines under a `push:` trigger:         0
workflows still filtering push by branch:       16   (unchanged)
YAML parse failures across all 22 workflows:     0
```

`push:` triggers are deliberately untouched — the concern there is which branches get CI on direct push, which is a different question and not what #3339 is about.

## What this PR does NOT prove

The `after` column is computed from the trigger definitions, not observed from a live run — the same predicate GitHub applies (base-ref glob match), evaluated locally. **The end-to-end confirmation requires a stacked PR to exist after this merges**, which cannot be produced beforehand. This PR's own base is `main`, so its CI being green says nothing about the fix either way.

Concretely checkable after merge: reopen or push to any of the 14 PRs above and its rollup should go from ~2 to ~17.

## Alternative considered

Adding `feat/**`, `fix/**` etc. to each `branches:` list. Rejected — it re-encodes a naming convention in 15 files and silently fails the moment someone uses a prefix nobody listed, which is the failure mode this issue already is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
