### PR TITLE
docs(proactive-loop): compute the surface hash, then commit only after sending

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -368,10 +368,16 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    Hash it with:
 
    ```bash
+   # 1. COMPUTE — no --commit, so nothing is stamped and you are free to decline.
+   echo '[["3166","owner"],["3274","owner"]]' |
+     python3 skills/proactive-loop/scripts/idle-surface-hash.py \
+       --state "$WORKSPACE/state/idle-streak.json"
+   # -> post <hash>   (changed set: surface it)   |   quiet <hash>  (unchanged)
+
+   # 2. Post the message. THEN, and only then, stamp the set as surfaced:
    echo '[["3166","owner"],["3274","owner"]]' |
      python3 skills/proactive-loop/scripts/idle-surface-hash.py \
        --state "$WORKSPACE/state/idle-streak.json" --commit
-   # -> post <hash>   (changed set: surface it)   |   quiet <hash>  (unchanged)
    ```
 
    ⚠⚠ **AND DO NOT BUILD THE LIST EITHER — pipe it from the record.** The hash script takes the
@@ -412,6 +418,13 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    still listed as "waiting only on the owner merge" **17 hours after it merged** — an FYI surface
    would have reported a blocker that no longer existed. A PR-backed held item is one `gh pr view`
    away from being checkable; retire it through `--remove <id> --reason "<why>"`.
+
+   ⚠ **Two steps, because `--commit` stamps at HASH time, not at SEND time.** The single-call form
+   is correct only when the send is unconditional — and it is not: the guardrails below tell you to
+   stay quiet when the owner is away, and step 1 tells you to keep generating instead. Committing
+   before deciding records a delivery that never happened, and the next genuinely-new change to the
+   same set is then deduped into silence — the failure this guard exists to prevent, pointing the
+   wrong way. The state keeps no history, so the stamp cannot be undone.
 
    ⚠ **Do not compute this hash yourself.** The rule used to live here as "sha1 the held-list", and an
    agent handed that instruction hashes the sentence it was about to send — so re-wording the same


### PR DESCRIPTION
## The defect

`idle-surface-hash.py --commit` stamps `last_surfaced_hash` at **hash time, not at send time**, and the documented example pairs compute and commit in a single call:

```bash
echo '[["3166","owner"],["3274","owner"]]' |
  python3 skills/proactive-loop/scripts/idle-surface-hash.py \
    --state "$WORKSPACE/state/idle-streak.json" --commit
```

That is correct only when the send is unconditional. It is not. The guardrails four lines below tell the agent to stay quiet when the owner is away, and sub-step 1 tells it to keep generating rather than surface. So the example prescribes committing *before* the decision it is meant to gate.

**Consequence when the agent declines to send:** the state records a delivery that never happened, and the next genuinely-new change to that same set is deduped into silence — the exact failure the guard exists to prevent, pointing the wrong way. The state file keeps no prior hash, so the stamp cannot be undone once written.

## Why this is a real path, not a hypothetical

It has bitten twice on this host, both times in the same shape — the guard returned `post`, the agent correctly judged that sending would be noise (owner idle; or the content had already reached them minutes earlier by another path), and the commit had already run.

## The fix is documentation only — the script already supports the safe form

Omitting `--commit` prints the identical verdict and leaves the state untouched. Measured against a copied state file:

```
without --commit:   post cc3567848ce2b550     probe state: unchanged
with    --commit:   post cc3567848ce2b550     probe state: stamped cc3567848ce2b550
```

So no code change is needed. The example becomes two steps — compute, decide, then stamp only after the message has actually gone — with a note naming why the single-call form is unsafe here.

## Scope

One example block plus one warning paragraph in `skills/proactive-loop/SKILL.md`. No script change, no behaviour change, nothing else touched.

## Testing

`review-checks.sh --diff` on the PR range: `PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)` — PARTIAL because the diff is Markdown only and `prose_exts` is `.py`, so prose-cap had nothing in scope. Reported rather than described, since PARTIAL is not PASS.

Not verified: I have not exercised a full loop pass end-to-end against the edited text; the claim rests on the measured flag behaviour above and on reading the surrounding guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
