### PR TITLE
fix(post-gate): strip mapping keys, not just values

### DIFF
--- a/docs/sutando-config.schema.json
+++ b/docs/sutando-config.schema.json
@@ -185,6 +185,10 @@
               "type": "object",
               "description": "Per-channel policy files. `*` is REQUIRED and is the fallback for any channel not listed: without it an unlisted channel would send unvalidated, so the resolver refuses the whole mapping. An entry with a null/blank path refuses that one channel.",
               "required": ["*"],
+              "propertyNames": {
+                "pattern": "^\\S+$",
+                "description": "Channel ids carry no surrounding whitespace. The resolver strips keys; an untrimmed one would route that channel to `*` instead of its own policy."
+              },
               "properties": {
                 "*": {
                   "type": "string",

--- a/src/channels/discord/post_gate.py
+++ b/src/channels/discord/post_gate.py
@@ -52,7 +52,7 @@ def _configured_target(repo_root=None):
     bridges = load_config(repo_root).get("bridges") or {}
     raw = bridges.get("discord_post_gate")
     if isinstance(raw, dict):
-        return {str(k): str(v or "").strip() for k, v in raw.items()}
+        return {str(k).strip(): str(v or "").strip() for k, v in raw.items()}
     return str(raw or "").strip()
 
 
@@ -115,7 +115,7 @@ def resolve_validator(repo_root=None):
     if isinstance(target, dict):
         # Normalize here too: a safety property must not depend on an
         # upstream caller having stripped its input ("   " is truthy).
-        target = {str(k): (v.strip() if isinstance(v, str) else v)
+        target = {str(k).strip(): (v.strip() if isinstance(v, str) else v)
                   for k, v in target.items()}
         if not any(target.values()):
             # A mapping naming no usable path is a CONFIGURED gate that would

--- a/tests/discord-post-gate-per-channel.test.py
+++ b/tests/discord-post-gate-per-channel.test.py
@@ -149,5 +149,18 @@ try:
 finally:
     os.environ.pop("SUTANDO_DISCORD_POST_GATE", None)
 
+# A key selects WHICH policy runs (#3389): an untrimmed one silently routes its
+# channel to `*` — still gated, but by the wrong and usually laxer policy.
+for _key in (" 111", "111 ", "\t111"):
+    _v = resolve({_key: str(D / "refuse.py"), "*": str(D / "star.py")})
+    check(f"whitespace key {_key!r} still reaches its own policy",
+          _v("111", P) == "refused-by-A", repr(_v("111", P)))
+_v = resolve({"111": str(D / "refuse.py"), "*": str(D / "star.py")})
+check("control — a clean key behaves identically", _v("111", P) == "refused-by-A", repr(_v("111", P)))
+check("control — an unlisted channel still falls through to `*`",
+      _v("999", P) == "refused-by-STAR", repr(_v("999", P)))
+_v = resolve({" * ": str(D / "star.py")})
+check("`*` itself survives key stripping", _v("999", P) == "refused-by-STAR", repr(_v("999", P)))
+
 print(("\nFAILED: " + ", ".join(FAILS)) if FAILS else "\nAll per-channel post-gate checks passed.")
 sys.exit(1 if FAILS else 0)


### PR DESCRIPTION
Closes #3389 — the finding I raised while reviewing #3355, filed rather than folded in because that
PR was already approved and merging.

## The defect

Both normalizers strip the **values** of a `{channel_id: path}` mapping and neither touches the
**keys**, so a key with stray whitespace matches no channel and falls through to `*`.

Before / after, same two policy files, only the key differs:

```
key='111'    -> DENY (its own policy)      key='111'    -> DENY   (unchanged)
key=' 111'   -> ALLOW (fell through to *)  key=' 111'   -> DENY
key='111 '   -> ALLOW (fell through to *)  key='111 '   -> DENY
key='\t111'  -> ALLOW (fell through to *)  key='\t111'  -> DENY
```

Not a gate bypass — the channel is still validated, by `*`. It is a silent policy **substitution** in
the unsafe direction: a per-channel entry exists to differ from the fallback, usually by being
stricter, and nothing errors or logs. It is also the case `post_gate.py`'s own comment argues against
— *"a safety property must not depend on an upstream caller having stripped its input"* — applied to
values but not to the keys that select which policy runs.

## Why both normalizers

`_configured_target` **and** `resolve_validator` each strip values, and I stripped keys in both. One
would not have been enough, and this is worth stating because it nearly shipped wrong: the
per-channel suite's `resolve()` helper patches `_configured_target` away entirely, so a fix confined
to it is invisible to every test in that file. **I wrote that version first, and the suite passed
without exercising the change at all.**

## Evidence

`discord-post-gate-per-channel.test.py` gains 4 checks + 2 controls, and the **mutation control**
matters more than the pass:

```
un-stripped keys ->  FAIL whitespace key ' 111' still reaches its own policy — 'refused-by-STAR'
                     FAIL whitespace key '111 ' ...
                     FAIL whitespace key '\t111' ...
                     FAIL `*` itself survives key stripping —
                          "mapping configured without a usable '*' fallback ... refusing all sends"
restored         ->  all pass
```

That fourth row is a hazard #3389 did not name: a `" * "` key un-stripped means the map has no usable
`*`, so **every send refuses**. The fix closes that too.

Schema: `propertyNames: {"pattern": "^\\S+$"}` on the object branch so the editor catches it as well.
Edited as text rather than through a json round-trip — `json.dump` reformatted two unrelated arrays
and escaped an em-dash in another key's description, which would have been unrelated churn in the
diff.

Green: 3 post-gate suites, `release-docs-audit` ALL PASS, `review-checks` PASS (hardcoded-paths +
root-artifacts + prose-cap).

Not a live-path change — resolution only, no delivery behaviour altered, and the wiring suite still
shows all five production sender paths blocked by a refusing policy with zero transport attempts.
