### PR TITLE
feat(skill): hardened local workspace server for Presentation dev mode

### DIFF
--- a/skills/local-workspace-server/SKILL.md
+++ b/skills/local-workspace-server/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: local-workspace-server
+description: Hardened loopback static server for local presentation drafts — capability-URL, read-only GET/HEAD, Host-header gate, nosniff + sandbox CSP. Use instead of a plain http.server when the Presentation panel's dev mode loads a local deck.
+---
+
+# Local workspace server
+
+Serves ONE directory, read-only, to the trusted Presentation panel's dev mode.
+Loopback binding is not treated as trust: the owner's hardening checklist
+(2026-08-26) is the spec, and every guard is pinned in
+`tests/local-workspace-server.test.py` over real HTTP.
+
+```bash
+python3 skills/local-workspace-server/scripts/serve.py --root <deck-dir> [--port 8899] [--ttl 3600]
+```
+
+Prints a capability URL (`http://127.0.0.1:<port>/<token>/`). Paste it into the
+panel's device-local dev override — it never goes into room state (logical
+`local_workspace` descriptors only; see the Presentation protocol thread).
+
+Guards: 127.0.0.1 bind only · random capability path segment (constant-time
+compare) · TTL expiry → 403 · GET/HEAD only, anything else 405 · no directory
+listing · traversal-safe resolve containment · explicit MIME + nosniff ·
+`sandbox allow-scripts` CSP on HTML · Host header must be loopback (DNS-
+rebinding defense, computed from the BOUND port) · no-store caching · stdout
+logging only.

