### PR TITLE
fix(collab-lookup): resolve reviewers from reviewer-stands.json by github field

### DIFF
--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -21,10 +21,8 @@ def store() -> pathlib.Path:
     return pathlib.Path(ws) / "data" / "collaboration-intelligence"
 
 def load(d):
-    # Either store may exist alone: quick-lookup.yaml (the bounded hot set) or
-    # reviewer-stands.json (the reviewer roster). A host with only the roster
-    # used to crash here, so every session hand-rolled its own lookup — and a
-    # hand-rolled get(github_login) misses a roster keyed by short name.
+    # Either store may exist alone; a host with only reviewer-stands.json
+    # must not crash here or sessions fall back to hand-rolled lookups.
     q, ents = {}, []
     yp = d / "quick-lookup.yaml"
     if yp.exists():

--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -21,13 +21,46 @@ def store() -> pathlib.Path:
     return pathlib.Path(ws) / "data" / "collaboration-intelligence"
 
 def load(d):
-    import yaml
-    q = yaml.safe_load((d / "quick-lookup.yaml").read_text())["quick_lookup"]
-    ents = []
-    p = d / "entities.yaml"
-    if p.exists():
-        ents = yaml.safe_load(p.read_text()).get("entities") or []
+    # Either store may exist alone: quick-lookup.yaml (the bounded hot set) or
+    # reviewer-stands.json (the reviewer roster). A host with only the roster
+    # used to crash here, so every session hand-rolled its own lookup — and a
+    # hand-rolled get(github_login) misses a roster keyed by short name.
+    q, ents = {}, []
+    yp = d / "quick-lookup.yaml"
+    if yp.exists():
+        import yaml
+        q = yaml.safe_load(yp.read_text())["quick_lookup"]
+        ep = d / "entities.yaml"
+        if ep.exists():
+            ents = yaml.safe_load(ep.read_text()).get("entities") or []
     return q, ents
+
+
+def load_roster(d):
+    """reviewer-stands.json rows, normalised to the quick-lookup row shape.
+
+    The roster is keyed by short name with the GitHub login in the `github`
+    FIELD; a key-equality lookup queries the wrong axis and reads a mapped
+    reviewer as absent (measured twice: 2026-08-27, 2026-08-28 — both times
+    `get("john-the-dev")` missed the entry keyed `rui`).
+    """
+    import json
+    p = d / "reviewer-stands.json"
+    if not p.exists():
+        return []
+    rows = []
+    for key, r in json.loads(p.read_text()).items():
+        if not isinstance(r, dict):
+            continue
+        rows.append({
+            "entity_id": key,
+            "agent_mxid": r.get("stand") or "",
+            "github": r.get("github") or "",
+            "human": r.get("human") or "",
+            "allowlisted": r.get("allowlisted"),
+            "one_line": f"github={r.get('github','')} human={r.get('human','')} stand={r.get('stand','')}",
+        })
+    return rows
 
 def match(rows, needle, ents=()):
     n = needle.lower().lstrip("@")
@@ -40,6 +73,8 @@ def match(rows, needle, ents=()):
     strong = [r for r in rows
               if n in str(r.get("entity_id", "")).lower()
               or n in str(r.get("agent_mxid", "")).lower()
+              or n == str(r.get("github", "")).lower()
+              or n in str(r.get("human", "")).lower()
               or r.get("entity_id") in by_ident]
     if strong:
         return strong
@@ -62,7 +97,11 @@ def main():
         print(f"MAP MISSING at {d}\n  -> persistence unavailable. Send anyway; say the identity is unverified.")
         return 0
     q, ents = load(d)
-    rows = q.get("recent_entities") or []
+    rows = (q.get("recent_entities") or []) + load_roster(d)
+    if not rows:
+        print(f"MAP EMPTY at {d} (no quick-lookup.yaml rows, no reviewer-stands.json)\n"
+              "  -> persistence unavailable. Send anyway; say the identity is unverified.")
+        return 0
 
     up = str(q.get("updated_at", "?"))
     try:

--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -24,8 +24,7 @@ def load(d):
     # Either store may exist alone; a host with only reviewer-stands.json
     # must not crash here or sessions fall back to hand-rolled lookups.
     q, ents = {}, []
-    # Each store is loaded on its OWN existence check — either may exist alone,
-    # and shapes vary per host: wrapped {quick_lookup:}, flat {people:}, MALFORMED.
+    # Each store loads on its OWN existence check — either may exist alone.
     yp = d / "quick-lookup.yaml"
     if yp.exists():
         import yaml

