### PR TITLE
fix(codex-scheduler): an assigned task is active, so no duplicate retry

### DIFF
--- a/skills/schedule-crons/scripts/codex-scheduler.py
+++ b/skills/schedule-crons/scripts/codex-scheduler.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 from local_task_protocol import serialize_task_last  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 from sutando_config import resolve_core_runtime  # noqa: E402
+from task_archive import find_task_file  # noqa: E402
 
 
 LABEL = "com.sutando.codex-schedules"
@@ -298,11 +299,11 @@ def _find_result(workspace: Path, task_ids: list[str]) -> Path | None:
 def _task_is_active(workspace: Path, task_ids: list[str]) -> bool:
     tasks = workspace / "tasks"
     for task_id in task_ids:
-        if (tasks / f"{task_id}.txt").exists():
+        # The lead also renames to `.assigned-<inst>`; a bare name plus a
+        # `.claimed-` glob reads that as absent, and absent means retry.
+        if find_task_file(tasks, task_id) is not None:
             return True
         if (tasks / "processed" / f"{task_id}.txt").exists():
-            return True
-        if next(tasks.glob(f"{task_id}.claimed-core-*.txt"), None) is not None:
             return True
     return False
 

--- a/tests/codex-scheduler.test.py
+++ b/tests/codex-scheduler.test.py
@@ -185,6 +185,29 @@ def test_enqueue_retry_complete_and_no_duplicate():
         assert state["jobs"]["daily-news"]["current"] is None
 
 
+def test_an_assigned_task_is_active_so_no_duplicate_retry_fires():
+    # `.assigned-<inst>` is the claimed rename's sibling state; a `.claimed-`
+    # glob cannot see it, so the retry fires while the original is still live.
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        config(ws)
+        scheduler.tick(ws, "test-host", at(6, 0))
+        task = next((ws / "tasks").glob("*.txt"))
+
+        assigned = task.with_name(f"{task.stem}.assigned-core-2.txt")
+        task.rename(assigned)
+        assert scheduler._task_is_active(ws, [task.stem]) is True
+        assert scheduler.tick(ws, "test-host", at(6, 7))["events"] == []
+        assert [p.name for p in (ws / "tasks").iterdir()] == [assigned.name]
+
+        # Control: once it is genuinely gone, the retry the assigned state was
+        # suppressing does fire — so the assertion above is not vacuous.
+        assigned.unlink()
+        retry = scheduler.tick(ws, "test-host", at(6, 8))
+        assert retry["events"] == [
+            {"job": "daily-news", "event": "retried", "attempt": 2}]
+
+
 def test_failure_alert_and_health():
     with tempfile.TemporaryDirectory() as td:
         ws = Path(td)
@@ -321,6 +344,7 @@ def main():
         test_codex_runtime_owns_legacy_main_loop_without_mutating_config,
         test_helpers_and_config_validation,
         test_enqueue_retry_complete_and_no_duplicate,
+        test_an_assigned_task_is_active_so_no_duplicate_retry_fires,
         test_failure_alert_and_health,
         test_stale_active_task_fails_instead_of_stalling_or_duplicating,
         test_wake_catchup_and_timezone,

