### PR TITLE
ci: raise the diff-coverage gate ceiling to 25 min — the suite outgrew 15

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -18,7 +18,7 @@ jobs:
   coverage-gate:
     name: diff coverage >= 95% (python)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The `diff coverage >= 95% (python)` job now dies at its own `timeout-minutes: 15` and GitHub reports the kill as `cancelled`, so it reads like a flake and invites futile re-runs.

**Evidence (owner's measurement on #3376, reproduced on #3384):** recent cancelled runs of this job cluster at the declared limit — 15.3 / 15.3 / 15.2 min — while genuinely superseded jobs scatter (4.7–9.2 min). Attempt-2 re-runs bought the same 15 minutes and died at the same mark, so a ceiling, not a flake.

**Before (at parent):** `.github/workflows/coverage-gate.yml:22` → `timeout-minutes: 15`; job killed at 15.3 min, conclusion `cancelled`.
**After (this head):** `timeout-minutes: 25` — one line, nothing else. 25 gives ~60% headroom over the observed ~15.3-min runtime while still bounding a hung job.

Splitting the gate into shards is the structural alternative; this unblocks the currently-red PRs (#3376, #3384) without redesigning the workflow, and a split can supersede it later.

Opened per sonichi's note on #3376 ('worth someone raising the ceiling or splitting the gate; happy to open that separately if nobody has') — searched open PRs first, nobody had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)