### PR TITLE
fix(restart): the relaunched app must not inherit SUTANDO_CORE_SESSION

### DIFF
--- a/src/restart.sh
+++ b/src/restart.sh
@@ -106,7 +106,9 @@ APP_BIN="$REPO/src/Sutando/Sutando"
 if pgrep -x Sutando > /dev/null 2>&1; then
     echo "  ✓ Sutando.app (already running)"
 elif [ -x "$APP_BIN" ]; then
-    nohup "$APP_BIN" > /tmp/sutando-app.log 2>&1 &
+    # The app is the OUT-of-session restart path: a core-session marker inherited
+    # here makes restart-guard refuse every restart the app later requests.
+    env -u SUTANDO_CORE_SESSION nohup "$APP_BIN" > /tmp/sutando-app.log 2>&1 &
     sleep 1
     # `pgrep -x`, never `-f`: -f matches this script's own argv and would report
     # a launch that did not happen. The ✓ stays inside the verified branch.

--- a/tests/restart-relaunches-the-app.test.py
+++ b/tests/restart-relaunches-the-app.test.py
@@ -56,6 +56,43 @@ class RestartRelaunchesTheApp(unittest.TestCase):
         self.assertRegex(self.text, r'elif \[ -x "\$APP_BIN" \]')
         self.assertIn("Sutando.app skipped", self.text)
 
+    LAUNCH_RE = re.compile(r'^[ \t]*(?:env -u SUTANDO_CORE_SESSION[ \t]+)?nohup "\$APP_BIN" > /tmp/sutando-app\.log 2>&1 &[ \t]*$', re.M)
+
+    def test_launch_line_scrubs_the_core_session_marker(self):
+        """restart.sh runs inside the core session, so a bare nohup hands the app
+        SUTANDO_CORE_SESSION=1; restart-guard then refuses every restart the app
+        later requests (intent file and menu bar both, measured 2026-09-02)."""
+        self.assertRegex(self.text, r'env -u SUTANDO_CORE_SESSION\s+nohup\s+"\$APP_BIN"')
+
+    def test_the_launched_app_does_not_inherit_the_marker(self):
+        """Behavioural: run the real launch line with a fake app that dumps its
+        environment, from a shell that carries the marker. FAILS on the parent
+        (the fake sees SUTANDO_CORE_SESSION=1) and passes once the line scrubs it."""
+        import os
+        import tempfile
+        import textwrap
+        m = self.LAUNCH_RE.search(self.text)
+        self.assertIsNotNone(m, "could not find the app launch line to exercise")
+        with tempfile.TemporaryDirectory() as d:
+            dump = os.path.join(d, "env.txt")
+            fake = os.path.join(d, "Sutando")
+            Path(fake).write_text("#!/bin/bash\nenv > \"$SUTANDO_TEST_ENV_DUMP\"\n")
+            os.chmod(fake, 0o755)
+            line = m.group(0).strip().replace("/tmp/sutando-app.log", os.path.join(d, "app.log"))
+            script = textwrap.dedent(f"""
+                export SUTANDO_CORE_SESSION=1
+                export SUTANDO_TEST_ENV_DUMP={dump!r}
+                APP_BIN={fake!r}
+                {line}
+                wait
+            """)
+            r = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=20)
+            self.assertEqual(0, r.returncode, r.stderr)
+            env = Path(dump).read_text()
+            self.assertIn("SUTANDO_TEST_ENV_DUMP=", env, "fake app never ran")
+            self.assertNotIn("SUTANDO_CORE_SESSION=", env,
+                             "the relaunched app inherited the core-session marker")
+
     def test_the_premise_still_holds_restart_kills_it(self):
         """CONTROL: if restart.sh stops killing the app, this fix is moot and the
         test should say so rather than passing for a stale reason."""


### PR DESCRIPTION
## Why

`src/restart.sh` runs inside the core session, so its `nohup "$APP_BIN"` relaunch handed Sutando.app `SUTANDO_CORE_SESSION=1`. The app is the **out-of-session** restart path, and `src/agent/restart-guard.sh` keys on exactly that variable — so every restart the app later requested was refused as an in-session self-kill: the `core-restart-requested.json` intent **and** the menu-bar Restart, both routed through `restartCore()` → `start-cli.sh --restart`.

Measured on this host, 2026-09-02 (`<workspace>/logs/restart-attempts.log`):

```
20:53:14Z [restart] refused: inherited SUTANDO_CORE_SESSION=1 (in-session self-kill), no override set   <- intent file
21:25:42Z [restart] refused: inherited SUTANDO_CORE_SESSION=1 (in-session self-kill), no override set   <- owner's menu click
21:32:42Z [manual-restart] triggering out-of-session restart via open -a Terminal
21:32:46Z [restart] kill-complete; creating fresh core                                                    <- the only route that worked
```

The app process (launched 2026-08-31 by this exact line — `ppid 1`, nohup) shows the marker in `ps eww`: `SUTANDO_CORE_SESSION=1`, beside `SUTANDO_CORE_RUNTIME=claude`, which no app-launched process should carry.

## What

One line: `env -u SUTANDO_CORE_SESSION nohup "$APP_BIN" …`. Nothing else about the relaunch changes (same guard against double launch, same `pgrep -x` liveness, same log path).

## Evidence

Two tests added to `tests/restart-relaunches-the-app.test.py`:
- `test_launch_line_scrubs_the_core_session_marker` — pins the scrub on the launch line.
- `test_the_launched_app_does_not_inherit_the_marker` — **behavioural**: extracts the real launch line, runs it with `APP_BIN` pointing at a fake app that dumps its environment, from a shell that has exported `SUTANDO_CORE_SESSION=1`, and asserts the dump lacks the marker.

At the parent (`5a6867f6`, tests added, `restart.sh` untouched) — the control:
```
FAIL: test_launch_line_scrubs_the_core_session_marker
FAIL: test_the_launched_app_does_not_inherit_the_marker
Ran 9 tests in 0.424s
FAILED (failures=2)
```
At HEAD (`61daf074`):
```
Ran 9 tests in 0.178s
OK
```
Neighbouring suites at HEAD: `restart-covers-compat-stub-bridge` OK · `restart-voice-agent-lock` passed · `health-check-workspace-root-tidy` passed · `startup-headless.test.sh` 5 passed, 0 failed · `graceful-restart.test.sh` ALL PASS. `bash -n src/restart.sh` clean; `scripts/review-checks.sh --diff` PASS.

## Capability vs configuration — read before merging

This fix is **inert on any host whose app is already running with the marker** (this one included): the scrub applies at the next `restart.sh` relaunch, and the app that needs it is the one that cannot restart itself. One-time repair per affected host, from a terminal outside the core: quit Sutando.app and relaunch it in a clean login shell (or run `bash src/restart.sh` once from a fresh `open -a Terminal` shell, which now relaunches it scrubbed). After that, both app-driven routes pass the guard again.

Belt for a follow-up, not this PR: `RestartCoordinator.swift`'s `restartCore()` spawns `graceful-restart.sh` with the app's own environment unmodified; scrubbing there too would make the app immune to whatever launched it, at the cost of an app rebuild.

@sonichi — this is the durable fix promised in the "restart failed" thread; the one-time app relaunch above is what makes it take effect here.

Stand: Echo Act IV Mini
