### PR TITLE
feat(hitl): serve the PermissionRequest hook event — a requirement only for real dialogs

### DIFF
--- a/hooks/hitl-hook-driver.py
+++ b/hooks/hitl-hook-driver.py
@@ -7,13 +7,19 @@ this hook JSON on stdin; the hook blocks until a human answers the card (or a
 policy answers for them), then prints the decision in the shape the firing
 event expects. Two events are served, told apart by `hook_event_name`:
 
-  PermissionRequest (preferred) — fires only when Claude Code would render a
-    permission dialog, so every requirement it creates is a real block. Output:
+  PermissionRequest — fires only when Claude Code would render a permission
+    dialog, so every requirement it creates is a real block, and its payload
+    carries `permission_suggestions` (the basis for an "allow always"). Output:
     `{"hookSpecificOutput": {"hookEventName": "PermissionRequest",
       "decision": {"behavior": "allow"} | {"behavior": "deny", "message": ...}}}`
-  PreToolUse (legacy registration) — fires before EVERY tool call, dialog or
-    not. Output: `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+    Measured (2.1.258): the TUI still DRAWS the dialog while this hook waits;
+    the decision resolves it. A screen sensor must treat that dialog as owned.
+  PreToolUse — fires before EVERY tool call, dialog or not; while it waits
+    nothing is drawn (the screen shows "Waiting…"). Output:
+    `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
       "permissionDecision": "allow" | "deny", "permissionDecisionReason": ...}}`
+    Neither event's allow clears the ExitPlanMode plan dialog (it asks HOW to
+    proceed, not whether); that dialog stays with the screen layer.
 
 A payload with no `hook_event_name` is treated as PreToolUse (the shape every
 existing registration produces). The card itself is posted by the supervisor's
@@ -25,8 +31,9 @@ Invariants (same as hooks/human-action-bridge.py, which owns AskUserQuestion):
     so Claude Code falls back to its own permission flow
   - policy first: an allowlisted tool never creates a requirement
 
-Registration (settings.json) — PermissionRequest, so the hook runs only for
-real dialogs; keep a PreToolUse entry only on installs that predate the event:
+Registration (settings.json) is a choice, not a default: PreToolUse keeps the
+terminal dialog-free; PermissionRequest is exact and enables "allow always" but
+leaves the dialog drawn under it. Register ONE of the two, never both:
   "PermissionRequest": [{"matcher": "*", "hooks": [{"type": "command",
       "command": "python3 <repo>/hooks/hitl-hook-driver.py", "timeout": 900}]}]
 The hook's own wait (SUTANDO_HITL_TIMEOUT, default 600s) must stay below the

--- a/hooks/hitl-hook-driver.py
+++ b/hooks/hitl-hook-driver.py
@@ -1,12 +1,22 @@
 #!/usr/bin/env python3
-"""hitl-hook-driver — PreToolUse hook that routes a tool-permission decision
+"""hitl-hook-driver — permission hook that routes a tool-permission decision
 through the HumanRequirement Manager instead of the terminal.
 
-Layer 1 of the no-TUI stack: structured, no screen parsing. Claude Code runs
-this hook before every tool call and feeds it JSON on stdin; the hook blocks
-until a human answers the card (or a policy answers for them), then prints
-`{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision":
-"allow" | "deny", ...}}`. The card itself is posted by the supervisor's
+Layer 1 of the no-TUI stack: structured, no screen parsing. Claude Code feeds
+this hook JSON on stdin; the hook blocks until a human answers the card (or a
+policy answers for them), then prints the decision in the shape the firing
+event expects. Two events are served, told apart by `hook_event_name`:
+
+  PermissionRequest (preferred) — fires only when Claude Code would render a
+    permission dialog, so every requirement it creates is a real block. Output:
+    `{"hookSpecificOutput": {"hookEventName": "PermissionRequest",
+      "decision": {"behavior": "allow"} | {"behavior": "deny", "message": ...}}}`
+  PreToolUse (legacy registration) — fires before EVERY tool call, dialog or
+    not. Output: `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+      "permissionDecision": "allow" | "deny", "permissionDecisionReason": ...}}`
+
+A payload with no `hook_event_name` is treated as PreToolUse (the shape every
+existing registration produces). The card itself is posted by the supervisor's
 projector from the same requirement record — this hook never talks to Matrix.
 
 Invariants (same as hooks/human-action-bridge.py, which owns AskUserQuestion):
@@ -15,8 +25,9 @@ Invariants (same as hooks/human-action-bridge.py, which owns AskUserQuestion):
     so Claude Code falls back to its own permission flow
   - policy first: an allowlisted tool never creates a requirement
 
-Registration (settings.json):
-  "PreToolUse": [{"matcher": "*", "hooks": [{"type": "command",
+Registration (settings.json) — PermissionRequest, so the hook runs only for
+real dialogs; keep a PreToolUse entry only on installs that predate the event:
+  "PermissionRequest": [{"matcher": "*", "hooks": [{"type": "command",
       "command": "python3 <repo>/hooks/hitl-hook-driver.py", "timeout": 900}]}]
 The hook's own wait (SUTANDO_HITL_TIMEOUT, default 600s) must stay below the
 registered hook timeout, or Claude Code kills it before it can deny.
@@ -109,8 +120,22 @@ def _requirement(data: dict) -> HumanRequirement:
     )
 
 
-def _emit(decision: dict) -> None:
-    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", **decision}}))
+PERMISSION_REQUEST = "PermissionRequest"
+PRE_TOOL_USE = "PreToolUse"
+
+
+def _event(data: dict) -> str:
+    # Absent = PreToolUse: every registration that predates PermissionRequest sends no name.
+    return PERMISSION_REQUEST if data.get("hook_event_name") == PERMISSION_REQUEST else PRE_TOOL_USE
+
+
+def _emit(event: str, behavior: str, reason: str) -> None:
+    if event == PERMISSION_REQUEST:
+        decision = {"behavior": "allow"} if behavior == "allow" else {"behavior": "deny", "message": reason}
+        out = {"hookEventName": PERMISSION_REQUEST, "decision": decision}
+    else:
+        out = {"hookEventName": PRE_TOOL_USE, "permissionDecision": behavior, "permissionDecisionReason": reason}
+    print(json.dumps({"hookSpecificOutput": out}))
 
 
 def _wait(manager: HitlManager, rid: str, timeout_s: float, poll_s: float):
@@ -133,23 +158,24 @@ def main() -> None:
     tool = str(data.get("tool_name") or "")
     if not tool or tool in OWNED_ELSEWHERE:
         sys.exit(0)  # not ours — no decision, Claude's own flow continues
+    event = _event(data)
     manager = HitlManager(HitlStore(default_store(_workspace())), policy=policy_from_env())
     req = manager.create(_requirement(data))
     if req.decided_by == POLICY_DECIDER and req.chosen_action == "allow":
         manager.resolve(req.id)
-        _emit({"permissionDecision": "allow", "permissionDecisionReason": f"hitl policy: allowlisted tool ({req.id})"})
+        _emit(event, "allow", f"hitl policy: allowlisted tool ({req.id})")
         sys.exit(0)
     timeout_s = float(os.environ.get("SUTANDO_HITL_TIMEOUT", "600"))
     poll_s = float(os.environ.get("SUTANDO_HITL_POLL", "1"))
     chosen = _wait(manager, req.id, timeout_s, poll_s)
     if chosen == "allow":
         manager.resolve(req.id)
-        _emit({"permissionDecision": "allow", "permissionDecisionReason": f"owner allowed via card {req.id}"})
+        _emit(event, "allow", f"owner allowed via card {req.id}")
     elif chosen == "deny":
         manager.resolve(req.id)
-        _emit({"permissionDecision": "deny", "permissionDecisionReason": f"owner denied via card {req.id}"})
+        _emit(event, "deny", f"owner denied via card {req.id}")
     else:
-        _emit({"permissionDecision": "deny", "permissionDecisionReason": TIMEOUT_REASON.format(rid=req.id)})
+        _emit(event, "deny", TIMEOUT_REASON.format(rid=req.id))
     sys.exit(0)
 
 

--- a/tests/hitl-hook-driver.test.py
+++ b/tests/hitl-hook-driver.test.py
@@ -154,6 +154,69 @@ class HookDriverTests(unittest.TestCase):
         [req] = self.mgr.store.all()
         self.assertEqual(req.kind, "confirmation")
 
+    # ── PermissionRequest: same requirement, the event's own decision shape ──
+
+    def _answer_first_active(self, action_id):
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            active = self.mgr.active()
+            if active:
+                req = active[0]
+                self.mgr.apply_action(ActionReply(hitl_id=req.id, expected_revision=req.revision, action_id=action_id, guard=req.guard))
+                return
+            time.sleep(0.1)
+
+    def test_permission_request_allow_uses_the_decision_behavior_shape(self):
+        t = threading.Thread(target=self._answer_first_active, args=("allow",)); t.start()
+        _, out, err = run_hook(self.ws, {"hook_event_name": "PermissionRequest", "tool_name": "Bash",
+                                         "tool_input": {"command": "rm -rf build"}, "permission_suggestions": []}, timeout="10")
+        t.join()
+        hso = out["hookSpecificOutput"]
+        self.assertEqual(hso["hookEventName"], "PermissionRequest", err)
+        self.assertEqual(hso["decision"], {"behavior": "allow"})
+        self.assertNotIn("permissionDecision", hso)  # the PreToolUse field must not leak into this event
+        [req] = self.mgr.store.all()
+        self.assertEqual((req.kind, req.status, req.chosen_action), ("permission", "resolved", "allow"))
+
+    def test_permission_request_deny_carries_the_reason_as_message(self):
+        t = threading.Thread(target=self._answer_first_active, args=("deny",)); t.start()
+        _, out, _ = run_hook(self.ws, {"hook_event_name": "PermissionRequest", "tool_name": "Write",
+                                       "tool_input": {"file_path": "/etc/hosts"}}, timeout="10")
+        t.join()
+        d = out["hookSpecificOutput"]["decision"]
+        self.assertEqual(d["behavior"], "deny")
+        self.assertIn("owner denied via card", d["message"])
+
+    def test_permission_request_timeout_denies_with_the_timeout_message(self):
+        _, out, _ = run_hook(self.ws, {"hook_event_name": "PermissionRequest", "tool_name": "Bash",
+                                       "tool_input": {"command": "true"}}, timeout="1")
+        d = out["hookSpecificOutput"]["decision"]
+        self.assertEqual(d["behavior"], "deny")
+        self.assertIn("No decision", d["message"])
+        [req] = self.mgr.store.all()
+        self.assertEqual(req.status, "expired")
+
+    def test_permission_request_policy_allow_needs_no_card(self):
+        _, out, _ = run_hook(self.ws, {"hook_event_name": "PermissionRequest", "tool_name": "Read",
+                                       "tool_input": {"file_path": "/x"}})
+        self.assertEqual(out["hookSpecificOutput"], {"hookEventName": "PermissionRequest", "decision": {"behavior": "allow"}})
+        [req] = self.mgr.store.all()
+        self.assertEqual(req.decided_by, "policy")
+
+    def test_pre_tool_use_named_explicitly_keeps_the_legacy_shape(self):
+        _, out, _ = run_hook(self.ws, {"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                                       "tool_input": {"command": "true"}}, timeout="1")
+        hso = out["hookSpecificOutput"]
+        self.assertEqual(hso["hookEventName"], "PreToolUse")
+        self.assertEqual(hso["permissionDecision"], "deny")
+        self.assertNotIn("decision", hso)
+
+    def test_unknown_event_name_falls_back_to_the_legacy_shape(self):
+        # A future event we do not know must not produce a PermissionRequest decision by accident.
+        _, out, _ = run_hook(self.ws, {"hook_event_name": "SomethingNew", "tool_name": "Bash",
+                                       "tool_input": {"command": "true"}}, timeout="1")
+        self.assertEqual(out["hookSpecificOutput"]["hookEventName"], "PreToolUse")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Claude Code 2.1.258 has a `PermissionRequest` hook event: it fires only when a permission dialog would render, and its decision replaces the dialog. `PreToolUse` fires before every tool call, dialog or not, so a driver registered there has to guess whether a human is actually needed. The HITL driver should sit on the event that exists precisely when a human is needed. This is PR 1 of the consolidation the owner directed on 2026-09-02 (hooks first; screen sensing only for the residue; one Requirement record).

## What

`hooks/hitl-hook-driver.py` reads `hook_event_name` and answers in the firing event's own shape:

- `PermissionRequest` → `hookSpecificOutput.decision = {"behavior": "allow"}` or `{"behavior": "deny", "message": ...}`
- `PreToolUse`, or no name (every existing registration) → `permissionDecision` / `permissionDecisionReason`, byte-identical to before
- an unknown event name falls back to the PreToolUse shape, so a future event cannot produce a PermissionRequest decision by accident

Requirement creation, the policy allowlist, the card wait, timeout-denies and fail-open are unchanged. Registration guidance in the module docstring moves to `PermissionRequest`.

The decision shapes were read from the installed binary (`hookSpecificOutput.decision: {"behavior": "allow"|"deny", ...}` schema and its validation message: *PermissionRequest decision must be {"behavior": "allow"} or {"behavior": "deny", "message": "..."}*).

## Evidence

Baseline at the parent (`5a6867f67`):

```
$ python3 tests/hitl-hook-driver.test.py
Ran 9 tests in 10.065s
OK
```

At this head (`cf70d76c9`), 6 new tests:

```
$ python3 tests/hitl-hook-driver.test.py
Ran 15 tests in 13.859s
OK
$ for t in tests/hitl-manager-identity.test.py tests/hitl-policy.test.py tests/hitl-schema.test.py tests/human-action-bridge.test.py; do python3 $t | tail -1; done
OK / OK / OK / PASS — human-action-bridge hook (v1 step 1)
```

Mutation control — `if event == PERMISSION_REQUEST:` → `if False:` in `_emit`, restored from the commit afterwards:

```
ERROR: test_permission_request_deny_carries_the_reason_as_message
ERROR: test_permission_request_timeout_denies_with_the_timeout_message
FAIL:  test_permission_request_allow_uses_the_decision_behavior_shape
FAIL:  test_permission_request_policy_allow_needs_no_card
Ran 15 tests in 13.755s
FAILED (failures=2, errors=2)
$ git checkout -- hooks/hitl-hook-driver.py && python3 tests/hitl-hook-driver.test.py | tail -1
OK
```

Exactly the four PermissionRequest-shape tests fail; the nine legacy tests and the two explicit-legacy tests stay green, which is the claim: the legacy path is untouched.

Review gate:

```
$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Live round trip (scratch Claude Code 2.1.258, private tmux socket, project settings register `PermissionRequest` → this driver via a stdin-logging wrapper)

