### PR TITLE
fix(start-cli): add scripts/start-cli.sh compat shim (closes #3362)

### DIFF
--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# COMPAT SHIM — DO NOT ADD LOGIC HERE.
+#
+# The canonical core launcher is src/agent/start-cli.sh (PR #1891). This wrapper
+# preserves the old path for callers that were not updated in lockstep — notably
+# a not-yet-rebuilt Sutando.app, whose backend-supervisor.mjs still resolves
+# scripts/start-cli.sh and silently no-ops when it is absent.
+_repo="$(cd "$(dirname "$0")/.." && pwd)"
+echo "scripts/start-cli.sh is a compat shim — moved to src/agent/start-cli.sh (update your caller)." >&2
+exec bash "$_repo/src/agent/start-cli.sh" "$@"

--- a/tests/start-cli-compat-shim.test.sh
+++ b/tests/start-cli-compat-shim.test.sh
@@ -1,21 +1,33 @@
 #!/bin/bash
-# Smoke test for the one-release compat shim added when the Claude-specific
-# shell setup moved to src/agent/claude/cli/ (PR #1891).
+# Smoke test for the one-release compat shims added when generic scripts moved
+# under src/agent/ (PR #1891 for sutando-shell-setup; the start-cli shim
+# followed later, closing the gap #1891 deliberately left — see
+# sonichi/sutando#3362).
 #
 # Guards against the "moved with no shim" regression: an already-installed /
-# not-yet-rebuilt Sutando.app (and health-check --recover-core) still invoke the
-# OLD scripts/sutando-shell-setup.sh path, and would hard-fail after a `git pull`
-# if that path vanished. This asserts the remaining shim exists, is executable,
-# parses, and exec-forwards to its canonical home. The generic core launcher has
-# no old-path shim: all callers use src/agent/start-cli.sh directly.
-# It does NOT run the shim — structural only.
+# not-yet-rebuilt Sutando.app still invokes the OLD scripts/*.sh paths, and
+# would hard-fail — or, for start-cli specifically, silently no-op with no
+# logging (ag2space-cinny-desktop's backend-supervisor.mjs launchCore,
+# sonichi/sutando#3362) — after a `git pull` if those paths vanished. This
+# asserts each remaining shim exists, is executable, parses, and
+# exec-forwards to its own canonical home (the two shims have DIFFERENT
+# targets, so this is keyed per name, not a single shared target string).
+# It does NOT run the shims — structural only.
 set -u
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 fail=0
 
-for name in sutando-shell-setup; do
+target_for() {
+    case "$1" in
+        sutando-shell-setup) echo "src/agent/claude/cli/sutando-shell-setup.sh" ;;
+        start-cli)           echo "src/agent/start-cli.sh" ;;
+        *)                   echo "" ;;
+    esac
+}
+
+for name in sutando-shell-setup start-cli; do
     shim="$REPO/scripts/$name.sh"
-    target="src/agent/claude/cli/$name.sh"
+    target="$(target_for "$name")"
 
     [ -f "$shim" ] || { echo "  FAIL: compat shim $shim is missing"; fail=1; continue; }
     [ -x "$shim" ] || { echo "  FAIL: compat shim $shim is not executable"; fail=1; }
@@ -26,7 +38,7 @@ for name in sutando-shell-setup; do
 done
 
 if [ "$fail" -eq 0 ]; then
-    echo "PASS: shell-setup compat shim forwards to its canonical target"
+    echo "PASS: compat shims forward to their canonical targets"
 else
     echo "compat-shim test FAILED"
     exit 1


### PR DESCRIPTION
## Summary
- PR #1891 moved the Claude-specific shell setup under `src/agent/claude/cli/` and added a one-release compat shim for `scripts/sutando-shell-setup.sh` — but deliberately skipped one for the generic core launcher. Its own test said so explicitly: *"The generic core launcher has no old-path shim: all callers use `src/agent/start-cli.sh` directly."*
- That assumption was false. `ag2-space/ag2space-cinny-desktop`'s `backend-supervisor.mjs` (the app supervisor that ships alongside the vendored `engine/sutando/` checkout) still resolves `scripts/start-cli.sh`, and its missing-file branch was a bare `return` with **zero logging** — so the core agent silently never starts, while every other service still reports "ready" (#3362).
- The primary fix for that lives in `ag2-space/ag2space-cinny-desktop` (loud logging + fallback path ordering — see [PR #417](https://github.com/ag2-space/ag2space-cinny-desktop/pull/417)). This is the defensive half sutando itself can ship: a shim for already-built app binaries that can't be patched retroactively.

## What changed
- Added `scripts/start-cli.sh` — matches the existing `scripts/sutando-shell-setup.sh` shim exactly (same exec-forward pattern, same "DO NOT ADD LOGIC HERE" header), forwarding to the canonical `src/agent/start-cli.sh`.
- Extended `tests/start-cli-compat-shim.test.sh` to cover both shims. The two shims forward to **different** targets, so the loop is now keyed per shim name (`target_for()`) rather than a single hardcoded target string. Also removed the file's own now-false claim about there being no old-path shim for the core launcher.

## Evidence
```
$ bash tests/start-cli-compat-shim.test.sh
PASS: compat shims forward to their canonical targets
$ echo $?
0
```
Before this change, the same test only checked `sutando-shell-setup` (the `start-cli` name wasn't in its loop at all, so it could not have caught this gap).

## Test plan
- [x] `bash tests/start-cli-compat-shim.test.sh` — passes, both shims verified structurally (exists, executable, valid syntax, exec-forwards to its own canonical target, target file exists)
- [x] `bash -n scripts/start-cli.sh` — syntax valid
- [x] Diffed against `scripts/sutando-shell-setup.sh` to confirm the pattern match is exact (comment shape, exec-forward style, `755` mode)
- [ ] Not run: actually invoking `scripts/start-cli.sh` live (it launches a real tmux core session — the existing shell-setup shim's own test is explicitly structural-only for the same reason, see its header comment)

Closes #3362