### PR TITLE
fix(hooks): a path-qualified gh is still gh, so the review gate sees it

### DIFF
--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -157,6 +157,16 @@ def _heredoc_owner(prefix):
     return None
 
 
+def _is_gh(word: str) -> bool:
+    """A path-qualified `gh` is still gh. `_heredoc_owner` already basenames;
+    the main scan compared the whole word, so an absolute path slipped past."""
+    return word.rsplit("/", 1)[-1] == "gh"
+
+
+def _has_gh(words) -> bool:
+    return any(_is_gh(w) for w in words)
+
+
 def classify(command: str) -> Optional[str]:
     """Return 'APPROVE' / 'REQUEST_CHANGES' / 'COMMENT', or None if not a formal review."""
     if not isinstance(command, str) or "gh" not in command:
@@ -204,8 +214,8 @@ def classify(command: str) -> Optional[str]:
             nested = classify(inner)
             if nested is not None:
                 return nested
-        if "gh" in low and "pr" in low and "review" in low:
-            starts = [i for i, w in enumerate(low) if w == "gh"]
+        if _has_gh(low) and "pr" in low and "review" in low:
+            starts = [i for i, w in enumerate(low) if _is_gh(w)]
             if any(low[i + 1:i + 3] == ["pr", "review"] for i in starts):
                 for w in low:
                     flag = w.lstrip("-")
@@ -219,7 +229,7 @@ def classify(command: str) -> Optional[str]:
                     return "COMMENT"
                 # `gh pr review` with no event flag opens an interactive prompt.
                 return "COMMENT"
-        if "gh" in low and "api" in low and _API_REVIEWS.search(seg):
+        if _has_gh(low) and "api" in low and _API_REVIEWS.search(seg):
             m = _API_EVENT.search(seg)
             if m:
                 return m.group(1)

--- a/hooks/review-authority-guard.py
+++ b/hooks/review-authority-guard.py
@@ -169,7 +169,9 @@ def _has_gh(words) -> bool:
 
 def classify(command: str) -> Optional[str]:
     """Return 'APPROVE' / 'REQUEST_CHANGES' / 'COMMENT', or None if not a formal review."""
