### PR TITLE
fix(tool-suites-check): watch the directory the tools are actually in

### DIFF
--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -157,10 +157,8 @@ def main(argv=None) -> int:
 
     ws = Path(a.workspace)
     statedir = ws / "state"
-    # Watch wherever the tools actually are. This read ws/"scripts" unconditionally,
-    # and on a workspace whose tools live in ws/"tools" that directory can exist and
-    # hold zero .py — so the mtime trigger globbed an empty dir and could never fire
-    # on a tool edit, leaving only the 24h fallback.
+    # A `scripts/` that exists but holds no .py makes the mtime trigger vacuous, so
+    # watch whichever of scripts//tools/ the tools are actually in.
     scripts = next((d for d in (ws / "scripts", ws / "tools")
                     if d.is_dir() and any(d.glob("*.py"))), ws / "scripts")
     if not scripts.is_dir():

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -38,6 +38,24 @@ SENTINEL = "tool-suites-last-run.json"
 EXTRAS = "tool-suites-extra.json"       # {"suites": ["tests/x.test.py", ...]}
 
 
+
+def watched_dirs(ws: Path):
+    """Every immediate subdir of the workspace holding a top-level *.py.
+
+    Named dirs were the bug: `(scripts, tools)` misses a host whose tools live in
+    `bin/`, and the trigger then reports fresh forever while that dir's tools go
+    unstat'd. Over-watching costs a stat; under-watching costs a gate that is
+    green by construction.
+    """
+    if not ws.is_dir():
+        return []
+    return sorted(
+        (d for d in ws.iterdir()
+         if d.is_dir() and not d.name.startswith(".") and any(d.glob("*.py"))),
+        key=lambda d: d.name,
+    )
+
+
 def tools_and_suites(dirs):
     """Union over EVERY candidate dir, not the first that matches: a workspace
     mid-migration holds .py in both, and picking one hides the other's suites."""
@@ -160,10 +178,9 @@ def main(argv=None) -> int:
 
     ws = Path(a.workspace)
     statedir = ws / "state"
-    # Watch EVERY dir holding .py, never the first: an empty result is a fact
-    # about the dirs, not the suite set (extras alone can supply every suite).
-    candidates = [d for d in (ws / "scripts", ws / "tools")
-                  if d.is_dir() and any(d.glob("*.py"))]
+    # DISCOVER the dirs; never name them. A fixed list is the same defect one
+    # name later — a third dir is unwatched and its staleness is silent (3852-r3).
+    candidates = watched_dirs(ws)
     tools, suites = tools_and_suites(candidates)
     try:
         extras = extra_suites(statedir, Path(a.repo).resolve())

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -38,9 +38,14 @@ SENTINEL = "tool-suites-last-run.json"
 EXTRAS = "tool-suites-extra.json"       # {"suites": ["tests/x.test.py", ...]}
 
 
-def tools_and_suites(scripts: Path):
-    suites = sorted(p for p in scripts.glob("*.test.py"))
-    tools = sorted(p for p in scripts.glob("*.py") if not p.name.endswith(".test.py"))
+def tools_and_suites(dirs):
+    """Union over EVERY candidate dir, not the first that matches: a workspace
+    mid-migration holds .py in both, and picking one hides the other's suites."""
+    if isinstance(dirs, Path):
+        dirs = [dirs]
+    found = [p for d in dirs for p in d.glob("*.py")]
+    suites = sorted(p for p in found if p.name.endswith(".test.py"))
+    tools = sorted(p for p in found if not p.name.endswith(".test.py"))
     return tools, suites
 
 
@@ -157,14 +162,14 @@ def main(argv=None) -> int:
 
     ws = Path(a.workspace)
     statedir = ws / "state"
-    # A `scripts/` that exists but holds no .py makes the mtime trigger vacuous, so
-    # watch whichever of scripts//tools/ the tools are actually in.
-    scripts = next((d for d in (ws / "scripts", ws / "tools")
-                    if d.is_dir() and any(d.glob("*.py"))), ws / "scripts")
-    if not scripts.is_dir():
-        print(f"CANNOT ANSWER: no {scripts}", file=sys.stderr)
+    # A `scripts/` that exists but holds no .py makes the mtime trigger vacuous,
+    # so watch EVERY one of scripts/ and tools/ that holds .py, never the first.
+    candidates = [d for d in (ws / "scripts", ws / "tools")
+                  if d.is_dir() and any(d.glob("*.py"))]
+    if not candidates:
+        print(f"CANNOT ANSWER: no {ws / 'scripts'}", file=sys.stderr)
         return 2
