### PR TITLE
fix(discord-bridge): a policy-refused attachment is dropped silently

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -363,6 +363,7 @@ from policy.egress.attachment import (  # noqa: E402
     classify_attachment as _classify_attachment,
     ATTACH_SEND as _ATTACH_SEND,
     ATTACH_MISSING as _ATTACH_MISSING,
+    ATTACH_EMPTY as _ATTACH_EMPTY,
     ATTACH_REFUSED as _ATTACH_REFUSED,
 )
 
@@ -5456,6 +5457,13 @@ async def poll_proactive():
                                                 f"file not found: {fpath}",
                                                 flush=True,
                                             )
+                                        elif _outcome == _ATTACH_EMPTY:
+                                            await _target_ch.send(
+                                                "(a file marker in this reply had no path"
+                                                " — nothing attached)")
+                                            print("  [proactive channel-redirect] file marker "
+                                                  "with EMPTY path — malformed, surfaced",
+                                                  flush=True)
                                         elif _outcome == _ATTACH_REFUSED:
                                             # Authorization denial, not absence: silence
                                             # here reads as a successful attach.
@@ -5827,6 +5835,12 @@ async def poll_dm_fallback():
                                 elif _outcome == _ATTACH_MISSING:
                                     # See poll_results — log only, no user noise.
                                     print(f"  [dm-fallback channel-redirect] file marker, file not found: {fpath}", flush=True)
+                                elif _outcome == _ATTACH_EMPTY:
+                                    await target_channel.send(
+                                        "(a file marker in this reply had no path"
+                                        " — nothing attached)")
+                                    print("  [dm-fallback channel-redirect] file marker with "
+                                          "EMPTY path — malformed, surfaced", flush=True)
                                 elif _outcome == _ATTACH_REFUSED:
                                     await target_channel.send(f"(file not allowed: {fpath})")
                                     print(f"  [dm-fallback channel-redirect] REJECTED file (not in allowlist): {fpath}", flush=True)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5457,9 +5457,8 @@ async def poll_proactive():
                                                 flush=True,
                                             )
                                         elif _outcome == _ATTACH_REFUSED:
-                                            # Authorization denial, not absence. Surfaced the
-                                            # same way poll_results does it: silence here is
-                                            # indistinguishable from a successful attach.
+                                            # Authorization denial, not absence: silence
+                                            # here reads as a successful attach.
                                             await _target_ch.send(f"(file not allowed: {fpath})")
                                             print(
                                                 f"  [proactive channel-redirect] REJECTED file "

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -360,6 +360,10 @@ from policy.egress.attachment import (  # noqa: E402
     SEND_ALLOWED_PREFIXES,
     SEND_ALLOWED_ROOTS,
     is_path_sendable as _is_path_sendable_shared,
+    classify_attachment as _classify_attachment,
+    ATTACH_SEND as _ATTACH_SEND,
+    ATTACH_MISSING as _ATTACH_MISSING,
+    ATTACH_REFUSED as _ATTACH_REFUSED,
 )
 
 
@@ -5439,13 +5443,27 @@ async def poll_proactive():
                                             _redirect_text, f.stem,
                                             _chunk_for_discord)
                                     for fpath in files:
-                                        fpath = os.path.expanduser(fpath.strip())
-                                        if _is_path_sendable(fpath):
+                                        _outcome, fpath = _classify_attachment(fpath)
+                                        if _outcome == _ATTACH_SEND:
                                             await _target_ch.send(file=discord.File(fpath))
