### PR TITLE
feat(hooks): inline-body-substitution-guard — a double-quoted gh body loses its code spans

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -222,6 +222,33 @@ a deployed copy searches upward for `state/authority.json`. Set
 
 Test: `python3 tests/review-authority-guard.test.py`.
 
+## `inline-body-substitution-guard.py`
+
+DENIES a `gh` command whose `--body` / `--notes` / `--title` is passed inline in
+**double quotes** and contains a backtick or `$(`. The shell substitutes both
+before gh runs, so a published comment arrives with holes where its code spans
+were — while the command succeeds and still returns a URL. Single quotes are
+safe and allowed; `--body-file` is the fix and is what the denial names.
+
+Measured 2026-09-03 on sonichi/sutando#3829: a review reply lost three sentences
+that way, and it was caught only by reading the comment back afterwards.
+
+### Deploy (per node)
+
+```bash
+CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+mkdir -p "$CFG/hooks"
+cp hooks/inline-body-substitution-guard.py "$CFG/hooks/"
+```
+
+Register under the `Bash` PreToolUse matcher exactly as the guards above do
+(same `shlex.quote` recipe — these paths routinely contain a space).
+
+Escape hatch: `SUTANDO_SKIP_INLINE_BODY_GUARD=1`. Fail-open on any internal
+error, like every guard here.
+
+Tests: `python3 tests/inline-body-substitution-guard.test.py`
+
 ## `result-file-marker-guard.py`
 
 Denies a **Write/Edit into `<workspace>/results/`** whose body carries a

