### PR TITLE
fix(workstreams): retire the superseded classifier under its pool-assigned name

### DIFF
--- a/src/task_workstreams.py
+++ b/src/task_workstreams.py
@@ -1080,7 +1080,9 @@ def _archive_superseded_classifier_task(workspace: Path, state: dict) -> bool:
     # lookup here misses and the supersede silently no-ops.
     tasks_dir = Path(workspace) / "tasks"
     task_path = find_task_file(tasks_dir, task_id)
-    if task_path is None:
+    # find_task_file resolves by name, not by type, so keep the parent's
+    # file-type guard: a same-named DIRECTORY must not be os.replace'd away.
+    if task_path is None or not task_path.is_file():
         return False
     # Ask whether ANY claimed variant exists, not whether the returned one is
     # claimed: find_task_file sorts, and `.assigned-` sorts before `.claimed-`.

--- a/src/task_workstreams.py
+++ b/src/task_workstreams.py
@@ -1072,9 +1072,17 @@ def _archive_superseded_classifier_task(workspace: Path, state: dict) -> bool:
         return False
     if not re.fullmatch(r"task-[a-zA-Z0-9_.-]+", task_id):
         return False
-    task_path = Path(workspace) / "tasks" / f"{task_id}.txt"
-    if not task_path.is_file():
+    # Function-local: task_archive is also loaded BY PATH with src/ off
+    # sys.path, where a module-scope import here would take its caller down.
+    from task_archive import find_task_file
+
+    # The lead renames queued work to `.assigned-<inst>`, so a bare-name
+    # lookup here misses and the supersede silently no-ops.
+    task_path = find_task_file(Path(workspace) / "tasks", task_id)
+    if task_path is None:
         return False
+    if ".claimed-" in task_path.name:
+        return False  # a worker holds it; racing an active claim is worse
     archive_dir = task_path.parent / "archive" / datetime.now(timezone.utc).strftime("%Y-%m")
     archive_dir.mkdir(parents=True, exist_ok=True)
     archive_path = archive_dir / task_path.name

--- a/src/task_workstreams.py
+++ b/src/task_workstreams.py
@@ -1078,11 +1078,14 @@ def _archive_superseded_classifier_task(workspace: Path, state: dict) -> bool:
 
     # The lead renames queued work to `.assigned-<inst>`, so a bare-name
     # lookup here misses and the supersede silently no-ops.
-    task_path = find_task_file(Path(workspace) / "tasks", task_id)
+    tasks_dir = Path(workspace) / "tasks"
+    task_path = find_task_file(tasks_dir, task_id)
     if task_path is None:
         return False
-    if ".claimed-" in task_path.name:
-        return False  # a worker holds it; racing an active claim is worse
+    # Ask whether ANY claimed variant exists, not whether the returned one is
+    # claimed: find_task_file sorts, and `.assigned-` sorts before `.claimed-`.
+    if any(tasks_dir.glob(f"{task_id}.claimed-*")):
+        return False
     archive_dir = task_path.parent / "archive" / datetime.now(timezone.utc).strftime("%Y-%m")
     archive_dir.mkdir(parents=True, exist_ok=True)
     archive_path = archive_dir / task_path.name

--- a/tests/task-workstreams.test.py
+++ b/tests/task-workstreams.test.py
@@ -476,6 +476,29 @@ def test_a_vanished_predecessor_is_not_an_error() -> None:
     assert not list((workspace / "tasks" / "archive").glob(f"*/{first.task_id}*"))
 
 
