### PR TITLE
fix(config): the runtime-socket fallback cannot run, and returns nothing

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -506,7 +506,7 @@ sys.path.insert(0, os.path.join(os.environ["SUTANDO_CONFIG_REPO"], "src", "runti
 import rundir
 sys.stdout.write(rundir.socket_path())
 PY
-)"
+)" || _sock=""
       # Never hard-fail this helper: everything shells out to it.
       if [ -n "$_sock" ]; then printf '%s' "$_sock"
       else printf '%s/sutando-runtime.sock' "$(bash "$0" run-dir)"; fi

--- a/tests/runtime-socket-fallback.test.py
+++ b/tests/runtime-socket-fallback.test.py
@@ -11,6 +11,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -19,9 +20,13 @@ RUNDIR = REPO / "src" / "runtime-api" / "rundir.py"
 
 
 def runtime_socket(env=None):
+    """Hermetic: SUTANDO_RUNTIME_SOCKET returns BEFORE the branch under test, so
+    inheriting it makes both cases pass on the unfixed implementation."""
+    clean = {k: v for k, v in os.environ.items() if k != "SUTANDO_RUNTIME_SOCKET"}
+    clean["SUTANDO_PY"] = sys.executable
     p = subprocess.run(["bash", "scripts/sutando-config.sh", "runtime-socket"],
                        cwd=REPO, capture_output=True, text=True,
-                       env={**os.environ, **(env or {})})
+                       env={**clean, **(env or {})})
     return p.returncode, p.stdout.strip()
 
 
@@ -45,6 +50,31 @@ class FallbackIsReachable(unittest.TestCase):
                 shutil.move(str(stash), str(RUNDIR))
         self.assertEqual(rc, 0, "the helper hard-failed; callers get an empty path")
         self.assertTrue(out.endswith("sutando-runtime.sock"), out or "<empty>")
+
+
+
+class TheOverrideDoesNotHideTheBranch(unittest.TestCase):
+    """The precondition itself, pinned.
+
+    A reviewer showed both cases above passing against the unfixed parent when
+    SUTANDO_RUNTIME_SOCKET was set in the ambient environment.
+    """
+
+    def test_the_helper_still_honours_an_explicit_override(self):
+        rc, out = runtime_socket({"SUTANDO_RUNTIME_SOCKET": "/tmp/explicit.sock"})
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, "/tmp/explicit.sock")
+
+    def test_the_regression_case_runs_with_the_override_cleared(self):
+        os.environ["SUTANDO_RUNTIME_SOCKET"] = "/tmp/ambient-should-be-ignored.sock"
+        try:
+            rc, out = runtime_socket()
+            self.assertEqual(rc, 0)
+            self.assertNotEqual(out, "/tmp/ambient-should-be-ignored.sock",
+                                "the harness inherited the override; the branch under "
+                                "test was never reached")
+        finally:
+            os.environ.pop("SUTANDO_RUNTIME_SOCKET", None)
 
 
 if __name__ == "__main__":

--- a/tests/runtime-socket-fallback.test.py
+++ b/tests/runtime-socket-fallback.test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""The runtime-socket helper must not hard-fail when the delegate is unavailable.
+
+`sutando-config.sh` sets `set -euo pipefail`, so a failing command substitution
+terminates the script at the assignment and the fallback below it never runs —
+the branch whose comment says the helper must never hard-fail.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+RUNDIR = REPO / "src" / "runtime-api" / "rundir.py"
+
+
+def runtime_socket(env=None):
+    p = subprocess.run(["bash", "scripts/sutando-config.sh", "runtime-socket"],
+                       cwd=REPO, capture_output=True, text=True,
+                       env={**os.environ, **(env or {})})
+    return p.returncode, p.stdout.strip()
+
+
+class FallbackIsReachable(unittest.TestCase):
+    def test_it_answers_when_the_delegate_is_present(self):
+        rc, out = runtime_socket()
+        self.assertEqual(rc, 0)
+        self.assertTrue(out.endswith("sutando-runtime.sock"), out)
+
+    def test_it_still_answers_when_the_delegate_is_missing(self):
+        # The regression: errexit killed the script at the assignment, so this
+        # returned rc=1 and zero bytes to every caller that shells out to it.
+        if not RUNDIR.exists():
+            self.skipTest("rundir.py absent in this checkout")
+        with tempfile.TemporaryDirectory() as td:
+            stash = pathlib.Path(td) / "rundir.py"
+            shutil.move(str(RUNDIR), str(stash))
+            try:
+                rc, out = runtime_socket()
+            finally:
+                shutil.move(str(stash), str(RUNDIR))
+        self.assertEqual(rc, 0, "the helper hard-failed; callers get an empty path")
+        self.assertTrue(out.endswith("sutando-runtime.sock"), out or "<empty>")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up to #3520, which merged with this finding open. Raised there first and offered rather than assumed; opening it because the defect is live on `main` and the fix is one line — a PR is cheaper to decline than a question is to answer.

## The defect

#3520 delegated the socket rule to `rundir` and kept a fallback for when that delegation fails. Its own comment states the requirement:

> Never hard-fail this helper: everything shells out to it.

`set -euo pipefail` sits near the top of the same file, so the failing command substitution terminates the script **at the assignment** and the `else` branch below is unreachable.

## Measured on origin/main, not argued

With `src/runtime-api/rundir.py` moved aside:

```
origin/main   rc=1   stdout=''                        (0 bytes)
this branch   rc=0   stdout='<run>/sutando-runtime.sock'
```

Before #3520 the same condition returned the correct path, so this is a **regression in the failure path**, not a pre-existing gap. Any caller doing `SOCK="$(bash scripts/sutando-config.sh runtime-socket)"` gets an empty string and a non-zero code it may or may not check.

## The fix

Move the guard outside the substitution so errexit sees a successful list:

```sh
_sock="$( … )" || _sock=""
```

`|| true` **inside** the substitution does not parse — `syntax error near unexpected token '||'` — so if that shape looked equivalent, it is not. I tried it first.

## Controls

| | delegate present | delegate absent |
|---|---|---|
| `origin/main` | rc=0, correct path | **rc=1, empty** |
| this branch | rc=0, correct path | rc=0, correct path |

`tests/runtime-socket-fallback.test.py` pins both directions and **fails against main's version** — the absent-delegate case returns rc=1 there.

`tests/sutando-config.test.py` and `tests/workspace-default.test.py` pass unchanged. `review-checks.sh` PASS, run from inside the worktree against `origin/main...HEAD` so prose-cap actually executes rather than skipping.

## Note on scope

This does not revisit the design question I raised alongside it — that a working fallback is still a silent second copy of the rule #3520 exists to remove, and could say so on stderr when it fires. That is a separate change and not bundled here.

Stand: Echo Act IV Mini
