### PR TITLE
feat(gateway): push the agent profile card to the broker on change

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1969,6 +1969,55 @@ def _maybe_push_workers_snapshot() -> bool:
     return True
 
 
+_profile_push_key = ""
+_profile_push_retry_at = 0.0
+
+
+def _build_agent_profile() -> "dict | None":
+    """The instance's identity card for PUT /v1/agents/{mxid}/profile.
+    Only instance-authoritative fields — appearance is user/platform-owned
+    and the broker drops it from instance PUTs anyway."""
+    name = (os.environ.get("SUTANDO_DISPLAY_NAME") or "Sutando").strip()
+    try:
+        host_id = socket.gethostname().split(".")[0]
+    except OSError:
+        host_id = "unknown-host"
+    return {"display": {"name": name},
+            "host": {"host_id": host_id, "kind": "local"}}
+
+
+def _maybe_push_agent_profile() -> bool:
+    """Push-on-change relay of the agent's profile card. Same failure
+    contract as the workers-snapshot push: 404 defers an hour (broker not
+    deployed yet), other errors 5m; nothing here may break the task loop."""
+    global _profile_push_key, _profile_push_retry_at
+    now = time.time()
+    if now < _profile_push_retry_at:
+        return False
+    mxid = _reenroll_identity()
+    if not mxid:
+        return False  # identity may appear mid-episode; recheck next loop
+    card = _build_agent_profile()
+    key = mxid + json.dumps(card, sort_keys=True)
+    if key == _profile_push_key:
+        return False
+    try:
+        _req("PUT", f"/v1/agents/{urllib.parse.quote(mxid)}/profile",
+             card, timeout=15)
+    except urllib.error.HTTPError as e:
+        _profile_push_retry_at = now + 3600
+        _log(f"agent-profile push deferred 1h (HTTP {e.code}"
+             f"{': broker has no profile API yet' if e.code == 404 else ''})")
+        return False
+    except Exception as e:  # noqa: BLE001 — relay must never kill the loop
+        _profile_push_retry_at = now + 300
+        _log(f"agent-profile push failed, retrying in 5m: {e}")
+        return False
+    _profile_push_key = key
+    _log(f"agent-profile pushed for {mxid}")
+    return True
+
+
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
     """Best-effort liveness + core-status ping. Liveness feeds hosted dashboards;
     the status/step feed the broker's presence sweep (agent working/available/…)."""
@@ -3629,6 +3678,7 @@ def main() -> None:
                 return
             _post_heartbeat(inflight)
             _maybe_push_workers_snapshot()
+            _maybe_push_agent_profile()
             _retry_pending_publications()
             _retry_review_card_resolutions()
             _retry_review_control_results()

