### PR TITLE
fix(proactive-loop): close each pass by asking the queue for unanswered tasks

### DIFF
--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tasks that were handled but never got a result file.
+
+A task file stays in `tasks/` until a result is written and the bridge archives
+it, so the queue is already the record of what is unanswered. Nothing reads it
+at the END of a pass, though, and the miss is invisible from inside: the agent
+answers in its own transcript, the terminal shows the reply, and only the queue
+disagrees. Measured five times in one session, caught every time by re-listing
+by hand and never by recall.
+
+Exit 1 when a task older than --min-age-sec has no result, 0 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+
+def _result_exists(results: Path, task_id: str) -> bool:
+    """Every shape a delivered result can take (CLAUDE.md 'Result-body protocol').
+
+    Missing one shape produces a FALSE ALARM, which is the safe direction here —
+    it costs a re-check, where a false all-clear costs the reply itself.
+    """
+    if (results / f"{task_id}.txt").exists():
+        return True
+    # Per-channel pull namespace: `<channel-key>.task-{id}.txt`.
+    if any(results.glob(f"*.{task_id}.txt")):
+        return True
+    # Claimed mid-delivery by a bridge rename.
+    if any(results.glob(f"{task_id}.txt.sending")) or any(results.glob(f"*.{task_id}.txt.sending")):
+        return True
+    # Archived: `task-<id>-<epoch>.txt` under results/archive/YYYY-MM/.
+    if any((results / "archive").glob(f"**/{task_id}*.txt")):
+        return True
+    return False
+
+
+def unanswered(workspace: Path, min_age_sec: float, now: float | None = None) -> list[tuple[str, float]]:
+    now = time.time() if now is None else now
+    tasks, results = workspace / "tasks", workspace / "results"
+    out: list[tuple[str, float]] = []
+    if not tasks.is_dir():
+        return out
+    for f in sorted(tasks.glob("task-*.txt")):
+        age = now - f.stat().st_mtime
+        if age < min_age_sec:
+            continue  # still plausibly in flight
+        if not _result_exists(results, f.stem):
+            out.append((f.stem, age))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", required=True)
+    ap.add_argument("--min-age-sec", type=float, default=120.0,
+                    help="ignore tasks younger than this (default 120)")
+    a = ap.parse_args()
+    rows = unanswered(Path(a.workspace), a.min_age_sec)
+    if not rows:
+        print("unanswered-tasks: none")
+        return 0
+    for task_id, age in rows:
+        print(f"UNANSWERED {task_id} ({age / 60:.1f}m old) — no result file; the room heard nothing")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -54,7 +54,22 @@ def _task_exists(tasks: Path, task_id: str) -> bool:
     return bool(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
 
 
+def _task_channel(tasks: Path, task_id: str) -> str | None:
+    """The task's originating channel, from its header."""
+    for cand in [tasks / f"{task_id}.txt", *sorted((tasks / "archive").glob(f"**/{task_id}*.txt"))]:
+        try:
+            text = cand.read_text(errors="replace")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if line.startswith("channel_id:"):
+                return line.split(":", 1)[1].strip()
+        return None
+    return None
+
+
 def _unanswered_reason(results: Path, task_id: str, tasks: Path | None = None,
+                       origin_channel: str | None = None,
                        _seen: set[str] | None = None) -> str | None:
     """None when the room actually heard something; else why it did not.
 
@@ -77,7 +92,14 @@ def _unanswered_reason(results: Path, task_id: str, tasks: Path | None = None,
     if not match:
         return None
     target = match.group(1)
-    reason = _unanswered_reason(results, target, tasks, seen)
+    if tasks is not None:
+        origin = origin_channel if origin_channel is not None else _task_channel(tasks, task_id)
+        dest = _task_channel(tasks, target)
+        # Resolving is not reaching: a target in ANOTHER channel answers someone
+        # else, and this sender is silenced while every existence check passes.
+        if origin and dest and origin != dest:
+            return f"CROSS-SENDER: deduped into {target}, whose reply goes to {dest}, not {origin}"
+    reason = _unanswered_reason(results, target, tasks, origin_channel, seen)
     if reason is None:
         return None
     # DANGLING vs ORPHANED: the fixes differ — "never name a peer's id" vs

--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -74,7 +74,8 @@ def _markers():
     global _MARKERS
     if _MARKERS is not None:
         return _MARKERS
-    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+    repo = Path(__file__).resolve().parent.parent  # lint-workspace-resolution: allow-repo-root (sys.path only; the root comes from the CLI arg)
+    sys.path.insert(0, str(repo / "src"))
     try:
         from result_markers import dedup_holder_delivered, parse_markers
     except ImportError as exc:

--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -51,15 +51,15 @@ def _task_exists(tasks: Path, task_id: str) -> bool:
     return bool(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
 
 
-def _task_channel(tasks: Path, task_id: str) -> str | None:
-    """The task's originating channel, from its header."""
+def _task_field(tasks: Path, task_id: str, key: str) -> str | None:
+    """One header field of a task, live or archived."""
     for cand in [tasks / f"{task_id}.txt", *sorted((tasks / "archive").glob(f"**/{task_id}*.txt"))]:
         try:
             text = cand.read_text(errors="replace")
         except OSError:
             continue
         for line in text.splitlines():
-            if line.startswith("channel_id:"):
+            if line.startswith(f"{key}:"):
                 return line.split(":", 1)[1].strip()
         return None
     return None
@@ -112,10 +112,15 @@ def _unanswered_reason(results: Path, task_id: str, tasks: Path | None = None) -
     if not target:
         return "deduped into nothing (no target id)"
     if tasks is not None:
-        origin, dest = _task_channel(tasks, task_id), _task_channel(tasks, target)
-        # Resolving is not reaching: a target in ANOTHER channel answers someone else.
-        if origin and dest and origin != dest:
-            return f"CROSS-SENDER: deduped into {target}, whose reply goes to {dest}, not {origin}"
+        # The dedup is sound only within ONE SENDER's thread. Comparing the CHANNEL
+        # misses every case in a shared room, which is where peers actually talk.
+        who = _task_field(tasks, task_id, "user_id")
+        to = _task_field(tasks, target, "user_id")
+        if who and to and who != to:
+            return f"CROSS-SENDER: deduped into {target}, which answers {to}, not {who}"
+        room, dest_room = _task_field(tasks, task_id, "channel_id"), _task_field(tasks, target, "channel_id")
+        if room and dest_room and room != dest_room:
+            return f"CROSS-ROOM: deduped into {target}, whose reply goes to {dest_room}, not {room}"
     target_path = _result_path(results, target)
     if delivered(_read(target_path)):
         return None

--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -14,11 +14,8 @@ from __future__ import annotations
 
 import argparse
 import sys
-import re
 import time
 from pathlib import Path
-
-_DEDUP = re.compile(r"\A\s*\[deduped:\s*(task-[\w-]+)\s*\]", re.IGNORECASE)
 
 
 def _result_path(results: Path, task_id: str) -> Path | None:
@@ -68,48 +65,69 @@ def _task_channel(tasks: Path, task_id: str) -> str | None:
     return None
 
 
-def _unanswered_reason(results: Path, task_id: str, tasks: Path | None = None,
-                       origin_channel: str | None = None,
-                       _seen: set[str] | None = None) -> str | None:
-    """None when the room actually heard something; else why it did not.
+_MARKERS = None
 
-    `[deduped: X]` promises the reply lives in X's result. If X never produced
-    one the reply is nowhere, and every cheap check still sees a result file on
-    disk for this task — which is exactly how two replies were lost silently.
-    """
-    seen = set() if _seen is None else _seen
-    if task_id in seen:
-        return f"dedup cycle at {task_id}"
-    seen.add(task_id)
-    path = _result_path(results, task_id)
-    if path is None:
-        return "no result file"
+
+def _markers():
+    """The marker grammar is centralised in src/result_markers.py (CLAUDE.md);
+    re-implementing it drifts from what the bridge actually does."""
+    global _MARKERS
+    if _MARKERS is not None:
+        return _MARKERS
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
     try:
-        head = path.read_text(errors="replace")[:200]
-    except OSError:
-        return None  # present but unreadable: someone wrote a result, don't invent an alarm
-    match = _DEDUP.match(head)
-    if not match:
+        from result_markers import dedup_holder_delivered, parse_markers
+    except ImportError as exc:
+        print(f"unanswered-tasks: cannot import src/result_markers.py ({exc}) — "
+              "refusing to re-implement the marker grammar", file=sys.stderr)
+        raise SystemExit(2) from exc
+    _MARKERS = (dedup_holder_delivered, parse_markers)
+    return _MARKERS
+
+
+def _read(path: Path | None) -> str | None:
+    if path is None:
         return None
-    target = match.group(1)
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return None
+
+
+def _unanswered_reason(results: Path, task_id: str, tasks: Path | None = None) -> str | None:
+    """None when the room heard something; else why it did not.
+
+    Delegates the `[deduped:]` verdict to `dedup_holder_delivered`, which is
+    what the bridge asks — a holder that is itself a skip never delivered.
+    """
+    delivered, parse = _markers()
+    text = _read(_result_path(results, task_id))
+    if text is None:
+        return "no result file"
+    dedup = next((a for a in parse(text).actions
+                  if a.kind == "skip" and a.value == "deduped"), None)
+    if dedup is None:
+        return None  # a real reply, or a deliberate skip decision for THIS task
+    target = str(dedup.extra or "").strip()
+    if not target:
+        return "deduped into nothing (no target id)"
     if tasks is not None:
-        origin = origin_channel if origin_channel is not None else _task_channel(tasks, task_id)
-        dest = _task_channel(tasks, target)
-        # Resolving is not reaching: a target in ANOTHER channel answers someone
-        # else, and this sender is silenced while every existence check passes.
+        origin, dest = _task_channel(tasks, task_id), _task_channel(tasks, target)
+        # Resolving is not reaching: a target in ANOTHER channel answers someone else.
         if origin and dest and origin != dest:
             return f"CROSS-SENDER: deduped into {target}, whose reply goes to {dest}, not {origin}"
-    reason = _unanswered_reason(results, target, tasks, origin_channel, seen)
-    if reason is None:
+    target_path = _result_path(results, target)
+    if delivered(_read(target_path)):
         return None
-    # DANGLING vs ORPHANED: the fixes differ — "never name a peer's id" vs
-    # "your own target never answered" — so never collapse them into one.
-    if tasks is not None and reason == "no result file" and not _task_exists(tasks, target):
-        return f"DANGLING: deduped into {target}, which does not exist in this workspace"
-    return f"ORPHANED: deduped into {target}, which has {reason}"
+    if target_path is None:
+        if tasks is not None and not _task_exists(tasks, target):
+            return f"DANGLING: deduped into {target}, which does not exist in this workspace"
+        return f"ORPHANED: deduped into {target}, which has no result file"
+    return f"HOLDER-SKIPPED: deduped into {target}, whose own result is a skip — the bridge requeues this"
 
 
 def unanswered(workspace: Path, min_age_sec: float, now: float | None = None) -> list[tuple[str, float, str]]:
+    _markers()  # resolve up front: an empty queue must not silently skip the guard
     now = time.time() if now is None else now
     tasks, results = workspace / "tasks", workspace / "results"
     out: list[tuple[str, float, str]] = []

--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -45,7 +45,17 @@ def _result_path(results: Path, task_id: str) -> Path | None:
     return hits[0] if hits else None
 
 
-def _unanswered_reason(results: Path, task_id: str, _seen: set[str] | None = None) -> str | None:
+def _task_exists(tasks: Path, task_id: str) -> bool:
+    """Did this id ever exist HERE? Task ids are minted per recipient, so a
+    peer's id is well-formed and still unresolvable — charset cannot tell."""
+    if (tasks / f"{task_id}.txt").exists():
+        return True
+    arch = tasks / "archive"
+    return bool(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
+
+
+def _unanswered_reason(results: Path, task_id: str, tasks: Path | None = None,
+                       _seen: set[str] | None = None) -> str | None:
     """None when the room actually heard something; else why it did not.
 
     `[deduped: X]` promises the reply lives in X's result. If X never produced
@@ -67,8 +77,14 @@ def _unanswered_reason(results: Path, task_id: str, _seen: set[str] | None = Non
     if not match:
         return None
     target = match.group(1)
-    reason = _unanswered_reason(results, target, seen)
-    return None if reason is None else f"deduped into {target}, which has {reason}"
+    reason = _unanswered_reason(results, target, tasks, seen)
+    if reason is None:
+        return None
+    # DANGLING vs ORPHANED: the fixes differ — "never name a peer's id" vs
+    # "your own target never answered" — so never collapse them into one.
+    if tasks is not None and reason == "no result file" and not _task_exists(tasks, target):
+        return f"DANGLING: deduped into {target}, which does not exist in this workspace"
+    return f"ORPHANED: deduped into {target}, which has {reason}"
 
 
 def unanswered(workspace: Path, min_age_sec: float, now: float | None = None) -> list[tuple[str, float, str]]:
@@ -81,7 +97,7 @@ def unanswered(workspace: Path, min_age_sec: float, now: float | None = None) ->
         age = now - f.stat().st_mtime
         if age < min_age_sec:
             continue  # still plausibly in flight
-        reason = _unanswered_reason(results, f.stem)
+        reason = _unanswered_reason(results, f.stem, tasks)
         if reason is not None:
             out.append((f.stem, age, reason))
     return out

--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -14,42 +14,73 @@ from __future__ import annotations
 
 import argparse
 import sys
+import re
 import time
 from pathlib import Path
 
+_DEDUP = re.compile(r"\A\s*\[deduped:\s*(task-[\w-]+)\s*\]", re.IGNORECASE)
 
-def _result_exists(results: Path, task_id: str) -> bool:
+
+def _result_path(results: Path, task_id: str) -> Path | None:
     """Every shape a delivered result can take (CLAUDE.md 'Result-body protocol').
 
     Missing one shape produces a FALSE ALARM, which is the safe direction here —
     it costs a re-check, where a false all-clear costs the reply itself.
+    `sorted` because an unordered glob picks by filesystem order, which differs
+    between APFS and the CI runner.
     """
-    if (results / f"{task_id}.txt").exists():
-        return True
-    # Per-channel pull namespace: `<channel-key>.task-{id}.txt`.
-    if any(results.glob(f"*.{task_id}.txt")):
-        return True
-    # Claimed mid-delivery by a bridge rename.
-    if any(results.glob(f"{task_id}.txt.sending")) or any(results.glob(f"*.{task_id}.txt.sending")):
-        return True
-    # Archived: `task-<id>-<epoch>.txt` under results/archive/YYYY-MM/.
-    if any((results / "archive").glob(f"**/{task_id}*.txt")):
-        return True
-    return False
+    direct = results / f"{task_id}.txt"
+    if direct.exists():
+        return direct
+    for pat in (f"*.{task_id}.txt",                      # per-channel pull namespace
+                f"{task_id}.txt.sending",                # claimed mid-delivery
+                f"*.{task_id}.txt.sending"):
+        hits = sorted(results.glob(pat))
+        if hits:
+            return hits[0]
+    hits = sorted((results / "archive").glob(f"**/{task_id}*.txt"))
+    return hits[0] if hits else None
 
 
-def unanswered(workspace: Path, min_age_sec: float, now: float | None = None) -> list[tuple[str, float]]:
+def _unanswered_reason(results: Path, task_id: str, _seen: set[str] | None = None) -> str | None:
+    """None when the room actually heard something; else why it did not.
+
+    `[deduped: X]` promises the reply lives in X's result. If X never produced
+    one the reply is nowhere, and every cheap check still sees a result file on
+    disk for this task — which is exactly how two replies were lost silently.
+    """
+    seen = set() if _seen is None else _seen
+    if task_id in seen:
+        return f"dedup cycle at {task_id}"
+    seen.add(task_id)
+    path = _result_path(results, task_id)
+    if path is None:
+        return "no result file"
+    try:
+        head = path.read_text(errors="replace")[:200]
+    except OSError:
+        return None  # present but unreadable: someone wrote a result, don't invent an alarm
+    match = _DEDUP.match(head)
+    if not match:
+        return None
+    target = match.group(1)
+    reason = _unanswered_reason(results, target, seen)
+    return None if reason is None else f"deduped into {target}, which has {reason}"
+
+
+def unanswered(workspace: Path, min_age_sec: float, now: float | None = None) -> list[tuple[str, float, str]]:
     now = time.time() if now is None else now
     tasks, results = workspace / "tasks", workspace / "results"
-    out: list[tuple[str, float]] = []
+    out: list[tuple[str, float, str]] = []
     if not tasks.is_dir():
         return out
     for f in sorted(tasks.glob("task-*.txt")):
         age = now - f.stat().st_mtime
         if age < min_age_sec:
             continue  # still plausibly in flight
-        if not _result_exists(results, f.stem):
-            out.append((f.stem, age))
+        reason = _unanswered_reason(results, f.stem)
+        if reason is not None:
+            out.append((f.stem, age, reason))
     return out
 
 
@@ -63,8 +94,8 @@ def main() -> int:
     if not rows:
         print("unanswered-tasks: none")
         return 0
-    for task_id, age in rows:
-        print(f"UNANSWERED {task_id} ({age / 60:.1f}m old) — no result file; the room heard nothing")
+    for task_id, age, reason in rows:
+        print(f"UNANSWERED {task_id} ({age / 60:.1f}m old) — {reason}; the room heard nothing")
     return 1
 
 

--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -38,7 +38,10 @@ def _result_path(results: Path, task_id: str) -> Path | None:
         hits = sorted(results.glob(pat))
         if hits:
             return hits[0]
-    hits = sorted((results / "archive").glob(f"**/{task_id}*.txt"))
+    # `{id}-*` requires the separator: a bare `{id}*` prefix also matches
+    # `{id}.too-old.<epoch>`, i.e. QUARANTINED, which is the opposite of delivered.
+    arch = results / "archive"
+    hits = sorted(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
     return hits[0] if hits else None
 
 

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -127,6 +127,21 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    - Only `access_tier: owner` (or tasks without an access_tier field) get full processing.
    - **Thread consolidation:** when several tasks in a short window are the same continuation thought (e.g. voice over-delegating "yes, right, this is useful…" as 3 separate tasks), put the FULL reply in the latest task's result and put `[deduped: task-<latest-id>]` in each earlier task's result. The bridge silently archives the deduped ones — no voice cascade, no DM duplicates. See CLAUDE.md "Result-body protocol markers" for the full marker list.
 
+   **⚠ CLOSE THE PASS BY ASKING THE QUEUE, NOT YOUR MEMORY.** Before writing the idle
+   status, run:
+
+   ```bash
+   python3 scripts/unanswered-tasks.py --workspace "$WORKSPACE"   # rc=1 => a task got no result
+   ```
+
+   A task file stays in `tasks/` until a result is written and the bridge archives it, so
+   the queue already *is* the record of what is unanswered — nothing reads it at the end of
+   a pass. The miss is invisible from the inside: the work gets done, the reply is composed
+   in the transcript, the terminal shows it, and only the queue disagrees. Measured five
+   times in one session, caught every time by re-listing by hand and never once by recall —
+   which is why this is a command and not a reminder. It fires only on tasks older than
+   `--min-age-sec` (default 120), so a task still in flight is never flagged.
+
 2. **Check pending questions.** Read the **per-host** `pending-questions.md` — `<workspace>/hosts/<hostname>/pending-questions.md` (`<hostname>` = `bash scripts/sutando-config.sh host-label`; this is the F1 per-host location, carried by `hosts/*/`, and where `personal_path("pending-questions.md")` resolves). If any unanswered items and voice client is connected, surface them via `results/question-{ts}.txt`. Also send a macOS notification.
 
 3. **Check system health.** Run `python3 src/health-check.py`. If issues found, fix what you can (`--fix` flag), note what you can't.

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -213,5 +213,31 @@ with tempfile.TemporaryDirectory() as d:
     check(len(rows) == 1 and rows[0][2].startswith("ORPHANED"),
           "a target that exists here but never answered is ORPHANED, not DANGLING")
 
+
+# Resolving is not reaching. The target ANSWERED, so every existence check
+# passes -- and the reply went to a different room, silencing this sender.
+def cross_sender_case(tmp, *, same_channel):
+    import os
+    root = Path(tmp)
+    (root / "tasks" / "archive").mkdir(parents=True); (root / "results").mkdir(parents=True)
+    t = root / "tasks" / "task-src.txt"
+    t.write_text("id: src\nchannel_id: !roomA:ag2.space\n")
+    old = time.time() - 600; os.utime(t, (old, old))
+    dest = "!roomA:ag2.space" if same_channel else "!roomB:ag2.space"
+    (root / "tasks" / "archive" / "task-dst.txt").write_text(f"id: dst\nchannel_id: {dest}\n")
+    (root / "results" / "task-src.txt").write_text("[deduped: task-dst]\n")
+    (root / "results" / "task-dst.txt").write_text("the reply, delivered to task-dst's room\n")
+    return root
+
+
+with tempfile.TemporaryDirectory() as d:
+    rows = uat.unanswered(cross_sender_case(d, same_channel=False), 120)
+    check(len(rows) == 1 and rows[0][2].startswith("CROSS-SENDER"),
+          "FIRES on a dedup whose target answers a DIFFERENT room (the target did answer)")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(cross_sender_case(d, same_channel=True), 120) == [],
+          "quiet when the dedup target is in the SAME room (the case dedup was designed for)")
+
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -71,5 +71,47 @@ with tempfile.TemporaryDirectory() as d:
 
 check(uat.unanswered(Path("/nonexistent-xyz"), 120) == [], "absent workspace is empty, not an error")
 
+# A bridge claims a proactive result by rename; that is delivery in flight, not a miss.
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(ws(d, result="task-abc123.txt.sending"), 120) == [],
+          "quiet: a `.sending` claim is mid-delivery, not unanswered")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(ws(d, result="discord-1.task-abc123.txt.sending"), 120) == [],
+          "quiet: a scoped `.sending` claim too")
+
+
+# --- main(): the exit code is the whole contract for a pass-closing check ------
+def run_main(argv):
+    """main() with argv patched; returns (rc, stdout)."""
+    import contextlib
+    import io
+    buf = io.StringIO()
+    old_argv = sys.argv
+    sys.argv = ["unanswered-tasks.py"] + argv
+    try:
+        with contextlib.redirect_stdout(buf):
+            rc = uat.main()
+    finally:
+        sys.argv = old_argv
+    return rc, buf.getvalue()
+
+
+with tempfile.TemporaryDirectory() as d:
+    rc, out = run_main(["--workspace", str(ws(d))])
+    check(rc == 1, "main() EXITS 1 when a task has no result (what the loop keys on)")
+    check("task-abc123" in out, "main() names the offending task, not just a count")
+    check("the room heard nothing" in out, "main() says what the miss cost")
+
+with tempfile.TemporaryDirectory() as d:
+    rc, out = run_main(["--workspace", str(ws(d, result="task-abc123.txt"))])
+    check(rc == 0, "main() exits 0 when every task is answered")
+    check(out.strip() == "unanswered-tasks: none", "main() is quiet-but-explicit on the clean path")
+
+with tempfile.TemporaryDirectory() as d:
+    # --min-age-sec is the in-flight guard; prove it is honoured through the CLI.
+    rc, _ = run_main(["--workspace", str(ws(d, age_sec=600)), "--min-age-sec", "99999"])
+    check(rc == 0, "main() honours --min-age-sec (a young task is not a miss)")
+
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -149,13 +149,14 @@ with tempfile.TemporaryDirectory() as d:
           "quiet when [deduped: X] points at a task that DID answer")
 
 with tempfile.TemporaryDirectory() as d:
-    check(uat.unanswered(dedup_case(d, target_exists=True, chain=True), 120) == [],
-          "follows a two-hop dedup chain to a real result")
+    rows = uat.unanswered(dedup_case(d, target_exists=True, chain=True), 120)
+    check(len(rows) == 1 and rows[0][2].startswith("HOLDER-SKIPPED"),
+          "a CHAIN is flagged: the bridge never delivers through a dedup holder")
 
 with tempfile.TemporaryDirectory() as d:
     rows = uat.unanswered(dedup_case(d, target_exists=False, cycle=True), 120)
-    check(len(rows) == 1 and "cycle" in rows[0][2],
-          "FIRES on a dedup cycle instead of recursing forever")
+    check(len(rows) == 1 and rows[0][2].startswith("HOLDER-SKIPPED"),
+          "a dedup CYCLE is flagged (single-hop, so recursion is impossible by construction)")
 
 
 # A DELIVERED target archives as `task-<id>-<epoch>.txt`, never `<id>.txt`.
@@ -238,6 +239,39 @@ with tempfile.TemporaryDirectory() as d:
 with tempfile.TemporaryDirectory() as d:
     check(uat.unanswered(cross_sender_case(d, same_channel=True), 120) == [],
           "quiet when the dedup target is in the SAME room (the case dedup was designed for)")
+
+
+# A [no-send] / [REPLIED] holder never delivered, so the bridge requeues. This
+# is `dedup_holder_delivered`'s verdict, not a rule restated here.
+for marker in ("[no-send]", "[REPLIED]"):
+    with tempfile.TemporaryDirectory() as d:
+        import os
+        root = Path(d)
+        (root / "tasks" / "archive").mkdir(parents=True); (root / "results").mkdir(parents=True)
+        t = root / "tasks" / "task-src.txt"; t.write_text("id: src\n")
+        old = time.time() - 600; os.utime(t, (old, old))
+        (root / "tasks" / "archive" / "task-dst.txt").write_text("id: dst\n")
+        (root / "results" / "task-src.txt").write_text("[deduped: task-dst]\n")
+        (root / "results" / "task-dst.txt").write_text(marker + "\n")
+        rows = uat.unanswered(root, 120)
+        check(len(rows) == 1 and rows[0][2].startswith("HOLDER-SKIPPED"),
+              f"a {marker} holder is not a delivery — flagged, as the bridge requeues it")
+
+
+# The guard must fire on an EMPTY queue too: a lazy per-task import means a
+# missing result_markers.py reports "none" instead of refusing.
+with tempfile.TemporaryDirectory() as d:
+    import shutil
+    import subprocess
+    root = Path(d)
+    (root / "src").mkdir(); (root / "scripts").mkdir()
+    shutil.copy(Path(__file__).resolve().parent.parent / "scripts" / "unanswered-tasks.py",
+                root / "scripts" / "unanswered-tasks.py")
+    ws = root / "ws"; (ws / "tasks").mkdir(parents=True); (ws / "results").mkdir()
+    proc = subprocess.run([sys.executable, str(root / "scripts" / "unanswered-tasks.py"),
+                           "--workspace", str(ws)], capture_output=True, text=True, cwd=root)
+    check(proc.returncode == 2 and "result_markers" in proc.stderr,
+          "refuses (exit 2) when result_markers.py is unimportable, even with an empty queue")
 
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -300,5 +300,54 @@ with tempfile.TemporaryDirectory() as d:
     check(uat.unanswered(same_room_case(d, same_sender=True), 120) == [],
           "quiet on same-room same-sender — the legitimate dedup")
 
+# Error and edge paths. The refusal is asserted above too, but via subprocess,
+# where no tracer follows — so these drive the same branches in-process.
+
+with tempfile.TemporaryDirectory() as d:
+    root = Path(d); (root / "tasks").mkdir()
+    (root / "tasks" / "task-live.txt").write_text("id: live\n")
+    check(uat._task_exists(root / "tasks", "task-live") is True,
+          "_task_exists: True while the task is still LIVE in tasks/ (not yet archived)")
+    check(uat._task_exists(root / "tasks", "task-never") is False,
+          "_task_exists: False for an id that never existed here")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat._read(Path(d)) is None, "_read: a directory (OSError) reads as None rather than raising")
+    check(uat._read(None) is None, "_read: a None path stays None")
+
+with tempfile.TemporaryDirectory() as d:
+    root = Path(d); (root / "results").mkdir()
+    (root / "results" / "task-x.txt").write_text("[deduped: ]\n")
+    check(uat._unanswered_reason(root / "results", "task-x") == "deduped into nothing (no target id)",
+          "a dedup naming NO target is unanswered — the marker parsed, the reply went nowhere")
+
+# `sys.modules[name] = None` is what makes `from name import x` raise ImportError,
+# so the refusal runs in-process instead of in a child the tracer cannot see.
+import contextlib
+import io
+_saved_markers, _had_mod = uat._MARKERS, "result_markers" in sys.modules
+_saved_mod = sys.modules.get("result_markers")
+uat._MARKERS = None
+sys.modules["result_markers"] = None
+_err = io.StringIO()
+try:
+    with contextlib.redirect_stderr(_err):
+        uat._markers()
+    check(False, "_markers refuses when src/result_markers.py is unimportable")
+except SystemExit as exc:
+    check(exc.code == 2, "_markers exits 2 when src/result_markers.py is unimportable")
+    check("result_markers" in _err.getvalue() and "re-implement" in _err.getvalue(),
+          "the refusal names the missing module and says it will not re-implement the grammar")
+finally:
+    if _had_mod:
+        sys.modules["result_markers"] = _saved_mod
+    else:
+        sys.modules.pop("result_markers", None)
+    uat._MARKERS = _saved_markers
+
+check(uat._markers() is not None,
+      "CONTROL: _markers still works afterwards — the refusal test restored global state")
+
+
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -113,5 +113,49 @@ with tempfile.TemporaryDirectory() as d:
     rc, _ = run_main(["--workspace", str(ws(d, age_sec=600)), "--min-age-sec", "99999"])
     check(rc == 0, "main() honours --min-age-sec (a young task is not a miss)")
 
+
+# --- [deduped: X] is only an answer if X answered ----------------------------
+# A marker naming a task with no result leaves a result file on disk either way.
+def dedup_case(tmp, *, target_exists, chain=False, cycle=False):
+    import os
+    root = Path(tmp)
+    (root / "tasks").mkdir(parents=True, exist_ok=True)
+    (root / "results").mkdir(parents=True, exist_ok=True)
+    t = root / "tasks" / "task-src.txt"
+    t.write_text("id: x\n")
+    old = time.time() - 600
+    os.utime(t, (old, old))
+    res = root / "results"
+    if cycle:
+        (res / "task-src.txt").write_text("[deduped: task-mid]\n")
+        (res / "task-mid.txt").write_text("[deduped: task-src]\n")
+        return root
+    hops = ["task-mid", "task-dst"] if chain else ["task-dst"]
+    (res / "task-src.txt").write_text(f"[deduped: {hops[0]}]\n")
+    for a, b in zip(hops, hops[1:]):
+        (res / f"{a}.txt").write_text(f"[deduped: {b}]\n")
+    if target_exists:
+        (res / f"{hops[-1]}.txt").write_text("the actual reply\n")
+    return root
+
+
+with tempfile.TemporaryDirectory() as d:
+    rows = uat.unanswered(dedup_case(d, target_exists=False), 120)
+    check(len(rows) == 1 and "task-dst" in rows[0][2],
+          "FIRES when [deduped: X] points at a task with no result (the loss this closes)")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(dedup_case(d, target_exists=True), 120) == [],
+          "quiet when [deduped: X] points at a task that DID answer")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(dedup_case(d, target_exists=True, chain=True), 120) == [],
+          "follows a two-hop dedup chain to a real result")
+
+with tempfile.TemporaryDirectory() as d:
+    rows = uat.unanswered(dedup_case(d, target_exists=False, cycle=True), 120)
+    check(len(rows) == 1 and "cycle" in rows[0][2],
+          "FIRES on a dedup cycle instead of recursing forever")
+
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""The unanswered-task check must FIRE on a missing result and STAY QUIET on
+every shape a delivered result actually takes.
+
+A checker that cannot fire is the failure this guards against, so the first
+assertion is that the positive case is reachable at all.
+Run: python3 tests/unanswered-tasks.test.py
+"""
+import importlib.util
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+_s = importlib.util.spec_from_file_location(
+    "uat", str(Path(__file__).resolve().parent.parent / "scripts" / "unanswered-tasks.py"))
+uat = importlib.util.module_from_spec(_s)
+_s.loader.exec_module(uat)
+
+PASS = FAIL = 0
+
+
+def check(cond, name):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"  ok   {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL {name}")
+
+
+def ws(tmp, task_id="task-abc123", result=None, age_sec=600):
+    root = Path(tmp)
+    (root / "tasks").mkdir(parents=True, exist_ok=True)
+    (root / "results").mkdir(parents=True, exist_ok=True)
+    t = root / "tasks" / f"{task_id}.txt"
+    t.write_text("id: x\n")
+    old = time.time() - age_sec
+    import os
+    os.utime(t, (old, old))
+    if result:
+        p = root / "results" / result
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("done\n")
+    return root
+
+
+with tempfile.TemporaryDirectory() as d:
+    rows = uat.unanswered(ws(d), min_age_sec=120)
+    check([r[0] for r in rows] == ["task-abc123"], "FIRES on a task with no result (the case this exists for)")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(ws(d, result="task-abc123.txt"), 120) == [], "quiet: plain results/<id>.txt")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(ws(d, result="phone-CA123.task-abc123.txt"), 120) == [],
+          "quiet: per-channel pull namespace <key>.task-<id>.txt")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(ws(d, result="archive/2026-09/task-abc123-1788375000.txt"), 120) == [],
+          "quiet: archived task-<id>-<epoch>.txt under archive/YYYY-MM/")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(ws(d, age_sec=5), 120) == [], "quiet: task younger than min-age is still in flight")
+
+with tempfile.TemporaryDirectory() as d:
+    root = Path(d)
+    (root / "tasks").mkdir(parents=True)
+    check(uat.unanswered(root, 120) == [], "no results/ dir is not a crash")
+
+check(uat.unanswered(Path("/nonexistent-xyz"), 120) == [], "absent workspace is empty, not an error")
+
+print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -188,5 +188,30 @@ with tempfile.TemporaryDirectory() as d:
     check(len(rows) == 1 and "task-dst" in rows[0][2],
           "a QUARANTINED (.too-old) target does not count as delivered")
 
