### PR TITLE
fix(tests): browser-persistent's harness timeout is a net, not a deadline

### DIFF
--- a/tests/browser-persistent.test.py
+++ b/tests/browser-persistent.test.py
@@ -11,6 +11,9 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "src" / "browser.mjs"
 HOOK = REPO / "tests" / "fixtures" / "browser-playwright-register.mjs"
+# Harness safety net, not an assertion: each deadline is asserted from in-Node
+# timestamps, so a slow runner must not read as a deadline leak.
+PROC_TIMEOUT = int(os.environ.get("SUTANDO_BROWSER_TEST_PROC_TIMEOUT", "30"))
 
 
 class PersistentBrowserTests(unittest.TestCase):
@@ -26,7 +29,7 @@ class PersistentBrowserTests(unittest.TestCase):
         )
         return env, log
 
-    def _wait_for_log(self, log, marker, timeout=5):
+    def _wait_for_log(self, log, marker, timeout=PROC_TIMEOUT):
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if log.exists() and marker in log.read_text(encoding="utf-8"):
@@ -74,7 +77,7 @@ class PersistentBrowserTests(unittest.TestCase):
             env, log = self._fake_browser_env(tmp, "error")
             result = subprocess.run(
                 ["node", str(SCRIPT), "https://example.test/", "text"],
-                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=PROC_TIMEOUT,
             )
             self.assertEqual(result.returncode, 1, result.stderr)
             self.assertIn("fixture navigation failed", result.stderr)
@@ -85,7 +88,7 @@ class PersistentBrowserTests(unittest.TestCase):
             env, log = self._fake_browser_env(tmp, "hang")
             result = subprocess.run(
                 ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=50"],
-                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=PROC_TIMEOUT,
             )
             self.assertEqual(result.returncode, 1, result.stderr)
             self.assertIn("timed out after 50ms", result.stderr)
@@ -96,7 +99,7 @@ class PersistentBrowserTests(unittest.TestCase):
             env, log = self._fake_browser_env(tmp, "late-launch")
             result = subprocess.run(
                 ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=120"],
-                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=PROC_TIMEOUT,
             )
             self.assertEqual(result.returncode, 1, result.stderr)
             self.assertIn("timed out after 120ms", result.stderr)
@@ -113,7 +116,7 @@ class PersistentBrowserTests(unittest.TestCase):
             env, log = self._fake_browser_env(tmp, "success")
             result = subprocess.run(
                 ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=60000"],
-                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=PROC_TIMEOUT,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertGreater(self._recorded_int(log, "page.goto.timeout"), 30000)
@@ -125,7 +128,7 @@ class PersistentBrowserTests(unittest.TestCase):
                 env, log = self._fake_browser_env(tmp, "success")
                 result = subprocess.run(
                     ["node", str(SCRIPT), "https://example.test/", *actions],
-                    cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+                    cwd=REPO, env=env, capture_output=True, text=True, timeout=PROC_TIMEOUT,
                 )
                 self.assertEqual(result.returncode, 1, result.stderr)
                 self.assertIn("exceeding the 45000ms command budget", result.stderr)
@@ -137,7 +140,7 @@ class PersistentBrowserTests(unittest.TestCase):
             env, log = self._fake_browser_env(tmp, "success")
             result = subprocess.run(
                 ["node", str(SCRIPT), "https://example.test/", "wait:60000", "--timeout=70000"],
-                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=PROC_TIMEOUT,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("Waited: 60000ms", result.stdout)
@@ -148,7 +151,7 @@ class PersistentBrowserTests(unittest.TestCase):
             env, log = self._fake_browser_env(tmp, "success")
             result = subprocess.run(
                 ["node", str(SCRIPT), "https://example.test/", "text", "--timeout=300001"],
-                cwd=REPO, env=env, capture_output=True, text=True, timeout=5,
+                cwd=REPO, env=env, capture_output=True, text=True, timeout=PROC_TIMEOUT,
             )
             self.assertEqual(result.returncode, 1, result.stderr)
             self.assertIn("cannot exceed 300000 milliseconds", result.stderr)


### PR DESCRIPTION
Closes #3365.

## The problem

`tests/browser-persistent.test.py` gave every `node` subprocess a fixed `timeout=5`. Under the Coverage Gate that budget is marginal, so the suite intermittently dies with `TimeoutExpired`, the gate stops at "suite must be green before coverage is meaningful", and the whole thing surfaces as a **failing `diff coverage >= 95% (python)`** on PRs whose diffs never touch browser code. #3365 has the full write-up, including a controlled same-head comparison where the uninstrumented job passes and the instrumented one fails.

## Why raising it is safe

The deadline assertions were **already** hardened against exactly this — the late-launch test compares timestamps recorded inside Node:

```python
# Compare timestamps inside Node so slow subprocess startup or
# coverage instrumentation cannot masquerade as a deadline leak.
launch_at = self._recorded_int(log, "context.launch.at")
close_at = self._recorded_int(log, "page.close.at")
self.assertLess(close_at - launch_at, 500)
```

Only the *harness net* still kept a wall-clock budget a loaded runner can exhaust before Node even starts. So this changes the safety net and not a single assertion: return codes, stderr text, cleanup ordering and the in-Node timing bound are all untouched. A real deadline leak still fails the test.

## Before / after

Both runs are on this branch's tree, with a `node` shim on PATH that sleeps 6s before exec'ing the real binary — a deterministic stand-in for the loaded runner, since the flake itself is load-dependent.

**Before** (`timeout=5`, as on `main`):

```
ERROR: test_command_deadline_includes_late_launch_cleanup
subprocess.TimeoutExpired: Command '['node', '.../src/browser.mjs',
  'https://example.test/', 'text', '--timeout=120']' timed out after 5 seconds
ERROR: test_error_closes_page_context_and_browser
subprocess.TimeoutExpired: ... timed out after 5 seconds
ERROR: test_overall_timeout_closes_page_context_and_browser
```

That is the same test and the same message the Coverage Gate reports in #3365.

**After** (`PROC_TIMEOUT`, same 6s shim):

```
Ran 11 tests in 80.981s

OK
```

The 81s is the shim's 6s × the subprocess spawns, not new overhead. **Unshimmed the suite is unchanged:**

```
Ran 11 tests in 2.946s      (before: 3.630s)

OK
```

## Notes

- `SUTANDO_BROWSER_TEST_PROC_TIMEOUT` overrides it, so a constrained environment can tune without another patch.
- `_wait_for_log`'s default shares the same class of net and moves with it.
- A genuine hang is still bounded — 30s instead of 5s, and only on a test that is already failing.
- `review-checks` passes (hardcoded-paths, root-artifacts, prose-cap).

I did not reproduce the flake on CI itself, since it is intermittent by nature; the shim reproduces the *mechanism* deterministically instead. If a maintainer would rather see it demonstrated by re-running a genuinely flaked job, #3365 already carries a same-head FAILED → SUCCESS rerun.
