### PR TITLE
docs(review): a mutation SURVIVED is untrusted until bytecode is invalidated

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -455,6 +455,33 @@ and loads whichever repo it reviews.
     mode *at settle time* — which is also what made it testable under node.
     Cheap form: for each side effect in a newly-async continuation, name the state it
     depends on and check the continuation re-reads it rather than closing over it.
+22. **A mutation-test `SURVIVED` is untrusted until the bytecode cache is invalidated.**
+    Two mutants of the *same byte length*, written within the same mtime second, share a
+    `__pycache__` entry: CPython validates a cached `.pyc` on source **mtime + size**, so the
+    second mutant silently executes the first one's compiled code. It reports SURVIVED, and
+    SURVIVED is the direction that sends someone to "fix" a gap that is not there.
+    *Measured on `scripts/my-stale-approvals.py` + its suite, five mutants, two arms:*
+
+    ```
+    mutant                       cache KEPT   cache CLEARED   mutant size
+    m1 parent-count -> True      CAUGHT       CAUGHT          8217
+    m2 staleness   > -> >=       SURVIVED     SURVIVED        8270
+    m3 commits_after > -> >=     SURVIVED     CAUGHT          8270   <-- flips
+    m4 decisive drops bar        SURVIVED     SURVIVED        8243
+    m5 decisive drops blockers   CAUGHT       CAUGHT          8252
+    ```
+
+    Exactly the colliding pair flips; the three distinctly-sized mutants are unchanged, which
+    is what rules out "the suite is flaky" and names the size collision as the mechanism. m3's
+    mutation is caught by a test *named for it* — `test_a_commit_AT_the_approval_timestamp_
+    does_not_count_as_after`, docstring "Pins the boundary so widening `>` to `>=` cannot pass
+    silently" — so the harness reported SURVIVED about a mutant the suite catches by design.
+    Acting on that report meant nearly replacing a deliberate documented semantic with its
+    opposite, in the name of rigour.
+    **Cure:** unlink `importlib.util.cache_from_source(...)` between mutants, or run the suite
+    with `PYTHONDONTWRITEBYTECODE=1`. **And run one mutant per invocation**, printing the
+    failing test's name for a CAUGHT and ending with a restore-control — a batch loop that
+    restores between iterations is itself stateful, and this collision is invisible inside it.
 
 ## Checks (machine-readable — consumed by scripts/review-checks.sh)
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -471,8 +471,14 @@ and loads whichever repo it reviews.
     m5 decisive drops blockers   CAUGHT       CAUGHT          8252
     ```
 
-    Exactly the colliding pair flips; the three distinctly-sized mutants are unchanged, which
-    is what rules out "the suite is flaky" and names the size collision as the mechanism. m3's
+    The only mutant that flips is **inside** the colliding pair — m3 — while its partner m2
+    (same 8270 bytes) and the three distinctly-sized mutants are unchanged. That asymmetry is
+    what rules out "the suite is flaky": a flaky suite would move mutants at random sizes, and
+    a collision can only corrupt a mutant that *shares* a size with the one written before it.
+    **m2 and m4 survive a CLEARED cache, so they are not artifacts** — the suite genuinely does
+    not catch `staleness > -> >=` or the dropped-bar mutation. Only m3's SURVIVED was false.
+    Stating that because a reader who takes "cache collision" as the explanation for every
+    SURVIVED here would discard two real uncaught mutations along with the artifact. m3's
     mutation is caught by a test *named for it* — `test_a_commit_AT_the_approval_timestamp_
     does_not_count_as_after`, docstring "Pins the boundary so widening `>` to `>=` cannot pass
     silently" — so the harness reported SURVIVED about a mutant the suite catches by design.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -478,8 +478,14 @@ and loads whichever repo it reviews.
     silently" — so the harness reported SURVIVED about a mutant the suite catches by design.
     Acting on that report meant nearly replacing a deliberate documented semantic with its
     opposite, in the name of rigour.
-    **Cure:** unlink `importlib.util.cache_from_source(...)` between mutants, or run the suite
-    with `PYTHONDONTWRITEBYTECODE=1`. **And run one mutant per invocation**, printing the
+    **Cure — and one obvious candidate is not one.** `PYTHONDONTWRITEBYTECODE=1` (and `-B`) stops
+    *writing* a `.pyc`, never *reading* one, so it does nothing once a cache exists — which is the
+    normal state, because the ordinary suite run before you start mutating leaves one. Measured on
+    3.14.6 with a populated cache: source `BBB`, `-B` plus the env var still returned the cached
+    `AAA`; unlinking first returned the new value. Reported on 3.12.14 by @qingyun-air, reproduced
+    here. What works: **unlink `importlib.util.cache_from_source(...)` between mutants**, or point
+    `PYTHONPYCACHEPREFIX` at a fresh temp dir per run (verified: stale `DDD` plain, correct `EEE`
+    and `FFF` under a per-run prefix). **And run one mutant per invocation**, printing the
     failing test's name for a CAUGHT and ending with a restore-control — a batch loop that
     restores between iterations is itself stateful, and this collision is invisible inside it.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -475,31 +475,35 @@ and loads whichever repo it reviews.
     A `checked-hash` cache does not collide at all, so a SURVIVED under one is not explained
     by this lesson; an `unchecked-hash` cache is worse than described, because it never
     revalidates and so stays stale even when size and mtime both change.
-    *Measured on `scripts/my-stale-approvals.py` + its suite, five mutants, two arms:*
+    *Re-derived on `scripts/my-stale-approvals.py` (11,285 B at `fcbd3539`) + its 45-test suite.
+    Mutating one line each, the five variants are 11,259 / 11,286 / 11,286 / 11,259 / 11,268 B —
+    two same-size pairs, m1/m4 and m2/m3:*
 
     ```
