### PR TITLE
fix(test): instance-registry env-dump readiness flips before the file has content

### DIFF
--- a/tests/runtime-api-instance-registry.test.py
+++ b/tests/runtime-api-instance-registry.test.py
@@ -184,16 +184,21 @@ class InstanceRegistryTests(unittest.TestCase):
         envdump = Path(self.tmp.name) / "env.txt"
         import stat as _stat
         launcher = Path(self.tmp.name) / "dump-env"
-        launcher.write_text("#!/bin/sh\nenv > \"%s\"\n" % envdump)
+        # Atomic: the readiness predicate below is exists(), and a bare `>` creates
+        # the file EMPTY before env writes, so a rename is what makes existence imply content.
+        launcher.write_text('#!/bin/sh\nenv > "%s.part" && mv "%s.part" "%s"\n'
+                            % (envdump, envdump, envdump))
         launcher.chmod(launcher.stat().st_mode | _stat.S_IXUSR)
         reg.write_manifest("q-1", endpoint=str(sock), instance="q-1",
                            tmux_socket="/run/q-1/tmux.sock", session="core-q1",
                            config_dir="/cfg/q-1",
                            launcher={"type": "process", "executable": str(launcher),
                                      "args": [], "working_directory": self.tmp.name})
-        # readiness true once the env dump exists
+        # readiness true once the env dump has CONTENT — exists() alone flips
+        # the instant the shell opens the file, before a byte is written.
         reg.start_instance("q-1", wait_s=5, instance="q-1",
-                           _ready=lambda m: {"attachable": envdump.exists()})
+                           _ready=lambda m: {"attachable": envdump.exists()
+                                            and envdump.stat().st_size > 0})
         text = envdump.read_text()
         self.assertIn("SUTANDO_INSTANCE_ID=q-1", text)
         self.assertIn("SUTANDO_TMUX_SOCKET=/run/q-1/tmux.sock", text)


### PR DESCRIPTION
## What breaks

`test_start_injects_instance_env_from_manifest` polls **`envdump.exists()`** as its readiness signal, then reads the file and asserts a marker is in it:

```python
launcher.write_text('#!/bin/sh\nenv > "%s"\n' % envdump)
reg.start_instance(..., _ready=lambda m: {"attachable": envdump.exists()})
text = envdump.read_text()
self.assertIn("SUTANDO_INSTANCE_ID=q-1", text)
```

A shell redirect **creates the file empty before `env` writes a byte**. So `exists()` is true strictly earlier than the invariant the test then depends on, and the read can legitimately return `''`.

## Observed, not theorised

Failing on CI right now at `9597b3fc` — **sonichi#3499, a dashboard PR that touches none of this code**:

```
FAIL: test_start_injects_instance_env_from_manifest
  File "tests/runtime-api-instance-registry.test.py", line 198
    self.assertIn("SUTANDO_INSTANCE_ID=q-1", text)
AssertionError: 'SUTANDO_INSTANCE_ID=q-1' not found in ''
```

The empty string is the whole story. And the blast radius is wider than one test, because `coverage-gate` refuses to compute on a red suite:

```
coverage-gate: suite must be green before coverage is meaningful.
##[error]Process completed with exit code 1.
```

so it surfaces as **`diff coverage >= 95% (python)`** on a branch nowhere near the defect. #3499 currently reads as a coverage failure and is not one.

## Why it usually passes

Polling the create/read pair tightly, outside the test:

```
readiness = exists()                 -> EMPTY on read in 200 of 200 runs
readiness = exists(), atomic rename  -> EMPTY on read in   0 of 200 runs
```

The test survives in practice only because `start_instance`'s poll interval usually lets `env` finish first. A loaded 2-core runner is what lands in the gap — it is not rare, it is scheduling.

## Scope correction (@bassilkhilo-ag2)

**This is test-fixture hygiene, not a production race.** Both changes live entirely inside the test's own fixture — the inline mock launcher and the inline `_ready` lambda. Production's real `attachable()` checks socket/RPC/health and nothing about file existence-vs-content. "Readiness race" is easy to misread as a runtime finding; it is not one.

## The fix — one concern: readiness must imply the content the test reads

1. **The launcher writes to `.part` and renames.** A rename inside one directory is atomic, so existence *implies* completeness rather than coinciding with it. **This is the fix.**
2. **`_ready` requires `st_size > 0`.** The belt: it keeps the predicate safe if someone later replaces the launcher with a non-atomic one.

**I had these labels backwards, and both reviewers independently corrected me.** `size > 0` means non-empty, not complete — it is sufficient here only because `env` output fits one stdio write. Measured: **2612 bytes** on this host, **2890** on @qingyun-air's, against a 4096 `st_blksize`. That is ~1.2 KB of headroom, and a GitHub Actions runner injects a large `GITHUB_*`/`RUNNER_*` block on top of the base environment — so the guard's sufficiency is a property of the machine the test happens to run on, and CI is the machine I control least.

@bassilkhilo-ag2 built the case that settles it: a launcher writing in **two** calls instead of one shot. Reproduced here:

```
size>0 guard alone, MULTI-write producer : readiness flipped on INCOMPLETE content 30 of 30
with atomic rename,  MULTI-write producer: readiness flipped on INCOMPLETE content  0 of 30
```

Building output incrementally is a completely normal thing for a launcher to do, so the guard-alone version breaks the same way the original bug did.

## Evidence — a deterministic control, not a flake hunt

Rather than re-running until it flakes, the gap CI hits is forced: a launcher that creates the file, sleeps 0.4s, then fills it.

```
CONTROL 0  baseline, unmodified                              32 tests  OK
M1  forced gap + non-atomic launcher, WITH size>0 guard      32 tests  OK      <- guard alone fixes it
M2  same forced gap, readiness back to exists() only         FAILED (1)
      AssertionError: 'SUTANDO_INSTANCE_ID=q-1' not found in ''    <- byte-identical to CI
CONTROL 3  restored                                          32 tests  OK
```

M2 reproduces the CI failure exactly.

**What this control CANNOT see, which @qingyun-air identified and I would have left implicit:** the forced-gap launcher creates the file, sleeps, then fills it — so it generates **EMPTY → COMPLETE and never PARTIAL**. M1 passing is therefore evidence about the empty case only; it *could not* have failed on the partial case regardless of the fix. That is not a flaw in the change, it is a limit on what the control certifies, and a reader would otherwise assume it covered both. The partial case is covered by the 30/30 table above instead.

`scripts/review-checks.sh --diff` PASS on the full `origin/main...HEAD` diff. (It first refused an empty diff with `ERROR — empty diff; nothing was scanned, so this is NOT a pass` because I generated the diff before committing. A gate that fails closed on no input is the right design and it caught my ordering mistake.)

## Scope

`+8 −3`, one test file. No production code. No other test touches `envdump`, and the suite's other 31 cases are unaffected in every row above.

