### PR TITLE
feat(scheduled-panel): publish the durable cron schedule as a room activity doc

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -51,6 +51,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`credential_resolver.py`** — Credential resolver — capability, not key (G8, desktop-parity plan).
 - **`cron-runner.py`** — OS-supervised cron runner — emits task files for due crons.json entries.
 - **`cron_entry_digest.py`** — Stable per-entry digests for `crons.json`, so config drift is DETECTABLE.
+- **`cron_eval.py`** — One 5-field cron evaluation contract for every scheduler and presentation surface (cron-runner, codex-scheduler, dashboard_schedules, scheduled-panel).
 - **`cron_task_id.py`** — Canonical naming contract for a cron job's task id and result filename.
 - **`dashboard.py`** — Sutando dashboard — current system status for the local agent.
 - **`dashboard_schedules.py`** — Cron parsing, schedule validation and atomic crons.json persistence.

--- a/skills/schedule-crons/scripts/codex-scheduler.py
+++ b/skills/schedule-crons/scripts/codex-scheduler.py
@@ -27,6 +27,7 @@ from task_archive import find_task_file  # noqa: E402
 from local_task_protocol import serialize_task_last  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 from sutando_config import resolve_core_runtime  # noqa: E402
+import cron_eval  # noqa: E402
 
 
 LABEL = "com.sutando.codex-schedules"
@@ -110,54 +111,11 @@ def scheduler_lock(workspace: Path) -> Iterator[None]:
 
 
 def _field_values(spec: str, minimum: int, maximum: int, *, sunday_7: bool = False) -> set[int]:
-    values: set[int] = set()
-    for token in spec.split(","):
-        token = token.strip()
-        if not token:
-            raise ValueError("empty cron field token")
-        base, slash, step_text = token.partition("/")
-        step = int(step_text) if slash else 1
-        if step <= 0:
-            raise ValueError("cron step must be positive")
-        if base == "*":
-            start, end = minimum, maximum
-        elif "-" in base:
-            left, right = base.split("-", 1)
-            start, end = int(left), int(right)
-        else:
-            start = end = int(base)
-        if start < minimum or end > maximum or start > end:
-            raise ValueError(f"cron value {base!r} outside {minimum}-{maximum}")
-        values.update(range(start, end + 1, step))
-    if sunday_7 and 7 in values:
-        values.remove(7)
-        values.add(0)
-    return values
+    return set(cron_eval.field_values(spec, minimum, maximum, sunday_7=sunday_7))
 
 
 def cron_matches(expression: str, local_dt: datetime) -> bool:
-    fields = expression.split()
-    if len(fields) != 5:
-        raise ValueError("cron expression must have five fields")
-    minute = _field_values(fields[0], 0, 59)
-    hour = _field_values(fields[1], 0, 23)
-    day = _field_values(fields[2], 1, 31)
-    month = _field_values(fields[3], 1, 12)
-    weekday = _field_values(fields[4], 0, 7, sunday_7=True)
-    cron_weekday = (local_dt.weekday() + 1) % 7
-    day_match = local_dt.day in day
-    weekday_match = cron_weekday in weekday
-    # Vixie cron treats restricted day-of-month and day-of-week fields as OR.
-    if fields[2] != "*" and fields[4] != "*":
-        calendar_match = day_match or weekday_match
-    else:
-        calendar_match = day_match and weekday_match
-    return (
-        local_dt.minute in minute
-        and local_dt.hour in hour
-        and local_dt.month in month
-        and calendar_match
-    )
+    return cron_eval.matches(expression, local_dt)
 
 
 def load_jobs(config_path: Path, *, include_main_loop: bool = False) -> list[dict[str, Any]]:

--- a/skills/scheduled-panel/SKILL.md
+++ b/skills/scheduled-panel/SKILL.md
@@ -27,8 +27,8 @@ python3 skills/agent-room-ops/room_ops.py doc get '!room:ag2.space' --folder act
 |---|---|
 | Schedule | the cron expression, humanised only when it has no calendar restriction |
 | Fires via | `dashboard_schedules.schedule_owner`: session, launchd, codex, dynamic-loop |
-| Last fired | the owning scheduler's own record: codex `state/schedules/codex-scheduler.json` `last_scheduled_slot`, launchd `state/cron-runner-state.json`, dynamic loop `.alive` mtime; session crons have no record and show `—` |
-| Next fire | `dashboard_schedules.next_run_for_job`, evaluated in the job's zone (codex: its `timezone`, default America/Los_Angeles; others: host-local), rendered in UTC |
+| Last fired | the owning scheduler's own FIRE record: codex `state/schedules/codex-scheduler.json` `last_scheduled_slot`; launchd `state/cron-runner-state.json` `__fired__[name]` (the per-name value there is a scan boundary that moves every tick, never a fire); dynamic loop the `.alive` payload's own `ts` (its mtime can be rewritten by sync). No record → `—`, never a guess |
+| Next fire | `dashboard_schedules.next_run_for_job`, walking real instants and judging each by its wall clock in the job's zone (codex: its `timezone`, default America/Los_Angeles; others: the host's IANA zone) — the predicate both schedulers apply, so a spring-forward minute is never shown and a fall-back minute is shown twice; rendered in UTC |
 
 Cron semantics come from `src/cron_eval.py`, the evaluator the launchd runner
 and the codex scheduler fire on, so the panel cannot disagree with them.
@@ -39,5 +39,14 @@ Add a launchd-owned shell entry to `hosts/<host>/crons.json`, for example:
 
 ```json
 {"name": "scheduled-panel-refresh", "cron": "7 */6 * * *", "launchd": true,
- "shell_command": "python3 skills/scheduled-panel/publish_schedule.py --publish --room '!room:ag2.space'"}
+ "shell_command": "\"$SUTANDO_PY\" skills/scheduled-panel/publish_schedule.py --publish --room '!room:ag2.space'"}
 ```
+
+`$SUTANDO_PY` is the interpreter the cron-runner itself runs on; it exports
+it into every `shell_command` child. Never write a bare `python3` here: the
+child's PATH is launchd's minimal one, where that name can resolve to the
+macOS developer-tools stub (`scripts/python-binary.sh` explains the dialog).
+
+If the schedule source cannot be resolved or read (config helper fails,
+`crons.json` missing or malformed) the script exits 2 without publishing, so
+the room keeps its last good table; a valid empty list publishes an empty one.

--- a/skills/scheduled-panel/SKILL.md
+++ b/skills/scheduled-panel/SKILL.md
@@ -1,0 +1,43 @@
+# scheduled-panel
+
+Publishes this host's durable schedule as the Room Context doc the AG2 Space
+"Scheduled" Activity tab reads (`folder=activity`, `name=SCHEDULE.md`).
+
+**Status: a manual utility.** Nothing in the repo invokes it on its own; the
+agent (or a cron entry the owner adds) runs it. It does not change any schedule.
+
+## Usage
+
+```bash
+python3 skills/scheduled-panel/publish_schedule.py                 # print the markdown
+python3 skills/scheduled-panel/publish_schedule.py --json          # rows as JSON
+python3 skills/scheduled-panel/publish_schedule.py --publish --room '!room:ag2.space'
+```
+
+`--publish` needs the gateway credentials `skills/agent-room-ops` already uses
+(`REMOTE_TASK_TOKEN`). Verify a publish by reading it back:
+
+```bash
+python3 skills/agent-room-ops/room_ops.py doc get '!room:ag2.space' --folder activity --name SCHEDULE.md
+```
+
+## What each column means
+
+| Column | Source |
+|---|---|
+| Schedule | the cron expression, humanised only when it has no calendar restriction |
+| Fires via | `dashboard_schedules.schedule_owner`: session, launchd, codex, dynamic-loop |
+| Last fired | the owning scheduler's own record: codex `state/schedules/codex-scheduler.json` `last_scheduled_slot`, launchd `state/cron-runner-state.json`, dynamic loop `.alive` mtime; session crons have no record and show `—` |
+| Next fire | `dashboard_schedules.next_run_for_job`, evaluated in the job's zone (codex: its `timezone`, default America/Los_Angeles; others: host-local), rendered in UTC |
+
+Cron semantics come from `src/cron_eval.py`, the evaluator the launchd runner
+and the codex scheduler fire on, so the panel cannot disagree with them.
+
+## To publish on a schedule
+
+Add a launchd-owned shell entry to `hosts/<host>/crons.json`, for example:
+
+```json
+{"name": "scheduled-panel-refresh", "cron": "7 */6 * * *", "launchd": true,
+ "shell_command": "python3 skills/scheduled-panel/publish_schedule.py --publish --room '!room:ag2.space'"}
+```

--- a/skills/scheduled-panel/publish_schedule.py
+++ b/skills/scheduled-panel/publish_schedule.py
@@ -52,15 +52,23 @@ def _next_fire(expr: str, now: datetime.datetime) -> str:
         return "—"
     try:
         mins, hrs = _field_set(p[0], 0, 59), _field_set(p[1], 0, 23)
-        dows = _field_set(p[3 + 1], 0, 6)  # cron dow 0-6 (Sun=0); mon field p[3] ignored (always * here)
+        doms, mons = _field_set(p[2], 1, 31), _field_set(p[3], 1, 12)
+        dows = _field_set(p[4], 0, 6)  # cron dow 0-6 (Sun=0)
     except Exception:
         return "—"
+    # Vixie cron: dom and dow are OR-ed when BOTH are restricted, AND-ed otherwise.
+    both = p[2] != "*" and p[4] != "*"
     t = now.replace(second=0, microsecond=0) + datetime.timedelta(minutes=1)
-    for _ in range(8 * 24 * 60):  # minute scan, 8-day bound
+    end = t + datetime.timedelta(days=400)  # bound: an annual job is inside, a never-firing one is not
+    while t < end:
         # python weekday(): Mon=0..Sun=6 -> cron dow Sun=0..Sat=6
-        if t.minute in mins and t.hour in hrs and ((t.weekday() + 1) % 7) in dows:
-            return t.strftime("%Y-%m-%dT%H:%MZ")
-        t += datetime.timedelta(minutes=1)
+        dom_ok, dow_ok = t.day in doms, ((t.weekday() + 1) % 7) in dows
+        if t.month in mons and ((dom_ok or dow_ok) if both else (dom_ok and dow_ok)):
+            if t.minute in mins and t.hour in hrs:
+                return t.strftime("%Y-%m-%dT%H:%MZ")
+            t += datetime.timedelta(minutes=1)
+        else:
+            t = (t + datetime.timedelta(days=1)).replace(hour=0, minute=0)
     return "—"
 
 def _iso(ts) -> str:
@@ -77,7 +85,8 @@ def _last_fired(job: dict, ws: str, host: str) -> str:
     state = os.path.join(ws, "state")
     def _read(path, key):
         try:
-            d = json.load(open(path)); return d.get(key)
+            with open(path) as fh:
+                return json.load(fh).get(key)
         except Exception:
             return None
     if name == "main-loop":

--- a/skills/scheduled-panel/publish_schedule.py
+++ b/skills/scheduled-panel/publish_schedule.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-"""Publish the agent's durable schedule (crons.json + last-run state) as a
-Room Context doc the AG2 Space "Scheduled" Activity tab reads. Owner-greenlit
-2026-08-21: source is durable crons.json, cross-session stable."""
+"""Publish the agent's durable schedule (crons.json + each scheduler's own
+last-fire record) as the Room Context doc the AG2 Space "Scheduled" Activity
+tab reads. Schedule evaluation, file shape and fire records come from
+src/dashboard_schedules (the schedule domain owner); this file only renders
+and publishes. Owner-greenlit 2026-08-21: source is durable crons.json."""
 from __future__ import annotations
 import datetime
 import importlib.util
@@ -9,129 +11,83 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO, "src"))
+import dashboard_schedules as ds  # noqa: E402
+
+# Wide enough that a leap-day job (29 Feb) always has a next fire inside it.
+PANEL_HORIZON_DAYS = 366 * 4 + 1
+
 
 def _cfg(arg: str) -> str:
     return subprocess.run(["bash", os.path.join(REPO, "scripts/sutando-config.sh"), arg],
                           capture_output=True, text=True).stdout.strip()
 
-def _field_set(field: str, lo: int, hi: int) -> set[int]:
-    # One cron field -> the set of matching ints. Handles *, */n, a,b, x-y, x-y/n.
-    vals: set[int] = set()
-    for part in field.split(","):
-        step = 1
-        if "/" in part:
-            part, s = part.split("/", 1); step = int(s)
-        if part == "*":
-            a, b = lo, hi
-        elif "-" in part:
-            a, b = (int(x) for x in part.split("-", 1))
-        else:
-            a = b = int(part)
-        vals.update(range(a, b + 1, step))
-    return vals
 
 def _human_cron(expr: str) -> str:
+    # Only an expression with no calendar restriction gets a short form; any
+    # restricted dom/month/dow field is shown verbatim so nothing is hidden.
     p = expr.split()
     if len(p) != 5:
         return expr
     m, h, dom, mon, dow = p
-    if m.startswith("*/") and h == "*":
+    unrestricted = dom == "*" and mon == "*" and dow == "*"
+    if m.startswith("*/") and h == "*" and unrestricted:
         return f"every {m[2:]} min"
-    if ("," in m or "-" in m) and h == "*":
+    if ("," in m or "-" in m) and h == "*" and unrestricted:
         return f"~every few min ({m})"
     if m.isdigit() and h.isdigit() and dom == "*" and mon == "*":
         return (f"daily {int(h):02d}:{int(m):02d}" if dow == "*"
                 else f"{dow} {int(h):02d}:{int(m):02d}")
     return expr
 
