### PR TITLE
fix(tests): slack-proactive test must not finalize with a live daemon writer

### DIFF
--- a/tests/slack-proactive-release-on-send-failure.test.py
+++ b/tests/slack-proactive-release-on-send-failure.test.py
@@ -213,4 +213,9 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    rc = main()
+    # The bridge's result_watcher runs as a daemon thread with no stop condition;
+    # interpreter finalization racing one of its stdout writes aborts the process.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(rc)


### PR DESCRIPTION
Closes #3800.

## What

`tests/slack-proactive-release-on-send-failure.test.py` ends with `raise SystemExit(main())` while
the `bridge.result_watcher` daemon thread it started at line 139 is still alive and still writing to
stdout. Flush explicitly and leave via `os._exit(rc)` so interpreter finalization never runs with a
live daemon writer.

+6/-1, one file, tests only.

## Why this is the shape of the fix, and not the other one

There is nothing a test can join on. Measured at `origin/main` (`6b9813b4e`):

```
$ git show origin/main:tests/slack-proactive-release-on-send-failure.test.py | wc -l
     216
$ git show origin/main:tests/... | grep -nE "join\(|stop|_STOP|is_alive|SystemExit|sys.exit"
216:    raise SystemExit(main())
```

One match in 216 lines — the exit itself. The thread's target has no exit condition and the bridge
has no stop flag:

```
$ # result_watcher, src/slack-bridge.py @ origin/main
result_watcher: lines 1643-1781, 139 lines
  1647: while True:
  1680: print(f"  Skipped (marker): {task_id}", flush=True)
  ... 9 more print(..., flush=True) in the body
$ git show origin/main:src/slack-bridge.py | grep -nE "^_?[A-Z_]*STOP|^_?[a-z_]*_stop|shutdown_event|threading\.Event\(\)"
$ echo $?
1        # genuine no-match; the same grep returns 0 on a known-present pattern
```

So the alternative — give `result_watcher` a shutdown `Event` — means changing a long-lived path on a
live bridge for a test's benefit. Probably worth having for clean bridge shutdown in its own right;
out of scope here.

## Before / after

**Before, at the parent commit (`6b9813b4e` = `origin/main`)** — the thread is alive by construction
when finalization begins:

```
$ python3 probe.py     # loads the real test file in place, calls main(), enumerates threads
PASS: a refused proactive Slack DM is released and retried, a delivered one is consumed
PROBE main() rc=0
PROBE non-main threads alive after main() returned: 1
PROBE     name='Thread-1 (result_watcher)' daemon=True alive=True
```

**The abort itself is intermittent in the real test and I could not reproduce it** — 20/20 clean
local runs before the change (recorded in #3800). What *is* deterministic is the mechanism. A model
carrying the same three properties the test has (line-buffered stdout via
`sys.stdout.reconfigure(line_buffering=True)`, as `src/slack-bridge.py` does at import; a daemon
thread printing with `flush=True`; the exit path) reproduces the exact CI text 40 times out of 40,
and the fix takes it to 0:

```
systemexit: nonzero-exit/abort in 40 of 40 runs
  first failure:
    Fatal Python error: _enter_buffered_busy: could not acquire lock for
    <_io.BufferedWriter name='<stdout>'> at interpreter shutdown, possibly due to daemon threads
    Python runtime state: finalizing (tstate=0x0000000102068980)
osexit: nonzero-exit/abort in 0 of 40 runs
```

The real test writes far less often than the model, which is why most runs miss the window — that is
the intermittency, not evidence against the cause.

**After, at HEAD (`107f6084b`)** — the test still passes and still reports:

```
$ for i in 1 2 3 4 5; do python3 tests/slack-proactive-release-on-send-failure.test.py; done
run1 rc=0 last=PASS: a refused proactive Slack DM is released and retried, a delivered one is consumed
run2 rc=0 last=PASS: ...
run3 rc=0 last=PASS: ...
run4 rc=0 last=PASS: ...
run5 rc=0 last=PASS: ...
```

**`os._exit` skips flushing, so both halves of the contract were checked explicitly.** Output
survives (the `PASS` line above is the process's last line), and the exit code still propagates —
forced one check to fail at HEAD:

```
$ python3 tests/slack-proactive-release-on-send-failure.test.py   # with one forced FAILURES entry
rc=1
FAIL — 1 check(s):
  - forced: exit-code propagation probe
```

That probe line was reverted; it is not in the diff.

## Scope and limits

- Tests only; no production file touched.
- The added lines contain no paths.
- `os._exit` bypasses `atexit`. This file registers none, and its only cleanup is `mkdtemp`
  directories that already outlive the process. A future `atexit` here would be silently skipped —
  the reason the two-line comment says why the exit is what it is.
- I did not reproduce the original abort, so "it stops failing" is not offered as evidence. The
  checkable claim is the mechanism above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
