### PR TITLE
feat(pool): SUTANDO_WORKER_ID/SEAT become the env surface; CORE_ID a one-release alias

### DIFF
--- a/scripts/core-status.sh
+++ b/scripts/core-status.sh
@@ -23,7 +23,7 @@ STEP="${2-}"
 # Discord bridge renders `step` live and graceful-restart gates busy() on it.
 # NUMERIC only — the pool plist assigns 1..N, while a main core carries
 # something else ('legacy' here) or nothing, and silence authorises a kill.
-case "${SUTANDO_CORE_ID-}" in
+case "${SUTANDO_WORKER_SEAT-${SUTANDO_CORE_ID-}}" in
 	'' | *[!0-9]* ) ;;                 # unset / non-numeric -> a main core, write
 	* ) exit 0 ;;                      # 1, 2, 3... -> a pool follower, no-op
 esac

--- a/scripts/install-core-pool.sh
+++ b/scripts/install-core-pool.sh
@@ -438,6 +438,8 @@ for i in $CORE_INDICES; do
   <key>EnvironmentVariables</key>
   <dict>
     <key>SUTANDO_CORE_ID</key><string>$i</string>
+    <key>SUTANDO_WORKER_SEAT</key><string>$i</string>
+    <key>SUTANDO_WORKER_ID</key><string>worker-$i</string>
     <key>SUTANDO_CORE_POOL_SIZE</key><string>$N</string>
 $SWEEP_NUDGE_ENTRY
     <key>POOL_REPO_DIR</key><string>$REPO_DIR</string>

--- a/skills/proactive-loop-pool/CODEX.md
+++ b/skills/proactive-loop-pool/CODEX.md
@@ -113,7 +113,7 @@ task: <id>
 EOF
 ```
 
-End every user-facing body with `— core-<n>`, plain text, never bracketed.
+End every user-facing body with `— worker-<n>` (formerly core-<n>; owner renamed 2026-08-31), plain text, never bracketed.
 
 ## What a Codex follower must not do
 

--- a/skills/proactive-loop-pool/SKILL.md
+++ b/skills/proactive-loop-pool/SKILL.md
@@ -66,7 +66,7 @@ The affinity machinery is **inside** `claim_task.py` — your only responsibilit
 
 Use the renamed `task-<id>.claimed-core-<n>.txt` path for all subsequent reads + result writes.
 
-**Core attribution (required, owner request 2026-08-23):** end every user-facing result body with a final line naming your core, em-dash form: `— core-<n>`. Plain text only — never a bracketed form (`[core-N]` would trip ag2space's `team_result_guard`, which withholds bodies carrying bracketed control markers). Skip the signature only on `[deduped:]`/`[no-send]` bodies, which no user reads.
+**Core attribution (required, owner request 2026-08-23):** end every user-facing result body with a final line naming your worker, em-dash form: `— worker-<n>` (formerly core-<n>; owner renamed 2026-08-31 — one core, N workers). Plain text only — never a bracketed form (`[core-N]` would trip ag2space's `team_result_guard`, which withholds bodies carrying bracketed control markers). Skip the signature only on `[deduped:]`/`[no-send]` bodies, which no user reads.
 
 **Completion step (required):** compose every result body starting with the line `task: <id>` (the id from your claimed file's name), then complete via the helper — one command replaces the manual write/flag/archive trio:
 


### PR DESCRIPTION
## What

One commit (2026-08-31): the pool's per-worker environment is named `SUTANDO_WORKER_ID` / `SUTANDO_WORKER_SEAT` (matching the owner's 08-27 "one core, N workers" naming), with `SUTANDO_CORE_ID` kept as a one-release alias.

- `scripts/install-core-pool.sh` +2 — the plist gains `SUTANDO_WORKER_SEAT` and `SUTANDO_WORKER_ID=worker-N`.
- `scripts/core-status.sh` — reads the new name, falls back to the alias.
- `skills/proactive-loop-pool/SKILL.md`, `CODEX.md` — one line each naming the new surface.

4 files, +5 / −3.

## Why

Lived only on the local rescue worktree; the owner asked for every local-only engine change to be put up as a PR. Cherry-picked with `-x` onto the current tip of `rescue/pool-uncommitted-2026-08-26`.

**Stacked PR:** parent is #3604 (adopt the rescue line). Merge order: #3604 first, then this.

## Evidence

Base `rescue/pool-uncommitted-2026-08-26` @ `115d72d8`.

```
$ bash scripts/review-checks.sh --diff /tmp/wt-pr-poolenv.diff
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
    (prose-cap scans .py only; this diff has none)

$ bash -n scripts/install-core-pool.sh && bash -n scripts/core-status.sh   → both parse
$ python3 tests/core-status-atomic-write.test.py            → ALL PASS
$ python3 tests/core-status-follower-guard.test.py          → OK — 0 failure(s)
$ bash tests/core-status-sh-python-resolution.test.sh       → PASS — 5/5 core-status.sh resolution checks
$ python3 tests/pool-follower-beat.test.py                  → OK
```

Live path note: the running pool on this host was installed before this change and still carries `SUTANDO_CORE_ID` only; the alias keeps it working, and the new names appear on the next `install-core-pool.sh` run.

— sutando-qingyun-001 (worker-1), at the owner's request