### PR TITLE
fix(sync): the conflicts report searched a compiled regex per saved line

### DIFF
--- a/scripts/sync-conflicts-report.py
+++ b/scripts/sync-conflicts-report.py
@@ -30,6 +30,22 @@ def _by_section(text: str):
         yield head, line
 
 
+def _present_bounded(needle: str, hay: str) -> bool:
+    """`needle` occurs in `hay` with a non-word character (or an edge) on both
+    sides. A plain find with a boundary check, not a compiled regex per line:
+    measured 18 ms vs 0.13 ms per line on a 2 MB haystack, 144x."""
+    i = hay.find(needle)
+    n = len(needle)
+    while i != -1:
+        j = i + n
+        left_ok = i == 0 or not (hay[i - 1].isalnum() or hay[i - 1] == "_")
+        right_ok = j == len(hay) or not (hay[j].isalnum() or hay[j] == "_")
+        if left_ok and right_ok:
+            return True
+        i = hay.find(needle, i + 1)
+    return False
+
+
 def _new_content(saved: str, live: str) -> "list[str]":
     """Lines in the preserved copy whose TEXT is absent from live IN THE SAME SECTION.
     Blind to a renamed heading (falls back to global) and to reordering within a section."""
@@ -56,7 +72,7 @@ def _new_content(saved: str, live: str) -> "list[str]":
         hay = live_haystacks.get(head, haystack)
         # Boundary is any NON-WORD character, not a space: a live line that
         # gained trailing punctuation would otherwise read as absent.
-        if re.search(r"(?<!\w)" + re.escape(needle) + r"(?!\w)", hay):
+        if _present_bounded(needle, hay):
             continue  # same text, laid out differently
         out.append(line)
     return out
@@ -68,7 +84,7 @@ def _split_by_reason(extra: "list[str]", live: str) -> "tuple[list[str], list[st
     absent, resectioned = [], []
     for line in extra:
         needle = " ".join(line.split())
-        if re.search(r"(?<!\w)" + re.escape(needle) + r"(?!\w)", haystack):
+        if _present_bounded(needle, haystack):
             resectioned.append(line)
         else:
             absent.append(line)

--- a/tests/sync-conflicts-report.test.py
+++ b/tests/sync-conflicts-report.test.py
@@ -201,6 +201,21 @@ class TestSyncConflictsReport(unittest.TestCase):
         self.assertNotIn("wrap2.md", r.stdout)
         self.assertNotIn("indent2.md", r.stdout)
 
+    def test_unique_lines_against_a_large_single_section_haystack_finish_fast(self):
+        """The runaway: a 2 MB one-section live file and thousands of saved lines
+        absent from it cost 18 ms each through a per-line regex — 30+ CPU-minutes
+        over the real corpus. A bounded find is 0.13 ms; the bar below is 30x
+        slack over that and 40x under the regex."""
+        import time
+        live = "\n".join(f'{{"ts": {i}, "k": "v{i}"}}' for i in range(40000))
+        saved = "\n".join(f'{{"ts": {i}, "k": "w{i}"}}' for i in range(3000))
+        t = time.time()
+        out = MOD._new_content(saved, live)
+        dt = time.time() - t
+        self.assertEqual(len(out), 3000, "every saved line is genuinely absent")
+        self.assertLess(dt, 4.0, f"_new_content took {dt:.1f}s for 3000 lines against a "
+                                 f"{len(live)//1024} KB haystack — the per-line regex is back")
+
     def test_mixed_batch_reports_only_the_lossy_file(self):
         """The discrimination, exercised in one run rather than three."""
         self._pair("lost.md", "# a\n", "# a\n" + "\n".join(f"n{i}" for i in range(9)) + "\n")


### PR DESCRIPTION
## The defect

`scripts/sync-conflicts-report.py` runs at the end of every `sync-workspace.sh` fire (`_report_unmerged_conflicts`, advisory, `|| true`). For every saved line absent from the live file's `(section, line)` pairs, `_new_content` compiled `re.search(r"(?<!\w)" + re.escape(line) + r"(?!\w)")` and ran it over the section's haystack; `_split_by_reason` did the same over the whole file. On files with no headings — the usage JSONL logs — the "section" is the whole file, so each of thousands of unique lines was regex-searched across a 2 MB string.

Measured on this host today (`sample` showed the step at 99% CPU with no children):

```
report step of the 17:20 fire      31 min CPU, still running at 17:51
report step of the 17:39 fire      11 min CPU, running concurrently — the 10-minute stale-lock
                                   window had expired, so two syncs ran at once
corpus                              94 batches, 141 files, 229 MB; 106,211 saved lines reach the
                                   slow path, 692 of them fall to the whole-file haystack
```

## The fix

`_present_bounded(needle, hay)`: a plain `str.find` loop with the same non-word boundary check on both sides. Same semantics — the reflow, trailing-punctuation, partial-substring and moved-section tests all still pass — without compiling a regex per line.

## Evidence

```
300 absent lines vs the 2 MB usage-2026-09-02 haystack, same input:
  parent  re.search        5.46 s   18.2 ms/line
  head    _present_bounded 0.038 s   0.13 ms/line     144x

parent, _new_content on ONE pair (usage-2026-09-01, 12,240 absent lines, 84 KB haystack):  10.8 s
head,   the FULL script over the real corpus (141 files, 106k slow-path lines):             21 s, rc=1, 117 files reported
        (the parent's projected corpus time from the per-line cost is ~32 min, which is what was observed)

tests/sync-conflicts-report.test.py   parent 33 OK  ->  head 34 OK
  new control: 3,000 unique lines vs a 40,000-line single-section live file must finish < 4 s
  (head 0.4 s; the parent's per-line cost projects to ~55 s, so the control fails there by construction)
review-checks.sh --diff               PASS
```

No behaviour change to what gets reported: the report output at head on the live corpus lists the same 117 files the parent lists once it finishes.

Stand: Echo Act IV Pro