### PR TITLE
fix(tests): scope the cc assertions to the message, not the whole argv

### DIFF
--- a/tests/notify-reviewers-human-shapes.test.py
+++ b/tests/notify-reviewers-human-shapes.test.py
@@ -33,25 +33,32 @@ class HumanShapeTests(unittest.TestCase):
             {"name": "x", "stand": "@stand:ag2.space", "room": "!r:ag2.space",
              "human": human}, "body")
 
+    @staticmethod
+    def _body(cmd):
+        """The message argument. Asserting over the joined argv puts the repo path
+        in the subject, so a checkout under /tmp/tmp.jrjxccG0z6 fails on "cc"."""
+        return cmd[-2]
+
     def test_dict_human_does_not_raise(self):
         """The defect: a structured human record crashed the send."""
         self._cmd({"discord": "123", "username": "someone"})
 
     def test_dict_human_is_not_ccd(self):
         """A dict has no room-addressable handle -- skip it, never stringify it."""
-        self.assertNotIn("cc", " ".join(self._cmd({"discord": "123"})))
+        self.assertEqual(self._body(self._cmd({"discord": "123"})), "body")
 
     def test_string_human_is_still_ccd(self):
-        self.assertIn("(cc @who:ag2.space)", " ".join(self._cmd("@who:ag2.space")))
+        self.assertEqual(self._body(self._cmd("@who:ag2.space")),
+                         "body (cc @who:ag2.space)")
 
     def test_string_human_not_duplicated_when_already_present(self):
         cmd = self.mod.command_for(
             {"name": "x", "stand": "@s:ag2.space", "room": "!r:ag2.space",
              "human": "@who:ag2.space"}, "hi @who:ag2.space")
-        self.assertEqual(" ".join(cmd).count("@who:ag2.space"), 1)
+        self.assertEqual(self._body(cmd).count("@who:ag2.space"), 1)
 
     def test_missing_human_is_fine(self):
-        self.assertNotIn("cc", " ".join(self._cmd(None)))
+        self.assertEqual(self._body(self._cmd(None)), "body")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

`tests/notify-reviewers-human-shapes.test.py` fails at random on CI, with nothing wrong in the code under test.

```python
self.assertNotIn("cc", " ".join(self._cmd(None)))
```

`command_for` returns **argv**, so `" ".join(...)` includes the interpreter path and the absolute repo path. CI checks out under `mktemp -d`. When the temp directory happens to contain the letters `cc`, the assertion fires:

```
AssertionError: 'cc' unexpectedly found in
'/usr/bin/python3 /tmp/tmp.jrjxccG0z6/2/skills/agent-room-ops/room_ops.py mention @stand:ag2.space body !r:ag2.space'
                       ^^
```

`tmp.jrjxccG0z6`. That is the entire failure — the assertion's subject contains the checkout path, and the checkout path is random.

Observed on the `python standalone tests` job of https://github.com/sonichi/sutando/actions/runs/33241513096 (`FAILED (failures=2)`), while `main` at the same source sha was green — because that run drew a temp name without `cc` in it. Nothing distinguishes the two runs but the dice.

## Reproduction at the parent commit

Deterministic, no luck required — check `origin/main` (288c9512) out under a path containing `cc`:

```
$ git archive origin/main | tar -x -C .../scratchpad/xccy && cd .../xccy
$ python3 tests/notify-reviewers-human-shapes.test.py
FAIL: test_dict_human_is_not_ccd
FAIL: test_missing_human_is_fine
AssertionError: 'cc' unexpectedly found in '... /scratchpad/xccy/skills/agent-room-ops/room_ops.py ...'
Ran 5 tests in 0.004s
FAILED (failures=2)
```

Same two tests, same assertion, same mechanism as CI.

## The fix

The subject was never the command line — it is the **message argument**. Scope the assertions to it, and use equality, which pins the contract exactly rather than probing it with a substring:

```python
@staticmethod
def _body(cmd):
    """The message argument. Asserting over the joined argv puts the repo path
    in the subject, so a checkout under /tmp/tmp.jrjxccG0z6 fails on "cc"."""
    return cmd[-2]

self.assertEqual(self._body(self._cmd(None)), "body")
self.assertEqual(self._body(self._cmd({"discord": "123"})), "body")
self.assertEqual(self._body(self._cmd("@who:ag2.space")), "body (cc @who:ag2.space)")
```

Tests only. No production code changed.

## Controls

**Path control** — the case that used to fail must now pass, from the same `cc`-containing path:

```
before (origin/main):   FAILED (failures=2)
after  (this branch):   Ran 5 tests ... OK
```

**Mutation control** — the test must still catch the defect it was written for. Removing the type guard in `command_for` (so a dict `human` gets stringified into the body, the original bug):

```
-   if isinstance(human, str) and human and human not in body:
+   if human and str(human) not in body:

FAILED (failures=1)
- body (cc {'discord': '123'})
+ body
```

Restored: 5 tests OK. So the assertions still test the contract, and the failure now reports a two-line diff instead of a 200-character command line.

## Why all four assertions, not the two that failed

Only two of the four collide today. The other two — the `assertIn("(cc @who…)")` and the `.count()` —
are changed as well, and the reason is not that they are *likely* to collide:

**The defect is the assertion's subject, not the string it searches for.** All four assert over
`" ".join(cmd)` while meaning to assert over the message, so the checkout path is in the subject of
every one of them. What differs between the four is only the odds of a collision, and odds are not the
defect — they are how long the defect takes to show up. Fixing two would leave two assertions still
testing a haystack containing the tmpdir name, and the next unlucky draw gets to rediscover this whole
analysis from a red CI run.

The boundary of a fix is the defect's extent, not the failure's extent. Those coincide for a
deterministic bug, which is why the narrow instinct usually works; for a flake the observed failures
are a sample of the defect, not its edge. (Framing owed to a reviewer — my original justification here
was the weaker probabilistic one, "same shape, less likely string", which invites a trim it does not
survive.)

## Why equality rather than a narrower substring

`assertNotIn("(cc ", ...)` would have fixed today's collision and left the same shape in place — a substring probe over a string that contains things the test does not mean to assert about. Equality on the body says what the function is supposed to return, and cannot be satisfied or broken by anything outside it.

