### PR TITLE
test(outbox-race): warm the phase-1 pool too, for phase 2's own stated reason

### DIFF
--- a/tests/outbox-race.test.py
+++ b/tests/outbox-race.test.py
@@ -34,12 +34,14 @@ def plant_stale_claim(root, item):
 if __name__ == "__main__":
     N, rounds = 24, 12
     totals = []
-    for r in range(rounds):
-        with tempfile.TemporaryDirectory() as tmp:
-            os.makedirs(os.path.join(tmp, ".claims"), exist_ok=True)  # pre-make so mkdir isn't the serializer
-            with mp.Pool(N) as pool:
+    # ONE warm pool here too, for the reason phase 2 already states: a fresh pool
+    # per round pays process startup inside the window under test.
+    with mp.Pool(N) as pool:
+        for r in range(rounds):
+            with tempfile.TemporaryDirectory() as tmp:
+                os.makedirs(os.path.join(tmp, ".claims"), exist_ok=True)  # pre-make so mkdir isn't the serializer
                 got = pool.map(worker, [(tmp, f"item-race-{r}", i) for i in range(N)])
-        totals.append(sum(got))
+            totals.append(sum(got))
     print(f"  {rounds} rounds x {N} concurrent PROCESSES racing one item")
     print(f"  winners per round: {totals}")
     bad = [t for t in totals if t != 1]


### PR DESCRIPTION
## The change

Phase 2 of `tests/outbox-race.test.py` already hoists one warm pool, and states why in its own comment:

> ONE warm pool for every round. A fresh pool per round pays process startup **inside the window under test, which staggers the workers and hides the race.**

Phase 1 — the *primary* exclusion test — still built a fresh `mp.Pool(24)` every round. This applies phase 2's own rationale to the loop it was never applied to. Seven lines.

## Why it matters twice

**Fidelity.** Staggered worker startup weakens exactly the contention phase 1 exists to create. That is phase 2's argument, and phase 1 is the loop where exclusion is actually asserted.

**A live CI cost.** 12 fresh pools × 24 workers is **288 process spawns instead of 24**. The coverage gate sets `SUTANDO_TEST_SUBPROCESS_COVERAGE=1`, so every spawn also starts a tracer. This file has hit the gate's 120s per-file cap **three times today, on three unrelated PRs** — #3501, #3519, #3512 — each time:

```
✖ test TIMED OUT under instrumentation (>120s): tests/outbox-race.test.py
coverage-gate: suite must be green before coverage is meaningful.
```

which fails the whole gate and costs a rerun. The timeout is not the file's own fault being flaky in isolation; it is 264 avoidable spawns meeting per-spawn tracer startup.

## Measured, on a 10-core host

```
uninstrumented                       3.59s / 3.34s   ->   0.95s / 1.13s
coverage run + subprocess tracing    4.34s           ->   1.06s
```

## What I did NOT establish

**I could not reproduce the >120s timeout locally.** This host has 10 cores; a standard runner has ~4, so both the oversubscription (24 workers) and the per-spawn tracer cost land far harder there. This PR removes 264 of 288 spawns and is a large measured saving — it is **not** proof the timeout is gone. If it recurs after this, the remaining cost is elsewhere and the hardcoded `N = 24` (never derived from `os.cpu_count()`) is the next thing I would look at.

## The speedup is not bought with coverage

Mutation control — force `acquire_delivery_claim` to always succeed, so exclusion is broken:

```
  12 rounds x 24 concurrent PROCESSES racing one item
  winners per round: [24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24]
  rounds with != 1 winner: 12  <-- EXCLUSION BROKEN
FAILED — more than one drainer acquired the same item
```

The hoisted phase 1 still detects the defect it exists for. Restored, it passes.

`review-checks --diff` PASS and `ruff` clean, both re-run on the final commit.
