### PR TITLE
fix(hooks): pre-push names the dirty-worktree cause of PARTIAL

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -56,10 +56,11 @@ out="$(printf '%s' "$DIFF" | "${RUN[@]}" 2>&1)"; rc=$?
 
 case "$rc" in
     0) # PARTIAL also exits 0 and "not scanned" is not "clean" — say so, and
-       # say why when the pushed ref is not the checked-out tree (no post-image).
+       # name the cause: prose-cap scans only files matching the working tree.
        if printf '%s' "$out" | grep -q "review-checks: PARTIAL"; then
            printf '%s\n' "$out" | grep "review-checks:" >&2
            [ "$offtree" = "1" ] && note "pushed ref is not the checked-out tree, so post-image scans skipped"
+           git diff --quiet 2>/dev/null || note "working tree is dirty — post-image scans skip any file in the range that does not match it"
            note "PARTIAL is not PASS — pushing (fail-open), CI is the verdict on what was not scanned"
        fi
        exit 0 ;;

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -60,7 +60,7 @@ case "$rc" in
        if printf '%s' "$out" | grep -q "review-checks: PARTIAL"; then
            printf '%s\n' "$out" | grep "review-checks:" >&2
            [ "$offtree" = "1" ] && note "pushed ref is not the checked-out tree, so post-image scans skipped"
-           git diff --quiet 2>/dev/null || note "working tree is dirty — post-image scans skip any file in the range that does not match it"
+           git diff --quiet HEAD 2>/dev/null || note "working tree is dirty — post-image scans skip any file in the range that does not match it"
            note "PARTIAL is not PASS — pushing (fail-open), CI is the verdict on what was not scanned"
        fi
        exit 0 ;;


### PR DESCRIPTION
## What

`.githooks/pre-push` (shipped by #3703) explains a `PARTIAL` verdict when the pushed ref is not the checked-out tree. That is the rarer cause. The common one — commit, keep editing, push `HEAD` — leaves `offtree` at 0, so the author sees `PARTIAL is not PASS` with no reason attached and nothing to act on.

One line, beside the existing `offtree` note:

```bash
git diff --quiet 2>/dev/null || note "working tree is dirty — post-image scans skip any file in the range that does not match it"
```

## Why this is the common case

`prose-cap` scans only files whose post-image matches the working tree, so **any** uncommitted edit to a file in the pushed range silently drops it from the scan. Committing and then continuing to edit before pushing is ordinary, and `offtree` is 0 throughout it.

## Before / after — the exact scenario

Pushing `HEAD` (so `offtree=0`) from a branch with `.py` in its range, one uncommitted edit to a file already in the diff:

```
 M src/policy/egress/unfurl.py
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap SKIPPED — no post-image)
pre-push: working tree is dirty — post-image scans skip any file in the range that does not match it   <- new
pre-push: PARTIAL is not PASS — pushing (fail-open), CI is the verdict on what was not scanned
```

`prose-cap SKIPPED — no post-image` is the real cause being named, and the existing `offtree` note stays correctly silent because the pushed ref *is* the checked-out tree.

**Negative control — clean tree, same hook, same branch:**

```
tree state: 0 dirty files
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
pre-push: PARTIAL is not PASS — pushing (fail-open), CI is the verdict on what was not scanned
```

The new line is absent, so it discriminates on tree state rather than firing on every `PARTIAL`.

## Scoping the wording to what the check proves

`git diff --quiet` establishes that the tree is dirty, **not** that the dirty files are the ones in the pushed range. The message says only the former and states the consequence conditionally ("any file in the range that does not match it"), so it cannot assert something the test did not check. A range-scoped test would need the file list parsed back out of `$DIFF`; that is more machinery than a diagnostic note warrants, and the conditional wording is accurate without it.

Behaviour is otherwise unchanged: still inside the `rc == 0` branch, still fail-open, still one `note` on stderr.

## Two honest notes on the evidence

- **`scripts/review-checks.sh` on `origin/main...HEAD` reports `PARTIAL`, not `PASS`** — `REVIEW.md`'s checks block sets `prose_exts: ['.py']`, so a `.sh`-only diff has nothing for prose-cap to scan. Hardcoded-paths and root-artifacts are clean. Reporting it as PARTIAL per the rule #3696 documents.
- **No live self-witness.** #3703's push ran the hook on its own diff; mine did not, because `core.hooksPath` is unset in this clone. The runs above are manual invocations of the hook with a ref line on stdin, which is the same code path but not the same proof, and I would rather say so than let the earlier precedent imply otherwise.

Follows #3703 (the hook) and #3696 (the manual recipe it automates); the gap was raised in my review of #3703.