-def _next_fire(expr: str, now: datetime.datetime) -> str:
-    p = expr.split()
-    if len(p) != 5:
-        return "—"
-    try:
-        mins, hrs = _field_set(p[0], 0, 59), _field_set(p[1], 0, 23)
-        doms, mons = _field_set(p[2], 1, 31), _field_set(p[3], 1, 12)
-        dows = _field_set(p[4], 0, 6)  # cron dow 0-6 (Sun=0)
-    except Exception:
-        return "—"
-    # Vixie cron: dom and dow are OR-ed when BOTH are restricted, AND-ed otherwise.
-    both = p[2] != "*" and p[4] != "*"
-    t = now.replace(second=0, microsecond=0) + datetime.timedelta(minutes=1)
-    end = t + datetime.timedelta(days=400)  # bound: an annual job is inside, a never-firing one is not
-    while t < end:
-        # python weekday(): Mon=0..Sun=6 -> cron dow Sun=0..Sat=6
-        dom_ok, dow_ok = t.day in doms, ((t.weekday() + 1) % 7) in dows
-        if t.month in mons and ((dom_ok or dow_ok) if both else (dom_ok and dow_ok)):
-            if t.minute in mins and t.hour in hrs:
-                return t.strftime("%Y-%m-%dT%H:%MZ")
-            t += datetime.timedelta(minutes=1)
-        else:
-            t = (t + datetime.timedelta(days=1)).replace(hour=0, minute=0)
-    return "—"
 
