### PR TITLE
feat(room-ops): doc_sync — put a shared record doc by row-keyed merge, never last-writer-wins

### DIFF
--- a/skills/agent-room-ops/doc_sync.py
+++ b/skills/agent-room-ops/doc_sync.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
-"""room-ops · doc_sync — get/put a shared Room Context doc without last-writer-wins.
+"""room-ops · doc_sync — get/put a shared Room Context doc with the last-writer-wins window
+narrowed to one round trip.
 
 A shared record doc (rows keyed `owner/repo#N | ...` under `## Section` headers) has
 many writers; a full-content `doc put` from a stale read silently erases every edit
 made since that read. `doc_sync` keeps a base copy per (folder, name) from the last
 `get`, and `put` applies the caller's ROW-LEVEL changes (add, edit, move, retire)
 onto the CURRENT remote, refusing only when the same row changed on both sides.
-Structure lines (headers, prose) are never merged: a change there refuses.
+Structure lines (headers, prose) are never merged: a change there refuses. Added and
+moved rows land at the top of their section, newest first.
+
+What this does NOT do: close the window. The transport put is an unconditional
+full-content write and the re-get verifies OUR bytes, which is what a clobber also
+looks like — so a writer landing between the pre-put read and the put is still lost,
+undetectably. That window is one round trip instead of "since your last get"; closing
+it needs a conditional write at the doc layer, not anything in this module.
 
 Every row the caller adds or edits is stamped `(w:<writer>)` from SUTANDO_CORE_ID
 (or --writer); an unset id stamps `unknown`, never a shape-valid empty slot.
@@ -32,8 +40,8 @@ from typing import Dict, List, NamedTuple, Optional, Tuple
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
-# A record is any line whose first token is a `owner/repo#N` key, whatever separator follows:
-# active rows use ` | `, the History convention retires a row as `key — MERGED <date> … was: …`.
+# A record is any line whose first token is a `owner/repo#N` key, whatever follows (` | ` rows, the
+# `key — MERGED <date> …` retirement, even prose) — fail-closed: a stray key then counts in `duplicates`.
 RECORD_RE = re.compile(r"^([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+#\d+)(?=\s|$)")
 SECTION_RE = re.compile(r"^## (.+?)\s*$")
 STAMP_RE = re.compile(r"\s*\(w:[^)]*\)\s*$")
@@ -76,6 +84,7 @@ def _stamp_of(line: str) -> str:
 
 
 def _insert_into_section(lines: List[str], section: str, text: str) -> bool:
+    """Insert right after the section header: adds and moves land at the top, newest first."""
     for i, line in enumerate(lines):
         m = SECTION_RE.match(line)
         if m and m.group(1) == section:
@@ -95,6 +104,7 @@ def duplicates(text: str) -> Dict[str, int]:
 
 
 def _significant(structure: List[str]) -> List[str]:
+    # Blank lines are not structure: whitespace-only reformatting must not refuse.
     return [l.rstrip() for l in structure if l.strip()]
 
 
@@ -115,6 +125,7 @@ def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str
     applied, conflicts, absorbed = [], [], []
 
     def find(key: str) -> int:
+        # A rescan per key makes merge O(rows²); fine at Room Context size (dozens of rows).
         for i, line in enumerate(lines):
             k = RECORD_RE.match(line)
             if k and k.group(1) == key:
@@ -193,6 +204,7 @@ def run_put(room: str, folder: str, name: str, content: str) -> dict:
 
 def fetch(room: str, folder: str, name: str, sleep=time.sleep) -> Tuple[int, dict]:
     # A transient failure has been observed to render as "not found"; one retry tells them apart.
+    # The substring test is a heuristic on a human-readable reason; it fails toward retry-then-3.
     res = run_get(room, folder, name)
     if not res.get("ok") and "not found" in str(res.get("reason") or ""):
         sleep(RETRY_AFTER_S)

