### PR TITLE
feat(health-check): a stale .git/index.lock silently blocks every git write

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3234,10 +3234,18 @@ def _git_dir(repo: Path) -> "Path | None":
         return None
     if not line.startswith("gitdir:"):
         return None
-    target = Path(line.split(":", 1)[1].strip())
-    if not target.is_absolute():
-        target = (repo / target).resolve()
-    return target if target.is_dir() else None
+    raw = line.split(":", 1)[1].strip()
+    # Path("") resolves to the checkout, aiming the removal advice at the wrong
+    # file; NUL and over-long targets raise out of an always-on sweep.
+    if not raw:
+        return None
+    try:
+        target = Path(raw)
+        if not target.is_absolute():
+            target = (repo / target).resolve()
+        return target if target.is_dir() else None
+    except (ValueError, OSError):
+        return None
 
 
 def check_git_index_lock(repo_dir: "Path | None" = None,
@@ -3265,21 +3273,30 @@ def check_git_index_lock(repo_dir: "Path | None" = None,
     lock = gitdir / "index.lock"
     try:
         st = lock.stat()
-    except OSError:
+    except FileNotFoundError:
         return {"name": name, "status": "ok", "detail": "no index.lock — git writes are unblocked"}
+    except OSError as e:
+        # Only a missing file is an absence; any other stat error leaves the
+        # question unanswered, and "unblocked" would state an unmade measurement.
+        return {"name": name, "status": "warn",
+                "detail": (f"cannot tell whether {lock} exists ({type(e).__name__}: {e.strerror or e}) "
+                           f"— this is UNMEASURED, not a clean checkout")}
     age = (now if now is not None else time.time()) - st.st_mtime
     if age < GIT_LOCK_STALE_S:
         return {"name": name, "status": "ok",
                 "detail": f"index.lock present but only {age:.0f}s old — a git write is in flight"}
     hrs = age / 3600.0
     when = f"{hrs:.1f}h" if hrs >= 1 else f"{age / 60:.0f}m"
+    # A path with spaces splits into separate argv words, so an unquoted
+    # command would probe — and remove — operands that are not the lock.
+    q = shlex.quote(str(lock))
     return {
         "name": name,
         "status": "warn",
         "detail": (f"{lock} is {when} old ({st.st_size} bytes) — every git write in this checkout "
                    f"is failing with \"Another git process seems to be running\". Confirm nothing "
-                   f"holds it (`lsof {lock}`; a real writer also keeps a git process in `ps`), "
-                   f"then `rm {lock}`"),
+                   f"holds it (`lsof {q}`; a real writer also keeps a git process in `ps`), "
+                   f"then `rm {q}`"),
     }
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3221,30 +3221,26 @@ GIT_LOCK_STALE_S = 300.0
 
 
 def _git_dir(repo: Path) -> "Path | None":
-    """The real .git directory, following a worktree's `.git` FILE pointer.
+    """The real .git directory, as GIT resolves it.
 
-    A worktree's index.lock lives in its own gitdir, not the common dir, so
-    resolving to the common dir would probe the wrong file."""
-    g = repo / ".git"
-    if g.is_dir():
-        return g
+    Asking git is what proves the answer belongs to THIS checkout. A
+    hand-parsed `gitdir:` pointer can name any existing directory, and the
+    probe would then advise removing an unrelated repository's lock; git's own
+    resolver also sidesteps `Path.resolve()`, whose symlink-loop RuntimeError
+    would escape an always-on sweep. Unresolvable means no remedy, not a guess.
+    """
+    import subprocess as _sp
     try:
-        line = g.read_text(encoding="utf-8", errors="replace").strip()
-    except OSError:
+        r = _sp.run(git_argv("-C", str(repo), "rev-parse", "--absolute-git-dir"),
+                    capture_output=True, text=True, timeout=20)
+    except (OSError, ValueError, _sp.SubprocessError):
         return None
-    if not line.startswith("gitdir:"):
-        return None
-    raw = line.split(":", 1)[1].strip()
-    # Path("") resolves to the checkout, aiming the removal advice at the wrong
-    # file; NUL and over-long targets raise out of an always-on sweep.
-    if not raw:
+    if r.returncode != 0 or not r.stdout.strip():
         return None
     try:
-        target = Path(raw)
-        if not target.is_absolute():
-            target = (repo / target).resolve()
-        return target if target.is_dir() else None
-    except (ValueError, OSError):
+        g = Path(r.stdout.strip())
+        return g if g.is_dir() else None
+    except (ValueError, OSError, RuntimeError):
         return None
 
 
@@ -3272,16 +3268,25 @@ def check_git_index_lock(repo_dir: "Path | None" = None,
                 "detail": f"{repo} is not a git checkout — nothing to lock"}
     lock = gitdir / "index.lock"
     try:
-        st = lock.stat()
+        # lstat, not stat: a DANGLING symlink named index.lock still occupies the
+        # directory entry, so git's exclusive create fails while stat() says absent.
+        st = lock.lstat()
     except FileNotFoundError:
         return {"name": name, "status": "ok", "detail": "no index.lock — git writes are unblocked"}
-    except OSError as e:
+    except (OSError, ValueError, RuntimeError) as e:
         # Only a missing file is an absence; any other stat error leaves the
         # question unanswered, and "unblocked" would state an unmade measurement.
         return {"name": name, "status": "warn",
                 "detail": (f"cannot tell whether {lock} exists ({type(e).__name__}: {e.strerror or e}) "
                            f"— this is UNMEASURED, not a clean checkout")}
     age = (now if now is not None else time.time()) - st.st_mtime
+    if age < 0:
+        # A future mtime makes every age comparison meaningless, and "in flight"
+        # would report an in-progress write this probe never observed.
+        return {"name": name, "status": "warn",
+                "detail": (f"{lock} is dated {-age:.0f}s in the FUTURE — its age is UNMEASURED, "
+                           f"not young; git writes may be blocked. Check the clock, then inspect "
+                           f"the lock by hand")}
     if age < GIT_LOCK_STALE_S:
         return {"name": name, "status": "ok",
                 "detail": f"index.lock present but only {age:.0f}s old — a git write is in flight"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3215,6 +3215,74 @@ def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
                        f"Re-arm the driver (TaskStop + Monitor) and confirm the stamp moves to {head}.")}
 
 
