### PR TITLE
fix(health-check): score a session-owned job from its completion sentinel

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5886,6 +5886,10 @@ def check_daily_cron_punctuality() -> dict:
         # sentinel is the only dated record that it finished.
         arts = (_daily_completion_minutes(ws / "state", jname) if launchd
                 else _daily_artifact_minutes(ws / "results", stem))
+        # `launchd` conflates "runs under launchd" with "publishes no dated results
+        # file"; a session-owned job can be the second without being the first.
+        if not arts and not launchd:
+            arts = _daily_completion_minutes(ws / "state", jname)
         # Staleness is computed HERE because `now` lives here; the interpret layer
         # reads it as an optional field so its fixtures stay clock-independent.
         newest = max((d for d, _ in arts), default=None)

--- a/tests/health-check-daily-punctuality.test.py
+++ b/tests/health-check-daily-punctuality.test.py
@@ -167,7 +167,7 @@ class TestArtifactDiscovery(unittest.TestCase):
 class TestCollector(unittest.TestCase):
     """The collector's FILTERING is where a job silently drops out of scope."""
 
-    def _run(self, entries, artifacts=()):
+    def _run(self, entries, artifacts=(), sentinels=()):
         with tempfile.TemporaryDirectory() as td:
             ws = Path(td)
             (ws / "hosts" / "H").mkdir(parents=True)
@@ -179,6 +179,13 @@ class TestCollector(unittest.TestCase):
                 f = res / name
                 f.write_text("x")
                 os.utime(f, (time.time(), time.mktime(when)))
+            if sentinels:
+                st = ws / "state"
+                st.mkdir(exist_ok=True)
+                # Body format is production's: morning-briefing.py writes
+                # `datetime.now().isoformat()` into state/<job>-<date>.sentinel.
+                for name, stamp in sentinels:
+                    (st / name).write_text(stamp)
             with mock.patch.object(hc, "WORKSPACE_DIR", ws), \
                  mock.patch.object(hc, "_host_label", lambda: "H"):
                 return hc.check_daily_cron_punctuality()
@@ -273,6 +280,57 @@ class TestCollector(unittest.TestCase):
         r = self._run(json.dumps({"crons": [entry]}), ())
         self.assertNotIn("no output today", r["detail"])
         self.assertIn("UNCHECKED", r["detail"])
+
+
+class TestSentinelFallbackForSessionOwnedJobs(unittest.TestCase):
+    """`launchd` conflates two properties: "runs under launchd" and "publishes
+    no dated results file". A session-owned job can be the second without the
+    first, and then it reports UNCHECKED forever while its dated completion
+    sentinels sit unread in state/."""
+
+    _run = TestCollector._run
+
+    @staticmethod
+    def _week(job, hour, minute):
+        # range must include TODAY: a window ending yesterday reads as missed-today.
+        days = [datetime.now().date() - timedelta(days=k) for k in range(6, -1, -1)]
+        return [(f"{job}-{d.isoformat()}.sentinel",
+                 datetime(d.year, d.month, d.day, hour, minute, 1).isoformat())
+                for d in days]
+
+    def test_a_session_owned_job_is_scored_from_its_completion_sentinel(self):
+        r = self._run(
+            json.dumps([{"name": "morning-briefing", "cron": "57 6 * * *"}]),
+            sentinels=self._week("morning-briefing", 7, 0),
+        )
+        self.assertNotIn("UNCHECKED", r["detail"],
+                         "7 dated sentinels exist; the job is observable")
+        self.assertIn("1 of 1 daily job(s) observable", r["detail"])
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_results_artifacts_still_win_when_present(self):
+        """The fallback fires only on an EMPTY results/ glob, so a job that does
+        publish there keeps its existing source and cannot be double-read."""
+        days = [datetime.now().date() - timedelta(days=k) for k in range(6, -1, -1)]
+        arts = [(f"insight-{d.isoformat()}.txt",
+                 (d.year, d.month, d.day, 6, 51, 0, 0, 0, -1)) for d in days]
+        r = self._run(
+            json.dumps([{"name": "daily-insight", "cron": "50 6 * * *"}]),
+            artifacts=arts,
+            sentinels=self._week("daily-insight", 23, 59),
+        )
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertNotIn("late", r["detail"],
+                         "scored from results/ (+1 min), not the 23:59 sentinels")
+
+    def test_a_launchd_job_is_unaffected(self):
+        """It already took the sentinel branch; the fallback must not re-read it."""
+        r = self._run(
+            json.dumps([{"name": "digest", "cron": "0 6 * * *", "launchd": True}]),
+            sentinels=self._week("digest", 6, 1),
+        )
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertIn("1 of 1 daily job(s) observable", r["detail"])
 
 
 class TestConditionalProducers(unittest.TestCase):


