### PR TITLE
test(durable-work-model): a call's options object is not a task stamp

### DIFF
--- a/tests/durable-work-model.test.py
+++ b/tests/durable-work-model.test.py
@@ -37,10 +37,11 @@ def _grep_stamped_values(key: str) -> set:
     Write signatures only — quoted-key assignment ("access_tier":
     "ambient") and header-line writes inside string literals ("access_tier:
     ambient\\n" or backtick-terminated `access_tier: owner`). Prose in
-    comments, `key: Type` annotations, `.key === 'x'` comparisons and a
-    third-party call's options object ({ priority: 'high' }) match none of
-    these, which is what keeps this a producer census rather than a word
-    search."""
+    comments, `key: Type` annotations, `.key === 'x'` comparisons, a
+    third-party call's options object ({ priority: 'high' }) and a struct
+    that merely carries the field (observability's Actor descriptor) match
+    none of these, which is what keeps this a producer census rather than a
+    word search."""
     pat = _stamp_pattern(key)
     found = set()
     roots = [REPO / "src", REPO / "skills", REPO / "packages"]
@@ -73,6 +74,13 @@ class TestStampPatternMatchesProducersOnly(unittest.TestCase):
                 "  `A delegated task just finished. ...`,\n"
                 "  { priority: 'high' });\n")
         self.assertEqual(self._found(text), set())
+
+    def test_a_struct_that_carries_the_field_is_not_a_stamp(self):
+        # src/observability/** builds Actor descriptors with access_tier, under
+        # its own AccessTier vocabulary ('owner'|'team'|'public'|'unknown').
+        text = ("const ACTOR = { user_id: 'core', channel: 'claude-code',\n"
+                "                access_tier: 'owner' as AccessTier, tenant_id: null };\n")
+        self.assertEqual(self._found(text, key="access_tier"), set())
 
     def test_a_header_line_write_IS_a_stamp(self):
         self.assertEqual(self._found('f"priority: urgent\\n"'), {"urgent"})

--- a/tests/durable-work-model.test.py
+++ b/tests/durable-work-model.test.py
@@ -21,22 +21,27 @@ sys.path.insert(0, str(REPO / "src"))
 import local_task_protocol as ltp  # noqa: E402
 
 
