### PR TITLE
fix(health-check): a conditional job that produced nothing is not a blind spot

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5895,11 +5895,13 @@ def _interpret_daily_punctuality(jobs: list) -> dict:
     """Score LATENESS, not presence: a file produced daily by another path looks
     identical to one produced by a working schedule."""
     name = "daily-cron-punctuality"
-    late, missed, unknown, drifted = [], [], [], []
+    late, missed, unknown, drifted, quiet = [], [], [], [], []
     for j in jobs:
         due = j["hour"] * 60 + j["minute"]
         if not j["artifacts"]:
-            unknown.append(j["name"])
+            # `conditional` declares that absence is expected, so it cannot also
+            # be the blind spot that pins this probe to warn with no path back.
+            (quiet if j.get("conditional") else unknown).append(j["name"])
             continue
         # The median would describe a corpus this job no longer writes, and a
         # missed-today verdict would blame it for the probe's own blind spot.
@@ -5918,13 +5920,15 @@ def _interpret_daily_punctuality(jobs: list) -> dict:
                 and (j.get("stem_declared") or j["artifacts"])):
             missed.append((j["name"], j["minutes_since_due"]))
     if not late and not missed and not drifted:
-        seen = len(jobs) - len(unknown)
+        seen = len(jobs) - len(unknown) - len(quiet)
         detail = f"{seen} of {len(jobs)} daily job(s) observable"
         detail += ", all on schedule" if seen else ""
+        if quiet:
+            detail += (f"; conditional, nothing produced to score: "
+                       f"{', '.join(sorted(quiet))}")
         if unknown:
             detail += (f"; UNCHECKED (no dated artifact, cannot tell whether it ran): "
                        f"{', '.join(sorted(unknown))}")
-        if unknown:
             # `ok` would certify jobs nobody measured: on a 1-of-5 host the four
             # UNCHECKED ones miss forever behind green. Coverage gates the verdict.
             scope = "no coverage on this host" if not seen else \
@@ -5943,6 +5947,8 @@ def _interpret_daily_punctuality(jobs: list) -> dict:
                     f"probe's filename match has drifted off this job's output; "
                     f"punctuality cannot be scored and a missed-today verdict would "
                     f"blame the job for the probe's own blind spot")
+    if quiet:
+        bits.append(f"conditional, nothing produced to score: {', '.join(sorted(quiet))}")
     if unknown:
         bits.append(f"unverifiable (no dated artifact): {', '.join(sorted(unknown))}")
     return {"name": name, "status": "warn", "detail": "; ".join(bits)}

--- a/tests/health-check-daily-punctuality.test.py
+++ b/tests/health-check-daily-punctuality.test.py
@@ -350,6 +350,38 @@ class TestConditionalProducers(unittest.TestCase):
         self.assertEqual(r["status"], "ok", r["detail"])
         self.assertNotIn("no output today", r["detail"])
 
+    def test_a_conditional_producer_that_has_produced_NOTHING_is_not_a_blind_spot(self):
+        """The quiet stretch can cover the whole window, and often does.
+
+        A threshold guard or an opt-in job may legitimately produce nothing for
+        months, so `conditional` has to excuse an empty artifact set too - not
+        only a single quiet day. Otherwise the flag can never reach `ok` on the
+        hosts it exists for, which is the standing warning #2754 rules out.
+        """
+        r = hc._interpret_daily_punctuality(
+            [job("rotate-log", 4, 23, [], today_seen=False, since_due=300,
+                 conditional=True)])
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertNotIn("UNCHECKED", r["detail"])
+
+    def test_an_unconditional_producer_with_no_artifacts_still_gates(self):
+        """The control that must keep failing: without the declaration an empty
+        artifact set is a real blind spot, and green would claim coverage."""
+        r = hc._interpret_daily_punctuality(
+            [job("mystery", 4, 23, [], today_seen=False, since_due=300)])
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("UNCHECKED", r["detail"])
+
+    def test_a_quiet_conditional_job_does_not_hide_a_real_warn(self):
+        """Excusing it must not also silence a genuinely late sibling."""
+        late = [(f"2026-08-{d:02d}", 6 * 60 + 200) for d in range(6, 13)]
+        r = hc._interpret_daily_punctuality(
+            [job("render", 6, 0, late),
+             job("rotate-log", 4, 23, [], today_seen=False, since_due=300,
+                 conditional=True)])
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("render", r["detail"])
+
     def test_conditional_does_not_suppress_LATENESS(self):
         """Only absence is excused. A conditional job that renders consistently
         late is still late, and that signal must survive the exemption."""


