### PR TITLE
fix(graceful-restart): retire the core's drain RESULT with its task, not just the task

### DIFF
--- a/src/agent/graceful-restart.sh
+++ b/src/agent/graceful-restart.sh
@@ -44,6 +44,14 @@ log() {
 PREP_TASK="$WS/tasks/task-restart-prep-$RID.txt"
 # The task has done its job once a decision is made; never leave it for the next boot's orphan-check.
 retire_prep_task() {
+  # The core answers the drain task in results/; no bridge collects a task the
+  # orchestrator wrote, so the orchestrator is its consumer: log it, archive it.
+  local res="$WS/results/task-restart-prep-$RID.txt"
+  if [ -f "$res" ]; then
+    log "drain result: $(head -c 300 "$res" | tr '\n' ' ')"
+    mkdir -p "$WS/results/archive"
+    mv "$res" "$WS/results/archive/" 2>/dev/null || true
+  fi
   [ -f "$PREP_TASK" ] || return 0
   mkdir -p "$WS/tasks/archive"
   mv "$PREP_TASK" "$WS/tasks/archive/" 2>/dev/null || true

--- a/src/agent/graceful-restart.sh
+++ b/src/agent/graceful-restart.sh
@@ -50,7 +50,7 @@ retire_prep_task() {
   if [ -f "$res" ]; then
     log "drain result: $(head -c 300 "$res" | tr '\n' ' ')"
     mkdir -p "$WS/results/archive"
-    mv "$res" "$WS/results/archive/" 2>/dev/null || true
+    mv "$res" "$WS/results/archive/" 2>/dev/null || log "drain result NOT archived (mv failed): $res"
   fi
   [ -f "$PREP_TASK" ] || return 0
   mkdir -p "$WS/tasks/archive"

--- a/tests/graceful-restart.test.sh
+++ b/tests/graceful-restart.test.sh
@@ -603,7 +603,13 @@ chmod +x "$stub20"
 # A fake core: stays busy until the drain task appears, keeps a copy, then goes idle.
 ( for _ in $(seq 1 40); do
     f="$(ls "$WS20"/tasks/task-restart-prep-*.txt 2>/dev/null | head -1)"
-    if [ -n "$f" ]; then cp "$f" "$TMP/ws20.task"; break; fi
+    if [ -n "$f" ]; then
+      cp "$f" "$TMP/ws20.task"
+      # The core-side half of the contract: answer the drain task in results/.
+      mkdir -p "$WS20/results"
+      printf 'nothing in flight (test)\n' > "$WS20/results/$(basename "$f")"
+      break
+    fi
     touch "$WS20/state/cores/$HOST.alive"; sleep 0.5
   done
   printf '{"status":"idle","ts":%s}\n' "$(date +%s)" > "$WS20/state/core-status.json" ) &
@@ -630,6 +636,10 @@ grep -q "restart" "$TMP/ws20.argv" 2>/dev/null \
 [ -f "$WS20/tasks/archive/task-restart-prep-$rid20.txt" ] && [ ! -f "$WS20/tasks/task-restart-prep-$rid20.txt" ] \
   && say ok "the drain task was retired to tasks/archive/ before the exec (no orphan for the next boot)" \
   || say FAIL "drain task not retired: live=$(ls "$WS20"/tasks/task-restart-prep-* 2>/dev/null) archive=$(ls "$WS20"/tasks/archive/ 2>/dev/null)"
+[ -f "$WS20/results/archive/task-restart-prep-$rid20.txt" ] && [ ! -f "$WS20/results/task-restart-prep-$rid20.txt" ] \
+  && grep -q "drain result: nothing in flight (test)" "$TMP/ws20.out" \
+  && say ok "the core's drain RESULT is logged and archived with the task (no bridge would ever collect it)" \
+  || say FAIL "drain result stranded: live=$(ls "$WS20"/results/task-restart-prep-* 2>/dev/null) archive=$(ls "$WS20"/results/archive/ 2>/dev/null) logged=$(grep -c 'drain result:' "$TMP/ws20.out")"
 
 WS20b="$TMP/ws20b"; mkws "$WS20b"; rm -f "$WS20b/state/cores/$HOST.alive"   # DEAD core
 STUB_ARGV_OUT="$TMP/ws20b.argv" GR_START_CLI="$stub20" GR_WS="$WS20b" GR_SYNC_CMD="true" \


### PR DESCRIPTION
## What

`retire_prep_task` moves `tasks/task-restart-prep-<rid>.txt` to `tasks/archive/` and leaves `results/task-restart-prep-<rid>.txt` where the core wrote it. No bridge collects a result for a task the orchestrator wrote, so every graceful restart strands exactly one result and health-check's `orphaned-results` probe warns until someone moves it by hand. The orchestrator is that result's consumer: at retire time it now logs the result's line into the phase stream (it is the witness of what was in flight) and archives it under `results/archive/`, by the same `$RID` it already holds — no glob over `results/`.

## Before / after

`tests/graceful-restart.test.sh`, case 20 gains an assertion (the fake core now answers the drain task in `results/`, as a real core does):

HEAD:
```
  ok: the drain task was retired to tasks/archive/ before the exec (no orphan for the next boot)
  ok: the core's drain RESULT is logged and archived with the task (no bridge would ever collect it)
…
ALL PASS        (82 ok)
```

Parent (`origin/main` `src/agent/graceful-restart.sh` checked out under the new test — `git status` showed only the test modified):
```
  FAIL: drain result stranded: live=<ws>/results/task-restart-prep-grp-1788466128-99652.txt archive= logged=0
rc=1            (81 ok, 1 FAIL — this assertion)
```

Probe-level control on a live host (the orphan left by this host's 19:14Z graceful restart), taken with health-check's own `orphaned-results` probe, not a file listing:
```
BEFORE  warn | 1 result(s) with no consumer coming — never delivered; oldest task-restart-prep-grp-1788462805-25958.txt (0h56m)
        <apply the retire action by hand: log line + mv to results/archive/, same rid>
AFTER   ok   | no undeliverable results
```

The end-to-end control (probe count across one real graceful restart at this head) is owed at the next owner-scheduled restart on this host; a graceful restart kills the core that would report it, so it is not run inside this review.

## Worst case for users

None new: the moved file was already unread by every consumer, and `results/archive/` is where the bridges archive delivered results. `log` is defined above `retire_prep_task` (line 36 vs 46), so the EXIT-trap path added in #3823 still resolves every name it calls (case 20e).

Stand: Echo Act IV Mini
