### PR TITLE
feat(notify-reviewers): --body-file, so an ask never crosses a shell boundary

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -10,6 +10,11 @@ sends (a bounced mention notifies no one).
 
 Usage:
   notify_reviewers.py --reviewers rui,kewei --message "re-review #3303" [--send]
+  notify_reviewers.py --reviewers rui,kewei --body-file ask.md [--send]
+
+Use --body-file for any prose carrying backticks, $ or an apostrophe: the shell
+rewrites those before argv reaches this process, so no validation here can
+recover the original. Same policy as bot2bot-post and discord-bridge.
 
 Without --send it prints the exact room_ops commands (plan mode). A refused
 entry never starves the batch: resolvable reviewers are still notified and
@@ -436,7 +441,11 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--reviewers", required=True,
                     help="comma-separated roster keys")
-    ap.add_argument("--message", required=True)
+    ap.add_argument("--message", default=None)
+    ap.add_argument("--body-file", dest="body_file", default=None,
+                    help="read the message from a FILE instead of argv. Use it for any "
+                         "prose containing backticks, $ or an apostrophe — the shell "
+                         "mangles those before this script can see them.")
     ap.add_argument("--send", action="store_true")
     ap.add_argument("--allow-single", metavar="REASON", default="",
                     help="deliberately notify ONE reviewer; requires a reason")
@@ -450,6 +459,17 @@ def main() -> int:
                          "Stand is not a member THERE is REFUSED rather than silently notified "
                          "in their recorded room — correctly addressed, wrong venue.")
     a = ap.parse_args()
+    # Resolved into a.message here so every gate below reads one field; a body that
+    # reached argv has already been through the shell and cannot be recovered.
+    if (a.message is None) == (a.body_file is None):
+        raise SystemExit("ERROR: give exactly one of --message or --body-file")
+    if a.body_file is not None:
+        # Imported here, not at module scope: `_REPO` is positional, so a copy run
+        # from elsewhere has no src/ path and a top-level import breaks --message too.
+        from body_file import read_body_file
+        a.message = read_body_file(a.body_file)
+        if not a.message.strip():
+            raise SystemExit(f"ERROR: --body-file {a.body_file!r} is empty — refusing to send")
     names = [n.strip() for n in a.reviewers.split(",") if n.strip()]
     targets, refusal_rc = resolve(names, load_roster())
     # Gates run on RESOLVED targets before any send, so no partial batch notifies

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -437,6 +437,25 @@ def _stale_repeat_ask(message: str, targets, roster, minutes: int = 30):
                   f"Not yet asked: {', '.join(unasked) or '<roster exhausted>'}")
 
 
+def resolve_body(message, body_file) -> str:
+    """The ask body, from argv or from a file — exactly one of the two.
+
+    A body that reached argv has already been through the shell and cannot be
+    recovered, so --body-file is the only path that preserves backticks and $.
+    """
+    if (message is None) == (body_file is None):
+        raise SystemExit("ERROR: give exactly one of --message or --body-file")
+    if body_file is None:
+        return message
+    # Imported here, not at module scope: `_REPO` is positional, so a copy run
+    # from elsewhere has no src/ path and a top-level import breaks --message too.
+    from body_file import read_body_file
+    text = read_body_file(body_file)
+    if not text.strip():
+        raise SystemExit(f"ERROR: --body-file {body_file!r} is empty — refusing to send")
+    return text
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--reviewers", required=True,
@@ -459,17 +478,7 @@ def main() -> int:
                          "Stand is not a member THERE is REFUSED rather than silently notified "
                          "in their recorded room — correctly addressed, wrong venue.")
     a = ap.parse_args()
-    # Resolved into a.message here so every gate below reads one field; a body that
-    # reached argv has already been through the shell and cannot be recovered.
-    if (a.message is None) == (a.body_file is None):
-        raise SystemExit("ERROR: give exactly one of --message or --body-file")
-    if a.body_file is not None:
-        # Imported here, not at module scope: `_REPO` is positional, so a copy run
-        # from elsewhere has no src/ path and a top-level import breaks --message too.
-        from body_file import read_body_file
-        a.message = read_body_file(a.body_file)
-        if not a.message.strip():
-            raise SystemExit(f"ERROR: --body-file {a.body_file!r} is empty — refusing to send")
+    a.message = resolve_body(a.message, a.body_file)
     names = [n.strip() for n in a.reviewers.split(",") if n.strip()]
     targets, refusal_rc = resolve(names, load_roster())
     # Gates run on RESOLVED targets before any send, so no partial batch notifies

