### PR TITLE
fix(discord-bridge): backfill missed messages on reconnect

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2736,6 +2736,9 @@ async def on_ready():
     # does NOT replay `MESSAGE_CREATE` events that arrived during the
     # gap. See `_catchup_missed_dms` for the replay flow.
     client.loop.create_task(_catchup_missed_dms())
+    # Same replay guarantee for served guild channels/threads — watermarked
+    # separately in state/discord-last-seen.json.
+    client.loop.create_task(_backfill_missed_channel_messages())
     # Start polling loops EXACTLY ONCE. `on_ready` fires on every gateway
     # reconnect (RESUME-expiry, network blip, Discord-side reconnect), not
     # just first boot — so spawning these long-lived `while True` loops here
@@ -2755,6 +2758,14 @@ async def on_ready():
         client.loop.create_task(_supervise_loop(poll_dm_fallback, "poll_dm_fallback"))
         # Auto-mod LLM-judge flush timer (per-guild gate enforced inside flush)
         client.loop.create_task(_supervise_loop(_mod_flush_timer_loop, "_mod_flush_timer_loop"))
+
+
+@client.event
+async def on_resumed():
+    # A RESUME can be accepted after events were already dropped at the
+    # gateway boundary; one after=<watermark> sweep per channel is cheap.
+    client.loop.create_task(_catchup_missed_dms())
+    client.loop.create_task(_backfill_missed_channel_messages())
 
 
 def _message_mentions_bot(message):
@@ -3090,6 +3101,8 @@ async def _handle_discord_message(message, force=False):
                 _update_dm_checkpoint(message.channel.id, message.id)
             except Exception as e:
                 print(f"  [dm-checkpoint] self-message update failed: {e}", flush=True)
+        else:
+            _note_channel_message_seen(message)
         return
     # Ahead of EVERY content consumer, the mod observer included: a THREAD_CREATED
     # notice carries the thread NAME as content and must not be judged or actioned.
@@ -3101,6 +3114,8 @@ async def _handle_discord_message(message, force=False):
                 _update_dm_checkpoint(message.channel.id, message.id)
             except Exception as e:
                 print(f"  [dm-checkpoint] system-message update failed: {e}", flush=True)
+        else:
+            _note_channel_message_seen(message)
         print(f"  [skip] system message type={message.type}", flush=True)
         return
 
@@ -3137,6 +3152,8 @@ async def _handle_discord_message(message, force=False):
             _update_dm_checkpoint(message.channel.id, message.id)
         except Exception as e:
             print(f"  [dm-checkpoint] update failed: {e}", flush=True)
+    elif hasattr(message, "id"):
+        _note_channel_message_seen(message)
 
     safe_log_text = redact_chat_body(text)   # the shared chain; see src/chat_redaction.py
     print(f"  [msg] #{channel_name} @{username}: {safe_log_text[:80]} (mentions: {[str(m) for m in message.mentions]}, is_dm: {is_dm}, embeds: {len(message.embeds)}, type: {message.type}, ref: {message.reference is not None})", flush=True)
@@ -4416,25 +4433,32 @@ async def poll_approved():
 # monotonic so `after=<id>` reliably returns only newer messages.
 DM_CHECKPOINT_FILE = REPO / "state" / "discord-dm-checkpoint.json"
 
-def _atomic_write_dm_checkpoint(data: dict) -> None:
-    """Write JSON atomically — same shape as _atomic_write_pending_replies."""
+# Guild-channel twin of the DM checkpoint: served channels/threads (access.json
+# `groups`) get the same reconnect backfill, watermarked in this file.
+LAST_SEEN_FILE = REPO / "state" / "discord-last-seen.json"
+
+# Bound on messages replayed per channel per backfill pass.
+CHANNEL_BACKFILL_MAX_MESSAGES = 50
+
+
+def _atomic_write_id_map(path: "Path", data: dict) -> None:
+    """Atomic tmp+replace write of a `{str: str}` watermark map; best-effort."""
     try:
