### PR TITLE
fix(health-check): daily-punctuality discarded every compact-dated artifact

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5890,11 +5890,13 @@ def _daily_artifact_minutes(results: Path, stem: str, limit: int = 7) -> list:
     # rglob, not glob: delivered results are archived into MONTH buckets
     # (results/archive/YYYY-MM/), so the durable copies sit two levels down.
     for f in results.rglob(f"{stem}-20*"):
-        m = re.match(rf"{re.escape(stem)}-(\d{{4}}-\d{{2}}-\d{{2}})", f.name)
+        # Both date spellings are in live use and the compact one dominates;
+        # matching only YYYY-MM-DD discards the majority of real artifacts.
+        m = re.match(rf"{re.escape(stem)}-(\d{{4}})-?(\d{{2}})-?(\d{{2}})", f.name)
         if not m:
             continue
         lt = datetime.fromtimestamp(f.stat().st_mtime)
-        out.append((m.group(1), lt.hour * 60 + lt.minute))
+        out.append(("-".join(m.groups()), lt.hour * 60 + lt.minute))
     out.sort()
     return out[-limit:]
 

--- a/tests/health-check-daily-punctuality.test.py
+++ b/tests/health-check-daily-punctuality.test.py
@@ -476,5 +476,45 @@ class TestCollectorMarksStaleNaming(unittest.TestCase):
         self.assertIn(r["status"], ("ok", "warn"))
 
 
+
+class ArtifactDateSpellingTests(unittest.TestCase):
+    """`<stem>-YYYYMMDD` and `<stem>-YYYY-MM-DD` are both in live use, and the
+    compact form is the majority; matching only the hyphenated one reports a
+    job that writes an artifact every day as having produced nothing."""
+
+    def _minutes(self, names):
+        with tempfile.TemporaryDirectory() as d:
+            r = Path(d)
+            for n in names:
+                (r / n).write_text("x")
+            return hc._daily_artifact_minutes(r, "widget-report")
+
+    def test_compact_dates_are_found(self):
+        got = self._minutes(["widget-report-20260825.txt", "widget-report-20260826.txt"])
+        self.assertEqual([d for d, _ in got], ["2026-08-25", "2026-08-26"],
+                         "compact YYYYMMDD artifacts must be seen, and normalised to ISO")
+
+    def test_hyphenated_dates_still_work(self):
+        got = self._minutes(["widget-report-2026-08-25.txt"])
+        self.assertEqual([d for d, _ in got], ["2026-08-25"])
+
+    def test_both_spellings_coexist_in_one_directory(self):
+        got = self._minutes(["widget-report-20260824.txt", "widget-report-2026-08-25.txt"])
+        self.assertEqual([d for d, _ in got], ["2026-08-24", "2026-08-25"],
+                         "a directory carrying both conventions must yield both")
+
+    def test_a_non_date_suffix_is_still_rejected(self):
+        # The control that can fail: widening the date match must not turn the
+        # matcher into a prefix match on the stem.
+        self.assertEqual(self._minutes(["widget-report-2026notadate.txt"]), [])
+        self.assertEqual(self._minutes(["widget-report-summary.txt"]), [])
+
+    def test_the_returned_date_parses_as_the_caller_expects(self):
+        # The caller does strptime(newest, "%Y-%m-%d") and compares against
+        # now.strftime("%Y-%m-%d"); a raw 20260826 would raise there.
+        (d, _), = self._minutes(["widget-report-20260826.txt"])
+        datetime.strptime(d, "%Y-%m-%d")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Why

`_daily_artifact_minutes` globs `<stem>-20*` and then requires the filename to match `\d{4}-\d{2}-\d{2}`. Both date spellings are in live use in `results/`, and the **compact one dominates**:

```
hyphenated (YYYY-MM-DD):  41
compact    (YYYYMMDD):   217
```

So every `<stem>-YYYYMMDD` artifact was globbed and then silently discarded, and `daily-cron-punctuality` reported *"no dated artifact, cannot tell whether it ran"* for jobs that write one every single day.

## Before → after, measured against the live results tree

```
loop-engineering-digest     0 -> 7
money-opportunities-daily   0 -> 7
agent-loop-video-ideas      0 -> 6
```

`loop-engineering-digest`'s newest is now `('2026-08-25', 364)` — minute 364 is 06:04 against a `2 6 * * *` schedule, i.e. two minutes late. That is the signal the probe exists to produce and could not.

Controls, same run: a stem that matches nothing still returns 0, and the hyphenated form still returns 7.

## Scoped honestly — this does NOT change this host's headline number

The probe still says **2 of 11 observable** after the fix, and I checked that end to end rather than inferring it from the unit-level 0→7. Every daily entry in this host's `crons.json` is `launchd: true`, and that lane reads completion sentinels (`state/<job>-YYYY-MM-DD.sentinel`) instead of artifacts, so it never reaches this matcher at all.

The bug is still real — it misreports any non-launchd daily job whose artifacts use the majority date spelling — but I am not claiming it clears the standing warn. **Whether a launchd job that publishes a dated artifact should be allowed to use it as punctuality evidence is a separate design question**, and a separate PR; `launchd` describes how a job is *scheduled*, not what evidence it *leaves*.

## Tests

Five cases added to `tests/health-check-daily-punctuality.test.py`: compact found and normalised, hyphenated still works, both spellings coexisting in one directory, the returned date parses under the caller's `strptime(..., "%Y-%m-%d")`, and — the control that can fail — widening the date match must not turn the matcher into a bare prefix match on the stem (`widget-report-summary.txt` and `widget-report-2026notadate.txt` are still rejected).

**Mutation-verified:** splicing `origin/main`'s function body back in takes the suite from **46/46 OK** to **2 failures + 1 error**; restoring returns 46/46. The sibling `daily-punctuality-completion-sentinels` suite is unaffected and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
