### PR TITLE
fix(workstreams): the dashboard-driven classifier enqueue is OFF by default

### DIFF
--- a/src/task_workstreams.py
+++ b/src/task_workstreams.py
@@ -984,12 +984,27 @@ def classifier_status(
     return _queue_result(True, False, "ready", snapshot_hash, "", source_state)
 
 
+#: Dashboard-driven enqueue is OFF by default (owner request 2026-09-02, pending
+#: a redesign). Set SUTANDO_WORKSTREAM_CLASSIFIER truthy to re-enable.
+_CLASSIFIER_ENABLE_VALUES = frozenset({"1", "on", "true", "yes", "enabled"})
+
+
+def classifier_enqueue_enabled() -> bool:
+    """Whether the classifier may enqueue a maintenance task. Default: no."""
+    return (os.environ.get("SUTANDO_WORKSTREAM_CLASSIFIER", "")
+            .strip().lower() in _CLASSIFIER_ENABLE_VALUES)
+
+
 def maybe_enqueue_classifier_task(
     workspace: Path,
     ttl_seconds: int = 900,
     limit: int = 100,
     skill_file: Optional[Path] = None,
 ) -> ClassifierQueueResult:
+    # Off by default gates EVERY caller — the dashboard POST and the manual
+    # endpoint alike; read-only classifier_status is unaffected.
+    if not classifier_enqueue_enabled():
+        return ClassifierQueueResult(False, False, "disabled")
     if skill_file is not None and not Path(skill_file).is_file():
         return ClassifierQueueResult(False, False, "skill-unavailable")
     with _workstream_store_lock(Path(workspace)):

--- a/tests/task-workstreams.test.py
+++ b/tests/task-workstreams.test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import multiprocessing
+import os
 import re
 import sys
 import tempfile
@@ -17,6 +18,10 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src"))
 
 import task_workstreams as workstreams  # noqa: E402
+
+# The enqueue is off by default; its gate is exercised directly in
+# test_classifier_enqueue_is_off_by_default. Every other test assumes it on.
+os.environ["SUTANDO_WORKSTREAM_CLASSIFIER"] = "on"
 
 
 def inherit_worker(workspace: str, child_id: str, start) -> None:
@@ -336,6 +341,20 @@ def test_classifier_enqueue_is_idle_gated_deduped_and_non_mutating() -> None:
     ):
         settled = workstreams.maybe_enqueue_classifier_task(workspace)
     assert not settled.pending and not settled.enqueued and settled.reason == "complete"
+
+
+def test_classifier_enqueue_is_off_by_default() -> None:
+    workspace = fixture_workspace()
+    # Unset: the gate refuses before any work; nothing is queued.
+    with mock.patch.dict(os.environ, {"SUTANDO_WORKSTREAM_CLASSIFIER": ""}):
+        off = workstreams.maybe_enqueue_classifier_task(workspace)
+    assert not off.pending and not off.enqueued and off.reason == "disabled"
+    assert not list((workspace / "tasks").glob("task-workstream-grouping-*.txt"))
+    # A truthy value re-enables it; the same ready workspace now queues one.
+    with mock.patch.dict(os.environ, {"SUTANDO_WORKSTREAM_CLASSIFIER": "on"}):
+        on = workstreams.maybe_enqueue_classifier_task(workspace)
+    assert on.pending and on.enqueued and on.reason == "enqueued"
+    assert list((workspace / "tasks").glob("task-workstream-grouping-*.txt"))
 
     write_task(
         workspace / "tasks" / "archive" / "2026-08" / "task-new.txt",
@@ -954,6 +973,7 @@ def main() -> None:
         test_apply_is_validated_stable_sticky_and_fail_open,
         test_legacy_project_sidecar_migrates_on_the_next_write,
         test_classifier_enqueue_is_idle_gated_deduped_and_non_mutating,
+        test_classifier_enqueue_is_off_by_default,
         test_classifier_task_is_envelope_stamped,
         test_classifier_task_survives_a_raising_stamper,
         test_classifier_source_directory_cache_rejects_unsafe_entries_fail_open,


### PR DESCRIPTION
## Why

The web dashboard's Tasks view POSTs `/tasks/workstreams/infer` on every refresh, which enqueues a `task-workstream-grouping` maintenance task whenever the task snapshot changed. The owner asked to stop triggering new groupings globally until the trigger is redesigned (Chi, 2026-09-02) — that instruction is what the default-OFF rests on. An earlier version of this paragraph also claimed the enqueues were "almost all no-ops"; that was a guess about one path on one host and is withdrawn (see TustinOC's measurement below: 13 runs, 0 no-ops on a third host). The redesign should not inherit it.

## What

Gate the enqueue in `maybe_enqueue_classifier_task` itself, **not** at the agent-api handler — `run_classifier_maintenance` is a second, dashboard-less caller (`task_workstreams.py:1137`), so only the core function catches both paths. Default OFF; set `SUTANDO_WORKSTREAM_CLASSIFIER` to a truthy value (`1/on/true/yes/enabled`) to re-enable. Read-only `classifier_status` is untouched, so the dashboard still **renders** existing groupings — it just stops **triggering** new ones. Takes effect on merge + restart.

## Evidence

Full suite, in a worktree at HEAD (`/usr/bin/python3 tests/task-workstreams.test.py`):
```
task workstream tests passed   (rc=0)
```
The new `test_classifier_enqueue_is_off_by_default` asserts: env unset -> `reason == "disabled"` and no `task-workstream-grouping-*.txt` queued; env `on` -> `reason == "enqueued"` and one queued. `tests/agent-api-task-workstreams.test.py` also passes (rc=0). Existing enqueue tests keep working via a module-level enable, so the enqueue LOGIC stays covered.

Stand: Echo Act IV Mini