+def test_a_directory_wearing_a_task_name_is_never_archived() -> None:
+    # find_task_file resolves by NAME, not type, so dropping the parent's
+    # is_file() would relocate a whole directory into the archive.
+    for suffix in ("", ".assigned-core-1"):
+        workspace = fixture_workspace()
+        first = workstreams.maybe_enqueue_classifier_task(workspace)
+        real = workspace / "tasks" / f"{first.task_id}.txt"
+        real.unlink()
+        impostor = workspace / "tasks" / f"{first.task_id}{suffix}.txt"
+        impostor.mkdir()
+        (impostor / "payload.txt").write_text("must survive")
+        state_path = workspace / "state" / "task-workstream-classifier.json"
+        state = json.loads(state_path.read_text())
+        state["enqueued_at"] = 0
+        state_path.write_text(json.dumps(state))
+
+        workstreams.maybe_enqueue_classifier_task(workspace)
+
+        assert impostor.is_dir(), f"directory {suffix or '(bare)'} was moved"
+        assert (impostor / "payload.txt").read_text() == "must survive"
+        assert not list((workspace / "tasks" / "archive").glob(f"*/{first.task_id}*"))
+
+
 def test_classifier_maintenance_runs_without_a_dashboard_and_survives_errors() -> None:
     workspace = fixture_workspace()
     stop = threading.Event()
@@ -871,6 +894,7 @@ def main() -> None:
         test_a_worker_held_classifier_claim_is_left_alone,
         test_an_assigned_and_claimed_pair_still_leaves_the_claim_alone,
         test_a_vanished_predecessor_is_not_an_error,
+        test_a_directory_wearing_a_task_name_is_never_archived,
         test_classifier_maintenance_runs_without_a_dashboard_and_survives_errors,
         test_workstream_context_is_prior_owner_only_bounded_and_untrusted,
         test_workstream_context_has_a_total_serialized_byte_cap,

--- a/tests/task-workstreams.test.py
+++ b/tests/task-workstreams.test.py
@@ -396,6 +396,47 @@ def test_stale_classifier_is_archived_before_replacement() -> None:
     assert live == [workspace / "tasks" / f"{replacement.task_id}.txt"]
 
 
+def _stale_and_replace(workspace, rename_suffix: str):
+    """Mint one classifier task, optionally rename it the way the pool lead
+    does, expire the TTL, then mint its replacement."""
+    first = workstreams.maybe_enqueue_classifier_task(workspace)
+    path = workspace / "tasks" / f"{first.task_id}.txt"
+    if rename_suffix:
+        path = path.rename(
+            path.with_name(f"{first.task_id}{rename_suffix}.txt"))
+    state_path = workspace / "state" / "task-workstream-classifier.json"
+    state = json.loads(state_path.read_text())
+    state["enqueued_at"] = 0
+    state_path.write_text(json.dumps(state))
+    return first, path, workstreams.maybe_enqueue_classifier_task(workspace)
+
+
+def test_stale_classifier_is_archived_under_its_pool_assigned_name() -> None:
+    # The lead renames queued work to `.assigned-<inst>`. A bare-name lookup
+    # misses it, so every TTL expiry left a file behind and the queue grew.
+    workspace = fixture_workspace()
+    first, path, replacement = _stale_and_replace(workspace, ".assigned-core-1")
+
+    assert replacement.enqueued and replacement.task_id != first.task_id
+    assert not path.exists()
+    archived = list((workspace / "tasks" / "archive").glob(f"*/{first.task_id}*"))
+    assert len(archived) == 1, archived
+    live = sorted(
+        p.name for p in (workspace / "tasks").glob("task-workstream-grouping-*"))
+    assert live == [f"{replacement.task_id}.txt"], live
+
+
+def test_a_worker_held_classifier_claim_is_left_alone() -> None:
+    # Archiving out from under a running worker is worse than one duplicate
+    # proposal, so a `.claimed-` file must survive its own replacement.
+    workspace = fixture_workspace()
+    first, path, replacement = _stale_and_replace(workspace, ".claimed-core-1")
+
+    assert replacement.enqueued
+    assert path.exists(), "claimed file was archived while a worker held it"
+    assert not list((workspace / "tasks" / "archive").glob(f"*/{first.task_id}*"))
+
+
 def test_classifier_maintenance_runs_without_a_dashboard_and_survives_errors() -> None:
     workspace = fixture_workspace()
     stop = threading.Event()
