### PR TITLE
feat(gateway): task-scoped attachment upload and a durable task acknowledgement

### DIFF
--- a/docs/remote-gateway-protocol.md
+++ b/docs/remote-gateway-protocol.md
@@ -79,12 +79,23 @@ room-specific provider session.
 Claim/acknowledge a task so the server stops redelivering it.
 
 ```
-body: { "id": "task-123" }
+body: { "id": "task-123", "durable": true }
 ```
 
 The client acks each task as it is accepted. A server with at-least-once
 delivery should treat ack as "stop redelivering"; the client is idempotent and
 will not re-queue a task it already claimed or archived.
+
+`durable: true` is sent only once the task file, its media sidecar and the
+in-flight set are all fsync'd, so the task survives a crash of this host. When a
+fresh queue write, its media sidecar, the in-flight set or the pending-ack
+ledger does not commit, the client withholds the ack entirely rather than
+claiming a task it could still lose. The flag is merely absent — a plain ack the
+server should treat as "stop redelivering" and nothing more — when a redelivered
+task is already queued and its durability could not be repaired. Acks that do
+not confirm are persisted and retried; a per-task `404 {"error": "not leased …"}`
+retires the retry for good, while a bare no-route 404/405 keeps the
+endpoint-unsupported cooldown.
 
 ### `POST /v1/results`
 
@@ -139,6 +150,18 @@ Credential routing is by parsed exact origin, never string matching:
 
 Authenticated fetches refuse redirects (a 3xx is a failure), so a
 gateway-controlled URL can never bounce a bearer to another host.
+
+Outbound `[file: …]` markers upload through `POST /v1/rooms/<room>/media`. A
+task the server marked with a `signal` object instead uploads against its own
+lease, `POST /v1/tasks/<id>/media` with `{ "ordinal": 0..9, "filename":
+"<name>", "content_b64": "…" }`, where `<id>` is the id the result is delivered
+under and `ordinal` is the marker's position in the body. The client records
+that mode in `state/remote-task-media[.<instance>].json` before the task is
+queued, so it survives a restart. `409` (content conflicts with an upload the
+server already recorded) and `423` (encrypted room) are reported in-band and
+never retried; a network failure or any 5xx defers the whole result, and the
+retry re-offers the same id, ordinal and bytes so the server can resume rather
+than store a second copy.
 
 ## Delivery + idempotency
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1281,6 +1281,9 @@ OUTBOUND_SCAN_S = float(os.environ.get("REMOTE_OUTBOUND_SCAN_S") or "1.0")
 _OUTBOUND_WAKE = threading.Event()
 _OUTBOUND_STOP = threading.Event()
 _INFLIGHT_MUTEX = threading.RLock()
+# True when the in-flight restore FAILED rather than finding no file. Both cases
+# yield an empty set, but only the second one means "nothing is in flight".
+_INFLIGHT_DEGRADED = False
 # Same hazard as the in-flight set: both ledgers are read-modify-written by the
 # poll loop and the outbound worker, so each load->mutate->write runs under a lock.
 _TASK_MEDIA_MUTEX = threading.RLock()
@@ -2127,9 +2130,12 @@ def _forget_pending_ack(tid: str) -> None:
 
 def _retry_pending_acks(inflight: "set[str]") -> None:
     """Re-post acks the gateway never confirmed. An id no longer in flight had
-    its lease closed by the result POST, so its record is retired unposted."""
+    its lease closed by the result POST, so its record is retired unposted.
+    That inference needs a TRUSTWORTHY in-flight set. When the restore degraded
+    the set is empty-because-unknown, so post instead and let the gateway's
+    'not leased' 404 retire the lease it actually closed."""
     for tid, durable in sorted(_load_pending_acks().items()):
-        if tid not in inflight:
+        if tid not in inflight and not _INFLIGHT_DEGRADED:
             _forget_pending_ack(tid)
             continue
         _post_task_ack(tid, durable)
@@ -3258,13 +3264,21 @@ def _post_proactive() -> None:
 
 
 def _load_inflight() -> set[str]:
-    """Restore the in-flight set from disk (fail-open to empty)."""
+    """Restore the in-flight set from disk (fail-open to empty).
+    A failed restore also sets _INFLIGHT_DEGRADED: the empty set it returns then
+    means "unknown", which is not what FileNotFoundError's empty set means."""
+    global _INFLIGHT_DEGRADED
     try:
         data = json.loads(INFLIGHT_FILE.read_text())
-        return {str(t) for t in data} if isinstance(data, list) else set()
+        if isinstance(data, list):
+            return {str(t) for t in data}
+        _INFLIGHT_DEGRADED = True
+        _log(f"inflight file is {type(data).__name__}, not a list — starting empty")
+        return set()
     except FileNotFoundError:
         return set()
     except Exception as e:  # noqa: BLE001
+        _INFLIGHT_DEGRADED = True
         _log(f"inflight file unreadable ({e}) — starting empty")
         return set()
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -412,6 +412,12 @@ INFLIGHT_FILE = _STATE / f"remote-task-inflight{_INST_SUFFIX}.json"
 # Sidecar map {task id → origin room id}, recorded at queue time. Outbound
 # file-attach needs the room because media uploads go to the room-scoped
 TASK_ROOMS_FILE = _STATE / f"remote-task-rooms{_INST_SUFFIX}.json"
+# Sidecar map {WIRE task id → {"mode": "task-media", "thread_root": …}}, committed
+# BEFORE the task is published: nothing else survives a restart to route the upload.
+TASK_MEDIA_FILE = _STATE / f"remote-task-media{_INST_SUFFIX}.json"
+# Acks the gateway has not confirmed yet, with the durability each one may claim.
+# The outbound worker retries them; a closed lease retires the record.
+PENDING_ACK_FILE = _STATE / f"remote-task-acks{_INST_SUFFIX}.json"
 # Re-asked task id -> the id the broker is waiting on. A dedup re-ask gets a
 # fresh local id, but the delivery it answers is still the original one.
 DEDUP_ALIAS_FILE = _STATE / f"remote-dedup-alias{_INST_SUFFIX}.json"
@@ -653,6 +659,53 @@ def _atomic_private_json(path: Path, payload: dict) -> None:
             os.unlink(temporary)
         except FileNotFoundError:
             pass
+
+
+def _stage_durable(path: Path, text: str) -> "Path | None":
+    """Write `text` to a sibling temp file and fsync it; None when nothing
+    reached the disk. Staging is separate from publishing because a sidecar the
+    published file refers to has to commit in between."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Per-INVOCATION, not per-PID: the poll loop and the outbound worker both
+        # publish through here, and a shared temp name lets one rename the other's bytes.
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+        with open(tmp, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return tmp
+    except Exception as exc:  # noqa: BLE001
+        _log(f"durable stage failed for {path.name} ({exc})")
+        return None
+
+
+def _publish_staged(tmp: Path, path: Path) -> bool:
+    """Rename a staged file into place and fsync the directory entry, so the
+    publication is durable the moment it becomes visible."""
+    try:
+        os.replace(tmp, path)
+        dfd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dfd)
+        finally:
+            os.close(dfd)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        _log(f"durable publish failed for {path.name} ({exc})")
+        return False
+
+
+def _durable_write(path: Path, text: str) -> bool:
+    """write temp → fsync file → rename → fsync parent directory. False when the
+    bytes did not commit, so the caller can withhold whatever they gate."""
+    tmp = _stage_durable(path, text)
+    if tmp is None:
+        return False
+    if _publish_staged(tmp, path):
+        return True
+    tmp.unlink(missing_ok=True)
+    return False
 
 
 def _read_private_json(path: Path) -> "dict | None":
@@ -1228,6 +1281,10 @@ OUTBOUND_SCAN_S = float(os.environ.get("REMOTE_OUTBOUND_SCAN_S") or "1.0")
 _OUTBOUND_WAKE = threading.Event()
 _OUTBOUND_STOP = threading.Event()
 _INFLIGHT_MUTEX = threading.RLock()
+# Same hazard as the in-flight set: both ledgers are read-modify-written by the
+# poll loop and the outbound worker, so each load->mutate->write runs under a lock.
+_TASK_MEDIA_MUTEX = threading.RLock()
+_PENDING_ACK_MUTEX = threading.RLock()
 
 
 def wake_outbound() -> None:
@@ -1256,6 +1313,10 @@ def _outbound_worker(inflight: "set[str]") -> None:
             _post_proactive()
         except Exception as e:  # noqa: BLE001
             _log(f"outbound worker: proactive drain error (isolated): {e}")
+        try:
+            _retry_pending_acks(inflight)
+        except Exception as e:  # noqa: BLE001
+            _log(f"outbound worker: pending-ack retry error (isolated): {e}")
         for tid in [t for t in first_seen if t not in inflight]:
             ms = (time.monotonic() - first_seen.pop(tid)) * 1000.0
             _log(f"outbound worker: {tid} seen->retired {ms:.0f}ms (monotonic)")
@@ -2035,8 +2096,49 @@ def _recover_auth(code: int) -> bool:
             return True
 
 
-def _post_task_ack(tid: str) -> bool:
-    """Tell the gateway a task made it safely into the local queue."""
+def _load_pending_acks() -> "dict[str, bool]":
+    """Acks the gateway never confirmed, mapped to the durability each may
+    claim (fail-open to empty: a lost ledger only costs a redelivery)."""
+    try:
+        data = json.loads(PENDING_ACK_FILE.read_text())
+    except FileNotFoundError:
+        return {}
+    except Exception as e:  # noqa: BLE001
+        _log(f"pending-ack file unreadable ({e}) — starting empty")
+        return {}
+    return {str(k): bool(v) for k, v in data.items()} if isinstance(data, dict) else {}
+
+
+def _record_pending_acks(pending: "list[tuple[str, bool]]") -> bool:
+    """Commit this round's acks before any of them is posted, so a crash between
+    ack and confirmation still leaves a ledger to retry from."""
+    with _PENDING_ACK_MUTEX:
+        acks = _load_pending_acks()
+        acks.update(dict(pending))
+        return _durable_write(PENDING_ACK_FILE, json.dumps(acks, sort_keys=True))
+
+
+def _forget_pending_ack(tid: str) -> None:
+    with _PENDING_ACK_MUTEX:
+        acks = _load_pending_acks()
+        if acks.pop(tid, None) is not None:
+            _durable_write(PENDING_ACK_FILE, json.dumps(acks, sort_keys=True))
+
+
+def _retry_pending_acks(inflight: "set[str]") -> None:
+    """Re-post acks the gateway never confirmed. An id no longer in flight had
+    its lease closed by the result POST, so its record is retired unposted."""
+    for tid, durable in sorted(_load_pending_acks().items()):
+        if tid not in inflight:
+            _forget_pending_ack(tid)
+            continue
+        _post_task_ack(tid, durable)
+
+
+def _post_task_ack(tid: str, durable: bool = False) -> bool:
+    """Tell the gateway a task made it safely into the local queue. `durable`
+    says the task file, its media sidecar and the in-flight set are all fsync'd,
+    which is the only thing that lets the relay call the task accepted."""
     global _ack_disabled_until
     # Validate the WIRE id (post-conversion): a named instance's LOCAL id may
     # legitimately exceed the 64-char wire bound (review P1 #1) — refusing on
@@ -2047,14 +2149,19 @@ def _post_task_ack(tid: str) -> bool:
     try:
         wire_tid = _broker_tid(tid)
         safe_tid = urllib.parse.quote(wire_tid, safe="")
-        _req("POST", f"/v1/tasks/{safe_tid}/ack", {"id": wire_tid}, timeout=10)
+        body = {"id": wire_tid}
+        if durable:
+            body["durable"] = True
+        _req("POST", f"/v1/tasks/{safe_tid}/ack", body, timeout=10)
         _ack_disabled_until = 0.0  # success (or re-enablement) → clear any backoff
+        _forget_pending_ack(tid)
         return True
     except urllib.error.HTTPError as e:
         if e.code in (404, 405):
             # A 404/405 is ambiguous. The pre-/ack broker returns a bare no-route
             # 404/405 → the endpoint is UNSUPPORTED: back off (cooldown) and retry
             if e.code == 404 and "not leased" in _http_error_body(e).lower():
+                _forget_pending_ack(tid)  # terminal: the lease is gone for good
                 return False   # per-task lease gone — keep acking the rest
             _ack_disabled_until = time.time() + ACK_UNSUPPORTED_COOLDOWN
             _log(f"gateway does not support task ack — retrying in "
@@ -2432,9 +2539,30 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
         _log(f"owner-activity write failed: {e}")
 
 
-def _write_task(task: dict) -> str | None:
+def _repair_pending_task(tid: str, task: dict) -> bool:
+    """A task the gateway redelivered while it is still queued here: fsync the
+    queued file and its directory and (re)commit the media sidecar, so a task
+    written by a pre-durability client can still earn a `durable` ack."""
+    tfile = find_task_file(TASKS_DIR, tid)
+    if tfile is None:
+        return False
+    try:
+        for target in (tfile, TASKS_DIR):
+            fd = os.open(target, os.O_RDONLY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+    except OSError as exc:
+        _log(f"durability repair failed for {tid} ({exc})")
+        return False
+    return _record_task_media(tid, task)
+
+
+def _write_task(task: dict) -> "tuple[str, bool] | None":
     """Serialize a gateway task into tasks/task-<id>.txt (same schema as bridges).
