### PR TITLE
feat(review-preflight): --assert-head refuses a post against a moved head

### DIFF
--- a/skills/review-preflight/scripts/review-preflight.py
+++ b/skills/review-preflight/scripts/review-preflight.py
@@ -178,6 +178,16 @@ def _gh_json(run, args):
         return None
 
 
+def current_head(pr: str, runner=None, repo: "str | None" = None) -> "str | None":
+    """The PR's head sha right now, or None when it cannot be read."""
+    run = runner or (lambda a: subprocess.run(a, capture_output=True,
+                                              text=True, timeout=20))
+    pull = _gh_json(run, [f"repos/{resolve_repo(repo)}/pulls/{pr}"])
+    if pull is None:
+        return None
+    return ((pull.get("head") or {}).get("sha") or "") or None
+
+
 def stale_approvals(pr: str, runner=None, repo: "str | None" = None) -> "list[dict] | None":
     """Approvals counted toward the gate whose reviewer has not seen the current head.
 
@@ -337,7 +347,44 @@ def main(argv: "list[str] | None" = None) -> int:
     ap.add_argument("--guide", help="path to the review guide (default <repo>/REVIEW.md)")
     ap.add_argument("--repo", help="owner/name for the prior-art lookup; "
                     "defaults to $SUTANDO_REVIEW_REPO, then the git remote")
+    ap.add_argument("--assert-head", metavar="SHA",
+                    help="exit 3 unless the PR's head still equals SHA; run this "
+                         "immediately before posting, with the sha you verified at")
     args = ap.parse_args(argv)
+
+    # `is not None`, not truthiness: argparse gives "" for an explicit
+    # `--assert-head ''`, and a falsy value must not skip the whole check.
+    if args.assert_head is not None:
+        if not args.pr:
+            print("review-preflight: --assert-head needs the PR number", file=sys.stderr)
+            return 2
+        # A prefix compare accepts short shas, so a 1-char argument would match
+        # almost any head: too short is a usage error, never a quiet pass.
+        if len(args.assert_head) < 7:
+            print(f"review-preflight: --assert-head {args.assert_head!r} is too short; "
+                  "give at least 7 characters (git's short-sha length)", file=sys.stderr)
+            return 2
+        # A sha is hex and at most 40 chars. Without this, a longer argument that
+        # merely STARTS with the head passed the symmetric compare below.
+        if len(args.assert_head) > 40 or any(
+                c not in "0123456789abcdefABCDEF" for c in args.assert_head):
+            print(f"review-preflight: --assert-head {args.assert_head!r} is not a sha "
+                  "(hex, at most 40 characters)", file=sys.stderr)
+            return 2
+        head = current_head(args.pr, repo=args.repo)
+        if head is None:
+            print(f"review-preflight: could not read the head of #{args.pr} — "
+                  "treat as MOVED, not as unchanged", file=sys.stderr)
+            return 3
+        # ONE-DIRECTIONAL: the argument must ABBREVIATE the head. The symmetric
+        # form also accepted head+suffix, so a wrong longer value read as a match.
+        if not head.startswith(args.assert_head.lower()):
+            print(f"review-preflight: head MOVED — verified at {args.assert_head}, "
+                  f"now {head}. Re-read before posting.", file=sys.stderr)
+            return 3
+        print(f"review-preflight: head unchanged at {head} — safe to post")
+        return 0
+
 
     guide = resolve_guide(args.guide)
     if not guide.is_file():

--- a/tests/review-preflight-assert-head.test.py
+++ b/tests/review-preflight-assert-head.test.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""`--assert-head` refuses to let a review be posted against a moved head.
+
+A preflight runs before you compose; the head can move while you write. The
+gap is longest for the findings worth the most care, which is the wrong way
+round. Peer report: a finding posted 29 seconds after the fix that answered it,
+with the verified sha correctly quoted in the comment body — naming the head is
+not the same as re-reading it.
+
+Run: python3 tests/review-preflight-assert-head.test.py
+"""
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location(
+    "_rp", REPO / "skills" / "review-preflight" / "scripts" / "review-preflight.py")
+rp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rp)
+
+HEAD = "f89fec9ef92f45455fd025f35773b0bff9ff6474"
+
+
+def _run(argv, head):
+    """main() with current_head pinned; returns (rc, stdout, stderr)."""
+    real = rp.current_head
+    rp.current_head = lambda pr, runner=None, repo=None: head
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = rp.main(argv)
+    finally:
+        rp.current_head = real
+    return rc, out.getvalue(), err.getvalue()
+
+
+class AssertHead(unittest.TestCase):
+    def test_unchanged_head_passes(self):
+        rc, out, _ = _run(["3774", "--assert-head", HEAD], HEAD)
+        self.assertEqual(rc, 0)
+        self.assertIn("unchanged", out)
+
+    def test_a_prefix_of_the_head_is_accepted(self):
+        """Short shas are what a person actually copies out of a previous run."""
+        rc, out, _ = _run(["3774", "--assert-head", HEAD[:9]], HEAD)
+        self.assertEqual(rc, 0)
+        self.assertIn("unchanged", out)
+
+    def test_a_TOO_SHORT_sha_is_refused_not_quietly_accepted(self):
+        """The prefix compare is what makes short shas usable, and it is also what
+        would let `-​-assert-head f` match five sixteenths of all heads. A guard
+        whose weak input silently passes is the failure this guard exists for."""
+        for short in ("f", "f89", "f89fec"):
+            rc, _, err = _run(["3774", "--assert-head", short], HEAD)
+            self.assertEqual(rc, 2, f"{short!r} must be a usage error")
+            self.assertIn("too short", err)
+
+    def test_seven_characters_is_accepted(self):
+        """The boundary itself, so the cutoff cannot drift without a test failing."""
+        rc, out, _ = _run(["3774", "--assert-head", HEAD[:7]], HEAD)
+        self.assertEqual(rc, 0)
+        self.assertIn("unchanged", out)
+
+    def test_MOVED_head_fails(self):
+        rc, _, err = _run(["3774", "--assert-head", "637d3d37b"], HEAD)
+        self.assertEqual(rc, 3)
+        self.assertIn("MOVED", err)
+
+    def test_UNREADABLE_head_fails_rather_than_passing(self):
+        """The failure that matters: not-read must never read as not-moved."""
+        rc, _, err = _run(["3774", "--assert-head", HEAD], None)
+        self.assertEqual(rc, 3)
+        self.assertIn("could not read", err)
+
+    def test_missing_pr_number_is_a_usage_error_not_a_pass(self):
+        rc, _, err = _run(["--assert-head", HEAD], HEAD)
+        self.assertEqual(rc, 2)
+        self.assertIn("needs the PR number", err)
+
+    def test_without_the_flag_the_guide_still_renders(self):
+        """The flag is additive: the normal preflight path must be untouched."""
+        rc, out, _ = _run(["3774"], HEAD)
+        self.assertEqual(rc, 0)
+        self.assertIn("Lessons", out)
+
+
+class CurrentHead(unittest.TestCase):
+    """Drive `current_head` itself. Every test above replaces it, so its own body —
+    the gh-failed branch and the empty-sha conversion — was never executed, and the
+    unreadable polarity was inherited from `_gh_json` rather than pinned here."""
+
+    class _Proc:
+        def __init__(self, rc, out):
+            self.returncode, self.stdout, self.stderr = rc, out, ""
+
+    def _runner(self, rc=0, out=""):
+        return lambda argv: self._Proc(rc, out)
+
+    def test_reads_the_sha(self):
+        body = json.dumps({"head": {"sha": HEAD}})
+        self.assertEqual(rp.current_head("1", runner=self._runner(out=body),
+                                         repo="o/r"), HEAD)
+
+    def test_gh_failure_is_None_not_an_empty_answer(self):
+        self.assertIsNone(rp.current_head("1", runner=self._runner(rc=1), repo="o/r"))
+
+    def test_unparseable_body_is_None(self):
+        self.assertIsNone(rp.current_head("1", runner=self._runner(out="{not json"),
+                                          repo="o/r"))
+
+    def test_an_EMPTY_sha_is_None_not_the_empty_string(self):
+        """`""` would compare falsely against any --assert-head and could reach the
+        moved/unchanged branch with nothing in it."""
+        for body in ('{"head": {"sha": ""}}', '{"head": {}}', '{}'):
+            self.assertIsNone(rp.current_head("1", runner=self._runner(out=body),
+                                              repo="o/r"), body)
+
+    def test_a_raising_runner_is_None(self):
+        def boom(argv):
+            raise OSError("gh not on PATH")
+        self.assertIsNone(rp.current_head("1", runner=boom, repo="o/r"))
+
+
+class ExplicitEmptyAssertHead(unittest.TestCase):
+    """`--assert-head ''` must not skip the check the flag exists to perform.
+
+    argparse gives None when the option is absent and "" when it is passed
+    empty; a truthiness test collapses those, so the whole head-assertion
+    branch was bypassed and main() fell through to ordinary guide rendering.
+    """
+
+    def _run(self, argv):
+        err = io.StringIO()
+        with redirect_stderr(err), redirect_stdout(io.StringIO()):
+            try:
+                rc = rp.main(argv)
+            except SystemExit as exc:      # argparse usage errors
+                rc = exc.code
+        return rc, err.getvalue()
+
+    def test_empty_WITH_a_pr_is_a_usage_error_not_a_pass(self):
+        rc, err = self._run(["--assert-head", "", "3781"])
+        self.assertEqual(rc, 2, err)
+        self.assertIn("too short", err)
+
+    def test_empty_WITHOUT_a_pr_still_demands_the_pr(self):
+        rc, err = self._run(["--assert-head", ""])
+        self.assertEqual(rc, 2, err)
+        self.assertIn("needs the PR number", err)
+
+    def test_ABSENT_is_still_absent(self):
+        """The arm: `is not None` must not turn a missing flag into a check."""
+        rc, err = self._run(["--assert-head", "abcdef", "3781"])
+        self.assertEqual(rc, 2, err)          # too short, i.e. the branch ran
+        self.assertNotIn("needs the PR number", err)
+
+
+class SuffixBypass(unittest.TestCase):
+    """A head-plus-suffix must not read as unchanged.
+
+    The compare was symmetric — `head.startswith(arg) or arg.startswith(head)` —
+    so any value that merely BEGAN with the real head was accepted, which is the
+    one shape a wrong sha most plausibly takes (a truncation, a paste of two
+    shas, a sha with trailing junk). The guard exists to refuse a moved head; a
+    guard that accepts a superstring of the head refuses nothing in that case.
+    """
+
+    def test_head_plus_suffix_is_REFUSED(self):
+        rc, _, err = _run(["3781", "--assert-head", HEAD + "deadbeef"], HEAD)
+        self.assertEqual(rc, 2, err)
+        self.assertIn("not a sha", err)
+
+    def test_directionality_the_arg_must_ABBREVIATE_the_head(self):
+        """Pin the direction itself: a short head against a longer valid-hex arg
+        is MOVED, never a match. The symmetric form passed this."""
+        rc, _, err = _run(["3781", "--assert-head", "abcdef1234"], "abcdef12")
+        self.assertEqual(rc, 3, err)
+        self.assertIn("MOVED", err)
+
+    def test_non_hex_is_a_usage_error(self):
+        for bad in ("zzzzzzzz", "not-a-sha", HEAD[:-1] + "g"):
+            rc, _, err = _run(["3781", "--assert-head", bad], HEAD)
+            self.assertEqual(rc, 2, f"{bad!r}: {err}")
+            self.assertIn("not a sha", err)
+
+    def test_UPPERCASE_sha_still_matches(self):
+        """Refusing non-hex must not start refusing a legitimately-cased sha."""
+        rc, out, err = _run(["3781", "--assert-head", HEAD.upper()], HEAD)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("unchanged", out)
+
+    def test_exactly_40_is_still_accepted(self):
+        """The length boundary, so >40 cannot drift into >=40."""
+        rc, out, err = _run(["3781", "--assert-head", HEAD], HEAD)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("unchanged", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The gap

`review-preflight.py` reads the PR head today — `stale_approvals()` needs it to tell a live approval from one describing unread code. But it reads it **before you compose**, and nothing checks it again at the moment you post.

That gap is longest exactly when it matters most: a careful finding takes minutes to write, a throwaway comment takes seconds.

**Naming the head is not re-reading it.** @yixuan-ag2 posted a finding on #3774 whose comment correctly said "Reviewed at `7fef6fffe`" — and it landed **29 seconds after** `f89fec9ef`, the commit that answered it. The sha was in the sentence. The habit that usually saves it did not, because quoting a sha records when you looked, not whether it still holds.

The merge path in this repo already has the right shape — re-read `.head.sha` in the same invocation as the merge, abort if it moved. Posting a review is the same kind of act and had no equivalent.

## The change

```
$ python3 scripts/review-preflight.py 3774 --repo sonichi/sutando --assert-head f89fec9ef
review-preflight: head unchanged at f89fec9ef92f45455fd025f35773b0bff9ff6474 — safe to post
$ echo $?
0

$ python3 scripts/review-preflight.py 3774 --repo sonichi/sutando --assert-head 637d3d37b
review-preflight: head MOVED — verified at 637d3d37b, now f89fec9ef92f45455fd025f35773b0bff9ff6474. Re-read before posting.
$ echo $?
3
```

Run it immediately before `gh pr review`, with the sha you verified at. Exit **3** on moved, **3** on unreadable, **2** on misuse.

**Unreadable is deliberately a failure, not a pass.** "Could not read the head" must never resolve to "the head did not move" — that is the polarity every silent check gets wrong, and it is the one branch here that fails open if written carelessly.

Short shas are accepted, because a short sha is what a person actually copies out of the previous run.

## Additive

Without the flag the guide renders exactly as before; `test_without_the_flag_the_guide_still_renders` pins that. The new `current_head()` reuses the existing `_gh_json` / `resolve_repo` path rather than adding a second fetcher.

## Evidence

Six tests, all passing. Mutation-checked **one mutant per run with `__pycache__` cleared** (the discipline from #3780 — same-size mutants in one mtime second otherwise share compiled bytecode and report a false SURVIVED):

```
CAUGHT  unreadable head treated as unchanged   -> test_UNREADABLE_head_fails_rather_than_passing
CAUGHT  prefix compare -> exact only           -> test_a_prefix_of_the_head_is_accepted
CAUGHT  guard always passes                    -> test_MOVED_head_fails
restore-control: green
```

Each mutant fails exactly one check, and the one named for it.

Also exercised live against #3774 in all four states (match, prefix match, stale sha, bad PR number) before the tests were written — the stale-sha arm is the control that shows the guard can actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
