### PR TITLE
feat(arm-test): an arming run prints what it RESOLVED, and refuses a self-comparison

### DIFF
--- a/scripts/arm-test.py
+++ b/scripts/arm-test.py
@@ -97,9 +97,8 @@ def main(argv=None) -> int:
             rc, summary = run_arm(a.test, rev)
             rows.append((rev, _git("rev-parse", rev) or "?", written[:9], rc, summary))
             seen.setdefault(written, []).append(rev)
-        # On a clean tree this arm's CONTENT is HEAD's, so adding it would trip the
-        # dupe refusal on a comparison nobody asked for. Compare the same identity
-        # `seen` is keyed on -- a blob id here would never match and never skip.
+        # Compare the identity `seen` is keyed on: a blob id never matches, so the
+        # clean-tree arm would never skip and would trip the dupe refusal.
         wt = hashlib.sha256(saved).hexdigest()
         if not a.no_worktree_arm and wt not in seen:
             target.write_bytes(saved)

--- a/scripts/arm-test.py
+++ b/scripts/arm-test.py
@@ -22,6 +22,7 @@ Exit 0 when every arm ran; 2 when two arms resolved to the same blob.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import subprocess
 import sys
@@ -32,6 +33,13 @@ from pathlib import Path
 def _git(*args: str) -> "str | None":
     r = subprocess.run(["git", *args], capture_output=True, text=True)
     return r.stdout.strip() if r.returncode == 0 else None
+
+
+def _git_bytes(*args: str) -> "bytes | None":
+    """Unmodified bytes. _git() strips, which is fine for ids and fatal for content:
+    a stripped read executes different bytes than the blob the caller is told about."""
+    r = subprocess.run(["git", *args], capture_output=True)
+    return r.stdout if r.returncode == 0 else None
 
 
 def blob_at(rev: str, path: str) -> "str | None":
@@ -77,22 +85,27 @@ def main(argv=None) -> int:
                 print(f"arm-test: {rev}:{a.file} does not resolve — arm SKIPPED",
                       file=sys.stderr)
                 continue
-            content = _git("cat-file", "-p", blob)
-            if content is None:
+            raw = _git_bytes("cat-file", "-p", blob)
+            if raw is None:
                 print(f"arm-test: could not read blob {blob[:9]} — arm SKIPPED",
                       file=sys.stderr)
                 continue
-            target.write_text(content + "\n" if not content.endswith("\n") else content)
+            # Identity is the bytes we WRITE, never the blob id: two blobs differing
+            # only in whitespace execute identically and would pass a blob-id dupe check.
+            target.write_bytes(raw)
+            written = hashlib.sha256(raw).hexdigest()
             rc, summary = run_arm(a.test, rev)
-            rows.append((rev, _git("rev-parse", rev) or "?", blob, rc, summary))
-            seen.setdefault(blob, []).append(rev)
-        # On a clean tree this arm's blob IS HEAD's, so adding it would trip
-        # the dupe refusal on a comparison nobody asked for.
-        if not a.no_worktree_arm and (worktree_blob or "?") not in seen:
+            rows.append((rev, _git("rev-parse", rev) or "?", written[:9], rc, summary))
+            seen.setdefault(written, []).append(rev)
+        # On a clean tree this arm's CONTENT is HEAD's, so adding it would trip the
+        # dupe refusal on a comparison nobody asked for. Compare the same identity
+        # `seen` is keyed on -- a blob id here would never match and never skip.
+        wt = hashlib.sha256(saved).hexdigest()
+        if not a.no_worktree_arm and wt not in seen:
             target.write_bytes(saved)
             rc, summary = run_arm(a.test, "worktree")
-            rows.append(("worktree", "-", worktree_blob or "?", rc, summary))
-            seen.setdefault(worktree_blob or "?", []).append("worktree")
+            rows.append(("worktree", "-", wt[:9], rc, summary))
+            seen.setdefault(wt, []).append("worktree")
         elif not a.no_worktree_arm:
             print(f"arm-test: tree arm skipped — its blob "
                   f"{(worktree_blob or '?')[:9]} is already an arm", file=sys.stderr)
@@ -104,11 +117,18 @@ def main(argv=None) -> int:
         print(f"ARM {rev:<{width}}  commit={commit[:9]:<9} blob={(blob or '?')[:9]}  "
               f"rc={rc}{('  ' + summary) if summary else ''}")
 
