### PR TITLE
fix(health-check): _SERVICE_SOURCES had drifted from the launchd manifest

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2827,6 +2827,10 @@ _SERVICE_SOURCES = (
     ("src/remote-gateway-bridge.py", "remote-gateway-bridge.py"),
     ("packages/ag2-sparrow/ag2_sparrow/", "remote-gateway-bridge.py"),
     ("skills/phone-conversation/scripts/conversation-server.ts", "conversation-server.ts"),
+    # KeepAlive jobs in src/launchd/ whose program SURVIVES as a process. A
+    # wrapper that `exec`s is gone from the table, so its payload's row covers it.
+    ("src/launchd/channel-bridge-wrapper.sh", "channel-bridge-wrapper.sh"),
+    ("src/Sutando/", "Sutando.app/Contents/MacOS/Sutando"),
 )
 
 

--- a/tests/service-sources-covers-launchd.test.py
+++ b/tests/service-sources-covers-launchd.test.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""_SERVICE_SOURCES must cover every persistent launchd job's program.
+
+The table is hand-maintained, so it drifts silently by construction: a job added
+to src/launchd/ with no row is invisible to check_live_checkout_branch, and the
+symptom is a service running stale source that no probe reports. This test turns
+that drift into a failing check instead of a gap nobody sees.
+
+Scope is deliberately KeepAlive jobs only. A StartInterval job is short-lived, so
+`pgrep` for it succeeds or fails depending on when the probe happens to run, and a
+row for one would report staleness nondeterministically.
+"""
+
+import importlib.util
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+failures = []
+checked = 0
+
+
+def check(label, ok, detail=""):
+    global checked
+    checked += 1
+    if ok:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}: {detail}")
+        failures.append(label)
+
+
+def load_table():
+    spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod._SERVICE_SOURCES
+
+
+def parse_plist(path):
+    """plistlib where it works, plutil where it does not, None when neither does.
+
+    Homebrew pythons here raise on the pyexpat import and some shipped templates
+    carry `--` inside an XML comment, which is valid to launchd but not to expat.
+    """
+    raw = re.sub(rb"<!--.*?-->", b"", path.read_bytes(), flags=re.S)
+    try:
+        import plistlib
+
+        return plistlib.loads(raw)
+    except Exception:
+        pass
+    try:
+        out = subprocess.run(
+            ["/usr/bin/plutil", "-convert", "json", "-o", "-", str(path)],
+            capture_output=True, text=True, timeout=10,
+        )
+        if out.returncode == 0:
+            return json.loads(out.stdout)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        pass
+    return None
+
+
+def program_path(data):
+    """Repo-relative path of the program this job runs, or None."""
+    args = data.get("ProgramArguments") or [data.get("Program", "")]
+    for arg in (str(a) for a in args):
+        if "__REPO__/" in arg:
+            return arg.split("__REPO__/", 1)[1]
+    return None
+
+
+def covered(rel, table):
+    for src, _pattern in table:
+        if rel == src or (src.endswith("/") and rel.startswith(src)):
+            return src
+    return None
+
+
+table = load_table()
+plists = sorted((REPO / "src" / "launchd").glob("*.plist"))
+
+# A glob that matches nothing would make every assertion below vacuously true,
+# which is the failure this file exists to prevent, turned on itself.
+check("found launchd plists to check", len(plists) >= 4, f"only {len(plists)}")
+
+def execs_away(rel):
+    """True when the program replaces itself, leaving no process to pgrep for."""
+    path = REPO / rel
+    if path.suffix != ".sh" or not path.is_file():
+        return False
+    return any(
+        re.match(r"\s*exec\s", line)
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+    )
+
+
+unparseable = []
+for plist in plists:
+    data = parse_plist(plist)
+    if data is None:
+        unparseable.append(plist.name)
+        continue
+    if not data.get("KeepAlive"):
+        continue
+    rel = program_path(data)
+    if rel is None:
+        continue
+    if execs_away(rel):
+        # The row would never match, and an unmatchable row reads as coverage.
+        check(
+            f"{plist.stem} execs away, so {rel} correctly has no row",
+            covered(rel, table) is None,
+            "this wrapper `exec`s into its payload, so its own path leaves the "
+            "process table — a pgrep row for it can never match, and an "
+            "unmatchable row looks identical to a covered service",
+        )
+        continue
+    check(
+        f"{plist.stem} -> {rel} has a _SERVICE_SOURCES row",
+        covered(rel, table) is not None,
+        "no row covers it, so staleness in this program is invisible to "
+        "check_live_checkout_branch",
+    )
+
+# Skipping silently would let a parser regression read as full coverage.
+check(
+    "every plist was parseable",
+    not unparseable,
+    f"could not parse: {', '.join(unparseable)} (no plistlib and no plutil?)",
+)
+
+# Guards the exclusion rule itself: if someone adds a row for a periodic job the
+# reason above stops holding, and this says so rather than letting it rot.
+for plist in plists:
+    data = parse_plist(plist)
+    if data is None or data.get("KeepAlive") or not data.get("StartInterval"):
+        continue
+    rel = program_path(data)
+    if rel is None:
+        continue
+    check(
+        f"{plist.stem} is periodic and correctly has no row",
+        covered(rel, table) is None,
+        f"{rel} is StartInterval={data['StartInterval']} — a pgrep for it is a "
+        "coin flip, so the row would report staleness nondeterministically",
+    )
+
+print(f"\n{checked - len(failures)}/{checked} passed")
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Why

`check_live_checkout_branch` warns when the live checkout is behind `origin/main` **and** a behind-commit touches source backing a running service. It decides "backing a running service" from `_SERVICE_SOURCES`, a hand-maintained table.

Two persistent launchd jobs had no row. A behind-commit touching either was invisible — the service ran stale source and no probe said so. One is `channel-bridge-wrapper.sh`, the supervisor for Slack, Discord and Telegram.

This is not hypothetical for that file: #3361 fixed a bug in it, and while the checkout was behind, nothing could report that the running supervisor lacked the fix. `check_live_checkout_branch` compares a process against the file **on disk**, and while the checkout is behind, those agree exactly.

## The part that changed the patch

My first cut added four rows — every KeepAlive job's program. Two of them would have been **inert**:

```
credential-proxy-wrapper.sh:132   exec "$NODE_BIN" "$DIST_PROXY"
gateway-bridge-wrapper.sh:80      exec python3 "$REPO/src/remote-gateway-bridge.py"
```

A wrapper that `exec`s replaces itself. Its path is gone from the process table, so `pgrep -f credential-proxy-wrapper.sh` can never match and the row can never fire. Ground truth on this host:

```
$ ps -eo command | grep -c 'launchd/[a-z-]*wrapper\.sh'
0
```

That zero is weak evidence on its own, because on this host `com.sutando.channel-bridge` is not loaded — so "absent because it `exec`s" and "absent because the job isn't running" look identical. Sutando-Pro supplied the discriminating measurement from a host where those two jobs **are** loaded:

```
com.sutando.credential-proxy   LOADED (pid 65438)   wrapper in process table: NO
com.sutando.gateway-bridge     LOADED (pid 66180)   wrapper in process table: NO
com.sutando.channel-bridge     not loaded as a job  wrapper in process table: YES x3
```

Loaded and still absent is the case that settles it. Measured on that host, not this one.

An unmatchable row is worse than a missing one: it reads as coverage. Both are dropped, and their payloads are already covered (`src/remote-gateway-bridge.py` is an existing row). The test now pins that exemption so the rows cannot creep back.

## Scope

| job | KeepAlive | row | why |
|---|---|---|---|
| `channel-bridge` | yes | **added** | wrapper survives as parent — no `exec` |
| `menubar` | yes | **added** | the `.app` binary is the process; `src/Sutando/` prefix row |
| `credential-proxy` | yes | none | `exec`s away — a row could never match |
| `gateway-bridge` | yes | none | `exec`s away; payload already covered |
| `cron-runner` | no (`StartInterval=60`) | none | short-lived; a pgrep for it is a coin flip |
| `health-check-fallback` | no (`StartInterval=300`) | none | same |

## Evidence

At HEAD:

```
8/8 passed
rc=0
```

Control — drop the `channel-bridge` row and restore the two exec'ing rows, i.e. the exact state this PR corrects:

```
FAIL com.sutando.channel-bridge -> src/launchd/channel-bridge-wrapper.sh has a _SERVICE_SOURCES row
FAIL com.sutando.credential-proxy execs away, so .../credential-proxy-wrapper.sh correctly has no row
FAIL com.sutando.gateway-bridge  execs away, so .../gateway-bridge-wrapper.sh correctly has no row
5/8 passed   rc=1
```

Three failures, not one — the test catches **inert** rows as well as **missing** ones, in both directions.

The test also fails rather than passing vacuously if the plist glob matches nothing, and fails if any plist is unparseable (Homebrew pythons here raise on the `pyexpat` import, and a shipped template carries `--` inside an XML comment, so it falls back to `plutil` and reports rather than silently skipping).

## What this does not fix

`src/single_instance.py` — the other file #3361 touched — is still invisible, and a row will not fix it. `_behind_commits_changing` diffs against the **paths** in `live_sources`, so being imported by `discord-bridge.py` never pulls it in. That needs an import closure, which is a separate change. Credit to Sutando-Pro for the sequencing argument: shipping the closure first would have left the wrapper uncovered while reading as a complete fix, and for the observation that a closure automates the table's *transitive* reach while leaving its *roots* manual — the roots being the half that actually rotted here.

@sonichi flagging you as the merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

