### PR TITLE
feat(startup): gate `/startup complete` on the session-crons stamp probe

### DIFF
--- a/skills/startup/SKILL.md
+++ b/skills/startup/SKILL.md
@@ -54,15 +54,29 @@ Invoke `/schedule-crons`. This handles:
   a hand-rolled registration leaves that probe reporting the crons as never registered.
 - Ensuring a fallback `/proactive-loop` cron exists at `*/10 * * * *` if `crons.json` doesn't include one (post-#954 belt-and-suspenders)
 
-### Step 3 — Confirm
+### Step 3 — Verify, then confirm
 
-Emit a one-line summary so the operator (or main session's first turn) sees what fired:
+**Run the ceremony gate BEFORE claiming completion.** It is health-check's `session-crons` probe
+— the same stamp-vs-session-boundary test the desktop app's ceremony-health uses to decide whether
+to re-send `/startup` — so the agent sees the app's criterion at the one moment it can act on it:
 
+```bash
+python3 skills/startup/scripts/verify-ceremony.py    # rc 0 = stamped this boot; rc 1 = NOT complete
 ```
-/startup complete: orphan-check (N tasks recovered, M archived), schedules (K crons + watcher).
-```
 
-The orphan-check fields say `skipped (skill not installed)` if step 1 was skipped.
+- **rc 0** → emit the one-line summary so the operator (or main session's first turn) sees what fired:
+
+  ```
+  /startup complete: orphan-check (N tasks recovered, M archived), schedules (K crons + watcher).
+  ```
+
+  The orphan-check fields say `skipped (skill not installed)` if step 1 was skipped.
+- **rc 1** → do NOT print `/startup complete`. Print the gate's output verbatim, invoke `/schedule-crons`
+  (the only writer of `hosts/<hostname>/schedule-crons-stamp.json`), and re-run the gate. A hand-rolled
+  `CronCreate` passes every cheap check — `CronList` looks perfect and the cron fires — and still fails
+  this one, which is exactly why the app kept re-sending `/startup` to a session that believed it was
+  done (135 sends across four episodes, the longest 25 h, stamp unchanged in every one).
+- **rc 2** → the probe could not run; say so and do not claim completion.
 
 ## Sequence diagram
 

--- a/skills/startup/scripts/verify-ceremony.py
+++ b/skills/startup/scripts/verify-ceremony.py
@@ -20,7 +20,12 @@ REPO = Path(__file__).resolve().parents[3]
 
 
 def load_probe():
-    spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+    probe_file = REPO / "src" / "health-check.py"
+    # spec_from_file_location returns a VALID spec for a missing file (None only for an
+    # unknown suffix), so the existence check has to be explicit or the guard guards nothing.
+    if not probe_file.is_file():
+        return None
+    spec = importlib.util.spec_from_file_location("health_check", probe_file)
     if spec is None or spec.loader is None:
         return None
     mod = importlib.util.module_from_spec(spec)
@@ -28,6 +33,8 @@ def load_probe():
         spec.loader.exec_module(mod)
     except SystemExit:
         pass
+    except Exception:  # unimportable probe is "cannot answer" (rc 2), never "not ok" (rc 1)
+        return None
     return getattr(mod, "check_session_cron_registration", None)
 
 

--- a/skills/startup/scripts/verify-ceremony.py
+++ b/skills/startup/scripts/verify-ceremony.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Gate for /startup step 3: exit 0 only when this session's cron ceremony is stamped complete.
+
+Runs health-check's `session-crons` probe — the same stamp-vs-session-boundary test the desktop
+app's ceremony-health uses to decide whether to re-send /startup — so the agent sees the app's
+criterion at the moment it can act. A hand-rolled `CronCreate` passes every cheap check
+(`CronList` looks perfect) and still fails this one, because only /schedule-crons writes the stamp.
+
+Usage: verify-ceremony.py [--workspace DIR] [--host-label LABEL]
+Exit: 0 = ok (emit "/startup complete"), 1 = not ok (do NOT emit; run /schedule-crons), 2 = probe unavailable.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def load_probe():
+    spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return getattr(mod, "check_session_cron_registration", None)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--workspace", type=Path, default=None)
+    ap.add_argument("--host-label", default=None)
+    a = ap.parse_args(argv)
+    probe = load_probe()
+    if probe is None:
+        print("verify-ceremony: session-crons probe unavailable — cannot confirm; do not report complete", file=sys.stderr)
+        return 2
+    result = probe(a.workspace, host_label=a.host_label)
+    status, detail = result.get("status"), result.get("detail", "")
+    if status == "ok":
+        print(f"verify-ceremony: ok — {detail}")
+        return 0
+    print(f"verify-ceremony: {status} — {detail}", file=sys.stderr)
+    print("verify-ceremony: NOT complete. Invoke /schedule-crons (the only writer of "
+          "schedule-crons-stamp.json) and re-run; do not hand-roll CronCreate.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/startup-ceremony-gate.test.py
+++ b/tests/startup-ceremony-gate.test.py
@@ -12,6 +12,9 @@ as local, which is what lets the session boundary resolve from `state/session-st
 """
 from __future__ import annotations
 
+import contextlib
+import importlib.util
+import io
 import json
 import os
 import subprocess
@@ -123,6 +126,41 @@ class VerifyCeremonyGate(unittest.TestCase):
             self.assertEqual(r.returncode, 2, f"rc={r.returncode}\n{r.stderr}")
             self.assertIn("probe unavailable", r.stderr)
             self.assertNotIn("Traceback", r.stderr)
+
+
+def _load_gate_module():
+    """Import the gate from its REPO path so coverage attributes the run to the real file —
+    the subprocess arms above copy it to a temp tree, which measures nothing in-repo."""
+    spec = importlib.util.spec_from_file_location("verify_ceremony", GATE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class VerifyCeremonyGateInProcess(unittest.TestCase):
+    def _main_with_repo(self, repo: Path) -> tuple[int, str]:
+        mod = _load_gate_module()
+        mod.REPO = repo
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc = mod.main(["--workspace", str(repo / "ws"), "--host-label", HOST])
+        return rc, err.getvalue()
+
+    def test_missing_probe_rc2_in_process(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td); (repo / "src").mkdir()
+            rc, err = self._main_with_repo(repo)
+            self.assertEqual(rc, 2, err)
+            self.assertIn("probe unavailable", err)
+
+    def test_raising_probe_rc2_in_process(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td); (repo / "src").mkdir()
+            (repo / "src" / "health-check.py").write_text('raise RuntimeError("boom at import")\n')
+            rc, err = self._main_with_repo(repo)
+            self.assertEqual(rc, 2, err)
+            self.assertIn("probe unavailable", err)
+            self.assertNotIn("Traceback", err)
 
 
 if __name__ == "__main__":

--- a/tests/startup-ceremony-gate.test.py
+++ b/tests/startup-ceremony-gate.test.py
@@ -28,6 +28,12 @@ GATE = REPO / "skills" / "startup" / "scripts" / "verify-ceremony.py"
 HOST = "gate-test-host"
 ENTRIES = [{"name": "main-loop", "cron": "*/15 * * * *", "prompt_skill": "proactive-loop"}]
 
+# Subprocess coverage is opt-in in this repo (see runtime-cli-surface.test.py): under the
+# gate, run the child through `coverage run` so the repo-path arms measure the real file.
+PYBASE = [sys.executable]
+if os.environ.get("SUTANDO_TEST_SUBPROCESS_COVERAGE") == "1":
+    PYBASE += ["-m", "coverage", "run", f"--rcfile={REPO / '.coveragerc'}"]
+
 
 def _workspace(root: Path, *, started_at: float, stamp_ts: float | None) -> Path:
     ws = root / "workspace"
@@ -49,8 +55,8 @@ def _workspace(root: Path, *, started_at: float, stamp_ts: float | None) -> Path
 def _run(ws: Path) -> subprocess.CompletedProcess:
     env = dict(os.environ, SUTANDO_HOST_LABEL=HOST)
     return subprocess.run(
-        [sys.executable, str(GATE), "--workspace", str(ws), "--host-label", HOST],
-        capture_output=True, text=True, env=env, timeout=60,
+        PYBASE + [str(GATE), "--workspace", str(ws), "--host-label", HOST],
+        capture_output=True, text=True, env=env, timeout=60, cwd=REPO,
     )
 
 
@@ -161,6 +167,27 @@ class VerifyCeremonyGateInProcess(unittest.TestCase):
             self.assertEqual(rc, 2, err)
             self.assertIn("probe unavailable", err)
             self.assertNotIn("Traceback", err)
+
+    def test_probe_exiting_at_import_is_rc2_in_process(self):
+        """`except SystemExit: pass` then no probe attribute → None → rc 2."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td); (repo / "src").mkdir()
+            (repo / "src" / "health-check.py").write_text("raise SystemExit(0)\n")
+            rc, err = self._main_with_repo(repo)
+            self.assertEqual(rc, 2, err)
+
+    def test_unloadable_spec_is_rc2_in_process(self):
+        """spec_from_file_location → None (unknown suffix) is guarded too; force it."""
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td); (repo / "src").mkdir()
+            (repo / "src" / "health-check.py").write_text("x = 1\n")
+            mod = _load_gate_module(); mod.REPO = repo
+            with mock.patch.object(mod.importlib.util, "spec_from_file_location", return_value=None):
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    rc = mod.main(["--workspace", str(repo / "ws"), "--host-label", HOST])
+            self.assertEqual(rc, 2, err.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/startup-ceremony-gate.test.py
+++ b/tests/startup-ceremony-gate.test.py
@@ -88,6 +88,24 @@ class VerifyCeremonyGate(unittest.TestCase):
             )
             self.assertEqual(_run(ws).returncode, 0)
 
