### PR TITLE
fix(runtime): attribute packaged engine versions

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -645,8 +645,9 @@ except Exception:
 # code: the source-version identity of the runtime — 'which Sutando is this,
 # behaviorally?' Prompts + skills + scripts in the repo determine behavior, so
 # the desktop app (and fleet tooling) wants this to reason about version-compat
-# and to spot a locally-modified core. All git-native + best-effort (None when
-# not a git checkout). tree_sha is the content hash of TRACKED files (version-
+# and to spot a locally-modified core. Git is authoritative for checkouts;
+# packaged engines fall back to the build-authored ENGINE_MANIFEST beside the
+# copied repo. tree_sha is the content hash of TRACKED files (version-
 # independent); dirty flags uncommitted edits. A stronger working-tree
 # 'source_sha' (hashes uncommitted + untracked behavior files) is a documented
 # follow-up alongside the identity block.
@@ -679,12 +680,45 @@ def _git(*a):
         return (r.stdout.strip() or None) if r.returncode == 0 else None
     except Exception:
         return None
+
+def _engine_manifest():
+    # Packaged installs place the manifest beside the copied engine directory.
+    for path in (os.path.join(os.path.dirname(repo), 'ENGINE_MANIFEST.json'),
+                 os.path.join(repo, 'ENGINE_MANIFEST.json')):
+        try:
+            with open(path) as f:
+                value = json.load(f)
+            if isinstance(value, dict):
+                return value
+        except (OSError, ValueError):
+            pass
+    return {}
+
+_git_revision = _git('rev-parse', 'HEAD')
+_manifest = {} if _git_revision else _engine_manifest()
+_manifest_revision = _manifest.get('sha')
+if not (isinstance(_manifest_revision, str) and len(_manifest_revision) >= 8
+        and all(c in '0123456789abcdefABCDEF' for c in _manifest_revision)):
+    _manifest_revision = None
+_revision = _git_revision or _manifest_revision
+_git_describe = _git('describe', '--tags', '--always', '--dirty')
+_manifest_branch = _manifest.get('branch')
+if not isinstance(_manifest_branch, str):
+    _manifest_branch = None
+_manifest_dirty = _manifest.get('dirty')
+if not isinstance(_manifest_dirty, bool):
+    _manifest_dirty = False
 code = {
-    'commit': _git('rev-parse', '--short', 'HEAD'),
-    'branch': _git('rev-parse', '--abbrev-ref', 'HEAD'),
-    'describe': _git('describe', '--tags', '--always', '--dirty'),
+    'commit': _revision[:7] if _revision else None,
+    'revision': _revision,
+    'branch': _git('rev-parse', '--abbrev-ref', 'HEAD') or _manifest_branch,
+    'describe': _git_describe or (_revision[:7] if _revision else None),
     'tree_sha': _git('rev-parse', 'HEAD^{tree}'),
-    'dirty': bool(_git('status', '--porcelain')),
+    'dirty': bool(_git('status', '--porcelain')) if _git_bin else _manifest_dirty,
+    'source': 'git' if _git_revision else ('engine-manifest' if _manifest_revision else None),
+    'built_at': _manifest.get('built_at') if isinstance(_manifest.get('built_at'), str) else None,
+    'tree_digest': (_manifest.get('post_build_tree_digest')
+                    if isinstance(_manifest.get('post_build_tree_digest'), str) else None),
 }
 # run-dir + runtime-api socket: mirror #2325 rundir.py (same policy as the
 # run-dir / runtime-socket subcommands). This is a second copy of the chain (the

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -648,7 +648,8 @@ except Exception:
 # and to spot a locally-modified core. Git is authoritative for checkouts;
 # packaged engines fall back to the build-authored ENGINE_MANIFEST beside the
 # copied repo. tree_sha is the content hash of TRACKED files (version-
-# independent); dirty flags uncommitted edits. A stronger working-tree
+# independent); packaged consumers use tree_digest instead. dirty flags
+# uncommitted edits. A stronger working-tree
 # 'source_sha' (hashes uncommitted + untracked behavior files) is a documented
 # follow-up alongside the identity block.
 # Resolve ONCE, before any spawn. Two gates, both required:
@@ -682,7 +683,7 @@ def _git(*a):
         return None
 
 def _engine_manifest():
-    # Packaged installs place the manifest beside the copied engine directory.
+    # Packaging authors the parent manifest; the in-repo path is compatibility-only.
     for path in (os.path.join(os.path.dirname(repo), 'ENGINE_MANIFEST.json'),
                  os.path.join(repo, 'ENGINE_MANIFEST.json')):
         try:
