### PR TITLE
fix(health-check): quarantine warn cannot tell a filling backlog from inert history

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8011,7 +8011,7 @@ def _park_reason_tally(kept) -> str:
     names a cause for the other four states something no writer recorded.
     """
     counts = {}
-    for name, _age in kept:
+    for name, *_ in kept:
         reason = next((p for p in str(name).split(".") if p in PARK_REASONS),
                       "unlabelled")
         counts[reason] = counts.get(reason, 0) + 1
@@ -8055,7 +8055,7 @@ def check_proactive_quarantine() -> dict:
     except OSError as e:  # noqa: BLE001 — a probe failure must not fail the check
         return {"name": name, "status": "warn",
                 "detail": f"could not scan results/undelivered/: {e}"}
-    kept: list[tuple[str, int]] = []
+    kept: list[tuple[str, int, int]] = []
     unreadable = 0
     for path in entries:
         # Per-file isolation, same reason as check_orphaned_results: one
@@ -8063,7 +8063,11 @@ def check_proactive_quarantine() -> dict:
         try:
             if not path.is_file():
                 continue
-            age = now - path.stat().st_mtime
+            st = path.stat()
+            age = now - st.st_mtime
+            # Every writer here MOVES an existing inode (rename, link+unlink),
+            # which keeps mtime and refreshes ctime: ctime is the arrival.
+            arrived = now - st.st_ctime
         except OSError:
             unreadable += 1
             continue
@@ -8077,7 +8081,7 @@ def check_proactive_quarantine() -> dict:
             skips = set()          # unreadable -> judge it as before, never silently clear
         if skips & {"no-send", "REPLIED"}:
             continue
-        kept.append((path.name, int(age)))
+        kept.append((path.name, int(age), int(arrived)))
     partial = (f" ({unreadable} entr{'y' if unreadable == 1 else 'ies'} unreadable)"
                if unreadable else "")
     if not kept:
@@ -8085,14 +8089,11 @@ def check_proactive_quarantine() -> dict:
         return {"name": name, "status": status,
                 "detail": f"no quarantined proactive bodies{partial}"}
     kept.sort(key=lambda item: -item[1])
-    oldest_name, oldest_age = kept[0]
-    # The oldest age only ever increases: it reads the same whether the
-    # directory is filling now or has been inert for a month. The newest says which.
-    newest_age = kept[-1][1]
-    # Gate on the ages DIFFERING, not on the count: identical mtimes would print
-    # one duration twice, and bulk writes leave exactly that shape.
-    arrival = (f"; newest arrived {newest_age // 3600}h{newest_age % 3600 // 60}m ago"
-               if newest_age != oldest_age else "")
+    oldest_name, oldest_age, _ = kept[0]
+    # Oldest reads the same filling or inert; the newest ARRIVAL (ctime, not
+    # mtime — see the loop) is what separates them.
+    newest_arrival = min(item[2] for item in kept)
+    arrival = _quarantine_arrival_clause(newest_arrival, oldest_age)
     return {
         "name": name,
         "status": "warn",
@@ -8101,9 +8102,28 @@ def check_proactive_quarantine() -> dict:
         "detail": (f"{len(kept)} proactive message(s) parked in results/undelivered/ "
                    f"({_park_reason_tally(kept)}) — preserved, but no consumer drains this "
                    f"directory, so they stay until someone acts; oldest {oldest_name} "
-                   f"({oldest_age // 3600}h{oldest_age % 3600 // 60}m)"
+                   f"({_quarantine_age_label(oldest_age)})"
                    f"{arrival}{partial}"),
     }
+
+
+def _quarantine_hm(seconds: int) -> str:
+    return f"{seconds // 3600}h{seconds % 3600 // 60}m"
+
+
+def _quarantine_age_label(age: int) -> str:
+    # Negative means the clock sits behind the file: skew, not a measurement.
+    return _quarantine_hm(age) if age >= 0 else f"future-dated by {_quarantine_hm(-age)}"
+
+
+def _quarantine_arrival_clause(newest_arrival: int, oldest_age: int) -> str:
+    if newest_arrival < 0:
+        return f"; newest is {_quarantine_age_label(newest_arrival)} (clock skew?)"
+    # Compare what is RENDERED: 7201s and 7200s both print 2h0m, and printing
+    # one duration twice is noise (bulk writes leave exactly that shape).
+    if _quarantine_hm(newest_arrival) == _quarantine_age_label(oldest_age):
+        return ""
+    return f"; newest arrived {_quarantine_hm(newest_arrival)} ago"
 
 
 def _ps_snapshot() -> "str | None":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8086,6 +8086,11 @@ def check_proactive_quarantine() -> dict:
                 "detail": f"no quarantined proactive bodies{partial}"}
     kept.sort(key=lambda item: -item[1])
     oldest_name, oldest_age = kept[0]
+    # The oldest age only ever increases: it reads the same whether the
+    # directory is filling now or has been inert for a month. The newest says which.
+    newest_age = kept[-1][1]
+    arrival = (f"; newest arrived {newest_age // 3600}h{newest_age % 3600 // 60}m ago"
+               if len(kept) > 1 else "")
     return {
         "name": name,
         "status": "warn",
@@ -8095,7 +8100,7 @@ def check_proactive_quarantine() -> dict:
                    f"({_park_reason_tally(kept)}) — preserved, but no consumer drains this "
                    f"directory, so they stay until someone acts; oldest {oldest_name} "
                    f"({oldest_age // 3600}h{oldest_age % 3600 // 60}m)"
-                   f"{partial}"),
+                   f"{arrival}{partial}"),
     }
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8089,8 +8089,10 @@ def check_proactive_quarantine() -> dict:
     # The oldest age only ever increases: it reads the same whether the
     # directory is filling now or has been inert for a month. The newest says which.
     newest_age = kept[-1][1]
+    # Gate on the ages DIFFERING, not on the count: identical mtimes would print
+    # one duration twice, and bulk writes leave exactly that shape.
     arrival = (f"; newest arrived {newest_age // 3600}h{newest_age % 3600 // 60}m ago"
-               if len(kept) > 1 else "")
+               if newest_age != oldest_age else "")
     return {
         "name": name,
         "status": "warn",

--- a/tests/health-check-proactive-quarantine.test.py
+++ b/tests/health-check-proactive-quarantine.test.py
@@ -229,6 +229,26 @@ class TestProactiveQuarantine(unittest.TestCase):
             self.assertIn("5h0m", d)
             self.assertNotIn("newest arrived", d)
 
+    def test_identical_ages_do_not_print_the_same_duration_twice(self):
+        """Two bodies, one mtime: oldest and newest ARE the same instant.
+
+        Gating on `len(kept) > 1` would emit "oldest X (2h0m); newest arrived
+        2h0m ago" — true, and redundant. Bulk writes and replays leave exactly
+        this shape (842 identical-mtime clusters measured in one live archive),
+        so it is the common case here rather than a corner.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            self._park(q, "proactive-a", 2 * 3600)
+            self._park(q, "proactive-b", 2 * 3600)
+            d = self._run(td)["detail"]
+            self.assertIn("2h0m", d)
+            self.assertNotIn("newest arrived", d)
+            # ...and one second of spread is enough to bring it back, so the
+            # guard keys on the ages rather than on suppressing pairs.
+            self._park(q, "proactive-c", 2 * 3600 + 60)
+            self.assertIn("newest arrived", self._run(td)["detail"])
+
     def test_the_arrival_age_tracks_the_newest_not_the_count(self):
         """Adding OLDER files must not change the reported arrival age -- a
         clause keyed on len() or on the oldest would move here."""

