### PR TITLE
feat(spawn-worker): a skill that leaves single-worker mode by growing the pool

### DIFF
--- a/skills/spawn-worker/SKILL.md
+++ b/skills/spawn-worker/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: spawn-worker
+description: "Leave single-worker mode: spawn one or more pool workers next to the core, or grow an existing pool. Wraps scripts/install-core-pool.sh, which also ensures the pool lead, so one command moves an install into multi-worker mode."
+user-invocable: true
+---
+
+# Spawn a worker
+
+Sutando ships in **single-worker mode**: the core is the only worker, and no
+`com.sutando.core-N` launchd job exists. When the user wants more hands — "spawn a
+worker", "add two workers", "go multi-worker" — this skill installs or grows the
+lead-follower pool. Every worker is a launchd-managed session sharing this
+workspace; the pool lead assigns tasks to them and the core keeps its own duties
+(see `docs/lead-follower-pool.md`).
+
+**Usage**: `/spawn-worker [N]` — add one worker (default), or `N` workers.
+
+## What to run
+
+```bash
+bash skills/spawn-worker/scripts/spawn-worker.sh --status          # which mode, how many
+bash skills/spawn-worker/scripts/spawn-worker.sh --dry-run         # the plan, no changes
+bash skills/spawn-worker/scripts/spawn-worker.sh                   # +1 worker
+bash skills/spawn-worker/scripts/spawn-worker.sh --count 2         # +2 workers
+bash skills/spawn-worker/scripts/spawn-worker.sh --to 3            # exactly 3 workers
+```
+
+The script prints `plan: installed=<n> target=<n> mode-after=multi-worker`, runs
+`scripts/install-core-pool.sh <target>` (that installer also installs and loads the
+pool lead), waits `SUTANDO_SPAWN_WAIT_S` seconds (default 20) for the first beats,
+then prints `done: mode=multi-worker workers=<n> live=<k> lead=installed`.
+
+## Steps
+
+1. **Status first.** Run `--status` and tell the user the current mode before
+   changing anything. If the pool already has the requested size, say so and stop.
+2. **Spawn.** Run the script with the requested count. It takes 20–60 s: the
+   installer boots out every pool job and the lead, re-stages them, and loads them
+   again. Existing workers' tmux sessions outlive their jobs, so they keep context.
+3. **Verify.** Read the `done:` line. `live` counts workers whose heartbeat is
+   younger than 90 s. A worker missing from `live` a minute after the spawn is a
+   real problem — point the user at `bash scripts/pool-status.sh`, and at
+   `docs/lead-follower-pool.md` → "Triaging a follower that stops working".
+4. **Report** the before/after mode in one line, e.g. "Was single-worker; now
+   multi-worker with 2 workers (both live) and the lead running."
+
+## Guards, by design
+
+- **Runs from the core, never from a worker.** With `SUTANDO_CORE_ID` set the
+  script refuses (exit 2): a worker re-running the installer reboots its own
+  supervisor.
+- **Scale-down is manual.** `--to` below the installed size is refused; removing a
+  worker can strand its live claims, so it stays an explicit
+  `scripts/uninstall-core-pool.sh` step.
+- **`SUTANDO_POOL_MAX`** (default 3) caps the lead's *automatic* growth only. An
+  explicit spawn above it works, but the lead will not add more on its own.
+- The runtime of new workers follows the installer's default (`claude`, or
+  `SUTANDO_POOL_RUNTIME`). To make one worker Codex, use
+  `scripts/install-core-pool.sh --only-core=<n> --core-runtime=<n>:codex` after
+  the spawn, as the design doc's "Turning on a Codex follower" describes.
+
+## Exit codes
+
+`0` done (or nothing to do), `2` usage or refused, otherwise the installer's own
+exit code with the installed count on stderr.