-    Returns the task id, or None if it has no id / already present."""
+    Returns (task id, durable) — `durable` says the queue write and its sidecar
+    committed, which is what an ack may claim — or None when nothing was queued."""
     broker_tid = str(task.get("id") or "").strip()
     if not broker_tid:
         _log("dropping task with no id")
@@ -2447,9 +2575,10 @@ def _write_task(task: dict) -> str | None:
     tid = _local_tid(broker_tid)
     task = {**task, "id": tid}
     dest = TASKS_DIR / f"{tid}.txt"
-    # Idempotent: don't re-write a task already queued, claimed, or archived.
+    # Idempotent: don't re-write a task already queued, claimed, or archived —
+    # but a pre-S1 queue file still has to earn its durability before the ack.
     if _task_pending(tid):
-        return tid
+        return tid, _repair_pending_task(tid, task)
     # Relay redelivery of already-handled work: on reconnect the gateway replays
     # its unacked pool, including tasks this node long since processed (the
     _task_archive = TASKS_DIR / "archive"
@@ -2462,14 +2591,15 @@ def _write_task(task: dict) -> str | None:
     )
     if task_archived or _delivered_copy_exists(tid):
         rfile = RESULTS_DIR / f"{tid}.txt"
+        durable = True
         if not rfile.exists():
-            RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-            rfile.write_text(GATEWAY_REDELIVERY_RESULT)
+            durable = _durable_write(rfile, GATEWAY_REDELIVERY_RESULT)
             # Provenance the result BODY cannot carry: a Team runtime controls
             # the body and can emit these exact bytes, but not this process's set.
-            _REDELIVERED.add(tid)
+            if durable:
+                _REDELIVERED.add(tid)
         _log(f"dedup: {tid} already handled — not re-queued")
-        return tid
+        return tid, durable
     TASKS_DIR.mkdir(parents=True, exist_ok=True)
     # Promote only the exact broker boolean plus Team request; the legacy Guest
     # wire tier keeps old nodes restricted and body text cannot opt itself in.
@@ -2593,10 +2723,20 @@ def _write_task(task: dict) -> str | None:
         lines.extend(render_skill_prelude(
             _one_line(task.get("channel_id") or ""), CHANNEL_DIR, tid,
             _one_line(task.get("addressed_to") or "")))
-    tmp = dest.with_suffix(".txt.tmp")
     from .local_task_protocol import apply_task_stamper
-    tmp.write_text(apply_task_stamper("\n".join(lines) + "\n"))
-    tmp.rename(dest)  # atomic publish so the watcher never sees a partial file
+    tmp = _stage_durable(dest, apply_task_stamper("\n".join(lines) + "\n"))
+    if tmp is None:
+        _log(f"task write FAILED for {tid} — not queued, not acked")
+        return None
+    # The sidecar has to be visible BEFORE the task is: the results watcher is
+    # already running, so a sidecar written after the publish can lose the race.
+    if not _record_task_media(tid, task):
+        tmp.unlink(missing_ok=True)
+        _log(f"media sidecar FAILED for {tid} — not queued, not acked")
+        return None
+    if not _publish_staged(tmp, dest):  # atomic publish: never a partial file
+        tmp.unlink(missing_ok=True)
+        return None
     _log(f"queued {tid}")
     # #2274 parity: one task_processed per NEWLY queued task (idempotent early
     # returns never reach here), bucketed to this gateway's own "remote" surface
@@ -2609,7 +2749,7 @@ def _write_task(task: dict) -> str | None:
     # Bridges-as-siblings: feed the proactive-loop's active-engagement gate — but
     # only for owner-tier senders (same resolved tier as the task above).
     _write_owner_activity(task, sender_tier)
-    return tid
+    return tid, True
 
 
 def _load_dedup_aliases() -> "dict[str, str] | None":
@@ -2701,33 +2841,114 @@ def _forget_task_room(tid: str) -> None:
         _save_task_rooms(rooms)
 
 
-def _upload_attachment(room: str, path_str: str) -> tuple[bool, str]:
-    """Upload one allowlisted local file to the task's room via the gateway
-    media endpoint. Returns (ok, reason)."""
+def _load_task_media() -> "dict | None":
+    """The per-task media-mode map, or None when it exists but cannot be read.
+
+    None is not the same as empty: guessing "no entry" sends a Signal task's
+    attachment down the room-scoped route, outside the task's own lease.
+    """
+    if not TASK_MEDIA_FILE.exists():
+        return {}
+    try:
+        loaded = json.loads(TASK_MEDIA_FILE.read_text())
+    except (OSError, ValueError) as exc:
+        _log(f"task-media sidecar unreadable ({exc}) — deferring")
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _record_task_media(tid: str, task: dict) -> bool:
+    """Commit this task's media mode, keyed by the WIRE id the media route posts
+    under. True when there is nothing to record (an ordinary relay task)."""
+    if not isinstance(task.get("signal"), dict):
+        return True
+    # A matching entry is re-committed rather than skipped: on the repair path an
+    # entry can be visible from a rename whose directory fsync never landed.
+    with _TASK_MEDIA_MUTEX:
+        media = _load_task_media()
+        if media is None:
+            return False
+        media[_broker_tid(tid)] = {"mode": "task-media",
+                                   "thread_root": str(task.get("thread_root") or "")}
+        return _durable_write(TASK_MEDIA_FILE, json.dumps(media, sort_keys=True))
+
+
+def _forget_task_media(tid: str) -> None:
+    """Retire a finished delivery's media mode (best-effort, like the room map)."""
+    delivery = _delivery_tid(tid)
+    if delivery is None:
+        return
+    with _TASK_MEDIA_MUTEX:
+        media = _load_task_media()
+        if media is None:
+            return
+        if media.pop(_broker_tid(delivery), None) is not None:
+            _durable_write(TASK_MEDIA_FILE, json.dumps(media, sort_keys=True))
+
+
+def _read_attachment(path_str: str) -> "tuple[str, str, str]":
+    """(basename, base64 bytes, "") for an allowlisted readable file, or
+    ("", "", reason) — the refusals both upload routes report in-band."""
     fpath = os.path.realpath(os.path.expanduser(path_str.strip()))
     if not is_path_sendable(fpath):
-        return False, "path not allowlisted"
+        return "", "", "path not allowlisted"
     try:
         size = os.path.getsize(fpath)
     except OSError as e:
-        return False, f"stat failed: {e}"
+        return "", "", f"stat failed: {e}"
     if size > MAX_MEDIA_BYTES:
-        return False, f"file exceeds {MAX_MEDIA_BYTES} bytes"
+        return "", "", f"file exceeds {MAX_MEDIA_BYTES} bytes"
     try:
         with open(fpath, "rb") as f:
-            content_b64 = base64.b64encode(f.read()).decode("ascii")
+            return os.path.basename(fpath), base64.b64encode(f.read()).decode("ascii"), ""
     except OSError as e:
-        return False, f"read failed: {e}"
+        return "", "", f"read failed: {e}"
+
+
+def _upload_attachment(room: str, path_str: str) -> tuple[bool, str]:
+    """Upload one allowlisted local file to the task's room via the gateway
+    media endpoint. Returns (ok, reason)."""
+    name, content_b64, reason = _read_attachment(path_str)
+    if reason:
+        return False, reason
     safe_room = urllib.parse.quote(room, safe="")
     try:
         _req("POST", f"/v1/rooms/{safe_room}/media",
-             {"filename": os.path.basename(fpath), "content_b64": content_b64},
-             timeout=60)
+             {"filename": name, "content_b64": content_b64}, timeout=60)
     except urllib.error.HTTPError as e:
         return False, f"HTTP {e.code}"
     except (urllib.error.URLError, TimeoutError) as e:
         return False, f"network error: {e}"
     return True, ""
+
+
+def _upload_task_attachment(wire_id: str, ordinal: int, path_str: str) -> "tuple[str, str]":
+    """Upload one attachment against a Signal task's own lease. Returns
+    ("ok"|"note"|"defer", reason).
+
+    "defer" holds the WHOLE result for the next scan rather than collapsing to
+    an in-band note: the retry has to re-offer the same wire id, ordinal and
+    bytes for the relay to resume the upload it may already have recorded.
+    """
+    name, content_b64, reason = _read_attachment(path_str)
+    if reason:
+        return "note", reason
+    safe_tid = urllib.parse.quote(wire_id, safe="")
+    try:
+        _req("POST", f"/v1/tasks/{safe_tid}/media",
+             {"ordinal": ordinal, "filename": name, "content_b64": content_b64},
+             timeout=60)
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            return "note", "content conflicts with the recorded upload"
+        if e.code == 423:
+            return "note", "room is encrypted"
+        if e.code >= 500:
+            return "defer", f"HTTP {e.code}"
+        return "note", f"HTTP {e.code}"
+    except (urllib.error.URLError, TimeoutError) as e:
+        return "defer", f"network error: {e}"
+    return "ok", ""
 
 
 def _archive_result(path: Path, tid: str) -> None:
@@ -3048,21 +3269,14 @@ def _load_inflight() -> set[str]:
         return set()
 
 
