### PR TITLE
fix(agent-api,local-task-protocol): /result 404s on the re-archive layout it writes

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -547,6 +547,11 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
         candidate = archive / month / fname
         if candidate.is_file():
             return candidate
+        # Re-archive inside a month dir suffixes the epoch (`<id>-<epoch>.txt`);
+        # a literal-name scan misses it. Fallback only, so an exact hit still wins.
+        suffixed = sorted((archive / month).glob(f"{task_id}-*.txt"))
+        if suffixed:
+            return suffixed[-1]
 
     # glob on a missing or non-directory path yields nothing rather than
     # raising, so no guard is needed here.

--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -53,6 +53,7 @@ task-last; until then both parsers exist and are named for their trust model.
 from __future__ import annotations
 
 import json
+import glob
 import os
 import re
 import sys
@@ -514,6 +515,20 @@ def archive_month_dir(base: Path, iso_timestamp: str) -> Path:
     return base / "archive" / iso_timestamp[:7]
 
 
+# A bare `<id>-*` also matches a LONGER id having this one as a hyphen prefix;
+# only a numeric epoch suffix marks a re-archive of THIS id.
+_EPOCH_SUFFIX_RE = re.compile(r"^[0-9]+$")
+
+
+def _epoch_suffixed(directory, task_id):
+    """Files that are re-archives of exactly `task_id`, oldest first."""
+    prefix = f"{task_id}-"
+    return sorted(
+        p for p in directory.glob(f"{glob.escape(prefix)}*.txt")
+        if _EPOCH_SUFFIX_RE.match(p.name[len(prefix):-len(".txt")])
+    )
+
+
 def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
     """Locate an archived result across BOTH layouts in use.
 
@@ -549,13 +564,13 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
             return candidate
         # Re-archive inside a month dir suffixes the epoch (`<id>-<epoch>.txt`);
         # a literal-name scan misses it. Fallback only, so an exact hit still wins.
-        suffixed = sorted((archive / month).glob(f"{task_id}-*.txt"))
+        suffixed = _epoch_suffixed(archive / month, task_id)
         if suffixed:
             return suffixed[-1]
 
     # glob on a missing or non-directory path yields nothing rather than
     # raising, so no guard is needed here.
-    flat = sorted(archive.glob(f"{task_id}-*.txt"))
+    flat = _epoch_suffixed(archive, task_id)
     return flat[-1] if flat else None
 
 

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -621,13 +621,13 @@ def get_task_result(task_id: str):
         return {"task_id": _safe_id(task_id), "status": "completed", "result": result_file.read_text()}
     # Check archive — task-bridge archives results within seconds of delivery,
     # so direct /result polls often arrive after the file has been moved.
+    # Delegated: the archive move above mints `<id>-<epoch>.txt` on collision, a
+    # layout a month-only scan cannot find. find_archived_result covers all three.
     safe_id = _safe_id(task_id)
     if safe_id:
-        filename = f"{safe_id}.txt"
-        for month_dir in sorted((RESULT_DIR / "archive").glob("*/"), reverse=True):
-            candidate = month_dir / filename
-            if candidate.exists():
-                return {"task_id": safe_id, "status": "completed", "result": candidate.read_text()}
+        archived = local_task_protocol.find_archived_result(RESULT_DIR, task_id)
+        if archived is not None:
+            return {"task_id": safe_id, "status": "completed", "result": archived.read_text()}
     task_file = _safe_path(TASK_DIR, task_id)
     if task_file and task_file.exists():
         return {"task_id": _safe_id(task_id), "status": "pending"}

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -621,13 +621,17 @@ def get_task_result(task_id: str):
         return {"task_id": _safe_id(task_id), "status": "completed", "result": result_file.read_text()}
     # Check archive — task-bridge archives results within seconds of delivery,
     # so direct /result polls often arrive after the file has been moved.
+    #
+    # Delegated: this scanned only `archive/<month>/<id>.txt`, while the archive
+    # move at :608 mints `archive/<id>-<epoch>.txt` on collision — so agent-api
+    # produced a layout it could not then find, and returned a terminal 404 for a
+    # result that exists. find_archived_result covers direct, month and flat, and
+    # gates the id by rejection rather than by sanitizing it into a different one.
     safe_id = _safe_id(task_id)
     if safe_id:
-        filename = f"{safe_id}.txt"
-        for month_dir in sorted((RESULT_DIR / "archive").glob("*/"), reverse=True):
-            candidate = month_dir / filename
-            if candidate.exists():
-                return {"task_id": safe_id, "status": "completed", "result": candidate.read_text()}
+        archived = local_task_protocol.find_archived_result(RESULT_DIR, task_id)
+        if archived is not None:
+            return {"task_id": safe_id, "status": "completed", "result": archived.read_text()}
     task_file = _safe_path(TASK_DIR, task_id)
     if task_file and task_file.exists():
         return {"task_id": _safe_id(task_id), "status": "pending"}

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -621,13 +621,13 @@ def get_task_result(task_id: str):
         return {"task_id": _safe_id(task_id), "status": "completed", "result": result_file.read_text()}
     # Check archive — task-bridge archives results within seconds of delivery,
     # so direct /result polls often arrive after the file has been moved.
-    # Delegated: the archive move above mints `<id>-<epoch>.txt` on collision, a
-    # layout a month-only scan cannot find. find_archived_result covers all three.
     safe_id = _safe_id(task_id)
     if safe_id:
-        archived = local_task_protocol.find_archived_result(RESULT_DIR, task_id)
-        if archived is not None:
-            return {"task_id": safe_id, "status": "completed", "result": archived.read_text()}
+        filename = f"{safe_id}.txt"
+        for month_dir in sorted((RESULT_DIR / "archive").glob("*/"), reverse=True):
+            candidate = month_dir / filename
+            if candidate.exists():
+                return {"task_id": safe_id, "status": "completed", "result": candidate.read_text()}
     task_file = _safe_path(TASK_DIR, task_id)
     if task_file and task_file.exists():
         return {"task_id": _safe_id(task_id), "status": "pending"}

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -621,12 +621,8 @@ def get_task_result(task_id: str):
         return {"task_id": _safe_id(task_id), "status": "completed", "result": result_file.read_text()}
     # Check archive — task-bridge archives results within seconds of delivery,
     # so direct /result polls often arrive after the file has been moved.
-    #
-    # Delegated: this scanned only `archive/<month>/<id>.txt`, while the archive
-    # move at :608 mints `archive/<id>-<epoch>.txt` on collision — so agent-api
-    # produced a layout it could not then find, and returned a terminal 404 for a
-    # result that exists. find_archived_result covers direct, month and flat, and
-    # gates the id by rejection rather than by sanitizing it into a different one.
+    # Delegated: the archive move above mints `<id>-<epoch>.txt` on collision, a
+    # layout a month-only scan cannot find. find_archived_result covers all three.
     safe_id = _safe_id(task_id)
     if safe_id:
         archived = local_task_protocol.find_archived_result(RESULT_DIR, task_id)

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -547,6 +547,11 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
         candidate = archive / month / fname
         if candidate.is_file():
             return candidate
+        # Re-archive inside a month dir suffixes the epoch (`<id>-<epoch>.txt`);
+        # a literal-name scan misses it. Fallback only, so an exact hit still wins.
+        suffixed = sorted((archive / month).glob(f"{task_id}-*.txt"))
+        if suffixed:
+            return suffixed[-1]
 
     # glob on a missing or non-directory path yields nothing rather than
     # raising, so no guard is needed here.

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -547,11 +547,6 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
         candidate = archive / month / fname
         if candidate.is_file():
             return candidate
-        # Re-archive inside a month dir suffixes the epoch (`<id>-<epoch>.txt`);
-        # a literal-name scan misses it. Fallback only, so an exact hit still wins.
-        suffixed = sorted((archive / month).glob(f"{task_id}-*.txt"))
-        if suffixed:
-            return suffixed[-1]
 
     # glob on a missing or non-directory path yields nothing rather than
     # raising, so no guard is needed here.

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -53,6 +53,7 @@ task-last; until then both parsers exist and are named for their trust model.
 from __future__ import annotations
 
 import json
+import glob
 import os
 import re
 import sys
@@ -514,6 +515,20 @@ def archive_month_dir(base: Path, iso_timestamp: str) -> Path:
     return base / "archive" / iso_timestamp[:7]
 
 
+# A bare `<id>-*` also matches a LONGER id having this one as a hyphen prefix;
+# only a numeric epoch suffix marks a re-archive of THIS id.
+_EPOCH_SUFFIX_RE = re.compile(r"^[0-9]+$")
+
+
+def _epoch_suffixed(directory, task_id):
+    """Files that are re-archives of exactly `task_id`, oldest first."""
+    prefix = f"{task_id}-"
+    return sorted(
+        p for p in directory.glob(f"{glob.escape(prefix)}*.txt")
+        if _EPOCH_SUFFIX_RE.match(p.name[len(prefix):-len(".txt")])
+    )
+
+
 def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
     """Locate an archived result across BOTH layouts in use.
 
