### PR TITLE
fix(calendar-cache): warn when a payload has no `start` instead of silently costing the briefing two lines

### DIFF
--- a/src/write_calendar_cache.py
+++ b/src/write_calendar_cache.py
@@ -120,7 +120,14 @@ def write_cache(events: list[dict], path: Path | None = None,
     path = path or cache_path()
     today = today or datetime.now().strftime("%Y-%m-%d")
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"date": today, "events": normalize_events(events)}
+    normalized = normalize_events(events)
+    if missing := sum(1 for e in normalized if not e.get("start")):
+        # The briefing gates BOTH "Next up" and "Last event" on every event
+        # having a start, so a payload without one degrades it with no other tell.
+        print(f"write_calendar_cache: {missing} of {len(normalized)} event(s) carry no "
+              "`start` — the briefing will omit its 'Next up' and 'Last event' lines. "
+              "Include `start` in each piped event to keep them.", file=sys.stderr)
+    payload = {"date": today, "events": normalized}
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(payload, indent=2) + "\n")
     os.replace(tmp, path)  # atomic — a concurrent briefing read never sees a partial file

--- a/tests/write-calendar-cache.test.py
+++ b/tests/write-calendar-cache.test.py
@@ -169,6 +169,30 @@ def test_nonempty_payload_no_usable_events_preserves_prior() -> None:
            rc != 0 and not cache.exists(), f"rc={rc} exists={cache.exists()}")
 
 
+def test_missing_start_warns_and_present_start_is_quiet() -> None:
+    """A payload with no `start` silently costs the briefing two lines, so the
+    producer says so; a payload that carries one must stay quiet."""
+    with tempfile.TemporaryDirectory() as td:
+        for label, events, want in (
+            ("no start", [{"raw": "09:00 Standup", "calendar": "primary"}], True),
+            ("with start", [{"raw": "09:00 Standup", "calendar": "primary",
+                             "start": "2026-08-25T09:00:00-07:00"}], False),
+        ):
+            err = io.StringIO()
+            with unittest.mock.patch("sys.stderr", err):
+                wcc.write_cache(events, path=Path(td) / f"{want}.json")
+            warned = "carry no" in err.getvalue()
+            ok(f"write_cache warns iff start missing ({label})", warned is want,
+               f"stderr={err.getvalue()!r}")
+        # The count must name the events that lack a start, not the whole list.
+        err = io.StringIO()
+        with unittest.mock.patch("sys.stderr", err):
+            wcc.write_cache([{"raw": "A", "calendar": "", "start": "2026-08-25T09:00:00-07:00"},
+                             {"raw": "B", "calendar": ""}], path=Path(td) / "mixed.json")
+        ok("warning counts only the events missing a start",
+           "1 of 2 event(s)" in err.getvalue(), err.getvalue())
+
+
 def test_cache_path_default_location() -> None:
     """The real (un-mocked) cache_path resolves under <workspace>/state/."""
     p = wcc.cache_path()
@@ -186,6 +210,7 @@ test_cli_events_json_flag()
 test_cli_stdin_events()
 test_cli_error_paths()
 test_nonempty_payload_no_usable_events_preserves_prior()
+test_missing_start_warns_and_present_start_is_quiet()
 test_cache_path_default_location()
 
 # --- `--from-gws`: the calendar is UNKNOWN on failure, never empty ------------


### PR DESCRIPTION
## What

`write_cache` now prints one stderr line when any event in the payload lacks a `start`, naming the count and what it costs. No behavioural change otherwise.

## Why

`morning-briefing._all_starts_known` gates **both** `_next_event` ("Next up") and `_last_event` on *every* event carrying a start. `normalize_events` treats `start` as optional. So a payload shaped exactly as the `morning-briefing` cron prompt describes — "pipe them as a JSON array of `{raw,calendar}`" — silently drops two briefing lines, and nothing anywhere says why.

## Before / after — measured on `main` (9cdadd217), against the real functions

Probe (`normalize_events` → `_all_starts_known`/`_next_event`/`_last_event`):

```
prompt literal {raw,calendar}    keys=['calendar', 'raw']          all_starts_known=False  next_up=NO   last=NO
flat start string                keys=['calendar', 'raw', 'start'] all_starts_known=True   next_up=yes  last=yes
google-shaped start dict         -> TypeError: calendar event `start` must be a rendered display string
```

Row 1 is the defect: the documented pipe shape, silent. Row 3 is **not** a defect — `_display_str` already refuses it loudly, and this PR does not touch that.

`write_cache` on `main` vs this branch, same input:

```
$ python3 -c "...write_cache([{'raw':'09:00 Standup','calendar':'primary'}], path=...)"
main:   (no output)
branch: write_calendar_cache: 1 of 1 event(s) carry no `start` — the briefing will omit its
        'Next up' and 'Last event' lines. Include `start` in each piped event to keep them.
```

Quiet paths stay quiet: an event carrying `start`, `--empty`, and `--from-gws` (which always sets `start` at `src/write_calendar_cache.py:240-241`).

## Tests

```
$ python3 tests/write-calendar-cache.test.py
PASS — 62/62 write-calendar-cache producer tests
```

Mutation control — revert `src/write_calendar_cache.py` to `main`, keep the new test, rerun:

```
FAIL — 2 of 62
```

So the new assertions are attached to this change rather than passing regardless.

Related briefing suites, unchanged and green: `morning-briefing-calendar-google-source`, `morning-briefing-next-not-first`, `morning-briefing-calendar-unavailable`, `briefing-all-clear-verified`.

## Scope

Single concern. This does **not** edit the cron prompt (persistent owner config) and does not change what the briefing renders — it makes the producer report a degradation it was already causing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)