### PR TITLE
docs(schedule-crons): capture is not handling — finish registration before processing a task

### DIFF
--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -47,6 +47,14 @@ When `core.runtime` is `codex`, the canonical unmarked `main-loop` entry (`promp
 
    Start it via the `Monitor` tool — pass `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`, `description: 'Streaming task watcher'`. The script emits one `TASK_FILE: <basename>` line per new task file (initial sweep + each subsequent event). Read the named file via the Read tool when notifications arrive. **Gate on running watcher TREES, not on the sentinel** — if one is already running, skip the Monitor call; the existing one continues. Reuse the shared enumerator rather than restating its rules here (the copies drift, and step 5 used to be one of the copies that did):
 
+   **Capture is not the same as handling.** Because the watcher is now armed *before* the
+   registration loop, a `TASK_FILE` notification can arrive while steps 2-4 are still running —
+   which was impossible when this ran last. If that happens, **finish registration first, then
+   process the queued task(s)**: the watcher's job here is to ensure the task is not MISSED, not
+   to have it handled immediately. Pivoting mid-loop can leave step 4's `/proactive-loop`
+   fallback unregistered, which is the one thing that guarantees the session has a recurring
+   work driver at all.
+
    ```bash
    python3 -c "
    import importlib.util, sys


### PR DESCRIPTION
## What

One paragraph in `skills/schedule-crons/SKILL.md` step 1.5. It closes the review item I raised on #3367 and did not get in before that PR merged.

## Why

#3367 (merged `e7fcb481`) moved the watcher start from step 5 to step 1.5, ahead of the `CronCreate` registration loop. That fixes a real, measured problem — with 9 session crons the watcher sat unarmed for **~76 seconds** on a fresh boot, and a new user's first ping sat unprocessed for the whole window.

It also creates an interleaving that was **structurally impossible** before: with the watcher armed at 1.5, a `TASK_FILE` notification can now arrive *while steps 2-4 are still running*. Under the old ordering the watcher only started after registration finished, so this could not happen.

The concrete worst case is not hypothetical positioning — it is specific: **if the agent pivots to the task mid-loop, step 4's `/proactive-loop` fallback may never run**, and the session ends with no recurring work driver. That is precisely the outcome step 4 exists to guarantee against:

> **Fallback — ensure `/proactive-loop` is scheduled.** … if `crons.json` is missing/empty/forgot-to-include-the-loop-entry the session goes idle with no recurring work driver.

And the window it opens is the same fresh-onboarding window #3367 targets, so the exposed user is the same new user whose 76-second delay we just fixed.

## What this changes

Adds a paragraph to step 1.5 saying capture ≠ handling: finish registration first, then process the queued task(s). It does not touch the gate logic, the `_ps_snapshot()` three-state branch, or the sentinel/`pgrep` warnings.

```
diff hunks:     1
lines removed:  0
lines added:    8
step 1.5:       3869 -> 4454 chars;  _watcher_trees intact: True;  pgrep -f warning intact: True
```

## Evidence

This is a prompt/skill-file change — the "test" is the documented sequence an agent follows at boot, so there is no unit test to run. What I did verify, before and after:

- **Before (main at `e7fcb481`):** step 1.5 is 3869 chars and contains none of `finish registration`, `steps 2`, `notification arrives while`, `not to process it`. The interleave is unaddressed.
- **After (this branch):** the paragraph is present, and a line-level diff confirms exactly one hunk, **zero** removed lines, eight added — nothing else in the 278-line file moved.
- **Cross-references still resolve:** #3367's own follow-up commit `9e80bc12` repointed step 5.4's "step 5" references to step 1.5; those are untouched here, and step 1.5 still holds both the `_watcher_trees` gate and the `pgrep -f` self-match warning that 5.4 points at.

## Provenance

Raised as a review item on #3367 (comment 5400603750, 20:00:03Z) after running `scripts/review-preflight.py 3367`. Criterion 5 asks what the worst-case disruption to users is and requires it be **named and mitigated** before merge; I had named it and left it unmitigated. #3367 merged at 20:09:20Z, so this lands the mitigation separately rather than holding a fix that closes a measured 76-second regression.

No duplicate: searched open issues/PRs for the interleave, and no open PR touches `skills/schedule-crons/`.

Single concern; no bundled changes.
