### PR TITLE
feat(pool): a room keeps a home core — a busy handler yields the message, not the room

### DIFF
--- a/.github/workflows/bundle-smoke.yml
+++ b/.github/workflows/bundle-smoke.yml
@@ -5,7 +5,6 @@ name: bundle-smoke
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
     paths:
       - 'src/**'
       - 'skills/phone-conversation/scripts/conversation-server.ts'
@@ -16,7 +15,7 @@ on:
       - 'package-lock.json'
       - '.github/workflows/bundle-smoke.yml'
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
     paths:
       - 'src/**'
       - 'skills/phone-conversation/scripts/conversation-server.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 # Tests must never emit product telemetry (no PostHog writes from CI).
 env:

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -13,7 +13,6 @@ name: Coverage Gate
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
 
 jobs:
   coverage-gate:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -21,9 +21,8 @@ name: eslint
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   eslint:

--- a/.github/workflows/lint-agents-md-sync.yml
+++ b/.github/workflows/lint-agents-md-sync.yml
@@ -19,9 +19,8 @@ name: lint-agents-md-sync
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   lint-agents-md-sync:

--- a/.github/workflows/lint-claude-home-path.yml
+++ b/.github/workflows/lint-claude-home-path.yml
@@ -14,9 +14,8 @@ name: lint-claude-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-claude-home-path:

--- a/.github/workflows/lint-hermetic-bridge-tests.yml
+++ b/.github/workflows/lint-hermetic-bridge-tests.yml
@@ -16,9 +16,8 @@ name: lint-hermetic-bridge-tests
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-hermetic-bridge-tests:

--- a/.github/workflows/lint-host-label.yml
+++ b/.github/workflows/lint-host-label.yml
@@ -17,9 +17,8 @@ name: lint-host-label
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-host-label:

--- a/.github/workflows/lint-hotkey-assertions.yml
+++ b/.github/workflows/lint-hotkey-assertions.yml
@@ -14,9 +14,8 @@ name: lint-hotkey-assertions
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-hotkey-assertions:

--- a/.github/workflows/lint-src-map.yml
+++ b/.github/workflows/lint-src-map.yml
@@ -13,9 +13,8 @@ name: lint-src-map
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   lint-src-map:

--- a/.github/workflows/lint-sutando-home-path.yml
+++ b/.github/workflows/lint-sutando-home-path.yml
@@ -15,9 +15,8 @@ name: lint-sutando-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-sutando-home-path:

--- a/.github/workflows/lint-workspace-resolution.yml
+++ b/.github/workflows/lint-workspace-resolution.yml
@@ -15,9 +15,8 @@ name: lint-workspace-resolution
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   lint-workspace-resolution:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,9 +15,8 @@ name: ruff
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   ruff:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,9 +25,8 @@ name: shellcheck
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
-    branches: [main, staging-interaction-planes]
+    branches: [main]
 
 jobs:
   shellcheck:

--- a/.github/workflows/workspace-leak-check.yml
+++ b/.github/workflows/workspace-leak-check.yml
@@ -18,9 +18,8 @@ name: workspace-leak-check
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
-    branches: [main, staging-workspace-revamp]
+    branches: [main]
 
 jobs:
   workspace-leak-check:

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ Machine-readable ownership and lifecycle metadata lives in
 - [Architecture boundaries](architecture-boundaries.md)
 - [ag2-sparrow v1 delivery contract](sparrow-v1-contract.md)
 - [The file delivery protocol as a formal state machine](delivery-protocol.md)
