### PR TITLE
fix(bridge-wrapper): rate-limit the restart alert — 945 owner notifications in 5 days

### DIFF
--- a/src/launchd/channel-bridge-wrapper.sh
+++ b/src/launchd/channel-bridge-wrapper.sh
@@ -71,12 +71,46 @@ WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
 STATE_DIR="$WORKSPACE/state/channel-bridge-supervisor"
 mkdir -p "$STATE_DIR" "$WORKSPACE/results"
 MARKER="$STATE_DIR/$CHANNEL.started"
+# One alert per flap EPISODE, plus one escalation per window. Unbounded alerting
+# turned a crashloop into ~945 owner DMs in five days, which retires the alert.
+FLAP_STATE="$STATE_DIR/$CHANNEL.flap"
+FLAP_QUIET="${SUTANDO_CHANNEL_BRIDGE_FLAP_QUIET:-900}"
+FLAP_ESCALATE="${SUTANDO_CHANNEL_BRIDGE_FLAP_ESCALATE:-1800}"
+
+_deliver_alert() {
+  # Unique or a same-second pair silently overwrites: one alert would be LOST.
+  _i=0
+  while :; do
+    RESULT="$WORKSPACE/results/proactive-$CHANNEL-bridge-restarted-$(date +%s)-$$-$_i.txt"
+    [ -e "$RESULT" ] || break
+    _i="$((_i + 1))"
+  done
+  printf '%s\n' "$1" > "$RESULT"
+  osascript -e "display notification \"$1\" with title \"Sutando\"" >/dev/null 2>&1 || true
+}
+
 emit_restart_alert() {
   NOW="$(date +%s)"
-  RESULT="$WORKSPACE/results/proactive-$CHANNEL-bridge-restarted-$NOW.txt"
+  # stderr is per-restart and unthrottled on purpose: the log keeps every event,
+  # only the owner-facing channel is rate limited.
   echo "[$CHANNEL-bridge-wrapper] previous process exited; automatically restarting" >&2
-  printf '%s\n' "⚠️ The $CHANNEL bridge exited and was automatically restarted." > "$RESULT"
-  osascript -e "display notification \"The $CHANNEL bridge exited and was automatically restarted.\" with title \"Sutando\"" >/dev/null 2>&1 || true
+  _first=0; _count=0; _lastr=0; _lasta=0
+  if [ -f "$FLAP_STATE" ]; then
+    read -r _first _count _lastr _lasta < "$FLAP_STATE" 2>/dev/null || true
+  fi
+  case "$_first$_count$_lastr$_lasta" in *[!0-9]*|"") _first=0; _count=0; _lastr=0; _lasta=0;; esac
+  if [ "$_lastr" -eq 0 ] || [ "$((NOW - _lastr))" -ge "$FLAP_QUIET" ]; then
+    printf '%s %s %s %s\n' "$NOW" 1 "$NOW" "$NOW" > "$FLAP_STATE"
+    _deliver_alert "⚠️ The $CHANNEL bridge exited and was automatically restarted."
+    return
+  fi
+  _count="$((_count + 1))"
+  if [ "$((NOW - _lasta))" -ge "$FLAP_ESCALATE" ]; then
+    printf '%s %s %s %s\n' "$_first" "$_count" "$NOW" "$NOW" > "$FLAP_STATE"
+    _deliver_alert "⚠️ The $CHANNEL bridge is FLAPPING — $_count restarts over $(( (NOW - _first) / 60 )) min. It is not recovering on its own."
+    return
+  fi
+  printf '%s %s %s %s\n' "$_first" "$_count" "$NOW" "$_lasta" > "$FLAP_STATE"
 }
 if [ -f "$MARKER" ]; then emit_restart_alert; fi
 date +%s > "$MARKER"

