### PR TITLE
fix(gateway): port the five cross-lane fence fixes to the live line

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -213,6 +213,18 @@ if GATEWAY_INSTANCE and not _INSTANCE_RE.fullmatch(GATEWAY_INSTANCE):
     sys.exit("FATAL: GATEWAY_INSTANCE must match "
              f"{_INSTANCE_RE.pattern} (ASCII only; got {GATEWAY_INSTANCE!r})")
 _INST_SUFFIX = f".{GATEWAY_INSTANCE}" if GATEWAY_INSTANCE else ""
+# Optional fence for instanced lanes: claim only rooms on this suffix
+GATEWAY_ROOM_SUFFIX = (os.environ.get("GATEWAY_ROOM_SUFFIX") or "").strip()
+
+
+def _instance_may_claim(peek_room: "str | None") -> bool:
+    """Unaddressed proactives default to the owner's primary surface, which
+    only the DEFAULT lane serves — an instanced lane must never claim them."""
+    if not GATEWAY_INSTANCE:
+        return True
+    if peek_room is None:
+        return False
+    return not GATEWAY_ROOM_SUFFIX or peek_room.endswith(GATEWAY_ROOM_SUFFIX)
 
 
 def _local_tid(broker_tid: str) -> str:
@@ -2813,6 +2825,8 @@ def _post_proactive() -> None:
             continue  # racing consumer already claimed it
         if route == "foreign":
             continue
+        if not _instance_may_claim(peek_room):
+            continue  # the default lane's file (or another lane's suffix)
         # No target of its own AND no default: skip BEFORE claiming. Claiming it
         # would spin (claim -> no destination -> hand back) on every pass.
         if route == "send" and peek_room is None and not PROACTIVE_ROOM:
@@ -2846,6 +2860,7 @@ def _post_proactive() -> None:
                      f"owner nudge stranded under live pid until restart")
             continue
         if route == "foreign" or (
+                route == "send" and not _instance_may_claim(room_override)) or (
                 route == "send" and room_override is None and not PROACTIVE_ROOM):
             # Hand back rather than eat: a foreign target seen only post-claim,
             # or one that vanished with no default (room_id=None loses the body).

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -274,11 +274,30 @@ def _valid_local_tid(tid: str) -> bool:
     return bool(m) and m.group(1) not in (".", "..")
 
 
+def _owns_local_tid(tid: str) -> bool:
+    """Is this LOCAL task id inside THIS bridge's namespace?
+
+    `_local_tid` mints `task-<inst>~<broker_id>` for a named instance and leaves
+    the primary's ids unscoped, so ownership is decidable from the id alone. A
+    shared `RESULTS_DIR` therefore needs no coordination — each lane can tell its
+    own files from a sibling's.
+
+    Both directions matter. A named instance must not touch unscoped ids, and the
+    primary must not touch `~`-scoped ones: `task-*` matches `task-dev~1` too, so
+    filtering only the instance side would leave the primary cannibalising every
+    named lane — the same defect mirrored.
+    """
+    if GATEWAY_INSTANCE:
+        return tid.startswith(f"task-{GATEWAY_INSTANCE}~")
+    # `~` is outside the broker-id alphabet, so any scoped id — including an
+    # instance this build does not know — is someone else's. Unowned > misrouted.
+    return "~" not in tid
+
+
 def _task_pending(tid: str) -> bool:
     """Is this task still live in tasks/, under ANY of its names?
 
-    A pooled task is renamed twice — unassigned -> `.assigned-<core>` (lead
-    picked a core) -> `.claimed-<core>` (core took it). Every caller asking
+    A pooled task is renamed twice — unassigned -> `.assigned-<core>` (lead    picked a core) -> `.claimed-<core>` (core took it). Every caller asking
     "is this still being worked?" must accept all three, so the question has
     one owner: a state missed here reads as finished, which drops a reply
     mid-flight or re-queues work another core already holds."""
