### PR TITLE
fix(hitl): a shorter button label must not claim a longer one's click

### DIFF
--- a/src/hitl/replies.py
+++ b/src/hitl/replies.py
@@ -193,19 +193,34 @@ def match_action(req: HumanRequirement, text: str):
     """
     t = (text or "").strip()
     low = t.lower()
+    # Exact match over the WHOLE action set outranks any prefix, or a shorter
+    # sibling label claims the click and eats the rest of the longer one.
     for action in req.actions:
         for cand in (action.label or "", action.id or ""):
             c = cand.strip()
-            if not c:
-                continue
-            if low == c.lower():
+            if c and low == c.lower():
                 return action, None
-            if low.startswith(c.lower()):
-                rest = t[len(c):].lstrip()
-                if rest[:1] in NOTE_SEPARATORS:
-                    # A separator with nothing after it is still the click; the
-                    # human just left the note empty.
-                    return action, (rest[1:].strip() or None)
+    best = None
+    for action in req.actions:
+        for cand in (action.label or "", action.id or ""):
+            c = cand.strip()
+            if not c or not low.startswith(c.lower()):
+                continue
+            tail = t[len(c):]
+            rest = tail.lstrip()
+            sep = rest[:1]
+            if sep not in NOTE_SEPARATORS:
+                continue
+            # "-" joins words in English, so it separates only where the text
+            # breaks around it; the dashes and ":" never join a word.
+            if sep == "-" and not (tail[:1].isspace() or rest[1:2].isspace()):
+                continue
+            # A separator with nothing after it is still the click; the human
+            # just left the note empty.
+            if best is None or len(c) > len(best[0]):
+                best = (c, action, rest[1:].strip() or None)
+    if best is not None:
+        return best[1], best[2]
     return None, None
 
 

--- a/tests/hitl-replies.test.py
+++ b/tests/hitl-replies.test.py
@@ -265,6 +265,73 @@ class TestFallbackCarriesTheNote(unittest.TestCase):
         self.assertEqual(a.id, "approve")
         self.assertEqual(note, "rui has waited long enough")
 
+    def test_a_longer_sibling_label_owns_its_own_click(self):
+        """A shorter label prefixes the longer one, and the hyphen inside the
+        longer label reads as a separator, so first-match returned the WRONG
+        action with the rest of the real label as its note."""
+        req = HumanRequirement(
+            kind="choice", runtime="claude", message="m", guard="g",
+            actions=[Action(id="approve", kind="answer", label="Approve"),
+                     Action(id="approve_all", kind="answer", label="Approve-all")])
+        a, note = match_action(req, "Approve-all")
+        self.assertEqual(a.id, "approve_all")
+        self.assertIsNone(note)
+
+    def test_exact_match_beats_a_prefix_from_an_earlier_action(self):
+        req = HumanRequirement(
+            kind="choice", runtime="claude", message="m", guard="g",
+            actions=[Action(id="not_now", kind="answer", label="Not now"),
+                     Action(id="not_now_later", kind="answer", label="Not now: later")])
+        a, note = match_action(req, "Not now: later")
+        self.assertEqual(a.id, "not_now_later")
+        self.assertIsNone(note)
+
+    def test_the_longest_matching_label_wins_when_a_note_follows(self):
+        """Exact match cannot decide this one — the text is longer than either
+        label — so the prefix pass has to prefer the longer label, or the
+        shorter sibling claims the click and eats the rest of the real label."""
+        req = HumanRequirement(
+            kind="choice", runtime="claude", message="m", guard="g",
+            actions=[Action(id="not_now", kind="answer", label="Not now"),
+                     Action(id="not_now_later", kind="answer", label="Not now: later")])
+        a, note = match_action(req, "Not now: later \u2014 but ask me again on Friday")
+        self.assertEqual(a.id, "not_now_later")
+        self.assertEqual(note, "but ask me again on Friday")
+
+    def test_a_hyphenated_word_is_not_a_separator(self):
+        """`-` joins words in English, so accepting it with no break around it
+        turns ordinary prose into a decision — the failure the separator
+        requirement exists to prevent, arriving through the separator list."""
+        a, note = match_action(self._req(), "Not now-ish, maybe Friday")
+        self.assertIsNone(a)
+        self.assertIsNone(note)
+
+    def test_a_label_that_is_a_word_stem_does_not_claim_a_hyphenated_reply(self):
+        req = HumanRequirement(
+            kind="choice", runtime="claude", message="m", guard="g",
+            actions=[Action(id="re", kind="answer", label="Re")])
+        a, note = match_action(req, "Re-run the job")
+        self.assertIsNone(a)
+        self.assertIsNone(note)
+
+    def test_a_hyphen_with_a_break_around_it_still_separates(self):
+        for text in ("Not now - later", "Not now- later"):
+            with self.subTest(text=text):
+                a, note = match_action(self._req(), text)
+                self.assertEqual(a.id, "not_now")
+                self.assertEqual(note, "later")
+
+    def test_the_dashes_and_colon_need_no_break(self):
+        """They never join two halves of a word, so the hyphen rule must not
+        widen to them — that would break the happy path this class covers."""
+        for text, want in (("Not now\u2014later", "later"),
+                           ("Not now\u2013later", "later"),
+                           ("Not now:later", "later")):
+            with self.subTest(text=text):
+                a, note = match_action(self._req(), text)
+                self.assertEqual(a.id, "not_now")
+                self.assertEqual(note, want)
+
     def test_the_note_reaches_the_wire_as_answer(self):
         h = HitlReplyHandler(_mgr_with(self._req()), "@owner:x")
         req = h._manager.active()[0]


### PR DESCRIPTION
Follow-up to #3842, which merged at 2026-09-03T23:49:59Z. Two ways an ordinary reply becomes a decision are on `main` right now.

## Measured on main (`a4bd327f`), by execution

`match_action` imported from `main` in an isolated worktree, four cases:

```
'Approve-all'                ['Approve', 'Approve-all']      -> ('approve', 'all')
'Not now: later'             ['Not now', 'Not now: later']   -> ('not_now', 'later')
'Not now-ish, maybe Friday'  ['Not now']                     -> ('not_now', 'ish, maybe Friday')
'Re-run the job'             ['Re']                          -> ('re', 'run the job')
```

Two causes:

1. **First-action-wins beats exact match.** The loop returned on the first action whose label prefixes the text, so with `[Approve, Approve-all]` the reply `Approve-all` clicked **Approve** — the exact match for the label the human typed belonged to a later action and was never reached.
2. **`-` was accepted with no break around it.** `-` joins words in English, so `Not now-ish, maybe Friday` clicked **Not now**. That is the failure the comment above `NOTE_SEPARATORS` says the separator exists to prevent. The em dash, en dash and `:` never join two halves of a word, so they keep their behaviour unchanged.

Found by @qingyun-wu's PR reviewer on the merged head (5533590801) and reproduced independently before this change (5533610628).

## After

Same harness, this branch:

```
'Approve all'                ['Approve', 'Approve all']      -> ('approve_all', None)
'Approve-all'                ['Approve', 'Approve-all']      -> ('approve_all', None)
'Not now: later'             ['Not now', 'Not now: later']   -> ('not_now_later', None)
'Not now-ish, maybe Friday'  ['Not now']                     -> (None, None)
'Re-run the job'             ['Re']                          -> (None, None)
'Re-run'                     ['Re-run']                      -> ('re_run', None)
'ok - fine'                  ['OK']                          -> ('ok', 'fine')
'OK: '                       ['OK']                          -> ('ok', None)
'Not now — I will talk…'     ['Not now']                     -> ('not_now', 'I will talk…')
'Not nowadays, this needs…'  ['Not now']                     -> (None, None)
```

The last two are #3842's own happy path and the case its existing test pins; both are unchanged.

## Tests

Six added to `tests/hitl-replies.test.py` (33 → 34 in the file, all green). Four mutations verified red rather than assumed:

| mutation | result |
|---|---|
| restore the pre-fix function | 4 failures |
| drop only the hyphen word-boundary rule | 2 failures |
| drop only the exact-match-first pass | 3 failures + 3 errors, including two pre-existing tests |
| take the first prefix match instead of the longest | 1 failure |

The last row is why there are six tests and not five: the first version of this suite passed under that mutation, so the longest-prefix rule was unpinned. `test_the_longest_matching_label_wins_when_a_note_follows` is the case that discriminates it — exact match cannot decide when a note follows both candidate labels.

Every other `tests/hitl-*.test.py` file passes. `tests/hitl-manager-identity.test.py` errors on `assertNoLogs`, which needs Python 3.10; it errors identically at `origin/main` under the same interpreter and is unreachable from these two files.

Stand: Echo Act IV Mini
