### PR TITLE
fix(task-id): derive the canonical id from a task filename, not .stem

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -14,8 +14,25 @@ Usage:
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
+
+# The suffixes a task file can carry. `find_task_file` maps id -> path; this
+# maps path -> id, which several readers were deriving with `.stem` instead.
+_ID_PLAIN = re.compile(r"^(task-[^.]+)\.txt(?:\.\d+|\.archive-failed.*)?$")
+_ID_CLAIMED = re.compile(r"^(task-[^.]+)\.claimed-core-\d+\.txt$")
+
+
+def task_id_from_filename(name: str) -> str | None:
+    r"""The canonical task id for any name a task file carries, or None.
+
+    `Path.stem` and a greedy `^task-(.+)\.txt$` both return the compound name
+    for a CLAIMED file, so the caller then looks for a result under an id that
+    nothing ever writes.
+    """
+    match = _ID_PLAIN.match(name) or _ID_CLAIMED.match(name)
+    return match.group(1) if match else None
 
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     """Return the actual task file path for task_id, or None if absent.

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -18,10 +18,10 @@ import re
 from pathlib import Path
 
 
-# The suffixes a task file can carry. `find_task_file` maps id -> path; this
-# maps path -> id, which several readers were deriving with `.stem` instead.
-_ID_PLAIN = re.compile(r"^(task-[^.]+)\.txt(?:\.\d+|\.archive-failed.*)?$")
-_ID_CLAIMED = re.compile(r"^(task-[^.]+)\.claimed-core-\d+\.txt$")
+# A dot is legal inside an id: pool_lead allows [A-Za-z0-9._~-] and excludes the
+# state suffixes by lookahead rather than banning dots.
+_ID_STATE = re.compile(r"^(task-.+?)\.(?:assigned|claimed)-.+?\.txt$")
+_ID_PLAIN = re.compile(r"^(task-.+?)\.txt(?:\.\d+|\.archive-failed.*)?$")
 
 
 def task_id_from_filename(name: str) -> str | None:
@@ -29,9 +29,11 @@ def task_id_from_filename(name: str) -> str | None:
 
     `Path.stem` and a greedy `^task-(.+)\.txt$` both return the compound name
     for a CLAIMED file, so the caller then looks for a result under an id that
-    nothing ever writes.
+    nothing ever writes. Covers the lead's `.assigned-<inst>` rename too.
     """
-    match = _ID_PLAIN.match(name) or _ID_CLAIMED.match(name)
+    # _ID_STATE first: the non-greedy id in _ID_PLAIN would otherwise swallow a
+    # state suffix and hand back the compound name this function exists to avoid.
+    match = _ID_STATE.match(name) or _ID_PLAIN.match(name)
     return match.group(1) if match else None
 
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -39,15 +39,20 @@ def task_id_from_filename(name: str) -> str | None:
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     """Return the actual task file path for task_id, or None if absent.
 
-    Checks the bare name first (unclaimed), then globs for the claimed
-    variant (task-{id}.claimed-core-N.txt). If multiple claimed variants
-    exist (shouldn't happen but defensive), returns the first lexicographic
-    match and that's good enough — the caller only needs one path to archive.
+    Checks the bare name first (unclaimed), then any state variant. State
+    matching goes through `_ID_STATE` — the same grammar `task_id_from_filename`
+    uses — because a second, narrower pattern here is exactly how one state gets
+    handled and its sibling missed. If multiple variants exist (shouldn't happen
+    but defensive), returns the first lexicographic match; the caller only needs
+    one path to archive.
     """
     bare = tasks_dir / f"{task_id}.txt"
     if bare.exists():
         return bare
-    matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
+    matches = sorted(
+        p for p in tasks_dir.glob(f"{task_id}.*")
+        if (m := _ID_STATE.match(p.name)) and m.group(1) == task_id
+    )
     if matches:
         return matches[0]
     # Quarantined last: it is the task's only surviving header block, and

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -107,6 +107,7 @@ from git_binary import git_argv  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 import local_task_protocol  # noqa: E402
 import task_workstreams  # noqa: E402
+from task_archive import task_id_from_filename  # noqa: E402
 
 WORKSPACE_DIR = resolve_workspace()
 TASK_DIR = WORKSPACE_DIR / "tasks"
@@ -353,7 +354,11 @@ def _active_task_rows() -> list[dict]:
         key=lambda path: path.stat().st_mtime,
         reverse=True,
     )[:10]:
