### PR TITLE
feat(health-check): a vendored resolver that still honours a removed env var

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9259,8 +9259,14 @@ def check_vendored_resolver_env(workspace_dir: "Path | None" = None) -> "dict | 
             if ".git" in f.parts or f.resolve() == canonical:
                 continue
             copies.append(f)
+    roots_seen = [str(r) for r in roots if r.is_dir()]
     if not copies:
-        return None                       # nothing vendored here; not a finding
+        # NOT None. A silent absence cannot be told from a scan that looked in the
+        # wrong place — the vacuous-green shape this probe exists to catch.
+        return {"name": name, "status": "ok",
+                "detail": f"no vendored workspace_default under {len(roots_seen)} "
+                          f"root(s) ({', '.join(roots_seen) or 'none present'}) — "
+                          "zero copies scanned, so this is coverage, not a clean bill"}
     bogus = "/tmp/sutando-healthcheck-not-the-workspace"
     probe_src = ("import sys; sys.path.insert(0, %r)\n"
                  "from workspace_default import resolve_workspace\n"

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9302,6 +9302,33 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                     return True
         return False
 
+    def murky_env_read(node) -> "str | None":
+        """An environment read whose KEY this analysis did not resolve.
+
+        reads_env() recognizes a literal key only, so `os.getenv(KEY)` would
+        otherwise register as no env read at all — a clean bill for a resolver
+        that still returns the removed variable."""
+        for n in ast.walk(node):
+            if isinstance(n, ast.Subscript):
+                base = _dots(n.value)
+                if not (base.endswith("environ") or base in aliases):
+                    continue
+                key = n.slice
+            elif isinstance(n, ast.Call):
+                d = _dots(n.func)
+                head, _, attr = d.rpartition(".")
+                if not (d.endswith("environ.get") or d.endswith("getenv")
+                        or (attr == "get" and head in aliases)):
+                    continue
+                if not n.args:
+                    return "an environment read with no key argument"
+                key = n.args[0]
+            else:
+                continue
+            if _const_str(key) is None:
+                return "an environment read whose key is not a literal"
+        return None
+
     def unresolved_call(node) -> "str | None":
         """Name the first call whose result this analysis cannot account for.
 
@@ -9320,7 +9347,7 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
             sib = sibling(d)
             if _hops > 0 and sib is not None and sib[1].name == "resolve_workspace":
                 continue                         # same-name delegate: analysed below
-            return d or "<expr>"
+            return f"{d}()" if d else "<expr>"
         return None
 
     def verdict(node, seen: frozenset) -> "tuple[str, str] | None":
@@ -9328,23 +9355,20 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
         if node.name in seen:
             return None                          # recursion guard
         seen = seen | {node.name}
+        binds = [pair for tgt, val in _bind_sites(node)
+                 for pair in _binding_pairs(tgt, val)]
         tainted, murky, changed = set(), {}, True
         while changed:                           # two fixpoints, one walk
             changed = False
-            for n in ast.walk(node):
-                if not (isinstance(n, (ast.Assign, ast.AnnAssign)) and n.value is not None):
-                    continue
-                names = [x.id for x in ast.walk(n.value) if isinstance(x, ast.Name)]
-                env = reads_env(n.value) or any(x in tainted for x in names)
-                unk = unresolved_call(n.value) or next(
-                    (murky[x] for x in names if x in murky), None)
-                for t in (n.targets if isinstance(n, ast.Assign) else [n.target]):
-                    if not isinstance(t, ast.Name):
-                        continue
-                    if env and t.id not in tainted:
-                        tainted.add(t.id); changed = True
-                    if unk and t.id not in murky:
-                        murky[t.id] = unk; changed = True
+            for name, val in binds:
+                names = [x.id for x in ast.walk(val) if isinstance(x, ast.Name)]
+                env = reads_env(val) or any(x in tainted for x in names)
+                unk = (unresolved_call(val) or murky_env_read(val)
+                       or next((murky[x] for x in names if x in murky), None))
+                if env and name not in tainted:
+                    tainted.add(name); changed = True
+                if unk and name not in murky:
+                    murky[name] = unk; changed = True
         for n in ast.walk(node):
             if not (isinstance(n, ast.Return) and n.value is not None):
                 continue
@@ -9370,17 +9394,65 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                     if sub != "ignores":
                         return sub, (f"{node.name}() delegates to {d}(), which is "
                                      f"{sub}")
-            bad = unresolved_call(n.value) or next(
-                (murky[x] for x in names if x in murky), None)
+            bad = (unresolved_call(n.value) or murky_env_read(n.value)
+                   or next((murky[x] for x in names if x in murky), None))
             if bad is not None:
                 return "unknown", (f"a return in {node.name}() flows through "
-                                   f"{bad}(), which this analysis cannot resolve")
+                                   f"{bad}, which this analysis cannot resolve")
         return None
 
     found = verdict(fn, frozenset())
     if found is not None:
         return found
     return "ignores", "no return derives from $SUTANDO_WORKSPACE"
+
+
+def _bind_sites(node):
+    """(target, value) for every name-binding form in a function body.
+
+    Enumerated rather than matched statement by statement: a binding form the
+    taint pass does not model leaves its names untainted, which reads as clean.
+    """
+    for n in ast.walk(node):
+        if isinstance(n, ast.Assign):
+            for t in n.targets:
+                yield t, n.value
+        elif isinstance(n, (ast.AnnAssign, ast.AugAssign)):
+            if n.value is not None:
+                yield n.target, n.value
+        elif isinstance(n, ast.NamedExpr):
+            yield n.target, n.value
+        elif isinstance(n, (ast.For, ast.AsyncFor)):
+            yield n.target, n.iter
+        elif isinstance(n, (ast.With, ast.AsyncWith)):
+            for item in n.items:
+                if item.optional_vars is not None:
+                    yield item.optional_vars, item.context_expr
+        elif isinstance(n, (ast.ListComp, ast.SetComp,
+                            ast.DictComp, ast.GeneratorExp)):
+            for g in n.generators:
+                yield g.target, g.iter
+
+
+def _binding_pairs(target, value):
+    """(name, value-node) for one binding.
+
+    A tuple target pairs element-wise with a tuple value of equal length; every
+    other shape binds the WHOLE value, which over-taints rather than under-taints.
+    """
+    if isinstance(target, ast.Name):
+        return [(target.id, value)]
+    if isinstance(target, ast.Starred):
+        return _binding_pairs(target.value, value)
+    if isinstance(target, (ast.Tuple, ast.List)):
+        elts = target.elts
+        if (isinstance(value, (ast.Tuple, ast.List))
+                and len(value.elts) == len(elts)
+                and not any(isinstance(e, ast.Starred) for e in elts + value.elts)):
+            return [pair for t, v in zip(elts, value.elts)
+                    for pair in _binding_pairs(t, v)]
+        return [pair for t in elts for pair in _binding_pairs(t, value)]
+    return [(x.id, value) for x in ast.walk(target) if isinstance(x, ast.Name)]
 
 
 def _dots(node) -> str:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9251,7 +9251,7 @@ def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
         return "unknown", "no resolve_workspace() to analyse"
 
     def reads_env(node) -> bool:
-        """os.environ.get("SUTANDO_WORKSPACE") or os.environ["SUTANDO_WORKSPACE"]."""
+        """An environ subscript or .get keyed by the removed workspace env var."""
         for n in ast.walk(node):
             if isinstance(n, ast.Subscript) and _dots(n.value).endswith("environ"):
                 if _const_str(n.slice) == "SUTANDO_WORKSPACE":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9354,15 +9354,22 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     # it holds; only these four sets carry a followed origin.
     proven = os_names | getenv_names | environ_names | expandvars_names
 
-    def _callee_bases(expr) -> set:
-        """Head name of every callee in expr — unresolved_call() already judged
-        these, so the import merely names a module it followed."""
+    def _callee_base_nodes(expr) -> set:
+        """id() of the Name NODE at the base of each callee chain.
+
+        Node-specific, not name-wide: `helper.resolve_workspace()` follows the
+        call while `helper.WORKSPACE` two characters away is an opaque value,
+        and exempting the NAME exempts both.
+        """
         out = set()
         for c in ast.walk(expr):
-            if isinstance(c, ast.Call):
-                d = _dots(c.func)
-                if d:
-                    out.add(d.split(".")[0])
+            if not isinstance(c, ast.Call):
+                continue
+            f = c.func
+            while isinstance(f, ast.Attribute):
+                f = f.value
+            if isinstance(f, ast.Name):
+                out.add(id(f))
         return out
 
     def _keyed(node) -> bool:
@@ -9497,11 +9504,13 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
         def opaque_import(expr) -> "str | None":
             """An imported name read as a VALUE. Same edge as an unresolved call,
             so it must run in the fixpoint too: one local hop hides it otherwise."""
-            bases = _callee_bases(expr)
-            for x in (n.id for n in ast.walk(expr) if isinstance(n, ast.Name)):
+            callee = _callee_base_nodes(expr)
+            for n in ast.walk(expr):
+                if not isinstance(n, ast.Name) or id(n) in callee:
+                    continue
+                x = n.id
                 if (x in imported and x not in proven and x not in bound
-                        and x not in modfns and x not in _RESOLVED_CALLS
-                        and x not in bases):
+                        and x not in modfns and x not in _RESOLVED_CALLS):
                     return f"the imported value {x}"
             return None
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9233,52 +9233,106 @@ def _file_digest(path: Path) -> str:
         return f"<unreadable:{path}>"
 
 
+# The workspace env var retired in v0.8 (#1440). A vendored resolver that still
+# reads it resolves a path nothing else agrees with.
+_REMOVED_WS_ENV = "SUTANDO_WORKSPACE"
+# Callees whose result cannot smuggle an env read past the analysis: pure
+# constructors over arguments this pass already walks.
+_RESOLVED_CALLS = frozenset({"Path", "str", "expanduser", "resolve", "home"})
+
+
 def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
     """(verdict, why) for one workspace_default copy, WITHOUT importing it.
 
     Verdicts: "honours" / "ignores" / "unknown". Static because detection must not
-    execute discovered source — a subprocess is failure isolation, not a security
-    boundary, and any checked-out skill could run import-time code otherwise.
+    execute discovered source. "ignores" is asserted only for dataflow this
+    analysis fully resolved; an unresolved call or alias is "unknown", never clean.
     """
     try:
         tree = ast.parse(path.read_text())
     except Exception as e:                       # noqa: BLE001 — unparseable is UNKNOWN
         return "unknown", f"could not parse: {str(e)[:60]}"
-    fn = next((n for n in ast.walk(tree)
-               if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
-               and n.name == "resolve_workspace"), None)
+    modfns = {n.name: n for n in ast.walk(tree)
+              if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    fn = modfns.get("resolve_workspace")
     if fn is None:
         return "unknown", "no resolve_workspace() to analyse"
 
+    # Names bound to the environ mapping itself (env = os.environ), so a .get on
+    # the alias is the same read as a .get on os.environ.
+    aliases = {t.id for n in ast.walk(tree)
+               if isinstance(n, ast.Assign) and _dots(n.value).endswith("environ")
+               for t in n.targets if isinstance(t, ast.Name)}
+
+    def _keyed(node) -> bool:
+        return _const_str(node) == _REMOVED_WS_ENV
+
     def reads_env(node) -> bool:
-        """An environ subscript or .get keyed by the removed workspace env var."""
+        """Any supported spelling of a read keyed by the removed env var."""
         for n in ast.walk(node):
-            if isinstance(n, ast.Subscript) and _dots(n.value).endswith("environ"):
-                if _const_str(n.slice) == "SUTANDO_WORKSPACE":
+            if isinstance(n, ast.Subscript):
+                base = _dots(n.value)
+                if (base.endswith("environ") or base in aliases) and _keyed(n.slice):
                     return True
-            if isinstance(n, ast.Call) and _dots(n.func).endswith("environ.get"):
-                if n.args and _const_str(n.args[0]) == "SUTANDO_WORKSPACE":
+            if isinstance(n, ast.Call):
+                d = _dots(n.func)
+                head, _, attr = d.rpartition(".")
+                hit = (d.endswith("environ.get") or d.endswith("getenv")
+                       or (attr == "get" and head in aliases))
+                if hit and n.args and _keyed(n.args[0]):
                     return True
         return False
 
-    tainted, changed = set(), True
-    while changed:                               # tiny fixpoint over local aliases
-        changed = False
-        for n in ast.walk(fn):
-            if isinstance(n, (ast.Assign, ast.AnnAssign)) and n.value is not None:
-                src = reads_env(n.value) or any(
-                    isinstance(x, ast.Name) and x.id in tainted
-                    for x in ast.walk(n.value))
-                if not src:
-                    continue
-                for t in (n.targets if isinstance(n, ast.Assign) else [n.target]):
-                    if isinstance(t, ast.Name) and t.id not in tainted:
-                        tainted.add(t.id); changed = True
-    for n in ast.walk(fn):
-        if isinstance(n, ast.Return) and n.value is not None:
+    def opaque_call(node) -> "str | None":
+        """Name a call whose result this analysis cannot account for."""
+        for n in ast.walk(node):
+            if not isinstance(n, ast.Call):
+                continue
+            d = _dots(n.func)
+            if d in modfns or d in _RESOLVED_CALLS or d.startswith("os.path."):
+                continue
+            if "." not in d and d not in modfns:
+                return d or "<expr>"
+        return None
+
+    def verdict(node, seen: frozenset) -> "tuple[str, str] | None":
+        """honours/unknown for one function; None means nothing found here."""
+        if node.name in seen:
+            return None                          # recursion guard
+        seen = seen | {node.name}
+        tainted, changed = set(), True
+        while changed:                           # tiny fixpoint over local aliases
+            changed = False
+            for n in ast.walk(node):
+                if isinstance(n, (ast.Assign, ast.AnnAssign)) and n.value is not None:
+                    if not (reads_env(n.value) or any(
+                            isinstance(x, ast.Name) and x.id in tainted
+                            for x in ast.walk(n.value))):
+                        continue
+                    for t in (n.targets if isinstance(n, ast.Assign) else [n.target]):
+                        if isinstance(t, ast.Name) and t.id not in tainted:
+                            tainted.add(t.id); changed = True
+        for n in ast.walk(node):
+            if not (isinstance(n, ast.Return) and n.value is not None):
+                continue
             if reads_env(n.value) or any(isinstance(x, ast.Name) and x.id in tainted
                                          for x in ast.walk(n.value)):
-                return "honours", f"a return in resolve_workspace() derives from the env (line {n.lineno})"
+                return "honours", (f"a return in {node.name}() derives from the env "
+                                   f"(line {n.lineno})")
+            for c in ast.walk(n.value):          # follow calls into this module
+                if isinstance(c, ast.Call) and _dots(c.func) in modfns:
+                    deeper = verdict(modfns[_dots(c.func)], seen)
+                    if deeper is not None:
+                        return deeper
+            bad = opaque_call(n.value)
+            if bad is not None:
+                return "unknown", (f"a return in {node.name}() flows through "
+                                   f"{bad}(), which this analysis cannot resolve")
+        return None
+
+    found = verdict(fn, frozenset())
+    if found is not None:
+        return found
     return "ignores", "no return derives from $SUTANDO_WORKSPACE"
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9493,6 +9493,18 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
             else:
                 binds.append((nm, dflt))
         bound = {nm for nm, _ in binds} | set(murky)
+
+        def opaque_import(expr) -> "str | None":
+            """An imported name read as a VALUE. Same edge as an unresolved call,
+            so it must run in the fixpoint too: one local hop hides it otherwise."""
+            bases = _callee_bases(expr)
+            for x in (n.id for n in ast.walk(expr) if isinstance(n, ast.Name)):
+                if (x in imported and x not in proven and x not in bound
+                        and x not in modfns and x not in _RESOLVED_CALLS
+                        and x not in bases):
+                    return f"the imported value {x}"
+            return None
+
         changed = True
         while changed:                           # two fixpoints, one walk
             changed = False
@@ -9502,6 +9514,7 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                 env = (reads_env(val) or any(x in tainted for x in names)
                        or (dv is not None and dv[0] == "honours"))
                 unk = (unresolved_call(val) or murky_env_read(val)
+                       or opaque_import(val)
                        or next((murky[x] for x in names if x in murky), None)
                        or (dv[1] if dv is not None and dv[0] == "unknown" else None))
                 if env and name not in tainted:
@@ -9524,11 +9537,7 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                 return dv
             bad = (unresolved_call(n.value) or murky_env_read(n.value)
                    or next((murky[x] for x in names if x in murky), None)
-                   or next((f"the imported value {x}" for x in names
-                            if x in imported and x not in proven
-                            and x not in bound and x not in modfns
-                            and x not in _RESOLVED_CALLS
-                            and x not in _callee_bases(n.value)), None)
+                   or opaque_import(n.value)
                    or next((f"the unbound name {x}" for x in names
                             if x not in bound and x not in imported
                             and x not in modfns and x not in _RESOLVED_CALLS

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9240,6 +9240,13 @@ _REMOVED_WS_ENV = "SUTANDO_WORKSPACE"
 # constructors over arguments this pass already walks.
 _RESOLVED_CALLS = frozenset({"Path", "str", "expanduser", "resolve", "home"})
 _BUILTIN_NAMES = frozenset(dir(__import__("builtins")))
+# os.path member-by-member, not namespace-wide: expandvars() reads the environment,
+# and an unlisted member is unknown rather than assumed pure.
+_PURE_OSPATH = frozenset({"join", "dirname", "basename", "abspath", "normpath",
+                          "realpath", "split", "splitext", "isabs", "exists",
+                          "isfile", "isdir", "relpath", "expanduser"})
+_EXPANDVARS = ("os.path.expandvars", "expandvars", "posixpath.expandvars")
+_VAR_RE = re.compile(r"\$(\w+)|\$\{(\w+)\}")
 
 
 def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
@@ -9300,9 +9307,23 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     def _keyed(node) -> bool:
         return _const_str(node) == _REMOVED_WS_ENV
 
+    def _expandvars_names(n) -> "frozenset | None":
+        """Variables an expandvars() call expands, or None if unprovable."""
+        d = _dots(n.func)
+        if d not in _EXPANDVARS or not n.args:
+            return None
+        lit = _const_str(n.args[0])
+        if lit is None:
+            return frozenset()                   # unresolved argument: caller decides
+        return frozenset(a or b for a, b in _VAR_RE.findall(lit))
+
     def reads_env(node) -> bool:
         """Any supported spelling of a read keyed by the removed env var."""
         for n in ast.walk(node):
+            if isinstance(n, ast.Call):
+                names = _expandvars_names(n)
+                if names and _REMOVED_WS_ENV in names:
+                    return True
             if isinstance(n, ast.Subscript):
                 base = _dots(n.value)
                 if (base.endswith("environ") or base in aliases) and _keyed(n.slice):
@@ -9317,6 +9338,13 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
         return False
 
     def murky_env_read(node) -> "str | None":
+        for n in ast.walk(node):
+            if isinstance(n, ast.Call) and _dots(n.func) in _EXPANDVARS:
+                if _expandvars_names(n) == frozenset():
+                    return "an expandvars() whose argument is not a literal"
+        return _murky_env_read_keys(node)
+
+    def _murky_env_read_keys(node) -> "str | None":
         """An environment read whose KEY this analysis did not resolve.
 
         reads_env() recognizes a literal key only, so `os.getenv(KEY)` would
@@ -9354,9 +9382,12 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
             if not isinstance(n, ast.Call):
                 continue
             d = _dots(n.func)
-            if d in modfns or d in _RESOLVED_CALLS or d.startswith("os.path."):
+            if d in modfns or d in _RESOLVED_CALLS:
                 continue
-            if d.endswith(".environ.get") or d.endswith("getenv"):
+            if d.startswith("os.path.") and d.rpartition(".")[2] in _PURE_OSPATH:
+                continue
+            if (d.endswith(".environ.get") or d.endswith("getenv")
+                    or d in _EXPANDVARS):
                 continue                         # an env read: reads_env judges it
             sib = sibling(d)
             if _hops > 0 and sib is not None and sib[1].name == "resolve_workspace":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9302,6 +9302,27 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                 elif al.name == "expandvars":
                     expandvars_names.add(bound)
 
+    # A trusted name that is REBOUND anywhere is no longer proven: `import os,
+    # helper; os = helper` and a second `from helper import getenv` both do it.
+    bound_counts: "dict[str, int]" = {}
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            for al in n.names:
+                nm = al.asname or al.name.split(".")[0]
+                bound_counts[nm] = bound_counts.get(nm, 0) + 1
+        elif isinstance(n, ast.ImportFrom):
+            for al in n.names:
+                nm = al.asname or al.name
+                bound_counts[nm] = bound_counts.get(nm, 0) + 1
+    for tgt, _val in _bind_sites(tree):
+        for nm, _v in _binding_pairs(tgt, _val):
+            bound_counts[nm] = bound_counts.get(nm, 0) + 1
+    rebound = {nm for nm, c in bound_counts.items() if c > 1}
+    os_names -= rebound
+    getenv_names -= rebound
+    environ_names -= rebound
+    expandvars_names -= rebound
+
     # env = os.environ: a .get on the alias is the same read, but only when the
     # base is a name proven to be os. Collected through the taint pass's own model.
     aliases = {nm for tgt, val in _bind_sites(tree)
@@ -9382,9 +9403,9 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
             if isinstance(n, ast.Subscript):
                 base = _dots(n.value)
                 if not _is_environ_base(base):
-                    # A subscript on an imported module's attribute is arbitrary
-                    # code, and no Call node exists for unresolved_call to catch.
-                    if "." in base and base.split(".")[0] in imported:
+                    # A subscript on imported-but-unproven code, dotted or bare;
+                    # no Call node exists for unresolved_call to catch either one.
+                    if base.split(".")[0] in imported:
                         return f"a subscript on the unresolved {base}"
                     continue
                 key = n.slice

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9245,7 +9245,6 @@ _BUILTIN_NAMES = frozenset(dir(__import__("builtins")))
 _PURE_OSPATH = frozenset({"join", "dirname", "basename", "abspath", "normpath",
                           "realpath", "split", "splitext", "isabs", "exists",
                           "isfile", "isdir", "relpath", "expanduser"})
-_EXPANDVARS = ("os.path.expandvars", "expandvars", "posixpath.expandvars")
 _VAR_RE = re.compile(r"\$(\w+)|\$\{(\w+)\}")
 
 
@@ -9285,11 +9284,44 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     if fn is None:
         return "unknown", "no resolve_workspace() to analyse"
 
-    # env = os.environ: a .get on the alias is the same read. Collected through
-    # the same binding model the taint pass uses, so the two cannot drift.
+    # Which names PROVABLY are os and its members. A suffix test cannot tell
+    # os.getenv from helper.getenv, and the second is arbitrary code.
+    os_names, getenv_names, environ_names, expandvars_names = set(), set(), set(), set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            for al in n.names:
+                if al.name == "os":
+                    os_names.add(al.asname or "os")
+        elif isinstance(n, ast.ImportFrom) and n.module in ("os", "posixpath", "os.path"):
+            for al in n.names:
+                bound = al.asname or al.name
+                if al.name == "getenv" and n.module == "os":
+                    getenv_names.add(bound)
+                elif al.name == "environ" and n.module == "os":
+                    environ_names.add(bound)
+                elif al.name == "expandvars":
+                    expandvars_names.add(bound)
+
+    # env = os.environ: a .get on the alias is the same read, but only when the
+    # base is a name proven to be os. Collected through the taint pass's own model.
     aliases = {nm for tgt, val in _bind_sites(tree)
                for nm, v in _binding_pairs(tgt, val)
-               if _dots(v).endswith("environ")}
+               if _dots(v) in {f"{o}.environ" for o in os_names}}
+    aliases |= environ_names
+
+    def _is_getenv(d: str) -> bool:
+        return d in getenv_names or d in {f"{o}.getenv" for o in os_names}
+
+    def _is_environ_get(d: str) -> bool:
+        head, _, attr = d.rpartition(".")
+        return attr == "get" and (head in aliases
+                                  or head in {f"{o}.environ" for o in os_names})
+
+    def _is_environ_base(base: str) -> bool:
+        return base in aliases or base in {f"{o}.environ" for o in os_names}
+
+    def _is_expandvars(d: str) -> bool:
+        return d in expandvars_names or d in {f"{o}.path.expandvars" for o in os_names}
 
     # Module scope is where a name can be bound once and read by every function
     # below it, and a body-scoped walk cannot see any of it.
@@ -9310,7 +9342,7 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     def _expandvars_names(n) -> "frozenset | None":
         """Variables an expandvars() call expands, or None if unprovable."""
         d = _dots(n.func)
-        if d not in _EXPANDVARS or not n.args:
+        if not _is_expandvars(d) or not n.args:
             return None
         lit = _const_str(n.args[0])
         if lit is None:
@@ -9325,21 +9357,17 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                 if names and _REMOVED_WS_ENV in names:
                     return True
             if isinstance(n, ast.Subscript):
-                base = _dots(n.value)
-                if (base.endswith("environ") or base in aliases) and _keyed(n.slice):
+                if _is_environ_base(_dots(n.value)) and _keyed(n.slice):
                     return True
             if isinstance(n, ast.Call):
                 d = _dots(n.func)
-                head, _, attr = d.rpartition(".")
-                hit = (d.endswith("environ.get") or d.endswith("getenv")
-                       or (attr == "get" and head in aliases))
-                if hit and n.args and _keyed(n.args[0]):
+                if (_is_getenv(d) or _is_environ_get(d)) and n.args and _keyed(n.args[0]):
                     return True
         return False
 
     def murky_env_read(node) -> "str | None":
         for n in ast.walk(node):
-            if isinstance(n, ast.Call) and _dots(n.func) in _EXPANDVARS:
+            if isinstance(n, ast.Call) and _is_expandvars(_dots(n.func)):
                 if _expandvars_names(n) == frozenset():
                     return "an expandvars() whose argument is not a literal"
         return _murky_env_read_keys(node)
@@ -9353,14 +9381,16 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
         for n in ast.walk(node):
             if isinstance(n, ast.Subscript):
                 base = _dots(n.value)
-                if not (base.endswith("environ") or base in aliases):
+                if not _is_environ_base(base):
+                    # A subscript on an imported module's attribute is arbitrary
+                    # code, and no Call node exists for unresolved_call to catch.
+                    if "." in base and base.split(".")[0] in imported:
+                        return f"a subscript on the unresolved {base}"
                     continue
                 key = n.slice
             elif isinstance(n, ast.Call):
                 d = _dots(n.func)
-                head, _, attr = d.rpartition(".")
-                if not (d.endswith("environ.get") or d.endswith("getenv")
-                        or (attr == "get" and head in aliases)):
+                if not (_is_getenv(d) or _is_environ_get(d)):
                     continue
                 if not n.args:
                     return "an environment read with no key argument"
@@ -9386,9 +9416,8 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                 continue
             if d.startswith("os.path.") and d.rpartition(".")[2] in _PURE_OSPATH:
                 continue
-            if (d.endswith(".environ.get") or d.endswith("getenv")
-                    or d in _EXPANDVARS):
-                continue                         # an env read: reads_env judges it
+            if _is_getenv(d) or _is_environ_get(d) or _is_expandvars(d):
+                continue                         # a PROVEN env read: reads_env judges it
             sib = sibling(d)
             if _hops > 0 and sib is not None and sib[1].name == "resolve_workspace":
                 continue                         # same-name delegate: analysed below

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9286,39 +9286,29 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     if fn is None:
         return "unknown", "no resolve_workspace() to analyse"
 
-    # Which names PROVABLY are os and its members. A suffix test cannot tell
-    # os.getenv from helper.getenv, and the second is arbitrary code.
-    os_names, getenv_names, environ_names, expandvars_names = set(), set(), set(), set()
-    for n in ast.walk(tree):
-        if isinstance(n, ast.Import):
-            for al in n.names:
-                if al.name == "os":
-                    os_names.add(al.asname or "os")
-        elif isinstance(n, ast.ImportFrom) and n.module in ("os", "posixpath", "os.path"):
-            for al in n.names:
-                bound = al.asname or al.name
-                if al.name == "getenv" and n.module == "os":
-                    getenv_names.add(bound)
-                elif al.name == "environ" and n.module == "os":
-                    environ_names.add(bound)
-                elif al.name == "expandvars":
-                    expandvars_names.add(bound)
+    # Which names PROVABLY are os and its members — from ONE module-scope,
+    # origin-preserving pass, so a name cannot borrow an identity from elsewhere.
+    provable = _import_provenance(tree)
+    if provable is None:
+        return "unknown", "a star import binds names this analysis cannot enumerate"
+
+    def _only(origin) -> set:
+        # Exactly one module-scope import AND it is the origin claimed. A nested
+        # `import os` never reaches here; `import helper as os` fails the origin.
+        return {nm for nm, o in provable.items() if o == [origin]}
+
+    os_names = _only("os")
+    getenv_names = _only("os.getenv")
+    environ_names = _only("os.environ")
+    expandvars_names = (_only("os.path.expandvars") | _only("posixpath.expandvars"))
 
     # Binding revocation is delegated to CPython's OWN symbol table, not enumerated
     # here: six hand-written rounds each shipped a form the next one found.
     rebound = _rebound_names(src)
     if rebound is None:
         return "unknown", "symbol table refused this source"
-    # `ignores` is certified for a PROVEN shape and refused otherwise, rather than
-    # for anything no blacklist has caught yet — the tail is unbounded, the shape is not.
-    provable = _import_provenance(tree)
-    if provable is None:
-        return "unknown", "a star import binds names this analysis cannot enumerate"
-    # Proven == bound by exactly one MODULE-SCOPE import. A nested `import os` does
-    # not prove a module-scope name, and two bindings prove neither.
-    rebound |= {nm for nm, c in provable.items() if c != 1}
-    for s in (os_names, getenv_names, environ_names, expandvars_names):
-        rebound |= {nm for nm in s if nm not in provable}
+    # The trusted sets above are already module-scope and origin-checked, so the
+    # only thing left to revoke is a name symtable saw bound somewhere as well.
     os_names -= rebound
     getenv_names -= rebound
     environ_names -= rebound
@@ -9450,6 +9440,32 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
         """honours/unknown for one function; None means nothing found here."""
         if node.name in seen:
             return None                          # recursion guard
+
+        def delegated(expr, who):
+            """A followed callee's verdict, for ANY expression holding one.
+
+            The return path and the binding fixpoint both need this; when only
+            the return path had it, `t = sibling.resolve_workspace(); return t`
+            lost the callee's verdict — the shape the canonical wrapper uses.
+            """
+            for c in ast.walk(expr):
+                if not isinstance(c, ast.Call):
+                    continue
+                d = _dots(c.func)
+                if d in modfns:
+                    deeper = verdict(modfns[d], seen)
+                    if deeper is not None:
+                        return deeper
+                    continue
+                sib = sibling(d)
+                if sib is not None and sib[1].name == who:
+                    if _hops <= 0:               # budget spent: mutual delegates
+                        return "unknown", (f"{who}() delegates to {d}() beyond "
+                                           f"the one-hop limit")
+                    sub, _ = _resolver_env_verdict(sib[0], _hops - 1)
+                    if sub != "ignores":
+                        return sub, f"{who}() delegates to {d}(), which is {sub}"
+            return None
         seen = seen | {node.name}
         binds = list(mod_binds) + [pair for tgt, val in _bind_sites(node)
                                    for pair in _binding_pairs(tgt, val)]
@@ -9465,9 +9481,12 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
             changed = False
             for name, val in binds:
                 names = [x.id for x in ast.walk(val) if isinstance(x, ast.Name)]
-                env = reads_env(val) or any(x in tainted for x in names)
+                dv = delegated(val, node.name)
+                env = (reads_env(val) or any(x in tainted for x in names)
+                       or (dv is not None and dv[0] == "honours"))
                 unk = (unresolved_call(val) or murky_env_read(val)
-                       or next((murky[x] for x in names if x in murky), None))
+                       or next((murky[x] for x in names if x in murky), None)
+                       or (dv[1] if dv is not None and dv[0] == "unknown" else None))
                 if env and name not in tainted:
                     tainted.add(name); changed = True
                 if unk and name not in murky:
