### PR TITLE
fix(health-check): the stale-deadline guard sampled the burst it was meant to detect

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2145,17 +2145,19 @@ def _index_growth_note(index: Path, effective_bytes: int) -> str:
             note += (f"; +{grew:,} B over the last {hours:.1f}h"
                      + (f", which is ~{left / rate:.1f}h of remaining headroom at that rate"
                         if rate > 0 and left > 0 else ""))
-            # The max window is the worst case, so `gain <= 0` skips every flat one
-            # and a quoted deadline outlives its regime. Report the recent window too.
-            recent = next(((at, sz) for at, sz in reversed(points)
-                           if (newest_at - at) / 3600.0 >= 0.5), None)
-            if recent is not None:
-                r_span = (newest_at - recent[0]) / 3600.0
-                r_gain = effective_bytes - recent[1]
-                if r_gain <= 0:
-                    note += (f"; but the last {r_span:.1f}h show {r_gain:+,} B — flat or "
+            # A stopped climb reads flat in the RECENT window; a burst on a flat
+            # run reads flat over the FULL history. Neither window sees both.
+            controls = [c for c in (next(((at, sz) for at, sz in reversed(points)
+                                          if (newest_at - at) / 3600.0 >= 0.5), None),
+                                    points[0]) if c is not None]
+            for c_at, c_sz in controls:
+                c_span = (newest_at - c_at) / 3600.0
+                c_gain = effective_bytes - c_sz
+                if c_span >= 0.5 and c_gain <= 0:
+                    note += (f"; but the last {c_span:.1f}h show {c_gain:+,} B — flat or "
                              f"shrinking, so the figure above spans a change in write rate "
                              f"and its deadline is stale; re-measure before acting on it")
+                    break
         return note
     except (GitUnavailable, OSError, subprocess.SubprocessError, ValueError):
         return _TREND_UNAVAILABLE

--- a/tests/health-check-memory-index-trend.test.py
+++ b/tests/health-check-memory-index-trend.test.py
@@ -345,5 +345,37 @@ class HistoricalBytesUseTheSAMEUnitsAsTheLimit(unittest.TestCase):
         self.assertNotIn("came within", note)
 
 
+class StaleDeadlineGuardCanActuallyFire(unittest.TestCase):
+    """The guard that says "this deadline is stale" must sample the FULL history.
+
+    It used to take the newest point >=0.5h back — the SHORTEST qualifying
+    window. But a short window with a gain is exactly what maximises gain/span
+    and wins `best_rate`, so the control was reading the same burst it was
+    meant to detect, and stayed silent in the one case it was written for.
+    Measured live 2026-08-26: the probe quoted "+146 B over 2.0h -> 17.7h of
+    remaining headroom" while the file's 224h history was net -102 B.
+    """
+
+    def test_recent_burst_on_a_flat_history_is_reported_as_stale(self):
+        m = _hc()
+        with tempfile.TemporaryDirectory() as td:
+            # net -110 B across the window, with a +146 B burst in the last hour
+            idx = _repo_with_sizes(Path(td), [23800, 23700, 23600, 23550, 23544, 23690])
+            note = m._index_growth_note(idx, 23690)
+        # the max window still quotes its deadline...
+        self.assertIn("of remaining headroom at that rate", note)
+        # ...and the control now contradicts it, which is the whole point
+        self.assertIn("deadline is stale", note)
+        self.assertIn("-110", note)
+
+    def test_sustained_growth_is_not_called_stale(self):
+        m = _hc()
+        with tempfile.TemporaryDirectory() as td:
+            idx = _repo_with_sizes(Path(td), [23000, 23150, 23300, 23450, 23600, 23690])
+            note = m._index_growth_note(idx, 23690)
+        self.assertIn("of remaining headroom at that rate", note)
+        self.assertNotIn("deadline is stale", note)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The defect

`_index_growth_note` quotes a deadline off the **fastest sustained climb** (a max over every start point — deliberate, so a compaction cannot hide a climb). It then adds a control that is supposed to say *"that regime has ended, re-measure"*.

That control took the newest point `>= 0.5h` back — the **shortest** qualifying window:

```python
recent = next(((at, sz) for at, sz in reversed(points)
               if (newest_at - at) / 3600.0 >= 0.5), None)
r_gain = effective_bytes - recent[1]
if r_gain <= 0:      # only speaks when flat or shrinking
```

A short window carrying a gain is precisely what maximises `gain/span` and wins `best_rate`. So `recent` is typically the *same* point the max selected, `r_gain == grew > 0` by construction, and the guard cannot fire in the case it was written for.

## Why it matters (measured live, 2026-08-26)

The probe told two separate sessions:

```
+146 B over the last 2.0h, which is ~17.7h of remaining headroom at that rate — compact it now
```

while `MEMORY.md`'s own 224.4h history over 25 revisions was net **−102 B**. Both sessions opened an investigation into a deadline that did not exist.

## Why swapping the window is NOT the fix

My first attempt pointed the control at the full history. That passes the new case and **breaks the existing one** — it moves the blind spot rather than closing it. The two regimes need opposite windows:

| regime | recent window | full history |
|---|---|---|
| a climb that **stopped** | flat ✅ detects | shows growth ❌ blind |
| a **burst** on a flat run | shows growth ❌ blind | flat ✅ detects |

So the fix checks **both** and reports whichever contradicts the quoted deadline.

## Evidence

Same three fixtures, parent vs HEAD (`_index_growth_note` called directly):

```
=== PARENT (origin/main) ===
  burst-on-flat    '; +146 B over the last 1.0h, which is ~9.0h of remaining headroom at that rate'
  stopped-climb    '; +1,600 B over the last 4.0h ... ; but the last 1.0h show -200 B — ... deadline is stale ...'
  sustained        '; +690 B over the last 5.0h, which is ~9.5h of remaining headroom at that rate'

=== HEAD ===
  burst-on-flat    '; +146 B over the last 1.0h, ... ; but the last 5.0h show -110 B — ... deadline is stale ...'
  stopped-climb    '; +1,600 B over the last 4.0h ... ; but the last 1.0h show -200 B — ... deadline is stale ...'
  sustained        '; +690 B over the last 5.0h, which is ~9.5h of remaining headroom at that rate'
```

`stopped-climb` and `sustained` are unchanged — the first is the regime the existing test pins, the second is the negative control.

Suite, both directions:

```
=== PARENT ===
FAIL: test_recent_burst_on_a_flat_history_is_reported_as_stale
AssertionError: 'deadline is stale' not found in
  '; +146 B over the last 1.0h, which is ~9.0h of remaining headroom at that rate'
Ran 19 tests
FAILED (failures=1)

=== HEAD ===
Ran 19 tests
OK
```

## Note on the test count

The two new cases were initially appended **below** the file's `if __name__ == "__main__": unittest.main()`, so they were never defined and never collected — the suite reported `Ran 17 ... OK` identically at parent and HEAD, green for the wrong reason. Baseline is 17; with the cases lifted above the entrypoint it is 19. Flagging it because a reader checking only the final numbers would not see that step.

## Scope

`src/health-check.py` — one guard, plus two cases in the existing trend test. No behavior change to the level or the quoted deadline itself; only the caveat that qualifies it.

@sonichi flagging you — this is a probe that has been costing sessions real time today.
