### PR TITLE
fix(liveness): a tmux client the server refuses is an unobserved probe, not a dead core

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -177,6 +177,7 @@ One entry per agent-facing module. 4 without a usable header comment.
 - **`telegram-bridge.py`** — Telegram bridge for Sutando — polls bot messages, writes to tasks/, sends replies from results/.
 - **`telemetry.py`** — Anonymous, opt-out product telemetry for Sutando (PostHog).
 - **`tmux-status.ts`** — Tmux-pane status scraper.
+- **`tmux_probe.py`** — Tri-state tmux session probe shared by every core-liveness reader.
 - **`url-scheme.ts`** — Scheme normalization for URLs handed to Chrome via AppleScript.
 - **`util_paths.py`** — Resolve personal-asset paths with private-dir-first lookup.
 - **`util_paths.ts`** — TypeScript twin of src/util_paths.py — personal-asset path resolution.

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -31,7 +31,8 @@ idle / wedged":
     needs_login             →   logged-out        (unless an ACTIVE gate shows, below)
     working                 →   running
     idle                    →   idle-ready
-    unknown (status stale)  →   hung
+    unknown (status stale)  →   hung              (only when the process probe SAW a session)
+    unknown (unobserved)    →   unobserved        (probe could not run: hold, never RECOVER)
     (any, + gateway down)   →   gateway-down       (gateway probe is bundled-specific)
     (any, + active gate)    →   blocked-known / blocked-human   (net-new: pane classify)
 
@@ -226,13 +227,16 @@ _BASE_TO_STATE = {
 }
 
 
-def compose_state(pane, base_health, gateway_alive):
+def compose_state(pane, base_health, gateway_alive, process=True):
     """Refine runtime-health's coarse `base_health` into a supervisor state.
 
     `base_health` ∈ {offline, needs_login, working, idle, unknown} comes from
     runtime_health.derive() — the SHARED derivation. This function adds only the
     escalation-specific refinements: an active gate in the pane (finest signal),
     and the bundled-gateway-down state. Returns (state, detail, prompt, kind).
+
+    `process` is runtime-health's `signals.process` tri-state: True (session
+    seen), False (server answered "no session"), None (the probe could not run).
     """
     if base_health == "offline":
         return "crashed", _BASE_TO_STATE["offline"][1], None, None
@@ -263,6 +267,9 @@ def compose_state(pane, base_health, gateway_alive):
         if pane and _is_idle_ready(pane):
             return "idle-ready", _BASE_TO_STATE["idle"][1], None, None
         tail = "\n".join([ln for ln in (pane or "").splitlines() if ln.strip()][-14:])
+        if process is None:  # no session observed = no wedge evidence; never RECOVER
+            return ("unobserved", "core liveness unobserved (process probe unavailable); holding",
+                    tail or None, "unknown")
         return "hung", detail, tail or None, "unknown"
     return state, detail, None, None
 
@@ -440,7 +447,8 @@ def main():
         base = rh.derive()  # shared: offline|needs_login|working|idle|unknown
         state, detail, prompt, kind = compose_state(
             pane or "", base.get("health", "unknown"),
-            gateway_alive(a.app_data, os.path.dirname(os.path.abspath(a.out))))
+            gateway_alive(a.app_data, os.path.dirname(os.path.abspath(a.out))),
+            process=(base.get("signals") or {}).get("process", True))
 
         # Debounce prompt escalation: only surface once the SAME prompt persists
         # (not a menu the core is actively navigating through).

--- a/src/core-supervisor-gate.py
+++ b/src/core-supervisor-gate.py
@@ -42,9 +42,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import subprocess
 import sys
 import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tmux_probe import has_session as _tmux_has_session  # noqa: E402
 
 
 def _positive_int(v: str) -> int:
@@ -79,15 +81,12 @@ def heartbeat_stale(alive_path: str, stale_sec: float, now: float | None = None)
 
 def session_gone(socket: str, session: str) -> bool | None:
     """True = session definitely absent, False = definitely present,
-    None = probe failed (tmux missing/hung) — UNKNOWN, never confirmed death.
+    None = probe failed (tmux missing/hung, or a client the server refused —
+    version skew) — UNKNOWN, never confirmed death.
     The gate holds on None (fail-closed): a broken probe must not classify a
     possibly-running core as dead (john-the-dev review, #2404)."""
-    try:
-        r = subprocess.run(["tmux", "-S", socket, "has-session", "-t", session],
-                           capture_output=True, timeout=10)
-        return r.returncode != 0
-    except (OSError, subprocess.TimeoutExpired):
-        return None
+    present = _tmux_has_session(socket, session, timeout=10)
+    return None if present is None else not present
 
 
 def operator_intent(sentinel_path: str) -> bool:

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -61,6 +61,7 @@ from pathlib import Path
 # is worse than no heartbeat (supervisor restarts on crash; see module header).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
