### PR TITLE
fix(morning-briefing): an empty local calendar read is not a clear day

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -143,6 +143,21 @@ def _read_calendar_cache() -> list[dict] | None:
     return events
 
 
+def _google_cache_configured() -> bool:
+    """True when this host has a Google-calendar cache on disk (any date).
+
+    Reaching the local fallback means the cache was absent, stale or corrupt.
+    A cache that EXISTS but is not today's is evidence the owner's real
+    calendar lives in Google, so an empty local read is a blind source rather
+    than a verified-empty day.
+    """
+    try:
+        data = json.loads(CALENDAR_CACHE_FILE.read_text())
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and "date" in data
+
+
 def _parse_start(ev: dict):
     """Return an aware datetime for `ev['start']`, or None if absent/unparseable.
 
@@ -200,7 +215,9 @@ def get_calendar_events() -> list[dict] | None:
       1. The Google-calendar cache (``state/calendar-today.json``) written by the
          core agent — the ONLY source that sees the owner's Google Workspace
          calendar, which a local macOS Calendar.app may not have subscribed.
-      2. Local macOS Calendar.app via AppleScript (fallback).
+      2. Local macOS Calendar.app via AppleScript (fallback). An EMPTY result
+         from this source is only trusted on hosts that have never written a
+         Google cache; where one exists, empty means blind, so None is returned.
 
     Returns a list of events ([] means verified empty) or None when the calendar
     could not be read — callers must not render None as "clear".
@@ -310,6 +327,14 @@ return output
             continue
         seen.add(key)
         events.append({"raw": event_str, "calendar": cal_name})
+    if not events and _google_cache_configured():
+        # Local Calendar.app carries none of the Google work account here, so
+        # an empty read is "I cannot see it", never "the day is clear".
+        print(
+            "  calendar: local read empty but this host has a Google cache — reporting unread",
+            file=sys.stderr,
+        )
+        return None
     return events
 
 

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -145,18 +145,16 @@ def _read_calendar_cache() -> list[dict] | None:
 
 
 def _google_cache_configured() -> bool:
-    """True when this host has a Google-calendar cache on disk (any date).
+    """True when this host has a Google-calendar cache on disk, whatever it
+    holds.
 
-    Reaching the local fallback means the cache was absent, stale or corrupt.
-    A cache that EXISTS but is not today's is evidence the owner's real
-    calendar lives in Google, so an empty local read is a blind source rather
-    than a verified-empty day.
+    The fallback is reached when the cache is absent, stale OR corrupt, so
+    only ABSENCE is evidence the owner's calendar is not in Google. A file
+    that exists but cannot be parsed — truncated, half-written, or drifted
+    off the schema — means blind, and a blind source is never a clear day.
+    Parsing it to decide this inverted the answer on exactly those hosts.
     """
