### PR TITLE
docs(review): a witness no host can produce is a first-deploy gate, not a merge gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@ please do — it saves a lot of round-trips.
 - [ ] Test added (or N/A explained below)
 - [ ] **Before/after evidence pasted below** — the actual command output for both states, not a description of it (this is the #1 reason PRs bounce)
 - [ ] Every claim in this PR body is verifiable from the diff or the pasted output — no statement the reviewer can't check
-- [ ] **Live path?** If this touches a bridge, network path, delivery loop, or startup, I included a real post-restart round-trip — unit tests / harnesses alone are not accepted for these
+- [ ] **Live path?** If this touches a bridge, network path, delivery loop, or startup, I included a real post-restart round-trip — unit tests / harnesses alone are not accepted for these (or: no witness target can be provisioned, the installer failure is pasted, and the owed witness is filed with `src/witness_owed.py open` per REVIEW.md lesson 15)
 - [ ] **Stacked PR?** I named the parent + merge order and will rebase/update + rerun full checks after the parent lands (or N/A)
 - [ ] Scanned added lines for host-specific hardcoded paths and inline home/workspace fallbacks; fixtures are narrowly scoped
 - [ ] If this PR adds or edits a CI workflow, I confirmed it actually runs on this PR (see the Checks tab — a `branches:` filter can silently exclude a stacked PR)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ and "After opening the PR" sections. The short checklist:
 - Single concern per PR; no bundled refactors
 - Confirm the bug exists on `upstream/main` before adding a fix
 - **Paste before/after evidence** — the actual command output at the parent commit and at HEAD, not a description of it. This is the #1 change-request on this repo. Every claim in the body must be checkable from the diff or that output.
-- **Live path (bridge / network / delivery loop / startup)?** Include a real post-restart round trip, not just unit tests — reviewers reject harness-only proof for these.
+- **Live path (bridge / network / delivery loop / startup)?** Include a real post-restart round trip, not just unit tests — reviewers reject harness-only proof for these. If no witness target can be provisioned, file the owed witness with `src/witness_owed.py open` (REVIEW.md lesson 15) — `self-upgrade` refuses to activate a head that still owes one.
 - **Stacked PR?** Name the parent and merge order; after the parent lands, rebase/update the child and rerun its full checks.
 - Scan added lines for hardcoded host paths and inline path fallbacks; production code must use the repo's path helpers.
 - `license/cla` missing after a push or `update-branch`? It is SHA-bound and the auto-recheck comment is unreliable — **close+reopen the PR** is the retry that works. Full ABSENT-vs-FAILING triage: `CONTRIBUTING.md` → "Check the CLA status"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ and "After opening the PR" sections. The short checklist:
 - Single concern per PR; no bundled refactors
 - Confirm the bug exists on `upstream/main` before adding a fix
 - **Paste before/after evidence** — the actual command output at the parent commit and at HEAD, not a description of it. This is the #1 change-request on this repo. Every claim in the body must be checkable from the diff or that output.
-- **Live path (bridge / network / delivery loop / startup)?** Include a real post-restart round trip, not just unit tests — reviewers reject harness-only proof for these.
+- **Live path (bridge / network / delivery loop / startup)?** Include a real post-restart round trip, not just unit tests — reviewers reject harness-only proof for these. If no witness target can be provisioned, file the owed witness with `src/witness_owed.py open` (REVIEW.md lesson 15) — `self-upgrade` refuses to activate a head that still owes one.
 - **Stacked PR?** Name the parent and merge order; after the parent lands, rebase/update the child and rerun its full checks.
 - Scan added lines for hardcoded host paths and inline path fallbacks; production code must use the repo's path helpers.
 - `license/cla` missing after a push or `update-branch`? It is SHA-bound and the auto-recheck comment is unreliable — **close+reopen the PR** is the retry that works. Full ABSENT-vs-FAILING triage: `CONTRIBUTING.md` → "Check the CLA status"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ In the order a reviewer reads them. Say "N/A" if a question doesn't apply, so th
   needed, say `N/A` and explain why.
 - **Before/after evidence — the single most-requested thing on this repo.** Paste the *actual output* for both states, not a description of it: the failing command/test at the parent commit, then passing at HEAD. "I verified X changes to Y" is not evidence; the pasted command that shows X→Y is. A reviewer should not have to reproduce your result to believe it.
 - What tests did you run? Include commands and results.
-- **Touching a live path (bridge, network, delivery loop, startup)?** A unit test or harness is not sufficient on its own — include a real post-restart round trip on the affected host (input received → reply delivered), with timings when latency is the point. This is the most common reason an otherwise-correct live-path fix is held from approval.
+- **Touching a live path (bridge, network, delivery loop, startup)?** A unit test or harness is not sufficient on its own — include a real post-restart round trip on the affected host (input received → reply delivered), with timings when latency is the point. This is the most common reason an otherwise-correct live-path fix is held from approval. The only exception is `REVIEW.md` lesson 15's first-deploy gate: no witness target can be provisioned (installer output pasted) AND the owed witness is filed as a `src/witness_owed.py` record that `self-upgrade` refuses to activate over.
 
   <details>
   <summary><strong>How to capture that round trip without checking the branch out over your live checkout</strong></summary>

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -286,13 +286,16 @@ and loads whichever repo it reviews.
     failing command pasted. "No supervised job is loaded" is not eligibility when the installer
     can load one. When eligible, the author (1) files the owed witness as a durable record —
     `python3 src/witness_owed.py --workspace "$WORKSPACE" open owner/repo#N --head <sha> --host
-    <host> --reason "<why no target exists>" --by <agent>` — and (2) says so in the PR body in
-    those terms. The PR may then be approved and merged on its harness proof. `self-upgrade`
+    <host> --reason "<why no target exists>" --by <agent>` — written under the carried
+    `hosts/<host>/witness-owed/` subtree so every host sees it — and (2) says so in the PR body
+    in those terms. The PR may then be approved and merged on its harness proof. `self-upgrade`
     reads the record and refuses to fast-forward a live core onto any head that newly contains
     the owed PR (`src/witness_owed.py check`, exit 3) until the exact-head round trip is posted
     back to the thread and the record is closed with its location (`close ... --witness <url>`).
-    The circular case — the owing host IS the first live core — is a declared canary, not an
-    exception: `upgrade.sh --canary owner/repo#N` marks the record for that host only, activates
+    A precondition on the whole exception: it is usable only once this gate itself is live on
+    every deployment host — an updater that predates the gate reads no record, so the first
+    deferral after the gate lands must wait for the fleet to carry it. The circular case — the
+    owing host IS the first live core — is a declared canary, not an exception: `upgrade.sh --canary owner/repo#N` marks the record for that host only, activates
     there, and the witness that activation produces closes the record; every other host stays
     refused until it does. The witness moves; it does not vanish. Silence about a missing
     witness stays the footnote this lesson forbids, and "could not run it" without the pasted

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -286,8 +286,17 @@ and loads whichever repo it reviews.
     failing command pasted. "No supervised job is loaded" is not eligibility when the installer
     can load one. When eligible, the author (1) files the owed witness as a durable record —
     `python3 src/witness_owed.py --workspace "$WORKSPACE" open owner/repo#N --head <sha> --host
-    <host> --reason "<why no target exists>" --by <agent>` — written under the carried
-    `hosts/<host>/witness-owed/` subtree so every host sees it — and (2) says so in the PR body
+    <host> --reason "<why no target exists>" --by <agent> --publish-with 'bash
+    scripts/sync-workspace.sh --push-only'` — written under the carried
+    `hosts/<host>/witness-owed/` subtree so every host sees it. `--publish-with` is the
+    publication contract, not a convenience: a hold is in force fleet-wide only once its
+    subtree AND the stamp naming its bytes have been PUSHED, so the push runs synchronously
+    and a failure is exit 6 with the stamp withdrawn, leaving the host visibly unpublished
+    and unable to activate. A hold that never left its host binds only that host. On the
+    reading side, a peer's directory is trusted only when the deploying host's own pull leg
+    succeeded this run (`sync-workspace.sh --pull-strict`) and that peer's stamp names it,
+    describes the bytes that arrived, and is younger than the declared max age; otherwise
+    the host is stale and blocks by itself — and (2) says so in the PR body
     in those terms. The PR may then be approved and merged on its harness proof. `self-upgrade`
     reads the record and refuses to fast-forward a live core onto any head that newly contains
     the owed PR (`src/witness_owed.py check`, exit 3) until the exact-head round trip is posted

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -277,6 +277,20 @@ and loads whichever repo it reviews.
     author's to run; if it needs an owner-scheduled service window, that is an ASK with
     its cost named (which service goes down, for how long, whether inbound is replayed) —
     never grounds to approve without it, and never a disclosure footnote on an approval.
+    **When no available host can produce the witness, it becomes a first-deploy gate, not
+    a merge gate.** The structural case: no supervised `com.sutando.<bridge>` job exists on
+    any reachable host, or the only restartable bridges are pinned holding another PR's
+    armed evidence that a restart would destroy. Then the PR body must say so in those
+    terms — "witness deferred to first deploy on <host>" with the reason — and the change
+    may be approved and merged on its harness proof, but MUST NOT be deployed to a live
+    core until the exact-head round trip is posted back to the PR thread. The witness
+    moves; it does not vanish. Silence about a missing witness stays the footnote this
+    lesson forbids, and "could not run it" without naming the structural reason is not a
+    deferral. *Grounded by:* #3305, #3249, #2126 and #3553 (2026-09-01) — four PRs by
+    three agents each filed the identical "I cannot produce the round trip on this host"
+    apology in its own thread, and `launchctl list` on the canonical host showed no
+    `com.sutando.*-bridge` job at all; a required artifact nobody can produce had stopped
+    gating quality and started gating merging, indefinitely and invisibly.
     *Grounded by:* #3174 (`fix(discord): suppress recreated task results after delivery`)
     — a Discord delivery-path change approved on its unit suite, then blocked back to
     CHANGES_REQUESTED on review because the delivery path had no post-restart witness. The

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -278,15 +278,25 @@ and loads whichever repo it reviews.
     its cost named (which service goes down, for how long, whether inbound is replayed) —
     never grounds to approve without it, and never a disclosure footnote on an approval.
     **When no available host can produce the witness, it becomes a first-deploy gate, not
-    a merge gate.** The structural case: no supervised `com.sutando.<bridge>` job exists on
-    any reachable host, or the only restartable bridges are pinned holding another PR's
-    armed evidence that a restart would destroy. Then the PR body must say so in those
-    terms — "witness deferred to first deploy on <host>" with the reason — and the change
-    may be approved and merged on its harness proof, but MUST NOT be deployed to a live
-    core until the exact-head round trip is posted back to the PR thread. The witness
-    moves; it does not vanish. Silence about a missing witness stays the footnote this
-    lesson forbids, and "could not run it" without naming the structural reason is not a
-    deferral. *Grounded by:* #3305, #3249, #2126 and #3553 (2026-09-01) — four PRs by
+    a merge gate — and a first-deploy gate is a RECORD the deployment path reads, not a
+    sentence in the thread.** Eligibility is narrow: the author has tried to provision a
+    witness target and can show why none exists — `bash src/install-channel-bridge-launchd.sh
+    <bridge>` fails or no channel is configured on any reachable host, AND the detached-worktree
+    procedure in `CONTRIBUTING.md` and a disposable target are both unavailable, with the
+    failing command pasted. "No supervised job is loaded" is not eligibility when the installer
+    can load one. When eligible, the author (1) files the owed witness as a durable record —
+    `python3 src/witness_owed.py --workspace "$WORKSPACE" open owner/repo#N --head <sha> --host
+    <host> --reason "<why no target exists>" --by <agent>` — and (2) says so in the PR body in
+    those terms. The PR may then be approved and merged on its harness proof. `self-upgrade`
+    reads the record and refuses to fast-forward a live core onto any head that newly contains
+    the owed PR (`src/witness_owed.py check`, exit 3) until the exact-head round trip is posted
+    back to the thread and the record is closed with its location (`close ... --witness <url>`).
+    The circular case — the owing host IS the first live core — is a declared canary, not an
+    exception: `upgrade.sh --canary owner/repo#N` marks the record for that host only, activates
+    there, and the witness that activation produces closes the record; every other host stays
+    refused until it does. The witness moves; it does not vanish. Silence about a missing
+    witness stays the footnote this lesson forbids, and "could not run it" without the pasted
+    provisioning failure and the record is not a deferral. *Grounded by:* #3305, #3249, #2126 and #3553 (2026-09-01) — four PRs by
     three agents each filed the identical "I cannot produce the round trip on this host"
     apology in its own thread, and `launchctl list` on the canonical host showed no
     `com.sutando.*-bridge` job at all; a required artifact nobody can produce had stopped

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -291,7 +291,7 @@ and loads whichever repo it reviews.
     in those terms. The PR may then be approved and merged on its harness proof. `self-upgrade`
     reads the record and refuses to fast-forward a live core onto any head that newly contains
     the owed PR (`src/witness_owed.py check`, exit 3) until the exact-head round trip is posted
-    back to the thread and the record is closed with its location (`close ... --witness <url>`).
+    back to the thread and the record is closed with its location (`close <owner/repo#N> --witness <url> --host <owing-host>`; from any other host, `tombstone` with the same arguments and `--host` naming THIS host).
     A precondition on the whole exception: it is usable only once this gate itself is live on
     every deployment host — an updater that predates the gate reads no record, so the first
     deferral after the gate lands must wait for the fleet to carry it. The circular case — the

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -229,6 +229,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`watcher_sentinel.sh`** — Ownership protocol for state/watch-tasks-stream.pid — the ONE writer contract.
 - **`web-client.ts`** — Web Audio Client for Sutando
 - **`web-voice-transport.ts`** — web-voice-transport — the framework-agnostic browser voice-client CORE.
+- **`witness_owed.py`** — Durable record of a live-path witness a merged PR still owes.
 - **`worker_identity.py`** — A worker's durable identity: which worker, which conversation, which run.
 - **`workspace_default.py`** — Canonical workspace-directory resolution for Sutando services.
 - **`workspace_default.ts`** — Canonical workspace-directory resolution for Sutando TS services.

--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -49,6 +49,7 @@
 #
 # Usage:
 #   bash scripts/sync-workspace.sh                # default: pull + push (one tick)
+#   bash scripts/sync-workspace.sh --pull-strict  # same tick; a failed PULL is a failed run (exit 3)
 #   bash scripts/sync-workspace.sh --pull-only    # fetch + merge peers, no push
 #   bash scripts/sync-workspace.sh --push-only    # commit + push to own host branch
 #   bash scripts/sync-workspace.sh --init         # one-time init: git init + setup vault remote
@@ -1564,7 +1565,14 @@ _push_only_impl() {
 
 # Default: pull peers first (so own commits build on latest peer state), then push.
 
-cmd_default_bidirectional() {
+cmd_default_bidirectional() { _bidirectional_tick default; }
+
+# Same legs, strict reading: the caller is asking whether its view of peer state
+# is CURRENT, so a refused pull is this run's failure (exit 3), not the push's.
+cmd_pull_strict_bidirectional() { _bidirectional_tick strict; }
+
+_bidirectional_tick() {
+    local _mode="$1"
     # Cross-machine sync is opt-in — enabled only when a vault URL is configured
     # (--vault-url, sutando.config vault.remote_url, or the legacy
     # SUTANDO_MEMORY_REPO). When none is set, sync is INTENTIONALLY disabled, and
@@ -1575,19 +1583,32 @@ cmd_default_bidirectional() {
     # explicit subcommands (--init / --pull-only / --push-only) keep their loud
     # "run --init first" feedback because the operator asked for them directly.
     if [ -z "$VAULT_URL" ]; then
-        log "cmd_default_bidirectional: no vault URL configured — cross-machine sync disabled; skipping."
+        # Strict callers asked whether the pull ran; a skipped one never did.
+        if [ "$_mode" = "strict" ]; then
+            log "_bidirectional_tick: strict — no vault URL configured, so no pull ran."
+            echo "sync-workspace: STRICT FAILURE — pull leg: cross-machine sync is disabled (no vault URL configured), so peer state was never fetched." >&2
+            return 3
+        fi
+        log "_bidirectional_tick: no vault URL configured — cross-machine sync disabled; skipping."
         echo "sync-workspace: cross-machine sync disabled (no vault URL configured) — skipping." >&2
         return 0
     fi
     acquire_lock
-    _pull_only_impl || true   # pull failures shouldn't block push
     # `|| _rc=$?`, NOT a bare call then `$?`: under `set -e` a non-zero
-    # `_push_only_impl` would exit before the reporter below ever runs.
+    # leg would exit before the reporter below ever runs.
+    local _pull_rc=0
+    _pull_only_impl || _pull_rc=$?
     local _rc=0
     _push_only_impl || _rc=$?
     # Report rather than auto-merge: a union merge loses no line but resurrects
     # an in-place retraction beneath its own correction, where it reads as current.
     _report_unmerged_conflicts || true   # fail-open: never change sync's outcome
+    # Default keeps push semantics: a refused pull must not block a push (a host
+    # whose peer is broken still has to publish its own state).
+    if [ "$_mode" = "strict" ] && [ "$_pull_rc" != "0" ]; then
+        echo "sync-workspace: STRICT FAILURE — pull leg exited $_pull_rc; this view of peer state is NOT current (push leg exited $_rc)." >&2
+        return 3
+    fi
     return "$_rc"
 }
 
@@ -1936,6 +1957,7 @@ case "$cmd" in
     --status|status)                   cmd_status ;;
     --migrate-from-legacy)             cmd_migrate_from_legacy ;;
     --help|-h|help)                    cmd_help ;;
+    --pull-strict|pull-strict)         cmd_pull_strict_bidirectional ;;
     --default|default|'')              cmd_default_bidirectional ;;
     *)
         echo "sync-workspace: unknown subcommand '$cmd'. Try --help." >&2

--- a/skills/self-upgrade/SKILL.md
+++ b/skills/self-upgrade/SKILL.md
@@ -29,7 +29,7 @@ services, and lets startup recreate the managed task notifier.
 
 ### Step 1 — Pull + durable restart handoff (mechanical)
 
-Before pulling, the script consults `<workspace>/state/witness-owed/` (`src/witness_owed.py check`): if the target head newly contains a merged live-path PR whose post-restart witness is still owed (REVIEW.md lesson 15), it exits 4 and leaves HEAD alone. Post the round trip and `close` the record, or on the host that owes it pass `--canary owner/repo#N`, which marks the record for this host only and proceeds.
+Before pulling, the script consults `<workspace>/hosts/<host>/witness-owed/` (`src/witness_owed.py check`): if the target head newly contains a merged live-path PR whose post-restart witness is still owed (REVIEW.md lesson 15), it exits 4 and leaves HEAD alone. Post the round trip and `close` the record, or on the host that owes it pass `--canary owner/repo#N`, which marks the record for this host only and proceeds.
 
 Run the helper. It aborts safely on a dirty tree or a non-fast-forward, pulls
 `--ff-only`, and launches `src/restart.sh` in the persistent
@@ -42,7 +42,9 @@ bash skills/self-upgrade/scripts/upgrade.sh          # origin/main
 ```
 
 Exit `0` = upgraded (or already latest); exit `2` = aborted (dirty tree /
-not a fast-forward) — surface the reason and stop.
+not a fast-forward); exit `4` = refused by the witness-owed gate, or the gate
+could not run (unresolvable workspace, python, repository or fleet freshness) —
+surface the reason and stop.
 
 If the diff touched `package*.json` / `tsconfig` / `*.swift` / `requirements`
 (the script prints this), a rebuild may be needed. For `*.swift`, rebuild the

--- a/skills/self-upgrade/SKILL.md
+++ b/skills/self-upgrade/SKILL.md
@@ -29,6 +29,8 @@ services, and lets startup recreate the managed task notifier.
 
 ### Step 1 — Pull + durable restart handoff (mechanical)
 
+Before pulling, the script consults `<workspace>/state/witness-owed/` (`src/witness_owed.py check`): if the target head newly contains a merged live-path PR whose post-restart witness is still owed (REVIEW.md lesson 15), it exits 4 and leaves HEAD alone. Post the round trip and `close` the record, or on the host that owes it pass `--canary owner/repo#N`, which marks the record for this host only and proceeds.
+
 Run the helper. It aborts safely on a dirty tree or a non-fast-forward, pulls
 `--ff-only`, and launches `src/restart.sh` in the persistent
 **`sutando-services` tmux session**:
@@ -36,6 +38,7 @@ Run the helper. It aborts safely on a dirty tree or a non-fast-forward, pulls
 ```bash
 bash skills/self-upgrade/scripts/upgrade.sh          # origin/main
 # bash skills/self-upgrade/scripts/upgrade.sh --no-restart   # pull only
+# bash skills/self-upgrade/scripts/upgrade.sh --canary owner/repo#N   # activate a head that still owes a witness, on the owing host only
 ```
 
 Exit `0` = upgraded (or already latest); exit `2` = aborted (dirty tree /

--- a/skills/self-upgrade/SKILL.md
+++ b/skills/self-upgrade/SKILL.md
@@ -29,7 +29,7 @@ services, and lets startup recreate the managed task notifier.
 
 ### Step 1 — Pull + durable restart handoff (mechanical)
 
-Before pulling, the script consults `<workspace>/hosts/<host>/witness-owed/` (`src/witness_owed.py check`): if the target head newly contains a merged live-path PR whose post-restart witness is still owed (REVIEW.md lesson 15), it exits 4 and leaves HEAD alone. Post the round trip and `close` the record, or on the host that owes it pass `--canary owner/repo#N`, which marks the record for this host only and proceeds.
+Before pulling, the script consults `<workspace>/hosts/<host>/witness-owed/` (`src/witness_owed.py check`): if the target head newly contains a merged live-path PR whose post-restart witness is still owed (REVIEW.md lesson 15), it exits 4 and leaves HEAD alone. Post the round trip and `close` the record, or on the host that owes it pass `--canary owner/repo#N`, which marks the record for this host only and proceeds. The gate reads the target SHA it pinned after `git fetch` and fast-forwards to exactly that object, so a remote that moves mid-run cannot activate a head the gate never checked. Its freshness bound `SUTANDO_WITNESS_MAX_AGE` is declared in this skill's `manifest.json` `config` block (env override wins; seconds, finite and > 0).
 
 Run the helper. It aborts safely on a dirty tree or a non-fast-forward, pulls
 `--ff-only`, and launches `src/restart.sh` in the persistent

--- a/skills/self-upgrade/manifest.json
+++ b/skills/self-upgrade/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "self-upgrade",
+  "version": "1.0.0",
+  "owner": "github:sonichi/sutando",
+  "license": "MIT",
+  "stability": "stable",
+  "description": "Pull the repo to latest and restart background services behind the witness-owed first-deploy gate. Manifest present to DECLARE config per skills/MANIFEST.md; it contributes no runtime tools.",
+  "access_tier": "owner",
+  "enabled": true,
+  "permissions": {
+    "network": true,
+    "filesystem": "read-write",
+    "secrets": "none"
+  },
+  "config": {
+    "SUTANDO_WITNESS_MAX_AGE": "3600"
+  },
+  "provenance": {
+    "source_repo": "https://github.com/sonichi/sutando"
+  }
+}

--- a/skills/self-upgrade/scripts/upgrade.sh
+++ b/skills/self-upgrade/scripts/upgrade.sh
@@ -124,7 +124,12 @@ esac
 awk -v v="$GATE_MAX_AGE" 'BEGIN{ exit !(v+0 > 0) }' ||
   { echo "self-upgrade: ABORT — SUTANDO_WITNESS_MAX_AGE must be > 0, got '$GATE_MAX_AGE'" >&2; exit 4; }
 if [ "$GATE_VAULT" = "true" ]; then
-  bash "$REPO/scripts/sync-workspace.sh" --pull-only || { echo "self-upgrade: ABORT — vault pull failed, so the fleet's witness-owed records cannot be called fresh" >&2; exit 4; }
+  # Stamp before the sync so this host's own records travel WITH the claim that
+  # peers can see them; a stamp pushed without its records is a false claim.
+  [ -n "$GATE_HOST" ] && "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" publish --host "$GATE_HOST" >/dev/null 2>&1 || true
+  # Full tick, not --pull-only: pulling alone never publishes this host, so a
+  # fleet of pull-only updaters ages every stamp out and then refuses forever.
+  bash "$REPO/scripts/sync-workspace.sh" || { echo "self-upgrade: ABORT — vault sync failed, so the fleet's witness-owed records cannot be called fresh" >&2; exit 4; }
 elif [ -d "$GATE_WS/hosts" ] && [ -n "$GATE_HOST" ] && find "$GATE_WS/hosts" -mindepth 2 -maxdepth 2 -name witness-owed -not -path "$GATE_WS/hosts/$GATE_HOST/*" | grep -q .; then
   echo "self-upgrade: ABORT — foreign host witness-owed subtrees exist but the vault is disabled, so they cannot be refreshed" >&2
   echo "  Enable the vault, or re-stamp this host's view once its records are current:" >&2
@@ -135,6 +140,9 @@ if [ -n "$CANARY" ]; then
   [ -n "$GATE_HOST" ] || { echo "self-upgrade: ABORT — cannot resolve this host's label, so it cannot be declared the canary for $CANARY" >&2; exit 4; }
   "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" canary "$CANARY" --host "$GATE_HOST" >/dev/null ||
     { echo "self-upgrade: ABORT — cannot declare $GATE_HOST the canary for $CANARY (no open record, or a different host owes it)" >&2; exit 4; }
+  # The declaration changed this host's record, so the stamp no longer
+  # describes it; re-stamp before the gate reads it back.
+  "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" publish --host "$GATE_HOST" >/dev/null 2>&1 || true
   echo "self-upgrade: canary activation of $CANARY declared for $GATE_HOST — post the round trip and close the record"
 fi
 if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" --repo "$GATE_REPO" --max-age "$GATE_MAX_AGE" ${GATE_HOST:+--host "$GATE_HOST"}; then
@@ -150,8 +158,6 @@ fi
 # 4. Fast-forward pull — the actual code upgrade.
 git pull --ff-only "$REMOTE" "$BRANCH" || { echo "self-upgrade: git pull --ff-only failed" >&2; exit 2; }
 NOW="$(git rev-parse --short HEAD)"
-# This host's view is now current: stamp it so peers can tell fresh from stale.
-[ -n "$GATE_HOST" ] && "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" publish --host "$GATE_HOST" >/dev/null 2>&1 || true
 echo "self-upgrade: pulled $LOCAL -> $NOW (0 behind)"
 
 if [ "$DO_RESTART" = "0" ]; then

--- a/skills/self-upgrade/scripts/upgrade.sh
+++ b/skills/self-upgrade/scripts/upgrade.sh
@@ -96,21 +96,26 @@ fi
 
 # 3.5 Witness-owed gate: a merged live-path PR that still owes its post-restart
 #     round trip (REVIEW.md lesson 15) is not activated here, except as a declared
-#     canary on the host that owes it. Runs BEFORE the pull so a refusal leaves HEAD alone.
+#     canary on the host that owes it. Runs BEFORE the pull so a refusal leaves HEAD
+#     alone, and FAILS CLOSED: a gate it cannot run is a gate it cannot pass.
 GATE_WS="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
