### PR TITLE
fix(health-check): results/held-no-consumer/ is watched by no probe

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -27,6 +27,7 @@ import json
 import os
 import re
 import shlex
+import stat
 import statistics
 import shutil
 import tempfile
@@ -7475,12 +7476,15 @@ def check_held_no_consumer(threshold_age_sec: int = 3600) -> dict:
         # Per-file isolation, same reason as check_orphaned_results: one
         # unreadable entry must not decide the answer for the directory.
         try:
-            if not path.is_file():
-                continue
-            age = int(now - path.stat().st_mtime)
+            # stat FIRST: is_file() swallows EACCES and returns False, so an
+            # unreadable entry would `continue` instead of counting as partial.
+            st = path.stat()
         except OSError:
             unreadable += 1
             continue
+        if not stat.S_ISREG(st.st_mode):
+            continue
+        age = int(now - st.st_mtime)
         if any(tok in path.name for tok in disposed_tokens):
             disposed += 1
             continue

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -7447,6 +7447,19 @@ def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300,
             "detail": f"{len(files)} task(s){held_note}{pool_note}, oldest {oldest_age}s"}
 
 
+def _held_age(seconds: int) -> str:
+    """Render an age at the granularity it actually has.
+
+    The threshold is in seconds, so storing days would print `(0d)` for
+    everything under a day and tie the sort at zero.
+    """
+    if seconds >= 86400:
+        return f"{seconds // 86400}d"
+    if seconds >= 3600:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 60}m"
+
+
 def check_held_no_consumer(threshold_age_sec: int = 3600) -> dict:
     """Results parked in results/held-no-consumer/ because no transport claimed them.
 
@@ -7490,7 +7503,7 @@ def check_held_no_consumer(threshold_age_sec: int = 3600) -> dict:
             continue
         if age < threshold_age_sec:
             continue
-        held.append((path.name, age // 86400))
+        held.append((path.name, age))
 
     if unreadable and not held:
         return {"name": name, "status": "warn",
@@ -7502,13 +7515,13 @@ def check_held_no_consumer(threshold_age_sec: int = 3600) -> dict:
         return {"name": name, "status": "ok", "detail": detail}
 
     held.sort(key=lambda t: -t[1])
-    shown = ", ".join(f"{n} ({d}d)" for n, d in held[:5])
+    shown = ", ".join(f"{n} ({_held_age(a)})" for n, a in held[:5])
     more = f" +{len(held) - 5} more" if len(held) > 5 else ""
     extra = f"; {disposed} excluded by disposition suffix" if disposed else ""
     if unreadable:
         extra += f"; {unreadable} unreadable, so this count is a floor"
     return {"name": name, "status": "warn",
-            "detail": (f"{len(held)} result(s) parked with no consumer, oldest {held[0][1]}d: "
+            "detail": (f"{len(held)} result(s) parked with no consumer, oldest {_held_age(held[0][1])}: "
                        f"{shown}{more}{extra} — these were addressed and never delivered")}
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -7446,6 +7446,68 @@ def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300,
             "detail": f"{len(files)} task(s){held_note}{pool_note}, oldest {oldest_age}s"}
 
 
+def check_held_no_consumer(threshold_age_sec: int = 3600) -> dict:
+    """Results parked in results/held-no-consumer/ because no transport claimed them.
+
+    The sibling probes glob `results/` and `results/.outbox*`; this directory
+    matches neither, so three of them reported clean while a 3-part digest sat
+    here for ten days. A container nothing globs is a container nothing watches.
+    """
+    name = "held-no-consumer"
+    held_dir = WORKSPACE_DIR / "results" / "held-no-consumer"
+    if not held_dir.exists():
+        return {"name": name, "status": "ok",
+                "detail": "results/held-no-consumer/ not created — no writer has parked here"}
+    now = time.time()
+    try:
+        entries = list(held_dir.iterdir())
+    except OSError as e:  # noqa: BLE001 — a probe failure must not fail the check
+        return {"name": name, "status": "warn",
+                "detail": f"could not scan results/held-no-consumer/: {e}"}
+
+    # Substring, not equality: disposition stamps carry dates, so an
+    # exact-match exclusion rescans them as live and reports them held.
+    disposed_tokens = (".withdrawn", ".superseded", ".archived")
+    held: list[tuple[str, int]] = []
+    disposed = 0
+    unreadable = 0
+    for path in entries:
+        # Per-file isolation, same reason as check_orphaned_results: one
+        # unreadable entry must not decide the answer for the directory.
+        try:
+            if not path.is_file():
+                continue
+            age = int(now - path.stat().st_mtime)
+        except OSError:
+            unreadable += 1
+            continue
+        if any(tok in path.name for tok in disposed_tokens):
+            disposed += 1
+            continue
+        if age < threshold_age_sec:
+            continue
+        held.append((path.name, age // 86400))
+
+    if unreadable and not held:
+        return {"name": name, "status": "warn",
+                "detail": f"{unreadable} entr(ies) unreadable — coverage is partial, not clean"}
+    if not held:
+        detail = "no undisposed held results"
+        if disposed:
+            detail += f"; {disposed} carry a disposition suffix and are excluded by it"
+        return {"name": name, "status": "ok", "detail": detail}
+
+    held.sort(key=lambda t: -t[1])
+    shown = ", ".join(f"{n} ({d}d)" for n, d in held[:5])
+    more = f" +{len(held) - 5} more" if len(held) > 5 else ""
+    extra = f"; {disposed} excluded by disposition suffix" if disposed else ""
+    if unreadable:
+        extra += f"; {unreadable} unreadable, so this count is a floor"
+    return {"name": name, "status": "warn",
+            "detail": (f"{len(held)} result(s) parked with no consumer, oldest {held[0][1]}d: "
+                       f"{shown}{more}{extra} — these were addressed and never delivered")}
+
+
 def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
     """Detect results that no consumer will ever claim.
 
