### PR TITLE
fix(sparrow): resolve the relay host via the system nameserver when the OS resolver returns a negative answer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
           timeout -k 5 120 python3 src/remote-gateway-bridge.test.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_gateway_status.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_dns_timeout.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_dns_fallback.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_ack_retry.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_inflight_recovery.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_write_task_atomic.py

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -143,8 +143,128 @@ def _resolve_bounded(host, *args, **kwargs):
     return call.result
 
 
+# Resolver fallback: the OS cache can hold a stuck negative answer for the relay
+# host while the configured nameserver still resolves it — ask that one directly.
+_FALLBACK_TTL_S = float(os.environ.get("REMOTE_GATEWAY_DNS_FALLBACK_TTL") or "300")
+_FALLBACK_QUERY_TIMEOUT_S = 2.0
+_RESOLV_CONF = "/etc/resolv.conf"
+_fallback_cache: dict = {}  # host -> (expires_at_monotonic, [ip, ...])
+_fallback_lock = threading.Lock()
+
+
+def _system_nameservers(path=None):
+    """IPv4 nameservers from resolv.conf in file order; [] when unreadable."""
+    out = []
+    try:
+        with open(path or _RESOLV_CONF) as fh:
+            for ln in fh:
+                parts = ln.split()
+                if len(parts) >= 2 and parts[0] == "nameserver" and ":" not in parts[1]:
+                    out.append(parts[1])
+    except OSError:
+        pass
+    return out
+
+
+def _skip_name(data, i):
+    while True:
+        n = data[i]
+        if n == 0:
+            return i + 1
+        if n & 0xC0 == 0xC0:
+            return i + 2
+        i += 1 + n
+
+
+def _parse_a_records(data, qid):
+    """A-record IPs from one DNS response; [] on mismatch, error RCODE or junk."""
+    import struct
+    try:
+        rid, flags, qd, an, _ns, _ar = struct.unpack("!HHHHHH", data[:12])
+        if rid != qid or flags & 0x000F:
+            return []
+        i = 12
+        for _ in range(qd):
+            i = _skip_name(data, i) + 4
+        ips = []
+        for _ in range(an):
+            i = _skip_name(data, i)
+            rtype, _cls, _ttl, rdlen = struct.unpack("!HHIH", data[i:i + 10])
+            i += 10
+            if rtype == 1 and rdlen == 4:
+                ips.append(socket.inet_ntoa(data[i:i + 4]))
+            i += rdlen
+        return ips
+    except (IndexError, struct.error, OSError):
+        return []
+
+
+def _dns_a_query(host, nameserver, timeout=None, port=53):
+    """One UDP A query (RFC 1035), stdlib only; [] on any failure."""
+    import random
+    import struct
+    qid = random.randrange(1, 0xFFFF)
+    q = struct.pack("!HHHHHH", qid, 0x0100, 1, 0, 0, 0)
+    for label in host.rstrip(".").split("."):
+        b = label.encode("idna")
+        q += bytes([len(b)]) + b
+    q += b"\x00" + struct.pack("!HH", 1, 1)
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.settimeout(_FALLBACK_QUERY_TIMEOUT_S if timeout is None else timeout)
+        s.sendto(q, (nameserver, port))
+        data, _ = s.recvfrom(4096)
+    except OSError:
+        return []
+    finally:
+        s.close()
+    return _parse_a_records(data, qid)
+
+
+def _fallback_resolve(host):
+    """IPs for host via the system nameservers, cached; [] when none answers."""
+    now = time.monotonic()
+    with _fallback_lock:
+        hit = _fallback_cache.get(host)
+        if hit and hit[0] > now:
+            return list(hit[1])
+    for ns in _system_nameservers():
+        ips = _dns_a_query(host, ns)
+        if ips:
+            with _fallback_lock:
+                _fallback_cache[host] = (now + _FALLBACK_TTL_S, ips)
+            _log(f"system resolver failed for {host}; nameserver {ns} answered "
+                 f"{ips[0]} — using it for {_FALLBACK_TTL_S:.0f}s")
+            return ips
+    return []
+
+
+def _is_ip_literal(host):
+    for fam in (socket.AF_INET, socket.AF_INET6):
+        try:
+            socket.inet_pton(fam, host)
+            return True
+        except (OSError, TypeError, ValueError):
+            pass
+    return False
+
+
 def _getaddrinfo_prefer_v4(host, *args, **kwargs):
