### PR TITLE
fix(sync): a DD conflict must not delete a file that still exists on disk

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -1172,10 +1172,13 @@ _resolve_conflicts_keep_ours() {
         # best-effort: a backup failure must never block the merge.
         if git checkout --ours -- "$f" 2>/dev/null; then
             git add -- "$f"
-        elif [ -e "$f" ]; then
+        elif [ -e "$f" ] || [ -L "$f" ]; then
             # Carrier enforcement untracks while KEEPING bytes on disk, so a
             # DD path can still hold live local state git no longer owns.
             # `--cached` resolves the index; `-f` would delete that data.
+            # `-L` because `-e` FOLLOWS the link: a dangling symlink reads as
+            # absent and would take the deleting branch (the `workspace` link
+            # is exactly this shape while its target is unavailable).
             git rm -q --cached -- "$f" 2>/dev/null || true
         else
             git rm -f -- "$f" 2>/dev/null || true

--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -1172,6 +1172,11 @@ _resolve_conflicts_keep_ours() {
         # best-effort: a backup failure must never block the merge.
         if git checkout --ours -- "$f" 2>/dev/null; then
             git add -- "$f"
+        elif [ -e "$f" ]; then
+            # Carrier enforcement untracks while KEEPING bytes on disk, so a
+            # DD path can still hold live local state git no longer owns.
+            # `--cached` resolves the index; `-f` would delete that data.
+            git rm -q --cached -- "$f" 2>/dev/null || true
         else
             git rm -f -- "$f" 2>/dev/null || true
         fi

--- a/tests/sync-workspace-conflict-preserves-theirs.test.sh
+++ b/tests/sync-workspace-conflict-preserves-theirs.test.sh
@@ -162,6 +162,31 @@ check $? "default backup root lives under the git dir (never trackable)"
 # so git status was trivially clean. The under-the-git-dir check above is the
 # one that actually discriminates.)
 
+# --- A DANGLING SYMLINK is local state too, and `-e` FOLLOWS the link, so it
+# --- reads as absent and takes the DELETING branch. This repo's own `workspace`
+# --- link has exactly that shape whenever its target is unavailable.
+# --- Built with PLUMBING (stage 1 only): a plain delete/delete merges CLEANLY
+# --- and would never reach the fallback at all — a vacuous pass. (I shipped
+# --- that fixture first and only the mutation run below caught it.)
+WS3="$TMP/ws3"; mkdir -p "$WS3"; cd "$WS3" || exit 1
+git init -q .; git config user.email t@t; git config user.name t
+printf 'seed\n' > seed; git add seed; git commit -qm base
+BLOB="$(printf '/nonexistent-target-xyz' | git hash-object -w --stdin)"
+printf '120000 %s 1\tlink\n' "$BLOB" | git update-index --index-info
+ln -s /nonexistent-target-xyz link          # live local state git no longer owns
+
+[ -n "$(git ls-files -u -- link)" ]
+check $? "fixture: link is genuinely UNMERGED (stage 1 only), not a clean merge"
+[ -L link ] && [ ! -e link ]
+check $? "fixture: the path is a DANGLING symlink (-L true, -e false)"
+
+_resolve_conflicts_keep_ours "origin/none" "$TMP/bk3" 2>/dev/null
+
+[ -L link ]
+check $? "THE POINT: a dangling symlink SURVIVES the DD fallback (\`-e\` alone deletes it)"
+[ -z "$(git ls-files -u -- link)" ]
+check $? "dangling-symlink DD conflict is still resolved in the index"
+
 printf '\n%s: %d passed, %d failed\n' "sync conflict preserves theirs" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1
 printf 'PASS — sync-workspace conflict fallback preserves the discarded side\n'

--- a/tests/sync-workspace-conflict-preserves-theirs.test.sh
+++ b/tests/sync-workspace-conflict-preserves-theirs.test.sh
@@ -71,6 +71,54 @@ _resolve_conflicts_keep_ours "origin/dd2" "$TMP/bk2" 2>/dev/null
 [ -z "$(git diff --name-only --diff-filter=U)" ]
 check $? "DD conflict (no stage 3) resolves without crashing"
 
+# --- A DD path can still hold LIVE local state, and `-f` deleted it ----------
+# Carrier enforcement (`_enforce_carrier_set_pre`) untracks paths outside this
+# host's carrier set with `git rm --cached` — bytes stay on disk — and commits
+# that removal, so it propagates. A peer whose carrier set differs then merges
+# a deletion for a path its own app is still WRITING. The old fallback ran
+# `git rm -f`, which removed the working-tree file: reported fleet-wide as
+# data/task-workstreams.json vanishing (absent, not emptied) three times in
+# ~35 min on one host.
+#
+# The index state is built with plumbing rather than a merge on purpose: a
+# plain delete/delete MERGES CLEANLY and leaves no unmerged path, so a fixture
+# that "resolves" would pass vacuously without ever exercising the branch.
+WS3="$TMP/ws3"; mkdir -p "$WS3"; cd "$WS3" || exit 1
+git init -q .; git config user.email t@t; git config user.name t
+mkdir -p data; printf 'base\n' > data/task-workstreams.json
+git add -A; git commit -qm base
+DD_BLOB="$(git rev-parse HEAD:data/task-workstreams.json)"
+git rm -q --cached data/task-workstreams.json
+printf '100644 %s 1\tdata/task-workstreams.json\n' "$DD_BLOB" | git update-index --index-info
+printf 'LIVE LOCAL STATE\n' > data/task-workstreams.json
+
+[ -n "$(git diff --name-only --diff-filter=U)" ]
+check $? "fixture really IS a DD conflict (guards against a vacuous pass)"
+! git checkout --ours -- data/task-workstreams.json 2>/dev/null
+check $? "fixture really takes the fallback (--ours fails on DD, as the comment says)"
+
+_resolve_conflicts_keep_ours "origin/peer-dd" "$TMP/bk3" >/dev/null 2>&1
+
+[ -z "$(git diff --name-only --diff-filter=U)" ]
+check $? "DD+on-disk: conflict is resolved, so the merge can still conclude"
+[ -f data/task-workstreams.json ]
+check $? "THE POINT: a DD path that still exists on disk is NOT deleted"
+grep -q 'LIVE LOCAL STATE' data/task-workstreams.json 2>/dev/null
+check $? "DD+on-disk: the local bytes are intact, not just the path"
+
+# Control: when the path genuinely is gone, the -f branch must still resolve.
+WS4="$TMP/ws4"; mkdir -p "$WS4"; cd "$WS4" || exit 1
+git init -q .; git config user.email t@t; git config user.name t
+mkdir -p data; printf 'base\n' > data/gone.json
+git add -A; git commit -qm base
+DD_BLOB2="$(git rev-parse HEAD:data/gone.json)"
+git rm -q --cached data/gone.json
+printf '100644 %s 1\tdata/gone.json\n' "$DD_BLOB2" | git update-index --index-info
+rm -f data/gone.json
+_resolve_conflicts_keep_ours "origin/peer-dd2" "$TMP/bk4" >/dev/null 2>&1
+[ -z "$(git diff --name-only --diff-filter=U)" ]
+check $? "control: an absent DD path still resolves (the -f branch is untouched)"
+
 # --- BLOCKER 1 regression: a backup WRITE FAILURE must be loud and must not
 # --- be summarised as success (john-the-dev #2476). Force it the way the
 # --- reviewer did: make the backup's parent dir a regular FILE.


### PR DESCRIPTION
Closes the data-loss half of the vault-sync report (`ce86a2e4`): `data/task-workstreams.json` disappearing fleet-wide.

## The defect

`_resolve_conflicts_keep_ours` resolves a delete/delete conflict with `git rm -f`, which removes the **working-tree** file. That path can still hold live local state:

1. `_enforce_carrier_set_pre` untracks anything outside this host's carrier set with `git rm --cached`. Bytes stay on disk deliberately — its own message says so: *"content stays on disk; untrack propagates via vault"*.
2. That untrack is **committed**, so it propagates to peers.
3. A host whose carrier set differs merges a deletion for a path its own app is still writing. On the DD branch, `git rm -f` deletes the file.

Reported as the file vanishing (absent, not emptied) three times in ~35 min on one host, with only `task-workstreams.lock` left. `data/.workstream-backups` beside it survived every incident — it was never tracked, which is exactly the tracked-vs-untracked split the mechanism predicts.

This class already has a bespoke per-file rescue in this script (`_migrate_flat_anchor`, #2567/#2607, whose own comment says enforcement *"COMMITS that deletion"*). That is why the pattern was known and still recurred for each new path.

## The fix

Use `--cached` when the path still exists on disk: the index is resolved so the merge concludes, and bytes git no longer owns are left alone. The genuinely-absent case keeps `-f` unchanged.

## Evidence

The new fixture builds the DD index state with plumbing rather than a merge, **on purpose**: a plain delete/delete merges cleanly and leaves no unmerged path, so a merge-based fixture would "resolve" without ever entering the branch — a vacuous pass. Two guard assertions pin that it really is a DD conflict and really does take the fallback.

At the parent commit (`scripts/sync-workspace.sh` from `origin/main`, new test kept):

```
  FAIL THE POINT: a DD path that still exists on disk is NOT deleted
  FAIL DD+on-disk: the local bytes are intact, not just the path
  ok   control: an absent DD path still resolves (the -f branch is untouched)

sync conflict preserves theirs: 17 passed, 2 failed
```

At this HEAD:

```
  ok   fixture really IS a DD conflict (guards against a vacuous pass)
  ok   fixture really takes the fallback (--ours fails on DD, as the comment says)
  ok   DD+on-disk: conflict is resolved, so the merge can still conclude
  ok   THE POINT: a DD path that still exists on disk is NOT deleted
  ok   DD+on-disk: the local bytes are intact, not just the path
  ok   control: an absent DD path still resolves (the -f branch is untouched)

sync conflict preserves theirs: 19 passed, 0 failed
PASS — sync-workspace conflict fallback preserves the discarded side
```

The control passes in **both** columns, so the two failures are the assertions discriminating rather than the fixture failing everything.

## Scope — what this does NOT do

This stops the data loss. It does **not** fix the underlying carrier-set divergence between hosts, which is the structural cause: per-host carrier config with a fleet-wide effect, so two hosts with differing sets oscillate — one untracks each tick, the other re-adds. The report's suggested structural fix (refuse to untrack-and-propagate a path a peer branch still tracks, or require carrier sets to agree) is a separate and larger change, and I would rather it be reviewed on its own than smuggled in here.

I also did not touch the tripwires. The report notes a single-file deletion slips both the `>50` absolute and the `>=50%` pull checks, and that `checkout -B` runs before the pre-pull snapshot. Both are real and both are out of scope for this one.
