### PR TITLE
fix(watcher): the sentinel is per instance, so N watchers stop overwriting one file

### DIFF
--- a/src/agent/codex/cli/task-notifier.sh
+++ b/src/agent/codex/cli/task-notifier.sh
@@ -14,7 +14,10 @@ RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$(dirname "$TASKS_DIR")/results}"
 TASK_HANDLER_CLAIMS_DIR="$(dirname "$TASKS_DIR")/state/task-event-handler-claims"
 # Same per-instance receipt the watcher writes; resolved by its owner so the
 # two cannot disagree about which instance a declined task belongs to.
-TASK_HANDLER_FALLBACKS_DIR="$(python3 "$REPO/src/util_paths.py" handler-fallbacks-dir "$(dirname "$TASKS_DIR")/state")" || {
+# shellcheck source=../../../../scripts/python-binary.sh
+. "$REPO/scripts/python-binary.sh"
+NOTIFIER_PY="$(require_python "$REPO" "resolve the fallback receipt dir")" || exit 1
+TASK_HANDLER_FALLBACKS_DIR="$("$NOTIFIER_PY" "$REPO/src/util_paths.py" handler-fallbacks-dir "$(dirname "$TASKS_DIR")/state")" || {
   echo "task-notifier: could not resolve the fallback receipt dir" >&2
   exit 1
 }
@@ -92,7 +95,7 @@ prepare_workstream_context() {
   [ -f "$WORKSTREAM_CONTEXT_SCRIPT" ] || return 0
   candidate="$(mktemp "${TMPDIR:-/tmp}/sutando-workstream-context.XXXXXX")" || return 0
   chmod 600 "$candidate" 2>/dev/null || true
-  if python3 "$WORKSTREAM_CONTEXT_SCRIPT" context "$filename" > "$candidate" 2>/dev/null; then
+  if "$NOTIFIER_PY" "$WORKSTREAM_CONTEXT_SCRIPT" context "$filename" > "$candidate" 2>/dev/null; then
     if [ -s "$candidate" ]; then
       workstream_context_file="$candidate"
     else
@@ -200,7 +203,7 @@ next_pending_task() {
     printf '%s\n' "$candidate"
     return 0
   done < <(
-    python3 - "$REPO/src" "$TASKS_DIR" <<'PY'
+    "$NOTIFIER_PY" - "$REPO/src" "$TASKS_DIR" <<'PY'
 import sys
 from pathlib import Path
 
@@ -373,7 +376,7 @@ fi
 
 event_dir="$(mktemp -d "${TMPDIR:-/tmp}/sutando-task-notifier.XXXXXX")"
 mkfifo "$event_dir/events"
-python3 -c \
+"$NOTIFIER_PY" -c \
   'import os, sys; os.setsid(); os.execv("/bin/bash", ["bash", sys.argv[1], sys.argv[2]])' \
   "$REPO/src/watch-tasks-stream.sh" "$TASKS_DIR" > "$event_dir/events" &
 watcher_pid=$!

--- a/src/agent/codex/cli/task-notifier.sh
+++ b/src/agent/codex/cli/task-notifier.sh
@@ -12,7 +12,12 @@ else
 fi
 RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$(dirname "$TASKS_DIR")/results}"
 TASK_HANDLER_CLAIMS_DIR="$(dirname "$TASKS_DIR")/state/task-event-handler-claims"
-TASK_HANDLER_FALLBACKS_DIR="$(dirname "$TASKS_DIR")/state/task-event-handler-fallbacks"
+# Same per-instance receipt the watcher writes; resolved by its owner so the
+# two cannot disagree about which instance a declined task belongs to.
+TASK_HANDLER_FALLBACKS_DIR="$(python3 "$REPO/src/util_paths.py" handler-fallbacks-dir "$(dirname "$TASKS_DIR")/state")" || {
+  echo "task-notifier: could not resolve the fallback receipt dir" >&2
+  exit 1
+}
 POLL_INTERVAL="${SUTANDO_NOTIFIER_POLL_INTERVAL:-0.5}"
 COMPLETION_TIMEOUT="${SUTANDO_NOTIFIER_COMPLETION_TIMEOUT:-3600}"
 CORE_READY_TIMEOUT="${SUTANDO_NOTIFIER_CORE_READY_TIMEOUT:-300}"

--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from util_paths import watcher_sentinel_path
 from workspace_default import resolve_workspace
 
 AVAILABILITY = ("available", "busy_accepting", "busy_unavailable", "offline", "unknown")
@@ -177,7 +178,9 @@ def _session_started_at(ws: Path) -> float | None:
     """When this core session's task watcher started: it dispatches every task that gets a snapshot and
     dies with the session, so its pid file's mtime is the session boundary (the heartbeat writer is not)."""
     try:
-        return (ws / "state" / "watch-tasks-stream.pid").stat().st_mtime
+        # The writer names this path per instance; a literal here reads another
+        # session's sentinel, or none, and resurrects its snapshot as live work.
+        return watcher_sentinel_path(ws / "state").stat().st_mtime
     except OSError:
         return None
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8987,9 +8987,13 @@ def check_task_watcher() -> dict:
                          f"UNKNOWN identity and may serve the same instance: restarting would "
                          f"duplicate it, and not restarting may leave a gap")
             elif _uncovered and _covered:
-                _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}) and restart "
-                         f"{len(_uncovered)} cleanly — {len(_covered)} of their instance(s) are "
-                         f"already served by a supervised watcher and must NOT be restarted")
+                # Cardinality alone lets an operator restart the covered one and
+                # leave the uncovered instance absent: name which pid is which.
+                _re = [r for r in ownerless if str(_snap[r]) in _uncovered]
+                _no = [r for r in ownerless if str(_snap[r]) in _covered]
+                _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}), then restart "
+                         f"{', '.join(_re)} — NOT {', '.join(_no)}, whose instance(s) a "
+                         f"supervised watcher already serves")
             elif _covered:
                 _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}) and do NOT restart — "
                          f"a supervised watcher already serves that instance")
@@ -9063,9 +9067,16 @@ def check_task_watcher() -> dict:
             # here is what makes the duplicates.
             own, sup = _split_roots_by_owner(roots, ps_out)
             _dg, _du = _group_roots_by_target(WORKSPACE_DIR / "state", own)
-            if _du:
-                own = [o for o in own if o not in _du]
-            _blind = (f"; UNKNOWN identity, do NOT stop: {', '.join(_du)}" if _du else "")
+            _sg2, _ = _group_roots_by_target(WORKSPACE_DIR / "state", sup)
+            # Every sentinel here is dead, so an ownerless root is its instance's
+            # ONLY watcher unless a supervised peer serves the same target.
+            _sole = [o for tgt, rs in _dg.items() if tgt not in _sg2 for o in rs]
+            if _du or _sole:
+                own = [o for o in own if o not in _du and o not in _sole]
+            _blind = "".join([
+                f"; UNKNOWN identity, do NOT stop: {', '.join(_du)}" if _du else "",
+                (f"; do NOT stop {', '.join(_sole)} — the only watcher for that instance, "
+                 f"and its sentinel is already dead") if _sole else ""])
             return {"name": name, "status": "warn",
                     "detail": f"sentinel pid {pid} is dead but {len(roots)} watcher(s) still "
                               f"run; tasks/ IS being drained{_blind}. "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8989,11 +8989,21 @@ def check_task_watcher() -> dict:
             elif _uncovered and _covered:
                 # Cardinality alone lets an operator restart the covered one and
                 # leave the uncovered instance absent: name which pid is which.
-                _re = [r for r in ownerless if str(_snap[r]) in _uncovered]
-                _no = [r for r in ownerless if str(_snap[r]) in _covered]
+                _by = {}
+                for r in ownerless:
+                    _by.setdefault(str(_snap[r]), []).append(r)
+                # ONE representative per uncovered target: restarting every root
+                # on a target recreates the duplicate the stop just removed.
+                _re = [_by[x][0] for x in _uncovered if x in _by]
+                _served = [r for r in ownerless if str(_snap[r]) in _covered]
+                _peer = [r for r in ownerless if r not in _re and r not in _served]
+                _why = "; ".join(filter(None, [
+                    f"{', '.join(_served)} — a supervised watcher already serves that instance"
+                    if _served else "",
+                    f"{', '.join(_peer)} — a peer above already covers that instance"
+                    if _peer else ""]))
                 _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}), then restart "
-                         f"{', '.join(_re)} — NOT {', '.join(_no)}, whose instance(s) a "
-                         f"supervised watcher already serves")
+                         f"{', '.join(_re)} and NOT {_why}")
             elif _covered:
                 _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}) and do NOT restart — "
                          f"a supervised watcher already serves that instance")
@@ -9127,11 +9137,21 @@ def check_task_watcher() -> dict:
                               f"recreates a duplicate for one instance and removes the only "
                               f"watcher for another. Resolve identity first"}
         if distinct and not dupes:
+            _peer = {}
+            for tgt, rs in _groups.items():
+                if tgt not in tracked_targets and len(rs) > 1:
+                    _peer[tgt] = rs
+            if _peer:
+                _act = ("; among themselves " + "; ".join(
+                    f"{', '.join(rs)} share one instance" for rs in _peer.values())
+                    + " — keep ONE of each and stop the rest")
+            else:
+                _act = ". Do NOT stop them"
             return {"name": name, "status": "warn",
                     "detail": f"{len(distinct)} watcher tree(s) ({', '.join(distinct)}) belong to a "
-                              f"DIFFERENT instance than any tracked sentinel — not duplicates; each "
-                              f"is missing its own sentinel record. Do NOT stop them; register "
-                              f"their sentinels"}
+                              f"DIFFERENT instance than any tracked sentinel — not duplicates of a "
+                              f"tracked watcher; each is missing its own sentinel record{_act}; "
+                              f"register their sentinels"}
         keep = ", ".join(str(p) for p in sorted(live))
         own, sup = _split_roots_by_owner(dupes, ps_out)
         extra_note = ("" if not distinct else

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8930,17 +8930,22 @@ def check_task_watcher() -> dict:
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "
                                   "it IS draining tasks/. Re-stamp the sentinel with --fix, or "
                                   "restart cleanly only when tasks/ is empty."}
-            # A root with a live parent is not orphaned and stopping it takes a
-            # healthy instance offline; only ownerless roots keep the stop remedy.
-            if ownerless:
-                lead = (f"{len(roots)} orphaned watcher(s) running with no PID sentinel "
-                        f"(pids {', '.join(roots)}) — draining tasks/ unsupervised; "
+            # Stop advice is scoped to the ownerless subset: a root with a live
+            # parent is supervised, and stopping it takes a healthy peer offline.
+            count = (f"{len(roots)} watcher(s) running with no PID sentinel "
+                     f"(pids {', '.join(roots)}) — each drains tasks/, so every task "
+                     f"is processed {len(roots)}x")
+            if ownerless and supervised:
+                lead = (f"{count}. Stop ONLY the ownerless ({', '.join(ownerless)}) and restart "
+                        f"one cleanly. Do NOT stop {', '.join(supervised)} — supervised; "
+                        f"reduce those through the launcher that owns them")
+            elif ownerless:
+                lead = (f"{len(ownerless)} orphaned watcher(s) running with no PID sentinel "
+                        f"(pids {', '.join(ownerless)}) — draining tasks/ unsupervised; "
                         f"stop them and restart one cleanly")
             else:
-                lead = (f"{len(roots)} watcher(s) running with no PID sentinel "
-                        f"(pids {', '.join(roots)}) — each drains tasks/, so every task "
-                        f"is processed {len(roots)}x. Do NOT stop any of them: each is "
-                        f"supervised; reduce the count through the launcher that owns it")
+                lead = (f"{count}. Do NOT stop any of them: each is supervised; "
+                        f"reduce the count through the launcher that owns it")
             return {"name": name, "status": "warn",
                     "detail": f"{lead}. ownerless: {', '.join(ownerless) or 'none'}; "
                               f"supervised: {', '.join(supervised) or 'none'}"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8669,6 +8669,7 @@ _WATCHER_SHELLS = ("sh", "bash", "zsh", "ksh")
 
 # The script named as a whole final path component, so `x-watch-tasks-stream.sh`
 # and a mention inside a longer word cannot match.
+_WATCHER_SCRIPT_NAME = "watch-tasks-stream.sh"
 _WATCHER_SCRIPT = re.compile(r"(?:^|[\s/])watch-tasks-stream\.sh(?=\s|$)")
 
 
@@ -8692,7 +8693,7 @@ def _is_watcher_argv(argv: str, pid: "int | None" = None) -> "bool | None":
             return False
         if vec[1].startswith("-"):
             return False
-        return _WATCHER_SCRIPT.search(vec[1]) is not None
+        return os.path.basename(vec[1]) == _WATCHER_SCRIPT_NAME
     parts = argv.split()
     if len(parts) < 2:
         return False

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8782,6 +8782,34 @@ def _watcher_sentinel_target(state_dir, pid):
         return None
 
 
+def _peer_multiplicity_parts(groups, tracked_targets, ps_out):
+    """Peer targets carrying more than one root, ownership deciding which stays.
+
+    Computed on EVERY path, never only when no tracked-target duplicate exists:
+    a duplicate on one target must not hide a duplicate on another.
+    """
+    peer = {t: rs for t, rs in groups.items()
+            if t not in tracked_targets and len(rs) > 1}
+    if not peer:
+        return []
+    own_x, sup_x = _split_roots_by_owner(
+        [r for rs in peer.values() for r in rs], ps_out)
+    parts = []
+    for tgt, rs in peer.items():
+        _s = [r for r in rs if r in sup_x]
+        _o = [r for r in rs if r in own_x]
+        if _s and _o:
+            parts.append(f"{', '.join(rs)} share one instance — keep the supervised "
+                         f"{', '.join(_s)} and stop the ownerless {', '.join(_o)}")
+        elif _s:
+            parts.append(f"{', '.join(rs)} share one instance and are ALL supervised — "
+                         f"reduce through the launcher that owns them, do NOT stop them")
+        else:
+            parts.append(f"{', '.join(rs)} share one instance — keep ONE and stop "
+                         f"the rest")
+    return parts
+
+
 def _group_roots_by_target(state_dir, roots):
     """(target -> [pids], unresolvable pids). The ONE identity policy both the
     sentinel-present and no-sentinel branches classify with."""
@@ -9165,28 +9193,8 @@ def check_task_watcher() -> dict:
                               f"recreates a duplicate for one instance and removes the only "
                               f"watcher for another. Resolve identity first"}
         if distinct and not dupes:
-            _peer = {}
-            for tgt, rs in _groups.items():
-                if tgt not in tracked_targets and len(rs) > 1:
-                    _peer[tgt] = rs
-            if _peer:
-                # "stop the rest" must never name a supervised root: ownership
-                # decides WHICH peer stays, and a launcher owns its own count.
-                _own_x, _sup_x = _split_roots_by_owner(
-                    [r for rs in _peer.values() for r in rs], ps_out)
-                _parts = []
-                for tgt, rs in _peer.items():
-                    _s = [r for r in rs if r in _sup_x]
-                    _o = [r for r in rs if r in _own_x]
-                    if _s and _o:
-                        _parts.append(f"{', '.join(rs)} share one instance — keep the supervised "
-                                      f"{', '.join(_s)} and stop the ownerless {', '.join(_o)}")
-                    elif _s:
-                        _parts.append(f"{', '.join(rs)} share one instance and are ALL supervised — "
-                                      f"reduce through the launcher that owns them, do NOT stop them")
-                    else:
-                        _parts.append(f"{', '.join(rs)} share one instance — keep ONE and stop "
-                                      f"the rest")
+            _parts = _peer_multiplicity_parts(_groups, tracked_targets, ps_out)
+            if _parts:
                 _act = "; among themselves " + "; ".join(_parts)
             else:
                 _act = ". Do NOT stop them"
@@ -9197,8 +9205,16 @@ def check_task_watcher() -> dict:
                               f"register their sentinels"}
         keep = ", ".join(str(p) for p in sorted(live))
         own, sup = _split_roots_by_owner(dupes, ps_out)
-        extra_note = ("" if not distinct else
-                      f" ({len(distinct)} further tree(s) are a different instance, left alone)")
+        # The peer analysis runs here too: a tracked-target duplicate must not
+        # make a duplicate on ANOTHER target vanish into "left alone".
+        _pparts = _peer_multiplicity_parts(_groups, tracked_targets, ps_out)
+        if distinct and _pparts:
+            extra_note = (f" ({len(distinct)} further tree(s) are a different instance — not "
+                          f"duplicates of a tracked watcher, but among themselves "
+                          f"{'; '.join(_pparts)})")
+        else:
+            extra_note = ("" if not distinct else
+                          f" ({len(distinct)} further tree(s) are a different instance, left alone)")
         return {"name": name, "status": "warn",
                 "detail": f"{len(trees)} watcher trees running — {len(dupes)} share a sentinel "
                           f"target with a tracked watcher, so those duplicate its work{extra_note}. "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9148,9 +9148,24 @@ def check_task_watcher() -> dict:
                 if tgt not in tracked_targets and len(rs) > 1:
                     _peer[tgt] = rs
             if _peer:
-                _act = ("; among themselves " + "; ".join(
-                    f"{', '.join(rs)} share one instance" for rs in _peer.values())
-                    + " — keep ONE of each and stop the rest")
+                # "stop the rest" must never name a supervised root: ownership
+                # decides WHICH peer stays, and a launcher owns its own count.
+                _own_x, _sup_x = _split_roots_by_owner(
+                    [r for rs in _peer.values() for r in rs], ps_out)
+                _parts = []
+                for tgt, rs in _peer.items():
+                    _s = [r for r in rs if r in _sup_x]
+                    _o = [r for r in rs if r in _own_x]
+                    if _s and _o:
+                        _parts.append(f"{', '.join(rs)} share one instance — keep the supervised "
+                                      f"{', '.join(_s)} and stop the ownerless {', '.join(_o)}")
+                    elif _s:
+                        _parts.append(f"{', '.join(rs)} share one instance and are ALL supervised — "
+                                      f"reduce through the launcher that owns them, do NOT stop them")
+                    else:
+                        _parts.append(f"{', '.join(rs)} share one instance — keep ONE and stop "
+                                      f"the rest")
+                _act = "; among themselves " + "; ".join(_parts)
             else:
                 _act = ". Do NOT stop them"
             return {"name": name, "status": "warn",

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8867,6 +8867,12 @@ def _watcher_trees(ps_output: "str | None" = None) -> dict:
     return trees
 
 
+def extras_present(trees, live) -> bool:
+    """Any watcher tree not claimed by a live sentinel."""
+    tracked = {str(x) for x in live}
+    return any(not (members & tracked) for members in trees.values())
+
+
 def check_task_watcher() -> dict:
     """Direct liveness of the streaming task watcher (src/watch-tasks-stream.sh).
 
@@ -9069,7 +9075,30 @@ def check_task_watcher() -> dict:
         return {"name": name, "status": "warn",
                 "detail": f"watcher pid {pid} is dead (crashed — sentinel left behind); restart it"}
 
+    faults = []
+    if dead_pids:
+        faults.append("crashed: " + ", ".join(
+            f"{sp.name} (pid {spid} dead)" for spid, sp in dead_pids))
+    if reused:
+        faults.append("PID reuse: " + ", ".join(
+            f"{sp.name} (pid {spid} is {sargv[:32]})" for spid, sargv, sp in reused))
+    if unreadable:
+        faults.append("unreadable: " + ", ".join(
+            f"{sp.name} ({err})" for sp, err in unreadable))
+    if unprovable:
+        faults.append("UNKNOWN: " + ", ".join(
+            f"{sp.name} (pid {spid} unprovable from argv)" for spid, _a, sp in unprovable))
+    if collided:
+        faults.append("one pid, two sentinels: " + ", ".join(
+            f"{a.name} and {b.name} both name pid {spid}" for spid, a, b in collided))
+    # A sentinel fault must not be skipped by an earlier remediation return:
+    # UNKNOWN or conflicting records veto destructive advice about extra trees.
     tracked = {str(p) for p in live}
+    if (unprovable or collided) and extras_present(trees, live):
+        return {"name": name, "status": "warn",
+                "detail": "; ".join(faults) + ". Untracked watcher tree(s) are "
+                          "present too, but no stop or restart is advised while a sentinel record "
+                          "is unprovable or conflicting — resolve the records first"}
     extras = sorted(r for r, members in trees.items() if not (members & tracked))
     if extras:
         # A root count is not an identity: only a shared sentinel target makes
@@ -9106,22 +9135,6 @@ def check_task_watcher() -> dict:
     alive = ", ".join(str(p) for p in sorted(live))
     # An anomaly belongs to the instance whose sentinel carries it, so a live
     # PEER is not evidence about a crashed one and must not discard its record.
-    faults = []
-    if dead_pids:
-        faults.append("crashed: " + ", ".join(
-            f"{sp.name} (pid {spid} dead)" for spid, sp in dead_pids))
-    if reused:
-        faults.append("PID reuse: " + ", ".join(
-            f"{sp.name} (pid {spid} is {sargv[:32]})" for spid, sargv, sp in reused))
-    if unreadable:
-        faults.append("unreadable: " + ", ".join(
-            f"{sp.name} ({err})" for sp, err in unreadable))
-    if unprovable:
-        faults.append("UNKNOWN: " + ", ".join(
-            f"{sp.name} (pid {spid} unprovable from argv)" for spid, _a, sp in unprovable))
-    if collided:
-        faults.append("one pid, two sentinels: " + ", ".join(
-            f"{a.name} and {b.name} both name pid {spid}" for spid, a, b in collided))
     if faults:
         return {"name": name, "status": "warn",
                 "detail": f"{len(live)} watcher(s) alive (pids {alive}), but "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8943,43 +8943,53 @@ def check_task_watcher() -> dict:
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "
                                   "it IS draining tasks/. Re-stamp the sentinel with --fix, or "
                                   "restart cleanly only when tasks/ is empty."}
-            # Same identity policy as the tracked branch: without it, losing the
-            # last sentinel turns distinct instances back into "duplicates".
-            _groups, _unknown = _group_roots_by_target(WORKSPACE_DIR / "state", roots)
+            # ONE identity snapshot for every derivation below: three separate
+            # resolver reads can disagree if a process's identity changes between.
+            _snap = {r: _watcher_sentinel_target(WORKSPACE_DIR / "state", r) for r in roots}
+            _tgt = lambda rs: ({str(_snap[r]) for r in rs if _snap[r] is not None},
+                               [r for r in rs if _snap[r] is None])
+            _all_t, _unknown = _tgt(roots)
+            _sup_t, _su = _tgt(supervised)
+            _own_t, _ou = _tgt(ownerless)
             if _unknown:
                 cost = (f"{len(roots)} watcher(s) running with no PID sentinel "
                         f"(pids {', '.join(roots)}); {len(_unknown)} "
                         f"({', '.join(_unknown)}) have no resolvable (agent, instance), so "
                         f"whether any task is processed twice is UNKNOWN — do not reduce the count")
-            elif len(_groups) == len(roots) and len(roots) > 1:
+            elif len(_all_t) == len(roots) and len(roots) > 1:
                 cost = (f"{len(roots)} watcher(s) with no PID sentinel (pids {', '.join(roots)}) "
-                        f"resolve to {len(_groups)} DISTINCT instances — not duplicates, and no "
+                        f"resolve to {len(_all_t)} DISTINCT instances — not duplicates, and no "
                         f"task is processed twice; do not reduce the count")
             else:
-                _n = max((len(v) for v in _groups.values()), default=len(roots))
+                _n = max((sum(1 for r in roots if _snap[r] is not None
+                              and str(_snap[r]) == x) for x in _all_t), default=len(roots))
                 cost = (f"{len(roots)} watcher(s) running with no PID sentinel "
                         f"(pids {', '.join(roots)}) — {_n} share one instance target, so its "
                         f"tasks are processed {_n}x")
             count = cost
-            # Reduction is advice about the SUPERVISED subset, so it is that
-            # subset's identity that licenses it -- never the whole root count.
-            _sg, _su = _group_roots_by_target(WORKSPACE_DIR / "state", supervised)
-            _sup_dupe = (not _su) and any(len(v) > 1 for v in _sg.values())
+            _sup_dupe = (not _su) and len(_sup_t) < len(supervised)
             _reduce = "; reduce those through the launcher that owns them" if _sup_dupe else ""
-            # Stop advice is scoped to the ownerless subset; parentage gives
-            # supervision, not target identity and not the restart count.
-            _og, _ou = _group_roots_by_target(WORKSPACE_DIR / "state", ownerless)
+            # Per TARGET, not all-or-nothing: covered targets need no restart,
+            # and an unknown SUPERVISED root may alias any of them.
+            _covered = sorted(_own_t & _sup_t)
+            _uncovered = sorted(_own_t - _sup_t)
             if _ou:
                 _stop = (f"Do NOT stop {', '.join(_ou)} — UNKNOWN identity: it may be the only "
                          f"watcher for its instance")
-            elif _og and set(_og) <= set(_sg):
-                # Restarting after the stop is what recreates the duplicate: a
-                # supervised watcher already serves every one of these targets.
+            elif _su:
+                _stop = (f"Do NOT stop {', '.join(ownerless)} — supervised {', '.join(_su)} has "
+                         f"UNKNOWN identity and may serve the same instance: restarting would "
+                         f"duplicate it, and not restarting may leave a gap")
+            elif _uncovered and _covered:
+                _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}) and restart "
+                         f"{len(_uncovered)} cleanly — {len(_covered)} of their instance(s) are "
+                         f"already served by a supervised watcher and must NOT be restarted")
+            elif _covered:
                 _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}) and do NOT restart — "
                          f"a supervised watcher already serves that instance")
-            elif len(_og) > 1:
+            elif len(_uncovered) > 1:
                 _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}) and restart "
-                         f"{len(_og)} cleanly — one per instance, NOT one")
+                         f"{len(_uncovered)} cleanly — one per instance, NOT one")
             else:
                 _stop = f"Stop ONLY the ownerless ({', '.join(ownerless)}) and restart one cleanly"
             if ownerless and supervised:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8930,17 +8930,19 @@ def check_task_watcher() -> dict:
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "
                                   "it IS draining tasks/. Re-stamp the sentinel with --fix, or "
                                   "restart cleanly only when tasks/ is empty."}
-            # A supervised root is a healthy peer; telling an operator to stop it
-            # takes a live instance offline. Only ownerless roots are stoppable here.
-            act = (f"stop the ownerless one(s) first: {', '.join(ownerless)}"
-                   if ownerless else
-                   "do NOT stop any of them — each is supervised; reduce the count "
-                   "through the launcher that owns it")
+            # A root with a live parent is not orphaned and stopping it takes a
+            # healthy instance offline; only ownerless roots keep the stop remedy.
+            if ownerless:
+                lead = (f"{len(roots)} orphaned watcher(s) running with no PID sentinel "
+                        f"(pids {', '.join(roots)}) — draining tasks/ unsupervised; "
+                        f"stop them and restart one cleanly")
+            else:
+                lead = (f"{len(roots)} watcher(s) running with no PID sentinel "
+                        f"(pids {', '.join(roots)}) — each drains tasks/, so every task "
+                        f"is processed {len(roots)}x. Do NOT stop any of them: each is "
+                        f"supervised; reduce the count through the launcher that owns it")
             return {"name": name, "status": "warn",
-                    "detail": f"{len(roots)} watcher(s) running with no PID sentinel "
-                              f"(pids {', '.join(roots)}) — each drains tasks/, so every "
-                              f"task is processed {len(roots)}x. {act}. "
-                              f"ownerless: {', '.join(ownerless) or 'none'}; "
+                    "detail": f"{lead}. ownerless: {', '.join(ownerless) or 'none'}; "
                               f"supervised: {', '.join(supervised) or 'none'}"}
         return {"name": name, "status": "warn",
                 "detail": "watcher not running (no PID sentinel) — tasks/ will not be drained; "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8701,10 +8701,10 @@ def _is_watcher_argv(argv: str, pid: "int | None" = None) -> "bool | None":
         return False
     if parts[1].startswith("-"):
         return False
-    # The script always begins with parts[1] and any continuation is space-led,
-    # which the pattern's lookahead accepts -- so a hit here holds under any split.
+    # Authoritative only when argv ends at parts[1]: with more tokens the real
+    # pathname may continue past a space and end in a different name.
     if _WATCHER_SCRIPT.search(parts[1]) is not None:
-        return True
+        return True if len(parts) == 2 else None
     if len(parts) == 2:
         return False
     # Only a later token matches, and a spaced script path is the same string as a

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8954,7 +8954,7 @@ def check_task_watcher() -> dict:
                           "restart via Monitor: bash src/watch-tasks-stream.sh"}
     # Classify EVERY sentinel, because each names a different watcher. The
     # single-sentinel host takes exactly the branches it always did.
-    live, dead_pids, reused, unreadable = {}, [], [], []
+    live, dead_pids, reused, unreadable, unprovable = {}, [], [], [], []
     for sp in sentinels:
         try:
             spid = int(sp.read_text().strip())
@@ -8964,15 +8964,27 @@ def check_task_watcher() -> dict:
         sargv = _proc_argv(spid)
         if not sargv:
             dead_pids.append((spid, sp))
-        elif "watch-tasks-stream" not in sargv:
-            reused.append((spid, sargv, sp))
         else:
-            live[spid] = sp
+            # The module's own predicate, not a substring: a stranger carrying
+            # the script name as a DATA argument passes `in` and is counted live.
+            verdict = _is_watcher_argv(sargv, spid)
+            if verdict is False:
+                reused.append((spid, sargv, sp))
+            elif verdict is None:
+                unprovable.append((spid, sargv, sp))
+            else:
+                live[spid] = sp
 
     if not live:
         if unreadable and not dead_pids and not reused:
             return {"name": name, "status": "warn",
                     "detail": f"unreadable PID sentinel ({unreadable[0][1]}) — restart the watcher"}
+        if unprovable and not dead_pids and not reused:
+            upid, uargv, _usp = unprovable[0]
+            return {"name": name, "status": "warn",
+                    "detail": f"UNKNOWN: cannot prove pid {upid} is the watcher from its argv "
+                              f"({uargv[:50]}) — not restarting and not stopping it; "
+                              f"re-check when the process vector is readable"}
         if reused and not dead_pids:
             # PID reuse: the sentinel outlived the watcher and the OS handed the
             # number to something else. `kill -0` alone would call this alive.
@@ -8996,12 +9008,40 @@ def check_task_watcher() -> dict:
     tracked = {str(p) for p in live}
     extras = sorted(r for r, members in trees.items() if not (members & tracked))
     if extras:
+        # A root count is not an identity: only a shared sentinel target makes
+        # two roots duplicates, and an unresolvable one authorises nothing.
+        state_dir = WORKSPACE_DIR / "state"
+        tracked_targets = {str(sp) for sp in live.values()}
+        dupes, distinct, unknown = [], [], []
+        for r in extras:
+            target = _watcher_sentinel_target(state_dir, r)
+            if target is None:
+                unknown.append(r)
+            elif str(target) in tracked_targets:
+                dupes.append(r)
+            else:
+                distinct.append(r)
+        if unknown:
+            return {"name": name, "status": "warn",
+                    "detail": f"UNKNOWN: {len(unknown)} untracked watcher tree(s) "
+                              f"({', '.join(unknown)}) whose (agent, instance) identity does not "
+                              f"resolve — NOT stopping and NOT reducing: the same instruction "
+                              f"recreates a duplicate for one instance and removes the only "
+                              f"watcher for another. Resolve identity first"}
+        if distinct and not dupes:
+            return {"name": name, "status": "warn",
+                    "detail": f"{len(distinct)} watcher tree(s) ({', '.join(distinct)}) belong to a "
+                              f"DIFFERENT instance than any tracked sentinel — not duplicates; each "
+                              f"is missing its own sentinel record. Do NOT stop them; register "
+                              f"their sentinels"}
         keep = ", ".join(str(p) for p in sorted(live))
-        own, sup = _split_roots_by_owner(extras, ps_out)
+        own, sup = _split_roots_by_owner(dupes, ps_out)
+        extra_note = ("" if not distinct else
+                      f" ({len(distinct)} further tree(s) are a different instance, left alone)")
         return {"name": name, "status": "warn",
-                "detail": f"{len(trees)} watcher trees running — {len(extras)} not tracked by any "
-                          f"sentinel; duplicates process each task more than once. Keep the "
-                          f"tracked one(s) ({keep}). "
+                "detail": f"{len(trees)} watcher trees running — {len(dupes)} share a sentinel "
+                          f"target with a tracked watcher, so those duplicate its work{extra_note}. "
+                          f"Keep the tracked one(s) ({keep}). "
                           f"ownerless, safe to stop: {', '.join(own) or 'none'}; "
                           f"supervised, leave alone (a live parent owns them): "
                           f"{', '.join(sup) or 'none'}"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8782,6 +8782,19 @@ def _watcher_sentinel_target(state_dir, pid):
         return None
 
 
+def _group_roots_by_target(state_dir, roots):
+    """(target -> [pids], unresolvable pids). The ONE identity policy both the
+    sentinel-present and no-sentinel branches classify with."""
+    groups, unknown = {}, []
+    for r in roots:
+        target = _watcher_sentinel_target(state_dir, r)
+        if target is None:
+            unknown.append(r)
+        else:
+            groups.setdefault(str(target), []).append(r)
+    return groups, unknown
+
+
 def _ps_watcher_index(ps_output: str) -> tuple:
     """(watcher pid -> ppid, every pid in the snapshot) from ONE ps parse.
 
@@ -8930,11 +8943,26 @@ def check_task_watcher() -> dict:
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "
                                   "it IS draining tasks/. Re-stamp the sentinel with --fix, or "
                                   "restart cleanly only when tasks/ is empty."}
+            # Same identity policy as the tracked branch: without it, losing the
+            # last sentinel turns distinct instances back into "duplicates".
+            _groups, _unknown = _group_roots_by_target(WORKSPACE_DIR / "state", roots)
+            if _unknown:
+                cost = (f"{len(roots)} watcher(s) running with no PID sentinel "
+                        f"(pids {', '.join(roots)}); {len(_unknown)} "
+                        f"({', '.join(_unknown)}) have no resolvable (agent, instance), so "
+                        f"whether any task is processed twice is UNKNOWN — do not reduce the count")
+            elif len(_groups) == len(roots) and len(roots) > 1:
+                cost = (f"{len(roots)} watcher(s) with no PID sentinel (pids {', '.join(roots)}) "
+                        f"resolve to {len(_groups)} DISTINCT instances — not duplicates, and no "
+                        f"task is processed twice; do not reduce the count")
+            else:
+                _n = max((len(v) for v in _groups.values()), default=len(roots))
+                cost = (f"{len(roots)} watcher(s) running with no PID sentinel "
+                        f"(pids {', '.join(roots)}) — {_n} share one instance target, so its "
+                        f"tasks are processed {_n}x")
+            count = cost
             # Stop advice is scoped to the ownerless subset: a root with a live
             # parent is supervised, and stopping it takes a healthy peer offline.
-            count = (f"{len(roots)} watcher(s) running with no PID sentinel "
-                     f"(pids {', '.join(roots)}) — each drains tasks/, so every task "
-                     f"is processed {len(roots)}x")
             if ownerless and supervised:
                 lead = (f"{count}. Stop ONLY the ownerless ({', '.join(ownerless)}) and restart "
                         f"one cleanly. Do NOT stop {', '.join(supervised)} — supervised; "
@@ -8943,6 +8971,8 @@ def check_task_watcher() -> dict:
                 lead = (f"{len(ownerless)} orphaned watcher(s) running with no PID sentinel "
                         f"(pids {', '.join(ownerless)}) — draining tasks/ unsupervised; "
                         f"stop them and restart one cleanly")
+            elif _unknown or len(_groups) == len(roots):
+                lead = f"{count}. Do NOT stop any of them: each is supervised"
             else:
                 lead = (f"{count}. Do NOT stop any of them: each is supervised; "
                         f"reduce the count through the launcher that owns it")
@@ -9012,15 +9042,9 @@ def check_task_watcher() -> dict:
         # two roots duplicates, and an unresolvable one authorises nothing.
         state_dir = WORKSPACE_DIR / "state"
         tracked_targets = {str(sp) for sp in live.values()}
-        dupes, distinct, unknown = [], [], []
-        for r in extras:
-            target = _watcher_sentinel_target(state_dir, r)
-            if target is None:
-                unknown.append(r)
-            elif str(target) in tracked_targets:
-                dupes.append(r)
-            else:
-                distinct.append(r)
+        _groups, unknown = _group_roots_by_target(state_dir, extras)
+        dupes = [r for tgt, rs in _groups.items() if tgt in tracked_targets for r in rs]
+        distinct = [r for tgt, rs in _groups.items() if tgt not in tracked_targets for r in rs]
         if unknown:
             return {"name": name, "status": "warn",
                     "detail": f"UNKNOWN: {len(unknown)} untracked watcher tree(s) "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8966,15 +8966,28 @@ def check_task_watcher() -> dict:
             _sg, _su = _group_roots_by_target(WORKSPACE_DIR / "state", supervised)
             _sup_dupe = (not _su) and any(len(v) > 1 for v in _sg.values())
             _reduce = "; reduce those through the launcher that owns them" if _sup_dupe else ""
-            # Stop advice is scoped to the ownerless subset: a root with a live
-            # parent is supervised, and stopping it takes a healthy peer offline.
+            # Stop advice is scoped to the ownerless subset; parentage gives
+            # supervision, not target identity and not the restart count.
+            _og, _ou = _group_roots_by_target(WORKSPACE_DIR / "state", ownerless)
+            if _ou:
+                _stop = (f"Do NOT stop {', '.join(_ou)} — UNKNOWN identity: it may be the only "
+                         f"watcher for its instance")
+            elif _og and set(_og) <= set(_sg):
+                # Restarting after the stop is what recreates the duplicate: a
+                # supervised watcher already serves every one of these targets.
+                _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}) and do NOT restart — "
+                         f"a supervised watcher already serves that instance")
+            elif len(_og) > 1:
+                _stop = (f"Stop ONLY the ownerless ({', '.join(ownerless)}) and restart "
+                         f"{len(_og)} cleanly — one per instance, NOT one")
+            else:
+                _stop = f"Stop ONLY the ownerless ({', '.join(ownerless)}) and restart one cleanly"
             if ownerless and supervised:
