### PR TITLE
fix(core-supervisor): the usage-limit remedy omits switching subscription

### DIFF
--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -92,7 +92,8 @@ def _limit_remedy(signal: dict) -> str:
     when = f"at {m.group(1)}" if m else "when the limit window resets"
     return (f" — the core hit its Claude usage limit, not a login problem; it resumes"
             f" on its own {when}. Nothing to do unless you want it sooner: at the"
-            " core's terminal, /usage-credits spends credits now and Esc stops the wait.")
+            " core's terminal, /usage-credits spends credits now, signing in under a"
+            " different subscription starts a fresh allowance, and Esc stops the wait.")
 
 
 #: A record older than this is a core that stopped beating; the socket it names

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -156,6 +156,9 @@ class TestComposeMessage(unittest.TestCase):
         m = compose_message(_LIMIT)
         self.assertIn("resumes on its own at 12:10pm", m)
         self.assertIn("/usage-credits", m)
+        # The owner named this third route (2026-09-02): the limit is per
+        # subscription, so signing in under another one is often the fastest.
+        self.assertIn("different subscription", m)
         self.assertNotIn("/login", m)
         self.assertNotIn("restart.sh", m)
 


### PR DESCRIPTION
## What

`_limit_remedy` lists the routes out of a Claude usage-limit screen. #3730 established them — resumes on its own, `/usage-credits`, Esc — and the owner named one that was missing: **the limit is per subscription, so signing in under a different one starts a fresh allowance.** On a blocked core that is frequently the fastest way out, and with it absent the message's *"Nothing to do unless you want it sooner"* overstates the case.

```diff
-            " core's terminal, /usage-credits spends credits now and Esc stops the wait.")
+            " core's terminal, /usage-credits spends credits now, signing in under a"
+            " different subscription starts a fresh allowance, and Esc stops the wait.")
```

## The wording is deliberate, and the tests are why

My first draft said *"/login on a different subscription"* and **broke two tests**:

```
FAIL: test_session_limit_names_the_reset_time_not_login
FAIL: test_session_limit_without_a_reset_time_still_avoids_login
  AssertionError: '/login' unexpectedly found in "...⚠️ Agent needs you — awaiting user: session-limit..."
```

Both assert `assertNotIn("/login", m)`, and that invariant *is* #3730: the defect it fixed was a quota screen reported as a login gate, sending the owner to restart and run `/login` — a remedy that cannot clear a quota limit. Reintroducing the literal token would have re-armed the confusion this file exists to prevent, in a message that also says "not a login problem".

So the route is described without the token. **I did not relax the assertions** — a checker that fails on a real regression is worth more than the phrasing I first reached for.

## Evidence

```
with the change        Ran 60 tests   OK
revert src only, keep the new assert   FAILED (failures=1)
                                       test_session_limit_names_the_reset_time_not_login
restore                Ran 60 tests   OK
```

The new assertion (`assertIn("different subscription", m)`) is pinned in `test_session_limit_names_the_reset_time_not_login`, and the control above shows it fails when the source change is absent — so it discriminates rather than passing by construction.

Stand: Echo Act IV Pro