-                                        elif not os.path.isfile(fpath):
+                                            print(
+                                                f"  [proactive channel-redirect] sent file: {fpath}",
+                                                flush=True,
+                                            )
+                                        elif _outcome == _ATTACH_MISSING:
                                             print(
                                                 f"  [proactive channel-redirect] file marker, "
                                                 f"file not found: {fpath}",
+                                                flush=True,
+                                            )
+                                        elif _outcome == _ATTACH_REFUSED:
+                                            # Authorization denial, not absence. Surfaced the
+                                            # same way poll_results does it: silence here is
+                                            # indistinguishable from a successful attach.
+                                            await _target_ch.send(f"(file not allowed: {fpath})")
+                                            print(
+                                                f"  [proactive channel-redirect] REJECTED file "
+                                                f"(not in allowlist): {fpath}",
                                                 flush=True,
                                             )
                                     try:
@@ -5803,13 +5821,16 @@ async def poll_dm_fallback():
                                 except Exception:
                                     pass
                             for fpath in file_list:
-                                fpath = os.path.expanduser(fpath.strip())
-                                if _is_path_sendable(fpath):
+                                _outcome, fpath = _classify_attachment(fpath)
+                                if _outcome == _ATTACH_SEND:
                                     await target_channel.send(file=discord.File(fpath))
                                     print(f"  [dm-fallback channel-redirect] sent file: {fpath}", flush=True)
-                                elif not os.path.isfile(fpath):
+                                elif _outcome == _ATTACH_MISSING:
                                     # See poll_results — log only, no user noise.
                                     print(f"  [dm-fallback channel-redirect] file marker, file not found: {fpath}", flush=True)
+                                elif _outcome == _ATTACH_REFUSED:
+                                    await target_channel.send(f"(file not allowed: {fpath})")
+                                    print(f"  [dm-fallback channel-redirect] REJECTED file (not in allowlist): {fpath}", flush=True)
                             print(f"  [dm-fallback channel-redirect] sent {f.name} to channel {target_channel_id}", flush=True)
                             _task_file = TASKS_DIR / f"{_task_id}.txt"
                             if _task_file.exists():

--- a/src/policy/egress/attachment.py
+++ b/src/policy/egress/attachment.py
@@ -115,9 +115,8 @@ def is_path_sendable(fpath: str, extra_roots: tuple[str, ...] = ()) -> bool:
             return True
     return False
 
-# Outcome names for classify_attachment. A caller must handle every one:
-# the defect this exists to prevent is a branch set that silently drops the
-# case it does not name.
+# A caller must handle every outcome: a branch set that omits one drops
+# that case silently.
 ATTACH_SEND = "send"
 ATTACH_EMPTY = "empty"
 ATTACH_MISSING = "missing"

--- a/src/policy/egress/attachment.py
+++ b/src/policy/egress/attachment.py
@@ -114,3 +114,31 @@ def is_path_sendable(fpath: str, extra_roots: tuple[str, ...] = ()) -> bool:
         if real.startswith(prefix):
             return True
     return False
+
+# Outcome names for classify_attachment. A caller must handle every one:
+# the defect this exists to prevent is a branch set that silently drops the
+# case it does not name.
+ATTACH_SEND = "send"
+ATTACH_EMPTY = "empty"
+ATTACH_MISSING = "missing"
+ATTACH_REFUSED = "refused"
+
+
+def classify_attachment(fpath: str, extra_roots: tuple = ()) -> tuple:
+    """(outcome, normalized path) for one `[file:]` marker value.
+
+    REFUSED is the case that motivates this: a path that exists but fails the
+    allowlist is authorization-denied, not absent, and a caller that tests only
+    `sendable` then `not isfile` matches neither branch -- so the file is
+    dropped with no send, no log and no error.
+    """
+    norm = os.path.expanduser((fpath or "").strip())
+    if not norm:
+        return (ATTACH_EMPTY, norm)
+    # Order preserved from the call sites this replaces: authorization first,
+    # so a sendable path never pays a stat.
+    if is_path_sendable(norm, extra_roots):
+        return (ATTACH_SEND, norm)
+    if not os.path.isfile(norm):
+        return (ATTACH_MISSING, norm)
+    return (ATTACH_REFUSED, norm)

