### PR TITLE
fix(collab-intel): an explicit same_actor_as must outrank a look-alike key

### DIFF
--- a/skills/collaboration-intelligence/scripts/lookup.py
+++ b/skills/collaboration-intelligence/scripts/lookup.py
@@ -48,15 +48,16 @@ def load(d):
 def load_roster(d):
     """reviewer-stands.json rows, normalised to the quick-lookup row shape.
 
-    The roster is keyed by short name with the GitHub login in the `github`
-    FIELD; a key-equality lookup queries the wrong axis and reads a mapped
-    reviewer as absent (measured twice: 2026-08-27, 2026-08-28 — both times
-    `get("john-the-dev")` missed the entry keyed `rui`).
+    The roster is keyed by short name with the GitHub login in a FIELD; a
+    key-equality lookup queries the wrong axis and reads a mapped reviewer as
+    absent (measured twice: 2026-08-27, 2026-08-28 — both times
+    `get("john-the-dev")` missed the entry keyed `rui`). Which field spells that
+    login is roster_union.roster_login's call, shared with the other reader.
     """
     # Same union, same collision semantics as notify_reviewers: both readers of
     # this store delegate to roster_union so they cannot drift apart.
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-    from roster_union import host_rosters, roster_union
+    from roster_union import host_rosters, roster_login, roster_union
     # The file this reader was pointed at is its LOCAL and goes first: on a
     # legacy host it is the shared file, which host_rosters lists LAST.
     local = d / "reviewer-stands.json"
@@ -69,13 +70,14 @@ def load_roster(d):
     for key, r in merged.items():
         if not isinstance(r, dict):
             continue
+        gh = roster_login(r)[0]
         rows.append({
             "entity_id": key,
             "agent_mxid": r.get("stand") or "",
-            "github": r.get("github") or "",
+            "github": gh,
             "human": r.get("human") or "",
             "allowlisted": r.get("allowlisted"),
-            "one_line": f"github={r.get('github','')} human={r.get('human','')} stand={r.get('stand','')}",
+            "one_line": f"github={gh} human={r.get('human','')} stand={r.get('stand','')}",
         })
     return rows
 

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -211,16 +211,19 @@ def _is_collaborator(repo: str, login: str) -> bool:
 def _github_login(name: str, roster: dict) -> "tuple[str, str]":
     """(login GitHub can answer for, why) — a roster key is not always one.
 
+    An explicit same_actor_as wins over the key itself: a roster key can
+    coincide with an unrelated real login, and then the key is not evidence.
+
     `johnm-desktop` is a Stand handle, not a login; probing it 404s and the
     capability check degrades to a silent no-op on exactly the aliased keys
     `_actor_map` exists to normalize. Follow same_actor_as to a sibling that is.
     """
     entry = (roster or {}).get(name) or {}
-    if _is_github_user(name):
-        return name, "key is a login"
     sib = entry.get("same_actor_as")
     if sib and _is_github_user(sib):
         return sib, f"via same_actor_as -> {sib}"
+    if _is_github_user(name):
+        return name, "key is a login"
     return name, "no login found for this key"
 
 

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -41,7 +41,7 @@ sys.path.insert(0, str(_REPO / "src"))
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from roster_union import host_rosters, roster_union
+from roster_union import host_rosters, roster_login, roster_union
 
 _ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
 
@@ -212,16 +212,17 @@ def _github_login(name: str, roster: dict) -> "tuple[str, str]":
     """(login GitHub can answer for, why) — a roster key is not always one.
 
     Explicit roster fields win over the key itself: a roster key can coincide
-    with an unrelated real login, and then the key is not evidence.
+    with an unrelated real login, and then the key is not evidence. Which field
+    declares that login is roster_union.roster_login's call, not this reader's.
 
     `johnm-desktop` is a Stand handle, not a login; probing it 404s and the
     capability check degrades to a silent no-op on exactly the aliased keys
     `_actor_map` exists to normalize. Follow same_actor_as to a sibling that is.
     """
     entry = (roster or {}).get(name) or {}
