### PR TITLE
fix(launchd): no owner alert for a deliberate bridge restart; one alert per crash loop

### DIFF
--- a/src/launchd/channel-bridge-wrapper.sh
+++ b/src/launchd/channel-bridge-wrapper.sh
@@ -72,10 +72,26 @@ WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
 STATE_DIR="$WORKSPACE/state/channel-bridge-supervisor"
 mkdir -p "$STATE_DIR" "$WORKSPACE/results"
 MARKER="$STATE_DIR/$CHANNEL.started"
+# A deliberate restart (src/restart.sh) stamps this; an exit inside the window is
+# not a crash and gets no owner alert. Same channel alerted within the cooldown: one line, not a stream.
+DELIBERATE="$STATE_DIR/deliberate-restart"
+DELIBERATE_WINDOW_S="${SUTANDO_BRIDGE_DELIBERATE_WINDOW_S:-180}"
+ALERT_STAMP="$STATE_DIR/$CHANNEL.last-alert"
+ALERT_COOLDOWN_S="${SUTANDO_BRIDGE_ALERT_COOLDOWN_S:-600}"
+_age() { local t; t="$(cat "$1" 2>/dev/null || echo 0)"; echo $(( $(date +%s) - ${t:-0} )); }
 emit_restart_alert() {
   NOW="$(date +%s)"
-  RESULT="$WORKSPACE/results/proactive-$CHANNEL-bridge-restarted-$NOW.txt"
   echo "[$CHANNEL-bridge-wrapper] previous process exited; automatically restarting" >&2
+  if [ -f "$DELIBERATE" ] && [ "$(_age "$DELIBERATE")" -lt "$DELIBERATE_WINDOW_S" ]; then
+    echo "[$CHANNEL-bridge-wrapper] exit within a deliberate restart window; no alert" >&2
+    return 0
+  fi
+  if [ -f "$ALERT_STAMP" ] && [ "$(_age "$ALERT_STAMP")" -lt "$ALERT_COOLDOWN_S" ]; then
+    echo "[$CHANNEL-bridge-wrapper] alert cooldown active; not repeating" >&2
+    return 0
+  fi
+  echo "$NOW" > "$ALERT_STAMP"
+  RESULT="$WORKSPACE/results/proactive-$CHANNEL-bridge-restarted-$NOW.txt"
   printf '%s\n' "⚠️ The $CHANNEL bridge exited and was automatically restarted." > "$RESULT"
   osascript -e "display notification \"The $CHANNEL bridge exited and was automatically restarted.\" with title \"Sutando\"" >/dev/null 2>&1 || true
 }

--- a/src/restart.sh
+++ b/src/restart.sh
@@ -52,6 +52,10 @@ if _VOICE_PY="$(bash "$REPO/scripts/sutando-config.sh" python-bin 2>/dev/null)";
 else
     echo "  WARN no usable python3 for the guarded voice lock helper — skipping voice-agent stop (fail closed)"
 fi
+# Deliberate restart: the launchd bridge wrappers treat an exit inside this
+# window as ours, not a crash, so the owner is not alerted for every restart.
+_WS="$(bash "$(dirname "$0")/../scripts/sutando-config.sh" workspace 2>/dev/null)"
+if [ -n "$_WS" ]; then mkdir -p "$_WS/state/channel-bridge-supervisor"; date +%s > "$_WS/state/channel-bridge-supervisor/deliberate-restart"; fi
 pkill -f "web-client.ts" 2>/dev/null
 pkill -f "dashboard.py" 2>/dev/null
 pkill -f "agent-api.py" 2>/dev/null

--- a/tests/channel-bridge-launchd-supervisor.test.py
+++ b/tests/channel-bridge-launchd-supervisor.test.py
@@ -271,6 +271,45 @@ def test_a_bare_exit_zero_is_NOT_a_standdown():
               "a bare exit 0 still alerts the owner - it is not a declared stand-down")
 
 
