### PR TITLE
fix(eslint): scp-voice.js lints clean — browser globals and ignored catches

### DIFF
--- a/.github/workflows/bundle-smoke.yml
+++ b/.github/workflows/bundle-smoke.yml
@@ -5,7 +5,6 @@ name: bundle-smoke
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
     paths:
       - 'src/**'
       - 'skills/phone-conversation/scripts/conversation-server.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -13,7 +13,6 @@ name: Coverage Gate
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
 
 jobs:
   coverage-gate:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -21,7 +21,6 @@ name: eslint
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-agents-md-sync.yml
+++ b/.github/workflows/lint-agents-md-sync.yml
@@ -19,7 +19,6 @@ name: lint-agents-md-sync
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-claude-home-path.yml
+++ b/.github/workflows/lint-claude-home-path.yml
@@ -14,7 +14,6 @@ name: lint-claude-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-hermetic-bridge-tests.yml
+++ b/.github/workflows/lint-hermetic-bridge-tests.yml
@@ -16,7 +16,6 @@ name: lint-hermetic-bridge-tests
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-host-label.yml
+++ b/.github/workflows/lint-host-label.yml
@@ -17,7 +17,6 @@ name: lint-host-label
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-hotkey-assertions.yml
+++ b/.github/workflows/lint-hotkey-assertions.yml
@@ -14,7 +14,6 @@ name: lint-hotkey-assertions
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-src-map.yml
+++ b/.github/workflows/lint-src-map.yml
@@ -13,7 +13,6 @@ name: lint-src-map
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/lint-sutando-home-path.yml
+++ b/.github/workflows/lint-sutando-home-path.yml
@@ -15,7 +15,6 @@ name: lint-sutando-home-path
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/lint-workspace-resolution.yml
+++ b/.github/workflows/lint-workspace-resolution.yml
@@ -15,7 +15,6 @@ name: lint-workspace-resolution
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,6 @@ name: ruff
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,7 +25,6 @@ name: shellcheck
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 

--- a/.github/workflows/workspace-leak-check.yml
+++ b/.github/workflows/workspace-leak-check.yml
@@ -18,7 +18,6 @@ name: workspace-leak-check
 
 on:
   pull_request:
-    branches: [main, staging-workspace-revamp]
   push:
     branches: [main, staging-workspace-revamp]
 

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -157,6 +157,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`task-emit.sh`** — TASK_FILE emitters — sourceable so a test can invoke them in isolation.
 - **`task_archive.py`** — Task-file locator for archive calls (#933).
 - **`task_body_guard.py`** — Confine untrusted user message content before embedding it in a task file.
+- **`task_body_guard.ts`** — confineUserContent — the ONE TypeScript implementation of the task-body injection guard.
 - **`task_envelope.py`** — Task-envelope authentication: an HMAC stamp that makes access_tier a verified claim instead of an honor-system header.
 - **`task_envelope.ts`** — task_envelope.ts — TypeScript mirror of src/task_envelope.py's stamping half, for the TS task writers (voice delegation seam, context-drop, wearable).
 - **`task_envelope_census.py`** — Soak census for HMAC task envelopes: the read-only measurement behind the "writer census reaches zero" gate.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -124,6 +124,12 @@ export default tseslint.config(
     files: ['skills/overlay-apps/app/stats-renderer.js', 'skills/overlay-apps/app/stats.js'],
     languageOptions: { sourceType: 'script', globals: { ...globals.browser } },
   },
+  // The SCP voice client ships to a web surface, so `window` and the audio
+  // APIs are its runtime — but it is an ES module, so no sourceType override.
+  {
+    files: ['src/runtime-api/scp-voice.js'],
+    languageOptions: { globals: { ...globals.browser } },
+  },
   // --- no-explicit-any ratchet allowlist --------------------------------------
   // THIS LIST ONLY SHRINKS. It is the set of files that already contained `any`
   // when the rule was promoted to an error; for them the rule stays a warning so

--- a/src/runtime-api/scp-voice.js
+++ b/src/runtime-api/scp-voice.js
@@ -54,7 +54,7 @@ export class ScpVoice {
 	}
 
 	_flush() {
-		for (const s of this.sources.splice(0)) { try { s.stop(); } catch (e) { /* */ } }
+		for (const s of this.sources.splice(0)) { try { s.stop(); } catch (_e) { /* */ } }
 		this.playCursor = 0;
 	}
 
@@ -120,7 +120,7 @@ export class ScpVoice {
 			}
 			return;
 		}