--- a/skills/agent-room-ops/doc_sync.py
+++ b/skills/agent-room-ops/doc_sync.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""room-ops · doc_sync — get/put a shared Room Context doc without last-writer-wins.
+
+A shared record doc (rows keyed `owner/repo#N | ...` under `## Section` headers) has
+many writers; a full-content `doc put` from a stale read silently erases every edit
+made since that read. `doc_sync` keeps a base copy per (folder, name) from the last
+`get`, and `put` applies the caller's ROW-LEVEL changes (add, edit, move, retire)
+onto the CURRENT remote, refusing only when the same row changed on both sides.
+Structure lines (headers, prose) are never merged: a change there refuses.
+
+Every row the caller adds or edits is stamped `(w:<writer>)` from SUTANDO_CORE_ID
+(or --writer); an unset id stamps `unknown`, never a shape-valid empty slot.
+
+    doc_sync.py get --room R --name N [--folder F] [--workspace W]
+    doc_sync.py put --room R --name N --file EDITED [--folder F] [--workspace W] [--writer ID]
+
+Room/name come from flags or ROOM_DOC_ROOM / ROOM_DOC_NAME / ROOM_DOC_FOLDER; a missing
+required value fails naming it (exit 2). Exit: 0 ok · 1 transport · 2 config · 3 not found
+after one retry · 4 refused (no base, conflict, structure change) · 5 put not verified.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional, Tuple
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+RECORD_RE = re.compile(r"^([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+#\d+)\s*\|")
+SECTION_RE = re.compile(r"^## (.+?)\s*$")
+STAMP_RE = re.compile(r"\s*\(w:[^)]*\)\s*$")
+RETRY_AFTER_S = 3.0
+
+
+class Record(NamedTuple):
+    section: str
+    text: str
+
+
+def parse(text: str) -> Tuple[List[str], Dict[str, Record]]:
+    """Structure lines (everything that is not a record) and records keyed by their id."""
+    structure, records, section = [], {}, ""
+    for line in text.split("\n"):
+        m = SECTION_RE.match(line)
+        if m:
+            section = m.group(1)
+        k = RECORD_RE.match(line)
+        if k:
+            records.setdefault(k.group(1), Record(section, line))
+        else:
+            structure.append(line)
+    return structure, records
+
+
+def writer_id(explicit: Optional[str] = None, env=None) -> str:
+    env = os.environ if env is None else env
+    w = (explicit or env.get("SUTANDO_CORE_ID") or "").strip()
+    return w or "unknown"
+
+
+def stamp(line: str, writer: str) -> str:
+    return f"{STAMP_RE.sub('', line).rstrip()} (w:{writer})"
+
+
+def _stamp_of(line: str) -> str:
+    m = re.search(r"\(w:([^)]*)\)\s*$", line)
+    return m.group(1) if m else "unstamped"
+
+
+def _insert_into_section(lines: List[str], section: str, text: str) -> bool:
+    for i, line in enumerate(lines):
+        m = SECTION_RE.match(line)
+        if m and m.group(1) == section:
+            lines.insert(i + 1, text)
+            return True
+    return False
+
+
+def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str], List[str]]:
+    """Apply my row deltas (base->mine) onto remote. Returns (text, applied, conflicts);
+    a non-empty conflicts list means nothing should be written."""
+    sb, rb = parse(base)
+    sm, rm = parse(mine)
+    if sb != sm:
+        return remote, [], ["structure lines changed (headers/prose); edit records only"]
+    _, rr = parse(remote)
+    lines = remote.split("\n")
+    applied, conflicts = [], []
+
+    def find(key: str) -> int:
+        for i, line in enumerate(lines):
+            k = RECORD_RE.match(line)
+            if k and k.group(1) == key:
+                return i
+        return -1
+
+    for key in sorted(set(rb) | set(rm)):
+        b, m, r = rb.get(key), rm.get(key), rr.get(key)
+        if b == m:
+            continue
+        if m is None:                                   # I retired the row
+            if r is None:
+                continue
+            if r != b:
+                conflicts.append(f"{key}: retired by me, changed remotely (w:{_stamp_of(r.text)})")
+                continue
+            del lines[find(key)]
+            applied.append(f"retire {key}")
+            continue
+        new = Record(m.section, stamp(m.text, writer))
+        if b is None:                                   # I added the row
+            if r is not None:
+                if r.text == m.text or r.text == new.text:
+                    continue
+                conflicts.append(f"{key}: added by me, already present remotely (w:{_stamp_of(r.text)})")
+                continue
+            if not _insert_into_section(lines, new.section, new.text):
+                conflicts.append(f"{key}: section '## {new.section}' not found remotely")
+                continue
+            applied.append(f"add {key} -> {new.section}")
+            continue
+        if r is None:
+            conflicts.append(f"{key}: edited by me, removed remotely")
+            continue
+        if r.text == m.text or r.text == new.text:
+            continue
+        if r != b:
+            conflicts.append(f"{key}: edited by me AND remotely (w:{_stamp_of(r.text)})")
+            continue
+        i = find(key)
+        if r.section == new.section:
+            lines[i] = new.text
+            applied.append(f"edit {key}")
+        else:
+            del lines[i]
+            if not _insert_into_section(lines, new.section, new.text):
+                conflicts.append(f"{key}: section '## {new.section}' not found remotely")
+                continue
+            applied.append(f"move {key} {r.section} -> {new.section}")
+    return "\n".join(lines), applied, conflicts
+
+
+# -- transport seams (tests replace these) ---------------------------------------------
+
+def run_get(room: str, folder: str, name: str) -> dict:
+    import doc  # noqa: WPS433 - sibling module, same skill dir
+    return doc.doc_get(room, folder=folder, name=name)
+
+
+def run_put(room: str, folder: str, name: str, content: str) -> dict:
+    import doc  # noqa: WPS433
+    return doc.doc_put(room, content, folder=folder, name=name)
+
+
+def fetch(room: str, folder: str, name: str, sleep=time.sleep) -> Tuple[int, dict]:
+    # A transient failure has been observed to render as "not found"; one retry tells them apart.
+    res = run_get(room, folder, name)
+    if not res.get("ok") and "not found" in str(res.get("reason") or ""):
+        sleep(RETRY_AFTER_S)
+        res = run_get(room, folder, name)
+        if not res.get("ok") and "not found" in str(res.get("reason") or ""):
+            return 3, res
+    if not res.get("ok"):
+        return 1, res
+    if not isinstance(res.get("content"), str):
+        return 1, {"ok": False, "reason": "ok=true but no content string"}
+    return 0, res
+
+
+def base_path(workspace: Path, folder: str, name: str) -> Path:
+    return Path(workspace) / "state" / "room-doc-sync" / f"{folder}__{name}.base"
+
+
+def cmd_get(room: str, folder: str, name: str, workspace: Path) -> int:
+    rc, res = fetch(room, folder, name)
+    if rc:
+        print(f"get FAILED rc={rc}: {res.get('reason')}", file=sys.stderr)
+        return rc
+    p = base_path(workspace, folder, name)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(res["content"])
+    print(f"ok  {folder}/{name}  {len(res['content'])} chars  base -> {p}")
+    return 0
+
+
+def cmd_put(room: str, folder: str, name: str, workspace: Path, edited: Path, writer: str) -> int:
+    p = base_path(workspace, folder, name)
+    if not p.exists():
+        print("put REFUSED (4): no base copy for this doc — run `get`, edit that, then put", file=sys.stderr)
+        return 4
+    rc, res = fetch(room, folder, name)
+    if rc:
+        print(f"put REFUSED: pre-put read failed rc={rc}: {res.get('reason')}", file=sys.stderr)
+        return rc
+    merged, applied, conflicts = merge(p.read_text(), edited.read_text(), res["content"], writer)
+    if conflicts:
+        print("put REFUSED (4): " + "; ".join(conflicts) + " — re-run `get`, re-apply, put", file=sys.stderr)
+        return 4
+    if merged == res["content"]:
+        print("put: no row changes to apply; nothing written")
+        p.write_text(merged)
+        return 0
+    put = run_put(room, folder, name, merged)
+    if not put.get("ok"):
+        print(f"put FAILED: {put.get('reason')}", file=sys.stderr)
+        return 1
+    rc, back = fetch(room, folder, name)
+    if rc or back["content"] != merged:
+        print("put NOT VERIFIED (5): re-get " + (f"failed: {back.get('reason')}" if rc else "differs from what was put"),
+              file=sys.stderr)
+        return 5
+    p.write_text(merged)
+    print(f"ok  put + verified  applied: {', '.join(applied)}  (w:{writer})")
+    return 0
+
+
+def _required(value: Optional[str], flag: str, env_key: str) -> str:
+    if value:
+        return value
+    print(f"config error (2): {flag} not given and {env_key} unset", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("action", choices=["get", "put"])
+    ap.add_argument("--room", default=os.environ.get("ROOM_DOC_ROOM"))
+    ap.add_argument("--folder", default=os.environ.get("ROOM_DOC_FOLDER") or "room-live-context")
+    ap.add_argument("--name", default=os.environ.get("ROOM_DOC_NAME"))
+    ap.add_argument("--file", help="put: the edited document")
+    ap.add_argument("--workspace", help="workspace root (default: the repo's resolver)")
+    ap.add_argument("--writer", help="row stamp (default: SUTANDO_CORE_ID, else 'unknown')")
+    a = ap.parse_args(argv)
+    room = _required(a.room, "--room", "ROOM_DOC_ROOM")
+    name = _required(a.name, "--name", "ROOM_DOC_NAME")
+    if a.workspace:
+        ws = Path(a.workspace)
+    else:
+        sys.path.insert(0, str(HERE.parent.parent / "src"))
+        from workspace_default import resolve_workspace  # noqa: WPS433
+        ws = Path(resolve_workspace())
+    if a.action == "get":
+        return cmd_get(room, a.folder, name, ws)
+    if not a.file:
+        ap.error("put needs --file")
+    return cmd_put(room, a.folder, name, ws, Path(a.file), writer_id(a.writer))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/agent-room-ops/doc_sync.py
+++ b/skills/agent-room-ops/doc_sync.py
@@ -81,6 +81,16 @@ def _insert_into_section(lines: List[str], section: str, text: str) -> bool:
     return False
 
 
+def duplicates(text: str) -> Dict[str, int]:
+    """Keys that occur more than once (a row present in two sections has no single identity)."""
+    counts: Dict[str, int] = {}
+    for line in text.split("\n"):
+        k = RECORD_RE.match(line)
+        if k:
+            counts[k.group(1)] = counts.get(k.group(1), 0) + 1
+    return {k: n for k, n in counts.items() if n > 1}
+
+
 def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str], List[str]]:
     """Apply my row deltas (base->mine) onto remote. Returns (text, applied, conflicts);
     a non-empty conflicts list means nothing should be written."""
