### PR TITLE
fix(task-progress): accept the desktop app's relocated channel .env via a second containment root ($SUTANDO_APP_SUPPORT)

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -27,6 +27,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`call-stats.py`** — Call statistics — summarize phone call activity over a time window.
 - **`cartesia-stt-provider.ts`** — Cartesia ink-whisper STT provider — drop-in replacement for GeminiBatchSTTProvider.
 - **`cartesia-tts.ts`** — Cartesia sonic-3 TTS — generates WAV audio files from text.
+- **`channel_env_containment.py`** — Shared containment policy for a channel's `.env` credential file.
 - **`channel_token.py`** — Shared token-resolution policy for the channel bridges.
 - **`chat-ui.ts`** — Sutando Chat UI — clean full-page chat experience.
 - **`chat_redaction.py`** — The chat-body redaction CHAIN, owned in one place.

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -255,7 +255,8 @@ def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
     # Belt and suspenders: even a slug-valid name must RESOLVE inside the
     # channels directory. The containment root is the realpath of channels/
     # itself (so a symlinked channels dir works), but a channel entry that
-    # symlinks OUT of the directory is refused by design.
+    # symlinks OUT of the directory is refused by design, unless the link's
+    # target still has shape <source>/.env (a relocation, not an escape).
     # Derive the EFFECTIVE gateway config from os.environ ALONE first — including
     # the alias and the combined "url|secret" one-token form. Only if that is still
     # missing a value do we resolve/guard/read the channel file. Checking just the
@@ -281,11 +282,15 @@ def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
 
     url, token = _derive(lambda k: os.environ.get(k, ""))
     if not (url and token):
-        # The file IS needed, so the containment check applies — unchanged. A
-        # channel entry that symlinks OUT of channels/ is refused by design.
+        # The file IS needed. Refuse unless the resolved target's filename and
+        # parent dirname match ".env" and `source` exactly (a relocation, not an escape).
         real_env = os.path.realpath(env_path)
         real_root = os.path.realpath(channels_dir)
-        if not real_env.startswith(real_root + os.sep):
+        same_shape = (
+            os.path.basename(real_env) == ".env"
+            and os.path.basename(os.path.dirname(real_env)) == source
+        )
+        if not real_env.startswith(real_root + os.sep) and not same_shape:
             print(f"[task-progress] refusing env path outside channels dir: {env_path}",
                   file=sys.stderr)
             return False

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -14,7 +14,8 @@ REMOTE_TASK_URL + REMOTE_TASK_TOKEN and posts the message through the gateway's
 POST /v1/room {op: "message"} endpoint — the same transport the task bridge for
 that provider uses, so progress updates land in the originating room. That file
 must resolve inside channels/ itself, or be the AG2 Space desktop app's own
-$SUTANDO_APP_SUPPORT/channels/<source>/.env (see _channel_env_is_contained).
+$SUTANDO_APP_SUPPORT/channels/<source>/.env (containment policy owned by
+src/channel_env_containment.py; see _channel_env_is_contained below).
 
 Exits 0 on success, 1 on failure. Fail-open by design — a failed send must never
 block the task itself. The caller should always continue working regardless of exit code.
@@ -241,34 +242,21 @@ def send_telegram(chat_id: str, message: str) -> bool:
 _SOURCE_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]|\.(?=[a-z0-9]))*$")
 
 
-def _channel_env_is_contained(env_path: Path, channels_dir: Path, source: str) -> bool:
-    """Containment for channels/<source>/.env, which may be a symlink.
+def _load_channel_env_containment():
+    """The shared containment policy (src/channel_env_containment.py), or a
+    fail-closed stub when src/ isn't importable this way — never silently
+    widen the guard just because the import failed."""
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+        from channel_env_containment import channel_env_is_contained  # type: ignore
+        return channel_env_is_contained
+    except Exception:
+        return lambda env_path, channels_dir, source: False
 
-    A resolution is accepted in exactly two cases, and fails closed otherwise:
 
-      1. it lands inside realpath(channels_dir) — the channels tree itself. A
-         symlinked channels/ dir is fine; an entry that links OUT of it is not.
-      2. it IS realpath($SUTANDO_APP_SUPPORT/channels/<source>/.env). The AG2
-         Space desktop app keeps the durable channel env under its own
-         app-support root and lays $CLAUDE_CONFIG_DIR/channels/ag2space/.env as
-         a symlink to it (launch-sutando.sh; #3150/#3201). SUTANDO_APP_SUPPORT
-         is exported by the app for every process it spawns, so this is a
-         second, explicitly configured root — a containment test, not a shape
-         match. A planted link to /tmp/<source>/.env or ~/x/<source>/.env still
-         fails closed, as does a link to another channel's file under the app
-         root, and everything fails closed when the variable is unset.
-
-    core-supervisor-relay._is_deliverable mirrors this rule exactly (sender/probe
-    alignment, #2701) — widen BOTH together or never.
-    """
-    real_env = os.path.realpath(env_path)
-    if real_env.startswith(os.path.realpath(channels_dir) + os.sep):
-        return True
-    app_support = (os.environ.get("SUTANDO_APP_SUPPORT") or "").strip()
-    if not app_support:
-        return False
-    relocated = os.path.join(app_support, "channels", source, ".env")
-    return real_env == os.path.realpath(relocated)
+# Single shared owner: src/channel_env_containment.py (see its docstring for
+# the accept/refuse rule; also delegated to by core-supervisor-relay.py).
+_channel_env_is_contained = _load_channel_env_containment()
 
 
 def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -12,7 +12,9 @@ Any --source other than slack/discord/telegram is treated as a remote-gateway
 channel: the sender reads channels/<source>/.env (under $CLAUDE_CONFIG_DIR) for
 REMOTE_TASK_URL + REMOTE_TASK_TOKEN and posts the message through the gateway's
 POST /v1/room {op: "message"} endpoint — the same transport the task bridge for
-that provider uses, so progress updates land in the originating room.
+that provider uses, so progress updates land in the originating room. That file
+must resolve inside channels/ itself, or be the AG2 Space desktop app's own
+$SUTANDO_APP_SUPPORT/channels/<source>/.env (see _channel_env_is_contained).
 
 Exits 0 on success, 1 on failure. Fail-open by design — a failed send must never
 block the task itself. The caller should always continue working regardless of exit code.
@@ -239,6 +241,36 @@ def send_telegram(chat_id: str, message: str) -> bool:
 _SOURCE_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]|\.(?=[a-z0-9]))*$")
 
 
