### PR TITLE
fix(proactive-loop): warn-already-triaged could not tokenize snake_case identifiers

### DIFF
--- a/skills/proactive-loop/scripts/warn-already-triaged.py
+++ b/skills/proactive-loop/scripts/warn-already-triaged.py
@@ -29,13 +29,13 @@ def parking_files():
                         personal_path("current-track.md")) if p.exists()]
 
 # entities worth searching for: paths, dotted filenames, backticked identifiers
-ENT = re.compile(r'`([^`]{3,40})`|([\w./-]+\.(?:py|sh|json|md|ts|yml))|\b([a-z][a-z0-9]+(?:-[a-z0-9]+){1,3})\b')
+ENT = re.compile(r'`([^`]{3,40})`|([\w./-]+\.(?:py|sh|json|md|ts|yml))|\b([a-z][a-z0-9]+(?:-[a-z0-9]+){1,3})\b|\b(_?[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+){1,4})\b')
 STOP = {"health-check", "not-running", "restart-needed", "session-read", "read-limit"}
 
 def tokens(name, text):
     out = [name] if name else []
     for m in ENT.finditer(text):
-        t = (m.group(1) or m.group(2) or m.group(3) or "").strip()
+        t = (m.group(1) or m.group(2) or m.group(3) or m.group(4) or "").strip()
         if 3 <= len(t) <= 40 and t.lower() not in STOP and t != name:
             out.append(t)
     seen, uniq = set(), []
@@ -57,7 +57,7 @@ def report(name, text, files):
         # produced by construction. That is cannot-answer, never untriaged.
         print(f"  NO NOUNS   {label:25} — extracted 0 searchable tokens, so NOTHING was "
               f"searched. Cannot answer; re-state with a filename, a `backticked` term, "
-              f"or a hyphenated-name.")
+              f"a hyphenated-name, or a snake_case identifier.")
         return "no_tokens"
     hits, seen_at = [], set()
     for tok in toks:

--- a/skills/proactive-loop/scripts/warn-already-triaged.py
+++ b/skills/proactive-loop/scripts/warn-already-triaged.py
@@ -29,7 +29,9 @@ def parking_files():
                         personal_path("current-track.md")) if p.exists()]
 
 # entities worth searching for: paths, dotted filenames, backticked identifiers
-ENT = re.compile(r'`([^`]{3,40})`|([\w./-]+\.(?:py|sh|json|md|ts|yml))|\b([a-z][a-z0-9]+(?:-[a-z0-9]+){1,3})\b|\b(_?[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+){1,4})\b')
+# Component count is unbounded; the 3..40 length check below is the only size
+# bound. A cap truncates a hyphenated name and drops a snake_case one entirely.
+ENT = re.compile(r'`([^`]{3,40})`|([\w./-]+\.(?:py|sh|json|md|ts|yml))|\b([a-z][a-z0-9]+(?:-[a-z0-9]+)+)\b|\b(_?[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+)\b')
 STOP = {"health-check", "not-running", "restart-needed", "session-read", "read-limit"}
 
 def tokens(name, text):

--- a/tests/proactive-loop-warn-already-triaged.test.py
+++ b/tests/proactive-loop-warn-already-triaged.test.py
@@ -47,6 +47,46 @@ class Tokens(unittest.TestCase):
         self.assertEqual(wat.tokens("memory-index", "text")[0], "memory-index")
 
 
+class SnakeCaseIdentifiers(unittest.TestCase):
+    """A claim whose only distinctive noun is snake_case used to yield ZERO
+    tokens, so the tool refused (exit 2) instead of searching. Most claims about
+    this codebase name a snake_case symbol -- `dev_dag2_dspace`, `PARK_REASONS`,
+    `notify_discord_dm` -- so the refusal covered the common case, not an edge.
+    """
+
+    def test_a_snake_case_identifier_is_extracted(self):
+        self.assertIn("dev_dag2_dspace",
+                      wat.tokens("", "the dev_dag2_dspace lane stopped writing"))
+
+    def test_an_uppercase_constant_is_extracted(self):
+        self.assertIn("PARK_REASONS",
+                      wat.tokens("", "PARK_REASONS is referenced only by the reader"))
+
+    def test_a_leading_underscore_identifier_is_extracted(self):
+        self.assertIn("_quarantine_undelivered",
+                      wat.tokens("", "_quarantine_undelivered drops its why argument"))
+
+    def test_a_snake_case_claim_reaches_parked_material(self):
+        # The end-to-end shape: before the fix this returned "no_tokens" and
+        # nothing was searched, so parked material stayed invisible.
+        f = _files("# notes\n## the dev_dag2_dspace lane is a lock flip, not a bug\nbody\n")
+        verdict, out = _report("", "the dev_dag2_dspace lane stopped writing", f)
+        self.assertEqual(verdict, "parked")
+
+    def test_a_snake_case_claim_that_is_genuinely_absent_still_reports_untriaged(self):
+        # Widening the tokenizer must not make every claim look parked; this is
+        # the half that fails if the new alternative matches too much.
+        f = _files("# notes\n## something else entirely\nbody\n")
+        verdict, _ = _report("", "the dev_dag2_dspace lane stopped writing", f)
+        self.assertEqual(verdict, "untriaged")
+
+    def test_ordinary_prose_still_yields_no_searchable_tokens(self):
+        # The refusal branch must survive: a sentence naming no identifier is
+        # still unanswerable, and saying so is the whole point of exit 2.
+        self.assertEqual(
+            wat.tokens("", "The owner asked me to review the pull request and merge it"), [])
+
+
 class ClaimFindsParkedMaterial(unittest.TestCase):
     def test_a_heading_hit_reports_candidates_and_is_not_untriaged(self):
         f = _files("# notes\n## the `widget-cache.py` decision\nbody\n")