-GATE_HOST="$(bash "$REPO/scripts/sutando-config.sh" host-label 2>/dev/null || hostname -s)"
-if [ -n "$GATE_WS" ] && [ -f "$REPO/src/witness_owed.py" ]; then
-  if [ -n "$CANARY" ]; then
-    python3 "$REPO/src/witness_owed.py" --workspace "$GATE_WS" canary "$CANARY" --host "$GATE_HOST" >/dev/null ||
-      { echo "self-upgrade: ABORT — no open witness-owed record for $CANARY" >&2; exit 4; }
-    echo "self-upgrade: canary activation of $CANARY declared for $GATE_HOST — post the round trip and close the record"
-  fi
-  if ! python3 "$REPO/src/witness_owed.py" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" --host "$GATE_HOST"; then
-    echo "self-upgrade: ABORT — the target head newly contains a live-path PR that still owes its witness (listed above)." >&2
-    echo "  Post the exact-head round trip to the PR thread and close the record: python3 src/witness_owed.py --workspace <ws> close owner/repo#N --witness <url>" >&2
-    echo "  Or, on the host that owes it, activate as the declared canary: $0 --canary owner/repo#N" >&2
-    exit 4
-  fi
+GATE_HOST="$(bash "$REPO/scripts/sutando-config.sh" host-label 2>/dev/null || true)"
+GATE_PY="$(bash "$REPO/scripts/sutando-config.sh" python-bin 2>/dev/null || true)"
+GATE_HELPER="$REPO/src/witness_owed.py"
+[ -n "$GATE_WS" ] || { echo "self-upgrade: ABORT — cannot resolve the workspace, so the witness-owed gate cannot run" >&2; exit 4; }
+[ -n "$GATE_HOST" ] || { echo "self-upgrade: ABORT — cannot resolve this host's label, so the witness-owed gate cannot run" >&2; exit 4; }
+[ -n "$GATE_PY" ] || { echo "self-upgrade: ABORT — no usable python (sutando-config.sh python-bin), so the witness-owed gate cannot run" >&2; exit 4; }
+[ -f "$GATE_HELPER" ] || { echo "self-upgrade: ABORT — $GATE_HELPER is missing, so the witness-owed gate cannot run" >&2; exit 4; }
+if [ -n "$CANARY" ]; then
+  "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" canary "$CANARY" --host "$GATE_HOST" >/dev/null ||
+    { echo "self-upgrade: ABORT — cannot declare $GATE_HOST the canary for $CANARY (no open record, or a different host owes it)" >&2; exit 4; }
+  echo "self-upgrade: canary activation of $CANARY declared for $GATE_HOST — post the round trip and close the record"
+fi
+if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" --host "$GATE_HOST"; then
+  echo "self-upgrade: ABORT — the target head newly contains a live-path PR that still owes its witness (listed above)." >&2
+  echo "  Post the exact-head round trip to the PR thread and close the record: witness_owed.py close owner/repo#N --witness <url>" >&2
+  echo "  Or, on the host that owes it, activate as the declared canary: $0 --canary owner/repo#N" >&2
+  exit 4
 fi
 
 # 4. Fast-forward pull — the actual code upgrade.

--- a/skills/self-upgrade/scripts/upgrade.sh
+++ b/skills/self-upgrade/scripts/upgrade.sh
@@ -116,10 +116,20 @@ GATE_REPO="$(printf '%s' "$GATE_URL" | sed -E 's#/+$##; s#\.git$##' | sed -nE 's
 # with it off, foreign host subtrees are a fleet this host cannot refresh.
 GATE_VAULT="$(bash "$REPO/scripts/sutando-config.sh" vault-enabled 2>/dev/null || true)"
 GATE_MAX_AGE="${SUTANDO_WITNESS_MAX_AGE:-3600}"
+# nan/inf parse as floats and defeat expiry entirely, so a stale fleet view
+# would read as fresh forever. Manifest declaration is still owed.
+case "$GATE_MAX_AGE" in
+  *[!0-9.]*|""|".") echo "self-upgrade: ABORT — SUTANDO_WITNESS_MAX_AGE must be a finite positive number of seconds, got '$GATE_MAX_AGE'" >&2; exit 4;;
+esac
+awk -v v="$GATE_MAX_AGE" 'BEGIN{ exit !(v+0 > 0) }' ||
+  { echo "self-upgrade: ABORT — SUTANDO_WITNESS_MAX_AGE must be > 0, got '$GATE_MAX_AGE'" >&2; exit 4; }
 if [ "$GATE_VAULT" = "true" ]; then
   bash "$REPO/scripts/sync-workspace.sh" --pull-only || { echo "self-upgrade: ABORT — vault pull failed, so the fleet's witness-owed records cannot be called fresh" >&2; exit 4; }
 elif [ -d "$GATE_WS/hosts" ] && [ -n "$GATE_HOST" ] && find "$GATE_WS/hosts" -mindepth 2 -maxdepth 2 -name witness-owed -not -path "$GATE_WS/hosts/$GATE_HOST/*" | grep -q .; then
-  echo "self-upgrade: ABORT — foreign host witness-owed subtrees exist but the vault is disabled, so they cannot be refreshed" >&2; exit 4
+  echo "self-upgrade: ABORT — foreign host witness-owed subtrees exist but the vault is disabled, so they cannot be refreshed" >&2
+  echo "  Enable the vault, or re-stamp this host's view once its records are current:" >&2
+  echo "    $GATE_PY $GATE_HELPER --workspace $GATE_WS publish --host ${GATE_HOST:-<this-host>}" >&2
+  exit 4
 fi
 if [ -n "$CANARY" ]; then
   [ -n "$GATE_HOST" ] || { echo "self-upgrade: ABORT — cannot resolve this host's label, so it cannot be declared the canary for $CANARY" >&2; exit 4; }
@@ -129,7 +139,10 @@ if [ -n "$CANARY" ]; then
 fi
 if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" --repo "$GATE_REPO" --max-age "$GATE_MAX_AGE" ${GATE_HOST:+--host "$GATE_HOST"}; then
   echo "self-upgrade: ABORT — the target head newly contains a live-path PR that still owes its witness (listed above)." >&2
-  echo "  Post the exact-head round trip to the PR thread and close the record: witness_owed.py close owner/repo#N --witness <url>" >&2
+  echo "  Post the exact-head round trip to the PR thread, then close the record ON THE OWING HOST:" >&2
+  echo "    $GATE_PY $GATE_HELPER --workspace $GATE_WS close owner/repo#N --witness <url> --host <owing-host>" >&2
+  echo "  From any OTHER host, tombstone it instead (same arguments, --host is THIS host):" >&2
+  echo "    $GATE_PY $GATE_HELPER --workspace $GATE_WS tombstone owner/repo#N --witness <url> --host ${GATE_HOST:-<this-host>}" >&2
   echo "  Or, on the host that owes it, activate as the declared canary: $0 --canary owner/repo#N" >&2
   exit 4
 fi

--- a/skills/self-upgrade/scripts/upgrade.sh
+++ b/skills/self-upgrade/scripts/upgrade.sh
@@ -11,7 +11,7 @@
 #   - run the post-upgrade health check / report to the owner
 #
 # Usage:
-#   bash skills/self-upgrade/scripts/upgrade.sh [--remote <name>] [--branch <name>] [--no-restart]
+#   bash skills/self-upgrade/scripts/upgrade.sh [--remote <name>] [--branch <name>] [--no-restart] [--canary owner/repo#N]
 # Exit codes: 0 = upgraded (or already latest); 2 = aborted (dirty tree / not FF-able)
 
 set -uo pipefail
@@ -19,6 +19,7 @@ set -uo pipefail
 REMOTE="origin"
 BRANCH="main"
 DO_RESTART=1
+CANARY=""
 SERVICE_SESSION="sutando-services"
 DONE_MARKER=""
 while [ $# -gt 0 ]; do
@@ -26,6 +27,7 @@ while [ $# -gt 0 ]; do
     --remote) REMOTE="$2"; shift 2 ;;
     --branch) BRANCH="$2"; shift 2 ;;
     --no-restart) DO_RESTART=0; shift ;;
+    --canary) CANARY="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -90,6 +92,25 @@ REBUILD="$(git diff --name-only "HEAD..$REMOTE/$BRANCH" | grep -iE 'package.*\.j
 if [ -n "$REBUILD" ]; then
   echo "self-upgrade: NOTE — dependency/build files changed; a rebuild (npm ci / tsc) may be needed after restart:"
   echo "$REBUILD" | sed 's/^/    /'
+fi
+
+# 3.5 Witness-owed gate: a merged live-path PR that still owes its post-restart
+#     round trip (REVIEW.md lesson 15) is not activated here, except as a declared
+#     canary on the host that owes it. Runs BEFORE the pull so a refusal leaves HEAD alone.
+GATE_WS="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
+GATE_HOST="$(bash "$REPO/scripts/sutando-config.sh" host-label 2>/dev/null || hostname -s)"
+if [ -n "$GATE_WS" ] && [ -f "$REPO/src/witness_owed.py" ]; then
+  if [ -n "$CANARY" ]; then
+    python3 "$REPO/src/witness_owed.py" --workspace "$GATE_WS" canary "$CANARY" --host "$GATE_HOST" >/dev/null ||
+      { echo "self-upgrade: ABORT — no open witness-owed record for $CANARY" >&2; exit 4; }
+    echo "self-upgrade: canary activation of $CANARY declared for $GATE_HOST — post the round trip and close the record"
+  fi
+  if ! python3 "$REPO/src/witness_owed.py" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" --host "$GATE_HOST"; then
+    echo "self-upgrade: ABORT — the target head newly contains a live-path PR that still owes its witness (listed above)." >&2
+    echo "  Post the exact-head round trip to the PR thread and close the record: python3 src/witness_owed.py --workspace <ws> close owner/repo#N --witness <url>" >&2
+    echo "  Or, on the host that owes it, activate as the declared canary: $0 --canary owner/repo#N" >&2
+    exit 4
+  fi
 fi
 
 # 4. Fast-forward pull — the actual code upgrade.

--- a/skills/self-upgrade/scripts/upgrade.sh
+++ b/skills/self-upgrade/scripts/upgrade.sh
@@ -12,7 +12,8 @@
 #
 # Usage:
 #   bash skills/self-upgrade/scripts/upgrade.sh [--remote <name>] [--branch <name>] [--no-restart] [--canary owner/repo#N]
-# Exit codes: 0 = upgraded (or already latest); 2 = aborted (dirty tree / not FF-able)
+# Exit codes: 0 = upgraded (or already latest); 2 = aborted (dirty tree / not FF-able);
+#             4 = refused by the witness-owed gate (or the gate could not run)
 
 set -uo pipefail
 
@@ -107,13 +108,26 @@ GATE_HELPER="$REPO/src/witness_owed.py"
 # `check` still runs; only a canary declaration needs the label and fails closed.
 [ -n "$GATE_PY" ] || { echo "self-upgrade: ABORT — no usable python (sutando-config.sh python-bin), so the witness-owed gate cannot run" >&2; exit 4; }
 [ -f "$GATE_HELPER" ] || { echo "self-upgrade: ABORT — $GATE_HELPER is missing, so the witness-owed gate cannot run" >&2; exit 4; }
+# The target repository scopes the gate: another project's (#N) is not ours.
+GATE_URL="$(git remote get-url "$REMOTE" 2>/dev/null || true)"
+GATE_REPO="$(printf '%s' "$GATE_URL" | sed -E 's#/+$##; s#\.git$##' | sed -nE 's#^.*[/:]([^/:]+)/([^/:]+)$#\1/\2#p')"
+[ -n "$GATE_REPO" ] || { echo "self-upgrade: ABORT — cannot derive owner/name from remote '$REMOTE' ($GATE_URL), so the witness-owed gate cannot scope its records" >&2; exit 4; }
+# Fleet view: with the vault on, refresh it first and fail closed if that fails;
+# with it off, foreign host subtrees are a fleet this host cannot refresh.
+GATE_VAULT="$(bash "$REPO/scripts/sutando-config.sh" vault-enabled 2>/dev/null || true)"
+GATE_MAX_AGE="${SUTANDO_WITNESS_MAX_AGE:-3600}"
+if [ "$GATE_VAULT" = "true" ]; then
+  bash "$REPO/scripts/sync-workspace.sh" --pull-only || { echo "self-upgrade: ABORT — vault pull failed, so the fleet's witness-owed records cannot be called fresh" >&2; exit 4; }
+elif [ -d "$GATE_WS/hosts" ] && [ -n "$GATE_HOST" ] && find "$GATE_WS/hosts" -mindepth 2 -maxdepth 2 -name witness-owed -not -path "$GATE_WS/hosts/$GATE_HOST/*" | grep -q .; then
+  echo "self-upgrade: ABORT — foreign host witness-owed subtrees exist but the vault is disabled, so they cannot be refreshed" >&2; exit 4
+fi
 if [ -n "$CANARY" ]; then
   [ -n "$GATE_HOST" ] || { echo "self-upgrade: ABORT — cannot resolve this host's label, so it cannot be declared the canary for $CANARY" >&2; exit 4; }
   "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" canary "$CANARY" --host "$GATE_HOST" >/dev/null ||
     { echo "self-upgrade: ABORT — cannot declare $GATE_HOST the canary for $CANARY (no open record, or a different host owes it)" >&2; exit 4; }
   echo "self-upgrade: canary activation of $CANARY declared for $GATE_HOST — post the round trip and close the record"
 fi
-if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" ${GATE_HOST:+--host "$GATE_HOST"}; then
+if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" --repo "$GATE_REPO" --max-age "$GATE_MAX_AGE" ${GATE_HOST:+--host "$GATE_HOST"}; then
   echo "self-upgrade: ABORT — the target head newly contains a live-path PR that still owes its witness (listed above)." >&2
   echo "  Post the exact-head round trip to the PR thread and close the record: witness_owed.py close owner/repo#N --witness <url>" >&2
   echo "  Or, on the host that owes it, activate as the declared canary: $0 --canary owner/repo#N" >&2
@@ -123,6 +137,8 @@ fi
 # 4. Fast-forward pull — the actual code upgrade.
 git pull --ff-only "$REMOTE" "$BRANCH" || { echo "self-upgrade: git pull --ff-only failed" >&2; exit 2; }
 NOW="$(git rev-parse --short HEAD)"
+# This host's view is now current: stamp it so peers can tell fresh from stale.
+[ -n "$GATE_HOST" ] && "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" publish --host "$GATE_HOST" >/dev/null 2>&1 || true
 echo "self-upgrade: pulled $LOCAL -> $NOW (0 behind)"
 
 if [ "$DO_RESTART" = "0" ]; then

--- a/skills/self-upgrade/scripts/upgrade.sh
+++ b/skills/self-upgrade/scripts/upgrade.sh
@@ -103,15 +103,17 @@ GATE_HOST="$(bash "$REPO/scripts/sutando-config.sh" host-label 2>/dev/null || tr
 GATE_PY="$(bash "$REPO/scripts/sutando-config.sh" python-bin 2>/dev/null || true)"
 GATE_HELPER="$REPO/src/witness_owed.py"
 [ -n "$GATE_WS" ] || { echo "self-upgrade: ABORT — cannot resolve the workspace, so the witness-owed gate cannot run" >&2; exit 4; }
-[ -n "$GATE_HOST" ] || { echo "self-upgrade: ABORT — cannot resolve this host's label, so the witness-owed gate cannot run" >&2; exit 4; }
+# An unresolved host label cannot release anything (no canary matches ""), so
+# `check` still runs; only a canary declaration needs the label and fails closed.
 [ -n "$GATE_PY" ] || { echo "self-upgrade: ABORT — no usable python (sutando-config.sh python-bin), so the witness-owed gate cannot run" >&2; exit 4; }
 [ -f "$GATE_HELPER" ] || { echo "self-upgrade: ABORT — $GATE_HELPER is missing, so the witness-owed gate cannot run" >&2; exit 4; }
 if [ -n "$CANARY" ]; then
+  [ -n "$GATE_HOST" ] || { echo "self-upgrade: ABORT — cannot resolve this host's label, so it cannot be declared the canary for $CANARY" >&2; exit 4; }
   "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" canary "$CANARY" --host "$GATE_HOST" >/dev/null ||
     { echo "self-upgrade: ABORT — cannot declare $GATE_HOST the canary for $CANARY (no open record, or a different host owes it)" >&2; exit 4; }
   echo "self-upgrade: canary activation of $CANARY declared for $GATE_HOST — post the round trip and close the record"
 fi
-if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" --host "$GATE_HOST"; then
+if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" ${GATE_HOST:+--host "$GATE_HOST"}; then
   echo "self-upgrade: ABORT — the target head newly contains a live-path PR that still owes its witness (listed above)." >&2
   echo "  Post the exact-head round trip to the PR thread and close the record: witness_owed.py close owner/repo#N --witness <url>" >&2
   echo "  Or, on the host that owes it, activate as the declared canary: $0 --canary owner/repo#N" >&2

--- a/skills/self-upgrade/scripts/upgrade.sh
+++ b/skills/self-upgrade/scripts/upgrade.sh
@@ -72,24 +72,27 @@ if [ "$DO_RESTART" = "1" ]; then
   fi
 fi
 
-# 2. Fetch + measure the gap.
+# 2. Fetch, then PIN the target: $REMOTE/$BRANCH is mutable, so gating one
+#    resolution of it and pulling another activates a head the gate never saw.
 git fetch "$REMOTE" --quiet || { echo "self-upgrade: git fetch failed" >&2; exit 2; }
+TARGET_SHA="$(git rev-parse --verify -q "$REMOTE/$BRANCH^{commit}" || true)"
+[ -n "$TARGET_SHA" ] || { echo "self-upgrade: ABORT — cannot resolve $REMOTE/$BRANCH to a commit" >&2; exit 2; }
 LOCAL="$(git rev-parse --short HEAD)"
-BEHIND="$(git rev-list --count "HEAD..$REMOTE/$BRANCH" 2>/dev/null || echo 0)"
-AHEAD="$(git rev-list --count "$REMOTE/$BRANCH..HEAD" 2>/dev/null || echo 0)"
-echo "self-upgrade: local=$LOCAL  behind=$BEHIND  ahead=$AHEAD"
+BEHIND="$(git rev-list --count "HEAD..$TARGET_SHA" 2>/dev/null || echo 0)"
+AHEAD="$(git rev-list --count "$TARGET_SHA..HEAD" 2>/dev/null || echo 0)"
+echo "self-upgrade: local=$LOCAL  behind=$BEHIND  ahead=$AHEAD  target=${TARGET_SHA:0:8}"
 
 if [ "$BEHIND" = "0" ]; then
   echo "self-upgrade: already at latest ($LOCAL). Nothing to pull."
   exit 0
 fi
 if [ "$AHEAD" != "0" ]; then
-  echo "self-upgrade: ABORT — local is $AHEAD commit(s) ahead of $REMOTE/$BRANCH; not a fast-forward. Resolve manually." >&2
+  echo "self-upgrade: ABORT — local is $AHEAD commit(s) ahead of ${TARGET_SHA:0:8} ($REMOTE/$BRANCH); not a fast-forward. Resolve manually." >&2
   exit 2
 fi
 
 # 3. Heads-up if a rebuild is likely needed (dependency/build files changed).
-REBUILD="$(git diff --name-only "HEAD..$REMOTE/$BRANCH" | grep -iE 'package.*\.json|package-lock|tsconfig|\.swift$|requirements' || true)"
+REBUILD="$(git diff --name-only "HEAD..$TARGET_SHA" | grep -iE 'package.*\.json|package-lock|tsconfig|\.swift$|requirements' || true)"
 if [ -n "$REBUILD" ]; then
   echo "self-upgrade: NOTE — dependency/build files changed; a rebuild (npm ci / tsc) may be needed after restart:"
   echo "$REBUILD" | sed 's/^/    /'
@@ -115,14 +118,15 @@ GATE_REPO="$(printf '%s' "$GATE_URL" | sed -E 's#/+$##; s#\.git$##' | sed -nE 's
 # Fleet view: with the vault on, refresh it first and fail closed if that fails;
 # with it off, foreign host subtrees are a fleet this host cannot refresh.
 GATE_VAULT="$(bash "$REPO/scripts/sutando-config.sh" vault-enabled 2>/dev/null || true)"
-GATE_MAX_AGE="${SUTANDO_WITNESS_MAX_AGE:-3600}"
-# nan/inf parse as floats and defeat expiry entirely, so a stale fleet view
-# would read as fresh forever. Manifest declaration is still owed.
-case "$GATE_MAX_AGE" in
-  *[!0-9.]*|""|".") echo "self-upgrade: ABORT — SUTANDO_WITNESS_MAX_AGE must be a finite positive number of seconds, got '$GATE_MAX_AGE'" >&2; exit 4;;
-esac
-awk -v v="$GATE_MAX_AGE" 'BEGIN{ exit !(v+0 > 0) }' ||
-  { echo "self-upgrade: ABORT — SUTANDO_WITNESS_MAX_AGE must be > 0, got '$GATE_MAX_AGE'" >&2; exit 4; }
+# Declared in this skill's manifest, read env > manifest > built-in per
+# skills/MANIFEST.md; the shell no longer keeps its own copy of the bound's rule.
+GATE_MAX_AGE="${SUTANDO_WITNESS_MAX_AGE:-}"
+[ -n "$GATE_MAX_AGE" ] || GATE_MAX_AGE="$("$GATE_PY" -c 'import json,sys; print(json.load(open(sys.argv[1]))["config"]["SUTANDO_WITNESS_MAX_AGE"])' "$REPO/skills/self-upgrade/manifest.json" 2>/dev/null || true)"
+[ -n "$GATE_MAX_AGE" ] || GATE_MAX_AGE=3600
+# nan/inf parse as floats and disable expiry while claiming a bound; the check
+# lives once, in the helper that consumes the value.
+PYTHONDONTWRITEBYTECODE=1 "$GATE_PY" -c 'import sys; sys.path.insert(0, sys.argv[1]); from witness_owed import validate_max_age; validate_max_age(sys.argv[2])' "$REPO/src" "$GATE_MAX_AGE" 2>/dev/null ||
+  { echo "self-upgrade: ABORT — witness max age must be a finite number of seconds > 0, got '$GATE_MAX_AGE' (declared in skills/self-upgrade/manifest.json)" >&2; exit 4; }
 if [ "$GATE_VAULT" = "true" ]; then
   # Stamp before the sync so this host's own records travel WITH the claim that
   # peers can see them; a stamp pushed without its records is a false claim.
@@ -153,7 +157,7 @@ if [ -n "$CANARY" ]; then
   "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" publish --host "$GATE_HOST" >/dev/null 2>&1 || true
   echo "self-upgrade: canary activation of $CANARY declared for $GATE_HOST — post the round trip and close the record"
 fi
-if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRANCH" --current HEAD --repo-root "$REPO" --repo "$GATE_REPO" --max-age "$GATE_MAX_AGE" ${GATE_HOST:+--host "$GATE_HOST"}; then
+if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$TARGET_SHA" --current HEAD --repo-root "$REPO" --repo "$GATE_REPO" --max-age "$GATE_MAX_AGE" ${GATE_HOST:+--host "$GATE_HOST"}; then
   echo "self-upgrade: ABORT — the target head newly contains a live-path PR that still owes its witness (listed above)." >&2
   echo "  Post the exact-head round trip to the PR thread, then close the record ON THE OWING HOST:" >&2
   echo "    $GATE_PY $GATE_HELPER --workspace $GATE_WS close owner/repo#N --witness <url> --host <owing-host>" >&2
@@ -163,8 +167,9 @@ if ! "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" check --ref "$REMOTE/$BRAN
   exit 4
 fi
 
-# 4. Fast-forward pull — the actual code upgrade.
-git pull --ff-only "$REMOTE" "$BRANCH" || { echo "self-upgrade: git pull --ff-only failed" >&2; exit 2; }
+# 4. Fast-forward to the PINNED object — the actual code upgrade. `git pull`
+#    would fetch again and activate whatever the remote moved to since the gate.
+git merge --ff-only "$TARGET_SHA" || { echo "self-upgrade: fast-forward to ${TARGET_SHA:0:8} failed" >&2; exit 2; }
 NOW="$(git rev-parse --short HEAD)"
 echo "self-upgrade: pulled $LOCAL -> $NOW (0 behind)"
 

--- a/skills/self-upgrade/scripts/upgrade.sh
+++ b/skills/self-upgrade/scripts/upgrade.sh
@@ -127,9 +127,17 @@ if [ "$GATE_VAULT" = "true" ]; then
   # Stamp before the sync so this host's own records travel WITH the claim that
   # peers can see them; a stamp pushed without its records is a false claim.
   [ -n "$GATE_HOST" ] && "$GATE_PY" "$GATE_HELPER" --workspace "$GATE_WS" publish --host "$GATE_HOST" >/dev/null 2>&1 || true
-  # Full tick, not --pull-only: pulling alone never publishes this host, so a
-  # fleet of pull-only updaters ages every stamp out and then refuses forever.
-  bash "$REPO/scripts/sync-workspace.sh" || { echo "self-upgrade: ABORT — vault sync failed, so the fleet's witness-owed records cannot be called fresh" >&2; exit 4; }
+  # --pull-strict, not the default tick: the default returns the PUSH's rc and
+  # its zero says nothing about whether peer records arrived (exit 3 = pull leg).
+  GATE_SYNC_RC=0
+  bash "$REPO/scripts/sync-workspace.sh" --pull-strict || GATE_SYNC_RC=$?
+  if [ "$GATE_SYNC_RC" = "3" ]; then
+    echo "self-upgrade: ABORT — vault sync's PULL leg failed, so this host's view of the fleet's witness-owed records is not current" >&2
+    exit 4
+  elif [ "$GATE_SYNC_RC" != "0" ]; then
+    echo "self-upgrade: ABORT — vault sync failed (exit $GATE_SYNC_RC, push leg), so the fleet's witness-owed records cannot be called fresh" >&2
+    exit 4
+  fi
 elif [ -d "$GATE_WS/hosts" ] && [ -n "$GATE_HOST" ] && find "$GATE_WS/hosts" -mindepth 2 -maxdepth 2 -name witness-owed -not -path "$GATE_WS/hosts/$GATE_HOST/*" | grep -q .; then
   echo "self-upgrade: ABORT — foreign host witness-owed subtrees exist but the vault is disabled, so they cannot be refreshed" >&2
   echo "  Enable the vault, or re-stamp this host's view once its records are current:" >&2

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3314,8 +3314,10 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
                 "detail": f"live checkout is on {expected!r} but {behind} commits behind "
                           f"origin/{expected} — merged fixes are not running here, and a "
                           "guard that never shipped to this machine reports nothing (so "
-                          "silence reads as health). Refresh with "
-                          f"`git -C {repo} pull --ff-only` + restart. Count is against the "
+                          "silence reads as health). Refresh THROUGH THE GATE with "
+                          f"`bash {repo}/skills/self-upgrade/scripts/upgrade.sh` (it fast-forwards "
+                          "and restarts; a direct `git pull` activates a head that still owes its "
+                          "witness). Count is against the "
                           "last-fetched ref; this probe does not fetch."}
     # Count is the wrong instrument for BEHAVIORAL staleness, and the threshold
     # above is deliberately 10 to avoid alert fatigue — correctly, since `main`
@@ -3361,15 +3363,15 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
                         "count is not available)")
             # "of them" needs a total to refer to.
             share = f"{len(subset)} commit(s) change"
-            refresh = (f"`git -C {repo} fetch --unshallow` first; `pull --ff-only` cannot "
-                       "apply without a shared history")
+            refresh = (f"`git -C {repo} fetch --unshallow` first; the gate-aware updater's "
+                       "`--ff-only` cannot apply without a shared history")
         else:
             distance = (f"live checkout is on {expected!r} and only {behind} commit(s) behind "
                         f"origin/{expected} — under the {_behind_warn_threshold(repo)}-commit "
                         "nag threshold")
             # The count above is the TOTAL, so "of them" keeps the subset a subset.
             share = f"{len(subset)} of them change"
-            refresh = f"`git -C {repo} pull --ff-only`"
+            refresh = f"`bash {repo}/skills/self-upgrade/scripts/upgrade.sh` (gate-aware; a direct `git pull` bypasses it)"
         tail = (f"Measured against the last-fetched ref; this probe does not fetch, "
                 f"so it can only under-report.")
         if stale_skills:
@@ -3388,7 +3390,7 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
                           "and while the checkout is behind those agree exactly. "
                           f"({'; '.join(stale_services[:3])}"
                           f"{'; …' if len(stale_services) > 3 else ''}) Refresh with "
