### PR TITLE
refactor(review-preflight): make "unchecked" a field, not a falsy return

### DIFF
--- a/skills/review-preflight/scripts/review-preflight.py
+++ b/skills/review-preflight/scripts/review-preflight.py
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 LESSONS_HEADING = re.compile(r"^##\s+Lessons\b", re.I)
 CHECKS_HEADING = re.compile(r"^##\s+Checks\b", re.I)
@@ -105,15 +106,26 @@ def resolve_repo(explicit: "str | None" = None, env: "dict | None" = None) -> st
 DECISIVE = ("APPROVED", "CHANGES_REQUESTED", "DISMISSED")
 
 
+class PriorArt(NamedTuple):
+    """Whether the check ran, and what it found — as separate fields, never one value.
+
+    `checked=False` and an empty `items` are both falsy, so a single return
+    value lets one `if not x` merge "unchecked" into "nothing there".
+    """
+    checked: bool
+    items: "list[str]"
+    verdicts: "list[str]"
+
+
 def prior_art(pr: str, runner=None,
-              repo: "str | None" = None) -> "tuple[list[str], list[str]] | None":
+              repo: "str | None" = None) -> PriorArt:
     """(prose to read, decisive verdicts) already on the PR, oldest first.
 
-    None means COULD NOT CHECK, which is not the same as "nothing there" — a
-    reviewer told nothing and a reviewer told the check failed behave
-    differently, so the two must never render alike.
+    checked=False means COULD NOT CHECK, which is not the same as "nothing
+    there" — a reviewer told nothing and a reviewer told the check failed
+    behave differently, so the two must never render alike.
 
-    The second list is latest-state-per-login and is NOT subject to the
+    `verdicts` is latest-state-per-login and is NOT subject to the
     display cap, so a verdict cannot be lost to prose or to truncation.
     """
     run = runner or (lambda a: subprocess.run(a, capture_output=True,
@@ -126,13 +138,13 @@ def prior_art(pr: str, runner=None,
         try:
             r = run(["gh", "api", f"repos/{resolve_repo(repo)}/" + path, "--paginate"])
         except (OSError, subprocess.SubprocessError):
-            return None
+            return PriorArt(False, [], [])
         if r.returncode != 0:
-            return None
+            return PriorArt(False, [], [])
         try:
             rows = json.loads(r.stdout) if r.stdout.strip() else []
         except ValueError:
-            return None
+            return PriorArt(False, [], [])
         for row in rows:
             state = row.get(verdict) if verdict else None
             who = (row.get("user") or {}).get("login", "?")
@@ -145,8 +157,8 @@ def prior_art(pr: str, runner=None,
                 continue
             label = kind if not state else f"{kind}, {state}"
             out.append(f"{ts}  {who} ({label})")
-    return sorted(out), sorted(
-        f"{ts}  {who}: {state}" for who, (ts, state) in latest.items())
+    return PriorArt(True, sorted(out), sorted(
+        f"{ts}  {who}: {state}" for who, (ts, state) in latest.items()))
 
 
 PRIOR_ART_SHOWN = 8
@@ -248,24 +260,31 @@ def stale_approval_block(pr: str, rows: "list[dict] | None") -> "list[str]":
                 verdict]
     return out
 
-def verdict_block(verdicts: "list[str] | None") -> "list[str]":
+def verdict_block(art: PriorArt) -> "list[str]":
     """Every login's current decisive state, uncapped and prose-independent.
 
     Separate from the prose list because the two answer different questions:
     what must I read, versus where does this PR actually stand.
     """
-    if verdicts is None:
+    # Same tri-state as prior_art_block, for the same reason: an unchecked call
+    # and a PR with no verdicts are both empty, and only `checked` tells them apart.
+    state = "unchecked" if not art.checked else "none" if not art.verdicts else "found"
+    if state == "unchecked":
         return ["DECISIVE STATE: *** COULD NOT CHECK *** — treat as unknown, not clean."]
-    if not verdicts:
+    if state == "none":
         return ["DECISIVE STATE: none — no APPROVED or CHANGES_REQUESTED on record."]
+    verdicts = art.verdicts
     return (["DECISIVE STATE (latest per login; a bare verdict carries no prose to read):"]
             + [f"  {v}" for v in verdicts])
 
 
-def prior_art_block(pr: str, seen: "list[str] | None",
+def prior_art_block(pr: str, art: PriorArt,
                     repo: "str | None" = None) -> "list[str]":
     """Render prior art so "nothing there" can never read as "unchecked"."""
-    if seen is None:
+    # Branch on a distinct state, never on falsiness: equality cannot merge two
+    # cases, so reordering these arms is a no-op rather than a silent bug.
+    state = "unchecked" if not art.checked else "empty" if not art.items else "found"
+    if state == "unchecked":
         # An unexpanded placeholder is the one COULD-NOT-CHECK with a fix the
         # reader can apply, so it must not read as generic gh flakiness.
         if (repo or resolve_repo()) == "{owner}/{repo}":
@@ -276,8 +295,9 @@ def prior_art_block(pr: str, seen: "list[str] | None",
         return ["ALREADY ON THIS THREAD: *** COULD NOT CHECK *** — gh is unavailable or",
                 "the call failed. Read the thread yourself: an unchecked thread is not an",
                 "empty one."]
-    if not seen:
+    if state == "empty":
         return ["ALREADY ON THIS THREAD: nothing to read — no prose on the thread yet."]
+    seen = art.items
     # Name the truncation: a bare count above a short list reads as the count
     # being wrong, not the list being cut.
     head = (f"ALREADY ON THIS THREAD — showing last {PRIOR_ART_SHOWN} of {len(seen)};"
@@ -296,9 +316,8 @@ def render(guide: Path, pr: str | None, repo: "str | None" = None) -> str:
     out = [f"review-preflight: criteria from {guide}", ""]
     if pr:
         out += [f"Reviewing PR #{pr}. Every lesson below is a criterion, not a suggestion.", ""]
-        got = prior_art(pr, repo=repo)
-        seen, verdicts = (None, None) if got is None else got
-        out += verdict_block(verdicts) + prior_art_block(pr, seen, repo=repo) + [""]
+        art = prior_art(pr, repo=repo)
+        out += verdict_block(art) + prior_art_block(pr, art, repo=repo) + [""]
         out += stale_approval_block(pr, stale_approvals(pr, repo=repo)) + [""]
     out.append(lessons if lessons else
                "WARNING: no '## Lessons' section found — the guide's criteria could not be read.")

--- a/tests/review-preflight.test.py
+++ b/tests/review-preflight.test.py
@@ -191,7 +191,7 @@ class PriorArtTest(unittest.TestCase):
     def test_a_comment_is_surfaced_even_though_it_is_not_a_review(self):
         run = self._runner(comments='[{"created_at":"2026-08-24T11:36:36Z",'
                                     '"user":{"login":"sonichi"},"body":"the finding"}]')
-        seen, _ = pf.prior_art("3327", runner=run)
+        seen = pf.prior_art("3327", runner=run).items
         self.assertEqual(len(seen), 1)
         self.assertIn("sonichi", seen[0])
         self.assertIn("(comment)", seen[0])
@@ -206,7 +206,7 @@ class PriorArtTest(unittest.TestCase):
         the only review shape an agent can leave."""
         run = self._runner(reviews='[{"submitted_at":"t","user":{"login":"a"},'
                                    '"state":"COMMENTED","body":"a real finding"}]')
-        seen, _ = pf.prior_art("1", runner=run)
+        seen = pf.prior_art("1", runner=run).items
         self.assertEqual(len(seen), 1)
         self.assertIn("COMMENTED", seen[0])
 
@@ -220,7 +220,8 @@ class PriorArtTest(unittest.TestCase):
         preflight answer "nothing here" over a live approval."""
         run = self._runner(reviews='[{"submitted_at":"t","user":{"login":"a"},'
                                    '"state":"APPROVED","body":"   "}]')
-        seen, verdicts = pf.prior_art("1", runner=run)
+        art = pf.prior_art("1", runner=run)
+        seen, verdicts = art.items, art.verdicts
         self.assertEqual(seen, [], "a bare approval carries no prose to read")
         self.assertEqual(verdicts, ["t  a: APPROVED"], "but the verdict stands")
 
@@ -230,7 +231,7 @@ class PriorArtTest(unittest.TestCase):
                                    '"user":{"login":"qingyun-wu"},'
                                    '"state":"APPROVED","body":""}]')
         got = pf.prior_art("1", runner=run)
-        rendered = "\n".join(pf.verdict_block(got[1]) + pf.prior_art_block("1", got[0]))
+        rendered = "\n".join(pf.verdict_block(got) + pf.prior_art_block("1", got))
         self.assertIn("qingyun-wu", rendered)
         self.assertIn("APPROVED", rendered)
         self.assertNotIn("DECISIVE STATE: none", rendered)
@@ -244,10 +245,11 @@ class PriorArtTest(unittest.TestCase):
         old_approval = ('{"submitted_at":"t00","user":{"login":"early"},'
                         '"state":"APPROVED","body":""}')
         run = self._runner(reviews=f"[{old_approval},{reviews}]")
-        seen, verdicts = pf.prior_art("1", runner=run)
-        shown = "\n".join(pf.prior_art_block("1", seen))
+        art = pf.prior_art("1", runner=run)
+        seen, verdicts = art.items, art.verdicts
+        shown = "\n".join(pf.prior_art_block("1", art))
         self.assertNotIn("early", shown, "precondition: prose list truncated it away")
-        self.assertIn("early", "\n".join(pf.verdict_block(verdicts)))
+        self.assertIn("early", "\n".join(pf.verdict_block(art)))
 
     def test_verdict_unknown_and_verdict_none_do_not_render_alike(self):
         """The same load-bearing distinction the prose block already makes.
@@ -256,8 +258,8 @@ class PriorArtTest(unittest.TestCase):
         decisive review. Rendering them alike would let a failed check read as
         a clean one — the exact substitution lesson 16 tells a reviewer to
         avoid, one layer down."""
-        unknown = "\n".join(pf.verdict_block(None))
-        none = "\n".join(pf.verdict_block([]))
+        unknown = "\n".join(pf.verdict_block(pf.PriorArt(False, [], [])))
+        none = "\n".join(pf.verdict_block(pf.PriorArt(True, [], [])))
         self.assertIn("COULD NOT CHECK", unknown)
         self.assertNotIn("COULD NOT CHECK", none)
         self.assertNotEqual(unknown, none)
@@ -268,7 +270,7 @@ class PriorArtTest(unittest.TestCase):
                                    '"state":"CHANGES_REQUESTED","body":""},'
                                    '{"submitted_at":"t1","user":{"login":"a"},'
                                    '"state":"APPROVED","body":""}]')
-        _, verdicts = pf.prior_art("1", runner=run)
+        verdicts = pf.prior_art("1", runner=run).verdicts
         self.assertEqual(verdicts, ["t9  a: CHANGES_REQUESTED"])
 
     def test_unknown_is_not_empty(self):
@@ -277,14 +279,48 @@ class PriorArtTest(unittest.TestCase):
                            ("gh failed", self._runner(rc=1)),
                            ("bad json", self._runner(reviews="not json"))):
             with self.subTest(label):
-                self.assertIsNone(pf.prior_art("1", runner=run), label)
+                self.assertFalse(pf.prior_art("1", runner=run).checked, label)
         # Pin the repo: unpinned, this falls through to resolve_repo() and reads the
         # real env, so the branch under test depends on the developer's shell.
-        unknown = "\n".join(pf.prior_art_block("1", None, repo="a/b"))
-        empty = "\n".join(pf.prior_art_block("1", []))
+        unknown = "\n".join(pf.prior_art_block("1", pf.PriorArt(False, [], []), repo="a/b"))
+        empty = "\n".join(pf.prior_art_block("1", pf.PriorArt(True, [], [])))
         self.assertIn("COULD NOT CHECK", unknown)
         self.assertNotIn("COULD NOT CHECK", empty)
         self.assertNotEqual(unknown, empty)
+
+    def test_checked_dominates_content_so_arm_ORDER_cannot_matter(self):
+        """The whole point of the field, and the one case falsiness cannot express.
+
+        Before this, the two states were told apart only by the ORDER of
+        `if seen is None` and `if not seen`. Under that scheme "the check
+        failed but I have content" is unrepresentable, so nothing could pin
+        which arm wins. With `checked` as its own field it IS representable,
+        and `checked=False` must win over non-empty content in both renderers
+        — a property that survives someone swapping the arms round.
+        """
+        contentful_but_unchecked = pf.PriorArt(False, ["t  who (comment)"], ["t  who: APPROVED"])
+        prose = "\n".join(pf.prior_art_block("1", contentful_but_unchecked, repo="a/b"))
+        verdicts = "\n".join(pf.verdict_block(contentful_but_unchecked))
+        self.assertIn("COULD NOT CHECK", prose)
+        self.assertNotIn("who (comment)", prose)
+        self.assertIn("COULD NOT CHECK", verdicts)
+        self.assertNotIn("APPROVED", verdicts)
+
+    def test_verdict_block_separates_unchecked_from_none(self):
+        """verdict_block had the same falsy conflation, one function over.
+
+        `prior_art` no longer returns None, so passing `art.verdicts` straight
+        through would render a FAILED check as "none — no APPROVED ... on
+        record": the exact clean-looking output this PR exists to prevent.
+        """
+        unchecked = "\n".join(pf.verdict_block(pf.PriorArt(False, [], [])))
+        none = "\n".join(pf.verdict_block(pf.PriorArt(True, [], [])))
+        found = "\n".join(pf.verdict_block(pf.PriorArt(True, [], ["t  who: APPROVED"])))
+        self.assertIn("COULD NOT CHECK", unchecked)
+        self.assertNotIn("COULD NOT CHECK", none)
+        self.assertIn("none", none)
+        self.assertIn("APPROVED", found)
+        self.assertEqual(len({unchecked, none, found}), 3, "two states render alike")
 
     def test_an_unexpanded_repo_placeholder_names_its_own_fix(self):
         """The one COULD-NOT-CHECK the reader can act on must say so.
@@ -293,8 +329,8 @@ class PriorArtTest(unittest.TestCase):
         and this check is inert on every run — indistinguishable, before this,
         from ordinary gh flakiness.
         """
-        no_repo = "\n".join(pf.prior_art_block("1", None, repo="{owner}/{repo}"))
-        gh_down = "\n".join(pf.prior_art_block("1", None, repo="a/b"))
+        no_repo = "\n".join(pf.prior_art_block("1", pf.PriorArt(False, [], []), repo="{owner}/{repo}"))
+        gh_down = "\n".join(pf.prior_art_block("1", pf.PriorArt(False, [], []), repo="a/b"))
         for body in (no_repo, gh_down):
             self.assertIn("COULD NOT CHECK", body)
         self.assertIn("--repo", no_repo)
@@ -304,14 +340,14 @@ class PriorArtTest(unittest.TestCase):
         self.assertNotEqual(no_repo, gh_down)
 
     def test_the_block_says_why_reviews_alone_are_not_enough(self):
-        body = "\n".join(pf.prior_art_block("1", ["t  sonichi (comment)"]))
+        body = "\n".join(pf.prior_art_block("1", pf.PriorArt(True, ["t  sonichi (comment)"], [])))
         self.assertIn("COMMENTED", body)
         self.assertIn("sonichi", body)
 
     def test_a_truncated_list_says_it_is_truncated(self):
         """A bare count above a shorter list reads as a wrong count, not a cut list."""
         many = [f"t{i}  sonichi (comment)" for i in range(63)]
-        body = pf.prior_art_block("1", many)
+        body = pf.prior_art_block("1", pf.PriorArt(True, many, []))
         rows = [ln for ln in body if ln.startswith("  t")]
         self.assertEqual(len(rows), pf.PRIOR_ART_SHOWN)
         self.assertIn(f"showing last {pf.PRIOR_ART_SHOWN} of 63", body[0])
@@ -319,7 +355,7 @@ class PriorArtTest(unittest.TestCase):
 
     def test_an_untruncated_list_does_not_claim_truncation(self):
         few = [f"t{i}  sonichi (comment)" for i in range(pf.PRIOR_ART_SHOWN)]
-        head = pf.prior_art_block("1", few)[0]
+        head = pf.prior_art_block("1", pf.PriorArt(True, few, []))[0]
         self.assertIn(f"({pf.PRIOR_ART_SHOWN})", head)
         self.assertNotIn("showing last", head)
 
@@ -357,9 +393,9 @@ class RepoResolution(unittest.TestCase):
         def failing(argv):
             return types.SimpleNamespace(returncode=1, stdout="")
 
-        self.assertIsNone(pf.prior_art("1", runner=failing, repo="a/b"))
+        self.assertFalse(pf.prior_art("1", runner=failing, repo="a/b").checked)
         self.assertIn("COULD NOT CHECK",
-                      "\n".join(pf.prior_art_block("1", None, repo="a/b")))
+                      "\n".join(pf.prior_art_block("1", pf.PriorArt(False, [], []), repo="a/b")))
 
 
 class StaleApprovalTest(unittest.TestCase):


### PR DESCRIPTION
> **Status (updated 2026-08-31).** The parent **#3538 has MERGED** (2026-08-29T09:19:52Z), so this PR's base auto-retargeted to `main` — the old "base is `fix/review-preflight-repo-resolution`, merge #3538 first" instruction is spent, and I am replacing it rather than annotating it.
> **Still a draft, and still deliberately yielding to #3482** (qingyun-wu), which changes the same function's return type in the same file incompatibly and is further along. #3482 is OPEN with CHANGES_REQUESTED as of this edit, so the rebase-onto-theirs I committed to below is not yet possible; that rebase is what will produce the final diff, and the on-`main` CI re-verification I promised follows it rather than preceding it.
> Supersedes and closes **#3539**.

## What it fixes

`prior_art` returned `list[str] | None`, with `None` meaning COULD NOT CHECK. `None` and `[]` are both falsy, so one `if not seen` merges "the check failed" into "nothing on this thread" — the rendering a genuinely clean PR gets, with nothing raised and nothing logged. A reviewer is told there is no prior art on a thread that may have a dozen findings.

Nothing enforced the distinction except the **order of two early returns**:

```python
if seen is None:   # identity FIRST
if not seen:       # truthiness SECOND
```

## The change

```python
class PriorArt(NamedTuple):
    checked: bool
    items: "list[str]"

# prior_art_block
state = "unchecked" if not art.checked else "empty" if not art.items else "found"
if state == "unchecked": ...
if state == "empty": ...
```

Two things, and they do different work: the tuple splits the two facts, and the **equality dispatch** is what makes the arms order-independent.

## Measured — the tuple alone is not sufficient, which surprised me

Three designs, two mutations each, at this branch's base. Baseline 22 OK; restored green after every run.

| design | reorder the two arms | claim `checked=True` on failure |
|---|---|---|
| `list \| None`, identity-then-truthiness (today) | **FAILED (2)** — a bug, caught | FAILED (4) |
| `PriorArt` + falsiness dispatch (the naive tuple) | **FAILED (2)** — still a bug | FAILED (4) |
| `PriorArt` + equality dispatch (**this PR**) | **22 OK** — a genuine no-op | FAILED (4) |

Row 2 is the point. A reviewer proposed the tuple on the grounds that it makes the reordering mutation *inexpressible*. It does not — with `if not art.checked:` / `if not art.items:` in that order, swapping them still routes `PriorArt(False, [])` into the empty branch and still renders "nothing":

```
AssertionError: 'COULD NOT CHECK' not found in
  'ALREADY ON THIS THREAD: nothing — no reviews or comments yet.'
```

The tuple downgrades the hazard from *silent* to *caught*; the equality dispatch is what removes it. Right direction, over-strong mechanism — so the PR carries the design that was actually measured rather than the one that was argued.

Column 2 is the honest limit: claiming `checked=True` on a failed call is still expressible and still caught by the tests. That is correct and not worth designing against — it is a **lie**, not an omission, and no type prevents lying. What the type removes is the *accidental* version.

## What this does NOT make order-free

Row 3 says reordering the two `if state == ...` arms is a no-op. That is the dispatch. **The
classification still has an order:**

```python
state = "unchecked" if not art.checked else "empty" if not art.items else "found"
```

Reordering *that* chain would break it. The ordering hazard is moved and narrowed, not eliminated —
from two early returns that read as independent guards, to one expression that reads as a single
classification and whose arms are visibly mutually exclusive. I think that is the right place for it,
but the table above should not be read as "order no longer matters anywhere in this function."

## Test changes

11 call sites updated to the new contract (`.items`, `.checked`, `PriorArt(...)` literals). No assertion was weakened — `assertIsNone(...)` became `assertFalse(....checked)`, which asserts the same fact about the new representation. `test_unknown_is_not_empty` and `test_COULD_NOT_CHECK_is_still_reachable` both still fail on column 2, which is what keeps them load-bearing.

## Credit

The instrument question was put to me directly by two reviewers who each measured before arguing: `prior_art` has 4 returns, `prior_art_block` one branch pair, and one call site in the file, so the structural fix is about the size of the comment PR it replaces — which killed the proportionality argument I had used to justify the comment.


