### PR TITLE
fix(config): the two loaders disagree on a config block of the wrong type

### DIFF
--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -165,6 +165,10 @@ def _load_json(path: Path) -> Dict[str, Any]:
             f"sutando config: {path} top-level must be a JSON object, got {type(data).__name__}"
         )
     for key in sorted(_OBJECT_TOP_LEVEL_KEYS & set(data)):
+        # null is how every consumer already spells "absent" (`or {}`), so
+        # rejecting it would break configs that work on both loaders today.
+        if data[key] is None:
+            continue
         if not isinstance(data[key], dict):
             raise RuntimeError(
                 f"sutando config: {path} key {key!r} must be a JSON object, got "

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -62,6 +62,18 @@ _KNOWN_TOP_LEVEL_KEYS = {
     "stand",          # this instance's `Stand:` commit-trailer value
 }
 
+# Blocks every consumer reads with `.get()`. A scalar here is what the schema's
+# `"type": "object"` already forbids; _load_json enforces it at read time.
+_OBJECT_TOP_LEVEL_KEYS = {
+    "core",
+    "workspace",
+    "claude_sutando_config_dir",
+    "vault",
+    "migrate",
+    "health_check",
+    "bridges",
+}
+
 _SUPPORTED_CORE_RUNTIMES = {"claude", "codex"}
 
 _DOWN_BRIDGE_ACTIONS = {"restart", "alert", "off"}
@@ -152,6 +164,13 @@ def _load_json(path: Path) -> Dict[str, Any]:
         raise RuntimeError(
             f"sutando config: {path} top-level must be a JSON object, got {type(data).__name__}"
         )
+    for key in sorted(_OBJECT_TOP_LEVEL_KEYS & set(data)):
+        if not isinstance(data[key], dict):
+            raise RuntimeError(
+                f"sutando config: {path} key {key!r} must be a JSON object, got "
+                f"{type(data[key]).__name__} {data[key]!r}. Did you mean "
+                f'{{"{key}": {{...}}}}?'
+            )
     return _strip_comments(data)
 
 
@@ -291,8 +310,8 @@ def load_config(repo_root: Optional[Path] = None) -> Dict[str, Any]:
     are tolerated (defaults file optional too, in which case caller falls
     through to the hardcoded resolver default — see `resolve_workspace`).
 
-    Raises `RuntimeError` only for parse errors (malformed JSON) or
-    structurally-invalid top-level (non-object).
+    Raises `RuntimeError` for parse errors (malformed JSON), a non-object
+    top-level, or an object-typed block holding a scalar.
     """
     global _CACHE, _CACHE_REPO_ROOT
     if _CACHE is not None and (repo_root is None or repo_root == _CACHE_REPO_ROOT):

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -50,6 +50,21 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
 ]);
 
 /**
+ * Blocks every consumer reads with property access. A scalar here is what the
+ * schema's `"type": "object"` already forbids; loadJson enforces it at read time.
+ * Python twin: _OBJECT_TOP_LEVEL_KEYS in sutando_config.py.
+ */
+const OBJECT_TOP_LEVEL_KEYS = new Set([
+	'core',
+	'workspace',
+	'claude_sutando_config_dir',
+	'vault',
+	'migrate',
+	'health_check',
+	'bridges',
+]);
+
+/**
  * Walk upward from `start` until we find a directory containing
  * `sutando.config.json`. Returns undefined if not found within 6 hops.
  * Anchors on the config file rather than `.git/` so app bundles + symlinked
@@ -122,6 +137,18 @@ function loadJsonFile(path: string): { [k: string]: Json } {
 	}
 	if (data === null || typeof data !== 'object' || Array.isArray(data)) {
 		throw new Error(`sutando config: ${path} top-level must be a JSON object, got ${typeof data}`);
+	}
+	const obj = data as { [k: string]: Json };
+	for (const key of [...OBJECT_TOP_LEVEL_KEYS].sort()) {
+		if (!(key in obj)) continue;
+		const v = obj[key];
+		if (v === null || typeof v !== 'object' || Array.isArray(v)) {
+			throw new Error(
+				`sutando config: ${path} key '${key}' must be a JSON object, got ` +
+					`${Array.isArray(v) ? 'array' : typeof v} ${JSON.stringify(v)}. ` +
+					`Did you mean {"${key}": {...}}?`,
+			);
+		}
 	}
 	const stripped = stripComments(data);
 	return stripped as { [k: string]: Json };

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -142,7 +142,10 @@ function loadJsonFile(path: string): { [k: string]: Json } {
 	for (const key of [...OBJECT_TOP_LEVEL_KEYS].sort()) {
 		if (!(key in obj)) continue;
 		const v = obj[key];
-		if (v === null || typeof v !== 'object' || Array.isArray(v)) {
+		// null is how every consumer already spells "absent" (`or {}`), so
+		// rejecting it would break configs that work on both loaders today.
+		if (v === null) continue;
+		if (typeof v !== 'object' || Array.isArray(v)) {
 			throw new Error(
 				`sutando config: ${path} key '${key}' must be a JSON object, got ` +
 					`${Array.isArray(v) ? 'array' : typeof v} ${JSON.stringify(v)}. ` +

--- a/tests/sutando-config-twin-contract.test.py
+++ b/tests/sutando-config-twin-contract.test.py
@@ -26,6 +26,7 @@ REPO = Path(__file__).resolve().parent.parent
 CONFIG = REPO / "sutando.config.json"
 SCHEMA = REPO / "docs" / "sutando-config.schema.json"
 TS_TWIN = REPO / "src" / "sutando_config.ts"
+PY_TWIN = REPO / "src" / "sutando_config.py"
 
 failures = []
 
@@ -36,19 +37,33 @@ def check(name, ok, detail=""):
         failures.append(f"{name}: {detail}")
 
 
-def ts_known_top_level_keys(text):
-    """Parse KNOWN_TOP_LEVEL_KEYS out of the TS twin without executing it."""
-    m = re.search(r"KNOWN_TOP_LEVEL_KEYS\s*=\s*new Set\(\[(.*?)\]\)", text, re.S)
+def ts_set_literal(text, name):
+    """Parse a `const NAME = new Set([...])` out of the TS twin without executing it."""
+    m = re.search(name + r"\s*=\s*new Set\(\[(.*?)\]\)", text, re.S)
     if not m:
         return None
     return set(re.findall(r"'([^']+)'", m.group(1)))
+
+
+def ts_known_top_level_keys(text):
+    return ts_set_literal(text, "KNOWN_TOP_LEVEL_KEYS")
+
+
+def py_set_literal(text, name):
+    """Parse a `NAME = {...}` string-set out of the Python twin without importing it."""
+    m = re.search(name + r"\s*=\s*\{(.*?)\}", text, re.S)
+    if not m:
+        return None
+    return set(re.findall(r'"([^"]+)"', m.group(1)))
 
 
 print("cross-loader config contract")
 
 config = json.loads(CONFIG.read_text())
 schema = json.loads(SCHEMA.read_text())
-ts_keys = ts_known_top_level_keys(TS_TWIN.read_text())
+ts_text = TS_TWIN.read_text()
+py_text = PY_TWIN.read_text()
+ts_keys = ts_known_top_level_keys(ts_text)
 
 check("TS twin exposes a parseable KNOWN_TOP_LEVEL_KEYS", ts_keys is not None,
       "regex found no Set literal — did the declaration shape change?")
@@ -82,6 +97,24 @@ check("every TS-known key is declared in the JSON schema",
       not ts_not_in_schema,
       f"TS accepts but schema rejects (a user setting these gets an invalid config): "
       f"{ts_not_in_schema}")
+
+# 4. A schema-object key missing from one twin's guard set means that loader keeps the
+#    old divergent behavior on a malformed config (Python raised, TS fell through).
+ts_obj = ts_set_literal(ts_text, "OBJECT_TOP_LEVEL_KEYS")
+py_obj = py_set_literal(py_text, "_OBJECT_TOP_LEVEL_KEYS")
+check("TS twin exposes a parseable OBJECT_TOP_LEVEL_KEYS", ts_obj is not None,
+      "regex found no Set literal — did the declaration shape change?")
+check("Python twin exposes a parseable _OBJECT_TOP_LEVEL_KEYS", py_obj is not None,
+      "regex found no set literal — did the declaration shape change?")
+ts_obj, py_obj = ts_obj or set(), py_obj or set()
+check("both twins guard the same object-typed blocks", ts_obj == py_obj,
+      f"TS-only: {sorted(ts_obj - py_obj)}; Python-only: {sorted(py_obj - ts_obj)}")
+
+schema_obj = {k for k, v in schema.get("properties", {}).items() if v.get("type") == "object"}
+check("the guarded set matches the schema's object-typed properties",
+      ts_obj == schema_obj,
+      f"guarded-not-in-schema: {sorted(ts_obj - schema_obj)}; "
+      f"schema-object-not-guarded: {sorted(schema_obj - ts_obj)}")
 
 print()
 if failures:

--- a/tests/sutando-config.test.py
+++ b/tests/sutando-config.test.py
@@ -702,5 +702,32 @@ class TestSutandoConfig(unittest.TestCase):
         self.assertEqual(out["scalar_int"], 42)  # non-string passthrough
 
 
+class TestNullBlockIsAbsent(unittest.TestCase):
+    """A null block loads today on both loaders; guarding it must not change that."""
+
+    def _load(self, body):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "sutando.config.local.json"
+            p.write_text(body)
+            return sutando_config._load_json(p)
+
+    def test_null_block_loads_and_reads_as_absent(self):
+        out = self._load('{"vault": null, "workspace": null}')
+        self.assertIsNone(out["vault"])
+        # the shape every consumer already relies on
+        self.assertIsNone((out.get("vault") or {}).get("remote_url"))
+
+    def test_scalar_and_array_blocks_still_rejected(self):
+        for body, shown in (('{"workspace": "/tmp/ws"}', "str"),
+                            ('{"vault": []}', "list")):
+            with self.assertRaises(RuntimeError) as cm:
+                self._load(body)
+            self.assertIn(shown, str(cm.exception))
+
+    def test_real_object_block_still_loads(self):
+        out = self._load('{"vault": {"remote_url": "git@example:v.git"}}')
+        self.assertEqual(out["vault"]["remote_url"], "git@example:v.git")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/sutando-config.test.py
+++ b/tests/sutando-config.test.py
@@ -190,6 +190,39 @@ class TestSutandoConfig(unittest.TestCase):
             load_config(repo_root=self.repo)
         self.assertIn("JSON object", str(ctx.exception))
 
+    def test_scalar_object_block_raises_naming_file_and_key(self):
+        # `{"workspace": "<path>"}` is the shape a user writes by hand. Before
+        # this guard it reached `(cfg.get("workspace") or {}).get("path")`.
+        _write_config(self.repo, "sutando.config.local.json", {"workspace": "/tmp/ws"})
+        with self.assertRaises(RuntimeError) as ctx:
+            load_config(repo_root=self.repo)
+        msg = str(ctx.exception)
+        self.assertIn("sutando.config.local.json", msg)
+        self.assertIn("'workspace'", msg)
+        self.assertIn("str", msg)
+
+    def test_scalar_object_block_raises_for_every_guarded_key(self):
+        for key in sorted(sutando_config._OBJECT_TOP_LEVEL_KEYS):
+            with self.subTest(key=key):
+                sutando_config._reset_cache_for_tests()
+                _write_config(self.repo, "sutando.config.json", {key: "scalar"})
+                with self.assertRaises(RuntimeError) as ctx:
+                    load_config(repo_root=self.repo)
+                self.assertIn(f"'{key}'", str(ctx.exception))
+
+    def test_list_valued_block_also_rejected(self):
+        _write_config(self.repo, "sutando.config.json", {"vault": ["a"]})
+        with self.assertRaises(RuntimeError) as ctx:
+            load_config(repo_root=self.repo)
+        self.assertIn("'vault'", str(ctx.exception))
+
+    def test_non_object_typed_keys_are_left_alone(self):
+        # `stand` is a string and `core_config_dirs` a list by design — guarding
+        # them would reject valid configs.
+        _write_config(self.repo, "sutando.config.json",
+                      {"stand": "mbp", "core_config_dirs": [], "workspace": {"path": "/tmp/w"}})
+        self.assertEqual(load_config(repo_root=self.repo)["stand"], "mbp")
+
     # ------------------------------------------------------------------ #
     #  6. Empty .local.json treated as {}                                 #
     # ------------------------------------------------------------------ #

--- a/tests/sutando-config.test.ts
+++ b/tests/sutando-config.test.ts
@@ -216,6 +216,46 @@ describe('sutando_config loader', () => {
 		}
 	});
 
+	it('a scalar in an object-typed block throws naming the file and the key', () => {
+		// `{"workspace": "<path>"}` is the shape a user writes by hand. Before this
+		// guard the TS loader silently fell through to the baked-in default.
+		writeConfig(repo, 'sutando.config.local.json', { workspace: '/tmp/ws' } as never);
+		try {
+			assert.throws(() => loadConfig(repo), (err: unknown) => {
+				const msg = err instanceof Error ? err.message : String(err);
+				return (
+					msg.includes('sutando.config.local.json') &&
+					msg.includes("'workspace'") &&
+					msg.includes('string')
+				);
+			});
+		} finally {
+			restoreEnvAndRepo();
+		}
+	});
+
+	it('an array in an object-typed block is rejected too', () => {
+		writeConfig(repo, 'sutando.config.json', { vault: ['a'] } as never);
+		try {
+			assert.throws(() => loadConfig(repo), /'vault' must be a JSON object, got array/);
+		} finally {
+			restoreEnvAndRepo();
+		}
+	});
+
+	it('leaves non-object-typed keys alone', () => {
+		writeConfig(repo, 'sutando.config.json', {
+			stand: 'mbp',
+			core_config_dirs: [],
+			workspace: { path: '/tmp/w' },
+		} as never);
+		try {
+			assert.equal(loadConfig(repo).stand, 'mbp');
+		} finally {
+			restoreEnvAndRepo();
+		}
+	});
+
 	// ------------------------------------------------------------------ //
 	//  6. Empty / missing .local.json treated as {}                       //
 	// ------------------------------------------------------------------ //


### PR DESCRIPTION
## The bug

`load_config` validates that the **top level** is a JSON object. Every consumer then assumes each *block* is one too, and nothing checks it. The two twins fail differently on the identical file:

```json
// sutando.config.local.json
{"workspace": "/tmp/ws"}
```

Measured on `origin/main` (`7da709a`), same scratch repo, both loaders, with a *valid* `{"workspace": {"path": ...}}` in the tracked `sutando.config.json`:

```
PYTHON loader:
   AttributeError: 'str' object has no attribute 'get'

TS loader:
   resolveWorkspace() -> /var/folders/.../tmpzs8r4dlg/workspace
```

**Python** dies inside `(cfg.get("workspace") or {}).get("path")` — `or {}` cannot help here, a non-empty string is truthy. It dies at **module import**: `src/health-check.py:73` is `WORKSPACE_DIR = resolve_workspace()`, so the health check and the core exit on a traceback that never mentions the config file. That is how this was found — a hand-written config of the obvious shape took down a session mid-run.

**TS** reads `?.path` off the string, gets `undefined`, and falls through to the baked-in default with no diagnostic. Note the resolved path above: it is **not** the `workspace.path` from the tracked `sutando.config.json` either, because deep-merge replaced that object wholesale with the string. So the Node services (task-bridge, voice-agent, web-client) and the Python core land in **different workspaces**, silently — the exact split the twin-contract test exists to prevent.

## After

Both loaders reject it where the existing top-level check already lives, naming the file, the key, the type found, and the shape meant:

```
PYTHON loader:
   RuntimeError: sutando config: .../sutando.config.local.json key 'workspace' must be a
   JSON object, got str '/tmp/ws'. Did you mean {"workspace": {...}}?

TS loader:
   Error: sutando config: .../sutando.config.local.json key 'workspace' must be a
   JSON object, got string "/tmp/ws". Did you mean {"workspace": {...}}?
```

Failing per-file rather than post-merge is deliberate: it names *which* of the two files is wrong, which is the only thing the user needs.

## Scope of the guard

The guarded set is exactly the schema's `"type": "object"` properties — `core`, `workspace`, `claude_sutando_config_dir`, `vault`, `migrate`, `health_check`, `bridges`. This enforces at read time what `docs/sutando-config.schema.json` already declares. `stand` (string) and `core_config_dirs` (array) are deliberately excluded; a test pins that they still load.

Arrays are rejected alongside scalars — `{"vault": ["a"]}` hits the same path in both loaders.

## Tests

- `tests/sutando-config.test.py` — scalar block names file + key; every guarded key rejects a scalar (subTest over the set, so adding a key to the set adds a case); list-valued block rejected; non-object-typed keys still load.
- `tests/sutando-config.test.ts` — the same three, mirrored.
- `tests/sutando-config-twin-contract.test.py` — new parity checks: both twins expose a parseable guard set, **the two sets are equal**, and they equal the schema's object-typed properties. This is the guardrail #2316 and #2308 established for `KNOWN_TOP_LEVEL_KEYS` after it drifted twice; a key added to the schema or one twin alone now fails here instead of shipping a loader that keeps the old divergent behavior.

Negative control, `src/` reverted to the parent with the tests kept: Python `FAILED (failures=2, errors=1)`, TS `# fail 2`, twin contract `FAILED (3)`.

With the fix: Python `Ran 44 tests OK`, TS `# pass 30 # fail 0`, twin contract passes, `ruff` clean, `review-checks.sh` PASS.

## Scope

One concern: block-type validation in the config loaders. No change to resolution order, merge semantics, defaults, or any consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)