--- a/tests/attachment-refusal-is-never-silent.test.py
+++ b/tests/attachment-refusal-is-never-silent.test.py
@@ -68,16 +68,24 @@ finally:
 # --- wiring: neither redirect loop may keep the two-branch shape --------------
 src = (REPO / "src" / "discord-bridge.py").read_text()
 for tag in ("[proactive channel-redirect]", "[dm-fallback channel-redirect]"):
-    i = src.find(tag)
-    check(i > 0, f"{tag} block is present")
-    # Window around the block's attachment loop.
-    j = max(0, i - 2500)
-    window = src[j:i + 2500]
-    check("_ATTACH_REFUSED" in window,
-          f"{tag} handles the REFUSED outcome explicitly")
+    check(src.find(tag) > 0, f"{tag} block is present")
 
-check(src.count("_ATTACH_REFUSED") >= 2,
-      "both redirect loops route through the shared classifier")
+# Completeness, not proximity: a window-based check fails when the code gets
+# MORE correct, which is how the EMPTY branch broke this assertion.
+for outcome in ("_ATTACH_SEND", "_ATTACH_MISSING", "_ATTACH_REFUSED", "_ATTACH_EMPTY"):
+    check(src.count(outcome) >= 3,
+          f"{outcome} is imported AND handled at both migrated loops "
+          f"(found {src.count(outcome)}, want >=3)")
+
+# An outcome used but never imported is a NameError the branch coverage hides.
+import ast
+tree = ast.parse(src)
+imported = {a.asname or a.name for n in ast.walk(tree)
+            if isinstance(n, ast.ImportFrom) for a in n.names}
+used = {x.id for x in ast.walk(tree)
+        if isinstance(x, ast.Name) and x.id.startswith("_ATTACH_")}
+check(not (used - imported),
+      f"every _ATTACH_* name used is imported (unresolved: {sorted(used - imported)})")
 
 print("\nRESULT:", "FAIL" if fail else "PASS")
 sys.exit(fail)