@@ -10700,6 +10762,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_core_supervisor())
     checks.append(check_task_queue(threshold_count=queue_count, threshold_age_sec=queue_age_sec))
     checks.append(check_orphaned_results())
+    checks.append(check_held_no_consumer())
     checks.append(check_proactive_quarantine())
     checks.append(check_stranded_destined_proactive())
     checks.append(check_stale_proactive_backlog())

--- a/tests/health-check-held-no-consumer.test.py
+++ b/tests/health-check-held-no-consumer.test.py
@@ -93,9 +93,31 @@ check("live-shape", _probe(_live_shape), "warn",
 # Something parked seconds ago is in flight, not stranded.
 check("under-threshold", _probe(_fresh), "ok", ("no undisposed",))
 
+# A file the probe cannot stat is partial coverage, never a clean pass. This is
+# the branch a later simplification is most likely to fold into `ok`.
+def _unreadable(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    _touch(held / "parked.no-push-transport.txt")
+    # Readable but not executable: iterdir lists the name, stat on the child
+    # raises EACCES. Root ignores mode bits, so skip rather than assert there.
+    held.chmod(0o400)
+
+
+if os.geteuid() != 0:
+    _root = Path(tempfile.mkdtemp())
+    (_root / "results").mkdir()
+    _unreadable(_root / "results")
+    hc.WORKSPACE_DIR = _root
+    _res = hc.check_held_no_consumer()
+    (_root / "results" / "held-no-consumer").chmod(0o700)
+    check("unreadable", _res, "warn", ("coverage is partial, not clean",))
+else:
+    print("note: running as root — unreadable arm skipped, mode bits do not apply")
+
 if FAILURES:
     print("FAIL")
     for line in FAILURES:
         print(" ", line)
     sys.exit(1)
-print("PASS: 6 controls, both directions")
+print("PASS: 7 controls, both directions")

--- a/tests/health-check-held-no-consumer.test.py
+++ b/tests/health-check-held-no-consumer.test.py
@@ -133,9 +133,68 @@ if "(0d)" in _sub["detail"]:
 if _sub["detail"].index("nearly-a-day") > _sub["detail"].index("just-over"):
     FAILURES.append("sub-day-render: ordered by filesystem, not by age")
 
+
+# qingyun-wu's four uncovered branches (diff coverage 90.2% at e06b34d2), each a fixture that
+# reaches exactly one line; the mixed unreadable+held case is the one no earlier arm could produce.
+def _unlistable(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    _touch(held / "parked.no-push-transport.txt")
+    held.chmod(0o000)          # exists, not listable: iterdir() itself raises
+
+
+if os.geteuid() != 0:
+    _r2 = Path(tempfile.mkdtemp())
+    (_r2 / "results").mkdir()
+    _unlistable(_r2 / "results")
+    hc.WORKSPACE_DIR = _r2
+    _res2 = hc.check_held_no_consumer()
+    (_r2 / "results" / "held-no-consumer").chmod(0o700)
+    check("unlistable-dir", _res2, "warn", ("could not scan results/held-no-consumer/",))
+else:
+    print("note: running as root — unlistable arm skipped, mode bits do not apply")
+
+
+def _nested_dir(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    (held / "nested").mkdir()                       # not S_ISREG -> skipped, never counted
+    _touch(held / "parked.no-push-transport.txt")
+
+
+_nested = _probe(_nested_dir)
+check("nested-dir-skipped", _nested, "warn", ("parked.no-push-transport.txt",))
+if "nested" in _nested["detail"]:
+    FAILURES.append(f"nested-dir-skipped: a directory was counted as a held result: {_nested['detail']!r}")
+
+
+def _mixed(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    _touch(held / "parked.no-push-transport.txt")
+    (held / "gone.no-push-transport.txt").symlink_to(held / "missing")   # stat() raises on the link only
+
+
+check("unreadable-beside-held", _probe(_mixed), "warn",
+      ("parked.no-push-transport.txt", "1 unreadable, so this count is a floor"))
+
+
+def _minutes(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    _touch(held / "young.no-push-transport.txt", time.time() - 300)
+
+
+_r3 = Path(tempfile.mkdtemp())
+(_r3 / "results").mkdir()
+_minutes(_r3 / "results")
+hc.WORKSPACE_DIR = _r3
+check("minutes-render-at-lowered-threshold", hc.check_held_no_consumer(threshold_age_sec=60),
+      "warn", ("young.no-push-transport.txt (5m)",))
+
 if FAILURES:
     print("FAIL")
     for line in FAILURES:
         print(" ", line)
     sys.exit(1)
-print("PASS: 8 controls, both directions")
+print("PASS: 12 controls, both directions")

--- a/tests/health-check-held-no-consumer.test.py
+++ b/tests/health-check-held-no-consumer.test.py
@@ -115,9 +115,27 @@ if os.geteuid() != 0:
 else:
     print("note: running as root — unreadable arm skipped, mode bits do not apply")
 
+# With days in the tuple these three all score 0, so each prints "(0d)" and the
+# "oldest" is whatever iterdir yielded first.
+def _sub_day(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    now = time.time()
+    _touch(held / "just-over.no-push-transport.txt", now - 3601)
+    _touch(held / "middle.no-push-transport.txt", now - 40000)
+    _touch(held / "nearly-a-day.no-push-transport.txt", now - 86399)
+
+
+_sub = _probe(_sub_day)
+check("sub-day-render", _sub, "warn", ("oldest 23h", "just-over.no-push-transport.txt (1h)"))
+if "(0d)" in _sub["detail"]:
+    FAILURES.append(f"sub-day-render: days-granularity leaked into {_sub['detail']!r}")
+if _sub["detail"].index("nearly-a-day") > _sub["detail"].index("just-over"):
+    FAILURES.append("sub-day-render: ordered by filesystem, not by age")
+
 if FAILURES:
     print("FAIL")
     for line in FAILURES:
         print(" ", line)
     sys.exit(1)
-print("PASS: 7 controls, both directions")
+print("PASS: 8 controls, both directions")

--- a/tests/health-check-held-no-consumer.test.py
+++ b/tests/health-check-held-no-consumer.test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""`results/held-no-consumer/` must be watched, and its exclusion must be a prefix test.
+
+The sibling probes glob `results/` and `results/.outbox*`; this directory matches
+neither, so all three report ok while addressed results sit undelivered. The
+exclusion is a substring test because disposition stamps carry dates — an
+exact-match on `superseded` rescans `.superseded-2026-08-26-...` as a live entry
+and reports every one of them as held.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+OLD = time.time() - 10 * 86400
+FAILURES = []
+
+
+def _probe(build):
+    root = Path(tempfile.mkdtemp())
+    (root / "results").mkdir()
+    build(root / "results")
+    hc.WORKSPACE_DIR = root
+    return hc.check_held_no_consumer()
+
+
+def _touch(path, when=OLD):
+    path.write_text("x")
+    os.utime(path, (when, when))
+
+
+def check(label, result, want_status, want_fragments=()):
+    if result["status"] != want_status:
+        FAILURES.append(f"{label}: status {result['status']!r} != {want_status!r}")
+        return
+    for fragment in want_fragments:
+        if fragment not in result["detail"]:
+            FAILURES.append(f"{label}: {fragment!r} missing from {result['detail']!r}")
+
+
+def _empty(results):
+    (results / "held-no-consumer").mkdir()
+
+
+def _only_disposed(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    _touch(held / "proactive-1.withdrawn-wrong-transport.txt")
+
+
+def _dated_disposition(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    _touch(held / "reply.superseded-2026-08-26-by-full-reply.txt")
+
+
+def _live_shape(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    for part in (1, 2, 3):
+        _touch(held / f"pr-digest-part{part}.no-push-transport.txt")
+    _touch(held / "proactive-9.withdrawn-wrong-transport.txt")
+
+
+def _fresh(results):
+    held = results / "held-no-consumer"
+    held.mkdir()
+    _touch(held / "just-parked.no-push-transport.txt", time.time() - 60)
+
+
+# A directory that no writer has created yet is not a finding.
+check("absent", _probe(lambda results: None), "ok", ("not created",))
+check("empty", _probe(_empty), "ok", ("no undisposed",))
+
+# A disposition suffix records a decision; it is excluded, and SAID to be.
+check("only-disposed", _probe(_only_disposed), "ok", ("1 carry a disposition suffix",))
+check("dated-disposition", _probe(_dated_disposition), "ok", ("1 carry a disposition suffix",))
+
+# The shape measured live: three held parts beside one withdrawn file.
+check("live-shape", _probe(_live_shape), "warn",
+      ("3 result(s) parked", "1 excluded by disposition suffix", "never delivered"))
+
+# Something parked seconds ago is in flight, not stranded.
+check("under-threshold", _probe(_fresh), "ok", ("no undisposed",))
+
+if FAILURES:
+    print("FAIL")
+    for line in FAILURES:
+        print(" ", line)
+    sys.exit(1)
+print("PASS: 6 controls, both directions")


### PR DESCRIPTION
## What

Adds a `held-no-consumer` probe. `orphaned-results`, `stale-proactive-backlog` and `stranded-destined-proactive` glob `results/` and `results/.outbox*`; `results/held-no-consumer/` matches neither, so all three report `ok` while addressed results sit there undelivered.

## Evidence

**BEFORE** — at the parent commit (`2f9095d1`), the probe does not exist and the three siblings are green on a host that has held files:

```
$ git show origin/main:src/health-check.py | grep -c 'held-no-consumer'
0
$ python3 src/health-check.py          # same host, same moment
  ✓ orphaned-results             ok    no undeliverable results
  ✓ stale-proactive-backlog      ok    no undelivered proactive bodies
  ✓ stranded-destined-proactive  ok    no aged destined proactive files awaiting a claim
```

**AFTER** — at this branch head, against that same live workspace:

```
warn: 3 result(s) parked with no consumer, oldest 9d: pr-digest-part1.no-push-transport.txt (9d),
pr-digest-part3.no-push-transport.txt (9d), pr-digest-part2.no-push-transport.txt (9d);
1 excluded by disposition suffix — these were addressed and never delivered
```

Those three are a PR digest carrying a `[channel:]` marker — addressed and never delivered.

## Controls, both directions

A checker never observed failing is not a validated checker:

```
dir ABSENT                                ok
dir EMPTY                                 ok
only a .withdrawn file                    ok    ...1 excluded by disposition suffix
3 held + 1 withdrawn (the LIVE shape)     warn  3 result(s)... 1 excluded
DATED disposition suffix                  ok    ...1 excluded by disposition suffix
held but only 60s old (under threshold)   ok
```

## Why the exclusion is a substring test

Disposition stamps carry dates (`.superseded-2026-08-26-by-full-reply.txt`). An exact-match exclusion on `superseded` rescans every dated variant as a live lane and reports each as held — a large, confident false positive that appears only on hosts that use dated stamps. That case is the fifth control above.

## Scope

One probe, one registration line. `unreadable` entries are counted per-file and reported as a floor rather than folded into a clean pass, matching `check_orphaned_results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)