@@ -9482,21 +9501,10 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
             for c in ast.walk(n.value):          # follow calls we can read
                 if not isinstance(c, ast.Call):
                     continue
-                d = _dots(c.func)
-                if d in modfns:
-                    deeper = verdict(modfns[d], seen)
-                    if deeper is not None:
-                        return deeper
-                    continue
-                sib = sibling(d)
-                if sib is not None and sib[1].name == node.name:
-                    if _hops <= 0:               # budget spent: mutual delegates
-                        return "unknown", (f"{node.name}() delegates to {d}() beyond "
-                                           f"the one-hop limit")
-                    sub, _ = _resolver_env_verdict(sib[0], _hops - 1)
-                    if sub != "ignores":
-                        return sub, (f"{node.name}() delegates to {d}(), which is "
-                                     f"{sub}")
+                pass
+            dv = delegated(n.value, node.name)
+            if dv is not None:
+                return dv
             bad = (unresolved_call(n.value) or murky_env_read(n.value)
                    or next((murky[x] for x in names if x in murky), None)
                    or next((f"the unbound name {x}" for x in names
@@ -9550,24 +9558,23 @@ def _walk_outside_functions(node):
 
 
 def _import_provenance(tree):
-    """{name: module-scope import count}, or None if the module star-imports.
+    """{bound name: [origin, ...]} for MODULE-SCOPE imports; None on a star import.
 
-    Scoped to module level on purpose: a nested `import os` is found by a
-    file-wide walk and proves nothing about the name the resolver actually sees.
+    Origin-preserving, because a COUNT cannot certify provenance: `import helper
+    as os` and `import os` are both one module-scope import of the name `os`.
     """
-    counts = {}
+    origins: "dict[str, list]" = {}
     for n in _walk_outside_functions(tree):
         if isinstance(n, ast.Import):
             for al in n.names:
-                nm = al.asname or al.name.split(".")[0]
-                counts[nm] = counts.get(nm, 0) + 1
+                origins.setdefault(al.asname or al.name.split(".")[0], []).append(al.name)
         elif isinstance(n, ast.ImportFrom):
             for al in n.names:
                 if al.name == "*":
                     return None
                 nm = al.asname or al.name
-                counts[nm] = counts.get(nm, 0) + 1
-    return counts
+                origins.setdefault(nm, []).append(f"{n.module}.{al.name}")
+    return origins
 
 
 def _rebound_names(src):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9428,10 +9428,6 @@ def _bind_sites(node):
             for item in n.items:
                 if item.optional_vars is not None:
                     yield item.optional_vars, item.context_expr
-        elif isinstance(n, (ast.ListComp, ast.SetComp,
-                            ast.DictComp, ast.GeneratorExp)):
-            for g in n.generators:
-                yield g.target, g.iter
 
 
 def _binding_pairs(target, value):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -34,6 +34,7 @@ import shutil
 import tempfile
 import socket
 import subprocess
+import symtable
 import sys
 import time
 import urllib.request
@@ -9256,7 +9257,8 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     analysis fully resolved; an unresolved call or alias is "unknown", never clean.
     """
     try:
-        tree = ast.parse(path.read_text())
+        src = path.read_text()
+        tree = ast.parse(src)
     except Exception as e:                       # noqa: BLE001 — unparseable is UNKNOWN
         return "unknown", f"could not parse: {str(e)[:60]}"
     modfns = {n.name: n for n in ast.walk(tree)
@@ -9302,12 +9304,24 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                 elif al.name == "expandvars":
                     expandvars_names.add(bound)
 
-    # A trusted name REBOUND anywhere is no longer proven — import, assignment or
-    # parameter default alike. One enumerator: a form left out is a false clean.
-    bound_counts: "dict[str, int]" = {}
-    for nm in _all_bound_names(tree):
-        bound_counts[nm] = bound_counts.get(nm, 0) + 1
-    rebound = {nm for nm, c in bound_counts.items() if c > 1}
+    # Binding revocation is delegated to CPython's OWN symbol table, not enumerated
+    # here: six hand-written rounds each shipped a form the next one found.
+    rebound = _rebound_names(src)
+    if rebound is None:
+        return "unknown", "symbol table refused this source"
+    # symtable calls colliding imports both `imported`, neither `assigned`; unlike
+    # binding forms, imports are a CLOSED set of two node types, so this enumerates.
+    imp_counts: "dict[str, int]" = {}
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            for al in n.names:
+                nm = al.asname or al.name.split(".")[0]
+                imp_counts[nm] = imp_counts.get(nm, 0) + 1
+        elif isinstance(n, ast.ImportFrom):
+            for al in n.names:
+                nm = al.asname or al.name
+                imp_counts[nm] = imp_counts.get(nm, 0) + 1
+    rebound |= {nm for nm, c in imp_counts.items() if c > 1}
     os_names -= rebound
     getenv_names -= rebound
     environ_names -= rebound
@@ -9538,40 +9552,28 @@ def _walk_outside_functions(node):
         stack.extend(ast.iter_child_nodes(n))
 
 
-def _all_bound_names(tree):
-    """Every name bound anywhere in the module, once per binding site.
+def _rebound_names(src):
+    """Every name BOUND by something other than an import, per CPython itself.
 
-    One enumerator, so a form modelled for taint but forgotten by revocation
-    cannot leave a shadowed name certified clean. Over-counting only costs an
-    `unknown`; under-counting is the false clean this exists to prevent.
+    symtable is the language's own answer, so no binding construct can be
+    forgotten — comprehension targets, parameters, `except as`, `with as`,
+    walrus, `global`, match captures included. It builds a table; it does not
+    execute the source, which the probe's first property requires.
     """
-    for n in ast.walk(tree):
-        if isinstance(n, ast.Import):
-            for al in n.names:
-                yield al.asname or al.name.split(".")[0]
-        elif isinstance(n, ast.ImportFrom):
-            for al in n.names:
-                yield al.asname or al.name
-        elif isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            yield n.name
-            for nm, _d in _param_binds(n):
-                yield nm
-        elif isinstance(n, ast.Lambda):
-            for nm, _d in _param_binds(n):
-                yield nm
-        elif isinstance(n, ast.ClassDef):
-            yield n.name
-        elif isinstance(n, ast.ExceptHandler) and n.name:
-            yield n.name
-        elif isinstance(n, ast.Global) or isinstance(n, ast.Nonlocal):
-            for nm in n.names:
-                yield nm
-        # `match x: case os:` binds too; ast.MatchAs is 3.10+, so probe by name.
-        elif type(n).__name__ == "MatchAs" and getattr(n, "name", None):
-            yield n.name
-    for tgt, val in _bind_sites(tree):
-        for nm, _v in _binding_pairs(tgt, val):
-            yield nm
+    out = set()
+
+    def walk(tbl):
+        for s in tbl.get_symbols():
+            if s.is_assigned() or s.is_parameter():
+                out.add(s.get_name())
+        for child in tbl.get_children():
+            walk(child)
+
+    try:
+        walk(symtable.symtable(src, "<resolver>", "exec"))
+    except (SyntaxError, ValueError):
+        return None                  # unknown-by-refusal, never an empty clean set
+    return out
 
 
 def _param_binds(fn):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9254,6 +9254,25 @@ def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
         return "unknown", f"could not parse: {str(e)[:60]}"
     modfns = {n.name: n for n in ast.walk(tree)
               if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+
+    def sibling(dotted: "str"):
+        """One hop: `mod.fn` where mod.py sits beside this file. A delegate we
+        can read is analysed, not guessed at."""
+        mod, _, name = dotted.rpartition(".")
+        if not mod or "." in mod:
+            return None
+        sib = path.parent / f"{mod}.py"
+        if not sib.is_file():
+            return None
+        try:
+            sub = ast.parse(sib.read_text())
+        except Exception:                        # noqa: BLE001
+            return None
+        for n in ast.walk(sub):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name:
+                return sib, n
+        return None
+
     fn = modfns.get("resolve_workspace")
     if fn is None:
         return "unknown", "no resolve_workspace() to analyse"
@@ -9283,16 +9302,25 @@ def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
                     return True
         return False
 
-    def opaque_call(node) -> "str | None":
-        """Name a call whose result this analysis cannot account for."""
+    def unresolved_call(node) -> "str | None":
+        """Name the first call whose result this analysis cannot account for.
+
+        Bare AND dotted callees both count: `mystery()` and `config.workspace()`
+        can each return the removed value. Only module functions (followed
+        below), pure constructors, and os.path helpers are resolved.
+        """
         for n in ast.walk(node):
             if not isinstance(n, ast.Call):
                 continue
             d = _dots(n.func)
             if d in modfns or d in _RESOLVED_CALLS or d.startswith("os.path."):
                 continue
-            if "." not in d and d not in modfns:
-                return d or "<expr>"
+            if d.endswith(".environ.get") or d.endswith("getenv"):
+                continue                         # an env read: reads_env judges it
+            sib = sibling(d)
+            if sib is not None and sib[1].name == "resolve_workspace":
+                continue                         # same-name delegate: analysed below
+            return d or "<expr>"
         return None
 
     def verdict(node, seen: frozenset) -> "tuple[str, str] | None":
@@ -9300,31 +9328,47 @@ def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
         if node.name in seen:
             return None                          # recursion guard
         seen = seen | {node.name}
-        tainted, changed = set(), True
-        while changed:                           # tiny fixpoint over local aliases
+        tainted, murky, changed = set(), {}, True
+        while changed:                           # two fixpoints, one walk
             changed = False
             for n in ast.walk(node):
-                if isinstance(n, (ast.Assign, ast.AnnAssign)) and n.value is not None:
-                    if not (reads_env(n.value) or any(
-                            isinstance(x, ast.Name) and x.id in tainted
-                            for x in ast.walk(n.value))):
+                if not (isinstance(n, (ast.Assign, ast.AnnAssign)) and n.value is not None):
+                    continue
+                names = [x.id for x in ast.walk(n.value) if isinstance(x, ast.Name)]
+                env = reads_env(n.value) or any(x in tainted for x in names)
+                unk = unresolved_call(n.value) or next(
+                    (murky[x] for x in names if x in murky), None)
+                for t in (n.targets if isinstance(n, ast.Assign) else [n.target]):
+                    if not isinstance(t, ast.Name):
                         continue
-                    for t in (n.targets if isinstance(n, ast.Assign) else [n.target]):
-                        if isinstance(t, ast.Name) and t.id not in tainted:
-                            tainted.add(t.id); changed = True
+                    if env and t.id not in tainted:
+                        tainted.add(t.id); changed = True
+                    if unk and t.id not in murky:
+                        murky[t.id] = unk; changed = True
         for n in ast.walk(node):
             if not (isinstance(n, ast.Return) and n.value is not None):
                 continue
-            if reads_env(n.value) or any(isinstance(x, ast.Name) and x.id in tainted
-                                         for x in ast.walk(n.value)):
+            names = [x.id for x in ast.walk(n.value) if isinstance(x, ast.Name)]
+            if reads_env(n.value) or any(x in tainted for x in names):
                 return "honours", (f"a return in {node.name}() derives from the env "
                                    f"(line {n.lineno})")
-            for c in ast.walk(n.value):          # follow calls into this module
-                if isinstance(c, ast.Call) and _dots(c.func) in modfns:
-                    deeper = verdict(modfns[_dots(c.func)], seen)
+            for c in ast.walk(n.value):          # follow calls we can read
+                if not isinstance(c, ast.Call):
+                    continue
+                d = _dots(c.func)
+                if d in modfns:
+                    deeper = verdict(modfns[d], seen)
                     if deeper is not None:
                         return deeper
-            bad = opaque_call(n.value)
+                    continue
+                sib = sibling(d)
+                if sib is not None and sib[1].name == node.name:
+                    sub, _ = _resolver_env_verdict(sib[0])   # one hop, same name
+                    if sub != "ignores":
+                        return sub, (f"{node.name}() delegates to {d}(), which is "
+                                     f"{sub}")
+            bad = unresolved_call(n.value) or next(
+                (murky[x] for x in names if x in murky), None)
             if bad is not None:
                 return "unknown", (f"a return in {node.name}() flows through "
                                    f"{bad}(), which this analysis cannot resolve")

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9241,7 +9241,7 @@ _REMOVED_WS_ENV = "SUTANDO_WORKSPACE"
 _RESOLVED_CALLS = frozenset({"Path", "str", "expanduser", "resolve", "home"})
 
 
-def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
+def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     """(verdict, why) for one workspace_default copy, WITHOUT importing it.
 
     Verdicts: "honours" / "ignores" / "unknown". Static because detection must not
@@ -9318,7 +9318,7 @@ def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
             if d.endswith(".environ.get") or d.endswith("getenv"):
                 continue                         # an env read: reads_env judges it
             sib = sibling(d)
-            if sib is not None and sib[1].name == "resolve_workspace":
+            if _hops > 0 and sib is not None and sib[1].name == "resolve_workspace":
                 continue                         # same-name delegate: analysed below
             return d or "<expr>"
         return None
@@ -9363,7 +9363,10 @@ def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
                     continue
                 sib = sibling(d)
                 if sib is not None and sib[1].name == node.name:
-                    sub, _ = _resolver_env_verdict(sib[0])   # one hop, same name
+                    if _hops <= 0:               # budget spent: mutual delegates
+                        return "unknown", (f"{node.name}() delegates to {d}() beyond "
+                                           f"the one-hop limit")
+                    sub, _ = _resolver_env_verdict(sib[0], _hops - 1)
                     if sub != "ignores":
                         return sub, (f"{node.name}() delegates to {d}(), which is "
                                      f"{sub}")

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9240,6 +9240,9 @@ _REMOVED_WS_ENV = "SUTANDO_WORKSPACE"
 # Callees whose result cannot smuggle an env read past the analysis: pure
 # constructors over arguments this pass already walks.
 _RESOLVED_CALLS = frozenset({"Path", "str", "expanduser", "resolve", "home"})
+# ...but only where the SPELLING still means what it says. `from helper import Path`
+# rebinds the name to arbitrary code, so trust is per-file, not global.
+_CANONICAL_CALL_ORIGIN = {"Path": "pathlib.Path"}
 _BUILTIN_NAMES = frozenset(dir(__import__("builtins")))
 # os.path member-by-member, not namespace-wide: expandvars() reads the environment,
 # and an unlisted member is unknown rather than assumed pure.
@@ -9354,13 +9357,16 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     # it holds; only these four sets carry a followed origin.
     proven = os_names | getenv_names | environ_names | expandvars_names
 
-    def _callee_base_nodes(expr) -> set:
-        """id() of the Name NODE at the base of each callee chain.
+    # A pure-callee spelling is trusted only where nothing rebinds it: an import
+    # or assignment of the same name supplies a different callable entirely.
+    resolved_calls = {n for n in _RESOLVED_CALLS
+                      if n not in rebound
+                      and (n not in provable
+                           or provable[n] == [_CANONICAL_CALL_ORIGIN.get(n)])}
 
-        Node-specific, not name-wide: `helper.resolve_workspace()` follows the
-        call while `helper.WORKSPACE` two characters away is an opaque value,
-        and exempting the NAME exempts both.
-        """
+    def _callee_base_nodes(expr) -> set:
+        """id() of the Name NODE at the base of each callee chain — node-specific,
+        because one identifier can be a followed callee and an opaque value at once."""
         out = set()
         for c in ast.walk(expr):
             if not isinstance(c, ast.Call):
@@ -9448,7 +9454,7 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
             if not isinstance(n, ast.Call):
                 continue
             d = _dots(n.func)
-            if d in modfns or d in _RESOLVED_CALLS:
+            if d in modfns or d in resolved_calls:
                 continue
             if d.startswith("os.path.") and d.rpartition(".")[2] in _PURE_OSPATH:
                 continue
@@ -9510,7 +9516,7 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                     continue
                 x = n.id
                 if (x in imported and x not in proven and x not in bound
-                        and x not in modfns and x not in _RESOLVED_CALLS):
+                        and x not in modfns and x not in resolved_calls):
                     return f"the imported value {x}"
             return None
 
@@ -9549,7 +9555,7 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                    or opaque_import(n.value)
                    or next((f"the unbound name {x}" for x in names
                             if x not in bound and x not in imported
-                            and x not in modfns and x not in _RESOLVED_CALLS
+                            and x not in modfns and x not in resolved_calls
                             and x not in _BUILTIN_NAMES), None))
             if bad is not None:
                 return "unknown", (f"a return in {node.name}() flows through "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9232,6 +9232,60 @@ def _file_digest(path: Path) -> str:
         return f"<unreadable:{path}>"
 
 
+def check_vendored_resolver_env(workspace_dir: "Path | None" = None) -> "dict | None":
+    """A vendored `workspace_default` that still honours $SUTANDO_WORKSPACE.
+
+    v0.8 (#1440) removed that env var as a workspace source. A copy predating the
+    change returns the env's value, so two resolvers disagree only when the env is
+    set — silently, and only for whoever imports the stale copy. Measured
+    2026-09-04: wire-skill's copy resolved to the pre-v0.8 legacy tree and
+    peg-signal output had been landing there since 08-16.
+
+    Deliberately a BEHAVIOUR probe, not a diff against src. That night's census
+    found 17 same-named vendored files and 3 content-drifted, of which one was
+    defective: `sparrowd.py` is two files by design and `send_allowlist.py`'s copy
+    uses package-internal paths on purpose. Hash-comparing names would flag 3 to
+    catch 1, and a gate that cries wolf gets ignored.
+    """
+    name = "vendored-resolver-env"
+    ws = Path(workspace_dir) if workspace_dir else WORKSPACE_DIR
+    roots = [ws / "skill-repos", REPO_DIR / "packages", REPO_DIR / "skills"]
+    canonical = (REPO_DIR / "src" / "workspace_default.py").resolve()
+    copies = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for f in root.rglob("workspace_default.py"):
+            if ".git" in f.parts or f.resolve() == canonical:
+                continue
+            copies.append(f)
+    if not copies:
+        return None                       # nothing vendored here; not a finding
+    bogus = "/tmp/sutando-healthcheck-not-the-workspace"
+    probe_src = ("import sys; sys.path.insert(0, %r)\n"
+                 "from workspace_default import resolve_workspace\n"
+                 "print(resolve_workspace())\n")
+    offenders = []
+    for f in sorted(set(copies)):
+        env = dict(os.environ, SUTANDO_WORKSPACE=bogus)
+        try:
+            r = subprocess.run([sys.executable, "-c", probe_src % str(f.parent)],
+                               capture_output=True, text=True, env=env, timeout=30)
+        except Exception:                 # noqa: BLE001 — a probe must not raise
+            continue
+        if r.returncode == 0 and r.stdout.strip().splitlines()[-1:] == [bogus]:
+            offenders.append(str(f))
+    if not offenders:
+        return {"name": name, "status": "ok",
+                "detail": f"{len(set(copies))} vendored resolver(s), none honour "
+                          "$SUTANDO_WORKSPACE"}
+    return {"name": name, "status": "warn",
+            "detail": f"{len(offenders)} vendored workspace_default still honour(s) "
+                      f"$SUTANDO_WORKSPACE, removed in v0.8 — it resolves elsewhere "
+                      f"than every v0.8 consumer whenever that env is set: "
+                      + ", ".join(offenders)}
+
+
 def check_legacy_notes_divergence() -> "dict | None":
     """Detect a canonical-vs-legacy notes/ divergence the #1266 probe cannot see.
 
@@ -10801,6 +10855,10 @@ def run_all_checks() -> list[dict]:
     _legacy_nd = check_legacy_notes_divergence()
     if _legacy_nd:
         checks.append(_legacy_nd)
+
+    _vre = check_vendored_resolver_env()
+    if _vre:
+        checks.append(_vre)
 
     # Memory sync
     checks.append(check_memory_sync())

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9261,7 +9261,9 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
         tree = ast.parse(src)
     except Exception as e:                       # noqa: BLE001 — unparseable is UNKNOWN
         return "unknown", f"could not parse: {str(e)[:60]}"
-    modfns = {n.name: n for n in ast.walk(tree)
+    # MODULE scope, not the whole file: a nested def of the same name would
+    # otherwise overwrite the one the runtime actually calls.
+    modfns = {n.name: n for n in _walk_outside_functions(tree)
               if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
 
     def sibling(dotted: "str"):
@@ -9277,7 +9279,7 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
             sub = ast.parse(sib.read_text())
         except Exception:                        # noqa: BLE001
             return None
-        for n in ast.walk(sub):
+        for n in _walk_outside_functions(sub):
             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name:
                 return sib, n
         return None
@@ -9347,6 +9349,21 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
         elif isinstance(n, ast.ImportFrom):
             for al in n.names:
                 imported.add(al.asname or al.name)
+
+    # Membership in `imported` proves a name was BOUND by an import, never what
+    # it holds; only these four sets carry a followed origin.
+    proven = os_names | getenv_names | environ_names | expandvars_names
+
+    def _callee_bases(expr) -> set:
+        """Head name of every callee in expr — unresolved_call() already judged
+        these, so the import merely names a module it followed."""
+        out = set()
+        for c in ast.walk(expr):
+            if isinstance(c, ast.Call):
+                d = _dots(c.func)
+                if d:
+                    out.add(d.split(".")[0])
+        return out
 
     def _keyed(node) -> bool:
         return _const_str(node) == _REMOVED_WS_ENV
@@ -9507,6 +9524,11 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                 return dv
             bad = (unresolved_call(n.value) or murky_env_read(n.value)
                    or next((murky[x] for x in names if x in murky), None)
+                   or next((f"the imported value {x}" for x in names
+                            if x in imported and x not in proven
+                            and x not in bound and x not in modfns
+                            and x not in _RESOLVED_CALLS
+                            and x not in _callee_bases(n.value)), None)
                    or next((f"the unbound name {x}" for x in names
                             if x not in bound and x not in imported
                             and x not in modfns and x not in _RESOLVED_CALLS
@@ -9665,9 +9687,9 @@ def check_vendored_resolver_env(workspace_dir: "Path | None" = None) -> "dict | 
     v0.8 (#1440) removed that env var as a workspace source, so a copy predating
     the change resolves elsewhere than every v0.8 consumer whenever it is set.
 
-    STATIC ONLY. An earlier draft imported each discovered copy in a subprocess;
-    qingyun-wu showed that executes arbitrary checked-out source with the health
-    check's environment. Nothing here runs the files it inspects.
+    STATIC ONLY. Importing a copy — even in a subprocess — executes arbitrary
+    checked-out source with this process's environment. Nothing here runs the
+    files it inspects.
 
     Three-valued on purpose: a copy that cannot be analysed is `unknown`, never
     folded into a clean bill — an unmeasured offender is the case this exists for.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9587,15 +9587,19 @@ def _rebound_names(src):
     """
     out = set()
 
-    def walk(tbl):
+    def walk(tbl, is_module):
         for s in tbl.get_symbols():
             if s.is_assigned() or s.is_parameter():
                 out.add(s.get_name())
+            # `global os; import helper as os` REPLACES the module binding, and
+            # CPython calls that imported+global in the child scope, never assigned.
+            elif not is_module and s.is_declared_global() and s.is_imported():
+                out.add(s.get_name())
         for child in tbl.get_children():
-            walk(child)
+            walk(child, False)
 
     try:
-        walk(symtable.symtable(src, "<resolver>", "exec"))
+        walk(symtable.symtable(src, "<resolver>", "exec"), True)
     except (SyntaxError, ValueError):
         return None                  # unknown-by-refusal, never an empty clean set
     return out

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9309,19 +9309,16 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     rebound = _rebound_names(src)
     if rebound is None:
         return "unknown", "symbol table refused this source"
-    # symtable calls colliding imports both `imported`, neither `assigned`; unlike
-    # binding forms, imports are a CLOSED set of two node types, so this enumerates.
-    imp_counts: "dict[str, int]" = {}
-    for n in ast.walk(tree):
-        if isinstance(n, ast.Import):
-            for al in n.names:
-                nm = al.asname or al.name.split(".")[0]
-                imp_counts[nm] = imp_counts.get(nm, 0) + 1
-        elif isinstance(n, ast.ImportFrom):
-            for al in n.names:
-                nm = al.asname or al.name
-                imp_counts[nm] = imp_counts.get(nm, 0) + 1
-    rebound |= {nm for nm, c in imp_counts.items() if c > 1}
+    # `ignores` is certified for a PROVEN shape and refused otherwise, rather than
+    # for anything no blacklist has caught yet — the tail is unbounded, the shape is not.
+    provable = _import_provenance(tree)
+    if provable is None:
+        return "unknown", "a star import binds names this analysis cannot enumerate"
+    # Proven == bound by exactly one MODULE-SCOPE import. A nested `import os` does
+    # not prove a module-scope name, and two bindings prove neither.
+    rebound |= {nm for nm, c in provable.items() if c != 1}
+    for s in (os_names, getenv_names, environ_names, expandvars_names):
+        rebound |= {nm for nm in s if nm not in provable}
     os_names -= rebound
     getenv_names -= rebound
     environ_names -= rebound
@@ -9550,6 +9547,27 @@ def _walk_outside_functions(node):
                           ast.ClassDef, ast.Lambda)):
             continue
         stack.extend(ast.iter_child_nodes(n))
+
+
+def _import_provenance(tree):
+    """{name: module-scope import count}, or None if the module star-imports.
+
+    Scoped to module level on purpose: a nested `import os` is found by a
+    file-wide walk and proves nothing about the name the resolver actually sees.
+    """
+    counts = {}
+    for n in _walk_outside_functions(tree):
+        if isinstance(n, ast.Import):
+            for al in n.names:
+                nm = al.asname or al.name.split(".")[0]
+                counts[nm] = counts.get(nm, 0) + 1
+        elif isinstance(n, ast.ImportFrom):
+            for al in n.names:
+                if al.name == "*":
+                    return None
+                nm = al.asname or al.name
+                counts[nm] = counts.get(nm, 0) + 1
+    return counts
 
 
 def _rebound_names(src):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9302,21 +9302,11 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                 elif al.name == "expandvars":
                     expandvars_names.add(bound)
 
-    # A trusted name that is REBOUND anywhere is no longer proven: `import os,
-    # helper; os = helper` and a second `from helper import getenv` both do it.
+    # A trusted name REBOUND anywhere is no longer proven — import, assignment or
+    # parameter default alike. One enumerator: a form left out is a false clean.
     bound_counts: "dict[str, int]" = {}
-    for n in ast.walk(tree):
-        if isinstance(n, ast.Import):
-            for al in n.names:
-                nm = al.asname or al.name.split(".")[0]
-                bound_counts[nm] = bound_counts.get(nm, 0) + 1
-        elif isinstance(n, ast.ImportFrom):
-            for al in n.names:
-                nm = al.asname or al.name
-                bound_counts[nm] = bound_counts.get(nm, 0) + 1
-    for tgt, _val in _bind_sites(tree):
-        for nm, _v in _binding_pairs(tgt, _val):
-            bound_counts[nm] = bound_counts.get(nm, 0) + 1
+    for nm in _all_bound_names(tree):
+        bound_counts[nm] = bound_counts.get(nm, 0) + 1
     rebound = {nm for nm, c in bound_counts.items() if c > 1}
     os_names -= rebound
     getenv_names -= rebound
@@ -9546,6 +9536,42 @@ def _walk_outside_functions(node):
                           ast.ClassDef, ast.Lambda)):
             continue
         stack.extend(ast.iter_child_nodes(n))
