### PR TITLE
feat(agent-api): /scan-text — decoded-value guard re-run for Signal Room dives

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
+++ b/packages/ag2-sparrow/ag2_sparrow/team_result_guard.py
@@ -202,6 +202,9 @@ def is_suppression_only(body: str) -> bool:
 VERDICT_DELIVER = "deliver"
 VERDICT_LEAK = "leak"
 VERDICT_SUPPRESS = "suppress"
+# Machine-detectable prefix of the fail-closed scanner-outage reason, so a
+# consumer that owns its own transport can map outage (not content) to an error.
+SCANNER_UNAVAILABLE = "scanner unavailable"
 WITHHELD_RESULT_DIR = "withheld-team-results"
 SUPPRESSED_RESULT_DIR = "suppressed-team-results"
 
@@ -382,15 +385,16 @@ def journal_suppressed_result(verdict: TeamResultVerdict, body: str,
 def classify_result_for_tier(body: str, tier, repo: Path,
                              secret_filter=None,
                              scan_sensitive_data: bool = True,
-                             allow_attach: bool = False) -> TeamResultVerdict:
+                             allow_attach: bool = False,
+                             honor_suppressions: bool = True) -> TeamResultVerdict:
     """The guard-owned policy verdict. Adapters apply transport mechanics only;
     re-deciding (or bypassing) this classification in a bridge is a boundary
     violation, not an implementation choice."""
     if not is_guarded_tier(tier):
         return TeamResultVerdict(VERDICT_DELIVER, body, None)
-    if is_suppression_only(body):
-        # Above the scan on purpose: an undelivered body has nothing to leak,
-        # and a LEAK here would put a notice back in the channel.
+    if honor_suppressions and is_suppression_only(body):
+        # Above the scan on purpose: an undelivered body has nothing to leak —
+        # marker-honouring adapters only (publishers pass honor_suppressions=False).
         return TeamResultVerdict(VERDICT_DELIVER, body, None)
     try:
         return TeamResultVerdict(
@@ -406,12 +410,13 @@ def classify_result_for_tier(body: str, tier, repo: Path,
         # Scanner unavailable is fail-CLOSED: an unscannable guarded result is
         # withheld, never delivered on the assumption that it was probably fine.
         return TeamResultVerdict(VERDICT_LEAK, TEAM_LEAK_RESULT,
-                                 f"scanner unavailable: {exc}")
+                                 f"{SCANNER_UNAVAILABLE}: {exc}")
 
 
 def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
                           scan_sensitive_data: bool = True, *,
-                          suppress_journal=None, allow_attach: bool = False):
+                          suppress_journal=None, allow_attach: bool = False,
+                          honor_suppressions: bool = True):
     """Consumer-facing gate: returns (safe_body, withheld_reason).
 
     Returns a body rather than raising, so a caller cannot deliver the raw text
@@ -424,7 +429,7 @@ def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
     """
     verdict = classify_result_for_tier(
         body, tier, repo, secret_filter, scan_sensitive_data,
-        allow_attach=allow_attach)
+        allow_attach=allow_attach, honor_suppressions=honor_suppressions)
     if (suppress_journal is not None and is_guarded_tier(tier)
             and is_suppression_only(body)):
         state_dir, task_id = suppress_journal

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -1322,8 +1322,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.send_private_json(503, {"error": "task workstream classifier unavailable"})
             return
 
-        # /scan-text — decoded-value guard re-run for the Signal Room daemon;
-        # tier pinned server-side, errors 500 (the caller fails closed on non-200).
+        # /scan-text — decoded-value guard re-run for the Signal Room daemon, which
+        # publishes the text itself: markers exempt nothing, scanner outage is a 500.
         if path == "/scan-text":
             if not self.check_auth():
                 return
@@ -1347,11 +1347,16 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.send_json(400, {"error": "texts must be 1..64 strings of <=16384 chars"})
                 return
             try:
-                from policy.egress.result import guard_result_for_tier
+                from policy.egress.result import (SCANNER_UNAVAILABLE,
+                                                  guard_result_for_tier)
                 verdict = "pass"
                 for t in texts:
-                    _safe, reason = guard_result_for_tier(t, SIGNAL_ROOM_TIER, REPO_DIR)
+                    _safe, reason = guard_result_for_tier(
+                        t, SIGNAL_ROOM_TIER, REPO_DIR, honor_suppressions=False)
                     if reason is not None:
