### PR TITLE
fix(quota): record upstream rejections in the proxy and page on them

### DIFF
--- a/skills/quota-tracker/SKILL.md
+++ b/skills/quota-tracker/SKILL.md
@@ -32,6 +32,8 @@ Output includes:
 - `anthropic-ratelimit-unified-7d-reset` — when the 7d window resets (epoch)
 - `anthropic-ratelimit-unified-status` — "allowed" or "rejected"
 
+`recent_rejections` is a bounded ledger (newest 20) of upstream responses the proxy forwarded with a 4xx/5xx other than 401 — `{ts, status, path, snippet}`. It survives the per-response header rewrite, and `health-check.py`'s `core-request-rejections` probe warns on one inside 15 minutes and fails on five inside an hour, so a credits/overage rejection that leaves every unified-status header `allowed` still reaches the owner.
+
 ## Setup
 
 ### 1. Start the credential proxy

--- a/skills/quota-tracker/SKILL.md
+++ b/skills/quota-tracker/SKILL.md
@@ -32,7 +32,7 @@ Output includes:
 - `anthropic-ratelimit-unified-7d-reset` — when the 7d window resets (epoch)
 - `anthropic-ratelimit-unified-status` — "allowed" or "rejected"
 
-`recent_rejections` is a bounded ledger (newest 20) of upstream responses the proxy forwarded with a 4xx/5xx other than 401 — `{ts, status, path, snippet}`. It survives the per-response header rewrite, and `health-check.py`'s `core-request-rejections` probe warns on one inside 15 minutes and fails on five inside an hour, so a credits/overage rejection that leaves every unified-status header `allowed` still reaches the owner.
+`recent_rejections` is a bounded ledger (newest 20) of upstream responses the proxy forwarded with a 4xx/5xx other than 401 — `{ts, status, path, snippet, model, user_agent, peer_port}` — the proxy serves every seat on the host, so the client fields are what make a rejection attributable; the probe counts only entries for this core's own model (`SUTANDO_CORE_MODEL` or `core-runtime.json`) and counts every client when that is unknown. It survives the per-response header rewrite, and `health-check.py`'s `core-request-rejections` probe warns on one inside 15 minutes and fails on five inside an hour, so a credits/overage rejection that leaves every unified-status header `allowed` still reaches the owner.
 
 ## Setup
 

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -15,7 +15,7 @@
 import { createServer, type RequestOptions } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { execFileSync } from 'node:child_process';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { statusPath } from '../../../src/workspace_default.js';
@@ -34,6 +34,10 @@ const UPSTREAM_IDLE_TIMEOUT_MS = Number(process.env.SUTANDO_PROXY_TIMEOUT_MS) ||
 // Historically written into the skill dir; readers (dashboard.py, read-quota.py)
 // keep the skill-dir path as a last-resort fallback for one release.
 const QUOTA_FILE = statusPath('quota-state.json');
+// Bounded ledger of upstream rejections (4xx/5xx other than the handled 401),
+// persisted in quota-state.json so health-check can page on a transient one.
+export const MAX_RECENT_REJECTIONS = 20;
+const REJECTION_SNIPPET_BYTES = 2048;
 
 // OAuth self-refresh. A namespaced CLAUDE_CONFIG_DIR uses a namespaced keychain
 // item (`Claude Code-credentials-<sha256(config-dir)[0..8]>`), while vanilla
@@ -302,6 +306,26 @@ export function authUnavailableBody(verdict: 'expired' | 'rejected'): string {
 
 // Injectable seams (keychain, refresh, upstream, clock) so the proxy's failure
 // semantics are testable hermetically; defaults are the production bindings.
+export interface RejectionRecord {
+	ts: string;
+	status: number;
+	path: string;
+	snippet: string;
+}
+
+function isRejectionRecord(x: unknown): x is RejectionRecord {
+	return !!x && typeof x === 'object'
+		&& typeof (x as RejectionRecord).ts === 'string'
+		&& typeof (x as RejectionRecord).status === 'number';
+}
+
+/** Append one rejection to a (possibly foreign/corrupt) prior ledger, keeping the newest `max`. */
+export function appendRejection(prev: unknown, rej: RejectionRecord, max: number = MAX_RECENT_REJECTIONS): RejectionRecord[] {
+	const list = Array.isArray(prev) ? prev.filter(isRejectionRecord) : [];
+	list.push(rej);
+	return list.slice(-max);
+}
+
 export interface ProxyDeps {
 	readCredCandidates: () => StoredClaudeOAuth[];
 	writeCred: (service: string, oauth: ClaudeOAuth) => boolean;
@@ -309,6 +333,7 @@ export interface ProxyDeps {
 	request: typeof httpsRequest;
 	upstreamUrl: URL;
 	updateQuotaState: (headers: Record<string, string>) => void;
+	recordRejection: (rej: RejectionRecord) => void;
 	now: () => number;
 	idleTimeoutMs: number;
 }
@@ -321,6 +346,7 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 		request: httpsRequest,
 		upstreamUrl: new URL(UPSTREAM),
 		updateQuotaState,
+		recordRejection,
 		now: Date.now,
 		idleTimeoutMs: UPSTREAM_IDLE_TIMEOUT_MS,
 		...overrides,
@@ -515,7 +541,24 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 							rejectedToken = injectedToken;
 						}
 
-						res.writeHead(upRes.statusCode!, upRes.headers);
+						const code = upRes.statusCode ?? 0;
+						if (code >= 400 && code !== 401) {
+							// The only component that sees a credits/overage rejection is this
+							// proxy; without a record the dropped request is invisible upstream.
+							const chunks: Buffer[] = [];
+							let seen = 0;
+							upRes.on('data', (c: Buffer) => {
+								if (seen < REJECTION_SNIPPET_BYTES) { chunks.push(c); seen += c.length; }
+							});
+							upRes.on('end', () => {
+								const snippet = redactForLog(Buffer.concat(chunks).toString('utf8').slice(0, REJECTION_SNIPPET_BYTES));
+								console.error(`${ts()} [Proxy] rejected HTTP ${code} on ${req.url}: ${snippet}`);
+								try {
+									deps.recordRejection({ ts: new Date(deps.now()).toISOString(), status: code, path: req.url ?? '', snippet });
+								} catch { /* best effort */ }
+							});
+						}
+						res.writeHead(code, upRes.headers);
 						upRes.pipe(res);
 					},
 				);
