### PR TITLE
fix(sync): commit local edits before the pull, so a refused pull's reset cannot erase them

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -1226,6 +1226,17 @@ _migrate_flat_anchor() {
     echo "sync-workspace: migrated the per-host anchor to hosts/$(_host)/current-track.md (was at the shared flat path; #2567)" >&2
 }
 
+# Commit modified + new carrier files before a pull. Runs generate_exclude first
+# so an out-of-carrier path cannot ride into the vault on this commit.
+_commit_local_pre_pull() {
+    generate_exclude 2>/dev/null || true
+    git add --ignore-removal . 2>/dev/null || true
+    if ! git diff --cached --quiet 2>/dev/null; then
+        git commit -q -m "Sync ${SUTANDO_HOST_OVERRIDE:-$(hostname)} $(date +%Y-%m-%dT%H:%M) path=${WORKSPACE_DIR}" \
+            && log "_pull_only_impl: committed local edits before the pull (a refused pull now resets to a commit that holds them)"
+    fi
+}
+
 _pull_only_impl() {
     cd "$WORKSPACE_DIR" || die "pull-only: cannot cd to $WORKSPACE_DIR"
     [ -d ".git" ] || die "pull-only: $WORKSPACE_DIR is not a git repo; run --init first"
@@ -1273,6 +1284,10 @@ _pull_only_impl() {
         fi
         [ "$_co_rc" -eq 0 ] || die "pull-only: failed to switch to $current_branch (git checkout exit $_co_rc); see $LOG"
     fi
+
+    # A refused pull resets to pre_pull_sha, so local edits must already be IN
+    # it; deletions stay unstaged for the push-side tripwire to count.
+    _commit_local_pre_pull
 
     # Pro #1445 review fix #2: snapshot pre-pull state for the mass-deletion
     # tripwire on the pull side. The push-side tripwire only catches staged

--- a/tests/sync-workspace-prepull-commit-survives-refusal.test.sh
+++ b/tests/sync-workspace-prepull-commit-survives-refusal.test.sh
@@ -63,6 +63,15 @@ git -C "$hostB_WS" log -1 --format=%s -- notes/hostB-note.md | grep -q "Sync hos
 rm "$hostB_WS/notes/bulk-1.md"
 runsync hostB wsb --pull-only >/dev/null 2>&1 || true
 git -C "$hostB_WS" ls-files notes/bulk-1.md | grep -q . && ok "a local deletion is left for the push tripwire (still tracked after the pull)" || bad "the pre-pull commit swallowed a local deletion"
+# The safety of committing before the pull rests on generate_exclude running
+# BEFORE the add: reordering the two would let an out-of-carrier path ride into
+# the vault with every behavioural check above still green. Pin the order.
+fn="$(awk '/^_commit_local_pre_pull\(\) \{/,/^\}/' "$REPO/scripts/sync-workspace.sh")"
+ex_line="$(printf '%s\n' "$fn" | grep -n 'generate_exclude' | head -1 | cut -d: -f1)"
+add_line="$(printf '%s\n' "$fn" | grep -n 'git add ' | head -1 | cut -d: -f1)"
+[ -n "$ex_line" ] && [ -n "$add_line" ] && [ "$ex_line" -lt "$add_line" ] \
+  && ok "generate_exclude runs BEFORE git add inside _commit_local_pre_pull (order pinned)" \
+  || bad "generate_exclude must precede git add in _commit_local_pre_pull (ex=$ex_line add=$add_line)"
 printf '\n%s: %d passed, %d failed\n' "sync pre-pull commit" "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 echo "PASS — local edits survive a refused pull"

--- a/tests/sync-workspace-prepull-commit-survives-refusal.test.sh
+++ b/tests/sync-workspace-prepull-commit-survives-refusal.test.sh
@@ -6,6 +6,11 @@
 # The fix commits local edits BEFORE the pull, so the reset cannot reach them.
 set -u
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
+# The script commits with whatever identity git can derive; a CI runner whose
+# user has no GECOS name yields "empty ident name", so pass one through env -i
+# exactly as tests/sync-workspace.test.sh exports it for its own runs.
+export GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-sync-prepull-test}"
+export GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-sync-prepull-test@invalid}"
 TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sync-prepull.XXXXXX")"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 pass=0; fail=0
