### PR TITLE
feat(proactive-loop): a pre-file gate that refuses a duplicate GitHub issue

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -281,6 +281,31 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    step 3 already gives: a memory loads when RECALLED, this file loads EVERY PASS — and all nine
    happened on a night when the memory existed and was loaded.
 
+3.45. **⚠ BEFORE `gh issue create`, RUN THE DUPLICATE GATE — CHAIN IT, do not just read it.**
+   Step 3.4 guards a claim you are about to make to the owner. This is the same rule for an artifact
+   you are about to file on GitHub, and it needs its own gate because the parking files it searches
+   are not GitHub.
+
+   ```bash
+   python3 skills/proactive-loop/scripts/gh-duplicate-check.py \
+       --repo <owner/name> --title "<the title you are about to file>" \
+     && gh issue create --repo <owner/name> --title "..." --body-file <f>
+   # 0 no candidate -> the `&&` lets the create run · 1 DO NOT FILE, names the candidates
+   # 2 could not answer (search failed / no tokens / a decision parameter below 1) -> NOT a green light
+   ```
+
+   **The `&&` is the whole mechanism.** On 2026-09-04 I filed #3889 duplicating #3862 after running
+   the search in the SAME command block as the create: the answer printed, nothing consumed it, and
+   the create ran anyway. A check whose result is not the action's precondition is decoration.
+
+   It fails closed — a failed search returns "did not search", never "found nothing"; partial
+   coverage with no hits is exit 2; and `--max-queries 0` / `--min-overlap 0` are refused rather than
+   scoring a vacuous clean bill. A rc=0 still says in words that it is not proof of absence: an
+   `in:title` search cannot see a duplicate worded differently in its title.
+
+   Guarded by `tests/proactive-loop-gh-duplicate-check.test.py`, which pins THIS wiring as well as
+   the tool — an unreferenced gate runs never, which is worse than one described only in prose.
+
 3.5. **Apply the self-development policy gate.** Run:
 
    ```bash

--- a/skills/proactive-loop/scripts/gh-duplicate-check.py
+++ b/skills/proactive-loop/scripts/gh-duplicate-check.py
@@ -132,8 +132,12 @@ def main(argv=None) -> int:
 
     toks = list(tokens(None, a.title))
     for w in bare_words(a.title, stop):
-        if w not in {t.lower() for t in toks}:
-            toks.append(w)
+        low = {t.lower() for t in toks}
+        # Skip a word already CONTAINED in an entity token: `watch-tasks-stream`
+        # then `watch`/`tasks`/`stream` spends the query budget re-asking itself.
+        if w in low or any(w in t for t in low):
+            continue
+        toks.append(w)
     if not toks:
         print(f"CANNOT ANSWER: no entity tokens in {a.title!r}, so nothing would be "
               f"searched and a clean result would be produced by construction.", file=sys.stderr)
@@ -161,8 +165,12 @@ def main(argv=None) -> int:
                   key=lambda p: -p[0])
     hits = [(s, it) for s, it in hits if s >= a.min_overlap]
 
-    print(f"searched {a.repo} on {len(toks[:a.max_queries])} token(s): "
-          f"{', '.join(toks[:a.max_queries])}")
+    used, dropped = toks[:a.max_queries], toks[a.max_queries:]
+    print(f"searched {a.repo} on {len(used)} of {len(toks)} token(s): {', '.join(used)}")
+    if dropped:
+        # Naming them keeps the bound visible: a duplicate sharing ONLY a dropped
+        # token scores 0, and token order is title order, not distinctiveness.
+        print(f"  ⚠ NOT searched (--max-queries={a.max_queries}): {', '.join(dropped)}")
     if failures:
         print(f"  ⚠ {failures} query(ies) failed — coverage is partial")
     if not hits:
@@ -173,9 +181,11 @@ def main(argv=None) -> int:
                   f"and the rest matched nothing, so this is 'not fully searched', "
                   f"not 'nothing is there'.", file=sys.stderr)
             return 2
-        print("  NO CANDIDATE  — but that is 'no title matched these tokens', "
-              "not proof of absence. A duplicate worded differently in the TITLE "
-              "is invisible to an in:title search.")
+        bound = (f" and {len(dropped)} token(s) were never searched"
+                 if dropped else "")
+        print(f"  NO CANDIDATE  — but that is 'no title matched these tokens'{bound}, "
+              f"not proof of absence. A duplicate worded differently in the TITLE "
+              f"is invisible to an in:title search.")
         return 0
 
     print(f"  DO NOT FILE — {len(hits)} candidate(s) share >= {a.min_overlap} tokens:")

--- a/skills/proactive-loop/scripts/gh-duplicate-check.py
+++ b/skills/proactive-loop/scripts/gh-duplicate-check.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Refuse to file a GitHub issue that duplicates one already open.
+
+WHY: on 2026-09-04 I ran the duplicate search, its answer PRINTED the existing
+issue, and I filed anyway — the search and the `gh issue create` were in one
+command block, so nothing consumed the result. A check that does not GATE the
+action is decoration. This exits non-zero so a caller can chain on it:
+
+    python3 gh-duplicate-check.py --repo owner/name --title "..." && gh issue create ...
+
+⚠ A PHRASE search cannot find the duplicate that matters. The pair that produced
+this tool had titles sharing almost no wording: "CI: eslint job times out in npm
+ci since ..." vs "eslint: 34 of 300 runs are killed by timeout-minutes: 5". Only
+shared ENTITY tokens (`eslint`, `npm`, `timeout-minutes`) connect them, which is
+why this scores token overlap rather than matching a string.
+
+Tokenisation DELEGATES to warn-already-triaged.py so the two cannot drift; if it
+cannot be imported this refuses (exit 2) rather than falling back to a private
+copy, because a guard that tokenises differently from its sibling clears what the
+sibling would catch.
+
+exit 0 no candidate found · 1 candidate(s) found -> DO NOT FILE · 2 cannot answer
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_tokens():
+    """Borrow `tokens()` from the sibling guard. Refuse if unavailable."""
+    sib = Path(__file__).with_name("warn-already-triaged.py")
+    if not sib.is_file():
+        return None, None
+    try:
+        spec = importlib.util.spec_from_file_location("_wat", sib)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.tokens, getattr(mod, "STOP", set())
+    except Exception:
+        return None, None
+
+
+def search(repo: str, term: str, timeout: float = 25.0):
+    """One search query. Returns None on failure — never an empty list.
+
+    The distinction is load-bearing: an empty list means "searched, found
+    nothing", None means "did not search". Collapsing them is how a failed
+    fetch becomes a green light.
+    """
+    q = f"repo:{repo} in:title {term}"
+    try:
+        r = subprocess.run(
+            ["gh", "api", "-X", "GET", "search/issues",
+             "-f", f"q={q}", "-f", "per_page=20"],
+            capture_output=True, text=True, timeout=timeout)
+    except Exception:
+        return None
+    if r.returncode != 0 or not (r.stdout or "").strip():
+        return None
+    try:
+        return json.loads(r.stdout).get("items") or []
+    except Exception:
+        return None
+
+
+BARE_STOP = {
+    "the","and","for","not","but","with","from","that","this","when","then","than","only",
+    "into","over","under","after","before","since","because","while","which","what","where",
+    "runs","run","job","jobs","are","was","were","has","have","had","its","it's","one","two",
+    "all","any","its","new","old","fix","fixes","fixed","bug","issue","pr","ci","by","of","in",
+    "on","at","to","is","as","a","an","it","we","i","my","our","you","your","killed","reported",
+}
+
+
+def bare_words(title: str, stop) -> list:
+    """Bare lowercase nouns the ENTITY tokenizer cannot see.
+
+    NOT a competing tokenizer — the entity tokens still come from the sibling.
+    This ADDS the shape a GitHub title carries and a parking file does not: a
+    plain product noun (`eslint`, `npm`) matches none of backticked /
+    with-extension / hyphenated / snake_case, so the sibling returns it never.
+    Measured: the duplicate that produced this tool shared ONLY bare words with
+    its original, and the entity path alone scored it 0 and said PROCEED.
+    """
+    out = []
+    for w in re.findall(r"[A-Za-z][A-Za-z0-9]{3,}", title):
+        lw = w.lower()
+        if lw in BARE_STOP or lw in stop:
+            continue
+        out.append(lw)
+    seen, uniq = set(), []
+    for w in out:
+        if w not in seen:
+            seen.add(w); uniq.append(w)
+    return uniq
+
+
+def score(item, toks) -> int:
+    hay = ((item.get("title") or "") + " " + (item.get("body") or "")[:2000]).lower()
+    return sum(1 for t in toks if t.lower() in hay)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", required=True, help="owner/name")
+    ap.add_argument("--title", required=True, help="the title you are about to file")
+    ap.add_argument("--min-overlap", type=int, default=2,
+                    help="entity tokens shared with a candidate before it is reported")
+    ap.add_argument("--max-queries", type=int, default=4)
+    a = ap.parse_args(argv)
+
+    tokens, stop = load_tokens()
+    if tokens is None:
+        print("CANNOT ANSWER: warn-already-triaged.py is not importable, so tokenisation "
+              "would have to be re-implemented here and could drift from it.", file=sys.stderr)
+        return 2
+
+    toks = list(tokens(None, a.title))
+    for w in bare_words(a.title, stop):
+        if w not in {t.lower() for t in toks}:
+            toks.append(w)
+    if not toks:
+        print(f"CANNOT ANSWER: no entity tokens in {a.title!r}, so nothing would be "
+              f"searched and a clean result would be produced by construction.", file=sys.stderr)
+        return 2
+
+    seen, failures = {}, 0
+    for t in toks[:a.max_queries]:
+        items = search(a.repo, t)
+        if items is None:
+            failures += 1
+            continue
+        for it in items:
+            seen[it["number"]] = it
+
+    hits = sorted(((score(it, toks), it) for it in seen.values()),
+                  key=lambda p: -p[0])
+    hits = [(s, it) for s, it in hits if s >= a.min_overlap]
+
+    print(f"searched {a.repo} on {len(toks[:a.max_queries])} token(s): "
+          f"{', '.join(toks[:a.max_queries])}")
+    if failures:
+        print(f"  ⚠ {failures} query(ies) failed — coverage is partial")
+    if not hits:
+        if failures:
+            # Partial coverage cannot produce a clean bill: the queries that did
+            # not run are exactly where an unseen duplicate would be.
+            print(f"CANNOT ANSWER: {failures} of {len(toks[:a.max_queries])} queries failed "
+                  f"and the rest matched nothing, so this is 'not fully searched', "
+                  f"not 'nothing is there'.", file=sys.stderr)
+            return 2
+        print("  NO CANDIDATE  — but that is 'no title matched these tokens', "
+              "not proof of absence. A duplicate worded differently in the TITLE "
+              "is invisible to an in:title search.")
+        return 0
+
+    print(f"  DO NOT FILE — {len(hits)} candidate(s) share >= {a.min_overlap} tokens:")
+    for s, it in hits[:5]:
+        print(f"    #{it['number']} [{it['state']}] overlap={s}  {(it.get('title') or '')[:78]}")
+        print(f"       {it['html_url']}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/proactive-loop/scripts/gh-duplicate-check.py
+++ b/skills/proactive-loop/scripts/gh-duplicate-check.py
@@ -139,6 +139,15 @@ def main(argv=None) -> int:
               f"searched and a clean result would be produced by construction.", file=sys.stderr)
         return 2
 
+    # A title yielding fewer distinct tokens than the threshold makes the MAXIMUM
+    # attainable score unreachable, so rc 0 would be arithmetic, not evidence.
+    if len(toks) < a.min_overlap:
+        print(f"CANNOT ANSWER: {len(toks)} distinct token(s) in {a.title!r} but "
+              f"--min-overlap={a.min_overlap}; no candidate could reach that score, so even an "
+              f"exact duplicate would score clean. Lower --min-overlap or give a longer title.",
+              file=sys.stderr)
+        return 2
+
     seen, failures = {}, 0
     for t in toks[:a.max_queries]:
         items = search(a.repo, t)

--- a/skills/proactive-loop/scripts/gh-duplicate-check.py
+++ b/skills/proactive-loop/scripts/gh-duplicate-check.py
@@ -174,6 +174,14 @@ def main(argv=None) -> int:
     if failures:
         print(f"  ⚠ {failures} query(ies) failed — coverage is partial")
     if not hits:
+        if dropped:
+            # The unsearched remainder can hold the ONLY qualifying overlap, and rc 0
+            # chains straight into `gh issue create` — a printed warning gates nothing.
+            print(f"CANNOT ANSWER: {len(dropped)} token(s) were never searched "
+                  f"({', '.join(dropped)}) and nothing matched the {len(used)} that were. "
+                  f"A duplicate sharing only a dropped token is invisible here. "
+                  f"Re-run with --max-queries {len(toks)}.", file=sys.stderr)
+            return 2
         if failures:
             # Partial coverage cannot produce a clean bill: the queries that did
             # not run are exactly where an unseen duplicate would be.

--- a/skills/proactive-loop/scripts/gh-duplicate-check.py
+++ b/skills/proactive-loop/scripts/gh-duplicate-check.py
@@ -116,6 +116,14 @@ def main(argv=None) -> int:
     ap.add_argument("--max-queries", type=int, default=4)
     a = ap.parse_args(argv)
 
+    # A decision parameter that can silence the search makes the gate fail OPEN
+    # by construction -- `--max-queries 0` scored NO CANDIDATE, rc 0 (found in review).
+    if a.max_queries < 1 or a.min_overlap < 1:
+        print(f"CANNOT ANSWER: --max-queries={a.max_queries} --min-overlap={a.min_overlap}; "
+              f"either below 1 makes a clean result arithmetic rather than evidence.",
+              file=sys.stderr)
+        return 2
+
     tokens, stop = load_tokens()
     if tokens is None:
         print("CANNOT ANSWER: warn-already-triaged.py is not importable, so tokenisation "

--- a/tests/proactive-loop-gh-duplicate-check.test.py
+++ b/tests/proactive-loop-gh-duplicate-check.test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Contract for gh-duplicate-check.py.
+
+Built after filing a duplicate issue whose original my own search had PRINTED:
+the search and the `gh issue create` sat in one command block, so nothing
+consumed the result. The gate therefore has to EXIT non-zero, not print.
+
+The discriminating test is `bare-word only`: the real pair shared no entity
+tokens at all, and the first build of this tool — delegating tokenisation to
+warn-already-triaged.py alone — returned PROCEED on it.
+"""
+
+import importlib.util
+import io
+import contextlib
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "proactive-loop" / "scripts"
+_s = importlib.util.spec_from_file_location("ghd", str(SCRIPTS / "gh-duplicate-check.py"))
+ghd = importlib.util.module_from_spec(_s)
+_s.loader.exec_module(ghd)
+
+REAL = ("eslint: 34 of 300 runs (11%) are killed by timeout-minutes: 5, and the "
+        "variance is npm ci (24s vs 274s), not the lint (constant 6s)")
+ORIG = {"number": 3862, "state": "open", "html_url": "u",
+        "title": "CI: eslint job times out in npm ci since 2026-09-03T22:37Z — 12 of "
+                 "last 100 runs killed at the 5-min cap, reported as 'cancelled'",
+        "body": "timeout-minutes: 5 ... npm ci ... eslint"}
+
+
+def run(argv, stub):
+    """Run main() with search stubbed. Returns (rc, stdout, stderr)."""
+    orig = ghd.search
+    ghd.search = stub
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = ghd.main(argv)
+    finally:
+        ghd.search = orig
+    return rc, out.getvalue(), err.getvalue()
+
+
+BASE = ["--repo", "o/n", "--title", REAL]
+
+
+class TheFailureThatProducedIt(unittest.TestCase):
+    def test_a_bare_word_only_duplicate_is_REFUSED(self):
+        rc, out, _ = run(BASE, lambda r, t, **k: [ORIG] if t in ("eslint", "npm") else [])
+        self.assertEqual(rc, 1, out)
+        self.assertIn("3862", out)
+        self.assertIn("DO NOT FILE", out)
+
+    def test_bare_words_are_what_make_it_fire(self):
+        # Entity tokens alone cannot see `eslint` — the shape of the original miss.
+        toks, _ = ghd.load_tokens()
+        self.assertNotIn("eslint", [t.lower() for t in toks(None, REAL)])
+        self.assertIn("eslint", ghd.bare_words(REAL, set()))
+
+
+class FailsClosed(unittest.TestCase):
+    def test_every_search_failing_is_cannot_answer_not_clean(self):
+        rc, _, err = run(BASE, lambda r, t, **k: None)
+        self.assertEqual(rc, 2)
+        self.assertIn("CANNOT ANSWER", err)
+
+    def test_partial_failure_with_no_hits_is_cannot_answer(self):
+        calls = {"n": 0}
+        def flaky(r, t, **k):
+            calls["n"] += 1
+            return None if calls["n"] % 2 else []
+        rc, _, err = run(BASE, flaky)
+        self.assertEqual(rc, 2, err)
+        self.assertIn("not fully searched", err)
+
+    def test_partial_failure_that_still_finds_one_REFUSES(self):
+        calls = {"n": 0}
+        def flaky(r, t, **k):
+            calls["n"] += 1
+            return None if calls["n"] % 2 else [ORIG]
+        rc, out, _ = run(BASE, flaky)
+        self.assertEqual(rc, 1, out)
+        self.assertIn("coverage is partial", out)
+
+    def test_a_title_with_no_tokens_is_cannot_answer(self):
+        rc, _, err = run(["--repo", "o/n", "--title", "a an it is"], lambda *a, **k: [])
+        self.assertEqual(rc, 2)
+        self.assertIn("CANNOT ANSWER", err)
+
+
+class SearchContract(unittest.TestCase):
+    def test_a_raising_fetch_returns_None_not_an_empty_list(self):
+        # Collapsing these is how a failed search becomes a green light.
+        self.assertIsNone(ghd.search("o/n", "x", timeout=0.001))
+
+    def test_a_NON_ZERO_EXIT_also_returns_None(self):
+        # The timeout test only reaches the `except` path, so it stays green
+        # when this branch -- the one a 403 rate limit takes -- is broken.
+        import subprocess as sp
+        orig = ghd.subprocess.run
+        ghd.subprocess.run = lambda *a, **k: sp.CompletedProcess(
+            a[0], 1, stdout='{"message":"API rate limit exceeded"}', stderr="")
+        try:
+            self.assertIsNone(ghd.search("o/n", "x"))
+        finally:
+            ghd.subprocess.run = orig
+
+    def test_unparseable_json_also_returns_None(self):
+        import subprocess as sp
+        orig = ghd.subprocess.run
+        ghd.subprocess.run = lambda *a, **k: sp.CompletedProcess(a[0], 0, stdout="<html>", stderr="")
+        try:
+            self.assertIsNone(ghd.search("o/n", "x"))
+        finally:
+            ghd.subprocess.run = orig
+
+
+class Scoring(unittest.TestCase):
+    def test_below_min_overlap_is_not_reported(self):
+        weak = {"number": 1, "state": "open", "html_url": "u",
+                "title": "something about eslint only", "body": ""}
+        rc, out, _ = run(BASE + ["--min-overlap", "3"], lambda r, t, **k: [weak])
+        self.assertEqual(rc, 0, out)
+        self.assertIn("NO CANDIDATE", out)
+
+    def test_clean_result_states_it_is_not_proof_of_absence(self):
+        rc, out, _ = run(BASE, lambda r, t, **k: [])
+        self.assertEqual(rc, 0)
+        self.assertIn("not proof of absence", out)
+
+    def test_candidates_are_ranked_by_overlap(self):
+        weak = {"number": 1, "state": "open", "html_url": "u",
+                "title": "eslint npm", "body": ""}
+        rc, out, _ = run(BASE, lambda r, t, **k: [weak, ORIG])
+        self.assertEqual(rc, 1)
+        self.assertLess(out.index("3862"), out.index("#1 "))
+
+
+class Delegation(unittest.TestCase):
+    def test_it_refuses_rather_than_reimplementing_the_tokenizer(self):
+        orig = ghd.load_tokens
+        ghd.load_tokens = lambda: (None, None)
+        try:
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = ghd.main(BASE)
+        finally:
+            ghd.load_tokens = orig
+        self.assertEqual(rc, 2)
+        self.assertIn("drift", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/proactive-loop-gh-duplicate-check.test.py
+++ b/tests/proactive-loop-gh-duplicate-check.test.py
@@ -124,19 +124,43 @@ class Scoring(unittest.TestCase):
         self.assertEqual(rc, 0, out)
         self.assertIn("NO CANDIDATE", out)
 
+
+    def test_a_candidate_sharing_only_a_DROPPED_token_is_not_cleared(self):
+        # qingyun-wu's control: the distinguishing overlap lies past the cap, so
+        # rc 0 would chain into `gh issue create` with the duplicate unseen.
+        title = "alpha bravo charlie delta epsilon foxtrot"
+        cand = {"number": 7, "state": "open", "html_url": "u",
+                "title": "epsilon foxtrot", "body": ""}
+        seen = {"n": 0}
+        def only_late(r, t, **k):
+            seen["n"] += 1
+            return [cand] if t in ("epsilon", "foxtrot") else []
+        rc, _, err = run(["--repo", "o/n", "--title", title], only_late)
+        self.assertEqual(rc, 2, err)
+        self.assertIn("never searched", err)
+
+    def test_raising_the_cap_finds_that_same_candidate(self):
+        title = "alpha bravo charlie delta epsilon foxtrot"
+        cand = {"number": 7, "state": "open", "html_url": "u",
+                "title": "epsilon foxtrot", "body": ""}
+        rc, out, _ = run(["--repo", "o/n", "--title", title, "--max-queries", "6"],
+                         lambda r, t, **k: [cand] if t in ("epsilon", "foxtrot") else [])
+        self.assertEqual(rc, 1, out)
+        self.assertIn("#7", out)
+
     def test_clean_result_states_it_is_not_proof_of_absence(self):
         rc, out, _ = run(BASE, lambda r, t, **k: [])
         self.assertEqual(rc, 0)
         self.assertIn("not proof of absence", out)
 
 
-    def test_a_clean_result_names_the_tokens_it_never_searched(self):
-        # The cap drops 2-8 tokens on real titles, often the most distinctive
-        # ones, so an unstated bound reads as a wider search than was run.
-        rc, out, _ = run(BASE + ["--max-queries", "1"], lambda r, t, **k: [])
-        self.assertEqual(rc, 0, out)
+    def test_the_header_names_the_tokens_it_never_searched(self):
+        # An unstated bound reads as a wider search than was run. The verdict is
+        # now rc 2 (see the dropped-token control); the header must still name them.
+        rc, out, err = run(BASE + ["--max-queries", "1"], lambda r, t, **k: [])
+        self.assertEqual(rc, 2, out)
         self.assertIn("NOT searched", out)
-        self.assertIn("never searched", out)
+        self.assertIn("never searched", err)
 
     def test_the_header_states_used_of_total(self):
         rc, out, _ = run(BASE + ["--max-queries", "1"], lambda r, t, **k: [])
@@ -206,7 +230,10 @@ class DecisionParametersCannotSilenceTheSearch(unittest.TestCase):
         self.assertEqual(rc, 1, out)
 
     def test_one_of_each_is_still_allowed(self):
-        rc, out, _ = run(BASE + ["--max-queries", "1", "--min-overlap", "1"],
+        # A title whose tokens all fit under the cap, so nothing is dropped and
+        # the genuine rc-0 path is reachable.
+        rc, out, _ = run(["--repo", "o/n", "--title", "eslint",
+                          "--max-queries", "1", "--min-overlap", "1"],
                          lambda r, t, **k: [])
         self.assertEqual(rc, 0, out)
 

--- a/tests/proactive-loop-gh-duplicate-check.test.py
+++ b/tests/proactive-loop-gh-duplicate-check.test.py
@@ -151,5 +151,45 @@ class Delegation(unittest.TestCase):
         self.assertIn("drift", err.getvalue())
 
 
+class DecisionParametersCannotSilenceTheSearch(unittest.TestCase):
+    """`--max-queries 0` ran zero searches and scored NO CANDIDATE, rc 0 (review finding)."""
+
+    def test_zero_queries_is_cannot_answer(self):
+        rc, _, err = run(BASE + ["--max-queries", "0"], lambda *a, **k: [])
+        self.assertEqual(rc, 2)
+        self.assertIn("CANNOT ANSWER", err)
+
+    def test_zero_overlap_is_cannot_answer(self):
+        rc, _, err = run(BASE + ["--min-overlap", "0"], lambda *a, **k: [])
+        self.assertEqual(rc, 2)
+        self.assertIn("CANNOT ANSWER", err)
+
+    def test_one_of_each_is_still_allowed(self):
+        rc, out, _ = run(BASE + ["--max-queries", "1", "--min-overlap", "1"],
+                         lambda r, t, **k: [])
+        self.assertEqual(rc, 0, out)
+
+
+class WiredIntoTheInstruction(unittest.TestCase):
+    """An unreferenced gate runs never — worse than one described only in prose.
+
+    The tool shipped invoked by nothing, so the workflow that filed the duplicate
+    was unchanged. These pin the wiring, not the script.
+    """
+
+    SKILL = Path(__file__).resolve().parents[1] / "skills" / "proactive-loop" / "SKILL.md"
+
+    def test_the_loop_instruction_names_the_script(self):
+        self.assertIn("gh-duplicate-check.py", self.SKILL.read_text())
+
+    def test_it_is_chained_so_the_result_gates_the_create(self):
+        # Naming the script is not enough: the `&&` is what makes the verdict a
+        # precondition rather than something printed next to the action.
+        text = self.SKILL.read_text()
+        i = text.index("gh-duplicate-check.py")
+        window = text[i:i + 700]
+        self.assertIn("&& gh issue create", window)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/proactive-loop-gh-duplicate-check.test.py
+++ b/tests/proactive-loop-gh-duplicate-check.test.py
@@ -164,6 +164,24 @@ class DecisionParametersCannotSilenceTheSearch(unittest.TestCase):
         self.assertEqual(rc, 2)
         self.assertIn("CANNOT ANSWER", err)
 
+
+    def test_an_EXACT_duplicate_is_not_cleared_by_a_short_title(self):
+        # "eslint bug" yields one token; with the default overlap of 2 no candidate
+        # can reach the threshold, so rc 0 would be arithmetic (review finding).
+        exact = {"number": 9, "state": "open", "html_url": "u",
+                 "title": "eslint bug", "body": ""}
+        rc, _, err = run(["--repo", "o/n", "--title", "eslint bug"],
+                         lambda r, t, **k: [exact])
+        self.assertEqual(rc, 2, err)
+        self.assertIn("exact duplicate would score clean", err)
+
+    def test_a_reachable_threshold_still_answers(self):
+        exact = {"number": 9, "state": "open", "html_url": "u",
+                 "title": "eslint bug", "body": ""}
+        rc, out, _ = run(["--repo", "o/n", "--title", "eslint bug", "--min-overlap", "1"],
+                         lambda r, t, **k: [exact])
+        self.assertEqual(rc, 1, out)
+
     def test_one_of_each_is_still_allowed(self):
         rc, out, _ = run(BASE + ["--max-queries", "1", "--min-overlap", "1"],
                          lambda r, t, **k: [])

--- a/tests/proactive-loop-gh-duplicate-check.test.py
+++ b/tests/proactive-loop-gh-duplicate-check.test.py
@@ -26,7 +26,7 @@ REAL = ("eslint: 34 of 300 runs (11%) are killed by timeout-minutes: 5, and the 
 ORIG = {"number": 3862, "state": "open", "html_url": "u",
         "title": "CI: eslint job times out in npm ci since 2026-09-03T22:37Z — 12 of "
                  "last 100 runs killed at the 5-min cap, reported as 'cancelled'",
-        "body": "timeout-minutes: 5 ... npm ci ... eslint"}
+        "body": "timeout-minutes: 5 ... npm ci ... eslint ... variance in install time"}
 
 
 def run(argv, stub):
@@ -129,12 +129,35 @@ class Scoring(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("not proof of absence", out)
 
+
+    def test_a_clean_result_names_the_tokens_it_never_searched(self):
+        # The cap drops 2-8 tokens on real titles, often the most distinctive
+        # ones, so an unstated bound reads as a wider search than was run.
+        rc, out, _ = run(BASE + ["--max-queries", "1"], lambda r, t, **k: [])
+        self.assertEqual(rc, 0, out)
+        self.assertIn("NOT searched", out)
+        self.assertIn("never searched", out)
+
+    def test_the_header_states_used_of_total(self):
+        rc, out, _ = run(BASE + ["--max-queries", "1"], lambda r, t, **k: [])
+        self.assertRegex(out, r"searched \S+ on 1 of \d+ token")
+
     def test_candidates_are_ranked_by_overlap(self):
+        # weak scores 2, ORIG 3 — a real gap. The old fixture tied on a phantom
+        # point: the token `lint` matching inside the word `eslint`.
         weak = {"number": 1, "state": "open", "html_url": "u",
-                "title": "eslint npm", "body": ""}
+                "title": "eslint variance", "body": ""}
         rc, out, _ = run(BASE, lambda r, t, **k: [weak, ORIG])
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc, 1, out)
         self.assertLess(out.index("3862"), out.index("#1 "))
+
+    def test_a_substring_only_match_does_not_reach_the_threshold(self):
+        # `score()` matches substrings, so a short token can hit inside a longer
+        # word; one real token plus such a hit must not clear an overlap of 2.
+        sub = {"number": 2, "state": "open", "html_url": "u",
+               "title": "eslint", "body": ""}
+        rc, out, _ = run(BASE, lambda r, t, **k: [sub])
+        self.assertEqual(rc, 0, out)
 
 
 class Delegation(unittest.TestCase):


### PR DESCRIPTION
A gate that refuses to file a GitHub issue duplicating one that already exists.

## Why it exists

I filed #3889, duplicating #3862. My own duplicate search had **printed #3862 in the same output** — the search and the `gh issue create` were in one command block, so the answer appeared and nothing consumed it. That is not "forgot to check": I checked, the answer was on screen, and the action was already committed to. **A check that does not gate the action is decoration.**

So this exits non-zero and is meant to be chained:

```
python3 gh-duplicate-check.py --repo o/n --title "..." && gh issue create ...
```

## The interesting failure: delegation was right and still insufficient

Tokenisation delegates to `warn-already-triaged.py` (and refuses, exit 2, if that is unimportable) so the two cannot drift.

**The first build then failed on the exact case it exists for**, returning `PROCEED`:

```
searched sonichi/sutando on 1 token(s): timeout-minutes
  NO CANDIDATE
