### PR TITLE
fix(gateway): only claim a durable ack when this process actually committed

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2545,15 +2545,12 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
         _log(f"owner-activity write failed: {e}")
 
 
-def _repair_pending_task(tid: str, task: dict) -> bool:
-    """A task the gateway redelivered while it is still queued here: fsync the
-    queued file and its directory and (re)commit the media sidecar, so a task
-    written by a pre-durability client can still earn a `durable` ack."""
-    tfile = find_task_file(TASKS_DIR, tid)
-    if tfile is None:
-        return False
+def _fsync_in_place(tid: str, *targets: Path) -> bool:
+    """fsync files (and directories) already on disk. A pre-durability writer
+    left these bytes uncommitted, so nothing may be claimed durable until this
+    lands; False when it did not."""
     try:
-        for target in (tfile, TASKS_DIR):
+        for target in targets:
             fd = os.open(target, os.O_RDONLY)
             try:
                 os.fsync(fd)
@@ -2561,6 +2558,18 @@ def _repair_pending_task(tid: str, task: dict) -> bool:
                 os.close(fd)
     except OSError as exc:
         _log(f"durability repair failed for {tid} ({exc})")
+        return False
+    return True
+
+
+def _repair_pending_task(tid: str, task: dict) -> bool:
+    """A task the gateway redelivered while it is still queued here: fsync the
+    queued file and its directory and (re)commit the media sidecar, so a task
+    written by a pre-durability client can still earn a `durable` ack."""
+    tfile = find_task_file(TASKS_DIR, tid)
+    if tfile is None:
+        return False
+    if not _fsync_in_place(tid, tfile, TASKS_DIR):
         return False
     return _record_task_media(tid, task)
 
@@ -2597,8 +2606,11 @@ def _write_task(task: dict) -> "tuple[str, bool] | None":
     )
     if task_archived or _delivered_copy_exists(tid):
         rfile = RESULTS_DIR / f"{tid}.txt"
-        durable = True
-        if not rfile.exists():
+        if rfile.exists():
+            # A reply the local core wrote with a plain write_text: this process
+            # has committed nothing yet, so fsync before claiming durable.
+            durable = _fsync_in_place(tid, rfile, RESULTS_DIR)
+        else:
             durable = _durable_write(rfile, GATEWAY_REDELIVERY_RESULT)
             # Provenance the result BODY cannot carry: a Team runtime controls
             # the body and can emit these exact bytes, but not this process's set.

--- a/tests/gateway-durable-ack.test.py
+++ b/tests/gateway-durable-ack.test.py
@@ -9,7 +9,8 @@ otherwise. Acks that never confirm are persisted and retried.
 Covers:
   1. the four state writes go temp → fsync file → rename → fsync directory;
   2. a task queued by a pre-durability client and redelivered after the upgrade
-     is verified, fsync'd and given its sidecar before a durable ack is allowed;
+     is verified, fsync'd and given its sidecar before a durable ack is allowed,
+     as is the pending reply of a redelivery this node already handled;
   3. every failure boundary (task write, sidecar, in-flight set, ack ledger)
      withholds the ack rather than claiming a task that could be lost;
   4. pending acks are retried by the outbound worker, retired on a per-task
@@ -28,6 +29,7 @@ import os
 import stat
 import sys
 import tempfile
+import time
 import unittest
 import urllib.error
 from pathlib import Path
@@ -183,6 +185,99 @@ class DurableAck(unittest.TestCase):
                          "id: task-old\naccess_tier: owner\ntask: earlier\n",
                          "repair must not rewrite the queued file")
 