### PR DESCRIPTION
`daily-cron-punctuality` picks its data source from the entry's `launchd` flag:

```python
arts = (_daily_completion_minutes(ws / "state", jname) if launchd
        else _daily_artifact_minutes(ws / "results", stem))
```

That flag conflates two independent properties — *"runs under launchd"* and *"publishes no dated results file, so read its completion sentinel"*. A session-owned job can be the second without being the first.

`morning-briefing` is exactly that: `launchd` unset → results/ branch → 0 matches → **UNCHECKED**, while **36** dated `state/morning-briefing-<date>.sentinel` files sit unread, today's included. The evidence has been on disk the whole time.

## The fix

One branch, no config change on any host, reusing the sentinel reader that already exists. It fires only on an **empty** results glob, so a job that does publish there is untouched and cannot be double-read.

## Before / after, on a live workspace

Both versions of the real `check_daily_cron_punctuality()` run against the same host state:

```
BEFORE (origin/main)
  warn  1 of 4 daily job(s) observable, all on schedule;
        UNCHECKED (no dated artifact, cannot tell whether it ran):
        learned-skills-scan, morning-briefing, obsidian-dream — 3 of 4 unverifiable

AFTER (this branch)
  warn  2 of 4 daily job(s) observable, all on schedule;
        UNCHECKED (no dated artifact, cannot tell whether it ran):
        learned-skills-scan, obsidian-dream — 2 of 4 unverifiable
```

`morning-briefing` leaves the UNCHECKED list and scores on-schedule. It still warns, correctly — the other two are gated producers (absent sentinel / unset env) that emit nothing by design. Whether the `unknown` bucket should honour `conditional` is a **separate** question and deliberately not bundled here.

## Tests

`tests/health-check-daily-punctuality.test.py` gains a `TestSentinelFallbackForSessionOwnedJobs` class (3 cases) and the collector harness gains an optional `sentinels=` fixture — default empty, so no existing test changes behaviour. Fixture bodies match what production writes (`morning-briefing.py:806` → `datetime.now().isoformat()`).

**With the fix:**
```
$ python3 tests/health-check-daily-punctuality.test.py
Ran 41 tests in 0.015s
OK
```

**Negative control — `src/health-check.py` reverted to `origin/main`, tests kept:**
```
$ git stash push src/health-check.py && python3 tests/health-check-daily-punctuality.test.py
FAIL: test_a_session_owned_job_is_scored_from_its_completion_sentinel
AssertionError: 'UNCHECKED' unexpectedly found in
  '0 of 1 daily job(s) observable; UNCHECKED (no dated artifact, cannot tell
   whether it ran): morning-briefing — no coverage on this host'
   : 7 dated sentinels exist; the job is observable
Ran 41 tests in 0.016s
FAILED (failures=1)                                            (exit 1)
```

Exactly one failure, and it's the fallback case. The other two new tests — launchd unaffected, results-still-wins — **pass without the fix too**, which is the point: they're guarding against regression, not restating the change, so they shouldn't flip.

## Gate

```
$ git diff origin/main | bash scripts/review-checks.sh
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Relation to #3372

Composes, doesn't compete. #3372 demotes a job whose artifact naming has drifted; a job with **zero** artifacts never enters its `drifted` bucket, because `newest` is `None`. Different half of the same probe — #3372 is merged and running on the host these measurements come from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
