### PR TITLE
fix(test): quote the notifier path like tmux does, so a spaced checkout passes

### DIFF
--- a/tests/health-check-codex-task-notifier.test.py
+++ b/tests/health-check-codex-task-notifier.test.py
@@ -105,7 +105,9 @@ class CodexTaskNotifierHealthTests(unittest.TestCase):
         return f"bash {REPO / 'src/agent/codex/cli/task-notifier.sh'}"
 
     def expected_notifier(self) -> str:
-        return f"bash {hc._expected_codex_notifier_entrypoint()}"
+        # Quote like tmux does. An unquoted path splits on its spaces, so this
+        # suite failed on any checkout under e.g. ~/Library/Application Support.
+        return f"bash {shlex.quote(str(hc._expected_codex_notifier_entrypoint()))}"
 
     def test_bare_watcher_can_be_green_while_managed_notifier_is_missing(self):
         self.write_local_core()


### PR DESCRIPTION
## The defect

`tests/health-check-codex-task-notifier.test.py` fails **two tests on any checkout whose path contains a space**, for a reason that has nothing to do with the code under test. On macOS that includes `~/Library/Application Support/...`, which is where the app installs — so a developer working there sees a red suite on a clean tree.

`expected_notifier()` built the command unquoted:

```python
return f"bash {hc._expected_codex_notifier_entrypoint()}"
```

`_command_runs_script` **tokenizes** the command rather than substring-matching it, and that is correct — its own docstring says why (`an unrelated wrapper may mention the expected path in an argument, suffix, or comment without running it`). But tmux shell-quotes `pane_start_command`, so the realistic input is quoted. An unquoted spaced path splits on its spaces and matches nothing.

## Production is NOT affected

This is the part that decides the fix, so I checked it before writing one. With the command tmux actually emits, the production function already handles a spaced path:

```
expected path has spaces: True
  fixture form  (unquoted) -> False
  realistic     (quoted)   -> True
```

So the health check works on a spaced-path install; only the fixture was unrealistic. Test-only change, no production diff.

## Before / after — actual output, same commit, same host, same Python

```
$ pwd
/Users/maxa1v/Library/Application Support/space.ag2.app/workspace/projects/sutando-upstream
$ python3 tests/health-check-codex-task-notifier.test.py
FAIL: test_fix_recreates_missing_session_without_restarting_core
FAIL: test_runtime_authored_socket_and_session_are_honored
Ran 18 tests   FAILED (failures=2)
  AssertionError: 'warn' != 'ok' : managed tmux session 'kewei-core-watcher' runs
  an unexpected command; expected task-notifier-supervisor.sh

$ git archive origin/main | tar -x -C /tmp/nospace-sutando      # same commit, no spaces
$ (cd /tmp/nospace-sutando && python3 tests/health-check-codex-task-notifier.test.py)
Ran 18 tests   OK
```

The space-free copy is the discriminating control: identical code, identical interpreter, only the path differs.

At this branch's HEAD:

```
spaced path (this checkout)   Ran 18 tests   OK
space-free copy of THIS head  Ran 18 tests   OK      <- fix does not over-fire
```

## The fix does not weaken the assertion

The reason `_command_runs_script` tokenizes is to reject a path that merely *appears* in the command. Quoting the fixture must not turn it into a substring match, so:

```
correct quoted command   -> True
a DIFFERENT script       -> False
path only as an ARGUMENT -> False
```

Both negative controls still refuse.

## Notes

- **The same file already quotes at lines 284-287** (`f"bash {shlex.quote(str(expected))}"`). One call site was inconsistent with its own neighbours; `shlex` is already imported at line 12.
- I checked the obvious sibling: `tests/health-check-claude-hook-registration.test.py` also builds `f"bash {r}/..."` unquoted, and it **passes** here — its production side does not tokenize, so it is unaffected. I did not change it.
- Why CI never caught this: the runner checkout is `/home/runner/work/sutando/sutando`, which has no spaces, so `python standalone tests` is green on `main` while the suite is red for a spaced-path developer.

Found while verifying that my own merges today had not regressed `main` — this was the single red in an 88-suite health-check sweep, and it predates those merges (identical failures at `7b54bc35`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
