### PR TITLE
fix(health-check): a task file vanishing mid-scan aborts the whole run

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6625,6 +6625,23 @@ def apply_skill_symlink_fixes(checks: list, stream=None) -> None:
             c.update(fresh)
 
 
+def _oldest_pending(files: "list[Path]") -> "tuple[Path, float] | None":
+    """(oldest file, its mtime), skipping entries that vanish mid-scan.
+
+    A claim renames the file, so any entry can be gone between the listing and
+    the stat; one unguarded stat() aborts the whole health run.
+    """
+    pairs = []
+    for f in files:
+        try:
+            pairs.append((f, f.stat().st_mtime))
+        except OSError:
+            continue
+    if not pairs:
+        return None
+    return min(pairs, key=lambda t: t[1])
+
+
 def _pending_task_files(tasks_dir: Path, results_dir: Optional[Path] = None) -> list[Path]:
     """Top-level task files that have not produced or archived a result."""
     if results_dir is None:
@@ -6842,7 +6859,8 @@ def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300,
     if pooled and not files:
         stuck = _pool_held_stuck(pooled, now, stuck_age_sec)
         if stuck:
-            oldest_h = int(now - min(f.stat().st_mtime for f in stuck)) // 3600
+            _st = _oldest_pending(stuck)
+            oldest_h = int(now - _st[1]) // 3600 if _st else 0
             return {"name": name, "status": "warn",
                     "detail": f"{len(stuck)} of {len(pooled)} pool-held task(s) have not moved "
                               f"in over {stuck_age_sec // 60} min (oldest {oldest_h}h): "
@@ -6854,8 +6872,11 @@ def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300,
     holdings = _worker_holdings()
     inflight = sum(1 for f in files if f.name in holdings)
     held_note = f", {inflight} in flight with a worker" if inflight else ""
-    oldest = min(files, key=lambda p: p.stat().st_mtime)
-    oldest_age = int(now - oldest.stat().st_mtime)
+    _oldest = _oldest_pending(files)
+    if _oldest is None:
+        return {"name": name, "status": "ok",
+                "detail": "queue drained while scanning"}
+    oldest_age = int(now - _oldest[1])
     # Deadline vs the WORKER's runtime, never the file's age: a task can queue
     # for hours before a worker claims it, and claiming does not touch the file.
     all_held = inflight == len(files)
@@ -10758,11 +10779,10 @@ def _oldest_pending_task(now: float, tasks_dir: Optional[Path] = None) -> "tuple
     files = _pending_task_files(tasks_dir)
     if not files:
         return None
-    try:
-        oldest = min(files, key=lambda p: p.stat().st_mtime)
-        mtime = oldest.stat().st_mtime
-    except OSError:
+    got = _oldest_pending(files)
+    if got is None:
         return None
+    oldest, mtime = got
     return (f"{oldest.name}|{int(mtime)}", int(now - mtime))
 
 

--- a/tests/health-check-task-queue-vanish.test.py
+++ b/tests/health-check-task-queue-vanish.test.py
@@ -8,6 +8,7 @@ probe is called unwrapped, so one unguarded stat() takes down every later check.
 import importlib.util
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -73,6 +74,47 @@ class VanishingTaskFile(unittest.TestCase):
         self.assertIsInstance(res, dict)
         self.assertEqual(res["name"], "task-queue")
         self.assertIn(res["status"], ("ok", "warn", "error"))
+
+
+class OldestPendingTaskIdentity(unittest.TestCase):
+    """The restart-gate identity reads the same oldest-file policy, so it must
+    survive a vanished entry too rather than raising into its caller."""
+
+    def setUp(self):
+        self.mod = _load()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name)
+        (self.ws / "tasks").mkdir()
+        (self.ws / "results").mkdir()
+        self.real = self.ws / "tasks" / "task-1788000000000.txt"
+        self.real.write_text("id: task-1788000000000\ntask: real\n")
+        self.gone = self.ws / "tasks" / "task-1788000000001.txt"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, listed):
+        with patch.object(self.mod, "WORKSPACE_DIR", self.ws), \
+             patch.object(self.mod, "_pending_task_files", return_value=listed):
+            return self.mod._oldest_pending_task(time.time(), self.ws / "tasks")
+
+    def test_identity_is_returned_for_a_present_file(self):
+        got = self._run([self.real])
+        self.assertIsNotNone(got)
+        ident, age = got
+        self.assertTrue(ident.startswith(self.real.name + "|"))
+        self.assertGreaterEqual(age, 0)
+
+    def test_a_vanished_entry_does_not_raise(self):
+        got = self._run([self.real, self.gone])
+        self.assertIsNotNone(got)
+        self.assertTrue(got[0].startswith(self.real.name + "|"))
+
+    def test_all_entries_vanished_yields_no_identity(self):
+        self.assertIsNone(self._run([self.gone]))
+
+    def test_an_empty_listing_yields_no_identity(self):
+        self.assertIsNone(self._run([]))
 
 
 if __name__ == "__main__":

