### PR TITLE
feat(startup): default lane derives GATEWAY_FOREIGN_SUFFIXES from named lanes

### DIFF
--- a/.github/workflows/bundle-smoke.yml
+++ b/.github/workflows/bundle-smoke.yml
@@ -5,7 +5,6 @@ name: bundle-smoke
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
     paths:
       - 'src/**'
       - 'skills/phone-conversation/scripts/conversation-server.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
+  # A pull_request run reads this file from the HEAD branch but matches any
+  # `branches:` filter against the BASE, so a filter here excludes non-main bases.
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -13,7 +13,6 @@ name: Coverage Gate
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
 
 jobs:
   coverage-gate:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -21,7 +21,6 @@ name: eslint
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-agents-md-sync.yml
+++ b/.github/workflows/lint-agents-md-sync.yml
@@ -19,7 +19,6 @@ name: lint-agents-md-sync
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-claude-home-path.yml
+++ b/.github/workflows/lint-claude-home-path.yml
@@ -14,7 +14,6 @@ name: lint-claude-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-hermetic-bridge-tests.yml
+++ b/.github/workflows/lint-hermetic-bridge-tests.yml
@@ -16,7 +16,6 @@ name: lint-hermetic-bridge-tests
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-host-label.yml
+++ b/.github/workflows/lint-host-label.yml
@@ -17,7 +17,6 @@ name: lint-host-label
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-hotkey-assertions.yml
+++ b/.github/workflows/lint-hotkey-assertions.yml
@@ -14,7 +14,6 @@ name: lint-hotkey-assertions
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-src-map.yml
+++ b/.github/workflows/lint-src-map.yml
@@ -13,7 +13,6 @@ name: lint-src-map
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-sutando-home-path.yml
+++ b/.github/workflows/lint-sutando-home-path.yml
@@ -15,7 +15,6 @@ name: lint-sutando-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-workspace-resolution.yml
+++ b/.github/workflows/lint-workspace-resolution.yml
@@ -15,7 +15,6 @@ name: lint-workspace-resolution
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,6 @@ name: ruff
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,7 +25,6 @@ name: shellcheck
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/workspace-leak-check.yml
+++ b/.github/workflows/workspace-leak-check.yml
@@ -18,7 +18,6 @@ name: workspace-leak-check
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -69,6 +69,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`event_log.py`** — Structured event log for Sutando — JSONL events for post-mortem debugging.
 - **`fix-setup.sh`** — One-shot fix for Mac Mini after migration bundle setup
 - **`friction-detector.py`** — Proactive friction detector for Sutando.
+- **`gateway-foreign-suffixes.sh`** — Source AFTER the channel .env is loaded: the derivation reads the AG2_REMOTE_TOKEN_<INST> variables out of the environment, so order decides it.
 - **`git_binary.py`** — Resolve a git executable that will actually run.
 - **`github-webhook.py`** — GitHub webhook bridge — receives GitHub events and writes task files.
 - **`health-check.py`** — Sutando health check — verifies all components are running correctly.
