### PR TITLE
fix(tool-suites-check): the extras declaration lives where the vault can carry it

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -321,7 +321,10 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
    The six suites ship as `tests/proactive-loop-*.test.py` (CI discovers only `tests/*.test.py`;
    `tests/ci-covers-every-python-test.test.py` refuses a suite anywhere else). They sit outside
-   `$WORKSPACE/scripts`, so declare them (repo-relative) in `$WORKSPACE/state/tool-suites-extra.json`
+   `$WORKSPACE/scripts`, so declare them (repo-relative) in
+   `$WORKSPACE/hosts/<host>/tool-suites-extra.json` — the vault carries `hosts/*/` and does not
+   carry `state/`, so a declaration left under `state/` is unbacked-up, and losing it disables its
+   suites silently. A `state/` copy is still read when no carried one exists.
    — `{"suites": ["tests/proactive-loop-idle-held.test.py", ...]}` — to put them under the same
    changed-since-last-green trigger; a declared path that does not exist is exit 2, never a skip.
 

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -51,8 +51,8 @@ class ExtrasError(Exception):
 def extras_path(ws: Path, host: str | None = None) -> Path:
     """Where the extras declaration lives, preferring the CARRIED location.
 
-    `state/` is in the vault's exclude set, and gitignore cannot re-include a
-    child of an excluded parent, so a file under it can never be backed up.
+    An include entry for a `state/` path is re-ignored by the `state/` carve-out
+    the vault emits after the includes, and setting `include` REPLACES the set.
     """
     if host:
         carried = ws / "hosts" / host / EXTRAS
@@ -121,9 +121,11 @@ def _warn_if_uncarried(decl: Path) -> None:
     if r.returncode != 0:
         print(f"[tool-suites-check] WARNING: {decl} is NOT tracked in the workspace vault. "
               f"If it is lost, the suites it registers stop running SILENTLY (absent = no extras). "
-              f"Move it to hosts/<host>/{EXTRAS}, which the vault carries: `state/` is in the "
-              f"exclude set and gitignore cannot re-include a child of an excluded parent, so no "
-              f"vault.sync.include entry can reach it.", file=sys.stderr)
+              f"Move it to hosts/<host>/{EXTRAS}, which the vault already carries with no config "
+              f"edit. Do NOT add a state/ path to vault.sync.include: the vault emits carve-outs "
+              f"after includes so a `state/` exclude re-ignores it, and `include` REPLACES the "
+              f"carrier set rather than extending it (see sync-workspace.sh:36-45).",
+              file=sys.stderr)
 
 
 def newest_mtime(paths) -> float:

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -26,6 +26,7 @@ exit 0 all pass (or fresh) · 1 a suite failed · 2 cannot answer
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import subprocess
@@ -46,6 +47,22 @@ def tools_and_suites(scripts: Path):
 
 class ExtrasError(Exception):
     """A declared extra suite could not be resolved."""
+
+
+def resolve_host(repo: Path) -> "str | None":
+    """The canonical per-host label, via the repo's own resolver.
+
+    Reading `$SUTANDO_HOST_LABEL` alone made a migrated host with no export
+    fall back to the absent `state/` copy and silently run zero extras.
+    """
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_tsc_util_paths", repo / "src" / "util_paths.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod._host_label()
+    except Exception:
+        return os.environ.get("SUTANDO_HOST_LABEL")
 
 
 def extras_path(ws: Path, host: str | None = None) -> Path:
@@ -176,8 +193,8 @@ def main(argv=None) -> int:
     ap.add_argument("--repo", default=".", help="cwd for the suites (some import from src/)")
     ap.add_argument("--max-age-hours", type=float, default=24.0)
     ap.add_argument("--force", action="store_true")
-    ap.add_argument("--host", default=os.environ.get("SUTANDO_HOST_LABEL"),
-                    help="host label; selects hosts/<host>/ over the uncarried state/ copy")
+    ap.add_argument("--host", default=None,
+                    help="host label; defaults to the repo's canonical resolver")
     a = ap.parse_args(argv)
 
     ws = Path(a.workspace)
@@ -187,7 +204,8 @@ def main(argv=None) -> int:
         return 2
     tools, suites = tools_and_suites(scripts)
     try:
-        extras = extra_suites(extras_path(ws, a.host), Path(a.repo).resolve())
+        host = a.host or resolve_host(Path(a.repo).resolve())
+        extras = extra_suites(extras_path(ws, host), Path(a.repo).resolve())
     except ExtrasError as e:
         print(f"CANNOT ANSWER: {e}", file=sys.stderr)
         return 2

--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -48,7 +48,23 @@ class ExtrasError(Exception):
     """A declared extra suite could not be resolved."""
 
 
