### PR TITLE
feat(health-check): a degraded secret scanner is invisible between boots

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -650,6 +650,62 @@ def resolve_node_runtime(env: Optional[dict] = None, which=shutil.which) -> dict
     return {"source": "none", "path": None}
 
 
+# Bridges that import vault_intercept, and so need detect-secrets at RUNTIME.
+# Mirrors the three _vault_scanner_check call sites in src/startup.sh.
+_VAULT_SCANNER_BRIDGES = ["telegram-bridge", "discord-bridge", "slack-bridge"]
+
+
+def check_secret_scanner_mode() -> dict:
+    """Report the secret scanner's DEGRADED mode as standing status.
+
+    startup.sh names it once at boot and vault_intercept names it at the moment
+    a `vault set` is refused; nothing reports it in between, so a host scans
+    inbound bridge text with 17 provider detectors off and health-check still
+    prints no failures.
+    """
+    degraded, checked = [], []
+    for bridge in _VAULT_SCANNER_BRIDGES:
+        interp = _bridge_interpreter(bridge)
+        if interp is None:
+            continue  # bridge cannot launch at all; its own probe owns that
+        if interp in checked:
+            continue
+        checked.append(interp)
+        try:
+            probe = subprocess.run([interp, "-c", "import detect_secrets"],
+                                   capture_output=True, timeout=10)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            return {
+                "name": "secret-scanner",
+                "status": "warn",
+                "detail": f"could not probe {interp} for detect-secrets ({exc}) — mode unknown, not proven healthy",
+            }
+        if probe.returncode != 0:
+            degraded.append(interp)
+    if not checked:
+        return {
+            "name": "secret-scanner",
+            "status": "warn",
+            "detail": "no launchable bridge interpreter found — scanner mode unknown",
+        }
+    if not degraded:
+        return {
+            "name": "secret-scanner",
+            "status": "ok",
+            "detail": f"detect-secrets present in all {len(checked)} bridge interpreter(s)",
+        }
+    fix = f"{degraded[0]} -m pip install detect-secrets"
+    return {
+        "name": "secret-scanner",
+        "status": "warn",
+        "detail": (f"DEGRADED in {len(degraded)}/{len(checked)} bridge interpreter(s) "
+                   f"({', '.join(degraded)}): detect-secrets missing, so its provider "
+                   f"detectors and entropy checks are off and inbound text is scanned by "
+                   f"repo-local whole-line rules only; unquoted `vault set` is REFUSED. "
+                   f"Fix: {fix} (add --break-system-packages if PEP 668 blocks it)"),
+    }
+
+
 def check_node_runtime() -> dict:
     """Surface WHICH node the JS services resolve to — or a loud red line when
     none exists. The 2026-07-13 outage class: an interactive terminal finding
@@ -9040,6 +9096,7 @@ def run_all_checks() -> list[dict]:
     # G1.5: which Node would JS services resolve to (bundled/app-bundle/
     # system), red when none — the silent-dead-services failure class.
     checks.append(check_node_runtime())
+    checks.append(check_secret_scanner_mode())
     # Comm-handling liveness (P1): loud when the owner-comm sweep goes stale.
     checks.append(check_comm_sweep_freshness())
     checks.extend(check_dynamic_loop_freshness())

--- a/tests/health-check-secret-scanner-mode.test.py
+++ b/tests/health-check-secret-scanner-mode.test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""A degraded secret scanner is invisible: startup.sh names it once at boot and
+vault_intercept names it only when a `vault set` is refused."""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from unittest import mock
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+sys.modules["hc"] = hc
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+
+def _run(interp_map, import_rc):
+    """Probe with _bridge_interpreter and the detect_secrets import both stubbed."""
+    def fake_interp(name):
+        return interp_map.get(name)
+
+    def fake_run(argv, **kw):
+        return subprocess.CompletedProcess(argv, import_rc.get(argv[0], 0))
+
+    with mock.patch.object(hc, "_bridge_interpreter", fake_interp), \
+         mock.patch.object(hc.subprocess, "run", fake_run):
+        return hc.check_secret_scanner_mode()
+
+
+ALL_THREE = {"telegram-bridge": "/py/a", "discord-bridge": "/py/b", "slack-bridge": "/py/c"}
+
+
+class SecretScannerModeIsStandingStatus(unittest.TestCase):
+    def test_all_interpreters_have_it(self):
+        r = _run(ALL_THREE, {})
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("3 bridge interpreter", r["detail"])
+
+    def test_one_degraded_interpreter_warns_and_names_it(self):
+        r = _run(ALL_THREE, {"/py/b": 1})
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("/py/b", r["detail"])
+        self.assertIn("1/3", r["detail"])
+
+    def test_fix_hint_names_the_degraded_interpreter_not_bare_python3(self):
+        # startup.sh's lesson: the fix must name THIS interpreter, because the
+        # bridges rarely run the python3 first on PATH.
+        r = _run(ALL_THREE, {"/py/c": 1})
+        self.assertIn("/py/c -m pip install detect-secrets", r["detail"])
+
+    def test_duplicate_interpreters_are_probed_once(self):
+        r = _run({k: "/py/same" for k in ALL_THREE}, {})
+        self.assertIn("1 bridge interpreter", r["detail"])
+
+    def test_unlaunchable_bridges_are_skipped_not_counted_degraded(self):
+        # _bridge_interpreter returns None when no candidate can import the
+        # bridge's client lib; that bridge's own probe owns the failure.
+        r = _run({"telegram-bridge": "/py/a", "discord-bridge": None,
+                  "slack-bridge": None}, {})
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("1 bridge interpreter", r["detail"])
+
+    def test_no_launchable_interpreter_is_unknown_not_healthy(self):
+        r = _run({k: None for k in ALL_THREE}, {})
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("unknown", r["detail"])
+
+    def test_a_failed_probe_is_unknown_not_healthy(self):
+        # An OSError/timeout must never read as "detect-secrets is present".
+        def boom(argv, **kw):
+            raise OSError("no such interpreter")
+        with mock.patch.object(hc, "_bridge_interpreter", lambda n: ALL_THREE.get(n)), \
+             mock.patch.object(hc.subprocess, "run", boom):
+            r = hc.check_secret_scanner_mode()
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("not proven healthy", r["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The gap

`src/secret_scanner.py` degrades to repo-local whole-line rules when `detect_secrets` is absent (#3103). In that mode its provider detectors and entropy checks are off for every inbound bridge message, and `vault_intercept` refuses every unquoted `vault set`.

Two places report it, and both are **event-time**:

- `src/startup.sh:1007` `_vault_scanner_check`, called at three sites (telegram/discord/slack) — once, at boot.
- `src/vault_intercept.py:265` — at the moment a `vault set` is refused.

Nothing reports it in between. `health-check.py` is the standing status surface the proactive loop runs every pass, and it has no probe for this, so a host with a degraded scanner reads as clean.

## Before / after, on a host that is actually degraded

At the parent commit — the probe simply is not there:

```
$ python3 src/health-check.py 2>/dev/null | grep -i secret-scanner
(no output)
```

At this head:

```
$ python3 src/health-check.py 2>/dev/null | grep -i secret-scanner
  ⚠ secret-scanner   warn   DEGRADED in 1/1 bridge interpreter(s) (/usr/local/bin/python3):
  detect-secrets missing, so its provider detectors and entropy checks are off and inbound text
  is scanned by repo-local whole-line rules only; unquoted `vault set` is REFUSED.
  Fix: /usr/local/bin/python3 -m pip install detect-secrets (add --break-system-packages if PEP 668 blocks it)
```

Independently corroborated on the same host: importing the scanner prints its own `[secret-scanner] mode: DEGRADED — detect-secrets missing` to stderr, which is the state health-check was silent about.

## Why per interpreter

`startup.sh` already checks this **per interpreter**, and says why in its own comment: each bridge is launched with whichever python had *its* client library, and those are frequently not the same binary. This reuses the existing `_bridge_interpreter()` resolver so the probe answers about the binary a bridge is actually launched with, dedupes when several resolve to the same path, and puts that interpreter — not a bare `python3` — in the fix hint.

## Fails safe in both unknown directions

- A bridge whose interpreter cannot be resolved is **skipped**, not counted healthy — that bridge's own probe owns the failure.
- A probe that raises `OSError`/timeout reports `mode unknown, not proven healthy` rather than `ok`. An unavailable check is not evidence of health.
- If no interpreter resolves at all, the result is `warn: unknown`, never `ok`.

## Test evidence

`tests/health-check-secret-scanner-mode.test.py`, 7 cases. Against **this** head:

```
Ran 7 tests in 0.000s
OK
```

Against the **unpatched** `health-check.py` with the new test present — i.e. the tests exercise the missing behaviour rather than passing vacuously:

```
Ran 7 tests in 0.001s
FAILED (errors=7)
```

`scripts/review-checks.sh` on the diff → `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`.
`ruff check` on both touched files → `All checks passed!`

## What I did NOT verify

- **The telegram lane inherits an approximation.** `_bridge_interpreter()` returns `sys.executable` for bridges with no hard import gate, so for telegram this probes health-check's own interpreter rather than the one launchd starts the bridge with. That is pre-existing helper behaviour, not introduced here, but it means the telegram answer is an approximation and I have not measured a case where the two diverge.
- I did not exercise the `slack-bridge` lane on a host that has `slack_bolt` installed; on this host that candidate resolves to `None` and is skipped by design.
- No post-restart round trip — this is a read-only probe in a diagnostic script, with no live path or delivery loop involved.

## Scope

One probe function plus its call site, and one new test file. No change to `secret_scanner.py`, `vault_intercept.py`, or `startup.sh`; nothing about *whether* to install detect-secrets, only about reporting the state that already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)