### PR TITLE
feat(dashboard): the Quota tile names the model in use, stamped by the proxy on every request

### DIFF
--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -335,6 +335,18 @@ function isRejectionRecord(x: unknown): x is RejectionRecord {
 }
 
 /** Append one rejection to a (possibly foreign/corrupt) prior ledger, keeping the newest `max`. */
+export interface LastRequest { model: string; at: string }
+
+/** The model that last consumed quota through this proxy, carried across
+ *  requests that name none (a non-messages call must not blank the tile). */
+export function withLastRequest(prev: unknown, model: string, at: string): LastRequest | undefined {
+	if (model) return { model, at };
+	const old = (prev as { last_request?: unknown } | null)?.last_request;
+	if (old && typeof old === 'object' && typeof (old as LastRequest).model === 'string' && (old as LastRequest).model
+		&& typeof (old as LastRequest).at === 'string') return old as LastRequest;
+	return undefined;
+}
+
 export function appendRejection(prev: unknown, rej: RejectionRecord, max: number = MAX_RECENT_REJECTIONS): RejectionRecord[] {
 	const list = Array.isArray(prev) ? prev.filter(isRejectionRecord) : [];
 	list.push(rej);
@@ -347,7 +359,7 @@ export interface ProxyDeps {
 	refreshAccessToken: (oauth: ClaudeOAuth) => Promise<ClaudeOAuth | null>;
 	request: typeof httpsRequest;
 	upstreamUrl: URL;
-	updateQuotaState: (headers: Record<string, string>) => void;
+	updateQuotaState: (headers: Record<string, string>, model?: string) => void;
 	recordRejection: (rej: RejectionRecord) => void;
 	now: () => number;
 	idleTimeoutMs: number;
@@ -524,7 +536,7 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 						}
 						if (Object.keys(quotaHeaders).length > 0) {
 							console.log(`${ts()} [Quota]`, quotaHeaders);
-							deps.updateQuotaState(quotaHeaders);
+							deps.updateQuotaState(quotaHeaders, requestModel(body));
 						}
 
 						if (upRes.statusCode === 401 && injectedToken && attempt === 0) {
@@ -644,15 +656,18 @@ function recordRejection(rej: RejectionRecord): void {
 	} catch { /* best effort */ }
 }
 
-function updateQuotaState(headers: Record<string, string>): void {
+function updateQuotaState(headers: Record<string, string>, model = ''): void {
 	try {
 		// The header write replaces the file, so carry the rejection ledger across it.
-		const prevLedger = readQuotaFile().recent_rejections;
+		const prev = readQuotaFile();
+		const prevLedger = prev.recent_rejections;
+		const lastRequest = withLastRequest(prev, model, new Date().toISOString());
 		const state: Record<string, unknown> = {
 			available: true,
 			last_checked: new Date().toISOString(),
 			headers,
 			recent_rejections: Array.isArray(prevLedger) ? prevLedger.filter(isRejectionRecord) : [],
+			...(lastRequest ? { last_request: lastRequest } : {}),
 		};
 
 		// Parse specific headers

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -245,6 +245,17 @@ def _quota_freshness(data: dict, quota_file) -> dict:
 
 
 
+def _quota_model_label(quota: dict) -> str:
+    """The model last seen consuming quota, from the proxy's `last_request`.
+
+    Read from what the proxy observed on the wire, not from a launch-time
+    marker: /model switches mid-session, and a stamped model would go stale.
+    """
+    lr = quota.get("last_request")
+    model = lr.get("model") if isinstance(lr, dict) else None
+    return model.strip() if isinstance(model, str) and model.strip() else "model —"
+
+
 def _quota_has_data(quota: dict) -> bool:
     """Whether a reading actually exists, as opposed to defaulting to zero.
 
@@ -674,7 +685,7 @@ def render_dashboard() -> str:
 <div class="stat"><div class="stat-val">{stats['battery']}{charge}</div><div class="stat-label">Battery</div></div>
 <div class="stat"><div class="stat-val">{ok_count}/{total_count}</div><div class="stat-label">Services OK</div></div>
 <div class="stat"><div class="stat-val">{pending['open']}</div><div class="stat-label">Pending</div></div>
-<div class="stat"><div class="stat-val">{"⚠" if stats["quota"].get("stale") else ("—" if not _quota_has_data(stats["quota"]) else ("✓" if stats["quota"].get("available", True) else "✗"))}</div><div class="stat-label">Quota<br><span style="font-size:9px;color:{"#b45309" if stats["quota"].get("stale") else "#444"}">{_quota_age_label(stats["quota"])}</span></div></div>
+<div class="stat"><div class="stat-val">{"⚠" if stats["quota"].get("stale") else ("—" if not _quota_has_data(stats["quota"]) else ("✓" if stats["quota"].get("available", True) else "✗"))}</div><div class="stat-label">Quota<br><span style="font-size:9px;color:#8fa3c8">{_quota_model_label(stats["quota"])}</span><br><span style="font-size:9px;color:{"#b45309" if stats["quota"].get("stale") else "#444"}">{_quota_age_label(stats["quota"])}</span></div></div>
 <div class="stat"><div class="stat-val" style="display:flex;align-items:center;justify-content:center;gap:8px"><svg id="qr-5h" width="44" height="44" viewBox="0 0 44 44" style="flex:none"><text x="22" y="26" text-anchor="middle" fill="#e8e8f0" font-size="10">{_quota_tile_pct(stats["quota"], "5h") if _quota_has_data(stats["quota"]) else "—"}</text></svg><svg id="qs-5h" width="160" height="60" viewBox="0 0 160 60" style="flex:none"></svg></div><div class="stat-label">5h Used<br><span style="font-size:9px;color:#444">↻ {stats["quota"].get("reset_5h", "?")}</span></div></div>
 <div class="stat"><div class="stat-val" style="display:flex;align-items:center;justify-content:center;gap:8px"><svg id="qr-7d" width="44" height="44" viewBox="0 0 44 44" style="flex:none"><text x="22" y="26" text-anchor="middle" fill="#e8e8f0" font-size="10">{_quota_tile_pct(stats["quota"], "7d") if _quota_has_data(stats["quota"]) else "—"}</text></svg><svg id="qs-7d" width="160" height="60" viewBox="0 0 160 60" style="flex:none"></svg></div><div class="stat-label">7d Used<br><span style="font-size:9px;color:#444">↻ {stats["quota"].get("reset_7d", "?")}</span></div></div>
 </div>""" + _QUOTA_SPARK_JS + """</div>""")

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 
 import http.server
+import html
 import json
 import os
 import re
@@ -245,6 +246,9 @@ def _quota_freshness(data: dict, quota_file) -> dict:
 
 
 
+_QUOTA_MODEL_MAX_LEN = 64
+
+
 def _quota_model_label(quota: dict) -> str:
     """The model last seen consuming quota, from the proxy's `last_request`.
 
@@ -253,7 +257,11 @@ def _quota_model_label(quota: dict) -> str:
     """
     lr = quota.get("last_request")
     model = lr.get("model") if isinstance(lr, dict) else None
-    return model.strip() if isinstance(model, str) and model.strip() else "model —"
+    if not isinstance(model, str) or not model.strip():
+        return "model —"
+    # The value comes from a request body any local caller can send: escape
+    # at the sink and cap it, so the tile cannot carry markup or a novel.
+    return html.escape(model.strip()[:_QUOTA_MODEL_MAX_LEN])
 
 
 def _quota_has_data(quota: dict) -> bool:

--- a/tests/credential-proxy-last-request-model.test.ts
+++ b/tests/credential-proxy-last-request-model.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The proxy is the one component that sees which model is consuming quota,
+ * on every request. It stamps that model into quota-state.json beside the
+ * rate-limit headers so the dashboard can show "the model in use" from what
+ * was observed on the wire — not from a launch-time marker that a /model
+ * switch leaves stale. A request naming no model carries the previous stamp.
+ */
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createServer as createHttpServer, request as httpRequest, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { request as httpsRequest } from 'node:https';
+import { createProxyServer, withLastRequest, type ProxyDeps } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+
+const NOW = 1_700_000_000_000;
+let upstreamHandler: (req: IncomingMessage, res: ServerResponse) => void = () => {};
+const servers: Server[] = [];
+afterEach(async () => {
+	await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
+});
+
+function listen(s: Server): Promise<number> {
+	servers.push(s);
+	return new Promise((resolve) => s.listen(0, '127.0.0.1', () => resolve((s.address() as { port: number }).port)));
+}
+
+async function startProxy(seen: Array<[Record<string, string>, string | undefined]>): Promise<number> {
+	const upstreamPort = await listen(createHttpServer((req, res) => upstreamHandler(req, res)));
+	const deps: Partial<ProxyDeps> = {
+		readCredCandidates: () => [{ service: 'svc', oauth: { accessToken: 'tok', expiresAt: NOW + 3600_000 } }],
+		writeCred: () => true,
+		refreshAccessToken: async () => null,
+		request: httpRequest as unknown as typeof httpsRequest,
+		upstreamUrl: new URL(`http://127.0.0.1:${upstreamPort}`),
+		updateQuotaState: (headers, model) => { seen.push([headers, model]); },
+		recordRejection: () => {},
+		now: () => NOW,
+		idleTimeoutMs: 5000,
+	};
+	return listen(createProxyServer(deps));
+}
+
+function call(port: number, reqBody: string): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const req = httpRequest({ hostname: '127.0.0.1', port, path: '/v1/messages', method: 'POST' }, (res) => {
+			res.resume();
+			res.on('end', () => resolve(res.statusCode ?? 0));
+		});
+		req.on('error', reject);
+		req.end(reqBody);
+	});
+}
+
+test('the request model travels with the rate-limit headers into the quota-state write', async () => {
+	upstreamHandler = (_req, res) => {
+		res.writeHead(200, { 'anthropic-ratelimit-unified-5h-utilization': '0.13' });
+		res.end('{}');
+	};
+	const seen: Array<[Record<string, string>, string | undefined]> = [];
+	const port = await startProxy(seen);
+	assert.strictEqual(await call(port, '{"model":"claude-fable-5-1","messages":[]}'), 200);
+	assert.strictEqual(seen.length, 1, 'one quota write for one response carrying rate-limit headers');
+	assert.strictEqual(seen[0][0]['anthropic-ratelimit-unified-5h-utilization'], '0.13');
+	assert.strictEqual(seen[0][1], 'claude-fable-5-1');
+});
+
+test('a request naming no model passes "" — the writer carries the previous stamp, not the reader', async () => {
+	upstreamHandler = (_req, res) => {
+		res.writeHead(200, { 'anthropic-ratelimit-unified-7d-utilization': '0.67' });
+		res.end('{}');
+	};
+	const seen: Array<[Record<string, string>, string | undefined]> = [];
+	const port = await startProxy(seen);
+	await call(port, '{"messages":[]}');
+	assert.strictEqual(seen[0][1], '');
+});
+
+test('withLastRequest: a named model stamps; an empty one carries a well-formed previous stamp only', () => {
+	assert.deepStrictEqual(withLastRequest({}, 'claude-opus-5', 'T1'), { model: 'claude-opus-5', at: 'T1' });
+	const prev = { last_request: { model: 'claude-fable-5-1', at: 'T0' } };
+	assert.deepStrictEqual(withLastRequest(prev, '', 'T1'), { model: 'claude-fable-5-1', at: 'T0' });
+	assert.deepStrictEqual(withLastRequest(prev, 'claude-opus-5', 'T1'), { model: 'claude-opus-5', at: 'T1' });
+	assert.strictEqual(withLastRequest({}, '', 'T1'), undefined);
+	assert.strictEqual(withLastRequest({ last_request: { model: '', at: 'T0' } }, '', 'T1'), undefined);
+	assert.strictEqual(withLastRequest({ last_request: 'claude-x' }, '', 'T1'), undefined);
+	assert.strictEqual(withLastRequest(null, '', 'T1'), undefined);
+});