+def _channel_env_is_contained(env_path: Path, channels_dir: Path, source: str) -> bool:
+    """Containment for channels/<source>/.env, which may be a symlink.
+
+    A resolution is accepted in exactly two cases, and fails closed otherwise:
+
+      1. it lands inside realpath(channels_dir) — the channels tree itself. A
+         symlinked channels/ dir is fine; an entry that links OUT of it is not.
+      2. it IS realpath($SUTANDO_APP_SUPPORT/channels/<source>/.env). The AG2
+         Space desktop app keeps the durable channel env under its own
+         app-support root and lays $CLAUDE_CONFIG_DIR/channels/ag2space/.env as
+         a symlink to it (launch-sutando.sh; #3150/#3201). SUTANDO_APP_SUPPORT
+         is exported by the app for every process it spawns, so this is a
+         second, explicitly configured root — a containment test, not a shape
+         match. A planted link to /tmp/<source>/.env or ~/x/<source>/.env still
+         fails closed, as does a link to another channel's file under the app
+         root, and everything fails closed when the variable is unset.
+
+    core-supervisor-relay._is_deliverable mirrors this rule exactly (sender/probe
+    alignment, #2701) — widen BOTH together or never.
+    """
+    real_env = os.path.realpath(env_path)
+    if real_env.startswith(os.path.realpath(channels_dir) + os.sep):
+        return True
+    app_support = (os.environ.get("SUTANDO_APP_SUPPORT") or "").strip()
+    if not app_support:
+        return False
+    relocated = os.path.join(app_support, "channels", source, ".env")
+    return real_env == os.path.realpath(relocated)
+
+
 def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
     """Generic sender for gateway-bridged channels (any --source with a
     channels/<source>/.env carrying REMOTE_TASK_URL + REMOTE_TASK_TOKEN)."""
@@ -252,11 +284,8 @@ def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
     _claude_config = Path(_base) if _base else Path.home() / ".claude"
     channels_dir = _claude_config / "channels"
     env_path = channels_dir / source / ".env"
-    # Belt and suspenders: even a slug-valid name must RESOLVE inside the
-    # channels directory. The containment root is the realpath of channels/
-    # itself (so a symlinked channels dir works), but a channel entry that
-    # symlinks OUT of the directory is refused by design, unless the link's
-    # target still has shape <source>/.env (a relocation, not an escape).
+    # Belt and suspenders: even a slug-valid name must RESOLVE inside an
+    # approved root (_channel_env_is_contained) — anything else is refused.
     # Derive the EFFECTIVE gateway config from os.environ ALONE first — including
     # the alias and the combined "url|secret" one-token form. Only if that is still
     # missing a value do we resolve/guard/read the channel file. Checking just the
@@ -282,19 +311,13 @@ def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
 
     url, token = _derive(lambda k: os.environ.get(k, ""))
     if not (url and token):
-        # The file IS needed. Refuse unless the resolved target's filename and
-        # parent dirname match ".env" and `source` exactly (a relocation, not an escape).
-        real_env = os.path.realpath(env_path)
-        real_root = os.path.realpath(channels_dir)
-        same_shape = (
-            os.path.basename(real_env) == ".env"
-            and os.path.basename(os.path.dirname(real_env)) == source
-        )
-        if not real_env.startswith(real_root + os.sep) and not same_shape:
+        # The file IS needed, so the containment check applies — two approved
+        # roots, fail-closed outside both (see _channel_env_is_contained).
+        if not _channel_env_is_contained(env_path, channels_dir, source):
             print(f"[task-progress] refusing env path outside channels dir: {env_path}",
                   file=sys.stderr)
             return False
-        env = _env_file(real_env)
+        env = _env_file(os.path.realpath(env_path))
         url, token = _derive(lambda k: os.environ.get(k, "") or env.get(k, ""))
     if not url or not token:
         print(f"[task-progress] no REMOTE_TASK_URL/REMOTE_TASK_TOKEN (or AG2_REMOTE_TOKEN) "

--- a/src/channel_env_containment.py
+++ b/src/channel_env_containment.py
@@ -1,0 +1,51 @@
+"""Shared containment policy for a channel's `.env` credential file.
+
+Two independent surfaces need the exact same answer to "is this
+`channels/<source>/.env` somewhere we trust?":
+
+  * `skills/task-progress/scripts/notify.py` (`send_remote_gateway`) — the
+    sender: refuses to READ a `.env` that resolves outside the trusted roots.
+  * `src/core-supervisor-relay.py` (`_is_deliverable`) — the probe: decides
+    whether a channel is routable BEFORE the sender ever runs, so it must
+    agree with the sender or a source gets selected that then fails to send
+    (#2701 review P1).
+
+That agreement used to be maintained by hand — byte-identical logic pasted in
+both files behind a "widen BOTH together or never" comment. This module is the
+single owner instead: both callers delegate here, so there is exactly one
+place to widen and no comment can go stale.
+
+`channel_env_is_contained(env_path, channels_dir, source)` accepts a
+resolution in exactly two cases, and fails closed otherwise:
+
+  1. it lands inside `realpath(channels_dir)` — the channels tree itself. A
+     symlinked `channels/` dir is fine; an entry that links OUT of it is not.
+  2. it IS `realpath($SUTANDO_APP_SUPPORT/channels/<source>/.env)`. The AG2
+     Space desktop app keeps the durable channel env under its own
+     app-support root and lays `$CLAUDE_CONFIG_DIR/channels/<source>/.env` as
+     a symlink to it (launch-sutando.sh; #3150/#3201). `SUTANDO_APP_SUPPORT`
+     is exported by the app for every process it spawns, so this is a second,
+     explicitly configured root — a containment test, not a shape match. A
+     planted link to `/tmp/<source>/.env` or `~/x/<source>/.env` still fails
+     closed, as does a link to another channel's file under the app root, and
+     everything fails closed when the variable is unset.
+
+Dependency-light by design (stdlib `os` only) so both a skill script and core
+can import it without pulling in either stack.
+"""
+from __future__ import annotations
+
+import os
+
+
+def channel_env_is_contained(env_path, channels_dir, source: str) -> bool:
+    """True iff `env_path` resolves inside `channels_dir` or the app-support
+    relocation for `source` (see module docstring for the exact two cases)."""
+    real_env = os.path.realpath(env_path)
+    if real_env.startswith(os.path.realpath(channels_dir) + os.sep):
+        return True
+    app_support = (os.environ.get("SUTANDO_APP_SUPPORT") or "").strip()
+    if not app_support:
+        return False
+    relocated = os.path.join(app_support, "channels", source, ".env")
+    return real_env == os.path.realpath(relocated)

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -261,35 +261,39 @@ _DELIVERABLE_SURFACES = {"discord", "slack", "telegram", "ag2space"}
 _SOURCE_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]|\.(?=[a-z0-9]))*$")
 
 
+def _load_channel_env_containment():
+    """The shared containment policy (src/channel_env_containment.py), or a
+    fail-closed stub when it isn't importable this way. Mirrors
+    _derive_backend's sys.path fix below: run as a script sys.path[0] is
+    src/, but loaded as a module (tests) it is not."""
+    try:
+        from pathlib import Path
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from channel_env_containment import channel_env_is_contained  # type: ignore
+        return channel_env_is_contained
+    except Exception:
+        return lambda env_path, channels_dir, source: False
+
+
+# Single shared owner: src/channel_env_containment.py (see its docstring for
+# the accept/refuse rule; also delegated to by notify.py).
+_channel_env_is_contained = _load_channel_env_containment()
+
+
 def _is_deliverable(source):
     if source in _DELIVERABLE_SURFACES:
         return True
     if not source or not _SOURCE_SLUG_RE.match(source):
         return False
