### PR TITLE
feat(supervisor): a blocked core's card carries the dialog's own buttons, and a click answers it

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -279,6 +279,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`replies.py`** — Inbound half of the client action wire.
 - **`schema.py`** — HITL v1 domain model + wire contract (space.ag2.hitl).
 - **`supervisor.py`** — Runtime supervisor pass: detector -> manager -> projector, one turn.
+- **`tui_gate.py`** — A TUI gate as a HumanRequirement with semantic actions, and the keys that answer it.
 
 ## `src/launchd/`
 

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -410,6 +410,9 @@ AUTO_ANSWER_CARRY_S = 120.0
 # `src/hitl` — the Manager dedups, the projector renders the card.
 _CHAT_ESCALATE_STATES = {"blocked-human", "logged-out"}
 HITL_KIND = "core-blocked"
+_TUI_SOURCE = "tui"
+#: a driven click that has not moved the core by then expires as "did not take".
+DRIVE_SETTLE_S = 15.0
 
 
 def escalation_message(state, detail, kind, prompt):
@@ -456,20 +459,9 @@ def escalate(manager, state, detail, kind, prompt, session):
     if manager is None:
         return None
     try:
-        from hitl.schema import Action, HumanRequirement
-        # Session in BOTH the guard and the identity: a pool shares one login, so
-        # a weekly limit blocks every worker on byte-identical prompt text at once.
-        req = HumanRequirement(
-            kind=HITL_KIND,
-            runtime="claude",
-            message=escalation_message(state, detail, kind, prompt),
-            guard=hashlib.sha256(f"{session}\n{prompt or state}".encode()).hexdigest()[:16],
-            device={"id": session},
-            title=f"{session} · {state}",
-            actions=[Action(id="ack", kind="acknowledge", label="I have answered it")],
-            subject={"state": state, "gate": kind or "", "detail": detail,
-                     "session": session},
-        )
+        from hitl import tui_gate
+        req = tui_gate.requirement_for(state, kind, prompt, session, detail,
+                                       escalation_message(state, detail, kind, prompt))
         return manager.create(req)
     except Exception as exc:  # noqa: BLE001 — never let the card take down the monitor
         print(f"hitl escalation failed: {exc}", file=_sys.stderr)
@@ -486,7 +478,7 @@ def resolve_escalations(manager, session):
         return []
     try:
         mine = [r.id for r in manager.active()
-                if r.kind == HITL_KIND
+                if (r.subject or {}).get("source") == _TUI_SOURCE
                 and (r.subject or {}).get("session") == session]
         for req_id in mine:
             manager.resolve(req_id)   # returns blocked task ids, not a verdict
@@ -494,6 +486,57 @@ def resolve_escalations(manager, session):
     except Exception as exc:  # noqa: BLE001
         print(f"hitl resolve failed: {exc}", file=_sys.stderr)
         return []
+
+
+def drive_escalations(manager, session, prompt, state, send):
+    """Realise the owner's click: the keys tui_gate derives for the dialog on screen
+    NOW, sent once. A dialog that changed since the click expires the card instead.
+    Returns [(req_id, keys or None)] for what this tick acted on.
+    """
+    if manager is None:
+        return []
+    acted = []
+    try:
+        from hitl import tui_gate
+        from hitl.manager import POLICY_DECIDER
+        from hitl.schema import STATUS_IN_PROGRESS
+
+        def _expire(req_id, note):
+            with manager.store.locked():
+                cur = manager.get(req_id)
+                if cur is not None:
+                    cur.answer = {"note": note}
+                    manager.store.save(cur)
+            manager.expire(req_id)
+
+        for r in manager.active():
+            subj = r.subject or {}
+            if (subj.get("source") != _TUI_SOURCE or subj.get("session") != session
+                    or r.status != STATUS_IN_PROGRESS or not r.chosen_action
+                    or r.decided_by == POLICY_DECIDER):
+                continue
+            keys = tui_gate.keys_for(r, prompt, state)
+            if subj.get("driven_at"):
+                if keys is not None and time.time() - subj["driven_at"] > DRIVE_SETTLE_S:
+                    _expire(r.id, tui_gate.DID_NOT_TAKE_NOTE)
+                    acted.append((r.id, None))
+                continue
+            if keys is None:
+                _expire(r.id, tui_gate.STALE_NOTE)
+                acted.append((r.id, None))
+                continue
+            for k in keys:
+                if not send(k):
+                    break
+            with manager.store.locked():
+                cur = manager.get(r.id)
+                if cur is not None:
+                    cur.subject = {**(cur.subject or {}), "driven_at": time.time(), "driven_keys": keys}
+                    manager.store.save(cur)
+            acted.append((r.id, keys))
+    except Exception as exc:  # noqa: BLE001 — never let the driver take down the monitor
+        print(f"hitl drive failed: {exc}", file=_sys.stderr)
+    return acted
 
 
 def _atomic_write(path, payload):
@@ -579,6 +622,8 @@ def main():
         # the card, so the owner sees it close without clicking anything.
         if a.chat_escalation:
             if state in _CHAT_ESCALATE_STATES:
+                drive_escalations(hitl, a.session, prompt, state,
+                                  lambda k: send_keys(a.socket, a.session, k))
                 escalate(hitl, state, detail, kind, prompt, a.session)
             else:
                 resolve_escalations(hitl, a.session)

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -489,10 +489,8 @@ def resolve_escalations(manager, session):
 
 
 def drive_escalations(manager, session, prompt, state, send):
-    """Realise the owner's click: the keys tui_gate derives for the dialog on screen
-    NOW, sent once. A dialog that changed since the click expires the card instead.
-    Returns [(req_id, keys or None)] for what this tick acted on.
-    """
+    """Realise a click as keys against the dialog on screen NOW, once; a dialog that
+    changed since the click expires the card. Returns [(req_id, keys or None)]."""
     if manager is None:
         return []
     acted = []
@@ -517,6 +515,8 @@ def drive_escalations(manager, session, prompt, state, send):
                 continue
             keys = tui_gate.keys_for(r, prompt, state)
             if subj.get("driven_at"):
