### PR TITLE
feat(hooks): pre-push runs review-checks on the CI population

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run the repo's own review-checks on what CI will see, BEFORE the push.
+#
+# Fail-open on infrastructure trouble (absent script, no local origin/main,
+# empty diff, no timeout binary): only an actual violation blocks. Escape
+# hatch: SUTANDO_SKIP_REVIEW_CHECKS=1 pushes anyway but logs the bypass.
+# No network here — the LOCAL origin/main ref bounds runtime; CI is the
+# authority when it is stale. Born of 4 prose-cap CI round-trips, 2026-09-01.
+set -uo pipefail
+
+REPO="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+CHECKS="$REPO/scripts/review-checks.sh"
+# --git-dir, not $REPO/.git: in a worktree .git is a FILE and the append
+# fails silently, which turns the logged escape hatch into a silent one.
+LOG="$(git rev-parse --git-dir)/pre-push-bypass.log"
+
+note() { echo "pre-push: $*" >&2; }
+
+if [ "${SUTANDO_SKIP_REVIEW_CHECKS:-0}" = "1" ]; then
+    if echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) bypass by $(git config user.email 2>/dev/null || echo '?') on $(git rev-parse --abbrev-ref HEAD 2>/dev/null)" >> "$LOG" 2>/dev/null; then
+        note "SUTANDO_SKIP_REVIEW_CHECKS=1 — bypass LOGGED to $LOG, pushing unchecked"
+    else
+        note "SUTANDO_SKIP_REVIEW_CHECKS=1 — bypass log UNWRITABLE ($LOG); pushing, but this bypass is only on your terminal"
+    fi
+    exit 0
+fi
+[ -f "$CHECKS" ] || { note "review-checks.sh absent — fail-open"; exit 0; }
+git rev-parse --verify -q origin/main >/dev/null || { note "no local origin/main ref — fail-open"; exit 0; }
+
+# Deletions and tag-only pushes have nothing to scan.
+any_branch=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+    [ "${local_sha:-}" != "0000000000000000000000000000000000000000" ] && [ -n "${local_sha:-}" ] && any_branch=1
+done
+[ "$any_branch" = "1" ] || exit 0
+
+DIFF="$(git diff origin/main...HEAD 2>/dev/null)"
+[ -n "$DIFF" ] || { note "empty three-dot diff vs local origin/main — nothing to scan, fail-open"; exit 0; }
+
+RUN=(bash "$CHECKS" --diff /dev/stdin)
+if command -v timeout >/dev/null 2>&1; then
+    RUN=(timeout -k 5 60 "${RUN[@]}")
+else
+    note "no timeout binary — running unbounded this once (still fail-open on its errors)"
+fi
+out="$(printf '%s' "$DIFF" | "${RUN[@]}" 2>&1)"; rc=$?
+
+case "$rc" in
+    0) exit 0 ;;
+    1) echo "$out" >&2
+       note "BLOCKED — review-checks found a violation CI would also find."
+       note "fix it, or push once with SUTANDO_SKIP_REVIEW_CHECKS=1 (logged)."
+       exit 1 ;;
+    *) echo "$out" >&2
+       note "review-checks infra trouble (rc=$rc, incl. timeout) — fail-open"
+       exit 0 ;;
+esac

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,15 +27,24 @@ fi
 [ -f "$CHECKS" ] || { note "review-checks.sh absent — fail-open"; exit 0; }
 git rev-parse --verify -q origin/main >/dev/null || { note "no local origin/main ref — fail-open"; exit 0; }
 