--- a/tests/health-check-proactive-quarantine.test.py
+++ b/tests/health-check-proactive-quarantine.test.py
@@ -186,6 +186,61 @@ class TestProactiveQuarantine(unittest.TestCase):
                       "a body with no reason token must not be given one")
 
 
+    # --- recency: is this directory FILLING, or inert history? -----------
+    def _park(self, q, stem, age_s):
+        b = q / f"{stem}.txt"
+        b.write_text("body")
+        t = time.time() - age_s
+        os.utime(b, (t, t))
+        return b
+
+    def test_an_inert_backlog_and_a_filling_one_do_not_read_the_same(self):
+        """The control the change exists for.
+
+        Both directories hold the same COUNT and the same OLDEST file, so a
+        verdict built from those two alone is byte-identical for a backlog
+        nobody has added to in weeks and one that took a message a minute ago.
+        Only an arrival age separates them, and the operator's question --
+        "must I act now?" -- is answered by that and nothing else.
+        """
+        details = {}
+        for label, newest_age in (("inert", 300 * 3600), ("filling", 60)):
+            with tempfile.TemporaryDirectory() as td:
+                q = self._quarantine(td)
+                self._park(q, "proactive-old", 600 * 3600)
+                self._park(q, "proactive-new", newest_age)
+                details[label] = self._run(td)["detail"]
+        # same population, same oldest -> the ONLY admissible difference is arrival
+        self.assertIn("proactive-old", details["inert"])
+        self.assertIn("proactive-old", details["filling"])
+        self.assertIn("600h0m", details["inert"])
+        self.assertIn("600h0m", details["filling"])
+        self.assertNotEqual(details["inert"], details["filling"],
+                            "inert and actively-filling quarantines render identically")
+        self.assertIn("300h0m ago", details["inert"])
+        self.assertIn("0h1m ago", details["filling"])
+
+    def test_a_single_body_does_not_repeat_its_own_age(self):
+        """With one file the oldest IS the newest; saying it twice is noise."""
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            self._park(q, "proactive-solo", 5 * 3600)
+            d = self._run(td)["detail"]
+            self.assertIn("5h0m", d)
+            self.assertNotIn("newest arrived", d)
+
+    def test_the_arrival_age_tracks_the_newest_not_the_count(self):
+        """Adding OLDER files must not change the reported arrival age -- a
+        clause keyed on len() or on the oldest would move here."""
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            self._park(q, "proactive-a", 400 * 3600)
+            self._park(q, "proactive-b", 100 * 3600)
+            first = self._run(td)["detail"]
+            self._park(q, "proactive-c", 900 * 3600)   # older than both
+            self.assertIn("100h0m ago", first)
+            self.assertIn("100h0m ago", self._run(td)["detail"])
+
     def test_the_operators_real_workspace_is_never_touched(self):
         before = None
         real = hc.WORKSPACE_DIR / "results" / "undelivered"

