### PR TITLE
test(runtime-api): readiness must mean the env dump is written, not created

### DIFF
--- a/tests/runtime-api-instance-registry.test.py
+++ b/tests/runtime-api-instance-registry.test.py
@@ -184,14 +184,18 @@ class InstanceRegistryTests(unittest.TestCase):
         envdump = Path(self.tmp.name) / "env.txt"
         import stat as _stat
         launcher = Path(self.tmp.name) / "dump-env"
-        launcher.write_text("#!/bin/sh\nenv > \"%s\"\n" % envdump)
+        # write to a temp path and rename: `> envdump` would truncate the file
+        # into existence before `env` writes, so readiness could read it empty
+        launcher.write_text("#!/bin/sh\nenv > \"%s\" && mv \"%s\" \"%s\"\n"
+                            % (envdump.with_suffix(".part"),
+                               envdump.with_suffix(".part"), envdump))
         launcher.chmod(launcher.stat().st_mode | _stat.S_IXUSR)
         reg.write_manifest("q-1", endpoint=str(sock), instance="q-1",
                            tmux_socket="/run/q-1/tmux.sock", session="core-q1",
                            config_dir="/cfg/q-1",
                            launcher={"type": "process", "executable": str(launcher),
                                      "args": [], "working_directory": self.tmp.name})
-        # readiness true once the env dump exists
+        # readiness true once the COMPLETE env dump has been renamed into place
         reg.start_instance("q-1", wait_s=5, instance="q-1",
                            _ready=lambda m: {"attachable": envdump.exists()})
         text = envdump.read_text()


### PR DESCRIPTION
## The failure

`tests/runtime-api-instance-registry.test.py` fails intermittently in CI, surfacing under whichever job runs the Python suite. Observed on PR #3499 — a dashboard-only diff that cannot reach or import this file:

```
File "tests/runtime-api-instance-registry.test.py", line 198,
  in test_start_injects_instance_env_from_manifest
    self.assertIn("SUTANDO_INSTANCE_ID=q-1", text)
AssertionError: 'SUTANDO_INSTANCE_ID=q-1' not found in ''
```

The read returns an **empty string**, not wrong content.

## Mechanism

The test's launcher is `#!/bin/sh\nenv > "$envdump"` and readiness is `_ready=lambda m: {"attachable": envdump.exists()}`.

`sh` opens and truncates `envdump` **before** forking `env`, and `env` buffers its output into a single write at exit. So the path exists and is empty for the entire lifetime of the child. `start_instance` polls `_ready` every 0.3s and returns correctly the moment it reports attachable — the defect is in the test's readiness predicate, not in `start_instance`.

## The change

One file. The launcher writes to a temp path and renames:

```sh
env > "$envdump.part" && mv "$envdump.part" "$envdump"
```

Rename is atomic on the same filesystem, so the readiness path can only appear once the content is whole — readiness means "the content is there" by construction.

`st_size > 0` was considered and rejected: it still admits a partial write, since a launcher whose output crossed a stdio flush boundary would satisfy it mid-write. No sleep was added; a sleep converts a race into a slow race.

## Evidence

The natural failure is timing-dependent, so the control injects the delay deterministically — same file-creation timing, content delayed:

```
before (origin/main)   AssertionError: 'SUTANDO_INSTANCE_ID=q-1' not found in ''
after                  Ran 1 test — OK
```

The "before" line is byte-identical to the CI failure above. Also passes at a 4x-harder 2.0s delay.

**10 consecutive runs of the file at this change: 10 pass, 0 fail.** Passes under `/usr/bin/python3` (3.9.6) as well as 3.12.

Every other importer of `instance_registry` passes: `runtime-attach-open`, `runtime-cli-surface`, `state-paths-adoption`, `runtime-api-restore-identity`, `runtime-api-instance-key-fs`, `runtime-tui-reference-client`.

`scripts/review-checks.sh --diff` → PASS.

## Scope

**One sibling was checked and deliberately left alone.** `test_start_waits_for_attachable_then_marks_running` also gates on `marker.exists()`, but its launcher is `touch` — the marker has no content, existence *is* the complete signal, and nothing reads the file afterwards. A repo-wide grep found no other `_ready` probe gated on path existence.

Assertions are unchanged; no production code is touched.

## Honest limit

The before/after comes from the injected-delay harness, a deterministic stand-in for CI timing — not a natural intermittent failure captured at `origin/main`. The mechanism above is what ties the two together.

Stand: Echo Act IV Mini
