### PR TITLE
refactor(runtime-api): ha_adapter writes HumanRequirements through HitlManager

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -357,7 +357,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`agents_view.py`** — Read-only agent discovery over the per-host liveness directory.
 - **`capability_registry.py`** — Provider-neutral, ephemeral read-capability registry.
 - **`dispatcher.py`** — Runtime-API request-domain dispatch, separated from socket transport.
-- **`ha_adapter.py`** — runtime-api ↔ human-action adapter — the v0 approve/answer transport.
+- **`ha_adapter.py`** — runtime-api ↔ human-action adapter, over the HITL Requirement store.
 - **`identity_view.py`** — Read-only identity surface for THIS agent (the Sutando Server "smallest slice"): sutando.info / sutando.status / sutando.owner / sutando.allowlist.
 - **`instance_key.py`** — Composite (agent_id, instance_id) identity encoding — the ONE owner shared by the durable registry (flat manifest filenames) and the live run dir (the directory holding this instance's socket and lock).
 - **`instance_registry.py`** — Sutando Instance Manifest registry — persistent "this agent exists here" records, M1 of the manifest spec (taxonomy part 4/5): Agent existence ≠ agent process existence.

--- a/src/hitl/manager.py
+++ b/src/hitl/manager.py
@@ -11,6 +11,7 @@ and neither ever mutates requirement state.
 from __future__ import annotations
 
 import json
+import logging
 import fcntl
 import os
 import re
@@ -56,6 +57,7 @@ class HitlStore:
         self.root.mkdir(parents=True, exist_ok=True)
         self._lock_fd: Optional[int] = None
         self._lock_depth = 0
+        self.last_skipped: tuple = ()
 
     @staticmethod
     def valid_id(req_id: str) -> bool:
@@ -120,12 +122,19 @@ class HitlStore:
         return raw.get("projection") or {"revision": 0, "event_id": None}
 
     def all(self) -> List[HumanRequirement]:
-        out = []
+        out, skipped = [], []
         for p in sorted(self.root.glob("hitl_*.json")):
             try:
                 out.append(_req_from_dict(json.loads(p.read_text())["requirement"]))
             except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-                continue  # one unreadable record must not hide the store
+                skipped.append(p.name)
+        # An empty store reads as "nothing needs the human", so a dropped
+        # record must leave a trace that a quiet day would not.
+        self.last_skipped = tuple(skipped)
+        if skipped:
+            logging.getLogger("hitl.store").warning(
+                "hitl: %d unreadable record(s) skipped in %s: %s",
+                len(skipped), self.root, ", ".join(skipped))
         return out
 
 

--- a/src/hitl/manager.py
+++ b/src/hitl/manager.py
@@ -16,6 +16,7 @@ import os
 import re
 import tempfile
 from contextlib import contextmanager
+import dataclasses
 from dataclasses import asdict
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -123,8 +124,8 @@ class HitlStore:
         for p in sorted(self.root.glob("hitl_*.json")):
             try:
                 out.append(_req_from_dict(json.loads(p.read_text())["requirement"]))
-            except (json.JSONDecodeError, KeyError):
-                continue
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+                continue  # one unreadable record must not hide the store
         return out
 
 
@@ -255,7 +256,12 @@ def _req_to_dict(req: HumanRequirement) -> Dict:
     return d
 
 
+_REQ_FIELDS = {f.name for f in dataclasses.fields(HumanRequirement)}
+
+
 def _req_from_dict(d: Dict) -> HumanRequirement:
-    d = dict(d)
+    """Unknown keys are dropped: a store shared by two engine revisions must stay
+    readable by the older one, and one foreign record must not blind the rest."""
+    d = {k: v for k, v in dict(d).items() if k in _REQ_FIELDS}
     d["actions"] = [Action(**a) for a in d.get("actions", [])]
     return HumanRequirement(**d)

--- a/src/hitl/manager.py
+++ b/src/hitl/manager.py
@@ -184,6 +184,8 @@ class HitlManager:
                 raise MalformedActionError(f"no requirement {reply.hitl_id}")
             action = validate_action(req, reply)
             req.chosen_action = action.id
+            if reply.answer is not None:
+                req.answer = reply.answer
             req.transition(STATUS_IN_PROGRESS)
             self.store.save(req)
             return action

--- a/src/hitl/schema.py
+++ b/src/hitl/schema.py
@@ -124,6 +124,8 @@ class HumanRequirement:
             wire["subject"] = dict(self.subject)
         if self.expires_at is not None:
             wire["expires_at"] = self.expires_at
+        # `answer` is inbound-only (what the human typed back); a card never
+        # renders it, so it is persisted but deliberately not on the wire.
         return wire
 
 

--- a/src/hitl/schema.py
+++ b/src/hitl/schema.py
@@ -66,6 +66,11 @@ class HumanRequirement:
     subject: Dict[str, Any] = field(default_factory=dict)
     # "policy" when the Manager auto-answered it: never projected as a card.
     decided_by: Optional[str] = None
+    # A payload beyond the chosen action (free text, multi-select labels): set by
+    # apply_action from ActionReply.answer; None for pure button clicks.
+    answer: Optional[Any] = None
+    # Absolute epoch after which the producer treats the requirement as expired.
+    expires_at: Optional[float] = None
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
 
@@ -117,6 +122,8 @@ class HumanRequirement:
             wire["actions"] = [a.to_wire() for a in self.actions]
         if self.subject:
             wire["subject"] = dict(self.subject)
+        if self.expires_at is not None:
+            wire["expires_at"] = self.expires_at
         return wire
 
 
@@ -133,6 +140,9 @@ class ActionReply:
     expected_revision: int
     action_id: str
     guard: str
+    # Optional payload for actions that carry more than a click: free text, a
+    # list of selected labels. Stored on the requirement as `answer`.
+    answer: Optional[Any] = None
 
     @classmethod
     def from_wire(cls, payload: Dict[str, Any]) -> "ActionReply":
@@ -142,6 +152,7 @@ class ActionReply:
                 expected_revision=int(payload["expected_revision"]),
                 action_id=str(payload["action_id"]),
                 guard=str(payload.get("guard", "")),
+                answer=payload.get("answer"),
             )
         except (KeyError, TypeError, ValueError) as e:
             raise MalformedActionError(f"bad action payload: {e}") from e