--- a/skills/spawn-worker/scripts/spawn-worker.sh
+++ b/skills/spawn-worker/scripts/spawn-worker.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# spawn-worker.sh — leave single-worker mode by adding workers to the pool.
+#
+# Single-worker mode is the default: the core is the only worker and no
+# com.sutando.core-N launchd job exists. Spawning installs (or grows) the
+# lead-follower pool through scripts/install-core-pool.sh, which also ensures
+# the pool lead, so one command takes an install from "just the core" to
+# multi-worker mode.
+#
+# Usage:
+#   bash skills/spawn-worker/scripts/spawn-worker.sh [--count K | --to N]
+#                                                   [--status] [--dry-run]
+#
+#   (no flags)   add ONE worker to whatever is installed (0 -> 1, 3 -> 4)
+#   --count K    add K workers instead of one
+#   --to N       resize to exactly N workers; N below the installed size is
+#                refused (scale-down is manual: scripts/uninstall-core-pool.sh)
+#   --status     print the current mode and exit; touches nothing
+#   --dry-run    print the plan (installed, target, command) and exit 0
+#
+# Exit codes: 0 done, 2 usage/refused, otherwise the installer's own code.
+#
+# Refuses when SUTANDO_CORE_ID is set: a pool worker re-running the installer
+# reboots its own supervisor. Run it from the core (or a plain shell) instead.
+set -u
+
+SUTANDO_SPAWN_WAIT_S="${SUTANDO_SPAWN_WAIT_S:-20}"
+
+# Installed skills are symlinks, so dirname "$0" points into the skills home,
+# not the repo; resolve the real path before walking up.
+_self="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+REPO="${SUTANDO_ROOT:-$(cd "$(dirname "$_self")/../../.." && pwd)}"
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+
+installed_workers() {
+  local n=0 p
+  shopt -s nullglob
+  for p in "$LAUNCH_AGENTS"/com.sutando.core-[0-9]*.plist; do n=$((n + 1)); done
+  shopt -u nullglob
+  echo "$n"
+}
+
+lead_state() {
+  [ -f "$LAUNCH_AGENTS/com.sutando.pool-lead.plist" ] && echo "installed" || echo "missing"
+}
+
+live_workers() {
+  # A beat younger than 90s is the pool's own liveness rule.
+  local ws n=0 f age now
+  ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" || { echo 0; return; }
+  now="$(date +%s)"
+  shopt -s nullglob
+  for f in "$ws"/state/cores/core-[0-9]*.alive; do
+    age=$(( now - $(stat -f %m "$f" 2>/dev/null || echo 0) ))
+    [ "$age" -lt 90 ] && n=$((n + 1))
+  done
+  shopt -u nullglob
+  echo "$n"
+}
+
+print_status() {
+  local n
+  n="$(installed_workers)"
+  if [ "$n" -eq 0 ]; then
+    echo "mode=single-worker workers=0 lead=$(lead_state)"
+  else
+    echo "mode=multi-worker workers=$n live=$(live_workers) lead=$(lead_state)"
+  fi
+}
+
+COUNT=1
+TO=""
+STATUS=0
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --status) STATUS=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    --count) shift; COUNT="${1:-}" ;;
+    --count=*) COUNT="${1#--count=}" ;;
+    --to) shift; TO="${1:-}" ;;
+    --to=*) TO="${1#--to=}" ;;
+    -h|--help) sed -n '2,24p' "$_self" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "error: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ "$STATUS" -eq 1 ]; then
+  print_status
+  exit 0
+fi
+
+case "$COUNT" in ''|*[!0-9]*|0) echo "error: --count needs a positive integer; got '$COUNT'" >&2; exit 2 ;; esac
+if [ -n "$TO" ]; then
+  case "$TO" in ''|*[!0-9]*|0) echo "error: --to needs a positive integer; got '$TO'" >&2; exit 2 ;; esac
+fi
+
+if [ -n "${SUTANDO_CORE_ID:-}" ]; then
+  echo "refused: this is pool worker core-${SUTANDO_CORE_ID}; spawning from inside a worker reboots its own supervisor. Run from the core." >&2
+  exit 2
+fi
+
+INSTALLED="$(installed_workers)"
+if [ -n "$TO" ]; then
+  TARGET="$TO"
+else
+  TARGET=$((INSTALLED + COUNT))
+fi
+if [ "$TARGET" -lt "$INSTALLED" ]; then
+  echo "refused: --to $TARGET is below the installed $INSTALLED workers; scale-down is manual (scripts/uninstall-core-pool.sh)." >&2
+  exit 2
+fi
+if [ "$TARGET" -eq "$INSTALLED" ]; then
+  echo "nothing to do: $INSTALLED workers already installed ($(print_status))"
+  exit 0
+fi
+
+INSTALLER="$REPO/scripts/install-core-pool.sh"
+[ -f "$INSTALLER" ] || { echo "error: installer not found at $INSTALLER" >&2; exit 2; }
+
+echo "plan: installed=$INSTALLED target=$TARGET mode-after=multi-worker"
+echo "command: bash scripts/install-core-pool.sh $TARGET"
+if [ "$DRY_RUN" -eq 1 ]; then
+  exit 0
+fi
+
+# The full install boots out the lead and every worker job; the tmux sessions
+# outlive the jobs, so a running worker keeps its context across the churn.
+bash "$INSTALLER" "$TARGET"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "spawn-worker: installer exited $rc; installed now: $(installed_workers)" >&2
+  exit "$rc"
+fi
+
+if [ "$SUTANDO_SPAWN_WAIT_S" -gt 0 ] 2>/dev/null; then
+  sleep "$SUTANDO_SPAWN_WAIT_S"
+fi
+echo "done: $(print_status)"

