### PR TITLE
fix(migrate): hosts/ and relay/ join the migration surface — per-host state is data

### DIFF
--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -2325,7 +2325,9 @@ verify_main() {
                 fi
             fi
         done
-        if [ -n "$landed" ]; then
+        # A union entry must clear union_contains, which owns the manifest mode
+        # check; byte identity with one input must never stand in for it.
+        if [ -n "$landed" ] && [ "$cls" != "union-json-array" ]; then
             pass=$((pass+1))
         elif [ "$cls" = "union-json-array" ] && [ -f "$dst_canonical" ] \
                 && union_contains "$src_file" "$dst_canonical" \

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -94,11 +94,11 @@ WORKSPACE_SURFACE_DIRS=(
     # Owner-custom tooling surface (report c8310df7): <workspace>/scripts is
     # DATA. The repo's own scripts/ is code — excluded via SOURCE_A_EXCLUDE.
     "scripts"
-    # Agent config tree (report 9de2a03d): skills, settings, hooks, memory.
-    # Quarantining it silently breaks every configured hook/skill path.
+    # Agent config tree: skills, settings, hooks, memory. Quarantining it
+    # silently breaks every configured hook/skill path.
     ".claude-sutando"
-    # Per-host state tree (tk-7e767bb426 class): crons.json, PERSONAL_CLAUDE.md,
-    # pending-questions, current-track — every reader resolves hosts/<label>/.
+    # Per-host state tree: crons.json, PERSONAL_CLAUDE.md, pending-questions,
+    # current-track — every reader resolves hosts/<label>/.
     "hosts"
     # Session-relay notes: the next session's catchup input.
     "relay"
@@ -388,7 +388,7 @@ record_xsrc() {
     local mt sz
     mt="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || echo 0)"
     sz="$(stat -f %z "$file" 2>/dev/null || stat -c %s "$file" 2>/dev/null || echo 0)"
-    printf '%s\t%s\t%s\t%s\t%s\n' "$rel" "$tag" "$cls" "$mt" "$sz" >> "$XSRC_INDEX"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$rel" "$tag" "$cls" "$mt" "$sz" "$file" >> "$XSRC_INDEX"
 }
 
 scan_source() {
@@ -794,28 +794,43 @@ report_cross_source() {
         return
     fi
 
-    # Identical-content collisions: cross-source rows where ALL entries share
-    # the same mtime AND size for the relpath. High-confidence "same file
-    # mirrored through sync" — commit can pick one source as canonical and
-    # skip the rest (no real conflict). Common case: memory-sync mirroring
-    # notes/ between B and C.
+    # Identical-content collisions: byte-verified (sha256 over every entry of
+    # the relpath). An unreadable entry fails closed to divergent — a proxy
+    # match (mtime+size) must never certify content identity.
     local total_identical
-    # Concatenated-key idiom (BSD awk has no array-of-array); detect identical
-    # across all entries of a relpath by counting distinct (mtime,size) pairs.
-    total_identical="$(awk -F'\t' '
-        {
-            n[$1]++
-            key = $1 SUBSEP $4 "|" $5
-            if (!(key in seen)) { seen[key]=1; pairs[$1]++ }
-        }
-        END {
-            ident=0
-            for (k in n) if (n[k]>1 && pairs[k]==1) ident++
-            print ident
-        }
-    ' "$XSRC_INDEX" 2>/dev/null || echo 0)"
+    total_identical="$(python3 - "$XSRC_INDEX" <<'PYIDENT'
+import sys, hashlib
+from collections import defaultdict
+by_rel = defaultdict(list)
+try:
+    with open(sys.argv[1]) as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) >= 6:
+                by_rel[parts[0]].append(parts[5])
+except OSError:
+    print(0); raise SystemExit
+def sha(path):
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+ident = 0
+for rel, paths in by_rel.items():
+    if len(paths) < 2:
+        continue
+    hs = {sha(p) for p in paths}
+    if None not in hs and len(hs) == 1:
+        ident += 1
+print(ident)
+PYIDENT
+)"
 
-    REPORT_LINES+=("  of which identical-content (same mtime + size):  $total_identical (commit will pick one canonical + skip rest)")
+    REPORT_LINES+=("  of which identical-content (byte-verified):  $total_identical (commit will pick one canonical + skip rest)")
     REPORT_LINES+=("  genuine cross-source conflicts (need strategy):  $((total_xs - total_identical))")
 
     # Per-class breakdown of cross-source collisions
@@ -2160,15 +2175,33 @@ entries = []
 if os.path.exists(idx_path):
     with open(idx_path) as f:
         for line in f:
-            rel, tag, cls, mt, sz = line.rstrip("\n").split("\t")
+            parts = line.rstrip("\n").split("\t")
+            rel, tag, cls, mt, sz = parts[:5]
+            path = parts[5] if len(parts) > 5 else ""
             entries.append({"rel": rel, "tag": tag, "class": cls,
-                            "mtime": int(mt or 0), "size": int(sz or 0)})
+                            "mtime": int(mt or 0), "size": int(sz or 0),
+                            "path": path})
 by_rel = defaultdict(list)
 for e in entries:
     by_rel[e["rel"]].append(e)
 collisions = {k: v for k, v in by_rel.items() if len(v) > 1}
-identical = sum(1 for v in collisions.values()
-                if len({(e["mtime"], e["size"]) for e in v}) == 1)
+import hashlib
+def _sha(path):
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+def byte_identical(v):
+    """Content identity is HASH identity; an unreadable entry fails closed to
+    divergent — a proxy match (mtime+size) must never certify it."""
+    hs = {_sha(e["path"]) for e in v}
+    return None not in hs and len(hs) == 1
+ident_verdict = {k: byte_identical(v) for k, v in collisions.items()}
+identical = sum(1 for x in ident_verdict.values() if x)
 genuine = len(collisions) - identical
 by_class = defaultdict(int)
 for v in collisions.values():
@@ -2178,36 +2211,43 @@ def has_size_mismatch(entries):
     return len({e["size"] for e in entries}) > 1
 def has_mtime_mismatch(entries):
     return len({e["mtime"] for e in entries}) > 1
-# Sort by actionability: size-mismatch (real content conflict) first, then
-# mtime-only diff (commit's newest-mtime resolves it), then identical
-# (drop-dup). Tiebreak by class then rel.
+# Sort by actionability: any byte-divergent collision whose proxies agree
+# (equal mtime+size, different content) is as real as a size mismatch and
+# sorts first with it; then mtime-only, then byte-identical (drop-dup).
 def sort_key(item):
     k, v = item
-    sz_diff = has_size_mismatch(v)
-    mt_diff = has_mtime_mismatch(v)
-    # priority: 0=size-diff (real), 1=mtime-only, 2=identical
-    if sz_diff: prio = 0
-    elif mt_diff: prio = 1
-    else: prio = 2
+    if has_size_mismatch(v) or not ident_verdict[k]:
+        prio = 0
+    elif has_mtime_mismatch(v):
+        prio = 1
+    else:
+        prio = 2
     return (prio, v[0]["class"], k)
 notable = [{"class": v[0]["class"], "rel": k,
+            "byte_identical": ident_verdict[k],
             "size_mismatch": has_size_mismatch(v),
             "mtime_mismatch": has_mtime_mismatch(v),
             "entries": [{"tag": e["tag"], "mtime": e["mtime"], "size": e["size"]} for e in v]}
            for k, v in sorted(collisions.items(), key=sort_key)]
 size_diff = sum(1 for v in collisions.values() if has_size_mismatch(v))
