### PR TITLE
fix(tool-suites-check): the uncarried-declaration advice empties the vault

### DIFF
--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -102,7 +102,11 @@ def _warn_if_uncarried(decl: Path) -> None:
     if r.returncode != 0:
         print(f"[tool-suites-check] WARNING: {decl} is NOT tracked in the workspace vault. "
               f"If it is lost, the suites it registers stop running SILENTLY (absent = no extras). "
-              f"Add its path to vault.sync.include.", file=sys.stderr)
+              f"To carry it, add its path to vault.sync.include AND restate the entries "
+              f"already there (`scripts/sutando-config.sh vault-sync-include` prints them) — "
+              f"that key REPLACES the carrier set rather than extending it, and the set is a "
+              f"whitelist, so listing this file alone drops everything else from the vault.",
+              file=sys.stderr)
 
 
 def newest_mtime(paths) -> float:

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -168,6 +168,26 @@ with tempfile.TemporaryDirectory() as td:
     check("stale-bytecode: and the failure names the suite",
           "thing.test.py" in (r2.stdout + r2.stderr), True)
 
+print("N. advice naming vault.sync.include must also name its REPLACE semantics")
+with tempfile.TemporaryDirectory() as td:
+    ws, repo = scaffold(td, extras=["tests/extra.test.py"])
+    # The warning only fires when the declaration is untracked inside a git repo.
+    subprocess.run(["git", "init", "-q", str(ws)], check=True)
+    subprocess.run(["git", "-C", str(ws), "config", "user.email", "t@e.com"], check=True)
+    subprocess.run(["git", "-C", str(ws), "config", "user.name", "t"], check=True)
+    (ws / "README.md").write_text("x\n")
+    subprocess.run(["git", "-C", str(ws), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(ws), "commit", "-qm", "init"], check=True)
+    rc, out = run(ws, repo)
+    check("the uncarried warning fires at all", "NOT tracked in the workspace vault" in out, True)
+    # The key REPLACES the carrier set and the set is a whitelist, so advice to
+    # add one path without restating the rest silently empties the vault.
+    names_key = "vault.sync.include" in out
+    names_replace = "REPLACES" in out and "restate" in out
+    check("advice names the key", names_key, True)
+    check("and does not stop before the replace semantics", not names_key or names_replace, True)
+
+
 if FAILURES:
     print(f"\nFAIL — {len(FAILURES)} check(s):")
     for f in FAILURES:


### PR DESCRIPTION
The warning is right; its remedy is destructive.

`_warn_if_uncarried` correctly detects that `tool-suites-extra.json` is unbacked, then says:
**"Add its path to vault.sync.include."** Following that literally drops the entire default
carrier set from the vault.

## Why

- `vault.sync.include` **replaces**, it does not union — pinned by `tests/sutando-config.test.py::test_local_replaces_arrays_wholesale` (a 3-entry default + 1-entry local yields the 1-entry list).
- `scripts/sync-workspace.sh::_compose_exclude_content` is a **whitelist**: it emits `*` (ignore everything) then un-ignores exactly the include list.
- So naming one file there stops `notes/`, `hosts/*/` and `.claude-sutando/projects/*/memory/` from being carried — and `sync-workspace.sh` keeps printing `pushed to <branch>`.
- There is deliberately no `include_extra` ("unioning a whitelist widens the vault"), so restating the full set is the only correct remedy.

## Evidence

Triggering the warning against a scratch workspace whose declaration is untracked.

**Before (`origin/main`):**
```
[tool-suites-check] WARNING: .../state/tool-suites-extra.json is NOT tracked in the workspace
vault. If it is lost, the suites it registers stop running SILENTLY (absent = no extras).
Add its path to vault.sync.include.
```

**After (this branch):**
```
[tool-suites-check] WARNING: .../state/tool-suites-extra.json is NOT tracked in the workspace
vault. If it is lost, the suites it registers stop running SILENTLY (absent = no extras).
To carry it, add its path to vault.sync.include AND restate the entries already there
(`scripts/sutando-config.sh vault-sync-include` prints them) — that key REPLACES the carrier
set rather than extending it, and the set is a whitelist, so listing this file alone drops
everything else from the vault.
```

## Test

`tests/proactive-loop-tool-suites-check.test.py` gains one case: advice naming the key must also
name the replace semantics.

```
$ python3 tests/proactive-loop-tool-suites-check.test.py
N. advice naming vault.sync.include must also name its REPLACE semantics
  ok   the uncarried warning fires at all
  ok   advice names the key
  ok   and does not stop before the replace semantics
PASS — tool-suites-check tests
```

Falsifiability control — revert only the tool, keep the test:
```
$ git checkout origin/main -- skills/proactive-loop/scripts/tool-suites-check.py
$ python3 tests/proactive-loop-tool-suites-check.test.py
  FAIL and does not stop before the replace semantics: got False want True
FAIL — 1 check(s)          # rc=1; restoring the tool returns rc=0
```

`scripts/review-checks.sh` re-run on the final amended diff: PASS (hardcoded-paths + root-artifacts + prose-cap).

## Note for the maintainer

Docs/advice only — no behaviour change to what the checker runs or reports.

#3852 (@yixuan-ag2) is open against the same file with a different concern (which directory is
watched). No shared lines that I can see, but whichever lands first, the other should rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)