### PR TITLE
ci(coverage): trace multiprocessing children; outbox-race pools use forkserver

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,6 +14,9 @@ parallel = True
 # combinable after the worktrees are removed (parallel-suite-lane.sh).
 relative_files = True
 sigterm = True
+# Children of a multiprocessing test get their own tracer + data fragment
+# instead of inheriting (fork) or losing (spawn/forkserver) the parent's.
+concurrency = multiprocessing
 source =
     src
     scripts

--- a/tests/outbox-race.test.py
+++ b/tests/outbox-race.test.py
@@ -1,5 +1,21 @@
 import json
 import multiprocessing as mp
+import contextlib
+# forkserver, not fork: a forked worker inherits a lock the parent's tracer
+# thread holds under coverage, and the pool then hangs in terminate() on CI.
+_CTX = mp.get_context("forkserver")
+
+
+@contextlib.contextmanager
+def _pool(n):
+    # close()+join(), never Pool.__exit__: that terminate()s, which kills
+    # workers mid-flush (empty coverage fragments) and is the CI hang site.
+    p = _CTX.Pool(n)
+    try:
+        yield p
+    finally:
+        p.close()
+        p.join()
 import os
 import sys
 import tempfile
@@ -66,7 +82,7 @@ if __name__ == "__main__":
     totals = []
     # ONE warm pool here too, for the reason phase 2 already states: a fresh pool
     # per round pays process startup inside the window under test.
-    with mp.Pool(N) as pool:
+    with _pool(N) as pool:
         def acquire_round(r):
             with tempfile.TemporaryDirectory() as tmp:
                 os.makedirs(os.path.join(tmp, ".claims"), exist_ok=True)  # pre-make so mkdir isn't the serializer
@@ -87,7 +103,7 @@ if __name__ == "__main__":
     orphan_flags = []
     # ONE warm pool for every round. A fresh pool per round pays process startup
     # inside the window under test, which staggers the workers and hides the race.
-    with mp.Pool(N) as pool:
+    with _pool(N) as pool:
         def reclaim_round(r):
             with tempfile.TemporaryDirectory() as tmp:
                 item = f"item-reclaim-{r}"


### PR DESCRIPTION
## Problem

`tests/outbox-race.test.py` timed out (>240s) under the Coverage Gate on three unrelated PRs tonight — #3690 (cleared on rerun), #3710 (twice, incl. a rerun) — the stalling class tracked in #3146. The same test runs in about a second without instrumentation, locally and in the `python standalone tests` job, so this is a coverage-under-fork defect, not the exclusion proof failing.

## Evidence — before (CI, #3710's Coverage Gate run 33702043317, job 100483206388)

#3638's faulthandler dump at the kill:

```
✖ test TIMED OUT under instrumentation (>240s): tests/outbox-race.test.py
Fatal Python error: Aborted
  File ".../multiprocessing/synchronize.py", line 95 in __enter__     <- worker: lock acquire
  File ".../multiprocessing/queues.py", line 386 in get
  File ".../multiprocessing/pool.py", line 114 in worker
  ...
  File ".../multiprocessing/pool.py", line 149 in join                <- parent: __exit__ -> terminate -> join
  File ".../multiprocessing/pool.py", line 732 in _terminate_pool
  File "/tmp/.../tests/outbox-race.test.py", line 69 in <module>
  File ".../coverage/execfile.py", line 222 in run
timeout: the monitored command dumped core
```

The parent is in the pool's `__exit__` → `terminate()` → `join()`; the worker is parked in `queues.get()` on a `synchronize` lock. A forked child inherits every lock the parent held at fork time, including the one coverage's tracer thread holds, and the pool cannot finish. That is why it only happens under `coverage run`.

## Fix

- **`.coveragerc`: `concurrency = multiprocessing`.** Children get their own tracer and data fragment (`parallel` is already on and `scripts/coverage-gate.sh` already combines). Under fork today the child runs on the parent's inherited tracer; under spawn/forkserver it runs untraced and the writers the test exists to exercise are invisible to the gate.
- **`tests/outbox-race.test.py`: pools come from a `forkserver` context and exit by `close()`+`join()`, not `Pool.__exit__`.** A forkserver worker starts from a clean server process and cannot inherit a held lock. `__exit__` calls `terminate()`, which is the frame in the dump and which also kills workers mid-flush: every gate-shaped run at the first push left 1–3 **zero-byte** `.coverage.*` fragments that `coverage combine` reported as errored; with `close()`+`join()` there are none across 3 gate-shaped runs and a full-size run. Same exclusion proof, same (already instrumentation-scaled) rounds; workers stay module-level and the body under `__main__`, which forkserver requires. The other multiprocessing suites already use `spawn` (`owner-activity-atomic-write`) or deliberately test fork inheritance (`task-workstreams`), so they are unchanged.

## Evidence — after (local, macOS, `coverage run --rcfile=.coveragerc`, gate-shaped invocation)

| start method | without `concurrency` | with `concurrency = multiprocessing` |
|---|---|---|
| fork | 0.9s PASS, `src/outbox.py` 42% (inherited tracer) | 6.8s PASS, 52% |
| spawn | 3.2s PASS, 29% (workers untraced) | 3.7s PASS, 52% |
| forkserver | 1.1s PASS, 29% (workers untraced) | 3.1s PASS, 52% |

All five suites that use multiprocessing or the outbox ran gate-shaped under the new rc and passed. With `close()`+`join()`: 0 zero-byte fragments, `Combined 9 files, skipped 20`, no errored files (3 gate-shaped repeats + 1 full-size run); `src/outbox.py` 51% under the gate-shaped run.

## Witness

The hang does not reproduce locally on any start method (fork included), so the Coverage Gate run on this branch is the live witness: `tests/outbox-race.test.py` must finish under instrumentation on ubuntu. If it still stalls there, the dump will say where and this PR is wrong about the mechanism.

Refs #3146. `scripts/review-checks.sh --diff` PASS.
