### PR TITLE
test(memory-index-trend): pin the fixture repo's git env so teardown cannot race

### DIFF
--- a/tests/health-check-memory-index-trend.test.py
+++ b/tests/health-check-memory-index-trend.test.py
@@ -14,6 +14,7 @@ draft.
 """
 from __future__ import annotations
 import importlib.util
+import os
 import subprocess
 import tempfile
 import time
@@ -31,8 +32,18 @@ def _hc():
     return m
 
 
-def _git(cwd: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
+# gc/fsmonitor writing into .git races TemporaryDirectory teardown (ENOTEMPTY),
+# so the fixture git ignores ambient config and background maintenance.
+_GIT_PIN = ["-c", "gc.auto=0", "-c", "maintenance.auto=false",
+            "-c", "core.fsmonitor=false"]
+_GIT_ENV = {"GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1"}
+
+
+def _git(cwd: Path, *args: str, env: "dict | None" = None) -> None:
+    subprocess.run(["git", *_GIT_PIN, "-C", str(cwd), *args], check=True,
+                   capture_output=True,
+                   env={**os.environ, **_GIT_ENV, **(env or {})})
 
 
 def _repo_with_sizes(tmp: Path, sizes: "list[int]", ago_h: float = 0.0) -> Path:
@@ -56,12 +67,8 @@ def _repo_with_sizes(tmp: Path, sizes: "list[int]", ago_h: float = 0.0) -> Path:
         _git(repo, "add", "MEMORY.md")
         # distinct, increasing author dates so the window spans real hours
         env_date = f"{base + 3600 * i} +0000"
-        subprocess.run(
-            ["git", "-C", str(repo), "commit", "-q", "-m", f"c{i}",
-             "--date", env_date],
-            check=True, capture_output=True,
-            env={**__import__("os").environ, "GIT_COMMITTER_DATE": env_date},
-        )
+        _git(repo, "commit", "-q", "-m", f"c{i}", "--date", env_date,
+             env={"GIT_COMMITTER_DATE": env_date})
     return idx
 
 
@@ -343,9 +350,8 @@ class HistoricalBytesUseTheSAMEUnitsAsTheLimit(unittest.TestCase):
                 idx.write_text(text)
                 _git(repo, "add", "MEMORY.md")
                 d = f"2026-08-03T{i:02d}:00:00"
-                subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", f"c{i}", "--date", d],
-                               check=True, capture_output=True,
-                               env={**os.environ, "GIT_COMMITTER_DATE": d})
+                _git(repo, "commit", "-q", "-m", f"c{i}", "--date", d,
+                     env={"GIT_COMMITTER_DATE": d})
             note = m._index_growth_note(idx, len(m._index_effective_text(lean).encode()))
 
         self.assertNotIn("ALREADY EXCEEDED", note,


### PR DESCRIPTION
Closes #3637.

## The gap

#3543 closed an `ENOTEMPTY` `TemporaryDirectory` teardown in `health-check-index-trend-unavailable.test.py` by pinning the fixture repo's git environment. **It changed one file.** This sibling builds its fixtures the same way, never received the pin, and hit the same failure the next day — attempt 1 of run `33414361365` on #3631:

```
ERROR: test_sustained_growth_is_not_called_stale (StaleDeadlineGuardCanActuallyFire)
  tempfile cleanup -> shutil.rmtree -> os.rmdir
OSError: [Errno 39] Directory not empty: '.git'
```

An **ERROR, not a FAILURE** (`FAILED (errors=1)`): every assertion passed, and the file died in teardown.

## The change

The pin moves into `_git`, and the **two raw `git commit --date` calls that bypassed it** (`_repo_with_sizes` and the `IdleHistoryDoesNotImplyALiveDeadline` fixture) are routed through it. That is the part that makes it hold: pinning the helper alone would have covered 8 of 10 call sites and left the two `commit` invocations — the operation most likely to spawn the writer — bare.

`_git` gains an `env` parameter so those calls keep their `GIT_COMMITTER_DATE` without needing a raw `subprocess.run`.

## Evidence

**Before/after, ambient config planted deliberately** (`~/.gitconfig` with `[gc] auto = 9999`):

```
ambient gc.auto WITHOUT pin : '9999'   <- control: the leak is real
ambient gc.auto WITH pin    : '0'      <- pinned value wins
```

The control matters: without it, a passing "with pin" arm proves nothing, because it cannot distinguish a working pin from an environment that never leaked.

Suite green at HEAD, **run locally** (`python3 tests/health-check-memory-index-trend.test.py`): `Ran 23 tests in 1.768s — OK`. CI cannot corroborate this number: its `python standalone tests` job prints only filenames on success (`Ran N tests` appears 0 times across the whole job log, against 717 `→ tests/` lines), so the count is local evidence and is labelled as such.
Push gate: `review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)`.

**Structural control**, that no bypass survives:

```
literal ["git"] occurrences in the file: 1   (inside _git)
```

## What I am NOT claiming

I have **no mutation test for the race itself.** It is nondeterministic and load-dependent, so removing the pin does not reliably turn the suite red — a green run without the pin is exactly what produced this gap in the first place. The evidence above pins that *the configuration reaches git*, not that the race is gone. `#3637` records the remaining measurement: #3543 took the signature 8 → 2, not 8 → 0, so a second cause may exist.

Scope: one test file, no production code.