+
+# DANGLING (target never existed here) and ORPHANED (own target never answered)
+# need opposite fixes, so a checker that reports one label for both misroutes.
+def split_case(tmp, *, target_task_exists):
+    import os
+    root = Path(tmp)
+    (root / "tasks" / "archive").mkdir(parents=True); (root / "results").mkdir(parents=True)
+    t = root / "tasks" / "task-src.txt"; t.write_text("id: x\n")
+    old = time.time() - 600; os.utime(t, (old, old))
+    (root / "results" / "task-src.txt").write_text("[deduped: task-dst]\n")
+    if target_task_exists:
+        (root / "tasks" / "archive" / "task-dst.txt").write_text("id: dst\n")
+    return root
+
+
+with tempfile.TemporaryDirectory() as d:
+    rows = uat.unanswered(split_case(d, target_task_exists=False), 120)
+    check(len(rows) == 1 and rows[0][2].startswith("DANGLING"),
+          "a target that never existed here is DANGLING (a peer's id), not ORPHANED")
+
+with tempfile.TemporaryDirectory() as d:
+    rows = uat.unanswered(split_case(d, target_task_exists=True), 120)
+    check(len(rows) == 1 and rows[0][2].startswith("ORPHANED"),
+          "a target that exists here but never answered is ORPHANED, not DANGLING")
+
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -171,5 +171,22 @@ with tempfile.TemporaryDirectory() as d:
     check(uat.unanswered(root, 120) == [],
           "quiet when the dedup target was DELIVERED (archived with an epoch suffix)")
 