--- a/tests/notify-reviewers-body-file.test.py
+++ b/tests/notify-reviewers-body-file.test.py
@@ -88,6 +88,42 @@ with tempfile.TemporaryDirectory() as td:
     check("a FIFO is refused rather than blocking forever",
           "not a regular file" in (r.stdout + r.stderr), True)
 
+print("\ncase: resolve_body, in-process")
+# In-process as well as via the CLI: a subprocess run is invisible to coverage,
+# so the arms above exercise these lines without ever attributing them.
+import importlib.util
+_spec = importlib.util.spec_from_file_location("nr", str(TOOL))
+nr = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(nr)
+except SystemExit:
+    pass
+
+check("argv body passes through unchanged", nr.resolve_body(HAZARD, None), HAZARD)
+
+with tempfile.TemporaryDirectory() as td:
+    p = Path(td) / "ask.md"
+    p.write_text(HAZARD + "\n")
+    check("a file body is read VERBATIM — backtick and apostrophe intact",
+          nr.resolve_body(None, str(p)), HAZARD)
+
+    for label, args in (("both", (HAZARD, str(p))), ("neither", (None, None))):
+        try:
+            nr.resolve_body(*args)
+            check(f"{label} -> SystemExit", "no raise", "SystemExit")
+        except SystemExit as e:
+            check(f"{label} -> SystemExit naming the rule",
+                  "give exactly one of" in str(e), True)
+
+    empty = Path(td) / "empty.md"
+    empty.write_text("\n  \n")
+    try:
+        nr.resolve_body(None, str(empty))
+        check("empty file -> SystemExit", "no raise", "SystemExit")
+    except SystemExit as e:
+        check("empty file -> refuses rather than sending a blank ask",
+              "refusing to send" in str(e), True)
+
 if FAILURES:
     print(f"\nFAIL — {len(FAILURES)} check(s)")
     sys.exit(1)

--- a/tests/notify-reviewers-body-file.test.py
+++ b/tests/notify-reviewers-body-file.test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""notify_reviewers accepts prose from a file, so it never crosses a shell boundary.
+
+`--message` takes the body as argv. A backtick or an apostrophe in ordinary
+prose is rewritten by the shell BEFORE this process starts, and the send still
+reports success — the sender sees their draft, the reviewer sees something
+shorter. Measured 2026-09-02: two spans were silently dropped from a review
+request that had already gone out.
+
+The repo already owns that policy in `src/body_file.py` (#2918, adopted by
+bot2bot-post and discord-bridge). These arms pin that notify_reviewers uses the
+SHARED reader rather than a fourth private spelling, and that the body arrives
+byte-identical.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TOOL = REPO / "skills" / "collaboration-intelligence" / "scripts" / "notify_reviewers.py"
+
+FAILURES = []
+
+
+def check(label, got, want):
+    if got != want:
+        FAILURES.append(f"{label}: got {got!r}, want {want!r}")
+        print(f"  FAIL {label}: got {got!r}, want {want!r}")
+    else:
+        print(f"  ok   {label}")
+
+
+def run(*args):
+    """Plan mode — no --send, so nothing is delivered by any arm here."""
+    return subprocess.run([sys.executable, str(TOOL), *args],
+                          capture_output=True, text=True, cwd=str(REPO))
+
+
+# The body that motivated this: a backtick pair and an apostrophe, which a
+# double-quoted shell argument would execute and truncate rather than pass.
+HAZARD = "re-review https://github.com/sonichi/sutando/pull/3303 — `merge-ready.py` says it's clean"
+
+print("case: --body-file is accepted in place of --message")
+# SCOPE: the read itself is tested by tests/body-file-read.test.py (#2918).
+# These arms pin ADOPTION — that this CLI reaches the shared reader.
+with tempfile.TemporaryDirectory() as td:
+    p = Path(td) / "ask.md"
+    p.write_text(HAZARD + "\n")
+    r = run("--reviewers", "definitely-not-a-roster-key", "--body-file", str(p))
+    out = r.stdout + r.stderr
+    check("argparse did not demand --message", "required: --message" in out, False)
+    check("--body-file is a known flag", "unrecognized arguments" in out, False)
+
+print("\ncase: exactly one of --message / --body-file")
+with tempfile.TemporaryDirectory() as td:
+    p = Path(td) / "ask.md"
+    p.write_text(HAZARD + "\n")
+    r = run("--reviewers", "x", "--message", "hi", "--body-file", str(p))
+    check("both -> refused", "give exactly one of" in (r.stdout + r.stderr), True)
+    r = run("--reviewers", "x")
+    check("neither -> refused", "give exactly one of" in (r.stdout + r.stderr), True)
+
+print("\ncase: an empty body is refused rather than sent")
+with tempfile.TemporaryDirectory() as td:
+    p = Path(td) / "empty.md"
+    p.write_text("\n\n  \n")
+    r = run("--reviewers", "x", "--body-file", str(p))
+    check("empty -> refused", "refusing to send" in (r.stdout + r.stderr), True)
+
+print("\ncase: it DELEGATES to src/body_file.py rather than re-implementing the read")
+# A private copy would drift from the shared limit and the FIFO guard, which is
+# the whole reason #2918 put this in one module.
+src = TOOL.read_text()
+check("imports the shared reader", "from body_file import read_body_file" in src, True)
+check("no private open() of the body path", "open(a.body_file" in src, False)
+
+print("\ncase: the shared reader's own refusals still apply")
+with tempfile.TemporaryDirectory() as td:
+    missing = Path(td) / "nope.md"
+    r = run("--reviewers", "x", "--body-file", str(missing))
+    check("a missing file is an ERROR, not an empty body",
+          "cannot read --body-file" in (r.stdout + r.stderr), True)
+    fifo = Path(td) / "fifo"
+    os.mkfifo(fifo)
+    r = run("--reviewers", "x", "--body-file", str(fifo))
+    check("a FIFO is refused rather than blocking forever",
+          "not a regular file" in (r.stdout + r.stderr), True)
+
+if FAILURES:
+    print(f"\nFAIL — {len(FAILURES)} check(s)")
+    sys.exit(1)
+print("\nPASS — notify-reviewers --body-file")


