### PR TITLE
fix(gateway): a task's priority is invisible to the reader that sorts on it

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1590,9 +1590,9 @@ _heartbeat_disabled = False
 _last_heartbeat_at = 0.0
 
 _TASK_FIELDS = ("id", "timestamp", "session_scope",
-                # Which worker the sender asked for. Ahead of "task" so it can never
-                # be read from under the untrusted body; copied verbatim, never derived.
-                "requested_worker",
+                # Both ahead of "task": the safe parser stops at the body, so a
+                # field written below it is invisible to every task-last reader.
+                "requested_worker", "priority",
                 "task", "source", "channel_id",
                 # Context enrichment (AG2 broker writer side): human room/sender
                 # names + reply reference. Serialized only when the gateway sends
@@ -1604,7 +1604,7 @@ _TASK_FIELDS = ("id", "timestamp", "session_scope",
                 # Room-membership context (gateway writer side, same contract):
                 # a capped one-line mxid list + the true joined total.
                 "room_members", "room_member_count",
-                "source_message_id", "user_id", "priority", "interaction_type",
+                "source_message_id", "user_id", "interaction_type",
                 # Platform-signed metadata pointer — serialized as a one-line
                 # JSON header by a dedicated branch below (dict, not scalar).
                 "platform_card")

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -367,6 +367,23 @@ def main() -> int:
           "no receiving_instance header when the agent identity is unknown")
     rtc._reenroll_identity = _orig_reenroll
 
+    # priority must survive to the reader that sorts the queue. The safe parser
+    # stops at `task:`, so a priority serialized below it is silently invisible.
+    import task_priority as _tp
+    for _want in ("urgent", "low"):
+        _pid = f"task-PRIO{_want.upper()}"
+        rtc._write_task({**TASK, "id": _pid, "task": "hi", "priority": _want})
+        _pf = rtc.TASKS_DIR / f"{_pid}.txt"
+        _pbody = _pf.read_text()
+        check(_pbody.index("priority:") < _pbody.index("task:"),
+              f"priority is serialized above task: ({_want})")
+        check(local_task_protocol.parse_task_headers(_pbody).get("priority") == _want,
+              f"safe parser reads a gateway priority ({_want})")
+        check(_tp.parse_priority_from_text(_pbody) == _want,
+              f"the production priority reader sees a gateway {_want}")
+        check(_tp.parse_priority_from_file(_pf) == _want,
+              f"parse_priority_from_file agrees for a gateway {_want}")
+
     rtc._write_task({**TASK, "id": "task-ROOMSESSION", "session_scope": "room"})
     room_session = (rtc.TASKS_DIR / "task-ROOMSESSION.txt").read_text()
     check(room_session.count("session_scope: room") == 1


### PR DESCRIPTION
## The bug

`_TASK_FIELDS` serialized `priority` **below** the `task:` body line. The safe parser stops at `task:`, so the reader that sorts the queue has never seen a gateway priority — **every gateway task has sorted as `normal`**, including an owner message marked urgent.

At `origin/main`, on a gateway-shaped file:

```
parse_task_headers          priority -> None
parse_task_headers_trusted  priority -> 'urgent'
```

This is not a new discovery so much as an unclosed one — `src/task_priority.py:63-70` already records it in its own docstring:

> *"task-mid writers like the gateway put `priority:` after `task:`, so this reader has never seen those headers; changing that is a semantics decision for the write-side convergence, not this refactor"*

That semantics decision is what this PR makes: the write side moves.

## The fix

One field moves ahead of `"task"` in `_TASK_FIELDS`. No parser changes, no reader changes, no new policy.

```
-                "source_message_id", "user_id", "priority", "interaction_type",
+                "source_message_id", "user_id", "interaction_type",
```
```
+                # Ahead of "task": the safe parser stops at the body, so a priority
+                # written below it is invisible and every task sorts as normal.
+                "priority",
```

## Evidence

Tested through the real writer (`rtc._write_task`) and the **production** reader, not a re-implementation — 8 new checks in the gateway's own suite:

```
ok  priority is serialized above task: (urgent)
ok  safe parser reads a gateway priority (urgent)
ok  the production priority reader sees a gateway urgent
ok  parse_priority_from_file agrees for a gateway urgent
ok  priority is serialized above task: (low)
ok  safe parser reads a gateway priority (low)
ok  the production priority reader sees a gateway low
ok  parse_priority_from_file agrees for a gateway low
```

Mutation-verified — putting the field back below `task:` reddens exactly those 8 and nothing else:

```
FAIL priority is serialized above task: (urgent)
FAIL safe parser reads a gateway priority (urgent)
FAIL the production priority reader sees a gateway urgent
FAIL parse_priority_from_file agrees for a gateway urgent
FAIL priority is serialized above task: (low)          ... and the low trio
```

Restored: `PASS — all checks green`.

Suites:

```
src/remote-gateway-bridge.test.py            PASS — all checks green
tests/task-priority.test.py                  OK
tests/task-priority-invariance.test.py       PASS — invariant under the 3b switch
tests/task-priority-stop-at-task-delimiter   All tests passed
packages/.../test_no_drift.py                PASS — package in sync with src/
scripts/review-checks.sh                     PASS
```

The delimiter and invariance suites matter here: they pin the #982 rule that a *body* cannot forge a priority. Both still pass, because this moves the trusted writer's own header — it does not widen what the parser trusts.

## Scope

This is the priority-only subset of the task-last convergence that #3860 makes a step-2 prerequisite (`docs/worker-pool-design.md:171,241`). It is a **strict step toward** that convergence, not a substitute: `task` still precedes `source`, `channel_id`, `access_tier` and the rest, and the readers still pick their parser by writer.

Deliberately not in scope: moving the remaining fields, and migrating `health-check.py:9054` / `remote_gateway_bridge.py:1126` off the last-wins parser. Both belong to the convergence PR — I've flagged the reader migration on #3860, since converging the writer without it would leave `access_tier` read by a parser whose contract forbids that shape.

Same one-field placement pattern as #3872 (`requested_worker`), independently useful and independently revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Added after review: this is convergence, not a new convention

Raised in review — the gateway was the **sole outlier**. Every other task writer already emits `priority` on the line immediately above `task:`. Measured on `origin/main`:

```
src/discord-bridge.py    4297: f"priority: {priority}\n"    4298: f"task: {user_task_text}\n"
src/telegram-bridge.py   1021: f"priority: {priority}\n"    1022: f"task: {...}\n"
src/slack-bridge.py      1234: f"priority: {priority}\n"    1235: f"task: {user_task_text}\n"
```

So the question "why this order" has a better answer than taste: three of four writers were already there, and their tasks have therefore always sorted correctly. Only gateway traffic was affected, which is why the defect survived — the bridges most people exercise never had it.

## No HMAC hazard, and it is worth stating why

An ordering change is exactly the shape that breaks a signature scheme, so it was checked rather than assumed. `verify_text` MACs **the bytes it received** — `_strip_stamp(text)` then `_mac(stripped, key)` — instead of re-serializing from `_TASK_FIELDS` and comparing. Field order is therefore not part of the verification contract, and an envelope minted by a peer still on the old order still verifies.

Had verification reconstructed the body from `_TASK_FIELDS`, this diff would have silently invalidated every in-flight envelope and no test here would have caught it.

## No rollout hazard

Tasks already queued in the old format still read `normal` through the safe parser, exactly as before. A mixed queue during rollout is fine; old tasks simply are not retroactively corrected.