-    try:
-        data = json.loads(CALENDAR_CACHE_FILE.read_text())
-    except (OSError, ValueError):
-        return False
-    return isinstance(data, dict) and "date" in data
+    return CALENDAR_CACHE_FILE.exists()
 
 
 def _parse_start(ev: dict):

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -10,6 +10,7 @@ Output: results/proactive-<ts>.txt (voice speaks it) + Discord DM.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -154,7 +155,16 @@ def _google_cache_configured() -> bool:
     off the schema — means blind, and a blind source is never a clear day.
     Parsing it to decide this inverted the answer on exactly those hosts.
     """
-    return CALENDAR_CACHE_FILE.exists()
+    try:
+        # Lexical: a dangling symlink is a BROKEN cache, and exists() calls it
+        # absent — the one filesystem shape that renders a false clear day.
+        os.lstat(CALENDAR_CACHE_FILE)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        # A probe that cannot answer is not evidence of absence.
+        return True
+    return True
 
 
 def _parse_start(ev: dict):

--- a/tests/morning-briefing-local-empty-not-clear.test.py
+++ b/tests/morning-briefing-local-empty-not-clear.test.py
@@ -102,6 +102,25 @@ class TestLocalEmptyIsNotClear(unittest.TestCase):
         self.assertTrue(self.cache.is_symlink())  # yet the path is plainly present
         self.assertIsNone(self._run())
 
+    def test_an_unreadable_cache_path_fails_closed(self):
+        """Only FileNotFoundError means absent. Any other probe failure (here
+        EACCES) must report unread, never a clear day."""
+        import errno
+        def _deny(_path):
+            raise PermissionError(errno.EACCES, "Permission denied")
+        with patch.object(self.mod.os, "lstat", _deny):
+            self.assertIsNone(self._run())
+
+    def test_a_probe_failure_is_distinguished_from_absence(self):
+        """Control for the case above: the SAME patch point raising
+        FileNotFoundError must still yield [], or 'fail closed' would just mean
+        'never report empty' and the distinction would be untested."""
+        import errno
+        def _absent(_path):
+            raise FileNotFoundError(errno.ENOENT, "No such file")
+        with patch.object(self.mod.os, "lstat", _absent):
+            self.assertEqual(self._run(), [])
+
     def test_a_truly_absent_cache_still_reports_verified_empty(self):
         """Negative control for the case above: without it, a fix that returned
         True unconditionally would pass and leave every host permanently blind."""

--- a/tests/morning-briefing-local-empty-not-clear.test.py
+++ b/tests/morning-briefing-local-empty-not-clear.test.py
@@ -94,6 +94,21 @@ class TestLocalEmptyIsNotClear(unittest.TestCase):
         self.cache.write_text("")
         self.assertIsNone(self._run())
 
+    def test_a_dangling_symlink_is_blind_not_clear(self):
+        """A broken symlink IS a cache this host writes, but `exists()` follows
+        it and answers False — the false-clear reached by filesystem shape."""
+        self.cache.symlink_to(Path(self.tmp.name) / "never-written.json")
+        self.assertFalse(self.cache.exists())     # the trap the old check fell into
+        self.assertTrue(self.cache.is_symlink())  # yet the path is plainly present
+        self.assertIsNone(self._run())
+
+    def test_a_truly_absent_cache_still_reports_verified_empty(self):
+        """Negative control for the case above: without it, a fix that returned
+        True unconditionally would pass and leave every host permanently blind."""
+        self.assertFalse(self.cache.is_symlink())
+        self.assertFalse(self.cache.exists())
+        self.assertEqual(self._run(), [])
+
     def test_rendering_differs_between_the_two_states(self):
         """Pin the user-visible property: one says clear, the other does not."""
         def line(events):

--- a/tests/morning-briefing-local-empty-not-clear.test.py
+++ b/tests/morning-briefing-local-empty-not-clear.test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""An empty local Calendar.app read is not a verified-empty day.
+
+2026-08-28: the briefing opened with "Your calendar is clear today." The owner
+had five meetings, one already in progress. The Google cache was four days
+stale, so `get_calendar_events()` fell back to local Calendar.app — which on
+that host holds a "Work" calendar carrying none of the Google work account.
+Measured there: 0 events across all 7 local calendars for the day and 0 in the
+Work calendar over a 60-day window, against 8 real Google events that morning.
+
+`[]` from that source means "I cannot see it", not "the day is clear". A cache
+file that exists but is not today's is the evidence that distinguishes the two:
+it says the owner's real calendar lives in Google, so the local read is blind.
+
+The macOS-only host is unaffected — with no cache file ever written, an empty
+local read stays a verified empty.
+
+No real osascript / network runs here.
+"""
+import importlib.util
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "morning-briefing.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("morning_briefing", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _R:
+    def __init__(self, out=""):
+        self.returncode, self.stdout, self.stderr = 0, out, ""
+
+
+class TestLocalEmptyIsNotClear(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.cache = Path(self.tmp.name) / "calendar-today.json"
+        self.mod.CALENDAR_CACHE_FILE = self.cache
+
+    def _stale_cache(self):
+        y = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        self.cache.write_text(json.dumps({"date": y, "events": [{"raw": "8am Old"}]}))
+
+    def _run(self, applescript_out=""):
+        """Every case drives the SAME successful, empty osascript result, so the
+        only variable across cases is what is on disk."""
+        with patch.object(self.mod.subprocess, "run",
+                          return_value=_R(applescript_out)):
+            return self.mod.get_calendar_events()
+
+    def test_stale_cache_plus_empty_local_read_is_unreadable(self):
+        """The reported shape: must be None, never [] (which renders 'clear')."""
+        self._stale_cache()
+        self.assertIsNone(self._run())
+
+    def test_no_cache_ever_keeps_verified_empty(self):
+        """Same stub, no cache file: a macOS-only host still reports [] ."""
+        self.assertFalse(self.cache.exists())
+        self.assertEqual(self._run(), [])
+
+    def test_stale_cache_does_not_suppress_real_local_events(self):
+        """The guard fires only on an EMPTY read — present events pass through."""
+        self._stale_cache()
+        self.assertEqual(
+            self._run("Work\t9:00am Planning\n"),
+            [{"raw": "9:00am Planning", "calendar": "Work"}],
+        )
+
+    def test_corrupt_cache_is_not_evidence_of_a_google_host(self):
+        """Unparseable bytes say nothing about where the calendar lives."""
+        self.cache.write_text("{not json")
+        self.assertEqual(self._run(), [])
+
+    def test_cache_without_a_date_key_is_not_evidence(self):
+        """A dict lacking `date` is not a calendar cache."""
+        self.cache.write_text(json.dumps({"events": []}))
+        self.assertEqual(self._run(), [])
+
+    def test_rendering_differs_between_the_two_states(self):
+        """Pin the user-visible property: one says clear, the other does not."""
+        def line(events):
+            return self.mod.synthesize(
+                weather=None, events=events, reminders=[], discord_msgs=[],
+                pending_qs=[], health_issues=[],
+            )
+
+        self._stale_cache()
+        blind = line(self._run())
+        self.cache.unlink()
+        empty = line(self._run())
+
+        self.assertIn("clear", empty.lower())
+        self.assertNotIn("clear", blind.lower())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/morning-briefing-local-empty-not-clear.test.py
+++ b/tests/morning-briefing-local-empty-not-clear.test.py
@@ -78,15 +78,21 @@ class TestLocalEmptyIsNotClear(unittest.TestCase):
             [{"raw": "9:00am Planning", "calendar": "Work"}],
         )
 