--- a/tests/health-check-task-queue-vanish.test.py
+++ b/tests/health-check-task-queue-vanish.test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""A task file that vanishes mid-scan must not abort the whole health run.
+
+A claim RENAMES the task file, so between `_pending_task_files()` listing a
+path and the probe stat()ing it, any entry can already be gone. The task-queue
+probe is called unwrapped, so one unguarded stat() takes down every later check.
+"""
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "health-check.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("health_check", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["health_check"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+class VanishingTaskFile(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name)
+        (self.ws / "tasks").mkdir()
+        (self.ws / "results").mkdir()
+        self.real = self.ws / "tasks" / "task-1788000000000.txt"
+        self.real.write_text("id: task-1788000000000\ntask: real\n")
+        # Plain name on purpose: a `.claimed-core-N` name is split to the
+        # pool-held branch before the stat, so it never reaches this defect.
+        self.gone = self.ws / "tasks" / "task-1788000000001.txt"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, listed):
+        with patch.object(self.mod, "WORKSPACE_DIR", self.ws), \
+             patch.object(self.mod, "_pending_task_files", return_value=listed), \
+             patch.object(self.mod, "_worker_holdings", return_value={}):
+            return self.mod.check_task_queue()
+
+    def test_a_vanished_file_does_not_raise(self):
+        """The defect: min(..., key=p.stat().st_mtime) over a gone path raises
+        FileNotFoundError out of the probe and ends the run."""
+        res = self._run([self.real, self.gone])
+        self.assertIsInstance(res, dict)
+        self.assertEqual(res["name"], "task-queue")
+
+    def test_the_surviving_file_still_drives_the_verdict(self):
+        """Skipping the vanished entry must not blind the probe to the rest."""
+        res = self._run([self.real, self.gone])
+        self.assertIn(res["status"], ("ok", "warn", "error"))
+
+    def test_all_entries_vanished_is_reported_not_raised(self):
+        res = self._run([self.gone])
+        self.assertIsInstance(res, dict)
+        self.assertEqual(res["status"], "ok")
+
+    def test_control_no_vanished_entry_behaves_normally(self):
+        """Negative control: with every listed path present, the probe answers
+        exactly as before — the fix must not change the healthy path."""
+        res = self._run([self.real])
+        self.assertIsInstance(res, dict)
+        self.assertEqual(res["name"], "task-queue")
+        self.assertIn(res["status"], ("ok", "warn", "error"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`check_task_queue()` is invoked unwrapped (`health-check.py`, `checks.append(check_task_queue(...))`), so an exception out of it **ends the entire health run** — every later probe simply never executes.

A claim RENAMES the task file. Between `_pending_task_files()` listing a path and the probe `stat()`ing it, any entry can already be gone.

**This is not hypothetical — it happened on a live host while running the routine health check:**

```
  File "src/health-check.py", line 6324, in check_task_queue
    oldest = min(files, key=lambda p: p.stat().st_mtime)
                                      ~~~~~~^^
FileNotFoundError: [Errno 2] No such file or directory:
  '.../workspace/tasks/task-workstream-grouping-1788309783129.claimed-core-3.txt'
```

No summary line was printed: the run died there. On that host task files are being created at roughly one per two minutes, so the window is hit routinely rather than rarely.

## Why a helper instead of a third `try/except`

The same expression exists three times, with **two different policies**:

| site | before |
|---|---|
| `check_task_queue` — pool-held stuck branch | unguarded |
| `check_task_queue` — oldest pending | **unguarded (the crash)** |
| restart-gate identity | `try/except OSError` |

The guarded copy is the one somebody already hit. Copying its `try/except` a third time keeps three copies of one policy, so this gives it a single owner — `_oldest_pending()` — and points all three at it.

It also removes a second latent bug at the crash site: the old code called `stat()` **twice** (once inside `min`'s key, once for `oldest_age`), so the age could be computed from a different mtime than the one that chose the file. The helper stats once and returns the pair.

## Evidence — before and after

`tests/health-check-task-queue-vanish.test.py`, same test, both heads:

```
at origin/main (55adfc21, unfixed):   Ran 4 tests ... FAILED (errors=3)   rc=1
  FileNotFoundError: .../tasks/task-1788000000001.txt      <- the production errno
at HEAD (87bd7e7f, fixed):            Ran 4 tests ... OK                  rc=0
```

The 4th case is a **negative control** — every listed path present — and it passes at *both* heads, so the healthy path is unchanged.

**A note on the fixture, because it is the reason this test is real.** My first version named the vanished file `task-...claimed-core-3.txt` and passed at the unfixed parent too — `_split_pool_held()` routes a pool-held name to the pool branch *before* the stat, so it never reached the defect. A plain `task-*.txt` name is what exercises it. `_pool_held_stuck()` already guards its own stat, so the pool-held branch is the narrower of the two.

## Suites

All 91 `tests/health-check-*.test.py` plus `core-health-verdict.test.py` pass at HEAD: **91 PASS / 0 FAIL**.

`scripts/review-checks.sh --diff` on the cumulative diff: **PASS** (hardcoded-paths + root-artifacts + prose-cap clean).

## Scope

Two files, +107/−7. No behavior change on any path where the files exist.
