### PR TITLE
feat(graceful-restart): hand the live core a drain task before the quiet gate

### DIFF
--- a/src/agent/graceful-restart.sh
+++ b/src/agent/graceful-restart.sh
@@ -31,6 +31,16 @@ POLL_S="${GR_POLL_S:-2}"                       # test override
 
 log() { echo "graceful-restart[$RID]: $*"; }
 
+# Defined BEFORE the EXIT/INT/TERM traps below are armed: bash resolves a
+# function at call time, so cleanup_lock must never name one that is not yet there.
+PREP_TASK="$WS/tasks/task-restart-prep-$RID.txt"
+# The task has done its job once a decision is made; never leave it for the next boot's orphan-check.
+retire_prep_task() {
+  [ -f "$PREP_TASK" ] || return 0
+  mkdir -p "$WS/tasks/archive"
+  mv "$PREP_TASK" "$WS/tasks/archive/" 2>/dev/null || true
+}
+
 # ---- Phase 0: serialize -------------------------------------------------
 
 # Sentinels are per-WORKSPACE and every run clears them, so without a lock two
@@ -141,7 +151,6 @@ busy() {
 
 # Phase 1a: hand the core a drain task. A busy core reads it at its next tool
 # boundary; only a wedged or dead core never does, and .alive covers that case.
-PREP_TASK="$WS/tasks/task-restart-prep-$RID.txt"
 write_prep_task() {
   if [ "$DRY_RUN" = 1 ]; then
     log "DRY-RUN — would write the drain task $PREP_TASK (not written: it would drain a live core)"
@@ -160,13 +169,6 @@ write_prep_task() {
   mv "$tmp" "$PREP_TASK"
   log "drain task written: tasks/$(basename "$PREP_TASK") — waiting for the core to go idle"
 }
-# The task has done its job once a decision is made; never leave it for the next boot's orphan-check.
-retire_prep_task() {
-  [ -f "$PREP_TASK" ] || return 0
-  mkdir -p "$WS/tasks/archive"
-  mv "$PREP_TASK" "$WS/tasks/archive/" 2>/dev/null || true
-}
-
 do_restart() {
   local reason="$1"
   if [ "$DRY_RUN" = 1 ]; then

--- a/src/agent/graceful-restart.sh
+++ b/src/agent/graceful-restart.sh
@@ -81,6 +81,7 @@ printf '%s' "$RID" > "$LOCKDIR/rid"
 # Release only OUR lock. Guarded by the rid so a reaper's lock is never removed.
 RESTART_DECIDED=0
 cleanup_lock() {
+  retire_prep_task
   # Production ends in `exec` so this never runs and retention is structural.
   # A dry-run DOES reach here; retaining would self-block the next real run.
   if [ "$RESTART_DECIDED" = 1 ] && \
@@ -138,6 +139,34 @@ busy() {
   [ "$(( $(date +%s) - ts ))" -le "$STATUS_TTL_S" ]
 }
 
+# Phase 1a: hand the core a drain task. A busy core reads it at its next tool
+# boundary; only a wedged or dead core never does, and .alive covers that case.
+PREP_TASK="$WS/tasks/task-restart-prep-$RID.txt"
+write_prep_task() {
+  if [ "$DRY_RUN" = 1 ]; then
+    log "DRY-RUN — would write the drain task $PREP_TASK (not written: it would drain a live core)"
+    return 0
+  fi
+  mkdir -p "$WS/tasks"
+  # Dot-prefixed staging name: the watcher globs task-*.txt, so it never sees a partial file.
+  local tmp="$WS/tasks/.task-restart-prep-$RID.tmp"
+  {
+    printf 'id: task-restart-prep-%s\n' "$RID"
+    printf 'timestamp: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'source: restart\ninteraction_type: message\nchannel_id: local-restart\n'
+    printf 'user_id: restart-orchestrator\naccess_tier: owner\npriority: urgent\n'
+    printf 'task: RESTART_PREP: %s — a graceful restart is waiting on this core. Finish the step in hand, start no new work, then run `bash scripts/core-status.sh idle`: that opens the kill window (the orchestrator syncs the workspace and relaunches you). Write results/task-restart-prep-%s.txt with one line naming what was in flight, or "nothing". Do NOT run --restart yourself.\n' "$RID" "$RID"
+  } > "$tmp"
+  mv "$tmp" "$PREP_TASK"
+  log "drain task written: tasks/$(basename "$PREP_TASK") — waiting for the core to go idle"
+}
+# The task has done its job once a decision is made; never leave it for the next boot's orphan-check.
+retire_prep_task() {
+  [ -f "$PREP_TASK" ] || return 0
+  mkdir -p "$WS/tasks/archive"
+  mv "$PREP_TASK" "$WS/tasks/archive/" 2>/dev/null || true
+}
+
 do_restart() {
   local reason="$1"
   if [ "$DRY_RUN" = 1 ]; then
@@ -147,6 +176,7 @@ do_restart() {
     # indistinguishable from a real restart to anyone reading the status.
     exit 5
   fi
+  retire_prep_task
   log "restarting core ($reason)…"
   # The `+` guard keeps an empty array valid under `set -u` on bash 3.2.
   # GR_START_CLI is a test seam: dry-run never reaches this line.
@@ -159,6 +189,7 @@ if [ "$(alive_age)" -gt "$STALE_S" ]; then
   DEAD=1
   log "core is DEAD (.alive stale/absent > ${STALE_S}s) — no wait; prep runs best-effort"
 else
+  write_prep_task
   log "quiet gate: waiting for a safe kill window (busy = core-status running + fresh ts)…"
   i=0
   while busy; do
@@ -188,7 +219,7 @@ if ! own_lock; then
 fi
 
 # ---- Phase 2: prep, direct invocation ------------------------------------
-log "running prep (direct invocation — no task-queue handoff)…"
+log "running prep (sync + record, orchestrator-side; the drain task above was the core-side half)…"
 prep_rc=0
 bash "$REPO/src/agent/restart-prep.sh" "$RID" || prep_rc=$?
 

--- a/tests/graceful-restart.test.sh
+++ b/tests/graceful-restart.test.sh
@@ -627,6 +627,27 @@ else
   say FAIL "exit $rc20d and live task(s): $(ls "$WS20d"/tasks/ 2>/dev/null | tr '\n' ' ')"
 fi
 
+echo "20e. everything cleanup_lock calls is DEFINED before the traps that call it are armed"
+# yixuan-ag2 on #3823: retire_prep_task was defined 60 lines after `trap cleanup_lock EXIT`,
+# so a TERM in that window exited 127 (command not found) instead of 143.
+def_line="$(grep -n '^retire_prep_task()' "$GR" | head -1 | cut -d: -f1)"
+trap_line="$(grep -n '^trap cleanup_lock EXIT' "$GR" | head -1 | cut -d: -f1)"
+pt_line="$(grep -n '^PREP_TASK=' "$GR" | head -1 | cut -d: -f1)"
+if [ -n "$def_line" ] && [ -n "$trap_line" ] && [ "$def_line" -lt "$trap_line" ] && [ "$pt_line" -lt "$trap_line" ]; then
+  say ok "retire_prep_task (line $def_line) and PREP_TASK (line $pt_line) precede the EXIT trap (line $trap_line)"
+else
+  say FAIL "ordering: retire_prep_task=$def_line PREP_TASK=$pt_line trap=$trap_line — a TERM before the definition exits 127"
+fi
+# behavioural control: a TERM delivered as early as bash allows still exits 143 and leaves no task behind
+WS20e="$TMP/ws20e"; mkws "$WS20e"
+printf '{"status":"running","step":"x","ts":%s}\n' "$(date +%s)" > "$WS20e/state/core-status.json"
+GR_WS="$WS20e" GR_SYNC_CMD="true" GR_POLL_S=1 bash "$GR" > "$TMP/ws20e.out" 2>&1 &
+gr20e=$!
+sleep 0.3; kill -TERM "$gr20e" 2>/dev/null; wait "$gr20e" 2>/dev/null; rc20e=$?
+[ "$rc20e" = 143 ] && ! grep -q "command not found" "$TMP/ws20e.out" \
+  && say ok "TERM 0.3s in -> exit 143, no 'command not found'" \
+  || say FAIL "early TERM -> exit $rc20e: $(grep -i 'not found' "$TMP/ws20e.out" | head -1)"
+
 if [ "$fails" = 0 ]; then
   echo "ALL PASS"
 else

--- a/tests/graceful-restart.test.sh
+++ b/tests/graceful-restart.test.sh
@@ -94,7 +94,7 @@ echo "$out" | grep -q "prep-ready" && say ok "prep-ready reason" || say FAIL "pr
 [ -f "$WS1/state/restart-ready.json" ] && say ok "ready sentinel written" || say FAIL "ready sentinel written"
 grep -q '"restart_id":"grp-' "$WS1/state/restart-ready.json" 2>/dev/null \
   && say ok "sentinel carries restart_id" || say FAIL "sentinel carries restart_id"
-echo "$out" | grep -q "no task-queue handoff" && say ok "direct invocation logged" || say FAIL "direct invocation logged"
+echo "$out" | grep -q "orchestrator-side" && say ok "orchestrator-side prep logged" || say FAIL "orchestrator-side prep logged"
 
 echo "2. busy core (fresh running status) → orchestrator WAITS, proceeds after idle flip"
 WS2="$TMP/ws2"; mkws "$WS2"
@@ -559,6 +559,73 @@ kill "$k18" 2>/dev/null || true; wait "$k18" 2>/dev/null || true
 grep -q "would exec" "$TMP/ws18.out" \
   && say ok "absent status = nothing running = proceed" \
   || say FAIL "absent status now blocks the restart — the empty-read fix over-reached"
+
+echo "20. a LIVE core is handed a drain TASK before the gate; it is retired before the exec"
+# Owner rule 2026-09-03: "a busy core may never read the task" justifies the .alive
+# fallback, not skipping the task. A real run (stub launcher) so the write is visible.
+WS20="$TMP/ws20"; mkws "$WS20"
+printf '{"status":"running","step":"x","ts":%s}\n' "$(date +%s)" > "$WS20/state/core-status.json"
+stub20="$TMP/stub20-start-cli.sh"
+cat > "$stub20" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$@" > "$STUB_ARGV_OUT"
+STUB
+chmod +x "$stub20"
+# A fake core: stays busy until the drain task appears, keeps a copy, then goes idle.
+( for _ in $(seq 1 40); do
+    f="$(ls "$WS20"/tasks/task-restart-prep-*.txt 2>/dev/null | head -1)"
+    if [ -n "$f" ]; then cp "$f" "$TMP/ws20.task"; break; fi
+    touch "$WS20/state/cores/$HOST.alive"; sleep 0.5
+  done
+  printf '{"status":"idle","ts":%s}\n' "$(date +%s)" > "$WS20/state/core-status.json" ) &
+core20=$!
+STUB_ARGV_OUT="$TMP/ws20.argv" GR_START_CLI="$stub20" GR_WS="$WS20" GR_SYNC_CMD="true" \
+  GR_POLL_S=1 bash "$GR" > "$TMP/ws20.out" 2>&1 || true
+wait "$core20" 2>/dev/null
+rid20="$(sed -n 's/^graceful-restart\[\(grp-[0-9]*-[0-9]*\)\].*/\1/p' "$TMP/ws20.out" | head -1)"
+[ -s "$TMP/ws20.task" ] \
+  && say ok "the core received a drain task while the gate was waiting" \
+  || say FAIL "no drain task reached the core (gate waited on status alone)"
+grep -q "^id: task-restart-prep-$rid20$" "$TMP/ws20.task" 2>/dev/null \
+  && say ok "task id is scoped to this run's RID ($rid20)" \
+  || say FAIL "task id not scoped to $rid20: $(head -1 "$TMP/ws20.task" 2>/dev/null)"
+grep -q "^priority: urgent$" "$TMP/ws20.task" 2>/dev/null && grep -q "^access_tier: owner$" "$TMP/ws20.task" 2>/dev/null \
+  && say ok "urgent + owner-tier, so the queue serves it first with full capability" \
+  || say FAIL "task headers wrong: $(grep -E '^(priority|access_tier):' "$TMP/ws20.task" 2>/dev/null | tr '\n' ' ')"
+grep -q "^task: RESTART_PREP: $rid20" "$TMP/ws20.task" 2>/dev/null && grep -q "task:.*core-status.sh idle" "$TMP/ws20.task" \
+  && say ok "the body tells the core the one action that opens the gate (status idle)" \
+  || say FAIL "task body does not carry the RESTART_PREP contract"
+grep -q "restart" "$TMP/ws20.argv" 2>/dev/null \
+  && say ok "and the restart proceeded once the core went idle" \
+  || say FAIL "the launcher stub was never exec'd"
+[ -f "$WS20/tasks/archive/task-restart-prep-$rid20.txt" ] && [ ! -f "$WS20/tasks/task-restart-prep-$rid20.txt" ] \
+  && say ok "the drain task was retired to tasks/archive/ before the exec (no orphan for the next boot)" \
+  || say FAIL "drain task not retired: live=$(ls "$WS20"/tasks/task-restart-prep-* 2>/dev/null) archive=$(ls "$WS20"/tasks/archive/ 2>/dev/null)"
+
+WS20b="$TMP/ws20b"; mkws "$WS20b"; rm -f "$WS20b/state/cores/$HOST.alive"   # DEAD core
+STUB_ARGV_OUT="$TMP/ws20b.argv" GR_START_CLI="$stub20" GR_WS="$WS20b" GR_SYNC_CMD="true" \
+  GR_POLL_S=1 bash "$GR" > "$TMP/ws20b.out" 2>&1 || true
+[ -z "$(ls "$WS20b"/tasks/task-restart-prep-* "$WS20b"/tasks/archive/task-restart-prep-* 2>/dev/null)" ] \
+  && say ok "CONTROL: a DEAD core gets no drain task (nobody would read it)" \
+  || say FAIL "a drain task was written for a dead core"
+
+WS20c="$TMP/ws20c"; mkws "$WS20c"
+out20c="$(GR_WS="$WS20c" GR_SYNC_CMD="true" GR_POLL_S=1 bash "$GR" --dry-run 2>&1)"
+[ -z "$(ls "$WS20c"/tasks/task-restart-prep-* 2>/dev/null)" ] && echo "$out20c" | grep -q "would write the drain task" \
+  && say ok "CONTROL: a dry run names the task it would write and writes nothing (a rehearsal must not drain a live core)" \
+  || say FAIL "dry run wrote a task or did not say so"
+
+WS20d="$TMP/ws20d"; mkws "$WS20d"
+printf '{"status":"running","step":"x","ts":%s}\n' "$(date +%s)" > "$WS20d/state/core-status.json"
+( sleep 2; printf '{"status":"idle","ts":%s}\n' "$(date +%s)" > "$WS20d/state/core-status.json" ) &
+flip20d=$!
+GR_WS="$WS20d" GR_SYNC_CMD="false" GR_POLL_S=1 bash "$GR" > "$TMP/ws20d.out" 2>&1; rc20d=$?
+wait "$flip20d" 2>/dev/null
+if [ "$rc20d" = 3 ] && [ -z "$(ls "$WS20d"/tasks/task-restart-prep-* 2>/dev/null)" ]; then
+  say ok "prep FAILURE (exit 3) still retires the drain task — the core is not left told to stay idle"
+else
+  say FAIL "exit $rc20d and live task(s): $(ls "$WS20d"/tasks/ 2>/dev/null | tr '\n' ' ')"
+fi
 
 if [ "$fails" = 0 ]; then
   echo "ALL PASS"


### PR DESCRIPTION
## What changed, and why

Owner direction on #3816 (2026-09-03, verbatim): **"'a busy core may never read the task' is not the reason to not write the task."** The 2026-07-27 design had the orchestrator hand the core a prep task; #2334 dropped it on the argument that a busy/wedged core might never read it. That argument is the reason the `.alive` fallback exists — it is not a reason to skip the task. A busy core reads a task at its next tool boundary; only a wedged or dead one never does, and that case was already covered.

`graceful-restart.sh` Phase 1a now writes `tasks/task-restart-prep-<RID>.txt` (urgent, owner tier) when the core is alive, **before** the quiet gate. The body tells the core the one action that opens the gate — finish the step in hand, start nothing new, `core-status.sh idle` — and asks for a one-line result naming what was in flight. Gate, mechanical prep (sync + record) and the `.alive` fallback are unchanged. The task is retired to `tasks/archive/` on every exit path (before the `exec`; from the EXIT trap on 3/4/5), so no boot's orphan-check sees it. Dry run names the task and writes nothing (the app's rehearsal mode must not drain a live core). Staged under a dot-prefixed name so the watcher's `task-*.txt` glob never reads a partial file.

Not in this PR (single concern): the launcher half of #3816 (decide busy *before* `kill-session`; `.alive`-bounded wait instead of 3 s; release the lock on exit-1). Independent of #3818 (log tee) — no stack.

## Look first
`src/agent/graceful-restart.sh` — `write_prep_task` / `retire_prep_task`, the call before the gate, the two retire sites. `tests/graceful-restart.test.sh` — case 20.

## What this proves
A live core is *asked* to drain, cooperatively, and the ask cannot outlive the decision it served.

## Docs
N/A — no `docs/catalog.json` entry for the restart orchestrator (design note lives in the workspace); the task body is self-describing, so the core needs no prompt-file change to act on it.

## Before / after

**Before — `origin/main` script under the new suite** (same fixture: busy core that goes idle only after it sees a task):
```
  FAIL: orchestrator-side prep logged
  FAIL: no drain task reached the core (gate waited on status alone)
  FAIL: task id not scoped to grp-1788453939-54376: 
  FAIL: task headers wrong: 
  FAIL: task body does not carry the RESTART_PREP contract
  FAIL: drain task not retired: live= archive=
  FAIL: dry run wrote a task or did not say so
rc=1   (7 FAIL: every case-20 assertion + case 1's retargeted wording check)
```
**After — HEAD `ffa108fb`:**
```
20. a LIVE core is handed a drain TASK before the gate; it is retired before the exec
  ok: the core received a drain task while the gate was waiting
  ok: task id is scoped to this run's RID (grp-1788453845-49028)
  ok: urgent + owner-tier, so the queue serves it first with full capability
  ok: the body tells the core the one action that opens the gate (status idle)
  ok: and the restart proceeded once the core went idle
  ok: the drain task was retired to tasks/archive/ before the exec (no orphan for the next boot)
  ok: CONTROL: a DEAD core gets no drain task (nobody would read it)
  ok: CONTROL: a dry run names the task it would write and writes nothing (a rehearsal must not drain a live core)
  ok: prep FAILURE (exit 3) still retires the drain task — the core is not left told to stay idle
ALL PASS
rc=0   (73 ok, 0 FAIL)
```
**Live workspace witness** (dry run against the real workspace, sync stubbed — a dry run must not drain this core, which is the point of the control):
```
graceful-restart[grp-1788454000-56542]: DRY-RUN — would write the drain task /Users/wangchi/stando-ui/sutando/workspace/tasks/task-restart-prep-grp-1788454000-56542.txt (not written: it would drain a live core)
graceful-restart[grp-1788454000-56542]: quiet gate: waiting for a safe kill window (busy = core-status running + fresh ts)…
graceful-restart[grp-1788454000-56542]: running prep (sync + record, orchestrator-side; the drain task above was the core-side half)…
graceful-restart[grp-1788454000-56542]: DRY-RUN — would exec 'start-cli.sh --restart' now (prep-ready). Skipping the actual kill.
rc=0
```

## Tests
`bash tests/graceful-restart.test.sh` → ALL PASS (73 ok). `review-checks.sh` → hardcoded-paths + root-artifacts clean; prose-cap N/A (shell-only diff).

## Live path?
Restart path; the real handshake is the next menu-bar restart on this branch — the witness is `tasks/archive/task-restart-prep-<rid>.txt` afterwards, plus the core's one-line result. A core cannot restart itself (#3458), so that run is @sonichi's.

## Hardcoded-path check
Added lines use `$WS/tasks/…` only; test uses `$TMP`.

Stand: Echo Act IV Pro
🤖 Generated with [Claude Code](https://claude.com/claude-code)
