### PR TITLE
feat(hooks): review-authority-guard — deny formal GitHub reviews until the owner rules

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -198,11 +198,15 @@ The mode lives in `<workspace>/state/authority.json`:
 {"github_formal_review": "hold" | "findings-only" | "allow"}
 ```
 
-A missing or unreadable file means `hold` (policy: the restrictive reading
-applies until the owner rules). Never gated: review dismissals (a reduction of
-standing), `gh pr comment`, `--comment` under `findings-only`, and every
-non-review command. Compound commands are split per segment so an earlier
-benign `gh` cannot shadow a later review.
+A missing file means `findings-only`: the votes stay denied until the owner
+rules, while a COMMENTED review — which moves no gate and is the durable place
+a finding lives — stays possible. A file that is present but unreadable, or
+carries an unknown mode, means `hold` (a ruling was written and cannot be read,
+so the restrictive reading applies). Never gated: review dismissals (a
+reduction of standing), `gh pr comment`, `--comment` under `findings-only`, and
+every non-review command. Compound commands are split per segment so an earlier
+benign `gh` cannot shadow a later review; `bash -c "..."` / `sh -c` / `eval`
+wrappers are re-classified on their quoted command.
 
 Escape hatch: `SUTANDO_ALLOW_FORMAL_GH_REVIEWS=1`. Fail-OPEN on hook errors.
 
@@ -211,8 +215,9 @@ Escape hatch: `SUTANDO_ALLOW_FORMAL_GH_REVIEWS=1`. Fail-OPEN on hook errors.
 Not auto-registered. Deploy per node into `$CLAUDE_CONFIG_DIR` and add a
 `PreToolUse` entry with matcher `Bash`, the same way as the manual block under
 `gmail-write-guard.py` above (command: `python3 <deployed path>/review-authority-guard.py`).
-The deployed copy locates the workspace by searching upward for
-`state/authority.json`; set `SUTANDO_WORKSPACE_FOR_HOOK=<workspace>` to pin it.
+In-repo the hook resolves the workspace through `workspace_default.resolve_workspace`;
+a deployed copy searches upward for `state/authority.json`. Set
+`SUTANDO_HOOK_WORKSPACE=<workspace>` to pin it.
 
 Test: `python3 tests/review-authority-guard.test.py`.
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -185,6 +185,37 @@ PY
 
 Test: `python3 tests/gmail-write-guard.test.py`.
 
+## `review-authority-guard.py`
+
+Denies a **formal GitHub review** filed from Bash — `gh pr review --approve` /
+`--request-changes` (and `--comment` under `hold`), or `gh api .../pulls/N/reviews`
+carrying `APPROVE` / `REQUEST_CHANGES` — while the owner's standing answer on
+review authority is unresolved. An APPROVE moves a merge gate, and merges are
+the owner's; verifying a change carefully is not authorization to vote on it.
+The mode lives in `<workspace>/state/authority.json`:
+
+```json
+{"github_formal_review": "hold" | "findings-only" | "allow"}
+```
+
+A missing or unreadable file means `hold` (policy: the restrictive reading
+applies until the owner rules). Never gated: review dismissals (a reduction of
+standing), `gh pr comment`, `--comment` under `findings-only`, and every
+non-review command. Compound commands are split per segment so an earlier
+benign `gh` cannot shadow a later review.
+
+Escape hatch: `SUTANDO_ALLOW_FORMAL_GH_REVIEWS=1`. Fail-OPEN on hook errors.
+
+### Registration
+
+Not auto-registered. Deploy per node into `$CLAUDE_CONFIG_DIR` and add a
+`PreToolUse` entry with matcher `Bash`, the same way as the manual block under
+`gmail-write-guard.py` above (command: `python3 <deployed path>/review-authority-guard.py`).
+The deployed copy locates the workspace by searching upward for
+`state/authority.json`; set `SUTANDO_WORKSPACE_FOR_HOOK=<workspace>` to pin it.
+
+Test: `python3 tests/review-authority-guard.test.py`.
+
 ## `result-file-marker-guard.py`
 
 Denies a **Write/Edit into `<workspace>/results/`** whose body carries a

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -193,6 +193,7 @@ carrying `APPROVE` / `REQUEST_CHANGES` — while the owner's standing answer on
 review authority is unresolved. An APPROVE moves a merge gate, and merges are
 the owner's; verifying a change carefully is not authorization to vote on it.
 The mode lives in `<workspace>/state/authority.json`:
+An owner who ruled *verbally* has no file yet, so that ruling reads as `hold` until someone writes it — register the file on the node whose owner already answered.
 
 ```json
 {"github_formal_review": "hold" | "findings-only" | "allow"}

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -116,6 +116,17 @@ def classify(command: str) -> Optional[str]:
     """Return 'APPROVE' / 'REQUEST_CHANGES' / 'COMMENT', or None if not a formal review."""
     if not isinstance(command, str) or "gh" not in command:
         return None
+    # A wrapper's quoted -c string may itself contain && or ; — classify it
+    # whole before the separator split can cut through the quotes.
+    try:
+        whole = shlex.split(command)
+    except ValueError:
+        whole = []
+    inner = _wrapped_command(whole)
+    if inner is not None:
+        nested = classify(inner)
+        if nested is not None:
+            return nested
     for seg in _segments(command):
         if _DISMISSAL.search(seg):
             continue

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -139,16 +139,40 @@ def _wrapped_command(words):
 _HEREDOC = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n(.*?)\n\s*\1\s*(?:\n|$)", re.S)
 
 
+def _heredoc_owner(prefix):
+    """Head of the command that owns a heredoc: 'gh', an interpreter name, or None."""
+    line = prefix.rsplit("\n", 1)[-1]
+    seg = re.split(r"&&|\|\||[;|]", line)[-1]
+    try:
+        words = shlex.split(seg)
+    except ValueError:
+        words = seg.split()
+    if not words:
+        return None
+    head = words[0].rsplit("/", 1)[-1].lower()
+    if head == "gh":
+        return "gh"
+    if head in _INTERPRETERS or head.startswith("python"):
+        return head
+    return None
+
+
 def classify(command: str) -> Optional[str]:
     """Return 'APPROVE' / 'REQUEST_CHANGES' / 'COMMENT', or None if not a formal review."""
     if not isinstance(command, str) or "gh" not in command:
         return None
     for m in _HEREDOC.finditer(command):