@@ -89,6 +99,7 @@ def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str
     if sb != sm:
         return remote, [], ["structure lines changed (headers/prose); edit records only"]
     _, rr = parse(remote)
+    dup = duplicates(remote)
     lines = remote.split("\n")
     applied, conflicts = [], []
 
@@ -102,6 +113,9 @@ def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str
     for key in sorted(set(rb) | set(rm)):
         b, m, r = rb.get(key), rm.get(key), rr.get(key)
         if b == m:
+            continue
+        if key in dup:
+            conflicts.append(f"{key}: appears {dup[key]} times remotely; resolve the duplicate by hand first")
             continue
         if m is None:                                   # I retired the row
             if r is None:

--- a/skills/agent-room-ops/doc_sync.py
+++ b/skills/agent-room-ops/doc_sync.py
@@ -92,17 +92,25 @@ def duplicates(text: str) -> Dict[str, int]:
     return {k: n for k, n in counts.items() if n > 1}
 
 
+def _significant(structure: List[str]) -> List[str]:
+    return [l.rstrip() for l in structure if l.strip()]
+
+
 def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str], List[str]]:
-    """Apply my row deltas (base->mine) onto remote. Returns (text, applied, conflicts);
-    a non-empty conflicts list means nothing should be written."""
+    """Apply my row deltas (base->mine) onto remote. Returns (text, applied, conflicts); on any
+    conflict the text is the remote unchanged and applied is empty. Every delta is accounted for
+    as applied, already present remotely, or a conflict; an unaccounted delta is a conflict."""
     sb, rb = parse(base)
     sm, rm = parse(mine)
-    if sb != sm:
+    if _significant(sb) != _significant(sm):
         return remote, [], ["structure lines changed (headers/prose); edit records only"]
+    mine_dup = duplicates(mine)
+    if mine_dup:
+        return remote, [], [f"{k}: appears {n} times in YOUR file (copy instead of move?)" for k, n in sorted(mine_dup.items())]
     _, rr = parse(remote)
     dup = duplicates(remote)
     lines = remote.split("\n")
-    applied, conflicts = [], []
+    applied, conflicts, absorbed = [], [], []
 
     def find(key: str) -> int:
         for i, line in enumerate(lines):
@@ -120,6 +128,7 @@ def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str
             continue
         if m is None:                                   # I retired the row
             if r is None:
+                absorbed.append(key)
                 continue
             if r != b:
                 conflicts.append(f"{key}: retired by me, changed remotely (w:{_stamp_of(r.text)})")
@@ -130,7 +139,8 @@ def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str
         new = Record(m.section, stamp(m.text, writer))
         if b is None:                                   # I added the row
             if r is not None:
-                if r.text == m.text or r.text == new.text:
+                if r == m or r == new:
+                    absorbed.append(key)
                     continue
                 conflicts.append(f"{key}: added by me, already present remotely (w:{_stamp_of(r.text)})")
                 continue
@@ -142,7 +152,8 @@ def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str
         if r is None:
             conflicts.append(f"{key}: edited by me, removed remotely")
             continue
-        if r.text == m.text or r.text == new.text:
+        if r == m or r == new:
+            absorbed.append(key)
             continue
         if r != b:
             conflicts.append(f"{key}: edited by me AND remotely (w:{_stamp_of(r.text)})")