-                          f"{refresh} + restart the affected service. {tail}"}
+                          f"{refresh}, which restarts the affected service. {tail}"}
     return {"name": name, "status": "ok",
             "detail": f"live checkout on {expected!r}"
                       + (f", {behind} commits behind" if behind else "")

--- a/src/witness_owed.py
+++ b/src/witness_owed.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Durable record of a live-path witness a merged PR still owes.
+
+REVIEW.md lesson 15 lets a live-path PR merge on harness proof only when no
+host can produce its post-restart round trip. That deferral is a promise made
+in a PR thread, which nothing on the deployment path reads. This module is the
+record the deployment path reads: `self-upgrade` refuses to activate a head
+that contains an owed PR until the record is closed with the witness, or the
+activation is an explicit canary on the host that owes it.
+
+Records live under <workspace>/state/witness-owed/<owner>-<repo>#<pr>.json and
+move to closed/ once the witness is posted. Policy only: no transport, no
+provider calls, no workspace resolution beyond the path handed in.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_RECORD_KEY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
+_SHA = re.compile(r"^[0-9a-f]{7,40}$")
+FIELDS = ("repo", "pr", "head", "host", "reason", "opened_by", "opened_at")
+
+
+def records_dir(workspace: Path) -> Path:
+    return Path(workspace) / "state" / "witness-owed"
+
+
+def record_path(workspace: Path, repo: str, pr: int) -> Path:
+    return records_dir(workspace) / f"{repo.replace('/', '-')}#{int(pr)}.json"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=1, sort_keys=True) + "\n")
+    os.replace(tmp, path)
+
+
+def open_record(workspace: Path, repo: str, pr: int, head: str, host: str,
+                reason: str, opened_by: str) -> Path:
+    """Write the owed-witness record. Every field is required: a record that
+    cannot say which head, which host, or why is not a deferral."""
+    if not _RECORD_KEY.match(f"{repo}#{pr}"):
+        raise ValueError(f"repo#pr must look like owner/name#N, got {repo}#{pr}")
+    if not _SHA.match(head or ""):
+        raise ValueError("head must be a commit sha")
+    for name, value in (("host", host), ("reason", reason), ("opened_by", opened_by)):
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{name} must be a non-empty string")
+    path = record_path(workspace, repo, pr)
+    _atomic_write(path, {"repo": repo, "pr": int(pr), "head": head, "host": host,
+                         "reason": reason.strip(), "opened_by": opened_by,
+                         "opened_at": _now(), "canary": None})
+    return path
+
+
+def list_open(workspace: Path) -> list[dict]:
+    """Open records, malformed ones included as blocking: a record that
+    cannot be read is not evidence the witness was posted."""
+    out = []
+    d = records_dir(workspace)
+    if not d.is_dir():
+        return out
+    for p in sorted(d.glob("*.json")):
+        try:
+            data = json.loads(p.read_text())
+            if not isinstance(data, dict) or any(k not in data for k in FIELDS):
+                raise ValueError("missing fields")
+        except (OSError, ValueError) as exc:
+            data = {"repo": "?", "pr": 0, "head": "", "host": "?", "opened_by": "?",
+                    "opened_at": "?", "reason": f"unreadable record {p.name}: {exc}",
+                    "canary": None, "malformed": True}
+        data["path"] = str(p)
+        out.append(data)
+    return out
+
+
+def _is_ancestor(repo_root: Path, ancestor: str, ref: str) -> bool:
+    r = subprocess.run(["git", "-C", str(repo_root), "merge-base", "--is-ancestor",
+                        ancestor, ref], capture_output=True, text=True)
+    if r.returncode in (0, 1):
+        return r.returncode == 0
+    # An unknown sha is not proof of absence; treat as contained (fail closed).
+    return True
+
+
+def blocking(workspace: Path, repo_root: Path, target_ref: str,
+             current_ref: str | None = None, host: str | None = None) -> list[dict]:
+    """Open records whose head is contained in target_ref and not already in
+    current_ref. A canary record for THIS host does not block: that host is
+    the one producing the witness, and it cannot do so without activating."""
+    hits = []
+    for rec in list_open(workspace):
+        if rec.get("malformed"):
+            hits.append(rec)
+            continue
+        if not _is_ancestor(repo_root, rec["head"], target_ref):
+            continue
+        if current_ref and _is_ancestor(repo_root, rec["head"], current_ref):
+            continue
+        if host and rec.get("canary") == host:
+            continue
+        hits.append(rec)
+    return hits
+
+
+def mark_canary(workspace: Path, repo: str, pr: int, host: str) -> Path:
+    path = record_path(workspace, repo, pr)
+    data = json.loads(path.read_text())
+    data["canary"] = host
+    data["canary_at"] = _now()
+    _atomic_write(path, data)
+    return path
+
+
+def close_record(workspace: Path, repo: str, pr: int, witness: str) -> Path:
+    """Retire the record with the witness's location; the closed copy keeps
+    the audit trail beside the open ones."""
+    if not isinstance(witness, str) or not witness.strip():
+        raise ValueError("witness must name where the round trip was posted")
+    path = record_path(workspace, repo, pr)
+    data = json.loads(path.read_text())
+    data["witness"] = witness.strip()
+    data["closed_at"] = _now()
+    closed = records_dir(workspace) / "closed" / path.name
+    _atomic_write(closed, data)
+    path.unlink()
+    return closed
+
+
+def _split(key: str) -> tuple[str, int]:
+    if not _RECORD_KEY.match(key):
+        raise SystemExit(f"witness-owed: expected owner/name#N, got {key!r}")
+    repo, pr = key.rsplit("#", 1)
+    return repo, int(pr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="witness_owed")
+    ap.add_argument("--workspace", required=True)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    o = sub.add_parser("open")
+    o.add_argument("key"); o.add_argument("--head", required=True)
+    o.add_argument("--host", required=True); o.add_argument("--reason", required=True)
+    o.add_argument("--by", required=True)
+    sub.add_parser("list")
+    c = sub.add_parser("check")
+    c.add_argument("--ref", required=True); c.add_argument("--current")
+    c.add_argument("--repo-root", default="."); c.add_argument("--host")
+    m = sub.add_parser("canary"); m.add_argument("key"); m.add_argument("--host", required=True)
+    x = sub.add_parser("close"); x.add_argument("key"); x.add_argument("--witness", required=True)
+    a = ap.parse_args(argv)
+    ws = Path(a.workspace)
+    if a.cmd == "open":
+        repo, pr = _split(a.key)
+        print(open_record(ws, repo, pr, a.head, a.host, a.reason, a.by)); return 0
+    if a.cmd == "list":
+        for rec in list_open(ws):
+            print(f"{rec['repo']}#{rec['pr']} head={rec['head'][:8]} host={rec['host']} "
+                  f"canary={rec.get('canary')} reason={rec['reason']}")
+        return 0
+    if a.cmd == "check":
+        hits = blocking(ws, Path(a.repo_root), a.ref, a.current, a.host)
+        for rec in hits:
+            print(f"witness owed: {rec['repo']}#{rec['pr']} head={rec['head'][:8]} "
+                  f"host={rec['host']} — {rec['reason']}", file=sys.stderr)
+        return 3 if hits else 0
+    if a.cmd == "canary":
+        repo, pr = _split(a.key); print(mark_canary(ws, repo, pr, a.host)); return 0
+    if a.cmd == "close":
+        repo, pr = _split(a.key); print(close_record(ws, repo, pr, a.witness)); return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/witness_owed.py
+++ b/src/witness_owed.py
@@ -25,8 +25,6 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-from workspace_default import resolve_workspace  # noqa: E402
 
 _RECORD_KEY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
 _SHA = re.compile(r"^[0-9a-f]{7,40}$")
@@ -244,7 +242,14 @@ def main(argv: list[str] | None = None) -> int:
     m = sub.add_parser("canary"); m.add_argument("key"); m.add_argument("--host", required=True)
     x = sub.add_parser("close"); x.add_argument("key"); x.add_argument("--witness", required=True)
     a = ap.parse_args(argv)
-    ws = Path(a.workspace) if a.workspace else resolve_workspace(migrate=False)
+    if a.workspace:
+        ws = Path(a.workspace)
+    else:
+        # Resolved lazily: with --workspace given, the helper must run in any
+        # checkout, including one that ships without the resolver module.
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from workspace_default import resolve_workspace
+        ws = resolve_workspace(migrate=False)
     if a.cmd == "open":
         repo, pr = _split(a.key)
         print(open_record(ws, repo, pr, a.head, a.host, a.reason, a.by)); return 0

--- a/src/witness_owed.py
+++ b/src/witness_owed.py
@@ -23,6 +23,7 @@ import re
 import subprocess
 import sys
 import uuid
+from hashlib import sha256
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -216,13 +217,54 @@ def list_open(workspace: Path) -> list[dict]:
     return out
 
 
+EMPTY_DIGEST = sha256().hexdigest()
+
+
+def records_digest(workspace: Path, host: str) -> str:
+    """Content hash of everything under this host's subtree except the stamp.
+
+    A timestamp alone says only WHEN someone stamped; it cannot say WHAT was
+    stamped, so a record opened a second later still read as published."""
+    d = records_dir(workspace, host)
+    h = sha256()
+    if d.is_dir():
+        for f in sorted(x for x in d.rglob("*") if x.is_file() and x.name != STAMP_NAME
+                        and not x.name.endswith(".tmp")):
+            h.update(str(f.relative_to(d)).encode())
+            h.update(b"\0")
+            h.update(f.read_bytes())
+            h.update(b"\0")
+    return h.hexdigest()
+
+
 def publish(workspace: Path, host: str) -> Path:
-    """Stamp this host's subtree so peers can tell a fresh view from a stale one."""
-    if not isinstance(host, str) or not host.strip():
-        raise ValueError("host must be a non-empty string")
+    """Stamp this host's subtree with WHAT it contains, not just when.
+
+    Call this only after the subtree has been pushed: the stamp is a claim
+    that peers can see these records, and an unpushed stamp claims it falsely."""
+    validate_host(host)
     p = records_dir(workspace, host) / STAMP_NAME
-    _atomic_write(p, {"host": host, "published_at": _now()})
+    _atomic_write(p, {"host": host, "published_at": _now(),
+                      "records": records_digest(workspace, host)})
     return p