+                        if reason.startswith(SCANNER_UNAVAILABLE):
+                            self.send_json(500, {"error": "scanner unavailable"})
+                            return
                         verdict = "withhold"
                         break
                 self.send_json(200, {"verdict": verdict})

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -1340,9 +1340,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
             except Exception:
                 self.send_json(400, {"error": "invalid JSON"})
                 return
-            # json.loads succeeds on any JSON VALUE, so a well-formed `[1]` or
-            # `"hi"` reaches .get() and raises AttributeError outside the except
-            # above — an uncaught 500 for an authenticated caller, not a 400.
+            # json.loads accepts any JSON value, so `[1]` reaches .get() outside
+            # the except above and raises instead of returning this 400.
             if not isinstance(data, dict):
                 self.send_json(400, {"error": "body must be a JSON object"})
                 return

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -1322,6 +1322,43 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.send_private_json(503, {"error": "task workstream classifier unavailable"})
             return
 
+        # /scan-text — decoded-value guard re-run for the Signal Room daemon;
+        # tier pinned server-side, errors 500 (the caller fails closed on non-200).
+        if path == "/scan-text":
+            if not self.check_auth():
+                return
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+            except (TypeError, ValueError):
+                self.send_json(400, {"error": "invalid Content-Length"})
+                return
+            if length < 0 or length > 262144:
+                self.send_json(413, {"error": "scan request too large"})
+                return
+            try:
+                data = json.loads(self.rfile.read(length).decode() or "{}")
+            except Exception:
+                self.send_json(400, {"error": "invalid JSON"})
+                return
+            texts = data.get("texts")
+            if (not isinstance(texts, list) or not texts or len(texts) > 64
+                    or not all(isinstance(t, str) for t in texts)
+                    or any(len(t) > 16384 for t in texts)):
+                self.send_json(400, {"error": "texts must be 1..64 strings of <=16384 chars"})
+                return
+            try:
+                from policy.egress.result import guard_result_for_tier
+                verdict = "pass"
+                for t in texts:
+                    _safe, reason = guard_result_for_tier(t, SIGNAL_ROOM_TIER, REPO_DIR)
+                    if reason is not None:
+                        verdict = "withhold"
+                        break
+                self.send_json(200, {"verdict": verdict})
+            except Exception:
+                self.send_json(500, {"error": "scanner unavailable"})
+            return
+
         # /guest-task — the Signal Room lane.
         if path == "/guest-task":
             if not self.check_auth():

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -1340,6 +1340,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
             except Exception:
                 self.send_json(400, {"error": "invalid JSON"})
                 return
