### PR TITLE
feat(quota): surface the top-tier-model weekly lane (7d_oi) and let it bind the tier

### DIFF
--- a/skills/proactive-loop/scripts/quota-tier.py
+++ b/skills/proactive-loop/scripts/quota-tier.py
@@ -71,9 +71,15 @@ def parse(text: str) -> dict:
             raise ValueError(f"no {win} window line in input")
         return int(m.group(1)) if what == "used" else int(m.group(2))
     resets = re.findall(r"Resets: (.+)", text)
-    return {"used5": grab("5h", "used"), "rem5": grab("5h", "rem"),
-            "used7": grab("7d", "used"), "rem7": grab("7d", "rem"),
-            "resets": resets}
+    out = {"used5": grab("5h", "used"), "rem5": grab("5h", "rem"),
+           "used7": grab("7d", "used"), "rem7": grab("7d", "rem"),
+           "resets": resets}
+    # Optional third lane, the top-tier-model weekly cap: same week as 7d, its
+    # own tier; absent on readers that do not report it.
+    m = re.search(r"7d-oi window[^:]*: (\d+)% used, (\d+)% remaining", text)
+    if m:
+        out["used7oi"], out["rem7oi"] = int(m.group(1)), int(m.group(2))
+    return out
 
 
 def main(argv=None) -> int:
@@ -100,12 +106,19 @@ def main(argv=None) -> int:
     t5, t7 = tier_5h(q["rem5"], m5), tier_7d(q["rem7"], el)
     burn = (q["used7"] / 100) / el if el > 0 else float("inf")
     head = (q["rem7"] / 100) / (1 - el) if el < 1 else float("inf")
-    sel = most_restrictive(t5, t7)
-    binding = "both" if t5 == t7 else ("5h" if sel == t5 else "7d")
+    tiers = {"5h": t5, "7d": t7}
+    if "rem7oi" in q:
+        tiers["7d-oi"] = tier_7d(q["rem7oi"], el)
+    sel = most_restrictive(*tiers.values())
+    bound = [w for w, t in tiers.items() if t == sel]
+    binding = "both" if len(bound) == len(tiers) == 2 else "+".join(bound)
     print(f"5h  {q['rem5']}% rem, {m5:.0f} min -> retained "
           f"{q['rem5']/(m5/5):.2f} %/pass -> {t5}")
     print(f"7d  {q['rem7']}% rem, elapsed {el:.4f}, burn {burn:.2f}, "
           f"headroom {head:.3f} -> {t7}")
+    if "rem7oi" in q:
+        head_oi = (q["rem7oi"] / 100) / (1 - el) if el < 1 else float("inf")
+        print(f"7d-oi (top-tier models) {q['rem7oi']}% rem, headroom {head_oi:.3f} -> {tiers['7d-oi']}")
     # burn guards its own denominator above and then BECOMES one here. A
     # just-reset window has used7 == 0, so the ratio is unbounded, not a number.
     ratio = (f"{head/burn:.2f}x CURRENT pace" if burn > 0

--- a/skills/proactive-loop/scripts/quota-tier.py
+++ b/skills/proactive-loop/scripts/quota-tier.py
@@ -70,12 +70,20 @@ def parse(text: str) -> dict:
         if not m:
             raise ValueError(f"no {win} window line in input")
         return int(m.group(1)) if what == "used" else int(m.group(2))
-    resets = re.findall(r"Resets: (.+)", text)
+    # Each `Resets:` belongs to the window line printed just above it, so the
+    # top-tier lane keeps ITS reset and never borrows the ordinary week's.
+    resets, by_win, cur = [], {}, None
+    for line in text.splitlines():
+        w = re.match(r"\s*(5h|7d-oi|7d) window", line)
+        if w:
+            cur = w.group(1); continue
+        r = re.match(r"\s*Resets: (.+)", line)
+        if r:
+            resets.append(r.group(1))
+            if cur and cur not in by_win: by_win[cur] = r.group(1)
     out = {"used5": grab("5h", "used"), "rem5": grab("5h", "rem"),
            "used7": grab("7d", "used"), "rem7": grab("7d", "rem"),
-           "resets": resets}
-    # Optional third lane, the top-tier-model weekly cap: same week as 7d, its
-    # own tier; absent on readers that do not report it.
+           "resets": resets, "resets_by_window": by_win}
     m = re.search(r"7d-oi window[^:]*: (\d+)% used, (\d+)% remaining", text)
     if m:
         out["used7oi"], out["rem7oi"] = int(m.group(1)), int(m.group(2))