+
+
+def unpublished(workspace: Path, host: str) -> bool:
+    """True when this host's records have moved since it last published.
+
+    Every writer leaves this True, so opening a record un-publishes the host
+    by CONSTRUCTION rather than by waiting for a clock to age out."""
+    d = records_dir(workspace, host)
+    digest = records_digest(workspace, host)
+    try:
+        stamp = json.loads((d / STAMP_NAME).read_text())
+    except (OSError, ValueError):
+        # A host with nothing to publish is not unpublished — otherwise every
+        # host without records blocks itself and the fleet cannot move at all.
+        return digest != EMPTY_DIGEST
+    if not isinstance(stamp, dict) or stamp.get("host") != host:
+        return True
+    return stamp.get("records") != digest
 
 
 def stale_hosts(workspace: Path, host: str | None, max_age_s: float,
@@ -241,6 +283,10 @@ def stale_hosts(workspace: Path, host: str | None, max_age_s: float,
             # evidence; unchecked, one host's stamp vouched for another's view.
             if not isinstance(stamp, dict) or stamp.get("host") != h:
                 raise ValueError("stamp does not name the host whose directory holds it")
+            # The stamp must describe the records that arrived with it: a fresh
+            # timestamp beside changed records is not a published view.
+            if stamp.get("records") != records_digest(workspace, h):
+                raise ValueError("stamp does not describe this host's current records")
             t = stamp.get("published_at")
             age = (now - datetime.strptime(t, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)).total_seconds()
         except (OSError, ValueError, TypeError):
@@ -322,6 +368,13 @@ def blocking(workspace: Path, repo_root: Path, target_ref: str,
     that owes the witness. With max_age_s, a foreign host whose stamp is
     missing or older blocks by itself: its records cannot be called fresh."""
     hits = []
+    if max_age_s is not None and host:
+        # A peer cannot fix this one and neither can waiting: the operator can.
+        if unpublished(workspace, host):
+            hits.append({"repo": "?", "pr": 0, "head": "", "host": host, "opened_by": "?",
+                         "opened_at": "?", "canary": None, "stale": True,
+                         "reason": f"host {host} has records its own stamp does not describe: "
+                                   "publish and push this subtree before activating"})
     if max_age_s is not None:
         for h in stale_hosts(workspace, host, max_age_s):
             hits.append({"repo": "?", "pr": 0, "head": "", "host": h, "opened_by": "?",

--- a/src/witness_owed.py
+++ b/src/witness_owed.py
@@ -8,9 +8,11 @@ record the deployment path reads: `self-upgrade` refuses to activate a head
 that contains an owed PR until the record is closed with the witness, or the
 activation is an explicit canary on the host that owes it.
 
-Records live under <workspace>/state/witness-owed/<owner>-<repo>#<pr>.json and
-move to closed/ once the witness is posted. Policy only: no transport, no
-provider calls, no workspace resolution beyond the path handed in.
+Records live under <workspace>/hosts/<host>/witness-owed/<owner>-<repo>#<pr>.json
+— inside the per-host subtree the vault carries to every host — and move to
+closed/ once the witness is posted. Readers scan every host's directory, so a
+record opened on one host refuses activation on all of them. Policy only: no
+transport, no provider calls, no workspace resolution beyond what is handed in.
 """
 from __future__ import annotations
 
@@ -31,12 +33,29 @@ _SHA = re.compile(r"^[0-9a-f]{7,40}$")
 FIELDS = ("repo", "pr", "head", "host", "reason", "opened_by", "opened_at")
 
 
-def records_dir(workspace: Path) -> Path:
-    return Path(workspace) / "state" / "witness-owed"
+def records_dir(workspace: Path, host: str) -> Path:
+    """Where THIS host writes: the carried per-host subtree, never state/."""
+    return Path(workspace) / "hosts" / host / "witness-owed"
 
 
-def record_path(workspace: Path, repo: str, pr: int) -> Path:
-    return records_dir(workspace) / f"{repo.replace('/', '-')}#{int(pr)}.json"
+def all_records_dirs(workspace: Path) -> list[Path]:
+    """Every host's record directory present in this workspace."""
+    hosts = Path(workspace) / "hosts"
+    if not hosts.is_dir():
+        return []
+    return sorted(d / "witness-owed" for d in hosts.iterdir() if (d / "witness-owed").is_dir())
+
+
+def record_path(workspace: Path, host: str, repo: str, pr: int) -> Path:
+    return records_dir(workspace, host) / f"{repo.replace('/', '-')}#{int(pr)}.json"
+
+
+def find_record(workspace: Path, repo: str, pr: int) -> Path | None:
+    name = f"{repo.replace('/', '-')}#{int(pr)}.json"
+    for d in all_records_dirs(workspace):
+        if (d / name).is_file():
+            return d / name
+    return None
 
 
 def _now() -> str:
@@ -61,7 +80,7 @@ def open_record(workspace: Path, repo: str, pr: int, head: str, host: str,
     for name, value in (("host", host), ("reason", reason), ("opened_by", opened_by)):
         if not isinstance(value, str) or not value.strip():
             raise ValueError(f"{name} must be a non-empty string")
-    path = record_path(workspace, repo, pr)
+    path = record_path(workspace, host, repo, pr)
     _atomic_write(path, {"repo": repo, "pr": int(pr), "head": head, "host": host,
                          "reason": reason.strip(), "opened_by": opened_by,
                          "opened_at": _now(), "canary": None})
@@ -69,58 +88,117 @@ def open_record(workspace: Path, repo: str, pr: int, head: str, host: str,
 
 
 def list_open(workspace: Path) -> list[dict]:
-    """Open records, malformed ones included as blocking: a record that
-    cannot be read is not evidence the witness was posted."""
+    """Open records from EVERY host directory; malformed ones are included as
+    blocking, since a record that cannot be read is not evidence the witness
+    was posted."""
     out = []
-    d = records_dir(workspace)
-    if not d.is_dir():
-        return out
-    for p in sorted(d.glob("*.json")):
-        try:
-            data = json.loads(p.read_text())
-            if not isinstance(data, dict) or any(k not in data for k in FIELDS):
-                raise ValueError("missing fields")
-        except (OSError, ValueError) as exc:
-            data = {"repo": "?", "pr": 0, "head": "", "host": "?", "opened_by": "?",
-                    "opened_at": "?", "reason": f"unreadable record {p.name}: {exc}",
-                    "canary": None, "malformed": True}
-        data["path"] = str(p)
-        out.append(data)
+    for d in all_records_dirs(workspace):
+        for p in sorted(d.glob("*.json")):
+            try:
+                data = json.loads(p.read_text())
+                if not isinstance(data, dict) or any(k not in data for k in FIELDS):
+                    raise ValueError("missing fields")
+            except (OSError, ValueError) as exc:
+                data = {"repo": "?", "pr": 0, "head": "", "host": "?", "opened_by": "?",
+                        "opened_at": "?", "reason": f"unreadable record {p.name}: {exc}",
+                        "canary": None, "malformed": True}
+            data["path"] = str(p)
+            out.append(data)
     return out
 
 
-def _is_ancestor(repo_root: Path, ancestor: str, ref: str) -> bool:
-    r = subprocess.run(["git", "-C", str(repo_root), "merge-base", "--is-ancestor",
-                        ancestor, ref], capture_output=True, text=True)
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo_root), *args],
+                          capture_output=True, text=True)
+
+
+def _is_ancestor(repo_root: Path, ancestor: str, ref: str) -> bool | None:
+    """True / False, or None when Git could not answer. A head this clone has
+    never fetched is the normal squash/rebase case, not an error: an absent
+    object cannot be an ancestor, so that is False and the subject scan
+    decides. A bad ref or a broken repository is None; callers fail closed."""
+    if _git(repo_root, "cat-file", "-e", f"{ancestor}^{{commit}}").returncode != 0:
+        if _git(repo_root, "rev-parse", "--verify", "-q", f"{ref}^{{commit}}").returncode != 0:
+            return None
+        return False
+    r = _git(repo_root, "merge-base", "--is-ancestor", ancestor, ref)
     if r.returncode in (0, 1):
         return r.returncode == 0
-    # An unknown sha is not proof of absence; treat as contained (fail closed).
-    return True
+    return None
+
+
+_MERGE_SUBJECT = re.compile(r"\(#(\d+)\)\s*$")
+
+
+def _contains(repo_root: Path, rec: dict, ref: str, since: str | None = None
+              ) -> bool | None:
+    """Does `ref` (optionally only the range since..ref) contain the owed PR?
+
+    A merge commit keeps the PR head as an ancestor; a squash or rebase merge
+    does not, so the PR is also recognised by its merge subject `(#N)` and by a
+    commit body naming the recorded head. None when Git could not answer."""
+    anc = _is_ancestor(repo_root, rec["head"], ref)
+    if anc is None:
+        return None
+    if anc:
+        if since is None:
+            return True
+        prior = _is_ancestor(repo_root, rec["head"], since)
+        if prior is None:
+            return None
+        if not prior:
+            return True
+    rng = f"{since}..{ref}" if since else ref
+    r = _git(repo_root, "log", "--format=%H%x1f%s%x1f%b%x1e", rng)
+    if r.returncode != 0:
+        return None
+    pr = str(int(rec["pr"]))
+    for entry in r.stdout.split("\x1e"):
+        parts = entry.strip("\n").split("\x1f")
+        if len(parts) < 2:
+            continue
+        subject = parts[1]
+        body = parts[2] if len(parts) > 2 else ""
+        m = _MERGE_SUBJECT.search(subject)
+        if (m and m.group(1) == pr) or (rec["head"] and rec["head"] in body):
+            return True
+    return False
 
 
 def blocking(workspace: Path, repo_root: Path, target_ref: str,
              current_ref: str | None = None, host: str | None = None) -> list[dict]:
-    """Open records whose head is contained in target_ref and not already in
-    current_ref. A canary record for THIS host does not block: that host is
-    the one producing the witness, and it cannot do so without activating."""
+    """Open records whose PR is contained in target_ref and not already in
+    current_ref. A Git error on either question blocks (fail closed). A canary
+    record releases only the host it names, and only when that is the host
+    that owes the witness."""
     hits = []
     for rec in list_open(workspace):
         if rec.get("malformed"):
             hits.append(rec)
             continue
-        if not _is_ancestor(repo_root, rec["head"], target_ref):
+        verdict = _contains(repo_root, rec, target_ref, current_ref)
+        if verdict is None:
+            rec["reason"] = f"git could not answer for head {rec['head'][:8]}: {rec['reason']}"
+            hits.append(rec)
             continue
-        if current_ref and _is_ancestor(repo_root, rec["head"], current_ref):
+        if not verdict:
             continue
-        if host and rec.get("canary") == host:
+        if host and rec.get("canary") == host and rec.get("host") == host:
             continue
         hits.append(rec)
     return hits
 
 
 def mark_canary(workspace: Path, repo: str, pr: int, host: str) -> Path:
-    path = record_path(workspace, repo, pr)
+    """Declare `host` the canary. Only the host that owes the witness may:
+    a record marked by any other host would release an activation the
+    deferral never covered."""
+    path = find_record(workspace, repo, pr)
+    if path is None:
+        raise FileNotFoundError(f"no open witness-owed record for {repo}#{pr}")
     data = json.loads(path.read_text())
+    if data.get("host") != host:
+        raise ValueError(f"{repo}#{pr} is owed by {data.get('host')!r}, not {host!r}")
     data["canary"] = host
     data["canary_at"] = _now()
     _atomic_write(path, data)
@@ -132,11 +210,13 @@ def close_record(workspace: Path, repo: str, pr: int, witness: str) -> Path:
     the audit trail beside the open ones."""
     if not isinstance(witness, str) or not witness.strip():
         raise ValueError("witness must name where the round trip was posted")
-    path = record_path(workspace, repo, pr)
+    path = find_record(workspace, repo, pr)
+    if path is None:
+        raise FileNotFoundError(f"no open witness-owed record for {repo}#{pr}")
     data = json.loads(path.read_text())
     data["witness"] = witness.strip()
     data["closed_at"] = _now()
-    closed = records_dir(workspace) / "closed" / path.name
+    closed = path.parent / "closed" / path.name
     _atomic_write(closed, data)
     path.unlink()
     return closed
@@ -180,9 +260,17 @@ def main(argv: list[str] | None = None) -> int:
                   f"host={rec['host']} — {rec['reason']}", file=sys.stderr)
         return 3 if hits else 0
     if a.cmd == "canary":
-        repo, pr = _split(a.key); print(mark_canary(ws, repo, pr, a.host)); return 0
+        repo, pr = _split(a.key)
+        try:
+            print(mark_canary(ws, repo, pr, a.host)); return 0
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"witness-owed: {exc}", file=sys.stderr); return 5
     if a.cmd == "close":
-        repo, pr = _split(a.key); print(close_record(ws, repo, pr, a.witness)); return 0
+        repo, pr = _split(a.key)
+        try:
+            print(close_record(ws, repo, pr, a.witness)); return 0
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"witness-owed: {exc}", file=sys.stderr); return 5
     return 2
 
 

--- a/src/witness_owed.py
+++ b/src/witness_owed.py
@@ -23,6 +23,9 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
 _RECORD_KEY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
 _SHA = re.compile(r"^[0-9a-f]{7,40}$")
 FIELDS = ("repo", "pr", "head", "host", "reason", "opened_by", "opened_at")
@@ -148,7 +151,7 @@ def _split(key: str) -> tuple[str, int]:
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(prog="witness_owed")
-    ap.add_argument("--workspace", required=True)
+    ap.add_argument("--workspace", help="defaults to the resolved Sutando workspace")
     sub = ap.add_subparsers(dest="cmd", required=True)
     o = sub.add_parser("open")
     o.add_argument("key"); o.add_argument("--head", required=True)
@@ -161,7 +164,7 @@ def main(argv: list[str] | None = None) -> int:
     m = sub.add_parser("canary"); m.add_argument("key"); m.add_argument("--host", required=True)
     x = sub.add_parser("close"); x.add_argument("key"); x.add_argument("--witness", required=True)
     a = ap.parse_args(argv)
-    ws = Path(a.workspace)
+    ws = Path(a.workspace) if a.workspace else resolve_workspace(migrate=False)
     if a.cmd == "open":
         repo, pr = _split(a.key)
         print(open_record(ws, repo, pr, a.head, a.host, a.reason, a.by)); return 0

--- a/src/witness_owed.py
+++ b/src/witness_owed.py
@@ -27,8 +27,42 @@ from pathlib import Path
 
 
 _RECORD_KEY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
+_REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _SHA = re.compile(r"^[0-9a-f]{7,40}$")
+_STAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 FIELDS = ("repo", "pr", "head", "host", "reason", "opened_by", "opened_at")
+STAMP_NAME = ".published"
+DEFAULT_MAX_AGE_S = 3600.0
+
+
+def validate_record(data: object, path: Path) -> dict:
+    """The full schema, and the file's place against its payload: a record
+    whose name, directory host or any value disagrees is not a record."""
+    if not isinstance(data, dict):
+        raise ValueError("not an object")
+    for k in FIELDS:
+        if k not in data:
+            raise ValueError(f"missing field {k}")
+    repo, pr, head, host = data["repo"], data["pr"], data["head"], data["host"]
+    if not isinstance(repo, str) or not _REPO.match(repo):
+        raise ValueError("repo must be owner/name")
+    if isinstance(pr, bool) or not isinstance(pr, int) or pr < 1:
+        raise ValueError("pr must be a positive integer")
+    if not isinstance(head, str) or not _SHA.match(head):
+        raise ValueError("head must be a commit sha")
+    for k in ("host", "reason", "opened_by"):
+        if not isinstance(data[k], str) or not data[k].strip():
+            raise ValueError(f"{k} must be a non-empty string")
+    if not isinstance(data["opened_at"], str) or not _STAMP.match(data["opened_at"]):
+        raise ValueError("opened_at must be an ISO-8601 UTC stamp")
+    canary = data.get("canary")
+    if canary is not None and canary != host:
+        raise ValueError("canary may only name the owing host")
+    if path.name != f"{repo.replace('/', '-')}#{pr}.json":
+        raise ValueError(f"file name does not match {repo}#{pr}")
+    if path.parent.name != "witness-owed" or path.parent.parent.name != host:
+        raise ValueError(f"record is not under hosts/{host}/witness-owed/")
+    return data
 
 
 def records_dir(workspace: Path, host: str) -> Path:
@@ -85,23 +119,74 @@ def open_record(workspace: Path, repo: str, pr: int, head: str, host: str,
     return path
 
 
+def tombstones(workspace: Path) -> dict[tuple[str, int], dict]:
+    """(repo, pr) -> tombstone written by a NON-owning host into its own
+    subtree; it closes the record it names without touching a peer's files."""
+    out = {}
+    for d in all_records_dirs(workspace):
+        for p in sorted((d / "tombstones").glob("*.json")):
+            try:
+                t = json.loads(p.read_text())
+                if not isinstance(t, dict) or not _REPO.match(str(t.get("repo"))) \
+                        or not _SHA.match(str(t.get("head"))) or not str(t.get("witness", "")).strip():
+                    continue
+                out[(t["repo"], int(t["pr"]))] = t
+            except (OSError, ValueError, TypeError):
+                continue
+    return out
+
+
 def list_open(workspace: Path) -> list[dict]:
-    """Open records from EVERY host directory; malformed ones are included as
-    blocking, since a record that cannot be read is not evidence the witness
-    was posted."""
+    """Open records from EVERY host directory, fully validated on every read.
+    Malformed ones are included as blocking: a record that cannot be read or
+    does not agree with its own path is not evidence the witness was posted.
+    A record closed by another host's tombstone for the same head is closed."""
     out = []
+    stones = tombstones(workspace)
     for d in all_records_dirs(workspace):
         for p in sorted(d.glob("*.json")):
             try:
-                data = json.loads(p.read_text())
-                if not isinstance(data, dict) or any(k not in data for k in FIELDS):
-                    raise ValueError("missing fields")
+                data = validate_record(json.loads(p.read_text()), p)
             except (OSError, ValueError) as exc:
                 data = {"repo": "?", "pr": 0, "head": "", "host": "?", "opened_by": "?",
                         "opened_at": "?", "reason": f"unreadable record {p.name}: {exc}",
                         "canary": None, "malformed": True}
+            else:
+                stone = stones.get((data["repo"], data["pr"]))
+                if stone and stone.get("head") == data["head"]:
+                    continue
             data["path"] = str(p)
             out.append(data)
+    return out
+
+
+def publish(workspace: Path, host: str) -> Path:
+    """Stamp this host's subtree so peers can tell a fresh view from a stale one."""
+    if not isinstance(host, str) or not host.strip():
+        raise ValueError("host must be a non-empty string")
+    p = records_dir(workspace, host) / STAMP_NAME
+    _atomic_write(p, {"host": host, "published_at": _now()})
+    return p
+
+
+def stale_hosts(workspace: Path, host: str | None, max_age_s: float,
+                now: datetime | None = None) -> list[str]:
+    """Foreign hosts whose stamp is missing or older than max_age_s: the view
+    of THEIR records cannot be called fresh, so a gate must fail closed."""
+    now = now or datetime.now(timezone.utc)
+    out = []
+    for d in all_records_dirs(workspace):
+        h = d.parent.name
+        if h == host:
+            continue
+        try:
+            t = json.loads((d / STAMP_NAME).read_text()).get("published_at")
+            age = (now - datetime.strptime(t, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)).total_seconds()
+        except (OSError, ValueError, TypeError):
+            out.append(h)
+            continue
+        if age > max_age_s or age < -60:
+            out.append(h)
     return out
 
 
@@ -128,13 +213,17 @@ def _is_ancestor(repo_root: Path, ancestor: str, ref: str) -> bool | None:
 _MERGE_SUBJECT = re.compile(r"\(#(\d+)\)\s*$")
 
 
-def _contains(repo_root: Path, rec: dict, ref: str, since: str | None = None
-              ) -> bool | None:
+def _contains(repo_root: Path, rec: dict, ref: str, since: str | None = None,
+              target_repo: str | None = None) -> bool | None:
     """Does `ref` (optionally only the range since..ref) contain the owed PR?
 
     A merge commit keeps the PR head as an ancestor; a squash or rebase merge
     does not, so the PR is also recognised by its merge subject `(#N)` and by a
-    commit body naming the recorded head. None when Git could not answer."""
+    commit body naming the recorded head. The `(#N)` match counts only for the
+    target repository: another project's #N is not this one's. None when Git
+    could not answer."""
+    if target_repo is not None and rec["repo"] != target_repo:
+        return False
     anc = _is_ancestor(repo_root, rec["head"], ref)
     if anc is None:
         return None
@@ -164,17 +253,24 @@ def _contains(repo_root: Path, rec: dict, ref: str, since: str | None = None
 
 
 def blocking(workspace: Path, repo_root: Path, target_ref: str,
-             current_ref: str | None = None, host: str | None = None) -> list[dict]:
+             current_ref: str | None = None, host: str | None = None,
+             target_repo: str | None = None, max_age_s: float | None = None) -> list[dict]:
     """Open records whose PR is contained in target_ref and not already in
     current_ref. A Git error on either question blocks (fail closed). A canary
     record releases only the host it names, and only when that is the host
-    that owes the witness."""
+    that owes the witness. With max_age_s, a foreign host whose stamp is
+    missing or older blocks by itself: its records cannot be called fresh."""
     hits = []
+    if max_age_s is not None:
+        for h in stale_hosts(workspace, host, max_age_s):
+            hits.append({"repo": "?", "pr": 0, "head": "", "host": h, "opened_by": "?",
+                         "opened_at": "?", "canary": None, "stale": True,
+                         "reason": f"host {h} has no fresh publication stamp (max age {max_age_s:.0f}s)"})
     for rec in list_open(workspace):
         if rec.get("malformed"):
             hits.append(rec)
             continue
-        verdict = _contains(repo_root, rec, target_ref, current_ref)
+        verdict = _contains(repo_root, rec, target_ref, current_ref, target_repo)
         if verdict is None:
             rec["reason"] = f"git could not answer for head {rec['head'][:8]}: {rec['reason']}"
             hits.append(rec)
@@ -203,21 +299,42 @@ def mark_canary(workspace: Path, repo: str, pr: int, host: str) -> Path:
     return path
 
 
-def close_record(workspace: Path, repo: str, pr: int, witness: str) -> Path:
+def close_record(workspace: Path, repo: str, pr: int, witness: str, host: str) -> Path:
     """Retire the record with the witness's location; the closed copy keeps
-    the audit trail beside the open ones."""
+    the audit trail beside the open ones. Only the owing host may: the vault
+    refuses a foreign-host deletion, so any other host must tombstone."""
     if not isinstance(witness, str) or not witness.strip():
         raise ValueError("witness must name where the round trip was posted")
     path = find_record(workspace, repo, pr)
     if path is None:
         raise FileNotFoundError(f"no open witness-owed record for {repo}#{pr}")
     data = json.loads(path.read_text())
+    if data.get("host") != host:
+        raise ValueError(f"{repo}#{pr} is owed by {data.get('host')!r}, not {host!r}: "
+                         "tombstone it from this host instead")
     data["witness"] = witness.strip()
     data["closed_at"] = _now()
     closed = path.parent / "closed" / path.name
     _atomic_write(closed, data)
     path.unlink()
     return closed
+
+
+def tombstone_record(workspace: Path, repo: str, pr: int, witness: str, host: str) -> Path:
+    """Close another host's record from THIS host's subtree: the tombstone
+    names the exact head, so a re-opened record for a new head stays open."""
+    if not isinstance(witness, str) or not witness.strip():
+        raise ValueError("witness must name where the round trip was posted")
+    if not isinstance(host, str) or not host.strip():
+        raise ValueError("host must be a non-empty string")
+    path = find_record(workspace, repo, pr)
+    if path is None:
+        raise FileNotFoundError(f"no open witness-owed record for {repo}#{pr}")
+    data = validate_record(json.loads(path.read_text()), path)
+    stone = records_dir(workspace, host) / "tombstones" / path.name
+    _atomic_write(stone, {"repo": repo, "pr": int(pr), "head": data["head"], "owed_by": data["host"],
+                          "witness": witness.strip(), "closed_by": host, "closed_at": _now()})
+    return stone
 
 
 def _split(key: str) -> tuple[str, int]:
@@ -239,8 +356,14 @@ def main(argv: list[str] | None = None) -> int:
     c = sub.add_parser("check")
     c.add_argument("--ref", required=True); c.add_argument("--current")
     c.add_argument("--repo-root", default="."); c.add_argument("--host")
+    c.add_argument("--repo", help="owner/name of the deployment target; scopes (#N) matches")
+    c.add_argument("--max-age", type=float, help="seconds; a foreign host stamped older than this blocks")
     m = sub.add_parser("canary"); m.add_argument("key"); m.add_argument("--host", required=True)
     x = sub.add_parser("close"); x.add_argument("key"); x.add_argument("--witness", required=True)
+    x.add_argument("--host", required=True)
+    t = sub.add_parser("tombstone"); t.add_argument("key"); t.add_argument("--witness", required=True)
+    t.add_argument("--host", required=True)
+    pb = sub.add_parser("publish"); pb.add_argument("--host", required=True)
     a = ap.parse_args(argv)
     if a.workspace:
         ws = Path(a.workspace)
@@ -259,11 +382,19 @@ def main(argv: list[str] | None = None) -> int:
                   f"canary={rec.get('canary')} reason={rec['reason']}")
         return 0
     if a.cmd == "check":
-        hits = blocking(ws, Path(a.repo_root), a.ref, a.current, a.host)
+        hits = blocking(ws, Path(a.repo_root), a.ref, a.current, a.host, a.repo, a.max_age)
         for rec in hits:
             print(f"witness owed: {rec['repo']}#{rec['pr']} head={rec['head'][:8]} "
                   f"host={rec['host']} — {rec['reason']}", file=sys.stderr)
         return 3 if hits else 0
+    if a.cmd == "publish":
+        print(publish(ws, a.host)); return 0
+    if a.cmd == "tombstone":
+        repo, pr = _split(a.key)
+        try:
+            print(tombstone_record(ws, repo, pr, a.witness, a.host)); return 0
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"witness-owed: {exc}", file=sys.stderr); return 5
     if a.cmd == "canary":
         repo, pr = _split(a.key)
         try:
@@ -273,7 +404,7 @@ def main(argv: list[str] | None = None) -> int:
     if a.cmd == "close":
         repo, pr = _split(a.key)
         try:
-            print(close_record(ws, repo, pr, a.witness)); return 0
+            print(close_record(ws, repo, pr, a.witness, a.host)); return 0
         except (FileNotFoundError, ValueError) as exc:
             print(f"witness-owed: {exc}", file=sys.stderr); return 5
     return 2

--- a/src/witness_owed.py
+++ b/src/witness_owed.py
@@ -22,6 +22,7 @@ import os
 import re
 import subprocess
 import sys
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -30,9 +31,26 @@ _RECORD_KEY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
 _REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _SHA = re.compile(r"^[0-9a-f]{7,40}$")
 _STAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+_HOST = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+TOMBSTONE_FIELDS = ("repo", "pr", "head", "owed_by", "witness", "closed_by", "closed_at")
 FIELDS = ("repo", "pr", "head", "host", "reason", "opened_by", "opened_at")
 STAMP_NAME = ".published"
 DEFAULT_MAX_AGE_S = 3600.0
+
+
+def validate_host(host: object) -> str:
+    """A host becomes a path component, so it must be ONE ordinary segment.
+    A bare non-empty check let `../../x` resolve outside the workspace."""
+    if not isinstance(host, str) or not _HOST.match(host) or host in (".", ".."):
+        raise ValueError(f"host must be one path segment matching {_HOST.pattern}, got {host!r}")
+    return host
+
+
+def record_key(repo: str, pr: int) -> str:
+    """Percent-encoding, because `/`->`-` is NOT injective: `a-b/c` and
+    `a/b-c` both became `a-b-c`, so two repos shared one record file."""
+    enc = repo.replace("%", "%25").replace("/", "%2F")
+    return f"{enc}#{int(pr)}.json"
 
 
 def validate_record(data: object, path: Path) -> dict:
@@ -58,7 +76,7 @@ def validate_record(data: object, path: Path) -> dict:
     canary = data.get("canary")
     if canary is not None and canary != host:
         raise ValueError("canary may only name the owing host")
-    if path.name != f"{repo.replace('/', '-')}#{pr}.json":
+    if path.name != record_key(repo, pr):
         raise ValueError(f"file name does not match {repo}#{pr}")
     if path.parent.name != "witness-owed" or path.parent.parent.name != host:
         raise ValueError(f"record is not under hosts/{host}/witness-owed/")
@@ -67,7 +85,13 @@ def validate_record(data: object, path: Path) -> dict:
 
 def records_dir(workspace: Path, host: str) -> Path:
     """Where THIS host writes: the carried per-host subtree, never state/."""
-    return Path(workspace) / "hosts" / host / "witness-owed"
+    validate_host(host)
+    d = Path(workspace) / "hosts" / host / "witness-owed"
+    # Containment is checked on the RESOLVED pair and the caller keeps its own
+    # path shape: returning the resolved form rewrites /var -> /private/var.
+    if Path(workspace).resolve() not in d.resolve().parents:
+        raise ValueError(f"host {host!r} resolves outside the workspace")
+    return d
 
 
 def all_records_dirs(workspace: Path) -> list[Path]:
@@ -79,11 +103,11 @@ def all_records_dirs(workspace: Path) -> list[Path]:
 
 
 def record_path(workspace: Path, host: str, repo: str, pr: int) -> Path:
-    return records_dir(workspace, host) / f"{repo.replace('/', '-')}#{int(pr)}.json"
+    return records_dir(workspace, host) / record_key(repo, pr)
 
 
 def find_record(workspace: Path, repo: str, pr: int) -> Path | None:
-    name = f"{repo.replace('/', '-')}#{int(pr)}.json"
+    name = record_key(repo, pr)
     for d in all_records_dirs(workspace):
         if (d / name).is_file():
             return d / name
@@ -96,7 +120,9 @@ def _now() -> str:
 
 def _atomic_write(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
+    # One shared `.tmp` name made two concurrent writers race: the loser's
+    # os.replace hit a name the winner had already consumed (FileNotFoundError).
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex[:8]}.tmp")
     tmp.write_text(json.dumps(data, indent=1, sort_keys=True) + "\n")
     os.replace(tmp, path)
 
@@ -126,14 +152,44 @@ def tombstones(workspace: Path) -> dict[tuple[str, int], dict]:
     for d in all_records_dirs(workspace):
         for p in sorted((d / "tombstones").glob("*.json")):
             try:
-                t = json.loads(p.read_text())
-                if not isinstance(t, dict) or not _REPO.match(str(t.get("repo"))) \
-                        or not _SHA.match(str(t.get("head"))) or not str(t.get("witness", "")).strip():
-                    continue
-                out[(t["repo"], int(t["pr"]))] = t
+                t = validate_tombstone(json.loads(p.read_text()), p)
             except (OSError, ValueError, TypeError):
                 continue
+            out[(t["repo"], int(t["pr"]))] = t
     return out
+
+
+def validate_tombstone(data: object, path: Path) -> dict:
+    """A tombstone CLOSES another host's record, so it is validated exactly as
+    hard as one. Three fields were checked; the writer's path, owners and
+    timestamp were not, and a malformed tombstone silently cleared a record."""
+    if not isinstance(data, dict):
+        raise ValueError("not an object")
+    for k in TOMBSTONE_FIELDS:
+        if k not in data:
+            raise ValueError(f"missing field {k}")
+    repo, pr, head = data["repo"], data["pr"], data["head"]
+    if not isinstance(repo, str) or not _REPO.match(repo):
+        raise ValueError("repo must be owner/name")
+    if isinstance(pr, bool) or not isinstance(pr, int) or pr < 1:
+        raise ValueError("pr must be a positive integer")
+    if not isinstance(head, str) or not _SHA.match(head):
+        raise ValueError("head must be a commit sha")
+    for k in ("owed_by", "witness", "closed_by"):
+        if not isinstance(data[k], str) or not data[k].strip():
+            raise ValueError(f"{k} must be a non-empty string")
+    validate_host(data["owed_by"])
+    validate_host(data["closed_by"])
+    if data["owed_by"] == data["closed_by"]:
+        raise ValueError("a tombstone is a FOREIGN closure; the owing host closes its own record")
+    if not isinstance(data["closed_at"], str) or not _STAMP.match(data["closed_at"]):
+        raise ValueError("closed_at must be an ISO-8601 UTC stamp")
+    if path.name != record_key(repo, pr):
+        raise ValueError(f"file name does not match {repo}#{pr}")
+    if path.parent.name != "tombstones" or path.parent.parent.name != "witness-owed" \
+            or path.parent.parent.parent.name != data["closed_by"]:
+        raise ValueError(f"tombstone is not under hosts/{data['closed_by']}/witness-owed/tombstones/")
+    return data
 
 
 def list_open(workspace: Path) -> list[dict]:
@@ -180,7 +236,12 @@ def stale_hosts(workspace: Path, host: str | None, max_age_s: float,
         if h == host:
             continue
         try:
-            t = json.loads((d / STAMP_NAME).read_text()).get("published_at")
+            stamp = json.loads((d / STAMP_NAME).read_text())
+            # A stamp naming a different host is not this host's freshness
+            # evidence; unchecked, one host's stamp vouched for another's view.
+            if not isinstance(stamp, dict) or stamp.get("host") != h:
+                raise ValueError("stamp does not name the host whose directory holds it")
+            t = stamp.get("published_at")
             age = (now - datetime.strptime(t, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)).total_seconds()
         except (OSError, ValueError, TypeError):
             out.append(h)

--- a/src/witness_owed.py
+++ b/src/witness_owed.py
@@ -13,16 +13,41 @@ Records live under <workspace>/hosts/<host>/witness-owed/<owner>-<repo>#<pr>.jso
 closed/ once the witness is posted. Readers scan every host's directory, so a
 record opened on one host refuses activation on all of them. Policy only: no
 transport, no provider calls, no workspace resolution beyond what is handed in.
+
+PUBLICATION CONTRACT — what "published" means, and when the gate may trust it.
+
+A hold is PUBLISHED when this host's witness-owed subtree AND a stamp naming
+its exact bytes have been pushed to the vault. The stamp is a claim, never
+proof: `publish()` writes it, and the push that makes it true belongs to the
+caller. So `open` takes `--publish-with <command>` and runs it synchronously;
+if that command fails the stamp is removed again, leaving the host visibly
+unpublished, and the exit code says the hold is local-only. A hold that never
+left its host binds only that host — which is why an unpublished host cannot
+activate (`unpublished()` -> a blocking hit) and why failing to publish is
+loud rather than silent.
+
+The gate may trust a peer host's directory only when ALL of:
+  (a) the deploying host's own PULL leg succeeded this run — the caller's job
+      (`sync-workspace.sh --pull-strict`, exit 3 on a refused pull);
+  (b) the peer's stamp names the host whose directory holds it;
+  (c) the stamp's digest describes the bytes that actually arrived;
+  (d) the stamp is younger than max-age and not from the future.
+Any of (b)-(d) failing makes that host stale, and a stale host blocks by
+itself: a directory whose freshness cannot be established is not evidence
+that it holds no hold.
 """
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
+import math
 import os
 import re
 import subprocess
 import sys
 import uuid
+from contextlib import contextmanager
 from hashlib import sha256
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,7 +57,7 @@ _RECORD_KEY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
 _REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _SHA = re.compile(r"^[0-9a-f]{7,40}$")
 _STAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
-_HOST = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_HOST_ILLEGAL = re.compile(r"[/\\\x00-\x1f\x7f]")
 TOMBSTONE_FIELDS = ("repo", "pr", "head", "owed_by", "witness", "closed_by", "closed_at")
 FIELDS = ("repo", "pr", "head", "host", "reason", "opened_by", "opened_at")
 STAMP_NAME = ".published"
@@ -40,10 +65,14 @@ DEFAULT_MAX_AGE_S = 3600.0
 
 
 def validate_host(host: object) -> str:
-    """A host becomes a path component, so it must be ONE ordinary segment.
-    A bare non-empty check let `../../x` resolve outside the workspace."""
-    if not isinstance(host, str) or not _HOST.match(host) or host in (".", ".."):
-        raise ValueError(f"host must be one path segment matching {_HOST.pattern}, got {host!r}")
+    """ONE ordinary path segment, and no narrower: the label is whatever
+    `_host_label()` resolved, and that contract trims the ENDS only — so the
+    legal `My Mac` keeps its space, while `/`, `.`, `..` and control
+    characters stay refused because they would resolve somewhere else."""
+    if not isinstance(host, str) or not host or host != host.strip():
+        raise ValueError(f"host must be a non-empty label with no leading/trailing space, got {host!r}")
+    if host in (".", "..") or _HOST_ILLEGAL.search(host):
+        raise ValueError(f"host must be ONE path segment (no '/', '\\', control chars, '.' or '..'), got {host!r}")
     return host
 
 
@@ -128,6 +157,23 @@ def _atomic_write(path: Path, data: dict) -> None:
     os.replace(tmp, path)
 
 
+@contextmanager
+def record_lock(workspace: Path, host: str, repo: str, pr: int):
+    """One writer at a time for one record key on one host.
+
+    Each `_atomic_write` is atomic on its own, which is not the invariant: a
+    close is READ -> archive -> unlink, and an open landing between the read
+    and the unlink had its brand-new hold deleted by the close of the old one."""
+    d = records_dir(workspace, host) / ".locks"
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / f"{record_key(repo, pr)}.lock", "a+") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
 def open_record(workspace: Path, repo: str, pr: int, head: str, host: str,
                 reason: str, opened_by: str) -> Path:
     """Write the owed-witness record. Every field is required: a record that
@@ -140,9 +186,10 @@ def open_record(workspace: Path, repo: str, pr: int, head: str, host: str,
         if not isinstance(value, str) or not value.strip():
             raise ValueError(f"{name} must be a non-empty string")
     path = record_path(workspace, host, repo, pr)
-    _atomic_write(path, {"repo": repo, "pr": int(pr), "head": head, "host": host,
-                         "reason": reason.strip(), "opened_by": opened_by,
-                         "opened_at": _now(), "canary": None})
+    with record_lock(workspace, host, repo, pr):
+        _atomic_write(path, {"repo": repo, "pr": int(pr), "head": head, "host": host,
+                             "reason": reason.strip(), "opened_by": opened_by,
+                             "opened_at": _now(), "canary": None})
     return path
 
 
@@ -229,7 +276,7 @@ def records_digest(workspace: Path, host: str) -> str:
     h = sha256()
     if d.is_dir():
         for f in sorted(x for x in d.rglob("*") if x.is_file() and x.name != STAMP_NAME
-                        and not x.name.endswith(".tmp")):
+                        and not x.name.endswith((".tmp", ".lock"))):
             h.update(str(f.relative_to(d)).encode())
             h.update(b"\0")
             h.update(f.read_bytes())
@@ -267,6 +314,27 @@ def unpublished(workspace: Path, host: str) -> bool:
     return stamp.get("records") != digest
 
 
+class NotPublished(RuntimeError):
+    """The record is on this host only: its push did not land."""
+
+
+def publish_push(workspace: Path, host: str, publish_with: str) -> None:
+    """Stamp, run the CALLER'S push command, and verify the stamp still
+    describes the subtree. The command is injected, never named here: this
+    module carries policy, and the vault transport lives at the edge.
+
+    On any failure the stamp is removed again, so the host reads unpublished
+    and its own gate refuses to activate rather than trusting a local hold."""
+    publish(workspace, host)
+    rc = subprocess.run(["bash", "-c", publish_with]).returncode
+    if rc == 0 and not unpublished(workspace, host):
+        return
+    (records_dir(workspace, host) / STAMP_NAME).unlink(missing_ok=True)
+    raise NotPublished(
+        f"publish command exited {rc}: this hold is on {host} only, so no peer's gate "
+        "can see it. Fix the vault push and re-run; until then the hold binds this host.")
+
+
 def stale_hosts(workspace: Path, host: str | None, max_age_s: float,
                 now: datetime | None = None) -> list[str]:
     """Foreign hosts whose stamp is missing or older than max_age_s: the view
@@ -295,6 +363,19 @@ def stale_hosts(workspace: Path, host: str | None, max_age_s: float,
         if age > max_age_s or age < -60:
             out.append(h)
     return out
+
+
+def validate_max_age(value: object) -> float:
+    """`float("inf")`/`float("nan")` parse happily and then disable expiry
+    entirely, so an unbounded window claimed a finite one. This is the Python
+    boundary the shell check said it was enforcing."""
+    try:
+        f = float(value)          # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise ValueError(f"max age must be a number of seconds, got {value!r}") from None
+    if not math.isfinite(f) or f <= 0:
+        raise ValueError(f"max age must be finite and > 0 seconds, got {value!r}")
+    return f
 
 
 def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess:
@@ -368,6 +449,8 @@ def blocking(workspace: Path, repo_root: Path, target_ref: str,
     that owes the witness. With max_age_s, a foreign host whose stamp is
     missing or older blocks by itself: its records cannot be called fresh."""
     hits = []
+    if max_age_s is not None:
+        max_age_s = validate_max_age(max_age_s)
     if max_age_s is not None and host:
         # A peer cannot fix this one and neither can waiting: the operator can.
         if unpublished(workspace, host):
@@ -401,15 +484,16 @@ def mark_canary(workspace: Path, repo: str, pr: int, host: str) -> Path:
     """Declare `host` the canary. Only the host that owes the witness may:
     a record marked by any other host would release an activation the
     deferral never covered."""
-    path = find_record(workspace, repo, pr)
-    if path is None:
-        raise FileNotFoundError(f"no open witness-owed record for {repo}#{pr}")
-    data = json.loads(path.read_text())
-    if data.get("host") != host:
-        raise ValueError(f"{repo}#{pr} is owed by {data.get('host')!r}, not {host!r}")
-    data["canary"] = host
-    data["canary_at"] = _now()
-    _atomic_write(path, data)
+    with record_lock(workspace, host, repo, pr):
+        path = find_record(workspace, repo, pr)
+        if path is None:
+            raise FileNotFoundError(f"no open witness-owed record for {repo}#{pr}")
+        data = json.loads(path.read_text())
+        if data.get("host") != host:
+            raise ValueError(f"{repo}#{pr} is owed by {data.get('host')!r}, not {host!r}")
+        data["canary"] = host
+        data["canary_at"] = _now()
+        _atomic_write(path, data)
     return path
 
 
@@ -419,18 +503,25 @@ def close_record(workspace: Path, repo: str, pr: int, witness: str, host: str) -
     refuses a foreign-host deletion, so any other host must tombstone."""
     if not isinstance(witness, str) or not witness.strip():
         raise ValueError("witness must name where the round trip was posted")
-    path = find_record(workspace, repo, pr)
-    if path is None:
-        raise FileNotFoundError(f"no open witness-owed record for {repo}#{pr}")
-    data = json.loads(path.read_text())
-    if data.get("host") != host:
-        raise ValueError(f"{repo}#{pr} is owed by {data.get('host')!r}, not {host!r}: "
-                         "tombstone it from this host instead")
-    data["witness"] = witness.strip()
-    data["closed_at"] = _now()
-    closed = path.parent / "closed" / path.name
-    _atomic_write(closed, data)
-    path.unlink()
+    with record_lock(workspace, host, repo, pr):
+        path = find_record(workspace, repo, pr)
+        if path is None:
+            raise FileNotFoundError(f"no open witness-owed record for {repo}#{pr}")
+        raw = path.read_text()
+        data = json.loads(raw)
+        if data.get("host") != host:
+            raise ValueError(f"{repo}#{pr} is owed by {data.get('host')!r}, not {host!r}: "
+                             "tombstone it from this host instead")
+        data["witness"] = witness.strip()
+        data["closed_at"] = _now()
+        closed = path.parent / "closed" / path.name
+        _atomic_write(closed, data)
+        # Compare-and-swap, so a writer that ignored the lock still cannot have
+        # its hold deleted: unlink only the bytes this close actually archived.
+        if path.read_text() != raw:
+            raise ValueError(f"{repo}#{pr} was rewritten while closing; the new record stands "
+                             f"(archived copy kept at {closed})")
+        path.unlink()
     return closed
 
 
@@ -466,12 +557,16 @@ def main(argv: list[str] | None = None) -> int:
     o.add_argument("key"); o.add_argument("--head", required=True)
     o.add_argument("--host", required=True); o.add_argument("--reason", required=True)
     o.add_argument("--by", required=True)
+    o.add_argument("--publish-with", metavar="CMD",
+                   help="shell command that pushes this workspace (e.g. "
+                        "'bash scripts/sync-workspace.sh --push-only'); the record is "
+                        "published only if it succeeds. Exit 6 when it does not.")
     sub.add_parser("list")
     c = sub.add_parser("check")
     c.add_argument("--ref", required=True); c.add_argument("--current")
     c.add_argument("--repo-root", default="."); c.add_argument("--host")
     c.add_argument("--repo", help="owner/name of the deployment target; scopes (#N) matches")
-    c.add_argument("--max-age", type=float, help="seconds; a foreign host stamped older than this blocks")
+    c.add_argument("--max-age", help="seconds; a foreign host stamped older than this blocks")
     m = sub.add_parser("canary"); m.add_argument("key"); m.add_argument("--host", required=True)
     x = sub.add_parser("close"); x.add_argument("key"); x.add_argument("--witness", required=True)
     x.add_argument("--host", required=True)
@@ -489,14 +584,28 @@ def main(argv: list[str] | None = None) -> int:
         ws = resolve_workspace(migrate=False)
     if a.cmd == "open":
         repo, pr = _split(a.key)
-        print(open_record(ws, repo, pr, a.head, a.host, a.reason, a.by)); return 0
+        print(open_record(ws, repo, pr, a.head, a.host, a.reason, a.by))
+        if not a.publish_with:
+            print("witness-owed: NOT PUBLISHED — this hold binds only this host until its "
+                  "subtree is pushed; re-run with --publish-with, or push the vault now.",
+                  file=sys.stderr)
+            return 0
+        try:
+            publish_push(ws, a.host, a.publish_with)
+        except NotPublished as exc:
+            print(f"witness-owed: {exc}", file=sys.stderr); return 6
+        return 0
     if a.cmd == "list":
         for rec in list_open(ws):
             print(f"{rec['repo']}#{rec['pr']} head={rec['head'][:8]} host={rec['host']} "
                   f"canary={rec.get('canary')} reason={rec['reason']}")
         return 0
     if a.cmd == "check":
-        hits = blocking(ws, Path(a.repo_root), a.ref, a.current, a.host, a.repo, a.max_age)
+        try:
+            max_age = validate_max_age(a.max_age) if a.max_age is not None else None
+        except ValueError as exc:
+            print(f"witness-owed: {exc}", file=sys.stderr); return 2
+        hits = blocking(ws, Path(a.repo_root), a.ref, a.current, a.host, a.repo, max_age)
         for rec in hits:
             print(f"witness owed: {rec['repo']}#{rec['pr']} head={rec['head'][:8]} "
                   f"host={rec['host']} — {rec['reason']}", file=sys.stderr)

--- a/tests/health-check-live-checkout-branch.test.py
+++ b/tests/health-check-live-checkout-branch.test.py
@@ -84,6 +84,7 @@ hc = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(hc)
 
 FAILS: list[str] = []
+_real_service_sources = hc._running_service_sources
 
 
 def check(cond: bool, msg: str) -> None:
@@ -919,6 +920,34 @@ def main() -> int:
             sys.modules.pop("git_binary", None)
         else:
             sys.modules["git_binary"] = real_mod
+
+    # aa) The PRESCRIPTION must route through the witness-owed gate: a bare
+    #     `git pull --ff-only` activates a head still owing its witness.
+    GATE_CMD = "skills/self-upgrade/scripts/upgrade.sh"
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind(Path(td), hc._BEHIND_WARN_DEFAULT + 2)
+        far = hc.check_live_checkout_branch(work)["detail"]
+    check(GATE_CMD in far, f"aa) far-behind guidance names the gate-aware updater, got {far[:140]}")
+    check("pull --ff-only" not in far,
+          f"aa) far-behind guidance must not prescribe a bare pull, got {far[:140]}")
+
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["skills/s/SKILL.md"])
+        near = hc.check_live_checkout_branch(work)["detail"]
+    check(GATE_CMD in near, f"aa) stale-skill guidance names the gate-aware updater, got {near[:140]}")
+    check("pull --ff-only" not in near,
+          f"aa) stale-skill guidance must not prescribe a bare pull, got {near[:140]}")
+
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["src/example-service.py"])
+        hc._running_service_sources = lambda: ["src/example-service.py"]
+        try:
+            svc = hc.check_live_checkout_branch(work)["detail"]
+        finally:
+            hc._running_service_sources = _real_service_sources
+    check(GATE_CMD in svc, f"aa) stale-service guidance names the gate-aware updater, got {svc[:140]}")
+    check("pull --ff-only" not in svc,
+          f"aa) stale-service guidance must not prescribe a bare pull, got {svc[:140]}")
 
     if FAILS:
         print(f"\n{len(FAILS)} failure(s)")

--- a/tests/self-upgrade-pinned-target.test.sh
+++ b/tests/self-upgrade-pinned-target.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# The gate decided about one resolution of $REMOTE/$BRANCH and `git pull` then
+# fetched a second one: a remote that moves between the two activates a head the
+# gate never saw (#3717, keweichen P1-2). Real git, real upgrade.sh, real
+# witness_owed.py; the vault sync is stubbed and moves the remote mid-run so the
+# window is deterministic. The control is the pre-fix check+pull pair.
+set -eu
+REPO="$(cd "$(dirname "$0")/.." && pwd -P)"
+HEAD_SCRIPT="$REPO/skills/self-upgrade/scripts/upgrade.sh"
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/self-upgrade-pinned.XXXXXX")"
+trap 'rm -rf "$TMPROOT"' EXIT
+export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+pass=0; fail=0
+ok()  { echo "  OK: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# Control = the shipped script with the two pre-fix lines substituted back, and
+# asserted to differ: a no-op substitution would test nothing.
+CONTROL_SCRIPT="$TMPROOT/upgrade-control.sh"
+python3 - "$HEAD_SCRIPT" "$CONTROL_SCRIPT" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+s = open(src).read()
+out = s.replace('check --ref "$TARGET_SHA"', 'check --ref "$REMOTE/$BRANCH"', 1)
+out = out.replace('git merge --ff-only "$TARGET_SHA"',
+                  'git pull --ff-only "$REMOTE" "$BRANCH"', 1)
+open(dst, "w").write(out)
+sys.exit(0 if out.count('"$REMOTE/$BRANCH"') > s.count('"$REMOTE/$BRANCH"') else 1)
+PY
+ok "control built: the pre-fix 'check the mutable ref, then pull again' pair, and it differs"
+
+# A fixture checkout at upgrade.sh's real depth. T1 is the target the gate sees;
+# T2 is the head the remote moves to mid-run, and T2 is the one that is owed.
+make_fixture() { # root script
+  local root="$1" script="$2" remote="$1.remote/owner/repo.git"
+  mkdir -p "$(dirname "$remote")" "$root/skills/self-upgrade/scripts" "$root/src" \
+           "$root/scripts" "$root/workspace/hosts/testhost/witness-owed"
+  cp "$REPO/src/witness_owed.py" "$root/src/witness_owed.py"
+  cp "$script" "$root/skills/self-upgrade/scripts/upgrade.sh"
+  cp "$REPO/skills/self-upgrade/manifest.json" "$root/skills/self-upgrade/manifest.json"
+  cat > "$root/scripts/sutando-config.sh" <<EOF
+#!/bin/bash
+case "\${1:-}" in
+  workspace) printf '%s\n' "$root/workspace" ;;
+  python-bin) command -v python3 ;;
+  host-label) printf '%s\n' testhost ;;
+  vault-enabled) printf '%s\n' true ;;
+esac
+EOF
+  # The stub sync is the deterministic stand-in for "the remote moved while the
+  # gate was running": it succeeds, and it advances origin/main from T1 to T2.
+  cat > "$root/scripts/sync-workspace.sh" <<EOF
+#!/bin/bash
+[ -f "$root.advance" ] && { git -C "$remote" update-ref refs/heads/main "\$(cat "$root.t2")"; rm -f "$root.advance"; }
+exit 0
+EOF
+  chmod +x "$root/scripts/sutando-config.sh" "$root/scripts/sync-workspace.sh"
+  printf '#!/bin/bash\nexit 0\n' > "$root/src/restart.sh"; chmod +x "$root/src/restart.sh"
+  printf 'workspace/\n__pycache__/\n' > "$root/.gitignore"   # as the real repo ignores them
+  git init -q -b main "$root"
+  ( cd "$root" && git add -A && git commit -qm init && git remote add origin "$remote" )
+  git init -q -b main --bare "$remote"
+  ( cd "$root" && git push -q -u origin main )
+  local work="$root.pusher"
+  git clone -q -b main "$remote" "$work"
+  ( cd "$work" && echo one > CHANGELOG && git add -A && git commit -qm "benign doc change" && git push -q origin main )
+  T1="$(git -C "$work" rev-parse HEAD)"
+  ( cd "$work" && echo two > CHANGELOG && git add -A && git commit -qm "live-path change (#77)" )
+  T2="$(git -C "$work" rev-parse HEAD)"
+  git -C "$work" push -q origin HEAD:refs/heads/staged   # present in the remote, NOT on main
+  rm -rf "$work"
+  printf '%s' "$T2" > "$root.t2"; : > "$root.advance"
+  # The hold is on T2 and already local, so nothing about this test depends on
+  # propagation: the only question is which object the run activates.
+  python3 "$root/src/witness_owed.py" --workspace "$root/workspace" open "owner/repo#77" \
+    --head "$T2" --host testhost --reason "live path; no supervised job here" --by testhost >/dev/null 2>&1
+  python3 "$root/src/witness_owed.py" --workspace "$root/workspace" publish --host testhost >/dev/null
+}
+
+run_upgrade() { # root -> RC, OUT, HEAD_AFTER
+  local root="$1"
+  set +e
+  OUT="$(cd "$root" && SUTANDO_WITNESS_MAX_AGE=86400 \
+         bash "$root/skills/self-upgrade/scripts/upgrade.sh" --no-restart 2>&1)"
+  RC=$?
+  set -e
+  HEAD_AFTER="$(git -C "$root" rev-parse HEAD)"
+}
+
+echo "-- the fixture really does move the remote mid-run --"
+CTL="$TMPROOT/ctl"; make_fixture "$CTL" "$CONTROL_SCRIPT"; CTL_T1="$T1"; CTL_T2="$T2"
+git -C "$CTL" fetch -q origin
+[ "$(git -C "$CTL" rev-parse origin/main)" = "$CTL_T1" ] \
+  && ok "before the run, the remote-tracking ref is T1 (${CTL_T1:0:8})" || bad "fixture: origin/main is not T1"
+python3 "$CTL/src/witness_owed.py" --workspace "$CTL/workspace" check --ref "$CTL_T1" \
+  --repo-root "$CTL" --repo owner/repo --host testhost >/dev/null 2>&1 \
+  && ok "T1 is NOT owed — the gate is entitled to pass it" || bad "fixture: T1 already blocked"
+set +e
+python3 "$CTL/src/witness_owed.py" --workspace "$CTL/workspace" check --ref "$CTL_T2" --current "$CTL_T1" \
+  --repo-root "$CTL" --repo owner/repo --host testhost >/dev/null 2>&1; T2_RC=$?
+set -e
+[ "$T2_RC" = "3" ] && ok "T2 IS owed — the production helper refuses it (exit 3)" || bad "fixture: T2 not blocked (rc=$T2_RC)"
+
+echo "-- the control activates the head the gate never checked --"
+run_upgrade "$CTL"; CTL_RC=$RC; CTL_HEAD="$HEAD_AFTER"
+[ "$CTL_RC" = "0" ] && [ "$CTL_HEAD" = "$CTL_T2" ] \
+  && ok "CONTROL (pre-fix): rc=0 and HEAD is T2 (${CTL_T2:0:8}) — the owed head, never gated" \
+  || bad "control did not reproduce the race (rc=$CTL_RC head=${CTL_HEAD:0:8} want ${CTL_T2:0:8})"
+
+echo "-- THE POINT: HEAD fast-forwards to exactly the object it checked --"
+FIX="$TMPROOT/fix"; make_fixture "$FIX" "$HEAD_SCRIPT"; FIX_T1="$T1"; FIX_T2="$T2"
+run_upgrade "$FIX"; FIX_RC=$RC; FIX_HEAD="$HEAD_AFTER"; FIX_OUT="$OUT"
+[ "$FIX_RC" = "0" ] && [ "$FIX_HEAD" = "$FIX_T1" ] \
+  && ok "HEAD: rc=0 and HEAD is the PINNED T1 (${FIX_T1:0:8}) on the identical fixture" \
+  || bad "HEAD activated something else (rc=$FIX_RC head=${FIX_HEAD:0:8} want ${FIX_T1:0:8}): $(echo "$FIX_OUT" | tail -2)"
+[ "$FIX_HEAD" != "$FIX_T2" ] && ok "a stale local ref with a newer remote did NOT pass the owed T2 through" \
+  || bad "the owed T2 was activated"
+echo "$FIX_OUT" | grep -q "target=${FIX_T1:0:8}" && ok "the run names the object it pinned" || bad "the pinned target is not reported"
+[ "$(git -C "$FIX.remote/owner/repo.git" rev-parse refs/heads/main)" = "$FIX_T2" ] \
+  && ok "control on the control: the remote really is at T2 while HEAD stopped at T1" \
+  || bad "the remote never advanced, so this scenario proved nothing"
+
+echo "-- nothing is lost: the next pass gates T2 on its own --"
+run_upgrade "$FIX"; NEXT_RC=$RC; NEXT_HEAD="$HEAD_AFTER"; NEXT_OUT="$OUT"
+[ "$NEXT_RC" = "4" ] && [ "$NEXT_HEAD" = "$FIX_T1" ] && echo "$NEXT_OUT" | grep -q "owner/repo#77" \
+  && ok "second pass: rc=4 on owner/repo#77 and HEAD still T1" \
+  || bad "second pass did not block on the owed record (rc=$NEXT_RC): $(echo "$NEXT_OUT" | tail -2)"
+
+echo "-- the wiring itself --"
+grep -q 'git pull --ff-only' "$HEAD_SCRIPT" && bad "upgrade.sh still re-fetches with git pull" \
+  || ok "upgrade.sh no longer re-fetches between the gate and the activation"
+grep -q 'check --ref "\$TARGET_SHA"' "$HEAD_SCRIPT" && ok "the gate checks the pinned SHA" || bad "the gate does not check the pinned SHA"
+
+echo "$pass passed, $fail failed"
+[ "$fail" = "0" ]