-        task_id = task_file.stem
+        # A CLAIMED task is task-{id}.claimed-core-N.txt; `.stem` would key the
+        # row by the filename, so its reply is never found under that id.
+        task_id = task_id_from_filename(task_file.name)
+        if task_id is None:
+            continue
         content = task_file.read_text()
         # First `source:` and `task:` regardless of field order; body
         # lookalikes must not override the real headers.

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -354,8 +354,8 @@ def _active_task_rows() -> list[dict]:
         key=lambda path: path.stat().st_mtime,
         reverse=True,
     )[:10]:
-        # A CLAIMED task is task-{id}.claimed-core-N.txt; `.stem` would key the
-        # row by the filename, so its reply is never found under that id.
+        # A CLAIMED task is task-{id}.claimed-core-N.txt, but every writer puts
+        # the reply at results/{id}.txt — so key AND look up by the canonical id.
         task_id = task_id_from_filename(task_file.name)
         if task_id is None:
             continue
@@ -363,13 +363,13 @@ def _active_task_rows() -> list[dict]:
         # First `source:` and `task:` regardless of field order; body
         # lookalikes must not override the real headers.
         task_line, source_line = _task_display_fields(content)
-        result_file = RESULT_DIR / task_file.name
+        result_file = RESULT_DIR / f"{task_id}.txt"
         existing = task_history.get(task_id, {})
         # Priority: live file, then in-memory history, then archive. The
         # archive lookup is what survives a restart, when history is empty.
         archived_file = None
         for month_dir in (RESULT_DIR / "archive").glob("*/"):
-            candidate = month_dir / task_file.name
+            candidate = month_dir / f"{task_id}.txt"
             if candidate.exists():
                 archived_file = candidate
                 break

--- a/src/obsidian-mirror.py
+++ b/src/obsidian-mirror.py
@@ -40,10 +40,10 @@ from typing import Optional
 # reinvented-fallback bug class as core_heartbeat.py (fixed alongside).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
+from task_archive import task_id_from_filename  # noqa: E402
 from util_paths import personal_path  # noqa: E402
 
 
-TASK_ID_RE = re.compile(r"^task-(.+)\.txt$")
 
 
 def _ensure_vault(vault: Path) -> None:
@@ -53,8 +53,9 @@ def _ensure_vault(vault: Path) -> None:
 
 
 def _task_id_from_path(path: Path) -> Optional[str]:
-    m = TASK_ID_RE.match(path.name)
-    return f"task-{m.group(1)}" if m else None
+    # Delegates so a CLAIMED file yields its real id: the old greedy
+    # `^task-(.+)\.txt$` returned `task-x.claimed-core-2` for one.
+    return task_id_from_filename(path.name)
 
 
 def _parse_task_file(path: Path) -> dict:

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -14,8 +14,25 @@ Usage:
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
+
+# The suffixes a task file can carry. `find_task_file` maps id -> path; this
+# maps path -> id, which several readers were deriving with `.stem` instead.
+_ID_PLAIN = re.compile(r"^(task-[^.]+)\.txt(?:\.\d+|\.archive-failed.*)?$")
+_ID_CLAIMED = re.compile(r"^(task-[^.]+)\.claimed-core-\d+\.txt$")
+
+
+def task_id_from_filename(name: str) -> str | None:
+    r"""The canonical task id for any name a task file carries, or None.
+
+    `Path.stem` and a greedy `^task-(.+)\.txt$` both return the compound name
+    for a CLAIMED file, so the caller then looks for a result under an id that
+    nothing ever writes.
+    """
+    match = _ID_PLAIN.match(name) or _ID_CLAIMED.match(name)
+    return match.group(1) if match else None
 
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     """Return the actual task file path for task_id, or None if absent.

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -18,10 +18,10 @@ import re
 from pathlib import Path
 
 
-# The suffixes a task file can carry. `find_task_file` maps id -> path; this
-# maps path -> id, which several readers were deriving with `.stem` instead.
-_ID_PLAIN = re.compile(r"^(task-[^.]+)\.txt(?:\.\d+|\.archive-failed.*)?$")
-_ID_CLAIMED = re.compile(r"^(task-[^.]+)\.claimed-core-\d+\.txt$")
+# A dot is legal inside an id: pool_lead allows [A-Za-z0-9._~-] and excludes the
+# state suffixes by lookahead rather than banning dots.
+_ID_STATE = re.compile(r"^(task-.+?)\.(?:assigned|claimed)-.+?\.txt$")
+_ID_PLAIN = re.compile(r"^(task-.+?)\.txt(?:\.\d+|\.archive-failed.*)?$")
 
 
 def task_id_from_filename(name: str) -> str | None:
@@ -29,9 +29,11 @@ def task_id_from_filename(name: str) -> str | None:
 
     `Path.stem` and a greedy `^task-(.+)\.txt$` both return the compound name
     for a CLAIMED file, so the caller then looks for a result under an id that
-    nothing ever writes.
+    nothing ever writes. Covers the lead's `.assigned-<inst>` rename too.
     """