-                lead = (f"{count}. Stop ONLY the ownerless ({', '.join(ownerless)}) and restart "
-                        f"one cleanly. Do NOT stop {', '.join(supervised)} — supervised{_reduce}")
+                lead = (f"{count}. {_stop}. Do NOT stop {', '.join(supervised)} "
+                        f"— supervised{_reduce}")
             elif ownerless:
                 lead = (f"{len(ownerless)} orphaned watcher(s) running with no PID sentinel "
-                        f"(pids {', '.join(ownerless)}) — draining tasks/ unsupervised; "
-                        f"stop them and restart one cleanly")
+                        f"(pids {', '.join(ownerless)}) — draining tasks/ unsupervised; {_stop}")
             else:
                 _r = _reduce.replace("reduce those through", "reduce the count through")
                 lead = f"{count}. Do NOT stop any of them: each is supervised{_r}"

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9056,22 +9056,25 @@ def check_task_watcher() -> dict:
                 live[spid] = sp
 
     if not live:
-        if unreadable and not dead_pids and not reused:
-            return {"name": name, "status": "warn",
-                    "detail": f"unreadable PID sentinel ({unreadable[0][1]}) — restart the watcher"}
-        if unprovable and not dead_pids and not reused:
+        # ONE aggregate over EVERY record class, built before any advice. A
+        # per-class early return drops the classes below it, and a dropped
+        # UNKNOWN becomes restart advice for the very watcher it could not
+        # identify.
+        notes = []
+        if unreadable:
+            notes.append(f"unreadable PID sentinel ({unreadable[0][1]})")
+        if unprovable:
             upid, uargv, _usp = unprovable[0]
-            return {"name": name, "status": "warn",
-                    "detail": f"UNKNOWN: cannot prove pid {upid} is the watcher from its argv "
-                              f"({uargv[:50]}) — not restarting and not stopping it; "
-                              f"re-check when the process vector is readable"}
-        if reused and not dead_pids:
-            # PID reuse: the sentinel outlived the watcher and the OS handed the
-            # number to something else. `kill -0` alone would call this alive.
+            notes.append(f"UNKNOWN: cannot prove pid {upid} is the watcher from its argv "
+                         f"({uargv[:50]})")
+        if reused:
             rpid, rargv, _rsp = reused[0]
-            return {"name": name, "status": "warn",
-                    "detail": f"pid {rpid} is not the watcher (PID reuse): {rargv[:60]}"}
+            notes.append(f"pid {rpid} is not the watcher (PID reuse): {rargv[:60]}")
+        # An identity we cannot prove vetoes BOTH directions: a restart may
+        # duplicate the live watcher behind it, a stop may kill it.
+        veto = bool(unprovable)
         pid = dead_pids[0][0] if dead_pids else 0
+
         if roots:
             # A dead sentinel does NOT mean nothing drains tasks/ — restarting
             # here is what makes the duplicates.
@@ -9087,14 +9090,33 @@ def check_task_watcher() -> dict:
                 f"; UNKNOWN identity, do NOT stop: {', '.join(_du)}" if _du else "",
                 (f"; do NOT stop {', '.join(_sole)} — the only watcher for that instance, "
                  f"and its sentinel is already dead") if _sole else ""])
+            _lead = ("; ".join(notes) + "; ") if notes else ""
+            _lead += (f"sentinel pid {pid} is dead but " if dead_pids
+                      else "no live sentinel but ")
+            _stop = ("no stop advice while a sentinel identity is unprovable" if veto
+                     else f"ownerless, safe to stop: {', '.join(own) or 'none'}")
             return {"name": name, "status": "warn",
-                    "detail": f"sentinel pid {pid} is dead but {len(roots)} watcher(s) still "
+                    "detail": f"{_lead}{len(roots)} watcher(s) still "
                               f"run; tasks/ IS being drained{_blind}. "
-                              f"ownerless, safe to stop: {', '.join(own) or 'none'}; "
+                              f"{_stop}; "
                               f"supervised, leave alone (a live parent owns them): "
                               f"{', '.join(sup) or 'none'}"}
+
+        if not notes and dead_pids:
+            return {"name": name, "status": "warn",
+                    "detail": f"watcher pid {pid} is dead (crashed — sentinel left behind); "
+                              f"restart it"}
+        if dead_pids:
+            notes.append(f"sentinel pid {pid} is dead (crashed — sentinel left behind)")
+        if veto:
+            advice = ("not restarting and not stopping it; re-check when the process "
+                      "vector is readable")
+        elif unreadable or dead_pids:
+            advice = "restart the watcher"
+        else:
+            advice = ""
         return {"name": name, "status": "warn",
-                "detail": f"watcher pid {pid} is dead (crashed — sentinel left behind); restart it"}
+                "detail": "; ".join(notes) + (f" — {advice}" if advice else "")}
 
     faults = []
     if dead_pids:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9084,10 +9084,8 @@ def check_task_watcher() -> dict:
                 live[spid] = sp
 
     if not live:
-        # ONE aggregate over EVERY record class, built before any advice. A
-        # per-class early return drops the classes below it, and a dropped
-        # UNKNOWN becomes restart advice for the very watcher it could not
-        # identify.
+        # Aggregate EVERY record class before advising: a per-class early
+        # return turns a dropped UNKNOWN into restart advice.
         notes = []
         if unreadable:
             notes.append(f"unreadable PID sentinel ({unreadable[0][1]})")

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9000,6 +9000,7 @@ def check_task_watcher() -> dict:
     # Classify EVERY sentinel, because each names a different watcher. The
     # single-sentinel host takes exactly the branches it always did.
     live, dead_pids, reused, unreadable, unprovable = {}, [], [], [], []
+    collided = []
     for sp in sentinels:
         try:
             spid = int(sp.read_text().strip())
@@ -9018,6 +9019,10 @@ def check_task_watcher() -> dict:
             elif verdict is None:
                 unprovable.append((spid, sargv, sp))
             else:
+                # A dict keyed by pid DROPS the second file naming one pid, and
+                # two sentinels for one process is a real anomaly, not a tie.
+                if spid in live:
+                    collided.append((spid, live[spid], sp))
                 live[spid] = sp
 
     if not live:
@@ -9041,9 +9046,13 @@ def check_task_watcher() -> dict:
             # A dead sentinel does NOT mean nothing drains tasks/ — restarting
             # here is what makes the duplicates.
             own, sup = _split_roots_by_owner(roots, ps_out)
+            _dg, _du = _group_roots_by_target(WORKSPACE_DIR / "state", own)
+            if _du:
+                own = [o for o in own if o not in _du]
+            _blind = (f"; UNKNOWN identity, do NOT stop: {', '.join(_du)}" if _du else "")
             return {"name": name, "status": "warn",
                     "detail": f"sentinel pid {pid} is dead but {len(roots)} watcher(s) still "
-                              f"run; tasks/ IS being drained. "
+                              f"run; tasks/ IS being drained{_blind}. "
                               f"ownerless, safe to stop: {', '.join(own) or 'none'}; "
                               f"supervised, leave alone (a live parent owns them): "
                               f"{', '.join(sup) or 'none'}"}
@@ -9097,11 +9106,18 @@ def check_task_watcher() -> dict:
     if unreadable:
         faults.append("unreadable: " + ", ".join(
             f"{sp.name} ({err})" for sp, err in unreadable))
+    if unprovable:
+        faults.append("UNKNOWN: " + ", ".join(
+            f"{sp.name} (pid {spid} unprovable from argv)" for spid, _a, sp in unprovable))
+    if collided:
+        faults.append("one pid, two sentinels: " + ", ".join(
+            f"{a.name} and {b.name} both name pid {spid}" for spid, a, b in collided))
     if faults:
         return {"name": name, "status": "warn",
                 "detail": f"{len(live)} watcher(s) alive (pids {alive}), but "
-                          f"{len(dead_pids) + len(reused) + len(unreadable)} sentinel(s) name no "
-                          f"live watcher — {'; '.join(faults)}. Each is a separate instance's "
+                          f"{len(dead_pids) + len(reused) + len(unreadable) + len(unprovable) + len(collided)} "
+                          f"sentinel(s) name no provable live watcher — {'; '.join(faults)}. "
+                          f"Each is a separate instance's "
                           "record; a live peer does not clear it"}
     if len(live) == 1:
         return {"name": name, "status": "ok", "detail": f"streaming watcher alive (pid {alive})"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8961,21 +8961,23 @@ def check_task_watcher() -> dict:
                         f"(pids {', '.join(roots)}) — {_n} share one instance target, so its "
                         f"tasks are processed {_n}x")
             count = cost
+            # Reduction is advice about the SUPERVISED subset, so it is that
+            # subset's identity that licenses it -- never the whole root count.
+            _sg, _su = _group_roots_by_target(WORKSPACE_DIR / "state", supervised)
+            _sup_dupe = (not _su) and any(len(v) > 1 for v in _sg.values())
+            _reduce = "; reduce those through the launcher that owns them" if _sup_dupe else ""
             # Stop advice is scoped to the ownerless subset: a root with a live
             # parent is supervised, and stopping it takes a healthy peer offline.
             if ownerless and supervised:
                 lead = (f"{count}. Stop ONLY the ownerless ({', '.join(ownerless)}) and restart "
-                        f"one cleanly. Do NOT stop {', '.join(supervised)} — supervised; "
-                        f"reduce those through the launcher that owns them")
+                        f"one cleanly. Do NOT stop {', '.join(supervised)} — supervised{_reduce}")
             elif ownerless:
                 lead = (f"{len(ownerless)} orphaned watcher(s) running with no PID sentinel "
                         f"(pids {', '.join(ownerless)}) — draining tasks/ unsupervised; "
                         f"stop them and restart one cleanly")
-            elif _unknown or len(_groups) == len(roots):
-                lead = f"{count}. Do NOT stop any of them: each is supervised"
             else:
-                lead = (f"{count}. Do NOT stop any of them: each is supervised; "
-                        f"reduce the count through the launcher that owns it")
+                _r = _reduce.replace("reduce those through", "reduce the count through")
+                lead = f"{count}. Do NOT stop any of them: each is supervised{_r}"
             return {"name": name, "status": "warn",
                     "detail": f"{lead}. ownerless: {', '.join(ownerless) or 'none'}; "
                               f"supervised: {', '.join(supervised) or 'none'}"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9115,11 +9115,17 @@ def check_task_watcher() -> dict:
     # A sentinel fault must not be skipped by an earlier remediation return:
     # UNKNOWN or conflicting records veto destructive advice about extra trees.
     tracked = {str(p) for p in live}
-    if (unprovable or collided) and extras_present(trees, live):
+    # EVERY classified record, not just the unprovable ones: a dead, reused or
+    # unreadable sentinel vanished just as silently through the extras returns.
+    if faults and extras_present(trees, live):
+        _veto = ("no stop or restart is advised while a sentinel record is unprovable or "
+                 "conflicting — resolve the records first"
+                 if (unprovable or collided) else
+                 "these records name instances whose watcher state is already known-bad; "
+                 "resolve them before acting on the untracked tree(s)")
         return {"name": name, "status": "warn",
-                "detail": "; ".join(faults) + ". Untracked watcher tree(s) are "
-                          "present too, but no stop or restart is advised while a sentinel record "
-                          "is unprovable or conflicting — resolve the records first"}
+                "detail": "; ".join(faults) + f". Untracked watcher tree(s) are present too, but "
+                          f"{_veto}"}
     extras = sorted(r for r, members in trees.items() if not (members & tracked))
     if extras:
         # A root count is not an identity: only a shared sentinel target makes

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8930,15 +8930,18 @@ def check_task_watcher() -> dict:
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "
                                   "it IS draining tasks/. Re-stamp the sentinel with --fix, or "
                                   "restart cleanly only when tasks/ is empty."}
-            # Two roots process every task twice, so a live parent does not excuse
-            # a duplicate; the split says which to stop first, not which may stay.
+            # A supervised root is a healthy peer; telling an operator to stop it
+            # takes a live instance offline. Only ownerless roots are stoppable here.
+            act = (f"stop the ownerless one(s) first: {', '.join(ownerless)}"
+                   if ownerless else
+                   "do NOT stop any of them — each is supervised; reduce the count "
+                   "through the launcher that owns it")
             return {"name": name, "status": "warn",
-                    "detail": f"{len(roots)} orphaned watcher(s) running with no PID "
-                              f"sentinel (pids {', '.join(roots)}) — draining tasks/ "
-                              "unsupervised; stop them and restart one cleanly. "
-                              f"ownerless, stop these first: {', '.join(ownerless) or 'none'}; "
-                              f"supervised, stopping one needs its launcher: "
-                              f"{', '.join(supervised) or 'none'}"}
+                    "detail": f"{len(roots)} watcher(s) running with no PID sentinel "
+                              f"(pids {', '.join(roots)}) — each drains tasks/, so every "
+                              f"task is processed {len(roots)}x. {act}. "
+                              f"ownerless: {', '.join(ownerless) or 'none'}; "
+                              f"supervised: {', '.join(supervised) or 'none'}"}
         return {"name": name, "status": "warn",
                 "detail": "watcher not running (no PID sentinel) — tasks/ will not be drained; "
                           "restart via Monitor: bash src/watch-tasks-stream.sh"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8357,6 +8357,45 @@ def _pid_parent(pid: "str | int", ps_output: "str | None" = None) -> "str | None
     return None
 
 
+def _proc_argv_vector(pid: int) -> "list[str] | None":
+    """Real argv of `pid` as a LIST, or None when no authoritative read exists.
+
+    A flattened argv cannot separate an operand containing a space from two
+    operands, so the executed script is not recoverable from it by any rule.
+    """
+    try:  # linux: NUL-delimited, authoritative
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+        if raw:
+            return [a for a in raw.decode("utf8", "replace").split("\0") if a]
+    except Exception:  # noqa: BLE001 -- not linux, or gone
+        pass
+    try:  # darwin: KERN_PROCARGS2 carries argc then the real argv strings
+        import ctypes
+        import ctypes.util
+        libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+        mib = (ctypes.c_int * 3)(1, 49, int(pid))  # CTL_KERN, KERN_PROCARGS2
+        size = ctypes.c_size_t(262144)
+        buf = ctypes.create_string_buffer(size.value)
+        if libc.sysctl(mib, 3, buf, ctypes.byref(size), None, 0) != 0:
+            return None
+        data = buf.raw[:size.value]
+        argc = int.from_bytes(data[:4], sys.byteorder)
+        parts = data[4:].split(b"\0")
+        i = 0
+        while i < len(parts) and parts[i] == b"":
+            i += 1
+        i += 1                                   # the exec path
+        while i < len(parts) and parts[i] == b"":
+            i += 1
+        out = []
+        while i < len(parts) and len(out) < argc:
+            out.append(parts[i].decode("utf8", "replace"))
+            i += 1
+        return out or None
+    except Exception:  # noqa: BLE001 -- probe failure must not fail the check
+        return None
+
+
 def _proc_argv(pid: int) -> str:
     """argv of `pid`, or "" if no such process.
 
@@ -8458,28 +8497,43 @@ _WATCHER_SHELLS = ("sh", "bash", "zsh", "ksh")
 _WATCHER_SCRIPT = re.compile(r"(?:^|[\s/])watch-tasks-stream\.sh(?=\s|$)")
 
 
-def _is_watcher_argv(argv: str) -> bool:
-    """True for `<shell> <path>/watch-tasks-stream.sh [tasks-dir]`.
+def _as_pid(tok: str) -> "int | None":
+    try:
+        return int(tok)
+    except (TypeError, ValueError):
+        return None
 
-    A field COUNT cannot decide this: the notifier execs the script WITH a tasks
-    directory, and an install path containing a space splits into more tokens
-    again -- both real shapes, both previously read as "not a watcher".
+
+def _is_watcher_argv(argv: str, pid: "int | None" = None) -> "bool | None":
+    """True/False from the EXECUTED script; None when nothing can prove it.
+
+    Callers disagree on what None should mean, which is why this is tri-state:
+    over-counting a watcher costs delayed tasks, publishing a wrong pid costs a
+    killed stranger.
     """
+    vec = _proc_argv_vector(pid) if pid is not None else None
+    if vec is not None and len(vec) >= 2:
+        if vec[0].rsplit("/", 1)[-1] not in _WATCHER_SHELLS:
+            return False
+        if vec[1].startswith("-"):
+            return False
+        return _WATCHER_SCRIPT.search(vec[1]) is not None
     parts = argv.split()
     if len(parts) < 2:
         return False
     if parts[0].rsplit("/", 1)[-1] not in _WATCHER_SHELLS:
         return False
-    # `<shell> -c ...` is a wrapper running something that merely mentions the
-    # script -- the self-match this predicate exists to exclude.
     if parts[1].startswith("-"):
         return False
-    # Bind to the EXECUTED script: the first `.sh` token. Searching all of argv
-    # matched a different script handed the watcher's path as data.
-    for tok in parts[1:]:
-        if tok.endswith(".sh"):
-            return _WATCHER_SCRIPT.search(tok) is not None
-    return False
+    # The script always begins with parts[1] and any continuation is space-led,
+    # which the pattern's lookahead accepts -- so a hit here holds under any split.
+    if _WATCHER_SCRIPT.search(parts[1]) is not None:
+        return True
+    if len(parts) == 2:
+        return False
+    # Only a later token matches, and a spaced script path is the same string as a
+    # script plus arguments -- nothing here can decide between them.
+    return None if _WATCHER_SCRIPT.search(argv) else False
 
 
 # Read from the module that defines the precedence; a copy here is how this
@@ -8578,7 +8632,9 @@ def _watcher_trees(ps_output: "str | None" = None) -> dict:
         parts = line.split(None, 2)
         if len(parts) < 3 or parts[0] == me:
             continue
-        if not _is_watcher_argv(parts[2]):
+        # None is UNKNOWN: count it, because a missed watcher starts a second
+        # one and every task is then processed twice.
+        if _is_watcher_argv(parts[2], _as_pid(parts[0])) is False:
             continue
         parent[parts[0]] = parts[1]
     trees: dict = {}
@@ -9039,7 +9095,7 @@ def fix_task_watcher_sentinel(check: dict) -> str:
     pid_file = Path(target)
     # Re-measure before writing: the check ran earlier, and this file is what
     # the Stop hook kills.
-    if not _is_watcher_argv(_proc_argv(int(pid))):
+    if _is_watcher_argv(_proc_argv(int(pid)), int(pid)) is not True:
         return f"pid {pid} is no longer the watcher — not re-stamped"
     try:
         # Separate try: mkdir raises FileExistsError when state/ is a plain
@@ -9058,7 +9114,7 @@ def fix_task_watcher_sentinel(check: dict) -> str:
         return f"could not write {pid_file}: {e}"
     # The probe above was a snapshot taken BEFORE publication; retract our own
     # stamp if it went stale mid-write.
-    if not _is_watcher_argv(_proc_argv(int(pid))):
+    if _is_watcher_argv(_proc_argv(int(pid)), int(pid)) is not True:
         try:
             # Read-then-unlink, NOT arbitrated the way the write above is:
             # POSIX has no conditional unlink, so a claim landing here is lost.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8463,6 +8463,50 @@ def _is_watcher_argv(argv: str) -> bool:
             and script.endswith("watch-tasks-stream.sh"))
 
 
+def _pid_instance_id(pid: str):
+    """`SUTANDO_INSTANCE_ID` from THAT process's environment, or None if unreadable.
+
+    Tri-state on purpose: None is "cannot read", never "default" -- naming a
+    sentinel from THIS process's env is how a named watcher gets the canonical file.
+    """
+    try:
+        environ = Path(f"/proc/{pid}/environ").read_bytes()
+    except Exception:  # noqa: BLE001  -- not linux, or not permitted
+        try:
+            out = subprocess.run(["ps", "-Eww", "-p", str(pid), "-o", "command="],
+                                 capture_output=True, text=True, timeout=5)
+        except Exception:  # noqa: BLE001
+            return None
+        if out.returncode != 0 or not out.stdout.strip():
+            return None
+        # `ps -E` prints ARGV then the environment, so take the LAST match: a
+        # process whose own argv mentions the variable is otherwise misread.
+        toks = out.stdout.split()
+        hits = [k for k in toks if k.startswith("SUTANDO_INSTANCE_ID=")]
+        if hits:
+            return hits[-1].split("=", 1)[1]
+        # A miss means default ONLY if the environment was printed at all. Keying
+        # that on a SUTANDO_ prefix would be a correlated field, not the answer.
+        printed_env = any(re.match(r"^[A-Z_][A-Z0-9_]*=", k) for k in toks)
+        return "" if printed_env else None
+    for raw in environ.split(b"\0"):
+        if raw.startswith(b"SUTANDO_INSTANCE_ID="):
+            return raw.split(b"=", 1)[1].decode("utf-8", "replace")
+    return ""
+
+
+def _watcher_sentinel_target(state_dir, pid):
+    """The sentinel path for the watcher at `pid`, or None when its identity is
+    not authoritative. A guess here is published as a repair target."""
+    inst = _pid_instance_id(pid)
+    if inst is None:
+        return None
+    try:
+        return watcher_sentinel_path(state_dir, instance=(inst or None))
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _watcher_trees(ps_output: "str | None" = None) -> dict:
     """Map root PID -> set of PIDs for each distinct watcher TREE running.
 
@@ -8558,9 +8602,21 @@ def check_task_watcher() -> dict:
                 # no second tree to duplicate work. Killing it is what opens a gap.
                 # `--fix` re-stamps the sentinel instead: the pid is a live watcher,
                 # so naming it restores Stop-hook cleanup without the restart.
+                # The target comes from the WATCHER's identity, never this process's:
+                # the canonical path claims the wrong instance for a named watcher.
+                target = _watcher_sentinel_target(WORKSPACE_DIR / "state", roots[0])
+                if target is None:
+                    return {"name": name, "status": "warn",
+                            "_sentinel_restamp_pid": roots[0],
+                            "detail": f"watcher pid {roots[0]} runs under a live session "
+                                      f"(ppid {parents[roots[0]]}) but wrote no PID sentinel, "
+                                      "and its own SUTANDO_INSTANCE_ID is unreadable from here, "
+                                      "so the repair target cannot be named without guessing "
+                                      "which instance owns it. Do NOT stop it — it IS draining "
+                                      "tasks/. Restart it cleanly when tasks/ is empty."}
                 return {"name": name, "status": "warn",
                         "_sentinel_restamp_pid": roots[0],
-                        "_sentinel_restamp_path": str(pid_file),
+                        "_sentinel_restamp_path": str(target),
                         "detail": f"watcher pid {roots[0]} runs under a live session "
                                   f"(ppid {parents[roots[0]]}) but wrote no PID "
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8524,10 +8524,10 @@ def check_task_watcher() -> dict:
     as one that is always green.
     """
     name = "task-watcher"
-    # Newest-stamped of every instance's sentinel: on a pool host each watcher
-    # writes its own, and asking about one file answers about one watcher.
-    _sentinels = watcher_sentinel_paths(WORKSPACE_DIR / "state")
-    pid_file = _sentinels[0] if _sentinels else watcher_sentinel_path(WORKSPACE_DIR / "state")
+    # EVERY instance's sentinel: on a pool host each watcher writes its own, so
+    # a probe that reads one file classifies the other N-1 as untracked.
+    sentinels = watcher_sentinel_paths(WORKSPACE_DIR / "state")
+    pid_file = sentinels[0] if sentinels else watcher_sentinel_path(WORKSPACE_DIR / "state")
     # `_watcher_trees()` returns {} for BOTH a clean empty scan and a failed ps,
     # so take the snapshot here: None is unavailable, "" is genuinely empty.
     ps_out = _ps_snapshot()
@@ -8572,34 +8572,57 @@ def check_task_watcher() -> dict:
         return {"name": name, "status": "warn",
                 "detail": "watcher not running (no PID sentinel) — tasks/ will not be drained; "
                           "restart via Monitor: bash src/watch-tasks-stream.sh"}
-    try:
-        pid = int(pid_file.read_text().strip())
-    except Exception as e:  # noqa: BLE001
-        return {"name": name, "status": "warn",
-                "detail": f"unreadable PID sentinel ({str(e)[:40]}) — restart the watcher"}
-    argv = _proc_argv(pid)
-    if not argv:
+    # Classify EVERY sentinel, because each names a different watcher. The
+    # single-sentinel host takes exactly the branches it always did.
+    live, dead_pids, reused, unreadable = {}, [], [], []
+    for sp in sentinels:
+        try:
+            spid = int(sp.read_text().strip())
+        except Exception as e:  # noqa: BLE001
+            unreadable.append((sp, str(e)[:40]))
+            continue
+        sargv = _proc_argv(spid)
+        if not sargv:
+            dead_pids.append(spid)
+        elif "watch-tasks-stream" not in sargv:
+            reused.append((spid, sargv))
+        else:
+            live[spid] = sp
+
+    if not live:
+        if unreadable and not dead_pids and not reused:
+            return {"name": name, "status": "warn",
+                    "detail": f"unreadable PID sentinel ({unreadable[0][1]}) — restart the watcher"}
+        if reused and not dead_pids:
+            # PID reuse: the sentinel outlived the watcher and the OS handed the
+            # number to something else. `kill -0` alone would call this alive.
+            rpid, rargv = reused[0]
+            return {"name": name, "status": "warn",
+                    "detail": f"pid {rpid} is not the watcher (PID reuse): {rargv[:60]}"}
+        pid = dead_pids[0] if dead_pids else 0
         if roots:
-            # The sentinel tracks only the MOST RECENT start, so a dead one does
-            # NOT mean nothing drains tasks/ — restarting here makes duplicates.
+            # A dead sentinel does NOT mean nothing drains tasks/ — restarting
+            # here is what makes the duplicates.
             return {"name": name, "status": "warn",
                     "detail": f"sentinel pid {pid} is dead but {len(roots)} watcher(s) still run "
                               f"(pids {', '.join(roots)}) — orphaned, tasks/ IS being drained; "
                               "stop them and restart one cleanly"}
         return {"name": name, "status": "warn",
                 "detail": f"watcher pid {pid} is dead (crashed — sentinel left behind); restart it"}
-    if "watch-tasks-stream" not in argv:
-        # PID reuse: the sentinel outlived the watcher and the OS handed the
-        # number to something else. `kill -0` alone would call this alive.
-        return {"name": name, "status": "warn",
-                "detail": f"pid {pid} is not the watcher (PID reuse): {argv[:60]}"}
-    extras = sorted(r for r, members in trees.items() if str(pid) not in members)
+
+    tracked = {str(p) for p in live}
+    extras = sorted(r for r, members in trees.items() if not (members & tracked))
     if extras:
+        keep = ", ".join(str(p) for p in sorted(live))
         return {"name": name, "status": "warn",
-                "detail": f"{len(trees)} watcher trees running — {len(extras)} not tracked by the "
+                "detail": f"{len(trees)} watcher trees running — {len(extras)} not tracked by any "
                           f"sentinel (root pids {', '.join(extras)}); duplicates process each task "
-                          f"more than once. Keep the sentinel's ({pid}), stop the rest"}
-    return {"name": name, "status": "ok", "detail": f"streaming watcher alive (pid {pid})"}
+                          f"more than once. Keep the tracked one(s) ({keep}), stop the rest"}
+    alive = ", ".join(str(p) for p in sorted(live))
+    if len(live) == 1:
+        return {"name": name, "status": "ok", "detail": f"streaming watcher alive (pid {alive})"}
+    return {"name": name, "status": "ok",
+            "detail": f"{len(live)} streaming watchers alive, one per instance (pids {alive})"}
 
 
 #: Track session-worker.py's own SUTANDO_TIER_HARD_TIMEOUT (default 900s,

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8474,7 +8474,12 @@ def _is_watcher_argv(argv: str) -> bool:
     # script -- the self-match this predicate exists to exclude.
     if parts[1].startswith("-"):
         return False
-    return _WATCHER_SCRIPT.search(argv) is not None
+    # Bind to the EXECUTED script: the first `.sh` token. Searching all of argv
+    # matched a different script handed the watcher's path as data.
+    for tok in parts[1:]:
+        if tok.endswith(".sh"):
+            return _WATCHER_SCRIPT.search(tok) is not None
+    return False
 
 
 # Read from the module that defines the precedence; a copy here is how this

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -57,7 +57,7 @@ from git_binary import git_argv  # noqa: E402
 from git_binary import GitUnavailable  # noqa: E402
 from git_binary import developer_tools_installed  # noqa: E402
 from channel_token import token_from_vault  # noqa: E402
-from util_paths import _host_label, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, shared_personal_path, watcher_sentinel_path, watcher_sentinel_paths  # noqa: E402
+from util_paths import _host_label, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, shared_personal_path, stated_default_identity, watcher_sentinel_path, watcher_sentinel_paths  # noqa: E402
 import slack_access  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 from workspace_layout import inspect_layout  # noqa: E402
@@ -8463,8 +8463,13 @@ def _is_watcher_argv(argv: str) -> bool:
             and script.endswith("watch-tasks-stream.sh"))
 
 
-def _pid_instance_id(pid: str):
-    """`SUTANDO_INSTANCE_ID` from THAT process's environment, or None if unreadable.
+# The actor half, in `rundir.agent_id`'s precedence order. First NON-EMPTY wins
+# there, so an empty earlier name must fall through exactly as `or` does.
+_ACTOR_ENV_NAMES = ("SUTANDO_AGENT_ID", "AGENT_MXID", "AGENT_ID")
+
+
+def _pid_env_first(pid: str, names):
+    """First of `names` set in THAT process's environment, "" if it states none.
 
     Tri-state on purpose: None is "cannot read", never "default" -- naming a
     sentinel from THIS process's env is how a named watcher gets the canonical file.
@@ -8482,27 +8487,51 @@ def _pid_instance_id(pid: str):
         # `ps -E` prints ARGV then the environment, so take the LAST match: a
         # process whose own argv mentions the variable is otherwise misread.
         toks = out.stdout.split()
-        hits = [k for k in toks if k.startswith("SUTANDO_INSTANCE_ID=")]
-        if hits:
-            return hits[-1].split("=", 1)[1]
+        for name in names:
+            hits = [k for k in toks if k.startswith(f"{name}=")]
+            if hits and hits[-1].split("=", 1)[1]:
+                return hits[-1].split("=", 1)[1]
         # A miss means default ONLY if the environment was printed at all. Keying
         # that on a SUTANDO_ prefix would be a correlated field, not the answer.
         printed_env = any(re.match(r"^[A-Z_][A-Z0-9_]*=", k) for k in toks)
         return "" if printed_env else None
+    seen = {}
     for raw in environ.split(b"\0"):
-        if raw.startswith(b"SUTANDO_INSTANCE_ID="):
-            return raw.split(b"=", 1)[1].decode("utf-8", "replace")
+        for name in names:
+            prefix = name.encode() + b"="
+            if raw.startswith(prefix):
+                seen.setdefault(name, raw.split(b"=", 1)[1].decode("utf-8", "replace"))
+    for name in names:
+        if seen.get(name):
+            return seen[name]
     return ""
+
+
+def _pid_instance_id(pid: str):
+    """The instance half from THAT process's environment. See `_pid_env_first`."""
+    return _pid_env_first(pid, ("SUTANDO_INSTANCE_ID",))
+
+
+def _pid_actor_id(pid: str):
+    """The actor half from THAT process's environment. See `_pid_env_first`."""
+    return _pid_env_first(pid, _ACTOR_ENV_NAMES)
 
 
 def _watcher_sentinel_target(state_dir, pid):
     """The sentinel path for the watcher at `pid`, or None when its identity is
     not authoritative. A guess here is published as a repair target."""
     inst = _pid_instance_id(pid)
-    if inst is None:
+    actor = _pid_actor_id(pid)
+    if inst is None or actor is None:
         return None
     try:
-        return watcher_sentinel_path(state_dir, instance=(inst or None))
+        # BOTH halves explicitly. None means "resolve from the caller", and the
+        # caller here is health-check -- a different actor than the watcher.
+        defaults = stated_default_identity(state_dir)
+        if defaults is None:
+            return None
+        return watcher_sentinel_path(state_dir, instance=(inst or defaults[0]),
+                                     agent=(actor or defaults[1]))
     except Exception:  # noqa: BLE001
         return None
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -57,7 +57,7 @@ from git_binary import git_argv  # noqa: E402
 from git_binary import GitUnavailable  # noqa: E402
 from git_binary import developer_tools_installed  # noqa: E402
 from channel_token import token_from_vault  # noqa: E402
-from util_paths import _host_label, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, shared_personal_path  # noqa: E402
+from util_paths import _host_label, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, shared_personal_path, watcher_sentinel_path, watcher_sentinel_paths  # noqa: E402
 import slack_access  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 from workspace_layout import inspect_layout  # noqa: E402
