### PR TITLE
fix(gateway): a lead-assigned task is still pending, so stop dropping its reply

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -260,6 +260,19 @@ def _valid_local_tid(tid: str) -> bool:
     m = _LOCAL_TID_RE.fullmatch(tid)
     return bool(m) and m.group(1) not in (".", "..")
 
+
+def _task_pending(tid: str) -> bool:
+    """Is this task still live in tasks/, under ANY of its names?
+
+    A pooled task is renamed twice -- unassigned -> `.assigned-<core>` (lead
+    picked a core) -> `.claimed-<core>` (core took it). Every caller asking
+    "is this still being worked?" must accept all three, so the question has
+    one owner: a state missed here reads as finished, which drops a reply
+    mid-flight or re-queues work another core already holds."""
+    return ((TASKS_DIR / f"{tid}.txt").exists()
+            or any(TASKS_DIR.glob(f"{tid}.assigned-*"))
+            or any(TASKS_DIR.glob(f"{tid}.claimed-*")))
+
 # Persist the in-flight set (tasks pulled from the gateway, awaiting result-POST)
 # so a client restart between pull and POST doesn't strand the result. Scoped to
 INFLIGHT_FILE = _STATE / f"remote-task-inflight{_INST_SUFFIX}.json"
@@ -2228,7 +2241,7 @@ def _write_task(task: dict) -> str | None:
     task = {**task, "id": tid}
     dest = TASKS_DIR / f"{tid}.txt"
     # Idempotent: don't re-write a task already queued, claimed, or archived.
-    if dest.exists() or any(TASKS_DIR.glob(f"{tid}.claimed-*")):
+    if _task_pending(tid):
         return tid
     # Relay redelivery of already-handled work: on reconnect the gateway replays
     # its unacked pool, including tasks this node long since processed (the
@@ -3123,8 +3136,7 @@ def _reconcile_abandoned(inflight: set[str], suspects: set[str]) -> set[str]:
     instead of being raced. Returns the new suspects set for the next pass."""
     gone = {tid for tid in inflight
             if _valid_local_tid(tid)
-            and not (TASKS_DIR / f"{tid}.txt").exists()
-            and not any(TASKS_DIR.glob(f"{tid}.claimed-*"))
+            and not _task_pending(tid)
             and not (RESULTS_DIR / f"{tid}.txt").exists()
             and not _task_archived_recently(tid)}
     confirmed = gone & suspects

--- a/tests/gateway-orphan-result-reconciler.test.py
+++ b/tests/gateway-orphan-result-reconciler.test.py
@@ -381,6 +381,38 @@ class AbandonedHardening(_Base):
         finally:
             gw._save_inflight = self._saved_save
 
+    def _pending_probe(self, name):
+        """Same two passes, with `name` pending in tasks/."""
+        (gw.TASKS_DIR / name).write_text("id: x\n")
+        self._saved_save = gw._save_inflight
+        gw._save_inflight = lambda s: None
+        try:
+            return self._drop_probe()
+        finally:
+            gw._save_inflight = self._saved_save
+
+    def test_every_pooled_pending_state_keeps_the_id(self):
+        # The pool renames a task through three names. A state the reconciler
+        # cannot see reads as abandoned, and the reply is dropped mid-flight.
+        for name in (f"{TID}.txt",
+                     f"{TID}.assigned-core-2.txt",
+                     f"{TID}.claimed-core-2.txt"):
+            with self.subTest(pending=name):
+                self.assertTrue(
+                    self._pending_probe(name),
+                    f"{name} is live work, not an abandoned id")
+            (gw.TASKS_DIR / name).unlink()
+
+    def test_nothing_pending_still_drops(self):
+        # The control: without it the test above passes on a reconciler that
+        # never drops anything at all.
+        self._saved_save = gw._save_inflight
+        gw._save_inflight = lambda s: None
+        try:
+            self.assertFalse(self._drop_probe())
+        finally:
+            gw._save_inflight = self._saved_save
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What changed, and why?

The bridge asks "is this task still being worked?" in two places. Both knew only **two** of the pool's **three** filenames.

A pooled task is renamed twice: `task-<id>.txt` → `task-<id>.assigned-<core>.txt` (lead picked a core) → `task-<id>.claimed-<core>.txt` (core took it). The unassigned and claimed names were checked. `.assigned-*` was not — anywhere:

```
$ grep -c "claimed-"  remote_gateway_bridge.py   → 3
$ grep -c "assigned-" remote_gateway_bridge.py   → 0
```

### Consequence 1 — replies dropped mid-flight (`_reconcile_abandoned`)

During the window after the lead assigns and before a follower claims, the task file exists under a name nothing looks for. Two consecutive passes see nothing, the id is discarded as *"completed elsewhere"*, and the reply that lands minutes later has nothing waiting for it.

From a live 4-core pool today:

```
01:33:59  queued  task-cbb7e5e0a599fb4f31
01:34:57  dropped abandoned in-flight id task-cbb7e5e0a599fb4f31 (no task/result file — completed elsewhere)
01:36:23  queued  task-f158847f70a92339dd
01:36:58  dropped abandoned in-flight id task-f158847f70a92339dd (no task/result file — completed elsewhere)
```

Both ids were alive the whole time, as `.assigned-core-1.txt`. Totals in that log:

```
dropped abandoned:                   133
orphan sweep: recovered + delivered:  51
```

The sweep is a real safety net and catches some. It does not catch most. Four owner-facing replies were sitting undelivered in `results/` when this was written.

**The bias is the bad part.** A short acknowledgement gets claimed and finished inside the ~60s window and survives. A substantial answer sits in the assigned state past the deadline and is dropped. The failure selects against the most considered replies, and it is silent — the sender sees nothing, and the log line says the task was *completed*.

### Consequence 2 — duplicate work (`write_task` dedup)

Same blind spot, opposite direction:

```python
# Idempotent: don't re-write a task already queued, claimed, or archived.
if dest.exists() or any(TASKS_DIR.glob(f"{tid}.claimed-*")):
```

The comment says "queued, claimed, or archived" but assigned isn't tested, so a gateway replay can re-queue `task-<id>.txt` while `.assigned-<core>.txt` already exists — two cores holding the same work, with whatever side effects that task performs.

### The fix

One predicate, `_task_pending`, owns the question; both callers bind it. The three states are a property of the **pool**, not of either caller, so a third caller must not have to rediscover them — which is exactly how the second site drifted from the first.

## Tests

Added to `tests/gateway-orphan-result-reconciler.test.py`:

- **all three pending names keep the id** (`.txt`, `.assigned-core-2.txt`, `.claimed-core-2.txt`), as a `subTest` per state
- **a control**: with nothing pending the id still drops — without this, the test above would pass on a reconciler that never drops anything at all

**Mutation control**: deleting the `assigned-*` line from `_task_pending` reds exactly the three-state test; restoring it greens. The assertion is load-bearing, not decorative.

**Suites picked by the file touched, not by the test written** — all 42 test files referencing `remote_gateway_bridge` (41 Python + 1 TypeScript):

```
TOTAL=42 PASS=42 FAIL=0
```

`scripts/review-checks.sh --diff` → PASS.

## Notes for the reviewer

- **Base is `main`**, deliberately. The defect is present on `main` today — verified with `git show origin/main:…` — and it is independent of the lead-follower pool stack, which is currently blocked behind a `CHANGES_REQUESTED` root. This should not wait on that.
- The `.assigned-*` name is produced by the pool's lead. On a single-core install the state never occurs, so the added glob simply never matches — no behaviour change there.
- I did not touch the orphan sweep. It stays as the second line of defence; this change means it has far less to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