@@ -22,6 +27,8 @@ mkhost() {  # name wsid -> sets ${name}_REPO ${name}_WS, runs --init
 JSON
   echo "$n note" > "$w/notes/$n-note.md"
   env -i HOME="$HOME" PATH="$PATH" SUTANDO_REPO_DIR="$r" SUTANDO_WORKSPACE="$w" SUTANDO_TEST_MODE=1 \
+      GIT_AUTHOR_NAME="$GIT_AUTHOR_NAME" GIT_AUTHOR_EMAIL="$GIT_AUTHOR_EMAIL" \
+      GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME" GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL" \
       SUTANDO_HOST_OVERRIDE="$n" SUTANDO_WS_ID_OVERRIDE="$wsid" \
       bash "$r/scripts/sync-workspace.sh" --vault-url "$VAULT" --init >/dev/null 2>&1
   eval "${n}_REPO=\"$r\"; ${n}_WS=\"$w\""
@@ -30,6 +37,8 @@ runsync() {  # name wsid args...
   local n="$1" wsid="$2"; shift 2
   local r="$TEST_ROOT/$n-repo" w="$TEST_ROOT/$n-ws"
   env -i HOME="$HOME" PATH="$PATH" SUTANDO_REPO_DIR="$r" SUTANDO_WORKSPACE="$w" SUTANDO_TEST_MODE=1 \
+      GIT_AUTHOR_NAME="$GIT_AUTHOR_NAME" GIT_AUTHOR_EMAIL="$GIT_AUTHOR_EMAIL" \
+      GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME" GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL" \
       SUTANDO_HOST_OVERRIDE="$n" SUTANDO_WS_ID_OVERRIDE="$wsid" SUTANDO_FORCE_SYNC="${FORCE:-0}" \
       bash "$r/scripts/sync-workspace.sh" --vault-url "$VAULT" "$@" 2>&1
 }

--- a/tests/sync-workspace-prepull-commit-survives-refusal.test.sh
+++ b/tests/sync-workspace-prepull-commit-survives-refusal.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# A refused pull resets to the pre-pull commit. Local edits that were never
+# committed before the pull are erased by that reset — measured 2026-09-02 on a
+# host whose every pull was refused for 18 hours: 34 resets, every uncommitted
+# edit under the carrier set gone within 30 minutes of being written.
+# The fix commits local edits BEFORE the pull, so the reset cannot reach them.
+set -u
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sync-prepull.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+pass=0; fail=0
+ok()   { echo "  OK: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+mkhost() {  # name wsid -> sets ${name}_REPO ${name}_WS, runs --init
+  local n="$1" wsid="$2" r="$TEST_ROOT/$1-repo" w="$TEST_ROOT/$1-ws"
+  mkdir -p "$w/notes" "$r/scripts" "$r/src"; touch "$r/CLAUDE.md"; git init -q "$r"
+  cp "$REPO/scripts/sync-workspace.sh" "$REPO/scripts/sutando-config.sh" "$REPO/scripts/python-binary.sh" "$r/scripts/"
+  cp "$REPO/src/sutando_config.py" "$r/src/"
+  cat > "$r/sutando.config.json" <<'JSON'
+{"workspace": {"path": "${REPO_DIR}/workspace"},
+ "vault": {"enabled": false, "sync": {"include": ["notes/"], "exclude": []}}}
+JSON
+  echo "$n note" > "$w/notes/$n-note.md"
+  env -i HOME="$HOME" PATH="$PATH" SUTANDO_REPO_DIR="$r" SUTANDO_WORKSPACE="$w" SUTANDO_TEST_MODE=1 \
+      SUTANDO_HOST_OVERRIDE="$n" SUTANDO_WS_ID_OVERRIDE="$wsid" \
+      bash "$r/scripts/sync-workspace.sh" --vault-url "$VAULT" --init >/dev/null 2>&1
+  eval "${n}_REPO=\"$r\"; ${n}_WS=\"$w\""
+}
+runsync() {  # name wsid args...
+  local n="$1" wsid="$2"; shift 2
+  local r="$TEST_ROOT/$n-repo" w="$TEST_ROOT/$n-ws"
+  env -i HOME="$HOME" PATH="$PATH" SUTANDO_REPO_DIR="$r" SUTANDO_WORKSPACE="$w" SUTANDO_TEST_MODE=1 \
+      SUTANDO_HOST_OVERRIDE="$n" SUTANDO_WS_ID_OVERRIDE="$wsid" SUTANDO_FORCE_SYNC="${FORCE:-0}" \
+      bash "$r/scripts/sync-workspace.sh" --vault-url "$VAULT" "$@" 2>&1
+}
+VAULT="$TEST_ROOT/vault.git"; git init -q --bare "$VAULT"
+mkhost hostA wsa; mkhost hostB wsb
+# host A publishes 60 files; host B pulls them so they are TRACKED on B.
+for i in $(seq 1 60); do echo "bulk $i" > "$hostA_WS/notes/bulk-$i.md"; done
+runsync hostA wsa --push-only >/dev/null
+runsync hostB wsb --pull-only >/dev/null
+[ "$(git -C "$hostB_WS" ls-files 'notes/bulk-*' | wc -l | tr -d ' ')" = "60" ] && ok "fixture: hostB tracks the 60 files" || bad "fixture: hostB does not track the 60 files"
+# host A deletes all 60 (>SUTANDO_SYNC_MAX_DELETE=50) and publishes.
+rm "$hostA_WS"/notes/bulk-*.md
+# host A's OWN push tripwire refuses 60 deletions too; the force override is A's
+# deliberate choice here, so the fixture reproduces the peer-side shape.
+FORCE=1 runsync hostA wsa --push-only >/dev/null 2>&1 || true
+git -C "$hostA_WS" ls-files 'notes/bulk-*' | grep -q . && bad "fixture: hostA still tracks bulk files" || ok "fixture: hostA published the 60 deletions"
+# host B: an UNCOMMITTED edit to a tracked file, then a pull that will be refused.
+echo "edit written before the pull" >> "$hostB_WS/notes/hostB-note.md"
+git -C "$hostB_WS" diff --quiet -- notes/hostB-note.md && bad "fixture: edit is not uncommitted" || ok "fixture: the edit is uncommitted at pull time"
+OUT="$(runsync hostB wsb --pull-only)"; rc=$?
+echo "$OUT" | grep -q "REFUSING pull" && ok "the pull was refused by the mass-delete tripwire (rc=$rc)" || bad "expected a refused pull; got rc=$rc: $(echo "$OUT" | tail -2)"
+grep -q "edit written before the pull" "$hostB_WS/notes/hostB-note.md" \
+  && ok "THE POINT: the uncommitted edit SURVIVES the refused pull's reset" \
+  || bad "THE POINT: the refused pull's reset ERASED the local edit"
+git -C "$hostB_WS" log -1 --format=%s -- notes/hostB-note.md | grep -q "Sync hostB" \
+  && ok "the edit was committed before the pull (so the reset target contains it)" \
+  || bad "the edit is not in a pre-pull commit"
+[ "$(git -C "$hostB_WS" ls-files 'notes/bulk-*' | wc -l | tr -d ' ')" = "60" ] && ok "hostB still tracks its 60 files (the refusal held)" || bad "hostB lost tracked files despite the refusal"
+# A LOCAL deletion must NOT be swept into the pre-pull commit: the push-side
+# tripwire counts staged deletions, and committing them here would bypass it.
+rm "$hostB_WS/notes/bulk-1.md"
+runsync hostB wsb --pull-only >/dev/null 2>&1 || true
+git -C "$hostB_WS" ls-files notes/bulk-1.md | grep -q . && ok "a local deletion is left for the push tripwire (still tracked after the pull)" || bad "the pre-pull commit swallowed a local deletion"
+printf '\n%s: %d passed, %d failed\n' "sync pre-pull commit" "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "PASS — local edits survive a refused pull"


### PR DESCRIPTION
## Why

`_pull_only_impl` snapshots `pre_pull_sha`, merges the peers, and on a tripped mass-delete guard runs `git reset --hard "$pre_pull_sha"` (`scripts/sync-workspace.sh:1366`). The local `Sync <host>` commit only happens afterwards in `_push_only_impl` (`:1495`), so at reset time every uncommitted edit under the carrier set is discarded.

Measured 2026-09-02 on a host whose every pull had been refused since ~05Z (a peer removed `data/` from the carrier — separate question, not this PR):

```
$ grep -c 'Reset to pre-pull state' <workspace>/logs/workspace-sync.log
34
$ git reflog -5 --format='%gs'        # workspace vault clone
commit: Sync <host> 2026-09-02T16:11 …
reset: moving to 0b009b9a…            <- the refusal's reset
merge origin/host/<peer>/…: Merge made by the 'ort' strategy.
merge origin/host/<peer2>/…: Merge made by the 'ort' strategy.
commit: Sync <host> 2026-09-02T16:04 …
```

A pending-questions entry counted at position 1 by the reader at 23:05Z was gone after the 23:11Z run; `current-track.md` lost every line written that session; the restart-watch heartbeat under `hosts/` reverted to a stale value on each run (so peers read the host as stale — the exact failure the beat exists to prevent). Files outside the carrier (`state/`, `results/`, the root build log) were untouched, which is what made it invisible for 18 hours.

## What

`_commit_local_pre_pull`, called at the top of `_pull_only_impl` before the snapshot: runs `generate_exclude` first (nothing outside the carrier can ride into the vault on this commit), stages modified + new files with `git add --ignore-removal`, commits with the same `Sync <host> <time> path=` message the push uses (cross-host wsId discovery reads that suffix). **Deletions are left unstaged on purpose**: the push-side tripwire counts staged deletions, and committing them here would let a mass local deletion bypass it. Trade-off, stated: a local deletion present at a refused pull is restored by the reset (the file comes back), which is the safe polarity.

**Order is load-bearing (reviewer note, Pro):** the safety of committing before the pull rests entirely on `generate_exclude` running BEFORE the `git add`; a later reorder would let an out-of-carrier path ride into the vault with every behavioural check still green. The test now pins that order from the function text (swapping the two lines fails exactly that check).

## Evidence

New `tests/sync-workspace-prepull-commit-survives-refusal.test.sh` drives the real script through the existing two-host harness: A publishes 60 files, B pulls them (tracked), A deletes all 60 and force-pushes, B appends to a tracked file and pulls.

Parent (`f39b2df2`, test added, script untouched):
```
  OK: the pull was refused by the mass-delete tripwire (rc=1)
  FAIL: THE POINT: the refused pull's reset ERASED the local edit
  FAIL: the edit is not in a pre-pull commit
sync pre-pull commit: 6 passed, 2 failed
```
HEAD:
```
  OK: the pull was refused by the mass-delete tripwire (rc=1)
  OK: THE POINT: the uncommitted edit SURVIVES the refused pull's reset
  OK: the edit was committed before the pull (so the reset target contains it)
  OK: hostB still tracks its 60 files (the refusal held)
  OK: a local deletion is left for the push tripwire (still tracked after the pull)
sync pre-pull commit: 8 passed, 0 failed
```
Existing suites at HEAD: `sync-workspace.test.sh` **89/89**; `-conflict-preserves-theirs` 13/13; `-gitignore-untrack`, `-uninit-guard`, `install-workspace-sync` ALL PASS; `-foreign-host-guard` 21/21; `-anchor-migration` 12/12; `vault-carrier-default-current-track` 14/14. `bash -n` clean; `review-checks.sh --diff` clean.

## Live path

This is the cron's sync script, read from disk at each fire — no restart involved. The post-merge witness on the affected host: the next refused run's log line followed by the pending-questions reader still counting the entry filed before it; I will post that here after the pull.

@sonichi — this is the data-loss half of Q55; the carrier-scope question stays yours.

Stand: Echo Act IV Mini