### PR TITLE
fix(notify-reviewers): refuse a reviewer whose approval cannot gate

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -143,8 +143,19 @@ def gate_capability(repo: str, login: str) -> "tuple[bool | None, str]":
     if perm in ("write", "admin", "maintain"):
         return True, perm
     if perm in ("read", "none", "triage"):
-        return False, perm
+        # `read` is also what this endpoint returns for someone who is not a
+        # collaborator at all, so the reason needs the membership check.
+        return False, perm if _is_collaborator(repo, login) else "not a collaborator"
     return None, f"unverified (permission={perm!r})"
+
+
+def _is_collaborator(repo: str, login: str) -> bool:
+    try:
+        p = subprocess.run(["gh", "api", f"repos/{repo}/collaborators/{login}"],
+                           capture_output=True, text=True, timeout=60)
+    except Exception:                            # noqa: BLE001 - probe must not raise
+        return True                              # unknown -> the milder wording
+    return p.returncode == 0
 
 
 def _github_login(name: str, roster: dict) -> "tuple[str, str]":
@@ -391,7 +402,9 @@ def main() -> int:
                     print(f"{t['name']}: probing GitHub as {login} ({why_login})",
                           file=sys.stderr)
                 if can is False:
-                    print(f"CANNOT GATE '{t['name']}': {why_cap}-only on {repo} — an "
+                    detail = (why_cap if why_cap == "not a collaborator"
+                              else f"{why_cap}-only")
+                    print(f"CANNOT GATE '{t['name']}': {detail} on {repo} — an "
                           f"approval from this account does not count toward the "
                           f"required approvals", file=sys.stderr)
                     refusal_rc = max(refusal_rc, 7)

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -147,6 +147,31 @@ def gate_capability(repo: str, login: str) -> "tuple[bool | None, str]":
     return None, f"unverified (permission={perm!r})"
 
 
+def _github_login(name: str, roster: dict) -> "tuple[str, str]":
+    """(login GitHub can answer for, why) — a roster key is not always one.
+
+    `johnm-desktop` is a Stand handle, not a login; probing it 404s and the
+    capability check degrades to a silent no-op on exactly the aliased keys
+    `_actor_map` exists to normalize. Follow same_actor_as to a sibling that is.
+    """
+    entry = (roster or {}).get(name) or {}
+    if _is_github_user(name):
+        return name, "key is a login"
+    sib = entry.get("same_actor_as")
+    if sib and _is_github_user(sib):
+        return sib, f"via same_actor_as -> {sib}"
+    return name, "no login found for this key"
+
+
+def _is_github_user(login: str) -> bool:
+    try:
+        p = subprocess.run(["gh", "api", f"users/{login}", "-q", ".login"],
+                           capture_output=True, text=True, timeout=60)
+    except Exception:                            # noqa: BLE001 - probe must not raise
+        return False
+    return p.returncode == 0 and p.stdout.strip().lower() == login.lower()
+
+
 def stand_present_in_room(target: dict) -> "tuple[bool, str]":
     """Is this stand actually a member of the room we are about to mention it in?
 
@@ -348,11 +373,23 @@ def main() -> int:
     # ask the repo named in the message rather than trusting a cached tier.
     if a.kind == "ask" and targets:
         refs = _PR_URL.findall(a.message or "")
+        if not refs:
+            # Every other refusal path here prints; the one case that cannot be
+            # checked must not be the one case that is silent.
+            print("gate capability NOT CHECKED: the message names no "
+                  "github.com/<owner>/<repo>/pull/<n> URL, so there is no repo to "
+                  "ask about — an unchecked send is not a checked one",
+                  file=sys.stderr)
         if refs:
             repo = refs[0][0]
+            roster_now = load_roster()
             kept = []
             for t in targets:
-                can, why_cap = gate_capability(repo, t["name"])
+                login, why_login = _github_login(t["name"], roster_now)
+                can, why_cap = gate_capability(repo, login)
+                if login != t["name"]:
+                    print(f"{t['name']}: probing GitHub as {login} ({why_login})",
+                          file=sys.stderr)
                 if can is False:
                     print(f"CANNOT GATE '{t['name']}': {why_cap}-only on {repo} — an "
                           f"approval from this account does not count toward the "

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -123,6 +123,30 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
     return out, worst
 
 
+def gate_capability(repo: str, login: str) -> "tuple[bool | None, str]":
+    """(can this login's approval discharge repo's approval gate?, why).
+
+    Asked of GitHub, not of the roster: a cached tier goes stale silently and an
+    approval from a read-only account is indistinguishable in the UI from one
+    that counts. None = could not determine; the caller prints, never refuses.
+    """
+    try:
+        p = subprocess.run(
+            ["gh", "api", f"repos/{repo}/collaborators/{login}/permission",
+             "-q", ".permission"],
+            capture_output=True, text=True, timeout=60)
+    except Exception as exc:                     # noqa: BLE001 - probe must not raise
+        return None, f"unverified ({type(exc).__name__})"
+    if p.returncode != 0:
+        return None, f"unverified (gh rc={p.returncode})"
+    perm = p.stdout.strip()
+    if perm in ("write", "admin", "maintain"):
+        return True, perm
+    if perm in ("read", "none", "triage"):
+        return False, perm
+    return None, f"unverified (permission={perm!r})"
+
+
 def stand_present_in_room(target: dict) -> "tuple[bool, str]":
     """Is this stand actually a member of the room we are about to mention it in?
 
@@ -320,6 +344,27 @@ def main() -> int:
     targets, refusal_rc = resolve(names, load_roster())
     # Gates run on RESOLVED targets before any send, so no partial batch notifies
     # one person; plan mode is exempt because only a real ASK can strand a PR.
+    # A read-only approval looks identical in the UI and discharges nothing, so
+    # ask the repo named in the message rather than trusting a cached tier.
+    if a.kind == "ask" and targets:
+        refs = _PR_URL.findall(a.message or "")
+        if refs:
+            repo = refs[0][0]
+            kept = []
+            for t in targets:
+                can, why_cap = gate_capability(repo, t["name"])
+                if can is False:
+                    print(f"CANNOT GATE '{t['name']}': {why_cap}-only on {repo} — an "
+                          f"approval from this account does not count toward the "
+                          f"required approvals", file=sys.stderr)
+                    refusal_rc = max(refusal_rc, 7)
+                    continue
+                if can is None:
+                    print(f"{t['name']}: gate capability {why_cap} on {repo} — "
+                          f"sending, but this is not a confirmation it can approve",
+                          file=sys.stderr)
+                kept.append(t)
+            targets = kept
     # The two-reviewer rule exists so one person being busy cannot stall a PR.
     # A notice asks for nothing, so it cannot stall anything by going to one.
     if a.send and a.kind == "ask" and len(targets) < 2 and not a.allow_single:

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -504,6 +504,39 @@ class GateCapabilityProbesAGitHubLogin(unittest.TestCase):
         self.assertIn("no login found", why)
 
 
+class GateCapabilityNamesTheRightReason(unittest.TestCase):
+    """`read` is also the endpoint's answer for a non-collaborator."""
+
+    def _cap(self, perm, is_collab):
+        # The two calls differ only by URL, so the stub must too — keying both
+        # on one return code makes the permission read fail as well.
+        def run(cmd, **k):
+            membership = not any("permission" in str(x) for x in cmd)
+            rc = (0 if is_collab else 1) if membership else 0
+            return type("R", (), {"stdout": "" if membership else perm,
+                                  "stderr": "", "returncode": rc})()
+        m = _load()
+        m.subprocess = type("S", (), {"run": staticmethod(run),
+                                      "TimeoutExpired": Exception})
+        return m.gate_capability("o/r", "who")
+
+    def test_a_non_collaborator_is_not_described_as_read_only(self):
+        can, why = self._cap("read", is_collab=False)
+        self.assertIs(can, False)
+        self.assertEqual(why, "not a collaborator")
+
+    def test_a_real_read_collaborator_keeps_its_permission_word(self):
+        # Control: without this the reason collapses to one string for both.
+        can, why = self._cap("read", is_collab=True)
+        self.assertIs(can, False)
+        self.assertEqual(why, "read")
+
+    def test_write_is_unaffected_by_the_membership_probe(self):
+        can, why = self._cap("write", is_collab=False)
+        self.assertIs(can, True)
+        self.assertEqual(why, "write")
+
+
 class GateCapabilitySkipIsAnnounced(unittest.TestCase):
     """The one case the tool cannot check must not be the one it is silent about."""
 

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -553,5 +553,92 @@ class GateCapabilitySkipIsAnnounced(unittest.TestCase):
         self.assertIn("gate capability NOT CHECKED", buf.getvalue())
 
 
+class ProbeFailureDefaultsAreDeliberate(unittest.TestCase):
+    """Every probe here can fail, and the three defaults disagree on purpose.
+
+    Each probe feeds an assertion of a different polarity, and each default is
+    the one that declines to assert: never refuse a reviewer, and never claim a
+    relationship, on the strength of a probe that did not answer. Read as return
+    values alone the trio looks inconsistent, which is why the direction is
+    pinned here per probe rather than left to be re-derived.
+    """
+
+    @staticmethod
+    def _raising(exc):
+        return type("S", (), {"run": staticmethod(lambda *a, **k: (_ for _ in ()).throw(exc)),
+                              "TimeoutExpired": Exception})
+
+    def test_gate_capability_returns_unverified_when_the_probe_raises(self):
+        m = _load()
+        m.subprocess = self._raising(OSError("boom"))
+        can, why = m.gate_capability("o/r", "who")
+        # None, not False: a probe that did not run has not shown anyone unable
+        # to approve, and main() prints on None while refusing on False.
+        self.assertIsNone(can)
+        self.assertIn("OSError", why)
+
+    def test_gate_capability_returns_unverified_when_gh_exits_nonzero(self):
+        m = _load()
+        m.subprocess = type("S", (), {
+            "run": staticmethod(lambda *a, **k: type("R", (), {
+                "stdout": "", "stderr": "", "returncode": 4})()),
+            "TimeoutExpired": Exception})
+        can, why = m.gate_capability("o/r", "who")
+        self.assertIsNone(can)
+        self.assertIn("rc=4", why)
+
+    def test_is_collaborator_defaults_to_TRUE_so_the_wording_stays_milder(self):
+        m = _load()
+        m.subprocess = self._raising(OSError("boom"))
+        # True keeps gate_capability saying "read", the weaker claim. False would
+        # print "not a collaborator" — asserting an absent relationship on no
+        # evidence, which is the bug 63d18d2c fixed in the other direction.
+        self.assertIs(m._is_collaborator("o/r", "who"), True)
+
+    def test_is_github_user_defaults_to_FALSE_and_that_is_not_a_contradiction(self):
+        m = _load()
+        m.subprocess = self._raising(OSError("boom"))
+        # Opposite literal, same rule: True here would assert an unprobed key IS
+        # a login. False degrades to "no login found", and the capability probe
+        # then reports unverified rather than refusing.
+        self.assertIs(m._is_github_user("who"), False)
+
+    def test_the_two_defaults_compose_to_send_with_a_caveat_not_to_refuse(self):
+        # The property that matters is not either literal but their composition:
+        # with every probe failing, a reviewer is still notified.
+        m = _load()
+        m.subprocess = self._raising(OSError("boom"))
+        login, _ = m._github_login("who", {"who": {"stand": "@w:x", "room": "!r"}})
+        can, _ = m.gate_capability("o/r", login)
+        self.assertIsNot(can, False)
+
+
+class AliasProbeIsAnnounced(unittest.TestCase):
+    """Probing under a different name than the one asked for must be visible."""
+
+    def test_the_substituted_login_is_named_on_stderr(self):
+        m = _load()
+        m.load_roster = lambda: {
+            "stand-only": {"stand": "@s:x", "room": "!r", "same_actor_as": "real-login"},
+            "b": {"stand": "@b:x", "room": "!r"}}
+        m.stand_present_in_room = lambda t: (True, "2 members")
+        m._is_github_user = lambda login: login == "real-login"
+        m.gate_capability = lambda repo, login: (True, "write")
+        m.send_to_stand = lambda *a, **k: type("R", (), {
+            "returncode": 0, "stdout": "ok", "stderr": ""})()
+        m.record_asks = lambda *a, **k: 1
+        buf = io.StringIO()
+        argv = ["nr", "--reviewers", "stand-only,b", "--kind", "ask",
+                "--message", "please review https://github.com/o/r/pull/1"]
+        with patch.object(sys, "argv", argv), contextlib.redirect_stderr(buf), \
+                contextlib.redirect_stdout(io.StringIO()):
+            m.main()
+        err = buf.getvalue()
+        self.assertIn("stand-only: probing GitHub as real-login", err)
+        # Control: the reviewer whose key IS the login gets no such line, so the
+        # assertion above cannot be satisfied by a message printed for everyone.
+        self.assertNotIn("b: probing GitHub as", err)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -590,17 +590,15 @@ class ProbeFailureDefaultsAreDeliberate(unittest.TestCase):
     def test_is_collaborator_defaults_to_TRUE_so_the_wording_stays_milder(self):
         m = _load()
         m.subprocess = self._raising(OSError("boom"))
-        # True keeps gate_capability saying "read", the weaker claim. False would
-        # print "not a collaborator" — asserting an absent relationship on no
-        # evidence, which is the bug 63d18d2c fixed in the other direction.
+        # True keeps the weaker word ("read"); False would assert an absent
+        # relationship on no evidence — the bug 63d18d2c fixed, reversed.
         self.assertIs(m._is_collaborator("o/r", "who"), True)
 
     def test_is_github_user_defaults_to_FALSE_and_that_is_not_a_contradiction(self):
         m = _load()
         m.subprocess = self._raising(OSError("boom"))
-        # Opposite literal, same rule: True here would assert an unprobed key IS
-        # a login. False degrades to "no login found", and the capability probe
-        # then reports unverified rather than refusing.
+        # Opposite literal, same rule: True would assert an unprobed key IS a
+        # login. False degrades to "no login found", then to unverified.
         self.assertIs(m._is_github_user("who"), False)
 
     def test_the_two_defaults_compose_to_send_with_a_caveat_not_to_refuse(self):

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -13,6 +13,7 @@ import importlib.util
 import io
 import json
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -301,6 +302,10 @@ class FailurePaths(unittest.TestCase):
         def fake_run(cmd, *a, **k):
             if "members" in cmd:
                 return type("R", (), {"stdout": ok, "stderr": "", "returncode": 0})()
+            # Capability probe, like `members` above: not a send, so it must not
+            # be counted by a proxy whose subject is send attempts.
+            if any("collaborators" in str(x) for x in cmd):
+                return type("R", (), {"stdout": "write", "stderr": "", "returncode": 0})()
             calls["n"] += 1
             if send_effect and calls["n"] == 1:
                 raise send_effect
@@ -418,6 +423,48 @@ class ResolveDedupesOneActor(unittest.TestCase):
         # "already addressed" and "unreachable" need different follow-ups.
         _, err = self.names("alice", "bob")
         self.assertIn("same person as 'alice'", err)
+
+
+class GateCapabilityFiltersBeforeTheCountGate(unittest.TestCase):
+    """A read-only approval looks identical in the UI and discharges nothing."""
+
+    ROSTER = {"alice": {"stand": "@a:x", "room": "!r"},
+              "bob": {"stand": "@b:x", "room": "!r"}}
+    MSG = "see https://github.com/o/r/pull/7"
+
+    def _run(self, caps, argv_extra=()):
+        m = _load()
+        m.gate_capability = lambda repo, login: caps[login]
+        m.load_roster = lambda: self.ROSTER
+        m.stand_present_in_room = lambda t: (True, "2 members")
+        buf = io.StringIO()
+        argv = ["nr", "--reviewers", "alice,bob", "--kind", "ask",
+                "--message", self.MSG, *argv_extra]
+        with patch.object(sys, "argv", argv), contextlib.redirect_stderr(buf), \
+                contextlib.redirect_stdout(io.StringIO()):
+            rc = m.main()
+        return rc, buf.getvalue()
+
+    def test_a_read_only_reviewer_is_dropped_and_the_count_gate_sees_it(self):
+        rc, err = self._run({"alice": (False, "read"), "bob": (True, "write")},
+                            ("--send",))
+        self.assertIn("CANNOT GATE 'alice'", err)
+        self.assertIn("REFUSED: 1 reviewer(s)", err)   # the gate saw the FILTERED list
+        self.assertNotEqual(rc, 0)
+
+    def test_two_write_tier_reviewers_are_not_filtered(self):
+        # Control: without this the assertions above pass on a filter that
+        # drops everyone.
+        rc, err = self._run({"alice": (True, "write"), "bob": (True, "write")})
+        self.assertNotIn("CANNOT GATE", err)
+        self.assertNotIn("REFUSED", err)
+
+    def test_an_undeterminable_capability_prints_but_does_not_refuse(self):
+        # Refusing on absent would block every reviewer whose tier we cannot read.
+        rc, err = self._run({"alice": (None, "unverified (gh rc=1)"),
+                             "bob": (True, "write")})
+        self.assertIn("gate capability unverified", err)
+        self.assertNotIn("CANNOT GATE", err)
 
 
 if __name__ == "__main__":

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -302,10 +302,13 @@ class FailurePaths(unittest.TestCase):
         def fake_run(cmd, *a, **k):
             if "members" in cmd:
                 return type("R", (), {"stdout": ok, "stderr": "", "returncode": 0})()
-            # Capability probe, like `members` above: not a send, so it must not
-            # be counted by a proxy whose subject is send attempts.
+            # Identity and capability probes, like `members` above: not sends,
+            # so a proxy whose subject is send attempts must not count them.
             if any("collaborators" in str(x) for x in cmd):
                 return type("R", (), {"stdout": "write", "stderr": "", "returncode": 0})()
+            if any(str(x).startswith("users/") for x in cmd):
+                login = next(str(x)[6:] for x in cmd if str(x).startswith("users/"))
+                return type("R", (), {"stdout": login, "stderr": "", "returncode": 0})()
             calls["n"] += 1
             if send_effect and calls["n"] == 1:
                 raise send_effect
@@ -435,6 +438,9 @@ class GateCapabilityFiltersBeforeTheCountGate(unittest.TestCase):
     def _run(self, caps, argv_extra=()):
         m = _load()
         m.gate_capability = lambda repo, login: caps[login]
+        # Stub the identity probe too: a test that needs the network can fail
+        # for a reason it is not about.
+        m._github_login = lambda name, roster: (name, "stubbed")
         m.load_roster = lambda: self.ROSTER
         m.stand_present_in_room = lambda t: (True, "2 members")
         buf = io.StringIO()
@@ -465,6 +471,53 @@ class GateCapabilityFiltersBeforeTheCountGate(unittest.TestCase):
                              "bob": (True, "write")})
         self.assertIn("gate capability unverified", err)
         self.assertNotIn("CANNOT GATE", err)
