### PR TITLE
fix(morning-briefing): say how many pending questions render nowhere

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -634,6 +634,20 @@ def get_pending_questions() -> list[str]:
 
 
 
+def below_fold_count(total: int) -> int:
+    """How many waiting questions render on no surface the owner reads.
+
+    The notifier sends `questions[:VISIBLE_PREFIX]`, so waiting order IS
+    priority order and everything past it counts as open while reaching
+    nobody. Returns 0 when the prefix cannot be read — an unknown cutoff
+    must not be guessed into a number the briefing then states as fact.
+    """
+    prefix = getattr(_CPQ, "VISIBLE_PREFIX", None)
+    if not isinstance(prefix, int) or isinstance(prefix, bool) or prefix < 0:
+        return 0
+    return max(0, total - prefix)
+
+
 def get_health_issues() -> "list[str] | None":
     """Failed health items, or None when the check could not run.
 
@@ -726,6 +740,9 @@ def synthesize(weather, events, reminders, discord_msgs, pending_qs, health_issu
             parts.append(f"One pending question waiting: {pending_qs[0]}.")
         else:
             parts.append(f"{len(pending_qs)} pending questions. Top item: {pending_qs[0]}.")
+        hidden = below_fold_count(len(pending_qs))
+        if hidden:
+            parts.append(f"{hidden} of them render below the fold.")
 
     # Overnight Discord
     if discord_msgs:

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -644,6 +644,10 @@ def below_fold_count(total: int) -> int:
     """
     prefix = getattr(_CPQ, "VISIBLE_PREFIX", None)
     if not isinstance(prefix, int) or isinstance(prefix, bool) or prefix < 0:
+        # Say so: without this, an unreadable prefix and a genuinely unhidden
+        # list both render as no line, which is the silent no-op this fixes.
+        print(f"  below-fold: VISIBLE_PREFIX unreadable ({prefix!r}) — line omitted",
+              file=sys.stderr)
         return 0
     return max(0, total - prefix)
 

--- a/tests/morning-briefing-below-fold.test.py
+++ b/tests/morning-briefing-below-fold.test.py
@@ -22,6 +22,13 @@ REPO = Path(__file__).resolve().parent.parent
 MB_PATH = REPO / "src" / "morning-briefing.py"
 
 
+# A missing target must FAIL, not skip: a skip gives rc=0 and
+# `OK (skipped=8)` — green with nothing executed.
+if not MB_PATH.exists():
+    raise SystemExit(f"morning-briefing.py not found at {MB_PATH} — refusing "
+                     "to report a green run in which no test executed")
+
+
 def _load_mb():
     spec = importlib.util.spec_from_file_location("morning_briefing", MB_PATH)
     mod = importlib.util.module_from_spec(spec)
@@ -31,8 +38,6 @@ def _load_mb():
 
 class TestBelowFoldCount(unittest.TestCase):
     def setUp(self):
-        if not MB_PATH.exists():
-            self.skipTest("morning-briefing.py not found")
         self.mb = _load_mb()
         self.orig = getattr(self.mb._CPQ, "VISIBLE_PREFIX", None)
 
@@ -79,8 +84,6 @@ class TestBelowFoldCount(unittest.TestCase):
 
 class TestNarrativeSaysIt(unittest.TestCase):
     def setUp(self):
-        if not MB_PATH.exists():
-            self.skipTest("morning-briefing.py not found")
         self.mb = _load_mb()
         self.orig = getattr(self.mb._CPQ, "VISIBLE_PREFIX", None)
         self.mb._CPQ.VISIBLE_PREFIX = 5