+                # Still the same dialog after the settle window: the keys did not take.
+                # A different dialog: the core moved, resolve_escalations closes it.
                 if keys is not None and time.time() - subj["driven_at"] > DRIVE_SETTLE_S:
                     _expire(r.id, tui_gate.DID_NOT_TAKE_NOTE)
                     acted.append((r.id, None))
@@ -525,15 +525,28 @@ def drive_escalations(manager, session, prompt, state, send):
                 _expire(r.id, tui_gate.STALE_NOTE)
                 acted.append((r.id, None))
                 continue
+            sent = []
             for k in keys:
                 if not send(k):
                     break
+                sent.append(k)
+            if len(sent) < len(keys):
+                # A half-walked caret is a dialog nobody can reason about: never
+                # finish it later. Record what went in, then hand it to the human.
+                with manager.store.locked():
+                    cur = manager.get(r.id)
+                    if cur is not None:
+                        cur.subject = {**(cur.subject or {}), "driven_keys": sent, "driven_partial": True}
+                        manager.store.save(cur)
+                _expire(r.id, tui_gate.DID_NOT_TAKE_NOTE)
+                acted.append((r.id, None))
+                continue
             with manager.store.locked():
                 cur = manager.get(r.id)
                 if cur is not None:
-                    cur.subject = {**(cur.subject or {}), "driven_at": time.time(), "driven_keys": keys}
+                    cur.subject = {**(cur.subject or {}), "driven_at": time.time(), "driven_keys": sent}
                     manager.store.save(cur)
-            acted.append((r.id, keys))
+            acted.append((r.id, sent))
     except Exception as exc:  # noqa: BLE001 — never let the driver take down the monitor
         print(f"hitl drive failed: {exc}", file=_sys.stderr)
     return acted