+# A git write holds index.lock for well under a second; five minutes is ~300x
+# the slowest legitimate case measured here and 113x below the incident's 9.4h.
+GIT_LOCK_STALE_S = 300.0
+
+
+def _git_dir(repo: Path) -> "Path | None":
+    """The real .git directory, following a worktree's `.git` FILE pointer.
+
+    A worktree's index.lock lives in its own gitdir, not the common dir, so
+    resolving to the common dir would probe the wrong file."""
+    g = repo / ".git"
+    if g.is_dir():
+        return g
+    try:
+        line = g.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    if not line.startswith("gitdir:"):
+        return None
+    target = Path(line.split(":", 1)[1].strip())
+    if not target.is_absolute():
+        target = (repo / target).resolve()
+    return target if target.is_dir() else None
+
+
+def check_git_index_lock(repo_dir: "Path | None" = None,
+                         now: "float | None" = None) -> dict:
+    """Warn when `.git/index.lock` has outlived any plausible git operation.
+
+    A crashed or killed git leaves the lock behind, and from then on EVERY
+    write in that checkout fails with "Another git process seems to be
+    running" — add, checkout, commit, stash, rebase. Nothing else surfaces it:
+    the failure is per-command, so a seat that does not happen to write sees a
+    healthy repo, and a seat that does write reads the message as a transient
+    collision and retries later. Measured on the live checkout 2026-09-04: a
+    ZERO-byte lock, 9.4 hours old, with no process holding it, had been
+    silently failing git writes for the whole night.
+
+    Read-only and warn-only: a lock younger than the threshold is an ordinary
+    in-flight write, and an unreadable repo is not this probe's business.
+    """
+    name = "git-index-lock"
+    repo = Path(repo_dir) if repo_dir is not None else REPO_DIR
+    gitdir = _git_dir(repo)
+    if gitdir is None:
+        return {"name": name, "status": "ok",
+                "detail": f"{repo} is not a git checkout — nothing to lock"}
+    lock = gitdir / "index.lock"
+    try:
+        st = lock.stat()
+    except OSError:
+        return {"name": name, "status": "ok", "detail": "no index.lock — git writes are unblocked"}
+    age = (now if now is not None else time.time()) - st.st_mtime
+    if age < GIT_LOCK_STALE_S:
+        return {"name": name, "status": "ok",
+                "detail": f"index.lock present but only {age:.0f}s old — a git write is in flight"}
+    hrs = age / 3600.0
+    when = f"{hrs:.1f}h" if hrs >= 1 else f"{age / 60:.0f}m"
+    return {
+        "name": name,
+        "status": "warn",
+        "detail": (f"{lock} is {when} old ({st.st_size} bytes) — every git write in this checkout "
+                   f"is failing with \"Another git process seems to be running\". Confirm nothing "
+                   f"holds it (`lsof {lock}`; a real writer also keeps a git process in `ps`), "
+                   f"then `rm {lock}`"),
+    }
+
+
 def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
     """Warn when the live checkout has drifted off its expected branch.
 
@@ -12514,6 +12582,7 @@ def run_all_checks() -> list[dict]:
     # Per-host channel access.json backup drift (live vs vault-carried copy)
     checks.append(check_per_host_config_backup())
     # Live checkout on its expected branch (PR-branch drift, 2026-07-29 incident)
+    checks.append(check_git_index_lock())
     checks.append(check_live_checkout_branch())
     checks.append(check_skills_driver_code_drift())
     checks.append(check_engine_revision_drift())

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3219,6 +3219,17 @@ def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
 # the slowest legitimate case measured here and 113x below the incident's 9.4h.
 GIT_LOCK_STALE_S = 300.0
 
+# `git rev-parse --local-env-vars` (git 2.50) plus the two discovery bounds. Any
+# of these inherited makes git answer for ANOTHER repository despite `-C`.
+GIT_REPO_SELECTION_ENV = frozenset({
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG", "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT", "GIT_OBJECT_DIRECTORY", "GIT_DIR", "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE", "GIT_GRAFT_FILE", "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS", "GIT_REPLACE_REF_BASE", "GIT_PREFIX",
+    "GIT_SHALLOW_FILE", "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES", "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+})
+
 
 def _git_dir(repo: Path) -> "Path | None":
     """The real .git directory, as GIT resolves it.