+
+
+def _all_bound_names(tree):
+    """Every name bound anywhere in the module, once per binding site.
+
+    One enumerator, so a form modelled for taint but forgotten by revocation
+    cannot leave a shadowed name certified clean. Over-counting only costs an
+    `unknown`; under-counting is the false clean this exists to prevent.
+    """
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            for al in n.names:
+                yield al.asname or al.name.split(".")[0]
+        elif isinstance(n, ast.ImportFrom):
+            for al in n.names:
+                yield al.asname or al.name
+        elif isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield n.name
+            for nm, _d in _param_binds(n):
+                yield nm
+        elif isinstance(n, ast.Lambda):
+            for nm, _d in _param_binds(n):
+                yield nm
+        elif isinstance(n, ast.ClassDef):
+            yield n.name
+        elif isinstance(n, ast.ExceptHandler) and n.name:
+            yield n.name
+        elif isinstance(n, ast.Global) or isinstance(n, ast.Nonlocal):
+            for nm in n.names:
+                yield nm
+        # `match x: case os:` binds too; ast.MatchAs is 3.10+, so probe by name.
+        elif type(n).__name__ == "MatchAs" and getattr(n, "name", None):
+            yield n.name
+    for tgt, val in _bind_sites(tree):
+        for nm, _v in _binding_pairs(tgt, val):
+            yield nm
 
 
 def _param_binds(fn):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9239,6 +9239,7 @@ _REMOVED_WS_ENV = "SUTANDO_WORKSPACE"
 # Callees whose result cannot smuggle an env read past the analysis: pure
 # constructors over arguments this pass already walks.
 _RESOLVED_CALLS = frozenset({"Path", "str", "expanduser", "resolve", "home"})
