### PR TITLE
fix(health-check): the owner alert DM must not unfurl its own links

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -10488,7 +10488,11 @@ def _default_slack_sender(text: str) -> bool:
         if not opened.get("ok"):
             return False
         channel = opened["channel"]["id"]
-        posted = _slack_api(token, "chat.postMessage", {"channel": channel, "text": text})
+        # Health output carries URLs, and this DM is the owner's alert channel:
+        # a wall of preview cards buries the failure it is reporting.
+        posted = _slack_api(token, "chat.postMessage", {
+            "channel": channel, "text": text,
+            "unfurl_links": False, "unfurl_media": False})
         return bool(posted.get("ok"))
     except Exception:
         return False

--- a/tests/health-check-slack-unfurl.test.py
+++ b/tests/health-check-slack-unfurl.test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""`_default_slack_sender` suppresses link/media unfurling on the owner alert DM.
+
+Health output carries URLs, and this sender DMs the owner arbitrary alert text.
+Slack expands up to 5 previews per message, so a multi-link alert arrives as a
+wall of cards with the failure buried under them.
+
+Raised by @sonichi reviewing #3632, which covered the bridge reply path and
+task-progress but not this sender. Suppression happens AT THE SEND: stripping
+URLs from the body would destroy the links the alert exists to deliver.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+_spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+sys.modules["hc"] = hc
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+
+class OwnerAlertDmDoesNotUnfurl(unittest.TestCase):
+    def _send(self, text="see https://example.com/a and https://example.com/b"):
+        """Drive the real sender with the network stubbed; return the postMessage payload."""
+        calls = []
+
+        def fake_api(token, method, payload):
+            calls.append((method, payload))
+            if method == "conversations.open":
+                return {"ok": True, "channel": {"id": "D123"}}
+            return {"ok": True}
+
+        with mock.patch.object(hc, "_slack_owner_creds", return_value=("xoxb-t", "U1")), \
+             mock.patch.object(hc, "_slack_api", side_effect=fake_api):
+            ok = hc._default_slack_sender(text)
+        post = next(p for m, p in calls if m == "chat.postMessage")
+        return ok, post
+
+    def test_the_owner_alert_dm_suppresses_unfurling(self) -> None:
+        ok, post = self._send()
+        self.assertTrue(ok)
+        self.assertIs(post.get("unfurl_links"), False, post)
+        self.assertIs(post.get("unfurl_media"), False, post)
+
+    def test_the_links_themselves_are_untouched(self) -> None:
+        """Suppression is at the SEND. Stripping URLs would destroy the payload."""
+        body = "see https://example.com/a and https://example.com/b"
+        _, post = self._send(body)
+        self.assertEqual(post["text"], body)
+
+    def test_the_channel_still_comes_from_conversations_open(self) -> None:
+        """CONTROL: the added keys must not disturb the existing contract."""
+        _, post = self._send()
+        self.assertEqual(post["channel"], "D123")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up to #3632, opened because @sonichi's review there named a sender that PR deliberately did not cover.

## The gap

#3632 suppressed unfurling on the bridge reply path and `task-progress`. `_default_slack_sender` in `health-check.py` was left uncovered, and it is the one remaining sender that carries **arbitrary** text:

```python
posted = _slack_api(token, "chat.postMessage", {"channel": channel, "text": text})
```

It DMs the owner health-alert text, and health output carries URLs. Slack expands up to 5 previews per message, so a multi-link alert arrives as a wall of cards with the failure buried under them.

His review checked the other senders before raising this one, and the check is why the scope is this narrow: `slack-bridge.py:914` posts a fixed enrollment-code string and `:734` a fixed not-allowlisted ack, so neither can carry a link. Those stay as they are.

*(Locating note: he cited `health-check.py:10382`; on current `main` the call is at **10491**.)*

## The change

```python
+        # Health output carries URLs, and this DM is the owner's alert channel:
+        # a wall of preview cards buries the failure it is reporting.
         posted = _slack_api(token, "chat.postMessage", {
             "channel": channel, "text": text,
             "unfurl_links": False, "unfurl_media": False})
```

Suppression happens **at the send**, never by stripping URLs from the body. The links are what the alert exists to deliver; a "fix" that removed them would destroy the payload. That framing is #3632's and it applies unchanged here.

## Before / after

The new test drives the real `_default_slack_sender` with the network stubbed, and asserts on the actual `chat.postMessage` payload rather than on source text.

**At the parent commit** (source reverted, tests kept):

```
AssertionError: None is not False : {'channel': 'D123', 'text': 'see https://example.com/a and https://example.com/b'}
FAILED (failures=1)
```

**At HEAD:**

```
test_the_owner_alert_dm_suppresses_unfurling ... ok
test_the_links_themselves_are_untouched ... ok
test_the_channel_still_comes_from_conversations_open ... ok
Ran 3 tests ... OK
```

Wider set, since this file reaches a long way: **90/90** across `tests/health-check*`.

The three tests are deliberately different assertions rather than three phrasings of one: the payload carries the flags; the body is byte-identical (suppression is not stripping); and the channel still comes from `conversations.open`, which is the control that the two added keys did not disturb the existing contract.

## Worst-case disruption

Two keys added to one API payload. `unfurl_links`/`unfurl_media` are standard `chat.postMessage` arguments, so no behaviour changes except that this DM stops rendering previews. No state, no migration, no config, and no other call site touched.

## Live-path note

This is a real delivery path, so per REVIEW.md it deserves a live witness rather than harness green. I do not have one for **this** sender yet: it fires only on a health failure reaching the owner-DM alert path, which has not occurred since the change. I would rather say that than imply coverage.

What I can offer is the matched evidence from #3632, where the identical mechanism is observable in production traffic across a bridge restart: same daily job, consecutive mornings, `attachments=5` before and `attachments=0` after, against a 1000-message control showing 17 messages in that channel did historically unfurl. Same API, same two keys, different sender.
