### PR TITLE
fix(start-cli): a plain --restart waits for the core to exit instead of aborting 3s after the kill it already issued

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -515,6 +515,15 @@ case "${1:-}" in
   --restart)       RESTART_REQUESTED=1 ;;
   --force-restart) RESTART_REQUESTED=1; FORCE_RESTART=1 ;;
 esac
+# graceful-restart.sh exec's this script holding its lock; an abort here would
+# otherwise leave that lock to age out (15 min) and defer the owner's next click.
+release_orchestrator_lock() {
+  [ -n "${GR_RID:-}" ] || return 0
+  local ws; ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" || return 0
+  local lock="$ws/state/locks/graceful-restart.lock"
+  [ "$(cat "$lock/rid" 2>/dev/null)" = "$GR_RID" ] && rm -rf "$lock"
+  return 0
+}
 log_restart_attempt() {
   local ws; ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" || return 0
   [ -n "$ws" ] || return 0
@@ -538,17 +547,17 @@ if [ -n "$RESTART_REQUESTED" ]; then
     core_claude_pids | while read -r pid; do
       [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
     done
-    # Graceful window: Claude Code flushes telemetry/state on shutdown and can
-    # take several seconds — longer than the old ~1s (5×0.2s) ceiling that let a
-    # still-dying core slip into the "orphan reuse → exit 0" guard below. Poll ~3s.
-    for _ in $(seq 1 15); do
-      tmux_session_exists || core_claude_running || break
-      sleep 0.2
+    # The kill is already issued, so this wait can only be bounded, never
+    # abandoned: a SessionEnd handoff takes longer than a few seconds.
+    GRACE_S="${SUTANDO_RESTART_GRACE_S:-90}"
+    _ticks=$(( GRACE_S * 5 ))
+    while [ "$_ticks" -gt 0 ] && { tmux_session_exists || core_claude_running; }; do
+      sleep 0.2; _ticks=$(( _ticks - 1 ))
     done
     if tmux_session_exists || core_claude_running; then
       if [ -n "$FORCE_RESTART" ]; then
         # force-restart: the core is wedged; escalate to SIGKILL, then poll ~3s.
-        echo "  core still alive ~3s after SIGTERM — force-restart escalating to SIGKILL" >&2
+        echo "  core still alive ${GRACE_S}s after SIGTERM — force-restart escalating to SIGKILL" >&2
         tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
         core_claude_pids | while read -r pid; do
           [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null || true
@@ -560,10 +569,10 @@ if [ -n "$RESTART_REQUESTED" ]; then
       else
         # plain restart must NOT hammer: the core may be legitimately mid-task.
         # Abort loud and point at force-restart rather than risk killing work.
-        echo "  ⚠ $SESSION core did not stop within ~3s of SIGTERM." >&2
-        echo "    'restart' won't SIGKILL a busy/wedged core — it may be mid-task." >&2
-        echo "    Re-run as: bash $0 --force-restart   (or wait and retry)." >&2
-        log_restart_attempt "abort: core would not stop gracefully (needs --force-restart)"
+        echo "  ⚠ $SESSION core did not stop within ${GRACE_S}s of SIGTERM." >&2
+        echo "    'restart' won't SIGKILL a wedged core — re-run as: bash $0 --force-restart" >&2
+        log_restart_attempt "abort: core would not stop within ${GRACE_S}s (needs --force-restart)"
+        release_orchestrator_lock
         exit 1
       fi
     fi
@@ -573,6 +582,7 @@ if [ -n "$RESTART_REQUESTED" ]; then
       echo "  ⚠ $SESSION core did not die after SIGKILL — aborting force-restart." >&2
       echo "    Investigate the stuck pid; rerun once it's gone." >&2
       log_restart_attempt "abort: core survived SIGKILL"
+      release_orchestrator_lock
       exit 1
     fi
   fi

--- a/src/agent/graceful-restart.sh
+++ b/src/agent/graceful-restart.sh
@@ -158,6 +158,7 @@ do_restart() {
   log "restarting core ($reason)… — start-cli.sh's own trace continues in logs/restart-attempts.log"
   # The `+` guard keeps an empty array valid under `set -u` on bash 3.2.
   # GR_START_CLI is a test seam: dry-run never reaches this line.
+  export GR_RID="$RID"   # lets the launcher release THIS run's lock if it aborts
   exec bash "${GR_START_CLI:-$REPO/src/agent/start-cli.sh}" --restart ${RESTART_ARGS[@]+"${RESTART_ARGS[@]}"}
 }
 

--- a/tests/start-cli-restart-verify.test.py
+++ b/tests/start-cli-restart-verify.test.py
@@ -51,7 +51,10 @@ case "$sub" in
   # killing the session normally kills its core → clear both markers. When
   # $WEDGED is set, model an unresponsive core: the session drops but the
   # `claude` process refuses to die (CORE_MARK stays) — so SIGTERM "doesn't take".
-  kill-session) rm -f "$SESS_MARK"; [ -n "$WEDGED" ] || rm -f "$CORE_MARK"; exit 0 ;;
+  kill-session) rm -f "$SESS_MARK"
+    if [ -n "$WEDGED" ]; then :;
+    elif [ -n "$SLOW_DEATH_S" ]; then ( sleep "$SLOW_DEATH_S"; rm -f "$CORE_MARK" ) & disown;
+    else rm -f "$CORE_MARK"; fi; exit 0 ;;
   *) exit 0 ;;  # start-server/set-option/bind/select-window/new-window/attach
 esac
 """
@@ -82,7 +85,8 @@ exit 0
 """ % FAKEPID
 
 
