### PR TITLE
docs(review-preflight): name the load-bearing branch order in prior_art_block

### DIFF
--- a/scripts/review-preflight.py
+++ b/scripts/review-preflight.py
@@ -128,6 +128,8 @@ PRIOR_ART_SHOWN = 8
 
 def prior_art_block(pr: str, seen: "list[str] | None") -> "list[str]":
     """Render prior art so "nothing there" can never read as "unchecked"."""
+    # Order is load-bearing: None is falsy, so a truthiness test first would
+    # render COULD NOT CHECK as "nothing" — silently, and identically to a clean thread.
     if seen is None:
         return ["ALREADY ON THIS THREAD: *** COULD NOT CHECK *** — gh is unavailable or",
                 "the call failed. Read the thread yourself: an unchecked thread is not an",


### PR DESCRIPTION
## What

Two comment lines above `prior_art_block`'s first branch, naming why the branch order cannot be changed. No behavior change.

```python
    """Render prior art so "nothing there" can never read as "unchecked"."""
+   # Order is load-bearing: None is falsy, so a truthiness test first would
+   # render COULD NOT CHECK as "nothing" — silently, and identically to a clean thread.
    if seen is None:
```

## Why

`prior_art_block` distinguishes three states — could-not-check, nothing-there, and a list. The first two are separated only by **which branch runs first**:

```python
if seen is None:   # identity FIRST
    ... "*** COULD NOT CHECK ***" ...
if not seen:       # truthiness SECOND
    ... "nothing — no reviews or comments yet." ...
```

`None` is falsy. Swap those two early-returns and the unknown case falls into the empty branch, so a failed `gh` call renders as **"nothing — no reviews or comments yet"** — byte-identical to a genuinely clean thread, with nothing raised and nothing logged. A reviewer is then told there is no prior art on a PR that may have a dozen findings on it.

The invariant is already pinned by a test. This PR does not change that and is not a fix — it is a note for the person editing the function, who is reading the function and not the test. Reordering two adjacent early-returns is the shape of edit a linter suggests and a reviewer skims.

## Evidence

Measured on this branch's base (`origin/main`), mutating the source and restoring:

```
baseline                                          17 tests OK
M5: swap the two branches (truthiness first)      FAILED (1)
      test_unknown_is_not_empty
      assertIn("COULD NOT CHECK", unknown)
      AssertionError: 'COULD NOT CHECK' not found in
        'ALREADY ON THIS THREAD: nothing — no reviews or comments yet.'
restored                                          17 tests OK
```

So the invariant holds on main by exactly **one** assertion, and the failure message above is the concrete rendering the comment warns about.

Related, measured on #3538's head (`73f8554e`, which adds 5 tests to this file) for contrast — the same edit in the *other* direction is the harmless one:

```
M4: collapse `if seen is None:` into `if not seen:`   FAILED (1)  -> everything renders COULD NOT CHECK (loud, self-announcing)
M5: swap, truthiness first                            FAILED (2)  -> unknown renders as nothing (silent)
```

Same one-line edit class, opposite blast radius. Both are caught today; only M5 is the one you would never hear about if the assertion that catches it were lost.

## Scope / sibling

Touches `scripts/review-preflight.py`, the same file as **#3538** (repo resolution), but a **different function** — #3538 changes `resolve_repo` and `prior_art`, this changes only the comment above `prior_art_block`. No textual overlap; either merge order works and neither needs a rebase of the other. Kept separate rather than folded into #3538 because that PR's concern is repo resolution.

The honest version of why that needed deciding: my first instinct was to push these two lines onto #3538, *because* that was the cheapest moment to absorb the re-approval cost — the diff was open, one approval deep, and two more reviewers had just been asked. The cost reasoning was correct and it was answering the wrong question. Scope is not decided by when it is cheapest to bundle, and **bundling pressure is strongest at exactly the moment a diff is open and approved, which is the moment scope discipline is worth most** (a reviewer's phrasing, kept because it states the mechanism better than the rule does).

Credit: the gap was named by a reviewer on #3538 — the test pins the order, nothing in the function tells the next person.