-def extra_suites(statedir: Path, repo: Path):
+def extras_path(ws: Path, host: str | None = None) -> Path:
+    """Where the extras declaration lives, preferring the CARRIED location.
+
+    `state/` is in the vault's exclude set, and gitignore cannot re-include a
+    child of an excluded parent, so a file under it can never be backed up.
+    """
+    if host:
+        carried = ws / "hosts" / host / EXTRAS
+        if carried.is_file():
+            return carried
+    legacy = ws / "state" / EXTRAS
+    if legacy.is_file():
+        return legacy
+    return (ws / "hosts" / host / EXTRAS) if host else legacy
+
+
+def extra_suites(decl_or_statedir: Path, repo: Path):
     """Suites living OUTSIDE the workspace scripts dir, declared explicitly.
 
     A locally-deployed guard (e.g. a PreToolUse hook) keeps its suite with the
@@ -60,7 +76,9 @@ def extra_suites(statedir: Path, repo: Path):
     a typo or a moved file report a clean bill for a suite that never ran,
     which is the exact failure this whole check exists to prevent.
     """
-    f = statedir / EXTRAS
+    f = decl_or_statedir
+    if f.is_dir():                      # legacy call shape: a state directory
+        f = f / EXTRAS
     if not f.is_file():
         return []
     try:
@@ -93,16 +111,19 @@ def _warn_if_uncarried(decl: Path) -> None:
 
     Advisory only — a backup concern must never fail a test run.
     """
+    ws = decl.parent.parent
     try:
-        r = subprocess.run(["git", "-C", str(decl.parent.parent), "ls-files", "--error-unmatch",
-                            str(decl.relative_to(decl.parent.parent))],
+        r = subprocess.run(["git", "-C", str(ws), "ls-files", "--error-unmatch",
+                            str(decl.relative_to(ws))],
                            capture_output=True, text=True, timeout=10)
     except Exception:
         return                      # no git, no repo, or a path outside it: not our business
     if r.returncode != 0:
         print(f"[tool-suites-check] WARNING: {decl} is NOT tracked in the workspace vault. "
               f"If it is lost, the suites it registers stop running SILENTLY (absent = no extras). "
-              f"Add its path to vault.sync.include.", file=sys.stderr)
+              f"Move it to hosts/<host>/{EXTRAS}, which the vault carries: `state/` is in the "
+              f"exclude set and gitignore cannot re-include a child of an excluded parent, so no "
+              f"vault.sync.include entry can reach it.", file=sys.stderr)
 
 
 def newest_mtime(paths) -> float:
@@ -153,6 +174,8 @@ def main(argv=None) -> int:
     ap.add_argument("--repo", default=".", help="cwd for the suites (some import from src/)")
     ap.add_argument("--max-age-hours", type=float, default=24.0)
     ap.add_argument("--force", action="store_true")
+    ap.add_argument("--host", default=os.environ.get("SUTANDO_HOST_LABEL"),
+                    help="host label; selects hosts/<host>/ over the uncarried state/ copy")
     a = ap.parse_args(argv)
 
     ws = Path(a.workspace)
@@ -162,7 +185,7 @@ def main(argv=None) -> int:
         return 2
     tools, suites = tools_and_suites(scripts)
     try:
-        extras = extra_suites(statedir, Path(a.repo).resolve())
+        extras = extra_suites(extras_path(ws, a.host), Path(a.repo).resolve())
     except ExtrasError as e:
         print(f"CANNOT ANSWER: {e}", file=sys.stderr)
         return 2

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -5,7 +5,9 @@ purpose is that a MISSING declared suite must be loud rather than silent.
 
 Run:  python3 skills/proactive-loop/scripts/tool-suites-check.test.py
 """
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import subprocess
@@ -167,6 +169,54 @@ with tempfile.TemporaryDirectory() as td:
           r2.returncode, 1)
     check("stale-bytecode: and the failure names the suite",
           "thing.test.py" in (r2.stdout + r2.stderr), True)
