### PR TITLE
feat(restart): --rebuild-app rebuilds the menu-bar app before relaunching it

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4207,7 +4207,7 @@ def mark_stale_if_outdated(check: dict, src_file: Path, pgrep_pattern: str, thre
                     return
                 age_min = int((src_mtime - bin_mtime) / 60)
                 check["status"] = "stale"
-                check["detail"] = f"running, but binary is {age_min} min older than source — rebuild needed"
+                check["detail"] = f"running, but binary is {age_min} min older than source — rebuild needed (bash src/restart.sh --rebuild-app)"
                 return
         except OSError:
             pass

--- a/src/restart.sh
+++ b/src/restart.sh
@@ -3,8 +3,11 @@
 # Does NOT touch the Claude Code CLI (core agent) — that's managed separately.
 # Usage: bash src/restart.sh
 #   --stop-only    Stop without restarting
+#   --rebuild-app  Rebuild the menu-bar app (scripts/install-menu-bar-app.sh) before relaunching it
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
+REBUILD_APP=0
+[ "${1:-}" = "--rebuild-app" ] && REBUILD_APP=1
 
 # The sentinel IS the clean-exit signal, so a failed write must be visible: a
 # stub interpreter here would let a stop look successful while nothing changed.
@@ -129,6 +132,18 @@ done
 # A restart is not a shutdown: a sentinel left set would make the surviving
 # core read it as one. --stop-only exits above and deliberately keeps it.
 _shutdown_state clear || true
+
+# The app is already stopped (pkill above, drained by the wait loop), so the
+# build replaces a binary nothing is running. A failed build keeps the old one.
+if [ "$REBUILD_APP" -eq 1 ]; then
+    echo "Rebuilding the menu-bar app..."
+    if bash "$REPO/scripts/install-menu-bar-app.sh" > /tmp/sutando-app-build.log 2>&1; then
+        echo "  ✓ menu-bar app rebuilt"
+    else
+        echo "  ✗ menu-bar app rebuild failed — see /tmp/sutando-app-build.log; relaunching the existing binary"
+    fi
+fi
+
 # Relaunch what line 73 killed. This belongs here, not in startup.sh: that file
 # is guarded headless (tests/startup-headless.test.sh) and owns no desktop UI.
 APP_BIN="$REPO/src/Sutando/Sutando"

--- a/tests/restart-rebuild-app.test.py
+++ b/tests/restart-rebuild-app.test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""restart.sh --rebuild-app rebuilds the menu-bar app before relaunching it.
+
+Without it a restart relaunches whatever binary is on disk, so a stale build
+survives every restart and health-check keeps saying "rebuild needed" with no
+command that does it. Set SUTANDO_TEST_RESTART_SH to run these against another
+copy (the control run against the parent fails every test below)."""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+RESTART = Path(os.environ.get("SUTANDO_TEST_RESTART_SH") or REPO / "src" / "restart.sh")
+BLOCK_RE = re.compile(r'^if \[ "\$REBUILD_APP" -eq 1 \]; then\n.*?^fi\n', re.M | re.S)
+
+
+class RestartRebuildApp(unittest.TestCase):
+
+    def setUp(self):
+        self.text = RESTART.read_text()
+
+    def test_the_flag_is_documented_in_the_usage_header(self):
+        self.assertRegex(self.text, re.compile(r"^#   --rebuild-app ", re.M), "usage header does not list --rebuild-app")
+
+    def test_the_flag_arms_the_rebuild(self):
+        self.assertRegex(self.text, r'\[ "\$\{1:-\}" = "--rebuild-app" \] && REBUILD_APP=1')
+
+    def test_the_build_runs_after_the_stop_and_before_the_relaunch(self):
+        """Building while the old app still runs replaces a mapped binary; building
+        after the exec never runs at all."""
+        build = self.text.find('bash "$REPO/scripts/install-menu-bar-app.sh"')
+        self.assertGreater(build, 0, "restart.sh never calls the install script")
+        stop_drained = self.text.index("_shutdown_state clear")
+        launch = self.text.index('nohup "$APP_BIN"')
+        execs = [m.start() for m in re.finditer(r'^exec bash "\$REPO/src/startup\.sh"', self.text, re.M)]
+        self.assertGreater(build, stop_drained, "the build sits before the stop has drained")
+        self.assertLess(build, launch, "the build sits after the relaunch, so the relaunch runs the old binary")
+        self.assertLess(build, min(execs), "the build sits after the terminal exec and can never run")
+
+    def _run_block(self, rebuild: int, stub_rc: int):
+        m = BLOCK_RE.search(self.text)
+        self.assertIsNotNone(m, "could not find the rebuild block to exercise")
+        d = Path(tempfile.mkdtemp())
+        (d / "scripts").mkdir()
+        marker = d / "built.txt"
+        stub = d / "scripts" / "install-menu-bar-app.sh"
+        stub.write_text(f"#!/bin/bash\necho built > {marker}\nexit {stub_rc}\n")
+        stub.chmod(0o755)
+        block = m.group(0).replace("/tmp/sutando-app-build.log", str(d / "build.log"))
+        script = textwrap.dedent(f"""
+            REPO={str(d)!r}
+            REBUILD_APP={rebuild}
+        """) + block + "\necho after-block\n"
+        r = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=20)
+        return r, marker
+
+    def test_without_the_flag_nothing_is_built(self):
+        r, marker = self._run_block(rebuild=0, stub_rc=0)
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertFalse(marker.exists(), "the install script ran without --rebuild-app")
+
+    def test_with_the_flag_the_install_script_runs(self):
+        r, marker = self._run_block(rebuild=1, stub_rc=0)
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertTrue(marker.exists(), "the install script never ran")
+        self.assertIn("menu-bar app rebuilt", r.stdout)
+
+    def test_a_failed_build_keeps_the_restart_going(self):
+        """A build error must not strand the restart before startup.sh."""
+        r, marker = self._run_block(rebuild=1, stub_rc=1)
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertTrue(marker.exists())
+        self.assertIn("rebuild failed", r.stdout)
+        self.assertIn("after-block", r.stdout, "the block aborted the script on a failed build")
+
+    def test_the_script_is_syntactically_valid(self):
+        r = subprocess.run(["bash", "-n", str(RESTART)], capture_output=True, text=True)
+        self.assertEqual(0, r.returncode, r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`bash src/restart.sh --rebuild-app` rebuilds the menu-bar app (via `scripts/install-menu-bar-app.sh`) after the old app has drained and before the existing relaunch. Without the flag nothing changes. A failed build keeps the old binary and the restart continues into `startup.sh`. `health-check.py`'s "rebuild needed" detail now names the command.

## Why

`restart.sh` has one flag (`--stop-only`) and relaunches whatever binary is on disk; the only build path is the install script, which nothing in the restart flow calls. So a stale app survives every restart, and the probe that detects it tells the user to rebuild without saying how. Measured today on one host: binary built Aug 20, newest app commit Aug 21 (#2726), probe red for 2 days across a restart; the fix was the two steps this flag composes, run by hand.

## Where the build sits

After `_shutdown_state clear` (the app is already pkilled and drained by the wait loop, so the build replaces a binary nothing is running) and before the `nohup "$APP_BIN"` relaunch and the terminal `exec`. The test pins all three orderings.

## Evidence

Control: the same test file against the parent's `src/restart.sh` (via `SUTANDO_TEST_RESTART_SH`):

```
$ SUTANDO_TEST_RESTART_SH=<parent restart.sh> python3 tests/restart-rebuild-app.test.py
FAIL: test_a_failed_build_keeps_the_restart_going
FAIL: test_the_build_runs_after_the_stop_and_before_the_relaunch
FAIL: test_the_flag_arms_the_rebuild
FAIL: test_the_flag_is_documented_in_the_usage_header
FAIL: test_with_the_flag_the_install_script_runs
FAIL: test_without_the_flag_nothing_is_built
Ran 7 tests — FAILED (failures=6)
```

At HEAD:

```
$ python3 tests/restart-rebuild-app.test.py
Ran 7 tests — OK
$ python3 tests/restart-relaunches-the-app.test.py            → OK
$ python3 tests/health-check-compiled-artifact-stale.test.py  → OK
$ bash tests/restart-test-harness.test.sh                      → passed=20 failed=0
$ python3 tests/ci-covers-every-python-test.test.py            → OK
$ bash scripts/review-checks.sh --diff <patch>                 → PASS
```

The behavioural tests run the extracted block with a stub install script: with `REBUILD_APP=1` the stub runs and the block prints "rebuilt"; with `0` it does not run; with the stub exiting 1 the block prints "rebuild failed" and the script continues.

## Live path

`restart.sh` is the startup path. The two steps the flag composes were each run live today on the same host (install script built binary+bundle; the relaunch line brought the app back, probe green), but the flag itself has not yet been run end to end because that bounces the bridges. I will run `bash src/restart.sh --rebuild-app` on this host as the round-trip witness in the owner's next restart window and paste the output here.

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)
