### PR TITLE
fix(delivery-core): a terminal item is not contention (#3453)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -79,6 +79,13 @@ class DesignAClaimBackend:
             return ClaimToken(item_id=item_id, worker=worker,
                               incarnation=incarnation)
 
+    def is_terminal(self, item_id: str) -> bool:
+        with outbox._item_lock(self.root, item_id):
+            if not outbox._item_path(self.root, item_id).exists():
+                return False
+            return outbox._read_item(
+                self.root, item_id).get("status") in self.TERMINAL
+
     def complete(self, token: ClaimToken, outcome: DeliveryOutcome,
                  park_at_attempts: Optional[int] = None,
                  provider: Optional[str] = None,

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_c.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_c.py
@@ -242,6 +242,20 @@ class DesignCClaimBackend:
         os.replace(str(tmp), str(p))
         return n
 
+    def is_terminal(self, item_id: str) -> bool:
+        # C records terminality by LOCATION, not a status field: ARCHIVE and
+        # PARKED entries lead with the item key as their first SEP component.
+        key = _safe_key(item_id)
+        prefix = key + SEP
+        for name in (ARCHIVE, PARKED):
+            d = self._d(name)
+            try:
+                if any(e.name.startswith(prefix) for e in d.iterdir()):
+                    return True
+            except FileNotFoundError:
+                continue
+        return False
+
     def attempts_by_key(self, key: str) -> int:
         try:
             return int(self._attempts_path(key).read_text(encoding="utf-8"))

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -40,10 +40,16 @@ class DeliveryOutcome(str, Enum):
 
 
 class DrainStatus(str, Enum):
-    """Why a drain attempt ended, locally. NOT_CLAIMED means another worker
-    owns the item: no provider call was made, so nothing external is
-    ambiguous."""
+    """Why a drain attempt ended, locally. Neither non-ATTEMPTED status made
+    a provider call, so nothing external is ambiguous in either.
+
+    NOT_CLAIMED and TERMINAL are split because they differ in whether a later
+    pass can ever succeed: NOT_CLAIMED is contention (another worker owns it;
+    a reclaim recovers it), TERMINAL is the item's own final state. Collapsing
+    them makes a drainer retry a decided item forever.
+    """
     NOT_CLAIMED = "not_claimed"
+    TERMINAL = "terminal"
     ATTEMPTED = "attempted"
 
 
@@ -169,7 +175,24 @@ class ClaimBackend(Protocol):
         ...
 
     def claim(self, item_id: str, worker: str) -> Optional[ClaimToken]:
-        """Acquire exclusive local ownership, or None on a lost race."""
+        """Acquire exclusive local ownership, or None when it was not taken.
+
+        None does NOT mean "another worker owns it" — it also covers an item
+        that is already terminal, absent, or whose incarnation vanished. Ask
+        `is_terminal` to tell a decided item from a contended one.
+        """
+        ...
+
+    def is_terminal(self, item_id: str) -> bool:
+        """True when this item has reached its own final state (delivered or
+        parked) and no drain will ever claim it again.
+
+        Only meaningful after a failed `claim`, and read separately because a
+        terminal item and a contended one are indistinguishable from `claim`
+        alone. Terminal is absorbing except via the administrative requeue
+        path, which resets the attempt budget — so a `True` that goes stale
+        that way costs one extra pass, never a stuck item.
+        """
         ...
 
     # False = complete() accepts provider/destination and DROPS them.

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
@@ -86,8 +86,10 @@ class DeliveryCore:
         """Claim -> deliver -> classify -> complete, with retry accounting."""
         token = self.backend.claim(item_id, self.worker)
         if token is None:
-            # Another worker owns it. No provider call was made, so there is
-            # no external ambiguity to report — this is not an outcome.
+            # No provider call either way, so nothing external is ambiguous.
+            # Terminal is unclaimable forever; contention is not.
+            if self.backend.is_terminal(item_id):
+                return DrainResult(status=DrainStatus.TERMINAL)
             return DrainResult(status=DrainStatus.NOT_CLAIMED)
         key = idempotency_key(item_id)
         outcome, destination = self._attempt(item_id, payload, key)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2996,8 +2996,23 @@ def _delivery_core() -> DeliveryCore:
     return _DELIVERY_CORE
 
 
+def _quarantine_undelivered(rfile, tid: str, why: str) -> None:
+    """Move a result the outbox has finally refused into results/undelivered/,
+    the same quarantine the proactive path uses. Without this the file is
+    rescanned every pass and the refusal is invisible."""
+    try:
+        UNDELIVERABLE_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        rfile.rename(UNDELIVERABLE_RESULTS_DIR /
+                     f"{rfile.stem}-{int(time.time())}.txt")
+        _log(f"result {tid}: {why} — quarantined to "
+             f"{UNDELIVERABLE_RESULTS_DIR.name}/, it will NOT be re-sent")
+    except OSError as e:
+        _log(f"result {tid}: {why} but quarantine failed ({e}) — "
+             "leaving it in place")
+
+
 def _deliver_result_payload(tid: str, broker_tid: str, body: str,
-                            no_send: bool = False) -> bool:
+                            no_send: bool = False, result_file=None) -> bool:
     """One outbound result POST through the delivery core. True = the
     gateway confirmed (server lease closed; caller archives). False = not
     confirmed this pass; leave the result file for the next one."""
@@ -3010,6 +3025,16 @@ def _deliver_result_payload(tid: str, broker_tid: str, body: str,
     payload = json.dumps(doc).encode("utf-8")
     core.backend.publish(broker_tid, payload)   # False = already live: retry pass
     res = core.deliver_one(broker_tid, payload)
+    if res.status is DrainStatus.TERMINAL:
+        # The outbox has decided this item; no pass will ever claim it again,
+        # so retrying logs forever and hides the failure behind "will retry".
+        why = (f"outbox item is terminal after "
+               f"{core.backend.attempts(broker_tid)} attempt(s)")
+        if result_file is not None:
+            _quarantine_undelivered(result_file, tid, why)
+        else:
+            _log(f"result {tid}: {why} — not retrying")
+        return False
     if res.status is DrainStatus.NOT_CLAIMED:
         # A dead prior incarnation's claim; reclaim-TTL recovers it, and
         # with an idempotent provider nothing parks on ambiguity.
@@ -3150,7 +3175,8 @@ def _post_ready_results(inflight: set[str]) -> None:
         if _delivery is None:
             _log(f"delivery deferred for {tid} — alias ledger unreadable")
             continue
-        if not _deliver_result_payload(tid, _broker_tid(_delivery), out_body):
+        if not _deliver_result_payload(tid, _broker_tid(_delivery), out_body,
+                                       result_file=rfile):
             continue
         _archive_result(rfile, tid)
         inflight.discard(tid)

--- a/tests/ag2space-provider.test.py
+++ b/tests/ag2space-provider.test.py
@@ -183,7 +183,9 @@ def main() -> int:
         # still-scripted {"ok": True} is never consumed.
         res = core.deliver_one("task-X", ENVELOPE)
         check("at the ceiling the item is PARKED, not retried forever",
-              res.status is DrainStatus.NOT_CLAIMED)
+              res.status is DrainStatus.TERMINAL)
+        check("and the ceiling is not reported as contention",
+              res.status is not DrainStatus.NOT_CLAIMED)
         check("a parked item refuses re-publish (operator holds it)",
               core.backend.publish("task-X", ENVELOPE) is False)
 

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -331,8 +331,11 @@ class CorePolicy(unittest.TestCase):
         self.assertEqual(outbox._read_item(root, ITEM).get("status"), "PARKED",
                          "ambiguity parks for a human; it does not stay READY")
         second = core.deliver_one(ITEM, b"body")
-        self.assertIs(second.status, DrainStatus.NOT_CLAIMED,
+        self.assertIs(second.status, DrainStatus.TERMINAL,
                       "a parked item is not re-drained")
+        self.assertIsNot(second.status, DrainStatus.NOT_CLAIMED,
+                         "and it is not contention: NOT_CLAIMED invites the "
+                         "caller to retry an item no pass can ever claim")
         self.assertEqual(prov.effects, 1,
                          "exactly one user-visible delivery, not two")
 

--- a/tests/delivery-core-terminal-not-contended.test.py
+++ b/tests/delivery-core-terminal-not-contended.test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""A drained item that has reached its own terminal state must not be reported
+as contention.
+
+`claim()` returns None for four different reasons — absent, terminal, held by
+a live worker, incarnation vanished — and the core used to collapse all four
+into NOT_CLAIMED, whose contract said "another worker owns it". A caller that
+reads NOT_CLAIMED as transient then retries a parked item on every pass, which
+is unbounded and, worse, silent: the log says "will retry" about a delivery
+that has already been abandoned.
+
+The ordering matters and is what makes this hard to test by accident: the item
+parks CORRECTLY at MAX_ATTEMPTS, and the loop begins on the pass AFTER that.
+A test that only asserts "reaches PARKED within MAX_ATTEMPTS" passes on the
+broken code, because the defect starts once that assertion is already
+satisfied. Every case below therefore drains at least once MORE than the cap.
+
+Run: python3 tests/delivery-core-terminal-not-contended.test.py
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_PKG = _REPO / "packages" / "ag2-sparrow"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from ag2_sparrow.delivery_core import (  # noqa: E402
+    DeliveryCore, DesignAClaimBackend, DesignCClaimBackend, ProviderRefused,
+    RetryPolicy)
+from ag2_sparrow.delivery_core.contract import (  # noqa: E402
+    DrainStatus, ProviderCapabilities)
+
+ITEM = "task-stuck-1"
+PAYLOAD = b'{"id": "task-stuck-1", "body": "hi"}'
+CAP = 5
+
+
+class _AlwaysRefuses:
+    """Provider that never delivers — drives the item to the attempt cap."""
+    capabilities = ProviderCapabilities()
+
+    def __init__(self):
+        self.calls = 0
+
+    def deliver(self, item_id, payload, idempotency_key):
+        self.calls += 1
+        raise ProviderRefused("destination is gone")
+
+    def reconcile(self, attempt):
+        return None
+
+
+def _core(backend, provider):
+    return DeliveryCore(backend, provider,
+                        policy=RetryPolicy(max_attempts=CAP),
+                        worker="test-drain")
+
+
+def _drain_to_cap(core, provider):
+    """Exhaust the budget exactly as production does, and prove we got there
+    by real provider calls rather than by assuming the loop count."""
+    for _ in range(CAP):
+        core.deliver_one(ITEM, PAYLOAD)
+    assert provider.calls == CAP, f"expected {CAP} provider calls, got {provider.calls}"
+
+
+class TerminalIsNotContention(unittest.TestCase):
+
+    def _backend_a(self, td):
+        b = DesignAClaimBackend(Path(td) / "outbox")
+        b.publish(ITEM, PAYLOAD)
+        return b
+
+    def test_drain_after_parking_reports_TERMINAL_not_NOT_CLAIMED(self):
+        """The regression. This is the pass the old code looped on forever."""
+        with tempfile.TemporaryDirectory() as td:
+            b, p = self._backend_a(td), _AlwaysRefuses()
+            core = _core(b, p)
+            _drain_to_cap(core, p)
+            self.assertTrue(b.is_terminal(ITEM),
+                            "precondition: the item should be parked at the cap")
+
+            res = core.deliver_one(ITEM, PAYLOAD)   # the pass AFTER parking
+
+            self.assertIs(res.status, DrainStatus.TERMINAL)
+            self.assertIsNot(res.status, DrainStatus.NOT_CLAIMED)
+            self.assertIsNone(res.outcome, "no provider call was made")
+            self.assertEqual(p.calls, CAP,
+                             "a terminal item must not reach the provider again")
+
+    def test_terminal_is_stable_across_further_passes(self):
+        """Unbounded-loop guard: repeated drains stay TERMINAL and stay silent
+        toward the provider, so a caller can stop on the first one."""
+        with tempfile.TemporaryDirectory() as td:
+            b, p = self._backend_a(td), _AlwaysRefuses()
+            core = _core(b, p)
+            _drain_to_cap(core, p)
+            for i in range(4):
+                self.assertIs(core.deliver_one(ITEM, PAYLOAD).status,
+                              DrainStatus.TERMINAL, f"pass {i} after parking")
+            self.assertEqual(p.calls, CAP)
+
+    def test_live_contention_still_reports_NOT_CLAIMED(self):
+        """The control. Terminal must not swallow the transient case it was
+        split from, or this trades an infinite retry for a dropped delivery."""
+        with tempfile.TemporaryDirectory() as td:
+            b = self._backend_a(td)
+            held = b.claim(ITEM, "someone-else")
+            self.assertIsNotNone(held, "precondition: the claim should be taken")
+            self.assertFalse(b.is_terminal(ITEM),
+                             "a claimed-but-live item is not terminal")
+
+            res = _core(b, _AlwaysRefuses()).deliver_one(ITEM, PAYLOAD)
+
+            self.assertIs(res.status, DrainStatus.NOT_CLAIMED)
+
+    def test_absent_item_is_not_terminal(self):
+        """None-from-claim also covers 'never published'. That is not a
+        decided item, so it must not be quarantined as one."""
+        with tempfile.TemporaryDirectory() as td:
+            b = DesignAClaimBackend(Path(td) / "outbox")
+            self.assertFalse(b.is_terminal("never-published"))
+            self.assertIs(
+                _core(b, _AlwaysRefuses()).deliver_one("never-published", PAYLOAD).status,
+                DrainStatus.NOT_CLAIMED)
+
+    def test_backend_c_reports_terminal_by_location(self):
+        """C records terminality as a directory move, not a status field, so
+        the parity has to be asserted rather than assumed from A."""
+        with tempfile.TemporaryDirectory() as td:
+            b = DesignCClaimBackend(Path(td) / "outbox-c", activate=True)
+            b.publish(ITEM, PAYLOAD)
+            p = _AlwaysRefuses()
+            core = _core(b, p)
+            _drain_to_cap(core, p)
+            self.assertTrue(b.is_terminal(ITEM))
+            self.assertIs(core.deliver_one(ITEM, PAYLOAD).status,
+                          DrainStatus.TERMINAL)
+            self.assertFalse(b.is_terminal("some-other-item"),
+                             "prefix match must not fire on an unrelated key")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #3453.

## The defect, and a correction to the issue's diagnosis

#3453 says *"MAX_ATTEMPTS is reached but never parks."* Measured on a live host today, **the item does park** — and parking is what starts the loop, so parking is the cause rather than the missing cure:

```
19:01:12Z  queued task-2f5e2439ed797502e4
19:06:50Z  result POST not confirmed (not_delivered) — will retry   <- attempt 1
19:06:51Z  ... 2      19:06:52Z ... 3      19:06:54Z ... 4
19:06:55Z  result POST not confirmed (not_delivered) — will retry   <- 5, complete() parks here
19:06:56Z  outbox item not claimable this pass (attempts=5) — will retry   <- loop BEGINS
   ... ~119 lines/min, unbounded (13M log here; 18M and 48,777 lines in the issue)
```

`ClaimBackend.claim()` returns `None` for **four** different reasons:

1. the item file does not exist,
2. **status is TERMINAL (DELIVERED or PARKED)** — permanent,
3. another worker holds a live claim — transient,
4. the incarnation vanished mid-claim.

`deliver_one` collapsed all four into `DrainStatus.NOT_CLAIMED`, whose docstring read *"another worker owns the item"* — only (3). The bridge's handler is written for (3) alone, so (2) is reported as `will retry` forever. The log line is not just noisy, it is **false**: nothing will retry, and the delivery has already been abandoned.

## The change

- `DrainStatus.TERMINAL`, split from `NOT_CLAIMED`. Both still mean "no provider call was made", so `DrainResult`'s outcome-iff-ATTEMPTED invariant is unchanged (asserted).
- `ClaimBackend.is_terminal(item_id)`, answered by each backend in its own terms — A reads the status field, C reads location (`ARCHIVE`/`PARKED`), because C has no status field. Consulted only after a failed claim.
- The gateway bridge quarantines a terminal result into `results/undelivered/` — **the quarantine its own proactive path already uses** (`_resolve_send_failure`, same file) — so the refusal becomes visible instead of silent. `_reconcile_abandoned` then clears the ledger id, since no result file remains.

On staleness: terminal is absorbing except via the administrative `requeue_item`, which resets the attempt budget to 0 and force-releases. So a `True` that goes stale that way costs one extra pass, never a stuck item.

## Evidence

**The test fails without the fix.** Removing just the two-line `is_terminal` branch from `deliver_one`:

```
$ python3 tests/delivery-core-terminal-not-contended.test.py     # fix removed
Ran 5 tests in 0.019s
FAILED (failures=3)

$ python3 tests/delivery-core-terminal-not-contended.test.py     # fix restored
Ran 5 tests in 0.019s
OK
```

**The regression test in the issue would pass on the buggy code.** #3453 proposes *"an item whose claim never succeeds must reach a terminal parked state within MAX_ATTEMPTS"*. Run against the mutated (broken) build:

```
"reaches a terminal parked state within MAX_ATTEMPTS" -> True
=> passes on the buggy code
```

It goes green because the item *does* reach PARKED — the loop starts on the pass **after** that assertion is satisfied. Every case in the new suite therefore drains at least once more than the cap.

**Against this host's real outbox records** (read-only, `is_terminal` only — `deliver_one` would mutate live state):

```
.outbox                      DELIVERED -> is_terminal=True: 312
                             PARKED    -> is_terminal=True: 2     <- the two looping right now
.outbox-ag2space-proactive   DELIVERED -> is_terminal=True: 50
.outbox-discord-proactive    DELIVERED -> is_terminal=True: 89
CONTROL, id that does not exist: False
```

**Suites at HEAD** (all previously green, all still green):

```
delivery-core-contract.test.py                             OK
delivery-core-enforcement.test.py                          OK
delivery-core-crash-between-terminal-and-release.test.py   OK
outbox-adapter-contract.test.py                            PASS — the adapter seam holds
sparrow-outbox-claim-protocol.test.py                      PASS — the claim protocol holds
outbox-recovery-paths.test.py                              PASS
outbox-error-paths.test.py                                 PASS
outbox-claim-fault-injection.test.py                       0 failure(s)
delivery-core-terminal-not-contended.test.py               OK
review-checks.sh --diff                                    PASS (rc=0 captured, not piped)
```

## One existing assertion changed — please look at this specifically

`delivery-core-contract.test.py` asserted `NOT_CLAIMED` under the message **"a parked item is not re-drained"**. That message is what `TERMINAL` now says; `NOT_CLAIMED` said the opposite of it. Updated to `TERMINAL` plus an explicit `assertIsNot(NOT_CLAIMED)`.

Its load-bearing assertion — `prov.effects == 1`, exactly one user-visible delivery — is untouched and still passes.

Worth noting that test parks via **ambiguity** (OUTCOME_UNKNOWN with reconcile refused), not attempt exhaustion. So this is a second, independent path into the same infinite retry, and the existing test had pinned the wrong behaviour as expected.

## What I did NOT verify — this touches a live path

Per `CONTRIBUTING.md`, a bridge/delivery-loop change wants a real post-restart round trip, and **I do not have one**. The `delivery_core` half is harness-proven and checked against real records above, but the bridge half — the `results/undelivered/` quarantine — is **not live-verified**: confirming it needs a core restart, which is the owner's call, not mine.

Concretely unverified: that a terminal result is quarantined once and the drain loop then goes quiet on a running bridge. The two parked items on this host are a ready-made subject for that check if someone wants to run it. I would rather name the gap than let harness-green stand in for it.

---

## Update at `c1927db5` — CI found a second symptom-pinning test, and it is the best evidence here

`tests/ag2space-provider.test.py` failed. It contains this:

```python
# Repeated refusals PARK at the ceiling. A retry that never terminates is a
# duplicate generator (#2959/#2960), so the cap is not optional here.
...
check("at the ceiling the item is PARKED, not retried forever",
      res.status is DrainStatus.NOT_CLAIMED)
```

**The label and the assertion say opposite things.** `NOT_CLAIMED` is precisely the status that produces the retry-forever the check is named against. A reader — or a reviewer — sees the label; CI checks the assertion.

So a test named for this exact invariant, sitting under a comment that cites the duplicate-generator issues, was green for the entire time the bug ran in production. It could not have caught it: it asserted the bug.

That makes **two** existing tests that pinned the symptom value under a correct label (`delivery-core-contract` was the first, in the parent commit). Both now assert `TERMINAL` plus an explicit `assertIsNot(NOT_CLAIMED)`, and in both cases the surrounding load-bearing checks — attempt accounting, provider not reached after the cap, re-publish refused, exactly-one-delivery — are untouched and still pass.

This is also the honest answer to "why did this survive so long": the coverage existed and read correctly. Only the assertion disagreed with it.

```
ag2space-provider.test.py                      PASS
delivery-core-contract.test.py                 OK
delivery-core-terminal-not-contended.test.py   OK
delivery-core-enforcement.test.py              OK
outbox-adapter-contract.test.py                PASS — the adapter seam holds
review-checks.sh --diff                        PASS (rc=0 captured)
```