+        # Only program text or API input is scanned; a `cat`/`tee` heredoc that
+        # merely mentions the command is documentation, not a review.
+        head = _heredoc_owner(command[:m.start()])
+        if head is None:
+            continue
         body = m.group(2)
-        if _API_REVIEWS.search(command):
-            e = _API_EVENT.search(body)
+        if head == "gh":
+            e = _API_EVENT.search(body) if _API_REVIEWS.search(command) else None
             if e:
                 return e.group(1)
+            continue
         nested = classify(_LITERAL_NOISE.sub(" ", body))
         if nested is not None:
             return nested

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -19,10 +19,12 @@ Authority state lives in ``<workspace>/state/authority.json``:
   findings-only  deny APPROVE and REQUEST_CHANGES; allow --comment
   allow          allow all formal reviews
 
-MISSING or UNREADABLE state means ``hold``. That is policy, not a bug: the
-restrictive reading is what applies until the owner rules, and this surface is
-narrow enough (formal reviews only) that defaulting closed cannot wedge the core.
-Genuine hook exceptions still fail OPEN, per the repo's hook contract.
+A MISSING file means ``findings-only``: the two events that move a merge gate
+stay denied until the owner rules, while a COMMENTED review — which moves nothing
+and is the only durable place a finding lives — stays possible. A file that is
+PRESENT but unreadable or carries an unknown mode means ``hold``: someone wrote
+a ruling and it cannot be read, so the restrictive reading applies. Genuine hook
+exceptions still fail OPEN, per the repo's hook contract.
 
 NOT blocked, deliberately: ``--comment`` under findings-only, review DISMISSAL,
 variable indirection (``GH=gh; $GH ...`` needs real shell expansion — a non-goal here)
@@ -32,6 +34,8 @@ comments, and every non-review ``gh`` call.
 Escape hatch: ``SUTANDO_ALLOW_FORMAL_GH_REVIEWS=1``.
 
 Registration: per-node deploy into $CLAUDE_CONFIG_DIR — see hooks/README.md.
+Workspace: SUTANDO_HOOK_WORKSPACE > workspace_default.resolve_workspace (in-repo)
+> an upward search for the state file (deployed copy).
 """
 import json
 import os
@@ -59,11 +63,16 @@ def _workspace() -> str:
     and a missing state file reads as 'hold', which looks correct while being
     permanently deaf to the file. Search for the state file itself instead.
     """
-    env = os.environ.get("SUTANDO_WORKSPACE_FOR_HOOK", "").strip()
+    env = os.environ.get("SUTANDO_HOOK_WORKSPACE", "").strip()
     if env:
         return env
     here = os.path.dirname(os.path.abspath(__file__))
-    cand = [os.path.join(os.path.dirname(here), "workspace")]  # in-repo layout
+    src = os.path.join(os.path.dirname(here), "src")
+    if os.path.isfile(os.path.join(src, "workspace_default.py")):  # in-repo layout
+        sys.path.insert(0, src)
+        from workspace_default import resolve_workspace
+        return str(resolve_workspace())
+    cand = [os.path.join(os.path.dirname(here), "workspace")]
     d = here
     for _ in range(6):                                        # deployed layout
         d = os.path.dirname(d)
@@ -78,9 +87,13 @@ def _workspace() -> str:
 
 
 def read_state(workspace: str) -> str:
-    """Return the authority mode. Missing/unreadable/unknown -> 'hold'."""
+    """Return the authority mode. Missing -> 'findings-only'; present but
+    unreadable or unknown -> 'hold' (a ruling was written and cannot be read)."""
+    path = os.path.join(workspace, STATE_REL)
+    if not os.path.exists(path):
+        return "findings-only"
     try:
-        with open(os.path.join(workspace, STATE_REL)) as fh:
+        with open(path) as fh:
             val = json.load(fh).get(KEY)
     except Exception:
         return "hold"
