### PR TITLE
fix(hitl): the plain-text fallback follows the card's categorisation

### DIFF
--- a/src/hitl/projector.py
+++ b/src/hitl/projector.py
@@ -48,7 +48,9 @@ def fallback_body(req: HumanRequirement) -> str:
     """Plain-text rendering for clients that ignore the hitl content field."""
     device = (req.device or {}).get("name", "")
     where = f" (on {device})" if device else ""
-    head = f"{_CATEGORY_HEADS[category_of(req.kind)]} — {req.message}{where}"
+    lead = _CATEGORY_HEADS.get(category_of(req.kind),
+                               _CATEGORY_HEADS[CATEGORY_BLOCKED])
+    head = f"{lead} — {req.message}{where}"
     closer = _STATUS_LINES.get(req.status)
     if closer:
         return f"{head}\n\n{closer}"

--- a/src/hitl/projector.py
+++ b/src/hitl/projector.py
@@ -18,14 +18,24 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from .manager import HitlManager
 from .schema import (
+    CATEGORY_BLOCKED,
+    CATEGORY_DECISION,
     HumanRequirement,
     STATUS_CANCELLED,
     STATUS_EXPIRED,
     STATUS_RESOLVED,
     WIRE_FIELD,
+    category_of,
 )
 
 Sender = Callable[[Dict], Dict]