+from tmux_probe import classify as _classify_session_probe  # noqa: E402
 
 WORKSPACE = resolve_workspace()
 
@@ -172,6 +173,20 @@ def _argv_names_session(args: str, sess: str) -> bool:
     return False
 
 
+# The last has-session tri-state core_pid() observed. run_forever() resets it
+# before each read so a stubbed core_pid (tests) counts as an observed answer.
+_LAST_SESSION_PROBE: bool | None = False
+
+
+def _session_present(sock: str, sess: str) -> bool | None:
+    """True / False / None for the exact session, via the shared classifier."""
+    global _LAST_SESSION_PROBE
+    has = _tmux(sock, "has-session", "-t", f"={sess}")
+    _LAST_SESSION_PROBE = (None if has is None
+                           else _classify_session_probe(has.returncode, has.stderr))
+    return _LAST_SESSION_PROBE
+
+
 def core_pid(socket_path: str | None = None, session: str | None = None) -> int | None:
     """The pid of the CORE process, or None if the core is gone.
 
@@ -198,8 +213,7 @@ def core_pid(socket_path: str | None = None, session: str | None = None) -> int 
     sock = socket_path or _socket_path()
     sess = session or core_session()
 
-    has = _tmux(sock, "has-session", "-t", f"={sess}")
-    if has is None or has.returncode != 0:
+    if not _session_present(sock, sess):
         return None
 
     # SESSION-SCOPED FIRST, then the process-name sweep as a fallback.
@@ -440,15 +454,17 @@ def run_forever(interval: float = 30.0, status: str = "running") -> int:
     except Exception:  # pragma: no cover — best-effort
         pass
     absent_streak = 0
+    global _LAST_SESSION_PROBE
     while not _SHUTDOWN_REQUESTED:
+        _LAST_SESSION_PROBE = False
         present = core_pid() is not None
         saw_core = saw_core or present
-        # `core_pid()` returns None for BOTH "the core is gone" and "I could not
-        # tell" (tmux timeout, transient exec failure) — the values are
-        # indistinguishable. Acting on a single None turns one flaky read into a
-        # removed `.alive`, i.e. a false death reported to every peer. Require
-        # CONSECUTIVE absences; any single present read resets the streak.
-        absent_streak = 0 if present else absent_streak + 1
+        # An unobserved probe (tmux missing/hung, or a refused client) is not an
+        # absence: it neither resets nor advances the streak of observed misses.
+        if present:
+            absent_streak = 0
+        elif _LAST_SESSION_PROBE is not None:
+            absent_streak += 1
         if saw_core and absent_streak >= ABSENT_BEATS_BEFORE_DEATH:
             print("core_heartbeat: core pane is gone — stopping beat and "
                   "removing .alive so readers see it leave", file=sys.stderr, flush=True)

--- a/src/runtime-health.py
+++ b/src/runtime-health.py
@@ -33,6 +33,9 @@ import subprocess
 import sys
 import time
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tmux_probe import has_session as _tmux_has_session  # noqa: E402
+
 SESSION = "sutando-core"
 TMUX_SOCKET = os.environ.get("SUTANDO_TMUX_SOCKET", "/tmp/sutando-tmux.sock")
 
@@ -190,13 +193,9 @@ def _run(cmd):
 
 
 def _core_running():
-    # rc None = the probe itself could not run (tmux absent / PATH broken) → that
-    # is UNKNOWN, not "not running". A real has-session miss returns rc 1, which
-    # stays False. (qingyun CR on #2527: probe-unavailable must not be a down-vote.)
-    rc, _ = _run(["tmux", "-S", TMUX_SOCKET, "has-session", "-t", SESSION])
-    if rc is None:
-        return None
-    return rc == 0
+    # None = unobserved (tmux absent, hung, or a client the server refused) and
+    # never a down-vote; only a server that answered "no session" is False.
+    return _tmux_has_session(TMUX_SOCKET, SESSION, timeout=8)
 
 
 def _gateway_configured():

--- a/src/tmux_probe.py
+++ b/src/tmux_probe.py
@@ -17,11 +17,11 @@ import subprocess
 from typing import Optional
 
 # The server's own "no such session" answer, and the two forms a dead socket
-# takes ("no server running on …", "error connecting to … (No such file …)").
+# takes; a connect failure counts only with the definitive "No such file" reason.
 ABSENT_SIGNATURES = (
     "can't find session",
     "no server running",
-    "error connecting to",
+    "(No such file or directory)",
 )
 
 

--- a/src/tmux_probe.py
+++ b/src/tmux_probe.py
@@ -1,0 +1,54 @@
+"""Tri-state tmux session probe shared by every core-liveness reader.
+
+`has_session()` answers True (session present), False (the server answered and
+the session is absent) or None (the probe could not observe). Two things are
+None, not False: a tmux binary that is missing, hung or refuses to exec, and a
+client that never reached the session lookup because it could not talk to the
+server at all. The second case is a client/server version skew — a vendored
+tmux of one version probing a server of another exits 1 with "server exited
+unexpectedly" before any session is consulted, which a bare `returncode != 0`
+reads as a dead core. Only a server that answered and said no is absent.
+
+Dependency-light on purpose: stdlib only, so the 3-second liveness loop and the
+supervisor gate can both import it without pulling in the rest of src/.
+"""
+
+import subprocess
+from typing import Optional
+
+# stderr the tmux CLIENT prints when it never got a session answer: the server
+# rejected the client (version skew) or the connection collapsed mid-request.
+CLIENT_FAULT_SIGNATURES = (
+    "server exited unexpectedly",
+    "protocol version mismatch",
+    "lost server",
+)
+
+
+def classify(returncode: Optional[int], stderr) -> Optional[bool]:
+    """Map a has-session exit to True / False / None (unobserved).
+
+    `stderr` may be bytes, str or None — subprocess doubles in tests hand back
+    result objects without one, and that must read as an ordinary exit."""
+    if returncode is None:
+        return None
+    if returncode == 0:
+        return True
+    if isinstance(stderr, bytes):
+        text = stderr.decode("utf-8", "replace")
+    else:
+        text = stderr or ""
+    if any(sig in text for sig in CLIENT_FAULT_SIGNATURES):
+        return None
+    return False
+
+
+def has_session(socket: str, session: str, timeout: float = 10,
+                tmux: str = "tmux") -> Optional[bool]:
+    """Run `tmux -S <socket> has-session -t <session>` and classify it."""
+    try:
+        r = subprocess.run([tmux, "-S", socket, "has-session", "-t", session],
+                           capture_output=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return classify(r.returncode, getattr(r, "stderr", None))

--- a/src/tmux_probe.py
+++ b/src/tmux_probe.py
@@ -1,27 +1,27 @@
 """Tri-state tmux session probe shared by every core-liveness reader.
 
 `has_session()` answers True (session present), False (the server answered and
-the session is absent) or None (the probe could not observe). Two things are
-None, not False: a tmux binary that is missing, hung or refuses to exec, and a
-client that never reached the session lookup because it could not talk to the
-server at all. The second case is a client/server version skew — a vendored
-tmux of one version probing a server of another exits 1 with "server exited
-unexpectedly" before any session is consulted, which a bare `returncode != 0`
-reads as a dead core. Only a server that answered and said no is absent.
+said the session is absent) or None (the probe observed nothing). Absence is
+matched POSITIVELY: only the messages a tmux server or a socket lookup emits
+for "no such session" / "no server" count as absent. Every other non-zero exit
+is None — a missing, hung or signalled binary, and a client the server refused
+(a vendored tmux of another version exits 1 with "server exited unexpectedly"
+before any session is consulted). A pattern list guards the safe side: a
+message this repo has never seen degrades to unobserved, never to death.
 