--- a/src/runtime-api/ha_adapter.py
+++ b/src/runtime-api/ha_adapter.py
@@ -1,48 +1,48 @@
-"""runtime-api ↔ human-action adapter — the v0 approve/answer transport.
+"""runtime-api ↔ human-action adapter, over the HITL Requirement store.
 
-The design doc's "server pending-request API + Space approve UI" already
-exists at v0.5 in this repo: the human-action lifecycle. A pending action
-written to `<state>/human-actions/ha_*.json` is picked up by the gateway's
-CardPoster (question card with buttons in the owner's room, rendered by all
-three clients) and resolved by DecisionHandler when the owner answers.
+A runtime request that needs a human (approval, elicitation, human_action)
+becomes ONE HumanRequirement in the HITL store — the same record the hook
+driver, the card projector and the bridge's reply handler already share — and
+the owner's card click resolves it through the Manager's revision + guard gate.
+The v0.5 `ha_*.json` action files and their separate card poster are gone: the
+Requirement is the only object, the card is its projection.
 
-So v0 approval/elicitation does NOT need a new server or UI: this adapter
-mirrors a runtime request into an ha_* pending action (CardPoster posts it)
-and a resolver poll maps the owner's decision back onto the runtime request's
-terminal state. `/v1/agent-requests` can formalize this server-side later
-without touching the daemon's contract.
+Mapping (kind / actions):
+  approval.request     → permission       Approve / Deny
+  elicitation.request  → choice           one action per option (opt1..optN), or
+                                          a free-text action when no options
+  human_action.request → external_action  Done / Decline
 
-Mapping:
-  approval.request     → single confirmation question (Approve / Deny)
-  elicitation.request  → free_text / single_select / multi_select /
-                         confirmation question
-Resolution:
-  decision.answers {"1": [idx, ...]} or {"1": "free text"}  (DecisionHandler
-  shapes) → approved/denied (approval) or resolved+answer (elicitation).
+`poll_resolution` keeps the dispatcher's answer shape — {"1": [idx, ...]} for
+selections, {"1": "text"} for free text — so `_settle` and `first_answer` are
+unchanged; the adapter maps the chosen action id back to the option index.
 """
 from __future__ import annotations
 
-import json
 import sys
 import time
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
-# Sibling-import bootstrap (NOT workspace resolution — that goes through the
-# sanctioned sutando_config helpers below): put src/ on sys.path so
-# sutando_config imports, then let its marker-walking _find_repo_root locate
-# the repo root for the in-repo sparrow package.
+# Sibling-import bootstrap (NOT workspace resolution): put src/ on sys.path so
+# the in-repo `hitl` package imports the same way the hook driver imports it.
 _HERE = Path(__file__).resolve().parent  # src/runtime-api
 _SRC = _HERE.parent                      # src
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
-from sutando_config import _find_repo_root  # noqa: E402
 
-_REPO = _find_repo_root(_HERE) or _SRC.parent
-_PKG = str(_REPO / "packages" / "ag2-sparrow")
-if _PKG not in sys.path:
-    sys.path.insert(0, _PKG)
+from hitl.manager import HitlManager, HitlStore  # noqa: E402
+from hitl.schema import (  # noqa: E402
+    Action,
+    ActionReply,
+    HumanRequirement,
+    MalformedActionError,
+    StaleRequirementError,
+)
 
-from ag2_sparrow.human_action import ActionStore  # noqa: E402
+RUNTIME = "runtime-api"
+DEFAULT_TTL_S = 24 * 3600
+FREE_TEXT_ACTION = "answer"
 
 
 def _now() -> float:
@@ -50,21 +50,20 @@ def _now() -> float:
 
 
 def ha_action_id(request_id: str) -> str:
-    """ha action id for a runtime request — MUST stay matchable by
-    DecisionHandler's answer grammar `ha_[0-9a-f]{6,}` (hex only!). The
-    requestId's uuid tail is hex; the type prefix ("approval-") is NOT and
-    must never leak into the id. Live-acceptance finding 2026-07-26: the
-    first cut used the full requestId and the owner's real answer could not
-    match — the local E2E missed it by writing resolutions directly."""
-    return "ha_" + request_id.split("-", 1)[-1][:24]
+    """Deterministic requirement id for a runtime request, so `recover()` can
+    relink a pending request after a daemon restart without any map. The
+    requestId's uuid tail is hex; the type prefix ("approval-") never leaks in."""
+    return "hitl_" + request_id.split("-", 1)[-1][:24]
 
 
 class HumanActionAdapter:
     def __init__(self, actions_dir: str):