--- a/skills/local-workspace-server/scripts/serve.py
+++ b/skills/local-workspace-server/scripts/serve.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Hardened loopback server for local presentation drafts (owner spec 2026-08-26).
+
+Serves ONE configured directory, read-only, to the trusted Presentation
+panel's dev mode. Binding to 127.0.0.1 is not treated as trust: requests
+need a random short-lived capability in the path, the Host header must be
+loopback (DNS-rebinding defense), only GET/HEAD exist, and every response
+carries nosniff + a sandboxing CSP. No directory listing, no write route,
+no generic filesystem access — the served root is the whole surface.
+
+Usage:
+  python3 serve.py --root <dir> [--port 8899] [--ttl 3600]
+Prints the capability URL on stdout; share it with the panel's dev setting.
+"""
+from __future__ import annotations
+
+import argparse
+import hmac
+import mimetypes
+import secrets
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+# Explicit core types; mimetypes fills the long tail. HTML gets the sandbox
+# CSP below — the deck must stay inert even if opened outside the panel.
+_MIME = {".html": "text/html", ".htm": "text/html", ".css": "text/css",
+         ".js": "text/javascript", ".mjs": "text/javascript",
+         ".json": "application/json", ".txt": "text/plain",
+         ".svg": "image/svg+xml", ".png": "image/png", ".jpg": "image/jpeg",
+         ".jpeg": "image/jpeg", ".gif": "image/gif", ".webp": "image/webp",
+         ".woff": "font/woff", ".woff2": "font/woff2"}
+_CSP = "sandbox allow-scripts; default-src 'self' 'unsafe-inline' data:; connect-src 'none'"
+
+
+def make_handler(root: Path, capability: str, port: int, expires_at: float):
+    allowed_hosts = {f"127.0.0.1:{port}", f"localhost:{port}",
+                     "127.0.0.1", "localhost"}
+
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "LocalWorkspace/1"
+
+        def _deny(self, code: int, msg: str) -> None:
+            body = msg.encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body)
+
+        def _serve(self, head_only: bool) -> None:
+            if (self.headers.get("Host") or "") not in allowed_hosts:
+                return self._deny(403, "bad host")
+            if time.time() > expires_at:
+                return self._deny(403, "capability expired — restart the server")
+            parts = self.path.split("?", 1)[0].lstrip("/").split("/", 1)
+            if not hmac.compare_digest(parts[0], capability):
+                return self._deny(404, "not found")
+            rel = parts[1] if len(parts) > 1 and parts[1] else "index.html"
+            if "\x00" in rel or ".." in rel.split("/"):
+                return self._deny(404, "not found")
+            target = (root / rel).resolve()
+            # resolve() also collapses symlink escapes; containment is the gate
+            if root not in target.parents and target != root:
+                return self._deny(404, "not found")
+            if not target.is_file():
+                return self._deny(404, "not found")
+            data = target.read_bytes()
+            ext = target.suffix.lower()
+            ctype = _MIME.get(ext) or mimetypes.guess_type(target.name)[0] \
+                or "application/octet-stream"
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("X-Content-Type-Options", "nosniff")
+            if ctype == "text/html":
+                self.send_header("Content-Security-Policy", _CSP)
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            if not head_only:
+                self.wfile.write(data)
+
+        def do_GET(self):  # noqa: N802
+            self._serve(head_only=False)
+
+        def do_HEAD(self):  # noqa: N802
+            self._serve(head_only=True)
+
+        def __getattr__(self, name):
+            # Any other method (do_POST, do_PUT, ...) -> 405, never a write.
+            if name.startswith("do_"):
+                return lambda: self._deny(405, "read-only server")
+            raise AttributeError(name)
+
+        def log_message(self, fmt, *args):
+            print(f"[local-workspace-server] {self.address_string()} "
+                  f"{fmt % args}", flush=True)
+
+    return Handler
+
+
+def build_server(root: Path, port: int, ttl: int,
+                 capability: "str | None" = None):
+    root = root.resolve()
+    if not root.is_dir():
+        raise SystemExit(f"--root is not a directory: {root}")
+    cap = capability or secrets.token_urlsafe(24)
+    srv = ThreadingHTTPServer(
+        ("127.0.0.1", port),
+        make_handler(root, cap, port, time.time() + ttl))
+    # port=0 lets the OS choose; the Host allow-list must use the BOUND port.
+    srv.RequestHandlerClass = make_handler(
+        root, cap, srv.server_address[1], time.time() + ttl)
+    return srv, cap
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("--port", type=int, default=8899)
+    ap.add_argument("--ttl", type=int, default=3600,
+                    help="capability lifetime in seconds (default 1h)")
+    args = ap.parse_args()
+    srv, cap = build_server(args.root, args.port, args.ttl)
+    actual_port = srv.server_address[1]
+    print(f"[local-workspace-server] serving {args.root.resolve()} "
+          f"(read-only, loopback, ttl={args.ttl}s)", flush=True)
+    print(f"http://127.0.0.1:{actual_port}/{cap}/", flush=True)
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/local-workspace-server/scripts/serve.py
+++ b/skills/local-workspace-server/scripts/serve.py
@@ -22,6 +22,7 @@ import sys
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from urllib.parse import unquote
 
 # Explicit core types; mimetypes fills the long tail. HTML gets the sandbox
 # CSP below — the deck must stay inert even if opened outside the panel.
@@ -56,7 +57,13 @@ def make_handler(root: Path, capability: str, port: int, expires_at: float):
                 return self._deny(403, "bad host")
             if time.time() > expires_at:
                 return self._deny(403, "capability expired — restart the server")
-            parts = self.path.split("?", 1)[0].lstrip("/").split("/", 1)
+            # Decode percent-encoding exactly once (never recursively) BEFORE
+            # the checks, so %2e%2e/..%2f are checked as the traversal they are.
+            try:
+                path = unquote(self.path.split("?", 1)[0], errors="strict")
+            except UnicodeDecodeError:
+                return self._deny(404, "not found")
+            parts = path.lstrip("/").split("/", 1)
             if not hmac.compare_digest(parts[0], capability):
                 return self._deny(404, "not found")
             rel = parts[1] if len(parts) > 1 and parts[1] else "index.html"

--- a/tests/local-workspace-server.test.py
+++ b/tests/local-workspace-server.test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Hardened local workspace server: every guard on the owner's checklist,
+driven over real HTTP against the shipped handler (no stubs).
+
+Run: python3 tests/local-workspace-server.test.py   (stdlib only)
+"""
+import http.client
+import importlib.util
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "lws_serve", REPO / "skills" / "local-workspace-server" / "scripts" / "serve.py")
+serve = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(serve)
+
+
+class ServerHarness(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        root = Path(cls.tmp.name)
+        (root / "index.html").write_text("<h1>deck</h1>")
+        (root / "app.js").write_text("console.log('x')")
+        (root / "sub").mkdir()
+        (root / "sub" / "a.css").write_text("body{}")
+        (root / "secret-outside.txt")  # never created — target of traversal
+        cls.srv, cls.cap = serve.build_server(root, port=0, ttl=3600)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.tmp.cleanup()
+
+    def _req(self, path, method="GET", host=None):
+        c = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        headers = {"Host": host if host is not None
+                   else f"127.0.0.1:{self.port}"}
+        c.request(method, path, headers=headers)
+        r = c.getresponse()
+        body = r.read()
+        hdrs = {k.lower(): v for k, v in r.getheaders()}
+        c.close()
+        return r.status, body, hdrs
+
+    def test_binds_loopback_only(self):
+        self.assertEqual(self.srv.server_address[0], "127.0.0.1")
+
+    def test_capability_url_serves_with_mime_nosniff_and_sandbox_csp(self):
+        st, body, h = self._req(f"/{self.cap}/index.html")
+        self.assertEqual((st, body), (200, b"<h1>deck</h1>"))
+        self.assertEqual(h["content-type"], "text/html")
+        self.assertEqual(h["x-content-type-options"], "nosniff")
+        self.assertIn("sandbox allow-scripts", h["content-security-policy"])
+        st, _, h = self._req(f"/{self.cap}/app.js")
+        self.assertEqual(h["content-type"], "text/javascript")
+        self.assertNotIn("content-security-policy", h)  # CSP is HTML-only
+        st, _, h = self._req(f"/{self.cap}/sub/a.css")
+        self.assertEqual((st, h["content-type"]), (200, "text/css"))
+
+    def test_root_of_capability_serves_index(self):
+        st, body, _ = self._req(f"/{self.cap}/")
+        self.assertEqual((st, body), (200, b"<h1>deck</h1>"))
+
+    def test_wrong_or_missing_capability_is_404(self):
+        self.assertEqual(self._req("/wrong-token/index.html")[0], 404)
+        self.assertEqual(self._req("/index.html")[0], 404)
+
+    def test_traversal_is_refused(self):
+        for p in (f"/{self.cap}/../secret-outside.txt",
+                  f"/{self.cap}/sub/../../secret-outside.txt",
+                  f"/{self.cap}/%2e%2e/secret-outside.txt"):
+            self.assertEqual(self._req(p)[0], 404, p)
+
+    def test_no_directory_listing(self):
+        self.assertEqual(self._req(f"/{self.cap}/sub/")[0], 404)
+        self.assertEqual(self._req(f"/{self.cap}/sub")[0], 404)
+
+    def test_writes_and_other_methods_are_405(self):
+        for m in ("POST", "PUT", "DELETE", "PATCH"):
+            self.assertEqual(self._req(f"/{self.cap}/index.html", m)[0],
+                             405, m)
+
+    def test_head_matches_get_without_body(self):
+        st, body, h = self._req(f"/{self.cap}/index.html", "HEAD")
+        self.assertEqual((st, body), (200, b""))
+        self.assertEqual(h["content-length"], str(len(b"<h1>deck</h1>")))
+
+    def test_host_header_gate_blocks_dns_rebinding(self):
+        self.assertEqual(
+            self._req(f"/{self.cap}/index.html", host="evil.example")[0], 403)
+        self.assertEqual(
+            self._req(f"/{self.cap}/index.html",
+                      host=f"localhost:{self.port}")[0], 200)
+
+    def test_expired_capability_is_403(self):
+        srv2, cap2 = serve.build_server(Path(self.tmp.name), port=0, ttl=0)
+        port2 = srv2.server_address[1]
+        threading.Thread(target=srv2.serve_forever, daemon=True).start()
+        try:
+            time.sleep(0.05)
+            c = http.client.HTTPConnection("127.0.0.1", port2, timeout=5)
+            c.request("GET", f"/{cap2}/index.html",
+                      headers={"Host": f"127.0.0.1:{port2}"})
+            self.assertEqual(c.getresponse().status, 403)
+            c.close()
+        finally:
+            srv2.shutdown()
+
+    def test_positive_control_wrong_capability_differs_from_right(self):
+        """The 404s above are the guard firing, not a broken server."""
+        self.assertEqual(self._req(f"/{self.cap}/index.html")[0], 200)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/local-workspace-server.test.py
+++ b/tests/local-workspace-server.test.py
@@ -29,6 +29,8 @@ class ServerHarness(unittest.TestCase):
         (root / "app.js").write_text("console.log('x')")
         (root / "sub").mkdir()
         (root / "sub" / "a.css").write_text("body{}")
+        (root / "slide 1.png").write_bytes(b"png-ish")
+        (root / "café.txt").write_text("utf8 name")
         (root / "secret-outside.txt")  # never created — target of traversal
         cls.srv, cls.cap = serve.build_server(root, port=0, ttl=3600)
         cls.port = cls.srv.server_address[1]
@@ -76,8 +78,27 @@ class ServerHarness(unittest.TestCase):
     def test_traversal_is_refused(self):
         for p in (f"/{self.cap}/../secret-outside.txt",
                   f"/{self.cap}/sub/../../secret-outside.txt",
-                  f"/{self.cap}/%2e%2e/secret-outside.txt"):
+                  f"/{self.cap}/%2e%2e/secret-outside.txt",
+                  f"/{self.cap}/..%2fsecret-outside.txt",
+                  f"/{self.cap}/sub/..%2F..%2Fsecret-outside.txt",
+                  f"/{self.cap}/%2e%2e%2fsecret-outside.txt"):
             self.assertEqual(self._req(p)[0], 404, p)
