### PR TITLE
feat(scripts): anchored-edit — an edit that changes nothing must not exit 0

### DIFF
--- a/scripts/anchored-edit.py
+++ b/scripts/anchored-edit.py
@@ -18,11 +18,22 @@ refusal is an exit code:
     0  the file changed, and the receipt counts the new text in it
     2  the anchor is absent, ambiguous, or the edit is a no-op
 
+CONCURRENCY, AND ITS BOUNDARY — this is a cooperative protocol, not a
+guarantee against arbitrary writers. The read, the compute and the replace are
+held under an exclusive flock on `<file>.anchored-lock`, so two writers that
+BOTH take that lock cannot interleave and neither can lose an update. A writer
+that ignores the lock is outside the protocol: the pre-replace reread narrows
+the window it can land in, but does not close it, and such an update can still
+be overwritten. Take `<file>.anchored-lock` if you edit these files from
+elsewhere. Do not read this tool as making arbitrary post-read updates safe.
+
 Usage:
     anchored-edit.py FILE --old-file OLD --new-file NEW [--count N] [--allow-multi]
     anchored-edit.py FILE --old TEXT --new TEXT
 """
 import argparse
+import contextlib
+import fcntl
 import os
 import shutil
 import sys
@@ -47,6 +58,25 @@ def apply_edit(text: str, old: str, new: str, allow_multi: bool = False):
             else text.replace(old, new, 1)), n
 
 
+LOCK_SUFFIX = ".anchored-lock"
+
+
+@contextlib.contextmanager
+def _edit_lock(p: Path):
+    """Exclusive flock on a sidecar, held across the read AND the replace.
+
+    Locking p itself cannot work: os.replace swaps the inode, so the lock a
+    writer holds no longer guards the file its successor sees.
+    """
+    lock = p.with_name(p.name + LOCK_SUFFIX)
+    fd = os.open(str(lock), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(fd)
+
+
 def _atomic_write(p: Path, text: str, expect: str) -> None:
     """Replace p's contents or leave them untouched — never a truncated middle.
 
@@ -60,8 +90,8 @@ def _atomic_write(p: Path, text: str, expect: str) -> None:
             f.flush()
             os.fsync(f.fileno())
         shutil.copymode(p, tmp)
-        # Precondition, not a posterior check: a writer that lands between the
-        # caller's read and this replace is invisible to any after-the-fact test.
+        # Second line of defence, for writers that ignore LOCK_SUFFIX. It
+        # narrows the window; only the lock closes it. See _edit_lock.
         if p.read_text() != expect:
             raise RuntimeError("target changed since it was read — refusing to overwrite")
         os.replace(tmp, p)          # atomic within a filesystem
@@ -96,6 +126,12 @@ def main(argv=None) -> int:
     if not p.is_file():
         print(f"anchored-edit: no such file: {p}", file=sys.stderr)
         return 2
+    with _edit_lock(p):
+        return _edit_locked(p, old, new, a)
+
+
+def _edit_locked(p: Path, old, new, a) -> int:
+    """The read-compute-replace critical section. Caller holds the edit lock."""
     before = p.read_text()
     try:
         after, n = apply_edit(before, old, new, a.allow_multi)