@@ -86,6 +94,7 @@ def main(argv=None) -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--reset5", help="5h reset, ISO or 'HH:MM Mon DD'")
     ap.add_argument("--reset7", help="7d reset, ISO")
+    ap.add_argument("--reset7oi", help="top-tier (7d_oi) weekly reset, ISO")
     a = ap.parse_args(argv)
     q = parse(sys.stdin.read())
     now = datetime.datetime.now()
@@ -103,12 +112,26 @@ def main(argv=None) -> int:
     m5 = (r5 - now).total_seconds() / 60
     s7 = r7 - datetime.timedelta(days=7)
     el = (now - s7).total_seconds() / (r7 - s7).total_seconds()
+    el_oi = None
+    if "rem7oi" in q:
+        # The top-tier lane is tiered against ITS OWN reset. Present utilization
+        # with no usable reset is a refusal, never a borrowed week.
+        try:
+            r7oi = (datetime.datetime.fromisoformat(a.reset7oi) if a.reset7oi
+                    else parse_reset(q["resets_by_window"]["7d-oi"], now, 8 * 24))
+        except (ValueError, KeyError) as e:
+            print(f"quota-tier: 7d-oi utilization is present but its reset is missing or invalid ({e}); "
+                  f"pass --reset7oi. Refusing to tier the top-tier lane against another window's week.",
+                  file=sys.stderr)
+            return 2
+        s7oi = r7oi - datetime.timedelta(days=7)
+        el_oi = (now - s7oi).total_seconds() / (r7oi - s7oi).total_seconds()
     t5, t7 = tier_5h(q["rem5"], m5), tier_7d(q["rem7"], el)
     burn = (q["used7"] / 100) / el if el > 0 else float("inf")
     head = (q["rem7"] / 100) / (1 - el) if el < 1 else float("inf")
     tiers = {"5h": t5, "7d": t7}
     if "rem7oi" in q:
-        tiers["7d-oi"] = tier_7d(q["rem7oi"], el)
+        tiers["7d-oi"] = tier_7d(q["rem7oi"], el_oi)
     sel = most_restrictive(*tiers.values())
     bound = [w for w, t in tiers.items() if t == sel]
     binding = "both" if len(bound) == len(tiers) == 2 else "+".join(bound)
@@ -117,8 +140,9 @@ def main(argv=None) -> int:
     print(f"7d  {q['rem7']}% rem, elapsed {el:.4f}, burn {burn:.2f}, "
           f"headroom {head:.3f} -> {t7}")
     if "rem7oi" in q:
