### PR TITLE
fix(hitl): a card click carrying a note is still a click

### DIFF
--- a/src/hitl/replies.py
+++ b/src/hitl/replies.py
@@ -161,15 +161,15 @@ class HitlReplyHandler:
         req = self.requirement_for_event(target)
         if req is None:
             return None
-        label = _reply_text(str(task.get("task") or "")).strip().lower()
-        action = next((a for a in req.actions
-                       if a.label.strip().lower() == label or a.id.lower() == label), None)
+        action, note = match_action(req, _reply_text(str(task.get("task") or "")))
         if action is None:
             return None  # a reply to the card that is not a click stays a message
         self.last_branch = "fallback"
-        return {**base, "content": {REPLY_FIELD: {
-            "hitl_id": req.id, "expected_revision": req.revision,
-            "action_id": action.id, "guard": req.guard}}}
+        payload = {"hitl_id": req.id, "expected_revision": req.revision,
+                   "action_id": action.id, "guard": req.guard}
+        if note:
+            payload["answer"] = note
+        return {**base, "content": {REPLY_FIELD: payload}}
 
     def requirement_for_event(self, event_id: str) -> Optional[HumanRequirement]:
         """The active requirement whose card is `event_id` (CREATE projection;
@@ -178,6 +178,35 @@ class HitlReplyHandler:
             if self._manager.projection_target(req.id) == event_id:
                 return req
         return None
+
+
+# The separator is required: without it a label prefix-matches an unrelated
+# sentence that merely starts with it, silently turning prose into a decision.
+NOTE_SEPARATORS = ("\u2014", "\u2013", "-", ":")
+
+
+def match_action(req: HumanRequirement, text: str):
+    """(Action, note) for a reply that is a click, else (None, None).
+
+    Exact label or id is a bare click. `<label> <sep> <note>` is the same click
+    carrying a free-text qualification, which travels on as ActionReply.answer.
+    """
+    t = (text or "").strip()
+    low = t.lower()
+    for action in req.actions:
+        for cand in (action.label or "", action.id or ""):
+            c = cand.strip()
+            if not c:
+                continue
+            if low == c.lower():
+                return action, None
+            if low.startswith(c.lower()):
+                rest = t[len(c):].lstrip()
+                if rest[:1] in NOTE_SEPARATORS:
+                    # A separator with nothing after it is still the click; the
+                    # human just left the note empty.
+                    return action, (rest[1:].strip() or None)
+    return None, None
 
 
 REPLY_CONTEXT_END = "[End AG2 Space reply context]"

--- a/tests/hitl-replies.test.py
+++ b/tests/hitl-replies.test.py
@@ -22,12 +22,21 @@ from hitl.replies import (  # noqa: E402
     REPLY_FIELD,
     HitlReplyHandler,
     actions_dir,
+    match_action,
     parse_reply,
 )
 from hitl.events import events_dir, ingest  # noqa: E402
 from hitl.manager import HitlManager, HitlStore  # noqa: E402
 
 OWNER = "@owner:ag2.space"
+
+
+def _mgr_with(req):
+    """A manager whose store already holds `req` — for the fallback path, which
+    looks a requirement up by the card event it was projected as."""
+    m = HitlManager(HitlStore(Path(tempfile.mkdtemp())))
+    m.create(req)
+    return m
 
 
 def event(payload, actor=OWNER, etype="message.created", eid="$e1", **content):
@@ -211,6 +220,69 @@ class ReplyHandlerTests(unittest.TestCase):
         self.assertEqual(chain.offer(event(None, eid="$chat")), ["$chat"])
         self.assertEqual(seen, ["$chat"])
         self.assertEqual(self.mgr.get(self.req.id).chosen_action, "allow")
+
+
+class TestFallbackCarriesTheNote(unittest.TestCase):
+    """The client appends the human's note to the click body so the timeline
+    shows what they actually said; the fallback must still recognise the click
+    AND carry the note on as the answer."""
+
+    def _req(self):
+        return HumanRequirement(
+            kind="choice", runtime="claude", message="m", guard="g",
+            actions=[Action(id="not_now", kind="answer", label="Not now"),
+                     Action(id="approve", kind="answer", label="Approve it")])
+
+    def test_a_bare_label_is_still_a_click_with_no_note(self):
+        a, note = match_action(self._req(), "Not now")
+        self.assertEqual(a.id, "not_now")
+        self.assertIsNone(note)
+
+    def test_label_plus_note_is_the_same_click_carrying_the_note(self):
+        a, note = match_action(
+            self._req(), "Not now — I will talk to him. Ignore his request for now.")
+        self.assertEqual(a.id, "not_now")
+        self.assertEqual(note, "I will talk to him. Ignore his request for now.")
+
+    def test_a_sentence_merely_starting_with_a_label_is_not_a_click(self):
+        """Without the separator requirement, 'Not nowadays...' would answer
+        the card — a prose reply silently becoming a decision."""
+        a, note = match_action(self._req(), "Not nowadays, this needs thought")
+        self.assertIsNone(a)
+        self.assertIsNone(note)
+
+    def test_an_unrelated_reply_stays_a_message(self):
+        a, _ = match_action(self._req(), "what does this even mean?")
+        self.assertIsNone(a)
+
+    def test_a_label_with_an_empty_note_is_a_bare_click(self):
+        a, note = match_action(self._req(), "Not now —   ")
+        self.assertEqual(a.id, "not_now")
+        self.assertIsNone(note)
+
+    def test_the_action_id_also_matches(self):
+        a, note = match_action(self._req(), "approve: rui has waited long enough")
+        self.assertEqual(a.id, "approve")
+        self.assertEqual(note, "rui has waited long enough")
+
+    def test_the_note_reaches_the_wire_as_answer(self):
+        h = HitlReplyHandler(_mgr_with(self._req()), "@owner:x")
+        req = h._manager.active()[0]
+        h._manager.store.save(req, projection={"revision": 1, "event_id": "$card"})
+        ev = h.task_to_event({"id": "t", "source_message_id": "$m", "channel_id": "!r",
+                              "user_id": "@owner:x", "reply_to_event": "$card",
+                              "task": "Not now — talking to him first"})
+        self.assertIsNotNone(ev)
+        self.assertEqual(ev["content"][REPLY_FIELD]["answer"], "talking to him first")
+
+    def test_a_bare_click_puts_no_answer_on_the_wire(self):
+        h = HitlReplyHandler(_mgr_with(self._req()), "@owner:x")
+        req = h._manager.active()[0]
+        h._manager.store.save(req, projection={"revision": 1, "event_id": "$card"})
+        ev = h.task_to_event({"id": "t", "source_message_id": "$m", "channel_id": "!r",
+                              "user_id": "@owner:x", "reply_to_event": "$card",
+                              "task": "Not now"})
+        self.assertNotIn("answer", ev["content"][REPLY_FIELD])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

The client appends the human's note to a card click's body so the timeline shows what they actually said — `Not now — I will talk to him. Ignore his request for now.` The task-relay fallback matched on **exact label equality**, so the note made the reply stop being a click at all. It fell through as an ordinary message and the decision was never applied.

Measured on a real card in the live store, before the fix:

```
HER ACTUAL TEXT    -> False   (recognised as a click?)
CONTROL bare label -> True
```

The control is the point: the label alone works, so this is the note doing it, not the card or the reply target.

## The fix

`match_action` accepts `<label> <separator> <note>` and carries the note on as `ActionReply.answer`, which `HitlManager.apply_action` already persists — the wire and the store needed nothing.

**The separator is required, deliberately.** Without it `"Not nowadays, this needs thought"` prefix-matches the `Not now` label and silently becomes a decision. A prose reply turning into an answer is a worse failure than the one being fixed, so it has its own test.

A separator with an empty note stays a bare click rather than being rejected — the human just left the note blank.

## Evidence

Eight new tests, suite 19 → 27, all passing. Two mutations, each reddening exactly its own assertion:

| mutation | reddens |
|---|---|
| drop the separator requirement (`if True:`) | `test_a_sentence_merely_starting_with_a_label_is_not_a_click` |
| never put the note on the wire | `test_the_note_reaches_the_wire_as_answer` |

Then the owner's actual message, through the fixed path against the live store:

```
hitl: hitl_d77513df9999 -> not_now by @qingyun:ag2.space (in_progress)
branch: fallback
chosen_action = not_now
answer        = 'I will talk to him. Ignore his request for now.'
```

## Ordering

Pairs with **ag2-space/cinny-webclient#847**, which is what starts sending the note. That PR degrades without this one — a note-carrying click becomes an ordinary message rather than being applied — so it degrades rather than breaking, but the two belong together and this half is the safe one to land first.

— sutando-qingyun-air (@qingyun-air.agent:ag2.space)
