### PR TITLE
fix(ci-triage): a superseded run's FAILURE is reported as a live failure

### DIFF
--- a/scripts/ci-triage.py
+++ b/scripts/ci-triage.py
@@ -78,18 +78,39 @@ def _gh(run, args) -> "object | None":
         return None
 
 
+def _is_bad(c: dict) -> bool:
+    # CANCELLED is capacity (job cap or a superseded run), not a defect — and
+    # triaging it sends the reader after a cause that does not exist.
+    return c.get("conclusion") in ("FAILURE", "TIMED_OUT") or c.get("state") in ("FAILURE", "ERROR")
+
+
+def latest_by_name(rollup) -> "list[dict]":
+    """One head can carry several runs, so a check name can appear more than once.
+
+    A concurrency cancellation leaves the loser's jobs in the rollup beside the
+    winner's, and a job that starts during cancellation records FAILURE.
+    """
+    latest: "dict[str, tuple[str, dict]]" = {}
+    for c in rollup or []:
+        name = c.get("name") or c.get("context") or "?"
+        stamp = c.get("completedAt") or c.get("startedAt") or ""
+        prev = latest.get(name)
+        # Equal stamps leave no order to read, so keep the failing entry rather
+        # than forgiving it on a coin flip.
+        if prev is None or stamp > prev[0] or (stamp == prev[0] and _is_bad(c)):
+            latest[name] = (stamp, c)
+    return [c for _, c in latest.values()]
+
+
 def failing_checks(pr: str, run, repo: str) -> "list[str] | None":
     j = _gh(run, ["pr", "view", pr, "--repo", repo, "--json", "statusCheckRollup"])
     if j is None:
         return None
-    out = []
-    for c in (j.get("statusCheckRollup") or []):
-        # CANCELLED is capacity (job cap or a superseded run), not a defect — and
-        # triaging it sends the reader after a cause that does not exist.
-        bad = c.get("conclusion") in ("FAILURE", "TIMED_OUT") or c.get("state") in ("FAILURE", "ERROR")
-        if bad:
-            out.append(c.get("name") or c.get("context") or "?")
-    return out
+    return [
+        c.get("name") or c.get("context") or "?"
+        for c in latest_by_name(j.get("statusCheckRollup"))
+        if _is_bad(c)
+    ]
 
 
 def failure_text(pr: str, run, repo: str) -> str:
@@ -113,10 +134,9 @@ def failure_text(pr: str, run, repo: str) -> str:
 def _run_ids(pr: str, run, repo: str) -> "list[str]":
     j = _gh(run, ["pr", "view", pr, "--repo", repo, "--json", "statusCheckRollup"])
     ids, seen = [], set()
-    for c in ((j or {}).get("statusCheckRollup") or []):
-        bad = c.get("conclusion") in ("FAILURE", "TIMED_OUT") or c.get("state") in ("FAILURE", "ERROR")
+    for c in latest_by_name((j or {}).get("statusCheckRollup")):
         m = re.search(r"/runs/(\d+)", c.get("detailsUrl") or "")
-        if bad and m and m.group(1) not in seen:
+        if _is_bad(c) and m and m.group(1) not in seen:
             seen.add(m.group(1))
             ids.append(m.group(1))
     return ids