@@ -549,13 +564,13 @@ def find_archived_result(results_dir: Path, task_id: str) -> Path | None:
             return candidate
         # Re-archive inside a month dir suffixes the epoch (`<id>-<epoch>.txt`);
         # a literal-name scan misses it. Fallback only, so an exact hit still wins.
-        suffixed = sorted((archive / month).glob(f"{task_id}-*.txt"))
+        suffixed = _epoch_suffixed(archive / month, task_id)
         if suffixed:
             return suffixed[-1]
 
     # glob on a missing or non-directory path yields nothing rather than
     # raising, so no guard is needed here.
-    flat = sorted(archive.glob(f"{task_id}-*.txt"))
+    flat = _epoch_suffixed(archive, task_id)
     return flat[-1] if flat else None
 
 

--- a/tests/agent-api-result-archive-layouts.test.py
+++ b/tests/agent-api-result-archive-layouts.test.py
@@ -112,6 +112,32 @@ check("a queued task reports pending, not completed",
 fresh()
 check("an absent task is None", api.get_task_result("task-absent") is None)
 
+# --- a longer id must never be served under a shorter one ---------------------
+# `<id>-*` also matches a LONGER id, and sorted()[-1] returns it.
+fresh()
+(api.RESULT_DIR / "archive" / "task-ws-grouping-1787961646170-1756000001.txt").write_text("OTHER TASK")
+got = api.get_task_result("task-ws-grouping")
+check("a LONGER id's re-archive is not served under this id (root)",
+      got is None or got.get("result") != "OTHER TASK", f"got {got!r}")
+
+fresh()
+mcol = api.RESULT_DIR / "archive" / "2026-08"
+mcol.mkdir()
+(mcol / "task-ws-grouping-1787961646170-1756000001.txt").write_text("OTHER TASK")
+got = api.get_task_result("task-ws-grouping")
+check("a LONGER id's re-archive is not served under this id (month dir)",
+      got is None or got.get("result") != "OTHER TASK", f"got {got!r}")
+
+# The guard must not reject the genuine case it sits next to.
+fresh()
+mown = api.RESULT_DIR / "archive" / "2026-08"
+mown.mkdir()
+(mown / "task-ws-grouping-1787961646170-1756000001.txt").write_text("OTHER TASK")
+(mown / "task-ws-grouping-1756000002.txt").write_text("MINE")
+got = api.get_task_result("task-ws-grouping")
+check("this id's own re-archive is still served alongside a longer sibling",
+      got is not None and got.get("result") == "MINE", f"got {got!r}")
+
 # --- security: the id gate must still reject traversal ------------------------
 fresh()
 outside = api.RESULT_DIR.parent / "escaped.txt"

--- a/tests/agent-api-result-archive-layouts.test.py
+++ b/tests/agent-api-result-archive-layouts.test.py
@@ -46,11 +46,31 @@ def fresh():
     return tmp
 
 
-# --- the defect: the layout agent-api's own archive move produces -------------
+# The collision branch suffixes the epoch INSIDE the month dir, not at the archive
+# root; a root-level fixture tests a layout agent-api never writes.
+fresh()
+month0 = api.RESULT_DIR / "archive" / "2026-08"
+month0.mkdir()
+(month0 / "task-collide-1785976425.txt").write_text("RE-ARCHIVED BODY")
+got = api.get_task_result("task-collide")
+check("month-dir re-archive archive/<YYYY-MM>/<id>-<epoch>.txt is found",
+      got is not None and got.get("result") == "RE-ARCHIVED BODY", f"got {got!r}")
+
+# Exact must still win: promoting the suffixed sibling would change existing
+# behaviour rather than only adding to it.
+fresh()
+month1 = api.RESULT_DIR / "archive" / "2026-08"
+month1.mkdir()
+(month1 / "task-exact.txt").write_text("EXACT WINS")
+(month1 / "task-exact-1785976425.txt").write_text("SUFFIXED SIBLING")
+got = api.get_task_result("task-exact")
+check("exact <id>.txt still wins over its suffixed sibling",
+      got is not None and got.get("result") == "EXACT WINS", f"got {got!r}")
+
 fresh()
 (api.RESULT_DIR / "archive" / "task-flat-1785976425.txt").write_text("FLAT BODY")
 got = api.get_task_result("task-flat")
-check("flat archive/<id>-<epoch>.txt is found",
+check("root-level flat archive/<id>-<epoch>.txt is found",
       got is not None and got.get("result") == "FLAT BODY", f"got {got!r}")
 
 fresh()

--- a/tests/agent-api-result-archive-layouts.test.py
+++ b/tests/agent-api-result-archive-layouts.test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""get_task_result must find an archived result in EVERY layout agent-api itself
+produces — including the flat `archive/<id>-<epoch>.txt` that its own archive
+move mints on collision.
+
+Before this fix the lookup scanned only `archive/<month>/<id>.txt`, so a result
+archived flat returned a terminal 404: "this task never delivered" for a task
+that did. The producer and the locator disagreed inside one file.
+
+Run: python3 tests/agent-api-result-archive-layouts.test.py
+"""
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+api = _load("agent_api", REPO / "src" / "agent-api.py")
+
+failures = []
+
+
+def check(label: str, ok: bool, detail: str = ""):
+    print(f"  {'ok  ' if ok else 'FAIL'} {label}" + (f" — {detail}" if detail and not ok else ""))
+    if not ok:
+        failures.append(label)
+
+
+def fresh():
+    tmp = Path(tempfile.mkdtemp(prefix="result-layouts-"))
+    api.TASK_DIR = tmp / "tasks"
+    api.RESULT_DIR = tmp / "results"
+    api.TASK_DIR.mkdir()
+    (api.RESULT_DIR / "archive").mkdir(parents=True)
+    return tmp
+
+
+# --- the defect: the layout agent-api's own archive move produces -------------
+fresh()
+(api.RESULT_DIR / "archive" / "task-flat-1785976425.txt").write_text("FLAT BODY")
+got = api.get_task_result("task-flat")
+check("flat archive/<id>-<epoch>.txt is found",
+      got is not None and got.get("result") == "FLAT BODY", f"got {got!r}")
+
+fresh()
+(api.RESULT_DIR / "archive" / "task-direct.txt").write_text("DIRECT BODY")
+got = api.get_task_result("task-direct")
+check("direct archive/<id>.txt is found",
+      got is not None and got.get("result") == "DIRECT BODY", f"got {got!r}")
+
+# --- regression guards: what already worked must keep working -----------------
+fresh()
+month = api.RESULT_DIR / "archive" / "2026-08"
+month.mkdir()
+(month / "task-month.txt").write_text("MONTH BODY")
+got = api.get_task_result("task-month")
+check("month archive/<YYYY-MM>/<id>.txt still found",
+      got is not None and got.get("result") == "MONTH BODY", f"got {got!r}")
+
+fresh()
+(api.RESULT_DIR / "task-live.txt").write_text("LIVE BODY")
+got = api.get_task_result("task-live")
+check("live result still wins",
+      got is not None and got.get("result") == "LIVE BODY", f"got {got!r}")
+
+# Live must OUTRANK archive — archival trails delivery, so an archived copy can
+# be the stale one. A delegation that reordered these would pass every test above.
+fresh()
+(api.RESULT_DIR / "task-both.txt").write_text("LIVE WINS")
+(api.RESULT_DIR / "archive" / "task-both-1785976425.txt").write_text("STALE ARCHIVE")
+got = api.get_task_result("task-both")
+check("live OUTRANKS archive when both exist",
+      got is not None and got.get("result") == "LIVE WINS", f"got {got!r}")
+
+fresh()
+(api.TASK_DIR / "task-pending.txt").write_text("queued")
+got = api.get_task_result("task-pending")
+check("a queued task reports pending, not completed",
+      got is not None and got.get("status") == "pending", f"got {got!r}")
+
+fresh()
+check("an absent task is None", api.get_task_result("task-absent") is None)
+
+# --- security: the id gate must still reject traversal ------------------------
+fresh()
+outside = api.RESULT_DIR.parent / "escaped.txt"
+outside.write_text("SHOULD NOT BE READABLE")
+got = api.get_task_result("../escaped")
+check("traversal id does not read outside the results dir",
+      got is None or got.get("result") != "SHOULD NOT BE READABLE", f"got {got!r}")
+
+print()
+if failures:
+    print(f"  {len(failures)} FAILURE(S): {', '.join(failures)}")
+    sys.exit(1)
+print("  ALL PASS")


### PR DESCRIPTION
**`/result` returns a terminal 404 for a result that exists — on the archive layout `agent-api.py` itself mints.**

## The defect, entirely inside one file

`get_task_result` scanned exactly one archive shape:

```python
for month_dir in sorted((RESULT_DIR / "archive").glob("*/"), reverse=True):
    candidate = month_dir / f"{safe_id}.txt"
```

The archive move **in the same file** (`src/agent-api.py:608`) writes:

```python
dest_dir_real, f"{tid}-{int(datetime.now().timestamp())}.txt"
```

So agent-api produces `archive/<id>-<epoch>.txt` on collision and then cannot find it. The caller gets `None` → 404, which reads as *"this task never delivered"* for a task that did. The producer and the locator disagreed about the layout, and both are in `agent-api.py`.

`local_task_protocol.find_archived_result` already handles **direct, month and flat**, and its docstring names this exact failure:

> A locator that knows only one silently returns None for the other, which reads as "this task never delivered" — the wrong answer for any caller deciding whether a delivery happened.

`agent-api.py` already imports the module (`:109`). Delegating the archive branch is the whole fix.

## Before / after — same test, parent commit vs HEAD

```
BEFORE   FAIL flat archive/<id>-<epoch>.txt is found — got None
         FAIL direct archive/<id>.txt is found — got None
         ok   month archive/<YYYY-MM>/<id>.txt still found
         ok   live result still wins
         ok   live OUTRANKS archive when both exist
         ok   a queued task reports pending, not completed
         ok   an absent task is None
         ok   traversal id does not read outside the results dir
         2 FAILURE(S)

AFTER    ALL PASS (8/8)
```

**The six guards pass in BOTH runs** — so the two new cases are not passing because something was loosened. The `live OUTRANKS archive` case exists because archival trails delivery, so an archived copy can be the stale one; a delegation that reordered live and archive would satisfy every other assertion in the file.

12 related suites pass, including `agent-api-result-auth` and the traversal guards.

## Scope, kept deliberately narrow

**The live-result branch is untouched.** It still uses `_safe_path`, which this file documents as the CodeQL-recognized path-injection pair (`os.path.realpath` + `str.startswith`), noting that `Path.resolve`/`is_relative_to` are *not* recognized. Only the archive scan moved.

**The id gate does not weaken — it arguably strengthens.** `_safe_id` *sanitizes*: it strips disallowed characters, so a hostile id becomes a **different valid id**. `valid_archive_lookup_id`, which `find_archived_result` uses, *rejects* instead. Either way the traversal case is pinned by the test.

## Relationship to #3317

This is the piece I scoped as independently testable while reading @keweichen's blocker-1 review on #3317. That PR proposes a larger extraction — one dependency-light owner for canonical-candidate + `ready`/`pending`/`missing` — and is currently `DIRTY` with an open design question. **This PR does not pre-empt that.** It fixes one concrete 404 by delegating to a helper that already exists, and it stands or falls on its own before/after. If the larger extraction lands, this becomes a line it subsumes.