--- a/tests/self-upgrade-sync-strict-gate.test.sh
+++ b/tests/self-upgrade-sync-strict-gate.test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# The witness-owed gate calls the vault sync to refresh the fleet's records. The
+# default tick returns the PUSH's rc, so a REFUSED PULL exits 0 and the gate
+# reads "records are current" over a view that never updated — and activates the
+# very head an owed record was holding (#3717, keweichen + john-the-dev).
+# Real git, real upgrade.sh, real witness_owed.py; the vault sync is stubbed so
+# nothing touches a real vault. The control is the pre-fix call line.
+set -eu
+REPO="$(cd "$(dirname "$0")/.." && pwd -P)"
+HEAD_SCRIPT="$REPO/skills/self-upgrade/scripts/upgrade.sh"
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/self-upgrade-strict.XXXXXX")"
+trap 'rm -rf "$TMPROOT"' EXIT
+export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+pass=0; fail=0
+ok()  { echo "  OK: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# The control is the pre-fix call built FROM the shipped script, and asserted to
+# differ from it: a no-op substitution would silently test nothing.
+CONTROL_SCRIPT="$TMPROOT/upgrade-control.sh"
+python3 - "$HEAD_SCRIPT" "$CONTROL_SCRIPT" <<'PY'
+import re, sys
+src, dst = sys.argv[1], sys.argv[2]
+s = open(src).read()
+pre = ('  bash "$REPO/scripts/sync-workspace.sh" || { echo "self-upgrade: ABORT — vault sync failed, '
+       'so the fleet\'s witness-owed records cannot be called fresh" >&2; exit 4; }\n')
+out = re.sub(r'  GATE_SYNC_RC=0\n.*?\n  fi\n', pre, s, count=1, flags=re.S)
+open(dst, "w").write(out)
+sys.exit(0 if out != s else 1)
+PY
+ok "control built: the pre-fix bare default-tick call, and it differs from HEAD's"
+
+# A fixture checkout: upgrade.sh at its real depth, the real gate helper, a
+# stub sutando-config.sh, a stub restart.sh (never reached: --no-restart).
+make_fixture() { # root sync_mode(refused|healthy|pushfail) script
+  # The remote's path ends in owner/repo so upgrade.sh derives the same repo key
+  # the record carries; a record for another project must not scope in.
+  local root="$1" mode="$2" script="$3" remote="$1.remote/owner/repo.git"
+  mkdir -p "$(dirname "$remote")"
+  mkdir -p "$root/skills/self-upgrade/scripts" "$root/src" "$root/scripts" \
+           "$root/workspace/hosts/testhost/witness-owed" "$root/peer-store/hosts/peerhost/witness-owed"
+  cp "$REPO/src/witness_owed.py" "$root/src/witness_owed.py"
+  cp "$script" "$root/skills/self-upgrade/scripts/upgrade.sh"
+  cat > "$root/scripts/sutando-config.sh" <<EOF
+#!/bin/bash
+case "\${1:-}" in
+  workspace) printf '%s\n' "$root/workspace" ;;
+  python-bin) command -v python3 ;;
+  host-label) printf '%s\n' testhost ;;
+  vault-enabled) printf '%s\n' true ;;
+esac
+EOF
+  # Stub vault sync with the REAL contract: default returns the push's rc, so a
+  # refused pull still exits 0; --pull-strict lets the pull leg answer.
+  cat > "$root/scripts/sync-workspace.sh" <<EOF
+#!/bin/bash
+mode="$mode"; strict=0; [ "\${1:-}" = "--pull-strict" ] && strict=1
+pull_rc=0; push_rc=0
+case "\$mode" in
+  refused)  echo "sync-workspace: REFUSING pull — peer deleted 18 of 22 files." >&2; pull_rc=1 ;;
+  pushfail) push_rc=1 ;;
+esac
+# A successful pull is what delivers the peer's records; a refused one does not.
+[ "\$pull_rc" = "0" ] && cp -R "$root/peer-store/hosts/." "$root/workspace/hosts/"
+[ "\$strict" = "1" ] && [ "\$pull_rc" != "0" ] && { echo "sync-workspace: STRICT FAILURE — pull leg exited \$pull_rc" >&2; exit 3; }
+exit "\$push_rc"
+EOF
+  chmod +x "$root/scripts/sutando-config.sh" "$root/scripts/sync-workspace.sh"
+  printf '#!/bin/bash\nexit 0\n' > "$root/src/restart.sh"; chmod +x "$root/src/restart.sh"
+  printf 'workspace/\npeer-store/\n' > "$root/.gitignore"
+  git init -q -b main "$root"
+  ( cd "$root" && git add -A && git commit -qm init && git remote add origin "$remote" )
+  git init -q -b main --bare "$remote"
+  ( cd "$root" && git push -q -u origin main )
+  # One upstream commit: the target the gate decides about.
+  local work="$root.pusher"
+  git clone -q -b main "$remote" "$work"
+  ( cd "$work" && echo change > CHANGELOG && git add -A && git commit -qm "upstream live-path change (#77)" && git push -q origin main )
+  TARGET_SHA="$(git -C "$work" rev-parse HEAD)"
+  rm -rf "$work"
+  # The peer host opened a hold on that exact head. It reaches this host ONLY
+  # through a successful pull — that is the whole point of the freshness gate.
+  python3 "$root/src/witness_owed.py" --workspace "$root/peer-store" open "owner/repo#77" \
+    --head "$TARGET_SHA" --host peerhost --reason "live path; no supervised job here" --by peerhost >/dev/null
+  python3 "$root/src/witness_owed.py" --workspace "$root/peer-store" publish --host peerhost >/dev/null
+}
+
+run_upgrade() { # root -> RC, OUT, HEAD_AFTER
+  local root="$1"
+  set +e
+  OUT="$(cd "$root" && SUTANDO_TEST_MODE=1 SUTANDO_WITNESS_MAX_AGE=86400 \
+         bash "$root/skills/self-upgrade/scripts/upgrade.sh" --no-restart 2>&1)"
+  RC=$?
+  set -e
+  HEAD_AFTER="$(git -C "$root" rev-parse HEAD)"
+}
+
+echo "-- scenario 1: the pull is refused (keweichen's repro) --"
+CTL="$TMPROOT/ctl"; make_fixture "$CTL" refused "$CONTROL_SCRIPT"; CTL_BEFORE="$(git -C "$CTL" rev-parse HEAD)"
+run_upgrade "$CTL"; CTL_RC=$RC; CTL_HEAD="$HEAD_AFTER"; CTL_OUT="$OUT"
+echo "$CTL_OUT" | grep -q "REFUSING pull" && ok "control: the stub's pull really was refused" || bad "control: no refusal in the stub output"
+[ "$CTL_RC" = "0" ] && [ "$CTL_HEAD" != "$CTL_BEFORE" ] \
+  && ok "CONTROL (pre-fix): rc=0 and HEAD ADVANCED past the owed #77 — the gate was bypassed" \
+  || bad "control did not reproduce the bypass (rc=$CTL_RC, head_advanced=$([ "$CTL_HEAD" != "$CTL_BEFORE" ] && echo true || echo false))"
+
+FIX="$TMPROOT/fix"; make_fixture "$FIX" refused "$HEAD_SCRIPT"; FIX_BEFORE="$(git -C "$FIX" rev-parse HEAD)"
+run_upgrade "$FIX"; FIX_RC=$RC; FIX_HEAD="$HEAD_AFTER"; FIX_OUT="$OUT"
+[ "$FIX_RC" = "4" ] && [ "$FIX_HEAD" = "$FIX_BEFORE" ] \
+  && ok "THE POINT (HEAD): rc=4 and HEAD UNMOVED on the identical fixture" \
+  || bad "HEAD did not abort (rc=$FIX_RC, head_advanced=$([ "$FIX_HEAD" != "$FIX_BEFORE" ] && echo true || echo false)): $(echo "$FIX_OUT" | tail -2)"
+echo "$FIX_OUT" | grep -q "PULL leg failed" \
+  && ok "the abort names the PULL leg, not 'vault sync failed'" || bad "the abort does not name the pull leg"
+
+echo "-- scenario 2: a healthy sync still upgrades (no false alarm) --"
+OKF="$TMPROOT/okf"; make_fixture "$OKF" healthy "$HEAD_SCRIPT"; OK_BEFORE="$(git -C "$OKF" rev-parse HEAD)"
+run_upgrade "$OKF"; OK_RC=$RC; OK_HEAD="$HEAD_AFTER"; OK_OUT="$OUT"
+# With the pull working, the peer's hold DOES arrive — and then the gate blocks
+# on the record itself (rc 4), which is the gate working, not the seam failing.
+[ "$OK_RC" = "4" ] && echo "$OK_OUT" | grep -q "owner/repo#77" \
+  && ok "healthy pull: the peer's hold arrived and the gate blocked on owner/repo#77" \
+  || bad "healthy pull: expected a record-based block, got rc=$OK_RC: $(echo "$OK_OUT" | tail -2)"
+echo "$OK_OUT" | grep -q "PULL leg failed" && bad "healthy pull wrongly reported a pull failure" || ok "healthy pull reports no sync failure"
+[ "$OK_HEAD" = "$OK_BEFORE" ] && ok "healthy pull: HEAD unmoved while the record is open" || bad "healthy pull advanced HEAD over an open record"
+
+echo "-- scenario 3: the push leg fails; the pull succeeded --"
+PF="$TMPROOT/pf"; make_fixture "$PF" pushfail "$HEAD_SCRIPT"
+run_upgrade "$PF"
+[ "$RC" = "4" ] && echo "$OUT" | grep -q "push leg" \
+  && ok "a failed push still aborts, named as the push leg (exit 1, not 3)" \
+  || bad "push-leg failure not reported: rc=$RC: $(echo "$OUT" | tail -2)"
+
+echo "-- the wiring itself --"
+grep -q 'sync-workspace.sh" --pull-strict' "$HEAD_SCRIPT" \
+  && ok "upgrade.sh asks for --pull-strict" || bad "upgrade.sh no longer asks for --pull-strict"
+grep -q -- "--pull-strict" "$REPO/scripts/sync-workspace.sh" \
+  && ok "sync-workspace.sh owns the strict mode (no sync logic copied into upgrade.sh)" \
+  || bad "sync-workspace.sh does not implement --pull-strict"
+
+echo "$pass passed, $fail failed"
+[ "$fail" = "0" ]

--- a/tests/self-upgrade.test.sh
+++ b/tests/self-upgrade.test.sh
@@ -44,11 +44,15 @@ make_fixture() {
   local root="$1"
   local remote="$root.remote.git"
   mkdir -p "$root/skills/self-upgrade/scripts" "$root/src" "$root/scripts" "$root/workspace/state/cores"
+  # The witness-owed gate is part of the upgrade path; a fixture without it is not the shipped script.
+  cp "$REPO/src/witness_owed.py" "$root/src/witness_owed.py"
   cp "$SRC_SCRIPT" "$root/skills/self-upgrade/scripts/upgrade.sh"
   cat > "$root/scripts/sutando-config.sh" <<EOF
 #!/bin/bash
 case "\${1:-}" in
   workspace) printf '%s\n' "$root/workspace" ;;
+  python-bin) command -v python3 ;;
+  host-label) printf '%s\n' testhost ;;
   tmux-socket) printf '%s\n' "$TEST_TMUX_SOCKET" ;;
 esac
 EOF

--- a/tests/self-upgrade.test.sh
+++ b/tests/self-upgrade.test.sh
@@ -53,6 +53,7 @@ case "\${1:-}" in
   workspace) printf '%s\n' "$root/workspace" ;;
   python-bin) command -v python3 ;;
   host-label) printf '%s\n' testhost ;;
+  vault-enabled) printf '%s\n' false ;;
   tmux-socket) printf '%s\n' "$TEST_TMUX_SOCKET" ;;
 esac
 EOF

--- a/tests/sync-workspace-pull-strict.test.sh
+++ b/tests/sync-workspace-pull-strict.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# The default tick returns the PUSH's rc: a refused pull exits 0, so a caller
+# reading that zero as "my view of peer state is current" reads a lie (#3717).
+# --pull-strict runs the same two legs and lets the pull leg say no (exit 3).
+set -u
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+export GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-sync-strict-test}"
+export GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-sync-strict-test@invalid}"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sync-strict.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+pass=0; fail=0
+ok()   { echo "  OK: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+mkhost() {  # name wsid -> builds an isolated repo+workspace pair and runs --init
+  local n="$1" wsid="$2" r="$TEST_ROOT/$1-repo" w="$TEST_ROOT/$1-ws"
+  mkdir -p "$w/notes" "$r/scripts" "$r/src"; touch "$r/CLAUDE.md"; git init -q "$r"
+  cp "$REPO/scripts/sync-workspace.sh" "$REPO/scripts/sutando-config.sh" "$REPO/scripts/python-binary.sh" "$r/scripts/"
+  cp "$REPO/src/sutando_config.py" "$r/src/"
+  cat > "$r/sutando.config.json" <<'JSON'
+{"workspace": {"path": "${REPO_DIR}/workspace"},
+ "vault": {"enabled": false, "sync": {"include": ["notes/"], "exclude": []}}}
+JSON
+  echo "$n note" > "$w/notes/$n-note.md"
+  runsync "$n" "$wsid" --init >/dev/null 2>&1
+}
+runsync() {  # name wsid args... -> runs sync-workspace in that host's sandbox
+  local n="$1" wsid="$2"; shift 2
+  local r="$TEST_ROOT/$n-repo" w="$TEST_ROOT/$n-ws"
+  env -i HOME="$HOME" PATH="$PATH" SUTANDO_REPO_DIR="$r" SUTANDO_WORKSPACE="$w" SUTANDO_TEST_MODE=1 \
+      GIT_AUTHOR_NAME="$GIT_AUTHOR_NAME" GIT_AUTHOR_EMAIL="$GIT_AUTHOR_EMAIL" \
+      GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME" GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL" \
+      SUTANDO_HOST_OVERRIDE="$n" SUTANDO_WS_ID_OVERRIDE="$wsid" SUTANDO_FORCE_SYNC="${FORCE:-0}" \
+      bash "$r/scripts/sync-workspace.sh" ${VAULT:+--vault-url "$VAULT"} "$@" 2>&1
+}
+
+VAULT="$TEST_ROOT/vault.git"; git init -q --bare "$VAULT"
+mkhost hostA wsa; mkhost hostB wsb
+
+echo "-- healthy fleet: both modes succeed --"
+OUT="$(runsync hostB wsb)"; rc=$?
+[ "$rc" = "0" ] && ok "default tick on a healthy fleet exits 0" || bad "default tick exited $rc: $(echo "$OUT" | tail -2)"
+OUT="$(runsync hostB wsb --pull-strict)"; rc=$?
+[ "$rc" = "0" ] && ok "--pull-strict on a healthy fleet exits 0 (no false alarm)" || bad "--pull-strict exited $rc: $(echo "$OUT" | tail -2)"
+
+echo "-- a pull the mass-deletion tripwire refuses --"
+# host A publishes 60 files, host B tracks them, then host A deletes all 60:
+# host B's next pull is refused by the production tripwire (>50 deletions).
+for i in $(seq 1 60); do echo "bulk $i" > "$TEST_ROOT/hostA-ws/notes/bulk-$i.md"; done
+runsync hostA wsa --push-only >/dev/null
+runsync hostB wsb --pull-only >/dev/null
+[ "$(git -C "$TEST_ROOT/hostB-ws" ls-files 'notes/bulk-*' | wc -l | tr -d ' ')" = "60" ] \
+  && ok "fixture: hostB tracks the 60 files" || bad "fixture: hostB does not track the 60 files"
+rm "$TEST_ROOT/hostA-ws"/notes/bulk-*.md
+FORCE=1 runsync hostA wsa --push-only >/dev/null 2>&1 || true
+
+# Each mode gets its own pre-pull state: the refusal must be reproduced twice.
+OUT_DEFAULT="$(runsync hostB wsb)"; rc_default=$?
+echo "$OUT_DEFAULT" | grep -q "REFUSING pull" \
+  && ok "fixture: the default tick's pull leg WAS refused" || bad "fixture: no refusal in the default tick"
+[ "$rc_default" = "0" ] \
+  && ok "default mode is unchanged: refused pull, successful push, exit 0" \
+  || bad "default mode changed behaviour: exit $rc_default (expected 0)"
+
+# A file only the strict run can publish, so "did the push leg run?" below has
+# an answer that is observable in the vault rather than inferred from a log line.
+echo "written before the strict tick" > "$TEST_ROOT/hostB-ws/notes/strict-marker.md"
+OUT_STRICT="$(runsync hostB wsb --pull-strict)"; rc_strict=$?
+echo "$OUT_STRICT" | grep -q "REFUSING pull" \
+  && ok "fixture: the strict tick's pull leg WAS refused too" || bad "fixture: no refusal in the strict tick"
+[ "$rc_strict" = "3" ] \
+  && ok "THE POINT: --pull-strict exits 3 on the same refusal the default reports as 0" \
+  || bad "THE POINT: --pull-strict exited $rc_strict, not 3"
+echo "$OUT_STRICT" | grep -q "STRICT FAILURE — pull leg" \
+  && ok "--pull-strict names the failing leg on stderr" || bad "--pull-strict does not name the pull leg"
+# The strict run must still have PUSHED: the gate's caller needs its own records
+# published, so strict must not degrade into --pull-only.
+git --git-dir="$VAULT" show "host/hostB/wsb:notes/strict-marker.md" 2>/dev/null | grep -q "written before the strict tick" \
+  && ok "--pull-strict still PUSHED (the marker reached the vault): it is the full tick, not --pull-only" \
+  || bad "--pull-strict skipped the push leg (no marker in the vault)"
+
+echo "-- sync disabled: a pull that never ran is not a fresh view --"
+VAULT="" OUT="$(VAULT="" runsync hostB wsb)"; rc=$?
+[ "$rc" = "0" ] && ok "default tick skips cleanly with no vault URL (cron stays quiet)" || bad "default tick exited $rc with no vault URL"
+OUT="$(VAULT="" runsync hostB wsb --pull-strict)"; rc=$?
+[ "$rc" = "3" ] && ok "--pull-strict exits 3 when sync is disabled (no pull ran)" || bad "--pull-strict exited $rc with no vault URL"
+VAULT="$TEST_ROOT/vault.git"
+
+echo "-- the seam itself: no caller may read the default's rc as freshness --"
+# Pin the contract in the source, so a future edit that re-swallows the pull rc
+# fails here rather than silently re-opening the bypass.
+grep -q '_pull_only_impl || _pull_rc=\$?' "$REPO/scripts/sync-workspace.sh" \
+  && ok "the shared tick captures the pull leg's rc instead of discarding it" \
+  || bad "the shared tick no longer captures the pull rc"
+grep -q '_pull_only_impl || true' "$REPO/scripts/sync-workspace.sh" \
+  && bad "a '_pull_only_impl || true' call site is back" \
+  || ok "no call site discards the pull's rc with '|| true'"
+
+echo "$pass passed, $fail failed"
+[ "$fail" = "0" ]

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -343,7 +343,7 @@ class UpgradeWiring(unittest.TestCase):
         for token in ('[ -n "$GATE_WS" ] ||', '[ -n "$GATE_PY" ] ||',
                       '[ -f "$GATE_HELPER" ] ||', 'sutando-config.sh" python-bin',
                       '[ -n "$GATE_REPO" ] ||', '--repo "$GATE_REPO"', '--max-age "$GATE_MAX_AGE"',
-                      'sync-workspace.sh" --pull-only ||', 'publish --host "$GATE_HOST"'):
+                      'sync-workspace.sh" ||', 'publish --host "$GATE_HOST"'):
             self.assertIn(token, self.SRC, token)
         self.assertNotIn('python3 "$REPO/src/witness_owed.py"', self.SRC, "bare python3 may hit the CLT stub")
         # A missing host label cannot release a record, so it must not stop
