### PR TITLE
docs(scp): v0 is not local-only — describe the shipped network surface accurately

### DIFF
--- a/docs/scp-v0.md
+++ b/docs/scp-v0.md
@@ -57,30 +57,50 @@ Trade-off: a daemon restart drops connected clients. (Contrast ACP's stdio, wher
 the client spawns the agent as a 1:1 child subprocess — session-shaped; the Unix
 socket is task-shaped, a durable service many clients submit tasks to.)
 
-### [v0.1+] — Remote agent support *(LAN transport SHIPPED and opt-in; WAN/relay not built)*
+### [v0.1+] — Remote agent support *(LAN WebSocket transport SHIPPED, opt-in, loopback-default; WAN/relay not built)*
 
 A remote transport so a client can drive a Sutando agent across machines. The task
 model makes this a clean extension rather than a retrofit — submit a task over the
 wire and stream `task.update` back — because a task is durable and channel-agnostic
 and does not require a co-located session.
 
-**⚠ v0 is NOT local-only. A LAN WSS transport is shipped.**
+**⚠ v0 is NOT local-only. A LAN WebSocket transport is shipped.**
 `src/runtime-api/ws_transport.py` is a second transport for the same daemon and the
 same dispatcher, alongside the Unix socket — one dispatcher, N transports. A
-phone-class client on the same network dials the Server's own WSS listener directly
+phone-class client on the same network dials the Server's own listener directly
 (no relay, no cloud). `src/runtime-api/server.py` starts it **only** when
-`SUTANDO_SCP_WSS_ENABLE` is truthy, so it is opt-in and off by default.
+`SUTANDO_SCP_WSS_ENABLE` is truthy, and binds **loopback (`127.0.0.1`) by
+default** — LAN exposure additionally requires an explicit non-loopback
+`SUTANDO_SCP_WSS_HOST`. So: opt-in, and local-host-only until deliberately opened.
 
-Because that leg is **network-exposed** — where the UDS transport is same-user local
-(0600, no auth needed) — it carries two edge protections the socket does not need:
+**The wire has two listeners, and the primary one is cleartext.** The primary
+listener speaks **plain `ws://`** (embedded devices like the M5 speak it). TLS is
+an optional **sibling** listener on its own port (default 8443), enabled
+separately by `SUTANDO_SCP_WSS_TLS` with a generated self-signed cert — it exists
+because browser mic APIs require a secure context. Enabling TLS does not encrypt
+the primary listener; on a LAN-exposed host, traffic to the primary port is
+readable on the network.
 
-1. **A bearer token on connect.**
-2. **A read-only method allowlist**: mutating methods are refused at the transport
-   edge until per-device authorization lands.
+Because the network leg is exposed where the UDS transport is same-user local
+(0600, no auth needed), authorization is **per-credential, not read-only across
+the board**:
 
-Still genuinely not built: a WAN/relay path (reaching an agent from off-LAN), and
-per-device authorization — which is what currently confines the LAN leg to
-read-only methods.
+1. **Shared bearer token** → confined to `READ_ONLY_METHODS` (status, listings,
+   results; plus `task.subscribe`). Cannot mutate state.
+2. **Pairing token** → may only call `pair.redeem`.
+3. **Paired device credential** → authorized by its **own per-device grants**
+   (`DEFAULT_DEVICE_GRANTS` in `device_store.py`): the read surface **plus
+   `task.submit`, `task.cancel`, and `voice.open`/`voice.close`**. A paired
+   device can submit and cancel owner-tier work by default — deliberately, the
+   wearable's core function — while `terminal.input`, `restart`, and
+   `approval.respond` stay off until the owner widens that device's grants.
+
+Per-device authorization is therefore **built and enforced**
+(`ws_transport.py:_resolve_auth`); the read-only confinement applies to the
+shared bearer only. A captured paired-device credential can mutate state, so the
+credential — not the transport — is the security boundary on the LAN leg.
+
+Still genuinely not built: a WAN/relay path (reaching an agent from off-LAN).
 
 ## 3. Core methods (implemented in v0)
 

--- a/docs/scp-v0.md
+++ b/docs/scp-v0.md
@@ -97,12 +97,15 @@ Because the network leg is exposed where the UDS transport is same-user local
 the board**:
 
 1. **Shared bearer token** → confined to `READ_ONLY_METHODS` (status, listings,
-   results; plus `task.subscribe`). Cannot mutate state.
+   results; plus `task.subscribe`). Cannot mutate state. (The `client.hello`
+   handshake is permitted for **every** authenticated credential, this one
+   included — `_dispatch_one` admits it before the grant check.)
 2. **Pairing token** → `pair.redeem` (plus the pre-authorization `client.hello`
    handshake).
 3. **Paired device credential** → authorized by its **own per-device grants**
    (`DEFAULT_DEVICE_GRANTS` in `device_store.py`): the read surface **plus
-   `task.submit`, `task.cancel`, and `voice.open`/`voice.close`**. A paired
+   `task.submit`, `task.cancel`, and `voice.open`/`voice.close`** (`voice.interrupt`
+   rides the `voice.open` grant). A paired
    device can submit and cancel owner-tier work by default — deliberately, the
    wearable's core function — while `approval.respond` stays off until the
    owner widens that device's grants. (`terminal.input` and restart are not SCP

--- a/docs/scp-v0.md
+++ b/docs/scp-v0.md
@@ -57,13 +57,30 @@ Trade-off: a daemon restart drops connected clients. (Contrast ACP's stdio, wher
 the client spawns the agent as a 1:1 child subprocess — session-shaped; the Unix
 socket is task-shaped, a durable service many clients submit tasks to.)
 
-### [v0.1+] — Remote agent support *(planned, not built)*
+### [v0.1+] — Remote agent support *(LAN transport SHIPPED and opt-in; WAN/relay not built)*
 
-A remote transport (e.g. WebSocket / HTTP) so a client can drive a Sutando agent
-across machines. The task model makes this a clean extension rather than a
-retrofit — submit a task over the wire and stream `task.update` back — because a
-task is durable and channel-agnostic and does not require a co-located session.
-**Until built, this is aspirational: v0 is local-only.**
+A remote transport so a client can drive a Sutando agent across machines. The task
+model makes this a clean extension rather than a retrofit — submit a task over the
+wire and stream `task.update` back — because a task is durable and channel-agnostic
+and does not require a co-located session.
+
+**⚠ v0 is NOT local-only. A LAN WSS transport is shipped.**
+`src/runtime-api/ws_transport.py` is a second transport for the same daemon and the
+same dispatcher, alongside the Unix socket — one dispatcher, N transports. A
+phone-class client on the same network dials the Server's own WSS listener directly
+(no relay, no cloud). `src/runtime-api/server.py` starts it **only** when
+`SUTANDO_SCP_WSS_ENABLE` is truthy, so it is opt-in and off by default.
+
+Because that leg is **network-exposed** — where the UDS transport is same-user local
+(0600, no auth needed) — it carries two edge protections the socket does not need:
+
+1. **A bearer token on connect.**
+2. **A read-only method allowlist**: mutating methods are refused at the transport
+   edge until per-device authorization lands.
+
+Still genuinely not built: a WAN/relay path (reaching an agent from off-LAN), and
+per-device authorization — which is what currently confines the LAN leg to
+read-only methods.
 
 ## 3. Core methods (implemented in v0)
 