-    tools, suites = tools_and_suites(scripts)
+    tools, suites = tools_and_suites(candidates)
     try:
         extras = extra_suites(statedir, Path(a.repo).resolve())
     except ExtrasError as e:

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -160,11 +160,8 @@ def main(argv=None) -> int:
 
     ws = Path(a.workspace)
     statedir = ws / "state"
-    # A `scripts/` that exists but holds no .py makes the mtime trigger vacuous,
-    # so watch EVERY one of scripts/ and tools/ that holds .py, never the first.
-    # No local candidate is a fact about the DIRS, not about the suite set: a
-    # workspace can run entirely off tool-suites-extra.json. Refusing here would
-    # skip every extra, so the only refusal is the zero-SUITES one below.
+    # Watch EVERY dir holding .py, never the first: an empty result is a fact
+    # about the dirs, not the suite set (extras alone can supply every suite).
     candidates = [d for d in (ws / "scripts", ws / "tools")
                   if d.is_dir() and any(d.glob("*.py"))]
     tools, suites = tools_and_suites(candidates)

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -162,11 +162,11 @@ def main(argv=None) -> int:
     statedir = ws / "state"
     # A `scripts/` that exists but holds no .py makes the mtime trigger vacuous,
     # so watch EVERY one of scripts/ and tools/ that holds .py, never the first.
+    # No local candidate is a fact about the DIRS, not about the suite set: a
+    # workspace can run entirely off tool-suites-extra.json. Refusing here would
+    # skip every extra, so the only refusal is the zero-SUITES one below.
     candidates = [d for d in (ws / "scripts", ws / "tools")
                   if d.is_dir() and any(d.glob("*.py"))]
-    if not candidates:
-        print(f"CANNOT ANSWER: no {ws / 'scripts'}", file=sys.stderr)
-        return 2
     tools, suites = tools_and_suites(candidates)
     try:
         extras = extra_suites(statedir, Path(a.repo).resolve())

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -156,7 +156,13 @@ def main(argv=None) -> int:
     a = ap.parse_args(argv)
 
     ws = Path(a.workspace)
-    scripts, statedir = ws / "scripts", ws / "state"
+    statedir = ws / "state"
+    # Watch wherever the tools actually are. This read ws/"scripts" unconditionally,
+    # and on a workspace whose tools live in ws/"tools" that directory can exist and
+    # hold zero .py — so the mtime trigger globbed an empty dir and could never fire
+    # on a tool edit, leaving only the 24h fallback.
+    scripts = next((d for d in (ws / "scripts", ws / "tools")
+                    if d.is_dir() and any(d.glob("*.py"))), ws / "scripts")
     if not scripts.is_dir():
         print(f"CANNOT ANSWER: no {scripts}", file=sys.stderr)
         return 2

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -41,8 +41,6 @@ EXTRAS = "tool-suites-extra.json"       # {"suites": ["tests/x.test.py", ...]}
 def tools_and_suites(dirs):
     """Union over EVERY candidate dir, not the first that matches: a workspace
     mid-migration holds .py in both, and picking one hides the other's suites."""
-    if isinstance(dirs, Path):
-        dirs = [dirs]
     found = [p for d in dirs for p in d.glob("*.py")]
     suites = sorted(p for p in found if p.name.endswith(".test.py"))
     tools = sorted(p for p in found if not p.name.endswith(".test.py"))

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -184,6 +184,58 @@ with tempfile.TemporaryDirectory() as td:
     check("touching a tool in the UNSELECTED dir re-triggers", "running" in p.stdout, True)
 
 
