### PR TITLE
ci: superseded runs were never cancelled — 21 of 22 workflows had no concurrency group

### DIFF
--- a/.github/workflows/bundle-smoke.yml
+++ b/.github/workflows/bundle-smoke.yml
@@ -26,6 +26,10 @@ on:
       - 'package-lock.json'
       - '.github/workflows/bundle-smoke.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -14,6 +14,10 @@ name: Coverage Gate
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   coverage-gate:
     name: diff coverage >= 95% (python)

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -24,6 +24,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   eslint:
     name: eslint over first-party TS + JS

--- a/.github/workflows/lint-agents-md-sync.yml
+++ b/.github/workflows/lint-agents-md-sync.yml
@@ -22,6 +22,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-agents-md-sync:
     name: refuse AGENTS.md stale vs CLAUDE.md

--- a/.github/workflows/lint-claude-home-path.yml
+++ b/.github/workflows/lint-claude-home-path.yml
@@ -17,6 +17,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-claude-home-path:
     name: refuse new inline CLAUDE_CONFIG_DIR fallback

--- a/.github/workflows/lint-hermetic-bridge-tests.yml
+++ b/.github/workflows/lint-hermetic-bridge-tests.yml
@@ -19,6 +19,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-hermetic-bridge-tests:
     name: refuse bridge tests that read host config

--- a/.github/workflows/lint-host-label.yml
+++ b/.github/workflows/lint-host-label.yml
@@ -20,6 +20,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-host-label:
     name: refuse raw hostname-slug recipe in agent docs

--- a/.github/workflows/lint-hotkey-assertions.yml
+++ b/.github/workflows/lint-hotkey-assertions.yml
@@ -17,6 +17,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-hotkey-assertions:
     name: refuse new hardcoded hotkey assertions

--- a/.github/workflows/lint-src-map.yml
+++ b/.github/workflows/lint-src-map.yml
@@ -16,6 +16,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-src-map:
     name: refuse docs/src-map.md stale vs src/

--- a/.github/workflows/lint-sutando-home-path.yml
+++ b/.github/workflows/lint-sutando-home-path.yml
@@ -18,6 +18,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-sutando-home-path:
     name: refuse new inline ~/.sutando/ install-path literal

--- a/.github/workflows/lint-workspace-resolution.yml
+++ b/.github/workflows/lint-workspace-resolution.yml
@@ -18,6 +18,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-workspace-resolution:
     name: refuse new direct workspace-path resolution

--- a/.github/workflows/python39-compat.yml
+++ b/.github/workflows/python39-compat.yml
@@ -23,6 +23,10 @@ on:
       - '.github/workflows/python39-compat.yml'
 
 # Tests must never emit product telemetry (no PostHog writes from CI).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   SUTANDO_TELEMETRY: "0"
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,6 +18,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ruff:
     name: ruff over Python sources

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -28,6 +28,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   shellcheck:
     name: shellcheck over shell scripts

--- a/.github/workflows/workspace-leak-check.yml
+++ b/.github/workflows/workspace-leak-check.yml
@@ -21,6 +21,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   workspace-leak-check:
     name: refuse workspace/ contents in commits


### PR DESCRIPTION
## The measurement

Taken live while investigating why @sonichi's PR feedback was slow:

```
29 workflow runs in flight — 29 QUEUED, 0 executing
one branch holding 14 of them
jobs that EXECUTE in under a minute, queued 24+ minutes
```

The pool was fully saturated. Nothing was slow; the queue was full of work that was obsolete when it was queued.

## The cause, exactly

**1 of 22 workflows declared a `concurrency:` group.** `ci.yml` has one and correctly cancels its own superseded runs. Every other workflow — including `coverage-gate.yml`, which is CI's critical path — had none.

So each push added a fresh queued run of all of them, and no superseded run was ever cancelled. A branch pushed 14 times has 14 live run-sets competing for the same runners, 13 of them answering a question nobody is asking any more.

This also corrects a measurement I published earlier: I had reported CI wall-clock as ~13 min, measured first-job-**start** to last-job-**end**. That excludes queue time entirely, so it described execution rather than time-to-feedback.

## The change

`ci.yml`'s own form, unchanged in shape — this is the pattern already proven in this repo, not a new idea:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**The guard is load-bearing.** `cancel-in-progress` is FALSE for anything that is not a `pull_request`, so push-to-main, tags, schedules and `workflow_run` are never cancelled mid-flight. A concurrency group without that guard is how a release gets killed halfway.

## Scope, and what I deliberately left out

15 PR-triggered workflows that lacked a group. Excluded on purpose:

| excluded | why |
|---|---|
| `publish-sparrow.yml` | Publishes to PyPI on `sparrow-v*` tags. The guard already makes tag runs uncancellable, and its PR job is a path-filtered advisory that is not part of the flood — but a **publish** workflow deserves its own decision rather than riding a sweep. |
| `cla-recheck-on-push.yml` | `pull_request_target` + `issues`, not `pull_request`. |
| `claim-machine-nightly.yml`, `regen-wire-list.yml` | `schedule` / `workflow_dispatch`. |
| `codeql.yml` | `push` + `schedule`. |
| `coverage-comment.yml` | `workflow_run` — cancelling it would drop the sticky coverage comment. |

## Verification

Purely additive: 15 files, +60/-0, no job, step, trigger or permission touched.

Every workflow re-parsed as YAML afterwards, and asserted **structurally** rather than by grepping text — that `concurrency` is a real top-level mapping key with both `group` and `cancel-in-progress` present, and that no file carries more than one block:

```
16 workflows carry exactly one well-formed concurrency block (incl. pre-existing ci.yml)
YAML: all parse OK
```

## Expected effect

This removes obsolete work from the queue, rather than making obsolete work faster. On the measurement above it is a larger lever than #3421 (which parallelises the coverage gate's execution) — the two are complementary and neither subsumes the other.

Worth stating plainly: on a fast-pushing branch this will make superseded runs disappear mid-flight. That is the intended behaviour and it will look like "my check vanished" the first time someone sees it.

@sonichi flagging you as the merge decision — you asked for this one directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
