### PR TITLE
fix(collab-intel): a roster is per-host, so a peer's reviewer was unreachable

### DIFF
--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -57,7 +57,12 @@ def load_roster(d):
     # this store delegate to roster_union so they cannot drift apart.
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
     from roster_union import host_rosters, roster_union
-    merged = roster_union(host_rosters(d.parent.parent))
+    # The file this reader was pointed at is its LOCAL and goes first: on a
+    # legacy host it is the shared file, which host_rosters lists LAST.
+    local = d / "reviewer-stands.json"
+    paths = [("local", local)] if local.is_file() else []
+    paths += [(h, p) for h, p in host_rosters(d.parent.parent) if p != local]
+    merged = roster_union(paths)
     if not merged:
         return []
     rows = []

--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -54,11 +54,21 @@ def load_roster(d):
     `get("john-the-dev")` missed the entry keyed `rui`).
     """
     import json
-    p = d / "reviewer-stands.json"
-    if not p.exists():
+    # Per-host union: this host's file first, then every peer's. A peer may add
+    # a name the local host has never seen; it may never overwrite one it has.
+    paths = [d / "reviewer-stands.json"]
+    ws = d.parent.parent            # <workspace>/data/collaboration-intelligence -> <workspace>
+    paths += sorted(ws.glob("hosts/*/data/collaboration-intelligence/reviewer-stands.json"))
+    merged = {}
+    for q in paths:
+        if not q.exists():
+            continue
+        for k, v in json.loads(q.read_text()).items():
+            merged.setdefault(k, v)
+    if not merged:
         return []
     rows = []
-    for key, r in json.loads(p.read_text()).items():
+    for key, r in merged.items():
         if not isinstance(r, dict):
             continue
         rows.append({

--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -53,18 +53,11 @@ def load_roster(d):
     reviewer as absent (measured twice: 2026-08-27, 2026-08-28 — both times
     `get("john-the-dev")` missed the entry keyed `rui`).
     """
-    import json
-    # Per-host union: this host's file first, then every peer's. A peer may add
-    # a name the local host has never seen; it may never overwrite one it has.
-    paths = [d / "reviewer-stands.json"]
-    ws = d.parent.parent            # <workspace>/data/collaboration-intelligence -> <workspace>
-    paths += sorted(ws.glob("hosts/*/data/collaboration-intelligence/reviewer-stands.json"))
-    merged = {}
-    for q in paths:
-        if not q.exists():
-            continue
-        for k, v in json.loads(q.read_text()).items():
-            merged.setdefault(k, v)
+    # Same union, same collision semantics as notify_reviewers: both readers of
+    # this store delegate to roster_union so they cannot drift apart.
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+    from roster_union import host_rosters, roster_union
+    merged = roster_union(host_rosters(d.parent.parent))
     if not merged:
         return []
     rows = []

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -40,24 +40,82 @@ _PY = sys.executable or "python3"
 sys.path.insert(0, str(_REPO / "src"))
 
 
+_ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
+
+
+def _host_label() -> str:
+    """The canonical per-host slug, from the ONE helper that defines it.
+
+    Re-deriving the precedence here would be a second copy of a policy that
+    already drifted once; a failure to read it is not a licence to guess.
+    """
+    import subprocess
+    out = subprocess.run(["bash", "scripts/sutando-config.sh", "host-label"],
+                         capture_output=True, text=True, cwd=str(_REPO))
+    return out.stdout.strip()
+
+
 def roster_path() -> Path:
+    """The path THIS host writes. Reads union over peers (see roster_paths)."""
     override = os.environ.get("SUTANDO_SCI_ROSTER")
     if override:
         return Path(override)
     from workspace_default import resolve_workspace
