### PR TITLE
test(slug-guard): the scanner could not see most spellings of what it scans for

### DIFF
--- a/tests/shell-project-slug-matches-helper.test.py
+++ b/tests/shell-project-slug-matches-helper.test.py
@@ -59,14 +59,45 @@ class TestShellSlugMatchesHelper(unittest.TestCase):
             self.assertTrue(SHELL_IDIOM in body,
                             f"{rel} must derive the slug with the complement set")
 
+    # Quote style and sed delimiter are free choices, so pinning one spelling
+    # scans for a typo rather than for the defect.
+    SLASH_ONLY = re.compile(
+        r"""tr\s+(['"])/\1\s+(['"])-\2"""     # tr '/' '-'    /  tr "/" "-"
+        r"""|sed\s+(['"])s(.)/\4-\4g\3"""     # sed 's|/|-|g' /  's:/:-:g'  /  "s|/|-|g"
+    )
+
+    def test_the_scanner_recognises_the_defect_it_scans_for(self):
+        # A scan that matches nothing reports zero offenders forever. This is a
+        # control on the REGEX; the control above is on the idiom's semantics.
+        must_fire = [
+            "tr '/' '-'",
+            'tr "/" "-"',
+            "sed 's|/|-|g'",
+            'sed "s|/|-|g"',
+            "sed 's:/:-:g'",
+        ]
+        for frag in must_fire:
+            line = "SLUG=\"$(printf '%s' \"$p\" | " + frag + ')"'
+            self.assertTrue(self.SLASH_ONLY.search(line),
+                            f"scanner blind to a slash-only spelling: {line}")
+        good = "SLUG=\"$(printf '%s' \"$p\" | " + SHELL_IDIOM + ')"'
+        self.assertIsNone(self.SLASH_ONLY.search(good),
+                          "scanner flags the prescribed idiom — it would be disabled, not obeyed")
+
     def test_no_shell_file_derives_a_slug_with_a_slash_only_replacement(self):
-        slash_only = re.compile(r"tr\s+'/'\s+'-'|sed\s+'s\|/\|-\|g'")
+        # `tests/` is deliberately out of scope: fixtures build their own paths
+        # and compare against themselves, which is a separate question.
         offenders = []
-        for d in ("src", "scripts"):
+        scanned = 0
+        for d in ("src", "scripts", "skills"):
             for f in sorted((REPO / d).rglob("*.sh")):
-                for i, line in enumerate(f.read_text().splitlines(), 1):
-                    if slash_only.search(line):
+                if "node_modules" in f.parts:
+                    continue
+                scanned += 1
+                for i, line in enumerate(f.read_text(errors="replace").splitlines(), 1):
+                    if self.SLASH_ONLY.search(line):
                         offenders.append(f"{f.relative_to(REPO)}:{i}")
+        self.assertGreater(scanned, 0, "scanned no shell files — the scan resolved nothing")
         self.assertEqual([], offenders,
                          "slash-only slug derivation(s) reintroduced: " + ", ".join(offenders))
 

--- a/tests/shell-project-slug-matches-helper.test.py
+++ b/tests/shell-project-slug-matches-helper.test.py
@@ -88,16 +88,20 @@ class TestShellSlugMatchesHelper(unittest.TestCase):
         # `tests/` is deliberately out of scope: fixtures build their own paths
         # and compare against themselves, which is a separate question.
         offenders = []
-        scanned = 0
+        # Per-directory, not a total: an aggregate stays non-zero when ONE
+        # directory silently contributes nothing, which is this PR's own bug.
+        scanned = {}
         for d in ("src", "scripts", "skills"):
+            scanned[d] = 0
             for f in sorted((REPO / d).rglob("*.sh")):
                 if "node_modules" in f.parts:
                     continue
-                scanned += 1
+                scanned[d] += 1
                 for i, line in enumerate(f.read_text(errors="replace").splitlines(), 1):
                     if self.SLASH_ONLY.search(line):
                         offenders.append(f"{f.relative_to(REPO)}:{i}")
