### PR TITLE
fix(tests): the heartbeat pid file was read between create and write

### DIFF
--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -151,10 +151,15 @@ exit 0
     def _wait_for_heartbeat_exit(self):
         pid_file = Path(self.tmp.name) / "heartbeat.pid"
         deadline = time.monotonic() + 5
-        while not pid_file.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
-        self.assertTrue(pid_file.exists(), "heartbeat stub did not record its pid")
-        pid = int(pid_file.read_text())
+        # Wait for parseable CONTENT, not existence: write_text() creates and
+        # truncates before writing, so exists() goes true while the file is empty.
+        pid = None
+        while pid is None and time.monotonic() < deadline:
+            try:
+                pid = int(pid_file.read_text())
+            except (FileNotFoundError, ValueError):
+                time.sleep(0.01)
+        self.assertIsNotNone(pid, "heartbeat stub did not record its pid")
         while time.monotonic() < deadline:
             try:
                 os.kill(pid, 0)

--- a/tests/heartbeat-pid-read-race.test.py
+++ b/tests/heartbeat-pid-read-race.test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Pins the read predicate in codex-core-launcher's _wait_for_heartbeat_exit.
+
+The heartbeat stub records its pid with `Path(...).write_text(str(os.getpid()))`.
+`write_text` opens with mode "w", which CREATES AND TRUNCATES before any bytes are
+written, so a reader waiting on `pid_file.exists()` can observe a zero-length file
+and raise `ValueError: invalid literal for int() with base 10: ''`.
+
+Observed in CI (run 12df9ee0, job "diff coverage >= 95% (python)"), where the
+suite -- not the coverage threshold -- is what failed.
+
+This drives the REAL method off the launcher suite rather than a copied recipe, so
+the assertion cannot pass against a surrogate while production keeps the defect.
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO / "tests" / "codex-core-launcher.test.py"
+
+
+def _load_launcher():
+    spec = importlib.util.spec_from_file_location("_codex_core_launcher", LAUNCHER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _dead_pid():
+    """A pid guaranteed to have exited, so the method's kill-loop returns."""
+    p = subprocess.Popen([sys.executable, "-c", ""])
+    p.wait()
+    return p.pid
+
+
+class HeartbeatPidReadRaceTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_launcher()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.pid_file = Path(self.tmp.name) / "heartbeat.pid"
+
+    def _subject(self):
+        """The real _wait_for_heartbeat_exit, bound to a minimal host object."""
+        cls = self.mod.CodexCoreLauncherTests
+        inst = cls.__new__(cls)
+        inst.tmp = self.tmp
+        return types.MethodType(cls._wait_for_heartbeat_exit, inst)
+
+    def _write_racily(self, pid, hold_s=0.30):
+        """Reproduce write_text()'s create-then-write window deterministically."""
+        def run():
+            fh = open(self.pid_file, "w")   # file now EXISTS and is EMPTY
+            time.sleep(hold_s)
+            fh.write(str(pid))
+            fh.close()
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        self.addCleanup(t.join)
+
+    # --- the defect, stated as a control -------------------------------------
+
+    def test_existence_predicate_raises_on_the_truncate_window(self):
+        """NEGATIVE CONTROL: proves the window is real, reachable, and fatal.
+
+        If this ever stops raising, the reproduction has gone inert and the
+        test below would pass for the wrong reason.
+        """
+        self._write_racily(_dead_pid())
+        deadline = time.monotonic() + 5
+        while not self.pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(self.pid_file.exists())
+        with self.assertRaises(ValueError):
+            int(self.pid_file.read_text())
+
+    # --- the fix --------------------------------------------------------------
+
+    def test_real_method_survives_the_truncate_window(self):
+        self._write_racily(_dead_pid())
+        self._subject()()          # must not raise ValueError
+
+    def test_real_method_survives_a_late_create(self):
+        """The file may not exist at all yet -- FileNotFoundError, not ValueError."""
+        pid = _dead_pid()
+
+        def run():
+            time.sleep(0.30)
+            self.pid_file.write_text(str(pid))
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        self.addCleanup(t.join)
+        self._subject()()
+
+    # --- negative controls: the fix must not over-correct ---------------------
+
+    def test_still_fails_when_the_pid_is_never_written(self):
+        """An empty file that never fills must still be a failure, not a hang."""
+        self.pid_file.write_text("")
+        with self.assertRaises(AssertionError):
+            self._subject()()
+
+    def test_still_fails_when_the_pid_never_exits(self):
+        """A live pid must still fail -- the method's second half must survive."""
+        self.pid_file.write_text(str(os.getpid()))
+        with self.assertRaises(AssertionError):
+            self._subject()()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`_wait_for_heartbeat_exit` in `tests/codex-core-launcher.test.py` waited for the pid file to **exist**, then immediately parsed it:

```python
while not pid_file.exists() and time.monotonic() < deadline:
    time.sleep(0.01)
pid = int(pid_file.read_text())
```

The stub records its pid with `Path(...).write_text(str(os.getpid()))`. `write_text` opens mode `"w"` — **create and truncate** — before writing any bytes, so `exists()` goes true *strictly before* the pid lands. A reader waking in that window reads `""` and dies on `int("")`.

Same shape as the `core-status.sh` hazard CLAUDE.md already documents from #3156: *"the redirect truncates before it writes, and a reader polling in that window sees a zero-length file."*

## Why now — it is failing CI on unrelated PRs

Hit on #2160 at head `12df9ee0`, in the job named **`diff coverage >= 95% (python)`**. The check name is misleading: coverage never ran.

```
coverage-gate: running Python suite under instrumentation...
✖ test failed under instrumentation: tests/codex-core-launcher.test.py

ERROR: test_starts_core_heartbeat_writer_on_launch
  File "tests/codex-core-launcher.test.py", line 157, in _wait_for_heartbeat_exit
    pid = int(pid_file.read_text())
ValueError: invalid literal for int() with base 10: ''

coverage-gate: suite must be green before coverage is meaningful.
```

That PR touches `src/health-check.py` and adds one test. `grep -c 'health.check' tests/codex-core-launcher.test.py` → **0**. The failure is this race, not that diff.

## Before / after

Both arms run against the same new test, in the same tree, changing only the predicate:

```
WITHOUT the fix (git checkout -- tests/codex-core-launcher.test.py):
    Ran 5 tests   FAILED (errors=2)
    ValueError: invalid literal for int() with base 10: ''
      at tests/codex-core-launcher.test.py:157, in _wait_for_heartbeat_exit

WITH the fix:
    Ran 5 tests   OK
```

The error raised by the control is character-for-character the CI one above.

## How the test is built

- **Drives the real method** — binds `CodexCoreLauncherTests._wait_for_heartbeat_exit` off the launcher suite via `importlib` rather than re-implementing the wait. A copied recipe could pass while production kept the defect.
- **Deterministic, not a scheduler race** — an explicit open→hold→write thread reproduces the truncate window every run instead of hoping to hit it.
- **Negative control included** (`test_existence_predicate_raises_on_the_truncate_window`) so the reproduction cannot go inert unnoticed: if that stops raising, the other assertions would be passing for the wrong reason.
- **Over-correction controls** — a pid never written still *fails* rather than hangs; a pid that never exits still fails.

## Scope

Single concern: this predicate only. Two other timing flakes surfaced in the same gate and are deliberately **not** touched here —

- `test_unassigned_notifier_task_bypasses_slow_history_scan` asserts a 1.0s wall-clock bound and measures **1.42s** on a loaded machine
- `tests/outbox-race.test.py` **timed out >120s** under instrumentation on the very next CI run

Both want their own change. Flagging them because together they appear to red this gate intermittently across the repo, not only on one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
