### PR TITLE
fix(supervisor): a blocked core announces itself in chat, once per episode

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1177,6 +1177,37 @@ def _monorepo_src(marker: str) -> str:
         cur = parent
 
 
+def _project_hitl(log=print) -> int:
+    """Push every un-projected HITL requirement out as a card, or 0 when
+    `src/hitl` is absent (standalone sparrow) — same optional tier as the
+    reply handler, and the outbound half of the same card.
+
+    The projector owns idempotency (a projection ledger per requirement), so
+    calling this every pulse re-sends nothing; it is the driver that was
+    missing, not the machinery.
+    """
+    if not PROACTIVE_ROOM:
+        return 0
+    try:
+        src = _monorepo_src(os.path.join("hitl", "projector.py"))
+        if not src:
+            return 0
+        if src not in sys.path:
+            sys.path.insert(0, src)
+        from hitl.manager import HitlManager, HitlStore, default_store
+        from hitl.projector import project
+    except Exception as e:  # noqa: BLE001 — an optional tier never breaks the pulse
+        log(f"hitl: projector unavailable ({e}); cards will not be delivered")
+        return 0
+    workspace = _STATE.parent
+    manager = HitlManager(HitlStore(default_store(workspace)))
+    done = project(manager, lambda payload: _req("POST", "/v1/room", payload, timeout=20),
+                   PROACTIVE_ROOM)
+    for req_id, event_id in done:
+        log(f"hitl: projected {req_id} -> {event_id or 'no event id'}")
+    return len(done)
+
+
 def _hitl_reply_handler(owner_mxid: str, log=print):
     """Owner card-click handler for HITL cards, or None when `src/hitl` is not
     around (standalone sparrow) — the chain then simply lacks it, like the vault tier."""
@@ -1316,6 +1347,10 @@ def _outbound_worker(inflight: "set[str]") -> None:
             _post_proactive()
         except Exception as e:  # noqa: BLE001
             _log(f"outbound worker: proactive drain error (isolated): {e}")
+        try:
+            _project_hitl(log=_log)
+        except Exception as e:  # noqa: BLE001
+            _log(f"outbound worker: hitl projection error (isolated): {e}")
         try:
             _retry_pending_acks(inflight)
         except Exception as e:  # noqa: BLE001

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1177,6 +1177,24 @@ def _monorepo_src(marker: str) -> str:
         cur = parent
 
 
+# `project()` assigns retry cadence to its caller and the worker drives this
+# every ~1s. Skip-until-deadline, not sleep: other drains share this thread.
+_HITL_BACKOFF = {"until": 0.0, "delay": 0.0}
+_HITL_BACKOFF_MAX_S = 60.0
+
+
+def _hitl_backoff_bump(log=print) -> None:
+    d = min((_HITL_BACKOFF["delay"] or 0.5) * 2, _HITL_BACKOFF_MAX_S)
+    _HITL_BACKOFF["delay"] = d
+    _HITL_BACKOFF["until"] = time.monotonic() + d
+    log(f"hitl: projection refused — backing off {d:g}s")
+
+
+def _hitl_backoff_reset() -> None:
+    _HITL_BACKOFF["delay"] = 0.0
+    _HITL_BACKOFF["until"] = 0.0
+
+
 def _project_hitl(log=print) -> int:
     """Push every un-projected HITL requirement out as a card, or 0 when
     `src/hitl` is absent (standalone sparrow) — same optional tier as the
@@ -1188,6 +1206,8 @@ def _project_hitl(log=print) -> int:
     """
     if not PROACTIVE_ROOM:
         return 0
+    if time.monotonic() < _HITL_BACKOFF["until"]:
+        return 0
     try:
         src = _monorepo_src(os.path.join("hitl", "projector.py"))
         if not src:
@@ -1195,14 +1215,25 @@ def _project_hitl(log=print) -> int:
         if src not in sys.path:
             sys.path.insert(0, src)
         from hitl.manager import HitlManager, HitlStore, default_store
-        from hitl.projector import project
+        from hitl.projector import pending_ids, project
     except Exception as e:  # noqa: BLE001 — an optional tier never breaks the pulse
         log(f"hitl: projector unavailable ({e}); cards will not be delivered")
         return 0
     workspace = _STATE.parent
     manager = HitlManager(HitlStore(default_store(workspace)))
-    done = project(manager, lambda payload: _req("POST", "/v1/room", payload, timeout=20),
-                   PROACTIVE_ROOM)
+    if not pending_ids(manager):
+        _hitl_backoff_reset()  # idle is not failure; a new card must not wait out a backoff
+        return 0
+    try:
+        done = project(manager, lambda payload: _req("POST", "/v1/room", payload, timeout=20),
+                       PROACTIVE_ROOM)
+    except Exception:
+        _hitl_backoff_bump(log)  # a raising sender is a refusal too
+        raise
+    if not done:
+        _hitl_backoff_bump(log)
+        return 0
+    _hitl_backoff_reset()
     for req_id, event_id in done:
         log(f"hitl: projected {req_id} -> {event_id or 'no event id'}")
     return len(done)

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -67,6 +67,7 @@ _sys.path.insert(0, _osp.dirname(_osp.abspath(__file__)))
 from gateway_serving import read_verdict as read_gateway_verdict  # noqa: E402
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import os
@@ -74,6 +75,7 @@ import re
 import shutil
 import subprocess
 import time
+from pathlib import Path as _Path
 
 
 def _ensure_tmux_on_path():
@@ -405,13 +407,15 @@ AUTO_ANSWER_CARRY_S = 120.0
 
 
 # ESCALATE (Layer 3) — the banner is a window the owner has to be looking at.
-# When nothing automatic can clear the gate, say so where they already are.
+# A blocked core is exactly a HumanRequirement, so it goes through `src/hitl`
+# like every other one: the Manager dedups, the projector renders the card.
 _CHAT_ESCALATE_STATES = {"blocked-human", "logged-out"}
+HITL_KIND = "core-blocked"
 
 
-def escalation_body(state, detail, kind, prompt):
-    """The owner-facing text. The core is blocked, so this is the only thing
-    that will reach them until they act."""
+def escalation_message(state, detail, kind, prompt):
+    """The card body. The core is blocked, so this is the only thing that will
+    reach the owner until they act."""
     head = ("I am blocked and cannot continue without you."
             if state == "blocked-human" else
             "I am signed out and cannot continue without you.")
@@ -426,27 +430,60 @@ def escalation_body(state, detail, kind, prompt):
     return "\n".join(lines)
 
 