-        DM_CHECKPOINT_FILE.parent.mkdir(parents=True, exist_ok=True)
-        tmp = DM_CHECKPOINT_FILE.with_suffix(".json.tmp")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(data))
-        tmp.replace(DM_CHECKPOINT_FILE)
+        tmp.replace(path)
     except Exception:
         pass
 
 
-def _load_dm_checkpoint() -> dict:
-    """Read `state/discord-dm-checkpoint.json`. Maps
-    `channel_id (str) → last_processed_message_id (str)`. Returns
-    `{}` on missing/malformed file (fail-open)."""
+def _load_id_map(path: "Path") -> dict:
+    """Read a `{key (str) → id (str)}` watermark map. Fail-open: a missing or
+    malformed file yields `{}`; malformed entries are dropped individually."""
     try:
-        if not DM_CHECKPOINT_FILE.exists():
+        if not path.exists():
             return {}
-        data = json.loads(DM_CHECKPOINT_FILE.read_text())
+        data = json.loads(path.read_text())
         if not isinstance(data, dict):
             return {}
         return {
@@ -4446,20 +4470,147 @@ def _load_dm_checkpoint() -> dict:
         return {}
 
 
-def _update_dm_checkpoint(channel_id: int, message_id: int) -> None:
-    """Atomically advance the per-channel checkpoint to `message_id`.
-    Only writes if the new id is strictly greater (forward-only)."""
-    current = _load_dm_checkpoint()
-    new_id_str = str(message_id)
-    channel_str = str(channel_id)
-    old_id_str = current.get(channel_str, "0")
+def _advance_id_map(path: "Path", key, new_id) -> None:
+    """Advance one watermark atomically — forward-only, so an out-of-order
+    replay can never move a channel's checkpoint backwards."""
+    current = _load_id_map(path)
+    new_id_str = str(new_id)
+    key_str = str(key)
+    old_id_str = current.get(key_str, "0")
     try:
         if int(new_id_str) <= int(old_id_str):
             return
     except (ValueError, TypeError):
         pass
-    current[channel_str] = new_id_str
-    _atomic_write_dm_checkpoint(current)
+    current[key_str] = new_id_str
+    _atomic_write_id_map(path, current)
+
+
+def _atomic_write_dm_checkpoint(data: dict) -> None:
+    """Write JSON atomically — same shape as _atomic_write_pending_replies."""
+    _atomic_write_id_map(DM_CHECKPOINT_FILE, data)
+
+
+def _load_dm_checkpoint() -> dict:
+    """Read `state/discord-dm-checkpoint.json`. Maps
+    `channel_id (str) → last_processed_message_id (str)`. Returns
+    `{}` on missing/malformed file (fail-open)."""
+    return _load_id_map(DM_CHECKPOINT_FILE)
+
+
+def _update_dm_checkpoint(channel_id: int, message_id: int) -> None:
+    """Atomically advance the per-channel checkpoint to `message_id`.
+    Only writes if the new id is strictly greater (forward-only)."""
+    _advance_id_map(DM_CHECKPOINT_FILE, channel_id, message_id)
+
+
+def _load_last_seen() -> dict:
+    """Read `state/discord-last-seen.json` — the served-channel watermark map,
+    `channel_id (str) → last_seen_message_id (str)`. Fail-open to `{}`."""
+    return _load_id_map(LAST_SEEN_FILE)
+
+
+def _update_last_seen(channel_id, message_id) -> None:
+    """Forward-only advance of a served channel's watermark."""
+    _advance_id_map(LAST_SEEN_FILE, channel_id, message_id)
+
+
+def _note_channel_message_seen(message) -> None:
+    """Advance the served-channel watermark for any OBSERVED guild message.
+
+    Seen != processed (same contract as the DM checkpoint): the watermark
+    records what the gateway already delivered, whether or not downstream
+    gates dropped it, so backfill never re-fetches a live-delivered id.
+    Only channels the bridge serves (access.json `groups`) are tracked;
+    DMs advance the DM checkpoint instead. Never raises."""
+    try:
+        channel = getattr(message, "channel", None)
+        msg_id = getattr(message, "id", None)
+        channel_id = getattr(channel, "id", None)
+        if channel is None or msg_id is None or channel_id is None:
+            return
+        if isinstance(channel, discord.DMChannel):
+            return
+        if load_channel_config(str(channel_id)) is None:
+            return
+        _update_last_seen(channel_id, msg_id)
+    except Exception as e:
+        print(f"  [channel-watermark] update failed: {e}", flush=True)
+
+
+def _backfill_channel_ids() -> "list[str]":
+    """Channels the reconnect backfill serves: access.json `groups` keys with a
+    Discord snowflake shape (guild channels + seeded threads). DM channels are
+    the DM checkpoint's job — `_catchup_missed_dms` covers them."""
+    try:
+        data = json.loads(ACCESS_FILE.read_text())
+        groups = data.get("groups", {}) if isinstance(data, dict) else {}
+        return [str(cid) for cid in groups if _is_discord_channel_id(str(cid))]
+    except Exception:
+        return []
+
+
+async def _backfill_one_channel(channel_id_str: str) -> None:
+    """Replay one served channel's missed messages through the live handler.
+
+    No watermark yet → initialize it to the channel's newest message id
+    WITHOUT replaying, so a fresh watermark never turns channel history into
+    tasks. With a watermark → fetch `after=<watermark>` oldest-first (REST,
+    via the client's own authenticated session) and route every non-self
+    message through `_handle_discord_message` — the exact choke point live
+    messages take, so allowFrom/tierMap/requireMention/collaborator gates
+    apply identically."""
+    channel = client.get_channel(int(channel_id_str))
+    if channel is None:
+        channel = await client.fetch_channel(int(channel_id_str))
+    if isinstance(channel, discord.DMChannel):
+        return
+    watermark = _load_last_seen().get(channel_id_str)
+    if watermark is None:
+        async for msg in channel.history(limit=1):
+            _update_last_seen(channel_id_str, msg.id)
+        return
+    fetched = []
+    # One over the cap, so "exactly at the cap" and "cap binds" are tellable.
+    async for msg in channel.history(
+        after=discord.Object(id=int(watermark)),
+        limit=CHANNEL_BACKFILL_MAX_MESSAGES + 1,
+        oldest_first=True,
+    ):
+        fetched.append(msg)
+    if len(fetched) > CHANNEL_BACKFILL_MAX_MESSAGES:
+        print(
+            f"  [channel-backfill] WARN: channel {channel_id_str} has more than "
+            f"{CHANNEL_BACKFILL_MAX_MESSAGES} missed messages — replaying the oldest "
+            f"{CHANNEL_BACKFILL_MAX_MESSAGES}; the rest are fetched on the next reconnect",
+            flush=True,
+        )
+        fetched = fetched[:CHANNEL_BACKFILL_MAX_MESSAGES]
+    replayed = 0
+    for msg in fetched:
+        if getattr(msg, "author", None) == client.user:
+            _update_last_seen(channel_id_str, msg.id)
+            continue
+        try:
+            await _handle_discord_message(msg)
+            replayed += 1
+        except Exception as e:
+            print(f"  [channel-backfill] replay failed for msg {msg.id}: {e}", flush=True)
+        _update_last_seen(channel_id_str, msg.id)
+    if replayed:
+        print(f"  [channel-backfill] replayed {replayed} missed message(s) on channel {channel_id_str}", flush=True)
+
+
+async def _backfill_missed_channel_messages() -> None:
+    """Reconnect-safety for served guild channels/threads, mirroring
+    `_catchup_missed_dms`: the gateway does not replay MESSAGE_CREATE events
+    lost during a disconnect, so REST-fetch what the watermark says we missed.
+    One channel's failure logs and moves on — never the whole pass."""
+    for channel_id_str in _backfill_channel_ids():
+        try:
+            await _backfill_one_channel(channel_id_str)
+        except Exception as e:
+            print(f"  [channel-backfill] channel {channel_id_str} failed: {e}", flush=True)
 
 
 async def _catchup_missed_dms():

--- a/tests/discord-reconnect-backfill.test.py
+++ b/tests/discord-reconnect-backfill.test.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Reconnect backfill for served guild channels (discord-bridge).
+
+## The gap
+
+A Discord gateway disconnect that outlasts the RESUME window forces a full
+IDENTIFY reconnect, and IDENTIFY does NOT replay `MESSAGE_CREATE` events that
+arrived during the gap. DMs already have a REST catch-up
+(`_catchup_missed_dms` + `state/discord-dm-checkpoint.json`); guild channels
+and threads the bridge serves had none — a channel message sent during the
+gap was silently lost.
+
+## The fix under test
+
+Per-channel watermark in `state/discord-last-seen.json` for every channel in
+access.json `groups`, advanced as live messages are observed. On READY and
+RESUMED, `_backfill_missed_channel_messages()` REST-fetches
+`after=<watermark>` (oldest-first, capped at
+CHANNEL_BACKFILL_MAX_MESSAGES per channel) and routes each missed message
+through `_handle_discord_message` — the same choke point live messages take,
+so every access gate applies identically. A channel with no watermark only
+initializes it to the newest id (fresh installs never ingest history).
+
+All tests drive the production functions; the Discord client and channels are
+faked at the API boundary only.
+"""
+
+import asyncio
+import importlib.util
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import types
+from contextlib import contextmanager, redirect_stdout
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Set workspace BEFORE importing the bridge — it captures state-file
+# paths at module-load time.
+_WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-reconnect-backfill-test-")
+os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
+(Path(_WORKSPACE_TMP) / "state").mkdir(parents=True, exist_ok=True)
+
+
+def _load(name: str, path: Path):
+    if "discord" not in sys.modules:
+        stub = types.ModuleType("discord")
+        stub.Intents = type("Intents", (), {"default": staticmethod(lambda: type("I", (), {"message_content": False})())})
+        stub.Client = type("Client", (), {"__init__": lambda self, **kw: None, "event": staticmethod(lambda fn: fn)})
+        stub.File = type("File", (), {})
+        stub.DMChannel = type("DMChannel", (), {})
+        stub.Object = lambda id: type("Object", (), {"id": id})()
+        sys.modules["discord"] = stub
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+bridge = _load("discord_bridge_backfill", REPO / "src" / "discord-bridge.py")
+
+# Redirect access control to a test-owned file: the backfill's channel set and
+# the live watermark gate both read ACCESS_FILE.
+ACCESS_TMP = Path(_WORKSPACE_TMP) / "access.json"
+bridge.ACCESS_FILE = ACCESS_TMP
+
+# Valid Discord snowflake shapes (17-20 digits) — _backfill_channel_ids
+# filters on shape.
+CH1 = "223456789012345678"
+CH2 = "323456789012345678"
+UNTRACKED = "423456789012345678"
+
+
+def _set_groups(*channel_ids):
+    ACCESS_TMP.write_text(json.dumps({
+        "allowFrom": [],
+        "groups": {cid: {"requireMention": False} for cid in channel_ids},
+    }))
+
+
+def _clear_watermarks():
+    f = bridge.LAST_SEEN_FILE
+    if f.exists():
+        f.unlink()
+
+
+def _msg(mid, author):
+    return types.SimpleNamespace(id=mid, author=author)
+
+
+class _AsyncIter:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+class _FakeChannel:
+    """Fakes only the `history()` API edge; everything else is production."""
+
+    def __init__(self, cid, messages=(), fail_history=False):
+        self.id = cid
+        self.history_calls = []
+        self._messages = list(messages)
+        self._fail = fail_history
+
+    def history(self, *, limit=None, after=None, oldest_first=False):
+        if self._fail:
+            raise RuntimeError("history exploded")
+        self.history_calls.append(
+            {"limit": limit, "after": after, "oldest_first": oldest_first})
+        msgs = list(self._messages)
+        if after is not None:
+            msgs = [m for m in msgs if m.id > after.id]
+        msgs.sort(key=lambda m: m.id, reverse=not oldest_first)
+        if limit is not None:
+            msgs = msgs[:limit]
+        return _AsyncIter(msgs)
+
+
+class _FakeClient:
+    def __init__(self, channels, user):
+        self._channels = {int(c.id): c for c in channels}
+        self.user = user
+
+    def get_channel(self, cid):
+        return self._channels.get(int(cid))
+
+    async def fetch_channel(self, cid):
+        ch = self._channels.get(int(cid))
+        if ch is None:
+            raise RuntimeError(f"unknown channel {cid}")
+        return ch
+
+
+class _HandlerSpy:
+    """Stands in for the module attribute `_handle_discord_message`, so a call
+    through it proves the backfill dispatches to the live choke-point NAME —
+    a private copy of the handler would not route through this."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def __call__(self, message, force=False):
+        self.calls.append(message)
+
+
+@contextmanager
+def _patched(client, handler):
+    real_client = bridge.client
+    real_handler = bridge._handle_discord_message
+    bridge.client = client
+    bridge._handle_discord_message = handler
+    try:
+        yield
+    finally:
+        bridge.client = real_client
+        bridge._handle_discord_message = real_handler
+
+
+def test_first_ready_initializes_watermarks_without_replay():
+    """(i) No watermark yet → pin to the channel's newest id via one
+    limit=1 fetch; nothing is replayed. A fresh install must never ingest
+    channel history as tasks."""
+    _clear_watermarks()
+    _set_groups(CH1)
+    me, other = object(), object()
+    ch = _FakeChannel(int(CH1), [_msg(100, other), _msg(300, other), _msg(200, other)])
+    spy = _HandlerSpy()
+    with _patched(_FakeClient([ch], me), spy):
+        asyncio.run(bridge._backfill_missed_channel_messages())
+    assert spy.calls == [], (
+        f"first READY must not replay history; handler got {[m.id for m in spy.calls]}")
+    assert bridge._load_last_seen().get(CH1) == "300", (
+        f"watermark should pin to newest id 300, got {bridge._load_last_seen()!r}")
+    assert len(ch.history_calls) == 1, ch.history_calls
+    call = ch.history_calls[0]
+    assert call["limit"] == 1 and call["after"] is None, (
+        f"init must be one cheap limit=1 fetch, got {call!r}")
+
+
+def test_reconnect_replays_after_watermark_through_live_handler():
+    """(ii) With a watermark, the backfill fetches after=<watermark>
+    oldest-first and each fetched message goes through the SAME
+    `_handle_discord_message` the live gateway path calls (the spy replaces
+    that module attribute — a copied handler would bypass it). Self-authored
+    messages are skipped but still advance the watermark."""
+    _clear_watermarks()
+    _set_groups(CH1)
+    me, other = object(), object()
+    bridge._update_last_seen(CH1, 100)
+    ch = _FakeChannel(int(CH1), [
+        _msg(100, other),   # at the watermark — must not be re-fetched
+        _msg(150, other),
+        _msg(200, me),      # bot's own message — skipped
+        _msg(250, other),
+    ])
+    spy = _HandlerSpy()
+    with _patched(_FakeClient([ch], me), spy):
+        asyncio.run(bridge._backfill_missed_channel_messages())
+    assert [m.id for m in spy.calls] == [150, 250], (
+        f"expected [150, 250] through the choke point, got {[m.id for m in spy.calls]}")
+    call = ch.history_calls[0]
+    assert call["after"] is not None and call["after"].id == 100, call
+    assert call["oldest_first"] is True, call
+    assert bridge._load_last_seen().get(CH1) == "250", bridge._load_last_seen()
+
+
+def test_backfill_routes_through_the_chokepoint_source_pin():
+    """Structural half of (ii): the backfill body awaits the exact name the
+    live `on_message` event awaits, so a refactor that swaps in a copy of the
+    handler fails loudly."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    assert "await _handle_discord_message(message)" in src, (
+        "live path no longer routes through _handle_discord_message")
+    block = re.search(
+        r"async def _backfill_one_channel\(.*?\):(.*?)(?=^(?:async )?def )",
+        src, re.MULTILINE | re.DOTALL)
+    assert block, "could not locate _backfill_one_channel"
+    assert "await _handle_discord_message(msg)" in block.group(1), (
+        "_backfill_one_channel must dispatch through _handle_discord_message, "
+        "not a private copy of the handling logic")
+
+
+def test_backfill_cap_binds_and_warns():
+    """(iii) More than CHANNEL_BACKFILL_MAX_MESSAGES missed → only the oldest
+    cap-many are replayed and a WARN names the cap; the watermark stops at the
+    last replayed id so the rest are fetched next reconnect."""
+    _clear_watermarks()
+    _set_groups(CH1)
+    me, other = object(), object()
+    cap = bridge.CHANNEL_BACKFILL_MAX_MESSAGES
+    bridge._update_last_seen(CH1, 1000)
+    ch = _FakeChannel(int(CH1), [_msg(1000 + i, other) for i in range(1, cap + 11)])
+    spy = _HandlerSpy()
+    buf = io.StringIO()
+    with _patched(_FakeClient([ch], me), spy), redirect_stdout(buf):
+        asyncio.run(bridge._backfill_missed_channel_messages())
+    out = buf.getvalue()
+    assert len(spy.calls) == cap, (
+        f"cap must bind at {cap}, handler got {len(spy.calls)} messages")
+    assert [m.id for m in spy.calls] == [1000 + i for i in range(1, cap + 1)], (
+        "cap must keep the OLDEST messages")
+    assert "WARN" in out and str(cap) in out, (
+        f"cap binding must log a WARN naming the cap; got: {out!r}")
+    assert bridge._load_last_seen().get(CH1) == str(1000 + cap), (
+        f"watermark must stop at the last replayed id, got {bridge._load_last_seen()!r}")
+
+
+def test_watermark_advances_on_live_messages():
+    """(iv) A live message observed in a served channel advances the
+    watermark, driven end-to-end through the production handler (self-author
+    branch — the same starvation class the DM checkpoint hit: our own replies
+    dominate active channels and must advance the watermark too)."""
+    _clear_watermarks()
+    _set_groups(CH1)
+    me = object()
+    fake_client = type("_C", (), {"user": me})()
+    msg = types.SimpleNamespace(
+        author=me, channel=types.SimpleNamespace(id=int(CH1)), id=99999)
+    real_client = bridge.client
+    bridge.client = fake_client
+    try:
+        asyncio.run(bridge._handle_discord_message(msg))
+    finally:
+        bridge.client = real_client
+    assert bridge._load_last_seen().get(CH1) == "99999", (
+        f"live message must advance the served-channel watermark; got "
+        f"{bridge._load_last_seen()!r}")
+
+
+def test_untracked_channel_leaves_watermark_untouched():
+    """Only channels in access.json `groups` are watermarked — the backfill
+    only serves those, so tracking every visible channel would be dead state."""
+    _clear_watermarks()
+    _set_groups(CH1)
+    me = object()
+    fake_client = type("_C", (), {"user": me})()
+    msg = types.SimpleNamespace(
+        author=me, channel=types.SimpleNamespace(id=int(UNTRACKED)), id=99999)
+    real_client = bridge.client
+    bridge.client = fake_client
+    try:
+        asyncio.run(bridge._handle_discord_message(msg))
+    finally:
+        bridge.client = real_client
+    assert bridge._load_last_seen() == {}, (
+        f"unserved channel must not be watermarked; got {bridge._load_last_seen()!r}")
+
+
+def test_live_advance_covers_all_observation_sites():
+    """Structural: the handler advances the watermark at every early-return
+    observation site (self-authored, system message) plus the main path —
+    a frozen watermark replays the same window on every reconnect."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    block = re.search(
+        r"async def _handle_discord_message\(.*?\):(.*?)(?=^(?:async )?def )",
+        src, re.MULTILINE | re.DOTALL)
+    assert block, "could not locate _handle_discord_message"
+    n = block.group(1).count("_note_channel_message_seen(message)")
+    assert n >= 3, (
+        f"expected the watermark advance at the self/system/main observation "
+        f"sites (>=3), found {n}")
+
+
+def test_channel_error_does_not_stop_other_channels():
+    """(v) One channel erroring mid-backfill logs and moves on; the remaining
+    channels still replay."""
+    _clear_watermarks()
+    _set_groups(CH1, CH2)
+    me, other = object(), object()
+    bridge._update_last_seen(CH1, 10)
+    bridge._update_last_seen(CH2, 20)
+    bad = _FakeChannel(int(CH1), fail_history=True)
+    good = _FakeChannel(int(CH2), [_msg(25, other)])
+    spy = _HandlerSpy()
+    buf = io.StringIO()
+    with _patched(_FakeClient([bad, good], me), spy), redirect_stdout(buf):
+        asyncio.run(bridge._backfill_missed_channel_messages())
+    assert [m.id for m in spy.calls] == [25], (
+        f"the healthy channel must still backfill; handler got "
+        f"{[m.id for m in spy.calls]}; log: {buf.getvalue()!r}")
+    assert CH1 in buf.getvalue(), (
+        f"the failing channel must be named in the log; got {buf.getvalue()!r}")
+
+
+def test_last_seen_advances_forward_only():
+    """The watermark shares the DM checkpoint's forward-only contract: an
+    out-of-order replay can never move it backwards."""
+    _clear_watermarks()
+    bridge._update_last_seen(CH1, 200)
+    bridge._update_last_seen(CH1, 150)
+    assert bridge._load_last_seen().get(CH1) == "200", bridge._load_last_seen()
+
+
+def test_source_wires_backfill_into_ready_and_resumed():
+    """Architectural: the backfill must be scheduled from BOTH `on_ready`
+    (IDENTIFY reconnects) and `on_resumed` (RESUME can be accepted after
+    boundary drops). Without the wiring the watermark advances but nothing
+    ever replays."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    ready = re.search(
+        r"async def on_ready\(\):(.*?)(?=^(?:async )?def )",
+        src, re.MULTILINE | re.DOTALL)
+    assert ready, "could not locate on_ready"
+    assert "_backfill_missed_channel_messages" in ready.group(1) and \
+        "create_task" in ready.group(1), (
+        "on_ready does not schedule _backfill_missed_channel_messages")
+    resumed = re.search(
+        r"async def on_resumed\(\):(.*?)(?=^(?:async )?def )",
+        src, re.MULTILINE | re.DOTALL)
+    assert resumed, "could not locate on_resumed"
+    assert "_backfill_missed_channel_messages" in resumed.group(1), (
+        "on_resumed does not schedule the channel backfill")
+    assert "_catchup_missed_dms" in resumed.group(1), (
+        "on_resumed does not schedule the DM catch-up alongside the channel "
+        "backfill — DM coverage would be READY-only")
+
+
+def main():
+    failures = []
+    for fn in (
+        test_first_ready_initializes_watermarks_without_replay,
+        test_reconnect_replays_after_watermark_through_live_handler,
+        test_backfill_routes_through_the_chokepoint_source_pin,
+        test_backfill_cap_binds_and_warns,
+        test_watermark_advances_on_live_messages,
+        test_untracked_channel_leaves_watermark_untouched,
+        test_live_advance_covers_all_observation_sites,
+        test_channel_error_does_not_stop_other_channels,
+        test_last_seen_advances_forward_only,
+        test_source_wires_backfill_into_ready_and_resumed,
+    ):
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"  ✗ {fn.__name__}")
+    if failures:
+        print("\nFailures:")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print("All reconnect-backfill tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/discord-reconnect-backfill.test.py
+++ b/tests/discord-reconnect-backfill.test.py
@@ -43,6 +43,11 @@ REPO = Path(__file__).resolve().parent.parent
 # paths at module-load time.
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-reconnect-backfill-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+# Hermetic-bridge-test lint: explicit config root, access.json seeded under it.
+_CFG = tempfile.mkdtemp(prefix="reconnect-backfill-test-cfg-")
+os.environ["CLAUDE_CONFIG_DIR"] = _CFG
+(Path(_CFG) / "channels" / "discord").mkdir(parents=True, exist_ok=True)
+(Path(_CFG) / "channels" / "discord" / "access.json").write_text('{"allowFrom": []}')
 os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 (Path(_WORKSPACE_TMP) / "state").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What

The Discord bridge loses messages that arrive during a gateway disconnect: Discord does not replay events missed across a session boundary, and the bridge had no recovery. Measured incident (2026-08-27): the gateway opened a new session at 22:10:09Z and the owner's 22:09 message never became a task — silent, no error, unfalsifiable until compared against the phone screen.

This adds reconnect backfill for the channels the bridge serves: a durable per-channel watermark (`state/discord-last-seen.json`, atomic tmp+`os.replace`, forward-only) advanced on every live message, and on `on_ready`/`on_resumed` a REST fetch of `history(after=<watermark>, oldest_first=True)` per configured channel, each recovered message routed through `_handle_discord_message` — the exact choke point live messages take, so allowFrom/tierMap/requireMention/collaborator gates apply identically to replayed traffic.

Guards: a channel with no watermark is initialized to its newest message id with ZERO replay (a fresh install must never ingest channel history as tasks); replay is capped at 50/channel/reconnect (fetches 51 so "at the cap" and "cap binds" are distinguishable; WARN names the remainder, which the next reconnect drains); self-authored messages advance the watermark without replay; a per-channel or per-message failure logs and continues — the live event loop is never blocked.

DMs are deliberately NOT tracked here: `state/discord-dm-checkpoint.json` + `_catchup_missed_dms` already own that exact policy (pinned by `tests/discord-bridge-dm-catchup.test.py`); duplicating it would double-replay DMs. Instead the shared watermark-storage policy was extracted (`_atomic_write_id_map`/`_load_id_map`/`_advance_id_map`) and both mechanisms delegate to it, and `_catchup_missed_dms` is now also scheduled on RESUMED so DM coverage matches channel coverage. The DM trio's behavior is unchanged; its suite passes.

## Evidence

At parent (6629b5d5): no watermark file, no backfill path — a message during a disconnect is simply gone (the 22:09 incident above is the field case).

At HEAD: `tests/discord-reconnect-backfill.test.py` → **10/10 pass**, covering: first-READY initializes without replay; reconnect fetches `after=watermark` and every fetched message goes through the SAME `_handle_discord_message` the live path uses (asserted on the choke point, not a copy); the 50-cap binds with the WARN; watermark advances on live messages; a failing channel doesn't stop the others; forward-only advance; untracked-channel exclusion; READY/RESUMED wiring.

Full `discord-*`/`bridge-*`/`bridges-*` sweep: **84/85** — the one failure (`discord-token-delegation.test.py`) fails identically at the parent commit (host-env token resolution, files untouched here), verified by re-running it against the base bridge. `scripts/review-checks.sh --diff` PASS; ruff clean; no host paths in added lines.

## Live-path witness (owed, per CONTRIBUTING)

This is a delivery-loop change, so harness-green is not the witness. The real round trip — send a message while the bridge is down, restart, observe it arrive as a task and get answered exactly once — requires bouncing the live Discord bridge (~15s outage; Discord does not replay, which is the point: the message sent during the bounce is the probe). The owner is active in-channel right now, so I'll run the witness in the next quiet window and post the transcript here before asking for approval. Until then this PR is explicitly not merge-ready by its own rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