--- a/src/hitl/tui_gate.py
+++ b/src/hitl/tui_gate.py
@@ -1,11 +1,5 @@
 """A TUI gate as a HumanRequirement with semantic actions, and the keys that answer it.
-
-The monitor (core-input-watch) sees a Claude Code dialog as text. This module is the
-policy between that text and the card: which kind it is, which buttons it carries, and
-— once a button is clicked — which keystrokes realise that click. The UI never names a
-key; the card says `allow`/`deny`/`opt3`/`continue` and this module translates, after
-re-checking that the dialog on screen is still the one the human saw.
-"""
+The card names an action; only this module knows which keys realise it on the live dialog."""
 from __future__ import annotations
 
 import hashlib
@@ -19,6 +13,9 @@ FALLBACK_KIND = "core-blocked"
 STALE_NOTE = "This prompt has changed. Refresh the action."
 DID_NOT_TAKE_NOTE = "The answer did not take. Open the terminal to finish it."
 
+# Only these gates may carry a one-click button; trust, bypass and credit-spending
+# dialogs keep the blocked card however their text is rendered.
+SEMANTIC_GATES = frozenset({"permission", "selection", "press-enter", "login"})
 _OPTION = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
 _FRAME = re.compile(r"^[\s─━│┃┌┐└┘╭╮╰╯├┤┬┴┼═║╔╗╚╝]*$")
 _HINT = re.compile(r"Esc to cancel|Enter to (confirm|select)|↑/↓|shift\+tab|Tab to", re.I)
@@ -31,28 +28,51 @@ def guard_for(session: str, prompt: Optional[str], state: str) -> str:
     return hashlib.sha256(f"{session}\n{prompt or state}".encode()).hexdigest()[:16]
 
 
-def parse_options(prompt: Optional[str]) -> Tuple[List[str], Optional[int]]:
-    """Numbered options in order, and the 0-based index the caret (❯) sits on."""
-    options: List[str] = []
-    caret: Optional[int] = None
-    for line in (prompt or "").splitlines():
+def option_blocks(prompt: Optional[str]) -> List[Tuple[int, List[str], Optional[int]]]:
+    """Each contiguous run of numbered lines: (start line, labels, caret index)."""
+    blocks: List[Tuple[int, List[str], Optional[int]]] = []
+    cur: Optional[Tuple[int, List[str], Optional[int]]] = None
+    for i, line in enumerate((prompt or "").splitlines()):
         m = _OPTION.match(line)
         if not m:
+            if cur is not None and line.strip():
+                blocks.append(cur)
+                cur = None
             continue
+        if cur is None:
+            cur = (i, [], None)
+        start, labels, caret = cur
         if m.group(1):
-            caret = len(options)
-        options.append(m.group(3))
-    return options, caret
+            caret = len(labels)
+        labels.append(m.group(3))
+        cur = (start, labels, caret)
+    if cur is not None:
+        blocks.append(cur)
+    return blocks
+
+
+def parse_options(prompt: Optional[str]) -> Tuple[List[str], Optional[int]]:
+    """The LIVE dialog's options: the block holding the caret, else the last one.
+    A resolved dialog still visible above the live one must not feed the buttons."""
+    blocks = option_blocks(prompt)
+    if not blocks:
+        return [], None
+    live = next((b for b in reversed(blocks) if b[2] is not None), blocks[-1])
+    return live[1], live[2]
 
 
 def question(prompt: Optional[str], detail: str) -> str:
     """The lines a human would read as the question: above the options, frames and
     key hints dropped, the last three kept."""
     kept: List[str] = []
-    for line in (prompt or "").splitlines():
-        if _OPTION.match(line):
-            break
+    blocks = option_blocks(prompt)
+    live_start = next((b[0] for b in reversed(blocks) if b[2] is not None), blocks[-1][0] if blocks else None)
+    lines = (prompt or "").splitlines()
+    for line in (lines[:live_start] if live_start is not None else lines):
         s = line.strip()
+        if _OPTION.match(line) or s.startswith("✓"):
+            kept = []  # an older dialog's options or its recorded answer: not this question
+            continue
         if not s or _FRAME.match(s) or _HINT.search(s):
             continue
         kept.append(s)
@@ -65,8 +85,8 @@ def _open_terminal() -> Action:
 
 def requirement_for(state: str, gate: Optional[str], prompt: Optional[str],
                     session: str, detail: str, fallback_message: str) -> HumanRequirement:
-    """Build the requirement a gate deserves. Unparseable dialogs fall back to the
-    blocked card with no semantic button: a key is never guessed."""
+    """The requirement a gate deserves; unparseable or non-semantic gates keep the
+    blocked card with no button, so a key is never guessed."""
     options, caret = parse_options(prompt)
     subject: Dict[str, object] = {
         "session": session,
@@ -80,7 +100,9 @@ def requirement_for(state: str, gate: Optional[str], prompt: Optional[str],
     kind, title, message, actions = FALLBACK_KIND, f"{session} · {state}", fallback_message, []
     option_for_action: Dict[str, int] = {}
 
-    if gate == "login" or state == "logged-out":
+    if gate is not None and gate not in SEMANTIC_GATES and state != "logged-out":
+        pass  # keeps the blocked card: never a one-click answer on a trust/spend gate
+    elif gate == "login" or state == "logged-out":
         kind, title = "auth", "Claude needs to be reconnected"
         message = "Your Claude session has expired. Sign in again to continue."
         actions = [Action(id="authenticate", kind="authenticate", label="Sign in to Claude")]
@@ -89,8 +111,7 @@ def requirement_for(state: str, gate: Optional[str], prompt: Optional[str],
         message = question(prompt, detail)
         actions = [Action(id="continue", kind="continue", label="Continue")]
     elif options:
-        # Kind follows the OPTIONS, not the gate label: classify() names a Yes/No
-        # dialog `selection` whenever its caret row sits below the question.
+        # Kind follows the OPTIONS: classify() names a Yes/No dialog `selection`.
         yes = next((i for i, o in enumerate(options) if _YES.match(o)), None)
         no = next((i for i, o in enumerate(options) if _NO.match(o)), None)
         message = question(prompt, detail)

--- a/src/hitl/tui_gate.py
+++ b/src/hitl/tui_gate.py
@@ -1,0 +1,126 @@
+"""A TUI gate as a HumanRequirement with semantic actions, and the keys that answer it.
+
+The monitor (core-input-watch) sees a Claude Code dialog as text. This module is the
+policy between that text and the card: which kind it is, which buttons it carries, and
+— once a button is clicked — which keystrokes realise that click. The UI never names a
+key; the card says `allow`/`deny`/`opt3`/`continue` and this module translates, after
+re-checking that the dialog on screen is still the one the human saw.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Dict, List, Optional, Tuple
+
+from .schema import Action, HumanRequirement
+
+SOURCE = "tui"
+FALLBACK_KIND = "core-blocked"
+STALE_NOTE = "This prompt has changed. Refresh the action."
+DID_NOT_TAKE_NOTE = "The answer did not take. Open the terminal to finish it."
+
+_OPTION = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
+_FRAME = re.compile(r"^[\s─━│┃┌┐└┘╭╮╰╯├┤┬┴┼═║╔╗╚╝]*$")
+_HINT = re.compile(r"Esc to cancel|Enter to (confirm|select)|↑/↓|shift\+tab|Tab to", re.I)
+_YES = re.compile(r"^\s*yes\b", re.I)
+_NO = re.compile(r"^\s*no\b", re.I)
+
+
+def guard_for(session: str, prompt: Optional[str], state: str) -> str:
+    """The episode key: same session + same dialog text = same requirement."""
+    return hashlib.sha256(f"{session}\n{prompt or state}".encode()).hexdigest()[:16]
+
+
+def parse_options(prompt: Optional[str]) -> Tuple[List[str], Optional[int]]:
+    """Numbered options in order, and the 0-based index the caret (❯) sits on."""
+    options: List[str] = []
+    caret: Optional[int] = None
+    for line in (prompt or "").splitlines():
+        m = _OPTION.match(line)
+        if not m:
+            continue
+        if m.group(1):
+            caret = len(options)
+        options.append(m.group(3))
+    return options, caret
+
+
+def question(prompt: Optional[str], detail: str) -> str:
+    """The lines a human would read as the question: above the options, frames and
+    key hints dropped, the last three kept."""
+    kept: List[str] = []
+    for line in (prompt or "").splitlines():
+        if _OPTION.match(line):
+            break
+        s = line.strip()
+        if not s or _FRAME.match(s) or _HINT.search(s):
+            continue
+        kept.append(s)
+    return " ".join(kept[-3:]) if kept else detail
+
+
+def _open_terminal() -> Action:
+    return Action(id="open_terminal", kind="open_terminal", label="Open terminal")
+
+
+def requirement_for(state: str, gate: Optional[str], prompt: Optional[str],
+                    session: str, detail: str, fallback_message: str) -> HumanRequirement:
+    """Build the requirement a gate deserves. Unparseable dialogs fall back to the
+    blocked card with no semantic button: a key is never guessed."""
+    options, caret = parse_options(prompt)
+    subject: Dict[str, object] = {"state": state, "gate": gate or "", "detail": detail,
+                                  "session": session, "source": SOURCE,
+                                  "options": options, "caret": caret}
+    kind, title, message, actions = FALLBACK_KIND, f"{session} · {state}", fallback_message, []
+    option_for_action: Dict[str, int] = {}
+
+    if gate == "login" or state == "logged-out":
+        kind, title = "auth", "Claude needs to be reconnected"
+        message = "Your Claude session has expired. Sign in again to continue."
+        actions = [Action(id="authenticate", kind="authenticate", label="Sign in to Claude")]
+    elif gate == "press-enter":
+        kind, title = "confirmation", "Agent needs your confirmation"
+        message = question(prompt, detail)
+        actions = [Action(id="continue", kind="continue", label="Continue")]
+    elif options:
+        # Kind follows the OPTIONS, not the gate label: classify() names a Yes/No
+        # dialog `selection` whenever its caret row sits below the question.
+        yes = next((i for i, o in enumerate(options) if _YES.match(o)), None)
+        no = next((i for i, o in enumerate(options) if _NO.match(o)), None)
+        message = question(prompt, detail)
+        if yes is not None and no is not None:
+            kind, title = "permission", "Agent needs your confirmation"
+            option_for_action = {"deny": no, "allow": yes}
+            actions = [Action(id="deny", kind="reject_once", label="No"),
+                       Action(id="allow", kind="allow_once", label="Yes")]
+        else:
+            kind, title = "choice", "Agent needs a decision"
+            option_for_action = {f"opt{i + 1}": i for i in range(len(options))}
+            actions = [Action(id=f"opt{i + 1}", kind="select", label=o) for i, o in enumerate(options)]
+
+    subject["option_for_action"] = option_for_action
+    return HumanRequirement(
+        kind=kind, runtime="claude", message=message, title=title,
+        guard=guard_for(session, prompt, state),
+        device={"id": session, "name": session},
+        actions=actions + [_open_terminal()],
+        subject=subject,
+    )
+
+
+def keys_for(req: HumanRequirement, current_prompt: Optional[str],
+             current_state: str) -> Optional[List[str]]:
+    """The keystrokes that realise `req.chosen_action` against the dialog on screen
+    NOW, or None when the screen no longer shows the dialog the human clicked on."""
+    subject = req.subject or {}
+    if guard_for(str(subject.get("session") or ""), current_prompt, current_state) != req.guard:
+        return None
+    action = req.chosen_action
+    if action == "continue":
+        return ["Enter"]
+    target = (subject.get("option_for_action") or {}).get(action)
+    _, caret = parse_options(current_prompt)
+    if target is None or caret is None:
+        return None
+    step = "Down" if target >= caret else "Up"
+    return [step] * abs(target - caret) + ["Enter"]

