### PR TITLE
test(outbox-race): stop at a phase budget instead of outrunning CI's file cap

### DIFF
--- a/tests/outbox-race.test.py
+++ b/tests/outbox-race.test.py
@@ -3,6 +3,7 @@ import multiprocessing as mp
 import os
 import sys
 import tempfile
+import time
 # CI runs this with no arguments, so the repo root must be derived, not passed.
 REPO = sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO, 'src'))
@@ -31,20 +32,41 @@ def plant_stale_claim(root, item):
         "start_usec": 1, "claimed_at": 0.0,
     }, sort_keys=True), encoding="utf-8")
 
+
+def run_rounds(pool, target, per_phase_s, min_rounds, max_rounds, one_round):
+    """Repeat one_round until max_rounds or the phase budget runs out.
+
+    A broken lock fails on nearly every round, so min_rounds keeps the power;
+    the extra rounds only chase rare interleavings and are the first thing a
+    thrashing 2-core CI runner can no longer afford inside its 120s file cap.
+    """
+    results, t0 = [], time.monotonic()
+    for r in range(max_rounds):
+        if r >= min_rounds and time.monotonic() - t0 > per_phase_s:
+            break
+        results.append(one_round(r))
+    return results
+
 if __name__ == "__main__":
     # Contention is workers-per-core, not an absolute: a fixed 24 is 12x
     # oversubscribed on a 2-core runner, and the thrash is what timed out.
-    N, rounds = max(8, (os.cpu_count() or 2) * 3), 12
+    N = max(8, (os.cpu_count() or 2) * 3)
+    MIN_ROUNDS, MAX_ROUNDS = 3, 12
+    # Well under CI's 120s per-file cap even with both phases at the budget,
+    # so a slow lane finishes early instead of being killed reportless.
+    PHASE_BUDGET_S = float(os.environ.get("OUTBOX_RACE_PHASE_BUDGET_S", "35"))
     totals = []
     # ONE warm pool here too, for the reason phase 2 already states: a fresh pool
     # per round pays process startup inside the window under test.
     with mp.Pool(N) as pool:
-        for r in range(rounds):
+        def acquire_round(r):
             with tempfile.TemporaryDirectory() as tmp:
                 os.makedirs(os.path.join(tmp, ".claims"), exist_ok=True)  # pre-make so mkdir isn't the serializer
                 got = pool.map(worker, [(tmp, f"item-race-{r}", i) for i in range(N)])
-            totals.append(sum(got))
-    print(f"  {rounds} rounds x {N} concurrent PROCESSES racing one item")
+            return sum(got)
+        totals = run_rounds(pool, totals, PHASE_BUDGET_S, MIN_ROUNDS, MAX_ROUNDS, acquire_round)
+    print(f"  {len(totals)} of {MAX_ROUNDS} rounds x {N} concurrent PROCESSES racing one item"
+          + (" (stopped at phase budget)" if len(totals) < MAX_ROUNDS else ""))
     print(f"  winners per round: {totals}")
     bad = [t for t in totals if t != 1]
     print(f"  rounds with != 1 winner: {len(bad)}  {'<-- EXCLUSION BROKEN' if bad else '(exclusion holds)'}")
@@ -54,23 +76,26 @@ if __name__ == "__main__":
 
     # Phase 2 — RECLAIM of a dead owner's claim. Exclusion on acquire says
     # nothing about two drainers acting on one stale observation.
-    rc_totals, orphaned = [], 0
+    orphan_flags = []
     # ONE warm pool for every round. A fresh pool per round pays process startup
     # inside the window under test, which staggers the workers and hides the race.
     with mp.Pool(N) as pool:
-        for r in range(rounds * 2):
+        def reclaim_round(r):
             with tempfile.TemporaryDirectory() as tmp:
                 item = f"item-reclaim-{r}"
                 plant_stale_claim(tmp, item)
                 got = pool.map(reclaim_worker, [(tmp, item, i) for i in range(N)], chunksize=1)
                 winners = [g for g in got if g]
-                rc_totals.append(len(winners))
                 held = read_delivery_claim(tmp, item)
                 # The winner must still hold it: a loser that unlinks unconditionally
                 # destroys the winner's claim and the item is delivered twice.
-                if len(winners) == 1 and (held is None or held.drainer_id != winners[0]):
-                    orphaned += 1
-    print(f"\n  {rounds} rounds x {N} concurrent PROCESSES reclaiming one dead owner's claim")
+                orphan_flags.append(
+                    len(winners) == 1 and (held is None or held.drainer_id != winners[0]))
+                return len(winners)
+        rc_totals = run_rounds(pool, None, PHASE_BUDGET_S, MIN_ROUNDS * 2, MAX_ROUNDS * 2, reclaim_round)
+    orphaned = sum(orphan_flags)
+    print(f"\n  {len(rc_totals)} of {MAX_ROUNDS * 2} rounds x {N} concurrent PROCESSES reclaiming one dead owner's claim"
+          + (" (stopped at phase budget)" if len(rc_totals) < MAX_ROUNDS * 2 else ""))
     print(f"  winners per round: {rc_totals}")
     bad_rc = [t for t in rc_totals if t != 1]
     print(f"  rounds with != 1 winner: {len(bad_rc)}  "

--- a/tests/outbox-race.test.py
+++ b/tests/outbox-race.test.py
@@ -33,12 +33,14 @@ def plant_stale_claim(root, item):
     }, sort_keys=True), encoding="utf-8")
 
 