--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -24,11 +24,11 @@ def load(d):
     # Either store may exist alone; a host with only reviewer-stands.json
     # must not crash here or sessions fall back to hand-rolled lookups.
     q, ents = {}, []
+    # Each store is loaded on its OWN existence check — either may exist alone,
+    # and shapes vary per host: wrapped {quick_lookup:}, flat {people:}, MALFORMED.
     yp = d / "quick-lookup.yaml"
     if yp.exists():
         import yaml
-        # Three live store states: wrapped {quick_lookup:...}, flat {people:...},
-        # and MALFORMED (hand-edited/synced yaml) — degrade, never starve the roster.
         try:
             raw = yaml.safe_load(yp.read_text()) or {}
         except Exception as e:
@@ -36,12 +36,13 @@ def load(d):
                   file=sys.stderr)
             raw = {}
         q = raw.get("quick_lookup") or raw if isinstance(raw, dict) else {}
-        ep = d / "entities.yaml"
-        if ep.exists():
-            try:
-                ents = yaml.safe_load(ep.read_text()).get("entities") or []
-            except Exception:
-                ents = []
+    ep = d / "entities.yaml"
+    if ep.exists():
+        import yaml
+        try:
+            ents = yaml.safe_load(ep.read_text()).get("entities") or []
+        except Exception:
+            ents = []
     return q, ents
 
 

--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -27,10 +27,21 @@ def load(d):
     yp = d / "quick-lookup.yaml"
     if yp.exists():
         import yaml
-        q = yaml.safe_load(yp.read_text())["quick_lookup"]
+        # Three live store states: wrapped {quick_lookup:...}, flat {people:...},
+        # and MALFORMED (hand-edited/synced yaml) — degrade, never starve the roster.
+        try:
+            raw = yaml.safe_load(yp.read_text()) or {}
+        except Exception as e:
+            print(f"warning: {yp} unparseable ({type(e).__name__}) — using roster only",
+                  file=sys.stderr)
+            raw = {}
+        q = raw.get("quick_lookup") or raw if isinstance(raw, dict) else {}
         ep = d / "entities.yaml"
         if ep.exists():
-            ents = yaml.safe_load(ep.read_text()).get("entities") or []
+            try:
+                ents = yaml.safe_load(ep.read_text()).get("entities") or []
+            except Exception:
+                ents = []
     return q, ents
 
 
@@ -70,13 +81,18 @@ def match(rows, needle, ents=()):
     # other people and repos, so a hit there is about the subject, not the person.
     strong = [r for r in rows
               if n in str(r.get("entity_id", "")).lower()
+              or n in str(r.get("id", "")).lower()
               or n in str(r.get("agent_mxid", "")).lower()
               or n == str(r.get("github", "")).lower()
               or n in str(r.get("human", "")).lower()
               or r.get("entity_id") in by_ident]
     if strong:
-        return strong
-    return [r for r in rows if n in str(r.get("one_line", "")).lower()]
+        # Multi-host merges leave one person under several keys; a field-poor
+        # duplicate must not shadow the row that carries an addressable Stand.
+        return sorted(strong, key=lambda r: not str(r.get("agent_mxid") or "").strip())
+    return [r for r in rows
+            if n in str(r.get("one_line", "")).lower()
+            or n in str(r.get("who", "")).lower()]
 
 def ids_for(ents, entity_id):
     for e in ents:
@@ -95,7 +111,7 @@ def main():
         print(f"MAP MISSING at {d}\n  -> persistence unavailable. Send anyway; say the identity is unverified.")
         return 0
     q, ents = load(d)
-    rows = (q.get("recent_entities") or []) + load_roster(d)
+    rows = (q.get("recent_entities") or q.get("people") or []) + load_roster(d)
     if not rows:
         print(f"MAP EMPTY at {d} (no quick-lookup.yaml rows, no reviewer-stands.json)\n"
               "  -> persistence unavailable. Send anyway; say the identity is unverified.")

--- a/tests/collab-lookup-store-shapes.test.py
+++ b/tests/collab-lookup-store-shapes.test.py
@@ -87,9 +87,8 @@ class StoreShapes(unittest.TestCase):
             self.assertEqual(hits[0]["agent_mxid"], "@sutando-rui:ag2.space")
 
     def test_entities_yaml_alone_loads_without_quick_lookup(self):