-    infos = _resolve_bounded(host, *args, **kwargs)
+    try:
+        infos = _resolve_bounded(host, *args, **kwargs)
+    except socket.gaierror as err:
+        ips = []
+        if isinstance(host, str) and host and not _is_ip_literal(host):
+            try:
+                ips = _fallback_resolve(host)
+            except Exception:  # noqa: BLE001 — fallback must never mask the gaierror
+                ips = []
+        if not ips:
+            raise err
+        infos = []
+        for ip in ips:
+            # A literal IP never touches DNS: this only shapes the tuples.
+            infos.extend(_orig_getaddrinfo(ip, *args, **kwargs))
     if _PREFER_V4 and host and "ag2.space" in str(host):
         v4 = [i for i in infos if i[0] == socket.AF_INET]
         return v4 or infos

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -153,7 +153,8 @@ _fallback_lock = threading.Lock()
 
 
 def _system_nameservers(path=None):
-    """IPv4 nameservers from resolv.conf in file order; [] when unreadable."""
+    """IPv4 nameservers from resolv.conf in file order; [] when unreadable.
+    IPv6 entries are skipped: the query socket is AF_INET only."""
     out = []
     try:
         with open(path or _RESOLV_CONF) as fh:
@@ -176,16 +177,28 @@ def _skip_name(data, i):
         i += 1 + n
 
 
-def _parse_a_records(data, qid):
-    """A-record IPs from one DNS response; [] on mismatch, error RCODE or junk."""
+def _encode_qname(host):
+    out = b""
+    for label in host.rstrip(".").split("."):
+        b = label.encode("idna")
+        out += bytes([len(b)]) + b
+    return out + b"\x00"
+
+
+def _parse_a_records(data, qid, qname=None):
+    """A-record IPs from one DNS response; [] unless id, QR bit, RCODE and
+    the echoed question all match what was asked."""
     import struct
     try:
         rid, flags, qd, an, _ns, _ar = struct.unpack("!HHHHHH", data[:12])
-        if rid != qid or flags & 0x000F:
+        if rid != qid or not flags & 0x8000 or flags & 0x000F:
             return []
         i = 12
         for _ in range(qd):
-            i = _skip_name(data, i) + 4
+            end = _skip_name(data, i)
+            if qname is not None and data[i:end].lower() != qname.lower():
+                return []
+            i = end + 4
         ips = []
         for _ in range(an):
             i = _skip_name(data, i)
@@ -201,24 +214,23 @@ def _parse_a_records(data, qid):
 
 def _dns_a_query(host, nameserver, timeout=None, port=53):
     """One UDP A query (RFC 1035), stdlib only; [] on any failure."""
-    import random
+    import secrets
     import struct
-    qid = random.randrange(1, 0xFFFF)
-    q = struct.pack("!HHHHHH", qid, 0x0100, 1, 0, 0, 0)
-    for label in host.rstrip(".").split("."):
-        b = label.encode("idna")
-        q += bytes([len(b)]) + b
-    q += b"\x00" + struct.pack("!HH", 1, 1)
+    qid = secrets.randbelow(0xFFFF) + 1
+    qname = _encode_qname(host)
+    q = struct.pack("!HHHHHH", qid, 0x0100, 1, 0, 0, 0) + qname + struct.pack("!HH", 1, 1)
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         s.settimeout(_FALLBACK_QUERY_TIMEOUT_S if timeout is None else timeout)
-        s.sendto(q, (nameserver, port))
-        data, _ = s.recvfrom(4096)
+        # connect(): the kernel then drops datagrams from any other peer.
+        s.connect((nameserver, port))
+        s.send(q)
+        data = s.recv(4096)
     except OSError:
         return []
     finally:
         s.close()
-    return _parse_a_records(data, qid)
+    return _parse_a_records(data, qid, qname)
 
 
 def _fallback_resolve(host):

--- a/packages/ag2-sparrow/tests/test_dns_fallback.py
+++ b/packages/ag2-sparrow/tests/test_dns_fallback.py
@@ -18,6 +18,7 @@ import struct
 import sys
 import tempfile
 import threading
+import time
 
 
 def _load():
@@ -42,7 +43,7 @@ def _restore(mod, saved):
         setattr(mod, k, v)
 
 
-def _response(qid, host, ips, *, rcode=0, cname=None):
+def _response(qid, host, ips, *, rcode=0, cname=None, qr=True):
     """Hand-built DNS response: question, optional CNAME, then A records that
     use a compression pointer back to the question name."""
     def name(h):
