### PR TITLE
fix(collab-intel): `--all` rendered as nameless a row `match()` can find

### DIFF
--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -71,6 +71,16 @@ def load_roster(d):
         })
     return rows
 
+def _name_of(r):
+    """quick-lookup.yaml keys people as `id`/`who`, the roster as `entity_id`/
+    `one_line`; match() reads both, so every render site must too."""
+    return r.get("entity_id") or r.get("id") or ""
+
+
+def _role_of(r):
+    return str(r.get("one_line") or r.get("who") or "")
+
+
 def _identity_id(i):
     # schema.md names this field `user_id`; this reader only ever read
     # `provider_id`, so a schema-faithful store matched nothing.
@@ -134,10 +144,7 @@ def main():
         print(f"KNOWN ENTITIES ({len(rows)})\n{stale}")
         for r in rows:
             st = r.get("agent_mxid") or "-- no Stand recorded --"
-            # quick-lookup.yaml rows key the name as `id`; match() already reads
-            # both, so a row findable by name must not render nameless here.
-            nm = r.get("entity_id") or r.get("id") or ""
-            print(f"  {nm:<28} {r.get('kind',''):<6} {st}")
+            print(f"  {_name_of(r):<28} {r.get('kind',''):<6} {st}")
         return 0
 
     hits = match(rows, a.query, ents)
@@ -148,14 +155,14 @@ def main():
         return 0
 
     for r in hits:
-        eid = r.get("entity_id", "")
+        eid = _name_of(r)
         stand = r.get("agent_mxid")
         print(f"\n  {eid}  [{r.get('kind','?')}]")
-        print(f"    role: {str(r.get('one_line',''))[:150]}")
+        print(f"    role: {_role_of(r)[:150]}")
         if stand:
             print(f"    ADDRESS THIS -> {stand}")
         else:
-            loose = re.findall(r"@[\w.\-]+", str(r.get("one_line", "")))
+            loose = re.findall(r"@[\w.\-]+", _role_of(r))
             if loose:
                 print(f"    ⚠ NO STRUCTURED Stand, but the role text names: {', '.join(loose)}")
                 print("      UNVERIFIED -- prose is not a resolved id. Use it, and say it is unconfirmed.")

--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -134,7 +134,10 @@ def main():
         print(f"KNOWN ENTITIES ({len(rows)})\n{stale}")
         for r in rows:
             st = r.get("agent_mxid") or "-- no Stand recorded --"
-            print(f"  {r.get('entity_id',''):<28} {r.get('kind',''):<6} {st}")
+            # quick-lookup.yaml rows key the name as `id`; match() already reads
+            # both, so a row findable by name must not render nameless here.
+            nm = r.get("entity_id") or r.get("id") or ""
+            print(f"  {nm:<28} {r.get('kind',''):<6} {st}")
         return 0
 
     hits = match(rows, a.query, ents)

--- a/tests/collab-lookup-store-shapes.test.py
+++ b/tests/collab-lookup-store-shapes.test.py
@@ -229,6 +229,28 @@ class StoreShapes(unittest.TestCase):
         self.assertEqual(len(body), 1, buf.getvalue())
         self.assertIn("gh:qingyun-wu", body[0])
 
+    def test_a_query_renders_the_name_and_role_of_an_id_who_row(self):
+        """The per-query detail path had the same blind spot as --all: it read
+        entity_id/one_line, so a matched quick-lookup row printed a blank name
+        above a blank role — on the one surface used to decide who to address.
+        """
+        import contextlib
+        import io
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, "people:\n  - id: 'gh:qingyun-wu'\n"
+                         "    who: 'reviewer on the server-PR stack'\n")
+            orig_store, orig_argv = lk.store, sys.argv
+            lk.store, sys.argv = (lambda: d), ["lookup.py", "gh:qingyun-wu"]
+            try:
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    lk.main()
+            finally:
+                lk.store, sys.argv = orig_store, orig_argv
+        out = buf.getvalue()
+        self.assertIn("gh:qingyun-wu", out, out)
+        self.assertIn("reviewer on the server-PR stack", out, out)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/collab-lookup-store-shapes.test.py
+++ b/tests/collab-lookup-store-shapes.test.py
@@ -204,6 +204,31 @@ class StoreShapes(unittest.TestCase):
             d = store(t, roster=ROSTER)
             self.assertEqual(lk.match(lk.load_roster(d), "no-such-login"), [])
 
