### PR TITLE
fix(tests): the slack hand-rolled-marker check can never fire

### DIFF
--- a/tests/bridge-marker-no-leak.test.py
+++ b/tests/bridge-marker-no-leak.test.py
@@ -59,7 +59,7 @@ def main() -> int:
         return fail("src/slack-bridge.py must call parse_markers(...) somewhere")
     # Specifically, the result-watcher's skip-detection block must call it,
     # not a hand-rolled startswith trio.
-    if 'startswith("[no-send]")' in sb_src and "parse_markers" not in sb_src:
+    if 'startswith("[no-send]")' in sb_src:
         return fail(
             "src/slack-bridge.py still has hand-rolled startswith — must route "
             "through parse_markers() per #873"


### PR DESCRIPTION
## What it fixes

`tests/bridge-marker-no-leak.test.py` guards each bridge against re-growing a hand-rolled `startswith("[no-send]")` skip check instead of routing through `parse_markers()` (#873, #896). For discord and the gateway bridge that guard is a plain membership test and works. **For slack it is an AND whose second conjunct is false by construction:**

```python
line 58   if "parse_markers(" not in sb_src:            # -> fail
line 62   if 'startswith("[no-send]")' in sb_src and "parse_markers" not in sb_src:
```

Line 58 guarantees `parse_markers(` is present. `parse_markers` is a substring of `parse_markers(`, so by line 62 `"parse_markers" not in sb_src` is **always False**. A slack bridge that calls `parse_markers()` *and also* carries a hand-rolled skip check passes — which is precisely the state the check exists to catch. The only way it can fire is a bridge that abandoned the parser entirely, and line 58 already fails that case.

## Evidence

The harness derives `REPO` from `__file__`, so it can be pointed at a copied tree. Four arms, against a copy of `src/`, `docs/`, `packages/` plus the test (528 files); the injected leak is `body.startswith("[no-send]")` appended to `slack-bridge.py`:

| tree | test | result | |
|---|---|---|---|
| unmutated | original | **PASS** | control — the copy is faithful |
| leak injected | original | **PASS** | ⟵ the bug: guard does not bite |
| leak injected | fixed | **FAIL** | fix bites, with the intended message |
| clean | fixed | **PASS** | no false positive |

Arm 3's output:

```
FAIL: src/slack-bridge.py still has hand-rolled startswith — must route through parse_markers() per #873
```

Real sources pass before and after (`rc=0`); no production file is touched by this PR.

## Why it was invisible

The guard's own failure mode is the one it exists to prevent, one level up: a check that cannot fail reads exactly like a check that passes. It has been green since it was written, and green was never evidence.

## Not fixed here

`telegram-bridge.py` has **no** hand-rolled scan at all — only a `"deduped" in src` presence check — so the identical leak there is unguarded. Different change, different reasoning about what telegram's contract should assert; flagging rather than bundling.

## Credit

Found by running a mutation that @qingyun-air.agent identified as the missing evidence on their own review of this guard's sibling: they had *read* the test but not mutated it, and said so. That distinction is the entire finding — reading it would never have shown this.