@@ -51,7 +52,7 @@ def _response(qid, host, ips, *, rcode=0, cname=None):
             out += bytes([len(label)]) + label.encode()
         return out + b"\x00"
     ancount = len(ips) + (1 if cname else 0)
-    r = struct.pack("!HHHHHH", qid, 0x8180 | rcode, 1, ancount, 0, 0)
+    r = struct.pack("!HHHHHH", qid, (0x8180 if qr else 0x0100) | rcode, 1, ancount, 0, 0)
     r += name(host) + struct.pack("!HH", 1, 1)
     ptr = b"\xc0\x0c"  # pointer to offset 12 = the question name
     if cname:
@@ -91,6 +92,12 @@ def test_parse_rejects_id_mismatch_error_rcode_and_junk():
     assert mod._parse_a_records(nx, 7) == [], "NXDOMAIN must not yield IPs"
     assert mod._parse_a_records(b"\x00\x07", 7) == []
     assert mod._parse_a_records(good[:20], 7) == [], "truncated answer must not raise"
+    query_echo = _response(7, "chat.ag2.space", ["1.2.3.4"], qr=False)
+    assert mod._parse_a_records(query_echo, 7) == [], "a query (QR=0) with a matching id is not a response"
+    other = _response(7, "evil.example", ["6.6.6.6"])
+    assert mod._parse_a_records(other, 7, mod._encode_qname("chat.ag2.space")) == [], \
+        "an answer for a different name must not be accepted for the asked one"
+    assert mod._parse_a_records(good, 7, mod._encode_qname("CHAT.ag2.space")) == ["1.2.3.4"], "QNAME match is case-insensitive"
     print("PASS test_parse_rejects_id_mismatch_error_rcode_and_junk")
 
 
@@ -185,6 +192,12 @@ def test_live_udp_query_against_a_local_nameserver():
     def serve():
         data, addr = srv.recvfrom(512)
         qid = struct.unpack("!H", data[:2])[0]
+        # Off-path first: a spoofed answer from a different source port must be dropped
+        # by the connected socket, so the real answer below is the one that lands.
+        rogue = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        rogue.sendto(_response(qid, "chat.ag2.space", ["6.6.6.6"]), addr)
+        rogue.close()
+        time.sleep(0.2)
         srv.sendto(_response(qid, "chat.ag2.space", ["104.26.15.112"]), addr)
 
     t = threading.Thread(target=serve, daemon=True)
@@ -194,7 +207,7 @@ def test_live_udp_query_against_a_local_nameserver():
     finally:
         t.join(5)
         srv.close()
-    assert got == ["104.26.15.112"], got
+    assert got == ["104.26.15.112"], f"off-path datagram was accepted: {got}"
     assert mod._dns_a_query("chat.ag2.space", "127.0.0.1", timeout=0.2, port=port) == [], \
         "a silent nameserver must yield [] within the timeout, never raise"
     print("PASS test_live_udp_query_against_a_local_nameserver")