+
+# A prefix without a separator also matches `{id}.too-old.<epoch>` (QUARANTINED)
+# and any longer id sharing the prefix — both would read as delivered.
+with tempfile.TemporaryDirectory() as d:
+    import os
+    root = Path(d)
+    (root / "tasks").mkdir(parents=True); (root / "results" / "archive" / "2026-09").mkdir(parents=True)
+    t = root / "tasks" / "task-src.txt"; t.write_text("id: x\n")
+    old = time.time() - 600; os.utime(t, (old, old))
+    (root / "results" / "task-src.txt").write_text("[deduped: task-dst]\n")
+    a = root / "results" / "archive" / "2026-09"
+    (a / "task-dst.too-old.1787014338.txt").write_text("aged out, never delivered\n")
+    (a / "task-dstrework-1788376009.txt").write_text("a DIFFERENT task sharing the prefix\n")
+    rows = uat.unanswered(root, 120)
+    check(len(rows) == 1 and "task-dst" in rows[0][2],
+          "a QUARANTINED (.too-old) target does not count as delivered")
+
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -217,7 +217,7 @@ with tempfile.TemporaryDirectory() as d:
 
 # Resolving is not reaching. The target ANSWERED, so every existence check
 # passes -- and the reply went to a different room, silencing this sender.
