### PR TITLE
feat(pool): the gateway client is a worker-aware queue client — worker id on the wire, cloud-worker mode, lease-safe redelivery

### DIFF
--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -202,6 +202,42 @@ handler must be before affinity yields — lower favors latency, higher favors
 conversational continuity; `continuity_breaks` in the pool metrics measures
 what that choice costs.
 
+### Cloud worker (#3794, slice 1 — client half)
+
+A cloud worker is the same gateway client (`packages/ag2-sparrow/ag2_sparrow/
+remote_gateway_bridge.py`) on another host, sharing the agent identity and
+speaking to the broker as one seat of it. Two env knobs, read at import like
+`REMOTE_TASK_URL`:
+
+- `SUTANDO_WORKER_ID` — the seat name on the wire (`home` by default;
+  `worker-<n>` is derived when only `SUTANDO_CORE_ID` is set, matching the
+  pool's own convention). Charset `[A-Za-z0-9_-]`, at most 32 characters.
+- `SUTANDO_WORKER_LOCATION` — `cloud` marks a cloud seat; anything else is
+  `local`.
+
+The seat rides every wire call: `worker=` on `GET /v1/tasks`, `worker_id` +
+`location` on `POST /v1/heartbeat` and on the `POST /v1/workers` snapshot push.
+A broker that predates seats ignores all three and serves the agent's queue
+exactly as before; a worker-aware broker (the ag2space-backend half of #3794)
+keys its queues and leases per seat and fails a lease over from a seat that
+stops beating.
+
+A cloud seat depends on nothing from this host: it pulls straight into its own
+`tasks/`, its seat answers into its own `results/`, and the client POSTs the
+result. `state/pool-status.json` and `state/cores/` are read only when they
+exist — no lead, no pool files, no affinity table are required on that host.
+`tests/gateway-worker-queue-client.test.py` runs that cycle against a stub
+broker with none of them present.
+
+Redelivery is at-least-once. The broker re-fronts a task whose lease expired,
+so a seat can receive an id it already holds. The client never queues it twice
+while the first copy is live (pending, `.assigned-*` or `.claimed-*` file) and
+re-acks it so the broker learns the seat still has it; an id already archived
+or delivered closes the lease with a `[no-send]` marker. What the client cannot
+prevent is a lease shorter than an honest task: the broker then hands the same
+id to another seat, which answers it too. Set the visibility timeout above the
+longest honest task.
+
 ### Turning on a Codex follower
 
 The runtime dimension (`--runtime` / `--core-runtime`) declares which CLI a core

--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -242,14 +242,15 @@ to another seat, and results dedupe by task id.
 
 The broker's pin route also enqueues a `worker-pin-<ms>-<hex>` compat task.
 The client consumes it as a control message — ack, then a `[no-send]` lease
-close, no task file — because `src/watch-tasks-stream.sh` only globs
-`task-*.txt` and a file under any other name would sit in flight until the
-lease expired. Log line: `archived worker-pin-… (marker no-send, lease closed,
-not sent)`.
+close, no task file — because `src/watch-tasks-stream.sh` globs `*.txt` under
+`tasks/`, so a pin written there would be dispatched as an ordinary task.
+Log line: `archived worker-pin-… (marker no-send, lease closed, not sent)`.
 
-Every result POST names the seat that produced it — `metadata.worker_id` +
-`metadata.location`. On a pool host the worker id is the done-flag owner
-(`state/cores/<worker>/done/<task>.flag`, the pool worker that answered a task
+A result POST names the seat that produced it — `metadata.worker_id` +
+`metadata.location` — only while the broker advertises the `worker-metadata`
+capability; control closes carry neither. On a pool host the worker id is the
+done-flag owner (`state/cores/<worker>/done/<task>.flag`, the worker that
+answered a task
 the lead routed); a cloud seat has no done-flag, so its own `SUTANDO_WORKER_ID`
 is the attribution of last resort (`cloud-1` / `cloud`, never an empty payload).
 

--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -240,6 +240,13 @@ id to another seat, which answers it too. Set `RELAY_VISIBILITY_TIMEOUT`
 consequence in one sentence: a task on a worker that dies mid-run is re-served
 to another seat, and results dedupe by task id.
 
+The broker's pin route also enqueues a `worker-pin-<ms>-<hex>` compat task.
+The client consumes it as a control message — ack, then a `[no-send]` lease
+close, no task file — because `src/watch-tasks-stream.sh` only globs
+`task-*.txt` and a file under any other name would sit in flight until the
+lease expired. Log line: `archived worker-pin-… (marker no-send, lease closed,
+not sent)`.
+
 Every result POST names the seat that produced it — `metadata.worker_id` +
 `metadata.location`. On a pool host the worker id is the done-flag owner
 (`state/cores/<worker>/done/<task>.flag`, the pool worker that answered a task

--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -215,10 +215,11 @@ speaking to the broker as one seat of it. Two env knobs, read at import like
 - `SUTANDO_WORKER_LOCATION` — `cloud` marks a cloud seat; anything else is
   `local`.
 
-The seat rides every wire call: `worker=` on `GET /v1/tasks`, `worker_id` +
-`location` on `POST /v1/heartbeat` and on the `POST /v1/workers` snapshot push.
-A broker that predates seats ignores all three and serves the agent's queue
-exactly as before; a worker-aware broker (the ag2space-backend half of #3794)
+The seat rides those three calls — `worker=` on `GET /v1/tasks`, `worker_id` +
+`location` on `POST /v1/heartbeat` and on the `POST /v1/workers` snapshot push —
+**only after the broker advertises `worker-routing`**. Until then each request is
+byte-for-byte the legacy shape, so a broker that predates seats keeps serving
+whether it ignores unknown fields or rejects them; a worker-aware broker (the ag2space-backend half of #3794)
 keys its queues and leases per seat and fails a lease over from a seat that
 stops beating.
 

--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -235,8 +235,16 @@ while the first copy is live (pending, `.assigned-*` or `.claimed-*` file) and
 re-acks it so the broker learns the seat still has it; an id already archived
 or delivered closes the lease with a `[no-send]` marker. What the client cannot
 prevent is a lease shorter than an honest task: the broker then hands the same
-id to another seat, which answers it too. Set the visibility timeout above the
-longest honest task.
+id to another seat, which answers it too. Set `RELAY_VISIBILITY_TIMEOUT`
+(seconds) on the broker above the longest honest task. The at-least-once
+consequence in one sentence: a task on a worker that dies mid-run is re-served
+to another seat, and results dedupe by task id.
+
+Every result POST names the seat that produced it — `metadata.worker_id` +
+`metadata.location`. On a pool host the worker id is the done-flag owner
+(`state/cores/<worker>/done/<task>.flag`, the pool worker that answered a task
+the lead routed); a cloud seat has no done-flag, so its own `SUTANDO_WORKER_ID`
+is the attribution of last resort (`cloud-1` / `cloud`, never an empty payload).
 
 ### Turning on a Codex follower
 

--- a/docs/remote-gateway-protocol.md
+++ b/docs/remote-gateway-protocol.md
@@ -67,6 +67,28 @@ A task object **must** carry a unique `"id"`. Recognized string fields
 and written into the local task file the core consumes. For AG2 Space, the
 broker also supplies its room-policy `access_tier` attestation.
 
+#### Worker pins are control messages, and `source` is what says so
+
+A broker may send a **worker pin** — a control message that binds a room to a
+worker rather than work to be executed. The bridge consumes a pin as control
+**only** when the task carries the broker's authoritative stamp
+`"source": "worker-picker"`. That stamp is the sole discriminator.
+
+The pin's `id` shape (`worker-pin-<digits>-<hex>`) is **not** a discriminator
+and must never be used as one. A task object is only required to carry a
+unique `id`, and `source` is optional, so an ordinary task is free to arrive
+with an id of any shape and no `source` at all. A classifier keyed on the id
+would consume such a task as control: journal it, ACK it — which stops
+redelivery — and close its lease with `[no-send]`, destroying owner work
+silently.
+
+**Compatibility:** a pin-shaped id arriving *without* the stamp is written as
+an ordinary task. That is the fail-safe direction — a pin mistaken for work is
+visible and recoverable, whereas work mistaken for a pin is destroyed. A bridge
+must not fall back to id-only consumption for older brokers, and must not gate
+on process-local state such as "a stamped pin was seen earlier": that resets on
+restart, so the destructive path re-arms on every start.
+
 An AG2 Space broker may additionally send `"session_scope": "room"`. The
 bridge writes only that exact value as a trusted pre-body header; missing,
 unknown, or malformed values are omitted, preserving the main-session path for

--- a/docs/remote-gateway-protocol.md
+++ b/docs/remote-gateway-protocol.md
@@ -124,6 +124,31 @@ reply: { "capabilities": ["worker-metadata"] }
 `worker-metadata` tells the client the broker accepts the optional `metadata`
 key on `POST /v1/results`. Brokers that omit it receive the documented envelope.
 
+`worker-routing` is a **separate** capability and is not implied by
+`worker-metadata`: a broker may accept result attribution without wanting to be
+routed to. It tells the client the broker accepts seat identity on three request
+bodies — `worker=` on `GET /v1/tasks`, and `worker_id` + `location` on both
+`POST /v1/heartbeat` and `POST /v1/workers`.
+
+Enable/revoke is a state machine driven entirely by the heartbeat, because the
+heartbeat reply is the only capability channel:
+
+| event | state |
+|---|---|
+| reply advertises `worker-routing` | enabled from the NEXT request onward |
+| reply omits it | revoked |
+| heartbeat 404/405 (no endpoint) | revoked, and the heartbeat is disabled |
+| other non-auth HTTP error | revoked |
+| network error / timeout | revoked |
+| malformed 200 (undecodable JSON) | revoked |
+| truncated 200 (`IncompleteRead`) | revoked |
+| 401/403 | raises; not a capability signal |
+
+Absence of a reply is absence of evidence, so every non-advertising outcome
+revokes. The asymmetry is deliberate: dropping the keys cannot lose a result,
+whereas keeping them against a strict broker can. The advertising heartbeat is
+itself legacy-shaped — identity rides only the requests that follow it.
+
 `team-collaborator` tells the AG2 Space control plane that this gateway
 understands the per-agent Collaborator control layered over Team. Gateways
 without it safely keep Team on their prior restricted path.

--- a/docs/remote-gateway-protocol.md
+++ b/docs/remote-gateway-protocol.md
@@ -94,6 +94,12 @@ Return a task's result.
 body: { "id": "task-123", "body": "<result text>" }
 ```
 
+`metadata` (`worker_id`, `location`) is an OPTIONAL extension to this envelope.
+The client sends it only after the broker advertises `worker-metadata` in its
+heartbeat reply, so a relay that rejects unknown keys keeps receiving exactly
+`{id, body}`. Result attribution is therefore absent, not lost, against a broker
+that does not advertise it.
+
 ### `POST /v1/heartbeat`
 
 Periodic liveness + capability ping.
@@ -108,6 +114,15 @@ body: {
   "capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"]
 }
 ```
+
+The reply may advertise the broker's own capabilities:
+
+```
+reply: { "capabilities": ["worker-metadata"] }
+```
+
+`worker-metadata` tells the client the broker accepts the optional `metadata`
+key on `POST /v1/results`. Brokers that omit it receive the documented envelope.
 
 `team-collaborator` tells the AG2 Space control plane that this gateway
 understands the per-agent Collaborator control layered over Team. Gateways

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -260,3 +260,11 @@ class DeliveryProvider(Protocol):
         cannot answer (capability-gated). The attempt carries the payload so
         a keyed-dedup provider may reconcile by safe re-send."""
         ...
+
+
+def is_declined_envelope(resp) -> bool:
+    """A 2xx whose body explicitly declines. Transports must not treat such a
+    reply as acceptance: the request was received and refused, not applied."""
+    if not isinstance(resp, dict):
+        return False
+    return bool(resp.get("ok") is False or resp.get("error") or resp.get("errcode"))

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/provider_ag2space.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/provider_ag2space.py
@@ -22,6 +22,7 @@ import urllib.error
 from typing import Callable, Optional
 
 from .contract import (DeliveryAttempt, DeliveryOutcome, DeliveryReceipt,
+                       is_declined_envelope,
                        ProviderCapabilities, ProviderIndeterminate,
                        ProviderRefused)
 
@@ -64,7 +65,7 @@ class AG2SpaceResultProvider:
                 f"transport failure for {item_id}: {e}") from e
         # 2xx IS confirmation here (recorded + lease-closed; see class doc);
         # only an explicit decline envelope on a 2xx maps to refusal.
-        if resp.get("ok") is False or resp.get("error") or resp.get("errcode"):
+        if is_declined_envelope(resp):
             raise ProviderRefused(f"gateway declined {item_id}: {str(resp)[:200]}")
         return DeliveryReceipt(
             outcome=DeliveryOutcome.CONFIRMED,

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -47,7 +47,15 @@ Locally a re-delivered id is never queued twice while the first copy is live
 delivered → `[no-send]` lease close), and the result sink dedupes on the task
 id. What this client cannot prevent: a lease shorter than the seat's honest
 task time hands the SAME id to another seat, which then answers it too — set
-the broker's visibility timeout above the longest honest task.
+RELAY_VISIBILITY_TIMEOUT (seconds, on the BROKER) above the longest honest
+task. The consequence is at-least-once: a task on a seat that dies mid-run is
+re-served to another seat, and the result sink dedupes by task id.
+
+Result attribution: every result POST carries `metadata.worker_id` and
+`metadata.location`. The worker id is the pool done-flag owner
+(`state/cores/<worker>/done/<task>.flag`) when exactly one exists — a pool
+worker answering a task its lead routed — else this seat's own WORKER_ID: a
+cloud seat has no done-flag, and its result is still its own.
 
 Config (env / .env):
   REMOTE_TASK_TOKEN      the onboarding string — the ONLY required setting
@@ -3376,9 +3384,9 @@ def _deliver_result_payload(tid: str, broker_tid: str, body: str,
         doc["no_send"] = True
     # Structured attribution, not the "— core-N" prose in the body: the
     # signature is for humans and reformatting it must not change routing.
-    worker = _worker_of(tid)
-    if worker:
-        doc["metadata"] = {"worker_id": worker}
+    # Pool done-flag owner first; else this seat answered it (cloud, home).
+    doc["metadata"] = {"worker_id": _worker_of(tid) or WORKER_ID,
+                       "location": WORKER_LOCATION}
     payload = json.dumps(doc).encode("utf-8")
     core.backend.publish(broker_tid, payload)   # False = already live: retry pass
     res = core.deliver_one(broker_tid, payload)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -14,15 +14,16 @@ Full spec: docs/remote-gateway-protocol.md
   Protocol (versioned, Bearer-auth):
   GET  {REMOTE_TASK_URL}/v1/tasks?wait=<sec>&worker=<worker-id>
        → 200 {"tasks": [ {<task fields...>}, ... ]}   (long-poll; [] on timeout)
-       `worker` names the pulling seat; a broker that ignores it serves the
-       agent's queue exactly as before (one queue per agent identity).
+       `worker` names the pulling seat and rides ONLY after the broker
+       advertises `worker-routing`; absent that, the poll is byte-for-byte
+       legacy, so a broker that rejects unknown query keys still serves.
   POST {REMOTE_TASK_URL}/v1/tasks/<task-id>/ack
        → body {"id": "<task-id>"}  → 200 on accepted
   POST {REMOTE_TASK_URL}/v1/results
        → body {"id": "<task-id>", "body": "<result text>"}  → 200 on accepted
   POST {REMOTE_TASK_URL}/v1/heartbeat
-       → body {"client": "...", "inflight": N, "worker_id": "...",
-               "location": "local|cloud", ...}  → 200 on accepted
+       → body {"client": "...", "inflight": N, ...}  → 200 on accepted
+         (`worker_id`/`location` are added only under `worker-routing`)
 
 Each task object uses the same schema Sutando's other bridges write, so this
 client just serializes it to `tasks/task-<id>.txt` and the core handles it like
@@ -33,9 +34,10 @@ original pull/result protocol.
 
 Worker seats (issue: cloud workers sharing the agent identity). Every client is
 a queue client for ONE seat of the agent: the home seat (`home`), a pool seat
-(`worker-N`) or a cloud seat. The seat rides every wire call (`worker=` on the
-pull, `worker_id`/`location` on heartbeat and the workers-snapshot push) so a
-worker-aware broker can dispatch per seat and fail a lease over from a seat
+(`worker-N`) or a cloud seat. The seat rides the wire ONLY once the broker advertises `worker-routing`
+(`worker=` on the pull, `worker_id`/`location` on heartbeat and the
+workers-snapshot push); until then every request is legacy-shaped. A
+worker-aware broker can then dispatch per seat and fail a lease over from a seat
 that stops beating. A cloud seat runs this same client with its own workspace:
 the pull → `tasks/` → `results/` → POST cycle needs nothing from another host —
 `state/pool-status.json` and `state/cores/` are read only when present.

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1082,6 +1082,13 @@ def _retry_review_card_resolutions() -> None:
             _log(f"withheld review {record.get('review_id')} card edit retry failed: {exc}")
 
 
+def _declined_envelope(resp) -> bool:
+    """Delegate to delivery_core's owner of this policy; a local copy would
+    drift from the provider that already classifies these envelopes."""
+    from .delivery_core.contract import is_declined_envelope
+    return is_declined_envelope(resp)
+
+
 def _control_result_path(task_id: str) -> Path:
     safe = re.sub(r"[^A-Za-z0-9_.-]", "_", task_id)[:160]
     return _WITHHELD_CONTROL_DIR / f"{safe}.json"
@@ -1106,8 +1113,14 @@ def _retry_review_control_results() -> None:
         if not record or not record.get("id"):
             continue
         try:
-            _req("POST", "/v1/results", {
+            resp = _req("POST", "/v1/results", {
                 "id": record["id"], "body": record.get("body") or "[no-send]"})
+            # A declining 2xx did NOT close the lease; dropping the journal here
+            # would strand it with nothing left on disk to retry.
+            if _declined_envelope(resp):
+                _log(f"review control result {record['id']} declined — journal kept:"
+                     f" {str(resp)[:120]}")
+                continue
             path.unlink(missing_ok=True)
         except Exception as exc:  # noqa: BLE001 — next poll retries
             _log(f"review control result {record.get('id')} retry deferred: {exc}")
@@ -2405,6 +2418,12 @@ def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
     except (urllib.error.URLError, TimeoutError) as e:
         _revoke_broker_capabilities()
         _log(f"heartbeat network error: {e} — continuing")
+        return False
+    except ValueError as e:
+        # A malformed 200 raises inside _req's json.loads, so the reply never
+        # reaches _note_broker_capabilities and advertises nothing.
+        _revoke_broker_capabilities()
+        _log(f"heartbeat reply undecodable: {e} — continuing")
         return False
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -53,11 +53,12 @@ re-served to another seat, and the result sink dedupes by task id.
 
 Control messages: the broker's pin route also enqueues a `worker-pin-<ms>-<hex>`
 compat task. It is consumed in-client (ack, `[no-send]` lease close) and never
-written to `tasks/` — the watcher globs `task-*.txt`, so a file under any other
-name would sit in flight until the lease expired.
+written to `tasks/` — the watcher globs `*.txt` there, so a pin written under
+any name would be dispatched as an ordinary task.
 
-Result attribution: every result POST carries `metadata.worker_id` and
-`metadata.location`. The worker id is the pool done-flag owner
+Result attribution: a result POST carries `metadata.worker_id` and
+`metadata.location` only while the broker advertises `worker-metadata`;
+control closes carry neither. The worker id is the pool done-flag owner
 (`state/cores/<worker>/done/<task>.flag`) when exactly one exists — a pool
 worker answering a task its lead routed — else this seat's own WORKER_ID: a
 cloud seat has no done-flag, and its result is still its own.

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1114,18 +1114,24 @@ def _retry_review_control_results() -> None:
 
 
 _WORKER_PIN_PREFIX = "worker-pin-"
+# Full documented grammar. A prefix test alone classifies ordinary work
+# (e.g. worker-pin-user-message) as control and silently closes it.
+_WORKER_PIN_RE = re.compile(r"worker-pin-[0-9]+-[0-9a-fA-F]+\Z")
 
 
 def _consume_worker_pin(task: dict) -> bool:
     """The broker's pin route enqueues a `worker-pin-<ms>-<hex>` compat task: a
     control message for this seat, never user work. It writes no task file
-    (the watcher only sees task-*.txt, so one would sit in flight until the
-    lease expired); it is acked and its lease closed [no-send]. False = not a pin."""
+    (the watcher globs *.txt, so one would sit in flight until the lease
+    expired); it is acked and its lease closed [no-send]. False = not a pin."""
     tid = str(task.get("id") or "").strip()
-    if not tid.startswith(_WORKER_PIN_PREFIX) or not _valid_tid(tid):
+    if not _WORKER_PIN_RE.fullmatch(tid) or not _valid_tid(tid):
         return False
+    # ACK, journal path, payload and status check must see ONE id, or a
+    # deferred close reports itself archived under a path nothing wrote.
+    pinned = dict(task, id=tid)
     _post_task_ack(_local_tid(tid))
-    _queue_review_control_result(task)
+    _queue_review_control_result(pinned)
     _retry_review_control_results()
     if _control_result_path(tid).is_file():
         _log(f"worker-pin {tid}: lease close deferred — next poll retries")

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -90,6 +90,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import http.client
 import json
 import os
 import uuid
@@ -2297,8 +2298,10 @@ def _maybe_push_workers_snapshot() -> bool:
         return False  # mid-write or malformed: the next change retries
     if not isinstance(snap, dict):
         return False
-    # The pushing seat is authoritative about itself; the lead's file is not.
-    snap = {**snap, "worker_id": WORKER_ID, "location": WORKER_LOCATION}
+    # Third request body carrying seat identity; gated like heartbeat and poll
+    # so a broker that never advertises sees the exact parent envelope.
+    if _broker_worker_routing:
+        snap = {**snap, "worker_id": WORKER_ID, "location": WORKER_LOCATION}
     try:
         _req("POST", "/v1/workers", snap, timeout=15)
     except urllib.error.HTTPError as e:
@@ -2436,7 +2439,9 @@ def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
         _revoke_broker_capabilities()
         _log(f"heartbeat failed: HTTP {e.code} — continuing")
         return False
-    except (urllib.error.URLError, TimeoutError) as e:
+    except (urllib.error.URLError, TimeoutError, http.client.HTTPException) as e:
+        # IncompleteRead subclasses HTTPException and escapes during resp.read(),
+        # so a truncated 200 carries no advertisement and must revoke like a 404.
         _revoke_broker_capabilities()
         _log(f"heartbeat network error: {e} — continuing")
         return False

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -385,10 +385,12 @@ if GATEWAY_INSTANCE and not _INSTANCE_RE.fullmatch(GATEWAY_INSTANCE):
     sys.exit("FATAL: GATEWAY_INSTANCE must match "
              f"{_INSTANCE_RE.pattern} (ASCII only; got {GATEWAY_INSTANCE!r})")
 _INST_SUFFIX = f".{GATEWAY_INSTANCE}" if GATEWAY_INSTANCE else ""
-# Per-instance, like every other mutable state path here: two gateways sharing
-# one workspace must not drain or delete each other's deferred control records.
-_WITHHELD_DM_CACHE = _STATE / f"withheld-review-dm{_INST_SUFFIX}.json"
+# The JOURNAL is instance-owned, so it is namespaced: two gateways sharing one
+# workspace must not drain or delete each other's deferred control records.
 _WITHHELD_CONTROL_DIR = _STATE / f"withheld-review-control-results{_INST_SUFFIX}"
+# The review DM is OWNER-owned, not instance-owned, and is already keyed by
+# owner on read; namespacing it would create one duplicate room per instance.
+_WITHHELD_DM_CACHE = _STATE / "withheld-review-dm.json"
 _WITHHELD_CONTROL_DIR_LEGACY = _STATE / "withheld-review-control-results"
 # Optional fence for instanced lanes: claim only rooms on this suffix
 GATEWAY_ROOM_SUFFIX = (os.environ.get("GATEWAY_ROOM_SUFFIX") or "").strip()

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -360,8 +360,6 @@ GATEWAY_REDELIVERY_RESULT = "[no-send] gateway redelivery of already-handled tas
 RESULTS_DIR = _result_dir()
 _STATE = _state_dir()
 _WITHHELD_TASK_OUTPUT: "dict[str, tuple]" = {}
-_WITHHELD_DM_CACHE = _STATE / "withheld-review-dm.json"
-_WITHHELD_CONTROL_DIR = _STATE / "withheld-review-control-results"
 _GATEWAY_OWNER_DM_HINT = ""
 ARCHIVE_RESULTS_DIR = RESULTS_DIR / "archive"
 # Transient-failure count per polled `.txt` name; _resolve_send_failure bounds
@@ -387,6 +385,11 @@ if GATEWAY_INSTANCE and not _INSTANCE_RE.fullmatch(GATEWAY_INSTANCE):
     sys.exit("FATAL: GATEWAY_INSTANCE must match "
              f"{_INSTANCE_RE.pattern} (ASCII only; got {GATEWAY_INSTANCE!r})")
 _INST_SUFFIX = f".{GATEWAY_INSTANCE}" if GATEWAY_INSTANCE else ""
+# Per-instance, like every other mutable state path here: two gateways sharing
+# one workspace must not drain or delete each other's deferred control records.
+_WITHHELD_DM_CACHE = _STATE / f"withheld-review-dm{_INST_SUFFIX}.json"
+_WITHHELD_CONTROL_DIR = _STATE / f"withheld-review-control-results{_INST_SUFFIX}"
+_WITHHELD_CONTROL_DIR_LEGACY = _STATE / "withheld-review-control-results"
 # Optional fence for instanced lanes: claim only rooms on this suffix
 GATEWAY_ROOM_SUFFIX = (os.environ.get("GATEWAY_ROOM_SUFFIX") or "").strip()
 # Rooms on these suffixes belong to a foreign lane; the default lane's gateway
@@ -1107,7 +1110,27 @@ def _queue_review_control_result(task: dict, body: str = "[no-send]") -> None:
         _atomic_private_json(path, {"id": task_id, "body": body})
 
 
+_LEGACY_CONTROL_WARNED = False
+
+
+def _warn_legacy_control_records() -> int:
+    """Count unsuffixed leftovers once. Never adopt them: with two instances
+    live, whoever starts first would claim records owned by the other."""
+    global _LEGACY_CONTROL_WARNED
+    try:
+        stale = sorted(_WITHHELD_CONTROL_DIR_LEGACY.glob("*.json"))
+    except OSError:
+        return 0
+    if stale and not _LEGACY_CONTROL_WARNED:
+        _LEGACY_CONTROL_WARNED = True
+        _log(f"{len(stale)} control record(s) under the pre-instance path "
+             f"{_WITHHELD_CONTROL_DIR_LEGACY}; not adopted (ownership unknown) — "
+             "move them into the owning instance's directory by hand")
+    return len(stale)
+
+
 def _retry_review_control_results() -> None:
+    _warn_legacy_control_records()
     try:
         paths = sorted(_WITHHELD_CONTROL_DIR.glob("*.json"))[:512]
     except OSError:

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -51,6 +51,11 @@ RELAY_VISIBILITY_TIMEOUT (seconds, on the BROKER) above the longest honest
 task. The consequence is at-least-once: a task on a seat that dies mid-run is
 re-served to another seat, and the result sink dedupes by task id.
 
+Control messages: the broker's pin route also enqueues a `worker-pin-<ms>-<hex>`
+compat task. It is consumed in-client (ack, `[no-send]` lease close) and never
+written to `tasks/` — the watcher globs `task-*.txt`, so a file under any other
+name would sit in flight until the lease expired.
+
 Result attribution: every result POST carries `metadata.worker_id` and
 `metadata.location`. The worker id is the pool done-flag owner
 (`state/cores/<worker>/done/<task>.flag`) when exactly one exists — a pool
@@ -1106,6 +1111,27 @@ def _retry_review_control_results() -> None:
             path.unlink(missing_ok=True)
         except Exception as exc:  # noqa: BLE001 — next poll retries
             _log(f"review control result {record.get('id')} retry deferred: {exc}")
+
+
+_WORKER_PIN_PREFIX = "worker-pin-"
+
+
+def _consume_worker_pin(task: dict) -> bool:
+    """The broker's pin route enqueues a `worker-pin-<ms>-<hex>` compat task: a
+    control message for this seat, never user work. It writes no task file
+    (the watcher only sees task-*.txt, so one would sit in flight until the
+    lease expired); it is acked and its lease closed [no-send]. False = not a pin."""
+    tid = str(task.get("id") or "").strip()
+    if not tid.startswith(_WORKER_PIN_PREFIX) or not _valid_tid(tid):
+        return False
+    _post_task_ack(_local_tid(tid))
+    _queue_review_control_result(task)
+    _retry_review_control_results()
+    if _control_result_path(tid).is_file():
+        _log(f"worker-pin {tid}: lease close deferred — next poll retries")
+    else:
+        _log(f"archived {tid} (marker no-send, lease closed, not sent)")
+    return True
 
 
 def _is_redelivery_control(body: str) -> bool:
@@ -3980,6 +4006,8 @@ def main() -> None:
             added = False
             pending_ack = []
             for task in resp.get("tasks", []):
+                if _consume_worker_pin(task):
+                    continue
                 hitl_out = _handle_hitl_action(task)
                 if hitl_out:
                     body = "[no-send]"

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2323,6 +2323,7 @@ def _read_core_status() -> tuple[str | None, str | None]:
 
 _WORKERS_SNAPSHOT_FILE = _STATE / "pool-status.json"
 _workers_push_mtime = 0.0
+_workers_push_routing = False
 _workers_push_retry_at = 0.0
 
 
@@ -2331,7 +2332,7 @@ def _maybe_push_workers_snapshot() -> bool:
     picker's read path). No file = no pool = no-op; a broker without the
     endpoint (404) backs the push off an hour; nothing here may ever
     break the task loop."""
-    global _workers_push_mtime, _workers_push_retry_at
+    global _workers_push_mtime, _workers_push_routing, _workers_push_retry_at
     now = time.time()
     if now < _workers_push_retry_at:
         return False
@@ -2339,7 +2340,10 @@ def _maybe_push_workers_snapshot() -> bool:
         mtime = _WORKERS_SNAPSHOT_FILE.stat().st_mtime
     except OSError:
         return False
-    if mtime <= _workers_push_mtime:
+    # Half this payload's shape is the capability, so the already-sent key has
+    # to carry it too: the same file under a new routing mode is a new snapshot.
+    routing = bool(_broker_worker_routing)
+    if mtime <= _workers_push_mtime and routing == _workers_push_routing:
         return False
     try:
         snap = json.loads(_WORKERS_SNAPSHOT_FILE.read_text())
@@ -2349,7 +2353,7 @@ def _maybe_push_workers_snapshot() -> bool:
         return False
     # Third request body carrying seat identity; gated like heartbeat and poll
     # so a broker that never advertises sees the exact parent envelope.
-    if _broker_worker_routing:
+    if routing:
         snap = {**snap, "worker_id": WORKER_ID, "location": WORKER_LOCATION}
     try:
         _req("POST", "/v1/workers", snap, timeout=15)
@@ -2363,6 +2367,7 @@ def _maybe_push_workers_snapshot() -> bool:
         _log(f"workers-snapshot push failed, retrying in 5m: {e}")
         return False
     _workers_push_mtime = mtime
+    _workers_push_routing = routing
     _log("workers-snapshot pushed")
     return True
 
@@ -2420,10 +2425,16 @@ def _note_broker_capabilities(reply) -> None:
     """Re-read the broker's advertised capabilities from each heartbeat reply.
     Recomputed (not latched) so a downgraded broker turns the extension back off."""
     global _broker_worker_metadata, _broker_worker_routing, _routing_downgrade_logged
+    global _workers_push_retry_at
     caps = reply.get("capabilities") if isinstance(reply, dict) else None
     known = caps if isinstance(caps, list) else []
+    was_routing = _broker_worker_routing
     _broker_worker_metadata = "worker-metadata" in known
     _broker_worker_routing = "worker-routing" in known
+    if _broker_worker_routing and not was_routing:
+        # An endpoint backoff is evidence about the broker we polled BEFORE it
+        # advertised routing; a new advertisement makes that evidence stale.
+        _workers_push_retry_at = 0.0
     if not _broker_worker_routing and not _routing_downgrade_logged:
         # One line per process: silence makes a safe downgrade undiagnosable,
         # a per-heartbeat line would be noise.

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1167,7 +1167,6 @@ _WORKER_PIN_RE = re.compile(r"worker-pin-[0-9]+-[0-9a-fA-F]+\Z")
 _WORKER_PIN_SOURCE = "worker-picker"
 _pin_source_downgrade_logged = False
 # Latched once a broker-stamped pin arrives: after that, id-only is not control.
-_pin_stamp_seen = False
 
 
 def _consume_worker_pin(task: dict) -> bool:
@@ -1175,7 +1174,7 @@ def _consume_worker_pin(task: dict) -> bool:
     control message for this seat, never user work. It writes no task file
     (the watcher globs *.txt, so one would sit in flight until the lease
     expired); it is acked and its lease closed [no-send]. False = not a pin."""
-    global _pin_source_downgrade_logged, _pin_stamp_seen
+    global _pin_source_downgrade_logged
     tid = str(task.get("id") or "").strip()
     if not _WORKER_PIN_RE.fullmatch(tid) or not _valid_tid(tid):
         return False
@@ -1185,16 +1184,13 @@ def _consume_worker_pin(task: dict) -> bool:
     if src and src != _WORKER_PIN_SOURCE:
         return False
     if not src:
-        # Bounded for real: one stamped pin proves the broker speaks source, so
-        # the id-only path retires for the process rather than only going quiet.
-        if _pin_stamp_seen:
-            return False
+        # The stamp is the ONLY discriminator. A process-memory latch is not a bound:
+        # it resets on restart, and an unstamped ordinary task is then destroyed again.
         if not _pin_source_downgrade_logged:
             _pin_source_downgrade_logged = True
-            _log("broker sent a worker-pin with no source stamp; using id grammar "
-                 "alone until the first stamped pin retires this fallback")
-    else:
-        _pin_stamp_seen = True
+            _log("broker sent a worker-pin with no source stamp; not consuming it as "
+                 "control — it will be written as an ordinary task")
+        return False
     # ACK, journal path, payload and status check must see ONE id, or a
     # deferred close reports itself archived under a path nothing wrote.
     pinned = dict(task, id=tid)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -385,9 +385,9 @@ if GATEWAY_INSTANCE and not _INSTANCE_RE.fullmatch(GATEWAY_INSTANCE):
     sys.exit("FATAL: GATEWAY_INSTANCE must match "
              f"{_INSTANCE_RE.pattern} (ASCII only; got {GATEWAY_INSTANCE!r})")
 _INST_SUFFIX = f".{GATEWAY_INSTANCE}" if GATEWAY_INSTANCE else ""
-# The JOURNAL is instance-owned, so EVERY lane gets an owned directory -- the
-# default one included, or its path collapses onto the legacy path below.
-_CONTROL_OWNER = GATEWAY_INSTANCE or "default"
+# Injective: a named lane always carries the `named.` infix and _INSTANCE_RE
+# forbids dots, so no instance name can spell the unnamed lane's directory.
+_CONTROL_OWNER = f"named.{GATEWAY_INSTANCE}" if GATEWAY_INSTANCE else "primary"
 _WITHHELD_CONTROL_DIR = _STATE / f"withheld-review-control-results.{_CONTROL_OWNER}"
 # The review DM is OWNER-owned, not instance-owned, and is already keyed by
 # owner on read; namespacing it would create one duplicate room per instance.
@@ -1166,6 +1166,8 @@ _WORKER_PIN_RE = re.compile(r"worker-pin-[0-9]+-[0-9a-fA-F]+\Z")
 # user-forgeable, this source stamp is written by the broker.
 _WORKER_PIN_SOURCE = "worker-picker"
 _pin_source_downgrade_logged = False
+# Latched once a broker-stamped pin arrives: after that, id-only is not control.
+_pin_stamp_seen = False
 
 
 def _consume_worker_pin(task: dict) -> bool:
@@ -1173,7 +1175,7 @@ def _consume_worker_pin(task: dict) -> bool:
     control message for this seat, never user work. It writes no task file
     (the watcher globs *.txt, so one would sit in flight until the lease
     expired); it is acked and its lease closed [no-send]. False = not a pin."""
-    global _pin_source_downgrade_logged
+    global _pin_source_downgrade_logged, _pin_stamp_seen
     tid = str(task.get("id") or "").strip()
     if not _WORKER_PIN_RE.fullmatch(tid) or not _valid_tid(tid):
         return False
@@ -1182,12 +1184,17 @@ def _consume_worker_pin(task: dict) -> bool:
     src = str(task.get("source") or "").strip()
     if src and src != _WORKER_PIN_SOURCE:
         return False
-    if not src and not _pin_source_downgrade_logged:
-        # Bounded compat: a broker predating the stamp leaves only the id.
-        # One line per process — the residual window must stay diagnosable.
-        _pin_source_downgrade_logged = True
-        _log("broker sent a worker-pin with no source stamp; "
-             "falling back to id grammar alone for control classification")
+    if not src:
+        # Bounded for real: one stamped pin proves the broker speaks source, so
+        # the id-only path retires for the process rather than only going quiet.
+        if _pin_stamp_seen:
+            return False
+        if not _pin_source_downgrade_logged:
+            _pin_source_downgrade_logged = True
+            _log("broker sent a worker-pin with no source stamp; using id grammar "
+                 "alone until the first stamped pin retires this fallback")
+    else:
+        _pin_stamp_seen = True
     # ACK, journal path, payload and status check must see ONE id, or a
     # deferred close reports itself archived under a path nothing wrote.
     pinned = dict(task, id=tid)
@@ -2485,9 +2492,9 @@ def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
         _revoke_broker_capabilities()
         _log(f"heartbeat failed: HTTP {e.code} — continuing")
         return False
-    except (urllib.error.URLError, TimeoutError, http.client.HTTPException) as e:
-        # IncompleteRead subclasses HTTPException and escapes during resp.read(),
-        # so a truncated 200 carries no advertisement and must revoke like a 404.
+    except (OSError, TimeoutError, http.client.HTTPException) as e:
+        # OSError covers URLError AND a bare ConnectionResetError from resp.read():
+        # any reply we could not read carries no advertisement, so it must revoke.
         _revoke_broker_capabilities()
         _log(f"heartbeat network error: {e} — continuing")
         return False

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1130,8 +1130,10 @@ def _consume_worker_pin(task: dict) -> bool:
     # ACK, journal path, payload and status check must see ONE id, or a
     # deferred close reports itself archived under a path nothing wrote.
     pinned = dict(task, id=tid)
-    _post_task_ack(_local_tid(tid))
+    # Durable close intent BEFORE the ack: an ack stops redelivery, so a crash
+    # between them strands a lease with nothing left on disk to close it.
     _queue_review_control_result(pinned)
+    _post_task_ack(_local_tid(tid))
     _retry_review_control_results()
     if _control_result_path(tid).is_file():
         _log(f"worker-pin {tid}: lease close deferred — next poll retries")

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1159,6 +1159,10 @@ _WORKER_PIN_PREFIX = "worker-pin-"
 # Full documented grammar. A prefix test alone classifies ordinary work
 # (e.g. worker-pin-user-message) as control and silently closes it.
 _WORKER_PIN_RE = re.compile(r"worker-pin-[0-9]+-[0-9a-fA-F]+\Z")
+# The broker, not the id shape, authorises closing a task unread: an id is
+# user-forgeable, this source stamp is written by the broker.
+_WORKER_PIN_SOURCE = "worker-picker"
+_pin_source_downgrade_logged = False
 
 
 def _consume_worker_pin(task: dict) -> bool:
@@ -1166,9 +1170,21 @@ def _consume_worker_pin(task: dict) -> bool:
     control message for this seat, never user work. It writes no task file
     (the watcher globs *.txt, so one would sit in flight until the lease
     expired); it is acked and its lease closed [no-send]. False = not a pin."""
+    global _pin_source_downgrade_logged
     tid = str(task.get("id") or "").strip()
     if not _WORKER_PIN_RE.fullmatch(tid) or not _valid_tid(tid):
         return False
+    # On id alone an ordinary task matching the grammar is closed [no-send]
+    # before reaching the task writer, losing the user's work silently.
+    src = str(task.get("source") or "").strip()
+    if src and src != _WORKER_PIN_SOURCE:
+        return False
+    if not src and not _pin_source_downgrade_logged:
+        # Bounded compat: a broker predating the stamp leaves only the id.
+        # One line per process — the residual window must stay diagnosable.
+        _pin_source_downgrade_logged = True
+        _log("broker sent a worker-pin with no source stamp; "
+             "falling back to id grammar alone for control classification")
     # ACK, journal path, payload and status check must see ONE id, or a
     # deferred close reports itself archived under a path nothing wrote.
     pinned = dict(task, id=tid)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1579,6 +1579,10 @@ _last_heartbeat_at = 0.0
 # Result `metadata` is an EXTENSION to the documented {id, body} envelope, so it
 # ships only once the broker advertises it; a strict relay 422s unknown keys.
 _broker_worker_metadata = False
+# A SEPARATE wire contract from result attribution: coupling them would let a
+# broker opt into routing merely by accepting result metadata.
+_broker_worker_routing = False
+_routing_downgrade_logged = False
 
 _TASK_FIELDS = ("id", "timestamp", "session_scope",
                 # Routing keys the pool lead reads with a strict task-last
@@ -1645,7 +1649,12 @@ def _worker_identity() -> "tuple[str, str]":
 
 WORKER_ID, WORKER_LOCATION = _worker_identity()
 # The poll's query suffix, built once: `&worker=<seat>` after `wait=<sec>`.
-_SEAT_QS = f"&worker={urllib.parse.quote(WORKER_ID, safe='')}"
+def _seat_qs() -> str:
+    """Computed per call: advertisement and revocation both happen at runtime, so
+    an import-time constant would send `worker=` to a broker that never allowed it."""
+    if not _broker_worker_routing:
+        return ""
+    return f"&worker={urllib.parse.quote(WORKER_ID, safe='')}"
 
 
 # A local per-sender map can only cap the broker tier; unlisted senders use LOCAL_TIER.
@@ -2357,9 +2366,16 @@ def _maybe_push_agent_profile() -> bool:
 def _note_broker_capabilities(reply) -> None:
     """Re-read the broker's advertised capabilities from each heartbeat reply.
     Recomputed (not latched) so a downgraded broker turns the extension back off."""
-    global _broker_worker_metadata
+    global _broker_worker_metadata, _broker_worker_routing, _routing_downgrade_logged
     caps = reply.get("capabilities") if isinstance(reply, dict) else None
-    _broker_worker_metadata = isinstance(caps, list) and "worker-metadata" in caps
+    known = caps if isinstance(caps, list) else []
+    _broker_worker_metadata = "worker-metadata" in known
+    _broker_worker_routing = "worker-routing" in known
+    if not _broker_worker_routing and not _routing_downgrade_logged:
+        # One line per process: silence makes a safe downgrade undiagnosable,
+        # a per-heartbeat line would be noise.
+        _routing_downgrade_logged = True
+        _log("broker did not advertise worker-routing; using legacy shared-queue polling")
 
 
 def _revoke_broker_capabilities() -> None:
@@ -2367,8 +2383,9 @@ def _revoke_broker_capabilities() -> None:
     extension is supported; the keys are additive and return on the next
     advertising reply, so dropping them cannot lose a result while keeping
     them can (a strict relay 422s an un-advertised key)."""
-    global _broker_worker_metadata
+    global _broker_worker_metadata, _broker_worker_routing
     _broker_worker_metadata = False
+    _broker_worker_routing = False
 
 
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
@@ -2389,11 +2406,14 @@ def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
             "provider": PROVIDER,
             "tier": LOCAL_TIER,
             "inflight": len(inflight),
-            "worker_id": WORKER_ID,
-            "location": WORKER_LOCATION,
             "capabilities": ["task-ack", "heartbeat", "result-skip-markers",
                              "core-status", "team-collaborator"],
         }
+        # Legacy-safe first exchange: seat identity rides only after the broker
+        # advertises `worker-routing`, so a strict relay never sees a new key.
+        if _broker_worker_routing:
+            payload["worker_id"] = WORKER_ID
+            payload["location"] = WORKER_LOCATION
         # Only include when present so a status-less node never clobbers the
         # broker's last-known core-status (the broker only records on presence).
         if _status is not None:
@@ -4048,7 +4068,7 @@ def main() -> None:
             _retry_review_card_resolutions()
             _retry_review_control_results()
             try:
-                resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}{_SEAT_QS}", timeout=POLL_WAIT + 10)
+                resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}{_seat_qs()}", timeout=POLL_WAIT + 10)
                 last_poll_ok = time.time()
             except (TimeoutError, socket.timeout):
                 # Read timeout only (URLError takes the outage path below).

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1166,14 +1166,15 @@ _WORKER_PIN_RE = re.compile(r"worker-pin-[0-9]+-[0-9a-fA-F]+\Z")
 # user-forgeable, this source stamp is written by the broker.
 _WORKER_PIN_SOURCE = "worker-picker"
 _pin_source_downgrade_logged = False
-# Latched once a broker-stamped pin arrives: after that, id-only is not control.
+# Log-once only. It never promotes id-only to control: the stamp stays the sole
+# discriminator, because a process latch resets on restart.
 
 
 def _consume_worker_pin(task: dict) -> bool:
     """The broker's pin route enqueues a `worker-pin-<ms>-<hex>` compat task: a
-    control message for this seat, never user work. It writes no task file
-    (the watcher globs *.txt, so one would sit in flight until the lease
-    expired); it is acked and its lease closed [no-send]. False = not a pin."""
+    control message for this seat, never user work. It writes no task file: the
+    watcher globs *.txt, so one would be dispatched to the core as ordinary work.
+    It is acked and its lease closed [no-send]. False = not a pin."""
     global _pin_source_downgrade_logged
     tid = str(task.get("id") or "").strip()
     if not _WORKER_PIN_RE.fullmatch(tid) or not _valid_tid(tid):

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2421,20 +2421,26 @@ def _maybe_push_agent_profile() -> bool:
     return True
 
 
+def _apply_broker_capabilities(metadata: bool, routing: bool) -> None:
+    """The one owner of a capability transition, so every path that changes
+    routing invalidates the same evidence in the same way."""
+    global _broker_worker_metadata, _broker_worker_routing, _workers_push_retry_at
+    was_routing = _broker_worker_routing
+    _broker_worker_metadata = metadata
+    _broker_worker_routing = routing
+    if routing != was_routing:
+        # EITHER edge: a backoff is evidence about a payload shape we no longer
+        # send, and the shape we now send may well be accepted.
+        _workers_push_retry_at = 0.0
+
+
 def _note_broker_capabilities(reply) -> None:
     """Re-read the broker's advertised capabilities from each heartbeat reply.
     Recomputed (not latched) so a downgraded broker turns the extension back off."""
-    global _broker_worker_metadata, _broker_worker_routing, _routing_downgrade_logged
-    global _workers_push_retry_at
+    global _routing_downgrade_logged
     caps = reply.get("capabilities") if isinstance(reply, dict) else None
     known = caps if isinstance(caps, list) else []
-    was_routing = _broker_worker_routing
-    _broker_worker_metadata = "worker-metadata" in known
-    _broker_worker_routing = "worker-routing" in known
-    if _broker_worker_routing and not was_routing:
-        # An endpoint backoff is evidence about the broker we polled BEFORE it
-        # advertised routing; a new advertisement makes that evidence stale.
-        _workers_push_retry_at = 0.0
+    _apply_broker_capabilities("worker-metadata" in known, "worker-routing" in known)
     if not _broker_worker_routing and not _routing_downgrade_logged:
         # One line per process: silence makes a safe downgrade undiagnosable,
         # a per-heartbeat line would be noise.
@@ -2447,15 +2453,7 @@ def _revoke_broker_capabilities() -> None:
     extension is supported; the keys are additive and return on the next
     advertising reply, so dropping them cannot lose a result while keeping
     them can (a strict relay 422s an un-advertised key)."""
-    global _broker_worker_metadata, _broker_worker_routing
-    global _workers_push_retry_at
-    was_routing = _broker_worker_routing
-    _broker_worker_metadata = False
-    _broker_worker_routing = False
-    if was_routing:
-        # EITHER transition invalidates a backoff: it is evidence about a payload
-        # shape we no longer send, and the other shape may well be accepted.
-        _workers_push_retry_at = 0.0
+    _apply_broker_capabilities(False, False)
 
 
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1563,6 +1563,9 @@ def _auth_probe() -> bool:
         return False
 _heartbeat_disabled = False
 _last_heartbeat_at = 0.0
+# Result `metadata` is an EXTENSION to the documented {id, body} envelope, so it
+# ships only once the broker advertises it; a strict relay 422s unknown keys.
+_broker_worker_metadata = False
 
 _TASK_FIELDS = ("id", "timestamp", "session_scope",
                 # Routing keys the pool lead reads with a strict task-last
@@ -2338,6 +2341,14 @@ def _maybe_push_agent_profile() -> bool:
     return True
 
 
+def _note_broker_capabilities(reply) -> None:
+    """Re-read the broker's advertised capabilities from each heartbeat reply.
+    Recomputed (not latched) so a downgraded broker turns the extension back off."""
+    global _broker_worker_metadata
+    caps = reply.get("capabilities") if isinstance(reply, dict) else None
+    _broker_worker_metadata = isinstance(caps, list) and "worker-metadata" in caps
+
+
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
     """Best-effort liveness + core-status ping. Liveness feeds hosted dashboards;
     the status/step feed the broker's presence sweep (agent working/available/…)."""
@@ -2367,7 +2378,7 @@ def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
             payload["status"] = _status
         if _step is not None:
             payload["step"] = _step
-        _req("POST", "/v1/heartbeat", payload, timeout=10)
+        _note_broker_capabilities(_req("POST", "/v1/heartbeat", payload, timeout=10))
         return True
     except urllib.error.HTTPError as e:
         if e.code in (404, 405):
@@ -3419,8 +3430,9 @@ def _deliver_result_payload(tid: str, broker_tid: str, body: str,
     # Structured attribution, not the "— core-N" prose in the body: the
     # signature is for humans and reformatting it must not change routing.
     # Pool done-flag owner first; else this seat answered it (cloud, home).
-    doc["metadata"] = {"worker_id": _worker_of(tid) or WORKER_ID,
-                       "location": WORKER_LOCATION}
+    if _broker_worker_metadata:
+        doc["metadata"] = {"worker_id": _worker_of(tid) or WORKER_ID,
+                           "location": WORKER_LOCATION}
     payload = json.dumps(doc).encode("utf-8")
     core.backend.publish(broker_tid, payload)   # False = already live: retry pass
     res = core.deliver_one(broker_tid, payload)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2349,6 +2349,15 @@ def _note_broker_capabilities(reply) -> None:
     _broker_worker_metadata = isinstance(caps, list) and "worker-metadata" in caps
 
 
+def _revoke_broker_capabilities() -> None:
+    """A heartbeat that returns no advertisement leaves us no evidence the
+    extension is supported; the keys are additive and return on the next
+    advertising reply, so dropping them cannot lose a result while keeping
+    them can (a strict relay 422s an un-advertised key)."""
+    global _broker_worker_metadata
+    _broker_worker_metadata = False
+
+
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
     """Best-effort liveness + core-status ping. Liveness feeds hosted dashboards;
     the status/step feed the broker's presence sweep (agent working/available/…)."""
@@ -2383,13 +2392,18 @@ def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
     except urllib.error.HTTPError as e:
         if e.code in (404, 405):
             _heartbeat_disabled = True
+            # Heartbeat is the only capability channel, so disabling it means no
+            # later reply can revoke the extension. Revoke here or it is latched.
+            _revoke_broker_capabilities()
             _log("gateway does not support heartbeat — continuing without")
             return False
         if e.code in (401, 403):
             raise
+        _revoke_broker_capabilities()
         _log(f"heartbeat failed: HTTP {e.code} — continuing")
         return False
     except (urllib.error.URLError, TimeoutError) as e:
+        _revoke_broker_capabilities()
         _log(f"heartbeat network error: {e} — continuing")
         return False
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -12,14 +12,17 @@ exposes a tiny HTTP protocol; this client pulls *your* tasks down into the local
 Full spec: docs/remote-gateway-protocol.md
 
   Protocol (versioned, Bearer-auth):
-  GET  {REMOTE_TASK_URL}/v1/tasks?wait=<sec>
+  GET  {REMOTE_TASK_URL}/v1/tasks?wait=<sec>&worker=<worker-id>
        → 200 {"tasks": [ {<task fields...>}, ... ]}   (long-poll; [] on timeout)
+       `worker` names the pulling seat; a broker that ignores it serves the
+       agent's queue exactly as before (one queue per agent identity).
   POST {REMOTE_TASK_URL}/v1/tasks/<task-id>/ack
        → body {"id": "<task-id>"}  → 200 on accepted
   POST {REMOTE_TASK_URL}/v1/results
        → body {"id": "<task-id>", "body": "<result text>"}  → 200 on accepted
   POST {REMOTE_TASK_URL}/v1/heartbeat
-       → body {"client": "...", "inflight": N, ...}  → 200 on accepted
+       → body {"client": "...", "inflight": N, "worker_id": "...",
+               "location": "local|cloud", ...}  → 200 on accepted
 
 Each task object uses the same schema Sutando's other bridges write, so this
 client just serializes it to `tasks/task-<id>.txt` and the core handles it like
@@ -27,6 +30,24 @@ any Discord/Telegram/Slack task. When `results/task-<id>.txt` appears, its body
 is POSTed back and the result file is archived. Ack/heartbeat are best-effort:
 if an older gateway returns 404/405, the client keeps working against the
 original pull/result protocol.
+
+Worker seats (issue: cloud workers sharing the agent identity). Every client is
+a queue client for ONE seat of the agent: the home seat (`home`), a pool seat
+(`worker-N`) or a cloud seat. The seat rides every wire call (`worker=` on the
+pull, `worker_id`/`location` on heartbeat and the workers-snapshot push) so a
+worker-aware broker can dispatch per seat and fail a lease over from a seat
+that stops beating. A cloud seat runs this same client with its own workspace:
+the pull → `tasks/` → `results/` → POST cycle needs nothing from another host —
+`state/pool-status.json` and `state/cores/` are read only when present.
+
+Lease safety (at-least-once). The broker's lease re-fronts a task on expiry, so
+a slow seat can see its own task delivered again, or a peer seat can receive it.
+Locally a re-delivered id is never queued twice while the first copy is live
+(`_write_task`: pending, assigned or claimed file → no rewrite; archived or
+delivered → `[no-send]` lease close), and the result sink dedupes on the task
+id. What this client cannot prevent: a lease shorter than the seat's honest
+task time hands the SAME id to another seat, which then answers it too — set
+the broker's visibility timeout above the longest honest task.
 
 Config (env / .env):
   REMOTE_TASK_TOKEN      the onboarding string — the ONLY required setting
@@ -42,6 +63,10 @@ Config (env / .env):
                         credentials or tier map. Env-only by necessity: the
                         .env file cannot name its own directory.
   REMOTE_TASK_POLL_WAIT long-poll seconds (default 25)
+  SUTANDO_WORKER_ID     this seat's worker id on the wire (default "home";
+                        `worker-<SUTANDO_CORE_ID>` when only the pool seat
+                        number is set). Charset [A-Za-z0-9_-], max 32.
+  SUTANDO_WORKER_LOCATION  "cloud" marks a cloud seat; anything else is "local"
   REMOTE_OUTBOUND_SCAN_S outbound worker scan period seconds (default 1.0)
 
 Stdlib only (urllib) — no new dependencies.
@@ -1536,6 +1561,34 @@ if LOCAL_TIER == "other":
 if LOCAL_TIER not in ("owner", "team", "guest"):
     LOCAL_TIER = "guest"
 
+# Same id charset as GATEWAY_INSTANCE: it lands in a query string and in
+# broker-side queue keys, so a stray value fails at import, never on the wire.
+_WORKER_ID_RE = _INSTANCE_RE
+
+
+def _worker_identity() -> "tuple[str, str]":
+    """(worker_id, location) for this seat, from env only.
+
+    SUTANDO_WORKER_ID wins; a bare pool seat number (SUTANDO_WORKER_SEAT or
+    SUTANDO_CORE_ID) derives `worker-<n>` the way the room-ops scripts do; an
+    unconfigured process is the home seat. Location is "cloud" only when
+    SUTANDO_WORKER_LOCATION says so — a typo degrades to today's local path."""
+    wid = (os.environ.get("SUTANDO_WORKER_ID") or "").strip()
+    if not wid:
+        seat = (os.environ.get("SUTANDO_WORKER_SEAT")
+                or os.environ.get("SUTANDO_CORE_ID") or "").strip()
+        wid = f"worker-{seat}" if seat else "home"
+    if not _WORKER_ID_RE.fullmatch(wid):
+        sys.exit("FATAL: SUTANDO_WORKER_ID must match "
+                 f"{_WORKER_ID_RE.pattern} (ASCII only; got {wid!r})")
+    loc = (os.environ.get("SUTANDO_WORKER_LOCATION") or "").strip().lower()
+    return wid, ("cloud" if loc == "cloud" else "local")
+
+
+WORKER_ID, WORKER_LOCATION = _worker_identity()
+# The poll's query suffix, built once: `&worker=<seat>` after `wait=<sec>`.
+_SEAT_QS = f"&worker={urllib.parse.quote(WORKER_ID, safe='')}"
+
 
 # A local per-sender map can only cap the broker tier; unlisted senders use LOCAL_TIER.
 # Cache identity includes mtime, size, and inode so revocations take effect promptly.
@@ -2176,6 +2229,8 @@ def _maybe_push_workers_snapshot() -> bool:
         return False  # mid-write or malformed: the next change retries
     if not isinstance(snap, dict):
         return False
+    # The pushing seat is authoritative about itself; the lead's file is not.
+    snap = {**snap, "worker_id": WORKER_ID, "location": WORKER_LOCATION}
     try:
         _req("POST", "/v1/workers", snap, timeout=15)
     except urllib.error.HTTPError as e:
@@ -2259,6 +2314,8 @@ def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
             "provider": PROVIDER,
             "tier": LOCAL_TIER,
             "inflight": len(inflight),
+            "worker_id": WORKER_ID,
+            "location": WORKER_LOCATION,
             "capabilities": ["task-ack", "heartbeat", "result-skip-markers",
                              "core-status", "team-collaborator"],
         }
@@ -3904,7 +3961,7 @@ def main() -> None:
             _retry_review_card_resolutions()
             _retry_review_control_results()
             try:
-                resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}", timeout=POLL_WAIT + 10)
+                resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}{_SEAT_QS}", timeout=POLL_WAIT + 10)
                 last_poll_ok = time.time()
             except (TimeoutError, socket.timeout):
                 # Read timeout only (URLError takes the outage path below).

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2448,8 +2448,14 @@ def _revoke_broker_capabilities() -> None:
     advertising reply, so dropping them cannot lose a result while keeping
     them can (a strict relay 422s an un-advertised key)."""
     global _broker_worker_metadata, _broker_worker_routing
+    global _workers_push_retry_at
+    was_routing = _broker_worker_routing
     _broker_worker_metadata = False
     _broker_worker_routing = False
+    if was_routing:
+        # EITHER transition invalidates a backoff: it is evidence about a payload
+        # shape we no longer send, and the other shape may well be accepted.
+        _workers_push_retry_at = 0.0
 
 
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -385,9 +385,10 @@ if GATEWAY_INSTANCE and not _INSTANCE_RE.fullmatch(GATEWAY_INSTANCE):
     sys.exit("FATAL: GATEWAY_INSTANCE must match "
              f"{_INSTANCE_RE.pattern} (ASCII only; got {GATEWAY_INSTANCE!r})")
 _INST_SUFFIX = f".{GATEWAY_INSTANCE}" if GATEWAY_INSTANCE else ""
-# The JOURNAL is instance-owned, so it is namespaced: two gateways sharing one
-# workspace must not drain or delete each other's deferred control records.
-_WITHHELD_CONTROL_DIR = _STATE / f"withheld-review-control-results{_INST_SUFFIX}"
+# The JOURNAL is instance-owned, so EVERY lane gets an owned directory -- the
+# default one included, or its path collapses onto the legacy path below.
+_CONTROL_OWNER = GATEWAY_INSTANCE or "default"
+_WITHHELD_CONTROL_DIR = _STATE / f"withheld-review-control-results.{_CONTROL_OWNER}"
 # The review DM is OWNER-owned, not instance-owned, and is already keyed by
 # owner on read; namespacing it would create one duplicate room per instance.
 _WITHHELD_DM_CACHE = _STATE / "withheld-review-dm.json"
@@ -1117,7 +1118,9 @@ _LEGACY_CONTROL_WARNED = False
 
 def _warn_legacy_control_records() -> int:
     """Count unsuffixed leftovers once. Never adopt them: with two instances
-    live, whoever starts first would claim records owned by the other."""
+    live, whoever starts first would claim records owned by the other. The
+    default lane is a lane like any other -- if it read this path directly the
+    warning would be false and it would drain the very rows it disclaims."""
     global _LEGACY_CONTROL_WARNED
     try:
         stale = sorted(_WITHHELD_CONTROL_DIR_LEGACY.glob("*.json"))

--- a/tests/gateway-result-worker-attribution.test.py
+++ b/tests/gateway-result-worker-attribution.test.py
@@ -10,6 +10,9 @@ change routing or attribution. A seat with no done-flag (a cloud seat, or the
 home seat outside a pool) attributes to its OWN worker id — the seat that
 POSTs the result answered it — so no result ever leaves unattributed.
 
+`metadata` is an OPTIONAL extension: the client sends it only once the broker
+advertises `worker-metadata` (see gateway-worker-queue-client.test.py section 8).
+
 Run: python3 tests/gateway-result-worker-attribution.test.py
 """
 from __future__ import annotations
@@ -54,6 +57,9 @@ class WorkerAttribution(unittest.TestCase):
     def _seat(self, **seat: str):
         self.mod = _load(**seat)
         self.mod._STATE = Path(self.tmp)
+        # Attribution is a negotiated extension; this suite is about WHICH
+        # worker is named, so grant the capability the broker would advertise.
+        self.mod._broker_worker_metadata = True
         seen = self.seen
 
         class _Backend:

--- a/tests/gateway-result-worker-attribution.test.py
+++ b/tests/gateway-result-worker-attribution.test.py
@@ -6,7 +6,9 @@ event's content["space.ag2.worker"].id (ag2space-backend#882).
 The worker is read from the per-core done-flag the pool already writes
 (state/cores/<core>/done/task-<id>.flag), NOT from the "- core-N" signature
 in the body: that line is for humans, and reformatting it must not silently
-change routing or attribution.
+change routing or attribution. A seat with no done-flag (a cloud seat, or the
+home seat outside a pool) attributes to its OWN worker id — the seat that
+POSTs the result answered it — so no result ever leaves unattributed.
 
 Run: python3 tests/gateway-result-worker-attribution.test.py
 """
@@ -14,15 +16,23 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 _SRC = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py"
+_SEAT_ENV = ("SUTANDO_WORKER_ID", "SUTANDO_WORKER_SEAT", "SUTANDO_CORE_ID",
+             "SUTANDO_WORKER_LOCATION")
 
 
-def _load():
+def _load(**seat: str):
+    # The seat identity is read at import; a fresh env per load keeps the
+    # cases independent of each other and of the host's own seat.
+    for k in _SEAT_ENV:
+        os.environ.pop(k, None)
+    os.environ.update(seat)
     spec = importlib.util.spec_from_file_location("_rgb_worker", _SRC)
     mod = importlib.util.module_from_spec(spec)
     sys.modules["_rgb_worker"] = mod
@@ -37,15 +47,18 @@ class _Captured(Exception):
 
 class WorkerAttribution(unittest.TestCase):
     def setUp(self):
-        self.mod = _load()
         self.tmp = tempfile.mkdtemp()
-        self.mod._STATE = Path(self.tmp)
-
         self.seen = {}
+        self._seat()
+
+    def _seat(self, **seat: str):
+        self.mod = _load(**seat)
+        self.mod._STATE = Path(self.tmp)
+        seen = self.seen
 
         class _Backend:
             def publish(_s, tid, payload):
-                self.seen["payload"] = json.loads(payload.decode())
+                seen["payload"] = json.loads(payload.decode())
                 raise _Captured()
 
         self.mod._delivery_core = lambda: type("C", (), {"backend": _Backend()})()
@@ -66,7 +79,7 @@ class WorkerAttribution(unittest.TestCase):
     def test_worker_rides_the_payload(self):
         self._flag("core-2", "task-0023dacce4b1f0a9c7")
         doc = self._doc("task-0023dacce4b1f0a9c7")
-        self.assertEqual(doc["metadata"], {"worker_id": "core-2"})
+        self.assertEqual(doc["metadata"], {"worker_id": "core-2", "location": "local"})
         # Attribution must not leak into the text the user reads.
         self.assertEqual(doc["body"], "done!")
 
@@ -78,15 +91,39 @@ class WorkerAttribution(unittest.TestCase):
         self.assertEqual(b["metadata"]["worker_id"], "core-3")
         self.assertNotEqual(a["metadata"], b["metadata"])
 
-    def test_control_no_flag_sends_no_metadata(self):
-        # Single-core installs write no per-core flag; absent must mean absent,
-        # never a fabricated default that would misattribute every result.
-        self.assertNotIn("metadata", self._doc("task-unflagged00000000"))
+    def test_no_flag_attributes_to_this_seat(self):
+        # Single-seat installs write no per-core flag; the seat that POSTs the
+        # result answered it, so its own id is the attribution of last resort.
+        self.assertEqual(self._doc("task-unflagged00000000")["metadata"],
+                         {"worker_id": "home", "location": "local"})
 
-    def test_control_ambiguous_flags_send_no_metadata(self):
+    def test_cloud_seat_attributes_to_itself(self):
+        # Measured defect: a cloud seat has no done-flag, and its results left
+        # with no metadata at all (worker_attribution_missing = 2 of 2).
+        self._seat(SUTANDO_WORKER_ID="cloud-1", SUTANDO_WORKER_LOCATION="cloud")
+        self.assertEqual((self.mod.WORKER_ID, self.mod.WORKER_LOCATION),
+                         ("cloud-1", "cloud"))
+        doc = self._doc("task-cloudseat0000000")
+        self.assertEqual(doc["metadata"], {"worker_id": "cloud-1", "location": "cloud"})
+        self.assertEqual(doc["body"], "done!")
+
+    def test_done_flag_outranks_the_seat(self):
+        # A pool worker's done-flag is the answering seat even when the lead
+        # (worker-1) is the one POSTing: pool attribution is unchanged.
+        self._seat(SUTANDO_WORKER_ID="worker-1")
+        self._flag("worker-2", "task-flagwins000000000")
+        self.assertEqual(self._doc("task-flagwins000000000")["metadata"]["worker_id"],
+                         "worker-2")
+        self.assertEqual(self._doc("task-noflag0000000000")["metadata"]["worker_id"],
+                         "worker-1")
+
+    def test_control_ambiguous_flags_fall_back_to_this_seat(self):
+        # Two flags name no single worker; the POSTing seat is the only fact.
+        self._seat(SUTANDO_WORKER_ID="worker-1")
         self._flag("core-1", "task-4ambiguous000000a")
         self._flag("core-2", "task-4ambiguous000000a")
-        self.assertNotIn("metadata", self._doc("task-4ambiguous000000a"))
+        self.assertEqual(self._doc("task-4ambiguous000000a")["metadata"]["worker_id"],
+                         "worker-1")
 
     def test_control_a_bare_id_does_not_attribute(self):
         # Production never passes a bare id; if one ever reaches here it must

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -45,7 +45,11 @@ STATE = {"gets": [], "acks": [], "results": [], "heartbeats": [], "workers": [],
          # relay that REJECTS unknown result keys instead of ignoring them.
          "advertise": True, "strict": False, "rejected": [],
          # a 200 whose body is not JSON, and a 200 that explicitly declines
-         "heartbeat_garbage": False, "results_decline": False}
+         "heartbeat_garbage": False, "results_decline": False,
+         # strict_wire models a LEGACY relay that REJECTS (not ignores) unknown
+         # heartbeat keys and unknown query params.
+         "strict_wire": False, "advertise_routing": False,
+         "hb_keys": [], "get_qkeys": [], "wire_rejected": []}
 TASK = {"id": "task-CLOUD1", "timestamp": "2026-09-03T00:00:00Z",
         "task": "hello cloud seat", "source": "remote-gateway",
         "channel_id": "!room:example.org", "user_id": "@qingyun:example.org",
@@ -70,6 +74,13 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path.startswith("/v1/tasks"):
             STATE["gets"].append(self.path)
+            from urllib.parse import urlparse, parse_qs
+            qk = sorted(parse_qs(urlparse(self.path).query).keys())
+            STATE["get_qkeys"].append(qk)
+            _okq = {"wait"} | ({"worker"} if STATE["advertise_routing"] else set())
+            if STATE["strict_wire"] and set(qk) - _okq:
+                STATE["wire_rejected"].append(("get-query", qk))
+                self._json(400, {"error": "unknown query parameter"}); return
             served = STATE["serve_n"] > 0
             if served:
                 STATE["serve_n"] -= 1
@@ -96,13 +107,24 @@ class Handler(BaseHTTPRequestHandler):
                 _hb = STATE["heartbeat_404"]
                 self.send_response(404 if _hb is True else int(_hb))
                 self.end_headers(); return
-            STATE["heartbeats"].append(self._body())
+            _hb = self._body()
+            STATE["heartbeats"].append(_hb)
+            STATE["hb_keys"].append(sorted(_hb.keys()))
+            _legacy = {"client", "protocol_version", "provider", "tier",
+                       "inflight", "capabilities", "status", "step"}
+            if STATE["advertise_routing"]:      # advertising it means accepting it
+                _legacy |= {"worker_id", "location"}
+            if STATE["strict_wire"] and set(_hb) - _legacy:
+                STATE["wire_rejected"].append(("heartbeat", sorted(set(_hb) - _legacy)))
+                self._json(422, {"error": "unknown field"}); return
             if STATE["heartbeat_garbage"]:
                 raw = b"<html>not json</html>"
                 self.send_response(200)
                 self.send_header("Content-Length", str(len(raw)))
                 self.end_headers(); self.wfile.write(raw); return
-            caps = {"capabilities": ["worker-metadata"]} if STATE["advertise"] else {}
+            _adv = (["worker-metadata"] if STATE["advertise"] else []) + \
+                   (["worker-routing"] if STATE["advertise_routing"] else [])
+            caps = {"capabilities": _adv} if _adv else {}
             self._json(200, caps); return
         if self.path == "/v1/workers":
             STATE["workers"].append(self._body()); self._json(200, {}); return
@@ -168,12 +190,22 @@ def main() -> int:
         check(False, "a path-shaped SUTANDO_WORKER_ID refuses at import")
     except SystemExit:
         check(True, "a path-shaped SUTANDO_WORKER_ID refuses at import")
-    check(home._SEAT_QS == "&worker=home" and named._SEAT_QS == "&worker=worker-9",
-          "the poll query suffix is &worker=<seat> (bare id for the legal charset)")
+    # The suffix is now NEGOTIATED, so assert the shape under an advertisement
+    # rather than at import; unconditional was keweichen's blocker 1.
+    check(home._seat_qs() == "" and named._seat_qs() == "",
+          "no advertisement -> the poll carries no seat (legacy shape)")
+    for _m in (home, named):
+        _m._note_broker_capabilities({"capabilities": ["worker-routing"]})
+    check(home._seat_qs() == "&worker=home" and named._seat_qs() == "&worker=worker-9",
+          "once advertised, the suffix is &worker=<seat> (bare id for the legal charset)")
+    for _m in (home, named):
+        _m._revoke_broker_capabilities()
 
     # ── 2. heartbeat + workers snapshot carry the seat ──────────────────────
     print("2. heartbeat / workers snapshot payloads")
     STATE["heartbeats"].clear()
+    STATE["advertise_routing"] = True          # identity is negotiated now
+    home._note_broker_capabilities({"capabilities": ["worker-routing"]})
     check(home._post_heartbeat({"task-A", "task-B"}, force=True)
           and STATE["heartbeats"][-1].get("worker_id") == "home"
           and STATE["heartbeats"][-1].get("location") == "local",
@@ -187,6 +219,8 @@ def main() -> int:
           "every pre-existing heartbeat field is byte-identical (additive change only)")
     print(f"     heartbeat payload (home): {json.dumps(hb, sort_keys=True)}")
     named._last_heartbeat_at = 0.0
+    # Identity is negotiated: teach this module the advertisement, then re-send.
+    named._note_broker_capabilities({"capabilities": ["worker-routing"]})
     named._post_heartbeat(set(), force=True)
     check(STATE["heartbeats"][-1].get("worker_id") == "worker-9"
           and STATE["heartbeats"][-1].get("location") == "cloud",
@@ -243,10 +277,12 @@ def main() -> int:
     check(calls["n"] == 5, "main: two full loop iterations ran")
     check(len(STATE["gets"]) == 2
           and all(g == "/v1/tasks?wait=0&worker=cloud-1" for g in STATE["gets"]),
-          f"poll URL carries the seat: {STATE['gets'][:1]}")
+          f"poll URL carries the seat once routing is advertised: {STATE['gets'][:1]}")
+    check(STATE["heartbeats"] and "worker_id" not in STATE["heartbeats"][0],
+          "the seat's FIRST heartbeat is legacy — it has not seen an advertisement yet")
     check(all(h.get("worker_id") == "cloud-1" and h.get("location") == "cloud"
-              for h in STATE["heartbeats"]) and STATE["heartbeats"],
-          "every heartbeat from the loop names the cloud seat")
+              for h in STATE["heartbeats"][1:]) and len(STATE["heartbeats"]) > 1,
+          "every heartbeat AFTER the advertising reply names the cloud seat")
     tfile = cloud.TASKS_DIR / "task-CLOUD1.txt"
     tfiles = sorted(p.name for p in cloud.TASKS_DIR.glob("task-CLOUD1*"))
     check(tfiles == ["task-CLOUD1.txt"], f"exactly one task file after redelivery: {tfiles}")
@@ -584,6 +620,68 @@ def main() -> int:
           f"the next drain closes it exactly once: {STATE['results']}")
     check(not d12._control_result_path(PIN12).is_file(),
           "and an ACCEPTED close does consume the journal")
+
+    # keweichen blocker 1: the worker-aware shape must be NEGOTIATED, never
+    # unconditional — a strict legacy relay rejects both requests otherwise.
+    print("\n13. worker routing is gated on the broker advertising `worker-routing`")
+    for k in ("gets", "acks", "results", "heartbeats", "other"):
+        STATE[k].clear()
+    for k in ("hb_keys", "get_qkeys", "wire_rejected"):
+        STATE[k].clear()
+    STATE["advertise"] = False; STATE["advertise_routing"] = False
+    STATE["heartbeat_404"] = False; STATE["heartbeat_garbage"] = False
+    STATE["strict_wire"] = True
+    ws13 = root / "ws13"; ws13.mkdir()
+    d13 = _load("routing13", ws13, port,
+                SUTANDO_WORKER_ID="cloud-9", SUTANDO_WORKER_LOCATION="cloud")
+
+    # (a) FIRST exchange must be byte-for-byte legacy against a rejecting relay
+    check(d13._post_heartbeat(set(), force=True) is True,
+          "first heartbeat is ACCEPTED by a relay that rejects unknown keys")
+    check(STATE["wire_rejected"] == [],
+          f"nothing was rejected on the first exchange: {STATE['wire_rejected']}")
+    check("worker_id" not in STATE["hb_keys"][0] and "location" not in STATE["hb_keys"][0],
+          f"first heartbeat carries NO seat identity: {STATE['hb_keys'][0]}")
+    check(d13._broker_worker_routing is False,
+          "no advertisement -> routing stays off")
+    check(d13._seat_qs() == "",
+          f"pre-advertisement poll suffix is empty: {d13._seat_qs()!r}")
+
+    # (b) broker advertises -> routing appears on BOTH surfaces
+    STATE["advertise_routing"] = True
+    check(d13._post_heartbeat(set(), force=True) is True, "second heartbeat sent")
+    check(d13._broker_worker_routing is True, "advertisement enables routing")
+    check("worker_id" not in STATE["hb_keys"][1],
+          "the ADVERTISING heartbeat is itself still legacy — the flag comes from its REPLY")
+    check(d13._post_heartbeat(set(), force=True) is True, "third heartbeat sent")
+    check("worker_id" in STATE["hb_keys"][2] and "location" in STATE["hb_keys"][2],
+          f"identity rides the request AFTER the advertisement: {STATE['hb_keys'][2]}")
+    check(d13._seat_qs().startswith("&worker="),
+          f"poll suffix carries the seat once advertised: {d13._seat_qs()!r}")
+
+    # (c) withdrawal returns BOTH shapes to legacy
+    STATE["advertise_routing"] = False
+    check(d13._post_heartbeat(set(), force=True) is False,
+          "the FIRST post-withdrawal heartbeat still carries identity and is 422'd")
+    check(("heartbeat", ["location", "worker_id"]) in STATE["wire_rejected"],
+          f"and the relay names exactly the routed keys: {STATE['wire_rejected']}")
+    check(d13._broker_worker_routing is False,
+          "that rejection REVOKES routing — one wasted round trip, then self-healed")
+    check(d13._seat_qs() == "", "poll suffix is back to legacy")
+    check(d13._post_heartbeat(set(), force=True) is True,
+          "and the next heartbeat is legacy-shaped and accepted again")
+
+    # (d) the two capabilities are INDEPENDENT, not aliases
+    STATE["advertise"] = True; STATE["advertise_routing"] = False
+    d13._post_heartbeat(set(), force=True)
+    check(d13._broker_worker_metadata is True and d13._broker_worker_routing is False,
+          "worker-metadata alone does NOT enable routing")
+    STATE["advertise"] = False; STATE["advertise_routing"] = True
+    d13._post_heartbeat(set(), force=True)
+    check(d13._broker_worker_metadata is False and d13._broker_worker_routing is True,
+          "worker-routing alone does NOT enable result metadata")
+    STATE["strict_wire"] = False
+    STATE["advertise"] = True; STATE["advertise_routing"] = False
 
     srv.shutdown()
     if FAILS:

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -426,6 +426,27 @@ def main() -> int:
     for k in ("acks", "results"):
         STATE[k].clear()
 
+    # keweichen: the fallback must RETIRE, not merely stop logging. One stamped
+    # pin proves the broker speaks source, so id-only is no longer control.
+    seat6._pin_stamp_seen = False
+    check(seat6._consume_worker_pin(
+        {"id": "worker-pin-1756000000002-feedface", "task": "legacy pin"}) is True,
+          "before any stamp, a source-less pin still rides the legacy id-only path")
+    for k in ("acks", "results"):
+        STATE[k].clear()
+    check(seat6._consume_worker_pin(dict(exact, source="worker-picker")) is True,
+          "a stamped pin arrives — the broker demonstrably speaks source")
+    for k in ("acks", "results"):
+        STATE[k].clear()
+    check(seat6._consume_worker_pin(
+        {"id": "worker-pin-1756000000003-0badcafe", "task": "an ordinary ask"}) is False,
+          "AFTER the stamp, a source-less exact-grammar task is USER WORK, not control")
+    check(STATE["acks"] == [] and STATE["results"] == [],
+          f"and it was neither acked nor closed: {STATE['acks']} {STATE['results']}")
+    seat6._pin_stamp_seen = False
+    for k in ("acks", "results"):
+        STATE[k].clear()
+
     # Same id, broker's own stamp -> control. Pins the discriminator as the
     # SOURCE, not the id: flip one field and the verdict flips with it.
     stamped = dict(exact, source="worker-picker")
@@ -435,7 +456,8 @@ def main() -> int:
           f"the stamped control was closed no-send: {STATE['results']}")
     for k in ("acks", "results"):
         STATE[k].clear()