@@ -3358,7 +3377,9 @@ def _reconcile_orphan_results(inflight: "set[str]") -> None:
         return
     _last_orphan_sweep = now
     try:
-        candidates = sorted(RESULTS_DIR.glob("task-*.txt"))
+        # RESULTS_DIR is shared across lanes; the glob is not namespace-aware.
+        candidates = sorted(p for p in RESULTS_DIR.glob("task-*.txt")
+                            if _owns_local_tid(p.stem))
     except OSError:
         return
     for rfile in candidates:

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -215,13 +215,20 @@ if GATEWAY_INSTANCE and not _INSTANCE_RE.fullmatch(GATEWAY_INSTANCE):
 _INST_SUFFIX = f".{GATEWAY_INSTANCE}" if GATEWAY_INSTANCE else ""
 # Optional fence for instanced lanes: claim only rooms on this suffix
 GATEWAY_ROOM_SUFFIX = (os.environ.get("GATEWAY_ROOM_SUFFIX") or "").strip()
+# Rooms on these suffixes belong to a foreign lane; the default lane's gateway
+# 403s them, and the failure policy then parks deliverable work as undeliverable.
+GATEWAY_FOREIGN_SUFFIXES = tuple(
+    s.strip() for s in (os.environ.get("GATEWAY_FOREIGN_SUFFIXES") or "").split(",")
+    if s.strip())
 
 
 def _instance_may_claim(peek_room: "str | None") -> bool:
     """Unaddressed proactives default to the owner's primary surface, which
     only the DEFAULT lane serves — an instanced lane must never claim them."""
     if not GATEWAY_INSTANCE:
-        return True
+        if peek_room is None:
+            return True
+        return not any(peek_room.endswith(s) for s in GATEWAY_FOREIGN_SUFFIXES)
     if peek_room is None:
         return False
     return not GATEWAY_ROOM_SUFFIX or peek_room.endswith(GATEWAY_ROOM_SUFFIX)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -3022,9 +3022,11 @@ def _dedup_plan(tid: str, holder_id: str | None):
         _save_task_rooms(rooms)
         return True
 
+    # The re-ask id must live in THIS lane's namespace (`_owns_local_tid`):
+    # an unscoped mint on a named instance is orphaned to the primary's sweep.
     action, payload = plan_dedup_recovery(
         RESULTS_DIR, TASKS_DIR, tid, holder_id, room,
-        f"task-{uuid.uuid4().hex[:18]}", commit_identity=_commit)
+        _local_tid(f"task-{uuid.uuid4().hex[:18]}"), commit_identity=_commit)
     return action, payload, room
 
 

