### PR TITLE
docs(proactive-loop): rc=0 from the triage gate is not proof of absence

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -267,7 +267,11 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    ```bash
    python3 skills/proactive-loop/scripts/warn-already-triaged.py --claim "<the sentence you are about to say>"
    # exit 1 = already parked, with file:line -> READ IT, then extend or say nothing is new
-   # exit 0 = genuinely untriaged -> proceed
+   # exit 0 = NO TOKEN MATCHED. That is not proof of absence -- the tool's own message says
+   #          "OR every token missed". Before proceeding, do step 3's fallback:
+   #          grep -n '^## ' "$H"/*.md  and read the ~25 headings. Enumerating cannot miss
+   #          the way a self-chosen token does, and the suspicion never generates the token
+   #          the answer is filed under.
    # exit 2 = could not answer (no parking files / empty claim) -> NOT a green light
    ```
 


### PR DESCRIPTION
## What

`skills/proactive-loop/SKILL.md` step 3.4 documents `warn-already-triaged.py`'s exit codes and reads `exit 0` as **"genuinely untriaged -> proceed"**. The tool does not claim that. Its own rc=0 message is:

```
NONE FOUND this claim — no heading, no body mention; genuinely untriaged, OR every
                        token missed (try one from the warn text)
```

Two different verdicts the caller cannot separate. The line turns an unanswerable result into a green light.

## Before / after, on live input

Claim: `the engine checkout at engine/sutando has no .git directory so it is not git-attached`

```
$ python3 skills/proactive-loop/scripts/warn-already-triaged.py --claim "<above>"
searching 2 parking file(s) for this claim's nouns
  NONE FOUND this claim  — no heading, no body mention; genuinely untriaged, OR every token missed
rc=0                                    <-- step 3.4 says: proceed

$ grep -in "engine tree" current-track.md | head -1
400:cannot be authored here: this engine tree is not a git checkout. Needs the git checkout.
```

The answer was already parked, one hand-grep away. Nothing in the tool misbehaved; the wording around it authorised proceeding.

## Why this polarity is the dangerous one

`rc=2` sends the reader to look, so it self-corrects — I hit that the same morning and it worked. `rc=0` **ends the enquiry**, which is precisely the failure step 3 exists to prevent.

## Interaction with #3871 — this gets worse, not better, when that lands

#3871 fixes the tokenizer so snake_case identifiers extract. That converts a class of claims from `rc=2` (refuse, go look) into `rc=0`/`rc=1` (searched). So **#3871 increases how often the loop reaches this line**. The two are independent changes — this one stands alone on `main` — but the ordering matters for anyone reviewing both: fixing the tokenizer without fixing the reading makes the false clear more reachable.

## Scope

Docs only, one hunk, no behaviour change. The replacement points at the fallback step 3 already prescribes — enumerate the ~25 headings rather than querying — because a self-chosen token fails exactly when the suspicion never generates the word the answer is filed under.

Branched from `main` (`6c9d12323`); deliberately not folded into #3871 or #3878, both of which touch this file and are mid-review.
