### PR TITLE
feat(hitl): apply card clicks that arrive on the task relay

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -781,6 +781,27 @@ def _resolve_review_card(path: Path, record: dict) -> bool:
     return True
 
 
+def _handle_hitl_action(task: dict) -> bool:
+    """An owner card click delivered on the task relay (its `hitl_action`, or a
+    reply to the card whose text is an action label). Applied to the HITL
+    store here so a click never becomes a chat task; the caller closes the
+    task with a [no-send] control result. False = an ordinary message."""
+    task_id = str(task.get("id") or "")
+    if task_id and _control_result_path(task_id).is_file():
+        return isinstance(task.get("hitl_action"), dict)  # redelivery of a consumed click
+    if not isinstance(task.get("hitl_action"), dict) and not task.get("reply_to_event"):
+        return False
+    owner = os.environ.get("SPARROW_HA_OWNER") or ""
+    handler = _hitl_reply_handler(owner, log=_log) if owner else None
+    if handler is None:
+        return False  # no owner or no store on this host: the click stays an ordinary task
+    try:
+        return bool(handler.offer_task(task))
+    except Exception as e:  # noqa: BLE001 — a broken click must not stall the poll loop
+        _log(f"hitl: task-relay click {task_id} not applied: {e}")
+        return False
+
+
 def _handle_review_decision(task: dict) -> bool:
     task_id = str(task.get("id") or "")
     if task_id and _control_result_path(task_id).is_file():
@@ -3642,6 +3663,11 @@ def main() -> None:
                     _queue_review_control_result(task)
                     _retry_review_control_results()
                     _log(f"consumed private review decision {task.get('id')}")
+                    continue
+                if _handle_hitl_action(task):
+                    _queue_review_control_result(task)
+                    _retry_review_control_results()
+                    _log(f"hitl: consumed card click {task.get('id')} from the task relay")
                     continue
                 tid = _write_task(task)
                 if tid:

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -934,6 +934,10 @@ def _handle_hitl_action(task: dict):
         return False
     if out == "rejected":
         return "rejected:" + (getattr(handler, "last_reason", "") or "stale or malformed")