--- a/tests/channel-bridge-restart-alert-rate-limit.test.sh
+++ b/tests/channel-bridge-restart-alert-rate-limit.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# 50 restarts must not produce 50 owner alerts. Before the rate limit they did:
+# ~945 alerts in five days retired the alert entirely.
+set -u
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export WORKSPACE="$TMP/ws"; STATE_DIR="$WORKSPACE/state/channel-bridge-supervisor"
+mkdir -p "$STATE_DIR" "$WORKSPACE/results"
+CHANNEL=testchan
+# Load only the alerting block, with osascript stubbed out.
+osascript() { :; }
+# Extract through the END of emit_restart_alert (the 2nd column-0 brace), not the 1st.
+BLOCK="$(awk '/^# One alert per flap EPISODE/{on=1} on{print} on&&/^}$/{n++; if(n==2) exit}' \
+         "$REPO/src/launchd/channel-bridge-wrapper.sh")"
+eval "$BLOCK"
+type emit_restart_alert >/dev/null 2>&1 || { echo "  FAIL could not load emit_restart_alert"; exit 1; }
+count_alerts() { ls -1 "$WORKSPACE/results/" 2>/dev/null | grep -c "bridge-restarted" || true; }
+fail=0
+# 1. a crashloop: 50 restarts back to back
+for _ in $(seq 1 50); do emit_restart_alert; done
+n="$(count_alerts)"
+if [ "$n" -eq 1 ]; then echo "  ok   50 rapid restarts -> $n alert"; else echo "  FAIL 50 rapid restarts -> $n alerts (want 1)"; fail=1; fi
+# 2. escalation fires once when the flap outlives the window
+read -r f c lr la < "$STATE_DIR/$CHANNEL.flap"
+printf '%s %s %s %s\n' "$f" "$c" "$(date +%s)" "$(( $(date +%s) - 2000 ))" > "$STATE_DIR/$CHANNEL.flap"
+emit_restart_alert; emit_restart_alert
+n2="$(count_alerts)"
+if [ "$n2" -eq 2 ]; then echo "  ok   sustained flap -> exactly 1 escalation (total $n2)"; else echo "  FAIL sustained flap -> total $n2 (want 2)"; fail=1; fi
+# 3. a NEW episode after quiet still alerts — the fix must not mute a real restart
+printf '%s %s %s %s\n' "$f" "$c" "$(( $(date +%s) - 5000 ))" "$(( $(date +%s) - 5000 ))" > "$STATE_DIR/$CHANNEL.flap"
+emit_restart_alert
+n3="$(count_alerts)"
+if [ "$n3" -eq 3 ]; then echo "  ok   restart after quiet period -> alerts again (total $n3)"; else echo "  FAIL after quiet -> total $n3 (want 3)"; fail=1; fi
+# 4. corrupt state must not silence the alert
+echo "garbage not numbers" > "$STATE_DIR/$CHANNEL.flap"
+emit_restart_alert
+n4="$(count_alerts)"
+if [ "$n4" -eq 4 ]; then echo "  ok   corrupt state -> fails OPEN, still alerts (total $n4)"; else echo "  FAIL corrupt state -> total $n4 (want 4)"; fail=1; fi
+[ "$fail" -eq 0 ] && echo "==== ALL RATE-LIMIT ASSERTIONS PASSED ====" || echo "==== FAILURES ===="
+exit "$fail"


### PR DESCRIPTION
## The defect

`emit_restart_alert()` in `src/launchd/channel-bridge-wrapper.sh` had **no rate limit**. Every bridge restart wrote a proactive result (delivered as an owner DM) and fired an `osascript` notification, so a crashloop from any cause produced one owner message per restart cycle.

## Measurement

Counting `results/**/proactive-*-bridge-restarted-*` on a live host — each file is exactly one DM plus one notification:

```
2026-08-22     4
2026-08-23     4
2026-08-24   229
2026-08-25   537
2026-08-26   171
            ----
             945   in five days

by channel:  telegram 680 · discord 253 · slack 12
```

537 in one day is a notification roughly every 2.7 minutes for a full day.

**This is an availability problem for the alert, not for the bridge.** At that volume the restart alert becomes the thing the owner scrolls past, so the next genuine event — a bridge that stays down, a revoked token — arrives in a channel that has been trained to ignore it.

## What changed

One alert per flap **episode**, plus at most one **escalation** per window:

- first restart after a quiet period → alert, as today
- subsequent restarts inside the episode → suppressed on the owner channel
- still flapping after `FLAP_ESCALATE` → **one** escalation naming the restart count and elapsed minutes, which the old output could not express at all: it could say "restarted", never "has been restarting for three days"
- `FLAP_QUIET` / `FLAP_ESCALATE` are env-overridable (900s / 1800s)

The alert count is now bounded by **time** rather than by restart count.

**stderr stays per-restart and unthrottled** — the log keeps every event; only the owner-facing channel is limited. Operators lose nothing.

**Corrupt state fails OPEN.** A malformed flap file resets to a fresh episode and alerts, rather than silently muting.

## Also fixed: a latent lost-alert collision

`_deliver_alert` named results `…-$(date +%s)-$$.txt`. Two alerts in the same second from the same wrapper shared a filename and the second **silently overwrote the first**. Now suffixed until unique. This is independent of the rate limit and would drop a real alert.

## Not touched

The `EXIT_STANDDOWN` (75) path is unchanged and still exits without alerting — benign lock contention was already correctly silent, and this PR is about genuine repeated restarts.

## Evidence

`tests/channel-bridge-restart-alert-rate-limit.test.sh` asserts the alert **COUNT**, which is the property that was unbounded:

```
  ok   50 rapid restarts -> 1 alert
  ok   sustained flap -> exactly 1 escalation (total 2)
  ok   restart after quiet period -> alerts again (total 3)
  ok   corrupt state -> fails OPEN, still alerts (total 4)
==== ALL RATE-LIMIT ASSERTIONS PASSED ====
```

**Mutation-checked, because a test that cannot fail certifies nothing.** With the gate stripped so every restart delivers — the pre-fix behaviour — the suite reports:

```
  FAIL 50 rapid restarts -> 50 alerts (want 1)
```

Two things the test itself got wrong first, both fixed and worth naming since they are the failure modes this kind of test invites:

1. It initially reported **0 alerts** because the function under test was never loaded and `2>/dev/null` swallowed `command not found`. The redirect is gone.
2. It then *passed for the wrong reason* — the filename collision above meant 50 deliveries produced 1 file whether or not the rate limit worked. The uniqueness fix is what makes case 1 discriminating at all.

Filed as #3433.

Stand: Echo Act IV Pro