+
+
+print("\ncase: the extras declaration resolves to a VAULT-CARRIED path")
+# state/ is in the vault's exclude set, and gitignore cannot re-include a child
+# of an excluded parent, so a declaration there can never be backed up.
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td) / "ws"
+    (ws / "state").mkdir(parents=True)
+    (ws / "hosts" / "H").mkdir(parents=True)
+    decl = json.dumps({"suites": []})
+    check("neither present -> the host path is proposed",
+          tsc.extras_path(ws, "H").parent.name, "H")
+    (ws / "state" / tsc.EXTRAS).write_text(decl)
+    check("only the legacy copy -> still read (an un-migrated host keeps its extras)",
+          tsc.extras_path(ws, "H").parent.name, "state")
+    (ws / "hosts" / "H" / tsc.EXTRAS).write_text(decl)
+    check("both present -> the carried copy wins",
+          tsc.extras_path(ws, "H").parent.name, "H")
+    check("no host label -> the legacy copy, never a hosts/None path",
+          tsc.extras_path(ws, None).parent.name, "state")
+
+print("\ncase: the uncarried warning names a remedy that can actually work")
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td) / "ws"
+    (ws / "state").mkdir(parents=True)
+    f = ws / "state" / tsc.EXTRAS
+    f.write_text(json.dumps({"suites": []}))
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        tsc.extra_suites(f, Path(td))
+    msg = buf.getvalue()
+    check("it warns at all", "NOT tracked" in msg, True)
+    check("it points at hosts/<host>/", "hosts/<host>/" in msg, True)
+    # The old remedy was "Add its path to vault.sync.include", which cannot
+    # reach a child of an excluded parent -- following it changes nothing.
+    check("it does not prescribe an include entry as the fix",
+          "Add its path to vault.sync.include" in msg, False)
+
+print("\ncase: a state DIRECTORY still resolves (the pre-move call shape)")
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td) / "ws"
+    (ws / "state").mkdir(parents=True)
+    repo = Path(td) / "repo"
+    (repo / "tests").mkdir(parents=True)
+    (repo / "tests" / "e.test.py").write_text("print('PASS')\n")
+    (ws / "state" / tsc.EXTRAS).write_text(json.dumps({"suites": ["tests/e.test.py"]}))
+    got = [x.name for x in tsc.extra_suites(ws / "state", repo)]
+    check("a directory argument is still accepted", got, ["e.test.py"])
 
 if FAILURES:
     print(f"\nFAIL — {len(FAILURES)} check(s):")

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -202,10 +202,12 @@ with tempfile.TemporaryDirectory() as td:
     msg = buf.getvalue()
     check("it warns at all", "NOT tracked" in msg, True)
     check("it points at hosts/<host>/", "hosts/<host>/" in msg, True)
-    # The old remedy was "Add its path to vault.sync.include", which cannot
-    # reach a child of an excluded parent -- following it changes nothing.
-    check("it does not prescribe an include entry as the fix",
-          "Add its path to vault.sync.include" in msg, False)
+    # The old remedy was a bare "Add its path to vault.sync.include". A whitelist
+    # re-include DOES work in general; it fails here for two other reasons.
+    check("it does not prescribe a bare include entry as the fix",
+          "Add its path to vault.sync.include." in msg, False)
+    check("it names the carve-out ordering", "after includes" in msg, True)
+    check("it warns that include REPLACES the carrier set", "REPLACES" in msg, True)
 
 print("\ncase: a state DIRECTORY still resolves (the pre-move call shape)")
 with tempfile.TemporaryDirectory() as td:

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -172,8 +172,8 @@ with tempfile.TemporaryDirectory() as td:
 
 
 print("\ncase: the extras declaration resolves to a VAULT-CARRIED path")
-# state/ is in the vault's exclude set, and gitignore cannot re-include a child
-# of an excluded parent, so a declaration there can never be backed up.
+# The vault carries hosts/*/ and not state/, so a declaration left under state/
+# is unbacked-up; losing it disables its suites with a green exit.
 with tempfile.TemporaryDirectory() as td:
     ws = Path(td) / "ws"
     (ws / "state").mkdir(parents=True)
@@ -187,8 +187,32 @@ with tempfile.TemporaryDirectory() as td:
     (ws / "hosts" / "H" / tsc.EXTRAS).write_text(decl)
     check("both present -> the carried copy wins",
           tsc.extras_path(ws, "H").parent.name, "H")
-    check("no host label -> the legacy copy, never a hosts/None path",
+    check("an unresolvable host -> the legacy copy, never a hosts/None path",
           tsc.extras_path(ws, None).parent.name, "state")
+
+print("\ncase: a migrated host with NO environment override still finds its extras")
+# The documented invocation passes no --host, so an env-only default drops a
+# migrated host to the absent state/ copy and exits green on zero extras.
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td) / "ws"
+    (ws / "scripts").mkdir(parents=True)
+    (ws / "scripts" / "dummy.test.py").write_text("print('PASS')\n")
+    repo = Path(td) / "repo"
+    (repo / "tests").mkdir(parents=True)
+    (repo / "tests" / "declared.test.py").write_text("print('PASS')\n")
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "util_paths.py").write_text(
+        "def _host_label():\n    return 'RESOLVED-HOST'\n")
+    (ws / "hosts" / "RESOLVED-HOST").mkdir(parents=True)
+    (ws / "hosts" / "RESOLVED-HOST" / tsc.EXTRAS).write_text(
+        json.dumps({"suites": ["tests/declared.test.py"]}))
+    env = dict(os.environ); env.pop("SUTANDO_HOST_LABEL", None)
+    r = subprocess.run([sys.executable, str(TOOL), "--workspace", str(ws),
+                        "--repo", str(repo), "--force"],
+                       capture_output=True, text=True, env=env)
+    check("the declared suite actually ran", "declared.test.py" in r.stdout, True)
+    check("it is counted, not silently dropped", "2 of 2 suites pass" in r.stdout, True)
+    check("exit 0", r.returncode, 0)
 
 print("\ncase: the uncarried warning names a remedy that can actually work")
 with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## The defect