@@ -428,6 +428,95 @@ class Round5Blockers(Fixture):
         self.assertIn(json.loads(path.read_text())["tag"], ("a", "b"))
         leftovers = list(path.parent.glob("*.tmp"))
         self.assertEqual(leftovers, [], f"temp files left behind: {leftovers}")
+
+
+class Round5Publication(Fixture):
+    """keweichen's round-5 P1-1 controls: a stamp is a claim about RECORDS."""
+
+    def test_a_record_opened_after_the_stamp_unpublishes_the_host(self):
+        wo.publish(self.ws, HOST_A)
+        self.assertFalse(wo.unpublished(self.ws, HOST_A), "a just-published empty host reads as published")
+        self.open12(host=HOST_A)
+        self.assertTrue(wo.unpublished(self.ws, HOST_A),
+                        "a record opened after the stamp still read as published")
+        wo.publish(self.ws, HOST_A)
+        self.assertFalse(wo.unpublished(self.ws, HOST_A))
+
+    def test_the_gate_names_this_hosts_own_unpublished_records(self):
+        later = self.merge_topology()
+        wo.publish(self.ws, HOST_A)
+        self.open12(host=HOST_A)
+        hits = wo.blocking(self.ws, self.repo, later, self.base, host=HOST_A,
+                           target_repo="o/r", max_age_s=3600)
+        own = [h for h in hits if h.get("stale") and h.get("host") == HOST_A]
+        self.assertTrue(own, f"the host's own unpublished records did not block it: {hits}")
+        self.assertIn("publish and push", own[0]["reason"])
+
+    def test_a_peer_stamp_that_does_not_describe_its_records_is_stale(self):
+        import shutil
+        self.open12(host=HOST_A)
+        wo.publish(self.ws, HOST_A)
+        ws_b = Path(self.tmp.name) / "ws-b2"
+        shutil.copytree(self.ws / "hosts" / HOST_A, ws_b / "hosts" / HOST_A)
+        self.assertEqual(wo.stale_hosts(ws_b, HOST_B, 3600), [],
+                         "a faithfully carried subtree should be fresh")
+        # The carried subtree gains a record its stamp never covered — the shape
+        # a mid-write copy or a hand edit produces.
+        extra = ws_b / "hosts" / HOST_A / "witness-owed" / wo.record_key("o/r", 99)
+        extra.write_text(json.dumps({"repo": "o/r", "pr": 99, "head": "c" * 40, "host": HOST_A,
+                                     "reason": "r", "opened_by": "x",
+                                     "opened_at": "2026-09-04T00:00:00Z", "canary": None}))
+        self.assertEqual(wo.stale_hosts(ws_b, HOST_B, 3600), [HOST_A],
+                         "a fresh timestamp beside records it never covered read as published")
+
+    def test_a_host_with_nothing_to_publish_never_blocks_itself(self):
+        # Every host without records once blocked itself, which is a fleet-wide
+        # deadlock rather than a safety property.
+        later = self.merge_topology()
+        self.assertFalse(wo.unpublished(self.ws, HOST_B))
+        hits = wo.blocking(self.ws, self.repo, later, self.base, host=HOST_B,
+                           target_repo="o/r", max_age_s=3600)
+        self.assertEqual([h for h in hits if h.get("host") == HOST_B], [])
+
+
+class UpgradePublicationWiring(unittest.TestCase):
+    """The stamp must be written where a push can carry it, and before the
+    fleet is read. Ordering, not spelling: the indices are the assertion."""
+
+    def setUp(self):
+        self.sh = (ROOT / "skills" / "self-upgrade" / "scripts" / "upgrade.sh").read_text()
+
+    def test_this_host_publishes_before_it_reads_the_fleet(self):
+        publish = self.sh.index('publish --host "$GATE_HOST"')
+        sync = self.sh.index('bash "$REPO/scripts/sync-workspace.sh"')
+        check = self.sh.index('check --ref "$REMOTE/$BRANCH"')
+        self.assertLess(publish, sync, "the stamp must travel WITH the records the sync pushes")
+        self.assertLess(sync, check, "the fleet is read before it is refreshed")
+
+    def test_the_pre_gate_sync_is_a_full_tick_not_pull_only(self):
+        # --pull-only never publishes this host, so a fleet of pull-only
+        # updaters ages every stamp out and then refuses forever.
+        check = self.sh.index('check --ref "$REMOTE/$BRANCH"')
+        # Only INVOCATIONS count: the first draft of this assertion matched its
+        # own explanatory comment and failed on prose.
+        calls = [ln for ln in self.sh[:check].splitlines()
+                 if "sync-workspace.sh" in ln and not ln.lstrip().startswith("#")]
+        self.assertTrue(calls, "nothing refreshes the fleet before the gate reads it")
+        self.assertEqual([c for c in calls if "--pull-only" in c], [])
+
+    def test_a_canary_declaration_restamps_before_the_gate_reads_it(self):
+        # Declaring a canary MUTATES this host's record; without a re-stamp the
+        # gate refuses the very host the canary was declared for.
+        declare = self.sh.index('canary "$CANARY" --host "$GATE_HOST"')
+        publish = self.sh.index('publish --host "$GATE_HOST"', declare)
+        check = self.sh.index('check --ref "$REMOTE/$BRANCH"')
+        self.assertLess(publish, check)
+
+    def test_nothing_heavy_sits_between_the_pull_and_the_restart_handoff(self):
+        # A synchronous vault push here delayed the handoff past its budget.
+        pull = self.sh.index('git pull --ff-only')
+        handoff = self.sh.index('new-session -d -s "$SERVICE_SESSION"')
+        self.assertNotIn("sync-workspace.sh", self.sh[pull:handoff])
 
 
 if __name__ == "__main__":

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -91,13 +91,13 @@ class Records(Fixture):
         recs = wo.list_open(self.ws)
         self.assertEqual([(r["repo"], r["pr"], r["head"]) for r in recs], [("o/r", 12, self.owed)])
         with self.assertRaises(ValueError):
-            wo.close_record(self.ws, "o/r", 12, "")
-        closed = wo.close_record(self.ws, "o/r", 12, "https://example/pr/12#c1")
+            wo.close_record(self.ws, "o/r", 12, "", HOST_A)
+        closed = wo.close_record(self.ws, "o/r", 12, "https://example/pr/12#c1", HOST_A)
         self.assertEqual(wo.list_open(self.ws), [])
         self.assertEqual(closed.parent.name, "closed")
         self.assertIn("closed_at", json.loads(closed.read_text()))
         with self.assertRaises(FileNotFoundError):
-            wo.close_record(self.ws, "o/r", 12, "again")
+            wo.close_record(self.ws, "o/r", 12, "again", HOST_A)
 
     def test_a_malformed_record_blocks_rather_than_vanishes(self):
         d = wo.records_dir(self.ws, HOST_A)
@@ -115,7 +115,7 @@ class Gate(Fixture):
         self.assertEqual(len(wo.blocking(self.ws, self.repo, later, self.base)), 1)
         self.assertEqual(wo.blocking(self.ws, self.repo, self.base), [])
         self.assertEqual(wo.blocking(self.ws, self.repo, later, later), [])
-        wo.close_record(self.ws, "o/r", 12, "posted")
+        wo.close_record(self.ws, "o/r", 12, "posted", HOST_A)
         self.assertEqual(wo.blocking(self.ws, self.repo, later, self.base), [])
 
     def test_squash_topology_is_recognised_by_the_merge_subject(self):
@@ -171,6 +171,79 @@ class Gate(Fixture):
             wo.mark_canary(self.ws, "o/r", 99, HOST_A)
 
 
+class Round4Blockers(Fixture):
+    """keweichen's round-4 blockers, each with the control that was missing."""
+
+    def test_all_keys_present_but_invalid_head_is_malformed_and_blocks(self):
+        p = self.open12(); later = self.merge_topology()
+        d = json.loads(p.read_text()); d["head"] = ""; p.write_text(json.dumps(d))
+        recs = wo.list_open(self.ws)
+        self.assertEqual([r.get("malformed") for r in recs], [True])
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, self.base)), 1)
+        for bad in ({"pr": True}, {"pr": 0}, {"repo": "nope"}, {"canary": "other-host"},
+                    {"opened_at": "yesterday"}, {"host": ""}):
+            d2 = dict(json.loads(p.read_text()) if p.exists() else {}); d2 = {**d2, **bad}
+            p.write_text(json.dumps({**d, "head": self.owed, **bad}))
+            self.assertTrue(wo.list_open(self.ws)[0].get("malformed"), bad)
+
+    def test_a_record_whose_path_disagrees_with_its_payload_is_malformed(self):
+        p = self.open12()
+        wrong = p.with_name("o-r#13.json"); p.rename(wrong)
+        self.assertTrue(wo.list_open(self.ws)[0].get("malformed"))
+        wrong.rename(p)
+        elsewhere = self.ws / "hosts" / HOST_B / "witness-owed" / p.name
+        elsewhere.parent.mkdir(parents=True); p.rename(elsewhere)
+        self.assertTrue(wo.list_open(self.ws)[0].get("malformed"))
+
+    def test_an_unrelated_repositorys_same_pr_number_does_not_block(self):
+        wo.open_record(self.ws, "unrelated/project", 12, "f" * 40, HOST_A, "elsewhere", "001")
+        sq, later = self.squash_topology()   # subject ends in (#12)
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, self.base, target_repo="o/r")), 0)
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, self.base)), 1,
+                         "without a target repo the (#N) match is unscoped — the CLI always passes --repo")
+        wo.open_record(self.ws, "o/r", 12, self.owed, HOST_A, "ours", "001")
+        hits = wo.blocking(self.ws, self.repo, later, self.base, target_repo="o/r")
+        self.assertEqual([h["repo"] for h in hits], ["o/r"])
+
+    def test_only_the_owing_host_may_close_and_a_peer_tombstones(self):
+        p = self.open12(host=HOST_A); later = self.merge_topology()
+        with self.assertRaises(ValueError):
+            wo.close_record(self.ws, "o/r", 12, "https://x/12", HOST_B)
+        self.assertTrue(p.exists(), "a foreign close must not touch the owner's file")
+        stone = wo.tombstone_record(self.ws, "o/r", 12, "https://x/12", HOST_B)
+        self.assertEqual(stone.parent.parent.parent.name, HOST_B, "the tombstone lives in the closer's subtree")
+        self.assertTrue(p.exists(), "the owner's record is untouched")
+        self.assertEqual(wo.list_open(self.ws), [], "a tombstone for the exact head closes the record")
+        self.assertEqual(wo.blocking(self.ws, self.repo, later, self.base, target_repo="o/r"), [])
+        # A re-opened record for a NEW head is not covered by the old tombstone.
+        p.unlink(); wo.open_record(self.ws, "o/r", 12, later, HOST_A, "reopened", "001")
+        self.assertEqual(len(wo.list_open(self.ws)), 1)
+
+    def test_freshness_two_workspaces_stale_copy_blocks_fresh_copy_passes(self):
+        # Host B's workspace holds a COPY of host A's subtree (what the vault carries).
+        ws_b = Path(self.tmp.name) / "ws-b"
+        self.open12(host=HOST_A); wo.publish(self.ws, HOST_A); later = self.merge_topology()
+        import shutil; shutil.copytree(self.ws / "hosts" / HOST_A, ws_b / "hosts" / HOST_A)
+        # Fresh stamp: the record itself blocks (it is open), not staleness.
+        hits = wo.blocking(ws_b, self.repo, later, self.base, host=HOST_B, target_repo="o/r", max_age_s=3600)
+        self.assertEqual([h.get("stale", False) for h in hits], [False])
+        # Host A closes at home; B's copy has not been refreshed: B must not activate on
+        # a stale view, and it must not read a stale-but-present stamp as fresh forever.
+        wo.close_record(self.ws, "o/r", 12, "https://x/12", HOST_A)
+        self.assertEqual(wo.blocking(self.ws, self.repo, later, self.base, host=HOST_A, target_repo="o/r"), [])
+        old = json.loads((ws_b / "hosts" / HOST_A / "witness-owed" / wo.STAMP_NAME).read_text())
+        old["published_at"] = "2000-01-01T00:00:00Z"; (ws_b / "hosts" / HOST_A / "witness-owed" / wo.STAMP_NAME).write_text(json.dumps(old))
+        hits = wo.blocking(ws_b, self.repo, later, self.base, host=HOST_B, target_repo="o/r", max_age_s=3600)
+        self.assertTrue(any(h.get("stale") for h in hits), "a stale foreign stamp blocks by itself")
+        # A missing stamp is the same as a stale one.
+        (ws_b / "hosts" / HOST_A / "witness-owed" / wo.STAMP_NAME).unlink()
+        self.assertEqual(wo.stale_hosts(ws_b, HOST_B, 3600), [HOST_A])
+        # After a refresh (the vault's copy step), the closed record is gone and the stamp is fresh.
+        shutil.rmtree(ws_b / "hosts" / HOST_A); wo.publish(self.ws, HOST_A)
+        shutil.copytree(self.ws / "hosts" / HOST_A, ws_b / "hosts" / HOST_A)
+        self.assertEqual(wo.blocking(ws_b, self.repo, later, self.base, host=HOST_B, target_repo="o/r", max_age_s=3600), [])
+
+
 class Cli(Fixture):
     def _run(self, *args):
         import contextlib
@@ -204,8 +277,8 @@ class Cli(Fixture):
         self.assertEqual(self._run("canary", "o/r#7", "--host", HOST_A).returncode, 0)
         self.assertEqual(self._run("check", "--ref", later, "--repo-root", rr, "--host", HOST_A).returncode, 0)
         self.assertEqual(self._run("check", "--ref", later, "--repo-root", rr, "--host", HOST_B).returncode, 3)
-        self.assertEqual(self._run("close", "o/r#7", "--witness", "thread").returncode, 0)
-        self.assertEqual(self._run("close", "o/r#7", "--witness", "thread").returncode, 5)
+        self.assertEqual(self._run("close", "o/r#7", "--witness", "thread", "--host", HOST_A).returncode, 0)
+        self.assertEqual(self._run("close", "o/r#7", "--witness", "thread", "--host", HOST_A).returncode, 5)
         self.assertEqual(self._run("check", "--ref", later, "--repo-root", rr).returncode, 0)
         self.assertNotEqual(self._run("open", "bad key", "--head", self.owed, "--host", "h",
                                       "--reason", "r", "--by", "me").returncode, 0)
@@ -224,7 +297,9 @@ class UpgradeWiring(unittest.TestCase):
 
     def test_gate_fails_closed_and_uses_the_canonical_python(self):
         for token in ('[ -n "$GATE_WS" ] ||', '[ -n "$GATE_PY" ] ||',
-                      '[ -f "$GATE_HELPER" ] ||', 'sutando-config.sh" python-bin'):
+                      '[ -f "$GATE_HELPER" ] ||', 'sutando-config.sh" python-bin',
+                      '[ -n "$GATE_REPO" ] ||', '--repo "$GATE_REPO"', '--max-age "$GATE_MAX_AGE"',
+                      'sync-workspace.sh" --pull-only ||', 'publish --host "$GATE_HOST"'):
             self.assertIn(token, self.SRC, token)
         self.assertNotIn('python3 "$REPO/src/witness_owed.py"', self.SRC, "bare python3 may hit the CLT stub")
         # A missing host label cannot release a record, so it must not stop

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -244,6 +244,50 @@ class Round4Blockers(Fixture):
         self.assertEqual(wo.blocking(ws_b, self.repo, later, self.base, host=HOST_B, target_repo="o/r", max_age_s=3600), [])
 
 