-def escalate_to_chat(out_path, state, detail, kind, prompt):
-    """Write ONE proactive message per episode. The bridge claims it independently
-    of the core, which is the point: the core is the thing that is stuck.
-
-    Returns the path written, or None when this episode was already announced —
-    a stuck core must not become a stuck core plus a message every tick.
-    """
-    ws = os.path.dirname(os.path.dirname(os.path.abspath(out_path)))
-    results = os.path.join(ws, "results")
+def _hitl_manager(out_path):
+    """The shared requirement store, or None when `src/hitl` is unavailable —
+    the monitor must keep writing its state file either way."""
     try:
-        os.makedirs(results, exist_ok=True)
-        path = os.path.join(results, f"proactive-core-blocked-{int(time.time())}.txt")
-        with open(path, "w") as f:
-            f.write(escalation_body(state, detail, kind, prompt) + "\n")
-            f.flush()
-            os.fsync(f.fileno())
-        return path
-    except OSError as exc:
-        # Never let the escalation take down the monitor that produces it.
-        print(f"chat escalation failed: {exc}", file=_sys.stderr)
+        here = _osp.dirname(_osp.abspath(__file__))
+        if here not in _sys.path:
+            _sys.path.insert(0, here)
+        from hitl.manager import HitlManager, HitlStore, default_store
+    except Exception as exc:  # noqa: BLE001
+        print(f"hitl unavailable ({exc}); no card will be raised", file=_sys.stderr)
         return None
+    ws = _osp.dirname(_osp.dirname(_osp.abspath(out_path)))
+    return HitlManager(HitlStore(default_store(_Path(ws))))
+
+
+def escalate(manager, state, detail, kind, prompt, session):
+    """Raise ONE requirement per episode. The Manager dedups on
+    (runtime, kind, device) + guard, so the prompt IS the episode key: the same
+    prompt returns the same record, a different one mints a new card.
+
+    Returns the requirement, or None when nothing could be raised.
+    """
+    if manager is None:
+        return None
+    try:
+        from hitl.schema import Action, HumanRequirement
+        req = HumanRequirement(
+            kind=HITL_KIND,
+            runtime="claude",
+            message=escalation_message(state, detail, kind, prompt),
+            guard=hashlib.sha256((prompt or state).encode()).hexdigest()[:16],
+            title=f"{session} · {state}",
+            actions=[Action(id="ack", kind="acknowledge", label="I have answered it")],
+            subject={"state": state, "gate": kind or "", "detail": detail},
+        )
+        return manager.create(req)
+    except Exception as exc:  # noqa: BLE001 — never let the card take down the monitor
+        print(f"hitl escalation failed: {exc}", file=_sys.stderr)
+        return None
+
+
+def resolve_escalations(manager):
+    """Clear this driver's requirements once the core is no longer blocked —
+    the card says answered because the core moved, not because anyone clicked."""
+    if manager is None:
+        return []
+    try:
+        mine = [r.id for r in manager.active() if r.kind == HITL_KIND]
+        for req_id in mine:
+            manager.resolve(req_id)   # returns blocked task ids, not a verdict
+        return mine
+    except Exception as exc:  # noqa: BLE001
+        print(f"hitl resolve failed: {exc}", file=_sys.stderr)
+        return []
 
 
 def _atomic_write(path, payload):
@@ -470,7 +507,7 @@ def main():
     ap.add_argument("--no-auto-answer", dest="auto_answer", action="store_false",
                     help="report allowlisted gates without typing their safe answer")
     ap.add_argument("--no-chat-escalation", dest="chat_escalation", action="store_false",
-                    help="write the supervisor state but never announce a block in chat")
+                    help="write the supervisor state but never raise a card for a block")
     a = ap.parse_args()
 
     # Make bare `tmux` resolvable before ANY probe (ours or runtime-health's) —
@@ -485,7 +522,7 @@ def main():
     rh.SESSION = a.session
 
     last_sig = None
-    escalated_episode = None
+    hitl = _hitl_manager(a.out) if a.chat_escalation else None
     stable_prompt = 0
     last_prompt = None
     answered_prompt = None
@@ -528,15 +565,13 @@ def main():
             _atomic_write(a.out, payload)
             last_sig = sig
 
-        # One announcement per EPISODE: leaving the blocked set clears the key,
-        # so a genuine second block is not swallowed by the first.
-        if a.chat_escalation and state in _CHAT_ESCALATE_STATES:
-            ep = (state, kind, prompt)
-            if ep != escalated_episode:
-                if escalate_to_chat(a.out, state, detail, kind, prompt):
-                    escalated_episode = ep
-        elif state not in _CHAT_ESCALATE_STATES:
-            escalated_episode = None
+        # The Manager owns per-episode dedup; leaving the blocked set resolves
+        # the card, so the owner sees it close without clicking anything.
+        if a.chat_escalation:
+            if state in _CHAT_ESCALATE_STATES:
+                escalate(hitl, state, detail, kind, prompt, a.session)
+            else:
+                resolve_escalations(hitl)
         if a.once:
             return
         time.sleep(a.interval)  # pragma: no cover - daemon heartbeat (tests use --once)

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -404,6 +404,51 @@ def answer_step(state, kind, prompt, answered_prompt, enabled=True):
 AUTO_ANSWER_CARRY_S = 120.0
 
 
