### PR TITLE
fix(morning-briefing): the location diagnostic reads env, the sentence reads config

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -66,6 +66,16 @@ def _run_applescript(script: str, timeout: int = 8) -> tuple[str | None, str]:
         return None, ""
 
 
+def weather_location_configured() -> bool:
+    """Are WEATHER_LAT/WEATHER_LON set for this install?
+
+    `config_get` reads the config stanza before os.environ, so an env-only
+    check answers a different question than the one get_weather() asks.
+    """
+    from sutando_config import config_get
+    return bool(config_get("WEATHER_LAT") and config_get("WEATHER_LON"))
+
+
 def get_weather() -> str:
     """Fetch current conditions from Open-Meteo (no key needed)."""
     try:
@@ -77,11 +87,10 @@ def get_weather() -> str:
         )
         # Use lat/lon from config (env legacy fallback) if set
         from sutando_config import config_get
-        _lat_cfg, _lon_cfg = config_get("WEATHER_LAT"), config_get("WEATHER_LON")
-        configured = bool(_lat_cfg and _lon_cfg)
+        configured = weather_location_configured()
         if configured:
-            lat = float(_lat_cfg)
-            lon = float(_lon_cfg)
+            lat = float(config_get("WEATHER_LAT"))
+            lon = float(config_get("WEATHER_LON"))
 
         unit = (config_get("WEATHER_UNIT", "fahrenheit") or "fahrenheit").strip().lower()
         if unit not in ("fahrenheit", "celsius"):
@@ -779,8 +788,7 @@ def main():
     # Gather all sources (skip errors silently)
     weather = get_weather()
     print(f"  weather: {weather or 'unavailable'}")
-    import os as _os
-    if weather and not (_os.environ.get("WEATHER_LAT") and _os.environ.get("WEATHER_LON")):
+    if weather and not weather_location_configured():
         print("    (default location; set WEATHER_LAT/WEATHER_LON for the owner's)")
 
     events = get_calendar_events()

--- a/tests/morning-briefing-weather-location.test.py
+++ b/tests/morning-briefing-weather-location.test.py
@@ -159,5 +159,45 @@ class TestWeatherUnit(unittest.TestCase):
         self.assertIn("°F", w)
 
 
