### PR TITLE
fix(graceful-restart): persist the phase stream so a kill-without-relaunch leaves a trace

### DIFF
--- a/.ws0path
+++ b/.ws0path
@@ -1,1 +1,0 @@
-/var/folders/06/t2flhjld0l34pxbnvd4k74pm0000gn/T/tmp.rcdCw7TOUX

--- a/.ws0path
+++ b/.ws0path
@@ -1,0 +1,1 @@
+/var/folders/06/t2flhjld0l34pxbnvd4k74pm0000gn/T/tmp.rcdCw7TOUX

--- a/src/agent/graceful-restart.sh
+++ b/src/agent/graceful-restart.sh
@@ -29,7 +29,15 @@ STATUS_TTL_S="${GR_STATUS_TTL_S:-900}"         # "running" older than this = wed
 STATUS_REREADS="${GR_STATUS_REREADS:-5}"       # empty-read retries before treating the status as absent
 POLL_S="${GR_POLL_S:-2}"                       # test override
 
-log() { echo "graceful-restart[$RID]: $*"; }
+# The app pipes stdout only into itself, so a kill-without-relaunch left no
+# trace on disk. Same text both ways: main.swift matches phases on its wording.
+GR_LOG="$WS/logs/graceful-restart.log"
+mkdir -p "$WS/logs" 2>/dev/null || true
+log() {
+  local line="graceful-restart[$RID]: $*"
+  echo "$line"
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$line" >> "$GR_LOG" 2>/dev/null || true
+}
 
 # ---- Phase 0: serialize -------------------------------------------------
 
