### PR TITLE
fix(health-check): a lane whose bridge STOPPED hides behind a healthy primary

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6032,7 +6032,7 @@ def check_gateway_bridge() -> "dict | None":
                       "ag2.space mobile messages are not being delivered",
         }
     if verdict is True:
-        return {"name": "gateway-bridge", "status": "ok", "detail": "running + connected"}
+        return _gateway_ok_unless_lane_stalled("running + connected")
     # The bridge rewrites this file on every poll outcome, so silence past the
     # freshness window means the writer stopped — evidence, not absence of it.
     stale_age = _gateway_status_stale_age_s()
@@ -6070,9 +6070,8 @@ def check_gateway_bridge() -> "dict | None":
         }
     if lanes:
         served = ", ".join(ln for ln, serving, _ in lanes if serving)
-        return {"name": "gateway-bridge", "status": "ok",
-                "detail": f"running + connected (lane {served})"}
-    return {"name": "gateway-bridge", "status": "ok", "detail": "running"}
+        return _gateway_ok_unless_lane_stalled(f"running + connected (lane {served})")
+    return _gateway_ok_unless_lane_stalled("running")
 
 
 GATEWAY_STATUS_MAX_AGE_S = 180.0
@@ -6241,6 +6240,53 @@ def _gateway_lane_verdicts(state_dir: "Path | None" = None,
             continue
         out.append((lane, v.serving, v.last_ok_ts is not None))
     return out
+
+
+def _gateway_stale_lanes(state_dir: "Path | None" = None,
+                         now: "float | None" = None) -> "list[tuple[str, float]]":
+    """(lane, age_s) for every lane sidecar whose `ts` is PAST the freshness
+    window — a lane that stopped, as opposed to one that failed.
+
+    A per-channel bridge that dies leaves its last record in place, and that
+    record almost always says `connected: true` — it did not fail, it stopped.
+    `_gateway_lane_verdicts` drops such a file (no fresh verdict), so a healthy
+    primary hides a dead lane completely. Only the sidecar's silence names it.
+    """
+    root = (Path(state_dir) if state_dir is not None
+            else Path(status_read_path("gateway-status.json", WORKSPACE_DIR)).parent)
+    out = []
+    try:
+        entries = sorted(root.glob("gateway-status.*.json"))
+    except OSError:
+        return out
+    for f in entries:
+        lane = f.name[len("gateway-status."):-len(".json")]
+        age = _gateway_status_stale_age_s(f, now=now)
+        if age is not None:
+            out.append((lane, age))
+    return out
+
+
+def _gateway_ok_unless_lane_stalled(detail: str) -> dict:
+    """The ok verdict for the bridge, demoted to warn when any lane's sidecar
+    has gone silent — the primary being healthy says nothing about a lane."""
+    stalled = _gateway_stale_lanes()
+    if not stalled:
+        return {"name": "gateway-bridge", "status": "ok", "detail": detail}
+    names = ", ".join(
+        f"{ln} (last write {age:.0f}s ago)" if age < 3600
+        else f"{ln} (last write {age / 3600:.1f}h ago)"
+        for ln, age in stalled)
+    return {
+        "name": "gateway-bridge",
+        "status": "warn",
+        "detail": (
+            f"{detail}, but lane {names} stopped writing its sidecar — its last "
+            "record still says connected, so only the silence shows it; messages "
+            "on that lane are not being delivered (retired lane? remove "
+            "state/gateway-status.<lane>.json)"
+        ),
+    }
 
 
 def _gateway_status_stale_age_s(path: "Path | None" = None,

--- a/tests/health-check-gateway-stale-lane.test.py
+++ b/tests/health-check-gateway-stale-lane.test.py
@@ -63,6 +63,13 @@ class GatewayStaleLanes(unittest.TestCase):
         _write(self.d, "gateway-status.local.json", connected=True, ts="soon")
         self.assertEqual(hc._gateway_stale_lanes(state_dir=self.d, now=NOW), [])
 
+    def test_unlistable_state_dir_is_empty_not_an_exception(self):
+        """`Path.glob` swallows most errors itself, so the OSError arm is reached
+        only when the listing genuinely fails; the probe must answer "no lanes"
+        rather than take the whole health run down."""
+        with patch.object(Path, "glob", side_effect=OSError("listing failed")):
+            self.assertEqual(hc._gateway_stale_lanes(state_dir=self.d, now=NOW), [])
+
     def test_missing_dir_is_empty(self):
         self.assertEqual(hc._gateway_stale_lanes(state_dir=Path("/nonexistent-xyz"), now=NOW), [])
 

--- a/tests/health-check-gateway-stale-lane.test.py
+++ b/tests/health-check-gateway-stale-lane.test.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""A lane whose bridge STOPPED is invisible behind a healthy primary.
+
+`_gateway_lane_verdicts` only reports lanes with a fresh sidecar, and a bridge
+that dies leaves its last record — almost always `connected: true` — in place.
+So with the primary serving, `check_gateway_bridge` read `ok` for as long as a
+lane stayed dead. The silence of the sidecar is the only evidence, and this
+suite pins that the verdict reads it.
+"""
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO / "src"))
+_spec = importlib.util.spec_from_file_location("hc", _REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+NOW = 1_800_000_000.0
+STALE = hc.GATEWAY_STATUS_MAX_AGE_S * 5
+
+
+def _write(d: Path, name: str, **rec) -> None:
+    (d / name).write_text(json.dumps(rec))
+
+
+class GatewayStaleLanes(unittest.TestCase):
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.d, ignore_errors=True)
+
+    def test_fresh_lane_is_not_stale(self):
+        _write(self.d, "gateway-status.local.json", connected=True, ts=NOW - 5)
+        self.assertEqual(hc._gateway_stale_lanes(state_dir=self.d, now=NOW), [])
+
+    def test_stopped_lane_is_named_with_its_age(self):
+        _write(self.d, "gateway-status.local.json", connected=True, ts=NOW - STALE)
+        self.assertEqual(hc._gateway_stale_lanes(state_dir=self.d, now=NOW),
+                         [("local", STALE)])
+
+    def test_connected_true_does_not_rescue_a_stopped_lane(self):
+        """The record's own claim is exactly what cannot be trusted."""
+        _write(self.d, "gateway-status.dev.json", connected=True, error=None,
+               last_ok_ts=NOW - STALE, ts=NOW - STALE)
+        self.assertEqual([ln for ln, _ in hc._gateway_stale_lanes(state_dir=self.d, now=NOW)],
+                         ["dev"])
+
+    def test_primary_sidecar_is_not_a_lane(self):
+        _write(self.d, "gateway-status.json", connected=True, ts=NOW - STALE)
+        self.assertEqual(hc._gateway_stale_lanes(state_dir=self.d, now=NOW), [])
+
+    def test_malformed_ts_is_not_reported_as_stale(self):
+        _write(self.d, "gateway-status.local.json", connected=True, ts="soon")
+        self.assertEqual(hc._gateway_stale_lanes(state_dir=self.d, now=NOW), [])
+
+    def test_missing_dir_is_empty(self):
+        self.assertEqual(hc._gateway_stale_lanes(state_dir=Path("/nonexistent-xyz"), now=NOW), [])
+
+
+class GatewayBridgeVerdictSeesStoppedLane(unittest.TestCase):
+    def _run(self, serving, lanes=(), stalled=()):
+        with patch.object(hc, "_gateway_configured", return_value=True), \
+             patch.object(hc, "subprocess") as sp, \
+             patch.object(hc, "_gateway_lock_pids", return_value={}), \
+             patch.object(hc, "_gateway_serving", return_value=serving), \
+             patch.object(hc, "_gateway_status_stale_age_s", return_value=None), \
+             patch.object(hc, "_gateway_lane_verdicts", return_value=list(lanes)), \
+             patch.object(hc, "_gateway_stale_lanes", return_value=list(stalled)):
+            sp.run.return_value = type("R", (), {"stdout": "4242\n", "returncode": 0})()
+            return hc.check_gateway_bridge()
+
+    def test_healthy_primary_no_longer_hides_a_stopped_lane(self):
+        r = self._run(True, stalled=[("local", 1470.0)])
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("local", r["detail"])
+        self.assertIn("stopped writing", r["detail"])
+        self.assertIn("1470s", r["detail"])
+
+    def test_healthy_primary_with_no_stopped_lane_is_unchanged(self):
+        r = self._run(True)
+        self.assertEqual(r, {"name": "gateway-bridge", "status": "ok",
+                             "detail": "running + connected"})
+
+    def test_served_lane_does_not_vouch_for_a_stopped_sibling(self):
+        r = self._run(None, lanes=[("dev", True, True)], stalled=[("local", 7200.0)])
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("lane dev", r["detail"])
+        self.assertIn("local (last write 2.0h ago)", r["detail"])
+
+    def test_process_only_verdict_still_sees_a_stopped_lane(self):
+        r = self._run(None, stalled=[("local", 600.0)])
+        self.assertEqual(r["status"], "warn")
+
+    def test_no_lanes_at_all_keeps_the_process_only_verdict(self):
+        r = self._run(None)
+        self.assertEqual(r, {"name": "gateway-bridge", "status": "ok", "detail": "running"})
+
+
+class ShippedPathReadsTheRealSidecar(unittest.TestCase):
+    """Same verdict without mocking the helper: the file on disk is the input."""
+
+    def test_stale_lane_file_next_to_a_serving_primary_warns(self):
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        now = time.time()
+        _write(d, "gateway-status.json", connected=True, last_ok_ts=now, ts=now)
+        _write(d, "gateway-status.local.json", connected=True, last_ok_ts=now - STALE,
+               ts=now - STALE)
+        with patch.object(hc, "_gateway_configured", return_value=True), \
+             patch.object(hc, "subprocess") as sp, \
+             patch.object(hc, "_gateway_lock_pids", return_value={}), \
+             patch.object(hc, "status_read_path",
+                          side_effect=lambda name, *_a, **_k: d / name):
+            sp.run.return_value = type("R", (), {"stdout": "4242\n", "returncode": 0})()
+            r = hc.check_gateway_bridge()
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("lane local", r["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`check_gateway_bridge()` returns `ok` as soon as the **primary** sidecar says serving. Per-lane sidecars (`state/gateway-status.<lane>.json`) are consulted only on the "primary said nothing" path, and even there `_gateway_lane_verdicts()` reports only lanes with a **fresh** sidecar. A lane bridge that dies leaves its last record on disk — almost always `connected: true, error: null` — so it does not fail, it **stops**, and the probe has no reader for the silence. With the primary healthy, a dead lane is invisible for as long as it stays dead.

## Measured on a live host, same workspace, same moment

The `local` lane's bridge heartbeated once at 02:24 PT and died; its sidecar still says `connected: true`. An owner reply sat stranded in `results/` (health-check's `orphaned-results` caught it as a downstream symptom 21 min later — the same shape as the 2026-09-01 incident that stranded three answers).

```
BEFORE (origin/main fb2688f2)
  ✓ gateway-bridge   ok    running + connected

AFTER (this branch)
  ⚠ gateway-bridge   warn  running + connected, but lane local (last write 1735s ago) stopped writing its sidecar — its last record still says connected, so only the silence shows it; messages on that lane are not being delivered (retired lane? remove state/gateway-status.<lane>.json)
```

## The fix

- `_gateway_stale_lanes(state_dir, now)` → `[(lane, age_s)]` for every lane sidecar whose `ts` is past `GATEWAY_STATUS_MAX_AGE_S`, reusing `_gateway_status_stale_age_s` per file (malformed `ts` → not reported, matching the primary's rule).
- `_gateway_ok_unless_lane_stalled(detail)` wraps all three `ok` returns (primary serving; lane-served; process-only). No change to any warn path.

A retired lane whose sidecar is left behind will warn until the file is removed; the detail says so. That is the intended direction — a configured-but-unlaunched channel is exactly the state that had no signal.

## Tests

`tests/health-check-gateway-stale-lane.test.py` — 12 cases: helper (fresh / stopped / `connected:true` does not rescue / primary file is not a lane / malformed ts / missing dir), verdict wiring on all three ok paths + the no-lanes regression guard, and one **shipped-path** case that writes real sidecar files and patches only `status_read_path`.

```
tests/health-check-gateway-stale-lane.test.py: OK (12)
tests/health-check-gateway-lane-verdict.test.py: OK
tests/gateway-serving-shared-owner.test.py: ok - 5 contract + 5 no-opinion + 21 malformed + 7 accepted cases
```

Negative control — suite against unpatched `origin/main` source: `FAILED (failures=1, errors=11)`; the 1 **failure** is the shipped-path case (behavioral), the 11 errors are the missing helper. Restored: `OK`.

`scripts/review-checks.sh --diff` on the cumulative diff: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