--- a/scripts/anchored-edit.py
+++ b/scripts/anchored-edit.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Anchored in-place edit that REFUSES rather than silently doing nothing.
+
+The failure this exists for: an ad-hoc `s.replace(old, new)` whose anchor has
+drifted matches nothing, writes the file back unchanged, and the surrounding
+script prints its own success message anyway — because that message was
+generated independently of the operation. `echo updated` proves the echo ran.
+
+Measured 2026-09-04, three times across two agents in one session: a patch
+script that printed "second copy updated" against an anchor the file did not
+contain; a build_log append whose redirect was dropped, rendering to the
+terminal; and two task closures narrated with no result file written. Every
+one reported success.
+
+So the receipt here is derived from the file AFTER the write, and every
+refusal is an exit code:
+
+    0  the file changed, and the receipt counts the new text in it
+    2  the anchor is absent, ambiguous, or the edit is a no-op
+
+Usage:
+    anchored-edit.py FILE --old-file OLD --new-file NEW [--count N] [--allow-multi]
+    anchored-edit.py FILE --old TEXT --new TEXT
+"""
+import argparse
+import sys
+from pathlib import Path
+
+
+def apply_edit(text: str, old: str, new: str, allow_multi: bool = False):
+    """(result, occurrences) or raise ValueError naming which guard refused."""
+    if not old:
+        raise ValueError("empty anchor: it would match at every position")
+    n = text.count(old)
+    if n == 0:
+        raise ValueError("anchor absent — nothing was changed; the anchor has "
+                         "drifted from the file, which is the failure this refuses")
+    if n > 1 and not allow_multi:
+        raise ValueError(f"anchor appears {n} times — ambiguous; pass --allow-multi "
+                         "to change all of them deliberately")
+    if old == new:
+        raise ValueError("old == new: the edit is a no-op")
+    return (text.replace(old, new) if allow_multi
+            else text.replace(old, new, 1)), n
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("file")
+    ap.add_argument("--old"); ap.add_argument("--new")
+    ap.add_argument("--old-file"); ap.add_argument("--new-file")
+    ap.add_argument("--allow-multi", action="store_true")
+    ap.add_argument("--count", type=int, default=None,
+                    help="assert the anchor occurs exactly N times before editing")
+    a = ap.parse_args(argv)
+
+    old = Path(a.old_file).read_text() if a.old_file else a.old
+    new = Path(a.new_file).read_text() if a.new_file else a.new
+    if old is None or new is None:
+        print("anchored-edit: need --old/--new or --old-file/--new-file", file=sys.stderr)
+        return 2
+
+    p = Path(a.file)
+    if not p.is_file():
+        print(f"anchored-edit: no such file: {p}", file=sys.stderr)
+        return 2
+    before = p.read_text()
+    try:
+        after, n = apply_edit(before, old, new, a.allow_multi)
+    except ValueError as e:
+        print(f"anchored-edit: REFUSED — {e}", file=sys.stderr)
+        return 2
+    if a.count is not None and n != a.count:
+        print(f"anchored-edit: REFUSED — anchor occurs {n} times, --count said {a.count}",
+              file=sys.stderr)
+        return 2
+    p.write_text(after)
+
+    # Read the file BACK. A receipt computed from `after` would still print if
+    # the write silently failed; this one cannot exist unless the bytes landed.
+    reread = p.read_text()
+    if reread == before:
+        print("anchored-edit: REFUSED — the file is unchanged after the write",
+              file=sys.stderr)
+        return 2
+    print(f"anchored-edit: {p} — anchor matched {n}x, "
+          f"replacement present {reread.count(new)}x, {len(before)} -> {len(reread)} bytes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/anchored-edit.py
+++ b/scripts/anchored-edit.py
@@ -23,7 +23,10 @@ Usage:
     anchored-edit.py FILE --old TEXT --new TEXT
 """
 import argparse
+import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -42,6 +45,25 @@ def apply_edit(text: str, old: str, new: str, allow_multi: bool = False):
         raise ValueError("old == new: the edit is a no-op")
     return (text.replace(old, new) if allow_multi
             else text.replace(old, new, 1)), n
+
+
+def _atomic_write(p: Path, text: str) -> None:
+    """Replace p's contents or leave them untouched — never a truncated middle.
+
+    write_text() truncates the live file first, so an interrupted or short
+    write destroys the original. A sibling temp + fsync + os.replace cannot.
+    """
+    fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix=p.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        shutil.copymode(p, tmp)
+        os.replace(tmp, p)          # atomic within a filesystem
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
 
 
 def main(argv=None) -> int:
@@ -74,13 +96,17 @@ def main(argv=None) -> int:
         print(f"anchored-edit: REFUSED — anchor occurs {n} times, --count said {a.count}",
               file=sys.stderr)
         return 2
-    p.write_text(after)
+    try:
+        _atomic_write(p, after)
+    except OSError as e:
+        print(f"anchored-edit: REFUSED — write failed, original retained: {e}", file=sys.stderr)
+        return 2
 
