### PR TITLE
feat(cloud-worker): one container per user — gateway client in cloud mode, pluggable seat runtime, provision script

### DIFF
--- a/deploy/cloud-worker/.env.example
+++ b/deploy/cloud-worker/.env.example
@@ -13,8 +13,9 @@ SUTANDO_WORKER_ID=
 # --- optional ---
 # Names the status file: state/gateway-status.<instance>.json. Default cloud.
 GATEWAY_INSTANCE=cloud
-# stub (test double, default) | claude (Claude Code CLI seat) | ag2-assistant (backup seat) | adapter (/workspace/runtime.sh)
-SUTANDO_WORKER_RUNTIME=stub
+# REQUIRED, no default. claude (Claude Code CLI seat) | ag2-assistant (backup seat)
+# | adapter (/workspace/runtime.sh) | stub (TEST DOUBLE — also needs SUTANDO_ALLOW_STUB_SEAT=1)
+SUTANDO_WORKER_RUNTIME=
 
 # --- runtime=ag2-assistant only (the sidecar; provision.sh forwards only these keys to it) ---
 # Shared secret between the seat and the sidecar's acp-serve --token. Required for this runtime.

--- a/deploy/cloud-worker/.env.example
+++ b/deploy/cloud-worker/.env.example
@@ -1,0 +1,33 @@
+# Env contract for ONE cloud worker container (one user = one file).
+# Copy to a per-user file outside the repo, fill the values, never commit it.
+# docker --env-file syntax: KEY=value, one per line, no inline comments.
+
+# --- required (entrypoint.sh refuses to start without each) ---
+# Broker base URL (the relay this user's agent enrolled with).
+REMOTE_TASK_URL=
+# This user's agent token: a bare secret, or the combined onboarding string.
+REMOTE_TASK_TOKEN=
+# Seat name on the wire, [A-Za-z0-9_-]{1,32}. provision.sh overrides it with argv.
+SUTANDO_WORKER_ID=
+
+# --- optional ---
+# Names the status file: state/gateway-status.<instance>.json. Default cloud.
+GATEWAY_INSTANCE=cloud
+# stub (test double, default) | claude (Claude Code CLI seat) | ag2-assistant (backup seat) | adapter (/workspace/runtime.sh)
+SUTANDO_WORKER_RUNTIME=stub
+
+# --- runtime=ag2-assistant only (the sidecar; provision.sh forwards only these keys to it) ---
+# Shared secret between the seat and the sidecar's acp-serve --token. Required for this runtime.
+AG2ASSISTANT_ACP_TOKEN=
+# The sidecar's model key (Gemini). Sidecar only; the worker never reads it.
+GEMINI_API_KEY=
+# Where the seat dials the sidecar. Default ws://assistant:8802 (provision.sh's network alias).
+AG2ASSISTANT_ACP_URL=
+# Per-task turn budget in seconds; a timeout writes a short failure result. Default 300.
+SUTANDO_ACP_TURN_TIMEOUT_S=
+# Long-poll seconds on GET /v1/tasks. Default 25.
+REMOTE_TASK_POLL_WAIT=25
+# Agent identity (MXID) for registry-loss re-enrolment; optional.
+AGENT_MXID=
+# Runtime=claude only: where the CLI keeps its login. Default /workspace/claude-config.
+CLAUDE_CONFIG_DIR=

--- a/deploy/cloud-worker/.env.example
+++ b/deploy/cloud-worker/.env.example
@@ -24,7 +24,8 @@ AG2ASSISTANT_ACP_TOKEN=
 GEMINI_API_KEY=
 # Where the seat dials the sidecar. Default ws://assistant:8802 (provision.sh's network alias).
 AG2ASSISTANT_ACP_URL=
-# Per-task turn budget in seconds; a timeout writes a short failure result. Default 300.
+# Per-task turn budget in seconds; a timeout writes NOTHING and leaves the task
+# pending for retry, because a delivered result closes the lease. Default 300.
 SUTANDO_ACP_TURN_TIMEOUT_S=
 # Long-poll seconds on GET /v1/tasks. Default 25.
 REMOTE_TASK_POLL_WAIT=25

--- a/deploy/cloud-worker/Dockerfile
+++ b/deploy/cloud-worker/Dockerfile
@@ -1,0 +1,46 @@
+# One cloud seat of a Sutando agent: the gateway client in cloud mode plus a
+# pluggable seat runtime. Context = repo root; provision.sh stages only the COPY sources.
+FROM python:3.12-slim AS base
+
+ARG ENGINE_SHA=""
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    SUTANDO_ENGINE_DIR=/app/engine \
+    SUTANDO_CLOUD_WORKSPACE=/workspace
+
+RUN useradd --system --uid 1000 --home-dir /srv/sutando --create-home sutando \
+ && mkdir -p /app/engine /workspace \
+ && chown -R sutando:sutando /app /workspace
+
+# ACP client for the ag2-assistant seat (the SDK ag2-assistant itself speaks); [http] = websockets.
+RUN pip install --no-cache-dir --root-user-action=ignore 'agent-client-protocol[http]==0.12.1'
+
+WORKDIR /app/engine
+
+# Exactly the client's import graph (tests/cloud-worker-container.test.sh pins
+# this list): package, loader shim + its src/ modules, the workspace resolver.
+COPY --chown=sutando:sutando sutando.config.json ./
+COPY --chown=sutando:sutando packages/ag2-sparrow/ag2_sparrow/ packages/ag2-sparrow/ag2_sparrow/
+COPY --chown=sutando:sutando src/remote-gateway-bridge.py src/workspace_default.py src/sutando_config.py src/util_paths.py src/proactive_routing.py src/task_envelope.py src/git_binary.py src/result_markers.py src/
+COPY --chown=sutando:sutando scripts/sutando-config.sh scripts/python-binary.sh scripts/
+COPY --chown=sutando:sutando deploy/cloud-worker/entrypoint.sh deploy/cloud-worker/seat-stub.py deploy/cloud-worker/seat-ag2-assistant.py deploy/cloud-worker/healthcheck.sh deploy/cloud-worker/
+
+# No git in the image: the client's runtime self-report reads the manifest sha.
+RUN if [ -n "$ENGINE_SHA" ]; then printf '{"sha": "%s"}\n' "$ENGINE_SHA" > ENGINE_MANIFEST.json; fi
+
+USER sutando
+VOLUME ["/workspace"]
+HEALTHCHECK --interval=60s --timeout=10s --start-period=45s --retries=3 \
+  CMD ["bash", "/app/engine/deploy/cloud-worker/healthcheck.sh"]
+ENTRYPOINT ["bash", "/app/engine/deploy/cloud-worker/entrypoint.sh"]
+
+# Opt-in seat runtime (`--target claude`): the Claude Code CLI via its native
+# installer, as the seat user. Login is per container — README.md "Runtime: claude".
+FROM base AS claude
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+USER sutando
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/srv/sutando/.local/bin:${PATH}"

--- a/deploy/cloud-worker/Dockerfile
+++ b/deploy/cloud-worker/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app/engine
 # this list): package, loader shim + its src/ modules, the workspace resolver.
 COPY --chown=sutando:sutando sutando.config.json ./
 COPY --chown=sutando:sutando packages/ag2-sparrow/ag2_sparrow/ packages/ag2-sparrow/ag2_sparrow/
-COPY --chown=sutando:sutando src/remote-gateway-bridge.py src/workspace_default.py src/sutando_config.py src/util_paths.py src/proactive_routing.py src/task_envelope.py src/git_binary.py src/result_markers.py src/
+COPY --chown=sutando:sutando src/remote-gateway-bridge.py src/task_archive.py src/workspace_default.py src/sutando_config.py src/util_paths.py src/proactive_routing.py src/task_envelope.py src/git_binary.py src/result_markers.py src/
 COPY --chown=sutando:sutando scripts/sutando-config.sh scripts/python-binary.sh scripts/
 COPY --chown=sutando:sutando deploy/cloud-worker/entrypoint.sh deploy/cloud-worker/seat-stub.py deploy/cloud-worker/seat-ag2-assistant.py deploy/cloud-worker/healthcheck.sh deploy/cloud-worker/
 

