### PR TITLE
feat(core-supervisor): answer the Fable weekly-limit dialog by switching model (stacked on #3730)

### DIFF
--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -110,6 +110,8 @@ def _load_runtime_health():
 # Claude Code's weekly Fable-consent dialog (title / body); Enter is safe there only
 # with the caret on its "Switch to <fallback> and continue" row.
 _FABLE_TEXT = re.compile(r"reached your Fable limit|included Fable usage for this week", re.I)
+#: Lines allowed between the nearest Fable text and the focused switch row (body may wrap).
+_FABLE_CARET_GAP = 3
 
 # ---- ESCALATE-detection: interactive-prompt signatures. First match classifies.
 # Specific so the idle "❯ " prompt (ready for a task) is NEVER flagged. This is
@@ -187,9 +189,11 @@ def classify(pane: str):
             for m in [max(rx.finditer(tail), key=lambda m: m.start(), default=None)] if m]
     if hits:
         start, _, kind = max(hits, key=lambda h: (h[0], -h[1]))
-        # A focused switch row is Enter-safe only under the Fable text; on any other
-        # dialog it is an unforeseen prompt and gets the human treatment.
-        if kind == "fable-limit" and not any(m.start() < start for m in _FABLE_TEXT.finditer(tail)):
+        # A focused switch row is Enter-safe only right under the Fable text (title, body,
+        # caret); a resolved Fable dialog higher up must not vouch for some other dialog's row.
+        if kind == "fable-limit" and not any(
+                m.start() < start and tail.count("\n", m.start(), start) <= _FABLE_CARET_GAP
+                for m in _FABLE_TEXT.finditer(tail)):
             return "unknown", tail
         return kind, tail
     # No specific signature — but an input affordance IS present and this is NOT

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -112,6 +112,10 @@ def _load_runtime_health():
 # the net-new layer over runtime-health: it identifies WHICH gate the core is
 # stuck at so ESCALATE can show the prompt and AUTO-ANSWER can decide.
 _SIGNATURES = [
+    # Claude Code's weekly Fable-consent dialog: its default-focused option is
+    # "Switch to <fallback> and continue", so Enter is the model switch itself.
+    ("fable-limit", re.compile(
+        r"reached your Fable limit|included Fable usage for this week|Switch to .+ and continue", re.I)),
     ("session-limit", re.compile(r"hit your (?:session|usage|weekly) limit", re.I)),
     ("folder-trust", re.compile(r"trust the files in this folder|Do you trust", re.I)),
     ("bypass-permissions", re.compile(r"Bypass Permissions mode|Yes, I accept", re.I)),
@@ -121,7 +125,8 @@ _SIGNATURES = [
     ("permission", re.compile(r"Do you want to (proceed|allow)|Allow this action|permission to", re.I)),
 ]
 _AWAIT_HINT = re.compile(
-    r"Esc to cancel|Enter to confirm|Press Enter|Paste code|to accept|Continuing automatically|❯\s*\d+\.", re.I)
+    r"Esc to cancel|Enter to confirm|Enter to select|to navigate|Press Enter|Paste code|to accept"
+    r"|Continuing automatically|❯\s*\d+\.", re.I)
 _IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
 
 # Gates that need a human (can't be auto-answered): login + any unrecognized
@@ -129,17 +134,16 @@ _IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
 # session-limit is a spend/wait decision: never auto-answered, never a login.
 _HUMAN_GATES = {"login", "selection", "permission", "session-limit", "unknown"}
 
-# --- M4 AUTO-ANSWER decision (Layer 2), PURE + report-only. -----------------
-# This returns WHICH keystroke would safely dismiss a gate; it does NOT send it —
-# a separate, opt-in supervisor actor does that (kept OUT of the report-only
-# monitor loop). The allowlist is deliberately TINY and strictly non-destructive:
-# EVERYTHING not explicitly listed (every _HUMAN_GATE, every unknown/ambiguous
-# state) returns None → ESCALATE. Expanding it is an owner-reviewed change.
+# --- M4 AUTO-ANSWER (Layer 2): the safe key per gate; `answer_step` in the loop sends it
+# once per prompt instance (`--no-auto-answer` disables). Unlisted → None → ESCALATE.
 _AUTO_ANSWER = {
     # "Press Enter to continue…" — purely informational (e.g. the post-login
     # confirmation). Pressing Enter only proceeds; it grants nothing and is not
-    # destructive. The one gate safe to auto-dismiss.
+    # destructive.
     "press-enter": "Enter",
+    # The Fable weekly-limit dialog focuses "Switch to <fallback> and continue" by
+    # default: Enter spends nothing and keeps the core working (owner 2026-09-02).
+    "fable-limit": "Enter",
 }
 
 
@@ -354,6 +358,32 @@ def capture(socket, session):
         return None
 
 
+def send_keys(socket, session, key):
+    """Type one key into the core pane. True only when tmux accepted it."""
+    try:
+        r = subprocess.run(["tmux", "-S", socket, "send-keys", "-t", f"{session}:0", key],
+                           capture_output=True, timeout=8)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def answer_step(state, kind, prompt, answered_prompt, enabled=True):
+    """The AUTO-ANSWER actor's pure half: the key to send now, or None.
+
+    One send per prompt instance: the same prompt still on screen after a send is
+    the gate not clearing, and typing again would answer whatever replaced it.
+    """
+    if not enabled or state != "blocked-known" or prompt == answered_prompt:
+        return None
+    return auto_answer(kind)
+
+
+#: How long a completed auto-answer stays in the signal file, so a relay that
+#: polls slower than the monitor still sees it exactly once.
+AUTO_ANSWER_CARRY_S = 120.0
+
+
 def _atomic_write(path, payload):
     os.makedirs(os.path.dirname(path), exist_ok=True)
     tmp = path + ".tmp"
