### PR TITLE
docs(startup): invoke /schedule-crons instead of hand-rolling CronCreate — the skill writes the stamp health-check reads

### DIFF
--- a/skills/startup/SKILL.md
+++ b/skills/startup/SKILL.md
@@ -49,6 +49,9 @@ Invoke `/schedule-crons`. This handles:
   **Not `skills/schedule-crons/crons.json`.** That path is git-ignored and installer-managed: `src/init.sh` seeds it from `crons.example.json` when it is absent and leaves it untouched when it is present. So the in-checkout copy holds whatever the host last left there — shipped sample jobs, or a stale legacy schedule — and nothing keeps it in step with the per-host file. `skills/schedule-crons/SKILL.md` records the move; `/startup` was never updated to match, so registering from the in-checkout copy silently replaces the host's real schedule with legacy state.
 - Starting the streaming task watcher via the `Monitor` tool (`bash src/watch-tasks-stream.sh`, persistent, description `"Streaming task watcher"`) — **first**, before any cron is registered (2026-08-24: moved ahead of registration so a task arriving during the registration loop isn't queued unprocessed; see `skills/schedule-crons/SKILL.md` step 1.5 for the measured impact)
 - Calling `CronCreate` for each entry that isn't already scheduled
+- Invoke the skill rather than hand-rolling `CronCreate` from this list: `/schedule-crons` also writes
+  `<workspace>/hosts/<hostname>/schedule-crons-stamp.json`, which health-check's `session-crons` probe reads —
+  a hand-rolled registration leaves that probe reporting the crons as never registered.
 - Ensuring a fallback `/proactive-loop` cron exists at `*/10 * * * *` if `crons.json` doesn't include one (post-#954 belt-and-suspenders)
 
 ### Step 3 — Confirm


### PR DESCRIPTION
## What

Three lines in `skills/startup/SKILL.md`, step 2: say explicitly that `/schedule-crons` must be *invoked*, not re-implemented from the bullet list, because the skill also writes `<workspace>/hosts/<hostname>/schedule-crons-stamp.json`, and health-check's `session-crons` probe reads that file. A hand-rolled `CronCreate` loop registers the crons but leaves the probe reporting them as never registered.

## Why

This note was sitting as an uncommitted edit in the main core's checkout (written against an older SKILL.md that still named the pre-migration `crons.json` path; `main` has since fixed the path, so only the invoke/stamp point remained to port). The owner asked for every local-only engine change to be put up as a PR.

## Evidence

The claim is checked against `main`, not inferred:

```
$ git grep -n 'schedule-crons-stamp' origin/main
skills/schedule-crons/SKILL.md:84:   STAMP="$WS/hosts/$(bash scripts/sutando-config.sh host-label)/schedule-…
src/health-check.py:1127:    `hosts/<hostname>/schedule-crons-stamp.json` when it finishes; if that
src/health-check.py:1215:    stamp_file = workspace / "hosts" / host / "schedule-crons-stamp.json"
tests/health-check-session-cron-stamp.test.py:54:  …schedule-crons-stamp.json…

$ bash scripts/review-checks.sh --diff /tmp/wt-doc.diff
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
```

— sutando-qingyun-001 (worker-1), at the owner's request