+class Round4Edges(Fixture):
+    """The error and skip branches the round-4 code added."""
+
+    def test_validation_and_publish_reject_the_shapes_they_name(self):
+        with self.assertRaises(ValueError):
+            wo.validate_record(["not", "an", "object"], self.ws / "x.json")
+        with self.assertRaises(ValueError):
+            wo.publish(self.ws, "")
+
+    def test_invalid_or_unreadable_tombstones_are_ignored(self):
+        p = self.open12(host=HOST_A)
+        tdir = wo.records_dir(self.ws, HOST_B) / "tombstones"; tdir.mkdir(parents=True)
+        (tdir / "o-r#12.json").write_text(json.dumps({"repo": "o/r", "pr": 12}))   # no head, no witness
+        (tdir / "broken.json").write_text("{not json")
+        (tdir / "dir.json").mkdir()
+        self.assertEqual(wo.tombstones(self.ws), {})
+        self.assertEqual([r["pr"] for r in wo.list_open(self.ws)], [12], "an invalid tombstone closes nothing")
+
+    def test_staleness_never_counts_this_host_and_an_unresolvable_current_ref_blocks(self):
+        self.open12(host=HOST_A)
+        self.assertEqual(wo.stale_hosts(self.ws, HOST_A, 1), [], "a host is never stale to itself")
+        later = self.merge_topology()
+        hits = wo.blocking(self.ws, self.repo, later, "no-such-ref", target_repo="o/r")
+        self.assertEqual(len(hits), 1)
+        self.assertIn("git could not answer", hits[0]["reason"])
+
+    def test_tombstone_helper_error_branches_through_the_cli(self):
+        r = wo.main(["--workspace", str(self.ws), "tombstone", "o/r#12", "--witness", "w", "--host", HOST_B])
+        self.assertEqual(r, 5, "no open record")
+        self.open12(host=HOST_A)
+        with self.assertRaises(ValueError):
+            wo.tombstone_record(self.ws, "o/r", 12, "", HOST_B)
+        with self.assertRaises(ValueError):
+            wo.tombstone_record(self.ws, "o/r", 12, "w", "")
+        self.assertEqual(wo.main(["--workspace", str(self.ws), "publish", "--host", HOST_B]), 0)
+        self.assertTrue((wo.records_dir(self.ws, HOST_B) / wo.STAMP_NAME).exists())
+        self.assertEqual(wo.main(["--workspace", str(self.ws), "tombstone", "o/r#12", "--witness", "w", "--host", HOST_B]), 0)
+        self.assertEqual(wo.list_open(self.ws), [])
+
+    def test_cli_resolves_the_workspace_when_none_is_given(self):
+        # Read-only: `list` on the resolved (real) workspace prints open records, if any.
+        self.assertEqual(wo.main(["list"]), 0)
+
+
 class Cli(Fixture):
     def _run(self, *args):
         import contextlib

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Contract for src/witness_owed.py and its wiring into self-upgrade."""
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("witness_owed", ROOT / "src" / "witness_owed.py")
+wo = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(wo)
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args], check=True,
+                          capture_output=True, text=True).stdout.strip()
+
+
+class Fixture(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name) / "ws"
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        _git(self.repo, "init", "-q", "-b", "main")
+        _git(self.repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+             "--allow-empty", "-m", "base")
+        self.base = _git(self.repo, "rev-parse", "HEAD")
+        _git(self.repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+             "--allow-empty", "-m", "owed pr")
+        self.owed = _git(self.repo, "rev-parse", "HEAD")
+        _git(self.repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+             "--allow-empty", "-m", "later")
+        self.later = _git(self.repo, "rev-parse", "HEAD")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+
+class Records(Fixture):
+    def test_open_requires_every_field(self):
+        for bad in ({"head": "notasha"}, {"host": ""}, {"reason": " "}, {"opened_by": ""}):
+            kw = dict(head=self.owed, host="h", reason="r", opened_by="me")
+            kw.update(bad)
+            with self.assertRaises(ValueError, msg=bad):
+                wo.open_record(self.ws, "o/r", 1, **kw)
+        with self.assertRaises(ValueError):
+            wo.open_record(self.ws, "o r", 1, head=self.owed, host="h", reason="r", opened_by="me")
+
+    def test_open_list_close_round_trip(self):
+        p = wo.open_record(self.ws, "o/r", 12, self.owed, "hostA", "no supervised lane", "001")
+        self.assertEqual(p.name, "o-r#12.json")
+        recs = wo.list_open(self.ws)
+        self.assertEqual([(r["repo"], r["pr"], r["head"]) for r in recs], [("o/r", 12, self.owed)])
+        with self.assertRaises(ValueError):
+            wo.close_record(self.ws, "o/r", 12, "")
+        closed = wo.close_record(self.ws, "o/r", 12, "https://example/pr/12#c1")
+        self.assertEqual(wo.list_open(self.ws), [])
+        data = json.loads(closed.read_text())
+        self.assertEqual(data["witness"], "https://example/pr/12#c1")
+        self.assertIn("closed_at", data)
+
+    def test_a_malformed_record_blocks_rather_than_vanishes(self):
+        d = wo.records_dir(self.ws)
+        d.mkdir(parents=True)
+        (d / "o-r#3.json").write_text("{not json")
+        (d / "o-r#4.json").write_text(json.dumps({"repo": "o/r"}))
+        hits = wo.blocking(self.ws, self.repo, self.later)
+        self.assertEqual(sorted(h["reason"][:10] for h in hits), ["unreadable", "unreadable"])
+
+
+class Gate(Fixture):
+    def test_blocks_only_a_target_that_newly_contains_the_owed_head(self):
+        wo.open_record(self.ws, "o/r", 1, self.owed, "hostA", "reason", "001")
+        # target contains the owed head, current does not -> blocked
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, self.later, self.base)), 1)
+        # target is before the owed head -> nothing to activate
+        self.assertEqual(wo.blocking(self.ws, self.repo, self.base), [])
+        # already running the owed head -> the upgrade adds nothing owed
+        self.assertEqual(wo.blocking(self.ws, self.repo, self.later, self.owed), [])
+        # closing it releases the gate
+        wo.close_record(self.ws, "o/r", 1, "posted")
+        self.assertEqual(wo.blocking(self.ws, self.repo, self.later, self.base), [])
+
+    def test_unknown_head_fails_closed(self):
+        wo.open_record(self.ws, "o/r", 1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "h", "r", "me")
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, self.later)), 1)
+
+    def test_canary_releases_only_the_owing_host(self):
+        wo.open_record(self.ws, "o/r", 1, self.owed, "hostA", "reason", "001")
+        wo.mark_canary(self.ws, "o/r", 1, "hostA")
+        self.assertEqual(wo.blocking(self.ws, self.repo, self.later, host="hostA"), [])
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, self.later, host="hostB")), 1)
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, self.later)), 1)
+
+
+class Cli(Fixture):
+    def _run(self, *args):
+        return subprocess.run([sys.executable, str(ROOT / "src" / "witness_owed.py"),
+                               "--workspace", str(self.ws), *args],
+                              capture_output=True, text=True)
+
+    def test_check_exit_codes_and_messages(self):
+        self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo)).returncode, 0)
+        r = self._run("open", "o/r#7", "--head", self.owed, "--host", "hostA",
+                      "--reason", "no supervised lane on any host", "--by", "001")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        r = self._run("check", "--ref", self.later, "--repo-root", str(self.repo))
+        self.assertEqual(r.returncode, 3)
+        self.assertIn("witness owed: o/r#7", r.stderr)
+        self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo),
+                                   "--host", "hostA").returncode, 3, "canary not yet declared")
+        self.assertEqual(self._run("canary", "o/r#7", "--host", "hostA").returncode, 0)
+        self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo),
+                                   "--host", "hostA").returncode, 0)
+        self.assertEqual(self._run("close", "o/r#7", "--witness", "thread").returncode, 0)
+        self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo)).returncode, 0)
+        self.assertNotEqual(self._run("open", "bad key", "--head", self.owed, "--host", "h",
+                                      "--reason", "r", "--by", "me").returncode, 0)
+
+
+class UpgradeWiring(unittest.TestCase):
+    def test_self_upgrade_checks_the_record_before_it_pulls(self):
+        src = (ROOT / "skills/self-upgrade/scripts/upgrade.sh").read_text()
+        check = src.index("src/witness_owed.py")
+        pull = src.index("git pull --ff-only")
+        self.assertLess(check, pull, "the gate must run before the head changes")
+        self.assertIn('check --ref "$REMOTE/$BRANCH"', src)
+        self.assertIn("--current HEAD", src)
+        self.assertIn("--canary", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -44,7 +44,9 @@ class Fixture(unittest.TestCase):
         self.tmp.cleanup()
 
     def merge_topology(self):
-        _git(self.repo, "merge", "-q", "--no-ff", "-m", "merge topic (#12)", "topic")
+        # The merge commit needs an identity too; the runner has none configured.
+        _git(self.repo, "-c", "user.email=t@t", "-c", "user.name=t",
+             "merge", "-q", "--no-ff", "-m", "merge topic (#12)", "topic")
         return _commit(self.repo, "later")
 
     def squash_topology(self):

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -99,9 +99,29 @@ class Gate(Fixture):
 
 class Cli(Fixture):
     def _run(self, *args):
-        return subprocess.run([sys.executable, str(ROOT / "src" / "witness_owed.py"),
-                               "--workspace", str(self.ws), *args],
-                              capture_output=True, text=True)
+        # In-process so the CLI arms count toward coverage; one subprocess case
+        # below still proves the entry point.
+        import contextlib
+        import io
+        import types
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            try:
+                rc = wo.main(["--workspace", str(self.ws), *args])
+            except SystemExit as e:
+                rc = e.code if isinstance(e.code, int) else 2
+        return types.SimpleNamespace(returncode=rc, stdout=out.getvalue(), stderr=err.getvalue())
+
+    def test_entry_point_runs_as_a_process(self):
+        r = subprocess.run([sys.executable, str(ROOT / "src" / "witness_owed.py"),
+                            "--workspace", str(self.ws), "list"], capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_list_prints_open_records_and_missing_dir_is_empty(self):
+        self.assertEqual(wo.list_open(self.ws), [])
+        r = self._run("list"); self.assertEqual((r.returncode, r.stdout), (0, ""))
+        wo.open_record(self.ws, "o/r", 9, self.owed, "hostA", "why", "001")
+        r = self._run("list"); self.assertIn("o/r#9 head=" + self.owed[:8], r.stdout)
 
     def test_check_exit_codes_and_messages(self):
         self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo)).returncode, 0)

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -2,6 +2,7 @@
 """Contract for src/witness_owed.py and its wiring into self-upgrade."""
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -12,11 +13,18 @@ ROOT = Path(__file__).resolve().parent.parent
 spec = importlib.util.spec_from_file_location("witness_owed", ROOT / "src" / "witness_owed.py")
 wo = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(wo)
+HOST_A, HOST_B = "host-a", "host-b"
 
 
 def _git(repo, *args):
     return subprocess.run(["git", "-C", str(repo), *args], check=True,
                           capture_output=True, text=True).stdout.strip()
+
+
+def _commit(repo, msg, body=""):
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+         "--allow-empty", "-m", msg, *(["-m", body] if body else []))
+    return _git(repo, "rev-parse", "HEAD")
 
 
 class Fixture(unittest.TestCase):
@@ -26,18 +34,30 @@ class Fixture(unittest.TestCase):
         self.repo = Path(self.tmp.name) / "repo"
         self.repo.mkdir()
         _git(self.repo, "init", "-q", "-b", "main")
-        _git(self.repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
-             "--allow-empty", "-m", "base")
-        self.base = _git(self.repo, "rev-parse", "HEAD")
-        _git(self.repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
-             "--allow-empty", "-m", "owed pr")
-        self.owed = _git(self.repo, "rev-parse", "HEAD")
-        _git(self.repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
-             "--allow-empty", "-m", "later")
-        self.later = _git(self.repo, "rev-parse", "HEAD")
+        self.base = _commit(self.repo, "base")
+        # A topic branch whose head is the recorded PR head.
+        _git(self.repo, "checkout", "-q", "-b", "topic")
+        self.owed = _commit(self.repo, "owed pr work")
+        _git(self.repo, "checkout", "-q", "main")
 
     def tearDown(self):
         self.tmp.cleanup()
+
+    def merge_topology(self):
+        _git(self.repo, "merge", "-q", "--no-ff", "-m", "merge topic (#12)", "topic")
+        return _commit(self.repo, "later")
+
+    def squash_topology(self):
+        # GitHub squash: ONE new commit, parent = base, subject ends in (#N);
+        # the PR head is NOT an ancestor.
+        sq = _commit(self.repo, "feat: owed pr work (#12)")
+        later = _commit(self.repo, "later")
+        assert subprocess.run(["git", "-C", str(self.repo), "merge-base", "--is-ancestor",
+                               self.owed, later]).returncode == 1
+        return sq, later
+
+    def open12(self, host=HOST_A):
+        return wo.open_record(self.ws, "o/r", 12, self.owed, host, "no supervised lane", "001")
 
 
 class Records(Fixture):
@@ -50,57 +70,107 @@ class Records(Fixture):
         with self.assertRaises(ValueError):
             wo.open_record(self.ws, "o r", 1, head=self.owed, host="h", reason="r", opened_by="me")
 
+    def test_record_lives_in_the_carried_per_host_subtree(self):
+        p = self.open12()
+        self.assertEqual(p.relative_to(self.ws).parts[:3], ("hosts", HOST_A, "witness-owed"))
+        self.assertFalse((self.ws / "state").exists(), "nothing under state/, which the vault never carries")
+        include = json.loads((ROOT / "sutando.config.json").read_text())["vault"]["sync"]["include"]
+        self.assertIn("hosts/*/", include, "the shipped carrier must cover the record path")
+
+    def test_a_record_opened_on_one_host_is_seen_by_every_host(self):
+        # Host A opens; host B's reader (same carried tree) sees it and is refused.
+        self.open12(host=HOST_A)
+        later = self.merge_topology()
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, self.base, host=HOST_B)), 1)
+        self.assertEqual([r["host"] for r in wo.list_open(self.ws)], [HOST_A])
+
     def test_open_list_close_round_trip(self):
-        p = wo.open_record(self.ws, "o/r", 12, self.owed, "hostA", "no supervised lane", "001")
-        self.assertEqual(p.name, "o-r#12.json")
+        self.open12()
         recs = wo.list_open(self.ws)
         self.assertEqual([(r["repo"], r["pr"], r["head"]) for r in recs], [("o/r", 12, self.owed)])
         with self.assertRaises(ValueError):
             wo.close_record(self.ws, "o/r", 12, "")
         closed = wo.close_record(self.ws, "o/r", 12, "https://example/pr/12#c1")
         self.assertEqual(wo.list_open(self.ws), [])
-        data = json.loads(closed.read_text())
-        self.assertEqual(data["witness"], "https://example/pr/12#c1")
-        self.assertIn("closed_at", data)
+        self.assertEqual(closed.parent.name, "closed")
+        self.assertIn("closed_at", json.loads(closed.read_text()))
+        with self.assertRaises(FileNotFoundError):
+            wo.close_record(self.ws, "o/r", 12, "again")
 
     def test_a_malformed_record_blocks_rather_than_vanishes(self):
-        d = wo.records_dir(self.ws)
+        d = wo.records_dir(self.ws, HOST_A)
         d.mkdir(parents=True)
         (d / "o-r#3.json").write_text("{not json")
         (d / "o-r#4.json").write_text(json.dumps({"repo": "o/r"}))
-        hits = wo.blocking(self.ws, self.repo, self.later)
+        hits = wo.blocking(self.ws, self.repo, self.merge_topology())
         self.assertEqual(sorted(h["reason"][:10] for h in hits), ["unreadable", "unreadable"])
 
 
 class Gate(Fixture):
-    def test_blocks_only_a_target_that_newly_contains_the_owed_head(self):
-        wo.open_record(self.ws, "o/r", 1, self.owed, "hostA", "reason", "001")
-        # target contains the owed head, current does not -> blocked
-        self.assertEqual(len(wo.blocking(self.ws, self.repo, self.later, self.base)), 1)
-        # target is before the owed head -> nothing to activate
+    def test_merge_topology_blocks_only_a_target_that_newly_contains_the_head(self):
+        self.open12()
+        later = self.merge_topology()
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, self.base)), 1)
         self.assertEqual(wo.blocking(self.ws, self.repo, self.base), [])
-        # already running the owed head -> the upgrade adds nothing owed
-        self.assertEqual(wo.blocking(self.ws, self.repo, self.later, self.owed), [])
-        # closing it releases the gate
-        wo.close_record(self.ws, "o/r", 1, "posted")
-        self.assertEqual(wo.blocking(self.ws, self.repo, self.later, self.base), [])
+        self.assertEqual(wo.blocking(self.ws, self.repo, later, later), [])
+        wo.close_record(self.ws, "o/r", 12, "posted")
+        self.assertEqual(wo.blocking(self.ws, self.repo, later, self.base), [])
 
-    def test_unknown_head_fails_closed(self):
-        wo.open_record(self.ws, "o/r", 1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "h", "r", "me")
-        self.assertEqual(len(wo.blocking(self.ws, self.repo, self.later)), 1)
+    def test_squash_topology_is_recognised_by_the_merge_subject(self):
+        # The PR head is not an ancestor of main after a squash merge; the
+        # gate must still see the owed PR in the range it is about to activate.
+        self.open12()
+        sq, later = self.squash_topology()
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, self.base)), 1)
+        self.assertEqual(wo.blocking(self.ws, self.repo, later, later), [], "already active: nothing new")
+        self.assertEqual(wo.blocking(self.ws, self.repo, self.base), [])
+        # A different PR whose head this clone never fetched: absent is not an
+        # error, and its number is not in the range, so it does not block.
+        other = wo.open_record(self.ws, "o/r", 13, "deadbeef" * 5, HOST_A, "r", "001")
+        hits = wo.blocking(self.ws, self.repo, later, self.base)
+        self.assertEqual(sorted(h["pr"] for h in hits), [12])
+        other.unlink()
+
+    def test_rebase_topology_is_recognised_by_a_body_naming_the_head(self):
+        self.open12()
+        _commit(self.repo, "rebased: owed pr work", body=f"Squashed from {self.owed}")
+        later = _commit(self.repo, "later")
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, self.base)), 1)
+
+    def test_an_unfetched_head_is_not_an_error_but_a_broken_repo_is(self):
+        # Squash merges leave the PR head unfetched on every deploying clone;
+        # that must resolve through the subject scan, not fail closed forever.
+        self.open12()
+        sq, later = self.squash_topology()
+        wo.open_record(self.ws, "o/r", 1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", HOST_A, "r", "me")
+        hits = wo.blocking(self.ws, self.repo, later, self.base)
+        self.assertEqual(sorted(h["pr"] for h in hits), [12], "only the PR named in the range blocks")
+        self.assertIs(wo._is_ancestor(self.repo, "deadbeef" * 5, later), False)
+        self.assertIs(wo._is_ancestor(self.repo, self.base, later), True)
+        self.assertIs(wo._is_ancestor(self.repo, later, self.base), False)
+        # A ref git cannot resolve, or no repository at all, is a real error
+        # and blocks every record — with or without a current ref.
+        self.assertIsNone(wo._is_ancestor(self.repo, self.base, "no-such-ref"))
+        hits = wo.blocking(self.ws, Path(self.tmp.name) / "not-a-repo", later, later)
+        self.assertEqual(len(hits), 2)
+        self.assertTrue(all("git could not answer" in h["reason"] for h in hits))
 
     def test_canary_releases_only_the_owing_host(self):
-        wo.open_record(self.ws, "o/r", 1, self.owed, "hostA", "reason", "001")
-        wo.mark_canary(self.ws, "o/r", 1, "hostA")
-        self.assertEqual(wo.blocking(self.ws, self.repo, self.later, host="hostA"), [])
-        self.assertEqual(len(wo.blocking(self.ws, self.repo, self.later, host="hostB")), 1)
-        self.assertEqual(len(wo.blocking(self.ws, self.repo, self.later)), 1)
+        self.open12(host=HOST_A)
+        later = self.merge_topology()
+        with self.assertRaises(ValueError):
+            wo.mark_canary(self.ws, "o/r", 12, HOST_B)
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, host=HOST_B)), 1)
+        wo.mark_canary(self.ws, "o/r", 12, HOST_A)
+        self.assertEqual(wo.blocking(self.ws, self.repo, later, host=HOST_A), [])
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later, host=HOST_B)), 1)
+        self.assertEqual(len(wo.blocking(self.ws, self.repo, later)), 1)
+        with self.assertRaises(FileNotFoundError):
+            wo.mark_canary(self.ws, "o/r", 99, HOST_A)
 
 
 class Cli(Fixture):
     def _run(self, *args):
-        # In-process so the CLI arms count toward coverage; one subprocess case
-        # below still proves the entry point.
         import contextlib
         import io
         import types
@@ -117,40 +187,44 @@ class Cli(Fixture):
                             "--workspace", str(self.ws), "list"], capture_output=True, text=True)
         self.assertEqual(r.returncode, 0, r.stderr)
 
-    def test_list_prints_open_records_and_missing_dir_is_empty(self):
-        self.assertEqual(wo.list_open(self.ws), [])
-        r = self._run("list"); self.assertEqual((r.returncode, r.stdout), (0, ""))
-        wo.open_record(self.ws, "o/r", 9, self.owed, "hostA", "why", "001")
-        r = self._run("list"); self.assertIn("o/r#9 head=" + self.owed[:8], r.stdout)
-
     def test_check_exit_codes_and_messages(self):
-        self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo)).returncode, 0)
-        r = self._run("open", "o/r#7", "--head", self.owed, "--host", "hostA",
+        later = self.merge_topology()
+        rr = str(self.repo)
+        self.assertEqual(self._run("check", "--ref", later, "--repo-root", rr).returncode, 0)
+        r = self._run("open", "o/r#7", "--head", self.owed, "--host", HOST_A,
                       "--reason", "no supervised lane on any host", "--by", "001")
         self.assertEqual(r.returncode, 0, r.stderr)
-        r = self._run("check", "--ref", self.later, "--repo-root", str(self.repo))
-        self.assertEqual(r.returncode, 3)
-        self.assertIn("witness owed: o/r#7", r.stderr)
-        self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo),
-                                   "--host", "hostA").returncode, 3, "canary not yet declared")
-        self.assertEqual(self._run("canary", "o/r#7", "--host", "hostA").returncode, 0)
-        self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo),
-                                   "--host", "hostA").returncode, 0)
+        r = self._run("check", "--ref", later, "--repo-root", rr)
+        self.assertEqual((r.returncode, "witness owed: o/r#7" in r.stderr), (3, True))
+        r = self._run("list"); self.assertIn("o/r#7 head=" + self.owed[:8], r.stdout)
+        self.assertEqual(self._run("check", "--ref", later, "--repo-root", rr, "--host", HOST_A).returncode, 3)
+        self.assertEqual(self._run("canary", "o/r#7", "--host", HOST_B).returncode, 5, "wrong host refused")
+        self.assertEqual(self._run("canary", "o/r#7", "--host", HOST_A).returncode, 0)
+        self.assertEqual(self._run("check", "--ref", later, "--repo-root", rr, "--host", HOST_A).returncode, 0)
+        self.assertEqual(self._run("check", "--ref", later, "--repo-root", rr, "--host", HOST_B).returncode, 3)
         self.assertEqual(self._run("close", "o/r#7", "--witness", "thread").returncode, 0)
-        self.assertEqual(self._run("check", "--ref", self.later, "--repo-root", str(self.repo)).returncode, 0)
+        self.assertEqual(self._run("close", "o/r#7", "--witness", "thread").returncode, 5)
+        self.assertEqual(self._run("check", "--ref", later, "--repo-root", rr).returncode, 0)
         self.assertNotEqual(self._run("open", "bad key", "--head", self.owed, "--host", "h",
                                       "--reason", "r", "--by", "me").returncode, 0)
 
 
 class UpgradeWiring(unittest.TestCase):
+    SRC = (ROOT / "skills/self-upgrade/scripts/upgrade.sh").read_text()
+
     def test_self_upgrade_checks_the_record_before_it_pulls(self):
-        src = (ROOT / "skills/self-upgrade/scripts/upgrade.sh").read_text()
-        check = src.index("src/witness_owed.py")
-        pull = src.index("git pull --ff-only")
-        self.assertLess(check, pull, "the gate must run before the head changes")
-        self.assertIn('check --ref "$REMOTE/$BRANCH"', src)
-        self.assertIn("--current HEAD", src)
-        self.assertIn("--canary", src)
+        gate = self.SRC.index("witness_owed.py")
+        pull = self.SRC.index("git pull --ff-only")
+        self.assertLess(gate, pull, "the gate must run before the head changes")
+        self.assertIn('check --ref "$REMOTE/$BRANCH"', self.SRC)
+        self.assertIn("--current HEAD", self.SRC)
+        self.assertIn("--canary", self.SRC)
+
+    def test_gate_fails_closed_and_uses_the_canonical_python(self):
+        for token in ('[ -n "$GATE_WS" ] ||', '[ -n "$GATE_HOST" ] ||', '[ -n "$GATE_PY" ] ||',
+                      '[ -f "$GATE_HELPER" ] ||', 'sutando-config.sh" python-bin'):
+            self.assertIn(token, self.SRC, token)
+        self.assertNotIn('python3 "$REPO/src/witness_owed.py"', self.SRC, "bare python3 may hit the CLT stub")
 
 
 if __name__ == "__main__":

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -223,10 +223,15 @@ class UpgradeWiring(unittest.TestCase):
         self.assertIn("--canary", self.SRC)
 
     def test_gate_fails_closed_and_uses_the_canonical_python(self):
-        for token in ('[ -n "$GATE_WS" ] ||', '[ -n "$GATE_HOST" ] ||', '[ -n "$GATE_PY" ] ||',
+        for token in ('[ -n "$GATE_WS" ] ||', '[ -n "$GATE_PY" ] ||',
                       '[ -f "$GATE_HELPER" ] ||', 'sutando-config.sh" python-bin'):
             self.assertIn(token, self.SRC, token)
         self.assertNotIn('python3 "$REPO/src/witness_owed.py"', self.SRC, "bare python3 may hit the CLT stub")
+        # A missing host label cannot release a record, so it must not stop
+        # `check`; it must stop a canary declaration.
+        canary = self.SRC.index('if [ -n "$CANARY" ]')
+        self.assertLess(canary, self.SRC.index('[ -n "$GATE_HOST" ] ||'))
+        self.assertIn('${GATE_HOST:+--host "$GATE_HOST"}', self.SRC)
 
 
 if __name__ == "__main__":

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -353,5 +353,82 @@ class UpgradeWiring(unittest.TestCase):
         self.assertIn('${GATE_HOST:+--host "$GATE_HOST"}', self.SRC)
 
 
+class Round5Blockers(Fixture):
+    """keweichen's round-5 P1-2 controls, each reproduced against the
+    production writers/readers. Every one of these passed BEFORE the fix."""
+
+    def _open(self, repo="o/r", pr=12, host=HOST_A):
+        return wo.open_record(self.ws, repo, pr, self.owed, host, "why", "me")
+
+    def test_a_malformed_tombstone_cannot_clear_an_open_record(self):
+        # Wrong filename, wrong owners, no timestamp — yet three fields were
+        # enough to close a peer's record.
+        self._open()
+        self.assertEqual(len(wo.list_open(self.ws)), 1)
+        bad = wo.records_dir(self.ws, HOST_B) / "tombstones" / "not-the-record-name.json"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text(json.dumps({"repo": "o/r", "pr": 12, "head": self.owed,
+                                   "witness": "https://example/x"}))
+        self.assertEqual(len(wo.list_open(self.ws)), 1,
+                         "a tombstone missing owners/timestamp and misnamed still closed the record")
+
+    def test_a_tombstone_cannot_be_written_by_the_owing_host(self):
+        self._open()
+        stone = wo.records_dir(self.ws, HOST_A) / "tombstones" / wo.record_key("o/r", 12)
+        stone.parent.mkdir(parents=True, exist_ok=True)
+        stone.write_text(json.dumps({"repo": "o/r", "pr": 12, "head": self.owed,
+                                     "owed_by": HOST_A, "closed_by": HOST_A,
+                                     "witness": "https://example/x", "closed_at": "2026-09-04T00:00:00Z"}))
+        self.assertEqual(len(wo.list_open(self.ws)), 1,
+                         "a host tombstoned its OWN record, bypassing close_record's checks")
+
+    def test_a_stamp_naming_another_host_is_not_freshness(self):
+        wo.open_record(self.ws, "o/r", 12, self.owed, HOST_B, "why", "me")
+        d = wo.records_dir(self.ws, HOST_B)
+        wo._atomic_write(d / wo.STAMP_NAME, {"host": HOST_A, "published_at": wo._now()})
+        self.assertEqual(wo.stale_hosts(self.ws, HOST_A, 3600.0), [HOST_B],
+                         "host-a's stamp vouched for host-b's directory")
+
+    def test_valid_repo_names_cannot_collide_on_one_record_file(self):
+        # `a-b/c` and `a/b-c` both became `a-b-c` under replace('/', '-').
+        first = self._open(repo="a-b/c", pr=7)
+        second = self._open(repo="a/b-c", pr=7)
+        self.assertNotEqual(first, second, "two distinct repos share one record file")
+        keys = {r["repo"] for r in wo.list_open(self.ws)}
+        self.assertEqual(keys, {"a-b/c", "a/b-c"},
+                         f"one repo's record overwrote the other's: {keys}")
+        self.assertIsNotNone(wo.find_record(self.ws, "a-b/c", 7))
+        self.assertIsNotNone(wo.find_record(self.ws, "a/b-c", 7))
+
+    def test_a_host_cannot_escape_the_workspace(self):
+        for bad in ("../../escaped", "a/b", ".", "..", "", "  "):
+            with self.assertRaises(ValueError, msg=f"host {bad!r} was accepted"):
+                wo.records_dir(self.ws, bad)
+
+    def test_concurrent_writers_do_not_destroy_each_other(self):
+        import threading
+        path = wo.records_dir(self.ws, HOST_A) / "concurrent.json"
+        start = threading.Barrier(2)
+        errors = []
+
+        def w(tag):
+            try:
+                start.wait(timeout=5)
+                wo._atomic_write(path, {"tag": tag})
+            except Exception as exc:            # noqa: BLE001 - the control IS the type
+                errors.append(type(exc).__name__)
+
+        ts = [threading.Thread(target=w, args=(t,)) for t in ("a", "b")]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join(10)
+        self.assertEqual(errors, [], f"a shared .tmp name made concurrent writers race: {errors}")
+        self.assertTrue(path.is_file())
+        self.assertIn(json.loads(path.read_text())["tag"], ("a", "b"))
+        leftovers = list(path.parent.glob("*.tmp"))
+        self.assertEqual(leftovers, [], f"temp files left behind: {leftovers}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -333,9 +333,9 @@ class UpgradeWiring(unittest.TestCase):
 
     def test_self_upgrade_checks_the_record_before_it_pulls(self):
         gate = self.SRC.index("witness_owed.py")
-        pull = self.SRC.index("git pull --ff-only")
+        pull = self.SRC.index("git merge --ff-only")
         self.assertLess(gate, pull, "the gate must run before the head changes")
-        self.assertIn('check --ref "$REMOTE/$BRANCH"', self.SRC)
+        self.assertIn('check --ref "$TARGET_SHA"', self.SRC)
         self.assertIn("--current HEAD", self.SRC)
         self.assertIn("--canary", self.SRC)
 
@@ -498,14 +498,14 @@ class UpgradePublicationWiring(unittest.TestCase):
     def test_this_host_publishes_before_it_reads_the_fleet(self):
         publish = self.sh.index('publish --host "$GATE_HOST"')
         sync = self.sh.index('bash "$REPO/scripts/sync-workspace.sh"')
-        check = self.sh.index('check --ref "$REMOTE/$BRANCH"')
+        check = self.sh.index('check --ref "$TARGET_SHA"')
         self.assertLess(publish, sync, "the stamp must travel WITH the records the sync pushes")
         self.assertLess(sync, check, "the fleet is read before it is refreshed")
 
     def test_the_pre_gate_sync_is_a_full_tick_not_pull_only(self):
         # --pull-only never publishes this host, so a fleet of pull-only
         # updaters ages every stamp out and then refuses forever.
-        check = self.sh.index('check --ref "$REMOTE/$BRANCH"')
+        check = self.sh.index('check --ref "$TARGET_SHA"')
         # Only INVOCATIONS count: the first draft of this assertion matched its
         # own explanatory comment and failed on prose.
         calls = [ln for ln in self.sh[:check].splitlines()
@@ -518,14 +518,258 @@ class UpgradePublicationWiring(unittest.TestCase):
         # gate refuses the very host the canary was declared for.
         declare = self.sh.index('canary "$CANARY" --host "$GATE_HOST"')
         publish = self.sh.index('publish --host "$GATE_HOST"', declare)
-        check = self.sh.index('check --ref "$REMOTE/$BRANCH"')
+        check = self.sh.index('check --ref "$TARGET_SHA"')
         self.assertLess(publish, check)
 
     def test_nothing_heavy_sits_between_the_pull_and_the_restart_handoff(self):
         # A synchronous vault push here delayed the handoff past its budget.
-        pull = self.sh.index('git pull --ff-only')
+        pull = self.sh.index('git merge --ff-only')
         handoff = self.sh.index('new-session -d -s "$SERVICE_SESSION"')
         self.assertNotIn("sync-workspace.sh", self.sh[pull:handoff])
+
+
+class Round7Serialization(Fixture):
+    """keweichen round-5 P1-3: close and open on one record key must not
+    interleave. The control is the production writers, raced."""
+
+    HEAD_A, HEAD_B = "a" * 40, "b" * 40
+
+    def _race(self, mod=wo):
+        """Run keweichen's ordering: pause close() the instant it archives,
+        let a concurrent open() fire, then resume. Returns (errors, close_exc)."""
+        import threading
+        import time
+        mod.open_record(self.ws, "o/r", 12, self.HEAD_A, HOST_A, "why", "me")
+        paused, errors, real_write = threading.Event(), [], mod._atomic_write
+
+        def instrumented(path, data):
+            real_write(path, data)
+            if path.parent.name == "closed":
+                paused.set()
+                time.sleep(1.5)
+
+        def opener():
+            if not paused.wait(10):
+                errors.append("close never archived")
+                return
+            try:
+                mod.open_record(self.ws, "o/r", 12, self.HEAD_B, HOST_A, "reopened", "me")
+            except Exception as exc:             # noqa: BLE001 - the race IS the subject
+                errors.append(repr(exc))
+
+        t = threading.Thread(target=opener)
+        t.start()
+        mod._atomic_write = instrumented
+        close_exc = None
+        try:
+            mod.close_record(self.ws, "o/r", 12, "https://x/12", HOST_A)
+        except Exception as exc:                 # noqa: BLE001 - same
+            close_exc = exc
+        finally:
+            mod._atomic_write = real_write
+        t.join(20)
+        return errors, close_exc
+
+    def _closed_head(self):
+        return json.loads((wo.records_dir(self.ws, HOST_A) / "closed"
+                           / wo.record_key("o/r", 12)).read_text())["head"]
+
+    def test_a_close_cannot_delete_a_concurrently_reopened_hold(self):
+        errors, close_exc = self._race()
+        self.assertEqual(errors, [], f"the concurrent open failed: {errors}")
+        self.assertIsNone(close_exc, f"the serialized close must succeed: {close_exc!r}")
+        # THE POINT: the lock serializes them, so the reopened B survives the
+        # close of A — the old ordering archived A and unlinked B.
+        heads = [r["head"] for r in wo.list_open(self.ws)]
+        self.assertEqual(heads, [self.HEAD_B],
+                         f"the reopened hold vanished; closed={self._closed_head()}")
+        self.assertEqual(self._closed_head(), self.HEAD_A)
+
+    def test_without_the_lock_the_close_refuses_rather_than_deleting(self):
+        """Control: disable ONLY the lock and the production compare-and-swap
+        still refuses to unlink bytes it did not archive."""
+        import contextlib
+        real_lock = wo.record_lock
+        wo.record_lock = lambda *a, **k: contextlib.nullcontext()
+        try:
+            errors, close_exc = self._race()
+        finally:
+            wo.record_lock = real_lock
+        self.assertEqual(errors, [])
+        self.assertIsInstance(close_exc, ValueError)
+        self.assertIn("rewritten while closing", str(close_exc))
+        self.assertEqual([r["head"] for r in wo.list_open(self.ws)], [self.HEAD_B],
+                         "an unlocked close deleted the reopened hold")
+
+    def test_the_lock_file_is_not_part_of_what_is_published(self):
+        wo.open_record(self.ws, "o/r", 12, self.HEAD_A, HOST_A, "why", "me")
+        wo.publish(self.ws, HOST_A)
+        self.assertTrue(list((wo.records_dir(self.ws, HOST_A) / ".locks").glob("*.lock")))
+        self.assertFalse(wo.unpublished(self.ws, HOST_A), "a lock file moved the digest")
+
+
+class Round7SerializationControl(Fixture):
+    """Before/after on ONE fixture: the PRE-FIX writer, built from the shipped
+    module by disabling exactly the two added mechanisms, loses the hold."""
+
+    HEAD_A, HEAD_B = Round7Serialization.HEAD_A, Round7Serialization.HEAD_B
+    _race = Round7Serialization._race
+    _closed_head = Round7Serialization._closed_head
+
+    def _prefix_module(self):
+        src = (ROOT / "src" / "witness_owed.py").read_text()
+        out = src.replace("fcntl.flock(fh.fileno(), fcntl.LOCK_EX)", "pass", 1)
+        out = out.replace("fcntl.flock(fh.fileno(), fcntl.LOCK_UN)", "pass", 1)
+        out = out.replace("if path.read_text() != raw:", "if False:", 1)
+        self.assertNotIn("LOCK_EX", out, "the lock substitution was a no-op")
+        self.assertNotIn("path.read_text() != raw", out, "the CAS substitution was a no-op")
+        mod = importlib.util.module_from_spec(spec)
+        exec(compile(out, "witness_owed_prefix", "exec"), mod.__dict__)
+        return mod
+
+    def test_the_pre_fix_writer_reproduces_the_lost_hold(self):
+        control = self._prefix_module()
+        errors, close_exc = self._race(control)
+        self.assertEqual(errors, [])
+        self.assertIsNone(close_exc, "the pre-fix close raised; it used to succeed silently")
+        # CONTROL: close archived A and unlinked the newly opened B.
+        self.assertEqual(wo.list_open(self.ws), [], "the pre-fix defect did not reproduce")
+        self.assertEqual(self._closed_head(), self.HEAD_A)
+
+
+class Round7HostLabel(Fixture):
+    """keweichen round-5 P1-4: the helper must accept every label the host
+    contract can produce, and still refuse anything that is not one segment."""
+
+    def test_a_legal_label_with_a_space_is_accepted_end_to_end(self):
+        # `_host_label()`/`_host()` trim the ENDS only, so `My Mac` is legal and
+        # `hosts/My Mac/` is the directory the vault carries.
+        self.assertEqual(wo.validate_host("My Mac"), "My Mac")
+        p = wo.open_record(self.ws, "o/r", 12, self.owed, "My Mac", "why", "me")
+        self.assertEqual(p.relative_to(self.ws).parts[:3], ("hosts", "My Mac", "witness-owed"))
+        later = self.merge_topology()
+        hits = wo.blocking(self.ws, self.repo, later, self.base, host="My Mac", target_repo="o/r")
+        self.assertEqual([h["host"] for h in hits], ["My Mac"],
+                         "a legal host label made the gate raise instead of answering")
+        self.assertEqual(wo.records_digest(self.ws, "My Mac") != wo.EMPTY_DIGEST, True)
+
+    def test_the_shell_and_python_host_resolvers_agree_that_ends_are_trimmed(self):
+        """Data pin on the contract this validator follows: both resolvers trim
+        the ends only, which is exactly why an internal space must be kept."""
+        py = (ROOT / "src" / "util_paths.py").read_text()
+        sh = (ROOT / "scripts" / "sync-workspace.sh").read_text()
+        self.assertIn("label containing a space is preserved", sh)
+        self.assertIn("Matches SutandoConfig.hostLabel()", py)
+
+    def test_a_host_that_is_not_one_segment_is_still_refused(self):
+        for bad in ("../../escaped", "a/b", ".", "..", "", "  ", " lead", "trail ",
+                    "nul\x00", "bell\x07", "back\\slash"):
+            with self.assertRaises(ValueError, msg=f"host {bad!r} was accepted"):
+                wo.validate_host(bad)
+
+
+class Round7Publication(Fixture):
+    """keweichen round-5 P1-1: what "published" means, and when the gate may
+    trust a peer's directory."""
+
+    def _peer_ws(self):
+        return Path(self.tmp.name) / "ws-peer"
+
+    def _push_cmd(self):
+        """Stand-in for the vault push: copy this host's subtree to the peer."""
+        import shlex
+        return (f"cp -R {shlex.quote(str(self.ws / 'hosts'))} "
+                f"{shlex.quote(str(self._peer_ws()))}/")
+
+    def _cli(self, *args):
+        return subprocess.run([sys.executable, str(ROOT / "src" / "witness_owed.py"),
+                               "--workspace", str(self.ws), *args],
+                              capture_output=True, text=True)
+
+    def test_a_published_hold_opened_on_one_host_blocks_the_gate_on_another(self):
+        peer = self._peer_ws(); peer.mkdir(parents=True)
+        r = self._cli("open", "o/r#12", "--head", self.owed, "--host", HOST_A,
+                      "--reason", "no supervised lane", "--by", "001",
+                      "--publish-with", self._push_cmd())
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertFalse(wo.unpublished(self.ws, HOST_A), "a successful push left the host unpublished")
+        later = self.merge_topology()
+        hits = wo.blocking(peer, self.repo, later, self.base, host=HOST_B,
+                           target_repo="o/r", max_age_s=3600)
+        self.assertEqual([(h["repo"], h["pr"]) for h in hits], [("o/r", 12)],
+                         "a published hold was invisible to the peer's gate")
+
+    def test_a_push_that_fails_withdraws_the_stamp_and_says_the_hold_is_local(self):
+        r = self._cli("open", "o/r#12", "--head", self.owed, "--host", HOST_A,
+                      "--reason", "no supervised lane", "--by", "001",
+                      "--publish-with", "exit 7")
+        self.assertEqual(r.returncode, 6, r.stdout + r.stderr)
+        self.assertIn("on host-a only", r.stderr)
+        self.assertFalse((wo.records_dir(self.ws, HOST_A) / wo.STAMP_NAME).exists(),
+                         "a failed push left a stamp claiming peers can see the hold")
+        # And the un-published host cannot activate: it blocks on itself.
+        later = self.merge_topology()
+        hits = wo.blocking(self.ws, self.repo, later, self.base, host=HOST_A,
+                           target_repo="o/r", max_age_s=3600)
+        self.assertTrue(any(h.get("stale") and "publish and push" in h["reason"] for h in hits),
+                        f"an unpublished host activated anyway: {hits}")
+
+    def test_open_without_publish_with_says_the_hold_is_not_in_force_fleet_wide(self):
+        r = self._cli("open", "o/r#12", "--head", self.owed, "--host", HOST_A,
+                      "--reason", "no supervised lane", "--by", "001")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("NOT PUBLISHED", r.stderr)
+        self.assertTrue(wo.unpublished(self.ws, HOST_A))
+
+    def test_the_deploying_host_must_have_pulled_before_it_trusts_the_fleet(self):
+        """The (a) clause of the contract is the caller's: upgrade.sh asks for
+        the strict tick, whose exit 3 is a refused pull."""
+        sh = (ROOT / "skills" / "self-upgrade" / "scripts" / "upgrade.sh").read_text()
+        self.assertIn('sync-workspace.sh" --pull-strict', sh)
+        self.assertIn('if [ "$GATE_SYNC_RC" = "3" ]', sh)
+
+
+class Round7MaxAge(Fixture):
+    """keweichen round-5 P2: a bound that accepts infinity is not a bound."""
+
+    def test_the_python_boundary_rejects_infinity_nan_and_non_positive(self):
+        for bad in ("1e400", "inf", "-inf", "nan", "0", "-1", "abc", None):
+            with self.assertRaises(ValueError, msg=f"max age {bad!r} was accepted"):
+                wo.validate_max_age(bad)
+        self.assertEqual(wo.validate_max_age("3600"), 3600.0)
+
+    def test_blocking_refuses_an_infinite_bound_rather_than_disabling_expiry(self):
+        self.open12(host=HOST_A)
+        with self.assertRaises(ValueError):
+            wo.blocking(self.ws, self.repo, self.base, None, HOST_B, "o/r", float("inf"))
+
+    def test_the_cli_exits_2_on_an_unbounded_max_age_instead_of_passing(self):
+        r = subprocess.run([sys.executable, str(ROOT / "src" / "witness_owed.py"),
+                            "--workspace", str(self.ws), "check", "--ref", self.base,
+                            "--repo-root", str(self.repo), "--max-age", "1e400"],
+                           capture_output=True, text=True)
+        self.assertEqual(r.returncode, 2, r.stdout + r.stderr)
+        self.assertIn("finite", r.stderr)
+
+
+class Round7Declaration(unittest.TestCase):
+    """keweichen round-5 P2: the bound is declared in the skill manifest, per
+    CLAUDE.md, and the shell keeps no second copy of its rule."""
+
+    MANIFEST = ROOT / "skills" / "self-upgrade" / "manifest.json"
+    SRC = (ROOT / "skills/self-upgrade/scripts/upgrade.sh").read_text()
+
+    def test_the_manifest_declares_the_setting_with_a_default(self):
+        m = json.loads(self.MANIFEST.read_text())
+        self.assertTrue(m.get("enabled"), "a disabled manifest declares nothing")
+        self.assertEqual(m["config"]["SUTANDO_WITNESS_MAX_AGE"], "3600")
+
+    def test_the_updater_reads_env_then_manifest_and_owns_no_numeric_policy(self):
+        self.assertIn('GATE_MAX_AGE="${SUTANDO_WITNESS_MAX_AGE:-}"', self.SRC)
+        self.assertIn("skills/self-upgrade/manifest.json", self.SRC)
+        # The finite/positive rule lives in the helper that consumes the value.
+        self.assertIn("from witness_owed import validate_max_age", self.SRC)
+        self.assertNotIn("awk -v v=", self.SRC, "the shell kept its own copy of the bound's rule")
 
 
 if __name__ == "__main__":

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -343,7 +343,7 @@ class UpgradeWiring(unittest.TestCase):
         for token in ('[ -n "$GATE_WS" ] ||', '[ -n "$GATE_PY" ] ||',
                       '[ -f "$GATE_HELPER" ] ||', 'sutando-config.sh" python-bin',
                       '[ -n "$GATE_REPO" ] ||', '--repo "$GATE_REPO"', '--max-age "$GATE_MAX_AGE"',
-                      'sync-workspace.sh" ||', 'publish --host "$GATE_HOST"'):
+                      'sync-workspace.sh" --pull-strict', 'publish --host "$GATE_HOST"'):
             self.assertIn(token, self.SRC, token)
         self.assertNotIn('python3 "$REPO/src/witness_owed.py"', self.SRC, "bare python3 may hit the CLT stub")
         # A missing host label cannot release a record, so it must not stop
