### PR TITLE
docs: tell authors to run review-checks before pushing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,23 @@ The goal of this phase is to confirm the PR is necessary at all. In rough order 
 3. For a bug-fix: is the bug still on `upstream/main`? (`git show upstream/main:path | grep buggy-line`) — don't fix something that's already gone.
 4. Is this a single concern? **One bug or one feature per PR.** If you're tempted to bundle several features into one PR ("while I'm here I'll also add Y, Z"), split them up front — open one PR per concern, each with its own closes-link. Mixing concerns triples the review burden, increases revert blast radius, and slows merge. "Drive-by" cleanup that happens to land in the same hunk is fine; net-new scope is not.
 
+5. **Run the repo's own scanner before you push**, not after CI tells you:
+
+   ```bash
+   git commit ...                                              # it reads COMMITS, not your worktree
+   bash scripts/review-checks.sh --diff <(git diff origin/main...HEAD)
+   ```
+
+   It runs the machine-readable `checks:` block in [`REVIEW.md`](REVIEW.md) — the same one CI runs — so a red result here is a red result there.
+
+   Three things that make it report something other than what you expect, each measured:
+
+   - **Commit first.** Against an uncommitted or merely staged worktree the three-dot range is empty and you get `ERROR — empty diff; nothing was scanned, so this is NOT a pass`. It fails loudly rather than passing, but it is easy to read as "clean".
+   - **Three dots, not two.** `origin/main..HEAD` renders `main`'s own newer commits as your removals.
+   - **`PARTIAL` is not `PASS`.** With no `.py` in the diff it prints `prose-cap had no in-scope files`; from a `gh pr diff` file with no tree to read it prints `prose-cap SKIPPED`. Neither one scanned any prose.
+
+   Worth the second it costs because these findings are mechanical and invisible while writing. `prose-cap` counts **consecutive added comment lines**, so a trailing comment on a code line folds into the block beneath it — `return None  # why` above a 2-line block is a 3-line run, and the fix is a blank line between them, not a rewrite. On 2026-09-01 one file cost four separate CI round-trips across two authors for that class alone.
+
 ## The PR body should answer
 
 In the order a reviewer reads them. Say "N/A" if a question doesn't apply, so the reviewer doesn't wonder whether you forgot it.


### PR DESCRIPTION
## What

`scripts/review-checks.sh` exists, is correct, and runs in CI on every PR. **Nothing tells an author to run it first** — `CONTRIBUTING.md` mentions it zero times, and `REVIEW.md` names it only as "run in CI", framed for reviewers.

Adds one item to **Before starting a PR** with the working invocation and the three ways it reports something other than what you expect.

## Why now

Measured 2026-09-01: `skills/collaboration-intelligence/scripts/notify_reviewers.py` cost **four separate CI round-trips across two authors** on `prose-cap` alone. Every one was mechanical, invisible while writing, and one local command away.

Three of the four were the same non-obvious shape — a trailing comment on a code line folding into the block beneath it:

```python
    return None                     # PRESENT but wrong: not an absent actor
    # EVERY present identity field, not just the one that wins the chain: a
    # valid endpoint must not smuggle a list-valued reviewer into the state.
```

`prose-cap` counts **consecutive added comment lines**, so that is a 3-line run. This is consistent with the rule as written (`Added COMMENT runs may not exceed this many PHYSICAL lines`) — it is not a scanner defect and this PR does not touch the scanner. The fix is a blank line, which the note says.

## Evidence

The documented recipe is what I measured, not what I assumed. **My first two drafts were both wrong and the scanner said so:**

```
uncommitted / staged   ERROR — empty diff; nothing was scanned, so this is NOT a pass
committed, three-dot   FAIL — prose-cap: src/proactive_routing.py:223
                       comment block is 3 lines (cap 2)              <- instrument fires
only a .md in range    PARTIAL — prose-cap had no in-scope files     <- not a pass
```

The middle row is a planted positive control (the fold shape above, committed), removed before this branch's final commit — so the check is shown able to produce a positive rather than only a quiet green.

Hence the note names all three: **commit first** (it reads commits, not your worktree), **three dots not two**, and **`PARTIAL` is not `PASS`**.

## Scope

One file, `CONTRIBUTING.md`. No code, no workflow, no scanner change.