### PR TITLE
chore(ci): drop branch names that no longer exist from push triggers

### DIFF
--- a/.github/workflows/bundle-smoke.yml
+++ b/.github/workflows/bundle-smoke.yml
@@ -16,7 +16,7 @@ on:
       - 'package-lock.json'
       - '.github/workflows/bundle-smoke.yml'
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
     paths:
       - 'src/**'
       - 'skills/phone-conversation/scripts/conversation-server.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 # Tests must never emit product telemetry (no PostHog writes from CI).
 env:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
     branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   eslint:

--- a/.github/workflows/lint-agents-md-sync.yml
+++ b/.github/workflows/lint-agents-md-sync.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
     branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   lint-agents-md-sync:

--- a/.github/workflows/lint-claude-home-path.yml
+++ b/.github/workflows/lint-claude-home-path.yml
@@ -16,7 +16,7 @@ on:
   pull_request:
     branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-claude-home-path:

--- a/.github/workflows/lint-hermetic-bridge-tests.yml
+++ b/.github/workflows/lint-hermetic-bridge-tests.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
     branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-hermetic-bridge-tests:

--- a/.github/workflows/lint-host-label.yml
+++ b/.github/workflows/lint-host-label.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
     branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-host-label:

--- a/.github/workflows/lint-hotkey-assertions.yml
+++ b/.github/workflows/lint-hotkey-assertions.yml
@@ -16,7 +16,7 @@ on:
   pull_request:
     branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-hotkey-assertions:

--- a/.github/workflows/lint-src-map.yml
+++ b/.github/workflows/lint-src-map.yml
@@ -15,7 +15,7 @@ on:
   pull_request:
     branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   lint-src-map:

--- a/.github/workflows/lint-sutando-home-path.yml
+++ b/.github/workflows/lint-sutando-home-path.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
     branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-sutando-home-path:

--- a/.github/workflows/lint-workspace-resolution.yml
+++ b/.github/workflows/lint-workspace-resolution.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
     branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-workspace-resolution:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
     branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   ruff:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -27,7 +27,7 @@ on:
   pull_request:
     branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   shellcheck:

--- a/.github/workflows/workspace-leak-check.yml
+++ b/.github/workflows/workspace-leak-check.yml
@@ -20,7 +20,7 @@ on:
   pull_request:
     branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   workspace-leak-check:


### PR DESCRIPTION
Follow-up to #3353. Both of its reviewers raised this independently as a non-blocking nit, and both said it belonged in its own PR rather than that one — this is that PR.

## The dead names

Neither staging branch exists. Verified against the live branch list, with `main` as a positive control so an empty result cannot be mistaken for a working query:

```
total branches: 312
  main                               PRESENT     <- positive control
  staging-interaction-planes         ABSENT
  staging-workspace-revamp           ABSENT
  feat/sutando-server                PRESENT
```

**One correction to the review that prompted this:** the nit named `staging-interaction-planes`. There are **two** dead names — `staging-workspace-revamp` is equally absent, and it accounts for 7 of the 14 files here. Fixing only the name that was quoted would have left half the problem in place.

## Scope — `push:` only

Across the workflow directory, 29 (file, trigger) pairs name a dead branch: 15 under `pull_request:` and 14 under `push:`. **#3353 removes the `pull_request` half by deleting those filters entirely**, so this PR touches only the `push:` half, leaving `[main]`.

```
additions=14 deletions=14 files=14
changed `branches:` lines under push: 14   under pull_request: 0
```

That split is deliberate and is why the two PRs do not overlap in intent: `pull_request.branches` filters the **base** and was silently excluding work (#3339); `push.branches` is correctly scoped and should keep filtering — it just should not name branches that are gone.

## No behaviour change

A push to a branch that does not exist cannot fire, so nothing that runs today stops running:

```
workflows whose push still fires on main: 16   (unchanged)
YAML parse failures across all workflows:  0
pull_request triggers still naming a dead branch: 15   (untouched — #3353's half)
```

The value is not behavioural. It is that a stale branch list which reads as meaningful is precisely what kept #3339 invisible through six regressions; leaving fifteen more of them in place invites the next reader to make the same assumption.

## Merge order

This is based on `main`, not stacked on #3353 — deliberately, so it gets real CI rather than the empty rollup #3353 exists to fix.

The two touch **adjacent lines in the same 14 files** (`pull_request.branches` sits directly above `push.branches`), so whichever lands second may need a trivial rebase. **#3353 should go first** — it fixes a live defect, it already has an approval, and this one is cosmetic. I will rebase this and re-run its checks once #3353 lands.

## Not claimed

I have not verified *why* the branches were deleted or whether a replacement staging branch is intended. If one is, adding it back to these `push:` lists is a one-line change — but it should be a live name chosen deliberately, not the dead one inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