+_BUILTIN_NAMES = frozenset(dir(__import__("builtins")))
 
 
 def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
@@ -9277,11 +9278,24 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     if fn is None:
         return "unknown", "no resolve_workspace() to analyse"
 
-    # Names bound to the environ mapping itself (env = os.environ), so a .get on
-    # the alias is the same read as a .get on os.environ.
-    aliases = {t.id for n in ast.walk(tree)
-               if isinstance(n, ast.Assign) and _dots(n.value).endswith("environ")
-               for t in n.targets if isinstance(t, ast.Name)}
+    # env = os.environ: a .get on the alias is the same read. Collected through
+    # the same binding model the taint pass uses, so the two cannot drift.
+    aliases = {nm for tgt, val in _bind_sites(tree)
+               for nm, v in _binding_pairs(tgt, val)
+               if _dots(v).endswith("environ")}
+
+    # Module scope is where a name can be bound once and read by every function
+    # below it, and a body-scoped walk cannot see any of it.
+    mod_binds = [pair for tgt, val in _bind_sites(tree, walker=_walk_outside_functions)
+                 for pair in _binding_pairs(tgt, val)]
+    imported = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            for al in n.names:
+                imported.add((al.asname or al.name).split(".")[0])
+        elif isinstance(n, ast.ImportFrom):
+            for al in n.names:
+                imported.add(al.asname or al.name)
 
     def _keyed(node) -> bool:
         return _const_str(node) == _REMOVED_WS_ENV
@@ -9355,9 +9369,16 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
         if node.name in seen:
             return None                          # recursion guard
         seen = seen | {node.name}
-        binds = [pair for tgt, val in _bind_sites(node)
-                 for pair in _binding_pairs(tgt, val)]
-        tainted, murky, changed = set(), {}, True
+        binds = list(mod_binds) + [pair for tgt, val in _bind_sites(node)
+                                   for pair in _binding_pairs(tgt, val)]
+        tainted, murky = set(), {}
+        for nm, dflt in _param_binds(node):
+            if dflt is None:                 # caller-supplied: unprovable, so unknown
+                murky.setdefault(nm, f"the caller-supplied parameter {nm}")
+            else:
+                binds.append((nm, dflt))
+        bound = {nm for nm, _ in binds} | set(murky)
+        changed = True
         while changed:                           # two fixpoints, one walk
             changed = False
             for name, val in binds:
@@ -9395,7 +9416,11 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
                         return sub, (f"{node.name}() delegates to {d}(), which is "
                                      f"{sub}")
             bad = (unresolved_call(n.value) or murky_env_read(n.value)
-                   or next((murky[x] for x in names if x in murky), None))
+                   or next((murky[x] for x in names if x in murky), None)
+                   or next((f"the unbound name {x}" for x in names
+                            if x not in bound and x not in imported
+                            and x not in modfns and x not in _RESOLVED_CALLS
+                            and x not in _BUILTIN_NAMES), None))
             if bad is not None:
                 return "unknown", (f"a return in {node.name}() flows through "
                                    f"{bad}, which this analysis cannot resolve")
@@ -9407,13 +9432,13 @@ def _resolver_env_verdict(path: "Path", _hops: int = 1) -> "tuple[str, str]":
     return "ignores", "no return derives from $SUTANDO_WORKSPACE"
 
 
-def _bind_sites(node):
-    """(target, value) for every name-binding form in a function body.
+def _bind_sites(node, walker=ast.walk):
+    """(target, value) for every name-binding form the walker reaches.
 
     Enumerated rather than matched statement by statement: a binding form the
     taint pass does not model leaves its names untainted, which reads as clean.
     """
-    for n in ast.walk(node):
+    for n in walker(node):
         if isinstance(n, ast.Assign):
             for t in n.targets:
                 yield t, n.value
@@ -9428,6 +9453,37 @@ def _bind_sites(node):
             for item in n.items:
                 if item.optional_vars is not None:
                     yield item.optional_vars, item.context_expr
+
+
+def _walk_outside_functions(node):
+    """ast.walk minus function and class bodies — i.e. module scope only."""
+    stack = list(ast.iter_child_nodes(node))
+    while stack:
+        n = stack.pop()
+        yield n
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef,
+                          ast.ClassDef, ast.Lambda)):
+            continue
+        stack.extend(ast.iter_child_nodes(n))
+
+
+def _param_binds(fn):
+    """(name, default-or-None) for every parameter.
+
+    A parameter is a binding the body never shows. Its default is analysable;
+    a caller-supplied value is not, so None here means unknown, never clean.
+    """
+    a = fn.args
+    pos = list(getattr(a, "posonlyargs", [])) + list(a.args)
+    out, covered = [], set()
+    if a.defaults:
+        for arg, d in zip(pos[len(pos) - len(a.defaults):], a.defaults):
+            out.append((arg.arg, d)); covered.add(arg.arg)
+    for arg, d in zip(a.kwonlyargs, a.kw_defaults):
+        if d is not None:
+            out.append((arg.arg, d)); covered.add(arg.arg)
+    rest = pos + list(a.kwonlyargs) + [x for x in (a.vararg, a.kwarg) if x]
+    return out + [(arg.arg, None) for arg in rest if arg.arg not in covered]
 
 
 def _binding_pairs(target, value):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -20,6 +20,7 @@ Checks:
   - Notes directory
 """
 
+import ast
 import functools
 import hashlib
 import fnmatch
@@ -9232,64 +9233,119 @@ def _file_digest(path: Path) -> str:
         return f"<unreadable:{path}>"
 
 
+def _resolver_env_verdict(path: "Path") -> "tuple[str, str]":
+    """(verdict, why) for one workspace_default copy, WITHOUT importing it.
+
+    Verdicts: "honours" / "ignores" / "unknown". Static because detection must not
+    execute discovered source — a subprocess is failure isolation, not a security
+    boundary, and any checked-out skill could run import-time code otherwise.
+    """
+    try:
+        tree = ast.parse(path.read_text())
+    except Exception as e:                       # noqa: BLE001 — unparseable is UNKNOWN
+        return "unknown", f"could not parse: {str(e)[:60]}"
+    fn = next((n for n in ast.walk(tree)
+               if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+               and n.name == "resolve_workspace"), None)
+    if fn is None:
+        return "unknown", "no resolve_workspace() to analyse"
+
+    def reads_env(node) -> bool:
+        """os.environ.get("SUTANDO_WORKSPACE") or os.environ["SUTANDO_WORKSPACE"]."""
+        for n in ast.walk(node):
+            if isinstance(n, ast.Subscript) and _dots(n.value).endswith("environ"):
+                if _const_str(n.slice) == "SUTANDO_WORKSPACE":
+                    return True
+            if isinstance(n, ast.Call) and _dots(n.func).endswith("environ.get"):
+                if n.args and _const_str(n.args[0]) == "SUTANDO_WORKSPACE":
+                    return True
+        return False
+
+    tainted, changed = set(), True
+    while changed:                               # tiny fixpoint over local aliases
+        changed = False
+        for n in ast.walk(fn):
+            if isinstance(n, (ast.Assign, ast.AnnAssign)) and n.value is not None:
+                src = reads_env(n.value) or any(
+                    isinstance(x, ast.Name) and x.id in tainted
+                    for x in ast.walk(n.value))
+                if not src:
+                    continue
+                for t in (n.targets if isinstance(n, ast.Assign) else [n.target]):
+                    if isinstance(t, ast.Name) and t.id not in tainted:
+                        tainted.add(t.id); changed = True
+    for n in ast.walk(fn):
+        if isinstance(n, ast.Return) and n.value is not None:
+            if reads_env(n.value) or any(isinstance(x, ast.Name) and x.id in tainted
+                                         for x in ast.walk(n.value)):
+                return "honours", f"a return in resolve_workspace() derives from the env (line {n.lineno})"
+    return "ignores", "no return derives from $SUTANDO_WORKSPACE"
+
+
+def _dots(node) -> str:
+    """Dotted name for Attribute/Name chains; '' for anything else."""
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr); node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _const_str(node) -> "str | None":
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
 def check_vendored_resolver_env(workspace_dir: "Path | None" = None) -> "dict | None":
     """A vendored `workspace_default` that still honours $SUTANDO_WORKSPACE.
 
-    v0.8 (#1440) removed that env var as a workspace source. A copy predating the
-    change returns the env's value, so two resolvers disagree only when the env is
-    set — silently, and only for whoever imports the stale copy. Measured
-    2026-09-04: wire-skill's copy resolved to the pre-v0.8 legacy tree and
-    peg-signal output had been landing there since 08-16.
+    v0.8 (#1440) removed that env var as a workspace source, so a copy predating
+    the change resolves elsewhere than every v0.8 consumer whenever it is set.
 
-    Deliberately a BEHAVIOUR probe, not a diff against src. That night's census
-    found 17 same-named vendored files and 3 content-drifted, of which one was
-    defective: `sparrowd.py` is two files by design and `send_allowlist.py`'s copy
-    uses package-internal paths on purpose. Hash-comparing names would flag 3 to
-    catch 1, and a gate that cries wolf gets ignored.
+    STATIC ONLY. An earlier draft imported each discovered copy in a subprocess;
+    qingyun-wu showed that executes arbitrary checked-out source with the health
+    check's environment. Nothing here runs the files it inspects.
+
+    Three-valued on purpose: a copy that cannot be analysed is `unknown`, never
+    folded into a clean bill — an unmeasured offender is the case this exists for.
     """
     name = "vendored-resolver-env"
     ws = Path(workspace_dir) if workspace_dir else WORKSPACE_DIR
     roots = [ws / "skill-repos", REPO_DIR / "packages", REPO_DIR / "skills"]
     canonical = (REPO_DIR / "src" / "workspace_default.py").resolve()
-    copies = []
+    copies, roots_seen = [], [str(r) for r in roots if r.is_dir()]
     for root in roots:
         if not root.is_dir():
             continue
         for f in root.rglob("workspace_default.py"):
-            if ".git" in f.parts or f.resolve() == canonical:
-                continue
-            copies.append(f)
-    roots_seen = [str(r) for r in roots if r.is_dir()]
+            if ".git" not in f.parts and f.resolve() != canonical:
+                copies.append(f)
     if not copies:
-        # NOT None. A silent absence cannot be told from a scan that looked in the
-        # wrong place — the vacuous-green shape this probe exists to catch.
         return {"name": name, "status": "ok",
                 "detail": f"no vendored workspace_default under {len(roots_seen)} "
                           f"root(s) ({', '.join(roots_seen) or 'none present'}) — "
                           "zero copies scanned, so this is coverage, not a clean bill"}
