### PR TITLE
fix(guest-delegation): say what to do when the sandbox cannot answer

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/team_guardrail.py
+++ b/packages/ag2-sparrow/ag2_sparrow/team_guardrail.py
@@ -77,7 +77,11 @@ SANDBOXED_DELEGATION_CODEX = (
     "OUTPUT is non-empty before writing it: codex exits 0 both when it refuses and on a usage "
     "error, so the exit code is not evidence that an answer exists. The sandbox also has NO "
     "NETWORK: if the task needs something the sandbox cannot reach, say so and decline — never "
-    "describe an artifact you could not read."
+    "describe an artifact you could not read. And if codex cannot answer at all — absent, "
+    "exiting non-zero, or exiting 0 having written nothing — there is NO permitted fallback: "
+    "do NOT answer with the owner's unrestricted core, and do not silently skip. Say that the "
+    "sandboxed path was unavailable and that no inspection was performed, so the requester can "
+    "tell a refusal from silence."
 )
 
 

--- a/src/policy/guardrail.py
+++ b/src/policy/guardrail.py
@@ -77,7 +77,11 @@ SANDBOXED_DELEGATION_CODEX = (
     "OUTPUT is non-empty before writing it: codex exits 0 both when it refuses and on a usage "
     "error, so the exit code is not evidence that an answer exists. The sandbox also has NO "
     "NETWORK: if the task needs something the sandbox cannot reach, say so and decline — never "
-    "describe an artifact you could not read."
+    "describe an artifact you could not read. And if codex cannot answer at all — absent, "
+    "exiting non-zero, or exiting 0 having written nothing — there is NO permitted fallback: "
+    "do NOT answer with the owner's unrestricted core, and do not silently skip. Say that the "
+    "sandboxed path was unavailable and that no inspection was performed, so the requester can "
+    "tell a refusal from silence."
 )
 
 

--- a/tests/guest-delegation-shared-owner.test.py
+++ b/tests/guest-delegation-shared-owner.test.py
@@ -76,6 +76,9 @@ class TestOwnerContract(unittest.TestCase):
         unavailable branch must produce a reply rather than nothing."""
         self.assertIn("do not silently skip", SANDBOXED_DELEGATION_CODEX)
         self.assertIn("no inspection was performed", SANDBOXED_DELEGATION_CODEX)
+        lines = sandboxed_delegation_lines(
+            "AG2 Space", "GUEST tier", "results/task-X.txt", "SCOPE-SENTINEL")
+        self.assertIn("no inspection was performed", "\n".join(lines))
 
     def test_scope_is_a_parameter_not_baked_in(self):
         """Slack's per-tier limits must not leak into the shared text."""

--- a/tests/guest-delegation-shared-owner.test.py
+++ b/tests/guest-delegation-shared-owner.test.py
@@ -59,6 +59,24 @@ class TestOwnerContract(unittest.TestCase):
             "AG2 Space", "GUEST tier", "results/task-X.txt", "SCOPE-SENTINEL")
         self.assertIn("NO NETWORK", "\n".join(lines))
 
+    def test_unavailable_sandbox_has_no_fallback(self):
+        """`assert the OUTPUT is non-empty` had no next step, so the branch where
+        codex cannot answer was unstated everywhere but Discord — whose bridge
+        carries a two-sentinel Stage-2 contract the shared owner never learned."""
+        self.assertIn("NO permitted fallback", SANDBOXED_DELEGATION_CODEX)
+        self.assertIn("unrestricted core", SANDBOXED_DELEGATION_CODEX)
+        for symptom in ("absent", "exiting non-zero", "exiting 0 having written nothing"):
+            self.assertIn(symptom, SANDBOXED_DELEGATION_CODEX)
+        lines = sandboxed_delegation_lines(
+            "AG2 Space", "GUEST tier", "results/task-X.txt", "SCOPE-SENTINEL")
+        self.assertIn("NO permitted fallback", "\n".join(lines))
+
+    def test_silence_is_not_an_outcome(self):
+        """A guest cannot distinguish a refusal from a dropped task, so the
+        unavailable branch must produce a reply rather than nothing."""
+        self.assertIn("do not silently skip", SANDBOXED_DELEGATION_CODEX)
+        self.assertIn("no inspection was performed", SANDBOXED_DELEGATION_CODEX)
+
     def test_scope_is_a_parameter_not_baked_in(self):
         """Slack's per-tier limits must not leak into the shared text."""
         self.assertNotIn("information-only", SANDBOXED_DELEGATION_CODEX)


### PR DESCRIPTION
## What