-    mutant                       cache KEPT   cache CLEARED   mutant size
-    m1 parent-count -> True      CAUGHT       CAUGHT          8217
-    m2 staleness   > -> >=       SURVIVED     SURVIVED        8270
-    m3 commits_after > -> >=     SURVIVED     CAUGHT          8270   <-- flips
-    m4 decisive drops bar        SURVIVED     SURVIVED        8243
-    m5 decisive drops blockers   CAUGHT       CAUGHT          8252
+    mutant                       alone, cache CLEARED   after a same-size predecessor
+    m1 parent-count -> True      CAUGHT                 -
+    m2 staleness   > -> >=       SURVIVED               -   (genuinely uncaught)
+    m3 commits_after > -> >=     CAUGHT                 SURVIVED   <-- the collision
+    m4 decisive drops bar        CAUGHT                 -
+    m5 decisive drops blockers   CAUGHT                 -
     ```
 
-    The only mutant that flips is **inside** the colliding pair — m3 — while its partner m2
-    (same 8270 bytes) and the three distinctly-sized mutants are unchanged. That asymmetry
-    *localizes* the cause to the colliding pair, which is what makes the cache hypothesis worth
-    testing; it does not by itself rule out flakiness, because a stochastic or input-correlated
-    failure need not move mutants at random sizes. What establishes the cause is the direct
-    pair of controls — stale bytecode kept vs. cache cleared — not the shape of the table.
-    **m2 and m4 survive a CLEARED cache, so they are not artifacts** — the suite genuinely does
-    not catch `staleness > -> >=` or the dropped-bar mutation. Only m3's SURVIVED was false.
-    That is stated explicitly because a reader who takes "cache collision" as the explanation for every
-    SURVIVED here would discard two real uncaught mutations along with the artifact. m3's
-    mutation is caught by a test *named for it* — `test_a_commit_AT_the_approval_timestamp_does_not_count_as_after`, docstring "Pins the boundary so widening `>` to `>=` cannot pass
-    silently" — so the harness reported SURVIVED about a mutant the suite catches by design.
-    Acting on that report meant nearly replacing a deliberate documented semantic with its
-    opposite, in the name of rigour.
+    **The flip is not a property of m3. It is a property of m3 written after m2** — same byte
+    length, same `int(st_mtime)`, cache not cleared between them. Run alone against a cleared
+    cache, m3 is CAUGHT; run immediately after its same-size partner, the suite executes m2's
+    compiled bytes and reports SURVIVED about a mutation the suite catches by design, by a test
+    named for it (`test_a_commit_AT_the_approval_timestamp_does_not_count_as_after`, docstring
+    "Pins the boundary so widening `>` to `>=` cannot pass silently").
+
+    That distinction is the practical warning, and it is why a harness matters more than a rule:
+    a loop that restores the pristine file between mutants never collides, because the pristine
+    size differs from every mutant's. A loop that goes mutant-to-mutant does collide, and only
+    for the same-size pairs. So the danger is not "mutation testing is unreliable" — it is
+    "consecutive same-size variants share a cache entry", which a per-mutant restore removes.
+
+    **m2's SURVIVED is real and must not be swept up in this.** Against a cleared cache it still
+    survives: the suite genuinely does not catch `staleness > -> >=`. A reader who blames the
+    cache for every SURVIVED here would discard a true uncaught mutation along with the artifact.
     **Cure — and one obvious candidate is not one.** `PYTHONDONTWRITEBYTECODE=1` (and `-B`) stops
     *writing* a `.pyc`, never *reading* one, so it does nothing once a cache exists — which is the
     normal state, because the ordinary suite run before you start mutating leaves one. Measured on

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -457,9 +457,24 @@ and loads whichever repo it reviews.
     depends on and check the continuation re-reads it rather than closing over it.
 22. **A mutation-test `SURVIVED` is untrusted until the bytecode cache is invalidated.**
     Two mutants of the *same byte length*, written within the same mtime second, share a
-    `__pycache__` entry: CPython validates a cached `.pyc` on source **mtime + size**, so the
-    second mutant silently executes the first one's compiled code. It reports SURVIVED, and
-    SURVIVED is the direction that sends someone to "fix" a gap that is not there.
+    `__pycache__` entry **when the cache is CPython's default timestamp mode** (`flags == 0`):
+    that mode validates on source `int(st_mtime)` + byte size, so the second mutant silently
+    executes the first one's compiled code. It reports SURVIVED, and SURVIVED is the direction
+    that sends someone to "fix" a gap that is not there.
+
+    The mode matters, so check it before reaching for this explanation. Driving all three
+    invalidation modes through `spec_from_file_location`, same path, same size, same
+    `int(mtime)` (CPython 3.13.5 and 3.14.6 agree):
+
+    ```
+    timestamp       flags=0  serves STALE bytecode   <-- the collision above
+    checked-hash    flags=3  detects the rewrite
+    unchecked-hash  flags=1  serves STALE bytecode, and needs neither condition
+    ```
+
+    A `checked-hash` cache does not collide at all, so a SURVIVED under one is not explained
+    by this lesson; an `unchecked-hash` cache is worse than described, because it never
+    revalidates and so stays stale even when size and mtime both change.
     *Measured on `scripts/my-stale-approvals.py` + its suite, five mutants, two arms:*
 
     ```
