### PR TITLE
fix: the two one-line CI failures this base had been hiding

### DIFF
--- a/.github/workflows/bundle-smoke.yml
+++ b/.github/workflows/bundle-smoke.yml
@@ -5,7 +5,6 @@ name: bundle-smoke
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
     paths:
       - 'src/**'
       - 'skills/phone-conversation/scripts/conversation-server.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -13,7 +13,6 @@ name: Coverage Gate
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
 
 jobs:
   coverage-gate:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -21,7 +21,6 @@ name: eslint
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-agents-md-sync.yml
+++ b/.github/workflows/lint-agents-md-sync.yml
@@ -19,7 +19,6 @@ name: lint-agents-md-sync
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-claude-home-path.yml
+++ b/.github/workflows/lint-claude-home-path.yml
@@ -14,7 +14,6 @@ name: lint-claude-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-hermetic-bridge-tests.yml
+++ b/.github/workflows/lint-hermetic-bridge-tests.yml
@@ -16,7 +16,6 @@ name: lint-hermetic-bridge-tests
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-host-label.yml
+++ b/.github/workflows/lint-host-label.yml
@@ -17,7 +17,6 @@ name: lint-host-label
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-hotkey-assertions.yml
+++ b/.github/workflows/lint-hotkey-assertions.yml
@@ -14,7 +14,6 @@ name: lint-hotkey-assertions
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-src-map.yml
+++ b/.github/workflows/lint-src-map.yml
@@ -13,7 +13,6 @@ name: lint-src-map
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-sutando-home-path.yml
+++ b/.github/workflows/lint-sutando-home-path.yml
@@ -15,7 +15,6 @@ name: lint-sutando-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-workspace-resolution.yml
+++ b/.github/workflows/lint-workspace-resolution.yml
@@ -15,7 +15,6 @@ name: lint-workspace-resolution
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,6 @@ name: ruff
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,7 +25,6 @@ name: shellcheck
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/workspace-leak-check.yml
+++ b/.github/workflows/workspace-leak-check.yml
@@ -18,7 +18,6 @@ name: workspace-leak-check
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -157,6 +157,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`task-emit.sh`** — TASK_FILE emitters — sourceable so a test can invoke them in isolation.
 - **`task_archive.py`** — Task-file locator for archive calls (#933).
 - **`task_body_guard.py`** — Confine untrusted user message content before embedding it in a task file.
+- **`task_body_guard.ts`** — confineUserContent — the ONE TypeScript implementation of the task-body injection guard.
 - **`task_envelope.py`** — Task-envelope authentication: an HMAC stamp that makes access_tier a verified claim instead of an honor-system header.
 - **`task_envelope.ts`** — task_envelope.ts — TypeScript mirror of src/task_envelope.py's stamping half, for the TS task writers (voice delegation seam, context-drop, wearable).
 - **`task_envelope_census.py`** — Soak census for HMAC task envelopes: the read-only measurement behind the "writer census reaches zero" gate.

--- a/src/runtime-cli/tui.py
+++ b/src/runtime-cli/tui.py
@@ -113,7 +113,7 @@ def instance_view(manifest: dict) -> dict:
 def render_view(view: dict) -> str:
     mark = {True: "verified", False: "MISMATCH", None: "-"}[view.get("identityVerified")]
     lines = [
-        f"Sutando Instance",
+        "Sutando Instance",
         f"  ID:         {view['agentId']}",
         f"  Existence:  {view['existence']}",
         f"  Server:     {view['server']}",


### PR DESCRIPTION
Two one-line defects on `feat/sutando-server`, both invisible until this week because the workflows that catch them were not running on this base.

## What and why

```
ruff over Python sources        src/runtime-cli/tui.py:116  F541 f-string without placeholders
refuse docs/src-map.md stale    gen-src-map reports a diff on the base itself
```

Both verified against `origin/feat/sutando-server` directly, and neither appears in the diff of the PR whose board exposed them.

## How they were hidden

A `pull_request` run reads the workflow from the head but matches `branches:` against the **base**. This base carries `branches: [main, staging-interaction-planes]` in its workflow copies, so they reject their own base. `origin/main` has already removed that filter from all 22 workflows; these heads inherited stale copies.

Removing it on one PR off this base took its board from **2 checks to 18, and four failed**.

## Before / after

```
$ git worktree add --detach wt origin/feat/sutando-server && cd wt
$ python3 scripts/gen-src-map.py && git diff --numstat docs/src-map.md
1  0  docs/src-map.md                      <- stale on the base

# at this branch, after the commit:
$ python3 scripts/gen-src-map.py && git status --porcelain docs/src-map.md
                                          <- clean, so the check passes
```

The `ruff` fix is a literal with no placeholders losing its `f` prefix. No behaviour change.

## What this deliberately does NOT fix

`eslint over first-party TS + JS` is the third of the four. It reports **259 problems on this base, 32 of them errors**, and they sit in exactly two files:

```
23  src/voice-host.ts
 9  src/runtime-api/scp-voice.js
by rule: no-explicit-any 20 · no-unused-vars 5 · no-undef 4 · no-useless-assignment 2 · prefer-const 1
```

Twenty are `no-explicit-any` on a live voice path. Typing those is judgment about the session API, not a sweep, and fixing only the twelve mechanical ones leaves the check red anyway. It belongs in its own change with its own review.

The fourth, `docs-audit: docs/scp-v0.md unindexed`, is already #3490's.