--- a/skills/spawn-worker/scripts/spawn-worker.sh
+++ b/skills/spawn-worker/scripts/spawn-worker.sh
@@ -32,6 +32,11 @@ _self="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BA
 REPO="${SUTANDO_ROOT:-$(cd "$(dirname "$_self")/../../.." && pwd)}"
 LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
 
+# stat's mtime flag differs between BSD and GNU; python is already a dependency.
+_mtime() {
+  python3 -c 'import os, sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$1" 2>/dev/null || echo 0
+}
+
 installed_workers() {
   local n=0 p
   shopt -s nullglob
@@ -53,7 +58,7 @@ live_workers() {
   now="$(date +%s)"
   shopt -s nullglob
   for f in "$ws"/state/cores/core-[0-9]*.alive; do
-    age=$(( now - $(stat -f %m "$f" 2>/dev/null || echo 0) ))
+    age=$(( now - $(_mtime "$f") ))
     [ "$age" -lt 90 ] && n=$((n + 1))
   done
   shopt -u nullglob

--- a/skills/spawn-worker/scripts/spawn-worker.sh
+++ b/skills/spawn-worker/scripts/spawn-worker.sh
@@ -45,9 +45,11 @@ lead_state() {
 }
 
 live_workers() {
-  # A beat younger than 90s is the pool's own liveness rule.
+  # A beat younger than 90s is the pool's own liveness rule. No beat dir means
+  # this checkout resolves a workspace the pool never wrote: unknown, not zero.
   local ws n=0 f age now
-  ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" || { echo 0; return; }
+  ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" || { echo "?"; return; }
+  [ -d "$ws/state/cores" ] || { echo "?"; return; }
   now="$(date +%s)"
   shopt -s nullglob
   for f in "$ws"/state/cores/core-[0-9]*.alive; do

--- a/tests/spawn-worker.test.py
+++ b/tests/spawn-worker.test.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""spawn-worker skill: single-worker -> multi-worker through the installer.
+
+Runs the real skill script against a fake repo in a temp dir: a recording
+stub stands in for scripts/install-core-pool.sh and writes the plists the real
+installer would, so the script's mode detection is exercised end to end. A temp
+$HOME keeps the live launchd domain out of it.
+"""
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT_REL = Path("skills") / "spawn-worker" / "scripts" / "spawn-worker.sh"
+
+INSTALLER_STUB = """#!/bin/bash
+# Records its argv, then materialises N worker plists plus the lead plist.
+printf '%s\\n' "$*" >> "$INSTALLER_LOG"
+[ -n "${INSTALLER_RC:-}" ] && exit "$INSTALLER_RC"
+n="$1"
+d="$HOME/Library/LaunchAgents"
+rm -f "$d"/com.sutando.core-*.plist
+i=1
+while [ "$i" -le "$n" ]; do
+  : > "$d/com.sutando.core-$i.plist"
+  i=$((i + 1))
+done
+: > "$d/com.sutando.pool-lead.plist"
+exit 0
+"""
+
+CONFIG_STUB = """#!/bin/bash
+case "$1" in
+  workspace) echo "$STUB_WORKSPACE" ;;
+  *) exit 2 ;;
+esac
+"""
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class SpawnWorkerTest(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        td = Path(self._td.name)
+        self.repo = td / "repo"
+        # The script resolves the repo from its own real path, so it must live
+        # at the same depth as in the checkout.
+        dst = self.repo / SCRIPT_REL
+        dst.parent.mkdir(parents=True)
+        shutil.copy(REPO / SCRIPT_REL, dst)
+        _write_exec(self.repo / "scripts" / "install-core-pool.sh", INSTALLER_STUB)
+        _write_exec(self.repo / "scripts" / "sutando-config.sh", CONFIG_STUB)
+        self.home = td / "home"
+        self.agents = self.home / "Library" / "LaunchAgents"
+        self.agents.mkdir(parents=True)
+        self.ws = td / "ws"
+        (self.ws / "state" / "cores").mkdir(parents=True)
+        self.log = td / "installer.log"
+        self.env = dict(
+            os.environ,
+            HOME=str(self.home),
+            STUB_WORKSPACE=str(self.ws),
+            INSTALLER_LOG=str(self.log),
+            SUTANDO_SPAWN_WAIT_S="0",
+        )
+        self.env.pop("SUTANDO_CORE_ID", None)
+        self.env.pop("SUTANDO_ROOT", None)
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def run_skill(self, *args, **extra):
+        env = dict(self.env, **extra)
+        return subprocess.run(
+            ["bash", str(self.repo / SCRIPT_REL), *args],
+            env=env, capture_output=True, text=True, timeout=60)
+
+    def installer_calls(self):
+        return self.log.read_text().splitlines() if self.log.exists() else []
+
+    def preinstall(self, n):
+        for i in range(1, n + 1):
+            (self.agents / f"com.sutando.core-{i}.plist").touch()
+        (self.agents / "com.sutando.pool-lead.plist").touch()
+
+    def test_status_single_worker_mode(self):
+        r = self.run_skill("--status")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.strip(), "mode=single-worker workers=0 lead=missing")
+        self.assertEqual(self.installer_calls(), [])
+
+    def test_status_counts_installed_and_live(self):
+        self.preinstall(2)
+        (self.ws / "state" / "cores" / "core-1.alive").touch()
+        r = self.run_skill("--status")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.strip(),
+                         "mode=multi-worker workers=2 live=1 lead=installed")
+
+    def test_dry_run_plans_without_installing(self):
+        r = self.run_skill("--dry-run")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("plan: installed=0 target=1 mode-after=multi-worker", r.stdout)
+        self.assertIn("command: bash scripts/install-core-pool.sh 1", r.stdout)
+        self.assertEqual(self.installer_calls(), [])
+        self.assertFalse(list(self.agents.glob("com.sutando.core-*.plist")))
+
+    def test_spawn_leaves_single_worker_mode(self):
+        r = self.run_skill()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(self.installer_calls(), ["1"])
+        self.assertIn("done: mode=multi-worker workers=1 live=0 lead=installed", r.stdout)
+        self.assertEqual(self.run_skill("--status").stdout.strip(),
+                         "mode=multi-worker workers=1 live=0 lead=installed")
+
+    def test_count_grows_an_existing_pool(self):
+        self.preinstall(1)
+        r = self.run_skill("--count", "2")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(self.installer_calls(), ["3"])
+        self.assertIn("workers=3", r.stdout)
+
+    def test_to_sets_an_exact_size(self):
+        self.preinstall(1)
+        r = self.run_skill("--to=4")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(self.installer_calls(), ["4"])
+
+    def test_to_below_installed_is_refused(self):
+        self.preinstall(3)
+        r = self.run_skill("--to", "2")
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("scale-down is manual", r.stderr)
+        self.assertEqual(self.installer_calls(), [])
+
+    def test_to_equal_installed_is_a_noop(self):
+        self.preinstall(2)
+        r = self.run_skill("--to", "2")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("nothing to do", r.stdout)
+        self.assertEqual(self.installer_calls(), [])
+
+    def test_refuses_from_inside_a_worker(self):
+        r = self.run_skill(SUTANDO_CORE_ID="2")
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("core-2", r.stderr)
+        self.assertEqual(self.installer_calls(), [])
+
+    def test_status_still_works_from_inside_a_worker(self):
+        r = self.run_skill("--status", SUTANDO_CORE_ID="2")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("mode=single-worker", r.stdout)
+
+    def test_installer_failure_propagates_its_code(self):
+        r = self.run_skill(INSTALLER_RC="3")
+        self.assertEqual(r.returncode, 3)
+        self.assertIn("installer exited 3", r.stderr)
+
+    def test_bad_arguments_exit_2(self):
+        for args in (["--count", "0"], ["--count", "x"], ["--to", "-1"], ["--bogus"]):
+            r = self.run_skill(*args)
+            self.assertEqual(r.returncode, 2, args)
+        self.assertEqual(self.installer_calls(), [])
+
+    def test_sutando_root_overrides_path_resolution(self):
+        other = Path(self._td.name) / "other"
+        _write_exec(other / "scripts" / "install-core-pool.sh", INSTALLER_STUB)
+        _write_exec(other / "scripts" / "sutando-config.sh", CONFIG_STUB)
+        r = self.run_skill("--dry-run", SUTANDO_ROOT=str(other))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("target=1", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/spawn-worker.test.py
+++ b/tests/spawn-worker.test.py
@@ -106,6 +106,16 @@ class SpawnWorkerTest(unittest.TestCase):
         self.assertEqual(r.stdout.strip(),
                          "mode=multi-worker workers=2 live=1 lead=installed")
 
+    def test_live_is_unknown_when_the_workspace_has_no_beat_dir(self):
+        # A checkout that resolves an unwritten workspace must not read as
+        # "installed but all dead".
+        self.preinstall(2)
+        shutil.rmtree(self.ws / "state")
+        r = self.run_skill("--status")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.strip(),
+                         "mode=multi-worker workers=2 live=? lead=installed")
+
     def test_dry_run_plans_without_installing(self):
         r = self.run_skill("--dry-run")
         self.assertEqual(r.returncode, 0, r.stderr)


### PR DESCRIPTION
Owner request (Pro-Main, 2026-09-03 06:26Z): *"Can we make it so that when the user is in the default single-worker mode, they spawn up a new worker and operate as multi-worker mode. Ideally via a skill."*

**Stacked on #3604** (`rescue/pool-uncommitted-2026-08-26`) — the installer this wraps lives only on that line. Merge order: #3604 first, then this.

## What it does
`/spawn-worker [N]` → `skills/spawn-worker/scripts/spawn-worker.sh`, a thin wrapper over `scripts/install-core-pool.sh` (which also installs and loads the pool lead):
- no flags: +1 worker (0 → 1 leaves single-worker mode); `--count K`; `--to N` exact size
- `--status`: `mode=single-worker workers=0 lead=missing` or `mode=multi-worker workers=N live=K lead=installed` (live = beats younger than 90 s; `live=?` when the resolved workspace has no beat dir at all)
- `--dry-run`: prints the plan and the exact installer command, changes nothing
- refuses `--to` below the installed size (scale-down stays manual, per the design doc) and refuses to run with `SUTANDO_CORE_ID` set (a worker re-running the installer reboots its own supervisor)
- exit codes: 0 done / nothing to do, 2 usage or refused, else the installer's own code

No behavior change anywhere else: 3 new files, nothing edited. Second commit (`86b19e72`) came out of the live run below: from a worktree whose config resolves an unwritten workspace the first cut printed `workers=4 live=0` — "installed but all dead" — so an absent beat dir now prints `?` and a test pins it.

## Evidence
Parent `be0aebfb`: neither `skills/spawn-worker/` nor `tests/spawn-worker.test.py` exists (`git ls-tree` → 0 entries).

Head, hermetic test (real script, recording installer stub, temp $HOME):
```text
----------------------------------------------------------------------
Ran 14 tests in 0.845s

OK
```

Head, live host (read-only calls only; the live 4-worker pool was NOT resized):
```text
$ spawn-worker.sh --status                       # from the PR worktree: its config resolves an unwritten workspace
mode=multi-worker workers=4 live=? lead=installed
$ SUTANDO_ROOT=<installed checkout> spawn-worker.sh --status
mode=multi-worker workers=4 live=4 lead=installed
$ spawn-worker.sh --dry-run
plan: installed=4 target=5 mode-after=multi-worker
command: bash scripts/install-core-pool.sh 5
$ SUTANDO_CORE_ID=1 spawn-worker.sh
refused: this is pool worker core-1; spawning from inside a worker reboots its own supervisor. Run from the core.
```

Not done: a real 0 → 1 spawn on a single-worker host. This host runs the live 4-worker pool, and spawning a fifth worker from a worker session is exactly what the guard refuses; the owner's own first `/spawn-worker` on a single-worker install is the natural round trip, and I will post its output here when it happens.

Gate: `review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)`; `ruff` clean; `bash -n` clean (shellcheck runs in CI — not installed on this host).

— sutando-qingyun-001 (worker-1)