+        # The directory is the HITL store root for this daemon (one store per
+        # workspace in production: default_store(workspace)).
         Path(actions_dir).mkdir(parents=True, exist_ok=True)
-        self.store = ActionStore(actions_dir)
+        self.manager = HitlManager(HitlStore(Path(actions_dir)))
 
-    # ── outbound: runtime request → pending ha action ──────────────────────
+    # ── outbound: runtime request → requirement ────────────────────────────
     def open_approval(self, request: dict) -> str:
         p = request["params"]
         action_line = p.get("action", "?")
@@ -73,94 +72,158 @@ class HumanActionAdapter:
         reason = p.get("reason")
         # The card must show the FULL effect being approved — including the
         # governed input (for message.send, the input IS the message body).
-        # The daemon binds the approval to this exact effect (review P1:
-        # an unshown input could be substituted after the owner answered).
-        q = (f"Approve: {action_line}"
-             + (f"\nResource: {json.dumps(resource, ensure_ascii=False)}" if resource else "")
-             + (f"\nInput: {json.dumps(inp, ensure_ascii=False)}" if inp else "")
-             + (f"\nReason: {reason}" if reason else ""))
-        return self._write(request, [{
-            "question": q,
-            "options": [{"label": "Approve"}, {"label": "Deny"}],
-        }])
+        message = (f"Approve: {action_line}"
+                   + (f"\nResource: {_json(resource)}" if resource else "")
+                   + (f"\nInput: {_json(inp)}" if inp else "")
+                   + (f"\nReason: {reason}" if reason else ""))
+        return self._create(request, kind="permission", message=message,
+                            options=["Approve", "Deny"],
+                            actions=[Action(id="approve", kind="allow_once", label="Approve"),
+                                     Action(id="deny", kind="reject_once", label="Deny")])
 
     def open_elicitation(self, request: dict) -> str:
         p = request["params"]
         etype = p.get("type", "single_select")
-        options = [{"label": str(o)} for o in (p.get("options") or [])]
+        options = [str(o) for o in (p.get("options") or [])]
         if etype == "confirmation" and not options:
-            options = [{"label": "Yes"}, {"label": "No"}]
-        q = {"question": str(p.get("question", "?")), "options": options}
-        if etype == "multi_select":
-            # The multiSelect flag switches DecisionHandler to the comma-list
-            # grammar; without it multiple numbers are rejected by the
-            # single-select branch (review P1 dead path).
-            q["multiSelect"] = True
-        return self._write(request, [q])
+            options = ["Yes", "No"]
+        question = str(p.get("question", "?"))
+        if options:
+            actions = [Action(id=f"opt{i}", kind="select", label=label)
+                       for i, label in enumerate(options, 1)]
+        else:
+            actions = [Action(id=FREE_TEXT_ACTION, kind="free_text", label="Answer")]
+        return self._create(request, kind="choice", message=question, options=options,
+                            actions=actions, extra={"type": etype,
+                                                    "multi_select": etype == "multi_select"})
 
     def open_human_action(self, request: dict) -> str:
         """A real-world act the human must perform (sign, pay, plug in, ...).
-        The card asks for the act and takes the outcome; Done/Decline map to
-        the request's completed/declined terminal states."""
+        Done/Decline map to the request's completed/declined terminal states."""
         p = request["params"]
-        q = (f"Action needed: {p.get('action', '?')}"
-             + (f"\nInstructions: {p['instructions']}" if p.get("instructions") else "")
-             + (f"\nDeadline: {p['deadline']}" if p.get("deadline") else ""))
-        return self._write(request, [{
-            "question": q,
-            "options": [{"label": "Done"}, {"label": "Decline"}],
-        }])
+        message = (f"Action needed: {p.get('action', '?')}"
+                   + (f"\nInstructions: {p['instructions']}" if p.get("instructions") else "")
+                   + (f"\nDeadline: {p['deadline']}" if p.get("deadline") else ""))
+        return self._create(request, kind="external_action", message=message,
+                            options=["Done", "Decline"],
+                            actions=[Action(id="done", kind="complete", label="Done"),
+                                     Action(id="decline", kind="reject_once", label="Decline")])
 
-    def close(self, action_id: str, resolved_by: str, note: str | None = None) -> None:
-        """Resolve a still-pending card out-of-band (API completion path) so
-        CardPoster stops showing a question the requester already settled."""
-        rec = self.store.get(action_id)
-        if rec is None or rec.get("status") != "pending":
+    def _create(self, request: dict, *, kind: str, message: str, options: List[str],
+                actions: List[Action], extra: Optional[Dict[str, Any]] = None) -> str:
+        rid = request["requestId"]
+        req = HumanRequirement(
+            id=ha_action_id(rid),
+            kind=kind,
+            runtime=RUNTIME,
+            message=message,
+            title=f"runtime request {rid}",
+            # The guard is the request identity: a runtime request never repaints.
+            guard=f"runtime:{rid}",
+            subject={"runtime_request_id": rid, "options": options, **(extra or {})},
+            actions=actions,
+            expires_at=request.get("expiresAt") or (_now() + DEFAULT_TTL_S),
+        )
+        self.manager.create(req)
+        return req.id
+
+    def close(self, action_id: str, resolved_by: str, note: Optional[str] = None) -> None:
+        """Settle a still-open requirement out-of-band (API completion path) so
+        the card does not dangle: the requester already settled it."""
+        req = self.manager.get(action_id)
+        if req is None or req.terminal:
             return
