### PR TITLE
fix(notify-reviewers): a refusal must carry the roster's reason, not just its shape

### DIFF
--- a/skills/collaboration-intelligence/references/schema.md
+++ b/skills/collaboration-intelligence/references/schema.md
@@ -270,3 +270,15 @@ Treat these as defaults, not truth:
 | Explicit identity / ownership | 180 days |
 
 Explicit end dates and newer contradictory evidence override these windows.
+
+## Roster refusal keys
+
+`allowlisted` (bool | null) — whether a mention to this Stand has been observed to
+trigger it. `false` REFUSES the send. **It records an observation, not a cause**:
+nothing in the tree sets it after a detected bounce, so no message may claim one.
+`null`/absent means never observed — send, then record.
+
+`refusal_basis` / `note` (string) — the entry's own words for why it refuses, printed
+verbatim by `notify_reviewers.resolve()`. Required whenever a blank `stand`/`room` is
+DELIBERATE: without it the refusal reads as missing data and the obvious repair —
+populating the fields — silently overrides it (#3468). `refusal_basis` wins over `note`.

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -60,6 +60,19 @@ def load_roster() -> dict:
     return data
 
 
+def stated_reason(entry: dict) -> str:
+    """The roster's own words for why an entry refuses, if it gave any.
+
+    A blank `stand` can be missing data OR a deliberate DO-NOT-ROUTE. Only the
+    entry knows which, and a refusal that omits it invites the repair that
+    overrides it (#3468)."""
+    for key in ("refusal_basis", "note"):
+        v = entry.get(key)
+        if isinstance(v, str) and v.strip():
+            return " ".join(v.split())
+    return ""
+
+
 def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
     """(targets, refusal_rc): one bad entry must never starve the rest of the
     batch — resolvable reviewers are still notified, the worst refusal code
@@ -73,14 +86,22 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
             worst = max(worst, 2)
             continue
         stand, room = entry.get("stand"), entry.get("room")
+        why = stated_reason(entry)
         if not stand or not room:
             # a human id alone cannot be a target: person-mentions trigger no Stand
             print(f"UNUSABLE entry '{name}': needs both 'stand' and 'room' "
                   f"(human-only = not Stand addressing)", file=sys.stderr)
+            # Without this the refusal reads as a data gap, and the obvious
+            # repair — populate the fields — silently overrides the refusal.
+            if why:
+                print(f"  roster says: {why}", file=sys.stderr)
             worst = max(worst, 3)
             continue
         if entry.get("allowlisted") is False:
-            print(f"OFF-ALLOWLIST '{name}': {stand} bounced a mention before —"
+            # "bounced before" is a claim about history this code never checked.
+            # Where the roster states a reason, print THAT instead of asserting one.
+            because = f"{stand} bounced a mention before" if not why else why
+            print(f"OFF-ALLOWLIST '{name}': {because} —"
                   " route through the owner instead of re-sending",
                   file=sys.stderr)
             worst = max(worst, 4)

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -98,11 +98,11 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
             worst = max(worst, 3)
             continue
         if entry.get("allowlisted") is False:
-            # "bounced before" is a claim about history this code never checked.
-            # Where the roster states a reason, print THAT instead of asserting one.
-            because = f"{stand} bounced a mention before" if not why else why
-            print(f"OFF-ALLOWLIST '{name}': {because} —"
-                  " route through the owner instead of re-sending",
+            # State the FLAG, never a cause: nothing sets allowlisted=False after
+            # a detected bounce, so any history claim here would be a guess.
+            print(f"OFF-ALLOWLIST '{name}': {stand} is not allowlisted for mentions"
+                  + (f" — {why}" if why else "")
+                  + " — route through the owner instead of re-sending",
                   file=sys.stderr)
             worst = max(worst, 4)
             continue

--- a/tests/sci-notify-reviewers-refusal-basis.test.py
+++ b/tests/sci-notify-reviewers-refusal-basis.test.py
@@ -83,13 +83,17 @@ class RefusalOutput(unittest.TestCase):
             {"x": {"stand": "@s:x", "room": "!r:x", "allowlisted": False, "note": BASIS}})
         self.assertEqual(rc, 4)
         self.assertIn("DO NOT ROUTE", err)
-        self.assertNotIn("bounced a mention before", err,
-                         "with a stated reason, the code must not assert a history it never checked")
+        self.assertNotIn("bounced", err,
+                         "the code must not assert a history it never checked")
 
-    def test_CONTROL_off_allowlist_without_a_note_keeps_the_old_wording(self):
+    def test_CONTROL_off_allowlist_without_a_note_claims_no_history_either(self):
+        # The old wording asserted "bounced a mention before". Nothing sets
+        # allowlisted=False after a bounce, so that was a guess, not a fallback.
         _, rc, err = self._resolve({"x": {"stand": "@s:x", "room": "!r:x", "allowlisted": False}})
         self.assertEqual(rc, 4)
-        self.assertIn("bounced a mention before", err)
+        self.assertIn("not allowlisted for mentions", err)
+        self.assertNotIn("bounced", err,
+                         "with no stated reason the code must still not invent a cause")
 
     # --- the batch must not be starved, and rc must not drift ------------
     def test_CONTROL_a_usable_entry_still_resolves_alongside_a_refused_one(self):

--- a/tests/sci-notify-reviewers-refusal-basis.test.py
+++ b/tests/sci-notify-reviewers-refusal-basis.test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""A refusal must carry the roster's REASON, or the obvious repair overrides it.
+
+Issue #3468: a blank `stand`/`room` can be missing data OR a deliberate
+DO-NOT-ROUTE. `resolve()` refused correctly and explained it mechanically
+("needs both 'stand' and 'room'"), which reads as a data gap — so the natural
+repair is to populate the fields, silently converting the refusal into a
+routable entry. The roster held the reason; the one code path that could
+surface it discarded it.
+
+Every assertion is paired with its negative: a note must appear when present
+AND must not be invented when absent. A suite that only checks the first
+proves the string was added, not that it came from the entry.
+
+Run: python3 tests/sci-notify-reviewers-refusal-basis.test.py   (stdlib only)
+"""
+import importlib.util
+import io
+import contextlib
+import unittest
+from pathlib import Path
+
+SCRIPT = (Path(__file__).resolve().parent.parent / "skills"
+          / "collaboration-intelligence" / "scripts" / "notify_reviewers.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_nr_basis", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+BASIS = "DO NOT ROUTE. Owner instruction; the empty stand is not missing data."
+
+
+class StatedReason(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def test_refusal_basis_wins_over_note(self):
+        r = self.mod.stated_reason({"refusal_basis": "the basis", "note": "the note"})
+        self.assertEqual(r, "the basis")
+
+    def test_note_is_used_when_there_is_no_basis(self):
+        self.assertEqual(self.mod.stated_reason({"note": "the note"}), "the note")
+
+    def test_absent_blank_and_non_string_all_yield_empty(self):
+        for entry in ({}, {"note": ""}, {"note": "   "}, {"note": None}, {"note": ["x"]}):
+            self.assertEqual(self.mod.stated_reason(entry), "",
+                             f"{entry!r} must not produce a reason")
+
+    def test_newlines_are_folded_so_the_reason_stays_one_line(self):
+        self.assertEqual(self.mod.stated_reason({"note": "a\n  b\nc"}), "a b c")
+
+
+class RefusalOutput(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def _resolve(self, roster, names=("x",)):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            targets, rc = self.mod.resolve(list(names), roster)
+        return targets, rc, err.getvalue()
+
+    # --- blank stand/room ------------------------------------------------
+    def test_unusable_entry_prints_the_roster_reason(self):
+        _, rc, err = self._resolve({"x": {"stand": "", "room": "", "note": BASIS}})
+        self.assertEqual(rc, 3)
+        self.assertIn("DO NOT ROUTE", err)
+
+    def test_CONTROL_unusable_without_a_note_invents_nothing(self):
+        _, rc, err = self._resolve({"x": {"stand": "", "room": ""}})
+        self.assertEqual(rc, 3)
+        self.assertIn("UNUSABLE", err)
+        self.assertNotIn("roster says", err,
+                         "a reason must come from the entry, never from the code")
+
+    # --- off-allowlist ---------------------------------------------------
+    def test_off_allowlist_states_the_roster_reason_instead_of_asserting_a_bounce(self):
+        _, rc, err = self._resolve(
+            {"x": {"stand": "@s:x", "room": "!r:x", "allowlisted": False, "note": BASIS}})
+        self.assertEqual(rc, 4)
+        self.assertIn("DO NOT ROUTE", err)
+        self.assertNotIn("bounced a mention before", err,
+                         "with a stated reason, the code must not assert a history it never checked")
+
+    def test_CONTROL_off_allowlist_without_a_note_keeps_the_old_wording(self):
+        _, rc, err = self._resolve({"x": {"stand": "@s:x", "room": "!r:x", "allowlisted": False}})
+        self.assertEqual(rc, 4)
+        self.assertIn("bounced a mention before", err)
+
+    # --- the batch must not be starved, and rc must not drift ------------
+    def test_CONTROL_a_usable_entry_still_resolves_alongside_a_refused_one(self):
+        roster = {"bad": {"stand": "", "room": "", "note": BASIS},
+                  "good": {"stand": "@g:x", "room": "!r:x", "human": "@h:x"}}
+        targets, rc, _ = self._resolve(roster, names=("bad", "good"))
+        self.assertEqual([t["name"] for t in targets], ["good"])
+        self.assertEqual(rc, 3, "the worst refusal code must still reach the caller")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #3468.

## The defect

A blank `stand`/`room` in the roster can mean two opposite things — **missing data**, or a **deliberate DO-NOT-ROUTE**. `resolve()` refused correctly and explained only the *shape*:

```
UNUSABLE entry 'X': needs both 'stand' and 'room' (human-only = not Stand addressing)
```

That reads as a data gap, so the obvious repair is to populate the fields — which **silently converts a deliberate refusal into a routable entry**. The person most likely to do it is whoever hits the wall later and has no idea the blank was intentional.

The roster already carries the reason. `resolve()` never read it.

## Before / after, on this host's real roster entry

Both measured on this tree at `origin/main` and at HEAD — not in an installed checkout:

```
BEFORE  rc=3
  UNUSABLE entry 'keweichen': needs both 'stand' and 'room' (human-only = not Stand addressing)

AFTER   rc=3
  UNUSABLE entry 'keweichen': needs both 'stand' and 'room' (human-only = not Stand addressing)
    roster says: UNCHANGED. The empty `stand` field is NOT missing data — routing is refused by
    owner instruction. Finding the Stand does not lift it. Do not populate `stand`.
```

Same exit code, same first line. The second line is the difference between a wall and a wall with a sign on it.

## The second branch — and review found my first fix half-closed it

`OFF-ALLOWLIST` hard-coded *"{stand} bounced a mention before"*. My first version replaced that with the entry's reason **only when one existed**; with none — the common case — it still printed the unfounded claim with its old authority. @sutando-rui caught that, and both reviewers checked the premise rather than weighing the argument.

Independently confirmed here:

```
allowlisted   in references/schema.md   0     (CONTROL: `room` -> 22, so the file does document things)
refusal_basis in references/schema.md   0
allowlisted set to False after a bounce anywhere in the tree   NONE
lookup.py                               passes the field through, no semantics
```

So the clause was never a *fallback for entries that really bounced* — nothing distinguishes those from any other `allowlisted: false`. It was a **guessed meaning for an undocumented boolean**, and our own roster already disproves it. That also rules out the alternative I floated (always assert, then append the reason): as @bassilkhilo-ag2 put it, that ships a message contradicting itself in the same breath.

Now it states the flag and appends the entry's words when it has any, so **no branch asserts history**:

```
with a reason : @s:x is not allowlisted for mentions — owner instruction — route through the owner...
no reason     : @s:x is not allowlisted for mentions — route through the owner...
```

## Schema, added for the same reason

`refusal_basis` is a key this PR teaches the code to read, with **0 mentions in `references/schema.md`** — shipping a reader for an undocumented field is exactly the store/reader drift #3560 describes, and `allowlisted` is the cautionary case sitting next to it: undocumented, which is why its meaning had to be guessed at in a user-facing string. Both are now defined.

## Test

`tests/sci-notify-reviewers-refusal-basis.test.py` — 9 assertions, calling `resolve()` and `stated_reason()` directly.

**Every positive is paired with its negative**, because a suite that only checks "the note appears" proves the string was added, not that it came from the entry:

| behaviour | with a stated reason | control: without one |
|---|---|---|
| blank stand/room | prints it, rc=3 | prints no `roster says`, rc=3 |
| off-allowlist | prints it, no bounce claim, rc=4 | keeps `bounced a mention before`, rc=4 |
| batch | the usable entry still resolves alongside the refused one; worst rc still reaches the caller |

Plus `stated_reason()` itself: `refusal_basis` wins over `note`; absent / blank / whitespace / `None` / non-string all yield empty; newlines fold so the reason stays one line.

## Mutation results

```
baseline                                          9/9 pass
UNUSABLE drops the reason                         KILLED
OFF-ALLOWLIST always asserts the bounce           KILLED
stated_reason ignores refusal_basis               KILLED
tuple -> list in the key order (same predicate)   SURVIVES
```

Each anchor asserted unique before substituting, source restored byte-identical after. The equivalent mutant is there because a suite that kills every mutant is pinning a spelling, not a behaviour.

## Checks

```
tests/sci-notify-reviewers-refusal-basis.test.py   9/9
sci-notify-reviewers.test.py                       pass  (sibling, unchanged)
sci-notify-reviewers-inproc.test.py                pass  (sibling, unchanged)
sci-notify-reviewers-kind.test.py                  pass  (sibling, unchanged)
notify-reviewers-human-shapes.test.py              pass  (sibling, unchanged)
scripts/review-checks.sh --diff                    rc=0
```

## Related

#3544 named this family — *the tool reports its own bookkeeping as a fact about the world* — and closed the half where a refusal reason overstated review state. This is the other half: a refusal that omits the reason it was given.
