### PR TITLE
fix(report-feedback): sendLogs defaults OFF — absence of a prefs file is not consent

### DIFF
--- a/skills/report-feedback/SKILL.md
+++ b/skills/report-feedback/SKILL.md
@@ -29,10 +29,12 @@ python3 skills/report-feedback/report-feedback.py \
 
 When **you** (not the user) determine that a bug or error is caused by Sutando itself or AG2 Space — engine services, bridges, the desktop app, AG2 Space connectivity, or the AG2 cloud — file it automatically with `--auto`. Never `--auto`-file problems in the user's own projects or code, third-party tools/sites/APIs, or expected failures (bad input, credentials the owner simply hasn't provided).
 
-`--auto` enforces the owner's Settings toggles (read from `<workspace>/state/feedback-prefs.json`, written by the desktop app; both default ON when the file is absent):
+`--auto` enforces the owner's Settings toggles (read from `<workspace>/state/feedback-prefs.json`, written by the desktop app). When the file is absent the two defaults differ:
 
-- **File automatic bug reports** off → the script prints `SKIPPED` and exits 3. Respect it — do not retry or route around it.
-- **Send logs with bug reports** off → the log excerpt is omitted from every report (auto and manual), same as `--no-logs`.
+- **File automatic bug reports** — defaults **ON**. Off → the script prints `SKIPPED` and exits 3. Respect it — do not retry or route around it.
+- **Send logs with bug reports** — defaults **OFF**, i.e. opt-in. Off → the log excerpt is omitted from every report (auto and manual), same as `--no-logs`.
+
+The split is deliberate. Absence of the file must not disable reporting on installs that predate the toggles, but absence is not consent either, and the log excerpt is the part that carries incidental owner data — paths containing usernames, hostnames, workspace content. An owner who has never opened Settings ships no logs.
 
 Auto reports are also deduped (an identical title within 24h) and rate-limited (5 per 24h) via `<workspace>/state/feedback-auto-reports.json`. A `SKIPPED` exit (3) is a normal outcome, not an error — just move on. After filing an auto report, tell the owner in one short sentence (e.g. "I've filed a bug report about this"); the Settings toggle is the consent surface, so don't ask permission first.
 

--- a/skills/report-feedback/report-feedback.py
+++ b/skills/report-feedback/report-feedback.py
@@ -46,7 +46,9 @@ RETIRED_CLOUD_ORIGINS = ("https://sutando.ag2.ai",)
 SIGNED_OUT_SENTINEL = "__signed_out__"
 
 # Owner prefs written by the desktop Settings UI (host is the single writer).
-PREFS_DEFAULTS = {"autoReport": True, "sendLogs": True}
+# autoReport defaults ON; sendLogs defaults OFF. The log excerpt is the part
+# that carries incidental owner data, so it is opt-in rather than opt-out.
+PREFS_DEFAULTS = {"autoReport": True, "sendLogs": False}
 # Auto-report throttle state (this script is the single writer).
 AUTO_STATE_FILE = "feedback-auto-reports.json"
 AUTO_DEDUPE_WINDOW_S = 24 * 3600
@@ -243,8 +245,13 @@ def read_prefs(ws: Path) -> dict:
 
     Written by the desktop Settings toggles ("File automatic bug reports",
     "Send logs with bug reports"). Missing file, missing key, or a non-bool
