### PR TITLE
fix(dedup): a dedup across senders in one room is not a valid dedup

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/dedup_recovery.py
+++ b/packages/ag2-sparrow/ag2_sparrow/dedup_recovery.py
@@ -40,6 +40,7 @@ __all__ = [
     "plan_dedup_recovery",
     "report_disposition",
     "REPORT_TEMPLATE",
+    "CROSS_SENDER_TEMPLATE",
     "MALFORMED_TEMPLATE",
 ]
 
@@ -51,6 +52,11 @@ MALFORMED_TEMPLATE = (
 REPORT_TEMPLATE = (
     "⚠️ This was folded into `{holder}`, which delivered nothing, and "
     "re-asking didn't recover it. It needs a direct answer."
+)
+
+CROSS_SENDER_TEMPLATE = (
+    "⚠️ This was folded into `{holder}`, which was asked by someone else, so the "
+    "reply went to them. Re-asking didn't recover it. It needs a direct answer."
 )
 
 
@@ -104,6 +110,10 @@ def plan_dedup_recovery(
         )
     if decision == "honour" and not cross_sender:
         return "honour", None
+    # `dedup_decision` short-circuits on holder-delivered, so its requeue cap is
+    # never reached here — a cross-sender fold is delivered by construction.
+    if cross_sender and dedup_requeue_count(orig_text) >= 1:
+        return "report", CROSS_SENDER_TEMPLATE.format(holder=holder)
 
     if (decision == "requeue" or cross_sender) and orig_text:
         if commit_identity is not None and not commit_identity(new_task_id):

--- a/packages/ag2-sparrow/ag2_sparrow/dedup_recovery.py
+++ b/packages/ag2-sparrow/ag2_sparrow/dedup_recovery.py
@@ -19,16 +19,20 @@ try:  # pragma: no cover - exercised by whichever context imports it
     from .local_task_protocol import find_result, valid_archive_lookup_id
     from .result_markers import (
         build_requeued_task,
+        dedup_cross_sender_target,
         dedup_decision,
         dedup_requeue_count,
+        task_user_id,
     )
     from .task_archive import find_task_file
 except ImportError:  # pragma: no cover - flat src/ import path
     from local_task_protocol import find_result, valid_archive_lookup_id
     from result_markers import (
         build_requeued_task,
+        dedup_cross_sender_target,
         dedup_decision,
         dedup_requeue_count,
+        task_user_id,
     )
     from task_archive import find_task_file
 
@@ -90,15 +94,24 @@ def plan_dedup_recovery(
     holder_text = _read(find_result(Path(results_dir), holder)) if holder else None
 
     decision = dedup_decision(holder_text, orig_text)
-    if decision == "honour":
+    # "honour" asks whether the holder replied, never WHO it replied to: across
+    # senders its reply reaches its own asker and this one is left silent.
+    cross_sender = None
+    if decision == "honour" and holder and orig_text:
+        cross_sender = dedup_cross_sender_target(
+            task_user_id(orig_text),
+            _read(find_task_file(Path(tasks_dir), holder)),
+        )
+    if decision == "honour" and not cross_sender:
         return "honour", None
 
-    if decision == "requeue" and orig_text:
+    if (decision == "requeue" or cross_sender) and orig_text:
         if commit_identity is not None and not commit_identity(new_task_id):
             return "defer", None
         body = build_requeued_task(
             orig_text, new_task_id, dedup_requeue_count(orig_text) + 1,
-            asking_channel, holder, reason="holder-empty",
+            asking_channel, holder,
+            reason="cross-sender" if cross_sender else "holder-empty",
         )
         try:
             (Path(tasks_dir) / f"{new_task_id}.txt").write_text(body)

--- a/packages/ag2-sparrow/ag2_sparrow/result_markers.py
+++ b/packages/ag2-sparrow/ag2_sparrow/result_markers.py
@@ -293,6 +293,7 @@ def parse_markers(text: str) -> ParseResult:
 
 
 _TASK_CHANNEL_RE = re.compile(r"^channel_id:\s*(\S+)\s*$", re.MULTILINE)
+_TASK_USER_RE = re.compile(r"^user_id:\s*(\S+)\s*$", re.MULTILINE)
 
 
 def dedup_cross_channel_target(deduped_channel_id, holder_task_text: str | None) -> str | None:
@@ -321,6 +322,44 @@ def dedup_cross_channel_target(deduped_channel_id, holder_task_text: str | None)
     holder_channel = m.group(1).strip()
     if holder_channel and str(holder_channel) != str(deduped_channel_id):
         return holder_channel
+    return None
+
+
+def task_user_id(task_text: str | None) -> str | None:
+    """The `user_id:` a task carries, or None. Owned here so callers never
+    re-derive the header grammar (CLAUDE.md: marker parsing is centralised)."""
+    if not task_text:
+        return None
+    m = _TASK_USER_RE.search(task_text)
+    return m.group(1).strip() if m else None
+
+
+def dedup_cross_sender_target(deduped_user_id, holder_task_text: str | None) -> str | None:
+    """Sender-aware dedup support — the silence the channel check cannot see.
+
+    `dedup_cross_channel_target` asks whether the reply went to another ROOM.
+    In a shared multi-member room every sender carries the SAME channel_id, so
+    folding one member's task into another member's returns None there and the
+    dedup is honoured: the holder is answered and the asker hears nothing.
+
+    Returns the holder's `user_id` when known AND different from the deduped
+    task's own. `user_id` rather than `sender_name` because a display name is
+    not unique — one human on two homeservers has two ids but one name, so
+    keying on the name merges them and misses a real cross-sender silence.
+
+    Conversely a strict id compare SPLITS that same human, so a dev/prod pair
+    can report as cross-sender when nobody was silenced. That is bounded: the
+    requeue path re-asks at most once (`dedup_requeue_count >= 1` -> report),
+    and a spurious re-ask costs a message where a missed one costs the answer.
+    """
+    if not holder_task_text:
+        return None
+    m = _TASK_USER_RE.search(holder_task_text)
+    if not m:
+        return None
+    holder_user = m.group(1).strip()
+    if holder_user and str(holder_user) != str(deduped_user_id):
+        return holder_user
     return None
 
 
@@ -381,6 +420,12 @@ _REQUEUE_REASONS = {
         f"DIFFERENT channel. Dedup is per-channel only — a cross-channel dedup leaves this "
         f"channel silent. Re-answer THIS task directly in its own channel (<#{asking_channel}>). "
         "Do NOT [deduped:] across channels.\n"
+    ),
+    "cross-sender": lambda holder_id, asking_channel: (
+        f"Your previous result used [deduped: {holder_id}], but that holder task was asked by a "
+        f"DIFFERENT sender. Dedup folds one reply into another task's result, which is delivered "
+        f"to whoever asked THAT task — so across senders the person who asked this one hears "
+        f"nothing. Answer THIS task directly. Only use [deduped:] within one sender's thread.\n"
     ),
     "holder-empty": lambda holder_id, asking_channel: (
         f"Your previous result used [deduped: {holder_id}], but that holder delivered nothing, "

--- a/src/dedup_recovery.py
+++ b/src/dedup_recovery.py
@@ -40,6 +40,7 @@ __all__ = [
     "plan_dedup_recovery",
     "report_disposition",
     "REPORT_TEMPLATE",
+    "CROSS_SENDER_TEMPLATE",
     "MALFORMED_TEMPLATE",
 ]
 
@@ -51,6 +52,11 @@ MALFORMED_TEMPLATE = (
 REPORT_TEMPLATE = (
     "⚠️ This was folded into `{holder}`, which delivered nothing, and "
     "re-asking didn't recover it. It needs a direct answer."
+)
+
+CROSS_SENDER_TEMPLATE = (
+    "⚠️ This was folded into `{holder}`, which was asked by someone else, so the "
+    "reply went to them. Re-asking didn't recover it. It needs a direct answer."
 )
 
 
@@ -104,6 +110,10 @@ def plan_dedup_recovery(
         )
     if decision == "honour" and not cross_sender:
         return "honour", None
+    # `dedup_decision` short-circuits on holder-delivered, so its requeue cap is
+    # never reached here — a cross-sender fold is delivered by construction.
+    if cross_sender and dedup_requeue_count(orig_text) >= 1:
+        return "report", CROSS_SENDER_TEMPLATE.format(holder=holder)
 
     if (decision == "requeue" or cross_sender) and orig_text:
         if commit_identity is not None and not commit_identity(new_task_id):

--- a/src/dedup_recovery.py
+++ b/src/dedup_recovery.py
@@ -19,16 +19,20 @@ try:  # pragma: no cover - exercised by whichever context imports it
     from .local_task_protocol import find_result, valid_archive_lookup_id
     from .result_markers import (
         build_requeued_task,
+        dedup_cross_sender_target,
         dedup_decision,
         dedup_requeue_count,
+        task_user_id,
     )
     from .task_archive import find_task_file
 except ImportError:  # pragma: no cover - flat src/ import path
     from local_task_protocol import find_result, valid_archive_lookup_id
     from result_markers import (
         build_requeued_task,
+        dedup_cross_sender_target,
         dedup_decision,
         dedup_requeue_count,
+        task_user_id,
     )
     from task_archive import find_task_file
 
@@ -90,15 +94,24 @@ def plan_dedup_recovery(
     holder_text = _read(find_result(Path(results_dir), holder)) if holder else None
 
     decision = dedup_decision(holder_text, orig_text)
-    if decision == "honour":
+    # "honour" asks whether the holder replied, never WHO it replied to: across
+    # senders its reply reaches its own asker and this one is left silent.
+    cross_sender = None
+    if decision == "honour" and holder and orig_text:
+        cross_sender = dedup_cross_sender_target(
+            task_user_id(orig_text),
+            _read(find_task_file(Path(tasks_dir), holder)),
+        )
+    if decision == "honour" and not cross_sender:
         return "honour", None
 
-    if decision == "requeue" and orig_text:
+    if (decision == "requeue" or cross_sender) and orig_text:
         if commit_identity is not None and not commit_identity(new_task_id):
             return "defer", None
         body = build_requeued_task(
             orig_text, new_task_id, dedup_requeue_count(orig_text) + 1,
-            asking_channel, holder, reason="holder-empty",
+            asking_channel, holder,
+            reason="cross-sender" if cross_sender else "holder-empty",
         )
         try:
             (Path(tasks_dir) / f"{new_task_id}.txt").write_text(body)

--- a/src/result_markers.py
+++ b/src/result_markers.py
@@ -293,6 +293,7 @@ def parse_markers(text: str) -> ParseResult:
 
 
 _TASK_CHANNEL_RE = re.compile(r"^channel_id:\s*(\S+)\s*$", re.MULTILINE)
+_TASK_USER_RE = re.compile(r"^user_id:\s*(\S+)\s*$", re.MULTILINE)
 
 
 def dedup_cross_channel_target(deduped_channel_id, holder_task_text: str | None) -> str | None:
@@ -321,6 +322,44 @@ def dedup_cross_channel_target(deduped_channel_id, holder_task_text: str | None)
     holder_channel = m.group(1).strip()
     if holder_channel and str(holder_channel) != str(deduped_channel_id):
         return holder_channel
+    return None
+
+
+def task_user_id(task_text: str | None) -> str | None:
+    """The `user_id:` a task carries, or None. Owned here so callers never
+    re-derive the header grammar (CLAUDE.md: marker parsing is centralised)."""
+    if not task_text:
+        return None
+    m = _TASK_USER_RE.search(task_text)
+    return m.group(1).strip() if m else None
+
+
+def dedup_cross_sender_target(deduped_user_id, holder_task_text: str | None) -> str | None:
+    """Sender-aware dedup support — the silence the channel check cannot see.
+
+    `dedup_cross_channel_target` asks whether the reply went to another ROOM.
+    In a shared multi-member room every sender carries the SAME channel_id, so
+    folding one member's task into another member's returns None there and the
+    dedup is honoured: the holder is answered and the asker hears nothing.
+
+    Returns the holder's `user_id` when known AND different from the deduped
+    task's own. `user_id` rather than `sender_name` because a display name is
+    not unique — one human on two homeservers has two ids but one name, so
+    keying on the name merges them and misses a real cross-sender silence.
+
+    Conversely a strict id compare SPLITS that same human, so a dev/prod pair
+    can report as cross-sender when nobody was silenced. That is bounded: the
+    requeue path re-asks at most once (`dedup_requeue_count >= 1` -> report),
+    and a spurious re-ask costs a message where a missed one costs the answer.
+    """
+    if not holder_task_text:
+        return None
+    m = _TASK_USER_RE.search(holder_task_text)
+    if not m:
+        return None
+    holder_user = m.group(1).strip()
+    if holder_user and str(holder_user) != str(deduped_user_id):
+        return holder_user
     return None
 
 
@@ -381,6 +420,12 @@ _REQUEUE_REASONS = {
         f"DIFFERENT channel. Dedup is per-channel only — a cross-channel dedup leaves this "
         f"channel silent. Re-answer THIS task directly in its own channel (<#{asking_channel}>). "
         "Do NOT [deduped:] across channels.\n"
+    ),
+    "cross-sender": lambda holder_id, asking_channel: (
+        f"Your previous result used [deduped: {holder_id}], but that holder task was asked by a "
+        f"DIFFERENT sender. Dedup folds one reply into another task's result, which is delivered "
+        f"to whoever asked THAT task — so across senders the person who asked this one hears "
+        f"nothing. Answer THIS task directly. Only use [deduped:] within one sender's thread.\n"
     ),
     "holder-empty": lambda holder_id, asking_channel: (
         f"Your previous result used [deduped: {holder_id}], but that holder delivered nothing, "

--- a/tests/dedup-cross-sender.test.py
+++ b/tests/dedup-cross-sender.test.py
@@ -53,13 +53,18 @@ class CrossSenderPredicate(unittest.TestCase):
 class PlanRefusesCrossSenderDedup(unittest.TestCase):
     """The regression: same room, different senders, holder DID deliver."""
 
-    def _plan(self, holder_user):
-        d = Path(self.tmp)
+    def _plan(self, holder_user, holder_result="a real, delivered answer\n", count=0):
+        # a fresh workspace per call: several plans run inside one test
+        d = Path(self.tmp) / f"ws{self._n}"
+        self._n += 1
         tasks, results = d / "tasks", d / "results"
-        tasks.mkdir(), results.mkdir()
-        (tasks / "task-victim.txt").write_text(_task("task-victim", "@alice:ag2.space"))
+        tasks.mkdir(parents=True), results.mkdir(parents=True)
+        victim = _task("task-victim", "@alice:ag2.space")
+        if count:
+            victim = victim.replace("access_tier: team\n", f"access_tier: team\ndedup_requeue_count: {count}\n")
+        (tasks / "task-victim.txt").write_text(victim)
         (tasks / "task-holder.txt").write_text(_task("task-holder", holder_user))
-        (results / "task-holder.txt").write_text("a real, delivered answer\n")
+        (results / "task-holder.txt").write_text(holder_result)
         return plan_dedup_recovery(
             results, tasks, "task-victim", "task-holder", ROOM, "task-new",
         )
@@ -67,6 +72,7 @@ class PlanRefusesCrossSenderDedup(unittest.TestCase):
     def setUp(self):
         self._td = tempfile.TemporaryDirectory()
         self.tmp = self._td.name
+        self._n = 0
 
     def tearDown(self):
         self._td.cleanup()
@@ -75,8 +81,24 @@ class PlanRefusesCrossSenderDedup(unittest.TestCase):
         action, payload = self._plan("@bob:ag2.space")
         self.assertEqual(action, "requeue", "a cross-sender dedup was honoured — the asker is silenced")
         self.assertEqual(payload, "task-new")
-        body = (Path(self.tmp) / "tasks" / "task-new.txt").read_text()
+        body = (Path(self.tmp) / "ws0" / "tasks" / "task-new.txt").read_text()
         self.assertIn("DIFFERENT sender", body)
+
+
+    def test_cross_sender_requeue_is_capped_like_the_other_branch(self):
+        # `dedup_decision` short-circuits on holder-delivered, so its
+        # `dedup_requeue_count >= 1 -> report` cap never runs for this path.
+        # Without an explicit cap here a cross-sender fold re-asks forever.
+        first, _ = self._plan("@bob:ag2.space")
+        self.assertEqual(first, "requeue")
+        second, msg = self._plan("@bob:ag2.space", count=1)
+        self.assertEqual(second, "report", "cross-sender re-asks without bound")
+        self.assertIn("asked by someone else", msg)
+
+    def test_holder_empty_cap_still_works(self):
+        # Positive control: the branch the existing cap does guard.
+        self.assertEqual(self._plan("@alice:ag2.space", holder_result="[no-send]\n")[0], "requeue")
+        self.assertEqual(self._plan("@alice:ag2.space", holder_result="[no-send]\n", count=1)[0], "report")
 
     def test_same_room_same_sender_is_still_honoured(self):
         # The case dedup exists for; a fix that requeues this is worse than the bug.

--- a/tests/dedup-cross-sender.test.py
+++ b/tests/dedup-cross-sender.test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""A dedup that folds one sender's task into another's must not be honoured.
+
+`dedup_cross_channel_target` asks whether the reply left the ROOM. In a shared
+multi-member room every sender carries the same `channel_id`, so it returns
+None and the dedup is honoured — the holder is answered, the asker hears
+nothing, and every existence check passes. Measured: 74 such silences in one
+20-member room across 6 senders.
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from dedup_recovery import plan_dedup_recovery  # noqa: E402
+
+ROOM = "!bKQkxfOrHZwejIyDLI:ag2.space"
+
+
+def _task(tid, user, channel=ROOM):
+    # Header shape the bridges actually write: `task:` stays last.
+    return (f"id: {tid}\nsource: ag2space\nchannel_id: {channel}\n"
+            f"user_id: {user}\naccess_tier: team\ntask: original ask\n")
+
+
+class CrossSenderPredicate(unittest.TestCase):
+    # imported here, not at module scope, so the behavioural class below
+    # still runs (and fails on its VERDICT) against a tree without them.
+    def test_flags_a_different_sender(self):
+        from result_markers import dedup_cross_sender_target
+        self.assertEqual(
+            dedup_cross_sender_target("@alice:ag2.space", _task("task-h", "@bob:ag2.space")),
+            "@bob:ag2.space",
+        )
+
+    def test_quiet_for_the_same_sender(self):
+        from result_markers import dedup_cross_sender_target
+        self.assertIsNone(
+            dedup_cross_sender_target("@alice:ag2.space", _task("task-h", "@alice:ag2.space")))
+
+    def test_quiet_when_the_holder_has_no_user_id(self):
+        from result_markers import dedup_cross_sender_target
+        self.assertIsNone(dedup_cross_sender_target("@alice:ag2.space", "id: task-h\ntask: x\n"))
+
+    def test_task_user_id_reads_the_header(self):
+        from result_markers import task_user_id
+        self.assertEqual(task_user_id(_task("task-a", "@alice:ag2.space")), "@alice:ag2.space")
+        self.assertIsNone(task_user_id(None))
+
+
+class PlanRefusesCrossSenderDedup(unittest.TestCase):
+    """The regression: same room, different senders, holder DID deliver."""
+
+    def _plan(self, holder_user):
+        d = Path(self.tmp)
+        tasks, results = d / "tasks", d / "results"
+        tasks.mkdir(), results.mkdir()
+        (tasks / "task-victim.txt").write_text(_task("task-victim", "@alice:ag2.space"))
+        (tasks / "task-holder.txt").write_text(_task("task-holder", holder_user))
+        (results / "task-holder.txt").write_text("a real, delivered answer\n")
+        return plan_dedup_recovery(
+            results, tasks, "task-victim", "task-holder", ROOM, "task-new",
+        )
+
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = self._td.name
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def test_same_room_different_sender_is_requeued_not_honoured(self):
+        action, payload = self._plan("@bob:ag2.space")
+        self.assertEqual(action, "requeue", "a cross-sender dedup was honoured — the asker is silenced")
+        self.assertEqual(payload, "task-new")
+        body = (Path(self.tmp) / "tasks" / "task-new.txt").read_text()
+        self.assertIn("DIFFERENT sender", body)
+
+    def test_same_room_same_sender_is_still_honoured(self):
+        # The case dedup exists for; a fix that requeues this is worse than the bug.
+        self.assertEqual(self._plan("@alice:ag2.space"), ("honour", None))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/dedup-cross-sender.test.py
+++ b/tests/dedup-cross-sender.test.py
@@ -86,9 +86,8 @@ class PlanRefusesCrossSenderDedup(unittest.TestCase):
 
 
     def test_cross_sender_requeue_is_capped_like_the_other_branch(self):
-        # `dedup_decision` short-circuits on holder-delivered, so its
-        # `dedup_requeue_count >= 1 -> report` cap never runs for this path.
-        # Without an explicit cap here a cross-sender fold re-asks forever.
+        # `dedup_decision` short-circuits on holder-delivered, so its own
+        # requeue cap never runs here and the fold would re-ask forever.
         first, _ = self._plan("@bob:ag2.space")
         self.assertEqual(first, "requeue")
         second, msg = self._plan("@bob:ag2.space", count=1)


### PR DESCRIPTION
Fixes the predicate @marklysze diagnosed in #3741.

## The bug

`dedup_cross_channel_target` asks whether a `[deduped: task-X]` reply left the **room**. In a shared multi-member room every sender carries the same `channel_id`, so it returns `None`, `dedup_decision` says `honour`, and the result is archived silently — the holder's asker gets the answer, this asker gets nothing, and every existence check on disk passes.

Measured on one live workspace: **74 such silences in a single 20-member room across 6 distinct senders**, none visible to any check. The guard was not missing or unwired; it ran on all 74 and returned "valid".

## Before / after — actual output, not a description

The behavioural test drives the unchanged public API (`plan_dedup_recovery`), so it runs against both trees.

At the parent (`363fd2ee`), source reverted, test kept:

```
FAIL: test_same_room_different_sender_is_requeued_not_honoured
AssertionError: 'honour' != 'requeue'
- honour
+ requeue
FAILED (failures=1, errors=4)          # 4 errors = the new predicate's own tests, symbol absent
```

At this HEAD:

```
Ran 6 tests in 0.003s
OK
```

`test_same_room_same_sender_is_still_honoured` **passes at both commits** — the legitimate intra-sender consolidation is untouched, so detection was not bought with false positives.

Existing suites, unchanged and green at HEAD:

```
rc=0  tests/dedup-holder-delivered.test.py
rc=0  tests/dedup-recovery-plan.test.py
rc=0  tests/bridge-dedup-report-retained.test.py
rc=0  tests/bridge-marker-no-leak.test.py
```

`scripts/review-checks.sh --diff` on the full PR diff: `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`.

## Why it binds in `plan_dedup_recovery`

`dedup_cross_channel_target`'s only production call site is `discord-bridge.py:5015`, so a fix there would cover one surface. `plan_dedup_recovery` is where `dedup_decision` is already bound, and it is reached by Discord, Slack, Telegram and — via the vendored `packages/ag2-sparrow/` copy — the AG2 Space bridge. Binding it there gives every surface the check.

## Why `user_id` and not `sender_name`

A display name is not unique across homeservers. Measured on two independent corpora: **3 display names mapped to multiple `user_id`s** (one human on dev and prod), and **0 `user_id`s mapped to multiple names**. Keying on the name merges those identities and misses a real cross-sender silence.

**The trade-off is real and deliberate, and worth a reviewer's attention.** A strict id compare *splits* that same human, so a dev/prod pair can report cross-sender when nobody was silenced. It is bounded — the requeue path re-asks at most once (`dedup_requeue_count >= 1` → `report`) — and a spurious re-ask costs a message where a missed one costs the answer. If you would rather treat same-localpart-different-homeserver as the same sender, say so and I will add that branch; I did not want to encode that judgement silently.

## Scope

- Both `result_markers.py` copies and both `dedup_recovery.py` copies stay byte-identical (vendored-copy invariant), verified in-run.
- No change to the channel predicate, to `dedup_decision`, or to marker grammar.
- `task_user_id()` is added as a public accessor so callers never re-derive the header regex.