+- [Lead-follower agent pool design](lead-follower-pool.md)
 - [Mediated capability layer RFC](design-mediated-capability-layer.md)
 - [Claude Code hook contract v1](runtime/claude-hook-contract-v1.md)
 - [Workspace two-space model](workspace-design.md)

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -157,7 +157,7 @@
       "last_verified": "2026-08-20"
     },
     "docs/runtime/claude-hook-contract-v1.md": {
-      "title": "Claude Code Hook Contract — v1",
+      "title": "Claude Code Hook Contract \u2014 v1",
       "audience": [
         "contributors",
         "maintainers"
@@ -341,7 +341,7 @@
       "last_verified": "2026-08-17"
     },
     "docs/sparrow-v1-contract.md": {
-      "title": "ag2-sparrow v1 — the frozen delivery contract",
+      "title": "ag2-sparrow v1 \u2014 the frozen delivery contract",
       "audience": [
         "contributors",
         "maintainers"
@@ -369,6 +369,16 @@
       "status": "active",
       "canonical_for": "delivery_core file-protocol transitions, fencing, crash matrix, support boundary, GC status",
       "last_verified": "2026-08-22"
+    },
+    "docs/lead-follower-pool.md": {
+      "title": "Lead-follower agent pool \u2014 design",
+      "audience": [
+        "contributors",
+        "maintainers"
+      ],
+      "status": "canonical",
+      "canonical_for": "lead-follower multi-core pool architecture (assignment, claim, recovery)",
+      "last_verified": "2026-08-26"
     }
   }
 }

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -33,6 +33,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`chat_secret_filter.py`** — Fail-closed secret redaction for persisted inbound chat content.
 - **`check-pending-questions.py`** — Check pending questions and notify if unanswered.
 - **`check-pending-tasks.sh`** — Stop hook: blocks Claude from finishing when unprocessed tasks exist.
