### PR TITLE
feat(skills): add claude-pi delegate and register pi in claude-router

### DIFF
--- a/skills/claude-pi/SKILL.md
+++ b/skills/claude-pi/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: claude-pi
+description: "Use the local Pi CLI (pi.dev) from Claude Code with the user's existing Pi authentication (Kimi, Claude Pro/Max, or ChatGPT OAuth). Use for second-opinion analysis, implementation, or reviews from a Kimi-family model in the current workspace."
+user-invocable: true
+---
+
+# Claude Pi
+
+Delegate work from Claude Code to the local `pi` CLI (pi.dev). This skill uses whatever
+authentication Pi is already logged into on this machine (`~/.pi/agent/auth.json` — OAuth
+for Kimi, Claude Pro/Max, or ChatGPT). It does not copy or export secrets.
+
+**Usage**: `/claude-pi [prompt]`
+
+ARGUMENTS: $ARGUMENTS
+
+## When to Use
+
+- "Use pi on this repo" / "ask kimi"
+- Need a second opinion from a Kimi-family model (default: `kimi-coding/kimi-for-coding`)
+- Need a non-Anthropic, non-OpenAI, non-Google perspective on a design or diff
+- Need a scripted, non-interactive agent pass (`pi -p`) in the current workspace
+
+## Guardrails
+
+- Default provider/model is `kimi-coding/kimi-for-coding`; override with `--provider`/`--model`.
+- Use `--read-only` for analysis passes — it restricts Pi to its `read` tool (no bash/edit/write).
+- Without `--read-only`, Pi has full tools (read, bash, edit, write) in the working directory —
+  same trust level as a default Codex `workspace-write` run.
+- Keep Pi in the target repo via `--cd`; prefer `--mode json` when another tool consumes the output.
+
+## Quick Checks
+
+```bash
+bash "$SKILL_DIR/scripts/pi-run.sh" --check
+```
+
+## Common Commands
+
+```bash
+# Read-only analysis
+bash "$SKILL_DIR/scripts/pi-run.sh" --read-only -- "Trace how tasks flow from voice input to execution"
+
+# Different provider/model (any Pi is logged into)
+bash "$SKILL_DIR/scripts/pi-run.sh" --provider kimi-coding --model k3 -- "Review the repo structure"
+
+# Machine-readable output
+bash "$SKILL_DIR/scripts/pi-run.sh" --mode json -- "Summarize risks in src/startup.sh"
+
+# Allow edits when the user asked for implementation help
+bash "$SKILL_DIR/scripts/pi-run.sh" -- "Implement a safer startup preflight for missing services"
+```
+
+## If Invoked As A Slash Command
+
+- If ARGUMENTS is empty, explain the available modes and suggest `--read-only` for analysis.
+- If ARGUMENTS is present, run:
+
+```bash
+bash "$SKILL_DIR/scripts/pi-run.sh" -- "$ARGUMENTS"
+```

--- a/skills/claude-pi/manifest.json
+++ b/skills/claude-pi/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "claude-pi",
+  "version": "1.0.0",
+  "owner": "github:sonichi/sutando",
+  "license": "MIT",
+  "stability": "stable",
+  "description": "Use the local Pi CLI (pi.dev) from Claude Code with the user's existing Pi authentication (Kimi, Claude Pro/Max, or ChatGPT OAuth). Use for second-opinion analysis, implementation, or reviews from a Kimi-family model in the current workspace.",
+  "provenance": {
+    "source_repo": "https://github.com/sonichi/sutando"
+  }
+}