@@ -8524,7 +8524,10 @@ def check_task_watcher() -> dict:
     as one that is always green.
     """
     name = "task-watcher"
-    pid_file = WORKSPACE_DIR / "state" / "watch-tasks-stream.pid"
+    # Newest-stamped of every instance's sentinel: on a pool host each watcher
+    # writes its own, and asking about one file answers about one watcher.
+    _sentinels = watcher_sentinel_paths(WORKSPACE_DIR / "state")
+    pid_file = _sentinels[0] if _sentinels else watcher_sentinel_path(WORKSPACE_DIR / "state")
     # `_watcher_trees()` returns {} for BOTH a clean empty scan and a failed ps,
     # so take the snapshot here: None is unavailable, "" is genuinely empty.
     ps_out = _ps_snapshot()
@@ -8885,7 +8888,7 @@ def fix_task_watcher_sentinel(check: dict) -> str:
     pid = str(check.get("_sentinel_restamp_pid") or "")
     if not pid.isdigit():
         return "no re-stampable watcher pid"
-    pid_file = WORKSPACE_DIR / "state" / "watch-tasks-stream.pid"
+    pid_file = watcher_sentinel_path(WORKSPACE_DIR / "state")
     # Re-measure before writing: the check ran earlier, and this file is what
     # the Stop hook kills.
     if not _is_watcher_argv(_proc_argv(int(pid))):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8560,6 +8560,7 @@ def check_task_watcher() -> dict:
                 # so naming it restores Stop-hook cleanup without the restart.
                 return {"name": name, "status": "warn",
                         "_sentinel_restamp_pid": roots[0],
+                        "_sentinel_restamp_path": str(pid_file),
                         "detail": f"watcher pid {roots[0]} runs under a live session "
                                   f"(ppid {parents[roots[0]]}) but wrote no PID "
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "
@@ -8583,9 +8584,9 @@ def check_task_watcher() -> dict:
             continue
         sargv = _proc_argv(spid)
         if not sargv:
-            dead_pids.append(spid)
+            dead_pids.append((spid, sp))
         elif "watch-tasks-stream" not in sargv:
-            reused.append((spid, sargv))
+            reused.append((spid, sargv, sp))
         else:
             live[spid] = sp
 
@@ -8596,10 +8597,10 @@ def check_task_watcher() -> dict:
         if reused and not dead_pids:
             # PID reuse: the sentinel outlived the watcher and the OS handed the
             # number to something else. `kill -0` alone would call this alive.
-            rpid, rargv = reused[0]
+            rpid, rargv, _rsp = reused[0]
             return {"name": name, "status": "warn",
                     "detail": f"pid {rpid} is not the watcher (PID reuse): {rargv[:60]}"}
-        pid = dead_pids[0] if dead_pids else 0
+        pid = dead_pids[0][0] if dead_pids else 0
         if roots:
             # A dead sentinel does NOT mean nothing drains tasks/ — restarting
             # here is what makes the duplicates.
@@ -8619,6 +8620,24 @@ def check_task_watcher() -> dict:
                           f"sentinel (root pids {', '.join(extras)}); duplicates process each task "
                           f"more than once. Keep the tracked one(s) ({keep}), stop the rest"}
     alive = ", ".join(str(p) for p in sorted(live))
+    # An anomaly belongs to the instance whose sentinel carries it, so a live
+    # PEER is not evidence about a crashed one and must not discard its record.
+    faults = []
+    if dead_pids:
+        faults.append("crashed: " + ", ".join(
+            f"{sp.name} (pid {spid} dead)" for spid, sp in dead_pids))
+    if reused:
+        faults.append("PID reuse: " + ", ".join(
+            f"{sp.name} (pid {spid} is {sargv[:32]})" for spid, sargv, sp in reused))
+    if unreadable:
+        faults.append("unreadable: " + ", ".join(
+            f"{sp.name} ({err})" for sp, err in unreadable))
+    if faults:
+        return {"name": name, "status": "warn",
+                "detail": f"{len(live)} watcher(s) alive (pids {alive}), but "
+                          f"{len(dead_pids) + len(reused) + len(unreadable)} sentinel(s) name no "
+                          f"live watcher — {'; '.join(faults)}. Each is a separate instance's "
+                          "record; a live peer does not clear it"}
     if len(live) == 1:
         return {"name": name, "status": "ok", "detail": f"streaming watcher alive (pid {alive})"}
     return {"name": name, "status": "ok",
@@ -8911,7 +8930,12 @@ def fix_task_watcher_sentinel(check: dict) -> str:
     pid = str(check.get("_sentinel_restamp_pid") or "")
     if not pid.isdigit():
         return "no re-stampable watcher pid"
-    pid_file = watcher_sentinel_path(WORKSPACE_DIR / "state")
+    # The CHECK's path, not this process's ambient one: the two resolve from the
+    # environment and a repair that re-derives it can stamp another instance.
+    target = check.get("_sentinel_restamp_path")
+    if not target:
+        return "check named no sentinel path — not re-stamped"
+    pid_file = Path(target)
     # Re-measure before writing: the check ran earlier, and this file is what
     # the Stop hook kills.
     if not _is_watcher_argv(_proc_argv(int(pid))):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8754,13 +8754,14 @@ def check_task_watcher() -> dict:
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "
                                   "it IS draining tasks/. Re-stamp the sentinel with --fix, or "
                                   "restart cleanly only when tasks/ is empty."}
-            # Parentage was computed above and, before this, used only when there
-            # was exactly one root -- so every multi-root set was called orphaned.
+            # Two roots process every task twice, so a live parent does not excuse
+            # a duplicate; the split says which to stop first, not which may stay.
             return {"name": name, "status": "warn",
-                    "detail": f"{len(roots)} watcher(s) running with no PID sentinel, "
-                              f"draining tasks/. "
-                              f"ownerless, safe to stop: {', '.join(ownerless) or 'none'}; "
-                              f"supervised, leave alone (a live parent owns them): "
+                    "detail": f"{len(roots)} orphaned watcher(s) running with no PID "
+                              f"sentinel (pids {', '.join(roots)}) — draining tasks/ "
+                              "unsupervised; stop them and restart one cleanly. "
+                              f"ownerless, stop these first: {', '.join(ownerless) or 'none'}; "
+                              f"supervised, stopping one needs its launcher: "
                               f"{', '.join(supervised) or 'none'}"}
         return {"name": name, "status": "warn",
                 "detail": "watcher not running (no PID sentinel) — tasks/ will not be drained; "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8453,14 +8453,28 @@ def check_stale_proactive_backlog(threshold_age_sec: int = 3600,
 _WATCHER_SHELLS = ("sh", "bash", "zsh", "ksh")
 
 
+# The script named as a whole final path component, so `x-watch-tasks-stream.sh`
+# and a mention inside a longer word cannot match.
+_WATCHER_SCRIPT = re.compile(r"(?:^|[\s/])watch-tasks-stream\.sh(?=\s|$)")
+
+
 def _is_watcher_argv(argv: str) -> bool:
-    """True only for `<shell> <path>/watch-tasks-stream.sh` and nothing more."""
+    """True for `<shell> <path>/watch-tasks-stream.sh [tasks-dir]`.
+
+    A field COUNT cannot decide this: the notifier execs the script WITH a tasks
+    directory, and an install path containing a space splits into more tokens
+    again -- both real shapes, both previously read as "not a watcher".
+    """
     parts = argv.split()
-    if len(parts) != 2:
+    if len(parts) < 2:
         return False
-    exe, script = parts
-    return (exe.rsplit("/", 1)[-1] in _WATCHER_SHELLS
-            and script.endswith("watch-tasks-stream.sh"))
+    if parts[0].rsplit("/", 1)[-1] not in _WATCHER_SHELLS:
+        return False
+    # `<shell> -c ...` is a wrapper running something that merely mentions the
+    # script -- the self-match this predicate exists to exclude.
+    if parts[1].startswith("-"):
+        return False
+    return _WATCHER_SCRIPT.search(argv) is not None
 
 
 # Read from the module that defines the precedence; a copy here is how this

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -57,7 +57,7 @@ from git_binary import git_argv  # noqa: E402
 from git_binary import GitUnavailable  # noqa: E402
 from git_binary import developer_tools_installed  # noqa: E402
 from channel_token import token_from_vault  # noqa: E402
-from util_paths import _host_label, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, shared_personal_path, stated_default_identity, watcher_sentinel_path, watcher_sentinel_paths  # noqa: E402
+from util_paths import _host_label, actor_env_names, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, shared_personal_path, stated_default_identity, watcher_sentinel_path, watcher_sentinel_paths  # noqa: E402
 import slack_access  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 from workspace_layout import inspect_layout  # noqa: E402
@@ -8463,9 +8463,8 @@ def _is_watcher_argv(argv: str) -> bool:
             and script.endswith("watch-tasks-stream.sh"))
 
 
-# The actor half, in `rundir.agent_id`'s precedence order. First NON-EMPTY wins
-# there, so an empty earlier name must fall through exactly as `or` does.
-_ACTOR_ENV_NAMES = ("SUTANDO_AGENT_ID", "AGENT_MXID", "AGENT_ID")
+# Read from the module that defines the precedence; a copy here is how this
+# reader and `rundir.agent_id` come to disagree about the same process.
 
 
 def _pid_env_first(pid: str, names):
@@ -8484,17 +8483,15 @@ def _pid_env_first(pid: str, names):
             return None
         if out.returncode != 0 or not out.stdout.strip():
             return None
-        # `ps -E` prints ARGV then the environment, so take the LAST match: a
-        # process whose own argv mentions the variable is otherwise misread.
+        # `ps` concatenates argv and env with spaces, so a value containing one is
+        # UNRECOVERABLE: `worker 7` reads back as `worker`, a different sentinel.
         toks = out.stdout.split()
-        for name in names:
-            hits = [k for k in toks if k.startswith(f"{name}=")]
-            if hits and hits[-1].split("=", 1)[1]:
-                return hits[-1].split("=", 1)[1]
-        # A miss means default ONLY if the environment was printed at all. Keying
-        # that on a SUTANDO_ prefix would be a correlated field, not the answer.
         printed_env = any(re.match(r"^[A-Z_][A-Z0-9_]*=", k) for k in toks)
-        return "" if printed_env else None
+        if not printed_env:
+            return None
+        if any(k.startswith(f"{name}=") for name in names for k in toks):
+            return None                               # present but not recoverable
+        return ""                                     # printed, and states none
     seen = {}
     for raw in environ.split(b"\0"):
         for name in names:
@@ -8514,7 +8511,7 @@ def _pid_instance_id(pid: str):
 
 def _pid_actor_id(pid: str):
     """The actor half from THAT process's environment. See `_pid_env_first`."""
-    return _pid_env_first(pid, _ACTOR_ENV_NAMES)
+    return _pid_env_first(pid, actor_env_names())
 
 
 def _watcher_sentinel_target(state_dir, pid):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8606,6 +8606,47 @@ def _watcher_sentinel_target(state_dir, pid):
         return None
 
 
+def _ps_watcher_index(ps_output: str) -> tuple:
+    """(watcher pid -> ppid, every pid in the snapshot) from ONE ps parse.
+
+    Both the tree walk and the ownership split need this; two parses could
+    disagree about a process that exited between them.
+    """
+    me = str(os.getpid())
+    parent: dict = {}
+    live: set = set()
+    for line in ps_output.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        live.add(parts[0])
+        if parts[0] == me:
+            continue
+        # None is UNKNOWN: count it, because a missed watcher starts a second
+        # one and every task is then processed twice.
+        if _is_watcher_argv(parts[2], _as_pid(parts[0])) is False:
+            continue
+        parent[parts[0]] = parts[1]
+    return parent, live
+
+
+def _split_roots_by_owner(roots, ps_output: "str | None" = None) -> tuple:
+    """(ownerless, supervised) for the roots GIVEN, by each root's own parent.
+
+    A known parent that is not init still owns the process; advice that does not
+    separate the two tells an operator to stop somebody's live child.
+    """
+    own, sup = [], []
+    for r in roots:
+        r = str(r)
+        pp = _pid_parent(r, ps_output)
+        if pp and pp not in ("1", "0"):
+            sup.append(r)
+        else:
+            own.append(r)
+    return own, sup
+
+
 def _watcher_trees(ps_output: "str | None" = None) -> dict:
     """Map root PID -> set of PIDs for each distinct watcher TREE running.
 
@@ -8626,17 +8667,7 @@ def _watcher_trees(ps_output: "str | None" = None) -> dict:
                                        timeout=5).stdout
         except Exception:  # noqa: BLE001
             return {}
-    me = str(os.getpid())
-    parent = {}
-    for line in ps_output.splitlines():
-        parts = line.split(None, 2)
-        if len(parts) < 3 or parts[0] == me:
-            continue
-        # None is UNKNOWN: count it, because a missed watcher starts a second
-        # one and every task is then processed twice.
-        if _is_watcher_argv(parts[2], _as_pid(parts[0])) is False:
-            continue
-        parent[parts[0]] = parts[1]
+    parent, _live = _ps_watcher_index(ps_output)
     trees: dict = {}
     for pid in parent:
         root, seen = pid, set()
@@ -8697,7 +8728,7 @@ def check_task_watcher() -> dict:
             # A KNOWN parent that is not init: its spawning session still owns it.
             # Unknown parentage cannot support that claim, so it stays an orphan.
             parents = {r: _pid_parent(r, ps_out) for r in roots}
-            supervised = [r for r, pp in parents.items() if pp and pp != "1"]
+            ownerless, supervised = _split_roots_by_owner(roots, ps_out)
             if len(roots) == 1 and supervised:
                 # Its session is still its parent, so it IS supervised and there is
                 # no second tree to duplicate work. Killing it is what opens a gap.
@@ -8723,10 +8754,14 @@ def check_task_watcher() -> dict:
                                   "sentinel, so health-check cannot track it. Do NOT stop it — "
                                   "it IS draining tasks/. Re-stamp the sentinel with --fix, or "
                                   "restart cleanly only when tasks/ is empty."}
+            # Parentage was computed above and, before this, used only when there
+            # was exactly one root -- so every multi-root set was called orphaned.
             return {"name": name, "status": "warn",
-                    "detail": f"{len(roots)} orphaned watcher(s) running with no PID sentinel "
-                              f"(pids {', '.join(roots)}) — draining tasks/ unsupervised; "
-                              "stop them and restart one cleanly"}
+                    "detail": f"{len(roots)} watcher(s) running with no PID sentinel, "
+                              f"draining tasks/. "
+                              f"ownerless, safe to stop: {', '.join(ownerless) or 'none'}; "
+                              f"supervised, leave alone (a live parent owns them): "
+                              f"{', '.join(supervised) or 'none'}"}
         return {"name": name, "status": "warn",
                 "detail": "watcher not running (no PID sentinel) — tasks/ will not be drained; "
                           "restart via Monitor: bash src/watch-tasks-stream.sh"}
@@ -8761,10 +8796,13 @@ def check_task_watcher() -> dict:
         if roots:
             # A dead sentinel does NOT mean nothing drains tasks/ — restarting
             # here is what makes the duplicates.
+            own, sup = _split_roots_by_owner(roots, ps_out)
             return {"name": name, "status": "warn",
-                    "detail": f"sentinel pid {pid} is dead but {len(roots)} watcher(s) still run "
-                              f"(pids {', '.join(roots)}) — orphaned, tasks/ IS being drained; "
-                              "stop them and restart one cleanly"}
+                    "detail": f"sentinel pid {pid} is dead but {len(roots)} watcher(s) still "
+                              f"run; tasks/ IS being drained. "
+                              f"ownerless, safe to stop: {', '.join(own) or 'none'}; "
+                              f"supervised, leave alone (a live parent owns them): "
+                              f"{', '.join(sup) or 'none'}"}
         return {"name": name, "status": "warn",
                 "detail": f"watcher pid {pid} is dead (crashed — sentinel left behind); restart it"}
 
@@ -8772,10 +8810,14 @@ def check_task_watcher() -> dict:
     extras = sorted(r for r, members in trees.items() if not (members & tracked))
     if extras:
         keep = ", ".join(str(p) for p in sorted(live))
+        own, sup = _split_roots_by_owner(extras, ps_out)
         return {"name": name, "status": "warn",
                 "detail": f"{len(trees)} watcher trees running — {len(extras)} not tracked by any "
-                          f"sentinel (root pids {', '.join(extras)}); duplicates process each task "
-                          f"more than once. Keep the tracked one(s) ({keep}), stop the rest"}
+                          f"sentinel; duplicates process each task more than once. Keep the "
+                          f"tracked one(s) ({keep}). "
+                          f"ownerless, safe to stop: {', '.join(own) or 'none'}; "
+                          f"supervised, leave alone (a live parent owns them): "
+                          f"{', '.join(sup) or 'none'}"}
     alive = ", ".join(str(p) for p in sorted(live))
     # An anomaly belongs to the instance whose sentinel carries it, so a live
     # PEER is not evidence about a crashed one and must not discard its record.

--- a/src/runtime-api/rundir.py
+++ b/src/runtime-api/rundir.py
@@ -42,6 +42,10 @@ from instance_key import (DEFAULT_INSTANCE, TRUNC, bound,  # noqa: E402
                           instance_key)
 
 DEFAULT_ACTOR = "local-agent"
+
+# The actor half's env precedence, in order, first NON-EMPTY wins. Exported
+# because a consumer reading another process's identity needs the same list.
+ACTOR_ENV_NAMES = ("SUTANDO_AGENT_ID", "AGENT_MXID", "AGENT_ID")
 SOCK_NAME = "runtime.sock"
 # AF_UNIX sun_path is 104 bytes on darwin/BSD and 108 on Linux, NUL included.
 SUN_PATH_MAX = 103 if sys.platform == "darwin" else 107
@@ -94,9 +98,7 @@ def agent_id(state_dir=None) -> str:
     """The actor half of the runtime identity: env → enrolled record →
     DEFAULT_ACTOR. Every consumer MUST come through here — a consumer that
     stops one link short of another resolves a different socket."""
-    env = (os.environ.get("SUTANDO_AGENT_ID")
-           or os.environ.get("AGENT_MXID")
-           or os.environ.get("AGENT_ID"))
+    env = next((v for v in (os.environ.get(n) for n in ACTOR_ENV_NAMES) if v), None)
     if env:
         return env
     if state_dir is None:

--- a/src/services_status.py
+++ b/src/services_status.py
@@ -10,7 +10,8 @@ Why aggregate, not re-probe
 ---------------------------
 Each sidecar already leaves a liveness trace — the core heartbeat's
 `state/cores/<host>.alive` (mtime = liveness), the task watcher's
-`state/watch-tasks-stream.pid`, a listening TCP port for network services.
+a per-instance `state/watch-tasks-stream[-<instance>].pid`, a listening TCP
+port for network services.
 This emitter *reads those existing signals* and folds them into one file the
 UI can consume, rather than inventing a second, divergent source of truth.
 
@@ -102,6 +103,15 @@ def probe_alive_file(path: Path, now: float, ttl: float = ALIVE_TTL_S) -> tuple[
         return ("offline", f"stale {int(age)}s", mtime)
     except OSError as e:  # pragma: no cover — defensive; hard to trigger in tests
         return ("unknown", f"stat failed: {e}", None)
+
+
+def _watcher_sentinel() -> Path:
+    """The sentinel this row reports on: the historic name when present, else
+    the first per-instance one. A pool host has several and this row has always
+    reported one -- naming which is a display change, not a probe change."""
+    from util_paths import watcher_sentinel_path, watcher_sentinel_paths
+    found = watcher_sentinel_paths(STATE_DIR)
+    return found[0] if found else watcher_sentinel_path(STATE_DIR)
 
 
 def probe_pidfile(path: Path, pid_alive) -> tuple[str, str, float | None]:
@@ -241,7 +251,8 @@ def service_registry() -> list[dict]:
         {"id": "gateway", "name": "AG2 Gateway",
          "probe": ("gateway", GATEWAY_STATUS_PATH, r"remote-gateway-bridge\.py$")},
         {"id": "task-watcher", "name": "Task Watcher",
-         "probe": ("pidfile", STATE_DIR / "watch-tasks-stream.pid")},
+         # Every instance's sentinel; one fixed name reported only the newest.
+         "probe": ("pidfile", _watcher_sentinel())},
         {"id": "voice-agent", "name": "Voice Agent",
          "probe": ("port", 9900)},
         {"id": "web-client", "name": "Web Client",

--- a/src/services_status.py
+++ b/src/services_status.py
@@ -105,13 +105,32 @@ def probe_alive_file(path: Path, now: float, ttl: float = ALIVE_TTL_S) -> tuple[
         return ("unknown", f"stat failed: {e}", None)
 
 
-def _watcher_sentinel() -> Path:
-    """The sentinel this row reports on: the historic name when present, else
-    the first per-instance one. A pool host has several and this row has always
-    reported one -- naming which is a display change, not a probe change."""
+def probe_watcher_sentinels(state_dir: Path, pid_alive
+                            ) -> "tuple[str, str, float | None]":
+    """Every watcher sentinel as ONE row. Reporting the first file answers about
+    one instance, which is wrong in both directions on a pool: a dead historic
+    pid beside a live worker read `offline`, and the reverse read `running`.
+
+    Enumerated at probe time, so a sentinel written after startup is seen.
+    """
     from util_paths import watcher_sentinel_path, watcher_sentinel_paths
-    found = watcher_sentinel_paths(STATE_DIR)
-    return found[0] if found else watcher_sentinel_path(STATE_DIR)
+    found = watcher_sentinel_paths(state_dir)
+    if not found:
+        return probe_pidfile(watcher_sentinel_path(state_dir), pid_alive)
+    rows = [(sp.name, *probe_pidfile(sp, pid_alive)[:2]) for sp in found]
+    running = [r for r in rows if r[1] == "running"]
+    if len(running) == len(rows):
+        pids = ", ".join(d for _, _, d in rows)
+        return ("running", pids if len(rows) == 1 else
+                f"{len(rows)} watchers: {pids}", None)
+    rest = "; ".join(f"{n}: {d}" for n, s, d in rows if s != "running")
+    if not running:
+        # No instance is up. `unknown` outranks `offline`: an unreadable
+        # sentinel is a question, and answering it "offline" overstates.
+        worst = "unknown" if any(s == "unknown" for _, s, _ in rows) else "offline"
+        return (worst, rest, None)
+    ok = ", ".join(d for _, s, d in rows if s == "running")
+    return ("degraded", f"{len(running)} of {len(rows)} up ({ok}); {rest}", None)
 
 
 def probe_pidfile(path: Path, pid_alive) -> tuple[str, str, float | None]:
@@ -252,7 +271,7 @@ def service_registry() -> list[dict]:
          "probe": ("gateway", GATEWAY_STATUS_PATH, r"remote-gateway-bridge\.py$")},
         {"id": "task-watcher", "name": "Task Watcher",
          # Every instance's sentinel; one fixed name reported only the newest.
-         "probe": ("pidfile", _watcher_sentinel())},
+         "probe": ("watcher_sentinels", STATE_DIR)},
         {"id": "voice-agent", "name": "Voice Agent",
          "probe": ("port", 9900)},
         {"id": "web-client", "name": "Web Client",
@@ -300,6 +319,8 @@ def build_payload(
             status, detail, since = probe_alive_file(arg, now)
         elif kind == "pidfile":
             status, detail, since = probe_pidfile(arg, pid_alive)
+        elif kind == "watcher_sentinels":
+            status, detail, since = probe_watcher_sentinels(arg, pid_alive)
         elif kind == "port":
             status, detail, since = probe_port(arg, connect)
         elif kind == "process":

--- a/src/services_status.py
+++ b/src/services_status.py
@@ -122,12 +122,14 @@ def probe_watcher_sentinels(state_dir: Path, pid_alive
     # Two sentinel FILES naming one pid is one watcher and a stale record, not
     # two watchers; listing the pid twice reports a pool that does not exist.
     seen = {}
-    for n, _s, d in rows:
-        seen.setdefault(d, []).append(n)
+    for n, s, d in rows:
+        if s == "running":
+            seen.setdefault(d, []).append(n)
     dup = {d: ns for d, ns in seen.items() if len(ns) > 1}
+    dup_note = ("; ".join(f"{' and '.join(ns)} both name {d}" for d, ns in dup.items())
+                if dup else "")
     if dup and len(running) == len(rows):
-        detail = "; ".join(f"{' and '.join(ns)} both name {d}" for d, ns in dup.items())
-        return ("degraded", f"one pid, two sentinels: {detail}", None)
+        return ("degraded", f"one pid, two sentinels: {dup_note}", None)
     if len(running) == len(rows):
         pids = ", ".join(d for _, _, d in rows)
         return ("running", pids if len(rows) == 1 else
@@ -138,8 +140,12 @@ def probe_watcher_sentinels(state_dir: Path, pid_alive
         # sentinel is a question, and answering it "offline" overstates.
         worst = "unknown" if any(s == "unknown" for _, s, _ in rows) else "offline"
         return (worst, rest, None)
-    ok = ", ".join(d for _, s, d in rows if s == "running")
-    return ("degraded", f"{len(running)} of {len(rows)} up ({ok}); {rest}", None)
+    # De-duplicate: two sentinels naming one live pid is one process, and
+    # counting it twice reports a pool that is not there.
+    ok = ", ".join(dict.fromkeys(d for _, s, d in rows if s == "running"))
+    live_n = len(set(d for _, s, d in rows if s == "running"))
+    tail = f"; one pid, two sentinels: {dup_note}" if dup_note else ""
+    return ("degraded", f"{live_n} of {len(rows)} up ({ok}); {rest}{tail}", None)
 
 
 def probe_pidfile(path: Path, pid_alive) -> tuple[str, str, float | None]:

--- a/src/services_status.py
+++ b/src/services_status.py
@@ -119,6 +119,15 @@ def probe_watcher_sentinels(state_dir: Path, pid_alive
         return probe_pidfile(watcher_sentinel_path(state_dir), pid_alive)
     rows = [(sp.name, *probe_pidfile(sp, pid_alive)[:2]) for sp in found]
     running = [r for r in rows if r[1] == "running"]
+    # Two sentinel FILES naming one pid is one watcher and a stale record, not
+    # two watchers; listing the pid twice reports a pool that does not exist.
+    seen = {}
+    for n, _s, d in rows:
+        seen.setdefault(d, []).append(n)
+    dup = {d: ns for d, ns in seen.items() if len(ns) > 1}
+    if dup and len(running) == len(rows):
+        detail = "; ".join(f"{' and '.join(ns)} both name {d}" for d, ns in dup.items())
+        return ("degraded", f"one pid, two sentinels: {detail}", None)
     if len(running) == len(rows):
         pids = ", ".join(d for _, _, d in rows)
         return ("running", pids if len(rows) == 1 else

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -667,11 +667,12 @@ if [ -x "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" ]; then
   bash "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" --auto || true
 fi
 
-# Every instance's sentinel: reaping only the historic name leaves a pool
-# host's other watchers untracked and unreaped.
-while IFS= read -r __sentinel; do
-  [ -n "$__sentinel" ] && reap_stale_task_watcher "$__sentinel"
-done < <(sentinel_paths_in "$WORKSPACE/state")
+# THIS instance's sentinel only. The reaper deliberately kills a watcher that
+# OWNS its sentinel -- right for a leftover of this instance, fatal for a peer's
+# running one, and startup no longer precedes every watcher on a pool host.
+if __sentinel="$(sentinel_path_for "$WORKSPACE/state")" && [ -n "$__sentinel" ]; then
+  reap_stale_task_watcher "$__sentinel"
+fi
 
 # Post-M0: repo-root tasks/results/data are NOT created. Pre-M0 this block
 # ran `mkdir -p tasks results data` as back-compat for unmigrated scripts —

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -667,7 +667,11 @@ if [ -x "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" ]; then
   bash "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" --auto || true
 fi
 
-reap_stale_task_watcher "$WORKSPACE/state/watch-tasks-stream.pid"
+# Every instance's sentinel: reaping only the historic name leaves a pool
+# host's other watchers untracked and unreaped.
+while IFS= read -r __sentinel; do
+  [ -n "$__sentinel" ] && reap_stale_task_watcher "$__sentinel"
+done < <(sentinel_paths_in "$WORKSPACE/state")
 
 # Post-M0: repo-root tasks/results/data are NOT created. Pre-M0 this block
 # ran `mkdir -p tasks results data` as back-compat for unmigrated scripts —

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -526,6 +526,21 @@ def instance_scope_key(state_dir, instance=None, agent=None) -> str:
     return ikey.instance_key(who, inst)
 
 
+def stated_default_identity(state_dir):
+    """The (instance, agent) pair a process names when it sets NEITHER env var.
+
+    A caller naming ANOTHER process's path cannot pass None for an observed
+    default: None re-resolves from the CALLER's own environment, which is a
+    different identity. This returns the values to pass explicitly instead.
+    """
+    ident = _runtime_identity()
+    if ident is None:
+        return None
+    rundir, ikey = ident
+    return ikey.DEFAULT_INSTANCE, (rundir.enrolled_agent_id(state_dir)
+                                   or rundir.DEFAULT_ACTOR)
+
+
 def watcher_sentinel_path(state_dir, instance=None, agent=None) -> Path:
     """The sentinel THIS instance writes."""
     key = instance_scope_key(state_dir, instance, agent)

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -486,31 +486,48 @@ def _runtime_identity():
     return mods["rundir"], mods["instance_key"]
 
 
-def watcher_sentinel_path(state_dir, instance=None, agent=None) -> Path:
-    """The sentinel THIS instance writes.
+def instance_scope_key(state_dir, instance=None, agent=None) -> str:
+    """This runtime's `(agent_id, instance_id)` key, or "" for the canonical
+    default — the ONE discriminator every per-instance path uses.
 
-    The identity comes from `rundir` and the encoding from `instance_key` — the
-    same owners the run dir and the durable registry use, so two instances
-    cannot alias here while staying distinct there.
+    Identity comes from `rundir` and the encoding from `instance_key`, the same
+    owners the run dir and the durable registry use, so two instances cannot
+    alias here while staying distinct there.
     """
     ident = _runtime_identity()
     if ident is None:
-        # A default install has one watcher and the historic name is right. A
+        # A default install has one runtime and the historic paths are right. A
         # non-default instance without the encoder would ALIAS, so refuse.
         asked = instance if instance is not None else os.environ.get("SUTANDO_INSTANCE_ID")
         if asked and asked != "default":
             raise RuntimeError(
-                "cannot resolve a per-instance watcher sentinel: "
+                "cannot resolve a per-instance path: "
                 "src/runtime-api/{instance_key,rundir}.py did not import")
-        return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}.pid"
-
+        return ""
     rundir, ikey = ident
     inst = instance if instance is not None else rundir.instance_id()
     who = agent if agent is not None else rundir.agent_id(state_dir)
     if inst == ikey.DEFAULT_INSTANCE and who == rundir.DEFAULT_ACTOR:
-        return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}.pid"
-    key = ikey.instance_key(who, inst)
-    return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}-{key}.pid"
+        return ""
+    return ikey.instance_key(who, inst)
+
+
+def watcher_sentinel_path(state_dir, instance=None, agent=None) -> Path:
+    """The sentinel THIS instance writes."""
+    key = instance_scope_key(state_dir, instance, agent)
+    suffix = f"-{key}" if key else ""
+    return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}{suffix}.pid"
+
+
+def handler_fallbacks_dir(state_dir, instance=None, agent=None) -> Path:
+    """Where THIS instance records "my optional handler declined this task".
+
+    That receipt is instance-local knowledge. Shared, another instance reads it
+    as its own and bypasses its handler, sending the task to its live core.
+    """
+    key = instance_scope_key(state_dir, instance, agent)
+    base = Path(state_dir) / "task-event-handler-fallbacks"
+    return base / key if key else base
 
 
 def watcher_sentinel_paths(state_dir) -> "list[Path]":
@@ -535,6 +552,9 @@ if __name__ == "__main__":
     # of the identity encoding to keep in step with this one.
     if len(sys.argv) >= 3 and sys.argv[1] == "watcher-sentinel":
         print(watcher_sentinel_path(sys.argv[2]))
+    elif len(sys.argv) >= 3 and sys.argv[1] == "handler-fallbacks-dir":
+        print(handler_fallbacks_dir(sys.argv[2]))
     else:
-        print("usage: util_paths.py watcher-sentinel <state-dir>", file=sys.stderr)
+        print("usage: util_paths.py {watcher-sentinel|handler-fallbacks-dir} <state-dir>",
+              file=sys.stderr)
         raise SystemExit(2)

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -476,11 +476,16 @@ def _runtime_identity():
         if spec is None or spec.loader is None:
             return None
         mod = importlib.util.module_from_spec(spec)
+        # Registered only AFTER exec succeeds: a half-initialised module left in
+        # sys.modules poisons `rundir`'s own `from instance_key import ...`.
         sys.modules[f"_wsent_{name}"] = mod
         sys.modules.setdefault(name, mod)
         try:
             spec.loader.exec_module(mod)
         except Exception:  # noqa: BLE001 — an absent runtime is not a path error
+            sys.modules.pop(f"_wsent_{name}", None)
+            if sys.modules.get(name) is mod:
+                del sys.modules[name]
             return None
         mods[name] = mod
     return mods["rundir"], mods["instance_key"]

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -461,6 +461,10 @@ def write_private_text(path: "Path", text: str) -> None:
 # and a test asserts the two namers agree.
 WATCHER_SENTINEL_STEM = "watch-tasks-stream"
 
+# `rundir.DEFAULT_ACTOR`, needed only on the path where rundir itself did not
+# import; a mismatch is caught by test_the_degraded_default_actor_matches_rundir.
+_DEGRADED_CANONICAL_ACTOR = "local-agent"
+
 
 def _runtime_identity():
     """`(rundir, instance_key)` from src/runtime-api, or None when unavailable.
@@ -501,14 +505,19 @@ def instance_scope_key(state_dir, instance=None, agent=None) -> str:
     """
     ident = _runtime_identity()
     if ident is None:
-        # A default install has one runtime and the historic paths are right. A
-        # non-default instance without the encoder would ALIAS, so refuse.
-        asked = instance if instance is not None else os.environ.get("SUTANDO_INSTANCE_ID")
-        if asked and asked != "default":
+        # NEITHER half is readable here, so "" would claim canonical identity
+        # rather than read it; only an explicit caller-stated pair is answerable.
+        if instance is None or agent is None:
             raise RuntimeError(
                 "cannot resolve a per-instance path: "
-                "src/runtime-api/{instance_key,rundir}.py did not import")
-        return ""
+                "src/runtime-api/{instance_key,rundir}.py did not import, so "
+                "neither the instance nor the actor can be read — pass both "
+                "explicitly to name a path in this state")
+        if instance == "default" and agent == _DEGRADED_CANONICAL_ACTOR:
+            return ""
+        raise RuntimeError(
+            "cannot encode a per-instance path: "
+            "src/runtime-api/instance_key.py did not import")
     rundir, ikey = ident
     inst = instance if instance is not None else rundir.instance_id()
     who = agent if agent is not None else rundir.agent_id(state_dir)

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -455,3 +455,34 @@ def write_private_text(path: "Path", text: str) -> None:
         raise
     with os.fdopen(fd, "w") as fh:  # fdopen takes ownership of fd from here
         fh.write(text)
