### PR TITLE
fix(notify-reviewers): a notice is not an ask — --kind gates the ledger and both ask-only rules

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -275,6 +275,9 @@ def main() -> int:
                     help="deliberately notify ONE reviewer; requires a reason")
     ap.add_argument("--widen-override", metavar="REASON", default="",
                     help="deliberately re-ask the SAME reviewers after 30min")
+    ap.add_argument("--kind", choices=("ask", "notice"), default="ask",
+                    help="ask (default) requests review; notice tells reviewers "
+                         "something about a PR without asking for anything")
     ap.add_argument("--room", default=None,
                     help="room the conversation is actually in. When given, a reviewer whose "
                          "Stand is not a member THERE is REFUSED rather than silently notified "
@@ -284,7 +287,9 @@ def main() -> int:
     targets, refusal_rc = resolve(names, load_roster())
     # Gates run on RESOLVED targets before any send, so no partial batch notifies
     # one person; plan mode is exempt because only a real ASK can strand a PR.
-    if a.send and len(targets) < 2 and not a.allow_single:
+    # The two-reviewer rule exists so one person being busy cannot stall a PR.
+    # A notice asks for nothing, so it cannot stall anything by going to one.
+    if a.send and a.kind == "ask" and len(targets) < 2 and not a.allow_single:
         print(f"REFUSED: {len(targets)} reviewer(s) resolved from {names!r}; the rule is at "
               "least TWO, so one being busy cannot stall the PR. Name another reviewer, "
               "or pass --allow-single '<reason>'.", file=sys.stderr)
@@ -293,7 +298,7 @@ def main() -> int:
         return refusal_rc if refusal_rc > 0 else 5
     if a.allow_single and len(targets) < 2:
         print(f"single-reviewer ask allowed: {a.allow_single}", file=sys.stderr)
-    stale, why = _stale_repeat_ask(a.message, targets, load_roster())
+    stale, why = _stale_repeat_ask(a.message, targets, load_roster()) if a.kind == "ask" else (False, "")
     if stale and not a.widen_override:
         print(f"REFUSED: {why} Re-asking the same people is not escalation — "
               "name someone new, or pass --widen-override '<reason>'.", file=sys.stderr)
@@ -381,14 +386,17 @@ def main() -> int:
             # The ask already happened; a lost ledger write makes pr-unattended
             # report NOBODY_EVER_ASKED for someone who was asked. Loud, not fatal.
             try:
-                n_logged = record_asks(a.message, t["name"])
+                n_logged = record_asks(a.message, t["name"]) if a.kind == "ask" else 0
             except OSError as e:
                 unlogged += 1
                 print(f"  WARNING: the ask to {t['name']} SUCCEEDED but was NOT recorded "
                       f"({e}) — pr-unattended will under-report this PR as unasked",
                       file=sys.stderr)
             else:
-                if n_logged:
+                if a.kind == "notice":
+                    print(f"  notice (not an ask) — nothing recorded for {t['name']}",
+                          file=sys.stderr)
+                elif n_logged:
                     print(f"  logged {n_logged} PR ask(s) for {t['name']}", file=sys.stderr)
                 else:
                     # Not counted as a failure: an ask need not concern a PR. But it

--- a/tests/sci-notify-reviewers-kind.test.py
+++ b/tests/sci-notify-reviewers-kind.test.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""A NOTICE is not an ASK: --kind must gate the ledger and both ask-only gates.
+
+Issue #3544: every message carrying a PR URL was treated as a review request,
+so telling two approvers their PR had merged was logged as an ask AND refused
+as a repeat-ask — the only way through being --widen-override, which files a
+DELIBERATE re-ask and makes the next genuine escalation look like the third.
+
+Each notice assertion is paired with the ask control that must still fire; a
+suite where only the notice cases run proves the flag is read, not that the
+gates it bypasses were ever armed.
+
+Run: python3 tests/sci-notify-reviewers-kind.test.py   (stdlib only)
+"""
+import datetime
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = (Path(__file__).resolve().parent.parent / "skills"
+          / "collaboration-intelligence" / "scripts" / "notify_reviewers.py")
+PR = "https://github.com/sonichi/sutando/pull/4242"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_nr_kind", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _iso(minutes_ago):
+    t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=minutes_ago)
+    return t.isoformat().replace("+00:00", "Z")
+
+
+class _Sent:
+    """Stands in for the room_ops mention so nothing leaves the machine."""
+    returncode = 0
+    stdout = json.dumps({"ok": True, "event_id": "$stub"})
+    stderr = ""
+
+
+class Kind(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+        self.tmp = tempfile.TemporaryDirectory()
+        d = Path(self.tmp.name)
+        self.ledger = d / "review-asks.jsonl"
+        roster = {k: {"stand": f"@{k}-stand:x", "room": "!r:x", "human": f"@{k}:x"}
+                  for k in ("alice", "bob")}
+        self.roster_file = d / "roster.json"
+        self.roster_file.write_text(json.dumps(roster))
+        self.calls = []
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, argv):
+        def fake_run(args, **kw):
+            self.calls.append(args)
+            return _Sent()
+        with patch.object(self.mod, "ledger_path", lambda: self.ledger), \
+             patch.object(self.mod, "roster_path", lambda: self.roster_file), \
+             patch.object(self.mod.subprocess, "run", fake_run), \
+             patch.object(self.mod.sys, "argv", ["notify_reviewers.py"] + argv):
+            return self.mod.main()
+
+    def _ledger_lines(self):
+        if not self.ledger.exists():
+            return []
+        return [x for x in self.ledger.read_text().splitlines() if x.strip()]
+
+    def _seed_stale_asks(self, *reviewers, minutes=45):
+        with open(self.ledger, "a") as fh:
+            for r in reviewers:
+                fh.write(json.dumps({"repo": "sonichi/sutando", "pr": 4242,
+                                     "reviewer": r, "ts": _iso(minutes),
+                                     "channel": "room"}) + "\n")
+
+    # --- the ledger -------------------------------------------------------
+    def test_CONTROL_an_ask_is_recorded(self):
+        rc = self._run(["--reviewers", "alice,bob", "--message", f"review {PR}", "--send"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(self._ledger_lines()), 2,
+                         "the ask path must write, or the notice assertion below is vacuous")
+
+    def test_a_notice_is_not_recorded_as_an_ask(self):
+        rc = self._run(["--reviewers", "alice,bob", "--message", f"merged {PR}",
+                        "--send", "--kind", "notice"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self._ledger_lines(), [],
+                         "a merge announcement recorded as an ask corrupts pr-unattended")
+
+    def test_a_notice_still_sends(self):
+        self._run(["--reviewers", "alice,bob", "--message", f"merged {PR}",
+                   "--send", "--kind", "notice"])
+        mentions = [c for c in self.calls if "mention" in c]
+        self.assertEqual(len(mentions), 2, "the notice must still reach both stands")
+
+    # --- the two-reviewer rule -------------------------------------------
+    def test_CONTROL_an_ask_to_one_reviewer_is_refused(self):
+        rc = self._run(["--reviewers", "alice", "--message", f"review {PR}", "--send"])
+        self.assertEqual(rc, 5)
+
+    def test_a_notice_to_one_reviewer_is_allowed(self):
+        rc = self._run(["--reviewers", "alice", "--message", f"merged {PR}",
+                        "--send", "--kind", "notice"])
+        self.assertEqual(rc, 0, "the rule stops a PR stalling on one person; "
+                                "a notice asks for nothing and cannot stall it")
+
+    # --- the repeat-ask gate ---------------------------------------------
+    def test_CONTROL_a_repeat_ask_is_refused(self):
+        self._seed_stale_asks("alice", "bob")
+        rc = self._run(["--reviewers", "alice,bob", "--message", f"re-review {PR}", "--send"])
+        self.assertEqual(rc, 6)
+
+    def test_a_notice_to_the_same_people_is_not_a_repeat_ask(self):
+        self._seed_stale_asks("alice", "bob")
+        rc = self._run(["--reviewers", "alice,bob", "--message", f"merged {PR}",
+                        "--send", "--kind", "notice"])
+        self.assertEqual(rc, 0, "telling the approvers their PR landed is the exact "
+                                "case #3544 reports being refused as spam")
+
+    # --- the default must not move ---------------------------------------
+    def test_the_default_kind_is_ask(self):
+        self._seed_stale_asks("alice", "bob")
+        rc = self._run(["--reviewers", "alice,bob", "--message", f"re-review {PR}", "--send"])
+        self.assertEqual(rc, 6, "omitting --kind must behave exactly as before")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #3544 — its **second** defect. The first (a refusal reading `none has reviewed` when the code only consults the local ask ledger) is **already fixed on `main`**: the string is gone and the message now says *"review state not checked here — read it before reporting anyone unresponsive."* Verified with a control before writing anything — `none has reviewed` grep-counts **0** on main while `_stale_repeat_ask` counts **2**, so the file is the right one and the zero is real.

## The live defect

`notify_reviewers.py` decides a message is a review request by looking for a PR URL in it:

```python
refs = {(m.group(1), int(m.group(2))) for m in _PR_URL.finditer(message)}
```

Nothing distinguishes *"please review this"* from *"this merged, thank you"*. So telling the two people who approved a PR that it landed is:

1. **written to the ask ledger** as if they had been asked again, which is what `pr-unattended.py` reads to decide whether a PR is waiting on someone, and
2. **refused by the repeat-ask gate** as spam, with `--widen-override '<reason>'` the only way through — and that files a *deliberate re-ask*, so the next genuine escalation reads as the third.

The courtesy of telling reviewers their work landed is exactly the message the tool cannot send.

## The fix

`--kind {ask,notice}`, default `ask`. A `notice` skips the ledger, the two-reviewer minimum, and the repeat-ask gate. Every existing caller is unchanged because the default is the old behaviour.

Intent is now **stated** rather than inferred from a URL, which is what the issue asked for.

**Exempting a notice from the two-reviewer rule is deliberate, not an oversight.** That rule exists so one busy person cannot stall a PR; a notice asks for nothing and cannot stall anything.

**Corrected after review — the original wording here cited a backstop that does not exist in this repo.** It said a smuggled ask would be caught because `pr-unattended` reports the PR as unasked. @sutando-rui grepped for it and found **5 occurrences, every one of them prose inside a comment or a test docstring** — there is no such reporter here. I confirmed it (control: `notify_reviewers` appears 14 times in the same search). The tool is real but **host-local**, living outside the repo entirely.

**And @sutando-rui checked their own machine: there is no `<workspace>/tools/` directory there at all.** I will not restate that as *"no host but mine has it"* — I have surveyed no hosts. What I can verify is the mechanism: `tools/` reaches my vault only through a local gitignore carve-out that the **shipped** `sutando.config.json` does not include (it carries `notes/`, `hosts/*/`, and the memory tree). So the tool is not distributed by anything; it is on this machine by local accident. For a safety argument about a gate every host relies on, host-local is the part that matters more than repo-absent, and it makes the reframing below load-bearing rather than stylistic: *nothing can misreport what nothing records* holds on a host with no reporter at all. My original justification would not have.

Their reframing is stronger and needs no reporter at all: a notice-smuggled ask **writes nothing**, so it produces *under*-attention (the PR sits and nothing claims it was asked) rather than *false* attention (a phantom ask recorded, the PR reading as attended). **Nothing can misreport what nothing records.** What is not true is that any tooling flags it — the correction is a human noticing.

## Test

`tests/sci-notify-reviewers-kind.test.py` — 8 assertions, driving the real `main()` in-process with the room_ops mention stubbed so nothing leaves the machine.

**Every notice assertion is paired with the ask control that must still fire.** A suite where only the notice cases run proves the flag is read, not that the gates it bypasses were ever armed:

| behaviour | ask (control) | notice |
|---|---|---|
| ledger | 2 lines written | 0 lines |
| one reviewer + `--send` | refused, rc 5 | allowed, rc 0 |
| repeat after a 45-min-old ask | refused, rc 6 | allowed, rc 0 |
| still reaches both stands | — | 2 mentions sent |

Plus `test_the_default_kind_is_ask`: omitting `--kind` still refuses the repeat-ask with rc 6.

## Mutation results

Each of the three routings reverted individually, and one equivalent mutant:

```
baseline                                          8/8 pass
two-reviewer gate ignores kind                    KILLED
repeat-ask gate ignores kind                      KILLED
ledger ignores kind                               KILLED
`a.kind != "notice"` (same predicate, respelled)  SURVIVES
```

The harness asserts each substitution anchor is unique before mutating and that the source is restored byte-identical afterwards, so a mutation that silently failed to apply cannot read as a kill.

## Checks

```
tests/sci-notify-reviewers-kind.test.py    8/8
sci-notify-reviewers.test.py               pass   (sibling, unchanged)
sci-notify-reviewers-inproc.test.py        pass   (sibling, unchanged)
notify-reviewers-human-shapes.test.py      pass   (sibling, unchanged)
scripts/review-checks.sh --diff            rc=0 — hardcoded-paths + root-artifacts + prose-cap
```

`ruff` is not installed on this host, so that one is unverified locally and left to CI rather than claimed.

## Known, not fixed here

**`--kind notice` also bypasses the 30-minute repeat throttle** (@sutando-rui, non-blocking): `_stale_repeat_ask` was the only limit on repeat traffic to the same Stand, so `notice` is now the unthrottled path to someone. Defensible for the courtesy case this fixes, and worth stating plainly rather than discovering.

One added line — the docstring in `sci-notify-reviewers-kind.test.py` reading "corrupts pr-unattended" — names that same repo-absent tool. Left as-is rather than pushing a new commit over a review already given at this head; happy to reword it if a reviewer would rather have it in.

## Related, not fixed here

#3468 — a deliberate DO-NOT-ROUTE refusal reported as missing data. Same family as this one and as #3544's first half: **the tool reports its own bookkeeping as a fact about the world.** Left separate; it is a different call site and deserves its own before/after.
