### PR TITLE
fix(health-check): a gateway sidecar too stale to read is evidence, not silence

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5556,9 +5556,8 @@ def check_gateway_bridge() -> "dict | None":
         }
     if verdict is True:
         return {"name": "gateway-bridge", "status": "ok", "detail": "running + connected"}
-    # A sidecar too STALE to consult is evidence the writer stopped, not absence
-    # of evidence: the bridge rewrites it on every poll outcome, so silence past
-    # the freshness window outranks whatever `connected` it froze on.
+    # The bridge rewrites this file on every poll outcome, so silence past the
+    # freshness window means the writer stopped — evidence, not absence of it.
     stale_age = _gateway_status_stale_age_s()
     if stale_age is not None:
         return {

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5556,6 +5556,21 @@ def check_gateway_bridge() -> "dict | None":
         }
     if verdict is True:
         return {"name": "gateway-bridge", "status": "ok", "detail": "running + connected"}
+    # A sidecar too STALE to consult is evidence the writer stopped, not absence
+    # of evidence: the bridge rewrites it on every poll outcome, so silence past
+    # the freshness window outranks whatever `connected` it froze on.
+    stale_age = _gateway_status_stale_age_s()
+    if stale_age is not None:
+        return {
+            "name": "gateway-bridge",
+            "status": "warn",
+            "detail": (
+                f"process running but its status sidecar has not been written for "
+                f"{stale_age:.0f}s (freshness window {GATEWAY_STATUS_MAX_AGE_S:.0f}s) — "
+                "the bridge is not reporting poll outcomes, so ag2.space mobile "
+                "messages may not be delivered"
+            ),
+        }
     return {"name": "gateway-bridge", "status": "ok", "detail": "running"}
 
 
@@ -5690,6 +5705,27 @@ def check_runtime_identity(path: "Path | None" = None,
                           + " ".join(bits)}
     return {"name": name, "status": "ok",
             "detail": ("entrypoint=canonical " + " ".join(bits))}
+
+
+def _gateway_status_stale_age_s(path: "Path | None" = None,
+                                now: "float | None" = None) -> "float | None":
+    """Age of the sidecar's `ts` when it is present, usable, and PAST the
+    freshness window; None when absent/unreadable/malformed or still fresh.
+
+    Distinct from `_gateway_serving()` returning None, which folds "no sidecar"
+    together with "sidecar stopped being written" — only the latter is a signal.
+    """
+    import time as _time
+    p = path or (status_read_path("gateway-status.json", WORKSPACE_DIR))
+    now = _time.time() if now is None else now
+    try:
+        ts = json.loads(Path(p).read_text()).get("ts")
+    except (OSError, ValueError, AttributeError, TypeError):
+        return None
+    if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+        return None
+    age = now - ts
+    return age if age > GATEWAY_STATUS_MAX_AGE_S else None
 
 
 def _gateway_serving(path: "Path | None" = None, now: "float | None" = None) -> "bool | None":

