### PR TITLE
fix(health-check): a rejection with both quota windows low is another client's gate, not this core's

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5257,6 +5257,20 @@ def check_core_quota_exhausted(fresh_sec: int = 1800) -> dict:
         )
         return check
 
+    # The proxy records the LAST response through it, whoever sent it: a
+    # rejection while both windows are far from full is another client's gate.
+    util = _quota_utilizations(headers)
+    if util is not None and max(util) < 0.9:
+        check["status"] = "warn"
+        check["detail"] = (
+            f"last response through the shared credential proxy was rejected "
+            f"(status={status}) but this core's windows are at {util[0]:.0%} (5h) / "
+            f"{util[1]:.0%} (7d) — another client's per-model or usage-credit limit "
+            "is the likely source (a seat out of credits); not paging. If THIS core "
+            "were stuck, its own passes would stop and quota-telemetry would go stale."
+        )
+        return check
+
     reset = _fmt_quota_reset(headers.get("anthropic-ratelimit-unified-5h-reset"))
     reset_note = f" 5h window resets {reset}." if reset else ""
     check["status"] = "fail"
@@ -5266,6 +5280,16 @@ def check_core_quota_exhausted(fresh_sec: int = 1800) -> dict:
         "this is the 'stuck silently' condition; tasks will queue undelivered."
     )
     return check
+
+
+def _quota_utilizations(headers: dict):
+    """(5h, 7d) utilization fractions from the unified headers, or None when
+    either is absent or unparseable — an unknown reading corroborates nothing."""
+    try:
+        return (float(headers["anthropic-ratelimit-unified-5h-utilization"]),
+                float(headers["anthropic-ratelimit-unified-7d-utilization"]))
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 def _scoped_keychain_service(config_dir: Optional[str]) -> Optional[str]:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5257,39 +5257,53 @@ def check_core_quota_exhausted(fresh_sec: int = 1800) -> dict:
         )
         return check
 
-    # The proxy records the LAST response through it, whoever sent it: a
-    # rejection while both windows are far from full is another client's gate.
-    util = _quota_utilizations(headers)
-    if util is not None and max(util) < 0.9:
+    # Every unified window is read, not just 5h/7d: a per-model window such as
+    # 7d_oi can be the one rejected while the headline windows sit low.
+    windows = _quota_windows(headers)
+    full = [w for w, (u, st) in windows.items() if st == "rejected" or (u is not None and u >= 0.9)]
+    if windows and not full:
+        summary = ", ".join(f"{w} {u:.0%}" for w, (u, st) in windows.items() if u is not None)
         check["status"] = "warn"
         check["detail"] = (
             f"last response through the shared credential proxy was rejected "
-            f"(status={status}) but this core's windows are at {util[0]:.0%} (5h) / "
-            f"{util[1]:.0%} (7d) — another client's per-model or usage-credit limit "
-            "is the likely source (a seat out of credits); not paging. If THIS core "
-            "were stuck, its own passes would stop and quota-telemetry would go stale."
+            f"(status={status}) but none of this core's windows is near full ({summary}) "
+            "— another client's limit is the likely source (a seat out of credits); "
+            "not paging. If THIS core were stuck, its own passes would stop and "
+            "quota-telemetry would go stale."
         )
         return check
 
     reset = _fmt_quota_reset(headers.get("anthropic-ratelimit-unified-5h-reset"))
     reset_note = f" 5h window resets {reset}." if reset else ""
+    window_note = ""
+    if full:
+        window_note = " Exhausted window(s): " + ", ".join(
+            f"{w} ({windows[w][0]:.0%}, {windows[w][1] or 'no status'})" for w in full) + "."
     check["status"] = "fail"
     check["detail"] = (
-        f"CORE IS OVER QUOTA (rate-limit status={status}).{reset_note} The core "
+        f"CORE IS OVER QUOTA (rate-limit status={status}).{window_note}{reset_note} The core "
         "cannot process tasks until quota resets or you switch models (/model) — "
         "this is the 'stuck silently' condition; tasks will queue undelivered."
     )
     return check
 
 
