### PR TITLE
test(model): a bare object-literal key is not a task-plane stamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
+  # A pull_request run reads this file from the HEAD branch but matches any
+  # `branches:` filter against the BASE, so a filter here excludes non-main bases.
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/tests/durable-work-model.test.py
+++ b/tests/durable-work-model.test.py
@@ -11,7 +11,9 @@ ci-covers-every-python-test.test.py: contract drift should fail a test, not
 wait to be noticed.
 """
 import re
+import shutil
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -21,24 +23,28 @@ sys.path.insert(0, str(REPO / "src"))
 import local_task_protocol as ltp  # noqa: E402
 
 
-def _grep_stamped_values(key: str) -> set:
+def _grep_stamped_values(key: str, roots=None) -> set:
     """Every literal value producers stamp for `key:` across live writer
     code, Python AND TypeScript (the TS bridges are live stampers too).
 
     Write signatures only — quoted-key assignment ("access_tier":
-    "ambient"), header-line writes inside string literals ("access_tier:
-    ambient\\n" or backtick-terminated `access_tier: owner`), and unquoted
-    object-literal keys with quoted values (access_tier: 'owner'). Prose in
-    comments, `key: Type` annotations, and `.key === 'x'` comparisons match
-    none of these, which is what keeps this a producer census rather than a
-    word search."""
+    "ambient") and header-line writes inside string literals ("access_tier:
+    ambient\\n" or backtick-terminated `access_tier: owner`). Each carries a
+    syntactic marker that a task RECORD is being written. Prose in comments,
+    `key: Type` annotations, and `.key === 'x'` comparisons match none of
+    these, which is what keeps this a producer census rather than a word
+    search.
+
+    A bare object-literal key (`priority: 'high'`) is deliberately NOT a
+    signature: it matches any option bag in any subsystem, so it cannot tell
+    a task stamp from an unrelated argument that reuses the word."""
     pat = re.compile(
         rf"""["']{key}["']\s*[:=]\s*f?["']([a-z_]+)["']"""
         rf"""|{key}:\s*([a-z_]+)\\n"""
-        rf"""|{key}:\s*([a-z_]+)`"""
-        rf"""|(?<![.\w"'`]){key}\s*:\s*['"]([a-z_]+)['"]""")
+        rf"""|{key}:\s*([a-z_]+)`""")
     found = set()
-    roots = [REPO / "src", REPO / "skills", REPO / "packages"]
+    roots = ([REPO / "src", REPO / "skills", REPO / "packages"]
+             if roots is None else [Path(r) for r in roots])
     for root in roots:
         for suffix in ("*.py", "*.ts", "*.tsx"):
             for f in root.rglob(suffix):
@@ -51,6 +57,31 @@ def _grep_stamped_values(key: str) -> set:
                 for m in pat.finditer(text):
                     found.add(next(g for g in m.groups() if g))
     return found - {None}
+
+
+class TestCensusSignatures(unittest.TestCase):
+    """What counts as a producer stamp, driven by synthetic files."""
+
+    def _scan(self, name, text):
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d, True)
+        (Path(d) / name).write_text(text)
+        return _grep_stamped_values("priority", roots=[d])
+
+    def test_record_signatures_are_counted(self):
+        # Positive control: a narrowed pattern that matched nothing would let
+        # every census below pass by being empty rather than by being clean.
+        self.assertEqual(self._scan("w.py", '"priority": "urgent"'), {"urgent"})
+        self.assertEqual(self._scan("w.py", 'f"priority: normal\\n"'), {"normal"})
+        self.assertEqual(self._scan("w.ts", '`priority: low`'), {"low"})
+
+    def test_option_bag_key_is_not_a_task_stamp(self):
+        # notifyBackground(msg, { priority: 'high' }) is a voice-session
+        # option; counting it made the model answer for a plane it does not own.
+        self.assertEqual(
+            self._scan("v.ts",
+                       "session.notifyBackground(msg, { priority: 'high' });"),
+            set())
 
 
 class TestVocabularyCoversLiveProducers(unittest.TestCase):


### PR DESCRIPTION
`tests/durable-work-model.test.py` fails on `feat/sutando-server` and on **every open PR based on it** — #3490, #3491, #3492, #3343. Two of those are APPROVED and waiting only on a merge.

## The bug

The producer census counts four write signatures. Three carry a syntactic marker that a task *record* is being written: a quoted key, a header line ending in `\n`, and a backtick-terminated header. The fourth — a bare object-literal key with a quoted value — carries no such marker and matches any option bag in any subsystem.

On this branch it matches exactly one thing:

```
session.notifyBackground(msg, { priority: 'high' })     src/voice-host.ts:201
```

That is a voice-session notification option, on a plane the task model does not own. The census read it as a producer stamping an unknown priority. The line is branch-only, which is why main never sees this.

## Before / after

```
$ git worktree add --detach wt-srv origin/feat/sutando-server && cd wt-srv
$ python3 tests/durable-work-model.test.py
AssertionError: Items in the first set but not the second:
'high' : producers stamp priorities the model does not name: {'high'}
Ran 6 tests — FAILED (failures=1)

# same command at origin/main (control): rc=0
# this branch:
$ python3 tests/durable-work-model.test.py
Ran 8 tests — OK
```

## Why removing the alternative is safe

Hits contributed by each signature, counted separately over `src/`, `skills/`, `packages/`:

| key | quoted | header `\n` | backtick | bare |
|---|---|---|---|---|
| `priority` | 1 (normal) | 3 (low, normal, urgent) | 2 | **1 (high)** |
| `access_tier` | 14 | 21 | 12 | 4 (owner, all already covered) |

The bare form contributes no value the other three miss, for either key, and its only unique hit is the false positive. `ambient` — the drift this suite was born from — comes from the backtick form and is untouched.

## Guards

`_grep_stamped_values` gains a `roots` parameter so the two new cases drive synthetic files rather than depending on what the tree happens to contain:

- **regression** — the option-bag shape is not counted.
- **positive control** — all three record signatures still are, so a narrowed pattern cannot pass by matching nothing.

**Control:** restoring the removed alternative fails exactly two cases — the new regression case and the original failure — and nothing else.

## Scope

Test-only, one file. It does not fix the other base-inherited failure: `dashboard-schedules` also fails on this base, and #3343 already fixes that one at its head. Together those two are what keeps this base red.