### PR TITLE
fix(hitl): the hook driver leaves ExitPlanMode to the screen layer

### DIFF
--- a/hooks/hitl-hook-driver.py
+++ b/hooks/hitl-hook-driver.py
@@ -46,7 +46,9 @@ from hitl.schema import Action, HumanRequirement  # noqa: E402
 
 # AskUserQuestion has its own bridge. The allowlist lives in hitl.policy: the
 # Manager answers it, so the record exists even when no human is needed.
-OWNED_ELSEWHERE = {"AskUserQuestion"}
+# ExitPlanMode: a PreToolUse allow does not clear Claude Code's own plan-approval
+# dialog (measured 2026-09-02), so the screen layer owns it, not this hook.
+OWNED_ELSEWHERE = {"AskUserQuestion", "ExitPlanMode"}
 TIMEOUT_REASON = (
     "No decision arrived from the owner within the wait window (requirement {rid}). "
     "Denied by default; the owner can re-run the tool once they answer."
@@ -77,8 +79,6 @@ def _summary(tool: str, tool_input: dict) -> str:
         return _clip(str(tool_input.get("command") or ""))
     if tool in ("Edit", "Write", "MultiEdit", "NotebookEdit"):
         return str(tool_input.get("file_path") or tool_input.get("notebook_path") or "")
-    if tool == "ExitPlanMode":
-        return "exit plan mode and start executing"
     return _clip(json.dumps(tool_input, sort_keys=True))
 
 
@@ -91,12 +91,10 @@ def _requirement(data: dict) -> HumanRequirement:
     tool = str(data.get("tool_name") or "")
     tool_input = data.get("tool_input") or {}
     session = os.environ.get("SUTANDO_TMUX_SESSION") or os.environ.get("SUTANDO_CORE_ID") or "sutando-core"
-    kind = "confirmation" if tool == "ExitPlanMode" else "permission"
-    verb = "wants to" if tool == "ExitPlanMode" else "wants to run"
     return HumanRequirement(
-        kind=kind,
+        kind="permission",
         runtime="claude",
-        message=f"Claude {verb} {tool}: {_summary(tool, tool_input)}",
+        message=f"Claude wants to run {tool}: {_summary(tool, tool_input)}",
         title=f"claude · {session}",
         guard=_guard(tool, tool_input),
         subject={"tool": tool, "input": _summary(tool, tool_input)},

--- a/tests/hitl-hook-driver.test.py
+++ b/tests/hitl-hook-driver.test.py
@@ -148,11 +148,12 @@ class HookDriverTests(unittest.TestCase):
         [req] = self.mgr.store.all()
         self.assertEqual(req.status, "expired")
 
-    def test_exit_plan_mode_is_a_confirmation(self):
-        _, out, _ = run_hook(self.ws, {"tool_name": "ExitPlanMode", "tool_input": {}}, timeout="1")
-        self.assertEqual(out["hookSpecificOutput"]["permissionDecision"], "deny")  # timed out
-        [req] = self.mgr.store.all()
-        self.assertEqual(req.kind, "confirmation")
+    def test_exit_plan_mode_is_left_to_the_screen_layer(self):
+        # An allow here does not dismiss the plan-approval dialog; filing a card
+        # would raise a requirement nothing can resolve.
+        rc, out, _ = run_hook(self.ws, {"tool_name": "ExitPlanMode", "tool_input": {}}, timeout="1")
+        self.assertEqual((rc, out), (0, None))
+        self.assertEqual(self.mgr.store.all(), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`hooks/hitl-hook-driver.py` no longer files a requirement for `ExitPlanMode`; it is left to the screen layer alongside `AskUserQuestion`.

## Why (measured, not assumed)

Plan-approval E2E, 2026-09-02, scratch Claude Code session in `--permission-mode plan` with this hook registered, harness answering every requirement "allow" through the Manager:

```
== requirement hitl_8c23232530b4 kind=permission   msg='Claude wants to run Write: …/plans/create-a-file-….md'
   screen dialog lines while blocked: NONE          <- hook layer works for Write
   applied allow -> status in_progress
== requirement hitl_71a4ad662583 kind=confirmation  msg='Claude wants to ExitPlanMode: exit plan mode and start executing'
   screen dialog lines while blocked: NONE
   applied allow -> status in_progress
== FAIL: expect file never appeared
   2. Yes, manually approve edits
   3. Tell Claude what to change
      shift+tab to approve with this feedback         <- Claude Code's plan dialog, AFTER the hook allowed
== final hitl_71a4ad662583: status=resolved rev=3 chosen=allow
```

The hook's allow resolved the requirement, and the session was still blocked on the plan dialog. That dialog is not a tool permission: it asks *how* to proceed (auto-accept edits / manual / feedback), so a PreToolUse decision cannot answer it. The screen classifier (`PlanApproval`, numbered options, digit + Enter) is the layer that can, and it already exists in the desktop detector.

So the confirmation card this hook filed was one nothing could resolve, which is the worst kind of card to show an owner.

## Change

- `OWNED_ELSEWHERE = {"AskUserQuestion", "ExitPlanMode"}`; the hook exits 0 with no decision and writes no record.
- The two `ExitPlanMode`-only branches (`kind="confirmation"`, the summary text) are removed with it; every remaining path is `permission`.

## Evidence

```
$ python3 tests/hitl-hook-driver.test.py           -> Ran 9 tests  OK
mutation: ExitPlanMode removed from OWNED_ELSEWHERE
  FAIL: test_exit_plan_mode_is_left_to_the_screen_layer
  Ran 9 tests  FAILED (failures=1)
$ git diff origin/main | bash scripts/review-checks.sh -> PASS
```

`hooks/` is outside `.coveragerc`'s source set, so the coverage gate reports no lines for this diff, as for the hook's original landing in #3705.

## Follow-up (not here)

The E2E harness's layer-2 leg: after the hook, drive the plan dialog with the classifier's keystroke (`1` + Enter) and confirm the file lands. That is a harness change, not a driver change.

## Review follow-up (sonichi's Stand, 2026-09-02): `kind="confirmation"` producer

After this PR nothing in this repo emits `kind="confirmation"`, although `src/hitl/schema.py` KINDS declares it and `src/hitl/events.py:60` renders it. It is kept on purpose: its producer is the screen classifier — ag2-space/ag2space-cinny-desktop#488 `src-tauri/src/hitl_events.rs` maps `PlanApproval`, `Trust` and `UpdateNag` to `Some("confirmation")` (lines 57/61/63 at d52b48d8e; #488 is approved and not yet merged, so desktop main carries no producer today). That is the layer this PR hands ExitPlanMode to, so the kind changed producers rather than losing one; dropping it would render #488's plan-dialog card as `unknown`.

**Trade stated plainly:** before, ExitPlanMode raised a card and denied on timeout; after, Claude Code's own plan dialog governs. That is a reduction in remote approval coverage, made deliberately because the remote path could not resolve anything (the dialog rendered and blocked regardless of the hook's answer). Do not restore the card thinking coverage was lost by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