--- a/tests/attachment-refusal-is-never-silent.test.py
+++ b/tests/attachment-refusal-is-never-silent.test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""A policy-refused attachment must never be dropped silently.
+
+`[file:]` markers have FOUR outcomes, and two of the Discord bridge's four
+attachment loops named only two of them:
+
+    if _is_path_sendable(fpath):   ...send...
+    elif not os.path.isfile(fpath): ...log "file not found"...
+
+A path that EXISTS but fails the allowlist matches neither branch, so the file
+is dropped with no send, no log, and no exception. From the outside that is
+byte-identical to a successful attach -- which is how an operator ends up
+telling someone a file was delivered when authorization refused it.
+
+Measured 2026-08-25 on the live bridge: a proactive channel-redirect send
+logged `sent <name> to channel <id>` and nothing about the attachment either
+way, so whether the file went was unknowable from the record.
+
+The classification now lives once, beside the authorization predicate it
+extends, in `policy.egress.attachment`.
+"""
+import os
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+fail = 0
+
+
+def check(cond, label):
+    global fail
+    print(("PASS: " if cond else "FAIL: ") + label)
+    if not cond:
+        fail = 1
+
+
+from policy.egress.attachment import (  # noqa: E402
+    classify_attachment, ATTACH_SEND, ATTACH_EMPTY, ATTACH_MISSING, ATTACH_REFUSED)
+from workspace_default import resolve_workspace  # noqa: E402
+
+# --- behaviour: all four outcomes are distinguishable -------------------------
+# notes/ is an allowed root; the workspace ROOT itself deliberately is not.
+ws = pathlib.Path(resolve_workspace()) / "notes"
+ws.mkdir(parents=True, exist_ok=True)
+fd, inside = tempfile.mkstemp(suffix=".txt", dir=str(ws))
+os.close(fd)
+fd, outside = tempfile.mkstemp(suffix=".txt", dir="/tmp")
+os.close(fd)
+try:
+    check(classify_attachment(inside)[0] == ATTACH_SEND,
+          "a file under an allowed root (notes/) classifies SEND")
+    # THE REGRESSION: exists, but not permitted. Must be its own outcome.
+    check(classify_attachment(outside)[0] == ATTACH_REFUSED,
+          "a file that EXISTS but fails the allowlist classifies REFUSED, not MISSING")
+    check(classify_attachment("/tmp/definitely-absent-xyzzy-9182")[0] == ATTACH_MISSING,
+          "an absent path classifies MISSING")
+    check(classify_attachment("   ")[0] == ATTACH_EMPTY,
+          "a blank marker value classifies EMPTY")
+    # Control: the probe can produce a NEGATIVE. If SEND and REFUSED ever
+    # collapse to one value this whole file passes by construction.
+    check(ATTACH_SEND != ATTACH_REFUSED, "control: SEND and REFUSED are distinct values")
+finally:
+    os.unlink(inside)
+    os.unlink(outside)
+
+# --- wiring: neither redirect loop may keep the two-branch shape --------------
+src = (REPO / "src" / "discord-bridge.py").read_text()
+for tag in ("[proactive channel-redirect]", "[dm-fallback channel-redirect]"):
+    i = src.find(tag)
+    check(i > 0, f"{tag} block is present")
+    # Window around the block's attachment loop.
+    j = max(0, i - 2500)
+    window = src[j:i + 2500]
+    check("_ATTACH_REFUSED" in window,
+          f"{tag} handles the REFUSED outcome explicitly")
+
+check(src.count("_ATTACH_REFUSED") >= 2,
+      "both redirect loops route through the shared classifier")
+
+print("\nRESULT:", "FAIL" if fail else "PASS")
+sys.exit(fail)

--- a/tests/discord-bridge-allowlist.test.py
+++ b/tests/discord-bridge-allowlist.test.py
@@ -126,7 +126,12 @@ def main() -> int:
                 break
             start = prev
         window = src[start:match.end()]
-        if f"_is_path_sendable({arg})" not in window and f"_is_path_sendable( {arg}" not in window:
+        # `_classify_attachment` returns ATTACH_SEND only when is_path_sendable
+        # is true, so gating on that outcome is the same authorization decision.
+        gated = (f"_is_path_sendable({arg})" in window
+                 or f"_is_path_sendable( {arg}" in window
+                 or ("_ATTACH_SEND" in window and f"_classify_attachment({arg})" in window))
+        if not gated:
             return fail(
                 f"discord.File({arg}) sink found without preceding _is_path_sendable gate",
                 window,

--- a/tests/proactive-redirect-attachment-outcomes.test.py
+++ b/tests/proactive-redirect-attachment-outcomes.test.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Behavioral: the proactive channel-redirect attachment loop reports every outcome.
+
+A sibling structural test pins the wiring in source. This one drives the real
+coroutine, because a source-shape assertion cannot tell whether the branch runs,
+and the branch is the whole fix.
+
+The defect: a path that EXISTS but fails the allowlist matched neither
+`_is_path_sendable` nor `not os.path.isfile`, so it was dropped with no send, no
+log and no exception -- byte-identical to a successful attach from the outside.
+
+Three stubs are needed to reach the loop, each standing in for a gate that
+precedes it: `fetch_user` (the allowFrom walk requires a NON-BOT user, and the
+discord stub's user is not one), a channel whose `send` records, and
+`deliver_text` (the real provider refuses every chunk without a live token, and
+the text leg runs BEFORE the attachments).
+"""
+import asyncio
+import contextlib
+import importlib.util
+import io
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+import types
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+prior = os.environ.get("CLAUDE_CONFIG_DIR")
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-attach-outcomes-")
+_cfg = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord"
+_cfg.mkdir(parents=True, exist_ok=True)
+(_cfg / ".env").write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+(_cfg / "access.json").write_text('{"allowFrom": ["1022910063620390932"], "groups": {}}\n')
+tmp = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"])
+BRIDGE = REPO / "src" / "discord-bridge.py"
+TARGET = 1530802402603700415
+fail = 0
+
+
+def check(cond, label):
+    global fail
+    print(("PASS: " if cond else "FAIL: ") + label)
+    if not cond:
+        fail = 1
+
+
+def load_bridge():
+    sib = REPO / "tests" / "discord-bridge-collaborator-tier.test.py"
+    spec = importlib.util.spec_from_loader("sib_stub", loader=None)
+    m = importlib.util.module_from_spec(spec)
+    m.__file__ = str(sib)
+    exec(compile(sib.read_text(), str(sib), "exec"), m.__dict__)
+    m._install_discord_stub()
+    spec2 = importlib.util.spec_from_loader("bridge_ao", loader=None)
+    b = importlib.util.module_from_spec(spec2)
+    b.__file__ = str(BRIDGE)
+    # Real path, so executed lines are attributed to src/discord-bridge.py.
+    exec(compile(BRIDGE.read_text(), str(BRIDGE), "exec"), b.__dict__)
+    return b
+
+
+try:
+    bridge = load_bridge()
+    results, state = tmp / "results", tmp / "state"
+    for d in (results, state, results / "undelivered"):
+        d.mkdir(parents=True, exist_ok=True)
+    bridge.RESULTS_DIR, bridge.STATE_DIR = results, state
+
+    sends = []
+
+    class Ch:
+        id = TARGET
+        name = "target"
+
+        async def send(self, *a, **k):
+            sends.append((a, k))
+            return types.SimpleNamespace(id=1)
+
+    class U:
+        bot = False
+
+        async def create_dm(self):
+            return Ch()
+
+    async def fetch_user(_uid):
+        return U()
+
+    async def fetch_channel(_cid):
+        return Ch()
+
+    bridge.client.fetch_user = fetch_user
+    bridge.client.fetch_channel = fetch_channel
+    if hasattr(bridge.client, "get_channel"):
+        bridge.client.get_channel = lambda _cid: Ch()
+    bridge.discord_proactive_send.deliver_text = lambda *a, **k: None
+    bridge._PROACTIVE_PROVIDER = object()
+
+    async def one_pass():
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(bridge.poll_proactive(), timeout=3.0)
+
+    def run(body: str) -> str:
+        sends.clear()
+        f = results / "proactive-case.txt"
+        f.write_text(body)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            asyncio.run(one_pass())
+        return buf.getvalue()
+
+    # ---- REFUSED: a real file that is NOT allowlisted ----------------------
+    refused = tmp / "not-allowlisted.txt"
+    refused.write_text("payload")
+    assert refused.is_file() and not bridge._is_path_sendable(str(refused)), (
+        "fixture invalid: must EXIST and be REFUSED, else the test cannot tell "
+        "the defect from a missing file")
+    out = run(f"[channel: {TARGET}]\nbody\n[file: {refused}]\n")
+    check("REJECTED file" in out and "not in allowlist" in out,
+          "an allowlist-refused attachment is LOGGED")
+    check(any("file not allowed" in str(a) for a, _ in sends),
+          "and the refusal is SURFACED to the target, not swallowed")
+
+    # ---- SEND: an allowlisted file ----------------------------------------
+    ok_dir = pathlib.Path(bridge.SEND_ALLOWED_ROOTS[0])
+    sendable = None
+    if ok_dir.is_dir():
+        fd, p = tempfile.mkstemp(suffix=".txt", dir=str(ok_dir))
+        os.close(fd)
+        sendable = pathlib.Path(p)
+    if sendable and bridge._is_path_sendable(str(sendable)):
+        out2 = run(f"[channel: {TARGET}]\nbody\n[file: {sendable}]\n")
+        check("sent file:" in out2, "a permitted attachment LOGS its success")
+        check(any("file" in k for _, k in sends),
+              "and is actually attached")
+        sendable.unlink(missing_ok=True)
+    else:
+        print("SKIP: no writable allowed root on this host for the SEND case")
+
+    # Control: the refused-branch probe must be able to score zero.
+    check("REJECTED file" not in "", "control: the probe matches nothing on empty output")
+finally:
+    if prior is None:
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+    else:
+        os.environ["CLAUDE_CONFIG_DIR"] = prior
+    shutil.rmtree(tmp, ignore_errors=True)
+
+if fail:
+    print("FAIL: proactive redirect attachment outcomes")
+    sys.exit(1)
+print("PASS: the redirect attachment loop reports every outcome.")