@@ -561,12 +604,36 @@ function getOAuthToken(): string | null {
 	return readCred()?.oauth.accessToken ?? null;
 }
 
+function readQuotaFile(): Record<string, unknown> {
+	try {
+		const parsed = JSON.parse(readFileSync(QUOTA_FILE, 'utf8'));
+		return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+function writeQuotaFile(state: Record<string, unknown>): void {
+	mkdirSync(dirname(QUOTA_FILE), { recursive: true });
+	writeFileSync(QUOTA_FILE, JSON.stringify(state, null, 2));
+}
+
+function recordRejection(rej: RejectionRecord): void {
+	try {
+		const prev = readQuotaFile();
+		writeQuotaFile({ ...prev, recent_rejections: appendRejection(prev.recent_rejections, rej) });
+	} catch { /* best effort */ }
+}
+
 function updateQuotaState(headers: Record<string, string>): void {
 	try {
+		// The header write replaces the file, so carry the rejection ledger across it.
+		const prevLedger = readQuotaFile().recent_rejections;
 		const state: Record<string, unknown> = {
 			available: true,
 			last_checked: new Date().toISOString(),
 			headers,
+			recent_rejections: Array.isArray(prevLedger) ? prevLedger.filter(isRejectionRecord) : [],
 		};
 
 		// Parse specific headers
@@ -587,8 +654,7 @@ function updateQuotaState(headers: Record<string, string>): void {
 			state.exhausted_since = new Date().toISOString();
 		}
 
-		mkdirSync(dirname(QUOTA_FILE), { recursive: true });
-		writeFileSync(QUOTA_FILE, JSON.stringify(state, null, 2));
+		writeQuotaFile(state);
 	} catch { /* best effort */ }
 }
 

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -311,6 +311,21 @@ export interface RejectionRecord {
 	status: number;
 	path: string;
 	snippet: string;
+	// The proxy serves every seat on a host, so a rejection is attributable only
+	// by what the request carried: the model, the CLI's user-agent, the peer port.
+	model?: string;
+	user_agent?: string;
+	peer_port?: number;
+}
+
+/** The `model` field of a JSON request body, or "" when absent or unparsable. */
+export function requestModel(body: Buffer): string {
+	try {
+		const m = JSON.parse(body.toString('utf8'))?.model;
+		return typeof m === 'string' ? m : '';
+	} catch {
+		return '';
+	}
 }
 
 function isRejectionRecord(x: unknown): x is RejectionRecord {
@@ -545,16 +560,20 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 						if (code >= 400 && code !== 401) {
 							// The only component that sees a credits/overage rejection is this
 							// proxy; without a record the dropped request is invisible upstream.
-							const chunks: Buffer[] = [];
+							const rejChunks: Buffer[] = [];
 							let seen = 0;
 							upRes.on('data', (c: Buffer) => {
-								if (seen < REJECTION_SNIPPET_BYTES) { chunks.push(c); seen += c.length; }
+								if (seen < REJECTION_SNIPPET_BYTES) { rejChunks.push(c); seen += c.length; }
 							});
 							upRes.on('end', () => {
-								const snippet = redactForLog(Buffer.concat(chunks).toString('utf8').slice(0, REJECTION_SNIPPET_BYTES));
-								console.error(`${ts()} [Proxy] rejected HTTP ${code} on ${req.url}: ${snippet}`);
+								const snippet = redactForLog(Buffer.concat(rejChunks).toString('utf8').slice(0, REJECTION_SNIPPET_BYTES));
+								const model = requestModel(body);
+								console.error(`${ts()} [Proxy] rejected HTTP ${code} on ${req.url} model=${model || '?'} peer=${req.socket.remotePort ?? '?'}: ${snippet}`);
 								try {
-									deps.recordRejection({ ts: new Date(deps.now()).toISOString(), status: code, path: req.url ?? '', snippet });
+									deps.recordRejection({
+										ts: new Date(deps.now()).toISOString(), status: code, path: req.url ?? '', snippet,
+										model, user_agent: String(req.headers['user-agent'] ?? ''), peer_port: req.socket.remotePort,
+									});
 								} catch { /* best effort */ }
 							});
 						}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5177,17 +5177,19 @@ def _rejection_epoch(entry: object) -> "float | None":
 
 
 def _own_core_model() -> "str | None":
-    """This core's model, or None when no writer has recorded it (Claude cores today)."""
+    """This core's model, or None when nothing on this host declares one.
+
+    NOT read from core-runtime.json: that marker records launch-time facts
+    (runtime, session), and the supervisor can switch model mid-session, so a
+    stamped model would go stale and attribute a rejection confidently and
+    wrongly — worse than reporting unattributed.
+    """
     env = os.environ.get("SUTANDO_CORE_MODEL")
     if env:
         return env
-    path = status_read_path("core-runtime.json", WORKSPACE_DIR)
-    try:
-        data = json.loads(path.read_text())
-    except (OSError, ValueError):
-        return None
-    m = data.get("model") if isinstance(data, dict) else None
-    return m if isinstance(m, str) and m else None
+    pins = {model for _label, model in _settings_model_pins()}
+    # Two settings files disagreeing is not a model this core can claim.
+    return pins.pop() if len(pins) == 1 else None
 
 
 def check_core_request_rejections(window_sec: int = 900, sustained: int = 5,

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5162,6 +5162,76 @@ def _fmt_quota_reset(epoch_str: Optional[str]) -> str:
         return ""
 
 
+
+def _rejection_epoch(entry: object) -> float | None:
+    if not isinstance(entry, dict):
+        return None
+    ts = entry.get("ts")
+    if not isinstance(ts, str):
+        return None
+    from datetime import datetime as _dt
+    try:
+        return _dt.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def check_core_request_rejections(window_sec: int = 900, sustained: int = 5,
+                                  hour_sec: int = 3600) -> dict:
+    """WARN on a recent upstream rejection (4xx/5xx other than 401) recorded by the
+    credential proxy, FAIL on a sustained run — the class `check_core_quota_exhausted`
+    cannot see.
+
+    Owner-reported 2026-09-03 (#3790): two scheduled fires were dropped with
+    "You're out of usage credits" while every unified-status header read
+    "allowed", so no probe fired. The proxy now records each such response into
+    `recent_rejections` in quota-state.json; this probe reads only that ledger.
+    A rejection younger than `window_sec` warns (the owner hears once per
+    episode via the transition-hash dedup); `sustained` or more inside
+    `hour_sec` fails. Missing, foreign or unparsable ledgers never page.
+    """
+    check = {"name": "core-request-rejections", "status": "ok"}
+    path = status_read_path("quota-state.json", WORKSPACE_DIR)
+    if not path.exists():
+        check["detail"] = "no quota-state.json (absence handled by quota-telemetry)"
+        return check
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        check["status"] = "warn"
+        check["detail"] = "quota-state.json present but unreadable"
+        return check
+    ledger = data.get("recent_rejections") if isinstance(data, dict) else None
+    if not isinstance(ledger, list) or not ledger:
+        check["detail"] = "no upstream rejections recorded by the proxy"
+        return check
+
+    now = time.time()
+    dated = [(e, t) for e in ledger for t in [_rejection_epoch(e)] if t is not None]
+    if not dated:
+        check["detail"] = f"{len(ledger)} ledger entr(y/ies) but none carry a parsable ts"
+        return check
+    last_entry, last_t = max(dated, key=lambda p: p[1])
+    in_hour = [p for p in dated if now - p[1] <= hour_sec]
+    in_window = [p for p in dated if now - p[1] <= window_sec]
+    age_min = int(max(now - last_t, 0) / 60)
+    what = (f"last: HTTP {last_entry.get('status')} {age_min}m ago — "
+            f"{str(last_entry.get('snippet') or '')[:160]!r}")
+    remedy = ("; the CLI drops the fire and prints the error in the core pane, so run "
+              "/usage-credits (or /model to switch) there")
+    if len(in_hour) >= sustained:
+        check["status"] = "fail"
+        check["detail"] = (f"{len(in_hour)} upstream rejections in the last "
+                           f"{hour_sec // 60}m ({what}){remedy}")
+    elif in_window:
+        check["status"] = "warn"
+        check["detail"] = (f"{len(in_window)} upstream rejection(s) in the last "
+                           f"{window_sec // 60}m ({what}){remedy}")
+    else:
+        check["detail"] = f"{len(ledger)} recorded, none in the last {window_sec // 60}m ({what})"
+    return check
+
+
 def check_core_quota_exhausted(fresh_sec: int = 1800) -> dict:
     """FAIL (loudly, to the remote owner surface) when the core's model quota is
     exhausted — the 'stuck silently' condition.
@@ -10249,6 +10319,9 @@ def run_all_checks() -> list[dict]:
     # Core over-quota — fail loudly to the remote owner surface so an exhausted
     # model no longer stalls every task silently (owner-reported 2026-08-01).
     checks.append(check_core_quota_exhausted())
+    # A credits/overage rejection leaves every unified-status header "allowed",
+    # so the check above cannot see it; the proxy's ledger is the only record.
+    checks.append(check_core_request_rejections())
 
     # G1.5: which Node would JS services resolve to (bundled/app-bundle/
     # system), red when none — the silent-dead-services failure class.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5163,7 +5163,7 @@ def _fmt_quota_reset(epoch_str: Optional[str]) -> str:
 
 
 
-def _rejection_epoch(entry: object) -> float | None:
+def _rejection_epoch(entry: object) -> "float | None":
     if not isinstance(entry, dict):
         return None
     ts = entry.get("ts")

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5176,6 +5176,20 @@ def _rejection_epoch(entry: object) -> "float | None":
         return None
 
 
+def _own_core_model() -> "str | None":
+    """This core's model, or None when no writer has recorded it (Claude cores today)."""
+    env = os.environ.get("SUTANDO_CORE_MODEL")
+    if env:
+        return env
+    path = status_read_path("core-runtime.json", WORKSPACE_DIR)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    m = data.get("model") if isinstance(data, dict) else None
+    return m if isinstance(m, str) and m else None
+
+
 def check_core_request_rejections(window_sec: int = 900, sustained: int = 5,
                                   hour_sec: int = 3600) -> dict:
     """WARN on a recent upstream rejection (4xx/5xx other than 401) recorded by the
@@ -5186,6 +5200,15 @@ def check_core_request_rejections(window_sec: int = 900, sustained: int = 5,
     "You're out of usage credits" while every unified-status header read
     "allowed", so no probe fired. The proxy now records each such response into
     `recent_rejections` in quota-state.json; this probe reads only that ledger.
+
+    The proxy serves every seat on the host, so the ledger mixes clients. Each
+    entry carries the request's `model`; when this core's own model is known
+    (`SUTANDO_CORE_MODEL` or core-runtime.json), only entries for that model
+    count toward the thresholds and the rest are reported as other clients'.
+    When it is unknown, every entry counts and the detail says so, because a
+    shared-proxy rejection that cannot be attributed must not be silently
+    discarded either.
+
     A rejection younger than `window_sec` warns (the owner hears once per
     episode via the transition-hash dedup); `sustained` or more inside
     `hour_sec` fails. Missing, foreign or unparsable ledgers never page.
@@ -5211,26 +5234,42 @@ def check_core_request_rejections(window_sec: int = 900, sustained: int = 5,
     if not dated:
         check["detail"] = f"{len(ledger)} ledger entr(y/ies) but none carry a parsable ts"
         return check
-    last_entry, last_t = max(dated, key=lambda p: p[1])
-    in_hour = [p for p in dated if now - p[1] <= hour_sec]
-    in_window = [p for p in dated if now - p[1] <= window_sec]
+
+    own = _own_core_model()
+    if own:
+        mine = [p for p in dated if p[0].get("model") == own]
+        others = [p for p in dated if p[0].get("model") != own]
+        attribution = f"counting model={own}"
+    else:
+        mine, others = dated, []
+        attribution = "unattributed (this core's model is unknown, so every client counts)"
+    other_models = sorted({str(p[0].get("model") or "?") for p in others})
+    other_note = (f"; {len(others)} from other client(s) [{', '.join(other_models)}] not counted"
+                  if others else "")
+
+    if not mine:
+        check["detail"] = (f"{len(ledger)} recorded, none for this core's model ({attribution}){other_note}")
+        return check
+    last_entry, last_t = max(mine, key=lambda p: p[1])
+    in_hour = [p for p in mine if now - p[1] <= hour_sec]
+    in_window = [p for p in mine if now - p[1] <= window_sec]
     age_min = int(max(now - last_t, 0) / 60)
-    what = (f"last: HTTP {last_entry.get('status')} {age_min}m ago — "
+    what = (f"last: HTTP {last_entry.get('status')} {age_min}m ago, model={last_entry.get('model') or '?'} — "
             f"{str(last_entry.get('snippet') or '')[:160]!r}")
-    remedy = ("; the CLI drops the fire and prints the error in the core pane, so run "
-              "/usage-credits (or /model to switch) there")
+    remedy = ("; the CLI drops the fire and prints the error in the pane of the seat that was "
+              "rejected, so run /usage-credits (or /model to switch) there")
     if len(in_hour) >= sustained:
         check["status"] = "fail"
-        check["detail"] = (f"{len(in_hour)} upstream rejections in the last "
-                           f"{hour_sec // 60}m ({what}){remedy}")
+        check["detail"] = (f"{len(in_hour)} upstream rejections in the last {hour_sec // 60}m "
+                           f"({attribution}; {what}){remedy}{other_note}")
     elif in_window:
         check["status"] = "warn"
-        check["detail"] = (f"{len(in_window)} upstream rejection(s) in the last "
-                           f"{window_sec // 60}m ({what}){remedy}")
+        check["detail"] = (f"{len(in_window)} upstream rejection(s) in the last {window_sec // 60}m "
+                           f"({attribution}; {what}){remedy}{other_note}")
     else:
-        check["detail"] = f"{len(ledger)} recorded, none in the last {window_sec // 60}m ({what})"
+        check["detail"] = (f"{len(mine)} recorded, none in the last {window_sec // 60}m "
+                           f"({attribution}; {what}){other_note}")
     return check
-
 
 def check_core_quota_exhausted(fresh_sec: int = 1800) -> dict:
     """FAIL (loudly, to the remote owner surface) when the core's model quota is

--- a/tests/credential-proxy-rejection-ledger.test.ts
+++ b/tests/credential-proxy-rejection-ledger.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The proxy must RECORD an upstream rejection (4xx/5xx other than the handled
+ * 401) while forwarding it unchanged — the only place a credits/overage
+ * rejection is visible is this response, and before #3790 it was dropped.
+ * Upstream, keychain and clock are injected; no network, no real keychain.
+ */
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createServer as createHttpServer, request as httpRequest, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { request as httpsRequest } from 'node:https';
+import { createProxyServer, appendRejection, MAX_RECENT_REJECTIONS, type ProxyDeps, type RejectionRecord } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+
+const NOW = 1_700_000_000_000;
+let upstreamHandler: (req: IncomingMessage, res: ServerResponse) => void = () => {};
+let recorded: RejectionRecord[] = [];
+let quotaWrites = 0;
+const servers: Server[] = [];
+
+beforeEach(() => { recorded = []; quotaWrites = 0; });
+afterEach(async () => {
+	await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
+});
+
+function listen(s: Server): Promise<number> {
+	servers.push(s);
+	return new Promise((resolve) => s.listen(0, '127.0.0.1', () => resolve((s.address() as { port: number }).port)));
+}
+
+async function startProxy(): Promise<number> {
+	const upstreamPort = await listen(createHttpServer((req, res) => upstreamHandler(req, res)));
+	const deps: Partial<ProxyDeps> = {
+		readCredCandidates: () => [{ service: 'svc', oauth: { accessToken: 'tok', expiresAt: NOW + 3600_000 } }],
+		writeCred: () => true,
+		refreshAccessToken: async () => null,
+		request: httpRequest as unknown as typeof httpsRequest,
+		upstreamUrl: new URL(`http://127.0.0.1:${upstreamPort}`),
+		updateQuotaState: () => { quotaWrites += 1; },
+		recordRejection: (rej) => { recorded.push(rej); },
+		now: () => NOW,
+		idleTimeoutMs: 5000,
+	};
+	return listen(createProxyServer(deps));
+}
+
+function call(port: number): Promise<{ status: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const req = httpRequest({ hostname: '127.0.0.1', port, path: '/v1/messages?beta=true', method: 'POST' }, (res) => {
+			const chunks: Buffer[] = [];
+			res.on('data', (c) => chunks.push(c));
+			res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }));
+		});
+		req.on('error', reject);
+		req.end('{}');
+	});
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 30));
+
+test('a 429 credits rejection is forwarded unchanged AND recorded with status, path and body snippet', async () => {
+	const body = '{"error":{"type":"overage","message":"You\'re out of usage credits. Run /usage-credits"}}';
+	upstreamHandler = (_req, res) => { res.writeHead(429, { 'content-type': 'application/json' }); res.end(body); };
+	const port = await startProxy();
+	const r = await call(port);
+	await settle();
+	assert.equal(r.status, 429);
+	assert.equal(r.body, body, 'the client still receives the whole upstream body');
+	assert.equal(recorded.length, 1);
+	assert.equal(recorded[0].status, 429);
+	assert.equal(recorded[0].path, '/v1/messages?beta=true');
+	assert.equal(recorded[0].ts, new Date(NOW).toISOString(), 'stamped from the injected clock');
+	assert.match(recorded[0].snippet, /out of usage credits/);
+});
+
+test('a 5xx is recorded too; a 2xx and a 401 are NOT (401 has its own auth path)', async () => {
+	upstreamHandler = (_req, res) => { res.writeHead(529); res.end('overloaded'); };
+	const port = await startProxy();
+	assert.equal((await call(port)).status, 529);
+	await settle();
+	assert.equal(recorded.length, 1);
+	assert.equal(recorded[0].status, 529);
+
+	upstreamHandler = (_req, res) => { res.writeHead(200, { 'anthropic-ratelimit-unified-status': 'allowed' }); res.end('{"ok":true}'); };
+	assert.equal((await call(port)).status, 200);
+	upstreamHandler = (_req, res) => { res.writeHead(401); res.end('{"error":"auth"}'); };
+	assert.equal((await call(port)).status, 401);
+	await settle();
+	assert.equal(recorded.length, 1, 'control: neither the 200 nor the 401 added a record');
+	assert.ok(quotaWrites >= 1, 'the 200 still fed the quota-state writer');
+});
+
+test('a recorder that throws does not break forwarding', async () => {
+	upstreamHandler = (_req, res) => { res.writeHead(429); res.end('x'); };
+	const upstreamPort = await listen(createHttpServer((req, res) => upstreamHandler(req, res)));
+	const port = await listen(createProxyServer({
+		readCredCandidates: () => [{ service: 'svc', oauth: { accessToken: 'tok', expiresAt: NOW + 3600_000 } }],
+		writeCred: () => true,
+		refreshAccessToken: async () => null,
+		request: httpRequest as unknown as typeof httpsRequest,
+		upstreamUrl: new URL(`http://127.0.0.1:${upstreamPort}`),
+		updateQuotaState: () => {},
+		recordRejection: () => { throw new Error('disk full'); },
+		now: () => NOW,
+		idleTimeoutMs: 5000,
+	}));
+	const r = await call(port);
+	assert.equal(r.status, 429);
+	assert.equal(r.body, 'x');
+});
+
+test('appendRejection bounds the ledger, drops foreign entries, keeps the newest', () => {
+	const mk = (i: number): RejectionRecord => ({ ts: new Date(NOW + i).toISOString(), status: 429, path: '/', snippet: String(i) });
+	let ledger: unknown = ['garbage', { ts: 5 }, null];
+	for (let i = 0; i < MAX_RECENT_REJECTIONS + 7; i++) ledger = appendRejection(ledger, mk(i));
+	const out = ledger as RejectionRecord[];
+	assert.equal(out.length, MAX_RECENT_REJECTIONS);
+	assert.equal(out[0].snippet, '7', 'oldest 7 evicted');
+	assert.equal(out[out.length - 1].snippet, String(MAX_RECENT_REJECTIONS + 6));
+	assert.deepEqual(appendRejection(undefined, mk(0)), [mk(0)], 'a missing ledger starts fresh');
+	assert.deepEqual(appendRejection('not-a-list', mk(0)), [mk(0)]);
+});