-    gh = entry.get("gh")
+    gh, field = roster_login(entry)
     if gh and _is_github_user(gh):
-        return gh, f"roster gh -> {gh}"
+        return gh, f"roster {field} -> {gh}"
     sib = entry.get("same_actor_as")
     if sib and _is_github_user(sib):
         return sib, f"via same_actor_as -> {sib}"

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -211,9 +211,10 @@ def _is_collaborator(repo: str, login: str) -> bool:
 def _github_login(name: str, roster: dict) -> "tuple[str, str]":
     """(login GitHub can answer for, why) — a roster key is not always one.
 
-    Explicit roster fields win over the key itself: a roster key can coincide
-    with an unrelated real login, and then the key is not evidence. Which field
-    declares that login is roster_union.roster_login's call, not this reader's.
+    Explicit roster fields win over the key itself, unconditionally: a roster
+    key can coincide with an unrelated real login, and then the key is not
+    evidence. Which field declares that login is roster_union.roster_login's
+    call, not this reader's.
 
     `johnm-desktop` is a Stand handle, not a login; probing it 404s and the
     capability check degrades to a silent no-op on exactly the aliased keys
@@ -223,10 +224,12 @@ def _github_login(name: str, roster: dict) -> "tuple[str, str]":
     # `or {}` keeps a truthy non-dict, and a hand-edited roster produces one.
     entry = entry if isinstance(entry, dict) else {}
     gh, field = roster_login(entry)
-    if gh and _is_github_user(gh):
+    # Not probed: _is_github_user collapses "no such user" and "probe failed",
+    # so a timeout would discard owner-stated identity for the colliding key.
+    if gh:
         return gh, f"roster {field} -> {gh}"
     sib = entry.get("same_actor_as")
-    if sib and _is_github_user(sib):
+    if sib:
         return sib, f"via same_actor_as -> {sib}"
     if _is_github_user(name):
         return name, "key is a login"

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -220,6 +220,8 @@ def _github_login(name: str, roster: dict) -> "tuple[str, str]":
     `_actor_map` exists to normalize. Follow same_actor_as to a sibling that is.
     """
     entry = (roster or {}).get(name) or {}
+    # `or {}` keeps a truthy non-dict, and a hand-edited roster produces one.
+    entry = entry if isinstance(entry, dict) else {}
     gh, field = roster_login(entry)
     if gh and _is_github_user(gh):
         return gh, f"roster {field} -> {gh}"

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -211,14 +211,17 @@ def _is_collaborator(repo: str, login: str) -> bool:
 def _github_login(name: str, roster: dict) -> "tuple[str, str]":
     """(login GitHub can answer for, why) — a roster key is not always one.
 
-    An explicit same_actor_as wins over the key itself: a roster key can
-    coincide with an unrelated real login, and then the key is not evidence.
+    Explicit roster fields win over the key itself: a roster key can coincide
+    with an unrelated real login, and then the key is not evidence.
 
     `johnm-desktop` is a Stand handle, not a login; probing it 404s and the
     capability check degrades to a silent no-op on exactly the aliased keys
     `_actor_map` exists to normalize. Follow same_actor_as to a sibling that is.
     """
     entry = (roster or {}).get(name) or {}
+    gh = entry.get("gh")
+    if gh and _is_github_user(gh):
+        return gh, f"roster gh -> {gh}"
     sib = entry.get("same_actor_as")
     if sib and _is_github_user(sib):
         return sib, f"via same_actor_as -> {sib}"

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -12,6 +12,26 @@ from pathlib import Path
 
 ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
 