-    value all read as the default (both ON) — absence of the file must never
-    disable reporting on installs that predate the toggles.
+    value all read as PREFS_DEFAULTS: autoReport ON, sendLogs OFF.
+
+    The two defaults differ on purpose. Absence of the file must never disable
+    REPORTING on installs that predate the toggles. But absence is not consent
+    either, and the log excerpt is the part that carries incidental owner data
+    (paths with usernames, hostnames, workspace content), so it is opt-in: an
+    owner who has never opened Settings ships no logs.
     """
     prefs = dict(PREFS_DEFAULTS)
     try:
@@ -408,8 +415,8 @@ def main() -> None:
             ctx["last_logs_excerpt"] = excerpt
             ctx["log_files"] = names
         else:
-            # Logs are on by default, so silence here is indistinguishable from
-            # a report that never wanted them. Say why they are absent.
+            # sendLogs is opt-in, so reaching here means logs were asked for:
+            # say why they are absent rather than shipping silence.
             ctx["logs_omitted"] = why_no_logs(ws)
 
     payload = {

--- a/skills/report-feedback/report-feedback.py
+++ b/skills/report-feedback/report-feedback.py
@@ -418,6 +418,10 @@ def main() -> None:
             # sendLogs is opt-in, so reaching here means logs were asked for:
             # say why they are absent rather than shipping silence.
             ctx["logs_omitted"] = why_no_logs(ws)
+    elif not prefs["sendLogs"]:
+        # Without this the payload carries NEITHER key and triage cannot tell a
+        # standing opt-out from logs that were wanted and missing. Carries no data.
+        ctx["logs_opted_out"] = True
 
     payload = {
         "kind": a.kind,

--- a/tests/report-feedback.test.py
+++ b/tests/report-feedback.test.py
@@ -232,11 +232,12 @@ class TestKeychainAuth(unittest.TestCase):
 
 
 class TestPrefs(unittest.TestCase):
-    def test_missing_file_defaults_both_on(self):
+    def test_missing_file_reports_but_sends_no_logs(self):
+        # Absence is not consent: reporting still works, the excerpt does not.
         with tempfile.TemporaryDirectory() as td:
             self.assertEqual(
                 report_feedback.read_prefs(Path(td)),
-                {"autoReport": True, "sendLogs": True},
+                {"autoReport": True, "sendLogs": False},
             )
 
     def test_reads_written_values(self):
@@ -257,9 +258,11 @@ class TestPrefs(unittest.TestCase):
             (ws / "state").mkdir()
             p = ws / "state" / "feedback-prefs.json"
             p.write_text("{not json")
-            self.assertEqual(report_feedback.read_prefs(ws), {"autoReport": True, "sendLogs": True})
-            p.write_text(json.dumps({"autoReport": "no", "sendLogs": False}))
             self.assertEqual(report_feedback.read_prefs(ws), {"autoReport": True, "sendLogs": False})
+            # Each key falls back to its OWN default, and an explicit True for
+            # sendLogs must still be honoured or the opt-in is unusable.
+            p.write_text(json.dumps({"autoReport": "no", "sendLogs": True}))
+            self.assertEqual(report_feedback.read_prefs(ws), {"autoReport": True, "sendLogs": True})
 
 
 class TestAutoGate(unittest.TestCase):
@@ -485,10 +488,23 @@ class TestMain(unittest.TestCase):
             self._run(argv)
         return seen["ctx"]
 
+    @staticmethod
+    def _opt_in_to_logs(ws: Path) -> None:
+        """sendLogs is opt-in, so a test ABOUT the excerpt must ask for it.
+
+        These two cover the excerpt/omission-note logic, not the default. They
+        used to rely on sendLogs defaulting ON, which made them silently depend
+        on a policy they were not testing.
+        """
+        (ws / "state").mkdir(parents=True, exist_ok=True)
+        (ws / "state" / "feedback-prefs.json").write_text(json.dumps({"sendLogs": True}))
+
     def test_absent_logs_are_explained_in_the_posted_context(self):
         """THE BUG: Odoo tickets carried exactly {source, platform, python}."""
         with tempfile.TemporaryDirectory() as td:
-            ctx = self._posted_context(["--title", "hello"], Path(td))
+            ws = Path(td)
+            self._opt_in_to_logs(ws)
+            ctx = self._posted_context(["--title", "hello"], ws)
         self.assertNotIn("last_logs_excerpt", ctx)
         self.assertIn("logs_omitted", ctx)
         self.assertIn("no logs directory", ctx["logs_omitted"])
@@ -497,11 +513,22 @@ class TestMain(unittest.TestCase):
         """Mutation guard: the note must not fire when logs actually shipped."""
         with tempfile.TemporaryDirectory() as td:
             ws = Path(td)
+            self._opt_in_to_logs(ws)
             (ws / "logs").mkdir()
             (ws / "logs" / "a.log").write_text("hello\n")
             ctx = self._posted_context(["--title", "hello"], ws)
         self.assertIn("last_logs_excerpt", ctx)
         self.assertNotIn("logs_omitted", ctx)
+
+    def test_default_prefs_ship_no_logs_even_when_logs_exist(self):
+        """The point of the change: no prefs file -> no excerpt, logs present."""
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            (ws / "logs").mkdir()
+            (ws / "logs" / "a.log").write_text("hello\n")
+            ctx = self._posted_context(["--title", "hello"], ws)
+        self.assertNotIn("last_logs_excerpt", ctx)
+        self.assertNotIn("log_files", ctx)
 
     def test_no_logs_flag_is_not_an_omission_to_explain(self):
         """--no-logs is the user's choice, not a failure to report."""