-        head_oi = (q["rem7oi"] / 100) / (1 - el) if el < 1 else float("inf")
-        print(f"7d-oi (top-tier models) {q['rem7oi']}% rem, headroom {head_oi:.3f} -> {tiers['7d-oi']}")
+        head_oi = (q["rem7oi"] / 100) / (1 - el_oi) if el_oi < 1 else float("inf")
+        print(f"7d-oi (top-tier models) {q['rem7oi']}% rem, elapsed {el_oi:.4f}, "
+              f"headroom {head_oi:.3f} -> {tiers['7d-oi']}")
     # burn guards its own denominator above and then BECOMES one here. A
     # just-reset window has used7 == 0, so the ratio is unbounded, not a number.
     ratio = (f"{head/burn:.2f}x CURRENT pace" if burn > 0

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -274,6 +274,11 @@ def main():
     util_7d = float(headers.get("anthropic-ratelimit-unified-7d-utilization", 0))
     reset_5h = headers.get("anthropic-ratelimit-unified-5h-reset", "")
     reset_7d = headers.get("anthropic-ratelimit-unified-7d-reset", "")
+    # The API also meters a top-tier-model weekly lane (`7d_oi`); a pinned
+    # Opus/Fable core can exhaust it while the all-model windows read fine.
+    util_7d_oi_raw = headers.get("anthropic-ratelimit-unified-7d_oi-utilization")
+    util_7d_oi = float(util_7d_oi_raw) if util_7d_oi_raw is not None else None
+    reset_7d_oi = headers.get("anthropic-ratelimit-unified-7d_oi-reset", "")
 
     # Stated once: a second copy of this predicate drifts the moment either is
     # extended, and the two fields then contradict each other in one payload.
@@ -308,6 +313,11 @@ def main():
         result["reset_5h"] = datetime.fromtimestamp(int(reset_5h)).isoformat()
     if reset_7d:
         result["reset_7d"] = datetime.fromtimestamp(int(reset_7d)).isoformat()
+    if util_7d_oi is not None:
+        result["utilization_7d_oi"] = util_7d_oi
+        result["remaining_7d_oi_pct"] = round((1 - util_7d_oi) * 100)
+        if reset_7d_oi:
+            result["reset_7d_oi"] = datetime.fromtimestamp(int(reset_7d_oi)).isoformat()
 
     # Unrouted: the utilization delta is another session's, and _update_burn_rate
     # ends in _save_burn_history — a foreign sample outlives the banner flagging it.
@@ -359,6 +369,11 @@ def main():
     print(f"7d window: {int(util_7d * 100)}% used, {result['remaining_7d_pct']}% remaining")
     if reset_7d:
         print(f"  Resets: {datetime.fromtimestamp(int(reset_7d)).strftime('%H:%M %b %d')}")
+    if util_7d_oi is not None:
+        print(f"7d-oi window (top-tier models): {int(util_7d_oi * 100)}% used, "
+              f"{result['remaining_7d_oi_pct']}% remaining")
+        if reset_7d_oi:
+            print(f"  Resets: {datetime.fromtimestamp(int(reset_7d_oi)).strftime('%H:%M %b %d')}")
     if not routed:
         print("Burn rate / passes-left: SUPPRESSED — computed from traffic that is not "
               "this session's.")

--- a/tests/proactive-loop-quota-tier.test.py
+++ b/tests/proactive-loop-quota-tier.test.py
@@ -187,8 +187,8 @@ class TopTierLane(unittest.TestCase):
     def _argv(self):
         import datetime
         now = datetime.datetime.now()
-        return ["--reset5", (now + datetime.timedelta(hours=1)).isoformat(),
-                "--reset7", (now + datetime.timedelta(days=3, hours=12)).isoformat()]  # elapsed 0.5
+        r7 = (now + datetime.timedelta(days=3, hours=12)).isoformat()   # elapsed 0.5
+        return ["--reset5", (now + datetime.timedelta(hours=1)).isoformat(), "--reset7", r7, "--reset7oi", r7]
 
     BASE = "5h window: 1% used, 99% remaining\n7d window: 4% used, 96% remaining\n"
 
@@ -205,6 +205,42 @@ class TopTierLane(unittest.TestCase):
         self.assertEqual(rc, 0, out)
         self.assertIn("7d-oi (top-tier models) 20% rem", out)
         self.assertIn("TIER LIGHT (bound by 7d-oi)", out)   # headroom 0.2/0.5 = 0.4
+
+    def test_the_oi_lane_is_tiered_against_ITS_OWN_reset_not_the_ordinary_week(self):
+        # Hold the oi lane fixed and move ONLY the ordinary 7d reset: its verdict must not
+        # change. Then move only the oi reset: it must.
+        import datetime
+        now = datetime.datetime.now(); iso = lambda d: (now + datetime.timedelta(days=d)).isoformat()
+        text = self.BASE + "7d-oi window (top-tier models): 80% used, 20% remaining\n"
+        r5 = (now + datetime.timedelta(hours=1)).isoformat()
+        far_7d, near_7d = iso(6), iso(1)
+        a = self._run(text, ["--reset5", r5, "--reset7", near_7d, "--reset7oi", iso(6)])
+        b = self._run(text, ["--reset5", r5, "--reset7", far_7d, "--reset7oi", iso(6)])
+        self.assertEqual(a[0], 0, a[1]); self.assertEqual(b[0], 0, b[1])
+        oi = lambda out: [l for l in out.splitlines() if l.startswith("7d-oi")][0]
+        self.assertEqual(oi(a[1]), oi(b[1]), "moving the ORDINARY reset changed the top-tier line")
+        self.assertIn("-> LIGHT", oi(a[1]))                       # 0.2 / (1 - 1/7) = 0.233
+        c = self._run(text, ["--reset5", r5, "--reset7", far_7d, "--reset7oi", iso(1)])
+        self.assertIn("-> MEDIUM", oi(c[1]))                      # 0.2 / (1 - 6/7) = 1.4
+
+    def test_oi_utilization_without_its_reset_is_a_refusal_not_a_borrowed_week(self):
+        import datetime
+        now = datetime.datetime.now()
+        text = self.BASE + "7d-oi window (top-tier models): 80% used, 20% remaining\n"
+        rc, out = self._run(text, ["--reset5", (now + datetime.timedelta(hours=1)).isoformat(),
+                                   "--reset7", (now + datetime.timedelta(days=3)).isoformat()])
+        self.assertEqual(rc, 2, out); self.assertIn("its reset is missing", out)
+
+    def test_printed_resets_bind_to_their_own_window_lines(self):
+        import datetime
+        now = datetime.datetime.now(); fmt = lambda d: (now + datetime.timedelta(days=d)).strftime("%H:%M %b %d")
+        text = ("5h window: 1% used, 99% remaining\n  Resets: " + (now + datetime.timedelta(hours=1)).strftime("%H:%M %b %d") +
+                "\n7d window: 4% used, 96% remaining\n  Resets: " + fmt(6) +
+                "\n7d-oi window (top-tier models): 80% used, 20% remaining\n  Resets: " + fmt(1) + "\n")
+        q = qt.parse(text)
+        self.assertEqual(q["resets_by_window"]["7d-oi"], fmt(1))
+        rc, out = self._run(text)
+        self.assertEqual(rc, 0, out); self.assertIn("-> MEDIUM", [l for l in out.splitlines() if l.startswith("7d-oi")][0])
 
     def test_a_healthy_oi_lane_changes_nothing(self):
         rc, out = self._run(self.BASE + "7d-oi window (top-tier models): 5% used, 95% remaining\n", self._argv())

--- a/tests/proactive-loop-quota-tier.test.py
+++ b/tests/proactive-loop-quota-tier.test.py
@@ -170,6 +170,46 @@ class FreshWindowZeroBurn(unittest.TestCase):
         self.assertEqual(rc, 0, text)
         self.assertRegex(text, r"sustainable \d+\.\d+x CURRENT pace")
 
+
+class TopTierLane(unittest.TestCase):
+    """The API meters a third window, `7d_oi` (top-tier models). A pinned Fable/Opus
+    core can exhaust it while 5h and 7d read fine, so it must be able to BIND."""
+
+    def _run(self, text, argv=()):
+        out = io.StringIO(); real = sys.stdin; sys.stdin = io.StringIO(text)
+        try:
+            with redirect_stdout(out), __import__("contextlib").redirect_stderr(out):
+                rc = qt.main(list(argv))
+        finally:
+            sys.stdin = real
+        return rc, out.getvalue()
+
+    def _argv(self):
+        import datetime
+        now = datetime.datetime.now()
+        return ["--reset5", (now + datetime.timedelta(hours=1)).isoformat(),
+                "--reset7", (now + datetime.timedelta(days=3, hours=12)).isoformat()]  # elapsed 0.5
+
+    BASE = "5h window: 1% used, 99% remaining\n7d window: 4% used, 96% remaining\n"
+
+    def test_parse_reads_the_oi_line_and_tolerates_its_absence(self):
+        q = qt.parse(self.BASE + "7d-oi window (top-tier models): 80% used, 20% remaining\n")
+        self.assertEqual((q["used7oi"], q["rem7oi"]), (80, 20))
+        self.assertNotIn("rem7oi", qt.parse(self.BASE))
+
+    def test_an_exhausted_oi_lane_binds_while_5h_and_7d_are_FULL(self):
+        # THE discriminating pair: identical 5h/7d, the oi line flips the verdict.
+        rc, out = self._run(self.BASE, self._argv())
+        self.assertEqual(rc, 0, out); self.assertIn("TIER FULL (bound by both)", out)
+        rc, out = self._run(self.BASE + "7d-oi window (top-tier models): 80% used, 20% remaining\n", self._argv())
+        self.assertEqual(rc, 0, out)
+        self.assertIn("7d-oi (top-tier models) 20% rem", out)
+        self.assertIn("TIER LIGHT (bound by 7d-oi)", out)   # headroom 0.2/0.5 = 0.4
+
+    def test_a_healthy_oi_lane_changes_nothing(self):
+        rc, out = self._run(self.BASE + "7d-oi window (top-tier models): 5% used, 95% remaining\n", self._argv())
+        self.assertEqual(rc, 0, out); self.assertIn("TIER FULL", out)
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)
 