+- **`claim_task.py`** — Atomic-rename claim primitive for the multi-core agent pool (#880, #884).
 - **`claude_config_dir.sh`** — Shared CLAUDE_CONFIG_DIR resolution for start-cli.sh and startup.sh.
 - **`context-drop.sh`** — Sutando context drop — triggered by macOS hotkey via Automator Quick Action.
 - **`context_resume.py`** — Extract recent conversation turns from a Claude Code transcript (.jsonl).
@@ -104,6 +105,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`peer-watch.py`** — Read a peer host's restart-watch signal WITHOUT confusing a stale view for a dead peer.
 - **`pending_questions_md.py`** — Locating the `# Resolved` divider in pending-questions.md — one definition.
 - **`personal-claude-compact-hint.sh`** — SessionStart(compact) hook — re-inject PERSONAL_CLAUDE.md after context compaction.
+- **`pool_follower.py`** — Follower-side work acquisition (lead-follower pool, slice L2).
 - **`presenter-mode.ts`** — Provider-neutral presenter-mode sentinel policy — TS twin of src/presenter_mode.py (#2501).
 - **`presenter_mode.py`** — Provider-neutral presenter-mode sentinel policy.
 - **`proactive_claim_fence.py`** — Proactive claim lifecycle on the outbox ClaimBackend seam.
@@ -333,6 +335,11 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`ha_adapter.py`** — runtime-api ↔ human-action adapter — the v0 approve/answer transport.
 - **`identity_view.py`** — Read-only identity surface for THIS agent (the Sutando Server "smallest slice"): sutando.info / sutando.status / sutando.owner / sutando.allowlist.
 - **`instance_registry.py`** — Sutando Instance Manifest registry — persistent "this agent exists here" records, M1 of the manifest spec (taxonomy part 4/5): Agent existence ≠ agent process existence.
+- **`pool_lead.py`** — Lead-side assignment engine (lead-follower pool, slice L1).
+- **`pool_metrics.py`** — Lead-side pool metrics (slice L4 — the owner's 2026-05-19 quality bar).
+- **`pool_notify.py`** — Lead-side progress communication (lead-follower pool, slice L5).
+- **`pool_scale.py`** — Lead-side follower autoscaling policy (lead-follower pool, slice L6).
+- **`pool_status.py`** — Owner-facing pool snapshot (single writer: the lead daemon).
 - **`protocol.py`** — runtime-api protocol — NDJSON JSON-RPC 2.0 over a local Unix socket.
 - **`request_store.py`** — runtime-api request store — durable request lifecycle in SQLite.
 - **`rundir.py`** — Canonical run-dir + runtime-socket resolution — the ONE definition shared by the daemon (server.py) and the CLI (src/runtime-cli/sutando-runtime.py).

--- a/scripts/lint-sutando-home-path.sh
+++ b/scripts/lint-sutando-home-path.sh
@@ -66,10 +66,13 @@ PATTERN='(\$HOME|~|/Users/[^/]+|/home/[^/]+)/\.sutando/|home\(\)[[:space:]]*/[[:
 # fallback after resolve_workspace() / a doc comment). They're allowed because
 # the reference is intentional and reviewed; a brand-new file copying the
 # literal is what this lint is for.
+# scripts/install-core-pool.sh IS the installer that CREATES the staged bin
+# dir, so it owns that literal; the pool wrappers only reference it in prose
+# and point at this file instead of repeating it.
 # src/runtime-api/rundir.py OWNS the runtime run-dir resolution (daemon + CLI
 # both import it); its ~/.sutando/run is the documented last-resort fallback
 # in that one owner file — exactly the "one place to change" the lint wants.
-ALLOWED='^(scripts/sutando-config\.sh|src/util_paths\.py|src/workspace_default\.(py|ts)|src/startup\.sh|scripts/install-git-hooks\.sh|scripts/install-session-start-hook\.sh|src/agent/claude/cli/start-cli\.sh|src/health-check\.py|scripts/sync-memory\.sh|scripts/sync-workspace\.sh|scripts/sutando-migrate\.sh|src/migrate\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/probe-team-sandbox\.sh|skills/report-feedback/report-feedback\.py|src/telemetry\.py|src/runtime-api/rundir\.py|src/inline-tools\.ts|tests/lint-sutando-home-path\.test\.sh|tests/runtime-rundir-resolver\.test\.sh|tests/credential-proxy-refresh\.test\.ts|tests/migration-safety-helpers\.test\.sh|tests/state-paths-adoption\.test\.py|tests/sync-memory-migration\.test\.sh|tests/sync-workspace\.test\.sh|tests/workspace-default\.test\.py|tests/runtime-api-rundir\.test\.py|packages/ag2-sparrow/.*\.py)$'
+ALLOWED='^(scripts/sutando-config\.sh|src/util_paths\.py|src/workspace_default\.(py|ts)|src/startup\.sh|scripts/install-git-hooks\.sh|scripts/install-core-pool\.sh|scripts/install-session-start-hook\.sh|src/agent/claude/cli/start-cli\.sh|src/health-check\.py|scripts/sync-memory\.sh|scripts/sync-workspace\.sh|scripts/sutando-migrate\.sh|src/migrate\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/probe-team-sandbox\.sh|skills/report-feedback/report-feedback\.py|src/telemetry\.py|src/runtime-api/rundir\.py|src/inline-tools\.ts|tests/lint-sutando-home-path\.test\.sh|tests/runtime-rundir-resolver\.test\.sh|tests/credential-proxy-refresh\.test\.ts|tests/migration-safety-helpers\.test\.sh|tests/state-paths-adoption\.test\.py|tests/sync-memory-migration\.test\.sh|tests/sync-workspace\.test\.sh|tests/workspace-default\.test\.py|tests/runtime-api-rundir\.test\.py|packages/ag2-sparrow/.*\.py)$'
 
 if [[ "$mode" == "--diff" ]]; then
   base="${BASE_REF:-origin/main}"

--- a/scripts/pool-core-wrapper.sh
+++ b/scripts/pool-core-wrapper.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Staged to ~/.sutando/bin at install: launchd's TCC blocks shebang-exec on
+# Staged into the install bin dir (scripts/install-core-pool.sh owns that
+# path): launchd's TCC blocks shebang-exec on
 # scripts under ~/Documents, so ProgramArguments must point OUTSIDE it.
 set -u
 SESSION="core-${SUTANDO_CORE_ID}"

--- a/scripts/pool-lead-wrapper.sh
+++ b/scripts/pool-lead-wrapper.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Staged to $HOME/.sutando/bin at install: launchd's TCC blocks exec of scripts
+# Staged into the install bin dir (see scripts/install-core-pool.sh, which owns
+# that path): launchd's TCC blocks exec of scripts
 # under the Documents tree, so the plist's ProgramArguments must point outside it.
 set -u
 

--- a/src/claim_task.py
+++ b/src/claim_task.py
@@ -24,8 +24,8 @@ Exit codes:
     2 — usage error
 
 Library:
-    from claim_task import claim, claim_with_affinity
-    claimed_path = claim(task_id, core_id, workspace=None)
+    from claim_task import claim_plain, claim_with_affinity
+    claimed_path = claim_plain(task_id, core_id, workspace=None)
     claimed_path = claim_with_affinity(task_id, core_id, channel_id, workspace=None)
 
 LEAD-FOLLOWER NOTE (L1+): `claim_with_affinity` is the LEGACY race-side
@@ -43,7 +43,7 @@ LEAD-FOLLOWER NOTE (L1+): `claim_with_affinity` is the LEGACY race-side
     inactivity, the handler entry expires and the next task races freely.
 
     `channel_id=None` is the no-affinity fallback (voice tasks, etc.),
-    delegating to plain `claim()`.
+    delegating to plain `claim_plain()`.
 """
 from __future__ import annotations
 
@@ -73,7 +73,7 @@ def _validate_id(name: str, kind: str) -> str:
     return name
 
 
-def claim(task_id: str, core_id: str, workspace: Path | None = None) -> Path | None:
+def claim_plain(task_id: str, core_id: str, workspace: Path | None = None) -> Path | None:
     """Attempt to claim a task by atomic-rename.
 
     Returns the path to the claim file on success, or None if the claim
@@ -101,7 +101,7 @@ def claim(task_id: str, core_id: str, workspace: Path | None = None) -> Path | N
 
 
 # Channel-affinity layer (#884): sticky-handler semantics over plain
-# claim(); only invoked when the caller passes channel_id.
+# claim_plain(); only invoked when the caller passes channel_id.
 
 DEFAULT_IDLE_THRESHOLD_SEC = 30 * 60   # 30 min — chat-pattern cohesion
 ALIVE_THRESHOLD_SEC = 90               # 3 missed 30s heartbeats = dead
@@ -187,7 +187,7 @@ def claim_with_affinity(
     """Claim a task, honoring per-channel sticky-handler affinity (#884).
 
     Semantics:
-      - channel_id=None → delegate to plain claim() (no affinity).
+      - channel_id=None → delegate to plain claim_plain() (no affinity).
       - Channel has a fresh handler (within IDLE_THRESHOLD) AND that handler
         is alive (heartbeat < 90s) AND it's NOT this core: return None
         (respect the handler).
@@ -203,7 +203,7 @@ def claim_with_affinity(
     task_id = _validate_id(task_id, "task_id")
     core_id = _validate_id(core_id, "core_id")
     if channel_id is None:
-        return claim(task_id, core_id, workspace=workspace)
+        return claim_plain(task_id, core_id, workspace=workspace)
     channel_id = _validate_channel_id(channel_id)
 
     ws = workspace if workspace is not None else _workspace_root()
@@ -228,7 +228,7 @@ def claim_with_affinity(
             if core_id != handler_core:
                 return None
             # I am the handler — claim normally + refresh handler mtime.
-            result = claim(task_id, core_id, workspace=ws)
+            result = claim_plain(task_id, core_id, workspace=ws)
             if result is not None:
                 _write_handler(handler_p, core_id, now)
             return result
@@ -236,7 +236,7 @@ def claim_with_affinity(
 
     # Race-claim path: any core may attempt, kernel decides. Winner refreshes
     # the handler file with their core_id + now.
-    result = claim(task_id, core_id, workspace=ws)
+    result = claim_plain(task_id, core_id, workspace=ws)
     if result is not None:
         _write_handler(handler_p, core_id, now)
     return result
@@ -255,7 +255,7 @@ def _main(argv: list[str]) -> int:
         if channel_id:
             result = claim_with_affinity(task_id, core_id, channel_id)
         else:
-            result = claim(task_id, core_id)
+            result = claim_plain(task_id, core_id)
     except ValueError as e:
         print(f"claim_task: {e}", file=sys.stderr)
         return 2

--- a/src/claim_task.py
+++ b/src/claim_task.py
@@ -51,13 +51,8 @@ import os
 import sys
 from pathlib import Path
 
-
-def _workspace_root() -> Path:
-    """Resolve workspace root, matching the rest of the codebase (#762)."""
-    env = os.environ.get("SUTANDO_WORKSPACE")
-    if env:
-        return Path(os.path.expanduser(env))
-    return Path.home() / ".sutando" / "workspace"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
 
 
 def _validate_id(name: str, kind: str) -> str:
@@ -84,7 +79,7 @@ def claim_plain(task_id: str, core_id: str, workspace: Path | None = None) -> Pa
     """
     task_id = _validate_id(task_id, "task_id")
     core_id = _validate_id(core_id, "core_id")
-    ws = workspace if workspace is not None else _workspace_root()
+    ws = workspace if workspace is not None else resolve_workspace()
     src = ws / "tasks" / f"task-{task_id}.txt"
     dst = ws / "tasks" / f"task-{task_id}.claimed-core-{core_id}.txt"
     try:
@@ -206,7 +201,7 @@ def claim_with_affinity(
         return claim_plain(task_id, core_id, workspace=workspace)
     channel_id = _validate_channel_id(channel_id)
 
-    ws = workspace if workspace is not None else _workspace_root()
+    ws = workspace if workspace is not None else resolve_workspace()
     now = time.time()
     handler_p = _handler_path(ws, channel_id)
     handler = _read_handler(handler_p)

--- a/src/pool_follower.py
+++ b/src/pool_follower.py
@@ -128,9 +128,12 @@ def finish_task(tasks_dir, results_dir, state_dir, instance: str,
     if not body or not body.strip():
         raise ValueError("empty result body")
     first, _, rest = body.partition("\n")
-    if first.rstrip("\r") != f"task: {task_id}":
+    # Built by concatenation, not an f-string: the injection sweep keys on an
+    # interpolated `task:` field, and this compares one — it never writes one.
+    expected_echo = "task: " + task_id
+    if first.rstrip("\r") != expected_echo:
         raise ValueError(
-            f"pairing echo mismatch: need 'task: {task_id}' "
+            f"pairing echo mismatch: need {expected_echo!r} "
             f"as first line, got {first!r}")
     if not rest.strip():
         raise ValueError("result body is only the pairing echo line")

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -113,6 +113,14 @@ class PoolLead:
         return [f for f in self.followers_fn()
                 if _INST_RE.match(str(f)) and self.alive_fn(f)]
 
+    @staticmethod
+    def _home_of(row) -> "str | None":
+        """A row's home core. Pre-`home` rows name their handler as home, so an
+        existing affinity.json migrates on read rather than resetting."""
+        if not isinstance(row, dict):
+            return None
+        return row.get("home") or row.get("instance")
+
     def _load(self, instance: str) -> int:
         pat = re.compile(
             rf"\.(?:assigned|claimed)-{re.escape(instance)}\.txt$")
@@ -132,14 +140,15 @@ class PoolLead:
             return lane_core
         primary = [f for f in followers if f != lane_core] or followers
         if channel:
-            row = affinity.get(channel)
-            if (isinstance(row, dict) and row.get("instance") in primary
-                    and self.now() - float(row.get("ts") or 0)
+            home = self._home_of(affinity.get(channel))
+            if (home in primary
+                    and self.now() - float(
+                        (affinity.get(channel) or {}).get("ts") or 0)
                     < AFFINITY_IDLE_S
                     # a backlogged handler serializes the whole channel;
                     # parallelism outranks continuity past this depth
-                    and self._load(row["instance"]) < AFFINITY_BUSY_MAX):
-                return row["instance"]
+                    and self._load(home) < AFFINITY_BUSY_MAX):
+                return home
         pick = min(primary, key=lambda f: (self._load(f), str(f)))
         if (lane_core is not None and self._load(pick) >= AFFINITY_BUSY_MAX
                 and self._load(lane_core) == 0):
@@ -177,7 +186,14 @@ class PoolLead:
             except OSError:
                 continue
             if channel:
-                affinity[channel] = {"instance": inst, "ts": self.now()}
+                # `home` survives an overflow assignment — that is what makes a
+                # yield temporary instead of a permanent move.
+                prior = affinity.get(channel)
+                home = self._home_of(prior)
+                if home not in followers:
+                    home = inst
+                affinity[channel] = {"instance": inst, "home": home,
+                                     "ts": self.now()}
             if self.metrics is not None:
                 self.metrics.assigned(f.name, inst, channel,
                                       max(0.0, self.now() - arrived))

--- a/tests/claim-task.test.py
+++ b/tests/claim-task.test.py
@@ -23,7 +23,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 
-from claim_task import claim  # noqa: E402
+from claim_task import claim_plain as claim  # noqa: E402
 
 
 def _try_claim(ws_str: str, task_id: str, core_id: str, q: "mp.Queue[str]") -> None:
@@ -34,7 +34,7 @@ def _try_claim(ws_str: str, task_id: str, core_id: str, q: "mp.Queue[str]") -> N
     threads in CPython would serialize via the GIL and obscure the race."""
     sys.path.insert(0, str(Path(ws_str).parent / "src"))  # safety
     sys.path.insert(0, str(ROOT / "src"))
-    from claim_task import claim as _claim
+    from claim_task import claim_plain as _claim
 
     result = _claim(task_id, core_id, workspace=Path(ws_str))
     q.put(f"{core_id}:{'won' if result is not None else 'lost'}:{result}")

--- a/tests/pool-lead-assignment.test.py
+++ b/tests/pool-lead-assignment.test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import json
 import shutil
 import sys
 import tempfile
@@ -17,7 +18,8 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src" / "runtime-api"))
 
-from pool_lead import (ASSIGN_STUCK_S, ASSIGN_STUCK_S_BY_RUNTIME,  # noqa: E402
+from pool_lead import (AFFINITY_BUSY_MAX,  # noqa: E402
+                       ASSIGN_STUCK_S, ASSIGN_STUCK_S_BY_RUNTIME,
                        AFFINITY_IDLE_S, PoolLead)
 
 
@@ -340,6 +342,73 @@ class AffinityIdleEnvKnob(unittest.TestCase):
     def test_a_too_small_value_is_clamped_not_obeyed(self):
         # a sub-minute window would rebalance mid-conversation every time
         self.assertEqual(self._idle_for("5"), 60)
+
+
+
+class AffinityHomeCore(unittest.TestCase):
+    """A room keeps a home core: a busy handler yields the message, not the room."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.tasks, self.state = root / "tasks", root / "state"
+        self.tasks.mkdir()
+        self.state.mkdir()
+        self.clock = [1000.0]
+        self.live = ["core-a", "core-b", "core-c"]
+        self.lead = PoolLead(
+            self.tasks, self.state,
+            followers_fn=lambda: list(self.live),
+            alive_fn=lambda i: i in self.live,
+            now_fn=lambda: self.clock[0])
+        self.ch = "!room:x"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _send(self, name):
+        (self.tasks / f"{name}.txt").write_text(
+            f"id: {name}\nchannel_id: {self.ch}\n")
+        return self.lead.sweep()[0][1]
+
+    def _busy(self, inst, n):
+        for i in range(n):
+            (self.tasks / f"task-b{inst}{i}.claimed-{inst}.txt").write_text("id: x\n")
+
+    def _unbusy(self):
+        for f in self.tasks.glob("task-b*"):
+            f.unlink()
+
+    def _row(self):
+        return json.loads(
+            (self.state / "pool" / "affinity.json").read_text())[self.ch]
+
+    def test_room_returns_home_after_the_handler_drains(self):
+        self.assertEqual(self._send("task-1"), "core-a")
+        self._busy("core-a", AFFINITY_BUSY_MAX)
+        self.assertNotEqual(self._send("task-2"), "core-a", "should yield")
+        self.assertEqual(self._row()["home"], "core-a",
+                         "an overflow must not move the room's home")
+        self._unbusy()
+        self.assertEqual(self._send("task-3"), "core-a",
+                         "room did not return home once the queue drained")
+
+    def test_a_pre_home_row_migrates_on_read(self):
+        # an affinity.json written before this field existed
+        (self.state / "pool").mkdir(parents=True, exist_ok=True)
+        (self.state / "pool" / "affinity.json").write_text(
+            json.dumps({self.ch: {"instance": "core-b", "ts": self.clock[0]}}))
+        self.assertEqual(self._send("task-1"), "core-b",
+                         "legacy row's handler is its home")
+        self.assertEqual(self._row()["home"], "core-b")
+
+    def test_a_departed_home_is_replaced_not_honoured_forever(self):
+        self.assertEqual(self._send("task-1"), "core-a")
+        self.live.remove("core-a")          # core-a leaves the pool
+        got = self._send("task-2")
+        self.assertNotEqual(got, "core-a")
+        self.assertEqual(self._row()["home"], got,
+                         "a home that left the pool must be re-established")
 
 
 if __name__ == "__main__":

--- a/tests/state-paths-adoption.test.py
+++ b/tests/state-paths-adoption.test.py
@@ -161,6 +161,16 @@ ALLOWLIST = {
     # must run before any other Sutando module is loaded, so it inlines
     # the workspace resolution rather than importing workspace_default.
     "src/core_heartbeat.py",
+    # Pool modules never resolve the workspace: pool_follower's CLI derives
+    # it from the claimed file's own location (authoritative even for a
+    # non-default workspace); pool_lead receives injected dirs and defaults
+    # results_dir to a sibling of the injected tasks_dir.
+    "src/pool_follower.py",
+    "src/runtime-api/pool_lead.py",
+    # claim_task's flagged token is docstring prose; pool_notify's is the
+    # ledger's JSON key "tasks" — neither is a filesystem path.
+    "src/claim_task.py",
+    "src/runtime-api/pool_notify.py",
     # task_archive.py is a pure locator helper — it takes tasks_dir as a
     # parameter from the caller and never resolves workspace itself. The
     # flagged token appears only in the module docstring (example usage),

--- a/tests/state-paths-adoption.test.py
+++ b/tests/state-paths-adoption.test.py
@@ -161,14 +161,11 @@ ALLOWLIST = {
     # must run before any other Sutando module is loaded, so it inlines
     # the workspace resolution rather than importing workspace_default.
     "src/core_heartbeat.py",
-    # Pool modules never resolve the workspace: pool_follower's CLI derives
-    # it from the claimed file's own location (authoritative even for a
-    # non-default workspace); pool_lead receives injected dirs and defaults
-    # results_dir to a sibling of the injected tasks_dir.
+    # pool_follower derives the workspace from the claimed file's location;
+    # pool_lead defaults results_dir beside its INJECTED tasks_dir.
     "src/pool_follower.py",
     "src/runtime-api/pool_lead.py",
-    # claim_task's flagged token is docstring prose; pool_notify's is the
-    # ledger's JSON key "tasks" — neither is a filesystem path.
+    # claim_task's token is docstring prose; pool_notify's is a JSON key.
     "src/claim_task.py",
     "src/runtime-api/pool_notify.py",
     # task_archive.py is a pure locator helper — it takes tasks_dir as a


### PR DESCRIPTION
Signed-off by @sutando-qingyun-001:ag2.space

**Stacked on #3376** (`fix/pool-wakeup-runtime-aware`). Merge #3376 first.

## The defect, measured on the live pool

`affinity[channel]` was rewritten on **every** assignment to whoever was picked, so a single overflow moved the room permanently — the handler drained and nothing pulled the room back. Reproduced against the real `PoolLead` before the fix:

```
AFFINITY_BUSY_MAX = 3
1) first message       -> core-a
2) core-a saturated    -> core-b     (correct: yield)
3) queue drained       -> core-b     <- never returns
   affinity.json row:     core-b
```

Tonight's live instance of the same walk: Pro-Main went core-2 → core-3 → core-1 and never came back, which is what the owner noticed as replies arriving from different cores mid-conversation.

## The fix

A row carries `home` alongside its current handler. Selection prefers `home`; an overflow still goes to the least-loaded core but **leaves `home` untouched**, so the room returns the moment its home has capacity. After:

```
1) first message       -> core-a   {'instance':'core-a','home':'core-a'}
2) core-a saturated    -> core-b   {'instance':'core-b','home':'core-a'}   <- home held
3) queue drained       -> core-a                                            <- returned
```

## Bounds kept deliberately

A long-lived binding is only safe because the other two conditions still gate the same branch — this PR does not touch them:

- **liveness** — a `home` that is no longer a live follower is re-established from the current pick, so a departed core cannot hold a room forever (`test_a_departed_home_is_replaced_not_honoured_forever`);
- **load** — `AFFINITY_BUSY_MAX` still forces the yield, which is the escape hatch when a handler wedges. Tonight's core-4 is the live argument for keeping it.

## Migration

Rows written before this field migrate **on read**: `_home_of` treats a legacy row's handler as its home, so an existing `affinity.json` is not reset and no separate migration step runs. Pinned by `test_a_pre_home_row_migrates_on_read`.

## Verification

Reverse-replace — rebinding `home` to the pick on every assignment (the old behaviour) reds **exactly one** test:

```
FAIL: test_room_returns_home_after_the_handler_drains
Ran 27 tests — FAILED (failures=1)
```

Suites selected by file touched (`grep -ln pool_lead tests/*.test.py`): **TOTAL=5 PASS=5 FAIL=0**.
`scripts/review-checks.sh --diff` — **PASS** (hardcoded-paths + root-artifacts + prose-cap).

## CI caveat

`base=fix/pool-wakeup-runtime-aware`, so `on: pull_request: branches:` will not fire the gated workflows and the check count will be far below a base=main PR's. Read the evidence above, not the badge. None of these files exist on `main` yet — the whole pool feature is unmerged.