### PR TITLE
fix(morning-briefing): make weather temperature unit configurable

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -82,12 +82,17 @@ def get_weather() -> str:
             lat = float(_lat_cfg)
             lon = float(_lon_cfg)
 
+        unit = (config_get("WEATHER_UNIT", "fahrenheit") or "fahrenheit").strip().lower()
+        if unit not in ("fahrenheit", "celsius"):
+            unit = "fahrenheit"
+        unit_symbol = "°F" if unit == "fahrenheit" else "°C"
+
         url = (
             f"https://api.open-meteo.com/v1/forecast"
             f"?latitude={lat}&longitude={lon}"
             f"&current=temperature_2m,weather_code"
             f"&daily=temperature_2m_max,temperature_2m_min,precipitation_probability_max"
-            f"&timezone=auto&forecast_days=1&temperature_unit=fahrenheit"
+            f"&timezone=auto&forecast_days=1&temperature_unit={unit}"
         )
         with urlopen(url, timeout=8) as resp:
             d = json.loads(resp.read())
@@ -102,7 +107,7 @@ def get_weather() -> str:
         rain_note = f", {rain}% chance of rain" if rain >= 30 else ""
         # Spoken aloud, so the label stays short and the remedy goes to the log.
         where = "" if configured else " in San Francisco (default location)"
-        return f"{temp}°F and {desc}{where}, high of {high}, low of {low}{rain_note}"
+        return f"{temp}{unit_symbol} and {desc}{where}, high of {high}, low of {low}{rain_note}"
     except (URLError, KeyError, ValueError, OSError):
         return None
 

--- a/tests/morning-briefing-weather-location.test.py
+++ b/tests/morning-briefing-weather-location.test.py
@@ -65,7 +65,7 @@ class TestWeatherLocation(unittest.TestCase):
 
     def _weather(self, env):
         clean = {k: v for k, v in os.environ.items()
-                 if k not in ("WEATHER_LAT", "WEATHER_LON")}
+                 if k not in ("WEATHER_LAT", "WEATHER_LON", "WEATHER_UNIT")}
         clean.update(env)
         with patch.dict(os.environ, clean, clear=True):
             return self.mod.get_weather()
@@ -109,6 +109,54 @@ class TestWeatherLocation(unittest.TestCase):
             self._weather({}),
             self._weather({"WEATHER_LAT": "33.45", "WEATHER_LON": "-112.07"}),
         )
+
+
+class TestWeatherUnit(unittest.TestCase):
+    """WEATHER_UNIT was previously not configurable: temperature_unit was a
+    fahrenheit literal in the Open-Meteo query, so any owner outside a
+    Fahrenheit-reporting country saw the wrong scale even after WEATHER_LAT/
+    WEATHER_LON were set correctly for their own location."""
+
+    def setUp(self):
+        self.mod = _load()
+        self.captured = {}
+
+        def _fake_urlopen(url, *a, **k):
+            self.captured["url"] = url
+            return _Resp()
+
+        patcher = patch.object(self.mod, "urlopen", _fake_urlopen)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _weather(self, env):
+        clean = {k: v for k, v in os.environ.items()
+                 if k not in ("WEATHER_LAT", "WEATHER_LON", "WEATHER_UNIT")}
+        clean.update(env)
+        with patch.dict(os.environ, clean, clear=True):
+            return self.mod.get_weather()
+
+    def test_default_stays_fahrenheit(self):
+        """Unset WEATHER_UNIT must not change behavior for existing installs."""
+        w = self._weather({})
+        self.assertIn("temperature_unit=fahrenheit", self.captured["url"])
+        self.assertIn("°F", w)
+
+    def test_celsius_changes_query_and_symbol(self):
+        w = self._weather({"WEATHER_UNIT": "celsius"})
+        self.assertIn("temperature_unit=celsius", self.captured["url"])
+        self.assertIn("°C", w)
+        self.assertNotIn("°F", w)
+
+    def test_unit_is_case_insensitive(self):
+        w = self._weather({"WEATHER_UNIT": "Celsius"})
+        self.assertIn("temperature_unit=celsius", self.captured["url"])
+        self.assertIn("°C", w)
+
+    def test_unrecognized_unit_falls_back_to_fahrenheit(self):
+        w = self._weather({"WEATHER_UNIT": "kelvin"})
+        self.assertIn("temperature_unit=fahrenheit", self.captured["url"])
+        self.assertIn("°F", w)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `get_weather()` in `src/morning-briefing.py` hardcoded `temperature_unit=fahrenheit` in the Open-Meteo query, so an owner who set `WEATHER_LAT`/`WEATHER_LON` for a non-US location still got Fahrenheit readings.
- Adds `WEATHER_UNIT` (read via `sutando_config.config_get`, same pattern as the existing `WEATHER_LAT`/`WEATHER_LON`): defaults to `fahrenheit` (no behavior change for existing installs), accepts `celsius`, falls back to `fahrenheit` on any other value.

## Before/after evidence
Ran the new `TestWeatherUnit` cases (which set `WEATHER_UNIT=celsius` and assert the outgoing query + rendered string) against the parent commit in an isolated worktree, then against this branch:

Parent commit (`36d88471`):
```
FAIL: test_celsius_changes_query_and_symbol
AssertionError: 'temperature_unit=celsius' not found in '...temperature_unit=fahrenheit'
FAIL: test_unit_is_case_insensitive
AssertionError: 'temperature_unit=celsius' not found in '...temperature_unit=fahrenheit'
Ran 4 tests in 0.655s
FAILED (failures=2)
```

This branch:
```
Ran 9 tests in 1.177s
OK
```
(`tests/morning-briefing-weather-location.test.py`, full file, no network — `urlopen` is mocked as in the existing tests in this file.)

`ruff check src/morning-briefing.py tests/morning-briefing-weather-location.test.py` → `All checks passed!`

## Test plan
- [x] `python3 tests/morning-briefing-weather-location.test.py -v` — 9/9 pass on this branch
- [x] Same file's new `TestWeatherUnit` class fails against the parent commit (proves the tests exercise the fixed behavior, not a tautology)
- [x] `ruff check` clean on both changed files
- [ ] Live round trip (owner's own install already set `WEATHER_LAT`/`WEATHER_LON` for Sydney via `sutando.config.local.json`'s `env` stanza; can additionally set `WEATHER_UNIT: "celsius"` there once this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)