### PR TITLE
feat(hooks): release-target-guard — refuse an abbreviated SHA to gh release --target

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -222,6 +222,34 @@ a deployed copy searches upward for `state/authority.json`. Set
 
 Test: `python3 tests/review-authority-guard.test.py`.
 
+## `release-target-guard.py`
+
+DENIES `gh release create|edit` whose `--target` is an abbreviated commit SHA
+(7-39 hex characters). GitHub answers `Release.target_commitish is invalid` and
+creates nothing, so the release reads as cut at the moment it did not happen.
+A full 40-character SHA and a branch/tag name both pass.
+
+It exists because the rule is easy to know and useless to know: the value is not
+chosen, it is pasted from whatever printed last, and every tool prints the
+abbreviated form. Measured twice in fourteen hours on one host, with the
+correction written into the build log between the two occurrences.
+
+### Deploy (per node)
+
+```bash
+CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+mkdir -p "$CFG/hooks"
+cp hooks/release-target-guard.py "$CFG/hooks/"
+```
+
+Register it under the `Bash` PreToolUse matcher exactly as the guards above do
+(same `shlex.quote` recipe — these paths routinely contain a space).
+
+Escape hatch: `SUTANDO_SKIP_RELEASE_TARGET_GUARD=1`. Fail-open on any internal
+error, like every guard here.
+
+Tests: `python3 tests/release-target-guard.test.py`
+
 ## `result-file-marker-guard.py`
 
 Denies a **Write/Edit into `<workspace>/results/`** whose body carries a

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -248,6 +248,11 @@ Register it under the `Bash` PreToolUse matcher exactly as the guards above do
 Escape hatch: `SUTANDO_SKIP_RELEASE_TARGET_GUARD=1`. Fail-open on any internal
 error, like every guard here.
 
+Scope: it sees only literal text. `--target "$(git rev-parse --short HEAD)"`
+is allowed, because the value is unknowable before execution — and that is a
+very plausible way to produce this bug. The guard bounds pasted values, not
+computed ones.
+
 Tests: `python3 tests/release-target-guard.test.py`
 
 ## `result-file-marker-guard.py`

--- a/hooks/release-target-guard.py
+++ b/hooks/release-target-guard.py
@@ -24,8 +24,10 @@ import re
 import shlex
 import sys
 
-FULL_SHA = re.compile(r"\A[0-9a-f]{40}\Z")
-HEX_RUN = re.compile(r"\A[0-9a-f]{7,}\Z")
+FULL_SHA = re.compile(r"\A[0-9a-fA-F]{40}\Z")
+# Both take the same case set: widening only HEX_RUN would deny a valid
+# 40-char uppercase sha.
+HEX_RUN = re.compile(r"\A[0-9a-fA-F]{7,}\Z")
 # A separator ends the gh command; anything after it belongs to another tool.
 SEPARATORS = (";", "&&", "||", "|", "&", "(", ")")
 

--- a/hooks/release-target-guard.py
+++ b/hooks/release-target-guard.py
@@ -26,6 +26,8 @@ import sys
 
 FULL_SHA = re.compile(r"\A[0-9a-f]{40}\Z")
 HEX_RUN = re.compile(r"\A[0-9a-f]{7,}\Z")
+# A separator ends the gh command; anything after it belongs to another tool.
+SEPARATORS = (";", "&&", "||", "|", "&", "(", ")")
 
 
 def _deny(reason):
@@ -40,18 +42,22 @@ def _deny(reason):
 def targets(command: str):
     """Every --target value belonging to a `gh release create|edit` in `command`.
 
-    Splitting into shell words rather than regexing the string keeps
-    `--target=X` and `--target X` one case, and stops a `--target` in unrelated
-    text (a different tool, a quoted sentence) from being read as one.
+    `punctuation_chars` tokenizes `;` `&&` `|` as their own words while leaving
+    quoted text intact, so a separator ends the gh command instead of gluing to
+    the sha before it — and another tool's `--target` after one is not read.
     """
     try:
-        words = shlex.split(command)
+        lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        words = list(lex)
     except ValueError:
         return []
     out, i, armed = [], 0, False
     while i < len(words):
         w = words[i]
-        if w == "gh":
+        if w in SEPARATORS:
+            armed = False
+        if os.path.basename(w) == "gh":
             armed = words[i + 1:i + 3] in (["release", "create"], ["release", "edit"])
         if armed and w == "--target" and i + 1 < len(words):
             out.append(words[i + 1])

--- a/hooks/release-target-guard.py
+++ b/hooks/release-target-guard.py
@@ -41,6 +41,32 @@ def _deny(reason):
     sys.exit(0)
 
 
+def _newline_separators(command: str) -> str:
+    """A newline ends the command unless it sits inside a quoted argument.
+
+    Same policy as hooks/inline-body-substitution-guard.py, deliberately
+    duplicated: hooks are standalone by convention. Extraction tracked separately.
+    """
+    out, quote, esc = [], None, False
+    for i, ch in enumerate(command):
+        if esc:
+            out.append(ch); esc = False; continue
+        if ch == "\\" and quote != "'":
+            out.append(ch); esc = True; continue
+        if quote is None and ch in ("'", '"'):
+            quote = ch
+        elif ch == quote:
+            quote = None
+        if ch in "\r\n" and quote is None:
+            # CRLF is ONE separator: two `;` lex as the single token `;;`,
+            # which is not in SEPARATORS, so `armed` would never reset.
+            if not (ch == "\r" and command[i + 1:i + 2] == "\n"):
+                out.append(";")
+            continue
+        out.append(ch)
+    return "".join(out)
+
+
 def _is_release_cut(rest) -> bool:
     """`release create|edit` anywhere in this gh command, not at a fixed offset.
 
@@ -62,6 +88,7 @@ def targets(command: str):
     quoted text intact, so a separator ends the gh command instead of gluing to
     the sha before it — and another tool's `--target` after one is not read.
     """
+    command = _newline_separators(command)
     try:
         lex = shlex.shlex(command, posix=True, punctuation_chars=True)
         lex.whitespace_split = True