-def _iso(ts) -> str:
-    try:
-        if isinstance(ts, (int, float)):
-            return datetime.datetime.fromtimestamp(ts, datetime.timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
-        return str(ts)[:16].replace(" ", "T")
-    except Exception:
+def _fmt(dt) -> str:
+    if not isinstance(dt, datetime.datetime):
         return "—"
+    if dt.tzinfo is None:
+        dt = dt.astimezone()
+    return dt.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
 
-def _last_fired(job: dict, ws: str, host: str) -> str:
-    # Best-effort per-cron last-run signal; heterogeneous by design.
-    name = job.get("name", "")
-    state = os.path.join(ws, "state")
-    def _read(path, key):
-        try:
-            with open(path) as fh:
-                return json.load(fh).get(key)
-        except Exception:
-            return None
-    if name == "main-loop":
-        v = _read(os.path.join(state, "core-status.json"), "ts")
-        if v:
-            return _iso(v)
-    # Crons that stamp their own state file expose last_pass (e.g. my-pr-shepherd).
-    v = _read(os.path.join(state, f"{name}.json"), "last_pass")
-    if v:
-        return _iso(v)
-    alive = os.path.join(state, f"dynamic-loop-{name}.alive")
-    if os.path.exists(alive):
-        return _iso(os.path.getmtime(alive))
-    return "—"
 
-def build_rows() -> list[dict]:
+def build_rows(now: datetime.datetime | None = None) -> list[dict]:
     ws, host = _cfg("workspace"), _cfg("host-label")
-    cf = os.path.join(ws, "hosts", host, "crons.json")
-    raw = json.load(open(cf))
-    jobs = raw if isinstance(raw, list) else raw.get("jobs", raw.get("crons", []))
-    now = datetime.datetime.now(datetime.timezone.utc)
+    jobs = ds.read_crons(Path(ws) / "hosts" / host / "crons.json")  # canonical shape only
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    state = Path(ws) / "state"
     rows = []
     for j in jobs:
-        expr = j.get("cron", "")
+        if not isinstance(j, dict):
+            continue
+        expr = j.get("cron") or ""
         dyn = j.get("loop") == "dynamic"
         rows.append({
             "name": j.get("name", "?"),
             "schedule": "adaptive (self-paced)" if dyn else _human_cron(expr),
-            "next_fire": "—" if dyn else _next_fire(expr, now),
-            "last_fired": _last_fired(j, ws, host),
-            "does": j.get("prompt_skill") or (j.get("prompt", "")[:48]) or "—",
+            "owner": ds.schedule_owner(j),
+            "next_fire": _fmt(ds.next_run_for_job(j, now, PANEL_HORIZON_DAYS)),
+            "last_fired": _fmt(ds.last_fired(j, state)),
+            "does": j.get("prompt_skill") or (j.get("prompt") or "")[:48] or "—",
         })
     return rows
 
+
 def render_md(rows: list[dict]) -> str:
     now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
-    out = ["# Scheduled jobs", f"*updated {now} — source: durable crons.json*", "",
-           "| Job | Schedule | Last fired | Next fire | Does |",
-           "|---|---|---|---|---|"]
+    out = ["# Scheduled jobs", f"*updated {now} — source: durable crons.json; times UTC*", "",
+           "| Job | Schedule | Fires via | Last fired | Next fire | Does |",
+           "|---|---|---|---|---|---|"]
     for r in rows:
-        out.append(f"| {r['name']} | {r['schedule']} | {r['last_fired']} | {r['next_fire']} | {r['does']} |")
+        out.append(f"| {r['name']} | {r['schedule']} | {r['owner']} | {r['last_fired']} "
+                   f"| {r['next_fire']} | {r['does']} |")
     return "\n".join(out) + "\n"
+
 
 SCHED_FOLDER = "activity"   # client "Scheduled" tab reads folder=activity name=SCHEDULE.md
 SCHED_NAME = "SCHEDULE.md"
+
 
 def publish(room: str, content: str) -> dict:
     # Reuse the gateway room-ops doc client; room is caller-supplied (no id baked in).
@@ -143,8 +99,10 @@ def publish(room: str, content: str) -> dict:
     return mod.doc_put(room, content, folder=SCHED_FOLDER, name=SCHED_NAME,
                        message="scheduled-jobs refresh")
 
+
 def _arg(flag: str):
     return sys.argv[sys.argv.index(flag) + 1] if flag in sys.argv else None
+
 
 if __name__ == "__main__":
     rows = build_rows()

--- a/skills/scheduled-panel/publish_schedule.py
+++ b/skills/scheduled-panel/publish_schedule.py
@@ -21,9 +21,32 @@ import dashboard_schedules as ds  # noqa: E402
 PANEL_HORIZON_DAYS = 366 * 4 + 1
 
 
+class SourceUnavailable(RuntimeError):
+    """The schedule source could not be resolved or read. Distinct from an
+    empty schedule: nothing may be published on it."""
+
+
 def _cfg(arg: str) -> str:
-    return subprocess.run(["bash", os.path.join(REPO, "scripts/sutando-config.sh"), arg],
-                          capture_output=True, text=True).stdout.strip()
+    proc = subprocess.run(["bash", os.path.join(REPO, "scripts/sutando-config.sh"), arg],
+                          capture_output=True, text=True)
+    value = proc.stdout.strip()
+    if proc.returncode != 0 or not value:
+        raise SourceUnavailable(
+            f"sutando-config.sh {arg}: rc={proc.returncode} {proc.stderr.strip()[:200]}")
+    return value
+
+
+def read_crons_strict(path: Path) -> list:
+    """The job list, or SourceUnavailable when the file is missing, unreadable
+    or not a JSON list. A valid empty list is an empty schedule and is returned."""
+    p = Path(path)
+    try:
+        jobs = json.loads(p.read_text())
+    except (OSError, ValueError) as exc:
+        raise SourceUnavailable(f"{p}: {exc}") from exc
+    if not isinstance(jobs, list):
+        raise SourceUnavailable(f"{p}: expected a JSON list, got {type(jobs).__name__}")
+    return jobs
 
 
 def _human_cron(expr: str) -> str:
@@ -54,7 +77,7 @@ def _fmt(dt) -> str:
 
 def build_rows(now: datetime.datetime | None = None) -> list[dict]:
     ws, host = _cfg("workspace"), _cfg("host-label")
-    jobs = ds.read_crons(Path(ws) / "hosts" / host / "crons.json")  # canonical shape only
+    jobs = read_crons_strict(Path(ws) / "hosts" / host / "crons.json")  # canonical shape only
     now = now or datetime.datetime.now(datetime.timezone.utc)
     state = Path(ws) / "state"
     rows = []
@@ -104,14 +127,28 @@ def _arg(flag: str):
     return sys.argv[sys.argv.index(flag) + 1] if flag in sys.argv else None
 
 
-if __name__ == "__main__":
-    rows = build_rows()
-    if "--json" in sys.argv:
-        print(json.dumps(rows, indent=2)); sys.exit(0)
+def main(argv: list[str]) -> int:
+    try:
+        rows = build_rows()
+    except SourceUnavailable as exc:
+        # Unknown is not empty: the room doc keeps its last good content.
+        print(f"refusing to publish: schedule source unavailable ({exc})", file=sys.stderr)
+        return 2
+    if "--json" in argv:
+        print(json.dumps(rows, indent=2))
+        return 0
     md = render_md(rows)
-    room = _arg("--room")
-    if "--publish" in sys.argv and room:
+    room = argv[argv.index("--room") + 1] if "--room" in argv else None
+    if "--publish" in argv and room:
         r = publish(room, md)
-        print("published" if r.get("ok") else f"FAILED: {r.get('reason')}")
-    else:
-        print(md)
+        if r.get("ok"):
+            print("published")
+            return 0
+        print(f"FAILED: {r.get('reason')}")
+        return 1
+    print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/scheduled-panel/publish_schedule.py
+++ b/skills/scheduled-panel/publish_schedule.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Publish the agent's durable schedule (crons.json + last-run state) as a
+Room Context doc the AG2 Space "Scheduled" Activity tab reads. Owner-greenlit
+2026-08-21: source is durable crons.json, cross-session stable."""
+from __future__ import annotations
+import datetime
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+def _cfg(arg: str) -> str:
+    return subprocess.run(["bash", os.path.join(REPO, "scripts/sutando-config.sh"), arg],
+                          capture_output=True, text=True).stdout.strip()
+
+def _field_set(field: str, lo: int, hi: int) -> set[int]:
+    # One cron field -> the set of matching ints. Handles *, */n, a,b, x-y, x-y/n.
+    vals: set[int] = set()
+    for part in field.split(","):
+        step = 1
+        if "/" in part:
+            part, s = part.split("/", 1); step = int(s)
+        if part == "*":
+            a, b = lo, hi
+        elif "-" in part:
+            a, b = (int(x) for x in part.split("-", 1))
+        else:
+            a = b = int(part)
+        vals.update(range(a, b + 1, step))
+    return vals
+
+def _human_cron(expr: str) -> str:
+    p = expr.split()
+    if len(p) != 5:
+        return expr
+    m, h, dom, mon, dow = p
+    if m.startswith("*/") and h == "*":
+        return f"every {m[2:]} min"
+    if ("," in m or "-" in m) and h == "*":
+        return f"~every few min ({m})"
+    if m.isdigit() and h.isdigit() and dom == "*" and mon == "*":
+        return (f"daily {int(h):02d}:{int(m):02d}" if dow == "*"
+                else f"{dow} {int(h):02d}:{int(m):02d}")
+    return expr
+
+def _next_fire(expr: str, now: datetime.datetime) -> str:
+    p = expr.split()
+    if len(p) != 5:
+        return "—"
+    try:
+        mins, hrs = _field_set(p[0], 0, 59), _field_set(p[1], 0, 23)
+        dows = _field_set(p[3 + 1], 0, 6)  # cron dow 0-6 (Sun=0); mon field p[3] ignored (always * here)
+    except Exception:
+        return "—"
+    t = now.replace(second=0, microsecond=0) + datetime.timedelta(minutes=1)
+    for _ in range(8 * 24 * 60):  # minute scan, 8-day bound
+        # python weekday(): Mon=0..Sun=6 -> cron dow Sun=0..Sat=6
+        if t.minute in mins and t.hour in hrs and ((t.weekday() + 1) % 7) in dows:
+            return t.strftime("%Y-%m-%dT%H:%MZ")
+        t += datetime.timedelta(minutes=1)
+    return "—"
+
+def _iso(ts) -> str:
+    try:
+        if isinstance(ts, (int, float)):
+            return datetime.datetime.fromtimestamp(ts, datetime.timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+        return str(ts)[:16].replace(" ", "T")
+    except Exception:
+        return "—"
+
+def _last_fired(job: dict, ws: str, host: str) -> str:
+    # Best-effort per-cron last-run signal; heterogeneous by design.
+    name = job.get("name", "")
+    state = os.path.join(ws, "state")
+    def _read(path, key):
+        try:
+            d = json.load(open(path)); return d.get(key)
+        except Exception:
+            return None
+    if name == "main-loop":
+        v = _read(os.path.join(state, "core-status.json"), "ts")
+        if v:
+            return _iso(v)
+    # Crons that stamp their own state file expose last_pass (e.g. my-pr-shepherd).
+    v = _read(os.path.join(state, f"{name}.json"), "last_pass")
+    if v:
+        return _iso(v)
+    alive = os.path.join(state, f"dynamic-loop-{name}.alive")
+    if os.path.exists(alive):
+        return _iso(os.path.getmtime(alive))
+    return "—"
+
+def build_rows() -> list[dict]:
+    ws, host = _cfg("workspace"), _cfg("host-label")
+    cf = os.path.join(ws, "hosts", host, "crons.json")
+    raw = json.load(open(cf))
+    jobs = raw if isinstance(raw, list) else raw.get("jobs", raw.get("crons", []))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    rows = []
+    for j in jobs:
+        expr = j.get("cron", "")
+        dyn = j.get("loop") == "dynamic"
+        rows.append({
+            "name": j.get("name", "?"),
+            "schedule": "adaptive (self-paced)" if dyn else _human_cron(expr),
+            "next_fire": "—" if dyn else _next_fire(expr, now),
+            "last_fired": _last_fired(j, ws, host),
+            "does": j.get("prompt_skill") or (j.get("prompt", "")[:48]) or "—",
+        })
+    return rows
+
+def render_md(rows: list[dict]) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    out = ["# Scheduled jobs", f"*updated {now} — source: durable crons.json*", "",
+           "| Job | Schedule | Last fired | Next fire | Does |",
+           "|---|---|---|---|---|"]
+    for r in rows:
+        out.append(f"| {r['name']} | {r['schedule']} | {r['last_fired']} | {r['next_fire']} | {r['does']} |")
+    return "\n".join(out) + "\n"
+
+SCHED_FOLDER = "activity"   # client "Scheduled" tab reads folder=activity name=SCHEDULE.md
+SCHED_NAME = "SCHEDULE.md"
+
+def publish(room: str, content: str) -> dict:
+    # Reuse the gateway room-ops doc client; room is caller-supplied (no id baked in).
+    ops = os.path.join(REPO, "skills/agent-room-ops")
+    if ops not in sys.path:
+        sys.path.insert(0, ops)   # doc.py does a sibling-relative `from _gateway import ...`
+    spec = importlib.util.spec_from_file_location("_ops_doc", os.path.join(ops, "doc.py"))
+    mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+    return mod.doc_put(room, content, folder=SCHED_FOLDER, name=SCHED_NAME,
+                       message="scheduled-jobs refresh")
+
+def _arg(flag: str):
+    return sys.argv[sys.argv.index(flag) + 1] if flag in sys.argv else None
+
+if __name__ == "__main__":
+    rows = build_rows()
+    if "--json" in sys.argv:
+        print(json.dumps(rows, indent=2)); sys.exit(0)
+    md = render_md(rows)
+    room = _arg("--room")
+    if "--publish" in sys.argv and room:
+        r = publish(room, md)
+        print("published" if r.get("ok") else f"FAILED: {r.get('reason')}")
+    else:
+        print(md)

--- a/src/cron-runner.py
+++ b/src/cron-runner.py
@@ -60,6 +60,7 @@ sys.path.insert(0, str(SRC_DIR))
 # last: confine_user_content() neutralizes forged fields even in a multi-line body.
 from task_body_guard import confine_user_content  # noqa: E402
 import cron_task_id  # noqa: E402
+import cron_eval  # noqa: E402
 
 try:
     from workspace_default import resolve_workspace  # type: ignore
@@ -113,33 +114,13 @@ DATE_LOOKAHEAD_DAYS = 2
 CORE_ALIVE_MAX_AGE_SECONDS = 90
 
 
-# --- minimal 5-field cron matcher (no external deps) ------------------------
+# --- 5-field cron matcher: thin bindings over the shared contract -----------
 @functools.lru_cache(maxsize=512)
 def _parse_field(field: str, lo: int, hi: int) -> frozenset[int]:
-    """Expand one cron field into the set of matching integers.
-
-    Supports ``*``, ``*/N``, ``A``, ``A,B``, ``A-B``, and ``A-B/N`` — the full
-    grammar used by Sutando's crons.json (e.g. ``*/5``, ``*/3`` day-of-month,
-    ``1-5`` weekdays).
-    """
-    result: set[int] = set()
-    for part in field.split(","):
-        step = 1
-        if "/" in part:
-            part, step_s = part.split("/", 1)
-            step = int(step_s)
-        if part == "*":
-            start, end = lo, hi
-        elif "-" in part:
-            start_s, end_s = part.split("-", 1)
-            start, end = int(start_s), int(end_s)
-        else:
-            start = end = int(part)
-        for v in range(start, end + 1, step):
-            if lo <= v <= hi:
-                result.add(v)
+    """Expand one cron field via cron_eval; out-of-range values are dropped
+    (this runner's historical contract), syntax errors raise ValueError."""
     # Frozen: the lru_cache hands every caller the SAME object.
-    return frozenset(result)
+    return cron_eval.field_values(field, lo, hi, clamp=True)
 
 
 def cron_matches(expr: str, t: time.struct_time) -> bool:
@@ -156,30 +137,14 @@ def cron_matches(expr: str, t: time.struct_time) -> bool:
 
 
 def _day_matches(dom: str, month: str, dow: str, t: time.struct_time) -> bool:
-    """True if the date part of ``t`` satisfies the dom/month/dow fields.
-
-    Split out so the period scan can reject a whole day with one test instead
-    of re-deriving DOM/DOW semantics — two copies of this would drift.
-    """
-    if t.tm_mon not in _parse_field(month, 1, 12):
-        return False
-    # Standard cron DOM/DOW semantics: when both are restricted (not '*'), a
-    # match on EITHER fires. tm_wday is Mon=0..Sun=6; cron uses Sun=0..Sat=6.
-    cron_dow = (t.tm_wday + 1) % 7
-    dom_restricted = dom != "*"
-    dow_restricted = dow != "*"
-    dom_ok = t.tm_mday in _parse_field(dom, 1, 31)
-    # DOW accepts 7 as an alias for Sunday (0). Expand with 7 permitted, then
-    # fold 7→0 at the SET level. Substituting 7→0 on the raw field string would
-    # corrupt ranges: "5-7" → "5-0" (empty set — never fires) and "0-7" → "0-0"
-    # (Sundays only) — the exact silent-miss class this runner exists to kill.
-    dow_set = _parse_field(dow, 0, 7)
-    if 7 in dow_set:
-        dow_set = (dow_set - {7}) | {0}
-    dow_ok = cron_dow in dow_set
-    if dom_restricted and dow_restricted:
-        return dom_ok or dow_ok
-    return dom_ok and dow_ok
+    """Date part of ``t`` against dom/month/dow — Vixie OR/AND and the Sunday=7
+    fold both live in cron_eval so no second copy can drift."""
+    spec = cron_eval.CronSpec(
+        minutes=frozenset(), hours=frozenset(),
+        doms=_parse_field(dom, 1, 31), months=_parse_field(month, 1, 12),
+        dows=cron_eval.fold_sunday(_parse_field(dow, 0, 7)),
+        dom_restricted=dom != "*", dow_restricted=dow != "*")
+    return spec.date_matches(t.tm_year, t.tm_mon, t.tm_mday)
 
 
 def _day_offsets(y: int, mo: int, d: int) -> "tuple[int, ...]":

--- a/src/cron-runner.py
+++ b/src/cron-runner.py
@@ -61,6 +61,7 @@ sys.path.insert(0, str(SRC_DIR))
 from task_body_guard import confine_user_content  # noqa: E402
 import cron_task_id  # noqa: E402
 import cron_eval  # noqa: E402
+from dashboard_schedules import LAUNCHD_FIRE_RECORD_KEY  # noqa: E402
 
 try:
     from workspace_default import resolve_workspace  # type: ignore
@@ -459,6 +460,9 @@ def _run_shell_command(name: str, command: str, timeout_s: int = SHELL_COMMAND_T
     try:
         # start_new_session gives the shell its own process group, which is what
         # makes killing the whole tree possible on timeout.
+        # The child's PATH is launchd's minimal one, so a bare `python3` can
+        # resolve to the CLT stub; hand it this runner's validated interpreter.
+        env = {**os.environ, "SUTANDO_PY": sys.executable} if sys.executable else None
         process = subprocess.Popen(
             command,
             shell=True,
@@ -467,6 +471,7 @@ def _run_shell_command(name: str, command: str, timeout_s: int = SHELL_COMMAND_T
             stderr=subprocess.PIPE,
             text=True,
             start_new_session=True,
+            env=env,
         )
         try:
             stdout, stderr = process.communicate(timeout=timeout_s)
@@ -588,6 +593,15 @@ def _emit_cron_telemetry() -> None:
         pass
 
 
+def _record_fire(state: dict, name: str, slot_epoch: int) -> None:
+    """The fire record is separate from the per-name scan boundary, which
+    advances on every tick whether or not anything ran."""
+    fired = state.get(LAUNCHD_FIRE_RECORD_KEY)
+    if not isinstance(fired, dict):
+        fired = state[LAUNCHD_FIRE_RECORD_KEY] = {}
+    fired[name] = int(slot_epoch)
+
+
 def run(now_epoch: Optional[int] = None) -> list:
     """One tick. Returns the list of cron names emitted this tick."""
     now_epoch = int(now_epoch if now_epoch is not None else time.time())
@@ -606,7 +620,7 @@ def run(now_epoch: Optional[int] = None) -> list:
                 continue  # session-owned or not reliability-critical — skip
             name = entry.get("name")
             expr = entry.get("cron")
-            if not name or not expr:
+            if not name or not expr or name == LAUNCHD_FIRE_RECORD_KEY:
                 continue
             has_shell_command = "shell_command" in entry
             shell_command = entry.get("shell_command")
@@ -635,6 +649,7 @@ def run(now_epoch: Optional[int] = None) -> list:
                     _run_shell_command(
                         name, shell_command, _shell_timeout_for(entry))
                     emitted.append(name)
+                    _record_fire(state, name, due_epoch)
                 elif not core_alive:
                     # Preserve the previous boundary so a short outage can
                     # recover this slot after the heartbeat returns.
@@ -645,6 +660,7 @@ def run(now_epoch: Optional[int] = None) -> list:
                     if lateness <= budget:
                         emit_task(name, entry)
                         emitted.append(name)
+                        _record_fire(state, name, due_epoch)
                     else:
                         # The drop is the only record a slot was skipped; undated,
                         # it cannot be tied to a sleep window or counted per day.

--- a/src/cron_eval.py
+++ b/src/cron_eval.py
@@ -10,7 +10,7 @@ restricted, AND-ed otherwise (Vixie cron). Malformed fields raise ValueError.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # (lo, hi) per field: minute, hour, day-of-month, month, day-of-week (7 = Sunday).
 FIELD_BOUNDS = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
@@ -108,17 +108,40 @@ def matches(expr: str, dt: datetime) -> bool:
 
 
 def next_match(expr: str, after: datetime, horizon_days: int = 8):
-    """First wall-clock minute strictly after ``after`` that fires, or None
-    inside the horizon. Whole days that cannot match are skipped, so a
-    multi-year horizon (a leap-day job) costs days, not minutes."""
+    """First minute strictly after ``after`` that fires, or None inside the
+    horizon. Whole days that cannot match are skipped, so a multi-year horizon
+    (a leap-day job) costs days, not minutes.
+
+    A naive ``after`` is walked as wall-clock minutes. An aware one is walked
+    as real instants, each judged by its wall clock in ``after``'s zone — the
+    predicate both schedulers apply to their minute slots — so a spring-forward
+    minute that never exists is never returned and a fall-back minute that
+    exists twice is visited twice.
+    """
     spec = parse(expr)
-    t = after.replace(second=0, microsecond=0) + timedelta(minutes=1)
-    end = after + timedelta(days=horizon_days)
+    tz = after.tzinfo
+    if tz is None:
+        t = after.replace(second=0, microsecond=0) + timedelta(minutes=1)
+        end = after + timedelta(days=horizon_days)
+        while t <= end:
+            if not spec.date_matches(t.year, t.month, t.day):
+                t = (t + timedelta(days=1)).replace(hour=0, minute=0)
+                continue
+            if t.minute in spec.minutes and t.hour in spec.hours:
+                return t
+            t += timedelta(minutes=1)
+        return None
+    utc = timezone.utc
+    t = after.astimezone(utc).replace(second=0, microsecond=0) + timedelta(minutes=1)
+    end = after.astimezone(utc) + timedelta(days=horizon_days)
     while t <= end:
-        if not spec.date_matches(t.year, t.month, t.day):
-            t = (t + timedelta(days=1)).replace(hour=0, minute=0)
+        local = t.astimezone(tz)
+        if not spec.date_matches(local.year, local.month, local.day):
+            midnight = (local + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+            jump = midnight.astimezone(utc)
+            t = jump if jump > t else t + timedelta(minutes=1)
             continue
-        if t.minute in spec.minutes and t.hour in spec.hours:
-            return t
+        if local.minute in spec.minutes and local.hour in spec.hours:
+            return local
         t += timedelta(minutes=1)
     return None

--- a/src/cron_eval.py
+++ b/src/cron_eval.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""One 5-field cron evaluation contract for every scheduler and presentation
+surface (cron-runner, codex-scheduler, dashboard_schedules, scheduled-panel).
+
+Grammar per field: ``*``, ``*/N``, ``A``, ``A,B``, ``A-B``, ``A-B/N``. Day-of-
+week accepts 7 as Sunday (folded to 0 at the SET level, so ``5-7`` and ``0-7``
+keep their meaning). Day-of-month and day-of-week are OR-ed when both are
+restricted, AND-ed otherwise (Vixie cron). Malformed fields raise ValueError.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+# (lo, hi) per field: minute, hour, day-of-month, month, day-of-week (7 = Sunday).
+FIELD_BOUNDS = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
+
+
+def field_values(spec: str, lo: int, hi: int, *, sunday_7: bool = False,
+                 clamp: bool = False) -> frozenset[int]:
+    """Expand one field to the set of matching ints.
+
+    clamp=True drops out-of-range values and empties an inverted range instead
+    of raising (the launchd runner's historical contract); syntax errors raise.
+    """
+    values: set[int] = set()
+    for token in spec.split(","):
+        token = token.strip()
+        if not token:
+            raise ValueError("empty cron field token")
+        base, slash, step_text = token.partition("/")
+        try:
+            step = int(step_text) if slash else 1
+        except ValueError as exc:
+            raise ValueError(f"cron step {step_text!r} is not an integer") from exc
+        if step <= 0:
+            raise ValueError("cron step must be positive")
+        try:
+            if base == "*":
+                start, end = lo, hi
+            elif "-" in base:
+                left, right = base.split("-", 1)
+                start, end = int(left), int(right)
+            else:
+                start = end = int(base)
+        except ValueError as exc:
+            raise ValueError(f"cron field {base!r} is not numeric") from exc
+        if not clamp and start > end:
+            raise ValueError(f"cron range {base!r} is inverted")
+        if not clamp and (start < lo or end > hi):
+            raise ValueError(f"cron value {base!r} outside {lo}-{hi}")
+        values.update(v for v in range(start, end + 1, step) if lo <= v <= hi)
+    return fold_sunday(values) if sunday_7 else frozenset(values)
+
+
+def fold_sunday(values) -> frozenset[int]:
+    """Fold a day-of-week set expanded over 0-7 so 7 means Sunday (0)."""
+    values = set(values)
+    if 7 in values:
+        values.discard(7)
+        values.add(0)
+    return frozenset(values)
+
+
+@dataclass(frozen=True)
+class CronSpec:
+    minutes: frozenset[int]
+    hours: frozenset[int]
+    doms: frozenset[int]
+    months: frozenset[int]
+    dows: frozenset[int]  # 0-6, Sunday = 0
+    dom_restricted: bool
+    dow_restricted: bool
+
+    def date_matches(self, year: int, month: int, day: int) -> bool:
+        if month not in self.months:
+            return False
+        dom_ok = day in self.doms
+        dow_ok = ((datetime(year, month, day).weekday() + 1) % 7) in self.dows
+        if self.dom_restricted and self.dow_restricted:
+            return dom_ok or dow_ok
+        return dom_ok and dow_ok
+
+    def matches(self, dt: datetime) -> bool:
+        return (dt.minute in self.minutes and dt.hour in self.hours
+                and self.date_matches(dt.year, dt.month, dt.day))
+
+
+def parse(expr: str, *, clamp: bool = False) -> CronSpec:
+    fields = expr.split()
+    if len(fields) != 5:
+        raise ValueError(f"cron expression must have 5 fields: {expr!r}")
+    (mlo, mhi), (hlo, hhi), (dlo, dhi), (molo, mohi), (wlo, whi) = FIELD_BOUNDS
+    return CronSpec(
+        minutes=field_values(fields[0], mlo, mhi, clamp=clamp),
+        hours=field_values(fields[1], hlo, hhi, clamp=clamp),
+        doms=field_values(fields[2], dlo, dhi, clamp=clamp),
+        months=field_values(fields[3], molo, mohi, clamp=clamp),
+        dows=field_values(fields[4], wlo, whi, sunday_7=True, clamp=clamp),
+        dom_restricted=fields[2] != "*",
+        dow_restricted=fields[4] != "*",
+    )
+
+
+def matches(expr: str, dt: datetime) -> bool:
+    """True when ``dt`` (a wall-clock time in the job's own zone) fires ``expr``."""
+    return parse(expr).matches(dt)
+
+
+def next_match(expr: str, after: datetime, horizon_days: int = 8):
+    """First wall-clock minute strictly after ``after`` that fires, or None
+    inside the horizon. Whole days that cannot match are skipped, so a
+    multi-year horizon (a leap-day job) costs days, not minutes."""
+    spec = parse(expr)
+    t = after.replace(second=0, microsecond=0) + timedelta(minutes=1)
+    end = after + timedelta(days=horizon_days)
+    while t <= end:
+        if not spec.date_matches(t.year, t.month, t.day):
+            t = (t + timedelta(days=1)).replace(hour=0, minute=0)
+            continue
+        if t.minute in spec.minutes and t.hour in spec.hours:
+            return t
+        t += timedelta(minutes=1)
+    return None

--- a/src/dashboard_schedules.py
+++ b/src/dashboard_schedules.py
@@ -90,6 +90,29 @@ def next_run(expr: str, now: datetime, horizon_days: int = 8):
 
 DEFAULT_CODEX_TIMEZONE = "America/Los_Angeles"
 
+# cron-runner-state.json: {name: scan boundary, ...}. The boundary advances on
+# every tick, so the last FIRE lives under this key: {name: fired slot epoch}.
+LAUNCHD_FIRE_RECORD_KEY = "__fired__"
+
+
+def host_zone():
+    """The host's IANA zone, so evaluation follows DST the way the launchd
+    runner's time.localtime does; a fixed offset only when no name resolves."""
+    name = os.environ.get("TZ") or ""
+    if not name:
+        try:
+            target = os.path.realpath("/etc/localtime")
+        except OSError:
+            target = ""
+        if "/zoneinfo/" in target:
+            name = target.split("/zoneinfo/", 1)[1]
+    if name:
+        try:
+            return ZoneInfo(name)
+        except (ZoneInfoNotFoundError, ValueError):
+            pass
+    return datetime.now().astimezone().tzinfo
+
 
 def job_timezone(job: dict):
     """The zone a job's cron fields are evaluated in by the scheduler that owns
@@ -97,7 +120,17 @@ def job_timezone(job: dict):
     every other owner fires on host-local wall-clock time."""
     if schedule_owner(job) == "codex":
         return ZoneInfo(str(job.get("timezone") or DEFAULT_CODEX_TIMEZONE))
-    return datetime.now().astimezone().tzinfo
+    return host_zone()
+
+
+def _positive_seconds(value):
+    """A finite positive number, or None. bool is an int and is excluded."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    seconds = float(value)
+    if seconds != seconds or seconds in (float("inf"), float("-inf")) or seconds <= 0:
+        return None
+    return seconds
 
 
 def next_run_for_job(job: dict, now: datetime, horizon_days: int = 8):
@@ -136,13 +169,20 @@ def last_fired(job: dict, state_dir: Path):
             if isinstance(slot, str) and slot:
                 return datetime.fromisoformat(slot.replace("Z", "+00:00")).astimezone(timezone.utc)
         elif owner == "launchd":
+            # The per-name value is the runner's scan boundary and moves every
+            # tick; only the fire record says a slot was actually run.
             raw = json.loads((state_dir / "cron-runner-state.json").read_text())
-            epoch = raw.get(name)
-            if isinstance(epoch, (int, float)) and not isinstance(epoch, bool):
+            fired = raw.get(LAUNCHD_FIRE_RECORD_KEY)
+            epoch = _positive_seconds(fired.get(name)) if isinstance(fired, dict) else None
+            if epoch is not None:
                 return datetime.fromtimestamp(epoch, timezone.utc)
         elif owner == "dynamic-loop":
+            # The payload's own `ts` is the clock; a sync can rewrite the mtime.
             alive = state_dir / f"dynamic-loop-{name}.alive"
-            return datetime.fromtimestamp(alive.stat().st_mtime, timezone.utc)
+            payload = json.loads(alive.read_text())
+            stamped = _positive_seconds(payload.get("ts")) if isinstance(payload, dict) else None
+            if stamped is not None:
+                return datetime.fromtimestamp(stamped, timezone.utc)
     except (OSError, ValueError, TypeError, AttributeError):
         return None
     return None

--- a/src/dashboard_schedules.py
+++ b/src/dashboard_schedules.py
@@ -27,32 +27,20 @@ import os
 import re
 import threading
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import cron_eval
 
 
-def cron_field_match(spec: str, value: int) -> bool:
-    """Match one cron field value against a spec supporting *, */N, A-B, A,B, N."""
-    for token in spec.split(","):
-        if token == "*":
-            return True
-        if token.startswith("*/"):
-            try:
-                step = int(token[2:])
-            except ValueError:
-                continue
-            if step and value % step == 0:
-                return True
-        elif "-" in token:
-            try:
-                a, b = (int(x) for x in token.split("-", 1))
-            except ValueError:
-                continue
-            if a <= value <= b:
-                return True
-        elif token.isdigit() and int(token) == value:
-            return True
-    return False
+def cron_field_match(spec: str, value: int, lo: int = 0, hi: int = 59) -> bool:
+    """Match one cron field value against a spec (*, */N, A-B, A,B, N, A-B/N).
+    Delegates to cron_eval; a malformed spec matches nothing."""
+    try:
+        return value in cron_eval.field_values(spec, lo, hi, sunday_7=(hi == 7))
+    except ValueError:
+        return False
 
 
 # Per-field value bounds (minute, hour, day-of-month, month, day-of-week).
@@ -91,25 +79,72 @@ def cron_field_valid(spec: str, lo: int, hi: int) -> bool:
 
 
 def next_run(expr: str, now: datetime, horizon_days: int = 8):
-    """Next datetime matching a 5-field cron expr (minute hour dom month dow),
-    scanning minute-by-minute up to horizon_days. Returns datetime or None.
-
-    dom/dow are AND-combined (sufficient for our crons, which restrict only one
-    of them); the rare cron OR-semantics edge case is not modeled.
-    """
-    parts = expr.split()
-    if len(parts) != 5:
+    """Next datetime matching a 5-field cron expr, or None inside the horizon.
+    Semantics (Vixie dom/dow OR, Sunday=7) come from cron_eval, the same
+    evaluator the launchd and codex schedulers fire on."""
+    try:
+        return cron_eval.next_match(expr, now, horizon_days)
+    except ValueError:
         return None
-    mnt, hr, dom, mon, dow = parts
-    t = now.replace(second=0, microsecond=0) + timedelta(minutes=1)
-    end = now + timedelta(days=horizon_days)
-    while t <= end:
-        cron_dow = (t.weekday() + 1) % 7  # python Mon=0..Sun=6 -> cron Sun=0..Sat=6
-        if (cron_field_match(mnt, t.minute) and cron_field_match(hr, t.hour)
-                and cron_field_match(dom, t.day) and cron_field_match(mon, t.month)
-                and cron_field_match(dow, cron_dow)):
-            return t
-        t += timedelta(minutes=1)
+
+
+DEFAULT_CODEX_TIMEZONE = "America/Los_Angeles"
+
+
+def job_timezone(job: dict):
+    """The zone a job's cron fields are evaluated in by the scheduler that owns
+    it: codex-task entries declare an IANA zone (default America/Los_Angeles);
+    every other owner fires on host-local wall-clock time."""
+    if schedule_owner(job) == "codex":
+        return ZoneInfo(str(job.get("timezone") or DEFAULT_CODEX_TIMEZONE))
+    return datetime.now().astimezone().tzinfo
+
+
+def next_run_for_job(job: dict, now: datetime, horizon_days: int = 8):
+    """Next fire as an aware datetime, evaluated in the job's own zone. None for
+    a dynamic loop, an invalid cron, an unknown zone, or nothing in horizon."""
+    expr = job.get("cron") or ""
+    if job.get("loop") == "dynamic" or not expr:
+        return None
+    try:
+        tz = job_timezone(job)
+    except ZoneInfoNotFoundError:
+        return None
+    if now.tzinfo is None:
+        now = now.astimezone()
+    return next_run(expr, now.astimezone(tz), horizon_days)
+
+
+# A job name may only address state files through this shape; anything else is
+# refused rather than joined into a path.
+SAFE_JOB_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def last_fired(job: dict, state_dir: Path):
+    """The owning scheduler's own record of the last fire, as an aware UTC
+    datetime, or None when no scheduler records one. Generic activity stamps
+    (core-status.json) are never a fire."""
+    name = str(job.get("name") or "")
+    if not SAFE_JOB_NAME_RE.match(name):
+        return None
+    owner = schedule_owner(job)
+    state_dir = Path(state_dir)
+    try:
+        if owner == "codex":
+            raw = json.loads((state_dir / "schedules" / "codex-scheduler.json").read_text())
+            slot = ((raw.get("jobs") or {}).get(name) or {}).get("last_scheduled_slot")
+            if isinstance(slot, str) and slot:
+                return datetime.fromisoformat(slot.replace("Z", "+00:00")).astimezone(timezone.utc)
+        elif owner == "launchd":
+            raw = json.loads((state_dir / "cron-runner-state.json").read_text())
+            epoch = raw.get(name)
+            if isinstance(epoch, (int, float)) and not isinstance(epoch, bool):
+                return datetime.fromtimestamp(epoch, timezone.utc)
+        elif owner == "dynamic-loop":
+            alive = state_dir / f"dynamic-loop-{name}.alive"
+            return datetime.fromtimestamp(alive.stat().st_mtime, timezone.utc)
+    except (OSError, ValueError, TypeError, AttributeError):
+        return None
     return None
 
 

--- a/tests/cron-eval.test.py
+++ b/tests/cron-eval.test.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""src/cron_eval.py is the one cron evaluation contract, and the launchd runner,
+the codex scheduler, dashboard_schedules and the scheduled-panel all bind it.
+
+Contract: grammar, Sunday=7 (incl. ranges 5-7 / 0-7), Vixie dom/dow OR, leap
+day, never-fires, malformed raises, clamp semantics, per-job timezone.
+Wiring: each caller is proven to reach cron_eval by making cron_eval raise a
+sentinel and watching it surface through the caller's public function.
+Run: python3 tests/cron-eval.test.py
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+from zoneinfo import ZoneInfo
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+import cron_eval as ce  # noqa: E402
+import dashboard_schedules as ds  # noqa: E402
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cr = _load("cron_runner", REPO / "src" / "cron-runner.py")
+cx = _load("codex_scheduler", REPO / "skills" / "schedule-crons" / "scripts" / "codex-scheduler.py")
+
+NOW = datetime(2026, 9, 3, 0, 40)  # a Thursday, naive wall clock
+
+
+class Sentinel(RuntimeError):  # not ValueError: the wrappers may swallow that on purpose
+    pass
+
+
+class ContractTests(unittest.TestCase):
+    def test_grammar(self):
+        self.assertEqual(ce.field_values("*", 0, 3), {0, 1, 2, 3})
+        self.assertEqual(ce.field_values("*/20", 0, 59), {0, 20, 40})
+        self.assertEqual(ce.field_values("1,5", 0, 6), {1, 5})
+        self.assertEqual(ce.field_values("2-4", 0, 6), {2, 3, 4})
+        self.assertEqual(ce.field_values("1-10/3", 1, 31), {1, 4, 7, 10})
+        self.assertEqual(ce.field_values("*/3", 1, 31), set(range(1, 32, 3)))  # lo-based, not value%3
+
+    def test_malformed_raises(self):
+        for bad in ("", "*/0", "9-3", "60", "x", "1-x", "*/x"):
+            with self.assertRaises(ValueError, msg=bad):
+                ce.field_values(bad, 0, 59)
+        with self.assertRaises(ValueError):
+            ce.parse("* * * *")
+
+    def test_clamp_is_the_launchd_contract(self):
+        self.assertEqual(max(ce.field_values("0-70", 0, 59, clamp=True)), 59)
+        self.assertEqual(ce.field_values("5-3", 0, 59, clamp=True), frozenset())
+        with self.assertRaises(ValueError):
+            ce.field_values("x", 0, 59, clamp=True)  # syntax still raises
+
+    def test_sunday_seven_and_ranges(self):
+        self.assertEqual(ce.field_values("7", 0, 7, sunday_7=True), {0})
+        self.assertEqual(ce.field_values("5-7", 0, 7, sunday_7=True), {0, 5, 6})
+        self.assertEqual(ce.field_values("0-7", 0, 7, sunday_7=True), set(range(7)))
+        self.assertEqual(ce.next_match("0 6 * * 7", NOW, 8), datetime(2026, 9, 6, 6, 0))  # Sunday
+        self.assertTrue(ce.matches("0 6 * * 5-7", datetime(2026, 7, 5, 6, 0)))   # Sun
+        self.assertFalse(ce.matches("0 6 * * 5-6", datetime(2026, 7, 5, 6, 0)))
+
+    def test_vixie_or_when_both_restricted(self):
+        self.assertEqual(ce.next_match("0 12 15 * 1", NOW, 8), datetime(2026, 9, 7, 12, 0))  # Monday first
+        self.assertEqual(ce.next_match("0 12 * * 1", NOW, 8), datetime(2026, 9, 7, 12, 0))
+        self.assertEqual(ce.next_match("0 12 15 * *", NOW, 30), datetime(2026, 9, 15, 12, 0))
+
+    def test_leap_day_and_never(self):
+        self.assertEqual(ce.next_match("0 0 29 2 *", NOW, 366 * 4 + 1), datetime(2028, 2, 29, 0, 0))
+        self.assertIsNone(ce.next_match("0 0 31 2 *", NOW, 366 * 4 + 1))
+        self.assertIsNone(ce.next_match("0 0 29 2 *", NOW, 400))  # a short horizon honestly says none
+
+    def test_day_of_month_step_and_annual(self):
+        self.assertEqual(ce.next_match("4 6 */3 * *", NOW, 8), datetime(2026, 9, 4, 6, 4))
+        self.assertEqual(ce.next_match("23 9 7 8 *", NOW, 400), datetime(2027, 8, 7, 9, 23))
+        self.assertEqual(ce.next_match("40 * * * *", NOW, 1), datetime(2026, 9, 3, 1, 40))
+
+
+class PerJobTimezoneTests(unittest.TestCase):
+    NOW_UTC = datetime(2026, 9, 3, 0, 40, tzinfo=timezone.utc)
+
+    def test_codex_job_fires_in_its_declared_zone(self):
+        job = {"name": "daily", "cron": "0 6 * * *", "execution": "codex-task", "prompt": "x"}
+        nxt = ds.next_run_for_job(job, self.NOW_UTC)
+        self.assertEqual(nxt.astimezone(timezone.utc), datetime(2026, 9, 3, 13, 0, tzinfo=timezone.utc))
+        job["timezone"] = "Asia/Tokyo"
+        nxt = ds.next_run_for_job(job, self.NOW_UTC)
+        self.assertEqual(nxt.astimezone(timezone.utc), datetime(2026, 9, 3, 21, 0, tzinfo=timezone.utc))
+
+    def test_unknown_zone_is_none_not_a_crash(self):
+        job = {"name": "z", "cron": "0 6 * * *", "execution": "codex-task", "timezone": "Mars/Olympus"}
+        self.assertIsNone(ds.next_run_for_job(job, self.NOW_UTC))
+
+    def test_host_local_job_evaluates_on_host_wall_clock(self):
+        job = {"name": "s", "cron": "0 6 * * *", "launchd": True}
+        local = self.NOW_UTC.astimezone()
+        want = ce.next_match("0 6 * * *", local, 8)
+        self.assertEqual(ds.next_run_for_job(job, self.NOW_UTC), want)
+
+    def test_dynamic_loop_and_invalid_are_none(self):
+        self.assertIsNone(ds.next_run_for_job({"name": "d", "loop": "dynamic"}, self.NOW_UTC))
+        self.assertIsNone(ds.next_run_for_job({"name": "b", "cron": "x * * * *"}, self.NOW_UTC))
+
+
+class LastFiredTests(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.ws = Path(self.td.name)
+        (self.ws / "state" / "schedules").mkdir(parents=True)
+        self.state = self.ws / "state"
+
+    def test_main_loop_never_reads_core_status(self):
+        (self.state / "core-status.json").write_text(json.dumps({"ts": "2026-09-03 12:34:00", "status": "running"}))
+        self.assertIsNone(ds.last_fired({"name": "main-loop", "cron": "*/5 * * * *", "prompt_skill": "proactive-loop"}, self.state))
+
+    def test_codex_record(self):
+        (self.state / "schedules" / "codex-scheduler.json").write_text(json.dumps(
+            {"jobs": {"nightly": {"last_scheduled_slot": "2026-09-02T13:00:00Z"}}}))
+        got = ds.last_fired({"name": "nightly", "cron": "0 6 * * *", "execution": "codex-task"}, self.state)
+        self.assertEqual(got, datetime(2026, 9, 2, 13, 0, tzinfo=timezone.utc))
+
+    def test_launchd_record(self):
+        (self.state / "cron-runner-state.json").write_text(json.dumps({"digest": 1788390000}))
+        got = ds.last_fired({"name": "digest", "cron": "0 6 * * *", "launchd": True}, self.state)
+        self.assertEqual(got, datetime.fromtimestamp(1788390000, timezone.utc))
+
+    def test_dynamic_alive_mtime(self):
+        p = self.state / "dynamic-loop-loopy.alive"
+        p.write_text("")
+        os.utime(p, (0, 0))
+        got = ds.last_fired({"name": "loopy", "loop": "dynamic"}, self.state)
+        self.assertEqual(got, datetime.fromtimestamp(0, timezone.utc))
+
+    def test_job_name_cannot_escape_state(self):
+        (self.ws / "outside.json").write_text(json.dumps({"last_pass": 1}))
+        (self.ws / "dynamic-loop-..").mkdir(exist_ok=True)
+        for name in ("../outside", "../../etc/passwd", "", "a/b"):
+            self.assertIsNone(ds.last_fired({"name": name, "cron": "0 0 * * *", "launchd": True}, self.state), name)
+            self.assertIsNone(ds.last_fired({"name": name, "loop": "dynamic"}, self.state), name)
+
+    def test_session_cron_has_no_record(self):
+        self.assertIsNone(ds.last_fired({"name": "x", "cron": "0 0 * * *"}, self.state))
+
+
+class WiringTests(unittest.TestCase):
+    """Each production caller reaches cron_eval: a sentinel raised inside
+    cron_eval surfaces through the caller's own public function."""
+
+    def test_launchd_runner_binds_cron_eval(self):
+        with mock.patch.object(ce, "field_values", side_effect=Sentinel("fv")):
+            cr._parse_field.cache_clear()
+            with self.assertRaises(Sentinel):
+                cr.cron_matches("0 6 * * *", time.localtime())
+        cr._parse_field.cache_clear()
+        with mock.patch.object(ce.CronSpec, "date_matches", side_effect=Sentinel("dm")):
+            with self.assertRaises(Sentinel):
+                cr._day_matches("*", "*", "7", time.localtime())
+        cr._parse_field.cache_clear()
+        self.assertTrue(cr.cron_matches("0 6 * * 7", time.struct_time((2026, 7, 5, 6, 0, 0, 6, 186, 0))))
+
+    def test_codex_scheduler_binds_cron_eval(self):
+        with mock.patch.object(ce, "matches", side_effect=Sentinel("m")):
+            with self.assertRaises(Sentinel):
+                cx.cron_matches("0 6 * * *", datetime(2026, 1, 1, tzinfo=timezone.utc))
+        with mock.patch.object(ce, "field_values", side_effect=Sentinel("fv")):
+            with self.assertRaises(Sentinel):
+                cx._field_values("*", 0, 59)
+        self.assertEqual(cx._field_values("7", 0, 7, sunday_7=True), {0})
+
+    def test_dashboard_schedules_binds_cron_eval(self):
+        with mock.patch.object(ce, "next_match", side_effect=Sentinel("nm")):
+            with self.assertRaises(Sentinel):
+                ds.next_run("0 6 * * *", NOW)
+        self.assertEqual(ds.next_run("0 12 15 * 1", NOW), datetime(2026, 9, 7, 12, 0))  # OR, via cron_eval
+        self.assertTrue(ds.cron_field_match("7", 0, 0, 7))   # Sunday=7 through the legacy helper
+        self.assertTrue(ds.cron_field_match("*/5", 15))
+        self.assertFalse(ds.cron_field_match("foo", 7))
+
+    def test_all_three_agree_on_the_reviewer_probes(self):
+        la = ZoneInfo("America/Los_Angeles")
+        for expr, at in (("0 6 * * *", datetime(2026, 9, 3, 6, 0)),
+                         ("0 6 * * 7", datetime(2026, 9, 6, 6, 0)),
+                         ("0 0 29 2 *", datetime(2028, 2, 29, 0, 0)),
+                         ("*/5 * 1 * *", datetime(2026, 10, 1, 0, 5))):
+            self.assertTrue(cx.cron_matches(expr, at.replace(tzinfo=la)), expr)
+            self.assertTrue(cr.cron_matches(expr, at.timetuple()), expr)
+            self.assertEqual(ds.next_run(expr, at - timedelta(minutes=1), 1), at, expr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/cron-eval.test.py
+++ b/tests/cron-eval.test.py
@@ -133,17 +133,53 @@ class LastFiredTests(unittest.TestCase):
         got = ds.last_fired({"name": "nightly", "cron": "0 6 * * *", "execution": "codex-task"}, self.state)
         self.assertEqual(got, datetime(2026, 9, 2, 13, 0, tzinfo=timezone.utc))
 
-    def test_launchd_record(self):
+    def test_launchd_scan_boundary_is_not_a_fire(self):
+        # The per-name value advances every tick; without a fire record the
+        # panel must say unknown, never render the boundary as a fire.
         (self.state / "cron-runner-state.json").write_text(json.dumps({"digest": 1788390000}))
+        self.assertIsNone(ds.last_fired({"name": "digest", "cron": "0 6 * * *", "launchd": True}, self.state))
+        (self.state / "cron-runner-state.json").write_text(json.dumps(
+            {"digest": 1788390000, ds.LAUNCHD_FIRE_RECORD_KEY: {"digest": 1788386400}}))
         got = ds.last_fired({"name": "digest", "cron": "0 6 * * *", "launchd": True}, self.state)
-        self.assertEqual(got, datetime.fromtimestamp(1788390000, timezone.utc))
+        self.assertEqual(got, datetime.fromtimestamp(1788386400, timezone.utc))
 
-    def test_dynamic_alive_mtime(self):
+    def _runner_at(self, root):
+        cr.WORKSPACE = root
+        cr.CRONS_FILE = root / "crons.json"
+        cr.STATE_FILE = root / "state" / "cron-runner-state.json"
+        cr.STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        cr.TASKS_DIR = root / "tasks"
+        cr.CORE_ALIVE_FILE = root / "state" / "cores" / "h.alive"
+
+    def test_launchd_record_comes_from_the_production_writer(self):
+        # Drive cron-runner.run() itself: a fired shell job leaves a fire record,
+        # an impossible cron advances the boundary and leaves none.
+        root = Path(self.td.name) / "runner"
+        self._runner_at(root)
+        now = 1788464040  # 2026-09-03T19:34:00Z
+        cr.CRONS_FILE.write_text(json.dumps([
+            {"name": "fires", "cron": "* * * * *", "launchd": True, "shell_command": "true"},
+            {"name": "parked", "cron": "0 0 31 2 *", "launchd": True, "shell_command": "true"}]))
+        cr.STATE_FILE.write_text(json.dumps({"fires": now - 120, "parked": now - 120}))
+        emitted = cr.run(now_epoch=now)
+        self.assertEqual(emitted, ["fires"])
+        state = json.loads(cr.STATE_FILE.read_text())
+        self.assertEqual(state["parked"], now, "boundary advanced although nothing fired")
+        self.assertIsNone(ds.last_fired({"name": "parked", "cron": "0 0 31 2 *", "launchd": True}, root / "state"))
+        fired = ds.last_fired({"name": "fires", "cron": "* * * * *", "launchd": True}, root / "state")
+        self.assertEqual(fired, datetime.fromtimestamp(now - now % 60, timezone.utc))
+
+    def test_dynamic_alive_uses_the_payload_ts_not_mtime(self):
         p = self.state / "dynamic-loop-loopy.alive"
-        p.write_text("")
-        os.utime(p, (0, 0))
+        p.write_text(json.dumps({"ts": 1000, "next_delay_s": 60}))
+        os.utime(p, (2000, 2000))
         got = ds.last_fired({"name": "loopy", "loop": "dynamic"}, self.state)
-        self.assertEqual(got, datetime.fromtimestamp(0, timezone.utc))
+        self.assertEqual(got, datetime.fromtimestamp(1000, timezone.utc))
+        p.write_text("")   # unparseable: unknown, not the synced mtime
+        os.utime(p, (2000, 2000))
+        self.assertIsNone(ds.last_fired({"name": "loopy", "loop": "dynamic"}, self.state))
+        p.write_text(json.dumps({"ts": True}))
+        self.assertIsNone(ds.last_fired({"name": "loopy", "loop": "dynamic"}, self.state))
 
     def test_job_name_cannot_escape_state(self):
         (self.ws / "outside.json").write_text(json.dumps({"last_pass": 1}))
@@ -199,6 +235,79 @@ class WiringTests(unittest.TestCase):
             self.assertTrue(cx.cron_matches(expr, at.replace(tzinfo=la)), expr)
             self.assertTrue(cr.cron_matches(expr, at.timetuple()), expr)
             self.assertEqual(ds.next_run(expr, at - timedelta(minutes=1), 1), at, expr)
+
+
+def _codex_style_next(expr, after_utc, tz, minutes=60 * 24 * 40):
+    """The exact tick() predicate: real minute slots, each judged in the zone."""
+    t = after_utc.replace(second=0, microsecond=0)
+    for i in range(1, minutes):
+        slot = t + timedelta(minutes=i)
+        if cx.cron_matches(expr, slot.astimezone(tz)):
+            return slot
+    return None
+
+
+class TimezoneTransitionTests(unittest.TestCase):
+    """The panel's next fire walks real instants, so it agrees with the codex
+    tick() scan across a spring gap and a fall fold, not only in ordinary time."""
+    LA = ZoneInfo("America/Los_Angeles")
+
+    def _agree(self, expr, after_utc):
+        panel = ce.next_match(expr, after_utc.astimezone(self.LA), 40)
+        tick = _codex_style_next(expr, after_utc, self.LA)
+        self.assertIsNotNone(panel, expr)
+        self.assertEqual(panel.astimezone(timezone.utc), tick, expr)
+        return panel
+
+    def test_ordinary(self):
+        got = self._agree("0 6 * * *", datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc))
+        self.assertEqual(got.astimezone(timezone.utc), datetime(2026, 9, 3, 13, 0, tzinfo=timezone.utc))
+
+    def test_spring_gap_skips_the_nonexistent_minute(self):
+        # 2026-03-08 02:30 PST does not exist; the next real 02:30 is March 9 (PDT).
+        got = self._agree("30 2 * * *", datetime(2026, 3, 8, 8, 0, tzinfo=timezone.utc))
+        self.assertEqual(got.astimezone(timezone.utc), datetime(2026, 3, 9, 9, 30, tzinfo=timezone.utc))
+
+    def test_fall_fold_visits_the_repeated_minute(self):
+        # 01:30 happens twice on 2026-11-01 (PDT then PST); after the first, the
+        # next fire is the second, the same slot tick() enqueues.
+        got = self._agree("30 1 * * *", datetime(2026, 11, 1, 8, 31, tzinfo=timezone.utc))
+        self.assertEqual(got.astimezone(timezone.utc), datetime(2026, 11, 1, 9, 30, tzinfo=timezone.utc))
+
+    def test_naive_after_keeps_wall_clock_semantics(self):
+        self.assertEqual(ce.next_match("30 2 * * *", datetime(2026, 3, 8, 1, 0)), datetime(2026, 3, 8, 2, 30))
+
+    def test_host_zone_is_a_named_zone_not_todays_offset(self):
+        # A launchd row on a future date must use that date's offset, which a
+        # fixed PDT/PST offset cannot do; TZ names the zone explicitly here.
+        with mock.patch.dict(os.environ, {"TZ": "America/New_York"}):
+            self.assertEqual(str(ds.host_zone()), "America/New_York")
+            nxt = ds.next_run_for_job({"name": "x", "cron": "0 6 1 12 *", "launchd": True},
+                                      datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc), 120)
+            self.assertEqual(nxt.astimezone(timezone.utc), datetime(2026, 12, 1, 11, 0, tzinfo=timezone.utc))
+        with mock.patch.dict(os.environ, {"TZ": "Not/AZone"}):
+            self.assertIsNotNone(ds.host_zone())   # falls back rather than raising
+        with mock.patch.dict(os.environ, {"TZ": ""}), \
+             mock.patch.object(ds.os.path, "realpath", side_effect=OSError("no localtime")):
+            self.assertIsNotNone(ds.host_zone())   # unreadable /etc/localtime: still a zone
+
+    def test_positive_seconds_rejects_non_finite_and_non_positive(self):
+        for bad in (float("nan"), float("inf"), float("-inf"), 0, -1, True, "5", None):
+            self.assertIsNone(ds._positive_seconds(bad), repr(bad))
+        self.assertEqual(ds._positive_seconds(5), 5.0)
+
+
+class ShellJobInterpreterTests(unittest.TestCase):
+    """A shell job gets the runner's own interpreter as $SUTANDO_PY, so the
+    documented invocation never resolves a bare python3 on launchd's PATH."""
+    def test_child_sees_the_runners_interpreter_outside_its_path(self):
+        td = tempfile.TemporaryDirectory(); self.addCleanup(td.cleanup)
+        root = Path(td.name); cr.WORKSPACE = root
+        with mock.patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}):
+            rc = cr._run_shell_command("probe", '"$SUTANDO_PY" -c "import sys; print(sys.executable)"', 30)
+        self.assertEqual(rc, 0)
+        log = next((root / "logs").rglob("*")).read_text() if (root / "logs").exists() else ""
+        self.assertIn(sys.executable, log or cr._shell_log_path().read_text())
 
 
 if __name__ == "__main__":

--- a/tests/scheduled-panel-publish-schedule.test.py
+++ b/tests/scheduled-panel-publish-schedule.test.py
@@ -51,10 +51,68 @@ class FmtTests(unittest.TestCase):
         self.assertEqual(ps._fmt(None), "—")
         self.assertEqual(ps._fmt("2026-09-03 00:40:11"), "—")
 
+    def test_naive_is_taken_as_host_local(self):
+        naive = datetime.datetime(2026, 9, 3, 12, 0)
+        self.assertEqual(ps._fmt(naive), naive.astimezone(UTC).strftime("%Y-%m-%dT%H:%MZ"))
+
 
 class CfgTests(unittest.TestCase):
     def test_reads_the_repo_config_helper(self):
         self.assertTrue(ps._cfg("workspace"))
+
+    def test_a_failing_config_helper_is_unavailable_not_empty(self):
+        fake = types.SimpleNamespace(returncode=3, stdout="", stderr="sutando config: malformed")
+        with mock.patch.object(ps.subprocess, "run", return_value=fake):
+            with self.assertRaises(ps.SourceUnavailable):
+                ps._cfg("workspace")
+        fake = types.SimpleNamespace(returncode=0, stdout="\n", stderr="")
+        with mock.patch.object(ps.subprocess, "run", return_value=fake):
+            with self.assertRaises(ps.SourceUnavailable):
+                ps._cfg("workspace")
+
+
+class StrictSourceTests(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory(); self.addCleanup(self.td.cleanup)
+        self.p = pathlib.Path(self.td.name) / "crons.json"
+
+    def test_missing_invalid_and_wrong_shape_are_unavailable(self):
+        with self.assertRaises(ps.SourceUnavailable):
+            ps.read_crons_strict(self.p)
+        self.p.write_text("{not json")
+        with self.assertRaises(ps.SourceUnavailable):
+            ps.read_crons_strict(self.p)
+        self.p.write_text(json.dumps({"jobs": []}))
+        with self.assertRaises(ps.SourceUnavailable):
+            ps.read_crons_strict(self.p)
+
+    def test_a_valid_empty_list_is_an_empty_schedule(self):
+        self.p.write_text("[]")
+        self.assertEqual(ps.read_crons_strict(self.p), [])
+
+    def test_main_refuses_to_publish_on_an_unavailable_source(self):
+        calls = []
+        with mock.patch.object(ps, "build_rows", side_effect=ps.SourceUnavailable("cfg rc=3")), \
+             mock.patch.object(ps, "publish", side_effect=lambda *a, **k: calls.append(a) or {"ok": True}):
+            rc = ps.main(["--publish", "--room", "!r:x"])
+        self.assertEqual(rc, 2)
+        self.assertEqual(calls, [], "doc_put ran on an unavailable source")
+
+    def test_main_other_paths(self):
+        with mock.patch.object(ps, "build_rows", return_value=[]):
+            self.assertEqual(ps.main(["--json"]), 0)
+            self.assertEqual(ps.main([]), 0)
+            with mock.patch.object(ps, "publish", return_value={"ok": False, "reason": "boom"}):
+                self.assertEqual(ps.main(["--publish", "--room", "!r:x"]), 1)
+
+    def test_main_publishes_a_valid_empty_schedule(self):
+        calls = []
+        with mock.patch.object(ps, "build_rows", return_value=[]), \
+             mock.patch.object(ps, "publish", side_effect=lambda room, md: calls.append((room, md)) or {"ok": True}):
+            rc = ps.main(["--publish", "--room", "!r:x"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("# Scheduled jobs", calls[0][1])
 
 
 class _Workspace(unittest.TestCase):
@@ -94,11 +152,13 @@ class BuildRowsTests(_Workspace):
         self.assertEqual(rows[1]["does"], "x" * 48)
         self.assertEqual(rows[2]["does"], "—")
 
-    def test_dict_shape_is_not_a_schedule(self):
-        # The schedulers reject a non-array crons.json; the panel must not
-        # publish jobs no scheduler owns.
-        self.assertEqual(self._rows({"jobs": [{"name": "a", "cron": "0 0 * * *"}]}), [])
-        self.assertEqual(self._rows({"crons": [{"name": "b", "cron": "0 0 * * *"}]}), [])
+    def test_dict_shape_is_unavailable_not_an_empty_schedule(self):
+        # The schedulers reject a non-array crons.json; the panel must neither
+        # publish jobs no scheduler owns nor overwrite the doc with an empty table.
+        with self.assertRaises(ps.SourceUnavailable):
+            self._rows({"jobs": [{"name": "a", "cron": "0 0 * * *"}]})
+        with self.assertRaises(ps.SourceUnavailable):
+            self._rows({"crons": [{"name": "b", "cron": "0 0 * * *"}]})
 
     def test_codex_job_next_fire_is_in_its_own_zone(self):
         rows = self._rows([{"name": "d", "cron": "0 6 * * *", "execution": "codex-task", "prompt": "x"},
@@ -120,7 +180,9 @@ class BuildRowsTests(_Workspace):
         self._write("state/core-status.json", {"ts": "2026-09-03 12:34:00"})
         self._write("state/schedules/codex-scheduler.json",
                     {"jobs": {"nightly": {"last_scheduled_slot": "2026-09-02T13:00:00Z"}}})
-        self._write("state/cron-runner-state.json", {"digest": 1788390000})
+        # boundary (moves every tick) vs the fire record: only the record renders
+        self._write("state/cron-runner-state.json",
+                    {"digest": 1788393600, "__fired__": {"digest": 1788390000}})
         self._write("state/ghost.json", {"last_pass": 1})
         self._write("outside.json", {"last_pass": 1})
         rows = self._rows([

--- a/tests/scheduled-panel-publish-schedule.test.py
+++ b/tests/scheduled-panel-publish-schedule.test.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""scheduled-panel/publish_schedule.py — the next-fire column must honour every
-cron field. Measured on a live crons.json: `4 6 */3 * *` and `23 9 7 8 *`
-(annual) both rendered as "fires today" because day-of-month and month were
-never consulted, beside a human column that fell back honestly to the raw
-expression for exactly those fields.
+"""scheduled-panel/publish_schedule.py renders and publishes; every schedule
+judgement (cron semantics, per-job zone, file shape, last-fire record) is
+delegated to src/dashboard_schedules, so the panel cannot drift from the
+schedulers. Cron semantics themselves are pinned in tests/cron-eval.test.py.
 
 Hermetic: `_cfg` is patched to a temp workspace; publish() gets a stub doc
 module. Run: python3 tests/scheduled-panel-publish-schedule.test.py
@@ -27,16 +26,6 @@ UTC = datetime.timezone.utc
 NOW = datetime.datetime(2026, 9, 3, 0, 40, tzinfo=UTC)  # a Thursday
 
 
-class FieldSetTests(unittest.TestCase):
-    def test_shapes(self):
-        self.assertEqual(ps._field_set("*", 0, 3), {0, 1, 2, 3})
-        self.assertEqual(ps._field_set("*/20", 0, 59), {0, 20, 40})
-        self.assertEqual(ps._field_set("1,5", 0, 6), {1, 5})
-        self.assertEqual(ps._field_set("2-4", 0, 6), {2, 3, 4})
-        self.assertEqual(ps._field_set("1-10/3", 1, 31), {1, 4, 7, 10})
-        self.assertEqual(ps._field_set("*/3", 1, 31), set(range(1, 32, 3)))
-
-
 class HumanCronTests(unittest.TestCase):
     def test_forms(self):
         self.assertEqual(ps._human_cron("*/5 * * * *"), "every 5 min")
@@ -46,56 +35,25 @@ class HumanCronTests(unittest.TestCase):
         self.assertEqual(ps._human_cron("4 6 */3 * *"), "4 6 */3 * *")  # honest fallback
         self.assertEqual(ps._human_cron("bad"), "bad")
 
-
-class NextFireTests(unittest.TestCase):
-    """Reviewer's four live expressions at now=2026-09-03T00:40Z, two of them controls."""
-
-    def test_day_of_month_step_is_consulted(self):
-        # */3 -> days 1,4,7,...; the 3rd is not one, so NOT 2026-09-03T06:04Z.
-        self.assertEqual(ps._next_fire("4 6 */3 * *", NOW), "2026-09-04T06:04Z")
-
-    def test_annual_job_is_eleven_months_out_not_nine_hours(self):
-        self.assertEqual(ps._next_fire("23 9 7 8 *", NOW), "2027-08-07T09:23Z")
-
-    def test_controls_unchanged(self):
-        self.assertEqual(ps._next_fire("*/5 * * * *", NOW), "2026-09-03T00:45Z")
-        self.assertEqual(ps._next_fire("7 16 * * 5", NOW), "2026-09-04T16:07Z")  # Friday
-
-    def test_month_field(self):
-        self.assertEqual(ps._next_fire("0 12 * 10 *", NOW), "2026-10-01T12:00Z")
-
-    def test_dom_and_dow_both_restricted_are_or_ed(self):
-        # Vixie cron: the 15th OR a Monday. Mon 2026-09-07 comes before the 15th.
-        self.assertEqual(ps._next_fire("0 12 15 * 1", NOW), "2026-09-07T12:00Z")
-        # Only dow restricted: still AND with the wildcard dom -> the same Monday.
-        self.assertEqual(ps._next_fire("0 12 * * 1", NOW), "2026-09-07T12:00Z")
-
-    def test_never_fires_and_malformed(self):
-        self.assertEqual(ps._next_fire("0 0 31 2 *", NOW), "—")  # Feb 31 never comes
-        self.assertEqual(ps._next_fire("not a cron", NOW), "—")
-        self.assertEqual(ps._next_fire("x * * * *", NOW), "—")
-
-    def test_next_minute_boundary(self):
-        # Fires at :40 exactly when now is :40 -> the scan starts at :41, so next hour.
-        self.assertEqual(ps._next_fire("40 * * * *", NOW), "2026-09-03T01:40Z")
+    def test_a_calendar_restriction_is_never_hidden(self):
+        # "every 5 min" would be false 30 days of 31: the restriction stays visible.
+        self.assertEqual(ps._human_cron("*/5 * 1 * *"), "*/5 * 1 * *")
+        self.assertEqual(ps._human_cron("1,31 * * 9 *"), "1,31 * * 9 *")
+        self.assertEqual(ps._human_cron("*/5 * * * 1"), "*/5 * * * 1")
 
 
-class IsoTests(unittest.TestCase):
-    def test_forms(self):
-        self.assertEqual(ps._iso(0), "1970-01-01T00:00Z")
-        self.assertEqual(ps._iso("2026-09-03 00:40:11"), "2026-09-03T00:40")
-        self.assertEqual(ps._iso(None), "None")
+class FmtTests(unittest.TestCase):
+    def test_aware_to_utc_minute(self):
+        tokyo = datetime.timezone(datetime.timedelta(hours=9))
+        self.assertEqual(ps._fmt(datetime.datetime(2026, 9, 3, 21, 0, tzinfo=tokyo)), "2026-09-03T12:00Z")
 
-    def test_unrenderable_is_a_dash(self):
-        class Boom:
-            def __str__(self):
-                raise RuntimeError("no")
-        self.assertEqual(ps._iso(Boom()), "—")
+    def test_none_and_junk_are_a_dash(self):
+        self.assertEqual(ps._fmt(None), "—")
+        self.assertEqual(ps._fmt("2026-09-03 00:40:11"), "—")
 
 
 class CfgTests(unittest.TestCase):
     def test_reads_the_repo_config_helper(self):
-        # The real helper, in-repo: the path it prints is a directory name, never empty.
         self.assertTrue(ps._cfg("workspace"))
 
 
@@ -105,72 +63,89 @@ class _Workspace(unittest.TestCase):
         self.addCleanup(self.td.cleanup)
         self.ws = self.td.name
         self.state = os.path.join(self.ws, "state")
-        os.makedirs(self.state)
+        os.makedirs(os.path.join(self.state, "schedules"))
         os.makedirs(os.path.join(self.ws, "hosts", "h1"))
 
     def _write(self, rel, obj):
         with open(os.path.join(self.ws, rel), "w") as fh:
             json.dump(obj, fh)
 
-
-class LastFiredTests(_Workspace):
-    def test_main_loop_reads_core_status(self):
-        self._write("state/core-status.json", {"ts": "2026-09-03 00:30:00"})
-        self.assertEqual(ps._last_fired({"name": "main-loop"}, self.ws, "h1"), "2026-09-03T00:30")
-
-    def test_per_cron_state_last_pass(self):
-        self._write("state/shepherd.json", {"last_pass": 1})
-        self.assertEqual(ps._last_fired({"name": "shepherd"}, self.ws, "h1"), "1970-01-01T00:00Z")
-
-    def test_main_loop_without_a_stamp_falls_through(self):
-        self._write("state/core-status.json", {"status": "idle"})
-        self.assertEqual(ps._last_fired({"name": "main-loop"}, self.ws, "h1"), "—")
-
-    def test_alive_file_mtime(self):
-        p = os.path.join(self.state, "dynamic-loop-loopy.alive")
-        open(p, "w").close()
-        os.utime(p, (0, 0))
-        self.assertEqual(ps._last_fired({"name": "loopy"}, self.ws, "h1"), "1970-01-01T00:00Z")
-
-    def test_nothing_known(self):
-        self.assertEqual(ps._last_fired({"name": "ghost"}, self.ws, "h1"), "—")
+    def _rows(self, jobs, now=NOW):
+        self._write("hosts/h1/crons.json", jobs)
+        with mock.patch.object(ps, "_cfg", side_effect=lambda a: {"workspace": self.ws, "host-label": "h1"}[a]):
+            return ps.build_rows(now)
 
 
 class BuildRowsTests(_Workspace):
-    def _rows(self, jobs):
-        self._write("hosts/h1/crons.json", jobs)
-        with mock.patch.object(ps, "_cfg", side_effect=lambda a: {"workspace": self.ws, "host-label": "h1"}[a]):
-            return ps.build_rows()
-
-    def test_rows_from_list_shape(self):
+    def test_rows_from_the_canonical_list_shape(self):
         rows = self._rows([
             {"name": "main-loop", "cron": "*/5 * * * *", "prompt_skill": "proactive-loop"},
             {"name": "dyn", "loop": "dynamic", "cron": "", "prompt": "x" * 60},
             {"cron": "7 16 * * 5"},
+            "not a job",
         ])
         self.assertEqual([r["name"] for r in rows], ["main-loop", "dyn", "?"])
         self.assertEqual(rows[0]["schedule"], "every 5 min")
+        self.assertEqual(rows[0]["owner"], "session")
         self.assertEqual(rows[0]["does"], "proactive-loop")
-        self.assertRegex(rows[0]["next_fire"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z$")
+        self.assertEqual(rows[0]["next_fire"], "2026-09-03T00:45Z")
         self.assertEqual(rows[1]["schedule"], "adaptive (self-paced)")
         self.assertEqual(rows[1]["next_fire"], "—")
         self.assertEqual(rows[1]["does"], "x" * 48)
         self.assertEqual(rows[2]["does"], "—")
 
-    def test_rows_from_dict_shape(self):
-        rows = self._rows({"jobs": [{"name": "a", "cron": "0 0 * * *"}]})
-        self.assertEqual(rows[0]["schedule"], "daily 00:00")
-        rows = self._rows({"crons": [{"name": "b", "cron": "0 0 * * *"}]})
-        self.assertEqual(rows[0]["name"], "b")
+    def test_dict_shape_is_not_a_schedule(self):
+        # The schedulers reject a non-array crons.json; the panel must not
+        # publish jobs no scheduler owns.
+        self.assertEqual(self._rows({"jobs": [{"name": "a", "cron": "0 0 * * *"}]}), [])
+        self.assertEqual(self._rows({"crons": [{"name": "b", "cron": "0 0 * * *"}]}), [])
+
+    def test_codex_job_next_fire_is_in_its_own_zone(self):
+        rows = self._rows([{"name": "d", "cron": "0 6 * * *", "execution": "codex-task", "prompt": "x"},
+                           {"name": "t", "cron": "0 6 * * *", "execution": "codex-task", "prompt": "x",
+                            "timezone": "Asia/Tokyo"}])
+        self.assertEqual(rows[0]["next_fire"], "2026-09-03T13:00Z")  # 06:00 Los Angeles
+        self.assertEqual(rows[1]["next_fire"], "2026-09-03T21:00Z")  # 06:00 Tokyo
+        self.assertEqual(rows[0]["owner"], "codex")
+
+    def test_sunday_seven_and_leap_day_have_a_next_fire(self):
+        rows = self._rows([{"name": "sun", "cron": "0 6 * * 7", "execution": "codex-task", "prompt": "x"},
+                           {"name": "leap", "cron": "0 0 29 2 *", "execution": "codex-task", "prompt": "x"},
+                           {"name": "never", "cron": "0 0 31 2 *", "execution": "codex-task", "prompt": "x"}])
+        self.assertEqual(rows[0]["next_fire"], "2026-09-06T13:00Z")
+        self.assertEqual(rows[1]["next_fire"], "2028-02-29T08:00Z")
+        self.assertEqual(rows[2]["next_fire"], "—")
+
+    def test_last_fired_comes_from_the_owning_scheduler_only(self):
+        self._write("state/core-status.json", {"ts": "2026-09-03 12:34:00"})
+        self._write("state/schedules/codex-scheduler.json",
+                    {"jobs": {"nightly": {"last_scheduled_slot": "2026-09-02T13:00:00Z"}}})
+        self._write("state/cron-runner-state.json", {"digest": 1788390000})
+        self._write("state/ghost.json", {"last_pass": 1})
+        self._write("outside.json", {"last_pass": 1})
+        rows = self._rows([
+            {"name": "main-loop", "cron": "*/5 * * * *", "prompt_skill": "proactive-loop"},
+            {"name": "nightly", "cron": "0 6 * * *", "execution": "codex-task", "prompt": "x"},
+            {"name": "digest", "cron": "0 6 * * *", "launchd": True},
+            {"name": "ghost", "cron": "0 6 * * *"},
+            {"name": "../outside", "cron": "0 6 * * *", "launchd": True},
+        ])
+        by = {r["name"]: r["last_fired"] for r in rows}
+        self.assertEqual(by["main-loop"], "—")           # core-status.ts is activity, not a fire
+        self.assertEqual(by["nightly"], "2026-09-02T13:00Z")
+        self.assertEqual(by["digest"], "2026-09-02T23:00Z")
+        self.assertEqual(by["ghost"], "—")               # no <name>.json convention
+        self.assertEqual(by["../outside"], "—")          # no path escape
 
 
 class RenderTests(unittest.TestCase):
     def test_markdown_table(self):
-        md = ps.render_md([{"name": "a", "schedule": "s", "last_fired": "l", "next_fire": "n", "does": "d"}])
+        md = ps.render_md([{"name": "a", "schedule": "s", "owner": "o", "last_fired": "l",
+                            "next_fire": "n", "does": "d"}])
         self.assertTrue(md.startswith("# Scheduled jobs\n*updated "))
         self.assertIn("source: durable crons.json", md)
-        self.assertIn("| Job | Schedule | Last fired | Next fire | Does |", md)
-        self.assertTrue(md.endswith("| a | s | l | n | d |\n"))
+        self.assertIn("| Job | Schedule | Fires via | Last fired | Next fire | Does |", md)
+        self.assertTrue(md.endswith("| a | s | o | l | n | d |\n"))
 
 
 class PublishTests(unittest.TestCase):
@@ -200,4 +175,4 @@ class ArgTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=1)

--- a/tests/scheduled-panel-publish-schedule.test.py
+++ b/tests/scheduled-panel-publish-schedule.test.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""scheduled-panel/publish_schedule.py — the next-fire column must honour every
+cron field. Measured on a live crons.json: `4 6 */3 * *` and `23 9 7 8 *`
+(annual) both rendered as "fires today" because day-of-month and month were
+never consulted, beside a human column that fell back honestly to the raw
+expression for exactly those fields.
+
+Hermetic: `_cfg` is patched to a temp workspace; publish() gets a stub doc
+module. Run: python3 tests/scheduled-panel-publish-schedule.test.py
+"""
+import datetime
+import importlib.util
+import json
+import os
+import pathlib
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "skills" / "scheduled-panel" / "publish_schedule.py"
+_spec = importlib.util.spec_from_file_location("publish_schedule", _SRC)
+ps = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ps)
+
+UTC = datetime.timezone.utc
+NOW = datetime.datetime(2026, 9, 3, 0, 40, tzinfo=UTC)  # a Thursday
+
+
+class FieldSetTests(unittest.TestCase):
+    def test_shapes(self):
+        self.assertEqual(ps._field_set("*", 0, 3), {0, 1, 2, 3})
+        self.assertEqual(ps._field_set("*/20", 0, 59), {0, 20, 40})
+        self.assertEqual(ps._field_set("1,5", 0, 6), {1, 5})
+        self.assertEqual(ps._field_set("2-4", 0, 6), {2, 3, 4})
+        self.assertEqual(ps._field_set("1-10/3", 1, 31), {1, 4, 7, 10})
+        self.assertEqual(ps._field_set("*/3", 1, 31), set(range(1, 32, 3)))
+
+
+class HumanCronTests(unittest.TestCase):
+    def test_forms(self):
+        self.assertEqual(ps._human_cron("*/5 * * * *"), "every 5 min")
+        self.assertEqual(ps._human_cron("1,31 * * * *"), "~every few min (1,31)")
+        self.assertEqual(ps._human_cron("7 16 * * *"), "daily 16:07")
+        self.assertEqual(ps._human_cron("7 16 * * 5"), "5 16:07")
+        self.assertEqual(ps._human_cron("4 6 */3 * *"), "4 6 */3 * *")  # honest fallback
+        self.assertEqual(ps._human_cron("bad"), "bad")
+
+
+class NextFireTests(unittest.TestCase):
+    """Reviewer's four live expressions at now=2026-09-03T00:40Z, two of them controls."""
+
+    def test_day_of_month_step_is_consulted(self):
+        # */3 -> days 1,4,7,...; the 3rd is not one, so NOT 2026-09-03T06:04Z.
+        self.assertEqual(ps._next_fire("4 6 */3 * *", NOW), "2026-09-04T06:04Z")
+
+    def test_annual_job_is_eleven_months_out_not_nine_hours(self):
+        self.assertEqual(ps._next_fire("23 9 7 8 *", NOW), "2027-08-07T09:23Z")
+
+    def test_controls_unchanged(self):
+        self.assertEqual(ps._next_fire("*/5 * * * *", NOW), "2026-09-03T00:45Z")
+        self.assertEqual(ps._next_fire("7 16 * * 5", NOW), "2026-09-04T16:07Z")  # Friday
+
+    def test_month_field(self):
+        self.assertEqual(ps._next_fire("0 12 * 10 *", NOW), "2026-10-01T12:00Z")
+
+    def test_dom_and_dow_both_restricted_are_or_ed(self):
+        # Vixie cron: the 15th OR a Monday. Mon 2026-09-07 comes before the 15th.
+        self.assertEqual(ps._next_fire("0 12 15 * 1", NOW), "2026-09-07T12:00Z")
+        # Only dow restricted: still AND with the wildcard dom -> the same Monday.
+        self.assertEqual(ps._next_fire("0 12 * * 1", NOW), "2026-09-07T12:00Z")
+
+    def test_never_fires_and_malformed(self):
+        self.assertEqual(ps._next_fire("0 0 31 2 *", NOW), "—")  # Feb 31 never comes
+        self.assertEqual(ps._next_fire("not a cron", NOW), "—")
+        self.assertEqual(ps._next_fire("x * * * *", NOW), "—")
+
+    def test_next_minute_boundary(self):
+        # Fires at :40 exactly when now is :40 -> the scan starts at :41, so next hour.
+        self.assertEqual(ps._next_fire("40 * * * *", NOW), "2026-09-03T01:40Z")
+
+
+class IsoTests(unittest.TestCase):
+    def test_forms(self):
+        self.assertEqual(ps._iso(0), "1970-01-01T00:00Z")
+        self.assertEqual(ps._iso("2026-09-03 00:40:11"), "2026-09-03T00:40")
+        self.assertEqual(ps._iso(None), "None")
+
+    def test_unrenderable_is_a_dash(self):
+        class Boom:
+            def __str__(self):
+                raise RuntimeError("no")
+        self.assertEqual(ps._iso(Boom()), "—")
+
+
+class CfgTests(unittest.TestCase):
+    def test_reads_the_repo_config_helper(self):
+        # The real helper, in-repo: the path it prints is a directory name, never empty.
+        self.assertTrue(ps._cfg("workspace"))
+
+
+class _Workspace(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.ws = self.td.name
+        self.state = os.path.join(self.ws, "state")
+        os.makedirs(self.state)
+        os.makedirs(os.path.join(self.ws, "hosts", "h1"))
+
+    def _write(self, rel, obj):
+        with open(os.path.join(self.ws, rel), "w") as fh:
+            json.dump(obj, fh)
+
+
+class LastFiredTests(_Workspace):
+    def test_main_loop_reads_core_status(self):
+        self._write("state/core-status.json", {"ts": "2026-09-03 00:30:00"})
+        self.assertEqual(ps._last_fired({"name": "main-loop"}, self.ws, "h1"), "2026-09-03T00:30")
+
+    def test_per_cron_state_last_pass(self):
+        self._write("state/shepherd.json", {"last_pass": 1})
+        self.assertEqual(ps._last_fired({"name": "shepherd"}, self.ws, "h1"), "1970-01-01T00:00Z")
+
+    def test_main_loop_without_a_stamp_falls_through(self):
+        self._write("state/core-status.json", {"status": "idle"})
+        self.assertEqual(ps._last_fired({"name": "main-loop"}, self.ws, "h1"), "—")
+
+    def test_alive_file_mtime(self):
+        p = os.path.join(self.state, "dynamic-loop-loopy.alive")
+        open(p, "w").close()
+        os.utime(p, (0, 0))
+        self.assertEqual(ps._last_fired({"name": "loopy"}, self.ws, "h1"), "1970-01-01T00:00Z")
+
+    def test_nothing_known(self):
+        self.assertEqual(ps._last_fired({"name": "ghost"}, self.ws, "h1"), "—")
+
+
+class BuildRowsTests(_Workspace):
+    def _rows(self, jobs):
+        self._write("hosts/h1/crons.json", jobs)
+        with mock.patch.object(ps, "_cfg", side_effect=lambda a: {"workspace": self.ws, "host-label": "h1"}[a]):
+            return ps.build_rows()
+
+    def test_rows_from_list_shape(self):
+        rows = self._rows([
+            {"name": "main-loop", "cron": "*/5 * * * *", "prompt_skill": "proactive-loop"},
+            {"name": "dyn", "loop": "dynamic", "cron": "", "prompt": "x" * 60},
+            {"cron": "7 16 * * 5"},
+        ])
+        self.assertEqual([r["name"] for r in rows], ["main-loop", "dyn", "?"])
+        self.assertEqual(rows[0]["schedule"], "every 5 min")
+        self.assertEqual(rows[0]["does"], "proactive-loop")
+        self.assertRegex(rows[0]["next_fire"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z$")
+        self.assertEqual(rows[1]["schedule"], "adaptive (self-paced)")
+        self.assertEqual(rows[1]["next_fire"], "—")
+        self.assertEqual(rows[1]["does"], "x" * 48)
+        self.assertEqual(rows[2]["does"], "—")
+
+    def test_rows_from_dict_shape(self):
+        rows = self._rows({"jobs": [{"name": "a", "cron": "0 0 * * *"}]})
+        self.assertEqual(rows[0]["schedule"], "daily 00:00")
+        rows = self._rows({"crons": [{"name": "b", "cron": "0 0 * * *"}]})
+        self.assertEqual(rows[0]["name"], "b")
+
+
+class RenderTests(unittest.TestCase):
+    def test_markdown_table(self):
+        md = ps.render_md([{"name": "a", "schedule": "s", "last_fired": "l", "next_fire": "n", "does": "d"}])
+        self.assertTrue(md.startswith("# Scheduled jobs\n*updated "))
+        self.assertIn("source: durable crons.json", md)
+        self.assertIn("| Job | Schedule | Last fired | Next fire | Does |", md)
+        self.assertTrue(md.endswith("| a | s | l | n | d |\n"))
+
+
+class PublishTests(unittest.TestCase):
+    def test_delegates_to_room_ops_doc_put(self):
+        calls = []
+
+        class _Loader:
+            def exec_module(self, mod):
+                mod.doc_put = lambda *a, **k: (calls.append((a, k)), {"ok": True})[1]
+
+        fake = types.SimpleNamespace(loader=_Loader())
+        with mock.patch.object(ps.importlib.util, "spec_from_file_location", return_value=fake), \
+             mock.patch.object(ps.importlib.util, "module_from_spec", side_effect=lambda s: types.ModuleType("_ops_doc")):
+            res = ps.publish("!room:hs", "# body")
+        self.assertEqual(res, {"ok": True})
+        (args, kw), = calls
+        self.assertEqual(args, ("!room:hs", "# body"))
+        self.assertEqual(kw, {"folder": "activity", "name": "SCHEDULE.md", "message": "scheduled-jobs refresh"})
+        self.assertIn(os.path.join(ps.REPO, "skills/agent-room-ops"), ps.sys.path)
+
+
+class ArgTests(unittest.TestCase):
+    def test_flag_value(self):
+        with mock.patch.object(ps.sys, "argv", ["x", "--room", "!r:hs"]):
+            self.assertEqual(ps._arg("--room"), "!r:hs")
+            self.assertIsNone(ps._arg("--nope"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Why

The AG2 Space "Scheduled" Activity tab reads a Room Context doc (`folder=activity`, `name=SCHEDULE.md`) and there was no producer on the agent side. The durable source of what runs when is `<workspace>/hosts/<host>/crons.json` (owner-greenlit 2026-08-21), and every scheduler on this repo must agree with the panel about what a cron expression means.

## What

- **`src/cron_eval.py`** — the one 5-field cron evaluator. The launchd runner (`src/cron-runner.py`), the codex scheduler (`skills/schedule-crons/scripts/codex-scheduler.py`) and `src/dashboard_schedules.py` bind it; their private parsers are deleted. `next_match` walks **real instants** for an aware `after` and judges each by its wall clock in the job's zone — the predicate both schedulers apply to their minute slots — so a spring-forward minute is never returned and a fall-back minute is visited twice.
- **`src/dashboard_schedules.py`** — `host_zone()` resolves the host's IANA zone (`$TZ`, else `/etc/localtime`), so a launchd row on a future date uses that date's offset, not today's. `last_fired()` reads only a scheduler's **fire record**: codex `last_scheduled_slot`; launchd `cron-runner-state.json["__fired__"][name]` (the per-name value is a scan boundary that moves every tick); dynamic loop the `.alive` payload's own `ts` (sync can rewrite the mtime). No record → unknown, never a guess.
- **`src/cron-runner.py`** — records `__fired__[name] = slot` only when a job actually ran (shell command or emitted task); exports `SUTANDO_PY=sys.executable` into every `shell_command` child so the documented invocation never resolves a bare `python3` on launchd's minimal PATH.
- **`skills/scheduled-panel/publish_schedule.py`** — renders and publishes. `_cfg` checks the config helper's exit code; `read_crons_strict` distinguishes a valid empty list from a missing/unreadable/non-list source; `main()` exits 2 **without** `doc_put` when the source is unavailable, so the room keeps its last good table.
- **`skills/scheduled-panel/SKILL.md`** — documents the fire-record sources, the instant-walk, `"$SUTANDO_PY"` in the scheduled invocation, and the refuse-to-publish rule.

## Evidence

Parent control — the previous head's sources (`2014bb03`) under the new suites:

```
tests/cron-eval.test.py                       FAIL/ERROR ×6 (boundary-as-fire, payload ts, writer-driven record, host zone, $SUTANDO_PY, DST agreement)
tests/scheduled-panel-publish-schedule.test.py ERROR ×5 (strict source, main refuses, empty schedule)
```

At head:

```
tests/cron-eval.test.py                        Ran 29 tests  OK
tests/scheduled-panel-publish-schedule.test.py Ran 20 tests  OK
tests/cron-runner.test.py                      ALL PASSED
health-check-cron-runner / durable-cron-reconcile / dashboard-schedule-delegation /
dashboard-editable-schedules / codex-scheduler (×3) / cron-lateness / runtime-api-edge-gaps   all OK
diff-cover vs origin/main: 251/252 lines (99.6%); the miss is the __main__ guard
scripts/review-checks.sh --diff PASS; lint-workspace-resolution clean; docs-audit PASS; git diff --check clean
```

DST agreement, measured against the codex `tick()` predicate (real minute slots judged in America/Los_Angeles):

```
ordinary     panel == tick == 2026-09-03T13:00Z
spring gap   30 2 * * *  after 2026-03-08T08:00Z  -> 2026-03-09T09:30Z (the nonexistent 02:30 PST is skipped)
fall fold    30 1 * * *  after 2026-11-01T08:31Z  -> 2026-11-01T09:30Z (the second 01:30, the slot tick() enqueues)
host offset  0 6 1 12 *  under TZ=America/New_York -> 2026-12-01T11:00Z (a fixed PDT offset gave 13:00Z)
```

Fire record, driven through `cron-runner.run()` itself: a `* * * * *` shell job leaves `__fired__` at its slot; `0 0 31 2 *` advances its boundary to now and the panel renders `—`.

Live publish (02:23Z, earlier head): the room's `activity/SCHEDULE.md` round trip was read back from the vault.

## Merge order

Not stacked; base `main`.
