### PR TITLE
feat(pool): per-message worker addressing — target_worker + fan_out

### DIFF
--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -39,6 +39,8 @@ NOCLAIM_COOLDOWN_S = ASSIGN_STUCK_S  # repool pops ledger; keep follower marked 
 _TASK_RE = re.compile(
     r"^task-(?!.*\.(?:assigned|claimed)-)[A-Za-z0-9._~-]+\.txt$")
 _CHANNEL_RE = re.compile(r"^(?:channel_id|chat_id):\s*(\S+)", re.M)
+_TARGET_RE = re.compile(r"^target_worker:\s*(\S+)", re.M)
+_FANOUT_RE = re.compile(r"^fan_out:\s*true\s*$", re.M | re.I)
 _INST_RE = re.compile(r"^[A-Za-z0-9@:._-]{1,128}$")
 _LANE_RE = re.compile(
     r"^(?P<key>access_tier|priority|interaction_type):\s*(?P<val>\S+)", re.M)
@@ -70,6 +72,17 @@ class _FlockCtx:
         finally:
             self._fh.close()
         return False
+
+
+def _read_addressing(path: Path) -> "tuple[str | None, bool]":
+    """(target_worker, fan_out) from the task header — the per-message
+    address outranks any room binding (owner semantics 2026-08-31)."""
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return None, False
+    t = _TARGET_RE.search(text)
+    return (t.group(1) if t else None), bool(_FANOUT_RE.search(text))
 
 
 def _read_lane(path: Path) -> str:
@@ -278,6 +291,35 @@ class PoolLead:
         self._last_pick[str(pick)] = self.now()
         return pick
 
