### PR TITLE
fix(startup): serve a waiting owner task before cron registration

### DIFF
--- a/skills/startup/SKILL.md
+++ b/skills/startup/SKILL.md
@@ -42,6 +42,12 @@ If the skill is not installed, skip silently. `/startup` works without it — ev
 
 Note: this step runs BEFORE step 2 so that the watcher (started by step 2's downstream) doesn't pick up an orphan task before recovery has classified it.
 
+### Step 1.5 — Serve a waiting owner task first
+
+After orphan recovery has classified the queue, check `<workspace>/tasks/` for a pending owner task (`access_tier: owner` or no tier field, and no matching file in `results/`). If one exists, process it and write its result NOW — before cron registration. A waiting owner beats bootstrap ceremony; crons registering 30 seconds later costs nothing. This is what makes a first message sent during onboarding answer in seconds instead of queuing behind the full bootstrap.
+
+Skip silently when the queue is empty (the common case). Runs after step 1, never before it: recovery must classify crash leftovers first so a stale half-executed task is not answered as if it just arrived.
+
 ### Step 2 — Register schedules + start watcher
 
 Invoke `/schedule-crons`. This handles:
@@ -69,6 +75,8 @@ session start
 /startup
     │
     ├─► step 1:  /task-orphan-check (optional) ──► classifies + archives orphan tasks
+    │
+    ├─► step 1.5: serve a pending owner task, if any ──► result written before bootstrap continues
     │
     ├─► step 2:  /schedule-crons ──┬─► step 1.5 (start watch-tasks-stream.sh via Monitor — FIRST, before registration)
     │                               ├─► step 2-3 (register crons.json entries)


### PR DESCRIPTION
## What changed and why

A task arriving during `/startup` waits for the entire bootstrap — orphan check, then every `CronCreate` call — before the Stop hook surfaces it. #3367 moved the watcher ahead of registration so an arriving task is at least **seen** during the loop; this PR adds the complementary half: after orphan recovery classifies the queue, a **pending owner task is processed and answered before any cron is registered** (new Step 1.5 in `skills/startup/SKILL.md`).

Crons registering 30 seconds later costs nothing; an owner watching an unanswered first message pays for every one of those registration calls. The case that motivated this is desktop onboarding: the app now sends the owner's first DM at attach time (ag2-space/cinny-webclient#557), which frequently lands exactly in the `/startup` window of a freshly-booted core.

Ordering is deliberate: Step 1.5 runs after Step 1, never before — orphan recovery must classify crash leftovers first so a stale half-executed task is not answered as if it just arrived. Empty queue (the common case) skips silently.

## Before / after

Before (this file at the parent commit) — first task on a cold core queues behind the full bootstrap. Measured on a fresh macOS VM (Tart, 2026-08-25): first local task answered **226s** after core start, the bulk of it behind `/startup`'s registration loop.

After — with the reordered instruction in the bundled engine on the same VM image, the first-contact DM task was picked up and answered in **~20s** core-side once delivered (`queued 03:09:26 → result delivered 03:09:47` in `remote-gateway-bridge.log`; the separate delivery-side stall observed in that run is the gateway singleton lock issue, reported separately).

Caveat stated plainly: this is a skill-instruction change executed by the core LLM, not code — the VM run above is one observed pass, not a deterministic test. The wording mirrors the existing steps' imperative style so it slots into the same instruction-following path as Steps 1–3.

## Scope

Single concern; one file (`skills/startup/SKILL.md` — Step 1.5 + sequence-diagram line). No code paths touched; `/schedule-crons` internals (including #3367's watcher-first move) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPJivb11deR3ULC2ixBYfd