-def _save_inflight(inflight: set[str]) -> None:
-    """Atomically persist the in-flight set. Best-effort (never blocks the loop).
+def _save_inflight(inflight: set[str]) -> bool:
+    """Durably persist the in-flight set; False when it did not commit, which
+    withholds the ack that would have claimed it.
     The mutex covers snapshot+write: the poll loop and the outbound worker both
     save, and an unguarded interleave could persist a state missing the other
     thread's mutation (resurrecting a delivered id or dropping a fresh one)."""
     with _INFLIGHT_MUTEX:
-        try:
-            INFLIGHT_FILE.parent.mkdir(parents=True, exist_ok=True)
-            # Per-PID staging (sonichi/sutando#2222 follow-up): collision-proof if
-            # a second sparrow instance ever runs. os.replace is atomic overwrite.
-            tmp = INFLIGHT_FILE.with_suffix(f".json.{os.getpid()}.tmp")
-            tmp.write_text(json.dumps(sorted(inflight)))
-            os.replace(tmp, INFLIGHT_FILE)
-        except Exception as e:  # noqa: BLE001
-            _log(f"inflight persist failed ({e}) — continuing")
+        return _durable_write(INFLIGHT_FILE, json.dumps(sorted(inflight)))
 
 
 # (tid, path) pairs already uploaded this process — result-POST retry guard.
@@ -3274,6 +3488,10 @@ def _post_ready_results(inflight: set[str]) -> None:
                 _archive_result(rfile, tid)
                 inflight.discard(tid)
                 _forget_task_room(tid)
+                # A requeue carries the SAME delivery forward under a fresh local
+                # id, so only a retired delivery gives up its media mode.
+                if action != "requeue":
+                    _forget_task_media(tid)
                 _forget_dedup_alias(tid)
                 if action == "requeue":
                     inflight.add(payload)
@@ -3296,6 +3514,7 @@ def _post_ready_results(inflight: set[str]) -> None:
             _REDELIVERED.discard(tid)
             inflight.discard(tid)
             _forget_task_room(tid)
+            _forget_task_media(tid)
             changed = True
             _log(f"archived {tid} (marker {skip.value}, lease closed, not sent)")
             continue
@@ -3306,38 +3525,59 @@ def _post_ready_results(inflight: set[str]) -> None:
             # re-stitch the marker the parser stripped so the server still
             out_body = f"[channel: {redirect.value}]\n{out_body}"
         attaches = [a.value for a in parsed.actions if a.kind == "attach"]
+        # Resolved before the uploads: a Signal task posts its media under the
+        # DELIVERY id, and an unreadable ledger must defer rather than guess.
+        _delivery = _delivery_tid(tid)
+        if _delivery is None:
+            _log(f"delivery deferred for {tid} — alias ledger unreadable")
+            continue
+        _wire = _broker_tid(_delivery)
         if attaches:
+            _media = _load_task_media()
+            if _media is None:
+                _log(f"delivery deferred for {tid} — media sidecar unreadable")
+                continue
+            task_media = (_media.get(_wire) or {}).get("mode") == "task-media"
             room = _load_task_rooms().get(tid, "")
             sent = 0
-            for fp in attaches:
+            deferred = False
+            for ordinal, fp in enumerate(attaches):
                 # Uploads happen before the result POST (so failures can be
                 # annotated in-band); if that POST then fails and this loop
                 if (tid, fp) in _uploaded_attachments:
                     sent += 1
                     continue
-                ok, reason = (_upload_attachment(room, fp) if room
-                              else (False, "origin room unknown"))
-                if ok:
+                if task_media:
+                    status, reason = _upload_task_attachment(_wire, ordinal, fp)
+                else:
+                    ok, reason = (_upload_attachment(room, fp) if room
+                                  else (False, "origin room unknown"))
+                    status = "ok" if ok else "note"
+                if status == "defer":
+                    # A retryable upload failure holds the whole result: the next
+                    # scan re-offers the same wire id, ordinal and bytes.
+                    _log(f"attachment deferred for {tid}: {fp} ({reason})")
+                    deferred = True
+                    break
+                if status == "ok":
                     sent += 1
                     _uploaded_attachments.add((tid, fp))
-                    _log(f"attached {fp} to {room} for {tid}")
+                    _log(f"attached {fp} for {tid}")
                 else:
                     # Keep the information in-band rather than dropping the
                     # file silently — mirrors the other bridges' rejection UX.
                     out_body += f"\n[attachment not sent: {fp} ({reason})]"
                     _log(f"attachment skipped for {tid}: {fp} ({reason})")
+            if deferred:
+                continue
             if not out_body.strip() and sent:
                 out_body = "(file attached)"
-        _delivery = _delivery_tid(tid)
-        if _delivery is None:
-            _log(f"delivery deferred for {tid} — alias ledger unreadable")
-            continue
-        if not _deliver_result_payload(tid, _broker_tid(_delivery), out_body,
-                                       result_file=rfile):
+        if not _deliver_result_payload(tid, _wire, out_body, result_file=rfile):
             continue
         _archive_result(rfile, tid)
         inflight.discard(tid)
         _forget_task_room(tid)
+        _forget_task_media(tid)
         _forget_dedup_alias(tid)
         changed = True
         _log(f"delivered result for {tid}")
@@ -3783,18 +4023,20 @@ def main() -> None:
                     _retry_review_control_results()
                     _log(f"consumed private review decision {task.get('id')}")
                     continue
-                tid = _write_task(task)
-                if tid:
+                written = _write_task(task)
+                if written:
+                    tid, durable = written
                     if tid not in inflight:
                         inflight.add(tid)
                         added = True
-                    pending_ack.append(tid)
-            if added:
-                _save_inflight(inflight)
-            # Ack only after both the task file and local in-flight state are
-            # durable, so a crash after ack does not strand the eventual result.
-            for tid in pending_ack:
-                _post_task_ack(tid)
+                    pending_ack.append((tid, durable))
+            # Ack only after task file, in-flight set and ack ledger are durable;
+            # any failure withholds every ack this round, redeliveries included.
+            committed = _save_inflight(inflight) if pending_ack else True
+            if pending_ack and committed:
+                committed = _record_pending_acks(pending_ack)
+            for tid, durable in pending_ack if committed else ():
+                _post_task_ack(tid, durable)
             if added:
                 wake_outbound()          # a fresh task often precedes its ack round-trip
             abandoned_suspects = _reconcile_abandoned(inflight, abandoned_suspects)

--- a/packages/ag2-sparrow/tests/test_write_task_atomic.py
+++ b/packages/ag2-sparrow/tests/test_write_task_atomic.py
@@ -41,13 +41,14 @@ def test_write_task_publishes_atomically_and_completely():
     with tempfile.TemporaryDirectory() as d:
         base = pathlib.Path(d)
         m = _load(base)
-        tid = m._write_task(_task())
+        tid, durable = m._write_task(_task())
         dest = m.TASKS_DIR / f"{tid}.txt"
         assert tid == "task-1784500000000"
+        assert durable, "a committed queue write must be ackable as durable"
         assert dest.exists(), "task file must be published"
         # No temp sidecar left behind — the tmp+rename must have completed.
-        assert not (dest.with_suffix(".txt.tmp")).exists()
-        # The watcher globs task-*.txt; the tmp name (…​.txt.tmp) must not match it.
+        assert not list(m.TASKS_DIR.glob(f"{tid}.txt.*.tmp"))
+        # The watcher globs task-*.txt; the staged name (.txt.<pid>.<uuid>.tmp) must not match.
         assert list(m.TASKS_DIR.glob("task-*.txt")) == [dest]
         body = dest.read_text()
         assert body.endswith("\n")
@@ -74,21 +75,17 @@ def test_write_task_never_leaves_partial_file_on_publish_crash():
         m = _load(base)
         tid = "task-1784500000001"
         dest = m.TASKS_DIR / f"{tid}.txt"
-        orig_rename = pathlib.Path.rename
+        orig_replace = m.os.replace
 
-        def boom(self, target):
+        def boom(src, target):
             raise OSError("simulated crash at publish")
 
-        pathlib.Path.rename = boom
+        m.os.replace = boom
         try:
-            raised = False
-            try:
-                m._write_task(_task(tid))
-            except OSError:
-                raised = True
-            assert raised, "a failed publish must surface, not silently succeed"
+            assert m._write_task(_task(tid)) is None, (
+                "a failed publish must report failure, not a queued task")
         finally:
-            pathlib.Path.rename = orig_rename
+            m.os.replace = orig_replace
         # The watcher-visible .txt must NOT exist — only nothing or a .tmp sidecar.
         assert not dest.exists(), "partial task must never be visible to the watcher"
         print("PASS test_write_task_never_leaves_partial_file_on_publish_crash")
@@ -101,14 +98,14 @@ def test_write_task_is_idempotent_under_redelivery():
         base = pathlib.Path(d)
         m = _load(base)
         t = _task("task-1784500000002")
-        tid1 = m._write_task(t)
+        tid1, _ = m._write_task(t)
         first = (m.TASKS_DIR / f"{tid1}.txt").read_text()
         # Redeliver the SAME id with a DIFFERENT body: the guard must skip the
         # rewrite entirely (return the id, leave the queued file byte-for-byte).
         # A modified body proves the guard fired — an identical body could pass
         # even with no guard at all.
         redelivered = dict(t, task="[AG2Space qingyun] TAMPERED redelivery body")
-        tid2 = m._write_task(redelivered)
+        tid2, _ = m._write_task(redelivered)
         assert tid1 == tid2
         assert list(m.TASKS_DIR.glob("task-*.txt")) == [m.TASKS_DIR / f"{tid1}.txt"]
         # Untouched — the original queued content wins, not the redelivery.
@@ -129,7 +126,7 @@ def test_write_task_does_not_reexecute_a_completed_task():
         arch = m.TASKS_DIR / "archive"
         arch.mkdir(parents=True, exist_ok=True)
         (arch / f"{tid}.txt").write_text(f"id: {tid}\ntask: handled earlier\n")
-        assert m._write_task(_task(tid)) == tid
+        assert m._write_task(_task(tid)) == (tid, True)
         # NOT re-queued — nothing live for the watcher to execute a second time.
         assert list(m.TASKS_DIR.glob("task-*.txt")) == []
         rfile = m.RESULTS_DIR / f"{tid}.txt"
@@ -142,7 +139,7 @@ def test_write_task_does_not_reexecute_a_completed_task():
         tid = "task-1784500000011"
         m.ARCHIVE_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
         (m.ARCHIVE_RESULTS_DIR / f"{tid}-1784500000999.txt").write_text("earlier reply\n")
-        assert m._write_task(_task(tid)) == tid
+        assert m._write_task(_task(tid)) == (tid, True)
         assert list(m.TASKS_DIR.glob("task-*.txt")) == []
         rfile = m.RESULTS_DIR / f"{tid}.txt"
         assert rfile.exists() and rfile.read_text().startswith("[no-send]")
@@ -168,7 +165,7 @@ def test_write_task_shell_quotes_channel_id_in_skill_instructions():
         malicious_chan = "!room'; touch /tmp/ag2sparrow_pwned; #"
         t = _task("task-1784500000020")
         t["channel_id"] = malicious_chan