+def third_dir_case(td):
+    """A THIRD layout: scripts/ populated, tools/ absent, tools also in bin/.
+
+    Reported by jsun-m on another host (3852-r3), measured not inferred: the
+    fixed `(scripts, tools)` pair resolves on the populated scripts/ and stops,
+    so four tools under bin/ are never stat'd. They broke one of them and the
+    sweep still printed `fresh` — the same invisible-from-inside shape this PR
+    exists to fix, with scripts/ populated instead of empty.
+    """
+    ws = Path(td) / "ws9"
+    for d in ("scripts", "bin", "state"):
+        (ws / d).mkdir(parents=True)
+    (ws / "scripts" / "kept.py").write_text("def verdict():\n    return 1\n")
+    (ws / "scripts" / "kept.test.py").write_text("import sys\nprint('ok')\nsys.exit(0)\n")
+    (ws / "bin" / "elsewhere.py").write_text("def verdict():\n    return 2\n")
+    (ws / "bin" / "elsewhere.test.py").write_text("import sys\nprint('ok')\nsys.exit(0)\n")
+    return ws
+
+
+with tempfile.TemporaryDirectory() as td:
+    ws = third_dir_case(td)
+    p = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                       capture_output=True, text=True)
+    check("a third dir's suite is DISCOVERED, not just unwatched", "elsewhere.test.py" in p.stdout, True)
+    check("...alongside the conventional one", "kept.test.py" in p.stdout, True)
+    check("...counted as 2, so neither sits silently outside the set",
+          "2 of 2 suites pass" in p.stdout, True)
+    # The reported symptom: an edit in the third dir left the trigger blind.
+    subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                   capture_output=True, text=True)
+    os.utime(ws / "bin" / "elsewhere.py", None)
+    p = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                       capture_output=True, text=True)
+    check("touching a tool in the THIRD dir re-triggers", "running" in p.stdout, True)
+
+with tempfile.TemporaryDirectory() as td:
+    # Discovery must stay bounded: a dir with no .py is not watched, and dotted
+    # dirs are skipped so a vendored tree cannot enlarge the sweep.
+    ws = Path(td) / "ws10"
+    for d in ("tools", "state", "notes", ".hidden"):
+        (ws / d).mkdir(parents=True)
+    (ws / "tools" / "t.py").write_text("x = 1\n")
+    (ws / "notes" / "readme.md").write_text("no python here\n")
+    (ws / ".hidden" / "h.py").write_text("x = 1\n")
+    names = [d.name for d in tsc.watched_dirs(ws)]
+    check("a dir with no .py is not watched", "notes" in names, False)
+    check("a dotted dir is skipped", ".hidden" in names, False)
+    check("the dir that does hold .py IS watched", "tools" in names, True)
+    check("a missing workspace yields no candidates, not a crash",
+          tsc.watched_dirs(Path(td) / "nope"), [])
+
+
 print("7. in-process: the trigger rule and the two scope refusals")
 check("no recorded run -> run", tsc.should_run({}, 0.0, 3600, 100.0)[0], True)
 check("unchanged and young -> fresh", tsc.should_run({"tools_mtime": 5.0, "ran_at": 90.0}, 5.0, 3600, 100.0)[0], False)

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -150,6 +150,40 @@ with tempfile.TemporaryDirectory() as td:
     check("touching a tool under tools/ re-triggers", "running" in p.stdout, True)
 
 
+def both_populated_case(td):
+    """BOTH scripts/ and tools/ hold .py — the ordinary mid-migration state.
+
+    `next(...)` returned scripts/ and stopped, so tools/ was neither watched nor
+    DISCOVERED: its suites never ran at all (3852-r1). Healthy from inside,
+    because the selected dir still yields a non-empty runnable set.
+    """
+    ws = Path(td) / "ws5"
+    for d in ("scripts", "tools", "state"):
+        (ws / d).mkdir(parents=True)
+    (ws / "scripts" / "legacy.py").write_text("def verdict():\n    return 1\n")
+    (ws / "scripts" / "legacy.test.py").write_text("import sys\nprint('ok')\nsys.exit(0)\n")
+    (ws / "tools" / "newer.py").write_text("def verdict():\n    return 2\n")
+    (ws / "tools" / "newer.test.py").write_text("import sys\nprint('ok')\nsys.exit(0)\n")
+    return ws
+
+
+with tempfile.TemporaryDirectory() as td:
+    ws = both_populated_case(td)
+    p = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                       capture_output=True, text=True)
+    check("both dirs populated: the scripts/ suite runs", "legacy.test.py" in p.stdout, True)
+    check("...and the tools/ suite runs too (next() dropped it)", "newer.test.py" in p.stdout, True)
+    check("...counted as 2, so neither is silently outside the set",
+          "2 of 2 suites pass" in p.stdout, True)
+    # The trigger must key on an edit in EITHER dir, not only the first one.
+    subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                   capture_output=True, text=True)
+    os.utime(ws / "tools" / "newer.py", None)
+    p = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                       capture_output=True, text=True)
+    check("touching a tool in the UNSELECTED dir re-triggers", "running" in p.stdout, True)
+
+
 print("7. in-process: the trigger rule and the two scope refusals")
 check("no recorded run -> run", tsc.should_run({}, 0.0, 3600, 100.0)[0], True)
 check("unchanged and young -> fresh", tsc.should_run({"tools_mtime": 5.0, "ran_at": 90.0}, 5.0, 3600, 100.0)[0], False)

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -194,6 +194,31 @@ with tempfile.TemporaryDirectory() as td:
     (Path(td) / "scripts").mkdir()
     check("zero suites -> exit 2 (a scope result, not a clean bill)", tsc.main(["--workspace", td]), 2)
 