@@ -152,12 +163,18 @@ def merge(base: str, mine: str, remote: str, writer: str) -> Tuple[str, List[str
             lines[i] = new.text
             applied.append(f"edit {key}")
         else:
-            del lines[i]
-            if not _insert_into_section(lines, new.section, new.text):
+            if not any(SECTION_RE.match(l) and SECTION_RE.match(l).group(1) == new.section for l in lines):
                 conflicts.append(f"{key}: section '## {new.section}' not found remotely")
                 continue
+            del lines[i]
+            _insert_into_section(lines, new.section, new.text)
             applied.append(f"move {key} {r.section} -> {new.section}")
-    return "\n".join(lines), applied, conflicts
+    deltas = [k for k in set(rb) | set(rm) if rb.get(k) != rm.get(k)]
+    unaccounted = sorted(set(deltas) - set(absorbed) - {a.split(" ")[1] for a in applied} - {c.split(":")[0] for c in conflicts})
+    conflicts += [f"{k}: changed by me but not applied, not present remotely, not a conflict — refusing" for k in unaccounted]
+    if conflicts:
+        return remote, [], conflicts
+    return "\n".join(lines), applied + [f"already-present {k}" for k in absorbed], []
 
 
 # -- transport seams (tests replace these) ---------------------------------------------
@@ -243,7 +260,10 @@ def cmd_put(room: str, folder: str, name: str, workspace: Path, edited: Path, wr
         print("put REFUSED (4): " + "; ".join(conflicts) + " — re-run `get`, re-apply, put", file=sys.stderr)
         return 4
     if merged == res["content"]:
-        print("put: no row changes to apply; nothing written")
+        if edited.read_text() == p.read_text():
+            print("put: no row changes to apply; nothing written")
+        else:
+            print("put: every change is already present remotely; nothing written — " + ", ".join(applied))
         p.write_text(merged)
         return 0
     put = run_put(room, folder, name, merged)

--- a/skills/agent-room-ops/doc_sync.py
+++ b/skills/agent-room-ops/doc_sync.py
@@ -32,7 +32,9 @@ from typing import Dict, List, NamedTuple, Optional, Tuple
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
-RECORD_RE = re.compile(r"^([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+#\d+)\s*\|")
+# A record is any line whose first token is a `owner/repo#N` key, whatever separator follows:
+# active rows use ` | `, the History convention retires a row as `key — MERGED <date> … was: …`.
+RECORD_RE = re.compile(r"^([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+#\d+)(?=\s|$)")
 SECTION_RE = re.compile(r"^## (.+?)\s*$")
 STAMP_RE = re.compile(r"\s*\(w:[^)]*\)\s*$")
 RETRY_AFTER_S = 3.0

--- a/skills/agent-room-ops/doc_sync.py
+++ b/skills/agent-room-ops/doc_sync.py
@@ -13,6 +13,7 @@ Every row the caller adds or edits is stamped `(w:<writer>)` from SUTANDO_CORE_I
 
     doc_sync.py get --room R --name N [--folder F] [--workspace W]
     doc_sync.py put --room R --name N --file EDITED [--folder F] [--workspace W] [--writer ID]
+    doc_sync.py duplicates --room R --name N [--folder F]      # keys present more than once
 
 Room/name come from flags or ROOM_DOC_ROOM / ROOM_DOC_NAME / ROOM_DOC_FOLDER; a missing
 required value fails naming it (exit 2). Exit: 0 ok · 1 transport · 2 config · 3 not found
@@ -190,6 +191,32 @@ def base_path(workspace: Path, folder: str, name: str) -> Path:
     return Path(workspace) / "state" / "room-doc-sync" / f"{folder}__{name}.base"
 
 
+def duplicate_report(text: str) -> List[str]:
+    """One line per duplicated key: sections and line numbers, for whoever resolves it."""
+    where: Dict[str, List[str]] = {}
+    section = ""
+    for n, line in enumerate(text.split("\n"), 1):
+        m = SECTION_RE.match(line)
+        if m:
+            section = m.group(1)
+        k = RECORD_RE.match(line)
+        if k:
+            where.setdefault(k.group(1), []).append(f"L{n} {section or '(none)'}")
+    return [f"{k}: {', '.join(v)}" for k, v in sorted(where.items()) if len(v) > 1]
+
+
+def cmd_duplicates(room: str, folder: str, name: str) -> int:
+    rc, res = fetch(room, folder, name)
+    if rc:
+        print(f"duplicates FAILED rc={rc}: {res.get('reason')}", file=sys.stderr)
+        return rc
+    rows = duplicate_report(res["content"])
+    print(f"{len(rows)} duplicated key(s) in {folder}/{name}")
+    for r in rows:
+        print("  " + r)
+    return 0
+
+
 def cmd_get(room: str, folder: str, name: str, workspace: Path) -> int:
     rc, res = fetch(room, folder, name)
     if rc:
@@ -242,7 +269,7 @@ def _required(value: Optional[str], flag: str, env_key: str) -> str:
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("action", choices=["get", "put"])
+    ap.add_argument("action", choices=["get", "put", "duplicates"])
     ap.add_argument("--room", default=os.environ.get("ROOM_DOC_ROOM"))
     ap.add_argument("--folder", default=os.environ.get("ROOM_DOC_FOLDER") or "room-live-context")
     ap.add_argument("--name", default=os.environ.get("ROOM_DOC_NAME"))
@@ -258,6 +285,8 @@ def main(argv=None) -> int:
         sys.path.insert(0, str(HERE.parent.parent / "src"))
         from workspace_default import resolve_workspace  # noqa: WPS433
         ws = Path(resolve_workspace())
+    if a.action == "duplicates":
+        return cmd_duplicates(room, a.folder, name)
     if a.action == "get":
         return cmd_get(room, a.folder, name, ws)
     if not a.file:

--- a/tests/room-doc-sync.test.py
+++ b/tests/room-doc-sync.test.py
@@ -90,6 +90,11 @@ class MergeTests(unittest.TestCase):
         self.assertEqual(applied, []); self.assertIn("org/repo#2", conflicts[0]); self.assertIn("2 times", conflicts[0])
         self.assertEqual(merged, remote)
 
+    def test_duplicate_report_names_sections_and_lines(self):
+        remote = BASE.replace("## History\n", "## History\norg/repo#2 | shepherd: a | status: merged | two\n")
+        self.assertEqual(ds.duplicate_report(BASE), [])
+        self.assertEqual(ds.duplicate_report(remote), ["org/repo#2: L5 Active, L7 History"])
+
     def test_structure_change_refuses(self):
         mine = BASE.replace("prose line", "prose line EDITED")
         merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")

--- a/tests/room-doc-sync.test.py
+++ b/tests/room-doc-sync.test.py
@@ -152,6 +152,34 @@ class MergeTests(unittest.TestCase):
         merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")
         self.assertEqual(applied, []); self.assertIn("structure", conflicts[0]); self.assertEqual(merged, BASE)
 
+    def test_retire_already_gone_remotely_is_absorbed_and_edit_of_a_removed_row_conflicts(self):
+        gone = "\n".join(l for l in BASE.split("\n") if not l.startswith("org/repo#9 "))
+        merged, applied, conflicts = ds.merge(BASE, gone, gone, "me")  # I retired #9; remote already did
+        self.assertEqual((applied, conflicts, merged), (["already-present org/repo#9"], [], gone))
+        mine = edit(BASE, "org/repo#1", "org/repo#1 | mine")
+        removed = "\n".join(l for l in BASE.split("\n") if not l.startswith("org/repo#1 "))
+        merged, applied, conflicts = ds.merge(BASE, mine, removed, "me")
+        self.assertEqual(applied, []); self.assertEqual(merged, removed)
+        self.assertEqual(conflicts, ["org/repo#1: edited by me, removed remotely"])
+
+    def test_move_into_a_section_the_remote_lacks_conflicts(self):
+        base = BASE + "\n## Parked"                      # base and mine share the header: no structure change
+        mine = "\n".join(l for l in base.split("\n") if not l.startswith("org/repo#9 ")) + "\norg/repo#9 | shepherd: a | status: merged | nine"
+        merged, applied, conflicts = ds.merge(base, mine, BASE, "me")  # remote never had ## Parked
+        self.assertEqual(applied, []); self.assertEqual(merged, BASE)
+        self.assertEqual(conflicts, ["org/repo#9: section '## Parked' not found remotely"])
+
+    def test_add_already_present_remotely_is_absorbed_and_add_into_a_missing_section_conflicts(self):
+        row = "org/repo#3 | shepherd: a | status: active | three"
+        mine = BASE.replace("## Active\n", "## Active\n" + row + "\n")
+        merged, applied, conflicts = ds.merge(BASE, mine, mine, "me")   # remote already carries my add
+        self.assertEqual((applied, conflicts, merged), (["already-present org/repo#3"], [], mine))
+        base = BASE + "\n## Parked"
+        mine = base + "\norg/repo#4 | parked by me"
+        merged, applied, conflicts = ds.merge(base, mine, BASE, "me")     # remote never had ## Parked
+        self.assertEqual((applied, merged), ([], BASE))
+        self.assertEqual(conflicts, ["org/repo#4: section '## Parked' not found remotely"])
+
     def test_writer_stamp_is_honest_when_unset_and_replaces_an_old_stamp(self):
         self.assertEqual(ds.writer_id(None, env={}), "unknown")
         self.assertEqual(ds.writer_id(None, env={"SUTANDO_CORE_ID": "3"}), "3")
@@ -162,12 +190,15 @@ class MergeTests(unittest.TestCase):
 class FakeOps:
     def __init__(self, gets, puts=None):
         self.gets, self.puts, self.calls = list(gets), list(puts or []), []
+        self.unqueued = 0
 
     def get(self, room, folder, name):
         self.calls.append(("get", folder, name)); return self.gets.pop(0)
 
     def put(self, room, folder, name, content):
-        self.calls.append(("put", folder, name, content)); return self.puts.pop(0)
+        self.calls.append(("put", folder, name, content))
+        if self.puts: return self.puts.pop(0)
+        self.unqueued += 1; return {"ok": True}
 
 
 def ok(content): return {"ok": True, "content": content}
@@ -183,7 +214,11 @@ class PutFlowTests(unittest.TestCase):
         self.tmp.cleanup()
 
     def _wire(self, fake):
+        real_get, real_put = ds.run_get, ds.run_put
         ds.run_get, ds.run_put = fake.get, fake.put
+        self.addCleanup(lambda: setattr(ds, "run_get", real_get) or setattr(ds, "run_put", real_put))
+        self.addCleanup(lambda: self.assertEqual(
+            fake.unqueued, 0, "a put ran with no queued response — mis-wired test"))
 
     def test_get_writes_base_and_retries_a_false_not_found_once(self):
         fake = FakeOps([NOT_FOUND, ok(BASE)]); self._wire(fake)
@@ -219,6 +254,34 @@ class PutFlowTests(unittest.TestCase):
             self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 4)
         self.assertFalse(any(c[0] == "put" for c in fake.calls))
 
+    def test_a_writer_landing_between_the_pre_put_read_and_the_put_is_lost_undetectably(self):
+        # The known-lost case: the window is one round trip, not zero. B edits a DIFFERENT row after
+        # our pre-put read; the unconditional put overwrites it and the re-get verifies our bytes.
+        ds.base_path(self.ws, "ops", "X.md").parent.mkdir(parents=True)
+        ds.base_path(self.ws, "ops", "X.md").write_text(BASE)
+        f = self.ws / "e.md"; f.write_text(edit(BASE, "org/repo#1", "org/repo#1 | mine"))
+        b_row = "org/repo#2 | theirs, IMPORTANT EDIT (w:b)"
+        state = {"remote": BASE, "puts": 0, "b_landed": False}
+
+        def get(room, folder, name):
+            content = state["remote"]
+            if not state["b_landed"]:  # B lands exactly once, right after our pre-put read
+                state["remote"] = edit(state["remote"], "org/repo#2", b_row); state["b_landed"] = True
+            return ok(content)
+
+        def put(room, folder, name, content):
+            state["puts"] += 1; state["remote"] = content; return {"ok": True}
+
+        real_get, real_put = ds.run_get, ds.run_put
+        ds.run_get, ds.run_put = get, put
+        self.addCleanup(lambda: setattr(ds, "run_get", real_get) or setattr(ds, "run_put", real_put))
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 0)  # reports success
+        self.assertEqual(state["puts"], 1)
+        self.assertIn("org/repo#1 | mine (w:me)", state["remote"])
+        self.assertNotIn("IMPORTANT EDIT", state["remote"])  # B's row is gone, and nothing said so
+        # Fails only once a conditional write closes the window: then fix the docstring, then this.
+
     def test_unverified_reget_is_5_and_base_untouched(self):
         ds.base_path(self.ws, "ops", "X.md").parent.mkdir(parents=True)
         ds.base_path(self.ws, "ops", "X.md").write_text(BASE)
@@ -247,6 +310,60 @@ class PutFlowTests(unittest.TestCase):
         self.assertIn("already present remotely", out.getvalue()); self.assertIn("org/repo#1", out.getvalue())
         self.assertFalse(any(c[0] == "put" for c in fake.calls))  # nothing written
         self.assertEqual(ds.base_path(self.ws, "ops", "X.md").read_text(), mine)  # base advanced to the remote
+
+    def test_transport_seams_pass_room_folder_name_through_to_doc(self):
+        import types
+        calls = []
+        fake_doc = types.SimpleNamespace(
+            doc_get=lambda room, folder, name: calls.append(("get", room, folder, name)) or {"ok": True, "content": "x"},
+            doc_put=lambda room, content, folder, name: calls.append(("put", room, folder, name, content)) or {"ok": True})
+        saved = sys.modules.get("doc"); sys.modules["doc"] = fake_doc
+        try:
+            self.assertEqual(ds.run_get("!r", "ops", "X.md")["content"], "x")
+            self.assertTrue(ds.run_put("!r", "ops", "X.md", "body")["ok"])
+        finally:
+            if saved is None: del sys.modules["doc"]
+            else: sys.modules["doc"] = saved
+        self.assertEqual(calls, [("get", "!r", "ops", "X.md"), ("put", "!r", "ops", "X.md", "body")])
+
+    def test_not_found_twice_is_3_and_a_plain_failure_is_1(self):
+        fake = FakeOps([NOT_FOUND, NOT_FOUND]); self._wire(fake)
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(ds.cmd_get("!r", "ops", "X.md", self.ws), 3)
+        self.assertEqual(len(fake.calls), 2)
+        fake = FakeOps([{"ok": False, "reason": "gateway 502"}]); self._wire(fake)
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(ds.cmd_duplicates("!r", "ops", "X.md"), 1)
+
+    def test_duplicates_command_reports_count_and_main_dispatches_with_and_without_workspace(self):
+        twice = BASE + "\norg/repo#1 | copied into History"
+        fake = FakeOps([ok(twice), ok(BASE), ok(BASE)]); self._wire(fake)
+        out = io.StringIO()
+        with redirect_stdout(out):
+            self.assertEqual(ds.main(["duplicates", "--room", "!r", "--folder", "ops", "--name", "X.md"]), 0)
+            self.assertEqual(ds.main(["get", "--room", "!r", "--folder", "ops", "--name", "X.md", "--workspace", str(self.ws)]), 0)
+        self.assertIn("1 duplicated key(s) in ops/X.md", out.getvalue())
+        self.assertIn("org/repo#1:", out.getvalue())
+        self.assertEqual(ds.base_path(self.ws, "ops", "X.md").read_text(), BASE)
+        with self.assertRaises(SystemExit) as cm, redirect_stderr(io.StringIO()):
+            ds._required(None, "--name", "ROOM_DOC_NAME")
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_transport_failures_are_1_at_each_step_ok_without_content_pre_put_read_and_put(self):
+        fake = FakeOps([{"ok": True}]); self._wire(fake)                       # ok=true, no content string
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(ds.cmd_get("!r", "ops", "X.md", self.ws), 1)
+        ds.base_path(self.ws, "ops", "X.md").parent.mkdir(parents=True)
+        ds.base_path(self.ws, "ops", "X.md").write_text(BASE)
+        f = self.ws / "e.md"; f.write_text(edit(BASE, "org/repo#1", "org/repo#1 | mine"))
+        fake = FakeOps([{"ok": False, "reason": "gateway 502"}]); self._wire(fake)   # pre-put read fails
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 1)
+        self.assertFalse(any(c[0] == "put" for c in fake.calls))
+        fake = FakeOps([ok(BASE)], puts=[{"ok": False, "reason": "denied"}]); self._wire(fake)  # put refused
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 1)
+        self.assertEqual(ds.base_path(self.ws, "ops", "X.md").read_text(), BASE)   # base untouched
 
     def test_missing_room_fails_naming_the_key(self):
         err = io.StringIO()