```
== event PermissionRequest  mode default
== prompt sent 22:45:49Z
== requirement hitl_85b0704949cc kind=permission rev=1 msg='Claude wants to run Bash: echo hello > …/permreq-ok.txt'
   screen dialog lines while blocked: [' Do you want to proceed?', '   2. Yes, and always allow access to … from this project', '   3. Yes, and switch to auto mode …']
   card CREATE: [('hitl_85b0704949cc', '$NvHS4BaXx7Tv…')]
   applied allow (allow_once) -> status in_progress
== EXPECT FILE CREATED after 14s
== final hitl_85b0704949cc: status=resolved rev=3 chosen=allow
== hook call 1: event=PermissionRequest tool=Bash keys=['cwd', 'effort', 'hook_event_name', 'permission_mode', 'permission_suggestions', 'prompt_id', 'scratchpad_dir', 'session_id', 'tool_name', 'transcript_path']
```

The hook fired on the event, the requirement was created, the card was projected, allow completed the tool call, the file appeared. **One measured difference from the PreToolUse path:** under `PermissionRequest` the terminal still draws Claude Code's own permission dialog while the hook waits, and the hook's decision resolves it; under `PreToolUse` (same harness, 2026-09-02T19:18Z) no dialog is drawn. So a screen-based Sensor watching the same pane will see the dialog and must treat a permission dialog as already-owned while a hook requirement for that tool is pending. `permission_suggestions` arriving in the payload is what makes an "allow always" action possible (`decision.updatedPermissions`), which `PreToolUse` cannot offer. Registration default (PreToolUse for a dialog-free screen vs PermissionRequest for the extra action) is the owner's pick; the driver serves both.