rc=0
```

The entity tokenizer recognises backticked / with-extension / hyphenated / snake_case subjects, because it searches parking files full of paths. **A GitHub title carries bare product nouns**, and the real pair shared *only* those:

```
#3862  "CI: eslint job times out in npm ci since ... reported as 'cancelled'"
#3889  "eslint: 34 of 300 runs are killed by timeout-minutes: 5 ..."
```

`eslint` and `npm` match none of the entity shapes, so entity tokens alone scored 0. `bare_words()` adds that shape **alongside** the delegated tokens — a second source for a different corpus, not a competing tokenizer.

## Verified against the failure that produced it

```
$ gh-duplicate-check.py --repo sonichi/sutando --title "<the title I actually filed>"
  DO NOT FILE — candidates sharing >= 2 tokens:
    #3889 [closed] overlap=7  eslint: 34 of 300 runs (11%) are killed by timeout-minutes: 5 ...
    #3862 [open]   overlap=5  CI: eslint job times out in npm ci since 2026-09-03T22:37Z ...
    #3880 [open]   overlap=5  ci(eslint): the job cap kills npm ci, and a timeout renders as a red check
rc=1
```

It also surfaced **#3880** — an open PR fixing the same cap, which I had approved without ever connecting it to #3862.

Negative control, live: `--title "quokka telemetry for the marzipan subsystem"` → `NO CANDIDATE`, rc=0. So the tool can return both answers.

## Fails closed

- A failed search returns `None`, never `[]`. A rate-limit 403 is "did not search", not "found nothing" — collapsing those is how a failed fetch becomes a green light. (Hit live during development; the tool reported partial coverage instead of silently under-reporting.)
- Partial coverage with **no** hits is exit 2, not 0 — the queries that did not run are exactly where an unseen duplicate would be.
- A clean result says in words that it is "not proof of absence": an `in:title` search cannot see a duplicate worded differently in its title.

## Tests

13 assertions. Two mutations verified red:

| mutation | result |
|---|---|
| drop `bare_words()` (the original defect) | **3 failures** |
| a failed fetch returns `[]` instead of `None` | **initially GREEN** → 1 failure after fixing the test |

That second one is worth calling out: the existing test used a tiny timeout, so it only ever reached the `except` path and never the returncode branch a rate limit actually takes. It looked like a guard on the None-vs-`[]` distinction and was not. Added the two branch tests that make it fail.
