### PR TITLE
fix(tests): the vault suite passes while writing the owner's real key manifest

### DIFF
--- a/tests/vault-intercept.test.py
+++ b/tests/vault-intercept.test.py
@@ -2,12 +2,17 @@
 """Tests for src/vault_intercept.py — bridge-level secret interception.
 
 All Keychain writes are mocked: no real 'security' subprocess is spawned,
-secrets never touch the test runner's Keychain.
+secrets never touch the test runner's Keychain. The manifest is redirected to
+a temp dir for the whole module (setUpModule) — mocking `subprocess.run` stops
+the Keychain half of a store, but `_store_in_keychain` calls `_register_key`
+afterwards, so an unredirected run writes fake key names into the real
+`<workspace>/state/secret-vault/keys.json`.
 """
 
 import importlib.util
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -48,9 +53,79 @@ import vault_intercept
 from vault_intercept import InterceptResult, intercept_vault_commands, redact_vault_commands
 
 
+_manifest_tmp = None
+_manifest_patches = []
+
+
+def setUpModule():
+    """Point the manifest at a temp dir before any test can write one.
+
+    Redirection is module-wide, not per-test: only 14 of the ~44 store-path
+    call sites here go through `_mock_store`, and a test added later that
+    forgets it would write the real manifest again.
+    """
+    global _manifest_tmp
+    _manifest_tmp = tempfile.TemporaryDirectory(prefix="vault-intercept-test-")
+    fake = os.path.join(_manifest_tmp.name, "keys.json")
+    _manifest_patches.extend([
+        patch.object(vault_intercept, "_manifest_path", return_value=fake),
+        # _read_manifest consults the legacy home-dir path directly, so a real
+        # one on the runner would still be read (and re-written) without this.
+        patch.object(vault_intercept, "_LEGACY_MANIFEST_PATH", fake),
+    ])
+    for p in _manifest_patches:
+        p.start()
+
+
+def tearDownModule():
+    for p in reversed(_manifest_patches):
+        p.stop()
+    _manifest_patches.clear()
+    if _manifest_tmp is not None:
+        _manifest_tmp.cleanup()
+
+
 def _mock_store(monkeypatch=None):
     """Return a patcher for subprocess.run that always succeeds."""
     return patch("vault_intercept.subprocess.run", return_value=MagicMock(returncode=0))
+
+
+class TestHermeticManifest(unittest.TestCase):
+    """The suite must not register key names in the real vault manifest.
+
+    `_mock_store` stops the `security` subprocess, which is why no secret VALUE
+    leaks — but `_store_in_keychain` treats returncode 0 as success and calls
+    `_register_key`, so the NAME still lands in whatever manifest resolves.
+    """
+
+    def _real_manifest_path(self):
+        from workspace_default import resolve_workspace
+        return os.path.join(
+            str(resolve_workspace()), "state", "secret-vault", "keys.json"
+        )
+
+    def test_manifest_path_is_redirected(self):
+        self.assertNotEqual(vault_intercept._manifest_path(), self._real_manifest_path())
+
+    def test_store_writes_the_temp_manifest_and_not_the_real_one(self):
+        real = self._real_manifest_path()
+        before = None
+        if os.path.exists(real):
+            with open(real) as f:
+                before = f.read()
+
+        with _mock_store():
+            vault_intercept.set_vault_key("HERMETIC_PROBE", "sk-" + "a" * 20)
+
+        # Positive control: a redirection that silently swallowed the write
+        # would pass the real-file-unchanged assertion below on its own.
+        self.assertIn("HERMETIC_PROBE", vault_intercept.list_vault_keys())
+
+        after = None
+        if os.path.exists(real):
+            with open(real) as f:
+                after = f.read()
+        self.assertEqual(before, after, f"suite wrote the real manifest at {real}")
 
 
 class TestNoVaultCommands(unittest.TestCase):
@@ -523,6 +598,7 @@ if __name__ == "__main__":
         TestSingleVaultSet,
         TestUnrecognizedValueFailsClosed,
         TestMultipleVaultSets,
+        TestHermeticManifest,
         TestKeychainInteraction,
         TestRedactVaultCommands,
         TestErrorHandling,