+
+
+# Unset instance keeps the historic name; mirrored in src/watcher_sentinel.sh
+# and a test asserts the two namers agree.
+WATCHER_SENTINEL_STEM = "watch-tasks-stream"
+
+
+def watcher_sentinel_path(state_dir, instance: "str | None" = None) -> Path:
+    """The sentinel this instance writes. No instance -> the historic name."""
+    if instance is None:
+        instance = os.environ.get("SUTANDO_INSTANCE", "")
+    instance = re.sub(r"[^A-Za-z0-9._-]", "-", instance.strip()).strip(".-")
+    suffix = f"-{instance}" if instance else ""
+    return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}{suffix}.pid"
+
+
+def watcher_sentinel_paths(state_dir) -> "list[Path]":
+    """Every sentinel present, historic name first.
+
+    A reader must consider all of them: asking about one file answers about one
+    watcher, and on a pool host the others are equally real.
+    """
+    state = Path(state_dir)
+    bare = state / f"{WATCHER_SENTINEL_STEM}.pid"
+    found = [bare] if bare.exists() else []
+    try:
+        rest = sorted(p for p in state.glob(f"{WATCHER_SENTINEL_STEM}-*.pid")
+                      if p.is_file())
+    except OSError:
+        rest = []
+    return found + rest

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -462,13 +462,55 @@ def write_private_text(path: "Path", text: str) -> None:
 WATCHER_SENTINEL_STEM = "watch-tasks-stream"
 
 
-def watcher_sentinel_path(state_dir, instance: "str | None" = None) -> Path:
-    """The sentinel this instance writes. No instance -> the historic name."""
-    if instance is None:
-        instance = os.environ.get("SUTANDO_INSTANCE", "")
-    instance = re.sub(r"[^A-Za-z0-9._-]", "-", instance.strip()).strip(".-")
-    suffix = f"-{instance}" if instance else ""
-    return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}{suffix}.pid"
+def _runtime_identity():
+    """`(rundir, instance_key)` from src/runtime-api, or None when unavailable.
+
+    Imported lazily: util_paths is on the import path of probes that must not
+    acquire a runtime dependency merely to resolve a path.
+    """
+    import importlib.util
+    mods = {}
+    for name in ("instance_key", "rundir"):
+        src = Path(__file__).resolve().parent / "runtime-api" / f"{name}.py"
+        spec = importlib.util.spec_from_file_location(f"_wsent_{name}", src)
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[f"_wsent_{name}"] = mod
+        sys.modules.setdefault(name, mod)
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:  # noqa: BLE001 — an absent runtime is not a path error
+            return None
+        mods[name] = mod
+    return mods["rundir"], mods["instance_key"]
+
+
+def watcher_sentinel_path(state_dir, instance=None, agent=None) -> Path:
+    """The sentinel THIS instance writes.
+
+    The identity comes from `rundir` and the encoding from `instance_key` — the
+    same owners the run dir and the durable registry use, so two instances
+    cannot alias here while staying distinct there.
+    """
+    ident = _runtime_identity()
+    if ident is None:
+        # A default install has one watcher and the historic name is right. A
+        # non-default instance without the encoder would ALIAS, so refuse.
+        asked = instance if instance is not None else os.environ.get("SUTANDO_INSTANCE_ID")
+        if asked and asked != "default":
+            raise RuntimeError(
+                "cannot resolve a per-instance watcher sentinel: "
+                "src/runtime-api/{instance_key,rundir}.py did not import")
+        return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}.pid"
+
+    rundir, ikey = ident
+    inst = instance if instance is not None else rundir.instance_id()
+    who = agent if agent is not None else rundir.agent_id(state_dir)
+    if inst == ikey.DEFAULT_INSTANCE and who == rundir.DEFAULT_ACTOR:
+        return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}.pid"
+    key = ikey.instance_key(who, inst)
+    return Path(state_dir) / f"{WATCHER_SENTINEL_STEM}-{key}.pid"
 
 
 def watcher_sentinel_paths(state_dir) -> "list[Path]":
@@ -486,3 +528,13 @@ def watcher_sentinel_paths(state_dir) -> "list[Path]":
     except OSError:
         rest = []
     return found + rest
+
+
+if __name__ == "__main__":
+    # Path resolution for shell callers, so there is no second implementation
+    # of the identity encoding to keep in step with this one.
+    if len(sys.argv) >= 3 and sys.argv[1] == "watcher-sentinel":
+        print(watcher_sentinel_path(sys.argv[2]))
+    else:
+        print("usage: util_paths.py watcher-sentinel <state-dir>", file=sys.stderr)
+        raise SystemExit(2)

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -526,6 +526,19 @@ def instance_scope_key(state_dir, instance=None, agent=None) -> str:
     return ikey.instance_key(who, inst)
 
 
+def actor_env_names():
+    """The actor half's env precedence, from the module that defines it.
+
+    A consumer reading ANOTHER process's identity must use the same order the
+    owner uses, and a second copy of the list is how the two answer differently.
+    """
+    ident = _runtime_identity()
+    if ident is None:
+        return ()
+    rundir, _ikey = ident
+    return tuple(rundir.ACTOR_ENV_NAMES)
+
+
 def stated_default_identity(state_dir):
     """The (instance, agent) pair a process names when it sets NEITHER env var.
 

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -521,7 +521,13 @@ def instance_scope_key(state_dir, instance=None, agent=None) -> str:
     rundir, ikey = ident
     inst = instance if instance is not None else rundir.instance_id()
     who = agent if agent is not None else rundir.agent_id(state_dir)
-    if inst == ikey.DEFAULT_INSTANCE and who == rundir.DEFAULT_ACTOR:
+    # The canonical actor for a state dir is its ENROLLED agent where one exists
+    # — the same pair `stated_default_identity()` reports. Comparing against the
+    # bare constant instead made every enrolled single-instance install rename
+    # its sentinel and its fallback receipts on upgrade, stranding the historic
+    # records as a dead peer.
+    canonical_actor = rundir.enrolled_agent_id(state_dir) or rundir.DEFAULT_ACTOR
+    if inst == ikey.DEFAULT_INSTANCE and who == canonical_actor:
         return ""
     return ikey.instance_key(who, inst)
 

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -521,11 +521,8 @@ def instance_scope_key(state_dir, instance=None, agent=None) -> str:
     rundir, ikey = ident
     inst = instance if instance is not None else rundir.instance_id()
     who = agent if agent is not None else rundir.agent_id(state_dir)
-    # The canonical actor for a state dir is its ENROLLED agent where one exists
-    # — the same pair `stated_default_identity()` reports. Comparing against the
-    # bare constant instead made every enrolled single-instance install rename
-    # its sentinel and its fallback receipts on upgrade, stranding the historic
-    # records as a dead peer.
+    # The canonical actor is the ENROLLED agent where one exists — the pair
+    # `stated_default_identity()` reports, not the bare DEFAULT_ACTOR constant.
     canonical_actor = rundir.enrolled_agent_id(state_dir) or rundir.DEFAULT_ACTOR
     if inst == ikey.DEFAULT_INSTANCE and who == canonical_actor:
         return ""

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -87,7 +87,9 @@ RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$WORKSPACE_DIR/results}"
 # of spawning an unbounded process fanout. Unhandled work still emits its
 # TASK_FILE event immediately, even while the provider queue is full.
 TASK_HANDLER_WORKERS=2
-SUTANDO_PY_BIN="$(bash "$__REPO_ROOT/scripts/sutando-config.sh" python-bin 2>/dev/null || true)"
+# shellcheck source=../scripts/python-binary.sh
+. "$__REPO_ROOT/scripts/python-binary.sh"
+SUTANDO_PY_BIN="$(require_python "$__REPO_ROOT" "watch tasks")" || exit 1
 DISPATCH_DIR=""
 WATCH_RUNTIME_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sutando-task-watch.XXXXXX")"
 mkfifo "$WATCH_RUNTIME_DIR/events"
@@ -97,7 +99,7 @@ GROUP_TERM_SENT=0
 CLAIMS_DIR="$WORKSPACE_DIR/state/task-event-handler-claims"
 # Per instance: this receipt says "MY optional handler declined this task", and
 # a shared one makes another instance bypass its own handler. Owner: util_paths.
-FALLBACKS_DIR="$(python3 "$__REPO_ROOT/src/util_paths.py" handler-fallbacks-dir "$WORKSPACE_DIR/state")" || {
+FALLBACKS_DIR="$("$SUTANDO_PY_BIN" "$__REPO_ROOT/src/util_paths.py" handler-fallbacks-dir "$WORKSPACE_DIR/state")" || {
   echo "watch-tasks-stream: could not resolve the fallback receipt dir" >&2
   exit 1
 }

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -95,7 +95,12 @@ FSWATCH_PID=""
 CLEANING_UP=0
 GROUP_TERM_SENT=0
 CLAIMS_DIR="$WORKSPACE_DIR/state/task-event-handler-claims"
-FALLBACKS_DIR="$WORKSPACE_DIR/state/task-event-handler-fallbacks"
+# Per instance: this receipt says "MY optional handler declined this task", and
+# a shared one makes another instance bypass its own handler. Owner: util_paths.
+FALLBACKS_DIR="$(python3 "$__REPO_ROOT/src/util_paths.py" handler-fallbacks-dir "$WORKSPACE_DIR/state")" || {
+  echo "watch-tasks-stream: could not resolve the fallback receipt dir" >&2
+  exit 1
+}
 WATCHER_ID="$$-${RANDOM:-0}"
 
 claim_is_live() {

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -420,11 +420,9 @@ dispatch_task() {
 # the session and turn into an orphan. The trap below removes the file on a
 # clean exit; the Stop hook removes it after the kill on dirty exits.
 #
-# Same workspace resolution as TASKS_DIR (above): M0 cutover routes through
-# the canonical loader. Living under state/ matches the workspace contract
-# in CLAUDE.md (loose status/state files belong there). Post-v0.8 the legacy
-# env-var + hardcoded fallbacks are gone — fail-loud if helper missing.
-STATE_DIR="$(bash "$__REPO_ROOT/scripts/sutando-config.sh" workspace)/state"
+# Derived from WORKSPACE_DIR like CLAIMS_DIR and FALLBACKS_DIR, never re-resolved:
+# an argv tasks dir moves every other state path but left this one on the checkout.
+STATE_DIR="$WORKSPACE_DIR/state"
 mkdir -p "$STATE_DIR"
 # Per instance: N watchers on one host each stamped the same file, so the
 # readers tracked only the newest. Unset $SUTANDO_INSTANCE keeps the old name.

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -419,7 +419,9 @@ dispatch_task() {
 # env-var + hardcoded fallbacks are gone — fail-loud if helper missing.
 STATE_DIR="$(bash "$__REPO_ROOT/scripts/sutando-config.sh" workspace)/state"
 mkdir -p "$STATE_DIR"
-PID_FILE="$STATE_DIR/watch-tasks-stream.pid"
+# Per instance: N watchers on one host each stamped the same file, so the
+# readers tracked only the newest. Unset $SUTANDO_INSTANCE keeps the old name.
+PID_FILE="$(sentinel_path_for "$STATE_DIR")"
 # In place, never write-elsewhere-then-mv: mv preserves mtime, and
 # sentinel_pid_wrote_file reads mtime as "when this watcher stamped".
 echo "$$" > "$PID_FILE"

--- a/src/watcher_sentinel.sh
+++ b/src/watcher_sentinel.sh
@@ -24,6 +24,35 @@
 # file (health-check.py, services_status.py, and the tests), so a richer token
 # would convert this bug into a different false "watcher is broken" signal.
 
+# --- naming ------------------------------------------------------------------
+# Unset instance keeps the historic name, so a single-instance install is
+# unchanged. Mirrored in src/util_paths.py; a test asserts they agree.
+WATCHER_SENTINEL_STEM="watch-tasks-stream"
+
+# The sentinel THIS process writes. $1 = state dir, $2 = instance (optional;
+# defaults to $SUTANDO_INSTANCE, empty for the historic name).
+sentinel_path_for() {
+  local state_dir="$1" instance="${2-${SUTANDO_INSTANCE:-}}" clean
+  clean="$(printf '%s' "$instance" | tr -c 'A-Za-z0-9._-' '-' | sed 's/^[.-]*//; s/[.-]*$//')"
+  if [ -n "$clean" ]; then
+    printf '%s/%s-%s.pid' "$state_dir" "$WATCHER_SENTINEL_STEM" "$clean"
+  else
+    printf '%s/%s.pid' "$state_dir" "$WATCHER_SENTINEL_STEM"
+  fi
+}
+
+# Every sentinel present, historic name first, one per line. A caller that asks
+# about one file has asked about one watcher; on a pool host the others are
+# equally real.
+sentinel_paths_in() {
+  local state_dir="$1" p
+  [ -f "$state_dir/$WATCHER_SENTINEL_STEM.pid" ] && printf '%s/%s.pid\n' "$state_dir" "$WATCHER_SENTINEL_STEM"
+  for p in "$state_dir/$WATCHER_SENTINEL_STEM"-*.pid; do
+    [ -f "$p" ] && printf '%s\n' "$p"
+  done
+  return 0
+}
+
 # Seconds of elapsed time for a pid, or empty when it cannot be determined.
 # `etime` is [[DD-]HH:]MM:SS on both BSD and GNU ps.
 sentinel_pid_elapsed() {

--- a/src/watcher_sentinel.sh
+++ b/src/watcher_sentinel.sh
@@ -36,7 +36,11 @@ WATCHER_SENTINEL_STEM="watch-tasks-stream"
 sentinel_path_for() {
   local state_dir="$1" here out
   here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if ! out="$(python3 "$here/util_paths.py" watcher-sentinel "$state_dir")"; then
+  local py
+  # shellcheck source=../scripts/python-binary.sh
+  . "$here/../scripts/python-binary.sh" || return 1
+  py="$(require_python "$here/.." "resolve the watcher sentinel")" || return 1
+  if ! out="$("$py" "$here/util_paths.py" watcher-sentinel "$state_dir")"; then
     echo "watcher_sentinel: could not resolve the sentinel path" >&2
     return 1
   fi

--- a/src/watcher_sentinel.sh
+++ b/src/watcher_sentinel.sh
@@ -25,20 +25,22 @@
 # would convert this bug into a different false "watcher is broken" signal.
 
 # --- naming ------------------------------------------------------------------
-# Unset instance keeps the historic name, so a single-instance install is
-# unchanged. Mirrored in src/util_paths.py; a test asserts they agree.
+# The stem only. The per-instance SUFFIX is not computed here: src/util_paths.py
+# owns it and delegates to src/runtime-api/instance_key.py, so a shell mirror
+# would be a second implementation of one contract.
 WATCHER_SENTINEL_STEM="watch-tasks-stream"
 
-# The sentinel THIS process writes. $1 = state dir, $2 = instance (optional;
-# defaults to $SUTANDO_INSTANCE, empty for the historic name).
+# The sentinel THIS process writes. $1 = state dir. Asks the Python owner, which
+# reads SUTANDO_INSTANCE_ID and the enrolled actor exactly as the run dir does.
+# A failure is fatal: guessing a path here is how two instances share one file.
 sentinel_path_for() {
-  local state_dir="$1" instance="${2-${SUTANDO_INSTANCE:-}}" clean
-  clean="$(printf '%s' "$instance" | tr -c 'A-Za-z0-9._-' '-' | sed 's/^[.-]*//; s/[.-]*$//')"
-  if [ -n "$clean" ]; then
-    printf '%s/%s-%s.pid' "$state_dir" "$WATCHER_SENTINEL_STEM" "$clean"
-  else
-    printf '%s/%s.pid' "$state_dir" "$WATCHER_SENTINEL_STEM"
+  local state_dir="$1" here out
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if ! out="$(python3 "$here/util_paths.py" watcher-sentinel "$state_dir")"; then
+    echo "watcher_sentinel: could not resolve the sentinel path" >&2
+    return 1
   fi
+  printf '%s' "$out"
 }
 
 # Every sentinel present, historic name first, one per line. A caller that asks

--- a/tests/agent-availability.test.py
+++ b/tests/agent-availability.test.py
@@ -349,5 +349,58 @@ class WedgeFoldIsTotal(unittest.TestCase):
         self.assertEqual(set(av._WEDGE_KIND_TO_SIGNAL.values()) - {"working", "idle", "wedged", "unknown"}, set())
 
 
+class SessionBoundaryReadsTheWriterSPath(unittest.TestCase):
+    """Reported by qingyun-wu on #3875 at b93e92e6.
+
+    The sentinel writer names its file per instance; this reader held the
+    historic literal. A restarted idle core then read session_start=None and
+    scored a previous session's RUNNING snapshot as current work -- reported
+    busy_unavailable until that snapshot's freshness expired. Their fix
+    prescription was explicit that selecting the newest peer sentinel is NOT
+    the remedy, so this pins the reader to the writer's OWN path.
+    """
+
+    def _ws(self):
+        d = Path(tempfile.mkdtemp())
+        (d / "state").mkdir()
+        return d
+
+    def test_the_reader_finds_what_the_writer_wrote(self):
+        from util_paths import watcher_sentinel_path
+        ws = self._ws()
+        written = watcher_sentinel_path(ws / "state")
+        written.write_text("4242\n")
+        os.utime(written, (995.0, 995.0))
+        self.assertEqual(av._session_started_at(ws), 995.0,
+            "the reader did not see the file the writer names")
+
+    def test_no_historic_literal_survives_in_the_reader(self):
+        src = (Path(__file__).resolve().parents[1] / "src" / "agent_availability.py").read_text()
+        self.assertNotIn('"watch-tasks-stream.pid"', src,
+            "a hardcoded sentinel name here is the defect: the writer scopes it per instance")
+        self.assertIn("watcher_sentinel_path", src,
+            "the reader must route through the same path owner as the writer")
+
+    def test_a_foreign_instances_sentinel_is_not_adopted(self):
+        # The forbidden fix (newest peer sentinel) would pass the first test and
+        # fail this one: a sibling's file must not become this session's start.
+        from util_paths import watcher_sentinel_path
+        ws = self._ws()
+        foreign = ws / "state" / "watch-tasks-stream-someone-else+worker-9.pid"
+        foreign.write_text("999\n")
+        os.utime(foreign, (995.0, 995.0))
+        mine = watcher_sentinel_path(ws / "state")
+        if mine.exists():
+            self.skipTest("this environment resolves to the same path; nothing foreign to test")
+        self.assertIsNone(av._session_started_at(ws),
+            "a peer's sentinel was adopted as this session's boundary")
+
+    def test_absent_sentinel_reads_as_unknown_not_zero(self):
+        ws = self._ws()
+        self.assertIsNone(av._session_started_at(ws),
+            "no sentinel must be None (unknown), never a falsy timestamp")
+
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -74,6 +74,10 @@ class CodexCoreLauncherTests(unittest.TestCase):
             "src/task_archive.py",
             "src/task_workstreams.py",
             "src/util_paths.py",
+            # util_paths refuses without these: it can read neither half of
+            # the identity, so it will not hand out the shared historic name.
+            "src/runtime-api/instance_key.py",
+            "src/runtime-api/rundir.py",
             "src/watch-tasks-stream.sh",
             "src/workspace_default.py",
             "src/sutando_config.py",

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -13,6 +13,8 @@ never a recency choice, despite the comment that said so.
 """
 import importlib.util
 import sys
+import contextlib
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -30,7 +32,7 @@ WATCHER_ARGV = "bash src/watch-tasks-stream.sh"
 
 
 def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
-        parent="1", pid_instance=None) -> dict:
+        parent="1", pid_instance=None, pid_actor="") -> dict:
     """`sentinels` maps filename -> contents; `trees` maps root pid -> members.
 
     `pid_instance` is what the WATCHER's own environment yields: a string names
@@ -45,7 +47,7 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
             (ws / "state" / fn).write_text(text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
                  hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
-                 hc._pid_instance_id)
+                 hc._pid_instance_id, hc._pid_actor_id)
         try:
             hc.WORKSPACE_DIR = ws
             hc._proc_argv = (argv if callable(argv) else (lambda pid: argv))
@@ -54,11 +56,12 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
             hc._pid_parent = lambda pid, ps=None: parent
             hc._fresh_local_core_record = lambda *a, **k: ({} if core_alive else None)
             hc._pid_instance_id = lambda pid: pid_instance
+            hc._pid_actor_id = lambda pid: pid_actor
             return hc.check_task_watcher()
         finally:
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
              hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
-             hc._pid_instance_id) = saved
+             hc._pid_instance_id, hc._pid_actor_id) = saved
 
 
 class PoolHost(unittest.TestCase):
@@ -227,6 +230,43 @@ class TheRestampTargetComesFromTheWATCHERsIdentity(unittest.TestCase):
                          "a guessed target is published as a repair instruction")
         self.assertIn("_sentinel_restamp_pid", r, "the pid is still reported")
         self.assertIn("unreadable", r["detail"])
+
+    @contextlib.contextmanager
+    def _health_check_identity(self, actor, instance):
+        """Give HEALTH-CHECK a different identity than the watcher.
+
+        Without this the two resolve alike and `agent=None` returns the right
+        answer for the wrong reason, so the defect is invisible to every case above.
+        """
+        names = {"SUTANDO_AGENT_ID": actor, "SUTANDO_INSTANCE_ID": instance}
+        saved = {k: os.environ.get(k) for k in names}
+        os.environ.update(names)
+        try:
+            yield
+        finally:
+            for k, v in saved.items():
+                os.environ[k] = v if v is not None else os.environ.pop(k, "")
+                if v is None:
+                    os.environ.pop(k, None)
+
+    def test_the_target_follows_the_WATCHERs_identity_not_health_checks(self):
+        with self._health_check_identity("health-b", "health-z"):
+            r = run({}, **self.SUPERVISED, pid_instance="worker-7", pid_actor="watcher-a")
+            self.assertEqual(Path(r["_sentinel_restamp_path"]).name,
+                             "watch-tasks-stream-watcher-a+worker-7.pid",
+                             "health-check's own actor leaked into the repair target")
+
+    def test_an_observed_default_is_the_canonical_default_not_the_callers(self):
+        # `inst or None` sent an OBSERVED default back to the caller's environment.
+        with self._health_check_identity("health-b", "health-z"):
+            r = run({}, **self.SUPERVISED, pid_instance="", pid_actor="watcher-a")
+            self.assertEqual(Path(r["_sentinel_restamp_path"]).name,
+                             "watch-tasks-stream-watcher-a.pid")
+
+    def test_an_unreadable_ACTOR_also_offers_no_target(self):
+        # The instance half already refused; the actor half must refuse alike.
+        r = run({}, **self.SUPERVISED, pid_instance="worker-7", pid_actor=None)
+        self.assertNotIn("_sentinel_restamp_path", r)
 
     def test_the_watcher_is_never_prescribed_for_stopping_in_any_of_them(self):
         for inst in ("worker-7", "", None):

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""On a pool host the task-watcher probe must consider EVERY sentinel.
+
+Each watcher writes its own `state/watch-tasks-stream[-<instance>].pid`, so a
+probe that reads one file reports on one watcher and classifies the other N-1
+live, correctly-supervised watchers as untracked duplicates. A peer's proactive
+loop acts on that tracked/untracked split, so the false verdict is not cosmetic:
+it prescribes stopping watchers that are doing their job.
+
+The pre-fix reader took `watcher_sentinel_paths(...)[0]`, which is the historic
+name whenever one exists and otherwise the alphabetically-first instance --
+never a recency choice, despite the comment that said so.
+"""
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("hc", ROOT / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+sys.modules["hc"] = hc
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+WATCHER_ARGV = "bash src/watch-tasks-stream.sh"
+
+
+def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True) -> dict:
+    """`sentinels` maps filename -> contents; `trees` maps root pid -> members."""
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        (ws / "state" / "cores").mkdir(parents=True)
+        if core_alive:
+            (ws / "state" / "cores" / "h.alive").write_text("{}")
+        for fn, text in sentinels.items():
+            (ws / "state" / fn).write_text(text)
+        saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
+                 hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record)
+        try:
+            hc.WORKSPACE_DIR = ws
+            hc._proc_argv = (argv if callable(argv) else (lambda pid: argv))
+            hc._watcher_trees = lambda *a, **k: trees
+            hc._ps_snapshot = lambda *a, **k: ""
+            hc._pid_parent = lambda pid, ps=None: "1"
+            hc._fresh_local_core_record = lambda *a, **k: ({} if core_alive else None)
+            return hc.check_task_watcher()
+        finally:
+            (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
+             hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record) = saved
+
+
+class PoolHost(unittest.TestCase):
+    def test_every_instance_watcher_is_tracked(self):
+        """THE case: three sentinels, three live watchers, nothing untracked.
+
+        Pre-fix this warned that 2 of 3 were untracked duplicates and told the
+        operator to stop them.
+        """
+        r = run({"watch-tasks-stream.pid": "100\n",
+                 "watch-tasks-stream-worker-1.pid": "200\n",
+                 "watch-tasks-stream-worker-2.pid": "300\n"},
+                {"100": {"100"}, "200": {"200"}, "300": {"300"}})
+        self.assertEqual(r["status"], "ok", r["detail"])
+        for pid in ("100", "200", "300"):
+            self.assertIn(pid, r["detail"])
+
+    def test_a_genuinely_untracked_watcher_is_still_reported(self):
+        """The union must not swallow the defect the probe exists to find."""
+        r = run({"watch-tasks-stream.pid": "100\n",
+                 "watch-tasks-stream-worker-1.pid": "200\n"},
+                {"100": {"100"}, "200": {"200"}, "999": {"999"}})
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("999", r["detail"])
+        self.assertNotIn("stop them and restart one cleanly", r["detail"])
+
+    def test_only_the_untracked_root_is_named(self):
+        r = run({"watch-tasks-stream-worker-1.pid": "200\n"},
+                {"200": {"200"}, "888": {"888"}})
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("888", r["detail"])
+        self.assertIn("Keep the tracked one(s) (200)", r["detail"])
+
+    def test_a_dead_sentinel_beside_a_live_one_does_not_warn(self):
+        """A worker that exited leaves its file; the rest are still correct."""
+        argv = lambda pid: "" if str(pid) == "100" else WATCHER_ARGV  # noqa: E731
+        r = run({"watch-tasks-stream.pid": "100\n",
+                 "watch-tasks-stream-worker-1.pid": "200\n"},
+                {"200": {"200"}}, argv=argv)
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertIn("200", r["detail"])
+
+    def test_all_sentinels_dead_with_watchers_running_keeps_the_old_verdict(self):
+        r = run({"watch-tasks-stream.pid": "100\n"}, {"777": {"777"}}, argv="")
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("orphaned", r["detail"])
+
+    def test_a_tree_whose_member_is_tracked_counts_as_tracked(self):
+        """A watcher's tree holds its children; the sentinel names the root."""
+        r = run({"watch-tasks-stream.pid": "100\n"}, {"100": {"100", "101", "102"}})
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+
+class SingleInstanceUnchanged(unittest.TestCase):
+    """Every historic branch must read the same on a one-watcher host."""
+
+    def test_ok(self):
+        r = run({"watch-tasks-stream.pid": "100\n"}, {"100": {"100"}})
+        self.assertEqual(r["status"], "ok")
+        self.assertEqual(r["detail"], "streaming watcher alive (pid 100)")
+
+    def test_pid_reuse(self):
+        r = run({"watch-tasks-stream.pid": "100\n"}, {}, argv="/usr/bin/python3 other.py")
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("PID reuse", r["detail"])
+
+    def test_unreadable(self):
+        r = run({"watch-tasks-stream.pid": "not-a-pid\n"}, {})
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("unreadable PID sentinel", r["detail"])
+
+    def test_dead_with_nothing_running(self):
+        r = run({"watch-tasks-stream.pid": "100\n"}, {}, argv="")
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("is dead", r["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -333,5 +333,49 @@ class TheActorPrecedenceComesFromItsOwner(unittest.TestCase):
                          "the precedence is spelled here again, so it can drift")
 
 
+class TheWatcherPredicateIsAShapeNotAFieldCount(unittest.TestCase):
+    """`len(parts) != 2` rejected two shapes that actually run.
+
+    The Codex notifier execs the script WITH a tasks directory, and an install
+    path containing a space splits into more tokens again -- so a production
+    watcher read as "not a watcher", which makes a duplicate invisible to the
+    tree count and hides the running process from the re-stamp branch. Every
+    existing case used the synthetic two-token form, so none of them could see it.
+    """
+
+    REAL = [
+        ("the synthetic form the older cases use", "bash src/watch-tasks-stream.sh"),
+        ("the notifier's production exec", "bash /repo/src/watch-tasks-stream.sh /w/tasks"),
+        ("an app checkout whose path has a space",
+         "bash /Users/x/Library/Application Support/Sutando/src/watch-tasks-stream.sh"),
+        ("both at once", "bash /Users/x/Application Support/src/watch-tasks-stream.sh /w/my tasks"),
+    ]
+    IMPOSTORS = [
+        ("a grep FOR the script", "grep watch-tasks-stream"),
+        ("a shell -c that merely mentions it", "bash -c ps | grep watch-tasks-stream"),
+        ("a similarly named script", "bash /repo/src/x-watch-tasks-stream.sh"),
+        ("the name inside a longer filename", "bash /repo/src/watch-tasks-stream.sh.bak"),
+        ("an unrelated shell script", "bash /repo/src/startup.sh"),
+    ]
+
+    def test_every_real_launch_shape_is_recognised(self):
+        for label, argv in self.REAL:
+            with self.subTest(shape=label):
+                self.assertTrue(hc._is_watcher_argv(argv), argv)
+
+    def test_the_controls_impostors_are_still_refused(self):
+        # Without these the predicate could pass by accepting anything.
+        for label, argv in self.IMPOSTORS:
+            with self.subTest(shape=label):
+                self.assertFalse(hc._is_watcher_argv(argv), argv)
+
+    def test_a_production_shaped_duplicate_is_counted_as_a_second_tree(self):
+        # The consequence: two real watchers read as one, so the duplicate the
+        # probe exists to find is invisible.
+        ps = ("  100 1 bash /repo/src/watch-tasks-stream.sh /w/tasks\n"
+              "  200 1 bash /repo/src/watch-tasks-stream.sh /w/tasks\n")
+        self.assertEqual(len(hc._watcher_trees(ps)), 2)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -84,14 +84,74 @@ class PoolHost(unittest.TestCase):
         self.assertIn("888", r["detail"])
         self.assertIn("Keep the tracked one(s) (200)", r["detail"])
 
-    def test_a_dead_sentinel_beside_a_live_one_does_not_warn(self):
-        """A worker that exited leaves its file; the rest are still correct."""
+    def test_a_dead_sentinel_beside_a_live_one_still_warns(self):
+        """A clean exit REMOVES the sentinel (the cleanup trap), so a file that
+        outlives its pid is a crash — and a live peer is a different instance,
+        not evidence about this one.
+
+        This assertion used to read `does_not_warn`, on the rationale that "a
+        worker that exited leaves its file". That contradicts the probe's own
+        docstring, and it pinned the false green rather than catching it.
+        """
         argv = lambda pid: "" if str(pid) == "100" else WATCHER_ARGV  # noqa: E731
         r = run({"watch-tasks-stream.pid": "100\n",
                  "watch-tasks-stream-worker-1.pid": "200\n"},
                 {"200": {"200"}}, argv=argv)
-        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertEqual(r["status"], "warn", r["detail"])
         self.assertIn("200", r["detail"])
+        self.assertIn("100", r["detail"])
+        self.assertIn("watch-tasks-stream.pid", r["detail"])
+
+    def test_a_reused_pid_beside_a_live_one_still_warns(self):
+        argv = lambda pid: ("/usr/bin/python3 unrelated" if str(pid) == "300"  # noqa: E731
+                            else WATCHER_ARGV)
+        r = run({"watch-tasks-stream.pid": "300\n",
+                 "watch-tasks-stream-worker-1.pid": "200\n"},
+                {"200": {"200"}}, argv=argv)
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("PID reuse", r["detail"])
+
+    def test_an_unreadable_sentinel_beside_a_live_one_still_warns(self):
+        r = run({"watch-tasks-stream.pid": "not-a-pid\n",
+                 "watch-tasks-stream-worker-1.pid": "200\n"},
+                {"200": {"200"}})
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("unreadable", r["detail"])
+
+    def test_a_clean_pool_is_still_ok(self):
+        """The negative control for the three above: nothing anomalous, no warn."""
+        r = run({"watch-tasks-stream.pid": "200\n",
+                 "watch-tasks-stream-worker-1.pid": "201\n"},
+                {"200": {"200"}, "201": {"201"}})
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_the_repair_writes_the_path_the_check_resolved(self):
+        """`fix_task_watcher_sentinel` used to re-derive the path from its own
+        environment, so a repair could stamp a different instance's file than
+        the one the check found missing."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "watch-tasks-stream-worker-9.pid"
+            # WORKSPACE_DIR is pinned inside the tempdir so a regression that
+            # re-derives the ambient path cannot reach a real workspace.
+            saved = (hc._proc_argv, hc._is_watcher_argv, hc.WORKSPACE_DIR)
+            try:
+                hc._proc_argv = lambda pid: WATCHER_ARGV
+                hc._is_watcher_argv = lambda argv: True
+                hc.WORKSPACE_DIR = Path(td) / "ws"
+                out = hc.fix_task_watcher_sentinel(
+                    {"_sentinel_restamp_pid": "4242",
+                     "_sentinel_restamp_path": str(target)})
+            finally:
+                (hc._proc_argv, hc._is_watcher_argv, hc.WORKSPACE_DIR) = saved
+            self.assertTrue(target.exists(), out)
+            self.assertFalse((Path(td) / "ws").exists(),
+                             "the repair touched the ambient workspace")
+            self.assertEqual(target.read_text().strip(), "4242")
+
+    def test_the_repair_refuses_when_the_check_named_no_path(self):
+        out = hc.fix_task_watcher_sentinel({"_sentinel_restamp_pid": "4242"})
+        self.assertIn("no sentinel path", out)
 
     def test_all_sentinels_dead_with_watchers_running_keeps_the_old_verdict(self):
         r = run({"watch-tasks-stream.pid": "100\n"}, {"777": {"777"}}, argv="")

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -29,8 +29,13 @@ except SystemExit:
 WATCHER_ARGV = "bash src/watch-tasks-stream.sh"
 
 
-def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True) -> dict:
-    """`sentinels` maps filename -> contents; `trees` maps root pid -> members."""
+def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
+        parent="1", pid_instance=None) -> dict:
+    """`sentinels` maps filename -> contents; `trees` maps root pid -> members.
+
+    `pid_instance` is what the WATCHER's own environment yields: a string names
+    its instance, "" is the default, and None means unreadable.
+    """
     with tempfile.TemporaryDirectory() as td:
         ws = Path(td)
         (ws / "state" / "cores").mkdir(parents=True)
@@ -39,18 +44,21 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True) -> dic
         for fn, text in sentinels.items():
             (ws / "state" / fn).write_text(text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-                 hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record)
+                 hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
+                 hc._pid_instance_id)
         try:
             hc.WORKSPACE_DIR = ws
             hc._proc_argv = (argv if callable(argv) else (lambda pid: argv))
             hc._watcher_trees = lambda *a, **k: trees
             hc._ps_snapshot = lambda *a, **k: ""
-            hc._pid_parent = lambda pid, ps=None: "1"
+            hc._pid_parent = lambda pid, ps=None: parent
             hc._fresh_local_core_record = lambda *a, **k: ({} if core_alive else None)
+            hc._pid_instance_id = lambda pid: pid_instance
             return hc.check_task_watcher()
         finally:
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-             hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record) = saved
+             hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
+             hc._pid_instance_id) = saved
 
 
 class PoolHost(unittest.TestCase):
@@ -186,6 +194,45 @@ class SingleInstanceUnchanged(unittest.TestCase):
         r = run({"watch-tasks-stream.pid": "100\n"}, {}, argv="")
         self.assertEqual(r["status"], "warn")
         self.assertIn("is dead", r["detail"])
+
+
+class TheRestampTargetComesFromTheWATCHERsIdentity(unittest.TestCase):
+    """A sentinel-less watcher is re-stamped at ITS path, never at this process's.
+
+    The probe runs with the host's ambient environment. Deriving the repair target
+    from that names the canonical file for a NAMED watcher: the wrong instance is
+    claimed, and the watcher's own exit trap removes a different filename, leaving
+    the bare sentinel stale and pointing at a pid that is not the canonical core's.
+    """
+
+    SUPERVISED = {"trees": {"901": {"901"}}, "parent": "900"}
+
+    def test_a_named_watcher_is_re_stamped_at_its_own_path(self):
+        r = run({}, **self.SUPERVISED, pid_instance="worker-7")
+        self.assertEqual(r["status"], "warn")
+        target = Path(r["_sentinel_restamp_path"]).name
+        self.assertNotEqual(target, "watch-tasks-stream.pid",
+                            "the canonical name claims the wrong instance")
+        self.assertIn("worker-7", target)
+
+    def test_the_default_watcher_still_gets_the_canonical_path(self):
+        # The fix must not refuse the case it was already handling correctly.
+        r = run({}, **self.SUPERVISED, pid_instance="")
+        self.assertEqual(Path(r["_sentinel_restamp_path"]).name, "watch-tasks-stream.pid")
+
+    def test_an_unreadable_identity_offers_NO_repair_target(self):
+        r = run({}, **self.SUPERVISED, pid_instance=None)
+        self.assertEqual(r["status"], "warn")
+        self.assertNotIn("_sentinel_restamp_path", r,
+                         "a guessed target is published as a repair instruction")
+        self.assertIn("_sentinel_restamp_pid", r, "the pid is still reported")
+        self.assertIn("unreadable", r["detail"])
+
+    def test_the_watcher_is_never_prescribed_for_stopping_in_any_of_them(self):
+        for inst in ("worker-7", "", None):
+            with self.subTest(instance=inst):
+                r = run({}, **self.SUPERVISED, pid_instance=inst)
+                self.assertIn("Do NOT stop it", r["detail"])
 
 
 if __name__ == "__main__":

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -275,5 +275,63 @@ class TheRestampTargetComesFromTheWATCHERsIdentity(unittest.TestCase):
                 self.assertIn("Do NOT stop it", r["detail"])
 
 
+class ThePsFallbackProvesAbsenceNeverAValue(unittest.TestCase):
+    """`ps` concatenates argv and env with spaces, so a value containing one is
+    unrecoverable: `worker 7` reads back as `worker`.
+
+    That is not a fails-safe error — it names a DIFFERENT sentinel, and the pair
+    are genuinely distinct keys (`watcher-a+worker%207` vs `watcher-a+worker`),
+    so the repair would re-stamp another instance's file. The fallback can prove
+    the environment was printed and the name absent; it cannot prove a value.
+    """
+
+    class _R:
+        def __init__(self, out):
+            self.stdout, self.returncode, self.stderr = out, 0, ""
+
+    def _read(self, out):
+        saved = hc.subprocess.run
+        try:
+            hc.subprocess.run = lambda *a, **k: self._R(out)
+            return hc._pid_env_first("999", ("SUTANDO_INSTANCE_ID",))
+        finally:
+            hc.subprocess.run = saved
+
+    def test_a_whitespace_value_is_refused_not_truncated(self):
+        self.assertIsNone(self._read("sleep 8 FOO=1 SUTANDO_INSTANCE_ID=worker 7 BAR=2"))
+
+    def test_even_a_plain_value_is_refused_because_wholeness_is_unprovable(self):
+        self.assertIsNone(self._read("sleep 8 FOO=1 SUTANDO_INSTANCE_ID=worker-7 BAR=2"))
+
+    def test_the_control_a_printed_environment_can_still_prove_absence(self):
+        # Or the refusal could pass by answering None to everything.
+        self.assertEqual(self._read("sleep 8 FOO=1 BAR=2"), "")
+
+    def test_the_control_no_environment_at_all_is_still_unreadable(self):
+        self.assertIsNone(self._read("sleep 8"))
+
+    def test_the_two_identities_it_would_have_confused_are_distinct(self):
+        # The premise: if these collapsed, truncation would be harmless.
+        sys.path.insert(0, str(ROOT / "src" / "runtime-api"))
+        ik = importlib.import_module("instance_key")
+        self.assertNotEqual(ik.instance_key("watcher-a", "worker 7"),
+                            ik.instance_key("watcher-a", "worker"))
+
+
+class TheActorPrecedenceComesFromItsOwner(unittest.TestCase):
+    """A consumer reading another process's identity must use the same order the
+    owner uses; a second copy of the list is how the two answer differently."""
+
+    def test_health_check_reads_the_owners_list(self):
+        sys.path.insert(0, str(ROOT / "src" / "runtime-api"))
+        rundir = importlib.import_module("rundir")
+        self.assertEqual(tuple(hc.actor_env_names()), tuple(rundir.ACTOR_ENV_NAMES))
+
+    def test_no_local_copy_of_the_list_remains(self):
+        src = (ROOT / "src" / "health-check.py").read_text()
+        self.assertNotIn('"AGENT_MXID"', src,
+                         "the precedence is spelled here again, so it can drift")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -263,6 +263,60 @@ class SingleInstanceUnchanged(unittest.TestCase):
         self.assertIn("is dead", r["detail"])
 
 
+class NoLiveFaultsAggregateBeforeAnyAdvice(unittest.TestCase):
+    """keweichen at a5933d4f: each no-live early return preceded the aggregate,
+    so a second fault class was discarded and an UNKNOWN turned into restart
+    advice for a watcher it could not identify. The single-fault cases above are
+    the positive controls; these are the cross-product."""
+
+    UNREADABLE = {"watch-tasks-stream.pid": "not-a-pid\n"}
+
+    def test_unreadable_plus_unprovable_does_not_advise_restart(self):
+        r = run(dict(self.UNREADABLE, **{"watch-tasks-stream-b.pid": "100\n"}),
+                {}, verdicts={"100": None})
+        self.assertNotIn("restart the watcher", r["detail"],
+            "an unprovable identity must veto restart advice; restarting can "
+            "duplicate the live watcher behind the pid we could not identify")
+
+    def test_unreadable_plus_unprovable_keeps_BOTH_records(self):
+        r = run(dict(self.UNREADABLE, **{"watch-tasks-stream-b.pid": "100\n"}),
+                {}, verdicts={"100": None})
+        self.assertIn("unreadable PID sentinel", r["detail"])
+        self.assertIn("UNKNOWN", r["detail"],
+            "the aggregate must carry every class, not the first one matched")
+
+    def test_dead_plus_unreadable_keeps_both(self):
+        r = run(dict(self.UNREADABLE, **{"watch-tasks-stream-b.pid": "100\n"}),
+                {}, argv="")
+        self.assertIn("unreadable PID sentinel", r["detail"])
+        self.assertIn("is dead", r["detail"])
+
+    def test_unprovable_with_visible_roots_gives_no_stop_advice(self):
+        """With roots visible the advice names pids to stop. An unprovable
+        sentinel must suppress that too -- same veto, other direction."""
+        r = run(dict(self.UNREADABLE, **{"watch-tasks-stream-b.pid": "100\n"}),
+                {"200": {"200"}}, verdicts={"100": None}, targets={})
+        # Assert it REACHES the aggregate first: unfixed, this returned early
+        # with restart advice and never reached the roots branch, so a bare
+        # assertNotIn("safe to stop") passed for the wrong reason.
+        self.assertIn("watcher(s) still run", r["detail"],
+            "must reach the roots aggregate, not return on the first fault")
+        self.assertNotIn("restart the watcher", r["detail"],
+            "advising a restart while a watcher tree is visible is the "
+            "duplicate-maker this branch exists to prevent")
+        self.assertNotIn("safe to stop", r["detail"],
+            "a stop list published beside an unprovable identity invites "
+            "killing the watcher we could not identify")
+
+    def test_single_fault_positive_controls_are_unchanged(self):
+        unreadable = run(self.UNREADABLE, {})
+        self.assertIn("restart the watcher", unreadable["detail"],
+            "lone unreadable sentinel still warrants a restart")
+        unprovable = run({"watch-tasks-stream.pid": "100\n"}, {},
+                         verdicts={"100": None})
+        self.assertIn("not restarting and not stopping", unprovable["detail"])
+
+
 class TheRestampTargetComesFromTheWATCHERsIdentity(unittest.TestCase):
     """A sentinel-less watcher is re-stamped at ITS path, never at this process's.
 

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -481,7 +481,9 @@ class TheWatcherPredicateIsAShapeNotAFieldCount(unittest.TestCase):
     def test_every_real_launch_shape_is_recognised(self):
         for label, argv in self.REAL:
             with self.subTest(shape=label):
-                self.assertIs(hc._is_watcher_argv(argv), True, argv)
+                # Reviewer-directed, #3875 at ad7f1bf7: without the OS vector a
+                # flattened argv is UNKNOWN, so it may not authorize repair.
+                self.assertIsNot(hc._is_watcher_argv(argv), False, argv)
 
     def test_an_undecidable_real_shape_is_never_REJECTED(self):
         # The defect this class was written for: a production watcher read as "not
@@ -546,6 +548,40 @@ class WhitespaceInsideAPathnameIsNotAnArgvBoundary(unittest.TestCase):
     def test_a_spaced_DIRECTORY_still_recognises_a_real_watcher(self):
         # The control that stops the fix from becoming "reject anything with a space".
         self.assertIs(self._with_vector("spaced dir/src/watch-tasks-stream.sh"), True)
+
+
+
+class AnUnreadableVectorSaysUnknownNeverTrue(unittest.TestCase):
+    """Reviewer-directed, #3875 at ad7f1bf7.
+
+    `assertIsNot(..., False)` in the launch-shape test is satisfied by True, so
+    relaxing it left the fallback unpinned. These assert the positive shape: an
+    ambiguous flattened argv is UNKNOWN, an unambiguous one is still True, and
+    UNKNOWN is counted as a tree rather than dropped.
+    """
+
+    AMBIGUOUS = "bash /repo/watch-tasks-stream.sh backup"
+    EXACT = "bash /repo/src/watch-tasks-stream.sh"
+
+    def _flat(self, argv):
+        orig = hc._proc_argv_vector
+        hc._proc_argv_vector = lambda pid: None
+        try:
+            return hc._is_watcher_argv(argv, 4242)
+        finally:
+            hc._proc_argv_vector = orig
+
+    def test_ambiguous_flattened_argv_is_unknown_not_true(self):
+        self.assertIsNone(self._flat(self.AMBIGUOUS),
+            "a flattened argv with trailing tokens cannot authorize repair")
+
+    def test_argv_ending_at_the_script_is_still_true(self):
+        self.assertIs(self._flat(self.EXACT), True,
+            "the unambiguous two-token shape must stay recognised")
+
+    def test_unknown_is_still_counted_as_a_tree(self):
+        trees = hc._watcher_trees("  4242 1 %s\n" % self.AMBIGUOUS)
+        self.assertTrue(trees, "UNKNOWN must count as a watcher, never read as absent")
 
 
 

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -510,5 +510,44 @@ class TheWatcherPredicateIsAShapeNotAFieldCount(unittest.TestCase):
         self.assertEqual(len(hc._watcher_trees(ps)), 2)
 
 
+class WhitespaceInsideAPathnameIsNotAnArgvBoundary(unittest.TestCase):
+    """Reported by qingyun-wu on #3875 at 631e7fea, with real launched processes.
+
+    The vector branch matched the script NAME anywhere in vec[1] via a regex whose
+    `[\\s/]` alternative treats a space as a component boundary. Inside one
+    authoritative pathname it is not: `backup/copy watch-tasks-stream.sh` is a file
+    named `copy watch-tasks-stream.sh`, and publishing its pid points cleanup at an
+    unrelated process. Compare the exact final component instead.
+    """
+
+    TABLE = [("plain/src/watch-tasks-stream.sh", True),
+             ("spaced dir/src/watch-tasks-stream.sh", True),
+             ("backup/watch-tasks-stream.sh backup", False),
+             ("backup/copy watch-tasks-stream.sh", False),
+             ("backup/watch-tasks-stream.sh.bak", False)]
+
+    def _with_vector(self, path):
+        orig = hc._proc_argv_vector
+        hc._proc_argv_vector = lambda pid: ["/bin/bash", path]
+        try:
+            return hc._is_watcher_argv("bash " + path, 4242)
+        finally:
+            hc._proc_argv_vector = orig
+
+    def test_the_reported_table_holds(self):
+        for path, want in self.TABLE:
+            self.assertIs(self._with_vector(path), want, path)
+
+    def test_a_name_that_is_not_the_final_component_is_refused(self):
+        # The two rows that published a wrong pid; each fails if the regex returns.
+        for path in ("backup/watch-tasks-stream.sh backup", "backup/copy watch-tasks-stream.sh"):
+            self.assertIs(self._with_vector(path), False, path)
+
+    def test_a_spaced_DIRECTORY_still_recognises_a_real_watcher(self):
+        # The control that stops the fix from becoming "reject anything with a space".
+        self.assertIs(self._with_vector("spaced dir/src/watch-tasks-stream.sh"), True)
+
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -646,15 +646,21 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
 
     W = "/repo/src/watch-tasks-stream.sh"
 
-    def _detail(self, ps):
-        orig = (hc._ps_snapshot, hc._proc_argv_vector, hc.watcher_sentinel_paths)
+    def _detail(self, ps, targets=None):
+        """`targets` maps pid -> sentinel target. Absent, identity is unreadable,
+        which is itself a case: the duplicate claim must not be made from a count."""
+        orig = (hc._ps_snapshot, hc._proc_argv_vector, hc.watcher_sentinel_paths,
+                hc._watcher_sentinel_target)
         hc._ps_snapshot = lambda: ps
         hc._proc_argv_vector = lambda pid: None
         hc.watcher_sentinel_paths = lambda sd: []
+        if targets is not None:
+            hc._watcher_sentinel_target = lambda sd, pid, _m=targets: _m.get(str(pid))
         try:
             return hc.check_task_watcher().get("detail") or ""
         finally:
-            hc._ps_snapshot, hc._proc_argv_vector, hc.watcher_sentinel_paths = orig
+            (hc._ps_snapshot, hc._proc_argv_vector, hc.watcher_sentinel_paths,
+             hc._watcher_sentinel_target) = orig
 
     def test_two_supervised_roots_are_never_told_to_stop(self):
         d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")
@@ -681,9 +687,32 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
         self.assertNotIn("Do NOT stop", d)
 
     def test_the_duplicate_processing_cost_is_still_stated(self):
-        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")
+        """A PROVEN duplicate — both roots resolve to one target — must still say
+        what it costs. The identity is what makes the claim true."""
+        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n",
+                         targets={"901": "/s/w-a.pid", "902": "/s/w-a.pid"})
         self.assertIn("processed 2x", d,
             "the reason a duplicate matters must survive the softened advice")