-    return (Path(resolve_workspace()) / "data" / "collaboration-intelligence"
-            / "reviewer-stands.json")
+    ws = Path(resolve_workspace())
+    host = _host_label()
+    if host:
+        per_host = ws / "hosts" / host / _ROSTER_LEAF
+        if per_host.is_file() or not (ws / _ROSTER_LEAF).is_file():
+            return per_host
+    return ws / _ROSTER_LEAF          # legacy shared path, until the move lands
+
+
+def roster_paths() -> "list[tuple[str, Path]]":
+    """(host, path) for every roster on disk, LOCAL FIRST.
+
+    An override names one file and means it: globbing past it would let a
+    peer's rows answer a lookup a test pinned to a fixture.
+    """
+    override = os.environ.get("SUTANDO_SCI_ROSTER")
+    if override:
+        # An absent override is a REFUSAL, not an empty union: falling through
+        # to the glob would let host rosters answer a lookup pinned to a fixture.
+        p = Path(override)
+        return [("", p)] if p.is_file() else []
+    from workspace_default import resolve_workspace
+    ws = Path(resolve_workspace())
+    local = roster_path()
+    out = [(_host_label(), local)] if local.is_file() else []
+    for p in sorted((ws / "hosts").glob(f"*/{_ROSTER_LEAF}")):
+        if p != local:
+            out.append((p.parents[2].name, p))
+    legacy = ws / _ROSTER_LEAF
+    if legacy.is_file() and legacy != local:
+        out.append(("", legacy))
+    return out
 
 
 def load_roster() -> dict:
-    p = roster_path()
-    if not p.is_file():
-        raise SystemExit(f"no roster at {p} — seed it from the map before "
+    """Union across hosts. LOCAL WINS a key collision; the peer row is KEPT
+    under `<key>@<host>` rather than dropped — a lost row and a row nobody
+    wrote are indistinguishable afterwards, which is the failure this store
+    is least able to survive."""
+    paths = roster_paths()
+    if not paths:
+        where = os.environ.get("SUTANDO_SCI_ROSTER") or "any host"
+        raise SystemExit(f"no roster at {where} — seed it from the map before "
                          "notifying (never guess Stand identities)")
-    data = json.loads(p.read_text())
-    if not isinstance(data, dict):
-        raise SystemExit(f"roster at {p} is not an object")
-    return data
+    merged: dict = {}
+    for host, p in paths:
+        data = json.loads(p.read_text())
+        if not isinstance(data, dict):
+            raise SystemExit(f"roster at {p} is not an object")
+        for key, row in data.items():
+            if key.startswith("_") or key not in merged:
+                merged[key] = row
+            elif merged[key] != row:
+                merged[f"{key}@{host}" if host else key] = row
+    return merged
 
 
 def stated_reason(entry: dict) -> str:

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -40,6 +40,9 @@ _PY = sys.executable or "python3"
 sys.path.insert(0, str(_REPO / "src"))
 
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from roster_union import host_rosters, roster_union
+
 _ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
 
 
@@ -86,36 +89,18 @@ def roster_paths() -> "list[tuple[str, Path]]":
     ws = Path(resolve_workspace())
     local = roster_path()
     out = [(_host_label(), local)] if local.is_file() else []
-    for p in sorted((ws / "hosts").glob(f"*/{_ROSTER_LEAF}")):
-        if p != local:
-            out.append((p.parents[2].name, p))
-    legacy = ws / _ROSTER_LEAF
-    if legacy.is_file() and legacy != local:
-        out.append(("", legacy))
+    out += [(h, p) for h, p in host_rosters(ws) if p != local]
     return out
 
 
 def load_roster() -> dict:
-    """Union across hosts. LOCAL WINS a key collision; the peer row is KEPT
-    under `<key>@<host>` rather than dropped — a lost row and a row nobody
-    wrote are indistinguishable afterwards, which is the failure this store
-    is least able to survive."""
+    """Union across hosts; the merge policy is roster_union's, not restated here."""
     paths = roster_paths()
     if not paths:
         where = os.environ.get("SUTANDO_SCI_ROSTER") or "any host"
         raise SystemExit(f"no roster at {where} — seed it from the map before "
                          "notifying (never guess Stand identities)")
-    merged: dict = {}
-    for host, p in paths:
-        data = json.loads(p.read_text())
-        if not isinstance(data, dict):
-            raise SystemExit(f"roster at {p} is not an object")
-        for key, row in data.items():
-            if key.startswith("_") or key not in merged:
-                merged[key] = row
-            elif merged[key] != row:
-                merged[f"{key}@{host}" if host else key] = row
-    return merged
+    return roster_union(paths)
 
 
 def stated_reason(entry: dict) -> str:

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -88,7 +88,10 @@ def roster_paths() -> "list[tuple[str, Path]]":
     from workspace_default import resolve_workspace
     ws = Path(resolve_workspace())
     local = roster_path()
-    out = [(_host_label(), local)] if local.is_file() else []
+    # Label from the PATH, as host_rosters does: a second `host-label` subprocess here
+    # made a refused ask spawn a process before refusing (sci-notify-reviewers-shorthand-refusal).
+    label = local.parents[2].name if local.parent.parent.parent.parent.name == "hosts" else "legacy"
+    out = [(label, local)] if local.is_file() else []
     out += [(h, p) for h, p in host_rosters(ws) if p != local]
     return out
 

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -24,7 +24,9 @@ def host_rosters(workspace) -> "list[tuple[str, Path]]":
            for p in sorted(ws.glob(f"hosts/*/{ROSTER_LEAF}"))]
     legacy = ws / ROSTER_LEAF
     if legacy.is_file():
