### PR TITLE
fix(discord-bridge): team-tier block 2b writes [no-send] so the routed task archives

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -4109,7 +4109,7 @@ async def _handle_discord_message(message, force=False):
             "   - On FAILURE (non-zero — stalled=125 / hit cap=124 / gh-or-codex error): FALL BACK to owner-ping — write results/proactive-{ts}.txt (who asked, which PR link, that the auto-review failed), and do NOT write results/task-{id}.txt. Owner-ping is the FALLBACK here, not the default.\n"
             "2b. MESSAGE OWNER — when the task needs owner decision for any OTHER reason (authorization, scope question, merge direction, repeated echo):\n"
             "   - Write a single proactive message to results/proactive-{ts}.txt summarizing what the sender asked and why it needs owner attention.\n"
-            "   - Do NOT write to results/task-{id}.txt (no sender reply).\n\n"
+            "   - Then write exactly `[no-send]` to results/task-{id}.txt: the bridge delivers nothing for that marker (no sender reply) and archives the task. A task left with no result stays in tasks/ forever, where health-check's task-queue probe and the end-of-pass queue check report it as unanswered.\n\n"
             "3. NO-REPLY — when the task is echo/noise:\n"
             "   - Content is EXACTLY a Stage-2 fallback sentinel: the legacy 'Sandbox unavailable; refusing non-owner task.', or 'Sandbox unavailable (codex exit <N>) — no reply generated.', or 'Sandbox unavailable (codex exited 0 with no output) — no reply generated.'. Exact match only — a message that merely BEGINS with those words (e.g. 'Sandbox unavailable after upgrading — can you diagnose it?') is ordinary prose and goes to RUN CODEX\n"
             "   - Content is empty / punctuation-only / meta-chatter about the relay itself\n"

--- a/tests/discord-bridge-team-rulebook-2b-archives.test.py
+++ b/tests/discord-bridge-team-rulebook-2b-archives.test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Block 2b (MESSAGE OWNER) of the team-tier rulebook must archive the task.
+
+Measured 2026-09-03 on a live host: a team-tier ask was routed to the owner
+exactly as 2b said — proactive file written, no task result — and the task
+then sat in tasks/ for 21 minutes, health-check's task-queue probe warned
+"undrained past 900s", and the end-of-pass queue checker (#3732) reported it
+UNANSWERED. The rulebook's own instruction produced the queue defect the rest
+of the system treats as a miss. `[no-send]` is the marker that delivers
+nothing AND archives, so 2b must say to write it.
+
+Run: python3 tests/discord-bridge-team-rulebook-2b-archives.test.py
+"""
+import re
+import unittest
+from pathlib import Path
+
+SRC = (Path(__file__).resolve().parent.parent / "src" / "discord-bridge.py").read_text()
+
+
+def block_2b(text: str) -> str:
+    start = text.index("2b. MESSAGE OWNER")
+    end = text.index("3. NO-REPLY", start)
+    return text[start:end]
+
+
+class Block2bArchives(unittest.TestCase):
+    def test_2b_instructs_a_no_send_result_so_the_task_archives(self):
+        b = block_2b(SRC)
+        self.assertIn("[no-send]", b)
+        self.assertIn("results/task-{id}.txt", b)
+
+    def test_2b_no_longer_forbids_the_task_result(self):
+        b = block_2b(SRC)
+        self.assertNotIn("Do NOT write to results/task-{id}.txt", b)
+
+    def test_2b_still_routes_the_content_to_the_owner(self):
+        b = block_2b(SRC)
+        self.assertIn("results/proactive-{ts}.txt", b)
+
+    def test_positive_control_the_old_wording_would_fail(self):
+        old = SRC.replace("Then write exactly `[no-send]` to results/task-{id}.txt", "Do NOT write to results/task-{id}.txt (no sender reply)")
+        b = block_2b(old)
+        self.assertIn("Do NOT write to results/task-{id}.txt", b)
+        self.assertNotIn("[no-send]", b.split("Do NOT")[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Priority
**Level:** medium. **Reason:** the team-tier rulebook's own instruction leaves a task in the queue forever; measured tonight, and it is the defect the new end-of-pass queue check (#3732) reports as a miss.

## Closes
No issue. Raised first as a finding on #3732 (option (a) there); this is that option.

## What happens on `main`
Block 2b of the team-tier rulebook (`src/discord-bridge.py:4110-4112`) says: write `results/proactive-{ts}.txt`, and *"Do NOT write to results/task-{id}.txt (no sender reply)"*. The bridge archives a task only when its result is delivered or skipped, so a 2b task has no exit path.

**Live instance (this host, 2026-09-03):** a team-tier ask in #game at 03:43Z was routed per 2b at 03:44Z. At 04:04Z:
```
⚠ task-queue   warn   1 unassigned task(s) queued, oldest 1259s — undrained past 900s
unanswered-tasks.py (#3732 at head):  UNANSWERED task-1788407007400 — no result file; the room heard nothing
```
Draining it by hand meant writing `[no-send]` to the task result — which is exactly what the marker exists for: delivers nothing (the "no sender reply" 2b wanted) and archives.

## Change
One sentence in 2b: after the proactive file, write exactly `[no-send]` to `results/task-{id}.txt`, with the reason. `tests/discord-bridge-team-rulebook-2b-archives.test.py` pins the paragraph: it must name `[no-send]`, still route content to the proactive file, and no longer carry the forbidding line — plus a positive control that the old wording fails the pin.

## Evidence
```
$ python3 tests/discord-bridge-team-rulebook-2b-archives.test.py     OK (4 tests)
$ /usr/bin/python3 (3.9.6) …/discord-bridge-team-rulebook-2b-archives.test.py   OK
$ python3 tests/discord-bridge-prose-marker.test.py; tests/bridge-marker-no-leak.test.py   PASS PASS
$ bash scripts/review-checks.sh --diff <this diff>   (output pasted below by CI as well)
$ python3 -c "import ast; ast.parse(open('src/discord-bridge.py').read())"   parses
```
Not a live-path behaviour change: the bridge's delivery code is untouched; only the rulebook text the core reads changes, so the witness is the drained queue above (the same marker, written by hand, archived the task within seconds).

## Checklist
- [x] No other open PR covers this (`gh pr list --search "2b no-send"`: none)
- [x] Git author email is the GH-mapped noreply
- [x] Single concern
- [x] Test added with a positive control
- [x] Before/after evidence pasted
- [x] No host paths in added lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
