### PR TITLE
fix(pool): a host sleep is not N dead followers, so reclaim defers a window (re-homed on the rescue line)

### DIFF
--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -483,9 +483,11 @@ class PoolLead:
         return w, m, du
 
     def _save_wake_evidence(self, wall: float, mono: float,
-                            defer_until: "float | None" = None) -> bool:
-        """Publish this lead's wake sample. False = not published, so a caller
-        can observe the loss instead of trusting a silent best-effort write."""
+                            defer_until: "float | None" = None
+                            ) -> "tuple[bool, float | None]":
+        """Publish this lead's wake sample; return (published, effective).
+        `effective` is the deadline the record now CARRIES, which may be
+        another lead's — decide from it, never from the pre-merge value."""
         p = self._wake_evidence_path()
         # Per-writer temp name, as pool_status does: briefly overlapping leads
         # are supported, and a shared temp lets one consume the other's bytes.
@@ -494,37 +496,42 @@ class PoolLead:
             # One lock across load..replace: unique temps stop a torn record,
             # not a stale write erasing a deadline opened since its load.
             with self._wake_lock():
-                payload = {"wall": wall, "mono": mono}
+                prior = self._load_wake_evidence()
+                # The loader bounds a deadline by the STORED mono, so an
+                # older sample beside a newer deadline voids grace on read.
+                if prior is not None and prior[1] > mono:
+                    wall, mono = prior[0], prior[1]
                 # The window belongs to the wake event, not to whoever ticked
                 # last, so the MAXIMUM still-open deadline survives.
-                prior = self._load_wake_evidence()
                 open_du = prior[2] if prior is not None else None
                 if open_du is not None and mono < open_du:
                     defer_until = (open_du if defer_until is None
                                    else max(defer_until, open_du))
+                payload = {"wall": wall, "mono": mono}
                 if defer_until is not None:
                     payload["defer_until"] = defer_until
                 p.parent.mkdir(parents=True, exist_ok=True)
                 tmp.write_text(json.dumps(payload))
                 os.replace(tmp, p)
-            return True
+            return True, defer_until
         except OSError:
             try:
                 tmp.unlink()
             except OSError:
                 pass
-            return False
+            return False, None
 
     def _publish_wake(self, wall: float, mono: float,
-                      defer_until: "float | None") -> bool:
+                      defer_until: "float | None") -> "tuple[bool, float | None]":
         """Publish the wake sample and REPORT a loss. A silent best-effort
         write is what let a failed publish renew the same window forever."""
-        if self._save_wake_evidence(wall, mono, defer_until):
-            return True
+        published, effective = self._save_wake_evidence(wall, mono, defer_until)
+        if published:
+            return True, effective
         print("pool-lead: wake evidence not published "
               f"(defer_until={defer_until}); grace cannot be bounded",
               file=sys.stderr, flush=True)
-        return False
+        return False, None
 
     def _host_gap_defers_reclaim(self) -> bool:
         """Host-sleep evidence is wall-vs-monotonic SKEW across the lead's
@@ -569,7 +576,12 @@ class PoolLead:
             if followers and not any(self.alive_fn(f) for f in followers):
                 self._reclaim_defer_until = mono + LEAD_STALE_S
         du = getattr(self, "_reclaim_defer_until", None)
-        if not self._publish_wake(now, mono, du):
+        published, effective = self._publish_wake(now, mono, du)
+        # Decide from the COMMITTED deadline: a peer's open grace binds this
+        # lead too, and it is only visible in what the record actually holds.
+        if effective is not None and (du is None or effective > du):
+            self._reclaim_defer_until = du = effective
+        if not published:
             # The one-window bound lives IN the record a successor seeds from;
             # unpublished, every restart re-opens grace. Refuse, don't renew.
             self._reclaim_defer_until = None

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -27,7 +27,7 @@ from task_priority import sort_tasks_by_priority  # noqa: E402
 from pool_follower import LEAD_STALE_S  # noqa: E402
 
 # tick gap past one beat period = host sleep; shorter can't stale a beat
-HOST_GAP_S = 30.0
+SLEEP_SKEW_S = 5.0  # wall clock advances through host sleep; monotonic pauses
 
 # Depth at which channelless work overflows to the idle lane core; room
 # affinity itself is binding and never yields on load (owner 2026-08-26).
@@ -124,7 +124,7 @@ def _read_lane(path: Path) -> str:
 class PoolLead:
     def __init__(self, tasks_dir, state_dir, followers_fn, alive_fn,
                  now_fn=time.time, metrics=None, results_dir=None,
-                 runtime_fn=None):
+                 mono_fn=time.monotonic, runtime_fn=None):
         """followers_fn() -> list of instance ids eligible for assignment.
         alive_fn(instance) -> bool (fresh heartbeat). Both injected — the
         production binder wires instance_registry + the .alive files.
@@ -141,6 +141,7 @@ class PoolLead:
         self.followers_fn = followers_fn
         self.alive_fn = alive_fn
         self.now = now_fn
+        self.mono = mono_fn
         self.metrics = metrics  # PoolMetrics or None; recording is optional
 
     # ── affinity table (single-writer: the lead) ────────────────────────────
@@ -440,22 +441,25 @@ class PoolLead:
 
     # ── crash recovery ──────────────────────────────────────────────────────
     def _host_gap_defers_reclaim(self) -> bool:
-        """Host-gap evidence comes from the LEAD'S OWN tick cadence: reclaim
-        entrypoints run every ~2s, so a large gap between calls means the host
-        slept — independent of which follower happens to re-beat first
-        (staggered 30s beats make sibling-before-claimant an ordinary wake).
+        """Host-sleep evidence is wall-vs-monotonic SKEW across the lead's
+        own tick, not mere tick-gap size: the monotonic clock pauses through
+        host sleep while wall time advances, so skew is definitive — and an
+        awake-but-slow daemon (long --interval, GC stall) shows wall ~= mono,
+        gets no grace, and cannot renew the deferral.
 
         The grace window, once opened, expires by TIME ONLY — a sibling
         heartbeat must not end it while the claim owner's beat is still due.
-        A genuine outage (no tick gap) is never deferred mid-run.
         """
         now = self.now()
+        mono = self.mono()
         last = getattr(self, "_last_reclaim_tick", None)
+        last_mono = getattr(self, "_last_reclaim_mono", None)
         self._last_reclaim_tick = now
-        if last is not None:
-            if now - last > HOST_GAP_S:
+        self._last_reclaim_mono = mono
+        if last is not None and last_mono is not None:
+            if (now - last) - (mono - last_mono) > SLEEP_SKEW_S:
                 self._reclaim_defer_until = now + LEAD_STALE_S
-        else:
+        elif last is None:
             # fresh lead + all-stale pool: indistinguishable from a
             # post-wake lead restart — grace one window
             try:

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -24,6 +24,7 @@ from pathlib import Path
 _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE.parent))
 from task_priority import sort_tasks_by_priority  # noqa: E402
+from pool_follower import LEAD_STALE_S  # noqa: E402
 
 # Depth at which channelless work overflows to the idle lane core; room
 # affinity itself is binding and never yields on load (owner 2026-08-26).
@@ -435,10 +436,34 @@ class PoolLead:
         return out
 
     # ── crash recovery ──────────────────────────────────────────────────────
+    def _host_gap_defers_reclaim(self) -> bool:
+        """Every follower stale in the same instant is a host gap (sleep, clock
+        jump), not N deaths — beats stop together only when the machine does.
+
+        Defers one stale window rather than suppressing: a woken follower
+        re-beats within it, while a genuine whole-pool outage still reclaims
+        once the window passes.
+        """
+        try:
+            followers = list(self.followers_fn())
+        except Exception:  # noqa: BLE001 — a broken resolver must not defer
+            return False
+        if not followers:
+            return False
+        if any(self.alive_fn(f) for f in followers):
+            self._reclaim_defer_until = None
+            return False
+        now = self.now()
+        if getattr(self, "_reclaim_defer_until", None) is None:
+            self._reclaim_defer_until = now + LEAD_STALE_S
+        return now < self._reclaim_defer_until
+
     def reclaim_dead(self) -> "list[str]":
         """Return dead followers' assignments to the unassigned pool.
         Claimed files are NOT touched here — a claim means work may have
         side-effected; that recovery keeps the done-flag path (L2)."""
+        if self._host_gap_defers_reclaim():
+            return []
         reclaimed = []
         pat = re.compile(r"^(task-[A-Za-z0-9._~-]+)\.assigned-(.+)\.txt$")
         try:
@@ -516,6 +541,8 @@ class PoolLead:
         session's wrapper keeps its heartbeat fresh, so reclaim_dead never
         fires — unclaimed age is the only signal. No claim = no work started,
         so repooling cannot double-fire a side effect."""
+        if self._host_gap_defers_reclaim():
+            return []
         pat = re.compile(r"^(task-[A-Za-z0-9._~-]+)\.assigned-(.+)\.txt$")
         ledger = self._load_assign_ledger()
         out = []
@@ -606,6 +633,8 @@ class PoolLead:
         deliver (sweep skips it). The reachable crash residue is a result
         with no done-flag — finish_task writes the result first — and that
         work is COMPLETE, so it must not be repooled for re-execution."""
+        if self._host_gap_defers_reclaim():
+            return []
         out = []
         pat = re.compile(r"^(task-[A-Za-z0-9._~-]+)\.claimed-(.+)\.txt$")
         try:

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -489,6 +489,10 @@ class PoolLead:
             m = pat.match(f.name)
             if not m or self.alive_fn(m.group(2)):
                 continue
+            # Same post-liveness re-check as the claimed variant: the entry
+            # guard cannot see a suspension that begins after it sampled.
+            if self._host_gap_defers_reclaim():
+                return reclaimed
             try:
                 os.rename(f, f.with_name(m.group(1) + ".txt"))
             except OSError:
@@ -660,6 +664,10 @@ class PoolLead:
             m = pat.match(f.name)
             if not m or self.alive_fn(m.group(2)):
                 continue
+            # Suspension can begin BETWEEN the entry guard and this liveness
+            # read, which would make a live owner read dead. Re-check first.
+            if self._host_gap_defers_reclaim():
+                return out
             canonical = m.group(1) + ".txt"
             try:
                 os.rename(f, f.with_name(canonical))

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -20,6 +20,7 @@ import re
 import sys
 import time
 from pathlib import Path
+from uuid import uuid4
 
 _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE.parent))
@@ -475,20 +476,33 @@ class PoolLead:
         return w, m, du
 
     def _save_wake_evidence(self, wall: float, mono: float,
-                            defer_until: "float | None" = None) -> None:
-        # Best-effort: losing the sample costs one grace window, while
-        # raising here would abort the reclaim sweep that called us.
+                            defer_until: "float | None" = None) -> bool:
+        """Publish this lead's wake sample. False = not published, so a caller
+        can observe the loss instead of trusting a silent best-effort write."""
+        p = self._wake_evidence_path()
+        payload = {"wall": wall, "mono": mono}
+        if defer_until is None:
+            # A deadline-free sample must not ERASE an open one: the window
+            # belongs to the host's wake event, not to whoever ticked last.
+            prior = self._load_wake_evidence()
+            if prior is not None and prior[2] is not None and mono < prior[2]:
+                payload["defer_until"] = prior[2]
+        else:
+            payload["defer_until"] = defer_until
+        # Per-writer temp name, as pool_status does: briefly overlapping leads
+        # are supported, and a shared temp lets one consume the other's bytes.
+        tmp = p.with_name(f".{p.name}.{os.getpid()}.{uuid4().hex[:8]}.tmp")
         try:
-            p = self._wake_evidence_path()
             p.parent.mkdir(parents=True, exist_ok=True)
-            tmp = p.with_suffix(".tmp")
-            payload = {"wall": wall, "mono": mono}
-            if defer_until is not None:
-                payload["defer_until"] = defer_until
             tmp.write_text(json.dumps(payload))
             os.replace(tmp, p)
+            return True
         except OSError:
-            pass
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            return False
 
     def _host_gap_defers_reclaim(self) -> bool:
         """Host-sleep evidence is wall-vs-monotonic SKEW across the lead's

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -654,6 +654,10 @@ class PoolLead:
                 # the cap anchors to file age, so a wedged core still yields
                 ledger[f.name] = self.now() - max_age_s + BUSY_EXIT_GRACE_S
                 continue