--- a/tests/credential-proxy-rejection-ledger.test.ts
+++ b/tests/credential-proxy-rejection-ledger.test.ts
@@ -8,7 +8,7 @@ import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { createServer as createHttpServer, request as httpRequest, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
 import type { request as httpsRequest } from 'node:https';
-import { createProxyServer, appendRejection, MAX_RECENT_REJECTIONS, type ProxyDeps, type RejectionRecord } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+import { createProxyServer, appendRejection, requestModel, MAX_RECENT_REJECTIONS, type ProxyDeps, type RejectionRecord } from '../skills/quota-tracker/scripts/credential-proxy.ts';
 
 const NOW = 1_700_000_000_000;
 let upstreamHandler: (req: IncomingMessage, res: ServerResponse) => void = () => {};
@@ -42,15 +42,15 @@ async function startProxy(): Promise<number> {
 	return listen(createProxyServer(deps));
 }
 
-function call(port: number): Promise<{ status: number; body: string }> {
+function call(port: number, reqBody = '{}', headers: Record<string, string> = {}): Promise<{ status: number; body: string }> {
 	return new Promise((resolve, reject) => {
-		const req = httpRequest({ hostname: '127.0.0.1', port, path: '/v1/messages?beta=true', method: 'POST' }, (res) => {
+		const req = httpRequest({ hostname: '127.0.0.1', port, path: '/v1/messages?beta=true', method: 'POST', headers }, (res) => {
 			const chunks: Buffer[] = [];
 			res.on('data', (c) => chunks.push(c));
 			res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }));
 		});
 		req.on('error', reject);
-		req.end('{}');
+		req.end(reqBody);
 	});
 }
 
@@ -69,6 +69,21 @@ test('a 429 credits rejection is forwarded unchanged AND recorded with status, p
 	assert.equal(recorded[0].path, '/v1/messages?beta=true');
 	assert.equal(recorded[0].ts, new Date(NOW).toISOString(), 'stamped from the injected clock');
 	assert.match(recorded[0].snippet, /out of usage credits/);
+});
+
+test('the record attributes the rejection to the requesting client: model from the body, user-agent, peer port', async () => {
+	upstreamHandler = (_req, res) => { res.writeHead(429); res.end('{"error":"credits"}'); };
+	const port = await startProxy();
+	await call(port, '{"model":"claude-fable-5-1","messages":[]}', { 'user-agent': 'claude-cli/9.9.9 (seat-3)' });
+	await call(port, 'not json', { 'user-agent': 'other-client/1' });
+	await settle();
+	assert.equal(recorded.length, 2);
+	assert.equal(recorded[0].model, 'claude-fable-5-1');
+	assert.equal(recorded[0].user_agent, 'claude-cli/9.9.9 (seat-3)');
+	assert.equal(typeof recorded[0].peer_port, 'number');
+	assert.equal(recorded[1].model, '', 'an unparsable body records an empty model, never throws');
+	assert.equal(recorded[1].user_agent, 'other-client/1');
+	assert.equal(requestModel(Buffer.from('{"model":5}')), '', 'a non-string model is empty');
 });
 
 test('a 5xx is recorded too; a 2xx and a 401 are NOT (401 has its own auth path)', async () => {

--- a/tests/health-check-core-request-rejections.test.py
+++ b/tests/health-check-core-request-rejections.test.py
@@ -21,6 +21,7 @@ import json
 import tempfile
 import time
 import unittest
+import unittest.mock
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -54,8 +55,11 @@ class TestCoreRequestRejections(unittest.TestCase):
         self.q.write_text(json.dumps({"available": True, "headers": {
             "anthropic-ratelimit-unified-status": "allowed"}, "recent_rejections": ledger}))
 
-    def _rej(self, age, status=429, snippet="You're out of usage credits. Run /usage-credits"):
-        return {"ts": _iso(age), "status": status, "path": "/v1/messages", "snippet": snippet}
+    def _rej(self, age, status=429, snippet="You're out of usage credits. Run /usage-credits", model="claude-fable-5-1"):
+        return {"ts": _iso(age), "status": status, "path": "/v1/messages", "snippet": snippet, "model": model}
+
+    def _own(self, model):
+        return unittest.mock.patch.dict("os.environ", {"SUTANDO_CORE_MODEL": model} if model else {}, clear=False)
 
     def test_fresh_rejection_warns_with_remedy_and_reaches_owner_filter(self):
         self._write([self._rej(120)])
@@ -109,6 +113,37 @@ class TestCoreRequestRejections(unittest.TestCase):
         c = self.hc.check_core_request_rejections()
         self.assertEqual(c["status"], "warn")
         self.assertIn("unreadable", c["detail"])
+
+    def test_shared_proxy_other_seats_rejections_do_not_count_when_own_model_known(self):
+        # Five rejections from another seat's model inside the hour; one fresh from mine.
+        self._write([self._rej(60 * k, model="claude-opus-5") for k in range(1, 6)] + [self._rej(30, model="claude-fable-5-1")])
+        with self._own("claude-fable-5-1"):
+            c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "warn", c)
+        self.assertIn("counting model=claude-fable-5-1", c["detail"])
+        self.assertIn("5 from other client(s) [claude-opus-5] not counted", c["detail"])
+
+    def test_only_other_seats_rejected_is_ok_for_this_core(self):
+        self._write([self._rej(60 * k, model="claude-opus-5") for k in range(1, 6)])
+        with self._own("claude-fable-5-1"):
+            c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "ok", c)
+        self.assertIn("none for this core's model", c["detail"])
+
+    def test_unknown_own_model_counts_every_client_and_says_so(self):
+        self._write([self._rej(60 * k, model="claude-opus-5") for k in range(1, 6)])
+        with self._own(None):
+            c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "fail", c)
+        self.assertIn("unattributed", c["detail"])
+
+    def test_control_attribution_is_what_flips_the_verdict(self):
+        ledger = [self._rej(60 * k, model="claude-opus-5") for k in range(1, 6)]
+        self._write(ledger)
+        with self._own("claude-fable-5-1"):
+            self.assertEqual(self.hc.check_core_request_rejections()["status"], "ok")
+        with self._own("claude-opus-5"):
+            self.assertEqual(self.hc.check_core_request_rejections()["status"], "fail")
 
     def test_probe_is_registered_next_to_core_quota(self):
         src = (REPO / "src" / "health-check.py").read_text()