-        # core-3's control: a host with entities.yaml and NO quick-lookup.yaml
-        # must still load entities — the read must not nest inside the other
-        # store's existence check.
+        # core-3's control: entities.yaml with NO quick-lookup.yaml must still
+        # load — the read must not nest inside the other store's existence check.
         with tempfile.TemporaryDirectory() as t:
             d = store(t)                             # writes NEITHER yaml
             (d / "entities.yaml").write_text(

--- a/tests/collab-lookup-store-shapes.test.py
+++ b/tests/collab-lookup-store-shapes.test.py
@@ -86,6 +86,18 @@ class StoreShapes(unittest.TestCase):
             self.assertEqual(len(hits), 2)
             self.assertEqual(hits[0]["agent_mxid"], "@sutando-rui:ag2.space")
 
+    def test_entities_yaml_alone_loads_without_quick_lookup(self):
+        # core-3's control: a host with entities.yaml and NO quick-lookup.yaml
+        # must still load entities — the read must not nest inside the other
+        # store's existence check.
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t)                             # writes NEITHER yaml
+            (d / "entities.yaml").write_text(
+                "entities:\n  - entity_id: solo\n    identities:\n"
+                "      - provider: github\n        provider_id: solo-login\n")
+            q, ents = lk.load(d)
+            self.assertEqual(len(ents), 1)
+
     def test_malformed_entities_yaml_degrades_to_empty(self):
         with tempfile.TemporaryDirectory() as t:
             d = store(t, "people: []\n")

--- a/tests/collab-lookup-store-shapes.test.py
+++ b/tests/collab-lookup-store-shapes.test.py
@@ -86,6 +86,61 @@ class StoreShapes(unittest.TestCase):
             self.assertEqual(len(hits), 2)
             self.assertEqual(hits[0]["agent_mxid"], "@sutando-rui:ag2.space")
 
+    def test_malformed_entities_yaml_degrades_to_empty(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, "people: []\n")
+            (d / "entities.yaml").write_text("entities:\n    broken [unclosed\n    no: colon here\n")
+            q, ents = lk.load(d)
+            self.assertEqual(ents, [])
+
+    def test_roster_absent_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, "people: []\n")
+            self.assertEqual(lk.load_roster(d), [])
+
+    def test_roster_non_dict_values_skipped(self):
+        with tempfile.TemporaryDirectory() as t:
+            r = dict(ROSTER)
+            r["_merge_log"] = ["a merge event"]     # real shape: sync writes a list here
+            d = store(t, roster=r)
+            rows = lk.load_roster(d)
+            self.assertEqual([x["entity_id"] for x in rows], ["rui"])
+
+    def test_main_empty_store_prints_map_empty(self):
+        import contextlib
+        import io
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t) / "data" / "collaboration-intelligence"
+            d.mkdir(parents=True)                    # store dir exists, holds nothing
+            orig_store, orig_argv = lk.store, sys.argv
+            out = io.StringIO()
+            try:
+                lk.store = lambda: d
+                sys.argv = ["lookup.py", "anyone"]
+                with contextlib.redirect_stdout(out):
+                    rc = lk.main()
+            finally:
+                lk.store, sys.argv = orig_store, orig_argv
+            self.assertEqual(rc, 0)
+            self.assertIn("MAP EMPTY", out.getvalue())
+
+    def test_main_resolves_through_full_path(self):
+        import contextlib
+        import io
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, roster=ROSTER)
+            orig_store, orig_argv = lk.store, sys.argv
+            out = io.StringIO()
+            try:
+                lk.store = lambda: d
+                sys.argv = ["lookup.py", "john-the-dev"]
+                with contextlib.redirect_stdout(out):
+                    rc = lk.main()
+            finally:
+                lk.store, sys.argv = orig_store, orig_argv
+            self.assertEqual(rc, 0)
+            self.assertIn("@sutando-rui:ag2.space", out.getvalue())
+
     def test_no_match_returns_empty_not_invented(self):
         with tempfile.TemporaryDirectory() as t:
             d = store(t, roster=ROSTER)

