### PR TITLE
docs(built-in-tools): Google Contacts is writable via CardDAV with the Gmail app password

### DIFF
--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -62,6 +62,30 @@ python3 $CLAUDE_CONFIG_DIR/skills/macos-tools/scripts/contacts.py search "Bob"  
 ```
 Use before sending email to resolve "email Bob" → actual email address. Returns name, emails, phones.
 
+**Google Contacts (read + WRITE) — a Gmail app password already reaches CardDAV.** The entry above is
+macOS Contacts and is lookup-only; it is not the only contacts path. A stored Gmail **app password**
+authenticates Basic auth against Google's CardDAV endpoint, so the same secret held for IMAP/SMTP can
+create and read contacts with no extra scope, no service-account delegation and no Admin-console
+change:
+
+```bash
+BASE="https://www.googleapis.com/carddav/v1/principals/$USER_EMAIL/lists/default/"
+curl -su "$USER_EMAIL:$APP_PASSWORD" -X PROPFIND "$BASE" -H 'Depth: 1'      # 207 = reachable
+curl -su "$USER_EMAIL:$APP_PASSWORD" -X PUT "$BASE<uid>.vcf" \
+     -H 'Content-Type: text/vcard; charset=utf-8' -H 'If-None-Match: *' \
+     --data-binary @contact.vcf                                            # 201 = created
+curl -su "$USER_EMAIL:$APP_PASSWORD" "$BASE<uid>.vcf"                      # read it back
+```
+
+`If-None-Match: *` makes the PUT create-only, so a retry cannot silently overwrite an existing card.
+Get the app password from the vault (`secret-vault.py get <KEY>`); never inline it.
+
+**⚠ The general rule this entry exists to teach: a credential's reach is not the name of the tool you
+got it for.** One Google app password unlocks **IMAP + SMTP + CardDAV + CalDAV**. Before telling the
+owner "I have no way to do X", check what your *held credentials* reach by protocol — not what this
+catalog happens to list. Answering from the catalog is how a capability that already existed gets
+reported as missing.
+
 **iMessage** — send and read iMessages:
 ```bash
 imsg send --to "+14155551234" --text "Hello!"    # send message

--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -62,29 +62,48 @@ python3 $CLAUDE_CONFIG_DIR/skills/macos-tools/scripts/contacts.py search "Bob"  
 ```
 Use before sending email to resolve "email Bob" → actual email address. Returns name, emails, phones.
 
-**Google Contacts (read + WRITE) — a Gmail app password already reaches CardDAV.** The entry above is
-macOS Contacts and is lookup-only; it is not the only contacts path. A stored Gmail **app password**
-authenticates Basic auth against Google's CardDAV endpoint, so the same secret held for IMAP/SMTP can
-create and read contacts with no extra scope, no service-account delegation and no Admin-console
-change:
+**Google Contacts — writable in practice, but NOT via a contract Google supports.** The entry above
+is macOS Contacts and is lookup-only. It is not the only contacts path: on 2026-09-04 an agent that
+had been told no write path existed created a contact on a live Google account using **only the Gmail
+app password already held for IMAP/SMTP** — `PROPFIND` returned 207, `PUT` of a vCard returned 201,
+and a `GET` read it back (#3903).
+
+**Read that as an observation, not as Google's credential contract.** Google's own CardDAV
+documentation specifies OAuth 2.0 with a registered application, tells clients to begin at
+`https://www.googleapis.com/.well-known/carddav` rather than hardcoding a discovered URI, and
+documents `POST` of a vCard as the insert operation (`PUT` being the update path). The app-password
+Basic-auth flow below matches none of that. It is legacy behaviour that happened to work once, on one
+account, and Google can withdraw it without notice.
+
+So: **probe before you rely on it, and never present it to the owner as a supported integration.**
 
 ```bash
-BASE="https://www.googleapis.com/carddav/v1/principals/$USER_EMAIL/lists/default/"
-curl -su "$USER_EMAIL:$APP_PASSWORD" -X PROPFIND "$BASE" -H 'Depth: 1'      # 207 = reachable
+# 1. DISCOVER — do not hardcode the principal URL; Google says it can change.
+curl -su "$USER_EMAIL:$APP_PASSWORD" -X PROPFIND \
+     https://www.googleapis.com/.well-known/carddav -H 'Depth: 0'
+# 2. PROBE the collection you discovered. 207 = this legacy path is still open for this account;
+#    401/403 = it is not — stop, and say so, rather than assuming the 2026-09-04 result still holds.
+BASE="<collection URL from step 1>"     # observed then: .../carddav/v1/principals/$USER_EMAIL/lists/default/
+curl -su "$USER_EMAIL:$APP_PASSWORD" -X PROPFIND "$BASE" -H 'Depth: 1'
+# 3. CREATE. Google documents POST for insert; PUT with `If-None-Match: *` is what was observed to
+#    work, and is create-only, so a retry cannot silently overwrite an existing card.
 curl -su "$USER_EMAIL:$APP_PASSWORD" -X PUT "$BASE<uid>.vcf" \
      -H 'Content-Type: text/vcard; charset=utf-8' -H 'If-None-Match: *' \
-     --data-binary @contact.vcf                                            # 201 = created
+     --data-binary @contact.vcf
 curl -su "$USER_EMAIL:$APP_PASSWORD" "$BASE<uid>.vcf"                      # read it back
 ```
 
