### PR TITLE
fix(coverage-gate): size the per-file cap for instrumentation, and default it once

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -22,7 +22,14 @@ jobs:
   coverage-gate:
     name: diff coverage >= 95% (python)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Moves with the per-file cap in scripts/coverage-gate.sh, or the two bounds
+    # drift: a file allowed 240s inside a job capped at 900s can burn the budget
+    # and get the job CANCELED mid-suite, which reports no per-file diagnostic at
+    # all. Measured over 18 real executions of this job: median 374s, max 498s.
+    # Worst case after the cap change -- two files capping on one worker, which
+    # #3606 actually exhibited -- is ~738s, so 20m restores the ~400s of headroom
+    # 15m gave before it. (air, agent of @qingyun-wu, on #3631.)
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -105,9 +105,16 @@ trap 'rm -rf "$RECDIR"' EXIT
 
 # `timeout` is coreutils and absent on stock macOS, where this also runs by
 # hand; degrade to no cap rather than failing the local path.
+#
+# 240s, not 120s: instrumentation slows race/bench-style tests well past their
+# uninstrumented runtime, so a cap sized for a bare run fails them here and the
+# red reads as the PR's fault (#3630). Defaulted ONCE -- the fallback used to be
+# written inline at both the cap and the timeout message, so changing one left
+# the other reporting a bound that was no longer enforced.
+COVERAGE_GATE_FILE_TIMEOUT="${COVERAGE_GATE_FILE_TIMEOUT:-240}"
 COVGATE_TIMEOUT=""
 if command -v timeout >/dev/null 2>&1; then
-    COVGATE_TIMEOUT="timeout -k 5 ${COVERAGE_GATE_FILE_TIMEOUT:-120}"
+    COVGATE_TIMEOUT="timeout -k 5 $COVERAGE_GATE_FILE_TIMEOUT"
 else
     echo "coverage-gate: no \`timeout\` binary — per-file cap disabled (local run)." >&2
 fi
@@ -133,7 +140,7 @@ while IFS= read -r f; do
     output="$(cat "$rec.out" 2>/dev/null || true)"
     if [ "$rc" -ne 0 ]; then
         if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
-            echo "✖ test TIMED OUT under instrumentation (>${COVERAGE_GATE_FILE_TIMEOUT:-120}s): $f"
+            echo "✖ test TIMED OUT under instrumentation (>${COVERAGE_GATE_FILE_TIMEOUT}s): $f"
         else
             echo "✖ test failed under instrumentation: $f"
         fi


### PR DESCRIPTION
Closes #3630.

## The failure

The coverage gate runs the Python suite under instrumentation with a **120s per-file cap** — a bound sized for an uninstrumented run. Instrumentation slows race/bench-style tests well past that, so a slow file trips the cap, the gate reports `suite must be green before coverage is meaningful`, and an unrelated PR goes red **reading as that PR's fault**.

Three hits today, every one on files the PR under test never touched:

| PR | head | file that timed out |
|---|---|---|
| #3626 | `4625fd0b` | `bench-claim-backends-smoke` (passed on rerun) |
| #3567 | `c5ed7815` | `outbox-race` |
| #3606 | `c4366768` | both of the above |

#3606 is the sharpest case: its entire diff is **1 TypeScript test file, +4/−0**. There is no path from that to a Python benchmark's wall-clock, and it failed twice — once on a rerun — so this is not something a retry reliably clears.

## The change

Raises the default to **240s** (option (a) in #3630) and, less obviously but more usefully, **resolves the default in one place**.

The fallback was previously written inline twice — at the cap and in the timeout message. Changing one would have left the other reporting a bound that was no longer enforced, and the message is the only thing a reader sees when it fires. That is a comment-shaped defect that survives review precisely because both copies look right in isolation.

`$COVERAGE_GATE_FILE_TIMEOUT` still overrides, so anyone wanting the old bound sets it explicitly.

## Checks

- `bash -n` clean, `shellcheck -S error` clean **on the patched file** — I ran both against the unpatched file first by accident and they passed, which proves nothing; these are the second run.
- Asserted mechanically that no `:-120` default survives and exactly one `:-240` remains, rather than eyeballing the diff.

## ⚠ Retracted: the bound this PR originally claimed

The first version of this body priced a worst case of ~738s and called it "still inside 900". **That is withdrawn.** @johnm-desktop showed two independent problems with it, and both are mine — @qingyun-air measured accurately, I used his number for something it could not support:

1. **738s prices an *assumed* two-timeout scenario, not the code's worst case.** The cap is per discovered file; at this head that is 718 `tests/**/*.test.py` across lanes that continue after a timeout. Cumulative capped work can approach 718 × 240s ÷ lanes, plus setup. Nothing here bounds how many files may time out, there is no fail-fast, and the lane count is not statically determinable (`COVERAGE_GATE_WORKERS` or `getconf`).
2. **The pricing measured the wrong regime.** median 374s / max 498s over 18 runs were all observed **under the old 120s cap**. Files that previously died at 120s now run to as much as 240s, so that distribution is not the post-change one and cannot bound it.

The reusable statement of the residue, @qingyun-air's phrasing: **elapsed time here is bounded by cancellation, not by design, and any per-file cap raise trades margin for diagnosability at a rate nobody has measured.**

Landing with that recorded rather than holding, on reviewers' call. A fail-fast bounding total capped work is the obvious completion, but it touches the shared parallel lane runner — and as @qingyun-air put it, a wrong fail-fast in a shared lane runner is worse than a documented bound.

## What this does not do

It does not make the slow tests fast, and it does not exempt them (option (b) in #3630). If instrumentation keeps getting slower, a fixed 240s inherits the same problem — the durable version is a cap derived from each file's uninstrumented runtime, which is more than this should carry.

