### PR TITLE
fix(session-handoff): read the pending-questions file the shell guarded

### DIFF
--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -256,6 +256,10 @@ import importlib.util
 spec = importlib.util.spec_from_file_location('cpq', '$REPO/src/check-pending-questions.py')
 m = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(m)
+# Read the file the shell already guarded. The module resolves its own PQ_FILE
+# independently, and a second resolution can name a file the [ -f ] never saw.
+from pathlib import Path as _P
+m.PQ_FILE = _P('$PQ_PATH')
 qs = m.get_waiting_questions()
 print('\n'.join('- ' + q['title'] for q in qs[:20]) if qs else 'None')
 " 2>/dev/null)

--- a/tests/session-handoff-pending-questions.test.py
+++ b/tests/session-handoff-pending-questions.test.py
@@ -91,6 +91,33 @@ for label, section in SHAPES.items():
             "-- the retired pattern's coverage is not what the regression assumed",
         )
 
+
+# 4. The guard and the read must name the SAME file: on disagreement `qs` is
+# empty, prints "None", and the honest parse-failure branch never fires.
+_snip = re.search(r"pq_out=\$\(python3 -c \"\n(.*?)\"\s*2>/dev/null\)",
+                  src, re.S)
+check("the extractor snippet is still locatable", bool(_snip))
+if _snip:
+    with tempfile.TemporaryDirectory() as td:
+        real = Path(td) / "pending-questions.md"
+        real.write_text("## UNIQUEMARKER-guarded-file question\n\nbody\n")
+        code = _snip.group(1).replace("$REPO", str(REPO)).replace("$PQ_PATH", str(real))
+
+        def run(src_code):
+            return subprocess.run([sys.executable, "-c", src_code],
+                                  capture_output=True, text=True).stdout
+
+        fixed = run(code)
+        # Negative control: strip the binding and the read reverts to whatever
+        # the module resolved on its own — the pre-fix behaviour.
+        unbound = run(re.sub(r"^m\.PQ_FILE = _P\(.*\)$", "", code, flags=re.M))
+
+        check("the read uses the guarded file", "UNIQUEMARKER" in fixed,
+              f"-- got {fixed.strip()[:60]!r}")
+        check("control: without the binding it does NOT read the guarded file",
+              "UNIQUEMARKER" not in unbound,
+              "-- the test cannot distinguish bound from unbound")
+
 print()
 if failures:
     print(f"FAILED ({len(failures)}): " + "; ".join(failures))


### PR DESCRIPTION
The guard and the read name different files. `[ -f "$PQ_PATH" ]` gates on the shell's resolution, but the snippet it guards calls `get_waiting_questions()`, which reads the module-global `PQ_FILE` that `check-pending-questions.py` resolves **independently at import**. `$PQ_PATH` is never passed in.

## Why this is worse than reading the wrong file

When the two resolutions disagree, `qs` comes back empty → the snippet prints `None` → `pq_out` is therefore **non-empty** → the explicit `(could not parse …)` branch never fires. The section renders `None`, which is indistinguishable from "nothing pending".

That is precisely what the comment four lines above forbids:

> a broken extractor must never be indistinguishable from an empty queue

The surrounding comment also records that this is already **the second fix to this same section**, and that repairing the path is what turned an honest `None` (file not found) into a silent `""`. This is the third instance of the same shape, and it is the one that survives.

## Credit, and why this is not hypothetical

Found by **@bassilkhilo-ag2** while reviewing #2379, with the one-line remedy already named there. It was never applied to that PR — and the same code reached `main` through its sibling **#2381** (merged 2026-08-03). So the reviewer's blocker is live in `main` while the PR it blocked sits open. I offered him the follow-through first and am taking it after ~an hour of quiet; happy to close this if he would rather own it.

## The fix

`get_waiting_questions()` reads `PQ_FILE` at call time (`check-pending-questions.py:123,125`), so rebinding it after `exec_module` takes effect and the read becomes provably the file the guard tested.

## The test drives production, and can fail

It parses the **real extractor snippet out of `session-handoff.sh`** rather than restating it, so it cannot drift from production. It carries its own negative control — stripping the binding must stop the guarded file being read, or the test cannot tell bound from unbound.

Against `main`'s current `session-handoff.sh`:

```
FAIL the read uses the guarded file -- got '- Question 0\n- Question 1\n- Question 2…'
FAILED (1): the read uses the guarded file
```

Those questions come from a file the guard never checked — the bug, shown rather than described. With the fix: `PASS`.

## What I could not reproduce

I could **not** make the two resolutions diverge on this host — both land on the same file (37 waiting), including with and without `SUTANDO_MEMORY_DIR` set, which was my hypothesis and was wrong. So this is a correctness fix for a structural hazard the reviewer reproduced with concrete numbers, not a fix for a failure I observed here.

Checks: `session-handoff-pending-questions.test.py` PASS on 3.12 · `bash -n` clean · `review-checks.sh` **PASS**.