+
+
+class GateCapabilityProbesAGitHubLogin(unittest.TestCase):
+    """A roster key is not always a login; probing one that is not is a no-op."""
+
+    ROSTER = {"stand-only": {"stand": "@s:x", "room": "!r",
+                             "same_actor_as": "real-login"},
+              "real-login": {"stand": "@r:x", "room": "!r",
+                             "same_actor_as": "stand-only"},
+              "plain": {"stand": "@p:x", "room": "!r"}}
+
+    def _resolve(self, name, users):
+        m = _load()
+        m._is_github_user = lambda login: login in users
+        return m._github_login(name, self.ROSTER)
+
+    def test_a_stand_only_key_resolves_through_same_actor_as(self):
+        login, why = self._resolve("stand-only", {"real-login"})
+        self.assertEqual(login, "real-login")
+        self.assertIn("same_actor_as", why)
+
+    def test_a_key_that_is_a_login_is_used_directly(self):
+        # Control: without this the mapping could rewrite every name.
+        login, why = self._resolve("plain", {"plain"})
+        self.assertEqual(login, "plain")
+        self.assertNotIn("same_actor_as", why)
+
+    def test_no_login_anywhere_returns_the_key_and_says_so(self):
+        login, why = self._resolve("stand-only", set())
+        self.assertEqual(login, "stand-only")
+        self.assertIn("no login found", why)
+
+
+class GateCapabilitySkipIsAnnounced(unittest.TestCase):
+    """The one case the tool cannot check must not be the one it is silent about."""
+
+    def test_a_message_without_a_pr_url_says_the_check_was_skipped(self):
+        m = _load()
+        m.load_roster = lambda: {"a": {"stand": "@a:x", "room": "!r"},
+                                 "b": {"stand": "@b:x", "room": "!r"}}
+        m.stand_present_in_room = lambda t: (True, "2 members")
+        buf = io.StringIO()
+        argv = ["nr", "--reviewers", "a,b", "--kind", "ask", "--message", "no url"]
+        with patch.object(sys, "argv", argv), contextlib.redirect_stderr(buf), \
+                contextlib.redirect_stdout(io.StringIO()):
+            m.main()
+        self.assertIn("gate capability NOT CHECKED", buf.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

An approval from a **read-only collaborator is indistinguishable in the GitHub UI** from one that discharges the merge gate. `notify_reviewers.py` had five refusal grounds — UNKNOWN, HUMAN-ONLY, OFF-ALLOWLIST, NOT REACHABLE, DUPLICATE — and none asked whether the reviewer can actually approve.

I hit this live: I widened a review ask to `marklysze`, whose approval could not have counted. My own roster carries `marklysze gates_sonichi_sutando = False`, and my command **printed that field immediately above the send**.

## Before / after — the exact case, dry run

```
BEFORE   PLAN: ... mention @mark-vm-sutando.agent ...
         PLAN: ... mention @johnm-desktop.agent ...

AFTER    CANNOT GATE 'marklysze': read-only on sonichi/sutando — an approval
           from this account does not count toward the required approvals
         PLAN: ... mention @johnm-desktop.agent ...
```

Verified permissions: `marklysze` read; `jsun-m`, `bassilkhilo-ag2`, `liususan091219`, `qingyun-wu`, `john-the-dev` write.

## Two design choices worth arguing with

**Asked of GitHub, not of the roster.** The roster has a `gates_*` field, and using it would have been one line. A cached tier goes stale silently, and this failure is silent by construction — the wrong answer looks exactly like the right one. The repo comes from the PR URL the message already contains.

**Placed BEFORE the two-reviewer count gate,** so the count sees the filtered list. My first version put it after; the filter ran, dropped a reviewer, and the gate had already passed on the unfiltered count — the same defect this PR is about, one layer up. Verified by mutation:

```
one of two filtered -> rc=7
  CANNOT GATE 'qingyun-wu': read-only on sonichi/sutando
  REFUSED: 1 reviewer(s) resolved ... the rule is at least TWO
```

## Undeterminable is printed, not refused

Refusing on absent capability would block every reviewer whose tier cannot be read — a worse failure than the one being fixed. So absence prints and proceeds. That is the weaker half and I would rather name it than claim the case is closed: it puts the discriminator on screen and still relies on someone reading it, which is precisely the failure that produced this PR.

## Tests

Three new cases in `tests/sci-notify-reviewers-inproc.test.py`: a read-only reviewer is dropped *and the count gate sees it*; two write-tier reviewers are **not** filtered (control — without it the first assertion passes on a filter that drops everyone); an undeterminable capability prints without refusing.

```
with fix       Ran 44 tests   OK
source reverted Ran 44 tests   FAILED (failures=2)
restored        OK
```

All five notify-reviewers suites pass. `scripts/review-checks.sh --diff <full PR diff>` PASS.

## One test-harness change, and why it is not an accommodation

`FailurePaths._run` counted *every* `subprocess.run` as a send attempt. It already excluded the `members` probe for exactly that reason; the capability probe needed the same exclusion. Without it three existing tests fail with `4 != 2` — the proxy's subject drifted from what its assertions claim.

## Credit

Found by **Mark's Sutando**, who checked the collaborator-permission API rather than the roster. **@qingyun-air.agent** independently applied the diagnosis to their own notifier and reported the sharper distinction: mine was *rendered but not consumed* (one edit from working), theirs was *never collected* (no near-miss to notice).
