### PR TITLE
fix(tests): stop two bridge suites from wiping the durable auth backup

### DIFF
--- a/tests/discord-bridge-logging-not-fatal.test.py
+++ b/tests/discord-bridge-logging-not-fatal.test.py
@@ -89,6 +89,11 @@ def _load_bridge():
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
+    # ACCESS_BACKUP_FILE resolves under the LIVE workspace at import, so the temp
+    # tree above is not isolation and the real durable file gets overwritten.
+    mod.ACCESS_BACKUP_FILE = (
+        Path(tempfile.mkdtemp(prefix="acl-bk-")) / "discord-access-backup.json")
+
     return mod
 
 

--- a/tests/discord-bridge-pairing-dm.test.py
+++ b/tests/discord-bridge-pairing-dm.test.py
@@ -37,6 +37,11 @@ spec = importlib.util.spec_from_file_location("discordbridge_pair", REPO / "src"
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
+
+# ACCESS_BACKUP_FILE resolves under the LIVE workspace at import, so the temp tree
+# above is not isolation: _backup_access_to_disk() overwrites the real durable file.
+mod.ACCESS_BACKUP_FILE = Path(tempfile.mkdtemp(prefix="acl-bk-")) / "discord-access-backup.json"
+
 # CLAUDE_CONFIG_DIR alone is not isolation: channel_access_path() falls back to
 # the real legacy access.json when the fresh canonical path does not exist.
 mod.ACCESS_FILE = Path(tempfile.mkdtemp(prefix="pair-acl-")) / "channels" / "discord" / "access.json"


### PR DESCRIPTION
## What

Two suites overwrite the operator's real `state/auth/discord-access-backup.json` on every run. One override line each, at the point they already build a tempdir.

## Why it happens

`ACCESS_BACKUP_FILE` resolves under the live workspace when `discord-bridge.py` is exec'd, so a suite's own `mkdtemp` does not cover it. `_backup_access_to_disk()` then writes for real.

`tests/discord-bridge-pairing-dm.test.py` already redirects `mod.ACCESS_FILE` at a fresh tempdir — it simply missed the sibling path. `tests/discord-bridge-logging-not-fatal.test.py` redirected neither.

## Why it is destructive rather than noisy

That file is what lets a restart restore the Discord allowlist instead of booting into an open pairing gate, and the repo documents `state/auth/` as durable per-host install state exempt from transient cleanup. A run takes it from **21,197 bytes to 207** and `allowFrom` from **1 entry to 0** — the state in which the owner is de-authorized. I hit this on a live core tonight and had to restore from a copy.

## Evidence

```
main     both suites WRITE      live file 21,197 -> 207 bytes
patched  neither writes         live file unchanged
```

Both suites still pass patched. The unpatched arm reproduces the destruction, so the control fails in the broken state rather than passing in both. The live file was restored from a pre-run copy and verified against its baseline sha.

## How they were found — and how they were nearly mis-named

By instrumenting **all 626 suites**: sha of that one file before and after each run. An earlier attempt reasoned from a call graph (`ensure_tier_map_seeded()` → `_backup_access_to_disk()`) and named six suites; I measured them afterwards and **all six were innocent**, so that claim was retracted. Neither real writer is reachable from that chain.

## Scope

Test-only; no production code, so there is no runtime behaviour to witness. The claim is about where a test writes.

Related: #3438 fixes the same shape in `slack-context-first-ungated` (leaking into `tasks/` rather than `state/auth/`). Both are instances of the escape that `_bridge_writes_redirected()` already solves privately inside one suite; extracting that fixture is the durable fix and is not this PR.

@sonichi flagging you — this is the one that wiped the auth backup on the Mini tonight.

Stand: Echo Act IV Mini