--- a/packages/ag2-sparrow/tests/test_dns_fallback.py
+++ b/packages/ag2-sparrow/tests/test_dns_fallback.py
@@ -1,0 +1,237 @@
+"""Resolver fallback — when the OS resolver returns a negative answer for the
+relay host but the configured nameserver still resolves it, the bridge asks
+that nameserver directly and connects by IP (hostname kept for SNI/Host).
+
+Regression guard for the 2026-09-02 owner outage: macOS mDNSResponder held a
+stuck negative entry for chat.ag2.space for ~32 min while `dig @<resolver>`
+answered the whole time; the bridge log shows the same shape on 8 of the
+previous 14 days. No root flush should be needed for the bridge to recover.
+
+Plain-script convention (run as `python3 test_dns_fallback.py`), matching the
+other ag2-sparrow tests — no pytest.
+"""
+import importlib
+import os
+import pathlib
+import socket
+import struct
+import sys
+import tempfile
+import threading
+
+
+def _load():
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    mod = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+    mod = importlib.reload(mod)
+    mod._fallback_cache.clear()
+    return mod
+
+
+def _swap(mod, **attrs):
+    saved = {k: getattr(mod, k) for k in attrs}
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return saved
+
+
+def _restore(mod, saved):
+    for k, v in saved.items():
+        setattr(mod, k, v)
+
+
+def _response(qid, host, ips, *, rcode=0, cname=None):
+    """Hand-built DNS response: question, optional CNAME, then A records that
+    use a compression pointer back to the question name."""
+    def name(h):
+        out = b""
+        for label in h.split("."):
+            out += bytes([len(label)]) + label.encode()
+        return out + b"\x00"
+    ancount = len(ips) + (1 if cname else 0)
+    r = struct.pack("!HHHHHH", qid, 0x8180 | rcode, 1, ancount, 0, 0)
+    r += name(host) + struct.pack("!HH", 1, 1)
+    ptr = b"\xc0\x0c"  # pointer to offset 12 = the question name
+    if cname:
+        rdata = name(cname)
+        r += ptr + struct.pack("!HHIH", 5, 1, 60, len(rdata)) + rdata
+    for ip in ips:
+        r += ptr + struct.pack("!HHIH", 1, 1, 60, 4) + socket.inet_aton(ip)
+    return r
+
+
+def _gaierror(*a, **k):
+    raise socket.gaierror(8, "nodename nor servname provided, or not known")
+
+
+def _resolver_that_fails_names_only(host, *args, **kwargs):
+    """Stand-in for the OS resolver during the outage: names fail, literals work."""
+    try:
+        socket.inet_pton(socket.AF_INET, host)
+    except OSError:
+        _gaierror()
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (host, args[0] if args else 0))]
+
+
+def test_parse_a_records_follows_cname_and_compression():
+    mod = _load()
+    data = _response(0x1234, "chat.ag2.space", ["104.26.15.112", "172.67.72.17"],
+                     cname="chat.ag2.space.cdn.example")
+    assert mod._parse_a_records(data, 0x1234) == ["104.26.15.112", "172.67.72.17"]
+    print("PASS test_parse_a_records_follows_cname_and_compression")
+
+
+def test_parse_rejects_id_mismatch_error_rcode_and_junk():
+    mod = _load()
+    good = _response(7, "chat.ag2.space", ["1.2.3.4"])
+    assert mod._parse_a_records(good, 8) == [], "id mismatch must not yield IPs"
+    nx = _response(7, "chat.ag2.space", ["1.2.3.4"], rcode=3)
+    assert mod._parse_a_records(nx, 7) == [], "NXDOMAIN must not yield IPs"
+    assert mod._parse_a_records(b"\x00\x07", 7) == []
+    assert mod._parse_a_records(good[:20], 7) == [], "truncated answer must not raise"
+    print("PASS test_parse_rejects_id_mismatch_error_rcode_and_junk")
+
+
+def test_fallback_used_when_system_resolver_fails():
+    mod = _load()
+    saved = _swap(mod, _orig_getaddrinfo=_resolver_that_fails_names_only,
+                  _fallback_resolve=lambda host: ["104.26.15.112"])
+    try:
+        infos = mod._getaddrinfo_prefer_v4("chat.ag2.space", 443, 0, socket.SOCK_STREAM)
+    finally:
+        _restore(mod, saved)
+    assert infos and infos[0][4] == ("104.26.15.112", 443), infos
+    print("PASS test_fallback_used_when_system_resolver_fails")
+
+
+def test_original_error_reraised_when_fallback_has_nothing():
+    mod = _load()
+    saved = _swap(mod, _orig_getaddrinfo=_resolver_that_fails_names_only,
+                  _fallback_resolve=lambda host: [])
+    try:
+        try:
+            mod._getaddrinfo_prefer_v4("chat.ag2.space", 443)
+        except socket.gaierror as e:
+            assert e.args[0] == 8, e
+        else:
+            raise AssertionError("empty fallback must re-raise the resolver error")
+    finally:
+        _restore(mod, saved)
+    print("PASS test_original_error_reraised_when_fallback_has_nothing")
+
+
+def test_fallback_never_queried_for_ip_literals_or_on_success():
+    mod = _load()
+    calls = []
+    saved = _swap(mod, _orig_getaddrinfo=_resolver_that_fails_names_only,
+                  _fallback_resolve=lambda host: calls.append(host) or [])
+    try:
+        try:
+            mod._getaddrinfo_prefer_v4("::1", 443)
+        except socket.gaierror:
+            pass
+        assert calls == [], f"literal host must not hit the fallback: {calls}"
+        ok = mod._getaddrinfo_prefer_v4("104.26.15.112", 443)
+        assert ok[0][4][0] == "104.26.15.112" and calls == []
+    finally:
+        _restore(mod, saved)
+    print("PASS test_fallback_never_queried_for_ip_literals_or_on_success")
+
+
+def test_fallback_exception_does_not_mask_the_resolver_error():
+    mod = _load()
+
+    def boom(host):
+        raise RuntimeError("parser bug")
+
+    saved = _swap(mod, _orig_getaddrinfo=_resolver_that_fails_names_only, _fallback_resolve=boom)
+    try:
+        try:
+            mod._getaddrinfo_prefer_v4("chat.ag2.space", 443)
+        except socket.gaierror:
+            pass
+        else:
+            raise AssertionError("expected the original gaierror")
+    finally:
+        _restore(mod, saved)
+    print("PASS test_fallback_exception_does_not_mask_the_resolver_error")
+
+
+def test_nameservers_parsed_from_resolv_conf_v4_only_in_order():
+    mod = _load()
+    with tempfile.NamedTemporaryFile("w", suffix=".conf", delete=False) as fh:
+        fh.write("# comment\nsearch example.net\nnameserver 100.100.100.100\n"
+                 "nameserver fd7a:115c:a1e0::53\nnameserver 10.0.200.1\n")
+        path = fh.name
+    try:
+        assert mod._system_nameservers(path) == ["100.100.100.100", "10.0.200.1"]
+        assert mod._system_nameservers(path + ".missing") == []
+    finally:
+        os.unlink(path)
+    print("PASS test_nameservers_parsed_from_resolv_conf_v4_only_in_order")
+
+
+def test_live_udp_query_against_a_local_nameserver():
+    """The real socket path: a fake nameserver on 127.0.0.1 answers the query id
+    it receives with one A record."""
+    mod = _load()
+    srv = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.settimeout(5)
+    port = srv.getsockname()[1]
+
+    def serve():
+        data, addr = srv.recvfrom(512)
+        qid = struct.unpack("!H", data[:2])[0]
+        srv.sendto(_response(qid, "chat.ag2.space", ["104.26.15.112"]), addr)
+
+    t = threading.Thread(target=serve, daemon=True)
+    t.start()
+    try:
+        got = mod._dns_a_query("chat.ag2.space", "127.0.0.1", timeout=3, port=port)
+    finally:
+        t.join(5)
+        srv.close()
+    assert got == ["104.26.15.112"], got
+    assert mod._dns_a_query("chat.ag2.space", "127.0.0.1", timeout=0.2, port=port) == [], \
+        "a silent nameserver must yield [] within the timeout, never raise"
+    print("PASS test_live_udp_query_against_a_local_nameserver")
+
+
+def test_fallback_resolve_caches_for_ttl_and_tries_nameservers_in_order():
+    mod = _load()
+    queries = []
+
+    def fake_query(host, ns, timeout=None, port=53):
+        queries.append(ns)
+        return ["9.9.9.9"] if ns == "10.0.200.1" else []
+
+    saved = _swap(mod, _system_nameservers=lambda path=None: ["100.100.100.100", "10.0.200.1"],
+                  _dns_a_query=fake_query, _log=lambda m: None, _FALLBACK_TTL_S=60.0)
+    try:
+        assert mod._fallback_resolve("chat.ag2.space") == ["9.9.9.9"]
+        assert queries == ["100.100.100.100", "10.0.200.1"], queries
+        assert mod._fallback_resolve("chat.ag2.space") == ["9.9.9.9"]
+        assert len(queries) == 2, "second call within TTL must be served from cache"
+        mod._fallback_cache["chat.ag2.space"] = (0.0, ["9.9.9.9"])  # expired
+        mod._fallback_resolve("chat.ag2.space")
+        assert len(queries) == 4, "an expired entry must re-query"
+    finally:
+        _restore(mod, saved)
+        mod._fallback_cache.clear()
+    print("PASS test_fallback_resolve_caches_for_ttl_and_tries_nameservers_in_order")
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+            except Exception as e:  # noqa: BLE001 — report every failure
+                failures += 1
+                print(f"FAIL {name}: {type(e).__name__}: {e}")
+    print("ALL PASS" if not failures else f"{failures} FAILED")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## What