@@ -3230,15 +3241,19 @@ def _git_dir(repo: Path) -> "Path | None":
     would escape an always-on sweep. Unresolvable means no remedy, not a guess.
     """
     import subprocess as _sp
+    env = {k: v for k, v in os.environ.items() if k not in GIT_REPO_SELECTION_ENV}
     try:
         r = _sp.run(git_argv("-C", str(repo), "rev-parse", "--absolute-git-dir"),
-                    capture_output=True, text=True, timeout=20)
+                    capture_output=True, text=True, timeout=20, env=env)
     except (OSError, ValueError, _sp.SubprocessError):
         return None
-    if r.returncode != 0 or not r.stdout.strip():
+    # Only the record terminator comes off: a trailing space in the path is
+    # significant, and stripping it names a different directory.
+    raw = r.stdout.removesuffix("\n")
+    if r.returncode != 0 or not raw:
         return None
     try:
-        g = Path(r.stdout.strip())
+        g = Path(raw)
         return g if g.is_dir() else None
     except (ValueError, OSError, RuntimeError):
         return None
@@ -3277,7 +3292,8 @@ def check_git_index_lock(repo_dir: "Path | None" = None,
         # Only a missing file is an absence; any other stat error leaves the
         # question unanswered, and "unblocked" would state an unmade measurement.
         return {"name": name, "status": "warn",
-                "detail": (f"cannot tell whether {lock} exists ({type(e).__name__}: {e.strerror or e}) "
+                "detail": (f"cannot tell whether {lock} exists "
+                           f"({type(e).__name__}: {getattr(e, 'strerror', None) or e}) "
                            f"— this is UNMEASURED, not a clean checkout")}
     age = (now if now is not None else time.time()) - st.st_mtime
     if age < 0:

--- a/tests/health-check-git-index-lock.test.py
+++ b/tests/health-check-git-index-lock.test.py
@@ -274,6 +274,41 @@ class TargetMustBelongToThisCheckout(unittest.TestCase):
         self.assertNotIn("unblocked", r["detail"],
                          "a dangling entry blocks git; stat() would have called it absent")
 
+    def test_git_unavailable_fails_closed_with_no_remedy(self):
+        """keweichen: when association cannot be established, no `rm` advice."""
+        import subprocess as sp
+        real = sp.run
+
+        def boom(argv, *a, **k):
+            if "rev-parse" in argv:
+                raise OSError(2, "No such file or directory: git")
+            return real(argv, *a, **k)
+
+        co = self.root / "nogit"
+        subprocess.run(["git", "init", "-q", str(co)], check=True, capture_output=True)
+        (co / ".git" / "index.lock").write_text("")
+        with unittest.mock.patch.object(sp, "run", boom):
+            r = hc.check_git_index_lock(co)
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("not a git checkout", r["detail"])
+        self.assertNotIn("rm ", r["detail"])
+
+    def test_an_unusable_resolver_answer_fails_closed(self):
+        """A path git returns that cannot even be inspected is not a gitdir."""
+        real_is_dir = Path.is_dir
+
+        def boom(self_path, *a, **k):
+            if self_path.name == ".git":
+                raise RuntimeError("Symlink loop")
+            return real_is_dir(self_path, *a, **k)
+
+        co = self.root / "loopy"
+        subprocess.run(["git", "init", "-q", str(co)], check=True, capture_output=True)
+        with unittest.mock.patch.object(Path, "is_dir", boom):
+            r = hc.check_git_index_lock(co)
+        self.assertEqual(r["status"], "ok")
+        self.assertNotIn("rm ", r["detail"])
+
     def test_a_future_dated_lock_is_unmeasured_not_in_flight(self):
         co = self.root / "future"
         subprocess.run(["git", "init", "-q", str(co)], check=True, capture_output=True)

--- a/tests/health-check-git-index-lock.test.py
+++ b/tests/health-check-git-index-lock.test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""A stale .git/index.lock blocks every git write; nothing else surfaced it.
+
+Drives the real probe against real git repositories, including a real crashed
+writer (the lock left behind by a killed `git add`), not a hand-made file only.
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("health_check", ROOT / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+sys.modules["health_check"] = hc
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+
+
+class GitIndexLock(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        _git(self.repo, "init", "-q", "-b", "main")
+        (self.repo / "f.txt").write_text("x")
+        _git(self.repo, "add", "f.txt")
+        _git(self.repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "base")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _lock(self, age_s):
+        p = self.repo / ".git" / "index.lock"
+        p.write_text("")
+        old = time.time() - age_s
+        os.utime(p, (old, old))
+        return p
+
+    def test_no_lock_is_ok(self):
+        r = hc.check_git_index_lock(self.repo)
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("unblocked", r["detail"])
+
+    def test_a_fresh_lock_is_an_in_flight_write_not_a_fault(self):
+        self._lock(5)
+        r = hc.check_git_index_lock(self.repo)
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertIn("in flight", r["detail"])
+
+    def test_a_stale_lock_warns_and_names_the_exact_file_to_remove(self):
+        lock = self._lock(9.4 * 3600)
+        r = hc.check_git_index_lock(self.repo)
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("9.4h", r["detail"])
+        self.assertIn(f"rm {lock}", r["detail"])
+        self.assertIn("lsof", r["detail"], "the remedy must be gated on checking for a live holder")
+
+    def test_the_warn_is_reachable_from_a_REAL_blocked_write(self):
+        # Not a hand-made file: hold the lock and confirm git itself refuses,
+        # which is the failure the probe claims to detect.
+        self._lock(9.4 * 3600)
+        r = _git(self.repo, "add", "f.txt")
+        self.assertNotEqual(r.returncode, 0, "git accepted a write while index.lock existed")
+        self.assertIn("index.lock", r.stderr)
+        self.assertEqual(hc.check_git_index_lock(self.repo)["status"], "warn")
+
+    def test_the_boundary_is_the_threshold_not_the_wording(self):
+        p = self._lock(hc.GIT_LOCK_STALE_S + 1)
+        self.assertEqual(hc.check_git_index_lock(self.repo)["status"], "warn")
+        old = time.time() - (hc.GIT_LOCK_STALE_S - 1)
+        os.utime(p, (old, old))
+        self.assertEqual(hc.check_git_index_lock(self.repo)["status"], "ok")
+
+    def test_a_worktree_probes_its_OWN_gitdir_not_the_common_dir(self):
+        wt = Path(self.tmp.name) / "wt"
+        self.assertEqual(_git(self.repo, "worktree", "add", "--detach", str(wt)).returncode, 0)
+        self.assertTrue((wt / ".git").is_file(), "expected a worktree .git FILE")
+        gd = hc._git_dir(wt)
+        self.assertIsNotNone(gd)
+        self.assertNotEqual(gd.resolve(), (self.repo / ".git").resolve())
+        # A stale lock in the MAIN repo must not be reported against the worktree.
+        self._lock(9.4 * 3600)
+        self.assertEqual(hc.check_git_index_lock(wt)["status"], "ok")
+        p = gd / "index.lock"
+        p.write_text("")
+        old = time.time() - 9.4 * 3600
+        os.utime(p, (old, old))
+        self.assertEqual(hc.check_git_index_lock(wt)["status"], "warn")
+
+    def test_a_non_repo_is_not_this_probes_business(self):
+        plain = Path(self.tmp.name) / "plain"
+        plain.mkdir()
+        self.assertEqual(hc.check_git_index_lock(plain)["status"], "ok")
+
+    def test_the_probe_is_wired_into_the_run(self):
+        src = (ROOT / "src" / "health-check.py").read_text()
+        self.assertIn("checks.append(check_git_index_lock())", src,
+                      "a probe nobody calls reports nothing")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-git-index-lock.test.py
+++ b/tests/health-check-git-index-lock.test.py
@@ -98,6 +98,31 @@ class GitIndexLock(unittest.TestCase):
         os.utime(p, (old, old))
         self.assertEqual(hc.check_git_index_lock(wt)["status"], "warn")
 
+    def test_a_dot_git_file_that_is_not_a_gitdir_pointer_is_not_a_repo(self):
+        # A `.git` FILE that is not a gitdir pointer: guessing a path from it
+        # would probe an arbitrary location.
+        odd = Path(self.tmp.name) / "odd"
+        odd.mkdir()
+        (odd / ".git").write_text("this is not a gitdir pointer\n")
+        self.assertIsNone(hc._git_dir(odd))
+        self.assertEqual(hc.check_git_index_lock(odd)["status"], "ok")
+
+    def test_a_RELATIVE_gitdir_pointer_resolves_against_the_checkout(self):
+        # git writes a relative `gitdir:` in some layouts; resolving it against
+        # the process cwd instead of the checkout would probe the wrong file.
+        host = Path(self.tmp.name) / "host"
+        (host / "real-gitdir").mkdir(parents=True)
+        (host / ".git").write_text("gitdir: real-gitdir\n")
+        self.assertEqual(hc._git_dir(host), (host / "real-gitdir").resolve())
+        self.assertEqual(hc.check_git_index_lock(host)["status"], "ok")
+        lock = host / "real-gitdir" / "index.lock"
+        lock.write_text("")
+        old = time.time() - 9.4 * 3600
+        os.utime(lock, (old, old))
+        r = hc.check_git_index_lock(host)
+        self.assertEqual(r["status"], "warn")
+        self.assertIn(str(lock), r["detail"])
+
     def test_a_non_repo_is_not_this_probes_business(self):
         plain = Path(self.tmp.name) / "plain"
         plain.mkdir()

--- a/tests/health-check-git-index-lock.test.py
+++ b/tests/health-check-git-index-lock.test.py
@@ -180,6 +180,62 @@ class GitIndexLock(unittest.TestCase):
         self.assertIsNone(hc._git_dir(d))
         self.assertEqual(hc.check_git_index_lock(d)["status"], "ok")
 
+    # ---- the answer must belong to THIS checkout ------------------------------
+
+    def _stale(self, lock):
+        lock.write_text("")
+        old = time.time() - 9 * 3600
+        os.utime(lock, (old, old))
+
+    def test_an_inherited_GIT_DIR_does_not_make_git_answer_for_another_repo(self):
+        """`git -C` does not neutralise GIT_DIR: inherited, it points the whole
+        resolver at another repository. False-clean AND wrong-target."""
+        a, b = self._repo("a"), self._repo("b")
+        self._stale(a / ".git" / "index.lock")
+        with unittest.mock.patch.dict(os.environ, {"GIT_DIR": str(b / ".git")}):
+            r = hc.check_git_index_lock(a)
+        self.assertEqual(r["status"], "warn")
+        self.assertIn(str(a / ".git" / "index.lock"), r["detail"])
+        os.unlink(a / ".git" / "index.lock")
+        self._stale(b / ".git" / "index.lock")
+        with unittest.mock.patch.dict(os.environ, {"GIT_DIR": str(b / ".git")}):
+            r = hc.check_git_index_lock(a)
+        self.assertEqual(r["status"], "ok")
+        self.assertNotIn(str(b), r["detail"])
+
+    def test_the_stripped_set_covers_gits_own_local_env_list(self):
+        """Git enumerates its repository-selection variables itself; the
+        shipped set must be a superset of what the installed git reports."""
+        out = _git(self.repo, "rev-parse", "--local-env-vars")
+        self.assertEqual(out.returncode, 0, out.stderr)
+        theirs = set(out.stdout.split())
+        self.assertTrue(theirs)
+        self.assertLessEqual(theirs, hc.GIT_REPO_SELECTION_ENV,
+                             f"git names variables the probe does not strip: "
+                             f"{sorted(theirs - hc.GIT_REPO_SELECTION_ENV)}")
+
+    def test_a_gitdir_with_a_trailing_space_is_probed_where_git_says_it_is(self):
+        """Git returns the significant trailing space; `.strip()` turned it into
+        the stripped SIBLING, which is a different existing directory."""
+        wt = Path(self.tmp.name) / "wt"
+        wt.mkdir()
+        real = Path(self.tmp.name) / "gitdir "
+        r = _git(wt, "init", "-q", "-b", "main", "--separate-git-dir", str(real))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        (wt / "f.txt").write_text("x")
+        _git(wt, "add", "f.txt")
+        sibling = Path(self.tmp.name) / "gitdir"
+        sibling.mkdir()
+        self._stale(sibling / "index.lock")          # unrelated: wrong-target bait
+        r = hc.check_git_index_lock(wt)
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self._stale(real / "index.lock")             # the real lock: false-clean bait
+        r = hc.check_git_index_lock(wt)
+        self.assertEqual(r["status"], "warn")
+        # git reports the realpath (/private/var on macOS); the space survives.
+        self.assertIn(shlex.quote(str(real.resolve() / "index.lock")), r["detail"])
+        self.assertNotIn(str(sibling.resolve() / "index.lock"), r["detail"])
+
     # ---- unknown stat result is not a measured absence -----------------------
 
     def test_a_stat_error_that_is_not_absence_is_reported_as_unmeasured(self):
@@ -196,6 +252,24 @@ class GitIndexLock(unittest.TestCase):
         self.assertEqual(r["status"], "warn")
         self.assertIn("UNMEASURED", r["detail"])
         self.assertNotIn("unblocked", r["detail"])
+
+    def test_every_caught_stat_error_class_is_reported_not_raised(self):
+        """The handler catches ValueError and RuntimeError too; formatting via
+        the OSError-only `.strerror` raised AttributeError out of the sweep."""
+        repo = self._repo("stat-classes")
+        real_stat = Path.lstat
+        for exc in (RuntimeError("symlink loop"), ValueError("embedded null"),
+                    PermissionError(13, "Permission denied")):
+            def boom(self_path, *a, _e=exc, **k):
+                if self_path.name == "index.lock":
+                    raise _e
+                return real_stat(self_path, *a, **k)
+            with unittest.mock.patch.object(Path, "lstat", boom):
+                r = hc.check_git_index_lock(repo)
+            self.assertEqual(r["status"], "warn", type(exc).__name__)
+            self.assertIn("UNMEASURED", r["detail"])
+            self.assertIn(type(exc).__name__, r["detail"])
+            self.assertIn(str(exc.args[-1]), r["detail"])
 
     def test_a_genuinely_missing_lock_is_still_a_clean_ok(self):
         repo = self._repo("no-lock")

--- a/tests/health-check-git-index-lock.test.py
+++ b/tests/health-check-git-index-lock.test.py
@@ -75,7 +75,9 @@ class GitIndexLock(unittest.TestCase):
         r = hc.check_git_index_lock(self.repo)
         self.assertEqual(r["status"], "warn")
         self.assertIn("9.4h", r["detail"])
-        self.assertIn(f"rm {lock}", r["detail"])
+        # git reports the fully resolved gitdir (/var -> /private/var on macOS),
+        # so the advice names the unambiguous path; compare resolved to resolved.
+        self.assertIn(f"rm {lock.resolve()}", r["detail"])
         self.assertIn("lsof", r["detail"], "the remedy must be gated on checking for a live holder")
 
     def test_the_warn_is_reachable_from_a_REAL_blocked_write(self):
@@ -119,15 +121,17 @@ class GitIndexLock(unittest.TestCase):
         self.assertIsNone(hc._git_dir(odd))
         self.assertEqual(hc.check_git_index_lock(odd)["status"], "ok")
 
-    def test_a_RELATIVE_gitdir_pointer_resolves_against_the_checkout(self):
-        # git writes a relative `gitdir:` in some layouts; resolving it against
-        # the process cwd instead of the checkout would probe the wrong file.
-        host = Path(self.tmp.name) / "host"
-        (host / "real-gitdir").mkdir(parents=True)
-        (host / ".git").write_text("gitdir: real-gitdir\n")
-        self.assertEqual(hc._git_dir(host), (host / "real-gitdir").resolve())
+    def test_a_REAL_worktree_probes_its_own_gitdir_not_the_common_dir(self):
+        # Built with `git worktree add`, not a hand-written pointer: the probe
+        # asks git, so only a checkout git recognises resolves at all.
+        host = Path(self.tmp.name) / "wt"
+        _git(self.repo, "worktree", "add", "-q", "--detach", str(host))
+        gitdir = hc._git_dir(host)
+        self.assertIsNotNone(gitdir)
+        self.assertNotEqual(gitdir, (self.repo / ".git").resolve(),
+                            "a worktree must not resolve to the common dir")
         self.assertEqual(hc.check_git_index_lock(host)["status"], "ok")
-        lock = host / "real-gitdir" / "index.lock"
+        lock = gitdir / "index.lock"
         lock.write_text("")
         old = time.time() - 9.4 * 3600
         os.utime(lock, (old, old))
@@ -140,7 +144,7 @@ class GitIndexLock(unittest.TestCase):
         plain.mkdir()
         self.assertEqual(hc.check_git_index_lock(plain)["status"], "ok")
 
-    # ---- malformed `gitdir:` pointers (keweichen, 2026-09-04) ----------------
+    # ---- malformed `gitdir:` pointers ---------------------------------------
 
     def _worktree_like(self, name, pointer_body):
         """A checkout whose `.git` is a FILE, as a worktree's is."""
