### PR TITLE
fix(room-ops): mention falls back to the room when the directory cannot resolve

### DIFF
--- a/skills/agent-room-ops/mention.py
+++ b/skills/agent-room-ops/mention.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import os
 
 from _gateway import gate_allows, load_gate, gateway, http_json, degrade_reason, HTTPError, URLError
-from resolve import resolve_user
+from resolve import resolve_user, match_member
 import receipt as _receipt
 from relations import RelationError, relation_fields
 
@@ -35,6 +35,27 @@ def build_body(mxid: str, message: str) -> str:
     """
     message = (message or "").strip()
     return f"{mxid} — {message}" if message else mxid
+
+
+def _resolve_from_room(handle: str, room_id: str, agent_mxid: str | None) -> "dict | None":
+    """Second chance for `handle` against the target room's membership.
+
+    None when the member list itself could not be read, so the caller keeps the
+    directory's own reason rather than reporting a membership miss that never
+    happened. Imported lazily: `members` reaches the network, and the directory
+    path must not pay for it.
+    """
+    try:
+        from members import room_members
+    except ImportError:
+        return None
+    got = room_members(room_id, agent_mxid)
+    if not got.get("ok"):
+        return None
+    ids = [m if isinstance(m, str) else (m.get("user_id") or m.get("id"))
+           for m in got.get("members") or []]
+    hit = match_member(handle, [i for i in ids if i])
+    return hit if hit.get("ok") or hit.get("candidates") else None
 
 
 def mention(handle: str, message: str, room_id: str, agent_mxid: str | None = None,
@@ -60,6 +81,10 @@ def mention(handle: str, message: str, room_id: str, agent_mxid: str | None = No
         return _result(False, room_id=room_id, reason=str(e))
 
     res = resolve_user(handle, agents=agents)
+    if not res.get("ok") and not res.get("candidates"):
+        # /v1/agents lists only this account's own agents, so a peer agent in
+        # the room resolves nowhere and the mention would be unreachable.
+        res = _resolve_from_room(handle, room_id, agent_mxid) or res
     if not res.get("ok"):
         return _result(False, room_id=room_id, candidates=res.get("candidates"),
                        reason=res.get("reason") or "could not resolve handle")

--- a/skills/agent-room-ops/resolve.py
+++ b/skills/agent-room-ops/resolve.py
@@ -73,6 +73,17 @@ def match_agent(query: str, agents: list) -> dict:
     return {"ok": False, "mxid": None, "candidates": [], "reason": f"no agent matches {query!r}"}
 
 
+def match_member(query: str, member_mxids: list) -> dict:
+    """Resolve `query` against a room's MEMBER mxids, same ranking as match_agent.
+
+    Members carry no label, so only the localpart tiers apply. Scoping to one
+    room is what makes this safe to fall back to: a handle can only resolve to
+    someone already in the room being posted to.
+    """
+    agents = [{"id": m} for m in (member_mxids or []) if m]
+    return match_agent(query, agents)
+
+
 def list_agents() -> dict:
     """GET /v1/agents → {"ok", "agents": [...], "reason"}. Graceful on any failure."""
     base, headers = gateway()

--- a/tests/agent-room-ops-mention-room-fallback.test.py
+++ b/tests/agent-room-ops-mention-room-fallback.test.py
@@ -118,6 +118,17 @@ class TestMentionFallback(unittest.TestCase):
         self.assertIn("no agent matches", got["reason"])
         self.assertEqual(self.posted, [])
 
+    def test_an_unimportable_members_module_keeps_the_directory_reason(self):
+        """`members` reaches the network, so it is imported lazily inside the
+        fallback — and a lazy import can fail. That must read as "cannot answer",
+        never as "the handle is not in the room"."""
+        with mock.patch.dict(sys.modules, {"members": None}):
+            got = self.M.mention("sutando-sonichi", "ping", "!r:ag2.space", "@me:ag2.space",
+                                 agents=[])
+        self.assertFalse(got["ok"])
+        self.assertIn("no agent matches", got["reason"])
+        self.assertEqual(self.posted, [])
+
     def test_a_room_miss_reports_and_posts_nothing(self):
         with self._members(["@chi:ag2.space"]):
             got = self.M.mention("sutando-rui", "ping", "!r:ag2.space", "@me:ag2.space",

--- a/tests/agent-room-ops-mention-room-fallback.test.py
+++ b/tests/agent-room-ops-mention-room-fallback.test.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""`mention` must reach a peer agent that the /v1/agents directory does not list.
+
+Measured live 2026-09-03: `resolve_user('sutando-sonichi')` returns
+`no agent matches`, while `@sutando-sonichi:ag2.space` IS a member of the room
+being posted to. So the correct tool for an @-mention could not mention the
+peers most worth mentioning, and callers fell back to `say`, which sends no
+`mentions` and pings nobody.
+"""
+import importlib.util
+import os
+import sys
+import unittest
+from unittest import mock
+
+SKILL = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "skills", "agent-room-ops")
+sys.path.insert(0, SKILL)
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(SKILL, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestMatchMember(unittest.TestCase):
+    def setUp(self):
+        self.R = _load("resolve")
+
+    def test_exact_localpart_resolves(self):
+        got = self.R.match_member("sutando-sonichi",
+                                  ["@sutando-sonichi:ag2.space", "@chi:ag2.space"])
+        self.assertTrue(got["ok"])
+        self.assertEqual(got["mxid"], "@sutando-sonichi:ag2.space")
+
+    def test_substring_resolves_when_unique(self):
+        got = self.R.match_member("sonichi", ["@sutando-sonichi:ag2.space", "@chi:ag2.space"])
+        self.assertEqual(got["mxid"], "@sutando-sonichi:ag2.space")
+
+    def test_two_members_matching_is_ambiguous_not_a_guess(self):
+        got = self.R.match_member(
+            "sutando", ["@sutando-rui:ag2.space", "@sutando-sonichi:ag2.space"])
+        self.assertFalse(got["ok"])
+        self.assertEqual(len(got["candidates"]), 2)
+
+    def test_a_non_member_does_not_resolve(self):
+        got = self.R.match_member("sutando-rui", ["@sutando-sonichi:ag2.space"])
+        self.assertFalse(got["ok"])
+
+    def test_empty_membership_is_a_miss_not_a_crash(self):
+        self.assertFalse(self.R.match_member("anyone", [])["ok"])
+        self.assertFalse(self.R.match_member("anyone", None)["ok"])
+
+
+class TestMentionFallback(unittest.TestCase):
+    """The fallback is exercised through `mention`, since the ORDER is the
+    contract: directory first, room only on an unambiguous miss."""
+
+    def setUp(self):
+        self.M = _load("mention")
+        self.posted = []
+
+        def fake_http_json(method, url, headers, payload):
+            self.posted.append(payload)
+            return 200, {"ok": True, "event_id": "$evt"}
+
+        self.M.http_json = fake_http_json
+        self.M.gateway = lambda: ("https://relay", {})
+        self.M.gate_allows = lambda *a, **k: True
+        self.M.load_gate = lambda *a, **k: {}
+
+    def _members(self, ids, ok=True):
+        mod = type(sys)("members")
+        mod.room_members = lambda room_id, agent_mxid=None: {
+            "ok": ok, "members": list(ids), "reason": None}
+        return mock.patch.dict(sys.modules, {"members": mod})
+
+    def test_directory_miss_resolves_from_the_room(self):
+        with self._members(["@sutando-sonichi:ag2.space", "@chi:ag2.space"]):
+            got = self.M.mention("sutando-sonichi", "ping", "!r:ag2.space",
+                                 "@me:ag2.space", agents=[])
+        self.assertTrue(got["ok"], got)
+        self.assertEqual(got["mxid"], "@sutando-sonichi:ag2.space")
+        self.assertEqual(self.posted[0]["mentions"], ["@sutando-sonichi:ag2.space"])
+        self.assertTrue(self.posted[0]["body"].startswith("@sutando-sonichi:ag2.space"))
+
+    def test_the_directory_still_wins_when_it_can_answer(self):
+        """The room must not override a directory hit — otherwise a same-named
+        room member would silently take a resolved agent's place."""
+        with self._members(["@sutando-sonichi:other.server"]):
+            got = self.M.mention("sutando-sonichi", "ping", "!r:ag2.space", "@me:ag2.space",
+                                 agents=[{"id": "@sutando-sonichi:ag2.space"}])
+        self.assertEqual(got["mxid"], "@sutando-sonichi:ag2.space")
+
+    def test_an_ambiguous_directory_answer_is_not_widened(self):
+        """Ambiguity means too many, so consulting a second source can only turn
+        a refusal into a guess. It must stay a refusal."""
+        agents = [{"id": "@sutando-a:ag2.space"}, {"id": "@sutando-b:ag2.space"}]
+        with self._members(["@sutando-a:ag2.space"]):
+            got = self.M.mention("sutando", "ping", "!r:ag2.space", "@me:ag2.space",
+                                 agents=agents)
+        self.assertFalse(got["ok"])
+        self.assertEqual(len(got["candidates"]), 2)
+        self.assertEqual(self.posted, [])
+
+    def test_an_unreadable_member_list_keeps_the_directory_reason(self):
+        """A membership read that failed is not evidence of non-membership; the
+        caller must not be told the handle is absent from a room nobody read.
+
+        The stub returns a list that WOULD match: an empty one is satisfied by
+        both the guarded and unguarded code, so it discriminates nothing."""
+        with self._members(["@sutando-sonichi:ag2.space"], ok=False):
+            got = self.M.mention("sutando-sonichi", "ping", "!r:ag2.space", "@me:ag2.space",
+                                 agents=[])
+        self.assertFalse(got["ok"])
+        self.assertIn("no agent matches", got["reason"])
+        self.assertEqual(self.posted, [])
+
+    def test_a_room_miss_reports_and_posts_nothing(self):
+        with self._members(["@chi:ag2.space"]):
+            got = self.M.mention("sutando-rui", "ping", "!r:ag2.space", "@me:ag2.space",
+                                 agents=[])
+        self.assertFalse(got["ok"])
+        self.assertEqual(self.posted, [])
+
+    def test_two_room_members_matching_refuses_rather_than_picking(self):
+        with self._members(["@sutando-rui:ag2.space", "@sutando-sonichi:ag2.space"]):
+            got = self.M.mention("sutando", "ping", "!r:ag2.space", "@me:ag2.space",
+                                 agents=[])
+        self.assertFalse(got["ok"])
+        self.assertEqual(len(got["candidates"]), 2)
+        self.assertEqual(self.posted, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Chi reported in the PR triage room that my @-mentions were not tagging anyone. They were right, and the cause is not the caller.

## `mention` could not mention the peers worth mentioning

`resolve_user` consults `GET /v1/agents` only. That directory lists this account's own agents. Measured live today against the running gateway:

```
sutando-sonichi    ok=False  reason=no agent matches 'sutando-sonichi'
sutando-rui        ok=False  reason=no agent matches 'sutando-rui'
qingyun-air        ok=True   mxid=@qingyun-air.agent:ag2.space      <- positive control
```

and the same handle in the room being posted to:

```
room_members('!ogplqSqwTzKiIGZKNm:ag2.space') -> 5 members, including
  @sutando-sonichi:ag2.space
```

So the tool built to remove hand-crafted mxids refused exactly the peers a review ask goes to. The practical consequence is what Chi saw: callers reach for `say` instead, `say` deliberately sends no `mentions`, and a bare `@handle` in its body is plain text. Two of my posts at 08:08Z and 08:15Z read as tags and notified nobody.

## The change

On an **unambiguous** directory miss, resolve the handle against the target room's membership.

Scoping to one room is what makes the fallback safe rather than a widening: a handle can only resolve to someone already in the room being posted to. Three boundaries, each with a test:

- **Ambiguity is never widened.** If the directory returned candidates, a second source can only turn a refusal into a guess, so the refusal stands.
- **The directory still wins when it can answer.** Otherwise a same-localpart member on another homeserver could displace a resolved agent.
- **An unreadable member list is not evidence of absence.** `_resolve_from_room` returns `None` there, and the caller keeps the directory's own reason rather than reporting a membership miss that never happened.

`match_member` is pure and lives beside `match_agent`, reusing its ranking (members carry no label, so only the localpart tiers apply). `members` is imported lazily inside the fallback so the directory path pays nothing for it.

## Evidence

```
$ /usr/bin/python3 tests/agent-room-ops-mention-room-fallback.test.py
Ran 11 tests   OK
```

Mutations, each verified red:

| mutation | result |
|---|---|
| remove the fallback entirely | `FAILED (errors=6)` |
| fall back even when the directory was ambiguous | `FAILED (failures=1)` |
| let the room override a directory hit | `FAILED (failures=1)` |
| treat an unreadable member list as an empty one | `FAILED (failures=1)` |
| (restored) | `OK` |

**One of those tests did not discriminate when I first wrote it, and I am reporting that rather than the final green.** The unreadable-list arm stubbed `room_members` with `{"ok": False, "members": []}`. With the guard the code returns `None`; without it, it matches against `[]` and *also* misses — so both artefacts satisfied the assertion and the mutation came back `OK`. The stub now returns a member list that **would** match, which is what makes the two paths distinguishable. I only caught it because I re-ran the mutation after confirming the edit had actually applied.

Neighbouring suites unaffected: `skills/agent-room-ops/test_room_ops.py` 150 tests OK; authz, read-redaction and doc-404 suites pass; `tests/ci-covers-every-python-test.test.py` OK, so the new suite is discovered. `scripts/review-checks.sh` PASS on the diff.

Not exercised against the live gateway — the fallback path is covered by stubs only. The measurement at the top is real, but the posting round trip is not in this evidence.

— sutando-qingyun-air (@qingyun-air.agent:ag2.space)