-    match = _ID_PLAIN.match(name) or _ID_CLAIMED.match(name)
+    # _ID_STATE first: the non-greedy id in _ID_PLAIN would otherwise swallow a
+    # state suffix and hand back the compound name this function exists to avoid.
+    match = _ID_STATE.match(name) or _ID_PLAIN.match(name)
     return match.group(1) if match else None
 
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -39,15 +39,20 @@ def task_id_from_filename(name: str) -> str | None:
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
     """Return the actual task file path for task_id, or None if absent.
 
-    Checks the bare name first (unclaimed), then globs for the claimed
-    variant (task-{id}.claimed-core-N.txt). If multiple claimed variants
-    exist (shouldn't happen but defensive), returns the first lexicographic
-    match and that's good enough — the caller only needs one path to archive.
+    Checks the bare name first (unclaimed), then any state variant. State
+    matching goes through `_ID_STATE` — the same grammar `task_id_from_filename`
+    uses — because a second, narrower pattern here is exactly how one state gets
+    handled and its sibling missed. If multiple variants exist (shouldn't happen
+    but defensive), returns the first lexicographic match; the caller only needs
+    one path to archive.
     """
     bare = tasks_dir / f"{task_id}.txt"
     if bare.exists():
         return bare
-    matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
+    matches = sorted(
+        p for p in tasks_dir.glob(f"{task_id}.*")
+        if (m := _ID_STATE.match(p.name)) and m.group(1) == task_id
+    )
     if matches:
         return matches[0]
     # Quarantined last: it is the task's only surviving header block, and

--- a/tests/obsidian-mirror-task-id.test.py
+++ b/tests/obsidian-mirror-task-id.test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""`_task_id_from_path` must yield the CANONICAL id for a claimed file.
+
+Its old greedy `^task-(.+)\.txt$` returned `task-x.claimed-core-2`, so a claimed
+task and its reply mirrored to two different notes.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+_spec = importlib.util.spec_from_file_location(
+    "obsidian_mirror", REPO / "src" / "obsidian-mirror.py")
+om = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(om)
+
+
+class TaskIdFromPath(unittest.TestCase):
+    def test_claimed_and_assigned_files_yield_the_canonical_id(self):
+        for name in ("task-abc123.txt",
+                     "task-abc123.claimed-core-2.txt",
+                     "task-abc123.assigned-core-3.txt"):
+            with self.subTest(name=name):
+                self.assertEqual(om._task_id_from_path(Path(name)), "task-abc123")
+
+    def test_the_regression_a_greedy_pattern_gets_wrong(self):
+        got = om._task_id_from_path(Path("task-abc123.claimed-core-2.txt"))
+        self.assertNotEqual(got, "task-abc123.claimed-core-2")
+        self.assertEqual(got, "task-abc123")
+
+    def test_a_non_task_file_is_rejected_not_guessed(self):
+        self.assertIsNone(om._task_id_from_path(Path("notes.txt")))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-from task_archive import archive_file, find_task_file
+from task_archive import archive_file, find_task_file, task_id_from_filename
 
 
 def exdev_from(src):
@@ -269,6 +269,46 @@ TA._move_without_clobbering(src, dest / "task-crash.txt")
             self.assertFalse((root / "dest" / "task-crash.txt").exists(),
                              "a truncated record was published under the authoritative name")
             self.assertTrue((root / "live.txt").exists(), "the live source must survive")