+# Both spellings are deployed. A row carrying only one must read identically to
+# every consumer, so the choice is made here rather than in each reader.
+IDENTITY_FIELDS = ("gh", "github")
+
+
+def roster_login(row) -> "tuple[str, str]":
+    """(GitHub login this row declares, the field it came from); ("", "") if none.
+
+    Measured on a live roster: 5 rows spell it `gh`, 2 spell it `github`, in one
+    file. A reader that knows one spelling reads the other rows as having no
+    login at all — an absence indistinguishable from a row nobody filled in.
+    """
+    if not isinstance(row, dict):
+        return "", ""
+    for field in IDENTITY_FIELDS:
+        value = row.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip(), field
+    return "", ""
+
 
 def host_rosters(workspace) -> "list[tuple[str, Path]]":
     """Every peer host's roster under `workspace`, then the shared legacy file.

--- a/tests/notify-reviewers-login-precedence.test.py
+++ b/tests/notify-reviewers-login-precedence.test.py
@@ -43,11 +43,18 @@ class LoginPrecedenceTests(unittest.TestCase):
         self.assertEqual(login, "sonichi")
         self.assertEqual(why, "key is a login")
 
-    def test_same_actor_as_to_a_nonlogin_falls_back_to_the_key(self):
+    def test_an_unresolvable_same_actor_as_is_KEPT_not_swapped_for_the_key(self):
+        """Owner-stated, so it is not discarded on a probe that answers False.
+
+        This arm previously asserted the opposite. The premise changed: falling
+        back to the key is what routes the gate at a colliding stranger, and
+        `_is_github_user` cannot tell "no such user" from "the probe failed".
+        An unresolvable login reaches `gate_capability` and reports unverified.
+        """
         roster = {"sonichi": {"same_actor_as": "not-a-real-account"}}
         login, why = self.mod._github_login("sonichi", roster)
-        self.assertEqual(login, "sonichi")
-        self.assertEqual(why, "key is a login")
+        self.assertEqual(login, "not-a-real-account")
+        self.assertIn("same_actor_as", why)
 
     def test_roster_gh_wins_over_a_colliding_key(self):
         # `gh` is the documented roster field and is a direct login, so it is
@@ -62,11 +69,11 @@ class LoginPrecedenceTests(unittest.TestCase):
         login, _ = self.mod._github_login("yixuan", roster)
         self.assertEqual(login, "yixuan-ag2")
 
-    def test_a_gh_that_is_not_a_login_falls_through(self):
+    def test_an_unresolvable_gh_is_KEPT_not_swapped_for_the_key(self):
         roster = {"sonichi": {"gh": "no-such-account"}}
         login, why = self.mod._github_login("sonichi", roster)
-        self.assertEqual(login, "sonichi")
-        self.assertEqual(why, "key is a login")
+        self.assertEqual(login, "no-such-account")
+        self.assertEqual(why, "roster gh -> no-such-account")
 
     def test_the_github_spelling_resolves_exactly_like_gh(self):
         # Both spellings are deployed in ONE live roster file (5 `gh`, 2
@@ -76,11 +83,11 @@ class LoginPrecedenceTests(unittest.TestCase):
         self.assertEqual(login, "yixuan-ag2")
         self.assertIn("github", why)
 
-    def test_a_github_that_is_not_a_login_falls_through(self):
+    def test_an_unresolvable_github_is_KEPT_not_swapped_for_the_key(self):
         roster = {"sonichi": {"github": "no-such-account"}}
         login, why = self.mod._github_login("sonichi", roster)
-        self.assertEqual(login, "sonichi")
-        self.assertEqual(why, "key is a login")
+        self.assertEqual(login, "no-such-account")
+        self.assertEqual(why, "roster github -> no-such-account")
 
     def test_gh_wins_when_a_row_carries_BOTH_spellings(self):
         """Deterministic, so the two readers cannot pick different answers."""
@@ -102,6 +109,32 @@ class LoginPrecedenceTests(unittest.TestCase):
         login, why = self.mod._github_login("sonichi", {"sonichi": "yixuan-ag2"})
         self.assertEqual(login, "sonichi")
         self.assertEqual(why, "key is a login")
+
+    def test_a_TRANSIENT_probe_failure_does_not_route_at_the_colliding_key(self):
+        """The reviewer's repro: mapped login probes False, colliding key True.
+
+        `_is_github_user` collapses timeout, nonzero rc and definitive absence
+        into one False, so a network blip on the explicit login used to select
+        the stranger — and if that stranger holds write, the gate certifies it.
+        """
+        calls = []
+
+        def two_result_stub(login):
+            calls.append(login)
+            return login == "yixuan"      # the unrelated real account
+
+        self.mod._is_github_user = two_result_stub
+        login, why = self.mod._github_login("yixuan", {"yixuan": {"gh": "yixuan-ag2"}})
+        self.assertEqual(login, "yixuan-ag2")
+        self.assertIn("gh", why)
+
+    def test_an_explicit_identity_is_never_PROBED(self):
+        """Structural, not behavioural: no probe means no transient to lose to."""
+        calls = []
+        self.mod._is_github_user = lambda l: calls.append(l) or True
+        self.mod._github_login("yixuan", {"yixuan": {"gh": "yixuan-ag2"}})
+        self.mod._github_login("kewei", {"kewei": {"same_actor_as": "keweichen"}})
+        self.assertEqual(calls, [], f"owner-stated identity was probed: {calls}")
 
     def test_neither_resolves(self):
         login, why = self.mod._github_login("stand-handle", {"stand-handle": {}})

--- a/tests/notify-reviewers-login-precedence.test.py
+++ b/tests/notify-reviewers-login-precedence.test.py
@@ -96,6 +96,13 @@ class LoginPrecedenceTests(unittest.TestCase):
         login, _ = self.mod._github_login("yixuan", roster)
         self.assertEqual(login, "yixuan-ag2")
 
+    def test_a_MALFORMED_row_falls_through_instead_of_raising(self):
+        # `(roster or {}).get(name) or {}` keeps a truthy non-dict, so a
+        # hand-edited roster reaches the resolver as a string, not a mapping.
+        login, why = self.mod._github_login("sonichi", {"sonichi": "yixuan-ag2"})
+        self.assertEqual(login, "sonichi")
+        self.assertEqual(why, "key is a login")
+
     def test_neither_resolves(self):
         login, why = self.mod._github_login("stand-handle", {"stand-handle": {}})
         self.assertEqual(login, "stand-handle")

--- a/tests/notify-reviewers-login-precedence.test.py
+++ b/tests/notify-reviewers-login-precedence.test.py
@@ -68,6 +68,34 @@ class LoginPrecedenceTests(unittest.TestCase):
         self.assertEqual(login, "sonichi")
         self.assertEqual(why, "key is a login")
 
+    def test_the_github_spelling_resolves_exactly_like_gh(self):
+        # Both spellings are deployed in ONE live roster file (5 `gh`, 2
+        # `github`); the other reader of this store reads only `github`.
+        roster = {"yixuan": {"github": "yixuan-ag2"}}
+        login, why = self.mod._github_login("yixuan", roster)
+        self.assertEqual(login, "yixuan-ag2")
+        self.assertIn("github", why)
+
+    def test_a_github_that_is_not_a_login_falls_through(self):
+        roster = {"sonichi": {"github": "no-such-account"}}
+        login, why = self.mod._github_login("sonichi", roster)
+        self.assertEqual(login, "sonichi")
+        self.assertEqual(why, "key is a login")
+
+    def test_gh_wins_when_a_row_carries_BOTH_spellings(self):
+        """Deterministic, so the two readers cannot pick different answers."""
+        roster = {"yixuan": {"gh": "yixuan-ag2", "github": "sonichi"}}
+        login, why = self.mod._github_login("yixuan", roster)
+        self.assertEqual(login, "yixuan-ag2")
+        self.assertEqual(why, "roster gh -> yixuan-ag2")
+
+    def test_an_EMPTY_identity_field_does_not_shadow_the_other_spelling(self):
+        # A live row carries `gh: null`; `get("gh") or get("github")` must not
+        # be re-derived per reader, and null must fall through, not dead-end.
+        roster = {"yixuan": {"gh": None, "github": "yixuan-ag2"}}
+        login, _ = self.mod._github_login("yixuan", roster)
+        self.assertEqual(login, "yixuan-ag2")
+
     def test_neither_resolves(self):
         login, why = self.mod._github_login("stand-handle", {"stand-handle": {}})
         self.assertEqual(login, "stand-handle")

--- a/tests/notify-reviewers-login-precedence.test.py
+++ b/tests/notify-reviewers-login-precedence.test.py
@@ -49,6 +49,25 @@ class LoginPrecedenceTests(unittest.TestCase):
         self.assertEqual(login, "sonichi")
         self.assertEqual(why, "key is a login")
 
+    def test_roster_gh_wins_over_a_colliding_key(self):
+        # `gh` is the documented roster field and is a direct login, so it is
+        # more explicit than a key alias resolved by probing.
+        roster = {"yixuan": {"gh": "yixuan-ag2"}}
+        login, why = self.mod._github_login("yixuan", roster)
+        self.assertEqual(login, "yixuan-ag2")
+        self.assertIn("gh", why)
+
+    def test_gh_outranks_same_actor_as(self):
+        roster = {"yixuan": {"gh": "yixuan-ag2", "same_actor_as": "sonichi"}}
+        login, _ = self.mod._github_login("yixuan", roster)
+        self.assertEqual(login, "yixuan-ag2")
+
+    def test_a_gh_that_is_not_a_login_falls_through(self):
+        roster = {"sonichi": {"gh": "no-such-account"}}
+        login, why = self.mod._github_login("sonichi", roster)
+        self.assertEqual(login, "sonichi")
+        self.assertEqual(why, "key is a login")
+
     def test_neither_resolves(self):
         login, why = self.mod._github_login("stand-handle", {"stand-handle": {}})
         self.assertEqual(login, "stand-handle")

--- a/tests/notify-reviewers-login-precedence.test.py
+++ b/tests/notify-reviewers-login-precedence.test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""An explicit `same_actor_as` must outrank a roster key that merely looks like a login.
+
+`_github_login` resolved the key first, so a roster key coinciding with an
+unrelated real GitHub account routed the collaborator gate at that stranger.
+Measured on a live roster: key `yixuan` is github.com/yixuan (a different
+person, `read`), while the intended `yixuan-ag2` holds `write` — the gate
+refused a legitimate reviewer. The dangerous polarity is the inverse: had the
+colliding stranger held write, the gate would have PASSED and certified an
+approver who is a different person.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+SCRIPT = (Path(__file__).resolve().parent.parent / "skills"
+          / "collaboration-intelligence" / "scripts" / "notify_reviewers.py")
+
+REAL_LOGINS = {"yixuan", "yixuan-ag2", "sonichi"}
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_notify_reviewers", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class LoginPrecedenceTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+        self.mod._is_github_user = lambda login: login in REAL_LOGINS
+
+    def test_same_actor_as_wins_over_colliding_key(self):
+        roster = {"yixuan": {"same_actor_as": "yixuan-ag2"}}
+        login, why = self.mod._github_login("yixuan", roster)
+        self.assertEqual(login, "yixuan-ag2")
+        self.assertIn("same_actor_as", why)
+
+    def test_bare_key_still_resolves_when_no_mapping(self):
+        login, why = self.mod._github_login("sonichi", {"sonichi": {}})
+        self.assertEqual(login, "sonichi")
+        self.assertEqual(why, "key is a login")
+
+    def test_same_actor_as_to_a_nonlogin_falls_back_to_the_key(self):
+        roster = {"sonichi": {"same_actor_as": "not-a-real-account"}}
+        login, why = self.mod._github_login("sonichi", roster)
+        self.assertEqual(login, "sonichi")
+        self.assertEqual(why, "key is a login")
+
+    def test_neither_resolves(self):
+        login, why = self.mod._github_login("stand-handle", {"stand-handle": {}})
+        self.assertEqual(login, "stand-handle")
+        self.assertEqual(why, "no login found for this key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/notify-reviewers-per-host-roster.test.py
+++ b/tests/notify-reviewers-per-host-roster.test.py
@@ -162,6 +162,34 @@ class PerHostRoster(unittest.TestCase):
         self.assertIn("alice@peerbox", via_notify,
                       "the losing peer row was dropped instead of surfaced")
 
+    def test_BOTH_readers_resolve_the_SAME_login_under_EITHER_spelling(self):
+        """Keys agreeing is not the readers agreeing.
+
+        The test above compares merged KEYS, so it passes while the two readers
+        interpret the identity FIELD differently — which they did: one read
+        `gh`, the other `github`, and one live file carries both. A row then
+        resolves for one reader and reads as login-less to the other.
+        """
+        self._write("LOCAL", {"a": {"gh": "john-the-dev"},
+                              "b": {"github": "sonichi"},
+                              "c": {"stand": "@c:x"}})
+
+        spec = importlib.util.spec_from_file_location(
+            "lk", REPO / "skills" / "collaboration-intelligence" / "scripts" / "lookup.py")
+        lk = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(lk)
+
+        sys.path.insert(0, str(SCRIPT.parent))
+        from roster_union import roster_login
+
+        via_notify = {k: roster_login(r)[0] for k, r in self.nr.load_roster().items()}
+        via_lookup = {r["entity_id"]: r["github"]
+                      for r in lk.load_roster(self.tmp / "data" / "collaboration-intelligence")}
+        self.assertEqual(via_notify, via_lookup,
+                         "the two readers disagree about which field declares the login")
+        self.assertEqual(via_notify, {"a": "john-the-dev", "b": "sonichi", "c": ""},
+                         "a deployed spelling resolved to nothing")
+
     def test_a_differing_LEGACY_row_is_kept_under_a_suffix_never_a_bare_overwrite(self):
         """john-the-dev's repro: host="" used to collapse the suffix to the bare
         key, so the LEGACY row overwrote local and nothing preserved the loser."""

--- a/tests/notify-reviewers-per-host-roster.test.py
+++ b/tests/notify-reviewers-per-host-roster.test.py
@@ -190,6 +190,15 @@ class PerHostRoster(unittest.TestCase):
         self.assertEqual(via_notify, {"a": "john-the-dev", "b": "sonichi", "c": ""},
                          "a deployed spelling resolved to nothing")
 
+    def test_roster_login_reports_no_login_for_a_row_that_is_not_a_mapping(self):
+        """The shared owner's contract: a malformed row yields no login rather
+        than raising into whichever reader happened to touch it first."""
+        sys.path.insert(0, str(SCRIPT.parent))
+        from roster_union import roster_login
+        self.assertEqual(roster_login("john-the-dev"), ("", ""))
+        self.assertEqual(roster_login(None), ("", ""))
+        self.assertEqual(roster_login({"gh": "x"}), ("x", "gh"))
+
     def test_a_differing_LEGACY_row_is_kept_under_a_suffix_never_a_bare_overwrite(self):
         """john-the-dev's repro: host="" used to collapse the suffix to the bare
         key, so the LEGACY row overwrote local and nothing preserved the loser."""

--- a/tests/sci-notify-reviewers-inproc.test.py
+++ b/tests/sci-notify-reviewers-inproc.test.py
@@ -498,9 +498,24 @@ class GateCapabilityProbesAGitHubLogin(unittest.TestCase):
         self.assertEqual(login, "plain")
         self.assertNotIn("same_actor_as", why)
 
-    def test_no_login_anywhere_returns_the_key_and_says_so(self):
+    def test_an_unresolvable_same_actor_as_is_KEPT_not_swapped_for_the_key(self):
+        """Premise inverted deliberately: this used to expect the key back.
+
+        `_is_github_user` cannot distinguish "no such user" from "the probe
+        failed", so discarding owner-stated identity on a False routes the gate
+        at whatever the key happens to be — a stranger, if the key collides.
+        An unresolvable login now reaches `gate_capability`, which reports it
+        unverified rather than certifying someone else.
+        """
         login, why = self._resolve("stand-only", set())
-        self.assertEqual(login, "stand-only")
+        self.assertEqual(login, "real-login")
+        self.assertIn("same_actor_as", why)
+
+    def test_a_key_with_NO_roster_identity_still_reports_no_login(self):
+        # The "no login found" branch is still reachable — it just needs a row
+        # that states no identity at all, rather than one that fails to probe.
+        login, why = self._resolve("bare-key", set())
+        self.assertEqual(login, "bare-key")
         self.assertIn("no login found", why)
 
 


### PR DESCRIPTION
A roster key that happens to be a real GitHub username silently routes the collaborator gate at a stranger.

`_github_login` tested the key first:

```python
if _is_github_user(name):          # <-- wins
    return name, "key is a login"
sib = entry.get("same_actor_as")   # <-- unreachable for exactly the keys that need it
```

So `same_actor_as` — the explicit, owner-stated mapping the docstring tells you to use — could never override a coincidence.

## Measured, on a live roster

| roster key | resolves to | who that is | permission |
|---|---|---|---|
| `yixuan` | `yixuan` | github.com/yixuan — a different person, joined 2010-03-05 | `read` |
| intended | `yixuan-ag2` | the actual collaborator | `write` |

```
$ gh api users/yixuan     -q .login,.name     -> yixuan, "Yixuan Qiu"
$ gh api users/yixuan-ag2 -q .login,.created_at -> yixuan-ag2, 2026-08-04
$ gh api repos/sonichi/sutando/collaborators/yixuan/permission     -> read
$ gh api repos/sonichi/sutando/collaborators/yixuan-ag2/permission -> write
```

`gate_capability` checked the stranger and refused a legitimate reviewer with `CANNOT GATE: not a collaborator` — a reason true of the stranger and false of the intended person. Two such collisions in a seven-entry roster, so this is not a rare shape.

**The refusal is the safe direction.** Had the colliding stranger held write, the gate would have PASSED and certified an approver who is a different person — silently, with the roster looking correct. That inverts the skill's own stated priority that owner-stated evidence outranks derived.

## Fix

Consult `same_actor_as` first; fall back to the key only when no explicit mapping resolves.

## Test

New `tests/notify-reviewers-login-precedence.test.py`, 4 cases, `_is_github_user` stubbed so it needs no network.

```
$ python3 tests/notify-reviewers-login-precedence.test.py
Ran 4 tests    OK
```

Falsifiability control — revert only the reorder, keep the tests:
```
FAIL: test_same_actor_as_wins_over_colliding_key
Ran 4 tests    FAILED (failures=1)      # rc=1, and ONLY the discriminating case
```
Restoring returns rc=0. Sibling suites `notify-reviewers-human-shapes`, `notify-reviewers-per-host-roster`, `sci-notify-reviewers` all still rc=0.

`scripts/review-checks.sh` on the final diff: PASS.

## Note for the maintainer

#3509 (@sonichi) is open on this same file and its hunks at `_github_login` are **whitespace only** — the body is untouched, so it does not fix this and there is no semantic overlap. A new test file was used rather than extending an existing one, since #3509 already modifies most of the notify-reviewers suites. Whichever lands first, the other rebases; happy to fold this into #3509 instead if you would rather carry it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)