### PR TITLE
fix(config): the runtime socket path has one owner, and it is rundir

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -495,14 +495,21 @@ print(_host_label(), end='')
     ;;
 
   runtime-socket)
-    # The runtime-API daemon's Unix socket. MIRRORS #2325's rundir.py
-    # socket_path(): SUTANDO_RUNTIME_SOCKET override wins, else
-    # <run-dir>/sutando-runtime.sock. (Filename is sutando-runtime.sock — NOT
-    # runtime-api.sock; #2325 ships that default and both ends interpret it here.)
+    # DELEGATES to rundir.socket_path() — the daemon decides where it listens,
+    # so this must not carry a second copy of that rule (it drifted once).
     if [ -n "${SUTANDO_RUNTIME_SOCKET:-}" ]; then
       printf '%s' "$SUTANDO_RUNTIME_SOCKET"
     else
-      printf '%s/sutando-runtime.sock' "$(bash "$0" run-dir)"
+      _sock="$(SUTANDO_CONFIG_REPO="$REPO_ROOT" "$PY" - <<'PY' 2>/dev/null
+import os, sys
+sys.path.insert(0, os.path.join(os.environ["SUTANDO_CONFIG_REPO"], "src", "runtime-api"))
+import rundir
+sys.stdout.write(rundir.socket_path())
+PY
+)"
+      # Never hard-fail this helper: everything shells out to it.
+      if [ -n "$_sock" ]; then printf '%s' "$_sock"
+      else printf '%s/sutando-runtime.sock' "$(bash "$0" run-dir)"; fi
     fi
     ;;
 
@@ -737,7 +744,13 @@ elif os.environ.get('XDG_RUNTIME_DIR'):
     _rundir = os.path.join(os.environ['XDG_RUNTIME_DIR'], 'sutando')
 else:
     _rundir = os.path.join(os.path.expanduser('~'), '.sutando', 'run')
-_runtime_socket = os.environ.get('SUTANDO_RUNTIME_SOCKET') or os.path.join(_rundir, 'sutando-runtime.sock')
+# Same delegation as the runtime-socket subcommand: rundir owns the rule.
+try:
+    sys.path.insert(0, os.path.join(repo, 'src', 'runtime-api'))
+    import rundir as _rundir_mod
+    _runtime_socket = _rundir_mod.socket_path()
+except Exception:
+    _runtime_socket = os.environ.get('SUTANDO_RUNTIME_SOCKET') or os.path.join(_rundir, 'sutando-runtime.sock')
 # runtimeRoot = parent of run/ when run-dir is <root>/run (darwin App-Support,
 # portable dot-sutando); for the XDG case the run-dir (XDG_RUNTIME_DIR/sutando) IS
 # the app dir (its parent is the shared XDG base), so use the run-dir itself.


### PR DESCRIPTION
Found by actually running the track-19 realtime E2E against this host rather than reasoning about the route.

## What the E2E turned up

`scripts/sutando-config.sh` carries its own copy of the runtime-socket rule in two places, under a comment claiming it **"MIRRORS #2325's rundir.py socket_path()"**. That claim is what decayed: `rundir` has since grown instance scoping and a conditional legacy fallback; the shell copy has not.

## Behaviour-preserving on main — shown, not asserted

```
config (fixed)   + main's rundir  ->  <run>/sutando-runtime.sock
config (unfixed) + main's rundir  ->  <run>/sutando-runtime.sock      identical
```

## And already diverging on feat/sutando-server

That branch's `rundir` returns an instance-scoped socket. Same matrix against it:

```
config (fixed)    ->  <run>/default/runtime.sock       follows the daemon
config (unfixed)  ->  <run>/sutando-runtime.sock       points at nothing
```

**The second row is live on this host right now.** The running daemon holds `<run>/default/instance.lock` and listens on `<run>/default/runtime.sock`; `sutando-config.sh runtime` advertises the flat path, which does not exist. Anything resolving the runtime through that descriptor gets a dead address — and the descriptor is documented in that same file as *"the single OSS-side contract the desktop app reads to resolve which runtime to attach its Terminal to."*

## The change

Both call sites delegate to `rundir.socket_path()`. The second also stops needing its own copy of the darwin/XDG/portable run-dir ladder for this purpose. Each keeps the previous literal as a fallback, so a partial checkout cannot hard-fail a helper that everything shells out to.

## Corrections to my own earlier claims, since I made two

1. A previous roadmap entry of mine said the realtime lane could not be verified because **"the daemon is down."** It is not down. It has been listening since Aug 22 — on the path the descriptor does not name. I had checked the descriptor's path, found nothing, and drew the wrong conclusion.
2. While measuring this I twice got empty output from `git show "$ref:path"` and blamed a flaky pipe. The real cause is zsh's colon modifier eating part of the path — `"${ref}:path"` works. Worth knowing before anyone reads a zero from that shape as evidence.

`bash -n` clean; `workspace`, `host-label`, `run-dir` all unchanged. Repo gate is **PARTIAL**, not PASS: prose-cap takes no `.sh`, so only hardcoded-paths and root-artifacts ran.