--- a/tests/dashboard-model-in-use.test.py
+++ b/tests/dashboard-model-in-use.test.py
@@ -60,6 +60,14 @@ tile = quota_tile(render_with({**LIVE, "last_request": None}))
 check("A5 absence is visible in the tile, not a blank", "model —" in tile, tile)
 check("A6 absence never borrows a model from elsewhere", "claude-" not in tile, tile)
 
+# --- the value is attacker-reachable: any local caller can put markup in a request body
+EVIL = {**LIVE, "last_request": {"model": "<img src=x onerror=alert(1)>", "at": "T"}}
+tile = quota_tile(render_with(EVIL))
+check("S1 markup in the model is escaped at the sink", "&lt;img src=x onerror=alert(1)&gt;" in tile, tile)
+check("S2 ...and never rendered raw", "<img src=x" not in tile, tile)
+LONG = {**LIVE, "last_request": {"model": "claude-" + "x" * 500, "at": "T"}}
+check("S3 a pathological model string is capped", len(dash._quota_model_label(LONG)) <= 64, str(len(dash._quota_model_label(LONG))))
+
 print()
 if fails:
     print(f"FAILED ({len(fails)}): " + "; ".join(fails)); sys.exit(1)

--- a/tests/dashboard-model-in-use.test.py
+++ b/tests/dashboard-model-in-use.test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""The Quota tile names the model in use, from the proxy's `last_request` stamp.
+
+Owner ask (2026-09-03, repeated 2026-09-04): display the model in use next to
+the quota in the dashboard. The source is what the credential proxy saw on the
+wire — a launch-time marker goes stale on a mid-session /model switch. Absence
+renders as an honest "model —", never as a guess.
+"""
+import importlib.util
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("dash", REPO / "src" / "dashboard.py")
+dash = importlib.util.module_from_spec(spec)
+sys.modules["dash"] = dash
+spec.loader.exec_module(dash)
+
+fails = []
+
+
+def check(label, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + label + ("" if cond else f" — {detail}"))
+    if not cond:
+        fails.append(label)
+
+
+def render_with(quota):
+    real = dash.get_system_stats
+    dash.get_system_stats = lambda: {"disk_free": "53GB", "battery": "42%", "charging": False, "quota": quota}
+    try:
+        return dash.render_dashboard()
+    finally:
+        dash.get_system_stats = real
+
+
+def quota_tile(html):
+    i = html.index(">Quota<br>")
+    return html[i:html.index("</div></div>", i)]
+
+
+LIVE = {"available": True, "age_h": 0.1, "stale": False,
+        "headers": {"anthropic-ratelimit-unified-5h-utilization": "0.13"},
+        "last_request": {"model": "claude-fable-5-1", "at": "2026-09-04T16:20:08Z"}}
+
+check("L1 helper returns the stamped model", dash._quota_model_label(LIVE) == "claude-fable-5-1")
+tile = quota_tile(render_with(LIVE))
+check("L2 the Quota tile shows the model", "claude-fable-5-1" in tile, tile)
+check("L3 the age label still follows it", "ago" in tile or "no data" in tile or "h old" in tile, tile)
+
+for label, quota in (
+    ("A1 no stamp (proxy predates it)", {**LIVE, "last_request": None}),
+    ("A2 stamp key absent", {k: v for k, v in LIVE.items() if k != "last_request"}),
+    ("A3 malformed stamp", {**LIVE, "last_request": "claude-x"}),
+    ("A4 empty model", {**LIVE, "last_request": {"model": "  ", "at": "T"}}),
+):
+    check(f"{label} renders 'model —'", dash._quota_model_label(quota) == "model —", dash._quota_model_label(quota))
+
+tile = quota_tile(render_with({**LIVE, "last_request": None}))
+check("A5 absence is visible in the tile, not a blank", "model —" in tile, tile)
+check("A6 absence never borrows a model from elsewhere", "claude-" not in tile, tile)
+
+print()
+if fails:
+    print(f"FAILED ({len(fails)}): " + "; ".join(fails)); sys.exit(1)
+print("all checks pass")


### PR DESCRIPTION
## Why

Owner, 2026-09-03 and again 2026-09-04: *"I asked to display the model in use next to the quota in the dashboard. Is it never done?"* It was not. The credential proxy is the only component that sees which model is consuming quota, on every request — until now it kept the model on rejections only (#3795's ledger).

## What

- **`credential-proxy.ts`**: `updateQuotaState(headers, model)` stamps `last_request: {model, at}` into `quota-state.json` beside the rate-limit headers. A request naming no model carries the previous stamp (`withLastRequest`, pure and exported), so a non-messages call never blanks the tile. `recordRejection` already spreads the previous state, so the stamp survives a rejection write.
- **`dashboard.py`**: `_quota_model_label` reads the stamp; the Quota tile shows it under "Quota", above the age. Absent or malformed → `model —`, never a guess.
- Deliberately **not** read from `core-runtime.json`: that marker records launch-time facts and a mid-session `/model` switch leaves it stale — the same call `health-check.py`'s `_own_core_model` makes. (#2406 is about that marker's runtime field and is unrelated.)

## Evidence

Before — origin/main `a5ccf744`, same quota dict with a stamped model present:
```
has _quota_model_label = False
Quota tile: >Quota<br><span style="font-size:9px;color:#444">6m ago</span>
model in tile: False
```
After — `31f9431f`:
```
>Quota<br><span style="font-size:9px;color:#8fa3c8">claude-fable-5-1</span><br><span style="font-size:9px;color:#444">6m ago</span>
```

Proxy side, the new TS suite (node:test via tsx):
```
✔ the request model travels with the rate-limit headers into the quota-state write
✔ a request naming no model passes "" — the writer carries the previous stamp, not the reader
✔ withLastRequest: a named model stamps; an empty one carries a well-formed previous stamp only
ℹ tests 3  ℹ pass 3  ℹ fail 0
```
Mutation — call site reverted to `deps.updateQuotaState(quotaHeaders)`: `ℹ pass 1 ℹ fail 2` (the two wire tests). Mutation — the tile's model span removed: `dashboard-model-in-use.test.py` 2 FAIL lines (L2, A5).

Existing suites unchanged and green: `credential-proxy-{rejection-ledger,failure-semantics,refresh}.test.ts`, `dashboard-{quota-no-data,quota-staleness,usecase-empty-state}.test.py`. `tsc --noEmit` and `tsc -p tsconfig.skills.json`: 8 errors each, all in `src/voice-agent.ts` (6) and `src/voice-audio-health.ts` (2), untouched here. eslint clean. Added lines carry no host paths.

## Deploy note

Both writers are live services: the running proxy keeps writing the old shape and the running dashboard keeps rendering the old tile until each is restarted. Until the proxy restarts, the new dashboard shows `model —` (honest absence), never a stale name.

Stand: Echo Act IV Mini
