### PR TITLE
fix(bench): --quick ran a 2,000-item archive scale, which is 60% of the smoke test

### DIFF
--- a/scripts/bench_claim_backends.py
+++ b/scripts/bench_claim_backends.py
@@ -337,7 +337,7 @@ def main(argv=None) -> int:
               f"{pc['per_item_us']:26.0f}   exactly-once A={pa['exactly_once']} C={pc['exactly_once']}")
     print(f"{'UNKNOWN complete (us/item)':34} {a['unknown_recover']['unknown_us']:26.0f} "
           f"{c['unknown_recover']['unknown_us']:26.0f}")
-    print(f"{'complete @ 2k archive (us/item)':34} "
+    print(f"{f'complete @ {_arch_hist} archive (us/item)':34} "
           f"{a['archive_2k']['complete_us_at_history']:26.0f} "
           f"{c['archive_2k']['complete_us_at_history']:26.0f}")
     for label in ("crash", "conflict"):

--- a/scripts/bench_claim_backends.py
+++ b/scripts/bench_claim_backends.py
@@ -302,11 +302,8 @@ def main(argv=None) -> int:
         for w in proc_counts:
             s[f"procs_{w}"] = bench_procs(kind, proc_items, w, k1)
         s["unknown_recover"] = bench_unknown_recover(kind, 100, k1)
-        # Archive history is a THROUGHPUT measurement, and --quick is the CI smoke
-        # path where no caller asserts archive_*. At 2000 it costs ~4000 claims,
-        # each a locked acquire plus a flushed write (~16ms), which is where the
-        # smoke test spends nearly all of its wall time. Keep the shape, drop the
-        # scale: the same code paths run, the numbers just stop being publishable.
+        # archive_* is a throughput number no caller asserts, and 2000 history is
+        # ~4000 claims at ~16ms each — 60% of the --quick smoke run.
         _arch_hist = 20 if args.quick else 2000
         s["archive_0"] = bench_archive_scale(kind, 0, 50, k1)
         s[f"archive_{_arch_hist}"] = bench_archive_scale(kind, _arch_hist, 50, k1)

--- a/scripts/bench_claim_backends.py
+++ b/scripts/bench_claim_backends.py
@@ -302,8 +302,15 @@ def main(argv=None) -> int:
         for w in proc_counts:
             s[f"procs_{w}"] = bench_procs(kind, proc_items, w, k1)
         s["unknown_recover"] = bench_unknown_recover(kind, 100, k1)
+        # Archive history is a THROUGHPUT measurement, and --quick is the CI smoke
+        # path where no caller asserts archive_*. At 2000 it costs ~4000 claims,
+        # each a locked acquire plus a flushed write (~16ms), which is where the
+        # smoke test spends nearly all of its wall time. Keep the shape, drop the
+        # scale: the same code paths run, the numbers just stop being publishable.
+        _arch_hist = 20 if args.quick else 2000
         s["archive_0"] = bench_archive_scale(kind, 0, 50, k1)
-        s["archive_2k"] = bench_archive_scale(kind, 2000, 50, k1)
+        s[f"archive_{_arch_hist}"] = bench_archive_scale(kind, _arch_hist, 50, k1)
+        s["archive_2k"] = s[f"archive_{_arch_hist}"]
         s["crash"] = bench_crash_injection(kind, k1)
         s["conflict"] = bench_publish_inflight_conflict(kind, k1)
         cpu1 = resource.getrusage(resource.RUSAGE_SELF)


### PR DESCRIPTION
`tests/bench-claim-backends-smoke.test.py` takes **~100s** and has timed out under coverage instrumentation on unrelated PRs — #3356 and #3509 both went red on it today, and neither touches this code.

## Where the time goes

Not the matrix `--quick` selects. One hardcoded number:

```python
s["archive_2k"] = bench_archive_scale(kind, 2000, 50, k1)
```

2000 history × 2 backends ≈ **4,000 claims**. Profile of the unpatched run:

```
89.2s   8 calls    bench_claim_backends.bench_archive_scale
85.6s   4694 calls backend_a.claim
80.3s   4696 calls outbox._acquire_locked
75.1s   4720 calls TextIOWrapper.flush      <-- ~16ms per claim
```

Each claim is a locked acquire plus a flushed write, so the claim count *is* the runtime.

## Why it is safe to cut

`archive_*` is a **throughput measurement**. The smoke test asserts only `crash.ok`, `conflict.ok` and `procs_*.exactly_once` — and nothing anywhere asserts `archive_*`:

```
$ grep -rn 'archive_2k\|archive_0' tests/
(no output)
```

So `--quick` paid for numbers no caller reads. This scales the history with `--quick` and keeps the shape — same code paths, and the JSON key stays `archive_2k` for any consumer.

**Non-quick runs are untouched**: `_arch_hist` is 2000 unless `--quick` is passed, so published benchmark numbers keep their scale.

## Before / after — same tree, same machine

```
baseline   99.10s, 101.26s
patched    40.90s            rc=0
```

Correctness output unchanged. Line 1 is the deliberately-mocked `_verdict=False` control printing `FAIL: correctness invariant violated`; **line 40 is `OK — quick matrix in-process, all correctness invariants held`**.

## What I got wrong first, since it is load-bearing for the diagnosis

Two earlier attempts measured **zero** improvement (98.62s, 98.85s against a 99–101s baseline). Both patched `_select_matrix`, on the theory that `--quick`'s matrix drove the cost. It does not — the 2000 never passes through `_select_matrix` at all. The first attempt was also profiled in a checkout 33 commits behind the tree I then measured against, so the 51s it "fixed" was not where that tree spends its time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment after review (head `49658635`)

Three corrections to what is written above. Appending rather than editing in place, since reviewers have already read the original.

**1. The body's grep was scoped to `tests/` (line 27) and that was too narrow.** @TustinOC and @bassilkhilo-ag2 each independently re-ran it across the whole tree, unscoped and without an extension filter, and confirmed no consumer outside the two print lines in the script itself. The conclusion held; the check that established it was theirs, not mine.

**2. "the JSON key stays `archive_2k` for any consumer" was true and misleading, and it hid a real defect.** @john-the-dev found it: the key stayed resolvable while what it *denoted* changed. The print label was a hardcoded literal reading an aliased key, so `--quick` printed a 20-item measurement labeled `2k`:

```
before (191de197):  complete @ 2k archive (us/item)   3544   1586
after  (49658635):  complete @ 20 archive (us/item)   3568   2079
```

JSON keys from that same before-run: `scenarios.a -> ['archive_0', 'archive_20', 'archive_2k']`. Before this branch that line was slow and true; the first version of this branch made it fast and wrong, which is worse — nothing in the output said it had changed. No consumer grep could see it, because the defect was in the meaning of the key rather than in who reads it. Fixed by deriving the label from the same `_arch_hist` that gates the measurement.

**3. "no published figure moves" is right about the figure and wrong about the output.** The non-quick *label text* does change, `complete @ 2k archive` -> `complete @ 2000 archive`. The measurement is untouched, but anything grepping the literal `2k` in this output stops matching. Flagging it here rather than letting the original phrasing imply byte-identical output.

On the scope argument for the fix: I said the assignment and the print are "both inside `main()`", which @john-the-dev correctly pointed out permits a `NameError` — the assignment sits at indent 8 inside a loop, the print at indent 4 after it. What actually guarantees `_arch_hist` is bound is that the loop iterates a literal, `for kind in ("a", "c")` (line 296), so it cannot be empty. A loop over a computed list would have satisfied my weaker claim and still crashed.

Verification at `49658635`: smoke test `rc=0` at **41.00s**, so the speedup survives the fix. The non-quick arm was not run locally (100s+); its label was verified by evaluating both arms of the expression, which speaks to the label only and not to the timing figures.
