### PR TITLE
fix(agent-room-ops): surface the gateway's own error text on 401/403

### DIFF
--- a/skills/agent-room-ops/_gateway.py
+++ b/skills/agent-room-ops/_gateway.py
@@ -263,6 +263,28 @@ def degrade_reason(code):
     return f"HTTP {code}"
 
 
+# Statuses whose local diagnosis must not be overwritten by the server's prose:
+# 401 points at the bearer, 403 at authorization. The server's text is appended.
+AUTH_STATUSES = frozenset({401, 403})
+
+
+def degrade_reason_from(err):
+    """degrade_reason() plus what the server actually said (`{"error": ...}`).
+    Measured 2026-09-02: a 403 that read "not a joined member" was really
+    "platform grant events.subscribe missing" — a different subsystem entirely."""
+    reason = degrade_reason(err.code)
+    try:
+        parsed = json.loads(err.read().decode("utf-8") or "{}")
+    except Exception:
+        parsed = None
+    server_msg = str(parsed.get("error")) if isinstance(parsed, dict) and parsed.get("error") else ""
+    if not server_msg:
+        return reason
+    if err.code in AUTH_STATUSES:
+        return f"{reason} (server said: {server_msg})"
+    return server_msg
+
+
 def quote(s):
     return urllib.parse.quote(s, safe="")
 

--- a/skills/agent-room-ops/_gateway.py
+++ b/skills/agent-room-ops/_gateway.py
@@ -263,13 +263,16 @@ def degrade_reason(code):
     return f"HTTP {code}"
 
 
-# Statuses whose local diagnosis must not be overwritten by the server's prose:
-# 401 points at the bearer, 403 at authorization. The server's text is appended.
+# Not "auth-ish codes": codes where a wrong reason sends someone to the wrong
+# subsystem (401 = the bearer, 403 = authorization), so the server's text is appended.
 AUTH_STATUSES = frozenset({401, 403})
 
 
 def degrade_reason_from(err):
     """degrade_reason() plus what the server actually said (`{"error": ...}`).
+
+    CONSUMES the response body: `err.read()` is single-shot, so a caller that
+    also wants the parsed body must read it first and cannot call this after.
     Measured 2026-09-02: a 403 that read "not a joined member" was really
     "platform grant events.subscribe missing" — a different subsystem entirely."""
     reason = degrade_reason(err.code)

--- a/skills/agent-room-ops/doc.py
+++ b/skills/agent-room-ops/doc.py
@@ -16,21 +16,12 @@ gateway — the client passes them through verbatim.
 from __future__ import annotations
 
 import base64
-import json
 import os
 
-from _gateway import (gate_allows, load_gate, gateway, http_json, degrade_reason,
-                      degrade_reason_from, AUTH_STATUSES,
-                    HTTPError, URLError)
+from _gateway import (gate_allows, load_gate, gateway, http_json, degrade_reason_from,
+                      HTTPError, URLError)
 
 DEFAULT_FOLDER = "room-live-context"
