### PR TITLE
fix(collab-lookup): honour the identity key the schema documents

### DIFF
--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -71,12 +71,18 @@ def load_roster(d):
         })
     return rows
 
+def _identity_id(i):
+    # schema.md names this field `user_id`; this reader only ever read
+    # `provider_id`, so a schema-faithful store matched nothing.
+    return str(i.get("provider_id") or i.get("user_id") or "")
+
+
 def match(rows, needle, ents=()):
     n = needle.lower().lstrip("@")
     # an entity whose GitHub/slack/discord id matches, even if the name does not
     by_ident = {e.get("entity_id") for e in ents
                 for i in (e.get("identities") or [])
-                if n in str(i.get("provider_id", "")).lower()}
+                if n in _identity_id(i).lower()}
     # Identity matches OUTRANK role text and never mix with it: role text names
     # other people and repos, so a hit there is about the subject, not the person.
     strong = [r for r in rows
@@ -160,7 +166,7 @@ def main():
             print("    ⚠ NO cross-platform ids in the store for this entity (discord/slack/github unknown).")
             print("      The SCRIPT cannot invent them -- the map was never given them.")
         for i in idents:
-            print(f"    id: {i.get('provider')}={i.get('provider_id')} verified={i.get('verified')}")
+            print(f"    id: {i.get('provider')}={_identity_id(i)} verified={i.get('verified')}")
         ev = str(r.get("evidence", ""))
         for kw in ("⚠", "Do NOT", "do NOT", "CORRECTED", "WRONG"):
             if kw in ev:

--- a/tests/collab-lookup-store-shapes.test.py
+++ b/tests/collab-lookup-store-shapes.test.py
@@ -152,6 +152,53 @@ class StoreShapes(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertIn("@sutando-rui:ag2.space", out.getvalue())
 
+    def test_identity_matches_on_the_schema_documented_user_id(self):
+        # schema.md documents `user_id`; the reader only read `provider_id`, so a
+        # store written to the schema returned NO MATCH for every identifier.
+        ents = [{"entity_id": "person-x",
+                 "identities": [{"provider": "github", "user_id": "octo-dev"}]}]
+        rows = [{"entity_id": "person-x", "id": "person-x", "one_line": "", "agent_mxid": ""}]
+        self.assertEqual([r["entity_id"] for r in lk.match(rows, "octo-dev", ents)],
+                         ["person-x"])
+
+    def test_main_renders_a_schema_user_id_identity(self):
+        # Covers the RENDER site: matching alone never executes the id line.
+        import contextlib
+        import io
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, yaml_text=(
+                "quick_lookup:\n"
+                "  updated_at: 2026-08-29T00:00:00Z\n"
+                "  recent_entities:\n"
+                "    - entity_id: person-x\n"
+                "      kind: human\n"
+                "      one_line: schema-faithful store\n"))
+            (d / "entities.yaml").write_text(
+                "entities:\n"
+                "  - entity_id: person-x\n"
+                "    identities:\n"
+                "      - {provider: github, user_id: octo-dev}\n")
+            orig_store, orig_argv = lk.store, sys.argv
+            out = io.StringIO()
+            try:
+                lk.store = lambda: d
+                sys.argv = ["lookup.py", "octo-dev"]
+                with contextlib.redirect_stdout(out):
+                    rc = lk.main()
+            finally:
+                lk.store, sys.argv = orig_store, orig_argv
+            self.assertEqual(rc, 0)
+            # Resolved by the documented key, and the id is actually printed.
+            self.assertIn("github=octo-dev", out.getvalue())
+
+    def test_identity_still_matches_on_provider_id(self):
+        # Existing stores use provider_id; honouring user_id must not drop them.
+        ents = [{"entity_id": "person-y",
+                 "identities": [{"provider": "github", "provider_id": "hubot"}]}]
+        rows = [{"entity_id": "person-y", "id": "person-y", "one_line": "", "agent_mxid": ""}]
+        self.assertEqual([r["entity_id"] for r in lk.match(rows, "hubot", ents)],
+                         ["person-y"])
+
     def test_no_match_returns_empty_not_invented(self):
         with tempfile.TemporaryDirectory() as t:
             d = store(t, roster=ROSTER)


### PR DESCRIPTION
## What

`references/schema.md` documents the identity field as `user_id`. `lookup.py` read only
`provider_id`, at both the match site and the render site.

## Why it matters more than a key rename

A store written faithfully to the documented schema **matches nothing**, and it does so silently:

- `--all` still lists every entity (that path reads `quick-lookup.yaml`, not identities), so the store
  looks populated and healthy.
- Every identifier query returns the `NO MATCH` branch, whose text is *"Do NOT invent an id. Either ask
  the owner for the mapping…"*.

So a correctly-built map is indistinguishable from one that was never given the mapping, and the
caller acts on the wrong one. Found while bootstrapping a real store: entities listed fine, every
lookup returned NO MATCH, and the cause read as *this person is not in the map*.

## Fix

One accessor reading either key, so existing `provider_id` stores keep working unchanged.

## Before / after

Same test file both sides, reverting only `lookup.py`:

**Before** — 1 of 15 fails, the `user_id` case:
```
+ ['person-x']
FAILED (failures=1)
```
**After**:
```
Ran 15 tests in 0.015s
OK
```

Suite goes 13 → 15. The second new test pins the `provider_id` path and **passes on both sides**, so
it demonstrates the compatibility guarantee rather than merely re-testing the fix.

`scripts/review-checks.sh` passes.