+            # Same post-observation re-check as the dead/claimed variants: the
+            # entry guard cannot see a suspension that began after the age read.
+            if self._host_gap_defers_reclaim():
+                return out
             try:
                 os.rename(f, f.with_name(m.group(1) + ".txt"))
             except OSError:

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -444,6 +444,13 @@ class PoolLead:
     def _wake_evidence_path(self) -> Path:
         return self.state_dir / "pool" / "lead-tick.json"
 
+    def _wake_lock(self) -> _FlockCtx:
+        """Serializes the wake record's load/merge/replace across overlapping
+        leads; plain reads of the atomic file need no lock."""
+        path = self._wake_evidence_path().with_suffix(".lock")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return _FlockCtx(path)
+
     def _load_wake_evidence(self) -> "tuple[float, float, float | None] | None":
         """Previous lead's last (wall, mono, defer_until) sample, or None.
 
@@ -480,22 +487,26 @@ class PoolLead:
         """Publish this lead's wake sample. False = not published, so a caller
         can observe the loss instead of trusting a silent best-effort write."""
         p = self._wake_evidence_path()
-        payload = {"wall": wall, "mono": mono}
-        if defer_until is None:
-            # A deadline-free sample must not ERASE an open one: the window
-            # belongs to the host's wake event, not to whoever ticked last.
-            prior = self._load_wake_evidence()
-            if prior is not None and prior[2] is not None and mono < prior[2]:
-                payload["defer_until"] = prior[2]
-        else:
-            payload["defer_until"] = defer_until
         # Per-writer temp name, as pool_status does: briefly overlapping leads
         # are supported, and a shared temp lets one consume the other's bytes.
         tmp = p.with_name(f".{p.name}.{os.getpid()}.{uuid4().hex[:8]}.tmp")
         try:
-            p.parent.mkdir(parents=True, exist_ok=True)
-            tmp.write_text(json.dumps(payload))
-            os.replace(tmp, p)
+            # One lock across load..replace: unique temps stop a torn record,
+            # not a stale write erasing a deadline opened since its load.
+            with self._wake_lock():
+                payload = {"wall": wall, "mono": mono}
+                # The window belongs to the wake event, not to whoever ticked
+                # last, so the MAXIMUM still-open deadline survives.
+                prior = self._load_wake_evidence()
+                open_du = prior[2] if prior is not None else None
+                if open_du is not None and mono < open_du:
+                    defer_until = (open_du if defer_until is None
+                                   else max(defer_until, open_du))
+                if defer_until is not None:
+                    payload["defer_until"] = defer_until
+                p.parent.mkdir(parents=True, exist_ok=True)
+                tmp.write_text(json.dumps(payload))
+                os.replace(tmp, p)
             return True
         except OSError:
             try:
@@ -503,6 +514,17 @@ class PoolLead:
             except OSError:
                 pass
             return False
+
+    def _publish_wake(self, wall: float, mono: float,
+                      defer_until: "float | None") -> bool:
+        """Publish the wake sample and REPORT a loss. A silent best-effort
+        write is what let a failed publish renew the same window forever."""
+        if self._save_wake_evidence(wall, mono, defer_until):
+            return True
+        print("pool-lead: wake evidence not published "
+              f"(defer_until={defer_until}); grace cannot be bounded",
+              file=sys.stderr, flush=True)
+        return False
 
     def _host_gap_defers_reclaim(self) -> bool:
         """Host-sleep evidence is wall-vs-monotonic SKEW across the lead's
@@ -541,13 +563,17 @@ class PoolLead:
             try:
                 followers = list(self.followers_fn())
             except Exception:  # noqa: BLE001 — broken resolver must not defer