-    # Read the file BACK. A receipt computed from `after` would still print if
-    # the write silently failed; this one cannot exist unless the bytes landed.
+    # Must equal `after` EXACTLY: comparing against `before` only proves
+    # something changed, which a concurrent writer's content also satisfies.
     reread = p.read_text()
-    if reread == before:
-        print("anchored-edit: REFUSED — the file is unchanged after the write",
+    if reread != after:
+        print("anchored-edit: REFUSED — the file on disk is not what this edit computed",
               file=sys.stderr)
         return 2
     print(f"anchored-edit: {p} — anchor matched {n}x, "

--- a/scripts/anchored-edit.py
+++ b/scripts/anchored-edit.py
@@ -47,7 +47,7 @@ def apply_edit(text: str, old: str, new: str, allow_multi: bool = False):
             else text.replace(old, new, 1)), n
 
 
-def _atomic_write(p: Path, text: str) -> None:
+def _atomic_write(p: Path, text: str, expect: str) -> None:
     """Replace p's contents or leave them untouched — never a truncated middle.
 
     write_text() truncates the live file first, so an interrupted or short
@@ -60,6 +60,10 @@ def _atomic_write(p: Path, text: str) -> None:
             f.flush()
             os.fsync(f.fileno())
         shutil.copymode(p, tmp)
+        # Precondition, not a posterior check: a writer that lands between the
+        # caller's read and this replace is invisible to any after-the-fact test.
+        if p.read_text() != expect:
+            raise RuntimeError("target changed since it was read — refusing to overwrite")
         os.replace(tmp, p)          # atomic within a filesystem
     except BaseException:
         Path(tmp).unlink(missing_ok=True)
@@ -83,6 +87,12 @@ def main(argv=None) -> int:
         return 2
 
     p = Path(a.file)
+    if p.is_symlink():
+        # os.replace() swaps the LINK entry, leaving the target untouched and
+        # turning the link into a regular file. Refuse rather than retarget.
+        print(f"anchored-edit: REFUSED — {p} is a symlink; edit its target directly",
+              file=sys.stderr)
+        return 2
     if not p.is_file():
         print(f"anchored-edit: no such file: {p}", file=sys.stderr)
         return 2
@@ -97,9 +107,10 @@ def main(argv=None) -> int:
               file=sys.stderr)
         return 2
     try:
-        _atomic_write(p, after)
-    except OSError as e:
-        print(f"anchored-edit: REFUSED — write failed, original retained: {e}", file=sys.stderr)
+        _atomic_write(p, after, before)
+    except (OSError, RuntimeError) as e:
+        # RuntimeError is the changed-target precondition; both leave p untouched.
+        print(f"anchored-edit: REFUSED — write not applied, original retained: {e}", file=sys.stderr)
         return 2
 
     # Must equal `after` EXACTLY: comparing against `before` only proves

--- a/scripts/anchored-edit.py
+++ b/scripts/anchored-edit.py
@@ -27,6 +27,14 @@ the window it can land in, but does not close it, and such an update can still
 be overwritten. Take `<file>.anchored-lock` if you edit these files from
 elsewhere. Do not read this tool as making arbitrary post-read updates safe.
 
+NOT FOR APPEND-ONLY SHARED STATE. The two shapes need different primitives:
+an append-only multi-writer file (build_log.md is the repo's documented case)
+wants O_APPEND, which is atomic per write and needs no lock; this tool does a
+REPLACEMENT, which has no lock-free form. A correct replacement of an
+append-only file still discards every append that landed since the read — the
+lock above does not change that, because nothing was raced, the write simply
+was not an append. Use O_APPEND there and this tool for replacements.
+
 Usage:
     anchored-edit.py FILE --old-file OLD --new-file NEW [--count N] [--allow-multi]
     anchored-edit.py FILE --old TEXT --new TEXT

--- a/tests/anchored-edit.test.py
+++ b/tests/anchored-edit.test.py
@@ -10,11 +10,14 @@ evidence about the operation at all.
 
 Run: python3 tests/anchored-edit.test.py
 """
+import contextlib
 import importlib.util
+import io
 import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -75,6 +78,83 @@ class AnchoredEdit(unittest.TestCase):
                                        "--allow-multi", "--count", "3")
         self.assertEqual(rc, 2)
         self.assertEqual(text, "x x")