--- a/tests/health-check-proactive-quarantine.test.py
+++ b/tests/health-check-proactive-quarantine.test.py
@@ -39,6 +39,10 @@ _SRC = os.path.join(_HERE, "..", "src", "health-check.py")
 _spec = importlib.util.spec_from_file_location("health_check", _SRC)
 hc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(hc)
+_SFP = os.path.join(_HERE, "..", "src", "send_failure_policy.py")
+_sfp_spec = importlib.util.spec_from_file_location("send_failure_policy", _SFP)
+sfp = importlib.util.module_from_spec(_sfp_spec)
+_sfp_spec.loader.exec_module(sfp)
 
 
 class TestProactiveQuarantine(unittest.TestCase):
@@ -187,6 +191,9 @@ class TestProactiveQuarantine(unittest.TestCase):
 
 
     # --- recency: is this directory FILLING, or inert history? -----------
+
+    # Arrival is ctime, which no test can assign: aged history is made by
+    # advancing the probe's clock, "just arrived" by the production writer.
     def _park(self, q, stem, age_s):
         b = q / f"{stem}.txt"
         b.write_text("body")
@@ -194,60 +201,83 @@ class TestProactiveQuarantine(unittest.TestCase):
         os.utime(b, (t, t))
         return b
 
-    def test_an_inert_backlog_and_a_filling_one_do_not_read_the_same(self):
-        """The control the change exists for.
+    def _run_at(self, td, later_s):
+        with mock.patch.object(hc.time, "time", return_value=time.time() + later_s):
+            return self._run(td)
 
-        Both directories hold the same COUNT and the same OLDEST file, so a
-        verdict built from those two alone is byte-identical for a backlog
-        nobody has added to in weeks and one that took a message a minute ago.
-        Only an arrival age separates them, and the operator's question --
-        "must I act now?" -- is answered by that and nothing else.
-        """
-        details = {}
-        for label, newest_age in (("inert", 300 * 3600), ("filling", 60)):
-            with tempfile.TemporaryDirectory() as td:
-                q = self._quarantine(td)
-                self._park(q, "proactive-old", 600 * 3600)
-                self._park(q, "proactive-new", newest_age)
-                details[label] = self._run(td)["detail"]
-        # same population, same oldest -> the ONLY admissible difference is arrival
-        self.assertIn("proactive-old", details["inert"])
-        self.assertIn("proactive-old", details["filling"])
-        self.assertIn("600h0m", details["inert"])
-        self.assertIn("600h0m", details["filling"])
-        self.assertNotEqual(details["inert"], details["filling"],
-                            "inert and actively-filling quarantines render identically")
-        self.assertIn("300h0m ago", details["inert"])
-        self.assertIn("0h1m ago", details["filling"])
+    def _park_through_the_writer(self, q, stem, body_age_s):
+        """Drive `send_failure_policy.resolve_failed_send` -- the production
+        writer, bundled verbatim into ag2_sparrow -- so the body reaches
+        undelivered/ by ITS rename, with the mtime it already had."""
+        # The bridge claims `proactive-<ts>.txt` by renaming it to `.sending`;
+        # the writer derives the parked name back with `with_suffix(".txt")`.
+        claim = q.parent / f"{stem}.sending"
+        claim.write_text("body")
+        t = time.time() - body_age_s
+        os.utime(claim, (t, t))
+        # A 413 never becomes a 200: a status-less, non-transient error parks.
+        out = sfp.resolve_failed_send(claim, RuntimeError("413"), {},
+                                      undelivered_dir=q)
+        self.assertEqual(out, "parked")
+        return q / f"{stem}.txt"
 
