### PR TITLE
fix(tests): stop slack-context-first from writing owner tasks into the live queue

### DIFF
--- a/tests/slack-context-first-ungated.test.py
+++ b/tests/slack-context-first-ungated.test.py
@@ -39,9 +39,7 @@ mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(mod)
 
 # TASKS_DIR resolves to the LIVE workspace at import, so the temp tree above is not
-# isolation on its own: `_write_task` dropped two real `access_tier: owner` files into
-# the operator's queue on every run, where cron-gate reads them as pending owner work
-# and defers every gated cron. The sibling suite already redirects it; this one did not.
+# isolation on its own and `_write_task` writes real owner tasks into the real queue.
 TASKS_DIR = Path(_tmp) / "tasks"
 TASKS_DIR.mkdir(parents=True, exist_ok=True)
 mod.TASKS_DIR = TASKS_DIR

--- a/tests/slack-context-first-ungated.test.py
+++ b/tests/slack-context-first-ungated.test.py
@@ -38,6 +38,14 @@ _spec = importlib.util.spec_from_file_location("slack_bridge", REPO / "src" / "s
 mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(mod)
 
+# TASKS_DIR resolves to the LIVE workspace at import, so the temp tree above is not
+# isolation on its own: `_write_task` dropped two real `access_tier: owner` files into
+# the operator's queue on every run, where cron-gate reads them as pending owner work
+# and defers every gated cron. The sibling suite already redirects it; this one did not.
+TASKS_DIR = Path(_tmp) / "tasks"
+TASKS_DIR.mkdir(parents=True, exist_ok=True)
+mod.TASKS_DIR = TASKS_DIR
+
 
 class ContextFirstUngated(unittest.TestCase):
     def _write(self, tier: str = "owner") -> str:


### PR DESCRIPTION
## What

`tests/slack-context-first-ungated.test.py` writes two real `access_tier: owner` task files into the **live** `workspace/tasks/` queue on every run. Three lines of isolation, mirroring what its sibling suite already does.

## Why it happens

The suite creates `tempfile.mkdtemp(prefix="slack-cf-")` and isolates `CLAUDE_CONFIG_DIR`, but never points `mod.TASKS_DIR` at that tree. `TASKS_DIR` resolves against the live workspace when `slack-bridge.py` is exec'd, so `_write_task` writes for real — and the suite's own assertion then globs that same live directory, which also makes it readable-as-passing for the wrong reason if unrelated tasks happen to be queued.

`tests/slack-bridge-write-task.test.py:78-82` already does the redirect. This suite was missed.

## Why it matters on a live core — both observed on this host tonight

- **It starves every gated cron.** `scripts/cron-gate.sh` treats any `task-*.txt` as pending owner work and defers. `pr-practice`, `timeline-guard` and `sync-workspace` all deferred here with no real owner task queued — I spent a fire diagnosing a phantom "external harness" before finding it was my own test run.
- **The fixtures claim owner tier from a placeholder sender** (`channel_id: CFAKE`, `user_id: U_OWNER`). A core working its queue can process them as genuine owner requests; `access_tier` in a task file is a claim the file makes about itself.

## Evidence

Control run against the live workspace, counting `tasks/task-*.txt` before and after:

```
main     tasks/ 0 -> 2   LEAKS
patched  tasks/ 2 -> 2   no leak
```

Patched suite still passes:

```
Ran 2 tests in 0.033s

OK
```

The unpatched arm reproduces the defect, so the control fails in the broken state rather than passing in both — the two leaked files from that arm were archived after the run.

## Scope

Test-only; no production code touched, so there is no live-path behaviour to witness. The claim being made is about where a test writes, and the before/after above is the whole of it.

@sonichi flagging you — this one is why the gated crons on the Mini kept deferring tonight.

Stand: Echo Act IV Mini
