### PR TITLE
fix(chunking): the line that closes a fence was charged the closer reserve

### DIFF
--- a/src/message_chunking.py
+++ b/src/message_chunking.py
@@ -152,8 +152,13 @@ def chunk_message(text: str, max_len: int = 1900):
         # treat as closing (we don't require exact length match for close).
 
         line_overhead = len(line) + 1  # +1 for newline
+        # The line that CLOSES the fence needs no reserve: after it the fence is
+        # shut, so charging for a synthetic closer splits a body that already fits.
+        closes_here = (fence_opener is not None and opener_on_line is not None
+                       and _closes_fence(opener_on_line, fence_opener))
         # Reserve space for closing fence if we'd cut mid-fence
-        reserve = (len(fence_closer(fence_opener)) + 1) if fence_opener else 0
+        reserve = 0 if closes_here else (
+            (len(fence_closer(fence_opener)) + 1) if fence_opener else 0)
 
         if buf_len + line_overhead + reserve > max_len and buf:
             # Outside a fence, prefer the last blank line in the lookback

--- a/tests/message-chunking.test.py
+++ b/tests/message-chunking.test.py
@@ -73,6 +73,18 @@ fenced_small = "before\n```python\nprint('hi')\n```\nafter"
 check("small fenced block → single unchanged chunk",
       list(chunk_message(fenced_small, 1900)) == [fenced_small])
 
+# 3b. The line that CLOSES a fence must not be charged the closer reserve:
+# a whole-body fence that fits was split into itself plus a content-free tail.
+for _L in (1896, 1897, 1899):
+    _over = len("```\n") + len("\n```")
+    _body = "```\n" + "z" * (_L - _over) + "\n```"
+    _out = list(chunk_message(_body, 1900))
+    check(f"closing fence charges no reserve (len {_L})",
+          _out == [_body], f"got {len(_out)} chunks, lens {[len(c) for c in _out]}")
+    check(f"no content-free tail chunk (len {_L})",
+          all(c.replace("`", "").strip() for c in _out),
+          f"a chunk is only fence markers: {[c for c in _out if not c.replace('`','').strip()]}")
+
 # 4. Inline backticks / info-string-in-prose do NOT toggle fence state → no spurious close.
 inline = 'talk about `print("```")` and ```js inline usage without a real block'
 out_inline = list(chunk_message(inline, 1900))


### PR DESCRIPTION
## The bug

`chunk_message` reserves room for a synthetic closing fence whenever it is inside one, and charges that reserve against **every** line — including the line that closes the fence, after which no closer is needed.

So a whole-body fenced message that **already fits** was split into itself plus a content-free tail:

```
body = "```\n" + "z"*1891 + "\n```"        # 1899 chars, max_len 1900

parent   2 chunks, lens [1899, 7]      chunk 0 IS the entire input
                                        chunk 1 is '```\n```'
HEAD     1 chunk,  lens [1899]
```

Strip the fence markers off that tail and it is the empty string. It is nonetheless a real second Discord message, it burns one of the four delivery chunks, and it trips the compose-side gate in `_chunk_for_discord` — whose log line then reads like an off-by-one. **That gate's wording is #3802; this is the reason it fires at all.**

## Scope

One shared chunker. `discord-bridge.py`, `dm-result.py` and `slack-bridge.py` all delegate to `message_chunking.chunk_message` and none carries a copy, so the three-line change covers every outbound surface.

## Evidence

Six new cases, **source fix reverted, tests kept**:

```
parent  FAIL closing fence charges no reserve (len 1896) — got 2 chunks, lens [1896, 7]
        FAIL no content-free tail chunk (len 1896) — a chunk is only fence markers
        ... the same pair at 1897 and 1899 — 6 failures

HEAD    PASS — message_chunking golden tests
```

Siblings at HEAD, all `rc=0`: `discord-chunker`, `bridge-timeout-guards`, `slack-proactive-release-on-send-failure`. `scripts/review-checks.sh --diff` PASS (its prose-cap refused my first commit at 3 comment lines; the pre-push hook is why there is no over-cap comment in this diff).

The second assertion is deliberately separate from the first: `== [body]` pins the count, and the fence-stripping check pins *why* the extra chunk was wrong. A future change that splits into two non-empty chunks should fail the first and pass the second, which is a different report than the bug this fixes.

## Scope boundary (added after review — @yixuan-ag2)

`telegram-bridge.py:60` imports `chunk_plain_text`, **not** `chunk_message`, so Telegram does not inherit this. That is correct — a plain-transport surface has no fences to reserve for — but "one shared chunker" plus a bridge count of three could read as four to someone checking. Three inherit; Telegram is a different function.

## NOT fixed here

Two distinct defects remain in the same function. Named rather than left for a reader to discover, since this PR's title could be read as covering them.

**1. A genuine split still emits content-free fence chunks.** A 1900-char whole-body fence yields `lens [7, 1900, 7]` — an empty fence on each side.

**2. `chunk_message` can exceed its own `max_len`, and this diff does not change that.** The docstring promises "chunks <= max_len chars". Searched six fenced shapes across lengths 1700–2099, at base and at this branch — **identical results**, so it is neither introduced nor fixed here:

```
shape                        first over-cap        max overshoot
unclosed fence, no prefix    L=1897 -> [7, 1901]        +4
unclosed fence, a\n\n prefix  L=1900 -> [10, 1901]       +4
unclosed ```python           L=1897 -> [13, 1901]      +10
closed whole-body            L=1901 -> [7, 1901, 7]     +4
```

~~The overshoot tracks the opener length, which points at the reopen path.~~ **That mechanism was falsified by @yixuan-ag2** — varying only the opener leaves the over-cap chunk at 1901 for all four openers; the real law is a bounded window, `overshoot = L - 1896` over exactly ten values, self-correcting at 1907. Either way it is not the reserve this PR touches. **Filed as #3806** — with the caller that makes it more than a contract violation: `slack-bridge.py:1486` passes **4000**, Slack's real limit, where nothing absorbs a 4010-char chunk. Harmless against Discord's 2000-char hard cap at the default 1900; a caller passing `max_len` equal to a real hard limit would have a send rejected. Found by Echo Act IV Blue on a different fixture; confirmed here by search rather than by trading examples, since our two fixtures disagreed on the numbers.

## Provenance

Found while tracing why a peer's gate log read `(1900 chars > 1900)`. Echo Act IV Blue reported that line and refuted two explanations for it — including one of mine — before this turned up underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



