### PR TITLE
fix(health-check): the drift probe reports a stale tree as current

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -7100,11 +7100,25 @@ def _porcelain_z_tracked_paths(porcelain: str) -> "list[str]":
     return out
 
 
+def _trunk_ref(git) -> str:
+    """The remote trunk to measure staleness against — origin/HEAD's target,
+    else the first of origin/main, origin/master that resolves. "" if none."""
+    rc, ref = git("symbolic-ref", "--quiet", "refs/remotes/origin/HEAD")
+    if rc == 0 and ref.startswith("refs/remotes/"):
+        return ref[len("refs/remotes/"):]
+    for cand in ("origin/main", "origin/master"):
+        rc, _ = git("rev-parse", "--verify", "--quiet", cand)
+        if rc == 0:
+            return cand
+    return ""
+
+
 def check_live_tree_drift(repo_root: "Path | None" = None,
                           behind_max: int = 30,
                           dirty_age_max_s: int = 86400) -> dict:
-    """Warn when the LIVE checkout drifts: >=behind_max commits behind its own
-    upstream branch, or tracked dirty files older than dirty_age_max_s.
+    """Warn when the LIVE checkout drifts: >=behind_max commits behind the
+    remote TRUNK (falling back to the branch's upstream when no trunk ref
+    resolves), or tracked dirty files older than dirty_age_max_s.
     Measured 2026-08-26: the live tree sat 116 behind with ~190 dirty files
     (some running in production while existing in no commit); nothing alarmed.
     Diagnostic only — reconciliation needs an attended restart window."""
@@ -7121,12 +7135,21 @@ def check_live_tree_drift(repo_root: "Path | None" = None,
         rc, branch = _git("rev-parse", "--abbrev-ref", "HEAD")
         if rc != 0:
             return {"name": name, "status": "ok", "detail": "not a git checkout"}
-        behind = 0
+        def _count_behind(ref):
+            rc_, n_ = _git("rev-list", "--count", f"HEAD..{ref}")
+            return int(n_) if rc_ == 0 and n_.isdigit() else None
+        # None means UNMEASURED, never 0: a branch with no upstream would
+        # otherwise keep the initial 0 and certify the drift it exists to catch.
+        behind_up = None
         rc, up = _git("rev-parse", "--abbrev-ref", "@{upstream}")
         if rc == 0 and up:
-            rc2, n = _git("rev-list", "--count", f"HEAD..{up}")
-            if rc2 == 0 and n.isdigit():
-                behind = int(n)
+            behind_up = _count_behind(up)
+        else:
+            up = ""
+        # Staleness is against the TRUNK, not a branch's own remote copy: a PR
+        # branch tracking itself is 0 behind however far the trunk has moved.
+        trunk = _trunk_ref(_git)
+        behind_trunk = _count_behind(trunk) if trunk else None
         rc, porcelain = _git("status", "--porcelain", "-z")
         if rc != 0:
             # A failed read yields empty stdout, which would read as a clean
@@ -7145,8 +7168,13 @@ def check_live_tree_drift(repo_root: "Path | None" = None,
             except OSError:
                 continue  # deleted-in-tree entries have no mtime; count as dirty only
         problems = []
-        if behind >= behind_max:
-            problems.append(f"{behind} commits behind {up}")
+        if behind_trunk is not None and behind_trunk >= behind_max:
+            problems.append(f"{behind_trunk} commits behind {trunk}")
+        elif behind_up is not None and behind_up >= behind_max:
+            problems.append(f"{behind_up} commits behind {up}")
+        if behind_trunk is None and behind_up is None:
+            problems.append("distance to the trunk is UNMEASURED, not zero "
+                            "(no upstream and no readable trunk ref)")
         if stale:
             problems.append(f"{len(stale)} tracked dirty file(s) older than "
                             f"{dirty_age_max_s // 3600}h (e.g. {stale[0]})")
@@ -7156,8 +7184,10 @@ def check_live_tree_drift(repo_root: "Path | None" = None,
                                " — running daemons restart onto whatever is on disk; "
                                "commit/rescue the dirty state, then reconcile in an "
                                "attended restart window")}
+        measured = (f"{behind_trunk} behind {trunk}" if behind_trunk is not None
+                    else f"{behind_up} behind {up}")
         return {"name": name, "status": "ok",
-                "detail": f"{behind} behind upstream, {len(dirty)} tracked dirty"}
+                "detail": f"{measured}, {len(dirty)} tracked dirty"}
     except GitUnavailable:
         # No runnable git is a host state, not drift — never re-warn per pass.
         return {"name": name, "status": "ok", "detail": "no runnable git on this host"}

--- a/tests/live-tree-drift-reference.test.py
+++ b/tests/live-tree-drift-reference.test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""check_live_tree_drift measures staleness against the TRUNK.
+
+Two shapes made it certify the drift it exists to catch: a branch with no
+upstream (distance defaulted to 0) and a PR branch tracking itself (0 behind
+by construction, however far the trunk moved).
+
+Run: python3 tests/live-tree-drift-reference.test.py
+"""
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+_spec = importlib.util.spec_from_file_location("hc", ROOT / "src/health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+
+def _git(root, *args):
+    return subprocess.run(["git", "-C", str(root), *args],
+                          capture_output=True, text=True)
+
+
+def _make_repo(commits_ahead_on_trunk=0, branch=None, set_upstream=False):
+    """origin/main with N commits, plus a checkout that may lag behind it."""
+    tmp = Path(tempfile.mkdtemp())
+    origin, work = tmp / "origin", tmp / "work"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(origin)], check=True)
+    _git(origin, "config", "user.email", "t@t.t")
+    _git(origin, "config", "user.name", "t")
+    (origin / "f.txt").write_text("0\n")
+    _git(origin, "add", "-A"); _git(origin, "commit", "-qm", "base")
+    subprocess.run(["git", "clone", "-q", str(origin), str(work)], check=True)
+    _git(work, "config", "user.email", "t@t.t")
+    _git(work, "config", "user.name", "t")
+    if branch:
+        _git(work, "checkout", "-q", "-b", branch)
+        if set_upstream:            # a PR branch tracking ITSELF
+            _git(work, "push", "-q", "-u", "origin", branch)
+        else:                       # no upstream at all
+            pass
+    for i in range(commits_ahead_on_trunk):
+        (origin / "f.txt").write_text(f"{i+1}\n")
+        _git(origin, "add", "-A"); _git(origin, "commit", "-qm", f"c{i}")
+    _git(work, "fetch", "-q", "origin")
+    return work
+
+
+class TrunkIsTheReference(unittest.TestCase):
+    def test_no_upstream_and_far_behind_trunk_warns(self):
+        w = _make_repo(commits_ahead_on_trunk=40, branch="rescue/local")
+        self.assertNotEqual(_git(w, "rev-parse", "--abbrev-ref", "@{upstream}").returncode, 0,
+                            "precondition: this branch has no upstream")
+        r = hc.check_live_tree_drift(repo_root=w, behind_max=30)
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("40 commits behind", r["detail"])
+
+    def test_branch_tracking_itself_and_far_behind_trunk_warns(self):
+        w = _make_repo(commits_ahead_on_trunk=40, branch="feat/x", set_upstream=True)
+        self.assertEqual(
+            _git(w, "rev-list", "--count", "HEAD..@{upstream}").stdout.strip(), "0",
+            "precondition: a self-tracking branch is 0 behind its own upstream")
+        r = hc.check_live_tree_drift(repo_root=w, behind_max=30)
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("40 commits behind", r["detail"])
+
+    def test_current_tree_is_ok(self):
+        # Control: the probe must not warn when it can measure and is current.
+        w = _make_repo(commits_ahead_on_trunk=0)
+        r = hc.check_live_tree_drift(repo_root=w, behind_max=30)
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("0 behind", r["detail"])
+
+    def test_just_under_threshold_is_ok(self):
+        w = _make_repo(commits_ahead_on_trunk=29, branch="rescue/local")
+        r = hc.check_live_tree_drift(repo_root=w, behind_max=30)
+        self.assertEqual(r["status"], "ok", r)
+
+    def test_unmeasurable_distance_is_not_zero(self):
+        # No upstream and no trunk ref: the honest answer is "unmeasured".
+        w = _make_repo(commits_ahead_on_trunk=40, branch="rescue/local")
+        _git(w, "remote", "remove", "origin")
+        r = hc.check_live_tree_drift(repo_root=w, behind_max=30)
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("UNMEASURED", r["detail"])
+
+    def test_not_a_git_checkout_stays_ok(self):
+        r = hc.check_live_tree_drift(repo_root=Path(tempfile.mkdtemp()), behind_max=30)
+        self.assertEqual(r["status"], "ok", r)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The bug

