### PR TITLE
fix(notify-reviewers): refuse a shorthand PR ask before it is sent

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -236,6 +236,27 @@ def command_for(target: dict, message: str) -> "list[str]":
 
 _PR_URL = re.compile("github[.]com/([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)/pull/([0-9]+)")
 
+# `owner/repo#12` and a bare `#12`. Two digits minimum: `#1` is far more often
+# prose than a PR, and a guard that cries wolf gets routed around.
+_PR_SHORTHAND = re.compile(
+    r"(?:(?P<repo>[A-Za-z0-9._-]+/[A-Za-z0-9._-]+)#|(?<![\w/#])#)(?P<num>[0-9]{2,})")
+
+
+def unrecordable_pr_refs(message: str) -> list:
+    """Shorthand PR references record_asks() will not log: (token, form that works).
+
+    Absence is never reported — an ask need not concern a PR. Only shorthand is,
+    because that is the case that reads as a PR reference and records nothing.
+    """
+    recorded = {num for _, num in _PR_URL.findall(message)}
+    out = []
+    for m in _PR_SHORTHAND.finditer(message):
+        if m.group("num") in recorded:
+            continue
+        repo = m.group("repo") or "<owner>/<repo>"
+        out.append((m.group(0), f"https://github.com/{repo}/pull/{m.group('num')}"))
+    return out
+
 def ledger_path() -> Path:
     from workspace_default import resolve_workspace
     return Path(resolve_workspace()) / "state" / "review-asks.jsonl"
@@ -430,6 +451,14 @@ def main() -> int:
         return refusal_rc if refusal_rc > 0 else 5
     if a.allow_single and len(targets) < 2:
         print(f"single-reviewer ask allowed: {a.allow_single}", file=sys.stderr)