+    def test_missing_probe_is_rc2_not_rc1(self):
+        """Copy-deployed tree: the script exists, src/health-check.py does not. Must be rc 2
+        ("cannot answer"), never rc 1 — rc 1 tells the agent to run /schedule-crons and retry,
+        which can never fix an unimportable probe and re-creates the re-send loop."""
+        with tempfile.TemporaryDirectory() as td:
+            tree = Path(td) / "copy"
+            dst = tree / "skills" / "startup" / "scripts" / "verify-ceremony.py"
+            dst.parent.mkdir(parents=True)
+            dst.write_text(GATE.read_text())
+            (tree / "src").mkdir()  # src/ present, health-check.py absent — the reviewer's second case
+            ws = _workspace(Path(td), started_at=1_000_000.0, stamp_ts=1_000_300.0)
+            env = dict(os.environ, SUTANDO_HOST_LABEL=HOST)
+            r = subprocess.run([sys.executable, str(dst), "--workspace", str(ws), "--host-label", HOST],
+                               capture_output=True, text=True, env=env, timeout=60)
+            self.assertEqual(r.returncode, 2, f"rc={r.returncode}\n{r.stderr}")
+            self.assertIn("probe unavailable", r.stderr)
+            self.assertNotIn("Traceback", r.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/startup-ceremony-gate.test.py
+++ b/tests/startup-ceremony-gate.test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Tests for skills/startup/scripts/verify-ceremony.py — the /startup step-3 gate.
+
+The failure it closes: cron registration done by hand (`CronCreate` from the crons.json list)
+passes every cheap check and never writes `schedule-crons-stamp.json`, so the desktop app's
+ceremony-health reads the session as never-completed and re-sends `/startup` every 10 minutes,
+indefinitely. The gate runs the same stamp-vs-session-boundary probe in-session so `/startup`
+cannot claim completion while the app would still call it diverged.
+
+Black-box: drives the real CLI in a subprocess. `SUTANDO_HOST_LABEL` makes the fixture host read
+as local, which is what lets the session boundary resolve from `state/session-starts.log`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GATE = REPO / "skills" / "startup" / "scripts" / "verify-ceremony.py"
+HOST = "gate-test-host"
+ENTRIES = [{"name": "main-loop", "cron": "*/15 * * * *", "prompt_skill": "proactive-loop"}]
+
+
+def _workspace(root: Path, *, started_at: float, stamp_ts: float | None) -> Path:
+    ws = root / "workspace"
+    cfg = ws / "hosts" / HOST / "crons.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps(ENTRIES))
+    state = ws / "state"
+    state.mkdir()
+    (state / "session-starts.log").write_text(
+        json.dumps({"host": HOST, "session_started_at": started_at}) + "\n"
+    )
+    if stamp_ts is not None:
+        (cfg.parent / "schedule-crons-stamp.json").write_text(
+            json.dumps({"ts": stamp_ts, "registered": 1, "config_total": 1})
+        )
+    return ws
+
+
+def _run(ws: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ, SUTANDO_HOST_LABEL=HOST)
+    return subprocess.run(
+        [sys.executable, str(GATE), "--workspace", str(ws), "--host-label", HOST],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+
+
+class VerifyCeremonyGate(unittest.TestCase):
+    def test_stale_stamp_refuses_completion(self):
+        """The hand-rolled-registration case: stamp predates this session's launch."""
+        with tempfile.TemporaryDirectory() as td:
+            ws = _workspace(Path(td), started_at=1_000_000.0, stamp_ts=900_000.0)
+            r = _run(ws)
+            self.assertEqual(r.returncode, 1, r.stderr)
+            self.assertIn("predates this session", r.stderr)
+            self.assertIn("NOT complete", r.stderr)
+            self.assertIn("/schedule-crons", r.stderr)
+            self.assertNotIn("ok", r.stdout)
+
+    def test_no_stamp_refuses_completion(self):
+        with tempfile.TemporaryDirectory() as td:
+            ws = _workspace(Path(td), started_at=1_000_000.0, stamp_ts=None)
+            r = _run(ws)
+            self.assertEqual(r.returncode, 1, r.stderr)
+            self.assertIn("never stamped", r.stderr)
+
+    def test_fresh_stamp_passes(self):
+        """Stamp written after the boundary — /schedule-crons completed this boot."""
+        with tempfile.TemporaryDirectory() as td:
+            ws = _workspace(Path(td), started_at=1_000_000.0, stamp_ts=1_000_300.0)
+            r = _run(ws)
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("verify-ceremony: ok", r.stdout)
+
+    def test_stamp_write_flips_the_verdict(self):
+        """One workspace, both verdicts: proves the gate reads the stamp, not a constant."""
+        with tempfile.TemporaryDirectory() as td:
+            ws = _workspace(Path(td), started_at=1_000_000.0, stamp_ts=900_000.0)
+            self.assertEqual(_run(ws).returncode, 1)
+            (ws / "hosts" / HOST / "schedule-crons-stamp.json").write_text(
+                json.dumps({"ts": 1_000_300.0, "registered": 1, "config_total": 1})
+            )
+            self.assertEqual(_run(ws).returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/startup-ceremony-gate.test.py
+++ b/tests/startup-ceremony-gate.test.py
@@ -106,6 +106,24 @@ class VerifyCeremonyGate(unittest.TestCase):
             self.assertIn("probe unavailable", r.stderr)
             self.assertNotIn("Traceback", r.stderr)
 
+    def test_probe_that_raises_at_import_is_rc2(self):
+        """The other half of the fix: the probe file EXISTS but fails to import. Must be rc 2,
+        no traceback — the same "cannot answer" verdict as a missing file."""
+        with tempfile.TemporaryDirectory() as td:
+            tree = Path(td) / "copy"
+            dst = tree / "skills" / "startup" / "scripts" / "verify-ceremony.py"
+            dst.parent.mkdir(parents=True)
+            dst.write_text(GATE.read_text())
+            (tree / "src").mkdir()
+            (tree / "src" / "health-check.py").write_text('raise RuntimeError("boom at import")\n')
+            ws = _workspace(Path(td), started_at=1_000_000.0, stamp_ts=1_000_300.0)
+            env = dict(os.environ, SUTANDO_HOST_LABEL=HOST)
+            r = subprocess.run([sys.executable, str(dst), "--workspace", str(ws), "--host-label", HOST],
+                               capture_output=True, text=True, env=env, timeout=60)
+            self.assertEqual(r.returncode, 2, f"rc={r.returncode}\n{r.stderr}")
+            self.assertIn("probe unavailable", r.stderr)
+            self.assertNotIn("Traceback", r.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed, and why

`/startup` Step 3 now runs a gate — `skills/startup/scripts/verify-ceremony.py` — before it may print `/startup complete`. The gate is health-check's existing `session-crons` probe (`check_session_cron_registration`): the stamp-vs-session-boundary test that the desktop app's `ceremony_health.rs` also uses to decide whether to re-send `/startup`. rc 0 → emit the completion line; rc 1 → print the probe's verdict, invoke `/schedule-crons`, re-run.

**Why a mechanism and not a doc line.** #3768 (merged 2026-09-03T03:31Z) added exactly the right sentence to Step 2: invoke `/schedule-crons`, don't hand-roll `CronCreate`, because only the skill writes the stamp. Eleven hours later a core on an install that had not yet received #3768 did precisely that — registered the cron by hand, saw it in `CronList`, watched it fire, and reported startup complete. The stamp stayed 35.6 h stale, so the app re-sent `/startup` every 10 minutes (`ceremony-health: … diverged=true … sent /startup`), and each re-send was handled the same way. A doc line in the repo does not run on an install that hasn't picked it up, and prose is what got skipped. The gate puts the app's criterion in front of the agent at the one moment it can act, so "the skill says complete" and "the app says diverged" can no longer both be true.

Host log evidence (`~/Library/Logs/AG2Space/host.log`, this install): 135 `sent /startup` records across four episodes — 11 (Aug 26), 119 (Aug 29–30, one ~25 h run), 5 (Sep 3) — with `diverged=true` and an unchanged stamp value in every record of every episode.

## What to look at first

1. `skills/startup/scripts/verify-ceremony.py` — 55 lines; loads `src/health-check.py` via importlib (the same pattern `skills/schedule-crons/SKILL.md` step 1.5 and `tests/health-check-session-cron-stamp.test.py` use) and maps the probe's `status` to an exit code. No new policy: the verdict is the probe's.
2. `skills/startup/SKILL.md` Step 3 — the only prose change; the gate call and the three rc branches.
3. `tests/startup-ceremony-gate.test.py` — black-box, drives the real CLI in a subprocess.

## What user behavior or bug does this prove

A `/startup` run whose cron registration was done by hand can no longer claim completion; the same run after `/schedule-crons` can. The 10-minute `/startup` re-send loop stops at its cause instead of being absorbed.

## Feature/documentation consistency

The skill file is the canonical document for `/startup`; no `docs/catalog.json` entry references it. `skills/startup/manifest.json` unchanged (no `scripts` declaration in this manifest shape).

## Verification

**Manual verify** — the gate against a temp workspace carrying this install's actual stale values (stamp `1788318369`, session boundary `1788446686`), then the stamp `/schedule-crons` really wrote at 15:59:48Z:

```
--- BEFORE ---
verify-ceremony: warn — stamp predates this session's launch (128317s older) — session crons are gone with the old session; re-run /schedule-crons
verify-ceremony: NOT complete. Invoke /schedule-crons (the only writer of schedule-crons-stamp.json) and re-run; do not hand-roll CronCreate.
rc=1
--- AFTER ---
verify-ceremony: ok — 1 session cron(s) stamped registered this boot
rc=0
```

`128317s` is the exact figure `health-check.py` reported live on the affected host before the fix.

**Bot verify** — `python3 tests/startup-ceremony-gate.test.py` → `Ran 5 tests … OK`. Cases: stale stamp → rc 1 with the remedy text; no stamp → rc 1; fresh stamp → rc 0; one workspace flipped from rc 1 to rc 0 by writing the stamp alone (proves the gate reads the stamp, not a constant); and — added at `d9691bdd` after @qingyun-wu's review — a copy-deployed tree with no `src/health-check.py` → **rc 2**, not rc 1 (that arm fails at `cb1d5453`, passes at `d9691bdd`; rc 1 would have told the agent to run `/schedule-crons` and retry forever).

**Live path** — this is a skill-side gate, not a bridge/network/delivery loop; the live round trip that motivated it is the host-log sequence above (last stale-stamp send 15:55:32Z; stamp written 15:59:48Z; zero sends in the following debounce windows, checked at 16:06, 16:20, 16:35Z).

## Related

- #3768 — the doc-level version of this rule (merged); this PR is its enforcement.
- #3669 — the sibling gap (honest stamp, 7-day-expired schedule); not addressed here.
- `tests/session-start-schedule-crons-hook.test.sh` — the SessionStart hint hook is complementary (it reminds; this gate refuses).
