### PR TITLE
test(sparrow-guard): address the withheld record by its id, not by glob order

### DIFF
--- a/tests/sparrow-result-guard.test.py
+++ b/tests/sparrow-result-guard.test.py
@@ -19,6 +19,7 @@ import urllib.error
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
 m = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+_guard = importlib.import_module("ag2_sparrow.team_result_guard")
 
 fail = 0
 
@@ -154,12 +155,16 @@ with tempfile.TemporaryDirectory() as td:
     write_task(tasks, "task-notice-one", "team", **notice_fields)
     first_notice, first_reason = m._guarded_result_body(
         "task-notice-one", BODY_WITH_MARKERS)
+    # task-team1 above was withheld too, so two records exist here; glob order
+    # is the filesystem's, so the record must be addressed by its own id.
     review_files = list((m._STATE / "withheld-team-results").glob("wr_*.json"))
+    review_file = (m._STATE / "withheld-team-results"
+                   / f"{_guard.withheld_review_id('task-notice-one')}.json")
     check(first_reason is not None
           and any(a.kind == "skip" for a in m.parse_markers(first_notice).actions),
           "first withhold closes the lease without posting into the shared room")
-    check(bool(review_files), "first withhold persists an owner-review artifact")
-    review_record = json.loads(review_files[0].read_text(encoding="utf-8"))
+    check(review_file.is_file(), "first withhold persists an owner-review artifact")
+    review_record = json.loads(review_file.read_text(encoding="utf-8"))
     check(review_record.get("context", {}).get("room_name") == "Design Room",
           "the bridge retains the human-readable room name for private review")
 


### PR DESCRIPTION
## What

`tests/sparrow-result-guard.test.py`'s private-review case asserted on `review_files[0]` from a glob over `wr_*.json`. But `task-team1` earlier in the same run is withheld too, so **two** records exist at that point and only `task-notice-one`'s carries `room_name`. Which one is `[0]` is the filesystem's readdir order — on ext4 that follows a per-filesystem htree seed, so the case fails on some ubuntu runners and passes on others, and always passes on APFS here.

The record's filename is `withheld_review_id(task_id)`, so the test now opens exactly its own record (`_guard = ag2_sparrow.team_result_guard`). The glob list is kept only for the later count check. Test-only; no production change.

## Where it bit

Within one hour today, on untouched files, while main's 14:16Z run (8c3934a8) was green:
- #3710 `diff coverage >= 95% (python)`: `✖ test failed under instrumentation: tests/sparrow-result-guard.test.py` → `FAIL: the bridge retains the human-readable room name for private review`
- #3418 `python standalone tests`: `##[error]FAILED: tests/sparrow-result-guard.test.py (exit 1)`

## Evidence

Instrumented run at main 7ed47a6a, printing the withheld dir at the assertion point:
```
PROBE wr_9ccd4554cb015608.json task_id= task-team1 room_name=
PROBE wr_aad0ae0ad0877614.json task_id= task-notice-one room_name= Design Room
```

Deterministic control — the suite run with `pathlib.Path.glob` patched to return reversed order (stands in for an ext4 runner with a different seed):

| | parent 7ed47a6a | HEAD d4d43df9 |
|---|---|---|
| plain suite | rc 0 | rc 0 |
| reversed-glob | **rc 1** — `FAIL: the bridge retains the human-readable room name for private review` | rc 0 |

`ruff check` clean; `bash scripts/review-checks.sh --diff` PASS.

Not a live path. Unrelated to #3527 (outbox-race timeout under coverage), which is the other red on these PRs today.