-# Deletions and tag-only pushes have nothing to scan.
-any_branch=0
-while read -r _local_ref local_sha _remote_ref _remote_sha; do
-    [ "${local_sha:-}" != "0000000000000000000000000000000000000000" ] && [ -n "${local_sha:-}" ] && any_branch=1
+# Scan the refs git SAYS are being pushed, not HEAD: `git push origin other`
+# from a different branch would otherwise scan the wrong commits entirely.
+shas=""
+while read -r local_ref local_sha _remote_ref _remote_sha; do
+    case "${local_ref:-}" in refs/tags/*) continue ;; esac
+    [ "${local_sha:-}" != "0000000000000000000000000000000000000000" ] && [ -n "${local_sha:-}" ] && shas="$shas $local_sha"
 done
-[ "$any_branch" = "1" ] || exit 0
+[ -n "$shas" ] || exit 0
 
-DIFF="$(git diff origin/main...HEAD 2>/dev/null)"
-[ -n "$DIFF" ] || { note "empty three-dot diff vs local origin/main — nothing to scan, fail-open"; exit 0; }
+DIFF=""
+head_sha="$(git rev-parse HEAD 2>/dev/null)"
+offtree=0
+for sha in $shas; do
+    [ "$sha" != "$head_sha" ] && offtree=1
+    DIFF="$DIFF$(git diff "origin/main...$sha" 2>/dev/null)
+"
+done
+[ -n "${DIFF//[[:space:]]/}" ] || { note "empty three-dot diff vs local origin/main — nothing to scan, fail-open"; exit 0; }
 
 RUN=(bash "$CHECKS" --diff /dev/stdin)
 if command -v timeout >/dev/null 2>&1; then
@@ -46,7 +55,14 @@ fi
 out="$(printf '%s' "$DIFF" | "${RUN[@]}" 2>&1)"; rc=$?
 
 case "$rc" in
-    0) exit 0 ;;
+    0) # PARTIAL also exits 0 and "not scanned" is not "clean" — say so, and
+       # say why when the pushed ref is not the checked-out tree (no post-image).
+       if printf '%s' "$out" | grep -q "review-checks: PARTIAL"; then
+           printf '%s\n' "$out" | grep "review-checks:" >&2
+           [ "$offtree" = "1" ] && note "pushed ref is not the checked-out tree, so post-image scans skipped"
+           note "PARTIAL is not PASS — pushing (fail-open), CI is the verdict on what was not scanned"
+       fi
+       exit 0 ;;
     1) echo "$out" >&2
        note "BLOCKED — review-checks found a violation CI would also find."
        note "fix it, or push once with SUTANDO_SKIP_REVIEW_CHECKS=1 (logged)."


### PR DESCRIPTION
## What

A tracked `.githooks/pre-push` that runs `scripts/review-checks.sh` on the exact population CI scans (three-dot against the **local** `origin/main` ref) before every branch push. Born of four prose-cap CI round-trips across two authors on 2026-09-01, each catchable locally in a second; #3696 documented the manual form, this makes it run without being remembered. Activation is the existing opt-in: `core.hooksPath=.githooks` is already wired by `scripts/install-git-hooks.sh` on every clone that ran it — @Sutando-Pro falsified the "owner-only git config" premise both of us held, and this PR is that finding built.

## Design constraints (Pro's, held verbatim)

- **Fail open on infrastructure trouble**: absent checks script, no local `origin/main`, empty diff, deletion/tag pushes, `timeout` missing, checker rc ≥ 2 — all push with a stderr note.
- **Fail closed only on an actual violation** (checker rc 1).
- **Bounded runtime**: `timeout -k 5 60` where the binary exists; no network in the hook — a stale local ref is accepted and CI stays the authority.
- **Logged escape hatch**: `SUTANDO_SKIP_REVIEW_CHECKS=1` pushes and appends to `$GIT_DIR/pre-push-bypass.log` — resolved via `--git-dir`, because in a worktree `.git` is a file and a `$REPO/.git/...` append fails *silently*, which I hit while testing and which would have turned the logged hatch into a silent one.

## Evidence

All five behaviors exercised in a worktree before pushing:

```
1 violation (added /Users/... host path)  -> rc=1, BLOCKED printed
2 escape hatch                            -> rc=0, one line in $GIT_DIR/pre-push-bypass.log
3 clean diff                              -> rc=0
4 checks script absent                    -> rc=0, "fail-open" printed
5 deletion push (zero local sha)          -> rc=0, skipped
```

And the live self-witness: **the push that opened this PR ran the hook on its own diff** — the `pre-push: no timeout binary — running unbounded this once` note in the push output is the hook executing on this host (macOS, no coreutils `timeout`) and passing.

## Scope

One new tracked hook file, +57 lines. No production code, no workflow change, opt-in by the existing installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
