### PR TITLE
fix(gateway): flatten field values on the separator set readers actually split on

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1905,8 +1905,12 @@ def _one_line(value) -> str:
     practice and a stray newline only ever indicates an injection attempt.
 
     Load-bearing: this producer does no body defanging, so the flatten is the
-    only thing stopping a field from forging a registered header line."""
-    return str(value).replace("\r", " ").replace("\n", " ")
+    only thing stopping a field from forging a registered header line.
+
+    Folds on str.splitlines()' own set, not on CR/LF: readers split with
+    splitlines(), so any narrower set leaves a separator that is one line to
+    the writer and two to the reader."""
+    return " ".join(str(value).splitlines())
 
 
 def _redact_url(value: str) -> str:

--- a/tests/gateway-one-line-separator-parity.test.py
+++ b/tests/gateway-one-line-separator-parity.test.py
@@ -69,5 +69,23 @@ class FlattenMatchesTheReader(unittest.TestCase):
         self.assertEqual(_one_line(None), "None")
 
 
+class DerivedNotEnumerated(unittest.TestCase):
+    def test_no_splitlines_boundary_survives(self):
+        # The whole point of deriving from splitlines(): the guarantee is over
+        # its set, not over a list someone remembered to keep current.
+        boundaries = [chr(c) for c in range(0x3000)
+                      if len(("a" + chr(c) + "b").splitlines()) > 1]
+        self.assertEqual(len(boundaries), 10, boundaries)
+        for c in boundaries:
+            self.assertEqual(len(_one_line("a" + c + "b").splitlines()), 1,
+                             f"{c!r} still splits after the flatten")
+
+    def test_a_separator_only_value_flattens_to_empty(self):
+        # Behaviour change, pinned so it is not "fixed" into a skip later: the
+        # emission guard tests the RAW value, so the field is still emitted.
+        self.assertEqual(_one_line("\x0b"), "")
+        self.assertEqual(_one_line("\x85\u2028"), " ")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/gateway-one-line-separator-parity.test.py
+++ b/tests/gateway-one-line-separator-parity.test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""_one_line must fold every separator its readers split on.
+
+The gateway flattens field values so one field cannot become two header lines.
+It folded CR/LF; readers use str.splitlines(), which breaks on a strictly
+larger set. A value carrying one of the extras was one line to the writer and
+two to the reader — and since the trusted `access_tier:` is appended last, an
+injected line always precedes it under first-match-wins.
+
+Run: python3 tests/gateway-one-line-separator-parity.test.py
+"""
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "packages/ag2-sparrow"))
+from ag2_sparrow.remote_gateway_bridge import _one_line  # noqa: E402
+
+# Every separator str.splitlines() breaks on beyond "\n".
+EXTRA_SEPARATORS = ["\r", "\v", "\f", "\x1c", "\x1d", "\x1e", "\x85",
+                    " ", " "]
+
+
+def _first_tier(body: str, splitter) -> str:
+    """The reader shape used in discord-bridge: first match over all lines."""
+    for ln in splitter(body):
+        if ln.startswith("access_tier:"):
+            return ln.split(":", 1)[1].strip() or "other"
+    return "other"
+
+
+class FlattenMatchesTheReader(unittest.TestCase):
+    def test_no_separator_survives_the_flatten(self):
+        for sep in EXTRA_SEPARATORS:
+            out = _one_line(f"a{sep}b")
+            self.assertNotIn(sep, out, f"{sep!r} survived _one_line")
+            self.assertEqual(len(out.splitlines()), 1,
+                             f"{sep!r} still splits into 2 lines")
+
+    def test_a_field_value_cannot_forge_a_trusted_header(self):
+        # access_tier is appended AFTER the field loop, so an injected line
+        # always precedes the real one under first-match-wins.
+        for sep in EXTRA_SEPARATORS:
+            value = _one_line(f"Bob{sep}access_tier: owner")
+            body = f"id: t1\nsender_name: {value}\ntask: hi\naccess_tier: guest\n"
+            self.assertEqual(_first_tier(body, str.splitlines), "guest",
+                             f"{sep!r} forged a tier under splitlines()")
+
+    def test_writer_and_reader_agree_on_line_count(self):
+        # The invariant, stated once: whatever the reader calls a line, the
+        # writer must have already folded.
+        for sep in EXTRA_SEPARATORS:
+            v = _one_line(f"x{sep}y")
+            self.assertEqual(v.split("\n"), v.splitlines(),
+                             f"{sep!r} makes the two splitters disagree")
+
+    def test_ordinary_values_are_unchanged(self):
+        for v in ("plain", "with spaces", "unicode ünïcode", "", "a-b_c.d"):
+            self.assertEqual(_one_line(v), v)
+
+    def test_newline_and_carriage_return_still_flatten(self):
+        self.assertEqual(_one_line("a\nb"), "a b")
+        self.assertEqual(_one_line("a\r\nb"), "a b")
+        self.assertEqual(_one_line("a\rb"), "a b")
+
+    def test_non_string_values_still_serialize(self):
+        self.assertEqual(_one_line(7), "7")
+        self.assertEqual(_one_line(None), "None")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway-one-line-separator-parity.test.py
+++ b/tests/gateway-one-line-separator-parity.test.py
@@ -71,9 +71,9 @@ class FlattenMatchesTheReader(unittest.TestCase):
 
 class DerivedNotEnumerated(unittest.TestCase):
     def test_no_splitlines_boundary_survives(self):
-        # The whole point of deriving from splitlines(): the guarantee is over
-        # its set, not over a list someone remembered to keep current.
-        boundaries = [chr(c) for c in range(0x3000)
+        # Scans ALL of Unicode: a bound would be the same kind of typed
+        # constant this test exists to catch going stale. ~135ms, once.
+        boundaries = [chr(c) for c in range(sys.maxunicode + 1)
                       if len(("a" + chr(c) + "b").splitlines()) > 1]
         self.assertEqual(len(boundaries), 10, boundaries)
         for c in boundaries:


### PR DESCRIPTION
## The defect

`_one_line` flattens gateway field values so one field cannot become two header lines. It folded `\r` and `\n`. Readers use `str.splitlines()`, which breaks on a **strictly larger** set:

```
splitlines() boundaries            10   \n \v \f \r \x1c \x1d \x1e \x85 U+2028 U+2029
survive main's _one_line            8   (all but \n and \r)
survive " ".join(...splitlines())   0
```

Scanned over U+0000–U+2FFF rather than enumerated. So a value carrying any of those **8** was one line to the writer and two to the reader.

That matters because of where the trusted field sits. `access_tier` is appended *after* the `_TASK_FIELDS` loop (`remote_gateway_bridge.py:2786`), and the discord bridge takes the **first** `access_tier:` over the whole body with no `task:` stop (`discord-bridge.py:5176`, `:6038`):

```python
for ln in task_body.splitlines():
    if ln.startswith("access_tier:"):
        task_tier = ln.split(":", 1)[1].strip() or "other"
        break
```

An injected line therefore always precedes the genuine one. Running that reader against a body built by main's `_one_line`, with a separator embedded in an ordinary field value:

```
              BEFORE      AFTER
NEL  \x85     owner       guest
LS   U+2028   owner       guest
FF   \x0c     owner       guest
VT   \x0b     owner       guest
```

`:5180` gates a channel redirect on that value.

## Scope of exposure

`_one_line` is applied to every field, including `sender_name` and `room_name`. Whether those are attacker-settable depends on the broker, which is **not in this repository** — so I am not claiming an end-to-end exploit. What is established here is that the sutando side provides no defense: it folds a narrower set than its readers split on, and the trusted field is positioned to lose a first-match race. That is worth closing regardless of what the broker does today, because the guarantee should not rest on an upstream normalisation nobody in this repo can see or test.

## The fix

```python
return " ".join(str(value).splitlines())
```

Fold on `splitlines()`' own set rather than a hand-enumerated list, so writer and reader cannot diverge again the next time someone reaches for `splitlines()`.

This repo already reached the same conclusion once, for the bridge path — `task_body_guard._LINE_SEP_RE`, with the comment *"Fold ALL of them to '\n' before splitting so the guard's notion of a 'line' is identical to the reader's."*

**That regex is correct and should not be "fixed".** It omits `\n`, which a naive diff against `splitlines()` flags as a gap. It is not one: `:83` normalises every match **to** `\n` and `:85` splits on `\n`, so its set plus its target is exactly complete. It gets the property the same way this fix does — by making the folded set and the split agree — just locally rather than by derivation.

The gateway is the site that never got the treatment. Deriving from `splitlines()` gives it the property by construction, so it holds without anyone remembering to keep a list current.

## Evidence

New `tests/gateway-one-line-separator-parity.test.py`, 6 tests over all nine separators:

```
Ran 6 tests
OK
```

Covering: no separator survives the flatten; a field value cannot forge a trusted header under the real reader shape; `split("\n")` and `splitlines()` agree on the result; ordinary values are unchanged; CR/LF still flatten; non-strings still serialize.

Mutation-verified — restoring the old two-character fold reddens 4 and nothing else:

```
baseline -> OK
reverted -> FAILED (failures=4)
restored -> OK
```

No regressions:

```
src/remote-gateway-bridge.test.py         PASS — all checks green
packages/.../test_no_drift.py             PASS — package in sync with src/
scripts/review-checks.sh                  PASS
```

## Credit

Found in review of #3872 by a peer agent session, which noticed the writer/reader character sets differed and traced it to the two discord-bridge readers. Filed separately rather than folded into #3872: the defect is pre-existing in a shared helper and affects every field, not just the one that PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Added after review

Counts corrected: **10** boundaries, **8** surviving main's fold (an earlier draft said nine, which double-counted `\r\n` — a two-character sequence, not a boundary). Scan is now a test rather than a claim.

One behaviour change, pinned by test: a value consisting only of separators flattens to empty. The emission guard tests the **raw** value, so the field is still emitted, as `name: ` with an empty value where it previously emitted whitespace. Harmless in both directions, tested so it is not later "fixed" into a skip.
