### PR TITLE
feat(schedule-crons): registration watchdog — mechanism replaces deferral for mid-boot tasks

### DIFF
--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -75,6 +75,21 @@ When `core.runtime` is `codex`, the canonical unmarked `main-loop` entry (`promp
 
    **Do not gate on the sentinel alone.** `watch-tasks-stream.sh` writes it once at startup, so an absent file means "no watcher" OR "a live watcher whose file was removed" — indistinguishable. Measured 2026-08-07 on a live core: `_watcher_trees()` returned `{'12631': ['12631']}` (functioning — it emitted `TASK_FILE:` for a probe) with the sentinel absent from disk. Gating on the sentinel there would have started a **second** watcher, and both then emit every task, so every task is processed twice. `_watcher_trees()` is also what makes the `pgrep` warning below unnecessary to re-solve: it drops its own pid and matches on argv shape. Don't use `pgrep -f watch-tasks-stream`: pgrep's `-f` argument matches the literal string `watch-tasks-stream` against full argv, which matches the bash wrapper invoking this very pgrep call (the wrapper's argv contains the search string), producing a transient self-match that returns a PID for a subshell that's already gone by the next `ps`. Same PID-stamp + `kill -0` pattern as the catchup sentinel in step 0 — single anti-pattern, single fix. Documented as F5 in `workspace/build_log.md` 2026-06-03T00:02Z validation pass; replayed on the very next session bootstrap (07:25Z) — Sutando.app's checkWatcher Timer caught the gap and sent a `watcher` keystroke, but two owner DMs were silently held in `tasks/` for ~5 min first. Don't kick off `bash src/watch-tasks.sh` (retired 2026-05-14).
 
+1.6. **Arm the registration watchdog, then handle tasks freely — registration is guarded by a mechanism, not by deferral.** Because step 1.5 arms the watcher before the registration loop, a `TASK_FILE` notification (the startup sweep's, or a live arrival) can land while steps 2-4 are still running. Without a rule here the agent improvises under the general "process notifications when they arrive" instruction, pivots to the task, and may never finish registration — losing the `/proactive-loop` fallback, the one thing that guarantees the session has a recurring work driver (that silent loss is the incident class this step exists to close). The old cure was a deferral rule ("finish registration first"), which cost a waiting user the whole registration window before any answer. This step replaces discipline with a watchdog: immediately after step 1.5, before touching any task, arm ONE Monitor:
+
+   ```
+   Monitor tool — description "schedule-crons watchdog", timeout_ms 3600000, command:
+   T0=$(date +%s); STAMP="$WORKSPACE/hosts/$(bash scripts/sutando-config.sh host-label)/schedule-crons-stamp.json"
+   sleep 90
+   while [ "$(stat -f %m "$STAMP" 2>/dev/null || echo 0)" -lt "$T0" ]; do
+     echo "CRONS-UNREGISTERED: schedule-crons has not stamped this boot — return and register now"
+     sleep 60
+   done
+   echo "CRONS-STAMPED: registration complete"
+   ```
+
+   Then respond to task notifications as they land: send the fail-open progress ack first (`python3 skills/task-progress/scripts/notify.py ...` — one subprocess, no state mutation, cannot derail anything), and use judgment on handling — a short waiting owner task may simply be served before registration continues; anything substantial gets the ack and is handled when the agent is next free. Either way registration cannot be silently dropped: if it slips, the watchdog emits a nag every 60s until step 5.7's completion stamp lands, and the terminal `CRONS-STAMPED` line confirms the guard saw the stamp — which is also why that stamp write is not optional bookkeeping; it is what releases the watchdog. The 90s grace means a normal boot never hears from it, and the 1-hour cap bounds noise if a boot dies (an unregistered state dies with its session). Detection and re-prompt share one source of truth: the same stamp `health-check.py`'s `session-crons` probe already reads. `stat -f %m` is the darwin form; swap for a `python3 -c` mtime read on linux.
+
 2. Check existing cron jobs with CronList
 3. For each job in the config:
    - Skip entries carrying a `monitor` object — they are Monitors, not crons (no `cron`, no prompt to register); step 5.4 owns their arming, and a `CronCreate` attempt on one is invalid.

--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -79,7 +79,10 @@ When `core.runtime` is `codex`, the canonical unmarked `main-loop` entry (`promp
 
    ```
    Monitor tool — description "schedule-crons watchdog", timeout_ms 3600000, command:
-   T0=$(date +%s); STAMP="$WORKSPACE/hosts/$(bash scripts/sutando-config.sh host-label)/schedule-crons-stamp.json"
+   cd "$(git -C . rev-parse --show-toplevel 2>/dev/null || echo .)" 2>/dev/null || true
+   T0=$(date +%s); WS="$(bash scripts/sutando-config.sh workspace)"
+   STAMP="$WS/hosts/$(bash scripts/sutando-config.sh host-label)/schedule-crons-stamp.json"
+   [ -n "$WS" ] || { echo "CRONS-WATCHDOG-INERT: workspace did not resolve — guard not armed"; exit 1; }
    sleep 90
    while [ "$(stat -f %m "$STAMP" 2>/dev/null || echo 0)" -lt "$T0" ]; do
      echo "CRONS-UNREGISTERED: schedule-crons has not stamped this boot — return and register now"
@@ -88,7 +91,7 @@ When `core.runtime` is `codex`, the canonical unmarked `main-loop` entry (`promp
    echo "CRONS-STAMPED: registration complete"
    ```
 
-   Then respond to task notifications as they land: send the fail-open progress ack first (`python3 skills/task-progress/scripts/notify.py ...` — one subprocess, no state mutation, cannot derail anything), and use judgment on handling — a short waiting owner task may simply be served before registration continues; anything substantial gets the ack and is handled when the agent is next free. Either way registration cannot be silently dropped: if it slips, the watchdog emits a nag every 60s until step 5.7's completion stamp lands, and the terminal `CRONS-STAMPED` line confirms the guard saw the stamp — which is also why that stamp write is not optional bookkeeping; it is what releases the watchdog. The 90s grace means a normal boot never hears from it, and the 1-hour cap bounds noise if a boot dies (an unregistered state dies with its session). Detection and re-prompt share one source of truth: the same stamp `health-check.py`'s `session-crons` probe already reads. `stat -f %m` is the darwin form; swap for a `python3 -c` mtime read on linux.
+   Then respond to task notifications as they land: send the fail-open progress ack first (`python3 skills/task-progress/scripts/notify.py ...` — one subprocess, no state mutation, cannot derail anything), and use judgment on handling — a short waiting owner task may simply be served before registration continues; anything substantial gets the ack and is handled when the agent is next free. Either way registration cannot be silently dropped: if it slips, the watchdog emits a nag every 60s until step 5.7's completion stamp lands, and the terminal `CRONS-STAMPED` line confirms the guard saw the stamp — which is also why that stamp write is not optional bookkeeping; it is what releases the watchdog. The 90s grace means a normal boot never hears from it, and the 1-hour cap bounds noise if a boot dies (an unregistered state dies with its session). Detection and re-prompt share one source of truth: the same stamp `health-check.py`'s `session-crons` probe already reads. `stat -f %m` is the darwin form; swap for a `python3 -c` mtime read on linux. **Resolve the workspace INSIDE the command** — a Monitor is a fresh shell and the loop's `WORKSPACE` is a per-command local that is never exported, so an inherited `$WORKSPACE` is empty there and the stamp path silently becomes `/hosts/<label>/...`, which never exists: the guard would then nag on every healthy boot (~58 times before the cap) and never print `CRONS-STAMPED`. That failure looks like the watchdog working hard, which is why the empty-`WS` refusal above is loud instead: an unarmed guard must announce itself rather than pass as a busy one.
 
 2. Check existing cron jobs with CronList
 3. For each job in the config:


### PR DESCRIPTION
## What

One new step (1.6) in `skills/schedule-crons/SKILL.md`: immediately after the watcher starts (step 1.5, #3367), arm a registration watchdog — a Monitor that emits a nag every 60s until step 5.7's completion stamp lands — then let the agent ack and handle arriving tasks freely. Registration becomes mechanically un-losable instead of discipline-protected; the deferral rule is retired.

## Why (the measured gap, before/after)

**Before (current main, #3367 in):** the watcher's startup sweep notifies about a waiting task within seconds of boot (`src/watch-tasks-stream.sh:639-645`, "Initial sweep — surface any pre-existing tasks"), but the merged text carries NO instruction for a mid-boot notification. The agent improvises under the general "process notifications when they arrive" rule: it pivots, and an unfinished registration loses the `/proactive-loop` fallback — the session's only recurring work driver — silently, until restart. Both halves are measured, not hypothetical: the ~76s unwatched window on RC9 onboarding (#3367's own body), and the 2026-06-03 incident where two owner DMs sat silent while a boot ran without protection.

**After:** the watchdog's nag makes an abandoned registration impossible to miss (60s cadence until the stamp lands, `CRONS-STAMPED` terminal line when it does), so handling a task early is safe — a short waiting owner task may simply be served first, anything substantial gets the fail-open ack and waits for a free turn. Healthy boots never hear from the guard (90s grace); a dead boot's watchdog dies with its session (1h cap). Detection and re-prompt now share one source of truth: the same `schedule-crons-stamp.json` that `health-check.py`'s `session-crons` probe already reads.

## Supersedes

- **#3369** (Rui): the capture-is-not-handling framing survives here; the deferral remedy it carried was superseded by the owner's watchdog design (PR-practice thread, 2026-08-25). Closing with credit.
- **#3380** (Vidhu): her ordering insight — a task already waiting at boot deserves priority — survives as this step's judgment line ("a short waiting owner task may simply be served"); the standalone answer-first step cost an unbounded registration delay on long tasks. Closing with credit.

## Evidence & testability

This is an agent-followed Markdown skill (like #3367): the test is the documented sequence itself. The watchdog command was syntax-shaped in-session tonight; its stamp-vs-T0 comparison uses the exact file `session-crons` already validates, so a wrong stamp path would already be red in health-check. `stat -f %m` is the darwin form (noted inline for linux). review-checks --diff: hardcoded-paths + root-artifacts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
