### PR TITLE
docs(CLAUDE.md): put `task:` last in the chat-path task template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,15 +154,17 @@ local _ts="$(date +%s)"
 cat > "$WORKSPACE/tasks/task-chat-${_ts}.txt" << EOF
 id: task-chat-${_ts}
 timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-task: <concise description of what you're doing>
 source: chat
 interaction_type: message
 channel_id: local-chat
 user_id: ${SUTANDO_DM_OWNER_ID:-chat-local}
 access_tier: owner
 priority: normal
+task: <concise description of what you're doing>
 EOF
 ```
+
+**`task:` must be the LAST header.** Its value is free-form and may span lines, so the strict `parse_task_headers` treats everything below it as body. Nothing is discarded, but `source`, `channel_id`, `access_tier` and `priority` all read as absent — so a task written with `task:` earlier routes nowhere and sorts as `normal` however it declares itself. The delimiter rule is deliberate (it stops a user-supplied body forging headers), so the writer is what must change.
 
 **Priority field**: `urgent` (voice/phone, sub-second latency target) | `normal` (chat/owner DM, default) | `low` (cron, health-check, non-owner DMs). When more than one task is pending, the consumer processes highest-priority first; tie-breaker is mtime FIFO. Defaults per source are encoded in `src/task_priority.py:default_priority_for_source`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ task: <concise description of what you're doing>
 EOF
 ```
 
-**`task:` must be the LAST header.** Its value is free-form and may span lines, so `parse_task_headers` treats everything after it as the body — any header placed below `task:` parses as `None`, including `source`, `channel_id` and `access_tier`.
+**`task:` must be the LAST header.** Its value is free-form and may span lines, so the strict `parse_task_headers` treats everything below it as body. Nothing is discarded, but `source`, `channel_id`, `access_tier` and `priority` all read as absent — so a task written with `task:` earlier routes nowhere and sorts as `normal` however it declares itself. The delimiter rule is deliberate (it stops a user-supplied body forging headers), so the writer is what must change.
 
 **Priority field**: `urgent` (voice/phone, sub-second latency target) | `normal` (chat/owner DM, default) | `low` (cron, health-check, non-owner DMs). When more than one task is pending, the consumer processes highest-priority first; tie-breaker is mtime FIFO. Defaults per source are encoded in `src/task_priority.py:default_priority_for_source`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,15 +154,17 @@ local _ts="$(date +%s)"
 cat > "$WORKSPACE/tasks/task-chat-${_ts}.txt" << EOF
 id: task-chat-${_ts}
 timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-task: <concise description of what you're doing>
 source: chat
 interaction_type: message
 channel_id: local-chat
 user_id: ${SUTANDO_DM_OWNER_ID:-chat-local}
 access_tier: owner
 priority: normal
+task: <concise description of what you're doing>
 EOF
 ```
+
+**`task:` must be the LAST header.** Its value is free-form and may span lines, so `parse_task_headers` treats everything after it as the body — any header placed below `task:` parses as `None`, including `source`, `channel_id` and `access_tier`.
 
 **Priority field**: `urgent` (voice/phone, sub-second latency target) | `normal` (chat/owner DM, default) | `low` (cron, health-check, non-owner DMs). When more than one task is pending, the consumer processes highest-priority first; tie-breaker is mtime FIFO. Defaults per source are encoded in `src/task_priority.py:default_priority_for_source`.
 


### PR DESCRIPTION
## Problem

The chat-path task template in `CLAUDE.md` places `task:` third, above `source:`, `channel_id:`, `user_id:`, `access_tier:` and `priority:`. `task:` is the free-form body header — its value may span lines — so `parse_task_headers` treats everything after it as body. An agent following the documented template verbatim writes a task file whose routing and access-control headers all parse as `None`.

## Evidence

`src/local_task_protocol.parse_task_headers` run on the template exactly as documented, versus the same fields with `task:` moved last:

```
CLAUDE.md template (task: 3rd)        task: last
  source      = None                    source      = 'chat'
  channel_id  = None                    channel_id  = 'local-chat'
  access_tier = None                    access_tier = 'owner'
  priority    = None                    priority    = 'normal'
  user_id     = None                    user_id     = 'owner'
```

## How it surfaced

Delivering an owner-requested post to a Discord channel. The task was written from this template, so `orphan_result_routes` (`src/orphan_result_routes.py`, called from `poll_results` in `src/discord-bridge.py`) found no `channel_id`, declined to adopt the route, and the result sat in `results/` undelivered — no error, no log line, bridge healthy and polling. Reordering the header made the identical file adopt on the next tick:

```
before:  source=None      channel_id=None                 ADOPTED -> None
after:   source='discord' channel_id='1485653767402553457' ADOPTED -> 1485653767402553457
```

## Scope

Documentation only — one reordered line plus a sentence naming the constraint. No code changes. Every bridge-written task already emits `task:` last (`task-cron-*`, ag2space, Discord); only the documented template disagreed, which is why the defect stayed latent.

Worth noting `access_tier` is among the swallowed fields. That is not a live vulnerability here — `CLAUDE.md` grants full processing to a task with no `access_tier`, which is the intended outcome for owner chat tasks — but it does mean the field is decorative in any file written from this template, so copying the template toward a non-owner path would silently grant full processing.