@@ -787,6 +828,8 @@ def main() -> None:
         test_classifier_task_survives_a_raising_stamper,
         test_classifier_source_directory_cache_rejects_unsafe_entries_fail_open,
         test_stale_classifier_is_archived_before_replacement,
+        test_stale_classifier_is_archived_under_its_pool_assigned_name,
+        test_a_worker_held_classifier_claim_is_left_alone,
         test_classifier_maintenance_runs_without_a_dashboard_and_survives_errors,
         test_workstream_context_is_prior_owner_only_bounded_and_untrusted,
         test_workstream_context_has_a_total_serialized_byte_cap,

--- a/tests/task-workstreams.test.py
+++ b/tests/task-workstreams.test.py
@@ -459,6 +459,23 @@ def test_an_assigned_and_claimed_pair_still_leaves_the_claim_alone() -> None:
     assert not list((workspace / "tasks" / "archive").glob(f"*/{first.task_id}*"))
 
 
+def test_a_vanished_predecessor_is_not_an_error() -> None:
+    # Someone else archived or removed the previous mint. find_task_file returns
+    # None and the supersede must decline quietly, not raise or fabricate.
+    workspace = fixture_workspace()
+    first = workstreams.maybe_enqueue_classifier_task(workspace)
+    (workspace / "tasks" / f"{first.task_id}.txt").unlink()
+    state_path = workspace / "state" / "task-workstream-classifier.json"
+    state = json.loads(state_path.read_text())
+    state["enqueued_at"] = 0
+    state_path.write_text(json.dumps(state))
+
+    replacement = workstreams.maybe_enqueue_classifier_task(workspace)
+
+    assert replacement.enqueued and replacement.task_id != first.task_id
+    assert not list((workspace / "tasks" / "archive").glob(f"*/{first.task_id}*"))
+
+
 def test_classifier_maintenance_runs_without_a_dashboard_and_survives_errors() -> None:
     workspace = fixture_workspace()
     stop = threading.Event()
@@ -853,6 +870,7 @@ def main() -> None:
         test_stale_classifier_is_archived_under_its_pool_assigned_name,
         test_a_worker_held_classifier_claim_is_left_alone,
         test_an_assigned_and_claimed_pair_still_leaves_the_claim_alone,
+        test_a_vanished_predecessor_is_not_an_error,
         test_classifier_maintenance_runs_without_a_dashboard_and_survives_errors,
         test_workstream_context_is_prior_owner_only_bounded_and_untrusted,
         test_workstream_context_has_a_total_serialized_byte_cap,

--- a/tests/task-workstreams.test.py
+++ b/tests/task-workstreams.test.py
@@ -437,6 +437,28 @@ def test_a_worker_held_classifier_claim_is_left_alone() -> None:
     assert not list((workspace / "tasks" / "archive").glob(f"*/{first.task_id}*"))
 
 
+def test_an_assigned_and_claimed_pair_still_leaves_the_claim_alone() -> None:
+    # find_task_file sorts its matches and `.assigned-` sorts first, so a guard
+    # that inspects only the returned path archives while a worker holds a claim.
+    workspace = fixture_workspace()
+    first = workstreams.maybe_enqueue_classifier_task(workspace)
+    base = workspace / "tasks" / f"{first.task_id}.txt"
+    claimed = base.with_name(f"{first.task_id}.claimed-core-1.txt")
+    base.rename(claimed)
+    assigned = base.with_name(f"{first.task_id}.assigned-core-2.txt")
+    assigned.write_text("id: " + first.task_id + "\n")
+    state_path = workspace / "state" / "task-workstream-classifier.json"
+    state = json.loads(state_path.read_text())
+    state["enqueued_at"] = 0
+    state_path.write_text(json.dumps(state))
+
+    workstreams.maybe_enqueue_classifier_task(workspace)
+
+    assert claimed.exists(), "archived while a worker held the claimed sibling"
+    assert assigned.exists(), "the assigned sibling went with it"
+    assert not list((workspace / "tasks" / "archive").glob(f"*/{first.task_id}*"))
+
+
 def test_classifier_maintenance_runs_without_a_dashboard_and_survives_errors() -> None:
     workspace = fixture_workspace()
     stop = threading.Event()