+
+# The card colours these two apart; a client that ignores the card field saw the
+# blocking header for every kind, so a mere decision read as an alarm.
+_CATEGORY_HEADS = {
+    CATEGORY_BLOCKED: "⚠ Sutando needs your attention",
+    CATEGORY_DECISION: "Sutando needs a decision",
+}
 
 _STATUS_LINES = {
     STATUS_RESOLVED: "✓ Resolved — Sutando has continued its work.",
@@ -38,7 +48,7 @@ def fallback_body(req: HumanRequirement) -> str:
     """Plain-text rendering for clients that ignore the hitl content field."""
     device = (req.device or {}).get("name", "")
     where = f" (on {device})" if device else ""
-    head = f"⚠ Sutando needs your attention — {req.message}{where}"
+    head = f"{_CATEGORY_HEADS[category_of(req.kind)]} — {req.message}{where}"
     closer = _STATUS_LINES.get(req.status)
     if closer:
         return f"{head}\n\n{closer}"

--- a/src/hitl/schema.py
+++ b/src/hitl/schema.py
@@ -21,8 +21,8 @@ KINDS = frozenset(
 
 CATEGORY_BLOCKED = "blocked"
 CATEGORY_DECISION = "decision"
-# Mirrors the client's hitlCategory.ts. An unlisted kind is BLOCKED: under-stating
-# a block strands the user, over-stating a decision only over-warns.
+# Mirrors ag2-space/cinny-webclient src/app/components/message/hitlCategory.ts
+# (#847). An unlisted kind is BLOCKED: under-stating a block strands the user.
 _KIND_CATEGORY = {
     "auth": CATEGORY_BLOCKED,
     "permission": CATEGORY_BLOCKED,

--- a/src/hitl/schema.py
+++ b/src/hitl/schema.py
@@ -18,6 +18,24 @@ KINDS = frozenset(
     {"auth", "permission", "choice", "confirmation", "billing", "external_action", "unknown"}
 )
 
+CATEGORY_BLOCKED = "blocked"
+CATEGORY_DECISION = "decision"
+# Mirrors the client's hitlCategory.ts. An unlisted kind is BLOCKED: under-stating
+# a block strands the user, over-stating a decision only over-warns.
+_KIND_CATEGORY = {
+    "auth": CATEGORY_BLOCKED,
+    "permission": CATEGORY_BLOCKED,
+    "billing": CATEGORY_BLOCKED,
+    "external_action": CATEGORY_BLOCKED,
+    "choice": CATEGORY_DECISION,
+    "confirmation": CATEGORY_DECISION,
+}
+
+
+def category_of(kind: "str | None") -> str:
+    """Which of the two presentations this kind gets."""
+    return _KIND_CATEGORY.get(kind or "", CATEGORY_BLOCKED)
+
 STATUS_PENDING = "pending"
 STATUS_IN_PROGRESS = "in_progress"
 STATUS_RESOLVED = "resolved"

--- a/tests/hitl-projector.test.py
+++ b/tests/hitl-projector.test.py
@@ -140,6 +140,31 @@ class ProjectorTests(unittest.TestCase):
         for kind in KINDS:
             self.assertIn(category_of(kind), (CATEGORY_BLOCKED, CATEGORY_DECISION), kind)
 
+    def test_a_kind_mapped_to_a_head_less_category_still_renders(self):
+        """The direct index was total only because construction coerces an
+        UNRECOGNISED kind to `unknown` — so the KeyError is unreachable that
+        way, and sonichi's first probe measured the coercion instead of the
+        renderer. It becomes reachable when a kind already IN `KINDS` is mapped
+        to a third category, which is why this remaps `choice` rather than
+        inventing one, and why the fallback is BLOCKED: raising here would
+        raise inside the renderer that exists for clients which cannot read
+        the structured field.
+        """
+        import hitl.schema as S
+        original = dict(S._KIND_CATEGORY)
+        S._KIND_CATEGORY["choice"] = "escalation"          # a category with no head
+        try:
+            req = make_req(kind="choice")
+            self.assertEqual(req.kind, "choice", "precondition: not coerced away")
+            self.assertEqual(category_of("choice"), "escalation")
+            body = fallback_body(req)
+            self.assertIn("⚠", body)
+            self.assertIn("needs your attention", body)
+        finally:
+            S._KIND_CATEGORY.clear()
+            S._KIND_CATEGORY.update(original)
+        self.assertEqual(category_of("choice"), CATEGORY_DECISION, "restored")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/hitl-projector.test.py
+++ b/tests/hitl-projector.test.py
@@ -14,7 +14,10 @@ from hitl.projector import (  # noqa: E402
     fallback_body,
     project,
 )
-from hitl.schema import Action, HumanRequirement, WIRE_FIELD  # noqa: E402
+from hitl.schema import (  # noqa: E402
+    Action, CATEGORY_BLOCKED, CATEGORY_DECISION, HumanRequirement, KINDS,
+    WIRE_FIELD, category_of,
+)
 
 ROOM = "!room:ag2.space"
 
@@ -112,6 +115,30 @@ class ProjectorTests(unittest.TestCase):
         req = make_req()
         req.transition("cancelled")
         self.assertIn("Cancelled", fallback_body(req))
+
+    def test_a_decision_does_not_wear_the_blocking_header(self):
+        """The card colours choice/confirmation apart from a real block; a client
+        that ignores the card field used to get the alarm header for every kind."""
+        for kind in ("choice", "confirmation"):
+            body = fallback_body(make_req(kind=kind))
+            self.assertNotIn("⚠", body, kind)
+            self.assertIn("needs a decision", body, kind)
+
+    def test_a_real_block_keeps_the_alarm(self):
+        for kind in ("auth", "permission", "billing", "external_action"):
+            body = fallback_body(make_req(kind=kind))
+            self.assertIn("⚠", body, kind)
+            self.assertIn("needs your attention", body, kind)
+
+    def test_an_unrecognised_kind_falls_back_to_blocked(self):
+        """Under-stating a block strands the user; over-warning only annoys."""
+        self.assertEqual(category_of("nonsense"), CATEGORY_BLOCKED)
+        self.assertIn("⚠", fallback_body(make_req(kind="unknown")))
+
+    def test_every_declared_kind_has_a_head(self):
+        """A kind added to KINDS without a category would KeyError at send time."""
+        for kind in KINDS:
+            self.assertIn(category_of(kind), (CATEGORY_BLOCKED, CATEGORY_DECISION), kind)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The card and its plain-text fallback disagreed about how alarming a requirement is.

## The gap

`ag2-space/cinny-webclient#847` colours a HITL card by kind — grey/light-blue for a decision, amber for a real block. `projector.fallback_body()` never got the same idea:

```python
head = f"⚠ Sutando needs your attention — {req.message}{where}"
```

Zero branches on `kind`, so **every** requirement wore the blocking header. On any client that ignores the `space.ag2.hitl` field — which is the whole reason the fallback exists — a mere `choice` or `confirmation` arrived as an alarm.

## The change

The mapping lives beside `KINDS` in `schema.py`, not in the projector, so the engine has **one owner** for it and it mirrors the client's `hitlCategory.ts` one-for-one:

| kind | category | fallback header |
|---|---|---|
| `auth` `permission` `billing` `external_action` | blocked | `⚠ Sutando needs your attention` |
| `choice` `confirmation` | decision | `Sutando needs a decision` |
| anything else, incl. `unknown` | blocked | `⚠ …` |

An unlisted kind is **blocked** on purpose: under-stating a block strands the user, over-stating a decision only over-warns. Same default the client picked.

## Evidence

Control — the new tests fail without the fix and pass with it, verified by reverting only the head line (anchor count asserted `== 1` before the edit):

```
ANCHOR OCCURRENCES BEFORE REVERT: 1
=== suite WITHOUT the fix ===   Ran 9 tests    FAILED (failures=1)
=== restored ===                Ran 9 tests    OK
```

All ten HITL suites on this branch:

```
hitl-detector  hitl-events  hitl-hook-driver  hitl-manager-identity  hitl-policy
hitl-projector  hitl-replies  hitl-schema  hitl-supervisor  hitl-task-relay-click
-> OK (10/10)
```

Four tests added, and one of them is a guard rather than a case: `test_every_declared_kind_has_a_head` iterates `KINDS`, so adding a kind without giving it a category fails here instead of `KeyError`-ing at send time.

## Scope

Engine only — no client change, no wire-format change. The `space.ag2.hitl` field is untouched, so a card-aware client renders exactly as it does today; only the plain-text body a non-card client sees is affected.

— sutando-qingyun-air (@qingyun-air.agent:ag2.space)