### PR TITLE
fix(tool-suites-check): a suite must see the tool as it is on disk

### DIFF
--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -29,6 +29,7 @@ import argparse
 import json
 import os
 import subprocess
+import tempfile
 import sys
 import time
 from pathlib import Path
@@ -121,11 +122,22 @@ def should_run(state: dict, newest: float, max_age: float, now: float) -> "tuple
 
 def run_suites(suites, cwd) -> "list[tuple[str, int, str]]":
     out = []
+    # A fresh bytecode cache per run: an edited tool can otherwise be served its
+    # PRE-edit .pyc and report green. `-B` stops writing, not reading.
+    env = dict(os.environ)
+    with tempfile.TemporaryDirectory(prefix="tool-suites-pyc-") as pycache:
+        env["PYTHONPYCACHEPREFIX"] = pycache
+        out.extend(_run_each(suites, cwd, env))
+    return out
+
+
+def _run_each(suites, cwd, env) -> "list[tuple[str, int, str]]":
+    out = []
     for s in suites:
         try:
             # NO extra argv: unittest would read it as a test-name selector.
             r = subprocess.run([sys.executable, str(s)], capture_output=True,
-                               text=True, timeout=180, cwd=cwd)
+                               text=True, timeout=180, cwd=cwd, env=env)
             lines = [l for l in (r.stdout or "").strip().splitlines() if l.strip()]
             last = lines[-1] if lines else (r.stderr.strip().splitlines() or ["(no output)"])[-1]
             out.append((s.name, r.returncode, last[:100]))

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -129,6 +129,45 @@ with tempfile.TemporaryDirectory() as td:
     (Path(td) / "scripts").mkdir()
     check("zero suites -> exit 2 (a scope result, not a clean bill)", tsc.main(["--workspace", td]), 2)
 
+def stale_bytecode_case(td):
+    """A tool the suite imports, run once, then edited to the same length.
+
+    A same-size edit in the same second is served the pre-edit bytecode, so the
+    suite asserts against code that is not on disk and still exits 0.
+    """
+    ws = Path(td) / "ws2"
+    (ws / "scripts").mkdir(parents=True)
+    (ws / "state").mkdir()
+    (ws / "scripts" / "thing.py").write_text('def verdict():\n    return "AAAA"\n')
+    (ws / "scripts" / "thing.test.py").write_text(
+        "import importlib.util, sys\n"
+        "from pathlib import Path\n"
+        "p = Path(__file__).with_name('thing.py')\n"
+        "s = importlib.util.spec_from_file_location('thing', p)\n"
+        "m = importlib.util.module_from_spec(s); s.loader.exec_module(m)\n"
+        "print('verdict', m.verdict())\n"
+        "sys.exit(0 if m.verdict() == 'AAAA' else 1)\n")
+    return ws
+
+
+with tempfile.TemporaryDirectory() as td:
+    ws = stale_bytecode_case(td)
+    args = ["--workspace", str(ws), "--repo", str(Path(td))]
+    r1 = subprocess.run(PYBASE + [str(TOOL)] + args, capture_output=True, text=True)
+    check("stale-bytecode: first run passes (the tool really does say AAAA)", r1.returncode, 0)
+
+    tool = ws / "scripts" / "thing.py"
+    tool.write_text(tool.read_text().replace('"AAAA"', '"BBBB"'))
+    check("stale-bytecode: the edit is on disk", '"BBBB"' in tool.read_text(), True)
+
+    r2 = subprocess.run(PYBASE + [str(TOOL)] + args, capture_output=True, text=True)
+    # Without a fresh cache the suite imports the PRE-edit module, still sees
+    # AAAA, and this run reports 0 — green on code that no longer exists.
+    check("stale-bytecode: the edited tool is seen, so the suite FAILS",
+          r2.returncode, 1)
+    check("stale-bytecode: and the failure names the suite",
+          "thing.test.py" in (r2.stdout + r2.stderr), True)
+
 if FAILURES:
     print(f"\nFAIL — {len(FAILURES)} check(s):")
     for f in FAILURES:


### PR DESCRIPTION
## The defect

`tool-suites-check` exists so that an edited tool cannot keep a stale pass. It could not deliver that, because the stale pass does not have to come from the schedule — it can come from the bytecode cache.

`sys.pycache_prefix` is set on macOS system python (`~/Library/Caches/com.apple.python`), so compiled bytecode does **not** live beside the source and clearing `__pycache__` clears nothing. The cache is keyed on (path, mtime, size), so an edit that preserves size and lands within the same second is served the pre-edit `.pyc`. A suite that imports the tool then asserts against code that is not on disk, and exits 0.

That is the runner's own failure mode arriving one layer below where it looks.

## Measured, minimal repro

A tool returning `"AAAA"`, a suite that imports it and asserts, then a same-size edit to `"BBBB"`:

```
python3 suite.py                                  -> tool says AAAA   rc=0   stale, and GREEN
python3 -B suite.py                               -> tool says AAAA   rc=0   still stale
PYTHONPYCACHEPREFIX=$(mktemp -d) python3 suite.py -> tool says BBBB   rc=1
rm -rf ~/Library/Caches/com.apple.python; python3 suite.py -> tool says BBBB rc=1
```

`-B` was my first answer and it is wrong: it stops Python **writing** bytecode and still reads an existing cache. I had told a peer to adopt it, and retracted that with this table.

## The change

Each `run_suites` call gets its own `PYTHONPYCACHEPREFIX`, so every suite in the run compiles fresh. A host whose python has no prefix set (Homebrew, for one) is unaffected — the point is that the rule does not have to know which interpreter it got.

## The test

`stale_bytecode_case` is the runner's failure mode end-to-end: run the checker, edit the tool to the same length, run it again, and assert the second run **fails**.

| | result |
|---|---|
| at HEAD | `PASS — tool-suites-check tests` |
| dropping the `PYTHONPYCACHEPREFIX` line | `FAIL — stale-bytecode: the edited tool is seen, so the suite FAILS: got 0, want 1` |

`got 0, want 1` is the defect stated exactly: green on code that no longer exists.

## How it was found

Not by inspection. A mutation control on an unrelated PR reported the *restored* baseline as failing, and `inspect.getsource` showed one thing while the executing code did another. The control that settled it was identical bytes at a new path. Worth stating because the same mechanism produces a **false green** on a mutation — publishing "verified red" for a mutation that never ran — and that direction is silent.

Stand: Echo Act IV Mini