-    if not isinstance(command, str) or "gh" not in command:
+    # Case-fold here too: the token scan lowercases, but this prefilter runs
+    # first, and a case-insensitive filesystem runs `GH` as the same binary.
+    if not isinstance(command, str) or "gh" not in command.lower():
         return None
     for m in _HEREDOC.finditer(command):
         # Only program text or API input is scanned; a `cat`/`tee` heredoc that

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -68,6 +68,30 @@ check("request-changes denied when gh is path-qualified",
 check("a binary merely ending in gh is NOT gh",
       run("/usr/bin/notgh pr review 1 --approve", "hold")[0], False)
 
+# macOS filesystems are case-INSENSITIVE, so `GH` runs the very same binary
+# (same inode). The early `"gh" not in command` prefilter was case-sensitive and
+# returned before the token scan lowercased anything.
+check("approve denied when the path is mixed-case",
+      run("/opt/homebrew/bin/" + APPROVE.replace("gh ", "GH ", 1), "hold")[0], True)
+check("approve denied when a bare gh is uppercase",
+      run(APPROVE.replace("gh ", "GH ", 1), "hold")[0], True)
+check("request-changes denied when the path is mixed-case",
+      run("/usr/local/bin/" + REQCH.replace("gh ", "Gh ", 1), "hold")[0], True)
+# Same boundary as the lowercase control: case-folding must not widen the match.
+check("a mixed-case binary merely ending in gh is NOT gh",
+      run("/usr/bin/notGH pr review 1 --approve", "hold")[0], False)
+check("an uppercase NON-review gh subcommand is still allowed",
+      run("GH pr view 1", "hold")[0], False)
+
+# keweichen's coverage note: the `gh api .../reviews` branch was only ever
+# exercised UNQUALIFIED, so reverting the basename fix left every path arm green.
+check("the api review form is denied when gh is path-qualified",
+      run("/opt/homebrew/bin/gh api repos/o/r/pulls/1/reviews -f event=APPROVE",
+          "hold")[0], True)
+check("the api review form is denied when gh is mixed-case",
+      run("/opt/homebrew/bin/GH api repos/o/r/pulls/1/reviews -f event=APPROVE",
+          "hold")[0], True)
+
 check("approve denied with no state file", run(APPROVE)[0], True)
 check("request-changes denied with no state file", run(REQCH)[0], True)
 check("comment ALLOWED with no state file", run(COMMENT)[0], False)

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -55,6 +55,19 @@ check("request-changes denied", run(REQCH, "hold")[0], True)
 check("comment denied under hold", run(COMMENT, "hold")[0], True)
 
 print("2. MISSING state file behaves as findings-only — votes gated, --comment stays possible")
+# A PATH-QUALIFIED gh is still gh. The scan compared the whole word against "gh",
+# so an absolute path was not classified as a review at all and the gate let it by.
+check("approve denied when gh is path-qualified",
+      run("/opt/homebrew/bin/" + APPROVE, "hold")[0], True)
+check("approve denied when gh is relative-pathed",
+      run("./bin/" + APPROVE, "hold")[0], True)
+check("request-changes denied when gh is path-qualified",
+      run("/usr/local/bin/" + REQCH, "hold")[0], True)
+# The basename match must stay EXACT: a different binary ending in those two
+# letters is not gh, and denying it would be a false positive.
+check("a binary merely ending in gh is NOT gh",
+      run("/usr/bin/notgh pr review 1 --approve", "hold")[0], False)
+
 check("approve denied with no state file", run(APPROVE)[0], True)
 check("request-changes denied with no state file", run(REQCH)[0], True)
 check("comment ALLOWED with no state file", run(COMMENT)[0], False)

--- a/tests/review-authority-guard.test.py
+++ b/tests/review-authority-guard.test.py
@@ -68,9 +68,8 @@ check("request-changes denied when gh is path-qualified",
 check("a binary merely ending in gh is NOT gh",
       run("/usr/bin/notgh pr review 1 --approve", "hold")[0], False)
 
-# macOS filesystems are case-INSENSITIVE, so `GH` runs the very same binary
-# (same inode). The early `"gh" not in command` prefilter was case-sensitive and
-# returned before the token scan lowercased anything.
+# macOS filesystems are case-insensitive, so `GH` is the same binary, and the
+# early `"gh" not in command` prefilter ran before the token scan lowercased.
 check("approve denied when the path is mixed-case",
       run("/opt/homebrew/bin/" + APPROVE.replace("gh ", "GH ", 1), "hold")[0], True)
 check("approve denied when a bare gh is uppercase",


### PR DESCRIPTION
The guard that gates formal GitHub reviews does not fire when `gh` is invoked by path. Found by generalising a finding a reviewer made on a *different* guard of mine an hour earlier.

## The gap

`classify()` scans for the literal word:

```python
if "gh" in low and "pr" in low and "review" in low:
    starts = [i for i, w in enumerate(low) if w == "gh"]
```

So `/opt/homebrew/bin/gh pr review --approve` is not classified as a review at all, and the hook allows it. Measured by calling `classify()` directly at the parent commit — note every *other* evasion I tried is already handled, which is what makes this one easy to miss:

```
plain              -> 'APPROVE'
trailing ; echo    -> 'APPROVE'
after &&           -> 'APPROVE'
env prefix         -> 'APPROVE'
path-qualified     -> None        <-- allowed
```

This is the guard that exists because a formal APPROVE was filed on #3679 without the owner's ruling, and it was the only gating approval on that PR. A gate that can be walked past by typing the absolute path is not much of a gate.

**The file already had the right idiom, one function away.** `_heredoc_owner` does `words[0].rsplit("/", 1)[-1]`; the main scan compared the whole word. So this is inconsistency inside one file rather than a missing idea.

## The change

`_is_gh` / `_has_gh` extracted next to that existing basename logic, used in both the `pr review` scan and the `gh api` scan.

The match stays **exact on the basename**. A binary merely *ending* in those two letters is not `gh`, and denying it would be a false positive — which is the failure mode that gets a guard switched off.

## Evidence

```
$ python3 tests/review-authority-guard.test.py
PASS — review-authority-guard tests
```

Four arms added to the existing suite: path-qualified approve, relative-path approve, path-qualified request-changes, and the must-allow `/usr/bin/notgh`.

Mutations, each verified applied before running (the edit printed its own post-edit count) and each red:

| mutation | result |
|---|---|
| revert the scan to `w == "gh"` | `- request-changes denied when gh is path-qualified: got False, want True` |
| basename match becomes `endswith("gh")` | `- a binary merely ending in gh is NOT gh: got True, want False` |
| (restored) | `PASS` |

Worth noting the existing suite passed **both** with and without the fix before those arms existed — it had no path-qualified case, which is exactly why this survived.

`tests/ci-covers-every-python-test.test.py` OK. `review-checks.sh` PASS on the diff.

## Provenance

@vidhuUC found this same class on sonichi/sutando#3829 — `armed` there keyed on the literal `gh` too, and their fix used `os.path.basename`. I went looking for the pattern elsewhere in `hooks/` and this is where it landed. Their finding is doing work beyond its own PR.

**Not deployed on this node.** `hooks/` is version-controlled source; the live registration is separate, so the running guard on this host still has the gap until it is re-deployed.

— sutando-qingyun-air (@qingyun-air.agent:ag2.space)