--- a/tests/health-check-gateway-bridge.test.py
+++ b/tests/health-check-gateway-bridge.test.py
@@ -54,7 +54,7 @@ def _pgrep(returncode, stdout):
 
 
 def _run(*, env=None, gw_env_path=None, pgrep_rc=1, pgrep_out="", pgrep_raises=False, serving=None,
-         locks=None):
+         locks=None, stale_age=None):
     """Call check_gateway_bridge() with env, the channel-.env path, and the
     pgrep result all controlled. env=None means the token vars are cleared.
     pgrep_raises=True makes subprocess.run raise (the except-branch path).
@@ -62,7 +62,10 @@ def _run(*, env=None, gw_env_path=None, pgrep_rc=1, pgrep_out="", pgrep_raises=F
     case depends on whether the host running the tests happens to have a live
     sidecar — without it, "one process -> ok" flips to warn on a real host.
     `locks` pins the role->PID instance-lock map; the default {} means "no lock
-    data", so no case reads the real state/locks/ of the host running them."""
+    data", so no case reads the real state/locks/ of the host running them.
+    `stale_age` pins the sidecar-staleness signal for the same reason `serving`
+    is pinned: unpinned, every serving=None case would read the host's own
+    sidecar and flip to warn on a machine whose bridge stopped writing one."""
     env = env or {}
     # Clear both token vars, then apply the requested env.
     base = {k: v for k, v in hc.os.environ.items()
@@ -74,6 +77,8 @@ def _run(*, env=None, gw_env_path=None, pgrep_rc=1, pgrep_out="", pgrep_raises=F
          unittest.mock.patch.object(hc, "claude_home_path", return_value=gw_env_path), \
          unittest.mock.patch.object(hc.subprocess, "run", run_mock):
         with unittest.mock.patch.object(hc, "_gateway_serving", lambda *a, **k: serving), \
+             unittest.mock.patch.object(hc, "_gateway_status_stale_age_s",
+                                        lambda *a, **k: stale_age), \
              unittest.mock.patch.object(hc, "_gateway_lock_pids", lambda: dict(locks or {})):
             return hc.check_gateway_bridge()
 
@@ -253,6 +258,35 @@ def main() -> int:
           hc._gateway_serving(_sc({"connected": True}), now) is None)
     check("_gateway_serving: absent file → None",
           hc._gateway_serving(Path(_tf.mkdtemp()) / "nope.json", now) is None)
+
+    # 7b) A sidecar too STALE to consult is evidence, not silence. Before this,
+    # _gateway_serving()'s None sent the probe to its process-only "ok" branch,
+    # so a bridge that stopped writing outcomes entirely read as healthy —
+    # strictly worse than the connected:false the same file was frozen on.
+    check("_gateway_status_stale_age_s: fresh → None",
+          hc._gateway_status_stale_age_s(_sc({"connected": True, "ts": now}), now) is None)
+    check("_gateway_status_stale_age_s: stale → the age in seconds",
+          abs((hc._gateway_status_stale_age_s(
+              _sc({"connected": False, "ts": now - 4000}), now) or 0) - 4000) < 2)
+    check("_gateway_status_stale_age_s: absent file → None (old build, no opinion)",
+          hc._gateway_status_stale_age_s(Path(_tf.mkdtemp()) / "nope.json", now) is None)
+    check("_gateway_status_stale_age_s: malformed ts → None",
+          hc._gateway_status_stale_age_s(_sc({"connected": True, "ts": "soon"}), now) is None)
+    check("_gateway_status_stale_age_s: bool ts is not a number → None",
+          hc._gateway_status_stale_age_s(_sc({"connected": True, "ts": True}), now) is None)
+
+    r = _run(env={"REMOTE_TASK_TOKEN": "t"}, pgrep_rc=0, pgrep_out="123",
+             serving=None, stale_age=3850.0)
+    check("probe: running + stale sidecar → warn naming the age",
+          r["status"] == "warn" and "3850s" in r["detail"], f"got {r!r}")
+    r = _run(env={"REMOTE_TASK_TOKEN": "t"}, pgrep_rc=0, pgrep_out="123",
+             serving=None, stale_age=None)
+    check("probe: running + NO sidecar → still ok (no opinion, not a fault)",
+          r["status"] == "ok" and r["detail"] == "running", f"got {r!r}")
+    r = _run(env={"REMOTE_TASK_TOKEN": "t"}, pgrep_rc=0, pgrep_out="123",
+             serving=True, stale_age=9999.0)
+    check("probe: a fresh connected verdict outranks any staleness signal",
+          r["status"] == "ok" and "connected" in r["detail"], f"got {r!r}")
 
     # --- _gateway_configured(): the shared predicate itself -----------------
     with _tf.TemporaryDirectory() as _td:

--- a/tests/health-check-gateway-bridge.test.py
+++ b/tests/health-check-gateway-bridge.test.py
@@ -259,10 +259,8 @@ def main() -> int:
     check("_gateway_serving: absent file → None",
           hc._gateway_serving(Path(_tf.mkdtemp()) / "nope.json", now) is None)
 
-    # 7b) A sidecar too STALE to consult is evidence, not silence. Before this,
-    # _gateway_serving()'s None sent the probe to its process-only "ok" branch,
-    # so a bridge that stopped writing outcomes entirely read as healthy —
-    # strictly worse than the connected:false the same file was frozen on.
+    # 7b) Stale sidecar. Before this, _gateway_serving()'s None sent the probe
+    # to its process-only "ok" branch, so a stopped writer read as healthy.
     check("_gateway_status_stale_age_s: fresh → None",
           hc._gateway_status_stale_age_s(_sc({"connected": True, "ts": now}), now) is None)
     check("_gateway_status_stale_age_s: stale → the age in seconds",


### PR DESCRIPTION
## The bug

`check_gateway_bridge` asks `_gateway_serving()` whether the bridge is serving. That helper returns `None` for **three different situations**, and all three fell through to the same process-only `ok — running` branch:

1. no sidecar at all (an old build — genuinely no opinion)
2. an unreadable/malformed sidecar
3. a sidecar whose `ts` is older than `GATEWAY_STATUS_MAX_AGE_S`

The third one is not absence of evidence. `remote-gateway-bridge.py` rewrites that file on **every** poll outcome, so silence past the freshness window means the writer stopped. The probe then reports *healthier* than it would have on the very same file one second before it aged out — when `connected: false` produced a `warn`.

## Before / after

Both runs drive `check_gateway_bridge()` with `pgrep` pinned to one running pid and the sidecar pinned to a temp file, so the only variable is the probe. `PARENT` is `git show HEAD:src/health-check.py` at `7da709a`.

```
--- PARENT ---
  bridge stopped writing 4000s ago, last wrote connected:false
    -> ok: running
  bridge writing normally, connected
    -> ok: running + connected
  bridge writing normally, disconnected
    -> warn: process running but NOT serving — last successful poll UNKNOWN; ag2.space mobile messages are not being delive

--- PATCHED ---
  bridge stopped writing 4000s ago, last wrote connected:false
    -> warn: process running but its status sidecar has not been written for 4000s (freshness window 180s) — the bridge is
  bridge writing normally, connected
    -> ok: running + connected
  bridge writing normally, disconnected
    -> warn: process running but NOT serving — last successful poll UNKNOWN; ag2.space mobile messages are not being delive
```

Row 1 is the fix. Rows 2 and 3 are unchanged — a fresh `connected: true` still outranks the staleness signal, and the existing not-serving warn is untouched.

A **missing** sidecar still yields `ok — running`. An old build that never writes one has no opinion, and that is not a fault.

## Why a separate helper

`_gateway_serving()` answers *"is it serving"*, which has no true/false answer when the file is stale. `_gateway_status_stale_age_s()` answers *"did the writer stop"*, which does. Folding the staleness case into `_gateway_serving()`'s `None` is what erased the distinction in the first place.

## Tests

`tests/health-check-gateway-bridge.test.py` gains 8 cases: 5 on the helper (fresh / stale / absent / malformed `ts` / bool `ts`) and 3 at the probe level (stale → warn naming the age, no sidecar → still ok, fresh-connected outranks staleness).

The `_run` helper now pins `_gateway_status_stale_age_s` the same way it already pins `_gateway_serving`. Without that pin every `serving=None` case would read the host's own sidecar and flip to warn on any machine whose bridge stopped writing one — the suite would pass or fail depending on who ran it.

Negative control: with `src/health-check.py` reverted to the parent and the tests left in place, the run aborts on `AttributeError: ... does not have the attribute '_gateway_status_stale_age_s'` — the new cases cannot pass without the change.

Full suite on this branch: `all check_gateway_bridge cases passed`.

## Scope

One concern: the probe's handling of a stale sidecar. No behavior change to the bridge, the freshness constant, or any other probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)