### PR TITLE
feat(review-checks): teach prose-cap to classify shell comments

### DIFF
--- a/scripts/review-checks-prose-cap.py
+++ b/scripts/review-checks-prose-cap.py
@@ -29,7 +29,8 @@ _HEREDOC = re.compile(r"""(?<!<)<<(?!<)-?\s*(?:(['"])([A-Za-z_]\w*)\1|([A-Za-z_]
 
 def comment_lines(path):
     """Line numbers carrying a COMMENT, or None if the file cannot be classified."""
-    if path.endswith((".sh", ".bash")):
+    # Callers pass PosixPath as well as str; str() covers both.
+    if str(path).endswith((".sh", ".bash")):
         return _shell_comment_lines(path)
     try:
         with open(path, "rb") as fh:

--- a/scripts/review-checks-prose-cap.py
+++ b/scripts/review-checks-prose-cap.py
@@ -18,19 +18,59 @@ INDEX = re.compile(r"^index [0-9a-f]+\.\.([0-9a-f]+)")
 # Fallbacks only. review-checks.sh normally supplies both from REVIEW.md.
 DEFAULT_CAP = 2
 DEFAULT_EXTS = (".py",)
-# Classification is `tokenize`, so only Python comment syntax is decidable here.
-# Any other extension yields zero COMMENT tokens — a clean PASS over unread text.
-SUPPORTED_EXTS = (".py", ".pyi")
+# Each extension needs a classifier that can tell a comment from a `#` in data.
+# Guessing is what this check exists to prevent, so an unlisted ext fails closed.
+SUPPORTED_EXTS = (".py", ".pyi", ".sh", ".bash")
+
+# `<<<` is a here-STRING, not a heredoc; guard BOTH sides or the match lands at
+# offset 1 of `<<<` and opens a heredoc that never terminates.
+_HEREDOC = re.compile(r"""(?<!<)<<(?!<)-?\s*(?:(['"])([A-Za-z_]\w*)\1|([A-Za-z_]\w*))""")
 
 
 def comment_lines(path):
-    """Line numbers carrying a COMMENT token, or None if the file cannot be tokenized."""
+    """Line numbers carrying a COMMENT, or None if the file cannot be classified."""
+    if path.endswith((".sh", ".bash")):
+        return _shell_comment_lines(path)
     try:
         with open(path, "rb") as fh:
             return {t.start[0] for t in tokenize.tokenize(fh.readline)
                     if t.type == tokenize.COMMENT}
     except (OSError, SyntaxError, tokenize.TokenError, UnicodeDecodeError):
         return None
+
+
+def _shell_comment_lines(path):
+    """Full-line shell comments, heredoc bodies excluded.
+
+    The cap counts runs of lines that are ENTIRELY comments, so a mid-line `#`
+    (`${v#pat}`, `"a#b"`) can never open one and needs no lexing. The live
+    hazard is a heredoc BODY line starting with `#`: 400 such lines across this
+    repo's .sh files would otherwise be miscounted as comments.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            lines = fh.read().splitlines()
+    except (OSError, UnicodeDecodeError):
+        return None
+    out, term, tabs = set(), None, False
+    for n, line in enumerate(lines, 1):
+        if term is not None:
+            candidate = line.lstrip("\t") if tabs else line
+            if candidate.strip() == term:
+                term = None
+            continue
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            if n != 1 or not stripped.startswith("#!"):
+                out.add(n)
+            continue
+        m = _HEREDOC.search(line)
+        if m:
+            term = m.group(2) or m.group(3)
+            tabs = "<<-" in line
+    # An unterminated heredoc means a `<<` we could not place (e.g. inside a
+    # string literal); from there on body and code are indistinguishable.
+    return None if term is not None else out
 
 
 def added_by_file(diff_text):

--- a/tests/review-checks-prose-cap-shell.test.py
+++ b/tests/review-checks-prose-cap-shell.test.py
@@ -81,6 +81,12 @@ class ShellCommentLines(unittest.TestCase):
         p = self._w("# one\n# two\nx = 1  # trailing\n", name="f.py")
         self.assertEqual(self.m.comment_lines(p), {1, 2, 3})
 
+    def test_accepts_a_Path_not_only_a_str(self):
+        """The production caller passes PosixPath; a str-only fixture hides that."""
+        p = Path(self.tmp.name) / "viapath.sh"
+        p.write_text("cat <<EOF\n# data\nEOF\n# real\n")
+        self.assertEqual(self.m.comment_lines(p), {4})
+
     def test_shell_ext_is_now_supported(self):
         self.assertIn(".sh", self.m.SUPPORTED_EXTS)
         self.assertIn(".py", self.m.SUPPORTED_EXTS)

--- a/tests/review-checks-prose-cap-shell.test.py
+++ b/tests/review-checks-prose-cap-shell.test.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Shell comment classification for the prose-cap gate.
+
+The gate previously supported `.py` only, and fail-closed on anything else, so
+the repo's two-line comment cap was unenforced on 216 tracked `.sh` files. The
+blocker was never the `#` character: the cap counts runs of lines that are
+ENTIRELY comments, so a mid-line `#` cannot open one. The live hazard is a
+heredoc BODY line beginning with `#` -- 410 such lines in this repo.
+"""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _mod():
+    spec = importlib.util.spec_from_file_location(
+        "prose_cap", REPO / "scripts" / "review-checks-prose-cap.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+class ShellCommentLines(unittest.TestCase):
+    def setUp(self):
+        self.m = _mod()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _w(self, body, name="f.sh"):
+        p = Path(self.tmp.name) / name
+        p.write_text(body)
+        return str(p)
+
+    def test_plain_comments_are_found(self):
+        p = self._w("#!/bin/bash\n# one\n# two\necho hi\n")
+        self.assertEqual(self.m.comment_lines(p), {2, 3})
+
+    def test_shebang_is_not_a_comment(self):
+        p = self._w("#!/bin/bash\necho hi\n")
+        self.assertEqual(self.m.comment_lines(p), set())
+
+    # --- the hazard this exists for -------------------------------------
+    def test_heredoc_body_hashes_are_NOT_comments(self):
+        p = self._w("cat <<'EOF' > out\n# not a comment\n# also not\nEOF\n# real\n")
+        self.assertEqual(self.m.comment_lines(p), {5})
+
+    def test_unquoted_heredoc_body_too(self):
+        p = self._w("cat <<EOF\n# data\nEOF\n# real\n")
+        self.assertEqual(self.m.comment_lines(p), {4})
+
+    def test_dash_heredoc_allows_tab_indented_terminator(self):
+        p = self._w("cat <<-EOF\n# data\n\tEOF\n# real\n")
+        self.assertEqual(self.m.comment_lines(p), {4})
+
+    # --- mid-line '#' is irrelevant, and that is the design claim -------
+    def test_parameter_expansion_hash_is_not_a_comment_line(self):
+        p = self._w('x=${v#pat}\ny="a#b"\n# real\n')
+        self.assertEqual(self.m.comment_lines(p), {3})
+
+    # --- here-STRING is not a heredoc -----------------------------------
+    def test_here_string_does_not_open_a_heredoc(self):
+        """`<<<` must not match -- guard BOTH sides, or it matches at offset 1."""
+        p = self._w("grep x <<< \"$v\"\n# real\n# also real\n")
+        self.assertEqual(self.m.comment_lines(p), {2, 3})
+
+    def test_here_string_inside_a_quoted_string(self):
+        p = self._w("M='# <<< managed block'\n# real\n")
+        self.assertEqual(self.m.comment_lines(p), {2})
+
+    # --- fail closed, never guess ---------------------------------------
+    def test_unterminated_heredoc_is_undecidable_not_empty(self):
+        """None (caller fails closed), never an empty set that reads as PASS."""
+        p = self._w("cat <<EOF\n# data\nnever terminated\n")
+        self.assertIsNone(self.m.comment_lines(p))
+
+    def test_python_path_is_unchanged(self):
+        p = self._w("# one\n# two\nx = 1  # trailing\n", name="f.py")
+        self.assertEqual(self.m.comment_lines(p), {1, 2, 3})
+
+    def test_shell_ext_is_now_supported(self):
+        self.assertIn(".sh", self.m.SUPPORTED_EXTS)
+        self.assertIn(".py", self.m.SUPPORTED_EXTS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

The repo's 2-line comment cap is **unenforced on 216 tracked `.sh` files.** `review-checks-prose-cap.py` classifies comments with Python's `tokenize` and fails closed on anything else, so shell PRs report `prose-cap: PASS` over text nobody scanned.

Surfaced by a reviewer on #3356 — eight over-cap shell blocks reached CI green there, while a 3-line **Python** comment in the same commit was caught within minutes. That asymmetry is the gap, observed from the inside.

## Why the obvious fix doesn't work

Adding `.sh` to `REVIEW.md`'s `prose_exts` is a **regression**, and the scanner says so:

```
RC_PROSE_EXTS=".py,.sh"  ->  configured extension '.sh' is not Python-tokenizable
                             FAIL-CLOSED — 1 unsupported (supported: .py,.pyi)
                             rc=2
```

I proposed exactly that on #3356 and had to retract it. This PR is the version that actually works.

## What makes shell tractable

Not lexing — **the shape of the check.** The cap counts runs of lines that are *entirely* comments, so a mid-line `#` (`${v#pat}`, `"a#b"`, `printf '%s#'`) can never open one and needs no parsing.

The single live hazard is a **heredoc body line beginning with `#`**. Measured on this repo: **410 such lines**. So the shell path tracks heredocs and nothing else.

## Measured over every tracked shell file

```
221 / 222  decidable
  1        fail-closed:  tests/core-status-sh-python-resolution.test.sh
                         (`if grep -q "<<'PY'"` — a heredoc token inside a string)
```

Returning `None` there is the point: the caller fails closed rather than guessing, exactly as the Python path does on an untokenizable file.

**`<<<` needs a guard on both sides.** With only a trailing `(?!<)`, the pattern matches at *offset 1* of `<<<` and opens a heredoc that never terminates — that alone caused 3 of the original 4 undecidable files.

## Evidence

```
tests            8 of 11 FAIL against the pre-change scanner;  12/12 pass after
gate on itself   review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

Including a fail-closed test asserting `None` rather than an empty set — an empty set reads as a clean PASS, which is the exact failure this check exists to prevent.

## Default behaviour is unchanged

`REVIEW.md` still scopes `prose_exts: ['.py']`. **No PR's verdict moves until someone adds `.sh` there.** This turns that from an rc=2 into a supported choice, and leaves the decision to enable it with the maintainers.

## One thing worth reading

The second commit exists because I ran this gate on its own diff and it caught `AttributeError: 'PosixPath' object has no attribute 'endswith'`. Eleven tests were green over an input shape the real caller never sends — my fixtures passed `str(p)`, production passes `Path`. The fixture agreed with me; the pipeline didn't. There's now a test that passes a `Path` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
