### PR TITLE
fix(agent-api): a task claimed mid-scan 500s the /tasks/active endpoint

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -340,30 +340,56 @@ def get_status() -> dict:
     }
 
 
+def _read_or_none(path) -> "str | None":
+    """Stripped file text, or None when it is absent — one call, no exists()
+    race between the check and the read."""
+    try:
+        return path.read_text().strip()
+    except FileNotFoundError:
+        return None
+
+
+def _newest_first(paths) -> list:
+    """Paths sorted newest-first, skipping any that vanish during the scan.
+
+    A claim renames a task file, so any glob entry can be gone before its stat.
+    """
+    pairs = []
+    for p in paths:
+        try:
+            pairs.append((p.stat().st_mtime, p))
+        except OSError:
+            continue
+    pairs.sort(key=lambda t: t[0], reverse=True)
+    return [p for _, p in pairs]
+
+
 def _active_task_rows() -> list[dict]:
     """Reconcile task/result files into the ten most recent history rows."""
     # Classifier tasks are machinery, not user work, so they stay out of the
     # history the UI shows.
-    for task_file in sorted(
-        (
-            path
-            for path in TASK_DIR.glob("*.txt")
-            if not path.stem.startswith(
-                (
-                    task_workstreams.CLASSIFIER_TASK_PREFIX,
-                    task_workstreams.LEGACY_CLASSIFIER_TASK_PREFIX,
-                )
+    for task_file in _newest_first(
+        path
+        for path in TASK_DIR.glob("*.txt")
+        if not path.stem.startswith(
+            (
+                task_workstreams.CLASSIFIER_TASK_PREFIX,
+                task_workstreams.LEGACY_CLASSIFIER_TASK_PREFIX,
             )
-        ),
-        key=lambda path: path.stat().st_mtime,
-        reverse=True,
+        )
     )[:10]:
         # A CLAIMED task is task-{id}.claimed-core-N.txt, but every writer puts
         # the reply at results/{id}.txt — so key AND look up by the canonical id.
         task_id = task_id_from_filename(task_file.name)
         if task_id is None:
             continue
-        content = task_file.read_text()
+        try:
+            content = task_file.read_text()
+            task_mtime = task_file.stat().st_mtime
+        except FileNotFoundError:
+            # Claimed and renamed between the glob and here; the row reappears
+            # under the claimed name on the next poll.
+            continue
         # First `source:` and `task:` regardless of field order; body
         # lookalikes must not override the real headers.
         task_line, source_line = _task_display_fields(content)
@@ -377,32 +403,28 @@ def _active_task_rows() -> list[dict]:
             if candidate.exists():
                 archived_file = candidate
                 break
-        if result_file.exists():
+        result_text = _read_or_none(result_file)
+        if result_text is not None:
             status = "done"
-            result_text = result_file.read_text().strip()
         elif existing.get("status") == "done" or existing.get("result"):
             status = "done"
             result_text = existing.get("result", "")
-        elif archived_file is not None:
+        elif archived_file is not None and (_archived := _read_or_none(archived_file)) is not None:
             status = "done"
-            result_text = archived_file.read_text().strip()
+            result_text = _archived
         else:
             status = "working"
             result_text = ""
         task_history[task_id] = {
             "status": status,
             "text": task_line or existing.get("text", task_id),
-            "time": task_file.stat().st_mtime,
+            "time": task_mtime,
             "result": result_text,
             "source": source_line or existing.get("source", ""),
         }
 
     # Results may outlive their task files after bridge cleanup.
-    for result_file in sorted(
-        RESULT_DIR.glob("task-*.txt"),
-        key=lambda path: path.stat().st_mtime,
-        reverse=True,
-    )[:10]:
+    for result_file in _newest_first(RESULT_DIR.glob("task-*.txt"))[:10]:
         _remember_done_result_file(result_file)
 
     # Reconcile stale rows after the disk scans above.

--- a/tests/agent-api-active-rows-vanish.test.py
+++ b/tests/agent-api-active-rows-vanish.test.py
@@ -80,6 +80,30 @@ class VanishingTaskFile(unittest.TestCase):
         self.assertIsInstance(rows, list)
         self.assertIn("task-1788000000000", hist)
 
+    def test_a_file_claimed_between_the_sort_and_the_read(self):
+        """The PRODUCTION traceback's window, which the ghost case does not reach.
+
+        The ghost is dropped by the mtime sort before the loop body runs. The
+        observed crash was a file that survived the sort and was renamed away
+        before read_text().
+        """
+        real_read = Path.read_text
+
+        def vanishing_read(self_path, *a, **k):
+            if self_path == self.real:
+                raise FileNotFoundError(2, "No such file or directory", str(self_path))
+            return real_read(self_path, *a, **k)
+
+        with patch.object(self.mod, "TASK_DIR", self.tasks), \
+             patch.object(self.mod, "RESULT_DIR", self.results), \
+             patch.dict(self.mod.task_history, {}, clear=True), \
+             patch.object(Path, "read_text", vanishing_read):
+            rows = self.mod._active_task_rows()
+            hist = dict(self.mod.task_history)
+        self.assertIsInstance(rows, list)
+        self.assertNotIn("task-1788000000000", hist)
+
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/agent-api-active-rows-vanish.test.py
+++ b/tests/agent-api-active-rows-vanish.test.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""A task file claimed mid-scan must not 500 the /tasks/active endpoint.
+
+A claim RENAMES `task-{id}.txt` to `task-{id}.claimed-core-N.txt`. Between
+`TASK_DIR.glob` listing the old name and `_active_task_rows` reading it, the
+path is gone; the exception escapes `do_GET` and the client sees the connection
+closed with no response.
+"""
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "agent-api.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("agent_api", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["agent_api"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+class VanishingTaskFile(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+        self.tmp = tempfile.TemporaryDirectory()
+        ws = Path(self.tmp.name)
+        self.tasks = ws / "tasks"
+        self.results = ws / "results"
+        self.tasks.mkdir()
+        self.results.mkdir()
+        (self.results / "archive").mkdir()
+        self.real = self.tasks / "task-1788000000000.txt"
+        self.real.write_text("id: task-1788000000000\ntask: real one\nsource: chat\n")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _rows(self, ghost=False):
+        """Returns (rows, snapshot of task_history taken INSIDE the patches).
+
+        The snapshot matters: patch.dict restores on exit, so asserting after
+        the with-block inspects the original empty dict, not the run's result.
+        """
+        real_glob = Path.glob
+
+        def fake_glob(self_path, pattern):
+            yield from real_glob(self_path, pattern)
+            if ghost and self_path == self.tasks:
+                yield self.tasks / "task-1788000000001.claimed-core-1.txt"
+
+        with patch.object(self.mod, "TASK_DIR", self.tasks), \
+             patch.object(self.mod, "RESULT_DIR", self.results), \
+             patch.dict(self.mod.task_history, {}, clear=True), \
+             patch.object(Path, "glob", fake_glob):
+            rows = self.mod._active_task_rows()
+            return rows, dict(self.mod.task_history)
+
+    def test_a_claimed_away_file_does_not_raise(self):
+        """The defect: read_text() on the renamed-away path escapes do_GET."""
+        rows, _ = self._rows(ghost=True)
+        self.assertIsInstance(rows, list)
+
+    def test_the_surviving_task_still_appears(self):
+        """Skipping the ghost must not drop the real row."""
+        _, hist = self._rows(ghost=True)
+        self.assertIn("task-1788000000000", hist)
+
+    def test_control_no_ghost_behaves_normally(self):
+        """Negative control: with every listed path present, unchanged."""
+        rows, hist = self._rows(ghost=False)
+        self.assertIsInstance(rows, list)
+        self.assertIn("task-1788000000000", hist)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Observed live on a running service, not inferred

A claim **renames** `task-{id}.txt` to `task-{id}.claimed-core-N.txt`. Between `TASK_DIR.glob` listing the old name and `_active_task_rows` reading it, the path is gone. The `FileNotFoundError` escapes `do_GET`, so the client sees the connection closed with no response.

From the running service's own log:

```
  File "src/agent-api.py", line 825, in do_GET
    self.send_json(200, _active_tasks_payload(watcher_ok, claude_ok))
  File "src/agent-api.py", line 432, in _active_tasks_payload
    "tasks": _active_task_rows(),
  File "src/agent-api.py", line 350, in _active_task_rows
    content = task_file.read_text()
FileNotFoundError: [Errno 2] No such file or directory:
  '.../workspace/tasks/task-d1695315e1ae1aa6e8.claimed-core-1.txt'
```

**Measured rate.** 300 requests to `/tasks/active` over 105 s against the live instance:

```
ok=299   failed=1   (RemoteDisconnected: Remote end closed connection without response)
```

That is not a 0.3% dice roll — exactly **one** task was created in that window, and it took exactly one request with it. *Any poll overlapping a claim fails*; every other poll is untouched. On this host task files arrive about one per two minutes and the dashboard polls this endpoint continuously, so the endpoint fails precisely when tasks are churning — which is when someone is most likely watching it.

## The line that actually fails is not the one you would guess

I came to this function looking for the `stat()` in the sort key, which is the same shape as #3689. **The live traceback names `read_text()` instead.** Patching only the sort would have left the crash exactly as it was. Both are fixed here, but the ordering matters for review: the read is the observed one.

Four windows in `_active_task_rows`, all the same policy — *a path we globbed or checked can be gone by the time we use it*:

| site | before |
|---|---|
| task-dir sort key | `key=lambda path: path.stat().st_mtime` |
| per-task body | `content = task_file.read_text()` ← **observed** |
| result / archive | `if f.exists(): f.read_text()` (TOCTOU) |
| result-dir sort key | `key=lambda path: path.stat().st_mtime` |

`_newest_first` skips entries that vanish during a scan; the per-task body skips a file claimed away between the glob and the read; `_read_or_none` collapses each `exists()`-then-`read_text()` into one call. `"time"` now reuses the mtime read alongside the content instead of taking a second, racier stat that could disagree with it.

## Evidence — before and after

`tests/agent-api-active-rows-vanish.test.py`, same test, both heads:

```
at origin/main (618e19e8, unfixed):  Ran 3 tests ... FAILED (errors=2)  rc=1
  FileNotFoundError: .../tasks/task-1788000000001.claimed-core-1.txt   <- production shape
at HEAD (d3575fad, fixed):           Ran 3 tests ... OK                 rc=0
```

The third case is a **negative control** — no ghost entry, every listed path present — and it passes at *both* heads, so the ordinary path is unchanged.

## Suites

All **17** `tests/agent-api*.test.py` pass at head: **17 PASS / 0 FAIL**. `scripts/review-checks.sh --diff` on the cumulative diff: **PASS**.

## Relationship to #3689

Same failure class, different service, found by following the mechanism rather than by grepping for the symptom — and the earlier PR's shape did not transfer cleanly, which is the note worth keeping. Independent of #3689; neither blocks the other.