+
+    def test_two_DISTINCT_instances_are_not_called_duplicates(self):
+        """qingyun-wu, #3875: losing the last sentinel must not turn two instances
+        into duplicate workers, and must not authorise reducing the count."""
+        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n",
+                         targets={"901": "/s/w-a.pid", "902": "/s/w-b.pid"})
+        self.assertIn("DISTINCT", d)
+        self.assertNotIn("processed 2x", d)
+        self.assertIn("do not reduce the count", d)
+        self.assertNotIn("reduce the count through the launcher", d,
+            "the affirmative reduce instruction must not survive a distinct-instance verdict")
+
+    def test_unreadable_identity_does_not_authorise_reduction(self):
+        """No identity, no duplicate claim: it may be one instance twice or two once."""
+        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")
+        self.assertIn("UNKNOWN", d)
+        self.assertNotIn("processed 2x", d)
+        self.assertIn("do not reduce the count", d)
+        self.assertNotIn("reduce the count through the launcher", d,
+            "unreadable identity must not authorise reduction")
 
 
 

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -608,14 +608,16 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
     def test_two_supervised_roots_are_never_told_to_stop(self):
         d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")
         self.assertNotIn("stop them", d, "blanket stop advice over supervised roots")
-        self.assertIn("do NOT stop any", d)
+        self.assertIn("Do NOT stop any of them", d)
         self.assertIn("supervised: 901, 902", d)
 
     def test_an_ownerless_root_is_still_named_as_stoppable(self):
         # The control: the fix must not become "never stop anything".
         d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n")
-        self.assertIn("stop the ownerless one(s) first: 903", d)
-        self.assertNotIn("do NOT stop any", d)
+        self.assertIn("orphaned watcher(s)", d)
+        self.assertIn("stop them and restart one cleanly", d)
+        self.assertIn("ownerless: 903", d)
+        self.assertNotIn("Do NOT stop any of them", d)
 
     def test_the_duplicate_processing_cost_is_still_stated(self):
         d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -642,6 +642,18 @@ class AnUnreadableVectorSaysUnknownNeverTrue(unittest.TestCase):
 
 
 
+class ADeadSentinelDoesNotLicenseStoppingASoleWatcher(unittest.TestCase):
+    """keweichen at 70a8887d: with every sentinel dead, an ownerless root is its
+    instance's only watcher unless a supervised peer serves the same target."""
+
+    def test_the_sole_live_ownerless_watcher_is_not_safe_to_stop(self):
+        r = run({"watch-tasks-stream-A.pid": "111\n"}, {"903": {"903"}},
+                argv=lambda pid: None if str(pid) == "111" else WATCHER_ARGV,
+                targets={"903": "B.pid"})
+        self.assertIn("do NOT stop 903", r["detail"])
+        self.assertIn("safe to stop: none", r["detail"])
+
+
 class SentinelReconciliationLosesNoRecord(unittest.TestCase):
     """keweichen at e3fbc2cf: `live[spid] = sp` is keyed by pid, so a second
     sentinel naming that pid vanished and the check reported a false green."""
@@ -791,9 +803,11 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
             f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n"
             f"  904 1 bash {self.W}\n",
             targets={"901": "/s/A.pid", "903": "/s/A.pid", "904": "/s/B.pid"})
-        self.assertIn("restart 1 cleanly", d)
-        self.assertIn("must NOT be restarted", d)
-        self.assertNotIn("restart 2 cleanly", d)
+        # keweichen: cardinality alone lets an operator restart the covered pid
+        # and leave the uncovered instance absent. Name which is which.
+        self.assertIn("restart 904", d)
+        self.assertIn("NOT 903", d)
+        self.assertNotIn("restart 2", d)
 
     def test_an_UNKNOWN_SUPERVISED_root_licenses_no_ownerless_action(self):
         """If 901 is actually A, restarting duplicates it; if it is not, stopping

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -611,13 +611,23 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
         self.assertIn("Do NOT stop any of them", d)
         self.assertIn("supervised: 901, 902", d)
 
-    def test_an_ownerless_root_is_still_named_as_stoppable(self):
-        # The control: the fix must not become "never stop anything".
+    def test_mixed_ownership_names_only_the_ownerless_as_stoppable(self):
+        # 901 is supervised (ppid 900 alive), 903 is ownerless (ppid 1). Reported by
+        # qingyun-wu on #3875: the blanket form told an operator to stop 901 too.
         d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n")
-        self.assertIn("orphaned watcher(s)", d)
-        self.assertIn("stop them and restart one cleanly", d)
+        self.assertIn("Stop ONLY the ownerless (903)", d)
+        self.assertIn("Do NOT stop 901", d)
+        self.assertNotIn("stop them and restart one cleanly", d,
+            "the blanket instruction must not survive when a supervised root is present")
         self.assertIn("ownerless: 903", d)
-        self.assertNotIn("Do NOT stop any of them", d)
+        self.assertIn("supervised: 901", d)
+
+    def test_an_all_ownerless_set_is_still_stoppable(self):
+        # The control: the fix must not become "never stop anything".
+        d = self._detail(f"  900 1 /bin/zsh -l\n  903 1 bash {self.W}\n  904 1 bash {self.W}\n")
+        self.assertIn("2 orphaned watcher(s)", d)
+        self.assertIn("stop them and restart one cleanly", d)
+        self.assertNotIn("Do NOT stop", d)
 
     def test_the_duplicate_processing_cost_is_still_stated(self):
         d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -642,6 +642,57 @@ class AnUnreadableVectorSaysUnknownNeverTrue(unittest.TestCase):
 
 
 
+class MultiplicitySurvivesToTheDiagnosis(unittest.TestCase):
+    """keweichen's invariant, #3875: every case tonight was one shape — a
+    multi-map reduced to a set before the multiplicity decision was finished.
+
+    So assert the property across the matrix rather than one regression row at a
+    time: wherever N roots share a target, the diagnosis must still be able to
+    say N, and must never advise an action that assumes one.
+    """
+
+    W = "/repo/src/watch-tasks-stream.sh"
+
+    def _d(self, ps, targets):
+        return StopAdviceNeverTargetsASupervisedWatcher._detail(self, ps, targets=targets)
+
+    def test_every_shared_target_is_still_countable_in_the_verdict(self):
+        cases = [
+            # (label, supervised, ownerless, targets, must_appear)
+            ("two ownerless on one uncovered target",
+             ["901"], ["903", "904", "905"],
+             {"901": "/s/A.pid", "903": "/s/A.pid", "904": "/s/B.pid", "905": "/s/B.pid"},
+             ["restart 904 and NOT", "peer above already covers"]),
+            ("three ownerless, three distinct targets",
+             ["901"], ["903", "904", "905"],
+             {"901": "/s/A.pid", "903": "/s/B.pid", "904": "/s/C.pid", "905": "/s/D.pid"},
+             ["restart"]),
+            ("all ownerless share one target",
+             [], ["903", "904"],
+             {"903": "/s/B.pid", "904": "/s/B.pid"},
+             ["restart one cleanly"]),
+        ]
+        for label, sup, own, targets, must in cases:
+            with self.subTest(label):
+                ps = "  900 1 /bin/zsh -l\n"
+                ps += "".join(f"  {p} 900 bash {self.W}\n" for p in sup)
+                ps += "".join(f"  {p} 1 bash {self.W}\n" for p in own)
+                d = self._d(ps, targets)
+                for m in must:
+                    self.assertIn(m, d, f"{label}: {d}")
+                # the invariant: never advise restarting more watchers than there
+                # are distinct uncovered targets
+                sup_t = {targets[p] for p in sup if p in targets}
+                own_t = {targets[p] for p in own if p in targets}
+                uncovered = len(own_t - sup_t)
+                import re as _re
+                named = _re.search(r"then restart ([0-9, ]+?) and NOT", d)
+                if named:
+                    self.assertLessEqual(
+                        len([x for x in named.group(1).split(",") if x.strip()]), uncovered,
+                        f"{label}: restarts more than the {uncovered} uncovered target(s): {d}")
+
+
 class ExtraTreesKeepTheirMultiplicity(unittest.TestCase):
     """keweichen: extras distinct from every TRACKED target can still duplicate
     EACH OTHER, and calling them "not duplicates" erased that."""

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -33,7 +33,7 @@ WATCHER_ARGV = "bash src/watch-tasks-stream.sh"
 
 
 def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
-        parent="1", pid_instance=None, pid_actor="") -> dict:
+        parent="1", pid_instance=None, pid_actor="", targets=None) -> dict:
     """`sentinels` maps filename -> contents; `trees` maps root pid -> members.
 
     `pid_instance` is what the WATCHER's own environment yields: a string names
@@ -48,7 +48,7 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
             (ws / "state" / fn).write_text(text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
                  hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
-                 hc._pid_instance_id, hc._pid_actor_id)
+                 hc._pid_instance_id, hc._pid_actor_id, hc._watcher_sentinel_target)
         try:
             hc.WORKSPACE_DIR = ws
             hc._proc_argv = (argv if callable(argv) else (lambda pid: argv))
@@ -58,11 +58,18 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
             hc._fresh_local_core_record = lambda *a, **k: ({} if core_alive else None)
             hc._pid_instance_id = lambda pid: pid_instance
             hc._pid_actor_id = lambda pid: pid_actor
+            if targets is not None:
+                # Per-pid sentinel TARGET, which is what decides duplicate vs
+                # separate instance. A pid absent from the map is unresolvable.
+                hc._watcher_sentinel_target = (
+                    lambda sd, pid, _m=targets: (
+                        (ws / "state" / _m[str(pid)]) if str(pid) in _m else None))
             return hc.check_task_watcher()
         finally:
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
              hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
-             hc._pid_instance_id, hc._pid_actor_id) = saved
+             hc._pid_instance_id, hc._pid_actor_id,
+             hc._watcher_sentinel_target) = saved
 
 
 class PoolHost(unittest.TestCase):
@@ -90,11 +97,55 @@ class PoolHost(unittest.TestCase):
         self.assertNotIn("stop them and restart one cleanly", r["detail"])
 
     def test_only_the_untracked_root_is_named(self):
+        """888 resolves to the SAME sentinel target as tracked 200, so it really
+        is a duplicate. Without the identity this case pinned the unsafe premise
+        that a second root is a duplicate by arithmetic alone."""
         r = run({"watch-tasks-stream-worker-1.pid": "200\n"},
-                {"200": {"200"}, "888": {"888"}})
+                {"200": {"200"}, "888": {"888"}},
+                targets={"200": "watch-tasks-stream-worker-1.pid",
+                         "888": "watch-tasks-stream-worker-1.pid"})
         self.assertEqual(r["status"], "warn")
         self.assertIn("888", r["detail"])
         self.assertIn("Keep the tracked one(s) (200)", r["detail"])
+
+    def test_a_stranger_carrying_the_script_NAME_is_not_a_live_watcher(self):
+        """The sentinel's pid must be validated by the module's own predicate.
+
+        A substring test on argv accepts any process that merely mentions
+        `watch-tasks-stream.sh` -- e.g. as a data argument -- and reports the
+        watcher healthy while nothing drains tasks/.
+        """
+        impostor = "/usr/bin/python3 -c import time;time.sleep(9) watch-tasks-stream.sh"
+        r = run({"watch-tasks-stream-worker-1.pid": "200\n"}, {}, argv=impostor)
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertNotIn("watcher is running", r["detail"])
+        self.assertTrue(
+            "not the watcher" in r["detail"] or "UNKNOWN" in r["detail"],
+            f"a stranger must read as PID reuse or UNKNOWN, got: {r['detail']}")
+
+    def test_a_DISTINCT_target_is_a_separate_instance_not_a_duplicate(self):
+        """worker-b is not worker-a running twice. Telling an operator to reduce
+        the count here removes the only watcher for that instance."""
+        r = run({"watch-tasks-stream-worker-a.pid": "901\n"},
+                {"901": {"901"}, "902": {"902"}},
+                targets={"901": "watch-tasks-stream-worker-a.pid",
+                         "902": "watch-tasks-stream-worker-b.pid"})
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("DIFFERENT instance", r["detail"])
+        self.assertIn("Do NOT stop", r["detail"])
+        self.assertNotIn("duplicate its work", r["detail"])
+
+    def test_an_UNREADABLE_identity_authorises_no_action(self):
+        """Unknown identity must not license stop OR reduce: the same sentence
+        recreates a duplicate for one instance and orphans another."""
+        r = run({"watch-tasks-stream-worker-a.pid": "901\n"},
+                {"901": {"901"}, "903": {"903"}},
+                targets={"901": "watch-tasks-stream-worker-a.pid"})
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("UNKNOWN", r["detail"])
+        self.assertIn("903", r["detail"])
+        self.assertNotIn("safe to stop", r["detail"])
+        self.assertNotIn("reduce the count", r["detail"])
 
     def test_a_dead_sentinel_beside_a_live_one_still_warns(self):
         """A clean exit REMOVES the sentinel (the cleanup trap), so a file that

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -669,21 +669,22 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
         self.assertIn("supervised: 901, 902", d)
 
     def test_mixed_ownership_names_only_the_ownerless_as_stoppable(self):
-        # 901 is supervised (ppid 900 alive), 903 is ownerless (ppid 1). Reported by
-        # qingyun-wu on #3875: the blanket form told an operator to stop 901 too.
-        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n")
+        """With identities resolved, the ownerless root is the only stop target."""
+        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n",
+                         targets={"901": "/s/a.pid", "903": "/s/c.pid"})
         self.assertIn("Stop ONLY the ownerless (903)", d)
         self.assertIn("Do NOT stop 901", d)
-        self.assertNotIn("stop them and restart one cleanly", d,
-            "the blanket instruction must not survive when a supervised root is present")
-        self.assertIn("ownerless: 903", d)
-        self.assertIn("supervised: 901", d)
 
     def test_an_all_ownerless_set_is_still_stoppable(self):
-        # The control: the fix must not become "never stop anything".
-        d = self._detail(f"  900 1 /bin/zsh -l\n  903 1 bash {self.W}\n  904 1 bash {self.W}\n")
+        """The control: the fix must not become "never stop anything".
+
+        Both roots resolve to ONE target, so they really are duplicates and the
+        stop-and-restart-one advice is correct here.
+        """
+        d = self._detail(f"  900 1 /bin/zsh -l\n  903 1 bash {self.W}\n  904 1 bash {self.W}\n",
+                         targets={"903": "/s/a.pid", "904": "/s/a.pid"})
         self.assertIn("2 orphaned watcher(s)", d)
-        self.assertIn("stop them and restart one cleanly", d)
+        self.assertIn("restart one cleanly", d)
         self.assertNotIn("Do NOT stop", d)
 
     MIXED = None  # set in the cases below
@@ -706,9 +707,40 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
     def test_mixed_ownership_UNKNOWN_identity_is_not_reduced(self):
         d = self._mixed({})   # stated: no pid resolves
         self.assertIn("UNKNOWN", d)
-        self.assertIn("Stop ONLY the ownerless (903)", d)
+        self.assertIn("Do NOT stop 903", d,
+            "an ownerless root whose identity is unreadable is not safe to stop either")
         self.assertNotIn("reduce those through the launcher", d,
             "unreadable identity must not authorise reduction in the mixed branch either")
+
+    def _own(self, ps, targets):
+        return self._detail(ps, targets=targets)
+
+    def test_distinct_all_ownerless_restart_ONE_PER_INSTANCE(self):
+        """keweichen, #3875: 'stop them and restart one' strands an instance when
+        the ownerless roots are distinct. Parentage is not restart cardinality."""
+        d = self._own(f"  901 1 bash {self.W}\n  902 1 bash {self.W}\n",
+                      {"901": "/s/a.pid", "902": "/s/b.pid"})
+        self.assertIn("restart 2 cleanly", d)
+        self.assertIn("one per instance", d)
+
+    def test_an_UNKNOWN_ownerless_root_is_not_named_safe_to_stop(self):
+        d = self._own(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n",
+                      {"901": "/s/a.pid"})
+        self.assertIn("Do NOT stop 903", d)
+        self.assertIn("UNKNOWN identity", d)
+
+    def test_an_ownerless_duplicate_of_a_SUPERVISED_root_is_not_restarted(self):
+        """Stopping 903 then restarting one recreates the duplicate: 901 already
+        serves that instance."""
+        d = self._own(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n",
+                      {"901": "/s/a.pid", "903": "/s/a.pid"})
+        self.assertIn("do NOT restart", d)
+        self.assertNotIn("and restart one cleanly", d)
+
+    def test_a_lone_ownerless_watcher_is_still_restarted(self):
+        """The advice survives where it is correct, or the gate is a mute."""
+        d = self._own(f"  901 1 bash {self.W}\n", {"901": "/s/a.pid"})
+        self.assertIn("restart one cleanly", d)
 
     def test_reduction_reads_the_SUPERVISED_subset_not_every_root(self):
         """901 and 902 are distinct instances; the OWNERLESS 903 duplicates 901.

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -655,11 +655,32 @@ class SentinelReconciliationLosesNoRecord(unittest.TestCase):
 
     def test_an_UNPROVABLE_sentinel_is_a_fault_beside_a_live_one(self):
         """A live peer does not clear another instance's unprovable record."""
+        # keweichen: production RETAINS the argv-UNKNOWN tree, and omitting it
+        # here is what let the extras branch bypass the fault aggregation.
         r = run({"watch-tasks-stream-a.pid": "100\n",
-                 "watch-tasks-stream-b.pid": "200\n"}, {"100": {"100"}},
+                 "watch-tasks-stream-b.pid": "200\n"},
+                {"100": {"100"}, "200": {"200"}},
                 verdicts={"100": True, "200": None})
         self.assertEqual(r["status"], "warn", r["detail"])
         self.assertNotIn("streaming watcher alive", r["detail"])
+
+
+    def test_an_UNKNOWN_sentinel_vetoes_advice_about_an_extra_tree(self):
+        """keweichen at 70a8887d: the extras schedules returned BEFORE the fault
+        aggregation, so an unprovable sentinel produced "belongs to a DIFFERENT
+        instance whose sentinel is missing" — and, when both resolved to one
+        target, "ownerless, safe to stop" for a pid whose sentinel exists."""
+        r = run({"watch-tasks-stream-a.pid": "100\n",
+                 "watch-tasks-stream-b.pid": "200\n"},
+                {"100": {"100"}, "200": {"200"}},
+                verdicts={"100": True, "200": None},
+                targets={"100": "watch-tasks-stream-a.pid",
+                         "200": "watch-tasks-stream-a.pid"})
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("unprovable", r["detail"])
+        self.assertIn("no stop or restart is advised", r["detail"])
+        self.assertNotIn("safe to stop", r["detail"])
+        self.assertNotIn("sentinel is missing", r["detail"])
 
 
 class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -33,7 +33,8 @@ WATCHER_ARGV = "bash src/watch-tasks-stream.sh"
 
 
 def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
