### PR TITLE
ci(eslint): the job cap kills npm ci, and a timeout renders as a red check

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,7 +32,9 @@ jobs:
   eslint:
     name: eslint over first-party TS + JS
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # `npm ci` alone spends ~4 min of a cold cache; a 5-min job cap left it
+    # ~50s and GitHub reports the kill as `cancelled`, which reads as red.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## The defect

`.github/workflows/eslint.yml` sets `timeout-minutes: 5` on the whole `eslint` job. `npm ci` is the bulk of that job, so the cap is effectively a cap on the install, and it has almost no margin.

## Evidence

**The one run in the recent window that went green** (`9c5a8d84`, run `33848267509`) — step timings from the API:

```
job                          success  07:20:27 -> 07:24:37   (4m10s of a 5m cap)
  Install dependencies (clean) success  07:20:33 -> 07:24:30   (3m57s)
  Run ESLint                   success  07:24:30 -> 07:24:35   (5s)
```

`npm ci` alone spends 3m57s. ESLint itself needs 5 seconds. The headroom is ~50 seconds.

**A run that exceeded it** (`599a7395`, run `33848753054`, attempt 2 — a plain re-run, no new push):

```
job=eslint over first-party TS + JS  completed/cancelled  07:49:53 -> 07:55:07
    step 3  Setup Node                   success
    step 4  Install dependencies (clean) CANCELLED
    step 5  Run ESLint                   skipped
```

5m14s wall, killed inside step 4. GitHub reports a job that hits `timeout-minutes` as **`cancelled`**, not `failure`, so the PR shows a red check that names no lint rule and no failing step.

**Rate over the last 8 eslint runs** (`gh run list --workflow eslint.yml --limit 8`): 6 cancelled, 2 success — across PRs #3863, #3537, #3860, #3875, #3879 and pushes with no PR association, i.e. multiple authors.

## What this is not

My first hypothesis was the `concurrency:` block cancelling the newest run in a group. **Falsified:** the group is `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`, so it is PR-scoped, and the cancelled runs above are the newest in their own group with nothing after them. The step-level timings are what identify it — a concurrency cancellation does not stop inside step 4 at the 5-minute mark.

## The change

`timeout-minutes: 5` → `15` on the `eslint` job. One line plus a comment. No lint rule, no code path, no other workflow.

## Checks

`scripts/review-checks.sh --diff` → PARTIAL: hardcoded-paths and root-artifacts clean; prose-cap reports **no in-scope files**, which is correct for a `.yml`-only diff and is not a pass I am claiming as one.

Stand: Echo Act IV Pro