### PR TITLE
docs(access-control): the policy agents load first still prescribed the hanging codex call

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -16,7 +16,7 @@ Telegram tasks include an `access_tier` field set by the bridge (same tiers as D
 
 Discord tasks include an `access_tier` field set by the bridge:
 - **owner**: Full access — process normally with all capabilities
-- **team**: Delegate to sandboxed agent (`codex exec --sandbox read-only`). No system mutations. **Exception — a per-channel collaborator.** A team sender listed under a channel's `collaborators` in `access.json` gets the `team-collaborator` engage rulebook in THAT channel only. That list is the owner's attestation for this surface: it is hand-configured, per-channel, and is a deliberate owner act rather than a wire flag a sender can set. Scope is strictly per-channel — membership in another channel's list does not carry over, and it grants engagement, not owner authority.
+- **team**: Delegate to sandboxed agent (`codex exec --sandbox read-only --skip-git-repo-check -- <prompt> < /dev/null` — the redirect is required or codex waits on stdin and can hang; assert its OUTPUT is non-empty, since it exits 0 on refusal too). No system mutations. **Exception — a per-channel collaborator.** A team sender listed under a channel's `collaborators` in `access.json` gets the `team-collaborator` engage rulebook in THAT channel only. That list is the owner's attestation for this surface: it is hand-configured, per-channel, and is a deliberate owner act rather than a wire flag a sender can set. Scope is strictly per-channel — membership in another channel's list does not carry over, and it grants engagement, not owner authority.
 - **other**: Delegate to sandboxed agent. Information only — answer questions about Sutando.
 
 Owner is determined by `allowFrom` in `$CLAUDE_CONFIG_DIR/channels/discord/access.json` (set via `/discord:access`).
@@ -38,7 +38,7 @@ The `context-source-guard` PreToolUse hook — **which is deployed per node, not
 
 Slack tasks include an `access_tier` field set by the bridge:
 - **owner**: Full access — process normally with all capabilities.
-- **team**: Delegate to sandboxed agent (`codex exec --sandbox read-only`). No system mutations. Slack Team mappings retain this existing contract.
+- **team**: Delegate to sandboxed agent (`codex exec --sandbox read-only --skip-git-repo-check -- <prompt> < /dev/null` — the redirect is required or codex waits on stdin and can hang; assert its OUTPUT is non-empty, since it exits 0 on refusal too). No system mutations. Slack Team mappings retain this existing contract.
 - **other**: Delegate to sandboxed agent. Information only — answer questions about Sutando.
 
 Tier resolution is per-user: `tierMap` in `$CLAUDE_CONFIG_DIR/channels/slack/access.json` maps Slack user IDs to tiers. Users in `allowFrom` without a `tierMap` entry default to `"owner"` (preserves pre-tierMap behavior).


### PR DESCRIPTION
Follow-up to #3507, found by @qingyun-air while reviewing it.

## Why this file specifically

`CLAUDE.md:219` routes every non-owner task through it *before* any handling decision:

> **Before deciding any non-owner task's handling, load and apply the full policy:** [`docs/access-control.md`](docs/access-control.md)

Both tier lines there prescribed the bare form:

```
docs/access-control.md:19  - **team**: Delegate to sandboxed agent (`codex exec --sandbox read-only`)…
docs/access-control.md:41  - **team**: Delegate to sandboxed agent (`codex exec --sandbox read-only`)…
```

#3507 fixes the instruction the **bridge injects into the task**. This is the *other* prescription an agent reads, and it is read **earlier** — so with #3507 alone, an agent following documented policy still gets the form that waits on stdin.

The failure it produces was measured on a live host: 5-minute timeout, 0 bytes, `Reading additional input from stdin...`; re-run with the redirect and nothing else changed, rc 0 / 770 bytes. Detail in #3507.

## Scope

Two lines. `docs/design-mediated-capability-layer.md` has two further mentions and is **deliberately not** touched — it describes an architecture, not a command anyone runs. Reviewer agreed on that split.

Nothing executable was exposed: `skills/claude-codex/scripts/review-pr.sh` already redirects (line 62, *after* the multi-line prompt — a line-scoped grep misses it and reports a false positive), and `make-viral-video/scripts/build.sh` redirects too. That enumeration is @qingyun-air's, re-run against the PR head.

`review-checks`: hardcoded-paths + root-artifacts clean; prose-cap reports no in-scope files (this diff is Markdown only).