### PR TITLE
fix(room-ops): raise read MAX_LIMIT 100 -> 1000 to match the gateway ceiling

### DIFF
--- a/skills/agent-room-ops/read.py
+++ b/skills/agent-room-ops/read.py
@@ -15,8 +15,8 @@ from _gateway import (gate_allows, load_gate, gateway, http_request, degrade_rea
                     quote, urlencode, HTTPError, URLError)
 
 DEFAULT_LIMIT = 20
-# Must not exceed the gateway's own clamp (room_ops.py MAX_CONTEXT_LIMIT):
-# beyond it the widest window repeats the previous page and reads as exhausted.
+# Must not exceed the gateway's clamp; beyond it the widest windows repeat the
+# previous page and buy nothing.
 MAX_LIMIT = 1000
 # How many times the raw-event window may widen before we stop. Small and FIXED so the
 # widening below is a bounded `for` rather than a resident loop: the room-ops skill bans

--- a/skills/agent-room-ops/read.py
+++ b/skills/agent-room-ops/read.py
@@ -15,7 +15,9 @@ from _gateway import (gate_allows, load_gate, gateway, http_request, degrade_rea
                     quote, urlencode, HTTPError, URLError)
 
 DEFAULT_LIMIT = 20
-MAX_LIMIT = 100
+# Must not exceed the gateway's own clamp (room_ops.py MAX_CONTEXT_LIMIT):
+# beyond it the widest window repeats the previous page and reads as exhausted.
+MAX_LIMIT = 1000
 # How many times the raw-event window may widen before we stop. Small and FIXED so the
 # widening below is a bounded `for` rather than a resident loop: the room-ops skill bans
 # new ones outright (tests/events-plane-boundary.test.py freezes the allowlist to two

--- a/tests/room_ops_read_limit.test.py
+++ b/tests/room_ops_read_limit.test.py
@@ -167,6 +167,23 @@ class ReadLimitCountsMessages(unittest.TestCase):
         self.assertLessEqual(max(seen), rd.MAX_LIMIT, "never request beyond MAX_LIMIT")
         self.assertFalse(res["complete"], "stopped early -> NOT complete")
 
+    def test_widening_reaches_the_cap_in_a_bounded_number_of_calls(self):
+        """Raising MAX_LIMIT must actually widen the reach AND stay cheap.
+
+        The schedule is geometric with a `_MAX_WIDENINGS` guard, so a bigger
+        cap could in principle be unreachable (guard truncates before the top)
+        or reachable only via many round trips. Pin both: the widest window IS
+        the cap, and getting there costs a handful of calls, not dozens.
+        """
+        for cap in (100, 1000):
+            w = rd._windows(rd.DEFAULT_LIMIT, cap)
+            self.assertEqual(w[-1], cap, f"schedule must reach cap {cap}")
+            self.assertEqual(sorted(set(w)), w, "strictly increasing, no repeats")
+            self.assertLessEqual(len(w), 8, f"too many round trips for cap {cap}")
+        # The floor start is the worst case — smallest first window, so the
+        # most doublings to climb. It is the one that would blow the budget.
+        self.assertLessEqual(len(rd._windows(1, rd.MAX_LIMIT)), 8)
+
     def test_leading_noise_wider_than_the_first_windows(self):
         """Two consecutive ZERO windows must not be read as an empty room.
 


### PR DESCRIPTION
## Why

There are **two** clamps on how much room history a read can reach, and they have to move together:

| clamp | where | was | now |
|---|---|---|---|
| gateway | `services/shared/transport/room_ops.py` (backend) | 100 | 1000 — [ag2space-backend#873](https://github.com/ag2-space/ag2space-backend/pull/873) |
| client | `skills/agent-room-ops/read.py` `MAX_LIMIT` | 100 | **1000 — this PR** |

Raising the gateway alone leaves every sutando read capped at 100 regardless, because the client never asks for more. This is the second half.

## The sizing, and where it comes from

1000 was chosen on the backend side from a measured cost curve against the busiest live room, not from a probed server maximum:

```
raw limit   messages   bytes    B/raw event   latency
   10           7       9,083      908         0.11s
  100          56     115,954    1,160         0.12s
```

Linear at ~1.16 KB per raw event, latency flat across a 10x range — so at 1000 a call costs ~1.2 MB and stays sub-second. Full rationale, including what could **not** be measured, is in the backend PR.

## Why the widening loop needs no redesign

`_windows` is geometric (`x3`, min `+10`) and always appends the cap, so from the default start the schedule goes:

```
cap=100     20 -> 60 -> 100                      (3 calls)
cap=1000    20 -> 60 -> 180 -> 540 -> 1000       (5 calls)
```

Two extra round trips, and only in a room noisy enough that the earlier windows did not already satisfy the request — the early `break` still fires as soon as `limit` messages are in hand.

## Tests

New `test_widening_reaches_the_cap_in_a_bounded_number_of_calls` pins the two properties a bigger cap could silently break:

- **the schedule must REACH the cap.** `_MAX_WIDENINGS = 6` guards the loop; a cap high enough that the guard truncates first would make the raise **inert** — MAX_LIMIT says 1000, no window ever asks for it.
- **it must get there cheaply.** Asserted at cap=100 *and* cap=1000, plus `_windows(1, MAX_LIMIT)` — the floor start is the worst case, most doublings to climb, and the one that would blow the budget first.

```
tests/room_ops_read_limit.test.py            18 tests, OK   (was 17)
tests/agent-room-ops-read-redaction.test.py  OK
tests/agent-room-ops-authz.test.py           PASS
scripts/review-checks.sh --diff <cumulative> PASS
```

The pre-existing `test_stops_at_max_limit` is parameterized on `rd.MAX_LIMIT`, which is why it followed the constant rather than pinning the old value — that is the behavior you want from a cap test and it is why nothing needed editing there.

## Sequencing

**Effective only once the backend deploys.** Until then the gateway clamps to 100 and behavior is unchanged: the widest window asks for more than it gets, which the loop already tolerates (it never infers exhaustion from a repeated count — see the comment block above the loop). So this is safe to land in either order, but it does nothing on its own.

— core-1

---

## Merge order: ag2-space/ag2space-backend#874 first, then this

This PR raises the client-side ceiling to 1000. That only buys reach once the
gateway's own clamp is raised **in production**:

| where | ceiling | via |
|---|---|---|
| backend `dev` | 1000 | #873 — merged 2026-08-29T20:05:56Z |
| backend `main` (prod) | 100 | #874 — **still open** |

Until #874 lands, production still clamps every request at 100, so windows
180/540/1000 return the same page three times. Nothing breaks — that is exactly
what the no-repeated-count-inference design in `read.py:186` buys — but the two
extra round trips buy **zero** additional messages there.

So the trade is "2 extra trips for 10x reach" after #874, and "2 extra trips for
nothing" before it. Merging this ahead of #874 is pure cost, not a regression.

Recorded at @john-the-dev's request: it is a merge-ordering fact, not a code
defect, and it is not recoverable from this diff.
