### PR TITLE
fix(gateway): source names the receiving lane, not the wire's contract label

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2354,7 +2354,12 @@ def _write_task(task: dict) -> str | None:
             if task.get(f) == "room":
                 lines.append("session_scope: room")
         elif f == "source":
-            lines.append(f"source: {_one_line(task.get('source') or PROVIDER)}")
+            # The RECEIVING lane is the origin authority — the wire label names
+            # the contract family, identical from BOTH homeservers (#3612 class).
+            lines.append(f"source: {_one_line(CHANNEL_DIR)}")
+            _wire_src = _one_line(str(task.get("source") or ""))
+            if _wire_src and _wire_src != CHANNEL_DIR:
+                lines.append(f"wire_source: {_wire_src}")
         elif f == "interaction_type":
             # Pass through when the gateway sends it; default to "message" —
             # all current gateway traffic is Matrix room messages. Whitelisted:

--- a/tests/gateway-source-names-the-lane.test.py
+++ b/tests/gateway-source-names-the-lane.test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""`source:` names the RECEIVING lane, never the wire's contract label.
+
+Both homeservers' brokers send source="ag2space" (the contract family), so a
+task's origin homeserver was undecidable from its header — prod and dev lanes
+stamped identical sources (owner finding, 2026-08-31). The lane's CHANNEL_DIR
+is the origin authority; a differing wire label survives as wire_source.
+Exercises the SHIPPED _write_task, not a copy of its field loop.
+
+Run: python3 tests/gateway-source-names-the-lane.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "packages" / "ag2-sparrow"))
+
+
+def _load(channel_dir, instance, tasks_dir):
+    os.environ["REMOTE_TASK_CHANNEL_DIR"] = channel_dir
+    os.environ["GATEWAY_INSTANCE"] = instance
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "t")
+    import ag2_sparrow.remote_gateway_bridge as m
+    m = importlib.reload(m)
+    m.TASKS_DIR = Path(tasks_dir)
+    return m
+
+
+class SourceNamesLane(unittest.TestCase):
+    def _write(self, channel_dir, instance, wire_source):
+        td = tempfile.mkdtemp(prefix="srclane-")
+        self.addCleanup(__import__("shutil").rmtree, td, True)
+        m = _load(channel_dir, instance, td)
+        tid = m._write_task({"id": "9f2b1c", "task": "probe",
+                            "source": wire_source, "access_tier": "owner"})
+        self.assertIsNotNone(tid)
+        body = (Path(td) / f"{tid}.txt").read_text()
+        return body
+
+    def test_dev_lane_stamps_its_own_name_and_keeps_wire(self):
+        body = self._write("dev-ag2space", "dev", "ag2space")
+        self.assertIn("source: dev-ag2space\n", body)
+        self.assertIn("wire_source: ag2space\n", body)
+        # line-anchored: "source: ag2space" is a SUBSTRING of the wire_source line
+        self.assertNotIn("\nsource: ag2space\n", "\n" + body)
+
+    def test_prod_lane_byte_identical_no_wire_line(self):
+        body = self._write("ag2space", "", "ag2space")
+        self.assertIn("source: ag2space\n", body)
+        self.assertNotIn("wire_source:", body)
+
+    def test_missing_wire_source_still_stamps_lane(self):
+        body = self._write("dev-ag2space", "dev", None)
+        self.assertIn("source: dev-ag2space\n", body)
+        self.assertNotIn("wire_source:", body)
+
+
+if __name__ == "__main__":
+    r = unittest.main(exit=False).result
+    ok = r.wasSuccessful()
+    print("PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
## What

Owner finding (2026-08-31): `source: ag2space` names the **contract family**, not the origin — both homeservers' brokers send the same label, so a task's origin homeserver was undecidable from its header. Measured live on the re-enabled dev lane: a task carrying `source: ag2space` beside `channel_id: !...:dev.ag2.space`.

The receiving lane is the origin authority: `_write_task` now stamps `source:` from the lane's `CHANNEL_DIR` (`dev-ag2space` on the dev lane). **Byte-identical on prod**, where wire label and lane name are both `ag2space` — no behavior change for every existing consumer. A wire label that differs from the lane survives as `wire_source:` for audit.

This restores the cross-channel ownership property to lanes: origin is now readable from the header the same way `source: discord` vs `source: telegram` is, instead of only from the id prefix or channel-id suffix.

Consumer survey before the change: no code branches on task `source == "ag2space"` (the one exact match, `identity_view.py`, keys on the channel-DIR name, which is unchanged).

## Evidence

`tests/gateway-source-names-the-lane.test.py` drives the **shipped `_write_task`** (not a copy of its field loop): dev lane stamps `source: dev-ag2space` + `wire_source: ag2space`; prod output byte-identical with no wire_source line; missing wire source still stamps the lane. 3/3 at head; `review-checks.sh` PASS.

Single concern; sibling of #3608 (fence port) on the same base — no file-region overlap with its five picks beyond the same module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)