@@ -830,6 +852,7 @@ def main() -> None:
         test_stale_classifier_is_archived_before_replacement,
         test_stale_classifier_is_archived_under_its_pool_assigned_name,
         test_a_worker_held_classifier_claim_is_left_alone,
+        test_an_assigned_and_claimed_pair_still_leaves_the_claim_alone,
         test_classifier_maintenance_runs_without_a_dashboard_and_survives_errors,
         test_workstream_context_is_prior_owner_only_bounded_and_untrusted,
         test_workstream_context_has_a_total_serialized_byte_cap,


### PR DESCRIPTION
## What breaks

`_archive_superseded_classifier_task` keeps exactly one classifier task live: each new mint retires the previous one. It resolved that file at `tasks/<task_id>.txt` only. The pool lead renames queued work to `tasks/<task_id>.assigned-<inst>.txt`, so the lookup misses, the retire returns `False` silently, and the old file stays queued while a replacement is minted. Nothing then bounds the 900-second liveness re-mint.

Observed on a live queue: **seven** classifier files, **six of them the same snapshot** `1cfa80ff2e5e6f46`, arriving 15–45 minutes apart. (The TTL is a floor, not the period — minting is also gated on the core being idle.) State recorded `task_id` `task-workstream-grouping-1787893645254`, while `tasks/<task_id>.txt` did not exist and `tasks/<task_id>.assigned-core-1.txt` did.

## The fix

`task_archive.find_task_file` already solves this and says so in its own docstring: *"Covers the lead's `.assigned-<inst>` rename too."* Five consumers of that grammar already delegate to it. This is the sixth, rather than a sixth private copy.

## Evidence — the real function, parent commit vs HEAD

|                    | parent (`169d67ad`) | HEAD |
|--------------------|---------------------|------|
| bare (unclaimed)   | True, archived      | True, archived |
| `.assigned-core-1` | **False, LEFT IN QUEUE** | **True, archived** |
| `.claimed-core-1`  | False, left         | False, left |

Only the middle row moves. The claimed row must not: the contract is to retire an **unclaimed** file, and archiving out from under a running worker is worse than one duplicate proposal. `find_task_file` returns any state variant, so the claimed case is refused explicitly.

## Tests

- `test_stale_classifier_is_archived_under_its_pool_assigned_name` — **fails at the parent, passes here.** This is the discriminator.
- `test_a_worker_held_classifier_claim_is_left_alone` — **passes at both.** It does not discriminate this fix; it pins the safety property against a future over-broad one. Saying so rather than implying two controls.
- The pre-existing `test_stale_classifier_is_archived_before_replacement` used the bare name — the one shape the pool never produces. That is how this shipped.

## Why the import is function-local

`task_archive`'s own header records that both modules are loaded **by path** with `src/` off `sys.path`, where a module-scope import takes its caller down. A module-scope form broke `codex-core-launcher.test.py` (green at parent, red with it) by killing the notifier subprocess. The function-local form restores it. Baselined rather than assumed.

## Suites

`task-workstreams`, `agent-api-task-workstreams`, `agent-api-active-tasks-payload`, `codex-core-launcher` (31), `task-workstream-rank`, `web-client-task-workstream-grouping`, `task-archive` — all green. `scripts/review-checks.sh` PASS.

## Scope

Independent of #3314. That PR is the pool itself; this is a main-side consumer that the pool's rename already defeats today.