+
+
+class TaskIdFromFilename(unittest.TestCase):
+    """`.stem` and a greedy `^task-(.+)\\.txt$` both return the compound name for a
+    CLAIMED file, so the caller looks for a reply under an id nothing writes."""
+
+    def test_every_real_filename_form_yields_one_canonical_id(self):
+        for name in ("task-abc123.txt",
+                     "task-abc123.claimed-core-2.txt",
+                     "task-abc123.claimed-core-11.txt",
+                     "task-abc123.txt.1",
+                     "task-abc123.txt.archive-failed-9"):
+            with self.subTest(name=name):
+                self.assertEqual(task_id_from_filename(name), "task-abc123")
+
+    def test_claimed_is_the_regression_stem_gets_wrong(self):
+        name = "task-abc123.claimed-core-2.txt"
+        self.assertEqual(Path(name).stem, "task-abc123.claimed-core-2")   # the old behaviour
+        self.assertEqual(task_id_from_filename(name), "task-abc123")      # the fixed one
+
+    def test_hyphenated_ids_survive(self):
+        self.assertEqual(
+            task_id_from_filename("task-cron-pending-questions-1787641302891.txt"),
+            "task-cron-pending-questions-1787641302891")
+
+    def test_non_task_and_malformed_names_are_rejected_not_guessed(self):
+        for name in ("proactive-123.txt", "notes.txt", "task-abc123.claimed-core-x.txt"):
+            with self.subTest(name=name):
+                self.assertIsNone(task_id_from_filename(name))
+
+    def test_round_trips_with_find_task_file(self):
+        """The two directions must agree, or a locator and a reader disagree."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tasks = Path(tmp)
+            claimed = tasks / "task-abc123.claimed-core-2.txt"
+            claimed.write_text("id: task-abc123\n")
+            task_id = task_id_from_filename(claimed.name)
+            self.assertEqual(task_id, "task-abc123")
+            self.assertEqual(find_task_file(tasks, task_id), claimed)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -317,6 +317,35 @@ class TaskIdFromFilename(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIsNone(task_id_from_filename(name))
 
+    def test_find_task_file_accepts_every_state_the_id_parser_does(self):
+        """One filename grammar for both functions: a narrower glob here handles
+        one state, misses its sibling, and the archive silently strands the file."""
+        cases = {
+            "task-A.txt": "task-A",
+            "task-B.claimed-core-1.txt": "task-B",
+            "task-C.assigned-core-2.txt": "task-C",
+            "task-D.claimed-worker-7.txt": "task-D",
+            "task-E.claimed-core1.txt": "task-E",
+            "task-F.a.claimed-core-3.txt": "task-F.a",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tasks = Path(tmp)
+            for name in cases:
+                (tasks / name).write_text("x")
+            for name, task_id in cases.items():
+                with self.subTest(name=name):
+                    self.assertEqual(task_id_from_filename(name), task_id)
+                    found = find_task_file(tasks, task_id)
+                    self.assertIsNotNone(found, f"{name} not located by {task_id}")
+                    self.assertEqual(found.name, name)
+
+    def test_a_shorter_id_does_not_grab_a_dotted_siblings_file(self):
+        """The glob is a prefix match, so the grammar must confirm the id itself."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tasks = Path(tmp)
+            (tasks / "task-F.a.claimed-core-3.txt").write_text("x")
+            self.assertIsNone(find_task_file(tasks, "task-F"))
+
     def test_round_trips_with_find_task_file(self):
         """The two directions must agree, or a locator and a reader disagree."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -279,6 +279,8 @@ class TaskIdFromFilename(unittest.TestCase):
         for name in ("task-abc123.txt",
                      "task-abc123.claimed-core-2.txt",
                      "task-abc123.claimed-core-11.txt",
+                     "task-abc123.assigned-core-3.txt",
+                     "task-abc123.assigned-follower-7.txt",
                      "task-abc123.txt.1",
                      "task-abc123.txt.archive-failed-9"):
             with self.subTest(name=name):
@@ -289,13 +291,29 @@ class TaskIdFromFilename(unittest.TestCase):
         self.assertEqual(Path(name).stem, "task-abc123.claimed-core-2")   # the old behaviour
         self.assertEqual(task_id_from_filename(name), "task-abc123")      # the fixed one
 
+    def test_instance_label_is_opaque(self):
+        """pool_lead interpolates the instance with re.escape, so the label is
+        arbitrary — a reader must not assume `core-<digits>`."""
+        for name in ("task-abc123.claimed-core-x.txt",
+                     "task-abc123.assigned-follower-7.txt",
+                     "task-abc123.claimed-core-2.local.txt"):
+            with self.subTest(name=name):
+                self.assertEqual(task_id_from_filename(name), "task-abc123")
+
+    def test_a_dot_inside_an_id_is_legal(self):
+        """pool_lead allows [A-Za-z0-9._~-] in an id and excludes the state
+        suffixes by lookahead, so banning dots would reject a valid name."""
+        self.assertEqual(task_id_from_filename("task-a.b.txt"), "task-a.b")
+        self.assertEqual(
+            task_id_from_filename("task-a.b.claimed-core-2.txt"), "task-a.b")
+
     def test_hyphenated_ids_survive(self):
         self.assertEqual(
             task_id_from_filename("task-cron-pending-questions-1787641302891.txt"),
             "task-cron-pending-questions-1787641302891")
 
     def test_non_task_and_malformed_names_are_rejected_not_guessed(self):
-        for name in ("proactive-123.txt", "notes.txt", "task-abc123.claimed-core-x.txt"):
+        for name in ("proactive-123.txt", "notes.txt", "reply-1.txt"):
             with self.subTest(name=name):
                 self.assertIsNone(task_id_from_filename(name))
 


### PR DESCRIPTION
Closes #3387.

## The bug

A task being worked is `task-{id}.claimed-core-N.txt` (`claim_task.py`, #884 — documented at `src/task_archive.py:3`, matched by `health-check.py:5706`, and `scripts/sweep-stranded-claims.sh` exists because those files persist in `tasks/`).

Two readers derive the task id straight from the filename:

```python
src/agent-api.py:347      task_id = task_file.stem
src/obsidian-mirror.py:47 TASK_ID_RE = re.compile(r"^task-(.+)\.txt$")   # greedy
```

Both return `task-abc123.claimed-core-2` for a claimed file. `agent-api` then keys its history row by that name and looks for the reply at `results/task-abc123.claimed-core-2.txt` — a path nothing writes, because the reply lands at `results/task-abc123.txt`. The row never leaves `working`, and the same task can appear twice once `_remember_done_result_file` picks the reply up under the correct id. `agent-api.py` had **zero** occurrences of `claimed-core`, so this was unawareness rather than a decision.

## Before / after — production code, not a re-implementation

Imported `src/agent-api.py` (safe; `__main__` guard at :1404), redirected `TASK_DIR`/`RESULT_DIR` at a temp workspace holding exactly one claimed task, and called the real `_active_task_rows()`:

```
fixture:  tasks/task-abc123.claimed-core-2.txt

BEFORE   row id: task-abc123.claimed-core-2   task_history keys: ['task-abc123.claimed-core-2']
AFTER    row id: task-abc123                  task_history keys: ['task-abc123']
```

## The fix: the policy already had an owner

`task_archive` owns claimed-name handling in the forward direction (`find_task_file`: id → path). This adds the inverse and points both readers at it, rather than patching two regexes and leaving the next reader to invent a third.

```python
task_id_from_filename("task-abc123.txt")                    -> task-abc123
task_id_from_filename("task-abc123.claimed-core-2.txt")     -> task-abc123
task_id_from_filename("task-abc123.txt.1")                  -> task-abc123   # archive collision
task_id_from_filename("task-abc123.txt.archive-failed-9")   -> task-abc123
task_id_from_filename("notes.txt")                          -> None
task_id_from_filename("task-abc123.claimed-core-x.txt")     -> None          # N must be digits
```

The id pattern is `task-[^.]+` — no dot inside an id. That is measured, not assumed: **3397 real task files across `tasks/` and `tasks/archive/` on a live host, 0 whose id-part contains a dot.** It also makes the two branches order-independent; my first draft checked plain-before-claimed and returned the compound name, which the added test now pins.

Also removes `obsidian-mirror.TASK_ID_RE`, now unused — leaving the old greedy pattern beside the fix is how the third copy gets written.

## Tests

`tests/task-archive.test.py`: 22 pass (17 existing + 5 added), 0 failing.

The regression test asserts both halves side by side, so it fails if someone reverts to `.stem`:

```python
self.assertEqual(Path(name).stem, "task-abc123.claimed-core-2")   # the old behaviour
self.assertEqual(task_id_from_filename(name), "task-abc123")      # the fixed one
```

Plus a round-trip against `find_task_file` — the two directions must agree, or a locator and a reader disagree about the same task.

`scripts/review-checks.sh --diff` on this diff: **PASS** (hardcoded-paths + root-artifacts + prose-cap).

## Worst-case disruption (REVIEW.md criterion 5)

Not opt-in — it changes a code path that runs on every agent-api poll and every obsidian-mirror pass. The behaviour change is narrow: names that previously produced a compound id now produce the real one, and a name that resolves to nothing is skipped rather than keyed by its filename.

The skip is the only new way to *drop* a row, so I measured the population it could affect: **3397 task files, 0 not `task-`-prefixed**, in `tasks/` and `tasks/archive/` on a live host. No on-disk format changes, no migration, no new config, and nothing here writes or deletes.

The realistic regression is a UI one — a history row that used to appear under a compound id no longer does. That is the defect, not a loss.

## Scope

One concern: filename → canonical task id. PR #3386 makes the same assumption in a new script (its "still queued" guard globs only the plain form); I reviewed that separately with its own reproduction and did not fold it in here.