### PR TITLE
feat(gateway): a result POST names the pool worker that produced it

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -3009,6 +3009,16 @@ def _quarantine_undelivered(rfile, tid: str, why: str) -> None:
              "leaving it in place")
 
 
+def _worker_of(task_id: str) -> str:
+    """Which pool worker finished this task, read from the per-core done-flag.
+    Ambiguous or absent means unattributed — never a guess, never an error."""
+    try:
+        hits = sorted((_STATE / "cores").glob(f"*/done/task-{task_id}.flag"))
+    except OSError:
+        return ""
+    return hits[0].parent.parent.name if len(hits) == 1 else ""
+
+
 def _deliver_result_payload(tid: str, broker_tid: str, body: str,
                             no_send: bool = False, result_file=None) -> bool:
     """One outbound result POST through the delivery core. True = the
@@ -3020,6 +3030,11 @@ def _deliver_result_payload(tid: str, broker_tid: str, body: str,
     doc = {"id": broker_tid, "body": body}
     if no_send:
         doc["no_send"] = True
+    # Structured attribution, not the "— core-N" prose in the body: the
+    # signature is for humans and reformatting it must not change routing.
+    worker = _worker_of(tid)
+    if worker:
+        doc["metadata"] = {"worker_id": worker}
     payload = json.dumps(doc).encode("utf-8")
     core.backend.publish(broker_tid, payload)   # False = already live: retry pass
     res = core.deliver_one(broker_tid, payload)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -3011,9 +3011,9 @@ def _quarantine_undelivered(rfile, tid: str, why: str) -> None:
 
 def _worker_of(task_id: str) -> str:
     """Which pool worker finished this task, read from the per-core done-flag.
-    Ambiguous or absent means unattributed — never a guess, never an error."""
+    `task_id` is the result stem, which already carries the `task-` prefix."""
     try:
-        hits = sorted((_STATE / "cores").glob(f"*/done/task-{task_id}.flag"))
+        hits = sorted((_STATE / "cores").glob(f"*/done/{task_id}.flag"))
     except OSError:
         return ""
     return hits[0].parent.parent.name if len(hits) == 1 else ""