**Plan approval (ExitPlanMode), same harness, `--permission-mode plan`:**

```
== requirement hitl_ac99552c1cf2 kind=confirmation rev=1 msg='Claude wants to ExitPlanMode: exit plan mode and start executing'
   screen dialog lines while blocked: [' Claude has written up a plan and is ready to execute. Would you like to proceed?', ' ❯ 1. Yes, and use auto mode']
   card CREATE: [('hitl_ac99552c1cf2', '$gxxpFEauLUCH…')]
   applied allow (allow_once) -> status in_progress
== FAIL: expect file never appeared            (plan dialog still on screen at the 240 s budget)
== hook call 1: event=PermissionRequest tool=ExitPlanMode
```

`PermissionRequest` does fire for ExitPlanMode and the driver answers it, but `{"behavior": "allow"}` does not clear the plan-approval dialog: it asks *how* to proceed (auto mode / manually approve edits / tell Claude what to change), not *whether*. So #3734 (leave ExitPlanMode to the screen layer) stands under this event too; this PR does not supersede it.

**AskUserQuestion, same harness:**

```
== hook call 1: event=PermissionRequest tool=AskUserQuestion
== screen at end:  ☐ Color / Do you prefer blue or green? / ❯ 1. Blue / 2. Green / 3. Type something. / 4. Chat about this
```

The event fires for AskUserQuestion as well (so the ask is reachable as structured data); this driver leaves that tool to `hooks/human-action-bridge.py` (`OWNED_ELSEWHERE`), which today registers on PreToolUse and returns the owner's answer as allow + `updatedInput`. Doing the same through `PermissionRequest` is the bridge's follow-up, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