--- a/skills/claude-pi/scripts/pi-run.sh
+++ b/skills/claude-pi/scripts/pi-run.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: pi-run.sh [options] -- [prompt]
+
+Wrap the local Pi CLI (pi.dev) from the current repo.
+
+Options:
+  --check                       Verify the pi CLI is installed and the provider is authenticated
+  --provider <name>             Provider name (default: kimi-coding)
+  --model <model>               Model pattern or ID (default: kimi-for-coding)
+  --mode <mode>                 Output mode: text (default) | json
+  --thinking <level>            off | minimal | low | medium | high | xhigh | max
+  --read-only                   Restrict pi to the read tool (no bash/edit/write)
+  --cd <dir>                    Working directory for the Pi run
+  --help                        Show this help
+
+Examples:
+  pi-run.sh -- "Audit the handoff flow in this repository"
+  pi-run.sh --read-only -- "Summarize likely failure modes"
+  pi-run.sh --provider anthropic --model claude-sonnet-5 -- "Review src/outbox.py"
+EOF
+}
+
+fail() {
+  echo "pi-run.sh: $*" >&2
+  exit 1
+}
+
+require_arg() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || fail "missing value for $flag"
+}
+
+CHECK=0
+PROVIDER="kimi-coding"
+MODEL="kimi-for-coding"
+MODE="text"
+THINKING=""
+READ_ONLY=0
+WORKDIR="${PWD}"
+PROMPT_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      CHECK=1
+      shift
+      ;;
+    --provider)
+      require_arg "$1" "${2:-}"
+      PROVIDER="$2"
+      shift 2
+      ;;
+    --model)
+      require_arg "$1" "${2:-}"
+      MODEL="$2"
+      shift 2
+      ;;
+    --mode)
+      require_arg "$1" "${2:-}"
+      MODE="$2"
+      shift 2
+      ;;
+    --thinking)
+      require_arg "$1" "${2:-}"
+      THINKING="$2"
+      shift 2
+      ;;
+    --read-only)
+      READ_ONLY=1
+      shift
+      ;;
+    --cd)
+      require_arg "$1" "${2:-}"
+      WORKDIR="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      PROMPT_ARGS+=("$@")
+      break
+      ;;
+    *)
+      PROMPT_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# The user-local install (~/.local/bin) is not on PATH in cron/bridge shells.
+PI_BIN="$(command -v pi 2>/dev/null || true)"
+[[ -z "$PI_BIN" && -x "$HOME/.local/bin/pi" ]] && PI_BIN="$HOME/.local/bin/pi"
+[[ -n "$PI_BIN" ]] || fail "pi CLI not found in PATH (install: curl -fsSL https://pi.dev/install.sh | sh)"
+
+if [[ "$CHECK" -eq 1 ]]; then
+  echo "pi: $PI_BIN ($("$PI_BIN" --version))"
+  echo "provider: $PROVIDER ($("$PI_BIN" auth check --provider "$PROVIDER"))"
+  exit 0
+fi
+
+if [[ ! -d "$WORKDIR" ]]; then
+  fail "working directory does not exist: $WORKDIR"
+fi
+
+PROMPT="${PROMPT_ARGS[*]-}"
+[[ -n "$PROMPT" ]] || fail "prompt required unless --check is used"
+
+cmd=("$PI_BIN" -p --provider "$PROVIDER" --model "$MODEL")
+[[ "$MODE" != "text" ]] && cmd+=(--mode "$MODE")
+[[ -n "$THINKING" ]] && cmd+=(--thinking "$THINKING")
+[[ "$READ_ONLY" -eq 1 ]] && cmd+=(--tools read)
+cmd+=(-- "$PROMPT")
+
+(
+  cd "$WORKDIR"
+  "${cmd[@]}"
+)

--- a/skills/claude-router/SKILL.md
+++ b/skills/claude-router/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: claude-router
-description: "Choose between the local Codex CLI and Gemini CLI from Claude Code. Use for automatic model selection when the user wants the best local delegate for code review, repo-wide analysis, planning, or implementation."
+description: "Choose between the local Codex CLI, Gemini CLI, and Pi CLI from Claude Code. Use for automatic model selection when the user wants the best local delegate for code review, repo-wide analysis, planning, or implementation."
 user-invocable: true
 ---
 
 # Claude Router
 
-Route a task from Claude Code to either local `codex` or local `gemini` using simple, explicit rules. This skill assumes the dedicated `claude-codex` and `claude-gemini` skills are installed from this repo.
+Route a task from Claude Code to local `codex`, `gemini`, or `pi` using simple, explicit rules. This skill assumes the dedicated `claude-codex`, `claude-gemini`, and `claude-pi` skills are installed from this repo.
 
 **Usage**: `/claude-router [prompt]`
 
@@ -25,7 +25,11 @@ ARGUMENTS: $ARGUMENTS
   - large-context summarization
   - multimodal or structured JSON output requests
 
-If the request explicitly names `codex` or `gemini`, honor that directly.
+- Route to `pi` when:
+  - the request names `pi` or `kimi`
+  - the user wants a Kimi-family second opinion
+
+If the request explicitly names `codex`, `gemini`, or `pi`, honor that directly.
 
 ## When NOT to Use
 