-    bogus = "/tmp/sutando-healthcheck-not-the-workspace"
-    probe_src = ("import sys; sys.path.insert(0, %r)\n"
-                 "from workspace_default import resolve_workspace\n"
-                 "print(resolve_workspace())\n")
-    offenders = []
+    honours, unknown = [], []
     for f in sorted(set(copies)):
-        env = dict(os.environ, SUTANDO_WORKSPACE=bogus)
-        try:
-            r = subprocess.run([sys.executable, "-c", probe_src % str(f.parent)],
-                               capture_output=True, text=True, env=env, timeout=30)
-        except Exception:                 # noqa: BLE001 — a probe must not raise
-            continue
-        if r.returncode == 0 and r.stdout.strip().splitlines()[-1:] == [bogus]:
-            offenders.append(str(f))
-    if not offenders:
-        return {"name": name, "status": "ok",
-                "detail": f"{len(set(copies))} vendored resolver(s), none honour "
-                          "$SUTANDO_WORKSPACE"}
-    return {"name": name, "status": "warn",
-            "detail": f"{len(offenders)} vendored workspace_default still honour(s) "
-                      f"$SUTANDO_WORKSPACE, removed in v0.8 — it resolves elsewhere "
-                      f"than every v0.8 consumer whenever that env is set: "
-                      + ", ".join(offenders)}
+        verdict, why = _resolver_env_verdict(f)
+        if verdict == "honours":
+            honours.append(f"{f} ({why})")
+        elif verdict == "unknown":
+            unknown.append(f"{f} ({why})")
+    if honours:
+        return {"name": name, "status": "warn",
+                "detail": f"{len(honours)} vendored workspace_default still honour(s) "
+                          f"$SUTANDO_WORKSPACE, removed in v0.8: " + "; ".join(honours)
+                          + (f" · {len(unknown)} more could not be analysed: "
+                             + "; ".join(unknown) if unknown else "")}
+    if unknown:
+        return {"name": name, "status": "warn",
+                "detail": f"{len(unknown)} of {len(set(copies))} vendored resolver(s) "
+                          "could NOT be analysed, so this is not a clean bill: "
+                          + "; ".join(unknown)}
+    return {"name": name, "status": "ok",
+            "detail": f"{len(set(copies))} vendored resolver(s), all analysed, "
+                      "none honour $SUTANDO_WORKSPACE"}
 
 
 def check_legacy_notes_divergence() -> "dict | None":

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -152,6 +152,57 @@ class EquivalentForms(unittest.TestCase):
             "    return Path(os.path.expanduser('~/w'))\n"), "ignores")
 
 
+class UnresolvedIsNeverClean(unittest.TestCase):
+    """Round 4: the fallback was applied only to the return expression and
+    ignored dotted callees, so both shapes below read 'ignores' at 6a4ace97."""
+
+    def _verdict(self, src):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text(src)
+        return hc._resolver_env_verdict(f)[0]
+
+    def test_a_local_assigned_from_an_opaque_call_taints_the_return(self):
+        self.assertEqual(self._verdict(
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    raw = mystery()\n"
+            "    return Path(raw)\n"), "unknown")
+
+    def test_a_dotted_callee_is_unresolved_too(self):
+        self.assertEqual(self._verdict(
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(config.workspace())\n"), "unknown")
+
+    def test_a_readable_same_name_delegate_is_analysed_not_guessed(self):
+        """The canonical resolver delegates to a sibling module; that hop is
+        taken, so a real file is not condemned as unknown."""
+        d = Path(tempfile.mkdtemp())
+        (d / "sutando_config.py").write_text(
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path('/configured')\n")
+        (d / "workspace_default.py").write_text(
+            "import sutando_config\n"
+            "def resolve_workspace():\n"
+            "    return sutando_config.resolve_workspace()\n")
+        self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
+
+    def test_the_delegate_carries_its_own_verdict_back(self):
+        """Same hop, dirty delegate: the honours verdict must propagate."""
+        d = Path(tempfile.mkdtemp())
+        (d / "sutando_config.py").write_text(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.environ['SUTANDO_WORKSPACE'])\n")
+        (d / "workspace_default.py").write_text(
+            "import sutando_config\n"
+            "def resolve_workspace():\n"
+            "    return sutando_config.resolve_workspace()\n")
+        self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "honours")
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -355,6 +355,94 @@ class EveryBindingFormIsModelled(unittest.TestCase):
             "    return Path(d['w'])\n"), "ignores")
 
 
+class BindingsOutsideTheBody(unittest.TestCase):
+    """Round 7: the taint pass walked the FUNCTION BODY only, and the alias
+    collector kept a private rule that never learned the new binding forms.
+    qingyun-wu's three controls all read 'ignores' at 757e2c90; the fourth is
+    the same class, found by asking what else binds a name before the body."""
+
+    def _verdict(self, src):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text(src)
+        return hc._resolver_env_verdict(f)[0]
+
+    def test_a_module_scope_binding_is_a_taint_source(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "RAW = os.getenv('SUTANDO_WORKSPACE')\n"
+            "def resolve_workspace():\n"
+            "    return Path(RAW)\n"), "honours")
+
+    def test_a_default_argument_is_a_binding(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace(raw=os.environ.get('SUTANDO_WORKSPACE')):\n"
+            "    return Path(raw)\n"), "honours")
+
+    def test_an_annotated_module_alias_is_still_an_alias(self):
+        """The alias collector now shares _bind_sites with the taint pass, so a
+        form one side learns cannot be missing from the other."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "env: object = os.environ\n"
+            "def resolve_workspace():\n"
+            "    return Path(env['SUTANDO_WORKSPACE'])\n"), "honours")
+
+    def test_a_caller_supplied_parameter_is_unknown(self):
+        self.assertEqual(self._verdict(
+            "from pathlib import Path\n"
+            "def resolve_workspace(base):\n"
+            "    return Path(base)\n"), "unknown")
+
+    def test_a_starargs_parameter_is_unknown_too(self):
+        self.assertEqual(self._verdict(
+            "from pathlib import Path\n"
+            "def resolve_workspace(*parts, **kw):\n"
+            "    return Path(parts[0])\n"), "unknown")
+
+    def test_a_keyword_only_default_is_analysed(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace(*, raw=os.getenv('SUTANDO_WORKSPACE')):\n"
+            "    return Path(raw)\n"), "honours")
+
+    def test_a_name_bound_nowhere_is_unknown(self):
+        """The backstop: 'no binding this analysis resolved' is unknown, not
+        clean. Without it every future scope gap defaults to a clean bill."""
+        self.assertEqual(self._verdict(
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(NOWHERE)\n"), "unknown")
+
+    def test_a_module_constant_stays_clean(self):
+        """Negative control: module scope became a taint SOURCE, not a taint."""
+        self.assertEqual(self._verdict(
+            "from pathlib import Path\n"
+            "DEFAULT = '/configured'\n"
+            "def resolve_workspace():\n"
+            "    return Path(DEFAULT)\n"), "ignores")
+
+    def test_a_clean_default_argument_stays_clean(self):
+        """Negative control: a default is analysed, and analysed means clean."""
+        self.assertEqual(self._verdict(
+            "from pathlib import Path\n"
+            "def resolve_workspace(raw='/configured'):\n"
+            "    return Path(raw)\n"), "ignores")
+
+    def test_the_probe_reports_it_too_not_only_the_verdict(self):
+        """qingyun ran both levels: a verdict that never reaches the probe's
+        detail is a fix nobody sees."""
+        ws = Path(tempfile.mkdtemp())
+        _vendor(ws, "import os\nfrom pathlib import Path\n"
+                    "RAW = os.getenv('SUTANDO_WORKSPACE')\n"
+                    "def resolve_workspace():\n"
+                    "    return Path(RAW)\n")
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("still honour", r["detail"])
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python3
 """`check_vendored_resolver_env` must be non-executing and fail honest.
 
-Two properties, both from qingyun-wu's review of the first draft (#3892):
-
-1. It must NOT execute discovered source. The first draft imported each copy in a
-   subprocess; a subprocess is failure isolation, not a security boundary, so any
-   checked-out skill could run import-time code with the health check's env. Their
-   control was a copy whose top level wrote a marker — it existed before the probe
-   returned. `test_a_marker_writing_copy_is_never_executed` is that control.
-
-2. An unmeasurable copy must NOT read as clean. The first draft skipped timeouts
-   and import errors, so `offenders == []` reported "none honour". The original
-   test PINNED that false reassurance; it is now inverted.
+Non-executing: a subprocess is failure isolation, not a security boundary, so a
+checked-out copy must never be imported. Fail-honest: an unmeasurable copy reads
+`unknown`, never as one of the clean ones.
 """
 import importlib.util
 import tempfile
@@ -41,7 +33,7 @@ def _vendor(ws: Path, body: str, name: str = "someskill") -> Path:
 
 class NonExecuting(unittest.TestCase):
     def test_a_marker_writing_copy_is_never_executed(self):
-        """qingyun-wu's control: detection must not run what it inspects."""
+        """Detection must not run what it inspects."""
         ws = Path(tempfile.mkdtemp())
         marker = ws / "side_effect_marker"
         _vendor(ws, f"open({str(marker)!r}, 'w').write('x')\n" + _HONOURS)
@@ -93,8 +85,8 @@ class Verdicts(unittest.TestCase):
         self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
 
     def test_a_delegate_verdict_survives_being_held_in_a_local(self):
-        """keweichen's round-14 finding 2: `t = sib.resolve_workspace(); return t`
-        dropped the callee's verdict, so a dirty delegate read clean."""
+        """`t = sib.resolve_workspace(); return t` must carry the callee's
+        verdict: a verdict taken only on the return path drops this shape."""
         d = Path(tempfile.mkdtemp())
         (d / "sutando_config.py").write_text(
             "import os\nfrom pathlib import Path\n"
@@ -122,8 +114,8 @@ class Verdicts(unittest.TestCase):
         self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
 
     def test_an_alias_that_is_not_os_is_never_trusted(self):
-        """keweichen's round-14 finding 1: `import helper as os` at module scope
-        while a nested `import os` supplies the identity to a file-wide scan."""
+        """`import helper as os` at module scope, with a nested `import os`
+        supplying the identity a file-wide scan would count instead."""
         d = Path(tempfile.mkdtemp())
         (d / "helper.py").write_text(
             "import os\ndef getenv(k):\n    return os.environ['SUTANDO_WORKSPACE']\n")
@@ -211,8 +203,8 @@ class EquivalentForms(unittest.TestCase):
 
 
 class UnresolvedIsNeverClean(unittest.TestCase):
-    """Round 4: the fallback was applied only to the return expression and
-    ignored dotted callees, so both shapes below read 'ignores' at 6a4ace97."""
+    """A call whose result is unaccounted for is `unknown`. Bare and dotted
+    callees alike: `mystery()` and `config.workspace()` each return a value."""
 
     def _verdict(self, src):
         d = Path(tempfile.mkdtemp())
@@ -262,8 +254,8 @@ class UnresolvedIsNeverClean(unittest.TestCase):
 
 
 class TheHopIsBudgeted(unittest.TestCase):
-    """Round 5: the one-hop limit was documented in prose and unenforced, so
-    mutual delegates recursed to RecursionError instead of failing closed."""
+    """The one-hop delegate limit is enforced, not documented: mutual
+    delegates must fail closed rather than recurse."""
 
     def test_mutual_delegates_fail_closed_instead_of_recursing(self):
         d = Path(tempfile.mkdtemp())
@@ -295,9 +287,8 @@ class TheHopIsBudgeted(unittest.TestCase):
 
 
 class TheKeyAndTheBindingAreDataflowToo(unittest.TestCase):
-    """Round 6: reads_env() recognized a literal key only and the taint pass
-    modelled Name targets only, so an env read reached the return unseen.
-    qingyun-wu's three controls all read 'ignores' at 2ca05484."""
+    """A non-literal key and a non-Name binding target are both dataflow. A
+    reader that models only literals and only Name targets misses the read."""
 
     def _verdict(self, src):
         d = Path(tempfile.mkdtemp())
@@ -414,10 +405,8 @@ class EveryBindingFormIsModelled(unittest.TestCase):
 
 
 class BindingsOutsideTheBody(unittest.TestCase):
-    """Round 7: the taint pass walked the FUNCTION BODY only, and the alias
-    collector kept a private rule that never learned the new binding forms.
-    qingyun-wu's three controls all read 'ignores' at 757e2c90; the fourth is
-    the same class, found by asking what else binds a name before the body."""
+    """Module scope binds names every function below reads, so a body-scoped
+    walk cannot see them; one shared binding enumerator, not a private rule."""
 
     def _verdict(self, src):
         d = Path(tempfile.mkdtemp())
@@ -489,8 +478,7 @@ class BindingsOutsideTheBody(unittest.TestCase):
             "    return Path(raw)\n"), "ignores")
 
     def test_the_probe_reports_it_too_not_only_the_verdict(self):
