### PR TITLE
fix(health-check): a launchd job's dated artifact is evidence too

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5986,9 +5986,8 @@ def check_daily_cron_punctuality() -> dict:
         arts = (_daily_completion_minutes(ws / "state", jname) if launchd
                 else _daily_artifact_minutes(ws / "results", stem))
         used_artifact_lane = not launchd
-        # Both fallbacks, so neither lane's absence is read as the job's silence.
-        # Without the launchd arm, a launchd job that publishes a dated artifact
-        # every day still reports "no dated artifact" forever.
+        # Both directions, so neither lane's absence reads as the job's silence:
+        # without the launchd arm a daily artifact reports "no dated artifact" forever.
         if not arts:
             arts = (_daily_artifact_minutes(ws / "results", stem) if launchd
                     else _daily_completion_minutes(ws / "state", jname))

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5890,11 +5890,13 @@ def _daily_artifact_minutes(results: Path, stem: str, limit: int = 7) -> list:
     # rglob, not glob: delivered results are archived into MONTH buckets
     # (results/archive/YYYY-MM/), so the durable copies sit two levels down.
     for f in results.rglob(f"{stem}-20*"):
-        m = re.match(rf"{re.escape(stem)}-(\d{{4}}-\d{{2}}-\d{{2}})", f.name)
+        # Both date spellings are in live use and the compact one dominates;
+        # matching only YYYY-MM-DD discards the majority of real artifacts.
+        m = re.match(rf"{re.escape(stem)}-(\d{{4}})-?(\d{{2}})-?(\d{{2}})", f.name)
         if not m:
             continue
         lt = datetime.fromtimestamp(f.stat().st_mtime)
-        out.append((m.group(1), lt.hour * 60 + lt.minute))
+        out.append(("-".join(m.groups()), lt.hour * 60 + lt.minute))
     out.sort()
     return out[-limit:]
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5981,14 +5981,18 @@ def check_daily_cron_punctuality() -> dict:
         declared = str(e.get("artifact") or "").strip()
         stem = declared or (jname.split("-")[-1] if "-" in jname else jname)
         launchd = bool(e.get("launchd"))
-        # The launchd lane publishes no dated results file; its completion
-        # sentinel is the only dated record that it finished.
+        # Each lane is a preference, not a restriction: `launchd` says how a job is
+        # SCHEDULED, which does not determine what dated evidence it leaves behind.
         arts = (_daily_completion_minutes(ws / "state", jname) if launchd
                 else _daily_artifact_minutes(ws / "results", stem))
-        # `launchd` conflates "runs under launchd" with "publishes no dated results
-        # file"; a session-owned job can be the second without being the first.
-        if not arts and not launchd:
-            arts = _daily_completion_minutes(ws / "state", jname)
+        used_artifact_lane = not launchd
+        # Both fallbacks, so neither lane's absence is read as the job's silence.
+        # Without the launchd arm, a launchd job that publishes a dated artifact
+        # every day still reports "no dated artifact" forever.
+        if not arts:
+            arts = (_daily_artifact_minutes(ws / "results", stem) if launchd
+                    else _daily_completion_minutes(ws / "state", jname))
+            used_artifact_lane = bool(arts) and launchd
         # Staleness is computed HERE because `now` lives here; the interpret layer
         # reads it as an optional field so its fixtures stay clock-independent.
         newest = max((d for d, _ in arts), default=None)