`check_live_tree_drift` is the probe that warns when the live checkout goes stale. On two common branch shapes it returns **`status: ok`** on a tree 40 commits behind the trunk — it certifies the condition it exists to catch.

Running `origin/main`'s own function against two purpose-built repos:

```
no upstream, 40 behind      -> {'status': 'ok', 'detail': '0 behind upstream, 0 tracked dirty'}
tracks itself, 40 behind    -> {'status': 'ok', 'detail': '0 behind upstream, 0 tracked dirty'}
```

At HEAD both warn with `40 commits behind origin/main`.

## Two causes, one line apart

```python
behind = 0
rc, up = _git("rev-parse", "--abbrev-ref", "@{upstream}")
if rc == 0 and up:
    ...
        behind = int(n)
```

**1. A missing upstream defaults to zero.** `rev-parse @{upstream}` exits non-zero (128), the assignment never runs, `behind` keeps its initial `0`, and `0 >= behind_max` is False. A branch cut locally — every rescue branch and most worktrees — has no upstream by construction, so the *more* detached the tree, the more confidently the probe reports health.

**2. The reference point answers a different question.** `behind` is measured against the branch's own upstream. A PR branch tracking `origin/<itself>` is **0 behind by construction**, however far the trunk has moved. This path never fails and never defaults — it is simply not the question "is this live tree stale?"

