### PR TITLE
feat(collab-intelligence): recruitment refuses approvals a PR already has

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -135,6 +135,34 @@ def command_for(target: dict, message: str) -> "list[str]":
             "mention", target["stand"], body, target["room"]]
 
 
+def approval_gate(pr: str, repo: str, required: int = 2):
+    """Refuse recruitment for approvals a PR already has (owner-durable
+    2026-08-28: a widening chased an approval that existed for 90 minutes —
+    the ask ran from a stale mental model instead of the live review list).
+
+    Returns (met, detail). Latest DECISIVE review per login; COMMENTED never
+    counts. Fail-open on query error: an unreachable API must not block a
+    legitimate ask, so the gate only refuses on POSITIVE evidence."""
+    try:
+        out = subprocess.run(
+            ["gh", "api", f"repos/{repo}/pulls/{pr}/reviews", "--paginate",
+             "--jq", "[.[] | {u: .user.login, s: .state, t: .submitted_at}]"],
+            capture_output=True, text=True, timeout=30)
+        if out.returncode != 0:
+            return False, f"gate query failed ({out.stderr.strip()[:60]}) — proceeding"
+        latest: dict = {}
+        for r in json.loads(out.stdout or "[]"):
+            if r["s"] in ("APPROVED", "CHANGES_REQUESTED"):
+                latest[r["u"]] = r
+        approvers = [f"{u}@{r['t'][:16]}" for u, r in latest.items()
+                     if r["s"] == "APPROVED"]
+        if len(approvers) >= required:
+            return True, ", ".join(sorted(approvers))
+        return False, f"{len(approvers)}/{required} standing"
+    except Exception as exc:
+        return False, f"gate error ({exc}) — proceeding"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--reviewers", required=True,
@@ -145,7 +173,21 @@ def main() -> int:
                     help="room the conversation is actually in. When given, a reviewer whose "
                          "Stand is not a member THERE is REFUSED rather than silently notified "
                          "in their recorded room — correctly addressed, wrong venue.")
+    ap.add_argument("--pr", default=None,
+                    help="PR number this ask is recruiting for. When given, the live "
+                         "review list is read FIRST and the send is REFUSED if the "
+                         "approval bar is already met — recruiting an approval that "
+                         "exists is noise to the reviewer and a stale-model tell.")
+    ap.add_argument("--repo", default="sonichi/sutando")
+    ap.add_argument("--force-extra", action="store_true",
+                    help="send anyway when the bar is met (a deliberate extra ask)")
     a = ap.parse_args()
+    if a.pr and not a.force_extra:
+        met, detail = approval_gate(a.pr, a.repo)
+        if met:
+            print(f"REFUSED: #{a.pr} already has the required approvals ({detail}). "
+                  f"Re-read the review list; --force-extra only for a deliberate extra ask.")
+            return 5
     names = [n.strip() for n in a.reviewers.split(",") if n.strip()]
     targets, refusal_rc = resolve(names, load_roster())
     failures = 0

--- a/tests/notify-reviewers-approval-gate.test.py
+++ b/tests/notify-reviewers-approval-gate.test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""approval_gate: recruitment refuses approvals a PR already has (#3505).
+
+Covers the gate's decision table without the network: the gh subprocess is
+stubbed at subprocess.run, so every branch executes — met, unmet, COMMENTED
+ignored, CR superseded by later APPROVED, query failure fails OPEN.
+"""
+import importlib.util
+import json
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+spec = importlib.util.spec_from_file_location(
+    "nr", REPO / "skills" / "collaboration-intelligence" / "scripts" / "notify_reviewers.py")
+nr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(nr)
+
+
+def _gh(rows, rc=0, err=""):
+    out = types.SimpleNamespace(returncode=rc, stdout=json.dumps(rows), stderr=err)
+    return patch.object(nr.subprocess, "run", return_value=out)
+
+
+class ApprovalGate(unittest.TestCase):
+    def test_two_distinct_approvals_refuse(self):
+        rows = [{"u": "a", "s": "APPROVED", "t": "2026-08-28T14:47:00Z"},
+                {"u": "b", "s": "APPROVED", "t": "2026-08-28T13:18:00Z"}]
+        with _gh(rows):
+            met, detail = nr.approval_gate("1", "o/r")
+        self.assertTrue(met)
+        self.assertIn("a@", detail)
+        self.assertIn("b@", detail)
+
+    def test_one_approval_passes(self):
+        rows = [{"u": "a", "s": "APPROVED", "t": "2026-08-28T14:47:00Z"}]
+        with _gh(rows):
+            met, detail = nr.approval_gate("1", "o/r")
+        self.assertFalse(met)
+        self.assertIn("1/2", detail)
+
+    def test_commented_never_counts(self):
+        rows = [{"u": "a", "s": "APPROVED", "t": "t1"},
+                {"u": "b", "s": "COMMENTED", "t": "t2"}]
+        with _gh(rows):
+            met, _ = nr.approval_gate("1", "o/r")
+        self.assertFalse(met)
+
+    def test_later_approval_supersedes_own_cr(self):
+        rows = [{"u": "a", "s": "CHANGES_REQUESTED", "t": "t1"},
+                {"u": "a", "s": "APPROVED", "t": "t2"},
+                {"u": "b", "s": "APPROVED", "t": "t3"}]
+        with _gh(rows):
+            met, _ = nr.approval_gate("1", "o/r")
+        self.assertTrue(met)
+
+    def test_later_cr_supersedes_own_approval(self):
+        rows = [{"u": "a", "s": "APPROVED", "t": "t1"},
+                {"u": "a", "s": "CHANGES_REQUESTED", "t": "t2"},
+                {"u": "b", "s": "APPROVED", "t": "t3"}]
+        with _gh(rows):
+            met, _ = nr.approval_gate("1", "o/r")
+        self.assertFalse(met)
+
+    def test_query_failure_fails_open(self):
+        with _gh([], rc=1, err="boom"):
+            met, detail = nr.approval_gate("1", "o/r")
+        self.assertFalse(met)
+        self.assertIn("proceeding", detail)
+
+    def test_exception_fails_open(self):
+        with patch.object(nr.subprocess, "run", side_effect=OSError("no gh")):
+            met, detail = nr.approval_gate("1", "o/r")
+        self.assertFalse(met)
+        self.assertIn("proceeding", detail)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Owner directive (2026-08-28, 'merge. durable fix for the error'): today's reviewer widening on #3473 recruited an approval that had existed for 90 minutes — the ask ran from momentum and a stale mental model instead of the live review list. The check-existing-reviews rule already existed in prose; prose failed the same way rule 9 did before notify_reviewers.py existed, so the fix goes in the same place: the tool.

## What

`notify_reviewers.py --pr N [--repo O/R] [--force-extra]`: when `--pr` is given, the live review list is read FIRST — latest DECISIVE review per login, COMMENTED never counts — and the send is REFUSED (rc 5) naming the standing approvers with timestamps when the bar is already met. `--force-extra` permits a deliberate extra ask. Fail-open on query errors: an unreachable API must not block a legitimate ask, so only positive evidence refuses.

## Evidence — live controls at the committed head

```
--pr 3473  ->  REFUSED: #3473 already has the required approvals
               (qingyun-wu@2026-08-28T16:47, yixuan-ag2@2026-08-28T14:47)   rc=5
--pr 3502  ->  gate passes (0/2 standing), proceeds to the roster path
```

The #3473 refusal names the exact approval today's incident missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)