### PR TITLE
fix(skills): resolve paths from the workspace and the module, not process.cwd()

### DIFF
--- a/skills/gws-gmail-voice/SCORING_RUNBOOK.md
+++ b/skills/gws-gmail-voice/SCORING_RUNBOOK.md
@@ -2,7 +2,11 @@
 
 Version-controlled source of truth for the LLM-driven inbox-importance scorer used by `skills/gws-gmail-voice/`. The cron prompt (`score-inbox-llm`, gitignored per-machine) is a thin wrapper that says: *"Run the procedure in `skills/gws-gmail-voice/SCORING_RUNBOOK.md`"*.
 
-When a scoring pass fires, it executes the steps below. The result is `state/external-cache/inbox-important.json` consumed by the `triage_email` voice tool (cache-first 3-tier path).
+**`<workspace>` is `bash scripts/sutando-config.sh workspace` — resolve it, never a bare
+relative path.** The reader resolves the cache from the workspace; a writer that resolves
+it against its own cwd lands the file where nothing reads it, which is #3546 in reverse.
+
+When a scoring pass fires, it executes the steps below. The result is `<workspace>/state/external-cache/inbox-important.json` consumed by the `triage_email` voice tool (cache-first 3-tier path).
 
 > **Note on owner-specific tuning.** Per-fleet additions (voice-friendly rationale rules, state-aware demotion logic for PR/issue notifications, active-thread boost, top-3 time-sensitive ordering) live in the operator's private skill repo because they encode specific people, PR numbers, and event names. The algorithm shape below is the version every clone gets; operators can layer their own tuning rules on top.
 
@@ -18,7 +22,7 @@ The LLM judges importance with full grounding. Rules retired in PR #705.
 
 ## Per-pass procedure (incremental)
 
-1. **Read existing cache** at `state/external-cache/inbox-important.json`. If absent, treat `scored_emails` as `{}`.
+1. **Read existing cache** at `<workspace>/state/external-cache/inbox-important.json`. If absent, treat `scored_emails` as `{}`.
 
 2. **Fetch current unread** via `gws gmail +triage --format json --max 200`. The full unread queue is ~200 messages; the runbook's incremental algorithm (see step 5) means each one gets scored ONCE then reused via `scored_at` TTL, so a wider net costs the same in steady state. The prior `--max 30` was caught missing buried-important items like calendar invitations and academic follow-ups several days into the queue.
 
@@ -46,7 +50,7 @@ The LLM judges importance with full grounding. Rules retired in PR #705.
 
 6. **Pick `top_3_ids`** by importance ordering: high > medium > low; tie-break by recency (newer first; gws returns newest-first so iterate the current scan in order).
 
-7. **Atomic-write** to `state/external-cache/inbox-important.json` via tmp+rename. Schema below.
+7. **Atomic-write** to `<workspace>/state/external-cache/inbox-important.json` via tmp+rename. Schema below.
 
 ## Cache schema (v2)
 

--- a/skills/gws-gmail-voice/tools.ts
+++ b/skills/gws-gmail-voice/tools.ts
@@ -31,10 +31,13 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
+import { resolveWorkspace } from '../../src/workspace_default.js';
 
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
-const CACHE_PATH = join(process.cwd(), 'state', 'external-cache', 'inbox-important.json');
+// The cache lives under the WORKSPACE. cwd is whatever launched the agent —
+// on this host the repo, which is a different tree, so tier 1 never hit.
+const CACHE_PATH = join(resolveWorkspace(), 'state', 'external-cache', 'inbox-important.json');
 // 30 min TTL: balances cache-hit rate (~95% at 30min vs ~70% at 15min) against
 // staleness. Live gws fallback covers the freshness edge case anyway. Per Mini PR #704 review.
 const CACHE_MAX_AGE_MS = 30 * 60 * 1000;