-        parent="1", pid_instance=None, pid_actor="", targets=None, verdicts=None) -> dict:
+        parent="1", pid_instance=None, pid_actor="", targets=None, verdicts=None,
+        ps="") -> dict:
     """`sentinels` maps filename -> contents; `trees` maps root pid -> members.
 
     `pid_instance` is what the WATCHER's own environment yields: a string names
@@ -59,8 +60,9 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
                 hc._is_watcher_argv = (
                     lambda a, pid=None, _v=verdicts: _v.get(str(pid), True))
             hc._watcher_trees = lambda *a, **k: trees
-            hc._ps_snapshot = lambda *a, **k: ""
-            hc._pid_parent = lambda pid, ps=None: parent
+            hc._ps_snapshot = lambda *a, **k: ps
+            hc._pid_parent = (parent if callable(parent)
+                              else (lambda pid, _p=None: parent))
             hc._fresh_local_core_record = lambda *a, **k: ({} if core_alive else None)
             hc._pid_instance_id = lambda pid: pid_instance
             hc._pid_actor_id = lambda pid: pid_actor
@@ -710,12 +712,37 @@ class ExtraTreesKeepTheirMultiplicity(unittest.TestCase):
         self.assertIn("777", r["detail"])
         self.assertNotIn("Do NOT stop them", r["detail"])
 
+    W2 = "bash /repo/src/watch-tasks-stream.sh"
+
+    def _peer(self, parents):
+        """Extras 200 and 300 both on target B; `parents` sets their ownership."""
+        ps = f"  900 1 /bin/zsh -l\n  100 1 {self.W2}\n  200 {parents['200']} {self.W2}\n" \
+             f"  300 {parents['300']} {self.W2}\n"
+        return run({"watch-tasks-stream-A.pid": "100\n"},
+                   {"100": {"100"}, "200": {"200"}, "300": {"300"}},
+                   parent=lambda pid, p=None: parents.get(str(pid), "1"),
+                   ps=ps,
+                   targets={"100": "A.pid", "200": "B.pid", "300": "B.pid"})
+
+    def test_peer_duplicates_MIXED_keep_the_supervised_one(self):
+        """qingyun-wu at 5425c7ad: "keep ONE and stop the rest" can name a
+        watcher with a live parent — the thing this PR exists to prevent."""
+        r = self._peer({"100": "1", "200": "900", "300": "1"})
+        self.assertIn("keep the supervised 200", r["detail"])
+        self.assertIn("stop the ownerless 300", r["detail"])
+
+    def test_peer_duplicates_ALL_supervised_are_not_stopped(self):
+        r = self._peer({"100": "1", "200": "900", "300": "900"})
+        self.assertIn("ALL supervised", r["detail"])
+        self.assertIn("do NOT stop them", r["detail"])
+        self.assertNotIn("keep ONE and stop", r["detail"])
+
     def test_two_extras_on_one_target_are_duplicates_of_each_other(self):
         r = run({"watch-tasks-stream-A.pid": "100\n"},
                 {"100": {"100"}, "200": {"200"}, "300": {"300"}},
                 targets={"100": "A.pid", "200": "B.pid", "300": "B.pid"})
         self.assertIn("share one instance", r["detail"])
-        self.assertIn("keep ONE of each", r["detail"])
+        self.assertIn("keep ONE and stop the rest", r["detail"])
         # the old wording called them "not duplicates" full stop, which erased
         # that they duplicate EACH OTHER; qualified is fine, unqualified is not.
         self.assertNotIn("not duplicates; each", r["detail"])

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -33,7 +33,7 @@ WATCHER_ARGV = "bash src/watch-tasks-stream.sh"
 
 
 def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
-        parent="1", pid_instance=None, pid_actor="", targets=None) -> dict:
+        parent="1", pid_instance=None, pid_actor="", targets=None, verdicts=None) -> dict:
     """`sentinels` maps filename -> contents; `trees` maps root pid -> members.
 
     `pid_instance` is what the WATCHER's own environment yields: a string names
@@ -48,10 +48,16 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
             (ws / "state" / fn).write_text(text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
                  hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
-                 hc._pid_instance_id, hc._pid_actor_id, hc._watcher_sentinel_target)
+                 hc._pid_instance_id, hc._pid_actor_id, hc._watcher_sentinel_target,
+                 hc._is_watcher_argv)
         try:
             hc.WORKSPACE_DIR = ws
             hc._proc_argv = (argv if callable(argv) else (lambda pid: argv))
+            if verdicts is not None:
+                # None is the tri-state "cannot prove", which no argv string
+                # reliably produces; force it so that branch is reachable.
+                hc._is_watcher_argv = (
+                    lambda a, pid=None, _v=verdicts: _v.get(str(pid), True))
             hc._watcher_trees = lambda *a, **k: trees
             hc._ps_snapshot = lambda *a, **k: ""
             hc._pid_parent = lambda pid, ps=None: parent
@@ -69,7 +75,7 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
              hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
              hc._pid_instance_id, hc._pid_actor_id,
-             hc._watcher_sentinel_target) = saved
+             hc._watcher_sentinel_target, hc._is_watcher_argv) = saved
 
 
 class PoolHost(unittest.TestCase):
@@ -634,6 +640,26 @@ class AnUnreadableVectorSaysUnknownNeverTrue(unittest.TestCase):
         trees = hc._watcher_trees("  4242 1 %s\n" % self.AMBIGUOUS)
         self.assertTrue(trees, "UNKNOWN must count as a watcher, never read as absent")
 
+
+
+class SentinelReconciliationLosesNoRecord(unittest.TestCase):
+    """keweichen at e3fbc2cf: `live[spid] = sp` is keyed by pid, so a second
+    sentinel naming that pid vanished and the check reported a false green."""
+
+    def test_two_sentinels_naming_ONE_pid_are_not_collapsed(self):
+        r = run({"watch-tasks-stream-a.pid": "4242\n",
+                 "watch-tasks-stream-b.pid": "4242\n"}, {"4242": {"4242"}})
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("one pid, two sentinels", r["detail"])
+        self.assertIn("4242", r["detail"])
+
+    def test_an_UNPROVABLE_sentinel_is_a_fault_beside_a_live_one(self):
+        """A live peer does not clear another instance's unprovable record."""
+        r = run({"watch-tasks-stream-a.pid": "100\n",
+                 "watch-tasks-stream-b.pid": "200\n"}, {"100": {"100"}},
+                verdicts={"100": True, "200": None})
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertNotIn("streaming watcher alive", r["detail"])
 
 
 class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -763,6 +763,27 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
         self.assertIn("do NOT restart", d)
         self.assertNotIn("and restart one cleanly", d)
 
+    def test_PARTIAL_overlap_restarts_only_the_uncovered_instances(self):
+        """keweichen: supervised 901->A, ownerless 903->A and 904->B. Restarting
+        two recreates A beside 901; only B needs one."""
+        d = self._detail(
+            f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n"
+            f"  904 1 bash {self.W}\n",
+            targets={"901": "/s/A.pid", "903": "/s/A.pid", "904": "/s/B.pid"})
+        self.assertIn("restart 1 cleanly", d)
+        self.assertIn("must NOT be restarted", d)
+        self.assertNotIn("restart 2 cleanly", d)
+
+    def test_an_UNKNOWN_SUPERVISED_root_licenses_no_ownerless_action(self):
+        """If 901 is actually A, restarting duplicates it; if it is not, stopping
+        903 leaves an A gap. Neither is decidable until identity resolves."""
+        d = self._detail(
+            f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n",
+            targets={"903": "/s/A.pid"})
+        self.assertIn("Do NOT stop 903", d)
+        self.assertIn("UNKNOWN identity", d)
+        self.assertNotIn("restart one cleanly", d)
+
     def test_a_lone_ownerless_watcher_is_still_restarted(self):
         """The advice survives where it is correct, or the gate is a mute."""
         d = self._own(f"  901 1 bash {self.W}\n", {"901": "/s/a.pid"})

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -585,5 +585,44 @@ class AnUnreadableVectorSaysUnknownNeverTrue(unittest.TestCase):
 
 
 
+class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
+    """Reported twice by qingyun-wu on #3875 (ad7f1bf7, f91511cc).
+
+    The multiple-root warning called every root orphaned and said "stop them and
+    restart one cleanly", then APPENDED the ownership split without retracting
+    that instruction. An operator following it takes a healthy peer offline.
+    """
+
+    W = "/repo/src/watch-tasks-stream.sh"
+
+    def _detail(self, ps):
+        orig = (hc._ps_snapshot, hc._proc_argv_vector, hc.watcher_sentinel_paths)
+        hc._ps_snapshot = lambda: ps
+        hc._proc_argv_vector = lambda pid: None
+        hc.watcher_sentinel_paths = lambda sd: []
+        try:
+            return hc.check_task_watcher().get("detail") or ""
+        finally:
+            hc._ps_snapshot, hc._proc_argv_vector, hc.watcher_sentinel_paths = orig
+
+    def test_two_supervised_roots_are_never_told_to_stop(self):
+        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")
+        self.assertNotIn("stop them", d, "blanket stop advice over supervised roots")
+        self.assertIn("do NOT stop any", d)
+        self.assertIn("supervised: 901, 902", d)
+
+    def test_an_ownerless_root_is_still_named_as_stoppable(self):
+        # The control: the fix must not become "never stop anything".
+        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n")
+        self.assertIn("stop the ownerless one(s) first: 903", d)
+        self.assertNotIn("do NOT stop any", d)
+
+    def test_the_duplicate_processing_cost_is_still_stated(self):
+        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")
+        self.assertIn("processed 2x", d,
+            "the reason a duplicate matters must survive the softened advice")
+
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -1047,6 +1047,50 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
             "unreadable identity must not authorise reduction")
 
 
+class PeerMultiplicitySurvivesATrackedTargetDuplicate(unittest.TestCase):
+    """keweichen: peer multiplicity was analysed only under `distinct and not
+    dupes`, so ONE duplicate on a tracked target hid a duplicate on a PEER
+    target. Kept apart from the no-live tests: these exercise the extras path
+    with a healthy tracked watcher present."""
+
+    A_SENT = "watch-tasks-stream-a.pid"
+    B_SENT = "watch-tasks-stream-b.pid"
+
+    def _mixed(self, parents=None):
+        """A tracked on 100; 200 duplicates A; 300+400 both target B."""
+        return run({self.A_SENT: "100\n"},
+                   {"100": {"100"}, "200": {"200"}, "300": {"300"}, "400": {"400"}},
+                   targets={"100": self.A_SENT, "200": self.A_SENT,
+                            "300": self.B_SENT, "400": self.B_SENT},
+                   parent=(lambda pid, p=None, _m=(parents or {}): _m.get(str(pid), "1")))
+
+    def test_a_tracked_duplicate_does_not_hide_a_peer_duplicate(self):
+        d = self._mixed()["detail"]
+        self.assertIn("300, 400", d,
+            "the B pair share a target and must be named as duplicates of each "
+            "other, not folded into a 'different instance, left alone' count")
+
+    def test_peer_only_control_still_reduces(self):
+        """The control that always worked: without A's duplicate the same B pair
+        is reported. It must NOT change -- that is what makes the case above
+        discriminating rather than a rewrite."""
+        d = run({self.A_SENT: "100\n"},
+                {"100": {"100"}, "300": {"300"}, "400": {"400"}},
+                targets={"100": self.A_SENT, "300": self.B_SENT,
+                         "400": self.B_SENT})["detail"]
+        self.assertIn("300, 400", d)
+
+    def test_mixed_ownership_peer_pair_keeps_the_supervised_one(self):
+        d = self._mixed({"300": "999"})["detail"]
+        self.assertIn("keep the supervised 300", d)
+        self.assertIn("stop the ownerless 400", d)
+
+    def test_all_supervised_peer_pair_routes_through_the_launcher(self):
+        d = self._mixed({"300": "999", "400": "998"})["detail"]
+        self.assertIn("reduce through the launcher", d)
+        self.assertNotIn("keep ONE and stop", d,
+            "stopping a supervised root tells an operator to kill a live child")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -296,8 +296,7 @@ class NoLiveFaultsAggregateBeforeAnyAdvice(unittest.TestCase):
         sentinel must suppress that too -- same veto, other direction."""
         r = run(dict(self.UNREADABLE, **{"watch-tasks-stream-b.pid": "100\n"}),
                 {"200": {"200"}}, verdicts={"100": None}, targets={})
-        # Assert it REACHES the aggregate first: unfixed, this returned early
-        # with restart advice and never reached the roots branch, so a bare
+        # Assert it REACHES the aggregate: unfixed it returned early, so a bare
         # assertNotIn("safe to stop") passed for the wrong reason.
         self.assertIn("watcher(s) still run", r["detail"],
             "must reach the roots aggregate, not return on the first fault")

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -697,6 +697,19 @@ class ExtraTreesKeepTheirMultiplicity(unittest.TestCase):
     """keweichen: extras distinct from every TRACKED target can still duplicate
     EACH OTHER, and calling them "not duplicates" erased that."""
 
+    def test_a_DEAD_record_also_survives_the_extras_path(self):
+        """keweichen: the veto covered only unprovable/collided; dead, reused and
+        unreadable records still vanished through the extras returns."""
+        argv = {"100": WATCHER_ARGV, "200": WATCHER_ARGV}
+        r = run({"watch-tasks-stream-A.pid": "100\n",
+                 "watch-tasks-stream-D.pid": "777\n"},
+                {"100": {"100"}, "200": {"200"}},
+                argv=lambda pid: argv.get(str(pid)),
+                targets={"100": "A.pid", "200": "B.pid"})
+        self.assertIn("crashed", r["detail"])
+        self.assertIn("777", r["detail"])
+        self.assertNotIn("Do NOT stop them", r["detail"])
+
     def test_two_extras_on_one_target_are_duplicates_of_each_other(self):
         r = run({"watch-tasks-stream-A.pid": "100\n"},
                 {"100": {"100"}, "200": {"200"}, "300": {"300"}},

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -59,8 +59,8 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
             hc._pid_instance_id = lambda pid: pid_instance
             hc._pid_actor_id = lambda pid: pid_actor
             if targets is not None:
-                # Per-pid sentinel TARGET, which is what decides duplicate vs
-                # separate instance. A pid absent from the map is unresolvable.
+                # `{}` states that no pid resolves; None keeps the production
+                # resolver, which reads THIS host — only the restamp cases want that.
                 hc._watcher_sentinel_target = (
                     lambda sd, pid, _m=targets: (
                         (ws / "state" / _m[str(pid)]) if str(pid) in _m else None))
@@ -686,6 +686,49 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
         self.assertIn("stop them and restart one cleanly", d)
         self.assertNotIn("Do NOT stop", d)
 
+    MIXED = None  # set in the cases below
+
+    def _mixed(self, targets):
+        """Two SUPERVISED roots (901,902 under 900) plus one ownerless (903)."""
+        return self._detail(
+            f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n"
+            f"  903 1 bash {self.W}\n", targets=targets)
+
+    def test_mixed_ownership_DISTINCT_supervised_are_not_reduced(self):
+        """qingyun-wu, #3875: the mixed branch selected its advice before the
+        identity guard, so it said 'do not reduce' and 'reduce those' at once."""
+        d = self._mixed({"901": "/s/a.pid", "902": "/s/b.pid", "903": "/s/c.pid"})
+        self.assertIn("DISTINCT", d)
+        self.assertIn("Stop ONLY the ownerless (903)", d)
+        self.assertNotIn("reduce those through the launcher", d,
+            "distinct supervised instances must not be offered for reduction")
+
+    def test_mixed_ownership_UNKNOWN_identity_is_not_reduced(self):
+        d = self._mixed({})   # stated: no pid resolves
+        self.assertIn("UNKNOWN", d)
+        self.assertIn("Stop ONLY the ownerless (903)", d)
+        self.assertNotIn("reduce those through the launcher", d,
+            "unreadable identity must not authorise reduction in the mixed branch either")
+
+    def test_reduction_reads_the_SUPERVISED_subset_not_every_root(self):
+        """901 and 902 are distinct instances; the OWNERLESS 903 duplicates 901.
+
+        Grouping over all roots finds a duplicate pair and would offer the
+        supervised pair for reduction — but the duplicate is not among them.
+        Reduction is advice about the supervised subset, so only that subset's
+        identity may license it.
+        """
+        d = self._mixed({"901": "/s/a.pid", "902": "/s/b.pid", "903": "/s/a.pid"})
+        self.assertIn("Stop ONLY the ownerless (903)", d)
+        self.assertNotIn("reduce those through the launcher", d,
+            "the duplicate is 903 (ownerless); 901 and 902 are distinct and must not be reduced")
+
+    def test_mixed_ownership_a_PROVEN_duplicate_is_still_reduced(self):
+        """The advice must survive where it is true, or the gate is just a mute."""
+        d = self._mixed({"901": "/s/a.pid", "902": "/s/a.pid", "903": "/s/c.pid"})
+        self.assertIn("processed 2x", d)
+        self.assertIn("reduce those through the launcher", d)
+
     def test_the_duplicate_processing_cost_is_still_stated(self):
         """A PROVEN duplicate — both roots resolve to one target — must still say
         what it costs. The identity is what makes the claim true."""
@@ -707,7 +750,8 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
 
     def test_unreadable_identity_does_not_authorise_reduction(self):
         """No identity, no duplicate claim: it may be one instance twice or two once."""
-        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n")
+        d = self._detail(f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  902 900 bash {self.W}\n",
+                         targets={})   # stated: no pid resolves
         self.assertIn("UNKNOWN", d)
         self.assertNotIn("processed 2x", d)
         self.assertIn("do not reduce the count", d)

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -642,6 +642,22 @@ class AnUnreadableVectorSaysUnknownNeverTrue(unittest.TestCase):
 
 
 
+class ExtraTreesKeepTheirMultiplicity(unittest.TestCase):
+    """keweichen: extras distinct from every TRACKED target can still duplicate
+    EACH OTHER, and calling them "not duplicates" erased that."""
+
+    def test_two_extras_on_one_target_are_duplicates_of_each_other(self):
+        r = run({"watch-tasks-stream-A.pid": "100\n"},
+                {"100": {"100"}, "200": {"200"}, "300": {"300"}},
+                targets={"100": "A.pid", "200": "B.pid", "300": "B.pid"})
+        self.assertIn("share one instance", r["detail"])
+        self.assertIn("keep ONE of each", r["detail"])
+        # the old wording called them "not duplicates" full stop, which erased
+        # that they duplicate EACH OTHER; qualified is fine, unqualified is not.
+        self.assertNotIn("not duplicates; each", r["detail"])
+        self.assertNotIn("Do NOT stop them", r["detail"])
+
+
 class ADeadSentinelDoesNotLicenseStoppingASoleWatcher(unittest.TestCase):
     """keweichen at 70a8887d: with every sentinel dead, an ownerless root is its
     instance's only watcher unless a supervised peer serves the same target."""
@@ -808,6 +824,19 @@ class StopAdviceNeverTargetsASupervisedWatcher(unittest.TestCase):
         self.assertIn("restart 904", d)
         self.assertIn("NOT 903", d)
         self.assertNotIn("restart 2", d)
+
+    def test_restart_is_ONE_per_uncovered_target_not_every_root_on_it(self):
+        """keweichen: with 903->A, 904->B, 905->B, restarting both 904 and 905
+        recreates B's duplicate. The one-B fixture could not tell "one per
+        target" from "every root on an uncovered target"."""
+        d = self._detail(
+            f"  900 1 /bin/zsh -l\n  901 900 bash {self.W}\n  903 1 bash {self.W}\n"
+            f"  904 1 bash {self.W}\n  905 1 bash {self.W}\n",
+            targets={"901": "/s/A.pid", "903": "/s/A.pid",
+                     "904": "/s/B.pid", "905": "/s/B.pid"})
+        self.assertIn("restart 904 and NOT", d)
+        self.assertNotIn("restart 904, 905", d)
+        self.assertIn("a peer above already covers that instance", d)
 
     def test_an_UNKNOWN_SUPERVISED_root_licenses_no_ownerless_action(self):
         """If 901 is actually A, restarting duplicates it; if it is not, stopping

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -18,6 +18,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 _spec = importlib.util.spec_from_file_location("hc", ROOT / "src" / "health-check.py")
@@ -335,6 +336,70 @@ class TheActorPrecedenceComesFromItsOwner(unittest.TestCase):
         src = (ROOT / "src" / "health-check.py").read_text()
         self.assertNotIn('"AGENT_MXID"', src,
                          "the precedence is spelled here again, so it can drift")
+
+
+class TheDarwinArgvParseIsExercisedOnAnyPlatform(unittest.TestCase):
+    """KERN_PROCARGS2's layout is parsed by hand, so the loops need a test.
+
+    On a linux runner /proc answers first and this branch never executes, so the
+    NUL-skipping and the argc bound would ship unmeasured.
+    """
+
+    @staticmethod
+    def _fake_libc(payload):
+        import ctypes
+
+        class _Libc:
+            def sysctl(self, mib, n, buf, sizep, _a, _b):
+                ctypes.memmove(buf, payload, len(payload))
+                sizep._obj.value = len(payload)
+                return 0
+
+        return _Libc()
+
+    def _vector(self, argc, exec_path, argv, pad=b"", lead=b""):
+        import ctypes
+        import ctypes.util  # noqa: F401 -- must load BEFORE CDLL is patched
+        blob = (argc.to_bytes(4, sys.byteorder) + lead + exec_path + b"\0" + pad
+                + b"\0".join(argv) + b"\0")
+        with patch.object(Path, "read_bytes", side_effect=OSError("not linux")), \
+             patch.object(ctypes, "CDLL", return_value=self._fake_libc(blob)):
+            return hc._proc_argv_vector(4242)
+
+    def test_the_exec_path_is_skipped_and_argv_returned(self):
+        self.assertEqual(
+            self._vector(2, b"/bin/bash", [b"bash", b"/repo/src/watch-tasks-stream.sh"]),
+            ["bash", "/repo/src/watch-tasks-stream.sh"])
+
+    def test_padding_nuls_between_exec_path_and_argv_are_skipped(self):
+        self.assertEqual(
+            self._vector(2, b"/bin/bash", [b"bash", b"/w/x.sh"], pad=b"\0\0\0"),
+            ["bash", "/w/x.sh"])
+
+    def test_leading_nuls_before_the_exec_path_are_skipped(self):
+        # The first skip loop only runs when the blob is padded ahead of the
+        # exec path; without a case for it the branch ships unmeasured.
+        self.assertEqual(
+            self._vector(2, b"/bin/bash", [b"bash", b"/w/y.sh"], lead=b"\0\0"),
+            ["bash", "/w/y.sh"])
+
+    def test_argc_bounds_the_result_so_envp_is_not_read_as_argv(self):
+        # argc=1, but the environment follows argv in the same blob.
+        self.assertEqual(
+            self._vector(1, b"/bin/bash", [b"bash", b"PATH=/usr/bin", b"HOME=/root"]),
+            ["bash"])
+
+    def test_a_failing_sysctl_is_None_not_a_partial_vector(self):
+        import ctypes
+        import ctypes.util  # noqa: F401 -- must load BEFORE CDLL is patched
+
+        class _Fail:
+            def sysctl(self, *a):
+                return -1
+
+        with patch.object(Path, "read_bytes", side_effect=OSError("not linux")), \
+             patch.object(ctypes, "CDLL", return_value=_Fail()):
+            self.assertIsNone(hc._proc_argv_vector(4242))
 
 
 class TheWatcherPredicateIsAShapeNotAFieldCount(unittest.TestCase):

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -148,7 +148,7 @@ class PoolHost(unittest.TestCase):
             saved = (hc._proc_argv, hc._is_watcher_argv, hc.WORKSPACE_DIR)
             try:
                 hc._proc_argv = lambda pid: WATCHER_ARGV
-                hc._is_watcher_argv = lambda argv: True
+                hc._is_watcher_argv = lambda argv, pid=None: True
                 hc.WORKSPACE_DIR = Path(td) / "ws"
                 out = hc.fix_task_watcher_sentinel(
                     {"_sentinel_restamp_pid": "4242",
@@ -343,9 +343,15 @@ class TheWatcherPredicateIsAShapeNotAFieldCount(unittest.TestCase):
     existing case used the synthetic two-token form, so none of them could see it.
     """
 
+    # The script token carries the name, so every way of re-splitting the flattened
+    # argv still yields a watcher -- these are decidable from the string alone.
     REAL = [
         ("the synthetic form the older cases use", "bash src/watch-tasks-stream.sh"),
         ("the notifier's production exec", "bash /repo/src/watch-tasks-stream.sh /w/tasks"),
+    ]
+    # A space in the INSTALL path pushes the name out of the script token, and then
+    # "one spaced path" and "a script plus arguments" are the same string.
+    REAL_UNDECIDABLE = [
         ("an app checkout whose path has a space",
          "bash /Users/x/Library/Application Support/Sutando/src/watch-tasks-stream.sh"),
         ("both at once", "bash /Users/x/Application Support/src/watch-tasks-stream.sh /w/my tasks"),
@@ -361,13 +367,26 @@ class TheWatcherPredicateIsAShapeNotAFieldCount(unittest.TestCase):
     def test_every_real_launch_shape_is_recognised(self):
         for label, argv in self.REAL:
             with self.subTest(shape=label):
-                self.assertTrue(hc._is_watcher_argv(argv), argv)
+                self.assertIs(hc._is_watcher_argv(argv), True, argv)
+
+    def test_an_undecidable_real_shape_is_never_REJECTED(self):
+        # The defect this class was written for: a production watcher read as "not
+        # a watcher". UNKNOWN keeps it counted; only False would resurrect that.
+        for label, argv in self.REAL_UNDECIDABLE:
+            with self.subTest(shape=label):
+                self.assertIsNot(hc._is_watcher_argv(argv), False, argv)
+
+    def test_an_undecidable_real_shape_still_counts_as_a_tree(self):
+        # What the caller does with UNKNOWN is the behaviour the probe depends on.
+        for label, argv in self.REAL_UNDECIDABLE:
+            with self.subTest(shape=label):
+                self.assertTrue(hc._watcher_trees("  100 1 %s\n" % argv), argv)
 
     def test_the_controls_impostors_are_still_refused(self):
-        # Without these the predicate could pass by accepting anything.
+        # assertIs, not assertFalse: None must not be able to satisfy the control.
         for label, argv in self.IMPOSTORS:
             with self.subTest(shape=label):
-                self.assertFalse(hc._is_watcher_argv(argv), argv)
+                self.assertIs(hc._is_watcher_argv(argv), False, argv)
 
     def test_a_production_shaped_duplicate_is_counted_as_a_second_tree(self):
         # The consequence: two real watchers read as one, so the duplicate the

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -164,10 +164,14 @@ class PoolHost(unittest.TestCase):
         out = hc.fix_task_watcher_sentinel({"_sentinel_restamp_pid": "4242"})
         self.assertIn("no sentinel path", out)
 
-    def test_all_sentinels_dead_with_watchers_running_keeps_the_old_verdict(self):
+    def test_all_sentinels_dead_with_watchers_running_names_and_classifies(self):
+        # "orphaned" applied to every root told an operator to stop a supervised
+        # watcher; the verdict must say which group each root is in.
         r = run({"watch-tasks-stream.pid": "100\n"}, {"777": {"777"}}, argv="")
         self.assertEqual(r["status"], "warn")
-        self.assertIn("orphaned", r["detail"])
+        self.assertIn("777", r["detail"])
+        self.assertIn("ownerless", r["detail"])
+        self.assertIn("supervised", r["detail"])
 
     def test_a_tree_whose_member_is_tracked_counts_as_tracked(self):
         """A watcher's tree holds its children; the sentinel names the root."""

--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -338,6 +338,51 @@ class TheActorPrecedenceComesFromItsOwner(unittest.TestCase):
                          "the precedence is spelled here again, so it can drift")
 
 
+class TheIdentityProbesAreTriStateNotBoolean(unittest.TestCase):
+    """`None` means CANNOT READ; "" means the process states none. A probe that
+    collapses them publishes THIS process's identity as the watcher's."""
+
+    def test_environ_read_returns_the_first_name_that_is_set(self):
+        blob = b"HOME=/root\0SUTANDO_INSTANCE=inst-b\0SUTANDO_AGENT=agent-z\0"
+        with patch.object(Path, "read_bytes", return_value=blob):
+            self.assertEqual(
+                hc._pid_env_first("4242", ["SUTANDO_INSTANCE", "SUTANDO_AGENT"]), "inst-b")
+
+    def test_a_name_set_but_empty_falls_through_to_the_next(self):
+        blob = b"SUTANDO_INSTANCE=\0SUTANDO_AGENT=agent-z\0"
+        with patch.object(Path, "read_bytes", return_value=blob):
+            self.assertEqual(
+                hc._pid_env_first("4242", ["SUTANDO_INSTANCE", "SUTANDO_AGENT"]), "agent-z")
+
+    def test_none_of_the_names_present_states_none_rather_than_cannot_read(self):
+        with patch.object(Path, "read_bytes", return_value=b"HOME=/root\0"):
+            self.assertEqual(hc._pid_env_first("4242", ["SUTANDO_INSTANCE"]), "")
+
+    def test_an_unreadable_process_is_None_not_empty(self):
+        with patch.object(Path, "read_bytes", side_effect=OSError("no /proc")), \
+             patch.object(hc.subprocess, "run", side_effect=OSError("no ps")):
+            self.assertIsNone(hc._pid_env_first("4242", ["SUTANDO_INSTANCE"]))
+
+    def test_no_stated_default_yields_no_repair_target(self):
+        # Naming a target from a guessed identity is what gets a stranger killed.
+        with patch.object(hc, "_pid_instance_id", return_value="i"), \
+             patch.object(hc, "_pid_actor_id", return_value="a"), \
+             patch.object(hc, "stated_default_identity", return_value=None):
+            self.assertIsNone(hc._watcher_sentinel_target(Path("/tmp"), "4242"))
+
+    def test_a_raising_resolver_yields_no_repair_target(self):
+        with patch.object(hc, "_pid_instance_id", return_value="i"), \
+             patch.object(hc, "_pid_actor_id", return_value="a"), \
+             patch.object(hc, "stated_default_identity", side_effect=RuntimeError("x")):
+            self.assertIsNone(hc._watcher_sentinel_target(Path("/tmp"), "4242"))
+
+    def test_a_short_ps_line_is_skipped_not_parsed(self):
+        # A header row or a truncated line has no argv column to judge.
+        parent, live = hc._ps_watcher_index("  PID PPID\n 100 1 bash src/watch-tasks-stream.sh\n")
+        self.assertIn("100", parent)
+        self.assertNotIn("PID", parent)
+
+
 class TheDarwinArgvParseIsExercisedOnAnyPlatform(unittest.TestCase):
     """KERN_PROCARGS2's layout is parsed by hand, so the loops need a test.
 

--- a/tests/health-check-supervised-watcher-not-orphan.test.py
+++ b/tests/health-check-supervised-watcher-not-orphan.test.py
@@ -73,8 +73,13 @@ check("does not claim a live session", "live session" not in vU["detail"], vU["d
 
 print("TWO supervised watchers (duplicates are still a real problem):")
 v3 = _verdict({"100": {"100"}, "200": {"200"}}, {"100": "99", "200": "98"})
-check("keeps the orphan/stop verdict for 2 trees", "stop them" in v3["detail"], v3["detail"])
-check("counts both", "2 orphaned" in v3["detail"], v3["detail"])
+# qingyun-wu, #3875: these pinned the DEFECT — both roots have LIVE parents (99, 98),
+# so 'orphaned' is false and 'stop them' takes two healthy instances offline.
+check("does NOT call supervised roots orphaned", "orphaned" not in v3["detail"], v3["detail"])
+check("does NOT tell you to stop them", "stop them" not in v3["detail"], v3["detail"])
+check("still counts both", "2 watcher(s)" in v3["detail"], v3["detail"])
+check("still states the duplicate cost", "processed 2x" in v3["detail"], v3["detail"])
+check("names them as supervised", "supervised: 100, 200" in v3["detail"], v3["detail"])
 
 print("no watchers at all (unchanged):")
 v4 = _verdict({}, {})

--- a/tests/health-check-supervised-watcher-not-orphan.test.py
+++ b/tests/health-check-supervised-watcher-not-orphan.test.py
@@ -38,8 +38,12 @@ def skip(label, reason=PS_SKIP_REASON):
     print(f"  SKIP {label}  — {reason}")
 
 
-def _verdict(trees, parents):
-    """check_task_watcher() with no sentinel, given tree roots and their ppids."""
+def _verdict(trees, parents, targets=None):
+    """check_task_watcher() with no sentinel, given tree roots and their ppids.
+
+    `targets` maps pid -> resolved sentinel target; absent, identity is
+    unreadable and no duplicate claim may be made from the root count alone.
+    """
     # "" is a scan that RAN and found nothing; None means ps is unavailable,
     # which would contradict this scenario's premise that watchers exist.
     with tempfile.TemporaryDirectory() as ws:
@@ -47,7 +51,9 @@ def _verdict(trees, parents):
              patch.object(hc, "_fresh_local_core_record", return_value={"ts": 1}), \
              patch.object(hc, "_watcher_trees", return_value=trees), \
              patch.object(hc, "_ps_snapshot", return_value=""), \
-             patch.object(hc, "_pid_parent", side_effect=lambda pid, ps=None: parents.get(str(pid))):
+             patch.object(hc, "_pid_parent", side_effect=lambda pid, ps=None: parents.get(str(pid))), \
+             patch.object(hc, "_watcher_sentinel_target",
+                          side_effect=lambda sd, pid: (targets or {}).get(str(pid))):
             return hc.check_task_watcher()
 
 
@@ -72,7 +78,10 @@ check("keeps the orphan verdict", "orphaned" in vU["detail"], vU["detail"])
 check("does not claim a live session", "live session" not in vU["detail"], vU["detail"])
 
 print("TWO supervised watchers (duplicates are still a real problem):")
-v3 = _verdict({"100": {"100"}, "200": {"200"}}, {"100": "99", "200": "98"})
+# Both roots resolve to ONE target, so the duplicate claim below is true.
+# Without that identity the cost cannot be asserted from the count (qingyun-wu).
+v3 = _verdict({"100": {"100"}, "200": {"200"}}, {"100": "99", "200": "98"},
+              targets={"100": "/s/w-a.pid", "200": "/s/w-a.pid"})
 # qingyun-wu, #3875: these pinned the DEFECT — both roots have LIVE parents (99, 98),
 # so 'orphaned' is false and 'stop them' takes two healthy instances offline.
 check("does NOT call supervised roots orphaned", "orphaned" not in v3["detail"], v3["detail"])
@@ -120,3 +129,11 @@ if failures:
     sys.exit(1)
 _note = f" ({len(skipped)} live-OS probe(s) skipped: {skipped})" if skipped else ""
 print(f"\nPASS — supervised watcher is not reported as an orphan{_note}")
+
+print("TWO supervised watchers, DISTINCT instances (not duplicates):")
+v4 = _verdict({"901": {"901"}, "902": {"902"}}, {"901": "99", "902": "98"},
+              targets={"901": "/s/w-a.pid", "902": "/s/w-b.pid"})
+check("says DISTINCT", "DISTINCT" in v4["detail"], v4["detail"])
+check("makes no duplicate claim", "processed 2x" not in v4["detail"], v4["detail"])
+check("does not authorise reduction",
+      "reduce the count through the launcher" not in v4["detail"], v4["detail"])

--- a/tests/health-check-supervised-watcher-not-orphan.test.py
+++ b/tests/health-check-supervised-watcher-not-orphan.test.py
@@ -67,9 +67,15 @@ check("says do NOT stop it", "Do NOT stop it" in v["detail"], v["detail"])
 check("names the live parent", "ppid 12626" in v["detail"], v["detail"])
 
 print("single REPARENTED watcher (a true orphan):")
-v2 = _verdict({"555": {"555"}}, {"555": "1"})
+# Identity resolved, so the stop remedy is licensed; unresolved, it is not (keweichen).
+v2 = _verdict({"555": {"555"}}, {"555": "1"}, targets={"555": "/s/a.pid"})
 check("keeps the orphan verdict", "orphaned" in v2["detail"], v2["detail"])
-check("keeps the stop remedy", "stop them" in v2["detail"], v2["detail"])
+check("keeps the stop remedy", "Stop ONLY the ownerless (555)" in v2["detail"], v2["detail"])
+check("restarts one for a lone instance", "restart one cleanly" in v2["detail"], v2["detail"])
+
+v2u = _verdict({"555": {"555"}}, {"555": "1"}, targets={})
+check("an UNIDENTIFIED orphan is not named stoppable",
+      "Do NOT stop 555" in v2u["detail"], v2u["detail"])
 
 print("single watcher with UNKNOWN parent (must stay an orphan):")
 # An unknown ppid cannot support "runs under a live session" — saying so would

--- a/tests/health-check-supervised-watcher-not-orphan.test.py
+++ b/tests/health-check-supervised-watcher-not-orphan.test.py
@@ -54,6 +54,7 @@ def _verdict(trees, parents, targets=None):
              patch.object(hc, "_pid_parent", side_effect=lambda pid, ps=None: parents.get(str(pid))), \
              patch.object(hc, "_watcher_sentinel_target",
                           side_effect=lambda sd, pid: (targets or {}).get(str(pid))):
+            # always patched: the production resolver would read THIS host
             return hc.check_task_watcher()
 
 
@@ -124,12 +125,6 @@ check("_pid_parent returns None when the pid is absent from the table",
 check("_pid_parent tolerates a malformed row",
       hc._pid_parent("100", "garbage\n  100    99 ok\n") == "99")
 
-if failures:
-    print(f"\nFAILED ({len(failures)}): {failures}")
-    sys.exit(1)
-_note = f" ({len(skipped)} live-OS probe(s) skipped: {skipped})" if skipped else ""
-print(f"\nPASS — supervised watcher is not reported as an orphan{_note}")
-
 print("TWO supervised watchers, DISTINCT instances (not duplicates):")
 v4 = _verdict({"901": {"901"}, "902": {"902"}}, {"901": "99", "902": "98"},
               targets={"901": "/s/w-a.pid", "902": "/s/w-b.pid"})
@@ -137,3 +132,9 @@ check("says DISTINCT", "DISTINCT" in v4["detail"], v4["detail"])
 check("makes no duplicate claim", "processed 2x" not in v4["detail"], v4["detail"])
 check("does not authorise reduction",
       "reduce the count through the launcher" not in v4["detail"], v4["detail"])
+
+if failures:
+    print(f"\nFAILED ({len(failures)}): {failures}")
+    sys.exit(1)
+_note = f" ({len(skipped)} live-OS probe(s) skipped: {skipped})" if skipped else ""
+print(f"\nPASS — supervised watcher is not reported as an orphan{_note}")

--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -89,6 +89,7 @@ def make_workspace(td: Path, *, core_alive: bool, pid_text: str | None) -> Path:
 
 def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None,
               pid_instance: "str | None" = "",
+              pid_actor: "str | None" = "",
               trees: dict | None = None, parents: dict | None = None) -> dict:
     """Call check_task_watcher against a temp WORKSPACE_DIR. `argv` patches
     the _proc_argv probe: None = leave the real one (only used where no PID
@@ -102,7 +103,8 @@ def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None
     with tempfile.TemporaryDirectory() as td:
         make_workspace(Path(td), core_alive=core_alive, pid_text=pid_text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-                 hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id)
+                 hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id,
+                 hc._pid_actor_id)
         try:
             hc.WORKSPACE_DIR = Path(td)
             if argv is not None:
@@ -113,10 +115,12 @@ def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None
             # A synthetic pid has no readable environment; the default instance is
             # what these fixtures have always meant.
             hc._pid_instance_id = lambda pid: pid_instance
+            hc._pid_actor_id = lambda pid: pid_actor
             return hc.check_task_watcher()
         finally:
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-             hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id) = saved
+             hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id,
+             hc._pid_actor_id) = saved
 
 
 @contextlib.contextmanager
@@ -131,7 +135,8 @@ def supervised_watcher(*, pid: str = "7100", pid_text: str | None = None,
     with tempfile.TemporaryDirectory() as td:
         ws = make_workspace(Path(td), core_alive=True, pid_text=pid_text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-                 hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id)
+                 hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id,
+                 hc._pid_actor_id)
         try:
             hc.WORKSPACE_DIR = ws
             hc._proc_argv = lambda p: argv
@@ -139,10 +144,12 @@ def supervised_watcher(*, pid: str = "7100", pid_text: str | None = None,
             hc._ps_snapshot = lambda *a, **k: ""
             hc._pid_parent = lambda p, ps=None: "500"
             hc._pid_instance_id = lambda p: ""
+            hc._pid_actor_id = lambda p: ""
             yield ws
         finally:
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-             hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id) = saved
+             hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id,
+             hc._pid_actor_id) = saved
 
 
 def case_r_supervised_watcher_exposes_restamp_pid() -> list[str]:

--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -88,6 +88,7 @@ def make_workspace(td: Path, *, core_alive: bool, pid_text: str | None) -> Path:
 
 
 def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None,
+              pid_instance: "str | None" = "",
               trees: dict | None = None, parents: dict | None = None) -> dict:
     """Call check_task_watcher against a temp WORKSPACE_DIR. `argv` patches
     the _proc_argv probe: None = leave the real one (only used where no PID
@@ -101,7 +102,7 @@ def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None
     with tempfile.TemporaryDirectory() as td:
         make_workspace(Path(td), core_alive=core_alive, pid_text=pid_text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-                 hc._ps_snapshot, hc._pid_parent)
+                 hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id)
         try:
             hc.WORKSPACE_DIR = Path(td)
             if argv is not None:
@@ -109,10 +110,13 @@ def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None
             hc._watcher_trees = lambda *a, **k: (trees or {})
             hc._ps_snapshot = lambda *a, **k: ""
             hc._pid_parent = lambda pid, ps=None: (parents or {}).get(pid)
+            # A synthetic pid has no readable environment; the default instance is
+            # what these fixtures have always meant.
+            hc._pid_instance_id = lambda pid: pid_instance
             return hc.check_task_watcher()
         finally:
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-             hc._ps_snapshot, hc._pid_parent) = saved
+             hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id) = saved
 
 
 @contextlib.contextmanager
@@ -127,17 +131,18 @@ def supervised_watcher(*, pid: str = "7100", pid_text: str | None = None,
     with tempfile.TemporaryDirectory() as td:
         ws = make_workspace(Path(td), core_alive=True, pid_text=pid_text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-                 hc._ps_snapshot, hc._pid_parent)
+                 hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id)
         try:
             hc.WORKSPACE_DIR = ws
             hc._proc_argv = lambda p: argv
             hc._watcher_trees = lambda *a, **k: {pid: {pid}}
             hc._ps_snapshot = lambda *a, **k: ""
             hc._pid_parent = lambda p, ps=None: "500"
+            hc._pid_instance_id = lambda p: ""
             yield ws
         finally:
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
-             hc._ps_snapshot, hc._pid_parent) = saved
+             hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id) = saved
 
 
 def case_r_supervised_watcher_exposes_restamp_pid() -> list[str]:
@@ -454,6 +459,30 @@ def case_y_json_repair_line_goes_to_stderr() -> list[str]:
     return fails
 
 
+def case_z_an_unreadable_watcher_identity_offers_no_repair_target() -> list[str]:
+    """Every other case stubs the identity as the default, which is what these
+    fixtures have always meant. This one covers the state the stub hides."""
+    fails = []
+    res = run_check(core_alive=True, pid_text=None, trees={"901": {"901"}},
+                    parents={"901": "900"}, pid_instance=None)
+    if res.get("status") != "warn":
+        fails.append(f"z) expected a warn, got {res.get('status')!r}")
+    if "_sentinel_restamp_path" in res:
+        fails.append("z) a guessed repair target was published for an unreadable identity")
+    if "_sentinel_restamp_pid" not in res:
+        fails.append("z) the live pid must still be reported")
+    if "unreadable" not in (res.get("detail") or ""):
+        fails.append(f"z) the detail must say why: {res.get('detail')!r}")
+    if "Do NOT stop it" not in (res.get("detail") or ""):
+        fails.append("z) a draining watcher must never be prescribed for stopping")
+    # The positive control: the SAME shape with a readable identity does offer one.
+    ok = run_check(core_alive=True, pid_text=None, trees={"901": {"901"}},
+                   parents={"901": "900"}, pid_instance="")
+    if "_sentinel_restamp_path" not in ok:
+        fails.append("z) control: a readable identity must still name a target")
+    return fails
+
+
 def case_y2_private_keys_stay_out_of_the_json_payload() -> list[str]:
     """`_sentinel_restamp_pid` is the fix pass's internal channel, and whether it
     is present depends on the flags — so `--json` must not publish it."""
@@ -767,6 +796,7 @@ def main() -> int:
         ("x", case_x_fix_is_reachable_from_main),
         ("y", case_y_json_repair_line_goes_to_stderr),
         ("y2", case_y2_private_keys_stay_out_of_the_json_payload),
+        ("z", case_z_an_unreadable_watcher_identity_offers_no_repair_target),
     ]
     all_failures = []
     for label, fn in cases:

--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -655,8 +655,8 @@ def case_l_dead_sentinel_with_live_orphan() -> list[str]:
     fails = []
     if r["status"] != "warn":
         fails.append(f"l) expected warn, got {r['status']}")
-    if "orphaned" not in r["detail"]:
-        fails.append(f"l) detail should name the orphan, got {r['detail']!r}")
+    if "ownerless" not in r["detail"] or "supervised" not in r["detail"]:
+        fails.append(f"l) detail must split roots by owner, got {r['detail']!r}")
     if "IS being drained" not in r["detail"]:
         fails.append("l) must not claim tasks/ is unattended when a watcher runs")
     return fails
@@ -667,8 +667,8 @@ def case_m_absent_sentinel_with_live_orphan() -> list[str]:
     fails = []
     if r["status"] != "warn":
         fails.append(f"m) expected warn, got {r['status']}")
-    if "orphaned" not in r["detail"]:
-        fails.append(f"m) detail should name the orphan, got {r['detail']!r}")
+    if "ownerless" not in r["detail"] or "supervised" not in r["detail"]:
+        fails.append(f"m) detail must split roots by owner, got {r['detail']!r}")
     return fails
 
 
@@ -683,7 +683,9 @@ def case_m2_fabricated_pid_ignores_the_host_process_table() -> list[str]:
         r = run_check(core_alive=True, pid_text=None, trees={"9000": {"9000"}})
     finally:
         hc._pid_parent = saved
-    if "orphaned" not in r["detail"]:
+    # run_check stubs _pid_parent from its own `parents` arg, so the lambda above
+    # is overwritten before the check runs -- 9000's parent reads None either way.
+    if "ownerless" not in r["detail"] or "9000" not in r["detail"]:
         return [f"m2) host pid table leaked into the verdict, got {r['detail']!r}"]
     return []
 

--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -768,22 +768,64 @@ def case_q_trees_swallows_probe_failure() -> list[str]:
 
 
 def case_aa_argv_classification_binds_to_the_executed_script():
-    """A different script handed the watcher's path as DATA is not a watcher."""
+    """The EXECUTED script decides, read from the real argv vector — not from spelling.
+
+    Spawns real processes: a flattened argv cannot separate a spaced path from
+    two operands, so no string rule can pass this matrix.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+
     fails = []
+    tmp = tempfile.mkdtemp()
+
+    def mk(rel):
+        path = os.path.join(tmp, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as fh:
+            fh.write("#!/bin/bash\nsleep 8\n")
+        os.chmod(path, 0o755)
+        return path
+
     shapes = [
-        ("bash /tmp/unrelated.sh /repo/src/watch-tasks-stream.sh", False),
-        ("bash /repo/src/watch-tasks-stream.sh", True),
-        ("bash /repo/src/watch-tasks-stream.sh /ws/tasks", True),
-        ("bash /My Path/src/watch-tasks-stream.sh", True),
-        ("bash /My Path/src/watch-tasks-stream.sh /ws/tasks", True),
-        ("bash -c echo watch-tasks-stream.sh", False),
-        ("bash /repo/src/x-watch-tasks-stream.sh", False),
-        ("python3 /repo/src/watch-tasks-stream.sh", False),
+        ("dir ending .sh, real watcher", ["/bin/bash", mk("dir.sh/src/watch-tasks-stream.sh"), "/ws/tasks"], True),
+        ("no extension + path as DATA", ["/bin/bash", mk("unrelated"), "/repo/src/watch-tasks-stream.sh"], False),
+        (".bash + path as DATA", ["/bin/bash", mk("unrelated.bash"), "/repo/src/watch-tasks-stream.sh"], False),
+        (".sh + path as DATA", ["/bin/bash", mk("unrelated.sh"), "/repo/src/watch-tasks-stream.sh"], False),
+        ("path WITH SPACES + tasks", ["/bin/bash", mk("My Path/src/watch-tasks-stream.sh"), "/ws/tasks"], True),
+        ("plain watcher, no args", ["/bin/bash", mk("plain/src/watch-tasks-stream.sh")], True),
     ]
-    for argv, want in shapes:
+    try:
+        for label, cmd, want in shapes:
+            proc = subprocess.Popen(cmd)
+            try:
+                time.sleep(0.35)
+                got = hc._is_watcher_argv(" ".join(cmd), proc.pid)
+                if got is not want:
+                    fails.append(f"aa) {label}: got {got}, want {want}")
+            finally:
+                proc.kill()
+                proc.wait()
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    return fails
+
+
+def case_ab_ambiguous_flattened_argv_declines_rather_than_guesses():
+    """No pid and >2 tokens is UNDECIDABLE, and must report None, not a guess."""
+    fails = []
+    checks = [
+        ("bash /a/b.sh /c/watch-tasks-stream.sh", None),   # script + operand, or spaced path?
+        ("bash /repo/src/watch-tasks-stream.sh", True),    # one operand however spelled
+        ("python3 /repo/src/watch-tasks-stream.sh", False),
+        ("bash -c echo watch-tasks-stream.sh", False),
+        ("bash", False),
+    ]
+    for argv, want in checks:
         got = hc._is_watcher_argv(argv)
         if got is not want:
-            fails.append(f"aa) _is_watcher_argv({argv!r}) = {got}, want {want}")
+            fails.append(f"ab) _is_watcher_argv({argv!r}) = {got}, want {want}")
     return fails
 
 
@@ -825,6 +867,7 @@ def main() -> int:
         ("y2", case_y2_private_keys_stay_out_of_the_json_payload),
         ("z", case_z_an_unreadable_watcher_identity_offers_no_repair_target),
         ("aa", case_aa_argv_classification_binds_to_the_executed_script),
+        ("ab", case_ab_ambiguous_flattened_argv_declines_rather_than_guesses),
     ]
     all_failures = []
     for label, fn in cases:

--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -767,6 +767,26 @@ def case_q_trees_swallows_probe_failure() -> list[str]:
     return []
 
 
+def case_aa_argv_classification_binds_to_the_executed_script():
+    """A different script handed the watcher's path as DATA is not a watcher."""
+    fails = []
+    shapes = [
+        ("bash /tmp/unrelated.sh /repo/src/watch-tasks-stream.sh", False),
+        ("bash /repo/src/watch-tasks-stream.sh", True),
+        ("bash /repo/src/watch-tasks-stream.sh /ws/tasks", True),
+        ("bash /My Path/src/watch-tasks-stream.sh", True),
+        ("bash /My Path/src/watch-tasks-stream.sh /ws/tasks", True),
+        ("bash -c echo watch-tasks-stream.sh", False),
+        ("bash /repo/src/x-watch-tasks-stream.sh", False),
+        ("python3 /repo/src/watch-tasks-stream.sh", False),
+    ]
+    for argv, want in shapes:
+        got = hc._is_watcher_argv(argv)
+        if got is not want:
+            fails.append(f"aa) _is_watcher_argv({argv!r}) = {got}, want {want}")
+    return fails
+
+
 def main() -> int:
     cases = [
         ("a", case_a_no_core_is_ok),
@@ -804,6 +824,7 @@ def main() -> int:
         ("y", case_y_json_repair_line_goes_to_stderr),
         ("y2", case_y2_private_keys_stay_out_of_the_json_payload),
         ("z", case_z_an_unreadable_watcher_identity_offers_no_repair_target),
+        ("aa", case_aa_argv_classification_binds_to_the_executed_script),
     ]
     all_failures = []
     for label, fn in cases:

--- a/tests/restart-gateway-lanes-no-watcher-touch.test.sh
+++ b/tests/restart-gateway-lanes-no-watcher-touch.test.sh
@@ -66,7 +66,10 @@ else
   bad "start_gateway_lanes is defined in src/startup-runtime.sh" "not found"
 fi
 
-reap_line="$(grep -n 'reap_stale_task_watcher "\$WORKSPACE' "$REPO/src/startup.sh" | head -1 | cut -d: -f1)"
+# Locate the reap CALL, not one particular argument spelling: the reaper now
+# enumerates every per-instance sentinel, so the argument is a loop variable.
+# Comment lines are skipped (startup.sh mentions the function in prose below).
+reap_line="$(awk '/reap_stale_task_watcher/ { l=$0; sub(/^[[:space:]]+/, "", l); if (l !~ /^#/) { print NR; exit } }' "$REPO/src/startup.sh")"
 gw_line="$(grep -n '^start_gateway_lanes$' "$REPO/src/startup.sh" | head -1 | cut -d: -f1)"
 if [ -n "$reap_line" ] && [ -n "$gw_line" ] && [ "$reap_line" -lt "$gw_line" ]; then
   ok "startup.sh still reaps before (re)starting gateway lanes on a real boot"

--- a/tests/services-status-liveness-patterns.test.py
+++ b/tests/services-status-liveness-patterns.test.py
@@ -143,3 +143,21 @@ if failures:
     print(f"{len(failures)} check(s) FAILED: {failures}")
     sys.exit(1)
 print("all checks passed — liveness patterns match the daemon, not mentions of it")
+
+def _dup_pid_sentinels_are_not_two_watchers():
+    """john-the-dev on #3875: two sentinel FILES naming one pid reported
+    "2 watchers: pid 95442, pid 95442" — a pool that does not exist."""
+    import tempfile
+    import pathlib as _pl
+    from services_status import probe_watcher_sentinels
+    td = _pl.Path(tempfile.mkdtemp())
+    (td / "watch-tasks-stream-agent+a.pid").write_text("95442")
+    (td / "watch-tasks-stream-agent+b.pid").write_text("95442")
+    status, detail, _ = probe_watcher_sentinels(td, lambda p: True)
+    assert status == "degraded", (status, detail)
+    assert "one pid, two sentinels" in detail, detail
+    assert "2 watchers" not in detail, detail
+    print("  ok   duplicate-pid sentinels are degraded, not two watchers")
+
+
+_dup_pid_sentinels_are_not_two_watchers()

--- a/tests/services-status-liveness-patterns.test.py
+++ b/tests/services-status-liveness-patterns.test.py
@@ -161,3 +161,23 @@ def _dup_pid_sentinels_are_not_two_watchers():
 
 
 _dup_pid_sentinels_are_not_two_watchers()
+
+def _collision_survives_a_partly_down_pool():
+    """keweichen: A/B -> live 100 plus C -> dead 999 reported
+    '2 of 3 up (pid 100, pid 100)' — the collision vanished and one process
+    was counted twice."""
+    import tempfile
+    import pathlib as _pl
+    from services_status import probe_watcher_sentinels
+    td = _pl.Path(tempfile.mkdtemp())
+    (td / "watch-tasks-stream-A.pid").write_text("100")
+    (td / "watch-tasks-stream-B.pid").write_text("100")
+    (td / "watch-tasks-stream-C.pid").write_text("999")
+    status, detail, _ = probe_watcher_sentinels(td, lambda p: int(p) == 100)
+    assert "1 of 3 up" in detail, detail
+    assert "pid 100, pid 100" not in detail, detail
+    assert "one pid, two sentinels" in detail, detail
+    print("  ok   a collision survives a partly-down pool")
+
+
+_collision_survives_a_partly_down_pool()

--- a/tests/services-status.test.py
+++ b/tests/services-status.test.py
@@ -212,7 +212,8 @@ def test_service_registry_full_desktop_set():
                      "discord-bridge", "slack-bridge", "telegram-bridge"):
         assert expected in ids, expected
     for s in reg:
-        assert s["probe"][0] in ("alive_file", "pidfile", "port", "process", "gateway")
+        assert s["probe"][0] in ("alive_file", "pidfile", "port", "process",
+                                 "gateway", "watcher_sentinels")
     # a full build over the real registry must not raise and covers every kind
     payload = ss.build_payload(reg, 1.0, pid_alive=lambda p: False,
                                connect=lambda p: False, pgrep=lambda pat: [])
@@ -387,6 +388,48 @@ def test_registry_gateway_uses_the_sidecar_probe():
     assert spec["probe"][0] == "gateway", spec["probe"]
     assert spec["probe"][1] == ss.GATEWAY_STATUS_PATH
 
+
+
+def test_watcher_row_aggregates_every_instance_sentinel():
+    """Reporting the FIRST sentinel answers about one instance, and is wrong in
+    both directions on a pool: a dead historic pid beside a live worker read
+    `offline`, and a live historic pid beside a dead worker read `running`."""
+    import tempfile
+    two = {"watch-tasks-stream.pid": "100", "watch-tasks-stream-worker-1.pid": "200"}
+
+    def probe(files, alive):
+        td = Path(tempfile.mkdtemp())
+        for n, txt in files.items():
+            (td / n).write_text(txt)
+        return ss.probe_watcher_sentinels(td, lambda pid: pid in alive)[:2]
+
+    assert probe(two, {200})[0] == "degraded"
+    assert probe(two, {100})[0] == "degraded"
+
+    # An unmixed set, and a single-instance host, keep their exact verdicts.
+    assert probe(two, {100, 200})[0] == "running"
+    assert probe(two, set())[0] == "offline"
+    assert probe({"watch-tasks-stream.pid": "100"}, {100})[0] == "running"
+    assert probe({"watch-tasks-stream.pid": "100"}, set())[0] == "offline"
+    assert probe({}, set()) == ("offline", "no pidfile")
+    # `unknown` outranks `offline` when nothing is up: an unreadable sentinel
+    # is a question, and "offline" would answer it.
+    assert probe({"watch-tasks-stream.pid": "xx"}, set())[0] == "unknown"
+    mixed_unreadable = {"watch-tasks-stream.pid": "xx", "watch-tasks-stream-w.pid": "200"}
+    assert probe(mixed_unreadable, set())[0] == "unknown"
+    assert probe(mixed_unreadable, {200})[0] == "degraded"
+
+
+def test_the_degraded_detail_names_which_instance_is_down():
+    """A row saying only "1 of 2 up" sends the reader to guess which."""
+    import tempfile
+    td = Path(tempfile.mkdtemp())
+    (td / "watch-tasks-stream.pid").write_text("100")
+    (td / "watch-tasks-stream-worker-1.pid").write_text("200")
+    status, detail, _ = ss.probe_watcher_sentinels(td, lambda pid: pid == 200)
+    assert status == "degraded"
+    assert "watch-tasks-stream.pid" in detail
+    assert "100" in detail and "200" in detail
 
 if __name__ == "__main__":
     # Minimal assert-runner so the file is self-executing without pytest too.

--- a/tests/startup-watcher-reaper-ownership.test.sh
+++ b/tests/startup-watcher-reaper-ownership.test.sh
@@ -125,8 +125,11 @@ fi
 fi  # have_fn
 
 # --- wiring: startup.sh must delegate, not re-implement ------------------------
-if grep -q 'reap_stale_task_watcher "\$WORKSPACE/state/watch-tasks-stream.pid"' "$REPO/src/startup.sh"; then
-  ok "startup.sh delegates to the shared reaper"
+# The argument is now every sentinel the resolver finds (one per instance), so
+# assert the delegation and the enumeration, not one literal path.
+if grep -q 'reap_stale_task_watcher "\$__sentinel"' "$REPO/src/startup.sh" \
+   && grep -q 'sentinel_paths_in "\$WORKSPACE/state"' "$REPO/src/startup.sh"; then
+  ok "startup.sh delegates to the shared reaper, once per instance sentinel"
 else
   bad "startup.sh delegates to the shared reaper" "call site not found"
 fi

--- a/tests/startup-watcher-reaper-ownership.test.sh
+++ b/tests/startup-watcher-reaper-ownership.test.sh
@@ -124,14 +124,54 @@ else
 fi
 fi  # have_fn
 
-# --- wiring: startup.sh must delegate, not re-implement ------------------------
-# The argument is now every sentinel the resolver finds (one per instance), so
-# assert the delegation and the enumeration, not one literal path.
+# --- wiring: startup.sh must delegate, and reap only THIS instance -------------
+# This used to assert `sentinel_paths_in` — the enumeration of EVERY instance's
+# sentinel. The reaper deliberately kills a watcher that owns its sentinel, so
+# that loop killed a peer's live watcher and removed its record.
 if grep -q 'reap_stale_task_watcher "\$__sentinel"' "$REPO/src/startup.sh" \
-   && grep -q 'sentinel_paths_in "\$WORKSPACE/state"' "$REPO/src/startup.sh"; then
-  ok "startup.sh delegates to the shared reaper, once per instance sentinel"
+   && grep -q 'sentinel_path_for "\$WORKSPACE/state"' "$REPO/src/startup.sh"; then
+  ok "startup.sh delegates to the shared reaper for its OWN sentinel"
 else
   bad "startup.sh delegates to the shared reaper" "call site not found"
+fi
+if grep -q 'sentinel_paths_in "\$WORKSPACE/state"' "$REPO/src/startup.sh"; then
+  bad "startup.sh reaps only its own identity" "it still enumerates every instance's sentinel"
+else
+  ok "startup.sh reaps only its own identity"
+fi
+
+# --- peer survival: the property the enumeration assertion could not express ---
+# LIMIT, measured: this case calls sentinel_path_for + the reaper DIRECTLY, so it
+# proves the scoped shape is safe -- it does NOT re-fail if startup.sh regresses
+# to the enumeration. The two greps above are what pin the wiring; restoring the
+# loop failed exactly those two while this case still reported ok.
+if [ -n "${have_fn:-}" ] && command -v sentinel_path_for >/dev/null 2>&1; then
+  _pt="$(mktemp -d)"; mkdir -p "$_pt/state" "$_pt/src"
+  printf '#!/bin/bash\nsleep 60\n' > "$_pt/src/watch-tasks-stream.sh"; chmod +x "$_pt/src/watch-tasks-stream.sh"
+  bash "$_pt/src/watch-tasks-stream.sh" & _a=$!
+  bash "$_pt/src/watch-tasks-stream.sh" & _b=$!
+  sleep 2
+  echo "$_a" > "$_pt/state/watch-tasks-stream.pid"
+  echo "$_b" > "$_pt/state/watch-tasks-stream-peer-b+w2.pid"
+  if kill -0 "$_a" 2>/dev/null && kill -0 "$_b" 2>/dev/null; then
+    if _s="$(sentinel_path_for "$_pt/state")" && [ -n "$_s" ]; then
+      reap_stale_task_watcher "$_s" >/dev/null 2>&1
+    fi
+    sleep 1
+    if kill -0 "$_b" 2>/dev/null && [ -f "$_pt/state/watch-tasks-stream-peer-b+w2.pid" ]; then
+      ok "a peer instance's live watcher and sentinel both survive this startup"
+    else
+      bad "a peer instance survives this startup" "the peer was killed or its sentinel removed"
+    fi
+    if kill -0 "$_a" 2>/dev/null; then
+      bad "this instance's own stale watcher is still reaped" "it survived, so the reap did nothing"
+    else
+      ok "this instance's own stale watcher is still reaped"
+    fi
+  else
+    bad "peer-survival fixture" "a fixture watcher was not alive; the case measured nothing"
+  fi
+  kill "$_a" "$_b" 2>/dev/null; rm -rf "$_pt"
 fi
 if grep -q 'rm -f "\$WATCHER_PID_FILE"' "$REPO/src/startup.sh"; then
   bad "startup.sh keeps no unguarded copy" "the inline rm -f is still there"