-        tid = m._write_task(t)
+        tid, _ = m._write_task(t)
         body = (m.TASKS_DIR / f"{tid}.txt").read_text()
         context_line = next(ln for ln in body.splitlines() if "room_ops.py read" in ln)
         context_cmd = context_line.split("`python3 ", 1)[1].split("`", 1)[0]

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -255,11 +255,12 @@ def main() -> int:
     # _post_ready_results dropped it from inflight with the result stranded.
     _maxid = "task-" + "M" * 59
     check(_lrtc._valid_tid(_maxid), "max-length broker id is wire-valid (precondition)")
-    _mt = _grtc._write_task({"id": _maxid, "timestamp": "2026-08-02T00:00:00Z",
-                             "task": "MAXLEN", "source": "remote-gateway",
-                             "channel_id": "!p:example.org", "user_id": "@q:example.org"})
-    check(_mt == f"task-dev~{_maxid}" and (_grtc.TASKS_DIR / f"{_mt}.txt").exists(),
-          "max-length broker id queues under the instance encoding")
+    _mt, _mt_durable = _grtc._write_task({"id": _maxid, "timestamp": "2026-08-02T00:00:00Z",
+                                          "task": "MAXLEN", "source": "remote-gateway",
+                                          "channel_id": "!p:example.org", "user_id": "@q:example.org"})
+    check(_mt == f"task-dev~{_maxid}" and _mt_durable
+          and (_grtc.TASKS_DIR / f"{_mt}.txt").exists(),
+          "max-length broker id queues durably under the instance encoding")
     check(_grtc._valid_local_tid(_mt) and not _lrtc._valid_tid(_mt),
           "local validator accepts the over-64 encoding the wire validator refuses")
     _ab = len(STATE["acks"])
@@ -284,8 +285,8 @@ def main() -> int:
     _collide = {"id": "task-COLLIDE", "timestamp": "2026-08-02T00:00:00Z",
                 "task": "PROD TASK", "source": "remote-gateway",
                 "channel_id": "!p:example.org", "user_id": "@qingyun:example.org"}