-        """qingyun ran both levels: a verdict that never reaches the probe's
-        detail is a fix nobody sees."""
+        """A verdict that never reaches the probe's detail is a fix nobody sees."""
         ws = Path(tempfile.mkdtemp())
         _vendor(ws, "import os\nfrom pathlib import Path\n"
                     "RAW = os.getenv('SUTANDO_WORKSPACE')\n"
@@ -502,9 +490,8 @@ class BindingsOutsideTheBody(unittest.TestCase):
 
 
 class OsPathIsNotAPureNamespace(unittest.TestCase):
-    """Round 8: unresolved_call() exempted `os.path.*` wholesale, and that
-    namespace contains expandvars(), which reads the environment. qingyun-wu's
-    control read 'ignores' at 1cca14b2, verdict AND probe detail."""
+    """`os.path` is not a pure namespace: it contains expandvars(), which reads
+    the environment, so a wholesale exemption of the namespace is a false clean."""
 
     def _verdict(self, src):
         d = Path(tempfile.mkdtemp())
@@ -569,9 +556,8 @@ class OsPathIsNotAPureNamespace(unittest.TestCase):
 
 
 class ProvenanceNotSuffix(unittest.TestCase):
-    """Round 9: the env APIs were matched by SUFFIX, so `helper.getenv(...)` and
-    `helper.environ[...]` — arbitrary imported code — were treated as understood
-    OS reads and exempted. qingyun-wu's controls read 'ignores' at cf974224."""
+    """Env APIs are matched by PROVEN origin, not by suffix: `helper.getenv(...)`
+    and `helper.environ[...]` are arbitrary imported code, not understood reads."""
 
     def _verdict(self, src):
         d = Path(tempfile.mkdtemp())
@@ -637,9 +623,8 @@ class ProvenanceNotSuffix(unittest.TestCase):
 
 
 class ProvenanceIsBindingAware(unittest.TestCase):
-    """Round 10: provenance was collected into unordered sets and never
-    invalidated, so a REBOUND trusted name kept its proof. qingyun-wu's two
-    controls read 'ignores' at 5ffd704b."""
+    """Proof of provenance is revoked by any later binding of the same name;
+    a trusted name that is rebound has stopped being the thing that was proven."""
 
     def _verdict(self, src):
         d = Path(tempfile.mkdtemp())
@@ -709,8 +694,8 @@ class ProvenanceCertifiesAProvenShape(unittest.TestCase):
         return hc._resolver_env_verdict(d / "workspace_default.py")[0]
 
     def test_a_star_import_is_never_proven(self):
-        """qingyun-wu's round-13 control: the star binds `os`, the nested import
-        is what the file-wide walk counted."""
+        """The star binds `os` unenumerably; a file-wide walk counts the nested
+        import instead and calls that provenance."""
         self.assertEqual(self._v(
             "from helper import *\nfrom pathlib import Path\n"
             "def unrelated():\n    import os\n"
@@ -744,10 +729,8 @@ class ProvenanceCertifiesAProvenShape(unittest.TestCase):
 
 
 class AGlobalRebindingIsABinding(unittest.TestCase):
-    """qingyun-wu's round-15 control: `global os; import helper as os` in a
-    function called at module init REPLACES the module binding, and CPython
-    records it as imported+global in that scope — never `assigned`. So a
-    revocation reading only is_assigned()/is_parameter() misses it."""
+    """`global os; import helper as os` REPLACES the module binding, and CPython
+    records it as imported+global in the child scope, never as assigned."""
 
     def _v(self, body):
         d = Path(tempfile.mkdtemp())
@@ -804,8 +787,8 @@ class BindingRevocationIsNotEnumerated(unittest.TestCase):
         return hc._resolver_env_verdict(d / "workspace_default.py")[0]
 
     def test_a_comprehension_target_is_not_proven(self):
-        """qingyun-wu's round-12 control. An earlier round DELETED the
-        comprehension branch as 'unreachable'; the value escapes via [0]."""
+        """A comprehension target binds the name for the comprehension, and the
+        value escapes via [0] — the branch is reachable."""
         self.assertEqual(self._v(
             "import os, helper\nfrom pathlib import Path\n"
             "def resolve_workspace():\n"
@@ -862,10 +845,8 @@ class BindingRevocationIsNotEnumerated(unittest.TestCase):
 
 
 class EveryBindingSourceRevokes(unittest.TestCase):
-    """Round 10 revoked provenance for imports and _bind_sites; parameters were a
-    SECOND enumerator it never consulted, so a parameter default could shadow a
-    trusted name and keep the module-level proof. Two enumerators of the same
-    question is the defect — one left out is one false clean per form."""
+    """Every source that binds a name revokes provenance. Two enumerators of
+    the same question is the defect: one left out is one false clean per form."""
 
     def _v(self, body):
         d = Path(tempfile.mkdtemp())
@@ -876,7 +857,7 @@ class EveryBindingSourceRevokes(unittest.TestCase):
         return hc._resolver_env_verdict(d / "workspace_default.py")[0]
 
     def test_a_parameter_default_shadowing_os_is_not_proven(self):
-        """qingyun-wu's round-11 control, verbatim. `ignores` at the parent."""
+        """A parameter default can shadow a trusted module-level name."""
         self.assertEqual(self._v(
             "import os, helper\nfrom pathlib import Path\n"
             "def resolve_workspace(os=helper):\n"
@@ -931,9 +912,109 @@ class EveryBindingSourceRevokes(unittest.TestCase):
         self.assertNotIn("none honour", r["detail"])
 
 
+class ScopeAndOriginAreProven(unittest.TestCase):
+    """A file-wide walk picks a function by NAME, and an import binds a name
+    without saying what it holds. Neither is the property being certified."""
+
+    def _v(self, body):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text(body)
+        return hc._resolver_env_verdict(f)[0]
+
+    _DIRTY = ("import os\nfrom pathlib import Path\n"
+              "def resolve_workspace():\n"
+              "    return Path(os.environ['SUTANDO_WORKSPACE'])\n")
+    _NESTED = ("def unrelated():\n"
+               "    def resolve_workspace():\n"
+               "        return Path('/clean')\n"
+               "    return resolve_workspace\n")
+
+    def test_a_nested_same_name_def_after_it_does_not_shadow_the_real_one(self):
+        self.assertEqual(self._v(self._DIRTY + self._NESTED), "honours")
+
+    def test_nor_does_one_declared_before_it(self):
+        """Ordering pair: a dict built by walking cannot depend on source order."""
+        self.assertEqual(
+            self._v("import os\nfrom pathlib import Path\n"
+                    + self._NESTED + self._DIRTY.split("\n", 2)[2]), "honours")
+
+    def test_a_genuinely_clean_module_level_resolver_still_reads_ignores(self):
+        """Positive control: scoping the lookup must not condemn every file."""
+        self.assertEqual(
+            self._v("from pathlib import Path\n"
+                    "def resolve_workspace():\n"
+                    "    return Path('/fixed')\n" + self._NESTED), "ignores")
+
+    def test_a_nested_def_in_the_DELEGATE_does_not_shadow_it_either(self):
+        """The sibling lookup selects by name across the whole file too."""
+        d = Path(tempfile.mkdtemp())
+        (d / "sutando_config.py").write_text(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.environ['SUTANDO_WORKSPACE'])\n"
+            "def unrelated():\n"
+            "    def resolve_workspace():\n"
+            "        return Path('/clean')\n"
+            "    return resolve_workspace\n")
+        (d / "workspace_default.py").write_text(
+            "import sutando_config\n"
+            "def resolve_workspace():\n"
+            "    return sutando_config.resolve_workspace()\n")
+        self.assertEqual(
+            hc._resolver_env_verdict(d / "workspace_default.py")[0], "honours")
+
+    def test_an_imported_value_is_unresolved_dataflow_not_a_clean_name(self):
+        """`WORKSPACE` holds whatever the other module put there — here, the env."""
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\nWORKSPACE = os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "from pathlib import Path\nfrom helper import WORKSPACE\n"
+            "def resolve_workspace():\n"
+            "    return Path(WORKSPACE)\n")
+        v, why = hc._resolver_env_verdict(d / "workspace_default.py")
+        self.assertEqual(v, "unknown", why)
+        self.assertIn("WORKSPACE", why)
+
+    def test_a_dotted_read_off_an_imported_module_is_unresolved_too(self):
+        self.assertEqual(
+            self._v("import helper\nfrom pathlib import Path\n"
+                    "def resolve_workspace():\n"
+                    "    return Path(helper.WORKSPACE)\n"), "unknown")
+
+    def test_but_a_followed_module_call_is_not_an_opaque_value(self):
+        """Negative control: the delegate hop must survive the origin rule."""
+        d = Path(tempfile.mkdtemp())
+        (d / "sutando_config.py").write_text(
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n    return Path('/c')\n")
+        (d / "workspace_default.py").write_text(
+            "import sutando_config\n"
+            "def resolve_workspace():\n"
+            "    return sutando_config.resolve_workspace()\n")
+        self.assertEqual(
+            hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
+
+    def test_the_probe_reports_the_opaque_import_rather_than_ok(self):
+        """Integrated: the classifier verdict must reach the probe's status."""
+        ws = Path(tempfile.mkdtemp())
+        d = ws / "skill-repos" / "opaque" / "scripts"
+        d.mkdir(parents=True)
+        (d / "helper.py").write_text(
+            "import os\nWORKSPACE = os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "from pathlib import Path\nfrom helper import WORKSPACE\n"
+            "def resolve_workspace():\n"
+            "    return Path(WORKSPACE)\n")
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertEqual(r["status"], "warn")
+        self.assertNotIn("none honour", r["detail"])
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
-        """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""
+        """A probe that finds nothing must SAY so."""
         r = hc.check_vendored_resolver_env(workspace_dir=Path(tempfile.mkdtemp()))
         self.assertIsNotNone(r)
         self.assertEqual(r["status"], "ok")

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -295,6 +295,66 @@ class TheKeyAndTheBindingAreDataflowToo(unittest.TestCase):
             "    return Path(b)\n"), "ignores")
 
 
+class EveryBindingFormIsModelled(unittest.TestCase):
+    """One test per binding form _bind_sites() enumerates. An untested branch
+    here IS the defect this round fixed: a form the pass does not reach leaves
+    its names clean."""
+
+    def _verdict(self, body):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text("import os\nfrom pathlib import Path\n"
+                     "def resolve_workspace():\n" + body)
+        return hc._resolver_env_verdict(f)[0]
+
+    def test_an_annotated_binding(self):
+        self.assertEqual(self._verdict(
+            "    raw: str = os.environ['SUTANDO_WORKSPACE']\n"
+            "    return Path(raw)\n"), "honours")
+
+    def test_an_augmented_binding(self):
+        self.assertEqual(self._verdict(
+            "    raw = ''\n"
+            "    raw += os.environ['SUTANDO_WORKSPACE']\n"
+            "    return Path(raw)\n"), "honours")
+
+    def test_a_walrus_binding(self):
+        self.assertEqual(self._verdict(
+            "    if (raw := os.environ['SUTANDO_WORKSPACE']):\n"
+            "        return Path(raw)\n"
+            "    return Path('/configured')\n"), "honours")
+
+    def test_a_loop_binding(self):
+        self.assertEqual(self._verdict(
+            "    for raw in [os.environ['SUTANDO_WORKSPACE']]:\n"
+            "        return Path(raw)\n"
+            "    return Path('/configured')\n"), "honours")
+
+    def test_a_starred_target_binds_the_whole_value(self):
+        """No element-wise pairing is possible across a star, so every name it
+        binds takes the whole value — over-tainting, which is the safe side."""
+        self.assertEqual(self._verdict(
+            "    first, *rest = os.environ['SUTANDO_WORKSPACE'], '/a'\n"
+            "    return Path(first)\n"), "honours")
+
+    def test_a_subscript_target_taints_its_container(self):
+        self.assertEqual(self._verdict(
+            "    holder = {}\n"
+            "    holder['w'] = os.environ['SUTANDO_WORKSPACE']\n"
+            "    return Path(holder['w'])\n"), "honours")
+
+    def test_an_env_read_with_no_key_is_unknown(self):
+        self.assertEqual(self._verdict(
+            "    return Path(os.environ.get())\n"), "unknown")
+
+    def test_a_subscript_on_something_else_is_not_an_env_read(self):
+        """Negative control: the key guard keys on the BASE, so an ordinary
+        dict lookup must not turn a clean resolver unknown."""
+        self.assertEqual(self._verdict(
+            "    d = {'w': '/configured'}\n"
+            "    return Path(d['w'])\n"), "ignores")
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -636,6 +636,55 @@ class ProvenanceIsBindingAware(unittest.TestCase):
             "    return Path(os.getenv('SUTANDO_WORKSPACE'))\n"), "honours")
 
 
+class ProvenanceCertifiesAProvenShape(unittest.TestCase):
+    """`ignores` is asserted for a shape this analysis can prove, and refused for
+    everything else. The prior rule enumerated what to EXCLUDE, which is a
+    blacklist over an open set: `import *` binds names it cannot list, and a
+    file-wide walk counted a nested import as module-scope proof."""
+
+    def _v(self, body, helper=None):
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(helper or (
+            "import os\ndef getenv(key):\n"
+            "    return os.environ['SUTANDO_WORKSPACE']\n"))
+        (d / "workspace_default.py").write_text(body)
+        return hc._resolver_env_verdict(d / "workspace_default.py")[0]
+
+    def test_a_star_import_is_never_proven(self):
+        """qingyun-wu's round-13 control: the star binds `os`, the nested import
+        is what the file-wide walk counted."""
+        self.assertEqual(self._v(
+            "from helper import *\nfrom pathlib import Path\n"
+            "def unrelated():\n    import os\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "unknown")
+
+    def test_a_nested_import_does_not_prove_a_module_scope_name(self):
+        """The scope half, on its own — no star import in sight."""
+        self.assertEqual(self._v(
+            "from pathlib import Path\n"
+            "def unrelated():\n    import os\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "unknown")
+
+    def test_a_module_scope_import_is_still_proven(self):
+        """The negative that keeps this a rule and not a refusal-of-everything."""
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "ignores")
+
+    def test_a_real_read_is_still_detected(self):
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.environ['SUTANDO_WORKSPACE'])\n"), "honours")
+
+    def test_the_helper_reports_star_as_unanalysable(self):
+        self.assertIsNone(hc._import_provenance(
+            __import__("ast").parse("from helper import *\n")))
+
+
 class BindingRevocationIsNotEnumerated(unittest.TestCase):
     """Six rounds each shipped a binding form the next round found, so the
     enumeration itself was the defect. CPython's symbol table is the language's

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -636,6 +636,78 @@ class ProvenanceIsBindingAware(unittest.TestCase):
             "    return Path(os.getenv('SUTANDO_WORKSPACE'))\n"), "honours")
 
 
+class BindingRevocationIsNotEnumerated(unittest.TestCase):
+    """Six rounds each shipped a binding form the next round found, so the
+    enumeration itself was the defect. CPython's symbol table is the language's
+    own answer and cannot omit a construct; these cases are evidence of that
+    property, not a list to extend when a seventh form appears."""
+
+    def _v(self, body):
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\ndef getenv(key):\n"
+            "    return os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(body)
+        return hc._resolver_env_verdict(d / "workspace_default.py")[0]
+
+    def test_a_comprehension_target_is_not_proven(self):
+        """qingyun-wu's round-12 control. An earlier round DELETED the
+        comprehension branch as 'unreachable'; the value escapes via [0]."""
+        self.assertEqual(self._v(
+            "import os, helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path([os.getenv('HOME') for os in [helper]][0])\n"), "unknown")
+
+    def test_a_with_as_rebinding_is_not_proven(self):
+        """Never named by any round — covered because symtable covers it."""
+        self.assertEqual(self._v(
+            "import os, helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    with open('/x') as os:\n        pass\n"
+            "    return Path(os.getenv('HOME'))\n"), "unknown")
+
+    def test_a_walrus_rebinding_is_not_proven(self):
+        """Likewise never named."""
+        self.assertEqual(self._v(
+            "import os, helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path((os := helper).getenv('HOME'))\n"), "unknown")
+
+    def test_colliding_imports_still_revoke(self):
+        """symtable calls both `imported` and neither `assigned`, so imports stay
+        AST-checked — a CLOSED set of two node types, unlike binding forms."""
+        self.assertEqual(self._v(
+            "from os import getenv\nfrom helper import getenv\n"
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(getenv('HOME'))\n"), "unknown")
+
+    def test_a_source_symtable_refuses_is_unknown_not_clean(self):
+        """The refusal must not degrade to an empty set, which reads as clean."""
+        self.assertIsNone(hc._rebound_names("def (:\n"))
+
+    def test_an_unshadowed_import_is_still_proven(self):
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "ignores")
+
+    def test_an_alias_binds_the_alias_not_the_module(self):
+        """`env = os.environ` binds env; revoking os here would make every
+        aliasing resolver unanalysable."""
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "env = os.environ\n"
+            "def resolve_workspace():\n"
+            "    return Path(env['HOME'])\n"), "ignores")
+
+    def test_a_real_read_is_still_detected(self):
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.environ['SUTANDO_WORKSPACE'])\n"), "honours")
+
+
 class EveryBindingSourceRevokes(unittest.TestCase):
     """Round 10 revoked provenance for imports and _bind_sites; parameters were a
     SECOND enumerator it never consulted, so a parameter default could shadow a

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -39,9 +39,18 @@ class VendoredResolverEnvProbe(unittest.TestCase):
     def _ws(self) -> Path:
         return Path(tempfile.mkdtemp())
 
-    def test_no_copies_is_not_a_finding(self):
-        """An empty tree must return None, never a warn — absence is not a defect."""
-        self.assertIsNone(hc.check_vendored_resolver_env(workspace_dir=self._ws()))
+    def test_zero_copies_reports_coverage_rather_than_going_silent(self):
+        """Sutando-Mini on #3892: a probe that finds nothing must SAY so.
+
+        Returning None makes "scanned, found none" indistinguishable from "the scan
+        looked in the wrong place", which is the vacuous-green shape this probe was
+        written to catch — one layer down, inside the probe itself.
+        """
+        r = hc.check_vendored_resolver_env(workspace_dir=self._ws())
+        self.assertIsNotNone(r, "a zero result went out as silence")
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("zero copies scanned", r["detail"],
+                      "the detail must state coverage, not imply a clean bill")
 
     def test_a_compliant_copy_reads_ok(self):
         """The discriminating control: without it the probe could warn on any copy."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -743,6 +743,52 @@ class ProvenanceCertifiesAProvenShape(unittest.TestCase):
             __import__("ast").parse("from helper import *\n")))
 
 
+class AGlobalRebindingIsABinding(unittest.TestCase):
+    """qingyun-wu's round-15 control: `global os; import helper as os` in a
+    function called at module init REPLACES the module binding, and CPython
+    records it as imported+global in that scope — never `assigned`. So a
+    revocation reading only is_assigned()/is_parameter() misses it."""
+
+    def _v(self, body):
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\ndef getenv(key):\n"
+            "    return os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(body)
+        return hc._resolver_env_verdict(d / "workspace_default.py")[0]
+
+    def test_a_nested_global_import_revokes_the_module_binding(self):
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def poison():\n    global os\n    import helper as os\n"
+            "poison()\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "unknown")
+
+    def test_a_global_READ_does_not_revoke(self):
+        """The discriminating negative: revoking on the mere presence of
+        `global` would make any module that reads a global unanalysable."""
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def helper_fn():\n    global os\n    return os\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "ignores")
+
+    def test_symtable_reports_the_shape_this_relies_on(self):
+        """Pin the CPython fact the rule rests on, so a semantics change is
+        caught here rather than as a silent false clean."""
+        import symtable
+        st = symtable.symtable(
+            "import os\ndef poison():\n    global os\n    import helper as os\n",
+            "m.py", "exec")
+        # By NAME, not index: 3.12+ emits an __annotate__ child scope first.
+        child = next(c for c in st.get_children() if c.get_name() == "poison")
+        sym = next(s for s in child.get_symbols() if s.get_name() == "os")
+        self.assertTrue(sym.is_declared_global())
+        self.assertTrue(sym.is_imported())
+        self.assertFalse(sym.is_assigned())
+
+
 class BindingRevocationIsNotEnumerated(unittest.TestCase):
     """Six rounds each shipped a binding form the next round found, so the
     enumeration itself was the defect. CPython's symbol table is the language's

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -1028,9 +1028,8 @@ class ScopeAndOriginAreProven(unittest.TestCase):
                     "    r = WS\n    return Path(r)\n"), "ignores")
 
     def test_a_followed_call_does_not_exempt_a_VALUE_read_of_the_same_name(self):
-        """The callee exemption is NODE-specific, not name-wide: `helper.f()` and
-        `helper.WORKSPACE` in one expression are a followed call and an opaque
-        value, and exempting the NAME exempts both."""
+        """One identifier, two roles: exempting the NAME exempts the value read
+        as well as the followed call."""
         d = Path(tempfile.mkdtemp())
         (d / "helper.py").write_text(
             "import os\nfrom pathlib import Path\n"
@@ -1044,6 +1043,53 @@ class ScopeAndOriginAreProven(unittest.TestCase):
         v, why = hc._resolver_env_verdict(d / "workspace_default.py")
         self.assertEqual(v, "unknown", why)
         self.assertIn("helper", why)
+
+    def test_a_shadowed_pure_callee_is_not_trusted_by_spelling(self):
+        """`Path` is trusted for what it IS, not what it is called: an import can
+        bind the spelling to arbitrary code."""
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\ndef Path(_):\n    return os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "from helper import Path\ndef resolve_workspace():\n"
+            "    return Path('/fixed')\n")
+        v, why = hc._resolver_env_verdict(d / "workspace_default.py")
+        self.assertEqual(v, "unknown", why)
+
+    def test_the_real_pathlib_Path_is_still_trusted(self):
+        """Negative control: distrusting a shadowed spelling must not distrust the
+        canonical one, or every clean resolver reads unknown."""
+        d = Path(tempfile.mkdtemp())
+        (d / "workspace_default.py").write_text(
+            "from pathlib import Path\ndef resolve_workspace():\n"
+            "    return Path('/fixed')\n")
+        self.assertEqual(
+            hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
+
+    def test_a_locally_reassigned_pure_callee_is_not_trusted_either(self):
+        """An assignment rebinds the spelling as surely as an import does."""
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\ndef f(_):\n    return os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "import helper\nPath = helper.f\ndef resolve_workspace():\n"
+            "    return Path('/fixed')\n")
+        v, why = hc._resolver_env_verdict(d / "workspace_default.py")
+        self.assertEqual(v, "unknown", why)
+
+    def test_the_probe_reports_the_shadowed_callee_too(self):
+        """Integrated: the classifier verdict must reach the probe's status."""
+        ws = Path(tempfile.mkdtemp())
+        d = ws / "skill-repos" / "shadowcall" / "scripts"
+        d.mkdir(parents=True)
+        (d / "helper.py").write_text(
+            "import os\ndef Path(_):\n    return os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "from helper import Path\ndef resolve_workspace():\n"
+            "    return Path('/fixed')\n")
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertEqual(r["status"], "warn")
+        self.assertNotIn("none honour", r["detail"])
 
     def test_the_probe_reports_the_mixed_shape_too(self):
         """Integrated: the classifier verdict must reach the probe's status."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -510,6 +510,74 @@ class OsPathIsNotAPureNamespace(unittest.TestCase):
             "    return Path(os.path.join(os.path.expanduser('~'), 'w'))\n"), "ignores")
 
 
+class ProvenanceNotSuffix(unittest.TestCase):
+    """Round 9: the env APIs were matched by SUFFIX, so `helper.getenv(...)` and
+    `helper.environ[...]` — arbitrary imported code — were treated as understood
+    OS reads and exempted. qingyun-wu's controls read 'ignores' at cf974224."""
+
+    def _verdict(self, src):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text(src)
+        return hc._resolver_env_verdict(f)[0]
+
+    def test_a_lookalike_dotted_getenv_is_unknown(self):
+        self.assertEqual(self._verdict(
+            "import helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(helper.getenv('HOME'))\n"), "unknown")
+
+    def test_a_lookalike_environ_subscript_is_unknown(self):
+        """No Call node exists here, so unresolved_call cannot see it; the
+        subscript itself has to be judged."""
+        self.assertEqual(self._verdict(
+            "import helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(helper.environ['HOME'])\n"), "unknown")
+
+    def test_a_bare_getenv_from_a_foreign_module_is_unknown(self):
+        """`from helper import getenv` and `from os import getenv` produce an
+        identical call site; only the import statement tells them apart."""
+        self.assertEqual(self._verdict(
+            "from helper import getenv\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(getenv('HOME'))\n"), "unknown")
+
+    def test_a_lookalike_expandvars_is_unknown(self):
+        self.assertEqual(self._verdict(
+            "import helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(helper.path.expandvars('$HOME'))\n"), "unknown")
+
+    def test_real_os_getenv_stays_analysed(self):
+        """Negative control: provenance must not make the genuine article
+        unanalysable, or the probe reports unknown for every resolver."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "ignores")
+
+    def test_an_os_module_alias_is_followed(self):
+        self.assertEqual(self._verdict(
+            "import os as _o\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(_o.getenv('HOME'))\n"), "ignores")
+
+    def test_from_os_import_getenv_is_followed(self):
+        self.assertEqual(self._verdict(
+            "from os import getenv\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(getenv('HOME'))\n"), "ignores")
+
+    def test_and_it_still_catches_the_removed_variable_through_them(self):
+        """Both directions on the same import shape: provenance decides whether
+        the read is analysed, the KEY decides the verdict."""
+        self.assertEqual(self._verdict(
+            "from os import getenv\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(getenv('SUTANDO_WORKSPACE'))\n"), "honours")
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -443,6 +443,73 @@ class BindingsOutsideTheBody(unittest.TestCase):
         self.assertIn("still honour", r["detail"])
 
 
+class OsPathIsNotAPureNamespace(unittest.TestCase):
+    """Round 8: unresolved_call() exempted `os.path.*` wholesale, and that
+    namespace contains expandvars(), which reads the environment. qingyun-wu's
+    control read 'ignores' at 1cca14b2, verdict AND probe detail."""
+
+    def _verdict(self, src):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text(src)
+        return hc._resolver_env_verdict(f)[0]
+
+    def test_expandvars_naming_the_removed_variable(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.path.expandvars('$SUTANDO_WORKSPACE'))\n"), "honours")
+
+    def test_the_braced_spelling_counts_too(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.path.expandvars('${SUTANDO_WORKSPACE}/w'))\n"), "honours")
+
+    def test_a_direct_import_of_expandvars_counts_too(self):
+        self.assertEqual(self._verdict(
+            "from os.path import expandvars\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(expandvars('$SUTANDO_WORKSPACE'))\n"), "honours")
+
+    def test_an_unresolvable_expandvars_argument_is_unknown(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "T = '$SUTANDO_WORKSPACE'\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.path.expandvars(T))\n"), "unknown")
+
+    def test_an_unlisted_os_path_member_is_unknown(self):
+        """The class, not the case: a member-by-member allowlist means a helper
+        nobody has classified fails closed instead of inheriting the namespace."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.path.some_future_helper('x'))\n"), "unknown")
+
+    def test_expanduser_stays_clean(self):
+        """Negative control: expanduser reads $HOME, which structurally cannot
+        yield the retired variable, so it stays on the pure list."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.path.expanduser('~/w'))\n"), "ignores")
+
+    def test_expandvars_naming_another_variable_stays_clean(self):
+        """Negative control: the literal PROVES which variable it expands, so
+        this is analysed-and-clean, not unknown."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.path.expandvars('$HOME/w'))\n"), "ignores")
+
+    def test_a_listed_os_path_helper_stays_clean(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.path.join(os.path.expanduser('~'), 'w'))\n"), "ignores")
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -636,6 +636,76 @@ class ProvenanceIsBindingAware(unittest.TestCase):
             "    return Path(os.getenv('SUTANDO_WORKSPACE'))\n"), "honours")
 
 