--- a/tests/health-check-core-request-rejections.test.py
+++ b/tests/health-check-core-request-rejections.test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""`check_core_request_rejections` must surface a proxy-recorded upstream
+rejection that `check_core_quota_exhausted` cannot see (#3790): two scheduled
+fires dropped with "out of usage credits" while every unified-status header
+read "allowed".
+
+  - fresh rejection (< window)       -> warn, names status + snippet + remedy,
+                                        survives the _slack_failures filter
+  - sustained (>= 5 in the hour)     -> fail
+  - only old rejections              -> ok
+  - absent file / empty / foreign    -> ok (never pages on nothing)
+  - unreadable file                  -> warn (bounded)
+  - the probe is registered          -> appears in the assembled check list
+
+Run: python3 tests/health-check-core-request-rejections.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("hc_rej_test", REPO / "src" / "health-check.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _iso(age_sec: float) -> str:
+    return datetime.fromtimestamp(time.time() - age_sec, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class TestCoreRequestRejections(unittest.TestCase):
+    def setUp(self):
+        self.hc = _load()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.hc.WORKSPACE_DIR = self.root
+        self.q = self.hc.status_read_path("quota-state.json", self.root)
+        self.q.parent.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, ledger):
+        self.q.write_text(json.dumps({"available": True, "headers": {
+            "anthropic-ratelimit-unified-status": "allowed"}, "recent_rejections": ledger}))
+
+    def _rej(self, age, status=429, snippet="You're out of usage credits. Run /usage-credits"):
+        return {"ts": _iso(age), "status": status, "path": "/v1/messages", "snippet": snippet}
+
+    def test_fresh_rejection_warns_with_remedy_and_reaches_owner_filter(self):
+        self._write([self._rej(120)])
+        c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "warn", c)
+        self.assertIn("HTTP 429", c["detail"])
+        self.assertIn("out of usage credits", c["detail"])
+        self.assertIn("/usage-credits", c["detail"])
+        self.assertEqual([x["name"] for x in self.hc._slack_failures([c])], ["core-request-rejections"])
+
+    def test_sustained_run_fails(self):
+        self._write([self._rej(60 * k) for k in range(1, 6)])
+        c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "fail", c)
+        self.assertIn("5 upstream rejections", c["detail"])
+
+    def test_four_in_hour_none_in_window_is_ok_but_states_it(self):
+        self._write([self._rej(1200 + 60 * k) for k in range(4)])
+        c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "ok", c)
+        self.assertIn("none in the last 15m", c["detail"])
+
+    def test_only_old_rejections_ok(self):
+        self._write([self._rej(7200), self._rej(86400)])
+        c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "ok", c)
+        self.assertIn("120m ago", c["detail"])
+
+    def test_control_the_fresh_case_is_what_flips_it(self):
+        old = [self._rej(7200)]
+        self._write(old)
+        self.assertEqual(self.hc.check_core_request_rejections()["status"], "ok")
+        self._write(old + [self._rej(30)])
+        self.assertEqual(self.hc.check_core_request_rejections()["status"], "warn")
+
+    def test_absent_empty_foreign_never_page(self):
+        self.assertEqual(self.hc.check_core_request_rejections()["status"], "ok")
+        self._write([])
+        self.assertEqual(self.hc.check_core_request_rejections()["status"], "ok")
+        self._write("not-a-list")
+        self.assertEqual(self.hc.check_core_request_rejections()["status"], "ok")
+        self._write([{"ts": 5}, "junk", None, {"status": 429}])
+        c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "ok", c)
+        self.assertIn("none carry a parsable ts", c["detail"])
+        self.q.write_text("[1,2]")
+        self.assertEqual(self.hc.check_core_request_rejections()["status"], "ok")
+
+    def test_unreadable_is_bounded_warn(self):
+        self.q.write_text("{not json")
+        c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "warn")
+        self.assertIn("unreadable", c["detail"])
+
+    def test_probe_is_registered_next_to_core_quota(self):
+        src = (REPO / "src" / "health-check.py").read_text()
+        i = src.index("checks.append(check_core_quota_exhausted())")
+        j = src.index("checks.append(check_core_request_rejections())")
+        self.assertLess(i, j)
+        self.assertLess(j - i, 400, "registered right after the core-quota probe")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/health-check-core-request-rejections.test.py
+++ b/tests/health-check-core-request-rejections.test.py
@@ -20,6 +20,8 @@ import importlib.util
 import json
 import tempfile
 import time
