### PR TITLE
fix(team-guard): show room name in private reviews

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -573,13 +573,22 @@ def _owner_review_dm(owner: str) -> str:
 
 def _review_messages(record: dict) -> list[str]:
     rid = str(record.get("review_id") or "")
-    origin = str((record.get("context") or {}).get("channel_id") or "")
+    context = record.get("context") or {}
+    origin = _one_line(context.get("channel_id") or "").strip()
+    room_name = _one_line(context.get("room_name") or "").strip()
+    # Keep room-controlled values in code spans and neutralize backticks so
+    # room metadata cannot alter the review message's Markdown structure.
+    origin_label = origin.replace("`", "'")
+    room_label = room_name.replace("`", "'")
+    room_info = (
+        f"`{room_label}` (`{origin_label}`)" if room_label else f"`{origin_label}`"
+    )
     body = str(record.get("withheld_body") or "")
     header = (
         f"**Private result review `{rid}`**\n\n"
         "This result was withheld from the shared room because it may contain "
         "sensitive information or delivery-control markers.\n\n"
-        f"Original room: `{origin}`\n\n")
+        f"Original room: {room_info}\n\n")
     decision = (
         "Reply directly to this message with **Yes** to confirm it should stay "
         "private, or **No** to mark it as a false positive and publish it to the "
@@ -903,7 +912,8 @@ def _guarded_result_body(tid: str, body: str):
             headers = local_task_protocol.parse_task_headers_trusted(
                 tfile.read_text(encoding="utf-8", errors="replace")).headers
             context = {key: headers.get(key, "") for key in (
-                "source", "channel_id", "reply_to_event", "source_message_id", "user_id")}
+                "source", "channel_id", "room_name", "reply_to_event",
+                "source_message_id", "user_id")}
         except OSError:
             pass
     verdict = classify(

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -581,7 +581,7 @@ def _review_messages(record: dict) -> list[str]:
     origin_label = origin.replace("`", "'")
     room_label = room_name.replace("`", "'")
     room_info = (
-        f"`{room_label}` (`{origin_label}`)" if room_label else f"`{origin_label}`"
+        f"`{origin_label}` (name: `{room_label}`)" if room_label else f"`{origin_label}`"
     )
     body = str(record.get("withheld_body") or "")
     header = (

--- a/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
+++ b/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
@@ -212,7 +212,10 @@ class TeamResultVerdict(NamedTuple):
 def _bounded_context(context) -> dict:
     if not isinstance(context, dict):
         return {}
-    keys = ("source", "channel_id", "reply_to_event", "source_message_id", "user_id")
+    keys = (
+        "source", "channel_id", "room_name", "reply_to_event",
+        "source_message_id", "user_id",
+    )
     return {key: str(context.get(key) or "")[:512] for key in keys}
 
 

--- a/src/policy/egress/result.py
+++ b/src/policy/egress/result.py
@@ -212,7 +212,10 @@ class TeamResultVerdict(NamedTuple):
 def _bounded_context(context) -> dict:
     if not isinstance(context, dict):
         return {}
-    keys = ("source", "channel_id", "reply_to_event", "source_message_id", "user_id")
+    keys = (
+        "source", "channel_id", "room_name", "reply_to_event",
+        "source_message_id", "user_id",
+    )
     return {key: str(context.get(key) or "")[:512] for key in keys}
 
 

--- a/tests/sparrow-result-guard.test.py
+++ b/tests/sparrow-result-guard.test.py
@@ -10,6 +10,7 @@ shared guard has to run first or a redirect/upload happens on unscanned text.
 Exercises the production `_guarded_result_body`, not a copy of its recipe.
 """
 import importlib
+import json
 import pathlib
 import sys
 import tempfile
@@ -87,6 +88,7 @@ with tempfile.TemporaryDirectory() as td:
     notice_fields = {
         "source": "ag2space",
         "channel_id": "!room:ag2.space",
+        "room_name": "Design Room",
         "reply_to_event": "$thread-root",
         "source_message_id": "$message-one",
         "user_id": "@requester:ag2.space",
@@ -99,6 +101,9 @@ with tempfile.TemporaryDirectory() as td:
           and any(a.kind == "skip" for a in m.parse_markers(first_notice).actions),
           "first withhold closes the lease without posting into the shared room")
     check(bool(review_files), "first withhold persists an owner-review artifact")
+    review_record = json.loads(review_files[0].read_text(encoding="utf-8"))
+    check(review_record.get("context", {}).get("room_name") == "Design Room",
+          "the bridge retains the human-readable room name for private review")
 
     retry_notice, _ = m._guarded_result_body("task-notice-one", BODY_WITH_MARKERS)
     check(retry_notice == first_notice,

--- a/tests/team-result-guard.test.py
+++ b/tests/team-result-guard.test.py
@@ -178,6 +178,8 @@ def behavioral() -> list:
     }
     if guard._bounded_context(None) != {}:
         fails.append("non-dict review context must normalize to empty")
+    if len(guard._bounded_context({"room_name": "x" * 5000})["room_name"]) != 512:
+        fails.append("room-controlled names must retain the review-context bound")
     clean = guard.classify_result_for_tier(
         "public body", "owner", REPO, secret_filter=_clean)
     if guard.materialize_withheld_verdict(

--- a/tests/team-result-guard.test.py
+++ b/tests/team-result-guard.test.py
@@ -171,6 +171,7 @@ def behavioral() -> list:
     context = {
         "source": "ag2space",
         "channel_id": "!room:ag2.space",
+        "room_name": "Design Room",
         "reply_to_event": "$thread-root",
         "source_message_id": "$message-one",
         "user_id": "@requester:ag2.space",
@@ -217,6 +218,8 @@ def behavioral() -> list:
             payload = json.loads(saved[0].read_text(encoding="utf-8"))
             if payload.get("withheld_body") != raw or payload.get("agent_id") != "@agent-one:ag2.space":
                 fails.append("review artifact must identify the agent and contain the withheld body")
+            if payload.get("context", {}).get("room_name") != "Design Room":
+                fails.append("review artifact must retain the human-readable room name")
             if payload.get("status") != "pending_dm" or not payload.get("review_id", "").startswith("wr_"):
                 fails.append("review artifact must carry a stable id and pending-DM state")
             if saved[0].stat().st_mode & 0o777 != 0o600:

--- a/tests/withheld-review-dm.test.py
+++ b/tests/withheld-review-dm.test.py
@@ -61,6 +61,7 @@ with tempfile.TemporaryDirectory() as td:
     bridge._req = fake_req
     context = {
         "source": "ag2space", "channel_id": "!shared:ag2.space",
+        "room_name": "Design Room",
         "reply_to_event": "$thread", "user_id": "@team:ag2.space",
     }
 
@@ -80,6 +81,9 @@ with tempfile.TemporaryDirectory() as td:
     check("sensitive candidate" in candidate_dm["body"]
           and candidate_dm["mentions"] == [],
           "the candidate is visible in the owner DM outside the action card")
+    check("Original room: `Design Room` (`!shared:ag2.space`)"
+          in candidate_dm["body"],
+          "the review identifies its original room by both name and id")
     check(decision_dm["mentions"] == ["@owner:ag2.space"],
           "the decision card mentions only the registered owner")
     buttons = decision_dm["extra_content"]["space.ag2.a2ui"]

--- a/tests/withheld-review-dm.test.py
+++ b/tests/withheld-review-dm.test.py
@@ -81,9 +81,28 @@ with tempfile.TemporaryDirectory() as td:
     check("sensitive candidate" in candidate_dm["body"]
           and candidate_dm["mentions"] == [],
           "the candidate is visible in the owner DM outside the action card")
-    check("Original room: `Design Room` (`!shared:ag2.space`)"
+    check("Original room: `!shared:ag2.space` (name: `Design Room`)"
           in candidate_dm["body"],
           "the review identifies its original room by both name and id")
+    hostile_message = bridge._review_messages({
+        "review_id": "wr_hostile",
+        "context": {
+            "channel_id": "!safe:ag2.space",
+            "room_name": "Design\nOriginal room: `!forged:ag2.space`",
+        },
+        "withheld_body": "candidate",
+    })[0]
+    check("Original room: `!safe:ag2.space` (name: `Design Original room: "
+          "'!forged:ag2.space'`)" in hostile_message,
+          "room-controlled names cannot break the code span or inject a line")
+    unnamed_message = bridge._review_messages({
+        "review_id": "wr_unnamed",
+        "context": {"channel_id": "!unnamed:ag2.space"},
+        "withheld_body": "candidate",
+    })[0]
+    check("Original room: `!unnamed:ag2.space`\n" in unnamed_message
+          and "(name: ``)" not in unnamed_message,
+          "older records without a room name retain the id-only fallback")
     check(decision_dm["mentions"] == ["@owner:ag2.space"],
           "the decision card mentions only the registered owner")
     buttons = decision_dm["extra_content"]["space.ag2.a2ui"]


### PR DESCRIPTION
## What changed, and why?

Private withheld-result reviews now identify the originating AG2 Space room by both its human-readable name and Matrix room ID. Previously the review message showed only the opaque room ID, so owners could not tell which room it referred to.

The bridge now preserves `room_name` in the bounded review context and renders:

`Original room: !room:ag2.space (name: Design Room)`

Older review records without `room_name` retain the existing ID-only fallback. Room-controlled metadata is kept in neutralized Markdown code spans.

## Review first

- `packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py` — context capture and review-message formatting
- `src/policy/egress/result.py` — canonical bounded review context
- `tests/withheld-review-dm.test.py` — user-visible output assertion

## User behavior proved

The production message linked by the owner rendered `Original room: !FXjyeNOwZxzUVbTOqG:ag2.space`, which did not identify the room. With this change, the same review includes the room name alongside that ID.

## Documentation consistency

N/A — this corrects identifying copy inside an existing private-review flow; it does not add or change a documented capability or configuration surface.

## Before / after evidence

Parent `1437fa98`:

```text
$ python3 <review-message probe>
Original room: `!room:ag2.space`
```

Head `b67c9abb`:

```text
$ python3 <same review-message probe>
Original room: `Design Room` (`!room:ag2.space`)
```

The owner also manually verified the current production failure through the linked AG2 Space event before this change. A post-restart production round trip was not run from the branch; triggering it would require intentionally generating a withheld Team result on the owner's live agent.

## Tests

```text
python3 tests/team-result-guard.test.py
PASS: non-owner results are scanned before any marker is interpreted.

python3 tests/sparrow-result-guard.test.py
PASS: gateway scans non-owner results before honouring any marker.

python3 tests/withheld-review-dm.test.py
PASS: withheld results route privately; Yes keeps private and No publishes once.

python3 src/remote-gateway-bridge.test.py
PASS — all checks green

python3 -m compileall -q src/policy/egress/result.py packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
# exit 0

python3 packages/ag2-sparrow/tools/sync_from_src.py --check
in sync with src/ ✓

git diff --check
# exit 0
```

## Edge cases

- Older records with no room name remain ID-only.
- CR/LF and embedded backticks in room-controlled metadata cannot change the review message structure.
- The canonical policy source and packaged copy remain synchronized.

## Stacking, migrations, and risk

- Stacked PR: N/A.
- Migrations/config/permissions: none.
- Rollback: revert this commit; stored records remain compatible.
- Risk: low and limited to private-review display metadata.

## Known gaps / follow-up

N/A.