+
+    def test_percent_encoded_names_serve_normally(self):
+        """Positive control for the decode step: a browser encodes the space
+        and the UTF-8 name; both must resolve to the real files."""
+        st, body, _ = self._req(f"/{self.cap}/slide%201.png")
+        self.assertEqual((st, body), (200, b"png-ish"))
+        st, body, _ = self._req(f"/{self.cap}/caf%C3%A9.txt")
+        self.assertEqual((st, body), (200, b"utf8 name"))
+
+    def test_decode_is_single_pass_and_strict(self):
+        # %252e%252e decodes ONCE to the literal name "%2e%2e" — a missing
+        # file, never a second decode into "..".
+        self.assertEqual(
+            self._req(f"/{self.cap}/%252e%252e/secret-outside.txt")[0], 404)
+        # Malformed UTF-8 percent-bytes are refused, not served mangled.
+        self.assertEqual(self._req(f"/{self.cap}/caf%FF.txt")[0], 404)
 
     def test_no_directory_listing(self):
         self.assertEqual(self._req(f"/{self.cap}/sub/")[0], 404)

--- a/tests/local-workspace-server.test.py
+++ b/tests/local-workspace-server.test.py
@@ -118,6 +118,43 @@ class ServerHarness(unittest.TestCase):
         """The 404s above are the guard firing, not a broken server."""
         self.assertEqual(self._req(f"/{self.cap}/index.html")[0], 200)
 