+import os
+import contextlib
 import unittest
 import unittest.mock
 from datetime import datetime, timezone
@@ -47,6 +49,12 @@ class TestCoreRequestRejections(unittest.TestCase):
         self.hc.WORKSPACE_DIR = self.root
         self.q = self.hc.status_read_path("quota-state.json", self.root)
         self.q.parent.mkdir(parents=True, exist_ok=True)
+        # The probe reads this core's model from the HOST, so an uncontrolled
+        # default makes every arm pass or fail by which machine runs it.
+        os.environ.pop("SUTANDO_CORE_MODEL", None)
+        pins = unittest.mock.patch.object(self.hc, "_settings_model_pins", lambda *a, **k: [])
+        pins.start()
+        self.addCleanup(pins.stop)
 
     def tearDown(self):
         self._tmp.cleanup()
@@ -58,8 +66,23 @@ class TestCoreRequestRejections(unittest.TestCase):
     def _rej(self, age, status=429, snippet="You're out of usage credits. Run /usage-credits", model="claude-fable-5-1"):
         return {"ts": _iso(age), "status": status, "path": "/v1/messages", "snippet": snippet, "model": model}
 
+    @contextlib.contextmanager
     def _own(self, model):
-        return unittest.mock.patch.dict("os.environ", {"SUTANDO_CORE_MODEL": model} if model else {}, clear=False)
+        """Declare (or un-declare) this core's model for the duration.
+
+        Both sources must be controlled: leaving the settings fallback live
+        would read the HOST's own pin, so the "unknown model" arm would pass
+        on a machine with no pin and fail on the developer's.
+        """
+        env = {"SUTANDO_CORE_MODEL": model} if model else {}
+        with unittest.mock.patch.dict("os.environ", env, clear=False):
+            if not model:
+                os.environ.pop("SUTANDO_CORE_MODEL", None)
+            with unittest.mock.patch.object(
+                self.hc, "_settings_model_pins",
+                lambda *a, **k: [("test", model)] if model else []
+            ):
+                yield
 
     def test_fresh_rejection_warns_with_remedy_and_reaches_owner_filter(self):
         self._write([self._rej(120)])
