### PR TITLE
feat(outbox): production-reachable list/inspect/requeue for parked deliveries

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -105,6 +105,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`osascript-setup-hint.ts`** — Extract the user-actionable sentence from an osascript failure.
 - **`outbox.py`** — Sparrow Outbox: durable delivery claims for an already-created outbound item.
 - **`outbox_adapter.py`** — The Outbox's transport seam: turn a provider response into a DeliveryReceipt.
+- **`outbox_cli.py`** — Operator recovery for the delivery outbox: list / inspect / requeue.
 - **`outbox_log.py`** — Outbox visibility log — single append-only sink for outbound messages.
 - **`output_sanitizer.ts`** — Pure predicate + state machine, no deps — importable so tests exercise THIS code rather than a copy that can pass while the real sanitizer drifts.
 - **`overlay-manager-ui.ts`** — Overlay Manager view for the Sutando web UI.
@@ -179,6 +180,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`telemetry.py`** — Anonymous, opt-out product telemetry for Sutando (PostHog).
 - **`tmux-status.ts`** — Tmux-pane status scraper.
 - **`tmux_probe.py`** — Tri-state tmux session probe shared by every core-liveness reader.
+- **`undelivered_quarantine.py`** — Naming and moves for `results/undelivered/` — the delivery quarantine.
 - **`url-scheme.ts`** — Scheme normalization for URLs handed to Chrome via AppleScript.
 - **`util_paths.py`** — Resolve personal-asset paths with private-dir-first lookup.
 - **`util_paths.ts`** — TypeScript twin of src/util_paths.py — personal-asset path resolution.

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_a.py
@@ -109,6 +109,10 @@ class DesignAClaimBackend:
                     outbox.park_item(self.root, item_id, "max-attempts")
             return outbox._release_locked(self.root, item_id, token.worker)
 
+    def resend_epoch(self, item_id: str) -> int:
+        """Operator re-send generation; 0 until a requeue bumps it."""
+        return outbox.resend_epoch_for(self.root, item_id)
+
     def attempts(self, item_id: str) -> int:
         return outbox.attempts_for(self.root, item_id)
 

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_c.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/backend_c.py
@@ -308,6 +308,15 @@ class DesignCClaimBackend:
     def attempts(self, item_id: str) -> int:
         return self.attempts_by_key(_safe_key(item_id))
 
+    def resend_epoch(self, item_id: str) -> int:
+        """Operator re-send generation; 0 until a requeue bumps it.
+
+        Same store as A: the epoch is written by `outbox.requeue_item` into the
+        item record on this root, so reading it here is what makes a requeue
+        present a NEW idempotency key instead of the parked attempt's.
+        """
+        return outbox.resend_epoch_for(self.root, item_id)
+
     def park(self, item_id: str, reason: str) -> None:
         key = _safe_key(item_id)
         with self._lock(key):

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/contract.py
@@ -195,6 +195,18 @@ class ClaimBackend(Protocol):
         """
         ...
 
+    def resend_epoch(self, item_id: str) -> int:
+        """The item's operator re-send generation; 0 until a requeue bumps it.
+
+        Declared, not duck-typed: the core derives the idempotency key from it,
+        so a backend that silently lacks it presents the SAME key the provider
+        already saw for the attempt that parked the item — the operator reads
+        `requeued`, and the provider dedupes the re-send away with no error on
+        any surface. Return 0 for a backend that does not track re-sends; that
+        is a decision the contract suite can see, not an absence it cannot.
+        """
+        ...
+
     # False = complete() accepts provider/destination and DROPS them.
     # Check this; a signature does not imply durable storage.
     persists_receipt_metadata: bool = False

--- a/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
+++ b/packages/ag2-sparrow/ag2_sparrow/delivery_core/core.py
@@ -39,6 +39,13 @@ def idempotency_key(item_id: str, resend_epoch: int = 0) -> str:
     return f"{item_id}#{resend_epoch}"
 
 
+def _resend_epoch(backend, item_id: str) -> int:
+    """0 for a backend that does not track re-sends: the key stays `id#0`,
+    which is exactly the pre-existing behaviour."""
+    fn = getattr(backend, "resend_epoch", None)
+    return int(fn(item_id)) if callable(fn) else 0
+
+
 class DeliveryCore:
     def __init__(self, backend: ClaimBackend, provider: DeliveryProvider,
                  policy: RetryPolicy | None = None,
@@ -91,7 +98,9 @@ class DeliveryCore:
             if self.backend.is_terminal(item_id):
                 return DrainResult(status=DrainStatus.TERMINAL)
             return DrainResult(status=DrainStatus.NOT_CLAIMED)
-        key = idempotency_key(item_id)
+        # A requeued item must present a NEW logical side effect, or the
+        # provider dedupes the re-send against the attempt that parked it.
+        key = idempotency_key(item_id, _resend_epoch(self.backend, item_id))
         outcome, destination = self._attempt(item_id, payload, key)
         if outcome is DeliveryOutcome.OUTCOME_UNKNOWN:
             caps = self.provider.capabilities

--- a/packages/ag2-sparrow/ag2_sparrow/outbox.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox.py
@@ -733,21 +733,85 @@ def park_item(root: Path, item_id: str, reason: str = "") -> None:
     _write_item(Path(root), item_id, d)
 
 
-def requeue_item(root: Path, item_id: str) -> None:
-    """Hand-recovered item returns to the queue with a FULL attempt budget.
+def resend_epoch_for(root: Path, item_id: str) -> int:
+    """The item's re-send generation. 0 until an operator requeues it.
 
-    Carrying the old count forward makes a re-queued item park again instantly,
-    which is indistinguishable from a broken destination and hides the recovery.
-
-    Uses force-release (administrative destruction — see
-    `release_delivery_claim`): a concurrent live delivery of this item may be
-    interrupted and the item re-delivered after re-queue. At-least-once on this
-    administrative path is accepted by design; operators invoke it exactly
-    because normal ownership state can no longer be trusted.
+    Read by the delivery core to derive the idempotency key, so a requeued item
+    presents a NEW logical side effect the provider will not dedupe away.
     """
-    d = _read_item(Path(root), item_id)
-    d["status"] = "QUEUED"
-    d["attempts"] = 0
-    d["reason"] = None
-    _write_item(Path(root), item_id, d)
-    release_delivery_claim(Path(root), item_id, force=True)
+    try:
+        return int(_read_item(Path(root), item_id).get("resend_epoch", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def read_item(root: Path, item_id: str) -> Optional[dict]:
+    """The whole item record, or None when no record exists. Operator read."""
+    if not _item_path(Path(root), item_id).exists():
+        return None
+    return _read_item(Path(root), item_id)
+
+
+def list_items(root: Path, status: Optional[str] = None) -> list[dict]:
+    """Every item record, newest id order, optionally filtered by status."""
+    d = _items_dir(Path(root))
+    if not d.is_dir():
+        return []
+    out: list[dict] = []
+    for p in sorted(d.glob("*.json")):
+        try:
+            rec = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if status is None or rec.get("status") == status:
+            out.append(rec)
+    return out
+
+
+class RequeueOutcome(str, Enum):
+    """Only REQUEUED means this call moved the item; the other two touched
+    nothing, which is what makes a repeated requeue safe to script."""
+
+    REQUEUED = "requeued"
+    NOT_PARKED = "not-parked"
+    ABSENT = "absent"
+
+
+def requeue_item(root: Path, item_id: str, *, reset_attempts: bool = False,
+                 operator: Optional[str] = None,
+                 reason: Optional[str] = None) -> RequeueOutcome:
+    """Operator recovery: PARKED -> QUEUED as ONE atomic transition.
+
+    Refuses anything not PARKED, which is what makes it idempotent AND keeps it
+    from creating a second delivery: a live claim only exists on an item that is
+    not parked, so this can never destroy one. The force-release below therefore
+    clears a residue of the parked attempt, never a peer's in-flight work.
+
+    Ordering is crash-shaped: the claim goes first, the status last. A crash
+    between them leaves the item PARKED with no claim -- unchanged from the
+    operator's view, and a re-run completes it. The reverse order would publish
+    QUEUED while a stale claim still blocked every drain.
+
+    `reset_attempts` is opt-in per the operator brief. Left False on an item
+    already at MAX_ATTEMPTS, the next failure re-parks it immediately; that is
+    the intended "one more try" semantic, and --reset-attempts is the full
+    budget.
+    """
+    root = Path(root)
+    with _item_lock(root, item_id):
+        if not _item_path(root, item_id).exists():
+            return RequeueOutcome.ABSENT
+        d = _read_item(root, item_id)
+        if d.get("status") != "PARKED":
+            return RequeueOutcome.NOT_PARKED
+        _release_locked(root, item_id, force=True)
+        d["resend_epoch"] = int(d.get("resend_epoch", 0) or 0) + 1
+        d["status"] = "QUEUED"
+        d["reason"] = None
+        if reset_attempts:
+            d["attempts"] = 0
+        d["requeued_at"] = time.time()
+        d["requeued_by"] = operator or "unknown"
+        d["requeue_reason"] = reason or ""
+        _write_item(root, item_id, d)
+        return RequeueOutcome.REQUEUED

--- a/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
@@ -91,9 +91,10 @@ def cmd_requeue(args) -> int:
         payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
         # The record is only half the recovery: the BODY was moved out of the
         # drain's view, and nothing re-reads the quarantine directory.
-        if args.results_dir:
-            restored = undelivered_quarantine.restore(args.results_dir, args.item_id)
-            payload["restored_body"] = str(restored) if restored else None
+        results_dir = args.results_dir or Path(args.root).parent
+        outcome, path = undelivered_quarantine.restore(results_dir, args.item_id)
+        payload["body"] = outcome.value
+        payload["body_path"] = str(path) if path else None
     _emit(payload, args.json)
     if result is outbox.RequeueOutcome.REQUEUED:
         return 0
@@ -123,9 +124,9 @@ def build_parser() -> argparse.ArgumentParser:
                     help="restore the full attempt budget (default: keep the "
                          "count, so one more failure re-parks)")
     rq.add_argument("--results-dir", type=Path,
-                    help="results/ directory: also returns the quarantined "
-                         "body to the drain (without it the record is "
-                         "requeued but nothing is re-sent)")
+                    help="override where result bodies live; defaults to the "
+                         "outbox root's parent, which is where every lane "
+                         "puts it (RESULTS_DIR/.outbox-*)")
     rq.add_argument("--operator", help="recorded as who did it")
     rq.add_argument("--reason", help="recorded as why")
     rq.set_defaults(func=cmd_requeue)

--- a/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Optional
 
 import outbox
+import undelivered_quarantine
 
 
 def _default_operator() -> str:
@@ -88,6 +89,11 @@ def cmd_requeue(args) -> int:
     payload = {"item_id": args.item_id, "result": result.value}
     if result is outbox.RequeueOutcome.REQUEUED:
         payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
+        # The record is only half the recovery: the BODY was moved out of the
+        # drain's view, and nothing re-reads the quarantine directory.
+        if args.results_dir:
+            restored = undelivered_quarantine.restore(args.results_dir, args.item_id)
+            payload["restored_body"] = str(restored) if restored else None
     _emit(payload, args.json)
     if result is outbox.RequeueOutcome.REQUEUED:
         return 0
@@ -116,6 +122,10 @@ def build_parser() -> argparse.ArgumentParser:
     rq.add_argument("--reset-attempts", action="store_true",
                     help="restore the full attempt budget (default: keep the "
                          "count, so one more failure re-parks)")
+    rq.add_argument("--results-dir", type=Path,
+                    help="results/ directory: also returns the quarantined "
+                         "body to the drain (without it the record is "
+                         "requeued but nothing is re-sent)")
     rq.add_argument("--operator", help="recorded as who did it")
     rq.add_argument("--reason", help="recorded as why")
     rq.set_defaults(func=cmd_requeue)

--- a/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
@@ -20,8 +20,13 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-import outbox
-import undelivered_quarantine
+# This module is src-canonical AND vendored into ag2_sparrow, so it must import
+# both ways. Relative first: it fails unambiguously when there is no package.
+try:
+    from . import outbox, undelivered_quarantine
+except ImportError:
+    import outbox
+    import undelivered_quarantine
 
 
 def _default_operator() -> str:

--- a/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Operator recovery for the delivery outbox: list / inspect / requeue.
+
+PARKED is a durable terminal state and nothing in production could lift it —
+`requeue_item` existed with test callers only. This is the reachable surface.
+It owns no policy: every transition is `outbox`'s, so the CLI and any other
+caller cannot drift apart.
+
+src-canonical (see packages/ag2-sparrow/tools/sync_from_src.py MAP) and vendored
+into the package, where `ag2-sparrow-outbox` exposes it. `sutando outbox`
+delegates here rather than re-implementing.
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import outbox
+
+
+def _default_operator() -> str:
+    """Who to record. An unattended caller must still be attributable."""
+    return (os.environ.get("SUTANDO_OPERATOR")
+            or os.environ.get("SUDO_USER")
+            or _login_name()
+            or "unknown")
+
+
+def _login_name() -> Optional[str]:
+    try:
+        return getpass.getuser()
+    except Exception:  # noqa: BLE001 — no passwd entry (container): not fatal
+        return None
+
+
+def _emit(obj, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(obj, sort_keys=True, default=str))
+        return
+    if isinstance(obj, list):
+        if not obj:
+            print("(no items)")
+            return
+        for rec in obj:
+            print(f"{rec.get('status','?'):<10} "
+                  f"attempts={rec.get('attempts',0)} "
+                  f"epoch={rec.get('resend_epoch',0)} "
+                  f"{rec.get('item_id','?')}"
+                  + (f"  reason={rec['reason']}" if rec.get("reason") else ""))
+        return
+    for k in sorted(obj):
+        print(f"{k}: {obj[k]}")
+
+
+def cmd_list(args) -> int:
+    _emit(outbox.list_items(args.root, args.status), args.json)
+    return 0
+
+
+def cmd_inspect(args) -> int:
+    rec = outbox.read_item(args.root, args.item_id)
+    if rec is None:
+        print(f"no such item: {args.item_id}", file=sys.stderr)
+        return 2
+    claim = outbox.read_delivery_claim(args.root, args.item_id)
+    rec = dict(rec)
+    rec["claim"] = f"{claim.drainer_id} pid={claim.pid} ({claim.state})" if claim else None
+    _emit(rec, args.json)
+    return 0
+
+
+def cmd_requeue(args) -> int:
+    """Exit 0 only when this call performed the transition; 3 = nothing to do.
+
+    A distinct code matters for the idempotent re-run: "already queued" is not
+    a failure, and a script must be able to tell it from "I recovered it".
+    """
+    result = outbox.requeue_item(
+        args.root, args.item_id,
+        reset_attempts=args.reset_attempts,
+        operator=args.operator or _default_operator(),
+        reason=args.reason)
+    payload = {"item_id": args.item_id, "result": result.value}
+    if result is outbox.RequeueOutcome.REQUEUED:
+        payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
+    _emit(payload, args.json)
+    if result is outbox.RequeueOutcome.REQUEUED:
+        return 0
+    return 2 if result is outbox.RequeueOutcome.ABSENT else 3
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="ag2-sparrow-outbox",
+        description="Inspect and recover parked outbound deliveries.")
+    p.add_argument("--root", type=Path, required=True,
+                   help="outbox root (the directory holding .items/)")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    ls = sub.add_parser("list", help="list items")
+    ls.add_argument("--status", help="filter, e.g. PARKED")
+    ls.set_defaults(func=cmd_list)
+
+    ins = sub.add_parser("inspect", help="show one item and its claim")
+    ins.add_argument("item_id")
+    ins.set_defaults(func=cmd_inspect)
+
+    rq = sub.add_parser("requeue", help="PARKED -> QUEUED for one item")
+    rq.add_argument("item_id")
+    rq.add_argument("--reset-attempts", action="store_true",
+                    help="restore the full attempt budget (default: keep the "
+                         "count, so one more failure re-parks)")
+    rq.add_argument("--operator", help="recorded as who did it")
+    rq.add_argument("--reason", help="recorded as why")
+    rq.set_defaults(func=cmd_requeue)
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
@@ -44,13 +44,15 @@ def _login_name() -> Optional[str]:
         return None
 
 
-def _emit(obj, as_json: bool) -> None:
+def _emit(obj, as_json: bool, where=None) -> None:
     if as_json:
         print(json.dumps(obj, sort_keys=True, default=str))
         return
     if isinstance(obj, list):
         if not obj:
-            print("(no items)")
+            # Name the root: an absent root and an empty one both list nothing,
+            # and "(no items)" alone cannot tell an operator which they hit.
+            print(f"(no items in {where})" if where is not None else "(no items)")
             return
         for rec in obj:
             print(f"{rec.get('status','?'):<10} "
@@ -64,7 +66,7 @@ def _emit(obj, as_json: bool) -> None:
 
 
 def cmd_list(args) -> int:
-    _emit(outbox.list_items(args.root, args.status), args.json)
+    _emit(outbox.list_items(args.root, args.status), args.json, where=args.root)
     return 0
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
@@ -94,16 +94,19 @@ def cmd_requeue(args) -> int:
         operator=args.operator or _default_operator(),
         reason=args.reason)
     payload = {"item_id": args.item_id, "result": result.value}
-    if result is outbox.RequeueOutcome.REQUEUED:
-        payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
-        # The record is only half the recovery: the BODY was moved out of the
-        # drain's view, and nothing re-reads the quarantine directory.
+    # NOT_PARKED too, not just REQUEUED: the two halves commit separately, so
+    # gating the restore on the transition strands the body on every retry.
+    restored = False
+    if result in (outbox.RequeueOutcome.REQUEUED, outbox.RequeueOutcome.NOT_PARKED):
+        if result is outbox.RequeueOutcome.REQUEUED:
+            payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
         results_dir = args.results_dir or Path(args.root).parent
         outcome, path = undelivered_quarantine.restore(results_dir, args.item_id)
         payload["body"] = outcome.value
         payload["body_path"] = str(path) if path else None
+        restored = outcome is undelivered_quarantine.RestoreOutcome.RESTORED
     _emit(payload, args.json)
-    if result is outbox.RequeueOutcome.REQUEUED:
+    if result is outbox.RequeueOutcome.REQUEUED or restored:
         return 0
     return 2 if result is outbox.RequeueOutcome.ABSENT else 3
 

--- a/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox_cli.py
@@ -101,7 +101,9 @@ def cmd_requeue(args) -> int:
         if result is outbox.RequeueOutcome.REQUEUED:
             payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
         results_dir = args.results_dir or Path(args.root).parent
-        outcome, path = undelivered_quarantine.restore(results_dir, args.item_id)
+        body_id = getattr(args, "body_id", None) or args.item_id
+        outcome, path = undelivered_quarantine.restore(results_dir, body_id)
+        payload["body_id"] = body_id
         payload["body"] = outcome.value
         payload["body_path"] = str(path) if path else None
         restored = outcome is undelivered_quarantine.RestoreOutcome.RESTORED
@@ -137,6 +139,12 @@ def build_parser() -> argparse.ArgumentParser:
                     help="override where result bodies live; defaults to the "
                          "outbox root's parent, which is where every lane "
                          "puts it (RESULTS_DIR/.outbox-*)")
+    rq.add_argument("--body-id", dest="body_id",
+                    help="task id the QUARANTINED BODY is filed under, when it "
+                         "differs from the outbox record id. A named gateway "
+                         "instance keys the record by the broker id and names "
+                         "the body file by the instance-qualified local id, so "
+                         "one id cannot address both.")
     rq.add_argument("--operator", help="recorded as who did it")
     rq.add_argument("--reason", help="recorded as why")
     rq.set_defaults(func=cmd_requeue)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -294,6 +294,7 @@ from .task_archive import find_task_file
 from .local_task_protocol import find_archived_task
 from . import local_task_protocol
 from .result_markers import parse_markers, render_skill_prelude
+from . import undelivered_quarantine
 from .team_guardrail import (team_guardrail_lines, engage_rulebook,
                              AG2SPACE_PROVENANCE, sandboxed_delegation_lines)
 from . import team_result_guard
@@ -3383,7 +3384,6 @@ def _quarantine_undelivered(rfile, tid: str, why: str) -> None:
     the same quarantine the proactive path uses. Without this the file is
     rescanned every pass and the refusal is invisible."""
     try:
-        import undelivered_quarantine
         undelivered_quarantine.quarantine(rfile, RESULTS_DIR)
         _log(f"result {tid}: {why} — quarantined to "
              f"{UNDELIVERABLE_RESULTS_DIR.name}/ — `ag2-sparrow-outbox requeue "

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -3383,11 +3383,11 @@ def _quarantine_undelivered(rfile, tid: str, why: str) -> None:
     the same quarantine the proactive path uses. Without this the file is
     rescanned every pass and the refusal is invisible."""
     try:
-        UNDELIVERABLE_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-        rfile.rename(UNDELIVERABLE_RESULTS_DIR /
-                     f"{rfile.stem}-{int(time.time())}.txt")
+        import undelivered_quarantine
+        undelivered_quarantine.quarantine(rfile, RESULTS_DIR)
         _log(f"result {tid}: {why} — quarantined to "
-             f"{UNDELIVERABLE_RESULTS_DIR.name}/, it will NOT be re-sent")
+             f"{UNDELIVERABLE_RESULTS_DIR.name}/ — `ag2-sparrow-outbox requeue "
+             f"{tid} --results-dir <dir>` restores it")
     except OSError as e:
         _log(f"result {tid}: {why} but quarantine failed ({e}) — "
              "leaving it in place")

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -3382,12 +3382,19 @@ def _delivery_core() -> DeliveryCore:
 def _quarantine_undelivered(rfile, tid: str, why: str) -> None:
     """Move a result the outbox has finally refused into results/undelivered/,
     the same quarantine the proactive path uses. Without this the file is
-    rescanned every pass and the refusal is invisible."""
+    rescanned every pass and the refusal is invisible.
+
+    The printed command must carry BOTH ids on a named instance: the record is
+    keyed by the broker id and the body file by the local one, so neither alone
+    recovers both halves.
+    """
     try:
         undelivered_quarantine.quarantine(rfile, RESULTS_DIR)
         _log(f"result {tid}: {why} — quarantined to "
-             f"{UNDELIVERABLE_RESULTS_DIR.name}/ — `ag2-sparrow-outbox requeue "
-             f"{tid} --results-dir <dir>` restores it")
+             f"{UNDELIVERABLE_RESULTS_DIR.name}/ — `ag2-sparrow-outbox "
+             f"--root {RESULTS_DIR / f'.outbox{_INST_SUFFIX}'} "
+             f"requeue {_broker_tid(tid)} "
+             f"--results-dir {RESULTS_DIR} --body-id {tid}` restores it")
     except OSError as e:
         _log(f"result {tid}: {why} but quarantine failed ({e}) — "
              "leaving it in place")

--- a/packages/ag2-sparrow/ag2_sparrow/undelivered_quarantine.py
+++ b/packages/ag2-sparrow/ag2_sparrow/undelivered_quarantine.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 import time
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -25,13 +26,14 @@ def quarantine_dir(results_dir: Path) -> Path:
     return Path(results_dir) / DIRNAME
 
 
-def quarantine_name(stem: str, when: Optional[float] = None) -> str:
-    """The one place the quarantined filename is spelled."""
-    return f"{stem}-{int(when if when is not None else time.time())}.txt"
+def quarantine_name(stem: str, when: Optional[int] = None) -> str:
+    """The one place the quarantined filename is spelled. Nanoseconds, not
+    seconds: the drain can quarantine one task several times inside a second."""
+    return f"{stem}-{int(when if when is not None else time.time_ns())}.txt"
 
 
 def quarantine(rfile: Path, results_dir: Path,
-               when: Optional[float] = None) -> Path:
+               when: Optional[int] = None) -> Path:
     """Move a refused result out of the drain's view. Returns the new path."""
     d = quarantine_dir(results_dir)
     d.mkdir(parents=True, exist_ok=True)
@@ -58,19 +60,28 @@ def find_quarantined(results_dir: Path, task_id: str) -> list[Path]:
     return [p for _, p in sorted(out)]
 
 
-def restore(results_dir: Path, task_id: str) -> Optional[Path]:
+class RestoreOutcome(str, Enum):
+    """Absence and refusal are different answers: one means the body is gone,
+    the other that a newer reply is already queued. Collapsing them to None
+    leaves the operator unable to tell whether they still have a problem."""
+
+    RESTORED = "restored"
+    NOTHING_QUARANTINED = "nothing-quarantined"
+    LIVE_RESULT_PRESENT = "live-result-present"
+
+
+def restore(results_dir: Path, task_id: str) -> "tuple[RestoreOutcome, Optional[Path]]":
     """Return the NEWEST quarantined body to the drain's canonical name.
 
-    Returns the restored path, or None when nothing was quarantined. Refuses to
-    overwrite a live result: a newer reply already waiting to go is the one the
-    user should get, not a resurrected older one.
+    Refuses to overwrite a live result: a newer reply already waiting to go is
+    the one the user should get, not a resurrected older one.
     """
     found = find_quarantined(results_dir, task_id)
     if not found:
-        return None
+        return RestoreOutcome.NOTHING_QUARANTINED, None
     stem = f"task-{task_id}" if not str(task_id).startswith("task-") else str(task_id)
     target = Path(results_dir) / f"{stem}.txt"
     if target.exists():
-        return None
+        return RestoreOutcome.LIVE_RESULT_PRESENT, target
     found[-1].rename(target)
-    return target
+    return RestoreOutcome.RESTORED, target

--- a/packages/ag2-sparrow/ag2_sparrow/undelivered_quarantine.py
+++ b/packages/ag2-sparrow/ag2_sparrow/undelivered_quarantine.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Naming and moves for `results/undelivered/` — the delivery quarantine.
+
+The convention (`<stem>-<epoch>.txt`) had exactly one owner, the sparrow bridge,
+and only one direction: in. Operator recovery needs the way back, and a second
+copy of the name format in a second module is how the two drift. So the format
+lives here once and both directions are derived from it.
+
+Dependency-light on purpose: no bridge import, no gateway, no env. The caller
+supplies the results directory.
+"""
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from typing import Optional
+
+DIRNAME = "undelivered"
+# `<task stem>-<unix seconds>.txt`; the stem may itself contain hyphens.
+_QUARANTINED = re.compile(r"^(?P<stem>.+)-(?P<epoch>\d+)\.txt$")
+
+
+def quarantine_dir(results_dir: Path) -> Path:
+    return Path(results_dir) / DIRNAME
+
+
+def quarantine_name(stem: str, when: Optional[float] = None) -> str:
+    """The one place the quarantined filename is spelled."""
+    return f"{stem}-{int(when if when is not None else time.time())}.txt"
+
+
+def quarantine(rfile: Path, results_dir: Path,
+               when: Optional[float] = None) -> Path:
+    """Move a refused result out of the drain's view. Returns the new path."""
+    d = quarantine_dir(results_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    target = d / quarantine_name(Path(rfile).stem, when)
+    Path(rfile).rename(target)
+    return target
+
+
+def find_quarantined(results_dir: Path, task_id: str) -> list[Path]:
+    """Every quarantined copy of one task, oldest first.
+
+    A task can be quarantined more than once (each failed recovery adds one), so
+    the caller decides which to restore rather than being handed a guess.
+    """
+    d = quarantine_dir(results_dir)
+    if not d.is_dir():
+        return []
+    stem = f"task-{task_id}" if not str(task_id).startswith("task-") else str(task_id)
+    out = []
+    for p in d.glob("*.txt"):
+        m = _QUARANTINED.match(p.name)
+        if m and m.group("stem") == stem:
+            out.append((int(m.group("epoch")), p))
+    return [p for _, p in sorted(out)]
+
+
+def restore(results_dir: Path, task_id: str) -> Optional[Path]:
+    """Return the NEWEST quarantined body to the drain's canonical name.
+
+    Returns the restored path, or None when nothing was quarantined. Refuses to
+    overwrite a live result: a newer reply already waiting to go is the one the
+    user should get, not a resurrected older one.
+    """
+    found = find_quarantined(results_dir, task_id)
+    if not found:
+        return None
+    stem = f"task-{task_id}" if not str(task_id).startswith("task-") else str(task_id)
+    target = Path(results_dir) / f"{stem}.txt"
+    if target.exists():
+        return None
+    found[-1].rename(target)
+    return target

--- a/packages/ag2-sparrow/pyproject.toml
+++ b/packages/ag2-sparrow/pyproject.toml
@@ -28,6 +28,10 @@ Source = "https://github.com/sonichi/sutando"
 
 [project.scripts]
 ag2-sparrow = "ag2_sparrow.remote_gateway_bridge:main"
+# Separate entry, not a subcommand: remote_gateway_bridge.main() reads no
+# argv, so every current invocation starts the bridge and any dispatcher
+# would change one of them.
+ag2-sparrow-outbox = "ag2_sparrow.outbox_cli:main"
 
 [tool.setuptools]
 packages = ["ag2_sparrow"]

--- a/packages/ag2-sparrow/tools/sync_from_src.py
+++ b/packages/ag2-sparrow/tools/sync_from_src.py
@@ -43,6 +43,8 @@ MAP = {
     # so the coverage gate (source = src) can see them.
     "outbox.py": "outbox.py",
     "outbox_adapter.py": "outbox_adapter.py",
+    # operator recovery surface; src-canonical for the same reason as outbox.py
+    "outbox_cli.py": "outbox_cli.py",
 }
 PKG_DIR = Path(__file__).resolve().parent.parent / "ag2_sparrow"
 SRC_DIR = Path(__file__).resolve().parents[3] / "src"

--- a/packages/ag2-sparrow/tools/sync_from_src.py
+++ b/packages/ag2-sparrow/tools/sync_from_src.py
@@ -45,6 +45,8 @@ MAP = {
     "outbox_adapter.py": "outbox_adapter.py",
     # operator recovery surface; src-canonical for the same reason as outbox.py
     "outbox_cli.py": "outbox_cli.py",
+    # quarantine naming: the bridge moves results in, requeue moves them back
+    "undelivered_quarantine.py": "undelivered_quarantine.py",
 }
 PKG_DIR = Path(__file__).resolve().parent.parent / "ag2_sparrow"
 SRC_DIR = Path(__file__).resolve().parents[3] / "src"

--- a/src/outbox.py
+++ b/src/outbox.py
@@ -733,21 +733,85 @@ def park_item(root: Path, item_id: str, reason: str = "") -> None:
     _write_item(Path(root), item_id, d)
 
 
-def requeue_item(root: Path, item_id: str) -> None:
-    """Hand-recovered item returns to the queue with a FULL attempt budget.
+def resend_epoch_for(root: Path, item_id: str) -> int:
+    """The item's re-send generation. 0 until an operator requeues it.
 
-    Carrying the old count forward makes a re-queued item park again instantly,
-    which is indistinguishable from a broken destination and hides the recovery.
-
-    Uses force-release (administrative destruction — see
-    `release_delivery_claim`): a concurrent live delivery of this item may be
-    interrupted and the item re-delivered after re-queue. At-least-once on this
-    administrative path is accepted by design; operators invoke it exactly
-    because normal ownership state can no longer be trusted.
+    Read by the delivery core to derive the idempotency key, so a requeued item
+    presents a NEW logical side effect the provider will not dedupe away.
     """
-    d = _read_item(Path(root), item_id)
-    d["status"] = "QUEUED"
-    d["attempts"] = 0
-    d["reason"] = None
-    _write_item(Path(root), item_id, d)
-    release_delivery_claim(Path(root), item_id, force=True)
+    try:
+        return int(_read_item(Path(root), item_id).get("resend_epoch", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def read_item(root: Path, item_id: str) -> Optional[dict]:
+    """The whole item record, or None when no record exists. Operator read."""
+    if not _item_path(Path(root), item_id).exists():
+        return None
+    return _read_item(Path(root), item_id)
+
+
+def list_items(root: Path, status: Optional[str] = None) -> list[dict]:
+    """Every item record, newest id order, optionally filtered by status."""
+    d = _items_dir(Path(root))
+    if not d.is_dir():
+        return []
+    out: list[dict] = []
+    for p in sorted(d.glob("*.json")):
+        try:
+            rec = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if status is None or rec.get("status") == status:
+            out.append(rec)
+    return out
+
+
+class RequeueOutcome(str, Enum):
+    """Only REQUEUED means this call moved the item; the other two touched
+    nothing, which is what makes a repeated requeue safe to script."""
+
+    REQUEUED = "requeued"
+    NOT_PARKED = "not-parked"
+    ABSENT = "absent"
+
+
+def requeue_item(root: Path, item_id: str, *, reset_attempts: bool = False,
+                 operator: Optional[str] = None,
+                 reason: Optional[str] = None) -> RequeueOutcome:
+    """Operator recovery: PARKED -> QUEUED as ONE atomic transition.
+
+    Refuses anything not PARKED, which is what makes it idempotent AND keeps it
+    from creating a second delivery: a live claim only exists on an item that is
+    not parked, so this can never destroy one. The force-release below therefore
+    clears a residue of the parked attempt, never a peer's in-flight work.
+
+    Ordering is crash-shaped: the claim goes first, the status last. A crash
+    between them leaves the item PARKED with no claim -- unchanged from the
+    operator's view, and a re-run completes it. The reverse order would publish
+    QUEUED while a stale claim still blocked every drain.
+
+    `reset_attempts` is opt-in per the operator brief. Left False on an item
+    already at MAX_ATTEMPTS, the next failure re-parks it immediately; that is
+    the intended "one more try" semantic, and --reset-attempts is the full
+    budget.
+    """
+    root = Path(root)
+    with _item_lock(root, item_id):
+        if not _item_path(root, item_id).exists():
+            return RequeueOutcome.ABSENT
+        d = _read_item(root, item_id)
+        if d.get("status") != "PARKED":
+            return RequeueOutcome.NOT_PARKED
+        _release_locked(root, item_id, force=True)
+        d["resend_epoch"] = int(d.get("resend_epoch", 0) or 0) + 1
+        d["status"] = "QUEUED"
+        d["reason"] = None
+        if reset_attempts:
+            d["attempts"] = 0
+        d["requeued_at"] = time.time()
+        d["requeued_by"] = operator or "unknown"
+        d["requeue_reason"] = reason or ""
+        _write_item(root, item_id, d)
+        return RequeueOutcome.REQUEUED

--- a/src/outbox_cli.py
+++ b/src/outbox_cli.py
@@ -91,9 +91,10 @@ def cmd_requeue(args) -> int:
         payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
         # The record is only half the recovery: the BODY was moved out of the
         # drain's view, and nothing re-reads the quarantine directory.
-        if args.results_dir:
-            restored = undelivered_quarantine.restore(args.results_dir, args.item_id)
-            payload["restored_body"] = str(restored) if restored else None
+        results_dir = args.results_dir or Path(args.root).parent
+        outcome, path = undelivered_quarantine.restore(results_dir, args.item_id)
+        payload["body"] = outcome.value
+        payload["body_path"] = str(path) if path else None
     _emit(payload, args.json)
     if result is outbox.RequeueOutcome.REQUEUED:
         return 0
@@ -123,9 +124,9 @@ def build_parser() -> argparse.ArgumentParser:
                     help="restore the full attempt budget (default: keep the "
                          "count, so one more failure re-parks)")
     rq.add_argument("--results-dir", type=Path,
-                    help="results/ directory: also returns the quarantined "
-                         "body to the drain (without it the record is "
-                         "requeued but nothing is re-sent)")
+                    help="override where result bodies live; defaults to the "
+                         "outbox root's parent, which is where every lane "
+                         "puts it (RESULTS_DIR/.outbox-*)")
     rq.add_argument("--operator", help="recorded as who did it")
     rq.add_argument("--reason", help="recorded as why")
     rq.set_defaults(func=cmd_requeue)

--- a/src/outbox_cli.py
+++ b/src/outbox_cli.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Optional
 
 import outbox
+import undelivered_quarantine
 
 
 def _default_operator() -> str:
@@ -88,6 +89,11 @@ def cmd_requeue(args) -> int:
     payload = {"item_id": args.item_id, "result": result.value}
     if result is outbox.RequeueOutcome.REQUEUED:
         payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
+        # The record is only half the recovery: the BODY was moved out of the
+        # drain's view, and nothing re-reads the quarantine directory.
+        if args.results_dir:
+            restored = undelivered_quarantine.restore(args.results_dir, args.item_id)
+            payload["restored_body"] = str(restored) if restored else None
     _emit(payload, args.json)
     if result is outbox.RequeueOutcome.REQUEUED:
         return 0
@@ -116,6 +122,10 @@ def build_parser() -> argparse.ArgumentParser:
     rq.add_argument("--reset-attempts", action="store_true",
                     help="restore the full attempt budget (default: keep the "
                          "count, so one more failure re-parks)")
+    rq.add_argument("--results-dir", type=Path,
+                    help="results/ directory: also returns the quarantined "
+                         "body to the drain (without it the record is "
+                         "requeued but nothing is re-sent)")
     rq.add_argument("--operator", help="recorded as who did it")
     rq.add_argument("--reason", help="recorded as why")
     rq.set_defaults(func=cmd_requeue)

--- a/src/outbox_cli.py
+++ b/src/outbox_cli.py
@@ -20,8 +20,13 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-import outbox
-import undelivered_quarantine
+# This module is src-canonical AND vendored into ag2_sparrow, so it must import
+# both ways. Relative first: it fails unambiguously when there is no package.
+try:
+    from . import outbox, undelivered_quarantine
+except ImportError:
+    import outbox
+    import undelivered_quarantine
 
 
 def _default_operator() -> str:

--- a/src/outbox_cli.py
+++ b/src/outbox_cli.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Operator recovery for the delivery outbox: list / inspect / requeue.
+
+PARKED is a durable terminal state and nothing in production could lift it —
+`requeue_item` existed with test callers only. This is the reachable surface.
+It owns no policy: every transition is `outbox`'s, so the CLI and any other
+caller cannot drift apart.
+
+src-canonical (see packages/ag2-sparrow/tools/sync_from_src.py MAP) and vendored
+into the package, where `ag2-sparrow-outbox` exposes it. `sutando outbox`
+delegates here rather than re-implementing.
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import outbox
+
+
+def _default_operator() -> str:
+    """Who to record. An unattended caller must still be attributable."""
+    return (os.environ.get("SUTANDO_OPERATOR")
+            or os.environ.get("SUDO_USER")
+            or _login_name()
+            or "unknown")
+
+
+def _login_name() -> Optional[str]:
+    try:
+        return getpass.getuser()
+    except Exception:  # noqa: BLE001 — no passwd entry (container): not fatal
+        return None
+
+
+def _emit(obj, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(obj, sort_keys=True, default=str))
+        return
+    if isinstance(obj, list):
+        if not obj:
+            print("(no items)")
+            return
+        for rec in obj:
+            print(f"{rec.get('status','?'):<10} "
+                  f"attempts={rec.get('attempts',0)} "
+                  f"epoch={rec.get('resend_epoch',0)} "
+                  f"{rec.get('item_id','?')}"
+                  + (f"  reason={rec['reason']}" if rec.get("reason") else ""))
+        return
+    for k in sorted(obj):
+        print(f"{k}: {obj[k]}")
+
+
+def cmd_list(args) -> int:
+    _emit(outbox.list_items(args.root, args.status), args.json)
+    return 0
+
+
+def cmd_inspect(args) -> int:
+    rec = outbox.read_item(args.root, args.item_id)
+    if rec is None:
+        print(f"no such item: {args.item_id}", file=sys.stderr)
+        return 2
+    claim = outbox.read_delivery_claim(args.root, args.item_id)
+    rec = dict(rec)
+    rec["claim"] = f"{claim.drainer_id} pid={claim.pid} ({claim.state})" if claim else None
+    _emit(rec, args.json)
+    return 0
+
+
+def cmd_requeue(args) -> int:
+    """Exit 0 only when this call performed the transition; 3 = nothing to do.
+
+    A distinct code matters for the idempotent re-run: "already queued" is not
+    a failure, and a script must be able to tell it from "I recovered it".
+    """
+    result = outbox.requeue_item(
+        args.root, args.item_id,
+        reset_attempts=args.reset_attempts,
+        operator=args.operator or _default_operator(),
+        reason=args.reason)
+    payload = {"item_id": args.item_id, "result": result.value}
+    if result is outbox.RequeueOutcome.REQUEUED:
+        payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
+    _emit(payload, args.json)
+    if result is outbox.RequeueOutcome.REQUEUED:
+        return 0
+    return 2 if result is outbox.RequeueOutcome.ABSENT else 3
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="ag2-sparrow-outbox",
+        description="Inspect and recover parked outbound deliveries.")
+    p.add_argument("--root", type=Path, required=True,
+                   help="outbox root (the directory holding .items/)")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    ls = sub.add_parser("list", help="list items")
+    ls.add_argument("--status", help="filter, e.g. PARKED")
+    ls.set_defaults(func=cmd_list)
+
+    ins = sub.add_parser("inspect", help="show one item and its claim")
+    ins.add_argument("item_id")
+    ins.set_defaults(func=cmd_inspect)
+
+    rq = sub.add_parser("requeue", help="PARKED -> QUEUED for one item")
+    rq.add_argument("item_id")
+    rq.add_argument("--reset-attempts", action="store_true",
+                    help="restore the full attempt budget (default: keep the "
+                         "count, so one more failure re-parks)")
+    rq.add_argument("--operator", help="recorded as who did it")
+    rq.add_argument("--reason", help="recorded as why")
+    rq.set_defaults(func=cmd_requeue)
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/outbox_cli.py
+++ b/src/outbox_cli.py
@@ -44,13 +44,15 @@ def _login_name() -> Optional[str]:
         return None
 
 
-def _emit(obj, as_json: bool) -> None:
+def _emit(obj, as_json: bool, where=None) -> None:
     if as_json:
         print(json.dumps(obj, sort_keys=True, default=str))
         return
     if isinstance(obj, list):
         if not obj:
-            print("(no items)")
+            # Name the root: an absent root and an empty one both list nothing,
+            # and "(no items)" alone cannot tell an operator which they hit.
+            print(f"(no items in {where})" if where is not None else "(no items)")
             return
         for rec in obj:
             print(f"{rec.get('status','?'):<10} "
@@ -64,7 +66,7 @@ def _emit(obj, as_json: bool) -> None:
 
 
 def cmd_list(args) -> int:
-    _emit(outbox.list_items(args.root, args.status), args.json)
+    _emit(outbox.list_items(args.root, args.status), args.json, where=args.root)
     return 0
 
 

--- a/src/outbox_cli.py
+++ b/src/outbox_cli.py
@@ -94,16 +94,19 @@ def cmd_requeue(args) -> int:
         operator=args.operator or _default_operator(),
         reason=args.reason)
     payload = {"item_id": args.item_id, "result": result.value}
-    if result is outbox.RequeueOutcome.REQUEUED:
-        payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
-        # The record is only half the recovery: the BODY was moved out of the
-        # drain's view, and nothing re-reads the quarantine directory.
+    # NOT_PARKED too, not just REQUEUED: the two halves commit separately, so
+    # gating the restore on the transition strands the body on every retry.
+    restored = False
+    if result in (outbox.RequeueOutcome.REQUEUED, outbox.RequeueOutcome.NOT_PARKED):
+        if result is outbox.RequeueOutcome.REQUEUED:
+            payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
         results_dir = args.results_dir or Path(args.root).parent
         outcome, path = undelivered_quarantine.restore(results_dir, args.item_id)
         payload["body"] = outcome.value
         payload["body_path"] = str(path) if path else None
+        restored = outcome is undelivered_quarantine.RestoreOutcome.RESTORED
     _emit(payload, args.json)
-    if result is outbox.RequeueOutcome.REQUEUED:
+    if result is outbox.RequeueOutcome.REQUEUED or restored:
         return 0
     return 2 if result is outbox.RequeueOutcome.ABSENT else 3
 

--- a/src/outbox_cli.py
+++ b/src/outbox_cli.py
@@ -101,7 +101,9 @@ def cmd_requeue(args) -> int:
         if result is outbox.RequeueOutcome.REQUEUED:
             payload["resend_epoch"] = outbox.resend_epoch_for(args.root, args.item_id)
         results_dir = args.results_dir or Path(args.root).parent
-        outcome, path = undelivered_quarantine.restore(results_dir, args.item_id)
+        body_id = getattr(args, "body_id", None) or args.item_id
+        outcome, path = undelivered_quarantine.restore(results_dir, body_id)
+        payload["body_id"] = body_id
         payload["body"] = outcome.value
         payload["body_path"] = str(path) if path else None
         restored = outcome is undelivered_quarantine.RestoreOutcome.RESTORED
@@ -137,6 +139,12 @@ def build_parser() -> argparse.ArgumentParser:
                     help="override where result bodies live; defaults to the "
                          "outbox root's parent, which is where every lane "
                          "puts it (RESULTS_DIR/.outbox-*)")
+    rq.add_argument("--body-id", dest="body_id",
+                    help="task id the QUARANTINED BODY is filed under, when it "
+                         "differs from the outbox record id. A named gateway "
+                         "instance keys the record by the broker id and names "
+                         "the body file by the instance-qualified local id, so "
+                         "one id cannot address both.")
     rq.add_argument("--operator", help="recorded as who did it")
     rq.add_argument("--reason", help="recorded as why")
     rq.set_defaults(func=cmd_requeue)

--- a/src/runtime-cli/sutando-runtime.py
+++ b/src/runtime-cli/sutando-runtime.py
@@ -737,7 +737,18 @@ def _print_stand_card(card: dict, section: "str | None") -> int:
     return 0
 
 
+def _delegate_outbox(rest) -> int:
+    """Hand straight to the one implementation; never re-derive its behaviour."""
+    from outbox_cli import main as outbox_main
+    return outbox_main(list(rest))
+
+
 def main(argv=None) -> int:
+    raw = list(sys.argv[1:] if argv is None else argv)
+    # Intercepted before argparse: REMAINDER drops a leading --option, and the
+    # delegate must receive argv byte-for-byte or the two surfaces diverge.
+    if raw and raw[0] == "outbox":
+        return _delegate_outbox(raw[1:])
     ap = argparse.ArgumentParser(prog="sutando-runtime")
     sub = ap.add_subparsers(dest="group", required=True)
 

--- a/src/undelivered_quarantine.py
+++ b/src/undelivered_quarantine.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 import time
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -25,13 +26,14 @@ def quarantine_dir(results_dir: Path) -> Path:
     return Path(results_dir) / DIRNAME
 
 
-def quarantine_name(stem: str, when: Optional[float] = None) -> str:
-    """The one place the quarantined filename is spelled."""
-    return f"{stem}-{int(when if when is not None else time.time())}.txt"
+def quarantine_name(stem: str, when: Optional[int] = None) -> str:
+    """The one place the quarantined filename is spelled. Nanoseconds, not
+    seconds: the drain can quarantine one task several times inside a second."""
+    return f"{stem}-{int(when if when is not None else time.time_ns())}.txt"
 
 
 def quarantine(rfile: Path, results_dir: Path,
-               when: Optional[float] = None) -> Path:
+               when: Optional[int] = None) -> Path:
     """Move a refused result out of the drain's view. Returns the new path."""
     d = quarantine_dir(results_dir)
     d.mkdir(parents=True, exist_ok=True)
@@ -58,19 +60,28 @@ def find_quarantined(results_dir: Path, task_id: str) -> list[Path]:
     return [p for _, p in sorted(out)]
 
 
-def restore(results_dir: Path, task_id: str) -> Optional[Path]:
+class RestoreOutcome(str, Enum):
+    """Absence and refusal are different answers: one means the body is gone,
+    the other that a newer reply is already queued. Collapsing them to None
+    leaves the operator unable to tell whether they still have a problem."""
+
+    RESTORED = "restored"
+    NOTHING_QUARANTINED = "nothing-quarantined"
+    LIVE_RESULT_PRESENT = "live-result-present"
+
+
+def restore(results_dir: Path, task_id: str) -> "tuple[RestoreOutcome, Optional[Path]]":
     """Return the NEWEST quarantined body to the drain's canonical name.
 
-    Returns the restored path, or None when nothing was quarantined. Refuses to
-    overwrite a live result: a newer reply already waiting to go is the one the
-    user should get, not a resurrected older one.
+    Refuses to overwrite a live result: a newer reply already waiting to go is
+    the one the user should get, not a resurrected older one.
     """
     found = find_quarantined(results_dir, task_id)
     if not found:
-        return None
+        return RestoreOutcome.NOTHING_QUARANTINED, None
     stem = f"task-{task_id}" if not str(task_id).startswith("task-") else str(task_id)
     target = Path(results_dir) / f"{stem}.txt"
     if target.exists():
-        return None
+        return RestoreOutcome.LIVE_RESULT_PRESENT, target
     found[-1].rename(target)
-    return target
+    return RestoreOutcome.RESTORED, target

--- a/src/undelivered_quarantine.py
+++ b/src/undelivered_quarantine.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Naming and moves for `results/undelivered/` — the delivery quarantine.
+
+The convention (`<stem>-<epoch>.txt`) had exactly one owner, the sparrow bridge,
+and only one direction: in. Operator recovery needs the way back, and a second
+copy of the name format in a second module is how the two drift. So the format
+lives here once and both directions are derived from it.
+
+Dependency-light on purpose: no bridge import, no gateway, no env. The caller
+supplies the results directory.
+"""
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from typing import Optional
+
+DIRNAME = "undelivered"
+# `<task stem>-<unix seconds>.txt`; the stem may itself contain hyphens.
+_QUARANTINED = re.compile(r"^(?P<stem>.+)-(?P<epoch>\d+)\.txt$")
+
+
+def quarantine_dir(results_dir: Path) -> Path:
+    return Path(results_dir) / DIRNAME
+
+
+def quarantine_name(stem: str, when: Optional[float] = None) -> str:
+    """The one place the quarantined filename is spelled."""
+    return f"{stem}-{int(when if when is not None else time.time())}.txt"
+
+
+def quarantine(rfile: Path, results_dir: Path,
+               when: Optional[float] = None) -> Path:
+    """Move a refused result out of the drain's view. Returns the new path."""
+    d = quarantine_dir(results_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    target = d / quarantine_name(Path(rfile).stem, when)
+    Path(rfile).rename(target)
+    return target
+
+
+def find_quarantined(results_dir: Path, task_id: str) -> list[Path]:
+    """Every quarantined copy of one task, oldest first.
+
+    A task can be quarantined more than once (each failed recovery adds one), so
+    the caller decides which to restore rather than being handed a guess.
+    """
+    d = quarantine_dir(results_dir)
+    if not d.is_dir():
+        return []
+    stem = f"task-{task_id}" if not str(task_id).startswith("task-") else str(task_id)
+    out = []
+    for p in d.glob("*.txt"):
+        m = _QUARANTINED.match(p.name)
+        if m and m.group("stem") == stem:
+            out.append((int(m.group("epoch")), p))
+    return [p for _, p in sorted(out)]
+
+
+def restore(results_dir: Path, task_id: str) -> Optional[Path]:
+    """Return the NEWEST quarantined body to the drain's canonical name.
+
+    Returns the restored path, or None when nothing was quarantined. Refuses to
+    overwrite a live result: a newer reply already waiting to go is the one the
+    user should get, not a resurrected older one.
+    """
+    found = find_quarantined(results_dir, task_id)
+    if not found:
+        return None
+    stem = f"task-{task_id}" if not str(task_id).startswith("task-") else str(task_id)
+    target = Path(results_dir) / f"{stem}.txt"
+    if target.exists():
+        return None
+    found[-1].rename(target)
+    return target

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -80,6 +80,31 @@ class ContractCase(unittest.TestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
+    def test_a_requeueable_backend_mints_its_own_resend_epoch(self):
+        """Pin the coupling, not the spelling (per sonichi on #3853).
+
+        `_resend_epoch` falls back to 0 for a backend without `resend_epoch`,
+        and 0 keeps the idempotency key at `id#0` — so the provider dedupes an
+        operator re-send against the very attempt that parked the item, while
+        the operator reads `result: requeued`. A bare `hasattr` assertion would
+        fail today for a reason that is not a defect: the one backend lacking
+        the method is also the one `outbox` cannot see, so no epoch is ever
+        minted on it. What must hold is the COUPLING — reachable by outbox
+        implies mints an epoch — which is inert now and fires the day a second
+        backend gains an outbox-backed store.
+        """
+        root = Path(self.tmp.name)
+        self.backend.publish(ITEM, b"x")
+        reachable = any(r.get("item_id") == ITEM for r in outbox.list_items(root))
+        if not reachable:
+            self.skipTest("outbox cannot reach this backend's items, so it "
+                          "mints no epoch — the exposure is unreachable here")
+        self.assertTrue(
+            callable(getattr(self.backend, "resend_epoch", None)),
+            "outbox can requeue this backend's items, so it must mint a resend "
+            "epoch; without one the key stays id#0 and the re-send is deduped "
+            "against the parked attempt")
+
     def test_capabilities_are_declared_not_sniffed(self):
         self.assertIsInstance(self.backend.capabilities, BackendCapabilities)
 

--- a/tests/delivery-core-contract.test.py
+++ b/tests/delivery-core-contract.test.py
@@ -25,6 +25,7 @@ from ag2_sparrow.delivery_core import (  # noqa: E402
     BackendCapabilities, ClaimToken, DeliveryCore, DeliveryOutcome, DeliveryReceipt,
     DesignAClaimBackend, DrainStatus, ProviderCapabilities,
     ProviderIndeterminate, ProviderRefused, RetryPolicy, idempotency_key)
+from ag2_sparrow.delivery_core.core import _resend_epoch  # noqa: E402
 from ag2_sparrow.delivery_core.backend_c import DesignCClaimBackend  # noqa: E402
 from ag2_sparrow import outbox  # noqa: E402
 
@@ -80,30 +81,43 @@ class ContractCase(unittest.TestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
-    def test_a_requeueable_backend_mints_its_own_resend_epoch(self):
-        """Pin the coupling, not the spelling (per sonichi on #3853).
+    def test_every_backend_declares_resend_epoch(self):
+        """Declared, not duck-typed (per sonichi on #3853).
 
-        `_resend_epoch` falls back to 0 for a backend without `resend_epoch`,
-        and 0 keeps the idempotency key at `id#0` — so the provider dedupes an
-        operator re-send against the very attempt that parked the item, while
-        the operator reads `result: requeued`. A bare `hasattr` assertion would
-        fail today for a reason that is not a defect: the one backend lacking
-        the method is also the one `outbox` cannot see, so no epoch is ever
-        minted on it. What must hold is the COUPLING — reachable by outbox
-        implies mints an epoch — which is inert now and fires the day a second
-        backend gains an outbox-backed store.
+        `_resend_epoch` falls back to 0 for a backend without the method, and 0
+        keeps the idempotency key at `id#0` — so the provider dedupes an
+        operator re-send against the very attempt that parked the item while
+        the operator reads `result: requeued`. The fallback is what made that
+        silent, so no first-party backend may rely on it.
+        """
+        fn = getattr(self.backend, "resend_epoch", None)
+        self.assertTrue(callable(fn),
+                        "resend_epoch is on the ClaimBackend protocol; a backend "
+                        "without it takes the duck-type fallback and its re-sends "
+                        "are deduped against the parked attempt")
+        self.assertIsInstance(fn(ITEM), int)
+
+    def test_a_requeue_presents_a_new_idempotency_key(self):
+        """The coupling itself, not the spelling: requeue must change the key.
+
+        Guarded on outbox visibility because the epoch lives in the outbox item
+        record — a backend whose items outbox cannot see mints no epoch, and
+        `requeue_item` correctly answers ABSENT there rather than reporting a
+        recovery it did not perform.
         """
         root = Path(self.tmp.name)
         self.backend.publish(ITEM, b"x")
-        reachable = any(r.get("item_id") == ITEM for r in outbox.list_items(root))
-        if not reachable:
-            self.skipTest("outbox cannot reach this backend's items, so it "
-                          "mints no epoch — the exposure is unreachable here")
-        self.assertTrue(
-            callable(getattr(self.backend, "resend_epoch", None)),
-            "outbox can requeue this backend's items, so it must mint a resend "
-            "epoch; without one the key stays id#0 and the re-send is deduped "
-            "against the parked attempt")
+        if not any(r.get("item_id") == ITEM for r in outbox.list_items(root)):
+            self.skipTest("outbox cannot see this backend's items, so requeue "
+                          "answers ABSENT and no epoch is minted")
+        before = idempotency_key(ITEM, _resend_epoch(self.backend, ITEM))
+        outbox.park_item(root, ITEM, "max-attempts")
+        self.assertIs(outbox.requeue_item(root, ITEM, operator="contract"),
+                      outbox.RequeueOutcome.REQUEUED)
+        after = idempotency_key(ITEM, _resend_epoch(self.backend, ITEM))
+        self.assertNotEqual(before, after,
+                            f"requeue must present a NEW logical side effect; "
+                            f"key stayed {after} so the provider dedupes it")
 
     def test_capabilities_are_declared_not_sniffed(self):
         self.assertIsInstance(self.backend.capabilities, BackendCapabilities)
@@ -211,6 +225,47 @@ class ContractCase(unittest.TestCase):
                                    msg="non-declaring backend must raise, "
                                        "never silently no-op"):
                 self.backend.force_release(ITEM)
+
+
+class SharedRootResendEpoch(unittest.TestCase):
+    """sonichi's #3853 control: two backends, ONE outbox root.
+
+    The per-backend suite above gives each backend its own root, so C never
+    holds an outbox-visible item and its behavioural coupling is skipped there.
+    This is the shape the defect was reported in: Design A published, so the
+    record exists and `requeue_item` mints an epoch — and C must read that same
+    epoch, or the operator is told `requeued` while the provider dedupes the
+    re-send against the attempt that parked the item.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.a = DesignAClaimBackend(self.root)
+        self.c = DesignCClaimBackend(self.root, activate=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_both_backends_see_the_same_requeued_epoch(self):
+        self.a.publish(ITEM, b"x")
+        outbox.park_item(self.root, ITEM, "max-attempts")
+        self.assertIs(outbox.requeue_item(self.root, ITEM, operator="contract"),
+                      outbox.RequeueOutcome.REQUEUED)
+        stored = outbox.resend_epoch_for(self.root, ITEM)
+        self.assertEqual(stored, 1, "requeue must mint an epoch on this root")
+        for name, backend in (("A", self.a), ("C", self.c)):
+            with self.subTest(backend=name):
+                self.assertEqual(
+                    _resend_epoch(backend, ITEM), stored,
+                    f"backend {name} reports epoch "
+                    f"{_resend_epoch(backend, ITEM)} against a stored {stored}; "
+                    f"its key would be {idempotency_key(ITEM, _resend_epoch(backend, ITEM))} "
+                    f"while the provider already saw {idempotency_key(ITEM, 0)}")
+        self.assertEqual(idempotency_key(ITEM, _resend_epoch(self.a, ITEM)),
+                         idempotency_key(ITEM, _resend_epoch(self.c, ITEM)),
+                         "the two backends must present the SAME key for the "
+                         "same item on the same root")
 
 
 class CorePolicy(unittest.TestCase):
@@ -536,6 +591,9 @@ def load_tests(loader, tests, pattern):
                     {"backend_name": name})
         suite.addTests(loader.loadTestsFromTestCase(case))
     suite.addTests(loader.loadTestsFromTestCase(CorePolicy))
+    # An unregistered class is collected by nothing here: load_tests
+    # replaces discovery, so a new case must be added explicitly.
+    suite.addTests(loader.loadTestsFromTestCase(SharedRootResendEpoch))
     return suite
 
 

--- a/tests/delivery-core-enforcement.test.py
+++ b/tests/delivery-core-enforcement.test.py
@@ -4,7 +4,9 @@ seam doc v0.2.1 riders):
 
 1. Cross-incarnation key identity — recovery/re-claim must not mint a new
    delivery idempotency key: the provider sees the SAME key from a second
-   incarnation (different worker/pid) as from the first.
+   incarnation (different worker/pid) as from the first. A DELIBERATE operator
+   requeue is the one sanctioned exception (contract rule 1 binds claim,
+   restart and migration; resend_epoch is the stated variation point).
 2. Static no-claim-material-in-key scan — AST over delivery_core: the
    idempotency_key function may reference only item_id + resend_epoch, and
    every provider.deliver call site passes a key derived from it.
@@ -92,7 +94,7 @@ class KeyIdentityAcrossIncarnations(unittest.TestCase):
                 self.assertNotIn(material, provider.keys[0],
                                  "claim material leaked into the key")
 
-    def test_key_stable_across_park_and_redrive(self):
+    def test_operator_requeue_mints_a_new_key(self):
         with tempfile.TemporaryDirectory(prefix="enf-key2-") as td:
             backend = DesignAClaimBackend(Path(td), reclaim_ttl_s=0.0)
             backend.publish(ITEM, b"x")
@@ -110,8 +112,13 @@ class KeyIdentityAcrossIncarnations(unittest.TestCase):
             self.assertTrue(p1.keys and p2.keys,
                             "neither provider was called — the comparison "
                             "below would pass on two empty lists")
-            self.assertEqual(p1.keys, p2.keys,
-                             "park -> re-drive changed the idempotency key")
+            self.assertNotEqual(
+                p1.keys, p2.keys,
+                "an operator requeue must present a NEW key: reusing the parked "
+                "attempt's key lets the provider dedupe the re-send away, which "
+                "is the silent non-delivery requeue exists to fix")
+            self.assertEqual(p1.keys, [f"{ITEM}#0"])
+            self.assertEqual(p2.keys, [f"{ITEM}#1"])
 
 
 class StaticKeyScan(unittest.TestCase):

--- a/tests/outbox-operator-recovery.test.py
+++ b/tests/outbox-operator-recovery.test.py
@@ -5,7 +5,9 @@ never manufacture a second delivery.
 Epoch assertions run against the SHIPPED key derivation, not a re-computation.
 """
 import json
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -359,6 +361,34 @@ class Delegation(unittest.TestCase):
         self.assertEqual(private, [],
                          f"outbox_cli.py reaches into outbox internals: {private}")
         self.assertNotIn("_write_item", src)
+
+
+class EntryPointImportsInThePackage(unittest.TestCase):
+    """The console script imports ONLY ag2_sparrow.outbox_cli, so it must work
+    with nothing else loaded. In-process this is unprovable: the bridge does
+    sys.path.insert(0, src), so anything importing it first masks a flat-import
+    failure. Hence a subprocess with only the package on PYTHONPATH.
+    """
+
+    def _run(self, code: str, pkg_parent: str):
+        import subprocess
+        env = dict(os.environ, PYTHONPATH=pkg_parent, PYTHONDONTWRITEBYTECODE="1")
+        return subprocess.run([sys.executable, "-c", code], env=env,
+                              capture_output=True, text=True, cwd=tempfile.gettempdir())
+
+    def test_console_script_entry_imports_alone(self):
+        import shutil
+        with TemporaryDirectory() as td:
+            shutil.copytree(ROOT / "packages" / "ag2-sparrow" / "ag2_sparrow",
+                            Path(td) / "ag2_sparrow")
+            r = self._run("from ag2_sparrow.outbox_cli import main", td)
+            self.assertEqual(r.returncode, 0,
+                             f"`ag2-sparrow-outbox` cannot start:\n{r.stderr}")
+
+    def test_flat_import_from_src_still_works(self):
+        """The same file is src-canonical, where the names are top-level."""
+        r = self._run("import outbox_cli", str(ROOT / "src"))
+        self.assertEqual(r.returncode, 0, r.stderr)
 
 
 class VendoredCopyInSync(unittest.TestCase):

--- a/tests/outbox-operator-recovery.test.py
+++ b/tests/outbox-operator-recovery.test.py
@@ -253,21 +253,48 @@ class BodyRestoredNotJustTheRecord(unittest.TestCase):
     non-recursive glob over results/ — so a requeue that only flips the record
     delivers nothing, silently, which is the failure this PR exists to fix."""
 
-    def _quarantined(self, td):
-        root, results = Path(td) / "ob", Path(td) / "results"
+    def _quarantined(self, td, root_inside_results=False):
+        results = Path(td) / "results"
         results.mkdir()
+        root = (results / ".outbox-test") if root_inside_results else Path(td) / "ob"
         _parked(root)
         (results / f"{ITEM}.txt").write_text("the reply", encoding="utf-8")
         uq.quarantine(results / f"{ITEM}.txt", results, when=1700000000)
         return root, results
 
-    def test_requeue_without_results_dir_leaves_the_body_quarantined(self):
+    def test_the_DEFAULT_requeue_restores_the_body(self):
+        """The common path must not be the broken one. `--root` is required and
+        every lane puts the outbox at RESULTS_DIR/.outbox-*, so root.parent IS
+        the results dir — no flag needed to get a complete recovery."""
         with TemporaryDirectory() as td:
-            root, results = self._quarantined(td)
+            root, results = self._quarantined(td, root_inside_results=True)
             self.assertEqual(outbox_cli.main(
                 ["--root", str(root), "requeue", ITEM]), 0)
-            self.assertFalse((results / f"{ITEM}.txt").exists())
-            self.assertEqual(len(uq.find_quarantined(results, ITEM)), 1)
+            self.assertTrue((results / f"{ITEM}.txt").exists(),
+                            "requeue with no flag must still restore the body")
+
+    def test_outcome_distinguishes_absent_from_refused(self):
+        """`None` for both left the operator unable to tell 'the body is gone'
+        from 'a newer reply is already queued'."""
+        with TemporaryDirectory() as td:
+            results = Path(td) / "results"; results.mkdir()
+            self.assertEqual(uq.restore(results, ITEM)[0],
+                             uq.RestoreOutcome.NOTHING_QUARANTINED)
+            (results / f"{ITEM}.txt").write_text("old", encoding="utf-8")
+            uq.quarantine(results / f"{ITEM}.txt", results)
+            (results / f"{ITEM}.txt").write_text("newer", encoding="utf-8")
+            self.assertEqual(uq.restore(results, ITEM)[0],
+                             uq.RestoreOutcome.LIVE_RESULT_PRESENT)
+
+    def test_two_quarantines_in_one_second_do_not_collide(self):
+        """Whole seconds silently overwrote; the incident had five attempts in
+        six seconds, and recovery needs the set to be complete."""
+        with TemporaryDirectory() as td:
+            results = Path(td) / "results"; results.mkdir()
+            for body in ("first", "second"):
+                (results / f"{ITEM}.txt").write_text(body, encoding="utf-8")
+                uq.quarantine(results / f"{ITEM}.txt", results)
+            self.assertEqual(len(uq.find_quarantined(results, ITEM)), 2)
 
     def test_requeue_with_results_dir_returns_the_body_to_the_drain(self):
         with TemporaryDirectory() as td:

--- a/tests/outbox-operator-recovery.test.py
+++ b/tests/outbox-operator-recovery.test.py
@@ -336,6 +336,102 @@ class BodyRestoredNotJustTheRecord(unittest.TestCase):
         self.assertIn("undelivered_quarantine.quarantine(", bridge)
 
 
+class CliRenderingAndErrorPaths(unittest.TestCase):
+    """The CLI's own output and refusal paths. Calling outbox directly, as the
+    other tests do, leaves every line of `_emit` and both readers unrun."""
+
+    def _capture(self, argv):
+        import contextlib
+        import io
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = outbox_cli.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_list_empty_says_so_rather_than_printing_nothing(self):
+        with TemporaryDirectory() as td:
+            rc, out, _ = self._capture(["--root", td, "list"])
+            self.assertEqual(rc, 0)
+            self.assertIn("(no items)", out)
+
+    def test_list_renders_status_attempts_epoch_and_reason(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            rc, out, _ = self._capture(["--root", td, "list", "--status", "PARKED"])
+            self.assertEqual(rc, 0)
+            self.assertIn("PARKED", out)
+            self.assertIn("attempts=5", out)
+            self.assertIn("epoch=0", out)
+            self.assertIn("max-attempts", out)
+
+    def test_json_output_is_machine_readable(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            rc, out, _ = self._capture(["--root", td, "--json", "list"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(json.loads(out)[0]["status"], "PARKED")
+
+    def test_inspect_reports_the_claim_and_exits_2_when_absent(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            outbox.acquire_delivery_claim(root, ITEM, "drainer-9")
+            rc, out, _ = self._capture(["--root", td, "inspect", ITEM])
+            self.assertEqual(rc, 0)
+            self.assertIn("drainer-9", out)
+            rc, _, err = self._capture(["--root", td, "inspect", "ghost"])
+            self.assertEqual(rc, 2)
+            self.assertIn("no such item", err)
+
+    def test_inspect_json_reports_a_null_claim_when_free(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            rc, out, _ = self._capture(["--root", td, "--json", "inspect", ITEM])
+            self.assertEqual(rc, 0)
+            self.assertIsNone(json.loads(out)["claim"])
+
+    def test_operator_falls_back_when_the_login_name_is_unavailable(self):
+        """A container with no passwd entry must still record something."""
+        import getpass
+        real = getpass.getuser
+        getpass.getuser = lambda: (_ for _ in ()).throw(KeyError("no passwd"))
+        try:
+            self.assertEqual(outbox_cli._login_name(), None)
+            self.assertTrue(outbox_cli._default_operator())
+        finally:
+            getpass.getuser = real
+
+
+class OutboxReaderEdges(unittest.TestCase):
+    """Malformed and absent state must degrade, never raise: these readers run
+    on an operator's machine against a store a crashed writer may have left."""
+
+    def test_absent_item_and_absent_store(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self.assertIsNone(outbox.read_item(root, "ghost"))
+            self.assertEqual(outbox.list_items(root), [])
+
+    def test_a_corrupt_record_is_skipped_not_fatal(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            (outbox._items_dir(root) / "torn.json").write_text("{not json",
+                                                              encoding="utf-8")
+            got = outbox.list_items(root)
+            self.assertEqual([r["item_id"] for r in got], [ITEM])
+
+    def test_a_non_integer_epoch_reads_as_zero(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            outbox._write_item(root, ITEM, {"item_id": ITEM, "status": "QUEUED",
+                                            "resend_epoch": "not-a-number"})
+            self.assertEqual(outbox.resend_epoch_for(root, ITEM), 0)
+
+
 class Delegation(unittest.TestCase):
     """`sutando outbox` must hand off, never re-implement outbox policy."""
 

--- a/tests/outbox-operator-recovery.test.py
+++ b/tests/outbox-operator-recovery.test.py
@@ -2,9 +2,7 @@
 """Operator recovery: PARKED -> QUEUED must be atomic, idempotent, and must
 never manufacture a second delivery.
 
-The epoch assertions run against the SHIPPED key derivation (DeliveryCore), not
-a local re-computation: a requeue that bumps a number nobody reads is the same
-silent non-delivery it exists to fix.
+Epoch assertions run against the SHIPPED key derivation, not a re-computation.
 """
 import json
 import sys
@@ -18,6 +16,8 @@ sys.path.insert(0, str(ROOT / "packages" / "ag2-sparrow"))
 
 import outbox  # noqa: E402
 import outbox_cli  # noqa: E402
+
+import undelivered_quarantine as uq  # noqa: E402
 
 ITEM = "task-abc"
 OTHER = "task-def"
@@ -245,6 +245,66 @@ class CliSurface(unittest.TestCase):
             self.assertEqual(rec["status"], "PARKED")
             claim = outbox.read_delivery_claim(root, ITEM)
             self.assertEqual(claim.drainer_id, "drainer-9")
+
+
+class BodyRestoredNotJustTheRecord(unittest.TestCase):
+    """The record is half the recovery. The BODY is a result file the terminal
+    path moved into results/undelivered/, and the drain's scan is a
+    non-recursive glob over results/ — so a requeue that only flips the record
+    delivers nothing, silently, which is the failure this PR exists to fix."""
+
+    def _quarantined(self, td):
+        root, results = Path(td) / "ob", Path(td) / "results"
+        results.mkdir()
+        _parked(root)
+        (results / f"{ITEM}.txt").write_text("the reply", encoding="utf-8")
+        uq.quarantine(results / f"{ITEM}.txt", results, when=1700000000)
+        return root, results
+
+    def test_requeue_without_results_dir_leaves_the_body_quarantined(self):
+        with TemporaryDirectory() as td:
+            root, results = self._quarantined(td)
+            self.assertEqual(outbox_cli.main(
+                ["--root", str(root), "requeue", ITEM]), 0)
+            self.assertFalse((results / f"{ITEM}.txt").exists())
+            self.assertEqual(len(uq.find_quarantined(results, ITEM)), 1)
+
+    def test_requeue_with_results_dir_returns_the_body_to_the_drain(self):
+        with TemporaryDirectory() as td:
+            root, results = self._quarantined(td)
+            self.assertEqual(outbox_cli.main(
+                ["--root", str(root), "requeue", ITEM,
+                 "--results-dir", str(results)]), 0)
+            restored = results / f"{ITEM}.txt"
+            self.assertTrue(restored.exists(),
+                            "requeue must return the body the drain scans for")
+            self.assertEqual(restored.read_text(encoding="utf-8"), "the reply")
+            self.assertEqual(uq.find_quarantined(results, ITEM), [])
+
+    def test_a_newer_live_result_is_never_overwritten(self):
+        """A reply already waiting to go is the one the user should get."""
+        with TemporaryDirectory() as td:
+            root, results = self._quarantined(td)
+            (results / f"{ITEM}.txt").write_text("newer", encoding="utf-8")
+            outbox_cli.main(["--root", str(root), "requeue", ITEM,
+                             "--results-dir", str(results)])
+            self.assertEqual(
+                (results / f"{ITEM}.txt").read_text(encoding="utf-8"), "newer")
+
+    def test_the_drains_glob_cannot_see_the_quarantine(self):
+        """Pins WHY the restore is needed: the scan is non-recursive."""
+        with TemporaryDirectory() as td:
+            _root, results = self._quarantined(td)
+            self.assertEqual(sorted(results.glob("task-*.txt")), [])
+            self.assertEqual(len(uq.find_quarantined(results, ITEM)), 1)
+
+    def test_quarantine_naming_has_one_owner(self):
+        """The bridge must not spell the quarantined name itself; two copies of
+        a filename format is how the two directions stop agreeing."""
+        bridge = (ROOT / "packages" / "ag2-sparrow" / "ag2_sparrow"
+                  / "remote_gateway_bridge.py").read_text(encoding="utf-8")
+        self.assertNotIn('f"{rfile.stem}-{int(time.time())}.txt"', bridge)
+        self.assertIn("undelivered_quarantine.quarantine(", bridge)
 
 
 class Delegation(unittest.TestCase):

--- a/tests/outbox-operator-recovery.test.py
+++ b/tests/outbox-operator-recovery.test.py
@@ -348,11 +348,20 @@ class CliRenderingAndErrorPaths(unittest.TestCase):
             rc = outbox_cli.main(argv)
         return rc, out.getvalue(), err.getvalue()
 
-    def test_list_empty_says_so_rather_than_printing_nothing(self):
+    def test_list_empty_names_the_root_it_read(self):
+        """An absent root and an empty one both list nothing, so the count
+        alone cannot tell an operator which they hit (sonichi on #3853)."""
         with TemporaryDirectory() as td:
             rc, out, _ = self._capture(["--root", td, "list"])
             self.assertEqual(rc, 0)
-            self.assertIn("(no items)", out)
+            self.assertIn("(no items", out)
+            self.assertIn(td, out, "the empty listing must name the root it read")
+            absent = str(Path(td) / "nope")
+            rc2, out2, _ = self._capture(["--root", absent, "list"])
+            self.assertEqual(rc2, 0)
+            self.assertIn(absent, out2)
+            self.assertNotEqual(out, out2,
+                                "absent and empty roots must be distinguishable")
 
     def test_list_renders_status_attempts_epoch_and_reason(self):
         with TemporaryDirectory() as td:

--- a/tests/outbox-operator-recovery.test.py
+++ b/tests/outbox-operator-recovery.test.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Operator recovery: PARKED -> QUEUED must be atomic, idempotent, and must
+never manufacture a second delivery.
+
+The epoch assertions run against the SHIPPED key derivation (DeliveryCore), not
+a local re-computation: a requeue that bumps a number nobody reads is the same
+silent non-delivery it exists to fix.
+"""
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT / "packages" / "ag2-sparrow"))
+
+import outbox  # noqa: E402
+import outbox_cli  # noqa: E402
+
+ITEM = "task-abc"
+OTHER = "task-def"
+
+
+def _parked(root: Path, item_id: str = ITEM, attempts: int = 5) -> None:
+    outbox._write_item(root, item_id, {"item_id": item_id, "attempts": attempts,
+                                       "status": "QUEUED", "reason": None})
+    outbox.park_item(root, item_id, "max-attempts")
+
+
+class RequeueTransition(unittest.TestCase):
+    def test_parked_to_queued_bumps_epoch_and_records_operator(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            self.assertEqual(outbox.resend_epoch_for(root, ITEM), 0)
+            r = outbox.requeue_item(root, ITEM, operator="alice", reason="relay 503")
+            self.assertIs(r, outbox.RequeueOutcome.REQUEUED)
+            rec = outbox.read_item(root, ITEM)
+            self.assertEqual(rec["status"], "QUEUED")
+            self.assertEqual(rec["resend_epoch"], 1)
+            self.assertEqual(rec["requeued_by"], "alice")
+            self.assertEqual(rec["requeue_reason"], "relay 503")
+            self.assertIsNone(rec["reason"])
+
+    def test_attempts_preserved_unless_reset_requested(self):
+        """Opt-in per the operator brief: the default keeps the count."""
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root, attempts=5)
+            outbox.requeue_item(root, ITEM)
+            self.assertEqual(outbox.attempts_for(root, ITEM), 5)
+            outbox.park_item(root, ITEM, "max-attempts")
+            outbox.requeue_item(root, ITEM, reset_attempts=True)
+            self.assertEqual(outbox.attempts_for(root, ITEM), 0)
+
+    def test_repeated_requeue_is_idempotent(self):
+        """The second call must not re-bump the epoch: a queued item is not a
+        parked one, so there is nothing to recover."""
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            self.assertIs(outbox.requeue_item(root, ITEM),
+                          outbox.RequeueOutcome.REQUEUED)
+            for _ in range(3):
+                self.assertIs(outbox.requeue_item(root, ITEM),
+                              outbox.RequeueOutcome.NOT_PARKED)
+            self.assertEqual(outbox.resend_epoch_for(root, ITEM), 1)
+
+    def test_delivered_item_is_never_requeued(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            outbox.record_delivered(root, ITEM, provider="p", destination="d")
+            self.assertIs(outbox.requeue_item(root, ITEM),
+                          outbox.RequeueOutcome.NOT_PARKED)
+            self.assertEqual(outbox.item_status(root, ITEM), "DELIVERED")
+
+    def test_absent_item_reports_absent(self):
+        with TemporaryDirectory() as td:
+            self.assertIs(outbox.requeue_item(Path(td), "nope"),
+                          outbox.RequeueOutcome.ABSENT)
+
+
+class ClaimSafety(unittest.TestCase):
+    def test_a_live_claim_on_an_unparked_item_survives(self):
+        """The no-concurrent-delivery guarantee. An item holding a live claim is
+        by definition not PARKED, so requeue refuses BEFORE any force-release —
+        it can never destroy a peer's in-flight delivery."""
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            outbox._write_item(root, ITEM, {"item_id": ITEM, "attempts": 1,
+                                            "status": "CLAIMED", "reason": None})
+            self.assertTrue(outbox.acquire_delivery_claim(root, ITEM, "drainer-1"))
+            self.assertIs(outbox.requeue_item(root, ITEM),
+                          outbox.RequeueOutcome.NOT_PARKED)
+            claim = outbox.read_delivery_claim(root, ITEM)
+            self.assertIsNotNone(claim)
+            self.assertEqual(claim.drainer_id, "drainer-1")
+
+    def test_stale_claim_on_a_parked_item_is_cleared(self):
+        """The residue case: parked, but a claim record outlived the attempt.
+        Left in place it blocks every future drain, so requeue must clear it."""
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            outbox.acquire_delivery_claim(root, ITEM, "dead-drainer")
+            self.assertIsNotNone(outbox.read_delivery_claim(root, ITEM))
+            self.assertIs(outbox.requeue_item(root, ITEM),
+                          outbox.RequeueOutcome.REQUEUED)
+            self.assertIsNone(outbox.read_delivery_claim(root, ITEM))
+            self.assertTrue(outbox.acquire_delivery_claim(root, ITEM, "fresh"))
+
+
+class CrashDuringTransition(unittest.TestCase):
+    def test_crash_after_claim_release_leaves_it_parked_and_recoverable(self):
+        """Ordering is the crash contract: claim first, status last. Interrupted
+        between them, the item is still PARKED — never QUEUED-but-unclaimable —
+        and a re-run completes the recovery."""
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            outbox.acquire_delivery_claim(root, ITEM, "dead-drainer")
+
+            boom = RuntimeError("crash between release and status write")
+            real_write = outbox._write_item
+
+            def explode(r, i, d):
+                if i == ITEM and d.get("status") == "QUEUED":
+                    raise boom
+                return real_write(r, i, d)
+
+            outbox._write_item = explode
+            try:
+                with self.assertRaises(RuntimeError):
+                    outbox.requeue_item(root, ITEM)
+            finally:
+                outbox._write_item = real_write
+
+            self.assertEqual(outbox.item_status(root, ITEM), "PARKED")
+            self.assertEqual(outbox.resend_epoch_for(root, ITEM), 0)
+            self.assertIs(outbox.requeue_item(root, ITEM),
+                          outbox.RequeueOutcome.REQUEUED)
+            self.assertEqual(outbox.item_status(root, ITEM), "QUEUED")
+            self.assertEqual(outbox.resend_epoch_for(root, ITEM), 1)
+
+
+    def test_crash_at_the_release_cannot_leave_queued_with_a_stale_claim(self):
+        """Pins the ORDER, not just the outcome. Interrupt the claim release:
+        with release first the status was never written (PARKED, recoverable);
+        written first, the item would be QUEUED behind a claim no drain can
+        take — deliverable-looking and permanently stuck."""
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            outbox.acquire_delivery_claim(root, ITEM, "dead-drainer")
+
+            real_release = outbox._release_locked
+
+            def explode(*a, **k):
+                raise RuntimeError("crash during claim release")
+
+            outbox._release_locked = explode
+            try:
+                with self.assertRaises(RuntimeError):
+                    outbox.requeue_item(root, ITEM)
+            finally:
+                outbox._release_locked = real_release
+
+            self.assertEqual(
+                outbox.item_status(root, ITEM), "PARKED",
+                "the status must not be written before the claim is released")
+            self.assertEqual(outbox.resend_epoch_for(root, ITEM), 0)
+
+
+class IdempotencyKeyChanges(unittest.TestCase):
+    """#0 -> #1 asserted through the shipped derivation, not a re-computation."""
+
+    def _keys_seen(self, root: Path, item_id: str) -> list:
+        from ag2_sparrow.delivery_core import DesignAClaimBackend
+        from ag2_sparrow.delivery_core.contract import (
+            BackendCapabilities, DeliveryReceipt, ProviderCapabilities)
+        from ag2_sparrow.delivery_core.core import DeliveryCore
+
+        seen = []
+
+        class Recorder:
+            capabilities = ProviderCapabilities(reconcile_capable=False,
+                                                idempotent_send=True)
+
+            def deliver(self, item_id, payload, idempotency_key):
+                seen.append(idempotency_key)
+                return DeliveryReceipt(outcome=outbox.DeliveryOutcome.CONFIRMED)
+
+        backend = DesignAClaimBackend(root)
+        backend.publish(item_id, b"payload")
+        DeliveryCore(backend, Recorder()).deliver_one(item_id, b"payload")
+        return seen
+
+    def test_key_moves_from_epoch_zero_to_one_after_requeue(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            first = self._keys_seen(root, ITEM)
+            self.assertEqual(first, [f"{ITEM}#0"])
+            outbox.park_item(root, ITEM, "max-attempts")
+            self.assertIs(outbox.requeue_item(root, ITEM),
+                          outbox.RequeueOutcome.REQUEUED)
+            second = self._keys_seen(root, ITEM)
+            self.assertEqual(second, [f"{ITEM}#1"],
+                             "a requeued send must present a NEW key or the "
+                             "provider dedupes it against the parked attempt")
+
+    def test_backend_without_the_method_still_derives_epoch_zero(self):
+        """Pre-existing behaviour for any backend that tracks no re-sends."""
+        from ag2_sparrow.delivery_core.core import _resend_epoch
+        self.assertEqual(_resend_epoch(object(), ITEM), 0)
+
+
+class CliSurface(unittest.TestCase):
+    def test_requeue_exit_codes_distinguish_recovered_from_nothing_to_do(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            argv = ["--root", str(root), "requeue", ITEM, "--operator", "bob"]
+            self.assertEqual(outbox_cli.main(argv), 0)
+            self.assertEqual(outbox_cli.main(argv), 3)      # idempotent re-run
+            self.assertEqual(outbox_cli.main(["--root", str(root),
+                                              "requeue", "ghost"]), 2)
+
+    def test_list_filters_by_status(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root, ITEM)
+            outbox.record_delivered(root, OTHER)
+            parked = outbox.list_items(root, "PARKED")
+            self.assertEqual([r["item_id"] for r in parked], [ITEM])
+            self.assertEqual(len(outbox.list_items(root)), 2)
+
+    def test_inspect_reports_the_claim_holder(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            outbox.acquire_delivery_claim(root, ITEM, "drainer-9")
+            rec = outbox.read_item(root, ITEM)
+            self.assertEqual(rec["status"], "PARKED")
+            claim = outbox.read_delivery_claim(root, ITEM)
+            self.assertEqual(claim.drainer_id, "drainer-9")
+
+
+class Delegation(unittest.TestCase):
+    """`sutando outbox` must hand off, never re-implement outbox policy."""
+
+    def test_sutando_outbox_delegates_verbatim(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "sutando_runtime", ROOT / "src" / "runtime-cli" / "sutando-runtime.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _parked(root)
+            self.assertEqual(
+                mod.main(["outbox", "--root", str(root), "requeue", ITEM]), 0)
+            self.assertEqual(outbox.item_status(root, ITEM), "QUEUED")
+
+    def test_cli_module_holds_no_transition_logic(self):
+        """Policy lives in outbox.py. If the CLI ever writes a status itself,
+        the two surfaces can disagree — which is the defect, not the symptom."""
+        import re
+        src = (ROOT / "src" / "outbox_cli.py").read_text(encoding="utf-8")
+        private = sorted(set(re.findall(r"\boutbox\.(_\w+)", src)))
+        self.assertEqual(private, [],
+                         f"outbox_cli.py reaches into outbox internals: {private}")
+        self.assertNotIn("_write_item", src)
+
+
+class VendoredCopyInSync(unittest.TestCase):
+    def test_package_copy_matches_src(self):
+        a = (ROOT / "src" / "outbox_cli.py").read_text(encoding="utf-8")
+        b = (ROOT / "packages" / "ag2-sparrow" / "ag2_sparrow"
+             / "outbox_cli.py").read_text(encoding="utf-8")
+        self.assertIn(a.strip(), b, "run tools/sync_from_src.py")
+
+    def test_entry_point_is_separate_not_a_dispatcher(self):
+        """remote_gateway_bridge.main() reads no argv, so every invocation today
+        starts the bridge; a dispatcher would change one of them."""
+        toml = (ROOT / "packages" / "ag2-sparrow" / "pyproject.toml").read_text()
+        self.assertIn('ag2-sparrow = "ag2_sparrow.remote_gateway_bridge:main"', toml)
+        self.assertIn('ag2-sparrow-outbox = "ag2_sparrow.outbox_cli:main"', toml)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/outbox-operator-recovery.test.py
+++ b/tests/outbox-operator-recovery.test.py
@@ -318,6 +318,54 @@ class BodyRestoredNotJustTheRecord(unittest.TestCase):
             self.assertEqual(outbox_cli.main(["--root", str(root), "requeue", ITEM]), 3,
                              "second run restored nothing and moved nothing")
 
+    def test_a_named_instance_recovers_with_both_ids(self):
+        """The record and the body are filed under DIFFERENT ids on a named
+        instance, so one argument cannot address both.
+
+        `_delivery_core` publishes under the BROKER id while the result file —
+        and therefore its quarantined copy — carries the instance-qualified
+        LOCAL id (`task-<inst>~<broker>`). Passing the local id finds no record
+        (`absent`); passing the broker id requeues the record but restores
+        nothing. Recovery has to carry both.
+        """
+        with TemporaryDirectory() as td:
+            results = Path(td) / "results"
+            results.mkdir()
+            root = results / ".outbox-dev"
+            broker_id, local_id = "task-abc", "task-dev~task-abc"
+            _parked(root, broker_id)
+            (results / f"{local_id}.txt").write_text("the reply", encoding="utf-8")
+            uq.quarantine(results / f"{local_id}.txt", results, when=1700000000)
+
+            # the local id addresses no record
+            self.assertEqual(
+                outbox_cli.main(["--root", str(root), "requeue", local_id]), 2,
+                "the record is keyed by the broker id, so the local id is absent")
+
+            # the broker id alone requeues the record and restores nothing
+            self.assertEqual(
+                outbox_cli.main(["--root", str(root), "requeue", broker_id]), 0)
+            self.assertFalse((results / f"{local_id}.txt").exists(),
+                             "the broker id cannot name the local body file")
+            self.assertEqual(len(uq.find_quarantined(results, local_id)), 1)
+
+            # both ids together complete the recovery
+            self.assertEqual(outbox_cli.main(
+                ["--root", str(root), "requeue", broker_id,
+                 "--body-id", local_id]), 0)
+            self.assertTrue((results / f"{local_id}.txt").exists(),
+                            "--body-id must restore the body filed under the local id")
+            self.assertEqual(len(uq.find_quarantined(results, local_id)), 0)
+
+    def test_body_id_defaults_to_the_record_id(self):
+        """The primary instance has one id for both; the flag must stay optional
+        or every unnamed lane's recovery would need a redundant argument."""
+        with TemporaryDirectory() as td:
+            root, results = self._quarantined(td, root_inside_results=True)
+            self.assertEqual(outbox_cli.main(
+                ["--root", str(root), "requeue", ITEM]), 0)
+            self.assertTrue((results / f"{ITEM}.txt").exists())
+
     def test_outcome_distinguishes_absent_from_refused(self):
         """`None` for both left the operator unable to tell 'the body is gone'
         from 'a newer reply is already queued'."""

--- a/tests/outbox-operator-recovery.test.py
+++ b/tests/outbox-operator-recovery.test.py
@@ -275,6 +275,49 @@ class BodyRestoredNotJustTheRecord(unittest.TestCase):
             self.assertTrue((results / f"{ITEM}.txt").exists(),
                             "requeue with no flag must still restore the body")
 
+    def test_a_failed_restore_is_recoverable_by_re_running(self):
+        """Interrupt exactly BETWEEN the two commits, then retry.
+
+        `requeue_item` commits PARKED -> QUEUED and `restore()` moves the body;
+        they are separate commits. Gating the restore on the REQUEUED transition
+        meant a restore that raised left the record QUEUED with the body still
+        quarantined, and every retry answered `not-parked` and skipped the
+        restore — the user's result stranded outside every drain, permanently,
+        while the operator was told the recovery had happened.
+        """
+        with TemporaryDirectory() as td:
+            root, results = self._quarantined(td, root_inside_results=True)
+            live = results / f"{ITEM}.txt"
+
+            real = uq.restore
+            outbox_cli.undelivered_quarantine.restore = \
+                lambda *a, **k: (_ for _ in ()).throw(OSError("simulated rename failure"))
+            try:
+                with self.assertRaises(OSError):
+                    outbox_cli.main(["--root", str(root), "requeue", ITEM])
+            finally:
+                outbox_cli.undelivered_quarantine.restore = real
+
+            # the record moved, the body did not: the half-committed state
+            self.assertEqual((outbox.read_item(root, ITEM) or {}).get("status"), "QUEUED")
+            self.assertFalse(live.exists())
+            self.assertEqual(len(uq.find_quarantined(results, ITEM)), 1)
+
+            # the retry must COMPLETE the recovery, not refuse it
+            rc = outbox_cli.main(["--root", str(root), "requeue", ITEM])
+            self.assertEqual(rc, 0, "a retry that restored the body did work, so not 3")
+            self.assertTrue(live.exists(), "the body must be back in the drain's view")
+            self.assertEqual(len(uq.find_quarantined(results, ITEM)), 0)
+
+    def test_a_retry_with_nothing_to_do_still_reports_nothing_to_do(self):
+        """The exit code must not become 0 for every already-queued item, or the
+        idempotent re-run loses the distinction the code exists to carry."""
+        with TemporaryDirectory() as td:
+            root, results = self._quarantined(td, root_inside_results=True)
+            self.assertEqual(outbox_cli.main(["--root", str(root), "requeue", ITEM]), 0)
+            self.assertEqual(outbox_cli.main(["--root", str(root), "requeue", ITEM]), 3,
+                             "second run restored nothing and moved nothing")
+
     def test_outcome_distinguishes_absent_from_refused(self):
         """`None` for both left the operator unable to tell 'the body is gone'
         from 'a newer reply is already queued'."""

--- a/tests/outbox-recovery-paths.test.py
+++ b/tests/outbox-recovery-paths.test.py
@@ -85,7 +85,13 @@ def main() -> int:
         check("note_attempt counts", ob.attempts_for(root, "i") == 2)
         ob.park_item(root, "i", reason="unconfirmed")
         ob.requeue_item(root, "i")
-        check("requeue clears the budget", ob.attempts_for(root, "i") == 0)
+        check("requeue keeps the budget unless the operator asks",
+              ob.attempts_for(root, "i") == 2,
+              "reset is opt-in: --reset-attempts is the full-budget form")
+        ob.park_item(root, "i", reason="unconfirmed")
+        ob.requeue_item(root, "i", reset_attempts=True)
+        check("requeue --reset-attempts clears the budget",
+              ob.attempts_for(root, "i") == 0)
         check("requeue also releases the claim",
               ob.read_delivery_claim(root, "i") is None,
               "a re-queued item still holding its claim can never be picked up")

--- a/tests/sparrow-outbox-claim-protocol.test.py
+++ b/tests/sparrow-outbox-claim-protocol.test.py
@@ -203,7 +203,7 @@ def _ttl_never_steals_live():
 
 
 # 6 ---------------------------------------------------------------------------
-@contract("a re-queued item starts from a full attempt budget")
+@contract("a re-queued item keeps its budget unless the operator resets it")
 def _requeue_resets_budget():
     m = outbox()
     acquire, park, requeue = need(m, "acquire_delivery_claim"), need(m, "park_item"), need(m, "requeue_item")
@@ -220,6 +220,11 @@ def _requeue_resets_budget():
             "the reset test is meaningless without a non-zero starting budget")
         park(root, "item-6", reason="unconfirmed")
         requeue(root, "item-6")
+        assert attempts(root, "item-6") == 3, (
+            f"reset is opt-in per the operator brief; got {attempts(root, 'item-6')}. "
+            "The plain form is 'one more try'; --reset-attempts is the full budget.")
+        park(root, "item-6", reason="unconfirmed")
+        requeue(root, "item-6", reset_attempts=True)
         assert attempts(root, "item-6") == 0, (
             f"re-queued item carries {attempts(root, 'item-6')} prior attempts; a "
             "hand-recovered item that parks instantly is indistinguishable from a "


### PR DESCRIPTION
## The bug

`PARKED` was a durable terminal state keyed on the item id, and **nothing in production could lift it**. `requeue_item()` existed — its only callers were four test files. So a transient relay failure wrote a permanent dead state with no operator exit.

Verified at the parent commit (`328d9003`) vs this head:

```
===== AT PARENT (origin/main 328d9003) =====        ===== AT HEAD =====
  status: PARKED                                      status: PARKED
  epoch : <no such function>                          epoch : 0
  cli   : <no output>                                 cli   : result: requeued
                                                              resend_epoch: 1
  after : PARKED     <- no way out                    after : QUEUED
```

## What this adds

- **`ag2-sparrow-outbox list|inspect|requeue`** — a **separate entry point, not a dispatcher**. `remote_gateway_bridge.main()` reads no argv, so *every* invocation today starts the bridge; any dispatcher would change one of them, which fails the brief's "fully backward-compatible" condition. A test pins both entry points.
- **`sutando outbox …` delegates verbatim**, intercepted before argparse (`argparse.REMAINDER` silently drops a leading `--option`). It carries no outbox policy — a test asserts it references no `outbox._` internal, so the two surfaces cannot drift.
- **`requeue_item` is one atomic transition** under the existing per-item lock: refuses anything not `PARKED`, force-releases the claim, bumps `resend_epoch`, records `requeued_by`/`requeued_at`/`requeue_reason`.
- **`resend_epoch` actually reaches `idempotency_key`** through a new optional backend method, so a requeued send presents `id#1` rather than being deduped against the attempt that parked it. Without this the bump increments a number nobody reads and the requeue silently does not deliver.

## Two design points worth reviewing

**Ordering is the crash contract: claim first, status last.** Interrupted between them the item is still `PARKED` with no claim — unchanged from the operator's view, and a re-run completes it. The reverse would publish `QUEUED` behind a stale claim that blocks every drain: deliverable-looking and permanently stuck. `test_crash_at_the_release_cannot_leave_queued_with_a_stale_claim` pins the order, not just the outcome.

**No concurrent deliveries, by refusing rather than by forcing.** A live claim only exists on an item that is *not* `PARKED`, so the `PARKED`-only guard runs before any force-release — this can never destroy a peer's in-flight send. The force-release therefore only ever clears residue of the parked attempt.

## Two existing contracts changed deliberately

Both flagged rather than quietly flipped.

1. **Attempts reset is now opt-in** (`--reset-attempts`), per the operator brief. Two contracts previously pinned unconditional reset, with a real rationale: *"a hand-recovered item that parks instantly is indistinguishable from a broken destination."* That rationale is weakened by this PR — the record now carries `requeued_by`/`requeued_at`/`resend_epoch`, so a re-park is distinguishable. Both tests now assert the new default **and** keep the old property covered under the flag. One line to reverse if you disagree.
2. **An operator requeue mints a new key.** `test_key_stable_across_park_and_redrive` asserted the key was unchanged across `requeue_item`. Contract rule 1 binds **claim, restart and migration** — an operator re-send is not in that list, and `resend_epoch` is its stated variation point (`idempotency_key`: *"changes only on a DELIBERATE operator re-send"*). Renamed to `test_operator_requeue_mints_a_new_key`. Crash re-claim stability is untouched and still pinned by `test_reclaim_reuses_the_same_key`.

## Evidence

- **25 related suites pass**: all `delivery-core-*`, `outbox-*`, `design-c-*`, `sparrow-outbox-claim-protocol`, `runtime-cli-*`, `bridge-marker-no-leak`.
- **18 new tests**, covering the four the brief named: repeated requeue, crash during transition, active claim handling, key `#0` → `#1`.
- **Mutation-verified** — each redden was confirmed with `__pycache__` cleared, after a stale-bytecode run gave a false "survived" result:

  | mutation | result |
  |---|---|
  | remove the `PARKED` guard | 4 failures |
  | do not bump the epoch | 4 failures |
  | write status before releasing the claim | 1 failure |
  | core ignores the epoch | 1 failure |

- `sync_from_src.py --check` → `in sync with src/ ✓`
- `review-checks.sh --diff` → **PASS** (hardcoded-paths + root-artifacts + prose-cap clean)

## Regime split

`outbox.py` / `outbox_cli.py` are **src-canonical** (in the sync MAP, written in `src/` and vendored). `delivery_core/*` is **package-canonical**. The epoch half therefore sits where `.coveragerc` cannot see it (`[run] source` is `src`/`scripts`/`skills`; `packages` appears zero times), which is why it is covered by direct tests in the established `delivery-core-*` style rather than left to the gate. `NOT MEASURED` reads like a pass and is not one.

## Scope

Operator recovery only. **Not** included, per the brief: payload-hash auto-generation, retry backoff / `next_attempt_at`, failure-receipt changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
