### PR TITLE
docs(proactive-loop): the idle-held pipeline commits at hash time too

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -390,11 +390,23 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    is why prose cannot fix it.
 
    ```bash
+   # 1. COMPUTE — no --write and no --commit, so nothing is persisted and nothing is
+   #    stamped. `idle-held.py` prints the resulting list before it consults --write.
+   python3 skills/proactive-loop/scripts/idle-held.py --state "$WORKSPACE/state/idle-streak.json" \
+       --remove <id> --reason "<why>" --add <id>:<gate> \
+     | python3 skills/proactive-loop/scripts/idle-surface-hash.py \
+         --state "$WORKSPACE/state/idle-streak.json"
+   # -> post <hash>   (changed set: surface it)   |   quiet <hash>  (unchanged)
+
+   # 2. Post the message. THEN persist the ops and stamp the set as surfaced:
    python3 skills/proactive-loop/scripts/idle-held.py --state "$WORKSPACE/state/idle-streak.json" \
        --remove <id> --reason "<why>" --add <id>:<gate> --write \
      | python3 skills/proactive-loop/scripts/idle-surface-hash.py \
          --state "$WORKSPACE/state/idle-streak.json" --commit
    ```
+
+   Both runs read the same unmutated state, so they print the same list and hash identically;
+   deferring `--write` too means a declined send leaves neither the stamp nor the ops behind.
 
    It reads `held_item_ids` from the state file and applies explicit ops; **there is no interface
    that accepts a whole list**, so a recall-built set cannot be expressed. A `--remove` of an id the


### PR DESCRIPTION
Follow-up to #3712, which I offered there and nobody declined: *"happy to open a follow-up making :393-396 two-step too."* #3712 merged at 11:54Z without it, so the inconsistency is now live on `main`.

## The defect

#3712 made the plain surface-hash call two-step, and added the paragraph that says why:

> ⚠ **Two steps, because `--commit` stamps at HASH time, not at SEND time.** The single-call form is correct only when the send is unconditional — and it is not…

That paragraph sits at **line 422** of `main`'s `SKILL.md`. A single-call form sits at **line 396**, twenty-six lines earlier:

```bash
python3 …/idle-held.py --state … --remove <id> --reason "<why>" --add <id>:<gate> --write \
  | python3 …/idle-surface-hash.py --state … --commit
```

So the file argues against a form it still shows, in the same section. Whichever a reader copies is the one they hit first.

## Why the fix is not just symmetry with the block above — and why deferring `--write` is safe

The naive worry is that a two-step split double-applies `--remove/--add`, because this pipeline carries `--write`. It does not, and the reason is a specific ordering in `idle-held.py`:

```python
299:    print(json.dumps(after, separators=(",", ":")))     # stdout, unconditional
...
308:    if a.write:                                          # persist, AFTER the print
```

The list is printed **before** `--write` is consulted. So a run without `--write` computes and prints the same list while persisting nothing.

**Measured on `main`'s `idle-held.py`** (temp state, `held_item_ids` as `[id, gate]` pairs):

```
before sha1 fe4bd7b475e4

WITHOUT --write   rc=0
  stdout  [["3166","owner"],["3274","owner"],["9999","ci"]]
  stderr  held 2 -> 3  +1  (not written; pass --write)
  after sha1 fe4bd7b475e4     UNCHANGED

WITH --write      rc=0
  stdout  [["3166","owner"],["3274","owner"],["9999","ci"]]    <- identical
  stderr  held 2 -> 3  +1
  after sha1 13c301a73db6     PERSISTED
```

Both claims the fix rests on: **identical stdout** (so step 1 and step 2 hash the same set) and **no mutation without `--write`** (so the compute step is free).

That makes deferring `--write` strictly better than only deferring `--commit`: a send you then decline leaves **neither** the stamp nor the ops behind. The block above can only defer the stamp.

## Diff

`skills/proactive-loop/SKILL.md`, +12/-0, docs only. No script changes, no behavior change to any tool.

## Honest limits

I did **not** run `tests/idle-held.test.py` or any suite — this is a docs-only change with no code path. My before/after evidence is the `idle-held.py` invocation above, run against `main`'s copy of the script in a scratch directory, not against a checkout of this branch (the branch does not touch the script). And **my first attempt at that evidence was worthless**: I used `"id:gate"` strings instead of `[id, gate]` pairs, both runs bailed `rc=2` before reaching the write path, and "state UNCHANGED" was true for the wrong reason. The numbers above are the corrected run.

CONTRIBUTOR account — advisory; needs maintainers.