+
+# 8. the EXTRAS-ONLY workspace: no local *.py at all, every suite declared.
+#    An empty candidate list is a fact about the dirs, not the suite set —
+#    refusing on it skipped all 10 declared suites on a real host (3852-r2).
+print("8. extras-only: no local *.py, suites come entirely from the extras file")
+with tempfile.TemporaryDirectory() as td:
+    ws, repo = Path(td) / "ws8", Path(td) / "repo"
+    (ws / "scripts").mkdir(parents=True)          # exists, 0 *.py — and no tools/
+    (ws / "state").mkdir()
+    (repo / "tests").mkdir(parents=True)
+    (repo / "tests" / "declared.test.py").write_text("import sys\nprint('ok')\nsys.exit(0)\n")
+    (ws / "state" / "tool-suites-extra.json").write_text(
+        '{"suites": ["tests/declared.test.py"]}')
+    p2 = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(repo)],
+                        capture_output=True, text=True)
+    check("extras-only workspace still RUNS (does not refuse on empty candidates)",
+          p2.returncode == 0 and "running" in p2.stdout, True)
+    check("...and the declared suite is the one that ran",
+          "declared.test.py" in p2.stdout, True)
+    # and with the extras file removed there is genuinely nothing -> refuse
+    (ws / "state" / "tool-suites-extra.json").unlink()
+    p2 = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(repo)],
+                        capture_output=True, text=True)
+    check("no local *.py AND no extras -> still exit 2", p2.returncode, 2)
+
 def stale_bytecode_case(td):
     """A tool the suite imports, run once, then edited to the same length.
 

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -119,6 +119,37 @@ with tempfile.TemporaryDirectory() as td:
                        capture_output=True, text=True)
     check("touching the extra re-triggers", "running" in p.stdout, True)
 
+def watched_dir_case(td):
+    """A workspace whose tools live in tools/, with an EMPTY scripts/ beside it.
+
+    The empty dir is the trap: it exists, so the `no scripts/` refusal does not
+    fire, and it holds no .py, so the newest-mtime trigger has nothing to watch.
+    """
+    ws = Path(td) / "ws3"
+    (ws / "scripts").mkdir(parents=True)          # exists, deliberately empty
+    (ws / "tools").mkdir()
+    (ws / "state").mkdir()
+    (ws / "tools" / "thing.py").write_text("def verdict():\n    return 1\n")
+    (ws / "tools" / "thing.test.py").write_text("import sys\nprint('ok')\nsys.exit(0)\n")
+    return ws
+
+
+with tempfile.TemporaryDirectory() as td:
+    ws = watched_dir_case(td)
+    p = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                       capture_output=True, text=True)
+    check("tools/ is watched when scripts/ is empty", "running" in p.stdout, True)
+    check("and the suite under tools/ actually ran", "thing.test.py" in p.stdout, True)
+    # The trigger must still key on an edit, not merely on the first run.
+    p = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                       capture_output=True, text=True)
+    check("second run is fresh", "fresh" in p.stdout, True)
+    os.utime(ws / "tools" / "thing.py", None)
+    p = subprocess.run([*PYBASE, str(TOOL), "--workspace", str(ws), "--repo", str(Path(td))],
+                       capture_output=True, text=True)
+    check("touching a tool under tools/ re-triggers", "running" in p.stdout, True)
+
+
 print("7. in-process: the trigger rule and the two scope refusals")
 check("no recorded run -> run", tsc.should_run({}, 0.0, 3600, 100.0)[0], True)
 check("unchanged and young -> fresh", tsc.should_run({"tools_mtime": 5.0, "ran_at": 90.0}, 5.0, 3600, 100.0)[0], False)

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -195,9 +195,8 @@ with tempfile.TemporaryDirectory() as td:
     check("zero suites -> exit 2 (a scope result, not a clean bill)", tsc.main(["--workspace", td]), 2)
 
 
-# 8. the EXTRAS-ONLY workspace: no local *.py at all, every suite declared.
-#    An empty candidate list is a fact about the dirs, not the suite set —
-#    refusing on it skipped all 10 declared suites on a real host (3852-r2).
+# 8. EXTRAS-ONLY: no local *.py; refusing on an empty candidate list skipped
+#    all 10 declared suites on a real host (3852-r2).
 print("8. extras-only: no local *.py, suites come entirely from the extras file")
 with tempfile.TemporaryDirectory() as td:
     ws, repo = Path(td) / "ws8", Path(td) / "repo"


### PR DESCRIPTION
## The defect

`main()` read `ws/"scripts"` unconditionally. On a workspace whose tools live in `ws/"tools"`, that directory can **exist and hold zero `.py`** — so the newest-mtime trigger globbed an empty directory and could never fire on a tool edit. Only the 24h fallback ever ran.

Measured on one host, before the fix:

```
$ ls "$WS/scripts/"*.py | wc -l      # the watched directory
0
$ ls "$WS/tools/"*.py | wc -l        # where the tools actually are
82
$ ls "$WS/tools/"*.test.py | wc -l   # suites the runner had never executed
10
```

The runner reported `fresh — 10 suite(s) skipped` in the same pass in which I had edited two of those 82 tools.

## Why it was invisible from inside

The tool's own `zero suites -> exit 2 (a scope result, not a clean bill)` refusal is correct and does **not** fire here, because `suites = suites + extras` and a declared `tool-suites-extra.json` makes the merged list non-empty. An empty *watched* set with a non-empty *runnable* set reads as healthy at every point the code checks.

## The fix, and one shape I tried first and backed out

**Discover** the watched dirs instead of naming them: `watched_dirs(ws)` returns every immediate subdir of the workspace that holds a top-level `*.py`. The existing `zero suites -> exit 2` refusal is unchanged.

⚠ **This replaced an earlier two-name form** (`scripts/`/`tools/` with a `scripts/` fallback), which this body described until now. @jsun-m measured a third host whose tools live in `bin/` — a fixed pair misses it and the trigger reports fresh forever while those tools go unstat'd, which is the same defect one name later. Changed at `cbbf6694`; the body had not caught up.

I first *also* refused on an empty `tools` list. That broke this suite's own `touching the extra re-triggers` case — correctly: a workspace whose suites come entirely from extras is legitimate, and the trigger keys on the extras' mtimes there. The test encoded a case the guard denied, so the guard was wrong, not the test.

## Evidence

New test — an empty `scripts/` beside a populated `tools/`. Against the **unfixed** tool:

```
FAIL tools/ is watched when scripts/ is empty: got False want True
FAIL and the suite under tools/ actually ran: got False want True
FAIL second run is fresh: got False want True
FAIL touching a tool under tools/ re-triggers: got False want True
rc=1
```

With the fix: `PASS — tool-suites-check tests`, rc=0. The last two assertions matter on their own — they check the trigger still keys on an *edit* rather than merely on the first run, so a fix that always returned "running" would not pass.

Payoff on the host it was measured on: the watched set went 10 → 20 suites and immediately surfaced a real broken one that had never been executed (a suite resolving its target relative to cwd rather than `__file__`).

## Scope

Stacked on nothing; branched from `main` at `1225c085` (which includes #3847). Single concern — the watched-directory resolution and its test. #3847 fixed a different failure in the same function (stale bytecode); the two are orthogonal and both are needed.

