### PR TITLE
docs(task-workstream-grouping): derive ranker keywords per task, not once per batch

### DIFF
--- a/skills/task-workstream-grouping/SKILL.md
+++ b/skills/task-workstream-grouping/SKILL.md
@@ -41,6 +41,18 @@ labels.
      unrelated roadmap workstream, after five earlier passes had looked correct —
      those five all had wide margins, so the streak was evidence about the
      inputs, not about the method.
+
+     **Derive `keywords` from the task being classified, inside the per-task
+     loop.** Hoisting one keyword list out of the loop is the mistake this
+     parameter invites, and it is silent: `best_match` then scores the same fixed
+     query against the workstream field on every iteration, so every task in the
+     batch gets a byte-identical ranking and no task title is ever read. The call
+     still returns well-formed ids and margins, and the shortlist still prints.
+     The only tell is two unrelated tasks scoring identically — easy to miss when
+     the answer is `None`, because a refusal is what a careful classifier looks
+     like. Both arguments fail this way: a degenerate input to either one yields
+     a well-formed refusal rather than an error, so neither can be caught by
+     checking that the call succeeded.
 4. Submit strict JSON to the validator:
 
    ```bash


### PR DESCRIPTION
## The defect

`best_match(candidates, keywords)` takes the query as a parameter, which invites hoisting it out of the per-task loop — one keyword list built once, reused for every task in the batch. Nothing rejects that. `best_match` scores the same fixed query against the workstream field on every iteration, so **every task gets a byte-identical ranking and no task title is ever read**, while the ids, the margins, and the printed shortlist all look exactly like a working classifier.

## Evidence — from a live run, not a constructed case

I hit this myself on today's grouping pass (snapshot `f11e5c37…`, then `a1e429ad…` on retry). I passed a fixed keyword list. Two unrelated tasks — a `pending-questions` cron fire and an ag2space dev-room game utterance — produced this:

```
TASK task-cron-pending-questions-1788373803311
   score=5 workstream-pending-questions-monitoring-5929334a
   score=4 workstream-recurring-ops-crons-fb14da77
   score=1 workstream-ag2-space-game-conversations-3835300c
   score=1 workstream-agent-landscape-digest-c150689a
   best_match -> None

TASK task-dev_dag2_dspace~task-3177476a5cf46682b0
   score=5 workstream-pending-questions-monitoring-5929334a
   score=4 workstream-recurring-ops-crons-fb14da77
   score=1 workstream-ag2-space-game-conversations-3835300c
   score=1 workstream-agent-landscape-digest-c150689a
   best_match -> None
```

Identical scores, identical ordering, identical refusal — for a cron fire and a game conversation. Note the second task is a *game-room utterance* and `workstream-ag2-space-game-conversations` scored 1, below two pending-questions workstreams, because the query never mentioned the task.

`apply` returned rc=0 with `{"assigned": 0, ...}`. The outcome was safe — both tasks stayed ungrouped, which is the conservative answer — but it was reached without reading either task.

## Why it survives every cheap check

The margin rule from #3470 makes `None` the *expected* output of a careful classifier, so a degenerate query that refuses everything is indistinguishable from correct low-confidence behaviour. There is no exception, no empty result, and no malformed value — checking that the call succeeded cannot catch it.

This is the same failure shape as #3598 (approved), which covers the *other* argument: a `candidates` list built with the wrong key yields empty text, every score collapses to 0, and `best_match` again refuses everything. Both arguments degrade into a well-formed refusal. #3598 closes its half with a helper (`candidates_from_snapshot`) so the choice cannot be made wrongly; `keywords` has no equivalent, because the correct value is inherently per-task and can only come from the caller's loop.

## Scope

Docs only — one paragraph in the skill the classifier reads on every pass. No code, no behaviour change, no test, because there is nothing here to assert against: the defect is in how a correct API gets called.

**Not stacked on #3598**, though they are siblings. I deliberately placed this paragraph at the *end* of the ranker bullet rather than at #3598's insertion point, so the two merge cleanly in either order.