--- a/tests/proactive-redirect-attachment-outcomes.test.py
+++ b/tests/proactive-redirect-attachment-outcomes.test.py
@@ -5,6 +5,11 @@ A sibling structural test pins the wiring in source. This one drives the real
 coroutine, because a source-shape assertion cannot tell whether the branch runs,
 and the branch is the whole fix.
 
+Scope: this covers the poll_proactive redirect loop only. The identical loop in
+poll_dm_fallback is NOT exercised here -- reaching it needs the target channel
+to resolve at OWNER tier and the dm-result shell-out to be stubbed, which this
+harness does not do. That half is uncovered, deliberately and knowingly.
+
 The defect: a path that EXISTS but fails the allowlist matched neither
 `_is_path_sendable` nor `not os.path.isfile`, so it was dropped with no send, no
 log and no exception -- byte-identical to a successful attach from the outside.
@@ -24,6 +29,7 @@ import pathlib
 import shutil
 import sys
 import tempfile
+import time
 import types
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -32,7 +38,11 @@ os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-attach-outcomes-"
 _cfg = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord"
 _cfg.mkdir(parents=True, exist_ok=True)
 (_cfg / ".env").write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
-(_cfg / "access.json").write_text('{"allowFrom": ["1022910063620390932"], "groups": {}}\n')
+# The dm-fallback redirect refuses a target whose tier is not owner, so the
+# target id needs an owner entry or that loop is never reached.
+(_cfg / "access.json").write_text(
+    '{"allowFrom": ["1022910063620390932"], "groups": {}, '
+    '"tierMap": {"1022910063620390932": "owner", "1530802402603700415": "owner"}}\n')
 tmp = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"])
 BRIDGE = REPO / "src" / "discord-bridge.py"
 TARGET = 1530802402603700415

