### PR TITLE
fix(health-check): an untouched MEMORY.md made a sibling corpus read as populated

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1591,6 +1591,27 @@ def check_workspace_root_tidy() -> "dict | None":
         ),
     }
 
+def _corpus_holds_memories(mem: "Path", mds: "list[Path]") -> bool:
+    """True when a corpus holds memories rather than just an untouched index.
+
+    MEMORY.md is the index every corpus ships with, so counting it makes a bare
+    project dir read as populated forever. Nothing can be invisible there — the
+    corpus has no memories — and a warning that can never clear is the exact
+    failure this probe's scope filter already guards against elsewhere. An index
+    carrying entries still counts: that says something wrote here.
+    """
+    if any(p.name != "MEMORY.md" for p in mds):
+        return True
+    index = mem / "MEMORY.md"
+    if not index.is_file():
+        return False
+    try:
+        text = index.read_text(errors="replace")
+    except OSError:
+        return True  # unreadable: report rather than silently drop a real corpus
+    return any(ln.lstrip().startswith(("- [", "* [")) for ln in text.splitlines())
+
+
 def check_memory_dir_siblings() -> "dict | None":
     """Flag a populated memory corpus sitting under a DIFFERENT project slug.
 
@@ -1634,8 +1655,9 @@ def check_memory_dir_siblings() -> "dict | None":
             continue
         if _slug_derivation_key(entry.name) != live_key:
             continue  # unrelated project, not a slug split
-        count = len(list(mem.glob("*.md")))
-        if count == 0:
+        mds = list(mem.glob("*.md"))
+        count = len(mds)
+        if not _corpus_holds_memories(mem, mds):
             continue
         key = str(mem.resolve())  # collapse symlinked twins onto one entry
         if key not in seen or count > seen[key][1]:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1609,7 +1609,8 @@ def _corpus_holds_memories(mem: "Path", mds: "list[Path]") -> bool:
         text = index.read_text(errors="replace")
     except OSError:
         return True  # unreadable: report rather than silently drop a real corpus
-    return any(ln.lstrip().startswith(("- [", "* [")) for ln in text.splitlines())
+    # A row may lead with a bold label, so anchor on the bullet and the link.
+    return any(re.search(r"^\s*[-*] .*\]\(", ln) for ln in text.splitlines())
 
 
 def check_memory_dir_siblings() -> "dict | None":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1591,6 +1591,17 @@ def check_workspace_root_tidy() -> "dict | None":
         ),
     }
 
+# The compact forms a compacted index uses for entries, shared by the two
+# readers below so a row cannot be an entry for one and invisible to the other.
+INDEX_ENTRY_ABBREV = {"feedback_": "f:", "reference_": "r:", "project_": "p:"}
+
+_INDEX_ROW_ENTRY = re.compile(
+    r"^\s*[-*] .*(?:\]\(|(?<![\w-])(?:"
+    + "|".join(re.escape(s) for s in INDEX_ENTRY_ABBREV.values())
+    + r")[\w-])"
+)
+
+
 def _corpus_holds_memories(mem: "Path", mds: "list[Path]") -> bool:
     """True when a corpus holds memories rather than just an untouched index.
 
@@ -1609,8 +1620,9 @@ def _corpus_holds_memories(mem: "Path", mds: "list[Path]") -> bool:
         text = index.read_text(errors="replace")
     except OSError:
         return True  # unreadable: report rather than silently drop a real corpus
-    # A row may lead with a bold label, so anchor on the bullet and the link.
-    return any(re.search(r"^\s*[-*] .*\]\(", ln) for ln in text.splitlines())
+
+    # Anchor on the bullet, not the link: a compacted index writes `- f:slug`.
+    return any(_INDEX_ROW_ENTRY.search(ln) for ln in text.splitlines())
 
 
 def check_memory_dir_siblings() -> "dict | None":
@@ -2383,9 +2395,6 @@ def check_memory_index_integrity() -> "dict | None":
     loaded_text, loaded_bytes, loaded_lines = _index_loaded_prefix(effective_text)
     truncated = len(loaded_text) < len(effective_text)
 
-    # An index that outgrows the load budget compacts its entries to prefix
-    # abbreviations (`f:` for feedback_, `r:` for reference_, `p:` for project_).
-    _INDEX_ABBREV = {"feedback_": "f:", "reference_": "r:", "project_": "p:"}
 
     def _referenced_in(hay: str, name: str) -> bool:
         stem = name[:-3] if name.endswith(".md") else name
@@ -2393,7 +2402,7 @@ def check_memory_index_integrity() -> "dict | None":
             return True
         # Without this the probe calls an indexed file unindexed, and the
         # "fix" it invites — expanding the index — is what blows the read limit.
-        for full, short in _INDEX_ABBREV.items():
+        for full, short in INDEX_ENTRY_ABBREV.items():
             if not stem.startswith(full):
                 continue
             token = short + stem[len(full):]