@@ -6006,7 +6010,7 @@ def check_daily_cron_punctuality() -> dict:
             "minutes_since_due": max(0, int((now - due).total_seconds() // 60)),
             # `artifact` names a results file, so it cannot vouch for a sentinel:
             # only an observed history makes a missing sentinel today actionable.
-            "stem": stem, "stem_declared": bool(declared) and not launchd,
+            "stem": stem, "stem_declared": bool(declared) and used_artifact_lane,
             # Renders only when new input exists, so a quiet day produces nothing
             # and absence is evidence of nothing rather than of a miss.
             "conditional": bool(e.get("conditional")),

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -161,9 +161,9 @@ check("missing state dir returns empty",
       hc._daily_completion_minutes(Path(tempfile.mkdtemp()) / "nope", "x") == [])
 
 # ── a launchd job that publishes a dated ARTIFACT but stamps no sentinel ─────
-# `launchd` says how a job is SCHEDULED; it does not determine what dated
-# evidence the job leaves. Without the fallback such a job reports "no dated
-# artifact" forever while writing one every single day.
+
+# `launchd` says how a job is SCHEDULED, not what dated evidence it leaves; without
+# the fallback such a job reports "no dated artifact" while writing one every day.
 def _launchd_artifact_ws(days=5, include_today=True, name="digest-job", stem="digest-job"):
     ws = Path(tempfile.mkdtemp(prefix="punct-la-"))
     (ws / "hosts" / "H").mkdir(parents=True)

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -203,5 +203,30 @@ check("no sentinel and no artifact stays UNCHECKED",
       f"got {r.get('detail')!r}")
 
 
+# ── declared artifact, zero evidence in EITHER lane (yixuan-ag2 on #3440) ────
+
+# `used_artifact_lane` flips here vs the old `not launchd`, but the interpret
+# layer `continue`s on empty artifacts before the stem_declared gate is read.
+ws = Path(tempfile.mkdtemp(prefix="punct-none-"))
+(ws / "hosts" / "H").mkdir(parents=True)
+(ws / "state").mkdir()
+(ws / "results").mkdir()
+(ws / "hosts" / "H" / "crons.json").write_text(json.dumps(
+    [{"name": "never-ran", "cron": "0 6 * * *", "artifact": "never-ran"}]))
+r = run(ws)
+_d = r.get("detail") or ""
+check("a job with no evidence in either lane is UNCHECKED, not a miss",
+      "never-ran" in _d and "past due" not in _d and "no output today" not in _d,
+      f"got {_d!r}")
+
+# The same property at the interpret layer, holding everything but the flag
+# fixed — it must not matter which value stem_declared carries.
+_base = dict(name="j", hour=6, minute=0, artifacts=[], today_seen=False,
+             minutes_since_due=999, conditional=False)
+_outs = [hc._interpret_daily_punctuality([dict(_base, stem_declared=sd)]).get("detail") or ""
+         for sd in (True, False)]
+check("stem_declared cannot change the verdict when artifacts is empty",
+      _outs[0] == _outs[1], f"got {_outs}")
+
 print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
 sys.exit(1 if failures else 0)

--- a/tests/daily-punctuality-completion-sentinels.test.py
+++ b/tests/daily-punctuality-completion-sentinels.test.py
@@ -160,5 +160,48 @@ for nm, body in (("z", f"{aware:%Y-%m-%dT%H:%M:%S}Z"),
 check("missing state dir returns empty",
       hc._daily_completion_minutes(Path(tempfile.mkdtemp()) / "nope", "x") == [])
 
+# ── a launchd job that publishes a dated ARTIFACT but stamps no sentinel ─────
+# `launchd` says how a job is SCHEDULED; it does not determine what dated
+# evidence the job leaves. Without the fallback such a job reports "no dated
+# artifact" forever while writing one every single day.
+def _launchd_artifact_ws(days=5, include_today=True, name="digest-job", stem="digest-job"):
+    ws = Path(tempfile.mkdtemp(prefix="punct-la-"))
+    (ws / "hosts" / "H").mkdir(parents=True)
+    (ws / "state").mkdir()
+    (ws / "results").mkdir()
+    (ws / "hosts" / "H" / "crons.json").write_text(json.dumps(
+        [{"name": name, "cron": "0 6 * * *", "launchd": True, "artifact": stem}]))
+    today = datetime.date.today()
+    for i in range(days):
+        if i == 0 and not include_today:
+            continue
+        d = today - datetime.timedelta(days=i)
+        f = ws / "results" / f"{stem}-{d:%Y%m%d}.txt"
+        f.write_text("x")
+        os.utime(f, (time.time(),
+                     datetime.datetime.combine(d, datetime.time(6, 4)).timestamp()))
+    return ws
+
+
+r = run(_launchd_artifact_ws())
+check("launchd + dated artifact is OBSERVABLE, not UNCHECKED",
+      "digest-job" not in (r.get("detail") or ""), f"got {r.get('detail')!r}")
+check("...and a punctual artifact history is not reported late",
+      r.get("status") == "ok", f"got {r.get('status')}: {r.get('detail')}")
+
+r = run(_launchd_artifact_ws(include_today=False))
+check("a launchd artifact history that stops TODAY surfaces as a named miss",
+      "digest-job" in (r.get("detail") or "") and "no output today" in (r.get("detail") or ""),
+      f"got {r.get('detail')!r}")
+
+# The control that can fail: with NO evidence in either lane the job must stay
+# UNCHECKED, so the fallback cannot manufacture observability out of nothing.
+r = run(_launchd_artifact_ws(days=0))
+check("no sentinel and no artifact stays UNCHECKED",
+      "digest-job" in (r.get("detail") or "")
+      and ("UNCHECKED" in (r.get("detail") or "") or "unverifiable" in (r.get("detail") or "")),
+      f"got {r.get('detail')!r}")
+
+
 print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
 sys.exit(1 if failures else 0)

--- a/tests/health-check-daily-punctuality.test.py
+++ b/tests/health-check-daily-punctuality.test.py
@@ -476,5 +476,45 @@ class TestCollectorMarksStaleNaming(unittest.TestCase):
         self.assertIn(r["status"], ("ok", "warn"))
 
 
+
+class ArtifactDateSpellingTests(unittest.TestCase):
+    """`<stem>-YYYYMMDD` and `<stem>-YYYY-MM-DD` are both in live use, and the
+    compact form is the majority; matching only the hyphenated one reports a
+    job that writes an artifact every day as having produced nothing."""
+
+    def _minutes(self, names):
+        with tempfile.TemporaryDirectory() as d:
+            r = Path(d)
+            for n in names:
+                (r / n).write_text("x")
+            return hc._daily_artifact_minutes(r, "widget-report")
+
+    def test_compact_dates_are_found(self):
+        got = self._minutes(["widget-report-20260825.txt", "widget-report-20260826.txt"])
+        self.assertEqual([d for d, _ in got], ["2026-08-25", "2026-08-26"],
+                         "compact YYYYMMDD artifacts must be seen, and normalised to ISO")
+
+    def test_hyphenated_dates_still_work(self):
+        got = self._minutes(["widget-report-2026-08-25.txt"])
+        self.assertEqual([d for d, _ in got], ["2026-08-25"])
+
+    def test_both_spellings_coexist_in_one_directory(self):
+        got = self._minutes(["widget-report-20260824.txt", "widget-report-2026-08-25.txt"])
+        self.assertEqual([d for d, _ in got], ["2026-08-24", "2026-08-25"],
+                         "a directory carrying both conventions must yield both")
+
+    def test_a_non_date_suffix_is_still_rejected(self):
+        # The control that can fail: widening the date match must not turn the
+        # matcher into a prefix match on the stem.
+        self.assertEqual(self._minutes(["widget-report-2026notadate.txt"]), [])
+        self.assertEqual(self._minutes(["widget-report-summary.txt"]), [])
+
+    def test_the_returned_date_parses_as_the_caller_expects(self):
+        # The caller does strptime(newest, "%Y-%m-%d") and compares against
+        # now.strftime("%Y-%m-%d"); a raw 20260826 would raise there.
+        (d, _), = self._minutes(["widget-report-20260826.txt"])
+        datetime.strptime(d, "%Y-%m-%d")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
> **Stacked on #3439** (`fix/daily-punctuality-compact-dates`). That fix is what makes these artifacts visible to the matcher at all — merge it first, then rebase this.

## The asymmetry

`check_daily_cron_punctuality` already falls back one way:

```python
arts = (_daily_completion_minutes(...) if launchd
        else _daily_artifact_minutes(...))
if not arts and not launchd:                 # non-launchd -> try the SENTINEL
    arts = _daily_completion_minutes(...)
```

A non-launchd job with no artifact reads its sentinel. **A launchd job with no sentinel never looks at `results/` at all** — so a launchd job that publishes a dated artifact every single day reports *"no dated artifact, cannot tell whether it ran"* forever.

The comment two lines below that routing already argues for the fix: *"`launchd` conflates 'runs under launchd' with 'publishes no dated results file'"*. It says how a job is **scheduled**; it does not determine what dated evidence the job leaves behind.

## Live before → after, and it is not a cosmetic delta

```
before   2 of 11 daily job(s) observable, ALL ON SCHEDULE
after    loop-engineering-digest: no output today, 976 min past due
```

`loop-engineering-digest` has artifacts through `2026-08-25` and **none for today**. It is due at 06:02; 976 minutes is ~16 hours. The probe was reporting **"all on schedule"** while that job's output had been missing all day — because the only lane that could see it was closed by a flag about scheduling.

**Correction to an earlier version of this paragraph, made before anyone reviewed it.** I first wrote "a daily job silently dead for 16 hours". That over-claims what the evidence shows. Checking further: `results/archive/2026-08/task-cron-loop-engineering-digest-1787749355939.txt` has mtime **Aug 26 06:26**, so the job *did* fire and complete this morning — it produced no dated artifact. Missing output is the real finding and is worth flagging; "the cron is dead" is a different claim my evidence does not support.

That is the finding this PR exists for. The 2→5 coverage improvement is the smaller half.

**Follow-up this measurement surfaced, deliberately not in this PR.** Every cron job leaves a `results/task-cron-<name>-<epoch>.txt` record whose mtime is its completion time. Measured across this host's daily jobs: **13 of 14 have one, most with 8 distinct days in the last 7**, including all six that stay UNCHECKED after this PR. That is a universal per-job completion record neither lane reads, and it would take coverage from 2/11 to essentially 11/11 with no per-job config and no scripts writing sentinels. Separate change, separate evidence.

## What it does

Both directions fall back, so neither lane's absence is read as the job's silence. `stem_declared` now tracks which lane actually produced the evidence instead of assuming `not launchd`, which keeps the missed-today branch correctly gated.

## Tests

Four cases added to `tests/daily-punctuality-completion-sentinels.test.py`:

- a launchd job with a dated artifact and no sentinel is **observable**, not UNCHECKED
- ...and a punctual artifact history is not mis-reported as late
- an artifact history that **stops today** surfaces as a named miss (the live case above)
- **the control that can fail:** with no evidence in *either* lane the job stays UNCHECKED — the fallback must not manufacture observability out of nothing

**Mutation-verified:** removing the launchd arm of the fallback takes the suite from **OK / 0 failures** to **3 failures**, and the control case correctly stays green through the mutation (it is testing the opposite property). Restoring returns 0 failures. The sibling `health-check-daily-punctuality` suite is unaffected: 46/46.

The pre-existing fixture case *"launchd but never stamps: must stay UNCHECKED"* also still passes — it declares an artifact stem but writes no artifacts, so the fallback correctly finds nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