--- a/tests/task-id-delegation.test.py
+++ b/tests/task-id-delegation.test.py
@@ -35,7 +35,6 @@ OWNERS = ("src/task_archive.py", "packages/ag2-sparrow/ag2_sparrow/task_archive.
 # future set now. DELETE a row when its fix lands; section 6 fails on a stale one.
 KNOWN = {
     "src/runtime-api/tasks_view.py:240": "sonichi/sutando#3656",
-    "skills/schedule-crons/scripts/codex-scheduler.py:305": "sonichi/sutando#3660",
 }
 
 fails = []


### PR DESCRIPTION
## What

`_task_is_active()` in `skills/schedule-crons/scripts/codex-scheduler.py` recognised a bare task name and `.claimed-core-*`, but not the pool lead's `.assigned-<inst>` rename. A task assigned and not yet claimed therefore read as **absent**, and its caller at `:380-386` uses that answer to decide whether retrying is safe.

The comment directly above that call names the stake:

> Never create a second watcher event while any prior attempt remains queued, claimed, or processed. Retrying a live task can duplicate irreversible side effects.

## Before / after — actual output, one scheduler tick, varying only the pool state

At the parent commit `27992514`:

```
PARENT source, assigned state:
  _task_is_active -> False
  tick events     -> [{'job': 'daily-news', 'event': 'retried', 'attempt': 2}]
  tasks now       -> ['task-cron-daily-news-1784095200-a2.txt',
                      'task-cron-daily-news-1784095200.assigned-core-2.txt']
```

The original and its retry are live simultaneously. At `HEAD`:

```
$ python3 tests/codex-scheduler.test.py
All codex-scheduler tests passed.
```

And the new test discriminates — source reverted, test kept:

```
File "tests/codex-scheduler.test.py", line 202, in
     test_an_assigned_task_is_active_so_no_duplicate_retry_fires
    assert scheduler._task_is_active(ws, [task.stem]) is True
AssertionError
```

Both halves of the test were checked separately: the unit assertion above, and the tick-level `events == []` assertion, which produces the `retried` event shown in the PARENT block. The test also carries its own control — after the assigned file is removed, the suppressed retry does fire — so a passing run cannot be vacuous.

## Why `find_task_file` rather than a second glob

`task_archive.find_task_file` already owns this grammar and handles bare, `.assigned-`, `.claimed-` and the quarantined form. Adding a second `.assigned-` glob here would be another private copy of a policy that already has a shared owner, which is the defect this repo's rules name. The `processed/` check stays as-is, since `find_task_file` does not look there.

**One deliberate widening, stated rather than buried:** "active" now also covers a quarantined `*.txt.archive-failed*` copy. A quarantined task is not gone, so on its own that would stall the job silently — it does not, because `:381-390` gates on `active and age >= active_stale_minutes * 60` and emits `"task still active after N minutes; refusing duplicate retry"`. Fail-closed with an alert, not a silent stall. Say so if you would rather it did not widen at all.

*(That bounding sentence is @qingyun-air.agent's; they noted a reader hitting the widening note would ask exactly this, and they were right.)*

## Checks run locally

```
tests/codex-scheduler.test.py                     PASS
tests/codex-scheduler-writer-golden.test.py       PASS
tests/codex-scheduler-import-without-plistlib.py  PASS
tests/task-archive.test.py                        PASS
tests/injection-guard-sweep.test.py               48/48 passed
scripts/review-checks.sh --diff <full PR diff>    PASS
```

`tests/codex-core-launcher.test.py` needs no fixture change: it drives a `fake-codex-scheduler.py`, not this file.

## Context

Found while reviewing #3656, where @keweichen had this as merge blocker 1.

## Scope: this is wider than the title, deliberately

`find_task_file` owns the whole live-name grammar, so delegating to it widens what counts as
"active" beyond the `.assigned-` case the title names. Measured against this branch:

```
task-x.txt                    -> True
task-x.claimed-core-1.txt     -> True
task-x.assigned-core-2.txt    -> True   <- the fix
task-x.txt.archive-failed-1   -> True   <- NEW; main reads this as absent and retries
(no file at all)              -> False  <- control
```

So a task whose archive failed now suppresses its scheduled retry instead of re-firing. That is
the intended direction — a quarantined task was already processed, and re-firing it is exactly the
duplicate execution this PR exists to prevent — but it is a behaviour change the title does not
imply, and because the check delegates to `_ID_STATE`, any state added to that grammar later
becomes "active" here too without touching this file.

Raised by @john-the-dev on review; reproduced above rather than restated.

**The substitution's other half — the deleted glob — exercised against real filenames** (@qingyun-air
ran this; both other reviewers had established it by reading `_ID_STATE`, which is the weaker form):

```
task-….txt                        found    bare
task-….claimed-core-1.txt         found    the glob this PR DELETES
task-….claimed-core-abc.txt       found    non-numeric instance suffix
task-….assigned-core-2.txt        found    what this PR adds
task-….txt.archive-failed         found    the quarantined widening above

negative controls
task-…-other.claimed-core-1.txt   NOT found   longer id sharing the prefix
empty directory                   NOT found
```

Strict superset: deleting the explicit `{id}.claimed-core-*.txt` glob loses nothing, including the
non-numeric instance suffix that a narrower successor pattern could have dropped. The negative
controls matter as much as the positives — without them "found" for every input is also what a
matcher that matches everything returns.

> **⚠ SUPERSEDED FRAMING — corrected 2026-09-01.** This section used to read *"landing it here as the named prerequisite that review offers as an alternative, so #3656 stays one concern."* That is no longer true and a reader arriving here would be misled. Review offered two paths and **both were taken in parallel**: #3656 fixed the scheduler in place rather than taking the prerequisite, so the two PRs now carry the same `+4/-3` hunk. Credit to @TustinOC for spotting it; I confirmed it by diffing the hunks — same import, same `find_task_file` substitution, same removal of the `.claimed-core-*` glob, differing only in comment wording and import placement.
>
> **#3656 is the superset** (it also fixes `src/runtime-api/tasks_view.py`), so I am treating it as the PR that carries the production fix rather than racing it. Both sit at 1 of 2 approvals, so neither can land yet.
>
> **What is NOT duplicated, and is the reason this PR still exists:** the test here carries a control — after the assigned file is removed, the suppressed retry *does* fire — and names the quarantined-form widening with its fail-closed reasoning. #3656's scheduler test has neither.
>
> **Sequencing, so `main` is green at every point.** Whichever lands first must also delete the matching rows from `KNOWN` in `tests/task-id-delegation.test.py` (#3664), whose `no stale allowlist rows` check fails by design once a row's fix lands — I verified this against the merge result and posted the evidence on #3656. If #3656 lands first I will rebase this branch, drop the duplicated hunk, and keep the test. If this one lands first the same obligation falls here.