@@ -151,6 +174,42 @@ class TestCoreRequestRejections(unittest.TestCase):
         j = src.index("checks.append(check_core_request_rejections())")
         self.assertLess(i, j)
         self.assertLess(j - i, 400, "registered right after the core-quota probe")
+
+
+    def test_a_model_stamped_in_core_runtime_json_is_ignored(self):
+        """The launch marker records runtime/session, not model. A model there
+        would be a launch-time copy of a value the supervisor can change
+        mid-session (#3739), so reading it would attribute confidently and
+        wrongly. This is the control for that: the file says fable, the probe
+        must still report unattributed."""
+        marker = self.hc.status_read_path("core-runtime.json", self.root)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(json.dumps(
+            {"runtime": "claude", "session": "sutando-core", "model": "claude-fable-5-1"}))
+        self._write([self._rej(120, model="claude-fable-5-1")])
+        c = self.hc.check_core_request_rejections()
+        self.assertIn("unattributed", c["detail"], c)
+        self.assertNotIn("counting model=", c["detail"], c)
+
+    def test_a_single_settings_pin_declares_the_model(self):
+        with unittest.mock.patch.object(
+            self.hc, "_settings_model_pins", lambda *a, **k: [("user", "claude-opus-5")]
+        ):
+            self._write([self._rej(120, model="claude-opus-5")])
+            c = self.hc.check_core_request_rejections()
+        self.assertEqual(c["status"], "warn", c)
+        self.assertIn("counting model=claude-opus-5", c["detail"], c)
+
+    def test_two_settings_pins_that_disagree_are_not_a_claim(self):
+        """Two files naming different models is not a model this core can claim;
+        guessing one would attribute every rejection to a coin flip."""
+        with unittest.mock.patch.object(
+            self.hc, "_settings_model_pins",
+            lambda *a, **k: [("user", "claude-opus-5"), ("project", "claude-fable-5-1")]
+        ):
+            self._write([self._rej(120, model="claude-opus-5")])
+            c = self.hc.check_core_request_rejections()
+        self.assertIn("unattributed", c["detail"], c)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3790.