When the OS resolver holds a stuck negative answer for the relay host, the bridge now asks the system-configured nameserver directly and connects by IP. Owner-approved ("go with the product fix", 2026-09-02) over a per-host root cache flush.

## Why

Measured on one host, 2026-09-02, from `logs/remote-gateway-bridge.log`:

```
2026-09-02T02:21:41Z … poll network error: <urlopen error [Errno 8] nodename nor servname provided, or not known> — backing off 60s
… (every 60s until 02:53:43Z, then again 18:02:47Z → 18:35:14Z)
```

During the outage, on the same machine:

```
$ python3 -c "import socket;print(socket.gethostbyname('chat.ag2.space'))"
socket.gaierror: [Errno 8] nodename nor servname provided, or not known
$ dig +short @100.100.100.100 chat.ag2.space          # the resolv.conf nameserver
104.26.15.112
104.26.14.112
172.67.72.17
$ curl -s -o /dev/null -w '%{http_code}\n' --resolve chat.ag2.space:443:104.26.15.112 https://chat.ag2.space/
200
$ dscacheutil -flushcache; echo rc=$?          # non-root: rc=0, resolution still fails
```

Errno 8 lines per day over the last two weeks: `08-20 62 · 08-24 64 · 08-25 127 · 08-26 65 · 08-28 63 · 08-29 115 · 08-31 123 · 09-02 124` — eight of fourteen days. The bridge's own 60 s retry recovers only when the cache entry expires (measured 19 min, 32 min, 43 min, 5 h on this host).