### PR DESCRIPTION
## The defect

`tests/vault-intercept.test.py` mocks `vault_intercept.subprocess.run`, so the `security add-generic-password` call never runs and **no secret value ever leaves the test**. That half is correct and the module docstring says so.

The other half is not mocked. `_store_in_keychain` treats `returncode == 0` as success and calls `_register_key()`, which writes to whatever `_manifest_path()` resolves — on a developer's machine, their live `<workspace>/state/secret-vault/keys.json`.

So the suite registers its fixture key names (`FOO`, `A`, `B`, `C`, `API_KEY`, `APOLLO_KEY`, `TOKEN`, `KEY1`, `KEY2`, `K`, `MYKEY`, `MY_KEY`, `MY_SECRET`) in the real manifest, **and reports `OK` while doing it**. Nothing fails at test time.

What fails is later and somewhere else: `list_vault_keys()` then advertises 13 names that `get_vault_key()` raises `KeyError` for, and health-check's `vault-manifest` probe reports the divergence as a standing warning. #2623 added that probe; the producer was never fixed.

This is the failure class already documented in `tests/channel-token-vault-fallback.test.py`'s docstring ("it wrote a fake token into the owner's live Keychain, added a manifest entry, and flipped their own credential probe from GUTTED to ok"). That suite guards against it with `test_hermetic_no_real_vault`; this one didn't.

## Before / after

Run in a clean worktree so the repo-default workspace (`<repo>/workspace/`) starts absent, with `detect-secrets` installed so the suite is green either way.

**Parent commit (`7da709a`):**

```
$ rm -rf workspace && python tests/vault-intercept.test.py 2>&1 | tail -4
----------------------------------------------------------------------
Ran 49 tests in 0.133s

OK
$ ls workspace/state/secret-vault/keys.json && python3 -c "import json;print(sorted(json.load(open('workspace/state/secret-vault/keys.json'))))"
workspace/state/secret-vault/keys.json
['A', 'API_KEY', 'APOLLO_KEY', 'B', 'C', 'FOO', 'K', 'KEY1', 'KEY2', 'MYKEY', 'MY_KEY', 'MY_SECRET', 'TOKEN']
```

A passing suite that just wrote 13 phantom entries into the real manifest.

**This commit (`a521471`):**

```
$ rm -rf workspace && python tests/vault-intercept.test.py 2>&1 | tail -4
----------------------------------------------------------------------
Ran 51 tests in 0.171s

OK
$ ls workspace/state/secret-vault/keys.json
ls: workspace/state/secret-vault/keys.json: No such file or directory
```

## The new tests fail without the fix

Negative control — same file with `setUpModule`'s body replaced by `return`:

```
test_manifest_path_is_redirected ... FAIL
test_store_writes_the_temp_manifest_and_not_the_real_one ... FAIL
AssertionError: ... : suite wrote the real manifest at <workspace>/state/secret-vault/keys.json
```

The control run also emitted `vault: read legacy manifest (~/.sutando-secret-vault/keys.json); migrating to <workspace>/state/secret-vault/ on next write.` — which is how a legacy manifest's contents get pulled into a fresh workspace by a test run.

## Why module-wide, not inside `_mock_store`

Only 14 of the ~44 store-path call sites in this file go through `_mock_store`. Fixing the helper leaves the rest — and any test added later that forgets it — still writing the real manifest. `setUpModule` cannot be bypassed by a future test.

`_LEGACY_MANIFEST_PATH` is redirected alongside `_manifest_path` because `_read_manifest` consults it directly; without that, a real legacy manifest on the runner is still read, and its contents re-written into the resolved workspace.

`TestHermeticManifest` carries a positive control (`assertIn("HERMETIC_PROBE", list_vault_keys())`) so a redirection that silently swallowed the write can't pass the real-file-unchanged assertion on its own.

## Scope

Tests only — no production code touched. `tests/vault-skill.test.py` and `tests/channel-token-vault-fallback.test.py` are already hermetic; `tests/secret-scanner-degraded-mode.test.py` only exercises the REFUSED path and never reaches `_register_key`. This is the last suite in the class.

Not a live path (no bridge, network, delivery loop, or startup code), so no post-restart round trip applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)