-`If-None-Match: *` makes the PUT create-only, so a retry cannot silently overwrite an existing card.
-Get the app password from the vault (`secret-vault.py get <KEY>`); never inline it.
+Get the app password from the vault (`secret-vault.py get <KEY>`); never inline it. If the probe in
+step 2 fails, the supported route is OAuth 2.0 against the People API or CardDAV with a registered
+client — build that rather than retrying Basic auth with the owner's secret.
 
 **⚠ The general rule this entry exists to teach: a credential's reach is not the name of the tool you
-got it for.** One Google app password unlocks **IMAP + SMTP + CardDAV + CalDAV**. Before telling the
-owner "I have no way to do X", check what your *held credentials* reach by protocol — not what this
-catalog happens to list. Answering from the catalog is how a capability that already existed gets
-reported as missing.
+got it for.** A Google app password is accepted by IMAP and SMTP, and — as above — was accepted by
+CardDAV. Before telling the owner "I have no way to do X", spend one probe on what your *held
+credentials* actually reach, rather than answering from what this catalog happens to list. Answering
+from the catalog is how a capability that already existed gets reported as missing. The probe is also
+what keeps the answer honest in the other direction: it distinguishes "this works" from "this worked
+once for someone else."
 
 **iMessage** — send and read iMessages:
 ```bash


### PR DESCRIPTION
Closes #3903.

## The defect, confirmed in this repo

The report says the agent answered a capability question from the tools catalog instead of from the
credential it held. Verified here rather than taken on trust:

```
$ grep -rn -il "carddav" docs/ src/ skills/
(no output — zero files)
$ grep -rn -il "imap" docs/ src/          # control: the probe CAN hit
docs/built-in-tools.md
$ grep -n -i "contacts" docs/built-in-tools.md
59:**Contacts** — look up people by name or email:
61:...skills/macos-tools/scripts/contacts.py search "Bob"   # find by name
```

So: **CardDAV appears nowhere in the repo**, the only Contacts entry is the macOS lookup recipe, and
there is no statement anywhere of what a stored credential reaches by protocol. An agent reading this
catalog and asked to write a Google contact has no path to the right answer, which is exactly the
false negative the owner was given twice.

## The change

One entry added next to the existing Contacts recipe (docs only, +24 lines, no behaviour change):

- the CardDAV recipe — PROPFIND to check reachability, `PUT <uid>.vcf` with `If-None-Match: *`, GET
  read-back — using the app password already held for IMAP/SMTP, with no extra scope, no
  service-account delegation and no Admin-console change;
- `If-None-Match: *` is called out because it makes the PUT create-only, so a retry cannot silently
  overwrite an existing card;
- the secret comes from the vault (`secret-vault.py get`), never inlined;
- and the general rule the incident actually turns on: **a credential's reach is not the name of the
  tool you obtained it for.** One Google app password reaches IMAP + SMTP + CardDAV + CalDAV.

## Scope, and what I did NOT do

The report suggests three fixes. This PR is **only the first**, to keep one concern per PR:

- **(2) a per-secret "credential reach" table** — a new doc/structure; worth doing, separate change.
- **(3) require a cheap probe before answering "I cannot do X"** — a behavioural rule belonging in
  the loop/agent guidance, not this catalog. It is the deepest of the three and deserves its own
  review.

**The live CardDAV verification (207 / 201 / read-back) is the incident's, not mine.** I did not
re-run it against the owner's account — that would mean exercising their Gmail credential to prove a
docs change. The repo-side evidence above is what I measured.

## Checks

`scripts/review-checks.sh` on `origin/main...HEAD`: hardcoded-paths and root-artifacts **clean**;
prose-cap reports "no in-scope files (exts .py)" — recording that as **PARTIAL**, not a pass, since a
scanner that examined nothing has cleared nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
