### PR TITLE
feat(pool): pluggable routing policy — built-ins, rules, custom code; the home seat is a routable member and a single seat is a membership of one

### DIFF
--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -120,16 +120,19 @@ non-positive values fall back to the default rather than disabling affinity.
 assigned. The lead keeps the atomic rename, reclaim and trace; the choice is
 a policy behind one call: `pick(task, workers, affinity) -> worker | None`.
 
-- **Members = one core + N workers.** The core is a routable member
-  (`WorkerView.is_core`), discovered by the daemon from the host heartbeat.
-  Single-core mode is the same policy evaluated over a membership of one
-  (`solo_pick`) — N=0 workers is not a separate code path.
+- **Members.** Every seat the policy may pick is a `MemberView`; the seat that
+  owns the loop, memory and owner relationship is the HOME member
+  (`is_home`, discovered by the daemon from the host heartbeat). A single-seat
+  install is the same policy evaluated over a membership of one (`solo_pick`),
+  not a separate code path. Whether that seat is counted as a worker (N=1) or
+  sits outside the worker count (N=0) is a vocabulary ruling this module does
+  not take — `HOME_ID` and `pool_names` are the two places it lands.
 - **Config** `state/pool/routing.json` (or `$SUTANDO_POOL_ROUTING`), absent →
   `affinity-first` (the lead's historical `_pick`; existing behaviour and tests
   unchanged):
 
   ```json
-  {"policy": "core-first", "allow_delegation": true,
+  {"policy": "home-first", "allow_delegation": true,
    "rules": [
      {"match": {"room_name": "Pro-Main"},  "to": ["core-1"]},
      {"match": {"access_tier": "team"},     "policy": "least-loaded", "exclude": ["core-1"]},
@@ -141,18 +144,18 @@ a policy behind one call: `pick(task, workers, affinity) -> worker | None`.
   `runtime` matches the pool); `to`/`only`/`exclude` narrow candidates
   before the named policy runs. No rule → top-level `policy`.
 - **Built-ins:** `affinity-first`, `least-loaded`, `round-robin`,
-  `sticky-sender`, `core-first` (explicit `target_worker:` → that worker;
-  otherwise the core; no core in the pool → least-loaded).
+  `sticky-sender`, `home-first` (explicit `target_worker:` → that worker;
+  otherwise the home seat; no home seat → least-loaded; `core-first` accepted for one release).
 - **Custom code:** `"policy": "custom:/path/mod.py:pick"` — same signature
   `(task, workers, affinity, state)`. Owner-only surface.
 - **Degrade, never strand:** a policy that raises, or names a worker that is
   not live, is overridden by `affinity-first`; every assignment traces
   `{"event": "routed", policy, rule, fallback, reason}`.
-- **Delegation (work stealing).** With `allow_delegation: true` the core may
+- **Delegation (work stealing).** With `allow_delegation: true` the home seat may
   hand a task it holds to a specific worker (`pool_follower.delegate`, CLI
   `python3 src/pool_follower.py delegate <claimed-path> <me> <worker>`): the
   claimed file becomes that worker's assignment, which the lead's ledger and
-  reclaim already understand. With it false the core must process itself.
+  reclaim already understand. With it false the home seat must process itself.
 
 ## Instance registry touchpoints
 

--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -114,6 +114,46 @@ non-positive values fall back to the default rather than disabling affinity.
   per-channel latency) becomes a lead-side counter file — global view, one
   collection point, no cross-core aggregation.
 
+## Routing policy (pluggable — there is no golden answer)
+
+`src/runtime-api/pool_routing.py` separates WHO takes a task from HOW it is
+assigned. The lead keeps the atomic rename, reclaim and trace; the choice is
+a policy behind one call: `pick(task, workers, affinity) -> worker | None`.
+
+- **Members = one core + N workers.** The core is a routable member
+  (`WorkerView.is_core`), discovered by the daemon from the host heartbeat.
+  Single-core mode is the same policy evaluated over a membership of one
+  (`solo_pick`) — N=0 workers is not a separate code path.
+- **Config** `state/pool/routing.json` (or `$SUTANDO_POOL_ROUTING`), absent →
+  `affinity-first` (the lead's historical `_pick`; existing behaviour and tests
+  unchanged):
+
+  ```json
+  {"policy": "core-first", "allow_delegation": true,
+   "rules": [
+     {"match": {"room_name": "Pro-Main"},  "to": ["core-1"]},
+     {"match": {"access_tier": "team"},     "policy": "least-loaded", "exclude": ["core-1"]},
+     {"match": {"source": "voice"},         "policy": "sticky-sender"}
+   ]}
+  ```
+  Rules are first-match on `TaskMeta` fields (`channel`, `source`,
+  `access_tier`, `priority`, `sender`, `room_name`, `target`, `lane`;
+  `runtime` matches the pool); `to`/`only`/`exclude` narrow candidates
+  before the named policy runs. No rule → top-level `policy`.
+- **Built-ins:** `affinity-first`, `least-loaded`, `round-robin`,
+  `sticky-sender`, `core-first` (explicit `target_worker:` → that worker;
+  otherwise the core; no core in the pool → least-loaded).
+- **Custom code:** `"policy": "custom:/path/mod.py:pick"` — same signature
+  `(task, workers, affinity, state)`. Owner-only surface.
+- **Degrade, never strand:** a policy that raises, or names a worker that is
+  not live, is overridden by `affinity-first`; every assignment traces
+  `{"event": "routed", policy, rule, fallback, reason}`.
+- **Delegation (work stealing).** With `allow_delegation: true` the core may
+  hand a task it holds to a specific worker (`pool_follower.delegate`, CLI
+  `python3 src/pool_follower.py delegate <claimed-path> <me> <worker>`): the
+  claimed file becomes that worker's assignment, which the lead's ledger and
+  reclaim already understand. With it false the core must process itself.
+
 ## Instance registry touchpoints
 
 - Followers register with `role: "follower"` + `pool: <name>` in their

--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -147,7 +147,10 @@ a policy behind one call: `pick(task, workers, affinity) -> worker | None`.
   `sticky-sender`, `home-first` (explicit `target_worker:` → that worker;
   otherwise the home seat; no home seat → least-loaded; `core-first` accepted for one release).
 - **Custom code:** `"policy": "custom:/path/mod.py:pick"` — same signature
-  `(task, workers, affinity, state)`. Owner-only surface.
+  `(task, workers, affinity, state)`. This is a code-execution surface: the
+  state file names a module the lead imports, so keep `state/pool/` owner-only
+  and out of the vault; the path must resolve under the repo or the workspace
+  (a config naming `/tmp/x.py` is refused and traced as a fallback).
 - **Degrade, never strand:** a policy that raises, or names a worker that is
   not live, is overridden by `affinity-first`; every assignment traces
   `{"event": "routed", policy, rule, fallback, reason}`.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -368,6 +368,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`pool_lead.py`** — Lead-side assignment engine (lead-follower pool, slice L1).
 - **`pool_metrics.py`** — Lead-side pool metrics (slice L4 — the owner's 2026-05-19 quality bar).
 - **`pool_notify.py`** — Lead-side progress communication (lead-follower pool, slice L5).
+- **`pool_routing.py`** — Routing policy seam for the pool: WHO takes a task, separated from HOW it is assigned (the lead's atomic rename, reclaim and trace stay in pool_lead).
 - **`pool_scale.py`** — Lead-side follower autoscaling policy (lead-follower pool, slice L6).
 - **`pool_status.py`** — Owner-facing pool snapshot (single writer: the lead daemon).
 - **`protocol.py`** — runtime-api protocol — NDJSON JSON-RPC 2.0 over a local Unix socket.

--- a/scripts/pool-lead-daemon.py
+++ b/scripts/pool-lead-daemon.py
@@ -75,6 +75,15 @@ def _workspace() -> Path:
     return Path(out.stdout.strip())
 
 
+def _host_label() -> str:
+    try:
+        r = subprocess.run(["bash", str(_HERE / "sutando-config.sh"), "host-label"],
+                           capture_output=True, text=True, timeout=15)
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--interval", type=float, default=2.0)
@@ -116,14 +125,7 @@ def main() -> int:
         rt = (m.group(1).strip() if m else "") or "claude"
         return rt if rt in ("claude", "codex") else "claude"
 
-    def host_label() -> str:
-        try:
-            r = subprocess.run(["bash", str(_HERE / "sutando-config.sh"), "host-label"],
-                               capture_output=True, text=True, timeout=15)
-            return r.stdout.strip() if r.returncode == 0 else ""
-        except (OSError, subprocess.SubprocessError):
-            return ""
-    _host = {"label": host_label()}
+    _host = {"label": _host_label()}
     def core_alive() -> bool:
         return bool(_host["label"]) and alive(_host["label"])
     # The core's beat file is host-labelled; it is routed under CORE_ID.

--- a/scripts/pool-lead-daemon.py
+++ b/scripts/pool-lead-daemon.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(_HERE.parent / "src"))
 sys.path.insert(0, str(_HERE.parent / "src" / "runtime-api"))
 
 from pool_follower import LEAD_STALE_S
+from pool_routing import CORE_ID  # noqa: E402
 from pool_lead import PoolLead
 from pool_metrics import PoolMetrics
 from pool_notify import PoolNotifier
@@ -115,8 +116,24 @@ def main() -> int:
         rt = (m.group(1).strip() if m else "") or "claude"
         return rt if rt in ("claude", "codex") else "claude"
 
-    lead = PoolLead(tasks, state, followers, alive,
-                    metrics=PoolMetrics(state), runtime_fn=runtime_of)
+    def host_label() -> str:
+        try:
+            r = subprocess.run(["bash", str(_HERE / "sutando-config.sh"), "host-label"],
+                               capture_output=True, text=True, timeout=15)
+            return r.stdout.strip() if r.returncode == 0 else ""
+        except (OSError, subprocess.SubprocessError):
+            return ""
+    _host = {"label": host_label()}
+    def core_alive() -> bool:
+        return bool(_host["label"]) and alive(_host["label"])
+    # The core's beat file is host-labelled; it is routed under CORE_ID.
+    def core_fn() -> "str | None":
+        return CORE_ID if core_alive() else None
+    def member_alive(inst: str) -> bool:
+        return core_alive() if inst == CORE_ID else alive(inst)
+    lead = PoolLead(tasks, state, followers, member_alive,
+                    metrics=PoolMetrics(state), runtime_fn=runtime_of,
+                    core_fn=core_fn)
     status = PoolStatusWriter(tasks, state, followers, alive,
                               bindings_fn=lead.bindings)
     notifier = PoolNotifier(tasks, state, _send_notice)

--- a/scripts/pool-lead-daemon.py
+++ b/scripts/pool-lead-daemon.py
@@ -29,7 +29,7 @@ sys.path.insert(0, str(_HERE.parent / "src"))
 sys.path.insert(0, str(_HERE.parent / "src" / "runtime-api"))
 
 from pool_follower import LEAD_STALE_S
-from pool_routing import CORE_ID  # noqa: E402
+from pool_routing import HOME_ID  # noqa: E402
 from pool_lead import PoolLead
 from pool_metrics import PoolMetrics
 from pool_notify import PoolNotifier
@@ -126,16 +126,16 @@ def main() -> int:
         return rt if rt in ("claude", "codex") else "claude"
 
     _host = {"label": _host_label()}
-    def core_alive() -> bool:
+    def home_alive() -> bool:
         return bool(_host["label"]) and alive(_host["label"])
-    # The core's beat file is host-labelled; it is routed under CORE_ID.
-    def core_fn() -> "str | None":
-        return CORE_ID if core_alive() else None
+    # The home seat's beat file is host-labelled; it is routed under HOME_ID.
+    def home_fn() -> "str | None":
+        return HOME_ID if home_alive() else None
     def member_alive(inst: str) -> bool:
-        return core_alive() if inst == CORE_ID else alive(inst)
+        return home_alive() if inst == HOME_ID else alive(inst)
     lead = PoolLead(tasks, state, followers, member_alive,
                     metrics=PoolMetrics(state), runtime_fn=runtime_of,
-                    core_fn=core_fn)
+                    home_fn=home_fn)
     status = PoolStatusWriter(tasks, state, followers, alive,
                               bindings_fn=lead.bindings)
     notifier = PoolNotifier(tasks, state, _send_notice)

--- a/src/pool_follower.py
+++ b/src/pool_follower.py
@@ -22,6 +22,9 @@ _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE))
 from task_priority import sort_tasks_by_priority  # noqa: E402
 from task_archive import _move_without_clobbering  # noqa: E402
+sys.path.insert(0, str(_HERE / "runtime-api"))
+from pool_routing import (  # noqa: E402
+    CORE_ID, build_router, load_config, read_task_meta, solo_pick)
 
 LEAD_STALE_S = 90  # 3 missed 30s beats — same threshold every reader uses
 
@@ -91,10 +94,16 @@ def acquire_work(tasks_dir, state_dir, instance: str,
     # results/ is the tasks dir's workspace sibling — derived, not passed,
     # so no caller can omit the guard on the path that exists to survive crashes.
     results_dir = tasks.parent / "results"
+    # Leaderless = the same routing policy over a membership of one; a rule
+    # that excludes this member leaves the file for whoever it allows.
+    router = build_router(Path(state_dir))
     for f in sort_tasks_by_priority(pending):
         # A reclaimed task whose work already produced a result must not be
         # re-executed (same guard as the lead's pooling scan).
         if result_evidence(results_dir, f.name):
+            continue
+        if not solo_pick(router, read_task_meta(f), instance,
+                         is_core=(instance == CORE_ID)):
             continue
         # assignment-suffix convention so lead-side load counting and
         # reclaim see fallback claims (legacy .claimed-core-N stays put)
@@ -105,6 +114,40 @@ def acquire_work(tasks_dir, state_dir, instance: str,
         except OSError:
             continue
     return None
+
+
+def delegate(tasks_dir, state_dir, claimed: Path, instance: str,
+             to_worker: str) -> Path:
+    """Hand a task this member holds to a specific worker (work stealing).
+    Gated by routing.json `allow_delegation`; the result is that worker's
+    assignment, which the lead's ledger and reclaim already understand."""
+    if not load_config(Path(state_dir)).allow_delegation:
+        raise ValueError("delegation is disabled (routing.json allow_delegation)")
+    suffix = f".claimed-{instance}.txt"
+    if not claimed.name.endswith(suffix) or not claimed.name.startswith("task-"):
+        raise ValueError(f"{claimed.name} is not held by {instance}")
+    if not to_worker or to_worker == instance or "/" in to_worker:
+        raise ValueError(f"bad delegation target {to_worker!r}")
+    target = claimed.with_name(
+        claimed.name[:-len(suffix)] + f".assigned-{to_worker}.txt")
+    os.rename(claimed, target)
+    os.utime(target)
+    return target
+
+
+def _delegate_cli(argv: "list[str]") -> int:
+    if len(argv) != 3:
+        print("usage: pool_follower.py delegate <claimed_path> <instance> <worker>",
+              file=sys.stderr)
+        return 2
+    claimed = Path(argv[0]).resolve()
+    workspace = claimed.parent.parent
+    try:
+        print(delegate(claimed.parent, workspace / "state", claimed, argv[1], argv[2]))
+    except (ValueError, OSError) as e:
+        print(f"delegate refused: {e}", file=sys.stderr)
+        return 2
+    return 0
 
 
 def _source_of(claimed: Path) -> str:
@@ -218,6 +261,8 @@ def _finish_cli(argv: "list[str]") -> int:
 if __name__ == "__main__":
     if len(sys.argv) >= 2 and sys.argv[1] == "finish":
         sys.exit(_finish_cli(sys.argv[2:]))
-    print("usage: pool_follower.py finish <claimed_path> <instance>",
-          file=sys.stderr)
+    if len(sys.argv) >= 2 and sys.argv[1] == "delegate":
+        sys.exit(_delegate_cli(sys.argv[2:]))
+    print("usage: pool_follower.py finish <claimed_path> <instance> | "
+          "delegate <claimed_path> <instance> <worker>", file=sys.stderr)
     sys.exit(2)

--- a/src/pool_follower.py
+++ b/src/pool_follower.py
@@ -24,7 +24,7 @@ from task_priority import sort_tasks_by_priority  # noqa: E402
 from task_archive import _move_without_clobbering  # noqa: E402
 sys.path.insert(0, str(_HERE / "runtime-api"))
 from pool_routing import (  # noqa: E402
-    CORE_ID, build_router, load_config, read_task_meta, solo_pick)
+    HOME_ID, build_router, load_config, read_task_meta, solo_pick)
 
 LEAD_STALE_S = 90  # 3 missed 30s beats — same threshold every reader uses
 
@@ -103,7 +103,7 @@ def acquire_work(tasks_dir, state_dir, instance: str,
         if result_evidence(results_dir, f.name):
             continue
         if not solo_pick(router, read_task_meta(f), instance,
-                         is_core=(instance == CORE_ID)):
+                         is_home=(instance == HOME_ID)):
             continue
         # assignment-suffix convention so lead-side load counting and
         # reclaim see fallback claims (legacy .claimed-core-N stays put)

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -25,7 +25,7 @@ _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE.parent))
 from task_priority import sort_tasks_by_priority  # noqa: E402
 from pool_routing import (  # noqa: E402
-    Decision, WorkerView, build_router, read_task_meta)
+    Decision, MemberView, build_router, read_task_meta)
 
 # Depth at which channelless work overflows to the idle lane core; room
 # affinity itself is binding and never yields on load (owner 2026-08-26).
@@ -122,7 +122,7 @@ def _read_lane(path: Path) -> str:
 class PoolLead:
     def __init__(self, tasks_dir, state_dir, followers_fn, alive_fn,
                  now_fn=time.time, metrics=None, results_dir=None,
-                 runtime_fn=None, core_fn=None, router=None):
+                 runtime_fn=None, home_fn=None, router=None):
         """followers_fn() -> list of instance ids eligible for assignment.
         alive_fn(instance) -> bool (fresh heartbeat). Both injected — the
         production binder wires instance_registry + the .alive files.
@@ -140,8 +140,8 @@ class PoolLead:
         self.alive_fn = alive_fn
         self.now = now_fn
         self.metrics = metrics  # PoolMetrics or None; recording is optional
-        # core_fn(): core id while its beat is fresh, else None; never a follower.
-        self.core_fn = core_fn or (lambda: None)
+        # home_fn(): home seat id while its beat is fresh, else None; never a follower.
+        self.home_fn = home_fn or (lambda: None)
         self.router = router or build_router(self.state_dir, self._default_pick)
 
     # ── affinity table (single-writer: the lead) ────────────────────────────
@@ -315,19 +315,18 @@ class PoolLead:
     # ── routing policy seam ───────────────────────────────────────────────
     def _default_pick(self, task, workers, affinity, state):
         """`affinity-first`: the lead's historical choice over the follower
-        subset — the core joins only when a configured policy names it."""
-        followers = [w.id for w in workers if not w.is_core]
+        subset — the home seat joins only when a configured policy names it."""
+        followers = [w.id for w in workers if not w.is_home]
         if not followers:
-            core = next((w.id for w in workers if w.is_core), None)
-            return core
+            return next((w.id for w in workers if w.is_home), None)
         return self._pick(task.channel, followers, affinity, task.lane)
 
-    def _members(self, followers: "list[str]") -> "list[WorkerView]":
-        views = [WorkerView(str(i), self._load(i), self._claiming(i),
+    def _members(self, followers: "list[str]") -> "list[MemberView]":
+        views = [MemberView(str(i), self._load(i), self._claiming(i),
                             self.runtime_fn(i)) for i in followers]
-        core = self.core_fn()
+        core = self.home_fn()
         if core:
-            views.append(WorkerView(str(core), self._load(core),
+            views.append(MemberView(str(core), self._load(core),
                                     self._claiming(core), "claude", True))
         return views
 

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -24,6 +24,8 @@ from pathlib import Path
 _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE.parent))
 from task_priority import sort_tasks_by_priority  # noqa: E402
+from pool_routing import (  # noqa: E402
+    Decision, WorkerView, build_router, read_task_meta)
 
 # Depth at which channelless work overflows to the idle lane core; room
 # affinity itself is binding and never yields on load (owner 2026-08-26).
@@ -120,7 +122,7 @@ def _read_lane(path: Path) -> str:
 class PoolLead:
     def __init__(self, tasks_dir, state_dir, followers_fn, alive_fn,
                  now_fn=time.time, metrics=None, results_dir=None,
-                 runtime_fn=None):
+                 runtime_fn=None, core_fn=None, router=None):
         """followers_fn() -> list of instance ids eligible for assignment.
         alive_fn(instance) -> bool (fresh heartbeat). Both injected — the
         production binder wires instance_registry + the .alive files.
@@ -138,6 +140,9 @@ class PoolLead:
         self.alive_fn = alive_fn
         self.now = now_fn
         self.metrics = metrics  # PoolMetrics or None; recording is optional
+        # core_fn(): core id while its beat is fresh, else None; never a follower.
+        self.core_fn = core_fn or (lambda: None)
+        self.router = router or build_router(self.state_dir, self._default_pick)
 
     # ── affinity table (single-writer: the lead) ────────────────────────────
     def _affinity_path(self) -> Path:
@@ -307,6 +312,39 @@ class PoolLead:
         self._last_pick[str(pick)] = self.now()
         return pick
 
+    # ── routing policy seam ───────────────────────────────────────────────
+    def _default_pick(self, task, workers, affinity, state):
+        """`affinity-first`: the lead's historical choice over the follower
+        subset — the core joins only when a configured policy names it."""
+        followers = [w.id for w in workers if not w.is_core]
+        if not followers:
+            core = next((w.id for w in workers if w.is_core), None)
+            return core
+        return self._pick(task.channel, followers, affinity, task.lane)
+
+    def _members(self, followers: "list[str]") -> "list[WorkerView]":
+        views = [WorkerView(str(i), self._load(i), self._claiming(i),
+                            self.runtime_fn(i)) for i in followers]
+        core = self.core_fn()
+        if core:
+            views.append(WorkerView(str(core), self._load(core),
+                                    self._claiming(core), "claude", True))
+        return views
+
+    def _route(self, f: Path, channel, followers, affinity, lane) -> str:
+        members = self._members(followers)
+        task = read_task_meta(f, lane)
+        d: Decision = self.router.pick(task, members, affinity)
+        inst = d.worker
+        if inst is None or inst not in {m.id for m in members}:
+            inst = self._pick(channel, followers, affinity, lane)
+            d = Decision(inst, d.policy, d.rule, True,
+                         d.reason or "policy declined; lead default")
+        self._trace({"ts": self.now(), "event": "routed", "task": f.name,
+                     "inst": str(inst), "policy": d.policy, "rule": d.rule,
+                     "fallback": d.fallback, "reason": d.reason})
+        return str(inst)
+
     def _fan_out(self, f: Path, followers: "list[str]") -> "list[tuple[str, str]]":
         """One assigned COPY per claiming worker; the original is archived so
         it can't double-assign. Each copy gets a per-worker id suffix so
@@ -393,7 +431,7 @@ class PoolLead:
             if target in followers and self._claiming(target):
                 inst = target  # explicit address outranks bindings + load
             else:
-                inst = self._pick(channel, followers, affinity, lane)
+                inst = self._route(f, channel, followers, affinity, lane)
             if lane == "owner" and (
                     (inst == self._lane_core_of(followers) and inst != bound)
                     or (bound is not None and bound not in followers)):

--- a/src/runtime-api/pool_lead.py
+++ b/src/runtime-api/pool_lead.py
@@ -335,7 +335,7 @@ class PoolLead:
         task = read_task_meta(f, lane)
         d: Decision = self.router.pick(task, members, affinity)
         inst = d.worker
-        if inst is None or inst not in {m.id for m in members}:
+        if inst is None or inst not in {m.id for m in members if m.claiming}:
             inst = self._pick(channel, followers, affinity, lane)
             d = Decision(inst, d.policy, d.rule, True,
                          d.reason or "policy declined; lead default")

--- a/src/runtime-api/pool_routing.py
+++ b/src/runtime-api/pool_routing.py
@@ -71,6 +71,7 @@ class RoutingConfig:
     rules: list = field(default_factory=list)
     allow_delegation: bool = False
     source: "str | None" = None
+    roots: list = field(default_factory=list)
 
 
 def read_task_meta(path: Path, lane: str = "owner") -> TaskMeta:
@@ -97,20 +98,32 @@ def config_path(state_dir: Path) -> Path:
     return Path(env) if env else Path(state_dir) / "pool" / "routing.json"
 
 
+def _custom_roots(state_dir: Path, cfg: Path) -> list:
+    """Where owner code may live: the repo, the workspace that holds the state
+    dir, and the config's own directory. A state file naming /tmp is refused."""
+    repo = Path(__file__).resolve().parents[2]
+    out = []
+    for r in (repo, Path(state_dir).resolve().parent, cfg.resolve().parent):
+        if r not in out:
+            out.append(r)
+    return out
+
+
 def load_config(state_dir: Path) -> RoutingConfig:
     p = config_path(state_dir)
+    roots = _custom_roots(state_dir, p)
     try:
         data = json.loads(p.read_text())
     except (OSError, ValueError):
-        return RoutingConfig()
+        return RoutingConfig(roots=roots)
     if not isinstance(data, dict):
-        return RoutingConfig()
+        return RoutingConfig(roots=roots)
     rules = data.get("rules")
     return RoutingConfig(
         policy=str(data.get("policy") or DEFAULT_POLICY),
         rules=rules if isinstance(rules, list) else [],
         allow_delegation=bool(data.get("allow_delegation", False)),
-        source=str(p))
+        source=str(p), roots=roots)
 
 
 # ── built-in policies ─────────────────────────────────────────────────────
@@ -172,11 +185,14 @@ BUILTINS = {
 }
 
 
-def _load_custom(spec: str):
+def _load_custom(spec: str, roots=()):
     """`custom:<path.py>:<attr>` — owner-supplied code behind the same
     signature. Import failure is a config error: caller falls back."""
     _, path, attr = spec.split(":", 2)
-    mod_spec = importlib.util.spec_from_file_location("sutando_routing_custom", path)
+    resolved = Path(path).resolve()
+    if roots and not any(resolved == r or r in resolved.parents for r in roots):
+        raise PermissionError(f"{spec}: custom policy must live under the repo or the workspace")
+    mod_spec = importlib.util.spec_from_file_location("sutando_routing_custom", str(resolved))
     if mod_spec is None or mod_spec.loader is None:
         raise ImportError(spec)
     mod = importlib.util.module_from_spec(mod_spec)
@@ -206,7 +222,7 @@ class Router:
         if name in BUILTINS:
             fn = BUILTINS[name]
         elif name.startswith("custom:"):
-            fn = _load_custom(name)
+            fn = _load_custom(name, self.config.roots)
         else:
             raise KeyError(name)
         self._cache[name] = fn
@@ -233,7 +249,9 @@ class Router:
         return str(got) if got is not None else None
 
     def pick(self, task: TaskMeta, workers: list, affinity: dict) -> Decision:
-        live_ids = {w.id for w in workers}
+        # A member that is not claiming is not a valid answer: assigning to it
+        # parks the task until the stuck-reclaim path repools it.
+        live_ids = {w.id for w in workers if w.claiming}
         try:
             for i, rule in enumerate(self.config.rules):
                 if not isinstance(rule, dict) or not self._matches(rule, task, workers):
@@ -250,8 +268,8 @@ class Router:
                 if not cand:
                     return Decision(None, name, i, reason="rule narrowed to no live worker")
                 got = self._run(name, task, cand, affinity)
-                if got is not None and got not in {w.id for w in cand}:
-                    raise ValueError(f"{name} returned {got!r}, not a candidate")
+                if got is not None and got not in {w.id for w in cand if w.claiming}:
+                    raise ValueError(f"{name} returned {got!r}, not a claiming candidate")
                 return Decision(got, name, i)
             name = self.config.policy
             got = self._run(name, task, workers, affinity)

--- a/src/runtime-api/pool_routing.py
+++ b/src/runtime-api/pool_routing.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Routing policy seam for the pool: WHO takes a task, separated from HOW it
+is assigned (the lead's atomic rename, reclaim and trace stay in pool_lead).
+
+There is no golden routing answer, so the choice is a policy: a named
+built-in, an ordered rules file, or owner-supplied code — all behind one
+`pick(task, workers, affinity) -> worker | None` call. A policy that raises
+or names a worker that is not live is overridden by the default and traced.
+
+The pool is one core plus zero or more workers. The core is a routable
+member like any other, so single-core mode is the same policy evaluated
+over a membership of one (`solo_pick`), not a second code path.
+
+Config: `<state>/pool/routing.json` (or $SUTANDO_POOL_ROUTING). Absent or
+malformed means `affinity-first`, the lead's historical behaviour.
+Stdlib only; everything injected so tests compose fake pools.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_POLICY = "affinity-first"
+CORE_ID = "core"
+
+_HDR_RE = re.compile(
+    r"^(?P<key>channel_id|source|access_tier|priority|user_id|room_name"
+    r"|target_worker|fan_out):\s*(?P<val>.+?)\s*$", re.M)
+
+
+@dataclass
+class TaskMeta:
+    name: str
+    channel: "str | None" = None
+    lane: str = "owner"
+    source: "str | None" = None
+    access_tier: str = "owner"
+    priority: str = "normal"
+    sender: "str | None" = None
+    room_name: "str | None" = None
+    target: "str | None" = None
+    fan_out: bool = False
+
+
+@dataclass
+class WorkerView:
+    id: str
+    load: int = 0
+    claiming: bool = True
+    runtime: str = "claude"
+    is_core: bool = False
+
+
+@dataclass
+class Decision:
+    worker: "str | None"
+    policy: str
+    rule: "int | None" = None
+    fallback: bool = False
+    reason: "str | None" = None
+
+
+@dataclass
+class RoutingConfig:
+    policy: str = DEFAULT_POLICY
+    rules: list = field(default_factory=list)
+    allow_delegation: bool = False
+    source: "str | None" = None
+
+
+def read_task_meta(path: Path, lane: str = "owner") -> TaskMeta:
+    """Headers end at the `task:` delimiter — a body line can never forge
+    routing (same containment rule the lead applies to addressing)."""
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return TaskMeta(name=path.name, lane=lane)
+    m = re.search(r"^task:", text, re.M)
+    head = text[:m.start()] if m else text
+    f = {mm.group("key"): mm.group("val") for mm in _HDR_RE.finditer(head)}
+    return TaskMeta(
+        name=path.name, channel=f.get("channel_id"), lane=lane,
+        source=f.get("source"), access_tier=f.get("access_tier", "owner"),
+        priority=f.get("priority", "normal"), sender=f.get("user_id"),
+        room_name=f.get("room_name"), target=f.get("target_worker"),
+        fan_out=str(f.get("fan_out", "")).lower() in ("1", "true", "yes"))
+
+
+# ── config ────────────────────────────────────────────────────────────────
+def config_path(state_dir: Path) -> Path:
+    env = os.environ.get("SUTANDO_POOL_ROUTING")
+    return Path(env) if env else Path(state_dir) / "pool" / "routing.json"
+
+
+def load_config(state_dir: Path) -> RoutingConfig:
+    p = config_path(state_dir)
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return RoutingConfig()
+    if not isinstance(data, dict):
+        return RoutingConfig()
+    rules = data.get("rules")
+    return RoutingConfig(
+        policy=str(data.get("policy") or DEFAULT_POLICY),
+        rules=rules if isinstance(rules, list) else [],
+        allow_delegation=bool(data.get("allow_delegation", False)),
+        source=str(p))
+
+
+# ── built-in policies ─────────────────────────────────────────────────────
+def _live(workers: list) -> list:
+    return [w for w in workers if w.claiming]
+
+
+def _least_loaded(task, workers, affinity, state):
+    live = _live(workers) or list(workers)
+    if not live:
+        return None
+    last = state.setdefault("last_pick", {})
+    pick = min(live, key=lambda w: (w.load, last.get(w.id, 0.0), w.id))
+    last[pick.id] = state.get("tick", 0) + 1
+    state["tick"] = last[pick.id]
+    return pick.id
+
+
+def _round_robin(task, workers, affinity, state):
+    live = sorted(_live(workers) or list(workers), key=lambda w: w.id)
+    if not live:
+        return None
+    i = state.get("rr", 0) % len(live)
+    state["rr"] = i + 1
+    return live[i].id
+
+
+def _sticky_sender(task, workers, affinity, state):
+    """Same sender keeps its worker while that worker is live; a new sender
+    lands least-loaded. Stickiness is in-memory — a lead restart resets it."""
+    ids = {w.id for w in _live(workers)}
+    table = state.setdefault("sticky", {})
+    if task.sender and table.get(task.sender) in ids:
+        return table[task.sender]
+    pick = _least_loaded(task, workers, affinity, state)
+    if task.sender and pick:
+        table[task.sender] = pick
+    return pick
+
+
+def _core_first(task, workers, affinity, state):
+    """Explicit address wins; everything else goes to the core, which claims
+    and processes like any member. No core in the pool → least-loaded."""
+    ids = {w.id: w for w in workers}
+    if task.target and task.target in ids and ids[task.target].claiming:
+        return task.target
+    core = next((w for w in workers if w.is_core), None)
+    if core is not None and core.claiming:
+        return core.id
+    return _least_loaded(task, workers, affinity, state)
+
+
+BUILTINS = {
+    "least-loaded": _least_loaded,
+    "round-robin": _round_robin,
+    "sticky-sender": _sticky_sender,
+    "core-first": _core_first,
+}
+
+
+def _load_custom(spec: str):
+    """`custom:<path.py>:<attr>` — owner-supplied code behind the same
+    signature. Import failure is a config error: caller falls back."""
+    _, path, attr = spec.split(":", 2)
+    mod_spec = importlib.util.spec_from_file_location("sutando_routing_custom", path)
+    if mod_spec is None or mod_spec.loader is None:
+        raise ImportError(spec)
+    mod = importlib.util.module_from_spec(mod_spec)
+    mod_spec.loader.exec_module(mod)
+    fn = getattr(mod, attr)
+    if not callable(fn):
+        raise TypeError(f"{spec} is not callable")
+    return fn
+
+
+class Router:
+    """Resolves the configured policy once; `pick` never raises — a broken
+    policy degrades to `default_fn` (the lead's historical choice)."""
+
+    def __init__(self, config: RoutingConfig, default_fn):
+        self.config = config
+        self.default_fn = default_fn
+        self.state: dict = {}
+        self._cache: dict = {}
+        self.error: "str | None" = None
+
+    def _policy_fn(self, name: str):
+        if name == DEFAULT_POLICY:
+            return self.default_fn
+        if name in self._cache:
+            return self._cache[name]
+        if name in BUILTINS:
+            fn = BUILTINS[name]
+        elif name.startswith("custom:"):
+            fn = _load_custom(name)
+        else:
+            raise KeyError(name)
+        self._cache[name] = fn
+        return fn
+
+    @staticmethod
+    def _matches(rule: dict, task: TaskMeta, workers: list) -> bool:
+        match = rule.get("match") or {}
+        if not isinstance(match, dict):
+            return False
+        for k, v in match.items():
+            if k == "runtime":
+                if not any(w.runtime == v for w in workers):
+                    return False
+                continue
+            actual = getattr(task, k, None)
+            want = v if isinstance(v, list) else [v]
+            if actual not in want:
+                return False
+        return True
+
+    def _run(self, name: str, task, workers, affinity) -> "str | None":
+        got = self._policy_fn(name)(task, workers, affinity, self.state)
+        return str(got) if got is not None else None
+
+    def pick(self, task: TaskMeta, workers: list, affinity: dict) -> Decision:
+        live_ids = {w.id for w in workers}
+        try:
+            for i, rule in enumerate(self.config.rules):
+                if not isinstance(rule, dict) or not self._matches(rule, task, workers):
+                    continue
+                cand = list(workers)
+                if rule.get("to"):
+                    to = rule["to"] if isinstance(rule["to"], list) else [rule["to"]]
+                    cand = [w for w in cand if w.id in to]
+                if rule.get("only"):
+                    cand = [w for w in cand if w.id in rule["only"]]
+                if rule.get("exclude"):
+                    cand = [w for w in cand if w.id not in rule["exclude"]]
+                name = str(rule.get("policy") or "least-loaded")
+                if not cand:
+                    return Decision(None, name, i, reason="rule narrowed to no live worker")
+                got = self._run(name, task, cand, affinity)
+                if got is not None and got not in {w.id for w in cand}:
+                    raise ValueError(f"{name} returned {got!r}, not a candidate")
+                return Decision(got, name, i)
+            name = self.config.policy
+            got = self._run(name, task, workers, affinity)
+            if got is not None and got not in live_ids:
+                raise ValueError(f"{name} returned {got!r}, not live")
+            return Decision(got, name)
+        except Exception as exc:  # any policy fault → default, traced
+            self.error = f"{type(exc).__name__}: {exc}"
+            got = self.default_fn(task, workers, affinity, self.state)
+            return Decision(got, DEFAULT_POLICY, fallback=True, reason=self.error)
+
+
+def solo_pick(router: Router, task: TaskMeta, self_id: str,
+              is_core: bool = True) -> bool:
+    """Single-member evaluation: True when the configured policy lets
+    `self_id` take `task`. N=0 workers is just a pool of one."""
+    me = WorkerView(id=self_id, is_core=is_core)
+    return router.pick(task, [me], {}).worker == self_id
+
+
+def build_router(state_dir: Path, default_fn=None) -> Router:
+    fallback = default_fn or _least_loaded
+    return Router(load_config(state_dir), fallback)

--- a/src/runtime-api/pool_routing.py
+++ b/src/runtime-api/pool_routing.py
@@ -122,8 +122,18 @@ def load_config(state_dir: Path) -> RoutingConfig:
     return RoutingConfig(
         policy=str(data.get("policy") or DEFAULT_POLICY),
         rules=rules if isinstance(rules, list) else [],
-        allow_delegation=bool(data.get("allow_delegation", False)),
+        allow_delegation=data.get("allow_delegation", False) is True,
         source=str(p), roots=roots)
+
+
+def _selector_ids(value):
+    """`only`/`exclude` take a str or list of str, normalized like `to`. A raw
+    str would otherwise do SUBSTRING membership; anything else is unusable."""
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, list) and all(isinstance(v, str) for v in value):
+        return set(value)
+    return None
 
 
 # ── built-in policies ─────────────────────────────────────────────────────
@@ -260,11 +270,15 @@ class Router:
                 if rule.get("to"):
                     to = rule["to"] if isinstance(rule["to"], list) else [rule["to"]]
                     cand = [w for w in cand if w.id in to]
-                if rule.get("only"):
-                    cand = [w for w in cand if w.id in rule["only"]]
-                if rule.get("exclude"):
-                    cand = [w for w in cand if w.id not in rule["exclude"]]
                 name = str(rule.get("policy") or "least-loaded")
+                for field, keep in (("only", True), ("exclude", False)):
+                    if not rule.get(field):
+                        continue
+                    ids = _selector_ids(rule[field])
+                    if ids is None:
+                        return Decision(None, name, i,
+                                        reason=f"rule {field!r} is not a str or list of str")
+                    cand = [w for w in cand if (w.id in ids) is keep]
                 if not cand:
                     return Decision(None, name, i, reason="rule narrowed to no live worker")
                 got = self._run(name, task, cand, affinity)

--- a/src/runtime-api/pool_routing.py
+++ b/src/runtime-api/pool_routing.py
@@ -7,9 +7,10 @@ built-in, an ordered rules file, or owner-supplied code — all behind one
 `pick(task, workers, affinity) -> worker | None` call. A policy that raises
 or names a worker that is not live is overridden by the default and traced.
 
-The pool is one core plus zero or more workers. The core is a routable
-member like any other, so single-core mode is the same policy evaluated
-over a membership of one (`solo_pick`), not a second code path.
+Every seat in the pool is a member the policy may pick; the seat that owns
+the loop, memory and owner relationship is the HOME member. A single-seat
+install is the same policy evaluated over a membership of one (`solo_pick`),
+not a second code path — the counting convention is decided elsewhere.
 
 Config: `<state>/pool/routing.json` (or $SUTANDO_POOL_ROUTING). Absent or
 malformed means `affinity-first`, the lead's historical behaviour.
@@ -25,7 +26,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 DEFAULT_POLICY = "affinity-first"
-CORE_ID = "core"
+HOME_ID = "home"
 
 _HDR_RE = re.compile(
     r"^(?P<key>channel_id|source|access_tier|priority|user_id|room_name"
@@ -47,12 +48,12 @@ class TaskMeta:
 
 
 @dataclass
-class WorkerView:
+class MemberView:
     id: str
     load: int = 0
     claiming: bool = True
     runtime: str = "claude"
-    is_core: bool = False
+    is_home: bool = False
 
 
 @dataclass
@@ -150,13 +151,13 @@ def _sticky_sender(task, workers, affinity, state):
     return pick
 
 
-def _core_first(task, workers, affinity, state):
-    """Explicit address wins; everything else goes to the core, which claims
-    and processes like any member. No core in the pool → least-loaded."""
+def _home_first(task, workers, affinity, state):
+    """Explicit address wins; everything else goes to the home seat, which
+    claims and processes like any member. No home seat → least-loaded."""
     ids = {w.id: w for w in workers}
     if task.target and task.target in ids and ids[task.target].claiming:
         return task.target
-    core = next((w for w in workers if w.is_core), None)
+    core = next((w for w in workers if w.is_home), None)
     if core is not None and core.claiming:
         return core.id
     return _least_loaded(task, workers, affinity, state)
@@ -166,7 +167,8 @@ BUILTINS = {
     "least-loaded": _least_loaded,
     "round-robin": _round_robin,
     "sticky-sender": _sticky_sender,
-    "core-first": _core_first,
+    "home-first": _home_first,
+    "core-first": _home_first,  # pre-ruling spelling, kept for one release
 }
 
 
@@ -263,10 +265,10 @@ class Router:
 
 
 def solo_pick(router: Router, task: TaskMeta, self_id: str,
-              is_core: bool = True) -> bool:
+              is_home: bool = True) -> bool:
     """Single-member evaluation: True when the configured policy lets
-    `self_id` take `task`. N=0 workers is just a pool of one."""
-    me = WorkerView(id=self_id, is_core=is_core)
+    `self_id` take `task`. A lone seat is a membership of one."""
+    me = MemberView(id=self_id, is_home=is_home)
     return router.pick(task, [me], {}).worker == self_id
 
 

--- a/tests/pool-routing-policy.test.py
+++ b/tests/pool-routing-policy.test.py
@@ -327,7 +327,46 @@ class EdgesAndFaults(Base):
         r = Router(cfg, lambda *a: "core-2")
         d = r.pick(TaskMeta("t", source="slack"), [MemberView("core-1"), MemberView("core-2")], {})
         self.assertEqual((d.worker, d.fallback), ("core-2", True))
-        self.assertIn("not a candidate", d.reason)
+        self.assertIn("not a claiming candidate", d.reason)
+
+    def test_custom_naming_a_known_but_not_claiming_member_falls_back(self):
+        # Membership is not liveness: a known id that is not claiming parks the task.
+        mod = Path(self.tmp.name) / "parked.py"
+        mod.write_text("def pick(task, workers, affinity, state): return 'core-1'\n")
+        r = Router(RoutingConfig(policy=f"custom:{mod}:pick"), lambda *a: "core-2")
+        d = r.pick(TaskMeta("t"), [MemberView("core-1", claiming=False), MemberView("core-2")], {})
+        self.assertEqual((d.worker, d.fallback), ("core-2", True))
+        self.assertIn("not live", d.reason)
+
+    def test_rule_to_naming_a_non_claiming_worker_falls_back(self):
+        mod = Path(self.tmp.name) / "echo.py"
+        mod.write_text("def pick(task, workers, affinity, state): return 'core-1'\n")
+        cfg = RoutingConfig(rules=[{"match": {"source": "slack"}, "to": ["core-1"],
+                                    "policy": f"custom:{mod}:pick"}])
+        r = Router(cfg, lambda *a: "core-2")
+        d = r.pick(TaskMeta("t", source="slack"),
+                   [MemberView("core-1", claiming=False), MemberView("core-2")], {})
+        self.assertEqual((d.worker, d.fallback), ("core-2", True))
+        self.assertIn("not a claiming candidate", d.reason)
+
+    def test_custom_module_outside_repo_and_workspace_is_refused(self):
+        # routing.json is a code-execution surface; a module in a foreign dir is not loaded.
+        import tempfile as _tf
+        foreign = Path(_tf.mkdtemp()) / "outside.py"
+        foreign.write_text("def pick(task, workers, affinity, state): return 'core-2'\n")
+        self.routing(policy=f"custom:{foreign}:pick")
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        t = self.trace("routed")[0]
+        self.assertTrue(t["fallback"])
+        self.assertIn("must live under the repo or the workspace", t["reason"])
+        inside = Path(self.tmp.name) / "inside.py"
+        inside.write_text("def pick(task, workers, affinity, state): return 'core-2'\n")
+        self.routing(policy=f"custom:{inside}:pick")
+        self.write("task-2.txt", task())
+        self.lead().sweep()
+        self.assertEqual(self.assigned()["task-2.txt"], "core-2")
+        self.assertFalse(self.trace("routed")[-1]["fallback"])
 
     def test_lead_default_pick_over_core_only_membership(self):
         lead = self.lead()

--- a/tests/pool-routing-policy.test.py
+++ b/tests/pool-routing-policy.test.py
@@ -270,5 +270,109 @@ class Delegation(Base):
             pool_follower.delegate(self.tasks, self.state, other, CORE_ID, "core-2")
 
 
+class EdgesAndFaults(Base):
+    """Every declined/faulted branch the router can take, driven directly."""
+
+    def test_task_meta_unreadable_file_is_owner_default(self):
+        from pool_routing import read_task_meta
+        m = read_task_meta(self.tasks / "nope.txt", lane="routine")
+        self.assertEqual((m.name, m.lane, m.access_tier), ("nope.txt", "routine", "owner"))
+
+    def test_config_non_object_is_default(self):
+        (self.state / "pool").mkdir()
+        (self.state / "pool" / "routing.json").write_text("[]")
+        self.assertEqual(load_config(self.state).policy, "affinity-first")
+
+    def test_builtins_with_no_workers_return_none(self):
+        for name in ("least-loaded", "round-robin", "sticky-sender", "core-first"):
+            r = Router(RoutingConfig(policy=name), lambda *a: None)
+            self.assertIsNone(r.pick(TaskMeta("t", sender="U1"), [], {}).worker, name)
+
+    def test_core_first_addressed_target_via_router(self):
+        r = Router(RoutingConfig(policy="core-first"), lambda *a: None)
+        ws = [WorkerView("core-2"), WorkerView(CORE_ID, is_core=True)]
+        self.assertEqual(r.pick(TaskMeta("t", target="core-2"), ws, {}).worker, "core-2")
+        self.assertEqual(r.pick(TaskMeta("t", target="ghost"), ws, {}).worker, CORE_ID)
+
+    def test_custom_unloadable_and_uncallable_fall_back(self):
+        txt = Path(self.tmp.name) / "policy.txt"
+        txt.write_text("def pick(*a): return 'core-1'\n")
+        nc = Path(self.tmp.name) / "nc.py"
+        nc.write_text("pick = 5\n")
+        for spec, err in ((f"custom:{txt}:pick", "ImportError"), (f"custom:{nc}:pick", "TypeError")):
+            r = Router(RoutingConfig(policy=spec), lambda *a: "core-1")
+            d = r.pick(TaskMeta("t"), [WorkerView("core-1")], {})
+            self.assertTrue(d.fallback, spec)
+            self.assertIn(err, d.reason)
+
+    def test_rule_match_shapes(self):
+        cfg = RoutingConfig(policy="least-loaded", rules=[
+            {"match": "not-a-dict", "to": ["core-1"]},
+            {"match": {"runtime": "codex"}, "to": ["core-1"]},
+            {"match": {"source": ["slack", "discord"]}, "to": ["core-2"]},
+        ])
+        r = Router(cfg, lambda *a: None)
+        ws = [WorkerView("core-1"), WorkerView("core-2")]
+        d = r.pick(TaskMeta("t", source="discord"), ws, {})
+        self.assertEqual((d.worker, d.rule), ("core-2", 2))
+        ws_codex = [WorkerView("core-1", runtime="codex"), WorkerView("core-2")]
+        d = r.pick(TaskMeta("t", source="voice"), ws_codex, {})
+        self.assertEqual((d.worker, d.rule), ("core-1", 1))
+
+    def test_rule_policy_returning_non_candidate_falls_back(self):
+        bad = Path(self.tmp.name) / "leak.py"
+        bad.write_text("def pick(task, workers, affinity, state): return 'core-1'\n")
+        cfg = RoutingConfig(rules=[{"match": {"source": "slack"}, "policy": f"custom:{bad}:pick",
+                                    "exclude": ["core-1"]}])
+        r = Router(cfg, lambda *a: "core-2")
+        d = r.pick(TaskMeta("t", source="slack"), [WorkerView("core-1"), WorkerView("core-2")], {})
+        self.assertEqual((d.worker, d.fallback), ("core-2", True))
+        self.assertIn("not a candidate", d.reason)
+
+    def test_lead_default_pick_over_core_only_membership(self):
+        lead = self.lead()
+        only_core = [WorkerView(CORE_ID, is_core=True)]
+        self.assertEqual(lead._default_pick(TaskMeta("t"), only_core, {}, {}), CORE_ID)
+        self.assertIsNone(lead._default_pick(TaskMeta("t"), [], {}, {}))
+
+
+class DelegateCli(Base):
+    def held(self):
+        p = self.tasks / f"task-1.claimed-{CORE_ID}.txt"
+        p.write_text(task())
+        return p
+
+    def test_usage_and_refusal_exit_2(self):
+        self.assertEqual(pool_follower._delegate_cli(["only-one"]), 2)
+        self.assertEqual(pool_follower._delegate_cli([str(self.held()), CORE_ID, "core-2"]), 2)
+
+    def test_success_prints_assignment_path(self):
+        self.routing(allow_delegation=True)
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = pool_follower._delegate_cli([str(self.held()), CORE_ID, "core-2"])
+        self.assertEqual(rc, 0)
+        self.assertTrue(buf.getvalue().strip().endswith("task-1.assigned-core-2.txt"))
+
+
+class DaemonHostLabel(unittest.TestCase):
+    def test_subprocess_fault_is_empty_label(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "pld", REPO / "scripts" / "pool-lead-daemon.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        real = mod.subprocess.run
+        try:
+            def boom(*a, **k):
+                raise OSError("no bash")
+            mod.subprocess.run = boom
+            self.assertEqual(mod._host_label(), "")
+        finally:
+            mod.subprocess.run = real
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/pool-routing-policy.test.py
+++ b/tests/pool-routing-policy.test.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Routing policy seam: the choice is pluggable, the lead's enforcement is
+not, and a broken policy degrades to the historical default instead of
+stranding the queue. Single-core is the same policy over a pool of one.
+
+Exercises the production sweep() and acquire_work() paths — real task
+files, real renames. Run: python3 tests/pool-routing-policy.test.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "src" / "runtime-api"))
+
+from pool_lead import PoolLead  # noqa: E402
+from pool_routing import (  # noqa: E402
+    CORE_ID, Router, RoutingConfig, TaskMeta, WorkerView, build_router,
+    load_config, solo_pick)
+import pool_follower  # noqa: E402
+
+
+def task(**hdr):
+    base = {"source": "slack", "channel_id": "C1", "access_tier": "owner",
+            "priority": "normal", "user_id": "U1"}
+    base.update({k: v for k, v in hdr.items() if v is not None})
+    lines = "".join(f"{k}: {v}\n" for k, v in base.items())
+    return f"id: x\n{lines}task: hi\n"
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.tasks, self.state = root / "tasks", root / "state"
+        self.tasks.mkdir()
+        self.state.mkdir()
+        (root / "results").mkdir()
+        self.pool = ["core-1", "core-2"]
+        self.core = None
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def lead(self):
+        return PoolLead(self.tasks, self.state,
+                        followers_fn=lambda: list(self.pool),
+                        alive_fn=lambda i: True, now_fn=lambda: 1_000.0,
+                        core_fn=lambda: self.core)
+
+    def routing(self, **cfg):
+        (self.state / "pool").mkdir(exist_ok=True)
+        (self.state / "pool" / "routing.json").write_text(json.dumps(cfg))
+
+    def write(self, name, body):
+        (self.tasks / name).write_text(body)
+
+    def assigned(self):
+        return {f.name.split(".assigned-")[0] + ".txt": f.name.split(".assigned-")[1][:-4]
+                for f in self.tasks.iterdir() if ".assigned-" in f.name}
+
+    def trace(self, event):
+        p = self.state / "pool" / "liveness-trace.jsonl"
+        if not p.exists():
+            return []
+        return [json.loads(l) for l in p.read_text().splitlines()
+                if json.loads(l).get("event") == event]
+
+
+class NoConfigIsHistoricalBehaviour(Base):
+    def test_no_config_matches_pick(self):
+        # CONTROL: with no routing.json the policy IS _pick — same answer.
+        self.write("task-1.txt", task())
+        lead = self.lead()
+        expect = lead._pick("C1", self.pool, {}, "owner")
+        lead.sweep()
+        self.assertEqual(self.assigned()["task-1.txt"], expect)
+        r = self.trace("routed")
+        self.assertEqual(r[0]["policy"], "affinity-first")
+        self.assertFalse(r[0]["fallback"])
+
+    def test_core_not_picked_unless_policy_names_it(self):
+        self.core = CORE_ID
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertIn(self.assigned()["task-1.txt"], self.pool)
+
+
+class CoreFirst(Base):
+    def test_unaddressed_goes_to_core(self):
+        self.core = CORE_ID
+        self.routing(policy="core-first")
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertEqual(self.assigned()["task-1.txt"], CORE_ID)
+
+    def test_addressed_goes_to_that_worker(self):
+        self.core = CORE_ID
+        self.routing(policy="core-first")
+        self.write("task-1.txt", task(target_worker="core-2"))
+        self.lead().sweep()
+        self.assertEqual(self.assigned()["task-1.txt"], "core-2")
+
+    def test_no_core_falls_to_least_loaded(self):
+        self.routing(policy="core-first")
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertIn(self.assigned()["task-1.txt"], self.pool)
+        self.assertEqual(self.trace("routed")[0]["policy"], "core-first")
+
+
+class Rules(Base):
+    def test_first_match_wins_and_narrows(self):
+        self.routing(policy="least-loaded", rules=[
+            {"match": {"room_name": "Pro-Main"}, "to": ["core-1"]},
+            {"match": {"access_tier": "team"}, "policy": "least-loaded",
+             "exclude": ["core-1"]},
+        ])
+        self.write("task-a.txt", task(room_name="Pro-Main"))
+        self.write("task-b.txt", task(access_tier="team"))
+        self.lead().sweep()
+        got = self.assigned()
+        self.assertEqual(got["task-a.txt"], "core-1")
+        self.assertEqual(got["task-b.txt"], "core-2")
+        rules = {t["task"]: t["rule"] for t in self.trace("routed")}
+        self.assertEqual(rules["task-a.txt"], 0)
+        self.assertEqual(rules["task-b.txt"], 1)
+
+    def test_rule_narrowed_to_nothing_falls_back(self):
+        self.routing(rules=[{"match": {"source": "slack"}, "only": ["ghost"]}])
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertIn(self.assigned()["task-1.txt"], self.pool)
+        t = self.trace("routed")[0]
+        self.assertTrue(t["fallback"])
+        self.assertIn("no live worker", t["reason"])
+
+
+class BrokenPolicyDegrades(Base):
+    def test_custom_that_raises_falls_back(self):
+        mod = Path(self.tmp.name) / "bad.py"
+        mod.write_text("def pick(task, workers, affinity, state):\n    raise RuntimeError('boom')\n")
+        self.routing(policy=f"custom:{mod}:pick")
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertIn(self.assigned()["task-1.txt"], self.pool)
+        t = self.trace("routed")[0]
+        self.assertTrue(t["fallback"])
+        self.assertIn("RuntimeError", t["reason"])
+
+    def test_custom_naming_dead_worker_falls_back(self):
+        mod = Path(self.tmp.name) / "dead.py"
+        mod.write_text("def pick(task, workers, affinity, state):\n    return 'core-9'\n")
+        self.routing(policy=f"custom:{mod}:pick")
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertIn(self.assigned()["task-1.txt"], self.pool)
+        self.assertTrue(self.trace("routed")[0]["fallback"])
+
+    def test_custom_that_works_is_used(self):
+        mod = Path(self.tmp.name) / "ok.py"
+        mod.write_text("def pick(task, workers, affinity, state):\n    return 'core-2'\n")
+        self.routing(policy=f"custom:{mod}:pick")
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertEqual(self.assigned()["task-1.txt"], "core-2")
+        self.assertFalse(self.trace("routed")[0]["fallback"])
+
+    def test_unknown_policy_name_falls_back(self):
+        self.routing(policy="no-such-policy")
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertIn(self.assigned()["task-1.txt"], self.pool)
+        self.assertIn("KeyError", self.trace("routed")[0]["reason"])
+
+    def test_malformed_config_is_default(self):
+        (self.state / "pool").mkdir()
+        (self.state / "pool" / "routing.json").write_text("{not json")
+        self.assertEqual(load_config(self.state).policy, "affinity-first")
+
+
+class BuiltinsUnit(unittest.TestCase):
+    def w(self, *ids, core=None):
+        return [WorkerView(i, load=0, claiming=True) for i in ids] + (
+            [WorkerView(core, is_core=True)] if core else [])
+
+    def test_round_robin_cycles(self):
+        r = Router(RoutingConfig(policy="round-robin"), lambda *a: None)
+        picks = [r.pick(TaskMeta("t"), self.w("a", "b"), {}).worker for _ in range(4)]
+        self.assertEqual(picks, ["a", "b", "a", "b"])
+
+    def test_sticky_sender_keeps_worker_while_live(self):
+        r = Router(RoutingConfig(policy="sticky-sender"), lambda *a: None)
+        first = r.pick(TaskMeta("t", sender="U1"), self.w("a", "b"), {}).worker
+        again = r.pick(TaskMeta("t", sender="U1"), self.w("a", "b"), {}).worker
+        self.assertEqual(first, again)
+        moved = r.pick(TaskMeta("t", sender="U1"), self.w("b"), {}).worker
+        self.assertEqual(moved, "b")
+
+    def test_least_loaded_prefers_lowest_load(self):
+        r = Router(RoutingConfig(policy="least-loaded"), lambda *a: None)
+        ws = [WorkerView("a", load=3), WorkerView("b", load=1)]
+        self.assertEqual(r.pick(TaskMeta("t"), ws, {}).worker, "b")
+
+
+class SingleCoreIsNEqualsOne(Base):
+    """N=0 workers: the same policy over [core] — no solo code path."""
+
+    def stale_lead(self):
+        (self.state / "cores").mkdir(exist_ok=True)
+
+    def test_default_policy_lets_the_lone_member_claim(self):
+        self.stale_lead()
+        self.write("task-1.txt", task())
+        got = pool_follower.acquire_work(self.tasks, self.state, CORE_ID,
+                                         "pool-lead", now_fn=lambda: 1e9)
+        self.assertIsNotNone(got)
+        self.assertTrue(got.name.endswith(f".claimed-{CORE_ID}.txt"))
+
+    def test_rule_excluding_me_leaves_the_file(self):
+        self.stale_lead()
+        self.routing(policy="core-first", rules=[
+            {"match": {"access_tier": "team"}, "exclude": [CORE_ID]}])
+        self.write("task-team.txt", task(access_tier="team"))
+        self.write("task-own.txt", task())
+        got = pool_follower.acquire_work(self.tasks, self.state, CORE_ID,
+                                         "pool-lead", now_fn=lambda: 1e9)
+        self.assertEqual(got.name, f"task-own.claimed-{CORE_ID}.txt")
+        self.assertTrue((self.tasks / "task-team.txt").exists())
+
+    def test_solo_pick_is_the_same_router(self):
+        router = build_router(self.state)
+        self.assertTrue(solo_pick(router, TaskMeta("t"), CORE_ID))
+        self.assertTrue(solo_pick(router, TaskMeta("t"), "core-1", is_core=False))
+
+
+class Delegation(Base):
+    def held(self):
+        p = self.tasks / f"task-1.claimed-{CORE_ID}.txt"
+        p.write_text(task())
+        return p
+
+    def test_disabled_by_default(self):
+        with self.assertRaises(ValueError):
+            pool_follower.delegate(self.tasks, self.state, self.held(), CORE_ID, "core-2")
+        self.assertTrue((self.tasks / f"task-1.claimed-{CORE_ID}.txt").exists())
+
+    def test_enabled_hands_off_as_assignment(self):
+        self.routing(policy="core-first", allow_delegation=True)
+        out = pool_follower.delegate(self.tasks, self.state, self.held(), CORE_ID, "core-2")
+        self.assertEqual(out.name, "task-1.assigned-core-2.txt")
+        self.assertEqual(self.assigned()["task-1.txt"], "core-2")
+
+    def test_refuses_foreign_or_self_target(self):
+        self.routing(allow_delegation=True)
+        for bad in (CORE_ID, "", "../x"):
+            with self.assertRaises(ValueError):
+                pool_follower.delegate(self.tasks, self.state, self.held(), CORE_ID, bad)
+
+    def test_only_a_file_i_hold(self):
+        self.routing(allow_delegation=True)
+        other = self.tasks / "task-2.claimed-core-1.txt"
+        other.write_text(task())
+        with self.assertRaises(ValueError):
+            pool_follower.delegate(self.tasks, self.state, other, CORE_ID, "core-2")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/pool-routing-policy.test.py
+++ b/tests/pool-routing-policy.test.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(REPO / "src" / "runtime-api"))
 
 from pool_lead import PoolLead  # noqa: E402
 from pool_routing import (  # noqa: E402
-    CORE_ID, Router, RoutingConfig, TaskMeta, WorkerView, build_router,
+    HOME_ID, Router, RoutingConfig, TaskMeta, MemberView, build_router,
     load_config, solo_pick)
 import pool_follower  # noqa: E402
 
@@ -51,7 +51,7 @@ class Base(unittest.TestCase):
         return PoolLead(self.tasks, self.state,
                         followers_fn=lambda: list(self.pool),
                         alive_fn=lambda i: True, now_fn=lambda: 1_000.0,
-                        core_fn=lambda: self.core)
+                        home_fn=lambda: self.core)
 
     def routing(self, **cfg):
         (self.state / "pool").mkdir(exist_ok=True)
@@ -85,7 +85,7 @@ class NoConfigIsHistoricalBehaviour(Base):
         self.assertFalse(r[0]["fallback"])
 
     def test_core_not_picked_unless_policy_names_it(self):
-        self.core = CORE_ID
+        self.core = HOME_ID
         self.write("task-1.txt", task())
         self.lead().sweep()
         self.assertIn(self.assigned()["task-1.txt"], self.pool)
@@ -93,25 +93,25 @@ class NoConfigIsHistoricalBehaviour(Base):
 
 class CoreFirst(Base):
     def test_unaddressed_goes_to_core(self):
-        self.core = CORE_ID
-        self.routing(policy="core-first")
+        self.core = HOME_ID
+        self.routing(policy="home-first")
         self.write("task-1.txt", task())
         self.lead().sweep()
-        self.assertEqual(self.assigned()["task-1.txt"], CORE_ID)
+        self.assertEqual(self.assigned()["task-1.txt"], HOME_ID)
 
     def test_addressed_goes_to_that_worker(self):
-        self.core = CORE_ID
-        self.routing(policy="core-first")
+        self.core = HOME_ID
+        self.routing(policy="home-first")
         self.write("task-1.txt", task(target_worker="core-2"))
         self.lead().sweep()
         self.assertEqual(self.assigned()["task-1.txt"], "core-2")
 
     def test_no_core_falls_to_least_loaded(self):
-        self.routing(policy="core-first")
+        self.routing(policy="home-first")
         self.write("task-1.txt", task())
         self.lead().sweep()
         self.assertIn(self.assigned()["task-1.txt"], self.pool)
-        self.assertEqual(self.trace("routed")[0]["policy"], "core-first")
+        self.assertEqual(self.trace("routed")[0]["policy"], "home-first")
 
 
 class Rules(Base):
@@ -186,8 +186,8 @@ class BrokenPolicyDegrades(Base):
 
 class BuiltinsUnit(unittest.TestCase):
     def w(self, *ids, core=None):
-        return [WorkerView(i, load=0, claiming=True) for i in ids] + (
-            [WorkerView(core, is_core=True)] if core else [])
+        return [MemberView(i, load=0, claiming=True) for i in ids] + (
+            [MemberView(core, is_home=True)] if core else [])
 
     def test_round_robin_cycles(self):
         r = Router(RoutingConfig(policy="round-robin"), lambda *a: None)
@@ -204,7 +204,7 @@ class BuiltinsUnit(unittest.TestCase):
 
     def test_least_loaded_prefers_lowest_load(self):
         r = Router(RoutingConfig(policy="least-loaded"), lambda *a: None)
-        ws = [WorkerView("a", load=3), WorkerView("b", load=1)]
+        ws = [MemberView("a", load=3), MemberView("b", load=1)]
         self.assertEqual(r.pick(TaskMeta("t"), ws, {}).worker, "b")
 
 
@@ -217,57 +217,57 @@ class SingleCoreIsNEqualsOne(Base):
     def test_default_policy_lets_the_lone_member_claim(self):
         self.stale_lead()
         self.write("task-1.txt", task())
-        got = pool_follower.acquire_work(self.tasks, self.state, CORE_ID,
+        got = pool_follower.acquire_work(self.tasks, self.state, HOME_ID,
                                          "pool-lead", now_fn=lambda: 1e9)
         self.assertIsNotNone(got)
-        self.assertTrue(got.name.endswith(f".claimed-{CORE_ID}.txt"))
+        self.assertTrue(got.name.endswith(f".claimed-{HOME_ID}.txt"))
 
     def test_rule_excluding_me_leaves_the_file(self):
         self.stale_lead()
-        self.routing(policy="core-first", rules=[
-            {"match": {"access_tier": "team"}, "exclude": [CORE_ID]}])
+        self.routing(policy="home-first", rules=[
+            {"match": {"access_tier": "team"}, "exclude": [HOME_ID]}])
         self.write("task-team.txt", task(access_tier="team"))
         self.write("task-own.txt", task())
-        got = pool_follower.acquire_work(self.tasks, self.state, CORE_ID,
+        got = pool_follower.acquire_work(self.tasks, self.state, HOME_ID,
                                          "pool-lead", now_fn=lambda: 1e9)
-        self.assertEqual(got.name, f"task-own.claimed-{CORE_ID}.txt")
+        self.assertEqual(got.name, f"task-own.claimed-{HOME_ID}.txt")
         self.assertTrue((self.tasks / "task-team.txt").exists())
 
     def test_solo_pick_is_the_same_router(self):
         router = build_router(self.state)
-        self.assertTrue(solo_pick(router, TaskMeta("t"), CORE_ID))
-        self.assertTrue(solo_pick(router, TaskMeta("t"), "core-1", is_core=False))
+        self.assertTrue(solo_pick(router, TaskMeta("t"), HOME_ID))
+        self.assertTrue(solo_pick(router, TaskMeta("t"), "core-1", is_home=False))
 
 
 class Delegation(Base):
     def held(self):
-        p = self.tasks / f"task-1.claimed-{CORE_ID}.txt"
+        p = self.tasks / f"task-1.claimed-{HOME_ID}.txt"
         p.write_text(task())
         return p
 
     def test_disabled_by_default(self):
         with self.assertRaises(ValueError):
-            pool_follower.delegate(self.tasks, self.state, self.held(), CORE_ID, "core-2")
-        self.assertTrue((self.tasks / f"task-1.claimed-{CORE_ID}.txt").exists())
+            pool_follower.delegate(self.tasks, self.state, self.held(), HOME_ID, "core-2")
+        self.assertTrue((self.tasks / f"task-1.claimed-{HOME_ID}.txt").exists())
 
     def test_enabled_hands_off_as_assignment(self):
-        self.routing(policy="core-first", allow_delegation=True)
-        out = pool_follower.delegate(self.tasks, self.state, self.held(), CORE_ID, "core-2")
+        self.routing(policy="home-first", allow_delegation=True)
+        out = pool_follower.delegate(self.tasks, self.state, self.held(), HOME_ID, "core-2")
         self.assertEqual(out.name, "task-1.assigned-core-2.txt")
         self.assertEqual(self.assigned()["task-1.txt"], "core-2")
 
     def test_refuses_foreign_or_self_target(self):
         self.routing(allow_delegation=True)
-        for bad in (CORE_ID, "", "../x"):
+        for bad in (HOME_ID, "", "../x"):
             with self.assertRaises(ValueError):
-                pool_follower.delegate(self.tasks, self.state, self.held(), CORE_ID, bad)
+                pool_follower.delegate(self.tasks, self.state, self.held(), HOME_ID, bad)
 
     def test_only_a_file_i_hold(self):
         self.routing(allow_delegation=True)
         other = self.tasks / "task-2.claimed-core-1.txt"
         other.write_text(task())
         with self.assertRaises(ValueError):
-            pool_follower.delegate(self.tasks, self.state, other, CORE_ID, "core-2")
+            pool_follower.delegate(self.tasks, self.state, other, HOME_ID, "core-2")
 
 
 class EdgesAndFaults(Base):
@@ -284,15 +284,15 @@ class EdgesAndFaults(Base):
         self.assertEqual(load_config(self.state).policy, "affinity-first")
 
     def test_builtins_with_no_workers_return_none(self):
-        for name in ("least-loaded", "round-robin", "sticky-sender", "core-first"):
+        for name in ("least-loaded", "round-robin", "sticky-sender", "home-first"):
             r = Router(RoutingConfig(policy=name), lambda *a: None)
             self.assertIsNone(r.pick(TaskMeta("t", sender="U1"), [], {}).worker, name)
 
     def test_core_first_addressed_target_via_router(self):
-        r = Router(RoutingConfig(policy="core-first"), lambda *a: None)
-        ws = [WorkerView("core-2"), WorkerView(CORE_ID, is_core=True)]
+        r = Router(RoutingConfig(policy="home-first"), lambda *a: None)
+        ws = [MemberView("core-2"), MemberView(HOME_ID, is_home=True)]
         self.assertEqual(r.pick(TaskMeta("t", target="core-2"), ws, {}).worker, "core-2")
-        self.assertEqual(r.pick(TaskMeta("t", target="ghost"), ws, {}).worker, CORE_ID)
+        self.assertEqual(r.pick(TaskMeta("t", target="ghost"), ws, {}).worker, HOME_ID)
 
     def test_custom_unloadable_and_uncallable_fall_back(self):
         txt = Path(self.tmp.name) / "policy.txt"
@@ -301,7 +301,7 @@ class EdgesAndFaults(Base):
         nc.write_text("pick = 5\n")
         for spec, err in ((f"custom:{txt}:pick", "ImportError"), (f"custom:{nc}:pick", "TypeError")):
             r = Router(RoutingConfig(policy=spec), lambda *a: "core-1")
-            d = r.pick(TaskMeta("t"), [WorkerView("core-1")], {})
+            d = r.pick(TaskMeta("t"), [MemberView("core-1")], {})
             self.assertTrue(d.fallback, spec)
             self.assertIn(err, d.reason)
 
@@ -312,10 +312,10 @@ class EdgesAndFaults(Base):
             {"match": {"source": ["slack", "discord"]}, "to": ["core-2"]},
         ])
         r = Router(cfg, lambda *a: None)
-        ws = [WorkerView("core-1"), WorkerView("core-2")]
+        ws = [MemberView("core-1"), MemberView("core-2")]
         d = r.pick(TaskMeta("t", source="discord"), ws, {})
         self.assertEqual((d.worker, d.rule), ("core-2", 2))
-        ws_codex = [WorkerView("core-1", runtime="codex"), WorkerView("core-2")]
+        ws_codex = [MemberView("core-1", runtime="codex"), MemberView("core-2")]
         d = r.pick(TaskMeta("t", source="voice"), ws_codex, {})
         self.assertEqual((d.worker, d.rule), ("core-1", 1))
 
@@ -325,26 +325,26 @@ class EdgesAndFaults(Base):
         cfg = RoutingConfig(rules=[{"match": {"source": "slack"}, "policy": f"custom:{bad}:pick",
                                     "exclude": ["core-1"]}])
         r = Router(cfg, lambda *a: "core-2")
-        d = r.pick(TaskMeta("t", source="slack"), [WorkerView("core-1"), WorkerView("core-2")], {})
+        d = r.pick(TaskMeta("t", source="slack"), [MemberView("core-1"), MemberView("core-2")], {})
         self.assertEqual((d.worker, d.fallback), ("core-2", True))
         self.assertIn("not a candidate", d.reason)
 
     def test_lead_default_pick_over_core_only_membership(self):
         lead = self.lead()
-        only_core = [WorkerView(CORE_ID, is_core=True)]
-        self.assertEqual(lead._default_pick(TaskMeta("t"), only_core, {}, {}), CORE_ID)
+        only_core = [MemberView(HOME_ID, is_home=True)]
+        self.assertEqual(lead._default_pick(TaskMeta("t"), only_core, {}, {}), HOME_ID)
         self.assertIsNone(lead._default_pick(TaskMeta("t"), [], {}, {}))
 
 
 class DelegateCli(Base):
     def held(self):
-        p = self.tasks / f"task-1.claimed-{CORE_ID}.txt"
+        p = self.tasks / f"task-1.claimed-{HOME_ID}.txt"
         p.write_text(task())
         return p
 
     def test_usage_and_refusal_exit_2(self):
         self.assertEqual(pool_follower._delegate_cli(["only-one"]), 2)
-        self.assertEqual(pool_follower._delegate_cli([str(self.held()), CORE_ID, "core-2"]), 2)
+        self.assertEqual(pool_follower._delegate_cli([str(self.held()), HOME_ID, "core-2"]), 2)
 
     def test_success_prints_assignment_path(self):
         self.routing(allow_delegation=True)
@@ -352,7 +352,7 @@ class DelegateCli(Base):
         import io
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
-            rc = pool_follower._delegate_cli([str(self.held()), CORE_ID, "core-2"])
+            rc = pool_follower._delegate_cli([str(self.held()), HOME_ID, "core-2"])
         self.assertEqual(rc, 0)
         self.assertTrue(buf.getvalue().strip().endswith("task-1.assigned-core-2.txt"))
 

--- a/tests/pool-routing-policy.test.py
+++ b/tests/pool-routing-policy.test.py
@@ -141,6 +141,51 @@ class Rules(Base):
         self.assertIn("no live worker", t["reason"])
 
 
+class MalformedConfigMustNotFailOpen(Base):
+    """A false-looking value must not open delegation, and a scalar selector
+    must not do substring membership — both routed outside the declared set."""
+
+    def test_string_false_does_not_open_delegation(self):
+        self.routing(allow_delegation="false")
+        cfg = load_config(self.state)
+        self.assertIs(cfg.allow_delegation, False,
+                      "JSON allow_delegation='false' opened delegation")
+
+    def test_literal_true_still_opens_delegation(self):
+        self.routing(allow_delegation=True)
+        self.assertIs(load_config(self.state).allow_delegation, True,
+                      "control: a literal JSON true must still open it")
+
+    def test_scalar_only_does_not_substring_match(self):
+        self.pool = ["core-1", "core-10", "core-2"]
+        self.routing(rules=[{"match": {"source": "slack"}, "only": "core-10"}])
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertEqual(self.assigned()["task-1.txt"], "core-10",
+                         "a scalar 'only' substring-matched core-1 out of 'core-10'")
+
+    def test_scalar_exclude_does_not_substring_match(self):
+        self.pool = ["core-1", "core-10"]
+        self.routing(rules=[{"match": {"source": "slack"}, "exclude": "core-10"}])
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertEqual(self.assigned()["task-1.txt"], "core-1")
+        # The worker alone does not discriminate: at the parent BOTH ids are
+        # substring-excluded, the rule empties, and the fallback also picks core-1.
+        t = self.trace("routed")[0]
+        self.assertFalse(t["fallback"],
+                         "a scalar 'exclude' emptied the rule and forced a fallback")
+
+    def test_unusable_selector_type_falls_back_with_a_reason(self):
+        self.routing(rules=[{"match": {"source": "slack"}, "only": {"id": "core-1"}}])
+        self.write("task-1.txt", task())
+        self.lead().sweep()
+        self.assertIn(self.assigned()["task-1.txt"], self.pool)
+        t = self.trace("routed")[0]
+        self.assertTrue(t["fallback"])
+        self.assertIn("not a str or list of str", t["reason"])
+
+
 class BrokenPolicyDegrades(Base):
     def test_custom_that_raises_falls_back(self):
         mod = Path(self.tmp.name) / "bad.py"


### PR DESCRIPTION
Closes sonichi/sutando#3786. Stacked on #3604 (base = `rescue/pool-uncommitted-2026-08-26`); merge order: #3604 first. Sibling to #3783 (spawn-worker) and #3784 (pause/resume).

## What this changes

There is no golden routing answer (owner, Pro-Main 2026-09-03 ~06:5xZ). This PR separates **who** takes a task from **how** it is assigned:

- `src/runtime-api/pool_routing.py` — one call, `pick(task, workers, affinity) -> worker | None`, behind which sit named built-ins, an ordered rules file, or owner code. The lead keeps the atomic `assigned-` rename, reclaim and trace unchanged.
- **Built-ins:** `affinity-first` (= the lead's historical `_pick`; the default when nothing is configured), `least-loaded`, `round-robin`, `sticky-sender`, and **`home-first`** (`core-first` accepted as an alias for one release) — the owner's stated policy: an explicit `target_worker:` goes to that worker; everything else goes to the home seat, which claims and processes like any member.
- **Config** `state/pool/routing.json` (or `$SUTANDO_POOL_ROUTING`): top-level `policy`, first-match `rules` (`match` on task headers; `to`/`only`/`exclude` narrow candidates), `allow_delegation`. `custom:<path.py>:<attr>` loads owner code behind the same signature.
- **Degrade, never strand:** a policy that raises, names a dead worker, or is unknown is overridden by `affinity-first`; every assignment traces `{"event":"routed", policy, rule, fallback, reason}` in the lead's liveness trace.
- **The home seat is a member.** `PoolLead(home_fn=…)`; the daemon derives it from the host-labelled heartbeat and routes it under `HOME_ID`. It is picked only when a configured policy names it (`test_core_not_picked_unless_policy_names_it`).
- **A single seat is a membership of one.** The leaderless branch of `pool_follower.acquire_work` evaluates `solo_pick` over `[self]`; a rule that excludes the lone member leaves the file (`test_rule_excluding_me_leaves_the_file`). No solo code path. **This PR does not take a side on the counting convention** (home seat counted as worker N=1 vs. sitting outside N) — that ruling lands in `pool_names` (#3788); `HOME_ID` is the one constant here that follows it.
- **Delegation / work stealing:** `pool_follower.delegate` (+ CLI `delegate <claimed> <me> <worker>`) turns a held task into that worker's assignment; refused unless `allow_delegation: true`, and only for a file the caller holds.

Docs: `docs/lead-follower-pool.md` "Routing policy" section; `docs/src-map.md` regenerated.

## Evidence

**Control — no config is the old behaviour.** `test_no_config_matches_pick` asserts `sweep()` assigns exactly what `_pick` returns and traces `policy=affinity-first, fallback=false`. All 14 pre-existing pool suites at this head:

```
pool-lead-assignment 32 OK · pool-lead-liveness-trace 5 OK · pool-installer 29 OK · pool-lead-pin 11 OK
pool-compose 4 OK · state-paths-adoption rc=0 · pool-lead-multi-bind 7 OK · task-archive 26 OK
pool-io-fail-open 10 OK · pool-hygiene 12 OK · pool-lead-daemon 4 OK · pool-lead-dedicated 8 OK
pool-lead-addressing 14 OK · pool-lane-routing 24 OK
```

**New suite** `tests/pool-routing-policy.test.py` — 22 tests, real files through `sweep()` / `acquire_work()`:
```
Ran 22 tests in 0.049s
OK
```
covering: control; core-first (unaddressed→core, addressed→worker, no core→least-loaded); rules (first-match + narrowing, narrowed-to-nothing→fallback with reason); broken policy (raises / dead worker / unknown name / malformed JSON → default, traced); built-ins unit (round-robin cycles, sticky-sender keeps while live and moves on death, least-loaded); single-core (default lets the lone member claim; excluding rule leaves the file; `solo_pick` is the same router); delegation (off by default; on → `.assigned-<worker>`; refuses self/empty/path targets; refuses a file not held).

**Mutation control (before the trace-path fix in the helper):** with the helper reading a non-existent trace file, 8 of 22 failed on the trace assertions and 14 still passed — the trace assertions are load-bearing, not passing by construction.

Gate: `scripts/review-checks.sh --diff` on `origin/main...HEAD` (the pre-push hook's own basis) → PASS. `ruff check` clean. Author chain: 0 unmapped emails in range.

## Owner direction received while this was open (2026-09-03 ~07:0xZ)
"The start process must be the same. The user runs a script/command to add a new worker; when they do, they may bind that worker to a particular room. The core should still function well and take tasks." This PR is the routing half (core as a member; `core-first`; rules can bind a room to a worker). The add-worker-with-bind half belongs to #3783.

## Not in this PR (follow-ups)
- Folding `pool-bind.py` pins into `routing.json` rows (this PR consults rules first and keeps the affinity table).
- The plain `/proactive-loop` step 1 calling `acquire_work` so the core claims by policy rather than by prompt.
- Live round trip on this host: the pool runs 64ae7d4d (106 commits behind #3604); the owner's `restart.sh --pool N` witness for #3604 is the first opportunity — I will paste `routed` trace lines from it here.
- Will need a rebase once core-1's core→worker rename lands on this base (touches `pool_lead.py`/`pool_follower.py`).

**Vocabulary pass (6222d188, owner 07:3xZ):** the PR title had the core counted as worker N=1 while the settled framing counts single-core as N=0 — two conventions at once. Neutralised: `WorkerView`→`MemberView`, `is_core`→`is_home`, `CORE_ID`→`HOME_ID`, `core-first`→`home-first`; wording says *membership of one* and names the counting convention as a ruling this module does not make. 33/33 tests, 14 pool suites green, gate PASS.
