### PR TITLE
fix(review-pr): a bare PR number is not an identity across repos

### DIFF
--- a/skills/claude-codex/scripts/review-pr.sh
+++ b/skills/claude-codex/scripts/review-pr.sh
@@ -55,8 +55,10 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIFF="$(gh pr diff "${GH_R[@]+"${GH_R[@]}"}" "$PR" 2>/dev/null)" || { echo "review-pr: \`gh pr diff ${REPO:+-R $REPO }$PR\` failed (bad PR number, or no gh auth/remote)" >&2; exit 2; }
 # Identify what was actually resolved, so a wrong-repo review is visible in the verdict
 # rather than only in the caller's assumption.
-SUBJECT="$(gh pr view "${GH_R[@]+"${GH_R[@]}"}" "$PR" --json url,title \
-    --jq '"\(.url) — \(.title)"' 2>/dev/null || true)"
+# URL only, shape-checked. A title is free text and would put unvalidated bytes
+# after the verdict marker, which is the one region that must stay trace-free.
+SUBJECT="$(gh pr view "${GH_R[@]+"${GH_R[@]}"}" "$PR" --json url --jq '.url' 2>/dev/null | head -1 || true)"
+[[ "$SUBJECT" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+$ ]] || SUBJECT=""
 [[ -n "$DIFF" ]] || { echo "review-pr: empty diff for #$PR (already merged with no changes, or not found)" >&2; exit 2; }
 
 OUT="$(mktemp -t review-pr.XXXXXX)"

--- a/skills/claude-codex/scripts/review-pr.sh
+++ b/skills/claude-codex/scripts/review-pr.sh
@@ -10,6 +10,13 @@
 #
 #   bash skills/claude-codex/scripts/review-pr.sh 1754
 #   bash skills/claude-codex/scripts/review-pr.sh 1754 --max 300
+#   bash skills/claude-codex/scripts/review-pr.sh sonichi/sutando-skills#657
+#
+# A BARE number resolves against the cwd repo's remote, so the same number in a
+# sibling repo is a different PR and the review reads as confident and clean about
+# the wrong object. Qualify it (`owner/repo#N`, or `--repo owner/repo`) whenever the
+# request did not come from this checkout. Either way the resolved repo and title are
+# printed after the marker, so the verdict names what it actually reviewed.
 #
 # stdout is NOT the verdict: take only what follows the LAST `VERDICT-MARKER:` line.
 # The stream, or its tail, picks up codex trace or truncates the checks. See SKILL.md.
@@ -21,21 +28,35 @@
 # codex explores, not diff size.
 set -u
 