-                self._save_wake_evidence(
+                self._publish_wake(
                     now, mono, getattr(self, "_reclaim_defer_until", None))
                 return False
             if followers and not any(self.alive_fn(f) for f in followers):
                 self._reclaim_defer_until = mono + LEAD_STALE_S
         du = getattr(self, "_reclaim_defer_until", None)
-        self._save_wake_evidence(now, mono, du)
+        if not self._publish_wake(now, mono, du):
+            # The one-window bound lives IN the record a successor seeds from;
+            # unpublished, every restart re-opens grace. Refuse, don't renew.
+            self._reclaim_defer_until = None
+            return False
         return du is not None and mono < du
 
     def reclaim_dead(self) -> "list[str]":

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -443,12 +443,18 @@ class PoolLead:
     def _wake_evidence_path(self) -> Path:
         return self.state_dir / "pool" / "lead-tick.json"
 
-    def _load_wake_evidence(self) -> "tuple[float, float] | None":
-        """Previous lead's last (wall, mono) sample, or None if unusable.
+    def _load_wake_evidence(self) -> "tuple[float, float, float | None] | None":
+        """Previous lead's last (wall, mono, defer_until) sample, or None.
 
         monotonic is BOOT-relative, so a predecessor's sample is
         differenceable here; a reboot resets it, which shows up as a stored
         value ahead of ours and is discarded.
+
+        The stored deadline carries an OPEN grace window across a respawn.
+        Without it the successor loads a post-wake pair showing no skew and
+        is ALSO excluded from the cold-lead fallback, because its seeded
+        sample is not None -- both escapes close together and the window is
+        silently lost.
         """
         try:
             d = json.loads(self._wake_evidence_path().read_text())
@@ -457,16 +463,29 @@ class PoolLead:
             return None
         if m > self.mono():
             return None
-        return w, m
+        try:
+            du = d.get("defer_until")
+            du = None if du is None else float(du)
+        except (TypeError, ValueError):
+            du = None
+        # A deadline outside the window it was opened for is corrupt or
+        # foreign, never evidence; an expired one must not resurrect grace.
+        if du is not None and not (m <= du <= m + LEAD_STALE_S):
+            du = None
+        return w, m, du
 
-    def _save_wake_evidence(self, wall: float, mono: float) -> None:
+    def _save_wake_evidence(self, wall: float, mono: float,
+                            defer_until: "float | None" = None) -> None:
         # Best-effort: losing the sample costs one grace window, while
         # raising here would abort the reclaim sweep that called us.
         try:
             p = self._wake_evidence_path()
             p.parent.mkdir(parents=True, exist_ok=True)
             tmp = p.with_suffix(".tmp")
-            tmp.write_text(json.dumps({"wall": wall, "mono": mono}))
+            payload = {"wall": wall, "mono": mono}
+            if defer_until is not None:
+                payload["defer_until"] = defer_until
+            tmp.write_text(json.dumps(payload))
             os.replace(tmp, p)
         except OSError:
             pass
@@ -490,10 +509,13 @@ class PoolLead:
             # left one: seed from it so the skew test below covers tick 1.
             seeded = self._load_wake_evidence()
             if seeded is not None:
-                last, last_mono = seeded
+                last, last_mono, carried = seeded
+                # The window belongs to the host's wake event, not to the
+                # process that opened it; expiry stays time-only.
+                if carried is not None and mono < carried:
+                    self._reclaim_defer_until = carried
         self._last_reclaim_tick = now
         self._last_reclaim_mono = mono
-        self._save_wake_evidence(now, mono)
         if last is not None and last_mono is not None:
             if (now - last) - (mono - last_mono) > SLEEP_SKEW_S:
                 # Deadline in MONOTONIC time: a backward wall correction must
@@ -505,10 +527,13 @@ class PoolLead:
             try:
                 followers = list(self.followers_fn())
             except Exception:  # noqa: BLE001 — broken resolver must not defer
+                self._save_wake_evidence(
+                    now, mono, getattr(self, "_reclaim_defer_until", None))
                 return False
             if followers and not any(self.alive_fn(f) for f in followers):
                 self._reclaim_defer_until = mono + LEAD_STALE_S
         du = getattr(self, "_reclaim_defer_until", None)
+        self._save_wake_evidence(now, mono, du)
         return du is not None and mono < du
 
     def reclaim_dead(self) -> "list[str]":

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -26,6 +26,9 @@ sys.path.insert(0, str(_HERE.parent))
 from task_priority import sort_tasks_by_priority  # noqa: E402
 from pool_follower import LEAD_STALE_S  # noqa: E402
 
+# tick gap past one beat period = host sleep; shorter can't stale a beat
+HOST_GAP_S = 30.0
+
 # Depth at which channelless work overflows to the idle lane core; room
 # affinity itself is binding and never yields on load (owner 2026-08-26).
 AFFINITY_BUSY_MAX = max(1, int(os.environ.get("SUTANDO_AFFINITY_BUSY_MAX", "3")))
@@ -437,26 +440,32 @@ class PoolLead:
 
     # ── crash recovery ──────────────────────────────────────────────────────
     def _host_gap_defers_reclaim(self) -> bool:
-        """Every follower stale in the same instant is a host gap (sleep, clock
-        jump), not N deaths — beats stop together only when the machine does.
+        """Host-gap evidence comes from the LEAD'S OWN tick cadence: reclaim
+        entrypoints run every ~2s, so a large gap between calls means the host
+        slept — independent of which follower happens to re-beat first
+        (staggered 30s beats make sibling-before-claimant an ordinary wake).
 
-        Defers one stale window rather than suppressing: a woken follower
-        re-beats within it, while a genuine whole-pool outage still reclaims
-        once the window passes.
+        The grace window, once opened, expires by TIME ONLY — a sibling
+        heartbeat must not end it while the claim owner's beat is still due.
+        A genuine outage (no tick gap) is never deferred mid-run.
         """
-        try:
-            followers = list(self.followers_fn())
-        except Exception:  # noqa: BLE001 — a broken resolver must not defer
-            return False
-        if not followers:
-            return False
-        if any(self.alive_fn(f) for f in followers):
-            self._reclaim_defer_until = None
-            return False
         now = self.now()
-        if getattr(self, "_reclaim_defer_until", None) is None:
-            self._reclaim_defer_until = now + LEAD_STALE_S
-        return now < self._reclaim_defer_until
+        last = getattr(self, "_last_reclaim_tick", None)
+        self._last_reclaim_tick = now
+        if last is not None:
+            if now - last > HOST_GAP_S:
+                self._reclaim_defer_until = now + LEAD_STALE_S
+        else:
+            # fresh lead + all-stale pool: indistinguishable from a
+            # post-wake lead restart — grace one window
+            try:
+                followers = list(self.followers_fn())
+            except Exception:  # noqa: BLE001 — broken resolver must not defer
+                return False
+            if followers and not any(self.alive_fn(f) for f in followers):
+                self._reclaim_defer_until = now + LEAD_STALE_S
+        du = getattr(self, "_reclaim_defer_until", None)
+        return du is not None and now < du
 
     def reclaim_dead(self) -> "list[str]":
         """Return dead followers' assignments to the unassigned pool.

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -440,6 +440,37 @@ class PoolLead:
         return out
 
     # ── crash recovery ──────────────────────────────────────────────────────
+    def _wake_evidence_path(self) -> Path:
+        return self.state_dir / "pool" / "lead-tick.json"
+
+    def _load_wake_evidence(self) -> "tuple[float, float] | None":
+        """Previous lead's last (wall, mono) sample, or None if unusable.
+
+        monotonic is BOOT-relative, so a predecessor's sample is
+        differenceable here; a reboot resets it, which shows up as a stored
+        value ahead of ours and is discarded.
+        """
+        try:
+            d = json.loads(self._wake_evidence_path().read_text())
+            w, m = float(d["wall"]), float(d["mono"])
+        except (OSError, ValueError, TypeError, KeyError):
+            return None
+        if m > self.mono():
+            return None
+        return w, m
+
+    def _save_wake_evidence(self, wall: float, mono: float) -> None:
+        # Best-effort: losing the sample costs one grace window, while
+        # raising here would abort the reclaim sweep that called us.
+        try:
+            p = self._wake_evidence_path()
+            p.parent.mkdir(parents=True, exist_ok=True)
+            tmp = p.with_suffix(".tmp")
+            tmp.write_text(json.dumps({"wall": wall, "mono": mono}))
+            os.replace(tmp, p)
+        except OSError:
+            pass
+
     def _host_gap_defers_reclaim(self) -> bool:
         """Host-sleep evidence is wall-vs-monotonic SKEW across the lead's
         own tick, not mere tick-gap size: the monotonic clock pauses through
@@ -454,8 +485,15 @@ class PoolLead:
         mono = self.mono()
         last = getattr(self, "_last_reclaim_tick", None)
         last_mono = getattr(self, "_last_reclaim_mono", None)
+        if last is None:
+            # A restarted lead has no in-process sample, but its predecessor
+            # left one: seed from it so the skew test below covers tick 1.
+            seeded = self._load_wake_evidence()
+            if seeded is not None:
+                last, last_mono = seeded
         self._last_reclaim_tick = now
         self._last_reclaim_mono = mono
+        self._save_wake_evidence(now, mono)
         if last is not None and last_mono is not None:
             if (now - last) - (mono - last_mono) > SLEEP_SKEW_S:
                 # Deadline in MONOTONIC time: a backward wall correction must

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -458,7 +458,9 @@ class PoolLead:
         self._last_reclaim_mono = mono
         if last is not None and last_mono is not None:
             if (now - last) - (mono - last_mono) > SLEEP_SKEW_S:
-                self._reclaim_defer_until = now + LEAD_STALE_S
+                # Deadline in MONOTONIC time: a backward wall correction must
+                # not stretch one stale window into hours of withheld recovery.
+                self._reclaim_defer_until = mono + LEAD_STALE_S
         elif last is None:
             # fresh lead + all-stale pool: indistinguishable from a
             # post-wake lead restart — grace one window
@@ -467,9 +469,9 @@ class PoolLead:
             except Exception:  # noqa: BLE001 — broken resolver must not defer
                 return False
             if followers and not any(self.alive_fn(f) for f in followers):
-                self._reclaim_defer_until = now + LEAD_STALE_S
+                self._reclaim_defer_until = mono + LEAD_STALE_S
         du = getattr(self, "_reclaim_defer_until", None)
-        return du is not None and now < du
+        return du is not None and mono < du
 
     def reclaim_dead(self) -> "list[str]":
         """Return dead followers' assignments to the unassigned pool.

--- a/tests/pool-hygiene.test.py
+++ b/tests/pool-hygiene.test.py
@@ -31,7 +31,8 @@ class HygieneBase(unittest.TestCase):
         self.lead = PoolLead(self.tasks, self.state,
                              followers_fn=lambda: list(self.alive),
                              alive_fn=lambda i: self.alive.get(i, False),
-                             now_fn=lambda: self.clock[0])
+                             now_fn=lambda: self.clock[0],
+            mono_fn=lambda: self.clock[0])
 
     def tearDown(self):
         self.tmp.cleanup()

--- a/tests/pool-hygiene.test.py
+++ b/tests/pool-hygiene.test.py
@@ -36,35 +36,44 @@ class HygieneBase(unittest.TestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
+    def _pass_awake(self, seconds, fn):
+        """Advance in daemon-cadence steps: one clock leap reads as a host
+        sleep to the wake guard, which is not what these tests mean."""
+        outs = []
+        end = self.clock[0] + seconds
+        while self.clock[0] < end:
+            self.clock[0] = min(self.clock[0] + 20, end)
+            outs += fn()
+        return outs
+
 
 class StuckAssignmentTests(HygieneBase):
     def test_first_sight_adopts_then_old_age_repools(self):
         f = self.tasks / "task-s1.assigned-core-1.txt"
         f.write_text("task: t\n")
         self.assertEqual(self.lead.reclaim_stuck_assignments(), [])  # adopted
-        self.clock[0] += 301
-        self.assertEqual(self.lead.reclaim_stuck_assignments(),
-                         ["task-s1.assigned-core-1.txt"])
+        outs = self._pass_awake(301, self.lead.reclaim_stuck_assignments)
+        self.assertEqual(outs, ["task-s1.assigned-core-1.txt"])
         self.assertTrue((self.tasks / "task-s1.txt").exists())
 
     def test_young_assignment_untouched(self):
         (self.tasks / "task-s2.assigned-core-1.txt").write_text("task: t\n")
         self.lead.reclaim_stuck_assignments()
-        self.clock[0] += 299
-        self.assertEqual(self.lead.reclaim_stuck_assignments(), [])
+        self.assertEqual(
+            self._pass_awake(299, self.lead.reclaim_stuck_assignments), [])
 
     def test_dead_follower_left_to_reclaim_dead(self):
         (self.tasks / "task-s3.assigned-core-1.txt").write_text("task: t\n")
         self.lead.reclaim_stuck_assignments()
         self.alive["core-1"] = False
-        self.clock[0] += 301
-        self.assertEqual(self.lead.reclaim_stuck_assignments(), [])
+        self.assertEqual(
+            self._pass_awake(301, self.lead.reclaim_stuck_assignments), [])
 
     def test_claimed_files_never_touched(self):
         (self.tasks / "task-s4.claimed-core-1.txt").write_text("task: t\n")
         self.lead.reclaim_stuck_assignments()
-        self.clock[0] += 10_000
-        self.assertEqual(self.lead.reclaim_stuck_assignments(), [])
+        self.assertEqual(
+            self._pass_awake(10_000, self.lead.reclaim_stuck_assignments), [])
         self.assertTrue((self.tasks / "task-s4.claimed-core-1.txt").exists())
 
     def test_ledger_forgets_departed_files(self):
@@ -72,8 +81,8 @@ class StuckAssignmentTests(HygieneBase):
         f.write_text("task: t\n")
         self.lead.reclaim_stuck_assignments()
         f.rename(self.tasks / "task-s5.claimed-core-1.txt")  # follower claimed
-        self.clock[0] += 400
-        self.assertEqual(self.lead.reclaim_stuck_assignments(), [])
+        self.assertEqual(
+            self._pass_awake(400, self.lead.reclaim_stuck_assignments), [])
         import json
         ledger = json.loads(
             (self.state / "pool" / "assignments.json").read_text())

--- a/tests/pool-lead-assignment.test.py
+++ b/tests/pool-lead-assignment.test.py
@@ -42,7 +42,8 @@ class PoolLeadTests(unittest.TestCase):
             self.tasks, self.state,
             followers_fn=lambda: list(self.alive),
             alive_fn=lambda i: self.alive.get(i, False),
-            now_fn=lambda: self.clock[0])
+            now_fn=lambda: self.clock[0],
+            mono_fn=lambda: self.clock[0])
 
     def tearDown(self):
         self.tmp.cleanup()
@@ -388,7 +389,8 @@ class RoutineLaneEscape(unittest.TestCase):
             self.tasks, self.state,
             followers_fn=lambda: list(self.alive),
             alive_fn=lambda i: self.alive.get(i, False),
-            now_fn=lambda: self.clock[0])
+            now_fn=lambda: self.clock[0],
+            mono_fn=lambda: self.clock[0])
         # highest-numbered follower is the routine lane
         self.lane = max(self.alive, key=lambda f: (len(f), f))
 

--- a/tests/pool-lead-assignment.test.py
+++ b/tests/pool-lead-assignment.test.py
@@ -18,6 +18,16 @@ from pool_lead import (AFFINITY_BUSY_MAX,  # noqa: E402
                        ASSIGN_STUCK_S, NOCLAIM_COOLDOWN_S, PoolLead)
 
 
+def _pass_awake(clock, seconds, fn):
+    """Daemon-cadence advance: a single clock leap reads as host sleep."""
+    outs = []
+    end = clock[0] + seconds
+    while clock[0] < end:
+        clock[0] = min(clock[0] + 20, end)
+        outs += fn()
+    return outs
+
+
 class PoolLeadTests(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -399,9 +409,9 @@ class RoutineLaneEscape(unittest.TestCase):
         # it never claims. The lead reclaims every pass: the first sighting
         # only adopts the assignment into the ledger, the next one repools it.
         self.assertEqual(self.lead.reclaim_stuck_assignments(), [])
-        self.clock[0] += ASSIGN_STUCK_S + 1
-        self.assertEqual(self.lead.reclaim_stuck_assignments(),
-                         [f"task-r1.assigned-{self.lane}.txt"])
+        outs = _pass_awake(self.clock, ASSIGN_STUCK_S + 1,
+                           self.lead.reclaim_stuck_assignments)
+        self.assertEqual(outs, [f"task-r1.assigned-{self.lane}.txt"])
         self.assertTrue(self.alive[self.lane], "lane core still heartbeats")
 
         second = dict(self.lead.sweep())["task-r1.txt"]
@@ -421,8 +431,8 @@ class RoutineLaneEscape(unittest.TestCase):
         self._routine("task-r3.txt")
         self.lead.sweep()
         self.lead.reclaim_stuck_assignments()          # adopt
-        self.clock[0] += ASSIGN_STUCK_S + 1
-        self.lead.reclaim_stuck_assignments()          # repool + mark
+        _pass_awake(self.clock, ASSIGN_STUCK_S + 1,
+                    self.lead.reclaim_stuck_assignments)  # repool + mark
         self.assertFalse(self.lead._claiming(self.lane))
         self.clock[0] += NOCLAIM_COOLDOWN_S
         self.assertTrue(self.lead._claiming(self.lane),
@@ -441,9 +451,9 @@ class RoutineLaneEscape(unittest.TestCase):
         self.assertEqual(dict(self.lead.sweep())["task-o1.txt"], victim)
 
         self.lead.reclaim_stuck_assignments()     # adopt
-        self.clock[0] += ASSIGN_STUCK_S + 1
-        self.assertEqual(self.lead.reclaim_stuck_assignments(),
-                         [f"task-o1.assigned-{victim}.txt"])
+        outs = _pass_awake(self.clock, ASSIGN_STUCK_S + 1,
+                           self.lead.reclaim_stuck_assignments)
+        self.assertEqual(outs, [f"task-o1.assigned-{victim}.txt"])
         again = dict(self.lead.sweep())["task-o1.txt"]
         self.assertNotEqual(again, victim,
                             "owner-lane work returned to the core that just "

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -66,6 +66,55 @@ class WakeGuardBase(unittest.TestCase):
         return outs
 
 
+class SuspensionAfterTheEntryGuard(WakeGuardBase):
+    """The entry guard samples the clocks BEFORE scanning, so a suspension
+    that begins after it cannot be seen by it — yet the owner liveness read
+    that authorizes the rename happens later, and by then the owner reads
+    dead. Re-check the skew after that read, or the rename lands on a live
+    claim. Both destructive variants must be pinned, not just the claimed one."""
+
+    def _sleep_at_liveness_read(self, owner):
+        """alive_fn is what the daemon calls per entry; make the suspension
+        begin exactly there, which is the window the entry guard cannot cover."""
+        original = self.alive.copy()
+
+        def alive_fn(inst):
+            if inst == owner and self.alive.get(inst, False):
+                self._sleep_whole_host(968)   # clamshell opens mid-scan
+                return False
+            return self.alive.get(inst, False)
+        self.lead.alive_fn = alive_fn
+        return original
+
+    def test_claimed_variant_declines_after_a_mid_scan_suspension(self):
+        (self.tasks / "task-race.claimed-core-2.txt").write_text("x")
+        self.assertEqual(self.lead.reclaim_claimed(), [])      # baseline tick
+        self._sleep_at_liveness_read("core-2")
+        self.assertEqual(self.lead.reclaim_claimed(), [],
+                         "a live claim was repooled on a suspension the entry guard missed")
+        self.assertEqual(self._names(), ["task-race.claimed-core-2.txt"])
+
+    def test_assigned_variant_declines_after_a_mid_scan_suspension(self):
+        (self.tasks / "task-race.assigned-core-2.txt").write_text("x")
+        self.assertEqual(self.lead.reclaim_dead(), [])         # baseline tick
+        self._sleep_at_liveness_read("core-2")
+        self.assertEqual(self.lead.reclaim_dead(), [],
+                         "an assignment was repooled on a suspension the entry guard missed")
+        self.assertEqual(self._names(), ["task-race.assigned-core-2.txt"])
+
+    def test_a_genuinely_dead_owner_with_no_suspension_still_reclaims(self):
+        """Control: without the mid-scan clock jump the rename MUST happen,
+        so the re-check cannot be passing by simply never reclaiming."""
+        (self.tasks / "task-dead.claimed-core-2.txt").write_text("x")
+        self.assertEqual(self.lead.reclaim_claimed(), [])      # baseline tick
+        self.alive["core-2"] = False
+        self.clock += 2
+        self.mono += 2
+        self.assertEqual(self.lead.reclaim_claimed(),
+                         [("task-dead.claimed-core-2.txt", "repooled")])
+        self.assertEqual(self._names(), ["task-dead.txt"])
+
+
 class HostGapDefersReclaim(WakeGuardBase):
     def test_claim_of_live_core_survives_a_host_sleep(self):
         (self.tasks / "task-a.claimed-core-2.txt").write_text("x")

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -400,6 +400,18 @@ class RestartedLeadInheritsWakeEvidence(WakeGuardBase):
         self.assertEqual(claimed, [("task-restart.claimed-core-2.txt", "repooled")])
         self.assertEqual(self._names(), ["task-restart.txt"])
 
+    def test_an_unwritable_state_dir_does_not_break_the_sweep(self):
+        """Persisting is best-effort: the sample is an optimisation, while
+        raising would abort the reclaim sweep that called it."""
+        (self.tasks / "task-restart.claimed-core-2.txt").write_text("x")
+        (self.state / "pool").write_text("not a directory")
+        self.alive["core-2"] = False
+        lead = self._restart_lead()
+        self.assertEqual(lead.reclaim_claimed(),
+                         [("task-restart.claimed-core-2.txt", "repooled")],
+                         "a failed evidence write must not stop recovery")
+        self.assertIsNone(lead._load_wake_evidence())
+
     def test_control_a_reboot_discards_the_inherited_sample(self):
         """Monotonic is boot-relative: after a reboot the stored value is
         ahead of ours, which is unusable rather than evidence of a sleep."""

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -367,8 +367,10 @@ class RestartedLeadInheritsWakeEvidence(WakeGuardBase):
         (self.tasks / "task-restart.claimed-core-2.txt").write_text("x")
         self.lead.reclaim_claimed()          # pre-sleep tick, persists evidence
         self._sleep_whole_host(968)          # wall jumps, monotonic does not
-        self.alive["core-1"] = True          # the sibling re-beats FIRST
-        self.alive["core-2"] = False         # the claim owner has not yet
+
+        # The ordering under test: sibling back first, claim owner still due.
+        self.alive["core-1"] = True
+        self.alive["core-2"] = False
         dead, claimed, stuck = self._daemon_order(self._restart_lead())
         self.assertEqual((dead, claimed, stuck), ([], [], []),
                          "a restarted lead repooled a live claim on a sibling-first wake")

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Wake guard: every follower going stale in the same instant is a host gap
+(sleep, clock jump), not N deaths, so reclaim defers one stale window.
+
+A 968s clamshell sleep aged every .alive file past the window at once; the lead
+read that as four dead cores and repooled a live core's claim, bouncing an owner
+task across cores for ~45 minutes. Exercises the production reclaim entrypoints.
+Run: python3 tests/pool-lead-wake-guard.test.py   (stdlib only)
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "src" / "runtime-api"))
+
+from pool_follower import LEAD_STALE_S  # noqa: E402
+from pool_lead import PoolLead  # noqa: E402
+
+
+class WakeGuardBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.tasks = root / "tasks"
+        self.state = root / "state"
+        self.results = root / "results"
+        for d in (self.tasks, self.state, self.results):
+            d.mkdir()
+        self.pool = ["core-1", "core-2"]
+        self.alive = {"core-1": True, "core-2": True}
+        self.clock = 1_000.0
+        self.lead = PoolLead(self.tasks, self.state,
+                             followers_fn=lambda: list(self.pool),
+                             alive_fn=lambda i: self.alive.get(i, False),
+                             now_fn=lambda: self.clock,
+                             results_dir=self.results)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _sleep_whole_host(self, seconds):
+        """What a clamshell sleep does: every beat ages together, clock jumps."""
+        for inst in self.pool:
+            self.alive[inst] = False
+        self.clock += seconds
+
+    def _names(self):
+        return sorted(f.name for f in self.tasks.iterdir())
+
+
+class HostGapDefersReclaim(WakeGuardBase):
+    def test_claim_of_live_core_survives_a_host_sleep(self):
+        (self.tasks / "task-a.claimed-core-2.txt").write_text("x")
+        self._sleep_whole_host(968)
+        self.assertEqual(self.lead.reclaim_claimed(), [])
+        self.assertEqual(self._names(), ["task-a.claimed-core-2.txt"])
+
+    def test_assignment_survives_a_host_sleep(self):
+        (self.tasks / "task-b.assigned-core-1.txt").write_text("x")
+        self._sleep_whole_host(968)
+        self.assertEqual(self.lead.reclaim_dead(), [])
+        self.assertEqual(self._names(), ["task-b.assigned-core-1.txt"])
+
+    def test_stuck_sweep_defers_too(self):
+        (self.tasks / "task-c.assigned-core-1.txt").write_text("x")
+        self.lead.reclaim_stuck_assignments()  # adopt into the ledger
+        self._sleep_whole_host(968)
+        self.assertEqual(self.lead.reclaim_stuck_assignments(), [])
+        self.assertEqual(self._names(), ["task-c.assigned-core-1.txt"])
+
+    def test_woken_follower_clears_the_deferral(self):
+        (self.tasks / "task-d.claimed-core-2.txt").write_text("x")
+        self._sleep_whole_host(968)
+        self.assertEqual(self.lead.reclaim_claimed(), [])
+        self.alive["core-2"] = True          # beat resumes on wake
+        self.assertEqual(self.lead.reclaim_claimed(), [])
+        self.assertEqual(self._names(), ["task-d.claimed-core-2.txt"])
+
+
+class GenuineFailuresStillReclaim(WakeGuardBase):
+    def test_one_dead_core_reclaims_immediately(self):
+        """The guard must not blunt the case it was never about."""
+        (self.tasks / "task-e.claimed-core-2.txt").write_text("x")
+        self.alive["core-2"] = False          # core-1 still beating
+        self.assertEqual(self.lead.reclaim_claimed(),
+                         [("task-e.claimed-core-2.txt", "repooled")])
+        self.assertEqual(self._names(), ["task-e.txt"])
+
+    def test_whole_pool_outage_reclaims_after_one_window(self):
+        """Deferral, not suppression: a real total outage still recovers."""
+        (self.tasks / "task-f.claimed-core-1.txt").write_text("x")
+        self._sleep_whole_host(968)
+        self.assertEqual(self.lead.reclaim_claimed(), [])
+        self.clock += LEAD_STALE_S + 1        # still nothing beating
+        self.assertEqual(self.lead.reclaim_claimed(),
+                         [("task-f.claimed-core-1.txt", "repooled")])
+        self.assertEqual(self._names(), ["task-f.txt"])
+
+    def test_empty_pool_is_not_a_host_gap(self):
+        """No followers means nothing to protect — never defer on an empty set."""
+        (self.tasks / "task-g.claimed-core-9.txt").write_text("x")
+        self.pool = []
+        self.assertEqual(self.lead.reclaim_claimed(),
+                         [("task-g.claimed-core-9.txt", "repooled")])
+
+    def test_broken_followers_resolver_does_not_defer(self):
+        """A resolver that raises must fail toward recovery, not toward stalling."""
+        def boom():
+            raise OSError("registry unreadable")
+        self.lead.followers_fn = boom
+        (self.tasks / "task-h.claimed-core-2.txt").write_text("x")
+        self.alive["core-2"] = False
+        self.assertEqual(self.lead.reclaim_claimed(),
+                         [("task-h.claimed-core-2.txt", "repooled")])
+
+
+class DeliveredTasksKeepTheirDisposition(WakeGuardBase):
+    def test_delivered_claim_still_reads_delivered_after_the_window(self):
+        (self.tasks / "task-i.claimed-core-2.txt").write_text("x")
+        done = self.state / "cores" / "core-2" / "done"
+        done.mkdir(parents=True)
+        (done / "task-i.flag").write_text("")
+        (self.results / "task-i.txt").write_text("answer")
+        self._sleep_whole_host(968)
+        self.assertEqual(self.lead.reclaim_claimed(), [])
+        self.clock += LEAD_STALE_S + 1
+        self.assertEqual(self.lead.reclaim_claimed(),
+                         [("task-i.claimed-core-2.txt", "delivered")])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -341,5 +341,69 @@ class AwakeSlowDaemonIsNotSleep(unittest.TestCase):
         self.assertTrue(claim.exists())
 
 
+
+class RestartedLeadInheritsWakeEvidence(WakeGuardBase):
+    """A lead that restarts across a host sleep has no in-process clock
+    sample, so tick 1 must read its predecessor's. Ordering matters: if a
+    sibling re-beats before the claim owner does, a liveness-only rule sees
+    a live pool and repools a claim whose owner is merely still waking."""
+
+    def _restart_lead(self):
+        """Same state dir, new instance — what launchd does on respawn."""
+        return PoolLead(self.tasks, self.state,
+                        followers_fn=lambda: list(self.pool),
+                        alive_fn=lambda i: self.alive.get(i, False),
+                        now_fn=lambda: self.clock,
+                        mono_fn=lambda: self.mono,
+                        results_dir=self.results)
+
+    def _daemon_order(self, lead):
+        """scripts/pool-lead-daemon.py:143-148 — reclaim_dead, then
+        reclaim_claimed, then reclaim_stuck_assignments."""
+        return (lead.reclaim_dead(), lead.reclaim_claimed(),
+                lead.reclaim_stuck_assignments())
+
+    def test_sibling_first_wake_does_not_repool_a_live_claim(self):
+        (self.tasks / "task-restart.claimed-core-2.txt").write_text("x")
+        self.lead.reclaim_claimed()          # pre-sleep tick, persists evidence
+        self._sleep_whole_host(968)          # wall jumps, monotonic does not
+        self.alive["core-1"] = True          # the sibling re-beats FIRST
+        self.alive["core-2"] = False         # the claim owner has not yet
+        dead, claimed, stuck = self._daemon_order(self._restart_lead())
+        self.assertEqual((dead, claimed, stuck), ([], [], []),
+                         "a restarted lead repooled a live claim on a sibling-first wake")
+        self.assertEqual(self._names(), ["task-restart.claimed-core-2.txt"])
+
+    def test_control_no_predecessor_evidence_keeps_the_old_behaviour(self):
+        """Nothing persisted: the all-stale fallback still decides, so this
+        change adds a path rather than replacing one."""
+        (self.tasks / "task-restart.claimed-core-2.txt").write_text("x")
+        for inst in self.pool:
+            self.alive[inst] = False
+        lead = self._restart_lead()          # never ticked; no file on disk
+        self.assertIsNone(lead._load_wake_evidence())
+        self.assertEqual(lead.reclaim_claimed(), [])
+
+    def test_control_a_restart_without_a_sleep_still_reclaims_a_dead_owner(self):
+        """The discriminating case: inherited evidence must not become a
+        blanket deferral. Lead restarts with NO wall/monotonic skew, so a
+        genuinely dead owner is reclaimed on tick 1."""
+        (self.tasks / "task-restart.claimed-core-2.txt").write_text("x")
+        self.lead.reclaim_claimed()          # persists evidence
+        self.clock += 2
+        self.mono += 2                       # awake: both advance together
+        self.alive["core-2"] = False         # owner genuinely gone
+        _, claimed, _ = self._daemon_order(self._restart_lead())
+        self.assertEqual(claimed, [("task-restart.claimed-core-2.txt", "repooled")])
+        self.assertEqual(self._names(), ["task-restart.txt"])
+
+    def test_control_a_reboot_discards_the_inherited_sample(self):
+        """Monotonic is boot-relative: after a reboot the stored value is
+        ahead of ours, which is unusable rather than evidence of a sleep."""
+        (self.tasks / "task-restart.claimed-core-2.txt").write_text("x")
+        self.lead.reclaim_claimed()
+        self.mono -= 400                     # monotonic reset by the reboot
+        self.assertIsNone(self._restart_lead()._load_wake_evidence())
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -9,8 +9,11 @@ Run: python3 tests/pool-lead-wake-guard.test.py   (stdlib only)
 """
 from __future__ import annotations
 
+import contextlib
+import io
 import sys
 import tempfile
+import time
 import threading
 import unittest
 from pathlib import Path
@@ -96,6 +99,86 @@ class TheWakeRecordHasOneWriterContract(WakeGuardBase):
         got = self.lead._load_wake_evidence()
         self.assertIsNotNone(got, "concurrent writers published a torn record")
         self.assertEqual(len(got), 3)
+
+    def _second_lead(self):
+        """A second PoolLead over the SAME state dir — the overlapping-lead
+        case the pgrep/exec TOCTOU in pool-lead-wrapper.sh admits."""
+        return PoolLead(self.tasks, self.state,
+                        followers_fn=lambda: list(self.pool),
+                        alive_fn=lambda i: self.alive.get(i, False),
+                        now_fn=lambda: self.clock,
+                        mono_fn=lambda: self.mono,
+                        results_dir=self.results)
+
+    def test_a_stale_read_modify_write_cannot_erase_a_newer_open_deadline(self):
+        """The DISCRIMINATING interleaving: a deadline-free writer loads the
+        record, another lead opens grace, then the first one publishes. Unique
+        temp names do not order these — only a lock held across load..replace
+        does, so this fails on the per-writer-temp parent."""
+        other = self._second_lead()
+        want = self.mono + LEAD_STALE_S
+        loaded = threading.Event()
+        real_load = self.lead._load_wake_evidence
+
+        def load_then_yield():
+            got = real_load()             # the REAL load, under the real lock
+            loaded.set()
+            time.sleep(0.25)              # hold the transaction open
+            return got
+        self.lead._load_wake_evidence = load_then_yield
+
+        opened = []
+
+        def opener():
+            loaded.wait(5)
+            # production writer, the deadline-carrying half
+            opened.append(other._save_wake_evidence(self.clock, self.mono, want))
+        t = threading.Thread(target=opener)
+        t.start()
+        # production writer, the deadline-FREE half that must not clobber
+        self.lead._save_wake_evidence(self.clock, self.mono, None)
+        t.join(10)
+        self.lead._load_wake_evidence = real_load
+
+        self.assertEqual(opened, [True], "opener never published")
+        got = self.lead._load_wake_evidence()
+        self.assertIsNotNone(got, "record lost entirely")
+        self.assertEqual(
+            got[2], want,
+            "a stale deadline-free write erased a newer open deadline — "
+            "the successor loses its grace and repools a live claim")
+
+    def test_a_shorter_deadline_never_shortens_the_open_window(self):
+        """Same lost-update shape with BOTH writers carrying a deadline: the
+        maximum still-open window is the one that belongs to the wake event."""
+        longer = self.mono + LEAD_STALE_S
+        self.lead._save_wake_evidence(self.clock, self.mono, longer)
+        other = self._second_lead()
+        other._save_wake_evidence(self.clock, self.mono, self.mono + 1.0)
+        got = self.lead._load_wake_evidence()
+        self.assertEqual(got[2], longer, "a shorter sample truncated the window")
+
+    def test_an_unpublishable_window_is_refused_and_reported_not_renewed(self):
+        """keweichen: `_save_wake_evidence` returning False was discarded at
+        both call sites, so a failing publish let each restart re-open the same
+        window forever. The bound lives IN the record, so grace it cannot
+        record must be refused — and said out loud."""
+        (self.tasks / "task-live.claimed-core-2.txt").write_text("x")
+        self.lead._save_wake_evidence(self.clock, self.mono, None)
+        self._sleep_whole_host(968)      # skew: wall jumps, mono does not
+
+        self.lead._save_wake_evidence = lambda *a, **k: False   # disk refuses
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            deferred = self.lead._host_gap_defers_reclaim()
+
+        self.assertFalse(deferred,
+                         "granted a grace window it could not record, so every "
+                         "restart re-opens it and recovery never runs")
+        self.assertIn("not published", err.getvalue(),
+                      "publication failure was swallowed at the call site")
+        self.assertIsNone(getattr(self.lead, "_reclaim_defer_until", None),
+                          "an unrecordable window stayed armed in-process")
 
     def test_a_deadline_free_sample_does_not_erase_an_open_deadline(self):
         want = self._open_deadline()

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -19,7 +19,7 @@ sys.path.insert(0, str(REPO / "src"))
 sys.path.insert(0, str(REPO / "src" / "runtime-api"))
 
 from pool_follower import LEAD_STALE_S  # noqa: E402
-from pool_lead import PoolLead  # noqa: E402
+from pool_lead import ASSIGN_STUCK_S, PoolLead  # noqa: E402
 
 
 class WakeGuardBase(unittest.TestCase):
@@ -101,6 +101,44 @@ class SuspensionAfterTheEntryGuard(WakeGuardBase):
         self.assertEqual(self.lead.reclaim_dead(), [],
                          "an assignment was repooled on a suspension the entry guard missed")
         self.assertEqual(self._names(), ["task-race.assigned-core-2.txt"])
+
+    def _sleep_at_nth_wall_read(self, n, seconds=968):
+        """Wall-only jump on the Nth now() call, owner still ALIVE. The stuck
+        sweep skips dead owners, so only a live-owner skew reaches its rename."""
+        calls = {"n": 0}
+        real = self.lead.now
+
+        def now():
+            calls["n"] += 1
+            if calls["n"] == n:
+                self.clock += seconds       # wall moves, monotonic does NOT
+            return real()
+        self.lead.now = now
+        return calls
+
+    def test_stuck_sweep_declines_after_a_mid_scan_suspension(self):
+        f = self.tasks / "task-midscan.assigned-core-2.txt"
+        f.write_text("x")
+        self.lead.reclaim_stuck_assignments()          # adopt into the ledger
+        self.clock += ASSIGN_STUCK_S + 10
+        self.mono += ASSIGN_STUCK_S + 10               # awake: both move together
+        self.assertTrue(self.alive["core-2"], "owner must stay alive for this path")
+        self._sleep_at_nth_wall_read(3)                # the first age read
+        self.assertEqual(self.lead.reclaim_stuck_assignments(), [],
+                         "a live core's assignment was repooled on a suspension "
+                         "the entry guard could not see")
+        self.assertEqual(self._names(), ["task-midscan.assigned-core-2.txt"])
+
+    def test_control_stuck_sweep_still_repools_with_no_suspension(self):
+        f = self.tasks / "task-stuck.assigned-core-2.txt"
+        f.write_text("x")
+        self.lead.reclaim_stuck_assignments()
+        self.clock += ASSIGN_STUCK_S + 10
+        self.mono += ASSIGN_STUCK_S + 10
+        self.assertEqual(self.lead.reclaim_stuck_assignments(),
+                         ["task-stuck.assigned-core-2.txt"],
+                         "control: without a skew the sweep must still repool")
+        self.assertEqual(self._names(), ["task-stuck.txt"])
 
     def test_a_genuinely_dead_owner_with_no_suspension_still_reclaims(self):
         """Control: without the mid-scan clock jump the rename MUST happen,

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -178,5 +178,51 @@ class DeliveredTasksKeepTheirDisposition(WakeGuardBase):
         self.assertEqual(outs, [("task-i.claimed-core-2.txt", "delivered")])
 
 
+class AwakeSlowDaemonIsNotSleep(unittest.TestCase):
+    """Kewei re-review blocker: a large tick gap while AWAKE must not renew
+    the grace — sleep evidence is wall-vs-monotonic skew, not gap size."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.tasks = root / "tasks"; self.tasks.mkdir()
+        self.state = root / "state"; self.state.mkdir()
+        self.results = root / "results"; self.results.mkdir()
+        self.wall = 1000.0
+        self.mono = 500.0
+        self.lead = PoolLead(self.tasks, self.state,
+                             followers_fn=lambda: ["core-1", "core-2"],
+                             alive_fn=lambda i: i == "core-1",
+                             now_fn=lambda: self.wall,
+                             mono_fn=lambda: self.mono,
+                             results_dir=self.results)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _stale_claim(self):
+        f = self.tasks / "task-w.claimed-core-2.txt"
+        f.write_text("id: task-w\n")
+        return f
+
+    def test_slow_awake_ticks_never_defer(self):
+        # wall and monotonic advance together: no skew, no grace, ever
+        claim = self._stale_claim()
+        self.lead.reclaim_claimed()
+        for _ in range(5):
+            self.wall += 300.0; self.mono += 300.0
+            out = self.lead.reclaim_claimed()
+        self.assertFalse(claim.exists(), "dead core-2's claim must repool")
+
+    def test_sleep_skew_opens_one_expiring_grace(self):
+        claim = self._stale_claim()
+        self.lead.reclaim_claimed()
+        self.wall += 300.0; self.mono += 2.0  # host slept ~298s
+        self.assertEqual(self.lead.reclaim_claimed(), [], "grace after sleep")
+        self.wall += LEAD_STALE_S + 1; self.mono += LEAD_STALE_S + 1
+        self.lead.reclaim_claimed()
+        self.assertFalse(claim.exists(), "grace expired: reclaim resumes")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -34,17 +34,20 @@ class WakeGuardBase(unittest.TestCase):
         self.pool = ["core-1", "core-2"]
         self.alive = {"core-1": True, "core-2": True}
         self.clock = 1_000.0
+        self.mono = 500.0
         self.lead = PoolLead(self.tasks, self.state,
                              followers_fn=lambda: list(self.pool),
                              alive_fn=lambda i: self.alive.get(i, False),
                              now_fn=lambda: self.clock,
+                             mono_fn=lambda: self.mono,
                              results_dir=self.results)
 
     def tearDown(self):
         self.tmp.cleanup()
 
     def _sleep_whole_host(self, seconds):
-        """What a clamshell sleep does: every beat ages together, clock jumps."""
+        """What a clamshell sleep does: every beat ages together, wall jumps
+        and monotonic does NOT — that skew is the evidence under test."""
         for inst in self.pool:
             self.alive[inst] = False
         self.clock += seconds
@@ -58,6 +61,7 @@ class WakeGuardBase(unittest.TestCase):
         outs = []
         while self.clock < target:
             self.clock += 2
+            self.mono += 2          # awake: both clocks advance together
             outs += fn()
         return outs
 
@@ -65,12 +69,14 @@ class WakeGuardBase(unittest.TestCase):
 class HostGapDefersReclaim(WakeGuardBase):
     def test_claim_of_live_core_survives_a_host_sleep(self):
         (self.tasks / "task-a.claimed-core-2.txt").write_text("x")
+        self.assertEqual(self.lead.reclaim_claimed(), [])  # baseline tick
         self._sleep_whole_host(968)
         self.assertEqual(self.lead.reclaim_claimed(), [])
         self.assertEqual(self._names(), ["task-a.claimed-core-2.txt"])
 
     def test_assignment_survives_a_host_sleep(self):
         (self.tasks / "task-b.assigned-core-1.txt").write_text("x")
+        self.assertEqual(self.lead.reclaim_dead(), [])  # baseline tick
         self._sleep_whole_host(968)
         self.assertEqual(self.lead.reclaim_dead(), [])
         self.assertEqual(self._names(), ["task-b.assigned-core-1.txt"])
@@ -190,9 +196,10 @@ class AwakeSlowDaemonIsNotSleep(unittest.TestCase):
         self.results = root / "results"; self.results.mkdir()
         self.wall = 1000.0
         self.mono = 500.0
+        self.alive = {"core-1": True, "core-2": True}
         self.lead = PoolLead(self.tasks, self.state,
                              followers_fn=lambda: ["core-1", "core-2"],
-                             alive_fn=lambda i: i == "core-1",
+                             alive_fn=lambda i: self.alive.get(i, False),
                              now_fn=lambda: self.wall,
                              mono_fn=lambda: self.mono,
                              results_dir=self.results)
@@ -200,28 +207,60 @@ class AwakeSlowDaemonIsNotSleep(unittest.TestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
-    def _stale_claim(self):
+    def _claim_of_live_core(self):
         f = self.tasks / "task-w.claimed-core-2.txt"
         f.write_text("id: task-w\n")
         return f
 
+    def _baseline_tick(self, claim):
+        """Seed the wall/monotonic pair the NEXT tick is compared against.
+
+        Without this the first call hits the fresh-lead branch, and with a
+        sibling alive it repools immediately — every later assertion then
+        holds for a claim that is already gone, so the gap-only rule passes
+        the suite too.
+        """
+        self.assertEqual(self.lead.reclaim_claimed(), [],
+                         "claimant alive: nothing to reclaim yet")
+        self.assertTrue(claim.exists(), "baseline must not consume the claim")
+
     def test_slow_awake_ticks_never_defer(self):
         # wall and monotonic advance together: no skew, no grace, ever
-        claim = self._stale_claim()
-        self.lead.reclaim_claimed()
+        claim = self._claim_of_live_core()
+        self._baseline_tick(claim)
+        self.alive["core-2"] = False          # now it genuinely dies
+        self.wall += 300.0; self.mono += 300.0
+        self.assertEqual(self.lead.reclaim_claimed(),
+                         [("task-w.claimed-core-2.txt", "repooled")],
+                         "a 300s AWAKE gap is not sleep: reclaim must proceed")
+        self.assertFalse(claim.exists())
+
+    def test_repeated_long_awake_gaps_never_renew_a_grace(self):
+        # his second shape: a recurring 60s recovery timeout must not keep
+        # re-opening the window ahead of the observation that it expired
+        claim = self._claim_of_live_core()
+        self._baseline_tick(claim)
+        self.alive["core-2"] = False
         for _ in range(5):
-            self.wall += 300.0; self.mono += 300.0
-            out = self.lead.reclaim_claimed()
-        self.assertFalse(claim.exists(), "dead core-2's claim must repool")
+            self.wall += 60.0; self.mono += 60.0
+            if not claim.exists():
+                break
+            self.lead.reclaim_claimed()
+        self.assertFalse(claim.exists(),
+                         "repeated awake 60s gaps must not defer forever")
 
     def test_sleep_skew_opens_one_expiring_grace(self):
-        claim = self._stale_claim()
-        self.lead.reclaim_claimed()
+        claim = self._claim_of_live_core()
+        self._baseline_tick(claim)
+        self.alive["core-2"] = False
         self.wall += 300.0; self.mono += 2.0  # host slept ~298s
         self.assertEqual(self.lead.reclaim_claimed(), [], "grace after sleep")
+        self.assertTrue(claim.exists(), "claim survives inside the grace")
         self.wall += LEAD_STALE_S + 1; self.mono += LEAD_STALE_S + 1
-        self.lead.reclaim_claimed()
-        self.assertFalse(claim.exists(), "grace expired: reclaim resumes")
+        self.assertEqual(self.lead.reclaim_claimed(),
+                         [("task-w.claimed-core-2.txt", "repooled")],
+                         "grace expired: reclaim resumes")
+        self.assertFalse(claim.exists())
 
 
 if __name__ == "__main__":

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 
@@ -64,6 +65,72 @@ class WakeGuardBase(unittest.TestCase):
             self.mono += 2          # awake: both clocks advance together
             outs += fn()
         return outs
+
+
+class TheWakeRecordHasOneWriterContract(WakeGuardBase):
+    """Overlapping leads are production-supported (TOCTOU pgrep + KeepAlive),
+    so the shared record needs collision-safe staging and merge semantics."""
+
+    def _open_deadline(self):
+        self.lead._save_wake_evidence(self.clock, self.mono, self.mono + LEAD_STALE_S)
+        return self.mono + LEAD_STALE_S
+
+    def test_concurrent_writers_never_publish_a_torn_record(self):
+        # NON-DISCRIMINATING on this platform: in-process threads did not
+        # reproduce the tear at the parent. Kept as a non-regression guard.
+        want = self._open_deadline()
+        start = threading.Barrier(4)
+
+        def writer(n):
+            start.wait()
+            for i in range(40):
+                # Variable-length payloads tear a shared temp name; mono stays
+                # <= the reader's, since a future mono reads as a reboot.
+                self.lead._save_wake_evidence(self.clock + n, self.mono - n,
+                                              want if i % 2 else None)
+        ts = [threading.Thread(target=writer, args=(n,)) for n in range(4)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join()
+        got = self.lead._load_wake_evidence()
+        self.assertIsNotNone(got, "concurrent writers published a torn record")
+        self.assertEqual(len(got), 3)
+
+    def test_a_deadline_free_sample_does_not_erase_an_open_deadline(self):
+        want = self._open_deadline()
+        self.lead._save_wake_evidence(self.clock, self.mono, None)
+        got = self.lead._load_wake_evidence()
+        self.assertIsNotNone(got)
+        self.assertEqual(got[2], want,
+                         "a deadline-free sample erased the open grace window")
+
+    def test_a_torn_record_would_reach_the_reclaim_decision(self):
+        # CONTROL for the consequence: a successor seeding from the record must
+        # still defer, which is what keeps a live claim from being repooled.
+        want = self._open_deadline()
+        self.lead._save_wake_evidence(self.clock, self.mono, None)
+        successor = self.lead
+        for attr in ("_last_reclaim_tick", "_last_reclaim_mono", "_reclaim_defer_until"):
+            if hasattr(successor, attr):
+                delattr(successor, attr)
+        self.assertTrue(successor._host_gap_defers_reclaim(),
+                        "successor lost the grace and would repool a live claim")
+        self.assertLess(self.mono, want)
+
+    def test_publication_failure_is_observable(self):
+        real = Path.write_text
+
+        def boom(self_p, *a, **k):
+            raise OSError("disk full")
+        Path.write_text = boom
+        try:
+            ok = self.lead._save_wake_evidence(self.clock, self.mono, None)
+        finally:
+            Path.write_text = real
+        # `is False`, not assertFalse: the parent returns None, which is falsy
+        # and would pass — a check that cannot fail certifies nothing.
+        self.assertIs(ok, False, "a failed publication reported success")
 
 
 class SuspensionAfterTheEntryGuard(WakeGuardBase):

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -52,6 +52,15 @@ class WakeGuardBase(unittest.TestCase):
     def _names(self):
         return sorted(f.name for f in self.tasks.iterdir())
 
+    def _tick_until(self, target, fn):
+        """Advance like the live daemon: 2s ticks, collecting reclaim output.
+        A single clock leap between calls would read as ANOTHER host sleep."""
+        outs = []
+        while self.clock < target:
+            self.clock += 2
+            outs += fn()
+        return outs
+
 
 class HostGapDefersReclaim(WakeGuardBase):
     def test_claim_of_live_core_survives_a_host_sleep(self):
@@ -73,13 +82,49 @@ class HostGapDefersReclaim(WakeGuardBase):
         self.assertEqual(self.lead.reclaim_stuck_assignments(), [])
         self.assertEqual(self._names(), ["task-c.assigned-core-1.txt"])
 
-    def test_woken_follower_clears_the_deferral(self):
+    def test_claim_owner_rebeat_within_grace_keeps_claim(self):
         (self.tasks / "task-d.claimed-core-2.txt").write_text("x")
         self._sleep_whole_host(968)
         self.assertEqual(self.lead.reclaim_claimed(), [])
         self.alive["core-2"] = True          # beat resumes on wake
         self.assertEqual(self.lead.reclaim_claimed(), [])
         self.assertEqual(self._names(), ["task-d.claimed-core-2.txt"])
+
+    def test_sibling_beating_first_does_not_end_the_grace(self):
+        # after wake a sibling can beat BEFORE the claim owner; the grace
+        # must hold on the lead's tick gap, not on any-follower-alive
+        (self.tasks / "task-e.claimed-core-2.txt").write_text("x")
+        self.assertEqual(self.lead.reclaim_claimed(), [])  # pre-sleep tick
+        self._sleep_whole_host(968)
+        self.alive["core-1"] = True          # sibling beats first
+        self.assertEqual(self.lead.reclaim_claimed(), [])
+        self.assertEqual(self.lead.reclaim_dead(), [])
+        self.assertEqual(self._names(), ["task-e.claimed-core-2.txt"])
+
+    def test_sibling_first_after_lead_observed_all_stale(self):
+        # other ordering: lead observes all-stale, THEN the sibling
+        # beats — the open window must not close early
+        (self.tasks / "task-f.claimed-core-2.txt").write_text("x")
+        self.assertEqual(self.lead.reclaim_claimed(), [])  # pre-sleep tick
+        self._sleep_whole_host(968)
+        self.assertEqual(self.lead.reclaim_claimed(), [])  # observes all-stale
+        self.alive["core-1"] = True          # sibling beats second
+        self.clock += 2
+        self.assertEqual(self.lead.reclaim_claimed(), [])
+        self.assertEqual(self._names(), ["task-f.claimed-core-2.txt"])
+
+    def test_grace_expires_by_time_and_still_stale_claimant_repools(self):
+        # the window is a grace, not amnesty: a claimant that never
+        # re-beats is reclaimed once the window passes, sibling alive or not.
+        (self.tasks / "task-g.claimed-core-2.txt").write_text(
+            "id: task-g\n")
+        self.assertEqual(self.lead.reclaim_claimed(), [])  # pre-sleep tick
+        self._sleep_whole_host(968)
+        self.alive["core-1"] = True
+        self.assertEqual(self.lead.reclaim_claimed(), [])  # in grace
+        outs = self._tick_until(968 + 1_000 + LEAD_STALE_S + 4,
+                                self.lead.reclaim_claimed)
+        self.assertEqual(outs, [("task-g.claimed-core-2.txt", "repooled")])
 
 
 class GenuineFailuresStillReclaim(WakeGuardBase):
@@ -96,9 +141,9 @@ class GenuineFailuresStillReclaim(WakeGuardBase):
         (self.tasks / "task-f.claimed-core-1.txt").write_text("x")
         self._sleep_whole_host(968)
         self.assertEqual(self.lead.reclaim_claimed(), [])
-        self.clock += LEAD_STALE_S + 1        # still nothing beating
-        self.assertEqual(self.lead.reclaim_claimed(),
-                         [("task-f.claimed-core-1.txt", "repooled")])
+        outs = self._tick_until(self.clock + LEAD_STALE_S + 4,
+                                self.lead.reclaim_claimed)  # nothing beating
+        self.assertEqual(outs, [("task-f.claimed-core-1.txt", "repooled")])
         self.assertEqual(self._names(), ["task-f.txt"])
 
     def test_empty_pool_is_not_a_host_gap(self):
@@ -128,9 +173,9 @@ class DeliveredTasksKeepTheirDisposition(WakeGuardBase):
         (self.results / "task-i.txt").write_text("answer")
         self._sleep_whole_host(968)
         self.assertEqual(self.lead.reclaim_claimed(), [])
-        self.clock += LEAD_STALE_S + 1
-        self.assertEqual(self.lead.reclaim_claimed(),
-                         [("task-i.claimed-core-2.txt", "delivered")])
+        outs = self._tick_until(self.clock + LEAD_STALE_S + 4,
+                                self.lead.reclaim_claimed)
+        self.assertEqual(outs, [("task-i.claimed-core-2.txt", "delivered")])
 
 
 if __name__ == "__main__":

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -387,6 +387,37 @@ class RestartedLeadInheritsWakeEvidence(WakeGuardBase):
         self.assertEqual(lead.reclaim_claimed(), [])
         self.assertEqual(self._names(), ["task-restart.claimed-core-2.txt"])
 
+    def test_a_respawn_inside_the_open_window_keeps_the_grace(self):
+        """THE REGRESSION. The deadline used to live only on the PoolLead
+        object while the durable sample was overwritten with the post-wake
+        pair, so a lead dying inside its own window handed the successor
+        evidence showing NO skew -- and a non-None seeded sample also
+        excluded it from the cold-lead fallback. Both escapes closed at
+        once, and a live core's claim was repooled."""
+        (self.tasks / "task-respawn.claimed-core-2.txt").write_text("x")
+        self._sleep_whole_host(968)      # wall jumps, monotonic does not
+        self.assertEqual(self.lead.reclaim_claimed(), [],
+                         "the first lead must open the grace window")
+        self.clock += 4
+        self.mono += 4                   # 4s later: still inside the window
+        self.assertEqual(self._restart_lead().reclaim_claimed(), [],
+                         "a successor inside the open window inherits it")
+        self.assertEqual(self._names(), ["task-respawn.claimed-core-2.txt"])
+
+    def test_control_a_respawn_after_the_window_still_reclaims(self):
+        """The discriminating control: inheritance must expire by TIME, or
+        the fix converts one host sleep into an unbounded deferral. Without
+        this, a test suite cannot tell the fix from a blanket defer."""
+        (self.tasks / "task-respawn.claimed-core-2.txt").write_text("x")
+        self._sleep_whole_host(968)
+        self.assertEqual(self.lead.reclaim_claimed(), [])
+        self.clock += LEAD_STALE_S + 10
+        self.mono += LEAD_STALE_S + 10   # the window has expired
+        self.assertEqual(
+            self._restart_lead().reclaim_claimed(),
+            [("task-respawn.claimed-core-2.txt", "repooled")],
+            "an expired window must not be inherited")
+
     def test_control_a_restart_without_a_sleep_still_reclaims_a_dead_owner(self):
         """The discriminating case: inherited evidence must not become a
         blanket deferral. Lead restarts with NO wall/monotonic skew, so a

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -262,6 +262,35 @@ class AwakeSlowDaemonIsNotSleep(unittest.TestCase):
                          "grace expired: reclaim resumes")
         self.assertFalse(claim.exists())
 
+    def test_grace_expires_on_monotonic_despite_a_backward_wall_step(self):
+        # The host clock is adjustable; a backward correction must not stretch
+        # one 90s stale window into hours of withheld recovery.
+        claim = self._claim_of_live_core()
+        self._baseline_tick(claim)
+        self.wall += 3600.0                      # a sleep opens grace
+        self.mono += 1.0
+        self.alive["core-2"] = False             # owner now reads dead
+        self.assertEqual(self.lead.reclaim_claimed(), [], "grace must open")
+        self.assertTrue(claim.exists())
+
+        self.mono += 91.0                        # past LEAD_STALE_S
+        self.wall -= 3600.0                      # ...and the wall steps BACK
+        self.assertEqual([r for r, _ in self.lead.reclaim_claimed()],
+                         ["task-w.claimed-core-2.txt"],
+                         "a wall correction must not extend the grace window")
+
+    def test_grace_still_holds_inside_the_monotonic_window(self):
+        # Control: the test above must not pass merely by never deferring.
+        claim = self._claim_of_live_core()
+        self._baseline_tick(claim)
+        self.wall += 3600.0
+        self.mono += 1.0
+        self.alive["core-2"] = False
+        self.assertEqual(self.lead.reclaim_claimed(), [], "grace must open")
+        self.mono += 10.0                        # well inside the window
+        self.assertEqual(self.lead.reclaim_claimed(), [], "still deferred")
+        self.assertTrue(claim.exists())
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -132,7 +132,7 @@ class TheWakeRecordHasOneWriterContract(WakeGuardBase):
         def opener():
             loaded.wait(5)
             # production writer, the deadline-carrying half
-            opened.append(other._save_wake_evidence(self.clock, self.mono, want))
+            opened.append(other._save_wake_evidence(self.clock, self.mono, want)[0])
         t = threading.Thread(target=opener)
         t.start()
         # production writer, the deadline-FREE half that must not clobber
@@ -158,6 +158,77 @@ class TheWakeRecordHasOneWriterContract(WakeGuardBase):
         got = self.lead._load_wake_evidence()
         self.assertEqual(got[2], longer, "a shorter sample truncated the window")
 
+    def _seed_a_lead_with_no_window_of_its_own(self):
+        """Give the lead an in-process sample with followers ALIVE, so the
+        cold-lead fallback cannot fire and there is no skew. Without this the
+        lead opens its OWN window and the peer's deadline is never needed —
+        which is exactly how the first version of these tests was vacuous."""
+        self.alive = {i: True for i in self.pool}
+        self.assertFalse(self.lead._host_gap_defers_reclaim(),
+                         "seed opened a window — the lead is not neutral")
+        self.clock += 2
+        self.mono += 2          # awake seconds: both clocks move, no skew
+
+    def test_a_lagging_lead_adopts_the_grace_a_peer_committed(self):
+        """keweichen: the lock made the RECORD atomic, but the DECISION was
+        still read from the caller's PRE-merge value, so a lead that had just
+        merged a peer's open deadline still repooled a live claim. Drives the
+        production `reclaim_claimed()` post-liveness re-check."""
+        live = self.tasks / "task-live.claimed-core-2.txt"
+        live.write_text("x")
+        self._seed_a_lead_with_no_window_of_its_own()
+        other, opened = self._second_lead(), {}
+
+        def alive(_inst):
+            # core-2 is dead, and a PEER opens grace during this very
+            # liveness read — the window the re-check exists to catch.
+            if not opened:
+                self.clock += 2
+                self.mono += 2
+                du = self.mono + LEAD_STALE_S
+                other._reclaim_defer_until = du
+                other._save_wake_evidence(self.clock, self.mono, du)
+                opened["du"] = du
+            return False
+        self.lead.alive_fn = alive
+
+        got = self.lead.reclaim_claimed()
+
+        self.assertTrue(opened, "the peer never opened grace — probe never fired")
+        self.assertEqual(got, [], "repooled a live claim while a peer's grace was open")
+        self.assertTrue(live.exists(), "the live claim was renamed away")
+
+    def test_control_once_the_window_expires_the_same_path_DOES_reclaim(self):
+        """Stops the test above from passing by simply never reclaiming."""
+        live = self.tasks / "task-live.claimed-core-2.txt"
+        live.write_text("x")
+        self._seed_a_lead_with_no_window_of_its_own()
+        self.alive = {i: False for i in self.pool}
+        self.lead.alive_fn = lambda _i: False
+        got = self.lead.reclaim_claimed()
+        self.assertNotEqual(got, [],
+                            "with no peer grace open the path refused to reclaim — "
+                            "the deferral is not conditional at all")
+
+    def test_an_older_sample_never_replaces_a_newer_one(self):
+        """The loader bounds a deadline by the STORED mono, so publishing an
+        older mono beside a newer deadline VOIDS that grace on the next read —
+        the record stays writable while the protection silently disappears."""
+        other = self._second_lead()
+        self.clock += 4
+        self.mono += 4
+        du = self.mono + LEAD_STALE_S
+        other._save_wake_evidence(self.clock, self.mono, du)
+
+        ok, eff = self.lead._save_wake_evidence(self.clock - 4, self.mono - 4, None)
+
+        self.assertTrue(ok, "the lagging write did not publish")
+        rec = self.lead._load_wake_evidence()
+        self.assertIsNotNone(rec, "record unreadable after the lagging write")
+        self.assertEqual(rec[2], du,
+                         "an older sample voided the peer's open deadline on read")
+        self.assertEqual(eff, du, "the writer did not report the committed deadline")
+
     def test_an_unpublishable_window_is_refused_and_reported_not_renewed(self):
         """keweichen: `_save_wake_evidence` returning False was discarded at
         both call sites, so a failing publish let each restart re-open the same
@@ -167,7 +238,7 @@ class TheWakeRecordHasOneWriterContract(WakeGuardBase):
         self.lead._save_wake_evidence(self.clock, self.mono, None)
         self._sleep_whole_host(968)      # skew: wall jumps, mono does not
 
-        self.lead._save_wake_evidence = lambda *a, **k: False   # disk refuses
+        self.lead._save_wake_evidence = lambda *a, **k: (False, None)  # disk refuses
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             deferred = self.lead._host_gap_defers_reclaim()
@@ -208,7 +279,7 @@ class TheWakeRecordHasOneWriterContract(WakeGuardBase):
             raise OSError("disk full")
         Path.write_text = boom
         try:
-            ok = self.lead._save_wake_evidence(self.clock, self.mono, None)
+            ok, _eff = self.lead._save_wake_evidence(self.clock, self.mono, None)
         finally:
             Path.write_text = real
         # `is False`, not assertFalse: the parent returns None, which is falsy

--- a/tests/pool-lead-wake-guard.test.py
+++ b/tests/pool-lead-wake-guard.test.py
@@ -375,14 +375,15 @@ class RestartedLeadInheritsWakeEvidence(WakeGuardBase):
         self.assertEqual(self._names(), ["task-restart.claimed-core-2.txt"])
 
     def test_control_no_predecessor_evidence_keeps_the_old_behaviour(self):
-        """Nothing persisted: the all-stale fallback still decides, so this
-        change adds a path rather than replacing one."""
+        """Nothing persisted: the all-stale fallback still decides. Asserted
+        through behaviour, not the new helper, so it runs unchanged against
+        the parent — an equivalence control has to be able to."""
         (self.tasks / "task-restart.claimed-core-2.txt").write_text("x")
         for inst in self.pool:
             self.alive[inst] = False
         lead = self._restart_lead()          # never ticked; no file on disk
-        self.assertIsNone(lead._load_wake_evidence())
         self.assertEqual(lead.reclaim_claimed(), [])
+        self.assertEqual(self._names(), ["task-restart.claimed-core-2.txt"])
 
     def test_control_a_restart_without_a_sleep_still_reclaims_a_dead_owner(self):
         """The discriminating case: inherited evidence must not become a


### PR DESCRIPTION
## Why this PR exists

Supersedes #3411. That PR's base stack (`feat/pool-operability`) was closed as superseded by #3604, which adopts the rescue line (`rescue/pool-uncommitted-2026-08-26`) — the line the live pool actually runs. This re-homes #3411's own work onto that line so the wake-aware reclaim guard can land where the pool code lives.

**Stack / merge order:** parent is #3604 (`rescue/pool-uncommitted-2026-08-26` → `main`). Merge #3604 first, then this PR. This PR targets the rescue branch directly so its diff is the child layer only (4 files, +559/-23).

## Live motivation

2026-09-03 ~04:xxZ: a ~25-minute host sleep aged every follower `.alive` file past `LEAD_STALE_S` at once. The lead read that as N dead cores and repooled a held release-task claim from core-1 to core-2. A host sleep is not N dead followers; the lead must defer reclaim for one stale window when it has sleep evidence.

## What the guard does (unchanged from #3411 head 80e0af82)

- Sleep evidence is **wall-vs-monotonic skew** across the lead's own reclaim tick (`SLEEP_SKEW_S`), not tick-gap size — an awake-but-slow daemon shows wall ≈ mono and gets no grace.
- The grace, once open, **expires on the monotonic clock** (`_reclaim_defer_until = mono + LEAD_STALE_S`), so a backward wall correction cannot stretch one window into hours.
- A **restarted lead reads its predecessor's `(wall, mono)` sample** from `state/pool/lead-tick.json`, so tick 1 after a respawn is covered; a reboot (stored mono ahead of ours) discards it.
- Skew is **re-checked after the owner liveness read** in both `reclaim_dead` and `reclaim_claimed`, closing the window where suspension begins after the entry guard sampled.
- `reclaim_stuck_assignments` also defers. Empty pool and a raising `followers_fn` never defer.

Rescue's busy-aware claim/reclaim design (`ASSIGN_STUCK_S`, `BUSY_EXIT_GRACE_S`, `_claiming`, `reclaim_stuck_assignments`, `reclaim_claimed`) is kept as-is; the guard is added in front of it.

## Cherry-picked verbatim vs ported

All 11 non-merge commits of `origin/feat/pool-operability..origin/fix/wake-aware-reclaim-guard` were cherry-picked in order (`git cherry-pick`, original author/date kept). None were hand-ported.

| #3411 commit | here | conflict? |
|---|---|---|
| 168ce1e8 fix(pool): a host sleep is not N dead followers… | c15a0677 | clean |
| 29c32866 fix(pool): host-gap evidence from the lead's own tick gap… | 10a20a56 | context-only: rescue lacks `AFFINITY_IDLE_S` block; kept rescue's constants, inserted `HOST_GAP_S` above them |
| ab1ec95a fix(pool): sleep evidence is wall-vs-monotonic skew… | beafc27b | context-only: `__init__` signature — rescue has `runtime_fn`; resolved to `mono_fn=time.monotonic, runtime_fn=None` (same as #3411's final signature) |
| 19b95bab test(pool): awake fixtures drive wall and monotonic… | 6f8d917c | clean |
| 2fb23d93 test(pool): the awake-gap tests never reached the rule… | 6c0e4cd6 | clean |
| 3e4ad0ba fix(pool): the reclaim grace expires on the monotonic clock | e66cdaa2 | clean |
| 35d8b8b1 fix(pool): re-check sleep skew after the liveness read… | e276dd73 | clean |
| bf3f9c90 fix(pool): a restarted lead reads its predecessor's clock sample | 12105b08 | clean |
| b0e0e00a test(pool): assert the equivalence control through behaviour | 74d21523 | clean |
| 59013e32 style: split a four-line trailing-comment run… | 13a281e8 | clean |
| 80e0af82 test(pool): a failed evidence write must not stop recovery | e17b8bf2 | clean |

Interdiff check: the `+`/`-` lines of `src/runtime-api/pool_lead.py` in this PR's cumulative diff are byte-identical to those in `git diff origin/feat/pool-operability..origin/fix/wake-aware-reclaim-guard -- src/runtime-api/pool_lead.py` (`diff` of the two line sets is empty).

## Review state carried from #3411

- **keweichen, CHANGES_REQUESTED at bc464f67 (2026-08-28)** filed three code blockers; each is carried here by the same commit that fixed it on #3411:
  1. restarted lead loses the sibling-first wake race → 12105b08 (`_load_wake_evidence` / `_save_wake_evidence`, `RestartedLeadInheritsWakeEvidence` tests incl. the daemon-order control)
  2. suspension can begin after the entry guard samples → e276dd73 (post-liveness re-check in both `reclaim_dead` and `reclaim_claimed`, `SuspensionAfterTheEntryGuard` tests)
  3. grace deadline used adjustable wall time → e66cdaa2 (monotonic deadline, `test_grace_expires_on_monotonic_despite_a_backward_wall_step` + control)
  His earlier blockers at 1cf65dbc / 29c32866 (any-alive clearing; awake tick-gap renewing grace) are carried by 10a20a56 and beafc27b.
- **john-the-dev, APPROVED at 80e0af82 (2026-08-29)** — that head is the last commit of the cherry-picked series (e17b8bf2 here); the code content is identical, only the base differs.
- **Still open from keweichen's review:** the repository-required live witness (an exact-head post-restart sleep/wake round trip). I did **not** run one for this re-home — no host suspend was performed in this session. What is below is harness-only evidence; the live witness is still owed before merge.

## Evidence

Parent = `e5456edc` (`origin/rescue/pool-uncommitted-2026-08-26`). Head = `e17b8bf2`.

**Before (parent e5456edc)** — the test file does not exist on the parent (`git ls-tree origin/rescue/pool-uncommitted-2026-08-26 tests/pool-lead-wake-guard.test.py` → 0 entries). Running HEAD's test file against a `git archive` export of the parent tree:

```text
$ python3 tests/pool-lead-wake-guard.test.py
...
TypeError: PoolLead.__init__() got an unexpected keyword argument 'mono_fn'
   (x25 — every test)
----------------------------------------------------------------------
Ran 25 tests in 0.019s

FAILED (errors=25)
```

**After (head e17b8bf2)**:

```text
$ python3 tests/pool-lead-wake-guard.test.py
----------------------------------------------------------------------
Ran 25 tests in 0.078s

OK

$ python3 tests/pool-hygiene.test.py
Ran 12 tests in 0.342s

OK
$ python3 tests/pool-lead-assignment.test.py
Ran 32 tests in 0.111s

OK
$ python3 tests/pool-lead-daemon.test.py
Ran 4 tests in 0.016s

OK
```

Every other `tests/pool-*.test.py` that imports `pool_lead`, at head:

```text
pool-compose                     Ran 4 tests in 0.018s OK
pool-installer                   Ran 29 tests in 12.004s OK
pool-io-fail-open                Ran 10 tests in 0.015s OK
pool-lane-routing                Ran 24 tests in 0.048s OK
pool-lead-addressing             Ran 14 tests in 0.026s OK
pool-lead-dedicated              Ran 8 tests in 0.019s OK
pool-lead-liveness-trace         Ran 5 tests in 0.012s OK
pool-lead-pin                    Ran 11 tests in 0.032s OK
pool-lead-multi-bind             Ran 7 tests in 0.016s OK
```

Repo gate on the cumulative diff (`git diff origin/rescue/pool-uncommitted-2026-08-26...HEAD`, 740 lines):

```text
$ bash scripts/review-checks.sh --diff <cumulative.diff>
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

Author email on all 11 new commits: `qingyun@ag2.ai`.

Not done here: #3411 is left open (not closed by me), no branch deleted, auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— sutando-qingyun-001 (worker-1)
