### PR TITLE
fix(lint): PATTERN_ENV missed the subscript env read its own header claims

### DIFF
--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -39,7 +39,7 @@ mode="${1:-all}"  # all | --diff
 
 # Patterns that signal direct workspace resolution.
 # Each pattern is a single ERE alternation we feed grep -E.
-PATTERN_ENV='(process\.env|process\.env\[)["'\'']?SUTANDO_WORKSPACE|os\.environ(\.get)?\(["'\'']SUTANDO_WORKSPACE|os\.getenv\(["'\'']SUTANDO_WORKSPACE'
+PATTERN_ENV='(process\.env|process\.env\[)["'\'']?SUTANDO_WORKSPACE|os\.environ(\.get)?\(["'\'']SUTANDO_WORKSPACE|os\.environ\[["'\'']SUTANDO_WORKSPACE|os\.getenv\(["'\'']SUTANDO_WORKSPACE'
 PATTERN_HARDCODED_HOME='\.sutando/workspace'
 PATTERN_REPO_WALK='Path\(__file__\)\.resolve\(\)\.parent\.parent'
 
@@ -97,7 +97,7 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # which predate this --diff lint and are grandfathered. A repo-tooling script has
 # no workspace to go through the wrapper for; the wrapper resolves the workspace,
 # which is the wrong directory here.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/check-python39-compat\.py|skills/review-preflight/scripts/review-preflight\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/check-python39-compat\.py|skills/review-preflight/scripts/review-preflight\.py|tests/.+\.(test\.)?(py|ts|sh)|src/[^/]+\.test\.py|packages/ag2-sparrow/.*\.py)$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form

--- a/tests/lint-workspace-resolution-env-forms.test.sh
+++ b/tests/lint-workspace-resolution-env-forms.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# PATTERN_ENV must catch every `$SUTANDO_WORKSPACE` read form its own header claims.
+#
+# The header comment lists `os.environ["SUTANDO_WORKSPACE"]` among the forms this lint
+# detects, but the regex required a PAREN after `os.environ` — so the subscript form,
+# the most idiomatic of the three in Python, passed the `--diff` gate silently. Doc and
+# regex disagreed, and the gate is what CI runs.
+#
+# Controls, in --diff mode because that is the branch that exits 1:
+#
+#   1. subscript form            FAILS   (the defect this pins)
+#   2. .get() form               FAILS   (the arm that already worked — proves the
+#                                         harness can produce a hit, so control 1's
+#                                         failure is about the regex, not the fixture)
+#   3. os.getenv() form          FAILS   (third documented form)
+#   4. a clean file              PASSES  (the lint is not simply failing everything —
+#                                         without this, a regex of `.` would score 3/3)
+#   5. a test under tests/<sub>/ PASSES  (widening the pattern must not start gating
+#                                         test files the ALLOWED policy already exempts)
+#
+# Control 4 is the one that matters for reading the set at a glance: three FAILs prove
+# nothing on their own, because a pattern that matches everything produces them too.
+#
+# Run: bash tests/lint-workspace-resolution-env-forms.test.sh
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LINT="$REPO/scripts/lint-workspace-resolution.sh"
+fails=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s %s\n' "$1" "${2:-}"; fails=$((fails+1)); }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+scaffold() {
+  rm -rf "$TMP/r"; mkdir -p "$TMP/r/scripts" "$TMP/r/src" "$TMP/r/tests/observability"
+  cp "$LINT" "$TMP/r/scripts/lint-workspace-resolution.sh"
+  cd "$TMP/r" || exit 9
+  git init -q . && git config user.email t@t && git config user.name t
+  printf 'placeholder\n' > README.md
+  git add -A && git commit -qm base
+  git branch -qM main
+  # Probe commits must sit off the base ref, or `git diff main...HEAD` is empty and
+  # every control passes vacuously.
+  git checkout -q -b probe
+}
+
+verdict() {  # $1 = repo-relative path, $2 = body -> exit code
+  printf '%s' "$2" > "$TMP/r/$1"
+  ( cd "$TMP/r" && git add -A && git commit -qm probe >/dev/null 2>&1 )
+  ( cd "$TMP/r" && BASE_REF=main bash scripts/lint-workspace-resolution.sh --diff >/dev/null 2>&1; echo $? )
+}
+
+echo "lint-workspace-resolution: every documented env-read form"
+
+PROBE="src/probe_reader.py"
+
+scaffold
+rc="$(verdict "$PROBE" 'import os
+ws = os.environ["SUTANDO_WORKSPACE"]
+')"
+[ "$rc" = 1 ] && ok 'subscript os.environ["SUTANDO_WORKSPACE"] is refused' \
+              || bad 'subscript form' "rc=$rc (expected 1)"
+
+scaffold
+rc="$(verdict "$PROBE" 'import os
+ws = os.environ.get("SUTANDO_WORKSPACE")
+')"
+[ "$rc" = 1 ] && ok 'os.environ.get("SUTANDO_WORKSPACE") is refused' \
+              || bad '.get form' "rc=$rc (expected 1)"
+
+scaffold
+rc="$(verdict "$PROBE" 'import os
+ws = os.getenv("SUTANDO_WORKSPACE")
+')"
+[ "$rc" = 1 ] && ok 'os.getenv("SUTANDO_WORKSPACE") is refused' \
+              || bad 'getenv form' "rc=$rc (expected 1)"
+
+scaffold
+rc="$(verdict "$PROBE" 'import os
+ws = os.environ["SOME_OTHER_VAR"]
+')"
+[ "$rc" = 0 ] && ok 'an unrelated env read still passes (pattern is not matching everything)' \
+              || bad 'clean file' "rc=$rc (expected 0)"
+
+scaffold
+rc="$(verdict "tests/observability/probe.test.py" 'import os
+ws = os.environ["SUTANDO_WORKSPACE"]
+')"
+[ "$rc" = 0 ] && ok 'a test under tests/<subdir>/ stays exempt' \
+              || bad 'tests subdir exemption' "rc=$rc (expected 0)"
+
+cd "$REPO" || exit 9
+if [ "$fails" -eq 0 ]; then echo "lint env-forms: all checks pass"; exit 0; fi
+echo "lint env-forms: $fails check(s) failed"; exit 1


### PR DESCRIPTION
## The bug

`scripts/lint-workspace-resolution.sh` documents three ways of reading `$SUTANDO_WORKSPACE` at line 10, including `os.environ["SUTANDO_WORKSPACE"]`. `PATTERN_ENV` required a **paren** after `os.environ`, so the subscript form — the most idiomatic of the three in Python — was never detected. The doc and the regex disagreed, and `--diff` is the branch CI gates on (`exit 1` at :192).

Found while building a control for the lint during review of #3902. That PR does not touch `PATTERN_ENV`; this is pre-existing and separate.

## Evidence — before, on this tree

A probe file at a non-exempt path, one form per run:

```
hits=0   os.environ["SUTANDO_WORKSPACE"]       <- undetected
hits=1   os.environ.get("SUTANDO_WORKSPACE")
hits=1   os.getenv("SUTANDO_WORKSPACE")
```

The two `hits=1` rows are the control: they prove the harness can produce a hit, so row one's zero is about the regex and not about my fixture.

## Why this is two changes and not one

Widening `PATTERN_ENV` alone newly flags **exactly two** files, and both are *tests* the `ALLOWED` policy already intends to exempt but cannot reach:

- `src/remote-gateway-bridge.test.py` — a test living outside `tests/`
- `tests/observability/meter.test.py` — a test in a **subdirectory**, which `tests/[^/]+` cannot match

Shipping the regex alone would have created a false gate on test files. So `ALLOWED` grows to cover both shapes. **Net effect on this tree: the offender set is unchanged — 9 before, 9 after, none added, none lost** (`comm` on the sorted offender lists is empty in both directions), while the new form is now caught.

## Tests

`tests/lint-workspace-resolution-env-forms.test.sh`, in `--diff` mode because that is the branch that exits 1. Five controls:

1. subscript form → refused *(the defect)*
2. `.get()` form → refused
3. `os.getenv()` → refused
4. **an unrelated env read still passes** — without this, a regex of `.` scores 3/3 on the rows above
5. **a test under `tests/<subdir>/` stays exempt** — pins that the widening does not start gating tests

Controls 4 and 5 are the ones that make the other three mean anything.

**Mutation-verified, each half failing only its own arm:**

```
revert PATTERN_ENV      -> FAIL subscript form rc=0 (expected 1);  other 4 ok
revert ALLOWED widening -> FAIL tests subdir exemption rc=1 (expected 0)
restored                -> 5/5 pass
```

Existing `tests/lint-workspace-resolution-pragma.test.sh` still passes. `review-checks.sh --diff` on the real diff: rc 0 (PARTIAL — prose-cap has no `.py` in scope, this is a `.sh` change). `lint-workspace-resolution.sh --diff` against `origin/main` after committing: rc 0.