--- a/tests/quota-read-top-tier-window.test.py
+++ b/tests/quota-read-top-tier-window.test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""read-quota.py surfaces the API's top-tier-model weekly lane (`7d_oi`) when the
+proxy captured it, and prints nothing extra when it did not."""
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_SCRIPT = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
+_BASE = {"anthropic-ratelimit-unified-status": "allowed",
+         "anthropic-ratelimit-unified-5h-utilization": "0.12",
+         "anthropic-ratelimit-unified-7d-utilization": "0.04",
+         "anthropic-ratelimit-unified-7d-reset": "1788598800"}
+_OI = {"anthropic-ratelimit-unified-7d_oi-utilization": "0.83",
+       "anthropic-ratelimit-unified-7d_oi-reset": "1788598800"}
+
+
+class TopTierWindow(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="quota-oi-")); self._env = dict(os.environ)
+
+    def tearDown(self):
+        os.environ.clear(); os.environ.update(self._env); shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _run(self, headers, argv):
+        os.environ["SUTANDO_WORKSPACE"] = str(self.tmp); os.environ["SUTANDO_TEST_MODE"] = "1"
+        state = self.tmp / "state"; state.mkdir(parents=True, exist_ok=True)
+        (state / "quota-state.json").write_text(json.dumps({"headers": headers}))
+        sys.modules.pop("read_quota_oi_under_test", None)
+        spec = importlib.util.spec_from_file_location("read_quota_oi_under_test", _SCRIPT)
+        mod = importlib.util.module_from_spec(spec); sys.path.insert(0, str(REPO / "src"))
+        spec.loader.exec_module(mod)
+        mod._update_burn_rate = lambda *a, **k: None
+        os.environ["ANTHROPIC_BASE_URL"] = f"{mod._PROXY_SCHEME}://127.0.0.1:{mod._PROXY_PORT}"
+        out = io.StringIO(); real = sys.argv; sys.argv = list(argv)
+        try:
+            with redirect_stdout(out):
+                try: mod.main()
+                except SystemExit: pass
+        finally:
+            sys.argv = real
+        return out.getvalue()
+
+    def test_human_output_carries_the_lane_when_captured(self):
+        out = self._run({**_BASE, **_OI}, ["read-quota.py"])
+        self.assertIn("7d-oi window (top-tier models): 83% used, 17% remaining", out)
+        # It follows the 7d block, so quota-tier's Resets[0]/[1] still mean 5h/7d.
+        self.assertLess(out.index("7d window:"), out.index("7d-oi window"))
+
+    def test_json_output_carries_the_lane_when_captured(self):
+        d = json.loads(self._run({**_BASE, **_OI}, ["read-quota.py", "--json"]))
+        self.assertEqual(d["utilization_7d_oi"], 0.83)
+        self.assertEqual(d["remaining_7d_oi_pct"], 17)
+        self.assertIn("reset_7d_oi", d)
+
+    def test_absent_header_prints_and_emits_nothing_extra(self):
+        out = self._run(_BASE, ["read-quota.py"]); self.assertNotIn("7d-oi", out)
+        d = json.loads(self._run(_BASE, ["read-quota.py", "--json"]))
+        self.assertNotIn("utilization_7d_oi", d); self.assertNotIn("remaining_7d_oi_pct", d)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
## Why

The API meters three unified windows: 5h, 7d (all models), and `7d_oi` (the top-tier-model weekly cap). The credential proxy already captures all three headers into `quota-state.json`, but `read-quota.py` printed only the first two and `quota-tier.py` could only choose between them. A core pinned to Fable or Opus can exhaust the top-tier cap while both all-model windows read fine — and the tier logic would keep authorising work. The owner asked today whether switching models helps when one model is out of credits; the tracker could not see the one cap that is model-specific.

## What

- `read-quota.py`: when the `7d_oi` header is present, print a `7d-oi window (top-tier models)` block **after** the 7d block (so `quota-tier`'s `Resets[0]`/`[1]` still mean 5h/7d), and add `utilization_7d_oi`, `remaining_7d_oi_pct`, `reset_7d_oi` to `--json`. Header absent → output byte-identical to today.
- `quota-tier.py`: parse the optional line, tier it with the 7d headroom rule (same week), include it in the most-restrictive selection, and name it in `bound by`.

## Evidence

**Before / after on this host's live state** (same `quota-state.json`, parent = current main):
```
BEFORE (main, f61a9338 — read-quota | quota-tier):
5h  71% rem, 201 min -> retained 1.77 %/pass -> MEDIUM
7d  96% rem, elapsed 0.9325, burn 0.04, headroom 14.213 -> FULL
TIER MEDIUM (bound by 5h)   sustainable 331.33x CURRENT pace (14.21x even pace)

AFTER (this head, bb70315d — same state file, seconds later):
5h  72% rem, 201 min -> retained 1.79 %/pass -> MEDIUM
7d  96% rem, elapsed 0.9324, burn 0.04, headroom 14.203 -> FULL
7d-oi (top-tier models) 95% rem, headroom 14.055 -> FULL
TIER MEDIUM (bound by 5h)   sustainable 331.08x CURRENT pace (14.20x even pace)
```

**Negative control** — the same state with the `_oi` headers stripped: read-quota prints no `7d-oi` line, `--json` has none of the three keys, quota-tier's verdict is unchanged.

**Mutation control** — the new tier test run against the PARENT `quota-tier.py`: `FAILED (failures=1, errors=1)` — `test_an_exhausted_oi_lane_binds_while_5h_and_7d_are_FULL` fails and the parse test errors (no `rem7oi` key) (the parent prints `TIER FULL (bound by both)` where the oi lane at 20% remaining must bind LIGHT). At this head: both suites OK.

Suites re-run at this head, all green: proactive-loop-quota-tier, quota-read-not-routed, quota-read-stale-fails-closed, quota-forecast-binding-window, proactive-loop-claude-quota-cadence, quota-projection, health-check-quota-telemetry, quota-available-prefers-proxy-flag, quota-burn-rate, plus the new `tests/quota-read-top-tier-window.test.py`.

Not in scope: the dashboard tile and `health-check.py`'s quota probes still read only 5h/7d; the cadence helper is unaffected (its regex matches `7d window:` exactly). Follow-ups if wanted.

Stand: Echo Act IV Mini