-def _quota_utilizations(headers: dict):
-    """(5h, 7d) utilization fractions from the unified headers, or None when
-    either is absent or unparseable — an unknown reading corroborates nothing."""
-    try:
-        return (float(headers["anthropic-ratelimit-unified-5h-utilization"]),
-                float(headers["anthropic-ratelimit-unified-7d-utilization"]))
-    except (KeyError, TypeError, ValueError):
-        return None
+def _quota_windows(headers: dict) -> dict:
+    """Every `anthropic-ratelimit-unified-<window>-utilization` header, keyed by
+    window, as (utilization or None, that window's own status or None)."""
+    out = {}
+    prefix, suffix = "anthropic-ratelimit-unified-", "-utilization"
+    for k, v in headers.items():
+        if not (k.startswith(prefix) and k.endswith(suffix)):
+            continue
+        w = k[len(prefix):-len(suffix)]
+        try:
+            u = float(v)
+        except (TypeError, ValueError):
+            u = None
+        st = headers.get(f"{prefix}{w}-status")
+        out[w] = (u, str(st) if st is not None else None)
+    return out
 
 
 def _scoped_keychain_service(config_dir: Optional[str]) -> Optional[str]:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5262,7 +5262,7 @@ def check_core_quota_exhausted(fresh_sec: int = 1800) -> dict:
     windows = _quota_windows(headers)
     full = [w for w, (u, st) in windows.items() if st == "rejected" or (u is not None and u >= 0.9)]
     if windows and not full:
-        summary = ", ".join(f"{w} {u:.0%}" for w, (u, st) in windows.items() if u is not None)
+        summary = _window_summary(windows)
         check["status"] = "warn"
         check["detail"] = (
             f"last response through the shared credential proxy was rejected "
@@ -5287,6 +5287,19 @@ def check_core_quota_exhausted(fresh_sec: int = 1800) -> dict:
         "this is the 'stuck silently' condition; tasks will queue undelivered."
     )
     return check
