### PR TITLE
feat(merge-gate): an approval is stale when the BASE moves under the PR's files

### DIFF
--- a/scripts/approval-covers-base.py
+++ b/scripts/approval-covers-base.py
@@ -23,6 +23,17 @@ def gh(args: list[str]) -> object:
     return json.loads(r.stdout) if r.stdout.strip() else None
 
 
+def refresh_base(repo_dir: str, remote: str, branch: str) -> bool:
+    """True when `remote/branch` is now up to date.
+
+    Fails CLOSED: the API calls here already raise on failure, and a fetch that
+    fails silently is the one error that makes the gate answer "covered".
+    """
+    r = subprocess.run(["git", "-C", repo_dir, "fetch", remote, branch, "-q"],
+                       capture_output=True, text=True)
+    return r.returncode == 0
+
+
 def base_touched_since(repo_dir: str, base_ref: str, since: str,
                        files: list[str]) -> list[str]:
     """Files in `files` that `base_ref` changed after `since`.
@@ -47,6 +58,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--repo", required=True)
     ap.add_argument("--repo-dir", default=".")
     ap.add_argument("--remote", default="origin")
+    ap.add_argument("--no-fetch", action="store_true",
+                    help="skip the base refresh; you are asserting it is current")
     a = ap.parse_args(argv)
 
     pr = gh(["pr", "view", str(a.pr), "--repo", a.repo, "--json",
@@ -56,8 +69,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     files = [f["path"] for f in pr["files"]]
     base = f"{a.remote}/{pr['baseRefName']}"
-    subprocess.run(["git", "-C", a.repo_dir, "fetch", a.remote,
-                    pr["baseRefName"], "-q"], check=False)
+    if not a.no_fetch and not refresh_base(a.repo_dir, a.remote, pr["baseRefName"]):
+        print(f"REFUSING: could not refresh {base}. A stale base has no commits since "
+              f"any approval, so every approval would read as covering — the answer "
+              f"this gate exists to distrust. Fetch and retry, or pass --no-fetch if "
+              f"you have already refreshed it.", file=sys.stderr)
+        return 3
 
     reviews = gh(["api", f"repos/{a.repo}/pulls/{a.pr}/reviews", "--paginate"])
     latest: dict = {}

--- a/scripts/approval-covers-base.py
+++ b/scripts/approval-covers-base.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Does each approval cover the tree that would actually merge?
+
+An approval is normally checked against the PR head. That misses the case where
+the BASE moved under the very files the PR edits: the PR's own commits are
+unchanged, the head may only be a base merge, and the approval can even be
+re-stamped onto it — yet nobody has read the combination that will land.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+QUALIFYING = ("write", "admin", "maintain")
+
+
+def gh(args: list[str]) -> object:
+    r = subprocess.run(["gh"] + args, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SystemExit(f"gh failed: {' '.join(args[:3])}: {r.stderr.strip()[:200]}")
+    return json.loads(r.stdout) if r.stdout.strip() else None
+
+
+def base_touched_since(repo_dir: str, base_ref: str, since: str,
+                       files: list[str]) -> list[str]:
+    """Files in `files` that `base_ref` changed after `since`.
+
+    Time, not commit_id: a re-stamped review keeps its submitted_at but points at
+    a head nobody re-read, so commit_id cannot answer this and timestamps can.
+    """
+    if not files:
+        return []
+    out = subprocess.run(
+        ["git", "-C", repo_dir, "log", f"--since={since}", "--name-only",
+         "--pretty=format:", base_ref, "--"] + files,
+        capture_output=True, text=True)
+    if out.returncode != 0:
+        raise SystemExit(f"git log failed: {out.stderr.strip()[:200]}")
+    return sorted({ln.strip() for ln in out.stdout.splitlines() if ln.strip()})
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("pr", type=int)
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--repo-dir", default=".")
+    ap.add_argument("--remote", default="origin")
+    a = ap.parse_args(argv)
+
+    pr = gh(["pr", "view", str(a.pr), "--repo", a.repo, "--json",
+             "baseRefName,files,state"])
+    if pr["state"] != "OPEN":
+        print(f"#{a.pr} is {pr['state']} — nothing to gate")
+        return 0
+    files = [f["path"] for f in pr["files"]]
+    base = f"{a.remote}/{pr['baseRefName']}"
+    subprocess.run(["git", "-C", a.repo_dir, "fetch", a.remote,
+                    pr["baseRefName"], "-q"], check=False)
+
+    reviews = gh(["api", f"repos/{a.repo}/pulls/{a.pr}/reviews", "--paginate"])
+    latest: dict = {}
+    for r in reviews or []:
+        login = (r.get("user") or {}).get("login")
+        if login and r.get("state") in ("APPROVED", "CHANGES_REQUESTED"):
+            latest[login] = r
+
+    covered = uncovered = 0
+    print(f"#{a.pr} base={base}  files={len(files)}")
+    for login, r in sorted(latest.items()):
+        if r["state"] != "APPROVED":
+            print(f"  {login:20s} {r['state']} — not an approval")
+            continue
+        perm = (gh(["api", f"repos/{a.repo}/collaborators/{login}/permission"])
+                or {}).get("permission", "?")
+        if perm not in QUALIFYING:
+            print(f"  {login:20s} APPROVED perm={perm} — does not count toward the gate")
+            continue
+        moved = base_touched_since(a.repo_dir, base, r["submitted_at"], files)
+        if moved:
+            uncovered += 1
+            print(f"  {login:20s} APPROVED {r['submitted_at']} perm={perm}")
+            print(f"      UNCOVERED — base moved these PR files since: {', '.join(moved)}")
+        else:
+            covered += 1
+            print(f"  {login:20s} APPROVED {r['submitted_at']} perm={perm}  covers the tree")
+
+    print(f"\nqualifying approvals covering the merge tree: {covered}"
+          f"   uncovered: {uncovered}")
+    if uncovered:
+        print("NOT READY: an approval that predates a base change to this PR's own "
+              "files has not read the combination that would land.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/approval-covers-base.test.py
+++ b/tests/approval-covers-base.test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""The gate must fire when the BASE moves under a PR's own files after approval.
+
+Built against a labeled real case (#3823): two approvals predated #3818's merge
+into the same two files, one re-approval followed it, and only that one covered
+the tree that landed. Driven here on a synthetic repo so it needs no network.
+"""
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("acb", ROOT / "scripts" / "approval-covers-base.py")
+acb = importlib.util.module_from_spec(spec); spec.loader.exec_module(acb)
+
+fails, ran = [], 0
+def check(name, cond, detail=""):
+    global ran; ran += 1
+    print(f"  {'ok  ' if cond else 'FAIL'}  {name}" + (f"   {detail}" if detail and not cond else ""))
+    if not cond: fails.append(name)
+
+def git(d, *a, when=None):
+    # `--date=` sets the AUTHOR date; `git log --since` filters on the COMMITTER
+    # date, so a fixture that sets only the former is filtered by wall clock.
+    import os
+    env = dict(os.environ)
+    if when:
+        env["GIT_COMMITTER_DATE"] = when
+        env["GIT_AUTHOR_DATE"] = when
+    r = subprocess.run(["git", "-C", d, *a], capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        raise SystemExit(f"git {' '.join(a)}: {r.stderr[:200]}")
+    return r.stdout.strip()
+
+print("approval-covers-base")
+with tempfile.TemporaryDirectory() as d:
+    git(d, "init", "-q", "-b", "main")
+    git(d, "config", "user.email", "t@t.t"); git(d, "config", "user.name", "t")
+    (pathlib.Path(d) / "shared.sh").write_text("v1\n")
+    (pathlib.Path(d) / "other.sh").write_text("v1\n")
+    git(d, "add", "shared.sh", "other.sh")
+    # Dates are the discriminator, so they are set explicitly, not by wall clock.
+    git(d, "commit", "-q", "-m", "base", when="2026-09-03T16:00:00Z")
+    T_EARLY = "2026-09-03T16:30:00Z"
+    (pathlib.Path(d) / "shared.sh").write_text("v2\n")
+    git(d, "add", "shared.sh")
+    git(d, "commit", "-q", "-m", "base moves shared.sh", when="2026-09-03T17:00:00Z")
+    T_LATE = "2026-09-03T17:30:00Z"
+
+    PR_FILES = ["shared.sh"]
+    early = acb.base_touched_since(d, "main", T_EARLY, PR_FILES)
+    late = acb.base_touched_since(d, "main", T_LATE, PR_FILES)
+    check("an approval BEFORE the base change is UNCOVERED", early == ["shared.sh"], f"got {early}")
+    check("an approval AFTER the base change is COVERED", late == [], f"got {late}")
+
+    # The property that makes it a gate and not a mood: a base change to a file
+    # the PR does NOT touch must not invalidate anybody's approval.
+    untouched = acb.base_touched_since(d, "main", T_EARLY, ["other.sh"])
+    check("a base change to an UNRELATED file does not fire", untouched == [], f"got {untouched}")
+    check("no files -> no claim", acb.base_touched_since(d, "main", T_EARLY, []) == [])
+
+# Non-OPEN returns early ON PURPOSE: once merged, the PR's own merge commit is
+# on the base and would match every approval, masking the covering one.
+src = (ROOT / "scripts" / "approval-covers-base.py").read_text()
+check("non-OPEN PRs are gated out before any base comparison",
+      'if pr["state"] != "OPEN"' in src)
+check("time-based, not commit_id: a re-stamped review keeps submitted_at",
+      "commit_id" not in src.split('"""')[2])
+
+print(f"\napproval-covers-base: {ran - len(fails)}/{ran} passed")
+if fails:
+    print("FAILED: " + ", ".join(fails)); raise SystemExit(1)
+print("all passed")

--- a/tests/approval-covers-base.test.py
+++ b/tests/approval-covers-base.test.py
@@ -61,6 +61,21 @@ with tempfile.TemporaryDirectory() as d:
     check("a base change to an UNRELATED file does not fire", untouched == [], f"got {untouched}")
     check("no files -> no claim", acb.base_touched_since(d, "main", T_EARLY, []) == [])
 
+# The fetch is the one call that fails toward "covered": a stale base has no
+# commits since any approval, so every row reads as covering.
+with tempfile.TemporaryDirectory() as d:
+    git(d, "init", "-q", "-b", "main")
+    ok = acb.refresh_base(d, "origin", "main")
+    check("a fetch against a MISSING remote returns False (fails closed)", ok is False,
+          f"got {ok!r} — a failed refresh must not read as a successful one")
+
+src_main = (ROOT / "scripts" / "approval-covers-base.py").read_text()
+check("main REFUSES on a failed refresh rather than comparing a stale base",
+      "REFUSING: could not refresh" in src_main and "return 3" in src_main)
+check("the refusal is reachable — main calls refresh_base",
+      "refresh_base(a.repo_dir" in src_main)
+check("check=False is gone from the fetch path", "check=False" not in src_main)
+
 # Non-OPEN returns early ON PURPOSE: once merged, the PR's own merge commit is
 # on the base and would match every approval, masking the covering one.
 src = (ROOT / "scripts" / "approval-covers-base.py").read_text()

--- a/tests/approval-covers-base.test.py
+++ b/tests/approval-covers-base.test.py
@@ -84,6 +84,81 @@ check("non-OPEN PRs are gated out before any base comparison",
 check("time-based, not commit_id: a re-stamped review keeps submitted_at",
       "commit_id" not in src.split('"""')[2])
 
+
+# --- main(), driven in-process: a subprocess run is invisible to coverage, and
+# these branches are the ones a caller actually reaches.
+import contextlib
+import io
+
+def drive(argv, *, pr, reviews, perms, refresh=True, touched=None):
+    """Run main(argv) with the network stubbed; returns (rc, stdout+stderr)."""
+    def fake_gh(args):
+        if args[0] == "pr":
+            return pr
+        if "/reviews" in args[1]:
+            return reviews
+        if "/permission" in args[1]:
+            return {"permission": perms}
+        raise AssertionError(f"unstubbed gh call: {args}")
+    real = (acb.gh, acb.refresh_base, acb.base_touched_since)
+    acb.gh = fake_gh
+    acb.refresh_base = lambda *a, **k: refresh
+    if touched is not None:
+        acb.base_touched_since = lambda *a, **k: touched
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = acb.main(argv)
+    finally:
+        acb.gh, acb.refresh_base, acb.base_touched_since = real
+    return rc, out.getvalue() + err.getvalue()
+
+ARGV = ["1", "--repo", "o/r"]
+APPROVED = [{"user": {"login": "alice"}, "state": "APPROVED",
+             "submitted_at": "2026-09-03T10:00:00Z"}]
+OPEN_PR = {"state": "OPEN", "baseRefName": "main", "files": [{"path": "a.py"}]}
+
+rc, txt = drive(ARGV, pr={"state": "MERGED", "baseRefName": "main", "files": []},
+                reviews=[], perms="write")
+check("main: a MERGED PR is gated out with rc 0", rc == 0 and "nothing to gate" in txt, txt)
+
+rc, txt = drive(ARGV, pr=OPEN_PR, reviews=APPROVED, perms="write", refresh=False)
+check("main: a FAILED refresh refuses with rc 3", rc == 3 and "REFUSING" in txt, txt)
+
+rc, txt = drive(ARGV, pr=OPEN_PR, reviews=APPROVED, perms="write", touched=[])
+check("main: an approval covering the tree exits 0", rc == 0 and "covers the tree" in txt, txt)
+
+rc, txt = drive(ARGV, pr=OPEN_PR, reviews=APPROVED, perms="write", touched=["a.py"])
+check("main: an UNCOVERED approval exits 1 and says NOT READY",
+      rc == 1 and "UNCOVERED" in txt and "NOT READY" in txt, txt)
+
+rc, txt = drive(ARGV, pr=OPEN_PR, reviews=APPROVED, perms="read", touched=["a.py"])
+check("main: a read-tier approval does not count toward the gate",
+      rc == 0 and "does not count" in txt, txt)
+
+rc, txt = drive(ARGV, pr=OPEN_PR,
+                reviews=[{"user": {"login": "bob"}, "state": "CHANGES_REQUESTED",
+                          "submitted_at": "2026-09-03T10:00:00Z"}],
+                perms="write", touched=["a.py"])
+check("main: a CHANGES_REQUESTED review is reported, not counted as an approval",
+      rc == 0 and "not an approval" in txt, txt)
+
+
+# --- the two IO helpers' failure paths, which the stubs above deliberately skip
+def raises_exit(fn, *a):
+    try:
+        fn(*a); return False
+    except SystemExit:
+        return True
+
+check("gh() RAISES on a failed call — it must not return a silent empty result",
+      raises_exit(acb.gh, ["--no-such-flag-here"]))
+
+with tempfile.TemporaryDirectory() as d:
+    subprocess.run(["git", "-C", d, "init", "-q", "-b", "main"], check=True)
+    check("base_touched_since RAISES when git log fails, rather than reporting no movement",
+          raises_exit(acb.base_touched_since, d, "no/such/ref", "2026-01-01T00:00:00Z", ["a.py"]))
+
 print(f"\napproval-covers-base: {ran - len(fails)}/{ran} passed")
 if fails:
     print("FAILED: " + ", ".join(fails)); raise SystemExit(1)


### PR DESCRIPTION
Every merge gate I have checks approvals against the **PR head**. That misses a case that happened on this repo today.

## The case, from a real PR

@yixuan-ag2 caught it on #3823 and told me before I hit it myself. #3823 showed 2 approvals, CLEAN, 0 failing, 0 running — and was still one at-head approval short:

```
bassilkhilo-ag2  APPROVED 16:57:00Z
yixuan-ag2       APPROVED 16:59:02Z
   4b72d77eb  #3818 merges -> src/agent/graceful-restart.sh, tests/graceful-restart.test.sh
yixuan-ag2       APPROVED 17:16:11Z   <- the only approval covering the tree that merged
```

#3818 landed changes into **the same two files #3823 edits**. The two earlier approvals were against a base that no longer existed. Nothing in the usual signals says so: the PR's own commits were unchanged, the head was a base merge, and `commit_id` was not re-stamped — every cheap check reads "stale in sha only".

## Why the existing checks cannot see it

- `mergeStateStatus` is `CLEAN` — the merge is *possible*, which is a different question from whether anyone read it.
- `reviewDecision` is `APPROVED` — it counts approvals, not what they covered.
- approval-time vs head-commit-time passes, because a base merge produces a *newer* head that the approval may still postdate.

## What this adds

`scripts/approval-covers-base.py <pr> --repo <owner/repo>` — for each qualifying approval, does the base branch have commits touching **this PR's files** since that approval was submitted?

```
$ python3 scripts/approval-covers-base.py 3814 --repo sonichi/sutando
#3814 base=origin/main  files=2
  yixuan-ag2           APPROVED 2026-09-03T15:49:27Z perm=write  covers the tree

qualifying approvals covering the merge tree: 1   uncovered: 0
```

Two deliberate choices, both from the measurement:

- **Time-based, not `commit_id`.** A re-stamped review keeps its `submitted_at` while pointing at a head nobody re-read, so `commit_id` cannot answer this — and on #3823 it was not re-stamped at all.
- **Non-OPEN PRs return before any comparison.** Once merged, the PR's *own* merge commit is on the base and matches every approval, so every row reads UNCOVERED — including the one that genuinely covered. I hit exactly that while validating against #3823 and it produced three false positives before I bounded the window.

## Tests

`tests/approval-covers-base.test.py` — 6 checks on a synthetic repo, no network:

```
ok  an approval BEFORE the base change is UNCOVERED
ok  an approval AFTER the base change is COVERED
ok  a base change to an UNRELATED file does not fire
ok  no files -> no claim
ok  non-OPEN PRs are gated out before any base comparison
ok  time-based, not commit_id: a re-stamped review keeps submitted_at
```

The third is the one that makes it a gate rather than a mood — a base change to a file the PR does not touch must not invalidate anybody's approval.

**The fixture was wrong first, and the test caught it.** Two cases failed because `git commit --date=` sets the *author* date while `git log --since` filters on the *committer* date, so the synthetic timestamps never applied. Committer date is the correct semantics here (when the change landed on the base), so the fix was in the fixture.

## Scope

Read-only. No CI wiring in this PR — it is a script plus its test, so it can be adopted at whatever gate its reviewers think right rather than being imposed on every PR by the same change that introduces it.

Credit: @yixuan-ag2 identified the failure mode and the #3823 instance.