+    if out == "ignored" and getattr(handler, "last_branch", None) == "fallback":
+        # A non-owner typed a label as a reply: that is a message, not a click
+        # to decline; it must reach _write_task like any other text.
+        return False
     return out or False
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -919,8 +919,10 @@ def _handle_hitl_action(task: dict):
     store here so a click never becomes a chat task; the caller closes the
     task with a [no-send] control result. False = an ordinary message."""
     task_id = str(task.get("id") or "")
+    # The control record exists only for a task already consumed here (either
+    # click form, or a review decision); its form must not be re-derived.
     if task_id and _control_result_path(task_id).is_file():
-        return "applied" if isinstance(task.get("hitl_action"), dict) else False  # redelivery
+        return "redelivered"
     if not isinstance(task.get("hitl_action"), dict) and not task.get("reply_to_event"):
         return False
     owner = os.environ.get("SPARROW_HA_OWNER") or ""
@@ -938,6 +940,8 @@ def _handle_hitl_action(task: dict):
         # A non-owner typed a label as a reply: that is a message, not a click
         # to decline; it must reach _write_task like any other text.
         return False
+    # A non-owner's real click stays consumed on purpose: a card press is not
+    # prose, so it closes [no-send] and is only logged, never a chat task.
     return out or False
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -781,14 +781,14 @@ def _resolve_review_card(path: Path, record: dict) -> bool:
     return True
 
 
-def _handle_hitl_action(task: dict) -> bool:
+def _handle_hitl_action(task: dict):
     """An owner card click delivered on the task relay (its `hitl_action`, or a
     reply to the card whose text is an action label). Applied to the HITL
     store here so a click never becomes a chat task; the caller closes the
     task with a [no-send] control result. False = an ordinary message."""
     task_id = str(task.get("id") or "")
     if task_id and _control_result_path(task_id).is_file():
-        return isinstance(task.get("hitl_action"), dict)  # redelivery of a consumed click
+        return "applied" if isinstance(task.get("hitl_action"), dict) else False  # redelivery
     if not isinstance(task.get("hitl_action"), dict) and not task.get("reply_to_event"):
         return False
     owner = os.environ.get("SPARROW_HA_OWNER") or ""
@@ -796,10 +796,13 @@ def _handle_hitl_action(task: dict) -> bool:
     if handler is None:
         return False  # no owner or no store on this host: the click stays an ordinary task
     try:
-        return bool(handler.offer_task(task))
+        out = handler.offer_task(task)
     except Exception as e:  # noqa: BLE001 — a broken click must not stall the poll loop
         _log(f"hitl: task-relay click {task_id} not applied: {e}")
         return False
+    if out == "rejected":
+        return "rejected:" + (getattr(handler, "last_reason", "") or "stale or malformed")
+    return out or False
 
 
 def _handle_review_decision(task: dict) -> bool:
@@ -868,13 +871,13 @@ def _control_result_path(task_id: str) -> Path:
     return _WITHHELD_CONTROL_DIR / f"{safe}.json"
 
 
-def _queue_review_control_result(task: dict) -> None:
+def _queue_review_control_result(task: dict, body: str = "[no-send]") -> None:
     task_id = str(task.get("id") or "")
     if not task_id:
         return
     path = _control_result_path(task_id)
     if not path.is_file():
-        _atomic_private_json(path, {"id": task_id, "body": "[no-send]"})
+        _atomic_private_json(path, {"id": task_id, "body": body})
 
 
 def _retry_review_control_results() -> None:
@@ -3659,15 +3662,20 @@ def main() -> None:
             added = False
             pending_ack = []
             for task in resp.get("tasks", []):
+                hitl_out = _handle_hitl_action(task)
+                if hitl_out:
+                    body = "[no-send]"
+                    if str(hitl_out).startswith("rejected:"):
+                        body = ("That click did not apply: the card had already moved "
+                                f"({str(hitl_out)[9:]}). Please use the current card.")
+                    _queue_review_control_result(task, body=body)
+                    _retry_review_control_results()
+                    _log(f"hitl: consumed card click {task.get('id')} from the task relay ({hitl_out})")
+                    continue
                 if _handle_review_decision(task):
                     _queue_review_control_result(task)
                     _retry_review_control_results()
                     _log(f"consumed private review decision {task.get('id')}")
-                    continue
-                if _handle_hitl_action(task):
-                    _queue_review_control_result(task)
-                    _retry_review_control_results()
-                    _log(f"hitl: consumed card click {task.get('id')} from the task relay")
                     continue
                 tid = _write_task(task)
                 if tid:

--- a/src/hitl/replies.py
+++ b/src/hitl/replies.py
@@ -84,6 +84,9 @@ class HitlReplyHandler:
         # What the most recent offer() did: applied | rejected | ignored (+ reason).
         self.last_outcome = None
         self.last_reason = ""
+        # Form task_to_event() last recognised: "click" (hitl_action) or
+        # "fallback" (typed label) — a non-owner's fallback is a MESSAGE.
+        self.last_branch = None
 
     def claims(self, event: Dict[str, Any]) -> bool:
         content = event.get("content") or {}
@@ -96,6 +99,7 @@ class HitlReplyHandler:
             return claimed
         actor = str(event.get("actor_id") or "")
         self.last_outcome = "ignored"
+        self.last_reason = ""
         # AUTHORIZATION — the whole point: only the owner resolves.
         if not self._owner or actor != self._owner:
             self._log(f"hitl: action reply from non-owner {actor or '?'} ignored")
@@ -146,8 +150,10 @@ class HitlReplyHandler:
             "room_id": task.get("channel_id"),
             "actor_id": str(task.get("user_id") or ""),
         }
+        self.last_branch = None
         payload = task.get("hitl_action")
         if isinstance(payload, dict):
+            self.last_branch = "click"
             return {**base, "content": {REPLY_FIELD: dict(payload)}}
         target = str(task.get("reply_to_event") or "")
         if not target:
@@ -160,6 +166,7 @@ class HitlReplyHandler:
                        if a.label.strip().lower() == label or a.id.lower() == label), None)
         if action is None:
             return None  # a reply to the card that is not a click stays a message
+        self.last_branch = "fallback"
         return {**base, "content": {REPLY_FIELD: {
             "hitl_id": req.id, "expected_revision": req.revision,
             "action_id": action.id, "guard": req.guard}}}

--- a/src/hitl/replies.py
+++ b/src/hitl/replies.py
@@ -81,6 +81,9 @@ class HitlReplyHandler:
         self._workspace = Path(workspace) if workspace is not None else None
         self._log = log
         self.last_path = None  # handler-contract compat (never promotes tasks)
+        # What the most recent offer() did: applied | rejected | ignored (+ reason).
+        self.last_outcome = None
+        self.last_reason = ""
 
     def claims(self, event: Dict[str, Any]) -> bool:
         content = event.get("content") or {}
@@ -115,16 +118,16 @@ class HitlReplyHandler:
 
     # -- task-relay path ---------------------------------------------------------
 
-    def offer_task(self, task: Dict[str, Any]) -> bool:
+    def offer_task(self, task: Dict[str, Any]) -> Optional[str]:
         """A click delivered as a relay TASK, not an event (an owner DM travels
-        only the task relay). True = it was a click and is consumed here,
-        whatever the Manager decided; False = an ordinary message, leave it on
-        the task path."""
+        only the task relay). Returns "applied" / "rejected" / "ignored" for a
+        click (consumed either way), or None for an ordinary message that stays
+        on the task path. A rejection is the owner's to hear about."""
         event = self.task_to_event(task)
         if event is None:
-            return False
+            return None
         self.offer(event)
-        return True
+        return self.last_outcome or "ignored"
 
     def task_to_event(self, task: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Exact form: `hitl_action` (the relay forwards the message's action

--- a/src/hitl/replies.py
+++ b/src/hitl/replies.py
@@ -95,6 +95,7 @@ class HitlReplyHandler:
         if not self.claims(event):
             return claimed
         actor = str(event.get("actor_id") or "")
+        self.last_outcome = "ignored"
         # AUTHORIZATION — the whole point: only the owner resolves.
         if not self._owner or actor != self._owner:
             self._log(f"hitl: action reply from non-owner {actor or '?'} ignored")
@@ -102,12 +103,17 @@ class HitlReplyHandler:
         reply = parse_reply(event)
         if reply is None:
             self._log("hitl: malformed action reply ignored")
+            self.last_outcome = "rejected"
+            self.last_reason = "malformed action payload"
             return claimed
         try:
             action = self._manager.apply_action(reply)
         except (StaleRequirementError, MalformedActionError) as e:
             self._log(f"hitl: reply for {reply.hitl_id} rejected — {e}")
+            self.last_outcome = "rejected"
+            self.last_reason = str(e)
             return claimed
+        self.last_outcome = "applied"
         note = ""
         if action.kind == TUI_ACTION_KIND and self._workspace is not None:
             req = self._manager.get(reply.hitl_id)

--- a/src/hitl/replies.py
+++ b/src/hitl/replies.py
@@ -112,3 +112,63 @@ class HitlReplyHandler:
                 note = f"; driver action {write_driver_action(self._workspace, req, action).name}"
         self._log(f"hitl: {reply.hitl_id} -> {action.id} by {actor} (in_progress{note})")
         return claimed
+
+    # -- task-relay path ---------------------------------------------------------
+
+    def offer_task(self, task: Dict[str, Any]) -> bool:
+        """A click delivered as a relay TASK, not an event (an owner DM travels
+        only the task relay). True = it was a click and is consumed here,
+        whatever the Manager decided; False = an ordinary message, leave it on
+        the task path."""
+        event = self.task_to_event(task)
+        if event is None:
+            return False
+        self.offer(event)
+        return True
+
+    def task_to_event(self, task: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Exact form: `hitl_action` (the relay forwards the message's action
+        field). Fallback: a reply to a card's own event whose text is one of
+        that card's action labels — the projection ledger names the card event,
+        so no field is needed. Anything else is not a click."""
+        base = {
+            "type": EVENT_TYPE,
+            "event_id": str(task.get("source_message_id") or task.get("id") or ""),
+            "room_id": task.get("channel_id"),
+            "actor_id": str(task.get("user_id") or ""),
+        }
+        payload = task.get("hitl_action")
+        if isinstance(payload, dict):
+            return {**base, "content": {REPLY_FIELD: dict(payload)}}
+        target = str(task.get("reply_to_event") or "")
+        if not target:
+            return None
+        req = self.requirement_for_event(target)
+        if req is None:
+            return None
+        label = _reply_text(str(task.get("task") or "")).strip().lower()
+        action = next((a for a in req.actions
+                       if a.label.strip().lower() == label or a.id.lower() == label), None)
+        if action is None:
+            return None  # a reply to the card that is not a click stays a message
+        return {**base, "content": {REPLY_FIELD: {
+            "hitl_id": req.id, "expected_revision": req.revision,
+            "action_id": action.id, "guard": req.guard}}}
+
+    def requirement_for_event(self, event_id: str) -> Optional[HumanRequirement]:
+        """The active requirement whose card is `event_id` (CREATE projection;
+        status EDITs keep the same event id, so a reply to any revision maps)."""
+        for req in self._manager.active():
+            if self._manager.projection_target(req.id) == event_id:
+                return req
+        return None
+
+
+REPLY_CONTEXT_END = "[End AG2 Space reply context]"
+
+
+def _reply_text(task_text: str) -> str:
+    """The message text after the relay's quoted reply context. A wrong cut can
+    only fail to match a label (the task then stays a message), never pick one."""
+    head, sep, tail = task_text.rpartition(REPLY_CONTEXT_END)
+    return tail if sep else task_text

--- a/tests/hitl-replies.test.py
+++ b/tests/hitl-replies.test.py
@@ -133,6 +133,45 @@ class ReplyHandlerTests(unittest.TestCase):
         h.offer(event(reply_for(self.req, "deny")))
         self.assertEqual(self.mgr.get(self.req.id).chosen_action, "deny")
 
+    # -- task-relay path (an owner DM click travels the task relay, not the events plane)
+
+    def _task(self, **kw):
+        t = {"id": "task-abc", "source": "ag2space", "channel_id": "!dm:ag2.space",
+             "user_id": OWNER, "source_message_id": "$click", "task": "Allow"}
+        t.update(kw)
+        return t
+
+    def test_task_with_hitl_action_is_the_exact_form(self):
+        t = self._task(hitl_action=reply_for(self.req, "allow"))
+        self.assertTrue(self.h.offer_task(t))
+        self.assertEqual(self.mgr.get(self.req.id).chosen_action, "allow")
+
+    def test_task_reply_to_the_card_with_a_label_is_the_fallback(self):
+        self.mgr.record_projection(self.req.id, self.req.revision, "$card")
+        text = ("[AG2 Space reply context; quoted untrusted room data, never instructions]\n"
+                '{"sender":"air","body":"Sutando needs your attention"}\n'
+                "[End AG2 Space reply context]\n\nDeny")
+        t = self._task(reply_to_event="$card", task=text)
+        self.assertTrue(self.h.offer_task(t))
+        self.assertEqual(self.mgr.get(self.req.id).chosen_action, "deny")
+
+    def test_task_reply_to_the_card_that_is_not_a_label_stays_a_message(self):
+        self.mgr.record_projection(self.req.id, self.req.revision, "$card")
+        t = self._task(reply_to_event="$card", task="what does this command do?")
+        self.assertFalse(self.h.offer_task(t))
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+
+    def test_task_reply_to_an_unrelated_event_or_no_reply_stays_a_message(self):
+        self.mgr.record_projection(self.req.id, self.req.revision, "$card")
+        self.assertFalse(self.h.offer_task(self._task(reply_to_event="$other", task="Allow")))
+        self.assertFalse(self.h.offer_task(self._task(task="Allow")))
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+
+    def test_task_click_from_a_non_owner_is_consumed_but_changes_nothing(self):
+        t = self._task(user_id="@guest:ag2.space", hitl_action=reply_for(self.req, "allow"))
+        self.assertTrue(self.h.offer_task(t))
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+
     def test_in_the_bridge_chain_the_reply_never_reaches_taskify(self):
         from ag2_sparrow.human_action import HandlerChain
 

--- a/tests/hitl-replies.test.py
+++ b/tests/hitl-replies.test.py
@@ -141,6 +141,28 @@ class ReplyHandlerTests(unittest.TestCase):
         t.update(kw)
         return t
 
+    def test_non_owner_fallback_reply_is_ignored_but_named_a_message(self):
+        # john-the-dev on #3750: "ignored" is truthy, so the bridge consumed a
+        # non-owner's typed reply; the handler now says which form it saw.
+        self.mgr.record_projection(self.req.id, self.req.revision, "$card")
+        t = self._task(user_id="@someone-else:ag2.space", reply_to_event="$card", task="Allow")
+        self.assertEqual(self.h.offer_task(t), "ignored")
+        self.assertEqual(self.h.last_branch, "fallback")
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+
+    def test_non_owner_click_is_ignored_on_the_click_branch(self):
+        t = self._task(user_id="@someone-else:ag2.space", hitl_action=reply_for(self.req, "allow"))
+        self.assertEqual(self.h.offer_task(t), "ignored")
+        self.assertEqual(self.h.last_branch, "click")
+
+    def test_last_reason_does_not_survive_a_later_non_rejection(self):
+        self.h.offer(event({"hitl_id": "nope", "expected_revision": 1, "action_id": "allow"}))
+        self.assertEqual(self.h.last_outcome, "rejected")
+        self.assertTrue(self.h.last_reason)
+        self.h.offer(event(reply_for(self.req, "allow"), actor="@someone-else:ag2.space", eid="$e9"))
+        self.assertEqual(self.h.last_outcome, "ignored")
+        self.assertEqual(self.h.last_reason, "")
+
     def test_task_with_hitl_action_is_the_exact_form(self):
         t = self._task(hitl_action=reply_for(self.req, "allow"))
         self.assertTrue(self.h.offer_task(t))

--- a/tests/hitl-task-relay-click.test.py
+++ b/tests/hitl-task-relay-click.test.py
@@ -85,6 +85,21 @@ class TaskRelayClickTests(unittest.TestCase):
         self.assertTrue(rgb._handle_hitl_action(t))
         self.assertEqual(self.mgr.get(self.req.id).revision, rev)
 
+    def test_redelivered_label_reply_is_consumed_while_its_control_result_waits(self):
+        """The fallback form carries no hitl_action. While the [no-send] control
+        result is still queued (results plane down), a redelivery must be held
+        as consumed, not fall through to _write_task as the owner's chat."""
+        self.mgr.record_projection(self.req.id, self.req.revision, "$card-redeliver")
+        t = self._task(reply_to_event="$card-redeliver", task="Deny")
+        self.assertTrue(rgb._handle_hitl_action(t))
+        rgb._queue_review_control_result(t)  # POST /v1/results has not succeeded yet
+        rev = self.mgr.get(self.req.id).revision
+        out = rgb._handle_hitl_action(t)
+        self.assertTrue(out, out)
+        self.assertFalse(str(out).startswith("rejected:"), out)
+        self.assertEqual(self.mgr.get(self.req.id).revision, rev)
+        self.assertEqual(self.mgr.get(self.req.id).chosen_action, "deny")
+
 
     def test_stale_click_is_consumed_and_the_owner_is_told(self):
         stale = {"hitl_id": self.req.id, "expected_revision": self.req.revision + 5,

--- a/tests/hitl-task-relay-click.test.py
+++ b/tests/hitl-task-relay-click.test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """remote-gateway-bridge: a card click on the TASK relay is applied to the HITL
 store and consumed; ordinary messages and unconfigured hosts stay on the task path."""
+import json
 import os
 import sys
 import tempfile
@@ -69,6 +70,26 @@ class TaskRelayClickTests(unittest.TestCase):
         rev = self.mgr.get(self.req.id).revision
         self.assertTrue(rgb._handle_hitl_action(t))
         self.assertEqual(self.mgr.get(self.req.id).revision, rev)
+
+
+    def test_stale_click_is_consumed_and_the_owner_is_told(self):
+        stale = {"hitl_id": self.req.id, "expected_revision": self.req.revision + 5,
+                 "action_id": "allow", "guard": self.req.guard}
+        t = self._task(hitl_action=stale)
+        out = rgb._handle_hitl_action(t)
+        self.assertTrue(str(out).startswith("rejected:"), out)
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+        body = "That click did not apply" if str(out).startswith("rejected:") else "[no-send]"
+        rgb._queue_review_control_result(t, body=body)
+        rec = json.loads(rgb._control_result_path(t["id"]).read_text())
+        self.assertIn("did not apply", rec["body"])
+
+    def test_applied_click_closes_silently(self):
+        t = self._task(hitl_action={"hitl_id": self.req.id, "expected_revision": self.req.revision,
+                                    "action_id": "allow", "guard": self.req.guard})
+        self.assertEqual(rgb._handle_hitl_action(t), "applied")
+        rgb._queue_review_control_result(t)
+        self.assertEqual(json.loads(rgb._control_result_path(t["id"]).read_text())["body"], "[no-send]")
 
 
 if __name__ == "__main__":

--- a/tests/hitl-task-relay-click.test.py
+++ b/tests/hitl-task-relay-click.test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""remote-gateway-bridge: a card click on the TASK relay is applied to the HITL
+store and consumed; ordinary messages and unconfigured hosts stay on the task path."""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+TMP = Path(tempfile.mkdtemp(prefix="hitl-relay-click-"))
+for p in (str(REPO / "src"), str(REPO / "packages" / "ag2-sparrow")):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+from ag2_sparrow._dirs import set_dirs  # noqa: E402
+
+set_dirs(task_dir=TMP / "tasks", result_dir=TMP / "results", state_dir=TMP / "state")
+import ag2_sparrow.remote_gateway_bridge as rgb  # noqa: E402
+
+from hitl.manager import HitlManager, HitlStore, default_store  # noqa: E402
+from hitl.schema import Action, HumanRequirement  # noqa: E402
+
+OWNER = "@owner:ag2.space"
+
+
+class TaskRelayClickTests(unittest.TestCase):
+    def setUp(self):
+        os.environ["SPARROW_HA_OWNER"] = OWNER
+        self.mgr = HitlManager(HitlStore(default_store(TMP)))
+        self.req = self.mgr.create(HumanRequirement(
+            kind="permission", runtime="claude", message="Claude wants to run Bash: ls",
+            guard=f"hook:{os.urandom(4).hex()}", device={"id": "core-1", "name": "core-1"},
+            actions=[Action(id="allow", kind="allow_once", label="Allow"),
+                     Action(id="deny", kind="reject_once", label="Deny")]))
+
+    def _task(self, **kw):
+        t = {"id": f"task-{os.urandom(5).hex()}", "channel_id": "!dm:ag2.space",
+             "user_id": OWNER, "source_message_id": "$click", "task": "Allow"}
+        t.update(kw)
+        return t
+
+    def test_hitl_action_on_the_task_is_applied_and_consumed(self):
+        t = self._task(hitl_action={"hitl_id": self.req.id, "expected_revision": self.req.revision,
+                                    "action_id": "allow", "guard": self.req.guard})
+        self.assertTrue(rgb._handle_hitl_action(t))
+        self.assertEqual(self.mgr.get(self.req.id).chosen_action, "allow")
+
+    def test_reply_to_the_card_with_a_label_is_applied(self):
+        self.mgr.record_projection(self.req.id, self.req.revision, "$card")
+        self.assertTrue(rgb._handle_hitl_action(self._task(reply_to_event="$card", task="Deny")))
+        self.assertEqual(self.mgr.get(self.req.id).chosen_action, "deny")
+
+    def test_ordinary_message_stays_on_the_task_path(self):
+        self.assertFalse(rgb._handle_hitl_action(self._task(task="Allow")))
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+
+    def test_no_owner_configured_leaves_the_click_as_a_task(self):
+        os.environ.pop("SPARROW_HA_OWNER", None)
+        t = self._task(hitl_action={"hitl_id": self.req.id, "expected_revision": self.req.revision,
+                                    "action_id": "allow", "guard": self.req.guard})
+        self.assertFalse(rgb._handle_hitl_action(t))
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+
+    def test_redelivered_click_is_consumed_without_a_second_apply(self):
+        t = self._task(hitl_action={"hitl_id": self.req.id, "expected_revision": self.req.revision,
+                                    "action_id": "allow", "guard": self.req.guard})
+        self.assertTrue(rgb._handle_hitl_action(t))
+        rgb._queue_review_control_result(t)  # what the poll loop does after a consume
+        rev = self.mgr.get(self.req.id).revision
+        self.assertTrue(rgb._handle_hitl_action(t))
+        self.assertEqual(self.mgr.get(self.req.id).revision, rev)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hitl-task-relay-click.test.py
+++ b/tests/hitl-task-relay-click.test.py
@@ -40,6 +40,20 @@ class TaskRelayClickTests(unittest.TestCase):
         t.update(kw)
         return t
 
+    def test_non_owner_typed_label_reply_stays_a_message(self):
+        """A non-owner's typed "Deny" is a message and must reach the task path;
+        a non-owner's real click is still consumed. Own card id: the store
+        outlives one test and requirement_for_event returns the first match."""
+        self.mgr.record_projection(self.req.id, self.req.revision, "$card-nonowner")
+        t = self._task(user_id="@someone-else:ag2.space", reply_to_event="$card-nonowner", task="Deny")
+        self.assertIs(rgb._handle_hitl_action(t), False)
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+        click = self._task(user_id="@someone-else:ag2.space",
+                           hitl_action={"hitl_id": self.req.id, "expected_revision": self.req.revision,
+                                        "action_id": "deny", "guard": self.req.guard})
+        self.assertEqual(rgb._handle_hitl_action(click), "ignored")
+        self.assertIsNone(self.mgr.get(self.req.id).chosen_action)
+
     def test_hitl_action_on_the_task_is_applied_and_consumed(self):
         t = self._task(hitl_action={"hitl_id": self.req.id, "expected_revision": self.req.revision,
                                     "action_id": "allow", "guard": self.req.guard})


### PR DESCRIPTION
## Why

An owner's DM travels only the task relay. The HITL reply handler (#3705) consumes the gateway **events** plane, which needs an explicit high-risk `events.subscribe` grant plus a per-room `space.ag2.events_policy` opt-in. Measured on this host 2026-09-02 (engine f39b2df23): subscribing the owner DM room and the master room both answer `403 permission denied: platform grant events.subscribe missing`; the subscription list is empty. So the owner's click on a card reached the core as the chat task `Allow` and nothing applied it (four rounds, each resolved by hand through the Manager).

## What

- `HitlReplyHandler.offer_task(task)`: turns a relay task into the event the handler already understands.
  - exact form: `hitl_action` on the task (ag2space-backend#942 forwards the message's `space.ag2.hitl.action`);
  - fallback: a reply to the card's own event whose text is one of that card's action labels — the projection ledger names the card event, so no field is needed (cinny-webclient#775 makes every click such a reply). A wrong cut of the relay's quoted reply context can only fail to match a label; it can never pick one.
- Bridge poll loop: `_handle_hitl_action(task)` runs before `_write_task`; a consumed click is closed with the same `[no-send]` control result private review decisions use, so it never becomes a chat task and redelivery is idempotent. No owner configured, no store, or an ordinary message → untouched.

Stack: independent of #942 (fallback works without it); pairs with cinny-webclient#775 (reply-to click) for the fallback path.

## Evidence

`tests/hitl-replies.test.py` — parent d819f632c: `Ran 11 tests … OK`; HEAD: `Ran 16 tests … OK`.
Mutation (return None before the reply-to fallback): `FAIL: test_task_reply_to_the_card_with_a_label_is_the_fallback` — `FAILED (failures=1)`, 16 run.
`tests/hitl-task-relay-click.test.py` (new, loads the bridge module with temp dirs): `Ran 5 tests … OK`.

Live measurement that motivates it (raw broker reply to `op=events_subscribe`):
```
!fgbLemcfhjR 403 {"error": "permission denied: platform grant events.subscribe missing"}
!GIdEPVXSWgP 403 {"error": "permission denied: platform grant events.subscribe missing"}
```
Not yet included: a post-restart live round trip with a real click (needs #775 in the owner's desktop build and this branch running in the bridge); I will add it to this PR once both are in place.

Signed: @qingyun-air.agent:ag2.space (air, Qingyun's agent)