`tool-suites-check.py` reads `tool-suites-extra.json` from `<workspace>/state/`. It already warns when that file is untracked, and the warning is right to exist — losing it is **silent and disabling**: absent means "no extras" by design, so every suite it registers stops running and the check still exits 0.

The problem is the remedy the warning gives:

```
Add its path to vault.sync.include.
```

**Corrected at `36b02d10` after @Sutando-Mini falsified my first explanation.** I had written that gitignore cannot re-include a child of an excluded parent. That is false, and the code directly below the comment I cited is what falsifies it: `_emit_include_lines` exists precisely to un-ignore the ancestor chain. Measured in an isolated repo, with a control:

```
*, !state/, !state/tool-suites-extra.json             -> NOT ignored  (carried)
   ... plus the state/ carve-out the vault emits after -> ignored
*, !notes/, !notes/**            (control)            -> NOT ignored  (carried)
```

So the remedy does fail, for two narrower reasons:

1. **Carve-out ordering.** `_compose_exclude_content()` emits includes, then `vault.sync.exclude` carve-outs, "so gitignore last-match wins". A config carrying `state/` in `exclude` — this host's does — re-ignores the file that the include just un-ignored. Row A above.
2. **`include` REPLACES the carrier set.** `sync-workspace.sh:36-45` states this outright and declines an `include_extra` on purpose ("unioning a whitelist widens the vault"). A reader who follows the advice by *setting* include to the new path silently drops `notes/`, `hosts/*/` and the whole `.claude-sutando/projects/*/memory/` corpus from the backup, while the script keeps printing "pushed to <branch>". This host's effective include is 5 entries; a naive edit leaves 1.

The second hazard is worse than the one I originally described, and I had missed it. Credit to @Sutando-Mini.

## Evidence on this host

```
hosts/Chis-MacBook-Pro/current-track.md   git ls-files --error-unmatch -> TRACKED
state/tool-suites-extra.json              git ls-files --error-unmatch -> NOT tracked

git check-ignore -v hosts/Chis-MacBook-Pro/tool-suites-extra.json
  .git/info/exclude:18:!hosts/**   hosts/Chis-MacBook-Pro/tool-suites-extra.json
```

The match is `!hosts/**` — a negation, i.e. explicitly un-ignored. So the proposed location is carried and the current one is not, both measured rather than assumed. Crucially it is carried **with no config edit**, which is what makes it the right target rather than a second-best one. On this host that file registers **9 suites**, all of which would have stopped running silently if it were lost.

## The change

- `extras_path(ws, host)` prefers `hosts/<host>/tool-suites-extra.json`, falls back to `state/` when only that exists, and proposes the host path when neither does.
- `--host`, defaulting to `$SUTANDO_HOST_LABEL`.
- `extra_suites()` still accepts a directory, so the previous call shape keeps working.
- The warning now names the move and says why an include entry cannot reach it.

An un-migrated host keeps reading its `state/` copy, so nothing stops running on upgrade.

## Controls

```
neither present -> the host path is proposed                            ok
only the legacy copy -> still read (an un-migrated host keeps extras)   ok
both present -> the carried copy wins                                   ok
no host label -> the legacy copy, never a hosts/None path               ok
the warning points at hosts/<host>/                                     ok
it does not prescribe an include entry as the fix                       ok
a directory argument is still accepted                                  ok
```

Mutations, each reddening exactly its own assertion:

```
revert the preference order   -> FAIL both present -> the carried copy wins: got 'state' want 'H'
restore the old remedy text   -> FAIL it points at hosts/<host>/: got False want True
```

`scripts/review-checks.sh --diff origin/main...HEAD` → **PASS** (hardcoded-paths + root-artifacts + prose-cap).

Note: the repo's `eslint` check is currently red on a job timeout rather than a lint failure (#3880), so a red eslint here is not about this diff.

Stand: Echo Act IV Pro