--- a/tests/room-doc-sync.test.py
+++ b/tests/room-doc-sync.test.py
@@ -1,0 +1,174 @@
+"""doc_sync: row-keyed merge onto the CURRENT remote (refuse only on a same-row change on
+both sides), structure lines never merged, writer stamp honest when the id is unset, config
+failures name the key, and put verified by re-get."""
+
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("doc_sync", REPO / "skills" / "agent-room-ops" / "doc_sync.py")
+ds = importlib.util.module_from_spec(spec)
+sys.modules["doc_sync"] = ds
+spec.loader.exec_module(ds)
+
+BASE = "\n".join([
+    "# List", "prose line", "## Active",
+    "org/repo#1 | shepherd: a | status: active | one",
+    "org/repo#2 | shepherd: a | status: active | two",
+    "## History",
+    "org/repo#9 | shepherd: a | status: merged | nine",
+])
+
+
+def edit(text, key, new_line):
+    return "\n".join(new_line if l.startswith(key + " ") else l for l in text.split("\n"))
+
+
+class MergeTests(unittest.TestCase):
+    def test_parse_keys_records_by_id_and_section(self):
+        structure, records = ds.parse(BASE)
+        self.assertEqual(sorted(records), ["org/repo#1", "org/repo#2", "org/repo#9"])
+        self.assertEqual(records["org/repo#9"].section, "History")
+        self.assertEqual(structure, ["# List", "prose line", "## Active", "## History"])
+
+    def test_non_conflicting_interleaving_keeps_both_sides(self):
+        mine = edit(BASE, "org/repo#1", "org/repo#1 | shepherd: a | status: active | one EDITED")
+        remote = BASE.replace("## Active\n", "## Active\norg/repo#3 | shepherd: b | status: active | three (w:b)\n")
+        merged, applied, conflicts = ds.merge(BASE, mine, remote, "me")
+        self.assertEqual(conflicts, [])
+        self.assertIn("org/repo#3 | shepherd: b | status: active | three (w:b)", merged)  # theirs kept
+        self.assertIn("org/repo#1 | shepherd: a | status: active | one EDITED (w:me)", merged)  # mine applied, stamped
+        self.assertEqual(applied, ["edit org/repo#1"])
+
+    def test_same_row_changed_on_both_sides_refuses_and_names_the_writer(self):
+        mine = edit(BASE, "org/repo#1", "org/repo#1 | mine")
+        remote = edit(BASE, "org/repo#1", "org/repo#1 | theirs (w:w3)")
+        merged, applied, conflicts = ds.merge(BASE, mine, remote, "me")
+        self.assertEqual(applied, [])
+        self.assertEqual(len(conflicts), 1)
+        self.assertIn("org/repo#1", conflicts[0]); self.assertIn("w:w3", conflicts[0])
+        self.assertEqual(merged, remote)  # nothing rewritten
+
+    def test_move_between_sections_is_applied_when_remote_unchanged(self):
+        mine = BASE.replace("org/repo#2 | shepherd: a | status: active | two\n", "").replace(
+            "## History\n", "## History\norg/repo#2 | shepherd: a | status: merged | two\n")
+        merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")
+        self.assertEqual(conflicts, [])
+        _, recs = ds.parse(merged)
+        self.assertEqual(recs["org/repo#2"].section, "History")
+        self.assertEqual(applied, ["move org/repo#2 Active -> History"])
+
+    def test_retire_applies_and_retire_vs_remote_edit_conflicts(self):
+        mine = BASE.replace("org/repo#2 | shepherd: a | status: active | two\n", "")
+        merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")
+        self.assertEqual((applied, conflicts), (["retire org/repo#2"], []))
+        self.assertNotIn("org/repo#2", merged)
+        remote = edit(BASE, "org/repo#2", "org/repo#2 | theirs")
+        _, applied, conflicts = ds.merge(BASE, mine, remote, "me")
+        self.assertEqual(applied, []); self.assertIn("org/repo#2", conflicts[0])
+
+    def test_add_lands_at_top_of_its_section_and_duplicate_add_conflicts(self):
+        mine = BASE.replace("## Active\n", "## Active\norg/repo#4 | new row\n")
+        merged, applied, _ = ds.merge(BASE, mine, BASE, "me")
+        lines = merged.split("\n")
+        self.assertEqual(lines[lines.index("## Active") + 1], "org/repo#4 | new row (w:me)")
+        remote = BASE.replace("## Active\n", "## Active\norg/repo#4 | their row (w:w2)\n")
+        _, applied, conflicts = ds.merge(BASE, mine, remote, "me")
+        self.assertEqual(applied, []); self.assertIn("org/repo#4", conflicts[0])
+
+    def test_structure_change_refuses(self):
+        mine = BASE.replace("prose line", "prose line EDITED")
+        merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")
+        self.assertEqual(applied, []); self.assertIn("structure", conflicts[0]); self.assertEqual(merged, BASE)
+
+    def test_writer_stamp_is_honest_when_unset_and_replaces_an_old_stamp(self):
+        self.assertEqual(ds.writer_id(None, env={}), "unknown")
+        self.assertEqual(ds.writer_id(None, env={"SUTANDO_CORE_ID": "3"}), "3")
+        self.assertEqual(ds.writer_id("air", env={"SUTANDO_CORE_ID": "3"}), "air")
+        self.assertEqual(ds.stamp("x | y (w:old)", "new"), "x | y (w:new)")
+
+
+class FakeOps:
+    def __init__(self, gets, puts=None):
+        self.gets, self.puts, self.calls = list(gets), list(puts or []), []
+
+    def get(self, room, folder, name):
+        self.calls.append(("get", folder, name)); return self.gets.pop(0)
+
+    def put(self, room, folder, name, content):
+        self.calls.append(("put", folder, name, content)); return self.puts.pop(0)
+
+
+def ok(content): return {"ok": True, "content": content}
+NOT_FOUND = {"ok": False, "reason": "ops/X.md not found"}
+
+
+class PutFlowTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(); self.ws = Path(self.tmp.name)
+        ds.time.sleep = lambda s: None
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _wire(self, fake):
+        ds.run_get, ds.run_put = fake.get, fake.put
+
+    def test_get_writes_base_and_retries_a_false_not_found_once(self):
+        fake = FakeOps([NOT_FOUND, ok(BASE)]); self._wire(fake)
+        self.assertEqual(ds.cmd_get("!r", "ops", "X.md", self.ws), 0)
+        self.assertEqual(ds.base_path(self.ws, "ops", "X.md").read_text(), BASE)
+        self.assertEqual(len(fake.calls), 2)
+
+    def test_put_without_base_refuses(self):
+        fake = FakeOps([]); self._wire(fake)
+        f = self.ws / "e.md"; f.write_text(BASE)
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 4)
+        self.assertEqual(fake.calls, [])
+
+    def test_put_merges_onto_moved_remote_and_verifies_by_reget(self):
+        ds.base_path(self.ws, "ops", "X.md").parent.mkdir(parents=True)
+        ds.base_path(self.ws, "ops", "X.md").write_text(BASE)
+        mine = edit(BASE, "org/repo#1", "org/repo#1 | mine"); f = self.ws / "e.md"; f.write_text(mine)
+        remote = BASE.replace("## Active\n", "## Active\norg/repo#3 | theirs (w:b)\n")
+        expected = ds.merge(BASE, mine, remote, "me")[0]
+        fake = FakeOps([ok(remote), ok(expected)], puts=[{"ok": True}]); self._wire(fake)
+        self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 0)
+        self.assertEqual([c[0] for c in fake.calls], ["get", "put", "get"])
+        self.assertEqual(fake.calls[1][3], expected)
+        self.assertEqual(ds.base_path(self.ws, "ops", "X.md").read_text(), expected)  # base refreshed
+
+    def test_put_conflict_refuses_without_writing(self):
+        ds.base_path(self.ws, "ops", "X.md").parent.mkdir(parents=True)
+        ds.base_path(self.ws, "ops", "X.md").write_text(BASE)
+        f = self.ws / "e.md"; f.write_text(edit(BASE, "org/repo#1", "org/repo#1 | mine"))
+        fake = FakeOps([ok(edit(BASE, "org/repo#1", "org/repo#1 | theirs (w:w3)"))]); self._wire(fake)
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 4)
+        self.assertFalse(any(c[0] == "put" for c in fake.calls))
+
+    def test_unverified_reget_is_5_and_base_untouched(self):
+        ds.base_path(self.ws, "ops", "X.md").parent.mkdir(parents=True)
+        ds.base_path(self.ws, "ops", "X.md").write_text(BASE)
+        f = self.ws / "e.md"; f.write_text(edit(BASE, "org/repo#1", "org/repo#1 | mine"))
+        fake = FakeOps([ok(BASE), ok(BASE)], puts=[{"ok": True}]); self._wire(fake)
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 5)
+        self.assertEqual(ds.base_path(self.ws, "ops", "X.md").read_text(), BASE)
+
+    def test_missing_room_fails_naming_the_key(self):
+        err = io.StringIO()
+        with redirect_stderr(err), self.assertRaises(SystemExit) as cm:
+            ds.main(["get", "--name", "X.md", "--workspace", str(self.ws)])
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("--room", err.getvalue()); self.assertIn("ROOM_DOC_ROOM", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/room-doc-sync.test.py
+++ b/tests/room-doc-sync.test.py
@@ -7,7 +7,7 @@ import io
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -210,6 +210,26 @@ class PutFlowTests(unittest.TestCase):
         with redirect_stderr(io.StringIO()):
             self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 5)
         self.assertEqual(ds.base_path(self.ws, "ops", "X.md").read_text(), BASE)