--- a/tests/proactive-loop-warn-already-triaged.test.py
+++ b/tests/proactive-loop-warn-already-triaged.test.py
@@ -66,6 +66,20 @@ class SnakeCaseIdentifiers(unittest.TestCase):
         self.assertIn("_quarantine_undelivered",
                       wat.tokens("", "_quarantine_undelivered drops its why argument"))
 
+    def test_a_long_snake_case_identifier_is_extracted(self):
+        # A component cap made the tokenizer drop the LONGEST identifiers -- the
+        # most distinctive ones -- so the refusal survived the fix it motivated.
+        self.assertIn(
+            "this_is_a_long_snake_case_identifier",
+            wat.tokens("", "this_is_a_long_snake_case_identifier failed"))
+
+    def test_a_long_hyphenated_identifier_is_not_truncated(self):
+        # The hyphen alternative failed OPEN where snake_case failed closed: it
+        # returned a prefix, so the search ran against a name nobody asked about.
+        self.assertEqual(
+            ["one-two-three-four-five-six"],
+            wat.tokens("", "one-two-three-four-five-six failed"))
+
     def test_a_snake_case_claim_reaches_parked_material(self):
         # The end-to-end shape: before the fix this returned "no_tokens" and
         # nothing was searched, so parked material stayed invisible.


### PR DESCRIPTION
## The bug

`ENT`'s bare-word alternative requires at least one hyphen:

```python
\b([a-z][a-z0-9]+(?:-[a-z0-9]+){1,3})\b
```

So a claim whose only distinctive noun is snake_case extracts **zero** tokens, `report()` takes its cannot-answer branch, and nothing is searched.

This is the common case, not an edge one — most claims about this codebase name a snake_case symbol. The tool fails *safe* (exit 2, which the loop already documents as "NOT a green light"), so nothing was mis-cleared. But the gate that runs before telling the owner "X is how this system behaves" was unanswerable precisely when the claim was most specific, and its own refusal text sent the caller away to re-word the sentence.

## Before / after — actual output, same four claims

At `origin/main`:

```
rc=2  snake_case subject (dev_dag2_dspace)       NO NOUNS — extracted 0 searchable tokens
rc=2  snake_case CONSTANT (PARK_REASONS)         NO NOUNS — extracted 0 searchable tokens
rc=2  snake_case function (notify_discord_dm)    NO NOUNS — extracted 0 searchable tokens
rc=0  hyphenated control                         NONE FOUND — searched, nothing parked
```

At this head:

```
rc=0  snake_case subject (dev_dag2_dspace)       NONE FOUND — searched
rc=0  snake_case CONSTANT (PARK_REASONS)         NONE FOUND — searched
rc=0  snake_case function (notify_discord_dm)    NONE FOUND — searched
rc=0  leading-underscore (_quarantine_undelivered) NONE FOUND — searched
rc=0  hyphenated control                         NONE FOUND — unchanged
```

Over-match control, `tokens()` on ordinary prose at this head:

```
[]                              <- "The owner asked me to review the pull request and merge it"
[]                              <- "I noticed the build failed again this morning"
['snake_case', 'read_quota']    <- "a snake_case identifier like read_quota lives in the quota tracker"
```

## Tests

20/20 pass (14 existing + 6 added). Three mutations, each run with `__pycache__` cleared first:

| mutation | result |
|---|---|
| tool at `origin/main` (alternative absent) | **FAILED (5)** — the 5 snake_case tests |
| `{1,4}` → `{0,4}` (over-widen to any bare word) | **FAILED (2)** — `test_ordinary_prose_still_yields_no_searchable_tokens` and the pre-existing `test_a_claim_with_no_searchable_nouns_cannot_answer` |
| drop `m.group(4)` from the picker | **FAILED (5)** — same 5 |
| restored | **OK (20)** |

The two tests that guard the *opposite* direction are the load-bearing ones: widening a tokenizer is only safe if ordinary prose still yields nothing and an absent subject still reports `untriaged` rather than `parked`.

## Scope

Pure text tool — no bridge, network, delivery loop, or startup path, so harness evidence is the appropriate proof here rather than a post-restart round trip. Single concern; no bundled refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
