### PR TITLE
fix(discord-bridge): the delivery gate printed an inequality its own predicate falsifies

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -518,9 +518,12 @@ def _chunk_for_discord(
     if len(preview) > 1:
         # Compose-side feedback: a multi-chunk delivery means the body failed
         # the one-message cap. The composer never sees the split otherwise.
+        # Not an inequality: the split point depends on line structure, so a
+        # body AT the cap can still need two chunks. Report both, claim neither.
         print(
             f"  [delivery-gate] body needed {len(preview)} chunk(s) "
-            f"({len(text)} chars > {max_len}) — compose-side cap missed",
+            f"(body {len(text)} chars, one-message cap {max_len}) "
+            "— compose-side cap missed",
             flush=True,
         )
     if len(preview) <= max_chunks:

--- a/tests/discord-chunker.test.py
+++ b/tests/discord-chunker.test.py
@@ -178,10 +178,47 @@ def _run_delivery_budget_cases():
     print("[discord delivery budget] all 3 cases OK")
 
 
+def _run_gate_message_cases():
+    """The gate line must not state an inequality its own predicate can falsify.
+
+    It fires on the CHUNK COUNT, so a structure that splits at exactly max_len
+    printed "N chars > N" — false, and it sends a reader hunting an off-by-one.
+    """
+    import contextlib
+    import io
+    import re
+
+    body = ("ab\n" * 200)[:40]
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        chunks = list(bridge._chunk_for_discord(body, max_len=40, max_chunks=4))
+    out = buf.getvalue()
+
+    assert len(chunks) > 1, (
+        "gate-message: fixture no longer splits at exactly max_len, so this "
+        "case cannot exercise the gate — pick another structure")
+    assert "[delivery-gate]" in out, f"gate-message: gate did not fire: {out!r}"
+    assert f"{len(chunks)} chunk(s)" in out, (
+        f"gate-message: chunk count missing from {out!r}")
+    for lhs, rhs in re.findall(r"(\d+) chars > (\d+)", out):
+        assert int(lhs) > int(rhs), (
+            f"gate-message: printed a FALSE inequality {lhs} > {rhs} in {out!r}")
+
+    plain = ("word " * 200)[:40]
+    buf2 = io.StringIO()
+    with contextlib.redirect_stdout(buf2):
+        assert len(list(bridge._chunk_for_discord(plain, max_len=40, max_chunks=4))) == 1
+    assert "[delivery-gate]" not in buf2.getvalue(), (
+        "gate-message: fired on a single-chunk body")
+
+    print("[delivery gate message] all 2 cases OK")
+
+
 def main():
     _run_against(bridge, "discord-bridge.py")
     _run_against(dm, "dm-result.py")
     _run_delivery_budget_cases()
+    _run_gate_message_cases()
     print("All chunker tests passed.")
 
 


### PR DESCRIPTION
## The bug

`_chunk_for_discord` fires its compose-side warning on **`len(preview) > 1`** — a chunk count — then reports `({len(text)} chars > {max_len})`. Those are different questions.

A live line from a peer host's `discord-bridge.log`:

```
[delivery-gate] body needed 2 chunk(s) (1900 chars > 1900) — compose-side cap missed
```

`1900 > 1900` is false. Someone debugging that hunts an off-by-one that is not there — which is exactly what happened: two agents on two hosts each built and discarded a boundary-splitting theory before measuring.

## Why one number can't state the constraint

The split point depends on line structure, so the effective cap is content-shaped. Measured on `origin/main` — first length that yields two chunks at `max_len=1900`:

```
plain words / no whitespace          first splits at 1901
newline-dense, md bullets            first splits at 1900   <- AT the cap
one fenced fixture (unclosed block)  first splits at 1896   <- BELOW the cap
```

**Corrected after review — the third row is a property of that fixture, not of fenced bodies.** Measured at 1899 chars:

```
fence truncated mid-block (unclosed)   2 chunks
prose + a short closed fence           1 chunk
bullets + a short closed fence         1 chunk
```

So the honest claim is the weaker and sufficient one: **a body at or below `max_len` can still need two chunks, depending on where its break opportunities fall.** That is all it takes for `len(text) > max_len` to be a false statement about a real split, which is what this diff fixes. An earlier revision of this body said "1899 SPLITS" for fenced bodies generally — a per-fixture threshold reported as a per-shape law, corrected here rather than quietly edited out.

**Consequence beyond this diff:** no length threshold is a sufficient compose-side guard, including `< 1900`. The exact guard is `len(list(_chunk_for_discord_unbounded(body))) == 1`.

## Evidence

New case, **source fix reverted, test kept**:

```
parent   AssertionError: gate-message: printed a FALSE inequality 40 > 40
           in '  [delivery-gate] body needed 2 chunk(s) (40 chars > 40) ...'

HEAD     [dm-result.py] all 7 cases OK
         [discord delivery budget] all 3 cases OK
         [delivery gate message] all 2 cases OK
         All chunker tests passed.
```

`scripts/review-checks.sh --diff` PASS. `ruff check` clean (its E401 on my first commit is why there are no bundled import tweaks here — the hook refused and I split them).

## On the test not going vacuous

The fixture asserts it **still splits at exactly `max_len`** before it judges the text, so a future chunker change turns this into a loud *"pick another structure"* rather than a silently passing no-op. The second case pins the other direction: a single-chunk body must not fire the gate at all.

## Scope

Message text and one test. The gate's fail-open behaviour — it logs, then `yield from preview` — is **unchanged and deliberate here**: making it refuse would drop long owner replies instead of chunking them, which is a worse failure and a separate decision.

## Credit

Found by Echo Act IV Blue, who spotted the false inequality across 192 gate lines on their host and refuted their own first explanation for it before reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