@@ -56,6 +60,9 @@ bash "$SKILL_DIR/scripts/route-ai.sh" --engine codex -- "Inspect src/task-bridge
 
 # Force Gemini
 bash "$SKILL_DIR/scripts/route-ai.sh" --engine gemini -- "Trace task flow across the entire repo"
+
+# Force Pi (Kimi)
+bash "$SKILL_DIR/scripts/route-ai.sh" --engine pi -- "Second opinion on this design"
 
 # Dry-run the route decision without executing
 bash "$SKILL_DIR/scripts/route-ai.sh" --dry-run -- "Summarize architecture risks in this repo"

--- a/skills/claude-router/manifest.json
+++ b/skills/claude-router/manifest.json
@@ -4,7 +4,7 @@
   "owner": "github:sonichi/sutando",
   "license": "MIT",
   "stability": "stable",
-  "description": "Choose between the local Codex CLI and Gemini CLI from Claude Code. Use for automatic model selection when the user wants the best local delegate for code review, repo-wide analysis, planning, or implementation.",
+  "description": "Choose between the local Codex CLI, Gemini CLI, and Pi CLI from Claude Code. Use for automatic model selection when the user wants the best local delegate for code review, repo-wide analysis, planning, or implementation.",
   "provenance": {
     "source_repo": "https://github.com/sonichi/sutando"
   }

--- a/skills/claude-router/scripts/route-ai.sh
+++ b/skills/claude-router/scripts/route-ai.sh
@@ -5,11 +5,11 @@ usage() {
   cat <<'EOF'
 Usage: route-ai.sh [options] -- [prompt]
 
-Route a prompt to codex or gemini.
+Route a prompt to codex, gemini, or pi.
 
 Options:
-  --check                 Verify both local wrappers are present
-  --engine <name>         Force codex or gemini
+  --check                 Verify the local wrappers are present
+  --engine <name>         Force codex, gemini, or pi
   --dry-run               Print the selected engine and command without running it
   --cd <dir>              Working directory for the delegated run
   --help                  Show this help
@@ -35,6 +35,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CODEX_WRAPPER="$SKILLS_DIR/claude-codex/scripts/codex-run.sh"
 GEMINI_WRAPPER="$SKILLS_DIR/claude-gemini/scripts/gemini-run.sh"
+PI_WRAPPER="$SKILLS_DIR/claude-pi/scripts/pi-run.sh"
 
 CHECK=0
 DRY_RUN=0
@@ -80,12 +81,15 @@ done
 
 [[ -x "$CODEX_WRAPPER" ]] || fail "missing Codex wrapper: $CODEX_WRAPPER"
 [[ -x "$GEMINI_WRAPPER" ]] || fail "missing Gemini wrapper: $GEMINI_WRAPPER"
+[[ -x "$PI_WRAPPER" ]] || fail "missing Pi wrapper: $PI_WRAPPER"
 
 if [[ "$CHECK" -eq 1 ]]; then
   echo "codex-wrapper: $CODEX_WRAPPER"
   echo "gemini-wrapper: $GEMINI_WRAPPER"
+  echo "pi-wrapper: $PI_WRAPPER"
   bash "$CODEX_WRAPPER" --check
   bash "$GEMINI_WRAPPER" --check
+  bash "$PI_WRAPPER" --check
   exit 0
 fi
 
@@ -100,6 +104,8 @@ if [[ -z "$ENGINE" ]]; then
     ENGINE="codex"
   elif [[ "$PROMPT_LC" == *"gemini"* ]]; then
     ENGINE="gemini"
+  elif [[ "$PROMPT_LC" == *"kimi"* ]] || [[ "$PROMPT_LC" =~ (^|[^a-z0-9])pi([^a-z0-9]|$) ]]; then
+    ENGINE="pi"
   elif [[ "$PROMPT_LC" == *"review"* ]] || [[ "$PROMPT_LC" == *"diff"* ]] || [[ "$PROMPT_LC" == *"regression"* ]] || [[ "$PROMPT_LC" == *"bug"* ]] || [[ "$PROMPT_LC" == *"implement"* ]] || [[ "$PROMPT_LC" == *"patch"* ]]; then
     ENGINE="codex"
   elif [[ "$PROMPT_LC" == *"architecture"* ]] || [[ "$PROMPT_LC" == *"repo-wide"* ]] || [[ "$PROMPT_LC" == *"entire repo"* ]] || [[ "$PROMPT_LC" == *"whole repo"* ]] || [[ "$PROMPT_LC" == *"trace"* ]] || [[ "$PROMPT_LC" == *"dependency"* ]] || [[ "$PROMPT_LC" == *"dependencies"* ]] || [[ "$PROMPT_LC" == *"summarize"* ]] || [[ "$PROMPT_LC" == *"json"* ]] || [[ "$PROMPT_LC" == *"multimodal"* ]]; then
@@ -115,6 +121,9 @@ case "$ENGINE" in
     ;;
   gemini)
     cmd=(bash "$GEMINI_WRAPPER" --cd "$WORKDIR" --approval-mode plan -- "$PROMPT")