-        rec["status"] = "resolved"
-        rec["resolved_by"] = resolved_by
-        rec["decision"] = {"answers": {}, "via": "runtime-api",
-                           **({"note": note} if note else {})}
-        rec.setdefault("audit", []).append(
-            {"at": _now(), "event": "resolved-via-api", "by": resolved_by})
-        self.store.update(rec)
+        with self.manager.store.locked():
+            req = self.manager.get(action_id)
+            if req is None or req.terminal:
+                return
+            req.decided_by = resolved_by
+            if note:
+                req.answer = {"note": note}
+            self.manager.store.save(req)
+        self.manager.resolve(action_id)
 
-    def _write(self, request: dict, questions: list) -> str:
-        action_id = ha_action_id(request["requestId"])
-        now = _now()
-        rec = {
-            "action_id": action_id,
-            "kind": "runtime_request",
-            "runtime_request_id": request["requestId"],
-            "status": "pending",
-            "claude_session_id": None,
-            "tool_input": {"questions": questions},
-            "questions": questions,
-            "decision": None,
-            "resolved_by": None,
-            "created_at": now,
-            "expires_at": request.get("expiresAt") or (now + 24 * 3600),
-            "audit": [{"at": now, "event": "created",
-                       "runtime_request": request["requestId"]}],
-        }
-        self.store.update(rec)
-        return action_id
-
-    # ── inbound: resolved ha action → runtime terminal state ───────────────
+    # ── inbound: resolved requirement → runtime terminal state ─────────────
     def poll_resolution(self, action_id: str):
-        """Return (status, payload, resolved_by) once the ha action reaches a
-        terminal state, else None while pending. status ∈ resolved|expired."""
-        rec = self.store.get(action_id)
-        if rec is None:
+        """Return (status, answers, resolved_by) once the requirement reaches a
+        terminal state, else None while pending. status ∈ resolved|expired.
+        `answers` keeps the DecisionHandler shape the dispatcher settles on."""
+        req = self.manager.get(action_id)
+        if req is None:
             return None
-        if rec.get("status") == "pending":
-            if rec.get("expires_at") and _now() > rec["expires_at"]:
+        if not req.terminal:
+            if req.expires_at and _now() > req.expires_at:
+                self.manager.expire(action_id)
                 return ("expired", None, None)
-            return None
-        if rec.get("status") == "resolved":
-            answers = ((rec.get("decision") or {}).get("answers")) or {}
-            return ("resolved", answers, rec.get("resolved_by"))
-        return ("expired", None, rec.get("resolved_by"))
+            if req.chosen_action is None:
+                return None
+            # in_progress with a chosen action: the click landed, finish it.
+            self.manager.resolve(action_id)
+            req = self.manager.get(action_id)
+        if req.status == "resolved":
+            return ("resolved", self._answers(req), req.decided_by or "owner")
+        return ("expired", None, req.decided_by)
+
+    def resolve(self, action_id: str, answers: Dict[str, Any], resolved_by: str) -> None:
+        """Apply an answer in the dispatcher's shape ({"1": [idx, ...]} or
+        {"1": "text"}) as the owner's action — the test and CLI entry point."""
+        req = self.manager.get(action_id)
+        if req is None:
+            raise MalformedActionError(f"no requirement {action_id}")
+        a = answers.get("1")
+        if a is None and answers:
+            a = next(iter(answers.values()))
+        if isinstance(a, list):
+            idxs = [int(i) for i in a if str(i).isdigit()]
+            valid = [i for i in idxs if 1 <= i <= len(req.subject.get("options") or [])]
+            if not valid:
+                raise MalformedActionError(f"{action_id}: no valid option index in {a!r}")
+            action_id_chosen = f"opt{valid[0]}" if req.kind == "choice" else self._label_action(req, valid[0])
+            payload = [req.subject["options"][i - 1] for i in valid] if len(valid) > 1 else None
+        else:
+            action_id_chosen = FREE_TEXT_ACTION if any(x.id == FREE_TEXT_ACTION for x in req.actions) \
+                else self._label_action(req, None, text=str(a))
+            payload = str(a)
+        try:
+            self.manager.apply_action(ActionReply(hitl_id=req.id, expected_revision=req.revision,
+                                                  action_id=action_id_chosen, guard=req.guard,
+                                                  answer=payload))
+        except StaleRequirementError:
+            return  # a late or duplicate answer changes nothing
+        with self.manager.store.locked():
+            cur = self.manager.get(action_id)
+            if cur is not None and not cur.terminal:
+                cur.decided_by = resolved_by
+                self.manager.store.save(cur)
+        self.manager.resolve(action_id)
+
+    @staticmethod
+    def _label_action(req: HumanRequirement, idx: Optional[int], text: Optional[str] = None) -> str:
+        """Approval / human_action cards: the option index or a typed label maps
+        onto the fixed action ids (approve/deny, done/decline)."""
+        opts = req.subject.get("options") or []
+        label = (opts[idx - 1] if idx is not None and 1 <= idx <= len(opts) else (text or "")).strip().lower()
+        for a in req.actions:
+            if a.label.lower() == label:
+                return a.id
+        raise MalformedActionError(f"{req.id}: {label!r} is not one of {[a.label for a in req.actions]}")
+
+    @staticmethod
+    def _answers(req: HumanRequirement) -> Dict[str, Any]:
+        """Back to the dispatcher's shape from the chosen action + payload."""
+        opts = req.subject.get("options") or []
+        if req.chosen_action == FREE_TEXT_ACTION:
+            return {"1": req.answer if isinstance(req.answer, str) else ""}
+        if isinstance(req.answer, list) and opts:
+            return {"1": [opts.index(x) + 1 for x in req.answer if x in opts]}
+        if isinstance(req.answer, str):
+            return {"1": req.answer}  # a typed label keeps the text shape the caller sent
+        chosen = next((a for a in req.actions if a.id == req.chosen_action), None)
+        if chosen is None:
+            return {}
+        if chosen.label in opts:
+            return {"1": [opts.index(chosen.label) + 1]}
+        return {"1": chosen.label}
 
     @staticmethod
     def first_answer(answers: dict, options: list):