-def cross_sender_case(tmp, *, same_channel):
+def cross_room_case(tmp, *, same_channel):
     import os
     root = Path(tmp)
     (root / "tasks" / "archive").mkdir(parents=True); (root / "results").mkdir(parents=True)
@@ -232,13 +232,13 @@ def cross_sender_case(tmp, *, same_channel):
 
 
 with tempfile.TemporaryDirectory() as d:
-    rows = uat.unanswered(cross_sender_case(d, same_channel=False), 120)
-    check(len(rows) == 1 and rows[0][2].startswith("CROSS-SENDER"),
+    rows = uat.unanswered(cross_room_case(d, same_channel=False), 120)
+    check(len(rows) == 1 and rows[0][2].startswith("CROSS-ROOM"),
           "FIRES on a dedup whose target answers a DIFFERENT room (the target did answer)")
 
 with tempfile.TemporaryDirectory() as d:
-    check(uat.unanswered(cross_sender_case(d, same_channel=True), 120) == [],
-          "quiet when the dedup target is in the SAME room (the case dedup was designed for)")
+    check(uat.unanswered(cross_room_case(d, same_channel=True), 120) == [],
+          "quiet when the dedup target is the SAME room and sender (what dedup is for)")
 
 
 # A [no-send] / [REPLIED] holder never delivered, so the bridge requeues. This
@@ -272,6 +272,33 @@ with tempfile.TemporaryDirectory() as d:
                            "--workspace", str(ws)], capture_output=True, text=True, cwd=root)
     check(proc.returncode == 2 and "result_markers" in proc.stderr,
           "refuses (exit 2) when result_markers.py is unimportable, even with an empty queue")