--- a/deploy/cloud-worker/README.md
+++ b/deploy/cloud-worker/README.md
@@ -1,0 +1,234 @@
+# Cloud worker container — one container per user
+
+A **cloud worker** is one more seat of a user's Sutando agent, running on a
+cloud host instead of the user's Mac. It shares the agent identity (same
+broker token, same MXID); it does not create a second agent. This directory
+packages that seat so one container can be provisioned per user:
+
+```
+container sutando-worker-<id>
+├── gateway client   src/remote-gateway-bridge.py, SUTANDO_WORKER_LOCATION=cloud
+│                    pulls GET /v1/tasks?worker=<id> → /workspace/tasks/
+│                    watches /workspace/results/ → POST /v1/results (metadata.worker_id=<id>)
+└── seat runtime     SUTANDO_WORKER_RUNTIME = stub | claude | ag2-assistant | adapter
+                     reads /workspace/tasks/task-*.txt, answers into /workspace/results/
+```
+
+The image carries only the client's import graph — the `ag2-sparrow` package,
+the loader shim and the seven `src/` modules it imports, the workspace
+resolver's shell wrapper, and this directory's scripts. No workspace, no
+skills, no secrets are baked in. `/workspace` is a volume; the engine's
+`sutando.config.local.json` is written at container start to point at it.
+
+Design: sonichi/sutando issue #3794. Client half (worker id on the wire,
+cloud mode): PR #3796. Broker half (per-seat queues, lease failover):
+ag2space-backend PR #945. Pool docs: `docs/lead-follower-pool.md` → "Cloud
+worker".
+
+## Files
+
+| file | role |
+|---|---|
+| `Dockerfile` | `base` target (default, ~150 MB): python:3.12-slim, non-root `sutando`, the allowlisted COPYs, HEALTHCHECK, ENTRYPOINT. `claude` target (~380 MB): adds the Claude Code CLI via its native installer, no node. |
+| `entrypoint.sh` | validates env, writes the workspace config, starts the client and the seat runtime, exits when either dies (the restart policy relaunches). |
+| `seat-stub.py` | `stub` runtime: answers every task with `answered by <worker id>`. |
+| `seat-ag2-assistant.py` | `ag2-assistant` runtime: one ACP session per task against the AG2 Assistant sidecar, result signed `— <worker id> (ag2-assistant)`. |
+| `assistant-bootstrap.sh` | runs *inside* the sidecar (mounted at `/bootstrap.sh`): first-boot profile, provider-key seed into its secret store, then `acp-serve`. |
+| `healthcheck.sh` | healthy while `state/gateway-status.<instance>.json` is younger than 3 minutes (the client rewrites it on every poll). |
+| `docker-compose.yml` | one worker service (+ one ag2-assistant sidecar) per user; copy the blocks to scale. |
+| `.env.example` | the env contract (keys, no values). |
+| `provision.sh` / `deprovision.sh` | one container per user, idempotent, from a per-user env file. |
+
+## Env contract
+
+Required — `entrypoint.sh` exits 2 naming every missing key:
+
+| key | meaning |
+|---|---|
+| `REMOTE_TASK_URL` | broker base URL the user's agent enrolled with |
+| `REMOTE_TASK_TOKEN` | that user's agent token (bare secret, or the combined onboarding string) |
+| `SUTANDO_WORKER_ID` | this seat's name on the wire, `[A-Za-z0-9_-]{1,32}` — `provision.sh` sets it from argv |
+
+Set by the entrypoint: `SUTANDO_WORKER_LOCATION=cloud` (always),
+`GATEWAY_INSTANCE` (default `cloud`; names the status file),
+`SUTANDO_SUPERVISED=1`.
+
+Optional: `SUTANDO_WORKER_RUNTIME` (`stub` default), `REMOTE_TASK_POLL_WAIT`,
+`AGENT_MXID`, `CLAUDE_CONFIG_DIR` (claude runtime only), every other
+`REMOTE_*` knob the client documents in its docstring. Full list with
+comments: `.env.example`.
+
+Runtime `ag2-assistant` adds: `AG2ASSISTANT_ACP_TOKEN` (required — the shared
+secret the sidecar's `acp-serve --token` checks on the WebSocket upgrade),
+`GEMINI_API_KEY` (sidecar only — the worker never reads it),
+`AG2ASSISTANT_ACP_URL` (default `ws://assistant:8802`, the alias `provision.sh`
+gives the sidecar), `SUTANDO_ACP_TURN_TIMEOUT_S` (default 300).
+
+## Provisioning one user
+
+```bash
+cp deploy/cloud-worker/.env.example /somewhere/private/alice.env   # fill URL + token
+bash deploy/cloud-worker/provision.sh cloud-alice /somewhere/private/alice.env --build
+docker logs -f sutando-worker-cloud-alice
+bash deploy/cloud-worker/deprovision.sh cloud-alice            # keep the volume
+bash deploy/cloud-worker/deprovision.sh cloud-alice --purge    # drop it too
+```
+
+`provision.sh` builds the image when it is absent (or on `--build`), trying
+`docker pull $SUTANDO_CLOUD_WORKER_IMAGE` first; the build context is a
+scratch directory holding only the Dockerfile's COPY sources, so the working
+tree never reaches the daemon. The target defaults to `base`; `--target
+claude` builds the CLI seat. Re-running it on a running container is a no-op (exit 0); on a
+stopped one it starts it. Extra `docker run` flags go after `--`.
+
+N users = N calls with N env files (one token + one worker id each), or N
+service blocks in `docker-compose.yml`.
+
+## Seat runtimes and their auth
+
+| `SUTANDO_WORKER_RUNTIME` | what runs | auth |
+|---|---|---|
+| `stub` (default) | `seat-stub.py` — answers `answered by <worker id>` | none; it is the test double |
+| `claude` | the Claude Code CLI seat, `claude --dangerously-skip-permissions --add-dir /workspace -- /proactive-loop`, the way the pool's `pool-core-wrapper.sh` launches a follower (no tmux, the container is the session) | Claude subscription, one **OAuth login per container**, stored under `CLAUDE_CONFIG_DIR` on the volume |
+| `ag2-assistant` | `seat-ag2-assistant.py` — the **backup seat**: one ACP session per task against an [AG2 Assistant](https://github.com/ag2ai/ag2-assistant) sidecar (`ghcr.io/ag2ai/ag2-assistant`, `acp-serve` on 8802) | the sidecar's model key (`GEMINI_API_KEY`) + the shared `AG2ASSISTANT_ACP_TOKEN`; no login |
+| `adapter` | `bash /workspace/runtime.sh` if executable, else exit 4 | whatever the adapter needs — an Agent SDK or codex app-server seat takes an **API key** in env |
+
+Credential order the owner set: the user's Claude **subscription** (`claude`),
+then the user's own **API key** (`adapter`), then **our key** as the backup
+(`ag2-assistant` on a Gemini key we hold).
+
+### Runtime: claude
+
+Build the `claude` target and log in once, inside the container, with the
+config dir on the volume. Nothing is copied from a Mac — no
+`.credentials.json`, no `.claude.json`:
+
+```bash
+bash deploy/cloud-worker/provision.sh cloud-alice alice.env --build --target claude
+docker exec -it sutando-worker-cloud-alice \
+  env CLAUDE_CONFIG_DIR=/workspace/claude-config claude auth login
+# follow the printed URL / code in a browser; the credential lands on the volume
+docker exec sutando-worker-cloud-alice \
+  env CLAUDE_CONFIG_DIR=/workspace/claude-config claude auth status
+docker restart sutando-worker-cloud-alice    # the seat starts once login exists
+```
+
+`claude setup-token` (subscription) or `CLAUDE_CODE_OAUTH_TOKEN` in the env
+file is the non-interactive alternative; the token is per user and lives in
+that user's env file, never in the image. `--dangerously-skip-permissions`
+is why the image runs as a non-root user (the CLI refuses it as root).
+
+The `/proactive-loop` skill shells into `scripts/` and `skills/` that the
+minimal image does not carry. If `/workspace/engine` exists (a full engine
+checkout on the volume) the seat runs from there; otherwise it runs from the
+minimal tree and only the task loop works. Populating the skill set for the
+container is not done in this slice.
+
+### Runtime: ag2-assistant (backup seat)
+
+A different brain, on purpose: AG2 Assistant has its own memory, tools and
+profile, and none of Sutando's skills. It is the cheap always-on seat that
+answers when the user's own seats are down, not a replacement for them.
+
+The official image runs as a **sidecar** — it is not baked into our image
+(its dependency set is heavy) — serving ONE headless profile over ACP
+WebSocket (`ag2-assistant acp-serve --host 0.0.0.0 --port 8802 --token …`,
+experimental). `provision.sh` starts it automatically when the env file says
+`SUTANDO_WORKER_RUNTIME=ag2-assistant` (or with `--with-assistant`): a
+per-user docker network, the sidecar `sutando-assistant-<id>` on alias
+`assistant`, volumes `<id>-data:/data` and `<id>-workspace:/workspace`, and
+only its own keys forwarded (`AG2ASSISTANT_ACP_TOKEN`, `GEMINI_API_KEY`,
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `TZ`) — the broker token never reaches
+it. The sidecar's entrypoint is our `assistant-bootstrap.sh`, mounted
+read-only: it runs `ag2-assistant profiles create backup` when
+`/data/profiles.json` is absent (registry-only; the default profile is
+Gemini), **seeds the provider key into the sidecar's secret store**
+(`SecretStore.set_key`, idempotent), then `exec`s `acp-serve`. The seed is
+needed because `acp-serve` gates every session on the store, not on the
+process env — its `serve_ws(...)` call passes no `env`, so the `env_var` auth
+method it advertises cannot be satisfied by `GEMINI_API_KEY` alone (measured:
+`session/new → Authentication required` with the key in env; `authMethods: []`
+and a session id after the seed). `docker-compose.yml` carries the same pair
+as a template.
+
+The seat (`seat-ag2-assistant.py`) is an adapter loop over the same file
+contract as the stub: for each pending `tasks/task-<id>.txt` it dials the
+sidecar with the bearer token (the ACP SDK's `acp.ws.client`, the package
+ag2-assistant itself imports; installed in our image as
+`agent-client-protocol[http]`), sends `initialize` → `session/new` →
+`session/prompt` with the `task:` body, concatenates the
+`agent_message_chunk` text, and writes `results/task-<id>.txt` ending with
+`— <worker id> (ag2-assistant)`. A permission request from the agent is
+answered `cancelled` (approvals are owner-side in ag2-assistant). Every turn
+is bounded by `SUTANDO_ACP_TURN_TIMEOUT_S` (300 s): the dial retries with
+backoff while the sidecar boots, and a timeout or transport failure still
+writes a short, signed failure result so the task is never swallowed.
+
+```bash
+# alice.env: SUTANDO_WORKER_RUNTIME=ag2-assistant, AG2ASSISTANT_ACP_TOKEN=<random>, GEMINI_API_KEY=<ours>
+bash deploy/cloud-worker/provision.sh cloud-alice alice.env
+docker logs sutando-assistant-cloud-alice     # "acp-serve (experimental) listening on ws://0.0.0.0:8802"
+```
+
+### Runtime: adapter
+
+The slot for the seat runtimes that do not exist yet (Agent SDK, codex
+app-server). Put an executable `runtime.sh` on the volume; it is run with the
+seat env (`SUTANDO_WORKER_ID`, `SUTANDO_WORKER_LOCATION`, `SUTANDO_CLOUD_WORKSPACE`)
+and must read `/workspace/tasks/task-*.txt` and write
+`/workspace/results/task-<id>.txt`. Without it the container exits 4 and stays
+down.
+
+## At-least-once, failover, dedupe
+
+The broker leases a task to the seat that pulled it. A seat that dies mid-run
+stops heartbeating; the lease expires and the broker re-fronts the task, and
+with ag2space-backend #945's per-seat dispatch on, the policy re-picks with
+the dead seat excluded — that is how a task lands on `cloud-1` when the Mac's
+`worker-1` is down, and vice versa. Consequences:
+
+- delivery is **at-least-once**: a task on a worker that dies is re-served;
+- results **dedupe by task id** at the sink, and the client never queues an id
+  it already holds (pending, `.assigned-*`, `.claimed-*`) — see the client
+  docstring "Lease safety";
+- the residual hazard is the broker's `RELAY_VISIBILITY_TIMEOUT` being shorter
+  than an honest task: set it above the longest one, or two seats answer.
+
+With the #945 flag off the broker keeps one queue per agent and ignores
+`worker=`; the container still works — it is simply another puller of the
+same queue.
+
+## Health
+
+`HEALTHCHECK` runs `healthcheck.sh` every 60 s (45 s start period, 3
+retries): healthy while `/workspace/state/gateway-status.<instance>.json` was
+written within 3 minutes. The client rewrites it after every poll
+(`REMOTE_TASK_POLL_WAIT`, 25 s), connected or not; a client that hangs or
+dies stops rewriting it. `docker inspect -f '{{.State.Health.Status}}'`.
+
+## Not done in this slice
+
+- no image registry publishing (`provision.sh` builds locally; `docker pull`
+  is tried only if `SUTANDO_CLOUD_WORKER_IMAGE` names a pushed tag);
+- no cloud IaC (no Terraform/Fly/ECS definitions — compose + scripts only);
+- no login automation for the `claude` runtime (per-container device login,
+  by hand, documented above);
+- no skill set in the image for the `claude` runtime beyond the task loop;
+- the Agent SDK / codex app-server adapters (`adapter` is the slot);
+- the ag2-assistant sidecar is `:latest` (no digest pin) and its `acp-serve`
+  is marked experimental upstream; the sidecar's own memory/tools are not
+  wired to Sutando's;
+- no workspace sync into the container: the seat's memory is the broker's room
+  history (#3794 §5a) until the sync lane covers cloud hosts.
+
+## Tests
+
+`tests/cloud-worker-container.test.sh` (hermetic, no docker daemon): the
+Dockerfile copies only allowlisted paths, `entrypoint.sh` refuses each missing
+required env var, writes the workspace config and marks the seat `cloud`,
+`provision.sh` refuses a missing env file and (under a fake `docker`) issues
+the right `run`/`start`/`build`/sidecar/network calls from a staged context of
+only the allowlisted paths, the ag2-assistant seat completes an ACP turn over
+an in-process transport (chunks → signed result; silent agent → signed
+timeout result; dead sidecar → signed failure), the compose file parses, and
+`healthcheck.sh` distinguishes fresh / stale / absent status files.

--- a/deploy/cloud-worker/README.md
+++ b/deploy/cloud-worker/README.md
@@ -67,7 +67,7 @@ gives the sidecar), `SUTANDO_ACP_TURN_TIMEOUT_S` (default 300).
 ## Provisioning one user
 
 ```bash
-cp deploy/cloud-worker/.env.example /somewhere/private/alice.env   # fill URL + token
+cp deploy/cloud-worker/.env.example /somewhere/private/alice.env   # fill URL, token, RUNTIME
 bash deploy/cloud-worker/provision.sh cloud-alice /somewhere/private/alice.env --build
 docker logs -f sutando-worker-cloud-alice
 bash deploy/cloud-worker/deprovision.sh cloud-alice            # keep the volume

--- a/deploy/cloud-worker/README.md
+++ b/deploy/cloud-worker/README.md
@@ -29,7 +29,7 @@ worker".
 
 | file | role |
 |---|---|
-| `Dockerfile` | `base` target (default, ~150 MB): python:3.12-slim, non-root `sutando`, the allowlisted COPYs, HEALTHCHECK, ENTRYPOINT. `claude` target (~380 MB): adds the Claude Code CLI via its native installer, no node. |
+| `Dockerfile` | `base` target (default, 161 MiB measured at `657d633c`): python:3.12-slim, non-root `sutando`, the allowlisted COPYs, HEALTHCHECK, ENTRYPOINT. `claude` target (~380 MB): adds the Claude Code CLI via its native installer, no node. |
 | `entrypoint.sh` | validates env, writes the workspace config, starts the client and the seat runtime, exits when either dies (the restart policy relaunches). |
 | `seat-stub.py` | `stub` runtime: answers every task with `answered by <worker id>`. |
 | `seat-ag2-assistant.py` | `ag2-assistant` runtime: one ACP session per task against the AG2 Assistant sidecar, result signed `— <worker id> (ag2-assistant)`. |

--- a/deploy/cloud-worker/README.md
+++ b/deploy/cloud-worker/README.md
@@ -53,7 +53,10 @@ Set by the entrypoint: `SUTANDO_WORKER_LOCATION=cloud` (always),
 `GATEWAY_INSTANCE` (default `cloud`; names the status file),
 `SUTANDO_SUPERVISED=1`.
 
-Optional: `SUTANDO_WORKER_RUNTIME` (`stub` default), `REMOTE_TASK_POLL_WAIT`,
+Required: `SUTANDO_WORKER_RUNTIME` — the entrypoint exits 2 when it is unset,
+and refuses `stub` unless `SUTANDO_ALLOW_STUB_SEAT=1` is also set.
+
+Optional: `REMOTE_TASK_POLL_WAIT`,
 `AGENT_MXID`, `CLAUDE_CONFIG_DIR` (claude runtime only), every other
 `REMOTE_*` knob the client documents in its docstring. Full list with
 comments: `.env.example`.
@@ -88,7 +91,7 @@ service blocks in `docker-compose.yml`.
 
 | `SUTANDO_WORKER_RUNTIME` | what runs | auth |
 |---|---|---|
-| `stub` (default) | `seat-stub.py` — answers `answered by <worker id>` | none; it is the test double |
+| `stub` (opt-in only: `SUTANDO_ALLOW_STUB_SEAT=1`) | `seat-stub.py` — answers `answered by <worker id>` | none; it is the test double, and it would post that string as a real result |
 | `claude` | the Claude Code CLI seat, `claude --dangerously-skip-permissions --add-dir /workspace -- /proactive-loop`, the way the pool's `pool-core-wrapper.sh` launches a follower (no tmux, the container is the session) | Claude subscription, one **OAuth login per container**, stored under `CLAUDE_CONFIG_DIR` on the volume |
 | `ag2-assistant` | `seat-ag2-assistant.py` — the **backup seat**: one ACP session per task against an [AG2 Assistant](https://github.com/ag2ai/ag2-assistant) sidecar (`ghcr.io/ag2ai/ag2-assistant`, `acp-serve` on 8802) | the sidecar's model key (`GEMINI_API_KEY`) + the shared `AG2ASSISTANT_ACP_TOKEN`; no login |
 | `adapter` | `bash /workspace/runtime.sh` if executable, else exit 4 | whatever the adapter needs — an Agent SDK or codex app-server seat takes an **API key** in env |
@@ -161,8 +164,11 @@ ag2-assistant itself imports; installed in our image as
 `— <worker id> (ag2-assistant)`. A permission request from the agent is
 answered `cancelled` (approvals are owner-side in ag2-assistant). Every turn
 is bounded by `SUTANDO_ACP_TURN_TIMEOUT_S` (300 s): the dial retries with
-backoff while the sidecar boots, and a timeout or transport failure still
-writes a short, signed failure result so the task is never swallowed.
+backoff while the sidecar boots, and a timeout or transport failure writes
+**nothing**: a delivered result closes the server lease, so failure prose would
+become the user's terminal answer and no other seat could be re-fronted. The
+task stays pending, this seat retries it under capped exponential backoff, and
+an unrecovered seat lets the lease expire into the documented failover.
 
 ```bash
 # alice.env: SUTANDO_WORKER_RUNTIME=ag2-assistant, AG2ASSISTANT_ACP_TOKEN=<random>, GEMINI_API_KEY=<ours>
@@ -229,6 +235,6 @@ required env var, writes the workspace config and marks the seat `cloud`,
 `provision.sh` refuses a missing env file and (under a fake `docker`) issues
 the right `run`/`start`/`build`/sidecar/network calls from a staged context of
 only the allowlisted paths, the ag2-assistant seat completes an ACP turn over
-an in-process transport (chunks → signed result; silent agent → signed
-timeout result; dead sidecar → signed failure), the compose file parses, and
+an in-process transport (chunks → signed result; silent agent → no body;
+dead sidecar → no body, task left pending), the compose file parses, and
 `healthcheck.sh` distinguishes fresh / stale / absent status files.

--- a/deploy/cloud-worker/assistant-bootstrap.sh
+++ b/deploy/cloud-worker/assistant-bootstrap.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Runs INSIDE the ag2-assistant sidecar (mounted at /bootstrap.sh): first-boot
+# profile + provider-key seed, then the ACP WebSocket listener. POSIX sh.
+set -eu
+[ -n "${AG2ASSISTANT_ACP_TOKEN:-}" ] || { echo "assistant-bootstrap: AG2ASSISTANT_ACP_TOKEN is required" >&2; exit 2; }
+[ -s /data/profiles.json ] || ag2-assistant profiles create backup
+# acp-serve gates sessions on the secret store, not the process env: seed it.
+python - <<'PY'
+import os
+from pathlib import Path
+from assistant.paths import Paths
+from assistant.secrets import SecretStore
+store = SecretStore(Paths.from_env(os.environ, Path.home()))
+for provider, var in (("gemini", "GEMINI_API_KEY"), ("openai", "OPENAI_API_KEY"), ("anthropic", "ANTHROPIC_API_KEY")):
+    if os.environ.get(var):
+        store.set_key(provider, os.environ[var])
+        print(f"assistant-bootstrap: {var} seeded into the secret store", flush=True)
+PY
+exec ag2-assistant acp-serve --host 0.0.0.0 --port "${AG2ASSISTANT_ACP_PORT:-8802}" --token "$AG2ASSISTANT_ACP_TOKEN"

--- a/deploy/cloud-worker/deprovision.sh
+++ b/deploy/cloud-worker/deprovision.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# deprovision.sh <worker-id> [--purge]
+# Idempotent: stops and removes sutando-worker-<id>, its ag2-assistant sidecar
+# and per-user network if present; --purge also deletes the volumes (the seat's
+# tasks, results, state, any CLI login, and the sidecar's /data + /workspace).
+# Exit: 0 removed or already absent, 2 usage, 4 docker unavailable, 6 removal failed.
+set -uo pipefail
+
+WORKER_ID=""; PURGE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --purge) PURGE=1; shift ;;
+    -h|--help) sed -n '2,5p' "${BASH_SOURCE[0]}" >&2; exit 2 ;;
+    -*) echo "deprovision: unknown option $1" >&2; exit 2 ;;
+    *) [ -z "$WORKER_ID" ] || { echo "deprovision: unexpected argument $1" >&2; exit 2; }
+       WORKER_ID="$1"; shift ;;
+  esac
+done
+[ -n "$WORKER_ID" ] || { sed -n '2,5p' "${BASH_SOURCE[0]}" >&2; exit 2; }
+if ! printf '%s' "$WORKER_ID" | grep -Eq '^[A-Za-z0-9_-]{1,32}$'; then
+  echo "deprovision: worker id must match [A-Za-z0-9_-]{1,32}, got '$WORKER_ID'" >&2; exit 2
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "deprovision: docker is not available (daemon down or not installed)" >&2; exit 4
+fi
+
+NAME="sutando-worker-$WORKER_ID"
+ASSISTANT="sutando-assistant-$WORKER_ID"
+for c in "$NAME" "$ASSISTANT"; do
+  if docker container inspect "$c" >/dev/null 2>&1; then
+    docker rm -f "$c" >/dev/null || { echo "deprovision: could not remove $c" >&2; exit 6; }
+    echo "deprovision: removed $c"
+  else
+    echo "deprovision: $c already absent"
+  fi
+done
+if docker network inspect "$NAME" >/dev/null 2>&1; then
+  docker network rm "$NAME" >/dev/null || { echo "deprovision: could not remove network $NAME" >&2; exit 6; }
+  echo "deprovision: removed network $NAME"
+fi
+if [ "$PURGE" -eq 1 ]; then
+  for v in "$NAME" "$ASSISTANT-data" "$ASSISTANT-workspace"; do
+    if docker volume inspect "$v" >/dev/null 2>&1; then
+      docker volume rm "$v" >/dev/null || { echo "deprovision: could not remove volume $v" >&2; exit 6; }
+      echo "deprovision: removed volume $v"
+    else
+      echo "deprovision: volume $v already absent"
+    fi
+  done
+fi

--- a/deploy/cloud-worker/docker-compose.yml
+++ b/deploy/cloud-worker/docker-compose.yml
@@ -1,0 +1,61 @@
+# One cloud worker per user. Each service is one container = one broker token
+# + one worker id + one /workspace volume. Build the image with
+# `bash deploy/cloud-worker/provision.sh --build-only` (the build context is the
+# Dockerfile's COPY allowlist, never the working tree), then `docker compose up -d`.
+#
+# To add a user, copy the `worker-example` block (and, for the ag2-assistant
+# backup seat, its `assistant-example` sidecar) and change: service names,
+# container_name, env_file (that user's env file), volume names, and
+# SUTANDO_WORKER_ID (a seat name, [A-Za-z0-9_-]{1,32}, e.g. cloud-alice).
+# `provision.sh <worker-id> <env-file>` does the same without editing this file.
+services:
+  worker-example:
+    image: ${SUTANDO_CLOUD_WORKER_IMAGE:-sutando-cloud-worker:local}
+    container_name: sutando-worker-example
+    env_file:
+      - .env.example
+    environment:
+      SUTANDO_WORKER_ID: cloud-example
+      SUTANDO_WORKER_LOCATION: cloud
+      # Only read when SUTANDO_WORKER_RUNTIME=ag2-assistant: the sidecar below.
+      AG2ASSISTANT_ACP_URL: ws://assistant-example:8802
+    volumes:
+      - worker-example:/workspace
+    depends_on:
+      - assistant-example
+    restart: unless-stopped
+
+  # The ag2-assistant backup seat: the official image as a sidecar, one per
+  # user, serving ONE headless profile over ACP WebSocket on port 8802.
+  # Not needed for the stub / claude / adapter runtimes — delete both blocks.
+  assistant-example:
+    image: ${SUTANDO_ASSISTANT_IMAGE:-ghcr.io/ag2ai/ag2-assistant:latest}
+    container_name: sutando-assistant-example
+    environment:
+      # Values come from the shell / compose .env at `up` time, not from the
+      # worker's env file: the sidecar must not see the broker token.
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      AG2ASSISTANT_ACP_TOKEN: ${AG2ASSISTANT_ACP_TOKEN:-}
+      TZ: ${TZ:-UTC}
+    # assistant-bootstrap.sh: first-boot profile, key seed into the secret
+    # store (acp-serve does not read the process env for it), then acp-serve.
+    entrypoint: ["sh", "/bootstrap.sh"]
+    volumes:
+      - ./assistant-bootstrap.sh:/bootstrap.sh:ro
+      - assistant-example-data:/data
+      - assistant-example-workspace:/workspace
+    restart: unless-stopped
+
+  # worker-alice:
+  #   image: ${SUTANDO_CLOUD_WORKER_IMAGE:-sutando-cloud-worker:local}
+  #   container_name: sutando-worker-alice
+  #   env_file: [users/alice.env]
+  #   environment: { SUTANDO_WORKER_ID: cloud-alice, SUTANDO_WORKER_LOCATION: cloud, AG2ASSISTANT_ACP_URL: ws://assistant-alice:8802 }
+  #   volumes: [worker-alice:/workspace]
+  #   restart: unless-stopped
+
+volumes:
+  worker-example:
+  assistant-example-data:
+  assistant-example-workspace:
+  # worker-alice:

--- a/deploy/cloud-worker/docker-compose.yml
+++ b/deploy/cloud-worker/docker-compose.yml
@@ -5,8 +5,10 @@
 #
 # To add a user, copy the `worker-example` block (and, for the ag2-assistant
 # backup seat, its `assistant-example` sidecar) and change: service names,
-# container_name, env_file (that user's env file), volume names, and
-# SUTANDO_WORKER_ID (a seat name, [A-Za-z0-9_-]{1,32}, e.g. cloud-alice).
+# container_name, env_file (that user's env file), volume names,
+# SUTANDO_WORKER_ID (a seat name, [A-Za-z0-9_-]{1,32}, e.g. cloud-alice),
+# the `networks:` name (its OWN — a shared network lets one user's worker reach
+# another's sidecar), and AG2ASSISTANT_ACP_TOKEN_<USER> (its own token var).
 # `provision.sh <worker-id> <env-file>` does the same without editing this file.
 services:
   worker-example:
@@ -21,6 +23,7 @@ services:
       AG2ASSISTANT_ACP_URL: ws://assistant-example:8802
     volumes:
       - worker-example:/workspace
+    networks: [example]
     depends_on:
       - assistant-example
     restart: unless-stopped
@@ -35,7 +38,9 @@ services:
       # Values come from the shell / compose .env at `up` time, not from the
       # worker's env file: the sidecar must not see the broker token.
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
-      AG2ASSISTANT_ACP_TOKEN: ${AG2ASSISTANT_ACP_TOKEN:-}
+      # PER USER, not project-wide: one shared value would let any user's worker
+      # authenticate to every other user's sidecar.
+      AG2ASSISTANT_ACP_TOKEN: ${AG2ASSISTANT_ACP_TOKEN_EXAMPLE:-}
       TZ: ${TZ:-UTC}
     # assistant-bootstrap.sh: first-boot profile, key seed into the secret
     # store (acp-serve does not read the process env for it), then acp-serve.
@@ -44,6 +49,7 @@ services:
       - ./assistant-bootstrap.sh:/bootstrap.sh:ro
       - assistant-example-data:/data
       - assistant-example-workspace:/workspace
+    networks: [example]
     restart: unless-stopped
 
   # worker-alice:
@@ -53,6 +59,12 @@ services:
   #   environment: { SUTANDO_WORKER_ID: cloud-alice, SUTANDO_WORKER_LOCATION: cloud, AG2ASSISTANT_ACP_URL: ws://assistant-alice:8802 }
   #   volumes: [worker-alice:/workspace]
   #   restart: unless-stopped
+
+# One network PER USER PAIR. Without this every service joins the project
+# default network and any worker can reach any other user's sidecar.
+networks:
+  example:
+  # alice:
 
 volumes:
   worker-example:

--- a/deploy/cloud-worker/docker-compose.yml
+++ b/deploy/cloud-worker/docker-compose.yml
@@ -58,6 +58,16 @@ services:
   #   env_file: [users/alice.env]
   #   environment: { SUTANDO_WORKER_ID: cloud-alice, SUTANDO_WORKER_LOCATION: cloud, AG2ASSISTANT_ACP_URL: ws://assistant-alice:8802 }
   #   volumes: [worker-alice:/workspace]
+  #   networks: [alice]
+  #   depends_on: [assistant-alice]
+  #   restart: unless-stopped
+  # assistant-alice:
+  #   image: ${SUTANDO_ASSISTANT_IMAGE:-ghcr.io/ag2ai/ag2-assistant:latest}
+  #   container_name: sutando-assistant-alice
+  #   environment: { GEMINI_API_KEY: "${GEMINI_API_KEY:-}", AG2ASSISTANT_ACP_TOKEN: "${AG2ASSISTANT_ACP_TOKEN_ALICE:-}", TZ: "${TZ:-UTC}" }
+  #   entrypoint: ["sh", "/bootstrap.sh"]
+  #   volumes: [./assistant-bootstrap.sh:/bootstrap.sh:ro, assistant-alice-data:/data, assistant-alice-workspace:/workspace]
+  #   networks: [alice]
   #   restart: unless-stopped
 
 # One network PER USER PAIR. Without this every service joins the project
@@ -71,3 +81,5 @@ volumes:
   assistant-example-data:
   assistant-example-workspace:
   # worker-alice:
+  # assistant-alice-data:
+  # assistant-alice-workspace:

--- a/deploy/cloud-worker/entrypoint.sh
+++ b/deploy/cloud-worker/entrypoint.sh
@@ -19,7 +19,17 @@ fi
 export GATEWAY_INSTANCE="${GATEWAY_INSTANCE:-cloud}"
 export SUTANDO_WORKER_LOCATION=cloud
 export SUTANDO_SUPERVISED=1
-RUNTIME="${SUTANDO_WORKER_RUNTIME:-stub}"
+# No default: a seat that answers must be chosen deliberately. Defaulting to the
+# test double let the documented quickstart post "answered by ..." as a real result.
+RUNTIME="${SUTANDO_WORKER_RUNTIME:-}"
+if [ -z "$RUNTIME" ]; then
+  echo "cloud-worker: SUTANDO_WORKER_RUNTIME is required (claude | ag2-assistant | adapter | stub)" >&2
+  exit 2
+fi
+if [ "$RUNTIME" = stub ] && [ "${SUTANDO_ALLOW_STUB_SEAT:-}" != "1" ]; then
+  echo "cloud-worker: runtime 'stub' is a TEST DOUBLE and would post 'answered by ...' as a real result; set SUTANDO_ALLOW_STUB_SEAT=1 to permit it" >&2
+  exit 2
+fi
 
 # The workspace lives on the volume; the resolver reads this file beside the engine.
 if ! mkdir -p "$WS/tasks" "$WS/results" "$WS/state" "$WS/logs"; then

--- a/deploy/cloud-worker/entrypoint.sh
+++ b/deploy/cloud-worker/entrypoint.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# One cloud seat: the gateway client in cloud mode + the seat runtime named by
+# SUTANDO_WORKER_RUNTIME. Exit: 2 env/usage, 3 workspace, 4 runtime unavailable, 5 child exited.
+set -uo pipefail
+
+ENGINE="${SUTANDO_ENGINE_DIR:-/app/engine}"
+WS="${SUTANDO_CLOUD_WORKSPACE:-/workspace}"
+HERE="$ENGINE/deploy/cloud-worker"
+
+missing=()
+for v in REMOTE_TASK_URL REMOTE_TASK_TOKEN SUTANDO_WORKER_ID; do
+  [ -n "${!v:-}" ] || missing+=("$v")
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "cloud-worker: missing required env: ${missing[*]}" >&2
+  exit 2
+fi
+
+export GATEWAY_INSTANCE="${GATEWAY_INSTANCE:-cloud}"
+export SUTANDO_WORKER_LOCATION=cloud
+export SUTANDO_SUPERVISED=1
+RUNTIME="${SUTANDO_WORKER_RUNTIME:-stub}"
+
+# The workspace lives on the volume; the resolver reads this file beside the engine.
+if ! mkdir -p "$WS/tasks" "$WS/results" "$WS/state" "$WS/logs"; then
+  echo "cloud-worker: cannot create workspace dirs under $WS" >&2
+  exit 3
+fi
+if ! printf '{"workspace": {"path": "%s"}}\n' "$WS" > "$ENGINE/sutando.config.local.json"; then
+  echo "cloud-worker: cannot write $ENGINE/sutando.config.local.json" >&2
+  exit 3
+fi
+resolved="$(bash "$ENGINE/scripts/sutando-config.sh" workspace 2>/dev/null)" || resolved=""
+if [ "$resolved" != "$WS" ]; then
+  echo "cloud-worker: workspace resolves to '${resolved:-<none>}', expected '$WS'" >&2
+  exit 3
+fi
+
+cd "$ENGINE" || exit 3
+echo "cloud-worker: seat=$SUTANDO_WORKER_ID instance=$GATEWAY_INSTANCE runtime=$RUNTIME workspace=$WS"
+
+python3 "$ENGINE/src/remote-gateway-bridge.py" &
+client=$!
+
+seat=""
+case "$RUNTIME" in
+  stub)
+    python3 "$HERE/seat-stub.py" &
+    seat=$!
+    ;;
+  claude)
+    if ! command -v claude >/dev/null 2>&1; then
+      echo "cloud-worker: runtime 'claude' needs the claude CLI on PATH — build with --target claude" >&2
+      kill "$client" 2>/dev/null; exit 4
+    fi
+    export CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$WS/claude-config}"
+    mkdir -p "$CLAUDE_CONFIG_DIR"
+    # A full engine checkout on the volume gives the skill its scripts/; else the minimal tree.
+    seat_cwd="$ENGINE"
+    [ -d "$WS/engine" ] && seat_cwd="$WS/engine"
+    (cd "$seat_cwd" && exec claude --dangerously-skip-permissions --add-dir "$WS" -- "/proactive-loop") &
+    seat=$!
+    ;;
+  ag2-assistant)
+    if [ -z "${AG2ASSISTANT_ACP_TOKEN:-}" ]; then
+      echo "cloud-worker: runtime 'ag2-assistant' needs AG2ASSISTANT_ACP_TOKEN (the sidecar's --token)" >&2
+      kill "$client" 2>/dev/null; exit 2
+    fi
+    export AG2ASSISTANT_ACP_URL="${AG2ASSISTANT_ACP_URL:-ws://assistant:8802}"
+    python3 "$HERE/seat-ag2-assistant.py" &
+    seat=$!
+    ;;
+  adapter)
+    if [ ! -x "$WS/runtime.sh" ]; then
+      echo "cloud-worker: runtime 'adapter' needs an executable $WS/runtime.sh (Agent SDK / codex app-server adapters are not shipped yet)" >&2
+      kill "$client" 2>/dev/null; exit 4
+    fi
+    bash "$WS/runtime.sh" &
+    seat=$!
+    ;;
+  *)
+    echo "cloud-worker: unknown SUTANDO_WORKER_RUNTIME='$RUNTIME' (stub | claude | ag2-assistant | adapter)" >&2
+    kill "$client" 2>/dev/null; exit 2
+    ;;
+esac
+
+stopping=0
+stop_all() { stopping=1; kill "$client" "$seat" 2>/dev/null; }
+trap stop_all TERM INT
+
+# No `wait -n` on bash 3: poll both children; the first to die ends the seat.
+while kill -0 "$client" 2>/dev/null && kill -0 "$seat" 2>/dev/null; do sleep 1; done
+if [ "$stopping" -eq 1 ]; then
+  wait; echo "cloud-worker: stopped"; exit 0
+fi
+if kill -0 "$client" 2>/dev/null; then who="seat runtime ($RUNTIME)"; wait "$seat"; rc=$?
+else who="gateway client"; wait "$client"; rc=$?; fi
+echo "cloud-worker: a child exited — $who rc=$rc — stopping the seat so the restart policy relaunches it" >&2
+kill "$client" "$seat" 2>/dev/null
+wait
+exit 5

--- a/deploy/cloud-worker/healthcheck.sh
+++ b/deploy/cloud-worker/healthcheck.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Healthy while the gateway client keeps rewriting its status file (once per poll).
+WS="${SUTANDO_CLOUD_WORKSPACE:-/workspace}"
+f="$WS/state/gateway-status.${GATEWAY_INSTANCE:-cloud}.json"
+if [ ! -f "$f" ]; then echo "unhealthy: no status file at $f"; exit 1; fi
+if [ -z "$(find "$f" -mmin -3 2>/dev/null)" ]; then echo "unhealthy: $f older than 3 minutes"; exit 1; fi
+echo "healthy: $f"

--- a/deploy/cloud-worker/provision.sh
+++ b/deploy/cloud-worker/provision.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# provision.sh <worker-id> <env-file> [--build] [--target claude] [--with-assistant] [-- <docker run args>]
+# provision.sh --build-only [--target claude]      (target defaults to base)
+# Idempotent: builds/pulls the image if absent, then creates or starts the
+# container sutando-worker-<id> on volume sutando-worker-<id>:/workspace. With
+# --with-assistant (implied by SUTANDO_WORKER_RUNTIME=ag2-assistant in the env
+# file) it also runs the ag2-assistant sidecar sutando-assistant-<id> on a
+# per-user network, alias `assistant`, forwarding only its own keys to it.
+# Exit: 0 running/built, 2 usage, 3 env file unreadable or missing a key the
+#       sidecar needs, 4 docker unavailable, 5 image unavailable, 6 a container did not start.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+IMAGE="${SUTANDO_CLOUD_WORKER_IMAGE:-sutando-cloud-worker:local}"
+ASSISTANT_IMAGE="${SUTANDO_ASSISTANT_IMAGE:-ghcr.io/ag2ai/ag2-assistant:latest}"
+DOCKERFILE_REL="deploy/cloud-worker/Dockerfile"
+
+usage() { sed -n '2,10p' "${BASH_SOURCE[0]}" >&2; exit 2; }
+
+WORKER_ID=""; ENV_FILE=""; BUILD=0; BUILD_ONLY=0; TARGET="base"; WITH_ASSISTANT=0; EXTRA=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --build) BUILD=1; shift ;;
+    --build-only) BUILD=1; BUILD_ONLY=1; shift ;;
+    --target) [ $# -ge 2 ] || usage; TARGET="$2"; shift 2 ;;
+    --with-assistant) WITH_ASSISTANT=1; shift ;;
+    --) shift; EXTRA=("$@"); break ;;
+    -h|--help) usage ;;
+    -*) echo "provision: unknown option $1" >&2; usage ;;
+    *)
+      if [ -z "$WORKER_ID" ]; then WORKER_ID="$1"
+      elif [ -z "$ENV_FILE" ]; then ENV_FILE="$1"
+      else echo "provision: unexpected argument $1" >&2; usage; fi
+      shift ;;
+  esac
+done
+
+if [ "$BUILD_ONLY" -eq 0 ]; then
+  [ -n "$WORKER_ID" ] && [ -n "$ENV_FILE" ] || usage
+  if ! printf '%s' "$WORKER_ID" | grep -Eq '^[A-Za-z0-9_-]{1,32}$'; then
+    echo "provision: worker id must match [A-Za-z0-9_-]{1,32}, got '$WORKER_ID'" >&2; exit 2
+  fi
+  if [ ! -r "$ENV_FILE" ]; then
+    echo "provision: env file not readable: $ENV_FILE" >&2; exit 3
+  fi
+fi
+
+# Last `KEY=value` line of the env file (docker --env-file syntax), or "".
+env_value() { grep -E "^$1=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2-; }
+if [ "$BUILD_ONLY" -eq 0 ] && [ "$(env_value SUTANDO_WORKER_RUNTIME)" = "ag2-assistant" ]; then
+  WITH_ASSISTANT=1
+fi
+if [ "$WITH_ASSISTANT" -eq 1 ] && [ -z "$(env_value AG2ASSISTANT_ACP_TOKEN)" ]; then
+  echo "provision: the ag2-assistant sidecar needs AG2ASSISTANT_ACP_TOKEN in $ENV_FILE" >&2; exit 3
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "provision: docker is not available (daemon down or not installed)" >&2; exit 4
+fi
+
+# Build context = the Dockerfile's own COPY sources, staged into a scratch dir.
+# The working tree (and any workspace under it) never reaches the daemon.
+copy_sources() {
+  grep -E '^COPY ' "$REPO/$DOCKERFILE_REL" \
+    | sed -E 's/--[a-z]+=[^ ]+ //g' \
+    | awk '{ for (i = 2; i < NF; i++) print $i }'
+}
+
+build_image() {
+  local sha ctx rc sources=()
+  sha="$(git -C "$REPO" rev-parse HEAD 2>/dev/null || true)"
+  while IFS= read -r p; do sources+=("$p"); done < <(copy_sources)
+  ctx="$(mktemp -d "${TMPDIR:-/tmp}/sutando-cloud-worker-ctx.XXXXXX")" || return 1
+  echo "provision: building $IMAGE (target $TARGET) from ${#sources[@]} COPY sources, sha=${sha:-none}"
+  tar -C "$REPO" --exclude='__pycache__' --exclude='*.pyc' -cf - "${sources[@]}" "$DOCKERFILE_REL" \
+    | tar -C "$ctx" -xf -
+  docker build -f "$ctx/$DOCKERFILE_REL" --build-arg "ENGINE_SHA=$sha" \
+    --target "$TARGET" -t "$IMAGE" "$ctx"
+  rc=$?
+  rm -rf "$ctx"
+  return $rc
+}
+
+ensure_image() {
+  if [ "$BUILD" -eq 0 ] && docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "provision: image $IMAGE present"; return 0
+  fi
+  if [ "$BUILD" -eq 0 ] && docker pull "$IMAGE" >/dev/null 2>&1; then
+    echo "provision: pulled $IMAGE"; return 0
+  fi
+  build_image && return 0
+  echo "provision: image $IMAGE unavailable — pull and build both failed" >&2
+  return 5
+}
+
+ensure_image || exit $?
+[ "$BUILD_ONLY" -eq 1 ] && exit 0
+
+NAME="sutando-worker-$WORKER_ID"
+VOLUME="$NAME"
+NET_ARGS=()
+if [ "$WITH_ASSISTANT" -eq 1 ]; then
+  NET="$NAME"; ASSISTANT="sutando-assistant-$WORKER_ID"
+  if ! docker network inspect "$NET" >/dev/null 2>&1; then
+    docker network create "$NET" >/dev/null || { echo "provision: could not create network $NET" >&2; exit 6; }
+  fi
+  if docker container inspect "$ASSISTANT" >/dev/null 2>&1; then
+    if [ "$(docker container inspect -f '{{.State.Status}}' "$ASSISTANT")" != running ]; then
+      docker start "$ASSISTANT" >/dev/null || { echo "provision: could not start $ASSISTANT" >&2; exit 6; }
+      echo "provision: started existing $ASSISTANT"
+    else
+      echo "provision: $ASSISTANT already running"
+    fi
+  else
+    # Only the sidecar's own keys reach it — never the broker token.
+    side_env="$(mktemp "${TMPDIR:-/tmp}/sutando-assistant-env.XXXXXX")"
+    grep -E '^(AG2ASSISTANT_ACP_TOKEN|GEMINI_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|TZ)=' "$ENV_FILE" > "$side_env"
+    if ! docker run -d --name "$ASSISTANT" --restart unless-stopped \
+        --network "$NET" --network-alias assistant --env-file "$side_env" \
+        -v "$ASSISTANT-data:/data" -v "$ASSISTANT-workspace:/workspace" \
+        -v "$HERE/assistant-bootstrap.sh:/bootstrap.sh:ro" \
+        --entrypoint sh "$ASSISTANT_IMAGE" /bootstrap.sh >/dev/null; then
+      rm -f "$side_env"; echo "provision: docker run failed for $ASSISTANT" >&2; exit 6
+    fi
+    rm -f "$side_env"
+    echo "provision: created $ASSISTANT (image $ASSISTANT_IMAGE, network $NET, alias assistant)"
+  fi
+  NET_ARGS=(--network "$NET" -e AG2ASSISTANT_ACP_URL=ws://assistant:8802)
+fi
+# Typed inspect: a bare `docker inspect <name>` also matches the same-named
+# network/volume. Existence first — `-f` on a missing name prints a blank line.
+if docker container inspect "$NAME" >/dev/null 2>&1; then
+  state="$(docker container inspect -f '{{.State.Status}}' "$NAME" 2>/dev/null)"
+else
+  state=absent
+fi
+case "$state" in
+  running)
+    echo "provision: $NAME already running"; exit 0 ;;
+  absent)
+    if ! docker run -d --name "$NAME" --restart unless-stopped \
+        --env-file "$ENV_FILE" -e "SUTANDO_WORKER_ID=$WORKER_ID" -e SUTANDO_WORKER_LOCATION=cloud \
+        -v "$VOLUME:/workspace" ${NET_ARGS[@]+"${NET_ARGS[@]}"} ${EXTRA[@]+"${EXTRA[@]}"} "$IMAGE" >/dev/null; then
+      echo "provision: docker run failed for $NAME" >&2; exit 6
+    fi
+    echo "provision: created $NAME (volume $VOLUME, image $IMAGE)" ;;
+  *)
+    if ! docker start "$NAME" >/dev/null; then
+      echo "provision: could not start existing $NAME (state $state)" >&2; exit 6
+    fi
+    echo "provision: started existing $NAME (was $state)" ;;
+esac
+docker container inspect -f 'provision: {{.Name}} state={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}n/a{{end}}' "$NAME" 2>/dev/null || true
+exit 0