+def test_a_deliberate_restart_window_suppresses_the_alert():
+    """restart.sh stamps state/channel-bridge-supervisor/deliberate-restart; a crash
+    inside that window is ours and must not reach the owner (four alerts per two
+    restarts, owner 2026-09-02)."""
+    with tempfile.TemporaryDirectory() as raw:
+        wrapper, workspace, exec_log, env = _stage_clean_exit(Path(raw), rc=1)
+        sup = workspace / "state" / "channel-bridge-supervisor"
+        sup.mkdir(parents=True)
+        (sup / "deliberate-restart").write_text(str(int(time.time())))
+        proc = subprocess.Popen(["bash", str(wrapper), "slack"], env=env,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        try:
+            _wait_for(lambda: _launches(exec_log) >= 3, SETTLE)
+            seen = _wait_for(lambda: bool(_alerts(workspace)), 1.0)
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+        check(_launches(exec_log) >= 3, "the wrapper still respawns inside the window")
+        check(not seen, f"no alert inside the deliberate window (found {_alerts(workspace)})")
+
+
+def test_repeated_crashes_alert_once_per_cooldown():
+    """A crash loop is one line, not a stream: the second alert within the cooldown is dropped."""
+    with tempfile.TemporaryDirectory() as raw:
+        wrapper, workspace, exec_log, env = _stage_clean_exit(Path(raw), rc=1)
+        proc = subprocess.Popen(["bash", str(wrapper), "slack"], env=env,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        try:
+            _wait_for(lambda: _launches(exec_log) >= 4, SETTLE)
+            _wait_for(lambda: bool(_alerts(workspace)), SETTLE)
+            time.sleep(0.3)
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+        check(_launches(exec_log) >= 4, "at least four launches happened")
+        check(len(_alerts(workspace)) == 1,
+              f"exactly one alert across the crash loop (found {_alerts(workspace)})")
+
+
 if __name__ == "__main__":
     test_contract()
     test_wrapper_restart_signal()
@@ -278,4 +317,6 @@ if __name__ == "__main__":
     test_a_launchd_relaunch_after_a_standdown_does_not_alert()
     test_the_alert_detector_actually_fires()
     test_a_bare_exit_zero_is_NOT_a_standdown()
+    test_a_deliberate_restart_window_suppresses_the_alert()
+    test_repeated_crashes_alert_once_per_cooldown()
     print("all passed")


### PR DESCRIPTION
## Why

`src/restart.sh` kills the launchd-supervised channel bridges. Each wrapper then sees its child gone, assumes a crash, and writes a proactive alert that every channel delivers. Two restarts on 2026-09-02 put four `⚠️ The slack bridge exited and was automatically restarted.` lines in the owner's DM timeline (screenshot in the owner's room; owner: "We should not flood the timeline like this"). Mechanism traced to `src/launchd/channel-bridge-wrapper.sh` `emit_restart_alert`, which fires on every respawn with a prior marker, twice per restart (the kill, then the startup eviction).

## What

- `src/restart.sh` stamps `state/channel-bridge-supervisor/deliberate-restart` before the kills.
- The wrapper skips the alert when an exit falls within 180 s of that stamp (it still respawns), and will not repeat an alert for the same channel within 600 s, so a genuine crash loop is one line. Both windows are env-tunable.

## Evidence

`python3 tests/channel-bridge-launchd-supervisor.test.py`
- parent: 6 tests, `all passed`
- HEAD: 8 tests, `all passed`, including
  ```
  ok  no alert inside the deliberate window (found [])
  ok  exactly one alert across the crash loop (found ['proactive-slack-bridge-restarted-…txt'])
  ```
- control: with `SUTANDO_BRIDGE_DELIBERATE_WINDOW_S=0 SUTANDO_BRIDGE_ALERT_COOLDOWN_S=0` the two new checks fail (2 FAIL lines); the existing crash positive control (`a CRASH is alerted…`) still passes, so the detector is live.

Not included: a live restart on this host (the owner asked for no more restarts tonight); the wrapper is exercised by the suite through the real script.

Signed: @qingyun-air.agent:ag2.space (air, Qingyun's agent)