--- a/src/hitl/tui_gate.py
+++ b/src/hitl/tui_gate.py
@@ -68,9 +68,15 @@ def requirement_for(state: str, gate: Optional[str], prompt: Optional[str],
     """Build the requirement a gate deserves. Unparseable dialogs fall back to the
     blocked card with no semantic button: a key is never guessed."""
     options, caret = parse_options(prompt)
-    subject: Dict[str, object] = {"state": state, "gate": gate or "", "detail": detail,
-                                  "session": session, "source": SOURCE,
-                                  "options": options, "caret": caret}
+    subject: Dict[str, object] = {
+        "session": session,
+        "source": SOURCE,
+        "supervisor_state": state,
+        "gate": gate or "",
+        "detail": detail,
+        "options": options,
+        "caret": caret,
+    }
     kind, title, message, actions = FALLBACK_KIND, f"{session} · {state}", fallback_message, []
     option_for_action: Dict[str, int] = {}
 

--- a/src/hitl/tui_gate.py
+++ b/src/hitl/tui_gate.py
@@ -16,6 +16,10 @@ DID_NOT_TAKE_NOTE = "The answer did not take. Open the terminal to finish it."
 # Only these gates may carry a one-click button; trust, bypass and credit-spending
 # dialogs keep the blocked card however their text is rendered.
 SEMANTIC_GATES = frozenset({"permission", "selection", "press-enter", "login"})
+# The classifier names the gate nearest the bottom, so a trust or credit dialog rendered
+# as a numbered list arrives labelled `selection`; the TEXT still says what it is.
+_NEVER_ONE_CLICK = re.compile(r"trust the files|Do you trust|Bypass Permissions|Yes, I accept|"
+                              r"Fable limit|usage credits|hit your (?:session|usage|weekly) limit", re.I)
 _OPTION = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
 _FRAME = re.compile(r"^[\s─━│┃┌┐└┘╭╮╰╯├┤┬┴┼═║╔╗╚╝]*$")
 _HINT = re.compile(r"Esc to cancel|Enter to (confirm|select)|↑/↓|shift\+tab|Tab to", re.I)
@@ -100,7 +104,7 @@ def requirement_for(state: str, gate: Optional[str], prompt: Optional[str],
     kind, title, message, actions = FALLBACK_KIND, f"{session} · {state}", fallback_message, []
     option_for_action: Dict[str, int] = {}
 
-    if gate is not None and gate not in SEMANTIC_GATES and state != "logged-out":
+    if _NEVER_ONE_CLICK.search(prompt or "") or (gate is not None and gate not in SEMANTIC_GATES and state != "logged-out"):
         pass  # keeps the blocked card: never a one-click answer on a trust/spend gate
     elif gate == "login" or state == "logged-out":
         kind, title = "auth", "Claude needs to be reconnected"

--- a/tests/core-input-watch-chat-escalation.test.py
+++ b/tests/core-input-watch-chat-escalation.test.py
@@ -310,5 +310,40 @@ class TestDrive(unittest.TestCase):
         self.assertEqual(M.drive_escalations(None, "s", PERM, "blocked-human", lambda k: True), [])
 
 
+class TestPartialSend(unittest.TestCase):
+    """Reviewer P1: a key sequence that half-lands must never read as driven, and
+    must never be finished later against a caret nobody can place."""
+
+    def _blocked(self, m):
+        return M.escalate(m, "blocked-human", "awaiting user: permission", "permission", PERM, "s")
+
+    def test_a_refused_second_key_expires_the_card_and_records_only_what_went_in(self):
+        from hitl.schema import STATUS_EXPIRED
+        m, sent = _mgr(), []
+        r = self._blocked(m)
+        _click(m, r, "deny")                      # plan: Down, Down, Enter
+        def flaky(k):
+            sent.append(k)
+            return len(sent) < 2                  # first Down accepted, second refused
+        acted = M.drive_escalations(m, "s", PERM, "blocked-human", flaky)
+        self.assertEqual(sent, ["Down", "Down"])
+        self.assertEqual(acted, [(r.id, None)])
+        cur = m.get(r.id)
+        self.assertEqual(cur.status, STATUS_EXPIRED)
+        self.assertEqual(cur.subject["driven_keys"], ["Down"])
+        self.assertTrue(cur.subject["driven_partial"])
+        self.assertEqual(cur.answer, {"note": "The answer did not take. Open the terminal to finish it."})
+
+    def test_after_a_partial_send_nothing_is_ever_typed_again_for_that_card(self):
+        m, sent = _mgr(), []
+        r = self._blocked(m)
+        _click(m, r, "deny")
+        M.drive_escalations(m, "s", PERM, "blocked-human", lambda k: sent.append(k) or len(sent) < 2)
+        moved = PERM.replace("  ❯ 1. Yes", "    1. Yes").replace("    2. Yes, and", "  ❯ 2. Yes, and")
+        for _ in range(3):
+            M.drive_escalations(m, "s", moved, "blocked-human", lambda k: sent.append(k) or True)
+        self.assertEqual(sent, ["Down", "Down"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/core-input-watch-chat-escalation.test.py
+++ b/tests/core-input-watch-chat-escalation.test.py
@@ -213,5 +213,102 @@ class TestDegradesWithoutDyingV(unittest.TestCase):
             self.assertIsNotNone(M._hitl_manager(str(ws / "state" / "core-status.json")))
 
 
+PERM = ("  Dangerous rm operation on a possibly-empty path\n  Do you want to proceed?\n"
+        "  ❯ 1. Yes\n    2. Yes, and don't ask again for rm commands\n    3. No\n  Esc to cancel")
+
+
+def _click(m, r, action_id):
+    from hitl.schema import ActionReply
+    m.apply_action(ActionReply(hitl_id=r.id, expected_revision=r.revision,
+                               action_id=action_id, guard=r.guard))
+
+
+class TestDrive(unittest.TestCase):
+    """A click on the card is realised as keystrokes into the dialog it was made
+    for — once, only by a human, only while that dialog is still on screen."""
+
+    def _blocked(self, m, session="s"):
+        return M.escalate(m, "blocked-human", "awaiting user: permission", "permission", PERM, session)
+
+    def test_the_real_dialog_through_classify_is_a_no_yes_card(self):
+        """Through the monitor's own classifier, not a hand-picked gate label: the
+        live pane names this dialog `selection`, and the card must still be No/Yes."""
+        state, detail, prompt, kind = M.compose_state(PERM, "working", True)
+        self.assertEqual((state, kind), ("blocked-human", "selection"))
+        r = M.escalate(_mgr(), state, detail, kind, prompt, "s")
+        self.assertEqual(r.kind, "permission")
+        self.assertEqual([a.label for a in r.actions], ["No", "Yes", "Open terminal"])
+
+    def test_a_permission_gate_carries_no_yes_buttons_not_ack(self):
+        r = self._blocked(_mgr())
+        self.assertEqual(r.kind, "permission")
+        self.assertEqual([a.label for a in r.actions], ["No", "Yes", "Open terminal"])
+
+    def test_a_clicked_no_walks_the_caret_to_no_and_confirms(self):
+        m, sent = _mgr(), []
+        r = self._blocked(m)
+        _click(m, r, "deny")
+        acted = M.drive_escalations(m, "s", PERM, "blocked-human", lambda k: sent.append(k) or True)
+        self.assertEqual(sent, ["Down", "Down", "Enter"])
+        self.assertEqual(acted, [(r.id, ["Down", "Down", "Enter"])])
+
+    def test_a_click_is_driven_once_not_every_tick(self):
+        m, sent = _mgr(), []
+        r = self._blocked(m)
+        _click(m, r, "allow")
+        for _ in range(5):
+            M.drive_escalations(m, "s", PERM, "blocked-human", lambda k: sent.append(k) or True)
+        self.assertEqual(sent, ["Enter"])
+
+    def test_a_click_against_a_changed_dialog_sends_nothing_and_expires_the_card(self):
+        from hitl.schema import STATUS_EXPIRED
+        m, sent = _mgr(), []
+        r = self._blocked(m)
+        _click(m, r, "allow")
+        other = PERM.replace("possibly-empty", "non-empty")
+        M.drive_escalations(m, "s", other, "blocked-human", lambda k: sent.append(k) or True)
+        self.assertEqual(sent, [])
+        self.assertEqual(m.get(r.id).status, STATUS_EXPIRED)
+        self.assertEqual(m.get(r.id).answer, {"note": "This prompt has changed. Refresh the action."})
+
+    def test_an_unclicked_card_is_never_driven(self):
+        m, sent = _mgr(), []
+        self._blocked(m)
+        M.drive_escalations(m, "s", PERM, "blocked-human", lambda k: sent.append(k) or True)
+        self.assertEqual(sent, [])
+
+    def test_another_sessions_click_is_not_driven_into_this_pane(self):
+        m, sent = _mgr(), []
+        r = self._blocked(m, session="worker-2")
+        _click(m, r, "allow")
+        M.drive_escalations(m, "worker-1", PERM, "blocked-human", lambda k: sent.append(k) or True)
+        self.assertEqual(sent, [])
+
+    def test_a_policy_decision_is_never_typed_into_a_human_gate(self):
+        from hitl.manager import POLICY_DECIDER
+        m, sent = _mgr(), []
+        r = self._blocked(m)
+        _click(m, r, "allow")
+        with m.store.locked():
+            cur = m.get(r.id); cur.decided_by = POLICY_DECIDER; m.store.save(cur)
+        M.drive_escalations(m, "s", PERM, "blocked-human", lambda k: sent.append(k) or True)
+        self.assertEqual(sent, [])
+
+    def test_a_hook_driver_permission_card_is_not_resolved_by_the_core_moving(self):
+        """TUI cards can now be kind=permission too; scope is the source, not the kind."""
+        m = _mgr()
+        from hitl.schema import Action, HumanRequirement
+        hook = m.create(HumanRequirement(kind="permission", runtime="claude", message="may I",
+                                         guard="hook:1", device={"id": "s", "name": "s"},
+                                         subject={"session": "s", "tool": "Bash"},
+                                         actions=[Action("allow", "allow_once", "Allow")]))
+        mine = self._blocked(m)
+        self.assertEqual(M.resolve_escalations(m, "s"), [mine.id])
+        self.assertNotEqual(m.get(hook.id).status, STATUS_RESOLVED)
+
+    def test_no_manager_is_survivable_for_the_driver_too(self):
+        self.assertEqual(M.drive_escalations(None, "s", PERM, "blocked-human", lambda k: True), [])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/core-input-watch-chat-escalation.test.py
+++ b/tests/core-input-watch-chat-escalation.test.py
@@ -239,6 +239,17 @@ class TestDrive(unittest.TestCase):
         self.assertEqual(r.kind, "permission")
         self.assertEqual([a.label for a in r.actions], ["No", "Yes", "Open terminal"])
 
+    def test_a_numbered_trust_dialog_through_classify_gets_no_button(self):
+        """End to end through the monitor's own classifier: this pane is labelled
+        `selection` (caret row nearest the bottom) and must still not offer Yes."""
+        TRUST = ("  Do you trust the files in this folder?\n  ❯ 1. Yes, proceed\n"
+                 "    2. No, exit\n  Enter to confirm · Esc to cancel")
+        state, detail, prompt, kind = M.compose_state(TRUST, "working", True)
+        self.assertEqual(kind, "selection", "fixture no longer reproduces the label collision")
+        r = M.escalate(_mgr(), state, detail, kind, prompt, "s")
+        self.assertEqual(r.kind, "core-blocked")
+        self.assertEqual([a.label for a in r.actions], ["Open terminal"])
+
     def test_a_permission_gate_carries_no_yes_buttons_not_ack(self):
         r = self._blocked(_mgr())
         self.assertEqual(r.kind, "permission")

--- a/tests/hitl-tui-gate.test.py
+++ b/tests/hitl-tui-gate.test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-"""A TUI dialog becomes a card with the buttons a human would expect, and a click
-becomes the keystrokes that answer THAT dialog — never a guessed key, never a key
-into a dialog the human did not see (owner spec 2026-09-04: the card says `yes`;
-the driver decides what `yes` means on screen, after checking the screen)."""
+"""A dialog becomes a card with the buttons a human expects; a click becomes the keys that
+answer THAT dialog: never a guessed key, never a key into a dialog the human did not see."""
 import pathlib
 import sys
 import unittest
@@ -132,6 +130,54 @@ class TestKeys(unittest.TestCase):
 
     def test_an_unknown_action_sends_nothing(self):
         self.assertIsNone(G.keys_for(clicked(req("permission", PERM), "open_terminal"), PERM, "blocked-human"))
+
+
+TWO_DIALOGS = ("  Do you want to proceed?\n"
+               "    1. Yes\n"
+               "    2. No\n"
+               "  ✓ Yes\n"
+               "  Select a deployment\n"
+               "  ❯ 1. Production\n"
+               "    2. Staging\n"
+               "  Esc to cancel")
+TRUST = "  Do you trust the files in this folder?\n  ❯ 1. Yes, proceed\n    2. No, exit"
+BYPASS = "  in Bypass Permissions mode.\n  ❯ 1. No, exit\n    2. Yes, I accept\n  Enter to confirm"
+
+
+class TestLiveDialogOnly(unittest.TestCase):
+    """Reviewer P1: a resolved dialog still visible above the live one must not
+    feed the buttons, even though the prompt fingerprint is identical."""
+
+    def test_only_the_block_with_the_caret_is_parsed(self):
+        self.assertEqual(G.parse_options(TWO_DIALOGS), (["Production", "Staging"], 0))
+
+    def test_the_card_is_built_from_the_live_dialog(self):
+        r = req("selection", TWO_DIALOGS)
+        self.assertEqual(r.kind, "choice")
+        self.assertEqual([a.label for a in r.actions], ["Production", "Staging", "Open terminal"])
+        self.assertEqual(r.message, "Select a deployment")
+        self.assertEqual(G.keys_for(clicked(r, "opt2"), TWO_DIALOGS, "blocked-human"), ["Down", "Enter"])
+
+    def test_no_caret_anywhere_falls_back_to_the_last_block(self):
+        flat = TWO_DIALOGS.replace("  ❯ 1. Production", "    1. Production")
+        self.assertEqual(G.parse_options(flat), (["Production", "Staging"], None))
+
+
+class TestNeverAOneClickOnATrustOrSpendGate(unittest.TestCase):
+    """Reviewer blocker: a numbered rendering of a trust / bypass / credit dialog
+    must still keep the blocked card, whatever its options say."""
+
+    def test_trust_bypass_fable_and_session_limit_keep_the_blocked_card(self):
+        for gate, prompt in (("folder-trust", TRUST), ("bypass-permissions", BYPASS),
+                             ("fable-limit-unfocused", FABLE), ("fable-limit", FABLE),
+                             ("session-limit", "  You've hit your usage limit\n  ❯ 1. Upgrade\n    2. Wait")):
+            r = req(gate, prompt)
+            self.assertEqual(r.kind, G.FALLBACK_KIND, gate)
+            self.assertEqual([a.id for a in r.actions], ["open_terminal"], gate)
+            self.assertIsNone(G.keys_for(clicked(r, "opt1"), prompt, "blocked-human"), gate)
+
+    def test_the_allowlist_is_the_only_way_in(self):
+        self.assertEqual(G.SEMANTIC_GATES, {"permission", "selection", "press-enter", "login"})
 
 
 if __name__ == "__main__":

--- a/tests/hitl-tui-gate.test.py
+++ b/tests/hitl-tui-gate.test.py
@@ -176,6 +176,16 @@ class TestNeverAOneClickOnATrustOrSpendGate(unittest.TestCase):
             self.assertEqual([a.id for a in r.actions], ["open_terminal"], gate)
             self.assertIsNone(G.keys_for(clicked(r, "opt1"), prompt, "blocked-human"), gate)
 
+    def test_a_trust_dialog_labelled_selection_still_gets_no_button(self):
+        """The classifier picks the match nearest the bottom, so a numbered trust dialog is
+        labelled `selection`; the text, not the label, must keep the button off it."""
+        for gate in ("selection", "permission", "unknown"):
+            r = req(gate, TRUST)
+            self.assertEqual(r.kind, G.FALLBACK_KIND, gate)
+            self.assertEqual([a.id for a in r.actions], ["open_terminal"], gate)
+            r = req(gate, BYPASS)
+            self.assertEqual([a.id for a in r.actions], ["open_terminal"], gate)
+
     def test_the_allowlist_is_the_only_way_in(self):
         self.assertEqual(G.SEMANTIC_GATES, {"permission", "selection", "press-enter", "login"})
 

--- a/tests/hitl-tui-gate.test.py
+++ b/tests/hitl-tui-gate.test.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""A TUI dialog becomes a card with the buttons a human would expect, and a click
+becomes the keystrokes that answer THAT dialog — never a guessed key, never a key
+into a dialog the human did not see (owner spec 2026-09-04: the card says `yes`;
+the driver decides what `yes` means on screen, after checking the screen)."""
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
+from hitl import tui_gate as G  # noqa: E402
+
+PERM = ("  Dangerous rm operation on a possibly-empty path\n"
+        "  Do you want to proceed?\n"
+        "  ❯ 1. Yes\n"
+        "    2. Yes, and don't ask again for rm commands\n"
+        "    3. No\n"
+        "  Esc to cancel")
+PERM_CARET_ON_NO = PERM.replace("  ❯ 1. Yes", "    1. Yes").replace("    3. No", "  ❯ 3. No")
+SELECT = ("  Select a tsconfig\n"
+          "  ❯ 1. ./tsconfig.json\n"
+          "    2. ./tsconfig.base.json\n"
+          "  Enter to confirm · Esc to cancel")
+LOGIN = "  Login\n  Select login method:\n  ❯ 1. Claude account with subscription\n    2. Anthropic Console account"
+PRESS = "  Login\n  Logged in as x@example.com\n  Login successful. Press Enter to continue…"
+FABLE = "  You've reached your Fable limit\n    Switch to Opus 5 and continue\n  ❯ Continue with Fable 5.1"
+FALLBACK = "I am blocked and cannot continue without you."
+
+
+def req(gate, prompt, state="blocked-human", session="s"):
+    return G.requirement_for(state, gate, prompt, session, f"awaiting user: {gate}", FALLBACK)
+
+
+def clicked(r, action_id):
+    r.chosen_action = action_id
+    return r
+
+
+class TestParsing(unittest.TestCase):
+    def test_options_and_caret(self):
+        self.assertEqual(G.parse_options(PERM),
+                         (["Yes", "Yes, and don't ask again for rm commands", "No"], 0))
+        self.assertEqual(G.parse_options(PERM_CARET_ON_NO)[1], 2)
+
+    def test_the_question_is_the_prose_above_the_options_without_frames_or_hints(self):
+        self.assertEqual(G.question(PERM, "d"),
+                         "Dangerous rm operation on a possibly-empty path Do you want to proceed?")
+        self.assertEqual(G.question(SELECT, "d"), "Select a tsconfig")
+        self.assertEqual(G.question("  ────────\n  Esc to cancel", "detail wins"), "detail wins")
+
+
+class TestRequirement(unittest.TestCase):
+    def test_a_permission_dialog_is_a_no_yes_card_in_the_owners_words(self):
+        r = req("permission", PERM)
+        self.assertEqual(r.kind, "permission")
+        self.assertEqual(r.title, "Agent needs your confirmation")
+        self.assertEqual([a.label for a in r.actions], ["No", "Yes", "Open terminal"])
+        self.assertEqual([a.kind for a in r.actions], ["reject_once", "allow_once", "open_terminal"])
+        self.assertEqual(r.message, "Dangerous rm operation on a possibly-empty path Do you want to proceed?")
+        self.assertEqual(r.subject["option_for_action"], {"deny": 2, "allow": 0})
+        self.assertEqual(r.subject["source"], G.SOURCE)
+        self.assertEqual(r.device, {"id": "s", "name": "s"})
+
+    def test_a_selection_is_a_choice_with_one_button_per_option(self):
+        r = req("selection", SELECT)
+        self.assertEqual(r.kind, "choice")
+        self.assertEqual([a.id for a in r.actions], ["opt1", "opt2", "open_terminal"])
+        self.assertEqual([a.label for a in r.actions][:2], ["./tsconfig.json", "./tsconfig.base.json"])
+        self.assertEqual(r.subject["option_for_action"], {"opt1": 0, "opt2": 1})
+
+    def test_login_is_an_auth_card_with_a_local_sign_in_and_no_keys(self):
+        for gate, state in (("login", "blocked-human"), (None, "logged-out")):
+            r = req(gate, LOGIN if gate else None, state=state)
+            self.assertEqual(r.kind, "auth")
+            self.assertEqual(r.title, "Claude needs to be reconnected")
+            self.assertEqual([a.kind for a in r.actions], ["authenticate", "open_terminal"])
+            self.assertIsNone(G.keys_for(clicked(r, "authenticate"), LOGIN if gate else None, state))
+
+    def test_press_enter_is_a_confirmation_that_continues(self):
+        r = req("press-enter", PRESS)
+        self.assertEqual(r.kind, "confirmation")
+        self.assertEqual([a.id for a in r.actions], ["continue", "open_terminal"])
+        self.assertEqual(G.keys_for(clicked(r, "continue"), PRESS, "blocked-human"), ["Enter"])
+
+    def test_an_unparseable_or_paying_dialog_keeps_the_blocked_card_with_no_guessed_button(self):
+        for gate, prompt in (("fable-limit-unfocused", FABLE), ("unknown", "  something odd\n  >")):
+            r = req(gate, prompt)
+            self.assertEqual(r.kind, G.FALLBACK_KIND, gate)
+            self.assertEqual([a.id for a in r.actions], ["open_terminal"], gate)
+            self.assertEqual(r.message, FALLBACK, gate)
+
+    def test_kind_follows_the_options_not_the_gate_label(self):
+        """classify() calls a real permission dialog `selection` (its caret row is
+        nearest the bottom); the buttons must still be No/Yes. And a gate labelled
+        permission whose options are not yes/no is a choice, one button per option."""
+        self.assertEqual(req("selection", PERM).kind, "permission")
+        self.assertEqual([a.label for a in req("selection", PERM).actions], ["No", "Yes", "Open terminal"])
+        r = req("permission", "  Proceed?\n  ❯ 1. Continue\n    2. Abort")
+        self.assertEqual(r.kind, "choice")
+        self.assertEqual([a.label for a in r.actions], ["Continue", "Abort", "Open terminal"])
+
+    def test_the_guard_is_session_plus_dialog(self):
+        self.assertEqual(req("permission", PERM).guard, req("permission", PERM).guard)
+        self.assertNotEqual(req("permission", PERM).guard, req("permission", PERM, session="t").guard)
+        self.assertNotEqual(req("permission", PERM).guard, req("permission", SELECT).guard)
+
+
+class TestKeys(unittest.TestCase):
+    def test_yes_with_the_caret_already_on_yes_is_just_enter(self):
+        self.assertEqual(G.keys_for(clicked(req("permission", PERM), "allow"), PERM, "blocked-human"),
+                         ["Enter"])
+
+    def test_no_walks_the_caret_down_to_no(self):
+        self.assertEqual(G.keys_for(clicked(req("permission", PERM), "deny"), PERM, "blocked-human"),
+                         ["Down", "Down", "Enter"])
+
+    def test_yes_walks_the_caret_up_when_it_sits_on_no(self):
+        r = clicked(req("permission", PERM_CARET_ON_NO), "allow")
+        self.assertEqual(G.keys_for(r, PERM_CARET_ON_NO, "blocked-human"), ["Up", "Up", "Enter"])
+
+    def test_a_click_against_a_dialog_that_changed_sends_nothing(self):
+        """The most important check (owner): the card showed prompt A; by the click
+        the terminal shows prompt B. Enter into B is a decision nobody made."""
+        r = clicked(req("permission", PERM), "allow")
+        self.assertIsNone(G.keys_for(r, SELECT, "blocked-human"))
+        self.assertIsNone(G.keys_for(r, PERM.replace("possibly-empty", "non-empty"), "blocked-human"))
+        self.assertIsNone(G.keys_for(r, None, "idle-ready"))
+
+    def test_no_caret_on_screen_means_no_navigation_is_attempted(self):
+        flat = PERM.replace("  ❯ 1. Yes", "    1. Yes")
+        self.assertIsNone(G.keys_for(clicked(req("permission", flat), "deny"), flat, "blocked-human"))
+
+    def test_an_unknown_action_sends_nothing(self):
+        self.assertIsNone(G.keys_for(clicked(req("permission", PERM), "open_terminal"), PERM, "blocked-human"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

#3840 raises one `core-blocked` card per blocked episode with a single **"I have answered it"** button, so the owner still has to find the terminal. This PR gives the card the buttons the dialog itself offers, and makes a click answer the dialog:

| gate on screen | card | buttons |
|---|---|---|
| Yes/No dialog (permission — `classify()` labels it `selection`) | `permission` · "Agent needs your confirmation" | **No** · **Yes** · Open terminal |
| numbered selection | `choice` · "Agent needs a decision" | one per option · Open terminal |
| login | `auth` · "Claude needs to be reconnected" | **Sign in to Claude** (client-local) · Open terminal |
| "Press Enter to continue" | `confirmation` | **Continue** · Open terminal |
| anything else / credit-spending (Fable) | `core-blocked` (unchanged) | Open terminal only — **a key is never guessed** |

New `src/hitl/tui_gate.py` owns the policy (parse options + caret, kind from the *options*, action → caret-relative keys). `core-input-watch.py` gains `drive_escalations()`: once per click, human decisions only, own session only. Before sending, the guard is recomputed from the pane on screen — a changed dialog **expires the card with "This prompt has changed. Refresh the action."** instead of typing into it. A driven click the core has not moved past within 15 s expires as "did not take".

Resolution is now scoped by `subject.source == "tui"` rather than kind (TUI cards can be `permission` too; a hook-driver permission card must not be cleared by the core moving).

Owner spec 2026-09-04 (Air - Frontend): semantic actions, driver owns the keys, fingerprint + stale rejection, no core/host/tmux jargon. The desktop side (local routing straight to `runtime.sock`, one-click sign-in) is a separate PR in cinny-webclient; this PR already works through the existing room-reply path.

## Before / after — same dialog, through `compose_state()` + `escalate()`

```
before (origin/main 22295a36): kind='core-blocked' actions=['I have answered it']   title='s · blocked-human'
after  (HEAD):                 kind='permission'   actions=['No', 'Yes', 'Open terminal']   title='Agent needs your confirmation'
```

## Live round trip (real tmux pane, scratch socket + scratch workspace, `--once` twice)

```
pane:   Dangerous rm operation on a possibly-empty path / Do you want to proceed? / ❯ 1. Yes / 2. Yes, and don't ask again… / 3. No
tick 1: card kind=permission title='Agent needs your confirmation' actions=['No','Yes','Open terminal']
        message='Dangerous rm operation on a possibly-empty path Do you want to proceed?'
click:  apply_action(deny) -> in_progress
tick 2: driven_keys=['Down','Down','Enter']
pane (cat -v) after:  ^[[B^[[B  + newline      <- two Downs and an Enter arrived in the pane
```

## Tests

- `tests/hitl-tui-gate.test.py` — 15 (parsing, kind/buttons per gate, guard, keys incl. Up/Down walks, stale → None, no caret → None)
- `tests/core-input-watch-chat-escalation.test.py` — 21 → **31** (drive once; stale expires; unclicked / other session / policy decision never driven; hook card untouched; the real dialog **through `classify()`** is a No/Yes card)
- unchanged and green: `core-input-watch` 56, `hitl-manager-identity` 10, `hitl-projector` 10, `hitl-replies` 42, `sparrow-hitl-projection` 8, `core-supervisor-gate` 27, `hitl-hook-driver` 16
- mutations verified red: guard check removed → `hitl-tui-gate` fails; drive-once removed → escalation suite fails; resolve scoped by kind → escalation suite fails (after making the hook card share the session, so only the source separates them)

— sutando-qingyun-air

> Scope note: `docs/interaction-semantics.md` (#3767) governs the agent-side `ask.*` vocabulary that compiles to A2UI; by its own §"Relationship to the shipped V1 wires" the `space.ag2.hitl` requirement card is the shipped lifecycle envelope this PR extends — no overlap.