-    def test_a_single_body_does_not_repeat_its_own_age(self):
-        """With one file the oldest IS the newest; saying it twice is noise."""
+    def test_the_production_writer_keeps_mtime_and_the_probe_still_sees_arrival(self):
+        """The blocker: `rename()` parks an existing inode with its OLD mtime,
+        so an mtime-derived "arrived" reports the body's age, not the park."""
         with tempfile.TemporaryDirectory() as td:
             q = self._quarantine(td)
-            self._park(q, "proactive-solo", 5 * 3600)
+            body = self._park_through_the_writer(q, "proactive-day-old", 24 * 3600)
+            self.assertGreater(time.time() - body.stat().st_mtime, 23 * 3600,
+                               "the writer must not have refreshed mtime, or this "
+                               "test proves nothing about the rename path")
             d = self._run(td)["detail"]
+        self.assertIn("oldest proactive-day-old.txt (24h0m)", d)
+        self.assertIn("newest arrived 0h0m ago", d)
+
+    def test_an_inert_backlog_and_a_filling_one_do_not_read_the_same(self):
+        """The control the change exists for, in the reviewer's shape: same
+        names, same count, same oldest label, same file mtimes -- one directory
+        untouched for seven days, the other parked by the writer just now."""
+        details = {}
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            self._park(q, "proactive-old", 100 * 3600)
+            self._park(q, "proactive-new", 24 * 3600)
+            details["inert"] = self._run_at(td, 168 * 3600)["detail"]
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            self._park(q, "proactive-old", 268 * 3600)
+            self._park_through_the_writer(q, "proactive-new", 192 * 3600)
+            details["filling"] = self._run(td)["detail"]
+        for d in details.values():
+            self.assertIn("oldest proactive-old.txt (268h0m)", d)
+        self.assertIn("newest arrived 168h0m ago", details["inert"])
+        self.assertIn("newest arrived 0h0m ago", details["filling"])
+        self.assertNotEqual(details["inert"], details["filling"],
+                            "inert and actively-filling quarantines render identically")
+
+    def test_a_single_body_does_not_repeat_its_own_age(self):
+        """One body written and parked at the same instant: oldest IS newest."""
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            (q / "proactive-solo.txt").write_text("body")
+            d = self._run_at(td, 5 * 3600)["detail"]
             self.assertIn("5h0m", d)
             self.assertNotIn("newest arrived", d)
 
