### PR TITLE
fix(questions): a bullet question delivers its ask, not just its label

### DIFF
--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -196,9 +196,13 @@ def get_waiting_questions():
             # that blank line and a start-anchored slice comes back empty.
             line_start = content.rfind("\n", 0, m.end()) + 1
             line_end = content.find("\n", m.end())
-            body = content[line_start:line_end if line_end != -1 else len(content)].strip()
+            stop = line_end if line_end != -1 else len(content)
+            body = content[line_start:stop].strip()
+            # The DM renders `snippet`, not `body`; an empty one delivered the
+            # bracketed label alone, so options and defaults never reached anyone.
+            ask = content[m.end():stop].strip().lstrip("*").strip()
             questions.append({"id": title[:40], "title": title,
-                              "snippet": "", "body": body or title})
+                              "snippet": ask[:120], "body": body or title})
     return questions
 
 

--- a/tests/check-pending-questions-snippet.test.py
+++ b/tests/check-pending-questions-snippet.test.py
@@ -89,9 +89,16 @@ ok("empty body → snippet is empty string",
 
 # 4. Bullet-format entries have no snippet (one-liners, body = "")
 qs = questions_for("  - **[bullet item, 2026-06-30]** action text here\n")
-ok("bullet entry → no snippet key or empty",
-   len(qs) == 1 and not qs[0].get("snippet"),
+# #1861 asserted bullets carry no snippet because at the time they were
+# one-liners whose label WAS the content. The format outgrew that premise.
+ok("bullet entry → snippet is the ask after the label",
+   len(qs) == 1 and qs[0].get("snippet") == "action text here",
    f"got {qs[0] if qs else 'N/A'}")
+
+qs_bare = questions_for("  - **[bare label, 2026-06-30]**\n")
+ok("label-only bullet → still no snippet",
+   len(qs_bare) == 1 and not qs_bare[0].get("snippet"),
+   f"got {qs_bare[0] if qs_bare else 'N/A'}")
 
 # 5. notify_discord_dm renders arrow-snippet under title when present
 qs_with_snippet = [{"title": "pending question", "snippet": "Run bash --init to fix."}]

--- a/tests/pending-questions-bullet-snippet.test.py
+++ b/tests/pending-questions-bullet-snippet.test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""A bullet question must deliver its ASK, not just its bracketed label.
+
+The proactive DM renders `snippet`; the bullet parser hardcoded it empty, so a
+question carrying options and a default arrived as a slug and a date.
+"""
+import importlib.util
+import tempfile
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "cpq", Path(__file__).resolve().parent.parent / "src" / "check-pending-questions.py")
+cpq = importlib.util.module_from_spec(spec)
+try:
+    spec.loader.exec_module(cpq)
+except SystemExit:
+    pass
+
+fails = []
+
+
+def check(name, cond):
+    print(("  ok  " if cond else "  FAIL ") + name)
+    if not cond:
+        fails.append(name)
+
+
+def load(text):
+    d = Path(tempfile.mkdtemp())
+    f = d / "pending-questions.md"
+    f.write_text(text)
+    cpq.PQ_FILE = f
+    return cpq.get_waiting_questions()
+
+
+ASK = "One word: `handler` (land it -- rec) / `ungate`. Silence takes the recommendation."
+q = load(f"# Pending\n\n- **[demo-slug, 2026-08-26]** {ASK}\n\n# Resolved\n")
+check("the bullet is counted", len(q) == 1)
+check("snippet carries the ask, not the empty string", bool(q and q[0]["snippet"]))
+check("the options reach the rendered snippet", bool(q) and "One word" in q[0]["snippet"])
+check("the label is not repeated into the snippet", bool(q) and "demo-slug" not in q[0]["snippet"])
+
+# The control that can fail: a label-only bullet has no ask, and must not
+# manufacture one out of its own title.
+q2 = load("# Pending\n\n- **[bare-label, 2026-08-26]**\n\n# Resolved\n")
+check("a bullet with no ask yields an empty snippet", len(q2) == 1 and q2[0]["snippet"] == "")
+
+# Section-format questions keep their existing snippet behaviour.
+q3 = load("# Pending\n\n## A section question\n\nBody line one.\n\n# Resolved\n")
+check("section format still populates its snippet", len(q3) == 1 and "Body line one" in q3[0]["snippet"])
+
+print(("FAILED: " + ", ".join(fails)) if fails else "ALL PASS")
+raise SystemExit(1 if fails else 0)


### PR DESCRIPTION
## What

The bullet parser in `check-pending-questions.py` hardcoded `"snippet": ""`. The proactive DM renders `snippet` (`:350`), so every question filed in the `- **[label, date]** ...` bullet form — **the format the proactive-loop skill instructs agents to use** — reached the owner as a bracketed slug and a date, with the actual ask discarded.

The body was parsed correctly all along. The existing comment even says so: *"the rest of the bullet — where the actual ask lives"*. Nothing rendered it.

## Evidence

Same fixture, both revisions:

```
MAIN    n=1 snippet='' options_visible=False
FIXED   n=1 snippet='The gate misbehaves on dev. One word: `handler` (land it — rec) / `ung' options_visible=True
```

Measured on this host's live file before the fix: 37 waiting questions, three of them mine at visible slots 2–4, **every rendered snippet empty**. They satisfied "counted" and "positioned" and still delivered nothing actionable.

## Why it matters beyond cosmetics

`docs`/skill guidance already tells agents a question must be answerable in one word from the rendered text — options, a recommendation, an inverted default. That guidance was unreachable by construction: the options are written into the bullet, and the bullet remainder never rendered.

This also explains a previously-misdiagnosed incident recorded on this host: a question delivered **36 times**, always inside the visible five, twice at the top, after which the owner asked what it had been. The prior post-mortem concluded the question lacked options and blamed phrasing. It had options — they never arrived.

## Tests

New `tests/pending-questions-bullet-snippet.test.py`, 6 assertions including two controls that can fail:

- a label-only bullet must **not** manufacture a snippet from its own title
- section-format questions keep their existing snippet behaviour

Mutation-verified — restoring `"snippet": ""`:

```
FAILED: snippet carries the ask, not the empty string, the options reach the rendered snippet
```

with both controls still passing, so they are not passing vacuously.

Existing suites green: `check-pending-questions-bullet`, `check-pending-questions-collapse`, `agent-api-pending-questions`, `auth-gate-question-is-counted`, `briefing-pending-status`. None of them asserted on bullet `snippet`, which is why this survived.

`review-checks: PASS`.