+
+    def test_put_distinguishes_nothing_changed_from_already_present(self):
+        ds.base_path(self.ws, "ops", "X.md").parent.mkdir(parents=True)
+        ds.base_path(self.ws, "ops", "X.md").write_text(BASE)
+        # (a) edited == base: a genuine no-op
+        f = self.ws / "e.md"; f.write_text(BASE)
+        self._wire(FakeOps([ok(BASE)]))
+        out = io.StringIO()
+        with redirect_stdout(out):
+            self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 0)
+        self.assertIn("no row changes", out.getvalue()); self.assertNotIn("already present", out.getvalue())
+        # (b) edited != base but the remote already carries my exact edit: reported by name, not silence
+        mine = edit(BASE, "org/repo#1", "org/repo#1 | mine"); f.write_text(mine)
+        fake = FakeOps([ok(mine)]); self._wire(fake)
+        out = io.StringIO()
+        with redirect_stdout(out):
+            self.assertEqual(ds.cmd_put("!r", "ops", "X.md", self.ws, f, "me"), 0)
+        self.assertIn("already present remotely", out.getvalue()); self.assertIn("org/repo#1", out.getvalue())
+        self.assertFalse(any(c[0] == "put" for c in fake.calls))  # nothing written
+        self.assertEqual(ds.base_path(self.ws, "ops", "X.md").read_text(), mine)  # base advanced to the remote
 
     def test_missing_room_fails_naming_the_key(self):
         err = io.StringIO()

