### PR TITLE
fix(hooks): pre-push tests diff emptiness by streaming, not a quadratic expansion

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -44,7 +44,9 @@ for sha in $shas; do
     DIFF="$DIFF$(git diff "origin/main...$sha" 2>/dev/null)
 "
 done
-[ -n "${DIFF//[[:space:]]/}" ] || { note "empty three-dot diff vs local origin/main — nothing to scan, fail-open"; exit 0; }
+# Streamed, not `${DIFF//[[:space:]]/}`: that substitution is quadratic in
+# bash and spins for minutes on a diff of a few tens of KB.
+grep -q '[^[:space:]]' <<< "$DIFF" || { note "empty three-dot diff vs local origin/main — nothing to scan, fail-open"; exit 0; }
 
 RUN=(bash "$CHECKS" --diff /dev/stdin)
 if command -v timeout >/dev/null 2>&1; then

--- a/tests/pre-push-large-diff-completes.test.sh
+++ b/tests/pre-push-large-diff-completes.test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# The pre-push hook must finish on a large diff: `${DIFF//[[:space:]]/}` was
+# quadratic in bash (a 74 KB diff spun for minutes); the bound is 10x streaming.
+set -euo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+git -C "$T" init -q -b main; git -C "$T" -c user.email=t@x -c user.name=t commit -q --allow-empty -m base
+git -C "$T" update-ref refs/remotes/origin/main HEAD
+mkdir -p "$T/scripts" "$T/.githooks"
+cp "$REPO/.githooks/pre-push" "$T/.githooks/pre-push"
+printf '#!/bin/bash\ncat >/dev/null\necho "review-checks: PASS"\n' > "$T/scripts/review-checks.sh"
+python3 - "$T/big.py" <<'PY'
+import sys; open(sys.argv[1],'w').write("".join(f"x{i} = {i}  # padding line\n" for i in range(6000)))
+PY
+git -C "$T" add -A && git -C "$T" -c user.email=t@x -c user.name=t commit -q -m big
+sha="$(git -C "$T" rev-parse HEAD)"
+echo "diff bytes: $(git -C "$T" diff origin/main...HEAD | wc -c | tr -d ' ')"
+start=$(date +%s)
+cd "$T"
+# The hook is $pid itself, so the bound can kill the spinning bash directly.
+bash .githooks/pre-push origin https://example.invalid/r.git \
+  <<< "refs/heads/main $sha refs/heads/main 0000000000000000000000000000000000000000" &
+pid=$!
+while kill -0 "$pid" 2>/dev/null; do
+  if [ $(( $(date +%s) - start )) -ge 30 ]; then kill "$pid" 2>/dev/null; echo "FAIL: pre-push still running after 30s on a large diff"; exit 1; fi
+  sleep 0.2
+done
+wait "$pid" && echo "PASS: pre-push completed in $(( $(date +%s) - start ))s"


### PR DESCRIPTION
## The defect

`.githooks/pre-push` (#3703) checks for an empty diff with `[ -n "${DIFF//[[:space:]]/}" ]`. Bash pattern substitution over a large string is quadratic. Measured on this host:

```
${DIFF//[[:space:]]/} on 20 000 bytes:  > 40 s (timed out)
                       on 80 000 bytes:  > 40 s (timed out)
```

A push of a 74 KB three-dot population (#3315 after merging main) left the hook in state `R` with **no child processes** for over 3 minutes — pure bash CPU. On macOS there is no `timeout` binary, so the hook's own 60 s bound (`timeout -k 5 60`) never engaged; the push only went through via the hook's logged `SUTANDO_SKIP_REVIEW_CHECKS=1` bypass, after running the identical `review-checks.sh --diff` by hand on the identical population. A 10 KB population (#3655) completed in about a minute — consistent with the curve.

## The fix

```bash
grep -q '[^[:space:]]' <<< "$DIFF" || { note "empty three-dot diff …"; exit 0; }
```

Linear, same predicate. A here-string rather than `printf | grep -q`: the hook runs under `set -o pipefail`, and an early-exiting `grep -q` gives `printf` SIGPIPE, which would make every non-empty diff read as "empty" — I hit exactly that on the first draft.

## Test

`tests/pre-push-large-diff-completes.test.sh` builds a throwaway repo with `origin/main` set and a ~200 KB commit, a stub `scripts/review-checks.sh` that drains stdin and prints PASS, runs the hook as the direct child (so the bound can kill it), and requires completion within 30 s.

```
patched:   PASS: pre-push completed in 0s
original:  (killed at the 30 s bound)  — negative control
bash -n: ok   review-checks.sh --diff: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap has no .py in scope)
```

Adjacent open PR on the same file: #3706 (TustinOC) touches the PARTIAL wording, not this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