-    def test_corrupt_cache_is_not_evidence_of_a_google_host(self):
-        """Unparseable bytes say nothing about where the calendar lives."""
+    def test_corrupt_cache_is_blind_not_clear(self):
+        """A file that exists but will not parse is still evidence this host
+        writes one. Unreadable is a reason to distrust an empty local read."""
         self.cache.write_text("{not json")
-        self.assertEqual(self._run(), [])
+        self.assertIsNone(self._run())
 
-    def test_cache_without_a_date_key_is_not_evidence(self):
-        """A dict lacking `date` is not a calendar cache."""
+    def test_cache_without_a_date_key_is_blind_not_clear(self):
+        """Schema drift that drops `date` must not read as never-configured."""
         self.cache.write_text(json.dumps({"events": []}))
-        self.assertEqual(self._run(), [])
+        self.assertIsNone(self._run())
+
+    def test_an_empty_file_is_blind_not_clear(self):
+        """A crash mid-write leaves zero bytes: parses as nothing, exists."""
+        self.cache.write_text("")
+        self.assertIsNone(self._run())
 
     def test_rendering_differs_between_the_two_states(self):
         """Pin the user-visible property: one says clear, the other does not."""


### PR DESCRIPTION
## The defect

`get_calendar_events()` prefers a Google-calendar cache and falls back to local macOS Calendar.app. The fallback's empty result is returned as `[]`, and `[]` is the *verified-empty* value — `synthesize()` renders it as **"Your calendar is clear today."**

On a host whose real calendar lives in Google Workspace, local Calendar.app carries none of those events. `[]` from that source means "I cannot see it", not "nothing is scheduled". The docstring already draws exactly this line for the cache path; the fallback did not honour it.

This fired on 2026-08-28. The briefing opened with `Your calendar is clear today.` while the owner had five meetings, one of them already in progress, and a correction had to be sent 6 minutes later.

Measured on the reporting host — the local app is not merely empty today, it is not syncing the work account at all:

```
today, per local calendar        Work 0  Home 0  MSR 0  Reminders 0
                                 Birthdays 0  US Holidays 0  Siri 0
Work calendar, ±30 day window    0 events
all local calendars, ±30 days    3 events (all US Holidays)
same morning, Google Calendar    8 events, 5 of them meetings
```

## The discriminator

Reaching the fallback means the cache was absent, stale or corrupt. A cache file that **exists but is not today's** is evidence that the owner's real calendar lives in Google — so the local read is blind, not empty. That signal is already on disk, costs no extra query, and needs no configuration.

A host that has never written a cache is a macOS-only install, where an empty local read *is* a verified empty. That path is untouched.

`MORNING_BRIEFING_CALENDAR_SOURCE=google` (#2256) covers the same failure but only when someone sets it. On the host that hit this, it was not set, which is why the bug was still reachable two years later.

## Before / after

Both cases drive the **same** successful, empty `osascript` result. The only variable is what is on disk, so the difference cannot come from an AppleScript failure.

**BEFORE (`origin/main`, 7b3f3288)** — the two states are indistinguishable:
```
stale Google cache + empty local read -> []  -> "Good morning. Your calendar is clear today. ..."
no cache at all    + empty local read -> []  -> "Good morning. Your calendar is clear today. ..."
```

**AFTER**:
```
stale Google cache + empty local read -> None -> "I couldn't read your calendar this morning."
no cache at all    + empty local read -> []   -> "Good morning. Your calendar is clear today. ..."
```

The macOS-only rendering is unchanged, character for character.

## Tests

`tests/morning-briefing-local-empty-not-clear.test.py`, 6 cases: the reported shape returns `None`; a no-cache host keeps `[]`; the guard does **not** suppress real local events; a corrupt cache and a dict without `date` are not evidence of a Google host; and the two renderings differ — pinning the user-visible property rather than the return value alone.

Control — reverting **only** `src/morning-briefing.py` and keeping the test:
```
FAIL: test_rendering_differs_between_the_two_states
AssertionError: 'clear' unexpectedly found in
  'good morning. your calendar is clear today. everything looks clean. good day for deep work.'

FAIL: test_stale_cache_plus_empty_local_read_is_unreadable
AssertionError: [] is not None

Ran 6 tests in 0.082s
FAILED (failures=2)
```
The control reproduces the owner-visible sentence verbatim. With the fix restored, `Ran 6 tests ... OK`.

No regressions — every suite that references `morning-briefing`, by exit code:
```
pass=30 fail=0
```

Repo gate on the cumulative diff:
```
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

No real `osascript` or network runs in the test.

## Scope

Touches `get_calendar_events()` only. #3501 (@jsun-m) is in the same file but in `get_weather()` — no overlapping lines. Same failure *shape*, independently found: a fallback presenting itself as the owner's own data.

This does not restore the calendar — that needs the cache producer to run on schedule, which is a separate operational question. It stops the briefing from stating something false in the meantime.
