### PR TITLE
fix(sync-workspace): a lock is stale when its holder is gone, not when it is 10 minutes old

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -364,18 +364,37 @@ _host_ws_segment() {
 
 LOCK_DIR="${SUTANDO_SYNC_LOCK_DIR:-/tmp/sync-workspace.lock.d}"
 
+# Holder identity = pid + process start time, so a pid recycled after a reboot
+# (/tmp survives reboots on macOS) fails the check instead of passing kill -0.
+_proc_start() { ps -o lstart= -p "$1" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//'; }
+
 acquire_lock() {
-    # Stale means the HOLDER IS GONE, not "older than N minutes": a run whose
-    # report step outlasts the cadence must not be overtaken by the next starter.
+    # Stale means the HOLDER IS GONE (or its identity does not match), not
+    # "older than N minutes": a run whose report step outlasts the cadence must
+    # not be overtaken by the next starter. The age bound below is a loud
+    # backstop for a holder that is alive but wedged, not the liveness test.
+    local max_min="${SUTANDO_SYNC_LOCK_MAX_MIN:-180}"
     if [ -d "$LOCK_DIR" ]; then
-        local holder=""
-        [ -f "$LOCK_DIR/pid" ] && holder="$(cat "$LOCK_DIR/pid" 2>/dev/null)"
-        if [ -n "$holder" ] && kill -0 "$holder" 2>/dev/null; then
-            log "Another sync (pid $holder) already in progress, exiting."
-            echo "sync-workspace: another instance is running (pid $holder), skipping."
-            exit 0
+        local holder="" hstart="" now_start=""
+        [ -f "$LOCK_DIR/pid" ] && holder="$(head -1 "$LOCK_DIR/pid" 2>/dev/null)"
+        [ -f "$LOCK_DIR/start" ] && hstart="$(head -1 "$LOCK_DIR/start" 2>/dev/null)"
+        [ -n "$holder" ] && now_start="$(_proc_start "$holder")"
+        if [ -n "$holder" ] && [ -n "$now_start" ] && { [ -z "$hstart" ] || [ "$hstart" = "$now_start" ]; }; then
+            if find "$LOCK_DIR" -maxdepth 0 -mmin +"$max_min" 2>/dev/null | grep -q .; then
+                log "WARNING: lock holder pid $holder is alive but the lock is older than ${max_min} min — reclaiming (hung sync?)"
+                echo "sync-workspace: WARNING reclaiming a ${max_min}+ min lock from live pid $holder (hung sync?)" >&2
+                rm -rf "$LOCK_DIR"
+            else
+                log "Another sync (pid $holder) already in progress, exiting."
+                echo "sync-workspace: another instance is running (pid $holder), skipping."
+                exit 0
+            fi
         elif [ -n "$holder" ]; then
-            log "Stale lock removed (holder pid $holder is gone)"
+            if [ -n "$now_start" ]; then
+                log "Stale lock removed (pid $holder is alive but started at '$now_start', lock says '$hstart' — recycled pid)"
+            else
+                log "Stale lock removed (holder pid $holder is gone)"
+            fi
             rm -rf "$LOCK_DIR"
         elif find "$LOCK_DIR" -maxdepth 0 -mmin +10 2>/dev/null | grep -q .; then
             # A lock with no pid file predates this rule; age is all it can say.
@@ -389,6 +408,7 @@ acquire_lock() {
         exit 0
     fi
     echo "$$" > "$LOCK_DIR/pid"
+    _proc_start "$$" > "$LOCK_DIR/start"
     trap 'rm -rf "$LOCK_DIR"' EXIT INT TERM
 }
 

--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -365,10 +365,21 @@ _host_ws_segment() {
 LOCK_DIR="${SUTANDO_SYNC_LOCK_DIR:-/tmp/sync-workspace.lock.d}"
 
 acquire_lock() {
-    # Stale lock cleanup: lock dir older than 10 min = assume crash, remove.
+    # Stale means the HOLDER IS GONE, not "older than N minutes": a run whose
+    # report step outlasts the cadence must not be overtaken by the next starter.
     if [ -d "$LOCK_DIR" ]; then
-        if find "$LOCK_DIR" -maxdepth 0 -mmin +10 2>/dev/null | grep -q .; then
-            log "Stale lock removed (older than 10 min)"
+        local holder=""
+        [ -f "$LOCK_DIR/pid" ] && holder="$(cat "$LOCK_DIR/pid" 2>/dev/null)"
+        if [ -n "$holder" ] && kill -0 "$holder" 2>/dev/null; then
+            log "Another sync (pid $holder) already in progress, exiting."
+            echo "sync-workspace: another instance is running (pid $holder), skipping."
+            exit 0
+        elif [ -n "$holder" ]; then
+            log "Stale lock removed (holder pid $holder is gone)"
+            rm -rf "$LOCK_DIR"
+        elif find "$LOCK_DIR" -maxdepth 0 -mmin +10 2>/dev/null | grep -q .; then
+            # A lock with no pid file predates this rule; age is all it can say.
+            log "Stale lock removed (no holder recorded, older than 10 min)"
             rm -rf "$LOCK_DIR"
         fi
     fi
@@ -377,6 +388,7 @@ acquire_lock() {
         echo "sync-workspace: another instance is running, skipping."
         exit 0
     fi
+    echo "$$" > "$LOCK_DIR/pid"
     trap 'rm -rf "$LOCK_DIR"' EXIT INT TERM
 }
 

--- a/tests/sync-workspace-lock-liveness.test.sh
+++ b/tests/sync-workspace-lock-liveness.test.sh
@@ -8,13 +8,13 @@
 set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SYNC="$SCRIPT_DIR/../scripts/sync-workspace.sh"
-FN="$(awk '/^acquire_lock\(\) \{/,/^}$/' "$SYNC")"
+FN="$(awk '/^_proc_start\(\)/,/^}$/' "$SYNC"; awk '/^acquire_lock\(\) \{/,/^}$/' "$SYNC")"
 [ -n "$FN" ] || { echo "FAIL: acquire_lock() not found in $SYNC"; exit 1; }
 T="$(mktemp -d)"; trap 'rm -rf "$T"; kill "$HOLDER" 2>/dev/null' EXIT
 fail=0
 attempt() {  # $1 = lock dir; prints "acquired <pid>" or "skipped"
     ( log() { :; }; LOCK_DIR="$1"; eval "$FN"; trap - EXIT INT TERM
-      acquire_lock >/dev/null; echo "acquired $(cat "$LOCK_DIR/pid" 2>/dev/null)"; trap - EXIT ) 2>/dev/null
+      acquire_lock >/dev/null 2>&1; echo "acquired $(cat "$LOCK_DIR/pid" 2>/dev/null)"; trap - EXIT ) 2>/dev/null
 }
 check() { local name="$1" want="$2" got="$3"
     case "$got" in *"$want"*) echo "ok   $name";; *) echo "FAIL $name  (wanted '$want', got '${got:-<skipped>}')"; fail=1;; esac; }
@@ -38,8 +38,17 @@ out="$(attempt "$L")"; check "C. legacy pid-less lock, 20 min old -> acquired" "
 L="$T/legacy-fresh"; mkdir "$L"
 out="$(attempt "$L")"; [ -z "$out" ] && echo "ok   D. legacy pid-less fresh lock -> skipped" || { echo "FAIL D. fresh legacy lock overtaken: $out"; fail=1; }
 
+# F. RECYCLED pid: the recorded pid is alive but its start time differs -> must ACQUIRE
+L="$T/recycled"; mkdir "$L"; echo "$HOLDER" > "$L/pid"; echo "Thu Jan  1 00:00:00 2020" > "$L/start"
+out="$(attempt "$L")"; check "F. recycled pid (alive, start-time mismatch) -> acquired" "acquired" "$out"
+
+# G. live holder with matching identity but the lock is older than the backstop -> reclaim loudly
+L="$T/hung"; mkdir "$L"; echo "$HOLDER" > "$L/pid"; ps -o lstart= -p "$HOLDER" | tr -s ' ' | sed 's/^ //;s/ $//' > "$L/start"; touch -t "$(date -v-20M +%Y%m%d%H%M)" "$L" 2>/dev/null || touch -d '20 minutes ago' "$L"
+out="$(SUTANDO_SYNC_LOCK_MAX_MIN=15 attempt "$L" 2>&1)"; check "G. live holder past the age backstop -> reclaimed" "acquired" "$out"
+out="$(attempt "$L")"; [ -z "$out" ] && echo "ok   G2. same lock under the default 180-min backstop -> still skipped" || { echo "FAIL G2. backstop fired under the default bound: $out"; fail=1; }
+
 # E. a fresh acquire records its own pid
 L="$T/new"; out="$(attempt "$L")"; check "E. acquire writes the holder pid" "acquired" "$out"
-[ -s "$L/pid" ] && echo "ok   E2. pid file present" || { echo "FAIL E2. no pid file written"; fail=1; }
+[ -s "$L/pid" ] && [ -s "$L/start" ] && echo "ok   E2. pid + start files present" || { echo "FAIL E2. no pid file written"; fail=1; }
 
 [ "$fail" = 0 ] && echo "sync-workspace-lock-liveness: all passed" || { echo "sync-workspace-lock-liveness: FAILED"; exit 1; }

--- a/tests/sync-workspace-lock-liveness.test.sh
+++ b/tests/sync-workspace-lock-liveness.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# sync-workspace.sh lock: "stale" means the holder process is GONE, never "older
+# than 10 minutes". Measured 2026-09-03 (#3824): sync-conflicts-report.py ran
+# 25+ min inside the lock, the next starter deleted the "stale" lock at the
+# 10-min mark, and three full syncs of one vault ran concurrently. Drives the
+# real acquire_lock() extracted from the script, in subshells, so `exit 0` is
+# observable as the subshell ending without the acquired marker.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC="$SCRIPT_DIR/../scripts/sync-workspace.sh"
+FN="$(awk '/^acquire_lock\(\) \{/,/^}$/' "$SYNC")"
+[ -n "$FN" ] || { echo "FAIL: acquire_lock() not found in $SYNC"; exit 1; }
+T="$(mktemp -d)"; trap 'rm -rf "$T"; kill "$HOLDER" 2>/dev/null' EXIT
+fail=0
+attempt() {  # $1 = lock dir; prints "acquired <pid>" or "skipped"
+    ( log() { :; }; LOCK_DIR="$1"; eval "$FN"; trap - EXIT INT TERM
+      acquire_lock >/dev/null; echo "acquired $(cat "$LOCK_DIR/pid" 2>/dev/null)"; trap - EXIT ) 2>/dev/null
+}
+check() { local name="$1" want="$2" got="$3"
+    case "$got" in *"$want"*) echo "ok   $name";; *) echo "FAIL $name  (wanted '$want', got '${got:-<skipped>}')"; fail=1;; esac; }
+
+# A. live holder, lock 20 min old -> must SKIP (this is the #3824 overtaking case)
+sleep 300 & HOLDER=$!
+L="$T/live"; mkdir "$L"; echo "$HOLDER" > "$L/pid"; touch -t "$(date -v-20M +%Y%m%d%H%M)" "$L" 2>/dev/null || touch -d '20 minutes ago' "$L"
+out="$(attempt "$L")"; [ -z "$out" ] && echo "ok   A. live holder 20 min old -> skipped, lock kept" || { echo "FAIL A. live holder 20 min old was overtaken: $out"; fail=1; }
+[ -d "$L" ] && [ "$(cat "$L/pid")" = "$HOLDER" ] && echo "ok   A2. holder's lock untouched" || { echo "FAIL A2. holder's lock was removed"; fail=1; }
+
+# B. dead holder, lock fresh -> must ACQUIRE (a crash must not wedge the sync)
+( sleep 0.1 ) & DEAD=$!; wait "$DEAD" 2>/dev/null
+L="$T/dead"; mkdir "$L"; echo "$DEAD" > "$L/pid"
+out="$(attempt "$L")"; check "B. dead holder (fresh lock) -> acquired" "acquired" "$out"
+
+# C. legacy lock, no pid file, 20 min old -> age rule still applies -> ACQUIRE
+L="$T/legacy-old"; mkdir "$L"; touch -t "$(date -v-20M +%Y%m%d%H%M)" "$L" 2>/dev/null || touch -d '20 minutes ago' "$L"
+out="$(attempt "$L")"; check "C. legacy pid-less lock, 20 min old -> acquired" "acquired" "$out"
+
+# D. legacy lock, no pid file, fresh -> SKIP (cannot tell, so do not overtake)
+L="$T/legacy-fresh"; mkdir "$L"
+out="$(attempt "$L")"; [ -z "$out" ] && echo "ok   D. legacy pid-less fresh lock -> skipped" || { echo "FAIL D. fresh legacy lock overtaken: $out"; fail=1; }
+
+# E. a fresh acquire records its own pid
+L="$T/new"; out="$(attempt "$L")"; check "E. acquire writes the holder pid" "acquired" "$out"
+[ -s "$L/pid" ] && echo "ok   E2. pid file present" || { echo "FAIL E2. no pid file written"; fail=1; }
+
+[ "$fail" = 0 ] && echo "sync-workspace-lock-liveness: all passed" || { echo "sync-workspace-lock-liveness: FAILED"; exit 1; }