-    # Probe for exactly what notify.py's sender reads, mirroring its FULL
-    # resolution contract (review P1 x2 on #2701 — filename alone was not
-    # enough): (1) same three-tier base, CLAUDE_CONFIG_DIR -> CLAUDE_HOME ->
-    # ~/.claude; (2) same realpath containment — a channel entry symlinked
-    # OUTSIDE channels/ is one the sender refuses, so probing it deliverable
-    # would recreate the selected-then-send-fails class via a different
-    # mismatch. If notify.py ever learns more filenames (#2686's try-both),
-    # widen BOTH sides together.
-    # The one sanctioned escape is the desktop app's own copy of the file,
-    # $SUTANDO_APP_SUPPORT/channels/<source>/.env (notify.py _channel_env_is_contained).
+    # Probe for exactly what notify.py's sender reads: same three-tier base,
+    # then the shared containment policy (review P1 x2 on #2701).
     base = (os.environ.get("CLAUDE_CONFIG_DIR") or os.environ.get("CLAUDE_HOME")
             or os.path.join(os.path.expanduser("~"), ".claude"))
     channels_dir = os.path.join(base, "channels")
     env_path = os.path.join(channels_dir, source, ".env")
     if not os.path.isfile(env_path):
         return False
-    real_env = os.path.realpath(env_path)
-    if real_env.startswith(os.path.realpath(channels_dir) + os.sep):
-        return True
-    app_support = (os.environ.get("SUTANDO_APP_SUPPORT") or "").strip()
-    if not app_support:
-        return False
-    relocated = os.path.join(app_support, "channels", source, ".env")
-    return real_env == os.path.realpath(relocated)
+    return _channel_env_is_contained(env_path, channels_dir, source)
 
 
 def resolve_active_target(activity_path):

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -274,6 +274,8 @@ def _is_deliverable(source):
     # would recreate the selected-then-send-fails class via a different
     # mismatch. If notify.py ever learns more filenames (#2686's try-both),
     # widen BOTH sides together.
+    # The one sanctioned escape is the desktop app's own copy of the file,
+    # $SUTANDO_APP_SUPPORT/channels/<source>/.env (notify.py _channel_env_is_contained).
     base = (os.environ.get("CLAUDE_CONFIG_DIR") or os.environ.get("CLAUDE_HOME")
             or os.path.join(os.path.expanduser("~"), ".claude"))
     channels_dir = os.path.join(base, "channels")
@@ -281,8 +283,13 @@ def _is_deliverable(source):
     if not os.path.isfile(env_path):
         return False
     real_env = os.path.realpath(env_path)
-    real_root = os.path.realpath(channels_dir)
-    return real_env.startswith(real_root + os.sep)
+    if real_env.startswith(os.path.realpath(channels_dir) + os.sep):
+        return True
+    app_support = (os.environ.get("SUTANDO_APP_SUPPORT") or "").strip()
+    if not app_support:
+        return False
+    relocated = os.path.join(app_support, "channels", source, ".env")
+    return real_env == os.path.realpath(relocated)
 
 
 def resolve_active_target(activity_path):

