### PR TITLE
fix(outbox-race): scale workers to cores, so contention is a ratio not a constant

### DIFF
--- a/tests/outbox-race.test.py
+++ b/tests/outbox-race.test.py
@@ -32,7 +32,9 @@ def plant_stale_claim(root, item):
     }, sort_keys=True), encoding="utf-8")
 
 if __name__ == "__main__":
-    N, rounds = 24, 12
+    # Contention is workers-per-core, not an absolute: a fixed 24 is 12x
+    # oversubscribed on a 2-core runner, and the thrash is what timed out.
+    N, rounds = max(8, (os.cpu_count() or 2) * 3), 12
     totals = []
     # ONE warm pool here too, for the reason phase 2 already states: a fresh pool
     # per round pays process startup inside the window under test.


### PR DESCRIPTION
Removes the `outbox-race` instrumentation timeout that has been failing branches unrelated to it. Follow-up to #3523, which reduced the cost and did not eliminate it.

## The cause

`N = 24` is a fixed process count meeting a variable machine. This box has 10 cores; `ubuntu-latest` has 2. Twenty-four processes on two cores under coverage instrumentation is mostly scheduler thrash — and the thrash is what crosses `coverage-gate`'s 120s cap. **The assertions passed every time it timed out.**

It is not confined to this file. `coverage-gate` refuses to compute when the suite is red, so the failure surfaces as `diff coverage >= 95% (python)` on branches nowhere near this test. It hit #3509 tonight, and #3523's own head after the warm-pool change was already in.

## Measured before choosing a number

The test's job is contention, so the question is whether fewer workers still catch a broken claim. With `O_EXCL` removed from `src/outbox.py`:

| N | mutant detected |
|---|---|
| 4 | yes |
| 6 | yes |
| 8 | yes |
| 12 | yes |

Detection does not depend on 24. Cost does — instrumented, N=8 runs in **0.34s** against **0.73s** at N=24 on this machine, and the saving is proportionally larger where cores are scarce.

## The change

`max(8, cpu_count * 3)` keeps the property the test actually needs — more workers than cores — at every machine size:

- 2 cores → 8 (still 4× oversubscribed)
- 4 cores → 12
- 10 cores → 30 (slightly more contention than today)

## Controls at HEAD

- passes normally
- the `O_EXCL` mutant fails all 12 rounds
- forcing the 2-core value gives **0.36s** instrumented with exclusion still holding

`review-checks.sh` PASS, run from inside the worktree against `origin/main...HEAD` so prose-cap executes rather than skipping.

## What this does not claim

It does not make the test immune to a loaded runner; it removes the 12× oversubscription that made a timeout likely. If it recurs after this, the next lever is `rounds`, not `N` — and I would want the measurement before touching it.

Stand: Echo Act IV Mini