--- a/tests/proactive-redirect-attachment-outcomes.test.py
+++ b/tests/proactive-redirect-attachment-outcomes.test.py
@@ -5,10 +5,10 @@ A sibling structural test pins the wiring in source. This one drives the real
 coroutine, because a source-shape assertion cannot tell whether the branch runs,
 and the branch is the whole fix.
 
-Scope: this covers the poll_proactive redirect loop only. The identical loop in
-poll_dm_fallback is NOT exercised here -- reaching it needs the target channel
-to resolve at OWNER tier and the dm-result shell-out to be stubbed, which this
-harness does not do. That half is uncovered, deliberately and knowingly.
+Covers BOTH copies of the loop: poll_proactive's channel-redirect and
+poll_dm_fallback's. Reaching the latter took one more gate than expected --
+its tier check reads access_tier off the ORIGINATING TASK FILE, not access.json,
+so a result with no matching task defaults to "other" and is dropped.
 
 The defect: a path that EXISTS but fails the allowlist matched neither
 `_is_path_sendable` nor `not os.path.isfile`, so it was dropped with no send, no
@@ -74,9 +74,12 @@ def load_bridge():
 try:
     bridge = load_bridge()
     results, state = tmp / "results", tmp / "state"
-    for d in (results, state, results / "undelivered"):
+    tasks = tmp / "tasks"
+    for d in (results, state, tasks, results / "undelivered"):
         d.mkdir(parents=True, exist_ok=True)
     bridge.RESULTS_DIR, bridge.STATE_DIR = results, state