@@ -714,7 +715,7 @@ code = {
     'branch': _git('rev-parse', '--abbrev-ref', 'HEAD') or _manifest_branch,
     'describe': _git_describe or (_revision[:7] if _revision else None),
     'tree_sha': _git('rev-parse', 'HEAD^{tree}'),
-    'dirty': bool(_git('status', '--porcelain')) if _git_bin else _manifest_dirty,
+    'dirty': bool(_git('status', '--porcelain')) if _git_revision else _manifest_dirty,
     'source': 'git' if _git_revision else ('engine-manifest' if _manifest_revision else None),
     'built_at': _manifest.get('built_at') if isinstance(_manifest.get('built_at'), str) else None,
     'tree_digest': (_manifest.get('post_build_tree_digest')

--- a/tests/sutando-config-runtime-git.test.sh
+++ b/tests/sutando-config-runtime-git.test.sh
@@ -57,7 +57,33 @@ c=$(code_field "$TMP/nogit" commit)
 if [ -z "$c" ]; then ok "no .git marker -> empty commit, still valid JSON" yes
 else ok "no .git marker -> empty commit, still valid JSON" no "got '$c'"; fi
 
-# --- 2. linked worktree (.git is a FILE) keeps identity ----------------------
+# --- 2. packaged engine reads its build manifest without spawning git --------
+mkdir -p "$TMP/bundle/engine/sutando"
+rsync -a --exclude '.git' --exclude 'node_modules' --exclude 'workspace' \
+      "$REPO/" "$TMP/bundle/engine/sutando/" 2>/dev/null
+cat > "$TMP/bundle/engine/ENGINE_MANIFEST.json" <<'JSON'
+{"sha":"1234567890abcdef1234567890abcdef12345678","branch":"release/test","dirty":false,"built_at":"2026-08-24T00:00:00Z","post_build_tree_digest":"sha256:abcdef"}
+JSON
+: > "$GITLOG"
+bundle_json="$(cd "$TMP/bundle/engine/sutando" && PATH="$TMP/shim:$PATH" bash scripts/sutando-config.sh runtime 2>/dev/null)"
+n=$(grep -c "^git " "$GITLOG" 2>/dev/null; true); n=${n:-0}
+if [ "$n" -eq 0 ]; then ok "packaged manifest -> zero git spawns" yes
+else ok "packaged manifest -> zero git spawns" no "$n spawns"; fi
+bundle_check="$(printf '%s' "$bundle_json" | python3 -c '
+import json,sys
+c=json.load(sys.stdin)["code"]
+want={
+ "commit":"1234567", "revision":"1234567890abcdef1234567890abcdef12345678",
+ "branch":"release/test", "describe":"1234567", "dirty":False,
+ "source":"engine-manifest", "built_at":"2026-08-24T00:00:00Z",
+ "tree_digest":"sha256:abcdef", "tree_sha":None,
+}
+print("yes" if all(c.get(k)==v for k,v in want.items()) else json.dumps(c,sort_keys=True))
+')"
+if [ "$bundle_check" = "yes" ]; then ok "packaged manifest -> exact revision + provenance populated" yes
+else ok "packaged manifest -> exact revision + provenance populated" no "$bundle_check"; fi
+
+# --- 3. linked worktree (.git is a FILE) keeps identity ----------------------
 if git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
     if git -C "$REPO" worktree add -q --detach "$TMP/wt" HEAD 2>/dev/null; then
         # Exercise the WORKING-TREE script, not whatever HEAD happens to carry —
@@ -82,11 +108,14 @@ else
     echo "skip linked-worktree case (not a git checkout)"
 fi
 
-# --- 3. ordinary checkout unaffected ----------------------------------------
+# --- 4. ordinary checkout unaffected ----------------------------------------
 if git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
     c=$(code_field "$REPO" commit)
     if [ -n "$c" ]; then ok "ordinary checkout -> commit populated" yes
     else ok "ordinary checkout -> commit populated" no "empty"; fi
+    src=$(code_field "$REPO" source)
+    if [ "$src" = "git" ]; then ok "ordinary checkout -> git remains authoritative" yes
+    else ok "ordinary checkout -> git remains authoritative" no "source '$src'"; fi
 fi
 
 echo

--- a/tests/sutando-config-runtime-git.test.sh
+++ b/tests/sutando-config-runtime-git.test.sh
@@ -62,7 +62,7 @@ mkdir -p "$TMP/bundle/engine/sutando"
 rsync -a --exclude '.git' --exclude 'node_modules' --exclude 'workspace' \
       "$REPO/" "$TMP/bundle/engine/sutando/" 2>/dev/null
 cat > "$TMP/bundle/engine/ENGINE_MANIFEST.json" <<'JSON'
-{"sha":"1234567890abcdef1234567890abcdef12345678","branch":"release/test","dirty":false,"built_at":"2026-08-24T00:00:00Z","post_build_tree_digest":"sha256:abcdef"}
+{"sha":"1234567890abcdef1234567890abcdef12345678","branch":"release/test","dirty":true,"built_at":"2026-08-24T00:00:00Z","post_build_tree_digest":"sha256:abcdef"}
 JSON
 : > "$GITLOG"
 bundle_json="$(cd "$TMP/bundle/engine/sutando" && PATH="$TMP/shim:$PATH" bash scripts/sutando-config.sh runtime 2>/dev/null)"
@@ -74,7 +74,7 @@ import json,sys
 c=json.load(sys.stdin)["code"]
 want={
  "commit":"1234567", "revision":"1234567890abcdef1234567890abcdef12345678",
- "branch":"release/test", "describe":"1234567", "dirty":False,
+ "branch":"release/test", "describe":"1234567", "dirty":True,
  "source":"engine-manifest", "built_at":"2026-08-24T00:00:00Z",
  "tree_digest":"sha256:abcdef", "tree_sha":None,
 }

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -55,9 +55,9 @@ assert d['repo']=='$REPO_DIR', f\"repo {d['repo']} != $REPO_DIR\"
 assert d['brain']==d['workspace']+'/.claude-sutando', f\"brain {d['brain']}\"
 assert d['session']=='sutando-core', d['session']
 assert isinstance(d['alive'], bool), d['alive']
-# code = source-version identity block (git-derived; keys always present, values may be null off-git)
+# code = source-version identity block (Git or packaged build manifest)
 c=d['code']
-for k in ('commit','branch','describe','tree_sha','dirty'):
+for k in ('commit','revision','branch','describe','tree_sha','dirty','source','built_at','tree_digest'):
     assert k in c, f'code missing {k}'
 assert isinstance(c['dirty'], bool), c['dirty']
 "


### PR DESCRIPTION
## What changed, and why?

`sutando-config.sh runtime` previously derived its `code` block only from `.git`. Desktop bundles intentionally copy the engine without `.git`, even though packaging already writes the exact source identity to `engine/ENGINE_MANIFEST.json`. As a result, every version field was null on the installed runtime and benchmark results could not be attributed to an engine revision.

This change keeps Git authoritative for checkouts and falls back to the build-authored manifest for packaged engines. The descriptor now includes the exact `revision`, short `commit`, branch, provenance source, build timestamp, and post-build tree digest. It still performs zero Git spawns on a non-checkout.

## Review first

- `scripts/sutando-config.sh`: packaged-manifest fallback and additive code identity fields
- `tests/sutando-config-runtime-git.test.sh`: packaged layout and zero-Git-spawn regression
- `tests/sutando-config-runtime.test.sh`: descriptor key contract

## User behavior proved

A packaged Sutando engine now reports the source revision that produced it, so benchmark and fleet records can be compared by version.

## Feature/documentation consistency

N/A. This repairs an existing runtime descriptor contract using the manifest already produced by packaging; it does not add a new user-facing capability or configuration.

## Before/after evidence

The same packaged layout (`engine/sutando` without `.git`, with `engine/ENGINE_MANIFEST.json`) was queried before and after.

Before (`origin/main`):

```json
{"branch": null, "commit": null, "describe": null, "dirty": false, "tree_sha": null}
```

After, using the actual installed desktop bundle manifest and live workspace:

```json
{"alive": true, "code": {"branch": "main", "built_at": "2026-08-18T22:47:20Z", "commit": "3a73e03", "describe": "3a73e03", "dirty": false, "revision": "3a73e0325fafb06173da338f07f815a42b38ecd6", "source": "engine-manifest", "tree_digest": "sha256:2fbc07d37f0b62ffe8abed1e01a6c8173ae7524582bdefbbae8accf015819fdb", "tree_sha": null}}
```

No live files were changed and no runtime restart was required; the witness ran the PR script against a temporary packaged-engine copy, the installed manifest, and the live workspace.

## Tests

```text
$ bash tests/sutando-config-runtime-git.test.sh
passed=9 failed=0

$ bash tests/sutando-config-runtime.test.sh
sutando-config-runtime: 11 passed, 0 failed

$ git diff | bash scripts/review-checks.sh
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)

$ git diff --check
# no output
```

## Hardcoded-path check

No host-specific paths or new path fallbacks were added. The production lookup derives the manifest path from the resolved repo directory.