@@ -372,6 +402,8 @@ def main():
     ap.add_argument("--stable", type=int, default=2,
                     help="consecutive identical prompt polls before escalating (debounce)")
     ap.add_argument("--once", action="store_true", help="one tick then exit (for tests/probes)")
+    ap.add_argument("--no-auto-answer", dest="auto_answer", action="store_false",
+                    help="report allowlisted gates without typing their safe answer")
     a = ap.parse_args()
 
     # Make bare `tmux` resolvable before ANY probe (ours or runtime-health's) —
@@ -388,6 +420,8 @@ def main():
     last_sig = None
     stable_prompt = 0
     last_prompt = None
+    answered_prompt = None
+    last_answered = None
     while True:
         pane = capture(a.socket, a.session)
         base = rh.derive()  # shared: offline|needs_login|working|idle|unknown
@@ -405,11 +439,24 @@ def main():
         else:
             stable_prompt = 0
             last_prompt = None
+        if state != "blocked-known":
+            answered_prompt = None
 
-        sig = (state, prompt)
+        # The actor: only a settled, allowlisted gate is typed at, once per instance.
+        key = answer_step(state, kind, prompt, answered_prompt, a.auto_answer)
+        if key and send_keys(a.socket, a.session, key):
+            answered_prompt = prompt
+            last_answered = {"kind": kind, "key": key, "at": time.time()}
+        if last_answered and time.time() - last_answered["at"] > AUTO_ANSWER_CARRY_S:
+            last_answered = None
+
+        sig = (state, prompt, last_answered and last_answered["at"])
         if sig != last_sig:
-            _atomic_write(a.out, {"state": state, "detail": detail,
-                                  "prompt": prompt, "kind": kind, "session": a.session})
+            payload = {"state": state, "detail": detail,
+                       "prompt": prompt, "kind": kind, "session": a.session}
+            if last_answered:
+                payload["auto_answered"] = last_answered
+            _atomic_write(a.out, payload)
             last_sig = sig
         if a.once:
             return

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -107,15 +107,19 @@ def _load_runtime_health():
     return mod
 
 