+# ESCALATE (Layer 3) — the banner is a window the owner has to be looking at.
+# When nothing automatic can clear the gate, say so where they already are.
+_CHAT_ESCALATE_STATES = {"blocked-human", "logged-out"}
+
+
+def escalation_body(state, detail, kind, prompt):
+    """The owner-facing text. The core is blocked, so this is the only thing
+    that will reach them until they act."""
+    head = ("I am blocked and cannot continue without you."
+            if state == "blocked-human" else
+            "I am signed out and cannot continue without you.")
+    lines = [head, "", f"State: {state} — {detail}"]
+    if kind and kind != "unknown":
+        lines.append(f"Gate: {kind}")
+    if prompt:
+        excerpt = "\n".join(prompt.strip().splitlines()[-6:])
+        lines += ["", "What the terminal is showing:", "```", excerpt, "```"]
+    lines += ["", "Open the Runtime panel (or the core's terminal) and answer it. "
+                  "Nothing else I do can clear this one."]
+    return "\n".join(lines)
+
+
+def escalate_to_chat(out_path, state, detail, kind, prompt):
+    """Write ONE proactive message per episode. The bridge claims it independently
+    of the core, which is the point: the core is the thing that is stuck.
+
+    Returns the path written, or None when this episode was already announced —
+    a stuck core must not become a stuck core plus a message every tick.
+    """
+    ws = os.path.dirname(os.path.dirname(os.path.abspath(out_path)))
+    results = os.path.join(ws, "results")
+    try:
+        os.makedirs(results, exist_ok=True)
+        path = os.path.join(results, f"proactive-core-blocked-{int(time.time())}.txt")
+        with open(path, "w") as f:
+            f.write(escalation_body(state, detail, kind, prompt) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        return path
+    except OSError as exc:
+        # Never let the escalation take down the monitor that produces it.
+        print(f"chat escalation failed: {exc}", file=_sys.stderr)
+        return None
+
+
 def _atomic_write(path, payload):
     os.makedirs(os.path.dirname(path), exist_ok=True)
     tmp = path + ".tmp"
@@ -424,6 +469,8 @@ def main():
     ap.add_argument("--once", action="store_true", help="one tick then exit (for tests/probes)")
     ap.add_argument("--no-auto-answer", dest="auto_answer", action="store_false",
                     help="report allowlisted gates without typing their safe answer")
+    ap.add_argument("--no-chat-escalation", dest="chat_escalation", action="store_false",
+                    help="write the supervisor state but never announce a block in chat")
     a = ap.parse_args()
 
     # Make bare `tmux` resolvable before ANY probe (ours or runtime-health's) —
@@ -438,6 +485,7 @@ def main():
     rh.SESSION = a.session
 
     last_sig = None
+    escalated_episode = None
     stable_prompt = 0
     last_prompt = None
     answered_prompt = None
@@ -479,6 +527,17 @@ def main():
                 payload["auto_answered"] = last_answered
             _atomic_write(a.out, payload)
             last_sig = sig
+
+        # One announcement per EPISODE, keyed on what the owner would act on.
+        # Re-keying on `prompt` alone would re-fire as a menu redraws; leaving
+        # the blocked set clears it so a genuine second block is not swallowed.
+        if a.chat_escalation and state in _CHAT_ESCALATE_STATES:
+            ep = (state, kind, prompt)
+            if ep != escalated_episode:
+                if escalate_to_chat(a.out, state, detail, kind, prompt):
+                    escalated_episode = ep
+        elif state not in _CHAT_ESCALATE_STATES:
+            escalated_episode = None
         if a.once:
             return
         time.sleep(a.interval)  # pragma: no cover - daemon heartbeat (tests use --once)

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -528,9 +528,8 @@ def main():
             _atomic_write(a.out, payload)
             last_sig = sig
 
-        # One announcement per EPISODE, keyed on what the owner would act on.
-        # Re-keying on `prompt` alone would re-fire as a menu redraws; leaving
-        # the blocked set clears it so a genuine second block is not swallowed.
+        # One announcement per EPISODE: leaving the blocked set clears the key,
+        # so a genuine second block is not swallowed by the first.
         if a.chat_escalation and state in _CHAT_ESCALATE_STATES:
             ep = (state, kind, prompt)
             if ep != escalated_episode:

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -455,14 +455,18 @@ def escalate(manager, state, detail, kind, prompt, session):
         return None
     try:
         from hitl.schema import Action, HumanRequirement
+        # Session in BOTH the guard and the identity: a pool shares one login, so
+        # a weekly limit blocks every worker on byte-identical prompt text at once.
         req = HumanRequirement(
             kind=HITL_KIND,
             runtime="claude",
             message=escalation_message(state, detail, kind, prompt),
-            guard=hashlib.sha256((prompt or state).encode()).hexdigest()[:16],
+            guard=hashlib.sha256(f"{session}\n{prompt or state}".encode()).hexdigest()[:16],
+            device={"id": session},
             title=f"{session} · {state}",
             actions=[Action(id="ack", kind="acknowledge", label="I have answered it")],
-            subject={"state": state, "gate": kind or "", "detail": detail},
+            subject={"state": state, "gate": kind or "", "detail": detail,
+                     "session": session},
         )
         return manager.create(req)
     except Exception as exc:  # noqa: BLE001 — never let the card take down the monitor
@@ -470,13 +474,18 @@ def escalate(manager, state, detail, kind, prompt, session):
         return None
 
 
-def resolve_escalations(manager):
-    """Clear this driver's requirements once the core is no longer blocked —
-    the card says answered because the core moved, not because anyone clicked."""
+def resolve_escalations(manager, session):
+    """Clear THIS session's requirements once its core is no longer blocked —
+    the card says answered because the core moved, not because anyone clicked.
+
+    Scoped by session: one worker recovering must not clear a sibling's card.
+    """
     if manager is None:
         return []
     try:
-        mine = [r.id for r in manager.active() if r.kind == HITL_KIND]
+        mine = [r.id for r in manager.active()
+                if r.kind == HITL_KIND
+                and (r.subject or {}).get("session") == session]
         for req_id in mine:
             manager.resolve(req_id)   # returns blocked task ids, not a verdict
         return mine
@@ -570,7 +579,7 @@ def main():
             if state in _CHAT_ESCALATE_STATES:
                 escalate(hitl, state, detail, kind, prompt, a.session)
             else:
-                resolve_escalations(hitl)
+                resolve_escalations(hitl, a.session)
         if a.once:
             return
         time.sleep(a.interval)  # pragma: no cover - daemon heartbeat (tests use --once)

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -437,11 +437,13 @@ def _hitl_manager(out_path):
         if here not in _sys.path:
             _sys.path.insert(0, here)
         from hitl.manager import HitlManager, HitlStore, default_store
+
+        ws = _osp.dirname(_osp.dirname(_osp.abspath(out_path)))
+        return HitlManager(HitlStore(default_store(_Path(ws))))
     except Exception as exc:  # noqa: BLE001
+        # A store that cannot be BUILT is as optional as one that cannot import.
         print(f"hitl unavailable ({exc}); no card will be raised", file=_sys.stderr)
         return None
-    ws = _osp.dirname(_osp.dirname(_osp.abspath(out_path)))
-    return HitlManager(HitlStore(default_store(_Path(ws))))
 
 
 def escalate(manager, state, detail, kind, prompt, session):

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -406,9 +406,8 @@ def answer_step(state, kind, prompt, answered_prompt, enabled=True):
 AUTO_ANSWER_CARRY_S = 120.0
 
 
-# ESCALATE (Layer 3) — the banner is a window the owner has to be looking at.
-# A blocked core is exactly a HumanRequirement, so it goes through `src/hitl`
-# like every other one: the Manager dedups, the projector renders the card.
+# ESCALATE (Layer 3): a blocked core IS a HumanRequirement, so it goes through
+# `src/hitl` — the Manager dedups, the projector renders the card.
 _CHAT_ESCALATE_STATES = {"blocked-human", "logged-out"}
 HITL_KIND = "core-blocked"
 

--- a/src/hitl/projector.py
+++ b/src/hitl/projector.py
@@ -45,6 +45,15 @@ def fallback_body(req: HumanRequirement) -> str:
     return head
 
 
+def pending_ids(manager: HitlManager) -> List[str]:
+    """Requirement ids whose revision is ahead of their projection.
+
+    A caller owning retry cadence needs to tell "nothing to send" from "every
+    send was refused"; `project()` returns an empty list for both.
+    """
+    return [r.id for r in manager.store.all() if manager.needs_projection(r.id)]
+
+
 def project(manager: HitlManager, send: Sender, room_id: str) -> List[Tuple[str, Optional[str]]]:
     """Drive every requirement whose revision is ahead of its projection.
 

--- a/src/hitl/schema.py
+++ b/src/hitl/schema.py
@@ -15,7 +15,8 @@ from typing import Any, Dict, List, Optional
 WIRE_FIELD = "space.ag2.hitl"
 
 KINDS = frozenset(
-    {"auth", "permission", "choice", "confirmation", "billing", "external_action", "unknown"}
+    {"auth", "permission", "choice", "confirmation", "billing", "external_action",
+     "core-blocked", "unknown"}
 )
 
 STATUS_PENDING = "pending"

--- a/tests/core-input-watch-chat-escalation.test.py
+++ b/tests/core-input-watch-chat-escalation.test.py
@@ -195,6 +195,23 @@ class TestDegradesWithoutDyingV(unittest.TestCase):
         self.assertIsNone(
             M.escalate(None, "blocked-human", "d", None, None, "s1"))
 
+    def test_a_store_that_cannot_be_CONSTRUCTED_is_as_optional_as_a_missing_import(self):
+        """The import sat inside the fail-open boundary and the construction did
+        not, so an unbuildable store killed the monitor before its first tick."""
+        with tempfile.TemporaryDirectory() as td:
+            ws = pathlib.Path(td)
+            (ws / "state").mkdir()
+            (ws / "state" / "hitl").write_text("a regular file, not a directory")
+            self.assertIsNone(M._hitl_manager(str(ws / "state" / "core-status.json")))
+
+    def test_the_healthy_path_still_returns_a_manager(self):
+        """Control: without it the test above passes on a function that always
+        returns None, which is not the behaviour being pinned."""
+        with tempfile.TemporaryDirectory() as td:
+            ws = pathlib.Path(td)
+            (ws / "state").mkdir()
+            self.assertIsNotNone(M._hitl_manager(str(ws / "state" / "core-status.json")))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/core-input-watch-chat-escalation.test.py
+++ b/tests/core-input-watch-chat-escalation.test.py
@@ -137,5 +137,64 @@ class TestScope(unittest.TestCase):
             self.assertNotIn(s, M._CHAT_ESCALATE_STATES, s)
 
 
+class TestDegradesWithoutDyingV(unittest.TestCase):
+    """The monitor's contract is that it keeps writing its state file whatever
+    the card layer does. Every branch below is a failure the card layer can
+    have; none of them may reach the caller as an exception."""
+
+    def test_it_puts_src_on_the_path_when_it_is_missing(self):
+        """The monitor is executed as a script, so `src` is not importable
+        unless it puts itself there."""
+        removed = [p for p in sys.path if p == str(SRC)]
+        for p in removed:
+            sys.path.remove(p)
+        try:
+            self.assertNotIn(str(SRC), sys.path, "control: src really was removed")
+            with tempfile.TemporaryDirectory() as d:
+                out = os.path.join(d, "state", "core-input.json")
+                self.assertIsNotNone(M._hitl_manager(out))
+            self.assertIn(str(SRC), sys.path, "it must re-insert src to import hitl")
+        finally:
+            for p in removed:
+                if p not in sys.path:
+                    sys.path.insert(0, p)
+
+    def test_no_hitl_package_yields_no_manager_and_no_exception(self):
+        """`src/hitl` is an optional tier: a standalone checkout without it
+        must still run the monitor, minus the card."""
+        saved = sys.modules.get("hitl.manager", "absent")
+        sys.modules["hitl.manager"] = None  # makes `from hitl.manager import ...` raise
+        try:
+            with tempfile.TemporaryDirectory() as d:
+                self.assertIsNone(M._hitl_manager(os.path.join(d, "state", "s.json")))
+        finally:
+            if saved == "absent":
+                del sys.modules["hitl.manager"]
+            else:
+                sys.modules["hitl.manager"] = saved
+
+    def test_a_raising_store_does_not_take_down_the_escalation(self):
+        class Boom:
+            def create(self, req):
+                raise RuntimeError("store on fire")
+
+        self.assertIsNone(
+            M.escalate(Boom(), "blocked-human", "d", "selection", "Pick one:", "s1"))
+
+    def test_resolution_without_a_manager_is_empty_not_an_error(self):
+        self.assertEqual(M.resolve_escalations(None, "s1"), [])
+
+    def test_a_raising_store_does_not_take_down_resolution(self):
+        class Boom:
+            def active(self):
+                raise RuntimeError("store on fire")
+
+        self.assertEqual(M.resolve_escalations(Boom(), "s1"), [])
+
+    def test_escalate_without_a_manager_is_none_not_an_error(self):
+        self.assertIsNone(
+            M.escalate(None, "blocked-human", "d", None, None, "s1"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/core-input-watch-chat-escalation.test.py
+++ b/tests/core-input-watch-chat-escalation.test.py
@@ -92,7 +92,7 @@ class TestResolve(unittest.TestCase):
     def test_leaving_the_blocked_set_resolves_the_card(self):
         m = _mgr()
         req = M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
-        self.assertEqual(M.resolve_escalations(m), [req.id])
+        self.assertEqual(M.resolve_escalations(m, "s"), [req.id])
         self.assertEqual(m.get(req.id).status, STATUS_RESOLVED)
 
     def test_it_resolves_only_its_own_kind(self):
@@ -104,13 +104,27 @@ class TestResolve(unittest.TestCase):
                                           message="may I", guard="g1",
                                           actions=[Action("allow", "allow", "Allow")]))
         M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
-        self.assertNotIn(other.id, M.resolve_escalations(m))
+        self.assertNotIn(other.id, M.resolve_escalations(m, "s"))
         self.assertNotEqual(m.get(other.id).status, STATUS_RESOLVED)
+
+    def test_it_resolves_only_its_own_session(self):
+        """A pool shares one login, so a weekly limit blocks every worker on
+        byte-identical prompt text. One worker recovering must not clear a
+        sibling's card, and two blocked workers are two cards, not one."""
+        m = _mgr()
+        P = "You've reached your Fable limit"
+        a = M.escalate(m, "blocked-human", "d", "fable-limit-unfocused", P, "worker-1")
+        b = M.escalate(m, "blocked-human", "d", "fable-limit-unfocused", P, "worker-2")
+        self.assertNotEqual(a.id, b.id, "two blocked workers collapsed to one card")
+        self.assertEqual(len(m.active()), 2)
+        self.assertEqual(M.resolve_escalations(m, "worker-1"), [a.id])
+        self.assertEqual([r.id for r in m.active()], [b.id],
+                         "worker-1 recovering cleared worker-2's card")
 
     def test_a_second_block_after_recovery_raises_again(self):
         m = _mgr()
         first = M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
-        M.resolve_escalations(m)
+        M.resolve_escalations(m, "s")
         again = M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
         self.assertNotEqual(first.id, again.id)
 

--- a/tests/core-input-watch-chat-escalation.test.py
+++ b/tests/core-input-watch-chat-escalation.test.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
-"""A blocked core must reach the owner where they already are.
+"""A blocked core raises a HumanRequirement, so it reaches the owner as a card.
 
-ESCALATE was a banner in the Runtime window, so the owner had to be looking at
-that window to learn the core was stuck (owner report 2026-09-03, after a
-weekly model-limit prompt held the core all morning). The monitor is a separate
-process and the bridge claims `results/proactive-*.txt` independently of the
-core, so the announcement can be made by the one layer that is not blocked.
+ESCALATE was a banner in the Runtime window, so learning the core was stuck
+required already looking at that window (owner report 2026-09-03, after a
+weekly model-limit prompt held the core all morning).
 
-The whole design risk is repetition: a stuck core stays stuck for as long as it
-takes someone to act, and a per-tick announcement would turn one problem into a
-room full of them. These tests pin once-per-episode.
+`src/hitl` already owns requirement dedup and card projection; the monitor is
+the driver it never had. These tests pin what the monitor contributes: the
+right states, an episode key the Manager can dedup on, resolution when the
+core moves on, and never dying of its own escalation.
 """
 import importlib.util as u
 import os
@@ -19,97 +18,107 @@ import tempfile
 import unittest
 
 HERE = pathlib.Path(__file__).resolve().parent
-SRC = HERE.parent / "src" / "core-input-watch.py"
-spec = u.spec_from_file_location("ciw", SRC)
+SRC = HERE.parent / "src"
+sys.path.insert(0, str(SRC))
+spec = u.spec_from_file_location("ciw", SRC / "core-input-watch.py")
 M = u.module_from_spec(spec)
 spec.loader.exec_module(M)
 
-
-def _ws():
-    d = tempfile.mkdtemp()
-    os.makedirs(os.path.join(d, "state"), exist_ok=True)
-    return d, os.path.join(d, "state", "core-supervisor.json")
+from hitl.manager import HitlManager, HitlStore  # noqa: E402
+from hitl.schema import STATUS_RESOLVED  # noqa: E402
 
 
-class TestEscalationBody(unittest.TestCase):
+def _mgr():
+    return HitlManager(HitlStore(pathlib.Path(tempfile.mkdtemp())))
+
+
+class TestMessage(unittest.TestCase):
     def test_it_names_the_gate_and_quotes_the_terminal(self):
-        b = M.escalation_body("blocked-human", "awaiting user: selection",
-                              "selection", "Pick one:\n> a\n  b")
+        b = M.escalation_message("blocked-human", "awaiting user: selection",
+                                 "selection", "Pick one:\n> a\n  b")
         self.assertIn("cannot continue without you", b)
         self.assertIn("selection", b)
         self.assertIn("Pick one:", b)
 
     def test_an_unknown_gate_is_not_rendered_as_a_gate_name(self):
-        """`unknown` is the classifier saying it could not tell, so printing
-        `Gate: unknown` reads as a fact about the prompt rather than about us."""
-        b = M.escalation_body("blocked-human", "awaiting user: unknown", "unknown", "x")
+        """`unknown` is the classifier saying it could not tell, so `Gate:
+        unknown` reads as a fact about the prompt rather than about us."""
+        b = M.escalation_message("blocked-human", "d", "unknown", "x")
         self.assertNotIn("Gate: unknown", b)
 
     def test_logged_out_says_signed_out_not_blocked(self):
-        b = M.escalation_body("logged-out", "core not authenticated", None, None)
-        self.assertIn("signed out", b)
+        self.assertIn("signed out",
+                      M.escalation_message("logged-out", "d", None, None))
 
 
-class TestWriter(unittest.TestCase):
-    def test_it_writes_into_the_workspace_results_dir(self):
-        d, out = _ws()
-        p = M.escalate_to_chat(out, "blocked-human", "awaiting user: selection", "selection", "x")
-        self.assertIsNotNone(p)
-        self.assertEqual(os.path.basename(os.path.dirname(p)), "results")
-        self.assertTrue(os.path.basename(p).startswith("proactive-"))
-        self.assertIn("cannot continue", open(p).read())
+class TestEscalate(unittest.TestCase):
+    def test_it_raises_one_requirement_with_an_actionable_card(self):
+        m = _mgr()
+        req = M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "sutando-core")
+        self.assertIsNotNone(req)
+        self.assertEqual(req.kind, M.HITL_KIND)
+        self.assertTrue(req.actions, "a card with no action cannot be answered")
+        self.assertIn("Pick one:", req.message)
 
-    def test_an_unwritable_results_dir_does_not_raise(self):
+    def test_the_same_prompt_held_for_many_ticks_raises_one_card(self):
+        m = _mgr()
+        ids = {M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s").id
+               for _ in range(40)}
+        self.assertEqual(len(ids), 1)
+
+    def test_a_different_prompt_is_a_different_card(self):
+        """Two things needing the owner are two cards, even back to back —
+        the second is not a redraw of the first."""
+        m = _mgr()
+        a = M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
+        b = M.escalate(m, "blocked-human", "d", "login", "Log in:", "s")
+        self.assertNotEqual(a.id, b.id)
+
+    def test_the_prompt_is_the_episode_key_not_the_state(self):
+        """Guard is derived from the prompt: keying on state alone would
+        collapse two unrelated blocks into one card."""
+        m = _mgr()
+        a = M.escalate(m, "blocked-human", "d", "selection", "A", "s")
+        b = M.escalate(m, "blocked-human", "d", "selection", "B", "s")
+        self.assertNotEqual(a.guard, b.guard)
+
+    def test_no_manager_is_survivable(self):
         """The monitor must outlive its own escalation: if this raised, the
         layer that DETECTS the block would die with the block unreported."""
-        d, out = _ws()
-        os.makedirs(os.path.join(d, "results"))
-        os.chmod(os.path.join(d, "results"), 0o500)
-        try:
-            self.assertIsNone(M.escalate_to_chat(out, "blocked-human", "d", "k", "p"))
-        finally:
-            os.chmod(os.path.join(d, "results"), 0o700)
+        self.assertIsNone(M.escalate(None, "blocked-human", "d", "k", "p", "s"))
 
 
-class TestOncePerEpisode(unittest.TestCase):
-    """The loop's own dedup, exercised through the same key it uses."""
+class TestResolve(unittest.TestCase):
+    def test_leaving_the_blocked_set_resolves_the_card(self):
+        m = _mgr()
+        req = M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
+        self.assertEqual(M.resolve_escalations(m), [req.id])
+        self.assertEqual(m.get(req.id).status, STATUS_RESOLVED)
 
-    def _run(self, states):
-        d, out = _ws()
-        episode = None
-        written = []
-        for state, kind, prompt in states:
-            if state in M._CHAT_ESCALATE_STATES:
-                ep = (state, kind, prompt)
-                if ep != episode:
-                    p = M.escalate_to_chat(out, state, "d", kind, prompt)
-                    if p:
-                        episode = ep
-                        written.append(p)
-            elif state not in M._CHAT_ESCALATE_STATES:
-                episode = None
-        return written
+    def test_it_resolves_only_its_own_kind(self):
+        """A permission card belongs to the hook driver; clearing it because
+        the CORE unblocked would dismiss a question nobody answered."""
+        m = _mgr()
+        from hitl.schema import Action, HumanRequirement
+        other = m.create(HumanRequirement(kind="permission", runtime="claude",
+                                          message="may I", guard="g1",
+                                          actions=[Action("allow", "allow", "Allow")]))
+        M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
+        self.assertNotIn(other.id, M.resolve_escalations(m))
+        self.assertNotEqual(m.get(other.id).status, STATUS_RESOLVED)
 
-    def test_a_block_held_for_many_ticks_announces_once(self):
-        ticks = [("blocked-human", "selection", "Pick one:")] * 40
-        self.assertEqual(len(self._run(ticks)), 1)
+    def test_a_second_block_after_recovery_raises_again(self):
+        m = _mgr()
+        first = M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
+        M.resolve_escalations(m)
+        again = M.escalate(m, "blocked-human", "d", "selection", "Pick one:", "s")
+        self.assertNotEqual(first.id, again.id)
 
-    def test_a_second_block_after_recovery_announces_again(self):
-        ticks = ([("blocked-human", "selection", "Pick one:")] * 5
-                 + [("running", None, None)] * 5
-                 + [("blocked-human", "selection", "Pick one:")] * 5)
-        self.assertEqual(len(self._run(ticks)), 2)
 
-    def test_a_different_gate_in_the_same_stretch_announces_again(self):
-        """Two different things needing the owner are two announcements, even
-        back to back — the second is not a redraw of the first."""
-        ticks = ([("blocked-human", "selection", "Pick one:")] * 3
-                 + [("blocked-human", "login", "Log in:")] * 3)
-        self.assertEqual(len(self._run(ticks)), 2)
-
-    def test_states_with_an_automatic_remedy_are_not_announced(self):
+class TestScope(unittest.TestCase):
+    def test_states_with_an_automatic_remedy_are_not_escalated(self):
         """`blocked-known` is auto-answered and `hung` is RECOVER's job; both
-        would resolve without the owner, so neither is theirs to be woken for."""
+        resolve without the owner, so neither is theirs to be woken for."""
         for s in ("blocked-known", "hung", "crashed", "running", "idle-ready"):
             self.assertNotIn(s, M._CHAT_ESCALATE_STATES, s)
 

--- a/tests/core-input-watch-chat-escalation.test.py
+++ b/tests/core-input-watch-chat-escalation.test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""A blocked core must reach the owner where they already are.
+
+ESCALATE was a banner in the Runtime window, so the owner had to be looking at
+that window to learn the core was stuck (owner report 2026-09-03, after a
+weekly model-limit prompt held the core all morning). The monitor is a separate
+process and the bridge claims `results/proactive-*.txt` independently of the
+core, so the announcement can be made by the one layer that is not blocked.
+
+The whole design risk is repetition: a stuck core stays stuck for as long as it
+takes someone to act, and a per-tick announcement would turn one problem into a
+room full of them. These tests pin once-per-episode.
+"""
+import importlib.util as u
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+SRC = HERE.parent / "src" / "core-input-watch.py"
+spec = u.spec_from_file_location("ciw", SRC)
+M = u.module_from_spec(spec)
+spec.loader.exec_module(M)
+
+
+def _ws():
+    d = tempfile.mkdtemp()
+    os.makedirs(os.path.join(d, "state"), exist_ok=True)
+    return d, os.path.join(d, "state", "core-supervisor.json")
+
+
+class TestEscalationBody(unittest.TestCase):
+    def test_it_names_the_gate_and_quotes_the_terminal(self):
+        b = M.escalation_body("blocked-human", "awaiting user: selection",
+                              "selection", "Pick one:\n> a\n  b")
+        self.assertIn("cannot continue without you", b)
+        self.assertIn("selection", b)
+        self.assertIn("Pick one:", b)
+
+    def test_an_unknown_gate_is_not_rendered_as_a_gate_name(self):
+        """`unknown` is the classifier saying it could not tell, so printing
+        `Gate: unknown` reads as a fact about the prompt rather than about us."""
+        b = M.escalation_body("blocked-human", "awaiting user: unknown", "unknown", "x")
+        self.assertNotIn("Gate: unknown", b)
+
+    def test_logged_out_says_signed_out_not_blocked(self):
+        b = M.escalation_body("logged-out", "core not authenticated", None, None)
+        self.assertIn("signed out", b)
+
+
+class TestWriter(unittest.TestCase):
+    def test_it_writes_into_the_workspace_results_dir(self):
+        d, out = _ws()
+        p = M.escalate_to_chat(out, "blocked-human", "awaiting user: selection", "selection", "x")
+        self.assertIsNotNone(p)
+        self.assertEqual(os.path.basename(os.path.dirname(p)), "results")
+        self.assertTrue(os.path.basename(p).startswith("proactive-"))
+        self.assertIn("cannot continue", open(p).read())
+
+    def test_an_unwritable_results_dir_does_not_raise(self):
+        """The monitor must outlive its own escalation: if this raised, the
+        layer that DETECTS the block would die with the block unreported."""
+        d, out = _ws()
+        os.makedirs(os.path.join(d, "results"))
+        os.chmod(os.path.join(d, "results"), 0o500)
+        try:
+            self.assertIsNone(M.escalate_to_chat(out, "blocked-human", "d", "k", "p"))
+        finally:
+            os.chmod(os.path.join(d, "results"), 0o700)
+
+
+class TestOncePerEpisode(unittest.TestCase):
+    """The loop's own dedup, exercised through the same key it uses."""
+
+    def _run(self, states):
+        d, out = _ws()
+        episode = None
+        written = []
+        for state, kind, prompt in states:
+            if state in M._CHAT_ESCALATE_STATES:
+                ep = (state, kind, prompt)
+                if ep != episode:
+                    p = M.escalate_to_chat(out, state, "d", kind, prompt)
+                    if p:
+                        episode = ep
+                        written.append(p)
+            elif state not in M._CHAT_ESCALATE_STATES:
+                episode = None
+        return written
+
+    def test_a_block_held_for_many_ticks_announces_once(self):
+        ticks = [("blocked-human", "selection", "Pick one:")] * 40
+        self.assertEqual(len(self._run(ticks)), 1)
+
+    def test_a_second_block_after_recovery_announces_again(self):
+        ticks = ([("blocked-human", "selection", "Pick one:")] * 5
+                 + [("running", None, None)] * 5
+                 + [("blocked-human", "selection", "Pick one:")] * 5)
+        self.assertEqual(len(self._run(ticks)), 2)
+
+    def test_a_different_gate_in_the_same_stretch_announces_again(self):
+        """Two different things needing the owner are two announcements, even
+        back to back — the second is not a redraw of the first."""
+        ticks = ([("blocked-human", "selection", "Pick one:")] * 3
+                 + [("blocked-human", "login", "Log in:")] * 3)
+        self.assertEqual(len(self._run(ticks)), 2)
+
+    def test_states_with_an_automatic_remedy_are_not_announced(self):
+        """`blocked-known` is auto-answered and `hung` is RECOVER's job; both
+        would resolve without the owner, so neither is theirs to be woken for."""
+        for s in ("blocked-known", "hung", "crashed", "running", "idle-ready"):
+            self.assertNotIn(s, M._CHAT_ESCALATE_STATES, s)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/sparrow-hitl-projection.test.py
+++ b/tests/sparrow-hitl-projection.test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""BEHAVIOURAL: the bridge's outbound HITL card driver, `_project_hitl`.
+
+`packages/` sits outside `.coveragerc`'s `[run] source`, so this function is
+neither covered nor uncovered — the gate reports on it by name via
+`scripts/coverage_unmeasured.py` and stops there. A function that posts into a
+room on every outbound pulse should not rest on that, hence this suite: it
+drives the real function against a real requirement store, stubbing only the
+one HTTP seam (`_req`).
+
+What is pinned is what `_project_hitl` itself contributes, not what the
+projector already guarantees: the room guard, the optional-tier guard, that a
+pulse posts an un-projected requirement exactly once, and that a REJECTED send
+records nothing so the next pulse retries it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+# The bridge reads its credentials at import time; give it inert ones.
+os.environ.setdefault("REMOTE_TASK_TOKEN", "test-token")
+os.environ.setdefault("REMOTE_TASK_URL", "https://example.invalid/relay")
+os.environ.setdefault("REMOTE_PROACTIVE_ROOM", "!test:example.invalid")
+sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
+sys.path.insert(0, str(REPO / "src"))
+
+from ag2_sparrow import remote_gateway_bridge as B  # noqa: E402
+from hitl import manager as hm, schema as hs  # noqa: E402
+
+
+class ProjectHitl(unittest.TestCase):
+    def setUp(self):
+        self.ws = Path(tempfile.mkdtemp())
+        self.calls = []
+        self._saved = (B._STATE, B.PROACTIVE_ROOM, B._req)
+        B._STATE = self.ws / "state"
+        B.PROACTIVE_ROOM = "!room:example.invalid"
+        self.answer = {"ok": True, "event_id": "$card"}
+        B._req = lambda method, path, payload=None, timeout=None: (
+            self.calls.append((method, path, payload)) or self.answer)
+        self.manager = hm.HitlManager(hm.HitlStore(hm.default_store(self.ws)))
+
+    def tearDown(self):
+        B._STATE, B.PROACTIVE_ROOM, B._req = self._saved
+
+    def _requirement(self, guard="g1"):
+        return self.manager.create(hs.HumanRequirement(
+            kind="choice", runtime="claude", message="answer me", guard=guard,
+            actions=[hs.Action(id="ok", kind="answer", label="OK")]))
+
+    def test_a_pulse_posts_an_unprojected_requirement_as_a_card(self):
+        req = self._requirement()
+        self.assertEqual(B._project_hitl(log=lambda *a: None), 1)
+        self.assertEqual(len(self.calls), 1)
+        method, path, payload = self.calls[0]
+        self.assertEqual((method, path), ("POST", "/v1/room"))
+        self.assertEqual(payload["room_id"], "!room:example.invalid")
+        self.assertEqual(payload["extra_content"][hs.WIRE_FIELD]["id"], req.id)
+        self.assertIn("answer me", payload["body"], "the plain-text fallback carries the message")
+
+    def test_a_second_pulse_re_sends_nothing(self):
+        """The driver runs on EVERY outbound pulse; without the ledger holding,
+        one card would become one card per pulse forever."""
+        self._requirement()
+        B._project_hitl(log=lambda *a: None)
+        self.assertEqual(B._project_hitl(log=lambda *a: None), 0)
+        self.assertEqual(len(self.calls), 1, "the second pulse must post nothing")
+
+    def test_a_rejected_send_is_retried_on_the_next_pulse(self):
+        """A refusal must record nothing — otherwise the card is lost silently
+        and the requirement waits forever on a projection that never happened."""
+        self._requirement()
+        self.answer = {"ok": False}
+        self.assertEqual(B._project_hitl(log=lambda *a: None), 0)
+        self.answer = {"ok": True, "event_id": "$card"}
+        self.assertEqual(B._project_hitl(log=lambda *a: None), 1)
+        self.assertEqual(len(self.calls), 2)
+
+    def test_no_proactive_room_posts_nothing(self):
+        self._requirement()
+        B.PROACTIVE_ROOM = ""
+        self.assertEqual(B._project_hitl(log=lambda *a: None), 0)
+        self.assertEqual(self.calls, [])
+
+    def test_an_absent_hitl_package_is_an_optional_tier_not_a_failure(self):
+        """Standalone sparrow has no monorepo `src/hitl`; the pulse must carry
+        on without it rather than raising into the outbound worker."""
+        self._requirement()
+        saved = B._monorepo_src
+        B._monorepo_src = lambda marker: ""
+        try:
+            self.assertEqual(B._project_hitl(log=lambda *a: None), 0)
+            self.assertEqual(self.calls, [])
+        finally:
+            B._monorepo_src = saved
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/sparrow-hitl-projection.test.py
+++ b/tests/sparrow-hitl-projection.test.py
@@ -44,6 +44,7 @@ class ProjectHitl(unittest.TestCase):
         B._req = lambda method, path, payload=None, timeout=None: (
             self.calls.append((method, path, payload)) or self.answer)
         self.manager = hm.HitlManager(hm.HitlStore(hm.default_store(self.ws)))
+        B._hitl_backoff_reset()  # module-level state: one test's backoff must not leak
 
     def tearDown(self):
         B._STATE, B.PROACTIVE_ROOM, B._req = self._saved
@@ -71,15 +72,53 @@ class ProjectHitl(unittest.TestCase):
         self.assertEqual(B._project_hitl(log=lambda *a: None), 0)
         self.assertEqual(len(self.calls), 1, "the second pulse must post nothing")
 
-    def test_a_rejected_send_is_retried_on_the_next_pulse(self):
+    def test_a_rejected_send_is_retried_once_the_backoff_elapses(self):
         """A refusal must record nothing — otherwise the card is lost silently
         and the requirement waits forever on a projection that never happened."""
         self._requirement()
         self.answer = {"ok": False}
         self.assertEqual(B._project_hitl(log=lambda *a: None), 0)
+        B._hitl_backoff_reset()  # stand in for the deadline elapsing
         self.answer = {"ok": True, "event_id": "$card"}
         self.assertEqual(B._project_hitl(log=lambda *a: None), 1)
         self.assertEqual(len(self.calls), 2)
+
+    def test_a_refusing_relay_does_not_get_one_post_per_pulse(self):
+        """The worker drives this every ~1s and `project()` assigns cadence to
+        its caller, so without a backoff a refusing relay is hammered forever."""
+        self._requirement()
+        self.answer = {"ok": False}
+        for _ in range(20):
+            B._project_hitl(log=lambda *a: None)
+        self.assertEqual(len(self.calls), 1,
+                         f"20 pulses against a refusing relay sent {len(self.calls)} requests")
+        self.assertGreater(B._HITL_BACKOFF["until"], 0.0)
+
+    def test_the_backoff_grows_and_is_capped(self):
+        self._requirement()
+        self.answer = {"ok": False}
+        seen = []
+        for _ in range(12):
+            B._HITL_BACKOFF["until"] = 0.0   # let each pulse through, keep the delay
+            B._project_hitl(log=lambda *a: None)
+            seen.append(B._HITL_BACKOFF["delay"])
+        self.assertEqual(seen[:4], [1.0, 2.0, 4.0, 8.0])
+        self.assertLessEqual(max(seen), B._HITL_BACKOFF_MAX_S)
+        self.assertEqual(seen[-1], B._HITL_BACKOFF_MAX_S, "it must reach the cap and stay")
+
+    def test_an_idle_pulse_clears_a_backoff_so_a_new_card_is_not_delayed(self):
+        """Backing off on idle would make the next genuine card wait out a
+        delay earned by an unrelated failure."""
+        self._requirement()
+        self.answer = {"ok": False}
+        B._project_hitl(log=lambda *a: None)
+        self.assertGreater(B._HITL_BACKOFF["until"], 0.0)
+        for r in self.manager.store.all():      # resolve everything: nothing left to project
+            self.manager.resolve(r.id)
+            self.manager.record_projection(r.id, 99, "$x")
+        B._HITL_BACKOFF["until"] = 0.0
+        self.assertEqual(B._project_hitl(log=lambda *a: None), 0)
+        self.assertEqual(B._HITL_BACKOFF["delay"], 0.0, "an idle pulse must reset the backoff")
 
     def test_no_proactive_room_posts_nothing(self):
         self._requirement()


### PR DESCRIPTION
When the core is blocked on something only a human can clear, it currently says so in the Runtime panel — a window you have to already be looking at. A weekly model-limit prompt held the core all morning on 2026-09-03 and the owner found it by opening that panel.

**The blocked core cannot announce itself.** The monitor can: `core-input-watch.py` is a separate process, ticks every 3s, and already computes the blocked state. And `src/hitl` already owns everything downstream — a Manager that dedups per `(runtime, kind, device)` + guard, and a projector that renders requirements as `space.ag2.hitl` cards idempotently.

What it never had is a **driver**. `supervise_once()` describes itself as the detector → manager → projector seam and has no caller; the requirement store's only records were e2e-test ones.

## The change

- **Creation** — the monitor calls `manager.create()` with a `HumanRequirement` (kind `core-blocked`, new in `KINDS`). The session and prompt form the guard, so the Manager's own dedup provides once-per-episode. Leaving the blocked set resolves this session's requirements, so the card closes because the core moved on, not because anyone clicked.
- **Projection** — the bridge's outbound pulse calls `project()` beside the proactive drain, with the room and credentials already in scope. The projector's ledger owns idempotency, so a per-pulse call re-sends nothing.

Both are optional tiers: absent `src/hitl`, or no room configured, each returns quietly rather than breaking the pulse. `--no-chat-escalation` opts out.

Scope is deliberately `blocked-human` and `logged-out` only — a test pins that set, because being woken for a state AUTO-ANSWER or RECOVER would clear is the other way to make this unwelcome.

## Evidence at head

`tests/core-input-watch-chat-escalation.test.py` — 13 tests, all green. Mutations, each with the anchor count printed before it was applied:

```
guard drops the session       -> FAIL test_it_resolves_only_its_own_session
resolve ignores the session   -> FAIL test_it_resolves_only_its_own_session
restored                      -> Ran 13 tests, OK
```

Also green: all twelve `hitl-*` suites, `core-input-watch.test.py` 56/56, the sparrow bridge suite, `ci-covers-every-python-test`, and `review-checks: PASS`.

## Findings taken from review

**@sonichi found a cross-session collision**, reproduced here against the real `HitlManager` before fixing:

```
two workers, same prompt -> active=1  titles=['worker-1 · blocked-human']  same_id=True
worker-1 recovers        -> resolved=1  still_active=0   (worker-2 still blocked, card gone)
control: two prompts, one session -> active=2
```

A pool shares one login, so a weekly limit blocks every worker on byte-identical text at once. Session now rides the guard, the `device` identity and the `subject`, and resolution filters on it. Not live today — no pool script on `main` starts the monitor — but #3788 is where it would become live.

**Two bugs the tests caught, both mine:**

- `KINDS` silently coerces an undeclared kind to `"unknown"`. No error. Since the resolver filters on kind, it would have cleared *other drivers'* cards while never clearing its own.
- `resolve()` returns blocked task ids, not a verdict, so an `is not None` check was true for an empty list and resolution silently did nothing.

## Note for reviewers

This branch carries #3835 and #3839 as ancestors — `main` moved into it mid-work and I merged rather than forced, re-running both gateway suites afterwards (`gateway-durable-ack`, `gateway-signal-task-media`: both pass). The review surface is `src/core-input-watch.py`, one line of `src/hitl/schema.py`, and the `_project_hitl` hunk in the bridge.

Not deployed on the authoring host — its watcher and bridge run pre-merge builds.

— sutando-qingyun-air
