### PR TITLE
fix(sci): resolve a reviewer's login from the roster field, not the key

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -216,6 +216,11 @@ def _github_login(name: str, roster: dict) -> "tuple[str, str]":
     `_actor_map` exists to normalize. Follow same_actor_as to a sibling that is.
     """
     entry = (roster or {}).get(name) or {}
+    stated = entry.get("github")
+    if stated:
+        # The entry's own field outranks the key heuristic below: a roster key
+        # can collide with an unrelated real account, and that probe is silent.
+        return stated, f"roster github field -> {stated}"
     if _is_github_user(name):
         return name, "key is a login"
     sib = entry.get("same_actor_as")

--- a/tests/sci-notify-reviewers-github-field.test.py
+++ b/tests/sci-notify-reviewers-github-field.test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""_github_login must read the entry's `github` field before guessing from the key.
+
+A roster key can collide with a real, unrelated GitHub account: `rui` (key) and
+`rui` (a stranger's login) both exist, so the key heuristic silently probes the
+wrong person and reports a confident capability verdict about someone else.
+"""
+import importlib.util
+import sys
+import unittest
+import unittest.mock
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_SRC = _REPO / "skills/collaboration-intelligence/scripts/notify_reviewers.py"
+_spec = importlib.util.spec_from_file_location("nr_gh", _SRC)
+nr = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(nr)
+except SystemExit:
+    pass
+
+
+class GithubFieldOutranksTheKey(unittest.TestCase):
+    def setUp(self):
+        # Every key looks like a real account, which is exactly the collision.
+        self._p = unittest.mock.patch.object(nr, "_is_github_user", return_value=True)
+        self._p.start()
+        self.addCleanup(self._p.stop)
+
+    def test_the_stated_field_wins_over_a_colliding_key(self):
+        roster = {"rui": {"github": "john-the-dev"}}
+        login, why = nr._github_login("rui", roster)
+        self.assertEqual(login, "john-the-dev",
+                         "the key collided with a real stranger's login and won")
+        self.assertIn("github", why)
+
+    def test_the_owner_alias_resolves_too(self):
+        roster = {"chi-wang": {"github": "sonichi"}}
+        self.assertEqual(nr._github_login("chi-wang", roster)[0], "sonichi")
+
+    def test_a_key_that_equals_its_login_is_unchanged(self):
+        """Negative control: the fix must not perturb the ordinary case."""
+        roster = {"keweichen": {"github": "keweichen"}}
+        self.assertEqual(nr._github_login("keweichen", roster)[0], "keweichen")
+
+    def test_no_github_field_still_falls_back_to_the_key(self):
+        """Negative control: entries without the field keep the old behaviour."""
+        roster = {"someone": {"stand": "@s:x"}}
+        login, why = nr._github_login("someone", roster)
+        self.assertEqual(login, "someone")
+        self.assertEqual(why, "key is a login")
+
+    def test_an_absent_entry_does_not_raise(self):
+        self.assertEqual(nr._github_login("ghost", {})[0], "ghost")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`_github_login` in `notify_reviewers.py` asks *"is the roster KEY itself a GitHub login?"* before anything else, and never reads the entry's own `github` field. A roster key can collide with a real, unrelated GitHub account — and then every downstream capability probe answers about a stranger.

## Before / after, measured on this host's live roster

```
key        origin/main          HEAD
rui        rui (a stranger)     john-the-dev   <- the actual reviewer
chi-wang   chi-wang             sonichi        <- the owner
keweichen  keweichen            keweichen      (unchanged — negative control)
someone    someone              someone        (no github field — fallback intact)
```

Both affected keys resolve to **real accounts that are not the reviewer**:

```
$ gh api users/rui -q .login          -> rui            (exists, unrelated person)
$ gh api users/john-the-dev -q .login -> john-the-dev
```

Because `rui` exists, `_is_github_user("rui")` is TRUE and the resolver stops with reason `key is a login`. That is what makes it silent — not a 404 falling through to a fallback, but a confident hit on the wrong person.

## What it cost, observed live

Asking for a second approval on #3885, the tool printed:

```
CANNOT GATE 'rui': not a collaborator on sonichi/sutando — an approval from
this account does not count toward the required approvals
```

and **refused the send**. The real login holds write access:

```
$ gh api repos/sonichi/sutando/collaborators/john-the-dev/permission -> write
```

So a reachable reviewer read as unreachable, and the notification contract went unmet with no error. Only two roster entries are affected today, but one of them is the owner's own alias.

## The change

Consult `entry["github"]` first; keep the key heuristic as the fallback for entries that carry no field. The field is explicit and owner-stated; the key check is a guess, and a guess that can hit a stranger should not outrank a stated fact.

## Evidence

```
new suite:  revert the fix -> FAILED (failures=2);  restore -> 5 pass
existing:   7/7 notify-reviewers suites green before AND after
review-checks: hardcoded-paths + root-artifacts + prose-cap clean
```

The suite includes two negative controls — a key that equals its login, and an entry with no `github` field — so the fix cannot pass by rewriting every lookup.

Stand: Echo Act IV Pro