+# Claude Code's weekly Fable-consent dialog (title / body); Enter is safe there only
+# with the caret on its "Switch to <fallback> and continue" row.
+_FABLE_TEXT = re.compile(r"reached your Fable limit|included Fable usage for this week", re.I)
+
 # ---- ESCALATE-detection: interactive-prompt signatures. First match classifies.
 # Specific so the idle "❯ " prompt (ready for a task) is NEVER flagged. This is
 # the net-new layer over runtime-health: it identifies WHICH gate the core is
 # stuck at so ESCALATE can show the prompt and AUTO-ANSWER can decide.
 _SIGNATURES = [
-    # Claude Code's weekly Fable-consent dialog: its default-focused option is
-    # "Switch to <fallback> and continue", so Enter is the model switch itself.
-    ("fable-limit", re.compile(
-        r"reached your Fable limit|included Fable usage for this week|Switch to .+ and continue", re.I)),
+    # The caret ON the Fable dialog's switch row (classify also demands the Fable text
+    # above it); the same dialog with the caret anywhere else is the human gate below.
+    ("fable-limit", re.compile(r"❯\s*Switch to .{1,80}? and continue", re.I)),
+    ("fable-limit-unfocused", _FABLE_TEXT),
     ("session-limit", re.compile(r"hit your (?:session|usage|weekly) limit", re.I)),
     ("folder-trust", re.compile(r"trust the files in this folder|Do you trust", re.I)),
     ("bypass-permissions", re.compile(r"Bypass Permissions mode|Yes, I accept", re.I)),
@@ -132,7 +136,7 @@ _IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
 # Gates that need a human (can't be auto-answered): login + any unrecognized
 # selection/permission. The rest (trust/bypass/press-enter) are known-safe.
 # session-limit is a spend/wait decision: never auto-answered, never a login.
-_HUMAN_GATES = {"login", "selection", "permission", "session-limit", "unknown"}
+_HUMAN_GATES = {"login", "selection", "permission", "session-limit", "fable-limit-unfocused", "unknown"}
 
 # --- M4 AUTO-ANSWER (Layer 2): the safe key per gate; `answer_step` in the loop sends it
 # once per prompt instance (`--no-auto-answer` disables). Unlisted → None → ESCALATE.
@@ -141,8 +145,8 @@ _AUTO_ANSWER = {
     # confirmation). Pressing Enter only proceeds; it grants nothing and is not
     # destructive.
     "press-enter": "Enter",
-    # The Fable weekly-limit dialog focuses "Switch to <fallback> and continue" by
-    # default: Enter spends nothing and keeps the core working (owner 2026-09-02).
+    # Matched only with the caret ON "Switch to <fallback> and continue" under the Fable
+    # text, so Enter is that switch and spends nothing (owner 2026-09-02).
     "fable-limit": "Enter",
 }
 
@@ -182,7 +186,12 @@ def classify(pane: str):
     hits = [(m.start(), i, kind) for i, (kind, rx) in enumerate(_SIGNATURES)
             for m in [max(rx.finditer(tail), key=lambda m: m.start(), default=None)] if m]
     if hits:
-        return max(hits, key=lambda h: (h[0], -h[1]))[2], tail
+        start, _, kind = max(hits, key=lambda h: (h[0], -h[1]))
+        # A focused switch row is Enter-safe only under the Fable text; on any other
+        # dialog it is an unforeseen prompt and gets the human treatment.
+        if kind == "fable-limit" and not any(m.start() < start for m in _FABLE_TEXT.finditer(tail)):
+            return "unknown", tail
+        return kind, tail
     # No specific signature — but an input affordance IS present and this is NOT
     # the idle prompt. That means an UNFORESEEN prompt. Surface it rather than
     # leave a silent dead-end (owner's no-dead-end requirement 2026-07-14): we

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -163,11 +163,11 @@ def compose_message(signal: dict) -> str:
     """The owner-facing 'action needed' line: what's stuck + a prompt excerpt."""
     aa = _soft_notice(signal)
     if aa and signal.get("state") not in HARD_ESCALATE:
-        return ("ℹ️ Fable weekly limit reached — the core answered Claude Code's limit dialog"
-                " with \"Switch to <fallback> and continue\", so it now runs on the fallback"
-                " model (Opus unless your model policy says otherwise) for this session."
-                " Nothing to do; at the core's terminal /model changes it and"
-                " /usage-credits keeps Fable running on credits.")
+        return ("ℹ️ Fable weekly limit reached — the core pressed Enter on the focused"
+                " \"Switch to <fallback> and continue\" of Claude Code's limit dialog, which"
+                " should leave it on the fallback model (Opus unless your model policy says"
+                " otherwise) for this session. Nothing to do unless the terminal shows"
+                " otherwise; /model there changes it, /usage-credits keeps Fable on credits.")
     detail = signal.get("detail") or signal.get("state") or "core needs attention"
     kind = signal.get("kind")
     prompt = (signal.get("prompt") or "").strip()
@@ -183,6 +183,11 @@ def compose_message(signal: dict) -> str:
         msg += f": {excerpt[:110]}"
     if signal.get("kind") == "session-limit":
         msg += _limit_remedy(signal)
+    elif signal.get("kind") == "fable-limit-unfocused":
+        msg += (" — Claude Code's Fable weekly-limit dialog is up but the focused option is"
+                " not \"Switch to <fallback> and continue\", so the core will not press Enter"
+                " (that could spend credits). Pick the switch at the core's terminal, or"
+                " /usage-credits to stay on Fable.")
     elif _is_login_class(signal):
         host = _core_host_label() or "the host"
         msg += (f" — needs GUI /login on {host}: open Terminal there, run"

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -49,11 +49,27 @@ import sys
 # Hard blockers only the USER can clear → escalate to the owner's channel.
 # crashed/hung belong to RECOVER (restart), not to user-escalation.
 HARD_ESCALATE = {"blocked-human", "logged-out"}
+# Gates the monitor answered by itself but the owner should still hear about:
+# the core changed something (its model) without anyone asking.
+SOFT_NOTICE_KINDS = {"fable-limit"}
+
+
+def _soft_notice(signal: dict):
+    """The auto-answer record worth a notice, or None."""
+    aa = signal.get("auto_answered")
+    if isinstance(aa, dict) and aa.get("kind") in SOFT_NOTICE_KINDS:
+        return aa
+    return None
 
 
 def _sig_hash(signal: dict) -> str:
-    """Stable hash of the escalation-relevant fields (state + prompt)."""
-    key = f"{signal.get('state')}\x00{signal.get('prompt') or ''}"
+    """Stable hash of the escalation-relevant fields (state + prompt); a soft
+    notice hashes its own record, so it fires once however the state moves on."""
+    aa = _soft_notice(signal)
+    if aa and signal.get("state") not in HARD_ESCALATE:
+        key = f"auto\x00{aa.get('kind')}\x00{aa.get('at')}"
+    else:
+        key = f"{signal.get('state')}\x00{signal.get('prompt') or ''}"
     return hashlib.sha1(key.encode()).hexdigest()
 
 
@@ -65,9 +81,11 @@ def should_escalate(signal: dict, last_hash):
       considered already-seen and does not double-notify.
     - A hard blocker escalates only when its (state,prompt) hash differs from the
       last escalated one (debounce) — a persistent prompt fires exactly once.
+    - A soft notice (an allowlisted gate the monitor answered) fires once per
+      answer record, on whichever state carries it first.
     """
     state = signal.get("state")
-    if state not in HARD_ESCALATE:
+    if state not in HARD_ESCALATE and not _soft_notice(signal):
         return False, last_hash
     h = _sig_hash(signal)
     if h == last_hash:
@@ -143,6 +161,13 @@ def _derive_backend() -> "dict | None":
 
 def compose_message(signal: dict) -> str:
     """The owner-facing 'action needed' line: what's stuck + a prompt excerpt."""
+    aa = _soft_notice(signal)
+    if aa and signal.get("state") not in HARD_ESCALATE:
+        return ("ℹ️ Fable weekly limit reached — the core answered Claude Code's limit dialog"
+                " with \"Switch to <fallback> and continue\", so it now runs on the fallback"
+                " model (Opus unless your model policy says otherwise) for this session."
+                " Nothing to do; at the core's terminal /model changes it and"
+                " /usage-credits keeps Fable running on credits.")
     detail = signal.get("detail") or signal.get("state") or "core needs attention"
     kind = signal.get("kind")
     prompt = (signal.get("prompt") or "").strip()

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -62,6 +62,12 @@ _FABLE_LIMIT = ("  You've reached your Fable limit\n"
                 "  Esc to cancel")
 # The same dialog under a select-list footer, in case the generic one is not rendered.
 _FABLE_LIMIT_SELECT_FOOTER = _FABLE_LIMIT.rsplit("\n", 1)[0] + "\n  ↑/↓ to navigate · Enter to select"
+# The caret on the PAYING option (rui, #3739): Enter here spends credits, so this
+# must be a human gate however the text around it reads.
+_FABLE_LIMIT_UNFOCUSED = _FABLE_LIMIT.replace(
+    "  ❯ Switch to Opus 5 and continue\n    Continue with Fable 5.1",
+    "    Switch to Opus 5 and continue\n  ❯ Continue with Fable 5.1")
+assert _FABLE_LIMIT_UNFOCUSED != _FABLE_LIMIT
 
 
 class TestClassify(unittest.TestCase):
@@ -138,6 +144,29 @@ class TestClassify(unittest.TestCase):
         st, _d, _p, kind = compose_state(_FABLE_LIMIT, "working", True)
         self.assertEqual((st, kind), ("blocked-known", "fable-limit"))
         self.assertEqual(auto_answer("fable-limit"), "Enter")
+
+    def test_fable_limit_with_the_caret_elsewhere_is_a_human_gate(self):
+        # Same dialog, caret on "Continue with Fable": Enter would spend credits.
+        kind, _ = classify(_FABLE_LIMIT_UNFOCUSED)
+        self.assertEqual(kind, "fable-limit-unfocused")
+        st, _d, _p, k = compose_state(_FABLE_LIMIT_UNFOCUSED, "working", True)
+        self.assertEqual((st, k), ("blocked-human", "fable-limit-unfocused"))
+        self.assertIsNone(auto_answer("fable-limit-unfocused"))
+        self.assertIsNone(_mod.answer_step("blocked-known", "fable-limit-unfocused", "p", None))
+
+    def test_switch_text_without_the_caret_is_not_the_answerable_kind(self):
+        # The switch phrase alone (scrollback, an unfocused row) must not read as focus.
+        pane = "  Switch to Opus 5 and continue\n  Esc to cancel"
+        self.assertNotEqual((classify(pane) or (None,))[0], "fable-limit")
+
+    def test_a_focused_switch_line_on_some_other_dialog_is_never_typed_at(self):
+        # sonichi (#3739): a dialog whose own text says it discards work carried the
+        # same "Switch to … and continue" row; without the Fable text it is unknown.
+        pane = ("  This will discard local changes\n"
+                "  ❯ Switch to origin/main and continue\n    Cancel\n  Esc to cancel")
+        kind, _ = classify(pane)
+        self.assertNotIn(kind, ("fable-limit", "fable-limit-unfocused"))
+        self.assertIsNone(auto_answer(kind))
 
     def test_fable_limit_and_session_limit_stay_distinct(self):
         # One is a switch the monitor may take; the other is a wait/spend decision.
@@ -257,7 +286,7 @@ class TestAnswerStep(unittest.TestCase):
         self.assertEqual(_mod.answer_step("blocked-known", "fable-limit", "p2", "p1"), "Enter")
 
     def test_human_gates_are_never_typed_at(self):
-        for kind in ("login", "session-limit", "permission", "selection", "unknown"):
+        for kind in ("login", "session-limit", "fable-limit-unfocused", "permission", "selection", "unknown"):
             self.assertIsNone(_mod.answer_step("blocked-known", kind, "p", None), kind)
         self.assertIsNone(_mod.answer_step("blocked-human", "fable-limit", "p", None))
 
@@ -272,11 +301,12 @@ class TestMainAutoAnswerWiring(unittest.TestCase):
     """One --once tick against a Fable-limit pane: the key is typed through send_keys
     and the signal file records it; --no-auto-answer only reports."""
 
-    def _tick(self, extra_args):
+    def _tick(self, extra_args, pane=None):
         import sys
         import tempfile
         from unittest.mock import patch
         sent = []
+        pane = _FABLE_LIMIT if pane is None else pane
         out = os.path.join(tempfile.mkdtemp(), "core-supervisor.json")
 
         class _RH:
@@ -286,7 +316,7 @@ class TestMainAutoAnswerWiring(unittest.TestCase):
                 return {"health": "working"}
         argv = ["core-input-watch.py", "--socket", "/tmp/x.sock", "--out", out,
                 "--once", "--stable", "1"] + extra_args
-        with patch.object(_mod, "capture", lambda s, sess: _FABLE_LIMIT), \
+        with patch.object(_mod, "capture", lambda s, sess: pane), \
                 patch.object(_mod, "_load_runtime_health", lambda: _RH()), \
                 patch.object(_mod, "gateway_alive", lambda *a: True), \
                 patch.object(_mod, "_ensure_tmux_on_path", lambda: None), \
@@ -302,6 +332,12 @@ class TestMainAutoAnswerWiring(unittest.TestCase):
         self.assertEqual(payload["kind"], "fable-limit")
         self.assertEqual(payload["auto_answered"]["kind"], "fable-limit")
         self.assertEqual(payload["auto_answered"]["key"], "Enter")
+
+    def test_caret_on_the_paying_option_is_escalated_never_typed(self):
+        sent, payload = self._tick([], pane=_FABLE_LIMIT_UNFOCUSED)
+        self.assertEqual(sent, [])
+        self.assertEqual((payload["state"], payload["kind"]), ("blocked-human", "fable-limit-unfocused"))
+        self.assertNotIn("auto_answered", payload)
 
     def test_no_auto_answer_flag_reports_only(self):
         sent, payload = self._tick(["--no-auto-answer"])

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -168,6 +168,20 @@ class TestClassify(unittest.TestCase):
         self.assertNotIn(kind, ("fable-limit", "fable-limit-unfocused"))
         self.assertIsNone(auto_answer(kind))
 
+    def test_a_resolved_fable_dialog_above_another_dialog_does_not_vouch_for_it(self):
+        # sonichi's residual: the Fable text still inside the tail, then a NEW dialog
+        # with its own focused switch row. Co-presence is not adjacency.
+        pane = (_FABLE_LIMIT.replace("  ❯ Switch to Opus 5 and continue", "    Switch to Opus 5 and continue")
+                .rsplit("\n", 1)[0]
+                + "\n  [resolved]\n  This will discard local changes\n"
+                  "  ❯ Switch to origin/main and continue\n    Cancel\n  Esc to cancel")
+        kind, _ = classify(pane)
+        self.assertEqual(kind, "unknown")
+        self.assertIsNone(auto_answer(kind))
+        # ...while the real dialog, whose body wraps onto a second line, still qualifies.
+        wrapped = _FABLE_LIMIT.replace("uses\n  usage credits", "uses\n  usage\n  credits")
+        self.assertEqual(classify(wrapped)[0], "fable-limit")
+
     def test_fable_limit_and_session_limit_stay_distinct(self):
         # One is a switch the monitor may take; the other is a wait/spend decision.
         self.assertEqual(classify(_FABLE_LIMIT)[0], "fable-limit")

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -339,11 +339,55 @@ class TestMainAutoAnswerWiring(unittest.TestCase):
         self.assertEqual((payload["state"], payload["kind"]), ("blocked-human", "fable-limit-unfocused"))
         self.assertNotIn("auto_answered", payload)
 
+    def test_an_expired_answer_record_is_dropped_from_the_signal(self):
+        # The record rides along for AUTO_ANSWER_CARRY_S; past that it is gone.
+        from unittest.mock import patch
+        with patch.object(_mod, "AUTO_ANSWER_CARRY_S", -1.0):
+            sent, payload = self._tick([])
+        self.assertEqual(len(sent), 1)
+        self.assertNotIn("auto_answered", payload)
+
     def test_no_auto_answer_flag_reports_only(self):
         sent, payload = self._tick(["--no-auto-answer"])
         self.assertEqual(sent, [])
         self.assertEqual(payload["kind"], "fable-limit")
         self.assertNotIn("auto_answered", payload)
+
+
+class TestSendKeys(unittest.TestCase):
+    """send_keys reports what tmux did: True only on a zero exit, False on a
+    non-zero exit or when tmux cannot be run at all — never an exception."""
+
+    def _with_fake_tmux(self, script):
+        import stat
+        import tempfile
+        d = tempfile.mkdtemp()
+        log = os.path.join(d, "argv.log")
+        p = os.path.join(d, "tmux")
+        with open(p, "w") as f:
+            f.write("#!/bin/sh\nprintf '%s\\n' \"$@\" > " + json.dumps(log) + "\n" + script + "\n")
+        os.chmod(p, os.stat(p).st_mode | stat.S_IEXEC)
+        return d, log
+
+    def test_zero_exit_is_true_and_the_key_reaches_the_session_pane(self):
+        from unittest.mock import patch
+        d, log = self._with_fake_tmux("exit 0")
+        with patch.dict(os.environ, {"PATH": d + os.pathsep + os.environ.get("PATH", "")}):
+            self.assertTrue(_mod.send_keys("/tmp/x.sock", "sutando-core", "Enter"))
+        with open(log) as f:
+            self.assertEqual(f.read().split("\n")[:6],
+                             ["-S", "/tmp/x.sock", "send-keys", "-t", "sutando-core:0", "Enter"])
+
+    def test_non_zero_exit_is_false(self):
+        from unittest.mock import patch
+        d, _ = self._with_fake_tmux("exit 1")
+        with patch.dict(os.environ, {"PATH": d + os.pathsep + os.environ.get("PATH", "")}):
+            self.assertFalse(_mod.send_keys("/tmp/x.sock", "sutando-core", "Enter"))
+
+    def test_an_unrunnable_tmux_is_false_not_an_exception(self):
+        from unittest.mock import patch
+        with patch.object(_mod.subprocess, "run", side_effect=OSError("no tmux")):
+            self.assertFalse(_mod.send_keys("/tmp/x.sock", "sutando-core", "Enter"))
 
 
 class TestEnsureTmuxOnPath(unittest.TestCase):

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -52,6 +52,16 @@ _SESSION_LIMIT = ("● Monitor event: \"Streaming task watcher\"\n"
 _PERMISSION_WITH_FOOTER = (
     "  Do you want to proceed?\n  Allow this action\n  Esc to cancel\n"
     "  ────────\n  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents")
+# Claude Code's Fable weekly-limit dialog, reconstructed from the CLI bundle (v2.1.258),
+# not captured live: "Switch to <fallback> and continue" is focused by default.
+_FABLE_LIMIT = ("  You've reached your Fable limit\n"
+                "  You've used your included Fable usage for this week. Continuing on Fable 5.1 uses\n"
+                "  usage credits — you have $0.00 in credits.\n"
+                "  ❯ Switch to Opus 5 and continue\n"
+                "    Continue with Fable 5.1\n"
+                "  Esc to cancel")
+# The same dialog under a select-list footer, in case the generic one is not rendered.
+_FABLE_LIMIT_SELECT_FOOTER = _FABLE_LIMIT.rsplit("\n", 1)[0] + "\n  ↑/↓ to navigate · Enter to select"
 
 
 class TestClassify(unittest.TestCase):
@@ -116,6 +126,23 @@ class TestClassify(unittest.TestCase):
         st, detail, _p, kind = compose_state(_SESSION_LIMIT, "working", True)
         self.assertEqual((st, kind), ("blocked-human", "session-limit"))
         self.assertIn("session-limit", detail)
+        self.assertIsNone(auto_answer("session-limit"))
+
+    def test_fable_limit_flags_as_its_own_kind(self):
+        self.assertEqual(classify(_FABLE_LIMIT)[0], "fable-limit")
+        self.assertEqual(classify(_FABLE_LIMIT_SELECT_FOOTER)[0], "fable-limit")
+
+    def test_fable_limit_is_a_known_gate_answered_with_enter(self):
+        # Enter takes the default-focused "Switch to <fallback> and continue": it
+        # spends nothing and keeps the core working (owner 2026-09-02).
+        st, _d, _p, kind = compose_state(_FABLE_LIMIT, "working", True)
+        self.assertEqual((st, kind), ("blocked-known", "fable-limit"))
+        self.assertEqual(auto_answer("fable-limit"), "Enter")
+
+    def test_fable_limit_and_session_limit_stay_distinct(self):
+        # One is a switch the monitor may take; the other is a wait/spend decision.
+        self.assertEqual(classify(_FABLE_LIMIT)[0], "fable-limit")
+        self.assertEqual(classify(_SESSION_LIMIT)[0], "session-limit")
         self.assertIsNone(auto_answer("session-limit"))
 
     def test_unforeseen_prompt_surfaces_as_unknown(self):
@@ -196,8 +223,10 @@ class TestComposeState(unittest.TestCase):
 class TestAutoAnswer(unittest.TestCase):
     """M4 decision safety: only strictly-safe gates auto-answer; all else escalates."""
 
-    def test_press_enter_is_the_only_auto_answer(self):
+    def test_allowlist_is_exactly_press_enter_and_fable_limit(self):
         self.assertEqual(auto_answer("press-enter"), "Enter")
+        self.assertEqual(auto_answer("fable-limit"), "Enter")
+        self.assertEqual(set(_mod._AUTO_ANSWER), {"press-enter", "fable-limit"})
 
     def test_login_never_auto_answered(self):
         self.assertIsNone(auto_answer("login"))
@@ -215,6 +244,70 @@ class TestAutoAnswer(unittest.TestCase):
         # auto-accept a trust / dangerous-mode prompt without explicit opt-in.
         self.assertIsNone(auto_answer("folder-trust"))
         self.assertIsNone(auto_answer("bypass-permissions"))
+
+
+class TestAnswerStep(unittest.TestCase):
+    """The actor's pure half: a settled, allowlisted gate gets one key per instance."""
+
+    def test_sends_enter_for_a_settled_fable_limit(self):
+        self.assertEqual(_mod.answer_step("blocked-known", "fable-limit", "p1", None), "Enter")
+
+    def test_same_prompt_instance_is_answered_once(self):
+        self.assertIsNone(_mod.answer_step("blocked-known", "fable-limit", "p1", "p1"))
+        self.assertEqual(_mod.answer_step("blocked-known", "fable-limit", "p2", "p1"), "Enter")
+
+    def test_human_gates_are_never_typed_at(self):
+        for kind in ("login", "session-limit", "permission", "selection", "unknown"):
+            self.assertIsNone(_mod.answer_step("blocked-known", kind, "p", None), kind)
+        self.assertIsNone(_mod.answer_step("blocked-human", "fable-limit", "p", None))
+
+    def test_a_settling_prompt_is_not_answered(self):
+        self.assertIsNone(_mod.answer_step("running", "fable-limit", None, None))
+
+    def test_disabled_flag_reports_only(self):
+        self.assertIsNone(_mod.answer_step("blocked-known", "fable-limit", "p1", None, enabled=False))
+
+
+class TestMainAutoAnswerWiring(unittest.TestCase):
+    """One --once tick against a Fable-limit pane: the key is typed through send_keys
+    and the signal file records it; --no-auto-answer only reports."""
+
+    def _tick(self, extra_args):
+        import sys
+        import tempfile
+        from unittest.mock import patch
+        sent = []
+        out = os.path.join(tempfile.mkdtemp(), "core-supervisor.json")
+
+        class _RH:
+            TMUX_SOCKET = SESSION = None
+
+            def derive(self):
+                return {"health": "working"}
+        argv = ["core-input-watch.py", "--socket", "/tmp/x.sock", "--out", out,
+                "--once", "--stable", "1"] + extra_args
+        with patch.object(_mod, "capture", lambda s, sess: _FABLE_LIMIT), \
+                patch.object(_mod, "_load_runtime_health", lambda: _RH()), \
+                patch.object(_mod, "gateway_alive", lambda *a: True), \
+                patch.object(_mod, "_ensure_tmux_on_path", lambda: None), \
+                patch.object(_mod, "send_keys", lambda s, sess, k: sent.append((s, sess, k)) or True), \
+                patch.object(sys, "argv", argv):
+            main()
+        with open(out) as f:
+            return sent, json.load(f)
+
+    def test_fable_limit_is_typed_at_and_recorded(self):
+        sent, payload = self._tick([])
+        self.assertEqual(sent, [("/tmp/x.sock", "sutando-core", "Enter")])
+        self.assertEqual(payload["kind"], "fable-limit")
+        self.assertEqual(payload["auto_answered"]["kind"], "fable-limit")
+        self.assertEqual(payload["auto_answered"]["key"], "Enter")
+
+    def test_no_auto_answer_flag_reports_only(self):
+        sent, payload = self._tick(["--no-auto-answer"])
+        self.assertEqual(sent, [])
+        self.assertEqual(payload["kind"], "fable-limit")
+        self.assertNotIn("auto_answered", payload)
 
 
 class TestEnsureTmuxOnPath(unittest.TestCase):

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -47,6 +47,14 @@ _IDLE = {"state": "idle-ready", "detail": "ready for a task", "prompt": None, "k
 _RUNNING = {"state": "running", "detail": "actively processing", "prompt": None, "kind": None}
 _CRASHED = {"state": "crashed", "detail": "core process/session not found", "prompt": None}
 _HUNG = {"state": "hung", "detail": "core alive but stalled", "prompt": "…", "kind": "unknown"}
+# The monitor answered the Fable weekly-limit dialog itself (Enter = switch model);
+# the record rides along in the signal for AUTO_ANSWER_CARRY_S whatever the state.
+_FABLE_AUTO = {"state": "blocked-known", "detail": "at known gate: fable-limit",
+               "prompt": "You've reached your Fable limit\n❯ Switch to Opus 5 and continue",
+               "kind": "fable-limit",
+               "auto_answered": {"kind": "fable-limit", "key": "Enter", "at": 1788380000.0}}
+_FABLE_AUTO_LATER = dict(_IDLE, auto_answered=_FABLE_AUTO["auto_answered"])
+_PRESS_ENTER_AUTO = dict(_RUNNING, auto_answered={"kind": "press-enter", "key": "Enter", "at": 1.0})
 
 
 @contextlib.contextmanager
@@ -125,7 +133,37 @@ class TestShouldEscalate(unittest.TestCase):
         self.assertFalse(should_escalate(_LOGIN, h_mid)[0])
 
 
+    def test_fable_auto_answer_notifies_once_across_states(self):
+        esc, h = should_escalate(_FABLE_AUTO, None)
+        self.assertTrue(esc)
+        # The same record carried on a later idle tick must not fire again.
+        esc2, h2 = should_escalate(_FABLE_AUTO_LATER, h)
+        self.assertFalse(esc2)
+        self.assertEqual(h, h2)
+
+    def test_a_new_fable_answer_notifies_again(self):
+        _, h = should_escalate(_FABLE_AUTO, None)
+        again = dict(_FABLE_AUTO, auto_answered=dict(_FABLE_AUTO["auto_answered"], at=1788390000.0))
+        self.assertTrue(should_escalate(again, h)[0])
+
+    def test_a_plain_known_gate_still_never_escalates(self):
+        plain = {k: v for k, v in _FABLE_AUTO.items() if k != "auto_answered"}
+        self.assertFalse(should_escalate(plain, None)[0])
+
+    def test_press_enter_auto_answer_is_silent(self):
+        self.assertFalse(should_escalate(_PRESS_ENTER_AUTO, None)[0])
+
+
 class TestComposeMessage(unittest.TestCase):
+    def test_fable_auto_answer_says_switched_not_needs_you(self):
+        msg = compose_message(_FABLE_AUTO)
+        self.assertIn("Fable weekly limit", msg)
+        self.assertIn("fallback model", msg)
+        self.assertNotIn("Agent needs you", msg)
+        self.assertNotIn("/login", msg)
+        # Carried onto a later idle tick, the notice reads the same.
+        self.assertEqual(compose_message(_FABLE_AUTO_LATER), msg)
+
     def test_includes_detail_and_prompt_excerpt(self):
         m = compose_message(_LOGIN)
         self.assertIn("awaiting user: login", m)

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -155,14 +155,25 @@ class TestShouldEscalate(unittest.TestCase):
 
 
 class TestComposeMessage(unittest.TestCase):
-    def test_fable_auto_answer_says_switched_not_needs_you(self):
+    def test_fable_auto_answer_says_what_was_pressed_not_needs_you(self):
         msg = compose_message(_FABLE_AUTO)
         self.assertIn("Fable weekly limit", msg)
+        self.assertIn("pressed Enter", msg)
         self.assertIn("fallback model", msg)
         self.assertNotIn("Agent needs you", msg)
         self.assertNotIn("/login", msg)
         # Carried onto a later idle tick, the notice reads the same.
         self.assertEqual(compose_message(_FABLE_AUTO_LATER), msg)
+
+    def test_fable_limit_with_the_caret_elsewhere_escalates_with_the_reason(self):
+        unfocused = {"state": "blocked-human", "detail": "awaiting user: fable-limit-unfocused",
+                     "prompt": "You've reached your Fable limit\n❯ Continue with Fable 5.1",
+                     "kind": "fable-limit-unfocused"}
+        self.assertTrue(should_escalate(unfocused, None)[0])
+        msg = compose_message(unfocused)
+        self.assertIn("Agent needs you", msg)
+        self.assertIn("will not press Enter", msg)
+        self.assertNotIn("/login", msg)
 
     def test_includes_detail_and_prompt_excerpt(self):
         m = compose_message(_LOGIN)


### PR DESCRIPTION
## What

When Claude Code runs out of included Fable usage for the week it stops the core at a consent dialog:

```
  You've reached your Fable limit
  You've used your included Fable usage for this week. Continuing on Fable 5.1 uses usage credits — you have $0.00 in credits.
  ❯ Switch to Opus 5 and continue
    Continue with Fable 5.1
```

(Text reconstructed from the CLI bundle, v2.1.258 — `Wo = "You've reached your Fable limit"`, options `[{label: "Switch to <fallback> and continue", value: "switch"}, {label: "Continue with <model>", value: "confirm"}]`, `defaultFocusValue: "switch"`. The fallback is `getFableDeclineFallbackModel()`: the main-loop model if it is not Fable, else the first allowed of Opus/Sonnet/Haiku; declining prints `Switched to <model> for this session · Fable requires usage credits · /model to change`.)

The owner's ask (2026-09-02): handle it too — just switch to the default model. The "switch" option is focused by default, so the whole answer is **Enter**, and it spends nothing.

## Change

- `src/core-input-watch.py`
  - new kind `fable-limit`, matched only when the caret sits on "Switch to <fallback> and continue" **under the Fable text** (one regex spanning both), plus `fable-limit-unfocused` — the Fable dialog with the caret anywhere else — which is a **human gate**: escalated with the reason, never typed at. Both distinct from `session-limit` (a wait-or-spend decision that stays a human gate). *(Second head, after john-the-dev's and sonichi's reviews: the first head matched the switch text without checking focus, and its third alternative matched any dialog carrying "Switch to … and continue" — a discard-changes dialog would have been typed at. Both pinned now.)*
  - `_AUTO_ANSWER["fable-limit"] = "Enter"` — the allowlist is now exactly `{press-enter, fable-limit}`, pinned.
  - **the actor — a deliberate inversion of the previous design, stated plainly:** the `_AUTO_ANSWER` block comment used to say the decision "does NOT send it; a separate, opt-in supervisor actor does that, kept OUT of the report-only monitor loop". No such actor was ever built (no `send-keys` consumer of `auto_answer()` existed in `src/`), so the press-enter entry was report-only in practice. This PR puts the actor **in the loop, on by default**: it types an allowlisted gate's key through `send_keys` (tmux `send-keys -t <session>:0`), once per prompt instance and only after the prompt has settled through the existing `--stable` debounce (a redrawing prompt never reaches `blocked-known`, so the exact-text guard in `answer_step` is not the thing holding it back — sonichi checked and cleared this). `--no-auto-answer` restores report-only. The owner asked for the switch to happen unattended; an opt-in actor that nobody enables is the report-only behaviour with a different name.
  - the signal file carries `auto_answered: {kind, key, at}` for `AUTO_ANSWER_CARRY_S` (120 s) so a relay polling slower than the monitor still sees it exactly once.
  - `_AWAIT_HINT` also accepts `Enter to select` / `to navigate` (select-list footers).
- `src/core-supervisor-relay.py`
  - `SOFT_NOTICE_KINDS = {"fable-limit"}`: an auto-answered Fable limit is not an escalation, but the owner should hear that the core changed model. One notice per answer record (hashed on the record, not on the state that carries it), text: *Fable weekly limit reached — the core answered … so it now runs on the fallback model … /model changes it, /usage-credits keeps Fable running on credits.* A plain `blocked-known` still never escalates; an auto-answered `press-enter` stays silent.

**Stacked on #3730** (`fix/session-limit-gate`): same `_SIGNATURES` / `_HUMAN_GATES` lines, and the session-limit kind is the control this one is measured against. Merge order: #3730, then this.

## Evidence

```
$ python3 tests/core-input-watch.test.py        # 33 -> 43
Ran 43 tests  OK
$ python3 tests/core-supervisor-relay.test.py   # 60 -> 65
Ran 65 tests  OK
```

New pins: classify under both footers; `blocked-known` + Enter; session-limit stays `blocked-human` and unanswered; the allowlist set; `answer_step` (once per prompt instance, never for a human gate, never while settling, never when disabled); a `--once` tick of `main()` against the Fable pane with `send_keys` recorded (`[("/tmp/x.sock","sutando-core","Enter")]`, payload `auto_answered.kind == "fable-limit"`) and the same tick under `--no-auto-answer` (nothing sent, no record); relay: notifies once across states, again on a new record, never for a plain known gate or a press-enter answer; message says switched, not "needs you", no `/login`.

Mutation controls (each run on a copy):

```
drop "fable-limit" from _AUTO_ANSWER        -> 4 FAIL (allowlist set, known-gate Enter, answer_step, main wiring)
answer_step ignores answered_prompt         -> 1 FAIL (same instance answered once)
relay: SOFT_NOTICE_KINDS = set()            -> 3 FAIL (notify once, notify again, compose says switched)
```

## Not verified

The dialog text comes from the bundle, not from a live screen — the core has not hit the Fable limit while this monitor was watching. The two footers in the fixtures cover the generic dialog's `Esc to cancel` and a select-list `Enter to select`; if the live footer carries neither, `classify` returns None and the gate is not seen (no wrong key is ever typed — the failure mode is silence, the pre-existing one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