--- a/deploy/cloud-worker/seat-ag2-assistant.py
+++ b/deploy/cloud-worker/seat-ag2-assistant.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""ag2-assistant seat runtime: the cheap always-on backup seat.
+
+Same file contract as seat-stub.py — every pending `tasks/task-<id>.txt` is
+answered into `results/task-<id>.txt` — but the answer comes from an AG2
+Assistant sidecar over ACP (JSON-RPC over WebSocket, `acp-serve`): one session
+per task, the task body as the prompt, the agent's message text as the result,
+signed `— <worker id> (ag2-assistant)`. Every turn is bounded by
+SUTANDO_ACP_TURN_TIMEOUT_S; a timeout or a transport failure still writes a
+short failure result, so a task is never silently swallowed.
+
+The WebSocket transport is the ACP SDK's own (`acp.ws.client`, the package
+ag2-assistant imports); the JSON-RPC turn is driven here over its Transport
+protocol, so a test can plug an in-process transport in.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import signal
+import sys
+import time
+from pathlib import Path
+
+WS = Path(os.environ.get("SUTANDO_CLOUD_WORKSPACE") or "/workspace")
+WORKER = os.environ.get("SUTANDO_WORKER_ID") or "cloud"
+ACP_URL = os.environ.get("AG2ASSISTANT_ACP_URL") or "ws://assistant:8802"
+ACP_TOKEN = os.environ.get("AG2ASSISTANT_ACP_TOKEN") or ""
+TURN_TIMEOUT_S = float(os.environ.get("SUTANDO_ACP_TURN_TIMEOUT_S") or "300")
+SCAN_S = float(os.environ.get("SUTANDO_STUB_SCAN_S") or "1.0")
+SIGNATURE = f"— {WORKER} (ag2-assistant)"
+PENDING = re.compile(r"^task-[^.]+\.txt$")
+PROTOCOL_VERSION = 1
+_STOP = False
+
+
+def _stop(*_a) -> None:
+    global _STOP
+    _STOP = True
+
+
+def prompt_of(task_text: str) -> str:
+    """The `task:` value — the last header, free-form to end of file."""
+    lines = task_text.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("task:"):
+            return "\n".join([line[len("task:"):].strip()] + lines[i + 1:]).strip()
+    return task_text.strip()
+
+
+class AcpTurn:
+    """One ACP client turn over a Transport (send(dict) / receive() -> dict|None / close())."""
+
+    def __init__(self, transport) -> None:
+        self.t = transport
+        self._next_id = 0
+        self.text: list[str] = []
+
+    async def call(self, method: str, params: dict) -> dict:
+        self._next_id += 1
+        rid = self._next_id
+        await self.t.send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        while True:
+            msg = await self.t.receive()
+            if msg is None:
+                raise ConnectionError("ACP transport closed mid-turn")
+            if msg.get("id") == rid and "method" not in msg:
+                if "error" in msg:
+                    err = msg["error"] or {}
+                    raise RuntimeError(f"ACP {method} failed: {err.get('message') or err}")
+                return msg.get("result") or {}
+            await self._handle_incoming(msg)
+
+    async def _handle_incoming(self, msg: dict) -> None:
+        method = msg.get("method")
+        if method == "session/update":
+            update = (msg.get("params") or {}).get("update") or {}
+            if update.get("sessionUpdate") == "agent_message_chunk":
+                content = update.get("content") or {}
+                if content.get("type") == "text":
+                    self.text.append(content.get("text") or "")
+            return
+        if msg.get("id") is None:
+            return  # some other notification
+        # A server request. Permissions are owner-side in ag2-assistant; deny anything that arrives here.
+        if method == "session/request_permission":
+            await self.t.send({"jsonrpc": "2.0", "id": msg["id"],
+                               "result": {"outcome": {"outcome": "cancelled"}}})
+            return
+        await self.t.send({"jsonrpc": "2.0", "id": msg["id"],
+                           "error": {"code": -32601, "message": f"unsupported client method {method}"}})
+
+    async def run(self, prompt: str, cwd: str) -> tuple[str, str]:
+        await self.call("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "clientCapabilities": {"fs": {"readTextFile": False, "writeTextFile": False},
+                                   "terminal": False},
+            "clientInfo": {"name": "sutando-cloud-worker", "version": "1"},
+        })
+        session = await self.call("session/new", {"cwd": cwd, "mcpServers": []})
+        sid = session.get("sessionId") or ""
+        resp = await self.call("session/prompt", {
+            "sessionId": sid, "prompt": [{"type": "text", "text": prompt}]})
+        return "".join(self.text).strip(), str(resp.get("stopReason") or "")
+
+
+async def ws_transport():
+    from acp.ws.client import create_websocket_stream  # SDK; needs the [http] extra
+    headers = {"Authorization": f"Bearer {ACP_TOKEN}"} if ACP_TOKEN else {}
+    return await create_websocket_stream(ACP_URL, headers=headers)
+
+
+async def _connect(transport_factory, deadline: float):
+    """Retry the dial until the budget runs out: the sidecar may still be booting."""
+    delay = 1.0
+    while True:
+        try:
+            return await transport_factory()
+        except Exception:  # noqa: BLE001 — connect errors are the retry case
+            if asyncio.get_running_loop().time() + delay >= deadline:
+                raise
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 15.0)
+
+
+async def turn(prompt: str, transport_factory, timeout_s: float) -> str:
+    """The agent's answer, or a short failure text — never an exception."""
+    transport = None
+    try:
+        async def _run():
+            nonlocal transport
+            deadline = asyncio.get_running_loop().time() + timeout_s
+            transport = await _connect(transport_factory, deadline)
+            return await AcpTurn(transport).run(prompt, str(WS))
+        text, stop = await asyncio.wait_for(_run(), timeout_s)
+        return text or f"(ag2-assistant returned no text; stop reason: {stop or 'unknown'})"
+    except asyncio.TimeoutError:
+        return f"ag2-assistant seat: no answer within {timeout_s:.0f}s — the task is not done."
+    except Exception as exc:  # noqa: BLE001 — every failure becomes a visible result
+        return f"ag2-assistant seat: turn failed ({type(exc).__name__}: {exc}) — the task is not done."
+    finally:
+        if transport is not None:
+            try:
+                await transport.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def answer(task: Path, results: Path, transport_factory=ws_transport,
+           timeout_s: float = TURN_TIMEOUT_S) -> str | None:
+    out = results / task.name
+    if out.exists():
+        return None
+    text = asyncio.run(turn(prompt_of(task.read_text(encoding="utf-8")), transport_factory, timeout_s))
+    body = f"{text.rstrip()}\n\n{SIGNATURE}\n"
+    tmp = out.with_name(out.name + f".{os.getpid()}.tmp")
+    tmp.write_text(body, encoding="utf-8")
+    os.replace(tmp, out)
+    return body
+
+
+def main() -> int:
+    tasks, results = WS / "tasks", WS / "results"
+    results.mkdir(parents=True, exist_ok=True)
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    done: set[str] = set()
+    print(f"seat-ag2-assistant: worker={WORKER} acp={ACP_URL} timeout={TURN_TIMEOUT_S:.0f}s "
+          f"watching {tasks}", flush=True)
+    while not _STOP:
+        for task in sorted(tasks.glob("task-*.txt")) if tasks.is_dir() else []:
+            if not PENDING.match(task.name) or task.name in done:
+                continue
+            done.add(task.name)
+            t0 = time.time()
+            body = answer(task, results)
+            if body is not None:
+                print(f"seat-ag2-assistant: answered {task.stem} in {time.time() - t0:.1f}s "
+                      f"({len(body)} chars)", flush=True)
+        time.sleep(SCAN_S)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/cloud-worker/seat-ag2-assistant.py
+++ b/deploy/cloud-worker/seat-ag2-assistant.py
@@ -23,6 +23,11 @@ import sys
 import time
 from pathlib import Path
 
+# The task-protocol owner decides what a pending filename is; a private copy of
+# that rule here is what dropped legal dotted broker ids.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from task_archive import is_pending_task_file  # noqa: E402
+
 WS = Path(os.environ.get("SUTANDO_CLOUD_WORKSPACE") or "/workspace")
 WORKER = os.environ.get("SUTANDO_WORKER_ID") or "cloud"
 ACP_URL = os.environ.get("AG2ASSISTANT_ACP_URL") or "ws://assistant:8802"
@@ -30,7 +35,6 @@ ACP_TOKEN = os.environ.get("AG2ASSISTANT_ACP_TOKEN") or ""
 TURN_TIMEOUT_S = float(os.environ.get("SUTANDO_ACP_TURN_TIMEOUT_S") or "300")
 SCAN_S = float(os.environ.get("SUTANDO_STUB_SCAN_S") or "1.0")
 SIGNATURE = f"— {WORKER} (ag2-assistant)"
-PENDING = re.compile(r"^task-[^.]+\.txt$")
 PROTOCOL_VERSION = 1
 _STOP = False
 
@@ -170,7 +174,7 @@ def main() -> int:
           f"watching {tasks}", flush=True)
     while not _STOP:
         for task in sorted(tasks.glob("task-*.txt")) if tasks.is_dir() else []:
-            if not PENDING.match(task.name) or task.name in done:
+            if not is_pending_task_file(task.name) or task.name in done:
                 continue
             done.add(task.name)
             t0 = time.time()

--- a/deploy/cloud-worker/seat-ag2-assistant.py
+++ b/deploy/cloud-worker/seat-ag2-assistant.py
@@ -6,8 +6,11 @@ answered into `results/task-<id>.txt` — but the answer comes from an AG2
 Assistant sidecar over ACP (JSON-RPC over WebSocket, `acp-serve`): one session
 per task, the task body as the prompt, the agent's message text as the result,
 signed `— <worker id> (ag2-assistant)`. Every turn is bounded by
-SUTANDO_ACP_TURN_TIMEOUT_S; a timeout or a transport failure still writes a
-short failure result, so a task is never silently swallowed.
+SUTANDO_ACP_TURN_TIMEOUT_S. A timeout or a transport failure writes NOTHING:
+the gateway closes the server lease on any delivered result, so a failure text
+would be the user's terminal answer and no other seat could be re-fronted. The
+task stays pending, this seat retries it under backoff, and an unrecovered seat
+lets the lease expire into the stack's documented failover.
 
 The WebSocket transport is the ACP SDK's own (`acp.ws.client`, the package
 ag2-assistant imports); the JSON-RPC turn is driven here over its Transport
@@ -34,6 +37,9 @@ ACP_URL = os.environ.get("AG2ASSISTANT_ACP_URL") or "ws://assistant:8802"
 ACP_TOKEN = os.environ.get("AG2ASSISTANT_ACP_TOKEN") or ""
 TURN_TIMEOUT_S = float(os.environ.get("SUTANDO_ACP_TURN_TIMEOUT_S") or "300")
 SCAN_S = float(os.environ.get("SUTANDO_STUB_SCAN_S") or "1.0")
+# A failed turn leaves the task pending, so the scan would re-attempt it every
+# SCAN_S. Back off per task instead: 2**attempt seconds, capped.
+RETRY_MAX_S = float(os.environ.get("SUTANDO_ACP_RETRY_MAX_S") or "60")
 SIGNATURE = f"— {WORKER} (ag2-assistant)"
 PROTOCOL_VERSION = 1
 _STOP = False
@@ -128,8 +134,12 @@ async def _connect(transport_factory, deadline: float):
             delay = min(delay * 2, 15.0)
 
 
-async def turn(prompt: str, transport_factory, timeout_s: float) -> str:
-    """The agent's answer, or a short failure text — never an exception."""
+async def turn(prompt: str, transport_factory, timeout_s: float) -> str | None:
+    """The agent's answer, or None when the turn failed — never an exception.
+
+    None is not "empty answer": it means nothing may be written to results/,
+    because a written result closes the lease and forecloses failover.
+    """
     transport = None
     try:
         async def _run():
@@ -140,9 +150,13 @@ async def turn(prompt: str, transport_factory, timeout_s: float) -> str:
         text, stop = await asyncio.wait_for(_run(), timeout_s)
         return text or f"(ag2-assistant returned no text; stop reason: {stop or 'unknown'})"
     except asyncio.TimeoutError:
-        return f"ag2-assistant seat: no answer within {timeout_s:.0f}s — the task is not done."
-    except Exception as exc:  # noqa: BLE001 — every failure becomes a visible result
-        return f"ag2-assistant seat: turn failed ({type(exc).__name__}: {exc}) — the task is not done."
+        print(f"seat-ag2-assistant: no answer within {timeout_s:.0f}s — leaving the task pending",
+              file=sys.stderr, flush=True)
+        return None
+    except Exception as exc:  # noqa: BLE001 — a failure must not become an answer
+        print(f"seat-ag2-assistant: turn failed ({type(exc).__name__}: {exc}) — leaving the task pending",
+              file=sys.stderr, flush=True)
+        return None
     finally:
         if transport is not None:
             try:
@@ -157,6 +171,8 @@ def answer(task: Path, results: Path, transport_factory=ws_transport,
     if out.exists():
         return None
     text = asyncio.run(turn(prompt_of(task.read_text(encoding="utf-8")), transport_factory, timeout_s))
+    if text is None:
+        return None            # failed turn: no result file, so the lease can expire
     body = f"{text.rstrip()}\n\n{SIGNATURE}\n"
     tmp = out.with_name(out.name + f".{os.getpid()}.tmp")
     tmp.write_text(body, encoding="utf-8")
@@ -170,18 +186,33 @@ def main() -> int:
     signal.signal(signal.SIGTERM, _stop)
     signal.signal(signal.SIGINT, _stop)
     done: set[str] = set()
+    # `done` records ANSWERED tasks, never attempted ones: marking on attempt
+    # strands a task whose sidecar was briefly down.
+    attempts: dict[str, int] = {}
+    retry_at: dict[str, float] = {}
     print(f"seat-ag2-assistant: worker={WORKER} acp={ACP_URL} timeout={TURN_TIMEOUT_S:.0f}s "
           f"watching {tasks}", flush=True)
     while not _STOP:
         for task in sorted(tasks.glob("task-*.txt")) if tasks.is_dir() else []:
             if not is_pending_task_file(task.name) or task.name in done:
                 continue
-            done.add(task.name)
+            if time.time() < retry_at.get(task.name, 0.0):
+                continue
             t0 = time.time()
             body = answer(task, results)
-            if body is not None:
-                print(f"seat-ag2-assistant: answered {task.stem} in {time.time() - t0:.1f}s "
-                      f"({len(body)} chars)", flush=True)
+            if body is not None or (results / task.name).exists():
+                done.add(task.name)
+                attempts.pop(task.name, None)
+                retry_at.pop(task.name, None)
+                if body is not None:
+                    print(f"seat-ag2-assistant: answered {task.stem} in {time.time() - t0:.1f}s "
+                          f"({len(body)} chars)", flush=True)
+            else:
+                n = attempts[task.name] = attempts.get(task.name, 0) + 1
+                delay = min(2.0 ** n, RETRY_MAX_S)
+                retry_at[task.name] = time.time() + delay
+                print(f"seat-ag2-assistant: {task.stem} still pending after attempt {n}; "
+                      f"retrying in {delay:.0f}s", file=sys.stderr, flush=True)
         time.sleep(SCAN_S)
     return 0
 

--- a/deploy/cloud-worker/seat-ag2-assistant.py
+++ b/deploy/cloud-worker/seat-ag2-assistant.py
@@ -19,6 +19,7 @@ protocol, so a test can plug an in-process transport in.
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import re
 import signal
@@ -180,6 +181,17 @@ def answer(task: Path, results: Path, transport_factory=ws_transport,
     return body
 
 
+def _backoff_delay(n: int) -> float:
+    """2**n seconds capped at RETRY_MAX_S, with the cap applied BEFORE the power.
+
+    Evaluating 2.0 ** n first raises OverflowError at n >= 1024, which exits the
+    seat; the entrypoint treats that exit as fatal and stops the gateway too.
+    """
+    if RETRY_MAX_S <= 0.0:
+        return 0.0
+    return RETRY_MAX_S if n >= math.log2(RETRY_MAX_S) else 2.0 ** n
+
+
 def main() -> int:
     tasks, results = WS / "tasks", WS / "results"
     results.mkdir(parents=True, exist_ok=True)
@@ -209,7 +221,7 @@ def main() -> int:
                           f"({len(body)} chars)", flush=True)
             else:
                 n = attempts[task.name] = attempts.get(task.name, 0) + 1
-                delay = min(2.0 ** n, RETRY_MAX_S)
+                delay = _backoff_delay(n)
                 retry_at[task.name] = time.time() + delay
                 print(f"seat-ag2-assistant: {task.stem} still pending after attempt {n}; "
                       f"retrying in {delay:.0f}s", file=sys.stderr, flush=True)

--- a/deploy/cloud-worker/seat-stub.py
+++ b/deploy/cloud-worker/seat-stub.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Stub seat runtime for a cloud worker container.
+
+Answers every pending `tasks/task-<id>.txt` with `answered by <worker id>` in
+`results/`, the same seat simulation tests/gateway-worker-queue-client.test.py
+drives — so the container round trip is testable without an LLM. Not a seat
+for real work: SUTANDO_WORKER_RUNTIME=claude|adapter is.
+"""
+from __future__ import annotations
+
+import os
+import re
+import signal
+import sys
+import time
+from pathlib import Path
+
+WS = Path(os.environ.get("SUTANDO_CLOUD_WORKSPACE") or "/workspace")
+WORKER = os.environ.get("SUTANDO_WORKER_ID") or "cloud"
+SCAN_S = float(os.environ.get("SUTANDO_STUB_SCAN_S") or "1.0")
+# A pending task only: `.assigned-*`, `.claimed-*` and archived names are someone else's.
+PENDING = re.compile(r"^task-[^.]+\.txt$")
+_STOP = False
+
+
+def _stop(*_a) -> None:
+    global _STOP
+    _STOP = True
+
+
+def answer(task: Path, results: Path) -> bool:
+    out = results / task.name
+    if out.exists():
+        return False
+    tmp = out.with_name(out.name + f".{os.getpid()}.tmp")
+    tmp.write_text(f"answered by {WORKER}\n", encoding="utf-8")
+    os.replace(tmp, out)
+    return True
+
+
+def main() -> int:
+    tasks, results = WS / "tasks", WS / "results"
+    results.mkdir(parents=True, exist_ok=True)
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    done: set[str] = set()
+    print(f"seat-stub: worker={WORKER} watching {tasks}", flush=True)
+    while not _STOP:
+        for task in sorted(tasks.glob("task-*.txt")) if tasks.is_dir() else []:
+            if not PENDING.match(task.name) or task.name in done:
+                continue
+            done.add(task.name)
+            if answer(task, results):
+                print(f"seat-stub: answered {task.stem}", flush=True)
+        time.sleep(SCAN_S)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/cloud-worker/seat-stub.py
+++ b/deploy/cloud-worker/seat-stub.py
@@ -9,17 +9,19 @@ for real work: SUTANDO_WORKER_RUNTIME=claude|adapter is.
 from __future__ import annotations
 
 import os
-import re
 import signal
 import sys
 import time
 from pathlib import Path
 
+# The task-protocol owner decides what a pending filename is; a private copy of
+# that rule here is what dropped legal dotted broker ids.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from task_archive import is_pending_task_file  # noqa: E402
+
 WS = Path(os.environ.get("SUTANDO_CLOUD_WORKSPACE") or "/workspace")
 WORKER = os.environ.get("SUTANDO_WORKER_ID") or "cloud"
 SCAN_S = float(os.environ.get("SUTANDO_STUB_SCAN_S") or "1.0")
-# A pending task only: `.assigned-*`, `.claimed-*` and archived names are someone else's.
-PENDING = re.compile(r"^task-[^.]+\.txt$")
 _STOP = False
 
 
@@ -47,7 +49,7 @@ def main() -> int:
     print(f"seat-stub: worker={WORKER} watching {tasks}", flush=True)
     while not _STOP:
         for task in sorted(tasks.glob("task-*.txt")) if tasks.is_dir() else []:
-            if not PENDING.match(task.name) or task.name in done:
+            if not is_pending_task_file(task.name) or task.name in done:
                 continue
             done.add(task.name)
             if answer(task, results):

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -452,7 +452,7 @@
    ],
    "status": "active",
    "canonical_for": "multi-worker pool design: lead assignment sweep, follower claim protocol, room pins, dedicated workers, crash recovery",
-   "last_verified": "2026-08-30"
+   "last_verified": "2026-09-03"
   },
   "docs/server-and-identity.md": {
    "title": "Sutando Server & the Agent ID card — design",

--- a/docs/lead-follower-pool.md
+++ b/docs/lead-follower-pool.md
@@ -253,6 +253,22 @@ Every result POST names the seat that produced it — `metadata.worker_id` +
 the lead routed); a cloud seat has no done-flag, so its own `SUTANDO_WORKER_ID`
 is the attribution of last resort (`cloud-1` / `cloud`, never an empty payload).
 
+#### Packaging a cloud worker (slice 2 — one container per user)
+
+`deploy/cloud-worker/` packages one cloud seat as a container: the gateway
+client above in cloud mode (`SUTANDO_WORKER_LOCATION=cloud`, `GATEWAY_INSTANCE`
+default `cloud`) plus a seat runtime chosen by `SUTANDO_WORKER_RUNTIME` —
+`stub` (answers every task, the test double), `claude` (the Claude Code CLI
+seat, one subscription login per container on the `/workspace` volume),
+`ag2-assistant` (the backup seat: an AG2 Assistant sidecar on a Gemini key,
+driven over ACP, its own brain and memory) or `adapter` (a
+`/workspace/runtime.sh` hook for the Agent SDK / codex app-server seats that
+do not exist yet). One container = one broker token + one worker
+id; `provision.sh <worker-id> <env-file>` creates it, `deprovision.sh` removes
+it, and the `HEALTHCHECK` reads the client's `state/gateway-status.<instance>.json`.
+Env contract, runtime auth, the at-least-once note and what is not done:
+[`deploy/cloud-worker/README.md`](../deploy/cloud-worker/README.md).
+
 ### Turning on a Codex follower
 
 The runtime dimension (`--runtime` / `--core-runtime`) declares which CLI a core

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -24,6 +24,20 @@ _ID_STATE = re.compile(r"^(task-.+?)\.(?:assigned|claimed)-.+?\.txt$")
 _ID_PLAIN = re.compile(r"^(task-.+?)\.txt(?:\.\d+|\.archive-failed.*)?$")
 
 
+# A pending file is plain: no state suffix, no archive-retry tail. Kept beside
+# the id patterns so a second copy cannot drift from what an id may contain.
+_ID_PENDING = re.compile(r"^task-.+?\.txt$")
+
+
+def is_pending_task_file(name: str) -> bool:
+    """True only for an UNCLAIMED, unarchived `task-<id>.txt`.
+
+    A `[^.]+` id class silently drops legal dotted broker ids (`task-a.b`),
+    leaving that task pending forever while health stays green.
+    """
+    return _ID_STATE.match(name) is None and _ID_PENDING.match(name) is not None
+
+
 def task_id_from_filename(name: str) -> str | None:
     r"""The canonical task id for any name a task file carries, or None.
 

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -24,6 +24,20 @@ _ID_STATE = re.compile(r"^(task-.+?)\.(?:assigned|claimed)-.+?\.txt$")
 _ID_PLAIN = re.compile(r"^(task-.+?)\.txt(?:\.\d+|\.archive-failed.*)?$")
 
 
+# A pending file is plain: no state suffix, no archive-retry tail. Kept beside
+# the id patterns so a second copy cannot drift from what an id may contain.
+_ID_PENDING = re.compile(r"^task-.+?\.txt$")
+
+
+def is_pending_task_file(name: str) -> bool:
+    """True only for an UNCLAIMED, unarchived `task-<id>.txt`.
+
+    A `[^.]+` id class silently drops legal dotted broker ids (`task-a.b`),
+    leaving that task pending forever while health stays green.
+    """
+    return _ID_STATE.match(name) is None and _ID_PENDING.match(name) is not None
+
+
 def task_id_from_filename(name: str) -> str | None:
     r"""The canonical task id for any name a task file carries, or None.
 

--- a/tests/cloud-seat-backoff-survives-long-outage.test.py
+++ b/tests/cloud-seat-backoff-survives-long-outage.test.py
@@ -84,6 +84,27 @@ def run_case(label, target, recover_at):
     return rc, exc, wrote
 
 
+def check_delay_directly():
+    """The equivalence and the edge cases the loop cases cannot reach."""
+    tmp = Path(tempfile.mkdtemp(prefix="seat-delay-"))
+    m = load_seat(tmp)
+
+    bad = []
+    for cap in (0.2, 1.0, 60.0, 3600.0, 1e6):
+        m.RETRY_MAX_S = cap
+        for n in range(1, 1024):
+            if m._backoff_delay(n) != min(2.0 ** n, cap):
+                bad.append((cap, n))
+    check(not bad, f"5 caps x n=1..1023 match min(2.0**n, cap) exactly ({len(bad)} mismatches)")
+
+    m.RETRY_MAX_S = 60.0
+    check(m._backoff_delay(1024) == 60.0, "n=1024 saturates to the cap instead of raising")
+    check(m._backoff_delay(10 ** 6) == 60.0, "n=1e6 saturates to the cap")
+
+    m.RETRY_MAX_S = 0.0
+    check(m._backoff_delay(5) == 0.0, "cap=0 returns 0 rather than a log2 domain error")
+
+
 def main() -> int:
     # 1024 is where 2.0 ** n stops being representable.
     rc, exc, wrote = run_case("long outage", target=1100, recover_at=None)
@@ -95,6 +116,8 @@ def main() -> int:
     check(exc is None, f"recovery past attempt 1024 does not raise (got {type(exc).__name__ if exc else None})")
     check(rc == 0, f"main() returns 0 after recovering (got {rc})")
     check(wrote, "the recovered answer is written")
+
+    check_delay_directly()
 
     print(("FAIL " + str(len(FAILS))) if FAILS else "PASS")
     return 1 if FAILS else 0

--- a/tests/cloud-seat-backoff-survives-long-outage.test.py
+++ b/tests/cloud-seat-backoff-survives-long-outage.test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+r"""A long outage must not crash the seat: the backoff cap is applied BEFORE the power.
+
+`min(2.0 ** n, RETRY_MAX_S)` evaluates the unbounded exponential first, so the
+1024th consecutive failure raises OverflowError and the seat exits. The
+entrypoint treats that exit as fatal and stops the container's gateway, so one
+provider outage long enough to reach ~17h at the default 60s cap takes down
+work unrelated to the failing task.
+
+Both cases drive the module's REAL `main()` loop with a fake clock, never a copy
+of its backoff decision.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SEAT = ROOT / "deploy" / "cloud-worker" / "seat-ag2-assistant.py"
+
+FAILS = []
+
+
+def check(ok, msg):
+    print(("  ok   " if ok else "  FAIL ") + msg)
+    if not ok:
+        FAILS.append(msg)
+
+
+class Clock:
+    """Advances far enough per scan that every retry_at deadline has passed."""
+
+    def __init__(self):
+        self.t = 1_000_000.0
+
+    def time(self):
+        return self.t
+
+    def sleep(self, _s):
+        self.t += 3600.0
+
+
+def load_seat(tmp):
+    (tmp / "tasks").mkdir()
+    (tmp / "tasks" / "task-B1.txt").write_text("id: task-B1\ntask: hello\n")
+    os.environ["SUTANDO_CLOUD_WORKSPACE"] = str(tmp)
+    os.environ["SUTANDO_WORKER_ID"] = "cloud-b"
+    os.environ["SUTANDO_STUB_SCAN_S"] = "0.0"
+    spec = importlib.util.spec_from_file_location(f"seat_backoff_{tmp.name}", SEAT)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    m.time = Clock()
+    m._STOP = False
+    return m
+
+
+def run_case(label, target, recover_at):
+    """Fail `target` times (recovering at `recover_at` if set); return (rc, exc, wrote)."""
+    tmp = Path(tempfile.mkdtemp(prefix="seat-backoff-"))
+    m = load_seat(tmp)
+    calls = []
+
+    def answer(task, results, *a, **k):
+        calls.append(task.name)
+        if recover_at is not None and len(calls) >= recover_at:
+            body = "recovered\n\n— cloud-b (ag2-assistant)\n"
+            results.mkdir(parents=True, exist_ok=True)
+            (results / task.name).write_text(body)
+            m._STOP = True
+            return body
+        if len(calls) >= target:
+            m._STOP = True
+        return None
+
+    m.answer = answer
+    rc, exc = None, None
+    try:
+        rc = m.main()
+    except BaseException as e:  # noqa: BLE001 — the defect IS an escaping exception
+        exc = e
+    wrote = (tmp / "results" / "task-B1.txt").exists()
+    print(f"  [{label}] attempts={len(calls)} rc={rc} exc={type(exc).__name__ if exc else None} results={int(wrote)}")
+    return rc, exc, wrote
+
+
+def main() -> int:
+    # 1024 is where 2.0 ** n stops being representable.
+    rc, exc, wrote = run_case("long outage", target=1100, recover_at=None)
+    check(exc is None, f"1100 consecutive failures do not raise (got {type(exc).__name__ if exc else None})")
+    check(rc == 0, f"main() returns 0 after a long outage (got {rc})")
+    check(not wrote, "a failing turn still writes no result file")
+
+    rc, exc, wrote = run_case("recovery past 1024", target=1200, recover_at=1050)
+    check(exc is None, f"recovery past attempt 1024 does not raise (got {type(exc).__name__ if exc else None})")
+    check(rc == 0, f"main() returns 0 after recovering (got {rc})")
+    check(wrote, "the recovered answer is written")
+
+    print(("FAIL " + str(len(FAILS))) if FAILS else "PASS")
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cloud-seat-dotted-task-ids.test.py
+++ b/tests/cloud-seat-dotted-task-ids.test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+r"""A legal dotted broker id must reach a cloud seat, and a claimed sibling must not.
+
+keweichen's blocker 1 on #3803: both seats carried a private `^task-[^.]+\.txt$`,
+so `_local_tid()`'s `task-cloud~task-a.b.txt` stayed pending forever while gateway
+health remained fresh. The rule now lives once, in the task-protocol owner.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FAILS: list[str] = []
+
+
+def check(ok: bool, msg: str) -> None:
+    print(("  ok  " if ok else "  FAIL ") + msg)
+    if not ok:
+        FAILS.append(msg)
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    owner = _load(ROOT / "src" / "task_archive.py", "ta_owner")
+
+    print("1. the owner's classifier accepts dots and rejects state suffixes")
+    for name, want in [
+        ("task-a.txt", True),
+        ("task-a.b.txt", True),
+        ("task-cloud~task-a.b.txt", True),      # the exact shape _local_tid mints
+        ("task-a.b.claimed-core-2.txt", False),
+        ("task-a.b.assigned-cloud.txt", False),
+        ("task-a.txt.5", False),
+    ]:
+        check(owner.is_pending_task_file(name) is want,
+              f"{name} -> {owner.is_pending_task_file(name)} (want {want})")
+
+    print("2. NEITHER seat keeps a private filename rule (that is the defect)")
+    for seat in ("seat-stub.py", "seat-ag2-assistant.py"):
+        src = (ROOT / "deploy" / "cloud-worker" / seat).read_text()
+        check("[^.]" not in src, f"{seat}: no `[^.]` id class remains")
+        check("is_pending_task_file" in src, f"{seat}: uses the shared classifier")
+
+    print("3. seat-stub's REAL scan loop answers a dotted id and skips claimed/assigned")
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        (ws / "tasks").mkdir()
+        (ws / "results").mkdir()
+        dotted = "task-cloud~task-a.b.txt"
+        (ws / "tasks" / dotted).write_text("task: dotted id\n")
+        (ws / "tasks" / "task-x.b.claimed-core-2.txt").write_text("task: someone else's\n")
+        (ws / "tasks" / "task-y.b.assigned-other.txt").write_text("task: assigned away\n")
+        env = {**os.environ, "SUTANDO_CLOUD_WORKSPACE": str(ws),
+               "SUTANDO_WORKER_ID": "cloud-t", "SUTANDO_STUB_SCAN_S": "0.1"}
+        proc = subprocess.Popen([sys.executable, str(ROOT / "deploy" / "cloud-worker" / "seat-stub.py")],
+                                env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        try:
+            deadline = time.time() + 12
+            while time.time() < deadline:
+                if list((ws / "results").glob("*.txt")):
+                    break
+                time.sleep(0.2)
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        got = sorted(p.name for p in (ws / "results").glob("*.txt"))
+        check(got == ["task-cloud~task-a.b.txt"],
+              f"only the dotted PLAIN task was answered by the real loop: {got}")
+        check(not any("claimed" in n or "assigned" in n for n in got),
+              "no claimed/assigned sibling was consumed")
+
+    print("\n" + (f"FAILED ({len(FAILS)})" if FAILS else "PASS — dotted broker ids reach a cloud seat"))
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cloud-seat-failed-turn-is-retryable.test.py
+++ b/tests/cloud-seat-failed-turn-is-retryable.test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+r"""A failed turn must leave the task retryable by the SAME seat.
+
+The seat's scan loop used to run `done.add(task.name)` BEFORE attempting the
+turn, so `done` recorded attempts rather than answers. Removing the terminal
+failure-result write does not cure that on its own: a task whose sidecar was
+briefly down would stay pending forever on this seat, and a single-seat
+deployment has no other seat to re-front the lease to.
+
+This drives the module's REAL `main()` loop — not a copy of its decision — with
+`answer` failing once and then succeeding.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SEAT = ROOT / "deploy" / "cloud-worker" / "seat-ag2-assistant.py"
+
+FAILS = []
+def check(ok, msg):
+    print(("  ok   " if ok else "  FAIL ") + msg)
+    if not ok:
+        FAILS.append(msg)
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="seat-retry-"))
+    (tmp / "tasks").mkdir()
+    (tmp / "tasks" / "task-R1.txt").write_text("id: task-R1\ntask: hello\n")
+
+    os.environ["SUTANDO_CLOUD_WORKSPACE"] = str(tmp)
+    os.environ["SUTANDO_WORKER_ID"] = "cloud-t"
+    os.environ["SUTANDO_STUB_SCAN_S"] = "0.05"
+    spec = importlib.util.spec_from_file_location("seat_retry", SEAT)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    m.RETRY_MAX_S = 0.2          # keep the backoff inside the test's patience
+
+    calls = []
+
+    def flaky_answer(task, results, *a, **k):
+        calls.append(task.name)
+        if len(calls) == 1:
+            return None          # the sidecar is down: no result file written
+        body = "recovered\n\n— cloud-t (ag2-assistant)\n"
+        (results / task.name).write_text(body)
+        return body
+
+    m.answer = flaky_answer
+    out = tmp / "results" / "task-R1.txt"
+
+    # main() installs SIGTERM/SIGINT handlers, which only works on the main
+    # thread — so the LOOP runs here and the stopper runs on the side.
+    def stopper():
+        deadline = time.time() + 10
+        while time.time() < deadline and not out.exists():
+            time.sleep(0.05)
+        time.sleep(0.1)
+        m._stop()
+
+    t = threading.Thread(target=stopper, daemon=True)
+    t.start()
+    rc = m.main()
+    t.join(timeout=5)
+
+    check(rc == 0, f"main() returned 0 after _stop() (got {rc})")
+    check(len(calls) >= 2,
+          f"the loop re-attempted the task after the failed turn (calls={len(calls)}) "
+          "— exactly 1 is the done-on-attempt defect")
+    check(out.exists(), "the recovered turn wrote results/task-R1.txt")
+    print("\n" + (f"FAILED ({len(FAILS)})" if FAILS else "PASS — a failed turn stays retryable"))
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cloud-worker-compose-copy-template.test.py
+++ b/tests/cloud-worker-compose-copy-template.test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+r"""The COMMENTED copy-me template must render an isolated second user.
+
+`cloud-worker-compose-isolation.test.py` walks `doc["services"]`, so it can only
+ever see the ACTIVE pair — a commented block is invisible to it by construction.
+That leaves the one artifact an operator actually copies untested: the template
+shipped with no `networks:` key rendered a worker on the project default
+network, which is the exact condition that test exists to prevent.
+
+Here the template is uncommented the way an operator would and then parsed.
+"""
+import pathlib
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:                                  # pragma: no cover
+    print("SKIP — pyyaml not available")
+    sys.exit(0)
+
+COMPOSE = pathlib.Path(__file__).resolve().parent.parent / "deploy" / "cloud-worker" / "docker-compose.yml"
+
+# A template line is a commented key for the alice pair, or its indented body.
+# Prose comments carry a single space after `#`, so they are left commented.
+NAME = re.compile(r"^(\s*)#\s((?:worker-|assistant-)?alice[\w-]*:)\s*$")
+BODY = re.compile(r"^(\s*)#(\s{3,}\S.*)$")
+
+FAILS = []
+
+
+def check(ok: bool, msg: str) -> None:
+    print(("  ok   " if ok else "  FAIL ") + msg)
+    if not ok:
+        FAILS.append(msg)
+
+
+def uncomment(raw: str) -> str:
+    out = []
+    for line in raw.split("\n"):
+        m = NAME.match(line) or BODY.match(line)
+        out.append(m.group(1) + m.group(2) if m else line)
+    return "\n".join(out)
+
+
+def main() -> int:
+    raw = COMPOSE.read_text()
+    rendered = uncomment(raw)
+    try:
+        doc = yaml.safe_load(rendered)
+    except yaml.YAMLError as exc:
+        check(False, f"the uncommented template parses as YAML: {exc}")
+        return 1
+
+    svc = doc.get("services") or {}
+    check(set(svc) >= {"worker-example", "assistant-example", "worker-alice", "assistant-alice"},
+          f"uncommenting yields BOTH user pairs: {sorted(svc)}")
+
+    for name in ("worker-alice", "assistant-alice"):
+        nets = (svc.get(name) or {}).get("networks") or []
+        check(bool(nets), f"{name}: declares a network (no key = project default = shared)")
+        check(list(nets) == ["alice"], f"{name}: on its own network, not example's: {nets}")
+
+    ex = set((svc.get("worker-example") or {}).get("networks") or [])
+    al = set((svc.get("worker-alice") or {}).get("networks") or [])
+    check(ex and al and not (ex & al),
+          f"the two users share NO network: example={sorted(ex)} alice={sorted(al)}")
+
+    declared = set((doc.get("networks") or {}).keys())
+    check({"example", "alice"} <= declared, f"both networks are declared top-level: {sorted(declared)}")
+
+    tok_ex = str(((svc.get("assistant-example") or {}).get("environment") or {}).get("AG2ASSISTANT_ACP_TOKEN") or "")
+    tok_al = str(((svc.get("assistant-alice") or {}).get("environment") or {}).get("AG2ASSISTANT_ACP_TOKEN") or "")
+    check(tok_ex and tok_al and tok_ex != tok_al,
+          f"each sidecar reads its OWN token var: {tok_ex!r} vs {tok_al!r}")
+    check(re.fullmatch(r"\$\{AG2ASSISTANT_ACP_TOKEN_[A-Z0-9_]+:?-?\}", tok_al) is not None,
+          f"alice's sidecar token is a per-user var, not the project-global one: {tok_al!r}")
+
+    vols = set((doc.get("volumes") or {}).keys())
+    check({"worker-alice", "assistant-alice-data", "assistant-alice-workspace"} <= vols,
+          f"alice's volumes are declared: {sorted(vols)}")
+
+    print("\n" + (f"FAILED ({len(FAILS)})" if FAILS else "PASS — the copy-me template renders an isolated user"))
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cloud-worker-compose-isolation.test.py
+++ b/tests/cloud-worker-compose-isolation.test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+r"""Per-user cloud workers must not share a network or a sidecar token.
+
+keweichen blocker 4 on #3803: the template advertised "N users = N service
+blocks" while declaring no networks (every service joins the project default,
+so any worker can reach any other user's sidecar) and sourcing every sidecar's
+token from one project-level `${AG2ASSISTANT_ACP_TOKEN}`.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# yaml reaches CI transitively via detect-secrets (its install pulls pyyaml);
+# if this import ever fails, that dependency changed, not this test.
+import yaml
+
+COMPOSE = Path(__file__).resolve().parents[1] / "deploy" / "cloud-worker" / "docker-compose.yml"
+FAILS: list[str] = []
+
+
+def check(ok: bool, msg: str) -> None:
+    print(("  ok  " if ok else "  FAIL ") + msg)
+    if not ok:
+        FAILS.append(msg)
+
+
+def main() -> int:
+    doc = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+    services = doc.get("services") or {}
+    print(f"1. every service declares its own network ({len(services)} services)")
+    check(bool(doc.get("networks")), "the file declares a `networks:` section at all")
+    for name, svc in services.items():
+        nets = svc.get("networks") or []
+        check(bool(nets), f"{name}: declares networks (default project network = shared)")
+
+    print("2. a worker and ITS sidecar share a network; different users do not")
+    worker = services.get("worker-example") or {}
+    sidecar = services.get("assistant-example") or {}
+    check(set(worker.get("networks") or []) == set(sidecar.get("networks") or []),
+          f"the example pair shares one network: {worker.get('networks')} vs {sidecar.get('networks')}")
+    declared = set((doc.get("networks") or {}).keys())
+    check("example" in declared, f"that network is declared: {sorted(declared)}")
+
+    print("3. the sidecar token is PER USER, not project-wide")
+    tok = str(((sidecar.get("environment") or {}).get("AG2ASSISTANT_ACP_TOKEN")) or "")
+    check(tok != "${AG2ASSISTANT_ACP_TOKEN:-}",
+          f"not the shared project-level var: {tok!r}")
+    check(re.fullmatch(r"\$\{AG2ASSISTANT_ACP_TOKEN_[A-Z0-9_]+:?-?\}", tok) is not None,
+          f"it is a per-user var: {tok!r}")
+
+    print("4. the copy-a-user instructions name both per-user things")
+    head = COMPOSE.read_text(encoding="utf-8")
+    check("networks" in head.split("services:")[0],
+          "the header tells an operator to change the network name")
+    check("AG2ASSISTANT_ACP_TOKEN_" in head.split("services:")[0],
+          "the header tells an operator to change the token var")
+
+    print("\n" + (f"FAILED ({len(FAILS)})" if FAILS else "PASS — per-user compose isolation"))
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cloud-worker-container.test.sh
+++ b/tests/cloud-worker-container.test.sh
@@ -90,7 +90,9 @@ run_entry() {  # run_entry <extra env assignments...> ; prints rc, stderr in $ER
       bash "$ENGINE/deploy/cloud-worker/entrypoint.sh" >"$OUT" 2>"$ERR"
   echo $?
 }
-FULL=(REMOTE_TASK_URL=http://broker.invalid REMOTE_TASK_TOKEN=secret SUTANDO_WORKER_ID=cloud-t)
+FULL=(REMOTE_TASK_URL=http://broker.invalid REMOTE_TASK_TOKEN=secret SUTANDO_WORKER_ID=cloud-t
+  # the harness is the legitimate test-double consumer, so it opts in explicitly
+  SUTANDO_WORKER_RUNTIME=stub SUTANDO_ALLOW_STUB_SEAT=1)
 
 rc="$(run_entry)"
 [ "$rc" = 2 ] && grep -q 'missing required env: REMOTE_TASK_URL REMOTE_TASK_TOKEN SUTANDO_WORKER_ID' "$ERR" \
@@ -123,6 +125,25 @@ rc="$(run_entry "${FULL[@]}" FAKE_WS=/elsewhere)"
 [ "$rc" = 3 ] && grep -q "expected '$WS'" "$ERR" && ok "workspace resolving elsewhere → exit 3" || bad "workspace mismatch → exit 3" "rc=$rc $(cat "$ERR")"
 rc="$(run_entry "${FULL[@]}" SUTANDO_WORKER_RUNTIME=bogus)"
 [ "$rc" = 2 ] && grep -q "unknown SUTANDO_WORKER_RUNTIME='bogus'" "$ERR" && ok "unknown runtime → exit 2" || bad "unknown runtime → exit 2" "rc=$rc"
+
+# keweichen blocker 2: the documented quickstart must not be able to answer with
+# the test double. Copy .env.example verbatim, fill only URL+token, and run it.
+ENVF="$(mktemp)"; grep -v '^#' "$REPO/deploy/cloud-worker/.env.example" > "$ENVF" || true
+set -a; . "$ENVF" 2>/dev/null || true; set +a
+grep -qE '^SUTANDO_WORKER_RUNTIME=stub' "$REPO/deploy/cloud-worker/.env.example" \
+  && bad "the shipped example does not select the stub" "it still sets stub" \
+  || ok "the shipped .env.example does not select the stub runtime"
+rc=0; env -i PATH="$PATH" REMOTE_TASK_URL=u REMOTE_TASK_TOKEN=t SUTANDO_WORKER_ID=w \
+  bash "$REPO/deploy/cloud-worker/entrypoint.sh" >/dev/null 2>"$ERR" || rc=$?
+[ "$rc" = 2 ] && grep -q 'SUTANDO_WORKER_RUNTIME is required' "$ERR" \
+  && ok "no runtime selected → exit 2 naming it (fail closed, not stub)" \
+  || bad "unset runtime must fail closed" "rc=$rc $(cat "$ERR")"
+rc=0; env -i PATH="$PATH" REMOTE_TASK_URL=u REMOTE_TASK_TOKEN=t SUTANDO_WORKER_ID=w \
+  SUTANDO_WORKER_RUNTIME=stub bash "$REPO/deploy/cloud-worker/entrypoint.sh" >/dev/null 2>"$ERR" || rc=$?
+[ "$rc" = 2 ] && grep -q 'SUTANDO_ALLOW_STUB_SEAT' "$ERR" \
+  && ok "stub without the explicit opt-in → exit 2 naming the opt-in" \
+  || bad "stub must require an explicit opt-in" "rc=$rc $(cat "$ERR")"
+rm -f "$ENVF"
 rc="$(run_entry "${FULL[@]}" SUTANDO_WORKER_RUNTIME=adapter)"
 [ "$rc" = 4 ] && grep -q 'runtime.sh' "$ERR" && ok "adapter without /workspace/runtime.sh → exit 4 naming the hook" || bad "adapter slot → exit 4" "rc=$rc $(cat "$ERR")"
 rc="$(run_entry "${FULL[@]}" SUTANDO_WORKER_RUNTIME=ag2-assistant)"

--- a/tests/cloud-worker-container.test.sh
+++ b/tests/cloud-worker-container.test.sh
@@ -31,6 +31,7 @@ grep -q 'profiles.json \] || ag2-assistant profiles create backup' "$D/assistant
 ALLOW="sutando.config.json
 packages/ag2-sparrow/ag2_sparrow/
 src/remote-gateway-bridge.py
+src/task_archive.py
 src/workspace_default.py
 src/sutando_config.py
 src/util_paths.py

--- a/tests/cloud-worker-container.test.sh
+++ b/tests/cloud-worker-container.test.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Hermetic checks for deploy/cloud-worker: no docker daemon, no network. Every
+# script is exercised as shipped (a fake python3 stands in for the interpreter).
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+D="$REPO/deploy/cloud-worker"
+fails=0; total=0
+ok()  { total=$((total+1)); printf '  ok   %s\n' "$1"; }
+bad() { total=$((total+1)); fails=$((fails+1)); printf '  FAIL %s %s\n' "$1" "${2:-}"; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/cloud-worker-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "cloud worker container:"
+
+# ── 1. files + syntax ─────────────────────────────────────────────────────
+for f in Dockerfile entrypoint.sh seat-stub.py seat-ag2-assistant.py assistant-bootstrap.sh healthcheck.sh docker-compose.yml .env.example provision.sh deprovision.sh README.md; do
+  [ -f "$D/$f" ] && ok "ships $f" || bad "ships $f" "missing"
+done
+for f in entrypoint.sh healthcheck.sh provision.sh deprovision.sh; do
+  bash -n "$D/$f" 2>/dev/null && ok "bash -n $f" || bad "bash -n $f"
+done
+python3 -m py_compile "$D/seat-stub.py" 2>/dev/null && ok "seat-stub.py compiles" || bad "seat-stub.py compiles"
+python3 -m py_compile "$D/seat-ag2-assistant.py" 2>/dev/null && ok "seat-ag2-assistant.py compiles" || bad "seat-ag2-assistant.py compiles"
+sh -n "$D/assistant-bootstrap.sh" 2>/dev/null && ok "sh -n assistant-bootstrap.sh (POSIX sh: runs inside the sidecar image)" || bad "sh -n assistant-bootstrap.sh"
+grep -q 'profiles.json \] || ag2-assistant profiles create backup' "$D/assistant-bootstrap.sh" && grep -q 'store.set_key(provider' "$D/assistant-bootstrap.sh" \
+  && grep -q 'exec ag2-assistant acp-serve --host 0.0.0.0 --port "${AG2ASSISTANT_ACP_PORT:-8802}" --token "$AG2ASSISTANT_ACP_TOKEN"' "$D/assistant-bootstrap.sh" \
+  && ok "assistant-bootstrap.sh: first-boot profile, key seed into the secret store, then acp-serve with the token" || bad "assistant-bootstrap.sh contents"
+
+# ── 2. Dockerfile copies only the client's import graph ───────────────────
+ALLOW="sutando.config.json
+packages/ag2-sparrow/ag2_sparrow/
+src/remote-gateway-bridge.py
+src/workspace_default.py
+src/sutando_config.py
+src/util_paths.py
+src/proactive_routing.py
+src/task_envelope.py
+src/git_binary.py
+src/result_markers.py
+scripts/sutando-config.sh
+scripts/python-binary.sh
+deploy/cloud-worker/entrypoint.sh
+deploy/cloud-worker/seat-stub.py
+deploy/cloud-worker/seat-ag2-assistant.py
+deploy/cloud-worker/healthcheck.sh"
+copies="$(grep -E '^COPY ' "$D/Dockerfile" | sed -E 's/--[a-z]+=[^ ]+ //g' | awk '{ for (i = 2; i < NF; i++) print $i }')"
+[ -n "$copies" ] && ok "Dockerfile has COPY lines" || bad "Dockerfile has COPY lines" "none parsed"
+while IFS= read -r src; do
+  [ -z "$src" ] && continue
+  if printf '%s\n' "$ALLOW" | grep -qxF "$src"; then
+    [ -e "$REPO/$src" ] && ok "COPY $src is allowlisted and exists" || bad "COPY $src exists in the repo" "missing"
+  else
+    bad "COPY $src is allowlisted" "not in the allowlist — a new import needs the list updated"
+  fi
+done <<< "$copies"
+grep -Eq '^COPY[^\n]* (\.|src|scripts|skills|workspace|packages)/? ' "$D/Dockerfile" \
+  && bad "no wholesale COPY of the repo, src/, scripts/, skills/, workspace/ or packages/" \
+  || ok "no wholesale COPY of the repo, src/, scripts/, skills/, workspace/ or packages/"
+grep -q '^USER sutando' "$D/Dockerfile" && ok "runs as the non-root user sutando" || bad "runs as the non-root user sutando"
+grep -q '^VOLUME \["/workspace"\]' "$D/Dockerfile" && ok "declares the /workspace volume" || bad "declares the /workspace volume"
+grep -q '^HEALTHCHECK' "$D/Dockerfile" && grep -q 'healthcheck.sh' "$D/Dockerfile" \
+  && ok "HEALTHCHECK runs healthcheck.sh" || bad "HEALTHCHECK runs healthcheck.sh"
+grep -q 'entrypoint.sh"\]$' "$D/Dockerfile" && ok "ENTRYPOINT is entrypoint.sh" || bad "ENTRYPOINT is entrypoint.sh"
+
+# ── 3. entrypoint.sh env contract, with a fake python3 ────────────────────
+FAKEBIN="$TMP/bin"; mkdir -p "$FAKEBIN"
+ENGINE="$TMP/engine"; WS="$TMP/ws"
+mkdir -p "$ENGINE/deploy/cloud-worker" "$ENGINE/scripts" "$ENGINE/src"
+cp "$D/entrypoint.sh" "$D/seat-stub.py" "$D/seat-ag2-assistant.py" "$D/healthcheck.sh" "$ENGINE/deploy/cloud-worker/"
+cp "$REPO/scripts/sutando-config.sh" "$REPO/scripts/python-binary.sh" "$ENGINE/scripts/"
+cp "$REPO/src/sutando_config.py" "$ENGINE/src/"
+: > "$ENGINE/src/remote-gateway-bridge.py"
+# The fake interpreter: `-c` answers the resolver with $FAKE_WS; a script run
+# records its env and exits so the entrypoint's child-exit path is reached.
+cat > "$FAKEBIN/python3" <<'PY'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-c" ]; then printf '%s' "${FAKE_WS:-}"; exit 0; fi
+env | sort > "${FAKE_ENV_OUT:-/dev/null}.$$"
+sleep 0.3
+exit 0
+PY
+chmod +x "$FAKEBIN/python3"
+ERR="$TMP/err"; OUT="$TMP/out"
+run_entry() {  # run_entry <extra env assignments...> ; prints rc, stderr in $ERR
+  env -i PATH="$FAKEBIN:/usr/bin:/bin" HOME="$TMP" SUTANDO_PY="$FAKEBIN/python3" \
+      SUTANDO_ENGINE_DIR="$ENGINE" SUTANDO_CLOUD_WORKSPACE="$WS" FAKE_WS="$WS" \
+      FAKE_ENV_OUT="$TMP/child-env" "$@" \
+      bash "$ENGINE/deploy/cloud-worker/entrypoint.sh" >"$OUT" 2>"$ERR"
+  echo $?
+}
+FULL=(REMOTE_TASK_URL=http://broker.invalid REMOTE_TASK_TOKEN=secret SUTANDO_WORKER_ID=cloud-t)
+
+rc="$(run_entry)"
+[ "$rc" = 2 ] && grep -q 'missing required env: REMOTE_TASK_URL REMOTE_TASK_TOKEN SUTANDO_WORKER_ID' "$ERR" \
+  && ok "empty env → exit 2 naming all three required vars" || bad "empty env → exit 2 naming all three" "rc=$rc $(cat "$ERR")"
+for v in REMOTE_TASK_URL REMOTE_TASK_TOKEN SUTANDO_WORKER_ID; do
+  partial=(); for kv in "${FULL[@]}"; do [ "${kv%%=*}" = "$v" ] || partial+=("$kv"); done
+  rc="$(run_entry "${partial[@]}")"
+  [ "$rc" = 2 ] && grep -q "missing required env: $v\$" "$ERR" \
+    && ok "missing $v alone → exit 2 naming exactly it" || bad "missing $v alone → exit 2 naming it" "rc=$rc $(cat "$ERR")"
+done
+
+rm -f "$TMP"/child-env.*
+rc="$(run_entry "${FULL[@]}")"
+[ "$rc" = 5 ] && grep -q 'a child exited' "$ERR" \
+  && ok "all env set, children exit → exit 5 (restart policy relaunches)" || bad "all env set → exit 5" "rc=$rc $(cat "$ERR")"
+grep -q '"path": "'"$WS"'"' "$ENGINE/sutando.config.local.json" 2>/dev/null \
+  && ok "writes sutando.config.local.json pointing at the workspace" || bad "writes sutando.config.local.json" "$(cat "$ENGINE/sutando.config.local.json" 2>/dev/null)"
+[ -d "$WS/tasks" ] && [ -d "$WS/results" ] && [ -d "$WS/state" ] && ok "creates tasks/ results/ state/ on the volume" || bad "creates workspace dirs"
+child_env="$(cat "$TMP"/child-env.* 2>/dev/null)"
+grep -q '^SUTANDO_WORKER_LOCATION=cloud$' <<< "$child_env" && ok "children see SUTANDO_WORKER_LOCATION=cloud" || bad "SUTANDO_WORKER_LOCATION=cloud" "$child_env"
+grep -q '^GATEWAY_INSTANCE=cloud$' <<< "$child_env" && ok "GATEWAY_INSTANCE defaults to cloud" || bad "GATEWAY_INSTANCE defaults to cloud"
+grep -q '^SUTANDO_WORKER_ID=cloud-t$' <<< "$child_env" && ok "children see the worker id" || bad "worker id passed to children"
+grep -q 'seat=cloud-t instance=cloud runtime=stub' "$OUT" && ok "announces seat/instance/runtime on stdout" || bad "announces seat on stdout" "$(cat "$OUT")"
+
+rm -f "$TMP"/child-env.*
+rc="$(run_entry "${FULL[@]}" GATEWAY_INSTANCE=dev)"
+grep -q '^GATEWAY_INSTANCE=dev$' <<< "$(cat "$TMP"/child-env.* 2>/dev/null)" && ok "an explicit GATEWAY_INSTANCE is kept" || bad "explicit GATEWAY_INSTANCE kept"
+
+rc="$(run_entry "${FULL[@]}" FAKE_WS=/elsewhere)"
+[ "$rc" = 3 ] && grep -q "expected '$WS'" "$ERR" && ok "workspace resolving elsewhere → exit 3" || bad "workspace mismatch → exit 3" "rc=$rc $(cat "$ERR")"
+rc="$(run_entry "${FULL[@]}" SUTANDO_WORKER_RUNTIME=bogus)"
+[ "$rc" = 2 ] && grep -q "unknown SUTANDO_WORKER_RUNTIME='bogus'" "$ERR" && ok "unknown runtime → exit 2" || bad "unknown runtime → exit 2" "rc=$rc"
+rc="$(run_entry "${FULL[@]}" SUTANDO_WORKER_RUNTIME=adapter)"
+[ "$rc" = 4 ] && grep -q 'runtime.sh' "$ERR" && ok "adapter without /workspace/runtime.sh → exit 4 naming the hook" || bad "adapter slot → exit 4" "rc=$rc $(cat "$ERR")"
+rc="$(run_entry "${FULL[@]}" SUTANDO_WORKER_RUNTIME=ag2-assistant)"
+[ "$rc" = 2 ] && grep -q 'AG2ASSISTANT_ACP_TOKEN' "$ERR" && ok "ag2-assistant without the sidecar token → exit 2 naming it" || bad "ag2-assistant token gate" "rc=$rc $(cat "$ERR")"
+rm -f "$TMP"/child-env.*
+rc="$(run_entry "${FULL[@]}" SUTANDO_WORKER_RUNTIME=ag2-assistant AG2ASSISTANT_ACP_TOKEN=t)"
+child_env="$(cat "$TMP"/child-env.* 2>/dev/null)"
+[ "$rc" = 5 ] && grep -q '^AG2ASSISTANT_ACP_URL=ws://assistant:8802$' <<< "$child_env" \
+  && ok "ag2-assistant seat launches with AG2ASSISTANT_ACP_URL defaulting to ws://assistant:8802" || bad "ag2-assistant seat launch" "rc=$rc"
+rc="$(run_entry "${FULL[@]}" SUTANDO_WORKER_RUNTIME=claude)"
+[ "$rc" = 4 ] && grep -q 'claude CLI on PATH' "$ERR" && ok "claude without the CLI on PATH → exit 4" || bad "claude without CLI → exit 4" "rc=$rc $(cat "$ERR")"
+
+# ── 4. seat-stub answers a pending task, ignores claimed/assigned names ───
+SWS="$TMP/stub-ws"; mkdir -p "$SWS/tasks" "$SWS/results"
+printf 'id: task-T1\ntask: hi\n' > "$SWS/tasks/task-T1.txt"
+printf 'id: task-T2\ntask: hi\n' > "$SWS/tasks/task-T2.claimed-core-1.txt"
+SUTANDO_CLOUD_WORKSPACE="$SWS" SUTANDO_WORKER_ID=cloud-t SUTANDO_STUB_SCAN_S=0.1 \
+  python3 "$D/seat-stub.py" >"$TMP/stub.out" 2>&1 &
+sp=$!; sleep 1; kill "$sp" 2>/dev/null; wait "$sp" 2>/dev/null
+[ "$(cat "$SWS/results/task-T1.txt" 2>/dev/null)" = "answered by cloud-t" ] \
+  && ok "stub answers task-T1 with 'answered by cloud-t'" || bad "stub answers task-T1" "$(ls "$SWS/results")"
+[ ! -e "$SWS/results/task-T2.claimed-core-1.txt" ] && ok "stub leaves a claimed file alone" || bad "stub leaves a claimed file alone"
+
+# ── 4b. ag2-assistant seat: ACP turn over an in-process transport ──────────
+AWS="$TMP/acp-ws"; mkdir -p "$AWS/tasks" "$AWS/results"
+printf 'id: task-A1\nsource: remote-gateway\ntask: What is 2+2?\nSecond line of the task.\n' > "$AWS/tasks/task-A1.txt"
+printf 'id: task-A2\ntask: never answered\n' > "$AWS/tasks/task-A2.txt"
+SUTANDO_CLOUD_WORKSPACE="$AWS" SUTANDO_WORKER_ID=cloud-t AG2ASSISTANT_ACP_TOKEN=tok python3 - "$D/seat-ag2-assistant.py" "$AWS" > "$TMP/acp.out" 2>&1 <<'PY'
+import asyncio, importlib.util, json, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("seat", sys.argv[1]); m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+ws = Path(sys.argv[2])
+LOG = []
+
+class FakeTransport:
+    """Scripted ACP agent: initialize → session/new → (permission request, two chunks) → end_turn."""
+    def __init__(self): self.q = asyncio.Queue(); self.closed = False
+    async def send(self, msg):
+        LOG.append(msg)
+        m = msg.get("method")
+        if m == "initialize":
+            await self.q.put({"jsonrpc": "2.0", "id": msg["id"], "result": {"protocolVersion": 1, "agentCapabilities": {}, "authMethods": []}})
+        elif m == "session/new":
+            await self.q.put({"jsonrpc": "2.0", "id": msg["id"], "result": {"sessionId": "s1"}})
+        elif m == "session/prompt":
+            self.prompt_id = msg["id"]
+            await self.q.put({"jsonrpc": "2.0", "id": 900, "method": "session/request_permission", "params": {"sessionId": "s1", "options": [{"optionId": "allow", "kind": "allow_once", "name": "Allow"}]}})
+        elif m is None and msg.get("id") == 900:
+            LOG.append(("permission-reply", msg))
+            for t in ("The answer ", "is 4."):
+                await self.q.put({"jsonrpc": "2.0", "method": "session/update", "params": {"sessionId": "s1", "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": t}}}})
+            await self.q.put({"jsonrpc": "2.0", "method": "session/update", "params": {"sessionId": "s1", "update": {"sessionUpdate": "agent_thought_chunk", "content": {"type": "text", "text": "(ignored)"}}}})
+            await self.q.put({"jsonrpc": "2.0", "id": self.prompt_id, "result": {"stopReason": "end_turn"}})
+    async def receive(self): return await self.q.get()
+    async def close(self): self.closed = True
+
+class SilentTransport(FakeTransport):
+    async def send(self, msg): pass  # never answers → the turn must time out
+
+fails = []
+def check(c, msg):
+    print(("  ok   " if c else "  FAIL ") + msg)
+    if not c: fails.append(msg)
+
+t = FakeTransport()
+async def f1(): return t
+body = m.answer(ws / "tasks" / "task-A1.txt", ws / "results", f1, 5)
+res = (ws / "results" / "task-A1.txt").read_text()
+check(res == body and res.startswith("The answer is 4.\n"), f"agent chunks concatenated into results/task-A1.txt: {res.splitlines()[0]!r}")
+check(res.rstrip().endswith("— cloud-t (ag2-assistant)"), "result ends with the signature line from SUTANDO_WORKER_ID")
+methods = [x.get("method") for x in LOG if isinstance(x, dict)]
+check(methods[:3] == ["initialize", "session/new", "session/prompt"], f"turn order initialize → session/new → session/prompt: {methods[:3]}")
+init = LOG[0]["params"]
+check(init["protocolVersion"] == 1 and init["clientCapabilities"]["fs"] == {"readTextFile": False, "writeTextFile": False}, "initialize declares protocol 1 and no fs/terminal capabilities")
+prompt = LOG[2]["params"]
+check(prompt["sessionId"] == "s1" and prompt["prompt"] == [{"type": "text", "text": "What is 2+2?\nSecond line of the task."}], "prompt is the task: value (multi-line body kept) on the new session")
+reply = [x for x in LOG if isinstance(x, tuple)]
+check(reply and reply[0][1]["result"] == {"outcome": {"outcome": "cancelled"}}, "a server permission request is answered 'cancelled' (owner-side approvals only)")
+check(t.closed, "transport closed after the turn")
+check(m.answer(ws / "tasks" / "task-A1.txt", ws / "results", f1, 5) is None, "an already-answered task is not answered twice")
+
+async def f2(): return SilentTransport()
+body = m.answer(ws / "tasks" / "task-A2.txt", ws / "results", f2, 0.5)
+check("no answer within 0s" in body or "no answer within 1s" in body, f"a silent agent → timeout failure result: {body.splitlines()[0]!r}")
+check(body.rstrip().endswith("— cloud-t (ag2-assistant)"), "the failure result is signed too")
+
+async def f3(): raise ConnectionRefusedError("sidecar down")
+body = m.turn("x", f3, 2); body = asyncio.run(body) if asyncio.iscoroutine(body) else body
+check(body.startswith("ag2-assistant seat: turn failed (ConnectionRefusedError"), f"a transport failure → short failure text: {body[:60]!r}")
+check(m.prompt_of("id: x\nsource: s\ntask: hello\nworld\n") == "hello\nworld" and m.prompt_of("no headers") == "no headers", "prompt_of: task: is the last header; headerless text passes through")
+sys.exit(1 if fails else 0)
+PY
+rc=$?
+sed 's/^/  /' "$TMP/acp.out" | grep -E '^\s+(ok|FAIL)' | sed 's/^  //'
+[ "$rc" = 0 ] && ok "ag2-assistant seat: in-process ACP turn suite passed" || bad "ag2-assistant seat: in-process ACP turn suite" "$(grep -vE '^\s+(ok|FAIL)' "$TMP/acp.out" | tail -5)"
+
+# ── 5. provision.sh / deprovision.sh argument gates (before any docker call) ──
+rc=0; out="$(env -i PATH=/usr/bin:/bin bash "$D/provision.sh" cloud-t "$TMP/nope.env" 2>&1)" || rc=$?
+[ "$rc" = 3 ] && grep -q 'env file not readable' <<< "$out" && ok "provision.sh refuses a missing env file (exit 3)" || bad "provision refuses missing env file" "rc=$rc $out"
+rc=0; env -i PATH=/usr/bin:/bin bash "$D/provision.sh" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 2 ] && ok "provision.sh without args → usage (exit 2)" || bad "provision.sh usage exit 2" "rc=$rc"
+rc=0; env -i PATH=/usr/bin:/bin bash "$D/provision.sh" 'bad id!' "$D/.env.example" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 2 ] && ok "provision.sh rejects a bad worker id (exit 2)" || bad "provision.sh bad id exit 2" "rc=$rc"
+grep -q '^WORKER_ID=""; ENV_FILE=""; BUILD=0; BUILD_ONLY=0; TARGET="base"' "$D/provision.sh" \
+  && ok "provision.sh builds the base target by default (claude is opt-in)" || bad "provision.sh default target is base"
+grep -q '^FROM base AS claude' "$D/Dockerfile" && ok "Dockerfile has the opt-in claude stage" || bad "Dockerfile claude stage"
+grep -q "pip install .*'agent-client-protocol\[http\]==" "$D/Dockerfile" && ok "Dockerfile pins the ACP SDK with the websocket extra" || bad "Dockerfile pins the ACP SDK"
+rc=0; env -i PATH=/usr/bin:/bin bash "$D/deprovision.sh" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 2 ] && ok "deprovision.sh without args → usage (exit 2)" || bad "deprovision.sh usage exit 2" "rc=$rc"
+
+# ── 5b. provision/deprovision against a fake docker (real argv, real flow) ──
+# The fake mimics the CLI shapes that matter: `inspect` of a missing name
+# prints a blank line and exits 1; `build` snapshots its context directory.
+FDLOG="$TMP/docker.log"; FDCTX="$TMP/docker-ctx.txt"
+cat > "$FAKEBIN/docker" <<'DK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
+case "$1 ${2:-}" in
+  "info ") exit 0 ;;
+  "image inspect") [ "${FAKE_IMAGE_PRESENT:-0}" = 1 ] ;;
+  "pull "*) exit 1 ;;
+  "build "*) ctx="${@: -1}"; (cd "$ctx" && find . -type f | sort) > "$FAKE_DOCKER_CTX"; exit 0 ;;
+  "container inspect") [ "${3:-}" = "-f" ] && { [ -n "${FAKE_STATE:-}" ] && { echo "$FAKE_STATE"; exit 0; }; echo; exit 1; }; [ -n "${FAKE_STATE:-}" ] ;;
+  "inspect "*) echo "fake docker: untyped inspect is ambiguous (network/volume share the name)" >&2; exit 99 ;;
+  "run "*) echo cid; exit 0 ;;
+  "network inspect") [ "${FAKE_NET:-0}" = 1 ] ;;
+  "start "*|"rm "*|"volume "*|"network "*) exit 0 ;;
+  *) exit 0 ;;
+esac
+DK
+chmod +x "$FAKEBIN/docker"
+run_prov() {  # run_prov <FAKE_STATE> <FAKE_IMAGE_PRESENT> <args...>
+  local st="$1" img="$2"; shift 2
+  : > "$FDLOG"
+  env -i PATH="$FAKEBIN:/usr/bin:/bin" HOME="$TMP" FAKE_DOCKER_LOG="$FDLOG" FAKE_DOCKER_CTX="$FDCTX" \
+      FAKE_STATE="$st" FAKE_IMAGE_PRESENT="$img" bash "$@" >"$OUT" 2>"$ERR"
+  echo $?
+}
+printf 'REMOTE_TASK_URL=http://x\nREMOTE_TASK_TOKEN=t\nSUTANDO_WORKER_ID=from-file\n' > "$TMP/u.env"
+
+rc="$(run_prov "" 1 "$D/provision.sh" cloud-t "$TMP/u.env" -- --add-host h:host-gateway)"
+runline="$(grep '^run ' "$FDLOG")"
+[ "$rc" = 0 ] && [ -n "$runline" ] && ok "absent container → docker run (exit 0)" || bad "absent container → docker run" "rc=$rc $(cat "$ERR") log=$(cat "$FDLOG")"
+grep -q -- '--name sutando-worker-cloud-t ' <<< "$runline" && ok "run: --name sutando-worker-<id>" || bad "run --name" "$runline"
+grep -q -- '--restart unless-stopped' <<< "$runline" && ok "run: --restart unless-stopped" || bad "run --restart" "$runline"
+grep -q -- "--env-file $TMP/u.env -e SUTANDO_WORKER_ID=cloud-t -e SUTANDO_WORKER_LOCATION=cloud" <<< "$runline" \
+  && ok "run: argv worker id is set AFTER --env-file (beats the file's value)" || bad "run: -e after --env-file" "$runline"
+grep -q -- '-v sutando-worker-cloud-t:/workspace' <<< "$runline" && ok "run: per-user volume on /workspace" || bad "run -v" "$runline"
+grep -q -- '--add-host h:host-gateway sutando-cloud-worker:local$' <<< "$runline" && ok "run: extra args after --, image last" || bad "run extra args" "$runline"
+grep -q '^container inspect sutando-worker-cloud-t$' "$FDLOG" && ! grep -q '^inspect ' "$FDLOG" \
+  && ok "existence is asked with a TYPED inspect (a bare inspect also matches the same-named network/volume)" || bad "typed existence check" "$(tr '\n' '|' < "$FDLOG")"
+
+rc="$(run_prov running 1 "$D/provision.sh" cloud-t "$TMP/u.env")"
+[ "$rc" = 0 ] && ! grep -q '^run ' "$FDLOG" && grep -q 'already running' "$OUT" && ok "running container → no-op (exit 0)" || bad "running → no-op" "rc=$rc $(cat "$FDLOG")"
+rc="$(run_prov exited 1 "$D/provision.sh" cloud-t "$TMP/u.env")"
+[ "$rc" = 0 ] && grep -q '^start sutando-worker-cloud-t$' "$FDLOG" && ! grep -q '^run ' "$FDLOG" && ok "exited container → docker start (exit 0)" || bad "exited → start" "rc=$rc $(cat "$FDLOG")"
+
+: > "$FDCTX"
+rc="$(run_prov "" 0 "$D/provision.sh" cloud-t "$TMP/u.env")"
+[ "$rc" = 0 ] && grep -q '^pull sutando-cloud-worker:local$' "$FDLOG" && grep -q -- '^build .* --target base ' "$FDLOG" \
+  && grep -q '^run ' "$FDLOG" && ok "image absent → pull tried, then build of the base target, then run" \
+  || bad "image absent → pull then build then run" "rc=$rc $(tr '\n' '|' < "$FDLOG")"
+ctx_files="$(sed 's|^\./||' "$FDCTX")"
+[ -n "$ctx_files" ] && ok "build context was staged ($(wc -l < "$FDCTX" | tr -d ' ') files)" || bad "build context staged" "empty"
+extra=0
+prefixes="$(printf '%s\n' "$ALLOW" | grep '/$')"
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ "$f" = "deploy/cloud-worker/Dockerfile" ] && continue
+  printf '%s\n' "$ALLOW" | grep -qxF "$f" && continue
+  hit=0; while IFS= read -r pre; do case "$f" in "$pre"*) hit=1 ;; esac; done <<< "$prefixes"
+  [ "$hit" -eq 1 ] && continue
+  extra=$((extra+1)); echo "    unexpected in context: $f"
+done <<< "$ctx_files"
+[ "$extra" -eq 0 ] && ok "build context holds only allowlisted paths + the Dockerfile" || bad "build context minimal" "$extra unexpected"
+grep -q '^workspace/\|^\.env$\|^skills/' <<< "$ctx_files" && bad "build context has no workspace/, .env or skills/" || ok "build context has no workspace/, .env or skills/"
+
+printf 'REMOTE_TASK_URL=http://x\nREMOTE_TASK_TOKEN=t\nSUTANDO_WORKER_RUNTIME=ag2-assistant\nAG2ASSISTANT_ACP_TOKEN=shared\nGEMINI_API_KEY=g\n' > "$TMP/a.env"
+rc="$(run_prov "" 1 "$D/provision.sh" cloud-t "$TMP/a.env")"
+side="$(grep '^run .*sutando-assistant-cloud-t' "$FDLOG")"; work="$(grep '^run .*--name sutando-worker-cloud-t' "$FDLOG")"
+[ "$rc" = 0 ] && grep -q '^network create sutando-worker-cloud-t$' "$FDLOG" && ok "runtime=ag2-assistant in the env file → per-user network created" || bad "sidecar: network create" "rc=$rc $(tr '\n' '|' < "$FDLOG")"
+grep -q -- '--network sutando-worker-cloud-t --network-alias assistant ' <<< "$side" && grep -q -- 'ghcr.io/ag2ai/ag2-assistant:latest /bootstrap.sh' <<< "$side" \
+  && ok "sidecar: official image on the network with alias assistant" || bad "sidecar run" "$side"
+grep -q -- '-v sutando-assistant-cloud-t-data:/data -v sutando-assistant-cloud-t-workspace:/workspace' <<< "$side" && ok "sidecar: /data and /workspace volumes" || bad "sidecar volumes" "$side"
+grep -q -- "-v $D/assistant-bootstrap.sh:/bootstrap.sh:ro --entrypoint sh ghcr.io/ag2ai/ag2-assistant:latest /bootstrap.sh\$" <<< "$side" && ok "sidecar: runs the mounted assistant-bootstrap.sh (profile, key seed, acp-serve)" || bad "sidecar command" "$side"
+! grep -q -- "--env-file $TMP/a.env" <<< "$side" && ok "sidecar: does NOT get the user's env file (no broker token)" || bad "sidecar env-file isolation" "$side"
+grep -q -- '--network sutando-worker-cloud-t -e AG2ASSISTANT_ACP_URL=ws://assistant:8802 ' <<< "$work" && ok "worker: joins the network and dials ws://assistant:8802" || bad "worker network args" "$work"
+printf 'REMOTE_TASK_URL=http://x\nSUTANDO_WORKER_RUNTIME=ag2-assistant\n' > "$TMP/b.env"
+rc="$(run_prov "" 1 "$D/provision.sh" cloud-t "$TMP/b.env")"
+[ "$rc" = 3 ] && grep -q 'AG2ASSISTANT_ACP_TOKEN' "$ERR" && ok "runtime=ag2-assistant without AG2ASSISTANT_ACP_TOKEN → exit 3" || bad "sidecar token gate" "rc=$rc $(cat "$ERR")"
+
+rc="$(run_prov "" 1 "$D/deprovision.sh" cloud-t)"
+[ "$rc" = 0 ] && ! grep -q '^rm ' "$FDLOG" && grep -q 'already absent' "$OUT" && ok "deprovision absent → exit 0, no rm" || bad "deprovision absent" "rc=$rc $(cat "$FDLOG")"
+rc="$(run_prov running 1 "$D/deprovision.sh" cloud-t --purge)"
+[ "$rc" = 0 ] && grep -q '^rm -f sutando-worker-cloud-t$' "$FDLOG" && grep -q '^rm -f sutando-assistant-cloud-t$' "$FDLOG" \
+  && grep -q '^volume rm sutando-worker-cloud-t$' "$FDLOG" && grep -q '^volume rm sutando-assistant-cloud-t-data$' "$FDLOG" \
+  && ok "deprovision --purge → rm -f worker + sidecar, volume rm for all three" || bad "deprovision purge" "rc=$rc $(tr '\n' '|' < "$FDLOG")"
+
+# ── 6. compose + env example ──────────────────────────────────────────────
+if python3 -c 'import yaml' 2>/dev/null; then
+  python3 - "$D/docker-compose.yml" <<'PY' && ok "docker-compose.yml parses: worker + ag2-assistant sidecar templates, volumes, restart" || bad "docker-compose.yml structure"
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+svcs = d["services"]; assert len(svcs) >= 1
+for name, s in svcs.items():
+    assert any(str(v).endswith(":/workspace") for v in s["volumes"]), name
+    assert s.get("restart"), name
+    if name.startswith("worker-"):
+        assert s.get("env_file") and s["environment"]["SUTANDO_WORKER_ID"], name
+        assert s["environment"]["AG2ASSISTANT_ACP_URL"].startswith("ws://assistant-"), name
+    if name.startswith("assistant-"):
+        assert any(str(v).endswith(":/data") for v in s["volumes"]), name
+        assert s["entrypoint"] == ["sh", "/bootstrap.sh"], name
+        assert "./assistant-bootstrap.sh:/bootstrap.sh:ro" in s["volumes"], name
+        assert "GEMINI_API_KEY" in s["environment"] and "env_file" not in s, name
+assert {n[:6] for n in svcs} == {"worker", "assist"}, "one worker + one sidecar template"
+named = {v.split(":")[0] for s in svcs.values() for v in s["volumes"] if not str(v).startswith((".", "/"))}
+assert set(d["volumes"]) >= named, (set(d["volumes"]), named)
+PY
+else
+  grep -q '^services:' "$D/docker-compose.yml" && grep -q ':/workspace$' "$D/docker-compose.yml" \
+    && grep -q 'restart:' "$D/docker-compose.yml" && ok "docker-compose.yml (structural grep; pyyaml absent)" || bad "docker-compose.yml structural"
+fi
+for k in REMOTE_TASK_URL REMOTE_TASK_TOKEN SUTANDO_WORKER_ID AG2ASSISTANT_ACP_TOKEN GEMINI_API_KEY; do
+  grep -qx "$k=" "$D/.env.example" && ok ".env.example lists $k with no value" || bad ".env.example lists $k with no value"
+done
+grep -Eq '^[A-Z_]+=.*#' "$D/.env.example" && bad ".env.example has no inline comments (docker --env-file keeps them as value)" \
+  || ok ".env.example has no inline comments"
+
+# ── 7. healthcheck.sh: fresh / stale / absent ─────────────────────────────
+HWS="$TMP/hc"; mkdir -p "$HWS/state"
+rc=0; SUTANDO_CLOUD_WORKSPACE="$HWS" bash "$D/healthcheck.sh" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 1 ] && ok "healthcheck: no status file → unhealthy" || bad "healthcheck absent" "rc=$rc"
+echo '{}' > "$HWS/state/gateway-status.cloud.json"
+rc=0; SUTANDO_CLOUD_WORKSPACE="$HWS" bash "$D/healthcheck.sh" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 0 ] && ok "healthcheck: fresh status file → healthy" || bad "healthcheck fresh" "rc=$rc"
+touch -t 202001010000 "$HWS/state/gateway-status.cloud.json"
+rc=0; SUTANDO_CLOUD_WORKSPACE="$HWS" bash "$D/healthcheck.sh" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 1 ] && ok "healthcheck: status older than 3 minutes → unhealthy" || bad "healthcheck stale" "rc=$rc"
+echo '{}' > "$HWS/state/gateway-status.dev.json"
+rc=0; SUTANDO_CLOUD_WORKSPACE="$HWS" GATEWAY_INSTANCE=dev bash "$D/healthcheck.sh" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 0 ] && ok "healthcheck: honours GATEWAY_INSTANCE in the file name" || bad "healthcheck instance" "rc=$rc"
+
+echo "  Total: $total — pass: $((total-fails)), fail: $fails"
+[ "$fails" -eq 0 ]

--- a/tests/cloud-worker-container.test.sh
+++ b/tests/cloud-worker-container.test.sh
@@ -227,12 +227,21 @@ check(m.answer(ws / "tasks" / "task-A1.txt", ws / "results", f1, 5) is None, "an
 
 async def f2(): return SilentTransport()
 body = m.answer(ws / "tasks" / "task-A2.txt", ws / "results", f2, 0.5)
-check("no answer within 0s" in body or "no answer within 1s" in body, f"a silent agent → timeout failure result: {body.splitlines()[0]!r}")
-check(body.rstrip().endswith("— cloud-t (ag2-assistant)"), "the failure result is signed too")
+# A delivered result closes the server lease, so a failure text would be the
+# user's terminal answer and no other seat could be re-fronted. Write nothing.
+check(body is None, f"a silent agent → no body returned, not failure prose: {body!r}")
+check(not (ws / "results" / "task-A2.txt").exists(), "a timed-out turn leaves NO results/ file, so the lease can expire")
 
 async def f3(): raise ConnectionRefusedError("sidecar down")
 body = m.turn("x", f3, 2); body = asyncio.run(body) if asyncio.iscoroutine(body) else body
-check(body.startswith("ag2-assistant seat: turn failed (ConnectionRefusedError"), f"a transport failure → short failure text: {body[:60]!r}")
+check(body is None, f"a transport failure → None, not a deliverable answer: {body!r}")
+
+# The recovery half: a task that failed must still be answerable, which is what
+# `done`-on-attempt broke — the seat marked it done before the turn was tried.
+async def f4(): return FakeTransport()   # a FRESH transport: the sidecar is back
+body = m.answer(ws / "tasks" / "task-A2.txt", ws / "results", f4, 5)
+check(body is not None and (ws / "results" / "task-A2.txt").exists(),
+      "after a failed turn the SAME task is answered once the sidecar returns")
 check(m.prompt_of("id: x\nsource: s\ntask: hello\nworld\n") == "hello\nworld" and m.prompt_of("no headers") == "no headers", "prompt_of: task: is the last header; headerless text passes through")
 sys.exit(1 if fails else 0)
 PY


### PR DESCRIPTION
## 


A **cloud worker** is one more seat of a user's *existing* agent on a cloud host — same broker token, same MXID. It is not a second agent. This PR packages that seat so one container can be provisioned per user, and ships the "B" backup seat (AG2 Assistant on a key we hold) as a working runtime.

Stacked on **#3796** (`feat/pool-worker-queue-client`, the client half: worker id on the wire + cloud mode). Base is `feat/pool-worker-queue-client`. Merge order: **#3604 → #3788 → #3796 → this**. Design: issue #3794. Broker half: ag2space-backend #945.

## Deliverables

`deploy/cloud-worker/` — the container, and the two scripts that create and destroy one:

| file | role |
|---|---|
| `Dockerfile` | `base` target (default): `python:3.12-slim`, non-root `sutando`, allowlisted `COPY`s only, `HEALTHCHECK`, `ENTRYPOINT`. `claude` target adds the Claude Code CLI via its native installer (no node). |
| `entrypoint.sh` | validates env, writes `sutando.config.local.json` at the volume, starts the gateway client + the seat runtime, exits when either dies (restart policy relaunches). |
| `seat-stub.py` | `stub` runtime — answers every task `answered by <worker id>`. The test double. |
| `seat-ag2-assistant.py` | `ag2-assistant` runtime — one ACP session per task against the sidecar, result signed `— <worker id> (ag2-assistant)`. |
| `assistant-bootstrap.sh` | runs *inside* the sidecar: first-boot profile, provider-key seed into its secret store, then `acp-serve`. |
| `healthcheck.sh` | healthy while `state/gateway-status.<instance>.json` is younger than 3 minutes. |
| `provision.sh` / `deprovision.sh` | idempotent, one container (+ optional sidecar, per-user network, own keys only) per user from a per-user env file. |
| `docker-compose.yml`, `.env.example`, `README.md` | compose template, the env contract (keys, no values), and the operator doc. |

Plus `docs/lead-follower-pool.md` → "Packaging a cloud worker (slice 2)", `docs/catalog.json` re-verify date, and `tests/cloud-worker-container.test.sh`.

The image carries **only the client's import graph** — the `ag2-sparrow` package, the loader shim, the seven `src/` modules the client imports, and the workspace resolver's shell wrapper. No workspace, no skills, no secrets are baked in; `/workspace` is a volume. `provision.sh` stages a scratch build context of exactly the `COPY` sources, so the working tree never reaches the docker daemon (asserted by the tests: *"build context holds only allowlisted paths + the Dockerfile"*, *"build context has no workspace/, .env or skills/"*).

## Env contract (names only — `.env.example` ships no values)

**Required** — `entrypoint.sh` exits 2 naming every missing key:
`REMOTE_TASK_URL`, `REMOTE_TASK_TOKEN`, `SUTANDO_WORKER_ID`

**Set by the entrypoint:** `SUTANDO_WORKER_LOCATION=cloud` (always), `GATEWAY_INSTANCE` (default `cloud`), `SUTANDO_SUPERVISED=1`

**Optional:** `SUTANDO_WORKER_RUNTIME`, `REMOTE_TASK_POLL_WAIT`, `AGENT_MXID`, `CLAUDE_CONFIG_DIR`

**`ag2-assistant` runtime adds:** `AG2ASSISTANT_ACP_TOKEN` (required), `GEMINI_API_KEY` (sidecar only — the worker never reads it), `AG2ASSISTANT_ACP_URL`, `SUTANDO_ACP_TURN_TIMEOUT_S`

## The four seat runtimes and what each needs

Credential order as the owner set it: the user's **subscription** first, then the user's **own API key**, then **our key** as the backup.

| `SUTANDO_WORKER_RUNTIME` | what runs | credential |
|---|---|---|
| `claude` | the Claude Code CLI seat, launched the way `pool-core-wrapper.sh` launches a follower (no tmux — the container is the session) | **Claude subscription**, one OAuth **device login per container**, stored under `CLAUDE_CONFIG_DIR` on the volume. Nothing is copied from a Mac. |
| `adapter` | `bash /workspace/runtime.sh` if executable, else exit 4 | the **user's own API key** — the slot for the Agent SDK / codex app-server seats |
| `ag2-assistant` | the **backup seat**: `ghcr.io/ag2ai/ag2-assistant` as a per-user sidecar (`acp-serve` on 8802), one ACP session per task | **our Gemini key** on the sidecar + a shared `AG2ASSISTANT_ACP_TOKEN`. No login. |
| `stub` (default) | `seat-stub.py` | none — it is the test double |

The sidecar is deliberately a *different brain* (its own memory, tools and profile, none of Sutando's skills): the cheap always-on seat that answers when the user's own seats are down. It never receives the broker token — `provision.sh` forwards only its own keys onto a per-user network.

One measured detail worth flagging for review: `acp-serve` gates every session on the sidecar's **secret store**, not on process env — its `serve_ws(...)` passes no `env`, so the `env_var` auth method it advertises cannot be satisfied by `GEMINI_API_KEY` alone (`session/new → Authentication required` with the key in env; `authMethods: []` and a session id after the seed). Hence `assistant-bootstrap.sh` seeds the key with `SecretStore.set_key` (idempotent) before `exec`ing `acp-serve`.

## Evidence

### Tests — `bash tests/cloud-worker-container.test.sh`, 102/102, rc 0

Hermetic: no docker daemon, no network. Every script is exercised as shipped (a fake `python3` and a fake `docker` stand in). It covers the COPY allowlist, each required-env refusal, the workspace-config write, the seat env, the four runtime gates, the stub responder, a full ACP turn over an in-process transport (chunk concatenation, signature, permission-request handling, timeout, dead sidecar), `provision`/`deprovision` argv under a fake docker (typed inspect, staged context, sidecar, network), the compose file, and the healthcheck's fresh/stale/absent cases.

<details><summary>full test output (102 checks)</summary>

```
cloud worker container:
  ok   ships Dockerfile
  ok   ships entrypoint.sh
  ok   ships seat-stub.py
  ok   ships seat-ag2-assistant.py
  ok   ships assistant-bootstrap.sh
  ok   ships healthcheck.sh
  ok   ships docker-compose.yml
  ok   ships .env.example
  ok   ships provision.sh
  ok   ships deprovision.sh
  ok   ships README.md
  ok   bash -n entrypoint.sh
  ok   bash -n healthcheck.sh
  ok   bash -n provision.sh
  ok   bash -n deprovision.sh
  ok   seat-stub.py compiles
  ok   seat-ag2-assistant.py compiles
  ok   sh -n assistant-bootstrap.sh (POSIX sh: runs inside the sidecar image)
  ok   assistant-bootstrap.sh: first-boot profile, key seed into the secret store, then acp-serve with the token
  ok   Dockerfile has COPY lines
  ok   COPY sutando.config.json is allowlisted and exists
  ok   COPY packages/ag2-sparrow/ag2_sparrow/ is allowlisted and exists
  ok   COPY src/remote-gateway-bridge.py is allowlisted and exists
  ok   COPY src/workspace_default.py is allowlisted and exists
  ok   COPY src/sutando_config.py is allowlisted and exists
  ok   COPY src/util_paths.py is allowlisted and exists
  ok   COPY src/proactive_routing.py is allowlisted and exists
  ok   COPY src/task_envelope.py is allowlisted and exists
  ok   COPY src/git_binary.py is allowlisted and exists
  ok   COPY src/result_markers.py is allowlisted and exists
  ok   COPY scripts/sutando-config.sh is allowlisted and exists
  ok   COPY scripts/python-binary.sh is allowlisted and exists
  ok   COPY deploy/cloud-worker/entrypoint.sh is allowlisted and exists
  ok   COPY deploy/cloud-worker/seat-stub.py is allowlisted and exists
  ok   COPY deploy/cloud-worker/seat-ag2-assistant.py is allowlisted and exists
  ok   COPY deploy/cloud-worker/healthcheck.sh is allowlisted and exists
  ok   no wholesale COPY of the repo, src/, scripts/, skills/, workspace/ or packages/
  ok   runs as the non-root user sutando
  ok   declares the /workspace volume
  ok   HEALTHCHECK runs healthcheck.sh
  ok   ENTRYPOINT is entrypoint.sh
  ok   empty env → exit 2 naming all three required vars
  ok   missing REMOTE_TASK_URL alone → exit 2 naming exactly it
  ok   missing REMOTE_TASK_TOKEN alone → exit 2 naming exactly it
  ok   missing SUTANDO_WORKER_ID alone → exit 2 naming exactly it
  ok   all env set, children exit → exit 5 (restart policy relaunches)
  ok   writes sutando.config.local.json pointing at the workspace
  ok   creates tasks/ results/ state/ on the volume
  ok   children see SUTANDO_WORKER_LOCATION=cloud
  ok   GATEWAY_INSTANCE defaults to cloud
  ok   children see the worker id
  ok   announces seat/instance/runtime on stdout
  ok   an explicit GATEWAY_INSTANCE is kept
  ok   workspace resolving elsewhere → exit 3
  ok   unknown runtime → exit 2
  ok   adapter without /workspace/runtime.sh → exit 4 naming the hook
  ok   ag2-assistant without the sidecar token → exit 2 naming it
  ok   ag2-assistant seat launches with AG2ASSISTANT_ACP_URL defaulting to ws://assistant:8802
  ok   claude without the CLI on PATH → exit 4
  ok   stub answers task-T1 with 'answered by cloud-t'
  ok   stub leaves a claimed file alone
  ok   agent chunks concatenated into results/task-A1.txt: 'The answer is 4.'
  ok   result ends with the signature line from SUTANDO_WORKER_ID
  ok   turn order initialize → session/new → session/prompt: ['initialize', 'session/new', 'session/prompt']
  ok   initialize declares protocol 1 and no fs/terminal capabilities
  ok   prompt is the task: value (multi-line body kept) on the new session
  ok   a server permission request is answered 'cancelled' (owner-side approvals only)
  ok   transport closed after the turn
  ok   an already-answered task is not answered twice
  ok   a silent agent → timeout failure result: 'ag2-assistant seat: no answer within 0s — the task is not done.'
  ok   the failure result is signed too
  ok   a transport failure → short failure text: 'ag2-assistant seat: turn failed (ConnectionRefusedError: sid'
  ok   prompt_of: task: is the last header; headerless text passes through
  ok   ag2-assistant seat: in-process ACP turn suite passed
  ok   provision.sh refuses a missing env file (exit 3)
  ok   provision.sh without args → usage (exit 2)
  ok   provision.sh rejects a bad worker id (exit 2)
  ok   provision.sh builds the base target by default (claude is opt-in)
  ok   Dockerfile has the opt-in claude stage
  ok   Dockerfile pins the ACP SDK with the websocket extra
  ok   deprovision.sh without args → usage (exit 2)
  ok   absent container → docker run (exit 0)
  ok   run: --name sutando-worker-<id>
  ok   run: --restart unless-stopped
  ok   run: argv worker id is set AFTER --env-file (beats the file's value)
  ok   run: per-user volume on /workspace
  ok   run: extra args after --, image last
  ok   existence is asked with a TYPED inspect (a bare inspect also matches the same-named network/volume)
  ok   running container → no-op (exit 0)
  ok   exited container → docker start (exit 0)
  ok   image absent → pull tried, then build of the base target, then run
  ok   build context was staged (50 files)
  ok   build context holds only allowlisted paths + the Dockerfile
  ok   build context has no workspace/, .env or skills/
  ok   runtime=ag2-assistant in the env file → per-user network created
  ok   sidecar: official image on the network with alias assistant
  ok   sidecar: /data and /workspace volumes
  ok   sidecar: runs the mounted assistant-bootstrap.sh (profile, key seed, acp-serve)
  ok   sidecar: does NOT get the user's env file (no broker token)
  ok   worker: joins the network and dials ws://assistant:8802
  ok   runtime=ag2-assistant without AG2ASSISTANT_ACP_TOKEN → exit 3
  ok   deprovision absent → exit 0, no rm
  ok   deprovision --purge → rm -f worker + sidecar, volume rm for all three
  ok   docker-compose.yml parses: worker + ag2-assistant sidecar templates, volumes, restart
  ok   .env.example lists REMOTE_TASK_URL with no value
  ok   .env.example lists REMOTE_TASK_TOKEN with no value
  ok   .env.example lists SUTANDO_WORKER_ID with no value
  ok   .env.example lists AG2ASSISTANT_ACP_TOKEN with no value
  ok   .env.example lists GEMINI_API_KEY with no value
  ok   .env.example has no inline comments
  ok   healthcheck: no status file → unhealthy
  ok   healthcheck: fresh status file → healthy
  ok   healthcheck: status older than 3 minutes → unhealthy
  ok   healthcheck: honours GATEWAY_INSTANCE in the file name
  Total: 102 — pass: 102, fail: 0
# exit rc=0
```
</details>

### Repo gate — `scripts/review-checks.sh` on the cumulative diff, rc 0

```
$ git diff origin/feat/pool-worker-queue-client...HEAD > cloud-worker.diff
$ bash scripts/review-checks.sh --diff cloud-worker.diff; echo "GATE_RC=$?"
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
GATE_RC=0
```

The prose-cap scanner only reads `.py`, so the comment runs in the shell / Dockerfile / compose additions were counted by hand over the full branch diff: every run longer than 2 is a **file-header usage banner** (`provision.sh` 9, `deprovision.sh` 5, `docker-compose.yml` 10, `.env.example` 3 — the last being the env contract itself), matching the existing repo baseline for shell headers (`scripts/core-status.sh` 15, `src/watch-tasks-stream.sh` 18, `scripts/review-checks.sh` 19). Excluding headers, the **maximum mid-file comment run is 2** in every added shell file and the Dockerfile.

Diff also scanned by hand for hardcoded host paths and credential values: no `/Users/`, `/private/tmp`, `/home/…` or `~/` on any added line, and every `*_KEY=`/`*_TOKEN=` hit is a test placeholder (`secret`, `tok`, `t`, `g`, `shared`) or a doc placeholder (`<random>`, `<ours>`) — no real value.

`shellcheck` is **not installed on this host**, so the added shell was not lint-checked beyond the suite's `bash -n` / `sh -n` parses (which pass for all five scripts).

### Docker — the two images, and a live stub run

Both images the build session produced are still on the host:

```
$ docker images | grep sutando-cloud-worker
sutando-cloud-worker   local    66fcada8a812   169MB
sutando-cloud-worker   claude   198b6c6b9665   384MB
```

**Verified in this session (first-hand):** a real `provision.sh` → task → result → health round trip on the `stub` runtime, against a deliberately unreachable broker (`http://broker.invalid`, throwaway token) to show the seat and the healthcheck are independent of broker reachability:

```
$ bash deploy/cloud-worker/provision.sh cloud-verify verify.env
provision: image sutando-cloud-worker:local present
provision: created sutando-worker-cloud-verify (volume sutando-worker-cloud-verify, image sutando-cloud-worker:local)
provision: /sutando-worker-cloud-verify state=running health=starting

$ docker logs sutando-worker-cloud-verify
cloud-worker: seat=cloud-verify instance=cloud runtime=stub workspace=/workspace
seat-stub: worker=cloud-verify watching /workspace/tasks
[remote-gateway-bridge] singleton: acquired workspace poller lock (acquired)
[remote-gateway-bridge] starting — gateway=http://broker.invalid provider=remote tasks=/workspace/tasks (restored 0 in-flight)
[remote-gateway-bridge] launched_via=supervised status=/workspace/state/gateway-status.cloud.json
[remote-gateway-bridge] outbound worker started (scan 1.0s + wake-on-kick) — outbound no longer rides the inbound long-poll
[remote-gateway-bridge] heartbeat network error: <urlopen error [Errno -2] Name or service not known> — continuing
[remote-gateway-bridge] poll network error: <urlopen error [Errno -2] Name or service not known> — backing off 1s

$ docker exec … 'printf "id: task-verify-1\n…\ntask: what seat answered this?\n" > /workspace/tasks/task-verify-1.txt'
$ docker exec … cat /workspace/results/task-verify-1.txt
answered by cloud-verify

$ docker inspect -f '{{.State.Health.Status}}' sutando-worker-cloud-verify
healthy                                    # after ~50s (45s start period)

$ bash deploy/cloud-worker/deprovision.sh cloud-verify --purge
deprovision: removed sutando-worker-cloud-verify
deprovision: sutando-assistant-cloud-verify already absent
deprovision: removed volume sutando-worker-cloud-verify
deprovision: volume sutando-assistant-cloud-verify-data already absent
deprovision: volume sutando-assistant-cloud-verify-workspace already absent
```

That also exercises `provision.sh` and `deprovision.sh` against a **real** docker daemon, not the suite's fake, and confirms the documented health semantics: healthy while the status file is fresh, *connected or not* (`"connected": false, "error": "network: …", "backoff_s": 32` in `state/gateway-status.cloud.json` at the moment it reported healthy).

**Reported by the build session, not re-verified here** — the session that wrote this commit ran both live paths and died before pushing; its transcript is not recoverable, so these are attributed, not re-captured:

- **stub:** task → `answered by cloud-1`, healthcheck healthy.
- **ag2-assistant sidecar on Gemini:** `2 plus 2 equals 4. — cloud-2 (ag2-assistant)` in 24.4 s.

I re-ran the stub path myself (above) and it reproduces. I did **not** re-run the Gemini path — the ag2-assistant runtime's live behaviour in this PR rests on the build session's report plus the in-process ACP turn suite, and a reviewer wanting an independent live check needs a Gemini key and `docker pull ghcr.io/ag2ai/ag2-assistant`.

## Not done in this slice

- **no image registry publishing** — `provision.sh` builds locally; `docker pull` is tried only if `SUTANDO_CLOUD_WORKER_IMAGE` names an already-pushed tag;
- **no cloud IaC** — no Terraform / Fly / ECS definitions; compose + the two scripts only;
- **no login automation** for the `claude` runtime — per-container device login, by hand, documented in the README (`claude setup-token` / `CLAUDE_CODE_OAUTH_TOKEN` is the non-interactive alternative);
- **no provisioner endpoint** — turning "one user signs up" into "one container exists" is **slice 3**; this slice is the artifact and the scripts a provisioner would call;
- no skill set in the image for the `claude` runtime beyond the task loop (it runs from `/workspace/engine` if a full checkout is on the volume);
- the Agent SDK / codex app-server adapters — `adapter` is the slot, not an implementation;
- the ag2-assistant sidecar is `:latest` (no digest pin) and its `acp-serve` is marked experimental upstream; its memory/tools are not wired to Sutando's;
- no workspace sync into the container — the seat's memory is the broker's room history (#3794 §5a) until the sync lane covers cloud hosts.

— sutando-qingyun-001 (worker-1)