+class EveryBindingSourceRevokes(unittest.TestCase):
+    """Round 10 revoked provenance for imports and _bind_sites; parameters were a
+    SECOND enumerator it never consulted, so a parameter default could shadow a
+    trusted name and keep the module-level proof. Two enumerators of the same
+    question is the defect — one left out is one false clean per form."""
+
+    def _v(self, body):
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\ndef getenv(key):\n"
+            "    return os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(body)
+        return hc._resolver_env_verdict(d / "workspace_default.py")[0]
+
+    def test_a_parameter_default_shadowing_os_is_not_proven(self):
+        """qingyun-wu's round-11 control, verbatim. `ignores` at the parent."""
+        self.assertEqual(self._v(
+            "import os, helper\nfrom pathlib import Path\n"
+            "def resolve_workspace(os=helper):\n"
+            "    return Path(os.getenv('HOME'))\n"), "unknown")
+
+    def test_an_except_as_rebinding_is_not_proven(self):
+        """Same class, a form neither round named. `ignores` at the parent."""
+        self.assertEqual(self._v(
+            "import os, helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    try:\n        pass\n"
+            "    except Exception as os:\n        pass\n"
+            "    return Path(os.getenv('HOME'))\n"), "unknown")
+
+    def test_a_parameter_that_shadows_nothing_stays_clean(self):
+        """The negative that makes it a rule and not 'revoke on any parameter'.
+
+        The key is a LITERAL, so the non-literal-key rule cannot fire and this
+        isolates the parameter axis by itself."""
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace(base='/tmp'):\n"
+            "    return Path(os.getenv('HOME'))\n"), "ignores")
+
+    def test_an_unshadowed_import_is_still_proven(self):
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "ignores")
+
+    def test_a_real_read_is_still_detected_through_a_parameter(self):
+        """Over-revoking would hide a genuine honours; it must not."""
+        self.assertEqual(self._v(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace(base='/tmp'):\n"
+            "    return Path(os.environ['SUTANDO_WORKSPACE'])\n"), "honours")
+
+    def test_the_probe_reports_the_shadowed_copy_rather_than_ok(self):
+        """Integrated: the classifier verdict must reach the probe's status."""
+        ws = Path(tempfile.mkdtemp())
+        d = ws / "skill-repos" / "shadowed" / "scripts"
+        d.mkdir(parents=True)
+        (d / "helper.py").write_text(
+            "import os\ndef getenv(key):\n"
+            "    return os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "import os, helper\nfrom pathlib import Path\n"
+            "def resolve_workspace(os=helper):\n"
+            "    return Path(os.getenv('HOME'))\n")
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertEqual(r["status"], "warn")
+        self.assertNotIn("none honour", r["detail"])
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -105,6 +105,53 @@ class Verdicts(unittest.TestCase):
         self.assertEqual(r["status"], "ok", r["detail"])
 
 
+class EquivalentForms(unittest.TestCase):
+    """Three spellings that honour the env without the two shapes the first
+    analysis recognized. All three read 'ignores' at 12d5f2ad."""
+
+    def _verdict(self, src):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text(src)
+        return hc._resolver_env_verdict(f)[0]
+
+    def test_os_getenv_is_the_same_read(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('SUTANDO_WORKSPACE'))\n"), "honours")
+
+    def test_a_module_level_environ_alias_is_the_same_read(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "env = os.environ\n"
+            "def resolve_workspace():\n"
+            "    raw = env.get('SUTANDO_WORKSPACE')\n"
+            "    return Path(raw)\n"), "honours")
+
+    def test_the_read_may_sit_in_another_function(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def legacy():\n"
+            "    return os.environ.get('SUTANDO_WORKSPACE')\n"
+            "def resolve_workspace():\n"
+            "    return Path(legacy())\n"), "honours")
+
+    def test_an_unresolvable_call_is_unknown_not_clean(self):
+        """The general guard: what the analysis cannot follow is never 'ignores'."""
+        self.assertEqual(self._verdict(
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(mystery())\n"), "unknown")
+
+    def test_a_genuinely_clean_resolver_is_still_clean(self):
+        """Negative control: the guard above must not make everything unknown."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.path.expanduser('~/w'))\n"), "ignores")
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""`check_vendored_resolver_env` must discriminate, not just fire on any copy.
+
+The defect it exists for: a vendored `workspace_default` predating v0.8 (#1440)
+still honours $SUTANDO_WORKSPACE, so it resolves elsewhere than every v0.8
+consumer whenever that env is set — silently. Measured 2026-09-04 on a live host.
+
+It is a BEHAVIOUR probe rather than a diff against src on purpose: a census that
+day found 17 same-named vendored files, 3 content-drifted, one defective, so a
+hash gate would have flagged 3 to catch 1.
+"""
+import importlib.util
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("hc_vre", _REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+
+def _vendored(ws: Path, source: Path) -> Path:
+    d = ws / "skill-repos" / "someskill" / "scripts"
+    d.mkdir(parents=True, exist_ok=True)
+    shutil.copy(source, d / "workspace_default.py")
+    for extra in ("util_paths.py", "sutando_config.py"):
+        s = _REPO / "src" / extra
+        if s.exists():
+            shutil.copy(s, d / extra)
+    return d
+
+
+class VendoredResolverEnvProbe(unittest.TestCase):
+    def _ws(self) -> Path:
+        return Path(tempfile.mkdtemp())
+
+    def test_no_copies_is_not_a_finding(self):
+        """An empty tree must return None, never a warn — absence is not a defect."""
+        self.assertIsNone(hc.check_vendored_resolver_env(workspace_dir=self._ws()))
+
+    def test_a_compliant_copy_reads_ok(self):
+        """The discriminating control: without it the probe could warn on any copy."""
+        ws = self._ws()
+        _vendored(ws, _REPO / "src" / "workspace_default.py")
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_a_pre_v08_copy_is_flagged_and_named(self):
+        ws = self._ws()
+        d = _vendored(ws, _REPO / "src" / "workspace_default.py")
+        # A copy that honours the removed env, which is exactly the pre-v0.8 shape.
+        (d / "workspace_default.py").write_text(
+            "import os\n"
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.environ.get('SUTANDO_WORKSPACE', '/fallback'))\n"
+        )
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("workspace_default.py", r["detail"],
+                      "the warn must NAME the offending file, not just count it")
+
+    def test_a_copy_that_cannot_even_import_is_not_flagged(self):
+        """A broken copy is not evidence of this defect; refuse to guess."""
+        ws = self._ws()
+        d = _vendored(ws, _REPO / "src" / "workspace_default.py")
+        (d / "workspace_default.py").write_text("this is not python(\n")
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -578,6 +578,64 @@ class ProvenanceNotSuffix(unittest.TestCase):
             "    return Path(getenv('SUTANDO_WORKSPACE'))\n"), "honours")
 
 
+class ProvenanceIsBindingAware(unittest.TestCase):
+    """Round 10: provenance was collected into unordered sets and never
+    invalidated, so a REBOUND trusted name kept its proof. qingyun-wu's two
+    controls read 'ignores' at 5ffd704b."""
+
+    def _verdict(self, src):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text(src)
+        return hc._resolver_env_verdict(f)[0]
+
+    def test_reassigning_the_os_name_revokes_its_proof(self):
+        self.assertEqual(self._verdict(
+            "import os, helper\nfrom pathlib import Path\n"
+            "os = helper\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "unknown")
+
+    def test_a_later_colliding_import_revokes_it_too(self):
+        self.assertEqual(self._verdict(
+            "from os import getenv\nfrom helper import getenv\n"
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(getenv('HOME'))\n"), "unknown")
+
+    def test_a_shadowed_bare_environ_subscript_too(self):
+        """A bare name has no dotted root, and a Subscript has no Call node, so
+        this needed the subscript check widened rather than provenance alone."""
+        self.assertEqual(self._verdict(
+            "from os import environ\nfrom helper import environ\n"
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(environ['HOME'])\n"), "unknown")
+
+    def test_an_unshadowed_import_keeps_its_proof(self):
+        """Negative control: revocation must key on REBINDING, not on the name
+        appearing twice in the file for any reason."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "ignores")
+
+    def test_an_os_environ_alias_still_works(self):
+        """Negative control: `env = os.environ` binds env, not os — the alias
+        must not be mistaken for a rebinding of the trusted name."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "env = os.environ\n"
+            "def resolve_workspace():\n"
+            "    return Path(env['HOME'])\n"), "ignores")
+
+    def test_and_the_removed_variable_is_still_caught(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('SUTANDO_WORKSPACE'))\n"), "honours")
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -996,6 +996,53 @@ class ScopeAndOriginAreProven(unittest.TestCase):
         self.assertEqual(
             hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
 
+    def test_one_local_hop_does_not_wash_out_the_import(self):
+        """The backstop must run in the BINDING fixpoint, not only on the return:
+        an assignment moves the imported name out of the return expression."""
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\nWORKSPACE = os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "from pathlib import Path\nfrom helper import WORKSPACE\n"
+            "def resolve_workspace():\n"
+            "    resolved = WORKSPACE\n"
+            "    return Path(resolved)\n")
+        v, why = hc._resolver_env_verdict(d / "workspace_default.py")
+        self.assertEqual(v, "unknown", why)
+        self.assertIn("WORKSPACE", why)
+
+    def test_two_hops_do_not_either(self):
+        """One hop is not a special case; the fixpoint carries it any distance."""
+        self.assertEqual(
+            self._v("import helper\nfrom pathlib import Path\n"
+                    "def resolve_workspace():\n"
+                    "    a = helper.WORKSPACE\n    b = a\n"
+                    "    return Path(b)\n"), "unknown")
+
+    def test_a_module_constant_defined_HERE_still_reads_ignores(self):
+        """Negative control: the rule is about IMPORTED values, not module scope.
+        A constant this file binds is dataflow the analysis fully resolved."""
+        self.assertEqual(
+            self._v("from pathlib import Path\nWS = '/fixed'\n"
+                    "def resolve_workspace():\n"
+                    "    r = WS\n    return Path(r)\n"), "ignores")
+
+    def test_the_probe_reports_the_one_hop_import_too(self):
+        """Integrated: the fixpoint verdict must reach the probe's status."""
+        ws = Path(tempfile.mkdtemp())
+        d = ws / "skill-repos" / "hopped" / "scripts"
+        d.mkdir(parents=True)
+        (d / "helper.py").write_text(
+            "import os\nWORKSPACE = os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "from pathlib import Path\nfrom helper import WORKSPACE\n"
+            "def resolve_workspace():\n"
+            "    resolved = WORKSPACE\n"
+            "    return Path(resolved)\n")
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertEqual(r["status"], "warn")
+        self.assertNotIn("none honour", r["detail"])
+
     def test_the_probe_reports_the_opaque_import_rather_than_ok(self):
         """Integrated: the classifier verdict must reach the probe's status."""
         ws = Path(tempfile.mkdtemp())

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -203,6 +203,39 @@ class UnresolvedIsNeverClean(unittest.TestCase):
         self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "honours")
 
 
+class TheHopIsBudgeted(unittest.TestCase):
+    """Round 5: the one-hop limit was documented in prose and unenforced, so
+    mutual delegates recursed to RecursionError instead of failing closed."""
+
+    def test_mutual_delegates_fail_closed_instead_of_recursing(self):
+        d = Path(tempfile.mkdtemp())
+        (d / "workspace_default.py").write_text(
+            "import b\ndef resolve_workspace():\n    return b.resolve_workspace()\n")
+        (d / "b.py").write_text(
+            "import workspace_default\n"
+            "def resolve_workspace():\n    return workspace_default.resolve_workspace()\n")
+        v, why = hc._resolver_env_verdict(d / "workspace_default.py")
+        self.assertEqual(v, "unknown")
+        self.assertIn("b.resolve_workspace", why)
+
+    def test_a_self_delegating_file_also_fails_closed(self):
+        d = Path(tempfile.mkdtemp())
+        (d / "workspace_default.py").write_text(
+            "import workspace_default\n"
+            "def resolve_workspace():\n    return workspace_default.resolve_workspace()\n")
+        self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "unknown")
+
+    def test_one_real_hop_still_resolves(self):
+        """Negative control: budgeting the hop must not disable it."""
+        d = Path(tempfile.mkdtemp())
+        (d / "sutando_config.py").write_text(
+            "from pathlib import Path\ndef resolve_workspace():\n    return Path('/c')\n")
+        (d / "workspace_default.py").write_text(
+            "import sutando_config\n"
+            "def resolve_workspace():\n    return sutando_config.resolve_workspace()\n")
+        self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -1027,6 +1027,42 @@ class ScopeAndOriginAreProven(unittest.TestCase):
                     "def resolve_workspace():\n"
                     "    r = WS\n    return Path(r)\n"), "ignores")
 