+
+
+# The real shape: ONE shared room, many senders. Comparing channels is silent
+# here, which is where every measured cross-sender silence actually happened.
+def same_room_case(tmp, *, same_sender):
+    import os
+    root = Path(tmp)
+    (root / "tasks" / "archive").mkdir(parents=True); (root / "results").mkdir(parents=True)
+    t = root / "tasks" / "task-src.txt"
+    t.write_text("id: src\nchannel_id: !room:ag2.space\nuser_id: @alice:ag2.space\n")
+    old = time.time() - 600; os.utime(t, (old, old))
+    who = "@alice:ag2.space" if same_sender else "@bob:ag2.space"
+    (root / "tasks" / "archive" / "task-dst.txt").write_text(
+        f"id: dst\nchannel_id: !room:ag2.space\nuser_id: {who}\n")
+    (root / "results" / "task-src.txt").write_text("[deduped: task-dst]\n")
+    (root / "results" / "task-dst.txt").write_text("the reply, delivered to dst's sender\n")
+    return root
+
+
+with tempfile.TemporaryDirectory() as d:
+    rows = uat.unanswered(same_room_case(d, same_sender=False), 120)
+    check(len(rows) == 1 and rows[0][2].startswith("CROSS-SENDER"),
+          "FIRES on same-room different-sender — the shape a channel compare cannot see")
+
+with tempfile.TemporaryDirectory() as d:
+    check(uat.unanswered(same_room_case(d, same_sender=True), 120) == [],
+          "quiet on same-room same-sender — the legitimate dedup")
 
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -157,5 +157,19 @@ with tempfile.TemporaryDirectory() as d:
     check(len(rows) == 1 and "cycle" in rows[0][2],
           "FIRES on a dedup cycle instead of recursing forever")
 