+            # json.loads succeeds on any JSON VALUE, so a well-formed `[1]` or
+            # `"hi"` reaches .get() and raises AttributeError outside the except
+            # above — an uncaught 500 for an authenticated caller, not a 400.
+            if not isinstance(data, dict):
+                self.send_json(400, {"error": "body must be a JSON object"})
+                return
             texts = data.get("texts")
             if (not isinstance(texts, list) or not texts or len(texts) > 64
                     or not all(isinstance(t, str) for t in texts)

--- a/src/policy/egress/result.py
+++ b/src/policy/egress/result.py
@@ -202,6 +202,9 @@ def is_suppression_only(body: str) -> bool:
 VERDICT_DELIVER = "deliver"
 VERDICT_LEAK = "leak"
 VERDICT_SUPPRESS = "suppress"
+# Machine-detectable prefix of the fail-closed scanner-outage reason, so a
+# consumer that owns its own transport can map outage (not content) to an error.
+SCANNER_UNAVAILABLE = "scanner unavailable"
 WITHHELD_RESULT_DIR = "withheld-team-results"
 SUPPRESSED_RESULT_DIR = "suppressed-team-results"
 
@@ -382,15 +385,16 @@ def journal_suppressed_result(verdict: TeamResultVerdict, body: str,
 def classify_result_for_tier(body: str, tier, repo: Path,
                              secret_filter=None,
                              scan_sensitive_data: bool = True,
-                             allow_attach: bool = False) -> TeamResultVerdict:
+                             allow_attach: bool = False,
+                             honor_suppressions: bool = True) -> TeamResultVerdict:
     """The guard-owned policy verdict. Adapters apply transport mechanics only;
     re-deciding (or bypassing) this classification in a bridge is a boundary
     violation, not an implementation choice."""
     if not is_guarded_tier(tier):
         return TeamResultVerdict(VERDICT_DELIVER, body, None)
-    if is_suppression_only(body):
-        # Above the scan on purpose: an undelivered body has nothing to leak,
-        # and a LEAK here would put a notice back in the channel.
+    if honor_suppressions and is_suppression_only(body):
+        # Above the scan on purpose: an undelivered body has nothing to leak —
+        # marker-honouring adapters only (publishers pass honor_suppressions=False).
         return TeamResultVerdict(VERDICT_DELIVER, body, None)
     try:
         return TeamResultVerdict(
@@ -406,12 +410,13 @@ def classify_result_for_tier(body: str, tier, repo: Path,
         # Scanner unavailable is fail-CLOSED: an unscannable guarded result is
         # withheld, never delivered on the assumption that it was probably fine.
         return TeamResultVerdict(VERDICT_LEAK, TEAM_LEAK_RESULT,
-                                 f"scanner unavailable: {exc}")
+                                 f"{SCANNER_UNAVAILABLE}: {exc}")
 
 
 def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
                           scan_sensitive_data: bool = True, *,
-                          suppress_journal=None, allow_attach: bool = False):
+                          suppress_journal=None, allow_attach: bool = False,
+                          honor_suppressions: bool = True):
     """Consumer-facing gate: returns (safe_body, withheld_reason).
 
     Returns a body rather than raising, so a caller cannot deliver the raw text
@@ -424,7 +429,7 @@ def guard_result_for_tier(body: str, tier, repo: Path, secret_filter=None,
     """
     verdict = classify_result_for_tier(
         body, tier, repo, secret_filter, scan_sensitive_data,
-        allow_attach=allow_attach)
+        allow_attach=allow_attach, honor_suppressions=honor_suppressions)
     if (suppress_journal is not None and is_guarded_tier(tier)
             and is_suppression_only(body)):
         state_dir, task_id = suppress_journal

--- a/tests/agent-api-scan-text.test.py
+++ b/tests/agent-api-scan-text.test.py
@@ -154,9 +154,8 @@ def run() -> None:
     h.do_POST()
     check("malformed JSON -> 400", h._responses[0][0] == 400)
 
-    # [1] and "hi" are VALID JSON that is not an object: json.loads succeeds, so
-    # they reach .get() outside the parse except and raised AttributeError —
-    # an uncaught 500 for an authenticated caller rather than a 400.
+    # [1] and "hi" are valid JSON that is not an object: they parse, then reach
+    # .get() outside the except and raised instead of returning 400.
     for bad in ({}, {"texts": []}, {"texts": "one"}, {"texts": [1]},
                 {"texts": ["x"] * 65}, {"texts": ["y" * 16385]},
                 [1], "hi"):

--- a/tests/agent-api-scan-text.test.py
+++ b/tests/agent-api-scan-text.test.py
@@ -154,8 +154,12 @@ def run() -> None:
     h.do_POST()
     check("malformed JSON -> 400", h._responses[0][0] == 400)
 
+    # [1] and "hi" are VALID JSON that is not an object: json.loads succeeds, so
+    # they reach .get() outside the parse except and raised AttributeError —
+    # an uncaught 500 for an authenticated caller rather than a 400.
     for bad in ({}, {"texts": []}, {"texts": "one"}, {"texts": [1]},
-                {"texts": ["x"] * 65}, {"texts": ["y" * 16385]}):
+                {"texts": ["x"] * 65}, {"texts": ["y" * 16385]},
+                [1], "hi"):
         h = post(bad)
         if h._responses[0][0] != 400:
             check(f"bad texts shape rejected: {str(bad)[:40]}", False)

