### PR TITLE
fix(morning-briefing): the daily deliverable is measurable again

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -803,8 +803,10 @@ def main():
     narrative = synthesize(weather, events, reminders, discord_msgs, pending_qs, health_issues)
 
     # Write voice result
+    # The DATE leads the suffix so health-check's daily-cron-punctuality probe
+    # can see this run: it matches `<stem>-YYYY-MM-DD`, never an epoch.
     ts = int(time.time() * 1000)
-    result_file = RESULTS_DIR / f"proactive-morning-{ts}.txt"
+    result_file = RESULTS_DIR / f"proactive-morning-{time.strftime('%Y-%m-%d')}-{ts}.txt"
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
     # Privacy: the briefing carries calendar + email — private data that must
     # go to the owner's DM only. The `[dm-only]` marker forces DM delivery and

--- a/tests/morning-briefing-artifact-is-datable.test.py
+++ b/tests/morning-briefing-artifact-is-datable.test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""The briefing's result filename must be measurable by the punctuality probe.
+
+`_daily_artifact_minutes` matches `<stem>-YYYY-MM-DD`; an epoch suffix never
+does, so the daily deliverable was unverifiable while running fine.
+"""
+import importlib.util
+import re
+import sys
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+hc = _load("health_check", ROOT / "src" / "health-check.py")
+SRC = (ROOT / "src" / "morning-briefing.py").read_text()
+
+
+class BriefingArtifactIsDatable(unittest.TestCase):
+    def test_the_written_name_carries_a_DATE_the_probe_can_match(self):
+        m = re.search(r'RESULTS_DIR / f"(proactive-morning-[^"]+)"', SRC)
+        self.assertIsNotNone(m, "could not find the result filename in morning-briefing.py")
+        rendered = m.group(1).replace(
+            "{time.strftime('%Y-%m-%d')}", time.strftime("%Y-%m-%d")).replace("{ts}", "1788000000000")
+        self.assertRegex(rendered, r"^proactive-morning-\d{4}-\d{2}-\d{2}-",
+                         f"the probe matches <stem>-YYYY-MM-DD; this name is {rendered!r}")
+
+    def test_the_probe_actually_finds_it(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            results = Path(td) / "results"
+            results.mkdir()
+            (results / f"proactive-morning-{time.strftime('%Y-%m-%d')}-1788000000000.txt").write_text("x")
+            found = hc._daily_artifact_minutes(results, "proactive-morning")
+            self.assertEqual([d for d, _ in found], [time.strftime("%Y-%m-%d")],
+                             "the punctuality probe cannot see the briefing's own output")
+
+    def test_an_epoch_only_name_is_invisible_to_the_probe(self):
+        # The control: this is what shipped from 2026-07-16, and it is why the
+        # probe reported UNCHECKED for a job that was running fine.
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            results = Path(td) / "results"
+            results.mkdir()
+            (results / "proactive-morning-1788000000000.txt").write_text("x")
+            self.assertEqual(hc._daily_artifact_minutes(results, "proactive-morning"), [])
+
+    def test_the_delivery_prefix_is_unchanged(self):
+        # Every bridge drains on the `proactive-` prefix; the date must not
+        # move it out of that namespace.
+        self.assertTrue(f"proactive-morning-{time.strftime('%Y-%m-%d')}-1.txt".startswith("proactive-"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The gap

`health-check`'s punctuality probe matches `<stem>-YYYY-MM-DD` (`_daily_artifact_minutes`). Since 2026-07-16 the briefing writes `proactive-morning-<epoch>.txt`, which never matches — so the one job the owner reads every morning is unverifiable. It shows up in two places at once:

```
health-check   unverifiable (no dated artifact): briefing-fallback, friction-room-sweep, morning-briefing
crons.json     {"name": "morning-briefing", ..., "artifact": "morning-briefing"}   <- cannot match either
```

The declaration is the worse half: it *looks* like the job is covered.

## Why this is the second half of an existing fix, not a re-fix

`tests/health-check-daily-punctuality.test.py::TestNamingDriftIsUncheckedNotLate` records what was done the first time this drift was found — for 38 days the probe reported *"7 run(s), median +31 min late"* from a dead July corpus and *"no output today"* daily, while the job ran fine. The response was to teach the probe to say **UNCHECKED** instead of computing a median from files it had stopped measuring.

That was right and it stands. **This is the other half: honesty about not measuring is not a substitute for measuring.** The failure mode is the expensive one — a briefing that silently stops produces no signal at all, because its only symptom is an absence.

## The change

```python
-    result_file = RESULTS_DIR / f"proactive-morning-{ts}.txt"
+    result_file = RESULTS_DIR / f"proactive-morning-{time.strftime('%Y-%m-%d')}-{ts}.txt"
```

The date leads; the epoch stays for within-day uniqueness. This is not an invented shape — `daily-insight` has been measurable throughout on exactly it:

```
results/archive/insight-2026-08-28-dedup-1787927287.txt      <- matched, scored
results/archive/proactive-morning-1787501370805-...txt       <- never matched
```

## Evidence

`tests/morning-briefing-artifact-is-datable.test.py`, 4 tests:

- the written name carries a date the probe's regex can match;
- **the probe actually finds it** — drives the real `_daily_artifact_minutes` against a real file;
- an **epoch-only control** proves the old name is invisible to it (so the test can fail, and shows what it is failing about);
- the `proactive-` prefix is unchanged, so no bridge's drain namespace moves.

Mutation control: reverting the date reddens the suite (1 failure).

Also green: `health-check-daily-punctuality`, `morning-briefing-completion-line`, `daily-punctuality-completion-sentinels`, `check-pending-questions-collapse`, `pending-questions-honest-notify`, and `review-checks.sh --diff <cumulative>` PASS.

## Follow-up (not in this PR)

After this lands, the host's `crons.json` should declare `artifact: "proactive-morning"` — that is per-host config, not repo state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)