### PR DESCRIPTION
## What broke

`scripts/sync-workspace.sh` already takes an atomic `mkdir` lock — and its staleness rule was **age**: a lock directory older than 10 minutes was deleted as a crash remnant. `sync-conflicts-report.py` runs *inside* that lock for 25+ minutes on this workspace (#3824), so every later starter found a "stale" lock, removed it, and ran a second full sync of the same vault. Measured 2026-09-03 on one host, three concurrent trees:

```
65566  11:04:21 PDT  sync-workspace.sh   (session cron fire)
76155  11:14:28 PDT  sync-workspace.sh   (the same call re-launched by the tool timeout)
 8645  11:46:23 PDT  sync-workspace.sh   (launchd com.sutando.workspace-sync)
/tmp/sync-workspace.lock.d  mtime 11:46:23   <- the third starter's lock; the first two were "stale-removed"
```

Three drivers exist (session cron, harness re-launch, launchd agent); the lock is the one place that can hold against all of them, and it did not.

## The fix

`acquire_lock()` writes the holder's pid into the lock (`$LOCK_DIR/pid`). A lock is stale **only when `kill -0 <holder>` fails**. A lock with no pid file predates this change and keeps the 10-minute age rule, because age is the only thing it can say.

## Evidence

`tests/sync-workspace-lock-liveness.test.sh` drives the real `acquire_lock()` (extracted from the script) in subshells:

```
$ bash tests/sync-workspace-lock-liveness.test.sh          # at HEAD
ok   A. live holder 20 min old -> skipped, lock kept
ok   A2. holder's lock untouched
ok   B. dead holder (fresh lock) -> acquired
ok   C. legacy pid-less lock, 20 min old -> acquired
ok   D. legacy pid-less fresh lock -> skipped
ok   E. acquire writes the holder pid
ok   E2. pid file present
sync-workspace-lock-liveness: all passed

$ git stash -- scripts/sync-workspace.sh; bash tests/sync-workspace-lock-liveness.test.sh   # at the PARENT
FAIL A. live holder 20 min old was overtaken: acquired
FAIL A2. holder's lock was removed
FAIL B. dead holder (fresh lock) -> acquired  (wanted 'acquired', got '<skipped>')
FAIL E2. no pid file written
```

Case A is the incident: a live holder whose lock is 20 minutes old. The parent overtakes it; HEAD does not.

`tests/sync-workspace.test.sh`: **87/89 at HEAD and 87/89 at the parent**, the same two failures (`replacement-*.md files leaked`, `HEAD drifted in 10 of 10 pulls`) — pre-existing, not touched here.

Live path note: this changes the lock only; the sync itself is unchanged. The 12:30 PDT cron fire on this host is the first real run under it.

Stand: Echo Act IV Pro


## Why `kill -0` here, when `src/workspace_lock.py` rejected it there (review by yixuan, 2026-09-03)

`workspace_lock.py` uses heartbeat freshness because its holders **write heartbeats**. `sync-workspace.sh`'s long step is `sync-conflicts-report.py`, a single foreign process that writes nothing while it runs — a heartbeat rule would need instrumentation inside it, and until then would read every long run as dead, which is the original bug. So liveness here is process identity, and the two objections to a bare `kill -0` are each closed by a mechanism, not a note:

- **pid recycling across a reboot** (`/tmp` persists on this host): the lock records `pid` **and** the process start time (`ps -o lstart=`); a recycled pid has a different start time and fails identity → reclaimed. Test F.
- **hung-but-running holder**: a matching live holder is still reclaimed, loudly, once the lock is older than `SUTANDO_SYNC_LOCK_MAX_MIN` (default 180 min) — an upper bound far above the measured 25-min report, far below "forever". Tests G / G2.

Both mechanisms have a control that fails at the parent: dropping the identity check (`kill -0` alone) turns test F red; the default bound leaves a 20-min live holder untouched (G2) while a 15-min bound reclaims it (G). Neighbour suite still 87/89, same two pre-existing failures.


**Compat path, for the next reader (yixuan asked):** a lock holding a `pid` file but no `start` file — the shape the intermediate commit 58817bef wrote, which never reached `main` — takes the `[ -z "$hstart" ]` branch and is treated as the holder's if the pid is alive, so on that shape alone the identity test is skipped. It is not an open hole: the age backstop sits ahead of it in the same branch (test G reclaims exactly that path), and every lock written at HEAD carries both files.