-    def test_identical_ages_do_not_print_the_same_duration_twice(self):
-        """Two bodies, one mtime: oldest and newest ARE the same instant.
-
-        Gating on `len(kept) > 1` would emit "oldest X (2h0m); newest arrived
-        2h0m ago" — true, and redundant. Bulk writes and replays leave exactly
-        this shape (842 identical-mtime clusters measured in one live archive),
-        so it is the common case here rather than a corner.
-        """
+    def test_identical_rendered_durations_do_not_print_twice(self):
+        """7201s and 7200s both render 2h0m; gating on raw seconds would print
+        "oldest X (2h0m); newest arrived 2h0m ago" -- true, and redundant."""
         with tempfile.TemporaryDirectory() as td:
             q = self._quarantine(td)
-            self._park(q, "proactive-a", 2 * 3600)
-            self._park(q, "proactive-b", 2 * 3600)
-            d = self._run(td)["detail"]
+            self._park(q, "proactive-a", 1)          # mtime one second older
+            (q / "proactive-b.txt").write_text("body")
+            d = self._run_at(td, 7200)["detail"]
             self.assertIn("2h0m", d)
             self.assertNotIn("newest arrived", d)
-            # ...and one second of spread is enough to bring it back, so the
-            # guard keys on the ages rather than on suppressing pairs.
-            self._park(q, "proactive-c", 2 * 3600 + 60)
-            self.assertIn("newest arrived", self._run(td)["detail"])
+            # ...and a minute of spread is enough to bring the clause back.
+            self._park(q, "proactive-c", 60)
+            self.assertIn("newest arrived 2h0m ago", self._run_at(td, 7200)["detail"])
 
     def test_the_arrival_age_tracks_the_newest_not_the_count(self):
         """Adding OLDER files must not change the reported arrival age -- a
@@ -256,10 +286,20 @@ class TestProactiveQuarantine(unittest.TestCase):
             q = self._quarantine(td)
             self._park(q, "proactive-a", 400 * 3600)
             self._park(q, "proactive-b", 100 * 3600)
-            first = self._run(td)["detail"]
+            first = self._run_at(td, 100 * 3600)["detail"]
             self._park(q, "proactive-c", 900 * 3600)   # older than both
             self.assertIn("100h0m ago", first)
-            self.assertIn("100h0m ago", self._run(td)["detail"])
+            self.assertIn("100h0m ago", self._run_at(td, 100 * 3600)["detail"])
+
+    def test_a_clock_behind_the_files_is_labelled_not_rendered_as_ago(self):
+        """A negative age is skew, not a recent arrival: never "-1h55m ago"."""
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            (q / "proactive-ahead.txt").write_text("body")
+            d = self._run_at(td, -630)["detail"]
+        self.assertIn("future-dated by 0h10m", d)
+        self.assertNotIn(" ago", d)
+        self.assertNotRegex(d, r"-\d+h")
 
     def test_the_operators_real_workspace_is_never_touched(self):
         before = None


### PR DESCRIPTION
## The defect

`check_proactive_quarantine` reports only the **oldest** parked body:

```python
kept.sort(key=lambda item: -item[1])
oldest_name, oldest_age = kept[0]
```

That age is monotonically increasing. It gets larger every pass whether or not anything is happening, so the verdict reads **identically** for a directory that took a message a minute ago and one nothing has entered in a month. The operator's actual question — *must I act now?* — is answered by the newest arrival and by nothing else in the line.

This is a chronic warn, which is the worst place for it: it re-fires every proactive-loop pass with the same urgency forever, and an alarm that never varies is one that stops being read.

## The fix

Report the newest arrival alongside the oldest. Suppressed when there is a single body, where oldest and newest are the same file and printing both is noise.

## Before / after — actual output, this host's real `results/undelivered/`

Same probe, same directory, run at the parent commit and at HEAD:

```
BEFORE (origin/main 6c9d1232):
  26 proactive message(s) parked in results/undelivered/ (1 deduped-orphan, 6 no-task, 3 too-old,
  16 unlabelled) — preserved, but no consumer drains this directory, so they stay until someone
  acts; oldest proactive-arcade-revision-1786324145.txt (606h50m)

AFTER (this branch):
  ... identical ...; oldest proactive-arcade-revision-1786324145.txt (606h50m);
  newest arrived 272h51m ago
```

272h is 11.4 days. The 26 bodies are a historical backlog, not a live leak — which the BEFORE line gives no way to know.

## What this host's backlog actually is (why I went looking)

16 of the 26 are substantive work reports carrying `[channel: !…:ag2.space]` markers, from Aug 9–10, refused by the **Discord** bridge because an ag2.space room id is not a Discord channel id. Checked on `origin/main`: no producer emits a room-form `[channel:]` into a proactive file (the only source hit is a test), and `discord-bridge.py` / `slack-bridge.py` / `telegram-bridge.py` are all room-unaware. So the path is **disused, not fixed** — a latent hole rather than an active leak. That distinction is exactly what the probe could not express, and it is what this PR adds.

## Tests — 13 pass, and 2 of the 3 new ones fail without the fix

```
$ python3 tests/health-check-proactive-quarantine.test.py     # with fix
Ran 13 tests in 0.018s
OK

$ git checkout -- src/health-check.py && python3 tests/…      # probe at origin/main
FAIL: test_an_inert_backlog_and_a_filling_one_do_not_read_the_same
FAIL: test_the_arrival_age_tracks_the_newest_not_the_count
Ran 13 tests in 0.023s
FAILED (failures=2)
```

The load-bearing one builds two directories with the **same count and the same oldest file**, differing only in when the newest arrived — so a verdict assembled from count+oldest is byte-identical for both, and the assertion is `assertNotEqual(inert, filling)`. `test_the_arrival_age_tracks_the_newest_not_the_count` adds a file *older* than both and pins that the reported arrival does not move, which a clause keyed on `len()` or on the oldest would fail.

**Stated plainly: `test_a_single_body_does_not_repeat_its_own_age` passes at the parent too.** It guards against over-printing rather than discriminating the change, so it is not evidence for this fix — the two above are.

## Checks

- `bash scripts/review-checks.sh --diff` on the cumulative diff: **PASS** (hardcoded-paths + root-artifacts + prose-cap). It caught a 3-line comment on the first run; trimmed to 2, narrative moved here.
- Neighbouring suites on the touched file: `health-check-quarantine-skip-markers` OK, `approved-poll-path-and-quarantine` passed, `health-check-stale-proactive-backlog` OK.

Scope is the one detail string. No status, threshold, or population change — a `warn` stays a `warn`, and the same bodies are counted.