## Problem

A request rejected for usage credits/overage is surfaced by nothing. Owner screenshot 2026-09-03 07:16Z: two scheduled fires dropped with `You're out of usage credits. Run /usage-credits …` while the proxy's headers at that moment read `unified-status: allowed`, `5h-status: allowed`, `7d-status: allowed`. `check_core_quota_exhausted` pages only on `unified-status == rejected` / `available:false`; the monitor's `classify()` returns `None` without an await-hint; the proxy forwarded `upRes.statusCode` and recorded nothing. The only component that sees the discriminating fact is the proxy, and it dropped it.

## Mechanism

- **Proxy** (`skills/quota-tracker/scripts/credential-proxy.ts`): a `recordRejection` dep (injectable like `updateQuotaState`). Any forwarded `>= 400` other than the already-handled 401 is logged as `[Proxy] rejected HTTP <code> on <path>: <redacted snippet>` and appended to a bounded `recent_rejections` ledger (newest 20) in `quota-state.json`. The response is forwarded unchanged (body tee'd, capped at 2 KB). The header write used to replace the file, so `updateQuotaState` now carries the ledger across it.
- **health-check** (`src/health-check.py`): `check_core_request_rejections` — WARN on a rejection younger than 15 min, FAIL on ≥5 inside an hour, naming the status, the body snippet and the remedy (`/usage-credits` or `/model` in the core pane). Registered right after `core-quota`. Missing / empty / foreign / unparsable ledgers never page. Delivery is the existing `_slack_failures()` path, whose dedup hashes the failure-set by name, so the owner hears once per episode even though the detail carries an age.

## Evidence

Tests (worktree at `711ebc62f`, all commands run):

```
$ node_modules/.bin/tsx --test --test-force-exit tests/credential-proxy-rejection-ledger.test.ts tests/credential-proxy-failure-semantics.test.ts tests/credential-proxy-refresh.test.ts
# tests 41
# pass 41
# fail 0
$ python3 tests/health-check-core-request-rejections.test.py
Ran 8 tests in 0.094s
OK
$ python3 tests/health-check-core-quota.test.py      # neighbour, unchanged
OK
$ node_modules/.bin/tsc --noEmit ; echo rc=$?
rc=0
```

Mutation controls (each restored afterwards):

```
# proxy: replace `deps.recordRejection({…})` with `void ({…})`
not ok 1 - a 429 credits rejection is forwarded unchanged AND recorded with status, path and body snippet
not ok 2 - a 5xx is recorded too; a 2xx and a 401 are NOT (401 has its own auth path)
# pass 2
# fail 2
# probe: delete `check["status"] = "warn"` in the in-window branch
Ran 8 tests in 0.089s
FAILED (failures=2)
```

Round trip through the REAL `createProxyServer` with the DEFAULT disk-writing `recordRejection`/`updateQuotaState` (only the upstream — a local server answering 429 with the exact production body — and the credential source injected), then the real probe reading the file it wrote:

```
1) /ok -> 200                                   # header write seeds the file
[Proxy] rejected HTTP 429 on /v1/messages: {"type":"error","error":{"type":"overage_error","message":"You're out of usage credits. Run /usage-credits to keep using Fable 5.1 or /model to switch models."}}
2) /v1/messages -> 429                          # forwarded unchanged
3) /ok -> 200                                   # header write must NOT clobber the ledger
available: true | unified-status: allowed | ledger entries: 1
ledger[0]: {"ts":"2026-09-03T08:05:51.040Z","status":429,"path":"/v1/messages","snippet":"…out of usage credits…"}

core-request-rejections warn
1 upstream rejection(s) in the last 15m (last: HTTP 429 0m ago — '…out of usage credits…'); the CLI drops the fire and prints the error in the core pane, so run /usage-credits (or /model to switch) there
passes _slack_failures: ['core-request-rejections']
control — core-quota still: ok | core quota not exhausted (status=allowed)
```

The last line is the blind spot this closes: on the same file the existing probe reads ok.

**Limit stated plainly:** a production overage rejection cannot be induced on demand, so the round trip above uses a local upstream. The proxy server, the disk writers, the file path resolution (`statusPath`) and the probe are the production code paths; only the upstream socket is substituted. Live proof will be the next real rejection episode with this build: expect a `[Proxy] rejected HTTP …` line in `logs/credential-proxy.log` and a `core-request-rejections` warn in the owner DM.

— sutando-qingyun-air (@qingyun-air.agent:ag2.space)