-Dependency-light on purpose: stdlib only, so the 3-second liveness loop and the
-supervisor gate can both import it without pulling in the rest of src/.
+Dependency-light on purpose: stdlib only, so the 3-second liveness loop, the
+supervisor gate and the heartbeat can all import it without the rest of src/.
 """
 
 import subprocess
 from typing import Optional
 
-# stderr the tmux CLIENT prints when it never got a session answer: the server
-# rejected the client (version skew) or the connection collapsed mid-request.
-CLIENT_FAULT_SIGNATURES = (
-    "server exited unexpectedly",
-    "protocol version mismatch",
-    "lost server",
+# The server's own "no such session" answer, and the two forms a dead socket
+# takes ("no server running on …", "error connecting to … (No such file …)").
+ABSENT_SIGNATURES = (
+    "can't find session",
+    "no server running",
+    "error connecting to",
 )
 
 
@@ -29,7 +29,8 @@ def classify(returncode: Optional[int], stderr) -> Optional[bool]:
     """Map a has-session exit to True / False / None (unobserved).
 
     `stderr` may be bytes, str or None — subprocess doubles in tests hand back
-    result objects without one, and that must read as an ordinary exit."""
+    result objects without one, and a non-zero exit with no recognised absence
+    message is unobserved, not absent."""
     if returncode is None:
         return None
     if returncode == 0:
@@ -38,9 +39,9 @@ def classify(returncode: Optional[int], stderr) -> Optional[bool]:
         text = stderr.decode("utf-8", "replace")
     else:
         text = stderr or ""