--- a/tests/util-paths-runtime-identity-absent.test.py
+++ b/tests/util-paths-runtime-identity-absent.test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""With the runtime identity module unavailable, both readers state ABSENCE.
+
+Neither may fall back to this process's own identity: the caller is health-check
+and the subject is a watcher, so a guessed default is published as a repair
+target for someone else's pid.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("util_paths", ROOT / "src" / "util_paths.py")
+up = importlib.util.module_from_spec(_spec)
+sys.modules["util_paths"] = up
+_spec.loader.exec_module(up)
+
+
+class RuntimeIdentityAbsent(unittest.TestCase):
+    def test_actor_env_names_is_empty_not_a_default_list(self):
+        with patch.object(up, "_runtime_identity", return_value=None):
+            self.assertEqual(up.actor_env_names(), ())
+
+    def test_stated_default_identity_is_None_not_this_process(self):
+        with patch.object(up, "_runtime_identity", return_value=None):
+            self.assertIsNone(up.stated_default_identity(Path("/tmp")))
+
+    def test_both_return_something_when_the_module_resolves(self):
+        """Without this the two nulls above would pass on a broken import."""
+        names = up.actor_env_names()
+        self.assertIsInstance(names, tuple)
+        if up._runtime_identity() is None:
+            self.skipTest("runtime identity module not importable in this env")
+        self.assertGreater(len(names), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/watch-tasks-stream-fallback-receipt-scope.test.py
+++ b/tests/watch-tasks-stream-fallback-receipt-scope.test.py
@@ -1,0 +1,97 @@
+"""A fallback receipt is instance-local knowledge, not a shared flag.
+
+The receipt says "MY optional handler declined this task". Written to one shared
+directory, every OTHER watcher read it as its own and bypassed its handler,
+emitting the task straight to its own live core. Measured against the real
+watcher with a stub fswatch and a logging handler:
+
+    FOREIGN receipt -> stdout=[TASK_FILE: task-demo.txt]  handler=[probe]
+    scoped receipt  -> stdout=[]                          handler=[probe, handle]
+
+The own-receipt cases are the negative control: bypassing on your OWN receipt is
+the feature, and a fix that broke it would pass a foreign-receipt test alone.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+FAILURES: list[str] = []
+
+def run(watcher_instance, receipt_owner):
+    """receipt_owner: None | 'default' | '<instance>' — whose receipt exists."""
+    tmp = Path(tempfile.mkdtemp(prefix="b4-"))
+    ws = tmp / "ws"
+    (ws / "tasks").mkdir(parents=True); (ws / "results" / "archive").mkdir(parents=True)
+    (ws / "state").mkdir()
+    feed = tmp / "feed"; feed.write_text("")
+    b = tmp / "bin"; b.mkdir()
+    (b / "fswatch").write_text(f"#!/bin/sh\nexec tail -n +1 -f {feed}\n"); (b / "fswatch").chmod(0o755)
+    log = tmp / "handler.log"; h = tmp / "handler.sh"
+    h.write_text('#!/bin/sh\nfor a in "$@"; do [ "$a" = "--probe" ] && { echo probe >> %s; exit 0; }; done\n'
+                 'echo handle >> %s\nexit 0\n' % (log, log)); h.chmod(0o755)
+    name = "task-demo.txt"
+    (ws / "tasks" / name).write_text("id: task-demo\naccess_tier: owner\ntask: probe\n")
+    if receipt_owner is not None:
+        env0 = dict(os.environ)
+        if receipt_owner != "default": env0["SUTANDO_INSTANCE_ID"] = receipt_owner
+        else: env0.pop("SUTANDO_INSTANCE_ID", None)
+        d = subprocess.run(["python3", str(REPO/"src/util_paths.py"), "handler-fallbacks-dir",
+                            str(ws/"state")], capture_output=True, text=True, env=env0).stdout.strip()
+        Path(d).mkdir(parents=True, exist_ok=True)
+        (Path(d) / name).write_text(str(ws / "tasks" / name) + "\n")
+    env = dict(os.environ)
+    env["PATH"] = f"{b}:{env['PATH']}"; env["TMPDIR"] = str(tmp)
+    env["SUTANDO_RESULTS_DIR"] = str(ws / "results")
+    env["SUTANDO_TASK_EVENT_HANDLER"] = str(h)
+    if watcher_instance: env["SUTANDO_INSTANCE_ID"] = watcher_instance
+    else: env.pop("SUTANDO_INSTANCE_ID", None)
+    p = subprocess.Popen(["bash", "src/watch-tasks-stream.sh", str(ws / "tasks")], cwd=str(REPO),
+                         env=env, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                         text=True, start_new_session=True)
+    out, t0 = [], time.time()
+    try:
+        os.set_blocking(p.stdout.fileno(), False)
+        while time.time() - t0 < 8:
+            time.sleep(0.3)
+            try:
+                c = p.stdout.read()
+                if c: out.append(c)
+            except Exception: pass
+            if log.exists() and "handle" in log.read_text(): break
+            if any("TASK_FILE" in c for c in out): break
+    finally:
+        try: os.killpg(os.getpgid(p.pid), 15)
+        except Exception: pass
+        p.wait(timeout=5)
+    return "".join(out).strip().splitlines(), (log.read_text().split() if log.exists() else [])
+
+def check(name, cond, detail=""):
+    print(("  ok   " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        FAILURES.append(name)
+
+
+HANDLED = ["probe", "handle"]
+BYPASSED = ["probe"]
+
+so, hl = run(None, None)
+check("no receipt: the handler handles it", hl == HANDLED and not so, f"{so} {hl}")
+
+so, hl = run(None, "default")
+check("own receipt: the watcher still bypasses to its core",
+      hl == BYPASSED and any("TASK_FILE" in s for s in so), f"{so} {hl}")
+
+so, hl = run("worker-1", "default")
+check("a FOREIGN receipt does not bypass this instance's handler",
+      hl == HANDLED and not so, f"{so} {hl}")
+
+so, hl = run("worker-1", "worker-1")
+check("worker-1 still bypasses on its OWN receipt",
+      hl == BYPASSED and any("TASK_FILE" in s for s in so), f"{so} {hl}")
+
+print(f"watch-tasks-stream-fallback-receipt-scope: {4 - len(FAILURES)}/4 passed")
+sys.exit(1 if FAILURES else 0)

--- a/tests/watch-tasks-stream-fallback-receipt-scope.test.py
+++ b/tests/watch-tasks-stream-fallback-receipt-scope.test.py
@@ -93,5 +93,23 @@ so, hl = run("worker-1", "worker-1")
 check("worker-1 still bypasses on its OWN receipt",
       hl == BYPASSED and any("TASK_FILE" in s for s in so), f"{so} {hl}")
 
-print(f"watch-tasks-stream-fallback-receipt-scope: {4 - len(FAILURES)}/4 passed")
+# keweichen at c40e6e61: STATE_DIR re-resolved the CHECKOUT workspace while every
+# other state path followed the argv-derived WORKSPACE_DIR, so this very test wrote
+# and then deleted a real installation's sentinel.
+_canon = Path(subprocess.run(["bash", str(REPO / "scripts/sutando-config.sh"), "workspace"],
+                             capture_output=True, text=True).stdout.strip()) / "state" / "watch-tasks-stream.pid"
+_had = _canon.exists()
+_before = _canon.read_bytes() if _had else None
+_canon.parent.mkdir(parents=True, exist_ok=True)
+if not _had:
+    _canon.write_bytes(b"sentinel-control-do-not-touch\n")
+    _before = _canon.read_bytes()
+run(None, None)
+_after = _canon.read_bytes() if _canon.exists() else None
+if not _had:
+    _canon.unlink(missing_ok=True)
+check("a pre-existing CHECKOUT sentinel is byte-for-byte untouched by this test",
+      _after == _before, f"before={_before!r} after={_after!r}")
+
+print(f"watch-tasks-stream-fallback-receipt-scope: {5 - len(FAILURES)}/5 passed")
 sys.exit(1 if FAILURES else 0)

--- a/tests/watch-tasks-stream-fallback-receipt-scope.test.py
+++ b/tests/watch-tasks-stream-fallback-receipt-scope.test.py
@@ -93,9 +93,8 @@ so, hl = run("worker-1", "worker-1")
 check("worker-1 still bypasses on its OWN receipt",
       hl == BYPASSED and any("TASK_FILE" in s for s in so), f"{so} {hl}")
 
-# keweichen at c40e6e61: STATE_DIR re-resolved the CHECKOUT workspace while every
-# other state path followed the argv-derived WORKSPACE_DIR, so this very test wrote
-# and then deleted a real installation's sentinel.
+# STATE_DIR once re-resolved the CHECKOUT workspace while every other state path
+# followed argv-derived WORKSPACE_DIR, so this test deleted a live sentinel.
 _canon = Path(subprocess.run(["bash", str(REPO / "scripts/sutando-config.sh"), "workspace"],
                              capture_output=True, text=True).stdout.strip()) / "state" / "watch-tasks-stream.pid"
 _had = _canon.exists()

--- a/tests/watch-tasks-stream-fallback-receipt-scope.test.py
+++ b/tests/watch-tasks-stream-fallback-receipt-scope.test.py
@@ -21,7 +21,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 FAILURES: list[str] = []
 
-def run(watcher_instance, receipt_owner):
+def run(watcher_instance, receipt_owner, want_state=False):
     """receipt_owner: None | 'default' | '<instance>' — whose receipt exists."""
     tmp = Path(tempfile.mkdtemp(prefix="b4-"))
     ws = tmp / "ws"
@@ -52,7 +52,7 @@ def run(watcher_instance, receipt_owner):
     p = subprocess.Popen(["bash", "src/watch-tasks-stream.sh", str(ws / "tasks")], cwd=str(REPO),
                          env=env, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
                          text=True, start_new_session=True)
-    out, t0 = [], time.time()
+    out, t0, seen_state = [], time.time(), set()
     try:
         os.set_blocking(p.stdout.fileno(), False)
         while time.time() - t0 < 8:
@@ -61,13 +61,17 @@ def run(watcher_instance, receipt_owner):
                 c = p.stdout.read()
                 if c: out.append(c)
             except Exception: pass
+            # Sample WHILE the watcher lives: its cleanup trap unlinks the
+            # sentinel on exit, so a post-hoc listing is always empty.
+            seen_state.update(q.name for q in (ws / "state").glob("watch-tasks-stream*.pid"))
             if log.exists() and "handle" in log.read_text(): break
             if any("TASK_FILE" in c for c in out): break
     finally:
         try: os.killpg(os.getpgid(p.pid), 15)
         except Exception: pass
         p.wait(timeout=5)
-    return "".join(out).strip().splitlines(), (log.read_text().split() if log.exists() else [])
+    _res = "".join(out).strip().splitlines(), (log.read_text().split() if log.exists() else [])
+    return (sorted(seen_state), _res) if want_state else _res
 
 def check(name, cond, detail=""):
     print(("  ok   " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
@@ -97,18 +101,22 @@ check("worker-1 still bypasses on its OWN receipt",
 # followed argv-derived WORKSPACE_DIR, so this test deleted a live sentinel.
 _canon = Path(subprocess.run(["bash", str(REPO / "scripts/sutando-config.sh"), "workspace"],
                              capture_output=True, text=True).stdout.strip()) / "state" / "watch-tasks-stream.pid"
-_had = _canon.exists()
-_before = _canon.read_bytes() if _had else None
-_canon.parent.mkdir(parents=True, exist_ok=True)
-if not _had:
-    _canon.write_bytes(b"sentinel-control-do-not-touch\n")
-    _before = _canon.read_bytes()
-run(None, None)
-_after = _canon.read_bytes() if _canon.exists() else None
-if not _had:
-    _canon.unlink(missing_ok=True)
-check("a pre-existing CHECKOUT sentinel is byte-for-byte untouched by this test",
-      _after == _before, f"before={_before!r} after={_after!r}")
+# READ-ONLY on the canonical path: never seed, never unlink. Seeding-then-
+# unlinking deletes the sentinel of a watcher that starts mid-test.
+_before = (_canon.exists(), _canon.read_bytes() if _canon.exists() else None)
+_scratch_seen, _ = run(None, None, want_state=True)
+_after = (_canon.exists(), _canon.read_bytes() if _canon.exists() else None)
+
+# The race-free discriminator: the watcher must have written INTO the argv-derived
+# scratch workspace. This fails on the pre-fix source and needs no canonical write.
+check("the watcher's sentinel lands in the SCRATCH workspace, not the checkout",
+      _scratch_seen == ["watch-tasks-stream.pid"],
+      f"sampled while alive, scratch state held {_scratch_seen}")
+
+check("the canonical CHECKOUT sentinel is unchanged (read-only check)",
+      _after == _before,
+      f"before={_before!r} after={_after!r} -- either this test wrote it, or a real "
+      f"watcher started mid-run; both are worth a human look")
 
 print(f"watch-tasks-stream-fallback-receipt-scope: {5 - len(FAILURES)}/5 passed")
 sys.exit(1 if FAILURES else 0)

--- a/tests/watcher-sentinel-naming.test.py
+++ b/tests/watcher-sentinel-naming.test.py
@@ -14,6 +14,7 @@ registry already share. An earlier revision of this file keyed on an invented
 with each other and disagreed with production, which is why "the two agree" is
 no longer an assertion here.
 """
+import importlib.util
 import os
 import subprocess
 import sys
@@ -211,6 +212,63 @@ class ReadersUseTheResolver(unittest.TestCase):
                 if "watch-tasks-stream.pid" in line and not line.lstrip().startswith("#"):
                     offenders.append(f"{rel}:{i}: {line.strip()}")
         self.assertEqual(offenders, [], "readers must resolve the sentinel, not name it")
+
+
+class TheFallbackReceiptIsScopedLikeTheSentinel(unittest.TestCase):
+    """Same identity, second path. A shared receipt made one instance bypass
+    another's handler, so this must move with the sentinel, not beside it."""
+
+    def setUp(self):
+        for k in ("SUTANDO_INSTANCE_ID", "SUTANDO_AGENT_ID", "AGENT_MXID",
+                  "AGENT_ID", "SUTANDO_INSTANCE"):
+            os.environ.pop(k, None)
+        self.d = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        os.environ.pop("SUTANDO_INSTANCE_ID", None)
+
+    def test_the_canonical_default_keeps_the_historic_directory(self):
+        self.assertEqual(up.handler_fallbacks_dir(self.d),
+                         self.d / "task-event-handler-fallbacks")
+
+    def test_each_instance_gets_its_own_subdirectory(self):
+        os.environ["SUTANDO_INSTANCE_ID"] = "worker-1"
+        one = up.handler_fallbacks_dir(self.d)
+        os.environ["SUTANDO_INSTANCE_ID"] = "worker-2"
+        two = up.handler_fallbacks_dir(self.d)
+        self.assertNotEqual(one, two)
+        for p in (one, two):
+            self.assertEqual(p.parent, self.d / "task-event-handler-fallbacks")
+
+    def test_it_shares_the_sentinel_key_rather_than_deriving_its_own(self):
+        os.environ["SUTANDO_INSTANCE_ID"] = "worker-1"
+        key = up.instance_scope_key(self.d)
+        self.assertTrue(key)
+        self.assertEqual(up.handler_fallbacks_dir(self.d).name, key)
+        self.assertIn(key, up.watcher_sentinel_path(self.d).name)
+
+
+class AnUnavailableEncoderIsNotADefaultInstance(unittest.TestCase):
+    """`_runtime_identity` returns None on both import failures. Covering it
+    through the public helper only exercises the caller, not these branches."""
+
+    def test_an_unloadable_spec_returns_none(self):
+        with unittest.mock.patch("importlib.util.spec_from_file_location",
+                                 return_value=None):
+            self.assertIsNone(up._runtime_identity())
+
+    def test_a_raising_exec_module_returns_none(self):
+        real = importlib.util.spec_from_file_location
+
+        def boom(name, src):
+            spec = real(name, src)
+            if spec is not None:
+                spec.loader.exec_module = lambda mod: (_ for _ in ()).throw(
+                    RuntimeError("no runtime here"))
+            return spec
+
+        with unittest.mock.patch("importlib.util.spec_from_file_location", boom):
+            self.assertIsNone(up._runtime_identity())
 
 
 if __name__ == "__main__":

--- a/tests/watcher-sentinel-naming.test.py
+++ b/tests/watcher-sentinel-naming.test.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -132,6 +133,25 @@ class Enumeration(unittest.TestCase):
         (self.d / "watch-tasks-stream-dir.pid").mkdir()
         self.assertEqual(self._names(), [])
         self.assertEqual(self._sh_names(), [])
+
+    def test_an_unreadable_state_dir_degrades_instead_of_raising(self):
+        """The reaper calls this at startup before anything else, so a raising
+        enumerator aborts the boot rather than skipping one sentinel.
+
+        `Path.glob` swallows a missing, unreadable or non-directory path on
+        CPython, so injection is the only way to reach the guard -- and the only
+        way to show it is not decoration.
+        """
+        (self.d / "watch-tasks-stream.pid").write_text("1\n")
+
+        def boom(self, pattern):
+            raise OSError(13, "Permission denied")
+
+        # The historic name comes from exists(); only the per-instance sweep
+        # raises, so a partial answer still beats an exception.
+        with unittest.mock.patch.object(Path, "glob", boom):
+            names = [p.name for p in up.watcher_sentinel_paths(self.d)]
+        self.assertEqual(names, ["watch-tasks-stream.pid"])
 
     def test_both_enumerators_agree(self):
         for n in ["watch-tasks-stream.pid", "watch-tasks-stream-w1.pid",

--- a/tests/watcher-sentinel-naming.test.py
+++ b/tests/watcher-sentinel-naming.test.py
@@ -120,11 +120,44 @@ class NamingContract(unittest.TestCase):
             try:
                 with self.assertRaises(RuntimeError):
                     up.watcher_sentinel_path(self.d)
-                os.environ["SUTANDO_INSTANCE_ID"] = "default"
-                self.assertEqual(up.watcher_sentinel_path(self.d).name,
-                                 "watch-tasks-stream.pid")
             finally:
                 os.environ.pop("SUTANDO_INSTANCE_ID", None)
+
+    def test_a_non_default_actor_refuses_too_not_only_a_non_default_instance(self):
+        """The measured hole: the refusal read ONLY the instance, so a
+        non-default ACTOR on the default instance took the historic name and two
+        actors shared one sentinel silently. AGENT_MXID is routinely set."""
+        with unittest.mock.patch.object(up, "_runtime_identity",
+                                        return_value=None):
+            for var in ("SUTANDO_AGENT_ID", "AGENT_MXID", "AGENT_ID"):
+                os.environ.pop("SUTANDO_INSTANCE_ID", None)
+                os.environ[var] = "@sutando-yixuan:ag2.space"
+                try:
+                    with self.assertRaises(RuntimeError, msg=var):
+                        up.watcher_sentinel_path(self.d)
+                finally:
+                    os.environ.pop(var, None)
+
+    def test_an_unreadable_runtime_answers_only_an_explicit_canonical_pair(self):
+        """POSITIVE CONTROL for the inversion: a caller that states both halves
+        and names the canonical tuple still gets the historic path, so the
+        refusal is about what cannot be READ, not a blanket outage."""
+        with unittest.mock.patch.object(up, "_runtime_identity",
+                                        return_value=None):
+            self.assertEqual(
+                up.watcher_sentinel_path(self.d, instance="default",
+                                         agent=up._DEGRADED_CANONICAL_ACTOR).name,
+                "watch-tasks-stream.pid")
+            with self.assertRaises(RuntimeError):
+                up.watcher_sentinel_path(self.d, instance="second",
+                                         agent=up._DEGRADED_CANONICAL_ACTOR)
+
+    def test_the_degraded_default_actor_matches_rundir(self):
+        """The one constant this module restates. A drift here would make the
+        canonical case above refuse on a healthy host."""
+        ident = up._runtime_identity()
+        self.assertIsNotNone(ident, "runtime-api must import in this checkout")
+        self.assertEqual(up._DEGRADED_CANONICAL_ACTOR, ident[0].DEFAULT_ACTOR)
 
 
 class Enumeration(unittest.TestCase):

--- a/tests/watcher-sentinel-naming.test.py
+++ b/tests/watcher-sentinel-naming.test.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""The watcher sentinel is per instance, and the shell and Python namers agree.
+
+The defect: every watcher on a host stamped `state/watch-tasks-stream.pid`, so
+on a pool host the Nth watcher's write erased the (N-1)th and the four readers
+tracked only whichever ran last. Measured on a live pool host: six watcher
+processes, one record, four of them invisible to the startup reaper and to
+health-check.
+
+Two namers exist because two runtimes read the file, so the test that matters
+is that they cannot drift.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+import util_paths as up  # noqa: E402
+
+SHELL = ROOT / "src" / "watcher_sentinel.sh"
+
+
+def _sh(fn: str, *args: str, env: "dict | None" = None) -> str:
+    e = {**os.environ, **(env or {})}
+    e.pop("SUTANDO_INSTANCE", None) if env is None else None
+    out = subprocess.run(
+        ["bash", "-c", f'source "{SHELL}"; {fn} ' + " ".join(f'"{a}"' for a in args)],
+        capture_output=True, text=True, env=e, check=True)
+    return out.stdout
+
+
+class NamingContract(unittest.TestCase):
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        os.environ.pop("SUTANDO_INSTANCE", None)
+
+    def test_no_instance_keeps_the_historic_name(self):
+        """A single-instance install must be byte-identical to before, or this
+        change is a migration rather than an addition."""
+        self.assertEqual(up.watcher_sentinel_path(self.d).name,
+                         "watch-tasks-stream.pid")
+        self.assertEqual(Path(_sh("sentinel_path_for", str(self.d)).strip()).name,
+                         "watch-tasks-stream.pid")
+
+    def test_an_instance_gets_its_own_file(self):
+        self.assertEqual(up.watcher_sentinel_path(self.d, "worker-2").name,
+                         "watch-tasks-stream-worker-2.pid")
+        self.assertEqual(
+            Path(_sh("sentinel_path_for", str(self.d), "worker-2").strip()).name,
+            "watch-tasks-stream-worker-2.pid")
+
+    def test_two_instances_do_not_collide(self):
+        a = up.watcher_sentinel_path(self.d, "worker-1")
+        b = up.watcher_sentinel_path(self.d, "worker-2")
+        self.assertNotEqual(a, b)
+
+    def test_the_env_default_is_read_by_both(self):
+        os.environ["SUTANDO_INSTANCE"] = "core-2"
+        try:
+            self.assertEqual(up.watcher_sentinel_path(self.d).name,
+                             "watch-tasks-stream-core-2.pid")
+            self.assertEqual(
+                Path(_sh("sentinel_path_for", str(self.d),
+                         env={"SUTANDO_INSTANCE": "core-2"}).strip()).name,
+                "watch-tasks-stream-core-2.pid")
+        finally:
+            os.environ.pop("SUTANDO_INSTANCE", None)
+
+    def test_both_namers_agree_across_a_range_of_names(self):
+        """The one assertion that survives either implementation being edited."""
+        for inst in ["", "core", "worker-2", "a.b_c", "../evil x", "  spaced  ",
+                     "UPPER", "-lead-", "...."]:
+            with self.subTest(inst=inst):
+                self.assertEqual(
+                    up.watcher_sentinel_path(self.d, inst).name,
+                    Path(_sh("sentinel_path_for", str(self.d), inst).strip()).name)
+
+    def test_a_hostile_instance_name_cannot_escape_the_state_dir(self):
+        p = up.watcher_sentinel_path(self.d, "../../etc/passwd")
+        self.assertEqual(p.parent, self.d)
+        self.assertNotIn("/", p.name)
+
+
+class Enumeration(unittest.TestCase):
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        os.environ.pop("SUTANDO_INSTANCE", None)
+
+    def _names(self):
+        return [p.name for p in up.watcher_sentinel_paths(self.d)]
+
+    def _sh_names(self):
+        out = _sh("sentinel_paths_in", str(self.d))
+        return [Path(x).name for x in out.split() if x]
+
+    def test_empty_state_dir_yields_nothing(self):
+        self.assertEqual(self._names(), [])
+        self.assertEqual(self._sh_names(), [])
+
+    def test_a_missing_state_dir_is_not_an_error(self):
+        """The reaper runs before anything guarantees state/ exists."""
+        gone = self.d / "nope"
+        self.assertEqual(up.watcher_sentinel_paths(gone), [])
+
+    def test_every_instance_sentinel_is_found(self):
+        for n in ["watch-tasks-stream.pid", "watch-tasks-stream-worker-1.pid",
+                  "watch-tasks-stream-worker-2.pid"]:
+            (self.d / n).write_text("1\n")
+        self.assertEqual(len(self._names()), 3)
+        self.assertEqual(len(self._sh_names()), 3)
+        self.assertEqual(self._names()[0], "watch-tasks-stream.pid")
+
+    def test_the_historic_name_comes_first(self):
+        """Readers that report one row keep reporting the same one as before."""
+        (self.d / "watch-tasks-stream-aaa.pid").write_text("1\n")
+        (self.d / "watch-tasks-stream.pid").write_text("2\n")
+        self.assertEqual(self._names()[0], "watch-tasks-stream.pid")
+
+    def test_unrelated_pid_files_are_not_swept_in(self):
+        """The glob decides what the reaper may signal, so it must be narrow."""
+        for n in ["watch-tasks-stream.pid.bak", "other.pid",
+                  "watch-tasks-streamer.pid", "watch-tasks-stream-x.pid.tmp"]:
+            (self.d / n).write_text("1\n")
+        self.assertEqual(self._names(), [])
+        self.assertEqual(self._sh_names(), [])
+
+    def test_a_directory_named_like_a_sentinel_is_skipped(self):
+        (self.d / "watch-tasks-stream-dir.pid").mkdir()
+        self.assertEqual(self._names(), [])
+        self.assertEqual(self._sh_names(), [])
+
+    def test_both_enumerators_agree(self):
+        for n in ["watch-tasks-stream.pid", "watch-tasks-stream-w1.pid",
+                  "watch-tasks-stream-w2.pid", "unrelated.pid"]:
+            (self.d / n).write_text("1\n")
+        self.assertEqual(sorted(self._names()), sorted(self._sh_names()))
+
+
+class ReadersUseTheResolver(unittest.TestCase):
+    """The naming rule is worthless if a reader still hardcodes the old path."""
+
+    def test_no_reader_hardcodes_the_sentinel_filename(self):
+        offenders = []
+        for rel in ["src/health-check.py", "src/services_status.py",
+                    "src/startup.sh", "src/watch-tasks-stream.sh"]:
+            for i, line in enumerate((ROOT / rel).read_text().splitlines(), 1):
+                if "watch-tasks-stream.pid" in line and not line.lstrip().startswith("#"):
+                    offenders.append(f"{rel}:{i}: {line.strip()}")
+        self.assertEqual(offenders, [], "readers must resolve the sentinel, not name it")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/watcher-sentinel-naming.test.py
+++ b/tests/watcher-sentinel-naming.test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""The watcher sentinel is per instance, and the shell and Python namers agree.
+"""The watcher sentinel is per instance, keyed on the runtime's own identity.
 
 The defect: every watcher on a host stamped `state/watch-tasks-stream.pid`, so
 on a pool host the Nth watcher's write erased the (N-1)th and the four readers
@@ -7,8 +7,12 @@ tracked only whichever ran last. Measured on a live pool host: six watcher
 processes, one record, four of them invisible to the startup reaper and to
 health-check.
 
-Two namers exist because two runtimes read the file, so the test that matters
-is that they cannot drift.
+There is ONE namer. The shell calls `util_paths.py`, which delegates to
+`src/runtime-api/instance_key.py` — the owner the run dir and the durable
+registry already share. An earlier revision of this file keyed on an invented
+`SUTANDO_INSTANCE` and mirrored a sanitizer in shell; both namers then agreed
+with each other and disagreed with production, which is why "the two agree" is
+no longer an assertion here.
 """
 import os
 import subprocess
@@ -37,53 +41,89 @@ def _sh(fn: str, *args: str, env: "dict | None" = None) -> str:
 class NamingContract(unittest.TestCase):
     def setUp(self):
         self.d = Path(tempfile.mkdtemp())
-        os.environ.pop("SUTANDO_INSTANCE", None)
+        for k in ("SUTANDO_INSTANCE_ID", "SUTANDO_AGENT_ID", "AGENT_MXID",
+                  "AGENT_ID", "SUTANDO_INSTANCE"):
+            os.environ.pop(k, None)
 
-    def test_no_instance_keeps_the_historic_name(self):
-        """A single-instance install must be byte-identical to before, or this
-        change is a migration rather than an addition."""
-        self.assertEqual(up.watcher_sentinel_path(self.d).name,
-                         "watch-tasks-stream.pid")
+    def _name(self, **env):
+        for k in ("SUTANDO_INSTANCE_ID", "SUTANDO_AGENT_ID", "AGENT_MXID",
+                  "AGENT_ID", "SUTANDO_INSTANCE"):
+            os.environ.pop(k, None)
+        os.environ.update(env)
+        try:
+            return up.watcher_sentinel_path(self.d).name
+        finally:
+            for k in env:
+                os.environ.pop(k, None)
+
+    def test_the_canonical_default_keeps_the_historic_name(self):
+        """A single-instance install must be byte-identical to before."""
+        self.assertEqual(self._name(), "watch-tasks-stream.pid")
         self.assertEqual(Path(_sh("sentinel_path_for", str(self.d)).strip()).name,
                          "watch-tasks-stream.pid")
 
-    def test_an_instance_gets_its_own_file(self):
-        self.assertEqual(up.watcher_sentinel_path(self.d, "worker-2").name,
-                         "watch-tasks-stream-worker-2.pid")
-        self.assertEqual(
-            Path(_sh("sentinel_path_for", str(self.d), "worker-2").strip()).name,
-            "watch-tasks-stream-worker-2.pid")
-
-    def test_two_instances_do_not_collide(self):
-        a = up.watcher_sentinel_path(self.d, "worker-1")
-        b = up.watcher_sentinel_path(self.d, "worker-2")
+    def test_the_canonical_env_separates_two_watchers(self):
+        """SUTANDO_INSTANCE_ID is what the launcher exports. Keying on anything
+        else leaves every production watcher on the historic name."""
+        a = self._name(SUTANDO_INSTANCE_ID="worker-1")
+        b = self._name(SUTANDO_INSTANCE_ID="worker-2")
         self.assertNotEqual(a, b)
+        self.assertNotEqual(a, "watch-tasks-stream.pid")
 
-    def test_the_env_default_is_read_by_both(self):
-        os.environ["SUTANDO_INSTANCE"] = "core-2"
-        try:
-            self.assertEqual(up.watcher_sentinel_path(self.d).name,
-                             "watch-tasks-stream-core-2.pid")
-            self.assertEqual(
-                Path(_sh("sentinel_path_for", str(self.d),
-                         env={"SUTANDO_INSTANCE": "core-2"}).strip()).name,
-                "watch-tasks-stream-core-2.pid")
-        finally:
-            os.environ.pop("SUTANDO_INSTANCE", None)
+    def test_the_invented_variable_is_not_read(self):
+        """Guards the exact defect: a name nothing in the repo produces."""
+        self.assertEqual(self._name(SUTANDO_INSTANCE="worker-1"),
+                         "watch-tasks-stream.pid")
 
-    def test_both_namers_agree_across_a_range_of_names(self):
-        """The one assertion that survives either implementation being edited."""
-        for inst in ["", "core", "worker-2", "a.b_c", "../evil x", "  spaced  ",
-                     "UPPER", "-lead-", "...."]:
+    def test_the_actor_half_participates(self):
+        self.assertNotEqual(self._name(SUTANDO_AGENT_ID="A"),
+                            self._name(SUTANDO_AGENT_ID="B"))
+
+    def test_case_differing_instances_do_not_share_a_file(self):
+        """macOS and Windows default to case-insensitive filesystems, where two
+        names that differ only in case are ONE file and the second write wins."""
+        self.assertNotEqual(self._name(SUTANDO_INSTANCE_ID="worker").lower(),
+                            self._name(SUTANDO_INSTANCE_ID="Worker").lower())
+
+    def test_punctuation_does_not_alias(self):
+        for a, b in (("lead", "-lead-"), ("a b", "a?b"), ("a.b", "a-b")):
+            with self.subTest(pair=(a, b)):
+                self.assertNotEqual(self._name(SUTANDO_INSTANCE_ID=a),
+                                    self._name(SUTANDO_INSTANCE_ID=b))
+
+    def test_a_punctuation_only_instance_does_not_become_the_default(self):
+        self.assertNotEqual(self._name(SUTANDO_INSTANCE_ID="...."),
+                            "watch-tasks-stream.pid")
+
+    def test_the_shell_asks_the_python_owner(self):
+        """Not "the two agree" — the shell has no namer of its own to disagree
+        with. Any instance the shell resolves must be the Python answer."""
+        self.assertNotIn("tr -c", SHELL.read_text())
+        for inst in ("worker-1", "Worker", "a?b", "-lead-", "...."):
             with self.subTest(inst=inst):
-                self.assertEqual(
-                    up.watcher_sentinel_path(self.d, inst).name,
-                    Path(_sh("sentinel_path_for", str(self.d), inst).strip()).name)
+                sh = Path(_sh("sentinel_path_for", str(self.d),
+                              env={"SUTANDO_INSTANCE_ID": inst}).strip()).name
+                self.assertEqual(sh, self._name(SUTANDO_INSTANCE_ID=inst))
 
     def test_a_hostile_instance_name_cannot_escape_the_state_dir(self):
         p = up.watcher_sentinel_path(self.d, "../../etc/passwd")
         self.assertEqual(p.parent, self.d)
         self.assertNotIn("/", p.name)
+
+    def test_a_non_default_instance_refuses_rather_than_aliasing(self):
+        """With the encoder unavailable, the historic name would silently put
+        two instances on one file. Refuse instead."""
+        with unittest.mock.patch.object(up, "_runtime_identity",
+                                        return_value=None):
+            os.environ["SUTANDO_INSTANCE_ID"] = "worker-1"
+            try:
+                with self.assertRaises(RuntimeError):
+                    up.watcher_sentinel_path(self.d)
+                os.environ["SUTANDO_INSTANCE_ID"] = "default"
+                self.assertEqual(up.watcher_sentinel_path(self.d).name,
+                                 "watch-tasks-stream.pid")
+            finally:
+                os.environ.pop("SUTANDO_INSTANCE_ID", None)
 
 
 class Enumeration(unittest.TestCase):

--- a/tests/watcher-sentinel-naming.test.py
+++ b/tests/watcher-sentinel-naming.test.py
@@ -15,6 +15,7 @@ with each other and disagreed with production, which is why "the two agree" is
 no longer an assertion here.
 """
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -302,6 +303,51 @@ class AnUnavailableEncoderIsNotADefaultInstance(unittest.TestCase):
 
         with unittest.mock.patch("importlib.util.spec_from_file_location", boom):
             self.assertIsNone(up._runtime_identity())
+
+
+class AnEnrolledDefaultInstallKeepsTheHistoricNames(unittest.TestCase):
+    """keweichen at a5933d4f: the compatibility test above uses an UNENROLLED
+    empty state dir, so it misses the normal upgrade shape. An enrolled install
+    with no instance env set is the ordinary single-host case, and it was
+    renaming both its sentinel and its durable fallback receipts on upgrade --
+    stranding the historic records as a dead peer."""
+
+    ENROLLED = "@enrolled:ag2.space"
+
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        for k in ("SUTANDO_INSTANCE_ID", "SUTANDO_AGENT_ID", "AGENT_MXID",
+                  "AGENT_ID", "SUTANDO_INSTANCE"):
+            os.environ.pop(k, None)
+        (self.d / "auth").mkdir(parents=True, exist_ok=True)
+        (self.d / "auth" / "ag2space.json").write_text(
+            json.dumps({"agent_id": self.ENROLLED}))
+
+    def test_the_sentinel_keeps_the_historic_bare_name(self):
+        self.assertEqual(up.watcher_sentinel_path(self.d).name,
+                         "watch-tasks-stream.pid",
+                         "an enrolled default install must not rename its "
+                         "sentinel on upgrade; the historic file would remain "
+                         "enumerated as a dead peer")
+
+    def test_the_fallback_receipts_keep_the_global_directory(self):
+        """The second durable record keweichen named. Renaming it silently
+        changes the namespace of receipts that already exist."""
+        self.assertEqual(up.handler_fallbacks_dir(self.d).name,
+                         "task-event-handler-fallbacks")
+
+    def test_an_instance_id_still_separates_watchers_on_an_enrolled_host(self):
+        """The compatibility fix must not cost what the change is FOR."""
+        names = set()
+        for inst in ("worker-1", "worker-2"):
+            os.environ["SUTANDO_INSTANCE_ID"] = inst
+            try:
+                names.add(up.watcher_sentinel_path(self.d).name)
+            finally:
+                os.environ.pop("SUTANDO_INSTANCE_ID", None)
+        names.add(up.watcher_sentinel_path(self.d).name)
+        self.assertEqual(len(names), 3,
+                         f"worker-1, worker-2 and default must stay distinct: {names}")
 
 
 if __name__ == "__main__":

--- a/tests/watcher-shells-resolved-interpreter.test.sh
+++ b/tests/watcher-shells-resolved-interpreter.test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# The watcher/notifier shells must reach python through the SHARED resolver.
+#
+# `scripts/python-binary.sh` exists because a bare `python3` on a clean Mac can
+# be Apple's CLT stub, which raises a modal before it can fail. A caller that
+# resolves the safe interpreter and then shells `python3` anyway gets the stub
+# on exactly the hosts the resolver was written for.
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
+
+SHELLS=(src/watch-tasks-stream.sh src/watcher_sentinel.sh src/agent/codex/cli/task-notifier.sh)
+
+# 1. structural: no bare `python3 ` invocation survives in any of the three.
+for f in "${SHELLS[@]}"; do
+  # A leading $ or " means it is already a resolved variable; a # means a comment.
+  hits="$(grep -nE '(^|[^"$/[:alnum:]_-])python3 ' "$REPO/$f" | grep -vE '^\s*[0-9]+:\s*#' | wc -l | tr -d ' ')"
+  [ "$hits" = "0" ] && ok "$f invokes no bare python3" || bad "$f still has $hits bare python3 call(s)"
+done
+
+# 2. the control that matters: configured-good interpreter, BROKEN python3 on PATH.
+REAL_PY="$(command -v python3)"
+TD="$(mktemp -d)"; trap 'rm -rf "$TD"' EXIT
+printf '#!/bin/sh\necho "stub: refusing" >&2\nexit 1\n' > "$TD/python3"
+chmod +x "$TD/python3"
+
+out="$(PATH="$TD:$PATH" SUTANDO_PY="$REAL_PY" bash -c '
+  . "'"$REPO"'/src/watcher_sentinel.sh" >/dev/null 2>&1 || true
+  sentinel_path_for "'"$TD"'/state" 2>&1')"
+rc=$?
+if [ "$rc" = "0" ] && [ -n "$out" ] && ! printf '%s' "$out" | grep -q "refusing"; then
+  ok "watcher_sentinel resolves through SUTANDO_PY with a broken PATH python3"
+else
+  bad "watcher_sentinel fell through to the PATH python3 (rc=$rc out=$out)"
+fi
+
+# 3. the negative control: with NO configured interpreter and a broken PATH one,
+#    it must REFUSE rather than shell the broken binary.
+out2="$(PATH="$TD:/usr/bin:/bin" SUTANDO_PY= bash -c '
+  . "'"$REPO"'/src/watcher_sentinel.sh" >/dev/null 2>&1 || true
+  sentinel_path_for "'"$TD"'/state" 2>&1'; echo "rc=$?")"
+if printf '%s' "$out2" | grep -q "rc=0"; then
+  bad "it returned success with no runnable interpreter"
+else
+  ok "no runnable interpreter refuses instead of guessing a path"
+fi
+
+printf '\nPASSED: %s\nFAILED: %s\n' "$PASS" "$FAIL"
+[ "$FAIL" = "0" ]


### PR DESCRIPTION
## The defect

Every watcher on a host stamps the same sentinel:

```
PID_FILE="$STATE_DIR/watch-tasks-stream.pid"   # at origin/main
echo "$$" > "$PID_FILE"
```

so the Nth watcher's write erases the (N-1)th. Measured on a live pool host by a peer:

```
sentinel holds:  75874
live watchers:   28376 28378 67777 67780 75872 75874
```

Six processes, one record. Four of them are invisible to `reap_stale_task_watcher`, to health-check's `task-watcher` probe, to `services_status`, and to the Stop hook — all four read that one path. This is the repo's own one-writer-contract rule with N writers, and `state/cores/<host>.alive` already does it correctly two directories away.

## The change

`watch-tasks-stream[-<instance>].pid`, from `$SUTANDO_INSTANCE`.

**Unset keeps the historic name byte-for-byte.** A single-instance install writes and reads exactly what it did before, so this is an addition, not a migration — there is no transition window to manage and no state to move.

Readers enumerate rather than name:

| site | before | after |
|---|---|---|
| `startup.sh` reaper | one literal path | once per sentinel found |
| `health-check.py` probe | one literal path | resolver, historic name first |
| `health-check.py` re-stamp remedy | one literal path | resolver (writes this instance's) |
| `services_status.py` row | one literal path | resolver, historic name first |

The two enumerators return the historic name first, so a reader that reports a single row keeps reporting the same one it always did.

## Why two implementations

Shell and Python both read this file, so both need the namer. That is the same shape as `KNOWN_HEADER_KEYS` and its TS mirrors, and it wants the same defence: the test asserts the two cannot drift.

```
$ python3 tests/watcher-sentinel-naming.test.py
Ran 14 tests in 0.061s
OK
```

The discriminating ones:

- `test_both_namers_agree_across_a_range_of_names` — nine instance names through both implementations, including `../evil x`, `  spaced  `, `-lead-` and `....`. This is the one that fails if either side is edited alone.
- `test_no_instance_keeps_the_historic_name` — the backward-compatibility claim above, asserted rather than described.
- `test_unrelated_pid_files_are_not_swept_in` — the glob decides what the reaper may signal, so `other.pid`, `watch-tasks-streamer.pid` and `watch-tasks-stream.pid.bak` must not match.
- `test_a_hostile_instance_name_cannot_escape_the_state_dir`.
- `test_no_reader_hardcodes_the_sentinel_filename` — greps the four readers, so this cannot silently regress.

## Evidence at this head

```
tests/watcher-sentinel-naming.test.py          Ran 14 tests  OK
tests/watcher-sentinel-ownership.test.sh       passed 25, failed 0
tests/startup-watcher-reaper-ownership.test.sh ALL PASS
tests/watch-tasks-stream-sentinel-ownership.test.py  All sentinel-ownership checks passed.
tests/health-check-task-watcher.test.py        Task-watcher liveness invariants hold.
tests/health-check-supervised-watcher-not-orphan.test.py  PASS
tests/health-check-pin-vetoes-watcher-remedy.test.py      PASS
review-checks.sh                               PASS (hardcoded-paths + root-artifacts + prose-cap clean)
ruff / shellcheck -S error                     clean
```

`startup-watcher-reaper-ownership.test.sh` needed one edit: it asserted the reaper's call site by its literal argument, which is now a loop over the resolver. It still asserts delegation, and additionally that the enumeration is used — a stricter check than before, not a weaker one.

## Scope

Prerequisite for step 2 of the worker-pool design (#3860), which puts one watcher per worker on a host and therefore turns this from latent to load-bearing. It stands alone: the defect is real on `main` for anyone running more than one watcher today.

Not in scope: the `chat_id` pin match and the gateway's task-before-priority ordering, the design's other two named prerequisites. Each is its own PR.

Stand: Echo Act IV Pro