+    if a.send and a.kind == "ask":
+        loose = unrecordable_pr_refs(a.message)
+        if loose:
+            print("REFUSED: this ask would DELIVER and record NOTHING. record_asks() logs "
+                  "only full github.com/<owner>/<repo>/pull/<n> URLs, so pr-unattended would "
+                  "read the PR as never asked. Refused reference(s), and the form that works: "
+                  + "; ".join(f"{tok} -> {fix}" for tok, fix in loose), file=sys.stderr)
+            return 7
     stale, why = _stale_repeat_ask(a.message, targets, load_roster()) if a.kind == "ask" else (False, "")
     if stale and not a.widen_override:
         print(f"REFUSED: {why} Re-asking the same people is not escalation — "

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -236,8 +236,8 @@ def command_for(target: dict, message: str) -> "list[str]":
 
 _PR_URL = re.compile("github[.]com/([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)/pull/([0-9]+)")
 
-# `owner/repo#12` and a bare `#12`. Two digits minimum: `#1` is far more often
-# prose than a PR, and a guard that cries wolf gets routed around.
+# `owner/repo#12` and a bare `#12`. Two digits minimum is a DELIBERATE trade, not
+# an oversight: `#7` is a real PR and passes silently, but `#1` is usually prose.
 _PR_SHORTHAND = re.compile(
     r"(?:(?P<repo>[A-Za-z0-9._-]+/[A-Za-z0-9._-]+)#|(?<![\w/#])#)(?P<num>[0-9]{2,})")
 
@@ -248,13 +248,16 @@ def unrecordable_pr_refs(message: str) -> list:
     Absence is never reported — an ask need not concern a PR. Only shorthand is,
     because that is the case that reads as a PR reference and records nothing.
     """
-    recorded = {num for _, num in _PR_URL.findall(message)}
+    pairs = set(_PR_URL.findall(message))
+    nums = {num for _, num in pairs}
     out = []
     for m in _PR_SHORTHAND.finditer(message):
-        if m.group("num") in recorded:
+        repo, num = m.group("repo"), m.group("num")
+        # Pair-keyed when the repo is known: a URL to one repo must not suppress
+        # another repo's same-numbered shorthand. Bare `#n` can only match a number.
+        if (repo, num) in pairs if repo is not None else num in nums:
             continue
-        repo = m.group("repo") or "<owner>/<repo>"
-        out.append((m.group(0), f"https://github.com/{repo}/pull/{m.group('num')}"))
+        out.append((m.group(0), f"https://github.com/{repo or '<owner>/<repo>'}/pull/{num}"))
     return out
 
 def ledger_path() -> Path:

--- a/tests/sci-notify-reviewers-shorthand-refusal.test.py
+++ b/tests/sci-notify-reviewers-shorthand-refusal.test.py
@@ -91,6 +91,19 @@ class Shorthand(unittest.TestCase):
     def test_shorthand_for_a_pr_already_named_by_url_is_not_flagged(self):
         self.assertEqual(self.mod.unrecordable_pr_refs(f"{URL} — i.e. #4242"), [])
 
+    def test_a_url_to_ANOTHER_repo_does_not_cover_a_colliding_number(self):
+        # Low PR numbers collide across repos constantly, so keying on the number
+        # alone let this guard's own failure mode arrive through the guard.
+        out = self.mod.unrecordable_pr_refs(
+            "https://github.com/ag2-space/backend/pull/12 and sonichi/sutando#12")
+        self.assertEqual([t for t, _ in out], ["sonichi/sutando#12"])
+        self.assertEqual(out[0][1], "https://github.com/sonichi/sutando/pull/12")
+
+    def test_CONTROL_a_url_and_the_SAME_repo_shorthand_is_still_allowed(self):
+        msg = "https://github.com/sonichi/sutando/pull/12 and sonichi/sutando#12"
+        self.assertEqual(self.mod.unrecordable_pr_refs(msg), [],
+                         "keying on the pair must not start refusing the same-repo case")
+
     def test_a_single_digit_hash_is_prose_not_a_pr(self):
         self.assertEqual(self.mod.unrecordable_pr_refs("point #1 is wrong"), [])
 

--- a/tests/sci-notify-reviewers-shorthand-refusal.test.py
+++ b/tests/sci-notify-reviewers-shorthand-refusal.test.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""An ask naming a PR in shorthand must be refused BEFORE it is sent.
+
+`record_asks()` logs only full github.com/<owner>/<repo>/pull/<n> URLs. Every
+other shape -- `#3760`, `sonichi/sutando#3622` -- delivers cleanly and records
+nothing, so pr-unattended then reads a correctly-asked PR as NOBODY_EVER_ASKED.
+#3562 made that loud, but the warning prints AFTER the send: it names a loss it
+cannot prevent. The same note was filed twice in three days by an agent who did
+not remember filing it the first time, which is the point-of-use guard failing
+at its own job rather than a discipline problem.
+
+Both polarities are asserted. Refusing shorthand is worthless if it also refuses
+the legitimate ask that names no PR at all, because a guard a caller cannot
+satisfy gets routed around and then there is neither guard nor warning.
+
+Run: python3 tests/sci-notify-reviewers-shorthand-refusal.test.py   (stdlib only)
+"""
+import importlib.util
+import io
+import json
+import contextlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = (Path(__file__).resolve().parent.parent / "skills"
+          / "collaboration-intelligence" / "scripts" / "notify_reviewers.py")
+URL = "https://github.com/sonichi/sutando/pull/4242"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_nr_short", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Sent:
+    returncode = 0
+    stdout = json.dumps({"ok": True, "event_id": "$stub"})
+    stderr = ""
+
+
+class Shorthand(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+        self.tmp = tempfile.TemporaryDirectory()
+        d = Path(self.tmp.name)
+        self.ledger = d / "review-asks.jsonl"
+        roster = {k: {"stand": f"@{k}-stand:x", "room": "!r:x", "human": f"@{k}:x"}
+                  for k in ("alice", "bob")}
+        self.roster_file = d / "roster.json"
+        self.roster_file.write_text(json.dumps(roster))
+        self.calls = []
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, message, extra=None):
+        def fake_run(args, **kw):
+            self.calls.append(args)
+            return _Sent()
+        argv = ["--reviewers", "alice,bob", "--message", message, "--send"] + (extra or [])
+        err = io.StringIO()
+        with patch.object(self.mod, "ledger_path", lambda: self.ledger), \
+             patch.object(self.mod, "roster_path", lambda: self.roster_file), \
+             patch.object(self.mod.subprocess, "run", fake_run), \
+             patch.object(self.mod.sys, "argv", ["notify_reviewers.py"] + argv), \
+             contextlib.redirect_stderr(err):
+            rc = self.mod.main()
+        return rc, err.getvalue()
+
+    # --- the helper, in isolation ----------------------------------------
+
+    def test_a_bare_hash_number_is_unrecordable(self):
+        out = self.mod.unrecordable_pr_refs("please review #3760 today")
+        self.assertEqual([t for t, _ in out], ["#3760"])
+        self.assertEqual(out[0][1], "https://github.com/<owner>/<repo>/pull/3760")
+
+    def test_owner_repo_shorthand_yields_the_EXACT_url(self):
+        out = self.mod.unrecordable_pr_refs("see sonichi/sutando#3622")
+        self.assertEqual(out[0][1], "https://github.com/sonichi/sutando/pull/3622")
+
+    def test_a_full_url_is_recordable(self):
+        self.assertEqual(self.mod.unrecordable_pr_refs(f"review {URL}"), [])
+
+    def test_a_message_naming_no_pr_is_not_flagged(self):
+        self.assertEqual(self.mod.unrecordable_pr_refs("can you look at the roster?"), [])
+
+    def test_shorthand_for_a_pr_already_named_by_url_is_not_flagged(self):
+        self.assertEqual(self.mod.unrecordable_pr_refs(f"{URL} — i.e. #4242"), [])
+
+    def test_a_single_digit_hash_is_prose_not_a_pr(self):
+        self.assertEqual(self.mod.unrecordable_pr_refs("point #1 is wrong"), [])
+
+    # --- the refusal, through main() -------------------------------------
+
+    def test_an_ask_naming_a_pr_in_shorthand_is_REFUSED_before_sending(self):
+        rc, err = self._run("please review #3760")
+        self.assertEqual(rc, 7)
+        self.assertEqual(self.calls, [], "refused ask must not reach room_ops")
+        self.assertEqual(self._ledger(), [], "nothing recorded either")
+
+    def test_the_refusal_says_what_it_refused_AND_what_would_satisfy_it(self):
+        _, err = self._run("please review sonichi/sutando#3622")
+        self.assertIn("sonichi/sutando#3622", err)
+        self.assertIn("https://github.com/sonichi/sutando/pull/3622", err)
+
+    def test_CONTROL_a_full_url_ask_sends(self):
+        rc, _ = self._run(f"please review {URL}")
+        self.assertEqual(rc, 0)
+        self.assertGreater(len(self.calls), 0, 'the ask must actually be sent')
+
+    def test_CONTROL_an_ask_with_no_pr_at_all_still_sends(self):
+        rc, _ = self._run("can you look at the roster when you get a moment?")
+        self.assertEqual(rc, 0, "an ask need not concern a PR; refusing it breaks the tool")
+        self.assertGreater(len(self.calls), 0, 'the ask must actually be sent')
+
+    def test_a_notice_is_not_refused(self):
+        rc, _ = self._run("heads up on #3760", extra=["--kind", "notice"])
+        self.assertEqual(rc, 0, "a notice records nothing by design, so it cannot lose a record")
+
+    def _ledger(self):
+        if not self.ledger.exists():
+            return []
+        return [x for x in self.ledger.read_text().splitlines() if x.strip()]
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`record_asks()` logs only `github.com/<owner>/<repo>/pull/<n>`. Every other shape delivers cleanly and records nothing, so `pr-unattended` reads a correctly-asked PR as `NOBODY_EVER_ASKED`:

```
full URL                    refs=1  LOGGED
sonichi/sutando#3622        refs=0  SILENTLY DROPPED
#3760                       refs=0  SILENTLY DROPPED
```

That table is from #3562, which measured it and made the loss **loud**. The wording is right; the *position* is not — the warning prints after the send, so it names a loss it structurally cannot prevent.

## Why a note was not enough

The remaining guard was a note at the point of use, in the roster's `_routing_practice`. It failed at its own job: I filed that note on 2026-09-01 after dropping `sonichi/sutando#3622`, then on 2026-09-03 made the identical mistake with `#3760`, went to file a note about it, **and found I had already written it**. A guard whose only mechanism is that someone recalls it does not become more effective by being louder.

## The change

The check moves ahead of the send, and refuses **shorthand only — never absence**:

| message | before | after |
|---|---|---|
| `#3760` | sends, records nothing, warns after | **REFUSED (rc 7)** |
| `sonichi/sutando#3622` | sends, records nothing, warns after | **REFUSED (rc 7)** |
| full URL | sends, records | sends, records |
| no PR mentioned at all | sends | **sends** — unchanged |
| `--kind notice` with `#3760` | sends | **sends** — a notice records nothing by design |

The absence case is deliberate. An ask need not concern a PR, and a guard that also blocks the legitimate no-PR ask gets routed around within a week — then there is neither guard nor warning.

Per @yixuan-ag2's one design request, the refusal states what it refused **and** what would satisfy it, constructing the exact URL when the shorthand carries the repo:

```
REFUSED: this ask would DELIVER and record NOTHING. record_asks() logs only full
github.com/<owner>/<repo>/pull/<n> URLs, so pr-unattended would read the PR as
never asked. Refused reference(s), and the form that works:
sonichi/sutando#3622 -> https://github.com/sonichi/sutando/pull/3622
```

`#1` is not treated as a PR — two digits minimum, because prose says "point #1" far more often than it names PR 1, and a guard that cries wolf gets demoted.

## Evidence

Parent (fix reverted, new test retained):

```
Ran 11 tests in 0.015s
FAILED (failures=2, errors=6)
```

At HEAD:

```
Ran 11 tests in 0.011s
OK
```

Siblings at HEAD, all `rc=0`:

```
sci-notify-reviewers.test.py                Ran 29 tests  OK
sci-notify-reviewers-kind.test.py           Ran 8 tests   OK
sci-notify-reviewers-refusal-basis.test.py  Ran 9 tests   OK
sci-notify-reviewers-inproc.test.py         Ran 57 tests  OK
notify-reviewers-human-shapes.test.py       Ran 8 tests   OK
```

`uvx ruff check` clean on both changed files.

## Provenance

Requested by @yixuan-ag2, who authored #3562 and owns the "loud, not fatal" choice this changes. I raised the two-instance evidence rather than working around their decision; they asked for the refusal and specified the satisfiable-refusal requirement above.