@@ -187,7 +191,7 @@ class GitIndexLock(unittest.TestCase):
                 raise PermissionError(13, "Permission denied")
             return real_stat(self_path, *a, **k)
 
-        with unittest.mock.patch.object(Path, "stat", boom):
+        with unittest.mock.patch.object(Path, "lstat", boom):
             r = hc.check_git_index_lock(repo)
         self.assertEqual(r["status"], "warn")
         self.assertIn("UNMEASURED", r["detail"])
@@ -210,13 +214,77 @@ class GitIndexLock(unittest.TestCase):
         detail = hc.check_git_index_lock(repo)["detail"]
         for verb in ("lsof", "rm"):
             argv = shlex.split(detail.split(f"`{verb} ", 1)[1].split("`", 1)[0])
-            self.assertEqual(argv, [str(lock)],
+            self.assertEqual(argv, [str(lock.resolve())],
                              f"{verb} would act on {len(argv)} operands, not the lock")
 
     def test_the_probe_is_wired_into_the_run(self):
         src = (ROOT / "src" / "health-check.py").read_text()
         self.assertIn("checks.append(check_git_index_lock())", src,
                       "a probe nobody calls reports nothing")
+
+
+
+class TargetMustBelongToThisCheckout(unittest.TestCase):
+    """keweichen's blockers: a pointer git does not recognise must not produce
+    `rm` advice, and neither resolution nor a dangling/future lock may read clean."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _worktree(self, pointer: str) -> Path:
+        co = self.root / "checkout"
+        co.mkdir()
+        (co / ".git").write_text(pointer)
+        return co
+
+    def test_pointer_to_an_unrelated_directory_gets_no_removal_advice(self):
+        unrelated = self.root / "unrelated"
+        unrelated.mkdir()
+        (unrelated / "index.lock").write_text("")
+        os.utime(unrelated / "index.lock", (0, 0))
+        r = hc.check_git_index_lock(self._worktree(f"gitdir: {unrelated}"))
+        self.assertNotIn("rm ", r["detail"],
+                         "advised removing a lock git never associated with this checkout")
+
+    def test_symlink_loop_target_does_not_escape_the_probe(self):
+        co = self._worktree("gitdir: loop")
+        loop = co / "loop"
+        os.symlink(loop, loop)  # self-referential: Path.resolve() raises RuntimeError
+        r = hc.check_git_index_lock(co)   # must return, not raise
+        self.assertIn(r["status"], ("ok", "warn"))
+
+    def test_a_dangling_lock_symlink_is_not_absent(self):
+        co = self.root / "real"
+        subprocess.run(["git", "init", "-q", str(co)], check=True, capture_output=True)
+        gd = co / ".git"
+        link = gd / "index.lock"
+        os.symlink(gd / "nonexistent-target", link)
+        stale = time.time() - 9.4 * 3600
+        os.utime(link, (stale, stale), follow_symlinks=False)
+        self.assertTrue(link.is_symlink())
+        self.assertFalse(link.exists(), "control: stat() through the link sees it as absent")
+        add = subprocess.run(["git", "-C", str(co), "add", "-A"], capture_output=True)
+        self.assertNotEqual(add.returncode, 0, "control: git really is blocked by the entry")
+        r = hc.check_git_index_lock(co)
+        self.assertEqual(r["status"], "warn")
+        self.assertNotIn("unblocked", r["detail"],
+                         "a dangling entry blocks git; stat() would have called it absent")
+
+    def test_a_future_dated_lock_is_unmeasured_not_in_flight(self):
+        co = self.root / "future"
+        subprocess.run(["git", "init", "-q", str(co)], check=True, capture_output=True)
+        lock = co / ".git" / "index.lock"
+        lock.write_text("")
+        future = time.time() + 86400
+        os.utime(lock, (future, future))
+        r = hc.check_git_index_lock(co)
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("FUTURE", r["detail"])
+        self.assertNotIn("in flight", r["detail"])
 
 
 if __name__ == "__main__":

--- a/tests/health-check-git-index-lock.test.py
+++ b/tests/health-check-git-index-lock.test.py
@@ -6,6 +6,8 @@ writer (the lock left behind by a killed `git add`), not a hand-made file only.
 """
 import importlib.util
 import os
+import shlex
+import unittest.mock
 import subprocess
 import sys
 import tempfile
@@ -39,6 +41,16 @@ class GitIndexLock(unittest.TestCase):
 
     def tearDown(self):
         self.tmp.cleanup()
+
+    def _repo(self, name):
+        """A real git repo at an arbitrary name, so a path with spaces is testable."""
+        d = Path(self.tmp.name) / name
+        d.mkdir()
+        _git(d, "init", "-q", "-b", "main")
+        (d / "f.txt").write_text("x")
+        _git(d, "add", "f.txt")
+        _git(d, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "base")
+        return d
 
     def _lock(self, age_s):
         p = self.repo / ".git" / "index.lock"
@@ -127,6 +139,79 @@ class GitIndexLock(unittest.TestCase):
         plain = Path(self.tmp.name) / "plain"
         plain.mkdir()
         self.assertEqual(hc.check_git_index_lock(plain)["status"], "ok")
+
+    # ---- malformed `gitdir:` pointers (keweichen, 2026-09-04) ----------------
+
+    def _worktree_like(self, name, pointer_body):
+        """A checkout whose `.git` is a FILE, as a worktree's is."""
+        d = Path(self.tmp.name) / name
+        d.mkdir()
+        (d / ".git").write_bytes(pointer_body)
+        return d
+
+    def test_an_empty_gitdir_target_is_rejected_not_resolved_to_the_checkout(self):
+        # Path("") resolves to the repo, so the advice would name <repo>/index.lock.
+        d = self._worktree_like("empty-target", b"gitdir:\n")
+        stray = d / "index.lock"
+        stray.write_text("")
+        old = time.time() - 9.4 * 3600
+        os.utime(stray, (old, old))
+        self.assertIsNone(hc._git_dir(d))
+        r = hc.check_git_index_lock(d)
+        self.assertEqual(r["status"], "ok")
+        self.assertNotIn("rm ", r["detail"])
+
+    def test_a_nul_gitdir_target_does_not_escape_the_always_on_sweep(self):
+        """NOT a control for the try/except: on CPython 3.14/macOS `is_dir()`
+        swallows both, so this passes with the guard removed. It pins the
+        CONTRACT (a malformed pointer yields None), and the guard exists for
+        the platforms where the reviewer measured ValueError/OSError."""
+        d = self._worktree_like("nul-target", b"gitdir: /tmp/a\x00b\n")
+        self.assertIsNone(hc._git_dir(d))
+        self.assertEqual(hc.check_git_index_lock(d)["status"], "ok")
+
+    def test_an_overlong_gitdir_target_does_not_escape_either(self):
+        """Same caveat as the NUL case above — contract pin, not a control."""
+        d = self._worktree_like("long-target", b"gitdir: /" + b"x" * 5000 + b"\n")
+        self.assertIsNone(hc._git_dir(d))
+        self.assertEqual(hc.check_git_index_lock(d)["status"], "ok")
+
+    # ---- unknown stat result is not a measured absence -----------------------
+
+    def test_a_stat_error_that_is_not_absence_is_reported_as_unmeasured(self):
+        repo = self._repo("stat-eacces")
+        real_stat = Path.stat
+
+        def boom(self_path, *a, **k):
+            if self_path.name == "index.lock":
+                raise PermissionError(13, "Permission denied")
+            return real_stat(self_path, *a, **k)
+
+        with unittest.mock.patch.object(Path, "stat", boom):
+            r = hc.check_git_index_lock(repo)
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("UNMEASURED", r["detail"])
+        self.assertNotIn("unblocked", r["detail"])
+
+    def test_a_genuinely_missing_lock_is_still_a_clean_ok(self):
+        repo = self._repo("no-lock")
+        r = hc.check_git_index_lock(repo)
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("no index.lock", r["detail"])
+
+    # ---- the advice must be shell-safe --------------------------------------
+
+    def test_the_advice_quotes_a_path_with_spaces_so_argv_stays_one_operand(self):
+        repo = self._repo("valid repo with spaces")
+        lock = repo / ".git" / "index.lock"
+        lock.write_text("")
+        old = time.time() - 9.4 * 3600
+        os.utime(lock, (old, old))
+        detail = hc.check_git_index_lock(repo)["detail"]
+        for verb in ("lsof", "rm"):
+            argv = shlex.split(detail.split(f"`{verb} ", 1)[1].split("`", 1)[0])
+            self.assertEqual(argv, [str(lock)],
+                             f"{verb} would act on {len(argv)} operands, not the lock")
 
     def test_the_probe_is_wired_into_the_run(self):
         src = (ROOT / "src" / "health-check.py").read_text()


### PR DESCRIPTION
## What happened

Measured on this host's live checkout, 2026-09-04: `.git/index.lock` was **zero bytes, 9.4 hours old**, with `lsof` showing no holder and no git process in `ps` beyond two Xcode `fsmonitor--daemon`s.

For that entire window **every git write in the checkout failed** — `add`, `checkout`, `commit`, `stash`, `rebase` — with *"Another git process seems to be running."* I found it only because a `git checkout --` of my own refused.

## Why nothing surfaced it

The failure is **per-command**. A seat that does not happen to write sees a perfectly healthy repo. A seat that does write reads the message as a transient collision with a peer — which on a shared checkout with four worker seats is the *likely* reading — and retries later. No state anywhere records "this checkout has not accepted a write since 10:15." On a host where several seats share one checkout, that is hours of silently failed commits.

## The probe

`git-index-lock`: warn when the lock has outlived any plausible git operation.

- `GIT_LOCK_STALE_S = 300`. A real write holds the lock for well under a second, so this is ~300x the slowest legitimate case and still **113x below the incident**. Under the threshold the probe reports *"a git write is in flight"* and stays ok, so an ordinary concurrent commit never warns.
- **Read-only, warn-only.**
- The detail names the exact file and **gates the remedy on checking for a live holder first** (`lsof`, plus the note that a real writer also keeps a git process in `ps`). An unconditional `rm` recipe would teach deleting a lock somebody is legitimately holding.
- `_git_dir()` follows a worktree's `.git` **file** pointer instead of resolving to the common dir — a worktree's `index.lock` lives in its own gitdir, so the common dir is the wrong file and a stale lock in the main repo would be reported against every worktree.

## Evidence

Tests drive **real git repositories**, not hand-made files:

- `test_the_warn_is_reachable_from_a_REAL_blocked_write` plants the lock and asserts **`git add` itself refuses** — the failure the probe claims to detect, verified by git rather than by my model of git.
- `test_a_worktree_probes_its_OWN_gitdir_not_the_common_dir` creates a real worktree and checks the two gitdirs are probed independently in both directions.

```
tests/health-check-git-index-lock.test.py            8/8 OK
```

**Mutation controls**, each reverted in turn against the production module:

```
remove the age gate (always warn)     -> 2 failures
resolve a worktree to the common dir  -> 1 failure
drop the call site                    -> 1 failure
```

Live run on this host:

```
✓ git-index-lock   ok   no index.lock — git writes are unblocked
```

(That reads ok because I removed the stale lock before opening this. The warn path is covered by the suite above rather than by planting a lock in a live checkout, which would block the owner's git writes for the duration.)

Also green: `health-check-bridge-probe-coverage`, `health-check-live-checkout-branch`, `health-check-community-support`, `gen-src-map.py --check` rc=0, and `scripts/review-checks.sh --diff <cumulative>` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)