### PR TITLE
fix(notify-reviewers): count reviewers by person, not by roster key

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -110,13 +110,14 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
         # One person can hold several roster keys, so counting NAMES lets the
         # two-reviewer gate in main() pass on one recipient addressed twice.
         actor = actor_of.get(name, name)
-        prior = covered.get(actor) or covered.get(stand)
+        # Tagged keys: a single dict would alias a roster key against an mxid.
+        prior = covered.get(("actor", actor)) or covered.get(("stand", stand))
         if prior is not None:
             print(f"DUPLICATE '{name}': same person as '{prior}' "
                   f"({stand}) — already covered, not a second reviewer",
                   file=sys.stderr)
             continue
-        covered[actor] = covered[stand] = name
+        covered[("actor", actor)] = covered[("stand", stand)] = name
         out.append({"name": name, "stand": stand, "room": room,
                     "human": entry.get("human")})
     return out, worst

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -78,6 +78,7 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
     batch — resolvable reviewers are still notified, the worst refusal code
     is carried to the exit so the caller sees somebody was skipped."""
     out, worst = [], 0
+    actor_of, covered = _actor_map(roster), {}
     for name in names:
         entry = roster.get(name)
         if entry is None:
@@ -106,6 +107,16 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
                   file=sys.stderr)
             worst = max(worst, 4)
             continue
+        # One person can hold several roster keys, so counting NAMES lets the
+        # two-reviewer gate in main() pass on one recipient addressed twice.
+        actor = actor_of.get(name, name)
+        prior = covered.get(actor) or covered.get(stand)
+        if prior is not None:
+            print(f"DUPLICATE '{name}': same person as '{prior}' "
+                  f"({stand}) — already covered, not a second reviewer",
+                  file=sys.stderr)
+            continue
+        covered[actor] = covered[stand] = name
         out.append({"name": name, "stand": stand, "room": room,
                     "human": entry.get("human")})
     return out, worst

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -403,6 +403,17 @@ class ResolveDedupesOneActor(unittest.TestCase):
         self.assertEqual(got, ["alice", "carol"])
         self.assertNotIn("DUPLICATE", err)
 
+    def test_an_mxid_shaped_roster_key_does_not_alias_a_stand(self):
+        # A flat keyspace lets a roster key collide with someone else's stand,
+        # and a false DUPLICATE drops a real second reviewer with no error.
+        roster = {"@shared:x": {"stand": "@a-stand:x", "room": "!r"},
+                  "bob": {"stand": "@shared:x", "room": "!r"}}
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            targets, _ = _load().resolve(["@shared:x", "bob"], roster)
+        self.assertEqual(sorted(t["name"] for t in targets), ["@shared:x", "bob"])
+        self.assertNotIn("DUPLICATE", buf.getvalue())
+
     def test_the_refusal_names_who_already_covers_the_slot(self):
         # "already addressed" and "unreachable" need different follow-ups.
         _, err = self.names("alice", "bob")

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -368,5 +368,46 @@ class FailurePaths(unittest.TestCase):
         self.assertFalse(refuse)
 
 
+class ResolveDedupesOneActor(unittest.TestCase):
+    """Two roster keys for one person must not satisfy the two-reviewer gate."""
+
+    ROSTER = {
+        "alice": {"stand": "@a:x", "room": "!r"},
+        "bob": {"stand": "@a:x", "room": "!r"},              # same stand, no link
+        "carol": {"stand": "@c:x", "room": "!r"},
+        "dave": {"stand": "@d:x", "room": "!r", "same_actor_as": "erin"},
+        "erin": {"stand": "@e:x", "room": "!r", "same_actor_as": "dave"},
+    }
+
+    def names(self, *keys):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            targets, _ = _load().resolve(list(keys), self.ROSTER)
+        return sorted(t["name"] for t in targets), buf.getvalue()
+
+    def test_two_keys_sharing_a_stand_count_once(self):
+        got, err = self.names("alice", "bob", "carol")
+        self.assertEqual(got, ["alice", "carol"])
+        self.assertIn("DUPLICATE 'bob'", err)
+
+    def test_two_keys_linked_by_same_actor_as_count_once(self):
+        # Distinct stands, one human — the link is the only signal.
+        got, err = self.names("dave", "erin", "carol")
+        self.assertEqual(got, ["carol", "dave"])
+        self.assertIn("DUPLICATE 'erin'", err)
+
+    def test_distinct_people_are_not_deduped(self):
+        # Control: without this the assertions above pass on a resolve() that
+        # simply drops every second name.
+        got, err = self.names("alice", "carol")
+        self.assertEqual(got, ["alice", "carol"])
+        self.assertNotIn("DUPLICATE", err)
+
+    def test_the_refusal_names_who_already_covers_the_slot(self):
+        # "already addressed" and "unreachable" need different follow-ups.
+        _, err = self.names("alice", "bob")
+        self.assertIn("same person as 'alice'", err)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
## What

`main()`'s two-reviewer gate exists so *"one being busy cannot stall the PR"* — but it counts the entries `resolve()` returns, and `resolve()` returned one entry per input **name**. One person holding two roster keys satisfied it, and the run emitted two identical mentions to one Stand.

## Before / after — actual output, live roster

```
BEFORE  resolve(["johnm-desktop", "jsun-m"])
        -> ['johnm-desktop', 'jsun-m']   len=2, gate PASSES
        both stands: @johnm-desktop.agent:ag2.space

AFTER   -> ['johnm-desktop']             len=1, gate REFUSES
        DUPLICATE 'jsun-m': same person as 'johnm-desktop'
        (@johnm-desktop.agent:ag2.space) — already covered, not a second reviewer

CONTROL resolve(["qingyun-wu", "john-the-dev"])  -> len=2   (two real people, unaffected)
```

Roster shape behind it: **8 keys carry a stand, 7 distinct.**

## Why this and not new dedupe logic

The file already knew. `_stale_repeat_ask`'s own comment says *"jsun-m IS johnm-desktop"*, and `_actor_map` already computes the connected component of `same_actor_as`. The policy existed and was applied when listing who had **not** been asked — but not on the gate the policy is *for*. This wires the existing map into `resolve()` rather than adding a second notion of identity. A stand match is kept as a fallback for keys whose `same_actor_as` link is not yet recorded, so roster hygiene is not load-bearing.

## Tests

New `ResolveDedupesOneActor` in `tests/sci-notify-reviewers-inproc.test.py`, four cases including a control:

```
WITH FIX          Ran 40 tests   OK
SOURCE REVERTED   Ran 40 tests   FAILED (failures=3)
  FAIL test_two_keys_sharing_a_stand_count_once
  FAIL test_two_keys_linked_by_same_actor_as_count_once
  FAIL test_the_refusal_names_who_already_covers_the_slot
```

The fourth — `test_distinct_people_are_not_deduped` — **passes in both arms by design**. Without it the three above are also satisfied by a `resolve()` that simply drops every second name.

All five notify-reviewers suites pass. `scripts/review-checks.sh --diff <full PR diff>`: PASS.

## Why it matters beyond one roster

The code defect is shared; the collision is host-local data — `data/collaboration-intelligence/` is not in the vault carrier set (`git ls-files data/` → 0), so each host has its own roster. @sutando-rui measured **7 keys / 7 distinct — no collision** on theirs, with a planted-duplicate control confirming the probe can see one; mine has a live collision. So the guard is sound or unsound by accident of who is in a given file, nothing reports which state a host is in, and a clean roster acquires the fault the next time someone adds a key whose person is already present. That is the argument for fixing the resolver rather than the data.

## Merge order

Touches two files that my unpushed `fix/notify-reviewers-unrecorded-ask` branch also touches, at **disjoint hunks** — `notify_reviewers.py` `@@78,@@106` here vs `@@390` there; `sci-notify-reviewers-inproc.test.py` `@@368` here vs `@@7,@@98,@@341` there. Shared files, zero shared anchors: git will merge cleanly, but whichever lands second wants a rebase rather than a blind merge.

## Credit

@qingyun-air.agent independently found and fixed the same latent gap in their copy tonight, with controls in both directions, and their framing of the refusal — that it must distinguish *already addressed* from *unreachable* — is why the message names the covering reviewer.