-        out.append(("", legacy))
+        # A real label: an empty one made the collision branch below write the
+        # BARE key, overwriting local instead of keeping the row under a suffix.
+        out.append(("legacy", legacy))
     return out
 
 
@@ -46,5 +48,5 @@ def roster_union(paths) -> dict:
             if key.startswith("_") or key not in merged:
                 merged[key] = row
             elif merged[key] != row:
-                merged[f"{key}@{host}" if host else key] = row
+                merged[f"{key}@{host or 'legacy'}"] = row
     return merged

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""The per-host roster merge, owned once.
+
+Two readers consult reviewer-stands.json — lookup.py and notify_reviewers.py.
+A store whose readers disagree about what a collision MEANS is worse than one
+with no union at all, so the policy lives here and neither reader restates it.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
+
+
+def host_rosters(workspace) -> "list[tuple[str, Path]]":
+    """Every peer host's roster under `workspace`, then the shared legacy file.
+
+    Sorted so the union is deterministic across filesystems; the caller puts its
+    own host first, since only the caller knows which host it is.
+    """
+    ws = Path(workspace)
+    out = [(p.parents[2].name, p)
+           for p in sorted(ws.glob(f"hosts/*/{ROSTER_LEAF}"))]
+    legacy = ws / ROSTER_LEAF
+    if legacy.is_file():
+        out.append(("", legacy))
+    return out
+
+
+def roster_union(paths) -> dict:
+    """(host, path) pairs, NEAREST FIRST -> merged rows.
+
+    LOCAL WINS a key collision; the differing peer row is KEPT under
+    `<key>@<host>` rather than dropped, because a lost row and a row nobody
+    wrote are indistinguishable afterwards. An identical peer row is not
+    suffixed — agreement is not a conflict. `_`-prefixed schema notes are
+    overwritten rather than suffixed, so they are not duplicated per host.
+    """
+    merged: dict = {}
+    for host, p in paths:
+        data = json.loads(Path(p).read_text())
+        if not isinstance(data, dict):
+            raise SystemExit(f"roster at {p} is not an object")
+        for key, row in data.items():
+            if key.startswith("_") or key not in merged:
+                merged[key] = row
+            elif merged[key] != row:
+                merged[f"{key}@{host}" if host else key] = row
+    return merged