+def _stamp_pattern(key: str) -> "re.Pattern":
+    """The write signatures a producer actually emits. Split out so the shapes
+    can be tested against fixtures instead of only against the live tree."""
+    return re.compile(
+        rf"""["']{key}["']\s*[:=]\s*f?["']([a-z_]+)["']"""
+        rf"""|{key}:\s*([a-z_]+)\\n"""
+        rf"""|{key}:\s*([a-z_]+)`""")
+
+
 def _grep_stamped_values(key: str) -> set:
     """Every literal value producers stamp for `key:` across live writer
     code, Python AND TypeScript (the TS bridges are live stampers too).
 
     Write signatures only — quoted-key assignment ("access_tier":
-    "ambient"), header-line writes inside string literals ("access_tier:
-    ambient\\n" or backtick-terminated `access_tier: owner`), and unquoted
-    object-literal keys with quoted values (access_tier: 'owner'). Prose in
-    comments, `key: Type` annotations, and `.key === 'x'` comparisons match
-    none of these, which is what keeps this a producer census rather than a
-    word search."""
-    pat = re.compile(
-        rf"""["']{key}["']\s*[:=]\s*f?["']([a-z_]+)["']"""
-        rf"""|{key}:\s*([a-z_]+)\\n"""
-        rf"""|{key}:\s*([a-z_]+)`"""
-        rf"""|(?<![.\w"'`]){key}\s*:\s*['"]([a-z_]+)['"]""")
+    "ambient") and header-line writes inside string literals ("access_tier:
+    ambient\\n" or backtick-terminated `access_tier: owner`). Prose in
+    comments, `key: Type` annotations, `.key === 'x'` comparisons and a
+    third-party call's options object ({ priority: 'high' }) match none of
+    these, which is what keeps this a producer census rather than a word
+    search."""
+    pat = _stamp_pattern(key)
     found = set()
     roots = [REPO / "src", REPO / "skills", REPO / "packages"]
     for root in roots:
@@ -51,6 +56,38 @@ def _grep_stamped_values(key: str) -> set:
                 for m in pat.finditer(text):
                     found.add(next(g for g in m.groups() if g))
     return found - {None}
+
+
+class TestStampPatternMatchesProducersOnly(unittest.TestCase):
+    """The census must count task-header writes and nothing that merely looks
+    like one. A third-party call's options object is the shape that slipped."""
+
+    def _found(self, text, key="priority"):
+        return {next(g for g in m.groups() if g)
+                for m in _stamp_pattern(key).finditer(text)}
+
+    def test_a_third_party_options_object_is_not_a_stamp(self):
+        # bodhi's notifyBackground takes priority?: 'normal' | 'high'. Counting
+        # it made the model look wrong when the dependency was simply obeyed.
+        text = ("session.notifyBackground(\n"
+                "  `A delegated task just finished. ...`,\n"
+                "  { priority: 'high' });\n")
+        self.assertEqual(self._found(text), set())
+
+    def test_a_header_line_write_IS_a_stamp(self):
+        self.assertEqual(self._found('f"priority: urgent\\n"'), {"urgent"})
+
+    def test_a_backtick_header_write_IS_a_stamp(self):
+        self.assertEqual(self._found("`priority: low`"), {"low"})
+
+    def test_a_quoted_key_assignment_IS_a_stamp(self):
+        self.assertEqual(self._found("""{"priority": "normal"}"""), {"normal"})
+
+    def test_the_same_holds_for_access_tier(self):
+        self.assertEqual(self._found("route(msg, { access_tier: 'owner' })",
+                                     key="access_tier"), set())
+        self.assertEqual(self._found('f"access_tier: team\\n"',
+                                     key="access_tier"), {"team"})
 
 
 class TestVocabularyCoversLiveProducers(unittest.TestCase):


### PR DESCRIPTION
Closes #3493.

## The defect

`tests/durable-work-model.test.py`'s producer census counts an unquoted object-literal key as a stamp, so a **third-party API's options object** registers as a Sutando producer.

It is green on `main` today only because the offending shape isn't here yet. On `feat/sutando-server` it already fails:

```
FAIL: test_every_stamped_priority_is_in_the_model
AssertionError: producers stamp priorities the model does not name: {'high'}
```

**The sole source is one line, and it is correct code:**

```ts
src/voice-host.ts:201
    session.notifyBackground(
        `A delegated task just finished. Relay the result ...`,
        { priority: 'high' });
```

`high` is that dependency's own vocabulary:

```ts
node_modules/bodhi-realtime-agent/dist/index.d.ts:1904
    notifyBackground(text: string, options?: { priority?: 'normal' | 'high'; ... }): void;
```

and the *genuine* task stamp in the same file — `src/voice-host.ts:95`, `'priority: urgent'` — is already modelled.

**Both obvious "fixes" are harmful**, which is why this is worth pre-empting rather than fixing when it goes red: adding `high` to `PRIORITIES` puts a value in the model that no task file ever carries, and editing line 201 breaks a type-correct call to a dependency.

## Why the pattern is removable, not just fixable

It contributes nothing. Measured on `main`, per contributing pattern, for **both** keys the census is used with:

```
key=access_tier   quoted-key      {guest, owner}
                  header-\n       {other, owner, team}
                  backtick        {ambient, owner, team}
                  object-literal  {owner}
                  values ONLY object-literal finds:  none

key=priority      quoted-key      {normal}
                  header-\n       {low, normal, urgent}
                  backtick        {normal, urgent}
                  object-literal  nothing
                  values ONLY object-literal finds:  none
```

Every value it finds is already found by a stricter shape. Its only distinct effect is the false positive.

## What changed

- Removed the object-literal alternative from the census pattern.
- Extracted the shapes into `_stamp_pattern(key)` so they can be tested against **fixtures** rather than only against the live tree — previously the only way to exercise them was to have a real producer in the repo.
- Pinned the contract both ways: an options object is not counted; quoted-key, `\n`-terminated and backtick-terminated header writes still are; same for `access_tier`.
- Updated the docstring, which enumerated three deliberate exclusions. An options object was a fourth shape and was not on the list.

## Evidence

**Before, on this branch's parent (`169d67ad9`, main):** `Ran 6 tests … OK` — green, because the shape isn't in-tree yet. The failure is only reproducible on `feat/sutando-server`, quoted above.

**After:** `Ran 11 tests … OK`

**Mutation** — restoring the removed alternative and rerunning:

```
FAIL: test_a_third_party_options_object_is_not_a_stamp
FAIL: test_the_same_holds_for_access_tier
Ran 11 tests   FAILED (failures=2)
```

Exactly the two options-object controls; the three positive controls stay green, so the removal is not simply making the census match less.

`review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)`, `git diff --check` clean, no files deleted.

## Worst case

The census could miss a *future* producer that stamps a task header as an unquoted object literal.

**Correction (2026-08-28), after @qingyun-wu's review.** This paragraph originally read "No such producer exists today for either key — measured above." **That was wrong**, and the error is instructive: my measurement was at the *value* level (`values ONLY object-literal finds: none`, which holds), and I generalised it into a claim about *producers*, which I never measured. Four object-literal producers do exist:

```
src/observability/claude/hook-normalizer.ts:73   actor: { ..., access_tier: 'owner', ... }
src/observability/claude/ids.ts:53               access_tier: 'owner',
src/observability/claude/jsonl-tail.ts:34        const ACTOR = { ..., access_tier: 'owner' as AccessTier, ... }
src/observability/realtime-map.ts:101            const VOICE_ACTOR: Actor = { ..., access_tier: 'owner', ... }
```

**They are all on a different plane, which is why removing the pattern is still right.** `src/observability/events.ts:15` declares its own vocabulary:

```ts
export type AccessTier = 'owner' | 'team' | 'public' | 'unknown';
```

versus the task protocol's `ACCESS_TIERS = ('owner','team','guest','other','ambient')`. Same field name, two shared values, different sets. So those four are not task-header stamps at all — they are the same class of false positive as the bodhi options object, merely harmless today because `owner` happens to be in both vocabularies.

Keeping the alternative for `access_tier` alone (the narrower option @qingyun-wu offered without blocking on) would therefore preserve sensitivity to the *wrong* plane.

**And that plane already contains a value the task model does not name.** `realtime-map.ts:107` stamps `access_tier: (isOwner ? 'owner' : 'public')`. `public` is absent from `ACCESS_TIERS`; it is invisible only because a ternary matches none of the four patterns. If that expression is ever simplified to a literal, the task-protocol suite fails over an observability event schema.

Task files are written as `key: value` header lines, which the retained `\n`/backtick shapes cover. If a genuine object-literal *task* producer ever appears, the fix is to add its shape deliberately rather than to keep a pattern that matches every options object in the tree. The wider question — whether the census should be scoped away from `src/observability/**` entirely — is a separate change and not folded in here.

Found while mapping the failing checks on the `feat/sutando-server` stack (#3490 / #3491 / #3492 / #3343); this was the one failure there with no owner. Checked the four open PRs touching these files — none modifies the census function.


