### PR TITLE
ci(coverage): the gate cannot fit the 15-minute cap on this base

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -33,6 +33,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`chat_secret_filter.py`** — Fail-closed secret redaction for persisted inbound chat content.
 - **`check-pending-questions.py`** — Check pending questions and notify if unanswered.
 - **`check-pending-tasks.sh`** — Stop hook: blocks Claude from finishing when unprocessed tasks exist.
+- **`claim_task.py`** — Atomic-rename claim primitive for the multi-core agent pool (#880, #884).
 - **`claude_config_dir.sh`** — Shared CLAUDE_CONFIG_DIR resolution for start-cli.sh and startup.sh.
 - **`context-drop.sh`** — Sutando context drop — triggered by macOS hotkey via Automator Quick Action.
 - **`context_resume.py`** — Extract recent conversation turns from a Claude Code transcript (.jsonl).
@@ -104,6 +105,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`peer-watch.py`** — Read a peer host's restart-watch signal WITHOUT confusing a stale view for a dead peer.
 - **`pending_questions_md.py`** — Locating the `# Resolved` divider in pending-questions.md — one definition.
 - **`personal-claude-compact-hint.sh`** — SessionStart(compact) hook — re-inject PERSONAL_CLAUDE.md after context compaction.
+- **`pool_follower.py`** — Follower-side work acquisition (lead-follower pool, slice L2).
 - **`presenter-mode.ts`** — Provider-neutral presenter-mode sentinel policy — TS twin of src/presenter_mode.py (#2501).
 - **`presenter_mode.py`** — Provider-neutral presenter-mode sentinel policy.
 - **`proactive_claim_fence.py`** — Proactive claim lifecycle on the outbox ClaimBackend seam.
@@ -333,6 +335,11 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`ha_adapter.py`** — runtime-api ↔ human-action adapter — the v0 approve/answer transport.
 - **`identity_view.py`** — Read-only identity surface for THIS agent (the Sutando Server "smallest slice"): sutando.info / sutando.status / sutando.owner / sutando.allowlist.
 - **`instance_registry.py`** — Sutando Instance Manifest registry — persistent "this agent exists here" records, M1 of the manifest spec (taxonomy part 4/5): Agent existence ≠ agent process existence.
+- **`pool_lead.py`** — Lead-side assignment engine (lead-follower pool, slice L1).
+- **`pool_metrics.py`** — Lead-side pool metrics (slice L4 — the owner's 2026-05-19 quality bar).
+- **`pool_notify.py`** — Lead-side progress communication (lead-follower pool, slice L5).
+- **`pool_scale.py`** — Lead-side follower autoscaling policy (lead-follower pool, slice L6).
+- **`pool_status.py`** — Owner-facing pool snapshot (single writer: the lead daemon).
 - **`protocol.py`** — runtime-api protocol — NDJSON JSON-RPC 2.0 over a local Unix socket.
 - **`request_store.py`** — runtime-api request store — durable request lifecycle in SQLite.
 - **`rundir.py`** — Canonical run-dir + runtime-socket resolution — the ONE definition shared by the daemon (server.py) and the CLI (src/runtime-cli/sutando-runtime.py).

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -94,9 +94,49 @@ failed=0
 skipped_total=0
 fully_skipped=()
 partly_skipped=()
+# Each file writes its own .coverage.* fragment (`parallel = True`), merged
+# by the `coverage combine` below.
+COVGATE_WORKERS="${COVERAGE_GATE_WORKERS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+RECDIR="$(mktemp -d)"
+trap 'rm -rf "$RECDIR"' EXIT
+
+# Per-file cap, mirroring ci.yml: without it one hung file burns the job
+# budget and the job is CANCELED mid-suite.
+
+# `timeout` is coreutils and absent on stock macOS, where this also runs by
+# hand; degrade to no cap rather than failing the local path.
+COVGATE_TIMEOUT=""
+if command -v timeout >/dev/null 2>&1; then
+    COVGATE_TIMEOUT="timeout -k 5 ${COVERAGE_GATE_FILE_TIMEOUT:-120}"
+else
+    echo "coverage-gate: no \`timeout\` binary — per-file cap disabled (local run)." >&2
+fi
+export RECDIR COVGATE_TIMEOUT
+
+find tests -name '*.test.py' -not -path '*/node_modules/*' | sort > "$RECDIR/files"
+# Key on the LINE INDEX: a name-derived key collides (`tr "/." "__"` maps
+# tests/a/b and tests/a_b alike), letting a failing rc be overwritten.
+_covgate_n="$(wc -l < "$RECDIR/files" | tr -d ' ')"
+
+# Shared scheduler: one SERIAL worker per worktree; the regression drives it.
+
+# It also brings the worktrees' .coverage.* fragments home for the combine.
+# shellcheck disable=SC2086
+bash "$(dirname "$0")/parallel-suite-lane.sh" "$COVGATE_WORKERS" "$RECDIR/files" "$RECDIR" \
+    env SUTANDO_TEST_SUBPROCESS_COVERAGE=1 $COVGATE_TIMEOUT python3 -m coverage run --rcfile=.coveragerc
+
+_covgate_idx=0
 while IFS= read -r f; do
-    if ! output=$(SUTANDO_TEST_SUBPROCESS_COVERAGE=1 python3 -m coverage run --rcfile=.coveragerc "$f" 2>&1); then
-        echo "✖ test failed under instrumentation: $f"
+    _covgate_idx=$((_covgate_idx + 1))
+    rec="$RECDIR/$_covgate_idx"
+    rc="$(cat "$rec.rc" 2>/dev/null || echo 1)"
+    output="$(cat "$rec.out" 2>/dev/null || true)"
+    if [ "$rc" -ne 0 ]; then
+        if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+            echo "✖ test TIMED OUT under instrumentation (>${COVERAGE_GATE_FILE_TIMEOUT:-120}s): $f"
+        else
+            echo "✖ test failed under instrumentation: $f"
+        fi
         echo "$output"
         failed=1
         continue
@@ -112,7 +152,7 @@ while IFS= read -r f; do
     elif [ "$skips" -gt 0 ]; then
         partly_skipped+=("$f ($skips/$ran skipped)")
     fi
-done < <(find tests -name '*.test.py' -not -path '*/node_modules/*' | sort)
+done < "$RECDIR/files"
 
 if [ "$skipped_total" -gt 0 ]; then
     echo "coverage-gate: $skipped_total test case(s) SKIPPED in this environment."

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -96,6 +96,8 @@ fully_skipped=()
 partly_skipped=()
 # Each file writes its own .coverage.* fragment (`parallel = True`), merged
 # by the `coverage combine` below.
+# One worktree per worker, so this trades disk for wall clock: the lanes are
+# CPU-bound once created, and an unbounded count would thrash a small runner.
 COVGATE_WORKERS="${COVERAGE_GATE_WORKERS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
 RECDIR="$(mktemp -d)"
 trap 'rm -rf "$RECDIR"' EXIT
@@ -113,11 +115,25 @@ else
 fi
 export RECDIR COVGATE_TIMEOUT
 
+# Lanes are worktrees at HEAD, so uncommitted work is invisible to them: a
+# clean report here would cover code this run never executed.
+if [ -z "${COVERAGE_GATE_ALLOW_DIRTY:-}" ] && git rev-parse --git-dir >/dev/null 2>&1; then
+    _covgate_dirty=""
+    git diff --quiet HEAD 2>/dev/null || _covgate_dirty="tracked edits"
+    if [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+        _covgate_dirty="${_covgate_dirty:+$_covgate_dirty, }untracked files"
+    fi
+    if [ -n "$_covgate_dirty" ]; then
+        echo "coverage-gate: working tree is dirty ($_covgate_dirty); lanes run against HEAD," >&2
+        echo "  so your edits would NOT be measured. Commit them, or set" >&2
+        echo "  COVERAGE_GATE_ALLOW_DIRTY=1 to measure HEAD deliberately." >&2
+        exit 1
+    fi
+fi
+
 find tests -name '*.test.py' -not -path '*/node_modules/*' | sort > "$RECDIR/files"
 # Key on the LINE INDEX: a name-derived key collides (`tr "/." "__"` maps
 # tests/a/b and tests/a_b alike), letting a failing rc be overwritten.
-_covgate_n="$(wc -l < "$RECDIR/files" | tr -d ' ')"
-
 # Shared scheduler: one SERIAL worker per worktree; the regression drives it.
 
 # It also brings the worktrees' .coverage.* fragments home for the combine.

--- a/scripts/parallel-suite-lane.sh
+++ b/scripts/parallel-suite-lane.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# One SERIAL worker per git worktree: worker w takes lines w, w+W, w+2W... so a
+# worktree never holds two suites at once — exclusivity is structural, not a lock.
+# usage: parallel-suite-lane.sh <workers> <files-list> <recdir> <cmd-prefix...>
+# Records land as <recdir>/<line-index>.{out,rc}; aggregation stays the caller's.
+set -uo pipefail
+WORKERS="$1"; FILES="$2"; RECDIR="$3"; shift 3
+N="$(wc -l < "$FILES" | tr -d ' ')"
+
+WTDIR="$(mktemp -d)"
+for _w in $(seq 1 "$WORKERS"); do
+    git worktree add --detach -q "$WTDIR/$_w" HEAD
+done
+_lane_cleanup() {
+    for _w in $(seq 1 "$WORKERS"); do
+        git worktree remove --force "$WTDIR/$_w" 2>/dev/null || true
+    done
+    rm -rf "$WTDIR"
+}
+trap _lane_cleanup EXIT
+
+for _w in $(seq 1 "$WORKERS"); do
+    (
+        idx="$_w"
+        while [ "$idx" -le "$N" ]; do
+            f="$(sed -n "${idx}p" "$FILES")"
+            rec="$RECDIR/$idx"
+            out="$(cd "$WTDIR/$_w" && "$@" "$f" 2>&1)" && rc=0 || rc=$?
+            printf "%s" "$out" > "$rec.out"
+            printf "%s\n" "$rc" > "$rec.rc"
+            idx=$((idx + WORKERS))
+        done
+    ) &
+done
+wait
+
+# Instrumented runs write .coverage.* inside the worktrees; `coverage combine`
+# searches the caller's cwd, so bring the fragments home (no-op when none).
+find "$WTDIR" -maxdepth 2 -name '.coverage.*' -exec mv {} . \; 2>/dev/null || true


### PR DESCRIPTION
The coverage gate on `feat/pool-runtime-drive` has **never once completed**. It is not slow — it is structurally unable to finish, so every PR stacked here shows a CANCELLED required check that no amount of re-running will clear.

## The evidence

**#3375** is the worked example: APPROVED, MERGEABLE, correct — and cancelled three times. The last run:

```
started    2026-08-28T23:06:49Z
completed  2026-08-28T23:22:04Z     = 15m15s
cap        timeout-minutes: 15
died in    step 4, "Run coverage gate"
```

That is the **job-cap** mode of CANCELLED. The other mode — concurrency-supersede — lands at 2–3 minutes. I had previously mis-tiered these cancellations as a coverage *content* failure; measured against this PR's own base, diff coverage is **96% against a 95% bar**. Coverage was never the problem. The job never got to say so.

## The cause

`main` carries the **same** 15-minute cap, plus two mechanisms that make the suite fit inside it. This base has neither:

| | main | this base |
|---|---|---|
| `COVERAGE_GATE_FILE_TIMEOUT` in `scripts/coverage-gate.sh` | 2 | **0** |
| `scripts/parallel-suite-lane.sh` | present | **absent** |

Without a per-file cap, one slow or hanging test consumes the whole job budget with nothing to bound it; without the lane, the suite runs serially. The run is killed before a verdict exists. This base is 112 commits behind main.

## The change

Both files ported **verbatim** from `origin/main` — byte-identical by `shasum`, no re-derivation. The call site matches the lane's documented contract (`<workers> <files-list> <recdir> <cmd-prefix...>`). The gate already degrades gracefully where `timeout` is absent (stock macOS), so the by-hand local path is unaffected.

## Scope, and what this does NOT fix

The five pool bases are **siblings, not a linear stack** — `git merge-base --is-ancestor` is false for all 20 ordered pairs — so this fix does **not** flow to the others. Each needs its own port. Eight open PRs sit on the five:

```
feat/pool-runtime-drive        #3375              <- this PR
feat/pool-operability          #3411 #3384 #3376 #3330
feat/pool-session-profiles     #3385
feat/pool-runtime-dimension    #3333
fix/pool-wakeup-runtime-aware  #3379
```

`main`, `feat/sutando-server-v0` and `feat/lead-follower-pool` already have both mechanisms and are unaffected.

## What I could not verify locally

`timeout` is coreutils and absent on stock macOS, so a local full run exercises the **uncapped** path and would prove nothing about the cap. CI on this branch is the evidence — the honest check is whether the gate on this PR reaches a verdict at all.

Checks: `bash -n` clean on both files; `review-checks.sh` PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap has no in-scope files — it is Python-only and this diff is shell).

---

## Why backport rather than rebase the base onto `main` (asked by @liususan091219, answered by measurement)

Fair question, and the answer is not "backporting is nicer" — I measured the alternative on this exact base:

```
feat/pool-runtime-drive vs origin/main:  114 behind, 70 ahead
trial merge (git merge-tree --write-tree): 14 CONFLICTS
  13 × .github/workflows/*.yml   (coverage-gate, eslint, ruff, shellcheck,
                                  workspace-leak-check, and 8 lint-*.yml)
   1 × docs/catalog.json
```

Two things make the rebase the more expensive option here rather than the "pay once" one:

1. **The conflicts are concentrated in exactly the surface this PR touches.** 13 of 14 are workflow files, and the coverage gate is a workflow. So a rebase would not sidestep the backport work — it would do the same reconciliation, by hand, across thirteen files instead of two, with no test to tell me I got each one right.
2. **Two PRs are stacked on this base** (`#3522` and `#3375`). A rebase rewrites their merge-base and forces both to be re-pushed and re-reviewed, and #3375 is the PR whose cancelled run is the evidence in this body.

The drift risk you name is real and I am not waving it away: this does create a second copy of policy `main` owns. What bounds it is that both files were ported **byte-identical** from `main` — so a future divergence is a `diff` away from being visible, and the right time to collapse the copy is when `feat/pool-runtime-drive` merges, not before, since that merge deletes one of the two copies by construction.

Recorded here rather than only in a comment, since you were right that the next person will ask.