### PR TITLE
fix(gateway): default lane skips foreign-suffix rooms it cannot deliver to

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -214,13 +214,20 @@ if GATEWAY_INSTANCE and not _INSTANCE_RE.fullmatch(GATEWAY_INSTANCE):
 _INST_SUFFIX = f".{GATEWAY_INSTANCE}" if GATEWAY_INSTANCE else ""
 # Optional fence for instanced lanes: claim only rooms on this suffix
 GATEWAY_ROOM_SUFFIX = (os.environ.get("GATEWAY_ROOM_SUFFIX") or "").strip()
+# Rooms on these suffixes belong to a foreign lane; the default lane's gateway
+# 403s them, and the failure policy then parks deliverable work as undeliverable.
+GATEWAY_FOREIGN_SUFFIXES = tuple(
+    s.strip() for s in (os.environ.get("GATEWAY_FOREIGN_SUFFIXES") or "").split(",")
+    if s.strip())
 
 
 def _instance_may_claim(peek_room: "str | None") -> bool:
     """Unaddressed proactives default to the owner's primary surface, which
     only the DEFAULT lane serves — an instanced lane must never claim them."""
     if not GATEWAY_INSTANCE:
-        return True
+        if peek_room is None:
+            return True
+        return not any(peek_room.endswith(s) for s in GATEWAY_FOREIGN_SUFFIXES)
     if peek_room is None:
         return False
     return not GATEWAY_ROOM_SUFFIX or peek_room.endswith(GATEWAY_ROOM_SUFFIX)

--- a/tests/bridge-proactive-instance-scope.test.py
+++ b/tests/bridge-proactive-instance-scope.test.py
@@ -17,6 +17,7 @@ class InstanceScope(unittest.TestCase):
     def tearDown(self):
         rgb.GATEWAY_INSTANCE = ""
         rgb.GATEWAY_ROOM_SUFFIX = ""
+        rgb.GATEWAY_FOREIGN_SUFFIXES = ()
 
     def test_default_lane_claims_everything(self):
         rgb.GATEWAY_INSTANCE = ""
@@ -37,6 +38,32 @@ class InstanceScope(unittest.TestCase):
         self.assertTrue(rgb._instance_may_claim("!r:dev.ag2.space"))
         self.assertFalse(rgb._instance_may_claim("!r:ag2.space"))
         self.assertFalse(rgb._instance_may_claim(None))
+
+    def test_default_lane_skips_foreign_suffix_rooms(self):
+        rgb.GATEWAY_INSTANCE = ""
+        rgb.GATEWAY_FOREIGN_SUFFIXES = (":dev.ag2.space",)
+        self.assertFalse(rgb._instance_may_claim("!r:dev.ag2.space"))
+        self.assertTrue(rgb._instance_may_claim("!r:ag2.space"))
+        self.assertTrue(rgb._instance_may_claim(None))
+
+    def test_default_lane_without_config_claims_everything(self):
+        rgb.GATEWAY_INSTANCE = ""
+        rgb.GATEWAY_FOREIGN_SUFFIXES = ()
+        self.assertTrue(rgb._instance_may_claim("!r:dev.ag2.space"))
+
+    def test_foreign_suffixes_env_parsing(self):
+        # exercises the module's own env read, not a copy of it
+        import importlib
+        import os
+        os.environ["GATEWAY_FOREIGN_SUFFIXES"] = " :dev.ag2.space , :stage.ag2.space ,"
+        try:
+            m = importlib.reload(rgb)
+            self.assertEqual(
+                m.GATEWAY_FOREIGN_SUFFIXES, (":dev.ag2.space", ":stage.ag2.space"))
+            self.assertFalse(m._instance_may_claim("!r:stage.ag2.space"))
+        finally:
+            del os.environ["GATEWAY_FOREIGN_SUFFIXES"]
+            importlib.reload(rgb)
 
     def test_claim_loop_calls_the_predicate(self):
         # wiring pin: the pre-claim gate must consult the predicate


### PR DESCRIPTION
## What

The default (unsuffixed) gateway lane's `_instance_may_claim` returned `True` unconditionally (`remote_gateway_bridge.py:222`), so a `[channel: !X:dev.ag2.space]` proactive was claimed by the prod lane, 403'd at the prod gateway, and parked to `results/undelivered/` by the 4xx failure policy — deliverable work lost to the wrong lane. Latent today (dev-room proactives are rare) but grows with dev-lane use now that both lanes run continuously.

Fix: new `GATEWAY_FOREIGN_SUFFIXES` env (comma-separated, e.g. `:dev.ag2.space`) — suffixes the default lane must leave to their own lane. Symmetric with the instanced lane's existing `GATEWAY_ROOM_SUFFIX` fence. Unaddressed proactives (`peek_room is None`) stay with the default lane, unchanged. Unconfigured (empty env) behavior is byte-identical to today.

## Before/after (actual output)

At parent `b923a791`:
```
default lane claims !r:dev.ag2.space -> True
```
At head `8cf30781` with `GATEWAY_FOREIGN_SUFFIXES=:dev.ag2.space`:
```
default lane claims !r:dev.ag2.space -> False
default lane claims !r:ag2.space    -> True
default lane claims unaddressed     -> True
```

## Tests

`tests/bridge-proactive-instance-scope.test.py` extended (8/8 OK): default lane skips a foreign-suffix room / still claims own-suffix + unaddressed; unconfigured default lane unchanged; env parsing exercised via module reload (shipped path, not a copied recipe). Adjacent suites green: `ag2-sparrow-drift`, `gateway-destined-proactive-not-claimed`, `gateway-dedup-recovery`. `scripts/review-checks.sh --diff` rc=0.

## Deploy note (live path)

Config-gated: inert until the prod launcher sets `GATEWAY_FOREIGN_SUFFIXES=:dev.ag2.space`. Plan: set the env in the tracked launcher config and pick it up on the already-pending owner-attended prod bounce #2 (the #3408 exact-head witness leg) — one restart serves both. Post-restart round-trip evidence will be added then; not claiming live verification yet.

## Stack

Based on `feat/sutando-server` (parent of the lane-scoping work, #3408 lineage). Merge into that branch, not main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)