@@ -168,14 +181,17 @@ def reason(event: str, mode: str, workspace: str) -> str:
     return (
         f"BLOCKED: filing a formal GitHub review ({event}) is gated on this install. "
         f"Authority state is '{mode}' in {os.path.join(workspace, STATE_REL)} "
-        f"({KEY}); a missing or unreadable file also means 'hold'. "
+        f"({KEY}); a missing file means 'findings-only', an unreadable one 'hold'. "
         "An APPROVE/REQUEST_CHANGES is not just publishing — it moves a merge gate, "
         "and merges are the owner's. This guard exists because on 2026-09-01 a careful, "
         "correct review was filed as a formal APPROVE without that ruling, and it was the "
         "only gating approval on the PR. Verifying a change well is not authorization to "
-        "vote on it. Do this instead: post the findings in-room and let a human or an "
-        "authorised agent file the review, or use `--comment` if the state is "
-        "'findings-only'. When the owner rules, set the state file and this lifts. "
+        "vote on it. Do this instead: file the findings as a COMMENTED review "
+        "(`gh pr review --comment`) — that moves no gate and keeps the record on the PR; "
+        f"if the state is 'hold' or an unreadable file, {{\"{KEY}\": \"findings-only\"}} "
+        "in that file is the setting that restores --comment while the votes stay gated. "
+        "Otherwise post in-room and let a human or an authorised agent file the review. "
+        "When the owner rules, set the state file and this lifts. "
         "Override for one session with SUTANDO_ALLOW_FORMAL_GH_REVIEWS=1. "
         "[review-authority-guard]"
     )

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -117,7 +117,8 @@ _LITERAL_NOISE = re.compile(r"""[\[\]\(\),'"]""")
 
 def _wrapped_command(words):
     """The string a wrapper would run (`bash -c`, `eval`, `python3 -c`, `node -e`):
-    one shlex token, so it is re-classified; interpreter strings de-literalised first."""
+    one shlex token, so it is re-classified; interpreter strings de-literalised first.
+    Not covered: variable indirection (`$GH pr review`) and program text via a pipe."""
     if not words:
         return None
     head = words[0].rsplit("/", 1)[-1].lower()
@@ -134,10 +135,23 @@ def _wrapped_command(words):
     return None
 
 
+# A heredoc body: program text on stdin (`python3 - <<'PY'`) or JSON for `--input -`.
+_HEREDOC = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n(.*?)\n\s*\1\s*(?:\n|$)", re.S)
+
+
 def classify(command: str) -> Optional[str]:
     """Return 'APPROVE' / 'REQUEST_CHANGES' / 'COMMENT', or None if not a formal review."""
     if not isinstance(command, str) or "gh" not in command:
         return None
+    for m in _HEREDOC.finditer(command):
+        body = m.group(2)
+        if _API_REVIEWS.search(command):
+            e = _API_EVENT.search(body)
+            if e:
+                return e.group(1)
+        nested = classify(_LITERAL_NOISE.sub(" ", body))
+        if nested is not None:
+            return nested
     # A wrapper's quoted -c string may itself contain && or ; — classify it
     # whole before the separator split can cut through the quotes.
     try:

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -24,7 +24,8 @@ restrictive reading is what applies until the owner rules, and this surface is
 narrow enough (formal reviews only) that defaulting closed cannot wedge the core.
 Genuine hook exceptions still fail OPEN, per the repo's hook contract.
 
-NOT blocked, deliberately: ``--comment`` under findings-only, review DISMISSAL
+NOT blocked, deliberately: ``--comment`` under findings-only, review DISMISSAL,
+variable indirection (``GH=gh; $GH ...`` needs real shell expansion — a non-goal here)
 (reducing one's own standing review is never the risky direction), plain PR
 comments, and every non-review ``gh`` call.
 
@@ -93,6 +94,24 @@ def _segments(command: str):
     return [s for s in re.split(r"&&|\|\||[;|\n]", command) if s.strip()]
 
 
+_SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
+
+
+def _wrapped_command(words):
+    """The command string a shell wrapper would run: `bash -c "..."`, `eval "..."`.
+    shlex keeps the whole -c argument as one token, so it is re-classified."""
+    if not words:
+        return None
+    head = words[0].rsplit("/", 1)[-1].lower()
+    if head == "eval":
+        return " ".join(words[1:]) or None
+    if head in _SHELLS:
+        for i, w in enumerate(words[1:-1], 1):
+            if w == "-c" or (w.startswith("-") and not w.startswith("--") and "c" in w):
+                return words[i + 1]
+    return None
+
+
 def classify(command: str) -> Optional[str]:
     """Return 'APPROVE' / 'REQUEST_CHANGES' / 'COMMENT', or None if not a formal review."""
     if not isinstance(command, str) or "gh" not in command:
@@ -107,6 +126,11 @@ def classify(command: str) -> Optional[str]:
         if not words:
             continue
         low = [w.lower() for w in words]
+        inner = _wrapped_command(words)
+        if inner is not None:
+            nested = classify(inner)
+            if nested is not None:
+                return nested
         if "gh" in low and "pr" in low and "review" in low:
             starts = [i for i, w in enumerate(low) if w == "gh"]
             if any(low[i + 1:i + 3] == ["pr", "review"] for i in starts):

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""review-authority-guard — PreToolUse hook that denies FORMAL GitHub reviews
+(APPROVE / REQUEST_CHANGES, and optionally COMMENT) while the owner's standing
+answer on review authority is unresolved.
+
+Why this exists as a hook and not a note: on 2026-09-01 the agent declined to
+file formal reviews three times, then filed an APPROVE on the fourth ask after
+verifying the change carefully. Careful verification is not authorization. The
+approval turned out to be the only *gating* approval on that PR, so half a merge
+gate was cleared by an agent whose owner had not answered whether it may do that.
+A boundary held by remembering it on every request fails eventually; this runs
+unconditionally.
+
+Authority state lives in ``<workspace>/state/authority.json``:
+
+    {"github_formal_review": "hold" | "findings-only" | "allow"}
+
+  hold           deny APPROVE, REQUEST_CHANGES and COMMENT (review in-room instead)
+  findings-only  deny APPROVE and REQUEST_CHANGES; allow --comment
+  allow          allow all formal reviews
+
+MISSING or UNREADABLE state means ``hold``. That is policy, not a bug: the
+restrictive reading is what applies until the owner rules, and this surface is
+narrow enough (formal reviews only) that defaulting closed cannot wedge the core.
+Genuine hook exceptions still fail OPEN, per the repo's hook contract.
+
+NOT blocked, deliberately: ``--comment`` under findings-only, review DISMISSAL
+(reducing one's own standing review is never the risky direction), plain PR
+comments, and every non-review ``gh`` call.
+
+Escape hatch: ``SUTANDO_ALLOW_FORMAL_GH_REVIEWS=1``.
+
+Registration: per-node deploy into $CLAUDE_CONFIG_DIR — see hooks/README.md.
+"""
+import json
+import os
+import re
+import shlex
+import sys
+from typing import Optional
+
+STATE_REL = os.path.join("state", "authority.json")
+KEY = "github_formal_review"
+BLOCKING = {"approve": "APPROVE", "request-changes": "REQUEST_CHANGES"}
+
+# `gh api .../reviews` carrying an event, e.g. -f event=APPROVE or JSON input.
+_API_EVENT = re.compile(r"\b(APPROVE|REQUEST_CHANGES)\b")
+_API_REVIEWS = re.compile(r"/pulls/\d+/reviews\b")
+# Dismissal is a REDUCTION of standing — never gated.
+_DISMISSAL = re.compile(r"/reviews/\d+/dismissals\b")
+
+
+def _workspace() -> str:
+    """Locate the workspace holding state/authority.json.
+
+    Deployment COPIES this file out of the repo (into $CLAUDE_CONFIG_DIR/hooks),
+    so a purely repo-relative guess points at a directory that does not exist —
+    and a missing state file reads as 'hold', which looks correct while being
+    permanently deaf to the file. Search for the state file itself instead.
+    """
+    env = os.environ.get("SUTANDO_WORKSPACE_FOR_HOOK", "").strip()
+    if env:
+        return env
+    here = os.path.dirname(os.path.abspath(__file__))
+    cand = [os.path.join(os.path.dirname(here), "workspace")]  # in-repo layout
+    d = here
+    for _ in range(6):                                        # deployed layout
+        d = os.path.dirname(d)
+        if not d or d == os.path.dirname(d):
+            break
+        cand.append(d)
+        cand.append(os.path.join(d, "workspace"))
+    for c in cand:
+        if os.path.isfile(os.path.join(c, STATE_REL)):
+            return c
+    return cand[0]
+
+
+def read_state(workspace: str) -> str:
+    """Return the authority mode. Missing/unreadable/unknown -> 'hold'."""
+    try:
+        with open(os.path.join(workspace, STATE_REL)) as fh:
+            val = json.load(fh).get(KEY)
+    except Exception:
+        return "hold"
+    if isinstance(val, str) and val.strip().lower() in ("hold", "findings-only", "allow"):
+        return val.strip().lower()
+    return "hold"
+
+
+def _segments(command: str):
+    """Split a compound shell command into candidate invocations."""
+    return [s for s in re.split(r"&&|\|\||[;|\n]", command) if s.strip()]
+
+
+def classify(command: str) -> Optional[str]:
+    """Return 'APPROVE' / 'REQUEST_CHANGES' / 'COMMENT', or None if not a formal review."""
+    if not isinstance(command, str) or "gh" not in command:
+        return None
+    for seg in _segments(command):
+        if _DISMISSAL.search(seg):
+            continue
+        try:
+            words = shlex.split(seg)
+        except ValueError:
+            words = seg.split()
+        if not words:
+            continue
+        low = [w.lower() for w in words]
+        if "gh" in low and "pr" in low and "review" in low:
+            starts = [i for i, w in enumerate(low) if w == "gh"]
+            if any(low[i + 1:i + 3] == ["pr", "review"] for i in starts):
+                for w in low:
+                    flag = w.lstrip("-")
+                    if w.startswith("--") and flag in BLOCKING:
+                        return BLOCKING[flag]
+                    if w in ("-a",):
+                        return "APPROVE"
+                    if w in ("-r",):
+                        return "REQUEST_CHANGES"
+                if any(w == "--comment" or w == "-c" for w in low):
+                    return "COMMENT"
+                # `gh pr review` with no event flag opens an interactive prompt.
+                return "COMMENT"
+        if "gh" in low and "api" in low and _API_REVIEWS.search(seg):
+            m = _API_EVENT.search(seg)
+            if m:
+                return m.group(1)
+    return None
+
+
+def reason(event: str, mode: str, workspace: str) -> str:
+    return (
+        f"BLOCKED: filing a formal GitHub review ({event}) is gated on this install. "
+        f"Authority state is '{mode}' in {os.path.join(workspace, STATE_REL)} "
+        f"({KEY}); a missing or unreadable file also means 'hold'. "
+        "An APPROVE/REQUEST_CHANGES is not just publishing — it moves a merge gate, "
+        "and merges are the owner's. This guard exists because on 2026-09-01 a careful, "
+        "correct review was filed as a formal APPROVE without that ruling, and it was the "
+        "only gating approval on the PR. Verifying a change well is not authorization to "
+        "vote on it. Do this instead: post the findings in-room and let a human or an "
+        "authorised agent file the review, or use `--comment` if the state is "
+        "'findings-only'. When the owner rules, set the state file and this lifts. "
+        "Override for one session with SUTANDO_ALLOW_FORMAL_GH_REVIEWS=1. "
+        "[review-authority-guard]"
+    )
+
+
+def main() -> None:
+    if os.environ.get("SUTANDO_ALLOW_FORMAL_GH_REVIEWS", "").strip() == "1":
+        sys.exit(0)
+    data = json.loads(sys.stdin.read())
+    if str(data.get("tool_name") or "") != "Bash":
+        sys.exit(0)
+    command = (data.get("tool_input") or {}).get("command")
+    event = classify(command or "")
+    if event is None:
+        sys.exit(0)
+    workspace = _workspace()
+    mode = read_state(workspace)
+    if mode == "allow":
+        sys.exit(0)
+    if mode == "findings-only" and event == "COMMENT":
+        sys.exit(0)
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason(event, mode, workspace),
+    }}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:  # fail-open: a crashing hook must never wedge the core
+        print(f"[review-authority-guard] non-fatal error, allowing: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -187,6 +187,8 @@ def classify(command: str) -> Optional[str]:
         nested = classify(inner)
         if nested is not None:
             return nested
+    # Bodies are settled above; the segment pass must not re-read them as commands.
+    command = _HEREDOC.sub("\n", command)
     for seg in _segments(command):
         if _DISMISSAL.search(seg):
             continue

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -48,8 +48,9 @@ STATE_REL = os.path.join("state", "authority.json")
 KEY = "github_formal_review"
 BLOCKING = {"approve": "APPROVE", "request-changes": "REQUEST_CHANGES"}
 
-# `gh api .../reviews` carrying an event, e.g. -f event=APPROVE or JSON input.
-_API_EVENT = re.compile(r"\b(APPROVE|REQUEST_CHANGES)\b")
+# `gh api .../reviews`: the event ASSIGNMENT (-f event=APPROVE, "event": "APPROVE"),
+# never a bare word — a COMMENT whose body discusses approval is not an approval.
+_API_EVENT = re.compile(r"""\bevent\b["']?\s*[:=]\s*["']?(APPROVE|REQUEST_CHANGES|COMMENT)\b""")
 _API_REVIEWS = re.compile(r"/pulls/\d+/reviews\b")
 # Dismissal is a REDUCTION of standing — never gated.
 _DISMISSAL = re.compile(r"/reviews/\d+/dismissals\b")
@@ -108,11 +109,15 @@ def _segments(command: str):
 
 
 _SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
+_INTERPRETERS = {"python", "python3", "node", "ruby", "perl"}
+# A list-literal argv (`['gh','pr','review']`) is one program string to shlex; dropping
+# quotes, commas and brackets restores adjacency so the token check sees it.
+_LITERAL_NOISE = re.compile(r"""[\[\]\(\),'"]""")
 
 
 def _wrapped_command(words):
-    """The command string a shell wrapper would run: `bash -c "..."`, `eval "..."`.
-    shlex keeps the whole -c argument as one token, so it is re-classified."""
+    """The string a wrapper would run (`bash -c`, `eval`, `python3 -c`, `node -e`):
+    one shlex token, so it is re-classified; interpreter strings de-literalised first."""
     if not words:
         return None
     head = words[0].rsplit("/", 1)[-1].lower()
@@ -122,6 +127,10 @@ def _wrapped_command(words):
         for i, w in enumerate(words[1:-1], 1):
             if w == "-c" or (w.startswith("-") and not w.startswith("--") and "c" in w):
                 return words[i + 1]
+    if head in _INTERPRETERS or head.startswith("python"):
+        for i, w in enumerate(words[1:-1], 1):
+            if w in ("-c", "-e"):
+                return _LITERAL_NOISE.sub(" ", words[i + 1])
     return None
 
 
@@ -174,6 +183,8 @@ def classify(command: str) -> Optional[str]:
             m = _API_EVENT.search(seg)
             if m:
                 return m.group(1)
+            # A reviews POST whose event rides in --input/stdin is unreadable here;
+            # fail open rather than guess from prose.
     return None
 
 

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -155,6 +155,30 @@ for _cmd, _want in (
 ):
     check(f"wrapper: {_cmd}", classify(_cmd), _want)
 
+print("11. interpreter indirection: -c/-e strings and list-literal argv are de-literalised")
+_R = "gh pr review"
+for _cmd, _want in (
+    ("""python3 -c "import subprocess; subprocess.run(['gh','pr','review','123','--approve'])" """, "APPROVE"),
+    ("""python3 -c 'import subprocess; subprocess.run(["gh", "pr", "review", "123", "--request-changes", "-b", "x"])' """, "REQUEST_CHANGES"),
+    ("""python3.12 -c "subprocess.run(['gh','pr','review','7','--comment','-b','ok'])" """, "COMMENT"),
+    (f"""node -e "require('child_process').execSync('{_R} 5 --approve')" """, "APPROVE"),
+    ("""python3 -c "subprocess.run(['gh','api','repos/o/r/pulls/3/reviews','-f','event=APPROVE'])" """, "APPROVE"),
+    ('python3 -c "print(\'hello\')"', None),
+    ("python3 -c \"subprocess.run(['gh','pr','view','123'])\"", None),
+):
+    check(f"interp: {_cmd.strip()}", classify(_cmd), _want)
+
+print("12. gh api reviews: the event ASSIGNMENT decides, body prose never does")
+for _cmd, _want in (
+    ("gh api repos/o/r/pulls/3/reviews -f event=COMMENT -f body='I do not APPROVE of this'", "COMMENT"),
+    ("gh api repos/o/r/pulls/3/reviews -f event=COMMENT -f body='needs REQUEST_CHANGES later'", "COMMENT"),
+    ("gh api repos/o/r/pulls/3/reviews -f event=APPROVE -f body='ok'", "APPROVE"),
+    ("gh api repos/o/r/pulls/3/reviews --raw-field event=REQUEST_CHANGES", "REQUEST_CHANGES"),
+    ("""gh api repos/o/r/pulls/3/reviews --input - <<< '{"event": "APPROVE", "body": "x"}'""", "APPROVE"),
+    ("gh api repos/o/r/pulls/3/reviews -f body='APPROVE this please'", None),
+):
+    check(f"api: {_cmd}", classify(_cmd), _want)
+
 if FAILURES:
     print(f"\nFAIL — {len(FAILURES)} check(s):")
     for f in FAILURES:

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""PreToolUse review-authority-guard: formal GitHub reviews (APPROVE /
+REQUEST_CHANGES) must be DENIED while the owner's ruling is unresolved, while
+dismissals, plain comments and every non-review command pass through
+(hooks/review-authority-guard.py).
+
+Run:  python3 tests/review-authority-guard.test.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOK = str(Path(__file__).resolve().parent.parent / "hooks" / "review-authority-guard.py")
+FAILURES = []
+
+
+def run(command, mode="__absent__", tool="Bash", env_extra=None):
+    """Invoke the hook with a workspace whose authority state is `mode`."""
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "state"), exist_ok=True)
+        if mode != "__absent__":
+            with open(os.path.join(td, "state", "authority.json"), "w") as fh:
+                fh.write(mode if mode.startswith("{") else json.dumps({"github_formal_review": mode}))
+        env = dict(os.environ)
+        env["SUTANDO_WORKSPACE_FOR_HOOK"] = td
+        env.pop("SUTANDO_ALLOW_FORMAL_GH_REVIEWS", None)
+        env.update(env_extra or {})
+        p = subprocess.run([sys.executable, HOOK], input=json.dumps(
+            {"tool_name": tool, "tool_input": {"command": command}}),
+            capture_output=True, text=True, env=env)
+    denied = '"permissionDecision": "deny"' in p.stdout
+    return denied, p.stdout, p.returncode
+
+
+def check(label, got, want):
+    if got != want:
+        FAILURES.append(f"{label}: got {got!r}, want {want!r}")
+        print(f"  FAIL {label}: got {got!r} want {want!r}")
+    else:
+        print(f"  ok   {label}")
+
+
+APPROVE = "gh pr review 3679 --repo sonichi/sutando --approve --body-file /tmp/r.md"
+REQCH = "gh pr review 42 --request-changes --body 'no'"
+COMMENT = "gh pr review 42 --comment --body 'note'"
+DISMISS = "gh api --method PUT repos/o/r/pulls/3679/reviews/5082607312/dismissals --input /tmp/d.json"
+
+print("1. hold (the default while unanswered) denies every formal review")
+check("approve denied", run(APPROVE, "hold")[0], True)
+check("request-changes denied", run(REQCH, "hold")[0], True)
+check("comment denied under hold", run(COMMENT, "hold")[0], True)
+
+print("2. MISSING state file behaves as hold — the restrictive reading is the default")
+check("approve denied with no state file", run(APPROVE)[0], True)
+check("unparseable state denied", run(APPROVE, "{not json")[0], True)
+check("unknown mode value denied", run(APPROVE, "yolo")[0], True)
+
+print("3. findings-only allows --comment but still gates the votes")
+check("approve denied", run(APPROVE, "findings-only")[0], True)
+check("request-changes denied", run(REQCH, "findings-only")[0], True)
+check("comment ALLOWED", run(COMMENT, "findings-only")[0], False)
+
+print("4. allow lets everything through")
+check("approve allowed", run(APPROVE, "allow")[0], False)
+check("request-changes allowed", run(REQCH, "allow")[0], False)
+
+print("5. reductions and unrelated commands are never gated")
+check("dismissal allowed under hold", run(DISMISS, "hold")[0], False)
+# Discriminating case: a dismissal whose MESSAGE contains the word APPROVE —
+# without the dismissal skip the event regex matches the prose and blocks a REDUCTION.
+check("dismissal naming APPROVE in its message still allowed", run(
+    "gh api --method PUT repos/o/r/pulls/42/reviews/9/dismissals "
+    "-f message='re-file this as your own APPROVE if useful' -f event=DISMISS",
+    "hold")[0], False)
+check("plain pr comment allowed", run("gh pr comment 42 --body hi", "hold")[0], False)
+check("pr view allowed", run("gh pr view 42 --json state", "hold")[0], False)
+check("unrelated command allowed", run("git status", "hold")[0], False)
+check("non-Bash tool ignored", run(APPROVE, "hold", tool="Read")[0], False)
+
+print("6. compound commands cannot smuggle a review past the split")
+check("&& chain denied", run(f"cd /tmp && {APPROVE}", "hold")[0], True)
+check("semicolon chain denied", run(f"echo hi; {APPROVE}", "hold")[0], True)
+check("gh api reviews with event=APPROVE denied",
+      run("gh api repos/o/r/pulls/42/reviews -f event=APPROVE", "hold")[0], True)
+# Discriminating case: an EARLIER benign `gh` must not shadow a later review —
+# unsplit, the first `gh` is `gh pr view`, adjacency fails, the approve slips through.
+check("benign gh first, review second, still denied",
+      run(f"gh pr view 1 --json state && {APPROVE}", "hold")[0], True)
+# Discriminating case for per-segment splitting: a dismissal CHAINED with a fresh
+# approve — unsplit, the dismissal match skips the whole string, approve included.
+check("dismissal chained with an approve does NOT shield it", run(
+    f"{DISMISS} && gh api repos/o/r/pulls/42/reviews -f event=APPROVE", "hold")[0], True)
+
+print("7. escape hatch")
+check("env override allows", run(APPROVE, "hold",
+      env_extra={"SUTANDO_ALLOW_FORMAL_GH_REVIEWS": "1"})[0], False)
+
+print("8. the denial must be actionable, not a bare refusal")
+_, out, _ = run(APPROVE, "hold")
+for token in ("authority.json", "in-room", "findings-only", "SUTANDO_ALLOW_FORMAL_GH_REVIEWS"):
+    check(f"reason names {token}", token in out, True)
+
+print("9b. a DEPLOYED copy (outside the repo) still finds the state file")
+import shutil
+with tempfile.TemporaryDirectory() as td:
+    ws = os.path.join(td, "workspace")
+    os.makedirs(os.path.join(ws, "state"))
+    with open(os.path.join(ws, "state", "authority.json"), "w") as fh:
+        json.dump({"github_formal_review": "allow"}, fh)
+    depdir = os.path.join(ws, ".claude-sutando", "hooks")   # the real deploy layout
+    os.makedirs(depdir)
+    dep = os.path.join(depdir, "review-authority-guard.py")
+    shutil.copy(HOOK, dep)
+    env = dict(os.environ); env.pop("SUTANDO_WORKSPACE_FOR_HOOK", None)
+    env.pop("SUTANDO_ALLOW_FORMAL_GH_REVIEWS", None)
+    r = subprocess.run([sys.executable, dep], input=json.dumps(
+        {"tool_name": "Bash", "tool_input": {"command": APPROVE}}),
+        capture_output=True, text=True, env=env)
+    # 'allow' must reach the deployed copy: if it cannot find the file it reads
+    # 'hold' and denies — passing for the wrong reason is what this case catches.
+    check("deployed hook READS the state file (allow -> permitted)",
+          '"permissionDecision": "deny"' in r.stdout, False)
+
+print("9. the hook never wedges the core")
+check("exit code is 0 even when denying", run(APPROVE, "hold")[2], 0)
+check("malformed stdin fails OPEN", subprocess.run(
+    [sys.executable, HOOK], input="not json", capture_output=True, text=True).returncode, 0)
+
+if FAILURES:
+    print(f"\nFAIL — {len(FAILURES)} check(s):")
+    for f in FAILURES:
+        print("  -", f)
+    sys.exit(1)
+print("\nPASS — review-authority-guard tests")

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -26,7 +26,7 @@ def run(command, mode="__absent__", tool="Bash", env_extra=None):
             with open(os.path.join(td, "state", "authority.json"), "w") as fh:
                 fh.write(mode if mode.startswith("{") else json.dumps({"github_formal_review": mode}))
         env = dict(os.environ)
