### PR TITLE
test(notify-reviewers): the refusal check asserts no SEND, not no subprocess

### DIFF
--- a/tests/sci-notify-reviewers-shorthand-refusal.test.py
+++ b/tests/sci-notify-reviewers-shorthand-refusal.test.py
@@ -112,7 +112,10 @@ class Shorthand(unittest.TestCase):
     def test_an_ask_naming_a_pr_in_shorthand_is_REFUSED_before_sending(self):
         rc, err = self._run("please review #3760")
         self.assertEqual(rc, 7)
-        self.assertEqual(self.calls, [], "refused ask must not reach room_ops")
+        # room_ops calls only. `self.calls` records EVERY subprocess, so a
+        # refusal that resolves config without sending used to fail this.
+        sends = [c for c in self.calls if any("room_ops" in str(a) for a in c)]
+        self.assertEqual(sends, [], "refused ask must not reach room_ops")
         self.assertEqual(self._ledger(), [], "nothing recorded either")
 
     def test_the_refusal_says_what_it_refused_AND_what_would_satisfy_it(self):


### PR DESCRIPTION
## The defect is in my own test, and it is blocking someone else

`tests/sci-notify-reviewers-shorthand-refusal.test.py` (mine, from #3771) reads:

```python
self.assertEqual(self.calls, [], "refused ask must not reach room_ops")
```

The message claims one thing; the assertion checks a strictly wider one. `self.calls` records **every** subprocess call, so the test fails on any change that runs a subprocess on the refusal path — even one that plainly does not send.

## It WAS failing on #3721 — corrected

> **Correction (yixuan-ag2, 2026-09-03):** the heading below read *"It is failing right now, on #3721"*. That was true at `bb492bf53`, but #3721's own main-merge fixed it and #3721 has since merged, so the present-tense claim is no longer accurate. The reproduction is kept because it is what motivated the change; it is now a past observation, not a live failure.

@sonichi's #3721 resolves the per-host roster via `scripts/sutando-config.sh host-label`, which runs before the refusal returns. Cumulative merge onto current main:

```
$ git merge --no-commit --no-ff origin/main    # onto bb492bf53
$ python3 tests/sci-notify-reviewers-shorthand-refusal.test.py
- [['bash', 'scripts/sutando-config.sh', 'host-label']]
+ [] : refused ask must not reach room_ops
FAILED (failures=1)
```

Reading a host label is not sending a message. The change is correct and my proxy was wrong.

## The fix

Filter to room_ops calls — the property the message always named:

```python
sends = [c for c in self.calls if any("room_ops" in str(a) for a in c)]
self.assertEqual(sends, [], "refused ask must not reach room_ops")
```

## Evidence

On `main` alone this is a no-op, because nothing there calls a subprocess on the refusal path — so there is no before/after to show here, and I am saying that rather than implying one:

```
main, before and after:  Ran 13 tests  OK
```

What proves it still discriminates is a mutation — inject a `room_ops` call into the refusal path and the narrowed assertion must still catch it:

```
MUTATED : Ran 13 tests  FAILED (failures=1)
RESTORED: Ran 13 tests  OK
```

And the case it stops failing on is the one above, from #3721's merge.

## Scope

One assertion in one test. No production code, no change to what the test proves.