## Change

`packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py`, inside the existing `getaddrinfo` wrapper:

- `_getaddrinfo_prefer_v4` catches `socket.gaierror` from `_resolve_bounded`, calls `_fallback_resolve(host)` (skipped for IP literals; any exception inside falls through to re-raising the **original** gaierror), and builds the addrinfo tuples by calling the original resolver with the literal IP. Hostname is untouched, so SNI and `Host` are unchanged.
- `_fallback_resolve`: nameservers from `/etc/resolv.conf` (IPv4 entries, file order) → `_dns_a_query` (one UDP RFC 1035 A query, 2 s timeout, stdlib only) → cache per host for `REMOTE_GATEWAY_DNS_FALLBACK_TTL` s (default 300); logs once per cache fill.
- `_parse_a_records`: id + RCODE checked, question skipped, CNAME chains and compression pointers handled, malformed input → `[]`.
- `.github/workflows/ci.yml`: the new suite added beside `test_dns_timeout.py`.

Nothing changes while the OS resolver works: the fallback lives entirely on the error path.

## Evidence

`packages/ag2-sparrow/tests/test_dns_fallback.py` — 9 tests, plain-script convention like `test_dns_timeout.py`:

```
$ python3 packages/ag2-sparrow/tests/test_dns_fallback.py
PASS test_fallback_exception_does_not_mask_the_resolver_error
PASS test_fallback_never_queried_for_ip_literals_or_on_success
PASS test_fallback_resolve_caches_for_ttl_and_tries_nameservers_in_order
PASS test_fallback_used_when_system_resolver_fails
PASS test_live_udp_query_against_a_local_nameserver      # real UDP socket path, fake nameserver on 127.0.0.1
PASS test_nameservers_parsed_from_resolv_conf_v4_only_in_order
PASS test_original_error_reraised_when_fallback_has_nothing
PASS test_parse_a_records_follows_cname_and_compression
PASS test_parse_rejects_id_mismatch_error_rcode_and_junk
ALL PASS
$ python3 packages/ag2-sparrow/tests/test_dns_timeout.py   -> ALL PASS
$ python3 src/remote-gateway-bridge.test.py                -> PASS — all checks green
```

Mutation controls (source edited, tests unchanged, then restored):

```
# 1. except-branch re-raises immediately (no fallback)
FAIL test_fallback_used_when_system_resolver_fails: gaierror: [Errno 8] …
1 FAILED
# 2. parser mishandles the compression pointer (return i + 1)
FAIL test_live_udp_query_against_a_local_nameserver: AssertionError: []
FAIL test_parse_a_records_follows_cname_and_compression
2 FAILED
```

```
$ git diff origin/main | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

Coverage gate: `.coveragerc` scopes to `src/`, `scripts/`, `skills/`, so `packages/` lines are outside it (`diff-cover`: "No lines with coverage information in this diff") — same as every sparrow change.

## Live path

This is the bridge's resolver, so a unit suite is not the whole proof. The live round trip needs the next negative-cache episode on the affected host with this build running; I will post the bridge log lines (`system resolver failed for chat.ag2.space; nameserver 100.100.100.100 answered …`) on this PR when it fires. Until then the evidence is the local fake-nameserver test plus the `curl --resolve` 200 above, which is the exact connect-by-IP path the fallback produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