@@ -178,3 +241,8 @@ class HumanActionAdapter:
                     pass
             return labels
         return a
+
+
+def _json(value: Any) -> str:
+    import json
+    return json.dumps(value, ensure_ascii=False)

--- a/tests/hitl-manager-identity.test.py
+++ b/tests/hitl-manager-identity.test.py
@@ -101,5 +101,30 @@ class IdentityTests(unittest.TestCase):
         self.assertEqual(self.mgr.store._lock_depth, 0)
 
 
+class ForeignRecordTests(unittest.TestCase):
+    """A store shared by two engine revisions: unknown fields are dropped, and a
+    record that cannot be constructed is skipped rather than blinding all()."""
+
+    def _store(self):
+        from pathlib import Path as _P
+        return HitlStore(_P(tempfile.mkdtemp()) / "req")
+
+    def test_unknown_fields_are_ignored_on_load(self):
+        store = self._store()
+        store.save(HumanRequirement(id="hitl_future01", kind="permission", runtime="claude", message="m",
+                                    actions=[Action(id="allow", kind="allow_once", label="Allow")]))
+        f = store.root / "hitl_future01.json"
+        raw = json.loads(f.read_text()); raw["requirement"]["some_future_field"] = {"x": 1}
+        f.write_text(json.dumps(raw))
+        self.assertEqual(store.load("hitl_future01").id, "hitl_future01")
+        self.assertEqual([r.id for r in store.all()], ["hitl_future01"])
+
+    def test_unconstructible_record_is_skipped_not_fatal(self):
+        store = self._store()
+        store.save(HumanRequirement(id="hitl_good00001", kind="permission", runtime="claude", message="m"))
+        (store.root / "hitl_bad000001.json").write_text(json.dumps({"requirement": {"id": "hitl_bad000001"}}))
+        self.assertEqual([r.id for r in store.all()], ["hitl_good00001"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/hitl-manager-identity.test.py
+++ b/tests/hitl-manager-identity.test.py
@@ -123,7 +123,20 @@ class ForeignRecordTests(unittest.TestCase):
         store = self._store()
         store.save(HumanRequirement(id="hitl_good00001", kind="permission", runtime="claude", message="m"))
         (store.root / "hitl_bad000001.json").write_text(json.dumps({"requirement": {"id": "hitl_bad000001"}}))
-        self.assertEqual([r.id for r in store.all()], ["hitl_good00001"])
+        with self.assertLogs("hitl.store", level="WARNING") as logs:
+            self.assertEqual([r.id for r in store.all()], ["hitl_good00001"])
+        # A dropped record must leave a trace: an empty store reads as "nothing
+        # needs the human", so silence here is the dangerous polarity.
+        self.assertEqual(store.last_skipped, ("hitl_bad000001.json",))
+        self.assertIn("1 unreadable record(s) skipped", logs.output[0])
+        self.assertIn("hitl_bad000001.json", logs.output[0])
+
+    def test_a_clean_store_leaves_no_trace(self):
+        store = self._store()
+        store.save(HumanRequirement(id="hitl_good00002", kind="permission", runtime="claude", message="m"))
+        with self.assertNoLogs("hitl.store", level="WARNING"):
+            self.assertEqual([r.id for r in store.all()], ["hitl_good00002"])
+        self.assertEqual(store.last_skipped, ())
 
 
 if __name__ == "__main__":

--- a/tests/runtime-api-e2e.test.py
+++ b/tests/runtime-api-e2e.test.py
@@ -87,16 +87,40 @@ def start_daemon():
     return proc
 
 
+class _HitlStoreView:
+    """The owner-side view of the daemon's HITL store, in the record shape the
+    older ActionStore returned, so the scenario reads as the owner sees it."""
+
+    def __init__(self, ha_dir):
+        sys.path.insert(0, str(REPO / "src"))
+        sys.path.insert(0, str(REPO / "src" / "runtime-api"))
+        from hitl.manager import HitlManager, HitlStore  # noqa: E402
+        from ha_adapter import HumanActionAdapter  # noqa: E402
+        self.adapter = HumanActionAdapter(str(ha_dir))
+        self.manager = self.adapter.manager
+
+    def get(self, aid):
+        req = self.manager.get(aid)
+        if req is None:
+            return None
+        subj = req.subject or {}
+        return {"action_id": req.id, "status": req.status,
+                "card_event_id": self.manager.projection_target(req.id),
+                "questions": [{"question": req.message,
+                               "options": [{"label": a.label} for a in req.actions],
+                               "multiSelect": bool(subj.get("multi_select"))}]}
+
+    def resolve(self, aid, answers, by):
+        self.adapter.resolve(aid, answers, by)
+        return True
+
+
 def ha_store():
-    spec = importlib.util.spec_from_file_location(
-        "ha", REPO / "packages" / "ag2-sparrow" / "ag2_sparrow" / "human_action.py")
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod.ActionStore(ENV["SUTANDO_HA_DIR"])
+    return _HitlStoreView(ENV["SUTANDO_HA_DIR"])
 
 
 def pending_action_for(request_id, store, timeout=5):
-    aid = "ha_" + request_id.split("-", 1)[-1][:24]
+    aid = "hitl_" + request_id.split("-", 1)[-1][:24]
     deadline = time.time() + timeout
     while time.time() < deadline:
         rec = store.get(aid)
@@ -170,9 +194,9 @@ def main() -> int:
         # `answer <action_id> N` and _ANSWER_RE only matches ha_ + HEX. A
         # non-hex id silently strands the card (live finding 2026-07-26).
         import re as _re
-        _answer_re = _re.compile(r"\banswer\s+(ha_[0-9a-f]{6,})\s+([0-9])")
-        check(act is not None and _answer_re.search(f"answer {act['action_id']} 1") is not None,
-              "ha action id matches DecisionHandler's answer grammar (hex-only)")
+        _id_re = _re.compile(r"^hitl_[A-Za-z0-9_-]+$")
+        check(act is not None and _id_re.match(act["action_id"]) is not None,
+              "requirement id matches the HITL store id contract")
         check(act is not None and act["status"] == "pending"
               and not act.get("card_event_id")
               and "Approve" in json.dumps(act["questions"]),
@@ -316,7 +340,7 @@ def main() -> int:
                   "--resource", '{"roomId":"!room:example.org"}',
                   "--input", '{"body":"benign approved body"}')
         actbi = pending_action_for(rbi["requestId"], store)
-        card_bi = json.loads((Path(ENV["SUTANDO_HA_DIR"]) / (actbi["action_id"] + ".json")).read_text())
+        card_bi = store.get(actbi["action_id"])
         check('"body": "benign approved body"' in card_bi["questions"][0]["question"]
               or 'benign approved body' in card_bi["questions"][0]["question"],
               "approval card SHOWS the governed input (the body the owner approves)")

--- a/tests/runtime-api-human-action.test.py
+++ b/tests/runtime-api-human-action.test.py
@@ -117,6 +117,62 @@ class HumanActionTests(unittest.TestCase):
         self.assertEqual(st["requestId"], rid)
 
 
+class AdapterEdgeTests(unittest.TestCase):
+    """The adapter's own branches, driven without a dispatcher: the free-text
+    decision both ways, expiry, malformed answers, the stale duplicate, and the
+    answer-shape helper's fallbacks (the coverage gate's 12 lines on #3753)."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ha = HumanActionAdapter(str(Path(self.tmp.name) / "ha"))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _req(self, rid, **params):
+        return {"requestId": rid, "params": params}
+
+    def test_free_text_decision_round_trips_the_typed_answer(self):
+        aid = self.ha.open_elicitation(self._req("r-ft", type="text", question="Your name?"))
+        req = self.ha.manager.get(aid)
+        self.assertEqual([(a.id, a.kind, a.label) for a in req.actions], [("answer", "free_text", "Answer")])
+        self.assertIn("expires_at", req.to_wire())
+        self.ha.resolve(aid, {"1": "Alice"}, "@owner:x")
+        self.assertEqual(self.ha.poll_resolution(aid), ("resolved", {"1": "Alice"}, "@owner:x"))
+
+    def test_an_expired_requirement_reports_expired_on_every_poll(self):
+        r = self._req("r-exp", action="x"); r["expiresAt"] = 1.0
+        aid = self.ha.open_approval(r)
+        self.assertEqual(self.ha.poll_resolution(aid), ("expired", None, None))
+        status, answers, _by = self.ha.poll_resolution(aid)
+        self.assertEqual((status, answers), ("expired", None))
+
+    def test_resolve_refuses_an_unknown_requirement_and_a_bad_index(self):
+        from hitl.schema import MalformedActionError
+        with self.assertRaises(MalformedActionError):
+            self.ha.resolve("ha-nope", {"1": [1]}, "@owner:x")
+        aid = self.ha.open_approval(self._req("r-idx", action="x"))
+        with self.assertRaises(MalformedActionError):
+            self.ha.resolve(aid, {"1": [9]}, "@owner:x")
+        with self.assertRaises(MalformedActionError):
+            self.ha.resolve(aid, {"1": "Maybe"}, "@owner:x")
+
+    def test_a_duplicate_answer_is_swallowed_not_raised(self):
+        aid = self.ha.open_approval(self._req("r-dup", action="x"))
+        self.ha.resolve(aid, {"1": [1]}, "@owner:x")
+        self.assertIsNone(self.ha.resolve(aid, {"1": [2]}, "@owner:x"))
+        self.assertEqual(self.ha.poll_resolution(aid)[0], "resolved")
+        self.assertEqual(self.ha.manager.get(aid).chosen_action, "approve")
+
+    def test_answer_shape_fallbacks(self):
+        aid = self.ha.open_approval(self._req("r-shape", action="x"))
+        req = self.ha.manager.get(aid)
+        req.chosen_action = "ghost"; req.answer = None
+        self.assertEqual(self.ha._answers(req), {})
+        req.chosen_action = "approve"; req.subject["options"] = []
+        self.assertEqual(self.ha._answers(req), {"1": "Approve"})
+
+
 class ProductionComposedSettleTests(unittest.TestCase):
     """The control that matters: the dispatcher the SHIPPED server composes,
     reached the way `RuntimeServer.client()` reaches it. A hand-built

--- a/tests/runtime-api-human-action.test.py
+++ b/tests/runtime-api-human-action.test.py
@@ -54,17 +54,16 @@ class HumanActionTests(unittest.TestCase):
 
     def test_request_mirrors_card_with_act_and_outcome_options(self):
         rid = self._request()
-        card = self.ha.store.get(self.d._ha_of[rid])
-        q = card["questions"][0]
-        self.assertIn("Sign the agreement", q["question"])
-        self.assertIn("Review section 4", q["question"])
-        self.assertEqual([o["label"] for o in q["options"]], ["Done", "Decline"])
+        req = self.ha.manager.get(self.d._ha_of[rid])
+        self.assertIn("Sign the agreement", req.message)
+        self.assertIn("Review section 4", req.message)
+        self.assertEqual([a.label for a in req.actions], ["Done", "Decline"])
 
     def test_card_done_completes_and_decline_declines(self):
         for answer, expected in ((1, "completed"), (2, "declined")):
             rid = self._request()
             aid = self.d._ha_of[rid]
-            self.ha.store.resolve(aid, {"1": [answer]}, "@owner:x")
+            self.ha.resolve(aid, {"1": [answer]}, "@owner:x")
             self.d._settle(rid)
             rec = self.store.get(rid)
             self.assertEqual(rec["status"], expected)
@@ -76,8 +75,7 @@ class HumanActionTests(unittest.TestCase):
                                               {"requestId": rid, "note": "signed"}))
         self.assertEqual(out["status"], "completed")
         self.assertEqual(self.store.get(rid)["result"], {"note": "signed"})
