### PR TITLE
fix(coverage-gate): a test may declare its own instrumented budget

### DIFF
--- a/scripts/coverage-file-timeout.sh
+++ b/scripts/coverage-file-timeout.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Resolves ONE test file's instrumented-run budget. Sole owner of that policy:
+# the gate's report message and the runner both come here, so they cannot drift.
+#
+#   coverage-file-timeout.sh --print <file>      -> prints the budget in seconds
+#   coverage-file-timeout.sh <cmd...> <file>     -> execs <cmd...> <file> under it
+#
+# A file opts out of the shared default by declaring its own budget in the first
+# 25 lines:  # coverage-gate: timeout=420
+set -eu
+
+DEFAULT="${COVERAGE_GATE_FILE_TIMEOUT:-120}"
+
+budget_for() {
+    local f="$1" declared=""
+    if [ -r "$f" ]; then
+        declared="$(sed -n '1,25p' "$f" 2>/dev/null \
+            | sed -nE 's/^#[[:space:]]*coverage-gate:[[:space:]]*timeout=([0-9]{1,4})[[:space:]]*$/\1/p' \
+            | head -1)"
+    fi
+    # A declaration of 0 is not "no cap"; it is malformed, so it falls through.
+    if [ -n "$declared" ] && [ "$declared" -gt 0 ] 2>/dev/null; then
+        printf '%s' "$declared"
+    else
+        printf '%s' "$DEFAULT"
+    fi
+}
+
+if [ "${1:-}" = "--print" ]; then
+    budget_for "${2:-}"
+    echo
+    exit 0
+fi
+
+[ "$#" -ge 1 ] || { echo "coverage-file-timeout: no command given" >&2; exit 2; }
+_file="${!#}"
+_budget="$(budget_for "$_file")"
+if command -v timeout >/dev/null 2>&1; then
+    exec timeout -k 5 "$_budget" "$@"
+fi
+exec "$@"

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -105,10 +105,8 @@ trap 'rm -rf "$RECDIR"' EXIT
 
 # `timeout` is coreutils and absent on stock macOS, where this also runs by
 # hand; degrade to no cap rather than failing the local path.
-COVGATE_TIMEOUT=""
-if command -v timeout >/dev/null 2>&1; then
-    COVGATE_TIMEOUT="timeout -k 5 ${COVERAGE_GATE_FILE_TIMEOUT:-120}"
-else
+COVGATE_TIMEOUT="bash $(dirname "$0")/coverage-file-timeout.sh"
+if ! command -v timeout >/dev/null 2>&1; then
     echo "coverage-gate: no \`timeout\` binary — per-file cap disabled (local run)." >&2
 fi
 export RECDIR COVGATE_TIMEOUT
@@ -133,7 +131,8 @@ while IFS= read -r f; do
     output="$(cat "$rec.out" 2>/dev/null || true)"
     if [ "$rc" -ne 0 ]; then
         if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
-            echo "✖ test TIMED OUT under instrumentation (>${COVERAGE_GATE_FILE_TIMEOUT:-120}s): $f"
+            _cap="$(bash "$(dirname "$0")/coverage-file-timeout.sh" --print "$f")"
+            echo "✖ test TIMED OUT under instrumentation (>${_cap}s): $f"
         else
             echo "✖ test failed under instrumentation: $f"
         fi