--- a/skills/obsidian-vault/tools.ts
+++ b/skills/obsidian-vault/tools.ts
@@ -20,6 +20,7 @@ import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { resolveWorkspace } from '../../src/workspace_default.js';
 
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
@@ -173,7 +174,9 @@ const runDreamTool: ToolDefinition = {
     parameters: z.object({}),
     execute: async () => {
         try {
-            const scriptPath = `${process.env.SUTANDO_REPO_DIR || process.cwd()}/skills/obsidian-vault/scripts/dream.py`;
+            // Sibling of this module, so it resolves wherever the skill is loaded
+            // from. fileURLToPath, never .pathname: the latter stays percent-encoded.
+            const scriptPath = fileURLToPath(new URL('scripts/dream.py', import.meta.url));
             // Fire-and-forget: detach so the voice turn returns immediately.
             // `--force` bypasses the SUTANDO_OBSIDIAN_MIRROR opt-in gate
             // because this is an explicit user invocation (the user said

--- a/tests/cwd-lint.test.py
+++ b/tests/cwd-lint.test.py
@@ -11,12 +11,14 @@ set but the write lands in the repo root.  Issue #863.
 
 ## What is checked
 
-TypeScript (src/ + scripts/):
+TypeScript (src/ + scripts/ + skills/):
   - Fail on any non-comment line containing `process.cwd()`
   - Allowlist: none needed (workspace_default.ts / util_paths.ts mention it
     only in docblocks; the canonical resolver uses $env + homedir(), not cwd)
 
-Python (src/ + scripts/):
+Python (src/ + scripts/) — skills/ NOT yet covered: 7 hits there need
+  per-site triage (comments explaining why getcwd is wrong, argparse
+  defaults for an explicit --cwd flag), not a blanket ban.
   - Fail on any non-comment line containing `Path.cwd()` or `os.getcwd()`
   - Allowlist: src/workspace_default.py (uses Path.cwd() for relative-path
     anchor in _expand_tilde, which is correct and intentional)
@@ -31,6 +33,14 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 SRC  = REPO / "src"
 SCRIPTS = REPO / "scripts"
+SKILLS = REPO / "skills"
+
+# One definition per language. The summary line used to re-derive these, so a
+# scope change silently left it reporting a count for a set nobody scanned.
+TS_ROOTS = [SRC, SCRIPTS, SKILLS]
+TS_EXTS = (".ts", ".tsx", ".js", ".mjs")
+PY_ROOTS = [SRC, SCRIPTS]
+PY_EXTS = (".py",)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,7 +83,9 @@ TS_ALLOWLIST: set[str] = set()  # no files need allowlisting today
 
 def check_ts_cwd() -> list[str]:
     failures = []
-    ts_files = _scan_files([SRC, SCRIPTS], (".ts", ".tsx", ".js", ".mjs"))
+    # skills/ included since #3546: a manifest skill's tools.ts is dynamic-
+    # imported at runtime and resolves paths exactly like src/ does.
+    ts_files = _scan_files(TS_ROOTS, TS_EXTS)
     for path in ts_files:
         rel = path.relative_to(REPO)
         if str(rel) in TS_ALLOWLIST:
@@ -96,7 +108,7 @@ PY_ALLOWLIST = {
 
 def check_py_cwd() -> list[str]:
     failures = []
-    py_files = _scan_files([SRC, SCRIPTS], (".py",))
+    py_files = _scan_files(PY_ROOTS, PY_EXTS)
     for path in py_files:
         rel = path.relative_to(REPO)
         if str(rel) in PY_ALLOWLIST:
@@ -154,6 +166,6 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    ts_count = len(_scan_files([SRC, SCRIPTS], (".ts", ".tsx", ".js", ".mjs")))
-    py_count = len(_scan_files([SRC, SCRIPTS], (".py",)))
+    ts_count = len(_scan_files(TS_ROOTS, TS_EXTS))
+    py_count = len(_scan_files(PY_ROOTS, PY_EXTS))
     print(f"cwd-lint: OK — {ts_count} TS files, {py_count} Python files, 0 violations")


### PR DESCRIPTION
Closes #3546.

## Two sites, and only one of them is currently broken

**`skills/gws-gmail-voice/tools.ts` — live defect.** The triage cache resolved against `process.cwd()`. Re-measured on this host today:

```
voice-agent cwd                    <repo>/engine/sutando        <- NOT the workspace
<repo>/state/external-cache        ABSENT      (where the code looked)
<workspace>/state/external-cache   ABSENT
CONTROL: <workspace>/state         EXISTS      (the probe can return a positive)
```

`SCORING_RUNBOOK.md` documents a cache-first 3-tier path (cache → live `gws` → generic handoff), and the reader could never find tier 1 where it was looking.

**⚠ Qualifier, raised by @sutando-rui and verified here: "tier 1 has never been able to hit" is under-determined on this host, and I stated it as measured.** A second cause is independently sufficient — `score-inbox-llm` is **not in this host's `crons.json`** (11 jobs, none matching; control: `main-loop` present), so the writer never runs and tier 1 could not hit whatever the reader's path was. The path defect is real and is the one that matters on a host where the cron *is* scheduled; it is not established as the operative cause here.

**⚠ This corrects the evidence in the issue**, which said cwd was `/Users/yixuan` and the cache resolved under the home directory. It does not, today — either the process was relaunched with a different cwd or my original `lsof` read a different pid. The defect is unchanged; the wrong directory is a different wrong directory, and "resolves to home" invites a different fix than "resolves to the repo instead of the workspace". Corrected on the issue too, not just here.

**`skills/obsidian-vault/tools.ts` — same class, currently latent.**

```ts
const scriptPath = `${process.env.SUTANDO_REPO_DIR || process.cwd()}/skills/obsidian-vault/scripts/dream.py`;
```

`SUTANDO_REPO_DIR` is **not set** in the running voice-agent (control: `PATH` and `HOME` both present in the same `ps eww` read), so the fallback is live — and resolves correctly *only because cwd is currently the repo*. The spawn is fire-and-forget, so from any other cwd this fails with no user-visible signal. Correct by circumstance, one relaunch from breaking.

Resolved from `import.meta.url` rather than the workspace, because the target is a repo file, not workspace state. Safe here: `scripts/build-bundle.mjs` records that these manifest-skill `tools.ts` are **not** bundled — they are dynamic-imported from the repo at runtime — so the module's own location is a stable anchor. `fileURLToPath`, never `.pathname`, per the note already in `src/voice-context.ts`.

## The writer side, added after review

@sutando-rui pointed out that fixing only the reader can **move** the mismatch rather than close it: `SCORING_RUNBOOK.md` specified the cache as a **bare relative path** in three places, and its writer is an agent-executed per-machine cron that resolves that against its own cwd. Verified here — `inbox-important` appears in exactly **two files** (the runbook and `tools.ts`; control: `resolveWorkspace` appears in 35 — **corrected: I first published 34, which I had measured in the installed engine checkout, a tree 29 commits behind this PR and not a git repo at all. The load-bearing 2 is identical on both trees, which is why it held; the control was well-formed about the wrong corpus. Found because @sutando-bassil got 53 unfiltered, called it a scope difference not worth chasing, and chasing it anyway surfaced the tree mix-up rather than the grep flag**), so the runbook is the only place the writer's path is specified at all. All three references are now anchored to `<workspace>/`, with the resolution rule stated once at the top.

**This invalidated @sutando-rui's approval at `1340ef57`, deliberately.** They flagged it non-blocking; I pushed anyway because leaving the writer relative ships a fix that can relocate a bug rather than end it — a correctness gap, not the comment nit they were right to wave through last time.

## The lint that should have caught both

`tests/cwd-lint.test.py` scoped to `src/` and `scripts/`. A manifest skill's `tools.ts` is dynamic-imported at runtime and resolves paths exactly the way `src/` does, so the exemption was never principled. TypeScript scanning now covers `skills/`:

```
src + scripts           92 files
src + scripts + skills 115 files   (+23)
violations after this PR: 0
```

**Python is deliberately left at `src/` + `scripts/`.** It has 7 hits under `skills/`, and several are legitimate — `ms365.py` mentions `os.getcwd()` only in comments explaining why it must not be used, and two files use it as an argparse default for an explicit `--cwd` flag. That needs per-site triage, not a blanket ban, and it is a different PR.

## Mutation results

```
baseline                                              0 violations, 115 TS files
revert gws to process.cwd()                           CAUGHT
revert obsidian to process.cwd()                      CAUGHT
CONTROL: same gws bug, skills/ removed from scope     MISSED (0 violations, 92 TS files)
```

The control is the one that matters: with `skills/` out of scope the identical bug goes uncaught, which is what shows the scope extension is doing the work rather than something incidental. Its anchor is asserted unique before substituting — **a mutation that silently fails to apply reads exactly like a pass**, and that is not hypothetical here: my first version of this control edited a string the refactor below had already removed, and the harness reported the expectation unmet rather than green.

## One defect I introduced and caught mid-change

Extending the check left `sanity_checks()` re-deriving the roots independently, so the summary line reported **92 files while the check scanned 115** — a correct check under a wrong label. The scan roots are now defined once (`TS_ROOTS`/`PY_ROOTS`) so the count and the check cannot disagree by construction. The tell was the file count not moving between two runs that should have differed.

## Checks

```
tests/cwd-lint.test.py                     0 violations, 115 TS / 187 Python files
mutation harness                           2 caught, 1 control missed as required
eslint (both changed files)                rc=0
tsc --noEmit                               8 pre-existing errors, 0 in changed files
                                           (control: same 8 with the diff stashed)
scripts/review-checks.sh --diff            rc=0 — hardcoded-paths + root-artifacts + prose-cap
```