-    check(seat6._consume_worker_pin({"id": " worker-pin-123-abc ", "task": "pin"}) is True,
+    check(seat6._consume_worker_pin(
+        {"id": " worker-pin-123-abc ", "task": "pin", "source": "worker-picker"}) is True,
           "a padded pin id is still a pin")
     check(STATE["acks"] == [("/v1/tasks/worker-pin-123-abc/ack",
                              {"id": "worker-pin-123-abc"})],
@@ -780,6 +802,29 @@ def main() -> int:
         d14.urllib.request.urlopen = _real_urlopen
     check(d14._broker_worker_routing is False and d14._broker_worker_metadata is False,
           "and it REVOKES both capabilities — absence of a reply is absence of evidence")
+
+    # (4) keweichen: a bare ConnectionResetError from resp.read() is NOT an
+    # HTTPException and was escaping the heartbeat with both flags left ON.
+    STATE["advertise"] = True; STATE["advertise_routing"] = True
+    d14._post_heartbeat(set(), force=True)
+    check(d14._broker_worker_routing is True, "capabilities ON before the reset control")
+
+    def _resetting(*a, **k):
+        raise ConnectionResetError(104, "Connection reset by peer")
+    d14.urllib.request.urlopen = _resetting
+    escaped = None
+    try:
+        returned = d14._post_heartbeat(set(), force=True)
+    except BaseException as exc:  # noqa: BLE001 — the escape IS the defect
+        returned, escaped = None, type(exc).__name__
+    finally:
+        d14.urllib.request.urlopen = _real_urlopen
+    check(escaped is None, f"a response-body reset does not escape the heartbeat: {escaped}")
+    check(returned is False, f"it reports failure like any other blind beat: {returned}")
+    check(d14._broker_worker_routing is False and d14._broker_worker_metadata is False,
+          "and BOTH capabilities are revoked — a reply we could not read advertises nothing")
+    check("worker=" not in d14._seat_qs(),
+          f"so the next poll is legacy-shaped, not stale worker=: {d14._seat_qs()!r}")
     STATE["strict_wire"] = False
 
 
@@ -848,6 +893,10 @@ def main() -> int:
     # The check above uses a NAMED instance, which is exactly why it passed while
     # the DEFAULT lane drained the rows it disclaims. Migration control:
     default = _load_inst("d15n", ws15, port, "")
+    literal = _load_inst("d15L", ws15, port, "default")
+    check(default._WITHHELD_CONTROL_DIR != literal._WITHHELD_CONTROL_DIR,
+          f"an instance literally NAMED 'default' does not alias the unnamed lane: "
+          f"{default._WITHHELD_CONTROL_DIR.name} vs {literal._WITHHELD_CONTROL_DIR.name}")
     check(default._WITHHELD_CONTROL_DIR != legacy,
           f"the DEFAULT lane owns a distinct dir, not the legacy path: "
           f"{default._WITHHELD_CONTROL_DIR.name} vs {legacy.name}")

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -6,8 +6,10 @@ value refused at import); heartbeat and workers-snapshot carry worker_id +
 location; the poll URL carries `worker=`; a legacy broker that ignores the
 param or 404s heartbeat is served exactly as before; a cloud seat with NO
 state/pool* and NO state/cores runs pull → tasks/ → results/ → POST end to end
-against a stub broker; and a task id re-delivered while its first copy is still
-in flight (pending, assigned or claimed) is never queued or answered twice.
+against a stub broker; a task id re-delivered while its first copy is still
+in flight (pending, assigned or claimed) is never queued or answered twice; and
+the broker's `worker-pin-*` compat task is consumed as a control message (no
+task file, one ack, one [no-send] lease close, nothing else on the wire).
 
 Run: python3 tests/gateway-worker-queue-client.test.py   (stdlib only)
 """
@@ -38,7 +40,7 @@ def check(cond: bool, msg: str) -> None:
 # ── stub broker: records every call; serves TASK on the first `serve_n` polls,
 # ignores the worker= query entirely (a broker that predates seats) ──────────
 STATE = {"gets": [], "acks": [], "results": [], "heartbeats": [], "workers": [],
-         "serve_n": 0, "heartbeat_404": False}
+         "other": [], "serve_n": 0, "heartbeat_404": False, "task": None}
 TASK = {"id": "task-CLOUD1", "timestamp": "2026-09-03T00:00:00Z",
         "task": "hello cloud seat", "source": "remote-gateway",
         "channel_id": "!room:example.org", "user_id": "@qingyun:example.org",
@@ -66,7 +68,7 @@ class Handler(BaseHTTPRequestHandler):
             served = STATE["serve_n"] > 0
             if served:
                 STATE["serve_n"] -= 1
-            self._json(200, {"tasks": [TASK] if served else []})
+            self._json(200, {"tasks": [STATE["task"] or TASK] if served else []})
             return
         self.send_response(404); self.end_headers()
 
@@ -81,6 +83,7 @@ class Handler(BaseHTTPRequestHandler):
             STATE["heartbeats"].append(self._body()); self._json(200, {}); return
         if self.path == "/v1/workers":
             STATE["workers"].append(self._body()); self._json(200, {}); return
+        STATE["other"].append((self.path, self._body()))
         self.send_response(404); self.end_headers()
 
 
@@ -267,6 +270,52 @@ def main() -> int:
           "result + task archived after delivery")
     check(cloud._load_inflight() == set(), "inflight empty after delivery")
     check(_pool_state_absent(ws4), "post-delivery: still no pool state on this host")
+
+    # ── 5. worker-pin compat task: a control message, never a user task ─────
+    print("5. worker-pin compat task is consumed in-client")
+    ws5 = root / "ws5"; ws5.mkdir()
+    seat = _load("wqc_pin", ws5, port, SUTANDO_WORKER_ID="cloud-1",
+                 SUTANDO_WORKER_LOCATION="cloud")
+    for k in ("gets", "acks", "results", "heartbeats", "other"):
+        STATE[k].clear()
+    STATE["task"] = {"id": "worker-pin-123-abc", "timestamp": "2026-09-03T00:00:01Z",
+                     "task": "pin cloud-1", "source": "remote-gateway",
+                     "channel_id": "!room:example.org", "user_id": "@broker:example.org",
+                     "access_tier": "owner", "priority": "normal"}
+    STATE["serve_n"] = 1
+    logs: list[str] = []
+    seat._log = lambda m: logs.append(str(m))
+    real_hb = seat._post_heartbeat
+    calls = {"n": 0}
+
+    def _one_iteration(inflight_arg):
+        calls["n"] += 1
+        if calls["n"] >= 3:
+            raise KeyboardInterrupt
+        return real_hb(inflight_arg, force=True)
+
+    seat._post_heartbeat = _one_iteration
+    try:
+        seat.main()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        seat._post_heartbeat = real_hb
+        seat._OUTBOUND_STOP.set(); seat._OUTBOUND_WAKE.set()
+        STATE["task"] = None
+    files = sorted(p.name for p in seat.TASKS_DIR.glob("*")) if seat.TASKS_DIR.exists() else []
+    check(files == [], f"no tasks/*.txt written for the pin: {files}")
+    check(STATE["acks"] == [("/v1/tasks/worker-pin-123-abc/ack", {"id": "worker-pin-123-abc"})],
+          f"exactly one ack, on the pin id: {STATE['acks']}")
+    check(STATE["results"] == [{"id": "worker-pin-123-abc", "body": "[no-send]"}],
+          f"exactly one [no-send] lease close: {STATE['results']}")
+    check(STATE["other"] == [], f"nothing else reached the broker (no room post): {STATE['other']}")
+    check(seat._load_inflight() == set(), "the pin never entered inflight")
+    check(not list((seat._STATE / "withheld-review-control-results").glob("*.json")),
+          "no deferred control result left behind")
+    target = "archived worker-pin-123-abc (marker no-send, lease closed, not sent)"
+    check(target in logs, f"log line matches the live-run target: {[l for l in logs if 'pin' in l]}")
+    print(f"     result payload: {json.dumps(STATE['results'][0], sort_keys=True)}")
 
     srv.shutdown()
     if FAILS:

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -477,6 +477,48 @@ def main() -> int:
     STATE["heartbeat_404"] = False
     STATE["strict"] = False
 
+    # The ordering only pays off if a LATER process finishes the close, so the
+    # control has to cross a real process boundary, not drain in the same one.
+    print("\n10. crash after a confirmed ack -> a fresh process closes it exactly once")
+    for k in ("gets", "acks", "results", "heartbeats", "other"):
+        STATE[k].clear()
+    STATE["advertise"] = True
+    ws10 = root / "ws10"; ws10.mkdir()
+    seat10 = _load("wqc_pin_restart", ws10, port, SUTANDO_WORKER_ID="cloud-2",
+                   SUTANDO_WORKER_LOCATION="cloud")
+    PIN = "worker-pin-909-d0d0"
+
+    def _die(*_a, **_k):
+        raise RuntimeError("process loss immediately after the confirmed ack")
+
+    seat10._retry_review_control_results = _die
+    try:
+        seat10._consume_worker_pin({"id": PIN, "task": "pin"})
+    except RuntimeError:
+        pass
+    check(STATE["acks"] == [(f"/v1/tasks/{PIN}/ack", {"id": PIN})],
+          f"the ack was CONFIRMED before the loss: {STATE['acks']}")
+    check(STATE["results"] == [],
+          f"the dying process did NOT close the lease: {STATE['results']}")
+    check(seat10._control_result_path(PIN).is_file(),
+          "the close intent survives on disk for whoever runs next")
+
+    # restart: a brand-new module over the same workspace, no in-process carry-over
+    seat10b = _load("wqc_pin_restart_b", ws10, port, SUTANDO_WORKER_ID="cloud-2",
+                    SUTANDO_WORKER_LOCATION="cloud")
+    check(seat10b is not seat10,
+          "control: a genuinely fresh module, not the crashed one")
+    check(seat10b._control_result_path(PIN).is_file(),
+          "the fresh process finds the pending close on DISK, not in memory")
+    seat10b._retry_review_control_results()
+    check(STATE["results"] == [{"id": PIN, "body": "[no-send]"}],
+          f"restart closes the lease exactly once: {STATE['results']}")
+    check(not seat10b._control_result_path(PIN).is_file(),
+          "and consumes the journal, so nothing can repeat it")
+    seat10b._retry_review_control_results()
+    check(STATE["results"] == [{"id": PIN, "body": "[no-send]"}],
+          f"a second drain after restart posts nothing more: {STATE['results']}")
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""The gateway client is a worker-aware queue client, backward compatible.
+
+Covers: the seat identity from env (home default, pool seat, cloud seat, bad
+value refused at import); heartbeat and workers-snapshot carry worker_id +
+location; the poll URL carries `worker=`; a legacy broker that ignores the
+param or 404s heartbeat is served exactly as before; a cloud seat with NO
+state/pool* and NO state/cores runs pull → tasks/ → results/ → POST end to end
+against a stub broker; and a task id re-delivered while its first copy is still
+in flight (pending, assigned or claimed) is never queued or answered twice.
+
+Run: python3 tests/gateway-worker-queue-client.test.py   (stdlib only)
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LOADER = REPO / "src" / "remote-gateway-bridge.py"
+FAILS: list[str] = []
+SEAT_ENV = ("SUTANDO_WORKER_ID", "SUTANDO_WORKER_SEAT", "SUTANDO_CORE_ID",
+            "SUTANDO_WORKER_LOCATION")
+
+
+def check(cond: bool, msg: str) -> None:
+    print(("  ok  " if cond else "  FAIL ") + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+# ── stub broker: records every call; serves TASK on the first `serve_n` polls,
+# ignores the worker= query entirely (a broker that predates seats) ──────────
+STATE = {"gets": [], "acks": [], "results": [], "heartbeats": [], "workers": [],
+         "serve_n": 0, "heartbeat_404": False}
+TASK = {"id": "task-CLOUD1", "timestamp": "2026-09-03T00:00:00Z",
+        "task": "hello cloud seat", "source": "remote-gateway",
+        "channel_id": "!room:example.org", "user_id": "@qingyun:example.org",
+        "access_tier": "owner", "priority": "normal"}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _json(self, code: int, body: dict) -> None:
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length") or 0)
+        return json.loads(self.rfile.read(n).decode()) if n else {}
+
+    def do_GET(self):
+        if self.path.startswith("/v1/tasks"):
+            STATE["gets"].append(self.path)
+            served = STATE["serve_n"] > 0
+            if served:
+                STATE["serve_n"] -= 1
+            self._json(200, {"tasks": [TASK] if served else []})
+            return
+        self.send_response(404); self.end_headers()
+
+    def do_POST(self):
+        if self.path == "/v1/results":
+            STATE["results"].append(self._body()); self._json(200, {"ok": True}); return
+        if self.path.startswith("/v1/tasks/") and self.path.endswith("/ack"):
+            STATE["acks"].append((self.path, self._body())); self._json(200, {}); return
+        if self.path == "/v1/heartbeat":
+            if STATE["heartbeat_404"]:
+                self.send_response(404); self.end_headers(); return
+            STATE["heartbeats"].append(self._body()); self._json(200, {}); return
+        if self.path == "/v1/workers":
+            STATE["workers"].append(self._body()); self._json(200, {}); return
+        self.send_response(404); self.end_headers()
+
+
+def _load(name: str, ws: Path, port: int, **seat: str):
+    """Fresh module under a fresh env: the client reads its seat at import."""
+    for k in SEAT_ENV:
+        os.environ.pop(k, None)
+    os.environ.update(seat)
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+    os.environ["SUTANDO_WORKSPACE"] = str(ws)
+    Path(ws, ".notes-migrated").touch()
+    Path(ws, ".build_log-migrated").touch()
+    os.environ["REMOTE_TASK_URL"] = f"http://127.0.0.1:{port}"
+    os.environ["REMOTE_TASK_TOKEN"] = "testtoken"
+    os.environ["REMOTE_TASK_PROVIDER"] = "remote-gateway"
+    os.environ["REMOTE_TASK_TIER"] = "owner"
+    os.environ["REMOTE_TASK_POLL_WAIT"] = "0"
+    os.environ["REMOTE_OUTBOUND_WATCHER"] = "off"
+    os.environ.pop("GATEWAY_INSTANCE", None)
+    # Hermetic: the tier map resolves from the config dir — never the host's.
+    os.environ.pop("AG2_DEVICE_ENV", None)
+    os.environ["CLAUDE_CONFIG_DIR"] = str(ws / "cfg")
+    spec = importlib.util.spec_from_file_location(name, LOADER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _pool_state_absent(ws: Path) -> bool:
+    st = ws / "state"
+    return (not (st / "pool").exists() and not (st / "pool-status.json").exists()
+            and not (st / "cores").exists())
+
+
+def main() -> int:
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    root = Path(tempfile.mkdtemp(prefix="wqc-test-"))
+
+    # ── 1. seat identity from env ───────────────────────────────────────────
+    print("1. seat identity")
+    ws1 = root / "ws1"; ws1.mkdir()
+    home = _load("wqc_home", ws1, port)
+    check((home.WORKER_ID, home.WORKER_LOCATION) == ("home", "local"),
+          "no seat env → the home seat, local")
+    pool = _load("wqc_pool", ws1, port, SUTANDO_CORE_ID="2")
+    check((pool.WORKER_ID, pool.WORKER_LOCATION) == ("worker-2", "local"),
+          "SUTANDO_CORE_ID=2 derives worker-2 (pool seat convention)")
+    named = _load("wqc_named", ws1, port, SUTANDO_CORE_ID="2",
+                  SUTANDO_WORKER_ID="worker-9", SUTANDO_WORKER_LOCATION=" Cloud ")
+    check((named.WORKER_ID, named.WORKER_LOCATION) == ("worker-9", "cloud"),
+          "SUTANDO_WORKER_ID wins over the seat number; location normalises to cloud")
+    typo = _load("wqc_typo", ws1, port, SUTANDO_WORKER_LOCATION="remote")
+    check(typo.WORKER_LOCATION == "local",
+          "an unknown location degrades to local (today's path), never to cloud")
+    try:
+        _load("wqc_bad", ws1, port, SUTANDO_WORKER_ID="../evil")
+        check(False, "a path-shaped SUTANDO_WORKER_ID refuses at import")
+    except SystemExit:
+        check(True, "a path-shaped SUTANDO_WORKER_ID refuses at import")
+    check(home._SEAT_QS == "&worker=home" and named._SEAT_QS == "&worker=worker-9",
+          "the poll query suffix is &worker=<seat> (bare id for the legal charset)")
+
+    # ── 2. heartbeat + workers snapshot carry the seat ──────────────────────
+    print("2. heartbeat / workers snapshot payloads")
+    STATE["heartbeats"].clear()
+    check(home._post_heartbeat({"task-A", "task-B"}, force=True)
+          and STATE["heartbeats"][-1].get("worker_id") == "home"
+          and STATE["heartbeats"][-1].get("location") == "local",
+          "heartbeat carries worker_id=home location=local for the home seat")
+    hb = STATE["heartbeats"][-1]
+    check(hb.get("client") == "sutando-gateway-client" and hb.get("protocol_version") == 1
+          and hb.get("provider") == "remote-gateway" and hb.get("tier") == "owner"
+          and hb.get("inflight") == 2
+          and hb.get("capabilities") == ["task-ack", "heartbeat", "result-skip-markers",
+                                         "core-status", "team-collaborator"],
+          "every pre-existing heartbeat field is byte-identical (additive change only)")
+    print(f"     heartbeat payload (home): {json.dumps(hb, sort_keys=True)}")
+    named._last_heartbeat_at = 0.0
+    named._post_heartbeat(set(), force=True)
+    check(STATE["heartbeats"][-1].get("worker_id") == "worker-9"
+          and STATE["heartbeats"][-1].get("location") == "cloud",
+          "heartbeat carries the configured seat + cloud location")
+    print(f"     heartbeat payload (cloud): {json.dumps(STATE['heartbeats'][-1], sort_keys=True)}")
+    snap = ws1 / "state" / "pool-status.json"
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    blob = {"ts": 1, "writer": "pool-lead", "live_cores": ["core-1"], "bindings": {}}
+    snap.write_text(json.dumps(blob))
+    check(named._maybe_push_workers_snapshot() is True
+          and STATE["workers"][-1] == {**blob, "worker_id": "worker-9", "location": "cloud"},
+          "workers-snapshot push stamps worker_id/location beside the lead's fields")
+    snap.unlink()
+
+    # ── 3. legacy broker: 404 heartbeat, ignored worker= ─────────────────────
+    print("3. legacy broker")
+    STATE["heartbeat_404"] = True
+    legacy = _load("wqc_legacy", ws1, port)
+    legacy._last_heartbeat_at = 0.0
+    check(legacy._post_heartbeat(set(), force=True) is False and legacy._heartbeat_disabled,
+          "heartbeat 404 still disables heartbeat quietly — the seat fields change nothing")
+    STATE["heartbeat_404"] = False
+
+    # ── 4. cloud seat, no pool state on this host: full cycle via main() ────
+    print("4. cloud seat end-to-end (no state/pool*, no state/cores)")
+    ws4 = root / "ws4"; ws4.mkdir()
+    cloud = _load("wqc_cloud", ws4, port, SUTANDO_WORKER_ID="cloud-1",
+                  SUTANDO_WORKER_LOCATION="cloud")
+    check(_pool_state_absent(ws4), "precondition: no pool-status.json / pool / cores")
+    check(cloud._worker_of("task-CLOUD1") == "", "no state/cores → attribution empty, no error")
+    check(cloud._maybe_push_workers_snapshot() is False, "no pool snapshot → push is a no-op")
+    for k in ("gets", "acks", "results", "heartbeats"):
+        STATE[k].clear()
+    STATE["serve_n"] = 2  # poll 1 serves the task; poll 2 RE-DELIVERS it (lease re-front)
+    real_hb = cloud._post_heartbeat
+    calls = {"n": 0}
+
+    def _bounded(inflight_arg):
+        # Heartbeats bracket each iteration: 1,2 = iteration 1; 3,4 = iteration 2;
+        # 5 = top of iteration 3 → stop. Two full polls ran by then.
+        calls["n"] += 1
+        if calls["n"] >= 5:
+            raise KeyboardInterrupt
+        return real_hb(inflight_arg, force=True)
+
+    cloud._post_heartbeat = _bounded
+    try:
+        cloud.main()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        cloud._post_heartbeat = real_hb
+        cloud._OUTBOUND_STOP.set(); cloud._OUTBOUND_WAKE.set()
+    check(calls["n"] == 5, "main: two full loop iterations ran")
+    check(len(STATE["gets"]) == 2
+          and all(g == "/v1/tasks?wait=0&worker=cloud-1" for g in STATE["gets"]),
+          f"poll URL carries the seat: {STATE['gets'][:1]}")
+    check(all(h.get("worker_id") == "cloud-1" and h.get("location") == "cloud"
+              for h in STATE["heartbeats"]) and STATE["heartbeats"],
+          "every heartbeat from the loop names the cloud seat")
+    tfile = cloud.TASKS_DIR / "task-CLOUD1.txt"
+    tfiles = sorted(p.name for p in cloud.TASKS_DIR.glob("task-CLOUD1*"))
+    check(tfiles == ["task-CLOUD1.txt"], f"exactly one task file after redelivery: {tfiles}")
+    body = tfile.read_text() if tfile.exists() else ""
+    check("task: hello cloud seat" in body and body.startswith("id: task-CLOUD1"),
+          "task serialised into this seat's own tasks/ (same schema as every bridge)")
+    check(cloud._load_inflight() == {"task-CLOUD1"},
+          "persisted inflight holds the id once, not twice")
+    check([a[0] for a in STATE["acks"]] == ["/v1/tasks/task-CLOUD1/ack"] * 2,
+          "re-delivered id is re-acked (broker learns the seat still holds it)")
+    check(STATE["results"] == [], "nothing answered yet — the seat has not produced a result")
+    check(_pool_state_absent(ws4), "the cycle created no pool-status.json / pool / cores")
+
+    # Re-delivery against the other live shapes: the seat has taken the file.
+    claimed = cloud.TASKS_DIR / "task-CLOUD1.claimed-cloud-1.txt"
+    tfile.rename(claimed)
+    check(cloud._write_task(dict(TASK)) == "task-CLOUD1"
+          and not tfile.exists() and claimed.exists(),
+          "redelivery while CLAIMED: id returned, no second task file")
+    assigned = cloud.TASKS_DIR / "task-CLOUD1.assigned-cloud-1.txt"
+    claimed.rename(assigned)
+    check(cloud._write_task(dict(TASK)) == "task-CLOUD1"
+          and not tfile.exists() and assigned.exists(),
+          "redelivery while ASSIGNED: id returned, no second task file")
+    assigned.rename(tfile)
+    check(sorted(p.name for p in cloud.TASKS_DIR.glob("task-CLOUD1*")) == ["task-CLOUD1.txt"],
+          "task file content untouched across three redeliveries")
+
+    # The seat answers → one POST, one archive, inflight cleared.
+    cloud.RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    (cloud.RESULTS_DIR / "task-CLOUD1.txt").write_text("answer from the cloud seat\n")
+    inflight = cloud._load_inflight()
+    cloud._post_ready_results(inflight)
+    check(len(STATE["results"]) == 1
+          and STATE["results"][0].get("id") == "task-CLOUD1"
+          and STATE["results"][0].get("body") == "answer from the cloud seat"
+          and "metadata" not in STATE["results"][0],
+          "result POSTed once with the broker id; no pool attribution without state/cores")
+    print(f"     result payload: {json.dumps(STATE['results'][0], sort_keys=True)}")
+    check(not (cloud.RESULTS_DIR / "task-CLOUD1.txt").exists()
+          and (cloud.TASKS_DIR / "archive" / "task-CLOUD1.txt").exists(),
+          "result + task archived after delivery")
+    check(cloud._load_inflight() == set(), "inflight empty after delivery")
+    check(_pool_state_absent(ws4), "post-delivery: still no pool state on this host")
+
+    srv.shutdown()
+    if FAILS:
+        print(f"\nFAILED ({len(FAILS)})"); return 1
+    print("\nPASS — worker-aware queue client: all checks green"); return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -426,12 +426,13 @@ def main() -> int:
     for k in ("acks", "results"):
         STATE[k].clear()
 
-    # keweichen: the fallback must RETIRE, not merely stop logging. One stamped
-    # pin proves the broker speaks source, so id-only is no longer control.
-    seat6._pin_stamp_seen = False
+    # keweichen: a process-memory latch is NOT a bound -- it resets on restart and
+    # the id-only path destroys ordinary work again. The stamp is the only bound.
     check(seat6._consume_worker_pin(
-        {"id": "worker-pin-1756000000002-feedface", "task": "legacy pin"}) is True,
-          "before any stamp, a source-less pin still rides the legacy id-only path")
+        {"id": "worker-pin-1756000000002-feedface", "task": "legacy pin"}) is False,
+          "a source-less pin is NEVER control, with or without a prior stamp")
+    check(STATE["acks"] == [] and STATE["results"] == [],
+          f"and it was neither acked nor closed: {STATE['acks']} {STATE['results']}")
     for k in ("acks", "results"):
         STATE[k].clear()
     check(seat6._consume_worker_pin(dict(exact, source="worker-picker")) is True,
@@ -440,10 +441,9 @@ def main() -> int:
         STATE[k].clear()
     check(seat6._consume_worker_pin(
         {"id": "worker-pin-1756000000003-0badcafe", "task": "an ordinary ask"}) is False,
-          "AFTER the stamp, a source-less exact-grammar task is USER WORK, not control")
+          "and a source-less exact-grammar task is STILL user work, not control")
     check(STATE["acks"] == [] and STATE["results"] == [],
           f"and it was neither acked nor closed: {STATE['acks']} {STATE['results']}")
-    seat6._pin_stamp_seen = False
     for k in ("acks", "results"):
         STATE[k].clear()
 
@@ -482,7 +482,8 @@ def main() -> int:
     real_queue = seat7._queue_review_control_result
     seat7._queue_review_control_result = _explode
     try:
-        seat7._consume_worker_pin({"id": "worker-pin-777-beef", "task": "pin"})
+        seat7._consume_worker_pin({"id": "worker-pin-777-beef", "task": "pin",
+                                   "source": "worker-picker"})
     except RuntimeError:
         pass
     finally:
@@ -494,7 +495,8 @@ def main() -> int:
 
     for k in ("acks", "results"):
         STATE[k].clear()
-    check(seat7._consume_worker_pin({"id": "worker-pin-778-cafe", "task": "pin"}) is True,
+    check(seat7._consume_worker_pin({"id": "worker-pin-778-cafe", "task": "pin",
+                                     "source": "worker-picker"}) is True,
           "the normal path still consumes the pin")
     check(STATE["acks"] == [("/v1/tasks/worker-pin-778-cafe/ack",
                              {"id": "worker-pin-778-cafe"})],
@@ -504,6 +506,26 @@ def main() -> int:
     seat7._retry_review_control_results()
     check(STATE["results"] == [{"id": "worker-pin-778-cafe", "body": "[no-send]"}],
           f"a second drain does not re-post the close: {STATE['results']}")
+
+    # keweichen: a process-memory latch resets on restart, so the id-only path came
+    # back and destroyed ordinary work again. Reload over the SAME workspace to prove it.
+    seat7b = _load("wqc_pin_restart", ws7, port, SUTANDO_WORKER_ID="cloud-1",
+                   SUTANDO_WORKER_LOCATION="cloud")
+    for k in ("acks", "results"):
+        STATE[k].clear()
+    check(seat7b._consume_worker_pin({"id": "worker-pin-901-cafebabe",
+                                      "source": "worker-picker", "task": "pin"}) is True,
+          "restart control: a STAMPED pin is still consumed by the fresh module")
+    for k in ("acks", "results"):
+        STATE[k].clear()
+    ordinary = {"id": "worker-pin-902-d15ea5e0", "task": "Please inspect the failing build",
+                "timestamp": "2026-09-06T00:00:01Z"}
+    check(seat7b._WORKER_PIN_RE.fullmatch(ordinary["id"]) is not None,
+          "PRECONDITION: the ordinary id really matches the pin grammar, or this is vacuous")
+    check(seat7b._consume_worker_pin(ordinary) is False,
+          "AFTER a restart, a source-less exact-grammar task is user work, not control")
+    check(STATE["acks"] == [] and STATE["results"] == [],
+          f"restart: it was neither acked nor closed: {STATE['acks']} {STATE['results']}")
 
     # A relay that 422s un-advertised keys must still receive the documented
     # {id, body}; before the fix `metadata` rode every result and was refused.
@@ -605,7 +627,7 @@ def main() -> int:
 
     seat10._retry_review_control_results = _die
     try:
-        seat10._consume_worker_pin({"id": PIN, "task": "pin"})
+        seat10._consume_worker_pin({"id": PIN, "task": "pin", "source": "worker-picker"})
     except RuntimeError:
         pass
     check(STATE["acks"] == [(f"/v1/tasks/{PIN}/ack", {"id": PIN})],
@@ -673,7 +695,8 @@ def main() -> int:
                 SUTANDO_WORKER_ID="cloud-3", SUTANDO_WORKER_LOCATION="cloud")
     PIN12 = "worker-pin-424-b0b0"
     STATE["results_decline"] = True
-    check(d12._consume_worker_pin({"id": PIN12, "task": "pin"}) is True,
+    check(d12._consume_worker_pin({"id": PIN12, "task": "pin",
+                                   "source": "worker-picker"}) is True,
           "the pin is consumed")
     check(len(STATE["results"]) == 1,
           f"one close attempt was made: {STATE['results']}")

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -87,7 +87,10 @@ class Handler(BaseHTTPRequestHandler):
             STATE["acks"].append((self.path, self._body())); self._json(200, {}); return
         if self.path == "/v1/heartbeat":
             if STATE["heartbeat_404"]:
-                self.send_response(404); self.end_headers(); return
+                # True keeps the historical 404; an int lets a case pick 405.
+                _hb = STATE["heartbeat_404"]
+                self.send_response(404 if _hb is True else int(_hb))
+                self.end_headers(); return
             STATE["heartbeats"].append(self._body())
             caps = {"capabilities": ["worker-metadata"]} if STATE["advertise"] else {}
             self._json(200, caps); return
@@ -436,6 +439,42 @@ def main() -> int:
           and STATE["results"][0].get("metadata")
           == {"worker_id": legacy8.WORKER_ID, "location": legacy8.WORKER_LOCATION},
           f"control: attribution rides again once advertised: {STATE['results']}")
+    STATE["strict"] = False
+
+    # A broker that advertised and is then rolled back must not leave the
+    # extension latched: 404/405 disables heartbeat, so no reply can revoke it.
+    print("\n9. advertised -> heartbeat 404/405 -> extension REVOKED, not latched")
+    for _code in (404, 405):
+        for k in ("gets", "acks", "results", "heartbeats", "other"):
+            STATE[k].clear()
+        STATE["rejected"].clear()
+        STATE["heartbeat_404"] = False
+        STATE["advertise"] = True
+        STATE["strict"] = True
+        ws9 = root / f"ws9_{_code}"; ws9.mkdir()
+        d9 = _load(f"down{_code}", ws9, port,
+                   SUTANDO_WORKER_ID="home-1", SUTANDO_WORKER_LOCATION="home")
+        check(d9._post_heartbeat(set(), force=True) is True
+              and d9._broker_worker_metadata is True,
+              f"[{_code}] a modern broker advertises -> extension ON")
+        # the broker is rolled back / re-routed: heartbeat now answers 404/405
+        STATE["heartbeat_404"] = _code
+        STATE["advertise"] = False
+        check(d9._post_heartbeat(set(), force=True) is False and d9._heartbeat_disabled,
+              f"[{_code}] heartbeat {_code} disables heartbeating for the process")
+        check(d9._broker_worker_metadata is False,
+              f"[{_code}] extension REVOKED on definitive absence (not latched on)")
+        d9.RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        (d9.RESULTS_DIR / f"task-DOWN{_code}.txt").write_text("answer after downgrade\n")
+        d9._save_inflight({f"task-DOWN{_code}"})
+        d9._post_ready_results(d9._load_inflight())
+        check(STATE["rejected"] == [],
+              f"[{_code}] the strict relay refused nothing: {STATE['rejected']}")
+        check(len(STATE["results"]) == 1
+              and sorted(STATE["results"][0]) == ["body", "id"],
+              f"[{_code}] wire-keys after downgrade are exactly the envelope: "
+              f"{sorted(STATE['results'][0]) if STATE['results'] else None}")
+    STATE["heartbeat_404"] = False
     STATE["strict"] = False
 
     srv.shutdown()

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -257,8 +257,10 @@ def main() -> int:
     check(len(STATE["results"]) == 1
           and STATE["results"][0].get("id") == "task-CLOUD1"
           and STATE["results"][0].get("body") == "answer from the cloud seat"
-          and "metadata" not in STATE["results"][0],
-          "result POSTed once with the broker id; no pool attribution without state/cores")
+          and STATE["results"][0].get("metadata")
+          == {"worker_id": "cloud-1", "location": "cloud"},
+          "result POSTed once with the broker id; attributed to the cloud seat itself "
+          "(no done-flag on this host → the seat's own WORKER_ID + location)")
     print(f"     result payload: {json.dumps(STATE['results'][0], sort_keys=True)}")
     check(not (cloud.RESULTS_DIR / "task-CLOUD1.txt").exists()
           and (cloud.TASKS_DIR / "archive" / "task-CLOUD1.txt").exists(),

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -755,6 +755,68 @@ def main() -> int:
           "and it REVOKES both capabilities — absence of a reply is absence of evidence")
     STATE["strict_wire"] = False
 
+
+    # ---- 15. two-instance isolation of the durable control journal -----------
+    # keweichen + Codex both blocked here: one workspace, two GATEWAY_INSTANCEs.
+    def _load_inst(name: str, ws: Path, port: int, inst: str):
+        for k in SEAT_ENV:
+            os.environ.pop(k, None)
+        os.environ["SUTANDO_TEST_MODE"] = "1"
+        os.environ["SUTANDO_WORKSPACE"] = str(ws)
+        Path(ws, ".notes-migrated").touch(); Path(ws, ".build_log-migrated").touch()
+        os.environ["REMOTE_TASK_URL"] = f"http://127.0.0.1:{port}"
+        os.environ["REMOTE_TASK_TOKEN"] = "testtoken"
+        os.environ["REMOTE_TASK_PROVIDER"] = "remote-gateway"
+        os.environ["REMOTE_TASK_TIER"] = "owner"
+        os.environ["REMOTE_TASK_POLL_WAIT"] = "0"
+        os.environ["REMOTE_OUTBOUND_WATCHER"] = "off"
+        os.environ.pop("AG2_DEVICE_ENV", None)
+        os.environ["CLAUDE_CONFIG_DIR"] = str(ws / "cfg")
+        os.environ["GATEWAY_INSTANCE"] = inst
+        spec = importlib.util.spec_from_file_location(name, LOADER)
+        mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+        os.environ.pop("GATEWAY_INSTANCE", None)
+        return mod
+
+    ws15 = root / "ws15"; ws15.mkdir()
+    prod = _load_inst("d15p", ws15, port, "prod")
+    dev = _load_inst("d15d", ws15, port, "dev")
+    check(prod._WITHHELD_CONTROL_DIR != dev._WITHHELD_CONTROL_DIR,
+          f"the two instances resolve DIFFERENT control dirs: "
+          f"{prod._WITHHELD_CONTROL_DIR.name} vs {dev._WITHHELD_CONTROL_DIR.name}")
+    check(prod._WITHHELD_DM_CACHE != dev._WITHHELD_DM_CACHE,
+          "the withheld-DM cache is per-instance too (same defect, unreported)")
+
+    tid15 = "worker-pin-909-d0d0"
+    prod._queue_review_control_result({"id": tid15})
+    check(prod._control_result_path(tid15).is_file(), "A journalled its close intent")
+    check(not dev._control_result_path(tid15).is_file(),
+          "B cannot SEE A's record — the whole point of the namespacing")
+
+    STATE["results"].clear()
+    dev._retry_review_control_results()
+    check(STATE["results"] == [],
+          f"B's drain posts nothing for A's record: {STATE['results']}")
+    check(prod._control_result_path(tid15).is_file(),
+          "and B did NOT delete it — this is the data-integrity half")
+
+    prod._retry_review_control_results()
+    check(len(STATE["results"]) == 1 and STATE["results"][0].get("id") == tid15,
+          f"A closes its own record exactly once: {STATE['results']}")
+    check(not prod._control_result_path(tid15).is_file(), "A's journal is cleared after its close")
+    STATE["results"].clear()
+    prod._retry_review_control_results()
+    check(STATE["results"] == [], "and a second drain by A posts nothing (exactly once, not at-least-once)")
+
+    legacy = ws15 / "state" / "withheld-review-control-results"
+    legacy.mkdir(parents=True, exist_ok=True)
+    (legacy / "orphan.json").write_text(json.dumps({"id": "task-orphan", "body": "[no-send]"}))
+    STATE["results"].clear()
+    prod._retry_review_control_results()
+    check(STATE["results"] == [] and (legacy / "orphan.json").is_file(),
+          "a pre-instance leftover is NEITHER adopted NOR deleted — ownership is unknown")
+    check(prod._warn_legacy_control_records() == 1, "but it IS counted, so it cannot rot silently")
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -43,7 +43,9 @@ STATE = {"gets": [], "acks": [], "results": [], "heartbeats": [], "workers": [],
          "other": [], "serve_n": 0, "heartbeat_404": False, "task": None,
          # A modern broker advertises the extension; `strict` models a legacy
          # relay that REJECTS unknown result keys instead of ignoring them.
-         "advertise": True, "strict": False, "rejected": []}
+         "advertise": True, "strict": False, "rejected": [],
+         # a 200 whose body is not JSON, and a 200 that explicitly declines
+         "heartbeat_garbage": False, "results_decline": False}
 TASK = {"id": "task-CLOUD1", "timestamp": "2026-09-03T00:00:00Z",
         "task": "hello cloud seat", "source": "remote-gateway",
         "channel_id": "!room:example.org", "user_id": "@qingyun:example.org",
@@ -82,7 +84,10 @@ class Handler(BaseHTTPRequestHandler):
             if STATE["strict"] and set(body) - allowed:
                 STATE["rejected"].append(sorted(body))
                 self._json(422, {"error": "unknown field"}); return
-            STATE["results"].append(body); self._json(200, {"ok": True}); return
+            STATE["results"].append(body)
+            if STATE["results_decline"]:
+                self._json(200, {"ok": False, "error": "declined"}); return
+            self._json(200, {"ok": True}); return
         if self.path.startswith("/v1/tasks/") and self.path.endswith("/ack"):
             STATE["acks"].append((self.path, self._body())); self._json(200, {}); return
         if self.path == "/v1/heartbeat":
@@ -92,6 +97,11 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_response(404 if _hb is True else int(_hb))
                 self.end_headers(); return
             STATE["heartbeats"].append(self._body())
+            if STATE["heartbeat_garbage"]:
+                raw = b"<html>not json</html>"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers(); self.wfile.write(raw); return
             caps = {"capabilities": ["worker-metadata"]} if STATE["advertise"] else {}
             self._json(200, caps); return
         if self.path == "/v1/workers":
@@ -518,6 +528,62 @@ def main() -> int:
     seat10b._retry_review_control_results()
     check(STATE["results"] == [{"id": PIN, "body": "[no-send]"}],
           f"a second drain after restart posts nothing more: {STATE['results']}")
+
+    # A 200 that cannot be decoded never reaches _note_broker_capabilities, so
+    # there is no fresh advertisement and the extension must not stay latched.
+    print("\n11. undecodable 200 heartbeat -> extension revoked, not latched")
+    for k in ("gets", "acks", "results", "heartbeats", "other"):
+        STATE[k].clear()
+    STATE["rejected"].clear(); STATE["advertise"] = True
+    STATE["heartbeat_404"] = False; STATE["heartbeat_garbage"] = False
+    STATE["strict"] = True
+    ws11 = root / "ws11"; ws11.mkdir()
+    d11 = _load("garbage11", ws11, port,
+                SUTANDO_WORKER_ID="home-1", SUTANDO_WORKER_LOCATION="home")
+    check(d11._post_heartbeat(set(), force=True) is True
+          and d11._broker_worker_metadata is True,
+          "advertising broker -> extension ON")
+    STATE["heartbeat_garbage"] = True
+    STATE["advertise"] = False
+    check(d11._post_heartbeat(set(), force=True) is False,
+          "an undecodable 200 does not raise out of the heartbeat")
+    check(d11._broker_worker_metadata is False,
+          "extension REVOKED after an undecodable reply (not latched on)")
+    d11.RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    (d11.RESULTS_DIR / "task-GARBAGE.txt").write_text("answer after a bad reply\n")
+    d11._save_inflight({"task-GARBAGE"})
+    d11._post_ready_results(d11._load_inflight())
+    check(STATE["rejected"] == [],
+          f"the strict relay refused nothing: {STATE['rejected']}")
+    check(len(STATE["results"]) == 1 and sorted(STATE["results"][0]) == ["body", "id"],
+          f"wire-keys stay the documented envelope: "
+          f"{sorted(STATE['results'][0]) if STATE['results'] else None}")
+    STATE["heartbeat_garbage"] = False; STATE["strict"] = False
+
+    # A declining 2xx means the lease did NOT close; deleting the journal there
+    # strands it with nothing on disk to retry from.
+    print("\n12. a declining 2xx keeps the pin-close journal for the next drain")
+    for k in ("gets", "acks", "results", "heartbeats", "other"):
+        STATE[k].clear()
+    STATE["advertise"] = True
+    ws12 = root / "ws12"; ws12.mkdir()
+    d12 = _load("decline12", ws12, port,
+                SUTANDO_WORKER_ID="cloud-3", SUTANDO_WORKER_LOCATION="cloud")
+    PIN12 = "worker-pin-424-b0b0"
+    STATE["results_decline"] = True
+    check(d12._consume_worker_pin({"id": PIN12, "task": "pin"}) is True,
+          "the pin is consumed")
+    check(len(STATE["results"]) == 1,
+          f"one close attempt was made: {STATE['results']}")
+    check(d12._control_result_path(PIN12).is_file(),
+          "the broker DECLINED, so the journal is KEPT for a later drain")
+    STATE["results_decline"] = False
+    STATE["results"].clear()
+    d12._retry_review_control_results()
+    check(STATE["results"] == [{"id": PIN12, "body": "[no-send]"}],
+          f"the next drain closes it exactly once: {STATE['results']}")
+    check(not d12._control_result_path(PIN12).is_file(),
+          "and an ACCEPTED close does consume the journal")
 
     srv.shutdown()
     if FAILS:

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -317,6 +317,32 @@ def main() -> int:
     check(target in logs, f"log line matches the live-run target: {[l for l in logs if 'pin' in l]}")
     print(f"     result payload: {json.dumps(STATE['results'][0], sort_keys=True)}")
 
+    # ── 6. pin classifier: full grammar, and ONE normalized id ──────────────
+    print("6. pin classifier rejects look-alikes and normalizes the id once")
+    ws6 = root / "ws6"; ws6.mkdir()
+    seat6 = _load("wqc_pin_edge", ws6, port, SUTANDO_WORKER_ID="cloud-1",
+                  SUTANDO_WORKER_LOCATION="cloud")
+    for k in ("gets", "acks", "results", "heartbeats", "other"):
+        STATE[k].clear()
+    look_alike = {"id": "worker-pin-user-message", "task": "an ordinary ask",
+                  "timestamp": "2026-09-03T00:00:01Z", "source": "remote-gateway"}
+    check(seat6._consume_worker_pin(look_alike) is False,
+          "worker-pin-user-message is ordinary work, not a control message")
+    check(STATE["acks"] == [] and STATE["results"] == [],
+          f"the look-alike was neither acked nor closed: {STATE['acks']} {STATE['results']}")
+    for k in ("acks", "results"):
+        STATE[k].clear()
+    check(seat6._consume_worker_pin({"id": " worker-pin-123-abc ", "task": "pin"}) is True,
+          "a padded pin id is still a pin")
+    check(STATE["acks"] == [("/v1/tasks/worker-pin-123-abc/ack",
+                             {"id": "worker-pin-123-abc"})],
+          f"ack uses the normalized id: {STATE['acks']}")
+    check(STATE["results"] == [{"id": "worker-pin-123-abc", "body": "[no-send]"}],
+          f"lease close uses the normalized id: {STATE['results']}")
+    left = sorted(p.name for p in
+                  (seat6._STATE / "withheld-review-control-results").glob("*.json"))
+    check(left == [], f"no journal file stranded under a raw-id path: {left}")
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -784,8 +784,9 @@ def main() -> int:
     check(prod._WITHHELD_CONTROL_DIR != dev._WITHHELD_CONTROL_DIR,
           f"the two instances resolve DIFFERENT control dirs: "
           f"{prod._WITHHELD_CONTROL_DIR.name} vs {dev._WITHHELD_CONTROL_DIR.name}")
-    check(prod._WITHHELD_DM_CACHE != dev._WITHHELD_DM_CACHE,
-          "the withheld-DM cache is per-instance too (same defect, unreported)")
+    check(prod._WITHHELD_DM_CACHE == dev._WITHHELD_DM_CACHE,
+          "the review-DM cache stays SHARED: it is owner-owned, already keyed by owner on "
+          "read, and a per-instance miss would create a duplicate owner DM room")
 
     tid15 = "worker-pin-909-d0d0"
     prod._queue_review_control_result({"id": tid15})

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -343,6 +343,43 @@ def main() -> int:
                   (seat6._STATE / "withheld-review-control-results").glob("*.json"))
     check(left == [], f"no journal file stranded under a raw-id path: {left}")
 
+    # ── 7. journal-before-ACK: a failed durable write must not leave an ack ──
+    print("7. the close intent is durable before the ack")
+    ws7 = root / "ws7"; ws7.mkdir()
+    seat7 = _load("wqc_pin_durable", ws7, port, SUTANDO_WORKER_ID="cloud-1",
+                  SUTANDO_WORKER_LOCATION="cloud")
+    for k in ("gets", "acks", "results", "heartbeats", "other"):
+        STATE[k].clear()
+
+    def _explode(*_a, **_k):
+        raise RuntimeError("process loss at the durability boundary")
+
+    real_queue = seat7._queue_review_control_result
+    seat7._queue_review_control_result = _explode
+    try:
+        seat7._consume_worker_pin({"id": "worker-pin-777-beef", "task": "pin"})
+    except RuntimeError:
+        pass
+    finally:
+        seat7._queue_review_control_result = real_queue
+    check(STATE["acks"] == [],
+          f"no ack when the close intent could not be persisted: {STATE['acks']}")
+    check(not seat7._control_result_path("worker-pin-777-beef").is_file(),
+          "and no journal file either — the pin stays redeliverable")
+
+    for k in ("acks", "results"):
+        STATE[k].clear()
+    check(seat7._consume_worker_pin({"id": "worker-pin-778-cafe", "task": "pin"}) is True,
+          "the normal path still consumes the pin")
+    check(STATE["acks"] == [("/v1/tasks/worker-pin-778-cafe/ack",
+                             {"id": "worker-pin-778-cafe"})],
+          f"normal path acks once: {STATE['acks']}")
+    check(STATE["results"] == [{"id": "worker-pin-778-cafe", "body": "[no-send]"}],
+          f"normal path closes the lease exactly once: {STATE['results']}")
+    seat7._retry_review_control_results()
+    check(STATE["results"] == [{"id": "worker-pin-778-cafe", "body": "[no-send]"}],
+          f"a second drain does not re-post the close: {STATE['results']}")
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -845,6 +845,22 @@ def main() -> int:
           "a pre-instance leftover is NEITHER adopted NOR deleted — ownership is unknown")
     check(prod._warn_legacy_control_records() == 1, "but it IS counted, so it cannot rot silently")
 
+    # The check above uses a NAMED instance, which is exactly why it passed while
+    # the DEFAULT lane drained the rows it disclaims. Migration control:
+    default = _load_inst("d15n", ws15, port, "")
+    check(default._WITHHELD_CONTROL_DIR != legacy,
+          f"the DEFAULT lane owns a distinct dir, not the legacy path: "
+          f"{default._WITHHELD_CONTROL_DIR.name} vs {legacy.name}")
+    check(default._WITHHELD_CONTROL_DIR != prod._WITHHELD_CONTROL_DIR,
+          "default and named lanes stay isolated from each other too")
+    STATE["results"].clear()
+    default._retry_review_control_results()
+    check(STATE["results"] == [] and (legacy / "orphan.json").is_file(),
+          f"the DEFAULT lane neither adopts nor deletes the leftover it disclaims: "
+          f"{STATE['results']} exists={(legacy / 'orphan.json').is_file()}")
+    check(default._warn_legacy_control_records() == 1,
+          "and the default lane's warning is TRUE — it counts a row it really does not touch")
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -354,8 +354,10 @@ def main() -> int:
                  SUTANDO_WORKER_LOCATION="cloud")
     for k in ("gets", "acks", "results", "heartbeats", "other"):
         STATE[k].clear()
+    # The live broker stamps worker-picker on the pin enqueue; the fixture
+    # said "remote-gateway", which no real pin task carries.
     STATE["task"] = {"id": "worker-pin-123-abc", "timestamp": "2026-09-03T00:00:01Z",
-                     "task": "pin cloud-1", "source": "remote-gateway",
+                     "task": "pin cloud-1", "source": "worker-picker",
                      "channel_id": "!room:example.org", "user_id": "@broker:example.org",
                      "access_tier": "owner", "priority": "normal"}
     STATE["serve_n"] = 1
@@ -406,6 +408,31 @@ def main() -> int:
           "worker-pin-user-message is ordinary work, not a control message")
     check(STATE["acks"] == [] and STATE["results"] == [],
           f"the look-alike was neither acked nor closed: {STATE['acks']} {STATE['results']}")
+    for k in ("acks", "results"):
+        STATE[k].clear()
+
+    # The control above cannot fail: its id never matched the grammar. The
+    # hazard is an ordinary task whose id matches EXACTLY.
+    exact = {"id": "worker-pin-1756000000000-deadbeef", "task": "an ordinary ask",
+             "timestamp": "2026-09-03T00:00:01Z", "source": "ag2space"}
+    check(seat6._WORKER_PIN_RE.fullmatch(exact["id"]) is not None,
+          "PRECONDITION: the ordinary task's id really does match the pin grammar "
+          "(without this the control is vacuous, exactly like the one above)")
+    check(seat6._consume_worker_pin(exact) is False,
+          "an exact-grammar id from an ordinary source is USER WORK, not control")
+    check(STATE["acks"] == [] and STATE["results"] == [],
+          f"the exact-grammar user task was neither acked nor closed: "
+          f"{STATE['acks']} {STATE['results']}")
+    for k in ("acks", "results"):
+        STATE[k].clear()
+
+    # Same id, broker's own stamp -> control. Pins the discriminator as the
+    # SOURCE, not the id: flip one field and the verdict flips with it.
+    stamped = dict(exact, source="worker-picker")
+    check(seat6._consume_worker_pin(stamped) is True,
+          "the same id WITH the broker's worker-picker stamp is control")
+    check(STATE["results"] == [{"id": exact["id"], "body": "[no-send]"}],
+          f"the stamped control was closed no-send: {STATE['results']}")
     for k in ("acks", "results"):
         STATE[k].clear()
     check(seat6._consume_worker_pin({"id": " worker-pin-123-abc ", "task": "pin"}) is True,

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -127,7 +127,19 @@ class Handler(BaseHTTPRequestHandler):
             caps = {"capabilities": _adv} if _adv else {}
             self._json(200, caps); return
         if self.path == "/v1/workers":
-            STATE["workers"].append(self._body()); self._json(200, {}); return
+            _w = self._body()
+            STATE["workers"].append(_w)
+            # A legacy relay REJECTS unknown keys on this endpoint too; without
+            # this the "parent envelope accepted" check could not fail.
+            _wlegacy = {"writer", "live_cores", "bindings", "ts", "seats", "lead"}
+            # A broker that ADVERTISED worker-routing must also accept the routed
+            # keys; a stub that advertises then rejects is an incoherent broker.
+            if STATE["advertise_routing"]:
+                _wlegacy |= {"worker_id", "location"}
+            if STATE["strict_wire"] and set(_w) - _wlegacy:
+                STATE["wire_rejected"].append(("workers", sorted(set(_w) - _wlegacy)))
+                self._json(422, {"error": "unknown fields"}); return
+            self._json(200, {}); return
         STATE["other"].append((self.path, self._body()))
         self.send_response(404); self.end_headers()
 
@@ -230,9 +242,14 @@ def main() -> int:
     snap.parent.mkdir(parents=True, exist_ok=True)
     blob = {"ts": 1, "writer": "pool-lead", "live_cores": ["core-1"], "bindings": {}}
     snap.write_text(json.dumps(blob))
+    # CHANGED with the routing capability: identity rides /v1/workers only after
+    # the broker advertises `worker-routing`, exactly like the heartbeat and poll.
+    STATE["advertise_routing"] = True
+    named._post_heartbeat(set(), force=True)
+    named._workers_push_mtime = 0.0; named._workers_push_retry_at = 0.0
     check(named._maybe_push_workers_snapshot() is True
           and STATE["workers"][-1] == {**blob, "worker_id": "worker-9", "location": "cloud"},
-          "workers-snapshot push stamps worker_id/location beside the lead's fields")
+          "workers-snapshot push stamps worker_id/location ONCE routing is advertised")
     snap.unlink()
 
     # ── 3. legacy broker: 404 heartbeat, ignored worker= ─────────────────────
@@ -682,6 +699,61 @@ def main() -> int:
           "worker-routing alone does NOT enable result metadata")
     STATE["strict_wire"] = False
     STATE["advertise"] = True; STATE["advertise_routing"] = False
+
+
+    # ---- 14. blockers 3 + 4: /v1/workers is the THIRD body carrying seat
+    # identity; ungated, a strict relay 422s it and the push backs off 1h.
+    import http.client as _hc
+    ws14 = root / "ws14"; (ws14 / "state").mkdir(parents=True, exist_ok=True)
+    d14 = _load("d14", ws14, port, SUTANDO_WORKER_ID="core-4",
+                SUTANDO_WORKER_LOCATION="cloud")
+    snap_file = ws14 / "state" / "pool-status.json"
+    snap_file.write_text(json.dumps({"writer": "lead", "live_cores": 2,
+                                     "bindings": {}, "ts": 1}))
+    STATE["strict_wire"] = True
+    STATE["advertise"] = False; STATE["advertise_routing"] = False
+    d14._post_heartbeat(set(), force=True)
+    check(d14._broker_worker_routing is False, "routing OFF for the snapshot control")
+    d14._workers_push_mtime = 0.0; d14._workers_push_retry_at = 0.0
+    check(d14._maybe_push_workers_snapshot() is True,
+          "un-advertised: the snapshot posts the EXACT parent envelope and is accepted")
+    check(all(r[0] != "workers" for r in STATE["wire_rejected"]),
+          f"the strict relay rejected nothing on /v1/workers: {STATE['wire_rejected']}")
+    check("worker_id" not in sorted(STATE["workers"][-1])
+          and "location" not in sorted(STATE["workers"][-1]),
+          f"and carries no seat keys: {sorted(STATE['workers'][-1])}")
+
+    STATE["advertise_routing"] = True
+    d14._post_heartbeat(set(), force=True)
+    check(d14._broker_worker_routing is True, "routing advertised")
+    snap_file.write_text(json.dumps({"writer": "lead", "live_cores": 3,
+                                     "bindings": {}, "ts": 2}))
+    d14._workers_push_mtime = 0.0; d14._workers_push_retry_at = 0.0
+    check(d14._maybe_push_workers_snapshot() is True, "advertised: snapshot posts")
+    check("worker_id" in sorted(STATE["workers"][-1])
+          and "location" in sorted(STATE["workers"][-1]),
+          f"and identity rides it only now: {sorted(STATE['workers'][-1])}")
+
+    # (3) a TRUNCATED successful heartbeat escapes during resp.read(); it carries
+    # no advertisement, so it must revoke exactly like a 404 or a malformed 200.
+    check(d14._broker_worker_metadata is True or d14._broker_worker_metadata is False,
+          "metadata flag readable before the truncation control")
+    STATE["advertise"] = True; STATE["advertise_routing"] = True
+    d14._post_heartbeat(set(), force=True)
+    check(d14._broker_worker_routing is True, "capabilities ON before truncation")
+    _real_urlopen = d14.urllib.request.urlopen
+
+    def _truncating(*a, **k):
+        raise _hc.IncompleteRead(b"{\"ok\": tr", 42)
+    d14.urllib.request.urlopen = _truncating
+    try:
+        check(d14._post_heartbeat(set(), force=True) is False,
+              "a truncated 200 does not raise out of the heartbeat")
+    finally:
+        d14.urllib.request.urlopen = _real_urlopen
+    check(d14._broker_worker_routing is False and d14._broker_worker_metadata is False,
+          "and it REVOKES both capabilities — absence of a reply is absence of evidence")
+    STATE["strict_wire"] = False
 
     srv.shutdown()
     if FAILS:

--- a/tests/gateway-worker-queue-client.test.py
+++ b/tests/gateway-worker-queue-client.test.py
@@ -40,7 +40,10 @@ def check(cond: bool, msg: str) -> None:
 # ── stub broker: records every call; serves TASK on the first `serve_n` polls,
 # ignores the worker= query entirely (a broker that predates seats) ──────────
 STATE = {"gets": [], "acks": [], "results": [], "heartbeats": [], "workers": [],
-         "other": [], "serve_n": 0, "heartbeat_404": False, "task": None}
+         "other": [], "serve_n": 0, "heartbeat_404": False, "task": None,
+         # A modern broker advertises the extension; `strict` models a legacy
+         # relay that REJECTS unknown result keys instead of ignoring them.
+         "advertise": True, "strict": False, "rejected": []}
 TASK = {"id": "task-CLOUD1", "timestamp": "2026-09-03T00:00:00Z",
         "task": "hello cloud seat", "source": "remote-gateway",
         "channel_id": "!room:example.org", "user_id": "@qingyun:example.org",
@@ -74,13 +77,20 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         if self.path == "/v1/results":
-            STATE["results"].append(self._body()); self._json(200, {"ok": True}); return
+            body = self._body()
+            allowed = {"id", "body"} | ({"metadata"} if STATE["advertise"] else set())
+            if STATE["strict"] and set(body) - allowed:
+                STATE["rejected"].append(sorted(body))
+                self._json(422, {"error": "unknown field"}); return
+            STATE["results"].append(body); self._json(200, {"ok": True}); return
         if self.path.startswith("/v1/tasks/") and self.path.endswith("/ack"):
             STATE["acks"].append((self.path, self._body())); self._json(200, {}); return
         if self.path == "/v1/heartbeat":
             if STATE["heartbeat_404"]:
                 self.send_response(404); self.end_headers(); return
-            STATE["heartbeats"].append(self._body()); self._json(200, {}); return
+            STATE["heartbeats"].append(self._body())
+            caps = {"capabilities": ["worker-metadata"]} if STATE["advertise"] else {}
+            self._json(200, caps); return
         if self.path == "/v1/workers":
             STATE["workers"].append(self._body()); self._json(200, {}); return
         STATE["other"].append((self.path, self._body()))
@@ -379,6 +389,54 @@ def main() -> int:
     seat7._retry_review_control_results()
     check(STATE["results"] == [{"id": "worker-pin-778-cafe", "body": "[no-send]"}],
           f"a second drain does not re-post the close: {STATE['results']}")
+
+    # A relay that 422s un-advertised keys must still receive the documented
+    # {id, body}; before the fix `metadata` rode every result and was refused.
+    print("\n8. legacy relay (does NOT advertise worker-metadata) — envelope preserved")
+    for k in ("gets", "acks", "results", "heartbeats", "other"):
+        STATE[k].clear()
+    STATE["rejected"].clear()
+    STATE["advertise"] = False
+    STATE["strict"] = True
+    ws8 = root / "ws8"; ws8.mkdir()
+    legacy8 = _load("legacy8", ws8, port,
+                    SUTANDO_WORKER_ID="home-1", SUTANDO_WORKER_LOCATION="home")
+    check(legacy8._post_heartbeat(set(), force=True) is True,
+          "heartbeat reaches the legacy broker")
+    check(legacy8._broker_worker_metadata is False,
+          "no advertisement → the client does NOT enable the metadata extension")
+    legacy8.RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    (legacy8.RESULTS_DIR / "task-LEGACY1.txt").write_text("answer for a legacy relay\n")
+    legacy8._save_inflight({"task-LEGACY1"})
+    legacy8._post_ready_results(legacy8._load_inflight())
+    check(STATE["rejected"] == [],
+          f"the strict relay refused nothing: {STATE['rejected']}")
+    check(len(STATE["results"]) == 1 and sorted(STATE["results"][0]) == ["body", "id"],
+          f"wire-keys are exactly the documented envelope: "
+          f"{sorted(STATE['results'][0]) if STATE['results'] else None}")
+    check(not (legacy8.RESULTS_DIR / "task-LEGACY1.txt").exists(),
+          "the result was delivered, not left behind for a retry")
+    check(not list((legacy8._STATE.parent / "results" / "undelivered").glob("*"))
+          if (legacy8._STATE.parent / "results" / "undelivered").exists() else True,
+          "nothing was quarantined as undelivered")
+    print(f"     legacy payload: {json.dumps(STATE['results'][0], sort_keys=True)}"
+          if STATE["results"] else "     legacy payload: NONE")
+
+    # control: the SAME strict relay, now advertising → the extension returns.
+    for k in ("results", "heartbeats"):
+        STATE[k].clear()
+    STATE["advertise"] = True
+    check(legacy8._post_heartbeat(set(), force=True) is True, "second heartbeat sent")
+    check(legacy8._broker_worker_metadata is True,
+          "control: an advertising broker re-enables the extension")
+    (legacy8.RESULTS_DIR / "task-LEGACY2.txt").write_text("answer once advertised\n")
+    legacy8._save_inflight({"task-LEGACY2"})
+    legacy8._post_ready_results(legacy8._load_inflight())
+    check(len(STATE["results"]) == 1
+          and STATE["results"][0].get("metadata")
+          == {"worker_id": legacy8.WORKER_ID, "location": legacy8.WORKER_LOCATION},
+          f"control: attribution rides again once advertised: {STATE['results']}")
+    STATE["strict"] = False
 
     srv.shutdown()
     if FAILS:

--- a/tests/gateway-workers-snapshot-capability-edge.test.py
+++ b/tests/gateway-workers-snapshot-capability-edge.test.py
@@ -130,6 +130,48 @@ def main() -> int:
     check(pushed is True and calls[-1][2] == {**BLOB, "ts": 2},
           "withdrawing routing retires that backoff and the EXACT legacy payload goes out")
 
+    # --- 2c. 2b drives the withdrawal through the revocation helper; a SUCCESSFUL
+    # reply takes _post_heartbeat instead, so fixing one leaves this branch broken.
+    m, snap = fresh(tmp)
+    calls = []
+    m._note_broker_capabilities(ADVERTISE)
+    m._req = recorder(calls)
+    check(m._maybe_push_workers_snapshot() is True and calls[-1][2] == ROUTED,
+          "routed snapshot goes out before the withdrawal")
+    snap.write_text(json.dumps({**BLOB, "ts": 3}))
+    os.utime(snap, (time.time() + 1, time.time() + 1))
+    m._req = recorder(calls, exc=lambda p: urllib.error.HTTPError(p, 422, "unprocessable", {}, None))
+    check(m._maybe_push_workers_snapshot() is False
+          and m._workers_push_retry_at > time.time() + 3000,
+          "a rejected ROUTED update earns the backoff (heartbeat path)")
+
+    def heartbeat_reply(caps):
+        def _req(method, path, payload=None, timeout=None):
+            calls.append((method, path, payload))
+            if path == "/v1/heartbeat":
+                return {"capabilities": caps}
+            return {}
+        return _req
+
+    m._req = heartbeat_reply([])              # SUCCESS, no advertisement
+    m._last_heartbeat_at = 0.0
+    m._post_heartbeat(set(), force=True)      # no rewrite, no utime, no reset
+    check(m._broker_worker_routing is False and m._workers_push_retry_at == 0.0,
+          "a SUCCESSFUL heartbeat that omits worker-routing retires the routed backoff")
+    m._req = recorder(calls)
+    pushed = m._maybe_push_workers_snapshot()
+    check(pushed is True and calls[-1][2] == {**BLOB, "ts": 3},
+          "and the EXACT legacy payload goes out on the next push")
+
+    # --- 2d. same-state control: an already-legacy broker keeps its backoff, so a
+    # non-advertising heartbeat every beat cannot hammer a rejecting endpoint.
+    m._workers_push_retry_at = time.time() + 3600
+    m._req = heartbeat_reply([])
+    m._last_heartbeat_at = 0.0
+    m._post_heartbeat(set(), force=True)
+    check(m._workers_push_retry_at > time.time() + 3000,
+          "control: a heartbeat omitting the capability when routing was ALREADY off keeps the backoff")
+
     # --- 3. the edge is an EDGE: a repeated advertisement never clears backoff
     m, _ = fresh(tmp)
     calls = []

--- a/tests/gateway-workers-snapshot-capability-edge.test.py
+++ b/tests/gateway-workers-snapshot-capability-edge.test.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Workers-snapshot push across the worker-routing capability EDGE.
+
+The payload's shape is half capability, so a snapshot sent in legacy mode is
+not "already sent" once routing is advertised, and an endpoint backoff earned
+before the advertisement is evidence about a broker that no longer exists.
+
+Every transition here runs with NO snapshot rewrite, NO utime bump and NO
+internal reset — those are exactly what let the earlier suites pass while the
+transition itself was broken.
+
+Run: python3 tests/gateway-workers-snapshot-capability-edge.test.py  (stdlib only)
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+from pathlib import Path
+
+FAILS = []
+MOD = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py"
+
+
+def check(cond, msg):
+    print(("ok  " if cond else "FAIL") + " " + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def fresh(tmp):
+    """A newly executed module = a fresh process's globals. Between SCENARIOS
+    that is legitimate; within one it would be the reset that hid this bug."""
+    spec = importlib.util.spec_from_file_location("rtc_edge", MOD)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    snap = Path(tmp) / "state" / "pool-status.json"
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    snap.write_text(json.dumps(BLOB))
+    return m, snap
+
+
+BLOB = {"ts": 1, "writer": "pool-lead", "live_cores": ["core-1"],
+        "bindings": {"!r:x": {"instance": "core-1", "pinned": True,
+                              "dedicated": False}}}
+ADVERTISE = {"capabilities": ["worker-routing"]}
+ROUTED = {**BLOB, "worker_id": "home", "location": "local"}
+
+
+def recorder(calls, exc=None):
+    def _req(method, path, payload=None, timeout=35):
+        calls.append((method, path, payload))
+        if exc is not None:
+            raise exc(path)
+        return {}
+    return _req
+
+
+def h404(path):
+    return urllib.error.HTTPError(path, 404, "nf", {}, None)
+
+
+def main() -> int:
+    tmp = tempfile.mkdtemp(prefix="wsedge-test-")
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+    os.environ["SUTANDO_WORKSPACE"] = tmp
+    Path(tmp, ".notes-migrated").touch()
+    Path(tmp, ".build_log-migrated").touch()
+    os.environ["REMOTE_TASK_URL"] = "http://127.0.0.1:9"   # never contacted
+    os.environ["REMOTE_TASK_TOKEN"] = "testtoken"
+    os.environ["REMOTE_TASK_PROVIDER"] = "remote-gateway"
+    for k in ("SUTANDO_WORKER_ID", "SUTANDO_WORKER_SEAT", "SUTANDO_CORE_ID",
+              "SUTANDO_WORKER_LOCATION"):
+        os.environ.pop(k, None)
+
+    # --- 1. successful legacy push -> advertise -> the routed snapshot goes out
+    m, _ = fresh(tmp)
+    calls = []
+    m._req = recorder(calls)
+    check(m._maybe_push_workers_snapshot() is True and calls[-1][2] == BLOB,
+          "legacy push goes out as the exact parent envelope")
+    m._note_broker_capabilities(ADVERTISE)
+    pushed = m._maybe_push_workers_snapshot()          # no rewrite, no reset
+    check(pushed is True and len(calls) == 2,
+          "advertising routing re-pushes the SAME file with no rewrite")
+    check(calls[-1] == ("POST", "/v1/workers", ROUTED),
+          "the re-push carries the seat the worker picker reads")
+
+    # control: a heartbeat that changes nothing must NOT re-push, or every
+    # beat would repost and the on-change relay would become a per-beat one.
+    m._note_broker_capabilities(ADVERTISE)
+    check(m._maybe_push_workers_snapshot() is False and len(calls) == 2,
+          "control: re-advertising the same mode does not re-push")
+
+    # --- 2. legacy 404 -> advertise -> the hour-long backoff is reconsidered
+    m, _ = fresh(tmp)
+    calls = []
+    m._req = recorder(calls, exc=h404)
+    check(m._maybe_push_workers_snapshot() is False and len(calls) == 1,
+          "404 on the legacy endpoint defers the push")
+    m._req = recorder(calls)
+    check(m._maybe_push_workers_snapshot() is False and len(calls) == 1,
+          "positive control: the backoff really is suppressing (a healthy "
+          "broker still gets no request)")
+    check(m._workers_push_retry_at > time.time() + 3000,
+          "positive control: the backoff is the hour-long one")
+    m._note_broker_capabilities(ADVERTISE)
+    pushed = m._maybe_push_workers_snapshot()          # no rewrite, no reset
+    check(pushed is True and calls[-1] == ("POST", "/v1/workers", ROUTED),
+          "a new advertisement retires a backoff earned before it")
+
+    # --- 3. the edge is an EDGE: a repeated advertisement never clears backoff
+    m, _ = fresh(tmp)
+    calls = []
+    m._note_broker_capabilities(ADVERTISE)             # rising edge, no backoff yet
+    m._req = recorder(calls, exc=h404)
+    check(m._maybe_push_workers_snapshot() is False and len(calls) == 1,
+          "routed push can 404 too")
+    m._note_broker_capabilities(ADVERTISE)             # same state: NOT an edge
+    m._req = recorder(calls)
+    check(m._maybe_push_workers_snapshot() is False and len(calls) == 1,
+          "control: an unchanged advertisement leaves the backoff intact "
+          "(level-triggered clearing would hammer a 404 broker every beat)")
+
+    print()
+    print(("FAILED: " + "; ".join(FAILS)) if FAILS else "all green")
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/gateway-workers-snapshot-capability-edge.test.py
+++ b/tests/gateway-workers-snapshot-capability-edge.test.py
@@ -111,6 +111,25 @@ def main() -> int:
     check(pushed is True and calls[-1] == ("POST", "/v1/workers", ROUTED),
           "a new advertisement retires a backoff earned before it")
 
+    # --- 2b. the RECIPROCAL transition: routed rejection -> withdrawal -> legacy push
+    m, snap = fresh(tmp)
+    calls = []
+    m._note_broker_capabilities(ADVERTISE)
+    m._req = recorder(calls)
+    check(m._maybe_push_workers_snapshot() is True and calls[-1][2] == ROUTED,
+          "routed snapshot goes out while routing is advertised")
+    snap.write_text(json.dumps({**BLOB, "ts": 2}))
+    os.utime(snap, (time.time() + 1, time.time() + 1))
+    m._req = recorder(calls, exc=lambda p: urllib.error.HTTPError(p, 422, "unprocessable", {}, None))
+    check(m._maybe_push_workers_snapshot() is False
+          and m._workers_push_retry_at > time.time() + 3000,
+          "a rejected ROUTED update earns the hour-long backoff")
+    m._revoke_broker_capabilities()          # no rewrite, no reset
+    m._req = recorder(calls)
+    pushed = m._maybe_push_workers_snapshot()
+    check(pushed is True and calls[-1][2] == {**BLOB, "ts": 2},
+          "withdrawing routing retires that backoff and the EXACT legacy payload goes out")
+
     # --- 3. the edge is an EDGE: a repeated advertisement never clears backoff
     m, _ = fresh(tmp)
     calls = []
@@ -123,6 +142,19 @@ def main() -> int:
     check(m._maybe_push_workers_snapshot() is False and len(calls) == 1,
           "control: an unchanged advertisement leaves the backoff intact "
           "(level-triggered clearing would hammer a 404 broker every beat)")
+
+    # --- 4. revocation is an EDGE too: a repeated withdrawal never clears backoff
+    m, _ = fresh(tmp)
+    calls = []
+    m._req = recorder(calls, exc=h404)          # routing already off: a LEGACY 404
+    check(m._maybe_push_workers_snapshot() is False
+          and m._workers_push_retry_at > time.time() + 3000,
+          "legacy 404 earns the backoff with routing already off")
+    m._revoke_broker_capabilities()             # SAME state — not a transition
+    m._req = recorder(calls)
+    check(m._maybe_push_workers_snapshot() is False and len(calls) == 1,
+          "control: revoking when routing was ALREADY off leaves the backoff intact "
+          "(level-triggered clearing would hammer an unchanged broker every beat)")
 
     print()
     print(("FAILED: " + "; ".join(FAILS)) if FAILS else "all green")

--- a/tests/gateway-workers-snapshot-push.test.py
+++ b/tests/gateway-workers-snapshot-push.test.py
@@ -32,6 +32,9 @@ def main() -> int:
     os.environ["REMOTE_TASK_URL"] = "http://127.0.0.1:9"  # never contacted
     os.environ["REMOTE_TASK_TOKEN"] = "testtoken"
     os.environ["REMOTE_TASK_PROVIDER"] = "remote-gateway"
+    for k in ("SUTANDO_WORKER_ID", "SUTANDO_WORKER_SEAT", "SUTANDO_CORE_ID",
+              "SUTANDO_WORKER_LOCATION"):
+        os.environ.pop(k, None)  # hermetic: the host's seat must not leak in
 
     spec = importlib.util.spec_from_file_location(
         "rtc_push", Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.py")
@@ -57,8 +60,11 @@ def main() -> int:
     snap_path.write_text(json.dumps(blob))
     check(rtc._maybe_push_workers_snapshot() is True,
           "new snapshot pushes")
-    check(calls == [("POST", "/v1/workers", blob)],
-          "pushed the exact blob to POST /v1/workers")
+    # The pushing seat stamps itself onto the lead's file (worker-aware brokers
+    # key workers by seat); an unconfigured process is the home seat.
+    check(calls == [("POST", "/v1/workers",
+                     {**blob, "worker_id": "home", "location": "local"})],
+          "pushed the blob + this seat's worker_id/location to POST /v1/workers")
     check(rtc._maybe_push_workers_snapshot() is False and len(calls) == 1,
           "unchanged snapshot never re-posts")
 

--- a/tests/gateway-workers-snapshot-push.test.py
+++ b/tests/gateway-workers-snapshot-push.test.py
@@ -72,6 +72,11 @@ def main() -> int:
                             {**blob, "ts": 99, "worker_id": "home", "location": "local"}),
           "once worker-routing is advertised, the seat rides the snapshot")
     rtc._broker_worker_routing = False
+    # Revocation changes the payload too, so it is a NEW snapshot: the seat
+    # keys must come off the wire or a strict legacy relay 422s them.
+    check(rtc._maybe_push_workers_snapshot() is True
+          and calls[-1] == ("POST", "/v1/workers", {**blob, "ts": 99}),
+          "revoking worker-routing re-pushes the legacy shape")
     calls[:] = calls[:1]
     check(rtc._maybe_push_workers_snapshot() is False and len(calls) == 1,
           "unchanged snapshot never re-posts")

--- a/tests/gateway-workers-snapshot-push.test.py
+++ b/tests/gateway-workers-snapshot-push.test.py
@@ -60,11 +60,19 @@ def main() -> int:
     snap_path.write_text(json.dumps(blob))
     check(rtc._maybe_push_workers_snapshot() is True,
           "new snapshot pushes")
-    # The pushing seat stamps itself onto the lead's file (worker-aware brokers
-    # key workers by seat); an unconfigured process is the home seat.
-    check(calls == [("POST", "/v1/workers",
-                     {**blob, "worker_id": "home", "location": "local"})],
-          "pushed the blob + this seat's worker_id/location to POST /v1/workers")
+    # Seat identity is NEGOTIATED: un-advertised, the push is the exact parent
+    # envelope, so a strict relay cannot 422 it and back the push off an hour.
+    check(calls == [("POST", "/v1/workers", blob)],
+          "un-advertised: pushes the lead's blob verbatim, no seat keys")
+    rtc._broker_worker_routing = True
+    snap_path.write_text(json.dumps({**blob, "ts": 99}))
+    os.utime(snap_path, (time.time() + 1, time.time() + 1))
+    check(rtc._maybe_push_workers_snapshot() is True
+          and calls[-1] == ("POST", "/v1/workers",
+                            {**blob, "ts": 99, "worker_id": "home", "location": "local"}),
+          "once worker-routing is advertised, the seat rides the snapshot")
+    rtc._broker_worker_routing = False
+    calls[:] = calls[:1]
     check(rtc._maybe_push_workers_snapshot() is False and len(calls) == 1,
           "unchanged snapshot never re-posts")
 


### PR DESCRIPTION
## Why

Owner direction in #3794: *"Dispatching in the cloud directly is simpler … a cloud **worker**, not a new cloud **agent**: cloud and local workers share the same agent identity."*

This is **slice 1, client half of #3794**: the gateway client (`packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py`, package-canonical; `src/remote-gateway-bridge.py` is the loader shim and needs no change) becomes a *worker-aware queue client* while staying 100% backward compatible with a broker that knows nothing about workers. The broker half (per-seat queues, lease failover, `/v1/workers/pin`) is a separate PR in ag2space-backend, dev-first.

**Stack:** #3604 (rescue line) → #3788 (worker names) → this. #3787 (routing policy seam) is a sibling on the same base. Base is `rescue/pool-uncommitted-2026-08-26`.

## What changed

1. **Seat identity on the wire.** `SUTANDO_WORKER_ID` (default `home`; `worker-<SUTANDO_CORE_ID>` derived, matching `install-core-pool.sh` / room-ops scripts) and `SUTANDO_WORKER_LOCATION` (`cloud`, else `local`), read at import like `REMOTE_TASK_URL`. Both documented in the client docstring header. `worker_id` + `location` are added to the `POST /v1/heartbeat` payload and to the `POST /v1/workers` snapshot push; `&worker=<id>` is appended to `GET /v1/tasks?wait=…`. Same id charset as `GATEWAY_INSTANCE`; a bad value refuses at import.
2. **Cloud-worker mode** needs nothing from another host: the pull → `tasks/` → `results/` → POST cycle runs with no `state/pool-status.json`, no `state/pool/`, no `state/cores/`. Verified by reading every reader (`_maybe_push_workers_snapshot`: no file → no-op; `_worker_of`: glob on a missing `state/cores` → `""`; `_read_core_status`: guarded) and by the hermetic e2e below. No code change was needed on that path — the test pins it.
3. **Lease safety** documented in the docstring + `docs/lead-follower-pool.md` → "Cloud worker": the existing `_write_task` idempotency (pending / `.assigned-*` / `.claimed-*` → no rewrite; archived or delivered → `[no-send]` lease close) plus the persisted inflight set is what makes a broker re-front safe locally; the residual hazard (lease shorter than an honest task → another seat also answers) is stated as the broker-side visibility-timeout rule. Nothing in the dedup/inflight logic was rewritten — coverage was extended.
4. `tests/gateway-workers-snapshot-push.test.py`: expectation updated (the push now carries the seat) and seat env scrubbed for hermeticity.

## Evidence

Probe: one bounded `main()` iteration against a stub broker, printing the pull path and the heartbeat body actually sent (`scratchpad/probe-wire.py`, hermetic tmp workspace).

**Before — parent commit `be0aebfb`:**
```
env seat   : (none)
GET path   : /v1/tasks?wait=0
heartbeat  : {"capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"], "client": "sutando-gateway-client", "inflight": 0, "protocol_version": 1, "provider": "remote-gateway", "tier": "owner"}
env seat   : {'SUTANDO_WORKER_ID': 'cloud-1', 'SUTANDO_WORKER_LOCATION': 'cloud'}
GET path   : /v1/tasks?wait=0
heartbeat  : {"capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"], "client": "sutando-gateway-client", "inflight": 0, "protocol_version": 1, "provider": "remote-gateway", "tier": "owner"}
```

**After — re-verified at HEAD `899fd32ed`** (block captured at `c944b01f4`; re-ran the probe at the
current head and the wire behaviour is identical — legacy first exchange, seat only after the broker
advertises. The two commits since (`a11692690` single capability-transition owner, `899fd32ed` pin
comments) change backoff invalidation and documentation, not the wire shape. This replaces a stale
`476a2435` probe that showed the seat riding the wire UNCONDITIONALLY; the shape has been NEGOTIATED
since, so that block described superseded behaviour — flagged by @keweichen):
```
env seat   : (none)
GET path   : /v1/tasks?wait=0
heartbeat  : {"capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"], "client": "sutando-gateway-client", "inflight": 0, "protocol_version": 1, "provider": "remote-gateway", "tier": "owner"}
  ...the ADVERTISING heartbeat is itself legacy-shaped:
heartbeat  : {"capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"], "client": "sutando-gateway-client", "inflight": 0, "protocol_version": 1, "provider": "remote-gateway", "tier": "owner"}
  ...once advertised, the seat rides the NEXT exchange:
GET path   : /v1/tasks?wait=0&worker=home
heartbeat  : {"capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"], "client": "sutando-gateway-client", "inflight": 0, "location": "local", "protocol_version": 1, "provider": "remote-gateway", "tier": "owner", "worker_id": "home"}

env seat   : {'SUTANDO_WORKER_ID': 'cloud-1', 'SUTANDO_WORKER_LOCATION': 'cloud'}
GET path   : /v1/tasks?wait=0
heartbeat  : {"capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"], "client": "sutando-gateway-client", "inflight": 0, "protocol_version": 1, "provider": "remote-gateway", "tier": "owner"}
  ...the ADVERTISING heartbeat is itself legacy-shaped:
heartbeat  : {"capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"], "client": "sutando-gateway-client", "inflight": 0, "protocol_version": 1, "provider": "remote-gateway", "tier": "owner"}
  ...once advertised, the seat rides the NEXT exchange:
GET path   : /v1/tasks?wait=0&worker=cloud-1
heartbeat  : {"capabilities": ["task-ack", "heartbeat", "result-skip-markers", "core-status", "team-collaborator"], "client": "sutando-gateway-client", "inflight": 0, "location": "cloud", "protocol_version": 1, "provider": "remote-gateway", "tier": "owner", "worker_id": "cloud-1"}
```

Three exchanges, because two of them are easy to conflate: the first is byte-for-byte the parent
envelope, **the advertising heartbeat is itself still legacy-shaped** (its payload is built before
the reply that advertises), and only the exchange after that carries `&worker=` and the
`worker_id`/`location` keys. A broker that never advertises therefore never sees a new key.
Every pre-existing field is byte-identical; the change is additive. Workers-snapshot push after (from the new test): `{**lead_blob, "worker_id": "worker-9", "location": "cloud"}`. Result POST from the cloud e2e: `{"body": "answer from the cloud seat", "id": "task-CLOUD1"}`.

**Tests (all run at HEAD):**
```
python3 tests/gateway-worker-queue-client.test.py     → PASS — worker-aware queue client: all checks green  (30 checks)
python3 tests/remote-gateway-bridge.test.py           → PASS — all checks green  (286 checks; src/remote-gateway-bridge.test.py)
python3 tests/gateway-workers-snapshot-push.test.py   → 0 failure(s)
python3 tests/ag2-sparrow-drift.test.py               → PASS — ag2-sparrow bundled utils in sync with src/
python3 tests/bridge-marker-no-leak.test.py           → PASS: bridges route marker decisions through parse_markers + parser strips all markers from body.
python3 tests/sparrow-integration-e2e.test.py         → PASS — connected → task-once → result-once → forced reconnect → inflight recovery, no duplicate, no loss.
python3 tests/gateway-longpoll-timeout.test.py        → Ran 7 tests OK
python3 tests/gateway-result-worker-attribution.test.py → Ran 6 tests OK
python3 tests/gateway-dedup-recovery.test.py          → Ran 11 tests OK
ruff check <touched .py>                              → All checks passed!
bash scripts/review-checks.sh --diff pr-3794-client.diff → review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

What the new hermetic test covers (`tests/gateway-worker-queue-client.test.py`, stub `ThreadingHTTPServer` that **ignores `worker=`**, i.e. a legacy broker): seat derivation (none → `home`; `SUTANDO_CORE_ID=2` → `worker-2`; explicit id wins; unknown location → `local`; path-shaped id → `SystemExit`); heartbeat + snapshot payloads; heartbeat 404 still disables quietly; a **cloud seat with no `state/pool*` and no `state/cores`** driving the real `main()` for two iterations — pull with `worker=cloud-1` on the wire, task file written once, the **same id re-delivered on the second poll** (lease re-front) is not re-queued and is re-acked, the same id re-delivered while the file is `.claimed-*` / `.assigned-*` is not re-queued, then the seat's result is POSTed exactly once with the broker id and archived, and no pool state was created on that host.

**Not run:** a live broker round trip. The worker-aware broker does not exist yet (it is the ag2space-backend half of #3794); against today's broker the only observable change is the extra query param and two extra heartbeat fields, both of which the legacy stub above ignores exactly as the deployed relay does. Not a live-path change to delivery, startup or the poll loop's control flow.

Closes nothing (slice 1 of #3794).

— sutando-qingyun-001 (worker-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order

Stacked PR. Parent: **#3604** (`rescue/pool-uncommitted-2026-08-26`) → **#3788** (worker rename, same base) → **this PR** (`feat/pool-worker-queue-client`) → child **#3803** (bases on this PR's head branch).

- Merge after #3604 and #3788 land; rebase this PR onto the new base then and re-run its full checks.
- **Do not delete `feat/pool-worker-queue-client` on merge until #3803 has been retargeted** to the parent branch — #3803's base is this branch.
- Independent of ag2space-backend#945 at the code level (that is the broker half of the same slice; it merges on `dev` under the owner's greenlight).

_(Merge-order section added by the shepherd 2026-09-03 11:5xZ at sonichi's request; the diff is untouched.)_


