### PR TITLE
fix(agent-api): gate GET /result/<id> on the API token

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -854,13 +854,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.send_json(*delegation_read_result(
                     unquote(path[len("/delegation/results/"):])))
         elif path.startswith("/result/"):
-            # Result bodies are owner data, so the poll leg is gated exactly
-            # like the write leg it belongs to (POST /task): the token is
-            # checked when one is configured, and a core with none stays open
-            # for local use. NOT the delegation posture above — those refuse
-            # outright without a token because remote submission is
-            # full-capability delegation; /result is polled by the same
-            # local clients that POST /task, so it keeps /task's default.
+            # Owner data: gated like the write leg it belongs to (POST /task) —
+            # token checked when configured. NOT delegation's refuse-outright.
             if not self.check_auth():
                 return
             task_id = path[len("/result/"):]

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -854,6 +854,15 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.send_json(*delegation_read_result(
                     unquote(path[len("/delegation/results/"):])))
         elif path.startswith("/result/"):
+            # Result bodies are owner data, so the poll leg is gated exactly
+            # like the write leg it belongs to (POST /task): the token is
+            # checked when one is configured, and a core with none stays open
+            # for local use. NOT the delegation posture above — those refuse
+            # outright without a token because remote submission is
+            # full-capability delegation; /result is polled by the same
+            # local clients that POST /task, so it keeps /task's default.
+            if not self.check_auth():
+                return
             task_id = path[len("/result/"):]
             result = get_task_result(task_id)
             if result:

--- a/tests/agent-api-result-auth.test.py
+++ b/tests/agent-api-result-auth.test.py
@@ -51,10 +51,8 @@ SECRET_BODY = "the owner's private answer\n"
 (api.RESULT_DIR / "task-owner-1.txt").write_text(SECRET_BODY)
 (api.TASK_DIR / "task-pending-1.txt").write_text("id: task-pending-1\ntask: still running\n")
 
-# Handler runs on the MAIN thread (plain HTTPServer + handle_request loop);
-# requests are issued from a worker thread. Inverted on purpose: the coverage
-# gate's tracer misses handler-THREAD execution, so serving on the main
-# thread is what makes the dispatch lines measurable.
+# Handler on the MAIN thread, requests from a worker: inverted on purpose, the
+# coverage tracer misses handler-THREAD execution so dispatch would read as 0.
 server = http.server.HTTPServer(("127.0.0.1", 0), api.Handler)
 server.timeout = 0.5
 port = server.server_address[1]
@@ -79,9 +77,8 @@ def _raw_req(method, path, body=None, token="test-token-123"):
         with urllib.request.urlopen(r, timeout=10) as resp:
             return resp.status, resp.read().decode()
     except urllib.error.HTTPError as e:
-        # The server may close the socket right after an error response;
-        # reading the body can hit ECONNRESET — the status code is what the
-        # assertions need, so treat the body as best-effort.
+        # The socket may close right after an error response (ECONNRESET), and
+        # only the status is asserted — so the body read is best-effort.
         try:
             payload = e.read().decode()
         except Exception:

--- a/tests/agent-api-result-auth.test.py
+++ b/tests/agent-api-result-auth.test.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""E2E test for token auth on GET /result/<id> on agent-api (T2.6) — run
+against a REAL HTTP server on an ephemeral port with the module's dirs
+patched to a temp workspace.
+
+Result bodies are owner data, so the poll leg is gated exactly like the write
+leg it belongs to (POST /task): bearer-checked when SUTANDO_API_TOKEN is
+configured, open when it is not (the documented local-dev default). This is
+deliberately NOT the /delegation/* posture, which refuses outright with no
+token configured — that stricter shape is for full-capability remote
+delegation, and the same local clients that POST /task poll /result.
+
+Covers: token configured — missing bearer is 401, wrong bearer is 401, the
+result body does not leak on either, correct bearer reads completed/pending/
+404 as before; no token configured — every one of those is unchanged; and
+POST /task's own gate is untouched in both modes.
+
+Run: python3 tests/agent-api-result-auth.test.py
+"""
+import http.server
+import importlib.util
+import json
+import sys
+import tempfile
+import threading
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+api = _load("agent_api", REPO / "src" / "agent-api.py")
+
+tmp = Path(tempfile.mkdtemp(prefix="result-auth-e2e-"))
+api.TASK_DIR = tmp / "tasks"
+api.RESULT_DIR = tmp / "results"
+api.TASK_DIR.mkdir()
+api.RESULT_DIR.mkdir()
+api.API_TOKEN = "test-token-123"
+
+SECRET_BODY = "the owner's private answer\n"
+(api.RESULT_DIR / "task-owner-1.txt").write_text(SECRET_BODY)
+(api.TASK_DIR / "task-pending-1.txt").write_text("id: task-pending-1\ntask: still running\n")
+
+# Handler runs on the MAIN thread (plain HTTPServer + handle_request loop);
+# requests are issued from a worker thread. Inverted on purpose: the coverage
+# gate's tracer misses handler-THREAD execution, so serving on the main
+# thread is what makes the dispatch lines measurable.
+server = http.server.HTTPServer(("127.0.0.1", 0), api.Handler)
+server.timeout = 0.5
+port = server.server_address[1]
+BASE = f"http://127.0.0.1:{port}"
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def _raw_req(method, path, body=None, token="test-token-123"):
+    r = urllib.request.Request(f"{BASE}{path}", method=method,
+                               data=None if body is None else json.dumps(body).encode())
+    if token:
+        r.add_header("Authorization", f"Bearer {token}")
+    r.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(r, timeout=10) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as e:
+        # The server may close the socket right after an error response;
+        # reading the body can hit ECONNRESET — the status code is what the
+        # assertions need, so treat the body as best-effort.
+        try:
+            payload = e.read().decode()
+        except Exception:
+            payload = ""
+        return e.code, payload
+    except Exception as e:  # connection-level failure — surface it as a check failure
+        return -1, repr(e)
+
+
+def req(method, path, body=None, token="test-token-123"):
+    """Issue the request from a worker thread while the MAIN thread serves it."""
+    out = {}
+    t = threading.Thread(target=lambda: out.update(
+        zip(("code", "raw"), _raw_req(method, path, body, token))), daemon=True)
+    t.start()
+    while t.is_alive():
+        server.handle_request()   # serve on the main thread (traced)
+    t.join()
+    try:
+        data = json.loads(out["raw"] or "{}")
+    except ValueError:
+        data = {}
+    return out["code"], data, out["raw"]
+
+
+# ── 1. Token configured: /result demands the bearer ──────────────────────────
+code, data, raw = req("GET", "/result/task-owner-1", token=None)
+check("no bearer on /result rejected (401)", code == 401, str(data))
+check("401 body does not leak the result", SECRET_BODY.strip() not in raw, raw[:120])
+
+code, data, raw = req("GET", "/result/task-owner-1", token="wrong")
+check("wrong bearer on /result rejected (401)", code == 401, str(data))
+check("wrong-bearer body does not leak the result", SECRET_BODY.strip() not in raw, raw[:120])
+
+# ── 2. Token configured: the authenticated poll is unchanged ─────────────────
+code, data, _ = req("GET", "/result/task-owner-1")
+check("authenticated /result returns the completed result",
+      code == 200 and data.get("status") == "completed" and data.get("result") == SECRET_BODY,
+      str(data))
+
+code, data, _ = req("GET", "/result/task-pending-1")
+check("authenticated /result reports a pending task",
+      code == 200 and data.get("status") == "pending", str(data))
+
+code, data, _ = req("GET", "/result/task-nonexistent-99999")
+check("authenticated /result 404s an unknown id", code == 404, str(data))
+
+# ── 3. Token configured: POST /task's existing behaviour is untouched ────────
+code, data, _ = req("POST", "/task", {"from": "agent-2", "task": "research the thing"}, token=None)
+check("POST /task still rejects a missing bearer (401)", code == 401, str(data))
+check("rejected POST /task wrote no task file",
+      not [p for p in api.TASK_DIR.glob("task-*.txt") if "research the thing" in p.read_text()])
+
+code, data, _ = req("POST", "/task", {"from": "agent-2", "task": "research the thing"})
+check("authenticated POST /task still accepted",
+      code == 200 and data.get("ok") is True, str(data))
+submitted_id = data.get("task_id", "")
+check("POST /task wrote a source: api task file",
+      bool(submitted_id) and "source: api" in (api.TASK_DIR / f"{submitted_id}.txt").read_text())
+# The advertised result_url is now on the same gate as the submit that minted it.
+code, data, _ = req("GET", data.get("result_url", "/result/missing"))
+check("the advertised result_url polls under the same token",
+      code == 200 and data.get("status") == "pending", str(data))
+
+# ── 4. No token configured: the local-dev default is unchanged ───────────────
+api.API_TOKEN = ""
+
+code, data, _ = req("GET", "/result/task-owner-1", token=None)
+check("tokenless core still serves /result unauthenticated",
+      code == 200 and data.get("result") == SECRET_BODY, str(data))
+
+code, data, _ = req("GET", "/result/task-pending-1", token=None)
+check("tokenless core still reports pending", code == 200 and data.get("status") == "pending", str(data))
+
+code, data, _ = req("GET", "/result/task-nonexistent-99999", token=None)
+check("tokenless core still 404s an unknown id", code == 404, str(data))
+
+code, data, _ = req("POST", "/task", {"from": "agent-2", "task": "tokenless submit"}, token=None)
+check("tokenless core still accepts POST /task",
+      code == 200 and data.get("ok") is True, str(data))
+code, data, _ = req("GET", data.get("result_url", "/result/missing"), token=None)
+check("tokenless submit → poll round-trip unchanged",
+      code == 200 and data.get("status") == "pending", str(data))
+
+server.server_close()
+
+if failures:
+    sys.exit(1)
+print("PASS — GET /result token auth")


### PR DESCRIPTION
`POST /task` is gated by `check_auth()`; the `GET /result/<id>` poll that reads the task's output back was not. Result bodies are owner data, so the read leg is now gated exactly like the write leg it belongs to.

## Why `POST /task`'s posture, not the delegation one

All three were read before choosing:

- `check_auth()` returns `True` when `API_TOKEN` is empty; `POST /task` calls it bare.
- `/delegation/*` adds a prior `if not API_TOKEN: 403`, and its own comment says why — *"remote submission is full-capability delegation, so a core with no API_TOKEN configured refuses (unlike the local-dev default elsewhere in this file)"*.

A delegation bearer can submit an arbitrary pre-serialized task file and archive results. `/result` only reads back a result for an id the caller already knows. Adopting the 403 would also break the tokenless local-dev default this file documents and that both in-repo web callers depend on.

## No in-repo caller breaks

Two exist — `src/chat-ui.ts:386` and `src/web-client.ts:2960` — and both send no `Authorization` header. But both reach `/result` only after their own `POST /task` (`chat-ui.ts:375`, `web-client.ts:2953`), which is **already** gated. So with a token configured they never obtain a `task_id` to poll (already broken at the submit leg, unchanged by this); without one, `check_auth()` passes them through exactly as before. There is no token-injecting proxy in front of :7843 — `dashboard.py:710` is a hyperlink, and `task-bridge.ts`/`discord-bridge.py` call `/task-done`, which is already gated.

Two non-callers touch the path and are unaffected: `scripts/poc-codeql-path-injection.sh` and `skills/self-upgrade/SKILL.md:63` (prose pairing a `POST /task` with a `GET /result/<id>` — symmetric under the new gate).

The module docstring is left alone: it annotates a route "authenticated" only where the gate is *stricter* than the file default. `POST /task` carries no such annotation, so `/result` matching it should carry none either.

## Tests

`tests/agent-api-result-auth.test.py` — 17 checks, auto-discovered by `npm run test:py`.

**Token configured:** bearer-less `/result` is 401 and the body does not leak the result; a wrong bearer is 401, same non-leak; the correct bearer still reads `completed`, still reads `pending`, still 404s an unknown id; the `result_url` that `POST /task` advertises polls under that same token.
**No token configured:** unauthenticated `/result` still returns the body, still reports pending, still 404s.
**`POST /task` untouched in both modes.**

The four new-behaviour checks fail against the unpatched `src/agent-api.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)