--- a/tests/agent-api-scan-text.test.py
+++ b/tests/agent-api-scan-text.test.py
@@ -1,0 +1,144 @@
+"""agent-api /scan-text — the Signal Room daemon's decoded-value guard re-run.
+
+Exercises the real Handler.do_POST (same harness as agent-api-guest-routes):
+
+  * the tier is pinned server-side (SIGNAL_ROOM_TIER) — the request carries no
+    tier and cannot pick one;
+  * verdicts: clean text -> pass; a withheld verdict from the guard -> withhold;
+  * a scanner exception -> 500 (the daemon reads any non-200 as fail-closed);
+  * input validation: auth, Content-Length caps, texts shape/limits.
+
+Run: `python3 tests/agent-api-scan-text.test.py`
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+_TEST_WS = tempfile.mkdtemp()
+os.environ["SUTANDO_TEST_MODE"] = "1"
+os.environ["SUTANDO_WORKSPACE"] = _TEST_WS
+SRC = Path(__file__).resolve().parent.parent / "src"
+_spec = importlib.util.spec_from_file_location("agent_api", str(SRC / "agent-api.py"))
+agent_api = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(agent_api)
+
+failures = 0
+
+
+def check(name: str, cond: bool) -> None:
+    global failures
+    print(("ok: " if cond else "FAIL: ") + name)
+    if not cond:
+        failures += 1
+
+
+class FakeRFile:
+    def __init__(self, body: bytes = b""):
+        self.body = body
+        self.read_calls = 0
+
+    def read(self, n: int = -1) -> bytes:
+        self.read_calls += 1
+        return self.body
+
+
+def make_handler(path: str, headers: dict, body: bytes = b"", auth: bool = True):
+    h = agent_api.Handler.__new__(agent_api.Handler)
+    h.path = path
+    h.headers = headers
+    h.rfile = FakeRFile(body)
+    h._responses = []
+    h.check_auth = lambda: (auth if auth else h._responses.append((401, {"error": "unauthorized"})) or False)
+    h.send_json = lambda status, data: h._responses.append((status, data))
+    h.send_private_json = lambda status, data: h._responses.append((status, data))
+    return h
+
+
+def post(payload, auth: bool = True):
+    body = json.dumps(payload).encode()
+    h = make_handler("/scan-text", {"Content-Length": str(len(body))}, body, auth=auth)
+    h.do_POST()
+    return h
+
+
+def run() -> None:
+    import policy.egress.result as egress
+
+    # --- verdicts, with the guard spied so verdicts are deterministic ---------
+    calls = []
+    real_guard = egress.guard_result_for_tier
+
+    def spy(body, tier, repo, *a, **kw):
+        calls.append((body, tier))
+        if "TRIGGER" in body:
+            return "[withheld]", "secret-scan"
+        return body, None
+
+    egress.guard_result_for_tier = spy
+    try:
+        h = post({"texts": ["clean one", "clean two"]})
+        check("clean texts -> 200 pass", h._responses[0] == (200, {"verdict": "pass"}))
+        check("tier is pinned server-side to the Signal Room lane",
+              all(t == agent_api.SIGNAL_ROOM_TIER for _b, t in calls))
+
+        calls.clear()
+        h = post({"texts": ["fine", "has TRIGGER inside", "never scanned"]})
+        check("any withheld verdict -> withhold", h._responses[0] == (200, {"verdict": "withhold"}))
+        check("scan short-circuits after the hit", len(calls) == 2)
+
+        # A caller-supplied tier field is ignored — there is nothing to elect.
+        calls.clear()
+        h = post({"texts": ["x"], "tier": "owner", "access_tier": "owner"})
+        check("caller cannot elect a tier", h._responses[0][0] == 200
+              and all(t == agent_api.SIGNAL_ROOM_TIER for _b, t in calls))
+    finally:
+        egress.guard_result_for_tier = real_guard
+
+    # --- scanner failure is a 500, never a silent pass ------------------------
+    def boom(*a, **kw):
+        raise RuntimeError("scanner down")
+
+    egress.guard_result_for_tier = boom
+    try:
+        h = post({"texts": ["anything"]})
+        check("scanner exception -> 500 (daemon fails closed on non-200)",
+              h._responses[0][0] == 500)
+    finally:
+        egress.guard_result_for_tier = real_guard
+
+    # --- input validation -----------------------------------------------------
+    h = post({"texts": ["x"]}, auth=False)
+    check("honours check_auth", not any(r[0] == 200 for r in h._responses))
+
+    h = make_handler("/scan-text", {"Content-Length": "999999"})
+    h.do_POST()
+    check("oversized request -> 413 before the body is read",
+          h._responses[0][0] == 413 and h.rfile.read_calls == 0)
+
+    h = make_handler("/scan-text", {"Content-Length": "nope"})
+    h.do_POST()
+    check("invalid Content-Length -> 400", h._responses[0][0] == 400)
+
+    h = make_handler("/scan-text", {"Content-Length": "5"}, b"{oops")
+    h.do_POST()
+    check("malformed JSON -> 400", h._responses[0][0] == 400)
+
+    for bad in ({}, {"texts": []}, {"texts": "one"}, {"texts": [1]},
+                {"texts": ["x"] * 65}, {"texts": ["y" * 16385]}):
+        h = post(bad)
+        if h._responses[0][0] != 400:
+            check(f"bad texts shape rejected: {str(bad)[:40]}", False)
+            break
+    else:
+        check("every bad texts shape -> 400", True)
+
+
+run()
+print()
+if failures:
+    print(f"FAILED ({failures})")
+    sys.exit(1)
+print("all /scan-text checks passed")

--- a/tests/agent-api-scan-text.test.py
+++ b/tests/agent-api-scan-text.test.py
@@ -5,7 +5,8 @@ Exercises the real Handler.do_POST (same harness as agent-api-guest-routes):
   * the tier is pinned server-side (SIGNAL_ROOM_TIER) — the request carries no
     tier and cannot pick one;
   * verdicts: clean text -> pass; a withheld verdict from the guard -> withhold;
-  * a scanner exception -> 500 (the daemon reads any non-200 as fail-closed);
+  * suppression markers exempt nothing (the daemon publishes the text itself);
+  * a failing underlying scanner -> 500 (the daemon reads non-200 as fail-closed);
   * input validation: auth, Content-Length caps, texts shape/limits.
 
 Run: `python3 tests/agent-api-scan-text.test.py`
@@ -72,7 +73,7 @@ def run() -> None:
     real_guard = egress.guard_result_for_tier
 
     def spy(body, tier, repo, *a, **kw):
-        calls.append((body, tier))
+        calls.append((body, tier, kw.get("honor_suppressions")))
         if "TRIGGER" in body:
             return "[withheld]", "secret-scan"
         return body, None
@@ -82,7 +83,9 @@ def run() -> None:
         h = post({"texts": ["clean one", "clean two"]})
         check("clean texts -> 200 pass", h._responses[0] == (200, {"verdict": "pass"}))
         check("tier is pinned server-side to the Signal Room lane",
-              all(t == agent_api.SIGNAL_ROOM_TIER for _b, t in calls))
+              all(t == agent_api.SIGNAL_ROOM_TIER for _b, t, _hs in calls))
+        check("published-text mode: honor_suppressions=False on every call",
+              all(hs is False for _b, _t, hs in calls))
 
         calls.clear()
         h = post({"texts": ["fine", "has TRIGGER inside", "never scanned"]})
@@ -93,18 +96,43 @@ def run() -> None:
         calls.clear()
         h = post({"texts": ["x"], "tier": "owner", "access_tier": "owner"})
         check("caller cannot elect a tier", h._responses[0][0] == 200
-              and all(t == agent_api.SIGNAL_ROOM_TIER for _b, t in calls))
+              and all(t == agent_api.SIGNAL_ROOM_TIER for _b, t, _hs in calls))
     finally:
         egress.guard_result_for_tier = real_guard
 
-    # --- scanner failure is a 500, never a silent pass ------------------------
+    # --- real guard: the daemon publishes the text itself, so a [no-send] skip
+    # marker exempts nothing and a failing underlying scanner is a 500 ---------
+    from types import SimpleNamespace
+
+    real_loader = egress.load_team_result_scanner
+    egress.load_team_result_scanner = lambda repo: (lambda body: SimpleNamespace(
+        detected="AKIA" in body, secret_types=["aws-key"]))
+    try:
+        h = post({"texts": ["[no-send]\nAKIAFAKEFAKEFAKEFAKE"]})
+        check("a skip marker does not exempt a secret from the scan",
+              h._responses[0] == (200, {"verdict": "withhold"}))
+        h = post({"texts": ["[no-send]\nnothing sensitive here"]})
+        check("a clean skip-marker body still passes",
+              h._responses[0] == (200, {"verdict": "pass"}))
+
+        def down(_repo):
+            raise RuntimeError("scanner down")
+
+        egress.load_team_result_scanner = down
+        h = post({"texts": ["anything"]})
+        check("failing underlying scanner -> 500 with the real guard in place",
+              h._responses[0] == (500, {"error": "scanner unavailable"}))
+    finally:
+        egress.load_team_result_scanner = real_loader
+
+    # --- a guard that itself throws (out-of-contract) still fails closed ------
     def boom(*a, **kw):
-        raise RuntimeError("scanner down")
+        raise RuntimeError("guard blew up")
 
     egress.guard_result_for_tier = boom
     try:
         h = post({"texts": ["anything"]})
-        check("scanner exception -> 500 (daemon fails closed on non-200)",
+        check("out-of-contract guard exception -> 500",
               h._responses[0][0] == 500)
     finally:
         egress.guard_result_for_tier = real_guard

--- a/tests/team-result-guard.test.py
+++ b/tests/team-result-guard.test.py
@@ -412,6 +412,26 @@ def main() -> int:
                     v = guard.classify_result_for_tier(body, tier, REPO, secret_filter=filt)
                     assert v.kind == guard.VERDICT_DELIVER, (body, tier, filt.__name__)
                     assert v.body == body, (body, tier, "suppression body was rewritten")
+    # honor_suppressions=False is the published-text mode (/scan-text): the caller
+    # delivers the body itself and executes no markers, so skip markers exempt nothing.
+    v = guard.classify_result_for_tier("[no-send]\nsecret text", "team", REPO,
+                                       secret_filter=_leaky,
+                                       honor_suppressions=False)
+    assert v.kind == guard.VERDICT_LEAK, "published-text mode must scan skip-marker bodies"
+    v = guard.classify_result_for_tier("[no-send]\nhide", "team", REPO,
+                                       secret_filter=_clean,
+                                       honor_suppressions=False)
+    assert v.kind == guard.VERDICT_DELIVER and v.body == "[no-send]\nhide", (
+        "a clean skip-marker body still delivers in published-text mode")
+    _b, _reason = guard.guard_result_for_tier(
+        "[no-send]\nsecret text", "team", REPO, secret_filter=_leaky,
+        honor_suppressions=False)
+    assert _reason is not None, "guard wrapper must thread honor_suppressions through"
+    # The fail-closed outage reason is machine-detectable by prefix, so a
+    # transport-owning consumer can map outage (not content) to an error.
+    v = guard.classify_result_for_tier("plain body", "team", REPO, secret_filter=_raises)
+    assert v.kind == guard.VERDICT_LEAK and v.reason.startswith(guard.SCANNER_UNAVAILABLE), (
+        "scanner outage must carry the SCANNER_UNAVAILABLE prefix")
     assert not hasattr(guard, "suppression_stub_for_tier"), (
         "the stub minter must be gone, not merely unused — it is what parsed and "
         "validated a dedup target inside the guard")


### PR DESCRIPTION
Companion to ag2-space/ag2space-backend#922 (Signal Room rich deep_dive results, Phase 1) — they land as a pair; the daemon fails closed while this endpoint is absent.

## What

`POST /scan-text {texts: [...]}` → `{"verdict": "pass" | "withhold"}` — the Signal Room daemon's guard re-run over a dive's **decoded** canonical card values before it posts them to the room. JSON `\uXXXX` escapes can smuggle content past the raw-body scan that already runs when a result leaves the core; only the daemon holds the decoded form, and the gateway is where the scanner lives.

- Each string is guarded with the existing `guard_result_for_tier` at `SIGNAL_ROOM_TIER` — **the tier is pinned server-side**; the request carries none and a caller-supplied one is ignored.
- Scanning text the caller already possesses grants no new data access, so the ordinary gateway auth suffices (unlike file reads, which backend's Phase 5G gates on a separate capability).
- Scanner failure → 500; the daemon reads any non-200 as fail-closed (card dropped, fixed safe notice spoken).
- Bounds mirror the sibling routes: Content-Length capped before the body is read (256 KiB), 1..64 strings ≤ 16 KiB each.

## Verification

`tests/agent-api-scan-text.test.py` drives the real handler (same harness as `agent-api-guest-routes`): verdicts incl. short-circuit on the first withhold, server-side tier pinning with a spied guard, caller-supplied tier ignored, scanner-exception 500, auth gate, 413-before-read, and every bad-shape rejection. Adjacent suites (guest-routes, task-field injection, injection sweep, state-paths) still pass; `review-checks.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)