+
+
+class AtomicReplacement(unittest.TestCase):
+    """qingyun-wu, 2026-09-04: write_text() truncates the live target, and a
+    read-back compared against `before` passes on ANY different content --
+    including a concurrent writer's. Both halves are tested here."""
+
+    def _tmp(self, body):
+        d = Path(tempfile.mkdtemp())
+        f = d / "target.txt"
+        f.write_text(body)
+        return f
+
+    def test_a_failed_write_retains_the_original_and_prints_no_receipt(self):
+        f = self._tmp("alpha beta")
+        with unittest.mock.patch.object(ae, "_atomic_write",
+                                        side_effect=OSError("ENOSPC")):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(io.StringIO()):
+                rc = ae.main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 2)
+        self.assertEqual(f.read_text(), "alpha beta",
+                         "a failed write must leave the original intact")
+        self.assertEqual(buf.getvalue(), "", "no success receipt on a failed write")
+
+    def test_content_that_is_merely_DIFFERENT_does_not_satisfy_the_receipt(self):
+        """The measured hole: comparing the re-read against `before` accepts a
+        concurrent writer's bytes as proof that MY edit landed."""
+        f = self._tmp("alpha beta")
+
+        def _clobber(path, text):
+            path.write_text("something another writer put here")
+
+        with unittest.mock.patch.object(ae, "_atomic_write", side_effect=_clobber):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(io.StringIO()):
+                rc = ae.main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 2, "different-from-before is not proof the edit landed")
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_the_target_is_never_truncated_in_place(self):
+        """No window exists in which the target is empty: the temp sibling
+        carries the new bytes and os.replace swaps them in one step."""
+        f = self._tmp("alpha beta")
+        seen = []
+        real = ae.os.replace
+
+        def _spy(src, dst):
+            seen.append(Path(dst).read_text())   # the target, just before the swap
+            return real(src, dst)
+
+        with unittest.mock.patch.object(ae.os, "replace", side_effect=_spy):
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = ae.main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(seen, ["alpha beta"],
+                         "the target still held its ORIGINAL bytes at swap time")
+        self.assertEqual(f.read_text(), "alpha gamma")
+
+    def test_mode_is_preserved_across_the_replace(self):
+        f = self._tmp("alpha beta")
+        f.chmod(0o640)
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = ae.main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(f.stat().st_mode & 0o777, 0o640)
+
+    def test_no_temp_sibling_survives_a_failure(self):
+        f = self._tmp("alpha beta")
+        with unittest.mock.patch.object(ae.os, "replace", side_effect=OSError("boom")):
+            with contextlib.redirect_stdout(io.StringIO()), \
+                 contextlib.redirect_stderr(io.StringIO()):
+                rc = ae.main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 2)
+        self.assertEqual(f.read_text(), "alpha beta")
+        self.assertEqual([q.name for q in f.parent.iterdir()], ["target.txt"],
+                         "a failed replace must not leave a temp file behind")
 
 
 if __name__ == "__main__":

--- a/tests/anchored-edit.test.py
+++ b/tests/anchored-edit.test.py
@@ -108,7 +108,7 @@ class AtomicReplacement(unittest.TestCase):
         concurrent writer's bytes as proof that MY edit landed."""
         f = self._tmp("alpha beta")
 
-        def _clobber(path, text):
+        def _clobber(path, text, expect):
             path.write_text("something another writer put here")
 
         with unittest.mock.patch.object(ae, "_atomic_write", side_effect=_clobber):
@@ -217,7 +217,7 @@ class AtomicWriteDirect(unittest.TestCase):
         f = Path(tempfile.mkdtemp()) / "t.txt"
         f.write_text("old")
         f.chmod(0o600)
-        ae._atomic_write(f, "new")
+        ae._atomic_write(f, "new", "old")
         self.assertEqual(f.read_text(), "new")
         self.assertEqual(f.stat().st_mode & 0o777, 0o600)
 