--- a/docs/scp-v0.md
+++ b/docs/scp-v0.md
@@ -57,7 +57,7 @@ Trade-off: a daemon restart drops connected clients. (Contrast ACP's stdio, wher
 the client spawns the agent as a 1:1 child subprocess — session-shaped; the Unix
 socket is task-shaped, a durable service many clients submit tasks to.)
 
-### [v0.1+] — Remote agent support *(LAN WebSocket transport SHIPPED, opt-in, loopback-default; WAN/relay not built)*
+### [v0.1+] — Remote agent support *(LAN WebSocket transport SHIPPED, opt-in, loopback-default; no SCP WAN transport yet — but see the remote-gateway relay below)*
 
 A remote transport so a client can drive a Sutando agent across machines. The task
 model makes this a clean extension rather than a retrofit — submit a task over the
@@ -100,7 +100,19 @@ Per-device authorization is therefore **built and enforced**
 shared bearer only. A captured paired-device credential can mutate state, so the
 credential — not the transport — is the security boundary on the LAN leg.
 
-Still genuinely not built: a WAN/relay path (reaching an agent from off-LAN).
+Still genuinely not built: a **WAN/relay transport for SCP's JSON-RPC method
+surface** — no SCP method reaches an agent from off-LAN.
+
+**That is a claim about SCP, not about reachability.** This repository already
+ships an off-LAN control path under a **separate protocol**: the remote gateway
+task/result relay (`docs/remote-gateway-protocol.md`). When configured,
+`src/startup-runtime.sh` starts `remote_gateway_bridge`, which authenticates to
+a remote HTTP gateway, long-polls `/v1/tasks`, and publishes received work into
+the local task queue — by default at **owner tier**. It is optional and
+token-gated, but do not read "SCP WebSocket disabled" as "no off-LAN control
+path exists": an operator auditing network exposure must check the gateway
+configuration too. The two surfaces are independent — disabling one says
+nothing about the other.
 
 ## 3. Core methods (implemented in v0)
 

--- a/docs/scp-v0.md
+++ b/docs/scp-v0.md
@@ -39,7 +39,10 @@ onto a task. See §6.
 
 ## 2. Transport
 
-SCP is **JSON-RPC 2.0**, newline-delimited (one message per line). Requests and
+SCP is **JSON-RPC 2.0**. Framing is per-transport: the **Unix socket** is
+newline-delimited (one message per line, `reader.readline()`); the **WebSocket**
+transport carries **exactly one JSON-RPC object per text frame** — two
+newline-joined records in one frame are a parse error, not two requests. Requests and
 responses carry an `id`; **notifications** (server-push) omit `id`. Actor identity
 is resolved **daemon-side** and never overridden by a client parameter. Framing
 limits and per-request timeouts are enforced daemon-side.
@@ -71,7 +74,15 @@ phone-class client on the same network dials the Server's own listener directly
 (no relay, no cloud). `src/runtime-api/server.py` starts it **only** when
 `SUTANDO_SCP_WSS_ENABLE` is truthy, and binds **loopback (`127.0.0.1`) by
 default** — LAN exposure additionally requires an explicit non-loopback
-`SUTANDO_SCP_WSS_HOST`. So: opt-in, and local-host-only until deliberately opened.
+`SUTANDO_SCP_WSS_HOST`. So: opt-in, and loopback-only until deliberately opened.
+
+**"LAN" here describes the intended use, not an enforced boundary.** The server
+accepts any bind address (a wildcard `0.0.0.0` bind is accepted as-is) and applies
+**no source-address or subnet restriction** — authorization is purely by credential.
+There is no bundled WAN relay or discovery path, but with a non-loopback bind,
+routing or port forwarding can make the plain-WS listener reachable **off-LAN**.
+Reachability is governed by the configured bind, your routing, and your firewall —
+the application does not enforce a LAN-only peer boundary.
 
 **The wire has two listeners, and the primary one is cleartext.** The primary
 listener speaks **plain `ws://`** (embedded devices like the M5 speak it). TLS is
@@ -87,21 +98,25 @@ the board**:
 
 1. **Shared bearer token** → confined to `READ_ONLY_METHODS` (status, listings,
    results; plus `task.subscribe`). Cannot mutate state.
-2. **Pairing token** → may only call `pair.redeem`.
+2. **Pairing token** → `pair.redeem` (plus the pre-authorization `client.hello`
+   handshake).
 3. **Paired device credential** → authorized by its **own per-device grants**
    (`DEFAULT_DEVICE_GRANTS` in `device_store.py`): the read surface **plus
    `task.submit`, `task.cancel`, and `voice.open`/`voice.close`**. A paired
    device can submit and cancel owner-tier work by default — deliberately, the
-   wearable's core function — while `terminal.input`, `restart`, and
-   `approval.respond` stay off until the owner widens that device's grants.
+   wearable's core function — while `approval.respond` stays off until the
+   owner widens that device's grants. (`terminal.input` and restart are not SCP
+   methods at all — absent from `protocol.METHODS` — so no grant can enable them.)
 
 Per-device authorization is therefore **built and enforced**
 (`ws_transport.py:_resolve_auth`); the read-only confinement applies to the
 shared bearer only. A captured paired-device credential can mutate state, so the
 credential — not the transport — is the security boundary on the LAN leg.
 
