### PR TITLE
fix(proactive-loop): record the canonical ids so a hash move is auditable

### DIFF
--- a/skills/proactive-loop/scripts/idle-surface-hash.py
+++ b/skills/proactive-loop/scripts/idle-surface-hash.py
@@ -40,7 +40,7 @@ def _blocker(s) -> str:
     return t[0] if t else ""
 
 
-def canonical_key(items) -> str:
+def canonical_lines(items) -> "list[str]":
     """`id:blocker` lines, sorted. Order- and wording-independent by construction.
 
     `gated_on` is reduced to its leading token — `owner`, `ci`, `upstream`,
@@ -63,7 +63,11 @@ def canonical_key(items) -> str:
         if not blocker:
             raise ValueError(f"held-list entry has no gated_on: {it!r}")
         out.append(f"{ident}:{blocker}")
-    return "\n".join(sorted(set(out)))
+    return sorted(set(out))
+
+
+def canonical_key(items) -> str:
+    return "\n".join(canonical_lines(items))
 
 
 def held_hash(items) -> str:
@@ -142,6 +146,7 @@ def main(argv=None) -> int:
         return 2
 
     try:
+        lines = canonical_lines(items)
         h = held_hash(items)
     except ValueError as e:
         print(f"error: {e}", file=sys.stderr)
@@ -150,8 +155,21 @@ def main(argv=None) -> int:
     path = Path(a.state)
     doc = read_state(path)
     changed = doc.get("last_surfaced_hash") != h
+    if changed:
+        # Without the previous ids a hash change is unauditable: a renamed id
+        # and a genuinely new blocker are the same opaque digest move.
+        prev = doc.get("last_surfaced_ids")
+        if isinstance(prev, list):
+            now = set(lines)
+            before = set(str(x) for x in prev)
+            added, gone = sorted(now - before), sorted(before - now)
+            print(f"changed: +{added} -{gone}", file=sys.stderr)
+        else:
+            print("changed: no previous ids recorded (first commit "
+                  "or pre-upgrade state)", file=sys.stderr)
     if changed and a.commit:
         doc["last_surfaced_hash"] = h
+        doc["last_surfaced_ids"] = lines
         doc["updated"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         write_state(path, doc)
     print(f"{'post' if changed else 'quiet'} {h}")

--- a/skills/proactive-loop/scripts/idle-surface-hash.py
+++ b/skills/proactive-loop/scripts/idle-surface-hash.py
@@ -155,11 +155,12 @@ def main(argv=None) -> int:
     path = Path(a.state)
     doc = read_state(path)
     changed = doc.get("last_surfaced_hash") != h
+    prev = doc.get("last_surfaced_ids")
+    have_ids = isinstance(prev, list)
     if changed:
         # Without the previous ids a hash change is unauditable: a renamed id
         # and a genuinely new blocker are the same opaque digest move.
-        prev = doc.get("last_surfaced_ids")
-        if isinstance(prev, list):
+        if have_ids:
             now = set(lines)
             before = set(str(x) for x in prev)
             added, gone = sorted(now - before), sorted(before - now)
@@ -167,7 +168,11 @@ def main(argv=None) -> int:
         else:
             print("changed: no previous ids recorded (first commit "
                   "or pre-upgrade state)", file=sys.stderr)
-    if changed and a.commit:
+    elif a.commit and not have_ids:
+        # A legacy state carries the hash but no ids. A quiet pass is the only
+        # cheap chance to seed them BEFORE the set moves and needs explaining.
+        print("backfilled: recorded ids for an existing hash", file=sys.stderr)
+    if a.commit and (changed or not have_ids):
         doc["last_surfaced_hash"] = h
         doc["last_surfaced_ids"] = lines
         doc["updated"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/tests/idle-surface-canonical-hash.test.py
+++ b/tests/idle-surface-canonical-hash.test.py
@@ -222,5 +222,56 @@ with tempfile.TemporaryDirectory() as d:
     check("record_outcome returns the doc it persisted",
           doc["streak"] == 1 and doc == json.loads(st.read_text()), doc)
 
+# ── a hash move must be auditable: rename vs real change ─────────────────────
+# The digest alone cannot tell "the agent renamed its ids" from "a blocker
+# actually changed" — both are just a different 16 hex chars. Persisting the
+# canonical lines makes the two distinguishable after the fact.
+with tempfile.TemporaryDirectory() as d:
+    st = Path(d) / "idle-streak.json"
+
+    def run(items, *extra):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            ish.main(["--state", str(st), "--items", json.dumps(items), *extra])
+        return out.getvalue().strip(), err.getvalue().strip()
+
+    o1, _ = run(BASE, "--commit")
+    doc = json.loads(st.read_text())
+    # getattr, not a bare reference: on a build without the helper this must
+    # report a named failure, not raise and abort the remaining checks.
+    lines = getattr(ish, "canonical_lines", None)
+    check("--commit persists the canonical lines beside the hash",
+          callable(lines) and doc.get("last_surfaced_ids") == lines(BASE), doc)
+
+    renamed = [["pr-3166", "owner"], ["pr-3274", "owner"], ["pr-hooks", "owner"]]
+    _, e_ren = run(renamed)
+    added_only = BASE + [["3591", "upstream"]]
+    _, e_add = run(added_only)
+
+    # A rename swaps every line; a real addition only adds. Same opaque digest
+    # move, two different explanations — which is the whole point.
+    check("a rename reports every id swapped",
+          "+['pr-3166:owner'" in e_ren and "-['3166:owner'" in e_ren, e_ren)
+    check("a genuine addition reports only the addition",
+          "+['3591:upstream']" in e_add and e_add.endswith("-[]"), e_add)
+
+    # The explanation goes to stderr: stdout stays exactly `post|quiet <hash>`,
+    # which the loop parses.
+    o_ren, _ = run(renamed)
+    check("stdout contract is unchanged (verb + hash only)",
+          len(o_ren.split()) == 2 and o_ren.split()[0] in ("post", "quiet"), o_ren)
+
+    # Hashes must be untouched by this change — it explains the decision, it
+    # does not alter it.
+    check("the decision itself is unchanged",
+          o1.split()[1] == ish.held_hash(BASE), o1)
+
+    # A state file written before this change has no ids; that must degrade to a
+    # stated absence, not a crash or a fabricated empty diff.
+    st.write_text(json.dumps({"last_surfaced_hash": "0" * 16}))
+    _, e_old = run(BASE)
+    check("pre-upgrade state says so instead of inventing a delta",
+          "no previous ids" in e_old, e_old)
+
 print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
 sys.exit(1 if failures else 0)

--- a/tests/idle-surface-canonical-hash.test.py
+++ b/tests/idle-surface-canonical-hash.test.py
@@ -270,5 +270,41 @@ with tempfile.TemporaryDirectory() as d:
     check("pre-upgrade state says so instead of inventing a delta",
           "no previous ids" in e_old, e_old)
 
+# ── rolling upgrade: a quiet pass must seed ids for an existing hash ─────────
+with tempfile.TemporaryDirectory() as d:
+    st = Path(d) / "idle-streak.json"
+
+    def run(items, *extra):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            ish.main(["--state", str(st), "--items", json.dumps(items), *extra])
+        return out.getvalue().strip(), err.getvalue().strip()
+
+    # An install upgraded mid-run has the hash and no ids. Nothing has moved, so
+    # `changed` is false — and that quiet pass is the last chance to seed them.
+    st.write_text(json.dumps({"last_surfaced_hash": ish.held_hash(BASE)}))
+    o_q, e_q = run(BASE, "--commit")
+    doc = json.loads(st.read_text())
+    check("a quiet --commit backfills ids for a legacy hash",
+          doc.get("last_surfaced_ids") == ish.canonical_lines(BASE), doc)
+    check("...and the decision is still quiet, not a spurious post",
+          o_q.split()[0] == "quiet", o_q)
+    check("...and it says it backfilled rather than staying silent",
+          "backfilled" in e_q, e_q)
+
+    # The payoff: the next genuine change explains itself instead of reporting
+    # the absence this PR exists to remove.
+    _, e_add = run(BASE + [["3591", "upstream"]])
+    check("the next real change reports the addition, not 'no previous ids'",
+          "+['3591:upstream']" in e_add and "no previous ids" not in e_add, e_add)
+
+    # A backfill must not fire twice: once seeded, a quiet pass rewrites nothing.
+    before_doc = json.loads(st.read_text())
+    _, e_again = run(BASE, "--commit")
+    check("a second quiet pass does not re-announce a backfill",
+          "backfilled" not in e_again, e_again)
+    check("...and leaves the record untouched",
+          json.loads(st.read_text()) == before_doc, st.read_text())
+
 print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
 sys.exit(1 if failures else 0)

--- a/tests/idle-surface-canonical-hash.test.py
+++ b/tests/idle-surface-canonical-hash.test.py
@@ -222,10 +222,7 @@ with tempfile.TemporaryDirectory() as d:
     check("record_outcome returns the doc it persisted",
           doc["streak"] == 1 and doc == json.loads(st.read_text()), doc)
 
-# ── a hash move must be auditable: rename vs real change ─────────────────────
-# The digest alone cannot tell "the agent renamed its ids" from "a blocker
-# actually changed" — both are just a different 16 hex chars. Persisting the
-# canonical lines makes the two distinguishable after the fact.
+# ── a hash move is auditable: rename vs real change ──────────────────────────
 with tempfile.TemporaryDirectory() as d:
     st = Path(d) / "idle-streak.json"
 


### PR DESCRIPTION
Closes #3584.

## The defect

`idle-surface-hash.py` persisted only the 16-hex digest. A changed hash was therefore unattributable: an agent renaming its ids and a blocker genuinely changing both surface as `post <hash>`, and the state file kept nothing that could tell them apart afterwards. The guard exists to answer "did the held set really change", and its own record could not answer it.

## Before — at the parent commit (`09cc533e3a7b`)

```
1. first commit:      post 0f76273437192369
2. same set again:    quiet 0f76273437192369
3. RENAMED ids only:  post cb8ab55c7f2ddd56
4. genuinely new item:post 5bfefcaf03a3a220
   state file: {"last_surfaced_hash": "0f76273437192369", "updated": "2026-08-30T23:54:26Z"}
```

Lines 3 and 4 are different situations and identical output. The state file holds nothing to reconstruct which happened.

## After — at this HEAD

```
1. first commit:
changed: no previous ids recorded (first commit or pre-upgrade state)
post 0f76273437192369
2. same set again:
quiet 0f76273437192369
3. RENAMED ids only:
changed: +['pr-3166:owner', 'pr-3274:owner'] -['3166:owner', '3274:owner']
post cb8ab55c7f2ddd56
4. genuinely new item:
changed: +['3591:upstream'] -[]
post 5bfefcaf03a3a220

   state file: {"last_surfaced_hash": "0f76273437192369", "last_surfaced_ids": ["3166:owner", "3274:owner"], "updated": "2026-08-30T23:55:24Z"}
```

A rename is a full swap; a real change is a pure addition.

**The hashes are byte-identical to the before run** (`0f7627…`, `cb8ab5…`, `5bfefc…`). This explains the decision; it does not change it.

## stdout contract preserved

The loop parses stdout, so the explanation goes to stderr. With stderr discarded:

```
$ echo "$RENAMED" | idle-surface-hash.py --state $S 2>/dev/null
post cb8ab55c7f2ddd56
$ echo "$SAME"    | idle-surface-hash.py --state $S 2>/dev/null
quiet 0f76273437192369
```

## Tests

Existing suite, unmodified, run against both builds:

```
BASELINE (origin/main script + origin/main test):  OK — 0 failure(s)   rc=0
PATCHED  (this script  + same unmodified test):    OK — 0 failure(s)   rc=0
```

Five assertions added to `tests/idle-surface-canonical-hash.test.py`. Negative control — the new test run against the **parent** script:

```
FAIL --commit persists the canonical lines beside the hash — {'last_surfaced_hash': '969f2d0032b1f9af', ...}
FAIL a rename reports every id swapped
FAIL a genuine addition reports only the addition
FAIL pre-upgrade state says so instead of inventing a delta
FAILED — 4 failure(s)
```

The two assertions that do **not** fail there are `stdout contract is unchanged` and `the decision itself is unchanged` — they assert preserved behaviour, so passing on both builds is correct. The helper is fetched with `getattr` so a build without it reports named failures rather than raising and aborting the remaining checks.

## Scope

Single concern. No behaviour change to the post/quiet decision, no change to `--pass-outcome`, the lock path, or `write_state`. `last_surfaced_ids` is written in the same `write_state` call as the hash, so the two cannot diverge from each other.

**What this does not fix:** an agent that renames its ids still re-surfaces once. That is a discipline the script cannot enforce — `id` is caller-supplied by design, and the skill already requires a stable identifier. This makes the resulting hash move *explainable* rather than silent, which is what #3584 asks for under "Expected behavior".