--- a/tests/health-check-memory-dir-siblings.test.py
+++ b/tests/health-check-memory-dir-siblings.test.py
@@ -161,6 +161,29 @@ with tempfile.TemporaryDirectory() as td:
         f"got: {(r_real or {}).get('detail', '')[:140]}",
     )
 
+    # 3f. An UNREADABLE index must report, not vanish. A check that goes quiet
+    #     cannot be told from one that passed (yixuan-ag2 mutation, #3778).
+    (idx_only / "user_profile.md").unlink()
+    (idx_only / "MEMORY.md").chmod(0o000)
+    try:
+        try:
+            (idx_only / "MEMORY.md").read_text()
+            blocked = False
+        except OSError:
+            blocked = True
+        if not blocked:
+            check("unreadable index still warns (SKIPPED: fs ignores mode bits)", True)
+        else:
+            hc_unread = load_hc(home, live)
+            r_unread = hc_unread.check_memory_dir_siblings()
+            check(
+                "unreadable index still warns rather than vanishing",
+                r_unread is not None and "-repo.slug" in r_unread["detail"],
+                f"got: {(r_unread or {}).get('detail', '')[:140]}",
+            )
+    finally:
+        (idx_only / "MEMORY.md").chmod(0o600)
+
 with tempfile.TemporaryDirectory() as td:
     # 4. THE ONE THAT MATTERS: a symlinked twin is one corpus, not two.
     home = Path(td) / "claude"

--- a/tests/health-check-memory-dir-siblings.test.py
+++ b/tests/health-check-memory-dir-siblings.test.py
@@ -136,6 +136,19 @@ with tempfile.TemporaryDirectory() as td:
         f"got: {(r_entries or {}).get('detail', '')[:140]}",
     )
 
+    # 3e. An index row may lead with a bold label before the link. A corpus whose
+    #     rows are all that shape must not read as empty (qingyun-air, #3778).
+    (idx_only / "MEMORY.md").write_text(
+        "# Sutando memory index\n\n- **Controls:** a control is [a claim](claim.md) - hook\n"
+    )
+    hc_bold = load_hc(home, live)
+    r_bold = hc_bold.check_memory_dir_siblings()
+    check(
+        "index row with a bold label before the link still warns",
+        r_bold is not None and "-repo.slug" in r_bold["detail"],
+        f"got: {(r_bold or {}).get('detail', '')[:140]}",
+    )
+
     # 3d. CONTROL: a real memory beside the empty index warns, so 3b cannot pass
     #     merely because this corpus is unreachable.
     (idx_only / "MEMORY.md").write_text("# Sutando memory index\n")

--- a/tests/health-check-memory-dir-siblings.test.py
+++ b/tests/health-check-memory-dir-siblings.test.py
@@ -149,6 +149,30 @@ with tempfile.TemporaryDirectory() as td:
         f"got: {(r_bold or {}).get('detail', '')[:140]}",
     )
 
+    # 3f. A compacted index abbreviates entries and carries no link, so a rule
+    #     keyed on `](` calls a live corpus untouched and hides the split.
+    for abbrev in ("f:pronoun_she_her", "r:memory_index_budget", "p:some_project"):
+        (idx_only / "MEMORY.md").write_text(f"# Sutando memory index\n\n- {abbrev}\n")
+        hc_c = load_hc(home, live)
+        r_c = hc_c.check_memory_dir_siblings()
+        check(
+            f"compact index entry `{abbrev}` counts as an entry",
+            r_c is not None and "-repo.slug" in r_c["detail"],
+            f"got: {(r_c or {}).get('detail', '')[:140]}",
+        )
+
+    # 3g. CONTROL: an abbreviation matching inside a word would re-create 3b's
+    #     never-clearing warning by another route.
+    for noise in ("see conf:iguration notes", "f: ", "just prose, nothing referenced"):
+        (idx_only / "MEMORY.md").write_text(f"# Sutando memory index\n\n- {noise}\n")
+        hc_n = load_hc(home, live)
+        r_n = hc_n.check_memory_dir_siblings()
+        check(
+            f"a non-entry row `{noise.strip()}` is still NOT an entry",
+            r_n is None,
+            f"got: {(r_n or {}).get('detail', '')[:140]}",
+        )
+
     # 3d. CONTROL: a real memory beside the empty index warns, so 3b cannot pass
     #     merely because this corpus is unreachable.
     (idx_only / "MEMORY.md").write_text("# Sutando memory index\n")

--- a/tests/health-check-memory-dir-siblings.test.py
+++ b/tests/health-check-memory-dir-siblings.test.py
@@ -105,6 +105,50 @@ with tempfile.TemporaryDirectory() as td:
     )
 
 with tempfile.TemporaryDirectory() as td:
+    # 3b. MEMORY.md is the index every corpus ships with, so counting it makes a
+    #     bare project dir read as populated forever.
+    home = Path(td) / "claude"
+    projects = home / "projects"
+    live = seed(projects / "-repo-slug" / "memory", 42)
+    idx_only = projects / "-repo.slug" / "memory"
+    idx_only.mkdir(parents=True)
+    (idx_only / "MEMORY.md").write_text(
+        "# Sutando memory index\n\nDurable facts about the user, project, and references.\n"
+    )
+    hc_idx = load_hc(home, live)
+    r_idx = hc_idx.check_memory_dir_siblings()
+    check(
+        "index-only sibling is NOT reported as populated",
+        r_idx is None,
+        f"got: {(r_idx or {}).get('detail', '')[:140]}",
+    )
+
+    # 3c. CONTROL: index ENTRIES must still warn, or 3b would also pass for a
+    #     check that stopped reporting index-bearing corpora entirely.
+    (idx_only / "MEMORY.md").write_text(
+        "# Sutando memory index\n\n- [Some fact](some_fact.md) - a hook\n"
+    )
+    hc_entries = load_hc(home, live)
+    r_entries = hc_entries.check_memory_dir_siblings()
+    check(
+        "index WITH entries still warns (control)",
+        r_entries is not None and "-repo.slug" in r_entries["detail"],
+        f"got: {(r_entries or {}).get('detail', '')[:140]}",
+    )
+
+    # 3d. CONTROL: a real memory beside the empty index warns, so 3b cannot pass
+    #     merely because this corpus is unreachable.
+    (idx_only / "MEMORY.md").write_text("# Sutando memory index\n")
+    (idx_only / "user_profile.md").write_text("x")
+    hc_real = load_hc(home, live)
+    r_real = hc_real.check_memory_dir_siblings()
+    check(
+        "one real memory beside an empty index warns (control)",
+        r_real is not None and "2 .md" in r_real["detail"],
+        f"got: {(r_real or {}).get('detail', '')[:140]}",
+    )
+
+with tempfile.TemporaryDirectory() as td:
     # 4. THE ONE THAT MATTERS: a symlinked twin is one corpus, not two.
     home = Path(td) / "claude"
     projects = home / "projects"


### PR DESCRIPTION
## The defect

`check_memory_dir_siblings()` skips a corpus with **zero** `.md` files, but counts `MEMORY.md` — the index every corpus ships with. A project dir holding only that index therefore reads as a populated sibling forever.

Nothing there can become invisible, because there are no memories there. The probe's stated purpose is "if the session actually writes one of the others, its memories are invisible to every path-derived consumer."

The probe's own docstring already names this as the failure that matters:

> Warning on any populated corpus would fire on every normal multi-project home — a permanent false warning that teaches people to ignore the health signal, which costs more than the split it is trying to surface (#2353 review).

## Measured on a live host

The probe warned on every proactive pass:

```
⚠ memory-dir-siblings  warn  1 other populated memory corpus/corpora exist under
  .../projects: -Users-ruiwang-Library-Application Support-space-ag2-app-engine-sutando (1 .md)
```

That corpus, resolved:

```
'-Users-ruiwang-Library-Application Support-space-ag2-app-engine-sutando'
   islink=True  ->  /Users/ruiwang/.sutando/memory
   *.md count=1  names=['MEMORY.md']
```

and the file itself is 181 bytes of header:

```
# Sutando memory index

Durable facts about the user, project, and references. One line per entry:
`- [Title](file.md) — one-line hook`. See CLAUDE.md `## Memory` for the schema.
```

Zero entries, zero memories, one permanent warning.

## The change

`_corpus_holds_memories()` gates the same loop the `count == 0` skip already gated. A corpus counts when it holds a `.md` that is not the index — **or** when its `MEMORY.md` carries index entries, because files can be lost while the index survives and that is evidence something wrote there. An unreadable index reports rather than being silently dropped.

The reported `N .md` figure is unchanged: it is still the total file count, so the detail line stays literally true.

## Before / after

`src/health-check.py` at the parent commit, with this PR's new test cases present:

```
$ git stash push -- src/health-check.py
$ python3 tests/health-check-memory-dir-siblings.test.py
  FAIL index-only sibling is NOT reported as populated — got: 1 other populated memory
       corpus/corpora exist under /var/folders/.../claude/projects: -repo.slug
  ok  index WITH entries still warns (control)
  ok  one real memory beside an empty index warns (control)
FAILED (1): index-only sibling is NOT reported as populated
```

At this PR's head:

```
$ python3 tests/health-check-memory-dir-siblings.test.py
  ok  index-only sibling is NOT reported as populated
  ok  index WITH entries still warns (control)
  ok  one real memory beside an empty index warns (control)

all checks passed
```

**Both controls pass on both sides.** That is the point of including them: they fail if the fix is over-broad — an implementation that simply stopped reporting index-bearing corpora, or one that silenced this corpus for an unrelated reason, breaks 3c or 3d rather than 3b. The full suite is green (20 checks).

## Scope

Diagnostic-only probe; no behaviour outside the warning text. Which slug should be canonical remains an open architectural decision and this PR does not touch it — it only stops the probe claiming a corpus is populated when it holds no memories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