--- a/tests/ci-triage-superseded-runs.test.py
+++ b/tests/ci-triage-superseded-runs.test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Regression pin: a superseded run's FAILURE is not a live failure.
+
+One head can carry several CI runs — a concurrency cancellation leaves the
+loser's jobs in the rollup beside the winner's, and a job that starts while its
+run is being cancelled exits non-zero and records FAILURE. Counting every
+rollup entry then reports a red on a PR whose every required context is green.
+Observed on sonichi/sutando#3777: `tsc + tests (clean install)` FAILURE at
+09:04:42Z (cancelled run) and SUCCESS at 09:17:30Z (live run), same sha; the
+PR merged CLEAN while `failing_checks` still named the job.
+
+Run: python3 tests/ci-triage-superseded-runs.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("ci_triage", REPO / "scripts" / "ci-triage.py")
+ct = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ct)
+
+failures: "list[str]" = []
+checked = 0
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    global checked
+    checked += 1
+    print(f"  {'ok  ' if cond else 'FAIL'} {label}")
+    if not cond:
+        if detail:
+            print(f"       {detail}")
+        failures.append(label)
+
+
+def run_for(rollup):
+    """Stand in for `gh`, returning one canned rollup."""
+    def _run(args, **kw):
+        class R:
+            returncode = 0
+            stdout = json.dumps({"statusCheckRollup": rollup})
+        return R()
+    return _run
+
+
+def cr(name, conclusion, at, url=""):
+    return {"name": name, "conclusion": conclusion, "completedAt": at, "detailsUrl": url}
+
+
+# --- the defect: superseded FAILURE, later SUCCESS, same name ----------------
+SUPERSEDED = [
+    cr("tsc + tests (clean install)", "FAILURE", "2026-09-03T09:04:42Z"),
+    cr("tsc + tests (clean install)", "SUCCESS", "2026-09-03T09:17:30Z"),
+    cr("eslint", "SUCCESS", "2026-09-03T09:05:00Z"),
+]
+got = ct.failing_checks("1", run_for(SUPERSEDED), "o/r")
+check("a) a superseded FAILURE with a later SUCCESS is NOT reported", got == [], f"got {got}")
+
+# --- the arm: the fix must not become a machine that only says "none" -------
+STILL_FAILING = [
+    cr("tsc + tests (clean install)", "SUCCESS", "2026-09-03T09:04:42Z"),
+    cr("tsc + tests (clean install)", "FAILURE", "2026-09-03T09:17:30Z"),
+]
+got = ct.failing_checks("1", run_for(STILL_FAILING), "o/r")
+check("b) SUCCESS superseded by a later FAILURE IS reported",
+      got == ["tsc + tests (clean install)"], f"got {got}")
+
+# --- a genuine single failure still reports ---------------------------------
+got = ct.failing_checks("1", run_for([cr("ruff", "FAILURE", "2026-09-03T09:00:00Z")]), "o/r")
+check("c) an undisputed FAILURE still reports", got == ["ruff"], f"got {got}")
+
+# --- CANCELLED as the latest is still not a defect (pre-existing contract) ---
+got = ct.failing_checks("1", run_for([
+    cr("bundle-smoke", "FAILURE", "2026-09-03T09:00:00Z"),
+    cr("bundle-smoke", "CANCELLED", "2026-09-03T09:10:00Z"),
+]), "o/r")
+check("d) CANCELLED as the latest is capacity, not a failure", got == [], f"got {got}")
+
+# --- equal stamps: keep the failing entry rather than forgive on a coin flip -
+got = ct.failing_checks("1", run_for([
+    cr("shellcheck", "SUCCESS", "2026-09-03T09:00:00Z"),
+    cr("shellcheck", "FAILURE", "2026-09-03T09:00:00Z"),
+]), "o/r")
+check("e) on an identical stamp the FAILURE wins (no silent forgiveness)",
+      got == ["shellcheck"], f"got {got}")
+got = ct.failing_checks("1", run_for([
+    cr("shellcheck", "FAILURE", "2026-09-03T09:00:00Z"),
+    cr("shellcheck", "SUCCESS", "2026-09-03T09:00:00Z"),
+]), "o/r")
+check("e2) ...regardless of rollup order", got == ["shellcheck"], f"got {got}")
+
+# --- StatusContext entries carry `context`, not `name` -----------------------
+got = ct.failing_checks("1", run_for([
+    {"context": "license/cla", "state": "FAILURE", "completedAt": "2026-09-03T09:00:00Z"},
+    {"context": "license/cla", "state": "SUCCESS", "completedAt": "2026-09-03T09:10:00Z"},
+]), "o/r")
+check("f) a StatusContext dedupes on `context` too", got == [], f"got {got}")
+
+# --- _run_ids must not send the reader to a superseded run's log ------------
+ids = ct._run_ids("1", run_for([
+    cr("tsc", "FAILURE", "2026-09-03T09:04:42Z", "https://x/runs/111/job/1"),
+    cr("tsc", "SUCCESS", "2026-09-03T09:17:30Z", "https://x/runs/222/job/2"),
+]), "o/r")
+check("g) _run_ids skips the superseded run's id", ids == [], f"got {ids}")
+
+ids = ct._run_ids("1", run_for([
+    cr("tsc", "SUCCESS", "2026-09-03T09:04:42Z", "https://x/runs/111/job/1"),
+    cr("tsc", "FAILURE", "2026-09-03T09:17:30Z", "https://x/runs/222/job/2"),
+]), "o/r")
+check("h) _run_ids returns the LIVE failing run's id", ids == ["222"], f"got {ids}")
+
+print(f"\nci-triage superseded runs: {checked - len(failures)} passed, {len(failures)} failed")
+raise SystemExit(1 if failures else 0)

--- a/tests/ci-triage-superseded-runs.test.py
+++ b/tests/ci-triage-superseded-runs.test.py
@@ -93,12 +93,34 @@ got = ct.failing_checks("1", run_for([
 ]), "o/r")
 check("e2) ...regardless of rollup order", got == ["shellcheck"], f"got {got}")
 
-# --- StatusContext entries carry `context`, not `name` -----------------------
+# --- StatusContext -----------------------------------------------------------
+# Keyed `context` not `name`, and carries startedAt with NO completedAt.
+def sc(context, state, started):
+    return {"__typename": "StatusContext", "context": context, "state": state,
+            "startedAt": started, "targetUrl": ""}
+
+
 got = ct.failing_checks("1", run_for([
-    {"context": "license/cla", "state": "FAILURE", "completedAt": "2026-09-03T09:00:00Z"},
-    {"context": "license/cla", "state": "SUCCESS", "completedAt": "2026-09-03T09:10:00Z"},
+    sc("license/cla", "FAILURE", "2026-09-03T09:00:00Z"),
+    sc("license/cla", "SUCCESS", "2026-09-03T09:10:00Z"),
 ]), "o/r")