+    def test_listing_names_an_id_who_row_instead_of_a_blank_column(self):
+        """--all must not render a row that match() can find as nameless.
+
+        The renderer read only `entity_id`; a real host's quick-lookup.yaml
+        keys people as `id`, so four rows listed as blank names against a
+        populated Stand column.
+        """
+        import contextlib
+        import io
+        with tempfile.TemporaryDirectory() as t:
+            d = store(t, "people:\n  - id: 'gh:qingyun-wu'\n"
+                         "    who: 'reviewer on the server-PR stack'\n")
+            orig_store, orig_argv = lk.store, sys.argv
+            lk.store, sys.argv = (lambda: d), ["lookup.py", "--all"]
+            try:
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    lk.main()
+            finally:
+                lk.store, sys.argv = orig_store, orig_argv
+        body = [l for l in buf.getvalue().splitlines()
+                if l.startswith("  ") and "updated_at" not in l]
+        self.assertEqual(len(body), 1, buf.getvalue())
+        self.assertIn("gh:qingyun-wu", body[0])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
## The defect

`lookup.py --all` printed each row's name as `r.get("entity_id", "")`. A real host's `quick-lookup.yaml` keys its people as `id` (with `who` carrying the role line).

`match()` **already reads both** — `tests/collab-lookup-store-shapes.test.py::test_flat_id_who_fields_match` has pinned that shape since #3517. So the matcher and the renderer disagreed about the same store: a row you could look up by name listed with an empty name.

## Before / after

On this host's live store (after repairing that store's YAML, see below):

```
BEFORE                                          AFTER
  KNOWN ENTITIES (13)                             KNOWN ENTITIES (13)
                    -- no Stand recorded --       gh:sonichi        -- no Stand recorded --
                    -- no Stand recorded --       gh:qingyun-wu     -- no Stand recorded --
                    -- no Stand recorded --       gh:john-the-dev   -- no Stand recorded --
                    -- no Stand recorded --       gh:keweichen      -- no Stand recorded --
  bassilkhilo-ag2   @sutando-bassil:ag2.space     bassilkhilo-ag2   @sutando-bassil:ag2.space
  ...                                             ...
```

The suite at the parent commit vs this branch:

```
########## BEFORE (origin/main 7ed47a6a1) ##########
FAIL: test_listing_names_an_id_who_row_instead_of_a_blank_column
Ran 17 tests in 0.100s
FAILED (failures=1)

########## AFTER (this branch) ##########
Ran 17 tests in 0.082s
OK
```

Exactly one test moves, and it is the one added here.

## Why nameless is worse than absent

The row is present, so the count reads correct — `KNOWN ENTITIES (13)` is true either way. What is lost is *which* identity has no Stand recorded, on the one surface whose whole purpose is deciding who to address. An empty name is indistinguishable from a rendering artifact, so it invites being ignored rather than resolved.

## How it surfaced

The store's `quick-lookup.yaml` was unparseable — `ScannerError`: a `fleet_facts` entry ended in `:` with plain prose continuation lines, so YAML expected a nested mapping and found none. `load()` catches that and warns `using roster only`, so **every** quick-lookup row was silently dropped and these four never rendered at all.

Repairing that YAML is a workspace data fix and is not in this diff. It is what exposed the renderer: entity count went 9 → 13, and four of the four new rows came out blank.

## Checks

```
collab-lookup-store-shapes   17 OK  (16 existing + 1 new)
scripts/review-checks.sh     PASS (hardcoded-paths + root-artifacts + prose-cap)
ruff                         clean (pre-commit initially refused E401 here; fixed, not bypassed)
```

## Scope

Single concern. #3721 changes `load_roster` in this same file for the per-host roster union; the hunks do not overlap and either can land first.

Stand: Echo Act IV Pro