-    _pt = _lrtc._write_task(dict(_collide))
-    _dt = _grtc._write_task({**_collide, "task": "DEV TASK"})
+    _pt, _ = _lrtc._write_task(dict(_collide))
+    _dt, _ = _grtc._write_task({**_collide, "task": "DEV TASK"})
     check(_pt == "task-COLLIDE" and _dt == "task-dev~task-COLLIDE",
           "same broker id yields DISTINCT local ids per instance")
     check((_lrtc.TASKS_DIR / "task-COLLIDE.txt").exists()
@@ -329,8 +330,8 @@ def main() -> int:
 
     # 1. pull a task and write it locally
     resp = rtc._req("GET", "/v1/tasks?wait=0")
-    tid = rtc._write_task(resp["tasks"][0])
-    check(tid == "task-MOCK1", "pull → task id parsed")
+    tid, _durable = rtc._write_task(resp["tasks"][0])
+    check(tid == "task-MOCK1" and _durable, "pull → task id parsed, durably queued")
     tfile = rtc.TASKS_DIR / "task-MOCK1.txt"
     check(tfile.exists(), "task file written")
     content = tfile.read_text() if tfile.exists() else ""
@@ -861,7 +862,7 @@ def main() -> int:
     # re-acks it upstream. (Regression for the reconnect redelivery floods.)
     (rtc.TASKS_DIR / "archive").mkdir(parents=True, exist_ok=True)
     (rtc.TASKS_DIR / "archive" / "task-DONE1.txt").write_text("handled")
-    check(rtc._write_task({**TASK, "id": "task-DONE1"}) == "task-DONE1"
+    check(rtc._write_task({**TASK, "id": "task-DONE1"}) == ("task-DONE1", True)
           and not (rtc.TASKS_DIR / "task-DONE1.txt").exists(),
           "redelivery of core-archived task not re-queued (id returned for ack)")
     check((rtc.RESULTS_DIR / "task-DONE1.txt").read_text().startswith("[no-send]"),
@@ -872,14 +873,14 @@ def main() -> int:
     # flat-only archive probe (PR #1896 review).
     (rtc.TASKS_DIR / "archive" / "2026-07").mkdir(parents=True, exist_ok=True)
     (rtc.TASKS_DIR / "archive" / "2026-07" / "task-MONTH.txt").write_text("handled")
-    check(rtc._write_task({**TASK, "id": "task-MONTH"}) == "task-MONTH"
+    check(rtc._write_task({**TASK, "id": "task-MONTH"}) == ("task-MONTH", True)
           and not (rtc.TASKS_DIR / "task-MONTH.txt").exists(),
           "redelivery of month-partitioned-archived task not re-queued")
     check((rtc.RESULTS_DIR / "task-MONTH.txt").read_text().startswith("[no-send]"),
           "month-archive dedup drops a [no-send] result")
     rtc.ARCHIVE_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
     (rtc.ARCHIVE_RESULTS_DIR / "task-DONE2-1750000000.txt").write_text("sent")
-    check(rtc._write_task({**TASK, "id": "task-DONE2"}) == "task-DONE2"
+    check(rtc._write_task({**TASK, "id": "task-DONE2"}) == ("task-DONE2", True)
           and not (rtc.TASKS_DIR / "task-DONE2.txt").exists(),
           "redelivery of archived-result task not re-queued")
     (rtc.RESULTS_DIR / "task-DONE3.txt").write_text("real result pending\n")
@@ -887,7 +888,7 @@ def main() -> int:
     rtc._write_task({**TASK, "id": "task-DONE3"})
     check((rtc.RESULTS_DIR / "task-DONE3.txt").read_text() == "real result pending\n",
           "dedup never clobbers an existing pending result")
-    check(rtc._write_task({**TASK, "id": "task-DONE"}) == "task-DONE"
+    check(rtc._write_task({**TASK, "id": "task-DONE"}) == ("task-DONE", True)
           and (rtc.TASKS_DIR / "task-DONE.txt").exists(),
           "prefix id does not false-match an archived sibling (task-DONE vs task-DONE2)")
 

--- a/tests/gateway-durable-ack.test.py
+++ b/tests/gateway-durable-ack.test.py
@@ -369,6 +369,66 @@ class DurableAck(unittest.TestCase):
             self._drive_main([self._task("task-main-old")])
         self.assertEqual(self._acks()[0][2], {"id": "task-main-old"})
 
+    # Two fail-opens compose: `_load_inflight` returns empty on a corrupt file, and
+    # `_retry_pending_acks` retires every id absent from it — unposted.
+
+    def _seed_acks(self, ids):
+        self.mod._durable_write(self.mod.PENDING_ACK_FILE,
+                                json.dumps({t: True for t in ids}, sort_keys=True))
+
+    def test_intact_inflight_posts_and_keeps_the_ledger(self):
+        """CONTROL: a readable in-flight set holding the same ids posts all three."""
+        mod = self.mod
+        ids = ["task-A", "task-B", "task-C"]
+        self._seed_acks(ids)
+        mod.INFLIGHT_FILE.write_text(json.dumps(ids))
+        mod._INFLIGHT_DEGRADED = False
+        mod._retry_pending_acks(mod._load_inflight())
+        self.assertEqual(sorted(c[1].split("/")[-2] for c in self._acks()), ids,
+                         "an intact in-flight set must post every pending ack")
+
+    def test_corrupt_inflight_does_not_retire_acks_unposted(self):
+        """TREATMENT: identical, except the in-flight file is truncated mid-write."""
+        mod = self.mod
+        ids = ["task-A", "task-B", "task-C"]
+        self._seed_acks(ids)
+        mod.INFLIGHT_FILE.write_text('["task-A", "task-B", "tas')   # truncated
+        mod._INFLIGHT_DEGRADED = False
+        inflight = mod._load_inflight()
+        self.assertEqual(inflight, set(), "precondition: the restore fails open to empty")
+        self.assertTrue(mod._INFLIGHT_DEGRADED, "a failed restore must mark itself degraded")
+        mod._retry_pending_acks(inflight)
+        self.assertEqual(sorted(c[1].split("/")[-2] for c in self._acks()), ids,
+                         "acks must be POSTED, not retired, when in-flight is unknown")
+        self.assertEqual(sorted(mod._load_pending_acks()), [],
+                         "a posted ack is retired normally by _post_task_ack")
+
+    def test_non_list_inflight_is_also_unknown(self):
+        """Valid JSON of the wrong type is corruption too, not an empty set."""
+        mod = self.mod
+        self._seed_acks(["task-A"])
+        mod.INFLIGHT_FILE.write_text('{"task-A": true}')            # object, not list
+        mod._INFLIGHT_DEGRADED = False
+        inflight = mod._load_inflight()
+        self.assertEqual(inflight, set())
+        self.assertTrue(mod._INFLIGHT_DEGRADED, "a non-list payload must mark degraded")
+        mod._retry_pending_acks(inflight)
+        self.assertEqual([c[1].split("/")[-2] for c in self._acks()], ["task-A"])
+
+    def test_missing_inflight_file_still_retires(self):
+        """The fix must NOT disable retirement generally: a genuinely absent file
+        means nothing is in flight, and that inference is still sound."""
+        mod = self.mod
+        self._seed_acks(["task-gone"])
+        if mod.INFLIGHT_FILE.exists():
+            mod.INFLIGHT_FILE.unlink()
+        mod._INFLIGHT_DEGRADED = False
+        inflight = mod._load_inflight()
+        self.assertFalse(mod._INFLIGHT_DEGRADED, "FileNotFoundError is not degradation")
+        mod._retry_pending_acks(inflight)
+        self.assertEqual(self._acks(), [], "a closed lease is retired without posting")
+        self.assertEqual(sorted(mod._load_pending_acks()), [])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/gateway-durable-ack.test.py
+++ b/tests/gateway-durable-ack.test.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""`durable: true` is a promise the client has to be able to keep.
+
+The relay only calls a task accepted when the ack carries `durable: true`, so
+the client may send it only once the task file, its media sidecar and the
+in-flight set have reached the disk — and must withhold the ack entirely
+otherwise. Acks that never confirm are persisted and retried.
+
+Covers:
+  1. the four state writes go temp → fsync file → rename → fsync directory;
+  2. a task queued by a pre-durability client and redelivered after the upgrade
+     is verified, fsync'd and given its sidecar before a durable ack is allowed;
+  3. every failure boundary (task write, sidecar, in-flight set, ack ledger)
+     withholds the ack rather than claiming a task that could be lost;
+  4. pending acks are retried by the outbound worker, retired on a per-task
+     `not leased` 404, and kept behind the cooldown on a bare no-route 404;
+  5. the production ack round — `main()` itself, not a copy of its ordering —
+     puts `durable` on the wire and withholds every ack of a failed round.
+
+Run: python3 tests/gateway-durable-ack.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "remote-gateway-bridge.py"
+
+SIGNAL = {"v": 1, "cid": "cid-9", "route_attempt": 1,
+          "source_root": "$root:server", "source_room": "!room:server"}
+
+
+def _load(ws: Path):
+    """Load the hyphenated bridge module against a scratch workspace."""
+    os.environ["SUTANDO_TEST_WORKSPACE"] = str(ws)
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "test-token-0123456789abcdef")
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.invalid/relay")
+    os.environ["GATEWAY_INSTANCE"] = ""
+    sys.path.insert(0, str(REPO / "src"))
+    spec = importlib.util.spec_from_file_location("rgb_durable_ack", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    with patch("workspace_default.resolve_workspace", return_value=ws):
+        spec.loader.exec_module(mod)
+    mod.WS = ws
+    mod.TASKS_DIR = ws / "tasks"
+    mod.RESULTS_DIR = ws / "results"
+    mod.ARCHIVE_RESULTS_DIR = ws / "results" / "archive"
+    mod.INFLIGHT_FILE = ws / "state" / "remote-task-inflight.json"
+    mod.TASK_ROOMS_FILE = ws / "state" / "remote-task-rooms.json"
+    mod.TASK_MEDIA_FILE = ws / "state" / "remote-task-media.json"
+    mod.PENDING_ACK_FILE = ws / "state" / "remote-task-acks.json"
+    mod.DEDUP_ALIAS_FILE = ws / "state" / "remote-dedup-alias.json"
+    mod._ack_disabled_until = 0.0
+    for d in (mod.TASKS_DIR, mod.RESULTS_DIR, ws / "state"):
+        d.mkdir(parents=True, exist_ok=True)
+    return mod
+
+
+def _http(code: int, body: bytes = b""):
+    return urllib.error.HTTPError("https://gw.invalid/relay", code, "err", {},
+                                  io.BytesIO(body))
+
+
+class DurableAck(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        self.mod = _load(self.ws)
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self._req_patch = patch.object(self.mod, "_req", side_effect=self._fake_req)
+        self._req_patch.start()
+        self.addCleanup(self._req_patch.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _fake_req(self, method, path, payload=None, timeout=35):
+        self.calls.append((method, path, payload))
+        return {}
+
+    def _acks(self):
+        return [c for c in self.calls if c[1].endswith("/ack")]
+
+    def _task(self, tid: str, signal: bool = True) -> dict:
+        task = {"id": tid, "task": "dig into this", "source": "ag2space",
+                "channel_id": "!room:server", "access_tier": "owner",
+                "user_id": "@owner:server", "thread_root": "$root:server"}
+        if signal:
+            task["signal"] = dict(SIGNAL)
+        return task
+
+    def _ack_round(self, tasks: list) -> list:
+        """main()'s ordering: nothing is acked until every durable write lands."""
+        mod = self.mod
+        inflight, pending = mod._load_inflight(), []
+        for task in tasks:
+            written = mod._write_task(task)
+            if written:
+                tid, durable = written
+                inflight.add(tid)
+                pending.append((tid, durable))
+        committed = mod._save_inflight(inflight) if pending else True
+        if pending and committed:
+            committed = mod._record_pending_acks(pending)
+        for tid, durable in pending if committed else ():
+            mod._post_task_ack(tid, durable)
+        return pending
+
+    # -- 1. the durable-write sequence -------------------------------------- #
+
+    def test_durable_write_fsyncs_the_file_then_the_directory(self):
+        mod = self.mod
+        trace: list[str] = []
+        real_fsync, real_replace = mod.os.fsync, mod.os.replace
+
+        def spy_fsync(fd):
+            kind = "dir" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
+            trace.append(f"fsync-{kind}")
+            return real_fsync(fd)
+
+        def spy_replace(src, dst):
+            trace.append("rename")
+            return real_replace(src, dst)
+
+        with patch.object(mod.os, "fsync", spy_fsync), \
+             patch.object(mod.os, "replace", spy_replace):
+            self.assertTrue(mod._durable_write(self.ws / "state" / "x.json", "{}"))
+        self.assertEqual(trace, ["fsync-file", "rename", "fsync-dir"])
+
+    def test_the_queue_write_publishes_through_the_durable_sequence(self):
+        mod = self.mod
+        trace: list[str] = []
+        real_fsync, real_replace = mod.os.fsync, mod.os.replace
+
+        def spy_fsync(fd):
+            trace.append("dir" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file")
+            return real_fsync(fd)
+
+        def spy_replace(src, dst):
+            trace.append(f"rename:{Path(dst).name}")
+            return real_replace(src, dst)
+
+        with patch.object(mod.os, "fsync", spy_fsync), \
+             patch.object(mod.os, "replace", spy_replace):
+            self.assertEqual(mod._write_task(self._task("task-seq")), ("task-seq", True))
+        at = trace.index("rename:remote-task-media.json")
+        # Both files are staged and fsync'd first; the sidecar then commits, and
+        # only after that does the task become visible to the watcher.
+        self.assertEqual(trace[:at].count("file"), 2)
+        self.assertEqual(trace[at:at + 4], ["rename:remote-task-media.json", "dir",
+                                            "rename:task-seq.txt", "dir"])
+
+    # -- 2. a pre-durability task redelivered after the upgrade -------------- #
+
+    def test_pre_s1_pending_task_is_repaired_before_a_durable_ack(self):
+        mod = self.mod
+        # What a pre-S1 client left behind: a queued task file and nothing else.
+        (mod.TASKS_DIR / "task-old.txt").write_text(
+            "id: task-old\naccess_tier: owner\ntask: earlier\n")
+        self.assertFalse(mod.TASK_MEDIA_FILE.exists())
+        seen: list[bool] = []
+        real = mod._post_task_ack
+
+        def ack(tid, durable=False):
+            seen.append(mod.TASK_MEDIA_FILE.exists())
+            return real(tid, durable)
+
+        with patch.object(mod, "_post_task_ack", side_effect=ack):
+            self._ack_round([self._task("task-old")])
+        self.assertEqual(seen, [True], "the sidecar must exist before the ack")
+        self.assertEqual(self._acks()[0][2], {"id": "task-old", "durable": True})
+        self.assertEqual(mod._load_task_media()["task-old"],
+                         {"mode": "task-media", "thread_root": "$root:server"})
+        self.assertEqual((mod.TASKS_DIR / "task-old.txt").read_text(),
+                         "id: task-old\naccess_tier: owner\ntask: earlier\n",
+                         "repair must not rewrite the queued file")
+
+    def test_a_redelivery_recommits_the_in_flight_set(self):
+        mod = self.mod
+        # A pre-durability client's ledger: readable, but never fsync'd.
+        mod.INFLIGHT_FILE.write_text(json.dumps(["task-old3"]))
+        (mod.TASKS_DIR / "task-old3.txt").write_text("id: task-old3\n")
+        saved: list = []
+        real = mod._save_inflight
+        with patch.object(mod, "_save_inflight",
+                          side_effect=lambda s: saved.append(sorted(s)) or real(s)):
+            self._ack_round([self._task("task-old3")])
+        self.assertEqual(saved, [["task-old3"]],
+                         "a redelivery of an already-inflight id still re-commits")
+        self.assertEqual(self._acks()[0][2], {"id": "task-old3", "durable": True})
+
+    def test_unrepairable_pending_task_is_acked_without_durability(self):
+        mod = self.mod
+        (mod.TASKS_DIR / "task-old2.txt").write_text("id: task-old2\n")
+        with patch.object(mod, "_record_task_media", return_value=False):
+            self._ack_round([self._task("task-old2")])
+        self.assertEqual(self._acks()[0][2], {"id": "task-old2"},
+                         "an unrepaired task must not be claimed as durable")
+
+    def test_an_ordinary_task_is_acked_durable_with_no_sidecar(self):
+        self._ack_round([self._task("task-plain", signal=False)])
+        self.assertEqual(self._acks()[0][2], {"id": "task-plain", "durable": True})
+        self.assertFalse(self.mod.TASK_MEDIA_FILE.exists())
+
+    # -- 3. every failure boundary withholds the ack ------------------------- #
+
+    def test_task_write_failure_queues_nothing_and_acks_nothing(self):
+        mod = self.mod
+        with patch.object(mod, "_stage_durable", return_value=None):
+            self.assertEqual(self._ack_round([self._task("task-w")]), [])
+        self.assertEqual(self._acks(), [])
+        self.assertFalse((mod.TASKS_DIR / "task-w.txt").exists())
+
+    def test_sidecar_failure_queues_nothing_and_acks_nothing(self):
+        mod = self.mod
+        with patch.object(mod, "_save_inflight", return_value=True), \
+             patch.object(mod, "_load_task_media", return_value=None):
+            self.assertEqual(self._ack_round([self._task("task-s")]), [])
+        self.assertEqual(self._acks(), [])
+        self.assertFalse((mod.TASKS_DIR / "task-s.txt").exists())
+
+    def test_inflight_persist_failure_withholds_the_ack(self):
+        mod = self.mod
+        with patch.object(mod, "_save_inflight", return_value=False):
+            self._ack_round([self._task("task-i")])
+        self.assertEqual(self._acks(), [])
+        self.assertTrue((mod.TASKS_DIR / "task-i.txt").exists(),
+                        "the task is queued; only the claim is withheld")
+
+    def test_ack_ledger_persist_failure_withholds_the_ack(self):
+        mod = self.mod
+        with patch.object(mod, "_record_pending_acks", return_value=False):
+            self._ack_round([self._task("task-a")])
+        self.assertEqual(self._acks(), [])
+
+    def test_one_failed_write_withholds_the_whole_round(self):
+        mod = self.mod
+        with patch.object(mod, "_save_inflight", return_value=False):
+            self._ack_round([self._task("task-b1"), self._task("task-b2")])
+        self.assertEqual(self._acks(), [])
+
+    # -- 4. the pending-ack ledger ------------------------------------------ #
+
+    def test_a_confirmed_ack_retires_its_record(self):
+        mod = self.mod
+        self._ack_round([self._task("task-ok")])
+        self.assertEqual(mod._load_pending_acks(), {})
+
+    def test_lost_response_keeps_the_record_and_the_worker_retries_it(self):
+        mod = self.mod
+        with patch.object(mod, "_req", side_effect=urllib.error.URLError("down")):
+            self._ack_round([self._task("task-lost")])
+        self.assertEqual(mod._load_pending_acks(), {"task-lost": True})
+        mod._retry_pending_acks({"task-lost"})
+        self.assertEqual(self._acks()[-1][2], {"id": "task-lost", "durable": True})
+        self.assertEqual(mod._load_pending_acks(), {})
+
+    def test_not_leased_404_retires_the_record_without_a_cooldown(self):
+        mod = self.mod
+        with patch.object(mod, "_req", side_effect=urllib.error.URLError("down")):
+            self._ack_round([self._task("task-gone")])
+        # The result completed before the retry, so the lease is closed for good.
+        with patch.object(mod, "_req",
+                          side_effect=_http(404, b'{"error":"not leased to you"}')):
+            mod._retry_pending_acks({"task-gone"})
+        self.assertEqual(mod._load_pending_acks(), {})
+        self.assertEqual(mod._ack_disabled_until, 0.0)
+
+    def test_bare_404_keeps_the_record_behind_the_cooldown(self):
+        mod = self.mod
+        with patch.object(mod, "_req", side_effect=_http(404, b"no route here")):
+            self._ack_round([self._task("task-nortr")])
+        self.assertEqual(mod._load_pending_acks(), {"task-nortr": True})
+        self.assertGreater(mod._ack_disabled_until, 0.0)
+
+    def test_a_retired_task_drops_its_pending_ack_unposted(self):
+        mod = self.mod
+        with patch.object(mod, "_req", side_effect=urllib.error.URLError("down")):
+            self._ack_round([self._task("task-done")])
+        before = len(self._acks())
+        mod._retry_pending_acks(set())     # the result POST already closed it
+        self.assertEqual(len(self._acks()), before)
+        self.assertEqual(mod._load_pending_acks(), {})
+
+    def test_the_ledger_survives_a_restart(self):
+        mod = self.mod
+        with patch.object(mod, "_req", side_effect=urllib.error.URLError("down")):
+            self._ack_round([self._task("task-restart")])
+        fresh = _load(self.ws)
+        self.assertEqual(fresh._load_pending_acks(), {"task-restart": True})
+        calls: list = []
+        with patch.object(fresh, "_req", side_effect=lambda *a, **k: calls.append(a) or {}):
+            fresh._retry_pending_acks({"task-restart"})
+        self.assertEqual(calls[0][2], {"id": "task-restart", "durable": True})
+
+
+    # -- 5. the production ack round, driven through main() ------------------ #
+
+    def _drive_main(self, tasks: list, ack_raises: BaseException | None = None) -> None:
+        """One iteration of the real `main()` — the second singleton check ends
+        it. `_write_task`, `_save_inflight`, `_record_pending_acks` and
+        `_post_task_ack` all stay live, so this drives the production ack round
+        rather than a copy of it. Mirrors tests/gateway-longpoll-timeout.test.py.
+        """
+        mod = self.mod
+        alive = [True, False]
+
+        def req(method, path, payload=None, timeout=35):
+            self.calls.append((method, path, payload))
+            if path.startswith("/v1/tasks?wait="):
+                return {"tasks": list(tasks)}
+            if ack_raises is not None and path.endswith("/ack"):
+                raise ack_raises
+            return {}
+
+        noops = ("_recover_orphan_proactive", "_maybe_start_event_channel",
+                 "_post_heartbeat", "_post_ready_results", "_post_proactive",
+                 "_retry_pending_acks", "_reconcile_orphan_results",
+                 "_retry_pending_publications", "_retry_review_card_resolutions",
+                 "_retry_review_control_results", "_emit_gateway_status",
+                 "_start_results_watcher", "_log")
+        with patch.multiple(mod, **{n: lambda *a, **k: None for n in noops}), \
+                patch.object(mod, "_acquire_singleton", return_value=True), \
+                patch.object(mod, "_heartbeat_singleton",
+                             side_effect=lambda *a, **k: alive.pop(0) if alive else False), \
+                patch.object(mod, "_reconcile_abandoned",
+                             side_effect=lambda inflight, s, *a, **k: s), \
+                patch.object(mod, "_req", side_effect=req):
+            mod.main()
+
+    def test_main_acks_the_task_it_durably_queued(self):
+        mod = self.mod
+        self._drive_main([self._task("task-main")])
+        self.assertEqual(self._acks()[0][2], {"id": "task-main", "durable": True},
+                         "the production call site must put `durable` on the wire")
+        self.assertTrue((mod.TASKS_DIR / "task-main.txt").exists())
+        self.assertEqual(json.loads(mod.INFLIGHT_FILE.read_text()), ["task-main"])
+        self.assertEqual(mod._load_pending_acks(), {})
+
+    def test_main_withholds_the_ack_when_the_in_flight_set_did_not_commit(self):
+        with patch.object(self.mod, "_save_inflight", return_value=False):
+            self._drive_main([self._task("task-main-i")])
+        self.assertEqual(self._acks(), [])
+
+    def test_main_withholds_the_ack_when_the_ack_ledger_did_not_commit(self):
+        with patch.object(self.mod, "_record_pending_acks", return_value=False):
+            self._drive_main([self._task("task-main-a")])
+        self.assertEqual(self._acks(), [])
+
+    def test_main_records_the_pending_ack_before_posting_it(self):
+        mod = self.mod
+        self._drive_main([self._task("task-main-lost")],
+                         ack_raises=urllib.error.URLError("down"))
+        self.assertEqual(mod._load_pending_acks(), {"task-main-lost": True},
+                         "the ledger must be committed before the ack is posted")
+
+    def test_main_acks_an_unrepaired_redelivery_without_the_flag(self):
+        mod = self.mod
+        (mod.TASKS_DIR / "task-main-old.txt").write_text("id: task-main-old\n")
+        with patch.object(mod, "_record_task_media", return_value=False):
+            self._drive_main([self._task("task-main-old")])
+        self.assertEqual(self._acks()[0][2], {"id": "task-main-old"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway-orphan-result-reconciler.test.py
+++ b/tests/gateway-orphan-result-reconciler.test.py
@@ -256,8 +256,8 @@ class WriteTaskSharedPredicate(_Base):
         d = gw.ARCHIVE_RESULTS_DIR / "2026-08"
         d.mkdir(parents=True)
         (d / f"{TID}.txt").write_text("the reply")
-        tid = gw._write_task({"id": TID, "task": "hi", "source": "ag2space"})
-        self.assertEqual(tid, TID)
+        written = gw._write_task({"id": TID, "task": "hi", "source": "ag2space"})
+        self.assertEqual(written, (TID, True))
         self.assertFalse((gw.TASKS_DIR / f"{TID}.txt").exists(),
                          "already-handled redelivery must not re-queue")
         self.assertIn("[no-send]", (gw.RESULTS_DIR / f"{TID}.txt").read_text())

--- a/tests/gateway-signal-task-media.test.py
+++ b/tests/gateway-signal-task-media.test.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Signal-task attachments upload against the task's own lease, not the room.
+
+A task the relay stamped with `signal` carries its media through
+`POST /v1/tasks/<wire id>/media`. The route is chosen from a sidecar committed
+before the task is queued, so it survives a restart between the ack and the
+upload — the served task itself never carries the flag.
+
+Covers:
+  1. wire-id resolution — the sidecar and the upload use the DELIVERY id
+     (dedup alias applied, instance prefix stripped), never the local id;
+  2. deferral — an unreadable alias ledger or media sidecar defers the whole
+     result instead of guessing a route;
+  3. route selection from the sidecar, including a restart between the ack and
+     the upload (a fresh module reads the mode off disk);
+  4. the sidecar is durable before the task file is renamed into tasks/;
+  5. a 503 before or after the upload defers the result — no POST, no archive —
+     and the retry re-offers the same wire id, ordinal and bytes;
+  6. 409 and 423 report in-band and are never retried;
+  7. two GATEWAY_INSTANCEs sharing a broker id never collide.
+
+Run: python3 tests/gateway-signal-task-media.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "remote-gateway-bridge.py"
+
+SIGNAL = {"v": 1, "cid": "cid-1", "route_attempt": 1,
+          "source_root": "$root:server", "source_room": "!room:server"}
+
+
+def _load(ws: Path, instance: str = ""):
+    """Load the hyphenated bridge module against a scratch workspace."""
+    os.environ["SUTANDO_TEST_WORKSPACE"] = str(ws)
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "test-token-0123456789abcdef")
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.invalid/relay")
+    os.environ["GATEWAY_INSTANCE"] = instance
+    sys.path.insert(0, str(REPO / "src"))
+    spec = importlib.util.spec_from_file_location("rgb_task_media", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    with patch("workspace_default.resolve_workspace", return_value=ws):
+        spec.loader.exec_module(mod)
+    suffix = f".{instance}" if instance else ""
+    mod.WS = ws
+    mod.TASKS_DIR = ws / "tasks"
+    mod.RESULTS_DIR = ws / "results"
+    mod.ARCHIVE_RESULTS_DIR = ws / "results" / "archive"
+    mod.INFLIGHT_FILE = ws / "state" / f"remote-task-inflight{suffix}.json"
+    mod.TASK_ROOMS_FILE = ws / "state" / f"remote-task-rooms{suffix}.json"
+    mod.TASK_MEDIA_FILE = ws / "state" / f"remote-task-media{suffix}.json"
+    mod.PENDING_ACK_FILE = ws / "state" / f"remote-task-acks{suffix}.json"
+    mod.DEDUP_ALIAS_FILE = ws / "state" / f"remote-dedup-alias{suffix}.json"
+    for d in (mod.TASKS_DIR, mod.RESULTS_DIR, ws / "state"):
+        d.mkdir(parents=True, exist_ok=True)
+    return mod
+
+
+def _http(code: int, body: bytes = b""):
+    return urllib.error.HTTPError("https://gw.invalid/relay", code, "err", {},
+                                  io.BytesIO(body))
+
+
+class TaskMediaRoute(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        self.mod = _load(self.ws)
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self._req_patch = patch.object(self.mod, "_req", side_effect=self._fake_req)
+        self._req_patch.start()
+        self.addCleanup(self._req_patch.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _fake_req(self, method, path, payload=None, timeout=35):
+        self.calls.append((method, path, payload))
+        return {}
+
+    # -- fixtures ---------------------------------------------------------- #
+
+    def _attachment(self) -> str:
+        """An allowlisted file: /tmp/sutando-* is a send_allowlist prefix."""
+        fd, fpath = tempfile.mkstemp(prefix="sutando-signal-media-", suffix=".txt",
+                                     dir="/tmp")
+        os.write(fd, b"payload")
+        os.close(fd)
+        self.addCleanup(lambda: os.path.exists(fpath) and os.unlink(fpath))
+        return fpath
+
+    def _signal_task(self, tid: str) -> dict:
+        return {"id": tid, "task": "dig into this", "source": "ag2space",
+                "channel_id": "!room:server", "access_tier": "owner",
+                "user_id": "@owner:server", "signal": dict(SIGNAL),
+                "thread_root": "$root:server", "source_room_id": "!room:server"}
+
+    def _result(self, mod, tid: str, body: str) -> None:
+        (mod.RESULTS_DIR / f"{tid}.txt").write_text(body)
+
+    def _media_posts(self):
+        return [c for c in self.calls if "/media" in c[1]]
+
+    def _result_posts(self):
+        return [c for c in self.calls if c[1] == "/v1/results"]
+
+    # -- 1. wire-id resolution --------------------------------------------- #
+
+    def test_upload_uses_the_delivery_id_not_the_local_id(self):
+        mod = self.mod
+        mod._write_task(self._signal_task("task-orig"))
+        # A dedup re-ask answers the ORIGINAL delivery: same wire id, new local id.
+        mod._save_dedup_aliases({"task-reask": "task-orig"})
+        (mod.TASKS_DIR / "task-reask.txt").write_text("id: task-reask\naccess_tier: owner\n")
+        self._result(mod, "task-reask", f"here [file: {self._attachment()}]")
+        mod._post_ready_results({"task-reask"})
+        self.assertEqual([c[1] for c in self._media_posts()],
+                         ["/v1/tasks/task-orig/media"])
+        self.assertEqual(self._result_posts()[0][2]["id"], "task-orig")
+
+    def test_named_instance_posts_the_wire_id(self):
+        with tempfile.TemporaryDirectory() as d:
+            mod = _load(Path(d), instance="alpha")
+            calls: list = []
+            with patch.object(mod, "_req", side_effect=lambda *a, **k: calls.append(a) or {}):
+                written = mod._write_task(self._signal_task("task-dup"))
+                self.assertEqual(written, ("task-alpha~task-dup", True))
+                self.assertEqual(mod._load_task_media()["task-dup"],
+                                 {"mode": "task-media", "thread_root": "$root:server"})
+                self._result(mod, "task-alpha~task-dup",
+                             f"x [file: {self._attachment()}]")
+                mod._post_ready_results({"task-alpha~task-dup"})
+            self.assertIn(("POST", "/v1/tasks/task-dup/media"),
+                          [(c[0], c[1]) for c in calls])
+
+    # -- 2. deferral -------------------------------------------------------- #
+
+    def test_unreadable_alias_ledger_defers_the_whole_result(self):
+        mod = self.mod
+        mod._write_task(self._signal_task("task-defer1"))
+        self._result(mod, "task-defer1", f"x [file: {self._attachment()}]")
+        inflight = {"task-defer1"}
+        with patch.object(mod, "_delivery_tid", return_value=None):
+            mod._post_ready_results(inflight)
+        self.assertEqual(self._media_posts() + self._result_posts(), [])
+        self.assertTrue((mod.RESULTS_DIR / "task-defer1.txt").exists())
+        self.assertIn("task-defer1", inflight)
+
+    def test_unreadable_media_sidecar_defers_rather_than_guessing_the_route(self):
+        mod = self.mod
+        mod._write_task(self._signal_task("task-defer2"))
+        self._result(mod, "task-defer2", f"x [file: {self._attachment()}]")
+        mod.TASK_MEDIA_FILE.write_text("{not json")
+        inflight = {"task-defer2"}
+        mod._post_ready_results(inflight)
+        self.assertEqual(self._media_posts() + self._result_posts(), [],
+                         "no route may be guessed from an unreadable map")
+        self.assertIn("task-defer2", inflight)
+
+    # -- 3. route selection ------------------------------------------------- #
+
+    def test_ordinary_task_still_uses_the_room_route(self):
+        mod = self.mod
+        task = self._signal_task("task-plain")
+        task.pop("signal")
+        mod._write_task(task)
+        self._result(mod, "task-plain", f"x [file: {self._attachment()}]")
+        mod._post_ready_results({"task-plain"})
+        self.assertEqual([c[1] for c in self._media_posts()],
+                         ["/v1/rooms/%21room%3Aserver/media"])
+        self.assertFalse(mod.TASK_MEDIA_FILE.exists(),
+                         "an ordinary task must not write a media sidecar")
+
+    def test_restart_between_ack_and_upload_still_routes_by_task(self):
+        self.mod._write_task(self._signal_task("task-restart"))
+        fresh = _load(self.ws)          # a new process: no in-memory state at all
+        self._result(fresh, "task-restart", f"x [file: {self._attachment()}]")
+        with patch.object(fresh, "_req", side_effect=self._fake_req):
+            fresh._post_ready_results({"task-restart"})
+        self.assertEqual([c[1] for c in self._media_posts()],
+                         ["/v1/tasks/task-restart/media"])
+
+    def test_delivered_result_retires_the_media_mode(self):
+        mod = self.mod
+        mod._write_task(self._signal_task("task-retire"))
+        self._result(mod, "task-retire", "plain answer")
+        mod._post_ready_results({"task-retire"})
+        self.assertEqual(json.loads(mod.TASK_MEDIA_FILE.read_text()), {})
+
+    # -- 4. the sidecar commits before the task is published ----------------- #
+
+    def test_sidecar_is_visible_before_the_task_rename(self):
+        mod = self.mod
+        published: list[str] = []
+        real = mod._publish_staged
+
+        def spy(tmp, path):
+            if path.name.endswith(".txt"):
+                on_disk = json.loads(mod.TASK_MEDIA_FILE.read_text())
+                self.assertIn("task-order", on_disk,
+                              "the watcher could see the task before its route")
+            published.append(path.name)
+            return real(tmp, path)
+
+        with patch.object(mod, "_publish_staged", side_effect=spy):
+            mod._write_task(self._signal_task("task-order"))
+        self.assertEqual(published, ["remote-task-media.json", "task-order.txt"])
+
+    def test_sidecar_failure_publishes_neither_task_nor_ack(self):
+        mod = self.mod
+        with patch.object(mod, "_record_task_media", return_value=False):
+            self.assertIsNone(mod._write_task(self._signal_task("task-nosidecar")))
+        self.assertFalse((mod.TASKS_DIR / "task-nosidecar.txt").exists())
+        self.assertEqual(list(mod.TASKS_DIR.glob("*.tmp")), [],
+                         "the staged file must not be left behind")
+
+    # -- 5. retryable upload failures defer the result ----------------------- #
+
+    def test_503_defers_the_result_and_the_retry_reoffers_the_same_bytes(self):
+        mod = self.mod
+        mod._write_task(self._signal_task("task-503"))
+        fpath = self._attachment()
+        self._result(mod, "task-503", f"x [file: {fpath}]")
+        inflight = {"task-503"}
+        with patch.object(mod, "_req", side_effect=_http(503, b"retry later")):
+            mod._post_ready_results(inflight)
+        self.assertEqual(self._result_posts(), [], "a deferred upload must not POST")
+        self.assertTrue((mod.RESULTS_DIR / "task-503.txt").exists())
+        self.assertFalse(list(mod.ARCHIVE_RESULTS_DIR.glob("task-503-*.txt")))
+        self.assertIn("task-503", inflight)
+        first: list = []
+
+        def refuse(method, path, payload=None, timeout=35):
+            first.append((path, payload))
+            raise _http(503)
+
+        with patch.object(mod, "_req", side_effect=refuse):
+            mod._post_ready_results(inflight)
+        mod._post_ready_results(inflight)
+        media = self._media_posts()
+        self.assertEqual(len(media), 1, "the successful pass uploads exactly once")
+        self.assertEqual(media[0][2], {"ordinal": 0,
+                                       "filename": os.path.basename(fpath),
+                                       "content_b64": "cGF5bG9hZA=="})
+        self.assertEqual(first[0], (media[0][1], media[0][2]),
+                         "the retry re-offers the same wire id, ordinal and bytes")
+        self.assertEqual(len(self._result_posts()), 1)
+
+    def test_503_after_a_restart_uploads_once_with_identical_content(self):
+        mod = self.mod
+        mod._write_task(self._signal_task("task-503r"))
+        fpath = self._attachment()
+        self._result(mod, "task-503r", f"x [file: {fpath}]")
+        sent: list = []
+
+        def record(method, path, payload=None, timeout=35):
+            sent.append((path, payload))
+            raise _http(503)
+
+        with patch.object(mod, "_req", side_effect=record):
+            mod._post_ready_results({"task-503r"})
+        fresh = _load(self.ws)          # restart: no _uploaded_attachments memory
+        with patch.object(fresh, "_req", side_effect=self._fake_req):
+            fresh._post_ready_results({"task-503r"})
+        media = self._media_posts()
+        self.assertEqual(len(media), 1)
+        self.assertEqual((media[0][1], media[0][2]), sent[0],
+                         "the resumed upload is byte-identical to the lost one")
+
+    def test_network_failure_defers_too(self):
+        mod = self.mod
+        mod._write_task(self._signal_task("task-net"))
+        self._result(mod, "task-net", f"x [file: {self._attachment()}]")
+        inflight = {"task-net"}
+        with patch.object(mod, "_req", side_effect=urllib.error.URLError("down")):
+            mod._post_ready_results(inflight)
+        self.assertTrue((mod.RESULTS_DIR / "task-net.txt").exists())
+        self.assertIn("task-net", inflight)
+
+    # -- 6. terminal upload refusals report in-band -------------------------- #
+
+    def test_conflict_and_encrypted_report_in_band_and_still_deliver(self):
+        for code, needle in ((409, "content conflicts with the recorded upload"),
+                             (423, "room is encrypted"),
+                             (429, "HTTP 429")):
+            with self.subTest(code=code):
+                mod = _load(self.ws)
+                tid = f"task-{code}"
+                mod._write_task(self._signal_task(tid))
+                fpath = self._attachment()
+                self._result(mod, tid, f"x [file: {fpath}]")
+                posts: list = []
+
+                def one(method, path, payload=None, timeout=35, _c=code):
+                    posts.append((path, payload))
+                    if "/media" in path:
+                        raise _http(_c)
+                    return {}
+
+                inflight = {tid}
+                with patch.object(mod, "_req", side_effect=one):
+                    mod._post_ready_results(inflight)
+                body = [p for p in posts if p[0] == "/v1/results"][0][1]["body"]
+                self.assertIn(f"[attachment not sent: {fpath} ({needle}", body)
+                self.assertNotIn(tid, inflight, "a reported refusal still delivers")
+
+    # -- 7. instance isolation ---------------------------------------------- #
+
+    def test_identical_wire_ids_in_two_instances_never_collide(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d)
+            alpha = _load(ws, instance="alpha")
+            beta = _load(ws, instance="beta")
+            self.assertNotEqual(alpha.TASK_MEDIA_FILE, beta.TASK_MEDIA_FILE)
+            a_task = self._signal_task("task-dup")
+            b_task = dict(a_task, thread_root="$beta:server")
+            with patch.object(alpha, "_req", return_value={}):
+                alpha._write_task(a_task)
+            with patch.object(beta, "_req", return_value={}):
+                beta._write_task(b_task)
+            self.assertEqual(alpha._load_task_media()["task-dup"]["thread_root"],
+                             "$root:server")
+            self.assertEqual(beta._load_task_media()["task-dup"]["thread_root"],
+                             "$beta:server")
+            self.assertTrue((ws / "tasks" / "task-alpha~task-dup.txt").exists())
+            self.assertTrue((ws / "tasks" / "task-beta~task-dup.txt").exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway-task-telemetry.test.py
+++ b/tests/gateway-task-telemetry.test.py
@@ -120,9 +120,9 @@ class _FakeTelemetry:
 # 1. newly queued task → one event tagged with the task's source
 _fresh_dirs()
 with _FakeTelemetry() as t:
-    tid = rgb._write_task({"id": "task-telem1", "task": "hello", "source": "ag2space",
-                           "user_id": "@rui:ag2.space", "access_tier": "owner",
-                           "channel_id": "!room:ag2.space"})
+    tid, _ = rgb._write_task({"id": "task-telem1", "task": "hello", "source": "ag2space",
+                              "user_id": "@rui:ag2.space", "access_tier": "owner",
+                              "channel_id": "!room:ag2.space"})
 check("write returns the task id", tid == "task-telem1")
 check("one task_processed event", t.calls == ["ag2space"], repr(t.calls))
 
@@ -158,8 +158,8 @@ check("archived redelivery writes no task file",
 _fresh_dirs()
 _prev = sys.modules.pop("telemetry", None)
 try:
-    tid = rgb._write_task({"id": "task-telem5", "task": "standalone", "source": "ag2space",
-                           "access_tier": "owner"})
+    tid, _ = rgb._write_task({"id": "task-telem5", "task": "standalone", "source": "ag2space",
+                              "access_tier": "owner"})
 finally:
     if _prev is not None:
         sys.modules["telemetry"] = _prev
@@ -169,8 +169,8 @@ check("missing telemetry module → task still queued",
 # 6. telemetry raising mid-call → write still succeeds (fire-and-forget)
 _fresh_dirs()
 with _FakeTelemetry(raise_on_call=True) as t:
-    tid = rgb._write_task({"id": "task-telem6", "task": "boom", "source": "ag2space",
-                           "access_tier": "owner"})
+    tid, _ = rgb._write_task({"id": "task-telem6", "task": "boom", "source": "ag2space",
+                              "access_tier": "owner"})
 check("raising telemetry never breaks the write",
       tid == "task-telem6" and (rgb.TASKS_DIR / "task-telem6.txt").exists())
 check("raising telemetry was attempted", t.calls == ["ag2space"], repr(t.calls))

--- a/tests/gateway-team-guardrail-inband.test.py
+++ b/tests/gateway-team-guardrail-inband.test.py
@@ -47,8 +47,9 @@ def _write(mod, **over) -> str:
     task = {"id": "inband1", "task": "please look at the parser",
             "user_id": "@x:ag2.space", "access_tier": "team"}
     task.update(over)
-    tid = mod._write_task(task)
-    assert tid, "writer returned no task id"
+    written = mod._write_task(task)
+    assert written, "writer returned no task id"
+    tid = written[0]
     return (mod.TASKS_DIR / f"{tid}.txt").read_text(), tid
 
 
@@ -104,8 +105,9 @@ class CollaboratorBranchReachesTheBody(unittest.TestCase):
                 "user_id": "@c:ag2.space", "access_tier": "team",
                 "collaborator": True}
         task.update(over)
-        tid = mod._write_task(task)
-        assert tid, "writer returned no task id"
+        written = mod._write_task(task)
+        assert written, "writer returned no task id"
+        tid = written[0]
         return (mod.TASKS_DIR / f"{tid}.txt").read_text(), tid
 
     def test_attested_collaborator_gets_the_engage_rulebook_at_its_own_result_path(self):

--- a/tests/gateway-writeside-attachments.test.py
+++ b/tests/gateway-writeside-attachments.test.py
@@ -55,8 +55,9 @@ TAG = rgb.MEDIA_MARKER_TAG  # default "remote-media"
 
 
 def _write_and_parse(task):
-    tid = rgb._write_task(task)
-    assert tid, f"_write_task rejected {task!r}"
+    written = rgb._write_task(task)
+    assert written, f"_write_task rejected {task!r}"
+    tid = written[0]
     text = (rgb.TASKS_DIR / f"{tid}.txt").read_text()
     return text, ltp.parse_task_headers_trusted(text)
 

--- a/tests/gateway-writeside-platform-card.test.py
+++ b/tests/gateway-writeside-platform-card.test.py
@@ -61,8 +61,9 @@ _n = 0
 def _write(pc):
     global _n
     _n += 1
-    tid = rgb._write_task({"id": f"task-pc-{_n}", "task": "hello", "platform_card": pc})
-    assert tid, "_write_task rejected the task"
+    written = rgb._write_task({"id": f"task-pc-{_n}", "task": "hello", "platform_card": pc})
+    assert written, "_write_task rejected the task"
+    tid = written[0]
     return (rgb.TASKS_DIR / f"{tid}.txt").read_text()
 
 

--- a/tests/remote-gateway-interaction-type.test.py
+++ b/tests/remote-gateway-interaction-type.test.py
@@ -32,8 +32,9 @@ rgb.ARCHIVE_RESULTS_DIR = tmp / "results" / "archive"
 
 
 def _headers(task):
-    tid = rgb._write_task(task)
-    assert tid, f"_write_task rejected {task!r}"
+    written = rgb._write_task(task)
+    assert written, f"_write_task rejected {task!r}"
+    tid = written[0]
     body = (rgb.TASKS_DIR / f"{tid}.txt").read_text()
     # This serializer emits `task:` mid-file (field order = _TASK_FIELDS; every
     # header is newline-stripped by _one_line, access_tier last) — so parse all

--- a/tests/sparrow-integration-e2e.test.py
+++ b/tests/sparrow-integration-e2e.test.py
@@ -125,19 +125,22 @@ def drive_poll(rtc, tasks):
     added = False
     pending_ack = []
     for task in tasks:
-        tid = rtc._write_task(task)
-        if tid:
+        written = rtc._write_task(task)
+        if written:
+            tid, durable = written
             if tid not in inflight:
                 inflight.add(tid)
                 added = True
-            pending_ack.append(tid)
-    if added:
-        rtc._save_inflight(inflight)
-    # Ack only after task file + in-flight state are durable (main()'s ordering).
-    for tid in pending_ack:
-        rtc._post_task_ack(tid)
+            pending_ack.append((tid, durable))
+    # Ack only after task file, in-flight state and ack ledger are durable
+    # (main()'s ordering).
+    committed = rtc._save_inflight(inflight) if pending_ack else True
+    if pending_ack and committed:
+        committed = rtc._record_pending_acks(pending_ack)
+    for tid, durable in pending_ack if committed else ():
+        rtc._post_task_ack(tid, durable)
     rtc._post_ready_results(inflight)
-    return pending_ack
+    return [tid for tid, _ in pending_ack]
 
 
 def main() -> int:

--- a/tests/sparrow-per-pid-staging.test.py
+++ b/tests/sparrow-per-pid-staging.test.py
@@ -43,15 +43,40 @@ class TestSparrowPerPidStaging(unittest.TestCase):
 
     def test_all_four_state_files_use_per_pid(self):
         code = SPARROW_PY.read_text()
-        # The three single-writer state files (gateway-status / task-rooms /
-        # inflight) are written only by the single-threaded poll loop, so a
-        # per-PID temp name is sufficient.
-        for var in ("GATEWAY_STATUS_FILE", "TASK_ROOMS_FILE", "INFLIGHT_FILE"):
+        # The two single-writer state files (gateway-status / task-rooms) are
+        # written only by the single-threaded poll loop, so per-PID is enough.
+        for var in ("GATEWAY_STATUS_FILE", "TASK_ROOMS_FILE"):
             pat = rf'{var}\.with_suffix\(\s*f["\']\.json\.\{{os\.getpid\(\)\}}\.tmp["\']'
             self.assertRegex(
                 code, pat,
                 f"{var} does not stage under a per-PID temp name",
             )
+        # The durable writer (INFLIGHT_FILE + the task-media / pending-ack sidecars)
+        # is used by two THREADS, so PID-only staging is not enough for it either.
+        self.assertRegex(
+            code, r'_durable_write\(INFLIGHT_FILE,',
+            "INFLIGHT_FILE no longer publishes through the durable writer",
+        )
+        self.assertRegex(
+            code,
+            r'tmp = path\.with_name\(f["\']\{path\.name\}\.\{os\.getpid\(\)\}'
+            r'\.\{uuid\.uuid4\(\)\.hex\}\.tmp["\']\)',
+            "_stage_durable must stage per-invocation (PID + uuid), not PID-only",
+        )
+        self.assertNotRegex(
+            code,
+            r'tmp = path\.with_name\(f["\']\{path\.name\}\.\{os\.getpid\(\)\}\.tmp["\']\)',
+            "_stage_durable still uses the thread-unsafe PID-only staging",
+        )
+        # The ledgers the durable writer serves are read-modify-written from both
+        # threads, so each mutation runs under its own lock (like _INFLIGHT_MUTEX).
+        for fn, mutex in (("_record_task_media", "_TASK_MEDIA_MUTEX"),
+                          ("_forget_task_media", "_TASK_MEDIA_MUTEX"),
+                          ("_record_pending_acks", "_PENDING_ACK_MUTEX"),
+                          ("_forget_pending_ack", "_PENDING_ACK_MUTEX")):
+            body = code.split(f"def {fn}(", 1)[1].split("\ndef ", 1)[0]
+            self.assertIn(f"with {mutex}:", body,
+                          f"{fn} mutates its ledger without holding {mutex}")
         # OWNER_ACTIVITY_FILE is written by FIVE processes AND (for Slack Bolt)
         # multiple threads within one process, so PID-only is NOT enough — it must
         # stage per-INVOCATION (PID + uuid4), unique across processes and threads.

--- a/tests/sparrow-thread-identity-ingress.test.py
+++ b/tests/sparrow-thread-identity-ingress.test.py
@@ -58,9 +58,10 @@ def _drive_gateway_writer(task: dict) -> "str | None":
     global _BOUND
     _BOUND = {"tasks": rgb.TASKS_DIR, "results": rgb.RESULTS_DIR,
               "state": rgb._STATE, "rooms": rgb.TASK_ROOMS_FILE}
-    tid = rgb._write_task(task)
-    if not tid:
+    written = rgb._write_task(task)
+    if not written:
         return None
+    tid = written[0]
     hits = list((tmp / "task").glob(f"{tid}*.txt")) or list(tmp.rglob(f"{tid}*.txt"))
     return hits[0].read_text() if hits else None
 

--- a/tests/task-envelope.test.py
+++ b/tests/task-envelope.test.py
@@ -340,12 +340,12 @@ class WriterWiring(unittest.TestCase):
             gw = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
             ltp.set_task_stamper(lambda t: E.stamp_text(t, ws))
             try:
-                tid = gw._write_task({
+                written = gw._write_task({
                     "task": "hello from the wire",
                     "source": "ag2space", "channel_id": "!room:x",
                     "user_id": "@qingyun:ag2.space", "id": "task-991"})
-                self.assertIsNotNone(tid)
-                out = (tasks / f"{tid}.txt").read_text()
+                self.assertIsNotNone(written)
+                out = (tasks / f"{written[0]}.txt").read_text()
                 self.assertEqual(E.verify_text(out, ws)["verdict"],
                                  "verified",
                                  "the LIVE gateway writer must emit stamped "


### PR DESCRIPTION
The client half of AG2 Space's room-native Sutando work. The relay side is ag2-space/ag2space-backend#946 and its stack; this PR is independent of them at the code level and can merge on its own.

## What changes

**Attachments for a Signal Room task** upload through the task-scoped media route instead of the room-scoped one, so the relay owns threading and re-hosting. Which route a task uses is recorded in a sidecar written and fsynced **before** the task file is renamed into the watched directory — the result watcher is already running by then, so a sidecar written after publication can lose the race. A task queued by an older client and redelivered after upgrade is repaired and fsynced on the way through, rather than being treated as already durable because it was already pending.

**`durable: true` now means what it says.** The task file, its parent directory, the inflight record and the pending-ack record are all committed before the acknowledgement is sent, and the ack is withheld on any failure. Pending acks survive a restart and are retried; an explicit not-leased answer retires one permanently, while a bare 404 keeps the existing cooldown for gateways that lack the route.

**Transient media failures defer the whole result** instead of dropping the attachment, and a retry reuses the same wire id, ordinal and hash so the server can resume without a second upload.

All new state file names carry the gateway-instance suffix, because broker task ids are unique only within a gateway.

## Two real defects review caught

- **A data race.** Both new ledgers were mutated from two threads with no lock, and staged through a temp name unique only per process — so the poller and the outbound worker shared one temp file. Staging is now per invocation, and each ledger has its own mutex beside the existing inflight one.
- **The only path that sends `durable: true` had no test.** Proven by mutation: replacing that block with the pre-change shape left the suite green. Five tests now drive the real main loop.

## Verification

8 gateway suites green, including 22 durable-ack tests and 14 task-media tests. `scripts/review-checks.sh` passes on the diff.

Rebased onto current `main` (`00a9d812`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)