### PR TITLE
fix(idle-held): the no-key refusal now names --init-empty

### DIFF
--- a/skills/proactive-loop/scripts/idle-held.py
+++ b/skills/proactive-loop/scripts/idle-held.py
@@ -91,7 +91,8 @@ def load(state: Path):
     except ValueError as exc:
         return None, f"state file is not JSON: {exc}"
     if KEY not in d:
-        return None, f"state file has no {KEY} — refusing to invent one"
+        return None, (f"state file has no {KEY} — refusing to invent one. "
+                      "Bootstrap it with --init-empty (seeds [], never a list).")
     items = d[KEY]
     if not isinstance(items, list) or any(
         not (isinstance(p, (list, tuple)) and len(p) == 2) for p in items

--- a/tests/proactive-loop-idle-held.test.py
+++ b/tests/proactive-loop-idle-held.test.py
@@ -477,5 +477,15 @@ check("a racer that already archived the orphan aborts the write, not re-moves i
       _rc == 0 and _ar.read_text() == _ar_before,
       f"rc={_rc} unchanged={_ar.read_text() == _ar_before}")
 
+# A refusal nobody can act on is a dead end: --init-empty is the only route out
+# of this state, so the message that blocks must name it.
+_dead = pathlib.Path(tempfile.mkdtemp()) / "idle-streak.json"
+_dead.write_text(json.dumps({"streak": 3}))
+_doc_d, _err2 = ih.load(_dead)
+check("the no-key refusal NAMES the flag that resolves it",
+      _doc_d is None and "--init-empty" in (_err2 or ""), repr(_err2))
+check("...and still says what it refuses to do, so the reason survives",
+      "refusing to invent one" in (_err2 or ""), repr(_err2))
+
 print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'all passed'} ({ran - len(fails)}/{ran} assertions)")
 sys.exit(1 if fails else 0)


### PR DESCRIPTION
Follow-up to #3901 (merged). `--init-empty` now exists; this makes the refusal that blocks a caller actually point at it. **No longer stacked** — applies directly to main.

Raised by @john-the-dev as a non-blocking note on #3901: *"the first `--add` still dead-ends at a refusal that does not name `--init-empty` — otherwise the fix exists and the caller does not find it."* Kept out of that PR because it was already approved at a settled head.

## The problem, measured

`load()` refuses a record with no `held_item_ids` and stops. On a host whose record predates the key, that is **every route the proactive loop's step 6.5 documents**. Two independent hosts, live records, run on copies:

```
against the pre-#3901 tool
--add 9999:owner       rc=2  state file has no held_item_ids — refusing to invent one
--audit-notes <repo>   rc=2  same
file unchanged: yes
```

The only remaining route is `echo '[...]' | idle-surface-hash.py --commit` — the recall-built whole list #3901 exists to make unreachable. So a refusal that will not say what to do instead pushes the caller toward the failure mode.

## Before / after

```
- state file has no held_item_ids — refusing to invent one
+ state file has no held_item_ids — refusing to invent one. Bootstrap it
+ with --init-empty (seeds [], never a list).
```

The parenthetical is not decoration: it forecloses the reading that `--init-empty` might accept a list, which is the property #3901 protects.

## Tests

Two arms, and the second is why there are two — a message could name the flag while losing the reason it refused:

```
ok  the no-key refusal NAMES the flag that resolves it
ok  ...and still says what it refuses to do, so the reason survives
```

Mutation (revert to the bare message) fails the first and quotes the wrong value:

```
FAIL  the no-key refusal NAMES the flag that resolves it
      'state file has no held_item_ids — refusing to invent one'
```

⚠ Worth stating because it nearly went the other way: **the first attempt at that mutation silently did not apply** — its search string spanned the implicit string concatenation — and produced **zero failures**, which reads exactly like a control confirming the arm is unnecessary. The applied version asserts its anchor is present before replacing.

`idle-held` 77/77. `review-checks: PASS`. Diff is 2 files, +12/-1.

## Not included

The skill-side line in `skills/proactive-loop/SKILL.md` step 6.5 — @john-the-dev offered to take that, and it is a separate file with a separate audience.