--- a/tests/report-feedback.test.py
+++ b/tests/report-feedback.test.py
@@ -530,6 +530,27 @@ class TestMain(unittest.TestCase):
         self.assertNotIn("last_logs_excerpt", ctx)
         self.assertNotIn("log_files", ctx)
 
+    def test_opt_out_is_stated_so_triage_can_tell_it_from_missing_logs(self):
+        # Silence is ambiguous: withheld consent and absent logs look identical.
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            (ws / "logs").mkdir()
+            (ws / "logs" / "a.log").write_text("hello\n")
+            ctx = self._posted_context(["--title", "hello"], ws)
+        self.assertIs(ctx.get("logs_opted_out"), True)
+        self.assertNotIn("logs_omitted", ctx)
+
+    def test_opt_in_never_claims_an_opt_out(self):
+        """Mutation guard: the marker must not fire when logs were requested."""
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            self._opt_in_to_logs(ws)
+            (ws / "logs").mkdir()
+            (ws / "logs" / "a.log").write_text("hello\n")
+            ctx = self._posted_context(["--title", "hello"], ws)
+        self.assertNotIn("logs_opted_out", ctx)
+        self.assertIn("last_logs_excerpt", ctx)
+
     def test_no_logs_flag_is_not_an_omission_to_explain(self):
         """--no-logs is the user's choice, not a failure to report."""
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Owner-requested. Follow-up to an audit of what the auto-filed reports in `#product-feedback` actually carry.

## The defect

`PREFS_DEFAULTS` read **both** toggles as ON when `<workspace>/state/feedback-prefs.json` is absent — and the file is absent on any host where nobody has opened Settings. Measured on a live host:

```
report-feedback.py:49   PREFS_DEFAULTS = {"autoReport": True, "sendLogs": True}
grep -c 'input(|confirm|approve'  ->  0
state/feedback-prefs.json         ->  ABSENT
```

So the log excerpt — the part that carries incidental owner data — shipped on a default nobody chose.

**This is not a rule being broken.** The script has no approval prompts *by design*: `SKILL.md` and `CLAUDE.md` both say the Settings toggle is the consent surface and the agent should not ask per report. The problem is narrower and worth stating precisely: a never-touched default was standing in for that consent.

What the reports carry, read from `#product-feedback` (a **public** channel): macOS usernames inside absolute paths quoted as evidence, hostnames, each reporter's email, a call SID — and in at least one report a verbatim line of owner activity from a `daily-insight` run ("You've created 8 notes in the last 7 days…"), which is content rather than fingerprint.

## The change

`autoReport` stays **ON** — absence must not disable reporting on installs that predate the toggles. `sendLogs` becomes **opt-in**. The two defaults now differ deliberately and the docstring says why.

## Evidence

At the parent commit (`report-feedback.py` from `origin/main`, new tests kept):

```
FAIL: test_default_prefs_ship_no_logs_even_when_logs_exist
FAIL: test_corrupt_or_nonbool_values_fall_back_to_defaults
FAIL: test_missing_file_reports_but_sends_no_logs
Ran 53 tests
FAILED (failures=3)
```

At this HEAD:

```
Ran 53 tests in 0.065s
OK
```

## A note on two tests I had to touch

`test_absent_logs_are_explained_in_the_posted_context` and `test_present_logs_carry_no_omission_note` began failing under the new default. They are about the excerpt and omission-note logic, **not** about the default — they had silently depended on `sendLogs` being ON. They now write `{"sendLogs": true}` explicitly.

That is deliberately not the same as loosening them: they pass in **both** columns above, so they no longer depend on which policy is in force. Only the three tests that are genuinely *about* the default flip between the columns.

## For the desktop side (not in this repo)

The host app is the single writer of `feedback-prefs.json`. `grep` for `sendLogs` across `*.swift` here returns nothing, so the Settings UI lives elsewhere. **If that toggle renders pre-checked, it should default unchecked to match** — otherwise the UI claims a state the engine no longer applies, which is a worse failure than either default alone.

## Not included

I did not change redaction. Usernames and hostnames still appear in report bodies that owners write by hand, and normalising those at the report boundary is a separate change with its own tradeoffs.
