### PR TITLE
fix(health-check): the PID proving "running" may belong to a parked lane

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5636,6 +5636,23 @@ def check_gateway_bridge() -> "dict | None":
                        "timestamp — the writer is not reporting poll outcomes, so "
                        "ag2.space mobile messages may not be delivered"),
         }
+    # Primary said nothing and is not merely stale, so it may not exist at all.
+    # Ask the lanes before calling a live PID healthy — one of them owns it.
+    lanes = _gateway_lane_verdicts()
+    if lanes and not any(serving for _, serving, _ in lanes):
+        never = [ln for ln, _, ever in lanes if not ever]
+        why = (f"lane {', '.join(never)} has never completed a poll" if never
+               else f"lane {', '.join(ln for ln, _, _ in lanes)} is not connected")
+        return {
+            "name": "gateway-bridge",
+            "status": "warn",
+            "detail": (f"process running but NOT serving — {why}; "
+                       "ag2.space mobile messages are not being delivered"),
+        }
+    if lanes:
+        served = ", ".join(ln for ln, serving, _ in lanes if serving)
+        return {"name": "gateway-bridge", "status": "ok",
+                "detail": f"running + connected (lane {served})"}
     return {"name": "gateway-bridge", "status": "ok", "detail": "running"}
 
 
@@ -5773,6 +5790,38 @@ def check_runtime_identity(path: "Path | None" = None,
                           + " ".join(bits)}
     return {"name": name, "status": "ok",
             "detail": ("entrypoint=canonical " + " ".join(bits))}
