### PR TITLE
fix(notify-reviewers): a delivered ask that records nothing must not be silent

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -390,6 +390,12 @@ def main() -> int:
             else:
                 if n_logged:
                     print(f"  logged {n_logged} PR ask(s) for {t['name']}", file=sys.stderr)
+                else:
+                    # Not counted as a failure: an ask need not concern a PR. But it
+                    # must not be silent -- an unrecorded PR ask reads as never-asked.
+                    print(f"  note: nothing recorded for {t['name']} — the message "
+                          f"names no github.com/<owner>/<repo>/pull/<n> URL, so any "
+                          f"PR it refers to will read as unasked", file=sys.stderr)
         else:
             detail = reason or p.stderr.strip()[:120] or fallback
             print(f"{t['name']}: ok=False reason={detail}", file=sys.stderr)

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -104,6 +104,9 @@ class Ledger(unittest.TestCase):
         cases = [
             ("https://github.com/o/r/pull/1", 1),
             ("https://github.com/o/r/pull/1 https://github.com/o/r/pull/2", 2),
+            # Reaches a dedup branch: the SAME pr twice, so findall > len(refs).
+            ("https://github.com/o/r/pull/1 again https://github.com/o/r/pull/1", 1),
+            ("self-ask https://github.com/o/r/pull/1 cc @me", 1),
             ("https://github.com/o/r/pull/1/files", 1),
             ("[#1](https://github.com/o/r/pull/1)", 1),
             ("o/r#1", 0),

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -98,6 +98,27 @@ class Ledger(unittest.TestCase):
         with self._at(self.tmp.name):
             self.assertEqual(self.mod.record_asks("no link here", "rui"), 0)
 
+    def test_zero_is_returned_ONLY_when_no_PR_URL_matched(self):
+        # main() names this cause in its warning, so a future early `return 0`
+        # would make that message assert something false while tests still pass.
+        cases = [
+            ("https://github.com/o/r/pull/1", 1),
+            ("https://github.com/o/r/pull/1 https://github.com/o/r/pull/2", 2),
+            ("https://github.com/o/r/pull/1/files", 1),
+            ("[#1](https://github.com/o/r/pull/1)", 1),
+            ("o/r#1", 0),
+            ("#1", 0),
+            ("https://api.github.com/repos/o/r/pulls/1", 0),
+            ("no link here", 0),
+            ("", 0),
+        ]
+        for msg, want in cases:
+            with self._at(self.tmp.name):
+                got = self.mod.record_asks(msg, "rui")
+            matched = self.mod._PR_URL.search(msg) is not None
+            self.assertEqual(got, want, msg)
+            self.assertEqual(got == 0, not matched, f"0-iff-no-match broken for {msg!r}")
+
     def test_two_PRs_in_one_message_record_both(self):
         msg = ("https://github.com/o/r/pull/1 and "
                "https://github.com/o/r/pull/2")

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -7,8 +7,10 @@ behaviour was tested. These call the functions directly.
 
 Run: python3 tests/sci-notify-reviewers-inproc.test.py   (stdlib only)
 """
+import contextlib
 import datetime
 import importlib.util
+import io
 import json
 import os
 import tempfile
@@ -314,6 +316,17 @@ class FailurePaths(unittest.TestCase):
         rc, sends = self._run(self.ARGS + self.M, record_effect=OSError("read-only"))
         self.assertEqual(sends, 2)
         self.assertNotEqual(rc, 0)
+
+    def test_a_delivered_ask_that_records_NOTHING_is_loud(self):
+        # Ask delivered, ledger empty -- the OSError case reached by a return
+        # value. Silent before the fix; measured on ag2space-backend#872.
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc, sends = self._run(self.ARGS + self.M,
+                                  record_effect=lambda *a, **k: 0)
+        self.assertEqual(sends, 2)
+        self.assertIn("nothing recorded", err.getvalue())
+        self.assertEqual(rc, 0)                 # a PR-less ask is not a failure
 
     def test_an_unreadable_ledger_does_not_refuse_the_ask(self):
         with patch.object(self.mod, "ledger_path", return_value=self.led), \


### PR DESCRIPTION
## The defect

`record_asks()` returns `0` when the message carries no
`github.com/<owner>/<repo>/pull/<n>` URL. `main()` guarded its report with
`if n_logged:`, so that zero printed **nothing at all** — the ask was delivered,
the ledger stayed empty, and `pr-unattended.py` then read the PR as
`NOBODY_EVER_ASKED` indefinitely.

The `OSError` path was already loud (`test_a_lost_ledger_write_is_loud_but_not_fatal_to_the_batch`).
This is the *same lost write* reached by a return value rather than an exception,
and it was the untested polarity.

## How it was found

`ag2-space/ag2space-backend#872` reports `NOBODY_EVER_ASKED` on every routing sweep.
It was in fact asked — via `notify_reviewers.py` — and reviewed in-room within five
minutes. The ledger holds 157 asks across 36 PRs; #872 is absent, while #851/#857/#858
in the same repo are present. Those messages happened to carry full URLs.

Reference styles, run against the live regex:

```
full URL                    refs=1  LOGGED
markdown link               refs=1  LOGGED
trailing /files             refs=1  LOGGED
owner/repo#872              refs=0  SILENTLY DROPPED
#872                        refs=0  SILENTLY DROPPED
api.github.com/.../pulls/N  refs=0  SILENTLY DROPPED
```

## Evidence

Parent (`origin/main`, source only reverted, new test retained):

```
FAIL: test_a_delivered_ask_that_records_NOTHING_is_loud
AssertionError: 'nothing recorded' not found in ''
Ran 36 tests   FAILED (failures=1)
```

The empty string is the defect: total silence.

At HEAD:

```
Ran 36 tests in 0.020s   OK
```

Neighbours, both at HEAD:

```
tests/sci-notify-reviewers.test.py          Ran 29 tests  OK
tests/notify-reviewers-human-shapes.test.py PASS
tests/collab-lookup-store-shapes.test.py    PASS
```

`scripts/review-checks.sh --diff` → PASS.

## Added after the first reviews (`171bdb05`, `f11e7c46`)

`main()`'s note names a *specific cause*, so that message becomes false the moment `record_asks`
can return 0 another way. Eleven cases now relate the return value to `_PR_URL` — 6 expecting a non-zero count, 5 expecting 0, and the corpus
includes a duplicate-URL and a self-ask-shaped message so it reaches the branch shapes a future
change would most likely add:

```
dedup early-return added     Ran 36 tests   FAILED (failures=1)
dedup early-return removed   Ran 36 tests   OK
```

The first version of that test had the biconditional but a corpus that could not reach the branch —
it passed unchanged with a dedup `return 0` applied. @qingyun-air caught that and re-verified the
fix with a mutant they injected themselves rather than reusing mine.

## Scope, and one thing I got wrong first

My first attempt incremented `unlogged`, making rc non-zero. **That broke three tests
in `sci-notify-reviewers.test.py`** — its fixtures pass `--message "m"`, so a PR-less
ask is legitimate and failing the batch would break real non-PR notifications. Kept the
narrow form: warn on stderr, rc unchanged.

Deliberately **not** in scope: widening the regex to accept `owner/repo#N`. That changes
what gets recorded rather than what gets reported, and belongs in its own PR.
