### PR TITLE
fix(daily-insight): "not enough data" is not an insight

### DIFF
--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -5,6 +5,8 @@ Analyzes call logs, task history, and notes to surface one actionable pattern.
 Output: results/insight-{date}.txt (voice agent can speak it).
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -532,7 +532,7 @@ def dev_activity_insight(dev):
             f"({where}); the other {n - landed} are still on branches.")
 
 
-def generate_insight():
+def generate_insight() -> str | None:
     # Real code output is the highest-signal insight — surface it first so a
     # productive day never reads as "you just made some notes" (owner 2026-07-21).
     dev_line = dev_activity_insight(analyze_dev_activity())
@@ -601,7 +601,11 @@ def generate_insight():
         )
 
     if not insights:
-        insights.append("Not enough data yet to generate behavioral insights. Keep using Sutando — patterns will emerge.")
+        # No insight is NOT an insight. Returning prose here made "not enough
+        # data" indistinguishable from a finding to every consumer downstream:
+        # main() wrote it to the delivered results file, and morning-briefing
+        # read it back out of the sentinel and spoke it as "Insight: …".
+        return None
 
     # Pick the most interesting one (longest = most specific)
     best = max(insights, key=len)
@@ -624,6 +628,15 @@ def main():
         return
 
     insight = generate_insight()
+    if insight is None:
+        # Stamp an EMPTY sentinel: it still suppresses same-day regeneration,
+        # and get_daily_insight()'s `.strip() or None` then yields no insight,
+        # so the briefing omits the line instead of reading this back. No
+        # results file, so nothing is delivered either.
+        sentinel.write_text("")
+        print("No insight today — not enough data. Sentinel stamped empty; nothing delivered.")
+        return
+
     output_path.write_text(insight)
     sentinel.write_text(insight)
     print(f"Daily insight → {output_path}")

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -601,10 +601,8 @@ def generate_insight() -> str | None:
         )
 
     if not insights:
-        # No insight is NOT an insight. Returning prose here made "not enough
-        # data" indistinguishable from a finding to every consumer downstream:
-        # main() wrote it to the delivered results file, and morning-briefing
-        # read it back out of the sentinel and spoke it as "Insight: …".
+        # Prose here is indistinguishable from a finding downstream: it gets
+        # written to the delivered results file and spoken by the briefing.
         return None
 
     # Pick the most interesting one (longest = most specific)
@@ -629,10 +627,8 @@ def main():
 
     insight = generate_insight()
     if insight is None:
-        # Stamp an EMPTY sentinel: it still suppresses same-day regeneration,
-        # and get_daily_insight()'s `.strip() or None` then yields no insight,
-        # so the briefing omits the line instead of reading this back. No
-        # results file, so nothing is delivered either.
+        # Empty sentinel still suppresses same-day regeneration, while
+        # get_daily_insight()'s `.strip() or None` yields no insight.
         sentinel.write_text("")
         print("No insight today — not enough data. Sentinel stamped empty; nothing delivered.")
         return