### PR DESCRIPTION
## The defect

`conditional: true` is documented as *"the job runs on schedule but produces output only if there is new input … the probe then treats 'no artifact today' as evidence of nothing rather than a miss."*

It excuses a quiet **day**. It does not excuse a quiet **window** — and for the jobs the flag exists for, the quiet window is the normal case.

`_interpret_daily_punctuality` sorts a job into `unknown` before it ever looks at the flag:

```python
if not j["artifacts"]:
    unknown.append(j["name"])     # src/health-check.py:5901-5902 on main
    continue
```

`unknown` then gates the verdict, by design and with a good reason (`"ok would certify jobs nobody measured"`). So a conditional job whose artifact set is empty pins the probe to `warn` **permanently, with no path back to ok**.

## Measured on `main` (`be08f44`)

Adding only the test, unmodified source:

```
FAIL: test_a_conditional_producer_that_has_produced_NOTHING_is_not_a_blind_spot
AssertionError: 'warn' != 'ok'
Ran 49 tests -- FAILED (failures=1)
```

Both controls in the same commit pass at the parent, because they describe behaviour that is already correct.

This host's actual shape, before and after — one punctual job plus three declared-conditional ones:

```
before:  warn | 1 of 4 daily job(s) observable, all on schedule;
               UNCHECKED (no dated artifact, cannot tell whether it ran):
               learned-skills-scan, obsidian-dream, rotate-tailscaled-log
               -- 3 of 4 unverifiable, status cannot be ok

after:   ok   | 1 of 4 daily job(s) observable, all on schedule;
               conditional, nothing produced to score:
               learned-skills-scan, obsidian-dream, rotate-tailscaled-log
```

The three jobs are still named. They stop gating the verdict; they do not stop being reported.

## Why these are not really unknown

All three are silent by construction, and each was verified rather than assumed:

| job | why it produces nothing |
|---|---|
| `rotate-tailscaled-log` | truncates only above 25 MB; measured growth **~29 KB/day**, so **~2.3 years** to threshold |
| `obsidian-dream` | `SUTANDO_OBSIDIAN_MIRROR` unset — documented default-off |
| `learned-skills-scan` | opt-in Settings toggle, default off |

`rotate-tailscaled-log` is the clearest case: waiting for it to produce an artifact means waiting years, and until then the flag its operator set cannot do anything.

## Relationship to #2754

Not a substitute for it. #2754 wants runner-written completion stamps, which is scheduler-side work with a different owner, and it would close this for every job rather than the declared subset.

It is #2754's own body that decides this one, though — it rules out exactly the state the current code produces:

> **Warn permanently when unobservable** — a standing warning on every run, for a condition nobody can act on, which trains operators to ignore the lane. Explicitly not wanted in review.

That is what a quiet conditional job does today. This restricts the fix to jobs where an operator has already declared the absence expected, and leaves every undeclared job gating exactly as before.

## Tests

`tests/health-check-daily-punctuality.test.py`: **46 -> 49**, all passing at HEAD. Three cases in `TestConditionalProducers`:

1. the defect — conditional, no artifacts, 300 min past due -> `ok`, no `UNCHECKED`
2. **control that must keep failing** — same job *without* the flag -> `warn`, `UNCHECKED` present
3. **control against over-reach** — a quiet conditional job alongside a genuinely late sibling -> still `warn`, and the late job is still named

Siblings re-run green: `daily-punctuality-completion-sentinels`, `health-check-cron-runner`.

One gap I should name: I could not run `scripts/review-checks.sh` to completion locally — it exceeded my 5-minute command ceiling rather than failing. CI covers it; I am not claiming a local pass I do not have.