-Still genuinely not built: a **WAN/relay transport for SCP's JSON-RPC method
-surface** — no SCP method reaches an agent from off-LAN.
+Still genuinely not built: a **bundled WAN relay or discovery path for SCP**.
+Whether the direct listener is reachable off-LAN is a deployment property
+(bind + routing + firewall), not something SCP prevents — see the boundary
+note above.
 
 **That is a claim about SCP, not about reachability.** This repository already
 ships an off-LAN control path under a **separate protocol**: the remote gateway

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -157,6 +157,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`task-emit.sh`** — TASK_FILE emitters — sourceable so a test can invoke them in isolation.
 - **`task_archive.py`** — Task-file locator for archive calls (#933).
 - **`task_body_guard.py`** — Confine untrusted user message content before embedding it in a task file.
+- **`task_body_guard.ts`** — confineUserContent — the ONE TypeScript implementation of the task-body injection guard.
 - **`task_envelope.py`** — Task-envelope authentication: an HMAC stamp that makes access_tier a verified claim instead of an honor-system header.
 - **`task_envelope.ts`** — task_envelope.ts — TypeScript mirror of src/task_envelope.py's stamping half, for the TS task writers (voice delegation seam, context-drop, wearable).
 - **`task_envelope_census.py`** — Soak census for HMAC task envelopes: the read-only measurement behind the "writer census reaches zero" gate.
@@ -349,7 +350,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`tasks_view.py`** — Task-pipeline surface for the Sutando Server: task.submit / task.status / task.get_result / task.details / task.cancel.
 - **`voice_bridge.py`** — voice_bridge.py — the boundary between SCP media framing and voice intelligence.
 - **`voice_host_bridge.py`** — voice_host_bridge.py — bridge SCP audio streams to a voice-host process.
-- **`ws_transport.py`** — ws_transport.py — LAN WSS transport for SCP (Sutando Client Protocol).
+- **`ws_transport.py`** — ws_transport.py — network transport for SCP (Sutando Client Protocol).
 
 ## `src/runtime-cli/`
 

--- a/src/runtime-api/server.py
+++ b/src/runtime-api/server.py
@@ -408,8 +408,10 @@ class RuntimeServer:
                 _log(f"SCP WSS TLS sibling on wss://{host}:{tls_port}/scp "
                      f"(browser/companion clients)")
             if host not in ("127.0.0.1", "localhost", "::1"):
-                _log(f"SCP WSS is LAN-exposed on {host}:{port} "
-                     f"(bearer-gated, read-only method set)")
+                _log(f"SCP plain-WS listener exposed beyond loopback on "
+                     f"ws://{host}:{port}/scp (per-credential authz: shared "
+                     f"bearer is read-only; paired devices may submit/cancel "
+                     f"tasks)")
                 self._advertiser = self._start_advertiser(wss_agent, port)
             return started
         except Exception as e:  # noqa: BLE001

--- a/src/runtime-api/server.py
+++ b/src/runtime-api/server.py
@@ -398,24 +398,30 @@ class RuntimeServer:
             wss = make_transport(port)
             await wss.start()
             started.append(wss)
-            ssl_ctx = self._wss_ssl_context()
-            if ssl_ctx is not None:
-                try:
-                    tls_port = int(os.environ.get("SUTANDO_SCP_WSS_TLS_PORT")
-                                   or "8443")
-                except ValueError:
-                    tls_port = 8443
-                tls = make_transport(tls_port)
-                await tls.start(ssl_context=ssl_ctx)
-                started.append(tls)
-                _log(f"SCP WSS TLS sibling on wss://{host}:{tls_port}/scp "
-                     f"(browser/companion clients)")
+            # Primary is live from here: the exposure warning fires and the
+            # handle list is returned even if the TLS sibling fails below.
             if host not in ("127.0.0.1", "localhost", "::1"):
                 _log(f"SCP plain-WS listener exposed beyond loopback on "
                      f"ws://{host}:{port}/scp (per-credential authz: shared "
                      f"bearer is read-only; paired devices may submit/cancel "
                      f"tasks)")
                 self._advertiser = self._start_advertiser(wss_agent, port)
+            try:
+                ssl_ctx = self._wss_ssl_context()
+                if ssl_ctx is not None:
+                    try:
+                        tls_port = int(os.environ.get("SUTANDO_SCP_WSS_TLS_PORT")
+                                       or "8443")
+                    except ValueError:
+                        tls_port = 8443
+                    tls = make_transport(tls_port)
+                    await tls.start(ssl_context=ssl_ctx)
+                    started.append(tls)
+                    _log(f"SCP WSS TLS sibling on wss://{host}:{tls_port}/scp "
+                         f"(browser/companion clients)")
+            except Exception as e:  # noqa: BLE001 — sibling is optional
+                _log(f"SCP TLS sibling failed (cleartext primary unaffected, "
+                     f"still serving): {e}")
             return started
         except Exception as e:  # noqa: BLE001
             _log(f"SCP WSS start failed (non-fatal, UDS unaffected): {e}")

--- a/src/runtime-api/server.py
+++ b/src/runtime-api/server.py
@@ -220,7 +220,7 @@ class RuntimeServer:
         return [r["requestType"] for r in self.store.pending()
                 if r.get("taskId") == task_id]
 
-    # ── LAN WSS transport (SCP over the network — opt-in) ────────────────────
+    # ── LAN WebSocket transport (SCP over the network — opt-in; cleartext ws) ─
     def _wss_token(self) -> str:
         """Resolve the bearer token: env wins, else a durable per-host token
         under state/auth/ (survives transient-state cleanup, like the other
@@ -245,7 +245,7 @@ class RuntimeServer:
         tok = secrets.token_urlsafe(32)
         tok_path.write_text(tok)
         os.chmod(tok_path, stat.S_IRUSR | stat.S_IWUSR)  # 0600
-        _log(f"generated SCP WSS token at {tok_path}")
+        _log(f"generated SCP shared bearer token (legacy scp-wss.token name) at {tok_path}")
         return tok
 
     def _wss_ssl_context(self):
@@ -338,7 +338,10 @@ class RuntimeServer:
             return None
 
     async def _maybe_start_wss(self):
-        """Start the LAN WSS transport iff SUTANDO_SCP_WSS_ENABLE is truthy.
+        """Start the LAN WebSocket transport iff SUTANDO_SCP_WSS_ENABLE is
+        truthy. The primary listener is cleartext ws://; the TLS sibling
+        (wss://) starts only when a certificate is available. Legacy _wss_*
+        names kept for env/back-compat.
         Best-effort: any failure here must NOT stop the UDS daemon from
         serving. Returns the transport (for cleanup) or None."""
         if (os.environ.get("SUTANDO_SCP_WSS_ENABLE") or "").lower() not in (

--- a/src/runtime-api/ws_transport.py
+++ b/src/runtime-api/ws_transport.py
@@ -1,27 +1,31 @@
-"""ws_transport.py — LAN WSS transport for SCP (Sutando Client Protocol).
+"""ws_transport.py — network transport for SCP (Sutando Client Protocol).
 
 A SECOND transport for the runtime-api daemon, alongside the Unix socket.
 Same SCP methods, same dispatcher — one dispatcher, N transports. This is the
-LAN-native leg: a phone-class client on the same network reaches the agent by
-dialing the Server's own WSS listener (no relay, no cloud).
+network leg: a phone-class client on the same network reaches the agent by
+dialing the Server's own listener (no relay, no cloud). The PRIMARY listener
+is plain ws:// (the SUTANDO_SCP_WSS_* env names predate that split); an
+OPTIONAL TLS sibling (SUTANDO_SCP_WSS_TLS, self-signed) exists for clients
+that require a secure context.
 
 Where the UDS transport is same-user local (0600, no auth needed), this
-transport is NETWORK-EXPOSED, so it adds two edge protections the socket does
-not need:
+transport is NETWORK-EXPOSED, so authorization is per-credential at the edge
+(_resolve_auth), not read-only across the board:
 
-  1. A bearer token on connect — Sutando's own credential. The socket's
-     filesystem permission has no analogue over the network; the token is the
-     precursor to per-device pairing credentials.
-  2. A read-only method allowlist. Network peers get the READ surface
-     (sutando.*, runtime.*, task.status/get_result, agent.*) only. Mutating
-     methods (task.submit/cancel, capability.execute, terminal.input, ...) are
-     refused at the transport edge until per-device authz lands in the
-     dispatcher. This is a coarse network-exposure stopgap — the fine-grained
-     per-device authorization stays a DISPATCHER concern (transport ≠ authz).
+  1. Shared bearer token — confined to READ_ONLY_METHODS plus task.subscribe.
+     Cannot mutate state.
+  2. Pairing token — pair.redeem only (plus the pre-auth client.hello
+     handshake, which every authenticated credential may call).
+  3. Paired device credential — authorized by its own per-device grants
+     (DEFAULT_DEVICE_GRANTS): the read surface PLUS task.submit/task.cancel
+     and voice.open/voice.close (voice.interrupt rides the voice.open grant).
+     A paired device can MUTATE owner-tier state by default; the credential,
+     not the transport, is the security boundary on the network leg.
 
-Binding defaults to loopback; exposing on the LAN is an explicit opt-in
-(SUTANDO_SCP_WSS_HOST). The transport itself is opt-in (off unless
-SUTANDO_SCP_WSS_ENABLE) so UDS-only deployments are unchanged.
+Binding defaults to loopback; exposing beyond loopback is an explicit opt-in
+(SUTANDO_SCP_WSS_HOST) with no source-address filtering. The transport itself
+is opt-in (off unless SUTANDO_SCP_WSS_ENABLE) so UDS-only deployments are
+unchanged.
 """
 from __future__ import annotations
 

--- a/src/runtime-api/ws_transport.py
+++ b/src/runtime-api/ws_transport.py
@@ -39,10 +39,8 @@ import media_frame  # noqa: E402
 from protocol import (MAX_LINE_BYTES, ProtocolError, error_frame,  # noqa: E402
                       parse_line, result_frame)
 
-# The read surface a network peer may call before per-device authz exists.
-# Anything that mutates state or reaches a governed capability is excluded and
-# refused at the edge (see module docstring). Kept as a frozenset so it cannot
-# be mutated at runtime.
+# The SHARED bearer's grant set only — paired-device credentials carry their
+# own per-device grants (task.submit/cancel/voice), resolved per connection.
 READ_ONLY_METHODS = frozenset({
     "sutando.info", "sutando.status", "sutando.owner", "sutando.allowlist",
     "runtime.health", "runtime.details",
@@ -85,7 +83,9 @@ class WsWriterSink:
 
 
 class WsTransport:
-    """A WSS front-end that dispatches SCP frames through a shared dispatcher.
+    """A WebSocket front-end that dispatches SCP frames through a shared
+    dispatcher. The primary listener is cleartext ws:// — wss:// only when a
+    TLS context is supplied (the optional sibling listener).
 
     The dispatcher is the SAME object the UDS transport uses — this class owns
     only the websocket mechanics + the network-edge gates (auth, allowlist).
@@ -393,8 +393,9 @@ class WsTransport:
                            ssl_context=ssl_context)
         await site.start()
         scheme = "wss" if ssl_context else "ws"
+        label = "SCP WebSocket (TLS)" if ssl_context else "SCP WebSocket (cleartext)"
         self._log(
-            f"SCP WSS listening on {scheme}://{self.host}:{self.port}{self.route}")
+            f"{label} listening on {scheme}://{self.host}:{self.port}{self.route}")
 
     async def cleanup(self) -> None:
         if self._runner is not None:

--- a/src/runtime-cli/sutando-runtime.py
+++ b/src/runtime-cli/sutando-runtime.py
@@ -53,14 +53,17 @@ from rundir import socket_path as _socket_path  # noqa: E402
 
 
 def _wss_url() -> str | None:
-    """Remote SCP target, if set — the SAME client, over the LAN-WSS transport
-    instead of the local Unix socket (one SCP, N transports). Env-driven so
-    every read command works over WSS with no per-command flag:
-      SUTANDO_SCP_WSS_URL    ws://<host>:<port>/scp
-      SUTANDO_SCP_WSS_TOKEN  bearer credential (from the Server's
-                             state/auth/scp-wss.token)
-    Only the read method set is served over WSS today (the transport's
-    allowlist) — mutating verbs are refused until per-device authz lands."""
+    """Remote SCP target, if set — the SAME client, over the network
+    WebSocket transport instead of the local Unix socket (one SCP, N
+    transports; ws:// is cleartext, wss:// only against the TLS sibling).
+    Env-driven so every command routes remotely with no per-command flag:
+      SUTANDO_SCP_WSS_URL    ws://<host>:<port>/scp   (legacy _WSS_ name)
+      SUTANDO_SCP_WSS_TOKEN  credential (shared bearer or a paired-device
+                             credential)
+    ALL methods route through the remote transport when the URL is set; what
+    the server serves depends on the credential — the shared bearer gets only
+    READ_ONLY_METHODS, a paired-device credential its per-device grants
+    (task.submit/cancel/voice by default)."""
     return os.environ.get("SUTANDO_SCP_WSS_URL") or None
 
 

--- a/src/runtime-cli/sutando-runtime.py
+++ b/src/runtime-cli/sutando-runtime.py
@@ -138,6 +138,14 @@ def _raw_tmux() -> int:
     # RAW = a live READ-ONLY view of the core's tmux window (everything it
     # prints). Uses tmux's own read-only attach — the firehose stays on the
     # tmux socket, never through the daemon push path. Ctrl-b d to detach.
+    if _wss_url():
+        # Gate at the chokepoint: raw is inherently LOCAL, and attaching the
+        # local tmux under a remote URL views the WRONG agent (#3565 r7).
+        print(json.dumps({"error": "raw view attaches the LOCAL tmux and is "
+                          "not served over the remote WebSocket transport — "
+                          "unset SUTANDO_SCP_WSS_URL for the local raw view"}),
+              flush=True)
+        return 2
     import subprocess
     sock = os.environ.get("SUTANDO_TMUX_SOCKET") or "/tmp/sutando-tmux.sock"
     session = os.environ.get("SUTANDO_TMUX_SESSION") or "sutando-core"

--- a/src/runtime-cli/sutando-runtime.py
+++ b/src/runtime-cli/sutando-runtime.py
@@ -140,7 +140,7 @@ def _raw_tmux() -> int:
     # tmux socket, never through the daemon push path. Ctrl-b d to detach.
     if _wss_url():
         # Gate at the chokepoint: raw is inherently LOCAL, and attaching the
-        # local tmux under a remote URL views the WRONG agent (#3565 r7).
+        # local tmux under a remote URL views the WRONG agent.
         print(json.dumps({"error": "raw view attaches the LOCAL tmux and is "
                           "not served over the remote WebSocket transport — "
                           "unset SUTANDO_SCP_WSS_URL for the local raw view"}),

--- a/src/runtime-cli/sutando-runtime.py
+++ b/src/runtime-cli/sutando-runtime.py
@@ -60,10 +60,11 @@ def _wss_url() -> str | None:
       SUTANDO_SCP_WSS_URL    ws://<host>:<port>/scp   (legacy _WSS_ name)
       SUTANDO_SCP_WSS_TOKEN  credential (shared bearer or a paired-device
                              credential)
-    ALL methods route through the remote transport when the URL is set; what
-    the server serves depends on the credential — the shared bearer gets only
-    READ_ONLY_METHODS, a paired-device credential its per-device grants
-    (task.submit/cancel/voice by default)."""
+    One-shot commands route through the remote transport when the URL is set
+    (persistent surfaces differ: task watch streams remotely, task chat
+    refuses — it is Unix-socket-only). What the server serves depends on the
+    credential — the shared bearer gets only READ_ONLY_METHODS, a paired
+    device its per-device grants (task.submit/cancel/voice by default)."""
     return os.environ.get("SUTANDO_SCP_WSS_URL") or None
 
 
@@ -148,8 +149,8 @@ def _raw_tmux() -> int:
 
 
 def _watch_wss(activity: bool = False) -> int:
-    # PUSH mode over the LAN-WSS transport — subscribe + stream results/activity
-    # live from a remote Server. Read-only stream (submit stays edge-refused).
+    # PUSH mode over the remote WebSocket transport — a read stream; what a
+    # credential may DO is resolved server-side per connection.
     import asyncio  # noqa: PLC0415
     import aiohttp  # noqa: PLC0415
     url = os.environ["SUTANDO_SCP_WSS_URL"]
@@ -162,8 +163,9 @@ def _watch_wss(activity: bool = False) -> int:
                 await ws.send_str(json.dumps({
                     "jsonrpc": "2.0", "id": "watch", "method": "task.subscribe",
                     "params": {"activity": activity}}))
+                scheme = url.split(":", 1)[0] if ":" in url else "ws"
                 print(json.dumps({"watching": True, "activity": activity,
-                                  "transport": "wss"}), flush=True)
+                                  "transport": scheme}), flush=True)
                 async for msg in ws:
                     if msg.type != aiohttp.WSMsgType.TEXT:
                         continue
@@ -602,6 +604,13 @@ async def _chat_tui(reader, writer, _send, level=0, agent_id=None) -> None:
 
 
 def _chat(activity: bool = False, verbose: bool = False, full: bool = False) -> int:
+    if _wss_url():
+        # chat multiplexes over the Unix socket only; opening the local UDS
+        # under a remote URL silently targets the WRONG agent — refuse loudly.
+        print(json.dumps({"error": "task chat is not served over the remote "
+                          "WebSocket transport yet — unset SUTANDO_SCP_WSS_URL "
+                          "to chat with the local agent"}), flush=True)
+        return 2
     try:
         asyncio.run(_chat_async(activity, verbose, full))
     except (KeyboardInterrupt, EOFError):

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -976,8 +976,8 @@ else
   echo "  ✓ screen capture (already running)"
 fi
 
-# 5a. Sutando Server (SCP WSS :8787) + voice host (:8788) — the companion/
-# wearable chain. Opt-in via SUTANDO_SCP_WSS_ENABLE=1 in .env; the voice host
+# 5a. Sutando Server (SCP WebSocket :8787, cleartext ws://) + voice host
+# (:8788) — the companion/wearable chain. Opt-in via SUTANDO_SCP_WSS_ENABLE=1 in .env; the voice host
 # additionally needs GEMINI_API_KEY (voice.open fail-softs without it).
 if [ "${SUTANDO_SCP_WSS_ENABLE:-0}" = "1" ]; then
   if ! lsof -i :8788 > /dev/null 2>&1; then

--- a/tests/runtime-api-tls-sibling-failure.test.py
+++ b/tests/runtime-api-tls-sibling-failure.test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""A TLS-sibling failure must not orphan the running cleartext primary.
+
+_maybe_start_wss starts the primary first; if the TLS sibling then raises,
+the primary's handle must still be RETURNED (so serve() can clean it up), the
+non-loopback exposure warning must already have fired, and the sibling
+failure must be logged as non-fatal.
+
+Run: python3 tests/runtime-api-tls-sibling-failure.test.py  (needs aiohttp)
+Exit: 0 on pass, 1 on fail.
+"""
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src" / "runtime-api"))
+
+FAILS = []
+
+
+def check(cond, msg):
+    print(("ok  " if cond else "FAIL") + " - " + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def run_case(tls_raises: bool, host: str):
+    import server as srv
+
+    logs = []
+    inst = srv.RuntimeServer.__new__(srv.RuntimeServer)
+    inst._state_dir = None
+    inst._subscribers = set()
+    inst._activity_subscribers = set()
+    inst._request_subscribers = set()
+    inst.dispatcher = None
+    inst._advertiser = None
+    inst._start_advertiser = lambda *a, **k: None
+    inst._wss_token = lambda: "t"
+    if tls_raises:
+        inst._wss_ssl_context = lambda: object()   # truthy → sibling attempted
+    else:
+        inst._wss_ssl_context = lambda: None
+
+    class _BoomTransport:
+        """First start() succeeds (primary); a TLS start (ssl_context set)
+        raises — reproducing a cert/bind failure on the sibling only."""
+        def __init__(self, port):
+            self.port = port
+
+        async def start(self, ssl_context=None):
+            if ssl_context is not None:
+                raise OSError("TLS probe failure")
+
+        async def cleanup(self):
+            pass
+
+    old_log = srv._log
+    srv._log = logs.append
+    old_env = os.environ.get("SUTANDO_SCP_WSS_HOST")
+    os.environ["SUTANDO_SCP_WSS_HOST"] = host
+    os.environ["SUTANDO_SCP_WSS_ENABLE"] = "1"
+    try:
+        import ws_transport
+        old_ws = ws_transport.WsTransport
+        # patch at the import site _maybe_start_wss uses
+        ws_transport.WsTransport = lambda *a, **k: _BoomTransport(k.get("port"))
+        try:
+            started = asyncio.run(inst._maybe_start_wss())
+        finally:
+            ws_transport.WsTransport = old_ws
+    finally:
+        srv._log = old_log
+        if old_env is None:
+            os.environ.pop("SUTANDO_SCP_WSS_HOST", None)
+        else:
+            os.environ["SUTANDO_SCP_WSS_HOST"] = old_env
+    return started, logs
+
+
+def main():
+    started, logs = run_case(tls_raises=True, host="0.0.0.0")
+    check(started is not None and len(started) == 1,
+          f"TLS-sibling failure still returns the primary handle: {started!r}")
+    check(any("exposed beyond loopback" in l for l in logs),
+          "non-loopback exposure warning fired before the sibling attempt")
+    check(any("TLS sibling failed" in l and "still serving" in l for l in logs),
+          f"sibling failure logged as non-fatal: {logs!r}")
+    check(not any("SCP WSS start failed" in l for l in logs),
+          "outer whole-start failure path NOT taken")
+
+    started2, logs2 = run_case(tls_raises=False, host="127.0.0.1")
+    check(started2 is not None and len(started2) == 1,
+          "no-TLS loopback start returns the primary handle")
+    check(not any("exposed beyond loopback" in l for l in logs2),
+          "loopback start emits no exposure warning")
+
+    print(f"\n{'PASS' if not FAILS else 'FAIL'} ({6 - len(FAILS)}/6)")
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/runtime-api-ws-framing.test.py
+++ b/tests/runtime-api-ws-framing.test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Framing is per-transport (docs/scp-v0.md section 2), pinned executably.
+
+Unix socket: newline-delimited — readline() hands parse_line one record per
+line. WebSocket: exactly ONE JSON-RPC object per text frame — two newline-
+joined records in a single frame are a parse error (-32700), not two requests.
+
+Run: python3 tests/runtime-api-ws-framing.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+import asyncio
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src" / "runtime-api"))
+
+import protocol  # noqa: E402
+import ws_transport as wst  # noqa: E402
+
+REQ = {"jsonrpc": "2.0", "id": 1, "method": "sutando.info", "params": {}}
+REQ2 = {"jsonrpc": "2.0", "id": 2, "method": "sutando.status", "params": {}}
+
+
+class _FakeWs:
+    def __init__(self):
+        self.sent = []
+
+    async def send_str(self, s):
+        self.sent.append(json.loads(s))
+
+
+class _FakeDispatcher:
+    def __init__(self):
+        self.calls = []
+
+    async def handle(self, method, params):
+        self.calls.append(method)
+        return {"ok": True}
+
+
+def _transport(dispatcher):
+    t = wst.WsTransport.__new__(wst.WsTransport)
+    t.dispatcher = dispatcher
+    t.device_store = None
+    t.voice_bridge = None
+    t._log = lambda *_: None
+    return t
+
+
+def _dispatch(t, ws, data):
+    auth = {"kind": "shared", "token": "x",
+            "grants": frozenset({"sutando.info", "sutando.status"})}
+    asyncio.run(t._dispatch_one(ws, None, auth, set(), data))
+
+
+class ParseLineFraming(unittest.TestCase):
+    def test_one_object_parses(self):
+        rid, method, params = protocol.parse_line(json.dumps(REQ).encode())
+        self.assertEqual((rid, method), (1, "sutando.info"))
+
+    def test_two_ndjson_records_in_one_buffer_are_a_parse_error(self):
+        raw = (json.dumps(REQ) + "\n" + json.dumps(REQ2)).encode()
+        with self.assertRaises(protocol.ProtocolError) as cm:
+            protocol.parse_line(raw)
+        self.assertEqual(cm.exception.code, -32700)
+
+    def test_unix_side_per_line_framing_is_fine(self):
+        # readline() splits; each line parses independently — the NDJSON contract.
+        for i, obj in enumerate((REQ, REQ2), 1):
+            rid, _, _ = protocol.parse_line((json.dumps(obj) + "\n").encode())
+            self.assertEqual(rid, i)
+
+
+class WsDispatchFraming(unittest.TestCase):
+    def test_one_text_frame_dispatches_once(self):
+        d = _FakeDispatcher(); ws = _FakeWs()
+        _dispatch(_transport(d), ws, json.dumps(REQ))
+        self.assertEqual(d.calls, ["sutando.info"])
+        self.assertEqual(ws.sent[0]["id"], 1)
+
+    def test_two_records_in_one_frame_dispatch_nothing(self):
+        d = _FakeDispatcher(); ws = _FakeWs()
+        _dispatch(_transport(d), ws, json.dumps(REQ) + "\n" + json.dumps(REQ2))
+        self.assertEqual(d.calls, [], "joined frame must not dispatch")
+        self.assertEqual(ws.sent[0]["error"]["code"], -32700)
+
+    def test_negative_control_presplit_frames_do_dispatch(self):
+        # Proves the assertion above can fail: split client-side and both run.
+        d = _FakeDispatcher(); ws = _FakeWs()
+        t = _transport(d)
+        for obj in (REQ, REQ2):
+            _dispatch(t, ws, json.dumps(obj))
+        self.assertEqual(d.calls, ["sutando.info", "sutando.status"])
+
+
+if __name__ == "__main__":
+    r = unittest.main(exit=False).result
+    sys.exit(0 if r.wasSuccessful() else 1)

--- a/tests/runtime-api-ws-framing.test.py
+++ b/tests/runtime-api-ws-framing.test.py
@@ -68,7 +68,8 @@ class ParseLineFraming(unittest.TestCase):
         self.assertEqual(cm.exception.code, -32700)
 
     def test_unix_side_per_line_framing_is_fine(self):
-        # readline() splits; each line parses independently — the NDJSON contract.
+        # Pins the PARSER half only: pre-split lines parse independently.
+        # The line-splitting is RuntimeServer.client readline(), not here.
         for i, obj in enumerate((REQ, REQ2), 1):
             rid, _, _ = protocol.parse_line((json.dumps(obj) + "\n").encode())
             self.assertEqual(rid, i)

--- a/tests/runtime-api-ws-startlog.test.py
+++ b/tests/runtime-api-ws-startlog.test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""The production start log names the wire it actually opened.
+
+Pinned both polarities: start() with no TLS context must announce a cleartext
+WebSocket at ws://, and with a TLS context a TLS WebSocket at wss:// — the
+word "WSS" beside a ws:// URL is the exact operator-facing ambiguity this
+guards against, so a cleartext start log containing "WSS" fails.
+
+Run: python3 tests/runtime-api-ws-startlog.test.py   (needs aiohttp + openssl)
+Exit: 0 on pass, 1 on fail.
+"""
+import asyncio
+import ssl
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src" / "runtime-api"))
+
+from ws_transport import WsTransport  # noqa: E402
+
+FAILS = []
+
+
+def check(cond, msg):
+    print(("ok  " if cond else "FAIL") + " - " + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+async def _start_and_log(ssl_context=None):
+    logs = []
+    t = WsTransport(dispatcher=None, token="t", log=logs.append,
+                    host="127.0.0.1", port=0)
+    await t.start(ssl_context=ssl_context)
+    try:
+        return logs[-1]
+    finally:
+        await t.cleanup()
+
+
+def main():
+    line = asyncio.run(_start_and_log(ssl_context=None))
+    check("ws://" in line, f"plain start logs a ws:// URL: {line!r}")
+    check("WSS" not in line,
+          f"plain start log never says WSS beside ws://: {line!r}")
+    check("cleartext" in line, f"plain start log says cleartext: {line!r}")
+
+    with tempfile.TemporaryDirectory() as td:
+        cert, key = Path(td) / "c.pem", Path(td) / "k.pem"
+        subprocess.run(["openssl", "req", "-x509", "-newkey", "rsa:2048",
+                        "-nodes", "-keyout", str(key), "-out", str(cert),
+                        "-days", "2", "-subj", "/CN=localhost"],
+                       check=True, capture_output=True)
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(cert, key)
+        line = asyncio.run(_start_and_log(ssl_context=ctx))
+    check("wss://" in line, f"TLS start logs a wss:// URL: {line!r}")
+    check("TLS" in line, f"TLS start log names TLS: {line!r}")
+
+    print(f"\n{'PASS' if not FAILS else 'FAIL'} "
+          f"({5 - len(FAILS)}/5)")
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/runtime-api-wss-client.test.py
+++ b/tests/runtime-api-wss-client.test.py
@@ -139,8 +139,9 @@ def main() -> int:
             return None
         try:
             started = _await_line(lambda l: '"watching": true' in l.lower(), 5)
-            check(started is not None and '"transport": "wss"' in started,
-                  "sutando watch over WSS opens a streaming subscription")
+            # label reflects the ACTUAL scheme: this test connects ws://
+            check(started is not None and '"transport": "ws"' in started,
+                  "sutando watch labels its true (cleartext) scheme")
             time.sleep(0.4)  # let the watcher seed past the initial step
             Path(TMP, "state", "core-status.json").write_text(json.dumps(
                 {"status": "running", "step": "WATCH-OVER-WSS", "ts": 9}))

--- a/tests/runtime-cli-remote-raw.test.py
+++ b/tests/runtime-cli-remote-raw.test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-"""Remote --raw routing: the REAL CLI refuses the local tmux attach under a
-remote URL, and leaves the local attach untouched without one.
+"""Remote routing of the persistent surfaces: the REAL CLI refuses the local
+tmux attach (--raw) and the local Unix-socket chat under a remote URL, and
+leaves both untouched without one.
 
 The raw view is inherently LOCAL (it attaches this host's tmux). With
 SUTANDO_SCP_WSS_URL configured, `task chat --raw` / `task watch --raw` must
@@ -9,9 +10,16 @@ remote profile shows the WRONG agent's output, which can include secrets and
 private task content. Without the URL, the attach must be byte-identical to
 what shipped: same tmux argv, exit code passed through.
 
-Both polarities run production dispatch via the real CLI process. A `tmux`
-shim first on PATH records its argv to a file and exits a sentinel, so "tmux
-was not invoked" is a filesystem fact, not a mock's claim.
+Ordinary `task chat` (no --raw) is a separate decision: it multiplexes over
+the local Unix socket only, so under a remote URL it must refuse (rc 2) with
+the explicit refusal and never open that socket — otherwise private or
+mutating work typed for the remote agent lands on the local one.
+
+Every polarity runs production dispatch via the real CLI process. A `tmux`
+shim first on PATH records its argv to a file and exits a sentinel, and a
+real listener bound at SUTANDO_RUNTIME_SOCKET records each accepted
+connection, so "tmux was not invoked" and "the local socket was not opened"
+are filesystem facts, not a mock's claim.
 
 Run: python3 tests/runtime-cli-remote-raw.test.py
 """
@@ -19,9 +27,11 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -42,7 +52,45 @@ def run_cli(args, env_extra, shim_dir):
     env["PATH"] = f"{shim_dir}:{env.get('PATH', '')}"
     env.update(env_extra)
     return subprocess.run([sys.executable, str(CLI), *args],
-                          capture_output=True, text=True, env=env, timeout=30)
+                          stdin=subprocess.DEVNULL, capture_output=True,
+                          text=True, env=env, timeout=30)
+
+
+def uds_listener(path, rec):
+    """Real Unix-socket server: appends one line to `rec` per accepted
+    connection, drains the peer until it closes (bounded), never replies."""
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(path)
+    srv.listen(4)
+    srv.settimeout(0.2)
+    stop = threading.Event()
+
+    def serve():
+        while not stop.is_set():
+            try:
+                conn, _ = srv.accept()
+            except socket.timeout:
+                continue
+            with open(rec, "a") as f:
+                f.write("connect\n")
+            conn.settimeout(3)
+            try:
+                while conn.recv(65536):
+                    pass
+            except OSError:
+                pass
+            conn.close()
+        srv.close()
+
+    threading.Thread(target=serve, daemon=True).start()
+    return stop
+
+
+def last_json(stdout):
+    try:
+        return json.loads(stdout.strip().splitlines()[-1])
+    except Exception:
+        return {}
 
 
 def main() -> int:
@@ -70,10 +118,7 @@ def main() -> int:
             check(r.returncode == 2, f"{name}: remote URL -> rc 2 "
                   f"(got {r.returncode})")
             check(not rec.exists(), f"{name}: remote URL -> tmux NOT invoked")
-            try:
-                err = json.loads(r.stdout.strip().splitlines()[-1])
-            except Exception:
-                err = {}
+            err = last_json(r.stdout)
             check("error" in err and "raw" in err["error"],
                   f"{name}: refusal is a machine-readable error naming raw")
 
@@ -87,6 +132,39 @@ def main() -> int:
             check(argv == ["-S", sock, "attach-session", "-t",
                            "raw-test-session", "-r"],
                   f"{name}: local -> shipped tmux argv (got {argv})")
+
+        # Ordinary `task chat`: remote URL -> refuse, and the local Unix
+        # socket must never be opened. A real listener records every accept.
+        uds = str(Path(td) / "rt.sock")
+        conn_rec = Path(td) / "uds-connects.txt"
+        stop = uds_listener(uds, conn_rec)
+        chat_env = {**base_env, "SUTANDO_RUNTIME_SOCKET": uds}
+        rec.unlink(missing_ok=True)
+        try:
+            r = run_cli(["task", "chat"],
+                        {**chat_env, "SUTANDO_SCP_WSS_URL": "ws://127.0.0.1:9/scp"},
+                        shim_dir)
+            check(r.returncode == 2,
+                  f"task chat: remote URL -> rc 2 (got {r.returncode})")
+            err = last_json(r.stdout)
+            check("not served over the remote WebSocket transport"
+                  in err.get("error", ""),
+                  "task chat: remote URL -> explicit refusal JSON")
+            check(not conn_rec.exists(),
+                  "task chat: remote URL -> local Unix socket NOT opened")
+            check(not rec.exists(),
+                  "task chat: remote URL -> tmux NOT invoked")
+
+            # Positive control: without the URL the same CLI opens the
+            # local socket, so the absence above measures the guard.
+            r = run_cli(["task", "chat"], chat_env, shim_dir)
+            n = conn_rec.read_text().count("connect") if conn_rec.exists() else 0
+            check(n == 1,
+                  f"task chat: local -> local Unix socket opened once (got {n})")
+            check(r.returncode != 2,
+                  f"task chat: local -> not the refusal rc (got {r.returncode})")
+        finally:
+            stop.set()
 
     print(("FAIL: " + "; ".join(FAILS)) if FAILS else "ALL OK")
     return 1 if FAILS else 0

--- a/tests/runtime-cli-remote-raw.test.py
+++ b/tests/runtime-cli-remote-raw.test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Remote --raw routing: the REAL CLI refuses the local tmux attach under a
+remote URL, and leaves the local attach untouched without one.
+
+The raw view is inherently LOCAL (it attaches this host's tmux). With
+SUTANDO_SCP_WSS_URL configured, `task chat --raw` / `task watch --raw` must
+refuse (rc 2) WITHOUT invoking tmux — attaching the local console under a
+remote profile shows the WRONG agent's output, which can include secrets and
+private task content. Without the URL, the attach must be byte-identical to
+what shipped: same tmux argv, exit code passed through.
+
+Both polarities run production dispatch via the real CLI process. A `tmux`
+shim first on PATH records its argv to a file and exits a sentinel, so "tmux
+was not invoked" is a filesystem fact, not a mock's claim.
+
+Run: python3 tests/runtime-cli-remote-raw.test.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CLI = REPO / "src" / "runtime-cli" / "sutando-runtime.py"
+
+FAILS: list = []
+
+
+def check(cond, msg):
+    print(("  ok  " if cond else "  FAIL ") + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def run_cli(args, env_extra, shim_dir):
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("SUTANDO_SCP_WSS_URL",)}
+    env["PATH"] = f"{shim_dir}:{env.get('PATH', '')}"
+    env.update(env_extra)
+    return subprocess.run([sys.executable, str(CLI), *args],
+                          capture_output=True, text=True, env=env, timeout=30)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        shim_dir = Path(td) / "bin"
+        shim_dir.mkdir()
+        rec = Path(td) / "tmux-argv.txt"
+        shim = shim_dir / "tmux"
+        shim.write_text("#!/bin/sh\n"
+                        f"printf '%s\\n' \"$@\" > {rec}\n"
+                        "exit 7\n")
+        shim.chmod(0o755)
+        sock = str(Path(td) / "fake-tmux.sock")
+        base_env = {"SUTANDO_TMUX_SOCKET": sock,
+                    "SUTANDO_TMUX_SESSION": "raw-test-session"}
+
+        for cmd in (["task", "chat", "--raw"], ["task", "watch", "--raw"]):
+            name = " ".join(cmd)
+
+            # Remote URL configured: refuse, and tmux must never run.
+            rec.unlink(missing_ok=True)
+            r = run_cli(cmd, {**base_env,
+                              "SUTANDO_SCP_WSS_URL": "ws://127.0.0.1:9/scp"},
+                        shim_dir)
+            check(r.returncode == 2, f"{name}: remote URL -> rc 2 "
+                  f"(got {r.returncode})")
+            check(not rec.exists(), f"{name}: remote URL -> tmux NOT invoked")
+            try:
+                err = json.loads(r.stdout.strip().splitlines()[-1])
+            except Exception:
+                err = {}
+            check("error" in err and "raw" in err["error"],
+                  f"{name}: refusal is a machine-readable error naming raw")
+
+            # No remote URL: the attach reaches tmux with the shipped argv and
+            # the exit code passes through.
+            rec.unlink(missing_ok=True)
+            r = run_cli(cmd, base_env, shim_dir)
+            check(r.returncode == 7,
+                  f"{name}: local -> tmux rc passes through (got {r.returncode})")
+            argv = rec.read_text().split() if rec.exists() else []
+            check(argv == ["-S", sock, "attach-session", "-t",
+                           "raw-test-session", "-r"],
+                  f"{name}: local -> shipped tmux argv (got {argv})")
+
+    print(("FAIL: " + "; ".join(FAILS)) if FAILS else "ALL OK")
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
docs/scp-v0.md said remote support was "aspirational: v0 is local-only" while the same branch ships `src/runtime-api/ws_transport.py` — a network transport for the same dispatcher. This PR replaces that claim with what actually ships, refined across three review rounds of production-method probes (keweichen) and per-claim verification (Echo Act IV Mini):

- **Opt-in WebSocket service** (`SUTANDO_SCP_WSS_ENABLE`), **loopback bind by default**; any bind address is accepted and no source-address restriction exists — "LAN" is intent, not an enforced boundary (reachability = bind + routing + firewall).
- **Primary listener is plain `ws://`**; TLS is an opt-in **sibling** listener (`SUTANDO_SCP_WSS_TLS`, self-signed, :8443) for browser secure-context — enabling it does not encrypt the primary port.
- **Three credential classes**: shared bearer → `READ_ONLY_METHODS`; pairing token → `pair.redeem` + the pre-auth `client.hello` handshake; paired device → its own `DEFAULT_DEVICE_GRANTS` including `task.submit`/`task.cancel`/voice — **may mutate state**. The credential, not the transport, is the security boundary.
- **Framing is per-transport**: Unix socket is newline-delimited; the WebSocket carries one JSON-RPC object per text frame.
- **Still not built**: a bundled WAN relay/discovery path for SCP. The separate remote-gateway task/result relay (its own protocol) is linked and distinguished so "SCP disabled" is never read as "no off-LAN control path exists."

Started docs-only; now also carries the code the doc's claims exposed as wrong: the per-transport framing test, the cleartext-listener start log (it said WSS beside a ws:// URL), and the stale read-only/WSS wording on the activated CLI/runtime surfaces, pinned by `tests/runtime-api-ws-startlog.test.py`. Base `feat/sutando-server` (lands on main when the parent line does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