--- a/tests/gateway-agent-profile-push.test.py
+++ b/tests/gateway-agent-profile-push.test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Gateway agent-profile push: the instance PUTs its identity card once per
+content change to /v1/agents/{mxid}/profile — no identity is a no-op, an
+unchanged card never re-puts, and a 404 broker backs off instead of
+hammering.
+
+Run: python3 tests/gateway-agent-profile-push.test.py   (stdlib only)
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+from pathlib import Path
+
+FAILS = []
+
+
+def check(cond, msg):
+    print(("ok  " if cond else "FAIL") + " " + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+MXID = "@sutando-test:ag2.space"
+
+
+def main() -> int:
+    tmp = tempfile.mkdtemp(prefix="profpush-test-")
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+    os.environ["SUTANDO_WORKSPACE"] = tmp
+    Path(tmp, ".notes-migrated").touch()
+    Path(tmp, ".build_log-migrated").touch()
+    os.environ["REMOTE_TASK_URL"] = "http://127.0.0.1:9"  # never contacted
+    os.environ["REMOTE_TASK_TOKEN"] = "testtoken"
+    os.environ["REMOTE_TASK_PROVIDER"] = "remote-gateway"
+    os.environ.pop("AGENT_MXID", None)
+    os.environ.pop("AGENT_ID", None)
+
+    spec = importlib.util.spec_from_file_location(
+        "rtc_prof",
+        Path(__file__).resolve().parent.parent / "src"
+        / "remote-gateway-bridge.py")
+    rtc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(rtc)
+
+    # hermetic: the channel .env fallback must not leak this host's identity
+    rtc._config_from_channel_env = lambda *a, **kw: ""
+
+    calls = []
+
+    def fake_req(method, path, payload=None, timeout=35):
+        calls.append((method, path, payload))
+        return {}
+
+    rtc._req = fake_req
+
+    check(rtc._maybe_push_agent_profile() is False and not calls,
+          "no identity: no-op, no request")
+
+    os.environ["AGENT_MXID"] = MXID
+    check(rtc._maybe_push_agent_profile() is True, "identity present: pushes")
+    method, path, card = calls[0]
+    check(method == "PUT"
+          and path == f"/v1/agents/{urllib.parse.quote(MXID)}/profile",
+          "PUT to the mxid-quoted profile route")
+    check(card["display"]["name"] == "Sutando"
+          and card["host"]["kind"] == "local"
+          and card["host"]["host_id"],
+          "card carries display name + host block")
+    check("appearance" not in card.get("display", {}),
+          "instance card never carries appearance fields")
+
+    check(rtc._maybe_push_agent_profile() is False and len(calls) == 1,
+          "unchanged card never re-puts")
+
+    os.environ["SUTANDO_DISPLAY_NAME"] = "Sutando Dev"
+    check(rtc._maybe_push_agent_profile() is True and len(calls) == 2,
+          "changed card pushes again")
+    check(calls[1][2]["display"]["name"] == "Sutando Dev",
+          "the changed name is what ships")
+
+    def req_404(method, path, payload=None, timeout=35):
+        raise urllib.error.HTTPError(path, 404, "nf", {}, None)
+
+    rtc._req = req_404
+    os.environ["SUTANDO_DISPLAY_NAME"] = "Sutando Three"
+    check(rtc._maybe_push_agent_profile() is False and len(calls) == 2,
+          "404 broker: push attempted once, reported deferred")
+    check(rtc._profile_push_retry_at > time.time() + 3000,
+          "404 backoff is about an hour")
+    rtc._req = fake_req
+    check(rtc._maybe_push_agent_profile() is False and len(calls) == 2,
+          "inside the 404 backoff no further request is made")
+
+    print(f"\n{len(FAILS)} failure(s)")
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

The **instance-side leg of the Agent Profile Service** (ag2space-backend#881, merged to dev): the gateway PUTs its identity card to `/v1/agents/{mxid}/profile` so a client that knows only the MXID can resolve who the agent is and where it runs at DM-create time.

- `_build_agent_profile()`: instance-authoritative fields ONLY — `display.name` (env `SUTANDO_DISPLAY_NAME`, default "Sutando") + `host {host_id, kind: local}`. Appearance is user/platform-owned per the #881 authority split and never rides this push.
- `_maybe_push_agent_profile()`: content-keyed (mxid + card hash) so an unchanged card never re-puts; an identity appearing mid-episode is picked up next loop; **404 → 1h defer** (broker's profile API not deployed yet — self-activates on deploy, same contract as the workers-snapshot push), other failures → 5m retry; fail-open, the relay can never break the task loop.
- Wired into the main loop directly after `_maybe_push_workers_snapshot()`.

## Stack

**Parent: #3604** (rescue → main). This PR is based on `rescue/pool-uncommitted-2026-08-26` because the push-leg substrate (workers-snapshot push, 47c52c4f) lives there. Merge order: #3604 first, then rebase this onto main and rerun checks.

## Evidence

At HEAD:
```
$ python3 tests/gateway-agent-profile-push.test.py
ok   no identity: no-op, no request
ok   identity present: pushes
ok   PUT to the mxid-quoted profile route
ok   card carries display name + host block
ok   instance card never carries appearance fields
ok   unchanged card never re-puts
ok   changed card pushes again
ok   the changed name is what ships
ok   404 broker: push attempted once, reported deferred
ok   404 backoff is about an hour
ok   inside the 404 backoff no further request is made
0 failure(s)
$ python3 tests/gateway-workers-snapshot-push.test.py   # sibling leg unchanged
0 failure(s)
```
At the base commit: no `_maybe_push_agent_profile` exists — `grep -c _maybe_push_agent_profile packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py` → 0.

Live-path note: the push self-activates once the dev broker deploys #881; until then every process logs one "deferred 1h" line — verified in the test's 404 case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)