@@ -226,9 +226,65 @@ class AtomicWriteDirect(unittest.TestCase):
         f.write_text("original")
         with unittest.mock.patch.object(ae.os, "replace", side_effect=OSError("boom")):
             with self.assertRaises(OSError):
-                ae._atomic_write(f, "replacement")
+                ae._atomic_write(f, "replacement", "original")
         self.assertEqual(f.read_text(), "original")
         self.assertEqual([q.name for q in f.parent.iterdir()], ["t.txt"])
+
+
+class IntegrityContract(unittest.TestCase):
+    """qingyun-wu, 2026-09-04, both reproduced with controls: os.replace swaps a
+    SYMLINK entry rather than editing its target, and the edit computed from
+    `before` was written unconditionally, so a writer landing between the read
+    and the replace was silently lost."""
+
+    def _dir(self):
+        return Path(tempfile.mkdtemp())
+
+    def _main(self, argv):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = ae.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_a_symlink_target_is_refused_not_retargeted(self):
+        d = self._dir()
+        real = d / "real.txt"
+        real.write_text("alpha beta")
+        link = d / "link.txt"
+        link.symlink_to(real)
+        rc, out, err = self._main([str(link), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 2)
+        self.assertIn("symlink", err)
+        self.assertEqual(out, "", "a refusal must print no receipt")
+        self.assertEqual(real.read_text(), "alpha beta", "the target must be untouched")
+        self.assertTrue(link.is_symlink(), "the link must still be a link, not a regular file")
+
+    def test_a_write_landing_after_the_read_is_refused_not_clobbered(self):
+        d = self._dir()
+        f = d / "t.txt"
+        f.write_text("alpha beta")
+        real_copymode = ae.shutil.copymode
+
+        def _race(src, dst):
+            # copymode(src=p, dst=tmp): SRC is the live target, and this runs
+            # inside the one window the precondition can actually observe.
+            Path(src).write_text("third-party")
+            return real_copymode(src, dst)
+
+        with unittest.mock.patch.object(ae.shutil, "copymode", side_effect=_race):
+            rc, out, err = self._main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 2, "a changed target must refuse, not overwrite")
+        self.assertEqual(f.read_text(), "third-party", "the concurrent update must survive")
+        self.assertEqual(out, "")
+
+    def test_the_unchanged_case_still_succeeds(self):
+        """Negative control: the precondition must not refuse an ordinary edit."""
+        d = self._dir()
+        f = d / "t.txt"
+        f.write_text("alpha beta")
+        rc, out, err = self._main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(f.read_text(), "alpha gamma")
 
 
 if __name__ == "__main__":