`SANDBOXED_DELEGATION_CODEX` (added by #3512) ends mid-instruction. It says:

> Then assert the OUTPUT is non-empty before writing it

and never says what to do when that assertion fails. This adds the branch.

**Sharpened after review (yixuan-ag2):** "never says" is imprecise, and the precise version is
worse for the constant, not better. The text *does* contain a decline instruction one clause later —
but scoped to a **third** cause:

```
"…codex exits 0 both when it refuses and on a usage error…"   <- names TWO empty-output causes
"The sandbox also has NO NETWORK: … say so and decline"        <- decline scoped to a THIRD
```

So the two causes it explicitly enumerates are the ones left unhandled, while an adjacent,
differently-caused failure gets an explicit decline. A reader who notices the second line can
reasonably infer the empty-output case was considered and deliberately not given that treatment.
That is worse than omission.

## Why this is the same defect #3512 closed, not a new one

#3512's premise was that Discord learned the codex contract and the other
adapters did not, because each carried a copy. The *failure* half of that
contract is still exactly where #3512 found the invocation half — only in
Discord. Measured at `origin/main` (`9a81ee7a`), **matching LINES** of `Sandbox unavailable` (`grep -c` counts lines, not occurrences — the occurrence count in discord-bridge.py is **17**, because three lines carry the phrase more than once: 4104 x2, 4114 x4, 4129 x2). The zeros are unaffected:

```
src/discord-bridge.py                                   -> 12
packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py ->  0
src/slack-bridge.py                                     ->  0
src/policy/guardrail.py (the shared owner)              ->  0
```

Discord's 12 lines are a real contract: two distinct sentinels for two distinct
failures (`SANDBOX_FALLBACK_NONZERO`, `SANDBOX_FALLBACK_NO_OUTPUT`), a legacy
alias, a delivery-suppression matcher, and an explicit note that neither is a
refusal. AG2 Space and Slack now bind the shared owner and inherit **none** of it.

So a delegate on those two surfaces reaches an empty result holding no
instruction at all. The reading then available is to answer with the owner's
unrestricted core — which the second line of the same block forbids. An
instruction that stops one sentence early is not neutral; it leaves the
forbidden action as the only obvious next move.

## What this does NOT do

It does not port Discord's sentinel strings or its suppression matcher.
Those are coupled: the strings are safe there *because* `is_sandbox_fallback_sentinel`
stops them reaching a public channel. Moving strings without the suppression
would have AG2 Space and Slack deliver cold internal text to a guest. Unifying
that machinery is a larger, separate concern and is deliberately left open.

## Before / after

New tests against the merged code they extend (`origin/main`, `9a81ee7a`):

```
$ python3 tests/guest-delegation-shared-owner.test.py
FAIL: test_unavailable_sandbox_has_no_fallback
AssertionError: 'NO permitted fallback' not found in 'Delegate it to Codex: ...'
FAIL: test_silence_is_not_an_outcome
AssertionError: 'do not silently skip' not found in 'Delegate it to Codex: ...'
Ran 11 tests in 0.001s
FAILED (failures=2)
```

At this branch's head (`b44e94bc`):

```
$ python3 tests/guest-delegation-shared-owner.test.py
...........
Ran 11 tests in 0.003s
OK
```

The nine tests #3512 shipped pass unchanged in both runs; only the two new ones
move. Diff is +28/-2 across three files.

## Correction — the first push was red, and the repo's own guard is why

`8641c2bf` failed four checks. One cause: `packages/ag2-sparrow/` bundles
`src/policy/guardrail.py` verbatim as `team_guardrail.py`, and I edited only the
src copy — the same both-copies edit #3512 got right and I did not. Fixed in
`b44e94bc` with `tools/sync_from_src.py`; no other bundled module moved.

Worth recording because three of the four failures pointed away from the cause:
`tsc + tests (clean install)` went red in 3s on a Python-only diff, and
`diff coverage >= 95% (python)` never measured coverage at all — it exits on
`coverage-gate: suite must be green before coverage is meaningful.` Only
`typecheck + node & shell tests` named it: `DRIFT — package out of sync with
src/: team_guardrail.py`.

At `b44e94bc`, locally: `sync_from_src.py --check` reports in sync, and
`ag2-sparrow-drift`, `gateway-team-guardrail-inband` and
`guest-delegation-shared-owner` all pass.

## Provenance

This is the follow-up drafted in #3512 and held until it merged, because the
constant did not exist on `main` (0 matches) and a stack would have widened an
already-stale approval gap. The wording posted there for review was:

> If `codex` is not installed, do NOT fall back to the unrestricted core and do
> not silently skip: reply saying the sandboxed path is unavailable and that no
> inspection was performed.

The shipped text widens "not installed" to the three symptoms that are one
outcome — absent, non-zero, exit-0-with-nothing — after finding that Discord
already distinguishes the last two and the shared owner distinguishes none.

The incident behind it is `@chi-chi-air-blue`, 2026-08-26: codex binary gone
after an engine update with `~/.codex/auth.json` intact — a wiped binary, not a
lost login. They declined rather than substituting, and said so in the reply.
That last part is what "tell a refusal from silence" encodes.

Related but distinct: #3426 is the *detection* half (a health-check probe for a
missing codex) and is blocked on a design question about where detection belongs.
This is the *policy text*, which should state what to do when it cannot be
followed regardless of who notices. Not a duplicate and not a dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