--- a/tests/bridge-inflight-assigned-not-abandoned.test.py
+++ b/tests/bridge-inflight-assigned-not-abandoned.test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""An in-flight id whose task file sits in the pool's ASSIGNED state is live.
+
+The abandoned-id cleaner once hand-rolled its liveness check and missed
+`.assigned-<core>`: a task waiting on a busy core was dropped from the
+in-flight ledger, so its result later delivered via the orphan sweep with
+the "(recovered result)" label instead of the normal path.
+Run: python3 tests/bridge-inflight-assigned-not-abandoned.test.py
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_TMP = tempfile.TemporaryDirectory()
+_ROOT = Path(_TMP.name)
+for d in ("tasks", "results", "state"):
+    (_ROOT / d).mkdir()
+os.environ["AGENT_CONNECT_TASK_DIR"] = str(_ROOT / "tasks")
+os.environ["AGENT_CONNECT_RESULTS_DIR"] = str(_ROOT / "results")
+os.environ["AGENT_CONNECT_STATE_DIR"] = str(_ROOT / "state")
+os.environ["REMOTE_TASK_TOKEN"] = "https://unit.test/relay|not-a-real-secret"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "packages" / "ag2-sparrow"))
+from ag2_sparrow import remote_gateway_bridge as rgb  # noqa: E402
+
+
+class AssignedIsNotAbandoned(unittest.TestCase):
+    def setUp(self):
+        for f in rgb.TASKS_DIR.iterdir():
+            if f.is_file():
+                f.unlink()
+
+    def _two_passes(self, inflight):
+        suspects = rgb._reconcile_abandoned(inflight, set())
+        rgb._reconcile_abandoned(inflight, suspects)
+        return inflight
+
+    def test_assigned_state_keeps_the_inflight_entry(self):
+        (rgb.TASKS_DIR / "task-a1.assigned-core-1.txt").write_text("x")
+        inflight = {"task-a1"}
+        self.assertEqual(self._two_passes(inflight), {"task-a1"})
+
+    def test_claimed_state_keeps_the_inflight_entry(self):
+        (rgb.TASKS_DIR / "task-a2.claimed-core-2.txt").write_text("x")
+        self.assertEqual(self._two_passes({"task-a2"}), {"task-a2"})
+
+    def test_truly_gone_id_is_dropped_after_two_sightings(self):
+        inflight = {"task-a3"}
+        self.assertEqual(self._two_passes(inflight), set())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/bridge-proactive-instance-scope.test.py
+++ b/tests/bridge-proactive-instance-scope.test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Instanced gateway lanes must never claim unaddressed proactive files —
+those default to the owner's primary surface, served by the default lane.
+Owner report 2026-08-26: the intermittent dev lane stole owner nudges."""
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
+
+from ag2_sparrow import remote_gateway_bridge as rgb  # noqa: E402
+
+
+class InstanceScope(unittest.TestCase):
+    def tearDown(self):
+        rgb.GATEWAY_INSTANCE = ""
+        rgb.GATEWAY_ROOM_SUFFIX = ""
+
+    def test_default_lane_claims_everything(self):
+        rgb.GATEWAY_INSTANCE = ""
+        self.assertTrue(rgb._instance_may_claim(None))
+        self.assertTrue(rgb._instance_may_claim("!r:ag2.space"))
+
+    def test_instanced_lane_never_claims_unaddressed(self):
+        rgb.GATEWAY_INSTANCE = "dev"
+        self.assertFalse(rgb._instance_may_claim(None))
+
+    def test_instanced_lane_claims_addressed(self):
+        rgb.GATEWAY_INSTANCE = "dev"
+        self.assertTrue(rgb._instance_may_claim("!r:dev.ag2.space"))
+
+    def test_suffix_fence_excludes_other_servers(self):
+        rgb.GATEWAY_INSTANCE = "dev"
+        rgb.GATEWAY_ROOM_SUFFIX = ":dev.ag2.space"
+        self.assertTrue(rgb._instance_may_claim("!r:dev.ag2.space"))
+        self.assertFalse(rgb._instance_may_claim("!r:ag2.space"))
+        self.assertFalse(rgb._instance_may_claim(None))
+
+    def test_claim_loop_calls_the_predicate(self):
+        # wiring pin: the pre-claim gate must consult the predicate
+        import inspect
+        src = inspect.getsource(rgb)
+        self.assertIn("if not _instance_may_claim(peek_room):", src)
+        self.assertIn("not _instance_may_claim(room_override)", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/bridge-proactive-instance-scope.test.py
+++ b/tests/bridge-proactive-instance-scope.test.py
@@ -17,6 +17,7 @@ class InstanceScope(unittest.TestCase):
     def tearDown(self):
         rgb.GATEWAY_INSTANCE = ""
         rgb.GATEWAY_ROOM_SUFFIX = ""
+        rgb.GATEWAY_FOREIGN_SUFFIXES = ()
 
     def test_default_lane_claims_everything(self):
         rgb.GATEWAY_INSTANCE = ""
@@ -37,6 +38,32 @@ class InstanceScope(unittest.TestCase):
         self.assertTrue(rgb._instance_may_claim("!r:dev.ag2.space"))
         self.assertFalse(rgb._instance_may_claim("!r:ag2.space"))
         self.assertFalse(rgb._instance_may_claim(None))
+
+    def test_default_lane_skips_foreign_suffix_rooms(self):
+        rgb.GATEWAY_INSTANCE = ""
+        rgb.GATEWAY_FOREIGN_SUFFIXES = (":dev.ag2.space",)
+        self.assertFalse(rgb._instance_may_claim("!r:dev.ag2.space"))
+        self.assertTrue(rgb._instance_may_claim("!r:ag2.space"))
+        self.assertTrue(rgb._instance_may_claim(None))
+
+    def test_default_lane_without_config_claims_everything(self):
+        rgb.GATEWAY_INSTANCE = ""
+        rgb.GATEWAY_FOREIGN_SUFFIXES = ()
+        self.assertTrue(rgb._instance_may_claim("!r:dev.ag2.space"))
+
+    def test_foreign_suffixes_env_parsing(self):
+        # exercises the module's own env read, not a copy of it
+        import importlib
+        import os
+        os.environ["GATEWAY_FOREIGN_SUFFIXES"] = " :dev.ag2.space , :stage.ag2.space ,"
+        try:
+            m = importlib.reload(rgb)
+            self.assertEqual(
+                m.GATEWAY_FOREIGN_SUFFIXES, (":dev.ag2.space", ":stage.ag2.space"))
+            self.assertFalse(m._instance_may_claim("!r:stage.ag2.space"))
+        finally:
+            del os.environ["GATEWAY_FOREIGN_SUFFIXES"]
+            importlib.reload(rgb)
 
     def test_claim_loop_calls_the_predicate(self):
         # wiring pin: the pre-claim gate must consult the predicate

--- a/tests/gateway-orphan-instance-ownership.test.py
+++ b/tests/gateway-orphan-instance-ownership.test.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Orphan reconciliation must only touch results in its OWN task namespace.
+
+`RESULTS_DIR` is shared by every gateway lane on a host. The orphan sweep globs
+`task-*.txt`, which matches both the primary's unscoped ids and a named
+instance's `task-<inst>~<id>` encoding — so without an ownership filter each lane
+recovers, delivers and archives the other's replies.
+
+Both directions are covered here. Filtering only the named-instance side leaves
+the primary claiming every lane's files, which is the same defect mirrored.
+"""
+import importlib
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+for _p in (REPO / "packages" / "ag2-sparrow", REPO / "src"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+def _bridge(instance):
+    """Import the bridge fresh with GATEWAY_INSTANCE set (or cleared).
+
+    Re-imported rather than monkeypatched: GATEWAY_INSTANCE is resolved at module
+    scope, so a patched attribute would not match what the real process computes.
+    """
+    if instance:
+        os.environ["GATEWAY_INSTANCE"] = instance
+    else:
+        os.environ.pop("GATEWAY_INSTANCE", None)
+    for name in [k for k in sys.modules if k.startswith("ag2_sparrow")]:
+        del sys.modules[name]
+    return importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+
+
+class OwnershipMatrix(unittest.TestCase):
+    """The table the fix has to satisfy, stated as the owner specified it."""
+
+    def test_primary_owns_unscoped_ids(self):
+        self.assertTrue(_bridge(None)._owns_local_tid("task-123"))
+
+    def test_primary_does_not_own_a_named_instance_id(self):
+        # The row the first draft of this fix missed: `task-*` matches this too.
+        self.assertFalse(_bridge(None)._owns_local_tid("task-dev~123"))
+
+    def test_instance_owns_its_own_ids(self):
+        self.assertTrue(_bridge("dev")._owns_local_tid("task-dev~123"))
+
+    def test_instance_does_not_own_unscoped_ids(self):
+        self.assertFalse(_bridge("dev")._owns_local_tid("task-123"))
+
+    def test_instance_does_not_own_another_instances_ids(self):
+        self.assertFalse(_bridge("dev")._owns_local_tid("task-staging~123"))
+
+    def test_an_unrecognised_scope_is_owned_by_nobody(self):
+        # Unowned beats misrouted: a lane this build does not know about must not
+        # fall through to the primary.
+        self.assertFalse(_bridge(None)._owns_local_tid("task-unknown~9"))
+        self.assertFalse(_bridge("dev")._owns_local_tid("task-unknown~9"))
+
+
+class DualBridgeSharedResultsDir(unittest.TestCase):
+    """Two lanes, one RESULTS_DIR: the selections must partition, not overlap."""
+
+    def _select(self, mod, results_dir):
+        return sorted(p.name for p in results_dir.glob("task-*.txt")
+                      if mod._owns_local_tid(p.stem))
+
+    def test_each_lane_selects_only_its_own_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            for n in ("task-111.txt", "task-222.txt",
+                      "task-dev~111.txt", "task-staging~111.txt"):
+                (d / n).write_text("body\n")
+
+            prod = self._select(_bridge(None), d)
+            dev = self._select(_bridge("dev"), d)
+
+            self.assertEqual(prod, ["task-111.txt", "task-222.txt"])
+            self.assertEqual(dev, ["task-dev~111.txt"])
+            self.assertEqual(set(prod) & set(dev), set(),
+                             "a file selected by both lanes is a double delivery")
+            # staging is absent on this host: its file is claimed by neither,
+            # which is the safe outcome — a stranded file, not a misrouted one.
+            self.assertNotIn("task-staging~111.txt", prod + dev)
+
+    def test_the_unfiltered_glob_would_have_overlapped(self):
+        """Positive control: without the filter these selections are identical,
+        so the assertions above are testing the filter and not the fixture."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            for n in ("task-111.txt", "task-dev~111.txt"):
+                (d / n).write_text("body\n")
+            unfiltered = sorted(p.name for p in d.glob("task-*.txt"))
+            self.assertEqual(unfiltered, ["task-111.txt", "task-dev~111.txt"])
+            self.assertIn("task-dev~111.txt", unfiltered,
+                          "the bare glob must match the named-instance file — "
+                          "that overlap is the bug being fixed")
+
+
+class SweepHonoursOwnership(unittest.TestCase):
+    """Wiring: the shipped `_reconcile_orphan_results` must apply the predicate.
+
+    The classes above exercise `_owns_local_tid` directly, so they stay green if
+    the sweep stops calling it. This one drives the real function and asserts on
+    what it POSTs.
+    """
+
+    def _run_sweep(self, instance, names):
+        mod = _bridge(instance)
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        d = Path(td.name)
+        old = time.time() - (mod.ORPHAN_GRACE_S + 60)
+        for n in names:
+            f = d / n
+            f.write_text("recovered body\n")
+            os.utime(f, (old, old))
+
+        posted = []
+        mod.RESULTS_DIR = d
+        mod.ARCHIVE_RESULTS_DIR = d / "archive"
+        mod._last_orphan_sweep = 0.0
+        mod._delivered_copy_exists = lambda tid: False
+        mod.find_task_file = lambda tasks_dir, tid: d / f"{tid}.task"
+        mod._delivery_tid = lambda tid: tid
+        mod._req = lambda method, path, payload=None, **kw: (
+            posted.append(payload.get("id")) or {})
+        mod._reconcile_orphan_results(set())
+        return posted
+
+    # Egress posts `_broker_tid(...)`, which unwraps the namespace: the primary's
+    # ids pass through, `task-dev~111` goes up as `111`. Asserting both pins that.
+    def test_primary_sweep_skips_named_instance_results(self):
+        posted = self._run_sweep(None, ["task-111.txt", "task-dev~111.txt"])
+        self.assertEqual(posted, ["task-111"],
+                         "the primary must deliver only its own result; "
+                         "'task-dev~111' here means it took the dev lane's file")
+
+    def test_instance_sweep_skips_primary_results(self):
+        posted = self._run_sweep("dev", ["task-111.txt", "task-dev~111.txt"])
+        self.assertEqual(posted, ["111"],
+                         "the dev lane must deliver only its own result (as the "
+                         "bare broker id); 'task-111' here is the original defect")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway-orphan-instance-ownership.test.py
+++ b/tests/gateway-orphan-instance-ownership.test.py
@@ -125,6 +125,10 @@ class SweepHonoursOwnership(unittest.TestCase):
         posted = []
         mod.RESULTS_DIR = d
         mod.ARCHIVE_RESULTS_DIR = d / "archive"
+        # TASKS_DIR must be fixture-bound too: _archive_result creates
+        # TASKS_DIR/archive, so an ambient value escapes the sandbox.
+        mod.TASKS_DIR = d / "tasks"
+        mod.TASKS_DIR.mkdir()
         mod._last_orphan_sweep = 0.0
         mod._delivered_copy_exists = lambda tid: False
         mod.find_task_file = lambda tasks_dir, tid: d / f"{tid}.task"
@@ -147,6 +151,95 @@ class SweepHonoursOwnership(unittest.TestCase):
         self.assertEqual(posted, ["111"],
                          "the dev lane must deliver only its own result (as the "
                          "bare broker id); 'task-111' here is the original defect")
+
+
+class DedupRequeueStaysInItsLane(unittest.TestCase):
+    """The re-ask id `_dedup_plan` mints must be OWNED by the minting lane.
+
+    Unscoped (`task-<uuid>`), a named instance's requeue is orphaned to the
+    primary: after an in-flight-ledger loss — the exact condition the orphan
+    sweep exists to recover — the dev lane skips its own recovered answer and
+    the primary consumes it without the dev alias. This drives the production
+    `_dedup_plan` (via `_post_ready_results`) and `_reconcile_orphan_results`
+    end to end across both lanes sharing one RESULTS_DIR.
+    """
+
+    ORIG_BROKER = "task-orig1234567890"       # the id the broker waits on
+    HOLDER = "task-22d83e59601f3a1fef"
+
+    def _bind(self, mod, d: Path, posted: list):
+        """Fixture-bind every path/state the flows touch (no ambient escapes)."""
+        results, tasks, state = d / "results", d / "tasks", d / "state"
+        (results / "archive").mkdir(parents=True, exist_ok=True)
+        tasks.mkdir(exist_ok=True)
+        state.mkdir(exist_ok=True)
+        mod.RESULTS_DIR = results
+        mod.ARCHIVE_RESULTS_DIR = results / "archive"
+        mod.TASKS_DIR = tasks
+        mod.DEDUP_ALIAS_FILE = state / f"remote-dedup-alias-{id(mod)}.json"
+        rooms = {}
+        mod._load_task_rooms = lambda *a, **k: dict(rooms)
+        mod._save_task_rooms = lambda r, *a, **k: rooms.update(r)
+        mod._forget_task_room = lambda *a, **k: None
+        mod._save_inflight = lambda *a, **k: None
+        mod._delivered_copy_exists = lambda tid: False
+        mod._req = lambda method, path, payload=None, **kw: (
+            posted.append(payload.get("id")) or {})
+
+    def test_named_lane_requeue_is_recovered_by_its_own_sweep(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        shared = Path(td.name)                  # one host: shared results dir
+
+        dev_posts, primary_posts = [], []
+        dev = _bridge("dev")
+        self._bind(dev, shared, dev_posts)
+        orig_local = dev._local_tid(self.ORIG_BROKER)
+
+        # Pass 1 on the dev lane: unsubstantiated dedup -> re-ask minted.
+        (dev.TASKS_DIR / f"{orig_local}.txt").write_text(
+            f"id: {orig_local}\nsource: gateway\naccess_tier: owner\ntask: q\n")
+        (dev.RESULTS_DIR / f"{orig_local}.txt").write_text(
+            f"[deduped: {self.HOLDER}]")
+        (dev.ARCHIVE_RESULTS_DIR / f"{self.HOLDER}-1785976425.txt").write_text("")
+        dev._post_ready_results({orig_local})
+        requeued = [p for p in dev.TASKS_DIR.glob("task-*")
+                    if p.stem != orig_local and p.parent == dev.TASKS_DIR]
+        self.assertEqual(len(requeued), 1, "no re-ask was written")
+        new_id = requeued[0].stem
+
+        # The blocker itself: the mint must live in the dev namespace.
+        self.assertTrue(dev._owns_local_tid(new_id),
+                        f"re-ask id {new_id!r} escaped the dev lane")
+
+        # The core answers the re-ask; the in-flight ledger is then LOST.
+        answer = shared / "results" / f"{new_id}.txt"
+        answer.write_text("the recovered answer\n")
+        old = time.time() - (dev.ORPHAN_GRACE_S + 60)
+        os.utime(answer, (old, old))
+
+        # Primary lane, same shared results dir: must leave it untouched.
+        primary = _bridge(None)
+        pdir = Path(tempfile.mkdtemp(dir=td.name))
+        self._bind(primary, pdir, primary_posts)
+        primary.RESULTS_DIR = shared / "results"          # the shared surface
+        primary.ARCHIVE_RESULTS_DIR = shared / "results" / "archive"
+        self.assertFalse(primary._owns_local_tid(new_id),
+                         "primary claims the dev lane's re-ask id")
+        primary._last_orphan_sweep = 0.0
+        primary._reconcile_orphan_results(set())
+        self.assertEqual(primary_posts, [],
+                         "primary sweep delivered the dev lane's answer")
+        self.assertTrue(answer.exists(),
+                        "primary sweep consumed the dev lane's file")
+
+        # Dev's own sweep recovers it — under the ORIGINAL broker id.
+        dev._last_orphan_sweep = 0.0
+        dev._reconcile_orphan_results(set())
+        self.assertEqual(dev_posts, [self.ORIG_BROKER],
+                         "recovered answer must POST under the id the broker "
+                         "is waiting on (alias -> _broker_tid unwrap)")
+        self.assertFalse(answer.exists(), "delivered result was not archived")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

The rescue line — which BOTH gateway lanes on the owner's host now execute (prod via sparrowd + the dev lane the owner re-enabled tonight) — predates the entire cross-lane fence series. The two-homeserver design contract (separate channels, zero duplication) held only for the basic namespacing; all five edge fixes lived on `feat/sutando-server` and never reached main or this line. Verified by content: `_owns_local_tid`, `GATEWAY_FOREIGN_SUFFIXES`, and `_instance_may_claim` had ZERO references in this tree.

Ported (oldest first, `-x` cherry-picks):
- `39001c35` → non-default lanes never claim UNADDRESSED proactives (the dev lane could steal owner-DM nudges)
- `179fd6a5` → orphan reconciliation stays inside the minting lane's namespace (`_owns_local_tid`, both directions)
- `63f7a5ab` → dedup re-ask ids minted in the owning lane's namespace
- `b923a791` → in-flight cleaner treats assigned-state tasks as live
- `ffe11e19` → default lane skips foreign-suffix rooms (`GATEWAY_FOREIGN_SUFFIXES`) instead of claiming, 403ing, and parking deliverable work

One conflict (179fd6a5): the fix's `_owns_local_tid` landed beside this line's pool-evolved `_task_pending` (richer: knows `.assigned-<core>` renames). Resolution keeps BOTH — the helper verbatim, the pool body untouched; `b923a791` then composes with the pool version, which is a superset of what it expects.

## Evidence

At head, in THIS tree: all three ported suites green (`gateway-orphan-instance-ownership` OK, `bridge-proactive-instance-scope` OK, `bridge-inflight-assigned-not-abandoned` OK), adjacent `sparrow-outbox-claim-protocol` + `gateway-destined-proactive-not-claimed` green, `review-checks.sh` cumulative PASS.

## Activation

Stacked into the rescue line so it rides #3604 to main. After merge: both gateway lanes on the owner's host restart to pick it up, and the prod lane gains `GATEWAY_FOREIGN_SUFFIXES=:dev-chat.ag2.space` (or the dev room suffix) in its env. Live path — a post-restart two-lane round trip will be recorded at activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)