--- a/tests/morning-briefing-below-fold.test.py
+++ b/tests/morning-briefing-below-fold.test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""The briefing must say how many pending questions reach no surface.
+
+`check-pending-questions.py` notifies `questions[:VISIBLE_PREFIX]`, so waiting
+order IS priority order: everything past the prefix counts as open and renders
+nowhere the owner reads. On 2026-09-03 there were 38 waiting and 33 of them were
+invisible, while the briefing said only "38 pending questions. Top item: ...".
+
+The audit used to be prose in the cron prompt telling the agent to name
+below-fold items *after* running this script — but the script publishes its
+result immediately and the bridge claims it, so the append had nowhere to land
+and the step silently no-opped. Counting it here is a mechanism instead: it runs
+whether or not anyone remembers.
+
+Run: python3 tests/morning-briefing-below-fold.test.py
+"""
+import importlib.util
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MB_PATH = REPO / "src" / "morning-briefing.py"
+
+
+def _load_mb():
+    spec = importlib.util.spec_from_file_location("morning_briefing", MB_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestBelowFoldCount(unittest.TestCase):
+    def setUp(self):
+        if not MB_PATH.exists():
+            self.skipTest("morning-briefing.py not found")
+        self.mb = _load_mb()
+        self.orig = getattr(self.mb._CPQ, "VISIBLE_PREFIX", None)
+
+    def tearDown(self):
+        if self.orig is None:
+            if hasattr(self.mb._CPQ, "VISIBLE_PREFIX"):
+                del self.mb._CPQ.VISIBLE_PREFIX
+        else:
+            self.mb._CPQ.VISIBLE_PREFIX = self.orig
+
+    def test_prefix_is_read_from_the_notifier_not_hardcoded_here(self):
+        # A local copy of the number is the bug this whole module family keeps
+        # having: the two would drift and the briefing would misreport.
+        self.assertIsInstance(self.orig, int)
+        self.mb._CPQ.VISIBLE_PREFIX = 7
+        self.assertEqual(self.mb.below_fold_count(10), 3)
+
+    def test_the_live_shape(self):
+        self.mb._CPQ.VISIBLE_PREFIX = 5
+        self.assertEqual(self.mb.below_fold_count(38), 33)
+
+    def test_nothing_hidden_when_the_list_fits(self):
+        self.mb._CPQ.VISIBLE_PREFIX = 5
+        self.assertEqual(self.mb.below_fold_count(5), 0)
+        self.assertEqual(self.mb.below_fold_count(3), 0)
+        self.assertEqual(self.mb.below_fold_count(0), 0)
+
+    def test_an_unreadable_prefix_yields_zero_not_a_guess(self):
+        # Absent, wrong-typed, or negative: the cutoff is unknown, and the
+        # briefing must not state a number it cannot derive.
+        del self.mb._CPQ.VISIBLE_PREFIX
+        self.assertEqual(self.mb.below_fold_count(38), 0)
+        self.mb._CPQ.VISIBLE_PREFIX = "five"
+        self.assertEqual(self.mb.below_fold_count(38), 0)
+        self.mb._CPQ.VISIBLE_PREFIX = -1
+        self.assertEqual(self.mb.below_fold_count(38), 0)
+
+    def test_bool_is_not_an_int_here(self):
+        # True == 1 under `isinstance(x, int)`, which would silently claim a
+        # 1-item fold. The guard exists so the assertion below can hold.
+        self.mb._CPQ.VISIBLE_PREFIX = True
+        self.assertEqual(self.mb.below_fold_count(38), 0)
+
+
+class TestNarrativeSaysIt(unittest.TestCase):
+    def setUp(self):
+        if not MB_PATH.exists():
+            self.skipTest("morning-briefing.py not found")
+        self.mb = _load_mb()
+        self.orig = getattr(self.mb._CPQ, "VISIBLE_PREFIX", None)
+        self.mb._CPQ.VISIBLE_PREFIX = 5
+
+    def tearDown(self):
+        if self.orig is not None:
+            self.mb._CPQ.VISIBLE_PREFIX = self.orig
+
+    def _narrate(self, n):
+        return self.mb.synthesize(
+            weather=None, events=[], reminders=[], discord_msgs=[],
+            pending_qs=[f"q{i}" for i in range(n)], health_issues=[])
+
+    def test_the_hidden_count_is_spoken(self):
+        text = self._narrate(38)
+        self.assertIn("38 pending questions", text)
+        self.assertIn("33 of them render below the fold", text)
+
+    def test_silent_when_everything_is_visible(self):
+        text = self._narrate(4)
+        self.assertIn("4 pending questions", text)
+        self.assertNotIn("below the fold", text)
+
+    def test_silent_on_a_single_question(self):
+        text = self._narrate(1)
+        self.assertNotIn("below the fold", text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The bug

`src/check-pending-questions.py` notifies `questions[:VISIBLE_PREFIX]` (`VISIBLE_PREFIX = 5`). Waiting order is therefore priority order: everything past position 5 counts as open and reaches no surface the owner reads. The briefing said only how many were open, never how many were invisible.

Live on this host today: **38 waiting, 33 of them below the fold.**

## Why prose did not fix it

The below-the-fold audit already existed — as an instruction in the morning-briefing cron prompt, added 2026-08-30 after a question worth 14 blocked PRs sat unseen at position 14 of 34 for 10 days. It tells the agent to name high-leverage below-fold items *in the briefing*, after running `src/morning-briefing.py`.

That is impossible by construction. The script writes `results/proactive-morning-<ts>.txt` and the bridge claims it within seconds. Measured today at 15:36Z: the append was attempted and the file was already gone —

```
$ [ -f "$WS/results/proactive-morning-1788449755847.txt" ] && ... || echo "already claimed/delivered"
already claimed/delivered — cannot append
```

So the step silently no-opped, and a no-op is indistinguishable from a day with nothing below the fold. Counting it inside the script runs whether or not anyone remembers.

## Before / after

Same input (38 waiting), parent commit vs HEAD:

```
### BEFORE (parent commit)
Good morning. It's 61F and overcast. Your calendar is clear today. 38 pending questions. Top item: q0.

### AFTER (HEAD)
Good morning. It's 61F and overcast. Your calendar is clear today. 38 pending questions. Top item: q0. 33 of them render below the fold.
```

## The prefix is read, not copied

`below_fold_count()` reads `VISIBLE_PREFIX` off the already-imported `_CPQ` module. A local copy of that number is precisely the drift this file has had before (2026-07-28: notifier counted 33, briefing counted 32). An absent, wrong-typed, or negative prefix yields `0` — an unknown cutoff must not become a number the briefing states as fact. `bool` is excluded explicitly because `isinstance(True, int)` is `True` and would claim a 1-item fold.

## Tests

`tests/morning-briefing-below-fold.test.py` — 8 checks. Armed by reverting `src/morning-briefing.py` to the parent and re-running:

```
### against the UNPATCHED source
FAILED (failures=1, errors=5)

### at HEAD
Ran 8 tests in 0.081s
OK
```

Two of the eight (`test_silent_when_everything_is_visible`, `test_silent_on_a_single_question`) pass at the parent as well — they are negative assertions guarding against a spurious line, not discriminators for this change. The six that move are the ones that carry the evidence.

## Scope

One concern. No prompt text changed; no other briefing line changed.