### PR TITLE
fix(test): reap harness waits for a worker RECEIPT, not just a running marker (#3886)

### DIFF
--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -15,6 +15,10 @@ FAILURES: list[str] = []
 FAILURE_TEXT = "could not safely process"
 
 
+class ReadinessTimeout(RuntimeError):
+    """A readiness wait expired. Never swallowed: a short kill leaves a worker alive."""
+
+
 def check(name: str, cond: bool, detail: str = "") -> None:
     print(("  ok   " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
     if not cond:
@@ -127,13 +131,20 @@ class Harness:
                 pass
         return pids
 
-    def kill_workers(self, expect: "int | None" = None) -> list[int]:
+    def kill_workers(self, expect: "int | None" = None,
+                     timeout: float = 15.0) -> list[int]:
         # Derived, not passed: every `running/` marker owes a receipt, and the
         # marker is written first -- so a call site cannot under-wait by default.
         if expect is None:
             expect = max(1, len(names(self.dispatch() / "running")))
-        wait_for(lambda: len(self.worker_pids()) >= expect, 15.0)
+        ready = wait_for(lambda: len(self.worker_pids()) >= expect, timeout)
         pids = self.worker_pids()
+        if not ready or len(pids) < expect:
+            # Continuing here kills a SHORT set and leaves a worker alive, which
+            # is the failure this helper exists to prevent -- so it must not return.
+            check("kill_workers readiness", False,
+                  f"timed out: {len(pids)} receipt pid(s), expected {expect}")
+            raise ReadinessTimeout(f"{len(pids)} of {expect} receipts after {timeout}s")
         for pid in pids:
             try:
                 os.kill(pid, signal.SIGKILL)
@@ -334,13 +345,59 @@ def scenario_answer_landing_during_the_reap_stays_deliverable() -> None:
 
 
 
+def scenario_readiness_timeout_fails_loudly() -> None:
+    """Two running markers, zero receipt pids, expired wait: the helper must NOT
+    return a short set. Exercises the PRODUCTION helper, not a copy of it."""
+    print("\nscenario: a timed-out readiness wait aborts instead of killing a short set")
+    print("  (the two 'FAIL kill_workers readiness' lines below are DELIBERATE)")
+    d = Path(tempfile.mkdtemp()) / "sutando-task-dispatch.probe"
+    (d / "running").mkdir(parents=True)
+    (d / "workers").mkdir(parents=True)
+    for n in ("task-a.txt", "task-b.txt"):
+        (d / "running" / n).write_text("/nowhere")
+        (d / "workers" / n).write_text("")      # created, pid never written
+
+    class _Stub:
+        dispatch = lambda self: d
+        worker_pids = Harness.worker_pids
+        kill_workers = Harness.kill_workers
+
+    before = len(FAILURES)
+    try:
+        _Stub().kill_workers(timeout=0.5)
+        check("a timed-out readiness wait raises instead of returning", False,
+              "returned normally with a short pid set")
+    except ReadinessTimeout:
+        # check() inside the helper recorded the readiness failure; that entry is
+        # expected here, so it is removed rather than counted against the run.
+        check("a timed-out readiness wait raises instead of returning",
+              len(FAILURES) == before + 1, f"recorded {len(FAILURES) - before} failure(s)")
+        del FAILURES[before]
+
+    (d / "workers" / "task-a.txt").write_text("999999")
+    try:
+        _Stub().kill_workers(timeout=0.5)
+        check("and it still refuses when only SOME receipts are ready", False,
+              "one of two receipts was enough")
+    except ReadinessTimeout:
+        check("and it still refuses when only SOME receipts are ready", True)
+        del FAILURES[-1]
+
+
 def main() -> int:
-    scenario_slot_recovery()
-    scenario_reap_publishes_only_without_an_exact_result()
-    scenario_placeholder_never_settles_the_task_as_success()
-    scenario_whitespace_archived_result_is_not_delivered()
-    scenario_unready_destination_is_left_untouched_and_unsettled()
-    scenario_answer_landing_during_the_reap_stays_deliverable()
+    for sc in (scenario_slot_recovery,
+               scenario_reap_publishes_only_without_an_exact_result,
+               scenario_placeholder_never_settles_the_task_as_success,
+               scenario_whitespace_archived_result_is_not_delivered,
+               scenario_unready_destination_is_left_untouched_and_unsettled,
+               scenario_answer_landing_during_the_reap_stays_deliverable,
+               scenario_readiness_timeout_fails_loudly):
+        try:
+            sc()
+        except ReadinessTimeout as e:
+            # Already recorded by check(); catching keeps one scenario from
+            # hiding the verdicts of the others.
+            print(f"  (scenario {sc.__name__} aborted: {e})")
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -127,9 +127,11 @@ class Harness:
                 pass
         return pids
 
-    def kill_workers(self, expect: int = 1) -> list[int]:
-        # `running/` appears before the receipt exists and again before it holds
-        # a pid, so waiting on it alone reads a short list and kills nothing.
+    def kill_workers(self, expect: "int | None" = None) -> list[int]:
+        # Derived, not passed: every `running/` marker owes a receipt, and the
+        # marker is written first -- so a call site cannot under-wait by default.
+        if expect is None:
+            expect = max(1, len(names(self.dispatch() / "running")))
         wait_for(lambda: len(self.worker_pids()) >= expect, 15.0)
         pids = self.worker_pids()
         for pid in pids:
@@ -172,7 +174,7 @@ def scenario_slot_recovery() -> None:
             check("both worker slots filled by the startup sweep", False, str(h.dispatch()))
             return
         check("both worker slots filled by the startup sweep", True)
-        check("worker pids recorded and killed", len(h.kill_workers(expect=2)) >= 2)
+        check("worker pids recorded and killed", len(h.kill_workers()) >= 2)
         h.deliver("task-ccc.txt")
         got = wait_for(lambda: "task-ccc.txt" in names(h.dispatch() / "running"))
         d = h.dispatch()

--- a/tests/watch-tasks-stream-dead-worker-reap.test.py
+++ b/tests/watch-tasks-stream-dead-worker-reap.test.py
@@ -113,14 +113,25 @@ class Harness:
         with self.feed.open("a") as fh:
             fh.write(str(p.resolve()) + "\n")
 
-    def kill_workers(self) -> list[int]:
+    def worker_pids(self) -> list[int]:
+        """Receipts that actually carry a pid yet.
+
+        The dispatcher creates `workers/<name>` EMPTY and writes the pid only
+        after spawning, so an unreadable receipt means "not ready", not "no worker".
+        """
         pids = []
-        d = self.dispatch()
-        for r in (d / "workers").iterdir():
+        for r in (self.dispatch() / "workers").iterdir():
             try:
                 pids.append(int(r.read_text().strip()))
             except (ValueError, OSError):
                 pass
+        return pids
+
+    def kill_workers(self, expect: int = 1) -> list[int]:
+        # `running/` appears before the receipt exists and again before it holds
+        # a pid, so waiting on it alone reads a short list and kills nothing.
+        wait_for(lambda: len(self.worker_pids()) >= expect, 15.0)
+        pids = self.worker_pids()
         for pid in pids:
             try:
                 os.kill(pid, signal.SIGKILL)
@@ -161,7 +172,7 @@ def scenario_slot_recovery() -> None:
             check("both worker slots filled by the startup sweep", False, str(h.dispatch()))
             return
         check("both worker slots filled by the startup sweep", True)
-        check("worker pids recorded and killed", len(h.kill_workers()) >= 2)
+        check("worker pids recorded and killed", len(h.kill_workers(expect=2)) >= 2)
         h.deliver("task-ccc.txt")
         got = wait_for(lambda: "task-ccc.txt" in names(h.dispatch() / "running"))
         d = h.dispatch()


### PR DESCRIPTION
Closes #3886.

`tests/watch-tasks-stream-dead-worker-reap.test.py` fails intermittently **only under coverage instrumentation**, reddening `diff coverage >= 95% (python)` on PRs that never touch it. Hit live on #3881, whose diff is `src/health-check.py` only.

## The bug is in the harness, not in production

The dispatcher orders three writes (`src/watch-tasks-stream.sh:327-342`):

```
327  mv "$marker" "$running_marker"           # running/<name> exists
332  : > "$worker_receipt"                    # workers/<name> created EMPTY
342  printf '%s\n' "$!" > "$worker_receipt"   # pid written LAST
```

The scenarios waited on `running/` and then read `workers/`. Two windows sit between those: the receipt not existing yet, and existing but empty. `kill_workers()` swallowed both — `int("")` raises `ValueError`, which was caught and skipped — so it returned a short list, **killed nothing**, and no reap ran.

That explains the signature that made this look untraceable: **two different assertions fail across runs of identical code.** `worker pids recorded and killed` fails where the count is asserted; `a whitespace-only ARCHIVED result does NOT suppress the failure` fails where it isn't, because nothing was killed so nothing was published.

Production already reads that receipt defensively — the live-worker count at `:300-306` uses `2>/dev/null` and treats an unreadable receipt as "not live". This is the **test** assuming a readiness production never promises, which is why no production change is needed.

## Fix

`worker_pids()` returns only receipts that carry a pid; `kill_workers(expect=N)` waits for N of them before killing.

## Before / after — actual output, same machine, back-to-back

```
bug present (main 6c9d12323, no PR code)
    coverage run --branch    6 pass / 3 fail of 9
    coverage run --branch    5 pass / 2 fail of 7     <- control, run AFTER the fix existed
                                                         (stashed, re-run, un-stashed)
fix applied
    coverage run --branch    9 pass / 0 fail of 9
```

Failing assertions in the control batches, none after the fix:

```
FAIL a whitespace-only ARCHIVED result does NOT suppress the failure — exists=False
FAIL worker pids recorded and killed
```

Uninstrumented was **3/3 green before and after** — instrumentation widens the window, it does not create it. The second control batch was run after the fix was written and stashed, so the comparison is not against an hour-old baseline whose machine conditions may have drifted.

## Scope

One file, one concern: harness readiness. No production change, no behaviour change to what the test asserts — the same invariants are checked, against a state that is actually ready.
