### PR TITLE
feat(pool): multi-worker room binding — a pinned set is the room's pool

### DIFF
--- a/scripts/pool-bind.py
+++ b/scripts/pool-bind.py
@@ -39,17 +39,19 @@ def main(argv, workspace=None) -> int:
     if argv[0] == "pin":
         dedicated = "--dedicated" in argv
         argv = [a for a in argv if a != "--dedicated"]
-        if len(argv) != 3:
-            print("usage: pool-bind.py pin <channel> <instance> [--dedicated]",
-                  file=sys.stderr)
+        if len(argv) < 3:
+            print("usage: pool-bind.py pin <channel> <instance>... "
+                  "[--dedicated]", file=sys.stderr)
             return 2
-        channel, instance = argv[1], argv[2]
-        beat = lead.state_dir / "cores" / f"{instance}.alive"
-        if not beat.exists():
-            print(f"warning: no liveness beat for {instance}; pinning anyway",
-                  file=sys.stderr)
+        channel, workers = argv[1], argv[2:]
+        for inst in workers:
+            beat = lead.state_dir / "cores" / f"{inst}.alive"
+            if not beat.exists():
+                print(f"warning: no liveness beat for {inst}; pinning anyway",
+                      file=sys.stderr)
+        target = workers[0] if len(workers) == 1 else workers
         print(json.dumps(
-            {channel: lead.pin_room(channel, instance, dedicated=dedicated)}))
+            {channel: lead.pin_room(channel, target, dedicated=dedicated)}))
         return 0
     if len(argv) != 2:
         print("usage: pool-bind.py unpin <channel>", file=sys.stderr)

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -136,11 +136,19 @@ class PoolLead:
         return _FlockCtx(path)
 
     # ── explicit pins: owner-declared room -> instance (2026-08-30) ─────────
