### PR TITLE
fix(coverage-gate): lane fragments record relative paths so the combine can resolve them

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,9 @@
 [run]
 parallel = True
 sigterm = True
+# Lanes run in mktemp worktrees (parallel-suite-lane.sh); relative paths let
+# the repo-root combine resolve sources after the worktrees are removed.
+relative_files = True
 source =
     src
     scripts


### PR DESCRIPTION
## What

One line in `.coveragerc`: `relative_files = True` (plus a 2-line comment).

## The defect

The gate runs each test lane with cwd inside a mktemp **git worktree** (`parallel-suite-lane.sh`), so coverage fragments record **absolute lane paths** (`/tmp/tmp.XXX/1/scripts/...`). The lane script's EXIT trap removes the worktrees before the gate's `coverage combine`/`coverage xml` run at the repo root, and no `[paths]` remap exists — so `coverage xml` aborts on the first vanished source, killing the job under `set -e`.

**Before (production, #3375's run, [job 99298617304](https://github.com/sonichi/sutando/actions/runs/33326929877/job/99298617304)):**
```
2026-08-30T18:07:47Z No source for code: '/tmp/tmp.cP0a3780ag/1/scripts/bench-claim-backends.py'; ...
2026-08-30T18:07:47Z ##[error]Process completed with exit code 1.
```
The suite itself was green (5m08s — the 15-min cap this base's #3522 removed is confirmed gone); the crash is the reporting step. The single error line is a first-failure abort, not single-file impact.

**Why #3522 didn't catch it:** its own PR changed no `.py` file, so the gate took the no-Python fast path (`coverage-gate.sh:76-80`) and the lane→combine→xml path shipped unexercised. #3375's run was its first real execution.

## Evidence (actual output)

Minimal repro (lane-shaped: run in a copied dir, combine at root) — **both polarities**:
```
baseline: No source for code: '/private/var/.../tmp.7iILCmfzyo/1/scripts/mod.py'  -> xml rc=1
with fix: xml rc=0, filename="mod.py" (repo-relative)
```

Targeted E2E on the **real pipeline** at this head (real `parallel-suite-lane.sh` worktrees, 2 workers; includes `tests/bench-claim-backends-smoke.test.py` — the file production crashed on):
```
test rcs: 0 0
combine+xml rc=0
diff-cover vs origin/feat/pool-runtime-drive (with a local covered-line probe commit, since dropped):
  src/result_markers.py (100%)  Total: 1 line  Missing: 0
```
The diff-cover line is the non-vacuousness check: the gate still **measures** changed lines after the fix — it did not become a silently-passing gate.

Full local whole-suite run stopped at a host-only env gap (`qrcode`'s PIL missing for the whatsapp guided-connect test) before reaching the reporting step — that's this laptop, not CI (CI's job log shows that test running fine).

Note: this PR changes no `.py` file, so the gate will fast-path here too — the true CI verification is #3375's next run after this merges (its branch is already refreshed and currently red on exactly this crash).

`review-checks.sh --diff` on the branch diff: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)