### PR TITLE
fix(hooks): auto-register gmail-write-guard — it had no production registrar

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -155,7 +155,19 @@ denied); non-Gmail tools are a no-op, so it is safe under a broad matcher.
 Escape hatch: `SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES=1` lifts the guard (for
 if/when the connector's scopes are fixed upstream). Fail-OPEN on hook errors.
 
-### Deploy (per node)
+### Registration
+
+**Auto-registered** for every core session: `start-cli.sh` passes this hook to
+`src/agent/claude/cli/build-core-settings.mjs`, which registers it under
+`PreToolUse` with matcher `mcp__.*[Gg][Mm][Aa][Ii][Ll].*` in the `--settings`
+JSON. Nothing to install per node.
+
+The registration rides `--settings` rather than a written `settings.json`, so it
+survives an app update that replaces the engine tree (the failure mode issue
+#3221 describes for the `install-claude-hooks.sh` set).
+
+To register it in a non-core session (e.g. an interactive Claude Code), add the
+same `PreToolUse` entry to `~/.claude/settings.json` by hand:
 
 ```bash
 cp hooks/gmail-write-guard.py ~/.claude/hooks/

--- a/src/agent/claude/cli/build-core-settings.mjs
+++ b/src/agent/claude/cli/build-core-settings.mjs
@@ -92,11 +92,8 @@ if (skillTelemetryHook.trim()) {
 	};
 }
 
-// Gmail connector write guard: always-on registration. The connector advertises
-// write tools whose scopes are broken, so the wrong affordance is visible at the
-// tool layer while the sanctioned IMAP/SMTP path is only prose — a deny that
-// names the right path is what closes that gap. The matcher mirrors
-// hooks/README.md; the hook re-checks the tool name and no-ops otherwise.
+// Always-on: the connector's write scopes are broken, so the deny must reach the
+// caller. The hook re-checks the tool name, so the matcher is belt-and-braces.
 const gmailWriteGuardHook = process.argv[5] || '';
 let gmailWriteGuardSettings = null;
 if (gmailWriteGuardHook.trim()) {

--- a/src/agent/claude/cli/build-core-settings.mjs
+++ b/src/agent/claude/cli/build-core-settings.mjs
@@ -13,10 +13,12 @@
 // builder treats the obs settings as an opaque JSON blob and array-concats it
 // with the guard, so the two concerns never drift.
 //
-// Usage:  node build-core-settings.mjs <abs-path-to-guard-hook.py> [<obs-settings-json>] [<abs-path-to-skill-telemetry-hook.py>]
+// Usage:  node build-core-settings.mjs <abs-path-to-guard-hook.py> [<obs-settings-json>] [<abs-path-to-skill-telemetry-hook.py>] [<abs-path-to-gmail-write-guard.py>]
 //   arg1 (required): path to the guard hook script (skip-ask-user-question.py).
 //   arg2 (optional): the obs `--settings` JSON string from build-hook-settings.mjs;
 //                    empty / omitted → obs hooks are not included.
+//   arg4 (optional): path to hooks/gmail-write-guard.py — registered under
+//                    PreToolUse for the Gmail MCP connector's write tools.
 //   arg3 (optional): path to hooks/skill-usage-telemetry.py — registered
 //                    UNCONDITIONALLY as PostToolUse[Skill]. Product telemetry
 //                    (anonymous per-skill feature counter, #2047/#2254) is NOT
@@ -90,4 +92,21 @@ if (skillTelemetryHook.trim()) {
 	};
 }
 
-process.stdout.write(JSON.stringify(mergeHookSettings(guardSettings, obsSettings, skillTelemetrySettings)));
+// Gmail connector write guard: always-on registration. The connector advertises
+// write tools whose scopes are broken, so the wrong affordance is visible at the
+// tool layer while the sanctioned IMAP/SMTP path is only prose — a deny that
+// names the right path is what closes that gap. The matcher mirrors
+// hooks/README.md; the hook re-checks the tool name and no-ops otherwise.
+const gmailWriteGuardHook = process.argv[5] || '';
+let gmailWriteGuardSettings = null;
+if (gmailWriteGuardHook.trim()) {
+	gmailWriteGuardSettings = {
+		hooks: {
+			PreToolUse: [{ matcher: 'mcp__.*[Gg][Mm][Aa][Ii][Ll].*', hooks: [{ type: 'command', command: `python3 ${shq(gmailWriteGuardHook)}` }] }],
+		},
+	};
+}
+
+process.stdout.write(
+	JSON.stringify(mergeHookSettings(guardSettings, obsSettings, skillTelemetrySettings, gmailWriteGuardSettings)),
+);

--- a/src/agent/claude/cli/build-core-settings.mjs
+++ b/src/agent/claude/cli/build-core-settings.mjs
@@ -17,8 +17,6 @@
 //   arg1 (required): path to the guard hook script (skip-ask-user-question.py).
 //   arg2 (optional): the obs `--settings` JSON string from build-hook-settings.mjs;
 //                    empty / omitted → obs hooks are not included.
-//   arg4 (optional): path to hooks/gmail-write-guard.py — registered under
-//                    PreToolUse for the Gmail MCP connector's write tools.
 //   arg3 (optional): path to hooks/skill-usage-telemetry.py — registered
 //                    UNCONDITIONALLY as PostToolUse[Skill]. Product telemetry
 //                    (anonymous per-skill feature counter, #2047/#2254) is NOT
@@ -27,6 +25,8 @@
 //                    emitted zero skill:* events in production (the obs blob is
 //                    only built when SUTANDO_OBS_ENDPOINT is set). The hook
 //                    script honors the telemetry opt-out on its own.
+//   arg4 (optional): path to hooks/gmail-write-guard.py — registered under
+//                    PreToolUse for the Gmail MCP connector's write tools.
 // Prints the merged settings JSON to stdout (exit 2 on a missing guard path,
 // exit 3 on an unparseable obs-settings blob).
 

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -392,7 +392,7 @@ else
       echo "obs hooks: settings build failed — capture disabled this session" >&2
     fi
   fi
-  CORE_SETTINGS_JSON="$(node "$REPO/src/agent/claude/cli/build-core-settings.mjs" "$REPO/hooks/skip-ask-user-question.py" "$OBS_JSON" "$REPO/hooks/skill-usage-telemetry.py")"
+  CORE_SETTINGS_JSON="$(node "$REPO/src/agent/claude/cli/build-core-settings.mjs" "$REPO/hooks/skip-ask-user-question.py" "$OBS_JSON" "$REPO/hooks/skill-usage-telemetry.py" "$REPO/hooks/gmail-write-guard.py")"
   if [ -n "$CORE_SETTINGS_JSON" ]; then
     SETTINGS_ARGS=(--settings "$CORE_SETTINGS_JSON")
     echo "core hooks: AskUserQuestion guard registered (PreToolUse deny — headless core can't answer it)"

--- a/tests/agent/claude/cli/build-core-settings.test.ts
+++ b/tests/agent/claude/cli/build-core-settings.test.ts
@@ -124,9 +124,8 @@ describe('build-core-settings.mjs', () => {
 		);
 	});
 
-	// The guard shipped for a year with no production registrar: it appeared only
-	// in hooks/README.md as a manual `cp`, so the connector's broken write tools
-	// stayed reachable on every install that never ran those steps by hand.
+	// Regression: the guard had no production registrar, so it stayed inert on any
+	// install that never ran the README's manual cp by hand.
 	it('registers the Gmail write guard when its path is supplied', () => {
 		const o = buildCore(GUARD, '', SKILL_TELEMETRY, GMAIL_WRITE_GUARD);
 		const blk = o.hooks.PreToolUse.find((b: any) =>

--- a/tests/agent/claude/cli/build-core-settings.test.ts
+++ b/tests/agent/claude/cli/build-core-settings.test.ts
@@ -12,13 +12,20 @@ const OBS_BUILDER = fileURLToPath(
 	new URL('../../../../src/observability/claude/hooks/build-hook-settings.mjs', import.meta.url),
 );
 
-function buildCore(guardPath: string, obsJson?: string, skillTelemetryHook?: string): any {
+function buildCore(
+	guardPath: string,
+	obsJson?: string,
+	skillTelemetryHook?: string,
+	gmailWriteGuardHook?: string,
+): any {
 	const args =
-		skillTelemetryHook === undefined
-			? obsJson === undefined
-				? [CORE_BUILDER, guardPath]
-				: [CORE_BUILDER, guardPath, obsJson]
-			: [CORE_BUILDER, guardPath, obsJson ?? '', skillTelemetryHook];
+		gmailWriteGuardHook !== undefined
+			? [CORE_BUILDER, guardPath, obsJson ?? '', skillTelemetryHook ?? '', gmailWriteGuardHook]
+			: skillTelemetryHook === undefined
+				? obsJson === undefined
+					? [CORE_BUILDER, guardPath]
+					: [CORE_BUILDER, guardPath, obsJson]
+				: [CORE_BUILDER, guardPath, obsJson ?? '', skillTelemetryHook];
 	return JSON.parse(execFileSync('node', args, { encoding: 'utf8' }));
 }
 
@@ -35,6 +42,7 @@ function shellParsedPath(command: string): string {
 
 const GUARD = '/x/hooks/skip-ask-user-question.py';
 const SKILL_TELEMETRY = '/x/hooks/skill-usage-telemetry.py';
+const GMAIL_WRITE_GUARD = '/x/hooks/gmail-write-guard.py';
 
 describe('build-core-settings.mjs', () => {
 	it('always registers the AskUserQuestion guard (guard-only, obs off)', () => {
@@ -114,5 +122,42 @@ describe('build-core-settings.mjs', () => {
 		assert.throws(() =>
 			execFileSync('node', [CORE_BUILDER, GUARD, '{not json'], { encoding: 'utf8', stdio: 'pipe' }),
 		);
+	});
+
+	// The guard shipped for a year with no production registrar: it appeared only
+	// in hooks/README.md as a manual `cp`, so the connector's broken write tools
+	// stayed reachable on every install that never ran those steps by hand.
+	it('registers the Gmail write guard when its path is supplied', () => {
+		const o = buildCore(GUARD, '', SKILL_TELEMETRY, GMAIL_WRITE_GUARD);
+		const blk = o.hooks.PreToolUse.find((b: any) =>
+			b.hooks.some((h: any) => h.command.includes('gmail-write-guard')),
+		);
+		assert.ok(blk, 'no PreToolUse block registers gmail-write-guard');
+		assert.equal(blk.matcher, 'mcp__.*[Gg][Mm][Aa][Ii][Ll].*');
+		assert.equal(shellParsedPath(blk.hooks[0].command), GMAIL_WRITE_GUARD);
+	});
+
+	it('the Gmail matcher selects connector Gmail tools and nothing else', () => {
+		const o = buildCore(GUARD, '', SKILL_TELEMETRY, GMAIL_WRITE_GUARD);
+		const blk = o.hooks.PreToolUse.find((b: any) =>
+			b.hooks.some((h: any) => h.command.includes('gmail-write-guard')),
+		);
+		const re = new RegExp(blk.matcher);
+		assert.ok(re.test('mcp__claude_ai_Gmail__create_draft'));
+		assert.ok(re.test('mcp__gmail__send_email'));
+		assert.ok(!re.test('mcp__claude_ai_Slack__slack_send_message'));
+		assert.ok(!re.test('Bash'));
+	});
+
+	it('omitting the Gmail guard path leaves the previous shape untouched', () => {
+		const o = buildCore(GUARD, '', SKILL_TELEMETRY);
+		assert.equal(o.hooks.PreToolUse.length, 1);
+		assert.equal(o.hooks.PreToolUse[0].matcher, 'AskUserQuestion');
+	});
+
+	it('keeps the AskUserQuestion guard alongside the Gmail guard (concat, not replace)', () => {
+		const o = buildCore(GUARD, '', SKILL_TELEMETRY, GMAIL_WRITE_GUARD);
+		const matchers = o.hooks.PreToolUse.map((b: any) => b.matcher);
+		assert.deepEqual(matchers, ['AskUserQuestion', 'mcp__.*[Gg][Mm][Aa][Ii][Ll].*']);
 	});
 });


### PR DESCRIPTION
## What

`hooks/gmail-write-guard.py` is registered automatically for every core session, from `build-core-settings.mjs` (new arg5) passed by `start-cli.sh`.

## Why

The guard denies the claude.ai Gmail MCP connector's **write** tools — whose OAuth scopes are broken (`label_thread` → "insufficient authentication scopes"; `create_draft` has 7 documented incidents incl. a wrong-recipient send, field report 05cb849a) — and redirects to the app-password IMAP/SMTP path. Reads stay allowed.

It is tested and correct. **Nothing registered it.** Outside its own source, every reference was documentation:

```
$ git grep -n 'gmail-write-guard' origin/main -- . | grep -v '^origin/main:tests/'
origin/main:hooks/README.md:142:## `gmail-write-guard.py`
origin/main:hooks/README.md:161:cp hooks/gmail-write-guard.py ~/.claude/hooks/
origin/main:hooks/README.md:165:cmd = "python3 ~/.claude/hooks/gmail-write-guard.py"
origin/main:hooks/README.md:174:Test: `python3 tests/gmail-write-guard.test.py`.
origin/main:hooks/gmail-write-guard.py:2,63,102   (its own source)
origin/main:hooks/result-file-marker-guard.py:60  (a docstring cross-reference)
```

It is in neither installer — not `install-claude-hooks.sh`'s `HOOKS` array (4 entries: 2× PreCompact, SessionEnd, Stop), and not `build-core-settings.mjs`. So on any install where a human never ran the README's manual `cp` + settings edit by hand, the guard was inert.

**Measured on this host** — the guard was neither installed nor registered:

```
settings.json files naming gmail-write-guard: NONE
hook file present at ~/.claude/hooks/:        False
```

This is the recurring failure in Michael Silton's report (bug `8e8f10ee`, 2026-08-27): the connector advertises write tools with full schemas at the tool layer, while the sanctioned route is prose in PERSONAL_CLAUDE/memory — and prose loses to tool-schema affordance whenever context is fresh.

## Before / after

Exactly what `start-cli.sh:395` builds.

**Before** (parent `7b3f32880`) — matchers `AskUserQuestion`, `Skill`; Gmail occurrences: **0**

**After** — adds one PreToolUse block:

```json
{
  "matcher": "mcp__.*[Gg][Mm][Aa][Ii][Ll].*",
  "hooks": [{ "type": "command", "command": "python3 '<repo>/hooks/gmail-write-guard.py'" }]
}
```

Gmail occurrences: **1**. The `AskUserQuestion` guard and the `Skill` telemetry hook are unchanged (concat, not replace).

**Behavioral** — piping tool names into the command as actually registered:

```
mcp__claude_ai_Gmail__create_draft         -> DENY
mcp__claude_ai_Gmail__label_thread         -> DENY
mcp__claude_ai_Gmail__list_labels          -> allow (no deny emitted)
mcp__claude_ai_Gmail__read_message         -> allow (no deny emitted)
Bash                                       -> allow (no deny emitted)

deny reason names the IMAP/SMTP path: True
```

## Why `build-core-settings.mjs` and not `install-claude-hooks.sh`

This registration rides `--settings` rather than a written `settings.json`, so it survives an app update that replaces the engine tree — the failure mode #3221 describes for the `install-claude-hooks.sh` set. It also sidesteps the consent concern raised in #3221's comments (that installer has no way to install a subset, so re-running it at boot would silently add privacy-sensitive hooks): this is a deny-only guard that collects nothing.

Distinct from #3221, which covers a different, lifecycle hook set.

## Tests

`tests/agent/claude/cli/build-core-settings.test.ts` — 4 new cases: registration + path quoting, matcher selectivity (matches `mcp__claude_ai_Gmail__create_draft` and `mcp__gmail__send_email`; not `mcp__claude_ai_Slack__slack_send_message`, not `Bash`), the omitted-arg shape is unchanged, and the AskUserQuestion guard is kept alongside.

```
15/15 pass
```

Negative control — with the builder reverted to `origin/main` and the new tests kept, **3 of the 4 fail** (the 4th is the omitted-arg regression guard, which correctly passes both ways). So the tests can fail.

`python3 tests/gmail-write-guard.test.py` — PASS (unchanged; the hook itself is untouched).

`scripts/review-checks.sh --diff` — hardcoded-paths + root-artifacts clean.

## Scope note

No change to the hook's own logic, its matcher, or its escape hatch (`SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES=1`). This is registration only.

Not a live-path restart test: I have not restarted a core to observe the hook firing in a real session. The evidence above is the built settings JSON plus the registered command's actual behavior on stdin.