+
+# A DELIVERED target archives as `task-<id>-<epoch>.txt`, never `<id>.txt`.
+# An exact-name predicate would call every delivered target ORPHANED.
+with tempfile.TemporaryDirectory() as d:
+    import os
+    root = Path(d)
+    (root / "tasks").mkdir(parents=True); (root / "results" / "archive" / "2026-09").mkdir(parents=True)
+    t = root / "tasks" / "task-src.txt"; t.write_text("id: x\n")
+    old = time.time() - 600; os.utime(t, (old, old))
+    (root / "results" / "task-src.txt").write_text("[deduped: task-dst]\n")
+    (root / "results" / "archive" / "2026-09" / "task-dst-1788376009.txt").write_text("the actual reply\n")
+    check(uat.unanswered(root, 120) == [],
+          "quiet when the dedup target was DELIVERED (archived with an epoch suffix)")
+
 print(f"\nunanswered-tasks: {PASS} passed, {FAIL} failed")
 sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## The defect

A task file stays in `tasks/` until a result is written and the bridge archives it — so **the queue is already the record of what is unanswered**. Nothing reads it at the end of a pass.

The miss is invisible from the inside. The work gets done, the reply is composed in the transcript, the terminal shows it, and only the queue disagrees. Every cheap signal says the task was handled.