--- a/tests/gateway-result-worker-attribution.test.py
+++ b/tests/gateway-result-worker-attribution.test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""A result POST carries which pool worker produced it, as structured
+metadata: {"metadata": {"worker_id": "core-2"}} -> broker -> the Matrix
+event's content["space.ag2.worker"].id (ag2space-backend#882).
+
+The worker is read from the per-core done-flag the pool already writes
+(state/cores/<core>/done/task-<id>.flag), NOT from the "- core-N" signature
+in the body: that line is for humans, and reformatting it must not silently
+change routing or attribution.
+
+Run: python3 tests/gateway-result-worker-attribution.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_rgb_worker", _SRC)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_rgb_worker"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Captured(Exception):
+    """Stops _deliver_result_payload right after the payload is built, so the
+    assertion never depends on delivery-status enum semantics."""
+
+
+class WorkerAttribution(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+        self.tmp = tempfile.mkdtemp()
+        self.mod._STATE = Path(self.tmp)
+
+        self.seen = {}
+
+        class _Backend:
+            def publish(_s, tid, payload):
+                self.seen["payload"] = json.loads(payload.decode())
+                raise _Captured()
+
+        self.mod._delivery_core = lambda: type("C", (), {"backend": _Backend()})()
+
+    def _flag(self, core: str, tid: str):
+        d = Path(self.tmp) / "cores" / core / "done"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"task-{tid}.flag").write_text("")
+
+    def _doc(self, tid: str) -> dict:
+        self.seen.clear()
+        with self.assertRaises(_Captured):
+            self.mod._deliver_result_payload(tid, f"broker-{tid}", "done!")
+        return self.seen["payload"]
+
+    def test_worker_rides_the_payload(self):
+        self._flag("core-2", "t1")
+        doc = self._doc("t1")
+        self.assertEqual(doc["metadata"], {"worker_id": "core-2"})
+        # Attribution must not leak into the text the user reads.
+        self.assertEqual(doc["body"], "done!")
+
+    def test_varying_the_worker_varies_the_payload(self):
+        self._flag("core-1", "t2")
+        self._flag("core-3", "t3")
+        a, b = self._doc("t2"), self._doc("t3")
+        self.assertEqual(a["metadata"]["worker_id"], "core-1")
+        self.assertEqual(b["metadata"]["worker_id"], "core-3")
+        self.assertNotEqual(a["metadata"], b["metadata"])
+
+    def test_control_no_flag_sends_no_metadata(self):
+        # Single-core installs write no per-core flag; absent must mean absent,
+        # never a fabricated default that would misattribute every result.
+        self.assertNotIn("metadata", self._doc("t-unflagged"))
+
+    def test_control_ambiguous_flags_send_no_metadata(self):
+        self._flag("core-1", "t4")
+        self._flag("core-2", "t4")
+        self.assertNotIn("metadata", self._doc("t4"))
+
+    def test_worker_of_survives_a_missing_state_tree(self):
+        self.mod._STATE = Path(self.tmp) / "nonexistent"
+        self.assertEqual(self.mod._worker_of("t5"), "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway-result-worker-attribution.test.py
+++ b/tests/gateway-result-worker-attribution.test.py
@@ -51,9 +51,11 @@ class WorkerAttribution(unittest.TestCase):
         self.mod._delivery_core = lambda: type("C", (), {"backend": _Backend()})()
 
     def _flag(self, core: str, tid: str):
+        # Named exactly as finish_task writes it: the full result stem, prefix
+        # included. A bare-id fixture agrees with a prefix bug and hides it.
         d = Path(self.tmp) / "cores" / core / "done"
         d.mkdir(parents=True, exist_ok=True)
-        (d / f"task-{tid}.flag").write_text("")
+        (d / f"{tid}.flag").write_text("")
 
     def _doc(self, tid: str) -> dict:
         self.seen.clear()
@@ -62,16 +64,16 @@ class WorkerAttribution(unittest.TestCase):
         return self.seen["payload"]
 
     def test_worker_rides_the_payload(self):
-        self._flag("core-2", "t1")
-        doc = self._doc("t1")
+        self._flag("core-2", "task-0023dacce4b1f0a9c7")
+        doc = self._doc("task-0023dacce4b1f0a9c7")
         self.assertEqual(doc["metadata"], {"worker_id": "core-2"})
         # Attribution must not leak into the text the user reads.
         self.assertEqual(doc["body"], "done!")
 
     def test_varying_the_worker_varies_the_payload(self):
-        self._flag("core-1", "t2")
-        self._flag("core-3", "t3")
-        a, b = self._doc("t2"), self._doc("t3")
+        self._flag("core-1", "task-dev~task-07c59a1b2d3e4f5061")
+        self._flag("core-3", "task-9f81c02de5a6b7c8d9")
+        a, b = self._doc("task-dev~task-07c59a1b2d3e4f5061"), self._doc("task-9f81c02de5a6b7c8d9")
         self.assertEqual(a["metadata"]["worker_id"], "core-1")
         self.assertEqual(b["metadata"]["worker_id"], "core-3")
         self.assertNotEqual(a["metadata"], b["metadata"])
@@ -79,16 +81,22 @@ class WorkerAttribution(unittest.TestCase):
     def test_control_no_flag_sends_no_metadata(self):
         # Single-core installs write no per-core flag; absent must mean absent,
         # never a fabricated default that would misattribute every result.
-        self.assertNotIn("metadata", self._doc("t-unflagged"))
+        self.assertNotIn("metadata", self._doc("task-unflagged00000000"))
 
     def test_control_ambiguous_flags_send_no_metadata(self):
-        self._flag("core-1", "t4")
-        self._flag("core-2", "t4")
-        self.assertNotIn("metadata", self._doc("t4"))
+        self._flag("core-1", "task-4ambiguous000000a")
+        self._flag("core-2", "task-4ambiguous000000a")
+        self.assertNotIn("metadata", self._doc("task-4ambiguous000000a"))
+
+    def test_control_a_bare_id_does_not_attribute(self):
+        # Production never passes a bare id; if one ever reaches here it must
+        # not resolve, or the prefix contract has silently changed shape.
+        self._flag("core-2", "task-6bareid00000000000")
+        self.assertEqual(self.mod._worker_of("6bareid00000000000"), "")
 
     def test_worker_of_survives_a_missing_state_tree(self):
         self.mod._STATE = Path(self.tmp) / "nonexistent"
-        self.assertEqual(self.mod._worker_of("t5"), "")
+        self.assertEqual(self.mod._worker_of("task-5missingstate0000"), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The sending half of worker attribution. Pairs with **ag2space-backend#882**, which accepts it and maps it onto the delivered Matrix event.

## Why

Every core in the pool delivers through **one** agent identity, so someone reading a room cannot tell which worker answered. #882 added the receiving contract:

```
POST /v1/results {"metadata": {"worker_id": "core-2"}}
  → content["space.ag2.worker"] = {"id": "core-2"}
```

This PR makes Sutando actually send it.

## Where the worker comes from

The per-core done-flag the pool **already** writes:

```
state/cores/<core>/done/task-<id>.flag
```

So nothing new is persisted, no result-file format changes, and no new convention is invented.

**Deliberately not parsed from the `— core-N` signature in the body.** That line is presentation for humans. Deriving attribution or routing from it would turn "reformat the signature" into a silent behaviour change — the failure mode is invisible because the body still looks right.

## Absent and ambiguous both mean absent

| case | sent |
|---|---|
| one flag | `metadata.worker_id` |
| no flag (single-core install) | *nothing* |
| two flags for one task | *nothing* |
| state tree missing | *nothing* |

Omitted rather than guessed. The backend already treats a missing field as an unattributed sender and adds no `space.ag2.worker` key, so degradation is graceful at both ends.

## Evidence

```
$ python3 tests/gateway-result-worker-attribution.test.py
test_worker_rides_the_payload ... ok
test_varying_the_worker_varies_the_payload ... ok
test_control_no_flag_sends_no_metadata ... ok
test_control_ambiguous_flags_send_no_metadata ... ok
test_worker_of_survives_a_missing_state_tree ... ok

Ran 5 tests — OK
```

The varying control is the load-bearing one: `core-1` and `core-3` must produce *different* payloads, so a hardcoded value cannot pass.

### Non-vacuity — each guard reverted in turn

| reverted | result |
|---|---|
| the `metadata` assignment | `FAILED (errors=2)` |
| the ambiguity guard (`len(hits) == 1` → `if hits`) | `FAILED (failures=1)` |
| restored | `OK` |

### No regressions

25 gateway-bridge suites green, including `src/remote-gateway-bridge.test.py` (the shipped-loader test) and `tests/gateway-channel-dir.test.py`.

```
passed=25 failed=0
```

### Repo gate

```
$ bash scripts/review-checks.sh --diff <cumulative>
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Sequencing

Safe in either order. Until #882 reaches dev, `/v1/results` silently drops the unknown `metadata` key and returns `ok: true` — so this change is inert rather than breaking. Nothing here depends on #882 having landed.

Based on `main` at `00497acd` (#3610).