### PR TITLE
fix(core-supervisor): classify the Claude usage-limit screen as its own gate, not a login

### DIFF
--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -113,7 +113,7 @@ def _load_runtime_health():
 # stuck at so ESCALATE can show the prompt and AUTO-ANSWER can decide.
 _SIGNATURES = [
     # First: the limit screen often sits below stale /login text in the same pane.
-    ("session-limit", re.compile(r"hit your (?:session|usage|weekly) limit|/usage-credits", re.I)),
+    ("session-limit", re.compile(r"hit your (?:session|usage|weekly) limit", re.I)),
     ("folder-trust", re.compile(r"trust the files in this folder|Do you trust", re.I)),
     ("bypass-permissions", re.compile(r"Bypass Permissions mode|Yes, I accept", re.I)),
     ("login", re.compile(r"Select login method|Paste code here|Browser didn'?t open", re.I)),

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -112,7 +112,6 @@ def _load_runtime_health():
 # the net-new layer over runtime-health: it identifies WHICH gate the core is
 # stuck at so ESCALATE can show the prompt and AUTO-ANSWER can decide.
 _SIGNATURES = [
-    # First: the limit screen often sits below stale /login text in the same pane.
     ("session-limit", re.compile(r"hit your (?:session|usage|weekly) limit", re.I)),
     ("folder-trust", re.compile(r"trust the files in this folder|Do you trust", re.I)),
     ("bypass-permissions", re.compile(r"Bypass Permissions mode|Yes, I accept", re.I)),
@@ -175,9 +174,11 @@ def classify(pane: str):
     # footer itself matches none of the signatures, so idle still suppresses.)
     if _IDLE.search(tail) and not any(rx.search(tail) for _, rx in _SIGNATURES):
         return None
-    for kind, rx in _SIGNATURES:
-        if rx.search(tail):
-            return kind, tail
+    # Two gates in one pane (one in scrollback): the live one is nearest the bottom.
+    hits = [(m.start(), i, kind) for i, (kind, rx) in enumerate(_SIGNATURES)
+            for m in [max(rx.finditer(tail), key=lambda m: m.start(), default=None)] if m]
+    if hits:
+        return max(hits, key=lambda h: (h[0], -h[1]))[2], tail
     # No specific signature — but an input affordance IS present and this is NOT
     # the idle prompt. That means an UNFORESEEN prompt. Surface it rather than
     # leave a silent dead-end (owner's no-dead-end requirement 2026-07-14): we

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -112,6 +112,8 @@ def _load_runtime_health():
 # the net-new layer over runtime-health: it identifies WHICH gate the core is
 # stuck at so ESCALATE can show the prompt and AUTO-ANSWER can decide.
 _SIGNATURES = [
+    # First: the limit screen often sits below stale /login text in the same pane.
+    ("session-limit", re.compile(r"hit your (?:session|usage|weekly) limit|/usage-credits", re.I)),
     ("folder-trust", re.compile(r"trust the files in this folder|Do you trust", re.I)),
     ("bypass-permissions", re.compile(r"Bypass Permissions mode|Yes, I accept", re.I)),
     ("login", re.compile(r"Select login method|Paste code here|Browser didn'?t open", re.I)),
@@ -120,12 +122,13 @@ _SIGNATURES = [
     ("permission", re.compile(r"Do you want to (proceed|allow)|Allow this action|permission to", re.I)),
 ]
 _AWAIT_HINT = re.compile(
-    r"Esc to cancel|Enter to confirm|Press Enter|Paste code|to accept|❯\s*\d+\.", re.I)
+    r"Esc to cancel|Enter to confirm|Press Enter|Paste code|to accept|Continuing automatically|❯\s*\d+\.", re.I)
 _IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
 
 # Gates that need a human (can't be auto-answered): login + any unrecognized
 # selection/permission. The rest (trust/bypass/press-enter) are known-safe.
-_HUMAN_GATES = {"login", "selection", "permission", "unknown"}
+# session-limit is a spend/wait decision: never auto-answered, never a login.
+_HUMAN_GATES = {"login", "selection", "permission", "session-limit", "unknown"}
 
 # --- M4 AUTO-ANSWER decision (Layer 2), PURE + report-only. -----------------
 # This returns WHICH keystroke would safely dismiss a gate; it does NOT send it —

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -83,6 +83,18 @@ def _is_login_class(signal: dict) -> bool:
     return signal.get("state") == "logged-out" or signal.get("kind") == "login"
 
 
+_RESET_AT = re.compile(r"resets?\s+(?:at\s+)?(\d{1,2}(?::\d{2})?\s*[ap]m)", re.I)
+
+
+def _limit_remedy(signal: dict) -> str:
+    """A usage-limit screen resumes by itself; /login cannot clear it."""
+    m = _RESET_AT.search(signal.get("prompt") or "")
+    when = f"at {m.group(1)}" if m else "when the limit window resets"
+    return (f" — the core hit its Claude usage limit, not a login problem; it resumes"
+            f" on its own {when}. Nothing to do unless you want it sooner: at the"
+            " core's terminal, /usage-credits spends credits now and Esc stops the wait.")
+
+
 #: A record older than this is a core that stopped beating; the socket it names
 #: may no longer exist, so pointing the owner at it is worse than generic phrasing.
 _ALIVE_STALE_SEC = 90
@@ -144,7 +156,9 @@ def compose_message(signal: dict) -> str:
         # The remedy is the actionable half, so it keeps its length; the prompt
         # echo is what gives way to stay inside the message-length bound.
         msg += f": {excerpt[:110]}"
-    if _is_login_class(signal):
+    if signal.get("kind") == "session-limit":
+        msg += _limit_remedy(signal)
+    elif _is_login_class(signal):
         host = _core_host_label() or "the host"
         msg += (f" — needs GUI /login on {host}: open Terminal there, run"
                 " `bash src/restart.sh` from the repo, then complete /login."

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -106,6 +106,12 @@ class TestClassify(unittest.TestCase):
         pane = _LOGIN_MENU + "\n" + _SESSION_LIMIT
         self.assertEqual(classify(pane)[0], "session-limit")
 
+    def test_stale_usage_credits_text_does_not_outrank_a_live_login_gate(self):
+        # The symmetric twin (rui, #3730 review): the limit signature sits above
+        # login, so a bare /usage-credits mention must not carry a login screen.
+        pane = "     /usage-credits to finish what you're working on.\n" + _LOGIN_MENU
+        self.assertEqual(classify(pane)[0], "login")
+
     def test_session_limit_is_a_human_gate_never_auto_answered(self):
         st, detail, _p, kind = compose_state(_SESSION_LIMIT, "working", True)
         self.assertEqual((st, kind), ("blocked-human", "session-limit"))

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -106,10 +106,10 @@ class TestClassify(unittest.TestCase):
         pane = _LOGIN_MENU + "\n" + _SESSION_LIMIT
         self.assertEqual(classify(pane)[0], "session-limit")
 
-    def test_stale_usage_credits_text_does_not_outrank_a_live_login_gate(self):
-        # The symmetric twin (rui, #3730 review): the limit signature sits above
-        # login, so a bare /usage-credits mention must not carry a login screen.
-        pane = "     /usage-credits to finish what you're working on.\n" + _LOGIN_MENU
+    def test_stale_limit_text_does_not_outrank_a_live_login_gate(self):
+        # The symmetric twin (rui + sonichi, #3730): a full limit screen left in
+        # scrollback above a live login menu; the live gate is the lower one.
+        pane = _SESSION_LIMIT + "\n" + _LOGIN_MENU
         self.assertEqual(classify(pane)[0], "login")
 
     def test_session_limit_is_a_human_gate_never_auto_answered(self):

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -40,6 +40,13 @@ _IDLE = ("──────── sutando-core ──\n❯ \n──────
          "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents")
 _IDLE_LOGGEDOUT = _IDLE + "\n     Not logged in · Run /login"
 _WORKING = ("⏺ Bash(WS=... echo WORKSPACE=...)\n  ⎿  WORKSPACE=/Users/x\n     HOST=mini\n     … +39 lines")
+# The usage-limit screen (owner screenshot 2026-09-02, Qingyuns-MacBook-Pro core):
+# a wait/spend decision that the relay had been reporting as a LOGIN gate.
+_SESSION_LIMIT = ("● Monitor event: \"Streaming task watcher\"\n"
+                  "  ⎿  You've hit your session limit · resets 12:10pm\n"
+                  "     (America/Los_Angeles)\n"
+                  "     /usage-credits to finish what you're working on.\n"
+                  "  Continuing automatically at 12:10pm · esc to cancel")
 # A real mid-session permission prompt rendered ABOVE the persistent idle footer
 # (review repro 2026-07-14). The footer's await-affordance must NOT suppress it.
 _PERMISSION_WITH_FOOTER = (
@@ -89,6 +96,21 @@ class TestClassify(unittest.TestCase):
         idle_hint = ("  ⏵⏵ bypass permissions on (shift+tab to cycle) · "
                      "press tab to accept · ← for agents")
         self.assertIsNone(classify(idle_hint))
+
+    def test_session_limit_flags_as_its_own_kind(self):
+        self.assertEqual(classify(_SESSION_LIMIT)[0], "session-limit")
+
+    def test_session_limit_wins_over_stale_login_text_above_it(self):
+        # The live misfire: an earlier /login menu still in the pane scrollback
+        # made the limit screen read as "login". The limit must win.
+        pane = _LOGIN_MENU + "\n" + _SESSION_LIMIT
+        self.assertEqual(classify(pane)[0], "session-limit")
+
+    def test_session_limit_is_a_human_gate_never_auto_answered(self):
+        st, detail, _p, kind = compose_state(_SESSION_LIMIT, "working", True)
+        self.assertEqual((st, kind), ("blocked-human", "session-limit"))
+        self.assertIn("session-limit", detail)
+        self.assertIsNone(auto_answer("session-limit"))
 
     def test_unforeseen_prompt_surfaces_as_unknown(self):
         # No matching signature, but an input affordance is present and it is NOT

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -36,6 +36,11 @@ import channel_env_containment  # noqa: E402 — the shared module the probe del
 
 _LOGIN = {"state": "blocked-human", "detail": "awaiting user: login",
           "prompt": "Login\nSelect login method:\n  1. Claude account", "kind": "login"}
+_LIMIT = {"state": "blocked-human", "detail": "awaiting user: session-limit",
+          "prompt": "You've hit your session limit · resets 12:10pm\n"
+                    "/usage-credits to finish what you're working on.\n"
+                    "Continuing automatically at 12:10pm · esc to cancel",
+          "kind": "session-limit"}
 _LOGGED_OUT = {"state": "logged-out", "detail": "core not authenticated (needs /login)",
                "prompt": None, "kind": None}
 _IDLE = {"state": "idle-ready", "detail": "ready for a task", "prompt": None, "kind": None}
@@ -143,6 +148,22 @@ class TestComposeMessage(unittest.TestCase):
         m = compose_message(_LOGIN)
         self.assertIn("GUI /login", m)
         self.assertNotIn("reply here or open the app", m)
+
+    def test_session_limit_escalates(self):
+        self.assertTrue(should_escalate(_LIMIT, None)[0])
+
+    def test_session_limit_names_the_reset_time_not_login(self):
+        m = compose_message(_LIMIT)
+        self.assertIn("resumes on its own at 12:10pm", m)
+        self.assertIn("/usage-credits", m)
+        self.assertNotIn("/login", m)
+        self.assertNotIn("restart.sh", m)
+
+    def test_session_limit_without_a_reset_time_still_avoids_login(self):
+        sig = dict(_LIMIT, prompt="You've hit your session limit")
+        m = compose_message(sig)
+        self.assertIn("when the limit window resets", m)
+        self.assertNotIn("/login", m)
 
     def test_non_login_blocker_names_the_cli_terminal(self):
         """A `blocked-human` prompt waits on the core's stdin. Neither a chat reply


### PR DESCRIPTION
## What

The core's pane watcher had no signature for Claude Code's usage-limit screen, so the supervisor relay reported it as a **login** gate and told the owner to restart + `/login`. That remedy cannot clear a quota limit; the screen resumes on its own at the reset time, and the only real choices are wait, `/usage-credits`, or Esc.

Live case (owner screenshot, 2026-09-02, a core on another host):

> ⚠️ Agent needs you — awaiting user: login: Continuing automatically at 12:10pm · esc to cancel — needs GUI /login on …: open Terminal there, run `bash src/restart.sh` from the repo, then complete /login. A chat reply can't resolve this.

while the pane read:

```
⎿  You've hit your session limit · resets 12:10pm
   (America/Los_Angeles)
   /usage-credits to finish what you're working on.
Continuing automatically at 12:10pm · esc to cancel
```

## Change

- `src/core-input-watch.py`: new `session-limit` signature, placed **first** in `_SIGNATURES` so `/login` text left in the scrollback cannot outrank it; `Continuing automatically` added to `_AWAIT_HINT`; `session-limit` added to `_HUMAN_GATES` (never auto-answered — spending credits is the owner's call).
- `src/core-supervisor-relay.py`: `compose_message` branches on `kind == "session-limit"` before the login branch and appends a remedy that parses the reset time from the prompt (`_RESET_AT`) and says it is not a login problem. The `/login` remedy is unreachable for this kind.

Single concern; no prompt or tool behaviour changed elsewhere.

## Evidence

Fixture in the tests is the pane text from the screenshot.

With the fix (HEAD):
```
$ python3 tests/core-input-watch.test.py     -> Ran 32 tests  OK
$ python3 tests/core-supervisor-relay.test.py -> Ran 60 tests  OK
```

Mutation control — `src/` reverted to `origin/main`, new tests kept:
```
FAIL: test_session_limit_flags_as_its_own_kind
FAIL: test_session_limit_is_a_human_gate_never_auto_answered
FAIL: test_session_limit_wins_over_stale_login_text_above_it
Ran 32 tests  FAILED (failures=3)
FAIL: test_session_limit_names_the_reset_time_not_login
FAIL: test_session_limit_without_a_reset_time_still_avoids_login
Ran 60 tests  FAILED (failures=2)
```

Gates run locally against `origin/main`:
```
$ git diff origin/main | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
$ diff-cover coverage.xml --compare-branch=origin/main --fail-under=95
Total: 9 lines  Missing: 0 lines  Coverage: 100%
```

Not a live-path change (no bridge/network/startup), so no post-restart round trip is included; the relay's DRY-RUN output in the suite still renders the login remedy for the login fixture, unchanged.

## Follow-up (not in this PR)

Projecting this gate as a HITL card with Wait / Use credits / Stop actions rides the `space.ag2.hitl` path from #3705 (`billing` kind) and the #488 keystroke executor; tracked on the owner's E2E-without-terminal ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