+
+
+def _gateway_lane_verdicts(state_dir: "Path | None" = None,
+                           now: "float | None" = None) -> "list[tuple[str, bool, bool]]":
+    """(lane, serving, ever_served) for each fresh non-primary lane sidecar.
+
+    The PID proving "running" can belong to a lane other than primary — the lane
+    selector runs exactly one lane and parks the rest — so on a lane-only host
+    primary never writes a sidecar and its absence is not evidence of health.
+    Freshness, schema and the serving rule stay owned by gateway_serving; this
+    enumerates lanes and asks it per file. `ever_served` is read off the
+    normalized record rather than reusing GatewayVerdict.never_polled, which
+    additionally requires `connected` — a lane that is both disconnected and has
+    no successful poll is the misconfigured-endpoint case this message names, and
+    never_polled reports False for it.
+    """
+    import time as _time
+    now = _time.time() if now is None else now
+    root = (Path(state_dir) if state_dir is not None
+            else Path(status_read_path("gateway-status.json", WORKSPACE_DIR)).parent)
+    out = []
+    try:
+        entries = sorted(root.glob("gateway-status.*.json"))
+    except OSError:
+        return out
+    for f in entries:
+        lane = f.name[len("gateway-status."):-len(".json")]
+        v = read_gateway_verdict(f, now=now, max_age=GATEWAY_STATUS_MAX_AGE_S)
+        if v is None:
+            continue
+        out.append((lane, v.serving, v.last_ok_ts is not None))
+    return out
 
 
 def _gateway_status_stale_age_s(path: "Path | None" = None,

--- a/tests/gateway-serving-shared-owner.test.py
+++ b/tests/gateway-serving-shared-owner.test.py
@@ -85,6 +85,14 @@ state, detail, since = ss.probe_gateway(p, "no-such-pattern", NOW, lambda *a, **
 if state != "offline" or since is not None:
     failures.append(f"delegation: services_status.probe_gateway must be offline/None, got {(state, detail, since)}")
 
+# A fourth reader of the same record: it must ask the owner per lane file
+# rather than re-derive "serving" from `connected`.
+lane_dir = tempfile.mkdtemp()
+(Path(lane_dir) / "gateway-status.ag2space_dlocal.json").write_text(json.dumps(NEVER_POLLED))
+lanes = hc._gateway_lane_verdicts(state_dir=Path(lane_dir), now=NOW)
+if lanes != [("ag2space_dlocal", False, False)]:
+    failures.append(f"delegation: health-check._gateway_lane_verdicts must be not-serving on never-polled, got {lanes}")
+
 # Each reader must actually CALL the owner, not re-derive an agreeing answer.
 for mod, name in ((hc, "health-check"), (ciw, "core-input-watch"), (ss, "services_status")):
     if getattr(mod, "read_gateway_verdict", None) is not gs.read_verdict:
@@ -208,4 +216,4 @@ if failures:
         print(f"FAIL: {f}")
     sys.exit(1)
 print(f"ok - {len(CONTRACT)} contract + {len(NO_OPINION) + 1} no-opinion + {malformed_checked} malformed + {len(ACCEPTED)} accepted cases, "
-      f"3 readers delegating, 3 reader-specific edges preserved")
+      f"4 readers delegating, 3 reader-specific edges preserved")

--- a/tests/health-check-gateway-lane-verdict.test.py
+++ b/tests/health-check-gateway-lane-verdict.test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""A live gateway PID may belong to a non-primary lane.
+
+The lane selector runs exactly ONE lane and parks the others, so on a lane-only
+host `state/gateway-status.json` is never written. An absent primary sidecar is
+not evidence of health, and the running lane's own sidecar is the signal.
+"""
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO / "src"))
+_spec = importlib.util.spec_from_file_location("hc", _REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+
+class GatewayLaneVerdicts(unittest.TestCase):
+    def _dir(self) -> Path:
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        return d
+
+    def _lane(self, d: Path, lane: str, *, connected: bool,
+              last_ok: "float | None", age_s: float = 5.0) -> None:
+        (d / f"gateway-status.{lane}.json").write_text(json.dumps(
+            {"connected": connected, "ts": time.time() - age_s, "last_ok_ts": last_ok}))
+
+    def test_never_polled_lane_is_reported(self):
+        d = self._dir()
+        self._lane(d, "ag2space_dlocal", connected=False, last_ok=None)
+        v = hc._gateway_lane_verdicts(state_dir=d)
+        self.assertEqual(v, [("ag2space_dlocal", False, False)])
+
+    def test_worked_then_died_is_distinguished_from_never_polled(self):
+        """Different failures: one is a misconfigured endpoint, the other an
+        outage. A probe that cannot tell them apart sends people the wrong way."""
+        d = self._dir()
+        self._lane(d, "never", connected=False, last_ok=None)
+        self._lane(d, "died", connected=False, last_ok=time.time() - 9000)
+        got = {ln: ever for ln, _, ever in hc._gateway_lane_verdicts(state_dir=d)}
+        self.assertEqual(got, {"never": False, "died": True})
+
+    def test_connected_without_a_completed_poll_is_not_serving(self):
+        """The discriminating case, and the state this probe was written for: a
+        lane whose sidecar says connected:true but that has never completed a
+        poll. `connected` alone is what a dead bridge's last write leaves
+        behind, so reading it directly reports a parked lane as healthy."""
+        d = self._dir()
+        self._lane(d, "ag2space_dlocal", connected=True, last_ok=None)
+        self.assertEqual(hc._gateway_lane_verdicts(state_dir=d),
+                         [("ag2space_dlocal", False, False)])
+
+    def test_unreadable_state_dir_yields_no_lanes_rather_than_raising(self):
+        """A probe must not take the whole health check down with it. An
+        unreadable state dir is no evidence about the lanes, not an error."""
+        d = self._dir()
+        self._lane(d, "ag2space_dlocal", connected=True, last_ok=None)
+        with patch.object(Path, "glob", side_effect=OSError("permission denied")):
+            self.assertEqual(hc._gateway_lane_verdicts(state_dir=d), [])
+
+    def test_stale_lane_sidecar_is_ignored(self):
+        d = self._dir()
+        self._lane(d, "old", connected=False, last_ok=None,
+                   age_s=hc.GATEWAY_STATUS_MAX_AGE_S + 60)
+        self.assertEqual(hc._gateway_lane_verdicts(state_dir=d), [])
+
+    def test_primary_sidecar_is_not_treated_as_a_lane(self):
+        """`gateway-status.json` has no lane segment; globbing it in would
+        invent a lane named after the file and double-count primary."""
+        d = self._dir()
+        (d / "gateway-status.json").write_text(json.dumps(
+            {"connected": True, "ts": time.time(), "last_ok_ts": time.time()}))
+        self.assertEqual(hc._gateway_lane_verdicts(state_dir=d), [])
+
+    def test_malformed_and_unreadable_lanes_do_not_raise(self):
+        d = self._dir()
+        (d / "gateway-status.bad.json").write_text("{not json")
+        (d / "gateway-status.nots.json").write_text(json.dumps({"connected": True}))
+        (d / "gateway-status.boolts.json").write_text(json.dumps(
+            {"connected": True, "ts": True}))
+        self.assertEqual(hc._gateway_lane_verdicts(state_dir=d), [])
+
+    def test_absent_state_dir_is_empty_not_an_error(self):
+        self.assertEqual(hc._gateway_lane_verdicts(state_dir=Path("/nonexistent-xyz")), [])
+
+
+class GatewayBridgeVerdictUsesLanes(unittest.TestCase):
+    """The caller: a live PID plus no primary opinion must not read as ok when a
+    fresh lane sidecar says otherwise."""
+
+    def _run(self, lanes):
+        with patch.object(hc, "_gateway_configured", return_value=True), \
+             patch.object(hc, "subprocess") as sp, \
+             patch.object(hc, "_gateway_lock_pids", return_value={}), \
+             patch.object(hc, "_gateway_serving", return_value=None), \
+             patch.object(hc, "_gateway_status_stale_age_s", return_value=None), \
+             patch.object(hc, "_gateway_lane_verdicts", return_value=lanes):
+            sp.run.return_value = type("R", (), {"stdout": "4242\n", "returncode": 0})()
+            return hc.check_gateway_bridge()
+
+    def test_never_polled_lane_warns_instead_of_ok(self):
+        r = self._run([("ag2space_dlocal", False, False)])
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("never completed a poll", r["detail"])
+        self.assertIn("ag2space_dlocal", r["detail"])
+
+    def test_disconnected_lane_that_once_worked_warns(self):
+        r = self._run([("primaryish", False, True)])
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("not connected", r["detail"])
+        self.assertNotIn("never completed", r["detail"])
+
+    def test_serving_lane_is_ok_and_names_the_lane(self):
+        r = self._run([("ag2space_dlocal", True, True)])
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("ag2space_dlocal", r["detail"])
+
+    def test_no_lane_sidecars_keeps_the_process_only_verdict(self):
+        """Regression guard: hosts with no lanes must be untouched."""
+        r = self._run([])
+        self.assertEqual(r["status"], "ok")
+        self.assertEqual(r["detail"], "running")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
## The bug

`check_gateway_bridge()` consults only the primary sidecar. The lane selector runs exactly **one** lane and parks the rest, so on a lane-only host primary never writes a sidecar at all — and its absence falls through to the process-only `ok`, leaving a live PID from a *parked* lane to carry the verdict.

This is the state that produced a silent outage on my host: the running lane's own sidecar read `last_ok_ts: null` after thousands of consecutive SSL failures — it had never completed a single poll — while the probe reported `ok / running`.

## Before / after

A lane-only host: no primary sidecar; one lane sidecar saying `connected: true` with `last_ok_ts: null`; a live PID.

At the parent (`b392f33b`):

```
  status='ok'
  detail='running'
```

At this HEAD:

```
  status='warn'
  detail='process running but NOT serving — lane ag2space_dlocal has never completed a poll; ag2.space mobile messages are not being delivered'
```

## Design

`_gateway_lane_verdicts()` enumerates the fresh non-primary sidecars and asks **`gateway_serving.read_verdict()` per file**, so freshness, schema handling and the serving rule stay with the owner #3471 established rather than being restated here. This branch predates #3471 and originally hand-rolled that parsing; rebasing onto the shared owner removed a real defect in my own code — the old version derived serving from `connected` alone, which is exactly the false-healthy #3471 exists to prevent.

Two deliberate choices worth a reviewer's attention:

- **`ever_served` is read off the normalized record rather than reusing `GatewayVerdict.never_polled`**, which additionally requires `connected`. A lane that is *both* disconnected and has no successful poll is the misconfigured-endpoint case this message names, and `never_polled` reports `False` for it. I am reading a normalized field to pick wording, not restating the serving policy.
- **main's malformed-timestamp branch stays ahead of the lane fallback.** An existing-but-unusable primary sidecar is a specific diagnosable state and should not be masked by a lane verdict; the lanes answer only when primary said nothing at all.

The probe distinguishes a lane that has *never* completed a poll (misconfigured endpoint) from one that worked and stopped (outage) — they send people in different directions.

## Tests

`tests/health-check-gateway-lane-verdict.test.py` — 11 cases. The added `connected: true` + `last_ok_ts: null` case is the discriminating one; it is the state that motivated the probe.

**Mutation control** — restoring the direct `connected` read fails exactly that case and no other:

```
FAIL: test_connected_without_a_completed_poll_is_not_serving
Ran 11 tests   FAILED (failures=1)
```

`tests/gateway-serving-shared-owner.test.py` gains this as a **fourth pinned reader** (`3 readers delegating` -> `4`), so it cannot drift back to hand-rolling the way this branch originally did. Same control, against that pin:

```
FAIL: delegation: health-check._gateway_lane_verdicts must be not-serving on never-polled, got [('ag2space_dlocal', True, False)]
```

Neighbouring suites at this HEAD: `health-check-gateway-bridge`, `-outage-duration`, `-transient-outage`, `gateway-serving-shared-owner` all pass. `ruff` clean; `scripts/review-checks.sh --diff` PASS.

## What I did not verify

I have not exercised this against a live multi-lane host other than my own, and the before/after above is the probe under a constructed state dir, not a post-restart round trip. This is a diagnostic probe rather than a delivery path, so it changes what health-check *reports*, not what the bridge does.