-        card = self.ha.store.get(self.d._ha_of[rid])
-        self.assertEqual(card["status"], "resolved")  # no dangling card
+        self.assertEqual(self.ha.manager.get(self.d._ha_of[rid]).status, "resolved")  # no dangling card
 
     def test_api_decline_and_terminal_is_idempotent_safe(self):
         rid = self._request()
@@ -106,7 +104,7 @@ class HumanActionTests(unittest.TestCase):
                                       {"requestId": rid}))
         self.assertEqual(cm.exception.code, -32601)
         self.assertEqual(self.store.get(rid)["status"], "pending")
-        self.assertEqual(self.ha.store.get(self.d._ha_of[rid])["status"],
+        self.assertEqual(self.ha.manager.get(self.d._ha_of[rid]).status,
                          "pending")
         with self.assertRaises(ProtocolError):
             asyncio.run(self.d.handle("human_action.decline", {"requestId": rid}))
@@ -149,7 +147,7 @@ class ProductionComposedSettleTests(unittest.TestCase):
         rec = self.srv.store.get(rid)
         self.assertEqual(rec["status"], "pending")
         self.assertIsNone(rec.get("resolvedBy"))
-        self.assertEqual(self.srv.ha.store.get(self.d._ha_of[rid])["status"],
+        self.assertEqual(self.srv.ha.manager.get(self.d._ha_of[rid]).status,
                          "pending")
 
 

--- a/tests/runtime-api-server.test.py
+++ b/tests/runtime-api-server.test.py
@@ -60,7 +60,7 @@ def _srv(tmp: Path) -> "rt.RuntimeServer":
 
 def _resolve_ha(srv, request_id, answers):
     aid = ha_action_id(request_id)
-    srv.ha.store.resolve(aid, answers, "@owner:hs")
+    srv.ha.resolve(aid, answers, "@owner:hs")
 
 
 def main() -> int:  # noqa: PLR0915 — one linear conformance script
@@ -96,9 +96,9 @@ def main() -> int:  # noqa: PLR0915 — one linear conformance script
                          "resource": {"roomId": "!r:hs"}, "reason": "why"}))
     check(ra["status"] == "pending", "approval.request issues pending")
     ha_file = tmp / "ha" / (ha_action_id(ra["requestId"]) + ".json")