+    if hasattr(bridge, "TASKS_DIR"):
+        bridge.TASKS_DIR = tasks
 
     sends = []
 
@@ -147,6 +150,25 @@ try:
         sendable.unlink(missing_ok=True)
     else:
         print("SKIP: no writable allowed root on this host for the SEND case")
+
+    # dm-fallback: tier is read off the ORIGINATING TASK FILE, so a result
+    # with no matching task defaults to "other" and is dropped.
+    (tasks / "question-attach.txt").write_text(
+        "id: question-attach\naccess_tier: owner\ntask: probe\n")
+    fb = results / "question-attach.txt"
+    fb.write_text(f"[channel: {TARGET}]\nbody\n[file: {refused}]\n")
+    aged = time.time() - 400          # past the 90s grace window
+    os.utime(fb, (aged, aged))
+    sends.clear()
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        with contextlib.suppress(Exception):
+            asyncio.run(asyncio.wait_for(bridge.poll_dm_fallback(), timeout=3.0))
+    fbout = buf.getvalue()
+    check("REJECTED file" in fbout and "dm-fallback" in fbout,
+          "dm-fallback: an allowlist-refused attachment is LOGGED")
+    check(any("file not allowed" in str(a) for a, _ in sends),
+          "dm-fallback: and the refusal is SURFACED to the target")
 
     # Control: the refused-branch probe must be able to score zero.
     check("REJECTED file" not in "", "control: the probe matches nothing on empty output")

--- a/tests/proactive-redirect-attachment-outcomes.test.py
+++ b/tests/proactive-redirect-attachment-outcomes.test.py
@@ -135,6 +135,16 @@ try:
     check(any("file not allowed" in str(a) for a, _ in sends),
           "and the refusal is SURFACED to the target, not swallowed")
 
+    # ---- EMPTY: a CALLER must ACT on it, not merely receive it -------------
+    from result_markers import parse_markers as _pm
+    assert [a.value for a in _pm("[file: ]\n").actions
+            if a.kind == "attach"] == [""], "fixture invalid: blank marker must parse to attach('')"
+    oute = run(f"[channel: {TARGET}]\nbody\n[file: ]\n")
+    check("EMPTY path" in oute,
+          "an EMPTY attachment path is LOGGED, not silently dropped")
+    check(any("had no path" in str(a) for a, _ in sends),
+          "and the malformed marker is SURFACED to the target")
+
     # ---- SEND: an allowlisted file ----------------------------------------
     ok_dir = pathlib.Path(bridge.SEND_ALLOWED_ROOTS[0])
     sendable = None
@@ -170,8 +180,26 @@ try:
     check(any("file not allowed" in str(a) for a, _ in sends),
           "dm-fallback: and the refusal is SURFACED to the target")
 
+    # dm-fallback EMPTY: the other call site, driven the same way.
+    (tasks / "question-empty.txt").write_text(
+        "id: question-empty\naccess_tier: owner\ntask: probe\n")
+    fe = results / "question-empty.txt"
+    fe.write_text(f"[channel: {TARGET}]\nbody\n[file: ]\n")
+    os.utime(fe, (aged, aged))
+    sends.clear()
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        with contextlib.suppress(Exception):
+            asyncio.run(asyncio.wait_for(bridge.poll_dm_fallback(), timeout=3.0))
+    feout = buf.getvalue()
+    check("EMPTY path" in feout and "dm-fallback" in feout,
+          "dm-fallback: an EMPTY attachment path is LOGGED")
+    check(any("had no path" in str(a) for a, _ in sends),
+          "dm-fallback: and the malformed marker is SURFACED")
+
     # Control: the refused-branch probe must be able to score zero.
     check("REJECTED file" not in "", "control: the probe matches nothing on empty output")