-        self.assertGreater(scanned, 0, "scanned no shell files — the scan resolved nothing")
+        for d, n in scanned.items():
+            self.assertGreater(n, 0, f"{d}/ contributed no shell files — renamed, moved, or empty")
         self.assertEqual([], offenders,
                          "slash-only slug derivation(s) reintroduced: " + ", ".join(offenders))
 


### PR DESCRIPTION
## What

`tests/shell-project-slug-matches-helper.test.py` guards a real defect — a slash-only slug derivation resolves to a directory Claude Code never creates on a path with a space or a dot, which is exactly the bundled `Application Support/space.ag2.app` install. Its scanner pins one spelling each of two idioms:

```python
slash_only = re.compile(r"tr\s+'/'\s+'-'|sed\s+'s\|/\|-\|g'")
```

Quote style and sed delimiter are free choices in shell, so that scans for a **typo**, not for the defect. Against five realistic spellings of the same derivation it misses three:

```
CAUGHT  tr '/' '-'
MISSED  tr "/" "-"
CAUGHT  sed 's|/|-|g'
MISSED  sed "s|/|-|g"
MISSED  sed 's:/:-:g'
```

The walk also covered `src` and `scripts` only — leaving **23 shell files under `skills/`** unscanned:

```
src        48 .sh files      (scanned)
scripts    48 .sh files      (scanned)
skills     23 .sh files      (NOT scanned)
```

## Demonstrated, not argued

One offender planted, same file, run against both revisions:

```
# skills/_slug_probe.sh  ->  SLUG="$(printf %s "$p" | tr "/" "-")"
main:  PASSES with the offender present   <-- the gap
HEAD:  FAILS  with the offender present   <-- caught

# src/_slug_probe.sh  ->  SLUG="$(printf %s "$p" | sed "s|/|-|g")"
main:  PASSES
HEAD:  FAILS                              <-- caught
```

With both probes removed, the suite is green on this HEAD (5 tests).

## What the file already had, and what it didn't

Credit where it is due: this file was **not** uncontrolled. `test_a_slash_only_derivation_would_be_caught` runs the old idiom and asserts it disagrees with `claude_project_slug()` — a control on the *semantics*, and the reason I read the whole file before writing this up.

What was missing is a control on the **scanner**. Nothing proved that regex could match anything, so a zero-offender result was indistinguishable from a dead pattern — the shape this repo keeps naming, where a check that cannot fail certifies nothing. Added, plus the converse that matters more: the prescribed `tr -c 'A-Za-z0-9' '-'` must **not** match, because a guard that flags the correct idiom gets disabled rather than obeyed. And `assertGreater(scanned, 0)`, so a walk that resolves nothing is a failure rather than a pass.

## `tests/` is deliberately out of scope

Widening the pattern surfaces six hits, **all in `tests/`**:

```
tests/sutando-shell-setup.test.sh:260   this_slug="$(printf '%s' "$REPO" | tr '/' '-')"
tests/sync-workspace.test.sh:200        LOCAL_SLUG=$(printf '%s' "$FIXTURE_REPO" | sed 's|/|-|g')
tests/sync-workspace.test.sh:1076,1101,1178,1208   (same shape)
```

Those are fixtures that construct a path and then assert against the same construction, so they are self-consistent and nothing is failing today. But they are not equivalent to production — `sync-workspace.sh:1650` uses `tr -c 'A-Za-z0-9' '-'`, and on a `mktemp` path the two disagree because the template carries a dot:

```
/tmp/sync-workspace-test.XyZ/repo
  sed:  -tmp-sync-workspace-test.XyZ-repo
  tr :  -tmp-sync-workspace-test-XyZ-repo
```

The comment above line 200 says the derivation mirrors "script + Claude Code". It does not. That is a real question — a fixture that agrees only with itself cannot notice a production slug change — but it is a different one from "does production code use the wrong idiom", it touches a suite that is on the CI known-failures allowlist, and it deserves its own change rather than riding along here. Measured and stated so it is not lost.

## Scope

One test file: a widened pattern, one added directory, one new control test, one non-empty-walk assertion. No `src/` change, no production behaviour change.