+    def _fsync_watch(self, want: "set[int]") -> "tuple[list, object]":
+        """(what the ack saw, a context manager) — records whether every inode in
+        `want` had been fsync'd by the time the ack was posted."""
+        mod = self.mod
+        synced: "set[int]" = set()
+        at_ack: list = []
+        real_fsync, real_ack = mod.os.fsync, mod._post_task_ack
+
+        def spy(fd):
+            synced.add(os.fstat(fd).st_ino)
+            return real_fsync(fd)
+
+        def ack(tid, durable=False):
+            at_ack.append(want <= synced)
+            return real_ack(tid, durable)
+
+        class _Watch:
+            def __enter__(_self):
+                _self._p = [patch.object(mod.os, "fsync", spy),
+                            patch.object(mod, "_post_task_ack", side_effect=ack)]
+                for one in _self._p:
+                    one.start()
+                return _self
+
+            def __exit__(_self, *exc):
+                for one in reversed(_self._p):
+                    one.stop()
+                return False
+
+        return at_ack, _Watch()
+
+    def _refuse_fsync_of(self, *paths):
+        """os.open refuses exactly these paths, so the fsync loop over them raises."""
+        real_open = self.mod.os.open
+        blocked = {str(p) for p in paths}
+
+        def refuse(path, *a, **k):
+            if str(path) in blocked:
+                raise OSError("cannot open for fsync")
+            return real_open(path, *a, **k)
+
+        return patch.object(self.mod.os, "open", refuse)
+
+    def test_the_repair_fsyncs_the_queued_task_and_its_directory(self):
+        mod = self.mod
+        tfile = mod.TASKS_DIR / "task-old4.txt"
+        tfile.write_text("id: task-old4\n")
+        at_ack, watch = self._fsync_watch({tfile.stat().st_ino,
+                                           mod.TASKS_DIR.stat().st_ino})
+        with watch:
+            self._ack_round([self._task("task-old4")])
+        self.assertEqual(at_ack, [True],
+                         "the queued file and tasks/ must be fsync'd before the ack")
+        self.assertEqual(self._acks()[0][2], {"id": "task-old4", "durable": True})
+
+    def test_a_repair_whose_fsync_fails_is_acked_without_durability(self):
+        mod = self.mod
+        tfile = mod.TASKS_DIR / "task-old5.txt"
+        tfile.write_text("id: task-old5\n")
+        with self._refuse_fsync_of(tfile, mod.TASKS_DIR):
+            self._ack_round([self._task("task-old5")])
+        self.assertEqual(self._acks()[0][2], {"id": "task-old5"},
+                         "an uncommitted queue file must not be claimed as durable")
+
+    def test_a_redelivery_commits_the_pending_reply_before_a_durable_ack(self):
+        mod = self.mod
+        (mod.TASKS_DIR / "archive").mkdir(parents=True, exist_ok=True)
+        (mod.TASKS_DIR / "archive" / "task-red.txt").write_text("id: task-red\n")
+        # What the local core left behind: a reply written with a plain
+        # write_text, so this process has committed nothing of its own.
+        rfile = mod.RESULTS_DIR / "task-red.txt"
+        rfile.write_text("the answer the core already produced")
+        at_ack, watch = self._fsync_watch({rfile.stat().st_ino,
+                                           mod.RESULTS_DIR.stat().st_ino})
+        with watch:
+            self._ack_round([self._task("task-red")])
+        self.assertEqual(at_ack, [True],
+                         "the pending reply and results/ must commit before the ack")
+        self.assertEqual(self._acks()[0][2], {"id": "task-red", "durable": True})
+        self.assertEqual(rfile.read_text(), "the answer the core already produced",
+                         "the repair must not rewrite the pending reply")
+
+    def test_a_redelivery_whose_reply_will_not_commit_is_acked_plain(self):
+        mod = self.mod
+        (mod.TASKS_DIR / "archive").mkdir(parents=True, exist_ok=True)
+        (mod.TASKS_DIR / "archive" / "task-red2.txt").write_text("id: task-red2\n")
+        rfile = mod.RESULTS_DIR / "task-red2.txt"
+        rfile.write_text("an earlier answer")
+        with self._refuse_fsync_of(rfile, mod.RESULTS_DIR):
+            self._ack_round([self._task("task-red2")])
+        self.assertEqual(self._acks()[0][2], {"id": "task-red2"},
+                         "an uncommitted reply must not be claimed as durable")
+
     def test_a_redelivery_recommits_the_in_flight_set(self):
         mod = self.mod
         # A pre-durability client's ledger: readable, but never fsync'd.
@@ -288,6 +383,30 @@ class DurableAck(unittest.TestCase):
         before = len(self._acks())
         mod._retry_pending_acks(set())     # the result POST already closed it
         self.assertEqual(len(self._acks()), before)
