### PR TITLE
fix(tests): sparrow-result-guard asserted on an arbitrary glob element

### DIFF
--- a/tests/sparrow-result-guard.test.py
+++ b/tests/sparrow-result-guard.test.py
@@ -151,15 +151,21 @@ with tempfile.TemporaryDirectory() as td:
         "source_message_id": "$message-one",
         "user_id": "@requester:ag2.space",
     }
+    # glob order is filesystem order, and earlier withholds already persisted
+    # artifacts: assert on the one THIS call created, not on whichever is [0].
+    before_review = set((m._STATE / "withheld-team-results").glob("wr_*.json"))
     write_task(tasks, "task-notice-one", "team", **notice_fields)
     first_notice, first_reason = m._guarded_result_body(
         "task-notice-one", BODY_WITH_MARKERS)
     review_files = list((m._STATE / "withheld-team-results").glob("wr_*.json"))
+    new_review = sorted(set(review_files) - before_review)
     check(first_reason is not None
           and any(a.kind == "skip" for a in m.parse_markers(first_notice).actions),
           "first withhold closes the lease without posting into the shared room")
     check(bool(review_files), "first withhold persists an owner-review artifact")
-    review_record = json.loads(review_files[0].read_text(encoding="utf-8"))
+    check(len(new_review) == 1,
+          "this withhold persists exactly one new owner-review artifact")
+    review_record = json.loads(new_review[0].read_text(encoding="utf-8"))
     check(review_record.get("context", {}).get("room_name") == "Design Room",
           "the bridge retains the human-readable room name for private review")
 


### PR DESCRIPTION
## Symptom

`tests/sparrow-result-guard.test.py` fails intermittently in CI with:

```
FAIL: the bridge retains the human-readable room name for private review
FAIL: sparrow result guard
coverage-gate: suite must be green before coverage is meaningful.
```

It took down the `diff coverage >= 95% (python)` gate on **#3721** and **#3722** — two unrelated PRs, neither touching this area — within an hour of each other. Because the gate refuses to compute coverage on a red suite, one order-dependent assertion blocks every PR it lands on.

## Cause — measured, not inferred

Three `_guarded_result_body(...)` calls run before the check, so more than one artifact exists when it indexes `[0]`:

```
DIAG wr_ count=2 ['wr_aad0ae0ad0877614.json', 'wr_9ccd4554cb015608.json']
DIAG room_names= ['Design Room', '']
```

`glob()` returns filesystem order, and the two records differ in **exactly the field being asserted**. The check therefore passes or fails on inode allocation, not on the bridge's behaviour. It is not flaky in the usual timing sense — it is deterministic per filesystem layout, which is why it survived review and then bit two PRs in one hour.

## Deterministic repro

Reversing only the glob result — no other change — reproduces the CI failure verbatim at `origin/main`:

```
# origin/main, glob result reversed:
FAIL: the bridge retains the human-readable room name for private review
FAIL: sparrow result guard

# this branch, same reversal:   0 failures
# this branch, normal order:    0 failures
```

Order-independent by construction rather than order-lucky.

## The fix

Take the set difference around the call, so the assertion is about the artifact **this** withhold created rather than whichever file the filesystem listed first — and pin that it creates exactly one, which is the property the existing `len(review_files) + 1` check two assertions later already assumes but never states.

No production code changes. The bridge behaviour under test is unchanged and still asserted; what changes is which record the assertion reads.

## Scope

Single concern, test-only. Deliberately not bundled into #3721/#3722 — those are the PRs this was blocking, not the PRs that caused it.

Stand: Echo Act IV Pro