--- a/tests/collab-lookup-store-shapes.test.py
+++ b/tests/collab-lookup-store-shapes.test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""lookup.py must resolve against every live store shape (#3517 review).
+
+Every case here is a store that existed on a real host on 2026-08-28 and
+broke a prior revision: wrapped {quick_lookup:}, flat {people:}, MALFORMED
+yaml, roster-only, and a multi-host merge leaving one person under two keys.
+"""
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "lookup", Path(__file__).resolve().parents[1]
+    / "skills" / "collaboration-intelligence" / "scripts" / "lookup.py")
+lk = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(lk)
+
+
+def store(tmp, yaml_text=None, roster=None):
+    d = Path(tmp) / "data" / "collaboration-intelligence"
+    d.mkdir(parents=True)
+    if yaml_text is not None:
+        (d / "quick-lookup.yaml").write_text(yaml_text)
+    if roster is not None:
+        (d / "reviewer-stands.json").write_text(json.dumps(roster))
+    return d
+
+
+ROSTER = {"rui": {"github": "john-the-dev", "stand": "@sutando-rui:ag2.space",
+                  "human": "@ruiwangwarm:ag2.space", "allowlisted": True}}
+
+
+class StoreShapes(unittest.TestCase):
+    def test_wrapped_schema_resolves_recent_entities(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, "quick_lookup:\n  recent_entities:\n"
+                         "    - entity_id: wrapped-test\n"
+                         "      agent_mxid: '@wrapped:ag2.space'\n")
+            q, _ = lk.load(d)
+            hits = lk.match(q.get("recent_entities") or q.get("people") or [], "wrapped-test")
+            self.assertEqual([h["entity_id"] for h in hits], ["wrapped-test"])
+
+    def test_flat_people_schema_resolves(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, "people:\n  - entity_id: keweichen\n"
+                         "    agent_mxid: '@kchen6red-m1max.agent:ag2.space'\n"
+                         "rooms: []\n")
+            q, _ = lk.load(d)
+            hits = lk.match(q.get("recent_entities") or q.get("people") or [], "keweichen")
+            self.assertEqual(len(hits), 1)
+
+    def test_flat_id_who_fields_match(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, "people:\n  - id: 'gh:qingyun-wu'\n"
+                         "    who: 'reviewer on the server-PR stack'\n")
+            q, _ = lk.load(d)
+            rows = q.get("recent_entities") or q.get("people") or []
+            self.assertEqual(len(lk.match(rows, "qingyun-wu")), 1)
+            self.assertEqual(len(lk.match(rows, "server-PR")), 1)
+
+    def test_malformed_yaml_degrades_to_roster(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, "people:\n    broken no colon here\n    another: [unclosed\n",
+                      roster=ROSTER)
+            q, _ = lk.load(d)          # must not raise
+            self.assertEqual(q, {})
+            rows = lk.load_roster(d)
+            hits = lk.match(rows, "john-the-dev")
+            self.assertEqual(hits[0]["agent_mxid"], "@sutando-rui:ag2.space")
+
+    def test_roster_github_field_not_key(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, roster=ROSTER)
+            hits = lk.match(lk.load_roster(d), "john-the-dev")
+            self.assertEqual(hits[0]["entity_id"], "rui")
+
+    def test_stand_bearing_row_orders_first(self):
+        with tempfile.TemporaryDirectory() as t:
+            r = dict(ROSTER)
+            r["john-the-dev"] = {"human_name": "Rui"}   # field-poor merge duplicate
+            d = store(t, roster=r)
+            hits = lk.match(lk.load_roster(d), "john-the-dev")
+            self.assertEqual(len(hits), 2)
+            self.assertEqual(hits[0]["agent_mxid"], "@sutando-rui:ag2.space")
+
+    def test_no_match_returns_empty_not_invented(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, roster=ROSTER)
+            self.assertEqual(lk.match(lk.load_roster(d), "no-such-login"), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
## What

`skills/collaboration-intelligence/scripts/lookup.py` — the resolver whose whole purpose is making the correct identity lookup the cheapest one — only read `quick-lookup.yaml` and **crashed** on a host whose live store is `reviewer-stands.json`. Sessions therefore hand-rolled lookups, and a hand-rolled `get(github_login)` queries the wrong axis of a roster keyed by short name.

## The measured failure (twice)

- 2026-08-27: recorded in the roster's own observations — a separate 'john-the-dev' entry was filed with stand=None while the mapping sat under key `rui`.
- 2026-08-28: `get("john-the-dev")` missed again and the owner was told the reviewer was unmapped ("who's john?" → "2 it's Rui. Why did you lose the mapping"). The mapping was in the store the whole time.

## Before/after at the live store

Before (parent commit): `lookup.py john-the-dev` → traceback (`FileNotFoundError: quick-lookup.yaml`).

After (this head):
```
QUERY 'john-the-dev' -> 1 hit(s)
  rui  — github=john-the-dev human=@ruiwangwarm:ag2.space stand=@sutando-rui:ag2.space
  ADDRESS THIS -> @sutando-rui:ag2.space
```
Controls: `rui` → same row (key axis still works); `no-such-login` → `NO MATCH. Do NOT invent an id...` (fails loud, never fabricates); a host with neither store → explicit `MAP EMPTY`, not a crash.

Owner-directed ("Durable fix of your error", 2026-08-28 21:09Z) — the memory-file fix was a discipline; this makes the tool the cheapest path again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)