+    ;;
+  pi)
+    cmd=(bash "$PI_WRAPPER" --cd "$WORKDIR" --read-only -- "$PROMPT")
     ;;
   *)
     fail "unsupported engine: $ENGINE"

--- a/tests/claude-pi-wrapper.test.py
+++ b/tests/claude-pi-wrapper.test.py
@@ -1,0 +1,121 @@
+"""Smoke test for skills/claude-pi/scripts/pi-run.sh and its claude-router wiring.
+
+Mocks the pi binary in PATH and verifies:
+  1. Default invocation uses -p with the kimi-coding provider/model defaults.
+  2. --read-only restricts pi to the read tool.
+  3. --mode json and --thinking are forwarded; text mode adds no --mode flag.
+  4. Prompt is required unless --check is used.
+  5. route-ai.sh routes "kimi"/word-"pi" prompts to the pi wrapper (dry-run),
+     but does not fire on substrings like "api" or "pipeline".
+
+Run: python3 tests/claude-pi-wrapper.test.py
+"""
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "skills" / "claude-pi" / "scripts" / "pi-run.sh"
+ROUTER = REPO / "skills" / "claude-router" / "scripts" / "route-ai.sh"
+
+
+def make_mock_pi(tmpdir: Path) -> Path:
+    bin_dir = tmpdir / "bin"
+    bin_dir.mkdir()
+    mock = bin_dir / "pi"
+    mock.write_text(
+        "#!/bin/bash\n"
+        'if [[ "${1:-}" == "--version" ]]; then echo 0.0.0-mock; exit 0; fi\n'
+        'if [[ "${1:-}" == "auth" ]]; then echo ready; exit 0; fi\n'
+        "printf '%s\\n' \"$@\" >\"$PI_MOCK_OUT\"\n"
+    )
+    mock.chmod(0o755)
+    return bin_dir
+
+
+def run(script: Path, bin_dir: Path, *args: str, mock_out: Path) -> tuple[int, str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["PI_MOCK_OUT"] = str(mock_out)
+    proc = subprocess.run(
+        ["bash", str(script), *args], env=env, capture_output=True, text=True
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def test_defaults(bin_dir: Path, mock_out: Path) -> None:
+    rc, _ = run(SCRIPT, bin_dir, "--", "Plain prompt", mock_out=mock_out)
+    assert rc == 0
+    argv = mock_out.read_text().splitlines()
+    assert "-p" in argv, f"missing -p (non-interactive): {argv}"
+    assert "kimi-coding" in argv, f"default provider missing: {argv}"
+    assert "kimi-for-coding" in argv, f"default model missing: {argv}"
+    assert "Plain prompt" in argv, f"prompt missing: {argv}"
+    assert "--mode" not in argv, f"--mode leaked in text mode: {argv}"
+    assert "--tools" not in argv, f"--tools leaked without --read-only: {argv}"
+
+
+def test_read_only(bin_dir: Path, mock_out: Path) -> None:
+    rc, _ = run(SCRIPT, bin_dir, "--read-only", "--", "x", mock_out=mock_out)
+    assert rc == 0
+    argv = mock_out.read_text().splitlines()
+    i = argv.index("--tools")
+    assert argv[i + 1] == "read", f"--read-only did not restrict tools: {argv}"
+
+
+def test_mode_and_thinking_forwarded(bin_dir: Path, mock_out: Path) -> None:
+    rc, _ = run(
+        SCRIPT, bin_dir, "--mode", "json", "--thinking", "high", "--", "x",
+        mock_out=mock_out,
+    )
+    assert rc == 0
+    argv = mock_out.read_text().splitlines()
+    assert argv[argv.index("--mode") + 1] == "json", f"mode not forwarded: {argv}"
+    assert argv[argv.index("--thinking") + 1] == "high", f"thinking not forwarded: {argv}"
+
+
+def test_prompt_required(bin_dir: Path, mock_out: Path) -> None:
+    rc, out = run(SCRIPT, bin_dir, mock_out=mock_out)
+    assert rc != 0, "expected non-zero exit without prompt"
+    assert "prompt required" in out, f"missing guard message: {out}"
+
+
+def route_engine(bin_dir: Path, mock_out: Path, prompt: str) -> str:
+    rc, out = run(ROUTER, bin_dir, "--dry-run", "--", prompt, mock_out=mock_out)
+    assert rc == 0, f"router failed on {prompt!r}: {out}"
+    for line in out.splitlines():
+        if line.startswith("engine: "):
+            return line.split(": ", 1)[1]
+    raise AssertionError(f"no engine line in: {out}")
+
+
+def test_router_pi_routing(bin_dir: Path, mock_out: Path) -> None:
+    assert route_engine(bin_dir, mock_out, "ask kimi about this design") == "pi"
+    assert route_engine(bin_dir, mock_out, "use pi to check this") == "pi"
+    assert route_engine(bin_dir, mock_out, "audit the api surface") != "pi"
+    assert route_engine(bin_dir, mock_out, "clean up the pipeline") != "pi"
+
+
+def main() -> None:
+    assert SCRIPT.exists(), f"missing: {SCRIPT}"
+    assert ROUTER.exists(), f"missing: {ROUTER}"
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        bin_dir = make_mock_pi(tmp)
+        for fn in (
+            test_defaults,
+            test_read_only,
+            test_mode_and_thinking_forwarded,
+            test_prompt_required,
+            test_router_pi_routing,
+        ):
+            mock_out = tmp / f"{fn.__name__}.argv"
+            fn(bin_dir, mock_out)
+            print(f"PASS {fn.__name__}")
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds Pi (pi.dev) as a third local delegate alongside Codex and Gemini:

- **`skills/claude-pi/`** — new skill mirroring `claude-gemini`/`claude-codex`: `scripts/pi-run.sh` wraps non-interactive `pi -p`, defaulting to the `kimi-coding/kimi-for-coding` OAuth provider (overridable via `--provider`/`--model`), with `--read-only` (restricts Pi to its `read` tool), `--mode json`, `--thinking`, `--cd`, and `--check`. Resolves `~/.local/bin/pi` when PATH lacks it (cron/bridge shells).
- **`skills/claude-router/`** — registers `pi` as an engine: `--engine pi`, auto-route on `kimi` or word-bounded `pi` in the prompt (substrings like "api"/"pipeline" do not fire), `--check` covers the new wrapper. Auto-routed pi runs are read-only, matching gemini's plan-mode default.
- **`tests/claude-pi-wrapper.test.py`** — mock-binary test in the style of `tests/claude-codex-goal-flag.test.py`: wrapper arg forwarding + the router routing table.

## Why

Owner logged Pi into Kimi (plus Claude/ChatGPT OAuth) and asked to integrate it as a delegate. Per the decision guide this is a self-contained feature → skill; router changes are the minimal registration.

## Evidence

**Before (at parent `cbb4fc33`, via temp worktree):**
```
$ route-ai.sh --dry-run -- "ask kimi for a second opinion on this diff"
engine: codex
$ route-ai.sh --engine pi --dry-run -- "x"
route-ai.sh: unsupported engine: pi
```

**After (HEAD):**
```
$ route-ai.sh --dry-run -- "ask kimi for a second opinion on this diff"
engine: pi
command: bash .../skills/claude-pi/scripts/pi-run.sh --cd /Users/john/ag2/sutando --read-only -- ask\ kimi\ for\ a\ second\ opinion\ on\ this\ diff

$ pi-run.sh --check
pi: /Users/john/.local/bin/pi (0.84.3)
provider: kimi-coding (ready)

$ pi-run.sh --read-only --cd . -- "Reply with exactly: PI-DELEGATE-OK"   # live run against Kimi
PI-DELEGATE-OK

$ python3 tests/claude-pi-wrapper.test.py
PASS test_defaults
PASS test_read_only
PASS test_mode_and_thinking_forwarded
PASS test_prompt_required
PASS test_router_pi_routing
OK

$ python3 tests/claude-codex-goal-flag.test.py   # existing wrapper test, no regression
OK

$ git diff main | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

Not a live bridge/delivery path — the wrapper is invoked on demand (slash command / router); the live proof above is the real `pi -p` round trip through the wrapper against the Kimi provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
