### PR TITLE
fix(identity): a variant spelling of my own stand read as a peer, twice today

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -147,6 +147,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`slack_owner.py`** — Slack owner-recipient resolution helpers.
 - **`slack_proactive_receipts.py`** — Durable idempotency receipts for Slack proactive-result delivery.
 - **`sparrowd.py`** — sparrowd launcher — the adapter edge that names concrete workers.
+- **`stand_identity.py`** — Is a `Stand:` trailer mine?
 - **`startup-runtime.sh`** — Runtime/credential decisions shared by startup and behavior-level tests.
 - **`startup.sh`** — Sutando startup — starts available services + the selected core CLI.
 - **`stop.sh`** — Stop all Sutando services (shortcut for restart.sh --stop-only)

--- a/src/stand_identity.py
+++ b/src/stand_identity.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Is a `Stand:` trailer mine?
+
+Ownership was being decided by comparing a trailer against one remembered
+spelling. The fleet writes several per agent, so a variant reads as a peer and
+an agent disowns its own PR. Measured on one branch of mine: 49 commits say
+`Echo Act IV Pro` and 9 say `Sutando-Pro` — same author, same work.
+
+Authority is `hosts/<host-label>/stand-identity.json`, never recall.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_PAREN = re.compile(r"\s*\([^)]*\)\s*$")
+
+
+def _norm(s: str) -> str:
+    """Fold case, spacing and punctuation so spelling variants converge."""
+    s = _PAREN.sub("", (s or "").strip())
+    return re.sub(r"[^a-z0-9]+", "", s.lower())
+
+
+def my_stand_aliases(workspace: Path, host_label: str) -> set[str]:
+    """Every spelling of THIS host's stand, normalised."""
+    p = Path(workspace) / "hosts" / host_label / "stand-identity.json"
+    d = json.loads(p.read_text())
+    name = d["name"]
+    out = {_norm(name), _norm(d.get("machine", ""))}
+    # "Echo Act IV Pro" also ships as "Sutando-Pro"; the suffix is the node.
+    node = name.split()[-1] if name.split() else ""
+    if node:
+        out |= {_norm(node), _norm(f"Sutando-{node}")}
+    return {a for a in out if a}
+
+
+def is_my_stand(trailer: str, workspace: Path, host_label: str) -> bool:
+    """True when `trailer` names THIS host's stand in any known spelling.
+
+    A trailing parenthetical is metadata, not identity: `Sutando-Pro (principal)`
+    is the same agent as `Sutando-Pro`.
+    """
+    return _norm(trailer) in my_stand_aliases(workspace, host_label)

--- a/tests/stand-identity-aliases.test.py
+++ b/tests/stand-identity-aliases.test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""A variant spelling of my own stand must not read as a peer.
+
+The live failure: ownership compared a `Stand:` trailer against one remembered
+name, so `Sutando-Pro` and `Sutando-Pro (principal)` — both written by me —
+were filed as another agent's and two of my own PRs went unworked.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from stand_identity import is_my_stand, my_stand_aliases  # noqa: E402
+
+HOST = "Chis-MacBook-Pro"
+
+
+def _ws(name="Echo Act IV Pro", machine="macbook-pro") -> Path:
+    w = Path(tempfile.mkdtemp(prefix="stand-"))
+    d = w / "hosts" / HOST
+    d.mkdir(parents=True)
+    (d / "stand-identity.json").write_text(
+        json.dumps({"name": name, "machine": machine}))
+    return w
+
+
+class StandIdentityTest(unittest.TestCase):
+    def test_the_two_spellings_that_were_disowned_are_mine(self) -> None:
+        w = _ws()
+        for t in ("Sutando-Pro", "Sutando-Pro (principal)", "Echo Act IV Pro"):
+            with self.subTest(trailer=t):
+                self.assertTrue(is_my_stand(t, w, HOST), f"{t!r} is mine")
+
+    def test_a_peer_stand_is_not_mine(self) -> None:
+        """The check must still be able to say NO, or it certifies nothing."""
+        w = _ws()
+        for t in ("Echo Act IV Mini", "Sutando-Mini", "Sutando-rui", "PRO-ish"):
+            with self.subTest(trailer=t):
+                self.assertFalse(is_my_stand(t, w, HOST), f"{t!r} is NOT mine")
+
+    def test_identity_comes_from_disk_not_from_a_constant(self) -> None:
+        """Point it at a Mini workspace and the Pro spellings stop matching."""
+        w = _ws(name="Echo Act IV Mini", machine="mac-mini")
+        self.assertTrue(is_my_stand("Sutando-Mini", w, HOST))
+        self.assertFalse(is_my_stand("Sutando-Pro", w, HOST))
+
+    def test_aliases_are_normalised_not_literal(self) -> None:
+        w = _ws()
+        self.assertIn("sutandopro", my_stand_aliases(w, HOST))
+        self.assertTrue(is_my_stand("  sutando pro  ", w, HOST))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

Ownership was decided by comparing a `Stand:` trailer against **one remembered name**. The fleet writes several spellings per agent, so a variant reads as somebody else — and an agent disowns its own PR.

## Evidence, from my own commit history

```
49  Stand: Echo Act IV Pro
 9  Stand: Sutando-Pro
```

One branch, one author, one body of work. Both spellings are mine.

I nonetheless filed **#2133** and **#2604** under a "Sutando-Pro" heading as a peer's to push, in **two consecutive triage digests**, and did the same to **#3361** earlier off the shared `sonichi` author field. Both PRs sat unworked as a result — nothing was lost to anyone else, they simply got no action from me.

The owner flagged it as a **repeating** error, which is the accurate diagnosis. Two existing memories cover this exact shape and **neither fired either time**, so "remember harder" is demonstrably not the fix.

## The change

`is_my_stand(trailer, workspace, host_label)` resolves against `hosts/<host-label>/stand-identity.json` — authority on disk, never recall. It normalises case, spacing and punctuation, and strips a trailing parenthetical, because `Sutando-Pro (principal)` is metadata attached to an identity rather than a different identity.

## Controls

```
exact-match against the remembered name (the live defect)
    -> FAILED (failures=4), including BOTH spellings actually disowned
a Mini workspace (name = "Echo Act IV Mini")
    -> Pro spellings correctly STOP matching  (identity is read, not compiled in)
unmutated
    -> OK (4 tests)
```

**One deliberate asymmetry worth reading before approving:** `test_a_peer_stand_is_not_mine` still **passes** under the mutant. That is intentional — exact-match rejects peers perfectly well and was wrong in one direction only. The suite discriminates *that* direction rather than merely detecting that something changed.

## Scope

This adds the resolver and its test. It does **not** yet rewire `pr-digest.py`'s `actor()` to call it — `sutando-skills#433` is already open against that file and a second PR there would make a conflict pair. Wiring follows once #433 lands.

@sonichi flagging you as the merge decision, and because you're the one who caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)