## Evidence

I hit this **five times in one session**, and caught it every time by re-listing the queue by hand, never once by recall. Most recent: I reviewed and approved sonichi/sutando#3731, submitted the review — and never wrote the result, so the room that asked heard nothing for 25 minutes.

Before (the state that actually existed) and after, against the checker:

```
$ python3 scripts/unanswered-tasks.py --workspace <ws>
UNANSWERED task-2999a1bf33df59607d (25.0m old) — no result file; the room heard nothing
rc=1

$ printf 'reviewed\n' > <ws>/results/task-2999a1bf33df59607d.txt
$ python3 scripts/unanswered-tasks.py --workspace <ws>
unanswered-tasks: none
rc=0
```

## Why the existing machinery doesn't cover it

- **`/task-orphan-check`** runs at `/startup`, not per-pass, and treats anything under 5 minutes old as FRESH — which is exactly the window a mid-pass miss lives in.
- **SKILL.md already names the failure** ("two completed owner tasks were left with no result file at all", step 7) — but only inside a warning about a *different* write, with no check attached. The knowledge was present and did nothing, which is the placement problem the loop file itself argues about elsewhere.

## The change

- `scripts/unanswered-tasks.py` — lists tasks with no result, exit 1 if any. Recognises every delivered-result shape from CLAUDE.md's "Result-body protocol markers": plain `results/<id>.txt`, the per-channel pull namespace `<key>.task-<id>.txt`, a `.sending` claim mid-delivery, and `archive/YYYY-MM/task-<id>-<epoch>.txt`. Missing a shape yields a **false alarm**, which is the safe direction — it costs a re-check, where a false all-clear costs the reply.
- One line in the loop's step 1 to run it before the idle status.
- `tests/unanswered-tasks.test.py` — 7 cases, all passing.

The first assertion is deliberately that the checker **fires**:

```
  ok   FIRES on a task with no result (the case this exists for)
  ok   quiet: plain results/<id>.txt
  ok   quiet: per-channel pull namespace <key>.task-<id>.txt
  ok   quiet: archived task-<id>-<epoch>.txt under archive/YYYY-MM/
  ok   quiet: task younger than min-age is still in flight
  ok   no results/ dir is not a crash
  ok   absent workspace is empty, not an error

unanswered-tasks: 7 passed, 0 failed
```

A guard that cannot produce a positive certifies nothing, and that is the failure mode this whole PR is about — so the control comes first rather than being assumed.

## Scope

One concern: closing the pass on unanswered tasks. No change to how tasks are processed, how results are written, or what the bridges do.