--- a/hooks/inline-body-substitution-guard.py
+++ b/hooks/inline-body-substitution-guard.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""inline-body-substitution-guard — PreToolUse hook that DENIES a `gh` command
+passing a `--body`/`--notes` inline in DOUBLE quotes when the text contains a
+backtick or `$(`.
+
+The shell substitutes both before gh ever sees them, so a published comment
+arrives with holes where its code spans were, and nothing reports an error: the
+command succeeds, the URL comes back, and only re-reading the comment shows it.
+
+Single quotes are safe and allowed; `--body-file` is the fix and is what this
+steers to. Scoped to `gh` because that is where the loss is silent AND public.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+
+BODY_FLAGS = ("--body", "--notes", "--title")
+# What the shell eats inside double quotes. `$VAR` is deliberately absent: it is
+# a normal, usually-intended interpolation, unlike a code span or a subshell.
+SUBSTITUTES = re.compile(r"`|\$\(")
+EQUALS_FORM = re.compile(r"(--body|--notes|--title)=")
+
+
+def _deny(reason):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}))
+    sys.exit(0)
+
+
+def offenders(command: str):
+    """Flags whose inline double-quoted value the shell would rewrite.
+
+    posix=False keeps the quote characters on each token, which is the whole
+    point — after posix parsing a single- and a double-quoted body look the same.
+    """
+    # `--body="x"` never lexes as one token: a quote only opens a string at a
+    # token boundary, so normalise it to the space form before splitting.
+    command = EQUALS_FORM.sub(r"\1 ", command)
+    try:
+        lex = shlex.shlex(command, posix=False, punctuation_chars=True)
+        lex.whitespace_split = True
+        words = list(lex)
+    except ValueError:
+        return []
+    out, i, armed = [], 0, False
+    while i < len(words):
+        w = words[i]
+        if w in (";", "&&", "||", "|", "&", "(", ")"):
+            armed = False
+        if os.path.basename(w) == "gh":
+            armed = True
+        if armed and w in BODY_FLAGS and i + 1 < len(words):
+            val = words[i + 1]
+            if val.startswith('"') and SUBSTITUTES.search(val):
+                out.append(w)
+        i += 1
+    return out
+
+
+def main(argv):
+    if os.environ.get("SUTANDO_SKIP_INLINE_BODY_GUARD") == "1":
+        sys.exit(0)
+    payload = json.load(sys.stdin)
+    if (payload.get("tool_name") or "") != "Bash":
+        sys.exit(0)
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    bad = offenders(command)
+    if not bad:
+        sys.exit(0)
+    _deny(
+        f"INLINE BODY GUARD: {', '.join(sorted(set(bad)))} is passed inline in double "
+        "quotes and contains a backtick or $( . The shell substitutes those before gh "
+        "runs, so the comment publishes with holes where its code spans were — and the "
+        "command still succeeds and still returns a URL.\n\n"
+        "Write the body to a file and pass it:\n"
+        "    cat > /tmp/body.md <<'EOF'\n    ...\n    EOF\n"
+        "    gh pr comment <n> --repo <o/r> --body-file /tmp/body.md\n\n"
+        "Single quotes are safe if the body has no single quote of its own.\n"
+        "[inline-body-substitution-guard]"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main(sys.argv[1:])
+    except SystemExit:
+        raise
+    except Exception as e:  # fail-open: never wedge the core on a guard bug
+        print(f"inline-body-substitution-guard: non-fatal error, allowing: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/hooks/inline-body-substitution-guard.py
+++ b/hooks/inline-body-substitution-guard.py
@@ -19,9 +19,8 @@ import shlex
 import sys
 
 BODY_FLAGS = ("--body", "--notes", "--title")
-# What the shell eats inside double quotes. `$VAR` is deliberately absent: it is
-# a normal, usually-intended interpolation, unlike a code span or a subshell.
-# An ESCAPED backtick publishes literally, so it is not a rewrite.
+# What the shell eats inside double quotes, escaped forms excluded. `$VAR` is
+# absent on purpose: an ordinary interpolation, not a code span or subshell.
 SUBSTITUTES = re.compile(r"(?<!\\)`|(?<!\\)\$\(")
 # `"$(cat f)"` as the WHOLE value is the intended content, not prose the shell
 # mangled — the standard file-passing idiom, and denying it cries wolf.

--- a/hooks/inline-body-substitution-guard.py
+++ b/hooks/inline-body-substitution-guard.py
@@ -21,7 +21,11 @@ import sys
 BODY_FLAGS = ("--body", "--notes", "--title")
 # What the shell eats inside double quotes. `$VAR` is deliberately absent: it is
 # a normal, usually-intended interpolation, unlike a code span or a subshell.
-SUBSTITUTES = re.compile(r"`|\$\(")
+# An ESCAPED backtick publishes literally, so it is not a rewrite.
+SUBSTITUTES = re.compile(r"(?<!\\)`|(?<!\\)\$\(")
+# `"$(cat f)"` as the WHOLE value is the intended content, not prose the shell
+# mangled — the standard file-passing idiom, and denying it cries wolf.
+WHOLE_SUBSTITUTION = re.compile(r'\A"\$\((?:[^()]|\([^()]*\))*\)"\Z')
 EQUALS_FORM = re.compile(r"(--body|--notes|--title)=")
 
 
@@ -35,19 +39,34 @@ def _deny(reason):
 
 
 def _newline_separators(command: str) -> str:
-    """A newline ends the command unless it sits inside a quoted argument,
-    where it is ordinary body text — so quote state decides, not str.split."""
-    out, quote, esc = [], None, False
-    for ch in command:
+    """Unquoted `#` comments out to end of line; an unquoted line break ends the
+    command. Comments go FIRST: once a newline is a `;`, nothing terminates one."""
+    out, quote, esc, comment = [], None, False, False
+    prev = " "
+    for i, ch in enumerate(command):
+        if comment:
+            if ch in "\r\n":
+                comment = False
+            else:
+                prev = ch
+                continue
         if esc:
-            out.append(ch); esc = False; continue
+            out.append(ch); esc = False; prev = ch; continue
         if ch == "\\" and quote != "'":
-            out.append(ch); esc = True; continue
+            out.append(ch); esc = True; prev = ch; continue
         if quote is None and ch in ("'", '"'):
             quote = ch
         elif ch == quote:
             quote = None
-        out.append(";" if (ch == "\n" and quote is None) else ch)
+        # A `#` starts a comment only at the start of a word — `a#b` is literal.
+        if ch == "#" and quote is None and (prev.isspace() or prev == ""):
+            comment = True; prev = ch; continue
+        if ch in "\r\n" and quote is None:
+            if not (ch == "\r" and command[i + 1:i + 2] == "\n"):
+                out.append(";")
+            prev = ch
+            continue
+        out.append(ch); prev = ch
     return "".join(out)
 
 
@@ -76,7 +95,8 @@ def offenders(command: str):
             armed = True
         if armed and w in BODY_FLAGS and i + 1 < len(words):
             val = words[i + 1]
-            if val.startswith('"') and SUBSTITUTES.search(val):
+            if (val.startswith('"') and SUBSTITUTES.search(val)
+                    and not WHOLE_SUBSTITUTION.match(val)):
                 out.append(w)
         i += 1
     return out

--- a/hooks/inline-body-substitution-guard.py
+++ b/hooks/inline-body-substitution-guard.py
@@ -34,6 +34,23 @@ def _deny(reason):
     sys.exit(0)
 
 
+def _newline_separators(command: str) -> str:
+    """A newline ends the command unless it sits inside a quoted argument,
+    where it is ordinary body text — so quote state decides, not str.split."""
+    out, quote, esc = [], None, False
+    for ch in command:
+        if esc:
+            out.append(ch); esc = False; continue
+        if ch == "\\" and quote != "'":
+            out.append(ch); esc = True; continue
+        if quote is None and ch in ("'", '"'):
+            quote = ch
+        elif ch == quote:
+            quote = None
+        out.append(";" if (ch == "\n" and quote is None) else ch)
+    return "".join(out)
+
+
 def offenders(command: str):
     """Flags whose inline double-quoted value the shell would rewrite.
 
@@ -43,6 +60,7 @@ def offenders(command: str):
     # `--body="x"` never lexes as one token: a quote only opens a string at a
     # token boundary, so normalise it to the space form before splitting.
     command = EQUALS_FORM.sub(r"\1 ", command)
+    command = _newline_separators(command)
     try:
         lex = shlex.shlex(command, posix=False, punctuation_chars=True)
         lex.whitespace_split = True

--- a/hooks/inline-body-substitution-guard.py
+++ b/hooks/inline-body-substitution-guard.py
@@ -57,17 +57,20 @@ def _newline_separators(command: str) -> str:
             quote = ch
         elif ch == quote:
             quote = None
-        # A `#` starts a comment only at the start of a word — `a#b` is literal.
-        if ch == "#" and quote is None and (prev.isspace() or prev == ""):
+        # bash opens a comment only at a word start, and `;&|()` end a word too.
+        # `a#b` and `x/y#frag` stay literal.
+        if ch == "#" and quote is None and (
+                prev.isspace() or prev == "" or prev in ";&|()"):
             comment = True; prev = ch; continue
         if ch in "\r\n" and quote is None:
+            # CRLF is ONE separator: two `;` lex as the single token `;;`,
+            # which is not in SEPARATORS, so `armed` would never reset.
             if not (ch == "\r" and command[i + 1:i + 2] == "\n"):
                 out.append(";")
             prev = ch
             continue
         out.append(ch); prev = ch
     return "".join(out)
-
 
 def offenders(command: str):
     """Flags whose inline double-quoted value the shell would rewrite.
@@ -81,6 +84,7 @@ def offenders(command: str):
     command = _newline_separators(command)
     try:
         lex = shlex.shlex(command, posix=False, punctuation_chars=True)
+        lex.commenters = ""  # _newline_separators owns comments; shlex's fire mid-word
         lex.whitespace_split = True
         words = list(lex)
     except ValueError:

--- a/tests/inline-body-substitution-guard.test.py
+++ b/tests/inline-body-substitution-guard.test.py
@@ -22,6 +22,36 @@ spec.loader.exec_module(G)
 
 
 class TestOffenders(unittest.TestCase):
+    def test_an_unquoted_hash_comments_out_the_rest_of_ITS_line_only(self):
+        """`shlex` keeps commenters='#', and once newlines became ';' nothing
+        terminated a comment — so a '#' on line 1 hid a violation on line 2
+        (vidhuUC, reproduced by sonichi, on both guards)."""
+        self.assertEqual(
+            G.offenders('echo hi # deploying now\n'
+                        'gh pr comment 1 --body "cost is $(wc -l)"'), ["--body"])
+        self.assertEqual(
+            G.offenders('echo hi # deploying now\r\n'
+                        'gh pr comment 1 --body "cost is $(wc -l)"'), ["--body"])
+
+    def test_a_fully_commented_command_is_not_a_violation(self):
+        """Why commenters='' would be the WRONG fix: it would flag this."""
+        self.assertEqual(G.offenders('# gh pr comment 1 --body "x $(date)"'), [])
+
+    def test_a_hash_inside_a_quoted_body_is_text(self):
+        self.assertEqual(G.offenders('gh pr comment 1 --body "a # b"'), [])
+
+    def test_an_escaped_backtick_publishes_literally(self):
+        """It is not a rewrite, so denying it cries wolf (sonichi)."""
+        self.assertEqual(G.offenders(r'gh pr comment 1 --body "use \`code\` here"'), [])
+        self.assertEqual(G.offenders('gh pr comment 1 --body "use `code` here"'), ["--body"])
+
+    def test_a_whole_value_substitution_is_the_intended_content(self):
+        """`--body "$(cat f)"` is the standard file-passing idiom: the value IS
+        the substitution, so nothing of the author's prose is lost."""
+        self.assertEqual(G.offenders('gh pr comment 1 --body "$(cat /tmp/body.md)"'), [])
+        self.assertEqual(
+            G.offenders('gh pr comment 1 --body "built at $(date) ok"'), ["--body"])
+
     def test_a_newline_ends_the_command_like_a_semicolon(self):
         """`whitespace_split` eats a newline, so `armed` survived a line break
         and a non-gh tool on line 2 was denied (yixuan-ag2, #3830)."""

--- a/tests/inline-body-substitution-guard.test.py
+++ b/tests/inline-body-substitution-guard.test.py
@@ -22,6 +22,25 @@ spec.loader.exec_module(G)
 
 
 class TestOffenders(unittest.TestCase):
+    def test_a_newline_ends_the_command_like_a_semicolon(self):
+        """`whitespace_split` eats a newline, so `armed` survived a line break
+        and a non-gh tool on line 2 was denied (yixuan-ag2, #3830)."""
+        self.assertEqual(
+            G.offenders('gh pr view 1 --repo o/r --json title\n'
+                        'my-notes-tool --title "x $(date)"'), [])
+
+    def test_a_newline_INSIDE_a_quoted_body_is_body_text(self):
+        """The obvious fix — split the raw string on newlines — loses this:
+        the token breaks, the lexer hits an unterminated quote, and a real
+        violation returns []. A multi-line body is how the incident was written."""
+        self.assertEqual(
+            G.offenders('gh pr comment 1 --body "built at $(date)\n'
+                        'second line of the body"'), ["--body"])
+
+    def test_a_violation_on_a_later_line_is_still_caught(self):
+        self.assertEqual(
+            G.offenders('echo hi\ngh pr comment 1 --body "x $(date)"'), ["--body"])
+
     def test_the_case_that_actually_published_with_holes(self):
         self.assertEqual(
             G.offenders('gh pr comment 3829 --repo o/r --body "Applied `shlex.shlex` as written"'),

--- a/tests/inline-body-substitution-guard.test.py
+++ b/tests/inline-body-substitution-guard.test.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""A `gh --body` written inline in double quotes loses every code span.
+
+Measured 2026-09-03 on sonichi/sutando#3829: a review reply containing
+`shlex.shlex(...)` and `shlex.split` published with holes where those spans had
+been — "Applied as you wrote it — with , reset on a separator, and ." The
+command succeeded and returned a comment URL, so nothing looked wrong until the
+comment was read back. Repaired by PATCHing the comment from a file.
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+HOOK = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                    "hooks", "inline-body-substitution-guard.py")
+spec = importlib.util.spec_from_file_location("ibg", HOOK)
+G = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(G)
+
+
+class TestOffenders(unittest.TestCase):
+    def test_the_case_that_actually_published_with_holes(self):
+        self.assertEqual(
+            G.offenders('gh pr comment 3829 --repo o/r --body "Applied `shlex.shlex` as written"'),
+            ["--body"])
+
+    def test_a_subshell_is_eaten_the_same_way(self):
+        self.assertEqual(
+            G.offenders('gh pr comment 1 --body "head is $(git rev-parse HEAD)"'), ["--body"])
+
+    def test_single_quotes_are_safe_and_allowed(self):
+        """The shell does not substitute inside single quotes, so this publishes
+        exactly what was written — denying it would be a false positive."""
+        self.assertEqual(
+            G.offenders("gh pr comment 1 --body 'Applied `shlex.shlex` as written'"), [])
+
+    def test_body_file_is_the_fix_and_is_never_flagged(self):
+        self.assertEqual(G.offenders("gh pr comment 1 --body-file /tmp/b.md"), [])
+
+    def test_a_plain_body_with_no_substitution_is_allowed(self):
+        self.assertEqual(G.offenders('gh pr comment 1 --body "no code spans here"'), [])
+
+    def test_a_dollar_variable_is_not_flagged(self):
+        """`$VAR` interpolation is ordinary and usually intended; flagging it
+        would make the guard fire on routine commands and get it switched off."""
+        self.assertEqual(G.offenders('gh pr comment 1 --body "head is $SHA"'), [])
+
+    def test_equals_form_is_the_same_case(self):
+        self.assertEqual(G.offenders('gh pr create --title="a `b` c"'), ["--title"])
+
+    def test_notes_on_a_release_counts_too(self):
+        self.assertEqual(
+            G.offenders('gh release create v1 --notes "see `foo`"'), ["--notes"])
+
+    def test_another_tool_is_not_this_guard_s_business(self):
+        self.assertEqual(G.offenders('curl -d "a `b` c" https://x'), [])
+
+    def test_a_non_gh_tool_using_the_same_flag_name_is_not_flagged(self):
+        """The scoping is load-bearing, and only a non-gh command using one of
+        these very flags can show it: `curl -d` shares no flag name, so it is
+        satisfied whether or not the guard checks which tool it is."""
+        self.assertEqual(G.offenders('glab mr note 1 --body "a `b` c"'), [])
+        self.assertEqual(G.offenders('my-tool --notes "a `b` c"'), [])
+
+    def test_a_separator_ends_the_gh_command(self):
+        self.assertEqual(
+            G.offenders('gh pr view 1 && curl -d "a `b` c" https://x'), [])
+
+    def test_a_path_qualified_gh_still_arms(self):
+        self.assertEqual(
+            G.offenders('/opt/homebrew/bin/gh pr comment 1 --body "a `b` c"'), ["--body"])
+
+    def test_unbalanced_quotes_do_not_raise(self):
+        self.assertEqual(G.offenders('gh pr comment 1 --body "unclosed `'), [])
+
+
+class TestHookIO(unittest.TestCase):
+    def _run(self, payload, env=None):
+        e = dict(os.environ)
+        e.pop("SUTANDO_SKIP_INLINE_BODY_GUARD", None)
+        e.update(env or {})
+        p = subprocess.run([sys.executable, HOOK], input=json.dumps(payload),
+                           capture_output=True, text=True, env=e)
+        return p.returncode, p.stdout
+
+    def test_denies_and_names_the_fix(self):
+        rc, out = self._run({"tool_name": "Bash", "tool_input": {
+            "command": 'gh pr comment 1 --body "a `b` c"'}})
+        self.assertEqual(rc, 0)
+        d = json.loads(out)["hookSpecificOutput"]
+        self.assertEqual(d["permissionDecision"], "deny")
+        self.assertIn("--body-file", d["permissionDecisionReason"])
+
+    def test_allows_body_file_silently(self):
+        rc, out = self._run({"tool_name": "Bash", "tool_input": {
+            "command": "gh pr comment 1 --body-file /tmp/b.md"}})
+        self.assertEqual((rc, out.strip()), (0, ""))
+
+    def test_a_non_bash_tool_is_ignored(self):
+        rc, out = self._run({"tool_name": "Write", "tool_input": {
+            "command": 'gh pr comment 1 --body "a `b` c"'}})
+        self.assertEqual((rc, out.strip()), (0, ""))
+
+    def test_the_escape_hatch_allows(self):
+        rc, out = self._run({"tool_name": "Bash", "tool_input": {
+            "command": 'gh pr comment 1 --body "a `b` c"'}},
+            env={"SUTANDO_SKIP_INLINE_BODY_GUARD": "1"})
+        self.assertEqual((rc, out.strip()), (0, ""))
+
+    def test_malformed_input_fails_open(self):
+        p = subprocess.run([sys.executable, HOOK], input="not json",
+                           capture_output=True, text=True)
+        self.assertEqual(p.returncode, 0)
+        self.assertEqual(p.stdout.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/inline-body-substitution-guard.test.py
+++ b/tests/inline-body-substitution-guard.test.py
@@ -122,6 +122,36 @@ class TestOffenders(unittest.TestCase):
         self.assertEqual(
             G.offenders('/opt/homebrew/bin/gh pr comment 1 --body "a `b` c"'), ["--body"])
 
+    def test_a_hash_opens_a_comment_after_a_separator_too_not_only_whitespace(self):
+        """The word-start test was `prev.isspace()`, but `;` `&` `|` `(` `)`
+        end a word in bash too — so `;#` commented the line and the guard then
+        never saw the NEXT line, which the shell does run."""
+        self.assertEqual(
+            G.offenders('echo hi;# note\ngh pr comment 1 --body "a `b` c"'), ["--body"])
+        self.assertEqual(
+            G.offenders('echo hi&&# note\ngh pr comment 1 --body "a `b` c"'), ["--body"])
+        self.assertEqual(
+            G.offenders('echo hi|# note\ngh pr comment 1 --body "a `b` c"'), ["--body"])
+
+    def test_a_mid_word_hash_is_literal_and_must_not_blank_the_rest(self):
+        """`shlex`'s own `commenters` fires anywhere, including inside a word,
+        where bash keeps a literal `#`. A URL fragment or an issue ref before
+        the `gh` silently disabled the guard for the rest of the command."""
+        self.assertEqual(
+            G.offenders('echo a#b; gh pr comment 1 --body "a `b` c"'), ["--body"])
+        self.assertEqual(
+            G.offenders('echo https://x/y#frag && gh pr comment 1 --body "a `b` c"'),
+            ["--body"])
+
+    def test_a_gh_INSIDE_a_comment_is_still_not_flagged(self):
+        """False-positive control. Green before and after the fix by
+        construction — it pins that stripping comments did not buy the
+        catches above by flagging text bash never runs."""
+        self.assertEqual(
+            G.offenders('echo hi\n# gh pr comment 1 --body "a `b` c"'), [])
+        self.assertEqual(
+            G.offenders('echo hi;# gh pr comment 1 --body "a `b` c"'), [])
+
     def test_unbalanced_quotes_do_not_raise(self):
         self.assertEqual(G.offenders('gh pr comment 1 --body "unclosed `'), [])
 


### PR DESCRIPTION
Closes a failure I committed today, in public, on another PR of mine.

## What happens

`gh pr comment <n> --body "…"` with a backtick inside the double quotes: the shell substitutes it before gh ever runs. The comment publishes with **holes** where its code spans were, the command exits 0, and a comment URL comes back. Nothing reports an error.

Measured on sonichi/sutando#3829 today. What I wrote:

```
Applied as you wrote it — `shlex.shlex(posix=True, punctuation_chars=True)` with
`whitespace_split`, `armed` reset on a separator, and `os.path.basename(w) == "gh"`.
```

What published:

```
Applied as you wrote it —  with ,  reset on a separator, and .
```

Three sentences arrived gutted, and I only found out by reading the comment back. Repaired with `gh api --method PATCH .../issues/comments/<id> -F body=@file`.

## The rule

Deny `--body` / `--notes` / `--title` passed inline **in double quotes** when the value contains a backtick or `$(`. Allowed:

- **single quotes** — the shell does not substitute inside them, so the text publishes verbatim. Denying these would be a false positive on a perfectly good command.
- **`--body-file`** — the fix, and what the denial message names.
- **`$VAR`** — ordinary interpolation, usually intended. Flagging it would make the guard fire on routine commands, and a guard that cries wolf gets switched off.

Scoped to `gh`, where the loss is both silent and public. `armed` resets on a shell separator and arms on `os.path.basename(w) == "gh"`, so a path-qualified `gh` counts and a later tool does not — the same shape as `release-target-guard`.

One tokenizer detail worth stating: `--body="x"` never lexes as a single token, because a quote only opens a string at a token boundary. The guard normalises `--flag=` to the space form before splitting rather than special-casing it downstream.

## Evidence

```
$ /usr/bin/python3 tests/inline-body-substitution-guard.test.py
Ran 18 tests   OK
```

Mutations, each verified red:

| mutation | result |
|---|---|
| flag single quotes too (false positive) | `FAILED (failures=1)` |
| treat `$VAR` as a substitution too | `FAILED (failures=1)` |
| drop the `--flag=` normalisation | `FAILED (failures=1)` |
| arm on any command, not just `gh` | `FAILED (failures=1)` |
| never deny | `FAILED (errors=1)` |
| (restored) | `OK` |

**Two of those five were green on my first attempt, for different reasons, and I am reporting that rather than the tidy table.**

The single-quote mutation came back green because the edit never applied — my substitution string did not match the source, so the "mutation" ran against unmodified code. It is red once actually applied, which I confirmed by printing the anchor count and the post-edit count before running.

The `gh`-scoping mutation was genuinely green: my only non-`gh` test used `curl -d`, which shares no flag name with the guard, so it passes whether or not the guard checks which tool it is. Added `glab mr note --body` and `my-tool --notes` — commands that use these exact flags — and the mutation goes red.

`tests/ci-covers-every-python-test.test.py` OK. `review-checks.sh` PASS on the diff.

**Not deployed on this node.** `hooks/` is version-controlled source; registration is the per-node step in the README section this PR adds. So the guard does not yet protect the machine that produced the incident — a follow-up, not a claim made here.

— sutando-qingyun-air (@qingyun-air.agent:ag2.space)