-def _run(restart: bool, session: bool, core: bool, force: bool = False, wedged: bool = False):
+def _run(restart: bool, session: bool, core: bool, force: bool = False, wedged: bool = False,
+         slow_death_s: float = 0, gr_rid: str = "", lock_rid: str = "", grace_s: str = "2"):
     """Run start-cli.sh in the stub env with the given initial state.
 
     force  → invoke --force-restart instead of --restart.
@@ -117,14 +121,27 @@ def _run(restart: bool, session: bool, core: bool, force: bool = False, wedged: 
             "SUTANDO_TEST_MODE": "1",
             "SUTANDO_WORKSPACE": str(td / "workspace"),
         }
+        # The post-kill wait is bounded by SUTANDO_RESTART_GRACE_S (90s in production);
+        # 2s keeps the wedged cases fast while still exceeding a 1s slow death.
+        env["SUTANDO_RESTART_GRACE_S"] = grace_s
         if wedged:
             env["WEDGED"] = "1"
+        if slow_death_s:
+            env["SLOW_DEATH_S"] = str(slow_death_s)
+        if gr_rid:
+            env["GR_RID"] = gr_rid
+        if lock_rid:
+            lock = td / "workspace" / "state" / "locks" / "graceful-restart.lock"
+            lock.mkdir(parents=True)
+            (lock / "rid").write_text(lock_rid)
         args = ["/bin/bash", str(SCRIPT)]
         if force:
             args.append("--force-restart")
         elif restart:
             args.append("--restart")
         r = subprocess.run(args, env=env, capture_output=True, text=True, timeout=60)
+        lock_left = (td / "workspace" / "state" / "locks" / "graceful-restart.lock").exists()
+        _run.last_lock_left = lock_left
         return r.returncode, (r.stdout + r.stderr)
 
 
@@ -195,6 +212,36 @@ def case_force_restart_wedged_escalates_to_sigkill():
     return fails
 
 
+def case_restart_waits_for_a_slow_death_instead_of_aborting():
+    """(#3816) The kill is already issued when the wait starts, so a core that
+    takes longer than ~3s to exit (SessionEnd handoff) must be waited for, not
+    abandoned: the old 3s abort left a dying core with no relaunch."""
+    # 4s exceeds the old fixed 3s poll (the control fails there) and sits inside a 6s grace.
+    rc, out = _run(restart=True, session=True, core=True, slow_death_s=4, grace_s="6")
+    fails = []
+    if "would not stop" in out or "force-restart" in out:
+        fails.append(f"a 4s slow death (within the grace window) was reported as an abort: out={out!r}")
+    if "kill-complete" not in out and "creating fresh core" not in out and "Killing existing" not in out:
+        fails.append(f"the wait never reached the create path: out={out!r}")
+    return fails
+
+
+def case_abort_releases_the_orchestrators_lock_only_for_its_own_rid():
+    """(#3816) An abort inside the exec'd launcher used to leave graceful-restart's
+    lock on disk for 15 minutes. It is released only when GR_RID matches the
+    lock's rid — a peer's lock is never touched."""
+    fails = []
+    rc, out = _run(restart=True, session=True, core=True, wedged=True, gr_rid="grp-1-1", lock_rid="grp-1-1")
+    if rc == 0:
+        fails.append("wedged core should still abort non-zero")
+    if _run.last_lock_left:
+        fails.append("abort left the orchestrator's own lock on disk")
+    rc, out = _run(restart=True, session=True, core=True, wedged=True, gr_rid="grp-1-1", lock_rid="grp-OTHER")
+    if not _run.last_lock_left:
+        fails.append("CONTROL: abort removed a lock held by a DIFFERENT rid")
+    return fails
+
+
 def _live_log_lines() -> "tuple[int, int]":
     """Line counts of the two logs start-cli.sh appends to in the LIVE workspace."""
     ws = subprocess.run(["bash", str(REPO / "scripts" / "sutando-config.sh"), "workspace"],
@@ -225,6 +272,8 @@ def main() -> int:
         ("restart-does-not-reuse-orphan", case_restart_does_not_reuse_orphan),
         ("restart-wedged-aborts-not-kills", case_restart_wedged_aborts_not_kills),
         ("force-restart-wedged-escalates-to-sigkill", case_force_restart_wedged_escalates_to_sigkill),
+        ("slow-death waits", case_restart_waits_for_a_slow_death_instead_of_aborting),
+        ("abort releases own lock", case_abort_releases_the_orchestrators_lock_only_for_its_own_rid),
         ("run-does-not-touch-the-live-workspace", case_run_does_not_touch_the_live_workspace),
     ]
     all_failures = []


### PR DESCRIPTION
## What changed, and why

Launcher half of #3816. `start-cli.sh --restart` issued `tmux kill-session` + SIGTERM, polled **3 s**, and if the core was still alive **aborted exit 1** ("may be mid-task, won't SIGKILL"). That judgement sits *after* the point of no return — the kill has already fired — so the abort preserves nothing and guarantees no relaunch. A core running its SessionEnd handoff (`session-handoff.sh` → `health-check.py`) takes longer than 3 s to exit; that is exactly what stranded the core on 2026-09-03 15:56Z (`restart-attempts.log`: `begin` 15:56:30Z → `abort: core would not stop gracefully` 15:56:34Z; `session-state.md` stamped 15:56:36Z).

- The post-kill wait is now bounded by `SUTANDO_RESTART_GRACE_S` (default 90 s — the same liveness horizon `graceful-restart.sh` uses for `.alive`) and aborts only past it. `--force-restart`'s SIGKILL escalation is unchanged.
- Both abort paths call `release_orchestrator_lock`, which removes `state/locks/graceful-restart.lock` **only when `GR_RID` matches the lock's rid**; `graceful-restart.sh` exports `GR_RID` before its `exec`. An aborted launcher no longer leaves the orchestrator's lock to age out over 15 min (today a second click would have *deferred* on a dead core).

Not here (own PRs): the cooperative drain task (#3823, approved); the "decide busy before the kill" gate for *direct* `start-cli --restart` callers — `graceful-restart.sh` already gates the menu-bar path, and duplicating `busy()` into the launcher would be a second copy of one policy.

## Look first
`src/agent/claude/cli/start-cli.sh` — the wait loop replacing the `seq 1 15` poll, `release_orchestrator_lock`, the two abort sites. `src/agent/graceful-restart.sh` — one `export`. `tests/start-cli-restart-verify.test.py` — `SLOW_DEATH_S` stub mode, two cases.

## Docs
N/A — `docs/catalog.json` has no entry for the launcher's restart semantics; the behaviour is documented at the code and in #3816.

## Before / after (same harness, script swapped)

**Before — `origin/main` script under the new suite:**
```
  ✗ case slow-death waits                 (4s slow death, 6s grace -> abort 'would not stop', no relaunch)
  ✗ case abort releases own lock          (lock rid == GR_RID left on disk after the abort)
2 failure(s)
```
**After — HEAD:**
```
  ✓ case fresh-start-core-down-exits-nonzero   ✓ case restart-core-down-exits-nonzero
  ✓ case non-restart-reuses-orphan-exits-zero  ✓ case restart-does-not-reuse-orphan
  ✓ case restart-wedged-aborts-not-kills       ✓ case force-restart-wedged-escalates-to-sigkill
  ✓ case slow-death waits                      ✓ case abort releases own lock
  ✓ case run-does-not-touch-the-live-workspace
start-cli.sh --restart verifies liveness and never false-succeeds.
```
The lock case carries its own control: a lock held by a *different* rid is left in place. `graceful-restart.sh --dry-run` against a fixture still reaches `would exec 'start-cli.sh --restart'` (the export sits on the exec path only). `review-checks.sh` → hardcoded-paths + root-artifacts clean; prose-cap N/A (no `.py` in the diff besides the test).

## Live path?
Restart path. The witness is the next menu-bar restart: `logs/restart-attempts.log` should show `kill-complete; creating fresh core` after a wait longer than 3 s instead of `abort: core would not stop gracefully`. A core cannot restart itself (#3458) — that run is @sonichi's.

## Hardcoded-path check
Added lines resolve the workspace via `scripts/sutando-config.sh`; the test uses its temp dir.

Stand: Echo Act IV Pro
🤖 Generated with [Claude Code](https://claude.com/claude-code)