+
+
+def _window_summary(windows: dict) -> str:
+    """Owner-facing per-window line. overage is a flag, not a budget: rendering
+    it as `0%` reads as a third window with headroom."""
+    parts = []
+    for w, (u, st) in windows.items():
+        if w == "overage":
+            on = bool(u) or (st is not None and st != "allowed")
+            parts.append(f"overage: {'on' if on else 'off'}")
+        elif u is not None:
+            parts.append(f"{w} {u:.0%}")
+    return ", ".join(parts)
 
 
 def _quota_windows(headers: dict) -> dict:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5278,7 +5278,8 @@ def check_core_quota_exhausted(fresh_sec: int = 1800) -> dict:
     window_note = ""
     if full:
         window_note = " Exhausted window(s): " + ", ".join(
-            f"{w} ({windows[w][0]:.0%}, {windows[w][1] or 'no status'})" for w in full) + "."
+            f"{w} ({'n/a' if windows[w][0] is None else format(windows[w][0], '.0%')}, "
+            f"{windows[w][1] or 'no status'})" for w in full) + "."
     check["status"] = "fail"
     check["detail"] = (
         f"CORE IS OVER QUOTA (rate-limit status={status}).{window_note}{reset_note} The core "

--- a/tests/health-check-core-quota.test.py
+++ b/tests/health-check-core-quota.test.py
@@ -142,6 +142,23 @@ class TestCoreQuotaExhausted(unittest.TestCase):
         self._write(available=True, status="rejected", reset=int(time.time()) + 60)
         self.assertEqual(self.hc.check_core_quota_exhausted()["status"], "fail")
 
+    def test_warn_summary_renders_overage_as_a_flag_not_a_budget(self):
+        """A live header set carries a third window, `overage`; `0%` there reads
+        as headroom, so the summary says on/off instead."""
+        self._write(available=False, status="rejected", util=(0.04, 0.24), extra={
+            "anthropic-ratelimit-unified-overage-utilization": "0.0",
+            "anthropic-ratelimit-unified-overage-status": "allowed"})
+        c = self.hc.check_core_quota_exhausted()
+        self.assertEqual(c["status"], "warn")
+        self.assertIn("overage: off", c["detail"])
+        self.assertNotIn("overage 0%", c["detail"])
+        self._write(available=False, status="rejected", util=(0.04, 0.24), extra={
+            "anthropic-ratelimit-unified-overage-utilization": "0.3",
+            "anthropic-ratelimit-unified-overage-status": "allowed"})
+        c = self.hc.check_core_quota_exhausted()
+        self.assertEqual(c["status"], "warn")
+        self.assertIn("overage: on", c["detail"])
+
     def test_rejected_with_both_windows_low_is_a_warn_naming_the_shared_proxy(self):
         # Another client's credit gate through the shared proxy, not this core's window.
         self._write(available=False, status="rejected", util=(0.13, 0.52))

--- a/tests/health-check-core-quota.test.py
+++ b/tests/health-check-core-quota.test.py
@@ -160,6 +160,15 @@ class TestCoreQuotaExhausted(unittest.TestCase):
         self.assertEqual(c["status"], "fail")
         self.assertIn("7d_oi (100%, rejected)", c["detail"])
 
+    def test_unparseable_window_utilization_with_rejected_status_still_fails(self):
+        # A rejected window whose utilization does not parse is named as n/a, not crashed on.
+        self._write(available=False, status="rejected", util=(0.13, 0.52), extra={
+            "anthropic-ratelimit-unified-7d_oi-utilization": "n/a",
+            "anthropic-ratelimit-unified-7d_oi-status": "rejected"})
+        c = self.hc.check_core_quota_exhausted()
+        self.assertEqual(c["status"], "fail")
+        self.assertIn("7d_oi (n/a, rejected)", c["detail"])
+
     def test_per_window_rejected_status_counts_even_below_the_utilization_bar(self):
         self._write(available=False, status="rejected", util=(0.13, 0.52), extra={
             "anthropic-ratelimit-unified-overage-utilization": "0.5",

--- a/tests/health-check-core-quota.test.py
+++ b/tests/health-check-core-quota.test.py
@@ -51,12 +51,15 @@ class TestCoreQuotaExhausted(unittest.TestCase):
     def tearDown(self):
         self._tmp.cleanup()
 
-    def _write(self, *, available, status, age_sec=0, reset=None):
+    def _write(self, *, available, status, age_sec=0, reset=None, util=None):
         payload = {"available": available, "headers": {
             "anthropic-ratelimit-unified-status": status,
         }}
         if reset is not None:
             payload["headers"]["anthropic-ratelimit-unified-5h-reset"] = str(reset)
+        if util is not None:
+            payload["headers"]["anthropic-ratelimit-unified-5h-utilization"] = str(util[0])
+            payload["headers"]["anthropic-ratelimit-unified-7d-utilization"] = str(util[1])
         self.qpath.write_text(json.dumps(payload))
         if age_sec:
             old = time.time() - age_sec
@@ -135,6 +138,26 @@ class TestCoreQuotaExhausted(unittest.TestCase):
     def test_status_not_allowed_even_if_available_flag_true(self):
         # Defensive: trust the unified status header, not just the bool.
         self._write(available=True, status="rejected", reset=int(time.time()) + 60)
+        self.assertEqual(self.hc.check_core_quota_exhausted()["status"], "fail")
+
+    def test_rejected_with_both_windows_low_is_a_warn_naming_the_shared_proxy(self):
+        # Another client's credit gate through the shared proxy, not this core's window.
+        self._write(available=False, status="rejected", util=(0.13, 0.52))
+        c = self.hc.check_core_quota_exhausted()
+        self.assertEqual(c["status"], "warn")
+        self.assertIn("shared credential proxy", c["detail"])
+        self.assertIn("13% (5h)", c["detail"])
+        self.assertIn("52% (7d)", c["detail"])
+
+    def test_rejected_with_a_window_near_full_still_fails(self):
+        self._write(available=False, status="rejected", util=(0.97, 0.52))
+        c = self.hc.check_core_quota_exhausted()
+        self.assertEqual(c["status"], "fail")
+        self.assertIn("OVER QUOTA", c["detail"])
+
+    def test_rejected_without_utilization_headers_still_fails(self):
+        # An unknown reading corroborates nothing: the original page stays loud.
+        self._write(available=False, status="rejected")
         self.assertEqual(self.hc.check_core_quota_exhausted()["status"], "fail")
 
     def test_stale_exhausted_does_not_alert(self):

--- a/tests/health-check-core-quota.test.py
+++ b/tests/health-check-core-quota.test.py
@@ -51,7 +51,7 @@ class TestCoreQuotaExhausted(unittest.TestCase):
     def tearDown(self):
         self._tmp.cleanup()
 
-    def _write(self, *, available, status, age_sec=0, reset=None, util=None):
+    def _write(self, *, available, status, age_sec=0, reset=None, util=None, extra=None):
         payload = {"available": available, "headers": {
             "anthropic-ratelimit-unified-status": status,
         }}
@@ -60,6 +60,8 @@ class TestCoreQuotaExhausted(unittest.TestCase):
         if util is not None:
             payload["headers"]["anthropic-ratelimit-unified-5h-utilization"] = str(util[0])
             payload["headers"]["anthropic-ratelimit-unified-7d-utilization"] = str(util[1])
+        for k, v in (extra or {}).items():
+            payload["headers"][k] = v
         self.qpath.write_text(json.dumps(payload))
         if age_sec:
             old = time.time() - age_sec
@@ -146,8 +148,25 @@ class TestCoreQuotaExhausted(unittest.TestCase):
         c = self.hc.check_core_quota_exhausted()
         self.assertEqual(c["status"], "warn")
         self.assertIn("shared credential proxy", c["detail"])
-        self.assertIn("13% (5h)", c["detail"])
-        self.assertIn("52% (7d)", c["detail"])
+        self.assertIn("5h 13%", c["detail"])
+        self.assertIn("7d 52%", c["detail"])
+
+    def test_rejected_per_model_window_at_full_still_fails_and_names_it(self):
+        # Live shape 2026-09-03: 5h 13% / 7d 52%, but 7d_oi rejected at 100%.
+        self._write(available=False, status="rejected", util=(0.13, 0.52), extra={
+            "anthropic-ratelimit-unified-7d_oi-utilization": "1.0",
+            "anthropic-ratelimit-unified-7d_oi-status": "rejected"})
+        c = self.hc.check_core_quota_exhausted()
+        self.assertEqual(c["status"], "fail")
+        self.assertIn("7d_oi (100%, rejected)", c["detail"])
+
+    def test_per_window_rejected_status_counts_even_below_the_utilization_bar(self):
+        self._write(available=False, status="rejected", util=(0.13, 0.52), extra={
+            "anthropic-ratelimit-unified-overage-utilization": "0.5",
+            "anthropic-ratelimit-unified-overage-status": "rejected"})
+        c = self.hc.check_core_quota_exhausted()
+        self.assertEqual(c["status"], "fail")
+        self.assertIn("overage (50%, rejected)", c["detail"])
 
     def test_rejected_with_a_window_near_full_still_fails(self):
         self._write(available=False, status="rejected", util=(0.97, 0.52))


### PR DESCRIPTION
## Correction (e5f380db, after sonichi's review)

The two-window check below was too narrow: on this host the rejection is the account's own `7d_oi` window at 100% (`unified-7d_oi-status rejected`, served on overage) while 5h/7d sit at 13%/52%. The probe now reads **every** `unified-<window>-utilization` header with that window's status; any window rejected or ≥ 90% keeps the FAIL and is named in the detail. The shared-proxy warning fires only when no window is near full.

## Problem

`quota-state.json` is written by the shared credential proxy from the **last** response through it, whoever sent it. This morning four pool seats on the same proxy were out of Fable 5.1 usage credits (every one of their passes ends in `You're out of usage credits`), so the unified status flapped `rejected` ↔ `allowed` while this core's own windows sat at 13% (5h) / 52% (7d). `check_core_quota_exhausted` treats an explicit `rejected` as exhaustion and pages the owner (Slack DM via `notify_slack_for_failures`, deduped per transition), so every flap was a fresh "CORE IS OVER QUOTA" page for a core that was running fine.

## Change

`src/health-check.py`: after the existing freshness guards, an explicit rejection is corroborated against the utilization headers (`_quota_utilizations`). Both windows under 90% → **warn** naming the shared proxy and the two percentages. A window near full, or no utilization headers at all → the original **FAIL** (the 2026-08-01 stuck-silently case is unchanged; an unknown reading corroborates nothing).

## Evidence

Live, same instant, real `quota-state.json` (`status=rejected`, 5h `0.13`, 7d `0.52`):
```
main checkout:  ✗ core-quota  fail  CORE IS OVER QUOTA (rate-limit status=rejected). 5h window resets 07:40 PDT. The core cannot process tasks until …
this branch:    core-quota  warn  last response through the shared credential proxy was rejected (status=rejected) but this core's windows are at 13% (5h) / 52% (7d) — another client's per-model or usage-credit limit is the likely source (a seat out of credits); not paging. …
```
`tests/health-check-core-quota.test.py` (+3 controls: both-windows-low → warn naming the shared proxy; a window at 97% → still FAIL; no utilization headers → still FAIL). At the parent (`711ebc62`) the first control fails, the other two pass:
```
FAIL: test_rejected_with_both_windows_low_is_a_warn_naming_the_shared_proxy
Ran 20 tests … FAILED (failures=1)
```
At HEAD: `Ran 20 tests … OK`; `health-check-notify-gateway` OK; `review-checks.sh --diff` PASS.

Relationship to #3795: complementary, different probe. #3795's new `check_core_request_rejections` counts rejections from the same shared ledger, so its "≥5 in an hour → FAIL" inherits this ambiguity (four credit-dead seats retrying produce that in minutes); noted on that PR.