Neither is hypothetical: this repo's own live checkouts hit both shapes today.

## The fix mirrors a guard already in the function

Six lines below, the same function already refuses to let an unmeasured working tree read as clean:

```python
if rc != 0:
    return {"status": "warn",
            "detail": "git status failed — the working tree is UNMEASURED, "
                      "not clean; a stale dirty checkout is invisible here"}
```

That reasoning is applied to the distance too:

- measure against the remote **trunk** (`origin/HEAD`'s target, else `origin/main` / `origin/master`), falling back to the branch's upstream when no trunk ref resolves;
- an unmeasurable distance is reported as **UNMEASURED, not zero**.

The docstring's cited incident (2026-08-26, "116 behind") was a live tree on `main` tracking `origin/main` — upstream and trunk coincided, so the probe did handle the case it was written for. It missed the two where they diverge.

## Evidence

New `tests/live-tree-drift-reference.test.py`, 6 tests, each building a real git repo:

```
Ran 6 tests in 8.2s
OK
```

Covering both defective shapes, an unmeasurable tree, a non-git path, a just-under-threshold case, and a **control** — a current tree still reports `ok`, so the fix does not warn indiscriminately.

Mutation-verified against the commit, caches cleared between runs:

```
baseline    -> OK
trunk       -> FAILED (failures=3)    # trunk ref forced empty
unmeasured  -> FAILED (failures=1)    # UNMEASURED branch removed
restored    -> OK
```

No regression in the existing suite:

```
tests/health-check-live-tree-drift.test.py        OK
tests/health-check-engine-revision-drift.test.py  OK
tests/core-health-verdict.test.py                 all passed
tests/health-check-alert-history-prune.test.py    OK
tests/health-check-bodhi-dist.test.py             OK
tests/health-check-bridge-launcher-dupe.test.py   OK
scripts/review-checks.sh                          PASS
```

## Credit

Found while two agent sessions disagreed about what `health-check.py` said and discovered they were reading different checkouts. The second cause — upstream-is-itself — was identified by the peer session, which also reproduced the primary defect independently with a control proving the probe fires when it *can* measure. Filed as one PR by agreement rather than two on the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