-def run_rounds(pool, target, per_phase_s, min_rounds, max_rounds, one_round):
+def run_rounds(per_phase_s, min_rounds, max_rounds, one_round):
     """Repeat one_round until max_rounds or the phase budget runs out.
 
     A broken lock fails on nearly every round, so min_rounds keeps the power;
     the extra rounds only chase rare interleavings and are the first thing a
     thrashing 2-core CI runner can no longer afford inside its 120s file cap.
+    The budget gates round STARTS: worst case is min_rounds + one budget's
+    worth of starts, each running to completion.
     """
     results, t0 = [], time.monotonic()
     for r in range(max_rounds):
@@ -52,8 +54,9 @@ if __name__ == "__main__":
     # oversubscribed on a 2-core runner, and the thrash is what timed out.
     N = max(8, (os.cpu_count() or 2) * 3)
     MIN_ROUNDS, MAX_ROUNDS = 3, 12
-    # Well under CI's 120s per-file cap even with both phases at the budget,
-    # so a slow lane finishes early instead of being killed reportless.
+    # The budget bounds round STARTS, and the floor rounds run unconditionally,
+    # so the true worst case is floor + budget + in-flight round durations —
+    # far below the old 36 unconditional rounds, not a hard ceiling.
     PHASE_BUDGET_S = float(os.environ.get("OUTBOX_RACE_PHASE_BUDGET_S", "35"))
     totals = []
     # ONE warm pool here too, for the reason phase 2 already states: a fresh pool
@@ -64,7 +67,7 @@ if __name__ == "__main__":
                 os.makedirs(os.path.join(tmp, ".claims"), exist_ok=True)  # pre-make so mkdir isn't the serializer
                 got = pool.map(worker, [(tmp, f"item-race-{r}", i) for i in range(N)])
             return sum(got)
-        totals = run_rounds(pool, totals, PHASE_BUDGET_S, MIN_ROUNDS, MAX_ROUNDS, acquire_round)
+        totals = run_rounds(PHASE_BUDGET_S, MIN_ROUNDS, MAX_ROUNDS, acquire_round)
     print(f"  {len(totals)} of {MAX_ROUNDS} rounds x {N} concurrent PROCESSES racing one item"
           + (" (stopped at phase budget)" if len(totals) < MAX_ROUNDS else ""))
     print(f"  winners per round: {totals}")
@@ -92,7 +95,7 @@ if __name__ == "__main__":
                 orphan_flags.append(
                     len(winners) == 1 and (held is None or held.drainer_id != winners[0]))
                 return len(winners)
-        rc_totals = run_rounds(pool, None, PHASE_BUDGET_S, MIN_ROUNDS * 2, MAX_ROUNDS * 2, reclaim_round)
+        rc_totals = run_rounds(PHASE_BUDGET_S, MIN_ROUNDS * 2, MAX_ROUNDS * 2, reclaim_round)
     orphaned = sum(orphan_flags)
     print(f"\n  {len(rc_totals)} of {MAX_ROUNDS * 2} rounds x {N} concurrent PROCESSES reclaiming one dead owner's claim"
           + (" (stopped at phase budget)" if len(rc_totals) < MAX_ROUNDS * 2 else ""))

--- a/tests/outbox-race.test.py
+++ b/tests/outbox-race.test.py
@@ -54,9 +54,8 @@ if __name__ == "__main__":
     # oversubscribed on a 2-core runner, and the thrash is what timed out.
     N = max(8, (os.cpu_count() or 2) * 3)
     MIN_ROUNDS, MAX_ROUNDS = 3, 12
-    # The budget bounds round STARTS, and the floor rounds run unconditionally,
-    # so the true worst case is floor + budget + in-flight round durations —
-    # far below the old 36 unconditional rounds, not a hard ceiling.
+    # Bounds round STARTS only: worst case is floor + budget + in-flight
+    # round durations — far below 36 unconditional rounds, not a ceiling.
     PHASE_BUDGET_S = float(os.environ.get("OUTBOX_RACE_PHASE_BUDGET_S", "35"))
     totals = []
     # ONE warm pool here too, for the reason phase 2 already states: a fresh pool


### PR DESCRIPTION
## What

`tests/outbox-race.test.py` timed out CI's per-file `timeout -k 5 120` cap on a 2-core runner (the #3597 red — a file its two-line diff cannot touch), then passed unchanged on re-run. The suite is 1.0s wall on a warm many-core host; the cost is pure lane thrash, and the cap kills it **reportless**.

Per the owner's direction, the fix makes the test **shorter where it is slow** instead of extending any deadline: each phase runs a floor of rounds (3 acquire / 6 reclaim) and continues to the original 12/24 only while a 35s per-phase budget lasts. What was dropped is printed (`N of M rounds (stopped at phase budget)`) — never a silent subset.

## Why the floor keeps the power

A broken lock fails on essentially every round — the extra rounds only chase rare interleavings. Mutation control at the floor budget:

## Evidence

At `5b5cacff`, fast host (all rounds still run — no behavior change where time is cheap):

```
  12 of 12 rounds x 30 concurrent PROCESSES racing one item
  24 of 24 rounds x 30 concurrent PROCESSES reclaiming one dead owner's claim
PASS — delivery-claim exclusion holds under real concurrency, on acquire AND reclaim
real 1.08
```

Starved budget (`OUTBOX_RACE_PHASE_BUDGET_S=0.01` — the CI-thrash regime), floor holds:

```
  3 of 12 rounds x 30 concurrent PROCESSES racing one item (stopped at phase budget)
  6 of 24 rounds x 30 concurrent PROCESSES reclaiming one dead owner's claim (stopped at phase budget)
PASS
```

Failure mode still caught at the floor — `acquire_delivery_claim` mutated to always-win:

```
  rounds with != 1 winner: 3  <-- EXCLUSION BROKEN
FAILED — more than one drainer acquired the same item
mutated exit=1
clean exit=0
```

## Scope

One file, test-only. No production code, no CI workflow change, no prompt change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