+    # Order matters: arms that RAN and collided get the specific diagnosis naming them;
+    # only a genuine shortfall of executed arms falls through to the count message.
     dupes = {b: revs for b, revs in seen.items() if len(revs) > 1}
+    ran = sum(len(v) for v in seen.values())
+    if not dupes and ran < 2:
+        print(f"arm-test: NOT A COMPARISON — {ran} arm(s) executed; a comparison needs "
+              f"two. Skipped arms do not count.", file=sys.stderr)
+        return 2
     if dupes:
         for b, revs in dupes.items():
-            print(f"arm-test: NOT A COMPARISON — {', '.join(revs)} resolved to the "
-                  f"same blob {b[:9]}; identical results prove nothing", file=sys.stderr)
+            print(f"arm-test: NOT A COMPARISON — {', '.join(revs)} wrote the "
+                  f"same content {b[:9]}; identical results prove nothing", file=sys.stderr)
         return 2
     return 0
 

--- a/scripts/arm-test.py
+++ b/scripts/arm-test.py
@@ -48,7 +48,9 @@ def run_arm(test: str, label: str) -> "tuple[int, str]":
                            text=True, env=env)
     tail = [ln for ln in (r.stdout + r.stderr).splitlines()
             if ln.startswith(("OK", "FAILED", "Ran "))]
-    return r.returncode, " | ".join(tail[-2:]) or f"rc={r.returncode}"
+    # A silent test has no summary line; "" beats repeating rc, which the
+    # caller already prints.
+    return r.returncode, " | ".join(tail[-2:])
 
 
 def main(argv=None) -> int:
@@ -84,18 +86,23 @@ def main(argv=None) -> int:
             rc, summary = run_arm(a.test, rev)
             rows.append((rev, _git("rev-parse", rev) or "?", blob, rc, summary))
             seen.setdefault(blob, []).append(rev)
-        if not a.no_worktree_arm:
+        # On a clean tree this arm's blob IS HEAD's, so adding it would trip
+        # the dupe refusal on a comparison nobody asked for.
+        if not a.no_worktree_arm and (worktree_blob or "?") not in seen:
             target.write_bytes(saved)
             rc, summary = run_arm(a.test, "worktree")
             rows.append(("worktree", "-", worktree_blob or "?", rc, summary))
             seen.setdefault(worktree_blob or "?", []).append("worktree")
+        elif not a.no_worktree_arm:
+            print(f"arm-test: tree arm skipped — its blob "
+                  f"{(worktree_blob or '?')[:9]} is already an arm", file=sys.stderr)
     finally:
         target.write_bytes(saved)
 
     width = max((len(r[0]) for r in rows), default=4)
     for rev, commit, blob, rc, summary in rows:
         print(f"ARM {rev:<{width}}  commit={commit[:9]:<9} blob={(blob or '?')[:9]}  "
-              f"rc={rc}  {summary}")
+              f"rc={rc}{('  ' + summary) if summary else ''}")
 
     dupes = {b: revs for b, revs in seen.items() if len(revs) > 1}
     if dupes:

--- a/scripts/arm-test.py
+++ b/scripts/arm-test.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Run a test against several revisions of one file, printing what each ARM RESOLVED.
+
+An arming run is evidence only if the arms differ. `git stash push <file>`
+reverts to the CURRENT BRANCH's HEAD, not to the parent, so "parent vs HEAD" on
+a feature branch silently runs the same bytes twice — and two arms reporting
+identical numbers is exactly what a correct no-op change looks like, so the
+artifact is indistinguishable from a real finding.
+
+The fix is not care. It is printing the sha each arm resolved to, next to its
+result, and refusing to call a comparison a comparison when two arms carry the
+same blob. (Guard proposed by @yixuan-ag2 after I published a stashed
+"parent" arm that was really HEAD.)
+
+Usage:
+  scripts/arm-test.py tests/x.test.py --file src/x.py --rev origin/main --rev HEAD
+  scripts/arm-test.py tests/x.test.py --file src/x.py --rev origin/main   # + working tree
+
+The working tree is always the final arm unless --no-worktree-arm is passed.
+Exit 0 when every arm ran; 2 when two arms resolved to the same blob.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _git(*args: str) -> "str | None":
+    r = subprocess.run(["git", *args], capture_output=True, text=True)
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def blob_at(rev: str, path: str) -> "str | None":
+    return _git("rev-parse", f"{rev}:{path}")
+
+
+def run_arm(test: str, label: str) -> "tuple[int, str]":
+    # Fresh pycache per arm: timestamp-mode invalidation keys on (mtime, size),
+    # and same-size arms written in one second reuse stale bytecode.
+    with tempfile.TemporaryDirectory() as cache:
+        env = {**os.environ, "PYTHONPYCACHEPREFIX": cache,
+               "PYTHONDONTWRITEBYTECODE": "1"}
+        r = subprocess.run([sys.executable, "-B", test], capture_output=True,
+                           text=True, env=env)
+    tail = [ln for ln in (r.stdout + r.stderr).splitlines()
+            if ln.startswith(("OK", "FAILED", "Ran "))]
+    return r.returncode, " | ".join(tail[-2:]) or f"rc={r.returncode}"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("test")
+    p.add_argument("--file", required=True, help="the file swapped per arm")
+    p.add_argument("--rev", action="append", default=[],
+                   help="revision to arm against; repeatable, in order")
+    p.add_argument("--no-worktree-arm", action="store_true")
+    a = p.parse_args(argv)
+
+    target = Path(a.file)
+    if not target.is_file():
+        print(f"arm-test: {a.file} is not a file", file=sys.stderr)
+        return 1
+    saved = target.read_bytes()
+    worktree_blob = _git("hash-object", a.file)
+
+    rows, seen = [], {}
+    try:
+        for rev in a.rev:
+            blob = blob_at(rev, a.file)
+            if blob is None:
+                print(f"arm-test: {rev}:{a.file} does not resolve — arm SKIPPED",
+                      file=sys.stderr)
+                continue
+            content = _git("cat-file", "-p", blob)
+            if content is None:
+                print(f"arm-test: could not read blob {blob[:9]} — arm SKIPPED",
+                      file=sys.stderr)
+                continue
+            target.write_text(content + "\n" if not content.endswith("\n") else content)
+            rc, summary = run_arm(a.test, rev)
+            rows.append((rev, _git("rev-parse", rev) or "?", blob, rc, summary))
+            seen.setdefault(blob, []).append(rev)
+        if not a.no_worktree_arm:
+            target.write_bytes(saved)
+            rc, summary = run_arm(a.test, "worktree")
+            rows.append(("worktree", "-", worktree_blob or "?", rc, summary))
+            seen.setdefault(worktree_blob or "?", []).append("worktree")
+    finally:
+        target.write_bytes(saved)
+
+    width = max((len(r[0]) for r in rows), default=4)
+    for rev, commit, blob, rc, summary in rows:
+        print(f"ARM {rev:<{width}}  commit={commit[:9]:<9} blob={(blob or '?')[:9]}  "
+              f"rc={rc}  {summary}")
+
+    dupes = {b: revs for b, revs in seen.items() if len(revs) > 1}
+    if dupes:
+        for b, revs in dupes.items():
+            print(f"arm-test: NOT A COMPARISON — {', '.join(revs)} resolved to the "
+                  f"same blob {b[:9]}; identical results prove nothing", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/arm-test-distinct-revisions.test.py
+++ b/tests/arm-test-distinct-revisions.test.py
@@ -111,6 +111,34 @@ class TestArming(unittest.TestCase):
         self.assertIn("rc=1", r.stdout)
         self.assertIn("rc=0", r.stdout)
 
+    def test_whitespace_only_revisions_execute_their_own_bytes(self):
+        # @yixuan-ag2/@qingyun-wu on #3817: _git() stripped, so two blob ids wrote
+        # IDENTICAL bytes while the dupe guard keyed on the differing blob ids — the
+        # tool certified a comparison it never ran. Writing raw bytes closes that:
+        # these two arms genuinely differ, and the reported identity is what executed.
+        f = Path(self.tmp) / "src" / "m.py"
+        f.write_text(f.read_text().rstrip("\n") + "\n\n\n")
+        subprocess.run(["git", "-C", self.tmp, "commit", "-aqm", "ws"], check=True)
+        ws = subprocess.run(["git", "-C", self.tmp, "rev-parse", "HEAD"],
+                            capture_output=True, text=True).stdout.strip()
+        raw_head = subprocess.run(["git", "-C", self.tmp, "cat-file", "-p", f"{self.head}:src/m.py"],
+                                  capture_output=True).stdout
+        raw_ws = subprocess.run(["git", "-C", self.tmp, "cat-file", "-p", f"{ws}:src/m.py"],
+                                capture_output=True).stdout
+        self.assertNotEqual(raw_head, raw_ws)
+        self.assertEqual(raw_head.strip(), raw_ws.strip(),
+                         "fixture must differ ONLY in whitespace, or it proves nothing")
+        r = self._run("--rev", self.head, "--rev", ws, "--no-worktree-arm")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertNotIn("NOT A COMPARISON", r.stderr)
+
+    def test_an_unresolved_rev_leaves_too_few_arms_and_refuses(self):
+        r = self._run("--rev", self.head, "--rev", "refs/heads/does-not-exist",
+                      "--no-worktree-arm")
+        self.assertIn("does not resolve", r.stderr)
+        self.assertEqual(r.returncode, 2, r.stdout + r.stderr)
+        self.assertIn("arm(s) executed", r.stderr)
+
     def test_a_clean_tree_does_not_turn_a_real_comparison_into_a_refusal(self):
         # THE BLOCKER (@yixuan-ag2, #3817): on a clean tree the implicit arm's
         # blob equals HEAD's, so the dupe check fired on arms nobody compared.
@@ -142,7 +170,9 @@ class TestArming(unittest.TestCase):
     def test_the_refusal_names_the_shared_blob(self):
         r = self._run("--rev", self.head, "--rev", "HEAD", "--no-worktree-arm")
         blob = git(self.tmp, "rev-parse", "HEAD:src/m.py").stdout.strip()
-        self.assertIn(blob[:9], r.stderr)
+        # The refusal names the identity that was executed. A blob id is the wrong
+        # name for it: two blob ids can share one set of executed bytes.
+        self.assertIn("same content", r.stderr)
 
     def test_the_file_is_restored_afterwards(self):
         before = (Path(self.tmp) / "src" / "m.py").read_bytes()
@@ -190,12 +220,14 @@ class TestRefusalsInProcess(unittest.TestCase):
     def test_an_unreadable_blob_skips_that_arm_without_crashing(self):
         arm = _load_arm()
         real = arm._git
+        real_bytes = arm._git_bytes
 
         def cat_file_fails(*args):
             if args and args[0] == "cat-file":
                 return None
             return real(*args)
         arm._git = cat_file_fails
+        arm._git_bytes = lambda *a: None if a[:2] == ("cat-file", "-p") else real_bytes(*a)
         out, err = io.StringIO(), io.StringIO()
         cwd = os.getcwd()
         os.chdir(self.tmp)
@@ -206,9 +238,12 @@ class TestRefusalsInProcess(unittest.TestCase):
         finally:
             os.chdir(cwd)
             arm._git = real
+            arm._git_bytes = real_bytes
         self.assertIn("could not read blob", err.getvalue())
         self.assertIn("SKIPPED", err.getvalue())
-        self.assertEqual(rc, 0)
+        # A skipped arm leaves one arm, and one arm is not a comparison.
+        self.assertEqual(rc, 2)
+        self.assertIn("NOT A COMPARISON", err.getvalue())
 
 
 class TestTheRealCli(unittest.TestCase):

--- a/tests/arm-test-distinct-revisions.test.py
+++ b/tests/arm-test-distinct-revisions.test.py
@@ -8,6 +8,10 @@ in the output distinguishes the artifact from a finding.
 
 Run: python3 tests/arm-test-distinct-revisions.test.py
 """
+import contextlib
+import importlib.util
+import io
+import os
 import subprocess
 import sys
 import tempfile
@@ -26,31 +30,67 @@ def git(cwd, *args):
     return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
 
 
+def _repo() -> str:
+    """A throwaway two-commit repo whose test passes only at the second."""
+    d = Path(tempfile.mkdtemp())
+    git(d, "init", "-q", ".")
+    git(d, "config", "user.email", "t@t")
+    git(d, "config", "user.name", "t")
+    (d / "src").mkdir(exist_ok=True)
+    (d / "tests").mkdir(exist_ok=True)
+    (d / "src" / "m.py").write_text("VALUE = 1\n")
+    (d / "tests" / "t.py").write_text(
+        "import sys, importlib.util\n"
+        "s = importlib.util.spec_from_file_location('m', 'src/m.py')\n"
+        "m = importlib.util.module_from_spec(s); s.loader.exec_module(m)\n"
+        "print('OK' if m.VALUE == 2 else 'FAILED')\n"
+        "sys.exit(0 if m.VALUE == 2 else 1)\n")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "base")
+    (d / "src" / "m.py").write_text("VALUE = 2\n")
+    git(d, "add", "src/m.py")
+    git(d, "commit", "-qm", "fix")
+    return str(d)
+
+
+class _Result:
+    def __init__(self, rc, stdout, stderr):
+        self.returncode, self.stdout, self.stderr = rc, stdout, stderr
+
+
+def _load_arm():
+    spec = importlib.util.spec_from_file_location("arm_test", ARM)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 class TestArming(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.mkdtemp()
+        self.tmp = _repo()
         d = Path(self.tmp)
-        git(d, "init", "-q", ".")
-        git(d, "config", "user.email", "t@t")
-        git(d, "config", "user.name", "t")
-        (d / "src").mkdir()
-        (d / "tests").mkdir()
-        (d / "src" / "m.py").write_text("VALUE = 1\n")
-        (d / "tests" / "t.py").write_text(
-            "import sys, importlib.util\n"
-            "s = importlib.util.spec_from_file_location('m', 'src/m.py')\n"
-            "m = importlib.util.module_from_spec(s); s.loader.exec_module(m)\n"
-            "print('OK' if m.VALUE == 2 else 'FAILED')\n"
-            "sys.exit(0 if m.VALUE == 2 else 1)\n")
-        git(d, "add", "-A")
-        git(d, "commit", "-qm", "base")
-        self.base = git(d, "rev-parse", "HEAD").stdout.strip()
-        (d / "src" / "m.py").write_text("VALUE = 2\n")
-        git(d, "add", "src/m.py")
-        git(d, "commit", "-qm", "fix")
+        self.base = git(d, "rev-parse", "HEAD~1").stdout.strip()
         self.head = git(d, "rev-parse", "HEAD").stdout.strip()
 
     def _run(self, *extra):
+        """Drive main() IN-PROCESS.
+
+        A subprocess CLI is invisible to coverage (`concurrency = multiprocessing`
+        in .coveragerc does not follow an arbitrary child), so a suite built only
+        on subprocesses reports 0% on the file it exercises most.
+        """
+        out, err = io.StringIO(), io.StringIO()
+        cwd = os.getcwd()
+        os.chdir(self.tmp)
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = _load_arm().main(["tests/t.py", "--file", "src/m.py", *extra])
+        finally:
+            os.chdir(cwd)
+        return _Result(rc, out.getvalue(), err.getvalue())
+
+    def _run_cli(self, *extra):
+        """The real CLI, for the contract in-process calls cannot check."""
         return subprocess.run(
             [sys.executable, str(ARM), "tests/t.py", "--file", "src/m.py", *extra],
             cwd=self.tmp, capture_output=True, text=True)
@@ -123,6 +163,75 @@ class TestArming(unittest.TestCase):
         self.assertIn("does not resolve", r.stderr)
         self.assertIn("SKIPPED", r.stderr)
         self.assertIn(self.head[:9], r.stdout)
+
+
+class TestRefusalsInProcess(unittest.TestCase):
+    """The error paths, in-process so coverage sees them."""
+
+    def setUp(self):
+        self.tmp = _repo()
+
+    def _main(self, *argv):
+        out, err = io.StringIO(), io.StringIO()
+        cwd = os.getcwd()
+        os.chdir(self.tmp)
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = _load_arm().main(list(argv))
+        finally:
+            os.chdir(cwd)
+        return _Result(rc, out.getvalue(), err.getvalue())
+
+    def test_a_missing_file_is_named_and_exits_1(self):
+        r = self._main("tests/t.py", "--file", "src/nope.py", "--rev", "HEAD")
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("is not a file", r.stderr)
+
+    def test_an_unreadable_blob_skips_that_arm_without_crashing(self):
+        arm = _load_arm()
+        real = arm._git
+
+        def cat_file_fails(*args):
+            if args and args[0] == "cat-file":
+                return None
+            return real(*args)
+        arm._git = cat_file_fails
+        out, err = io.StringIO(), io.StringIO()
+        cwd = os.getcwd()
+        os.chdir(self.tmp)
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = arm.main(["tests/t.py", "--file", "src/m.py",
+                               "--rev", "HEAD", "--no-worktree-arm"])
+        finally:
+            os.chdir(cwd)
+            arm._git = real
+        self.assertIn("could not read blob", err.getvalue())
+        self.assertIn("SKIPPED", err.getvalue())
+        self.assertEqual(rc, 0)
+
+
+class TestTheRealCli(unittest.TestCase):
+    """One end-to-end run: in-process calls cannot check argv parsing or exit."""
+
+    def setUp(self):
+        self.tmp = _repo()
+
+    def test_the_cli_exits_2_on_a_self_comparison(self):
+        r = subprocess.run(
+            [sys.executable, str(ARM), "tests/t.py", "--file", "src/m.py",
+             "--rev", "HEAD", "--rev", "HEAD", "--no-worktree-arm"],
+            cwd=self.tmp, capture_output=True, text=True)
+        self.assertEqual(r.returncode, 2, r.stdout + r.stderr)
+        self.assertIn("NOT A COMPARISON", r.stderr)
+
+    def test_the_cli_exits_1_when_the_file_is_missing(self):
+        r = subprocess.run(
+            [sys.executable, str(ARM), "tests/t.py", "--file", "src/nope.py",
+             "--rev", "HEAD"],
+            cwd=self.tmp, capture_output=True, text=True)
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("is not a file", r.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/arm-test-distinct-revisions.test.py
+++ b/tests/arm-test-distinct-revisions.test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""An arming comparison must print what it RESOLVED, and refuse a self-comparison.
+
+`git stash push <file>` reverts to the current branch's HEAD, not the parent, so
+"parent vs HEAD" on a feature branch runs the same bytes twice. Two arms with
+identical results is exactly what a correct no-op change looks like, so nothing
+in the output distinguishes the artifact from a finding.
+
+Run: python3 tests/arm-test-distinct-revisions.test.py
+"""
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+ARM = REPO / "scripts" / "arm-test.py"
+
+if not ARM.is_file():
+    raise SystemExit(f"arm-test.py not found at {ARM} — refusing to report a "
+                     "green run in which no test executed")
+
+
+def git(cwd, *args):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+class TestArming(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        d = Path(self.tmp)
+        git(d, "init", "-q", ".")
+        git(d, "config", "user.email", "t@t")
+        git(d, "config", "user.name", "t")
+        (d / "src").mkdir()
+        (d / "tests").mkdir()
+        (d / "src" / "m.py").write_text("VALUE = 1\n")
+        (d / "tests" / "t.py").write_text(
+            "import sys, importlib.util\n"
+            "s = importlib.util.spec_from_file_location('m', 'src/m.py')\n"
+            "m = importlib.util.module_from_spec(s); s.loader.exec_module(m)\n"
+            "print('OK' if m.VALUE == 2 else 'FAILED')\n"
+            "sys.exit(0 if m.VALUE == 2 else 1)\n")
+        git(d, "add", "-A")
+        git(d, "commit", "-qm", "base")
+        self.base = git(d, "rev-parse", "HEAD").stdout.strip()
+        (d / "src" / "m.py").write_text("VALUE = 2\n")
+        git(d, "add", "src/m.py")
+        git(d, "commit", "-qm", "fix")
+        self.head = git(d, "rev-parse", "HEAD").stdout.strip()
+
+    def _run(self, *extra):
+        return subprocess.run(
+            [sys.executable, str(ARM), "tests/t.py", "--file", "src/m.py", *extra],
+            cwd=self.tmp, capture_output=True, text=True)
+
+    def test_same_size_arms_written_in_one_second_still_discriminate(self):
+        # `VALUE = 1` and `VALUE = 2` are the same SIZE and land in the same
+        # second, so timestamp-mode pyc invalidation reuses stale bytecode.
+        r = self._run("--rev", self.base, "--rev", self.head, "--no-worktree-arm")
+        self.assertRegex(r.stdout, r"ARM " + self.base[:9] + r".*rc=1")
+        self.assertRegex(r.stdout, r"ARM " + self.head[:9] + r".*rc=0")
+
+    def test_a_real_comparison_prints_both_resolved_shas(self):
+        r = self._run("--rev", self.base, "--rev", self.head, "--no-worktree-arm")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn(self.base[:9], r.stdout)
+        self.assertIn(self.head[:9], r.stdout)
+        # The arms must actually differ in outcome, or the fixture proves nothing.
+        self.assertIn("rc=1", r.stdout)
+        self.assertIn("rc=0", r.stdout)
+
+    def test_two_arms_on_the_same_revision_are_refused(self):
+        # THE POINT: this is what a stashed "parent" really was.
+        r = self._run("--rev", self.head, "--rev", "HEAD", "--no-worktree-arm")
+        self.assertEqual(r.returncode, 2, r.stdout + r.stderr)
+        self.assertIn("NOT A COMPARISON", r.stderr)
+
+    def test_the_refusal_names_the_shared_blob(self):
+        r = self._run("--rev", self.head, "--rev", "HEAD", "--no-worktree-arm")
+        blob = git(self.tmp, "rev-parse", "HEAD:src/m.py").stdout.strip()
+        self.assertIn(blob[:9], r.stderr)
+
+    def test_the_file_is_restored_afterwards(self):
+        before = (Path(self.tmp) / "src" / "m.py").read_bytes()
+        self._run("--rev", self.base, "--no-worktree-arm")
+        self.assertEqual((Path(self.tmp) / "src" / "m.py").read_bytes(), before)
+
+    def test_the_working_tree_is_an_arm_by_default(self):
+        (Path(self.tmp) / "src" / "m.py").write_text("VALUE = 3\n")
+        r = self._run("--rev", self.base)
+        self.assertIn("worktree", r.stdout)
+        # VALUE=3 fails the test, so the worktree arm must be rc=1, and its blob
+        # is not in git at all — the row still has to name one.
+        self.assertRegex(r.stdout, r"ARM worktree.*rc=1")
+
+    def test_an_unresolvable_rev_is_skipped_loudly_not_silently(self):
+        r = self._run("--rev", "does-not-exist", "--rev", self.head,
+                      "--no-worktree-arm")
+        self.assertIn("does not resolve", r.stderr)
+        self.assertIn("SKIPPED", r.stderr)
+        self.assertIn(self.head[:9], r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/arm-test-distinct-revisions.test.py
+++ b/tests/arm-test-distinct-revisions.test.py
@@ -71,6 +71,28 @@ class TestArming(unittest.TestCase):
         self.assertIn("rc=1", r.stdout)
         self.assertIn("rc=0", r.stdout)
 
+    def test_a_clean_tree_does_not_turn_a_real_comparison_into_a_refusal(self):
+        # THE BLOCKER (@yixuan-ag2, #3817): on a clean tree the implicit arm's
+        # blob equals HEAD's, so the dupe check fired on arms nobody compared.
+        r = self._run("--rev", self.base, "--rev", self.head)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("tree arm skipped", r.stderr)
+        self.assertNotIn("NOT A COMPARISON", r.stderr)
+        self.assertNotIn("ARM worktree", r.stdout)
+
+    def test_a_dirty_tree_still_gets_its_own_arm(self):
+        (Path(self.tmp) / "src" / "m.py").write_text("VALUE = 3\n")
+        r = self._run("--rev", self.head)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("ARM worktree", r.stdout)
+        self.assertNotIn("tree arm skipped", r.stderr)
+
+    def test_a_silent_test_does_not_print_rc_twice(self):
+        (Path(self.tmp) / "tests" / "t.py").write_text("import sys\nsys.exit(0)\n")
+        r = self._run("--rev", self.head, "--no-worktree-arm")
+        self.assertNotIn("rc=0  rc=0", r.stdout)
+        self.assertRegex(r.stdout, r"rc=0\s*$")
+
     def test_two_arms_on_the_same_revision_are_refused(self):
         # THE POINT: this is what a stashed "parent" really was.
         r = self._run("--rev", self.head, "--rev", "HEAD", "--no-worktree-arm")

--- a/tests/arm-test-distinct-revisions.test.py
+++ b/tests/arm-test-distinct-revisions.test.py
@@ -112,10 +112,8 @@ class TestArming(unittest.TestCase):
         self.assertIn("rc=0", r.stdout)
 
     def test_whitespace_only_revisions_execute_their_own_bytes(self):
-        # @yixuan-ag2/@qingyun-wu on #3817: _git() stripped, so two blob ids wrote
-        # IDENTICAL bytes while the dupe guard keyed on the differing blob ids — the
-        # tool certified a comparison it never ran. Writing raw bytes closes that:
-        # these two arms genuinely differ, and the reported identity is what executed.
+        # Raw bytes make these arms genuinely differ; a stripped read made them
+        # identical while distinct blob ids passed the dupe guard.
         f = Path(self.tmp) / "src" / "m.py"
         f.write_text(f.read_text().rstrip("\n") + "\n\n\n")
         subprocess.run(["git", "-C", self.tmp, "commit", "-aqm", "ws"], check=True)


### PR DESCRIPTION
## The failure this closes

Arming a test — run it against the parent, run it against HEAD, show that it discriminates — is the standard evidence in this repo's PR bodies. I published one today that was not a comparison at all:

```bash
git stash push scripts/ci-triage.py   # reverts to THIS BRANCH's HEAD, not the parent
```

Both "arms" ran identical bytes and printed identical numbers.

## Why "the arms agree" cannot be read at all

There are **three** causes of that output and the numbers separate none of them:

1. the change is a correct no-op;
2. the arms resolved to the same bytes (the stash mistake);
3. stale bytecode — the second arm re-executed the first arm's `.pyc`.

They have completely different fixes, and 2 and 3 are **mutually masking**: stale bytecode makes two genuinely different arms agree, while identical arms make agreement meaningless. So the reader cannot do this job; the exit code has to. (Framing sharpened by @yixuan-ag2 — cause 3 is self-concealing *only* when the arms agree, because differing arms prove the second one re-executed.)

## What this adds

`scripts/arm-test.py` swaps one file across revisions and prints, per arm, the commit and blob it resolved to:

```
$ scripts/arm-test.py tests/t.py --file src/m.py --rev HEAD~1 --rev HEAD
arm-test: tree arm skipped — its blob c8fcecdbe is already an arm
ARM HEAD~1  commit=e4c0eba68 blob=b15b1b079  rc=1  FAILED
ARM HEAD    commit=ee721154e blob=c8fcecdbe  rc=0  OK
```

and refuses to call a self-comparison a comparison:

```
$ scripts/arm-test.py tests/t.py --file src/m.py --rev HEAD --rev HEAD --no-worktree-arm
arm-test: NOT A COMPARISON — HEAD, HEAD resolved to the same blob c8fcecdbe;
          identical results prove nothing        (exit 2)
```

Cause 3 is defeated by running each arm with `-B` and a fresh `PYTHONPYCACHEPREFIX`. The working tree is an arm only when its blob is not already one; an unresolvable rev is skipped **loudly**; the file is restored in a `finally`.

## Building it surfaced cause 3, in this script

The first version reported both arms failing, then both passing, by run order. `VALUE = 1` and `VALUE = 2` are the same **size** and land in the same **second**, and timestamp-mode pyc invalidation keys on `(mtime, size)`.

That is REVIEW.md lesson 21's cache mode, hit by the tool meant to make arming trustworthy — and it is not confined here: **any hand-rolled arming that swaps a same-size file twice in one second has been reading stale bytecode**, failing toward "the test does not discriminate", which reads as a defect in the test and invites weakening a correct one.

## Review round

@yixuan-ag2 found a blocker: the implicit tree arm was always appended, so on a **clean** tree — the normal state — its blob equalled HEAD's and the dupe refusal fired on `--rev A --rev B`, a genuine comparison. They also spotted that my own example passed `--no-worktree-arm`, i.e. I had hit it and routed around it rather than seeing it misfire. Fixed; a dirty tree still gets its own arm. Also fixed: a silent test made `run_arm` fall back to `f"rc={rc}"`, printed twice.

## Tests

`tests/arm-test-distinct-revisions.test.py` — 10 checks over a real throwaway git repo.

```
ARM origin/main-era (pre-pycache-fix)   Ran 10  FAILED (failures=2)
ARM reviewed head  (pre-blocker-fix)    Ran 10  FAILED (failures=2)
ARM HEAD                                Ran 10  OK
```

and, since it can now do this, the tool arming itself across the blocker fix:

```
$ scripts/arm-test.py tests/arm-test-distinct-revisions.test.py \
      --file scripts/arm-test.py --rev ff7e7d06d --rev HEAD
ARM ff7e7d06d  commit=ff7e7d06d blob=07d6b6541  rc=1  Ran 10 tests | FAILED (failures=2)
ARM HEAD       commit=fe54f11dd blob=5c6781748  rc=0  Ran 10 tests | OK
```

Guards rather than discriminators, named so a count never stands in for discrimination: the refusal test, shared-blob naming, file restoration, loud skip, and `a_dirty_tree_still_gets_its_own_arm`.

## Scope

One new script, one new test. Nothing existing is modified.