+class DiagnosticAgreesWithRendering(unittest.TestCase):
+    """The operator line and the sentence it describes must read one source.
+
+    `get_weather()` resolves the location through `config_get`, which reads the
+    config stanza BEFORE os.environ. An env-only check therefore answers a
+    different question, and on the documented way to configure this — the
+    config file — it reported "default location" over a correctly configured
+    install, which trains the reader to ignore the one warning that matters.
+    """
+
+    def setUp(self):
+        self.mod = _load()
+
+    def _configured(self, cfg):
+        import sutando_config
+        clean = {k: v for k, v in os.environ.items()
+                 if k not in ("WEATHER_LAT", "WEATHER_LON")}
+        with patch.dict(os.environ, clean, clear=True), \
+                patch.object(sutando_config, "config_get",
+                             lambda k, d=None: cfg.get(k, d)):
+            return self.mod.weather_location_configured()
+
+    def test_config_file_only_counts_as_configured(self):
+        # The discriminating case: env is empty, the config stanza is not.
+        self.assertTrue(self._configured({"WEATHER_LAT": "33.4255",
+                                          "WEATHER_LON": "-111.9400"}))
+
+    def test_nothing_set_is_unconfigured(self):
+        self.assertFalse(self._configured({}))
+
+    def test_a_half_set_location_is_unconfigured(self):
+        self.assertFalse(self._configured({"WEATHER_LAT": "33.4255"}))
+
+    def test_env_alone_still_counts(self):
+        """config_get falls back to os.environ, so the legacy path is intact."""
+        with patch.dict(os.environ,
+                        {"WEATHER_LAT": "33.4255", "WEATHER_LON": "-111.9400"}):
+            self.assertTrue(self.mod.weather_location_configured())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/morning-briefing-weather-location.test.py
+++ b/tests/morning-briefing-weather-location.test.py
@@ -12,9 +12,12 @@ The fallback now names itself. A configured install is unaffected.
 
 No real network runs here.
 """
+import contextlib
 import importlib.util
+import io
 import json
 import os
+import sys
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -197,6 +200,49 @@ class DiagnosticAgreesWithRendering(unittest.TestCase):
         with patch.dict(os.environ,
                         {"WEATHER_LAT": "33.4255", "WEATHER_LON": "-111.9400"}):
             self.assertTrue(self.mod.weather_location_configured())
+
+
+class DiagnosticAtTheCallSite(unittest.TestCase):
+    """Drives main()'s own line, not the helper it calls.
+
+    A suite that only exercises `weather_location_configured()` verifies the
+    fix where it was introduced and leaves it unverified where it was observed:
+    reverting just the call site to an os.environ read keeps that suite green.
+    """
+
+    class _Stop(Exception):
+        """Raised from the next gatherer to end main() after the weather block."""
+
+    def _weather_block_output(self, cfg):
+        mod = _load()
+        import sutando_config
+        clean = {k: v for k, v in os.environ.items()
+                 if k not in ("WEATHER_LAT", "WEATHER_LON")}
+        buf = io.StringIO()
+        with patch.dict(os.environ, clean, clear=True), \
+                patch.object(sutando_config, "config_get",
+                             lambda k, d=None: cfg.get(k, d)), \
+                patch.object(mod, "get_weather",
+                             lambda: "70\u00b0F and clear, high of 75, low of 60"), \
+                patch.object(mod, "get_calendar_events", side_effect=self._Stop), \
+                patch.object(sys, "argv", ["morning-briefing.py", "--force"]), \
+                contextlib.redirect_stdout(buf):
+            with self.assertRaises(self._Stop):
+                mod.main()
+        return buf.getvalue()
+
+    def test_config_file_only_does_not_print_the_default_location_line(self):
+        out = self._weather_block_output({"WEATHER_LAT": "33.4255",
+                                          "WEATHER_LON": "-111.9400"})
+        self.assertIn("weather: 70", out, "the block under test did not run")
+        self.assertNotIn("default location", out)
+
+    def test_unconfigured_still_prints_it(self):
+        # The positive control: without it, the assertion above passes for a
+        # line that was simply never reached.
+        out = self._weather_block_output({})
+        self.assertIn("weather: 70", out)
+        self.assertIn("default location", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

`get_weather()` resolves `WEATHER_LAT`/`WEATHER_LON` through `config_get`, which reads the config stanza **before** `os.environ` (#1832). The operator line added next to it in #3501 reads `os.environ` directly. Two readers, one setting, no shared owner — so they answer different questions.

## Before, on a host that configures it the documented way

`sutando.config.local.json` sets `WEATHER_LAT 33.4255 / WEATHER_LON -111.9400`. Today's real briefing run at the parent commit:

```
  weather: 85°F and clear, high of 102, low of 84
    (default location; set WEATHER_LAT/WEATHER_LON for the owner's)
```

The **sentence is correct** — `configured` is true at `:81`, `where` is empty at `:110`, and no fallback label is rendered, which is exactly what #3501 intended. The **diagnostic under it is wrong**, and it points the safe way round: it cries "unconfigured" over a correctly configured install. That is how a warning earns being ignored on the day it is right.

## After

```
  weather: 85°F and clear, high of 102, low of 84
```

## The fix

Both call sites read one helper rather than each restating the predicate:

```python
def weather_location_configured() -> bool:
    from sutando_config import config_get
    return bool(config_get("WEATHER_LAT") and config_get("WEATHER_LON"))
```

Patching only the diagnostic (`_os.environ` → `config_get`) would have fixed today's symptom and left the duplicate in place. The duplication is the defect.

## Verification

- **Four new cases** on the helper. The discriminating one is `test_config_file_only_counts_as_configured` — config stanza set, `os.environ` empty. That is the shape this host is in and the only one where the two readers disagree; the three existing configured/unconfigured tests set env, so they pass under both readers and cannot catch this.
- **Mutation control**: reverting the helper body to an `os.environ` read fails exactly `test_config_file_only_counts_as_configured` and nothing else. Restored → 13/13 OK.
- `test_env_alone_still_counts` pins the legacy path: `config_get` falls back to `os.environ`, so an env-only install is unaffected.
- **Siblings at head**, all rc=0: `morning-briefing-completion-line`, `morning-briefing-calendar-google-source`, `morning-briefing-src-dir-wiring`, `morning-briefing-clip-for-speech`.
- `scripts/review-checks.sh` on the cumulative diff: **PASS**. `git diff --check`: clean.

## Scope

Diagnostic output only — the delivered briefing text is unchanged in every case, before and after. Single concern; no bundled cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