### PR DESCRIPTION
## What

`notify_reviewers.py` gains `--body-file <path>`, an alternative to `--message`. Exactly one of the two is required. The body is read through **`src/body_file.py`** — the module #2918 already added for this, in use by `bot2bot-post` and `discord-bridge`.

## Why

`--message` takes the ask as argv, so the shell rewrites it before this process exists. A backtick pair or an apostrophe in ordinary prose is consumed, **the send still reports success**, and the sender sees their draft while the reviewer sees something shorter. Measured 2026-09-02 on this tool: two spans were silently dropped from a review request that had already gone out. No validation inside the script can catch it — the mangling happens upstream of argv, so the only fix is a path that never touches the shell.

This is the same argument #2918 made, and it shipped the shared reader then. `notify_reviewers` is the one message-sending CLI that never adopted it.

## Evidence

Suite is red at the parent and green at HEAD — **7 of 9 arms flip**:

```
$ git checkout HEAD -- skills/collaboration-intelligence/scripts/notify_reviewers.py
$ python3 tests/notify-reviewers-body-file.test.py
  FAIL argparse did not demand --message: got True, want False
  FAIL both -> refused / neither -> refused
  FAIL empty -> refused
  FAIL imports the shared reader
  FAIL a missing file is an ERROR, not an empty body
  FAIL a FIFO is refused rather than blocking forever
FAIL — 7 check(s)          rc=1

$ # at HEAD
PASS — notify-reviewers --body-file        rc=0
```

The two arms that stay green at the parent do so **vacuously** (the flag does not exist there, so "no private `open()`" and "not an unrecognized argument" are trivially true). They are drift-guards, not evidence; the 7 above are the measurement.

Every other suite touching this file, at HEAD:

```
sci-notify-reviewers.test.py                   rc=0   (29 tests, OK)
sci-notify-reviewers-{inproc,kind}.test.py     rc=0
sci-notify-reviewers-{refusal-basis,shorthand-refusal}.test.py  rc=0
notify-reviewers-{human-shapes,per-host-roster}.test.py         rc=0
discord-post-gate-{wiring,schema,per-channel}.test.py           rc=0
```

`scripts/review-checks.sh --diff` on the full PR diff: `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`.

## The import is lazy on purpose

My first version imported `read_body_file` at module scope and **broke `sci-notify-reviewers.test.py` — 31 failures**, none of them in the new code. That suite copies the script to a temp directory and runs it there; `_REPO = Path(__file__).resolve().parents[3]` is positional, so the copy has no `src/` on its path and a top-level import fails for *every* caller, including plain `--message`:

```
ModuleNotFoundError: No module named 'body_file'
```

Importing inside the `--body-file` branch confines the dependency to the path that actually needs it. A copy run outside the repo still cannot use `--body-file` — that is honest and it fails loudly, rather than taking `--message` down with it.

## Not in scope

- `tests/collab-lookup-store-shapes.test.py` fails at this HEAD **and at the parent, with byte-identical output** — pre-existing, untouched here.
- `_REPO = parents[3]` is fragile in the way the paragraph above describes; `bot2bot-post` uses a "walk up until `src/body_file.py` exists" probe instead. Changing it is a separate concern and a separate PR.
- #3509 rewrites this file wholesale from a base 42 commits behind `main`. If it lands by taking its own side of the file, this flag goes with it — flagging that here so the merge order is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