-mtime_only = sum(1 for v in collisions.values() if not has_size_mismatch(v) and has_mtime_mismatch(v))
+mtime_only = sum(1 for k, v in collisions.items() if not has_size_mismatch(v)
+                 and has_mtime_mismatch(v) and not ident_verdict[k])
+proxy_identical_divergent = sum(
+    1 for k, v in collisions.items()
+    if not has_size_mismatch(v) and not has_mtime_mismatch(v) and not ident_verdict[k])
 out = {
     "dest": dest,
     "sources": {"A": a or None, "B": b or None, "C": c or None},
     "totals": {
         "unique_relpaths": len(by_rel),
         "collisions": len(collisions),
-        "identical_content": identical,
+        "identical_content": identical,  # byte-verified, never proxy-inferred
         "mtime_only_diff": mtime_only,  # commit's newest-mtime auto-resolves
-        "size_mismatch": size_diff,     # the actionable subset — real content conflicts
-        # Legacy "genuine_conflicts" kept for backward-compat; equals mtime_only + size_mismatch
-        "genuine_conflicts": genuine,
+        "size_mismatch": size_diff,     # actionable — real content conflicts
+        # Actionable — equal mtime+size but different bytes; the proxies lie here.
+        "proxy_identical_divergent": proxy_identical_divergent,
+        "genuine_conflicts": genuine,   # collisions - byte-identical
+
         "by_class": dict(by_class),
     },
     "notable_collisions": notable[:50],

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1079,10 +1079,8 @@ copy_preserving_mtime() {
     fi
 }
 
-# Unions top-level arrays; non-array fields follow the newer source.
-# Malformed input returns non-zero — a silent degrade is access loss.
-# Pure merge policy: containment is commit_one's concern and is NOT enforced
-# here, so standalone callers can drive it against arbitrary paths.
+# Unions top-level arrays; non-array fields follow the newer source. Malformed
+# input returns non-zero, and containment is commit_one's concern, not this.
 union_json_arrays_into() {
     local src="$1" dst="$2"
     mkdir -p "$(dirname "$dst")"
@@ -1224,12 +1222,13 @@ if manifest and rel and os.path.exists(manifest):
     if not isinstance(m, dict) or rel not in m or not isinstance(m[rel], dict):
         sys.exit(1)
     expected = m[rel]
-    # A widened dest is a disclosure the scalar comparison cannot see. Absent
-    # on pre-key manifests: nothing to check there, which is not a failure.
+    # record_union_scalars writes the mode beside every rel it records, so a
+    # missing table or rel is damage; certifying an unknown mode is the leak.
     modes = m.get("__union_modes__")
-    if isinstance(modes, dict) and rel in modes:
-        if oct(stat.S_IMODE(os.stat(dst).st_mode)) != modes[rel]:
-            sys.exit(1)
+    if not isinstance(modes, dict) or rel not in modes:
+        sys.exit(1)
+    if oct(stat.S_IMODE(os.stat(dst).st_mode)) != modes[rel]:
+        sys.exit(1)
 if expected is not None:
     have = {k: v for k, v in d.items() if not isinstance(v, list)}
     if have != expected:
@@ -1414,6 +1413,11 @@ commit_one() {
                 return 0
             fi
             if identity_match "$src_file" "$dst_path"; then
+                # The union carries the winner's mtime forward; a drop must too,
+                # or a later OLDER source outranks it and its scalars win.
+                if [ "$src_file" -nt "$dst_path" ]; then
+                    touch -r "$src_file" "$dst_path"
+                fi
                 echo "identical-drop"
                 return 0
             fi

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1153,7 +1153,7 @@ union_contains() {
     local py; py="$(resolve_python "$REPO_DIR")"
     [ -n "$py" ] || return 1
     "$py" - "$src" "$dst" <<'PY'
-import json, sys
+import json, os, sys
 
 src, dst = sys.argv[1:3]
 try:
@@ -1161,18 +1161,27 @@ try:
         s = json.load(fh)
     with open(dst, encoding="utf-8") as fh:
         d = json.load(fh)
+    src_mt = os.path.getmtime(src)
+    dst_mt = os.path.getmtime(dst)
 except Exception:
     sys.exit(1)
 if not isinstance(s, dict) or not isinstance(d, dict):
     sys.exit(1)
+# The union stamps the dest with the WINNER's mtime, and the writer contract
+# says non-array fields come from that winner. So when THIS source's mtime
+# equals the dest's, its scalars won and must survive verbatim; a dest mtime
+# newer than every source means the pre-union dest won, whose content is not
+# recoverable per-source — arrays alone are checkable there.
+scalar_winner = src_mt == dst_mt
 for key, val in s.items():
-    if not isinstance(val, list):
-        continue
-    dv = d.get(key)
-    if not isinstance(dv, list):
-        sys.exit(1)
-    have = {json.dumps(e, sort_keys=True) for e in dv}
-    if any(json.dumps(e, sort_keys=True) not in have for e in val):
+    if isinstance(val, list):
+        dv = d.get(key)
+        if not isinstance(dv, list):
+            sys.exit(1)
+        have = {json.dumps(e, sort_keys=True) for e in dv}
+        if any(json.dumps(e, sort_keys=True) not in have for e in val):
+            sys.exit(1)
+    elif scalar_winner and (key not in d or d[key] != val):
         sys.exit(1)
 sys.exit(0)
 PY

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -785,7 +785,7 @@ index_dest_for_collisions() {
 xsrc_identity_verdicts() {
     local py; py="$(require_python "$REPO_DIR" "hash cross-source collisions")" || exit 2
     "$py" - "$XSRC_INDEX" <<'PYIDENT'
-import sys, json, hashlib
+import sys, os, json, hashlib
 from collections import defaultdict
 by_rel = defaultdict(list)
 try:
@@ -805,14 +805,24 @@ def sha(path):
         return h.hexdigest()
     except OSError:
         return None
+def ident_key(path):
+    # Identity is bytes AND mode — same rule as the shell's identity_match, so
+    # the scan's "identical" can never promise a drop commit would not honor.
+    h = sha(path)
+    if h is None:
+        return None
+    try:
+        return (h, oct(os.stat(path).st_mode & 0o7777))
+    except OSError:
+        return None
 out = {}
 for rel, paths in by_rel.items():
     if len(paths) < 2:
         continue
-    hs = [sha(p) for p in paths]
-    if None in hs:
+    ks = [ident_key(p) for p in paths]
+    if None in ks:
         out[rel] = "unverified"
-    elif len(set(hs)) == 1:
+    elif len(set(ks)) == 1:
         out[rel] = "identical"
     else:
         out[rel] = "divergent"
@@ -1165,6 +1175,20 @@ preflight_summary() {
 }
 
 # SHA-256 verify (macOS shasum / Linux sha256sum). Returns 0 if hashes match.
+# Permission bits only (no file-type prefix): BSD %Lp and GNU %a agree.
+mode_of() {
+    stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1"
+}
+
+# The ONE identity decision (kewei review, blocker 2): equal bytes alone must
+# never certify a duplicate — copy_preserving_mtime preserves MODE, and these
+# classes include owner scripts and hooks, so a dropped 0755 source against a
+# 0644 dest silently loses the exec bit with no backup carrying it. Identity
+# is bytes AND mode, and scan/commit/verify/delete all use this same test.
+identity_match() {
+    sha_match "$1" "$2" && [ "$(mode_of "$1")" = "$(mode_of "$2")" ]
+}
+
 sha_match() {
     local a="$1" b="$2"
     local ha hb
@@ -1192,7 +1216,7 @@ commit_one() {
                 echo "copied"
                 return 0
             fi
-            if sha_match "$src_file" "$dst_path"; then
+            if identity_match "$src_file" "$dst_path"; then
                 echo "identical-drop"
                 return 0
             fi
@@ -1210,12 +1234,15 @@ commit_one() {
         structural|collision-keep-both)
             dst_path="$DEST_REAL/$rel"
             if [ -e "$dst_path" ]; then
-                # Identical content (sha) → identical-drop. mtime+size alone
-                # certified equal-mtime/equal-size DIFFERENT bytes as identical.
+                # Identity (bytes AND mode) → identical-drop. mtime+size alone
+                # certified equal-mtime/equal-size DIFFERENT bytes as identical,
+                # and bytes alone dropped a 0755 source against a 0644 dest.
+                # A mode-only difference falls through to keep-both below, so
+                # the source's mode survives in whichever file carries it.
                 local src_mt dst_mt
                 src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
                 dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
-                if sha_match "$src_file" "$dst_path"; then
+                if identity_match "$src_file" "$dst_path"; then
                     echo "identical-drop"
                     return 0
                 fi
@@ -1678,7 +1705,7 @@ commit_source() {
                 "$DEST_REAL/$rel_d" \
                 "$DEST_REAL/legacy/$tag/$rel_d" \
                 "$DEST_REAL/legacy/$tag/quarantine/$rel_d"; do
-                if [ -f "$cand" ] && sha_match "$file" "$cand"; then
+                if [ -f "$cand" ] && identity_match "$file" "$cand"; then
                     matched="$cand"; break
                 fi
             done
@@ -1688,7 +1715,7 @@ commit_source() {
             if [ -z "$matched" ]; then
                 local g
                 for g in "$DEST_REAL/$rel_d.legacy-"*; do
-                    if [ -f "$g" ] && sha_match "$file" "$g"; then
+                    if [ -f "$g" ] && identity_match "$file" "$g"; then
                         matched="$g"; break
                     fi
                 done
@@ -1698,7 +1725,7 @@ commit_source() {
             if [ -z "$matched" ] && [ "$cls_d" = "rehome-state" ]; then
                 local b="$(basename "$rel_d")"
                 for cand in "$DEST_REAL/state/auth/$b" "$DEST_REAL/state/$b"; do
-                    if [ -f "$cand" ] && sha_match "$file" "$cand"; then
+                    if [ -f "$cand" ] && identity_match "$file" "$cand"; then
                         matched="$cand"; break
                     fi
                 done
@@ -2068,7 +2095,7 @@ verify_main() {
         done
         for cand in "${cands[@]}"; do
             if [ -f "$cand" ]; then
-                if sha_match "$src_file" "$cand"; then
+                if identity_match "$src_file" "$cand"; then
                     landed="$cand"; break
                 fi
             fi
@@ -2217,7 +2244,9 @@ _MAP = {"identical": True, "divergent": False, "unverified": None}
 ident_verdict = {k: _MAP[_verdicts.get(k, "unverified")] for k in collisions}
 identical = sum(1 for x in ident_verdict.values() if x is True)
 unverified = sum(1 for x in ident_verdict.values() if x is None)
-genuine = len(collisions) - identical
+# Proven divergence ONLY: unverified stays its own class — unknown must never
+# be published as genuine conflict (they already surface as identity_unverified).
+genuine = sum(1 for x in ident_verdict.values() if x is False)
 by_class = defaultdict(int)
 for v in collisions.values():
     by_class[v[0]["class"]] += 1
@@ -2226,24 +2255,31 @@ def has_size_mismatch(entries):
     return len({e["size"] for e in entries}) > 1
 def has_mtime_mismatch(entries):
     return len({e["mtime"] for e in entries}) > 1
-# Actionability sort: size-mismatch, verified-divergent-with-agreeing-proxies,
-# and unverified first; then mtime-only; byte-identical (drop-dup) last.
+# Actionability sort keys on the VERDICT first: every divergent (False) and
+# unverified (None) entry outranks every byte-identical (True) one, whatever
+# the mtimes — the old shape put identical-with-differing-mtimes in the same
+# bucket as verified mtime-only divergence, so 50 ignorable entries could
+# push the one actionable entry past the render cap.
 def sort_key(item):
     k, v = item
-    if has_size_mismatch(v) or ident_verdict[k] is None or (
-            ident_verdict[k] is False and not has_mtime_mismatch(v)):
+    if ident_verdict[k] is not True:
         prio = 0
-    elif has_mtime_mismatch(v):
+    elif has_mtime_mismatch(v) or has_size_mismatch(v):
         prio = 1
     else:
         prio = 2
     return (prio, v[0]["class"], k)
-notable = [{"class": v[0]["class"], "rel": k,
-            "byte_identical": ident_verdict[k],
-            "size_mismatch": has_size_mismatch(v),
-            "mtime_mismatch": has_mtime_mismatch(v),
-            "entries": [{"tag": e["tag"], "mtime": e["mtime"], "size": e["size"]} for e in v]}
-           for k, v in sorted(collisions.items(), key=sort_key)]
+_rows = [{"class": v[0]["class"], "rel": k,
+          "byte_identical": ident_verdict[k],
+          "size_mismatch": has_size_mismatch(v),
+          "mtime_mismatch": has_mtime_mismatch(v),
+          "entries": [{"tag": e["tag"], "mtime": e["mtime"], "size": e["size"]} for e in v]}
+         for k, v in sorted(collisions.items(), key=sort_key)]
+# The cap may only ever trim IGNORABLE rows: every actionable entry (verdict
+# False or None) is retained even when there are more than 50 of them.
+_actionable = [r for r in _rows if r["byte_identical"] is not True]
+_ignorable = [r for r in _rows if r["byte_identical"] is True]
+notable = _actionable + _ignorable[: max(0, 50 - len(_actionable))]
 size_diff = sum(1 for v in collisions.values() if has_size_mismatch(v))
 mtime_only = sum(1 for k, v in collisions.items() if not has_size_mismatch(v)
                  and has_mtime_mismatch(v) and ident_verdict[k] is False)
@@ -2264,11 +2300,11 @@ out = {
         "proxy_identical_divergent": proxy_identical_divergent,
         # Actionable — hash failed (unreadable entry); fix permissions, re-scan.
         "identity_unverified": unverified,
-        "genuine_conflicts": genuine,   # collisions - byte-identical (incl. unverified)
+        "genuine_conflicts": genuine,   # verified-divergent only; unverified is separate
 
         "by_class": dict(by_class),
     },
-    "notable_collisions": notable[:50],
+    "notable_collisions": notable,
 }
 json.dump(out, sys.stdout, indent=2)
 print()

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -257,7 +257,7 @@ CLASS_RULES=(
     "agent-inbox/*|structural"
     "scripts/*|collision-keep-both"  # owner-custom tools: user content, never drop a version
     ".claude-sutando/*|structural"  # agent config tree: same relpath, never clobber dest
-    "hosts/*|structural"  # per-host identity state: same relpath, never clobber (as state/auth)
+    "hosts/*|structural"  # per-host identity state; collisions keep both (newer primary + sidecar)
     "relay/*|structural"
     # Catchall — per Lucy #design 2026-06-02 + owner direction: workspace
     # sources B+C may have user-custom dirs/files (experiments/, obsidian-vault/,
@@ -1174,14 +1174,12 @@ commit_one() {
         structural|collision-keep-both)
             dst_path="$DEST_REAL/$rel"
             if [ -e "$dst_path" ]; then
-                # Same content (mtime+size) → identical-drop. Different →
-                # keep-both: rename source-incoming to <file>.legacy-<tag>.
-                local src_mt src_sz dst_mt dst_sz
+                # Identical content (sha) → identical-drop. mtime+size alone
+                # certified equal-mtime/equal-size DIFFERENT bytes as identical.
+                local src_mt dst_mt
                 src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
-                src_sz="$(stat -f %z "$src_file" 2>/dev/null || stat -c %s "$src_file")"
                 dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
-                dst_sz="$(stat -f %z "$dst_path" 2>/dev/null || stat -c %s "$dst_path")"
-                if [ "$src_mt" = "$dst_mt" ] && [ "$src_sz" = "$dst_sz" ]; then
+                if sha_match "$src_file" "$dst_path"; then
                     echo "identical-drop"
                     return 0
                 fi

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -97,6 +97,11 @@ WORKSPACE_SURFACE_DIRS=(
     # Agent config tree (report 9de2a03d): skills, settings, hooks, memory.
     # Quarantining it silently breaks every configured hook/skill path.
     ".claude-sutando"
+    # Per-host state tree (tk-7e767bb426 class): crons.json, PERSONAL_CLAUDE.md,
+    # pending-questions, current-track — every reader resolves hosts/<label>/.
+    "hosts"
+    # Session-relay notes: the next session's catchup input.
+    "relay"
 )
 
 # Per `feedback_per_source_surface_lists` 2026-06-02: dirs in Mini's #7
@@ -252,6 +257,8 @@ CLASS_RULES=(
     "agent-inbox/*|structural"
     "scripts/*|collision-keep-both"  # owner-custom tools: user content, never drop a version
     ".claude-sutando/*|structural"  # agent config tree: same relpath, never clobber dest
+    "hosts/*|structural"  # per-host identity state: same relpath, never clobber (as state/auth)
+    "relay/*|structural"
     # Catchall — per Lucy #design 2026-06-02 + owner direction: workspace
     # sources B+C may have user-custom dirs/files (experiments/, obsidian-vault/,
     # personal-src/, repro-*.ts, etc.) outside the canonical surface. Anything

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1013,9 +1013,33 @@ any_source_sentinel() {
 }
 
 # Atomic per-file copy preserving mtime. Returns 0 on success.
+# Mirror source directory modes onto the destination chain. `cp -p` carries a
+# FILE's mode; parents created by `mkdir -p` would otherwise take umask, so a
+# 0700 source dir lands 0755 and exposes its contents to other local accounts.
+# Never widens: the dest dir takes the INTERSECTION, the same non-widening rule
+# the union-json path already applies to files.
+mirror_dir_modes() {
+    local s d
+    s="$(dirname "$1")"; d="$(dirname "$2")"
+    local -a sd=() dd=()
+    while [ "$s" != "/" ] && [ "$d" != "/" ] && [ "$(basename "$s")" = "$(basename "$d")" ]; do
+        sd+=("$s"); dd+=("$d")
+        s="$(dirname "$s")"; d="$(dirname "$d")"
+    done
+    local i sm dm
+    for (( i=${#sd[@]}-1; i>=0; i-- )); do
+        [ -d "${sd[$i]}" ] && [ -d "${dd[$i]}" ] || continue
+        sm="$(mode_of "${sd[$i]}")"; dm="$(mode_of "${dd[$i]}")"
+        [ -n "$sm" ] && [ -n "$dm" ] || continue
+        [ "$sm" = "$dm" ] && continue
+        chmod "$(printf '%o' $(( 0$sm & 0$dm )))" "${dd[$i]}" 2>/dev/null || true
+    done
+}
+
 copy_preserving_mtime() {
     local src="$1" dst="$2"
     mkdir -p "$(dirname "$dst")"
+    mirror_dir_modes "$src" "$dst"
     # Atomic: cp -p to sibling tmp then mv. -p preserves mtime + mode.
     local tmp="$dst.tmp.$$"
     cp -p "$src" "$tmp" && mv -f "$tmp" "$dst"

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1042,11 +1042,8 @@ mirror_dir_modes() {
     return "$rc"
 }
 
-# Create (if needed) and physically validate the directory a dest write will
-# land in. A textual prefix test passes a symlinked component while the
-# mutation escapes the rollback boundary, so containment is proven on the
-# RESOLVED path — and the deepest existing ancestor is checked BEFORE mkdir,
-# so a symlink escape refuses without creating anything outside either.
+# Containment is proven on the RESOLVED path and BEFORE mkdir: a textual
+# prefix test passes a symlinked component that escapes the rollback root.
 ensure_contained_destdir() {
     local ddir="$1" probe real
     probe="$ddir"
@@ -1064,9 +1061,8 @@ ensure_contained_destdir() {
     esac
 }
 
-# Atomic per-file copy preserving mtime. Returns 0 on success; any mkdir,
-# containment, directory-mode, or copy failure returns non-zero so the commit
-# outcome can fail closed instead of certifying a write that did not happen.
+# Atomic per-file copy preserving mtime. Any mkdir/containment/mode/copy
+# failure returns non-zero, so commit fails closed instead of certifying it.
 copy_preserving_mtime() {
     local src="$1" dst="$2"
     ensure_contained_destdir "$(dirname "$dst")" || return 1
@@ -1085,9 +1081,8 @@ copy_preserving_mtime() {
 
 # Unions top-level arrays; non-array fields follow the newer source.
 # Malformed input returns non-zero — a silent degrade is access loss.
-# NB: pure merge policy — no dest-boundary enforcement here. Containment is
-# the COMMIT path's concern (commit_one), so standalone callers and the test
-# harness can drive the policy against arbitrary paths.
+# Pure merge policy: containment is commit_one's concern and is NOT enforced
+# here, so standalone callers can drive it against arbitrary paths.
 union_json_arrays_into() {
     local src="$1" dst="$2"
     mkdir -p "$(dirname "$dst")"
@@ -1147,10 +1142,8 @@ PY
     return 1
 }
 
-# Record the union result's non-array fields so mandatory verification can
-# check the scalar winner even when the PRE-UNION DEST won (its content is
-# otherwise unrecoverable per-source). One manifest per backup id, keyed by
-# rel; the last union for a rel wins, matching the file's final state.
+# Records the union's non-array fields so verification can check the scalar
+# winner even when the PRE-UNION DEST won; last union for a rel wins.
 record_union_scalars() {
     local dst="$1" rel="$2" manifest="$3"
     local py; py="$(resolve_python "$REPO_DIR")"
@@ -1182,10 +1175,8 @@ union_mode = stat.S_IMODE(os.stat(dst).st_mode)
 modes = m.get(MODES_KEY)
 m[MODES_KEY] = ({} if not isinstance(modes, dict) else modes)
 m[MODES_KEY][rel] = oct(union_mode)
-# The manifest holds every union's non-array state, so it must be no wider than
-# the most restrictive file it describes — a 0600 source's scalars in a 0644
-# manifest is the same disclosure, one file over. Create at 0600 so it is never
-# briefly world-readable, then narrow to the intersection.
+# No wider than the most restrictive file it describes: a 0600 source's
+# scalars in a 0644 manifest disclose the same bytes. Create 0600, then narrow.
 want_mode = union_mode
 if os.path.exists(manifest):
     want_mode &= stat.S_IMODE(os.stat(manifest).st_mode)
@@ -1198,10 +1189,8 @@ os.replace(tmp, manifest)
 PY
 }
 
-# Semantic-verify companion to union_json_arrays_into: same element
-# fingerprint (sorted-key JSON). A union result differs from both inputs BY
-# DESIGN, so the per-source invariant is containment — every array element of
-# the source present in the dest — not byte identity.
+# Semantic companion to union_json_arrays_into, same sorted-key fingerprint:
+# the invariant is containment of every source element, not byte identity.
 union_contains() {
     local src="$1" dst="$2" manifest="${3:-}" rel="${4:-}"
     local py; py="$(resolve_python "$REPO_DIR")"
@@ -1221,17 +1210,12 @@ except Exception:
     sys.exit(1)
 if not isinstance(s, dict) or not isinstance(d, dict):
     sys.exit(1)
-# Scalars, strongest evidence first: the commit-time manifest holds the
-# union result's non-array fields whichever side won, so the dest must match
-# it exactly. Without a manifest entry, fall back to the mtime invariant: the
-# union stamps the dest with the WINNER's mtime, so an mtime-equal source's
-# scalars must survive verbatim; only when neither source of truth exists do
-# arrays alone remain checkable.
+# Scalars, strongest evidence first: the commit-time manifest, else the
+# union's WINNER-mtime invariant, else arrays alone.
 expected = None
 if manifest and rel and os.path.exists(manifest):
-    # A present manifest is the AUTHORITY: parse/type failures and a missing
-    # rel entry are damage and must FAIL — degrading to the mtime fallback
-    # would let a dest-winner corruption pass by damaging the manifest.
+    # A present manifest is AUTHORITATIVE: parse/type failure or a missing rel
+    # is damage and must FAIL, or damaging it would buy the weaker fallback.
     try:
         with open(manifest, encoding="utf-8") as fh:
             m = json.load(fh)
@@ -1240,9 +1224,8 @@ if manifest and rel and os.path.exists(manifest):
     if not isinstance(m, dict) or rel not in m or not isinstance(m[rel], dict):
         sys.exit(1)
     expected = m[rel]
-    # The commit recorded what the union's mode should be; a widened dest is a
-    # disclosure the scalar comparison cannot see. Absent for manifests written
-    # before this key existed — then there is nothing to check, not a failure.
+    # A widened dest is a disclosure the scalar comparison cannot see. Absent
+    # on pre-key manifests: nothing to check there, which is not a failure.
     modes = m.get("__union_modes__")
     if isinstance(modes, dict) and rel in modes:
         if oct(stat.S_IMODE(os.stat(dst).st_mode)) != modes[rel]:
@@ -1841,9 +1824,8 @@ commit_source() {
             n_skipped=$((n_skipped+1)); continue
         fi
         cls="$(classify "$rel")"
-        # || true: the failure signal is the outcome string; the tally below
-        # decides the source's fate, so one bad file cannot abort the walk
-        # half-committed with no summary and no verdict.
+        # || true: the outcome string is the failure signal and the tally
+        # below judges, so one bad file cannot abort the walk with no verdict.
         outcome="$(commit_one "$file" "$rel" "$tag" "$cls")" || true
         # Per-file progress on stderr — visible feedback during the copy walk
         # so long migrations don't feel like a hang. Skipped when PROGRESS_TOTAL
@@ -2333,9 +2315,8 @@ verify_main() {
                 && union_contains "$src_file" "$dst_canonical" \
                     "$(ls -t "$DEST_REAL/state/.migration-union-scalars-"*.json 2>/dev/null | head -1)" \
                     "$rel"; then
-            # A union result is byte-different from both inputs by design;
-            # the per-source invariant is array containment, checked through
-            # the union policy owner's own element fingerprint.
+            # A union result differs from both inputs by design, so the
+            # invariant is containment via the union owner's fingerprint.
             pass=$((pass+1))
         elif [ -f "$dst_canonical" ] || [ -f "$dst_sidecar_legacy" ]; then
             # A dest path exists but sha doesn't match — content mismatch.

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1193,10 +1193,23 @@ union_contains() {
     local src="$1" dst="$2" manifest="${3:-}" rel="${4:-}"
     local py; py="$(resolve_python "$REPO_DIR")"
     [ -n "$py" ] || return 1
-    "$py" - "$src" "$dst" "$manifest" "$rel" <<'PY'
+    "$py" - "$src" "$dst" "$manifest" "$rel" "${DEST_REAL:-}" <<'PY'
 import json, os, stat, sys
 
-src, dst, manifest, rel = sys.argv[1:5]
+src, dst, manifest, rel, dest_root = sys.argv[1:6]
+# A 0644 leaf under a 0755 parent discloses what a 0700 source parent protected;
+# only parents strictly inside the dest root are governed (the root is never narrowed).
+try:
+    sdir = os.path.dirname(os.path.realpath(src))
+    ddir = os.path.dirname(os.path.realpath(dst))
+    root = os.path.realpath(dest_root) if dest_root else None
+    if root and ddir != root and ddir.startswith(root + os.sep):
+        sp = stat.S_IMODE(os.stat(sdir).st_mode)
+        dp = stat.S_IMODE(os.stat(ddir).st_mode)
+        if dp & ~sp:
+            sys.exit(1)
+except OSError:
+    sys.exit(1)
 try:
     with open(src, encoding="utf-8") as fh:
         s = json.load(fh)
@@ -1387,7 +1400,17 @@ identity_match() {
 # source's mtime, or a later OLDER source outranks it and its scalars win.
 identity_drop_keeping_newest() {
     [ "$1" -nt "$2" ] || return 0
-    touch -r "$1" "$2"
+    # Never mutate the existing inode: a hard link (or a symlink touch follows)
+    # can alias a file outside DEST_REAL. Materialize a contained inode instead.
+    copy_preserving_mtime "$1" "$2"
+}
+
+# A destination leaf that is a symlink resolves to a file the rollback root does
+# not own; reading or replacing it acts outside DEST_REAL. Refuse before either.
+refuse_leaf_symlink() {
+    [ -L "$1" ] || return 0
+    echo "ERROR: $2 — destination leaf is a symlink ($1); refusing to read or replace it" >&2
+    return 1
 }
 
 # SHA-256 verify (macOS shasum / Linux sha256sum). Returns 0 if hashes match.
@@ -1414,6 +1437,7 @@ commit_one() {
         union-json-array)
             dst_path="$DEST_REAL/$rel"
             ensure_contained_destdir "$(dirname "$dst_path")" || { echo "write-failed"; return 1; }
+            refuse_leaf_symlink "$dst_path" "$rel" || { echo "write-failed"; return 1; }
             if [ ! -e "$dst_path" ]; then
                 copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                 # Verify's mode check runs only where a manifest exists, so a
@@ -1440,6 +1464,11 @@ commit_one() {
                 echo "write-failed"
                 return 1
             fi
+            # The union rewrote the leaf in place: its parents must take the same
+            # non-widening intersection every copied file gets, or fail closed.
+            mirror_dir_modes "$src_file" "$dst_path" || {
+                echo "ERROR: directory-mode enforcement failed for $dst_path" >&2
+                echo "write-failed"; return 1; }
             # The manifest is what lets phase three verify the scalar winner
             # when the pre-union dest won — failing to record it fails closed.
             record_union_scalars "$dst_path" "$rel" "$(union_scalar_manifest)" \
@@ -1449,6 +1478,7 @@ commit_one() {
             ;;
         structural|collision-keep-both)
             dst_path="$DEST_REAL/$rel"
+            refuse_leaf_symlink "$dst_path" "$rel" || { echo "write-failed"; return 1; }
             if [ -e "$dst_path" ]; then
                 # Identical requires bytes AND mode; a mode-only difference
                 # falls through to keep-both so the source's mode survives.
@@ -1494,6 +1524,7 @@ commit_one() {
             ;;
         newest-mtime)
             dst_path="$DEST_REAL/$rel"
+            refuse_leaf_symlink "$dst_path" "$rel" || { echo "write-failed"; return 1; }
             if [ -e "$dst_path" ]; then
                 local src_mt dst_mt
                 src_mt="$(_stat %Y %m "$src_file")"

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -513,7 +513,7 @@ scan_source() {
         # state/<basename>, not the original relpath, so we index under the
         # re-homed path so re-home collisions surface correctly.
         case "$cls" in
-            structural|append|newest-mtime|collision-keep-both)
+            structural|append|newest-mtime|collision-keep-both|union-json-array)
                 record_xsrc "$tag" "$rel" "$cls" "$file"
                 ;;
             rehome-state)
@@ -772,7 +772,7 @@ index_dest_for_collisions() {
         local cls
         cls="$(classify "$rel")"
         case "$cls" in
-            structural|append|newest-mtime|collision-keep-both|rehome-state)
+            structural|append|newest-mtime|collision-keep-both|union-json-array|rehome-state)
                 record_xsrc "DEST" "$rel" "existing" "$file"
                 ;;
         esac
@@ -1064,6 +1064,13 @@ with open(tmp, "w", encoding="utf-8") as fh:
 # the next source compares against "now" and its scalars can never win.
 win = max(os.path.getmtime(src), os.path.getmtime(dst))
 os.utime(tmp, (win, win))
+# The temp is created fresh, so without this the process umask decides the
+# result and a 0600 destination silently becomes world-readable. Intersect
+# instead: the union may narrow permissions, never widen either input's.
+import stat as _stat
+_s = _stat.S_IMODE(os.stat(src).st_mode)
+_d = _stat.S_IMODE(os.stat(dst).st_mode)
+os.chmod(tmp, _s & _d)
 PY
     then
         mv -f "$tmp" "$dst"

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -381,6 +381,10 @@ declare -a REPORT_LINES
 # >1 source (cross-source collisions per-source scan misses — e.g. build_log.md
 # in A AND C bound for the same dest path).
 XSRC_INDEX="$(mktemp -t sutando-migrate-xsrc.XXXXXX)"
+# Shadow any INHERITED value before the trap installs: without this, an
+# environment-supplied _VERDICTS_TMP is rm -f'd on EXIT — even by --help —
+# so cleanup could delete an arbitrary writable path this process never made.
+_VERDICTS_TMP=""
 trap 'rm -f "$XSRC_INDEX" "${_VERDICTS_TMP:-}"' EXIT INT TERM
 # Also include dest's existing files (tag "DEST") so we surface dest-collisions
 # uniformly with cross-source collisions.

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1023,28 +1023,68 @@ mirror_dir_modes() {
         sd+=("$s"); dd+=("$d")
         s="$(dirname "$s")"; d="$(dirname "$d")"
     done
-    local i sm dm
+    local i sm dm want got rc=0
     for (( i=${#sd[@]}-1; i>=0; i-- )); do
         [ -d "${sd[$i]}" ] && [ -d "${dd[$i]}" ] || continue
         sm="$(mode_of "${sd[$i]}")"; dm="$(mode_of "${dd[$i]}")"
-        [ -n "$sm" ] && [ -n "$dm" ] || continue
+        # A failed probe on an EXISTING dir fails closed: committing under an
+        # unknown mode is a confidentiality window certified as success.
+        if [ -z "$sm" ] || [ -z "$dm" ]; then rc=1; continue; fi
         [ "$sm" = "$dm" ] && continue
-        chmod "$(printf '%o' $(( 0$sm & 0$dm )))" "${dd[$i]}" 2>/dev/null || true
+        want="$(printf '%o' $(( 0$sm & 0$dm )))"
+        if ! chmod "$want" "${dd[$i]}" 2>/dev/null; then rc=1; continue; fi
+        got="$(mode_of "${dd[$i]}")"
+        if [ -z "$got" ] || [ "$(( 0$got ))" -ne "$(( 0$want ))" ]; then rc=1; fi
     done
+    return "$rc"
 }
 
-# Atomic per-file copy preserving mtime. Returns 0 on success.
+# Create (if needed) and physically validate the directory a dest write will
+# land in. A textual prefix test passes a symlinked component while the
+# mutation escapes the rollback boundary, so containment is proven on the
+# RESOLVED path — and the deepest existing ancestor is checked BEFORE mkdir,
+# so a symlink escape refuses without creating anything outside either.
+ensure_contained_destdir() {
+    local ddir="$1" probe real
+    probe="$ddir"
+    while [ ! -d "$probe" ]; do probe="$(dirname "$probe")"; done
+    real="$(cd "$probe" 2>/dev/null && pwd -P)" || return 1
+    case "$real/" in
+        "$DEST_REAL"/*) ;;
+        *) echo "ERROR: dest path escapes the dest root: $ddir resolves via $real" >&2; return 1 ;;
+    esac
+    mkdir -p "$ddir" 2>/dev/null || return 1
+    real="$(cd "$ddir" 2>/dev/null && pwd -P)" || return 1
+    case "$real/" in
+        "$DEST_REAL"/*) return 0 ;;
+        *) echo "ERROR: dest path escapes the dest root: $ddir resolves to $real" >&2; return 1 ;;
+    esac
+}
+
+# Atomic per-file copy preserving mtime. Returns 0 on success; any mkdir,
+# containment, directory-mode, or copy failure returns non-zero so the commit
+# outcome can fail closed instead of certifying a write that did not happen.
 copy_preserving_mtime() {
     local src="$1" dst="$2"
-    mkdir -p "$(dirname "$dst")"
-    mirror_dir_modes "$src" "$dst"
+    ensure_contained_destdir "$(dirname "$dst")" || return 1
+    mirror_dir_modes "$src" "$dst" || {
+        echo "ERROR: directory-mode enforcement failed for $dst" >&2
+        return 1
+    }
     # Atomic: cp -p to sibling tmp then mv. -p preserves mtime + mode.
     local tmp="$dst.tmp.$$"
-    cp -p "$src" "$tmp" && mv -f "$tmp" "$dst"
+    if ! { cp -p "$src" "$tmp" && mv -f "$tmp" "$dst"; }; then
+        rm -f "$tmp" 2>/dev/null
+        echo "ERROR: copy failed: $src -> $dst" >&2
+        return 1
+    fi
 }
 
 # Unions top-level arrays; non-array fields follow the newer source.
 # Malformed input returns non-zero — a silent degrade is access loss.
+# NB: pure merge policy — no dest-boundary enforcement here. Containment is
+# the COMMIT path's concern (commit_one), so standalone callers and the test
+# harness can drive the policy against arbitrary paths.
 union_json_arrays_into() {
     local src="$1" dst="$2"
     mkdir -p "$(dirname "$dst")"
@@ -1102,6 +1142,40 @@ PY
     fi
     rm -f "$tmp"
     return 1
+}
+
+# Semantic-verify companion to union_json_arrays_into: same element
+# fingerprint (sorted-key JSON). A union result differs from both inputs BY
+# DESIGN, so the per-source invariant is containment — every array element of
+# the source present in the dest — not byte identity.
+union_contains() {
+    local src="$1" dst="$2"
+    local py; py="$(resolve_python "$REPO_DIR")"
+    [ -n "$py" ] || return 1
+    "$py" - "$src" "$dst" <<'PY'
+import json, sys
+
+src, dst = sys.argv[1:3]
+try:
+    with open(src, encoding="utf-8") as fh:
+        s = json.load(fh)
+    with open(dst, encoding="utf-8") as fh:
+        d = json.load(fh)
+except Exception:
+    sys.exit(1)
+if not isinstance(s, dict) or not isinstance(d, dict):
+    sys.exit(1)
+for key, val in s.items():
+    if not isinstance(val, list):
+        continue
+    dv = d.get(key)
+    if not isinstance(dv, list):
+        sys.exit(1)
+    have = {json.dumps(e, sort_keys=True) for e in dv}
+    if any(json.dumps(e, sort_keys=True) not in have for e in val):
+        sys.exit(1)
+sys.exit(0)
+PY
 }
 
 # Human-readable byte size: 1234 → "1.2 KB", 5242880 → "5.0 MB", etc.
@@ -1260,8 +1334,9 @@ commit_one() {
     case "$cls" in
         union-json-array)
             dst_path="$DEST_REAL/$rel"
+            ensure_contained_destdir "$(dirname "$dst_path")" || { echo "write-failed"; return 1; }
             if [ ! -e "$dst_path" ]; then
-                copy_preserving_mtime "$src_file" "$dst_path"
+                copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                 echo "copied"
                 return 0
             fi
@@ -1275,6 +1350,7 @@ commit_one() {
                 echo "ERROR: $rel — cannot union $src_file into $dst_path (malformed JSON" >&2
                 echo "       or a field that is an array in one file and not the other)." >&2
                 echo "       Refusing to fall back to newest-wins; that would drop grants." >&2
+                echo "write-failed"
                 return 1
             fi
             echo "unioned"
@@ -1308,17 +1384,17 @@ commit_one() {
                     # Name it .legacy-prior-<src_tag>-<ts> to convey "this is
                     # what was at dest before <src_tag> overwrote it" + the
                     # timestamp ensures 3-way collisions don't clobber.
-                    copy_preserving_mtime "$dst_path" "$dst_path.legacy-prior-from-$tag-$ts_suffix"
-                    copy_preserving_mtime "$src_file" "$dst_path"
+                    copy_preserving_mtime "$dst_path" "$dst_path.legacy-prior-from-$tag-$ts_suffix" || { echo "write-failed"; return 1; }
+                    copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                     echo "src-wins-newer"
                 else
                     # src loses; preserve under tagged + timestamped sidecar.
-                    copy_preserving_mtime "$src_file" "$dst_path.legacy-$tag-$ts_suffix"
+                    copy_preserving_mtime "$src_file" "$dst_path.legacy-$tag-$ts_suffix" || { echo "write-failed"; return 1; }
                     echo "dest-wins-newer"
                 fi
                 return 0
             else
-                copy_preserving_mtime "$src_file" "$dst_path"
+                copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                 echo "copied"
                 return 0
             fi
@@ -1330,13 +1406,13 @@ commit_one() {
                 src_mt="$(_stat %Y %m "$src_file")"
                 dst_mt="$(_stat %Y %m "$dst_path")"
                 if [ "$src_mt" -gt "$dst_mt" ]; then
-                    copy_preserving_mtime "$src_file" "$dst_path"
+                    copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                     echo "src-newer"
                 else
                     echo "dest-newer"
                 fi
             else
-                copy_preserving_mtime "$src_file" "$dst_path"
+                copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                 echo "copied"
             fi
             return 0
@@ -1372,13 +1448,13 @@ commit_one() {
                 src_mt="$(_stat %Y %m "$src_file")"
                 dst_mt="$(_stat %Y %m "$dst_path")"
                 if [ "$src_mt" -gt "$dst_mt" ]; then
-                    copy_preserving_mtime "$src_file" "$dst_path"
+                    copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                     echo "rehomed-newer"
                 else
                     echo "rehomed-skip-older"
                 fi
             else
-                copy_preserving_mtime "$src_file" "$dst_path"
+                copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                 echo "rehomed"
             fi
             return 0
@@ -1398,7 +1474,7 @@ commit_one() {
             # with a divider header carrying src-tag + mtime + size so the
             # downstream reader can split if needed.
             dst_path="$DEST_REAL/logs/workspace-narrative.log"
-            mkdir -p "$(dirname "$dst_path")"
+            ensure_contained_destdir "$(dirname "$dst_path")" || { echo "write-failed"; return 1; }
             local src_mt src_sz
             src_mt="$(_stat %Y %m "$src_file")"
             src_sz="$(_stat %s %z "$src_file")"
@@ -1484,7 +1560,7 @@ commit_one() {
             # --merge-append (Strategy B): concat with divider to <dest>/<rel>.
             if [ "$MERGE_APPEND" = "1" ]; then
                 dst_path="$DEST_REAL/$rel"
-                mkdir -p "$(dirname "$dst_path")"
+                ensure_contained_destdir "$(dirname "$dst_path")" || { echo "write-failed"; return 1; }
                 if [ -e "$dst_path" ]; then
                     # IMPORTANT: split the compound-redirect + mv + echo "merged"
                     # into separate statements with explicit error returns.
@@ -1520,12 +1596,12 @@ commit_one() {
                     }
                     echo "merged"
                 else
-                    copy_preserving_mtime "$src_file" "$dst_path"
+                    copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                     echo "copied"
                 fi
             else
                 dst_path="$DEST_REAL/legacy/$tag/$rel"
-                copy_preserving_mtime "$src_file" "$dst_path"
+                copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                 echo "sidecar"
             fi
             return 0
@@ -1540,7 +1616,7 @@ commit_one() {
                 local subdir="${rel%%/*}"  # tasks or results
                 local file_base="${rel#*/}" # task-*.txt
                 dst_path="$DEST_REAL/$subdir/archive/$tag/$file_base"
-                copy_preserving_mtime "$src_file" "$dst_path"
+                copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
                 echo "archived-stale"
             else
                 echo "skipped-inflight"
@@ -1553,7 +1629,7 @@ commit_one() {
             # experiments/, obsidian-vault/, personal-src/). Preserve under a
             # namespaced quarantine path rather than skip-unknown'ing it.
             dst_path="$DEST_REAL/legacy/$tag/quarantine/$rel"
-            copy_preserving_mtime "$src_file" "$dst_path"
+            copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
             echo "quarantined"
             return 0
             ;;
@@ -1641,7 +1717,7 @@ commit_source() {
     esac
     [ ${#walk_paths[@]} -eq 0 ] && { echo "  (nothing on surface; skip)"; return 0; }
 
-    local n_copied=0 n_kept=0 n_skipped=0 n_sidecar=0 n_rehomed=0 n_identical=0 n_quarantined=0 n_other=0
+    local n_copied=0 n_kept=0 n_skipped=0 n_sidecar=0 n_rehomed=0 n_identical=0 n_quarantined=0 n_other=0 n_write_failed=0
     # Phase 2 mode skips the commit walk entirely.
     if [ "$DO_COMMIT_WALK" = "0" ]; then
         # Skip ahead to the delete block (it walks walk_paths independently).
@@ -1671,7 +1747,10 @@ commit_source() {
             n_skipped=$((n_skipped+1)); continue
         fi
         cls="$(classify "$rel")"
-        outcome="$(commit_one "$file" "$rel" "$tag" "$cls")"
+        # || true: the failure signal is the outcome string; the tally below
+        # decides the source's fate, so one bad file cannot abort the walk
+        # half-committed with no summary and no verdict.
+        outcome="$(commit_one "$file" "$rel" "$tag" "$cls")" || true
         # Per-file progress on stderr — visible feedback during the copy walk
         # so long migrations don't feel like a hang. Skipped when PROGRESS_TOTAL
         # is 0 (delete-source phase-2 path; pre-flight didn't run).
@@ -1701,6 +1780,8 @@ commit_source() {
                 n_quarantined=$((n_quarantined+1)) ;;
             skipped-class|skipped-inflight|skipped-fallthrough)
                 n_skipped=$((n_skipped+1)) ;;
+            write-failed|"")
+                n_write_failed=$((n_write_failed+1)) ;;
             *)
                 n_other=$((n_other+1)) ;;
         esac
@@ -1716,6 +1797,10 @@ commit_source() {
         echo "  skipped:     $n_skipped"
         [ "$n_other" -gt 0 ] && echo "  other:       $n_other"
 
+        if [ "$n_write_failed" -gt 0 ]; then
+            echo "  WRITE-FAILED: $n_write_failed — sentinel NOT written; source $tag is NOT committed" >&2
+            return 1
+        fi
         touch "$(source_sentinel "$tag")"
         echo "  sentinel:    $(source_sentinel "$tag")"
     fi
@@ -2147,6 +2232,12 @@ verify_main() {
             fi
         done
         if [ -n "$landed" ]; then
+            pass=$((pass+1))
+        elif [ "$cls" = "union-json-array" ] && [ -f "$dst_canonical" ] \
+                && union_contains "$src_file" "$dst_canonical"; then
+            # A union result is byte-different from both inputs by design;
+            # the per-source invariant is array containment, checked through
+            # the union policy owner's own element fingerprint.
             pass=$((pass+1))
         elif [ -f "$dst_canonical" ] || [ -f "$dst_sidecar_legacy" ]; then
             # A dest path exists but sha doesn't match — content mismatch.

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1156,7 +1156,9 @@ record_union_scalars() {
     local py; py="$(resolve_python "$REPO_DIR")"
     [ -n "$py" ] || return 1
     "$py" - "$dst" "$rel" "$manifest" <<'PY'
-import json, os, sys
+import json, os, stat, sys
+
+MODES_KEY = "__union_modes__"
 
 dst, rel, manifest = sys.argv[1:4]
 with open(dst, encoding="utf-8") as fh:
@@ -1171,10 +1173,27 @@ if os.path.exists(manifest):
         sys.exit(1)
 else:
     m = {}
+if rel == MODES_KEY:
+    # A rel can never be this key, but if one ever were, its scalars would be
+    # read back as the mode table. Refuse rather than corrupt the manifest.
+    sys.exit(1)
 m[rel] = scalars
+union_mode = stat.S_IMODE(os.stat(dst).st_mode)
+modes = m.get(MODES_KEY)
+m[MODES_KEY] = ({} if not isinstance(modes, dict) else modes)
+m[MODES_KEY][rel] = oct(union_mode)
+# The manifest holds every union's non-array state, so it must be no wider than
+# the most restrictive file it describes — a 0600 source's scalars in a 0644
+# manifest is the same disclosure, one file over. Create at 0600 so it is never
+# briefly world-readable, then narrow to the intersection.
+want_mode = union_mode
+if os.path.exists(manifest):
+    want_mode &= stat.S_IMODE(os.stat(manifest).st_mode)
 tmp = manifest + ".tmp"
-with open(tmp, "w", encoding="utf-8") as fh:
+fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(fd, "w", encoding="utf-8") as fh:
     json.dump(m, fh, indent=1, sort_keys=True)
+os.chmod(tmp, want_mode)
 os.replace(tmp, manifest)
 PY
 }
@@ -1188,7 +1207,7 @@ union_contains() {
     local py; py="$(resolve_python "$REPO_DIR")"
     [ -n "$py" ] || return 1
     "$py" - "$src" "$dst" "$manifest" "$rel" <<'PY'
-import json, os, sys
+import json, os, stat, sys
 
 src, dst, manifest, rel = sys.argv[1:5]
 try:
@@ -1221,6 +1240,13 @@ if manifest and rel and os.path.exists(manifest):
     if not isinstance(m, dict) or rel not in m or not isinstance(m[rel], dict):
         sys.exit(1)
     expected = m[rel]
+    # The commit recorded what the union's mode should be; a widened dest is a
+    # disclosure the scalar comparison cannot see. Absent for manifests written
+    # before this key existed — then there is nothing to check, not a failure.
+    modes = m.get("__union_modes__")
+    if isinstance(modes, dict) and rel in modes:
+        if oct(stat.S_IMODE(os.stat(dst).st_mode)) != modes[rel]:
+            sys.exit(1)
 if expected is not None:
     have = {k: v for k, v in d.items() if not isinstance(v, list)}
     if have != expected:

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -421,8 +421,7 @@ scan_source() {
         REPORT_LINES+=("  prior partial migration sentinels:")
         while IFS= read -r s; do
             local sm
-            sm="$(stat -c '%y' "$s" 2>/dev/null | cut -d' ' -f1)"
-            [ -n "$sm" ] || sm="$(stat -f '%Sm' -t '%Y-%m-%d' "$s" 2>/dev/null)"
+            sm="$(mtime_date "$s")"
             REPORT_LINES+=("    $(basename "$s")  ($sm)")
         done <<<"$sentinels"
     fi
@@ -1201,6 +1200,15 @@ _stat() {
 # delegate here silently yields an empty mode and every identity check passes.
 mode_of() {
     _stat %a %Lp "$1"
+}
+
+# BSD needs -t for a formatted date and GNU needs a cut, so this cannot use
+# _stat's two-format shape; each probe is guarded so failure reaches the next.
+mtime_date() {
+    local d=""
+    d="$(stat -c %y "$1" 2>/dev/null | cut -d' ' -f1)" || d=""
+    [ -n "$d" ] || d="$(stat -f %Sm -t %Y-%m-%d "$1" 2>/dev/null)" || d=""
+    printf '%s' "$d"
 }
 
 # Identity is bytes AND mode, at every decision site: dropping a 0755 source

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1383,6 +1383,13 @@ identity_match() {
     sha_match "$1" "$2" && [ "$ma" = "$mb" ]
 }
 
+# An identical drop keeps the destination bytes but must carry the newer
+# source's mtime, or a later OLDER source outranks it and its scalars win.
+identity_drop_keeping_newest() {
+    [ "$1" -nt "$2" ] || return 0
+    touch -r "$1" "$2"
+}
+
 # SHA-256 verify (macOS shasum / Linux sha256sum). Returns 0 if hashes match.
 sha_match() {
     local a="$1" b="$2"
@@ -1409,15 +1416,18 @@ commit_one() {
             ensure_contained_destdir "$(dirname "$dst_path")" || { echo "write-failed"; return 1; }
             if [ ! -e "$dst_path" ]; then
                 copy_preserving_mtime "$src_file" "$dst_path" || { echo "write-failed"; return 1; }
+                # Verify's mode check runs only where a manifest exists, so a
+                # fresh copy without one cannot be proven un-widened later.
+                record_union_scalars "$dst_path" "$rel" "$(union_scalar_manifest)" \
+                    || { echo "write-failed"; return 1; }
                 echo "copied"
                 return 0
             fi
             if identity_match "$src_file" "$dst_path"; then
-                # The union carries the winner's mtime forward; a drop must too,
-                # or a later OLDER source outranks it and its scalars win.
-                if [ "$src_file" -nt "$dst_path" ]; then
-                    touch -r "$src_file" "$dst_path"
-                fi
+                identity_drop_keeping_newest "$src_file" "$dst_path" \
+                    || { echo "write-failed"; return 1; }
+                record_union_scalars "$dst_path" "$rel" "$(union_scalar_manifest)" \
+                    || { echo "write-failed"; return 1; }
                 echo "identical-drop"
                 return 0
             fi
@@ -1446,6 +1456,8 @@ commit_one() {
                 src_mt="$(_stat %Y %m "$src_file")"
                 dst_mt="$(_stat %Y %m "$dst_path")"
                 if identity_match "$src_file" "$dst_path"; then
+                    identity_drop_keeping_newest "$src_file" "$dst_path" \
+                        || { echo "write-failed"; return 1; }
                     echo "identical-drop"
                     return 0
                 fi

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1162,10 +1162,14 @@ dst, rel, manifest = sys.argv[1:4]
 with open(dst, encoding="utf-8") as fh:
     d = json.load(fh)
 scalars = {k: v for k, v in d.items() if not isinstance(v, list)}
-try:
+if os.path.exists(manifest):
+    # An existing-but-invalid manifest is damage; silently replacing it would
+    # erase every prior rel's expectation. Fail so the commit fails closed.
     with open(manifest, encoding="utf-8") as fh:
         m = json.load(fh)
-except Exception:
+    if not isinstance(m, dict):
+        sys.exit(1)
+else:
     m = {}
 m[rel] = scalars
 tmp = manifest + ".tmp"
@@ -1205,12 +1209,18 @@ if not isinstance(s, dict) or not isinstance(d, dict):
 # scalars must survive verbatim; only when neither source of truth exists do
 # arrays alone remain checkable.
 expected = None
-if manifest and rel:
+if manifest and rel and os.path.exists(manifest):
+    # A present manifest is the AUTHORITY: parse/type failures and a missing
+    # rel entry are damage and must FAIL — degrading to the mtime fallback
+    # would let a dest-winner corruption pass by damaging the manifest.
     try:
         with open(manifest, encoding="utf-8") as fh:
-            expected = json.load(fh).get(rel)
+            m = json.load(fh)
     except Exception:
-        expected = None
+        sys.exit(1)
+    if not isinstance(m, dict) or rel not in m or not isinstance(m[rel], dict):
+        sys.exit(1)
+    expected = m[rel]
 if expected is not None:
     have = {k: v for k, v in d.items() if not isinstance(v, list)}
     if have != expected:

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -805,9 +805,8 @@ def sha(path):
     except OSError:
         return None
 def ident_key(path):
-    # Bytes and mode are reported SEPARATELY: a drop decision needs both, but
-    # `byte_identical` is a claim about bytes and must not be false when no
-    # byte differs. `mode-divergent` keeps the drop as actionable regardless.
+    # `byte_identical` is a claim about bytes alone; `mode-divergent` keeps a
+    # bytes-equal/modes-differ row actionable without falsifying it.
     h = sha(path)
     if h is None:
         return None
@@ -1013,11 +1012,8 @@ any_source_sentinel() {
 }
 
 # Atomic per-file copy preserving mtime. Returns 0 on success.
-# Mirror source directory modes onto the destination chain. `cp -p` carries a
-# FILE's mode; parents created by `mkdir -p` would otherwise take umask, so a
-# 0700 source dir lands 0755 and exposes its contents to other local accounts.
-# Never widens: the dest dir takes the INTERSECTION, the same non-widening rule
-# the union-json path already applies to files.
+# `cp -p` carries a FILE's mode; `mkdir -p` parents take umask, so a 0700 source
+# dir would land 0755. The dest takes the INTERSECTION — it never widens.
 mirror_dir_modes() {
     local s d
     s="$(dirname "$1")"; d="$(dirname "$2")"
@@ -1091,9 +1087,8 @@ with open(tmp, "w", encoding="utf-8") as fh:
 # the next source compares against "now" and its scalars can never win.
 win = max(os.path.getmtime(src), os.path.getmtime(dst))
 os.utime(tmp, (win, win))
-# The temp is created fresh, so without this the process umask decides the
-# result and a 0600 destination silently becomes world-readable. Intersect
-# instead: the union may narrow permissions, never widen either input's.
+# The temp is fresh, so umask would otherwise decide the result. Intersect:
+# the union may narrow permissions, never widen either input's.
 import stat as _stat
 _s = _stat.S_IMODE(os.stat(src).st_mode)
 _d = _stat.S_IMODE(os.stat(dst).st_mode)
@@ -1207,21 +1202,14 @@ preflight_summary() {
     echo "$_total_files"
 }
 
-# SHA-256 verify (macOS shasum / Linux sha256sum). Returns 0 if hashes match.
-# Permission bits only (no file-type prefix): BSD %Lp and GNU %a agree.
-# GNU FIRST, and the order is load-bearing: GNU `stat -f` is --file-system, not
-# a format flag, so it prints a filesystem block to STDOUT and still exits
-# non-zero — a BSD-first `||` chain concatenates that block with the real mode.
-# BSD stat rejects `-c` outright, so GNU-first degrades cleanly the other way.
-# Single owner of the stat portability split.
-# _stat <gnu-fmt> <bsd-fmt> <file> [fallback]
+# _stat <gnu-fmt> <bsd-fmt> <file> [fallback]. GNU FIRST is load-bearing:
+# there `stat -f` is --file-system — it prints a block AND exits non-zero.
 _stat() {
     stat -c "$1" "$3" 2>/dev/null || stat -f "$2" "$3" 2>/dev/null || printf '%s' "${4-}"
 }
 
-# Multi-line on purpose: tests/sutando-migrate-identity-mode.test.sh extracts
-# helpers with a `sed` RANGE that needs a lone closing brace, so a one-line
-# delegate here silently yields an empty mode and every identity check passes.
+# Keep multi-line: the identity-mode test extracts helpers by `sed` range and
+# needs a lone closing brace; a one-liner silently yields an empty mode.
 mode_of() {
     _stat %a %Lp "$1"
 }
@@ -1247,6 +1235,7 @@ identity_match() {
     sha_match "$1" "$2" && [ "$ma" = "$mb" ]
 }
 
+# SHA-256 verify (macOS shasum / Linux sha256sum). Returns 0 if hashes match.
 sha_match() {
     local a="$1" b="$2"
     local ha hb
@@ -2293,11 +2282,8 @@ for e in entries:
 collisions = {k: v for k, v in by_rel.items() if len(v) > 1}
 with open(verdicts_path) as vf:
     _verdicts = json.load(vf)
-# Tri-state from the shared owner: True / False / None (None = could not hash;
-# unverified is its own actionable class, never rendered as proven divergence).
-# byte tri-state and mode conflict are two facts; mode-divergent means the
-# bytes ARE identical, so byte_identical must say True while the row stays
-# actionable via mode_conflict.
+# Tri-state: None = could not hash — unverified, never proven divergence.
+# mode-divergent keeps byte_identical True, actionable via mode_conflict.
 _MAP = {"identical": True, "mode-divergent": True, "divergent": False, "unverified": None}
 _MODE = {"mode-divergent": True}
 ident_verdict = {k: _MAP[_verdicts.get(k, "unverified")] for k in collisions}

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -283,6 +283,20 @@ if [ ! -x "$HELPER" ] && [ ! -f "$HELPER" ]; then
     echo "sutando-migrate: cannot find $HELPER (expected next to this script)" >&2
     exit 2
 fi
+
+# Scan reports need a real interpreter; resolve_python refuses Apple's CLT stub,
+# so a miss dies loudly here instead of raising the stub's modal dialog.
+_SUTANDO_PY_RESOLVED=""
+require_python() {
+    if [ -z "$_SUTANDO_PY_RESOLVED" ]; then
+        _SUTANDO_PY_RESOLVED="$(resolve_python "$REPO_DIR")"
+        if [ -z "$_SUTANDO_PY_RESOLVED" ]; then
+            echo "sutando-migrate: no runnable python3 — set SUTANDO_PY or install the Command Line Tools" >&2
+            exit 2
+        fi
+    fi
+    printf '%s' "$_SUTANDO_PY_RESOLVED"
+}
 # Dest resolution deferred to after arg parsing so --respect-env can take effect.
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -773,10 +787,49 @@ index_dest_for_collisions() {
     done < <(find "${dest_walk[@]}" -type f -print0 2>/dev/null)
 }
 
+# Single owner of content-identity policy for BOTH renderers (human + JSON):
+# per-relpath verdict identical|divergent|unverified over the XSRC index.
+xsrc_identity_verdicts() {
+    local py; py="$(require_python)"
+    "$py" - "$XSRC_INDEX" <<'PYIDENT'
+import sys, json, hashlib
+from collections import defaultdict
+by_rel = defaultdict(list)
+try:
+    with open(sys.argv[1]) as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) >= 6:
+                by_rel[parts[0]].append(parts[5])
+except OSError:
+    print("{}"); raise SystemExit
+def sha(path):
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+out = {}
+for rel, paths in by_rel.items():
+    if len(paths) < 2:
+        continue
+    hs = [sha(p) for p in paths]
+    if None in hs:
+        out[rel] = "unverified"
+    elif len(set(hs)) == 1:
+        out[rel] = "identical"
+    else:
+        out[rel] = "divergent"
+json.dump(out, sys.stdout)
+PYIDENT
+}
+
 report_cross_source() {
-    # Post-process XSRC_INDEX (TSV: relpath\ttag\tclass\tmtime\tsize) and print
-    # any relpath that appears in 2+ rows (cross-source / dest collision).
-    # Emits a compact per-class summary + a per-class detail list (capped).
+    # Print every relpath appearing in 2+ XSRC_INDEX rows (cross-source / dest
+    # collision) as a per-class summary + capped per-class detail list.
     local total_xs total_xs_files
     total_xs_files="$(awk -F'\t' '{print $1}' "$XSRC_INDEX" | sort -u | wc -l | tr -d ' ')"
     total_xs="$(awk -F'\t' '
@@ -794,44 +847,18 @@ report_cross_source() {
         return
     fi
 
-    # Identical-content collisions: byte-verified (sha256 over every entry of
-    # the relpath). An unreadable entry fails closed to divergent — a proxy
-    # match (mtime+size) must never certify content identity.
-    local total_identical
-    total_identical="$(python3 - "$XSRC_INDEX" <<'PYIDENT'
-import sys, hashlib
-from collections import defaultdict
-by_rel = defaultdict(list)
-try:
-    with open(sys.argv[1]) as f:
-        for line in f:
-            parts = line.rstrip("\n").split("\t")
-            if len(parts) >= 6:
-                by_rel[parts[0]].append(parts[5])
-except OSError:
-    print(0); raise SystemExit
-def sha(path):
-    try:
-        h = hashlib.sha256()
-        with open(path, "rb") as fh:
-            for chunk in iter(lambda: fh.read(1 << 20), b""):
-                h.update(chunk)
-        return h.hexdigest()
-    except OSError:
-        return None
-ident = 0
-for rel, paths in by_rel.items():
-    if len(paths) < 2:
-        continue
-    hs = {sha(p) for p in paths}
-    if None not in hs and len(hs) == 1:
-        ident += 1
-print(ident)
-PYIDENT
-)"
+    # Verdicts come from the single identity owner (xsrc_identity_verdicts);
+    # an unreadable entry is UNVERIFIED — never certified, never called divergent.
+    local verdicts total_identical total_unverified
+    verdicts="$(xsrc_identity_verdicts)"
+    read -r total_identical total_unverified <<<"$("$(require_python)" -c \
+'import sys,json;v=json.load(sys.stdin);print(sum(1 for x in v.values() if x=="identical"), sum(1 for x in v.values() if x=="unverified"))' <<<"$verdicts")"
 
     REPORT_LINES+=("  of which identical-content (byte-verified):  $total_identical (commit will pick one canonical + skip rest)")
-    REPORT_LINES+=("  genuine cross-source conflicts (need strategy):  $((total_xs - total_identical))")
+    if [ "$total_unverified" -gt 0 ]; then
+        REPORT_LINES+=("  unverified (could not hash — fix permissions, re-scan):  $total_unverified")
+    fi
+    REPORT_LINES+=("  genuine cross-source conflicts (need strategy):  $((total_xs - total_identical - total_unverified))")
 
     # Per-class breakdown of cross-source collisions
     REPORT_LINES+=("  by class:")
@@ -2163,14 +2190,14 @@ rollback_main() {
 }
 
 emit_json() {
-    # Reads XSRC_INDEX (TSV) + the resolved source paths/state and emits a
-    # machine-readable JSON dump for downstream tooling (dashboards, skill
-    # wrappers, the eventual --commit dry-run UI). Python3 is the bash-friendly
-    # path — sutando already requires it.
-    python3 - "$DEST_REAL" "$A_REAL_OK" "$B_REAL_OK" "$C_REAL_OK" "$XSRC_INDEX" <<'PY'
+    # Machine-readable JSON for downstream tooling. Identity verdicts come from
+    # xsrc_identity_verdicts (single policy owner shared with the human report).
+    local py vf; py="$(require_python)"; vf="$(mktemp)"
+    xsrc_identity_verdicts > "$vf"
+    "$py" - "$DEST_REAL" "$A_REAL_OK" "$B_REAL_OK" "$C_REAL_OK" "$XSRC_INDEX" "$vf" <<'PY'
 import json, sys, os
 from collections import defaultdict
-dest, a, b, c, idx_path = sys.argv[1:6]
+dest, a, b, c, idx_path, verdicts_path = sys.argv[1:7]
 entries = []
 if os.path.exists(idx_path):
     with open(idx_path) as f:
@@ -2185,23 +2212,14 @@ by_rel = defaultdict(list)
 for e in entries:
     by_rel[e["rel"]].append(e)
 collisions = {k: v for k, v in by_rel.items() if len(v) > 1}
-import hashlib
-def _sha(path):
-    try:
-        h = hashlib.sha256()
-        with open(path, "rb") as fh:
-            for chunk in iter(lambda: fh.read(1 << 20), b""):
-                h.update(chunk)
-        return h.hexdigest()
-    except OSError:
-        return None
-def byte_identical(v):
-    """Content identity is HASH identity; an unreadable entry fails closed to
-    divergent — a proxy match (mtime+size) must never certify it."""
-    hs = {_sha(e["path"]) for e in v}
-    return None not in hs and len(hs) == 1
-ident_verdict = {k: byte_identical(v) for k, v in collisions.items()}
-identical = sum(1 for x in ident_verdict.values() if x)
+with open(verdicts_path) as vf:
+    _verdicts = json.load(vf)
+# Tri-state from the shared owner: True / False / None (None = could not hash;
+# unverified is its own actionable class, never rendered as proven divergence).
+_MAP = {"identical": True, "divergent": False, "unverified": None}
+ident_verdict = {k: _MAP[_verdicts.get(k, "unverified")] for k in collisions}
+identical = sum(1 for x in ident_verdict.values() if x is True)
+unverified = sum(1 for x in ident_verdict.values() if x is None)
 genuine = len(collisions) - identical
 by_class = defaultdict(int)
 for v in collisions.values():
@@ -2211,12 +2229,12 @@ def has_size_mismatch(entries):
     return len({e["size"] for e in entries}) > 1
 def has_mtime_mismatch(entries):
     return len({e["mtime"] for e in entries}) > 1
-# Sort by actionability: any byte-divergent collision whose proxies agree
-# (equal mtime+size, different content) is as real as a size mismatch and
-# sorts first with it; then mtime-only, then byte-identical (drop-dup).
+# Actionability sort: size-mismatch, verified-divergent-with-agreeing-proxies,
+# and unverified first; then mtime-only; byte-identical (drop-dup) last.
 def sort_key(item):
     k, v = item
-    if has_size_mismatch(v) or not ident_verdict[k]:
+    if has_size_mismatch(v) or ident_verdict[k] is None or (
+            ident_verdict[k] is False and not has_mtime_mismatch(v)):
         prio = 0
     elif has_mtime_mismatch(v):
         prio = 1
@@ -2231,10 +2249,11 @@ notable = [{"class": v[0]["class"], "rel": k,
            for k, v in sorted(collisions.items(), key=sort_key)]
 size_diff = sum(1 for v in collisions.values() if has_size_mismatch(v))
 mtime_only = sum(1 for k, v in collisions.items() if not has_size_mismatch(v)
-                 and has_mtime_mismatch(v) and not ident_verdict[k])
+                 and has_mtime_mismatch(v) and ident_verdict[k] is False)
+# Only two successfully-read, differing hashes may claim proven divergence.
 proxy_identical_divergent = sum(
     1 for k, v in collisions.items()
-    if not has_size_mismatch(v) and not has_mtime_mismatch(v) and not ident_verdict[k])
+    if not has_size_mismatch(v) and not has_mtime_mismatch(v) and ident_verdict[k] is False)
 out = {
     "dest": dest,
     "sources": {"A": a or None, "B": b or None, "C": c or None},
@@ -2244,9 +2263,11 @@ out = {
         "identical_content": identical,  # byte-verified, never proxy-inferred
         "mtime_only_diff": mtime_only,  # commit's newest-mtime auto-resolves
         "size_mismatch": size_diff,     # actionable — real content conflicts
-        # Actionable — equal mtime+size but different bytes; the proxies lie here.
+        # Actionable — equal mtime+size but PROVEN different bytes (both read OK).
         "proxy_identical_divergent": proxy_identical_divergent,
-        "genuine_conflicts": genuine,   # collisions - byte-identical
+        # Actionable — hash failed (unreadable entry); fix permissions, re-scan.
+        "identity_unverified": unverified,
+        "genuine_conflicts": genuine,   # collisions - byte-identical (incl. unverified)
 
         "by_class": dict(by_class),
     },

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -805,8 +805,9 @@ def sha(path):
     except OSError:
         return None
 def ident_key(path):
-    # Identity is bytes AND mode — same rule as the shell's identity_match, so
-    # the scan's "identical" can never promise a drop commit would not honor.
+    # Bytes and mode are reported SEPARATELY: a drop decision needs both, but
+    # `byte_identical` is a claim about bytes and must not be false when no
+    # byte differs. `mode-divergent` keeps the drop as actionable regardless.
     h = sha(path)
     if h is None:
         return None
@@ -821,10 +822,12 @@ for rel, paths in by_rel.items():
     ks = [ident_key(p) for p in paths]
     if None in ks:
         out[rel] = "unverified"
-    elif len(set(ks)) == 1:
-        out[rel] = "identical"
-    else:
+    elif len({k[0] for k in ks}) > 1:
         out[rel] = "divergent"
+    elif len({k[1] for k in ks}) > 1:
+        out[rel] = "mode-divergent"
+    else:
+        out[rel] = "identical"
 json.dump(out, sys.stdout)
 PYIDENT
 }
@@ -2246,9 +2249,18 @@ with open(verdicts_path) as vf:
     _verdicts = json.load(vf)
 # Tri-state from the shared owner: True / False / None (None = could not hash;
 # unverified is its own actionable class, never rendered as proven divergence).
-_MAP = {"identical": True, "divergent": False, "unverified": None}
+# byte tri-state and mode conflict are two facts; mode-divergent means the
+# bytes ARE identical, so byte_identical must say True while the row stays
+# actionable via mode_conflict.
+_MAP = {"identical": True, "mode-divergent": True, "divergent": False, "unverified": None}
+_MODE = {"mode-divergent": True}
 ident_verdict = {k: _MAP[_verdicts.get(k, "unverified")] for k in collisions}
-identical = sum(1 for x in ident_verdict.values() if x is True)
+mode_conflict = {k: _MODE.get(_verdicts.get(k, "unverified"), False) for k in collisions}
+# A row is actionable unless bytes are proven equal AND the modes agree — the
+# drop-safety rule is unchanged, only its REPORTING was split.
+def _actionable_rel(k):
+    return ident_verdict[k] is not True or mode_conflict[k]
+identical = sum(1 for k, x in ident_verdict.items() if x is True and not mode_conflict[k])
 unverified = sum(1 for x in ident_verdict.values() if x is None)
 # Proven divergence ONLY: unverified stays its own class — unknown must never
 # be published as genuine conflict (they already surface as identity_unverified).
@@ -2265,7 +2277,7 @@ def has_mtime_mismatch(entries):
 # else ignorable entries can push the one actionable one past the render cap.
 def sort_key(item):
     k, v = item
-    if ident_verdict[k] is not True:
+    if _actionable_rel(k):
         prio = 0
     elif has_mtime_mismatch(v) or has_size_mismatch(v):
         prio = 1
@@ -2274,14 +2286,15 @@ def sort_key(item):
     return (prio, v[0]["class"], k)
 _rows = [{"class": v[0]["class"], "rel": k,
           "byte_identical": ident_verdict[k],
+          "mode_conflict": mode_conflict[k],
           "size_mismatch": has_size_mismatch(v),
           "mtime_mismatch": has_mtime_mismatch(v),
           "entries": [{"tag": e["tag"], "mtime": e["mtime"], "size": e["size"]} for e in v]}
          for k, v in sorted(collisions.items(), key=sort_key)]
 # The cap may only ever trim IGNORABLE rows: every actionable entry (verdict
 # False or None) is retained even when there are more than 50 of them.
-_actionable = [r for r in _rows if r["byte_identical"] is not True]
-_ignorable = [r for r in _rows if r["byte_identical"] is True]
+_actionable = [r for r in _rows if _actionable_rel(r["rel"])]
+_ignorable = [r for r in _rows if not _actionable_rel(r["rel"])]
 notable = _actionable + _ignorable[: max(0, 50 - len(_actionable))]
 size_diff = sum(1 for v in collisions.values() if has_size_mismatch(v))
 mtime_only = sum(1 for k, v in collisions.items() if not has_size_mismatch(v)

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1004,6 +1004,9 @@ backup_dest() {
 source_sentinel() {
     echo "$DEST_REAL/state/.migrated-from-$1-$BACKUP_ID"
 }
+union_scalar_manifest() {
+    echo "$DEST_REAL/state/.migration-union-scalars-$BACKUP_ID.json"
+}
 any_source_sentinel() {
     # Any sentinel for this source tag (commit may have been run before with a
     # different backup id). Returns 0 if found.
@@ -1144,18 +1147,46 @@ PY
     return 1
 }
 
+# Record the union result's non-array fields so mandatory verification can
+# check the scalar winner even when the PRE-UNION DEST won (its content is
+# otherwise unrecoverable per-source). One manifest per backup id, keyed by
+# rel; the last union for a rel wins, matching the file's final state.
+record_union_scalars() {
+    local dst="$1" rel="$2" manifest="$3"
+    local py; py="$(resolve_python "$REPO_DIR")"
+    [ -n "$py" ] || return 1
+    "$py" - "$dst" "$rel" "$manifest" <<'PY'
+import json, os, sys
+
+dst, rel, manifest = sys.argv[1:4]
+with open(dst, encoding="utf-8") as fh:
+    d = json.load(fh)
+scalars = {k: v for k, v in d.items() if not isinstance(v, list)}
+try:
+    with open(manifest, encoding="utf-8") as fh:
+        m = json.load(fh)
+except Exception:
+    m = {}
+m[rel] = scalars
+tmp = manifest + ".tmp"
+with open(tmp, "w", encoding="utf-8") as fh:
+    json.dump(m, fh, indent=1, sort_keys=True)
+os.replace(tmp, manifest)
+PY
+}
+
 # Semantic-verify companion to union_json_arrays_into: same element
 # fingerprint (sorted-key JSON). A union result differs from both inputs BY
 # DESIGN, so the per-source invariant is containment — every array element of
 # the source present in the dest — not byte identity.
 union_contains() {
-    local src="$1" dst="$2"
+    local src="$1" dst="$2" manifest="${3:-}" rel="${4:-}"
     local py; py="$(resolve_python "$REPO_DIR")"
     [ -n "$py" ] || return 1
-    "$py" - "$src" "$dst" <<'PY'
+    "$py" - "$src" "$dst" "$manifest" "$rel" <<'PY'
 import json, os, sys
 
-src, dst = sys.argv[1:3]
+src, dst, manifest, rel = sys.argv[1:5]
 try:
     with open(src, encoding="utf-8") as fh:
         s = json.load(fh)
@@ -1167,11 +1198,23 @@ except Exception:
     sys.exit(1)
 if not isinstance(s, dict) or not isinstance(d, dict):
     sys.exit(1)
-# The union stamps the dest with the WINNER's mtime, and the writer contract
-# says non-array fields come from that winner. So when THIS source's mtime
-# equals the dest's, its scalars won and must survive verbatim; a dest mtime
-# newer than every source means the pre-union dest won, whose content is not
-# recoverable per-source — arrays alone are checkable there.
+# Scalars, strongest evidence first: the commit-time manifest holds the
+# union result's non-array fields whichever side won, so the dest must match
+# it exactly. Without a manifest entry, fall back to the mtime invariant: the
+# union stamps the dest with the WINNER's mtime, so an mtime-equal source's
+# scalars must survive verbatim; only when neither source of truth exists do
+# arrays alone remain checkable.
+expected = None
+if manifest and rel:
+    try:
+        with open(manifest, encoding="utf-8") as fh:
+            expected = json.load(fh).get(rel)
+    except Exception:
+        expected = None
+if expected is not None:
+    have = {k: v for k, v in d.items() if not isinstance(v, list)}
+    if have != expected:
+        sys.exit(1)
 scalar_winner = src_mt == dst_mt
 for key, val in s.items():
     if isinstance(val, list):
@@ -1362,6 +1405,10 @@ commit_one() {
                 echo "write-failed"
                 return 1
             fi
+            # The manifest is what lets phase three verify the scalar winner
+            # when the pre-union dest won — failing to record it fails closed.
+            record_union_scalars "$dst_path" "$rel" "$(union_scalar_manifest)" \
+                || { echo "write-failed"; return 1; }
             echo "unioned"
             return 0
             ;;
@@ -2243,7 +2290,9 @@ verify_main() {
         if [ -n "$landed" ]; then
             pass=$((pass+1))
         elif [ "$cls" = "union-json-array" ] && [ -f "$dst_canonical" ] \
-                && union_contains "$src_file" "$dst_canonical"; then
+                && union_contains "$src_file" "$dst_canonical" \
+                    "$(ls -t "$DEST_REAL/state/.migration-union-scalars-"*.json 2>/dev/null | head -1)" \
+                    "$rel"; then
             # A union result is byte-different from both inputs by design;
             # the per-source invariant is array containment, checked through
             # the union policy owner's own element fingerprint.

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1186,7 +1186,14 @@ mode_of() {
 # 0644 dest silently loses the exec bit with no backup carrying it. Identity
 # is bytes AND mode, and scan/commit/verify/delete all use this same test.
 identity_match() {
-    sha_match "$1" "$2" && [ "$(mode_of "$1")" = "$(mode_of "$2")" ]
+    # FAIL CLOSED on an unreadable mode: with both probes failing, a bare
+    # comparison sees "" = "" and certifies identity with mode UNKNOWN —
+    # re-opening the destructive drop/delete path on a transient stat error.
+    local ma mb
+    ma="$(mode_of "$1")" || return 1
+    mb="$(mode_of "$2")" || return 1
+    [ -n "$ma" ] && [ -n "$mb" ] || return 1
+    sha_match "$1" "$2" && [ "$ma" = "$mb" ]
 }
 
 sha_match() {

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1251,7 +1251,9 @@ if expected is not None:
     have = {k: v for k, v in d.items() if not isinstance(v, list)}
     if have != expected:
         sys.exit(1)
-scalar_winner = src_mt == dst_mt
+# The manifest already proved the scalars above; re-deriving a winner from
+# mtime there rejects a valid destination-winner union when the two tie.
+scalar_winner = expected is None and src_mt == dst_mt
 for key, val in s.items():
     if isinstance(val, list):
         dv = d.get(key)

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1015,31 +1015,51 @@ any_source_sentinel() {
 
 # `cp -p` carries a FILE's mode, but `mkdir -p` parents take umask, so a 0700
 # source dir lands 0755. The dest takes the INTERSECTION — it never widens.
-mirror_dir_modes() {
+# Governed parents, outermost first: basename-agreeing ancestors STRICTLY
+# inside the dest root. The writer and the verifier walk this one chain.
+dir_mode_chain() {
     local s d
     s="$(dirname "$1")"; d="$(dirname "$2")"
     local -a sd=() dd=()
     while [ "$s" != "/" ] && [ "$d" != "/" ] && [ "$(basename "$s")" = "$(basename "$d")" ]; do
-        # Bound to paths STRICTLY inside the dest root. Basename agreement alone
-        # lets the walk climb past it and chmod ancestors outside the rollback.
+        # Basename agreement alone lets the walk climb past the dest root and
+        # chmod ancestors outside the rollback.
         [ -n "${DEST_REAL:-}" ] && [ "${d#"$DEST_REAL"/}" != "$d" ] || break
         sd+=("$s"); dd+=("$d")
         s="$(dirname "$s")"; d="$(dirname "$d")"
     done
-    local i sm dm want got rc=0
-    for (( i=${#sd[@]}-1; i>=0; i-- )); do
-        [ -d "${sd[$i]}" ] && [ -d "${dd[$i]}" ] || continue
-        sm="$(mode_of "${sd[$i]}")"; dm="$(mode_of "${dd[$i]}")"
+    local i
+    for (( i=${#sd[@]}-1; i>=0; i-- )); do printf '%s\t%s\n' "${sd[$i]}" "${dd[$i]}"; done
+}
+
+mirror_dir_modes() {
+    local sdir ddir sm dm want got rc=0
+    while IFS=$'\t' read -r sdir ddir; do
+        [ -d "$sdir" ] && [ -d "$ddir" ] || continue
+        sm="$(mode_of "$sdir")"; dm="$(mode_of "$ddir")"
         # A failed probe on an EXISTING dir fails closed: committing under an
         # unknown mode is a confidentiality window certified as success.
         if [ -z "$sm" ] || [ -z "$dm" ]; then rc=1; continue; fi
         [ "$sm" = "$dm" ] && continue
         want="$(printf '%o' $(( 0$sm & 0$dm )))"
-        if ! chmod "$want" "${dd[$i]}" 2>/dev/null; then rc=1; continue; fi
-        got="$(mode_of "${dd[$i]}")"
+        if ! chmod "$want" "$ddir" 2>/dev/null; then rc=1; continue; fi
+        got="$(mode_of "$ddir")"
         if [ -z "$got" ] || [ "$(( 0$got ))" -ne "$(( 0$want ))" ]; then rc=1; fi
-    done
+    done < <(dir_mode_chain "$1" "$2")
     return "$rc"
+}
+
+# Read-only twin for phase three: a governed parent wider than its source
+# discloses what the source protected, whatever the leaf's own mode says.
+verify_dir_modes() {
+    local sdir ddir sm dm
+    while IFS=$'\t' read -r sdir ddir; do
+        [ -d "$sdir" ] && [ -d "$ddir" ] || continue
+        sm="$(mode_of "$sdir")"; dm="$(mode_of "$ddir")"
+        [ -n "$sm" ] && [ -n "$dm" ] || return 1
+        [ "$(( 0$dm & ~0$sm ))" -eq 0 ] || return 1
+    done < <(dir_mode_chain "$1" "$2")
+    return 0
 }
 
 # Containment is proven on the RESOLVED path and BEFORE mkdir: a textual
@@ -1084,6 +1104,12 @@ copy_preserving_mtime() {
 union_json_arrays_into() {
     local src="$1" dst="$2"
     mkdir -p "$(dirname "$dst")"
+    # Parents take the intersection BEFORE the leaf exists in any form: a
+    # failure here leaves the pre-union destination exactly as it was.
+    mirror_dir_modes "$src" "$dst" || {
+        echo "ERROR: directory-mode enforcement failed for $dst" >&2
+        return 1
+    }
     local tmp="$dst.tmp.$$"
     local py; py="$(resolve_python "$REPO_DIR")"
     [ -n "$py" ] || return 1
@@ -1118,19 +1144,20 @@ for key in set(src_doc) | set(dst_doc):
             seen.add(fp)
             out.append(entry)
     merged[key] = out
-with open(tmp, "w", encoding="utf-8") as fh:
+# The temp is born at the intersection and narrowed again before its first
+# byte: a fresh 0644 temp holding merged grants is readable until then.
+import stat as _stat
+_s = _stat.S_IMODE(os.stat(src).st_mode)
+_d = _stat.S_IMODE(os.stat(dst).st_mode)
+_fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _s & _d)
+os.fchmod(_fd, _s & _d)
+with os.fdopen(_fd, "w", encoding="utf-8") as fh:
     json.dump(merged, fh, indent=2, sort_keys=True)
     fh.write("\n")
 # The union rewrites dst, so the result must carry the winner's mtime; otherwise
 # the next source compares against "now" and its scalars can never win.
 win = max(os.path.getmtime(src), os.path.getmtime(dst))
 os.utime(tmp, (win, win))
-# The temp is fresh, so umask would otherwise decide the result. Intersect:
-# the union may narrow permissions, never widen either input's.
-import stat as _stat
-_s = _stat.S_IMODE(os.stat(src).st_mode)
-_d = _stat.S_IMODE(os.stat(dst).st_mode)
-os.chmod(tmp, _s & _d)
 PY
     then
         mv -f "$tmp" "$dst"
@@ -1399,6 +1426,12 @@ identity_match() {
 # An identical drop keeps the destination bytes but must carry the newer
 # source's mtime, or a later OLDER source outranks it and its scalars win.
 identity_drop_keeping_newest() {
+    # A drop writes no leaf, but its parents are still published: an older or
+    # equal source must narrow them exactly as a copied one would.
+    mirror_dir_modes "$1" "$2" || {
+        echo "ERROR: directory-mode enforcement failed for $2" >&2
+        return 1
+    }
     [ "$1" -nt "$2" ] || return 0
     # Never mutate the existing inode: a hard link (or a symlink touch follows)
     # can alias a file outside DEST_REAL. Materialize a contained inode instead.
@@ -1464,11 +1497,6 @@ commit_one() {
                 echo "write-failed"
                 return 1
             fi
-            # The union rewrote the leaf in place: its parents must take the same
-            # non-widening intersection every copied file gets, or fail closed.
-            mirror_dir_modes "$src_file" "$dst_path" || {
-                echo "ERROR: directory-mode enforcement failed for $dst_path" >&2
-                echo "write-failed"; return 1; }
             # The manifest is what lets phase three verify the scalar winner
             # when the pre-union dest won — failing to record it fails closed.
             record_union_scalars "$dst_path" "$rel" "$(union_scalar_manifest)" \
@@ -2356,12 +2384,20 @@ verify_main() {
         done
         # A union entry must clear union_contains, which owns the manifest mode
         # check; byte identity with one input must never stand in for it.
+        # The leaf alone certifies nothing under a widened parent: the same
+        # governed chain the commit narrowed is re-checked here, read-only.
         if [ -n "$landed" ] && [ "$cls" != "union-json-array" ]; then
-            pass=$((pass+1))
+            if verify_dir_modes "$src_file" "$landed"; then
+                pass=$((pass+1))
+            else
+                mismatch=$((mismatch+1))
+                [ "$mismatch" -le 5 ] && echo "  MISMATCH: $tag/$rel ($cls) — a destination parent is wider than the source's"
+            fi
         elif [ "$cls" = "union-json-array" ] && [ -f "$dst_canonical" ] \
                 && union_contains "$src_file" "$dst_canonical" \
                     "$(ls -t "$DEST_REAL/state/.migration-union-scalars-"*.json 2>/dev/null | head -1)" \
-                    "$rel"; then
+                    "$rel" \
+                && verify_dir_modes "$src_file" "$dst_canonical"; then
             # A union result differs from both inputs by design, so the
             # invariant is containment via the union owner's fingerprint.
             pass=$((pass+1))

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -284,19 +284,8 @@ if [ ! -x "$HELPER" ] && [ ! -f "$HELPER" ]; then
     exit 2
 fi
 
-# Scan reports need a real interpreter; resolve_python refuses Apple's CLT stub,
-# so a miss dies loudly here instead of raising the stub's modal dialog.
-_SUTANDO_PY_RESOLVED=""
-require_python() {
-    if [ -z "$_SUTANDO_PY_RESOLVED" ]; then
-        _SUTANDO_PY_RESOLVED="$(resolve_python "$REPO_DIR")"
-        if [ -z "$_SUTANDO_PY_RESOLVED" ]; then
-            echo "sutando-migrate: no runnable python3 — set SUTANDO_PY or install the Command Line Tools" >&2
-            exit 2
-        fi
-    fi
-    printf '%s' "$_SUTANDO_PY_RESOLVED"
-}
+# Interpreter resolution: python-binary.sh's require_python is the single
+# loud-failure owner — never redefine it here (it shadows the sourced contract).
 # Dest resolution deferred to after arg parsing so --respect-env can take effect.
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -392,7 +381,7 @@ declare -a REPORT_LINES
 # >1 source (cross-source collisions per-source scan misses — e.g. build_log.md
 # in A AND C bound for the same dest path).
 XSRC_INDEX="$(mktemp -t sutando-migrate-xsrc.XXXXXX)"
-trap 'rm -f "$XSRC_INDEX"' EXIT INT TERM
+trap 'rm -f "$XSRC_INDEX" "${_VERDICTS_TMP:-}"' EXIT INT TERM
 # Also include dest's existing files (tag "DEST") so we surface dest-collisions
 # uniformly with cross-source collisions.
 
@@ -790,7 +779,7 @@ index_dest_for_collisions() {
 # Single owner of content-identity policy for BOTH renderers (human + JSON):
 # per-relpath verdict identical|divergent|unverified over the XSRC index.
 xsrc_identity_verdicts() {
-    local py; py="$(require_python)"
+    local py; py="$(require_python "$REPO_DIR" "hash cross-source collisions")" || exit 2
     "$py" - "$XSRC_INDEX" <<'PYIDENT'
 import sys, json, hashlib
 from collections import defaultdict
@@ -849,9 +838,10 @@ report_cross_source() {
 
     # Verdicts come from the single identity owner (xsrc_identity_verdicts);
     # an unreadable entry is UNVERIFIED — never certified, never called divergent.
-    local verdicts total_identical total_unverified
+    local verdicts total_identical total_unverified count_py
     verdicts="$(xsrc_identity_verdicts)"
-    read -r total_identical total_unverified <<<"$("$(require_python)" -c \
+    count_py="$(require_python "$REPO_DIR" "count identity verdicts")" || exit 2
+    read -r total_identical total_unverified <<<"$("$count_py" -c \
 'import sys,json;v=json.load(sys.stdin);print(sum(1 for x in v.values() if x=="identical"), sum(1 for x in v.values() if x=="unverified"))' <<<"$verdicts")"
 
     REPORT_LINES+=("  of which identical-content (byte-verified):  $total_identical (commit will pick one canonical + skip rest)")
@@ -2192,7 +2182,10 @@ rollback_main() {
 emit_json() {
     # Machine-readable JSON for downstream tooling. Identity verdicts come from
     # xsrc_identity_verdicts (single policy owner shared with the human report).
-    local py vf; py="$(require_python)"; vf="$(mktemp)"
+    local py vf; py="$(require_python "$REPO_DIR" "emit the scan JSON")" || exit 2
+    # Named template like XSRC_INDEX: auditable, and countable by the cleanup
+    # regression on macOS, whose mktemp ignores $TMPDIR for placement.
+    vf="$(mktemp -t sutando-migrate-verdicts.XXXXXX)"; _VERDICTS_TMP="$vf"
     xsrc_identity_verdicts > "$vf"
     "$py" - "$DEST_REAL" "$A_REAL_OK" "$B_REAL_OK" "$C_REAL_OK" "$XSRC_INDEX" "$vf" <<'PY'
 import json, sys, os
@@ -2276,6 +2269,7 @@ out = {
 json.dump(out, sys.stdout, indent=2)
 print()
 PY
+    rm -f "$vf"; _VERDICTS_TMP=""
 }
 
 explain_main() {

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -284,9 +284,8 @@ if [ ! -x "$HELPER" ] && [ ! -f "$HELPER" ]; then
     exit 2
 fi
 
-# Interpreter resolution: python-binary.sh's require_python is the single
-# loud-failure owner — never redefine it here (it shadows the sourced contract).
-# Dest resolution deferred to after arg parsing so --respect-env can take effect.
+# python-binary.sh's require_python is the single loud-failure owner — never
+# redefine it here. Dest resolution waits for arg parsing, so --respect-env works.
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Source detection
@@ -1011,14 +1010,16 @@ any_source_sentinel() {
     ls "$DEST_REAL/state/.migrated-from-$1-"* >/dev/null 2>&1
 }
 
-# Atomic per-file copy preserving mtime. Returns 0 on success.
-# `cp -p` carries a FILE's mode; `mkdir -p` parents take umask, so a 0700 source
-# dir would land 0755. The dest takes the INTERSECTION — it never widens.
+# `cp -p` carries a FILE's mode, but `mkdir -p` parents take umask, so a 0700
+# source dir lands 0755. The dest takes the INTERSECTION — it never widens.
 mirror_dir_modes() {
     local s d
     s="$(dirname "$1")"; d="$(dirname "$2")"
     local -a sd=() dd=()
     while [ "$s" != "/" ] && [ "$d" != "/" ] && [ "$(basename "$s")" = "$(basename "$d")" ]; do
+        # Bound to paths STRICTLY inside the dest root. Basename agreement alone
+        # lets the walk climb past it and chmod ancestors outside the rollback.
+        [ -n "${DEST_REAL:-}" ] && [ "${d#"$DEST_REAL"/}" != "$d" ] || break
         sd+=("$s"); dd+=("$d")
         s="$(dirname "$s")"; d="$(dirname "$d")"
     done
@@ -1032,6 +1033,7 @@ mirror_dir_modes() {
     done
 }
 
+# Atomic per-file copy preserving mtime. Returns 0 on success.
 copy_preserving_mtime() {
     local src="$1" dst="$2"
     mkdir -p "$(dirname "$dst")"

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1185,8 +1185,12 @@ preflight_summary() {
 
 # SHA-256 verify (macOS shasum / Linux sha256sum). Returns 0 if hashes match.
 # Permission bits only (no file-type prefix): BSD %Lp and GNU %a agree.
+# GNU FIRST, and the order is load-bearing: GNU `stat -f` is --file-system, not
+# a format flag, so it prints a filesystem block to STDOUT and still exits
+# non-zero — a BSD-first `||` chain concatenates that block with the real mode.
+# BSD stat rejects `-c` outright, so GNU-first degrades cleanly the other way.
 mode_of() {
-    stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1"
+    stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null
 }
 
 # Identity is bytes AND mode, at every decision site: dropping a 0755 source

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -364,7 +364,7 @@ age_safe() {
     local file="$1"
     local now mtime age
     now="$(date +%s)"
-    mtime="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || echo 0)"
+    mtime="$(_stat %Y %m "$file" 0)"
     age=$((now - mtime))
     [ "$age" -ge "$INFLIGHT_GUARD_SEC" ]
 }
@@ -392,8 +392,8 @@ record_xsrc() {
     # $1=tag, $2=relpath, $3=class, $4=abs-path
     local tag="$1" rel="$2" cls="$3" file="$4"
     local mt sz
-    mt="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || echo 0)"
-    sz="$(stat -f %z "$file" 2>/dev/null || stat -c %s "$file" 2>/dev/null || echo 0)"
+    mt="$(_stat %Y %m "$file" 0)"
+    sz="$(_stat %s %z "$file" 0)"
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$rel" "$tag" "$cls" "$mt" "$sz" "$file" >> "$XSRC_INDEX"
 }
 
@@ -421,7 +421,8 @@ scan_source() {
         REPORT_LINES+=("  prior partial migration sentinels:")
         while IFS= read -r s; do
             local sm
-            sm="$(stat -f '%Sm' -t '%Y-%m-%d' "$s" 2>/dev/null || stat -c '%y' "$s" 2>/dev/null | cut -d' ' -f1)"
+            sm="$(stat -c '%y' "$s" 2>/dev/null | cut -d' ' -f1)"
+            [ -n "$sm" ] || sm="$(stat -f '%Sm' -t '%Y-%m-%d' "$s" 2>/dev/null)"
             REPORT_LINES+=("    $(basename "$s")  ($sm)")
         done <<<"$sentinels"
     fi
@@ -504,7 +505,7 @@ scan_source() {
         esac
 
         cls="$(classify "$rel")"
-        size="$(stat -f %z "$file" 2>/dev/null || stat -c %s "$file" 2>/dev/null || echo 0)"
+        size="$(_stat %s %z "$file" 0)"
         bytes_total=$((bytes_total + size))
 
         # Index for cross-source collision detection (only classes that
@@ -1189,8 +1190,17 @@ preflight_summary() {
 # a format flag, so it prints a filesystem block to STDOUT and still exits
 # non-zero — a BSD-first `||` chain concatenates that block with the real mode.
 # BSD stat rejects `-c` outright, so GNU-first degrades cleanly the other way.
+# Single owner of the stat portability split.
+# _stat <gnu-fmt> <bsd-fmt> <file> [fallback]
+_stat() {
+    stat -c "$1" "$3" 2>/dev/null || stat -f "$2" "$3" 2>/dev/null || printf '%s' "${4-}"
+}
+
+# Multi-line on purpose: tests/sutando-migrate-identity-mode.test.sh extracts
+# helpers with a `sed` RANGE that needs a lone closing brace, so a one-line
+# delegate here silently yields an empty mode and every identity check passes.
 mode_of() {
-    stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null
+    _stat %a %Lp "$1"
 }
 
 # Identity is bytes AND mode, at every decision site: dropping a 0755 source
@@ -1253,8 +1263,8 @@ commit_one() {
                 # Identical requires bytes AND mode; a mode-only difference
                 # falls through to keep-both so the source's mode survives.
                 local src_mt dst_mt
-                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
-                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                src_mt="$(_stat %Y %m "$src_file")"
+                dst_mt="$(_stat %Y %m "$dst_path")"
                 if identity_match "$src_file" "$dst_path"; then
                     echo "identical-drop"
                     return 0
@@ -1294,8 +1304,8 @@ commit_one() {
             dst_path="$DEST_REAL/$rel"
             if [ -e "$dst_path" ]; then
                 local src_mt dst_mt
-                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
-                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                src_mt="$(_stat %Y %m "$src_file")"
+                dst_mt="$(_stat %Y %m "$dst_path")"
                 if [ "$src_mt" -gt "$dst_mt" ]; then
                     copy_preserving_mtime "$src_file" "$dst_path"
                     echo "src-newer"
@@ -1336,8 +1346,8 @@ commit_one() {
             # Per-mtime swap, identical-drop, or write-fresh.
             if [ -e "$dst_path" ]; then
                 local src_mt dst_mt
-                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
-                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                src_mt="$(_stat %Y %m "$src_file")"
+                dst_mt="$(_stat %Y %m "$dst_path")"
                 if [ "$src_mt" -gt "$dst_mt" ]; then
                     copy_preserving_mtime "$src_file" "$dst_path"
                     echo "rehomed-newer"
@@ -1367,8 +1377,8 @@ commit_one() {
             dst_path="$DEST_REAL/logs/workspace-narrative.log"
             mkdir -p "$(dirname "$dst_path")"
             local src_mt src_sz
-            src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
-            src_sz="$(stat -f %z "$src_file" 2>/dev/null || stat -c %s "$src_file")"
+            src_mt="$(_stat %Y %m "$src_file")"
+            src_sz="$(_stat %s %z "$src_file")"
             # Mini #design 2026-06-02 08:10Z: an `{ ... } > tmp && mv ...`
             # compound on a single line is NOT covered by `set -e` for its
             # left-side failure — the compound returns non-zero but execution
@@ -1644,7 +1654,7 @@ commit_source() {
         # is 0 (delete-source phase-2 path; pre-flight didn't run).
         if [ "$PROGRESS_TOTAL" -gt 0 ]; then
             PROGRESS_N=$((PROGRESS_N + 1))
-            _fsize="$(stat -f %z "$file" 2>/dev/null || stat -c %s "$file" 2>/dev/null || echo 0)"
+            _fsize="$(_stat %s %z "$file" 0)"
             printf "  [%d/%d] %s (%s) → %s\n" \
                 "$PROGRESS_N" "$PROGRESS_TOTAL" "${rel:0:60}" \
                 "$(humanize_bytes "$_fsize")" "$outcome" >&2
@@ -2197,7 +2207,7 @@ rollback_main() {
     else
         : > "$tar_listing"  # empty backup: nothing to preserve, everything is "added since"
     fi
-    [ "${SUTANDO_MIGRATE_DEBUG:-0}" = "1" ] && echo "[debug] tar_listing size=$(wc -l < "$tar_listing") backup_path size=$(stat -f %z "$backup_path")" >&2
+    [ "${SUTANDO_MIGRATE_DEBUG:-0}" = "1" ] && echo "[debug] tar_listing size=$(wc -l < "$tar_listing") backup_path size=$(_stat %s %z "$backup_path" 0)" >&2
     local sd
     [ "${SUTANDO_MIGRATE_DEBUG:-0}" = "1" ] && echo "[debug] rollback walk: DEST_REAL=$DEST_REAL" >&2
     for sd in "${WORKSPACE_SURFACE_DIRS[@]}" "${WORKSPACE_SURFACE_FILES[@]}"; do

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -381,9 +381,8 @@ declare -a REPORT_LINES
 # >1 source (cross-source collisions per-source scan misses — e.g. build_log.md
 # in A AND C bound for the same dest path).
 XSRC_INDEX="$(mktemp -t sutando-migrate-xsrc.XXXXXX)"
-# Shadow any INHERITED value before the trap installs: without this, an
-# environment-supplied _VERDICTS_TMP is rm -f'd on EXIT — even by --help —
-# so cleanup could delete an arbitrary writable path this process never made.
+# Shadow any inherited value before the trap installs, or cleanup rm -f's
+# an arbitrary environment-supplied path this process never created.
 _VERDICTS_TMP=""
 trap 'rm -f "$XSRC_INDEX" "${_VERDICTS_TMP:-}"' EXIT INT TERM
 # Also include dest's existing files (tag "DEST") so we surface dest-collisions
@@ -1180,15 +1179,11 @@ mode_of() {
     stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1"
 }
 
-# The ONE identity decision (kewei review, blocker 2): equal bytes alone must
-# never certify a duplicate — copy_preserving_mtime preserves MODE, and these
-# classes include owner scripts and hooks, so a dropped 0755 source against a
-# 0644 dest silently loses the exec bit with no backup carrying it. Identity
-# is bytes AND mode, and scan/commit/verify/delete all use this same test.
+# Identity is bytes AND mode, at every decision site: dropping a 0755 source
+# against a byte-equal 0644 dest silently loses the exec bit, unrecoverably.
 identity_match() {
-    # FAIL CLOSED on an unreadable mode: with both probes failing, a bare
-    # comparison sees "" = "" and certifies identity with mode UNKNOWN —
-    # re-opening the destructive drop/delete path on a transient stat error.
+    # Fail closed on an unreadable mode: both probes failing would
+    # blank-compare "" = "" and certify identity with mode unknown.
     local ma mb
     ma="$(mode_of "$1")" || return 1
     mb="$(mode_of "$2")" || return 1
@@ -1241,11 +1236,8 @@ commit_one() {
         structural|collision-keep-both)
             dst_path="$DEST_REAL/$rel"
             if [ -e "$dst_path" ]; then
-                # Identity (bytes AND mode) → identical-drop. mtime+size alone
-                # certified equal-mtime/equal-size DIFFERENT bytes as identical,
-                # and bytes alone dropped a 0755 source against a 0644 dest.
-                # A mode-only difference falls through to keep-both below, so
-                # the source's mode survives in whichever file carries it.
+                # Identical requires bytes AND mode; a mode-only difference
+                # falls through to keep-both so the source's mode survives.
                 local src_mt dst_mt
                 src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
                 dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
@@ -2262,11 +2254,8 @@ def has_size_mismatch(entries):
     return len({e["size"] for e in entries}) > 1
 def has_mtime_mismatch(entries):
     return len({e["mtime"] for e in entries}) > 1
-# Actionability sort keys on the VERDICT first: every divergent (False) and
-# unverified (None) entry outranks every byte-identical (True) one, whatever
-# the mtimes — the old shape put identical-with-differing-mtimes in the same
-# bucket as verified mtime-only divergence, so 50 ignorable entries could
-# push the one actionable entry past the render cap.
+# Sort on the VERDICT first: divergent/unverified outrank byte-identical,
+# else ignorable entries can push the one actionable one past the render cap.
 def sort_key(item):
     k, v = item
     if ident_verdict[k] is not True:

--- a/skills/sutando-migrate/SKILL.md
+++ b/skills/sutando-migrate/SKILL.md
@@ -22,8 +22,8 @@ Guided workspace migration for existing users (M1 Part 2). Reach for this when:
 Run `bash scripts/sutando-migrate.sh scan --json`. Parse the JSON for:
 - Total unique relpaths across A+B+C+dest
 - Per-source byte counts
-- Cross-source collision triage: `identical_content` (drop-dup, no action) + `mtime_only_diff` (commit's newest-mtime auto-resolves) + `size_mismatch` (REAL content conflicts — owner attention)
-- Notable size-mismatch entries (build_log, conversation.log, state/* divergences)
+- Cross-source collision triage: `identical_content` (byte-verified drop-dup, no action) + `mtime_only_diff` (commit's newest-mtime auto-resolves) + `size_mismatch` and `proxy_identical_divergent` (REAL content conflicts — owner attention; the latter is equal mtime+size with DIFFERENT bytes, where proxies lie)
+- Notable actionable entries — anything with `byte_identical: false` (build_log, conversation.log, hosts/*, state/* divergences)
 
 Present a concise 4–6 line summary to owner via:
 - Discord DM (text)

--- a/skills/sutando-migrate/SKILL.md
+++ b/skills/sutando-migrate/SKILL.md
@@ -23,7 +23,8 @@ Run `bash scripts/sutando-migrate.sh scan --json`. Parse the JSON for:
 - Total unique relpaths across A+B+C+dest
 - Per-source byte counts
 - Cross-source collision triage: `identical_content` (byte-verified drop-dup, no action) + `mtime_only_diff` (commit's newest-mtime auto-resolves) + `size_mismatch` and `proxy_identical_divergent` (REAL content conflicts — owner attention; the latter is equal mtime+size with PROVEN-different bytes, both hashes read OK) + `identity_unverified` (hash failed on an unreadable entry — actionable: fix permissions, re-scan; per-collision `byte_identical` is tri-state true/false/null)
-- Notable actionable entries — anything with `byte_identical: false` (proven divergence) **or `byte_identical: null`** (unverified: the hash could not be read — surface the relpath + source so the owner can fix permissions BEFORE greenlight, or commit may partially write then abort)
+- Notable actionable entries — anything with `byte_identical: false` (proven divergence), **`byte_identical: null`** (unverified: the hash could not be read — surface the relpath + source so the owner can fix permissions BEFORE greenlight, or commit may partially write then abort), **or `mode_conflict: true`** (bytes are equal but the permission bits are not — dropping the duplicate would silently pick one file's mode, so it needs the same attention as a content conflict)
+- `byte_identical` is a claim about BYTES ONLY and is never false when no byte differs; a mode-only difference reports `byte_identical: true` **with** `mode_conflict: true`. `identical_content` counts only the drop-safe case — equal bytes AND equal modes — so it stays the signal for "no action".
 
 Present a concise 4–6 line summary to owner via:
 - Discord DM (text)

--- a/skills/sutando-migrate/SKILL.md
+++ b/skills/sutando-migrate/SKILL.md
@@ -22,7 +22,7 @@ Guided workspace migration for existing users (M1 Part 2). Reach for this when:
 Run `bash scripts/sutando-migrate.sh scan --json`. Parse the JSON for:
 - Total unique relpaths across A+B+C+dest
 - Per-source byte counts
-- Cross-source collision triage: `identical_content` (byte-verified drop-dup, no action) + `mtime_only_diff` (commit's newest-mtime auto-resolves) + `size_mismatch` and `proxy_identical_divergent` (REAL content conflicts — owner attention; the latter is equal mtime+size with DIFFERENT bytes, where proxies lie)
+- Cross-source collision triage: `identical_content` (byte-verified drop-dup, no action) + `mtime_only_diff` (commit's newest-mtime auto-resolves) + `size_mismatch` and `proxy_identical_divergent` (REAL content conflicts — owner attention; the latter is equal mtime+size with PROVEN-different bytes, both hashes read OK) + `identity_unverified` (hash failed on an unreadable entry — actionable: fix permissions, re-scan; per-collision `byte_identical` is tri-state true/false/null)
 - Notable actionable entries — anything with `byte_identical: false` (build_log, conversation.log, hosts/*, state/* divergences)
 
 Present a concise 4–6 line summary to owner via:

--- a/skills/sutando-migrate/SKILL.md
+++ b/skills/sutando-migrate/SKILL.md
@@ -23,7 +23,7 @@ Run `bash scripts/sutando-migrate.sh scan --json`. Parse the JSON for:
 - Total unique relpaths across A+B+C+dest
 - Per-source byte counts
 - Cross-source collision triage: `identical_content` (byte-verified drop-dup, no action) + `mtime_only_diff` (commit's newest-mtime auto-resolves) + `size_mismatch` and `proxy_identical_divergent` (REAL content conflicts — owner attention; the latter is equal mtime+size with PROVEN-different bytes, both hashes read OK) + `identity_unverified` (hash failed on an unreadable entry — actionable: fix permissions, re-scan; per-collision `byte_identical` is tri-state true/false/null)
-- Notable actionable entries — anything with `byte_identical: false` (build_log, conversation.log, hosts/*, state/* divergences)
+- Notable actionable entries — anything with `byte_identical: false` (proven divergence) **or `byte_identical: null`** (unverified: the hash could not be read — surface the relpath + source so the owner can fix permissions BEFORE greenlight, or commit may partially write then abort)
 
 Present a concise 4–6 line summary to owner via:
 - Discord DM (text)

--- a/tests/shell-ci-known-failures.txt
+++ b/tests/shell-ci-known-failures.txt
@@ -14,5 +14,4 @@
 # quarantining, not an entry here.
 #
 # Burn this list to zero: https://github.com/sonichi/sutando/issues/1934
-tests/sutando-migrate.test.sh
 tests/sync-workspace.test.sh

--- a/tests/sutando-migrate-dirmode-bounds.test.sh
+++ b/tests/sutando-migrate-dirmode-bounds.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# The dir-mode walk is held only by basename agreement, so with matching
+# ancestors it climbs past the dest root and chmods paths outside the rollback.
+set -u
+cd "$(dirname "$0")/.."
+fails=0
+check() { if [ "$2" = "$3" ]; then echo "  ok  $1"; else echo "FAIL  $1 — got '$2', want '$3'"; fails=$((fails+1)); fi; }
+
+MIGRATE="$PWD/scripts/sutando-migrate.sh"
+tmp="$(mktemp -d -t migrate-dirmode.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Ancestors agree ABOVE both roots ('shared', then 'workspace'), which is what
+# lets the walk leave the destination — the real legacy/canonical pair does too.
+SRC="$tmp/left/shared/workspace"
+DEST="$tmp/right/shared/workspace"
+OUTSIDE="$tmp/right/shared"          # parent of DEST_REAL: outside target AND backup
+mkdir -p "$SRC/hosts/H" "$DEST/hosts/H"
+printf 'secret\n' > "$SRC/hosts/H/PERSONAL_CLAUDE.md"
+# The SOURCE-side outside ancestor must be NARROWER, or the intersection is a
+# no-op and the test passes with or without the bound (measured: it did).
+chmod 0700 "$SRC" "$SRC/hosts" "$SRC/hosts/H" "$tmp/left/shared"
+chmod 0755 "$OUTSIDE"
+
+before_outside="$(stat -c %a "$OUTSIDE" 2>/dev/null || stat -f %Lp "$OUTSIDE")"
+SUTANDO_MIGRATE_SRC_C="$SRC" SUTANDO_MIGRATE_DEST="$DEST" \
+    bash "$MIGRATE" commit --source C --no-confirm >"$tmp/out.txt" 2>&1 || true
+after_outside="$(stat -c %a "$OUTSIDE" 2>/dev/null || stat -f %Lp "$OUTSIDE")"
+
+check "a path ABOVE the dest root is never chmodded" "$after_outside" "$before_outside"
+
+# Positive control: without it this passes just as well when mirroring is dead.
+inner="$DEST/hosts/H"
+inner_mode="$(stat -c %a "$inner" 2>/dev/null || stat -f %Lp "$inner")"
+check "control: a dir INSIDE the dest root still takes the intersection" "$inner_mode" "700"
+check "control: the file actually migrated (else nothing was exercised)" \
+      "$([ -f "$DEST/hosts/H/PERSONAL_CLAUDE.md" ] && echo yes || echo no)" "yes"
+
+[ "$fails" -eq 0 ] && echo "ALL PASS" || echo "$fails FAILED"
+exit "$fails"

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -105,25 +105,62 @@ check "the escape is named in output" grep -q "escapes the dest root" "$TMP/syml
 echo "5. UNION_VERIFY: a correct union passes mandatory phase-three verification"
 new_case union
 mkdir -p "$CASE_A/state"
-printf '{"users": ["alice", "bob"]}\n' > "$CASE_A/state/slack-allowed-recipients.json"
-printf '{"users": ["bob", "carol"]}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
-touch -t 202606011200 "$CASE_A/state/slack-allowed-recipients.json"
-touch -t 202606011300 "$CASE_DEST/state/slack-allowed-recipients.json"
+# The SOURCE is the newer side (the reviewer's shape): its scalars win, and
+# the union stamps the dest with its mtime — which is what arms the
+# scalar-winner check in union_contains.
+printf '{"users": ["alice", "bob"], "schemaVersion": 2}\n' > "$CASE_A/state/slack-allowed-recipients.json"
+printf '{"users": ["bob", "carol"], "schemaVersion": 1}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
+touch -t 202606011300 "$CASE_A/state/slack-allowed-recipients.json"
+touch -t 202606011200 "$CASE_DEST/state/slack-allowed-recipients.json"
 rc=0; RUN --commit > "$TMP/union-commit.log" 2>&1 || rc=$?
 check "divergent union commit succeeds" [ "$rc" -eq 0 ]
-check "the union really merged both sides" \
+UNION_DST="$CASE_DEST/state/slack-allowed-recipients.json"
+check "the union merged both arrays and kept the newer scalar" \
     python3 -c "
 import json
-d = json.load(open('$CASE_DEST/state/slack-allowed-recipients.json'))
-import sys; sys.exit(0 if sorted(d['users']) == ['alice','bob','carol'] else 1)
+d = json.load(open('$UNION_DST'))
+import sys; sys.exit(0 if sorted(d['users']) == ['alice','bob','carol'] and d['schemaVersion'] == 2 else 1)
 "
 rc=0; RUN --verify > "$TMP/union-verify.log" 2>&1 || rc=$?
 check "verify passes the union result (rc 0)" [ "$rc" -eq 0 ]
 check "verify reports zero mismatches" grep -q "mismatch=0" "$TMP/union-verify.log"
-# Negative control: verify must still FAIL when the dest LOST a source element.
-printf '{"users": ["carol"]}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
+
+# Content-only corruptions from here on: every edit preserves the dest mtime,
+# and the pristine bytes are restored (with mtime) between controls.
+GOOD_UNION="$(cat "$UNION_DST")"
+corrupt() {  # $1 = python expression mutating dict d
+    python3 - "$UNION_DST" "$1" <<'PY'
+import json, os, sys
+p, expr = sys.argv[1], sys.argv[2]
+mt = os.path.getmtime(p)
+d = json.load(open(p))
+exec(expr)
+json.dump(d, open(p, "w"), indent=2, sort_keys=True)
+os.utime(p, (mt, mt))
+PY
+}
+restore() {
+    python3 - "$UNION_DST" <<PY
+import os, sys
+p = sys.argv[1]
+mt = os.path.getmtime(p)
+open(p, "w").write("""$GOOD_UNION""")
+os.utime(p, (mt, mt))
+PY
+}
+
+corrupt "d['users'] = ['carol']"
 rc=0; RUN --verify > "$TMP/union-verify-neg.log" 2>&1 || rc=$?
 check "a union that DROPPED an element still fails verify (control)" [ "$rc" -ne 0 ]
+restore
+rc=0; RUN --verify > "$TMP/union-verify-restore.log" 2>&1 || rc=$?
+check "restored union verifies again (the controls are not wedged)" [ "$rc" -eq 0 ]
+
+# The reviewer's scalar repro: arrays fully intact, only the winning scalar
+# altered to a value no input carried.
+corrupt "d['schemaVersion'] = 999"
+rc=0; RUN --verify > "$TMP/union-verify-scalar.log" 2>&1 || rc=$?
+check "a corrupted WINNING SCALAR fails verify (arrays all intact)" [ "$rc" -ne 0 ]
 
 echo ""
 echo "$pass passed, $fail failed"

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -162,6 +162,40 @@ corrupt "d['schemaVersion'] = 999"
 rc=0; RUN --verify > "$TMP/union-verify-scalar.log" 2>&1 || rc=$?
 check "a corrupted WINNING SCALAR fails verify (arrays all intact)" [ "$rc" -ne 0 ]
 
+echo "6. UNION_VERIFY dest-winner: the pre-union dest's scalars verify via the manifest"
+# The reviewer's paired control: when the DEST was newer, ITS scalars won and
+# no source's mtime can vouch for them — only the commit-time manifest can.
+new_case destwin
+mkdir -p "$CASE_A/state"
+printf '{"users": ["alice"], "schemaVersion": 1}\n' > "$CASE_A/state/slack-allowed-recipients.json"
+printf '{"users": ["bob"], "schemaVersion": 2}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
+touch -t 202606011200 "$CASE_A/state/slack-allowed-recipients.json"
+touch -t 202606011300 "$CASE_DEST/state/slack-allowed-recipients.json"
+rc=0; RUN --commit > "$TMP/destwin-commit.log" 2>&1 || rc=$?
+check "dest-newer union commit succeeds" [ "$rc" -eq 0 ]
+DW_DST="$CASE_DEST/state/slack-allowed-recipients.json"
+check "the dest's scalar won and both arrays merged" \
+    python3 -c "
+import json
+d = json.load(open('$DW_DST'))
+import sys; sys.exit(0 if sorted(d['users']) == ['alice','bob'] and d['schemaVersion'] == 2 else 1)
+"
+check "the commit recorded a union-scalars manifest" \
+    bash -c "ls '$CASE_DEST/state/.migration-union-scalars-'*.json >/dev/null 2>&1"
+rc=0; RUN --verify > "$TMP/destwin-verify.log" 2>&1 || rc=$?
+check "pristine dest-winner union passes verify" [ "$rc" -eq 0 ]
+python3 - "$DW_DST" <<'PY'
+import json, os, sys
+p = sys.argv[1]
+mt = os.path.getmtime(p)
+d = json.load(open(p))
+d["schemaVersion"] = 999
+json.dump(d, open(p, "w"), indent=2, sort_keys=True)
+os.utime(p, (mt, mt))
+PY
+rc=0; RUN --verify > "$TMP/destwin-verify-corrupt.log" 2>&1 || rc=$?
+check "a corrupted DEST-WINNER scalar fails verify (the reviewer's paired control)" [ "$rc" -ne 0 ]
+
 echo ""
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -12,6 +12,14 @@ MIGRATE="$REPO/scripts/sutando-migrate.sh"
 TMP="$(mktemp -d -t sutando-mig-failclosed.XXXXXX)"
 trap 'chmod -R u+w "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
+# Portable octal file mode. `stat -f %Lp` is the BSD/macOS spelling; on GNU
+# coreutils `-f` is --file-system, which EXITS 0 printing filesystem info — so
+# a `stat -f ... || stat -c ...` chain never reaches its fallback on Linux and
+# compares the wrong command's output. Ask python; it means the same on both.
+_mode() {
+    python3 -c 'import os,stat,sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$1"
+}
+
 pass=0
 fail=0
 check() {
@@ -98,7 +106,7 @@ ln -s "$OUTSIDE" "$CASE_DEST/hosts"
 rc=0; RUN --commit > "$TMP/symlink.log" 2>&1 || rc=$?
 check "commit exits non-zero" [ "$rc" -ne 0 ]
 check "nothing was created outside the dest root" [ -z "$(ls -A "$OUTSIDE")" ]
-check "the outside dir's mode is untouched" [ "$(/usr/bin/stat -f %Lp "$OUTSIDE" 2>/dev/null || /usr/bin/stat -c %a "$OUTSIDE")" = "755" ]
+check "the outside dir's mode is untouched" [ "$(_mode "$OUTSIDE")" = "755" ]
 check "NO sentinel was written" no_sentinel
 check "the escape is named in output" grep -q "escapes the dest root" "$TMP/symlink.log"
 
@@ -263,10 +271,8 @@ rc=0; RUN --commit > "$TMP/modes-commit.log" 2>&1 || rc=$?
 check "private-input union commit succeeds" [ "$rc" -eq 0 ]
 MODE_DST="$CASE_DEST/state/slack-allowed-recipients.json"
 MODE_MANIFEST="$(ls "$CASE_DEST/state/.migration-union-scalars-"*.json | head -1)"
-check "the union file is still private" \
-    bash -c "[ \"\$(stat -f '%Lp' '$MODE_DST' 2>/dev/null || stat -c '%a' '$MODE_DST')\" = 600 ]"
-check "the manifest is no wider than the union it describes" \
-    bash -c "[ \"\$(stat -f '%Lp' '$MODE_MANIFEST' 2>/dev/null || stat -c '%a' '$MODE_MANIFEST')\" = 600 ]"
+check "the union file is still private" [ "$(_mode "$MODE_DST")" = "600" ]
+check "the manifest is no wider than the union it describes" [ "$(_mode "$MODE_MANIFEST")" = "600" ]
 check "the manifest carries the union's private scalar (so its mode matters)" \
     bash -c "grep -q schemaVersion '$MODE_MANIFEST'"
 check "the commit recorded the expected union mode" \

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Commit must FAIL CLOSED: no sentinel and rc!=0 after any failed write, no
-# mutation outside the physically-resolved dest root, and a correct union must
-# pass mandatory verification. Controls mirror the #3418 review's injections.
+# Commit must FAIL CLOSED: no sentinel and rc!=0 after a failed write, no
+# mutation outside the resolved dest root, and a correct union must verify.
 
 set -euo pipefail
 
@@ -111,9 +110,8 @@ check "the escape is named in output" grep -q "escapes the dest root" "$TMP/syml
 echo "5. UNION_VERIFY: a correct union passes mandatory phase-three verification"
 new_case union
 mkdir -p "$CASE_A/state"
-# The SOURCE is the newer side (the reviewer's shape): its scalars win, and
-# the union stamps the dest with its mtime — which is what arms the
-# scalar-winner check in union_contains.
+# The SOURCE is the newer side, so its scalars win and the union stamps the
+# dest with its mtime, which is what arms the scalar-winner check.
 printf '{"users": ["alice", "bob"], "schemaVersion": 2}\n' > "$CASE_A/state/slack-allowed-recipients.json"
 printf '{"users": ["bob", "carol"], "schemaVersion": 1}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
 touch -t 202606011300 "$CASE_A/state/slack-allowed-recipients.json"
@@ -162,14 +160,14 @@ restore
 rc=0; RUN --verify > "$TMP/union-verify-restore.log" 2>&1 || rc=$?
 check "restored union verifies again (the controls are not wedged)" [ "$rc" -eq 0 ]
 
-# The reviewer's scalar repro: arrays fully intact, only the winning scalar
+# Scalar repro: arrays fully intact, only the winning scalar
 # altered to a value no input carried.
 corrupt "d['schemaVersion'] = 999"
 rc=0; RUN --verify > "$TMP/union-verify-scalar.log" 2>&1 || rc=$?
 check "a corrupted WINNING SCALAR fails verify (arrays all intact)" [ "$rc" -ne 0 ]
 
 echo "6. UNION_VERIFY dest-winner: the pre-union dest's scalars verify via the manifest"
-# The reviewer's paired control: when the DEST was newer, ITS scalars won and
+# Paired control: when the DEST was newer, ITS scalars won and
 # no source's mtime can vouch for them — only the commit-time manifest can.
 new_case destwin
 mkdir -p "$CASE_A/state"
@@ -233,10 +231,8 @@ printf '{"users": ["x"], "schemaVersion": 1}\n' > "$CASE_A/state/slack-allowed-r
 printf '{"users": ["y"], "schemaVersion": 2}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
 touch -t 202606011300 "$CASE_A/state/slack-allowed-recipients.json"
 touch -t 202606011200 "$CASE_DEST/state/slack-allowed-recipients.json"
-# pre-plant an invalid manifest for EVERY possible backup id? The id is minted
-# at run time — plant via the same glob shape the recorder writes and verify
-# reads... the recorder writes a NEW id, so instead assert on the direct
-# helper: drive record_union_scalars against an invalid manifest file.
+# The backup id is minted at run time, so a pre-planted manifest can never
+# match it; drive record_union_scalars against an invalid manifest instead.
 INVALID="$TMP/invalid-manifest.json"
 printf 'not json{' > "$INVALID"
 REC_FN="$TMP/record_fn.sh"
@@ -256,9 +252,8 @@ check "recorder REFUSES an invalid existing manifest (rc != 0)" [ "$rc" -ne 0 ]
 check "...and did not replace it with {}" bash -c "grep -q 'not json{' '$INVALID'"
 
 echo "8. MANIFEST MODE: the manifest is never wider than the union it describes"
-# keweichen on #3418: the writer used a plain open(), so under umask 0022 a
-# private (0600) union file's non-array state was duplicated into a 0644
-# manifest — the same disclosure, one file over.
+# A plain open() under umask 0022 duplicated a 0600 union's non-array state
+# into a 0644 manifest: the same disclosure, one file over.
 new_case modes
 mkdir -p "$CASE_A/state"
 printf '{"users": ["alice"], "schemaVersion": 1}\n' > "$CASE_A/state/slack-allowed-recipients.json"

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Commit must FAIL CLOSED: no sentinel and rc!=0 after any failed write, no
+# mutation outside the physically-resolved dest root, and a correct union must
+# pass mandatory verification. Controls mirror the #3418 review's injections.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+MIGRATE="$REPO/scripts/sutando-migrate.sh"
+
+TMP="$(mktemp -d -t sutando-mig-failclosed.XXXXXX)"
+trap 'chmod -R u+w "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+check() {
+    local description="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        echo "OK: $description"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $description"
+        fail=$((fail + 1))
+    fi
+}
+
+# One isolated fixture per control: a single source A and a dest.
+new_case() {  # $1 = name; sets CASE_A, CASE_DEST
+    CASE_A="$TMP/$1/source-a"
+    CASE_DEST="$TMP/$1/dest"
+    mkdir -p "$CASE_A" "$CASE_DEST/state"
+}
+RUN() {  # rc surfaced to caller; output to per-case log
+    SUTANDO_MIGRATE_SRC_A="$CASE_A" \
+    SUTANDO_MIGRATE_SRC_B="$TMP/absent-b" \
+    SUTANDO_MIGRATE_SRC_C="$TMP/absent-c" \
+    SUTANDO_MIGRATE_DEST="$CASE_DEST" \
+        bash "$MIGRATE" "$@"
+}
+no_sentinel() { [ -z "$(ls "$CASE_DEST/state/.migrated-from-A-"* 2>/dev/null)" ]; }
+
+echo "1. COPY_FAIL: an unwritable dest dir must fail the commit, not certify it"
+new_case copyfail
+mkdir -p "$CASE_A/hosts/Test-Host" "$CASE_DEST/hosts/Test-Host"
+echo "payload" > "$CASE_A/hosts/Test-Host/crons.json"
+chmod 555 "$CASE_DEST/hosts/Test-Host"
+rc=0; RUN --commit > "$TMP/copyfail.log" 2>&1 || rc=$?
+chmod 755 "$CASE_DEST/hosts/Test-Host"
+check "commit exits non-zero" [ "$rc" -ne 0 ]
+check "the file did NOT land" [ ! -f "$CASE_DEST/hosts/Test-Host/crons.json" ]
+check "NO sentinel was written" no_sentinel
+check "the failure is named in output" grep -q "WRITE-FAILED" "$TMP/copyfail.log"
+
+echo "2. MODE_PROBE_FAIL: an unprobeable existing dest dir refuses the copy"
+new_case probefail
+mkdir -p "$CASE_A/hosts/probefail-host" "$CASE_DEST/hosts/probefail-host"
+echo "payload" > "$CASE_A/hosts/probefail-host/crons.json"
+chmod 700 "$CASE_A/hosts/probefail-host"   # differs from dest so the probe path runs
+BIN="$TMP/bin-probefail"; mkdir -p "$BIN"
+cat > "$BIN/stat" <<'SH'
+#!/bin/bash
+for a in "$@"; do case "$a" in *probefail-host*) exit 1;; esac; done
+exec /usr/bin/stat "$@"
+SH
+chmod +x "$BIN/stat"
+rc=0; PATH="$BIN:$PATH" RUN --commit > "$TMP/probefail.log" 2>&1 || rc=$?
+check "commit exits non-zero" [ "$rc" -ne 0 ]
+check "the file did NOT land under an unverified mode" [ ! -f "$CASE_DEST/hosts/probefail-host/crons.json" ]
+check "NO sentinel was written" no_sentinel
+
+echo "3. CHMOD_FAIL: a mode that cannot be applied refuses the copy"
+new_case chmodfail
+mkdir -p "$CASE_A/hosts/chmodfail-host" "$CASE_DEST/hosts/chmodfail-host"
+echo "payload" > "$CASE_A/hosts/chmodfail-host/crons.json"
+chmod 700 "$CASE_A/hosts/chmodfail-host"
+chmod 755 "$CASE_DEST/hosts/chmodfail-host"
+BIN="$TMP/bin-chmodfail"; mkdir -p "$BIN"
+cat > "$BIN/chmod" <<'SH'
+#!/bin/bash
+for a in "$@"; do case "$a" in *chmodfail-host*) exit 1;; esac; done
+exec /bin/chmod "$@"
+SH
+chmod +x "$BIN/chmod"
+rc=0; PATH="$BIN:$PATH" RUN --commit > "$TMP/chmodfail.log" 2>&1 || rc=$?
+check "commit exits non-zero" [ "$rc" -ne 0 ]
+check "the file did NOT land under the widened mode" [ ! -f "$CASE_DEST/hosts/chmodfail-host/crons.json" ]
+check "NO sentinel was written" no_sentinel
+
+echo "4. SYMLINK_BOUND: a dest child symlink must refuse BEFORE any outside mutation"
+new_case symlink
+OUTSIDE="$TMP/outside-the-boundary"
+mkdir -p "$OUTSIDE"; chmod 755 "$OUTSIDE"
+mkdir -p "$CASE_A/hosts/Test-Host"
+echo "payload" > "$CASE_A/hosts/Test-Host/crons.json"
+ln -s "$OUTSIDE" "$CASE_DEST/hosts"
+rc=0; RUN --commit > "$TMP/symlink.log" 2>&1 || rc=$?
+check "commit exits non-zero" [ "$rc" -ne 0 ]
+check "nothing was created outside the dest root" [ -z "$(ls -A "$OUTSIDE")" ]
+check "the outside dir's mode is untouched" [ "$(/usr/bin/stat -f %Lp "$OUTSIDE" 2>/dev/null || /usr/bin/stat -c %a "$OUTSIDE")" = "755" ]
+check "NO sentinel was written" no_sentinel
+check "the escape is named in output" grep -q "escapes the dest root" "$TMP/symlink.log"
+
+echo "5. UNION_VERIFY: a correct union passes mandatory phase-three verification"
+new_case union
+mkdir -p "$CASE_A/state"
+printf '{"users": ["alice", "bob"]}\n' > "$CASE_A/state/slack-allowed-recipients.json"
+printf '{"users": ["bob", "carol"]}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
+touch -t 202606011200 "$CASE_A/state/slack-allowed-recipients.json"
+touch -t 202606011300 "$CASE_DEST/state/slack-allowed-recipients.json"
+rc=0; RUN --commit > "$TMP/union-commit.log" 2>&1 || rc=$?
+check "divergent union commit succeeds" [ "$rc" -eq 0 ]
+check "the union really merged both sides" \
+    python3 -c "
+import json
+d = json.load(open('$CASE_DEST/state/slack-allowed-recipients.json'))
+import sys; sys.exit(0 if sorted(d['users']) == ['alice','bob','carol'] else 1)
+"
+rc=0; RUN --verify > "$TMP/union-verify.log" 2>&1 || rc=$?
+check "verify passes the union result (rc 0)" [ "$rc" -eq 0 ]
+check "verify reports zero mismatches" grep -q "mismatch=0" "$TMP/union-verify.log"
+# Negative control: verify must still FAIL when the dest LOST a source element.
+printf '{"users": ["carol"]}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
+rc=0; RUN --verify > "$TMP/union-verify-neg.log" 2>&1 || rc=$?
+check "a union that DROPPED an element still fails verify (control)" [ "$rc" -ne 0 ]
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -249,6 +249,37 @@ rc=0
 check "recorder REFUSES an invalid existing manifest (rc != 0)" [ "$rc" -ne 0 ]
 check "...and did not replace it with {}" bash -c "grep -q 'not json{' '$INVALID'"
 
+echo "8. MANIFEST MODE: the manifest is never wider than the union it describes"
+# keweichen on #3418: the writer used a plain open(), so under umask 0022 a
+# private (0600) union file's non-array state was duplicated into a 0644
+# manifest — the same disclosure, one file over.
+new_case modes
+mkdir -p "$CASE_A/state"
+printf '{"users": ["alice"], "schemaVersion": 1}\n' > "$CASE_A/state/slack-allowed-recipients.json"
+printf '{"users": ["bob"], "schemaVersion": 2}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
+chmod 600 "$CASE_A/state/slack-allowed-recipients.json"
+chmod 600 "$CASE_DEST/state/slack-allowed-recipients.json"
+rc=0; RUN --commit > "$TMP/modes-commit.log" 2>&1 || rc=$?
+check "private-input union commit succeeds" [ "$rc" -eq 0 ]
+MODE_DST="$CASE_DEST/state/slack-allowed-recipients.json"
+MODE_MANIFEST="$(ls "$CASE_DEST/state/.migration-union-scalars-"*.json | head -1)"
+check "the union file is still private" \
+    bash -c "[ \"\$(stat -f '%Lp' '$MODE_DST' 2>/dev/null || stat -c '%a' '$MODE_DST')\" = 600 ]"
+check "the manifest is no wider than the union it describes" \
+    bash -c "[ \"\$(stat -f '%Lp' '$MODE_MANIFEST' 2>/dev/null || stat -c '%a' '$MODE_MANIFEST')\" = 600 ]"
+check "the manifest carries the union's private scalar (so its mode matters)" \
+    bash -c "grep -q schemaVersion '$MODE_MANIFEST'"
+check "the commit recorded the expected union mode" \
+    bash -c "grep -q '__union_modes__' '$MODE_MANIFEST'"
+rc=0; RUN --verify > "$TMP/modes-verify.log" 2>&1 || rc=$?
+check "a pristine private union passes verify" [ "$rc" -eq 0 ]
+# The recorded mode is load-bearing: widening the dest must FAIL verification
+# even though every scalar and array still matches.
+chmod 644 "$MODE_DST"
+rc=0; RUN --verify > "$TMP/modes-verify-widened.log" 2>&1 || rc=$?
+check "a WIDENED union fails verify though its content is untouched" [ "$rc" -ne 0 ]
+chmod 600 "$MODE_DST"
+
 echo ""
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -278,6 +278,12 @@ check "the manifest carries the union's private scalar (so its mode matters)" \
 check "the commit recorded the expected union mode" \
     bash -c "grep -q '__union_modes__' '$MODE_MANIFEST'"
 rc=0; RUN --verify > "$TMP/modes-verify.log" 2>&1 || rc=$?
+# This one fails on Linux only, so its log has to travel to CI: a bare FAIL
+# line says nothing a macOS run can reproduce.
+[ "$rc" -eq 0 ] || { echo "--- verify log (rc=$rc) ---"; cat "$TMP/modes-verify.log"; \
+    echo "--- observed modes ---"; \
+    echo "dst=$(_mode "$MODE_DST") manifest=$(_mode "$MODE_MANIFEST")"; \
+    echo "--- manifest ---"; cat "$MODE_MANIFEST"; echo "---"; }
 check "a pristine private union passes verify" [ "$rc" -eq 0 ]
 # The recorded mode is load-bearing: widening the dest must FAIL verification
 # even though every scalar and array still matches.

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -196,6 +196,59 @@ PY
 rc=0; RUN --verify > "$TMP/destwin-verify-corrupt.log" 2>&1 || rc=$?
 check "a corrupted DEST-WINNER scalar fails verify (the reviewer's paired control)" [ "$rc" -ne 0 ]
 
+echo "7. MANIFEST AUTHORITY: a damaged manifest fails verify, never degrades to mtime"
+MANIFEST="$(ls "$CASE_DEST/state/.migration-union-scalars-"*.json | head -1)"
+GOOD_MANIFEST="$(cat "$MANIFEST")"
+# 7a. malformed manifest + corrupted dest-winner scalar -> must FAIL
+python3 - "$DW_DST" <<'PY'
+import json, os, sys
+p = sys.argv[1]
+mt = os.path.getmtime(p)
+d = json.load(open(p))
+d["schemaVersion"] = 999
+json.dump(d, open(p, "w"), indent=2, sort_keys=True)
+os.utime(p, (mt, mt))
+PY
+printf 'not json{' > "$MANIFEST"
+rc=0; RUN --verify > "$TMP/manifest-malformed.log" 2>&1 || rc=$?
+check "malformed manifest + corrupt scalar FAILS verify (no mtime degrade)" [ "$rc" -ne 0 ]
+# 7b. entry deleted from an otherwise-valid manifest -> must FAIL
+printf '{}' > "$MANIFEST"
+rc=0; RUN --verify > "$TMP/manifest-missing-entry.log" 2>&1 || rc=$?
+check "missing rel entry in a present manifest FAILS verify" [ "$rc" -ne 0 ]
+# 7c. restore manifest, dest still corrupt -> still fails (via the entry)
+printf '%s' "$GOOD_MANIFEST" > "$MANIFEST"
+rc=0; RUN --verify > "$TMP/manifest-restored-corrupt.log" 2>&1 || rc=$?
+check "restored manifest still catches the corrupt scalar (control)" [ "$rc" -ne 0 ]
+# 7d. recorder refuses an invalid existing manifest instead of replacing it
+new_case recorder-guard
+mkdir -p "$CASE_A/state"
+printf '{"users": ["x"], "schemaVersion": 1}\n' > "$CASE_A/state/slack-allowed-recipients.json"
+printf '{"users": ["y"], "schemaVersion": 2}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
+touch -t 202606011300 "$CASE_A/state/slack-allowed-recipients.json"
+touch -t 202606011200 "$CASE_DEST/state/slack-allowed-recipients.json"
+# pre-plant an invalid manifest for EVERY possible backup id? The id is minted
+# at run time — plant via the same glob shape the recorder writes and verify
+# reads... the recorder writes a NEW id, so instead assert on the direct
+# helper: drive record_union_scalars against an invalid manifest file.
+INVALID="$TMP/invalid-manifest.json"
+printf 'not json{' > "$INVALID"
+REC_FN="$TMP/record_fn.sh"
+python3 - "$MIGRATE" "$REC_FN" "$REPO" <<'PYX'
+import sys
+src, out, repo = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(src).read()
+i = s.index("record_union_scalars() {")
+j = s.index("\n}\n", i) + 3
+open(out, "w").write(
+    f'SCRIPT_DIR="{repo}/scripts"\nREPO_DIR="{repo}"\n'
+    f'. "{repo}/scripts/python-binary.sh"\n\n' + s[i:j])
+PYX
+rc=0
+( . "$REC_FN"; record_union_scalars "$CASE_A/state/slack-allowed-recipients.json" "state/x.json" "$INVALID" ) || rc=$?
+check "recorder REFUSES an invalid existing manifest (rc != 0)" [ "$rc" -ne 0 ]
+check "...and did not replace it with {}" bash -c "grep -q 'not json{' '$INVALID'"
+
 echo ""
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/sutando-migrate-fail-closed.test.sh
+++ b/tests/sutando-migrate-fail-closed.test.sh
@@ -12,10 +12,8 @@ MIGRATE="$REPO/scripts/sutando-migrate.sh"
 TMP="$(mktemp -d -t sutando-mig-failclosed.XXXXXX)"
 trap 'chmod -R u+w "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
-# Portable octal file mode. `stat -f %Lp` is the BSD/macOS spelling; on GNU
-# coreutils `-f` is --file-system, which EXITS 0 printing filesystem info — so
-# a `stat -f ... || stat -c ...` chain never reaches its fallback on Linux and
-# compares the wrong command's output. Ask python; it means the same on both.
+# Portable octal mode: GNU `stat -f` is --file-system and EXITS 0, so a
+# `stat -f ... || stat -c ...` chain never reaches its fallback on Linux.
 _mode() {
     python3 -c 'import os,stat,sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$1"
 }
@@ -290,6 +288,26 @@ check "a pristine private union passes verify" [ "$rc" -eq 0 ]
 chmod 644 "$MODE_DST"
 rc=0; RUN --verify > "$TMP/modes-verify-widened.log" 2>&1 || rc=$?
 check "a WIDENED union fails verify though its content is untouched" [ "$rc" -ne 0 ]
+
+# 9. Equal mtimes, different scalars. With a manifest the winner is RECORDED, so
+# re-deriving one from mtime is what rejected a valid destination winner.
+new_case equal_mtime
+mkdir -p "$CASE_A/state"
+printf '{"users": ["alice"], "schemaVersion": 1}\n' > "$CASE_A/state/slack-allowed-recipients.json"
+printf '{"users": ["bob"], "schemaVersion": 2}\n' > "$CASE_DEST/state/slack-allowed-recipients.json"
+# The tie is the whole point: same stamp on both sides, to the second.
+touch -t 202601010000 "$CASE_A/state/slack-allowed-recipients.json" \
+    "$CASE_DEST/state/slack-allowed-recipients.json"
+EQ_SRC_MT="$(python3 -c 'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$CASE_A/state/slack-allowed-recipients.json")"
+EQ_DST_MT="$(python3 -c 'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$CASE_DEST/state/slack-allowed-recipients.json")"
+check "the fixture actually ties the mtimes" [ "$EQ_SRC_MT" = "$EQ_DST_MT" ]
+rc=0; RUN --commit > "$TMP/eqmt-commit.log" 2>&1 || rc=$?
+check "an equal-mtime union commits" [ "$rc" -eq 0 ]
+check "both sides' array entries survive the union" \
+    bash -c "grep -q alice '$CASE_DEST/state/slack-allowed-recipients.json' && grep -q bob '$CASE_DEST/state/slack-allowed-recipients.json'"
+rc=0; RUN --verify > "$TMP/eqmt-verify.log" 2>&1 || rc=$?
+[ "$rc" -eq 0 ] || { echo "--- eqmt verify log (rc=$rc) ---"; cat "$TMP/eqmt-verify.log"; echo "---"; }
+check "an equal-mtime union passes verify" [ "$rc" -eq 0 ]
 chmod 600 "$MODE_DST"
 
 echo ""

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -31,6 +31,18 @@ check "same bytes + different mode is NOT identical (exec bit must survive)" \
   "$(identity_match "$tmp/a.sh" "$tmp/b.sh" && echo yes || echo no)" "no"
 check "different bytes never identical whatever the mode" \
   "$(printf 'other\n' > "$tmp/d.sh"; chmod 0755 "$tmp/d.sh"; identity_match "$tmp/a.sh" "$tmp/d.sh" && echo yes || echo no)" "no"
+# reviewer control (exact-head finding at beeec419): a failing mode probe
+# must FAIL the identity, never blank-compare into a false duplicate.
+mode_of() { return 1; }
+check "both mode probes failing -> NOT identical (fail closed)" \
+  "$(identity_match "$tmp/a.sh" "$tmp/c.sh" && echo yes || echo no)" "no"
+mode_of() { echo ""; }
+check "empty mode output -> NOT identical (fail closed)" \
+  "$(identity_match "$tmp/a.sh" "$tmp/c.sh" && echo yes || echo no)" "no"
+# restore the real helper for anything below
+# shellcheck disable=SC1090
+. "$helpers"
+
 # every commit/delete/verify decision site uses identity_match, none bare sha_match
 bare="$(grep -cE 'if (\[ -f "\$(cand|g)" \] && )?sha_match ' scripts/sutando-migrate.sh)"
 check "no decision site bypasses the mode check (bare sha_match ifs)" "$bare" "0"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -198,8 +198,10 @@ _stubdir="$(mktemp -d -t migrate-stub.XXXXXX)"
 
 _mk_stub() {  # $1 = gnu|bsd|none
   case "$1" in
-    gnu)  printf '%s\n' '#!/bin/bash' 'if [ "$1" = "-c" ]; then exec /usr/bin/stat -f "%Sm" -t "%Y-%m-%d 00:00:00" "${@:3}"; fi' 'if [ "$1" = "-f" ]; then echo "  File: fs-info"; exit 1; fi' 'exec /usr/bin/stat "$@"' > "$_stubdir/stat" ;;
-    bsd)  printf '%s\n' '#!/bin/bash' 'if [ "$1" = "-c" ]; then echo "stat: illegal option -- c" >&2; exit 1; fi' 'exec /usr/bin/stat "$@"' > "$_stubdir/stat" ;;
+    # HERMETIC: emit fixed output rather than delegating to the host's stat.
+    # Shelling out to /usr/bin/stat made these probes pass on BSD and fail on GNU.
+    gnu)  printf '%s\n' '#!/bin/bash' 'if [ "$1" = "-c" ]; then echo "2026-01-01 00:00:00.000000000 +0000"; exit 0; fi' 'if [ "$1" = "-f" ]; then echo "  File: fs-info"; exit 1; fi' 'exit 1' > "$_stubdir/stat" ;;
+    bsd)  printf '%s\n' '#!/bin/bash' 'if [ "$1" = "-c" ]; then echo "stat: illegal option -- c" >&2; exit 1; fi' 'if [ "$1" = "-f" ]; then echo "2026-01-01"; exit 0; fi' 'exit 1' > "$_stubdir/stat" ;;
     none) printf '%s\n' '#!/bin/bash' 'exit 1' > "$_stubdir/stat" ;;
   esac
   chmod +x "$_stubdir/stat"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -98,5 +98,39 @@ check "51-collision: genuine_conflicts counts only the proven one" "$A_genuine" 
 check "unreadable-only: genuine_conflicts is 0" "$B_genuine" "0"
 check "unreadable-only: surfaced as identity_unverified" "$B_unverified" "1"
 
+
+# --- control 4: the PRODUCTION scan -> commit -> verify path, not helpers ---
+# The union writer creates a fresh temp and `mv`s it over the destination, so
+# without an explicit policy the process umask decides the result and a private
+# 0600 allowlist silently becomes 0644 while scan and verify both report clean.
+# Every check below drives the real CLI; helper-level coverage cannot see this.
+e2e="$(mktemp -d -t migrate-mode-e2e.XXXXXX)"
+trap 'rm -rf "$tmp" "$e2e"' EXIT
+SRC="$e2e/A"; DEST="$e2e/dest"
+mkdir -p "$SRC/state" "$DEST/state"
+REL="state/slack-allowed-recipients.json"   # the shipped union-json-array rule
+printf '{"allow": ["a@example.org"]}\n' > "$SRC/$REL";  chmod 0644 "$SRC/$REL"
+printf '{"allow": ["b@example.org"]}\n' > "$DEST/$REL"; chmod 0600 "$DEST/$REL"
+
+RUN_E2E() { SUTANDO_MIGRATE_SRC_A="$SRC" SUTANDO_MIGRATE_DEST="$DEST" \
+            bash scripts/sutando-migrate.sh "$@" 2>&1; }
+
+_scan="$(RUN_E2E scan --source A)"
+check "the union collision is SURFACED by scan, not silently absent" \
+  "$(printf '%s' "$_scan" | grep -c 'slack-allowed-recipients' | tr -d ' ')" "1"
+
+RUN_E2E commit --source A >/dev/null 2>&1
+_mode="$(stat -f '%Lp' "$DEST/$REL" 2>/dev/null || stat -c '%a' "$DEST/$REL")"
+check "a 0644 source must NOT widen a 0600 destination through the union" "$_mode" "600"
+check "and the union still merged both allow-lists" \
+  "$(grep -c 'a@example.org' "$DEST/$REL" | tr -d ' ')" "1"
+check "the pre-existing entry survives the union" \
+  "$(grep -c 'b@example.org' "$DEST/$REL" | tr -d ' ')" "1"
+
+# Positive control: the check above must be capable of FAILING. A destination
+# the union never touched would also read 0600, so prove the path ran.
+check "the destination was actually rewritten (control: not an untouched file)" \
+  "$(grep -c 'a@example.org' "$DEST/$REL" | tr -d ' ')" "1"
+
 if [ "$fails" -gt 0 ]; then echo "$fails FAILURE(S)"; exit 1; fi
 echo "ALL PASS"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -14,7 +14,7 @@ printf '#!/bin/sh\necho hi\n' > "$tmp/a.sh"; chmod 0755 "$tmp/a.sh"
 printf '#!/bin/sh\necho hi\n' > "$tmp/b.sh"; chmod 0644 "$tmp/b.sh"
 printf '#!/bin/sh\necho hi\n' > "$tmp/c.sh"; chmod 0755 "$tmp/c.sh"
 helpers="$tmp/helpers.sh"
-sed -n '/^_stat() {/,/^}/p; /^mode_of() {/,/^}/p; /^identity_match() {/,/^}/p; /^sha_match() {/,/^}/p' scripts/sutando-migrate.sh > "$helpers"
+sed -n '/^_stat() {/,/^}/p; /^mode_of() {/,/^}/p; /^mtime_date() {/,/^}/p; /^identity_match() {/,/^}/p; /^sha_match() {/,/^}/p' scripts/sutando-migrate.sh > "$helpers"
 # shellcheck disable=SC1090
 . "$helpers"
 # A failed extraction must fail loudly HERE: command-not-found inside a
@@ -187,6 +187,51 @@ _first="$(SUTANDO_MIGRATE_SRC_A="$w6/A" SUTANDO_MIGRATE_DEST="$w6/dest" \
 check "a mode-only difference still outranks a drop-safe row (stays ACTIONABLE)" \
       "$_first" "notes/zzz-mode-only.md"
 rm -rf "$j5"
+
+# --- control 6: the sentinel date probe must SURVIVE either stat dialect ---
+# The scan prints partial-migration sentinels. A bare `sm="$(stat -c ...)"` under
+# `set -euo pipefail` exits the script before its fallback, so on BSD the mere
+# PRESENCE of a sentinel aborted the mandatory preview.
+type mtime_date >/dev/null 2>&1 || { echo "FAIL  mtime_date not extracted — the probes below would pass vacuously"; exit 1; }
+_md="$(mktemp -d -t migrate-mtime.XXXXXX)"; printf 'x\n' > "$_md/f"
+_stubdir="$(mktemp -d -t migrate-stub.XXXXXX)"
+
+_mk_stub() {  # $1 = gnu|bsd|none
+  case "$1" in
+    gnu)  printf '%s\n' '#!/bin/bash' 'if [ "$1" = "-c" ]; then exec /usr/bin/stat -f "%Sm" -t "%Y-%m-%d 00:00:00" "${@:3}"; fi' 'if [ "$1" = "-f" ]; then echo "  File: fs-info"; exit 1; fi' 'exec /usr/bin/stat "$@"' > "$_stubdir/stat" ;;
+    bsd)  printf '%s\n' '#!/bin/bash' 'if [ "$1" = "-c" ]; then echo "stat: illegal option -- c" >&2; exit 1; fi' 'exec /usr/bin/stat "$@"' > "$_stubdir/stat" ;;
+    none) printf '%s\n' '#!/bin/bash' 'exit 1' > "$_stubdir/stat" ;;
+  esac
+  chmod +x "$_stubdir/stat"
+}
+_probe() {  # $1 = semantics -> prints "<rc>:<value>"
+  _mk_stub "$1"
+  PATH="$_stubdir:$PATH" bash -c 'set -euo pipefail
+'"$(sed -n '/^mtime_date() {/,/^}/p' scripts/sutando-migrate.sh)"'
+v="$(mtime_date "$1")"; printf "%s:%s" "$?" "$v"' _ "$_md/f" 2>/dev/null || printf 'DIED:'
+}
+_g="$(_probe gnu)";  check "sentinel date resolves under GNU stat"        "${_g%%:*}" "0"
+check "  ...and is non-empty under GNU"                                   "$([ -n "${_g#*:}" ] && echo yes || echo no)" "yes"
+_b="$(_probe bsd)";  check "sentinel date resolves under BSD stat"        "${_b%%:*}" "0"
+check "  ...and is non-empty under BSD"                                   "$([ -n "${_b#*:}" ] && echo yes || echo no)" "yes"
+_n="$(_probe none)"; check "neither dialect works -> caller SURVIVES"     "${_n%%:*}" "0"
+check "  ...with an empty value (control: the probe CAN come back empty)" "$([ -z "${_n#*:}" ] && echo yes || echo no)" "yes"
+rm -rf "$_md" "$_stubdir"
+
+# --- control 6b: the REAL scan path, sentinel present, on this host's own stat ---
+# This is the control that DISCRIMINATES. The dialect probes above cannot: the
+# pre-fix code was INLINE, and `set -e` aborts an inline failing assignment but
+# not the same assignment inside a function reached via $(fn) — so a function-
+# shaped probe survives either way. Only the end-to-end scan sees the abort.
+_e2e="$(mktemp -d -t migrate-e2e.XXXXXX)"; mkdir -p "$_e2e/notes"; printf 'x\n' > "$_e2e/notes/a.md"
+_rc_before=0; env SUTANDO_WORKSPACE="$_e2e" bash scripts/sutando-migrate.sh --source C >/dev/null 2>&1 || _rc_before=$?
+check "baseline: scan of a sentinel-free source succeeds" "$_rc_before" "0"
+: > "$_e2e/.legacy-migrated-test"
+_out="$(env SUTANDO_WORKSPACE="$_e2e" bash scripts/sutando-migrate.sh --source C 2>&1)" && _rc_after=0 || _rc_after=$?
+check "a partial-migration sentinel does NOT abort the scan" "$_rc_after" "0"
+check "  ...and the sentinel is actually reported" \
+      "$(printf '%s\n' "$_out" | grep -c 'prior partial migration sentinels')" "1"
+rm -rf "$_e2e"
 
 if [ "$fails" -gt 0 ]; then echo "$fails FAILURE(S)"; exit 1; fi
 echo "ALL PASS"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -120,7 +120,8 @@ check "the union collision is SURFACED by scan, not silently absent" \
   "$(printf '%s' "$_scan" | grep -c 'slack-allowed-recipients' | tr -d ' ')" "1"
 
 RUN_E2E commit --source A >/dev/null 2>&1
-_mode="$(stat -f '%Lp' "$DEST/$REL" 2>/dev/null || stat -c '%a' "$DEST/$REL")"
+# GNU first — see mode_of()'s note: BSD-first emits filesystem info AND the mode.
+_mode="$(stat -c '%a' "$DEST/$REL" 2>/dev/null || stat -f '%Lp' "$DEST/$REL" 2>/dev/null)"
 check "a 0644 source must NOT widen a 0600 destination through the union" "$_mode" "600"
 check "and the union still merged both allow-lists" \
   "$(grep -c 'a@example.org' "$DEST/$REL" | tr -d ' ')" "1"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -224,15 +224,15 @@ check "structural: the newest source survives an identical drop" \
 
 # --- control 4f: a failed mtime promotion is write-failed, not a silent drop ---
 
-# Shadow only `touch -r`; every other touch must still work or the fixture
-# itself cannot be built.
+# The promotion materializes through the contained copy (cp -p + mv), never
+# `touch -r` on the existing inode. Shadow only `cp -p`; plain cp still works.
 _tf="$(mktemp -d)"; mkdir -p "$_tf/bin"
-cat > "$_tf/bin/touch" <<'STUB'
+cat > "$_tf/bin/cp" <<'STUB'
 #!/bin/sh
-[ "$1" = "-r" ] && exit 1
-exec /usr/bin/touch "$@"
+[ "$1" = "-p" ] && exit 1
+exec /bin/cp "$@"
 STUB
-chmod +x "$_tf/bin/touch"
+chmod +x "$_tf/bin/cp"
 mkdir -p "$_tf/A/scripts" "$_tf/dest/scripts"
 printf 'version=3\n' > "$_tf/dest/$SREL"; touch -t 202608281100 "$_tf/dest/$SREL"
 printf 'version=3\n' > "$_tf/A/$SREL";    touch -t 202608281300 "$_tf/A/$SREL"
@@ -367,6 +367,69 @@ _dm_probe() {  # $1=src hosts mode  $2=pre-existing dest mode ("" = none) -> "ho
 check "a 0700 source dir does NOT land world-readable"        "$(_dm_probe 0700 '')"     "700:700:644"
 check "non-widening: a 0755 source never opens a 0700 dest"   "$(_dm_probe 0755 0700)"   "700:700:644"
 check "control: an ordinary 0755 source stays 0755"           "$(_dm_probe 0755 '')"     "755:755:644"
+
+# --- control 8: a destination leaf that is a SYMLINK is refused before it is read ---
+
+# `touch -r` on the leaf followed the link and stamped a file outside DEST_REAL while
+# commit certified success; the leaf must be refused with no sentinel and the target untouched.
+_mt() { stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1"; }
+_nl() { stat -c '%h' "$1" 2>/dev/null || stat -f '%l' "$1"; }
+_sl="$(mktemp -d)"; mkdir -p "$_sl/A/scripts" "$_sl/dest/scripts" "$_sl/dest/state" "$_sl/outside"
+printf 'version=3\n' > "$_sl/outside/target"; chmod 0755 "$_sl/outside/target"; touch -t 202608281100 "$_sl/outside/target"
+ln -s "$_sl/outside/target" "$_sl/dest/$SREL"
+printf 'version=3\n' > "$_sl/A/$SREL"; chmod 0755 "$_sl/A/$SREL"; touch -t 202608281300 "$_sl/A/$SREL"
+_sl_before="$(_mt "$_sl/outside/target")"
+_sl_rc=0; SUTANDO_MIGRATE_SRC_A="$_sl/A" SUTANDO_MIGRATE_DEST="$_sl/dest" \
+  bash scripts/sutando-migrate.sh commit --source A >/dev/null 2>&1 || _sl_rc=$?
+check "symlink leaf: commit FAILS" "$([ "$_sl_rc" -ne 0 ] && echo failed || echo certified)" "failed"
+check "symlink leaf: no sentinel is written" \
+  "$(ls "$_sl/dest/state"/.migrated-from-A-* 2>/dev/null | wc -l | tr -d ' ')" "0"
+check "symlink leaf: the external target's mtime is untouched" "$(_mt "$_sl/outside/target")" "$_sl_before"
+check "symlink leaf: the leaf is still the symlink (not replaced, not read into)" \
+  "$([ -L "$_sl/dest/$SREL" ] && echo link || echo file)" "link"
+rm -rf "$_sl"
+
+# --- control 9: a HARDLINK leaf gets its own contained inode; the alias is untouched ---
+
+_hl="$(mktemp -d)"; mkdir -p "$_hl/A/scripts" "$_hl/dest/scripts" "$_hl/dest/state" "$_hl/outside"
+printf 'version=3\n' > "$_hl/outside/target"; chmod 0755 "$_hl/outside/target"; touch -t 202608281100 "$_hl/outside/target"
+ln "$_hl/outside/target" "$_hl/dest/$SREL"
+printf 'version=3\n' > "$_hl/A/$SREL"; chmod 0755 "$_hl/A/$SREL"; touch -t 202608281300 "$_hl/A/$SREL"
+_hl_before="$(_mt "$_hl/outside/target")"
+_hl_rc=0; SUTANDO_MIGRATE_SRC_A="$_hl/A" SUTANDO_MIGRATE_DEST="$_hl/dest" \
+  bash scripts/sutando-migrate.sh commit --source A >/dev/null 2>&1 || _hl_rc=$?
+check "hardlink leaf: commit succeeds" "$_hl_rc" "0"
+check "hardlink leaf: the external inode's mtime is untouched" "$(_mt "$_hl/outside/target")" "$_hl_before"
+check "hardlink leaf: a contained regular inode landed (link count 1)" "$(_nl "$_hl/dest/$SREL")" "1"
+check "hardlink leaf: the contained copy carries the newer source mtime" \
+  "$(_mt "$_hl/dest/$SREL")" "$(_mt "$_hl/A/$SREL")"
+_hl_v=0; SUTANDO_MIGRATE_SRC_A="$_hl/A" SUTANDO_MIGRATE_DEST="$_hl/dest" \
+  bash scripts/sutando-migrate.sh verify --source A >/dev/null 2>&1 || _hl_v=$?
+check "hardlink leaf: verify passes on the contained copy" "$_hl_v" "0"
+rm -rf "$_hl"
+
+# --- control 10: a union write takes the shared directory-mode policy; verify sees the parent ---
+
+# 0700 source parent, 0755 destination parent, 0644 divergent union: before,
+# the union path wrote directly and the parent stayed 0755 while verify passed.
+_up="$(mktemp -d)"; mkdir -p "$_up/A/state" "$_up/dest/state"
+printf '{"allow": ["a@example.org"]}\n' > "$_up/A/$REL";    chmod 0644 "$_up/A/$REL"
+printf '{"allow": ["b@example.org"]}\n' > "$_up/dest/$REL"; chmod 0644 "$_up/dest/$REL"
+chmod 0700 "$_up/A/state"; chmod 0755 "$_up/dest/state"
+_up_rc=0; SUTANDO_MIGRATE_SRC_A="$_up/A" SUTANDO_MIGRATE_DEST="$_up/dest" \
+  bash scripts/sutando-migrate.sh commit --source A >/dev/null 2>&1 || _up_rc=$?
+check "union under a 0700 source parent: commit succeeds" "$_up_rc" "0"
+check "union parent takes the non-widening intersection (0755 -> 0700)" "$(mode_of "$_up/dest/state")" "700"
+check "the union still merged (control: the path ran)" "$(grep -c 'a@example.org' "$_up/dest/$REL" | tr -d ' ')" "1"
+_up_v=0; SUTANDO_MIGRATE_SRC_A="$_up/A" SUTANDO_MIGRATE_DEST="$_up/dest" \
+  bash scripts/sutando-migrate.sh verify --source A >/dev/null 2>&1 || _up_v=$?
+check "verify passes with the narrowed parent" "$_up_v" "0"
+chmod 0755 "$_up/dest/state"
+_up_w=0; SUTANDO_MIGRATE_SRC_A="$_up/A" SUTANDO_MIGRATE_DEST="$_up/dest" \
+  bash scripts/sutando-migrate.sh verify --source A >/dev/null 2>&1 || _up_w=$?
+check "verify FAILS once the destination parent is widened past the source's" \
+  "$([ "$_up_w" -ne 0 ] && echo failed || echo certified)" "failed"
+rm -rf "$_up"
 
 if [ "$fails" -gt 0 ]; then echo "$fails FAILURE(S)"; exit 1; fi
 echo "ALL PASS"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -133,8 +133,9 @@ check "the destination was actually rewritten (control: not an untouched file)" 
 
 
 # --- control 4b: VERIFY owns the manifest mode for a union entry ---
-# The bypass needs the union output to be BYTE-EQUAL to the source, so the
-# source must already carry the merged set in the writer's own serialization.
+
+# Byte-equal union output is the bypass precondition, so the source must
+# already carry the merged set in the writer's own serialization.
 _u="$e2e/u"; mkdir -p "$_u/s1/state" "$_u/d1/state"
 printf '{"allow": ["a@example.org", "b@example.org"]}\n' > "$_u/s1/$REL"
 printf '{"allow": ["b@example.org"]}\n'                  > "$_u/d1/$REL"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -233,5 +233,23 @@ check "  ...and the sentinel is actually reported" \
       "$(printf '%s\n' "$_out" | grep -c 'prior partial migration sentinels')" "1"
 rm -rf "$_e2e"
 
+# --- control 7: newly migrated directories keep their SOURCE mode ---
+# `cp -p` carries a file's mode; parents from `mkdir -p` take umask, so a 0700
+# source dir landed 0755 and exposed protected personal/relay notes to other
+# local accounts. Drives the real commit path end to end.
+_dm_probe() {  # $1=src hosts mode  $2=pre-existing dest mode ("" = none) -> "hosts:Test-Host:file"
+  local S D; S="$(mktemp -d)"; D="$(mktemp -d)"
+  mkdir -p "$S/hosts/Test-Host"; printf 'x\n' > "$S/hosts/Test-Host/PERSONAL_CLAUDE.md"
+  chmod 0644 "$S/hosts/Test-Host/PERSONAL_CLAUDE.md"
+  chmod "$1" "$S/hosts" "$S/hosts/Test-Host"
+  if [ -n "$2" ]; then mkdir -p "$D/hosts/Test-Host"; chmod "$2" "$D/hosts" "$D/hosts/Test-Host"; fi
+  env SUTANDO_WORKSPACE="$S" SUTANDO_MIGRATE_DEST="$D" bash scripts/sutando-migrate.sh commit --source C >/dev/null 2>&1
+  printf '%s:%s:%s' "$(mode_of "$D/hosts")" "$(mode_of "$D/hosts/Test-Host")" "$(mode_of "$D/hosts/Test-Host/PERSONAL_CLAUDE.md")"
+  rm -rf "$S" "$D"
+}
+check "a 0700 source dir does NOT land world-readable"        "$(_dm_probe 0700 '')"     "700:700:644"
+check "non-widening: a 0755 source never opens a 0700 dest"   "$(_dm_probe 0755 0700)"   "700:700:644"
+check "control: an ordinary 0755 source stays 0755"           "$(_dm_probe 0755 '')"     "755:755:644"
+
 if [ "$fails" -gt 0 ]; then echo "$fails FAILURE(S)"; exit 1; fi
 echo "ALL PASS"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -101,10 +101,7 @@ check "unreadable-only: surfaced as identity_unverified" "$B_unverified" "1"
 
 
 # --- control 4: the PRODUCTION scan -> commit -> verify path, not helpers ---
-# The union writer creates a fresh temp and `mv`s it over the destination, so
-# without an explicit policy the process umask decides the result and a private
-# 0600 allowlist silently becomes 0644 while scan and verify both report clean.
-# Every check below drives the real CLI; helper-level coverage cannot see this.
+# Umask would decide the fresh temp's mode: 0600 allowlist -> 0644, scan clean.
 e2e="$(mktemp -d -t migrate-mode-e2e.XXXXXX)"
 trap 'rm -rf "$tmp" "$e2e"' EXIT
 SRC="$e2e/A"; DEST="$e2e/dest"
@@ -136,16 +133,12 @@ check "the destination was actually rewritten (control: not an untouched file)" 
 
 
 # --- control 5: byte_identical is a claim about BYTES, through the real JSON ---
-# Reviewer input: equal bytes, equal mtime, modes 0755 vs 0644 previously reported
-# byte_identical=False and proxy_identical_divergent=1 — no byte differed. Bytes
-# and mode are now two fields; every DECISION still uses both, so drop-safety is
-# unchanged and only the reporting was split.
+# Equal bytes, modes 0755 vs 0644 -> True; every DECISION still uses both fields.
 j5="$(mktemp -d -t migrate-json5.XXXXXX)"
 _scan_case() {  # $1=bytes_differ(0|1) $2=srcmode $3=dstmode -> prints compact json
     local w="$j5/$RANDOM$RANDOM"; mkdir -p "$w/A/notes" "$w/dest/notes"
-    # SAME LENGTH as the destination on purpose: proxy_identical_divergent means
-    # equal size + equal mtime + PROVEN different bytes, so a shorter variant
-    # would be a size_mismatch instead and never exercise that counter.
+    # SAME LENGTH on purpose: proxy_identical_divergent needs equal size + mtime
+    # + different bytes; a shorter variant is a size_mismatch and never reaches it.
     if [ "$1" = "1" ]; then printf 'IDENTICAL BYTES\n' > "$w/A/notes/same.md"
     else printf 'identical bytes\n' > "$w/A/notes/same.md"; fi
     printf 'identical bytes\n' > "$w/dest/notes/same.md"
@@ -168,11 +161,8 @@ check "control: real byte divergence still counts as proven divergence" "$(echo 
 # Control: the only drop-safe shape still reads drop-safe.
 _i="$(_scan_case 0 0644 0644)"
 check "control: equal bytes AND equal modes remain drop-safe" "$(echo "$_i" | cut -d'|' -f4)" "1"
-# A mode-only difference must remain ACTIONABLE, not merely reported. Presence in
-# notable_collisions cannot show that — the cap admits ignorable rows too — but
-# ORDER can: actionable rows sort to the front. The names are chosen so that
-# alphabetical order is the OPPOSITE of the expected order, otherwise this check
-# would pass on the tie-break alone and prove nothing.
+# Presence in notable_collisions cannot show ACTIONABLE (the cap admits ignorable
+# rows); order can. Names make alphabetical the OPPOSITE, so no tie-break pass.
 w6="$j5/ordering"; mkdir -p "$w6/A/notes" "$w6/dest/notes"
 printf 'identical bytes\n' > "$w6/A/notes/aaa-drop-safe.md"
 printf 'identical bytes\n' > "$w6/dest/notes/aaa-drop-safe.md"
@@ -189,9 +179,7 @@ check "a mode-only difference still outranks a drop-safe row (stays ACTIONABLE)"
 rm -rf "$j5"
 
 # --- control 6: the sentinel date probe must SURVIVE either stat dialect ---
-# The scan prints partial-migration sentinels. A bare `sm="$(stat -c ...)"` under
-# `set -euo pipefail` exits the script before its fallback, so on BSD the mere
-# PRESENCE of a sentinel aborted the mandatory preview.
+# Under `set -e` a bare inline `stat -c` exits before reaching its fallback.
 type mtime_date >/dev/null 2>&1 || { echo "FAIL  mtime_date not extracted — the probes below would pass vacuously"; exit 1; }
 _md="$(mktemp -d -t migrate-mtime.XXXXXX)"; printf 'x\n' > "$_md/f"
 _stubdir="$(mktemp -d -t migrate-stub.XXXXXX)"
@@ -220,11 +208,8 @@ _n="$(_probe none)"; check "neither dialect works -> caller SURVIVES"     "${_n%
 check "  ...with an empty value (control: the probe CAN come back empty)" "$([ -z "${_n#*:}" ] && echo yes || echo no)" "yes"
 rm -rf "$_md" "$_stubdir"
 
-# --- control 6b: the REAL scan path, sentinel present, on this host's own stat ---
-# This is the control that DISCRIMINATES. The dialect probes above cannot: the
-# pre-fix code was INLINE, and `set -e` aborts an inline failing assignment but
-# not the same assignment inside a function reached via $(fn) — so a function-
-# shaped probe survives either way. Only the end-to-end scan sees the abort.
+# --- control 6b: the REAL scan path, sentinel present — the DISCRIMINATING control ---
+# `set -e` aborts an inline assignment but not one inside $(fn), so the probes above cannot.
 _e2e="$(mktemp -d -t migrate-e2e.XXXXXX)"; mkdir -p "$_e2e/notes"; printf 'x\n' > "$_e2e/notes/a.md"
 _rc_before=0; env SUTANDO_WORKSPACE="$_e2e" bash scripts/sutando-migrate.sh --source C >/dev/null 2>&1 || _rc_before=$?
 check "baseline: scan of a sentinel-free source succeeds" "$_rc_before" "0"
@@ -236,9 +221,7 @@ check "  ...and the sentinel is actually reported" \
 rm -rf "$_e2e"
 
 # --- control 7: newly migrated directories keep their SOURCE mode ---
-# `cp -p` carries a file's mode; parents from `mkdir -p` take umask, so a 0700
-# source dir landed 0755 and exposed protected personal/relay notes to other
-# local accounts. Drives the real commit path end to end.
+# `cp -p` carries a file's mode; `mkdir -p` parents take umask: 0700 -> 0755.
 _dm_probe() {  # $1=src hosts mode  $2=pre-existing dest mode ("" = none) -> "hosts:Test-Host:file"
   local S D; S="$(mktemp -d)"; D="$(mktemp -d)"
   mkdir -p "$S/hosts/Test-Host"; printf 'x\n' > "$S/hosts/Test-Host/PERSONAL_CLAUDE.md"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -132,5 +132,59 @@ check "the pre-existing entry survives the union" \
 check "the destination was actually rewritten (control: not an untouched file)" \
   "$(grep -c 'a@example.org' "$DEST/$REL" | tr -d ' ')" "1"
 
+
+# --- control 5: byte_identical is a claim about BYTES, through the real JSON ---
+# Reviewer input: equal bytes, equal mtime, modes 0755 vs 0644 previously reported
+# byte_identical=False and proxy_identical_divergent=1 — no byte differed. Bytes
+# and mode are now two fields; every DECISION still uses both, so drop-safety is
+# unchanged and only the reporting was split.
+j5="$(mktemp -d -t migrate-json5.XXXXXX)"
+_scan_case() {  # $1=bytes_differ(0|1) $2=srcmode $3=dstmode -> prints compact json
+    local w="$j5/$RANDOM$RANDOM"; mkdir -p "$w/A/notes" "$w/dest/notes"
+    # SAME LENGTH as the destination on purpose: proxy_identical_divergent means
+    # equal size + equal mtime + PROVEN different bytes, so a shorter variant
+    # would be a size_mismatch instead and never exercise that counter.
+    if [ "$1" = "1" ]; then printf 'IDENTICAL BYTES\n' > "$w/A/notes/same.md"
+    else printf 'identical bytes\n' > "$w/A/notes/same.md"; fi
+    printf 'identical bytes\n' > "$w/dest/notes/same.md"
+    chmod "$2" "$w/A/notes/same.md"; chmod "$3" "$w/dest/notes/same.md"
+    touch -t 202606010000 "$w/A/notes/same.md" "$w/dest/notes/same.md"
+    SUTANDO_MIGRATE_SRC_A="$w/A" SUTANDO_MIGRATE_DEST="$w/dest" \
+        bash scripts/sutando-migrate.sh scan --json --source A 2>/dev/null \
+        | python3 -c 'import sys,json;d=sys.stdin.read();j=json.loads(d[d.index("{"):]);r={x["rel"]:x for x in j["notable_collisions"]}.get("notes/same.md",{});print("%s|%s|%s|%s"%(r.get("byte_identical"),r.get("mode_conflict"),j["totals"]["proxy_identical_divergent"],j["totals"]["identical_content"]))'
+}
+_m="$(_scan_case 0 0755 0644)"
+check "mode-only difference: byte_identical is True (no byte differs)" "$(echo "$_m" | cut -d'|' -f1)" "True"
+check "mode-only difference: mode_conflict is True" "$(echo "$_m" | cut -d'|' -f2)" "True"
+check "mode-only difference is NOT proven byte divergence" "$(echo "$_m" | cut -d'|' -f3)" "0"
+check "mode-only difference is NOT drop-safe (identical_content stays 0)" "$(echo "$_m" | cut -d'|' -f4)" "0"
+# Control: real byte divergence must still report as such, or the split above
+# could be satisfied by a scan that simply stopped detecting divergence.
+_d="$(_scan_case 1 0644 0644)"
+check "control: real byte divergence still reports byte_identical False" "$(echo "$_d" | cut -d'|' -f1)" "False"
+check "control: real byte divergence still counts as proven divergence" "$(echo "$_d" | cut -d'|' -f3)" "1"
+# Control: the only drop-safe shape still reads drop-safe.
+_i="$(_scan_case 0 0644 0644)"
+check "control: equal bytes AND equal modes remain drop-safe" "$(echo "$_i" | cut -d'|' -f4)" "1"
+# A mode-only difference must remain ACTIONABLE, not merely reported. Presence in
+# notable_collisions cannot show that — the cap admits ignorable rows too — but
+# ORDER can: actionable rows sort to the front. The names are chosen so that
+# alphabetical order is the OPPOSITE of the expected order, otherwise this check
+# would pass on the tie-break alone and prove nothing.
+w6="$j5/ordering"; mkdir -p "$w6/A/notes" "$w6/dest/notes"
+printf 'identical bytes\n' > "$w6/A/notes/aaa-drop-safe.md"
+printf 'identical bytes\n' > "$w6/dest/notes/aaa-drop-safe.md"
+chmod 0644 "$w6/A/notes/aaa-drop-safe.md" "$w6/dest/notes/aaa-drop-safe.md"
+printf 'identical bytes\n' > "$w6/A/notes/zzz-mode-only.md"
+printf 'identical bytes\n' > "$w6/dest/notes/zzz-mode-only.md"
+chmod 0755 "$w6/A/notes/zzz-mode-only.md"; chmod 0644 "$w6/dest/notes/zzz-mode-only.md"
+touch -t 202606010000 "$w6/A/notes"/*.md "$w6/dest/notes"/*.md
+_first="$(SUTANDO_MIGRATE_SRC_A="$w6/A" SUTANDO_MIGRATE_DEST="$w6/dest" \
+    bash scripts/sutando-migrate.sh scan --json --source A 2>/dev/null \
+    | python3 -c 'import sys,json;d=sys.stdin.read();j=json.loads(d[d.index("{"):]);print(j["notable_collisions"][0]["rel"])')"
+check "a mode-only difference still outranks a drop-safe row (stays ACTIONABLE)" \
+      "$_first" "notes/zzz-mode-only.md"
+rm -rf "$j5"
+
 if [ "$fails" -gt 0 ]; then echo "$fails FAILURE(S)"; exit 1; fi
 echo "ALL PASS"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -206,6 +206,64 @@ check "a widened dest with NO mode table is refused"       "$(_md_probe table)" 
 check "a widened dest with an empty mode table is refused" "$(_md_probe rel)"   "refused"
 check "control: an intact manifest still certifies"        "$(_md_probe none)"  "certified"
 
+# --- control 4e: the STRUCTURAL branch obeys the same provenance rule ---
+
+# Same three-input chain as 4c but on a non-JSON path, which takes the
+# structural branch. Before the shared owner existed only union promoted.
+_s="$e2e/s"; SREL="scripts/tool.sh"
+mkdir -p "$_s/A/scripts" "$_s/B/scripts" "$_s/dest/scripts"
+printf 'version=3\n' > "$_s/dest/$SREL"; touch -t 202608281100 "$_s/dest/$SREL"
+printf 'version=3\n' > "$_s/A/$SREL";    touch -t 202608281300 "$_s/A/$SREL"
+printf 'version=2\n' > "$_s/B/$SREL";    touch -t 202608281200 "$_s/B/$SREL"
+_RUN_S(){ SUTANDO_MIGRATE_SRC_A="$_s/A" SUTANDO_MIGRATE_SRC_B="$_s/B" \
+          SUTANDO_MIGRATE_DEST="$_s/dest" bash scripts/sutando-migrate.sh "$@" >/dev/null 2>&1; }
+_RUN_S commit --source A
+_RUN_S commit --source B
+check "structural: the newest source survives an identical drop" \
+  "$(cat "$_s/dest/$SREL")" "version=3"
+
+# --- control 4f: a failed mtime promotion is write-failed, not a silent drop ---
+
+# Shadow only `touch -r`; every other touch must still work or the fixture
+# itself cannot be built.
+_tf="$(mktemp -d)"; mkdir -p "$_tf/bin"
+cat > "$_tf/bin/touch" <<'STUB'
+#!/bin/sh
+[ "$1" = "-r" ] && exit 1
+exec /usr/bin/touch "$@"
+STUB
+chmod +x "$_tf/bin/touch"
+mkdir -p "$_tf/A/scripts" "$_tf/dest/scripts"
+printf 'version=3\n' > "$_tf/dest/$SREL"; touch -t 202608281100 "$_tf/dest/$SREL"
+printf 'version=3\n' > "$_tf/A/$SREL";    touch -t 202608281300 "$_tf/A/$SREL"
+_tf_out="$(PATH="$_tf/bin:$PATH" SUTANDO_MIGRATE_SRC_A="$_tf/A" \
+           SUTANDO_MIGRATE_DEST="$_tf/dest" \
+           bash scripts/sutando-migrate.sh commit --source A 2>&1)"; _tf_rc=$?
+check "a failed identity-drop mtime promotion is reported, not swallowed" \
+  "$([ "$_tf_rc" -ne 0 ] && echo reported || echo swallowed)" "reported"
+rm -rf "$_tf"
+
+# --- control 4g: every union-class outcome leaves a verifiable expectation ---
+
+# Verify's mode check runs only where a manifest exists, so an outcome without
+# one is unprovable rather than proven-good.
+_uc_probe() {  # $1=fresh|drop -> certified|refused after a widen
+  local w; w="$(mktemp -d)"; mkdir -p "$w/A/state" "$w/dest/state"
+  printf '{"schemaVersion": 3, "allow": ["a"]}\n' > "$w/A/$REL"; chmod 0600 "$w/A/$REL"
+  if [ "$1" = "drop" ]; then
+    printf '{"schemaVersion": 3, "allow": ["a"]}\n' > "$w/dest/$REL"; chmod 0600 "$w/dest/$REL"
+  fi
+  SUTANDO_MIGRATE_SRC_A="$w/A" SUTANDO_MIGRATE_DEST="$w/dest" \
+    bash scripts/sutando-migrate.sh commit --source A >/dev/null 2>&1
+  chmod 0644 "$w/dest/$REL"
+  SUTANDO_MIGRATE_SRC_A="$w/A" SUTANDO_MIGRATE_DEST="$w/dest" \
+    bash scripts/sutando-migrate.sh verify --source A >/dev/null 2>&1
+  local rc=$?; rm -rf "$w"
+  [ "$rc" -eq 0 ] && echo certified || echo refused
+}
+check "a widened FRESH union copy is refused"    "$(_uc_probe fresh)" "refused"
+check "a widened identical-drop dest is refused" "$(_uc_probe drop)"  "refused"
+
 # --- control 5: byte_identical is a claim about BYTES, through the real JSON ---
 # Equal bytes, modes 0755 vs 0644 -> True; every DECISION still uses both fields.
 j5="$(mktemp -d -t migrate-json5.XXXXXX)"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -162,6 +162,50 @@ _v_widened=0; _RUN_U verify --source A || _v_widened=$?
 check "verify FAILS on a widened union dest, despite byte identity with the source" \
   "$([ "$_v_widened" -ne 0 ] && echo failed || echo certified)" "failed"
 
+# --- control 4c: an identical drop must carry the winner's mtime ---
+
+# The union preserves max(mtime); a drop that skips it lets a later OLDER
+# source outrank the newest input and win the scalars.
+_m="$e2e/m"; mkdir -p "$_m/A/state" "$_m/B/state" "$_m/dest/state"
+printf '{"schemaVersion": 3, "allow": ["pre"]}\n' > "$_m/dest/$REL"; touch -t 202608281100 "$_m/dest/$REL"
+printf '{"schemaVersion": 3, "allow": ["pre"]}\n' > "$_m/A/$REL";    touch -t 202608281300 "$_m/A/$REL"
+printf '{"schemaVersion": 2, "allow": ["b"]}\n'   > "$_m/B/$REL";    touch -t 202608281200 "$_m/B/$REL"
+_RUN_M(){ SUTANDO_MIGRATE_SRC_A="$_m/A" SUTANDO_MIGRATE_SRC_B="$_m/B" \
+          SUTANDO_MIGRATE_DEST="$_m/dest" bash scripts/sutando-migrate.sh "$@" >/dev/null 2>&1; }
+_RUN_M commit --source A
+_RUN_M commit --source B
+check "the newest source wins the scalar even when its content is an identical drop" \
+  "$(python3 -c "import json;print(json.load(open('$_m/dest/$REL'))['schemaVersion'])")" "3"
+check "and the union still accumulated both arrays" \
+  "$(grep -c 'b' "$_m/dest/$REL" | tr -d ' ')" "1"
+
+# --- control 4d: a missing mode table cannot certify an unknown mode ---
+
+# record_union_scalars writes the mode beside every rel, so an absent table or
+# rel is damage; the pristine case below proves the check can still pass.
+_md_probe() {
+  local drop="$1" md; md="$(mktemp -d)"
+  mkdir -p "$md/A/state" "$md/dest/state"
+  printf '{"schemaVersion": 3, "allow": ["a"]}\n' > "$md/A/$REL";    chmod 0600 "$md/A/$REL"
+  printf '{"schemaVersion": 3, "allow": ["b"]}\n' > "$md/dest/$REL"; chmod 0600 "$md/dest/$REL"
+  SUTANDO_MIGRATE_SRC_A="$md/A" SUTANDO_MIGRATE_DEST="$md/dest" \
+    bash scripts/sutando-migrate.sh commit --source A >/dev/null 2>&1
+  local man; man="$(ls -t "$md/dest/state/.migration-union-scalars-"*.json 2>/dev/null | head -1)"
+  if [ "$drop" = "table" ]; then
+    python3 -c "import json,sys;p=sys.argv[1];d=json.load(open(p));d.pop('__union_modes__',None);json.dump(d,open(p,'w'))" "$man"
+  elif [ "$drop" = "rel" ]; then
+    python3 -c "import json,sys;p=sys.argv[1];d=json.load(open(p));d.get('__union_modes__',{}).clear();json.dump(d,open(p,'w'))" "$man"
+  fi
+  [ "$drop" = "none" ] || chmod 0644 "$md/dest/$REL"
+  SUTANDO_MIGRATE_SRC_A="$md/A" SUTANDO_MIGRATE_DEST="$md/dest" \
+    bash scripts/sutando-migrate.sh verify --source A >/dev/null 2>&1
+  local rc=$?; rm -rf "$md"
+  [ "$rc" -eq 0 ] && echo certified || echo refused
+}
+check "a widened dest with NO mode table is refused"       "$(_md_probe table)" "refused"
+check "a widened dest with an empty mode table is refused" "$(_md_probe rel)"   "refused"
+check "control: an intact manifest still certifies"        "$(_md_probe none)"  "certified"
+
 # --- control 5: byte_identical is a claim about BYTES, through the real JSON ---
 # Equal bytes, modes 0755 vs 0644 -> True; every DECISION still uses both fields.
 j5="$(mktemp -d -t migrate-json5.XXXXXX)"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -14,12 +14,13 @@ printf '#!/bin/sh\necho hi\n' > "$tmp/a.sh"; chmod 0755 "$tmp/a.sh"
 printf '#!/bin/sh\necho hi\n' > "$tmp/b.sh"; chmod 0644 "$tmp/b.sh"
 printf '#!/bin/sh\necho hi\n' > "$tmp/c.sh"; chmod 0755 "$tmp/c.sh"
 helpers="$tmp/helpers.sh"
-sed -n '/^mode_of() {/,/^}/p; /^identity_match() {/,/^}/p; /^sha_match() {/,/^}/p' scripts/sutando-migrate.sh > "$helpers"
+sed -n '/^_stat() {/,/^}/p; /^mode_of() {/,/^}/p; /^identity_match() {/,/^}/p; /^sha_match() {/,/^}/p' scripts/sutando-migrate.sh > "$helpers"
 # shellcheck disable=SC1090
 . "$helpers"
 # A failed extraction must fail loudly HERE: command-not-found inside a
 # yes/no capture reads as a clean "no" and false-passes the no-expecting checks.
 type identity_match >/dev/null 2>&1 || { echo "FAIL  helper extraction produced no identity_match"; exit 1; }
+type _stat >/dev/null 2>&1 || { echo "FAIL  helper extraction produced no _stat (mode_of would return empty and every identity check would false-pass)"; exit 1; }
 check "same bytes + same mode IS identical" "$(identity_match "$tmp/a.sh" "$tmp/c.sh" && echo yes || echo no)" "yes"
 check "same bytes + different mode is NOT identical (exec bit must survive)" \
   "$(identity_match "$tmp/a.sh" "$tmp/b.sh" && echo yes || echo no)" "no"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
-# Identity = bytes AND mode, uniformly (kewei review on #3418, blockers 2+3).
-# Three controls the review asked for:
-#   1. same-bytes/different-mode commit path — the 0755 source must NOT be
-#      dropped against a 0644 dest (the exec bit used to vanish unrecoverably);
-#   2. 51-collision summary — 50 byte-identical mtime-differing entries must
-#      not push the one divergent entry past the render cap;
-#   3. unreadable-only — an unverified collision is NOT a genuine conflict.
+# Identity = bytes AND mode, uniformly: mode-only differences are divergence,
+# ignorable entries never outrank actionable ones, unverified is never genuine.
 set -u
 cd "$(dirname "$0")/.."
 fails=0
@@ -22,16 +17,15 @@ helpers="$tmp/helpers.sh"
 sed -n '/^mode_of() {/,/^}/p; /^identity_match() {/,/^}/p; /^sha_match() {/,/^}/p' scripts/sutando-migrate.sh > "$helpers"
 # shellcheck disable=SC1090
 . "$helpers"
-# A failed extraction must fail HERE, loudly — command-not-found inside a
-# $(... && echo yes || echo no) capture reads as a clean "no" and false-passes
-# exactly the checks that expect "no" (measured on this test's first run).
+# A failed extraction must fail loudly HERE: command-not-found inside a
+# yes/no capture reads as a clean "no" and false-passes the no-expecting checks.
 type identity_match >/dev/null 2>&1 || { echo "FAIL  helper extraction produced no identity_match"; exit 1; }
 check "same bytes + same mode IS identical" "$(identity_match "$tmp/a.sh" "$tmp/c.sh" && echo yes || echo no)" "yes"
 check "same bytes + different mode is NOT identical (exec bit must survive)" \
   "$(identity_match "$tmp/a.sh" "$tmp/b.sh" && echo yes || echo no)" "no"
 check "different bytes never identical whatever the mode" \
   "$(printf 'other\n' > "$tmp/d.sh"; chmod 0755 "$tmp/d.sh"; identity_match "$tmp/a.sh" "$tmp/d.sh" && echo yes || echo no)" "no"
-# reviewer control (exact-head finding at beeec419): a failing mode probe
+# a failing mode probe
 # must FAIL the identity, never blank-compare into a false duplicate.
 mode_of() { return 1; }
 check "both mode probes failing -> NOT identical (fail closed)" \
@@ -48,13 +42,10 @@ bare="$(grep -cE 'if (\[ -f "\$(cand|g)" \] && )?sha_match ' scripts/sutando-mig
 check "no decision site bypasses the mode check (bare sha_match ifs)" "$bare" "0"
 
 # --- controls 2+3: the summary logic, driven through the real python block ---
-# The summary python lives inline; exercise its logic via a faithful driver
-# that imports the same rules by regenerating verdicts/sort from fixtures.
 summary_out="$(python3 - <<'PYEOF'
 import json, os, tempfile, hashlib, subprocess, re, sys
-# Extract the inline summary python from the shipped script and run it against
-# a synthetic collision index: 50 identical(mtime-diff) + 1 divergent + the
-# unreadable-only variant.
+# Run the shipped summary python against a synthetic index:
+# 50 identical(mtime-diff) + 1 divergent + the unreadable-only variant.
 src = open("scripts/sutando-migrate.sh").read()
 m = re.search(r"_MAP = \{\"identical\": True.*?json\.dump\(out, sys\.stdout, indent=2\)", src, re.S)
 assert m, "summary block not found"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Identity = bytes AND mode, uniformly (kewei review on #3418, blockers 2+3).
+# Three controls the review asked for:
+#   1. same-bytes/different-mode commit path — the 0755 source must NOT be
+#      dropped against a 0644 dest (the exec bit used to vanish unrecoverably);
+#   2. 51-collision summary — 50 byte-identical mtime-differing entries must
+#      not push the one divergent entry past the render cap;
+#   3. unreadable-only — an unverified collision is NOT a genuine conflict.
+set -u
+cd "$(dirname "$0")/.."
+fails=0
+check() { if [ "$2" = "$3" ]; then echo "  ok  $1"; else echo "FAIL  $1 — got '$2', want '$3'"; fails=$((fails+1)); fi; }
+
+# --- control 1: identity_match itself, plus the commit-path consequence ---
+# Extract and exercise the REAL helpers from the shipped script.
+tmp="$(mktemp -d -t migrate-identity.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+printf '#!/bin/sh\necho hi\n' > "$tmp/a.sh"; chmod 0755 "$tmp/a.sh"
+printf '#!/bin/sh\necho hi\n' > "$tmp/b.sh"; chmod 0644 "$tmp/b.sh"
+printf '#!/bin/sh\necho hi\n' > "$tmp/c.sh"; chmod 0755 "$tmp/c.sh"
+helpers="$tmp/helpers.sh"
+sed -n '/^mode_of() {/,/^}/p; /^identity_match() {/,/^}/p; /^sha_match() {/,/^}/p' scripts/sutando-migrate.sh > "$helpers"
+# shellcheck disable=SC1090
+. "$helpers"
+# A failed extraction must fail HERE, loudly — command-not-found inside a
+# $(... && echo yes || echo no) capture reads as a clean "no" and false-passes
+# exactly the checks that expect "no" (measured on this test's first run).
+type identity_match >/dev/null 2>&1 || { echo "FAIL  helper extraction produced no identity_match"; exit 1; }
+check "same bytes + same mode IS identical" "$(identity_match "$tmp/a.sh" "$tmp/c.sh" && echo yes || echo no)" "yes"
+check "same bytes + different mode is NOT identical (exec bit must survive)" \
+  "$(identity_match "$tmp/a.sh" "$tmp/b.sh" && echo yes || echo no)" "no"
+check "different bytes never identical whatever the mode" \
+  "$(printf 'other\n' > "$tmp/d.sh"; chmod 0755 "$tmp/d.sh"; identity_match "$tmp/a.sh" "$tmp/d.sh" && echo yes || echo no)" "no"
+# every commit/delete/verify decision site uses identity_match, none bare sha_match
+bare="$(grep -cE 'if (\[ -f "\$(cand|g)" \] && )?sha_match ' scripts/sutando-migrate.sh)"
+check "no decision site bypasses the mode check (bare sha_match ifs)" "$bare" "0"
+
+# --- controls 2+3: the summary logic, driven through the real python block ---
+# The summary python lives inline; exercise its logic via a faithful driver
+# that imports the same rules by regenerating verdicts/sort from fixtures.
+summary_out="$(python3 - <<'PYEOF'
+import json, os, tempfile, hashlib, subprocess, re, sys
+# Extract the inline summary python from the shipped script and run it against
+# a synthetic collision index: 50 identical(mtime-diff) + 1 divergent + the
+# unreadable-only variant.
+src = open("scripts/sutando-migrate.sh").read()
+m = re.search(r"_MAP = \{\"identical\": True.*?json\.dump\(out, sys\.stdout, indent=2\)", src, re.S)
+assert m, "summary block not found"
+block = m.group(0)
+def run_case(verdict_map, collisions):
+    g = {"_verdicts": verdict_map, "collisions": collisions,
+         "by_rel": {k: [1,2] for k in collisions}, "defaultdict": __import__("collections").defaultdict,
+         "json": json, "sys": sys, "a": "", "b": "", "c": "", "dest": "d"}
+    import io
+    old = sys.stdout; sys.stdout = io.StringIO()
+    try:
+        exec(block + "\n", g)
+        return json.loads(sys.stdout.getvalue())
+    finally:
+        sys.stdout = old
+def entry(tag, mtime, size):
+    return {"tag": tag, "mtime": mtime, "size": size, "class": "structural"}
+# case A: 50 identical-with-differing-mtimes + 1 proven divergent (same size/mtime)
+coll = {}
+verd = {}
+for i in range(50):
+    k = f"zz-ident-{i:02d}"          # names sort AFTER the divergent one alphabetically? make them sort FIRST to stress the cap:
+    k = f"aa-ident-{i:02d}"
+    coll[k] = [entry("A", 100+i, 10), entry("B", 200+i, 10)]
+    verd[k] = "identical"
+coll["zz-the-divergent"] = [entry("A", 100, 10), entry("B", 200, 10)]
+verd["zz-the-divergent"] = "divergent"
+outA = run_case(verd, coll)
+notable = outA["notable_collisions"]
+first = notable[0]["rel"] if notable else ""
+present = any(r["rel"] == "zz-the-divergent" for r in notable)
+# case B: unreadable-only
+outB = run_case({"u1": "unverified"}, {"u1": [entry("A", 1, 5), entry("B", 2, 6)]})
+print(json.dumps({
+    "A_first": first, "A_divergent_present": present,
+    "A_genuine": outA["totals"]["genuine_conflicts"],
+    "B_genuine": outB["totals"]["genuine_conflicts"],
+    "B_unverified": outB["totals"]["identity_unverified"],
+}))
+PYEOF
+)"
+A_first="$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['A_first'])" "$summary_out")"
+A_present="$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['A_divergent_present'])" "$summary_out")"
+A_genuine="$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['A_genuine'])" "$summary_out")"
+B_genuine="$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['B_genuine'])" "$summary_out")"
+B_unverified="$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['B_unverified'])" "$summary_out")"
+check "51-collision: the one divergent entry renders FIRST" "$A_first" "zz-the-divergent"
+check "51-collision: the divergent entry survives the cap" "$A_present" "True"
+check "51-collision: genuine_conflicts counts only the proven one" "$A_genuine" "1"
+check "unreadable-only: genuine_conflicts is 0" "$B_genuine" "0"
+check "unreadable-only: surfaced as identity_unverified" "$B_unverified" "1"
+
+if [ "$fails" -gt 0 ]; then echo "$fails FAILURE(S)"; exit 1; fi
+echo "ALL PASS"

--- a/tests/sutando-migrate-identity-mode.test.sh
+++ b/tests/sutando-migrate-identity-mode.test.sh
@@ -132,6 +132,35 @@ check "the destination was actually rewritten (control: not an untouched file)" 
   "$(grep -c 'a@example.org' "$DEST/$REL" | tr -d ' ')" "1"
 
 
+# --- control 4b: VERIFY owns the manifest mode for a union entry ---
+# The bypass needs the union output to be BYTE-EQUAL to the source, so the
+# source must already carry the merged set in the writer's own serialization.
+_u="$e2e/u"; mkdir -p "$_u/s1/state" "$_u/d1/state"
+printf '{"allow": ["a@example.org", "b@example.org"]}\n' > "$_u/s1/$REL"
+printf '{"allow": ["b@example.org"]}\n'                  > "$_u/d1/$REL"
+SUTANDO_MIGRATE_SRC_A="$_u/s1" SUTANDO_MIGRATE_DEST="$_u/d1" \
+  bash scripts/sutando-migrate.sh commit --source A >/dev/null 2>&1
+
+mkdir -p "$_u/A/state" "$_u/dest/state"
+cp "$_u/d1/$REL" "$_u/A/$REL";                 chmod 0644 "$_u/A/$REL"
+printf '{"allow": ["b@example.org"]}\n' > "$_u/dest/$REL"; chmod 0600 "$_u/dest/$REL"
+_RUN_U() { SUTANDO_MIGRATE_SRC_A="$_u/A" SUTANDO_MIGRATE_DEST="$_u/dest" \
+           bash scripts/sutando-migrate.sh "$@" >/dev/null 2>&1; }
+_RUN_U commit --source A
+
+check "the union output is byte-equal to the source (the bypass precondition)" \
+  "$(cmp -s "$_u/A/$REL" "$_u/dest/$REL" && echo yes || echo no)" "yes"
+_um="$(stat -c '%a' "$_u/dest/$REL" 2>/dev/null || stat -f '%Lp' "$_u/dest/$REL")"
+check "commit still refuses to widen the 0600 destination" "$_um" "600"
+
+_v_rc=0; _RUN_U verify --source A || _v_rc=$?
+check "verify passes while the dest still holds its manifest mode" "$_v_rc" "0"
+
+chmod 0644 "$_u/dest/$REL"
+_v_widened=0; _RUN_U verify --source A || _v_widened=$?
+check "verify FAILS on a widened union dest, despite byte identity with the source" \
+  "$([ "$_v_widened" -ne 0 ] && echo failed || echo certified)" "failed"
+
 # --- control 5: byte_identical is a claim about BYTES, through the real JSON ---
 # Equal bytes, modes 0755 vs 0644 -> True; every DECISION still uses both fields.
 j5="$(mktemp -d -t migrate-json5.XXXXXX)"

--- a/tests/sutando-migrate-publication-order.test.sh
+++ b/tests/sutando-migrate-publication-order.test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Protected state is never readable before its mode policy holds: temp born at
+# the intersection, parents narrowed before any leaf, verify re-checks the chain.
+set -u
+cd "$(dirname "$0")/.."
+fails=0
+check() { if [ "$2" = "$3" ]; then echo "  ok  $1"; else echo "FAIL  $1 — got '$2', want '$3'"; fails=$((fails+1)); fi; }
+mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+MIGRATE="$PWD/scripts/sutando-migrate.sh"
+REL="state/slack-allowed-recipients.json"   # the shipped union-json-array rule
+tmp="$(mktemp -d -t migrate-pub.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+umask 022
+
+# --- control 1: the union temp is never observed non-empty and wider than the intersection ---
+
+# The production python block runs unchanged under a shim that records the
+# temp's (mode, size) at every later audit event; fchmod itself emits none.
+REALPY="$(command -v python3)"
+mkdir -p "$tmp/shim"
+cat > "$tmp/shim/audit.py" <<'PYS'
+import os, sys
+log_fd = os.open(os.environ["MIG_AUDIT_LOG"], os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+seen = []
+def hook(ev, args):
+    if ev not in ("open", "os.chmod", "os.utime", "os.rename", "os.replace"):
+        return
+    p = args[0] if args else None
+    if isinstance(p, (str, bytes, os.PathLike)):
+        p = os.fsdecode(p)
+        if ".tmp." in p and p not in seen:
+            seen.append(p)
+    for t in seen:
+        try:
+            st = os.stat(t)
+        except OSError:
+            continue
+        os.write(log_fd, f"{ev}\t{t}\t{st.st_mode & 0o7777:o}\t{st.st_size}\n".encode())
+if sys.argv[1] != "-":
+    os.execv(sys.argv[0].replace("audit.py", "") and os.environ["MIG_REAL_PY"], [os.environ["MIG_REAL_PY"]] + sys.argv[1:])
+sys.addaudithook(hook)
+code = sys.stdin.read()
+sys.argv = sys.argv[1:]
+exec(compile(code, "<stdin>", "exec"), {"__name__": "__main__"})
+PYS
+printf '#!/bin/bash\nexec "$MIG_REAL_PY" "%s" "$@"\n' "$tmp/shim/audit.py" > "$tmp/shim/python3"
+chmod 0755 "$tmp/shim/python3"
+
+U="$tmp/u1"; mkdir -p "$U/A/state" "$U/dest/state"
+# Large enough that buffered writes reach the disk before the file is closed.
+python3 - "$U/A/$REL" "$U/dest/$REL" <<'PYS'
+import json, sys
+for path, tag in ((sys.argv[1], "a"), (sys.argv[2], "b")):
+    with open(path, "w") as fh:
+        json.dump({"allow": [f"{tag}{i}@example.org" for i in range(4000)]}, fh)
+PYS
+chmod 0600 "$U/A/$REL" "$U/dest/$REL"; chmod 0755 "$U/A/state" "$U/dest/state"
+touch -t 202601020000 "$U/A/$REL"; touch -t 202601010000 "$U/dest/$REL"
+: > "$tmp/audit.log"
+_rc=0; MIG_AUDIT_LOG="$tmp/audit.log" MIG_REAL_PY="$REALPY" SUTANDO_PY="$tmp/shim/python3" \
+  SUTANDO_MIGRATE_SRC_A="$U/A" SUTANDO_MIGRATE_DEST="$U/dest" \
+  bash "$MIGRATE" commit --source A --no-confirm >"$tmp/u1.out" 2>&1 || _rc=$?
+check "union commit succeeds under the audit shim" "$_rc" "0"
+check "the union merged (control: the production block ran)" \
+  "$(grep -c 'a1@example.org' "$U/dest/$REL" | tr -d ' ')" "1"
+check "the shim observed the temp's life (control: the hook can see)" \
+  "$([ "$(wc -l < "$tmp/audit.log" | tr -d ' ')" -ge 1 ] && echo yes || echo no)" "yes"
+first="$(head -1 "$tmp/audit.log")"
+check "first observation of the temp: empty (no byte precedes the mode)" "$(printf '%s' "$first" | cut -f4)" "0"
+check "first observation of the temp: born at the 0600 intersection" "$(printf '%s' "$first" | cut -f3)" "600"
+wide="$(awk -F'\t' '$4 > 0 && $3 != "600" { n++ } END { print n+0 }' "$tmp/audit.log")"
+check "the temp is never non-empty while wider than the intersection" "$wide" "0"
+check "the published leaf keeps the intersection" "$(mode_of "$U/dest/$REL")" "600"
+
+# --- control 2: a failed parent enforcement leaves the pre-union destination untouched ---
+union_fixture() {   # $1 = root; 0700 source parent, 0755 destination parent, divergent leaves
+    mkdir -p "$1/A/state" "$1/dest/state"
+    printf '{"allow": ["a@example.org"]}\n' > "$1/A/$REL";    chmod 0644 "$1/A/$REL"
+    printf '{"allow": ["b@example.org"]}\n' > "$1/dest/$REL"; chmod 0644 "$1/dest/$REL"
+    chmod 0700 "$1/A/state"; chmod 0755 "$1/dest/state"
+    touch -t 202601020000 "$1/A/$REL"; touch -t 202601010000 "$1/dest/$REL"
+}
+# Positive control first, on its own fixture: the same inputs commit and narrow.
+U="$tmp/u2b"; union_fixture "$U"
+_rc=0; SUTANDO_MIGRATE_SRC_A="$U/A" SUTANDO_MIGRATE_DEST="$U/dest" \
+  bash "$MIGRATE" commit --source A --no-confirm >"$tmp/u2b.out" 2>&1 || _rc=$?
+check "control: without the shim the union commits" "$_rc" "0"
+check "control: and the parent takes the 0700 intersection" "$(mode_of "$U/dest/state")" "700"
+check "control: and the leaf merged" "$(grep -c 'a@example.org' "$U/dest/$REL" | tr -d ' ')" "1"
+# A chmod shim fails ONLY the destination parent, exactly the review's probe.
+# The script chmods the RESOLVED path, so the shim must compare against it.
+U="$tmp/u2"; union_fixture "$U"
+dest_state_real="$(cd "$U/dest/state" && pwd -P)"
+mkdir -p "$tmp/chmod-shim"
+cat > "$tmp/chmod-shim/chmod" <<EOS
+#!/bin/bash
+for a in "\$@"; do [ "\$a" = "$dest_state_real" ] && exit 97; done
+exec /bin/chmod "\$@"
+EOS
+chmod 0755 "$tmp/chmod-shim/chmod"
+before_sha="$(shasum -a 256 "$U/dest/$REL" | cut -d' ' -f1)"
+_rc=0; PATH="$tmp/chmod-shim:$PATH" SUTANDO_MIGRATE_SRC_A="$U/A" SUTANDO_MIGRATE_DEST="$U/dest" \
+  bash "$MIGRATE" commit --source A --no-confirm >"$tmp/u2.out" 2>&1 || _rc=$?
+check "failed parent enforcement: commit fails" "$([ "$_rc" -ne 0 ] && echo failed || echo ok)" "failed"
+check "failed parent enforcement: the shim fired (control: the parent stayed 0755)" "$(mode_of "$U/dest/state")" "755"
+check "failed parent enforcement: the pre-union leaf is byte-identical" \
+  "$(shasum -a 256 "$U/dest/$REL" | cut -d' ' -f1)" "$before_sha"
+check "failed parent enforcement: no union temp is left behind" \
+  "$(ls "$U/dest/state"/*.tmp.* 2>/dev/null | wc -l | tr -d ' ')" "0"
+check "failed parent enforcement: no union manifest certifies the leaf" \
+  "$(ls "$U/dest/state"/.migration-union-scalars-*.json 2>/dev/null | wc -l | tr -d ' ')" "0"
+
+# --- control 3: an identity drop with NO copy still narrows the governed parents ---
+S="$tmp/s3"; mkdir -p "$S/C/hosts/Test-Host" "$S/dest/hosts/Test-Host"
+printf 'private per-host rules\n' > "$S/C/hosts/Test-Host/PERSONAL_CLAUDE.md"
+cp "$S/C/hosts/Test-Host/PERSONAL_CLAUDE.md" "$S/dest/hosts/Test-Host/PERSONAL_CLAUDE.md"
+chmod 0644 "$S/C/hosts/Test-Host/PERSONAL_CLAUDE.md" "$S/dest/hosts/Test-Host/PERSONAL_CLAUDE.md"
+chmod 0700 "$S/C/hosts" "$S/C/hosts/Test-Host"; chmod 0755 "$S/dest/hosts" "$S/dest/hosts/Test-Host"
+touch -t 202601010000 "$S/C/hosts/Test-Host/PERSONAL_CLAUDE.md"
+touch -t 202601020000 "$S/dest/hosts/Test-Host/PERSONAL_CLAUDE.md"   # dest newer: no copy
+ino_before="$(stat -c '%i %Y' "$S/dest/hosts/Test-Host/PERSONAL_CLAUDE.md" 2>/dev/null || stat -f '%i %m' "$S/dest/hosts/Test-Host/PERSONAL_CLAUDE.md")"
+_rc=0; SUTANDO_MIGRATE_SRC_C="$S/C" SUTANDO_MIGRATE_DEST="$S/dest" \
+  bash "$MIGRATE" commit --source C --no-confirm >"$tmp/s3.out" 2>&1 || _rc=$?
+check "structural identity drop (dest newer): commit succeeds" "$_rc" "0"
+check "structural identity drop: reported as identical-drop" \
+  "$(grep -c 'identical-drop' "$tmp/s3.out" | tr -d ' ')" "1"
+check "structural identity drop: the leaf was NOT copied (inode + mtime unchanged)" \
+  "$(stat -c '%i %Y' "$S/dest/hosts/Test-Host/PERSONAL_CLAUDE.md" 2>/dev/null || stat -f '%i %m' "$S/dest/hosts/Test-Host/PERSONAL_CLAUDE.md")" "$ino_before"
+check "structural identity drop: hosts/Test-Host takes the 0700 intersection" "$(mode_of "$S/dest/hosts/Test-Host")" "700"
+check "structural identity drop: hosts takes the 0700 intersection" "$(mode_of "$S/dest/hosts")" "700"
+# The union class has the same no-copy branch.
+U="$tmp/u3"; mkdir -p "$U/A/state" "$U/dest/state"
+printf '{"allow": ["a@example.org"]}\n' > "$U/A/$REL"; cp "$U/A/$REL" "$U/dest/$REL"
+chmod 0644 "$U/A/$REL" "$U/dest/$REL"; chmod 0700 "$U/A/state"; chmod 0755 "$U/dest/state"
+touch -t 202601010000 "$U/A/$REL"; touch -t 202601020000 "$U/dest/$REL"
+_rc=0; SUTANDO_MIGRATE_SRC_A="$U/A" SUTANDO_MIGRATE_DEST="$U/dest" \
+  bash "$MIGRATE" commit --source A --no-confirm >"$tmp/u3.out" 2>&1 || _rc=$?
+check "union identity drop (dest newer): commit succeeds" "$_rc" "0"
+check "union identity drop: state takes the 0700 intersection" "$(mode_of "$U/dest/state")" "700"
+
+# --- control 4: verify checks the governed parent chain, not only the leaf ---
+_v=0; SUTANDO_MIGRATE_SRC_C="$S/C" SUTANDO_MIGRATE_DEST="$S/dest" \
+  bash "$MIGRATE" verify --source C >"$tmp/s4.out" 2>&1 || _v=$?
+check "verify passes on the narrowed chain" "$_v" "0"
+chmod 0755 "$S/dest/hosts/Test-Host"
+_w=0; SUTANDO_MIGRATE_SRC_C="$S/C" SUTANDO_MIGRATE_DEST="$S/dest" \
+  bash "$MIGRATE" verify --source C >"$tmp/s4w.out" 2>&1 || _w=$?
+check "verify FAILS once a governed parent is widened after commit" \
+  "$([ "$_w" -ne 0 ] && echo failed || echo certified)" "failed"
+check "verify names the widened parent" "$(grep -c 'parent is wider' "$tmp/s4w.out" | tr -d ' ')" "1"
+chmod 0700 "$S/dest/hosts/Test-Host"
+_v2=0; SUTANDO_MIGRATE_SRC_C="$S/C" SUTANDO_MIGRATE_DEST="$S/dest" \
+  bash "$MIGRATE" verify --source C >"$tmp/s4r.out" 2>&1 || _v2=$?
+check "control: verify passes again once the parent is restored" "$_v2" "0"
+
+if [ "$fails" -gt 0 ]; then echo "$fails FAILURE(S)"; exit 1; fi
+echo "ALL PASS"

--- a/tests/sutando-migrate-rules.test.sh
+++ b/tests/sutando-migrate-rules.test.sh
@@ -48,6 +48,13 @@ assert_class "pending-questions.md" "append" || fail=1
 assert_class "pending-questions-resolved-archive-2026-05-24.md" "rehome-dated-snapshot" "notes/archive" || fail=1
 assert_class "session-state.md" "newest-mtime" || fail=1
 
+# Per-host state tree + relay notes (tk-7e767bb426 class): quarantining these
+# breaks every hosts/<label>/ reader; PERSONAL_CLAUDE.md's canonical home is here.
+assert_class "hosts/Some-Host/crons.json" "structural" "<dest>/hosts/Some-Host/crons.json" || fail=1
+assert_class "hosts/Some-Host/PERSONAL_CLAUDE.md" "structural" "<dest>/hosts/Some-Host/PERSONAL_CLAUDE.md" || fail=1
+assert_class "hosts/Some-Host/pending-questions.md" "structural" || fail=1
+assert_class "relay/relay-1787753000.md" "structural" "<dest>/relay/relay-1787753000.md" || fail=1
+
 # Loose JSONs (rehome-state)
 assert_class "cloud-auth.json" "rehome-state" "state/auth/cloud-auth.json" || fail=1
 assert_class "device.json" "rehome-state" "state/auth/device.json" || fail=1

--- a/tests/sutando-migrate-rules.test.sh
+++ b/tests/sutando-migrate-rules.test.sh
@@ -48,8 +48,8 @@ assert_class "pending-questions.md" "append" || fail=1
 assert_class "pending-questions-resolved-archive-2026-05-24.md" "rehome-dated-snapshot" "notes/archive" || fail=1
 assert_class "session-state.md" "newest-mtime" || fail=1
 
-# Per-host state tree + relay notes (tk-7e767bb426 class): quarantining these
-# breaks every hosts/<label>/ reader; PERSONAL_CLAUDE.md's canonical home is here.
+# Per-host state tree + relay notes: quarantining these breaks every
+# hosts/<label>/ reader; PERSONAL_CLAUDE.md's canonical home is here.
 assert_class "hosts/Some-Host/crons.json" "structural" "<dest>/hosts/Some-Host/crons.json" || fail=1
 assert_class "hosts/Some-Host/PERSONAL_CLAUDE.md" "structural" "<dest>/hosts/Some-Host/PERSONAL_CLAUDE.md" || fail=1
 assert_class "hosts/Some-Host/pending-questions.md" "structural" || fail=1

--- a/tests/sutando-migrate-trap-hygiene.test.sh
+++ b/tests/sutando-migrate-trap-hygiene.test.sh
@@ -15,7 +15,7 @@ rc=$?
 check "--help exits 0 with an inherited _VERDICTS_TMP" "$rc" "0"
 check "the inherited path SURVIVES (trap must not delete what it did not create)" \
   "$( [ -f "$victim" ] && echo alive || echo deleted )" "alive"
-# non-JSON path variant of the same control (the finding asked for one).
+# non-JSON path variant of the same control.
 victim2="$(mktemp -t trap-hygiene-victim2.XXXXXX).txt"
 printf 'plain text\n' > "$victim2"
 _VERDICTS_TMP="$victim2" bash scripts/sutando-migrate.sh --help >/dev/null 2>&1

--- a/tests/sutando-migrate-trap-hygiene.test.sh
+++ b/tests/sutando-migrate-trap-hygiene.test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The cleanup trap must only ever remove paths THIS process created.
+# Regression (review finding on #3418): the EXIT trap referenced
+# _VERDICTS_TMP before the script initialized it, so an inherited
+# environment value was rm -f'd on every exit — including `--help`.
+set -u
+cd "$(dirname "$0")/.."
+fails=0
+check() { if [ "$2" = "$3" ]; then echo "  ok  $1"; else echo "FAIL  $1 — got '$2', want '$3'"; fails=$((fails+1)); fi; }
+
+victim="$(mktemp -t trap-hygiene-victim.XXXXXX)"
+echo "precious" > "$victim"
+
+# kewei's exact repro shape: inherited var + a non-mutating command.
+_VERDICTS_TMP="$victim" bash scripts/sutando-migrate.sh --help >/dev/null 2>&1
+rc=$?
+check "--help exits 0 with an inherited _VERDICTS_TMP" "$rc" "0"
+check "the inherited path SURVIVES (trap must not delete what it did not create)" \
+  "$( [ -f "$victim" ] && echo alive || echo deleted )" "alive"
+# non-JSON path variant of the same control (the finding asked for one).
+victim2="$(mktemp -t trap-hygiene-victim2.XXXXXX).txt"
+printf 'plain text\n' > "$victim2"
+_VERDICTS_TMP="$victim2" bash scripts/sutando-migrate.sh --help >/dev/null 2>&1
+check "a non-JSON inherited path survives too" \
+  "$( [ -f "$victim2" ] && echo alive || echo deleted )" "alive"
+rm -f "$victim" "$victim2"
+
+if [ "$fails" -gt 0 ]; then echo "$fails FAILURE(S)"; exit 1; fi
+echo "ALL PASS"

--- a/tests/sutando-migrate-trap-hygiene.test.sh
+++ b/tests/sutando-migrate-trap-hygiene.test.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-# The cleanup trap must only ever remove paths THIS process created.
-# Regression (review finding on #3418): the EXIT trap referenced
-# _VERDICTS_TMP before the script initialized it, so an inherited
-# environment value was rm -f'd on every exit — including `--help`.
+# The cleanup trap must only remove paths THIS process created — reading
+# _VERDICTS_TMP before init rm -f's an inherited value even on --help.
 set -u
 cd "$(dirname "$0")/.."
 fails=0
@@ -11,7 +9,7 @@ check() { if [ "$2" = "$3" ]; then echo "  ok  $1"; else echo "FAIL  $1 — got 
 victim="$(mktemp -t trap-hygiene-victim.XXXXXX)"
 echo "precious" > "$victim"
 
-# kewei's exact repro shape: inherited var + a non-mutating command.
+# Repro shape: inherited var + a non-mutating command.
 _VERDICTS_TMP="$victim" bash scripts/sutando-migrate.sh --help >/dev/null 2>&1
 rc=$?
 check "--help exits 0 with an inherited _VERDICTS_TMP" "$rc" "0"

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -217,7 +217,9 @@ REAL_T="$(dirname "$(mktemp -u)")"
 PRE_VERDICTS="$(ls "$REAL_T" 2>/dev/null | grep -c "sutando-migrate-verdicts" || true)"
 TMPDIR="$ISO_TMP" RUN_MIGRATE scan --source A,B,C --json > /dev/null 2>&1
 TMPDIR="$ISO_TMP" RUN_MIGRATE scan --source A,B,C > /dev/null 2>&1
-LEFTOVER="$(ls -A "$ISO_TMP")"
+# Scope to the tempfiles THIS script creates. Any-file-is-a-leak is wrong on a
+# Command-Line-Tools host, where Apple's xcrun caches `xcrun_db` into $TMPDIR.
+LEFTOVER="$(ls -A "$ISO_TMP" 2>/dev/null | grep '^sutando-migrate-verdicts' || true)"
 POST_VERDICTS="$(ls "$REAL_T" 2>/dev/null | grep -c "sutando-migrate-verdicts" || true)"
 if [ -n "$LEFTOVER" ]; then
     echo "  FAIL: scan left files in isolated TMPDIR: $LEFTOVER"
@@ -228,6 +230,29 @@ elif [ "$POST_VERDICTS" != "$PRE_VERDICTS" ]; then
 else
     echo "  OK: no scan residue (isolated TMPDIR empty; verdict count stable $PRE_VERDICTS)"
 fi
+
+# Controls for the narrowed probe: it must still SEE a real leak, and must NOT
+# fire on foreign tooling residue. Without the first, narrowing could have made
+# the assertion unable to fail at all.
+_ctl="$TMP/leak-ctl"; mkdir -p "$_ctl"
+: > "$_ctl/sutando-migrate-verdicts.abc123"
+_pos="$(ls -A "$_ctl" 2>/dev/null | grep '^sutando-migrate-verdicts' || true)"
+if [ -n "$_pos" ]; then
+    echo "  OK: control — the narrowed probe still CATCHES a real verdict tempfile"
+else
+    echo "  FAIL: control — narrowed probe cannot see a real leak; it can no longer fail"
+    fail_stub=1
+fi
+rm -f "$_ctl/sutando-migrate-verdicts.abc123"
+: > "$_ctl/xcrun_db"
+_neg="$(ls -A "$_ctl" 2>/dev/null | grep '^sutando-migrate-verdicts' || true)"
+if [ -z "$_neg" ]; then
+    echo "  OK: control — foreign tooling residue (xcrun_db) is correctly ignored"
+else
+    echo "  FAIL: control — probe fired on foreign residue: $_neg"
+    fail_stub=1
+fi
+rm -rf "$_ctl"
 
 echo
 echo "==== TEST: python-binary.sh owns require_python (no shadow) ===="

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -501,11 +501,16 @@ python3 - "$MIGRATE" "$u3_fn" "$REPO" <<'PYX'
 import sys
 src, out, repo = sys.argv[1], sys.argv[2], sys.argv[3]
 s = open(src).read()
-i = s.index("union_json_arrays_into() {")
-j = s.index("\n}\n", i) + 3
+def fn(name):
+    i = s.index(name + "() {")
+    return s[i:s.index("\n}\n", i) + 3]
+# The writer delegates parent modes to the shared policy; extract that too,
+# or the harness fails on a missing command rather than on the rule.
+body = "".join(fn(n) for n in
+               ("_stat", "mode_of", "dir_mode_chain", "mirror_dir_modes", "union_json_arrays_into"))
 open(out, "w").write(
     f'SCRIPT_DIR="{repo}/scripts"\nREPO_DIR="{repo}"\n'
-    f'. "{repo}/scripts/python-binary.sh"\n\n' + s[i:j])
+    f'. "{repo}/scripts/python-binary.sh"\n\n' + body)
 PYX
 u3_check="$(
   . "$u3_fn"

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -568,9 +568,8 @@ done
 # 9. Idempotency: re-run commit, should detect sentinel + skip
 echo
 echo "==== TEST: verify (mandatory phase three — this suite claims scan→commit→verify) ===="
-# The fixture includes a divergent union (state/slack-allowed-recipients.json),
-# so this also pins class-aware semantic verification: a union result differs
-# from both inputs by design and must still verify.
+# The fixture's divergent union pins class-aware semantic verification: the
+# result differs from both inputs by design and must still verify.
 VERIFY_OUT="$(RUN_MIGRATE --verify 2>&1)" && verify_rc=0 || verify_rc=$?
 echo "$VERIFY_OUT" | grep -E "verify summary|verify:" | head -3
 if [ "$verify_rc" -ne 0 ]; then

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -231,9 +231,8 @@ else
     echo "  OK: no scan residue (isolated TMPDIR empty; verdict count stable $PRE_VERDICTS)"
 fi
 
-# Controls for the narrowed probe: it must still SEE a real leak, and must NOT
-# fire on foreign tooling residue. Without the first, narrowing could have made
-# the assertion unable to fail at all.
+# The narrowed probe must still SEE a real leak and NOT fire on foreign residue;
+# without the first, narrowing could make the assertion unable to fail at all.
 _ctl="$TMP/leak-ctl"; mkdir -p "$_ctl"
 : > "$_ctl/sutando-migrate-verdicts.abc123"
 _pos="$(ls -A "$_ctl" 2>/dev/null | grep '^sutando-migrate-verdicts' || true)"

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -41,6 +41,17 @@ touch -t 202506010800 "$B/notes/divergent.md"
 touch -t 202606010800 "$C/notes/divergent.md"
 touch -t 202606012100 "$A/notes/divergent.md"
 
+# --- Fixture: hosts/ + relay/ same-mtime same-size DIFFERENT content (reviewer
+# repro on #3418): mtime+size identical-drop certified these as identical and
+# dropped the source variant. Content-hash must classify them as collisions.
+mkdir -p "$A/hosts/Test-Host" "$A/relay" "$DEST/hosts/Test-Host" "$DEST/relay"
+printf 'AAAA\n' > "$A/hosts/Test-Host/crons.json"
+printf 'BBBB\n' > "$DEST/hosts/Test-Host/crons.json"
+touch -t 202606011200 "$A/hosts/Test-Host/crons.json" "$DEST/hosts/Test-Host/crons.json"
+printf 'RRRR\n' > "$A/relay/relay-1.md"
+printf 'SSSS\n' > "$DEST/relay/relay-1.md"
+touch -t 202606011200 "$A/relay/relay-1.md" "$DEST/relay/relay-1.md"
+
 # --- Fixture: rehome — loose root JSON at C ---
 echo '{"k":"v"}' > "$C/cloud-auth.json"
 
@@ -170,6 +181,19 @@ else
         echo "  OK: notes/divergent.md collision A-wins; C-version sidecared at $(basename "$sidecar_path") (timestamped per Mini #3)"
     fi
 fi
+
+# 3b. hosts/ + relay/ equal-mtime equal-size different content must be a
+#     COLLISION (both variants present under DEST), never identical-drop.
+for pair in "hosts/Test-Host/crons.json|AAAA|BBBB" "relay/relay-1.md|RRRR|SSSS"; do
+    rel="${pair%%|*}"; rest="${pair#*|}"; srcv="${rest%%|*}"; dstv="${rest#*|}"
+    hits_src="$( { grep -rl "$srcv" "$DEST/$(dirname "$rel")" 2>/dev/null || true; } | wc -l | tr -d ' ')"
+    hits_dst="$( { grep -rl "$dstv" "$DEST/$(dirname "$rel")" 2>/dev/null || true; } | wc -l | tr -d ' ')"
+    if [ "$hits_src" -ge 1 ] && [ "$hits_dst" -ge 1 ]; then
+        echo "  OK: $rel equal-mtime/equal-size different content preserved as collision (both variants under DEST)"
+    else
+        echo "  FAIL: $rel — same-mtime/same-size different content lost a variant (src-present=$hits_src dst-present=$hits_dst)"; fail=1
+    fi
+done
 
 # 4. cloud-auth.json re-homed to dest/state/auth/ per Mini #design 2026-06-02
 if [ ! -f "$DEST/state/auth/cloud-auth.json" ]; then

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -51,6 +51,14 @@ printf 'RRRR\n' > "$A/relay/relay-1.md"
 printf 'SSSS\n' > "$DEST/relay/relay-1.md"
 touch -t 202606011200 "$A/relay/relay-1.md" "$DEST/relay/relay-1.md"
 
+# --- Fixture: unreadable-identity — identical bytes both sides, but the SOURCE
+# copy is unreadable: the scan must report UNVERIFIED, never proven divergence.
+mkdir -p "$A/notes" "$DEST/notes"
+printf 'same bytes\n' > "$A/notes/unreadable.md"
+printf 'same bytes\n' > "$DEST/notes/unreadable.md"
+touch -t 202606011300 "$A/notes/unreadable.md" "$DEST/notes/unreadable.md"
+chmod 000 "$A/notes/unreadable.md"
+
 # --- Fixture: rehome — loose root JSON at C ---
 echo '{"k":"v"}' > "$C/cloud-auth.json"
 
@@ -153,6 +161,16 @@ if t.get("proxy_identical_divergent", 0) < 2:
 ident_true = sum(1 for n in notable.values() if n["byte_identical"] is True)
 if t["identical_content"] != ident_true:
     bad.append(f"identical_content={t['identical_content']} != byte-verified count {ident_true}")
+n = notable.get("notes/unreadable.md")
+if n is None:
+    bad.append("notes/unreadable.md: missing from notable_collisions")
+elif n["byte_identical"] is not None:
+    bad.append(f"notes/unreadable.md: byte_identical={n['byte_identical']!r}, want None (unverified)")
+if t.get("identity_unverified") != 1:
+    bad.append(f"identity_unverified={t.get('identity_unverified')!r}, want 1")
+if any(nn["rel"] == "notes/unreadable.md" for nn in d["notable_collisions"])\
+        and t.get("proxy_identical_divergent", 0) != 2:
+    bad.append(f"proxy_identical_divergent={t.get('proxy_identical_divergent')} counts the unreadable file, want exactly 2")
 if bad:
     print("; ".join(bad)); sys.exit(1)
 sys.exit(0)
@@ -165,6 +183,35 @@ else
 fi
 
 echo
+echo "==== TEST: scan uses the resolved interpreter, not PATH python3 ===="
+# Control for the clean-macOS CLT-stub case: PATH python3 is a failing shim and
+# $SUTANDO_PY points at a real interpreter — both report paths must still work.
+REAL_PY="$(command -v python3)"
+SHIMDIR="$TMP/shim-bin"
+mkdir -p "$SHIMDIR"
+printf '#!/bin/sh\nexit 97\n' > "$SHIMDIR/python3"
+chmod +x "$SHIMDIR/python3"
+fail_stub=0
+STUB_HUMAN="$(PATH="$SHIMDIR:$PATH" SUTANDO_PY="$REAL_PY" RUN_MIGRATE scan --source A,B,C 2>&1 || true)"
+if ! echo "$STUB_HUMAN" | grep -q "of which identical-content (byte-verified):  [0-9]"; then
+    echo "  FAIL: human scan lost its identity report under a shadowed PATH python3"
+    fail_stub=1
+fi
+STUB_JSON="$TMP/scan-stub.json"
+if ! PATH="$SHIMDIR:$PATH" SUTANDO_PY="$REAL_PY" RUN_MIGRATE scan --source A,B,C --json 2>/dev/null > "$STUB_JSON"; then
+    echo "  FAIL: json scan exited non-zero under a shadowed PATH python3"
+    fail_stub=1
+elif ! "$REAL_PY" -c 'import json,sys;raw=open(sys.argv[1]).read();d=json.JSONDecoder().raw_decode(raw[raw.index("{"):])[0];assert "identity_unverified" in d["totals"]' "$STUB_JSON" 2>/dev/null; then
+    echo "  FAIL: json scan emitted no parseable contract under a shadowed PATH python3"
+    fail_stub=1
+fi
+[ "$fail_stub" -eq 0 ] && echo "  OK: both report paths ran on \$SUTANDO_PY with PATH python3 shadowed"
+
+# Restore the unreadable fixture before commit — its scan job is done, and the
+# commit-phase copy semantics for unreadable sources are a separate contract.
+chmod 644 "$A/notes/unreadable.md"
+
+echo
 echo "==== TEST: commit ===="
 COMMIT_OUT="$(RUN_MIGRATE commit --source A,B,C 2>&1)"
 echo "$COMMIT_OUT" | grep -E "Committing source|copied:|identical:|kept-dest:|sidecar:|skipped:|sentinel:|backup|COMMIT" | head -40
@@ -173,6 +220,7 @@ INITIAL_BACKUP_ID="$(echo "$COMMIT_OUT" | grep -E "migration-backup-.*\.tar\.gz"
 echo
 echo "==== ASSERTIONS ===="
 fail=0
+[ "${fail_stub:-0}" -ne 0 ] && { echo "FAIL: interpreter-resolution control"; fail=1; }
 [ "${fail_scan_json:-0}" = "1" ] && fail=1
 
 # 1. build_log.md sidecar default: each source's variant goes to legacy/<tag>/build_log.md

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -41,9 +41,8 @@ touch -t 202506010800 "$B/notes/divergent.md"
 touch -t 202606010800 "$C/notes/divergent.md"
 touch -t 202606012100 "$A/notes/divergent.md"
 
-# --- Fixture: hosts/ + relay/ same-mtime same-size DIFFERENT content (reviewer
-# repro on #3418): mtime+size identical-drop certified these as identical and
-# dropped the source variant. Content-hash must classify them as collisions.
+# --- Fixture: hosts/ + relay/ same-mtime same-size DIFFERENT content —
+# equal proxies must never certify identity; only a content hash may.
 mkdir -p "$A/hosts/Test-Host" "$A/relay" "$DEST/hosts/Test-Host" "$DEST/relay"
 printf 'AAAA\n' > "$A/hosts/Test-Host/crons.json"
 printf 'BBBB\n' > "$DEST/hosts/Test-Host/crons.json"
@@ -131,6 +130,41 @@ RUN_MIGRATE scan --source A,B,C 2>&1 \
     | head -25 || true
 
 echo
+echo "==== TEST: scan --json content-identity regression ===="
+# Equal mtime+size but different bytes (hosts/ + relay/ fixtures) must be
+# actionable, never certified identical_content, in the machine contract.
+SCAN_JSON_FILE="$TMP/scan-out.json"
+RUN_MIGRATE scan --source A,B,C --json 2>/dev/null > "$SCAN_JSON_FILE"
+if python3 - "$SCAN_JSON_FILE" <<'PYSCAN'
+import json, sys
+raw = open(sys.argv[1]).read()
+d = json.JSONDecoder().raw_decode(raw[raw.index("{"):])[0]
+t = d["totals"]
+notable = {n["rel"]: n for n in d["notable_collisions"]}
+bad = []
+for rel in ("hosts/Test-Host/crons.json", "relay/relay-1.md"):
+    n = notable.get(rel)
+    if n is None:
+        bad.append(f"{rel}: missing from notable_collisions"); continue
+    if n["byte_identical"] is not False:
+        bad.append(f"{rel}: byte_identical={n['byte_identical']!r}, want False")
+if t.get("proxy_identical_divergent", 0) < 2:
+    bad.append(f"proxy_identical_divergent={t.get('proxy_identical_divergent')}, want >=2")
+ident_true = sum(1 for n in notable.values() if n["byte_identical"] is True)
+if t["identical_content"] != ident_true:
+    bad.append(f"identical_content={t['identical_content']} != byte-verified count {ident_true}")
+if bad:
+    print("; ".join(bad)); sys.exit(1)
+sys.exit(0)
+PYSCAN
+then
+    echo "  OK: scan --json marks equal-proxy divergent fixtures actionable (byte_identical=false)"
+else
+    echo "  FAIL: scan --json content-identity contract"
+    fail_scan_json=1
+fi
+
+echo
 echo "==== TEST: commit ===="
 COMMIT_OUT="$(RUN_MIGRATE commit --source A,B,C 2>&1)"
 echo "$COMMIT_OUT" | grep -E "Committing source|copied:|identical:|kept-dest:|sidecar:|skipped:|sentinel:|backup|COMMIT" | head -40
@@ -139,6 +173,7 @@ INITIAL_BACKUP_ID="$(echo "$COMMIT_OUT" | grep -E "migration-backup-.*\.tar\.gz"
 echo
 echo "==== ASSERTIONS ===="
 fail=0
+[ "${fail_scan_json:-0}" = "1" ] && fail=1
 
 # 1. build_log.md sidecar default: each source's variant goes to legacy/<tag>/build_log.md
 for tag in A B C; do

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -567,6 +567,18 @@ done
 
 # 9. Idempotency: re-run commit, should detect sentinel + skip
 echo
+echo "==== TEST: verify (mandatory phase three — this suite claims scan→commit→verify) ===="
+# The fixture includes a divergent union (state/slack-allowed-recipients.json),
+# so this also pins class-aware semantic verification: a union result differs
+# from both inputs by design and must still verify.
+VERIFY_OUT="$(RUN_MIGRATE --verify 2>&1)" && verify_rc=0 || verify_rc=$?
+echo "$VERIFY_OUT" | grep -E "verify summary|verify:" | head -3
+if [ "$verify_rc" -ne 0 ]; then
+    echo "  FAIL: verify exited $verify_rc after a successful commit"; fail=1
+else
+    echo "  OK: post-commit verify passes"
+fi
+
 echo "==== TEST: re-run commit (idempotency) ===="
 out="$(RUN_MIGRATE commit --source A,B,C 2>&1)"
 if echo "$out" | grep -q "prior migration sentinel — skip"; then

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -207,6 +207,42 @@ elif ! "$REAL_PY" -c 'import json,sys;raw=open(sys.argv[1]).read();d=json.JSONDe
 fi
 [ "$fail_stub" -eq 0 ] && echo "  OK: both report paths ran on \$SUTANDO_PY with PATH python3 shadowed"
 
+echo
+echo "==== TEST: scan leaves no residue in TMPDIR (verdict tempfile cleanup) ===="
+# Two probes: GNU mktemp honors $TMPDIR (isolated dir discriminates on Linux);
+# macOS ignores it, so the named-template count in the real temp root gates there.
+ISO_TMP="$TMP/iso-tmpdir"
+mkdir -p "$ISO_TMP"
+REAL_T="$(dirname "$(mktemp -u)")"
+PRE_VERDICTS="$(ls "$REAL_T" 2>/dev/null | grep -c "sutando-migrate-verdicts" || true)"
+TMPDIR="$ISO_TMP" RUN_MIGRATE scan --source A,B,C --json > /dev/null 2>&1
+TMPDIR="$ISO_TMP" RUN_MIGRATE scan --source A,B,C > /dev/null 2>&1
+LEFTOVER="$(ls -A "$ISO_TMP")"
+POST_VERDICTS="$(ls "$REAL_T" 2>/dev/null | grep -c "sutando-migrate-verdicts" || true)"
+if [ -n "$LEFTOVER" ]; then
+    echo "  FAIL: scan left files in isolated TMPDIR: $LEFTOVER"
+    fail_stub=1
+elif [ "$POST_VERDICTS" != "$PRE_VERDICTS" ]; then
+    echo "  FAIL: verdict tempfiles accumulated in $REAL_T ($PRE_VERDICTS -> $POST_VERDICTS)"
+    fail_stub=1
+else
+    echo "  OK: no scan residue (isolated TMPDIR empty; verdict count stable $PRE_VERDICTS)"
+fi
+
+echo
+echo "==== TEST: python-binary.sh owns require_python (no shadow) ===="
+# The sourced helper is the single loud-failure owner; a local redefinition
+# shadows it and its subshell memoization silently never caches.
+if [ "$(grep -cE '^require_python\(\)' "$REPO/scripts/sutando-migrate.sh")" != "0" ]; then
+    echo "  FAIL: sutando-migrate.sh redefines require_python (shadows python-binary.sh)"
+    fail_stub=1
+elif ! grep -q 'python-binary.sh' "$REPO/scripts/sutando-migrate.sh"; then
+    echo "  FAIL: sutando-migrate.sh no longer sources python-binary.sh"
+    fail_stub=1
+else
+    echo "  OK: single require_python owner (sourced from python-binary.sh)"
+fi
+
 # Restore the unreadable fixture before commit — its scan job is done, and the
 # commit-phase copy semantics for unreadable sources are a separate contract.
 chmod 644 "$A/notes/unreadable.md"


### PR DESCRIPTION
## What — two defects, different severities

This PR fixes two distinct defects that surfaced in the same audit; they fail differently and would need different remedies if either ever fired:

1. **`hosts/` + `relay/` fall to `quarantine-unknown`** (function loss, bytes survive): a migration parks them under `legacy/<tag>/quarantine/` where no reader resolves them — the host keeps `crons.json`, `PERSONAL_CLAUDE.md`, `pending-questions.md`, `current-track.md` as files and loses all four as *state*. Silent until something fails to fire; recoverable by hand once someone knows where to look. Fix: both dirs join `WORKSPACE_SURFACE_DIRS` with `structural` class rules (same relpath, **dest content is never lost** — the `state/auth` per-host rationale). ⚠ **Corrected 2026-08-27 (reviewer):** an earlier draft of this line said "never clobber dest", which is not what the code does. At `scripts/sutando-migrate.sh:1269` a **newer source does replace the canonical path**, after the prior destination is written to a sidecar. Nothing is lost, but the canonical file can change hands — "never clobber" overstated it.
2. **`identical-drop` keyed on mtime+size** (genuine loss, no sidecar): a structural collision between same-size/same-mtime files with *different bytes* dropped one variant from the canonical tree. ⚠ **Corrected 2026-08-27:** this line said "permanently", which overstates it — the reviewer measured `main`'s manual phase-two cleanup **failing closed** on exactly that divergent file (`deleted: 0`, `KEPT unsafe: 1`; the source remains on disk). Their measurement, not re-derived here. The defect is real and the drop is still wrong; the recovery path is better than "permanent" implied. Strictly worse than defect 1. Fix: the drop decision now requires `sha_match` (content hash) — a hash cannot be wrong where a proxy can.

## Why

`hosts/<label>/` carries the per-host `crons.json`, **`PERSONAL_CLAUDE.md`** (its canonical home), `pending-questions.md`, and `current-track.md` — and every reader resolves them at `<workspace>/hosts/<label>/…`. `relay/` holds the next session's catchup notes. Neither had a rule, so both fell to the `*|quarantine-unknown` catchall: a migration parks them under `legacy/<tag>/quarantine/` where **no reader looks** — content preserved, function silently lost. This is the same class as the `scripts/` loss fixed in #3036 (report c8310df7), reported as part of the deep-audit ticket (tk-7e767bb426 on the owner's Support board), and it feeds the PERSONAL_CLAUDE.md-loss reports: the compact-hook fix (#3396) re-injects the file, but a migration that quarantines the per-host tree removes the file the hook re-injects.

## Evidence — before at parent, after at HEAD

Parent commit (unpatched script), the new test rows fail:

```
  FAIL: hosts/Some-Host/crons.json — expected class=structural got quarantine-unknown
  FAIL: hosts/Some-Host/PERSONAL_CLAUDE.md — expected class=structural got quarantine-unknown
  FAIL: hosts/Some-Host/pending-questions.md — expected class=structural got quarantine-unknown
  FAIL: relay/relay-1787753000.md — expected class=structural got quarantine-unknown
==== TEST FAILED ====
```

HEAD:

```
  OK: hosts/Some-Host/crons.json  →  structural  (<dest>/hosts/Some-Host/crons.json)
  OK: hosts/Some-Host/PERSONAL_CLAUDE.md  →  structural  (<dest>/hosts/Some-Host/PERSONAL_CLAUDE.md)
  OK: hosts/Some-Host/pending-questions.md  →  structural  (<dest>/hosts/Some-Host/pending-questions.md)
  OK: relay/relay-1787753000.md  →  structural  (<dest>/relay/relay-1787753000.md)
==== ALL CLASS_RULES ROW ASSERTIONS PASSED ====
```

Full suites at HEAD: `tests/sutando-migrate.test.sh` → `ALL ASSERTIONS PASSED`; `sutando-migrate-argparse.test.py` + `sutando-migrate-preflight.test.sh` → `ALL TESTS PASS` (rc=0 verified directly, not via a pipe). `scripts/review-checks.sh` on the diff: hardcoded-paths + root-artifacts clean (prose-cap has no .py in scope). The live defect was also reproduced on a real path before writing the fix: `explain hosts/Qingyun-Airs-MacBook-Air/crons.json` → `quarantine-unknown` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