--- a/hooks/release-target-guard.py
+++ b/hooks/release-target-guard.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""release-target-guard — PreToolUse hook that DENIES `gh release create|edit`
+whose ``--target`` is an abbreviated commit SHA.
+
+GitHub rejects those with ``Release.target_commitish is invalid`` and creates
+nothing, so the cut silently does not happen at the moment it looks finished.
+
+Why a hook rather than a note: this failed twice in fourteen hours on one host,
+with the correction written into the build log between the two occurrences. The
+rule is easy to know and useless to know, because the value is not chosen — it is
+pasted from whatever printed last, and every tool prints the abbreviated form
+(``gh pr view``, ``.sha[0:12]``, a previous log line). A lesson cannot intercept a
+paste; the shell can.
+
+Allowed: a branch or tag name, and a full 40-character hex SHA. Denied: a hex run
+of 7 or more that is not exactly 40 — git's default abbreviation is 7, so a
+shorter hex-looking value is a name, not a paste.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+
+FULL_SHA = re.compile(r"\A[0-9a-f]{40}\Z")
+HEX_RUN = re.compile(r"\A[0-9a-f]{7,}\Z")
+
+
+def _deny(reason):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}))
+    sys.exit(0)
+
+
+def targets(command: str):
+    """Every --target value belonging to a `gh release create|edit` in `command`.
+
+    Splitting into shell words rather than regexing the string keeps
+    `--target=X` and `--target X` one case, and stops a `--target` in unrelated
+    text (a different tool, a quoted sentence) from being read as one.
+    """
+    try:
+        words = shlex.split(command)
+    except ValueError:
+        return []
+    out, i, armed = [], 0, False
+    while i < len(words):
+        w = words[i]
+        if w == "gh":
+            armed = words[i + 1:i + 3] in (["release", "create"], ["release", "edit"])
+        if armed and w == "--target" and i + 1 < len(words):
+            out.append(words[i + 1])
+        elif armed and w.startswith("--target="):
+            out.append(w.split("=", 1)[1])
+        i += 1
+    return out
+
+
+def offenders(command: str):
+    """The --target values GitHub will reject. Full SHAs and names are fine."""
+    return [t for t in targets(command)
+            if HEX_RUN.match(t) and not FULL_SHA.match(t)]
+
+
+def main(argv):
+    if os.environ.get("SUTANDO_SKIP_RELEASE_TARGET_GUARD") == "1":
+        sys.exit(0)
+    payload = json.load(sys.stdin)
+    if (payload.get("tool_name") or "") != "Bash":
+        sys.exit(0)
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    bad = offenders(command)
+    if not bad:
+        sys.exit(0)
+    _deny(
+        f"RELEASE TARGET GUARD: --target {', '.join(bad)} is an abbreviated SHA. "
+        "GitHub answers 'Release.target_commitish is invalid' and creates nothing, "
+        "so the release looks cut and is not.\n\n"
+        "Use the branch, or resolve the full SHA in the same command so it is "
+        "never typed:\n"
+        "    --target main\n"
+        "    FULL=$(gh api repos/<owner>/<repo>/commits/main -q '.sha')\n"
+        "    gh release edit <tag> --target \"$FULL\"\n\n"
+        "[release-target-guard]"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main(sys.argv[1:])
+    except SystemExit:
+        raise
+    except Exception as e:  # fail-open: never wedge the core on a guard bug
+        print(f"release-target-guard: non-fatal error, allowing: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/hooks/release-target-guard.py
+++ b/hooks/release-target-guard.py
@@ -39,6 +39,20 @@ def _deny(reason):
     sys.exit(0)
 
 
+def _is_release_cut(rest) -> bool:
+    """`release create|edit` anywhere in this gh command, not at a fixed offset.
+
+    A global flag between them (`-R`, `--repo`, `--hostname`) is ordinary, and
+    keying on the two words right after `gh` let it disarm the guard entirely.
+    """
+    for j, w in enumerate(rest):
+        if w in SEPARATORS:
+            return False
+        if w == "release" and rest[j + 1:j + 2] in (["create"], ["edit"]):
+            return True
+    return False
+
+
 def targets(command: str):
     """Every --target value belonging to a `gh release create|edit` in `command`.
 
@@ -58,7 +72,7 @@ def targets(command: str):
         if w in SEPARATORS:
             armed = False
         if os.path.basename(w) == "gh":
-            armed = words[i + 1:i + 3] in (["release", "create"], ["release", "edit"])
+            armed = _is_release_cut(words[i + 1:])
         if armed and w == "--target" and i + 1 < len(words):
             out.append(words[i + 1])
         elif armed and w.startswith("--target="):

--- a/hooks/release-target-guard.py
+++ b/hooks/release-target-guard.py
@@ -42,30 +42,39 @@ def _deny(reason):
 
 
 def _newline_separators(command: str) -> str:
-    """A newline ends the command unless it sits inside a quoted argument.
-
-    Same policy as hooks/inline-body-substitution-guard.py, deliberately
-    duplicated: hooks are standalone by convention. Extraction tracked separately.
-    """
-    out, quote, esc = [], None, False
+    """Unquoted `#` comments out to end of line; an unquoted line break ends the
+    command. Comments go FIRST: once a newline is a `;`, nothing terminates one."""
+    out, quote, esc, comment = [], None, False, False
+    prev = " "
     for i, ch in enumerate(command):
+        if comment:
+            if ch in "\r\n":
+                comment = False
+            else:
+                prev = ch
+                continue
         if esc:
-            out.append(ch); esc = False; continue
+            out.append(ch); esc = False; prev = ch; continue
         if ch == "\\" and quote != "'":
-            out.append(ch); esc = True; continue
+            out.append(ch); esc = True; prev = ch; continue
         if quote is None and ch in ("'", '"'):
             quote = ch
         elif ch == quote:
             quote = None
+        # bash opens a comment only at a word start, and `;&|()` end a word too.
+        # `a#b` and `x/y#frag` stay literal.
+        if ch == "#" and quote is None and (
+                prev.isspace() or prev == "" or prev in ";&|()"):
+            comment = True; prev = ch; continue
         if ch in "\r\n" and quote is None:
             # CRLF is ONE separator: two `;` lex as the single token `;;`,
             # which is not in SEPARATORS, so `armed` would never reset.
             if not (ch == "\r" and command[i + 1:i + 2] == "\n"):
                 out.append(";")
+            prev = ch
             continue
-        out.append(ch)
+        out.append(ch); prev = ch
     return "".join(out)
-
 
 def _is_release_cut(rest) -> bool:
     """`release create|edit` anywhere in this gh command, not at a fixed offset.
@@ -91,6 +100,7 @@ def targets(command: str):
     command = _newline_separators(command)
     try:
         lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lex.commenters = ""  # _newline_separators owns comments; shlex's fire mid-word
         lex.whitespace_split = True
         words = list(lex)
     except ValueError:

--- a/tests/release-target-guard.test.py
+++ b/tests/release-target-guard.test.py
@@ -80,6 +80,29 @@ class TestOffenders(unittest.TestCase):
         self.assertEqual(G.offenders(f"gh release edit v1 --target {SHORT}; echo done"), [SHORT])
         self.assertEqual(G.offenders(f"gh release edit v1 --target {SHORT} && echo ok"), [SHORT])
 
+    def test_a_global_flag_between_gh_and_release_does_not_disarm(self):
+        """`targets` armed only on the two words immediately after `gh`, so a
+        global flag disarmed it entirely — and `-R` is exactly how a release is
+        cut from another repo's checkout (Sutando-Mini via sonichi, #3829)."""
+        self.assertEqual(
+            G.offenders("gh -R sonichi/sutando release create v1 --target abcdef1"), ["abcdef1"])
+        self.assertEqual(
+            G.offenders(f"gh --repo o/r release edit v1 --target {SHORT}"), [SHORT])
+        self.assertEqual(
+            G.offenders(f"/opt/homebrew/bin/gh -R o/r release edit v1 --target {SHORT}"), [SHORT])
+
+    def test_a_global_flag_does_not_make_every_gh_a_release_cut(self):
+        """Arming on `release create|edit` anywhere in the segment must not
+        arm on a different subcommand that merely follows a flag."""
+        self.assertEqual(G.offenders(f"gh -R o/r pr view 1 --target {SHORT}"), [])
+        self.assertEqual(G.offenders(f"gh -R o/r release list --target {SHORT}"), [])
+
+    def test_the_arm_scan_stops_at_a_separator(self):
+        """Scanning past a separator would let a LATER `gh release create` arm
+        an EARLIER, unrelated gh command — so its --target gets flagged."""
+        self.assertEqual(
+            G.offenders(f"gh pr view 1 --target {SHORT} && gh release create v2 --target main"), [])
+
     def test_a_path_qualified_gh_still_arms(self):
         self.assertEqual(
             G.offenders(f"/opt/homebrew/bin/gh release edit v1 --target {SHORT}"), [SHORT])

--- a/tests/release-target-guard.test.py
+++ b/tests/release-target-guard.test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""`gh release --target <abbreviated sha>` must be denied before it runs.
+
+GitHub answers `Release.target_commitish is invalid` and creates nothing, so the
+release reads as cut at the exact moment it did not happen. Measured twice in
+fourteen hours on one host, the correction written between the two.
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+HOOK = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                    "hooks", "release-target-guard.py")
+
+spec = importlib.util.spec_from_file_location("rtg", HOOK)
+G = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(G)
+
+SHORT = "f653b4d9f8a4"
+FULL = "f653b4d9f8a43e35486d85da909ede509b3b85de"
+
+
+class TestOffenders(unittest.TestCase):
+    def test_the_abbreviated_form_that_actually_failed(self):
+        self.assertEqual(
+            G.offenders(f"gh release edit v0.6.3 --repo o/r --draft=false --target {SHORT}"),
+            [SHORT])
+
+    def test_the_full_sha_is_allowed(self):
+        self.assertEqual(G.offenders(f"gh release edit v0.6.3 --target {FULL}"), [])
+
+    def test_a_branch_name_is_allowed(self):
+        self.assertEqual(G.offenders("gh release create v1 --target main"), [])
+
+    def test_equals_form_is_the_same_case(self):
+        self.assertEqual(G.offenders(f"gh release create v1 --target={SHORT}"), [SHORT])
+
+    def test_a_seven_char_sha_is_still_abbreviated(self):
+        self.assertEqual(G.offenders("gh release create v1 --target 544a68f"), ["544a68f"])
+
+    def test_a_short_hex_branch_name_is_a_name_not_a_paste(self):
+        """git abbreviates to 7 by default, so a shorter hex run is a branch
+        someone named. Denying it would refuse a legitimate cut."""
+        self.assertEqual(G.offenders("gh release create v1 --target dad"), [])
+        self.assertEqual(G.offenders("gh release create v1 --target abcdef"), [])
+
+    def test_a_41_char_hex_run_is_not_a_sha_either(self):
+        self.assertEqual(G.offenders("gh release create v1 --target " + "a" * 41), ["a" * 41])
+
+    def test_a_branch_whose_name_is_hex_words_is_not_a_sha(self):
+        """`deadbeef-fix` and `main` are names; only a bare hex run is the paste
+        this guard exists to catch."""
+        self.assertEqual(G.offenders("gh release create v1 --target deadbeef-fix"), [])
+
+    def test_a_target_belonging_to_another_command_is_not_read(self):
+        """The flag is common. Reading one that belongs to a different tool would
+        refuse work this guard has no claim on."""
+        self.assertEqual(G.offenders(f"some-other-tool --target {SHORT}"), [])
+
+    def test_gh_pr_is_not_gh_release(self):
+        self.assertEqual(G.offenders(f"gh pr merge 1 --target {SHORT}"), [])
+
+    def test_a_later_gh_command_disarms_the_previous_release(self):
+        self.assertEqual(
+            G.offenders(f"gh release create v1 --target main && gh pr view 1 --target {SHORT}"),
+            [])
+
+    def test_both_targets_in_one_chain_are_reported(self):
+        self.assertEqual(
+            G.offenders(f"gh release create v1 --target {SHORT} ; gh release edit v2 --target 544a68f"),
+            [SHORT, "544a68f"])
+
+    def test_unbalanced_quotes_do_not_raise(self):
+        self.assertEqual(G.offenders("gh release create v1 --target 'unclosed"), [])
+
+
+class TestHookIO(unittest.TestCase):
+    def _run(self, payload, env=None):
+        e = dict(os.environ)
+        e.pop("SUTANDO_SKIP_RELEASE_TARGET_GUARD", None)
+        e.update(env or {})
+        p = subprocess.run([sys.executable, HOOK], input=json.dumps(payload),
+                           capture_output=True, text=True, env=e)
+        return p.returncode, p.stdout
+
+    def test_denies_with_a_pretooluse_decision(self):
+        rc, out = self._run({"tool_name": "Bash", "tool_input": {
+            "command": f"gh release edit v0.6.3 --target {SHORT}"}})
+        self.assertEqual(rc, 0)
+        d = json.loads(out)["hookSpecificOutput"]
+        self.assertEqual(d["permissionDecision"], "deny")
+        self.assertIn("Release.target_commitish is invalid", d["permissionDecisionReason"])
+        self.assertIn("gh api", d["permissionDecisionReason"])
+
+    def test_allows_the_full_sha_silently(self):
+        rc, out = self._run({"tool_name": "Bash", "tool_input": {
+            "command": f"gh release edit v0.6.3 --target {FULL}"}})
+        self.assertEqual((rc, out.strip()), (0, ""))
+
+    def test_a_non_bash_tool_is_not_this_guard_s_business(self):
+        rc, out = self._run({"tool_name": "Write", "tool_input": {
+            "command": f"gh release edit v1 --target {SHORT}"}})
+        self.assertEqual((rc, out.strip()), (0, ""))
+
+    def test_the_escape_hatch_allows(self):
+        rc, out = self._run({"tool_name": "Bash", "tool_input": {
+            "command": f"gh release edit v1 --target {SHORT}"}},
+            env={"SUTANDO_SKIP_RELEASE_TARGET_GUARD": "1"})
+        self.assertEqual((rc, out.strip()), (0, ""))
+
+    def test_malformed_input_fails_open_rather_than_wedging_the_core(self):
+        p = subprocess.run([sys.executable, HOOK], input="not json",
+                           capture_output=True, text=True)
+        self.assertEqual(p.returncode, 0)
+        self.assertEqual(p.stdout.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/release-target-guard.test.py
+++ b/tests/release-target-guard.test.py
@@ -115,6 +115,27 @@ class TestOffenders(unittest.TestCase):
         self.assertEqual(G.offenders("gh release create v1 --target " + "F" * 40), [])
         self.assertEqual(G.offenders("gh release create v1 --target " + "aF" * 20), [])
 
+    def test_a_newline_ends_the_command(self):
+        """`armed` survived a line break, so a --target on a LATER, unrelated
+        line was flagged. Raised three times by vidhuUC on #3829."""
+        self.assertEqual(
+            G.offenders("gh release create v1 --target main\ncargo build --target deadbeef1"), [])
+        self.assertEqual(
+            G.offenders("gh release create v1 --target main\ndocker build --target abcdef1234 ."), [])
+
+    def test_CRLF_is_ONE_separator_not_two(self):
+        """Mapping both \r and \n to ';' yields ';;', which lexes as a single
+        token that is not in SEPARATORS — so `armed` would never reset and the
+        CRLF case would keep failing while the LF case passed."""
+        self.assertEqual(
+            G.offenders("gh release create v1 --target main\r\ncargo build --target deadbeef1"), [])
+
+    def test_a_violation_on_a_later_line_is_still_caught(self):
+        self.assertEqual(
+            G.offenders("echo hi\ngh release edit v1 --target f653b4d9f8a4"), ["f653b4d9f8a4"])
+        self.assertEqual(
+            G.offenders("echo hi\r\ngh release edit v1 --target f653b4d9f8a4"), ["f653b4d9f8a4"])
+
     def test_a_path_qualified_gh_still_arms(self):
         self.assertEqual(
             G.offenders(f"/opt/homebrew/bin/gh release edit v1 --target {SHORT}"), [SHORT])

--- a/tests/release-target-guard.test.py
+++ b/tests/release-target-guard.test.py
@@ -103,6 +103,18 @@ class TestOffenders(unittest.TestCase):
         self.assertEqual(
             G.offenders(f"gh pr view 1 --target {SHORT} && gh release create v2 --target main"), [])
 
+    def test_an_abbreviated_sha_is_caught_in_any_case(self):
+        """git resolves an uppercase abbreviated sha and GitHub rejects it the
+        same way, so a case-sensitive HEX_RUN let it through (sonichi, #3829)."""
+        self.assertEqual(G.offenders("gh release create v1 --target ABCDEF1"), ["ABCDEF1"])
+        self.assertEqual(G.offenders("gh release create v1 --target AbCdEf1"), ["AbCdEf1"])
+
+    def test_a_full_uppercase_sha_is_still_allowed(self):
+        """The pair must move together: widening HEX_RUN alone would deny a
+        40-char uppercase sha, which is valid and is what --target wants."""
+        self.assertEqual(G.offenders("gh release create v1 --target " + "F" * 40), [])
+        self.assertEqual(G.offenders("gh release create v1 --target " + "aF" * 20), [])
+
     def test_a_path_qualified_gh_still_arms(self):
         self.assertEqual(
             G.offenders(f"/opt/homebrew/bin/gh release edit v1 --target {SHORT}"), [SHORT])

--- a/tests/release-target-guard.test.py
+++ b/tests/release-target-guard.test.py
@@ -73,6 +73,31 @@ class TestOffenders(unittest.TestCase):
             G.offenders(f"gh release create v1 --target {SHORT} ; gh release edit v2 --target 544a68f"),
             [SHORT, "544a68f"])
 
+    def test_a_separator_ends_the_gh_command(self):
+        """`shlex.split` glues `;` to the word before it, so the incident command
+        with a trailing `; echo` read as target `<sha>;` and was ALLOWED — the
+        guard missing the exact command it was built for (vidhuUC, #3829)."""
+        self.assertEqual(G.offenders(f"gh release edit v1 --target {SHORT}; echo done"), [SHORT])
+        self.assertEqual(G.offenders(f"gh release edit v1 --target {SHORT} && echo ok"), [SHORT])
+
+    def test_a_path_qualified_gh_still_arms(self):
+        self.assertEqual(
+            G.offenders(f"/opt/homebrew/bin/gh release edit v1 --target {SHORT}"), [SHORT])
+
+    def test_another_tool_after_a_gh_command_is_not_attributed_to_it(self):
+        """`armed` used to survive every non-`gh` word, so a later tool's own
+        --target was denied. A false denial is how a guard gets switched off."""
+        self.assertEqual(
+            G.offenders("gh release create v1 --target main && docker build --target abcdef1234 ."), [])
+        self.assertEqual(
+            G.offenders("gh release create v1 --target main; cargo build --target deadbeef1"), [])
+
+    def test_a_quoted_separator_stays_one_word(self):
+        """The tokenizer change must not split quoted text — that is the obvious
+        way this fix breaks something."""
+        self.assertEqual(
+            G.offenders(f'gh release create v1 --notes "a && b" --target {SHORT}'), [SHORT])
+
     def test_unbalanced_quotes_do_not_raise(self):
         self.assertEqual(G.offenders("gh release create v1 --target 'unclosed"), [])
 

--- a/tests/release-target-guard.test.py
+++ b/tests/release-target-guard.test.py
@@ -123,6 +123,35 @@ class TestOffenders(unittest.TestCase):
         self.assertEqual(
             G.offenders("gh release create v1 --target main\ndocker build --target abcdef1234 ."), [])
 
+    def test_a_comment_on_an_EARLIER_line_must_not_swallow_the_next_one(self):
+        """The newline rewrite made every line break a `;`, and after that
+        nothing terminates a `#` comment — so the guard's own normaliser
+        commented out the rest of the command it was inspecting."""
+        self.assertEqual(G.offenders(f"echo hi # note\ngh release edit v1 --target {SHORT}"),
+                         [SHORT])
+
+    def test_the_same_with_CRLF(self):
+        self.assertEqual(G.offenders(f"echo hi # x\r\ngh release edit v1 --target {SHORT}"),
+                         [SHORT])
+
+    def test_a_hash_opens_a_comment_after_a_separator_too_not_only_whitespace(self):
+        """bash starts a comment at a word start, and `;` `&` `|` `(` `)` all
+        end a word — so `;#` comments the line and the NEXT one still runs."""
+        self.assertEqual(G.offenders(f"echo hi;# note\ngh release edit v1 --target {SHORT}"),
+                         [SHORT])
+
+    def test_a_release_cut_INSIDE_a_comment_is_not_a_cut(self):
+        """The over-correction control: bash never runs it, so neither do we."""
+        self.assertEqual(G.offenders(f"echo hi\n# gh release edit v1 --target {SHORT}"), [])
+        self.assertEqual(G.offenders(f"echo hi # gh release edit v1 --target {SHORT}"), [])
+
+    def test_a_mid_word_hash_is_literal_and_must_not_blank_the_rest(self):
+        """A URL fragment or an issue ref is not a comment to bash. `shlex`'s
+        own `commenters` fires mid-word, which silently disabled the guard."""
+        self.assertEqual(
+            G.offenders(f"echo https://x/y#frag && gh release edit v1 --target {SHORT}"),
+            [SHORT])
+
     def test_CRLF_is_ONE_separator_not_two(self):
         """Mapping both \r and \n to ';' yields ';;', which lexes as a single
         token that is not in SEPARATORS — so `armed` would never reset and the


### PR DESCRIPTION
Closes a failure of mine that recurred with the correction already written down between the two occurrences.

## What happens

`gh release create|edit --target <abbreviated sha>` is rejected by GitHub with `Release.target_commitish is invalid` and creates nothing. The release reads as cut at the exact moment it did not happen.

Twice on this host in fourteen hours, both while cutting a real release:

```
04:14Z  gh release create v0.6.3-rc2 --target <12-char sha>   -> target_commitish is invalid
17:50Z  gh release edit   v0.6.3     --target f653b4d9f8a4    -> target_commitish is invalid
```

The build log entry written at 04:14Z says, in plain words, *"never extend a short hash; use `--target main` or the full sha from the API."* I wrote that, and then did it again thirteen hours later.

## Why a hook and not a note

Because the value is not chosen — it is pasted from whatever printed last, and **every** tool prints the abbreviated form: `gh pr view`, `.sha[0:12]`, a previous log line, a commit listing. Knowing the rule does not reach the moment of use, because at that moment you are copying a value you did not evaluate. A lesson cannot intercept a paste; the shell can.

## The rule

Allowed: a branch or tag name, and a full 40-character hex SHA. Denied: a hex run of **7 or more that is not exactly 40**. Git's default abbreviation is 7, so a shorter hex-looking value (`dad`, `abcdef`) is a branch someone named, not a paste — denying those would refuse legitimate cuts.

Scoped by shell word, not by regex over the string, so `--target=X` and `--target X` are one case and a `--target` belonging to a different tool is not read. A later `gh` command disarms the previous `gh release`.

Fail-open on any internal error and an escape hatch (`SUTANDO_SKIP_RELEASE_TARGET_GUARD=1`), like every guard in `hooks/`.

## Evidence

```
$ /usr/bin/python3 tests/release-target-guard.test.py
Ran 18 tests   OK
```

Mutations, each verified red:

| mutation | result |
|---|---|
| drop the exactly-40 exclusion (deny full SHAs too) | `FAILED (failures=2)` |
| lower the floor from 7 to 1 (deny short branch names) | `FAILED (failures=1)` |
| arm on any `gh` command, not just `release create\|edit` | `FAILED (failures=2)` |
| never deny | `FAILED (errors=1)` |
| drop the fail-open handler | `FAILED (failures=1)` |
| (restored) | `OK` |

**Two of those mutations initially came back green, and the reasons are different — both worth stating.**

1. My first version had `ABBREV_SHA = {7,39}` **and** `not FULL_SHA.match(t)`. The second clause was dead: a 40-char SHA already fails `{7,39}`. Removing it changed nothing, so the mutation was green because the code was redundant, not because the test was weak. The boundary is now expressed once — `{7,}` minus exactly-40 — and the mutation discriminates.

2. Lowering the floor to `{1,}` was green because no test used a short hex-looking name. Added `--target dad` and `--target abcdef` as must-allow.

**And a third thing made the loop itself lie.** After a restore, the suite reported `FAILED` on code that was byte-identical to the passing baseline: `{7,}` and `{1,}` are the same length, so a same-second restore hit CPython's `(mtime, size)` bytecode cache and `exec_module` ran the stale `.pyc`. The file said one thing and the import ran another. Every mutation run here now bumps the mtime and clears `__pycache__` first. Worth naming because a mutation loop over same-length edits is exactly where this is invisible: it can show a live mutation as green.

`tests/ci-covers-every-python-test.test.py` OK, so the suite is discovered. `scripts/review-checks.sh` passes via the pre-push hook.

Not deployed on this node — `hooks/` is version-controlled source, and registration is a per-node step documented in the README section this PR adds. So the guard does not yet protect the host that produced the incident; that is a follow-up, not a claim made here.

— sutando-qingyun-air (@qingyun-air.agent:ag2.space)