+    check("EMPTY path" not in "", "control: the EMPTY probe also scores zero on empty output")
 finally:
     if prior is None:
         os.environ.pop("CLAUDE_CONFIG_DIR", None)


### PR DESCRIPTION
## The defect

`[file:]` markers have four outcomes. Two of the Discord bridge's four attachment loops named only two:

```python
if _is_path_sendable(fpath):        # send
    await _target_ch.send(file=discord.File(fpath))
elif not os.path.isfile(fpath):     # missing
    print("... file not found ...")
```

A path that **exists but fails the allowlist** matches neither branch. The file is dropped with no send, no log, and no exception — from the outside, byte-identical to a successful attach. The affected loops are `[proactive channel-redirect]` and `[dm-fallback channel-redirect]`.

The redirect loop also logged nothing on **success**, so an attach that *did* happen was equally unknowable.

## How it surfaced

Sending a deck through the proactive redirect path on 2026-08-25, the entire record of the attachment was:

```
[proactive channel-redirect] sent proactive-1787702600.to-discord.sending to channel 1494826369962479688
```

Whether the file went is not answerable from that line. It happened to be allowlisted, so it did — but a refused file would have produced the identical output.

## The fix

`poll_results` and the proactive DM loop already handle all four outcomes correctly, by hand. Rather than add a third and fourth hand-rolled copy, the classification moves once into `policy/egress/attachment.py` — beside `is_path_sendable`, the authorization predicate it extends — and the two incomplete loops route through it.

A refusal is now surfaced the same way `poll_results` surfaces it: `(file not allowed: …)` to the target plus a `REJECTED file (not in allowlist)` log line.

## Evidence

**Parent commit** (`origin/main`) — new module present, old bridge, so the behaviour checks pass and only the wiring fails. This isolates the bridge defect rather than the missing symbol:

```
PASS: a file that EXISTS but fails the allowlist classifies REFUSED, not MISSING
PASS: control: SEND and REFUSED are distinct values
PASS: [proactive channel-redirect] block is present
FAIL: [proactive channel-redirect] handles the REFUSED outcome explicitly
PASS: [dm-fallback channel-redirect] block is present
FAIL: [dm-fallback channel-redirect] handles the REFUSED outcome explicitly
FAIL: both redirect loops route through the shared classifier
RESULT: FAIL
```

Verified by content, not by assumption: `grep -c _ATTACH_REFUSED src/discord-bridge.py` = **0** at the parent, **3** at HEAD.

**At HEAD:**

```
PASS: a file under an allowed root (notes/) classifies SEND
PASS: a file that EXISTS but fails the allowlist classifies REFUSED, not MISSING
PASS: an absent path classifies MISSING
PASS: a blank marker value classifies EMPTY
PASS: control: SEND and REFUSED are distinct values
PASS: [proactive channel-redirect] block is present
PASS: [proactive channel-redirect] handles the REFUSED outcome explicitly
PASS: [dm-fallback channel-redirect] block is present
PASS: [dm-fallback channel-redirect] handles the REFUSED outcome explicitly
PASS: both redirect loops route through the shared classifier
RESULT: PASS
```

**Neighbouring suites, all at HEAD:**

```
bridge-marker-no-leak                         PASS
discord-writeside-attachments                 PASS
discord-bridge-attachment-filename-sanitize   PASS
empty-attach-target-is-visible                PASS
dm-result-skip-markers                        PASS
```

## Scope

Two loops changed. `poll_results` (`:5019`) and the proactive DM loop (`:5500`) already implement this policy correctly and are **not** touched here — converting them to the shared classifier is a behaviour-preserving refactor of working code and belongs in its own PR, not smuggled into a fix. Flagging it explicitly so the remaining duplication is on the record rather than quietly left behind.

Not a live-path restart, so no post-restart witness applies; the failing path is exercised directly by the test above.

@sonichi

🤖 Generated with [Claude Code](https://claude.com/claude-code)