+    def _fan_out(self, f: Path, followers: "list[str]") -> "list[tuple[str, str]]":
+        """One assigned COPY per claiming worker; the original is archived so
+        it can't double-assign. Each copy gets a per-worker id suffix so
+        results and dedup stay distinct."""
+        live = [i for i in followers if self._claiming(i)]
+        if not live:
+            return []
+        try:
+            body = f.read_text(errors="replace")
+        except OSError:
+            return []
+        out = []
+        stem = f.name[:-len(".txt")]
+        for inst in sorted(live):
+            copy = f.with_name(f"{stem}~{inst}.assigned-{inst}.txt")
+            try:
+                copy.write_text(body)
+                out.append((copy.name, inst))
+            except OSError:
+                continue
+        if out:
+            try:
+                archive = f.parent / "archive"
+                archive.mkdir(parents=True, exist_ok=True)
+                os.rename(f, archive / f.name)
+            except OSError:
+                pass  # copies exist; a stale original re-sweeps as dup-guarded
+        return out
+
     # ── the sweep ───────────────────────────────────────────────────────────
     def sweep(self) -> "list[tuple[str, str]]":
         """Assign every unassigned task; returns [(task_name, instance)].
@@ -305,10 +347,18 @@ class PoolLead:
                 continue
             channel = _read_channel(f)
             lane = _read_lane(f)
+            target, fan_out = _read_addressing(f)
+            if fan_out:
+                assigned = self._fan_out(f, followers)
+                out.extend(assigned)
+                continue
             bound = None
             if channel and isinstance(affinity.get(channel), dict):
                 bound = affinity[channel].get("instance")
-            inst = self._pick(channel, followers, affinity, lane)
+            if target in followers and self._claiming(target):
+                inst = target  # explicit address outranks bindings + load
+            else:
+                inst = self._pick(channel, followers, affinity, lane)
             if lane == "owner" and (
                     (inst == self._lane_core_of(followers) and inst != bound)
                     or (bound is not None and bound not in followers)):

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -302,12 +302,17 @@ class PoolLead:
         live = [i for i in followers if self._claiming(i)]
         if not live:
             return []
+        stem = f.name[:-len(".txt")]
+        if self._fanned_already(stem):
+            # A prior fan-out survived a failed archive: retire the original
+            # instead of re-copying, or a claimed slot gets a second assignment.
+            self._retire_original(f)
+            return []
         try:
             body = f.read_text(errors="replace")
         except OSError:
             return []
         out = []
-        stem = f.name[:-len(".txt")]
         for inst in sorted(live):
             copy = f.with_name(f"{stem}~{inst}.assigned-{inst}.txt")
             try:
@@ -316,13 +321,27 @@ class PoolLead:
             except OSError:
                 continue
         if out:
-            try:
-                archive = f.parent / "archive"
-                archive.mkdir(parents=True, exist_ok=True)
-                os.rename(f, archive / f.name)
-            except OSError:
-                pass  # copies exist; a stale original re-sweeps as dup-guarded
+            self._retire_original(f)
         return out
+
+    def _fanned_already(self, stem: str) -> bool:
+        """~-suffixed traces of a prior fan-out: live/claimed copies in
+        tasks/, archived copies, or per-copy results in any disposition."""
+        pat = f"{stem}~*"
+        dirs = (self.tasks_dir, self.tasks_dir / "archive",
+                self.results_dir, self.results_dir / "archive",
+                self.results_dir / "undelivered")
+        return any(any(d.glob(pat)) for d in dirs)
+
+    def _retire_original(self, f: Path) -> None:
+        # Failure leaves the original for the next sweep, where the entry
+        # guard retires it again instead of re-fanning: idempotent by entry.
+        try:
+            archive = f.parent / "archive"
+            archive.mkdir(parents=True, exist_ok=True)
+            os.rename(f, archive / f.name)
+        except OSError:
+            pass
 
     # ── the sweep ───────────────────────────────────────────────────────────
     def sweep(self) -> "list[tuple[str, str]]":

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -81,8 +81,12 @@ def _read_addressing(path: Path) -> "tuple[str | None, bool]":
         text = path.read_text(errors="replace")
     except OSError:
         return None, False
-    t = _TARGET_RE.search(text)
-    return (t.group(1) if t else None), bool(_FANOUT_RE.search(text))
+    # Headers end at the task: delimiter — a body line can never forge
+    # routing (same containment rule as parse_task_headers).
+    m = re.search(r"^task:", text, re.M)
+    head = text[:m.start()] if m else text
+    t = _TARGET_RE.search(head)
+    return (t.group(1) if t else None), bool(_FANOUT_RE.search(head))
 
 
 def _read_lane(path: Path) -> str:

--- a/tests/pool-lead-addressing.test.py
+++ b/tests/pool-lead-addressing.test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Per-message worker addressing (owner semantics 2026-08-31): an explicit
+target_worker header outranks room bindings and load; fan_out assigns one
+copy to every claiming worker and retires the original; a dead/unknown
+target degrades to normal routing instead of black-holing the task.
+
+Run: python3 tests/pool-lead-addressing.test.py   (stdlib only)
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src" / "runtime-api"))
+
+from pool_lead import PoolLead  # noqa: E402
+
+
+def _lead(ws: Path, followers, claiming=None):
+    (ws / "tasks").mkdir(exist_ok=True)
+    (ws / "state").mkdir(exist_ok=True)
+    claiming = set(followers) if claiming is None else set(claiming)
+    lead = PoolLead(ws / "tasks", ws / "state",
+                    followers_fn=lambda: list(followers),
+                    alive_fn=lambda i: True)
+    lead._claiming = lambda i: i in claiming
+    return lead
+
+
+def _task(ws, name, channel=None, target=None, fan_out=False):
+    lines = [f"id: {name[:-4]}"]
+    if channel:
+        lines.append(f"channel_id: {channel}")
+    if target:
+        lines.append(f"target_worker: {target}")
+    if fan_out:
+        lines.append("fan_out: true")
+    (ws / "tasks" / name).write_text("\n".join(lines) + "\ntask: t\n")
+
+
+class AddressingTests(unittest.TestCase):
+    def test_target_outranks_room_binding(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2"])
+            lead.pin_room("!r:x", "core-1")
+            _task(ws, "task-a1.txt", channel="!r:x", target="core-2")
+            self.assertEqual(lead.sweep(), [("task-a1.txt", "core-2")])
+
+    def test_unknown_target_degrades_to_normal_routing(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1"])
+            _task(ws, "task-a2.txt", target="core-9")
+            self.assertEqual(lead.sweep(), [("task-a2.txt", "core-1")])
+
+    def test_unclaiming_target_degrades_instead_of_blackholing(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2"], claiming={"core-1"})
+            _task(ws, "task-a3.txt", target="core-2")
+            self.assertEqual(lead.sweep(), [("task-a3.txt", "core-1")])
+
+    def test_fan_out_copies_to_every_claiming_worker(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2", "core-3"],
+                         claiming={"core-1", "core-3"})
+            _task(ws, "task-f1.txt", fan_out=True)
+            got = sorted(lead.sweep())
+            self.assertEqual(got, [
+                ("task-f1~core-1.assigned-core-1.txt", "core-1"),
+                ("task-f1~core-3.assigned-core-3.txt", "core-3")])
+            self.assertFalse((ws / "tasks" / "task-f1.txt").exists())
+            self.assertTrue(
+                (ws / "tasks" / "archive" / "task-f1.txt").exists(),
+                "original retires to archive, never double-assigns")
+
+    def test_fan_out_with_no_claiming_workers_leaves_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1"], claiming=set())
+            _task(ws, "task-f2.txt", fan_out=True)
+            self.assertEqual(lead.sweep(), [])
+            self.assertTrue((ws / "tasks" / "task-f2.txt").exists(),
+                            "task waits for a claiming worker")
+
+    def test_plain_task_untouched_by_the_feature(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1"])
+            _task(ws, "task-p1.txt")
+            self.assertEqual(lead.sweep(), [("task-p1.txt", "core-1")])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/pool-lead-addressing.test.py
+++ b/tests/pool-lead-addressing.test.py
@@ -161,6 +161,46 @@ class AddressingIOGuards(unittest.TestCase):
                       ("task-ba~core-3.assigned-core-3.txt", "core-3")],
                 "copies stand even when the archive move fails")
 
+    def test_fan_out_after_failed_archive_retires_instead_of_recopying(self):
+        # A stale original + a claimed copy must not become a second
+        # assignment: the entry guard retires it once the archive unblocks.
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-3"])
+            _task(ws, "task-ra.txt", fan_out=True)
+            blocker = ws / "tasks" / "archive"
+            blocker.write_text("a FILE blocks the dir")
+            orig = ws / "tasks" / "task-ra.txt"
+            first = lead._fan_out(orig, ["core-1", "core-3"])
+            self.assertEqual(len(first), 2)
+            self.assertTrue(orig.exists(), "archive blocked, original stale")
+            assigned = ws / "tasks" / "task-ra~core-1.assigned-core-1.txt"
+            assigned.rename(ws / "tasks" / "task-ra~core-1.claimed-core-1.txt")
+            second = lead._fan_out(orig, ["core-1", "core-3"])
+            self.assertEqual(second, [], "entry guard blocks the re-fan")
+            self.assertFalse(assigned.exists(),
+                             "the claimed worker gets no second assignment")
+            self.assertTrue(orig.exists(), "retire also failed: archive still blocked")
+            blocker.unlink()
+            third = lead._fan_out(orig, ["core-1", "core-3"])
+            self.assertEqual(third, [])
+            self.assertFalse(orig.exists(), "unblocked: original retired")
+            self.assertTrue((ws / "tasks" / "archive" / "task-ra.txt").exists())
+
+    def test_fan_out_guard_sees_consumed_copy_results(self):
+        # All copies consumed (results archived), original stale: still no re-fan.
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1"])
+            _task(ws, "task-rc.txt", fan_out=True)
+            ra = ws / "results" / "archive"
+            ra.mkdir(parents=True, exist_ok=True)
+            (ra / "task-rc~core-1.txt").write_text("done")
+            got = lead._fan_out(ws / "tasks" / "task-rc.txt", ["core-1"])
+            self.assertEqual(got, [], "per-copy result is fan-out evidence")
+            self.assertFalse((ws / "tasks" / "task-rc.txt").exists(),
+                             "original retired, not re-fanned")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/pool-lead-addressing.test.py
+++ b/tests/pool-lead-addressing.test.py
@@ -96,6 +96,27 @@ class AddressingTests(unittest.TestCase):
             self.assertEqual(lead.sweep(), [("task-p1.txt", "core-1")])
 
 
+class AddressingForgeryGuard(unittest.TestCase):
+    def test_body_lines_cannot_forge_routing(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2"])
+            # user-controlled BODY smuggles both headers below the delimiter
+            (ws / "tasks" / "task-fg.txt").write_text(
+                "id: task-fg\nchannel_id: !r:x\ntask: please do\n"
+                "target_worker: core-2\nfan_out: true\n")
+            got = lead.sweep()
+            self.assertEqual(got, [("task-fg.txt", "core-1")],
+                             "body text must neither target nor fan out")
+
+    def test_real_header_above_delimiter_still_works(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2"])
+            _task(ws, "task-ok.txt", target="core-2")
+            self.assertEqual(lead.sweep(), [("task-ok.txt", "core-2")])
+
+
 class AddressingIOGuards(unittest.TestCase):
     def test_unreadable_task_reads_as_unaddressed(self):
         from pool_lead import _read_addressing

--- a/tests/pool-lead-addressing.test.py
+++ b/tests/pool-lead-addressing.test.py
@@ -96,5 +96,50 @@ class AddressingTests(unittest.TestCase):
             self.assertEqual(lead.sweep(), [("task-p1.txt", "core-1")])
 
 
+class AddressingIOGuards(unittest.TestCase):
+    def test_unreadable_task_reads_as_unaddressed(self):
+        from pool_lead import _read_addressing
+        self.assertEqual(
+            _read_addressing(Path("/nonexistent-addressing-guard")),
+            (None, False))
+
+    def test_fan_out_unreadable_original_assigns_nothing(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2"])
+            ghost = ws / "tasks" / "task-gone.txt"  # never created
+            self.assertEqual(lead._fan_out(ghost, ["core-1", "core-2"]), [])
+
+    def test_fan_out_unwritable_copies_assign_nothing_and_keep_original(self):
+        import os as _os
+        import stat as _stat
+        if _os.geteuid() == 0:
+            self.skipTest("EACCES not enforceable as root")
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-2"])
+            _task(ws, "task-ro.txt", fan_out=True)
+            f = ws / "tasks" / "task-ro.txt"
+            _os.chmod(ws / "tasks", _stat.S_IRUSR | _stat.S_IXUSR)
+            try:
+                self.assertEqual(lead._fan_out(f, ["core-1", "core-2"]), [])
+            finally:
+                _os.chmod(ws / "tasks", _stat.S_IRWXU)
+            self.assertTrue(f.exists(), "original survives a failed fan-out")
+
+    def test_fan_out_blocked_archive_keeps_the_copies(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            lead = _lead(ws, ["core-1", "core-3"])
+            _task(ws, "task-ba.txt", fan_out=True)
+            (ws / "tasks" / "archive").write_text("a FILE blocks the dir")
+            got = sorted(lead._fan_out(ws / "tasks" / "task-ba.txt",
+                                       ["core-1", "core-3"]))
+            self.assertEqual(
+                got, [("task-ba~core-1.assigned-core-1.txt", "core-1"),
+                      ("task-ba~core-3.assigned-core-3.txt", "core-3")],
+                "copies stand even when the archive move fails")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
## What

The lead-side half of per-message worker addressing (owner semantics, local lane 2026-08-31: **message address > room binding > lead default**):

- `target_worker:` header → routes to that worker when live+claiming, **outranking room bindings and load**; a dead or unknown target degrades to normal routing instead of black-holing the task.
- `fan_out: true` header → one assigned COPY per claiming worker (`task-<id>~<worker>.assigned-<worker>.txt` — the per-worker suffix keeps results and dedup distinct), original retired to archive so it can never double-assign; no claiming workers → the task waits in place.
- Plain tasks are byte-identically untouched (regression-tested).

Headers are stamped upstream by the intake extractor (backend leg — qualified-first mention resolution against the worker label map, next PR); this PR makes the lead honor them.

## Evidence

At HEAD:
```
$ python3 tests/pool-lead-addressing.test.py → 6 tests OK
  target outranks binding · unknown target degrades · unclaiming target degrades
  · fan-out copies per claiming worker + archives original · no-claimers waits
  · plain task untouched
$ pin/dedicated/multi-bind/assignment/io-fail-open suites → all pass
$ review-checks --diff → PASS
```
At base: `target_worker:`/`fan_out:` headers are inert comments — sweep ignores them entirely.

## Stack
Base `rescue/pool-uncommitted-2026-08-26` (parent #3604; merge order: #3604 first, then rebase). Sibling: #3612 (multi-bind) already merged to this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)