-check("f) a StatusContext dedupes on `context` too", got == [], f"got {got}")
+check("f) a StatusContext dedupes on `context`, ordered by `startedAt` alone",
+      got == [], f"got {got}")
+
+got = ct.failing_checks("1", run_for([
+    sc("license/cla", "SUCCESS", "2026-09-03T09:00:00Z"),
+    sc("license/cla", "FAILURE", "2026-09-03T09:10:00Z"),
+]), "o/r")
+check("f2) ...and a later StatusContext FAILURE is still reported",
+      got == ["license/cla"], f"got {got}")
+
+got = ct.failing_checks("1", run_for([
+    sc("license/cla", "FAILURE", "2026-09-03T09:00:00Z"),
+    sc("license/cla", "SUCCESS", "2026-09-03T09:10:00Z"),
+    sc("continuous-integration", "FAILURE", "2026-09-03T09:10:00Z"),
+]), "o/r")
+check("f3) two distinct contexts: only the genuinely bad one reports",
+      got == ["continuous-integration"], f"got {got}")
 
 # --- _run_ids must not send the reader to a superseded run's log ------------
 ids = ct._run_ids("1", run_for([


### PR DESCRIPTION
## The defect

One head can carry several CI runs. A concurrency cancellation leaves the loser's jobs in `statusCheckRollup` beside the winner's, and a job that starts *while* its run is being cancelled exits non-zero and records `FAILURE` (not `CANCELLED`). `failing_checks()` counted every rollup entry, so that dead verdict read as a live red — and `_run_ids()` then pointed the reader at the cancelled run's log.

`mergeStateStatus` does not agree, because GitHub evaluates the **latest** entry per context. So the tool disagreed with the merge gate and the gate was right.

Observed on #3777: `tsc + tests (clean install)` FAILURE at `09:04:42Z` (cancelled run `33736582767`) and SUCCESS at `09:17:30Z` (live run `33736729725`) — **same sha**. The PR merged `CLEAN` while the tool still named the job. A head comparison cannot catch this: both runs are at the same head, so every staleness check passes.

## Before / after — live, on merged PR #3777

Pre-fix tree (`00a9d8129` = `dade9fe2b^`):

```
$ python3 -c "…; print(m.failing_checks('3777', run, 'sonichi/sutando'))"
['tsc + tests (clean install)']
```

At HEAD:

```
$ python3 -c "…; print(m.failing_checks('3777', run, 'sonichi/sutando'))"
[]
```

`gh pr view 3777 --json state` → `MERGED`; all 15 required contexts pass at their latest state.

## The fix

Dedupe by check name, keeping the latest by `completedAt`/`startedAt`. On an identical stamp there is no order to read, so **the failing entry wins** rather than being forgiven on a coin flip.

The pre-existing "CANCELLED is capacity, not a defect" contract is unchanged — and now also holds when CANCELLED is the *latest* entry for a name, not only when it is the sole one.

## Tests — 5 arms, 6 guards, stated separately

`tests/ci-triage-superseded-runs.test.py`. Run against the **pre-fix tree `00a9d8129`** (= `dade9fe2b^`), **5 of 11 fail; all 11 pass at HEAD**:

```
FAIL a) a superseded FAILURE with a later SUCCESS is NOT reported
  ok   b) SUCCESS superseded by a later FAILURE IS reported
  ok   c) an undisputed FAILURE still reports
  FAIL d) CANCELLED as the latest is capacity, not a failure
  ok   e) on an identical stamp the FAILURE wins (no silent forgiveness)
  ok   e2) ...regardless of rollup order
  FAIL f) a StatusContext dedupes on `context`, ordered by `startedAt` alone
  ok   f2) ...and a later StatusContext FAILURE is still reported
  FAIL f3) two distinct contexts: only the genuinely bad one reports
  FAIL g) _run_ids skips the superseded run's id
  ok   h) _run_ids returns the LIVE failing run's id

ci-triage superseded runs: 6 passed, 5 failed        <- 00a9d8129 (pre-fix)
ci-triage superseded runs: 11 passed, 0 failed        <- HEAD
```

**a, d, f, f3, g are arms** — they fail at `00a9d8129` and pass here. **b, c, e, e2, f2, h are guards**: they pass on the broken code too, because the broken code reports *every* failure and so trivially includes the ones they assert. They are not evidence the fix works; they exist so the fix cannot become a machine that only ever says "none", which is the failure mode a dedupe-by-latest invites. Stating which is which because a guard wearing an arm's name is how a suite passes while proving nothing.

`tests/ci-triage-subjects.test.py` (the existing pin) still passes.

## Scope

`scripts/ci-triage.py` only. No prompt or behaviour changes elsewhere.


> **⚠ The pre-fix tree is `00a9d8129`, NOT `HEAD^`.** `dade9fe2b` *is* the fix commit and `fcfe0e976`
> only touches the test, so `scripts/ci-triage.py` is byte-identical at `HEAD` and `HEAD^` — blob
> `dc7ef3b61` at both. Re-running the arms off `HEAD^` yields 11/0 twice and reads as "this test pins
> nothing". Use `00a9d8129` (blob `da492b1c6`). Caught by @yixuan-ag2, who lost an hour to it.