--- a/tests/room-doc-sync.test.py
+++ b/tests/room-doc-sync.test.py
@@ -130,6 +130,23 @@ class MergeTests(unittest.TestCase):
         self.assertEqual(ds.duplicate_report(BASE), [])
         self.assertEqual(ds.duplicate_report(remote), ["org/repo#2: L5 Active, L7 History"])
 
+    def test_history_convention_retirement_is_a_record_move_not_a_structure_change(self):
+        # The list retires a row as `key — MERGED <date> … was: <old row>`; that is the same record, moved.
+        row = "org/repo#2 | shepherd: a | status: active | two"
+        kept = [l for l in BASE.split("\n") if l != row]
+        kept.insert(kept.index("## History") + 1, "org/repo#2 — MERGED 2026-09-02 14:16Z by owner. was: " + row)
+        mine = "\n".join(kept)
+        merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")
+        self.assertEqual(conflicts, [])
+        self.assertEqual(applied, ["move org/repo#2 Active -> History"])
+        self.assertEqual(ds.parse(merged)[1]["org/repo#2"].section, "History")
+        self.assertIn("org/repo#2 — MERGED 2026-09-02 14:16Z by owner. was: " + row + " (w:me)", merged)
+
+    def test_duplicates_see_both_row_shapes(self):
+        remote = BASE + "\norg/repo#1 — MERGED 2026-09-02 by owner. was: org/repo#1 | one"
+        self.assertEqual(ds.duplicates(remote), {"org/repo#1": 2})
+        self.assertNotIn("org/repo#1", ds.duplicates(BASE))
+
     def test_structure_change_refuses(self):
         mine = BASE.replace("prose line", "prose line EDITED")
         merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")