+        self.assertEqual(mod._load_pending_acks(), {})
+
+    def test_the_outbound_worker_is_what_retries_a_pending_ack(self):
+        """The retry reaches production only through `_outbound_worker`, so the
+        seam — not the inner function — is what has to be driven."""
+        mod = self.mod
+        with patch.object(mod, "_req", side_effect=urllib.error.URLError("down")):
+            self._ack_round([self._task("task-worker")])
+        self.assertEqual(mod._load_pending_acks(), {"task-worker": True})
+        mod.OUTBOUND_SCAN_S = 0.2
+        worker = mod._start_outbound_worker({"task-worker"})
+        try:
+            mod.wake_outbound()
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline and not self._acks():
+                time.sleep(0.02)
+        finally:
+            mod._OUTBOUND_STOP.set()
+            mod.wake_outbound()
+            worker.join(timeout=5)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual([c[2] for c in self._acks()],
+                         [{"id": "task-worker", "durable": True}],
+                         "the worker never re-posted the persisted ack")
         self.assertEqual(mod._load_pending_acks(), {})
 
     def test_the_ledger_survives_a_restart(self):

--- a/tests/gateway-signal-task-media.test.py
+++ b/tests/gateway-signal-task-media.test.py
@@ -189,6 +189,35 @@ class TaskMediaRoute(unittest.TestCase):
         self.assertEqual([c[1] for c in self._media_posts()],
                          ["/v1/tasks/task-restart/media"])
 
+    def test_a_dedup_requeue_keeps_the_task_media_route(self):
+        """A requeue carries the SAME delivery forward, so its route must survive.
+
+        The sidecar is keyed by the delivery wire id; retiring it here would
+        silently downgrade the re-ask's attachment to the room-scoped route,
+        outside the task's own lease.
+        """
+        mod = self.mod
+        holder = "task-22d83e59601f3a1fef"
+        mod._write_task(self._signal_task("task-requeue"))
+        # The holder delivered nothing, so the plan re-asks rather than honouring.
+        mod.ARCHIVE_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        (mod.ARCHIVE_RESULTS_DIR / f"{holder}-1785976425.txt").write_text("")
+        self._result(mod, "task-requeue", f"[deduped: {holder}]")
+        inflight = {"task-requeue"}
+        mod._post_ready_results(inflight)
+        reask = [p.stem for p in mod.TASKS_DIR.glob("task-*.txt")
+                 if p.stem != "task-requeue"]
+        self.assertEqual(len(reask), 1, "the dedup was not re-asked")
+        self.assertEqual(mod._load_task_media().get("task-requeue"),
+                         {"mode": "task-media", "thread_root": "$root:server"},
+                         "the re-ask lost the delivery's media route")
+        # The re-ask answers the ORIGINAL delivery, so its attachment still
+        # uploads against that task's lease.
+        self._result(mod, reask[0], f"here [file: {self._attachment()}]")
+        mod._post_ready_results(inflight)
+        self.assertEqual([c[1] for c in self._media_posts()],
+                         ["/v1/tasks/task-requeue/media"])
+
     def test_delivered_result_retires_the_media_mode(self):
         mod = self.mod
         mod._write_task(self._signal_task("task-retire"))


### PR DESCRIPTION
Follow-up to **#3799** (merged). An audit against defect classes found later in the same workstream turned up three issues.

**A durable ack could be claimed without committing anything.** The repair path hardcoded `durable = True` and returned it whenever the task file merely existed, so a redelivered task could be acknowledged as durably persisted when this process had written nothing. That is exactly what `durable: true` is supposed to rule out — the relay stops retrying on the strength of it. The flag now reflects what was actually committed.

**Two seams reached production through a single call each, with no coverage.** The pending-ack retry is the entire "acks survive a restart" feature, and the fsync loop is the durability half of the repair. Both were mutation-proven dead: deleting either left the suite green. Both now covered.

Also pins the dedup-requeue guard that keeps a re-asked Signal task's media route alive, since the sidecar is keyed by the delivery wire id and retiring it early would silently send the attachment down the room-scoped path.

Verified: `gateway-durable-ack` and `gateway-signal-task-media` green; `review-checks.sh` clean. Rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)