### PR TITLE
fix(tests): pin the fixture repo's git config instead of inheriting the host's

### DIFF
--- a/tests/health-check-index-trend-unavailable.test.py
+++ b/tests/health-check-index-trend-unavailable.test.py
@@ -52,9 +52,8 @@ def index_in(dirpath, size, gitted, revisions=1):
     if not gitted:
         idx.write_text("- [x](x.md) — " + "y" * size + "\n")
         return idx
-    # Pin the fixture repo's config: bare `git` inherits the host's gc/maintenance
-    # settings and hooks, so ambient config decides whether a background writer
-    # touches .git/objects while TemporaryDirectory is removing it (#3542).
+    # Bare `git` inherits the host's gc/maintenance settings and hooks, so ambient
+    # config decides whether a background writer touches .git/objects (#3542).
     genv = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull,
                 GIT_CONFIG_NOSYSTEM="1")
     git = ["git", "-c", "gc.auto=0", "-c", "maintenance.auto=false", "-c", "core.fsmonitor=false"]

--- a/tests/health-check-index-trend-unavailable.test.py
+++ b/tests/health-check-index-trend-unavailable.test.py
@@ -52,16 +52,22 @@ def index_in(dirpath, size, gitted, revisions=1):
     if not gitted:
         idx.write_text("- [x](x.md) — " + "y" * size + "\n")
         return idx
-    subprocess.run(["git", "init", "-q", str(d)], check=True)
-    subprocess.run(["git", "-C", str(d), "config", "user.email", "t@t"], check=True)
-    subprocess.run(["git", "-C", str(d), "config", "user.name", "t"], check=True)
+    # Pin the fixture repo's config: bare `git` inherits the host's gc/maintenance
+    # settings and hooks, so ambient config decides whether a background writer
+    # touches .git/objects while TemporaryDirectory is removing it (#3542).
+    genv = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull,
+                GIT_CONFIG_NOSYSTEM="1")
+    git = ["git", "-c", "gc.auto=0", "-c", "maintenance.auto=false", "-c", "core.fsmonitor=false"]
+    subprocess.run(git + ["init", "-q", str(d)], env=genv, check=True)
+    subprocess.run(git + ["-C", str(d), "config", "user.email", "t@t"], env=genv, check=True)
+    subprocess.run(git + ["-C", str(d), "config", "user.name", "t"], env=genv, check=True)
     for i in range(revisions):
         idx.write_text("- [x](x.md) — " + "y" * (size - (revisions - 1 - i) * 4000) + "\n")
-        env = dict(os.environ,
+        env = dict(genv,
                    GIT_AUTHOR_DATE=str(int(time.time()) - (revisions - i) * 3600),
                    GIT_COMMITTER_DATE=str(int(time.time()) - (revisions - i) * 3600))
-        subprocess.run(["git", "-C", str(d), "add", "MEMORY.md"], check=True)
-        subprocess.run(["git", "-C", str(d), "commit", "-q", "-m", f"c{i}"], env=env, check=True)
+        subprocess.run(git + ["-C", str(d), "add", "MEMORY.md"], env=genv, check=True)
+        subprocess.run(git + ["-C", str(d), "commit", "-q", "-m", f"c{i}"], env=env, check=True)
     return idx
 
 


### PR DESCRIPTION
## The defect

`tests/health-check-index-trend-unavailable.test.py:55-64` builds its fixture repo with bare `git`:

```python
subprocess.run(["git", "init", "-q", str(d)], check=True)
...
subprocess.run(["git", "-C", str(d), "commit", "-q", "-m", f"c{i}"], env=env, check=True)
```

So the fixture inherits the caller's **global and system** git config — `gc.*`, `maintenance.*`, `core.hooksPath`, `init.templateDir`, `core.fsmonitor`, `commit.gpgSign`. The test's behaviour depends on machine configuration that is not in the repository, on any host that runs it.

## Control — the dependency is real, and this is the before/after

A hostile global config (`commit.gpgSign = true`, `gc.auto = 1`), same command both times:

```
$ printf '[commit]\n\tgpgSign = true\n[gc]\n\tauto = 1\n' > /tmp/hostile.gitconfig

# at origin/main
$ GIT_CONFIG_GLOBAL=/tmp/hostile.gitconfig python3 tests/health-check-index-trend-unavailable.test.py
subprocess.CalledProcessError: Command '['git', '-C', '/var/folders/.../tmpvq9ol6q3',
  'commit', '-q', '-m', 'c0']' returned non-zero exit status 128

# at HEAD
$ GIT_CONFIG_GLOBAL=/tmp/hostile.gitconfig python3 tests/health-check-index-trend-unavailable.test.py
  ok   a failed cat-file yields the marker
  ok   an exception in the git layer yields the marker
index trend unavailable: all checks passed
```

Unmodified environment at HEAD: passes (`all checks passed`).

## This is also an experiment for #3542

`#3542` is the same file dying in `TemporaryDirectory` teardown with `OSError: [Errno 39] Directory not empty: 'objects'` — `rmtree` racing something that writes under `.git/objects`. One of the leads there is a **detached background writer** (`gc --auto` / `git maintenance run --auto`), which should not fire at 3 commits of a 16 KB blob *unless ambient config lowers the threshold*.

So this change discriminates the lead without waiting to catch another occurrence:

- teardown failure **stops** recurring → ambient config was the cause, and #3542 closes with this.
- teardown failure **still** recurs → ambient config was not the cause, lead 1 is dead, and #3542 keeps its remaining leads with one fewer unknown.

Either outcome is information, which is why this is worth landing before the next occurrence rather than after. Credit for spotting that the fix and the experiment are the same change: a reviewer on #3542.

**What this PR does not claim.** It does **not** claim to fix the ENOTEMPTY. The control above proves the config dependency existed and is now closed; it says nothing about which writer touched `objects/`. I have not reproduced the teardown failure at all — 6/6 clean locally under `coverage run`, on macOS, with a different filesystem, a different git build, no parallel suite lanes and no `timeout` cap, which is not evidence of rarity on the runner.

## Scope

One file, test-only. No production code, no assertion changed, no behaviour under test touched.