--- a/tests/room-doc-sync.test.py
+++ b/tests/room-doc-sync.test.py
@@ -54,6 +54,41 @@ class MergeTests(unittest.TestCase):
         self.assertIn("org/repo#1", conflicts[0]); self.assertIn("w:w3", conflicts[0])
         self.assertEqual(merged, remote)  # nothing rewritten
 
+    def test_a_pure_move_with_identical_text_is_applied(self):
+        # The resolution rule says move the row, do not retype it; the merge must see a pure move.
+        row = "org/repo#9 | shepherd: a | status: merged | nine"
+        kept = [l for l in BASE.split("\n") if l != row]
+        kept.insert(kept.index("## Active") + 1, row)
+        mine = "\n".join(kept)
+        merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")
+        self.assertEqual(conflicts, [])
+        self.assertEqual(applied, ["move org/repo#9 History -> Active"])
+        self.assertEqual(ds.parse(merged)[1]["org/repo#9"].section, "Active")
+
+    def test_every_delta_is_accounted_for_and_already_present_is_reported(self):
+        mine = edit(BASE, "org/repo#1", "org/repo#1 | mine")
+        remote = edit(BASE, "org/repo#1", "org/repo#1 | mine")  # someone landed my exact edit first
+        merged, applied, conflicts = ds.merge(BASE, mine, remote, "me")
+        self.assertEqual((merged, conflicts), (remote, []))
+        self.assertEqual(applied, ["already-present org/repo#1"])  # not silence
+
+    def test_duplicate_key_in_the_callers_file_refuses(self):
+        mine = BASE.replace("## History\n", "## History\norg/repo#2 | shepherd: a | status: merged | two\n")  # copied, not moved
+        merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")
+        self.assertEqual((merged, applied), (BASE, []))
+        self.assertIn("org/repo#2", conflicts[0]); self.assertIn("YOUR file", conflicts[0])
+
+    def test_conflict_returns_the_remote_untouched_even_after_a_partial_apply(self):
+        mine = edit(edit(BASE, "org/repo#1", "org/repo#1 | mine"), "org/repo#2", "org/repo#2 | mine2")
+        remote = edit(BASE, "org/repo#2", "org/repo#2 | theirs (w:w1)")
+        merged, applied, conflicts = ds.merge(BASE, mine, remote, "me")
+        self.assertEqual(merged, remote); self.assertEqual(applied, []); self.assertEqual(len(conflicts), 1)
+
+    def test_blank_line_changes_in_structure_do_not_refuse(self):
+        mine = BASE.replace("## History\n", "\n## History\n")
+        merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")
+        self.assertEqual((applied, conflicts), ([], []))
+
     def test_move_between_sections_is_applied_when_remote_unchanged(self):
         mine = BASE.replace("org/repo#2 | shepherd: a | status: active | two\n", "").replace(
             "## History\n", "## History\norg/repo#2 | shepherd: a | status: merged | two\n")

--- a/tests/room-doc-sync.test.py
+++ b/tests/room-doc-sync.test.py
@@ -81,6 +81,15 @@ class MergeTests(unittest.TestCase):
         _, applied, conflicts = ds.merge(BASE, mine, remote, "me")
         self.assertEqual(applied, []); self.assertIn("org/repo#4", conflicts[0])
 
+    def test_a_key_duplicated_remotely_refuses_by_name(self):
+        # A row in two sections has no single identity; editing "the first one" silently is wrong.
+        mine = edit(BASE, "org/repo#2", "org/repo#2 | mine")
+        remote = BASE.replace("## History\n", "## History\norg/repo#2 | shepherd: a | status: merged | two\n")
+        self.assertEqual(ds.duplicates(remote), {"org/repo#2": 2})
+        merged, applied, conflicts = ds.merge(BASE, mine, remote, "me")
+        self.assertEqual(applied, []); self.assertIn("org/repo#2", conflicts[0]); self.assertIn("2 times", conflicts[0])
+        self.assertEqual(merged, remote)
+
     def test_structure_change_refuses(self):
         mine = BASE.replace("prose line", "prose line EDITED")
         merged, applied, conflicts = ds.merge(BASE, mine, BASE, "me")


### PR DESCRIPTION
## What

`skills/agent-room-ops/doc_sync.py`: `get`/`put` for a shared Room Context record doc that applies the caller's **row-level** changes onto the **current** remote instead of replacing the whole document. Plus `tests/room-doc-sync.test.py` (14 tests).

## Why

A shared doc with several writers loses edits whenever a full-content `doc put` is built from a stale read; nothing ties the put to the read that preceded it. Measured today on a five-writer list: one put from a base a few minutes old silently reverted three edits (a merged row moved back to Active, a row's note dropped, a row's text replaced). Both sides had the same tooling and the same intent; the tool had no notion of a base.

## How

- `get` stores a base copy per (folder, name) under `<workspace>/state/room-doc-sync/`.
- `put` parses base, edited and remote into structure lines + records keyed by the `owner/repo#N |` prefix, computes my deltas (add / edit / move between `## Section`s / retire), and applies them onto the remote. Refuses (exit 4) only on: the same row changed on both sides, a structure-line change, or no base. Nothing is written on a refusal.
- Every row I add or edit is stamped `(w:<writer>)` from `SUTANDO_CORE_ID` or `--writer`; unset stamps `unknown` rather than a shape-valid empty slot, so a conflict can name who to ask.
- Room/name from `--room/--name` or `ROOM_DOC_ROOM/ROOM_DOC_NAME`; folder defaults to `room-live-context`; a missing required value fails naming both the flag and the env key (exit 2).
- A not-found on `get` is retried once: a transient failure has been observed to render as "not found". A put is verified by re-get (exit 5 if it differs).

No room ids, folders or names in the source.

## Evidence

```text
$ python3 tests/room-doc-sync.test.py
Ran 14 tests in 3.022s
OK

# mutation: same-row conflict check removed
FAIL: test_same_row_changed_on_both_sides_refuses_and_names_the_writer
ERROR: test_put_conflict_refuses_without_writing        FAILED (failures=1, errors=1)
# mutation: structure check removed
ERROR: test_structure_change_refuses                    FAILED (errors=1)
# mutation: unset writer id stamps empty
FAIL: test_writer_stamp_is_honest_when_unset...          FAILED (failures=1)
# restored: OK

# live control, production doc (115 KB, 100+ records), scratch workspace
$ doc_sync.py get  --room <room> --folder ops --name <doc> --workspace <scratch>
ok  ops/<doc>  117075 chars  base -> <scratch>/state/room-doc-sync/ops__<doc>.base
$ doc_sync.py put  ... --file <that base>
put: no row changes to apply; nothing written

$ scripts/review-checks.sh --diff
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

— sutando-qingyun-air (@sutando-qingyun-air:ag2.space)