@@ -157,6 +158,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`task-emit.sh`** — TASK_FILE emitters — sourceable so a test can invoke them in isolation.
 - **`task_archive.py`** — Task-file locator for archive calls (#933).
 - **`task_body_guard.py`** — Confine untrusted user message content before embedding it in a task file.
+- **`task_body_guard.ts`** — confineUserContent — the ONE TypeScript implementation of the task-body injection guard.
 - **`task_envelope.py`** — Task-envelope authentication: an HMAC stamp that makes access_tier a verified claim instead of an honor-system header.
 - **`task_envelope.ts`** — task_envelope.ts — TypeScript mirror of src/task_envelope.py's stamping half, for the TS task writers (voice delegation seam, context-drop, wearable).
 - **`task_envelope_census.py`** — Soak census for HMAC task envelopes: the read-only measurement behind the "writer census reaches zero" gate.

--- a/src/gateway-foreign-suffixes.sh
+++ b/src/gateway-foreign-suffixes.sh
@@ -2,12 +2,23 @@
 # Source AFTER the channel .env is loaded: the derivation reads the
 # AG2_REMOTE_TOKEN_<INST> variables out of the environment, so order decides it.
 
+_dfs_channels_root() {
+  if [ -n "${GATEWAY_CHANNELS_DIR:-}" ]; then
+    printf '%s' "$GATEWAY_CHANNELS_DIR"
+    return 0
+  fi
+  local _dfs_repo="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  bash "$_dfs_repo/scripts/sutando-config.sh" claude-home-path channels 2>/dev/null
+}
+
 derive_foreign_suffixes() {
   if [ -n "${GATEWAY_FOREIGN_SUFFIXES:-}" ]; then
     printf '%s' "$GATEWAY_FOREIGN_SUFFIXES"
     return 0
   fi
-  local _dfs_out="" _dfs_var _dfs_inst
+  local _dfs_root
+  _dfs_root="$(_dfs_channels_root)"
+  local _dfs_out="" _dfs_var _dfs_inst _dfs_env _dfs_mxid _dfs_suffix
   # Iterate NAMES: parsing `env` output cannot tell a real variable from a
   # value carrying a newline that looks like an assignment.
   for _dfs_var in ${!AG2_REMOTE_TOKEN_@}; do
@@ -15,7 +26,18 @@ derive_foreign_suffixes() {
     # A bare AG2_REMOTE_TOKEN_ names no instance; :.ag2.space is not a lane.
     [ -n "$_dfs_inst" ] || continue
     _dfs_inst="$(printf '%s' "$_dfs_inst" | tr '[:upper:]' '[:lower:]')"
-    _dfs_out="${_dfs_out:+$_dfs_out,}:${_dfs_inst}.ag2.space"
+    # The instance name is a LABEL, not a homeserver: a lane's true suffix is
+    # its identity's domain (AGENT_MXID), e.g. instance "local" -> :localhost.
+    _dfs_suffix=""
+    _dfs_env="$_dfs_root/${_dfs_inst}-ag2space/.env"
+    if [ -n "$_dfs_root" ] && [ -f "$_dfs_env" ]; then
+      _dfs_mxid="$(sed -n 's/^AGENT_MXID=//p' "$_dfs_env" | tail -1)"
+      case "$_dfs_mxid" in
+        *:*) _dfs_suffix=":${_dfs_mxid##*:}" ;;
+      esac
+    fi
+    [ -n "$_dfs_suffix" ] || _dfs_suffix=":${_dfs_inst}.ag2.space"
+    _dfs_out="${_dfs_out:+$_dfs_out,}${_dfs_suffix}"
   done
   printf '%s' "$_dfs_out"
 }

--- a/src/gateway-foreign-suffixes.sh
+++ b/src/gateway-foreign-suffixes.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
-# Shared derivation of GATEWAY_FOREIGN_SUFFIXES, sourced by every gateway
-# launch path so supervised and bare launches fence identically.
-#
-# Every configured named lane <inst> serves rooms on :<inst>.ag2.space (the
-# same convention that maps <inst> to channels/<inst>-ag2space/), so those
-# suffixes are foreign to the default lane. Operator-set
-# GATEWAY_FOREIGN_SUFFIXES wins verbatim.
-#
-# Callers must source this AFTER loading the channel .env that carries the
-# AG2_REMOTE_TOKEN_<INST> variables — the derivation reads them from the
-# environment.
+# Source AFTER the channel .env is loaded: the derivation reads the
+# AG2_REMOTE_TOKEN_<INST> variables out of the environment, so order decides it.
 
 derive_foreign_suffixes() {
   if [ -n "${GATEWAY_FOREIGN_SUFFIXES:-}" ]; then

--- a/src/gateway-foreign-suffixes.sh
+++ b/src/gateway-foreign-suffixes.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Shared derivation of GATEWAY_FOREIGN_SUFFIXES, sourced by every gateway
+# launch path so supervised and bare launches fence identically.
+#
+# Every configured named lane <inst> serves rooms on :<inst>.ag2.space (the
+# same convention that maps <inst> to channels/<inst>-ag2space/), so those
+# suffixes are foreign to the default lane. Operator-set
+# GATEWAY_FOREIGN_SUFFIXES wins verbatim.
+#
+# Callers must source this AFTER loading the channel .env that carries the
+# AG2_REMOTE_TOKEN_<INST> variables — the derivation reads them from the
+# environment.
+
+derive_foreign_suffixes() {
+  if [ -n "${GATEWAY_FOREIGN_SUFFIXES:-}" ]; then
+    printf '%s' "$GATEWAY_FOREIGN_SUFFIXES"
+    return 0
+  fi
+  local _dfs_out="" _dfs_var _dfs_inst
+  for _dfs_var in $(env | grep -o '^AG2_REMOTE_TOKEN_[A-Za-z0-9_][A-Za-z0-9_]*' || true); do
+    _dfs_inst="$(printf '%s' "${_dfs_var#AG2_REMOTE_TOKEN_}" | tr '[:upper:]' '[:lower:]')"
+    _dfs_out="${_dfs_out:+$_dfs_out,}:${_dfs_inst}.ag2.space"
+  done
+  printf '%s' "$_dfs_out"
+}

--- a/src/gateway-foreign-suffixes.sh
+++ b/src/gateway-foreign-suffixes.sh
@@ -8,8 +8,13 @@ derive_foreign_suffixes() {
     return 0
   fi
   local _dfs_out="" _dfs_var _dfs_inst
-  for _dfs_var in $(env | grep -o '^AG2_REMOTE_TOKEN_[A-Za-z0-9_][A-Za-z0-9_]*' || true); do
-    _dfs_inst="$(printf '%s' "${_dfs_var#AG2_REMOTE_TOKEN_}" | tr '[:upper:]' '[:lower:]')"
+  # Iterate NAMES: parsing `env` output cannot tell a real variable from a
+  # value carrying a newline that looks like an assignment.
+  for _dfs_var in ${!AG2_REMOTE_TOKEN_@}; do
+    _dfs_inst="${_dfs_var#AG2_REMOTE_TOKEN_}"
+    # A bare AG2_REMOTE_TOKEN_ names no instance; :.ag2.space is not a lane.
+    [ -n "$_dfs_inst" ] || continue
+    _dfs_inst="$(printf '%s' "$_dfs_inst" | tr '[:upper:]' '[:lower:]')"
     _dfs_out="${_dfs_out:+$_dfs_out,}:${_dfs_inst}.ag2.space"
   done
   printf '%s' "$_dfs_out"

--- a/src/launchd/gateway-bridge-wrapper.sh
+++ b/src/launchd/gateway-bridge-wrapper.sh
@@ -57,6 +57,7 @@ export REMOTE_TASK_TOKEN REMOTE_TASK_TIER REMOTE_MEDIA_MARKER
 
 # The supervised path must fence exactly like the bare launch in
 # startup-runtime.sh; without this the default lane claims named-lane rooms.
+
 # shellcheck source=../gateway-foreign-suffixes.sh
 . "$REPO/src/gateway-foreign-suffixes.sh"
 GATEWAY_FOREIGN_SUFFIXES="$(derive_foreign_suffixes)"

--- a/src/launchd/gateway-bridge-wrapper.sh
+++ b/src/launchd/gateway-bridge-wrapper.sh
@@ -55,6 +55,13 @@ REMOTE_TASK_TIER="${REMOTE_TASK_TIER:-${AG2_REMOTE_TIER:-owner}}"
 REMOTE_MEDIA_MARKER="${REMOTE_MEDIA_MARKER:-ag2space-media}"
 export REMOTE_TASK_TOKEN REMOTE_TASK_TIER REMOTE_MEDIA_MARKER
 
+# The supervised path must fence exactly like the bare launch in
+# startup-runtime.sh; without this the default lane claims named-lane rooms.
+# shellcheck source=../gateway-foreign-suffixes.sh
+. "$REPO/src/gateway-foreign-suffixes.sh"
+GATEWAY_FOREIGN_SUFFIXES="$(derive_foreign_suffixes)"
+export GATEWAY_FOREIGN_SUFFIXES
+
 # If there's still no token, the bridge would FATAL-exit and KeepAlive would
 # crash-loop. Exit 0 quietly instead — the install path only loads this job when
 # a token is configured, so reaching here means the token was removed after

--- a/src/startup-runtime.sh
+++ b/src/startup-runtime.sh
@@ -405,6 +405,7 @@ reap_stale_task_watcher() {
 #
 # The derivation is shared with the launchd wrapper so both launch paths fence
 # identically; sourcing it here keeps `derive_foreign_suffixes` in scope.
+
 # shellcheck source=gateway-foreign-suffixes.sh
 . "$(dirname "${BASH_SOURCE[0]}")/gateway-foreign-suffixes.sh"
 

--- a/src/startup-runtime.sh
+++ b/src/startup-runtime.sh
@@ -403,22 +403,10 @@ reap_stale_task_watcher() {
 # reach this block, which reaped a live, mid-session watcher as a side effect.
 # scripts/restart-gateway-lanes.sh calls only this function.
 #
-# Default-lane foreign-suffix fence: every configured named lane <inst> serves
-# rooms on :<inst>.ag2.space (the same convention that maps <inst> to
-# channels/<inst>-ag2space/ below), so those suffixes are foreign to the
-# default lane. Operator-set GATEWAY_FOREIGN_SUFFIXES wins verbatim.
-derive_foreign_suffixes() {
-  if [ -n "${GATEWAY_FOREIGN_SUFFIXES:-}" ]; then
-    printf '%s' "$GATEWAY_FOREIGN_SUFFIXES"
-    return 0
-  fi
-  local _dfs_out="" _dfs_var _dfs_inst
-  for _dfs_var in $(env | grep -o '^AG2_REMOTE_TOKEN_[A-Za-z0-9_][A-Za-z0-9_]*' || true); do
-    _dfs_inst="$(printf '%s' "${_dfs_var#AG2_REMOTE_TOKEN_}" | tr '[:upper:]' '[:lower:]')"
-    _dfs_out="${_dfs_out:+$_dfs_out,}:${_dfs_inst}.ag2.space"
-  done
-  printf '%s' "$_dfs_out"
-}
+# The derivation is shared with the launchd wrapper so both launch paths fence
+# identically; sourcing it here keeps `derive_foreign_suffixes` in scope.
+# shellcheck source=gateway-foreign-suffixes.sh
+. "$(dirname "${BASH_SOURCE[0]}")/gateway-foreign-suffixes.sh"
 
 # Requires REPO, PY (resolved via scripts/python-binary.sh) and LOGS_DIR set
 # by the caller — same contract as every other block in startup.sh.

--- a/src/startup-runtime.sh
+++ b/src/startup-runtime.sh
@@ -403,6 +403,23 @@ reap_stale_task_watcher() {
 # reach this block, which reaped a live, mid-session watcher as a side effect.
 # scripts/restart-gateway-lanes.sh calls only this function.
 #
+# Default-lane foreign-suffix fence: every configured named lane <inst> serves
+# rooms on :<inst>.ag2.space (the same convention that maps <inst> to
+# channels/<inst>-ag2space/ below), so those suffixes are foreign to the
+# default lane. Operator-set GATEWAY_FOREIGN_SUFFIXES wins verbatim.
+derive_foreign_suffixes() {
+  if [ -n "${GATEWAY_FOREIGN_SUFFIXES:-}" ]; then
+    printf '%s' "$GATEWAY_FOREIGN_SUFFIXES"
+    return 0
+  fi
+  local _dfs_out="" _dfs_var _dfs_inst
+  for _dfs_var in $(env | grep -o '^AG2_REMOTE_TOKEN_[A-Za-z0-9_][A-Za-z0-9_]*' || true); do
+    _dfs_inst="$(printf '%s' "${_dfs_var#AG2_REMOTE_TOKEN_}" | tr '[:upper:]' '[:lower:]')"
+    _dfs_out="${_dfs_out:+$_dfs_out,}:${_dfs_inst}.ag2.space"
+  done
+  printf '%s' "$_dfs_out"
+}
+
 # Requires REPO, PY (resolved via scripts/python-binary.sh) and LOGS_DIR set
 # by the caller — same contract as every other block in startup.sh.
 start_gateway_lanes() {
@@ -489,7 +506,8 @@ start_gateway_lanes() {
     # the redirect below); the bridge stamps launched_via into gateway-status
     # and skips its own bare-launch file log. See remote_gateway_bridge._log.
     if [ -n "$PY" ]; then
-      SUTANDO_SUPERVISED=1 "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
+      SUTANDO_SUPERVISED=1 GATEWAY_FOREIGN_SUFFIXES="$(derive_foreign_suffixes)" \
+        "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
       echo "  ✓ gateway bridge (self-defers if already running)"
     else
       echo "  ⊘ gateway bridge skipped — no runnable python3"

--- a/tests/gateway-default-lane-foreign-suffixes.test.sh
+++ b/tests/gateway-default-lane-foreign-suffixes.test.sh
@@ -65,6 +65,7 @@ else
 fi
 
 # --- wiring: BOTH launch paths carry the derived value ----------------------
+
 # Assert the claim, not a file-wide count: an `== 1` over the whole file is
 # stronger than the intent and fails on any second legitimate injection site.
 named_lane_block="$(awk '/GATEWAY_INSTANCE="\$_gw_inst"/,/remote-gateway-bridge\.py/' \

--- a/tests/gateway-default-lane-foreign-suffixes.test.sh
+++ b/tests/gateway-default-lane-foreign-suffixes.test.sh
@@ -64,14 +64,39 @@ else
   bad "operator GATEWAY_FOREIGN_SUFFIXES wins verbatim over derivation" "got '$got'"
 fi
 
-# --- wiring: the default-lane spawn actually passes the derived value -------
-# The named-lane loop must NOT get it (instanced lanes fence by
-# GATEWAY_ROOM_SUFFIX; the foreign list is the default lane's mirror).
-spawn_lines="$(grep -n 'GATEWAY_FOREIGN_SUFFIXES="\$(derive_foreign_suffixes)"' "$REPO/src/startup-runtime.sh" | wc -l | tr -d ' ')"
-if [ "$spawn_lines" = 1 ]; then
-  ok "exactly one spawn site injects the derived value (default lane)"
+# --- wiring: BOTH launch paths carry the derived value ----------------------
+# Assert the claim, not a file-wide count: an `== 1` over the whole file is
+# stronger than the intent and fails on any second legitimate injection site.
+named_lane_block="$(awk '/GATEWAY_INSTANCE="\$_gw_inst"/,/remote-gateway-bridge\.py/' \
+  "$REPO/src/startup-runtime.sh")"
+if printf '%s' "$named_lane_block" | grep -q 'GATEWAY_FOREIGN_SUFFIXES'; then
+  bad "the named-lane spawn does not inject the foreign list" "found it in the lane block"
 else
-  bad "exactly one spawn site injects the derived value (default lane)" "found $spawn_lines"
+  ok "the named-lane spawn does not inject the foreign list"
+fi
+
+if grep -q 'GATEWAY_FOREIGN_SUFFIXES="\$(derive_foreign_suffixes)"' "$REPO/src/startup-runtime.sh"; then
+  ok "the bare default-lane spawn injects the derived value"
+else
+  bad "the bare default-lane spawn injects the derived value" "no injection site found"
+fi
+
+# The supervised path is the PREFERRED one, so a fence only on the fallback
+# leaves the same host behaving two ways depending on launchd health.
+wrapper="$REPO/src/launchd/gateway-bridge-wrapper.sh"
+if grep -q 'GATEWAY_FOREIGN_SUFFIXES="\$(derive_foreign_suffixes)"' "$wrapper" \
+   && grep -q 'export GATEWAY_FOREIGN_SUFFIXES' "$wrapper"; then
+  ok "the launchd wrapper derives and exports the value (supervised path)"
+else
+  bad "the launchd wrapper derives and exports the value (supervised path)" "not wired"
+fi
+
+# One derivation, not two copies that can drift.
+defs="$(grep -rl 'derive_foreign_suffixes() {' "$REPO/src" | wc -l | tr -d ' ')"
+if [ "$defs" = 1 ]; then
+  ok "exactly one definition of derive_foreign_suffixes in src/"
+else
+  bad "exactly one definition of derive_foreign_suffixes in src/" "found $defs"
 fi
 
 # --- negative control: the harness can fail ---------------------------------

--- a/tests/gateway-default-lane-foreign-suffixes.test.sh
+++ b/tests/gateway-default-lane-foreign-suffixes.test.sh
@@ -20,9 +20,13 @@ echo "default-lane GATEWAY_FOREIGN_SUFFIXES derivation:"
 
 # Each case runs the SHIPPED function in a clean subshell so ambient
 # AG2_REMOTE_TOKEN_* / GATEWAY_FOREIGN_SUFFIXES on the invoking host cannot
-# leak into the derivation under test.
+# leak into the derivation under test. GATEWAY_CHANNELS_DIR always points at a
+# fixture so the host's real channel .envs never reach the derivation.
+FIXTURES="$(mktemp -d)"
+trap 'rm -rf "$FIXTURES"' EXIT
+mkdir -p "$FIXTURES/empty"
 derive() {
-  env -i HOME="$HOME" PATH="$PATH" "$@" bash -c \
+  env -i HOME="$HOME" PATH="$PATH" GATEWAY_CHANNELS_DIR="$FIXTURES/empty" "$@" bash -c \
     "source '$REPO/src/startup-runtime.sh' >/dev/null 2>&1; derive_foreign_suffixes"
 }
 
@@ -62,6 +66,50 @@ if [ "$got" = ":custom.example" ]; then
   ok "operator GATEWAY_FOREIGN_SUFFIXES wins verbatim over derivation"
 else
   bad "operator GATEWAY_FOREIGN_SUFFIXES wins verbatim over derivation" "got '$got'"
+fi
+
+# --- the lane's identity domain outranks the name convention ----------------
+# The instance name is a label; the homeserver is whatever the lane's
+# AGENT_MXID says. A local homeserver named "localhost" must fence
+# ":localhost" — ":local.ag2.space" fences a suffix that exists nowhere.
+mkdir -p "$FIXTURES/mxid/local-ag2space" "$FIXTURES/mxid/dev-ag2space"
+printf 'AGENT_MXID=@qingyun-local.agent:localhost\n' \
+  > "$FIXTURES/mxid/local-ag2space/.env"
+printf 'REMOTE_TASK_PROVIDER=dev-ag2space\n' \
+  > "$FIXTURES/mxid/dev-ag2space/.env"
+got="$(derive GATEWAY_CHANNELS_DIR="$FIXTURES/mxid" AG2_REMOTE_TOKEN_LOCAL=x)"
+if [ "$got" = ":localhost" ]; then
+  ok "AGENT_MXID domain outranks the name convention (:localhost)"
+else
+  bad "AGENT_MXID domain outranks the name convention (:localhost)" "got '$got'"
+fi
+
+# A lane .env WITHOUT an AGENT_MXID keeps the conventional suffix (pre-identity
+# lanes must fence exactly as before this change).
+got="$(derive GATEWAY_CHANNELS_DIR="$FIXTURES/mxid" AG2_REMOTE_TOKEN_DEV=x)"
+if [ "$got" = ":dev.ag2.space" ]; then
+  ok "lane .env without AGENT_MXID falls back to the convention"
+else
+  bad "lane .env without AGENT_MXID falls back to the convention" "got '$got'"
+fi
+
+# Mixed fleet: one identity-bearing lane + one conventional lane, both fenced.
+got="$(derive GATEWAY_CHANNELS_DIR="$FIXTURES/mxid" AG2_REMOTE_TOKEN_DEV=x AG2_REMOTE_TOKEN_LOCAL=y)"
+case "$got" in
+  *":dev.ag2.space"*":localhost"*|*":localhost"*":dev.ag2.space"*)
+    ok "mixed fleet derives both the mxid and conventional suffixes" ;;
+  *)
+    bad "mixed fleet derives both the mxid and conventional suffixes" "got '$got'" ;;
+esac
+
+# A malformed AGENT_MXID (no colon) cannot produce an empty suffix.
+mkdir -p "$FIXTURES/bad/dev-ag2space"
+printf 'AGENT_MXID=not-an-mxid\n' > "$FIXTURES/bad/dev-ag2space/.env"
+got="$(derive GATEWAY_CHANNELS_DIR="$FIXTURES/bad" AG2_REMOTE_TOKEN_DEV=x)"
+if [ "$got" = ":dev.ag2.space" ]; then
+  ok "malformed AGENT_MXID falls back to the convention"
+else
+  bad "malformed AGENT_MXID falls back to the convention" "got '$got'"
 fi
 
 # --- wiring: BOTH launch paths carry the derived value ----------------------

--- a/tests/gateway-default-lane-foreign-suffixes.test.sh
+++ b/tests/gateway-default-lane-foreign-suffixes.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# The default gateway lane must not claim unaddressed proactives whose peek
+# room sits on a named lane's homeserver suffix — its gateway 403s them and
+# the failure policy parks deliverable work as undeliverable (#3427 adds the
+# bridge-side fence, read from GATEWAY_FOREIGN_SUFFIXES). This test pins the
+# LAUNCHER half: the tracked config derives that env for the default lane
+# from the configured named instances, so a deploy cannot forget it.
+#
+# Run: bash tests/gateway-default-lane-foreign-suffixes.test.sh
+# Exit: 0 = all pass, 1 = failure
+set -uo pipefail
+
+REPO="${REPO_UNDER_TEST:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+fails=0
+
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s — %s\n' "$1" "${2:-}"; fails=$((fails + 1)); }
+
+echo "default-lane GATEWAY_FOREIGN_SUFFIXES derivation:"
+
+# Each case runs the SHIPPED function in a clean subshell so ambient
+# AG2_REMOTE_TOKEN_* / GATEWAY_FOREIGN_SUFFIXES on the invoking host cannot
+# leak into the derivation under test.
+derive() {
+  env -i HOME="$HOME" PATH="$PATH" "$@" bash -c \
+    "source '$REPO/src/startup-runtime.sh' >/dev/null 2>&1; derive_foreign_suffixes"
+}
+
+# --- no named instances → empty (fence stays inert) -------------------------
+got="$(derive)"
+if [ "$got" = "" ]; then
+  ok "no named instances derives empty"
+else
+  bad "no named instances derives empty" "got '$got'"
+fi
+
+# --- one named instance → its conventional suffix ---------------------------
+got="$(derive AG2_REMOTE_TOKEN_DEV=x)"
+if [ "$got" = ":dev.ag2.space" ]; then
+  ok "AG2_REMOTE_TOKEN_DEV derives :dev.ag2.space"
+else
+  bad "AG2_REMOTE_TOKEN_DEV derives :dev.ag2.space" "got '$got'"
+fi
+
+# --- two named instances → comma-joined, both present -----------------------
+got="$(derive AG2_REMOTE_TOKEN_DEV=x AG2_REMOTE_TOKEN_STAGING=y)"
+case "$got" in
+  *":dev.ag2.space"*) dev_in=1 ;; *) dev_in=0 ;;
+esac
+case "$got" in
+  *":staging.ag2.space"*) stg_in=1 ;; *) stg_in=0 ;;
+esac
+if [ "$dev_in" = 1 ] && [ "$stg_in" = 1 ] && [ "$(printf '%s' "$got" | tr -cd ',' | wc -c | tr -d ' ')" = 1 ]; then
+  ok "two instances derive both suffixes, comma-joined"
+else
+  bad "two instances derive both suffixes, comma-joined" "got '$got'"
+fi
+
+# --- operator override wins verbatim ----------------------------------------
+got="$(derive AG2_REMOTE_TOKEN_DEV=x GATEWAY_FOREIGN_SUFFIXES=":custom.example")"
+if [ "$got" = ":custom.example" ]; then
+  ok "operator GATEWAY_FOREIGN_SUFFIXES wins verbatim over derivation"
+else
+  bad "operator GATEWAY_FOREIGN_SUFFIXES wins verbatim over derivation" "got '$got'"
+fi
+
+# --- wiring: the default-lane spawn actually passes the derived value -------
+# The named-lane loop must NOT get it (instanced lanes fence by
+# GATEWAY_ROOM_SUFFIX; the foreign list is the default lane's mirror).
+spawn_lines="$(grep -n 'GATEWAY_FOREIGN_SUFFIXES="\$(derive_foreign_suffixes)"' "$REPO/src/startup-runtime.sh" | wc -l | tr -d ' ')"
+if [ "$spawn_lines" = 1 ]; then
+  ok "exactly one spawn site injects the derived value (default lane)"
+else
+  bad "exactly one spawn site injects the derived value (default lane)" "found $spawn_lines"
+fi
+
+# --- negative control: the harness can fail ---------------------------------
+got="$(derive AG2_REMOTE_TOKEN_DEV=x)"
+if [ "$got" = ":wrong.example" ]; then
+  bad "negative control" "harness cannot fail — ':wrong.example' matched"
+else
+  ok "negative control: a wrong expectation would be caught"
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "ALL PASS"
+  exit 0
+else
+  echo "$fails FAILURE(S)"
+  exit 1
+fi


### PR DESCRIPTION
## What

Roadmap queued slice 1 (gateway MIRROR GAP follow-through): the tracked launcher now supplies `GATEWAY_FOREIGN_SUFFIXES` to the **default lane's** spawn, derived from the configured named instances (`AG2_REMOTE_TOKEN_<INST>` → `:<inst>.ag2.space`, the same convention the launcher already uses to map `<inst>` → `channels/<inst>-ag2space/`). An operator-set value wins verbatim. Named lanes are untouched (they fence via `GATEWAY_ROOM_SUFFIX`).

**Pairs with #3427** (bridge-side fence, same base): the env is ignored by pre-#3427 bridge code, so this PR is inert on its own and can land in either order. Activation = both on the lane's checkout + the next owner-attended bounce (bounce #2 already queued for the #3408 exact-head witness).

## Why the launcher, not hand-set env

#3427 shipped config-gated; nothing sets its env. A hand-exported variable on the box is exactly the untracked drift the git-first rule prohibits — the tracked launcher is where lane env already lives (`GATEWAY_INSTANCE`, per-instance tokens, channel dirs).

## Before / after

Parent commit (`origin/feat/sutando-server`, b923a791):
```
$ git grep -c GATEWAY_FOREIGN_SUFFIXES origin/feat/sutando-server -- src/startup-runtime.sh
0 (no match)   # the default-lane spawn exports nothing; #3427's fence stays inert
```

HEAD:
```
$ bash tests/gateway-default-lane-foreign-suffixes.test.sh
default-lane GATEWAY_FOREIGN_SUFFIXES derivation:
  ok   no named instances derives empty
  ok   AG2_REMOTE_TOKEN_DEV derives :dev.ag2.space
  ok   two instances derive both suffixes, comma-joined
  ok   operator GATEWAY_FOREIGN_SUFFIXES wins verbatim over derivation
  ok   exactly one spawn site injects the derived value (default lane)
  ok   negative control: a wrong expectation would be caught
ALL PASS
```

Neighbor suite `tests/restart-gateway-lanes-no-watcher-touch.test.sh`: ALL PASS at HEAD. `scripts/review-checks.sh --diff`: PASS (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files — shell-only diff).

The test cases run the **shipped** `derive_foreign_suffixes` in an `env -i` subshell (no copy of the logic), plus one wiring assertion that exactly one spawn site injects it.

## Known limits (named, not hidden)

- **launchd-supervised gateway path not covered**: when the bridge runs under the launchd installer, its env comes from the plist, not this spawn. The live lanes on this host run the bare-launch path (relaunch log 14:29Z, pids 20511/81359), which is the bounce-#2 path. Extending the plist installer is a separate concern.
- `.ag2.space` domain is the existing instance-naming convention; a lane on a different domain uses the operator override.
- Base is `feat/sutando-server` (same as #3427) — feature-base CI runs the reduced check set; the two shell suites above were run locally at HEAD.

## Live-path note

This is startup/launcher surface: the real post-restart round trip rides owner bounce #2 (one restart serves the #3408 exact-head witness AND this pickup + #3427's). Until then the change is provably inert (env unread by the running @b923a791 bridges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)