### PR TITLE
fix(review-preflight): resolve the repo explicitly; remote inference is the last resort

### DIFF
--- a/scripts/review-preflight.py
+++ b/scripts/review-preflight.py
@@ -22,6 +22,7 @@ and succeeds is the failure mode this exists to prevent.
 from __future__ import annotations
 
 import argparse
+import os
 import json
 import re
 import subprocess
@@ -88,7 +89,20 @@ def count_check_patterns(checks_section: str) -> "tuple[int, int]":
     return counts["flag"], counts["allow"]
 
 
-def prior_art(pr: str, runner=None) -> "list[str] | None":
+def resolve_repo(explicit: "str | None" = None, env: "dict | None" = None) -> str:
+    """`--repo` > $SUTANDO_REVIEW_REPO > gh's `{owner}/{repo}` remote inference.
+
+    Remote inference is LAST, not only: an app-pinned install has no `.git`, so
+    `{owner}/{repo}` cannot resolve and the prior-art check silently degrades on
+    every run. A hardcoded repo would fix that host and break every fork.
+    """
+    if explicit:
+        return explicit
+    environ = os.environ if env is None else env
+    return environ.get("SUTANDO_REVIEW_REPO") or "{owner}/{repo}"
+
+
+def prior_art(pr: str, runner=None, repo: "str | None" = None) -> "list[str] | None":
     """Reviews and non-COMMENTED activity already on the PR, oldest first.
 
     None means COULD NOT CHECK, which is not the same as "nothing there" — a
@@ -102,7 +116,7 @@ def prior_art(pr: str, runner=None) -> "list[str] | None":
             ("review", f"pulls/{pr}/reviews", "submitted_at", "state"),
             ("comment", f"issues/{pr}/comments", "created_at", None)):
         try:
-            r = run(["gh", "api", "repos/{owner}/{repo}/" + path, "--paginate"])
+            r = run(["gh", "api", f"repos/{resolve_repo(repo)}/" + path, "--paginate"])
         except (OSError, subprocess.SubprocessError):
             return None
         if r.returncode != 0:
@@ -145,14 +159,14 @@ def prior_art_block(pr: str, seen: "list[str] | None") -> "list[str]":
             + [f"  {line}" for line in seen[-PRIOR_ART_SHOWN:]])
 
 
-def render(guide: Path, pr: str | None) -> str:
+def render(guide: Path, pr: str | None, repo: "str | None" = None) -> str:
     text = guide.read_text(encoding="utf-8", errors="replace")
     lessons = extract_section(text, LESSONS_HEADING)
     checks = extract_section(text, CHECKS_HEADING)
     out = [f"review-preflight: criteria from {guide}", ""]
     if pr:
         out += [f"Reviewing PR #{pr}. Every lesson below is a criterion, not a suggestion.", ""]
-        out += prior_art_block(pr, prior_art(pr)) + [""]
+        out += prior_art_block(pr, prior_art(pr, repo=repo)) + [""]
     out.append(lessons if lessons else
                "WARNING: no '## Lessons' section found — the guide's criteria could not be read.")
     n_flag, n_allow = count_check_patterns(checks)
@@ -169,6 +183,8 @@ def main(argv: "list[str] | None" = None) -> int:
     ap = argparse.ArgumentParser(description="Print review criteria before reviewing a PR.")
     ap.add_argument("pr", nargs="?", help="PR number, for the header line only")
     ap.add_argument("--guide", help="path to the review guide (default <repo>/REVIEW.md)")
+    ap.add_argument("--repo", help="owner/name for the prior-art lookup; "
+                    "defaults to $SUTANDO_REVIEW_REPO, then the git remote")
     args = ap.parse_args(argv)
 
     guide = resolve_guide(args.guide)
@@ -176,7 +192,7 @@ def main(argv: "list[str] | None" = None) -> int:
         print(f"review-preflight: guide not found at {guide}", file=sys.stderr)
         return 1
     try:
-        print(render(guide, args.pr))
+        print(render(guide, args.pr, args.repo))
     except OSError as exc:
         print(f"review-preflight: cannot read {guide}: {exc}", file=sys.stderr)
         return 1

--- a/tests/review-preflight.test.py
+++ b/tests/review-preflight.test.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import tempfile
+import types
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -247,6 +248,43 @@ class PriorArtTest(unittest.TestCase):
         head = pf.prior_art_block("1", few)[0]
         self.assertIn(f"({pf.PRIOR_ART_SHOWN})", head)
         self.assertNotIn("showing last", head)
+
+
+class RepoResolution(unittest.TestCase):
+    """`{owner}/{repo}` is gh's REMOTE inference; an app-pinned install has no
+    `.git`, so it resolved to nothing and prior-art degraded on every run."""
+
+    def test_explicit_repo_wins(self):
+        self.assertEqual(pf.resolve_repo("a/b", env={"SUTANDO_REVIEW_REPO": "c/d"}), "a/b")
+
+    def test_env_is_used_when_no_flag(self):
+        self.assertEqual(pf.resolve_repo(None, env={"SUTANDO_REVIEW_REPO": "c/d"}), "c/d")
+
+    def test_remote_inference_is_the_LAST_resort_not_the_only_one(self):
+        self.assertEqual(pf.resolve_repo(None, env={}), "{owner}/{repo}")
+
+    def test_the_resolved_repo_reaches_the_gh_call(self):
+        seen = []
+
+        def run(argv):
+            seen.append(argv)
+            return types.SimpleNamespace(returncode=0, stdout="[]")
+
+        pf.prior_art("1", runner=run, repo="a/b")
+        self.assertTrue(seen, "no gh call was made")
+        self.assertTrue(any("repos/a/b/" in x for x in seen[0]), seen[0])
+        self.assertFalse(any("{owner}/{repo}" in x for x in seen[0]), seen[0])
+
+    def test_COULD_NOT_CHECK_is_still_reachable(self):
+        """The tell that this fix works is not that the check passes — it is
+        that the caveat still fires. A resolution fix that makes it unreachable
+        has replaced one silent failure with another."""
+
+        def failing(argv):
+            return types.SimpleNamespace(returncode=1, stdout="")
+
+        self.assertIsNone(pf.prior_art("1", runner=failing, repo="a/b"))
+        self.assertIn("COULD NOT CHECK", "\n".join(pf.prior_art_block("1", None)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Found by @sutando-rui. Filed by me at their explicit request — their quota tier is LIGHT and excludes self-development tonight, and *"finding it does not reserve it; a defect live since install should not wait on whoever happened to notice."*

## What breaks

`prior_art()` calls gh with the literal `repos/{owner}/{repo}/`, which is gh's **remote inference**. An app-pinned engine install carries no `.git`:

```
$ git rev-parse --is-inside-work-tree
fatal: not a git repository (or any of the parent directories): .git

$ python3 scripts/review-preflight.py 3530
ALREADY ON THIS THREAD: *** COULD NOT CHECK *** — gh is unavailable or the call failed
```

**So the prior-art dedup has never once run on that install class.** And the failure mode is the nastier kind: it degrades *honestly* and it degrades **every time**, so the honesty is invisible — a caveat that fires on 100% of runs is indistinguishable from a header.

The cost is concrete. With the repo resolved, **#3530 showed 11 items** that a reviewer on this host was never shown — and the denominator matters, because the block merges two endpoints on purpose:

```
pulls/<pr>/reviews        6      <- the reviews endpoint alone
issues/<pr>/comments      6
merged, non-COMMENTED    12      <- what prior_art actually assembles (11 when first measured)
```

About half of it is unreachable from the reviews endpoint alone, which is the block's own stated reason for querying both: *"an issue comment is not in the review list, and a COMMENTED review's body is not in the comments list."* A bare count here would have been the wrong shape — thanks to @qingyun-air for measuring 5 against my 11 and making the difference visible.

## The fix, and the constraint that shapes it

@sutando-rui's design note, which I took verbatim: hardcoding `--repo sonichi/sutando` would fix this host and **break every fork and developer clone that legitimately has a remote**. The script has to work in both worlds.

```
--repo <owner/name>          explicit
$SUTANDO_REVIEW_REPO         env override
{owner}/{repo}               remote inference — LAST, not only
```

## Evidence

```
A  --repo, from a non-git dir        ALREADY ON THIS THREAD — showing last 8 of 11
B  $SUTANDO_REVIEW_REPO, same dir    ALREADY ON THIS THREAD — showing last 8 of 11
C  neither, no remote                ALREADY ON THIS THREAD: *** COULD NOT CHECK ***
```

**C is the control that matters, and it is rui's:**

> *The tell that the fix works is not that the check passes; it is that the COULD NOT CHECK branch still fires when it should. A repo-resolution fix that makes the caveat unreachable has replaced one silent failure with another.*

That is pinned as `test_COULD_NOT_CHECK_is_still_reachable`, asserting both that `prior_art` returns `None` on a failing call and that the rendered block still says it.

Five cases added (17 → 22), and mutation controls:

```
CONTROL 0  baseline                                       22 tests  OK
M1  ignore --repo (revert to old behaviour)               FAILED (2)
M2  hardcode the repo (rui's fork-breaking case)          FAILED (1)
CONTROL 3  restored                                       22 tests  OK
```

M2 exists because the obvious fix is the one that would have shipped without their note — a test that only checks "this host now works" passes on a hardcode.

`scripts/review-checks.sh --diff` PASS on the full `origin/main` diff.

## Scope

`+45 −4` across the script and its test. No output format changes, no new dependency; `prior_art`'s existing `runner=` seam is what makes the mutation controls cheap. Behaviour in a normal checkout is unchanged — remote inference is still what happens when nothing else is set.