-    def pin_room(self, channel: str, instance: str,
+    def pin_room(self, channel: str, instance: "str | list[str]",
                  dedicated: bool = False) -> dict:
+        """Pin a room to one worker, or to a bound SET (pool-restriction
+        semantics: the lead routes each task to one member of the set)."""
+        instances = [instance] if isinstance(instance, str) else [
+            str(i) for i in instance if str(i).strip()]
+        if not instances:
+            raise ValueError("pin_room: empty worker set")
         with self._affinity_lock():
             table = self._load_affinity()
-            row = {"instance": instance, "ts": self.now(), "pinned": True}
+            row = {"instance": instances[0], "ts": self.now(), "pinned": True}
+            if len(instances) > 1:
+                row["instances"] = instances
             if dedicated:
                 row["exclusive"] = True
             table[channel] = row
@@ -157,6 +165,7 @@ class PoolLead:
                 return False
             row.pop("pinned", None)
             row.pop("exclusive", None)
+            row.pop("instances", None)
             self._save_affinity(table)
             return True
 
@@ -241,7 +250,19 @@ class PoolLead:
             row = affinity.get(channel)
             # Binding: a live home core keeps its room; only death or an
             # unclaimed-reclaim moves it. Explicit pins beat lane defaults.
-            if isinstance(row, dict) and row.get("instance") in followers:
+            bound = row.get("instances") if isinstance(row, dict) else None
+            if isinstance(bound, list) and row.get("pinned"):
+                # Bound SET: the selected workers ARE the room's pool; pick
+                # the least-loaded claiming member, whole set busy -> loan.
+                live = [i for i in bound if i in followers
+                        and self._claiming(i)]
+                if live:
+                    pick = min(live, key=lambda f: (
+                        self._load(f), self._last_pick.get(str(f), 0.0),
+                        str(f)))
+                    self._last_pick[str(pick)] = self.now()
+                    return pick
+            elif isinstance(row, dict) and row.get("instance") in followers:
                 # A pinned home that stopped claiming is loaned out below;
                 # the pin survives, so the room returns when it recovers.
                 if not row.get("pinned") or self._claiming(row["instance"]):

--- a/tests/pool-lead-multi-bind.test.py
+++ b/tests/pool-lead-multi-bind.test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Multi-worker room binding (pool-restriction semantics): a pinned SET is
+the room's whole pool — the lead routes each task to its least-loaded
+claiming member, skips busy/dead members, and loans only when the entire
+set cannot claim. Unpin clears the set.
+
+Run: python3 tests/pool-lead-multi-bind.test.py   (stdlib only)
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src" / "runtime-api"))
+
+from pool_lead import PoolLead  # noqa: E402
+
+
+def _lead(ws: Path, followers, claiming=None):
+    (ws / "tasks").mkdir(exist_ok=True)
+    (ws / "state").mkdir(exist_ok=True)
+    claiming = set(followers) if claiming is None else set(claiming)
+    lead = PoolLead(ws / "tasks", ws / "state",
+                    followers_fn=lambda: list(followers),
+                    alive_fn=lambda i: True)
+    lead._claiming = lambda i: i in claiming
+    return lead
+
+
+class MultiBindTests(unittest.TestCase):
+    def test_pin_set_persists_and_lists(self):
+        with tempfile.TemporaryDirectory() as td:
+            lead = _lead(Path(td), ["core-1", "core-2", "core-3"])
+            row = lead.pin_room("!r:x", ["core-2", "core-3"])
+            self.assertEqual(row["instances"], ["core-2", "core-3"])
+            self.assertTrue(row["pinned"])
+            self.assertEqual(
+                lead.bindings()["!r:x"]["instances"], ["core-2", "core-3"])
+
+    def test_single_pin_stays_compact_legacy_form(self):
+        with tempfile.TemporaryDirectory() as td:
+            lead = _lead(Path(td), ["core-1"])
+            row = lead.pin_room("!r:x", "core-1")
+            self.assertNotIn("instances", row)
+            self.assertEqual(row["instance"], "core-1")
+
+    def test_sweep_routes_within_the_set_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2", "core-3"])
+            lead.pin_room("!r:x", ["core-2", "core-3"])
+            for i in range(4):
+                (ws / "tasks" / f"task-m{i}.txt").write_text(
+                    f"id: task-m{i}\nchannel_id: !r:x\ntask: t\n")
+            picks = {inst for _n, inst in lead.sweep()}
+            self.assertTrue(picks and picks <= {"core-2", "core-3"}, picks)
+
+    def test_busy_member_yields_to_the_other(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2", "core-3"])
+            lead.pin_room("!r:x", ["core-2", "core-3"])
+            # load core-2 with an in-flight claim; core-3 idle
+            (ws / "tasks" / "task-b.claimed-core-2.txt").write_text("x")
+            (ws / "tasks" / "task-y.txt").write_text(
+                "id: task-y\nchannel_id: !r:x\ntask: t\n")
+            self.assertEqual(lead.sweep(), [("task-y.txt", "core-3")])
+
+    def test_whole_set_not_claiming_falls_through_to_loan(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2", "core-3"],
+                         claiming={"core-1"})
+            lead.pin_room("!r:x", ["core-2", "core-3"])
+            (ws / "tasks" / "task-z.txt").write_text(
+                "id: task-z\nchannel_id: !r:x\ntask: t\n")
+            self.assertEqual(lead.sweep(), [("task-z.txt", "core-1")],
+                             "availability beats the binding when the whole "
+                             "set is unclaiming")
+            self.assertEqual(
+                lead.bindings()["!r:x"]["instances"], ["core-2", "core-3"],
+                "the loan must not consume the pin")
+
+    def test_unpin_clears_the_set(self):
+        with tempfile.TemporaryDirectory() as td:
+            lead = _lead(Path(td), ["core-1", "core-2"])
+            lead.pin_room("!r:x", ["core-1", "core-2"])
+            self.assertTrue(lead.unpin_room("!r:x"))
+            row = lead.bindings()["!r:x"]
+            self.assertNotIn("instances", row)
+            self.assertNotIn("pinned", row)
+
+    def test_empty_set_is_refused(self):
+        with tempfile.TemporaryDirectory() as td:
+            lead = _lead(Path(td), ["core-1"])
+            with self.assertRaises(ValueError):
+                lead.pin_room("!r:x", [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
## What

Layer 1 of the DM-create worker picker (owner spec, local lane 2026-08-31): **multi-select = every selected worker gets a binding to the room.** Semantics are **pool-restriction** (recommended to the owner, confirmation pending): the bound set is the room's whole eligible pool — the lead routes each task to the set's least-loaded claiming member, skips busy/dead members, and loans outside the set only when NO member can claim. Availability beats the binding; the pin survives the loan, so the room returns to its set on recovery.

- `pin_room(channel, instance | [instances], dedicated=)` — a list stores `instances: [...]` beside the primary; a single worker keeps the compact legacy row byte-identical, so every existing consumer (status writer, broker snapshot, picker view) is unaffected until a set exists.
- `_pick`: a pinned set short-circuits to least-loaded-claiming within the set (same tiebreak chain as the global pool); whole-set-unclaiming falls through to the normal loan path.
- `unpin_room` clears the set with the flags.
- `pool-bind.py pin <channel> <worker>... [--dedicated]` accepts N workers.

## Evidence

At HEAD:
```
$ python3 tests/pool-lead-multi-bind.test.py
Ran 7 tests ... OK   # set persists+lists, single stays legacy-compact, sweep routes
                     # within set only, busy member yields, whole-set-unclaiming
                     # loans without consuming the pin, unpin clears, empty set refused
$ for t in pin dedicated assignment bind-cli io-fail-open status-bindings; ... all pass
$ bash scripts/review-checks.sh --diff <branch diff>  -> PASS
```
At base: `pin_room` accepts a single instance only; a list argument raises at the row build.

## Stack

Base is `rescue/pool-uncommitted-2026-08-26` (the live pool line; parent PR #3604 rescue→main). Merge order: #3604 first, then rebase this to main. Follow-ups: broker pin endpoint accepts `workers: [...]` (backend PR), client dialog UI (cinny PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)