--- a/tests/channel-env-containment-contract.test.py
+++ b/tests/channel-env-containment-contract.test.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Contract tests for src/channel_env_containment.py — the single shared owner
+of "is this channels/<source>/.env somewhere we trust?".
+
+Before this module existed, the same ~8-line rule was pasted byte-identical
+into skills/task-progress/scripts/notify.py (_channel_env_is_contained, the
+sender) and src/core-supervisor-relay.py (_is_deliverable, the probe) behind a
+"widen BOTH together or never" comment — the exact duplication CLAUDE.md's
+architecture rules call out as the defect, not a tidiness issue, and #2701
+already shipped one sender/probe mismatch from hand-syncing it. This file
+pins the shared function's accept/refuse behavior directly; each caller's own
+delegation test (in tests/task-progress-skill.test.py and
+tests/core-supervisor-relay.test.py) then only has to prove it calls through
+here rather than re-verifying every case.
+
+Cases below are the union of what TestChannelEnvContainment (task-progress-
+skill.test.py) and TestResolveActiveTarget's containment-specific cases
+(core-supervisor-relay.test.py) already covered — none invented, none dropped.
+
+Run: python3 tests/channel-env-containment-contract.test.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+import channel_env_containment as m  # noqa: E402
+
+
+class TestChannelEnvIsContained(unittest.TestCase):
+    def setUp(self):
+        self._saved_app_support = os.environ.get("SUTANDO_APP_SUPPORT")
+        os.environ.pop("SUTANDO_APP_SUPPORT", None)
+
+    def tearDown(self):
+        if self._saved_app_support is None:
+            os.environ.pop("SUTANDO_APP_SUPPORT", None)
+        else:
+            os.environ["SUTANDO_APP_SUPPORT"] = self._saved_app_support
+
+    def _tmpdir(self) -> Path:
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        return d
+
+    def test_plain_file_inside_channels_dir_is_contained(self):
+        root = self._tmpdir()
+        channels_dir = root / "channels"
+        env_path = channels_dir / "ag2space" / ".env"
+        env_path.parent.mkdir(parents=True)
+        env_path.write_text("REMOTE_TASK_TOKEN=x\n")
+        self.assertTrue(m.channel_env_is_contained(env_path, channels_dir, "ag2space"))
+
+    def test_symlinked_channels_dir_is_still_contained(self):
+        # A symlinked channels/ dir itself is fine; what matters is where the
+        # RESOLVED entry lands, not whether channels_dir is itself a link.
+        real_root = self._tmpdir()
+        (real_root / "ag2space").mkdir()
+        (real_root / "ag2space" / ".env").write_text("REMOTE_TASK_TOKEN=x\n")
+        root = self._tmpdir()
+        channels_dir = root / "channels"
+        channels_dir.symlink_to(real_root)
+        env_path = channels_dir / "ag2space" / ".env"
+        self.assertTrue(m.channel_env_is_contained(env_path, channels_dir, "ag2space"))
+
+    def test_exact_relocation_under_app_support_is_contained(self):
+        cfg = self._tmpdir()
+        app = self._tmpdir()
+        real_dir = app / "channels" / "ag2space"
+        real_dir.mkdir(parents=True)
+        real = real_dir / ".env"
+        real.write_text("REMOTE_TASK_TOKEN=x\n")
+        channels_dir = cfg / "channels"
+        link_dir = channels_dir / "ag2space"
+        link_dir.mkdir(parents=True)
+        env_path = link_dir / ".env"
+        env_path.symlink_to(real)
+        os.environ["SUTANDO_APP_SUPPORT"] = str(app)
+        self.assertTrue(m.channel_env_is_contained(env_path, channels_dir, "ag2space"))
+
+    def test_relocation_refused_when_app_support_unset(self):
+        cfg = self._tmpdir()
+        app = self._tmpdir()
+        real_dir = app / "channels" / "ag2space"
+        real_dir.mkdir(parents=True)
+        real = real_dir / ".env"
+        real.write_text("REMOTE_TASK_TOKEN=x\n")
+        channels_dir = cfg / "channels"
+        link_dir = channels_dir / "ag2space"
+        link_dir.mkdir(parents=True)
+        env_path = link_dir / ".env"
+        env_path.symlink_to(real)
+        # SUTANDO_APP_SUPPORT left unset — no approved second root.
+        self.assertFalse(m.channel_env_is_contained(env_path, channels_dir, "ag2space"))
+
+    def test_relocation_refused_under_a_different_root(self):
+        cfg = self._tmpdir()
+        app = self._tmpdir()
+        other = self._tmpdir()
+        real_dir = app / "channels" / "ag2space"
+        real_dir.mkdir(parents=True)
+        real = real_dir / ".env"
+        real.write_text("REMOTE_TASK_TOKEN=x\n")
+        channels_dir = cfg / "channels"
+        link_dir = channels_dir / "ag2space"
+        link_dir.mkdir(parents=True)
+        env_path = link_dir / ".env"
+        env_path.symlink_to(real)
+        os.environ["SUTANDO_APP_SUPPORT"] = str(other)
+        self.assertFalse(m.channel_env_is_contained(env_path, channels_dir, "ag2space"))
+
+    def test_off_exact_path_under_app_support_is_refused(self):
+        # Same approved root, but not the exact <source>/.env under it: another
+        # channel's dir, outside channels/ entirely, or a differently named file.
+        cases = {
+            "other channel": ("discord", "channels", ".env"),
+            "outside channels/": ("ag2space", "workspace", ".env"),
+            "wrong filename": ("ag2space", "channels", "secrets.txt"),
+        }
+        for label, (dirname, subdir, filename) in cases.items():
+            with self.subTest(label):
+                cfg = self._tmpdir()
+                app = self._tmpdir()
+                real_dir = app / subdir / dirname
+                real_dir.mkdir(parents=True)
+                real = real_dir / filename
+                real.write_text("REMOTE_TASK_TOKEN=x\n")
+                channels_dir = cfg / "channels"
+                link_dir = channels_dir / "ag2space"
+                link_dir.mkdir(parents=True)
+                env_path = link_dir / ".env"
+                env_path.symlink_to(real)
+                os.environ["SUTANDO_APP_SUPPORT"] = str(app)
+                self.assertFalse(
+                    m.channel_env_is_contained(env_path, channels_dir, "ag2space"))
+
+    def test_arbitrary_escape_with_no_app_support_at_all_is_refused(self):
+        cfg = self._tmpdir()
+        outside = self._tmpdir()
+        real = outside / ".env"
+        real.write_text("REMOTE_TASK_TOKEN=x\n")
+        channels_dir = cfg / "channels"
+        link_dir = channels_dir / "ag2space"
+        link_dir.mkdir(parents=True)
+        env_path = link_dir / ".env"
+        env_path.symlink_to(real)
+        # No SUTANDO_APP_SUPPORT set at all — plain traversal-style escape.
+        self.assertFalse(m.channel_env_is_contained(env_path, channels_dir, "ag2space"))
+
+    def test_accepts_str_paths_same_as_path_objects(self):
+        # Callers pass either str (core-supervisor-relay.py, via os.path.join)
+        # or Path (notify.py) — the function must not care.
+        root = self._tmpdir()
+        channels_dir = root / "channels"
+        env_path = channels_dir / "ag2space" / ".env"
+        env_path.parent.mkdir(parents=True)
+        env_path.write_text("REMOTE_TASK_TOKEN=x\n")
+        self.assertTrue(
+            m.channel_env_is_contained(str(env_path), str(channels_dir), "ag2space"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -14,12 +14,15 @@ import importlib.util
 import json
 import os
 import shutil
+import sys
 import tempfile
 import contextlib
 import unittest
+from unittest.mock import patch
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _SRC = os.path.join(_HERE, "..", "src", "core-supervisor-relay.py")
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
 _spec = importlib.util.spec_from_file_location("core_supervisor_relay", _SRC)
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
@@ -28,6 +31,8 @@ compose_message = _mod.compose_message
 run_cycle = _mod.run_cycle
 main = _mod.main
 resolve_active_target = _mod.resolve_active_target
+
+import channel_env_containment  # noqa: E402 — the shared module the probe delegates to
 
 _LOGIN = {"state": "blocked-human", "detail": "awaiting user: login",
           "prompt": "Login\nSelect login method:\n  1. Claude account", "kind": "login"}
@@ -552,6 +557,63 @@ class TestResolveActiveTarget(unittest.TestCase):
             self.assertEqual(resolve_active_target(self._write(td, "{bad json")), ("", ""))
             self.assertEqual(resolve_active_target(self._write(td, [1, 2, 3])), ("", ""))
 
+
+
+class TestChannelEnvContainmentDelegation(unittest.TestCase):
+    """The probe (_is_deliverable) must call the shared
+    src/channel_env_containment.py function, not carry its own copy of the
+    containment rule — the exact duplication CLAUDE.md's architecture rules
+    call out as the defect."""
+
+    def _reload(self):
+        """A fresh module instance, separate from the shared `_mod` every
+        other test class depends on, so patching the shared function's
+        binding here can't affect them."""
+        spec = importlib.util.spec_from_file_location("core_supervisor_relay_fresh", _SRC)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_binds_the_shared_function_by_identity(self):
+        self.assertIs(_mod._channel_env_is_contained,
+                      channel_env_containment.channel_env_is_contained)
+
+    def test_containment_delegates_to_shared_module_not_a_copy(self):
+        """Stub the shared function to always refuse, reload the probe, and
+        confirm even an otherwise-deliverable app-support relocation is now
+        refused. If _is_deliverable carried its own copy of the rule, this
+        module-level stub would have no effect."""
+        with tempfile.TemporaryDirectory() as td:
+            cfg = tempfile.mkdtemp()
+            app = tempfile.mkdtemp()
+            self.addCleanup(shutil.rmtree, cfg, ignore_errors=True)
+            self.addCleanup(shutil.rmtree, app, ignore_errors=True)
+            real_dir = os.path.join(app, "channels", "dev-ag2space")
+            os.makedirs(real_dir)
+            with open(os.path.join(real_dir, ".env"), "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            link_dir = os.path.join(cfg, "channels", "dev-ag2space")
+            os.makedirs(link_dir)
+            os.symlink(os.path.join(real_dir, ".env"), os.path.join(link_dir, ".env"))
+
+            p = os.path.join(td, "last-owner-activity.json")
+            with open(p, "w") as f:
+                json.dump({"channel": "dev-ag2space", "channel_id": "!r:d"}, f)
+
+            saved = {k: os.environ.get(k) for k in ("CLAUDE_CONFIG_DIR", "SUTANDO_APP_SUPPORT")}
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+            os.environ["SUTANDO_APP_SUPPORT"] = app
+            try:
+                with patch.object(channel_env_containment, "channel_env_is_contained",
+                                  return_value=False):
+                    fresh = self._reload()
+                    self.assertEqual(fresh.resolve_active_target(p), ("", ""))
+            finally:
+                for k, v in saved.items():
+                    if v is None:
+                        os.environ.pop(k, None)
+                    else:
+                        os.environ[k] = v
 
 
 class TestBackendRecordContract(unittest.TestCase):

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
 import tempfile
 import contextlib
 import unittest
@@ -461,6 +462,59 @@ class TestResolveActiveTarget(unittest.TestCase):
                     del os.environ["CLAUDE_CONFIG_DIR"]
                 else:
                     os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def _with_env(self, **values):
+        """Set/unset env vars for one test; None means unset."""
+        saved = {k: os.environ.get(k) for k in values}
+        for k, v in values.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+        def _restore():
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+        self.addCleanup(_restore)
+
+    def _relocated_layout(self, source="ag2space"):
+        """$CLAUDE_CONFIG_DIR/channels/<source>/.env -> $APP/channels/<source>/.env,
+        the AG2 Space desktop-app layout (#3150/#3201). Returns (cfg, app)."""
+        cfg = tempfile.mkdtemp()
+        app = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, cfg, ignore_errors=True)
+        self.addCleanup(shutil.rmtree, app, ignore_errors=True)
+        real_dir = os.path.join(app, "channels", source)
+        os.makedirs(real_dir)
+        with open(os.path.join(real_dir, ".env"), "w") as f:
+            f.write("REMOTE_TASK_TOKEN=x\n")
+        link_dir = os.path.join(cfg, "channels", source)
+        os.makedirs(link_dir)
+        os.symlink(os.path.join(real_dir, ".env"), os.path.join(link_dir, ".env"))
+        return cfg, app
+
+    def test_app_support_relocated_env_is_deliverable(self):
+        # notify.py accepts $SUTANDO_APP_SUPPORT/channels/<source>/.env as a
+        # second root (#3150/#3201); the probe must agree or the lane never routes.
+        with tempfile.TemporaryDirectory() as td:
+            cfg, app = self._relocated_layout("dev-ag2space")
+            self._with_env(CLAUDE_CONFIG_DIR=cfg, SUTANDO_APP_SUPPORT=app)
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:d"})
+            self.assertEqual(resolve_active_target(p), ("dev-ag2space", "!r:d"))
+
+    def test_same_shape_outside_app_support_is_not_deliverable(self):
+        # Containment, not a leaf-shape match: same layout with the var unset or
+        # pointed at another root is a symlink the sender refuses — so must the probe.
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as other:
+            cfg, _app = self._relocated_layout("dev-ag2space")
+            p = self._write(td, {"channel": "dev-ag2space", "channel_id": "!r:d"})
+            self._with_env(CLAUDE_CONFIG_DIR=cfg, SUTANDO_APP_SUPPORT=None)
+            self.assertEqual(resolve_active_target(p), ("", ""))
+            self._with_env(SUTANDO_APP_SUPPORT=other)
+            self.assertEqual(resolve_active_target(p), ("", ""))
 
     def test_claude_home_tier_is_honored(self):
         # notify.py resolves CLAUDE_CONFIG_DIR -> CLAUDE_HOME -> ~/.claude; the

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -615,6 +615,32 @@ class TestChannelEnvContainmentDelegation(unittest.TestCase):
                     else:
                         os.environ[k] = v
 
+    def test_load_channel_env_containment_fails_closed_when_import_fails(self):
+        """The fallback lambda itself, not just the already-bound result:
+        force the shared module's import to fail and confirm the returned
+        callable refuses even an otherwise-valid-looking containment case —
+        never silently widen the guard just because the import failed."""
+        import builtins
+        real_import = builtins.__import__
+
+        def boom(name, *a, **kw):
+            if name == "channel_env_containment":
+                raise ImportError("simulated: src/ not importable")
+            return real_import(name, *a, **kw)
+
+        fresh = self._reload()
+        with patch.object(builtins, "__import__", boom):
+            fallback = fresh._load_channel_env_containment()
+
+        with tempfile.TemporaryDirectory() as td:
+            channels_dir = os.path.join(td, "channels")
+            env_dir = os.path.join(channels_dir, "dev-ag2space")
+            os.makedirs(env_dir)
+            env_path = os.path.join(env_dir, ".env")
+            with open(env_path, "w") as f:
+                f.write("REMOTE_TASK_TOKEN=x\n")
+            self.assertFalse(fallback(env_path, channels_dir, "dev-ag2space"))
+
 
 class TestBackendRecordContract(unittest.TestCase):
     """`_derive_backend` reads the file `core_heartbeat` wrote. The label and the

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -673,6 +673,28 @@ class TestSendRemoteGateway(unittest.TestCase):
                 result = mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
         self.assertFalse(result)
 
+    def test_load_channel_env_containment_fails_closed_when_import_fails(self):
+        """The fallback lambda itself, not just `_channel_env_is_contained`'s
+        already-bound result: force the shared src/channel_env_containment.py
+        import to fail and assert the returned callable refuses even an
+        otherwise-valid-looking containment case — never silently widen the
+        guard just because the import failed."""
+        import builtins
+        real_import = builtins.__import__
+
+        def boom(name, *a, **kw):
+            if name == "channel_env_containment":
+                raise ImportError("simulated: src/ not importable")
+            return real_import(name, *a, **kw)
+
+        with patch.object(builtins, "__import__", boom):
+            fallback = self.mod._load_channel_env_containment()
+
+        cfg, app = self._symlinked_channels_root()
+        env_path = os.path.join(cfg, "channels", "ag2space", ".env")
+        channels_dir = os.path.join(cfg, "channels")
+        self.assertFalse(fallback(env_path, channels_dir, "ag2space"))
+
     def test_remote_task_token_combined_form_delivers(self):
         """Regression for #2101 review round 2 (P1): the compact combined form in
         REMOTE_TASK_TOKEN itself (REMOTE_TASK_TOKEN=url|secret, no separate

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -21,6 +21,8 @@ REPO = Path(__file__).parent.parent
 SCRIPT = REPO / "skills" / "task-progress" / "scripts" / "notify.py"
 sys.path.insert(0, str(REPO / "src"))
 
+import channel_env_containment  # noqa: E402 — the shared module notify.py delegates to
+
 
 def _load() -> types.ModuleType:
     spec = importlib.util.spec_from_file_location("notify", SCRIPT)
@@ -656,6 +658,21 @@ class TestSendRemoteGateway(unittest.TestCase):
                          {"op": "message", "room_id": "!room:ag2.space", "body": "hi"})
         self.assertEqual(captured["auth"], "Bearer sekret")
 
+    def test_containment_delegates_to_shared_module_not_a_copy(self):
+        """Delegation, not re-implementation: stub the shared
+        src/channel_env_containment.py function to always refuse, and even
+        the legitimate app-support relocation (normally accepted) must now
+        be refused. If notify.py carried its own copy of the rule, this
+        module-level stub would have no effect and the send would still
+        succeed."""
+        cfg, app = self._symlinked_channels_root()
+        with patch.object(channel_env_containment, "channel_env_is_contained",
+                          return_value=False):
+            mod = _load()  # reload so the patched shared function is bound in
+            with patch.dict(os.environ, self._clean_env(cfg, app), clear=True):
+                result = mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
+        self.assertFalse(result)
+
     def test_remote_task_token_combined_form_delivers(self):
         """Regression for #2101 review round 2 (P1): the compact combined form in
         REMOTE_TASK_TOKEN itself (REMOTE_TASK_TOKEN=url|secret, no separate
@@ -878,6 +895,19 @@ class TestChannelEnvContainment(unittest.TestCase):
         os.environ.pop("REMOTE_TASK_URL", None)
         os.environ.pop("REMOTE_TASK_TOKEN", None)
         self.assertTrue(self._refused())
+
+
+class TestChannelEnvContainmentDelegation(unittest.TestCase):
+    """notify.py must call the shared src/channel_env_containment.py function,
+    not carry its own copy — the exact duplication CLAUDE.md's architecture
+    rules call out (see also TestSendRemoteGateway
+    .test_containment_delegates_to_shared_module_not_a_copy for the
+    behavioral half of this proof)."""
+
+    def test_binds_the_shared_function_by_identity(self):
+        mod = _load()
+        self.assertIs(mod._channel_env_is_contained,
+                      channel_env_containment.channel_env_is_contained)
 
 
 if __name__ == "__main__":

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -483,6 +483,109 @@ class TestSendRemoteGateway(unittest.TestCase):
         self.assertFalse(result)
 
 
+    def _symlinked_channels_root(
+        self,
+        source: str = "ag2space",
+        target_dirname: str | None = None,
+        target_filename: str = ".env",
+    ) -> str:
+        """A channels/<source>/.env that is a SYMLINK to a real file living in a
+        SEPARATE temp directory — mirrors the real-world AG2 Space desktop-app
+        layout, where `$CLAUDE_CONFIG_DIR/channels/ag2space/.env` symlinks OUT to
+        `<app-root>/channels/ag2space/.env` (see #3150/#3201). That is distinct
+        from `_hermetic_channels_root` above, which is deliberately a real file
+        (never a symlink) so tests that aren't about *this* guard stay pinned.
+
+        By default the symlink target keeps the same `<source>/.env` shape as
+        the real install (same immediate parent dirname, same filename) — that
+        is the one shape the containment guard is meant to accept. Pass
+        `target_dirname`/`target_filename` to break the shape, for the
+        regression test proving the guard still refuses everything else.
+        """
+        root = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        external = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, external, ignore_errors=True)
+
+        target_dir = external / (source if target_dirname is None else target_dirname)
+        target_dir.mkdir(parents=True)
+        target = target_dir / target_filename
+        target.write_text(
+            "REMOTE_TASK_URL=https://gw.example/relay\n"
+            "REMOTE_TASK_TOKEN=symlinked-token\n"
+        )
+
+        channel_dir = root / "channels" / source
+        channel_dir.mkdir(parents=True)
+        (channel_dir / ".env").symlink_to(target)
+
+        return str(root)
+
+    def test_symlinked_env_matching_shape_is_delivered(self):
+        """Regression for #3150/#3201: the AG2 Space desktop app installs
+        channels/<source>/.env as a symlink OUT of the channels dir, to a real
+        file whose own immediate parent directory is still named <source> — e.g.
+        realpath(.../workspace/.claude-sutando/channels/ag2space/.env) ==
+        .../space.ag2.app/channels/ag2space/.env. That is the app relocating its
+        own per-channel credential file while preserving the <source>/.env
+        relative shape, not an attacker-planted link to an arbitrary target, so
+        the guard must accept it and deliver — not refuse "outside channels dir"."""
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b'{"ok": true}'
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["auth"] = req.get_header("Authorization")
+            return mock_resp
+
+        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
+        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
+        clean_env["CLAUDE_CONFIG_DIR"] = self._symlinked_channels_root()
+        clean_env.pop("CLAUDE_HOME", None)
+        with patch.dict(os.environ, clean_env, clear=True), \
+             patch("urllib.request.urlopen", fake_urlopen):
+            result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
+        self.assertTrue(result)
+        self.assertEqual(captured["url"], "https://gw.example/relay/v1/room")
+        self.assertEqual(captured["auth"], "Bearer symlinked-token")
+
+    def test_symlinked_env_shape_mismatch_still_refused(self):
+        """The exception is a narrow SHAPE match (same filename, same immediate
+        parent dirname as the source) — not "any symlink is fine". A symlink
+        whose target does NOT have that shape (e.g. its parent directory isn't
+        named after the source — the shape an attacker-planted link to some
+        unrelated sensitive file would have) must still be refused. This is the
+        test that would catch an overly-broad "fix" that disabled the guard."""
+        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
+        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
+        clean_env["CLAUDE_CONFIG_DIR"] = self._symlinked_channels_root(
+            target_dirname="not-the-source")
+        clean_env.pop("CLAUDE_HOME", None)
+        err = io.StringIO()
+        with patch.dict(os.environ, clean_env, clear=True), \
+             contextlib.redirect_stderr(err):
+            result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
+        self.assertFalse(result)
+        self.assertIn("refusing env path outside channels dir", err.getvalue())
+
+    def test_symlinked_env_wrong_filename_still_refused(self):
+        """Same narrow-shape argument, other axis: the target file itself isn't
+        named `.env` (parent dirname matches, filename doesn't) — still refused."""
+        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
+        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
+        clean_env["CLAUDE_CONFIG_DIR"] = self._symlinked_channels_root(
+            target_filename="secrets.txt")
+        clean_env.pop("CLAUDE_HOME", None)
+        err = io.StringIO()
+        with patch.dict(os.environ, clean_env, clear=True), \
+             contextlib.redirect_stderr(err):
+            result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
+        self.assertFalse(result)
+        self.assertIn("refusing env path outside channels dir", err.getvalue())
+
     def _hermetic_channels_root(self, source: str = "ag2space") -> str:
         """A real channels/<source>/.env inside a temp dir, for CLAUDE_CONFIG_DIR.
 

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -486,28 +486,27 @@ class TestSendRemoteGateway(unittest.TestCase):
     def _symlinked_channels_root(
         self,
         source: str = "ag2space",
+        target_subdir: str = "channels",
         target_dirname: str | None = None,
         target_filename: str = ".env",
-    ) -> str:
-        """A channels/<source>/.env that is a SYMLINK to a real file living in a
-        SEPARATE temp directory — mirrors the real-world AG2 Space desktop-app
-        layout, where `$CLAUDE_CONFIG_DIR/channels/ag2space/.env` symlinks OUT to
-        `<app-root>/channels/ag2space/.env` (see #3150/#3201). That is distinct
-        from `_hermetic_channels_root` above, which is deliberately a real file
-        (never a symlink) so tests that aren't about *this* guard stay pinned.
+    ) -> tuple[str, str]:
+        """A channels/<source>/.env that is a SYMLINK to a real file living under
+        a SEPARATE app-support temp dir — mirrors the AG2 Space desktop-app
+        layout (launch-sutando.sh), where `$CLAUDE_CONFIG_DIR/channels/ag2space/.env`
+        symlinks OUT to `$SUTANDO_APP_SUPPORT/channels/ag2space/.env` (#3150/#3201).
+        Distinct from `_hermetic_channels_root` below, which is deliberately a
+        real file (never a symlink) so tests that aren't about this guard stay pinned.
 
-        By default the symlink target keeps the same `<source>/.env` shape as
-        the real install (same immediate parent dirname, same filename) — that
-        is the one shape the containment guard is meant to accept. Pass
-        `target_dirname`/`target_filename` to break the shape, for the
-        regression test proving the guard still refuses everything else.
+        Returns (config_dir, app_support). By default the target is EXACTLY the
+        one path the guard accepts under the app root; the keyword args move it
+        off that path for the regression tests proving everything else is refused.
         """
         root = pathlib.Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, root, ignore_errors=True)
-        external = pathlib.Path(tempfile.mkdtemp())
-        self.addCleanup(shutil.rmtree, external, ignore_errors=True)
+        app_support = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, app_support, ignore_errors=True)
 
-        target_dir = external / (source if target_dirname is None else target_dirname)
+        target_dir = app_support / target_subdir / (source if target_dirname is None else target_dirname)
         target_dir.mkdir(parents=True)
         target = target_dir / target_filename
         target.write_text(
@@ -519,17 +518,36 @@ class TestSendRemoteGateway(unittest.TestCase):
         channel_dir.mkdir(parents=True)
         (channel_dir / ".env").symlink_to(target)
 
-        return str(root)
+        return str(root), str(app_support)
 
-    def test_symlinked_env_matching_shape_is_delivered(self):
+    def _clean_env(self, config_dir: str, app_support: str | None) -> dict:
+        """os.environ with every gateway/base var the sender consults removed, so
+        the file-read path (and only it) is under test. SUTANDO_APP_SUPPORT is
+        set only when the test passes one — a dev running this suite inside the
+        desktop app's core session has the real one exported."""
+        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN",
+                 "AG2_REMOTE_URL", "CLAUDE_HOME", "SUTANDO_APP_SUPPORT")
+        env = {k: v for k, v in os.environ.items() if k not in _drop}
+        env["CLAUDE_CONFIG_DIR"] = config_dir
+        if app_support is not None:
+            env["SUTANDO_APP_SUPPORT"] = app_support
+        return env
+
+    def _refused(self, env: dict) -> bool:
+        err = io.StringIO()
+        with patch.dict(os.environ, env, clear=True), \
+             contextlib.redirect_stderr(err):
+            result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
+        self.assertFalse(result)
+        return "refusing env path outside channels dir" in err.getvalue()
+
+    def test_symlinked_env_under_app_support_is_delivered(self):
         """Regression for #3150/#3201: the AG2 Space desktop app installs
-        channels/<source>/.env as a symlink OUT of the channels dir, to a real
-        file whose own immediate parent directory is still named <source> — e.g.
-        realpath(.../workspace/.claude-sutando/channels/ag2space/.env) ==
-        .../space.ag2.app/channels/ag2space/.env. That is the app relocating its
-        own per-channel credential file while preserving the <source>/.env
-        relative shape, not an attacker-planted link to an arbitrary target, so
-        the guard must accept it and deliver — not refuse "outside channels dir"."""
+        channels/<source>/.env as a symlink OUT of the channels dir to
+        $SUTANDO_APP_SUPPORT/channels/<source>/.env, its own durable copy of the
+        same credential file. With SUTANDO_APP_SUPPORT exported (the app exports
+        it for every process it spawns) that target is inside the second
+        approved root, so the guard must accept it and deliver."""
         mock_resp = MagicMock()
         mock_resp.__enter__ = lambda s: s
         mock_resp.__exit__ = MagicMock(return_value=False)
@@ -541,50 +559,45 @@ class TestSendRemoteGateway(unittest.TestCase):
             captured["auth"] = req.get_header("Authorization")
             return mock_resp
 
-        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
-        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
-        clean_env["CLAUDE_CONFIG_DIR"] = self._symlinked_channels_root()
-        clean_env.pop("CLAUDE_HOME", None)
-        with patch.dict(os.environ, clean_env, clear=True), \
+        cfg, app = self._symlinked_channels_root()
+        with patch.dict(os.environ, self._clean_env(cfg, app), clear=True), \
              patch("urllib.request.urlopen", fake_urlopen):
             result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
         self.assertTrue(result)
         self.assertEqual(captured["url"], "https://gw.example/relay/v1/room")
         self.assertEqual(captured["auth"], "Bearer symlinked-token")
 
-    def test_symlinked_env_shape_mismatch_still_refused(self):
-        """The exception is a narrow SHAPE match (same filename, same immediate
-        parent dirname as the source) — not "any symlink is fine". A symlink
-        whose target does NOT have that shape (e.g. its parent directory isn't
-        named after the source — the shape an attacker-planted link to some
-        unrelated sensitive file would have) must still be refused. This is the
-        test that would catch an overly-broad "fix" that disabled the guard."""
-        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
-        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
-        clean_env["CLAUDE_CONFIG_DIR"] = self._symlinked_channels_root(
-            target_dirname="not-the-source")
-        clean_env.pop("CLAUDE_HOME", None)
-        err = io.StringIO()
-        with patch.dict(os.environ, clean_env, clear=True), \
-             contextlib.redirect_stderr(err):
-            result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
-        self.assertFalse(result)
-        self.assertIn("refusing env path outside channels dir", err.getvalue())
+    def test_symlinked_env_refused_when_app_support_unset(self):
+        """Fail-closed: the SAME layout without SUTANDO_APP_SUPPORT is just a
+        symlink to some <dir>/channels/ag2space/.env with the right leaf shape —
+        exactly the case a leaf-only check would wave through (review on #3416).
+        No approved second root means no exception."""
+        cfg, _app = self._symlinked_channels_root()
+        self.assertTrue(self._refused(self._clean_env(cfg, None)))
 
-    def test_symlinked_env_wrong_filename_still_refused(self):
-        """Same narrow-shape argument, other axis: the target file itself isn't
-        named `.env` (parent dirname matches, filename doesn't) — still refused."""
-        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
-        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
-        clean_env["CLAUDE_CONFIG_DIR"] = self._symlinked_channels_root(
-            target_filename="secrets.txt")
-        clean_env.pop("CLAUDE_HOME", None)
-        err = io.StringIO()
-        with patch.dict(os.environ, clean_env, clear=True), \
-             contextlib.redirect_stderr(err):
-            result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
-        self.assertFalse(result)
-        self.assertIn("refusing env path outside channels dir", err.getvalue())
+    def test_symlinked_env_under_a_different_root_is_refused(self):
+        """Shape is not identity: SUTANDO_APP_SUPPORT names one root, and a
+        target with the right `<source>/.env` shape under some OTHER root is
+        still outside it. This is the test that would catch a regression back
+        to matching the last two path components."""
+        cfg, _app = self._symlinked_channels_root()
+        other_root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, other_root, ignore_errors=True)
+        self.assertTrue(self._refused(self._clean_env(cfg, other_root)))
+
+    def test_symlinked_env_off_the_exact_path_under_app_support_is_refused(self):
+        """Even under the approved root, only the app's copy of THIS channel's
+        env is accepted: another channel's file, a same-shaped file outside
+        channels/, or a differently named file are all refused."""
+        cases = {
+            "other channel": dict(target_dirname="discord"),
+            "outside channels/": dict(target_subdir="workspace"),
+            "wrong filename": dict(target_filename="secrets.txt"),
+        }
+        for label, kwargs in cases.items():
+            with self.subTest(label):
+                cfg, app = self._symlinked_channels_root(**kwargs)
+                self.assertTrue(self._refused(self._clean_env(cfg, app)))
 
     def _hermetic_channels_root(self, source: str = "ag2space") -> str:
         """A real channels/<source>/.env inside a temp dir, for CLAUDE_CONFIG_DIR.


### PR DESCRIPTION
## The bug

`skills/task-progress/scripts/notify.py`'s `send_remote_gateway()` containment
guard refuses **any** `channels/<source>/.env` whose realpath resolves outside
`$CLAUDE_CONFIG_DIR/channels/`.

On a real AG2 Space desktop-app install, `$CLAUDE_CONFIG_DIR/channels/ag2space/.env`
is exactly that: a symlink the app's `launch-sutando.sh` lays to
`$SUTANDO_APP_SUPPORT/channels/ag2space/.env`, the app's durable copy of the
same credential file. The guard refuses it, so every `notify.py --source ag2space`
call that doesn't happen to source the channel env into `os.environ` first is
silently dropped — the mandated "on it" progress ping never reaches the owner.

Closes #3150
Closes #3201

## Prior art

- **#3150** is the root-cause analysis. It proposes (1) moving the app's symlink
  up a level (out of scope for this repo), or (2) "teach the guard a sanctioned
  target root" — flagged as needing a maintainer's call. This PR is (2).
- **#3201** is the original bug report, same root cause.
- **#3397** (open) is a **different, complementary** fix: it patches the
  auto-generated `===SKILL INSTRUCTIONS===` block so the generated notify step
  sources the channel env first and never reaches this guard. This PR fixes every
  other caller — manual invocations, cron-driven calls, any future caller.

## The fix

A second, **explicitly configured containment root** — not a pattern match on the
target path (the first revision of this PR did a leaf-shape match, which review
correctly pointed out is not containment: any reachable `<x>/<source>/.env` passed).

`_channel_env_is_contained(env_path, channels_dir, source)` accepts a resolution in
exactly two cases and fails closed otherwise:

1. it lands inside `realpath(channels_dir)` — the channels tree itself (unchanged);
2. it **is** `realpath($SUTANDO_APP_SUPPORT/channels/<source>/.env)` — the desktop
   app's own copy of this channel's file. `SUTANDO_APP_SUPPORT` is what the app
   exports to every process it spawns (it's the same variable its launcher uses to
   create the symlink), so the real install is fixed with no app change.

Still refused: the variable unset; a same-shaped `/tmp/<source>/.env` or
`~/x/<source>/.env`; another channel's file under the app root; a same-shaped
file under the app root but outside `channels/`; any traversal / escape shape the
existing suite already covers.

`src/core-supervisor-relay.py`'s `_is_deliverable` probe carries the same guard
with a "widen BOTH sides together" note, so it mirrors the two-root rule — otherwise
the app's ag2space lane would probe undeliverable while the sender delivers.

## Tests

`tests/task-progress-skill.test.py` (`TestSendRemoteGateway`):
- `_symlinked_channels_root()` — builds the real layout: `channels/<source>/.env`
  symlinked to a file under a separate app-support temp dir.
- `test_symlinked_env_under_app_support_is_delivered` — positive.
- `test_symlinked_env_refused_when_app_support_unset` — fail-closed.
- `test_symlinked_env_under_a_different_root_is_refused` — shape ≠ identity (the
  review case).
- `test_symlinked_env_off_the_exact_path_under_app_support_is_refused` — subTests:
  other channel, outside `channels/`, wrong filename.

`tests/core-supervisor-relay.test.py` (`TestResolveActiveTarget`):
- `test_app_support_relocated_env_is_deliverable` / `test_same_shape_outside_app_support_is_not_deliverable`.

## Evidence

**The three negatives catch the previous shape-match guard** (`notify.py` stashed,
tests present):

```
FAIL: test_symlinked_env_off_the_exact_path_under_app_support_is_refused [outside channels/]
FAIL: test_symlinked_env_refused_when_app_support_unset
FAIL: test_symlinked_env_under_a_different_root_is_refused
Ran 8 tests in 0.027s
FAILED (failures=3)
```

**Patched:** `tests/task-progress-skill.test.py` — 55 tests OK;
`tests/core-supervisor-relay.test.py` — 54 tests OK; `scripts/review-checks.sh` — PASS.

**Hermetic `env -i` repro of the real layout** (`app/workspace/.claude-sutando` as
config dir, `.env` symlinked to `app/channels/ag2space/.env`):

```
# (a) SUTANDO_APP_SUPPORT=$W/app  — the desktop case: past the guard, real POST attempted
[task-progress] send failed: <urlopen error [Errno 8] nodename nor servname provided, or not known>
# (b) SUTANDO_APP_SUPPORT unset  — fail-closed
[task-progress] refusing env path outside channels dir: .../app/workspace/.claude-sutando/channels/ag2space/.env
# (c) link re-pointed to $W/elsewhere/ag2space/.env (right leaf shape, wrong root) — refused
[task-progress] refusing env path outside channels dir: .../app/workspace/.claude-sutando/channels/ag2space/.env
```

(a) only fails because `gw.example` doesn't resolve — the guard is no longer the blocker.

## Known gaps / follow-up

- Does not touch `SKILL.md`'s documentation gap for the remote-gateway
  `--source <provider>` path — separate, larger doc gap.
- Does not touch #3397's generated-instruction-block fix — complementary, different code path.