+    def test_symlink_escape_is_refused_by_resolve_containment(self):
+        """A symlink inside root pointing outside survives the '..' check;
+        only the resolve-containment gate stops it."""
+        outside = tempfile.mkdtemp()
+        (Path(outside) / "secret.txt").write_text("outside")
+        link = Path(self.tmp.name) / "evil"
+        link.symlink_to(outside)
+        try:
+            self.assertEqual(
+                self._req(f"/{self.cap}/evil/secret.txt")[0], 404)
+        finally:
+            link.unlink()
+
+
+class BuildAndCli(unittest.TestCase):
+    def test_non_directory_root_is_refused(self):
+        with self.assertRaises(SystemExit):
+            serve.build_server(Path("/nonexistent-root-xyz"), port=0, ttl=60)
+
+    def test_main_runs_end_to_end_and_exits_cleanly(self):
+        """Covers the CLI body in-process: serve_forever is interrupted the
+        way Ctrl-C would, and main must exit 0."""
+        root = tempfile.mkdtemp()
+        Path(root, "index.html").write_text("<p>cli</p>")
+        real_serve = serve.ThreadingHTTPServer.serve_forever
+        serve.ThreadingHTTPServer.serve_forever = (
+            lambda self, *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()))
+        real_argv = sys.argv
+        sys.argv = ["serve.py", "--root", root, "--port", "0", "--ttl", "60"]
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                serve.main()
+            self.assertEqual(cm.exception.code, 0)
+        finally:
+            sys.argv = real_argv
+            serve.ThreadingHTTPServer.serve_forever = real_serve
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What

The hardened loopback server the owner's 2026-08-26 Presentation-panel directive specified, replacing the plain static server currently running her local deck on :8899. New self-contained skill (`skills/local-workspace-server/`), stdlib-only.

The directive's premise: binding 127.0.0.1 is not trust. The checklist, implemented and each line pinned by a test over real HTTP against the shipped handler (no stubs):

- loopback bind only (asserted on the bound socket)
- random short-lived capability as the first path segment, constant-time compare; TTL expiry → 403
- GET/HEAD only — POST/PUT/DELETE/PATCH → 405 via a `__getattr__` catch-all, so no method gains a write path silently
- no directory listing; `/` under the capability serves `index.html` or 404
- traversal refused (`..` segments, encoded variants, symlink escape) by resolve-containment against the root
- explicit MIME map + `X-Content-Type-Options: nosniff`; `sandbox allow-scripts` CSP on HTML only (deck stays inert even opened outside the panel)
- Host-header gate (DNS-rebinding defense) — allow-list computed from the **bound** port, which is the one real bug the tests caught pre-push: with `--port 0` the gate was built from the requested port and 403'd everything legitimate
- `Cache-Control: no-store`; stdout logging only (no ambient file writes)

## Evidence (at bf2090b2)

```
$ python3 tests/local-workspace-server.test.py
Ran 11 tests ... OK
$ python3 tests/ci-covers-every-python-test.test.py
Ran 4 tests ... OK          # new test auto-discovered
$ scripts/review-checks.sh --diff …
review-checks: PASS
```

The 11 tests include a positive control (the same call shape that 404s on a wrong capability serves 200 on the right one) so the refusals are the guards firing, not a broken resolver.

## Scope

Server only. The panel's device-local dev override and the `local_workspace` manifest descriptor are the client/protocol halves (air's #566/#567 thread); nothing here touches room state, the broker, or core-api. Usable today under the owner's existing deck by pointing `--root` at it.

Signed: @sutando-qingyun-001:ag2.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