@@ -147,7 +155,7 @@ do_restart() {
     # indistinguishable from a real restart to anyone reading the status.
     exit 5
   fi
-  log "restarting core ($reason)…"
+  log "restarting core ($reason)… — start-cli.sh's own trace continues in logs/restart-attempts.log"
   # The `+` guard keeps an empty array valid under `set -u` on bash 3.2.
   # GR_START_CLI is a test seam: dry-run never reaches this line.
   exec bash "${GR_START_CLI:-$REPO/src/agent/start-cli.sh}" --restart ${RESTART_ARGS[@]+"${RESTART_ARGS[@]}"}

--- a/tests/graceful-restart.test.sh
+++ b/tests/graceful-restart.test.sh
@@ -560,6 +560,36 @@ grep -q "would exec" "$TMP/ws18.out" \
   && say ok "absent status = nothing running = proceed" \
   || say FAIL "absent status now blocks the restart — the empty-read fix over-reached"
 
+echo "19. the phase stream is PERSISTED to logs/graceful-restart.log (the app pipes stdout only into itself)"
+WS19="$TMP/ws19"; mkws "$WS19"
+out="$(GR_WS="$WS19" GR_SYNC_CMD="true" GR_POLL_S=1 bash "$GR" --dry-run 2>&1)"
+rid="$(printf '%s\n' "$out" | sed -n 's/^graceful-restart\[\(grp-[0-9]*-[0-9]*\)\].*/\1/p' | head -1)"
+LOG19="$WS19/logs/graceful-restart.log"
+[ -f "$LOG19" ] \
+  && say ok "log file created under the workspace" \
+  || say FAIL "no $LOG19 — the stream still lives only in the caller's pipe"
+[ -n "$rid" ] && grep -q "graceful-restart\[$rid\]: DRY-RUN — would exec" "$LOG19" 2>/dev/null \
+  && say ok "the decision line landed on disk, scoped to this run's RID ($rid)" \
+  || say FAIL "decision line for rid='$rid' missing from the log"
+grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z graceful-restart\[' "$LOG19" 2>/dev/null \
+  && say ok "persisted lines are UTC-timestamped" \
+  || say FAIL "persisted lines carry no timestamp"
+# stdout is a contract with main.swift's phase matcher: no timestamp may leak into it.
+if printf '%s\n' "$out" | grep -q '^graceful-restart\[' && ! printf '%s\n' "$out" | grep -q '^[0-9]\{4\}-[0-9]\{2\}-'; then
+  say ok "stdout shape unchanged (no timestamp prefix in the app's phase stream)"
+else
+  say FAIL "stdout shape changed — main.swift's restartPhaseMessage matcher may break"
+fi
+n_out="$(printf '%s\n' "$out" | grep -c '^graceful-restart\[')"
+n_log="$(grep -c "graceful-restart\[$rid\]" "$LOG19" 2>/dev/null || echo 0)"
+[ "$n_out" -gt 0 ] && [ "$n_out" = "$n_log" ] \
+  && say ok "every stdout phase line ($n_out) has a disk twin" \
+  || say FAIL "stdout has $n_out phase lines, disk has $n_log — one side is missing a line"
+GR_WS="$WS19" GR_SYNC_CMD="true" GR_POLL_S=1 bash "$GR" --dry-run >/dev/null 2>&1
+grep -q "graceful-restart\[$rid\]" "$LOG19" \
+  && say ok "a later run APPENDS — the earlier run's trace survives" \
+  || say FAIL "the second run truncated the first run's trace"
+
 if [ "$fails" = 0 ]; then
   echo "ALL PASS"
 else


### PR DESCRIPTION
## What changed, and why

`src/agent/graceful-restart.sh`'s `log()` was a bare `echo`. Sutando.app runs the script with stdout piped only into its own phase-notification matcher (`main.swift:restartCore`), so when a menu-bar restart kills the core and the relaunch never comes back — today, 2026-09-03 15:56Z — nothing on disk records what the orchestrator saw or decided. Every `log()` line is now **also** appended, UTC-timestamped and scoped by the run's RID, to `<workspace>/logs/graceful-restart.log`. stdout is byte-for-byte what it was: `main.swift` matches phases on the exact wording.

The exec hand-off line additionally names where the trace continues (`logs/restart-attempts.log`, written by `start-cli.sh`) — that is where today's abort was actually recorded, and nothing pointed at it from the orchestrator side. The root failure mode itself (plain `--restart` aborting **after** `kill-session` fired) is #3816 — deliberately **not** fixed here (single concern).

## Look first
- `src/agent/graceful-restart.sh` — `log()` (+9 lines), the `do_restart` hand-off line.
- `tests/graceful-restart.test.sh` — case 19 (6 assertions).

## What this proves
A kill-without-relaunch is diagnosable from the workspace afterwards: which RID, which gate decision, at what UTC time, and where the trace continues.

## Docs
N/A — `docs/catalog.json` has no canonical entry for the restart orchestrator (its design note lives in the workspace, not `docs/`); `docs/graceful-shutdown.md` covers the sentinel, not this stream.

## Before / after evidence

**Before — parent `4d90b8b9`** (`--dry-run` against a fresh workspace; the flow runs, the decision is printed, and nothing is written under `logs/`):
```
graceful-restart[grp-1788451702-96708]: quiet gate: waiting for a safe kill window (busy = core-status running + fresh ts)…
graceful-restart[grp-1788451702-96708]: running prep (direct invocation — no task-queue handoff)…
graceful-restart[grp-1788451702-96708]: prep READY: {"restart_id":"grp-1788451702-96708",...}
graceful-restart[grp-1788451702-96708]: DRY-RUN — would exec 'start-cli.sh --restart' now (prep-ready). Skipping the actual kill.
rc=5
$ ls $WS/logs
ls: .../logs: No such file or directory
```

**After — HEAD, same invocation, LIVE workspace** (not a fixture; `GR_SYNC_CMD=true` stubs the vault push, and the kill is skipped because a core cannot restart itself — the real kill+relaunch is the owner's menu-bar action):
```
graceful-restart[grp-1788451996-9382]: reaping stale restart lock (age 1009s > 900s, holder grp-1788450190-61932)
graceful-restart[grp-1788451996-9382]: quiet gate: waiting for a safe kill window (busy = core-status running + fresh ts)…
graceful-restart[grp-1788451996-9382]: running prep (direct invocation — no task-queue handoff)…
restart-prep[grp-1788451996-9382]: Phase-1 starting…
restart-prep[grp-1788451996-9382]: checkpoint: 1 non-prep task(s) in queue
restart-prep[grp-1788451996-9382]: READY: synced=true branch=fix/graceful-restart-persist-log dirty=0 queue=1
graceful-restart[grp-1788451996-9382]: prep READY: {"restart_id":"grp-1788451996-9382","ts":1788451997,"synced":true,"branch":"fix/graceful-restart-persist-log","dirty":0,"queue":1}
graceful-restart[grp-1788451996-9382]: DRY-RUN — would exec 'start-cli.sh --restart' now (prep-ready). Skipping the actual kill.
rc=5
$ tail -4 <workspace>/logs/graceful-restart.log
2026-09-03T16:13:16Z graceful-restart[grp-1788451996-9382]: quiet gate: waiting for a safe kill window (busy = core-status running + fresh ts)…
2026-09-03T16:13:16Z graceful-restart[grp-1788451996-9382]: running prep (direct invocation — no task-queue handoff)…
2026-09-03T16:13:17Z graceful-restart[grp-1788451996-9382]: prep READY: {"restart_id":"grp-1788451996-9382","ts":1788451997,"synced":true,"branch":"fix/graceful-restart-persist-log","dirty":0,"queue":1}
2026-09-03T16:13:17Z graceful-restart[grp-1788451996-9382]: DRY-RUN — would exec 'start-cli.sh --restart' now (prep-ready). Skipping the actual kill.
```

## Tests
```
$ bash tests/graceful-restart.test.sh          # HEAD
19. the phase stream is PERSISTED to logs/graceful-restart.log (the app pipes stdout only into itself)
  ok: log file created under the workspace
  ok: the decision line landed on disk, scoped to this run's RID (grp-1788451844-2863)
  ok: persisted lines are UTC-timestamped
  ok: stdout shape unchanged (no timestamp prefix in the app's phase stream)
  ok: every stdout phase line (4) has a disk twin
  ok: a later run APPENDS — the earlier run's trace survives
ALL PASS
rc=0   (70 ok, 0 FAIL)
```
**Mutation — parent script under the new suite** (`git show origin/main:src/agent/graceful-restart.sh` swapped in, suite re-run):
```
23:4. prep FAILURE on a live core → exit 3, NO restart, failed sentinel
27:4b. prep sync FAILURE is diagnosable: nonzero exit vs timeout, with command output
91:  FAIL: no <ws19>/logs/graceful-restart.log — the stream still lives only in the caller's pipe
92:  FAIL: decision line for rid='grp-1788451934-8135' missing from the log
93:  FAIL: persisted lines carry no timestamp
95:  FAIL: stdout has 4 phase lines, disk has 0 — one side is missing a line
97:  FAIL: the second run truncated the first run's trace
98:5 FAILURE(S)
rc=1
```
5 of case 19's 6 assertions go red; the 6th ("stdout shape unchanged") is the negative control and passes on both, as it must.

`bash scripts/review-checks.sh --diff <(git diff origin/main...HEAD)` → hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files (shell-only diff).

## Live path?
Restart/startup path — the witness above is against the live workspace but stops at the dry-run boundary. A real post-restart round trip requires killing this core, which is the owner's action (`docs/codex-core.md`; `--restart` is refused from inside the session, #3458). @sonichi — the next menu-bar restart on this branch is the full witness; the file to read afterwards is `<workspace>/logs/graceful-restart.log`.

## Hardcoded-path check
Added lines scanned: only `$WS/logs/graceful-restart.log` via the resolved workspace; test uses `$TMP`.

Closes nothing on its own; observability half of #3816.

Stand: Echo Act IV Pro
🤖 Generated with [Claude Code](https://claude.com/claude-code)