@@ -472,15 +487,16 @@ and loads whichever repo it reviews.
     ```
 
     The only mutant that flips is **inside** the colliding pair — m3 — while its partner m2
-    (same 8270 bytes) and the three distinctly-sized mutants are unchanged. That asymmetry is
-    what rules out "the suite is flaky": a flaky suite would move mutants at random sizes, and
-    a collision can only corrupt a mutant that *shares* a size with the one written before it.
+    (same 8270 bytes) and the three distinctly-sized mutants are unchanged. That asymmetry
+    *localizes* the cause to the colliding pair, which is what makes the cache hypothesis worth
+    testing; it does not by itself rule out flakiness, because a stochastic or input-correlated
+    failure need not move mutants at random sizes. What establishes the cause is the direct
+    pair of controls — stale bytecode kept vs. cache cleared — not the shape of the table.
     **m2 and m4 survive a CLEARED cache, so they are not artifacts** — the suite genuinely does
     not catch `staleness > -> >=` or the dropped-bar mutation. Only m3's SURVIVED was false.
-    Stating that because a reader who takes "cache collision" as the explanation for every
+    That is stated explicitly because a reader who takes "cache collision" as the explanation for every
     SURVIVED here would discard two real uncaught mutations along with the artifact. m3's
-    mutation is caught by a test *named for it* — `test_a_commit_AT_the_approval_timestamp_
-    does_not_count_as_after`, docstring "Pins the boundary so widening `>` to `>=` cannot pass
+    mutation is caught by a test *named for it* — `test_a_commit_AT_the_approval_timestamp_does_not_count_as_after`, docstring "Pins the boundary so widening `>` to `>=` cannot pass
     silently" — so the harness reported SURVIVED about a mutant the suite catches by design.
     Acting on that report meant nearly replacing a deliberate documented semantic with its
     opposite, in the name of rigour.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -464,7 +464,8 @@ and loads whichever repo it reviews.
 
     The mode matters, so check it before reaching for this explanation. Driving all three
     invalidation modes through `spec_from_file_location`, same path, same size, same
-    `int(mtime)` (CPython 3.13.5 and 3.14.6 agree):
+    `int(mtime)` (CPython 3.13.5 and 3.14.6 agree), **under the interpreter's default
+    `check-hash-based-pycs` policy**:
 
     ```
     timestamp       flags=0  serves STALE bytecode   <-- the collision above
