### PR TITLE
feat(app): a Model submenu switches the core's model through switch-model.sh --confirm

### DIFF
--- a/skills/model-switch/manifest.json
+++ b/skills/model-switch/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "model-switch",
+  "version": "1.0.0",
+  "owner": "github:sonichi/sutando",
+  "license": "MIT",
+  "stability": "stable",
+  "description": "Switch the core CLI's model through its /model command, recording only after the CLI accepts. Contributes no tools; manifest present to DECLARE config per skills/MANIFEST.md: MODEL_SWITCH_CHOICES is the id=Title list the menu-bar app's Model submenu offers.",
+  "provenance": {
+    "source_repo": "https://github.com/sonichi/sutando"
+  },
+  "config": {
+    "MODEL_SWITCH_CHOICES": "default=Default (auto-fallback);opus=Opus 5;sonnet=Sonnet 5;haiku=Haiku 4.5;claude-fable-5-1[1m]=Fable 5.1"
+  }
+}

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -343,6 +343,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         pauseItem.submenu = pauseSubmenu
         menu.addItem(pauseItem)
         menu.addItem(NSMenuItem(title: "Resume Loop", action: #selector(resumeLoop), keyEquivalent: ""))
+        // Model submenu — switches the core's model through scripts/switch-model.sh
+        // with --confirm, so it works while the core itself is stalled on an exhausted model.
+        let modelSubmenu = NSMenu()
+        for (title, model) in [("Default (auto-fallback)", "default"), ("Opus 5", "opus"), ("Sonnet 5", "sonnet"),
+                               ("Haiku 4.5", "haiku"), ("Fable 5.1", "claude-fable-5-1[1m]")] {
+            let it = NSMenuItem(title: title, action: #selector(switchModel(_:)), keyEquivalent: "")
+            it.representedObject = model
+            modelSubmenu.addItem(it)
+        }
+        let modelItem = NSMenuItem(title: "Model", action: nil, keyEquivalent: "")
+        modelItem.submenu = modelSubmenu
+        menu.addItem(modelItem)
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Restart Core CLI", action: #selector(restartCore), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Force Restart Core CLI", action: #selector(forceRestartCore), keyEquivalent: ""))
@@ -2541,6 +2553,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         runCoreAction(script: repoRoot + "/src/agent/stop-core.sh", args: [],
                       okMessage: "Core stopped. It stays stopped until you restart it.",
                       failVerb: "Core stop")
+    }
+
+    /// Switch the core's model via scripts/switch-model.sh --confirm: the click is the
+    /// owner's instruction, and the script records only after the CLI accepts.
+    @objc func switchModel(_ sender: NSMenuItem) {
+        guard let model = sender.representedObject as? String else { return }
+        notify("Sutando", "Switching core to \(sender.title)…")
+        runCoreAction(script: repoRoot + "/scripts/switch-model.sh",
+                      args: [model, "--confirm", "--session", "sutando-core", "--socket", sutandoTmuxSocket],
+                      okMessage: "Core switched to \(sender.title) — accepted by the CLI and saved as its default.",
+                      failVerb: "Model switch to \(sender.title)")
     }
 
     /// Shared runner for core start/stop scripts: detached bash, stderr

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -83,6 +83,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // modePresenterMenuItem} requests the switch via state/voice-mode.request
     // (for active/meeting) or POST :7877/presenter/on (for presenter).
     var voiceMode: String = "active"
+    var modelSubmenu: NSMenu?
     weak var modeActiveMenuItem: NSMenuItem?
     weak var modeMeetingMenuItem: NSMenuItem?
     weak var modePresenterMenuItem: NSMenuItem?
@@ -343,15 +344,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         pauseItem.submenu = pauseSubmenu
         menu.addItem(pauseItem)
         menu.addItem(NSMenuItem(title: "Resume Loop", action: #selector(resumeLoop), keyEquivalent: ""))
-        // Model submenu — switches the core's model through scripts/switch-model.sh
-        // with --confirm, so it works while the core itself is stalled on an exhausted model.
+        // Model submenu — items are read from skills/model-switch/manifest.json on every
+        // open, so the choices change with the skill and never need an app rebuild.
         let modelSubmenu = NSMenu()
-        for (title, model) in [("Default (auto-fallback)", "default"), ("Opus 5", "opus"), ("Sonnet 5", "sonnet"),
-                               ("Haiku 4.5", "haiku"), ("Fable 5.1", "claude-fable-5-1[1m]")] {
-            let it = NSMenuItem(title: title, action: #selector(switchModel(_:)), keyEquivalent: "")
-            it.representedObject = model
-            modelSubmenu.addItem(it)
-        }
+        modelSubmenu.delegate = self
+        self.modelSubmenu = modelSubmenu
         let modelItem = NSMenuItem(title: "Model", action: nil, keyEquivalent: "")
         modelItem.submenu = modelSubmenu
         menu.addItem(modelItem)
@@ -2734,3 +2731,72 @@ let delegate = AppDelegate()
 app.delegate = delegate
 app.setActivationPolicy(.accessory) // menu bar only, no dock icon
 app.run()
+
+extension AppDelegate: NSMenuDelegate {
+    static let modelChoicesManifest = "/skills/model-switch/manifest.json"
+    static let modelChoicesKey = "MODEL_SWITCH_CHOICES"
+
+    /// `id=Title;id=Title…` from the manifest's config block; nil when unreadable or empty.
+    func modelChoices() -> [(title: String, id: String)]? {
+        guard let data = FileManager.default.contents(atPath: repoRoot + AppDelegate.modelChoicesManifest),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let cfg = root["config"] as? [String: Any],
+              let raw = cfg[AppDelegate.modelChoicesKey] as? String else { return nil }
+        let pairs = raw.split(separator: ";").compactMap { entry -> (title: String, id: String)? in
+            guard let eq = entry.firstIndex(of: "=") else { return nil }
+            let id = entry[..<eq].trimmingCharacters(in: .whitespaces)
+            let title = entry[entry.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            return (id.isEmpty || title.isEmpty) ? nil : (title: title, id: id)
+        }
+        return pairs.isEmpty ? nil : pairs
+    }
+
+    /// The model the switch script last recorded as accepted (state/model-switch.json).
+    func recordedModel() -> String? {
+        guard let data = FileManager.default.contents(atPath: workspace + "/state/model-switch.json"),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return root["model"] as? String
+    }
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        guard menu === modelSubmenu else { return }
+        menu.removeAllItems()
+        let current = recordedModel()
+        if let choices = modelChoices() {
+            for c in choices {
+                let it = NSMenuItem(title: c.title, action: #selector(switchModel(_:)), keyEquivalent: "")
+                it.target = self
+                it.representedObject = c.id
+                it.state = (c.id == current) ? .on : .off
+                menu.addItem(it)
+            }
+        } else {
+            let it = NSMenuItem(title: "Choices unreadable: skills/model-switch/manifest.json", action: nil, keyEquivalent: "")
+            it.isEnabled = false
+            menu.addItem(it)
+        }
+        menu.addItem(NSMenuItem.separator())
+        let other = NSMenuItem(title: "Other model…", action: #selector(switchOtherModel), keyEquivalent: "")
+        other.target = self
+        menu.addItem(other)
+    }
+
+    /// Any id the owner types; the script still refuses one the CLI does not accept.
+    @objc func switchOtherModel() {
+        let alert = NSAlert()
+        alert.messageText = "Switch the core to which model?"
+        alert.informativeText = "An alias (opus, sonnet, fable) or a full id (claude-fable-5-1[1m]). The switch is recorded only after the CLI accepts it."
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        field.placeholderString = "model id"
+        alert.accessoryView = field
+        alert.addButton(withTitle: "Switch")
+        alert.addButton(withTitle: "Cancel")
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let model = field.stringValue.trimmingCharacters(in: .whitespaces)
+        guard !model.isEmpty else { return }
+        let it = NSMenuItem(title: model, action: nil, keyEquivalent: "")
+        it.representedObject = model
+        switchModel(it)
+    }
+}

--- a/tests/app-model-submenu.test.sh
+++ b/tests/app-model-submenu.test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# The menu-bar app's Model submenu switches through scripts/switch-model.sh --confirm,
+# never by typing /model itself; this pins the wiring CI cannot compile.
+set -u
+HERE="$(cd "$(dirname "$0")/.." && pwd)"; F="$HERE/src/Sutando/main.swift"; fails=0
+ok(){ echo "  ok   $1"; }; fail(){ echo "  FAIL $1 — $2"; fails=$((fails+1)); }
+grep -q 'NSMenuItem(title: "Model", action: nil' "$F" && ok "1 a Model submenu exists" || fail "1" "no Model item"
+for m in default opus sonnet haiku 'claude-fable-5-1\[1m\]'; do grep -q "\"$m\")" "$F" && ok "2 model id $m is offered" || fail "2 $m" "missing"; done
+grep -q 'runCoreAction(script: repoRoot + "/scripts/switch-model.sh"' "$F" && ok "3 the handler runs scripts/switch-model.sh through the shared runner" || fail "3" "handler does not call the script"
+grep -A2 'scripts/switch-model.sh' "$F" | grep -q '"--confirm"' && ok "4 ...with --confirm (the click is the owner's instruction)" || fail "4" "no --confirm"
+grep -A2 'scripts/switch-model.sh' "$F" | grep -q '"--socket", sutandoTmuxSocket' && ok "5 ...on the configured socket" || fail "5" "socket not passed"
+! grep -q 'send-keys.*"/model' "$F" && ok "6 the app never types /model itself" || fail "6" "raw /model send-keys in the app"
+[ -x "$HERE/scripts/switch-model.sh" ] && ok "7 the script the menu calls exists and is executable" || fail "7" "scripts/switch-model.sh missing"
+echo; [ $fails -eq 0 ] && echo "app-model-submenu: all checks pass" || { echo "app-model-submenu: $fails FAILED"; exit 1; }

--- a/tests/app-model-submenu.test.sh
+++ b/tests/app-model-submenu.test.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
-# The menu-bar app's Model submenu switches through scripts/switch-model.sh --confirm,
-# never by typing /model itself; this pins the wiring CI cannot compile.
+# The menu-bar app's Model submenu reads its choices from skills/model-switch/manifest.json
+# at open time and switches through scripts/switch-model.sh --confirm; pins wiring CI cannot compile.
 set -u
-HERE="$(cd "$(dirname "$0")/.." && pwd)"; F="$HERE/src/Sutando/main.swift"; fails=0
+HERE="$(cd "$(dirname "$0")/.." && pwd)"; F="$HERE/src/Sutando/main.swift"; M="$HERE/skills/model-switch/manifest.json"; fails=0
 ok(){ echo "  ok   $1"; }; fail(){ echo "  FAIL $1 — $2"; fails=$((fails+1)); }
 grep -q 'NSMenuItem(title: "Model", action: nil' "$F" && ok "1 a Model submenu exists" || fail "1" "no Model item"
-for m in default opus sonnet haiku 'claude-fable-5-1\[1m\]'; do grep -q "\"$m\")" "$F" && ok "2 model id $m is offered" || fail "2 $m" "missing"; done
+! grep -qE '"(opus|sonnet|haiku|claude-fable-5-1\[1m\])"' "$F" && ok "2 no model id is compiled into the app" || fail "2" "a model id literal is in main.swift"
+grep -q '"/skills/model-switch/manifest.json"' "$F" && grep -q '"MODEL_SWITCH_CHOICES"' "$F" && ok "2b the app reads the choices from the skill manifest config key" || fail "2b" "manifest path or key not read"
+grep -q 'func menuNeedsUpdate' "$F" && grep -q 'modelSubmenu.delegate = self' "$F" && ok "2c ...on every open (menuNeedsUpdate on the submenu delegate)" || fail "2c" "not rebuilt at open"
+python3 - "$M" <<'PY' && ok "2d the manifest lists >=2 id=Title choices including default" || fail "2d" "manifest config invalid"
+import json, sys
+raw = json.load(open(sys.argv[1]))["config"]["MODEL_SWITCH_CHOICES"]
+pairs = [e.split("=", 1) for e in raw.split(";")]
+assert len(pairs) >= 2 and all(len(p) == 2 and p[0].strip() and p[1].strip() for p in pairs), pairs
+assert "default" in [p[0].strip() for p in pairs]
+PY
+grep -q 'title: "Other model' "$F" && grep -q 'func switchOtherModel' "$F" && ok "2e a free-form Other model… entry exists for ids the list lacks" || fail "2e" "no Other model entry"
+grep -q '"/state/model-switch.json"' "$F" && grep -q 'it.state = (c.id == current)' "$F" && ok "2f the recorded model is check-marked" || fail "2f" "no current-model mark"
 grep -q 'runCoreAction(script: repoRoot + "/scripts/switch-model.sh"' "$F" && ok "3 the handler runs scripts/switch-model.sh through the shared runner" || fail "3" "handler does not call the script"
 grep -A2 'scripts/switch-model.sh' "$F" | grep -q '"--confirm"' && ok "4 ...with --confirm (the click is the owner's instruction)" || fail "4" "no --confirm"
 grep -A2 'scripts/switch-model.sh' "$F" | grep -q '"--socket", sutandoTmuxSocket' && ok "5 ...on the configured socket" || fail "5" "socket not passed"


### PR DESCRIPTION
## Why

Chi, 2026-09-04 22:50Z: *"have you made the menu bar change?"* — after asking whether a core stalled on an exhausted model could still be switched. It cannot switch itself; the app can. #3898 (merged 22295a36) shipped the script that does the switch from outside an agent turn and answers the CLI's confirm dialog under `--confirm`. This adds the menu that calls it.

## What

`src/Sutando/main.swift`: a **Model ▸** submenu after Pause/Resume. Its items are **not compiled in**: on every open (`NSMenuDelegate.menuNeedsUpdate`) the app reads `skills/model-switch/manifest.json` → `config.MODEL_SWITCH_CHOICES` (`id=Title;id=Title…`, per the config-only manifest convention in `skills/MANIFEST.md`) and rebuilds the list, so adding or retiring a model is a one-line skill edit with no app rebuild — Chi's review on the first head: *"the choices may get outdated"*. An **Other model…** entry opens a text prompt for any id the CLI accepts, so a stale list never blocks a switch; the model recorded in `state/model-switch.json` is check-marked; an unreadable manifest shows one disabled row naming the file instead of a silently empty menu.

Each item's handler runs `scripts/switch-model.sh <model> --confirm --session sutando-core --socket <configured>` through the existing `runCoreAction` runner, so success and failure report the way Restart/Stop already do, with the script's own stderr on failure (exit 3 no session, 5 pending text, 6 dialog cancelled, 8 no acceptance). The app never types `/model` itself, and the script refuses whatever the CLI rejects, so a retired id fails loudly.

`skills/model-switch/manifest.json` (new, config-only) carries the initial five: default, opus, sonnet, haiku, claude-fable-5-1[1m]. `skills/model-switch/SKILL.md` documents where the list lives.

## Evidence

At 958d20c5 (this head):
```
swiftc -O … main.swift SutandoConfig.swift RestartCoordinator.swift  → rc=0, 0 errors, 0 warnings
bash tests/app-model-submenu.test.sh                                   → app-model-submenu: all checks pass (12)
same test with F= pointed at origin/main's main.swift                  → 11 FAIL (only "script exists" passes, since #3898 merged)
```
The wiring test pins: the Model item exists; **no model id literal is compiled into main.swift**; the app reads the manifest path and the `MODEL_SWITCH_CHOICES` key; the submenu is rebuilt in `menuNeedsUpdate` with the delegate set; the manifest parses to ≥2 `id=Title` pairs including `default`; an Other model… entry exists; the recorded model is check-marked; the handler calls `scripts/switch-model.sh` through the shared runner with `--confirm` and the configured socket; no raw `/model` send-keys; the script exists and is executable.

First head be328ec8 (superseded): compiled list of five, 7-check test, 9 FAIL at parent.

## Live click — witnessed at 958d20c5

App built from this head via `scripts/install-menu-bar-app.sh`, launched in place of the running app (restored afterwards), Model submenu opened by UI scripting and read back from the accessibility tree: `Default (auto-fallback), Opus 5, Sonnet 5, Haiku 4.5, Fable 5.1, <separator>, Other model…` — the manifest's list. Clicked Fable 5.1; the switch script recorded only after the CLI's acceptance line:
```
{
  "model": "claude-fable-5-1[1m]",
  "previous": "claude-fable-5-1[1m]",
  "previous_source": "settings.json",
  "accepted": true,
  "confirmed": false,
  "ts": "2026-09-05T00:04:35Z",
  "by": "skills/model-switch/scripts/switch-model.sh",
  "settings_read": "/Users/wangchi/stando-ui/sutando/workspace/.claude-sutando/settings.json"
}
```
`ts` moved 2026-09-04T21:00:43Z → 2026-09-05T00:04:35Z. A first attempt was refused by the script's send preflight (typed text in the core prompt) and wrote no record: the fail-closed path, live.

Stand: Echo Act IV Mini

