### PR TITLE
feat(proactive-loop): refuse to post into a PR thread that is only me

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -688,6 +688,29 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
    **Don't hand-roll a process check to second-guess the probe.** `pgrep -f watch-tasks` / `ps | grep watch-tasks-stream` both match the wrapper shell that runs the check (its own argv contains the search string), so they return a pid for a transient subshell or pick the wrapper instead of the watcher — an attempt at this on 2026-08-07 reported rc=1 with the watcher demonstrably alive. `_watcher_trees()` already solves this by scoping to process trees; use its verdict via the probe.
 
+9.5. **⚠ BEFORE POSTING TO A PR THREAD, CHECK YOU ARE NOT TALKING TO YOURSELF (added
+   2026-09-04 after measuring it on this host).** Re-verifying a standing review is right; posting
+   that re-verification into silence is noise, and each repeat makes the next less likely to be
+   read. Measured across 36 open PRs: **5 threads where every recent event was mine and unanswered**
+   — #2300 at **7 events over 14.3 days** with the author never replying once, and I was composing
+   an eighth when this check was written.
+
+   ```bash
+   python3 skills/proactive-loop/scripts/pr-monologue-check.py <number> --me <your-login>
+   # 0 safe to post · 1 REFUSE, naming the run and its span · 2 could not answer (NOT a green light)
+   ```
+
+   It merges BOTH surfaces (issue comments + reviews) so a thread answered only by a review does not
+   read as silence, and **drops `*[bot]` logins**: a CI bot commenting is not a human reading you.
+   That bot case was a live false SAFE — `github-actions[bot]` reset a real run of 2 to 0 on #2406,
+   clearing exactly the post the guard exists to stop. `--count-bots` reproduces the old answer, so
+   the fix has a control rather than an assertion.
+
+   **On a REFUSE, the answer is not "post anyway with better wording."** The thread has no reader;
+   re-solicit through a stand (`collaboration-intelligence`), or leave the flag standing and spend
+   the pass elsewhere. Guarded by `tests/proactive-loop-pr-monologue-check.test.py` (17 tests;
+   4 mutations verified red, including one that makes a fetch failure read as safe).
+
 10. **Monitor Discord.** If Discord channel IDs are configured in memory (`reference_discord_channels.md`), check those channels for new messages. Forward actionable items from public channels to the dev channel. Skip bot messages (unless in #bot2bot), Zoom invites, and messages already sent by you.
 
    **#bot2bot conventions** (cross-bot coordination channel):

--- a/skills/proactive-loop/scripts/pr-monologue-check.py
+++ b/skills/proactive-loop/scripts/pr-monologue-check.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Refuse to post into a PR thread whose recent history is only me, unanswered.
+
+A standing review deserves periodic re-verification, but re-verification posted into
+silence is noise: nobody is reading it, and each repeat makes the next one less likely
+to be read. This counts the TRAILING run of consecutive events authored by one login
+across both comment surfaces (issue comments + reviews) and refuses at a threshold.
+
+Exit 0 safe to post - 1 REFUSE, the run is named - 2 could not answer (NOT a green light).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+DEFAULT_THRESHOLD = 3
+
+
+def parse_ts(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def is_bot(login: str) -> bool:
+    """A CI bot commenting is not a human reading you; counting it as engagement
+    resets the run and clears the very post this guard exists to stop."""
+    return login.endswith("[bot]")
+
+
+def merge_events(comments, reviews, keep_bots: bool = False):
+    """One timeline across both surfaces. A review IS engagement, so a thread answered
+    only by a review must not read as silence. Bots are dropped, not counted either way."""
+    events = []
+    for c in comments or []:
+        ts = c.get("created_at")
+        login = ((c.get("user") or {}).get("login")) or ""
+        if ts:
+            events.append({"ts": ts, "login": login, "kind": "comment"})
+    for r in reviews or []:
+        ts = r.get("submitted_at")
+        login = ((r.get("user") or {}).get("login")) or ""
+        if ts:
+            events.append({"ts": ts, "login": login, "kind": "review"})
+    if not keep_bots:
+        events = [e for e in events if not is_bot(e["login"])]
+    events.sort(key=lambda e: parse_ts(e["ts"]))
+    return events
+
+
+def trailing_run(events, me: str):
+    """Count consecutive trailing events authored by `me`. Returns (run, span_days)."""
+    run = 0
+    for e in reversed(events):
+        if e["login"] == me:
+            run += 1
+        else:
+            break
+    if run == 0:
+        return 0, 0.0
+    tail = events[-run:]
+    span = (parse_ts(tail[-1]["ts"]) - parse_ts(tail[0]["ts"])).total_seconds() / 86400.0
+    return run, span
+
+
+def _gh_json(path: str):
+    proc = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh api failed for {path}: {proc.stderr.strip()[:200]}")
+    return json.loads(proc.stdout)
+
+
+def fetch(repo: str, number: int):
+    comments = _gh_json(f"repos/{repo}/issues/{number}/comments?per_page=100")
+    reviews = _gh_json(f"repos/{repo}/pulls/{number}/reviews?per_page=100")
+    return comments, reviews
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("number", type=int)
+    ap.add_argument("--repo", default="sonichi/sutando")
+    ap.add_argument("--me", required=True)
+    ap.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
+    ap.add_argument("--count-bots", action="store_true",
+                    help="treat bot comments as engagement (default: ignore them)")
+    args = ap.parse_args(argv)
+
+    if args.threshold < 1:
+        print("threshold must be >= 1", file=sys.stderr)
+        return 2
+    try:
+        comments, reviews = fetch(args.repo, args.number)
+    except (RuntimeError, ValueError) as exc:
+        print(f"CANNOT ANSWER: {exc}", file=sys.stderr)
+        return 2
+
+    events = merge_events(comments, reviews, keep_bots=args.count_bots)
+    run, span = trailing_run(events, args.me)
+    if not events:
+        print(f"#{args.number}: no comment/review activity yet — safe to post")
+        return 0
+    if run >= args.threshold:
+        print(
+            f"REFUSE #{args.number}: your last {run} events on this thread are ALL yours, "
+            f"spanning {span:.1f}d, with no reply from anyone else.\n"
+            f"  Posting again talks into silence. Re-solicit a human/stand, or leave it."
+        )
+        return 1
+    print(f"#{args.number}: trailing run of yours = {run} (threshold {args.threshold}) — safe to post")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/proactive-loop/scripts/pr-monologue-check.py
+++ b/skills/proactive-loop/scripts/pr-monologue-check.py
@@ -65,7 +65,9 @@ def trailing_run(events, me: str):
 
 
 def _gh_json(path: str):
-    proc = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    # --paginate or the newest events are missing: GitHub returns the OLDEST 100
+    # first, so an unpaginated read computes the trailing run from a stale end.
+    proc = subprocess.run(["gh", "api", "--paginate", path], capture_output=True, text=True)
     if proc.returncode != 0:
         raise RuntimeError(f"gh api failed for {path}: {proc.stderr.strip()[:200]}")
     return json.loads(proc.stdout)

--- a/tests/proactive-loop-pr-monologue-check.test.py
+++ b/tests/proactive-loop-pr-monologue-check.test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Contract for the PR monologue guard: refuse to post into a thread that is only me."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MOD = REPO / "skills" / "proactive-loop" / "scripts" / "pr-monologue-check.py"
+spec = importlib.util.spec_from_file_location("pr_monologue_check", MOD)
+g = importlib.util.module_from_spec(spec)
+sys.modules["pr_monologue_check"] = g
+spec.loader.exec_module(g)
+
+ME = "me"
+
+
+def c(ts, login):
+    return {"created_at": ts, "user": {"login": login}}
+
+
+def r(ts, login):
+    return {"submitted_at": ts, "user": {"login": login}}
+
+
+def T(n):
+    return f"2026-09-0{n}T00:00:00Z"
+
+
+class TestTrailingRun(unittest.TestCase):
+    def test_all_mine_counts_every_one(self):
+        ev = g.merge_events([c(T(1), ME), c(T(2), ME), c(T(3), ME)], [])
+        self.assertEqual(g.trailing_run(ev, ME)[0], 3)
+
+    def test_someone_else_last_gives_zero(self):
+        ev = g.merge_events([c(T(1), ME), c(T(2), ME), c(T(3), "peer")], [])
+        self.assertEqual(g.trailing_run(ev, ME)[0], 0)
+
+    def test_only_the_trailing_run_counts(self):
+        ev = g.merge_events([c(T(1), ME), c(T(2), "peer"), c(T(3), ME)], [])
+        self.assertEqual(g.trailing_run(ev, ME)[0], 1)
+
+    def test_empty_timeline(self):
+        self.assertEqual(g.trailing_run([], ME), (0, 0.0))
+
+    def test_span_measures_the_run_not_the_thread(self):
+        ev = g.merge_events([c(T(1), "peer"), c(T(3), ME), c(T(5), ME)], [])
+        run, span = g.trailing_run(ev, ME)
+        self.assertEqual(run, 2)
+        self.assertAlmostEqual(span, 2.0, places=3)
+
+
+class TestSurfaces(unittest.TestCase):
+    def test_a_review_is_engagement_and_breaks_the_run(self):
+        # A thread answered only by a review must not read as silence.
+        ev = g.merge_events([c(T(1), ME), c(T(2), ME)], [r(T(3), "peer")])
+        self.assertEqual(g.trailing_run(ev, ME)[0], 0)
+
+    def test_my_own_review_extends_the_run(self):
+        ev = g.merge_events([c(T(1), ME), c(T(2), ME)], [r(T(3), ME)])
+        self.assertEqual(g.trailing_run(ev, ME)[0], 3)
+
+    def test_events_interleave_by_timestamp_across_surfaces(self):
+        ev = g.merge_events([c(T(1), ME), c(T(3), ME)], [r(T(2), "peer")])
+        self.assertEqual([e["login"] for e in ev], [ME, "peer", ME])
+
+
+class TestBots(unittest.TestCase):
+    def test_a_bot_comment_does_not_count_as_a_reply(self):
+        # Measured live: github-actions[bot] reset a real run of 2 to 0 on #2406.
+        ev = g.merge_events([c(T(1), ME), c(T(2), ME), c(T(3), "github-actions[bot]")], [])
+        self.assertEqual(g.trailing_run(ev, ME)[0], 2)
+
+    def test_count_bots_reproduces_the_false_safe(self):
+        ev = g.merge_events(
+            [c(T(1), ME), c(T(2), ME), c(T(3), "github-actions[bot]")], [], keep_bots=True)
+        self.assertEqual(g.trailing_run(ev, ME)[0], 0)
+
+    def test_is_bot_only_matches_the_suffix(self):
+        self.assertTrue(g.is_bot("dependabot[bot]"))
+        self.assertFalse(g.is_bot("randombet"))
+        self.assertFalse(g.is_bot("open-mac-bot"))
+
+
+class TestMain(unittest.TestCase):
+    def _with_fetch(self, comments, reviews, argv):
+        real = g.fetch
+        g.fetch = lambda repo, number: (comments, reviews)
+        try:
+            return g.main(argv)
+        finally:
+            g.fetch = real
+
+    def test_refuses_at_the_threshold(self):
+        ev = [c(T(1), ME), c(T(2), ME), c(T(3), ME)]
+        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME]), 1)
+
+    def test_allows_below_the_threshold(self):
+        ev = [c(T(1), ME), c(T(2), ME)]
+        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME]), 0)
+
+    def test_threshold_is_configurable(self):
+        ev = [c(T(1), ME), c(T(2), ME)]
+        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME, "--threshold", "2"]), 1)
+
+    def test_empty_thread_is_safe(self):
+        self.assertEqual(self._with_fetch([], [], ["1", "--me", ME]), 0)
+
+    def test_a_fetch_failure_is_cannot_answer_not_a_green_light(self):
+        real = g.fetch
+
+        def boom(repo, number):
+            raise RuntimeError("injected: gh api failed")
+
+        g.fetch = boom
+        try:
+            self.assertEqual(g.main(["1", "--me", ME]), 2)
+        finally:
+            g.fetch = real
+
+    def test_a_nonsense_threshold_refuses_rather_than_guessing(self):
+        self.assertEqual(self._with_fetch([], [], ["1", "--me", ME, "--threshold", "0"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/proactive-loop-pr-monologue-check.test.py
+++ b/tests/proactive-loop-pr-monologue-check.test.py
@@ -170,7 +170,9 @@ class TestFetchLayer(unittest.TestCase):
         finally:
             g.subprocess.run = real
         self.assertEqual((comments, reviews), ([], []))
-        paths = [c[2] for c in calls]
+        # Search the whole argv, not a fixed index — a new flag must not silently
+        # shift what this assertion is reading.
+        paths = [a for c in calls for a in c]
         self.assertTrue(any("issues/7/comments" in p for p in paths), paths)
         self.assertTrue(any("pulls/7/reviews" in p for p in paths), paths)
 
@@ -183,6 +185,62 @@ class TestFetchLayer(unittest.TestCase):
             self.assertEqual(g.main(["1", "--me", ME]), 2)
         finally:
             g.subprocess.run = real
+
+
+class TestPagination(unittest.TestCase):
+    """>100 records on either surface. GitHub returns the OLDEST page first, so an
+    unpaginated read computes the trailing run from a stale end and fails OPEN."""
+
+    def test_gh_json_requests_every_page(self):
+        seen = []
+
+        class R:
+            returncode, stdout, stderr = 0, "[]", ""
+
+        def run(args, **kw):
+            seen.append(args)
+            return R()
+
+        real = g.subprocess.run
+        g.subprocess.run = run
+        try:
+            g._gh_json("repos/o/r/issues/1/comments")
+        finally:
+            g.subprocess.run = real
+        self.assertIn("--paginate", seen[0],
+                      "unpaginated: only the OLDEST 100 records are read")
+
+    def _long_thread(self, tail):
+        """147 peer events, then `tail` — more than one page on either surface."""
+        ev = [c(f"2026-01-01T00:{i // 60:02d}:{i % 60:02d}Z", "peer") for i in range(147)]
+        return ev + tail
+
+    def test_over_100_records_with_my_three_newest_refuses(self):
+        tail = [c("2026-09-01T00:00:00Z", ME), c("2026-09-02T00:00:00Z", ME),
+                c("2026-09-03T00:00:00Z", ME)]
+        ev = self._long_thread(tail)
+        self.assertGreater(len(ev), 100)
+        run, _ = g.trailing_run(g.merge_events(ev, []), ME)
+        self.assertEqual(run, 3)
+
+    def test_over_100_records_with_a_peer_newest_is_safe(self):
+        # The discriminating twin: same 150 records, one different last event.
+        tail = [c("2026-09-01T00:00:00Z", ME), c("2026-09-02T00:00:00Z", ME),
+                c("2026-09-03T00:00:00Z", "peer")]
+        ev = self._long_thread(tail)
+        self.assertGreater(len(ev), 100)
+        run, _ = g.trailing_run(g.merge_events(ev, []), ME)
+        self.assertEqual(run, 0)
+
+    def test_the_stale_prefix_a_truncated_read_would_see_says_safe(self):
+        # Fail-OPEN, not merely incomplete: the first 100 records end in peer
+        # traffic, so a truncated read clears the post the full thread refuses.
+        tail = [c("2026-09-01T00:00:00Z", ME), c("2026-09-02T00:00:00Z", ME),
+                c("2026-09-03T00:00:00Z", ME)]
+        ev = self._long_thread(tail)
+        full, _ = g.trailing_run(g.merge_events(ev, []), ME)
+        truncated, _ = g.trailing_run(g.merge_events(ev[:100], []), ME)
+        self.assertEqual((full, truncated), (3, 0))
 
 
 if __name__ == "__main__":

--- a/tests/proactive-loop-pr-monologue-check.test.py
+++ b/tests/proactive-loop-pr-monologue-check.test.py
@@ -124,5 +124,66 @@ class TestMain(unittest.TestCase):
         self.assertEqual(self._with_fetch([], [], ["1", "--me", ME, "--threshold", "0"]), 2)
 
 
+class TestFetchLayer(unittest.TestCase):
+    """The gh layer the other tests inject around. Its failure path is the one that
+    decides between REFUSE and a false 'safe', so it needs its own coverage."""
+
+    def _fake_run(self, rc, out="", err=""):
+        class R:
+            returncode, stdout, stderr = rc, out, err
+
+        calls = []
+
+        def run(args, **kw):
+            calls.append(args)
+            return R()
+
+        return run, calls
+
+    def test_gh_json_parses_a_successful_response(self):
+        run, calls = self._fake_run(0, '[{"x": 1}]')
+        real = g.subprocess.run
+        g.subprocess.run = run
+        try:
+            self.assertEqual(g._gh_json("repos/o/r/issues/1/comments"), [{"x": 1}])
+        finally:
+            g.subprocess.run = real
+        self.assertEqual(calls[0][:2], ["gh", "api"])
+
+    def test_gh_json_raises_naming_the_path_when_gh_fails(self):
+        run, _ = self._fake_run(1, "", "HTTP 404: Not Found")
+        real = g.subprocess.run
+        g.subprocess.run = run
+        try:
+            with self.assertRaises(RuntimeError) as ctx:
+                g._gh_json("repos/o/r/pulls/9/reviews")
+            self.assertIn("pulls/9/reviews", str(ctx.exception))
+        finally:
+            g.subprocess.run = real
+
+    def test_fetch_reads_both_surfaces(self):
+        run, calls = self._fake_run(0, "[]")
+        real = g.subprocess.run
+        g.subprocess.run = run
+        try:
+            comments, reviews = g.fetch("o/r", 7)
+        finally:
+            g.subprocess.run = real
+        self.assertEqual((comments, reviews), ([], []))
+        paths = [c[2] for c in calls]
+        self.assertTrue(any("issues/7/comments" in p for p in paths), paths)
+        self.assertTrue(any("pulls/7/reviews" in p for p in paths), paths)
+
+    def test_a_gh_failure_reaches_main_as_cannot_answer(self):
+        # End to end through the real fetch: a failing gh must exit 2, not 0.
+        run, _ = self._fake_run(1, "", "boom")
+        real = g.subprocess.run
+        g.subprocess.run = run
+        try:
+            self.assertEqual(g.main(["1", "--me", ME]), 2)
+        finally:
+            g.subprocess.run = real
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
## The problem, measured on a live host

Re-verifying a standing review is right — a blocking flag records what one reviewer believed at one commit and never re-evaluates itself. But posting that re-verification **into silence** is noise, and each repeat makes the next one less likely to be read. Nothing measured whether anyone was still listening.

Across **36 open PRs** (mine + the 5 I hold a `CHANGES_REQUESTED` on):

| PR | trailing events, all mine | span | author replies in that run |
|---|---|---|---|
| #2300 | **7** | 14.3d | 0 |
| #3672 | 6 | 1.6d | 0 |
| #2061 | 6 | 1.9d | 0 |

I found this because I was composing an **eighth** comment on #2300.

## What it does

```
$ python3 skills/proactive-loop/scripts/pr-monologue-check.py 2300 --me john-the-dev
REFUSE #2300: your last 7 events on this thread are ALL yours, spanning 14.3d, with no reply from anyone else.
  Posting again talks into silence. Re-solicit a human/stand, or leave it.
$ echo $?
1
```

`0` safe · `1` refuse · `2` could not answer. **A fetch failure exits 2, never 0** — a guard that reads an API error as "safe to post" is worse than no guard.

## Two details that decide whether it is correct

**It merges both surfaces.** Issue comments *and* reviews, interleaved by timestamp, so a thread answered only by a review does not read as silence.

**It drops `*[bot]` logins — and that was a live false SAFE, not a hypothetical.** On #2406 my last two comments were unanswered, then `github-actions[bot]` posted, and the guard reported `run = 0, safe to post` — clearing exactly the post it exists to stop:

```
last 5 events on #2406:
  2026-09-03T17:44:35Z comment 'qingyun-wu'
  2026-09-04T01:41:28Z comment 'john-the-dev'
  2026-09-04T06:27:09Z comment 'john-the-dev'
  2026-09-04T06:30:57Z comment 'github-actions[bot]'   <- reset the run to 0

before fix:  #2406: trailing run of yours = 0 — safe to post     (WRONG)
after fix:   #2406: trailing run of yours = 2 — safe to post     (correct: 2, below threshold 3)
--count-bots: #2406: trailing run of yours = 0                    (reproduces the old answer)
```

`--count-bots` exists so the fix ships with a **control** rather than an assertion.

## Discrimination on live data

```
#2300  REFUSE (7, 14.3d)      #2148  safe (0)
#3672  REFUSE (6, 1.6d)       #2126  safe (1)
#2061  REFUSE (6, 1.9d)       #3571  safe (0)
                              #2406  safe (2)
```
It refuses 3 and clears 4 — it is not a guard that only ever says no.

## Tests

`tests/proactive-loop-pr-monologue-check.test.py` — **17 tests**, no network (the fetch layer is injected). **4 mutations verified red**, `__pycache__` cleared between runs:

| mutation | result |
|---|---|
| `is_bot` always `False` | FAILED (2) |
| count mine *anywhere* instead of trailing | FAILED (4) |
| drop reviews from the timeline | FAILED (3) |
| fetch failure returns `0` instead of `2` | FAILED (1) |

`review-checks.sh --diff`: `prose-cap: PASS`, `review-checks: PASS`.

## Scope

Wired into `SKILL.md` as step 9.5 so it **runs before a post**, rather than being a script nobody calls — the same reason the other gates in that file live there instead of in a memory.

Single concern: the guard, its test, and the one SKILL.md step that invokes it. No behaviour change to any existing tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)