### PR TITLE
docs(task-workstream-grouping): the summary is capped at 160 and never rewritten

### DIFF
--- a/skills/task-workstream-grouping/SKILL.md
+++ b/skills/task-workstream-grouping/SKILL.md
@@ -33,6 +33,16 @@ labels.
    - omit isolated, ambiguous, or low-confidence tasks so they remain
      ungrouped;
    - give every proposed group a confidence from 0 to 1.
+   - **a new workstream's `summary` is truncated to 160 characters and is then
+     immutable — write to that budget and front-load the distinctive nouns.**
+     `apply` stores the summary only in the creation branch
+     (`src/task_workstreams.py`, `_safe_text(group.get("summary"), 160)`), so a
+     later `apply` that reuses the id never rewrites it and nothing reports the
+     cut. A longer summary is silently halved at the 160th character, and the
+     tail is exactly what a future task would have matched on: submitting 260
+     characters cost the words `confidence`, `verification`, `render` and
+     `intros` from a workstream whose first line survived intact, which is the
+     failure mode — it looks fine because the beginning is fine.
    - **when reusing an existing workstream, rank with `scripts/rank_workstreams.py`
      rather than by eye.** `best_match(candidates, keywords)` returns the top id
      only if it beats the runner-up by a margin, and `None` otherwise — on a tie


### PR DESCRIPTION
## What

One bullet in the skill's inference rules: a new workstream's `summary` is truncated to 160 characters and is never rewritten afterwards.

## Why

`apply` writes the summary only in the creation branch, so a later `apply` that reuses the id leaves it alone, and nothing reports the truncation.

`src/task_workstreams.py` at `main` (4207406f1):

```python
        if workstream_id not in workstreams:
            workstreams[workstream_id] = {
                "title": title,
                "summary": _safe_text(group.get("summary"), 160),
                "created_at": now,
                "updated_at": now,
            }
```

The skill tells you to "give every proposed group ... a one short semantic description" and says nothing about a budget, so the cap is discovered afterwards or not at all.

## Evidence

Submitting a 260-character summary while creating a workstream. Nothing errored and `apply` reported `{"assigned": 2, "workstreams_created": 1}`. What was stored:

```
Reviewing and editing the founder-facing MatchPE / PE Portfolio Introduction Portal that Tustin AI builds for Act One po
```

Cut mid-word at 160. The lost tail carried `confidence`, `verification`, `render` and `intros` — the terms a later task on the same subject would have matched on, since `rank_workstreams.score()` reads name plus summary. The opening survived intact, which is why the loss is easy to miss: the summary looks fine until you count it.

## Scope

Docs only, one file, `+10/-0`. No behaviour change, and deliberately not a code change: raising or removing the cap is a separate decision with storage and ranking implications, and this PR does not take a position on it.

`scripts/review-checks.sh` over `origin/main...HEAD`: `hardcoded-paths` and `root-artifacts` clean; `prose-cap` reports no in-scope files because it scans `.py` only.
