### PR TITLE
fix(test): the idle-surface control raced instead of forcing its overlap

### DIFF
--- a/tests/proactive-loop-idle-surface-hash.test.py
+++ b/tests/proactive-loop-idle-surface-hash.test.py
@@ -21,6 +21,7 @@ import pathlib
 import subprocess
 import sys as _sys
 import tempfile
+import time
 
 SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "skills" / "proactive-loop" / "scripts"
 spec = importlib.util.spec_from_file_location("ish", SCRIPTS / "idle-surface-hash.py")
@@ -117,22 +118,30 @@ check("streak matches the same count under concurrency",
 
 # CONTROL: this harness must be ABLE to observe a lost count, or the assertion
 # above is satisfied by a race that never happens. Same shape, no lock.
+
+# A shared wall-clock barrier FORCES the overlap: interpreter startup on a
+# loaded runner can otherwise exceed the window and serialise every process.
 UNLOCKED = r"""
 import json, pathlib, sys, time
-q = pathlib.Path(sys.argv[1])
+q, start_at = pathlib.Path(sys.argv[1]), float(sys.argv[2])
+while time.time() < start_at:
+    time.sleep(0.002)
 doc = json.loads(q.read_text())
 doc["noop_total"] = int(doc.get("noop_total") or 0) + 1
-time.sleep(0.05)
+time.sleep(0.20)
 q.write_text(json.dumps(doc))
 """
 p3 = fresh()
-rcs = run_concurrent([[_sys.executable, "-c", UNLOCKED, str(p3)] for _ in range(N)])
+start_at = time.time() + 3.0
+rcs = run_concurrent([[_sys.executable, "-c", UNLOCKED, str(p3), repr(start_at)]
+                      for _ in range(N)])
 lost = json.loads(p3.read_text())["noop_total"]
 check("CONTROL: the unlocked variant also ran (rc=0 everywhere)", rcs == [0] * N, f"rcs={rcs}")
 check("CONTROL: it incremented at least once — the harness is live, not inert",
       lost >= 1, f"unlocked total={lost}; 0 means no process ran and the check above is vacuous")
 check("CONTROL: and it LOSES counts, so the locked assertion is discriminating",
-      lost < N, f"unlocked total={lost}; equal to {N} means this harness cannot see the bug")
+      lost < N, f"unlocked total={lost}; equal to {N} means the barrier did not "
+                f"overlap the windows and this harness cannot see the bug")
 
 print(f"\nidle-surface-hash: {ran - len(fails)}/{ran} passed")
 if fails:


### PR DESCRIPTION
## This is mine, and it is currently reding other people's PRs

`tests/proactive-loop-idle-surface-hash.test.py` landed in #3810 this morning. It is the **single failing python file** on #3818 — @sonichi's shell-only PR that touches `graceful-restart.sh` and nothing Python:

```
##[notice]1 python test file(s) failed:
  tests/proactive-loop-idle-surface-hash.test.py
```

It passes locally every time, which is exactly why it took someone else's red PR to surface it.

## The flaky half is the CONTROL, not the property

The suite asserts the production writer loses no count under 12 concurrent invocations. To prove that assertion can fail, a control runs the same shape **without** the lock and asserts a count IS lost.

A lost count requires two processes inside one read-modify-write window. The control gave that window 0.05 s and simply started 12 interpreters, hoping they would overlap. On a loaded runner they do not: each completes its read-sleep-write alone, the total comes back 12/12, and the control fires — correctly reporting that *this harness cannot see the bug*, which is a true statement and a useless failure.

## Reproduced deterministically

Staggering the starts is what a loaded runner does:

```
simultaneous (a fast runner)        OLD control total= 1/12 -> PASS   |  NEW total= 1/12 -> PASS
staggered 0.12s (a loaded runner)   OLD control total=12/12 -> FAIL   |  NEW total= 1/12 -> PASS
```

## The fix

Every unlocked process now waits on a **shared wall-clock barrier** before its read, so startup skew is absorbed instead of raced against, and the window widens 0.05 s → 0.20 s for margin. The overlap is forced rather than hoped for.

The locked assertion is untouched — it was never the flaky half, and it does not depend on the processes overlapping (it must equal N whether they interleave or serialise).

## Note on what this does NOT do

It does not weaken the control. A control that cannot observe the bug should fail loudly; the defect was that it could not observe the bug *for a reason unrelated to the code under test*. Distinguishing those two is the whole change.

25/25 locally, three consecutive runs.