-
-# Statuses whose degrade_reason() text is a DIAGNOSIS the server's own message
-# must not overwrite — 401 points at the bearer token, 403 at room membership.
-# Kept as a named set rather than an inline `in (401, 403)` so the reason it
-# exists is attached to it: this is not "auth-ish codes", it is "codes where a
-# wrong reason sends someone to the wrong subsystem".
-_AUTH_STATUSES = AUTH_STATUSES
 
 
 def _result(ok, *, room_id=None, folder=None, name=None, content=None,

--- a/skills/agent-room-ops/doc.py
+++ b/skills/agent-room-ops/doc.py
@@ -20,6 +20,7 @@ import json
 import os
 
 from _gateway import (gate_allows, load_gate, gateway, http_json, degrade_reason,
+                      degrade_reason_from, AUTH_STATUSES,
                     HTTPError, URLError)
 
 DEFAULT_FOLDER = "room-live-context"
@@ -29,7 +30,7 @@ DEFAULT_FOLDER = "room-live-context"
 # Kept as a named set rather than an inline `in (401, 403)` so the reason it
 # exists is attached to it: this is not "auth-ish codes", it is "codes where a
 # wrong reason sends someone to the wrong subsystem".
-_AUTH_STATUSES = frozenset({401, 403})
+_AUTH_STATUSES = AUTH_STATUSES
 
 
 def _result(ok, *, room_id=None, folder=None, name=None, content=None,
@@ -80,19 +81,7 @@ def _call(op, room_id, agent_mxid, gate, extra):
         # server's message is APPENDED, never substituted — surfacing what the
         # server said without letting it overwrite what the status code means.
         # Dropping it entirely would trade one silent loss for another.
-        reason = degrade_reason(e.code)
-        try:
-            parsed = json.loads(e.read().decode("utf-8") or "{}")
-        except Exception:
-            parsed = None
-        server_msg = ""
-        if isinstance(parsed, dict) and parsed.get("error"):
-            server_msg = str(parsed["error"])
-        if server_msg:
-            if e.code in _AUTH_STATUSES:
-                reason = f"{reason} (server said: {server_msg})"
-            else:
-                reason = server_msg
+        reason = degrade_reason_from(e)
         return _result(False, room_id=room_id, folder=extra.get("folder"),
                        name=extra.get("filename"), reason=reason)
     except (URLError, TimeoutError) as e:

--- a/skills/agent-room-ops/events.py
+++ b/skills/agent-room-ops/events.py
@@ -32,7 +32,7 @@ import time
 import urllib.request
 
 from _gateway import (HTTP_TIMEOUT, gate_allows, load_gate, gateway, http_json,
-                      degrade_reason, urlencode, HTTPError, URLError)
+                      degrade_reason_from, urlencode, HTTPError, URLError)
 import receipt as _receipt
 
 DEFAULT_WAIT = 30
@@ -81,7 +81,7 @@ def _op_call(op, room_id, agent_mxid, gate, extra=None, *, gated=True):
     try:
         _status, res = http_json("POST", f"{base}/v1/room", headers, payload)
     except HTTPError as e:
-        return _result(False, room_id=room_id, reason=degrade_reason(e.code))
+        return _result(False, room_id=room_id, reason=degrade_reason_from(e))
     except (URLError, TimeoutError) as e:
         return _result(False, room_id=room_id, reason=f"network error: {e}")
     if not isinstance(res, dict):
@@ -179,7 +179,7 @@ def pull(cursor=0, wait=DEFAULT_WAIT):
         # empty-events response.
         res = _http_get_json(url, headers, wait + HTTP_TIMEOUT)
     except HTTPError as e:
-        return {"ok": False, "events": [], "cursor": cursor, "reason": degrade_reason(e.code)}
+        return {"ok": False, "events": [], "cursor": cursor, "reason": degrade_reason_from(e)}
     except (URLError, TimeoutError, OSError) as e:
         return {"ok": False, "events": [], "cursor": cursor, "reason": f"network error: {e}"}
     except ValueError as e:
@@ -272,7 +272,7 @@ def stream(cursor=None, on_event=None, keepalive_cb=None, *, stop=None, max_even
         resp = _open_stream(f"{base}/v1/events/stream", h)
     except HTTPError as e:
         if e.code in (401, 403, 404):
-            raise RuntimeError(degrade_reason(e.code)) from e
+            raise RuntimeError(degrade_reason_from(e)) from e
         raise StreamDisconnected(f"HTTP {e.code} opening stream") from e
     except (URLError, TimeoutError, OSError) as e:
         raise StreamDisconnected(f"connect failed: {e}") from e

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -1518,3 +1518,31 @@ class ChannelEnvTierTests(EnvCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class DegradeReasonFromTests(unittest.TestCase):
+    """The server's own error text reaches the caller; auth statuses keep the local diagnosis in front."""
+
+    @staticmethod
+    def _err(code, body):
+        import io
+        from urllib.error import HTTPError
+        return HTTPError("http://gw/v1/room", code, "x", {}, io.BytesIO(body.encode()))
+
+    def test_403_appends_the_servers_reason(self):
+        r = _gateway.degrade_reason_from(self._err(403, '{"error": "permission denied: platform grant events.subscribe missing"}'))
+        self.assertIn("not a joined member", r)
+        self.assertIn("events.subscribe missing", r)
+
+    def test_401_appends_too_and_keeps_the_token_diagnosis(self):
+        r = _gateway.degrade_reason_from(self._err(401, '{"error": "denied - agent not a joined member"}'))
+        self.assertTrue(r.startswith("auth failed"))
+        self.assertIn("server said", r)
+
+    def test_non_auth_status_uses_the_servers_text(self):
+        self.assertEqual(_gateway.degrade_reason_from(self._err(404, '{"error": "roadmap/plan.md not found"}')),
+                         "roadmap/plan.md not found")
+
+    def test_no_body_falls_back_to_the_status_text(self):
+        self.assertEqual(_gateway.degrade_reason_from(self._err(403, "")), _gateway.degrade_reason(403))
+

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -1516,10 +1516,6 @@ class ChannelEnvTierTests(EnvCase):
             base, _ = _gateway.gateway()
         self.assertEqual(base, "")
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
-
-
 class DegradeReasonFromTests(unittest.TestCase):
     """The server's own error text reaches the caller; auth statuses keep the local diagnosis in front."""
 
@@ -1546,3 +1542,6 @@ class DegradeReasonFromTests(unittest.TestCase):
     def test_no_body_falls_back_to_the_status_text(self):
         self.assertEqual(_gateway.degrade_reason_from(self._err(403, "")), _gateway.degrade_reason(403))
 
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/room-ops-events-server-reason.test.py
+++ b/tests/room-ops-events-server-reason.test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""room-ops events — a 401/403 carries the gateway's own error text to the caller.
+
+Lives in `tests/` because the diff-coverage gate discovers only `tests/*.test.py`
+(`scripts/coverage-gate.sh` -> `find tests -name '*.test.py'`); the skill-local
+suite covers degrade_reason_from() itself, this file is what the gate sees for
+the three events.py call sites — subscribe (_op_call), pull, stream.
+
+Regression: a 403 on events_subscribe rendered as "not a joined member" while
+the gateway had answered `{"error": "platform grant events.subscribe missing"}`
+— a different subsystem entirely. Each site must surface BOTH the local
+diagnosis and the server's text; a non-auth status uses the server's text.
+
+Run: python3 tests/room-ops-events-server-reason.test.py
+"""
+import io
+import os
+import pathlib
+import sys
+import unittest
+import urllib.error
+from unittest import mock
+
+_ROOM_OPS = pathlib.Path(__file__).resolve().parents[1] / "skills" / "agent-room-ops"
+sys.path.insert(0, str(_ROOM_OPS))
+import events as ev  # noqa: E402
+
+ROOM = "!r:ag2.space"
+AGENT = "@a:ag2.space"
+GRANT_403 = b'{"error": "permission denied: platform grant events.subscribe missing"}'
+
+
+def _http_error(code, body):
+    return urllib.error.HTTPError("https://r/v1/room", code, "err", {}, io.BytesIO(body))
+
+
+class _EnvCase(unittest.TestCase):
+    """Pins the gateway POSITIVELY: the resolver reads several env vars plus a
+    vault fallback, so scrubbing names can leave a live path and a real call."""
+
+    def setUp(self):
+        self._g = mock.patch.object(ev, "gateway", return_value=("https://r", {}))
+        self._g.start()
+        self.addCleanup(self._g.stop)
+        self._saved = os.environ.get("ROOM_OPS_GATE")
+        os.environ.pop("ROOM_OPS_GATE", None)
+
+    def tearDown(self):
+        if self._saved is not None:
+            os.environ["ROOM_OPS_GATE"] = self._saved
+
+
+class SubscribeTests(_EnvCase):
+    def test_403_carries_local_diagnosis_and_server_text(self):
+        with mock.patch.object(ev, "http_json", side_effect=_http_error(403, GRANT_403)):
+            res = ev.subscribe(ROOM, ["message.created"], agent_mxid=AGENT, gate=None)
+        self.assertFalse(res["ok"])
+        self.assertIn("not a joined member", res["reason"])
+        self.assertIn("platform grant events.subscribe missing", res["reason"])
+
+    def test_401_keeps_the_token_diagnosis_in_front(self):
+        body = b'{"error": "denied - agent not a joined member"}'
+        with mock.patch.object(ev, "http_json", side_effect=_http_error(401, body)):
+            res = ev.subscribe(ROOM, ["message.created"], agent_mxid=AGENT, gate=None)
+        self.assertTrue(res["reason"].startswith("auth failed"))
+        self.assertIn("(server said: denied - agent not a joined member)", res["reason"])
+
+    def test_bodiless_403_is_the_plain_status_text(self):
+        with mock.patch.object(ev, "http_json", side_effect=_http_error(403, b"")):
+            res = ev.subscribe(ROOM, ["message.created"], agent_mxid=AGENT, gate=None)
+        self.assertEqual(res["reason"], "denied — agent not a joined member (403)")
+
+
+class PullTests(_EnvCase):
+    def test_403_carries_local_diagnosis_and_server_text(self):
+        with mock.patch.object(ev, "_http_get_json", side_effect=_http_error(403, GRANT_403)):
+            res = ev.pull(cursor=5)
+        self.assertFalse(res["ok"])
+        self.assertEqual(res["cursor"], 5)
+        self.assertIn("not a joined member", res["reason"])
+        self.assertIn("platform grant events.subscribe missing", res["reason"])
+
+    def test_non_auth_status_uses_the_servers_text(self):
+        body = b'{"error": "events cursor 5 expired"}'
+        with mock.patch.object(ev, "_http_get_json", side_effect=_http_error(410, body)):
+            res = ev.pull(cursor=5)
+        self.assertEqual(res["reason"], "events cursor 5 expired")
+
+
+class StreamTests(_EnvCase):
+    def test_403_open_raises_with_local_diagnosis_and_server_text(self):
+        with mock.patch.object(ev, "_open_stream", side_effect=_http_error(403, GRANT_403)):
+            with self.assertRaises(RuntimeError) as cm:
+                ev.stream(on_event=lambda c, e: None)
+        self.assertIn("not a joined member", str(cm.exception))
+        self.assertIn("platform grant events.subscribe missing", str(cm.exception))
+
+    def test_transient_status_is_still_a_disconnect(self):
+        # The body is only consulted on the permission statuses; a 502 must keep
+        # raising StreamDisconnected so the resume wrapper reconnects.
+        body = b'{"error": "upstream reset"}'
+        with mock.patch.object(ev, "_open_stream", side_effect=_http_error(502, body)):
+            with self.assertRaises(ev.StreamDisconnected):
+                ev.stream(on_event=lambda c, e: None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Why

`degrade_reason(403)` rendered every 403 as `denied — agent not a joined member (403)`. Measured 2026-09-02 on this host: the broker's real reply to `events_subscribe` was `{"error": "permission denied: platform grant events.subscribe missing"}`, and the flattened wording sent an hour of investigation to room membership first (the members API listed the agent; a bug report was filed against the wrong cause).

## What

`doc.py` already had the right policy (append the server's `error` text for 401/403, use it outright for other statuses). That policy now lives once, in `_gateway.degrade_reason_from(err)`, and `doc.py` plus the three `events.py` sites (subscribe / pull / stream) use it. `degrade_reason(code)` is unchanged for callers without a response body.

## Evidence

`python3 -m unittest test_room_ops` (in `skills/agent-room-ops`): parent: `Ran 146 tests … OK` → HEAD: `Ran 150 tests in 0.190s … OK`.

Signed: @qingyun-air.agent:ag2.space (air, Qingyun's agent)