-		let m; try { m = JSON.parse(ev.data); } catch (e) { return; }
+		let m; try { m = JSON.parse(ev.data); } catch (_e) { return; }
 		if (m.id && this.pending.has(m.id)) {
 			const p = this.pending.get(m.id); this.pending.delete(m.id);
 			m.error ? p.rej(new Error(m.error.message || 'error')) : p.res(m.result);
@@ -138,13 +138,13 @@ export class ScpVoice {
 		try {
 			this.proc?.disconnect(); this.srcNode?.disconnect();
 			this.stream?.getTracks().forEach((t) => t.stop());
-		} catch (e) { /* */ }
+		} catch (_e) { /* */ }
 		this.proc = this.srcNode = this.stream = null;
 		if (this.sid != null && this.ws?.readyState === 1) {
-			try { await this._rpc('voice.close', { streamId: this.sid }); } catch (e) { /* */ }
+			try { await this._rpc('voice.close', { streamId: this.sid }); } catch (_e) { /* */ }
 		}
 		this.sid = null;
-		try { this.ws?.close(); } catch (e) { /* */ }
+		try { this.ws?.close(); } catch (_e) { /* */ }
 		this.ws = null;
 		this.opts.onState?.('');
 	}


### PR DESCRIPTION
Nine of this base's 32 `eslint` errors sat in one file, and none of them were about the code being wrong. That file now lints clean.

## The nine

**Four `no-undef` on `window`.** `scp-voice.js` is a browser client — its own header calls it a *"drop-in toggle-live voice client for ANY web surface"* and it publishes `window.ScpVoice` — but it was being linted against Node globals. Declared browser globals for it, the same mechanism the renderer block already uses for `stats-renderer.js`.

Deliberately **not** with that block's `sourceType: 'script'`: this file is an ES module (`export class ScpVoice`), and the override would break parsing. The `window` accesses are also already guarded where it matters — `if (typeof window !== 'undefined') window.ScpVoice = ScpVoice`.

**Five `no-unused-vars` on ignored `catch (e)`.** Renamed to `_e`, which is exactly what the config's own `caughtErrorsIgnorePattern: '^_'` asks for. No control flow moved; every one was already an empty or early-return catch.

## Before / after

```
src/runtime-api/scp-voice.js    9 errors  ->  0 errors, 0 warnings
repo-wide                      32 errors  ->  23, now all in a single file
```

## Why the workflow change is here too

This PR also carries the `pull_request` branch-filter removal. Without it `eslint` does not run on this base at all, and a fix for a check that is not running is an assertion rather than a verification. Same one-line-per-workflow removal #3316, #3442 and #3513 carry; `origin/main` filters none of its 22.

## What this deliberately leaves

The 23 remaining errors are all in `src/voice-host.ts`, 20 of them `no-explicit-any`. **They are not lazy annotations.** They are casts reaching methods the `VoiceSession` type does not declare:

```ts
const s = session as any;
(session as any).notifyBackground(...)
const origTransportClose = (session as any).handleTransportClose?.bind(session);
```

Typing those means writing down what we believe that third-party surface to be, on a live voice path. That is a design decision deserving its own change and its own review, and I would rather it be made deliberately than swept into a lint pass. So `eslint` stays red on this base until that lands — this PR shrinks it to one file and one decision.