-    rec = json.loads(ha_file.read_text())
-    check("Approve: message.send" in rec["questions"][0]["question"]
-          and "Reason: why" in rec["questions"][0]["question"],
+    rec = json.loads(ha_file.read_text())["requirement"]
+    check("Approve: message.send" in rec["message"]
+          and "Reason: why" in rec["message"],
           "ha mirror carries action + reason in the card question")
     for bad_params, frag in (
             ({"question": "q", "type": "bogus"}, "type must be"),
@@ -114,7 +114,7 @@ def main() -> int:  # noqa: PLR0915 — one linear conformance script
                          {"question": "Which?", "type": "multi_select",
                           "options": ["a", "b", "c"]}))
     rec1 = json.loads((tmp / "ha" / (ha_action_id(re1["requestId"]) + ".json")).read_text())
-    check(rec1["questions"][0].get("multiSelect") is True,
+    check(rec1["requirement"]["subject"].get("multi_select") is True,
           "multi_select sets the multiSelect card flag")
     try:
         run(srv.dispatcher.handle("no.such", {}))
@@ -258,7 +258,7 @@ def main() -> int:  # noqa: PLR0915 — one linear conformance script
     rx = run(srv.dispatcher.handle("approval.request", {"action": "x.y"}))
     xf = tmp / "ha" / (ha_action_id(rx["requestId"]) + ".json")
     xr = json.loads(xf.read_text())
-    xr["expires_at"] = time.time() - 5
+    xr["requirement"]["expires_at"] = time.time() - 5
     xf.write_text(json.dumps(xr))
     srv.dispatcher._settle(rx["requestId"])
     check(srv.store.get(rx["requestId"])["status"] == "expired",
@@ -371,15 +371,15 @@ def main() -> int:  # noqa: PLR0915 — one linear conformance script
     ad = HumanActionAdapter(str(tmp / "ha4"))
     aid = ad.open_elicitation({"requestId": "elicitation-cafe01234567",
                                "params": {"type": "confirmation", "question": "Go?"}})
-    got = ad.store.get(aid)
-    check([o["label"] for o in got["questions"][0]["options"]] == ["Yes", "No"],
+    got = ad.manager.get(aid)
+    check([a.label for a in got.actions] == ["Yes", "No"],
           "confirmation without options defaults Yes/No")
     check(ad.poll_resolution("ha_missing000000") is None,
           "poll: unknown action → None")
     check(ad.poll_resolution(aid) is None, "poll: pending → None")
-    rec = ad.store.get(aid)
-    rec["expires_at"] = time.time() - 1
-    ad.store.update(rec)
+    rec = ad.manager.get(aid)
+    rec.expires_at = time.time() - 1
+    ad.manager.store.save(rec)
     check(ad.poll_resolution(aid)[0] == "expired", "poll: past deadline → expired")
     opts = [{"label": "A"}, {"label": "B"}]
     check(HumanActionAdapter.first_answer({"1": [2, 99]}, opts) == ["B"],
@@ -595,7 +595,7 @@ def main() -> int:  # noqa: PLR0915 — one linear conformance script
                               "input": {"body": "benign"}}))
         card = json.loads((tmp / "ha" / (ha_action_id(rbi["requestId"]) + ".json"))
                           .read_text())
-        check("benign" in card["questions"][0]["question"],
+        check("benign" in card["requirement"]["message"],
               "approval card shows the governed input")
         _resolve_ha(srv, rbi["requestId"], {"1": [1]})
         run(srv.dispatcher.handle("request.wait", {"requestId": rbi["requestId"], "timeoutS": 5}))


### PR DESCRIPTION
## Why

Owner ask (2026-09-02): consolidate the runtime-api's human-action mirror onto the HITL Requirement layer ("Proceed with a consolidated implementation. It's fine to break the previous human-action. It's half done and not actively used."). Two implementations of the same object existed; the runtime-api adapter was the last producer of the v0.5 `ha_*.json` shape.

## What

- `src/hitl/schema.py`: `HumanRequirement.answer` (free text / multi-select payload) and `expires_at` (on the wire); `ActionReply.answer` (+ `from_wire`).
- `src/hitl/manager.py`: `apply_action` stores `reply.answer`.
- `src/runtime-api/ha_adapter.py`: same public API, but one `HumanRequirement` per runtime request through `HitlManager` (approval → permission approve/deny; elicitation → choice opt1..N or a free-text action; human_action → external_action done/decline). `poll_resolution` keeps the dispatcher's answer shape so `_settle`/`first_answer` are untouched. `ActionStore` is no longer imported here.
- Tests migrated to the Manager API and the on-disk `{"requirement": …}` shape.

Series: after #3705 (engine) and #3745 (hook driver); next is the bridge/CardPoster/DecisionHandler retirement.

## Evidence

HEAD, all run with `python3 <file>`:
```
tests/runtime-api-server.test.py        rc=0  73 ok, 0 FAIL  PASS — in-process daemon suite green
tests/runtime-api-dispatcher.test.py    rc=0  67 ok, 0 FAIL  PASS — runtime-api dispatcher
tests/runtime-api-human-action.test.py  Ran 9 tests  OK
tests/runtime-api-edge-gaps.test.py     Ran 22 tests OK
tests/hitl-replies.test.py              Ran 11 tests OK
tests/hitl-hook-driver.test.py          Ran 9 tests  OK
```
Parent (origin/main): the same four runtime-api suites pass against the old adapter; the first run after the rewrite showed 5 `AttributeError: 'HumanActionAdapter' object has no attribute 'store'` until the tests were migrated, which is the intended break.

Signed: @qingyun-air.agent:ag2.space (air, Qingyun's agent)