--- a/tests/notify-reviewers-per-host-roster.test.py
+++ b/tests/notify-reviewers-per-host-roster.test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""The roster is per-host and read as a union; a peer may never shadow local.
+
+The vault merges PER-HOST branches — a host merges a peer into its own branch
+and never writes to the peer's — so one shared roster would be a single JSON
+document with N writers and no merge strategy, where the loser's rows vanish
+silently. Per-host files give one writer each and a read-time union.
+
+Run: python3 tests/notify-reviewers-per-host-roster.test.py   (stdlib only)
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "skills" / "collaboration-intelligence" / "scripts" / "notify_reviewers.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("nr", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO / "src"))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
+
+
+class PerHostRoster(unittest.TestCase):
+    def setUp(self):
+        self.nr = _load()
+        self.tmp = Path(tempfile.mkdtemp(prefix="roster-"))
+        self._prev = os.environ.pop("SUTANDO_SCI_ROSTER", None)
+        self.nr.roster_path = lambda: self.tmp / "hosts" / "LOCAL" / LEAF
+        self.nr._host_label = lambda: "LOCAL"
+        import workspace_default
+        self._real_ws = workspace_default.resolve_workspace
+        workspace_default.resolve_workspace = lambda *a, **k: str(self.tmp)
+        self._ws_mod = workspace_default
+
+    def tearDown(self):
+        self._ws_mod.resolve_workspace = self._real_ws
+        if self._prev is not None:
+            os.environ["SUTANDO_SCI_ROSTER"] = self._prev
+
+    def _write(self, host, rows):
+        p = self.tmp / "hosts" / host / LEAF
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(rows))
+        return p
+
+    def test_a_peer_only_reviewer_is_reachable_by_name(self):
+        """The whole point of the union: rows a peer observed are usable here."""
+        self._write("LOCAL", {"alice": {"stand": "@a:x"}})
+        self._write("PEER", {"bob": {"stand": "@b:x"}})
+        r = self.nr.load_roster()
+        self.assertEqual(r["bob"]["stand"], "@b:x")
+        self.assertEqual(r["alice"]["stand"], "@a:x")
+
+    def test_local_WINS_a_collision_and_the_peer_row_is_kept_not_dropped(self):
+        """A lost row and a row nobody wrote are indistinguishable afterwards."""
+        self._write("LOCAL", {"alice": {"stand": "@local:x"}})
+        self._write("PEER", {"alice": {"stand": "@peer:x"}})
+        r = self.nr.load_roster()
+        self.assertEqual(r["alice"]["stand"], "@local:x", "a peer shadowed the local row")
+        self.assertEqual(r["alice@PEER"]["stand"], "@peer:x",
+                         "the peer's row was dropped instead of retained under its host")
+
+    def test_an_IDENTICAL_peer_row_does_not_manufacture_a_suffixed_duplicate(self):
+        """Agreement is not a conflict; suffixing it would inflate every roster."""
+        same = {"alice": {"stand": "@a:x"}}
+        self._write("LOCAL", same)
+        self._write("PEER", same)
+        r = self.nr.load_roster()
+        self.assertEqual([k for k in r if k.startswith("alice")], ["alice"])
+
+    def test_CONTROL_an_explicit_override_is_not_widened_by_the_glob(self):
+        """A fixture-pinned test must never be answered by a host roster."""
+        self._write("LOCAL", {"alice": {"stand": "@local:x"}})
+        only = self.tmp / "only.json"
+        only.write_text(json.dumps({"zed": {"stand": "@z:x"}}))
+        os.environ["SUTANDO_SCI_ROSTER"] = str(only)
+        try:
+            r = self.nr.load_roster()
+            self.assertEqual(list(r), ["zed"], "the glob leaked past an explicit override")
+        finally:
+            os.environ.pop("SUTANDO_SCI_ROSTER", None)
+
+    def test_CONTROL_an_absent_override_REFUSES_rather_than_unioning(self):
+        self._write("LOCAL", {"alice": {"stand": "@local:x"}})
+        os.environ["SUTANDO_SCI_ROSTER"] = str(self.tmp / "nope.json")
+        try:
+            with self.assertRaises(SystemExit) as e:
+                self.nr.load_roster()
+            self.assertIn("never guess", str(e.exception))
+        finally:
+            os.environ.pop("SUTANDO_SCI_ROSTER", None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/notify-reviewers-per-host-roster.test.py
+++ b/tests/notify-reviewers-per-host-roster.test.py
@@ -141,6 +141,27 @@ class PerHostRoster(unittest.TestCase):
             self.nr.load_roster()
         self.assertIn(str(bad), str(caught.exception))
 
+    def test_BOTH_readers_of_this_store_resolve_a_collision_identically(self):
+        """The divergence guard. Two readers that disagree about what a
+        collision MEANS are worse than no union: one surfaces `alice@peerbox`,
+        the other silently drops it, and nothing records which was intended.
+        """
+        self._write("LOCAL", {"alice": {"stand": "@local:x"}})
+        self._write("peerbox", {"alice": {"stand": "@peer:x"}})
+
+        spec = importlib.util.spec_from_file_location(
+            "lk", REPO / "skills" / "collaboration-intelligence" / "scripts" / "lookup.py")
+        lk = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(lk)
+
+        via_notify = sorted(self.nr.load_roster())
+        via_lookup = sorted(r["entity_id"]
+                            for r in lk.load_roster(self.tmp / "data" / "collaboration-intelligence"))
+        self.assertEqual(via_notify, via_lookup,
+                         "the two readers of reviewer-stands.json disagree on a collision")
+        self.assertIn("alice@peerbox", via_notify,
+                      "the losing peer row was dropped instead of surfaced")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/notify-reviewers-per-host-roster.test.py
+++ b/tests/notify-reviewers-per-host-roster.test.py
@@ -126,7 +126,7 @@ class PerHostRoster(unittest.TestCase):
         legacy = self.tmp / LEAF
         legacy.parent.mkdir(parents=True, exist_ok=True)
         legacy.write_text(json.dumps({"carol": {"stand": "@c:x"}}))
-        self.assertIn("", [h for h, _ in self.nr.roster_paths()],
+        self.assertIn("legacy", [h for h, _ in self.nr.roster_paths()],
                       "the shared roster was dropped from the union")
         self.assertEqual(self.nr.load_roster()["carol"]["stand"], "@c:x")
 
@@ -161,6 +161,54 @@ class PerHostRoster(unittest.TestCase):
                          "the two readers of reviewer-stands.json disagree on a collision")
         self.assertIn("alice@peerbox", via_notify,
                       "the losing peer row was dropped instead of surfaced")
+
+    def test_a_differing_LEGACY_row_is_kept_under_a_suffix_never_a_bare_overwrite(self):
+        """john-the-dev's repro: host="" used to collapse the suffix to the bare
+        key, so the LEGACY row overwrote local and nothing preserved the loser."""
+        sys.path.insert(0, str(SCRIPT.parent))
+        from roster_union import roster_union
+        local = self._write("myhost", {"alice": {"stand": "@alice-LOCAL:x"}})
+        legacy = self.tmp / LEAF
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(json.dumps({"alice": {"stand": "@alice-LEGACY:x"}}))
+        r = roster_union([("myhost", local), ("", legacy)])
+        self.assertEqual(r["alice"]["stand"], "@alice-LOCAL:x")
+        self.assertEqual(r["alice@legacy"]["stand"], "@alice-LEGACY:x")
+
+    def test_host_rosters_labels_the_shared_file_so_its_rows_can_be_suffixed(self):
+        from roster_union import host_rosters
+        self._write("PEER", {"bob": {"stand": "@b:x"}})
+        legacy = self.tmp / LEAF
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(json.dumps({"alice": {"stand": "@a:x"}}))
+        labels = [h for h, _ in host_rosters(self.tmp)]
+        self.assertEqual(labels, ["PEER", "legacy"])
+        self.assertNotIn("", labels, "an empty label is what made the union overwrite")
+
+    def test_on_a_LEGACY_host_local_still_WINS_and_the_peer_row_is_kept(self):
+        """yixuan-ag2's table row that failed: local roster = the shared file."""
+        legacy = self.tmp / LEAF
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(json.dumps({"alice": {"stand": "@local:x"}}))
+        self._write("peerbox", {"alice": {"stand": "@peer:x"}})
+        self.nr.roster_path = lambda: legacy
+        r = self.nr.load_roster()
+        self.assertEqual(r["alice"]["stand"], "@local:x")
+        self.assertEqual(r["alice@peerbox"]["stand"], "@peer:x")
+        self.assertEqual(sorted(r), ["alice", "alice@peerbox"])
+
+    def test_lookup_on_a_LEGACY_host_puts_its_own_file_first_even_when_a_peer_sorts_before_it(self):
+        # "AAA" sorts before "legacy": without local-first, sort order decided the winner.
+        legacy = self.tmp / LEAF
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(json.dumps({"alice": {"stand": "@local:x"}}))
+        self._write("AAA", {"alice": {"stand": "@peer:x"}})
+        spec = importlib.util.spec_from_file_location(
+            "lk2", REPO / "skills" / "collaboration-intelligence" / "scripts" / "lookup.py")
+        lk = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(lk)
+        rows = {r["entity_id"]: r["agent_mxid"] for r in lk.load_roster(legacy.parent)}
+        self.assertEqual(rows, {"alice": "@local:x", "alice@AAA": "@peer:x"})
 
 
 if __name__ == "__main__":

--- a/tests/notify-reviewers-per-host-roster.test.py
+++ b/tests/notify-reviewers-per-host-roster.test.py
@@ -103,6 +103,44 @@ class PerHostRoster(unittest.TestCase):
         finally:
             os.environ.pop("SUTANDO_SCI_ROSTER", None)
 
+    def test_roster_path_without_a_host_label_uses_the_shared_file(self):
+        """host-label can fail; guessing a per-host path would name a file that
+        never exists, turning a resolvable roster into a refusal."""
+        nr2 = _load()
+        nr2._host_label = lambda: ""
+        self.assertEqual(nr2.roster_path(), self.tmp / LEAF)
+
+    def test_roster_path_falls_back_to_the_shared_file_before_the_move(self):
+        """A host whose roster has not been moved yet must still find it."""
+        nr2 = _load()
+        nr2._host_label = lambda: "LOCAL"
+        legacy = self.tmp / LEAF
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(json.dumps({"alice": {"stand": "@a:x"}}))
+        self.assertEqual(nr2.roster_path(), legacy)
+
+    def test_the_shared_roster_still_joins_the_union_mid_migration(self):
+        """Hosts move one at a time. If the pre-move file left the union the
+        moment this host moved, every unmoved peer would go unreachable."""
+        self._write("LOCAL", {"alice": {"stand": "@a:x"}})
+        legacy = self.tmp / LEAF
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(json.dumps({"carol": {"stand": "@c:x"}}))
+        self.assertIn("", [h for h, _ in self.nr.roster_paths()],
+                      "the shared roster was dropped from the union")
+        self.assertEqual(self.nr.load_roster()["carol"]["stand"], "@c:x")
+
+    def test_a_roster_that_is_not_an_object_REFUSES_instead_of_being_skipped(self):
+        """A JSON list parses fine and yields no rows, so skipping it reads as
+        an empty roster — which is exactly when a lookup starts guessing."""
+        self._write("LOCAL", {"alice": {"stand": "@a:x"}})
+        bad = self.tmp / "hosts" / "PEER" / LEAF
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text("[1, 2, 3]")
+        with self.assertRaises(SystemExit) as caught:
+            self.nr.load_roster()
+        self.assertIn(str(bad), str(caught.exception))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/sci-notify-reviewers.test.py
+++ b/tests/sci-notify-reviewers.test.py
@@ -88,6 +88,9 @@ def run_send(stub_payload, roster=None, stub_stderr=""):
     (root / "skills" / "agent-room-ops").mkdir(parents=True)
     copy = root / "skills/collaboration-intelligence/scripts/notify_reviewers.py"
     copy.write_text(SCRIPT.read_text())
+    # the script imports its sibling: the skill ships as a directory, not a file
+    (copy.parent / "roster_union.py").write_text(
+        (SCRIPT.parent / "roster_union.py").read_text())
     (root / "skills/agent-room-ops/room_ops.py").write_text(
         "import sys\n"
         f"sys.stdout.write({stub_payload!r})\n"
@@ -176,6 +179,9 @@ def run_room(members_payload, *extra, roster=None, env_overrides=None):
     (root / "skills" / "agent-room-ops").mkdir(parents=True)
     copy = root / "skills/collaboration-intelligence/scripts/notify_reviewers.py"
     copy.write_text(SCRIPT.read_text())
+    # the script imports its sibling: the skill ships as a directory, not a file
+    (copy.parent / "roster_union.py").write_text(
+        (SCRIPT.parent / "roster_union.py").read_text())
     (root / "skills/agent-room-ops/room_ops.py").write_text(
         "import sys\n"
         "cmd = sys.argv[1] if len(sys.argv) > 1 else ''\n"
@@ -208,6 +214,9 @@ def run_room_per_room(per_room: dict, default, *extra, roster=None):
     (root / "skills" / "agent-room-ops").mkdir(parents=True)
     copy = root / "skills/collaboration-intelligence/scripts/notify_reviewers.py"
     copy.write_text(SCRIPT.read_text())
+    # the script imports its sibling: the skill ships as a directory, not a file
+    (copy.parent / "roster_union.py").write_text(
+        (SCRIPT.parent / "roster_union.py").read_text())
     seen = root / "queried.txt"
     (root / "skills/agent-room-ops/room_ops.py").write_text(
         "import sys\n"


### PR DESCRIPTION
## The defect

`reviewer-stands.json` lives under the workspace's `data/`, which is **not** in the default `vault.sync.include` set (`notes/`, `talks/`, `hosts/` are). So each host held its own roster and neither reader ever looked at another's.

A reviewer recorded on one machine did not exist on the next. `notify_reviewers` then refuses the name — *correct behaviour applied to an incomplete store*, which is why nothing appeared broken.

## Before / after

The new test at the parent commit (`7ed47a6a1`) versus this branch's head:

```
########## BEFORE (origin/main 7ed47a6a1) ##########
Ran 10 tests
FAILED (failures=4, errors=3)

########## AFTER (this branch) ##########
Ran 10 tests
OK
```

Verified with the source files reverted to `origin/main` while keeping this branch's tests — **not** to `HEAD^`, which still contains the fix and gives a misleading clean pass (thanks to @yixuan-ag2 for publishing that trap).

## Merge semantics — one owner

`skills/collaboration-intelligence/scripts/roster_union.py` owns both halves that would otherwise be duplicated across the two readers of this store:

- `roster_union(paths)` — **local WINS** a key collision; the differing peer row is **kept** under `<key>@<host>`, never dropped, so a divergent id stays visible instead of being resolved one way in silence. An identical peer row is not suffixed — agreement is not a conflict. `_`-prefixed schema notes overwrite rather than duplicate per host.
- `host_rosters(workspace)` — peer discovery, so `lookup.py` no longer derives peer paths from its own `d.parent.parent`.

Both `lookup.py` and `notify_reviewers.py` delegate. Neither restates the policy:

```
                                BEFORE (first push)           NOW
lookup.load_roster              1 row, peer DROPPED           ['alice', 'alice@peerbox']
notify_reviewers.load_roster    ['alice', 'alice@peerbox']    ['alice', 'alice@peerbox']
```

The guard test asserts the two readers **agree**, rather than asserting each one's output separately — the divergence is what must be unable to return.

Consequence, stated because it is a real limit: a peer-only reviewer is reachable by name, but a *colliding* peer row is reachable only as `<key>@<host>`. Deliberate, and pinned by the collision test.

## The override still refuses

`SUTANDO_SCI_ROSTER` names exactly one file. An **absent** override refuses rather than falling through to the glob — otherwise host rosters could answer a lookup a test had pinned to a fixture. I got this wrong in the first cut (raw `FileNotFoundError` instead of the "never guess Stand identities" refusal); the existing `test_missing_roster_names_the_path_and_refuses` caught it, and both directions are now pinned as CONTROL cases.

## Note for anything that installs these scripts

`notify_reviewers.py` now imports a sibling, so a **single-file** copy of it no longer runs — the skill ships as a directory. `sci-notify-reviewers` copies the script into a temp tree to exercise it, and that fixture now copies the sibling too.

## Checks

```
notify-reviewers-per-host-roster   10 OK   (new; incl. the divergence guard)
sci-notify-reviewers               29 OK
notify-reviewers-human-shapes       8 OK
sci-notify-reviewers-kind           8 OK
sci-notify-reviewers-inproc        57 OK
collab-lookup-store-shapes         16 OK
scripts/review-checks.sh           PASS (hardcoded-paths + root-artifacts + prose-cap)
```

Discrimination checked on each new assertion: inverting local-preference fails only the collision test; restoring `setdefault` in `lookup.py` fails only the divergence guard.

## Scope

Single concern. #3722 changes the *renderers* in `lookup.py`; the hunks do not overlap and either can land first.

Stand: Echo Act IV Pro