--- a/tests/anchored-edit.test.py
+++ b/tests/anchored-edit.test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""An edit that changes nothing must not exit 0.
+
+Measured 2026-09-04, three times across two agents in one session: a patch
+script printed "second copy updated" against an anchor the file did not
+contain; a build_log append lost its redirect and rendered to the terminal;
+two task closures were narrated with no result file written. In all three the
+success message was generated INDEPENDENTLY of the operation, so it was never
+evidence about the operation at all.
+
+Run: python3 tests/anchored-edit.test.py
+"""
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TOOL = REPO / "scripts" / "anchored-edit.py"
+spec = importlib.util.spec_from_file_location("ae", TOOL)
+ae = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ae)
+
+
+class AnchoredEdit(unittest.TestCase):
+    def test_a_real_edit_applies(self):
+        """Control: without this, refusing everything would pass every other test."""
+        out, n = ae.apply_edit("alpha beta", "beta", "gamma")
+        self.assertEqual((out, n), ("alpha gamma", 1))
+
+    def test_a_drifted_anchor_refuses_instead_of_no_op(self):
+        with self.assertRaises(ValueError) as cm:
+            ae.apply_edit("alpha beta", "delta", "gamma")
+        self.assertIn("absent", str(cm.exception))
+
+    def test_an_ambiguous_anchor_refuses_unless_deliberate(self):
+        with self.assertRaises(ValueError):
+            ae.apply_edit("x x", "x", "y")
+        self.assertEqual(ae.apply_edit("x x", "x", "y", allow_multi=True), ("y y", 2))
+
+    def test_old_equals_new_is_a_no_op_and_refuses(self):
+        with self.assertRaises(ValueError):
+            ae.apply_edit("alpha", "alpha", "alpha")
+
+    def test_an_empty_anchor_refuses(self):
+        """It matches at every position, so it is never the edit anyone meant."""
+        with self.assertRaises(ValueError):
+            ae.apply_edit("alpha", "", "x")
+
+    def _run(self, text, *argv):
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "f.txt"
+            f.write_text(text)
+            p = subprocess.run([sys.executable, str(TOOL), str(f), *argv],
+                               capture_output=True, text=True)
+            return p.returncode, p.stdout, p.stderr, f.read_text()
+
+    def test_the_cli_exits_2_and_writes_nothing_when_the_anchor_drifted(self):
+        rc, out, err, text = self._run("alpha", "--old", "delta", "--new", "x")
+        self.assertEqual(rc, 2)
+        self.assertEqual(text, "alpha", "a refused edit must leave the file alone")
+        self.assertIn("REFUSED", err)
+        self.assertEqual(out, "", "a refusal must print no success receipt")
+
+    def test_the_cli_receipt_is_read_back_from_the_file(self):
+        rc, out, err, text = self._run("alpha beta", "--old", "beta", "--new", "gamma")
+        self.assertEqual(rc, 0)
+        self.assertEqual(text, "alpha gamma")
+        self.assertIn("replacement present 1x", out)
+
+    def test_count_mismatch_refuses(self):
+        rc, out, err, text = self._run("x x", "--old", "x", "--new", "y",
+                                       "--allow-multi", "--count", "3")
+        self.assertEqual(rc, 2)
+        self.assertEqual(text, "x x")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/anchored-edit.test.py
+++ b/tests/anchored-edit.test.py
@@ -15,6 +15,7 @@ import importlib.util
 import io
 import subprocess
 import sys
+import time
 import tempfile
 import unittest
 import unittest.mock
@@ -153,8 +154,13 @@ class AtomicReplacement(unittest.TestCase):
                 rc = ae.main([str(f), "--old", "beta", "--new", "gamma"])
         self.assertEqual(rc, 2)
         self.assertEqual(f.read_text(), "alpha beta")
-        self.assertEqual([q.name for q in f.parent.iterdir()], ["target.txt"],
-                         "a failed replace must not leave a temp file behind")
+        # The lock sidecar is durable and expected; a .tmp is the leak. Listing
+        # every name would now pass for the wrong reason, so name the leak.
+        leaked = [q.name for q in f.parent.iterdir() if q.name.endswith(".tmp")]
+        self.assertEqual(leaked, [], "a failed replace must not leave a temp file behind")
+        self.assertEqual(sorted(q.name for q in f.parent.iterdir()),
+                         ["target.txt", "target.txt" + ae.LOCK_SUFFIX],
+                         "nothing but the target and its lock may remain")
 
 
 class InProcessPaths(unittest.TestCase):
@@ -285,6 +291,76 @@ class IntegrityContract(unittest.TestCase):
         rc, out, err = self._main([str(f), "--old", "beta", "--new", "gamma"])
         self.assertEqual(rc, 0)
         self.assertEqual(f.read_text(), "alpha gamma")
+
+    def test_the_lock_is_held_across_the_replace_not_only_the_precondition(self):
+        """The window the precondition CANNOT close: after the reread, at replace.
+
+        qingyun-wu reproduced a clobber by injecting exactly there. A cooperating
+        writer is now excluded for that whole span, and this proves it by trying
+        to take the lock at the moment of replacement.
+        """
+        d = self._dir()
+        f = d / "t.txt"
+        f.write_text("alpha beta")
+        seen = {}
+        real_replace = ae.os.replace
+
+        def _at_replace(src, dst):
+            lock = Path(str(f) + ae.LOCK_SUFFIX)
+            fd = ae.os.open(str(lock), ae.os.O_CREAT | ae.os.O_RDWR, 0o644)
+            try:
+                ae.fcntl.flock(fd, ae.fcntl.LOCK_EX | ae.fcntl.LOCK_NB)
+                seen["held"] = False          # got in -> the window is OPEN
+                ae.fcntl.flock(fd, ae.fcntl.LOCK_UN)
+            except BlockingIOError:
+                seen["held"] = True           # refused -> the window is CLOSED
+            finally:
+                ae.os.close(fd)
+            return real_replace(src, dst)
+
+        with unittest.mock.patch.object(ae.os, "replace", side_effect=_at_replace):
+            rc, out, err = self._main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 0)
+        self.assertTrue(seen.get("held"),
+                        "a cooperating writer got the lock DURING the replace — "
+                        "the read-to-replace span is not actually locked")
+        self.assertEqual(f.read_text(), "alpha gamma")
+
+    def test_a_second_process_holding_the_lock_blocks_the_edit(self):
+        """End-to-end: the lock is a real cross-process exclusion, not bookkeeping."""
+        import subprocess
+        import textwrap
+        d = self._dir()
+        f = d / "t.txt"
+        f.write_text("alpha beta")
+        holder = subprocess.Popen(
+            [sys.executable, "-c", textwrap.dedent(f"""
+                import fcntl, os, sys, time
+                fd = os.open({str(f) + ".anchored-lock"!r}, os.O_CREAT | os.O_RDWR, 0o644)
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                sys.stdout.write("held"); sys.stdout.flush()
+                time.sleep(1.5)
+            """)], stdout=subprocess.PIPE, text=True)
+        self.assertEqual(holder.stdout.read(4), "held")
+        started = time.monotonic()
+        rc, out, err = self._main([str(f), "--old", "beta", "--new", "gamma"])
+        waited = time.monotonic() - started
+        holder.wait()
+        self.assertEqual(rc, 0)
+        self.assertGreater(waited, 0.5,
+                           "the edit did not wait for the lock — exclusion is not real")
+        self.assertEqual(f.read_text(), "alpha gamma")
+
+    def test_the_lock_does_not_leak_into_the_edited_content(self):
+        """Negative control: the sidecar is beside the file, never inside it."""
+        d = self._dir()
+        f = d / "t.txt"
+        f.write_text("alpha beta")
+        rc, out, err = self._main([str(f), "--old", "beta", "--new", "gamma"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(f.read_text(), "alpha gamma")
+        self.assertNotIn(ae.LOCK_SUFFIX, f.read_text())
+        self.assertTrue((d / ("t.txt" + ae.LOCK_SUFFIX)).exists())
 
 
 if __name__ == "__main__":

--- a/tests/anchored-edit.test.py
+++ b/tests/anchored-edit.test.py
@@ -157,5 +157,79 @@ class AtomicReplacement(unittest.TestCase):
                          "a failed replace must not leave a temp file behind")
 
 
+class InProcessPaths(unittest.TestCase):
+    """The CLI cases run under subprocess, so coverage cannot see the lines they
+    execute. These drive the same branches in-process, which is also the only way
+    `_atomic_write` itself gets executed rather than mocked."""
+
+    def _tmp(self, body="alpha beta"):
+        f = Path(tempfile.mkdtemp()) / "t.txt"
+        f.write_text(body)
+        return f
+
+    def _main(self, argv):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = ae.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_old_file_and_new_file_are_read_from_disk(self):
+        f = self._tmp()
+        d = f.parent
+        (d / "o").write_text("beta")
+        (d / "n").write_text("gamma")
+        rc, out, _ = self._main([str(f), "--old-file", str(d / "o"),
+                                 "--new-file", str(d / "n")])
+        self.assertEqual(rc, 0)
+        self.assertEqual(f.read_text(), "alpha gamma")
+
+    def test_missing_target_refuses(self):
+        rc, out, err = self._main(["/nonexistent/nope.txt", "--old", "a", "--new", "b"])
+        self.assertEqual(rc, 2)
+        self.assertIn("no such file", err)
+        self.assertEqual(out, "")
+
+    def test_neither_old_nor_old_file_refuses(self):
+        rc, out, err = self._main([str(self._tmp())])
+        self.assertEqual(rc, 2)
+        self.assertEqual(out, "")
+
+    def test_drifted_anchor_refuses_in_process(self):
+        f = self._tmp()
+        rc, out, err = self._main([str(f), "--old", "delta", "--new", "x"])
+        self.assertEqual(rc, 2)
+        self.assertIn("REFUSED", err)
+        self.assertEqual(f.read_text(), "alpha beta")
+
+    def test_count_mismatch_refuses_in_process(self):
+        f = self._tmp("x x")
+        rc, out, err = self._main([str(f), "--old", "x", "--new", "y",
+                                   "--allow-multi", "--count", "3"])
+        self.assertEqual(rc, 2)
+        self.assertEqual(f.read_text(), "x x")
+
+
+class AtomicWriteDirect(unittest.TestCase):
+    """`_atomic_write` executed for real. Every other test mocks it, so without
+    this the helper the review asked for is the one thing never run."""
+
+    def test_it_replaces_content_and_preserves_mode(self):
+        f = Path(tempfile.mkdtemp()) / "t.txt"
+        f.write_text("old")
+        f.chmod(0o600)
+        ae._atomic_write(f, "new")
+        self.assertEqual(f.read_text(), "new")
+        self.assertEqual(f.stat().st_mode & 0o777, 0o600)
+
+    def test_a_failure_mid_write_leaves_no_temp_and_keeps_the_original(self):
+        f = Path(tempfile.mkdtemp()) / "t.txt"
+        f.write_text("original")
+        with unittest.mock.patch.object(ae.os, "replace", side_effect=OSError("boom")):
+            with self.assertRaises(OSError):
+                ae._atomic_write(f, "replacement")
+        self.assertEqual(f.read_text(), "original")
+        self.assertEqual([q.name for q in f.parent.iterdir()], ["t.txt"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## The failure

An ad-hoc `s.replace(old, new)` whose anchor has drifted matches nothing, writes the file back unchanged, and the surrounding script prints its own success message anyway — because that message is **generated independently of the operation**. `echo updated` proves the echo ran, and nothing else.

## Measured, 2026-09-04 — three times across two agents in one session

- A patch script printed `second copy updated` against an anchor the file did not contain (`set(got_bad[0])` where the file says `set(got_bad)`). Caught only because a *different* test failed afterwards.
- A `build_log.md` append lost its `>>` redirect and rendered to the terminal, identical to a successful write.
- Two task closures were narrated with no result file written; only the queue disagreed.

All three reported success. @Sutando-Mini named the class: the success message is not evidence about the operation, it is evidence that control reached the print.

## Why this repo in particular

This codebase already applies *make the check able to fail* to health probes, the build-log append, the pending-questions reader, and the tool-suites runner. **Edit scripts were the exemption** — and an edit script is a probe whose subject is a file. Three of one night's failures lived in that exemption.

## The tool

Every refusal is exit 2, never a quiet pass:

| refused | why |
|---|---|
| anchor absent | the drift case — the one that silently no-ops |
| anchor ambiguous | >1 match without `--allow-multi` |
| `old == new` | a no-op dressed as an edit |
| empty anchor | matches everywhere, never the edit anyone meant |
| `--count` mismatch | the caller asserted N occurrences and got M |

A refused edit **leaves the file untouched and prints no receipt**.

The receipt is **read back from the file after the write**:

```
anchored-edit: /path/f.txt — anchor matched 1x, replacement present 1x, 11 -> 12 bytes
```

A receipt computed from the in-memory result would still print if the write silently failed. This one cannot exist unless the bytes landed.

## Controls

8 tests, including a positive control (a real edit applies — without it, refusing everything would pass every other case).

Mutation: removing the absent-anchor guard reds `test_a_drifted_anchor_refuses_instead_of_no_op`. The **CLI test still passes**, and that is the design rather than a weak assertion — the read-back guard catches what the first guard let through:

```
anchored-edit: REFUSED — the file is unchanged after the write
CLI rc=2
```

The two guards are independent, not redundant.

`scripts/review-checks.sh --diff` → PASS.

Stand: Echo Act IV Pro