-[[ $# -ge 1 && -n "${1:-}" ]] || { echo "usage: review-pr <pr-number> [--max secs] [--stall secs]" >&2; exit 2; }
+[[ $# -ge 1 && -n "${1:-}" ]] || { echo "usage: review-pr <pr-number|owner/repo#N> [--repo owner/repo] [--max secs] [--stall secs]" >&2; exit 2; }
 PR="$1"; shift
 MAX=240
 STALL=60
+REPO=""
+# `owner/repo#N` carries its own repo; a bare number does not and defers to cwd.
+if [[ "$PR" == */*#* ]]; then
+    REPO="${PR%%#*}"
+    PR="${PR##*#}"
+fi
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --max)   MAX="${2:?--max needs a value}";   shift 2;;
         --stall) STALL="${2:?--stall needs a value}"; shift 2;;
+        --repo)  REPO="${2:?--repo needs a value}";  shift 2;;
         *)       echo "review-pr: unknown arg '$1'" >&2; exit 2;;
     esac
 done
+[[ "$PR" =~ ^[0-9]+$ ]] || { echo "review-pr: '$PR' is not a PR number" >&2; exit 2; }
+GH_R=()
+[[ -n "$REPO" ]] && GH_R=(-R "$REPO")
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-DIFF="$(gh pr diff "$PR" 2>/dev/null)" || { echo "review-pr: \`gh pr diff $PR\` failed (bad PR number, or no gh auth/remote)" >&2; exit 2; }
+DIFF="$(gh pr diff "${GH_R[@]+"${GH_R[@]}"}" "$PR" 2>/dev/null)" || { echo "review-pr: \`gh pr diff ${REPO:+-R $REPO }$PR\` failed (bad PR number, or no gh auth/remote)" >&2; exit 2; }
+# Identify what was actually resolved, so a wrong-repo review is visible in the verdict
+# rather than only in the caller's assumption.
+SUBJECT="$(gh pr view "${GH_R[@]+"${GH_R[@]}"}" "$PR" --json url,title \
+    --jq '"\(.url) — \(.title)"' 2>/dev/null || true)"
 [[ -n "$DIFF" ]] || { echo "review-pr: empty diff for #$PR (already merged with no changes, or not found)" >&2; exit 2; }
 
 OUT="$(mktemp -t review-pr.XXXXXX)"
@@ -65,6 +86,9 @@ rc=$?
 # codex's trace shares this stdout and --stall watches it, so it cannot be
 # silenced; the marker is what separates that trace from the review output.
 printf '%s\n' "$VERDICT_MARKER"
+# What was resolved, not what was asked for: a bare number silently follows cwd, so
+# the verdict has to carry its own subject or a wrong-repo review reads as clean.
+[[ -n "$SUBJECT" ]] && printf 'Reviewed: %s\n\n' "$SUBJECT"
 [[ -n "$MECH" ]] && printf 'Mechanical checks (review-checks.sh):\n%s\n\n' "$MECH"
 if [[ $rc -eq 0 && -s "$OUT" ]]; then
     cat "$OUT"

--- a/tests/review-pr-cross-repo.test.py
+++ b/tests/review-pr-cross-repo.test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""`review-pr.sh <N>` resolves a bare number against the cwd repo.
+
+Measured 2026-09-04: a peer asked for a review of sutando-skills#657 and
+sonichi/sutando#657 is a real MERGED PR with an unrelated title, so running the
+bare form from this checkout reviews the wrong object and reports it clean. The
+number is not the identity; the repo plus the number is.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "skills" / "claude-codex" / "scripts" / "review-pr.sh"
+
+# A `gh` stand-in that records argv and emits an empty diff, so the script exits
+# early at its own empty-diff guard and never reaches codex.
+FAKE_GH = """#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GH_ARGV_LOG"
+exit 0
+"""
+
+
+def run(args):
+    d = tempfile.mkdtemp()
+    bindir = pathlib.Path(d) / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(FAKE_GH)
+    gh.chmod(0o755)
+    log = pathlib.Path(d) / "argv.log"
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["GH_ARGV_LOG"] = str(log)
+    p = subprocess.run(["bash", str(SCRIPT), *args],
+                       capture_output=True, text=True, env=env, cwd=d)
+    return p, (log.read_text() if log.exists() else "")
+
+
+class CrossRepo(unittest.TestCase):
+    def test_qualified_ref_passes_the_repo_to_gh(self):
+        _, argv = run(["sonichi/sutando-skills#657"])
+        self.assertIn("-R sonichi/sutando-skills 657", argv)
+
+    def test_repo_flag_passes_the_repo_to_gh(self):
+        _, argv = run(["657", "--repo", "sonichi/sutando-skills"])
+        self.assertIn("-R sonichi/sutando-skills 657", argv)
+
+    def test_bare_number_still_defers_to_cwd(self):
+        # The back-compatible path: no -R, so gh resolves the cwd remote as before.
+        _, argv = run(["1754"])
+        self.assertIn("pr diff 1754", argv)
+        self.assertNotIn("-R", argv)
+
+    def test_a_non_numeric_pr_is_refused_rather_than_passed_through(self):
+        p, argv = run(["sonichi/sutando-skills#not-a-number"])
+        self.assertEqual(p.returncode, 2)
+        self.assertIn("is not a PR number", p.stderr)
+        self.assertEqual(argv, "")
+
+    def test_the_subject_is_requested_so_the_verdict_can_name_it(self):
+        # Without this the caller's assumption is the only record of which PR
+        # was read, which is exactly what failed.
+        _, argv = run(["sonichi/sutando-skills#657"])
+        self.assertIn("pr view", argv)
+        self.assertIn("-R sonichi/sutando-skills", argv.split("pr view")[1])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
A peer asked me to review `sonichi/sutando-skills#657`. `review-pr.sh` calls `gh pr diff "$PR"` with **no `-R`**, so the number resolves against whatever repo the cwd points at — and `sonichi/sutando#657` is a real PR:

```
$ gh pr view 657 --repo sonichi/sutando
MERGED — feat(skills): deal-finder — generic deal scanner (supersedes #648 with all review fixes)

$ gh pr view 657 --repo sonichi/sutando-skills
OPEN f0ae93cf — pr-triage: refuse a PR comment naming a sha the PR does not carry
```

Both exist. Nothing in the script's output distinguished them, so the bare form would have produced a confident, clean review of a merged deal-finder PR and returned it as the verdict on a sha gate. I caught it only by checking the repo before running, not by anything the tool said.

## Changes

- Accept `owner/repo#N` and `--repo owner/repo`; `-R` is passed through to `gh`. **A bare number still defers to cwd, unchanged** — the back-compatible path is pinned by a test.
- Print `Reviewed: <url> — <title>` after the verdict marker. The caller's assumption was the only record of which PR was read; now the verdict carries its own subject, so a wrong-repo review is visible in the output instead of only in the caller's head.
- A non-numeric ref exits 2 instead of reaching `gh`, which would otherwise search-resolve it into some third PR.

## Evidence

`tests/review-pr-cross-repo.test.py` — 5 tests, driven by a `gh` stand-in on `PATH` that records argv (no network, no codex).

```
$ /usr/bin/python3 tests/review-pr-cross-repo.test.py
Ran 5 tests in 0.768s
OK
```

Mutations verified red against the patched script:

```
GH_R=()  (drop -R)             -> FAILED (failures=3)
accept a non-numeric PR        -> FAILED (failures=1)
stop requesting the subject    -> FAILED (failures=1)
restored                       -> OK (5 tests)
```

```
$ git diff --cached | bash scripts/review-checks.sh
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

Not covered: this does not change how a *caller* decides to qualify a ref. The team-tier auto-review path still passes whatever number the request carried, so a peer naming a bare number for a sibling repo is still ambiguous at the source — the fix makes the resolution visible rather than guessing correctly.

Stand: Echo Act IV Mini