### PR TITLE
docs(heartbeat): sync the documented payload schema

### DIFF
--- a/docs/claude-md-moved-detail.md
+++ b/docs/claude-md-moved-detail.md
@@ -35,7 +35,7 @@ api_key = get_vault_key("OPENAI_API_KEY")  # raises KeyError if not found
 
 Payload schema:
 ```json
-{"host": "...", "pid": ..., "started_at": ..., "last_beat_at": ..., "status": "...", "socket": "...", "locality": {"kind": "local|cloud", "host": "..."}, "schema_version": 2}
+{"host": "...", "pid": ..., "heartbeat_pid": ..., "started_at": ..., "last_beat_at": ..., "status": "...", "socket": "...", "session": "...", "locality": {"kind": "local|cloud", "host": "..."}, "schema_version": 3}
 ```
 
 This is foundation for the lease-based multi-core scheduler — workers consult


### PR DESCRIPTION
## Priority

**Level:** low
**Reason:** Documentation-only correction for a confirmed good-first-issue; no release or runtime path is blocked.

## Closes

Closes #2923

## Summary

Synchronize the documented heartbeat payload with `src/core_heartbeat.py`: add the existing `heartbeat_pid` and `session` fields and update `schema_version` from 2 to 3.

Review `docs/claude-md-moved-detail.md` first; it is the only changed file. Readers of the agent-facing reference now see the same payload contract the runtime writes.

Feature/documentation consistency: this PR corrects the canonical documentation itself. No `docs/catalog.json` or navigation update is needed because no feature, capability, or documentation path changes.

Live path: N/A — documentation only; no bridge, network, delivery, or startup code changes.

Stacked PR: N/A — this is based directly on `upstream/main`.

## Checklist

- [x] Confirmed no other open PR closes the same issue (`gh pr list --repo sonichi/sutando --state all --limit 100 --search "2923"` returned `[]`)
- [ ] Git author email matches my CLA-signed email — the commit maps to `sunxiayi@umich.edu`; CLA status will be reported by CLA Assistant
- [x] Single concern per PR — no bundled refactors / drive-by feature additions
- [x] Confirmed the stale documentation exists on `upstream/main`
- [x] Test added (N/A: documentation-only schema synchronization; existing heartbeat tests cover the runtime contract)
- [x] Before/after evidence pasted below
- [x] Every claim in this PR body is verifiable from the diff or the pasted output
- [x] Live path? N/A — documentation only
- [x] Stacked PR? N/A
- [x] Scanned added lines for host-specific hardcoded paths and inline home/workspace fallbacks; none found
- [x] CI workflow check: N/A — no workflow files changed
- [x] Workspace/home-path resolution check: N/A — no path-resolution code changed

## Before / after evidence

Command: a small AST/Markdown comparison of the keys written by `write_heartbeat()` and the documented JSON example.

Before (`upstream/main`):

```text
runtime keys: host pid heartbeat_pid started_at last_beat_at status socket session locality schema_version
documented keys: host pid started_at last_beat_at status socket locality kind host schema_version
missing from docs: heartbeat_pid session
schema version: runtime=3 docs=2
```

After (`d38a405a`):

```text
runtime keys: host pid heartbeat_pid started_at last_beat_at status socket session locality schema_version
documented keys: host pid heartbeat_pid started_at last_beat_at status socket session locality kind host schema_version
missing from docs: <none>
schema version: runtime=3 docs=3
```

## Test plan

```text
$ python3 tests/core-heartbeat.test.py
Ran 12 tests in 0.069s
OK

$ python3 tests/core-heartbeat-core-pid.test.py
PASS: heartbeat_pid is persisted separately from pid
PASS: schema version remains 3
All core heartbeat PID tests passed.

$ git diff --check upstream/main...HEAD
(no output)
```

Known gaps / rollback risk: none. Reverting the single documentation line restores the prior text; runtime behavior is unchanged.