@@ -351,6 +351,15 @@ class UpgradeWiring(unittest.TestCase):
         canary = self.SRC.index('if [ -n "$CANARY" ]')
         self.assertLess(canary, self.SRC.index('[ -n "$GATE_HOST" ] ||'))
         self.assertIn('${GATE_HOST:+--host "$GATE_HOST"}', self.SRC)
+
+    def test_the_sync_the_gate_trusts_can_report_a_failed_pull(self):
+        """The default tick returns the PUSH's rc, so its zero cannot mean
+        "peer records arrived"; the gate must ask for the strict reading."""
+        sync = (ROOT / "scripts/sync-workspace.sh").read_text()
+        self.assertIn("--pull-strict|pull-strict)", sync, "sync-workspace owns the strict mode")
+        self.assertNotIn("_pull_only_impl || true", sync, "a call site discards the pull's rc")
+        self.assertIn('sync-workspace.sh" --pull-strict', self.SRC)
+        self.assertNotIn('sync-workspace.sh" ||', self.SRC, "the bare default tick is back")
 
 
 class Round5Blockers(Fixture):

--- a/tests/witness-owed.test.py
+++ b/tests/witness-owed.test.py
@@ -681,10 +681,9 @@ class Round7Publication(Fixture):
         return (f"cp -R {shlex.quote(str(self.ws / 'hosts'))} "
                 f"{shlex.quote(str(self._peer_ws()))}/")
 
-    def _cli(self, *args):
-        return subprocess.run([sys.executable, str(ROOT / "src" / "witness_owed.py"),
-                               "--workspace", str(self.ws), *args],
-                              capture_output=True, text=True)
+    # In-process, so the CLI branches under test are actually instrumented;
+    # `test_entry_point_runs_as_a_process` covers the process path separately.
+    _cli = Cli._run
 
     def test_a_published_hold_opened_on_one_host_blocks_the_gate_on_another(self):
         peer = self._peer_ws(); peer.mkdir(parents=True)
@@ -743,13 +742,16 @@ class Round7MaxAge(Fixture):
         with self.assertRaises(ValueError):
             wo.blocking(self.ws, self.repo, self.base, None, HOST_B, "o/r", float("inf"))
 
+    _run = Cli._run
+
     def test_the_cli_exits_2_on_an_unbounded_max_age_instead_of_passing(self):
-        r = subprocess.run([sys.executable, str(ROOT / "src" / "witness_owed.py"),
-                            "--workspace", str(self.ws), "check", "--ref", self.base,
-                            "--repo-root", str(self.repo), "--max-age", "1e400"],
-                           capture_output=True, text=True)
+        r = self._run("check", "--ref", self.base, "--repo-root", str(self.repo),
+                      "--max-age", "1e400")
         self.assertEqual(r.returncode, 2, r.stdout + r.stderr)
         self.assertIn("finite", r.stderr)
+        # And a legal bound still runs the gate rather than tripping the guard.
+        self.assertEqual(self._run("check", "--ref", self.base, "--repo-root",
+                                   str(self.repo), "--max-age", "3600").returncode, 0)
 
 
 class Round7Declaration(unittest.TestCase):


### PR DESCRIPTION
## What

REVIEW.md lesson 15's first-deploy gate becomes a **record the deployment path reads**, not a sentence in a PR thread.

- `src/witness_owed.py` — durable owed-witness record under the carried `hosts/<host>/witness-owed/` subtree (every host's directory is read); `open` (with `--publish-with`) / `list` / `check` / `canary` / `close` / `tombstone` / `publish`. Containment is squash-aware: head ancestry (merge), merge subject `(#N)` (squash), body naming the head (rebase). An unfetched head is not an error; a broken repo or unresolvable ref is, and blocks. Only the owing host can declare itself the canary.
- `scripts/sync-workspace.sh` — **new `--pull-strict` mode** (round 6): the same two legs as the default tick, but the PULL leg's failure is the run's failure (exit 3). Default push semantics are untouched for every existing caller.
- `skills/self-upgrade/scripts/upgrade.sh` — pins `$TARGET_SHA` after the fetch, runs `check` on that object **before** `git merge --ff-only "$TARGET_SHA"`, exits 4 when the target newly contains an owed PR, and **fails closed** when the workspace, host label, python (`sutando-config.sh python-bin`), helper, or the **fleet refresh** cannot be resolved. `--canary owner/repo#N` declares this host.
- `REVIEW.md` lesson 15 — eligibility narrowed to a pasted provisioning failure; the exception is usable only once the gate is live fleet-wide (bootstrap precondition); circular case = declared canary.
- `skills/self-upgrade/manifest.json` — config-only manifest declaring `SUTANDO_WITNESS_MAX_AGE`.
- Pointers in `CONTRIBUTING.md`, `AGENTS.md`, `CLAUDE.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `skills/self-upgrade/SKILL.md`; `docs/src-map.md` regenerated.

Eighteen files, +2011 / -25 at `75460d19a`. This is a live self-upgrade change, not docs only.

## Why

Four PRs by three agents deferred their live-path witness in prose on 2026-09-01; nothing downstream read the deferral, and "no supervised job loaded" was treated as structural when the installer could load one.

## Round 6 — rebase + the refresh-bypass blocker

**Rebased onto `origin/main` (`4b02fbaf0`)** after 5 days DIRTY. One conflict, in the generated `docs/src-map.md`: main added `worker_identity.py` on the line this branch added `witness_owed.py`. Resolved by keeping both in alphabetical order; `python3 scripts/gen-src-map.py --check` → `docs/src-map.md is up to date`.

**The ask** (@keweichen, round 5 P1; confirmed in source from both ends by @john-the-dev): `upgrade.sh` treated a zero from `bash scripts/sync-workspace.sh` as proof the fleet's witness-owed records were fresh, but the default tick runs `_pull_only_impl || true` by design and returns the **push's** rc. A pull refused by the mass-deletion tripwire exits 0, so the gate activated the very head an owed record was holding.

**The fix, where the policy lives.** `sync-workspace.sh` owns the legs, so the strict reading is a mode there, not a re-implementation in the caller:

```bash
cmd_default_bidirectional() { _bidirectional_tick default; }
cmd_pull_strict_bidirectional() { _bidirectional_tick strict; }
# ...one shared body...
_pull_only_impl || _pull_rc=$?      # was: _pull_only_impl || true
_push_only_impl || _rc=$?
if [ "$_mode" = "strict" ] && [ "$_pull_rc" != "0" ]; then ... return 3; fi
return "$_rc"                       # default: unchanged push semantics
```

A pull that never ran is not a fresh view either, so strict also returns 3 when cross-machine sync is disabled. `upgrade.sh` asks for `--pull-strict` and names which leg failed (pull → 3, anything else → push).

### Evidence — before/after on ONE fixture, real git, stubbed vault sync

`tests/self-upgrade-sync-strict-gate.test.sh` builds the control **from the shipped `upgrade.sh`** by substituting back the pre-fix call line, and asserts the control differs (a no-op substitution would test nothing). Both scripts then run against an identical fixture whose stub sync reproduces the real contract: refused pull → default exits 0, `--pull-strict` exits 3; a successful pull is what delivers the peer host's open record.

```text
  OK: control built: the pre-fix bare default-tick call, and it differs from HEAD's
-- scenario 1: the pull is refused (keweichen's repro) --
  OK: control: the stub's pull really was refused
  OK: CONTROL (pre-fix): rc=0 and HEAD ADVANCED past the owed #77 — the gate was bypassed
  OK: THE POINT (HEAD): rc=4 and HEAD UNMOVED on the identical fixture
  OK: the abort names the PULL leg, not 'vault sync failed'
-- scenario 2: a healthy sync still upgrades (no false alarm) --
  OK: healthy pull: the peer's hold arrived and the gate blocked on owner/repo#77
  OK: healthy pull reports no sync failure
  OK: healthy pull: HEAD unmoved while the record is open
-- scenario 3: the push leg fails; the pull succeeded --
  OK: a failed push still aborts, named as the push leg (exit 1, not 3)
-- the wiring itself --
  OK: upgrade.sh asks for --pull-strict
  OK: sync-workspace.sh owns the strict mode (no sync logic copied into upgrade.sh)
11 passed, 0 failed
```

`tests/sync-workspace-pull-strict.test.sh` pins the mode itself against the **production** tripwire (host A deletes 60 tracked files; host B's pull is refused), with the default's unchanged behaviour as its own control:

```text
  OK: fixture: the default tick's pull leg WAS refused
  OK: default mode is unchanged: refused pull, successful push, exit 0
  OK: fixture: the strict tick's pull leg WAS refused too
  OK: THE POINT: --pull-strict exits 3 on the same refusal the default reports as 0
  OK: --pull-strict names the failing leg on stderr
  OK: --pull-strict still PUSHED (the marker reached the vault): it is the full tick, not --pull-only
  OK: --pull-strict exits 3 when sync is disabled (no pull ran)
  OK: no call site discards the pull's rc with '|| true'
13 passed, 0 failed
```

### Suites at `872658d52` (round 6)

| suite | result |
|---|---|
| `tests/witness-owed.test.py` | `Ran 39 tests` `OK` (was 38; +1 pins the strict wiring at both ends) |
| `tests/self-upgrade.test.sh` | `PASS — self-upgrade behavioral suite (3/3)` |
| `tests/self-upgrade-sync-strict-gate.test.sh` | `11 passed, 0 failed` (new) |
| `tests/sync-workspace-pull-strict.test.sh` | `13 passed, 0 failed` (new) |
| 10 other `tests/sync-workspace-*.test.sh` | rc=0 each |
| `tests/sync-workspace.test.sh` | `Total: 89 — pass: 87, fail: 2` — **identical at `origin/main` (4b02fbaf0)**, pre-existing and CI-allowlisted |
| `scripts/review-checks.sh --diff <cumulative>` | `review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)` |
| `gen-src-map.py --check`, `git diff --check`, `bash -n`, `ruff check` | clean |

`tests/witness-owed.test.py`'s wiring test previously pinned the literal `sync-workspace.sh" ||`. That token WAS the bug, so it is replaced with an assertion on the behaviour the gate needs — that the sync it trusts can report a failed pull — plus a negative assertion that the bare default tick cannot come back.

## Round 7 — the five remaining blockers, each fixed where its policy lives

@keweichen's round-5 review listed six; round 6 cleared the refresh bypass. This round
clears the other five. Head is now `75460d19a` (`c3cffe761` + one test-only follow-up: the new CLI cases run in-process instead of via subprocess, so the diff-coverage gate can see them; every tail below is unchanged).

| # | keweichen's blocker | status at `c3cffe761` |
|---|---|---|
| 1 | **P1** an unpropagated hold; `open` does not publish/verify | **fixed** — `open --publish-with <cmd>`, contract stated in the module docstring |
| 2 | **P1** the checked ref is not the ref that is pulled | **fixed** — `$TARGET_SHA` pinned after the fetch; `git merge --ff-only "$TARGET_SHA"` |
| 3 | **P1** `close_record()`/`open_record()` are not serialized | **fixed** — `record_lock()` (flock) + compare-and-swap before the unlink |
| 4 | **P1** `validate_host()` rejects the legal label `My Mac` | **fixed** — one path segment, ends trimmed only |
| 5 | **P2** `SUTANDO_WITNESS_MAX_AGE` undeclared, `isfinite` unenforced | **fixed** — declared in `skills/self-upgrade/manifest.json`; `validate_max_age()` owns the rule |
| 6 | **P2** health-check recovery guidance bypasses the gate | **fixed** — all three prescriptions name the gate-aware updater |

### 1 — the publication contract (P1)

`src/witness_owed.py`'s docstring now **states** it rather than leaving it implied:

> A hold is PUBLISHED when this host's witness-owed subtree AND a stamp naming its exact
> bytes have been pushed to the vault. The stamp is a claim, never proof … The gate may
> trust a peer host's directory only when ALL of: (a) the deploying host's own PULL leg
> succeeded this run; (b) the peer's stamp names the host whose directory holds it; (c) the
> stamp's digest describes the bytes that actually arrived; (d) the stamp is younger than
> max-age and not from the future.

`open` takes `--publish-with <command>` and runs it **synchronously**; the transport is
injected, never named in the policy module. A failed push withdraws the stamp, so the host
stays visibly unpublished and its own gate refuses it, and the CLI exits 6. `open` without
`--publish-with` says so on stderr instead of returning a silent success. REVIEW.md lesson
15's recipe now carries the flag.

```text
test_a_published_hold_opened_on_one_host_blocks_the_gate_on_another ... ok
test_a_push_that_fails_withdraws_the_stamp_and_says_the_hold_is_local ... ok
test_open_without_publish_with_says_the_hold_is_not_in_force_fleet_wide ... ok
test_the_deploying_host_must_have_pulled_before_it_trusts_the_fleet ... ok
```

The first of those opens a hold on host A through the **CLI**, with `--publish-with` doing
the vault's copy into a separate peer workspace, then asserts host B's `blocking()` returns
`[('o/r', 12)]`. That is the "visible on another host" claim, end to end.

**Not fixed, deliberately:** a hold whose push never leaves the machine still cannot reach a
peer — no policy can publish bytes that were never sent. What changes is that this state is
now loud (exit 6) and self-limiting (the owing host cannot activate either).

### 2 — checked ref ≠ pulled ref (P1)

```bash
-BEHIND="$(git rev-list --count "HEAD..$REMOTE/$BRANCH" …)"
+TARGET_SHA="$(git rev-parse --verify -q "$REMOTE/$BRANCH^{commit}" || true)"
+BEHIND="$(git rev-list --count "HEAD..$TARGET_SHA" …)"
-… check --ref "$REMOTE/$BRANCH" …
+… check --ref "$TARGET_SHA" …
-git pull --ff-only "$REMOTE" "$BRANCH"
+git merge --ff-only "$TARGET_SHA"
```

`tests/self-upgrade-pull-strict`-style fixture, new file `tests/self-upgrade-pinned-target.test.sh`:
real git, real `upgrade.sh`, real `witness_owed.py`, a stub sync that advances the bare
remote from T1 to T2 mid-run. The control is built **from the shipped script** by
substituting the pre-fix check+pull pair back, and is asserted to differ.

```text
  OK: control built: the pre-fix 'check the mutable ref, then pull again' pair, and it differs
-- the fixture really does move the remote mid-run --
  OK: before the run, the remote-tracking ref is T1 (5c8fd644)
  OK: T1 is NOT owed — the gate is entitled to pass it
  OK: T2 IS owed — the production helper refuses it (exit 3)
-- the control activates the head the gate never checked --
  OK: CONTROL (pre-fix): rc=0 and HEAD is T2 (ac2f973b) — the owed head, never gated
-- THE POINT: HEAD fast-forwards to exactly the object it checked --
  OK: HEAD: rc=0 and HEAD is the PINNED T1 (6cf02f55) on the identical fixture
  OK: a stale local ref with a newer remote did NOT pass the owed T2 through
  OK: the run names the object it pinned
  OK: control on the control: the remote really is at T2 while HEAD stopped at T1
-- nothing is lost: the next pass gates T2 on its own --
  OK: second pass: rc=4 on owner/repo#77 and HEAD still T1
-- the wiring itself --
  OK: upgrade.sh no longer re-fetches between the gate and the activation
  OK: the gate checks the pinned SHA
12 passed, 0 failed
```

### 3 — serialized transitions (P1)

`record_lock(workspace, host, repo, pr)` — `fcntl.flock` on
`hosts/<host>/witness-owed/.locks/<key>.lock`, excluded from `records_digest()` so it cannot
move the publication stamp — wraps `open_record`, `mark_canary` and `close_record`. `close`
additionally **compare-and-swaps**: it re-reads the record and refuses to unlink bytes it did
not archive, so a writer that ignores the lock still cannot delete a reopened hold.

Three tests run @keweichen's exact ordering (pause `close()` the instant it archives, fire a
concurrent `open()`, resume) against the **production** writers:

```text
test_a_close_cannot_delete_a_concurrently_reopened_hold ... ok
test_without_the_lock_the_close_refuses_rather_than_deleting ... ok
test_the_lock_file_is_not_part_of_what_is_published ... ok
test_the_pre_fix_writer_reproduces_the_lost_hold ... ok
```

The last is the before/after on one fixture: the pre-fix module is built from the shipped
source by disabling exactly the two added mechanisms (`LOCK_EX`/`LOCK_UN` → `pass`, the CAS
→ `if False:`), asserted to differ, then raced — and it reproduces the loss (`list_open == []`,
archived head = A). `tombstone_record` is deliberately not locked: it is a single
`_atomic_write` of a new file in its own subtree, not a read-modify-write.

### 4 — the host-label contract (P1)

```python
-_HOST = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_HOST_ILLEGAL = re.compile(r"[/\\\x00-\x1f\x7f]")
```

`_host_label()` (`src/util_paths.py`) and `_host()` (`scripts/sync-workspace.sh`) both trim
the **ends only** — sync-workspace says so in words: "an (unusual but legal) label containing
a space is preserved rather than silently compacted". The validator now matches: one path
segment, non-empty, no leading/trailing space, and `/`, `\`, control characters, `.` and `..`
still refused. The resolved-containment check in `records_dir()` is unchanged.

```text
test_a_legal_label_with_a_space_is_accepted_end_to_end ... ok
test_a_host_that_is_not_one_segment_is_still_refused ... ok
test_the_shell_and_python_host_resolvers_agree_that_ends_are_trimmed ... ok
```

The first opens a record under `hosts/My Mac/witness-owed/`, then asserts `blocking(..., host="My Mac")`
returns that record instead of raising — the behaviour a `My Mac` host was denied.

### 5 — declaration + `isfinite`, and the guidance that bypassed the gate (P2)

New `skills/self-upgrade/manifest.json` (config-only, per `skills/MANIFEST.md`) declares
`SUTANDO_WITNESS_MAX_AGE: "3600"`. `upgrade.sh` reads **env > manifest > built-in** and no
longer carries its own numeric rule — the `case`/`awk` pair is gone, replaced by a call to
`validate_max_age()`, which is where the value is consumed:

```python
+def validate_max_age(value: object) -> float:
+    if not math.isfinite(f) or f <= 0:
+        raise ValueError(...)
```

`--max-age` also lost `type=float` in argparse, which was silently accepting `inf`.

```text
test_the_python_boundary_rejects_infinity_nan_and_non_positive ... ok   # 1e400, inf, -inf, nan, 0, -1, abc, None
test_blocking_refuses_an_infinite_bound_rather_than_disabling_expiry ... ok
test_the_cli_exits_2_on_an_unbounded_max_age_instead_of_passing ... ok
test_the_manifest_declares_the_setting_with_a_default ... ok
test_the_updater_reads_env_then_manifest_and_owns_no_numeric_policy ... ok
```

`src/health-check.py`'s three refresh prescriptions (far-behind, stale-`skills/`,
stale-running-`src/`) now name `bash <repo>/skills/self-upgrade/scripts/upgrade.sh` and no
longer print `pull --ff-only` as an instruction; the shallow-clone arm still prescribes
`fetch --unshallow` first. Pinned behaviourally in `tests/health-check-live-checkout-branch.test.py`
against real git fixtures for all three arms:

```text
  ok   aa) far-behind guidance names the gate-aware updater
  ok   aa) far-behind guidance must not prescribe a bare pull
  ok   aa) stale-skill guidance names the gate-aware updater
  ok   aa) stale-skill guidance must not prescribe a bare pull
  ok   aa) stale-service guidance names the gate-aware updater
  ok   aa) stale-service guidance must not prescribe a bare pull

live-checkout-branch probe invariants hold.
```

One incidental fix found by the new fixture: the max-age validation call wrote
`src/__pycache__/` into the live checkout, which made the **next** `upgrade.sh` abort as
dirty. `PYTHONDONTWRITEBYTECODE=1` on that one invocation.

### Suites at `75460d19a`

| suite | result |
|---|---|
| `tests/witness-owed.test.py` | `Ran 55 tests` `OK` (was 39; +16 for this round) |
| `tests/self-upgrade-pinned-target.test.sh` | `12 passed, 0 failed` (new) |
| `tests/self-upgrade-sync-strict-gate.test.sh` | `11 passed, 0 failed` |
| `tests/sync-workspace-pull-strict.test.sh` | `13 passed, 0 failed` |
| `tests/self-upgrade.test.sh` | `PASS — self-upgrade behavioral suite (3/3)` |
| `tests/health-check-live-checkout-branch.test.py` | `live-checkout-branch probe invariants hold.` |
| `tests/health-check-commits-behind-shallow.test.py` | `Ran 5 tests` `OK` |
| `tests/health-check-pin-covers-every-prescription.test.py` | `PASS: all three prescriptions consult the pin` |
| `scripts/review-checks.sh --diff <cumulative>` | `review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)` |
| `gen-src-map.py --check`, `git diff --check`, `bash -n`, `ruff check` | clean |

Added shell comment blocks hand-counted: every added block is ≤ 2 lines except the new test
file's 5-line `#!`-header, which matches its two sibling suites on this branch (6 and 3 lines).

## Live witness

**Still not supplied at `75460d19a`.** This PR changes `upgrade.sh`, a live path, so under the existing rule it needs an exact-head restarted-service round trip before approval, and it cannot use the exception it proposes because every host runs the pre-gate updater until it lands (keweichen, 22:19Z). The owner is deciding between landing the gate first under the existing rule, with its own round trip, and re-proposing the REVIEW.md exception separately. Until then: no witness, no record filed. Nothing in this round was run against the live workspace, vault, or services — the new suites use scratch git repos and a stubbed sync.