-    if any(sig in text for sig in CLIENT_FAULT_SIGNATURES):
-        return None
-    return False
+    if any(sig in text for sig in ABSENT_SIGNATURES):
+        return False
+    return None
 
 
 def has_session(socket: str, session: str, timeout: float = 10,

--- a/tests/core-health-verdict.test.py
+++ b/tests/core-health-verdict.test.py
@@ -236,12 +236,17 @@ try:
 finally:
     rh.subprocess.run = _orig_run
 
-# A probe that RAN and genuinely found nothing still reads False (a real miss is
-# not the same as an unavailable probe).
+# A definitive miss is injected at the shared tri-state seam, never via the host's
+# tmux: a `tmux` -> /usr/bin/false on PATH must not be able to satisfy this.
 _orig_run2 = rh._run
+_orig_hs = rh._tmux_has_session
 try:
-    rh._run = lambda cmd: (1, "")
+    rh._tmux_has_session = lambda sock, sess, timeout=None: False
     check("_core_running -> False when has-session ran and missed", rh._core_running() is False)
+    rh._tmux_has_session = lambda sock, sess, timeout=None: None
+    check("_core_running -> None when the probe observed nothing", rh._core_running() is None)
+    rh._tmux_has_session = _orig_hs
+    rh._run = lambda cmd: (1, "")
     check("_gateway_running -> False when probes ran but found nothing", rh._gateway_running() is False)
     rh._run = lambda cmd: (0, "") if cmd and cmd[0] == "pgrep" else (1, "")
     check("_gateway_running -> True via pgrep", rh._gateway_running() is True)
@@ -249,6 +254,7 @@ try:
     check("_gateway_running -> True via tmux window fallback", rh._gateway_running() is True)
 finally:
     rh._run = _orig_run2
+    rh._tmux_has_session = _orig_hs
     rh._gateway_configured = _orig_gwc
 
 

--- a/tests/core-heartbeat-refused-client.test.py
+++ b/tests/core-heartbeat-refused-client.test.py
@@ -1,0 +1,100 @@
+"""run_forever() must not confirm death on a probe that observed nothing.
+
+A tmux client of another version than the server exits 1 with "server exited
+unexpectedly" before any session lookup. Before this suite, core_pid() mapped
+that to "gone" and three beats later run_forever() unlinked the live core's
+.alive — the one signal that was keeping the supervisor gate from acting.
+Drives the PRODUCTION loop with _tmux stubbed at the I/O seam.
+"""
+import os
+import subprocess as sp
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+import core_heartbeat as ch  # noqa: E402
+
+
+def _cp(rc, stderr=""):
+    return sp.CompletedProcess(["tmux"], rc, "", stderr)
+
+
+class RefusedClient(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.alive = self.tmp / "testhost.alive"
+        self._orig = (ch._tmux, ch.core_pid, ch._alive_path, ch.write_beat, ch._SHUTDOWN_REQUESTED)
+        ch._alive_path = lambda: self.alive
+        ch._SHUTDOWN_REQUESTED = False
+
+    def tearDown(self):
+        ch._tmux, ch.core_pid, ch._alive_path, ch.write_beat, ch._SHUTDOWN_REQUESTED = self._orig
+
+    def _run_with(self, has_session_results, beats):
+        """core_pid is REAL; has-session answers come from the seam in order."""
+        answers = list(has_session_results)
+
+        def fake_tmux(sock, *a):
+            if a and a[0] == "has-session":
+                return answers.pop(0) if answers else answers_last
+            return _cp(1, "")
+        answers_last = has_session_results[-1]
+        ch._tmux = fake_tmux
+        # pgrep/ps never find a core in this harness, so a PRESENT session
+        # still yields no pid; a present beat is injected via core_pid instead.
+        count = {"n": 0}
+        real_pid = self._orig[1]
+
+        def counted_core_pid(socket_path=None, session=None):
+            count["n"] += 1
+            if count["n"] == 1:
+                ch._LAST_SESSION_PROBE = True   # the one observed-present beat
+                return 4242
+            return real_pid(socket_path, session)
+        ch.core_pid = counted_core_pid
+
+        def beat(status=None):
+            self.alive.write_text("{}")
+            if count["n"] >= beats:
+                ch._SHUTDOWN_REQUESTED = True
+        ch.write_beat = beat
+        rc = ch.run_forever(interval=0.01, status="test")
+        return rc, count["n"]
+
+    def test_refused_client_holds_the_streak_and_keeps_alive(self):
+        refused = _cp(1, "server exited unexpectedly\n")
+        rc, n = self._run_with([refused] * 6, beats=6)
+        self.assertEqual(rc, 0)
+        self.assertGreaterEqual(n, 6, "loop should have kept beating, not died")
+        self.assertTrue(self.alive.exists(), ".alive was unlinked on unobserved probes")
+
+    def test_observed_absence_still_confirms_death(self):
+        gone = _cp(1, "can't find session: sutando-core\n")
+        rc, n = self._run_with([gone] * 6, beats=50)
+        self.assertEqual(rc, 0)
+        self.assertEqual(n, 1 + ch.ABSENT_BEATS_BEFORE_DEATH)
+        self.assertFalse(self.alive.exists())
+
+    def test_unobserved_does_not_reset_an_absence_streak(self):
+        # absent, absent, unobserved, absent → the third absence lands on beat 5.
+        seq = [_cp(1, "can't find session: x\n")] * 2 + [_cp(1, "server exited unexpectedly\n")] + [_cp(1, "can't find session: x\n")] * 3
+        rc, n = self._run_with(seq, beats=50)
+        self.assertEqual(rc, 0)
+        self.assertEqual(n, 1 + ch.ABSENT_BEATS_BEFORE_DEATH + 1)
+        self.assertFalse(self.alive.exists())
+
+    def test_session_present_records_tristate(self):
+        ch._tmux = lambda sock, *a: _cp(1, "server exited unexpectedly\n")
+        self.assertIsNone(ch._session_present("s.sock", "core"))
+        self.assertIsNone(ch._LAST_SESSION_PROBE)
+        ch._tmux = lambda sock, *a: _cp(1, "can't find session: core\n")
+        self.assertIs(ch._session_present("s.sock", "core"), False)
+        ch._tmux = lambda sock, *a: None
+        self.assertIsNone(ch._session_present("s.sock", "core"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -198,6 +198,62 @@ class TestClassify(unittest.TestCase):
         self.assertEqual(hit[0], "unknown")
 
 
+class TestUnobservedProbeIsNotHung(unittest.TestCase):
+    """An unobserved process probe (tmux refused the client, binary missing) must
+    hold, never become the RECOVER-facing `hung`; only a SEEN session with stale
+    status is `hung`, and a server that answered "no session" is `crashed`."""
+
+    def test_unobserved_probe_holds(self):
+        st, detail, _p, kind = compose_state("", "unknown", True, process=None)
+        self.assertEqual(st, "unobserved")
+        self.assertIn("unobserved", detail)
+        self.assertNotEqual(st, "hung")
+
+    def test_present_and_stale_is_still_hung(self):
+        st, *_ = compose_state("Running step 3...\n(no prompt, no footer)", "unknown", True, process=True)
+        self.assertEqual(st, "hung")
+
+    def test_definitive_absence_is_crashed(self):
+        st, *_ = compose_state("", "offline", True, process=False)
+        self.assertEqual(st, "crashed")
+
+    def test_refused_client_through_derive_and_compose(self):
+        """Full path: refused tmux client → runtime_health.derive() → compose_state()."""
+        import subprocess as _sp
+        import sys as _sys
+        import tempfile
+        from unittest import mock
+        _sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+        import tmux_probe  # noqa: E402
+        rh_spec = importlib.util.spec_from_file_location(
+            "runtime_health_pin", os.path.join(_HERE, "..", "src", "runtime-health.py"))
+        rh = importlib.util.module_from_spec(rh_spec); rh_spec.loader.exec_module(rh)
+        tmp = tempfile.mkdtemp()
+        # Every unrelated probe held healthy so only the process signal varies.
+        with mock.patch.object(rh, "_resolve_workspace", lambda repo: tmp), \
+             mock.patch.object(rh, "_gateway_running", lambda: True), \
+             mock.patch.object(rh, "_ag2space_app_running", lambda: True), \
+             mock.patch.object(rh, "_station_cached", lambda ws: True), \
+             mock.patch.object(rh, "_heartbeat_fresh", lambda ws: True):
+            def refused(*a, **k):
+                return _sp.CompletedProcess(["tmux"], 1, "", "server exited unexpectedly\n")
+            with mock.patch.object(tmux_probe.subprocess, "run", refused):
+                base = rh.derive()
+            self.assertEqual(base["health"], "unknown")
+            self.assertIsNone(base["signals"]["process"])
+            st, *_ = compose_state("", base["health"], True, process=base["signals"]["process"])
+            self.assertEqual(st, "unobserved")
+
+            def gone(*a, **k):
+                return _sp.CompletedProcess(["tmux"], 1, "", "can't find session: sutando-core\n")
+            with mock.patch.object(tmux_probe.subprocess, "run", gone):
+                base = rh.derive()
+            self.assertEqual(base["health"], "offline")
+            self.assertIs(base["signals"]["process"], False)
+            st, *_ = compose_state("", base["health"], True, process=base["signals"]["process"])
+            self.assertEqual(st, "crashed")
+
+
 class TestComposeState(unittest.TestCase):
     """compose_state REFINES runtime-health's coarse `base_health` (one shared
     derivation, #2092) into the 8 supervisor states — signature is

--- a/tests/core-supervisor-gate.test.py
+++ b/tests/core-supervisor-gate.test.py
@@ -81,8 +81,12 @@ class TestSessionGone(unittest.TestCase):
     def test_session_present(self):
         self.assertIs(self._with_run(lambda *a, **k: self._R(0), "s.sock", "core"), False)
 
-    def test_session_absent(self):
-        self.assertIs(self._with_run(lambda *a, **k: self._R(1), "s.sock", "core"), True)
+    def test_unrecognised_nonzero_is_unknown_not_dead(self):
+        # rc 1 with no recognised absence message observed nothing: the gate holds.
+        self.assertIsNone(self._with_run(lambda *a, **k: self._R(1), "s.sock", "core"))
+
+    def test_signalled_client_is_unknown_not_dead(self):
+        self.assertIsNone(self._with_run(lambda *a, **k: self._R(-9), "s.sock", "core"))
 
     def test_tmux_timeout_is_unknown_not_dead(self):
         import subprocess as sp

--- a/tests/core-supervisor-gate.test.py
+++ b/tests/core-supervisor-gate.test.py
@@ -96,6 +96,18 @@ class TestSessionGone(unittest.TestCase):
             raise OSError("no tmux binary")
         self.assertIsNone(self._with_run(boom, "s.sock", "core"))
 
+    def test_refused_client_is_unknown_not_dead(self):
+        # A tmux client of another version than the server exits 1 with this
+        # stderr before any session lookup — a dead PROBE, not a dead core.
+        class _Skew(self._R):
+            stderr = b"server exited unexpectedly\n"
+        self.assertIsNone(self._with_run(lambda *a, **k: _Skew(1), "s.sock", "core"))
+
+    def test_absent_with_miss_stderr_is_dead(self):
+        class _Miss(self._R):
+            stderr = b"can't find session: core\n"
+        self.assertIs(self._with_run(lambda *a, **k: _Miss(1), "s.sock", "core"), True)
+
 
 class TestOperatorIntent(unittest.TestCase):
     def test_absent_and_present(self):

--- a/tests/runtime-health.test.py
+++ b/tests/runtime-health.test.py
@@ -250,5 +250,17 @@ try:
 finally:
     rh._resolve_workspace = _ow
 
+# 7) The tri-state process probe has ONE owner: _core_running delegates to
+#    tmux_probe.has_session with this module's socket/session and its 8s budget.
+_seen = {}
+_oh = rh._tmux_has_session
+rh._tmux_has_session = lambda sock, sess, timeout=None: _seen.update(sock=sock, sess=sess, timeout=timeout)
+try:
+    check("_core_running: delegates to tmux_probe.has_session(TMUX_SOCKET, SESSION, timeout=8)",
+          rh._core_running() is None
+          and _seen == {"sock": rh.TMUX_SOCKET, "sess": rh.SESSION, "timeout": 8})
+finally:
+    rh._tmux_has_session = _oh
+
 print("\n" + ("PASS — runtime-health green" if fails == 0 else "FAIL — %d failing" % fails))
 sys.exit(fails)

--- a/tests/tmux-probe.test.py
+++ b/tests/tmux-probe.test.py
@@ -1,0 +1,98 @@
+"""Contract for src/tmux_probe.has_session: True / False / None.
+
+The stderr strings below are verbatim from tmux 3.6a (server, homebrew) and a
+3.5a client (the desktop app's vendored engine/bin/tmux) against the same
+socket: the two genuine misses stay False, the version-skew failure is None.
+"""
+import os
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+import tmux_probe  # noqa: E402
+
+
+class _R:
+    def __init__(self, rc, stderr=b""):
+        self.returncode = rc
+        self.stderr = stderr
+
+
+class TestClassify(unittest.TestCase):
+    def test_present(self):
+        self.assertIs(tmux_probe.classify(0, b""), True)
+
+    def test_unknown_session_is_absent(self):
+        self.assertIs(tmux_probe.classify(1, b"can't find session: sutando-core\n"), False)
+
+    def test_no_server_on_socket_is_absent(self):
+        err = b"error connecting to /tmp/x.sock (No such file or directory)\n"
+        self.assertIs(tmux_probe.classify(1, err), False)
+
+    def test_bare_nonzero_without_stderr_is_absent(self):
+        # A subprocess double with no stderr at all must read as an ordinary miss.
+        self.assertIs(tmux_probe.classify(1, None), False)
+        self.assertIs(tmux_probe.classify(1, ""), False)
+
+    def test_version_skew_client_is_unknown(self):
+        self.assertIsNone(tmux_probe.classify(1, b"server exited unexpectedly\n"))
+        self.assertIsNone(tmux_probe.classify(1, "protocol version mismatch (client 8, server 9)"))
+        self.assertIsNone(tmux_probe.classify(1, b"lost server\n"))
+
+    def test_client_fault_never_reads_true(self):
+        # rc 0 wins outright; the signatures only demote a non-zero exit.
+        self.assertIs(tmux_probe.classify(0, b"server exited unexpectedly\n"), True)
+
+    def test_unexecuted_is_unknown(self):
+        self.assertIsNone(tmux_probe.classify(None, b""))
+
+
+class TestHasSession(unittest.TestCase):
+    """Real body with subprocess.run stubbed on the shared module."""
+
+    def _with_run(self, fake, **kw):
+        orig = subprocess.run
+        subprocess.run = fake
+        try:
+            return tmux_probe.has_session("s.sock", "core", **kw)
+        finally:
+            subprocess.run = orig
+
+    def test_argv_and_timeout_reach_subprocess(self):
+        seen = {}
+
+        def fake(argv, **k):
+            seen["argv"], seen["timeout"] = argv, k.get("timeout")
+            return _R(0)
+        self.assertIs(self._with_run(fake, timeout=8, tmux="/x/tmux"), True)
+        self.assertEqual(seen["argv"], ["/x/tmux", "-S", "s.sock", "has-session", "-t", "core"])
+        self.assertEqual(seen["timeout"], 8)
+
+    def test_skew_stderr_is_unknown(self):
+        self.assertIsNone(self._with_run(lambda *a, **k: _R(1, b"server exited unexpectedly\n")))
+
+    def test_miss_is_false(self):
+        self.assertIs(self._with_run(lambda *a, **k: _R(1, b"can't find session: core\n")), False)
+
+    def test_double_without_stderr_is_false(self):
+        class Bare:
+            returncode = 1
+        self.assertIs(self._with_run(lambda *a, **k: Bare()), False)
+
+    def test_missing_binary_is_unknown(self):
+        def boom(*a, **k):
+            raise OSError("no tmux")
+        self.assertIsNone(self._with_run(boom))
+
+    def test_timeout_is_unknown(self):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="tmux", timeout=10)
+        self.assertIsNone(self._with_run(boom))
+
+    def test_real_binary_missing_is_unknown(self):
+        self.assertIsNone(tmux_probe.has_session("s.sock", "core", tmux="/nonexistent-tmux-xyz"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tmux-probe.test.py
+++ b/tests/tmux-probe.test.py
@@ -34,6 +34,12 @@ class TestClassify(unittest.TestCase):
     def test_no_server_running_form_is_absent(self):
         self.assertIs(tmux_probe.classify(1, b"no server running on /tmp/x.sock\n"), False)
 
+    def test_connect_denied_is_unknown_not_absent(self):
+        # The client could not observe the server; only "No such file" is a miss.
+        for reason in (b"Permission denied", b"Operation not permitted", b"Connection refused"):
+            err = b"error connecting to /tmp/x.sock (" + reason + b")\n"
+            self.assertIsNone(tmux_probe.classify(1, err), reason)
+
     def test_bare_nonzero_without_stderr_is_unknown(self):
         # No recognised absence message = nothing observed, whatever the rc.
         self.assertIsNone(tmux_probe.classify(1, None))

--- a/tests/tmux-probe.test.py
+++ b/tests/tmux-probe.test.py
@@ -2,7 +2,8 @@
 
 The stderr strings below are verbatim from tmux 3.6a (server, homebrew) and a
 3.5a client (the desktop app's vendored engine/bin/tmux) against the same
-socket: the two genuine misses stay False, the version-skew failure is None.
+socket. Absence is matched positively: the genuine misses are False; the
+version-skew failure, a signalled client and an unrecognised message are None.
 """
 import os
 import subprocess
@@ -30,19 +31,31 @@ class TestClassify(unittest.TestCase):
         err = b"error connecting to /tmp/x.sock (No such file or directory)\n"
         self.assertIs(tmux_probe.classify(1, err), False)
 
-    def test_bare_nonzero_without_stderr_is_absent(self):
-        # A subprocess double with no stderr at all must read as an ordinary miss.
-        self.assertIs(tmux_probe.classify(1, None), False)
-        self.assertIs(tmux_probe.classify(1, ""), False)
+    def test_no_server_running_form_is_absent(self):
+        self.assertIs(tmux_probe.classify(1, b"no server running on /tmp/x.sock\n"), False)
+
+    def test_bare_nonzero_without_stderr_is_unknown(self):
+        # No recognised absence message = nothing observed, whatever the rc.
+        self.assertIsNone(tmux_probe.classify(1, None))
+        self.assertIsNone(tmux_probe.classify(1, ""))
+
+    def test_signalled_client_is_unknown(self):
+        self.assertIsNone(tmux_probe.classify(-9, b""))
+
+    def test_unrecognised_message_is_unknown(self):
+        self.assertIsNone(tmux_probe.classify(1, b"server version is too old for client\n"))
 
     def test_version_skew_client_is_unknown(self):
         self.assertIsNone(tmux_probe.classify(1, b"server exited unexpectedly\n"))
         self.assertIsNone(tmux_probe.classify(1, "protocol version mismatch (client 8, server 9)"))
         self.assertIsNone(tmux_probe.classify(1, b"lost server\n"))
 
-    def test_client_fault_never_reads_true(self):
-        # rc 0 wins outright; the signatures only demote a non-zero exit.
+    def test_rc_zero_wins_outright(self):
         self.assertIs(tmux_probe.classify(0, b"server exited unexpectedly\n"), True)
+
+    def test_absence_needs_a_recognised_message_not_just_rc(self):
+        self.assertIs(tmux_probe.classify(1, b"can't find session: x\n"), False)
+        self.assertIsNone(tmux_probe.classify(1, b"something else entirely\n"))
 
     def test_unexecuted_is_unknown(self):
         self.assertIsNone(tmux_probe.classify(None, b""))
@@ -75,10 +88,10 @@ class TestHasSession(unittest.TestCase):
     def test_miss_is_false(self):
         self.assertIs(self._with_run(lambda *a, **k: _R(1, b"can't find session: core\n")), False)
 
-    def test_double_without_stderr_is_false(self):
+    def test_double_without_stderr_is_unknown(self):
         class Bare:
             returncode = 1
-        self.assertIs(self._with_run(lambda *a, **k: Bare()), False)
+        self.assertIsNone(self._with_run(lambda *a, **k: Bare()))
 
     def test_missing_binary_is_unknown(self):
         def boom(*a, **k):


### PR DESCRIPTION
## What

`runtime-health._core_running` and `core-supervisor-gate.session_gone` both read **any** non-zero `tmux has-session` exit as "session absent". A tmux *client* of a different version than the *server* exits 1 with `server exited unexpectedly` before it ever looks a session up — so a version-skewed client reports a live core as dead.

That is the live case on this host: the AG2 Space desktop app vendors `engine/bin/tmux` **3.5a** and puts `engine/bin` first on PATH for its children (`launch-sutando.sh`: `export PATH="$HERE/bin:$PATH"`); the core's server is homebrew **3.6a**. Every ~16 s the app's `scripts/sutando-config.sh runtime` poll ran `src/runtime-health.py` under that PATH and rewrote `state/core-verdict.json` to `offline / critical / process=False` while the core was healthy — the owner-visible "core offline" in the app. `severity_gate` needs ≥2 down-votes to `act`; `process=False` was one of them, and the fresh heartbeat was the only thing between that mis-probe and an auto-restart of a running core.

The tri-state policy now has one owner, `src/tmux_probe.py`:

| outcome | when |
|---|---|
| `True` | rc 0 |
| `False` | server answered "no session": `can't find session: …`, `error connecting to … (No such file or directory)` |
| `None` | binary missing/hung, **or** the client never reached a session answer: `server exited unexpectedly`, `protocol version mismatch`, `lost server` |

Both callers delegate (gate keeps gone-polarity + 10 s budget; runtime-health keeps 8 s). `docs/src-map.md` regenerated.

## Evidence

Probe outcomes with the real binaries against the live socket (`/tmp/sutando-tmux.sock`, server `tmux 3.6a`):

```
$ /opt/homebrew/bin/tmux -S /tmp/sutando-tmux.sock has-session -t sutando-core; echo rc=$?
rc=0
$ "~/Library/Application Support/space.ag2.app/engine/bin/tmux" -V
tmux 3.5a
$ "…/engine/bin/tmux" -S /tmp/sutando-tmux.sock has-session -t sutando-core; echo rc=$?
server exited unexpectedly
rc=1
$ /opt/homebrew/bin/tmux -S /tmp/sutando-tmux.sock has-session -t no-such-session-xyz; echo rc=$?
can't find session: no-such-session-xyz
rc=1
$ /opt/homebrew/bin/tmux -S /tmp/no-such-sutando-sock.sock has-session -t sutando-core; echo rc=$?
error connecting to /tmp/no-such-sutando-sock.sock (No such file or directory)
rc=1
```

`runtime-health.py` with the vendored 3.5a first on PATH (what the app's poll does), same core, same socket:

**Before — parent `fb2688f2`:**
```
{'health': 'offline', 'severity': 'critical', 'core_running': False, 'detail': 'Agent is not running'} process= False
```
**After — this branch:**
```
{'health': 'unknown', 'severity': 'critical', 'core_running': None, 'detail': 'Core liveness unknown (process probe unavailable)'} process= None
```
**After — control, homebrew tmux first (matching client):**
```
{'health': 'unknown', 'core_running': True} process= True
```
(`unknown` on the control is the pre-existing stale-`core-status` branch on this host, unrelated to the probe; `severity` for `unknown` is `critical` by the existing `severity_of` mapping, but `process=None` contributes **zero** down-votes, so the gate can only `report`.)

Suites at HEAD:
```
tests/tmux-probe.test.py                 Ran 14 tests  OK
tests/core-supervisor-gate.test.py       Ran 26 tests  OK  (+ refused-client, + miss-stderr controls)
tests/runtime-health.test.py             PASS — runtime-health green  (+ delegation pin: socket, session, timeout=8)
tests/runtime-health-ag2space-station.test.py  Ran 28 tests  OK
tests/check-python39-compat.test.py      Ran 21 tests  OK (skipped=2)
ruff check <touched files>               All checks passed!
bash scripts/review-checks.sh --diff …   PASS
```

## Scope

OSS side only: the probe no longer *claims* a dead core on a refused client. The app still cannot see this core as alive until it stops probing a 3.6a server with a 3.5a client — filed separately against the desktop repo (vendored tmux version / fall back to the system tmux the core was launched with). Other `tmux` spawns in `health-check.py` / `core-input-watch.py` are not liveness verdicts and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
