### PR TITLE
fix(gateway): the injected instruction must name the task's own channel dir

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2411,6 +2411,9 @@ def _write_task(task: dict) -> str | None:
         # shlex.quote: an unescaped quote in _chan must not close the shell
         # string early and turn the remainder into executable shell syntax.
         _chan_q = shlex.quote(_chan)
+        # The credential and the notify lane are per-instance: a dev-homeserver
+        # task needs ITS channel dir, not the default one this file was written for.
+        _cdir_q = shlex.quote(CHANNEL_DIR)
         _step = 1
         _skill = ["", "===SKILL INSTRUCTIONS (follow before any other action)==="]
         _addr = _one_line(task.get("addressed_to") or "")
@@ -2429,7 +2432,7 @@ def _write_task(task: dict) -> str | None:
                 f"message, reconstruct the room thread — `python3 "
                 f"skills/agent-room-ops/room_ops.py read {_chan_q} --limit 30` (if it "
                 f"reports no gateway configured, load the channel env first: `set -a; . "
-                f"\"$(bash scripts/channel-env.sh ag2space)\"; set +a`) — and read it "
+                f"\"$(bash scripts/channel-env.sh {_cdir_q})\"; set +a`) — and read it "
                 "back (everyone's messages including your own prior replies) until this "
                 "message stands on its own, then answer from the reconstructed thread, "
                 "NOT from memory. Do this every time; do NOT skip it because the message "
@@ -2441,8 +2444,8 @@ def _write_task(task: dict) -> str | None:
             # prelude resolves it by content; notify.py's own guard can refuse a symlink.
             _skill.append(
                 f"{_step}. NOTIFY FIRST (if task takes >60s): `set -a; . "
-                f"\"$(bash scripts/channel-env.sh ag2space)\"; set +a` then python3 "
-                f"skills/task-progress/scripts/notify.py --source ag2space "
+                f"\"$(bash scripts/channel-env.sh {_cdir_q})\"; set +a` then python3 "
+                f"skills/task-progress/scripts/notify.py --source {_cdir_q} "
                 f"--channel-id {_chan_q} --message \"On it — back in a moment.\"")
             _step += 1
         _skill.append(f"{_step}. Process and write the result to results/{tid}.txt")

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -497,6 +497,21 @@ def main() -> int:
           "notify step carries the channel-env prelude BEFORE the notify.py call")
     check(sum(_env_hint in ln for ln in sk.splitlines()) == 2,
           "the env prelude rides both gateway-calling steps (context-first + notify)")
+    # CHANNEL_DIR defaults to "ag2space", so every assertion above passes even
+    # when the hint is hardcoded; varying it is what makes this prove anything.
+    _saved_dir, _saved_tier2 = rtc.CHANNEL_DIR, rtc.LOCAL_TIER
+    rtc.CHANNEL_DIR, rtc.LOCAL_TIER = "dev-ag2space", "owner"
+    try:
+        rtc._write_task({**TASK, "id": "task-SKILLDEV", "channel_id": "!r:dev.ag2.space"})
+        skd = (rtc.TASKS_DIR / "task-SKILLDEV.txt").read_text()
+    finally:
+        rtc.CHANNEL_DIR, rtc.LOCAL_TIER = _saved_dir, _saved_tier2
+    check("channel-env.sh dev-ag2space" in skd
+          and "--source dev-ag2space " in skd
+          and "channel-env.sh ag2space)" not in skd,
+          "a non-default CHANNEL_DIR reaches BOTH env preludes and the notify --source")
+    check(sum("channel-env.sh dev-ag2space" in ln for ln in skd.splitlines()) == 2,
+          "both gateway-calling steps name the task's own channel dir, not the default")
     # A string assertion passes even when the named file holds no gateway vars,
     # so drive the resolver itself across both real layouts and neither-has-it.
     import os as _os


### PR DESCRIPTION
## What

The `===SKILL INSTRUCTIONS===` block the gateway injects into owner tasks hardcoded `ag2space` in three places, while `CHANNEL_DIR` is per-instance (`REMOTE_TASK_CHANNEL_DIR`, default `ag2space`).

A task from the **dev** homeserver therefore carried a header saying `source: dev-ag2space` and, two lines later, an instruction to load the `ag2space` credential.

## Why it matters

The wrong credential does not error — it returns an **empty room**:

```
$ channel-env.sh ag2space     -> messages: 0     (reads as "room has no context")
$ channel-env.sh dev-ag2space -> messages: 1     (the actual request)
```

CONTEXT-FIRST exists so a handler answers from the reconstructed thread instead of the task body alone. A silent zero-message read defeats it in the failure direction that looks like success — the handler concludes there is no context and proceeds.

Observed live on `!NYKzJYiPgQOXZMyQUv:dev.ag2.space` while handling a dev-room task.

## How

`_cdir_q = shlex.quote(CHANNEL_DIR)` beside the existing `_chan_q`, interpolated into both env preludes and `notify.py --source`. `shlex.quote` because the value lands inside `$(bash scripts/channel-env.sh …)` in text a handler pastes into a shell; `channel-env.sh` validates the name, but only after the shell has parsed it.

## Evidence

The default path could not have caught this — `CHANNEL_DIR` defaults to `"ag2space"`, so every pre-existing assertion passes with the bug present. The new control varies the one instance-specific value:

```
before (fix reverted, test kept):
  FAIL a non-default CHANNEL_DIR reaches BOTH env preludes and the notify --source

after:
  PASS — all checks green
```

Also green: `test_write_task_atomic.py`, `slack-context-first-ungated.test.py`, `slack-bridge-write-task.test.py`.

`review-checks.sh --diff` on the cumulative diff: `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`.

## Scope

Two files, +21/-3. No behaviour change for the default instance — the emitted text is byte-identical when `CHANNEL_DIR == "ag2space"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)