--- a/tests/daily-insight-no-data-is-not-an-insight.test.py
+++ b/tests/daily-insight-no-data-is-not-an-insight.test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+""""Not enough data" must not be delivered AS an insight.
+
+Regression test for an owner-visible falsehood in the 2026-08-25 briefing:
+
+    Insight: Not enough data yet to generate behavioral insights.
+
+`generate_insight()` returned that prose when it had nothing to say, so every
+consumer downstream faithfully treated it as a finding: `main()` wrote it to
+`results/insight-<date>.txt` (which a bridge delivers) and stamped it into the
+sentinel, and `morning-briefing.get_daily_insight()` read it back out of that
+sentinel and spoke it.
+
+morning-briefing already guards the *shape* of an insight — it skips strings
+containing `{` or more than two colons, and anything under 20 characters. A
+prose placeholder passes all three, which is why the guard did not catch this.
+The condition is "the generator had nothing", and only the generator can say so.
+
+Test 2 is the control: a real insight must still be returned and still be
+written, so the fix cannot pass by suppressing everything.
+
+Run: python3 tests/daily-insight-no-data-is-not-an-insight.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("daily_insight", REPO / "src" / "daily-insight.py")
+di = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(di)
+
+failures = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    print(f"{'  ok  ' if ok else 'FAIL  '}{name}{'' if ok else f' — {detail}'}")
+    if not ok:
+        failures.append(name)
+
+
+# 1. Nothing to say → None, not prose.
+di_orig = (di.analyze_dev_activity, di.load_calls, di.analyze_task_patterns, di.analyze_note_activity)
+di.analyze_dev_activity = lambda *a, **k: {}
+di.dev_activity_insight = lambda *a, **k: None
+di.load_calls = lambda *a, **k: []
+di.analyze_task_patterns = lambda *a, **k: None
+di.analyze_note_activity = lambda *a, **k: {"age_known": False, "recent_7d": 0, "total": 0, "top_tags": []}
+got = di.generate_insight()
+check("no data yields None, not placeholder prose", got is None, f"got {got!r}")
+
+# 1b. The exact string that reached the owner must not be produced at all.
+check(
+    "the placeholder string is never returned",
+    got is None or "Not enough data" not in got,
+    f"got {got!r}",
+)
+
+# 2. CONTROL — a real insight is still produced. Without this, returning None
+#    unconditionally would pass test 1.
+di.analyze_dev_activity = di_orig[0]
+di.dev_activity_insight_orig = di.dev_activity_insight
+di.dev_activity_insight = lambda *a, **k: "Shipped 3 PRs and 210 lines of tests today."
+real = di.generate_insight()
+check("a real insight is still returned", real is not None and "Shipped 3 PRs" in str(real), f"got {real!r}")
+di.dev_activity_insight = di.dev_activity_insight_orig
+
+# 3. main() with no insight: sentinel stamped EMPTY (dedupe preserved), and NO
+#    results file — so nothing is delivered.
+with tempfile.TemporaryDirectory() as td:
+    tmp = Path(td)
+    (tmp / "results").mkdir()
+    (tmp / "state").mkdir()
+    di.RESULTS_DIR, di.STATE_DIR = tmp / "results", tmp / "state"
+    di.analyze_dev_activity = lambda *a, **k: {}
+    di.dev_activity_insight = lambda *a, **k: None
+    di.analyze_note_activity = lambda *a, **k: {"age_known": False, "recent_7d": 0, "total": 0, "top_tags": []}
+    di.main()
+    sentinels = list((tmp / "state").glob("daily-insight-*.sentinel"))
+    results = list((tmp / "results").glob("insight-*.txt"))
+    check("sentinel is stamped (same-day dedupe preserved)", len(sentinels) == 1, f"{sentinels}")
+    check("sentinel is EMPTY", sentinels and sentinels[0].read_text().strip() == "",
+          f"{sentinels[0].read_text()!r}" if sentinels else "no sentinel")
+    check("no results file written, so nothing is delivered", results == [], f"{results}")
+
+    # 4. Round trip through the briefing's own reader: an empty sentinel must
+    #    yield no insight, which is what removes the spoken line.
+    body = sentinels[0].read_text().strip() if sentinels else ""
+    check("briefing reader contract (`.strip() or None`) yields None", (body or None) is None)
+
+di.analyze_dev_activity, di.load_calls, di.analyze_task_patterns, di.analyze_note_activity = di_orig
+print("\nFAILED" if failures else "\nAll checks passed")
+raise SystemExit(1 if failures else 0)


### PR DESCRIPTION
## The defect

`generate_insight()` returned prose when it had nothing to say, so every consumer downstream treated it as a finding. Owner-visible in this morning's briefing:

> Insight: Not enough data yet to generate behavioral insights.

Two delivery paths carried it, not one:

- `main()` wrote it to `results/insight-<date>.txt`, which a bridge delivers;
- `main()` also stamped it into the sentinel, and `morning-briefing.get_daily_insight()` read it back out and spoke it.

## Why the existing guard didn't catch it

`morning-briefing` already filters insights (`src/morning-briefing.py:720-725`) — it skips a string containing `{`, or more than two colons, or a first sentence under 20 characters. Those guard the **shape** of an insight. A prose placeholder passes all three.

The actual condition is *"the generator had nothing"*, and only the generator can report that. So the fix belongs at the source rather than as a string match downstream — a downstream match would also break the moment the placeholder wording changed.

## The change

`generate_insight()` now returns `None`. `main()` stamps an **empty** sentinel — which preserves the same-day dedupe the sentinel exists for, while `get_daily_insight()`'s existing `.strip() or None` yields no insight so the briefing simply omits the line — and writes **no** results file, so nothing is delivered.

## Evidence

Test: `tests/daily-insight-no-data-is-not-an-insight.test.py` — 7 checks.

**As shipped:**
```
  ok  no data yields None, not placeholder prose
  ok  the placeholder string is never returned
  ok  a real insight is still returned
  ok  sentinel is stamped (same-day dedupe preserved)
  ok  sentinel is EMPTY
  ok  no results file written, so nothing is delivered
  ok  briefing reader contract (`.strip() or None`) yields None
All checks passed
```

**Against the unpatched source (`git stash` of the fix only) — 5 of 7 fail:**
```
FAIL  no data yields None, not placeholder prose — got 'Not enough data yet to generate behavioral insights. …'
FAIL  the placeholder string is never returned — got 'Not enough data yet to generate behavioral insights. …'
  ok  a real insight is still returned
  ok  sentinel is stamped (same-day dedupe preserved)
FAIL  sentinel is EMPTY — 'Not enough data yet to generate behavioral insights. …'
FAIL  no results file written, so nothing is delivered — [PosixPath('…/results/insight-2026-08-25.txt')]
FAIL  briefing reader contract (`.strip() or None`) yields None —
FAILED
```

That fourth failure is worth pointing at: it prints the actual `results/insight-<date>.txt` the unpatched code writes, which is the file a bridge delivers. I could not confirm the delivery from my own workspace because the bridge unlinks that file on send — the mutation run is what established it.

**"a real insight is still returned" passes in both directions.** That is the control: without it, returning `None` unconditionally would satisfy every other assertion.

## Worst-case disruption, and the mitigation

The behaviour change is that on a no-data day the owner gets **no** insight line and no insight DM, instead of a placeholder. That is the intent, but it is a real change: anyone who reads the daily insight DM as a liveness signal would now see silence on a quiet day rather than a message.

Mitigated by keeping the human-readable line on stdout (`No insight today — not enough data. Sentinel stamped empty; nothing delivered.`), so the cron log still shows the run happened and why it was quiet. Same-day dedupe is unchanged, so this cannot cause repeat generation or repeat DMs.

Scope: one function and one `main()` branch in `src/daily-insight.py`. No config, no schema, no path or flag renames, nothing outside the repo invokes `generate_insight()` directly.