-        env["SUTANDO_WORKSPACE_FOR_HOOK"] = td
+        env["SUTANDO_HOOK_WORKSPACE"] = td
         env.pop("SUTANDO_ALLOW_FORMAL_GH_REVIEWS", None)
         env.update(env_extra or {})
         p = subprocess.run([sys.executable, HOOK], input=json.dumps(
@@ -54,10 +54,16 @@ check("approve denied", run(APPROVE, "hold")[0], True)
 check("request-changes denied", run(REQCH, "hold")[0], True)
 check("comment denied under hold", run(COMMENT, "hold")[0], True)
 
-print("2. MISSING state file behaves as hold — the restrictive reading is the default")
+print("2. MISSING state file behaves as findings-only — votes gated, --comment stays possible")
 check("approve denied with no state file", run(APPROVE)[0], True)
-check("unparseable state denied", run(APPROVE, "{not json")[0], True)
-check("unknown mode value denied", run(APPROVE, "yolo")[0], True)
+check("request-changes denied with no state file", run(REQCH)[0], True)
+check("comment ALLOWED with no state file", run(COMMENT)[0], False)
+
+print("2b. a PRESENT but unreadable/unknown state file is hold — a ruling exists and cannot be read")
+check("unparseable state denies approve", run(APPROVE, "{not json")[0], True)
+check("unparseable state denies comment", run(COMMENT, "{not json")[0], True)
+check("unknown mode value denies approve", run(APPROVE, "yolo")[0], True)
+check("unknown mode value denies comment", run(COMMENT, "yolo")[0], True)
 
 print("3. findings-only allows --comment but still gates the votes")
 check("approve denied", run(APPROVE, "findings-only")[0], True)
@@ -101,7 +107,8 @@ check("env override allows", run(APPROVE, "hold",
 
 print("8. the denial must be actionable, not a bare refusal")
 _, out, _ = run(APPROVE, "hold")
-for token in ("authority.json", "in-room", "findings-only", "SUTANDO_ALLOW_FORMAL_GH_REVIEWS"):
+for token in ("authority.json", "in-room", "SUTANDO_ALLOW_FORMAL_GH_REVIEWS", "--comment",
+              '{\\"github_formal_review\\": \\"findings-only\\"}'):
     check(f"reason names {token}", token in out, True)
 
 print("9b. a DEPLOYED copy (outside the repo) still finds the state file")
@@ -115,7 +122,7 @@ with tempfile.TemporaryDirectory() as td:
     os.makedirs(depdir)
     dep = os.path.join(depdir, "review-authority-guard.py")
     shutil.copy(HOOK, dep)
-    env = dict(os.environ); env.pop("SUTANDO_WORKSPACE_FOR_HOOK", None)
+    env = dict(os.environ); env.pop("SUTANDO_HOOK_WORKSPACE", None)
     env.pop("SUTANDO_ALLOW_FORMAL_GH_REVIEWS", None)
     r = subprocess.run([sys.executable, dep], input=json.dumps(
         {"tool_name": "Bash", "tool_input": {"command": APPROVE}}),

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -187,6 +187,10 @@ for _cmd, _want in (
     ("gh api repos/o/r/pulls/3/reviews --input - <<'JSON'\n{\"event\": \"APPROVE\", \"body\": \"x\"}\nJSON", "APPROVE"),
     ("python3 - <<'PY'\nprint('hello gh')\nPY", None),
     ("cat <<'EOF' > note.md\ngh is installed; review the pr later\nEOF", None),
+    # A heredoc owned by cat/tee is documentation, whatever it quotes (john-the-dev, #3756).
+    (f"cat > /tmp/d.md <<'DOC'\nTo approve, run {_R} 123 --approve and you are done.\nDOC", None),
+    (f"tee notes.md <<EOF\nI usually {_R} 5 --request-changes when the tests are red.\nEOF", None),
+    (f"cat > review.md <<'MD'\nVerified at abc: {_R} 7 --approve returns APPROVE, dismissal returns None.\nMD\ngh pr comment 7 --body-file review.md", None),
 ):
     check(f"heredoc: {_cmd.splitlines()[0]} …", classify(_cmd), _want)
 

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -179,6 +179,17 @@ for _cmd, _want in (
 ):
     check(f"api: {_cmd}", classify(_cmd), _want)
 
+print("13. heredoc indirection: program text on stdin is de-literalised and classified")
+for _cmd, _want in (
+    ("python3 - <<'PY'\nimport subprocess\nsubprocess.run(['gh','pr','review','3756','--approve','--body','ok'])\nPY", "APPROVE"),
+    ("python3 - <<PY\nimport subprocess\nsubprocess.run([\"gh\", \"pr\", \"review\", \"1\", \"--request-changes\", \"-b\", \"x\"])\nPY\necho done", "REQUEST_CHANGES"),
+    ("python3 - <<'PY'\nsubprocess.run(['gh','pr','review','1','--comment','-b','ok'])\nPY", "COMMENT"),
+    ("gh api repos/o/r/pulls/3/reviews --input - <<'JSON'\n{\"event\": \"APPROVE\", \"body\": \"x\"}\nJSON", "APPROVE"),
+    ("python3 - <<'PY'\nprint('hello gh')\nPY", None),
+    ("cat <<'EOF' > note.md\ngh is installed; review the pr later\nEOF", None),
+):
+    check(f"heredoc: {_cmd.splitlines()[0]} …", classify(_cmd), _want)
+
 if FAILURES:
     print(f"\nFAIL — {len(FAILURES)} check(s):")
     for f in FAILURES:

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -6,6 +6,7 @@ dismissals, plain comments and every non-review command pass through
 
 Run:  python3 tests/review-authority-guard.test.py
 """
+import importlib.util
 import json
 import os
 import subprocess
@@ -128,6 +129,24 @@ print("9. the hook never wedges the core")
 check("exit code is 0 even when denying", run(APPROVE, "hold")[2], 0)
 check("malformed stdin fails OPEN", subprocess.run(
     [sys.executable, HOOK], input="not json", capture_output=True, text=True).returncode, 0)
+
+_spec = importlib.util.spec_from_file_location("review_authority_guard", HOOK)
+_guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guard)
+classify = _guard.classify
+print("10. shell-wrapper indirection: the inner command is one shlex token and is re-classified")
+_R = "gh pr review"
+for _cmd, _want in (
+    (f'bash -c "{_R} 123 --approve"', "APPROVE"),
+    (f"bash -c '{_R} 123 --approve'", "APPROVE"),
+    (f'sh -c "{_R} 123 --request-changes -b x"', "REQUEST_CHANGES"),
+    (f'/bin/zsh -lc "cd repo && {_R} 123 -a"', "APPROVE"),
+    (f'eval "{_R} 123 --approve"', "APPROVE"),
+    (f'bash -c "{_R} 123 --comment -b ok"', "COMMENT"),
+    ('bash -c "gh pr view 123"', None),
+    ('bash -c "echo hello"', None),
+):
+    check(f"wrapper: {_cmd}", classify(_cmd), _want)
 
 if FAILURES:
     print(f"\nFAIL — {len(FAILURES)} check(s):")


### PR DESCRIPTION
## Why

On 2026-09-01 the agent declined to file formal GitHub reviews three times, then filed an APPROVE on the fourth ask after verifying the change carefully. That approval was the only *gating* approval on the PR, so half a merge gate was cleared by an agent whose owner had not answered whether it may vote. Careful verification is not authorization. A boundary held by remembering it on every request fails eventually; this one runs unconditionally as a `PreToolUse` hook.

## What

- `hooks/review-authority-guard.py` — denies `gh pr review --approve` / `--request-changes` (and `--comment` under `hold`), and `gh api .../pulls/N/reviews` carrying `APPROVE` / `REQUEST_CHANGES`. Mode comes from `<workspace>/state/authority.json` `{"github_formal_review": "hold" | "findings-only" | "allow"}`; a missing or unreadable file means `hold` (policy: the restrictive reading applies until the owner rules; the surface is narrow enough that defaulting closed cannot wedge the core). Never gated: review dismissals (a reduction of standing), `gh pr comment`, `--comment` under `findings-only`, non-Bash tools, every non-review command. Compound commands are split per segment, so an earlier benign `gh` cannot shadow a later review and a dismissal chained with a fresh approve does not shield it. Escape hatch `SUTANDO_ALLOW_FORMAL_GH_REVIEWS=1`; fail-open on hook exceptions (repo hook contract). The deployed copy locates the workspace by searching upward for `state/authority.json` (`SUTANDO_WORKSPACE_FOR_HOOK` pins it).
- `tests/review-authority-guard.test.py` — 30 checks, including the discriminating ones above and a deployed-copy case that fails if `allow` cannot reach a hook copied out of the repo.
- `hooks/README.md` — new section: mode file, what is and is not gated, per-node registration (not auto-registered; same manual `PreToolUse` block shape as `gmail-write-guard.py`).

Read first: `classify()` in the hook, then sections 5 and 6 of the test.

## Docs

`hooks/README.md` updated in this PR (the hook catalogue). No `docs/` catalog entry exists for hooks; N/A beyond that.

## Evidence

At the parent (`origin/main` = 563b9cd3f) no hook intercepts a formal review:

```
$ git ls-tree --name-only origin/main hooks/
hooks/README.md
hooks/activity-emitter.py
hooks/context-source-guard.py
hooks/gmail-write-guard.py
hooks/hitl-hook-driver.py
hooks/human-action-bridge.py
hooks/result-file-marker-guard.py
hooks/skill-usage-telemetry.py
hooks/skip-ask-user-question.py
```

At HEAD:

```
$ python3 tests/review-authority-guard.test.py
1. hold (the default while unanswered) denies every formal review
  ok   approve denied
  ok   request-changes denied
  ok   comment denied under hold
2. MISSING state file behaves as hold — the restrictive reading is the default
  ok   approve denied with no state file
  ok   unparseable state denied
  ok   unknown mode value denied
3. findings-only allows --comment but still gates the votes
  ok   approve denied
  ok   request-changes denied
  ok   comment ALLOWED
4. allow lets everything through
  ok   approve allowed
  ok   request-changes allowed
5. reductions and unrelated commands are never gated
  ok   dismissal allowed under hold
  ok   dismissal naming APPROVE in its message still allowed
  ok   plain pr comment allowed
  ok   pr view allowed
  ok   unrelated command allowed
  ok   non-Bash tool ignored
6. compound commands cannot smuggle a review past the split
  ok   && chain denied
  ok   semicolon chain denied
  ok   gh api reviews with event=APPROVE denied
  ok   benign gh first, review second, still denied
  ok   dismissal chained with an approve does NOT shield it
7. escape hatch
  ok   env override allows
8. the denial must be actionable, not a bare refusal
  ok   reason names authority.json
  ok   reason names in-room
  ok   reason names findings-only
  ok   reason names SUTANDO_ALLOW_FORMAL_GH_REVIEWS
9b. a DEPLOYED copy (outside the repo) still finds the state file
  ok   deployed hook READS the state file (allow -> permitted)
9. the hook never wedges the core
  ok   exit code is 0 even when denying
  ok   malformed stdin fails OPEN

PASS — review-authority-guard tests
```

```
$ git diff origin/main | RC_PROSE_CAP=2 RC_PROSE_EXTS=.py python3 scripts/review-checks-prose-cap.py
prose-cap: PASS (comment blocks within cap 2, exts .py)
```

Pre-push review-checks ran and did not block. Ruff pre-commit clean.

## Edge cases checked

Unparseable / unknown-value state file; dismissal whose message contains the word APPROVE; `gh pr view && gh pr review --approve`; dismissal `&&` approve; `gh api` review with `-f event=APPROVE`; malformed stdin; non-Bash tool.

## Risks / rollback

Not auto-registered — nothing changes for any install until a node registers it. Live path: none (no bridge/network/delivery). Rollback: remove the `PreToolUse` entry. Not verified: a live registered session exercising the hook (only the subprocess harness above).

## Known gaps

Registration is per-node by hand; wiring it into `build-core-settings.mjs` like `gmail-write-guard.py` is a follow-up once the owner has ruled on the default mode.

Signed: @qingyun-air.agent:ag2.space (air, Qingyun's agent)
