### PR TITLE
test(outbox-race): halve the instrumented round floor so the 240s cap holds

### DIFF
--- a/tests/outbox-race.test.py
+++ b/tests/outbox-race.test.py
@@ -56,11 +56,12 @@ if __name__ == "__main__":
     # the 240s file cap fired mid-spawn on a thrashed lane (2026-09-02, x3 PRs).
     INSTRUMENTED = os.environ.get("SUTANDO_TEST_SUBPROCESS_COVERAGE") == "1"
     N = max(4, (os.cpu_count() or 2)) if INSTRUMENTED else max(8, (os.cpu_count() or 2) * 3)
-    # MAX one above the floor instrumented, so the budget stays a REACHABLE
-    # backstop there instead of a line that reads like one and cannot run.
-    MIN_ROUNDS, MAX_ROUNDS = 3, (4 if INSTRUMENTED else 12)
-    # Bounds round STARTS only: worst case is floor + budget + in-flight
-    # round durations — far below 36 unconditional rounds, not a ceiling.
+    # Instrumented floor is halved to 2 (phase 2 runs MIN_ROUNDS*2 -> 6 guaranteed
+    # rounds, not 9) with MAX == floor, so the 240s coverage cap holds. Why: PR body.
+    MIN_ROUNDS = 2 if INSTRUMENTED else 3
+    MAX_ROUNDS = MIN_ROUNDS if INSTRUMENTED else 12
+    # Bounds round STARTS only (moot when MAX == floor, i.e. instrumented): worst
+    # case off-instrumentation is floor + budget + in-flight round durations.
     PHASE_BUDGET_S = float(os.environ.get("OUTBOX_RACE_PHASE_BUDGET_S", "35"))
     totals = []
     # ONE warm pool here too, for the reason phase 2 already states: a fresh pool


### PR DESCRIPTION
## The defect

`tests/outbox-race.test.py` timed out under coverage instrumentation (`✖ test TIMED OUT under instrumentation (>240s)`), failing the `diff coverage >= 95%` gate on **unrelated** PRs whose only change was a base-merge — measured 2026-09-02 on the coverage-gate runs for #3704, #3710, and #3713.

The **floor**, not the extra rounds, is the cause. Phase 2 races `MIN_ROUNDS * 2` rounds, so a floor of 3 is **9 guaranteed race-rounds** across the two phases. #3693/#3700 already capped the *extra* rounds (MAX one above the floor instrumented) and shrank `N` — but 9 guaranteed rounds of an N-process pool, each paying coverage-instrumented execution, still overran the 240s per-file cap on a thrashed 2-core CI runner.

## The fix

Halve the instrumented floor to 2 → **2 + 4 = 6 guaranteed rounds**, and set `MAX == floor` under instrumentation so no budget-chased extra round can push a thrashed lane past the cap. Off instrumentation is untouched: the full `3 / 6-to-12`-round rare-interleaving hunt still runs on dev machines.

**Power is unchanged.** A broken lock fails nearly *every* round, so the power comes from the floor *existing*, not from its height — 6 guaranteed N-process races still catch a broken lock on the first rounds. Only the round-count constants move; the exclusion assertion is byte-identical.

## Evidence

Locally (this host):
```
instrumented (SUTANDO_TEST_SUBPROCESS_COVERAGE=1):
  2 of 2 rounds ... (exclusion holds)
  4 of 4 rounds ... (exclusion holds)      # was 3-4 / 6-8
  PASS

non-instrumented:
  12 of 12 rounds ... (exclusion holds)
  24 of 24 rounds ... (exclusion holds)    # unchanged
  PASS
```

Broken-lock control — the worker patched to always "win" (a broken lock), run instrumented against the reduced floor, still trips on the first rounds:
```
  winners per round: [10, 10]
  rounds with != 1 winner: 2  <-- EXCLUSION BROKEN
  FAILED — more than one drainer acquired the same item   (exit 1)
```

Not verified: I cannot reproduce the loaded-2-core-runner timeout on this host (faster CPU, APFS), so the fix rests on the mechanism — fewer guaranteed rounds is strictly less instrumented wall-clock — plus the local pass/power evidence above, not on a reproduced red-to-green of the timeout itself.

Follow-up to #3693/#3700 (my own fix — it reduced the timeout risk but did not zero it). The sibling flake in the same coverage-gate failures, `sparrow-result-guard`'s readdir-order dependency, is fixed separately by #3715.

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)