+    def test_a_followed_call_does_not_exempt_a_VALUE_read_of_the_same_name(self):
+        """The callee exemption is NODE-specific, not name-wide: `helper.f()` and
+        `helper.WORKSPACE` in one expression are a followed call and an opaque
+        value, and exempting the NAME exempts both."""
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\nfrom pathlib import Path\n"
+            "WORKSPACE = os.environ['SUTANDO_WORKSPACE']\n"
+            "def resolve_workspace():\n    return Path('/x')\n")
+        (d / "workspace_default.py").write_text(
+            "import helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(helper.WORKSPACE) if helper.resolve_workspace() "
+            "else Path('/fixed')\n")
+        v, why = hc._resolver_env_verdict(d / "workspace_default.py")
+        self.assertEqual(v, "unknown", why)
+        self.assertIn("helper", why)
+
+    def test_the_probe_reports_the_mixed_shape_too(self):
+        """Integrated: the classifier verdict must reach the probe's status."""
+        ws = Path(tempfile.mkdtemp())
+        d = ws / "skill-repos" / "mixed" / "scripts"
+        d.mkdir(parents=True)
+        (d / "helper.py").write_text(
+            "import os\nfrom pathlib import Path\n"
+            "WORKSPACE = os.environ['SUTANDO_WORKSPACE']\n"
+            "def resolve_workspace():\n    return Path('/x')\n")
+        (d / "workspace_default.py").write_text(
+            "import helper\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(helper.WORKSPACE) if helper.resolve_workspace() "
+            "else Path('/fixed')\n")
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertEqual(r["status"], "warn")
+        self.assertNotIn("none honour", r["detail"])
+
     def test_the_probe_reports_the_one_hop_import_too(self):
         """Integrated: the fixpoint verdict must reach the probe's status."""
         ws = Path(tempfile.mkdtemp())

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-"""`check_vendored_resolver_env` must discriminate, not just fire on any copy.
+"""`check_vendored_resolver_env` must be non-executing and fail honest.
 
-The defect it exists for: a vendored `workspace_default` predating v0.8 (#1440)
-still honours $SUTANDO_WORKSPACE, so it resolves elsewhere than every v0.8
-consumer whenever that env is set — silently. Measured 2026-09-04 on a live host.
+Two properties, both from qingyun-wu's review of the first draft (#3892):
 
-It is a BEHAVIOUR probe rather than a diff against src on purpose: a census that
-day found 17 same-named vendored files, 3 content-drifted, one defective, so a
-hash gate would have flagged 3 to catch 1.
+1. It must NOT execute discovered source. The first draft imported each copy in a
+   subprocess; a subprocess is failure isolation, not a security boundary, so any
+   checked-out skill could run import-time code with the health check's env. Their
+   control was a copy whose top level wrote a marker — it existed before the probe
+   returned. `test_a_marker_writing_copy_is_never_executed` is that control.
+
+2. An unmeasurable copy must NOT read as clean. The first draft skipped timeouts
+   and import errors, so `offenders == []` reported "none honour". The original
+   test PINNED that false reassurance; it is now inverted.
 """
 import importlib.util
-import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -23,66 +26,92 @@ try:
 except SystemExit:
     pass
 
+_HONOURS = ("import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    p = os.environ.get('SUTANDO_WORKSPACE')\n"
+            "    return Path(p)\n")
 
-def _vendored(ws: Path, source: Path) -> Path:
-    d = ws / "skill-repos" / "someskill" / "scripts"
+
+def _vendor(ws: Path, body: str, name: str = "someskill") -> Path:
+    d = ws / "skill-repos" / name / "scripts"
     d.mkdir(parents=True, exist_ok=True)
-    shutil.copy(source, d / "workspace_default.py")
-    for extra in ("util_paths.py", "sutando_config.py"):
-        s = _REPO / "src" / extra
-        if s.exists():
-            shutil.copy(s, d / extra)
+    (d / "workspace_default.py").write_text(body)
     return d
 
 
-class VendoredResolverEnvProbe(unittest.TestCase):
-    def _ws(self) -> Path:
-        return Path(tempfile.mkdtemp())
-
-    def test_zero_copies_reports_coverage_rather_than_going_silent(self):
-        """Sutando-Mini on #3892: a probe that finds nothing must SAY so.
-
-        Returning None makes "scanned, found none" indistinguishable from "the scan
-        looked in the wrong place", which is the vacuous-green shape this probe was
-        written to catch — one layer down, inside the probe itself.
-        """
-        r = hc.check_vendored_resolver_env(workspace_dir=self._ws())
-        self.assertIsNotNone(r, "a zero result went out as silence")
-        self.assertEqual(r["status"], "ok")
-        self.assertIn("zero copies scanned", r["detail"],
-                      "the detail must state coverage, not imply a clean bill")
-
-    def test_a_compliant_copy_reads_ok(self):
-        """The discriminating control: without it the probe could warn on any copy."""
-        ws = self._ws()
-        _vendored(ws, _REPO / "src" / "workspace_default.py")
+class NonExecuting(unittest.TestCase):
+    def test_a_marker_writing_copy_is_never_executed(self):
+        """qingyun-wu's control: detection must not run what it inspects."""
+        ws = Path(tempfile.mkdtemp())
+        marker = ws / "side_effect_marker"
+        _vendor(ws, f"open({str(marker)!r}, 'w').write('x')\n" + _HONOURS)
         r = hc.check_vendored_resolver_env(workspace_dir=ws)
-        self.assertIsNotNone(r)
-        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertFalse(marker.exists(),
+                         "the probe EXECUTED a discovered module — it wrote its marker")
+        self.assertEqual(r["status"], "warn", "and it must still detect the defect statically")
 
-    def test_a_pre_v08_copy_is_flagged_and_named(self):
-        ws = self._ws()
-        d = _vendored(ws, _REPO / "src" / "workspace_default.py")
-        # A copy that honours the removed env, which is exactly the pre-v0.8 shape.
-        (d / "workspace_default.py").write_text(
-            "import os\n"
-            "from pathlib import Path\n"
-            "def resolve_workspace():\n"
-            "    return Path(os.environ.get('SUTANDO_WORKSPACE', '/fallback'))\n"
-        )
+
+class FailsHonest(unittest.TestCase):
+    def test_an_unanalysable_copy_is_not_reported_clean(self):
+        """Inverted from the first draft, which asserted `ok` here."""
+        ws = Path(tempfile.mkdtemp())
+        _vendor(ws, "this is not python(\n")
         r = hc.check_vendored_resolver_env(workspace_dir=ws)
-        self.assertIsNotNone(r)
         self.assertEqual(r["status"], "warn", r["detail"])
-        self.assertIn("workspace_default.py", r["detail"],
-                      "the warn must NAME the offending file, not just count it")
+        self.assertIn("could NOT be analysed", r["detail"])
+        self.assertNotIn("none honour", r["detail"],
+                         "an unmeasured copy was folded into a clean bill")
 
-    def test_a_copy_that_cannot_even_import_is_not_flagged(self):
-        """A broken copy is not evidence of this defect; refuse to guess."""
-        ws = self._ws()
-        d = _vendored(ws, _REPO / "src" / "workspace_default.py")
-        (d / "workspace_default.py").write_text("this is not python(\n")
+    def test_a_copy_without_the_function_is_also_unknown(self):
+        ws = Path(tempfile.mkdtemp())
+        _vendor(ws, "import os\nx = 1\n")
+        self.assertEqual(hc.check_vendored_resolver_env(workspace_dir=ws)["status"], "warn")
+
+
+class Verdicts(unittest.TestCase):
+    def test_the_canonical_resolver_ignores_the_env(self):
+        """Positive control: without it a detector that says 'ignores' for
+        everything would pass every case below."""
+        v, _ = hc._resolver_env_verdict(_REPO / "src" / "workspace_default.py")
+        self.assertEqual(v, "ignores")
+
+    def test_a_pre_v08_shape_is_flagged_and_named(self):
+        ws = Path(tempfile.mkdtemp())
+        _vendor(ws, _HONOURS)
+        r = hc.check_vendored_resolver_env(workspace_dir=ws)
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("workspace_default.py", r["detail"],
+                      "the warn must NAME the offender, not just count it")
+
+    def test_an_alias_through_a_local_still_counts(self):
+        """`p = os.environ[...]` then `return Path(p)` — the shape the real copy uses."""
+        ws = Path(tempfile.mkdtemp())
+        _vendor(ws, "import os\nfrom pathlib import Path\n"
+                    "def resolve_workspace():\n"
+                    "    raw = os.environ['SUTANDO_WORKSPACE']\n"
+                    "    q = raw\n"
+                    "    return Path(q)\n")
+        self.assertEqual(hc.check_vendored_resolver_env(workspace_dir=ws)["status"], "warn")
+
+    def test_mentioning_the_name_without_returning_it_is_not_a_hit(self):
+        """Negative control: the canonical file mentions the env only to warn."""
+        ws = Path(tempfile.mkdtemp())
+        _vendor(ws, "import os\nfrom pathlib import Path\n"
+                    "def resolve_workspace():\n"
+                    "    if os.environ.get('SUTANDO_WORKSPACE'):\n"
+                    "        print('warning: no longer honored')\n"
+                    "    return Path('/configured')\n")
         r = hc.check_vendored_resolver_env(workspace_dir=ws)
         self.assertEqual(r["status"], "ok", r["detail"])
+
+
+class Coverage(unittest.TestCase):
+    def test_zero_copies_reports_coverage_rather_than_going_silent(self):
+        """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""
+        r = hc.check_vendored_resolver_env(workspace_dir=Path(tempfile.mkdtemp()))
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("zero copies scanned", r["detail"])
 
 
 if __name__ == "__main__":

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -69,11 +69,69 @@ class FailsHonest(unittest.TestCase):
 
 
 class Verdicts(unittest.TestCase):
-    def test_the_canonical_resolver_ignores_the_env(self):
-        """Positive control: without it a detector that says 'ignores' for
-        everything would pass every case below."""
-        v, _ = hc._resolver_env_verdict(_REPO / "src" / "workspace_default.py")
-        self.assertEqual(v, "ignores")
+    def test_the_canonical_resolver_does_not_honour_the_env(self):
+        """The canonical file reads `unknown`, and that is the honest verdict.
+
+        It used to read `ignores`, but only because a callee's verdict was
+        dropped when the call was held in a local: the wrapper stores
+        `sutando_config.resolve_workspace()` in `target` and returns it, and
+        that delegate is itself `unknown` (its resolver flows through `get()`).
+        So the old `ignores` was the false clean this analysis exists to refuse.
+        What must hold is that it never reads `honours`.
+        """
+        v, why = hc._resolver_env_verdict(_REPO / "src" / "workspace_default.py")
+        self.assertNotEqual(v, "honours", why)
+        self.assertEqual(v, "unknown", why)
+
+    def test_a_clean_resolver_still_reads_ignores(self):
+        """The positive control the canonical file no longer provides: without
+        it, a detector that answers `unknown` for everything would pass."""
+        d = Path(tempfile.mkdtemp())
+        (d / "workspace_default.py").write_text(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n    return Path(os.getenv('HOME'))\n")
+        self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
+
+    def test_a_delegate_verdict_survives_being_held_in_a_local(self):
+        """keweichen's round-14 finding 2: `t = sib.resolve_workspace(); return t`
+        dropped the callee's verdict, so a dirty delegate read clean."""
+        d = Path(tempfile.mkdtemp())
+        (d / "sutando_config.py").write_text(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.environ['SUTANDO_WORKSPACE'])\n")
+        (d / "workspace_default.py").write_text(
+            "import sutando_config\n"
+            "def resolve_workspace():\n"
+            "    target = sutando_config.resolve_workspace()\n"
+            "    return target\n")
+        v, why = hc._resolver_env_verdict(d / "workspace_default.py")
+        self.assertEqual(v, "honours", why)
+
+    def test_a_clean_delegate_held_in_a_local_stays_ignores(self):
+        """The negative: propagation must not taint every held call."""
+        d = Path(tempfile.mkdtemp())
+        (d / "sutando_config.py").write_text(
+            "from pathlib import Path\n"
+            "def resolve_workspace():\n    return Path('/configured')\n")
+        (d / "workspace_default.py").write_text(
+            "import sutando_config\n"
+            "def resolve_workspace():\n"
+            "    target = sutando_config.resolve_workspace()\n"
+            "    return target\n")
+        self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
+
+    def test_an_alias_that_is_not_os_is_never_trusted(self):
+        """keweichen's round-14 finding 1: `import helper as os` at module scope
+        while a nested `import os` supplies the identity to a file-wide scan."""
+        d = Path(tempfile.mkdtemp())
+        (d / "helper.py").write_text(
+            "import os\ndef getenv(k):\n    return os.environ['SUTANDO_WORKSPACE']\n")
+        (d / "workspace_default.py").write_text(
+            "import helper as os\nfrom pathlib import Path\n"
+            "def unrelated():\n    import os\n"
+            "def resolve_workspace():\n    return Path(os.getenv('HOME'))\n")
+        self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "unknown")
 
     def test_a_pre_v08_shape_is_flagged_and_named(self):
         ws = Path(tempfile.mkdtemp())

--- a/tests/health-check-vendored-resolver-env.test.py
+++ b/tests/health-check-vendored-resolver-env.test.py
@@ -236,6 +236,65 @@ class TheHopIsBudgeted(unittest.TestCase):
         self.assertEqual(hc._resolver_env_verdict(d / "workspace_default.py")[0], "ignores")
 
 
+class TheKeyAndTheBindingAreDataflowToo(unittest.TestCase):
+    """Round 6: reads_env() recognized a literal key only and the taint pass
+    modelled Name targets only, so an env read reached the return unseen.
+    qingyun-wu's three controls all read 'ignores' at 2ca05484."""
+
+    def _verdict(self, src):
+        d = Path(tempfile.mkdtemp())
+        f = d / "workspace_default.py"
+        f.write_text(src)
+        return hc._resolver_env_verdict(f)[0]
+
+    def test_getenv_through_a_named_key_is_not_clean(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "KEY = 'SUTANDO_WORKSPACE'\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv(KEY))\n"), "unknown")
+
+    def test_subscript_through_a_named_key_is_not_clean(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "KEY = 'SUTANDO_WORKSPACE'\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.environ[KEY])\n"), "unknown")
+
+    def test_a_tuple_target_carries_the_taint(self):
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    raw, other = os.getenv('SUTANDO_WORKSPACE'), None\n"
+            "    return Path(raw)\n"), "honours")
+
+    def test_a_with_binding_is_modelled_too(self):
+        """The two shapes above are instances; an unmodelled binding form is
+        the class. `with ... as` bound a name the old loop never visited."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    with open(os.environ['SUTANDO_WORKSPACE']) as raw:\n"
+            "        return Path(raw)\n"), "honours")
+
+    def test_a_literal_key_for_another_variable_stays_clean(self):
+        """Negative control: only an UNRESOLVED key is unknown. A resolved key
+        naming some other variable is analysed, and analysed means clean."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    return Path(os.getenv('HOME'))\n"), "ignores")
+
+    def test_the_untainted_half_of_a_tuple_stays_clean(self):
+        """Negative control: element-wise pairing, not blanket over-tainting —
+        otherwise every tuple mentioning the env would read 'honours'."""
+        self.assertEqual(self._verdict(
+            "import os\nfrom pathlib import Path\n"
+            "def resolve_workspace():\n"
+            "    a, b = os.getenv('SUTANDO_WORKSPACE'), '/configured'\n"
+            "    return Path(b)\n"), "ignores")
+
+
 class Coverage(unittest.TestCase):
     def test_zero_copies_reports_coverage_rather_than_going_silent(self):
         """Sutando-Mini on #3892: a probe that finds nothing must SAY so."""


### PR DESCRIPTION
## The defect

v0.8 (#1440) removed `$SUTANDO_WORKSPACE` as a workspace source. A **vendored** copy of `workspace_default` predating that change still returns the env's value — so it and every v0.8 consumer resolve to different trees, but only when the env is set, and with no error on either side.

Measured on a live host, 2026-09-04:

```
vendored wire-skill copy    $SUTANDO_WORKSPACE set -> returns the env's path
src/workspace_default.py    $SUTANDO_WORKSPACE set -> WARNS, returns configured

legacy    notes/sutando-wire/peg-signals/2026-09-01.md   2026-08-31 19:33
legacy    notes/sutando-wire/peg-signals/2026-09-03.md   2026-09-03 16:04
canonical peg-signals newest                             2026-08-16 07:38
```

Peg-signal output had been landing in the pre-v0.8 tree for **18 days** while every v0.8-aware reader saw nothing newer than 08-16.

## Why a behaviour probe and not a diff against `src/`

That was my first instinct and the census killed it. Seventeen same-named vendored files, three content-drifted after resolving phase-1a transition aliases, and exactly **one** defective:

| file | drifted? | verdict |
|---|---|---|
| `wire-skill/.../workspace_default.py` | yes | **real defect** — honours the removed env |
| `ag2-sparrow/sparrowd.py` | yes | by design — `src/sparrowd.py`'s own docstring says the package shell "is deliberately blind to what it supervises; THIS file owns the worker list" |
| `ag2-sparrow/send_allowlist.py` | yes | by design — the copy uses package-internal path resolution (`from ._dirs import result_dir`) |

A name-and-hash gate flags 3 to catch 1. A gate at 33% precision gets ignored, so this asserts the one contract that is unambiguous instead.

## Why it is a probe and not a test

A repo suite **cannot see the offender**. `workspace/skill-repos/` is not in the repository, so an in-repo scan finds zero copies and passes vacuously forever. I wrote that test first; its inertness control failed immediately, which is the only reason I did not ship a permanently-green no-op. The check belongs where the workspace is readable.

## Evidence

```
mutation: `if not offenders` -> `if True`      FAILED (failures=1)
mutation: drop the filename from the detail    FAILED (failures=1)
restored                                       4 pass

live positive        warns, naming the one real offender
compliant copy       reads ok, not warn      <- discriminating control
empty tree           returns None, never a warn — absence is not a defect
unparseable copy     ok, not a guess
25 existing health-check suites   25/25 green
review-checks        hardcoded-paths + root-artifacts + prose-cap clean
```

The compliant-copy control is the load-bearing one: without it the probe could warn on *any* vendored copy and still look correct.

## Scope

Detection only. It does not fix the wire-skill copy — that is a separate change in another repo, and the underlying "which tree is authoritative" question is already parked for the owner.

Stand: Echo Act IV Pro