--- a/tests/coverage-gate-per-file-timeout.test.py
+++ b/tests/coverage-gate-per-file-timeout.test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""One wall-clock ceiling for every test file makes the cap a merge gate.
+
+A concurrency test that spends its time spawning instrumented subprocesses is
+measured against a budget sized for ordinary unit tests, so it fails while
+asserting nothing wrong. A file may declare its own budget; everything else is
+untouched.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "coverage-file-timeout.sh"
+DEFAULT = "120"
+
+
+def budget(path: Path, env: dict | None = None) -> str:
+    e = dict(os.environ)
+    e.pop("COVERAGE_GATE_FILE_TIMEOUT", None)
+    e.update(env or {})
+    out = subprocess.run(["bash", str(SCRIPT), "--print", str(path)],
+                         capture_output=True, text=True, env=e, check=True)
+    return out.stdout.strip()
+
+
+class BudgetResolution(unittest.TestCase):
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.d, True)
+
+    def _write(self, name: str, body: str) -> Path:
+        f = self.d / name
+        f.write_text(body)
+        return f
+
+    def test_undeclared_file_gets_the_shared_default(self):
+        f = self._write("plain.test.py", "print(1)\n")
+        self.assertEqual(budget(f), DEFAULT)
+
+    def test_a_declared_budget_is_honoured(self):
+        f = self._write("slow.test.py", "# coverage-gate: timeout=420\nprint(1)\n")
+        self.assertEqual(budget(f), "420")
+
+    def test_env_still_moves_the_default_for_undeclared_files(self):
+        f = self._write("plain.test.py", "print(1)\n")
+        self.assertEqual(budget(f, {"COVERAGE_GATE_FILE_TIMEOUT": "77"}), "77")
+
+    def test_a_declaration_beats_the_env_default(self):
+        f = self._write("slow.test.py", "# coverage-gate: timeout=420\nprint(1)\n")
+        self.assertEqual(budget(f, {"COVERAGE_GATE_FILE_TIMEOUT": "77"}), "420")
+
+    def test_malformed_declarations_fall_through_rather_than_disable_the_cap(self):
+        # zero is the dangerous one: read as a number it would mean "no time at
+        # all", and a lenient parser could turn it into "no cap".
+        for body in ("# coverage-gate: timeout=0\n",
+                     "# coverage-gate: timeout=abc\n",
+                     "# coverage-gate: timeout=\n",
+                     "# coverage-gate:timeout=300 trailing\n"):
+            with self.subTest(body=body.strip()):
+                self.assertEqual(budget(self._write("m.test.py", body)), DEFAULT)
+
+    def test_a_declaration_below_the_scanned_window_does_not_count(self):
+        f = self._write("late.test.py", "\n" * 40 + "# coverage-gate: timeout=999\n")
+        self.assertEqual(budget(f), DEFAULT)
+
+    def test_an_unreadable_path_is_the_default_not_an_error(self):
+        self.assertEqual(budget(self.d / "nope.test.py"), DEFAULT)
+
+
+class CommandConstruction(unittest.TestCase):
+    """What the runner execs — asserted without needing coreutils present."""
+
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.d, True)
+        stub = self.d / "timeout"
+        stub.write_text('#!/usr/bin/env bash\necho "ARGS: $*"\n')
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        self.env = dict(os.environ)
+        self.env.pop("COVERAGE_GATE_FILE_TIMEOUT", None)
+        self.env["PATH"] = f"{self.d}:{self.env['PATH']}"
+
+    def _run(self, f: Path) -> str:
+        return subprocess.run(["bash", str(SCRIPT), "python3", "-m", "coverage", "run", str(f)],
+                              capture_output=True, text=True, env=self.env).stdout.strip()
+
+    def test_the_declared_budget_reaches_timeout(self):
+        f = self.d / "slow.test.py"
+        f.write_text("# coverage-gate: timeout=420\n")
+        self.assertEqual(self._run(f), f"ARGS: -k 5 420 python3 -m coverage run {f}")
+
+    def test_an_undeclared_file_still_gets_the_default(self):
+        f = self.d / "plain.test.py"
+        f.write_text("print(1)\n")
+        self.assertEqual(self._run(f), f"ARGS: -k 5 {DEFAULT} python3 -m coverage run {f}")
+
+
+class TheFileThisWasOpenedFor(unittest.TestCase):
+    def test_outbox_race_declares_a_budget(self):
+        f = REPO / "tests" / "outbox-race.test.py"
+        self.assertTrue(f.is_file())
+        self.assertEqual(budget(f), "300")
+
+    def test_a_neighbouring_test_is_unaffected(self):
+        for name in ("cron-notify.test.py", "cwd-lint.test.py"):
+            f = REPO / "tests" / name
+            if f.is_file():
+                self.assertEqual(budget(f), DEFAULT, name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/outbox-race.test.py
+++ b/tests/outbox-race.test.py
@@ -1,3 +1,5 @@
+# coverage-gate: timeout=300
+# 36 rounds of 12-way process concurrency: ~1s bare, >120s under `coverage run`.
 import json
 import multiprocessing as mp
 import os


### PR DESCRIPTION
Closes the `outbox-race` half of #3146.

**On why I opened this rather than waiting.** I listed three levers there and said I would open whichever was chosen. Nobody chose one — @john-the-dev deliberately deferred the remedy to the issue, and no maintainer has weighed in — while the cap is now gating four branches. So this is the lever I argued for, built. **If you prefer raising the global cap or scaling the test's rounds, close this; it cost little.**

## The defect

One wall-clock ceiling covers every file in the suite. `scripts/coverage-gate.sh` builds a single prefix and hands it to every lane:

```bash
COVGATE_TIMEOUT="timeout -k 5 ${COVERAGE_GATE_FILE_TIMEOUT:-120}"
```

So a concurrency test whose cost is spawning instrumented subprocesses is measured against a budget sized for ordinary unit tests. It **passes its own assertion and is then killed** — from the failing job on #3587:

```
✖ test TIMED OUT under instrumentation (>120s): tests/outbox-race.test.py
  12 rounds x 12 concurrent PROCESSES racing one item
  winners per round: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
  rounds with != 1 winner: 0  (exclusion holds)
```

**Scope** (@john-the-dev, all 300 `Coverage Gate` runs over ~47h): 8 of 49 gate failures are this timeout, across **4 distinct branches** — only 3 on the PR it was found on. And 212 successes in the same window, so it is not deterministic; it sits just under the line most of the time.

## The magnitude, measured

```
tests/outbox-race.test.py, uninstrumented, this laptop:   rc=0  wall=1.1s
same file, instrumented, CI:                              >120s (killed)
```

Two orders of magnitude. A CI runner is not 100x slower than a laptop, so `coverage run` per subprocess is what dominates — the test does about a second of real work.

## The change

`scripts/coverage-file-timeout.sh` **solely owns** the budget policy: both the runner and the gate's report message resolve through it, so the cap that gets reported cannot drift from the cap that was applied. A file opts out of the shared default in its first 25 lines:

```python
# coverage-gate: timeout=300
```

Everything undeclared keeps 120s, and `COVERAGE_GATE_FILE_TIMEOUT` still moves that default. Malformed declarations fall through rather than disabling the cap — `timeout=0` especially, which a lenient parser would turn into "no limit".

## Before / after

At the parent commit, with the test kept and the implementation reverted:

```
Ran 11 tests — FAILED (failures=2, errors=12)
```

At HEAD:

```
Ran 11 tests in 0.524s — OK
```

The constructed command is asserted with a `timeout` **stub on PATH**, so it holds on a host without coreutils rather than silently proving nothing:

```
declared.test.py   ARGS: -k 5 420 python3 -m coverage run /tmp/declared.test.py
plain.test.py      ARGS: -k 5 120 python3 -m coverage run /tmp/plain.test.py
zero.test.py       ARGS: -k 5 120 python3 -m coverage run /tmp/zero.test.py
```

That stub is load-bearing: my first attempt at this evidence ran a 5s sleep against a declared 1s budget and got `rc=0`, which I nearly read as success. This host has no `timeout` binary, so the script had correctly degraded to running uncapped — the run proved the opposite of what I wanted it to.

## Checks

```
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
ruff check                                        All checks passed!
tests/coverage-gate-per-file-timeout.test.py      PASS (11 new)
tests/ci-covers-every-python-test.test.py         PASS
tests/check-python39-compat.test.py               PASS
tests/cwd-lint.test.py                            PASS
bash -n on both shell files                       clean
```

**Not verified locally: `shellcheck`** — not installed on this host, so CI's `-S error` pass is the first real run of it. Flagging that rather than implying I checked.