@@ -472,9 +473,21 @@ and loads whichever repo it reviews.
     unchecked-hash  flags=1  serves STALE bytecode, and needs neither condition
     ```
 
-    A `checked-hash` cache does not collide at all, so a SURVIVED under one is not explained
-    by this lesson; an `unchecked-hash` cache is worse than described, because it never
-    revalidates and so stays stale even when size and mtime both change.
+    Under that same default policy, a `checked-hash` cache does not collide at all, so a
+    SURVIVED under one is not explained by this lesson; an `unchecked-hash` cache is worse
+    than described, because it never revalidates and so stays stale even when size and mtime
+    both change. **Both statements are policy-conditional, and the flag inverts them** —
+    PEP 552's `--check-hash-based-pycs` overrides the per-file bit in either direction.
+    Measured on 3.14.6, rebuilding the cache for every row so no run inherits the previous
+    one's rewrite:
+
+    ```
+    unchecked-hash  flags=1  default -> STALE    always -> caught    never -> STALE
+    checked-hash    flags=3  default -> caught   always -> caught    never -> STALE
+    ```
+
+    So `always` rescues the mode this lesson calls hopeless, and `never` breaks the one it
+    calls safe. Read the policy before trusting either row.
     *Re-derived on `scripts/my-stale-approvals.py` (11,285 B at `fcbd3539`) + its 45-test suite.
     Mutating one line each, the five variants are 11,259 / 11,286 / 11,286 / 11,259 / 11,268 B —
     two same-size pairs, m1/m4 and m2/m3:*

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -496,10 +496,14 @@ and loads whichever repo it reviews.
     "Pins the boundary so widening `>` to `>=` cannot pass silently").
 
     That distinction is the practical warning, and it is why a harness matters more than a rule:
-    a loop that restores the pristine file between mutants never collides, because the pristine
-    size differs from every mutant's. A loop that goes mutant-to-mutant does collide, and only
-    for the same-size pairs. So the danger is not "mutation testing is unreliable" — it is
-    "consecutive same-size variants share a cache entry", which a per-mutant restore removes.
+    a loop that restores the pristine file between mutants **and runs it** never collides, because
+    that run is what makes CPython observe the pristine size and rewrite the entry. A restore that
+    is written but never imported does not: CPython never sees the intermediate file, so m2's entry
+    still matches m3's size and mtime and serves m2's bytes. Measured both ways at this head —
+    write m2, run, write pristine WITHOUT running, write m3, run reports SURVIVED; the same m3
+    against a cleared cache reports CAUGHT, as does the same sequence with the pristine restore
+    executed. So the danger is "consecutive same-size variants share a cache entry", and the
+    remedies are clearing the cache or a restore that executes. A restore alone is not one.
 
     **m2's SURVIVED is real and must not be swept up in this.** Against a cleared cache it still
     survives: the suite genuinely does not catch `staleness > -> >=`. A reader who blames the


### PR DESCRIPTION
## The trap

Mutation testing is a standard several of us apply in reviews here. It has a silent failure mode on any module loaded through `importlib.util.spec_from_file_location`:

**Two mutants of the same byte length, written within the same mtime second, share a `__pycache__` entry.** CPython validates a cached `.pyc` on source **mtime + size**, so the second mutant executes the *first one's* compiled code — and reports `SURVIVED`.

`SURVIVED` is the dangerous direction. It sends someone to write a test for a gap that is not there, or worse, to "fix" behaviour that is already correct and pinned.

## Measured, two arms

Same five mutants against `scripts/my-stale-approvals.py` and its suite, run twice — once leaving `__pycache__` alone, once unlinking it before each run:

```
mutant                       cache KEPT   cache CLEARED   mutant size
m1 parent-count -> True      CAUGHT       CAUGHT          8217
m2 staleness   > -> >=       SURVIVED     SURVIVED        8270
m3 commits_after > -> >=     SURVIVED     CAUGHT          8270   <-- flips
m4 decisive drops bar        SURVIVED     SURVIVED        8243
m5 decisive drops blockers   CAUGHT       CAUGHT          8252
```

**Exactly the colliding pair flips.** The three distinctly-sized mutants are identical across both arms, which is what rules out "the suite is flaky" and names the size collision as the mechanism. m2 and m3 are both 8270 bytes; m3 inherits m2's bytecode, and m2's mutation passes.

## Why it mattered concretely

m3's mutation is caught by a test *named for it*:

```
test_a_commit_AT_the_approval_timestamp_does_not_count_as_after
    "Pins the boundary so widening `>` to `>=` cannot pass silently."
```

So the harness reported SURVIVED about a mutant the suite catches **by design and by name**. I acted on that report: wrote the "fix" plus a test asserting the opposite semantics, and only found out when the existing test failed. Two minutes later I would have pushed a change that inverted a deliberate, documented boundary — on my own PR, while performing rigour.

## The cure, both halves

- Unlink `importlib.util.cache_from_source(...)` between mutants, or run with `PYTHONDONTWRITEBYTECODE=1`.
- **One mutant per invocation**, printing the failing test's name on a CAUGHT and ending with a restore-control. A batch loop that restores between iterations is itself stateful, and this collision is invisible from inside it.

## Scope

`REVIEW.md` only — no code, no behaviour change. Per CLAUDE.md, adding or editing a lesson is a PR to `REVIEW.md` alone. The `checks:` block is untouched, so `scripts/review-checks.sh` behaviour is unchanged.

Also worth noting for reviewers: this is a first-hand incident report, not a general-knowledge write-up. The numbers above are from one reproduction I can re-run on request; the collision is deterministic given equal sizes and a shared mtime second, but how often that co-occurs in practice will vary with harness speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
