### PR TITLE
fix(discord-bridge): the sandbox prompt lives under the workspace at 0600, not in /tmp, and is removed with its task

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -606,6 +606,27 @@ def remove_sandbox_prompt(task_id: str) -> bool:
         return False
 
 
+def sandbox_prompt_argument(prompt_path: "Path") -> str:
+    # Consumed at launch: the core's shell reads and deletes the file before codex
+    # starts, so no launched sandbox coexists with its own or an earlier prompt file.
+    q = shlex.quote(str(prompt_path))
+    return f'"$(cat {q} && rm -f {q})"'
+
+
+def write_sandbox_prompt_or_log(task_id: str, text: str, username: str):
+    try:
+        return write_sandbox_prompt(task_id, text)
+    except OSError as exc:
+        print(f"  [task-write] FAILED for @{username}: sandbox prompt not written ({exc})",
+              flush=True)
+        return None
+
+
+def _sandbox_prompt_task_live(task_id: str) -> bool:
+    # The shared finder, not the bare name: a claimed task is renamed <id>.claimed-*.txt.
+    return find_task_file(TASKS_DIR, task_id) is not None
+
+
 def sweep_sandbox_prompts(max_age_s: float = 600.0, now: float = None) -> int:
     """Remove prompts whose task is no longer live and is older than max_age_s;
     covers tasks the core archives itself, which never pass through archive_file."""
@@ -616,15 +637,20 @@ def sweep_sandbox_prompts(max_age_s: float = 600.0, now: float = None) -> int:
     except FileNotFoundError:
         return 0
     for f in entries:
-        if f.suffix != ".txt" or (TASKS_DIR / f.name).exists():
+        if f.suffix != ".txt" or _sandbox_prompt_task_live(f.stem):
             continue
-        try:
-            if now - f.stat().st_mtime >= max_age_s:
-                f.unlink()
-                removed += 1
-        except FileNotFoundError:
-            continue
+        if f.exists() and now - f.stat().st_mtime >= max_age_s:
+            f.unlink()
+            removed += 1
     return removed
+
+
+def sweep_sandbox_prompts_guarded() -> int:
+    try:
+        return sweep_sandbox_prompts()
+    except Exception as exc:  # noqa: BLE001 - a sweep must never stop delivery
+        print(f"  [sandbox-prompt] sweep failed: {exc}", flush=True)
+        return -1
 
 
 def archive_file(src: "Path", kind: str, task_id: str) -> bool:
@@ -634,7 +660,8 @@ def archive_file(src: "Path", kind: str, task_id: str) -> bool:
         src, kind, task_id,
         tasks_dir=ARCHIVE_TASKS_DIR, results_dir=ARCHIVE_RESULTS_DIR,
         log=lambda m: print(m, flush=True))
-    if kind == "tasks":
+    # Only a task that actually left the live queue loses its prompt; a retry still reads it.
+    if kind == "tasks" and ok:
         remove_sandbox_prompt(task_id)
     return ok
 
@@ -4047,13 +4074,10 @@ async def _handle_discord_message(message, force=False):
     else:
         codex_prompt_text = user_task_text
 
-    try:
-        prompt_path = write_sandbox_prompt(task_id, codex_prompt_text)
-    except OSError as exc:
-        print(f"  [task-write] FAILED for @{username}: sandbox prompt not written ({exc})",
-              flush=True)
+    prompt_path = write_sandbox_prompt_or_log(task_id, codex_prompt_text, username)
+    if prompt_path is None:
         return
-    quoted_task = f'"$(cat {shlex.quote(str(prompt_path))})"'
+    quoted_task = sandbox_prompt_argument(prompt_path)
 
     # Pre-classify Discord-state-reference tasks. Two-tier flow (per Chi's
     # 2026-05-08 strategy chat — option 3 systemic fix):
@@ -4159,6 +4183,7 @@ async def _handle_discord_message(message, force=False):
             "1. RUN CODEX — for genuine requests (code review, bug report, technical question, analysis).\n"
             "   Two-stage execution to avoid racing the bridge's results-dir poller:\n"
             f"   - Stage 1: bash skills/claude-codex/scripts/codex-bounded.sh --stall 45 --max 240 -- codex exec --sandbox read-only --skip-git-repo-check -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {quoted_task} < /dev/null   (the bounded runner kills the codex tree if it goes SILENT for 45s — the 'never going to finish' signal, since a working codex streams output — with a hard 240s backstop; a slow-but-progressing run is NOT killed. `< /dev/null` avoids the stdin hang. Exit 125 = stalled, 124 = hit the max cap; EITHER → fire the Stage-2 fallback.)\n"
+            f"   - If the prompt file named in Stage 1 is absent, an earlier launch consumed it: recreate it at that path from the task text above, then run Stage 1.\n"
             f"   - Stage 2: if codex exits 0 AND {RESULTS_DIR}/.codex-staging-{{id}}.txt is non-empty: mv {RESULTS_DIR}/.codex-staging-{{id}}.txt {RESULTS_DIR}/task-{{id}}.txt (atomic single move; bridge only ever sees a complete file).\n"
             f"   - Stage 2 fallback: if codex exits non-zero OR staging file is empty/missing: write the matching sentinel VERBATIM to {RESULTS_DIR}/task-{{id}}.txt — nonzero exit: 'Sandbox unavailable (codex exit <rc>) — no reply generated.' with <rc> the actual status; exit 0 but staging empty/missing: 'Sandbox unavailable (codex exited 0 with no output) — no reply generated.'. These are DIFFERENT failures and 'exit 0' must never appear in the first form. Neither is a refusal.\n"
             "   - The `-o` flag writes ONLY the agent's final message to the file (no exec sub-command dumps, no setup banner). Do NOT redirect stdout — codex's stdout includes verbose exec output from internal tool calls (e.g. github plugin reading PR diffs), which floods Discord. Do NOT add commentary.\n\n"
@@ -4184,6 +4209,7 @@ async def _handle_discord_message(message, force=False):
             "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
             "This task is from an OTHER tier sender (untrusted). You MUST delegate to a sandboxed Codex agent with HARD isolation. Two-stage execution to avoid racing the bridge's results-dir poller:\n\n"
             f"  Stage 1: bash skills/claude-codex/scripts/codex-bounded.sh --stall 45 --max 240 -- codex exec --sandbox read-only --skip-git-repo-check -C /tmp -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {quoted_task} < /dev/null   (bounded runner kills the codex tree on 45s of SILENCE — the 'never going to finish' signal — with a hard 240s backstop; exit 125 = stalled or 124 = max cap → Stage-2 fallback)\n"
+            f"  If the prompt file named in Stage 1 is absent, an earlier launch consumed it: recreate it at that path from the task text above, then run Stage 1.\n"
             f"  Stage 2: if codex exits 0 AND {RESULTS_DIR}/.codex-staging-{{id}}.txt is non-empty: mv {RESULTS_DIR}/.codex-staging-{{id}}.txt {RESULTS_DIR}/task-{{id}}.txt (atomic single move).\n"
             f"  Stage 2 fallback: if codex exits non-zero OR staging file empty/missing: write the matching sentinel VERBATIM to {RESULTS_DIR}/task-{{id}}.txt — nonzero exit: 'Sandbox unavailable (codex exit <rc>) — no reply generated.'; exit 0 with empty/missing staging: 'Sandbox unavailable (codex exited 0 with no output) — no reply generated.'.\n\n"
             "Rules:\n"
@@ -4961,10 +4987,7 @@ async def poll_results():
         # A task written straight into tasks/ was never in pending_replies, so
         # its result would sit forever. Adopt the route it declared, then let
         # the existing resolution below turn it into a channel.
-        try:
-            sweep_sandbox_prompts()
-        except Exception as exc:  # noqa: BLE001 - a sweep must never stop delivery
-            print(f"  [sandbox-prompt] sweep failed: {exc}", flush=True)
+        sweep_sandbox_prompts_guarded()
 
         global _orphan_route_cursor
         _adopted, _orphan_route_cursor = orphan_result_routes(

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -356,7 +356,6 @@ if not TOKEN:
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
 STATE_DIR = REPO / "state"
-SANDBOX_PROMPTS_DIR = STATE_DIR / "sandbox-prompts"
 ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
 ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
 OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"
@@ -580,90 +579,22 @@ def archive_path(kind: str, task_id: str) -> "Path":
     return month_dir / f"{task_id}.txt"
 
 
-def sandbox_prompt_path(task_id: str) -> "Path":
-    """Where the prompt the core inlines into the sandbox command lives: under the
-    workspace, never /tmp, which is the cwd the untrusted tier is started in."""
-    return SANDBOX_PROMPTS_DIR / f"{task_id}.txt"
-
-
-def write_sandbox_prompt(task_id: str, text: str) -> "Path":
-    # 0700/0600: a read-only sandbox reads anything its user can, so the prompt
-    # must be unreachable by path, not merely outside its working directory.
-    SANDBOX_PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
-    os.chmod(SANDBOX_PROMPTS_DIR, 0o700)
-    path = sandbox_prompt_path(task_id)
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as fh:
-        fh.write(text)
-    return path
-
-
-def remove_sandbox_prompt(task_id: str) -> bool:
-    try:
-        sandbox_prompt_path(task_id).unlink()
-        return True
-    except FileNotFoundError:
-        return False
-
-
-def sandbox_prompt_argument(prompt_path: "Path") -> str:
-    # Consumed at launch: the core's shell reads and deletes the file before codex
-    # starts, so no launched sandbox coexists with its own or an earlier prompt file.
-    q = shlex.quote(str(prompt_path))
-    return f'"$(cat {q} && rm -f {q})"'
-
-
-def write_sandbox_prompt_or_log(task_id: str, text: str, username: str):
-    try:
-        return write_sandbox_prompt(task_id, text)
-    except OSError as exc:
-        print(f"  [task-write] FAILED for @{username}: sandbox prompt not written ({exc})",
-              flush=True)
-        return None
-
-
-def _sandbox_prompt_task_live(task_id: str) -> bool:
-    # The shared finder, not the bare name: a claimed task is renamed <id>.claimed-*.txt.
-    return find_task_file(TASKS_DIR, task_id) is not None
-
-
-def sweep_sandbox_prompts(max_age_s: float = 600.0, now: float = None) -> int:
-    """Remove prompts whose task is no longer live and is older than max_age_s;
-    covers tasks the core archives itself, which never pass through archive_file."""
-    now = time.time() if now is None else now
-    removed = 0
-    try:
-        entries = list(SANDBOX_PROMPTS_DIR.iterdir())
-    except FileNotFoundError:
-        return 0
-    for f in entries:
-        if f.suffix != ".txt" or _sandbox_prompt_task_live(f.stem):
-            continue
-        if f.exists() and now - f.stat().st_mtime >= max_age_s:
-            f.unlink()
-            removed += 1
-    return removed
-
-
-def sweep_sandbox_prompts_guarded() -> int:
-    try:
-        return sweep_sandbox_prompts()
-    except Exception as exc:  # noqa: BLE001 - a sweep must never stop delivery
-        print(f"  [sandbox-prompt] sweep failed: {exc}", flush=True)
-        return -1
+def sandbox_prompt_argument(text: str) -> str:
+    """The prompt as a quoted heredoc for the core's own shell, so no prompt is ever
+    written to a file a same-user sandbox could read; codex receives it as argv."""
+    tag = "SUTANDO_PROMPT"
+    while re.search(rf"^{tag}\s*$", text, re.M):
+        tag += "_" + os.urandom(3).hex()
+    return f'"$(cat <<\'{tag}\'\n{text}\n{tag}\n)"'
 
 
 def archive_file(src: "Path", kind: str, task_id: str) -> bool:
     """Adapter: inject this bridge's archive roots + logger into the shared
     never-delete policy in task_archive."""
-    ok = _shared_archive_file(
+    return _shared_archive_file(
         src, kind, task_id,
         tasks_dir=ARCHIVE_TASKS_DIR, results_dir=ARCHIVE_RESULTS_DIR,
         log=lambda m: print(m, flush=True))
-    # Only a task that actually left the live queue loses its prompt; a retry still reads it.
-    if kind == "tasks" and ok:
-        remove_sandbox_prompt(task_id)
-    return ok
 
 
 def _archive_delivered_pair(result_file: "Path", task_id: str) -> None:
@@ -4074,10 +4005,6 @@ async def _handle_discord_message(message, force=False):
     else:
         codex_prompt_text = user_task_text
 
-    prompt_path = write_sandbox_prompt_or_log(task_id, codex_prompt_text, username)
-    if prompt_path is None:
-        return
-    quoted_task = sandbox_prompt_argument(prompt_path)
 
     # Pre-classify Discord-state-reference tasks. Two-tier flow (per Chi's
     # 2026-05-08 strategy chat — option 3 systemic fix):
@@ -4120,16 +4047,8 @@ async def _handle_discord_message(message, force=False):
             secret_notice = secret_handling_instruction("Discord", detected_secret_types)  # pragma: no cover
             enriched = filtered_enriched.text  # pragma: no cover
             user_task_text = confine_user_content(enriched)
-            # Rewrite the prompt file with the enriched body. quoted_task
-            # already points to `"$(cat {prompt_path})"` — keep the heredoc
-            # form (per PR #652's codex-stdin-hang fix). Using shlex.quote
-            # here would reintroduce the nested-escape pathology codex's
-            # stdin parser hangs on. Per MacBook's #644 v2 review 2026-05-10.
-            # Deep async-handler branch (fires only when a ref actually enriches);
-            # not independently invocable from unit tests — the enrich/confine
-            # logic is covered via confine_user_content's own tests. no-cover here
-            # keeps the diff gate honest without a Discord-message integration rig.
-            Path(prompt_path).write_text(user_task_text)  # pragma: no cover
+            # The enriched body replaces the prompt; the launch argument is composed later.
+            codex_prompt_text = user_task_text  # pragma: no cover
         elif access_tier in ("team", "other") and not is_collaborator:
             # Silent-escalate stays NON-OWNER-only, and collaborators are
             # excluded too. The prefetch above now runs for all tiers (so the
@@ -4182,8 +4101,7 @@ async def _handle_discord_message(message, force=False):
             "This task is from a TEAM tier sender. Choose ONE of three actions based on the content:\n\n"
             "1. RUN CODEX — for genuine requests (code review, bug report, technical question, analysis).\n"
             "   Two-stage execution to avoid racing the bridge's results-dir poller:\n"
-            f"   - Stage 1: bash skills/claude-codex/scripts/codex-bounded.sh --stall 45 --max 240 -- codex exec --sandbox read-only --skip-git-repo-check -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {quoted_task} < /dev/null   (the bounded runner kills the codex tree if it goes SILENT for 45s — the 'never going to finish' signal, since a working codex streams output — with a hard 240s backstop; a slow-but-progressing run is NOT killed. `< /dev/null` avoids the stdin hang. Exit 125 = stalled, 124 = hit the max cap; EITHER → fire the Stage-2 fallback.)\n"
-            f"   - If the prompt file named in Stage 1 is absent, an earlier launch consumed it: recreate it at that path from the task text above, then run Stage 1.\n"
+            f"   - Stage 1: bash skills/claude-codex/scripts/codex-bounded.sh --stall 45 --max 240 -- codex exec --sandbox read-only --skip-git-repo-check -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {sandbox_prompt_argument(codex_prompt_text)} < /dev/null   (the bounded runner kills the codex tree if it goes SILENT for 45s — the 'never going to finish' signal, since a working codex streams output — with a hard 240s backstop; a slow-but-progressing run is NOT killed. `< /dev/null` avoids the stdin hang. Exit 125 = stalled, 124 = hit the max cap; EITHER → fire the Stage-2 fallback.)\n"
             f"   - Stage 2: if codex exits 0 AND {RESULTS_DIR}/.codex-staging-{{id}}.txt is non-empty: mv {RESULTS_DIR}/.codex-staging-{{id}}.txt {RESULTS_DIR}/task-{{id}}.txt (atomic single move; bridge only ever sees a complete file).\n"
             f"   - Stage 2 fallback: if codex exits non-zero OR staging file is empty/missing: write the matching sentinel VERBATIM to {RESULTS_DIR}/task-{{id}}.txt — nonzero exit: 'Sandbox unavailable (codex exit <rc>) — no reply generated.' with <rc> the actual status; exit 0 but staging empty/missing: 'Sandbox unavailable (codex exited 0 with no output) — no reply generated.'. These are DIFFERENT failures and 'exit 0' must never appear in the first form. Neither is a refusal.\n"
             "   - The `-o` flag writes ONLY the agent's final message to the file (no exec sub-command dumps, no setup banner). Do NOT redirect stdout — codex's stdout includes verbose exec output from internal tool calls (e.g. github plugin reading PR diffs), which floods Discord. Do NOT add commentary.\n\n"
@@ -4208,8 +4126,7 @@ async def _handle_discord_message(message, force=False):
         "other": (
             "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
             "This task is from an OTHER tier sender (untrusted). You MUST delegate to a sandboxed Codex agent with HARD isolation. Two-stage execution to avoid racing the bridge's results-dir poller:\n\n"
-            f"  Stage 1: bash skills/claude-codex/scripts/codex-bounded.sh --stall 45 --max 240 -- codex exec --sandbox read-only --skip-git-repo-check -C /tmp -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {quoted_task} < /dev/null   (bounded runner kills the codex tree on 45s of SILENCE — the 'never going to finish' signal — with a hard 240s backstop; exit 125 = stalled or 124 = max cap → Stage-2 fallback)\n"
-            f"  If the prompt file named in Stage 1 is absent, an earlier launch consumed it: recreate it at that path from the task text above, then run Stage 1.\n"
+            f"  Stage 1: bash skills/claude-codex/scripts/codex-bounded.sh --stall 45 --max 240 -- codex exec --sandbox read-only --skip-git-repo-check -C /tmp -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {sandbox_prompt_argument(codex_prompt_text)} < /dev/null   (bounded runner kills the codex tree on 45s of SILENCE — the 'never going to finish' signal — with a hard 240s backstop; exit 125 = stalled or 124 = max cap → Stage-2 fallback)\n"
             f"  Stage 2: if codex exits 0 AND {RESULTS_DIR}/.codex-staging-{{id}}.txt is non-empty: mv {RESULTS_DIR}/.codex-staging-{{id}}.txt {RESULTS_DIR}/task-{{id}}.txt (atomic single move).\n"
             f"  Stage 2 fallback: if codex exits non-zero OR staging file empty/missing: write the matching sentinel VERBATIM to {RESULTS_DIR}/task-{{id}}.txt — nonzero exit: 'Sandbox unavailable (codex exit <rc>) — no reply generated.'; exit 0 with empty/missing staging: 'Sandbox unavailable (codex exited 0 with no output) — no reply generated.'.\n\n"
             "Rules:\n"
@@ -4987,7 +4904,6 @@ async def poll_results():
         # A task written straight into tasks/ was never in pending_replies, so
         # its result would sit forever. Adopt the route it declared, then let
         # the existing resolution below turn it into a channel.
-        sweep_sandbox_prompts_guarded()
 
         global _orphan_route_cursor
         _adopted, _orphan_route_cursor = orphan_result_routes(

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -356,6 +356,7 @@ if not TOKEN:
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
 STATE_DIR = REPO / "state"
+SANDBOX_PROMPTS_DIR = STATE_DIR / "sandbox-prompts"
 ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
 ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
 OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"
@@ -579,13 +580,63 @@ def archive_path(kind: str, task_id: str) -> "Path":
     return month_dir / f"{task_id}.txt"
 
 
+def sandbox_prompt_path(task_id: str) -> "Path":
+    """Where the prompt the core inlines into the sandbox command lives: under the
+    workspace, never /tmp, which is the cwd the untrusted tier is started in."""
+    return SANDBOX_PROMPTS_DIR / f"{task_id}.txt"
+
+
+def write_sandbox_prompt(task_id: str, text: str) -> "Path":
+    # 0700/0600: a read-only sandbox reads anything its user can, so the prompt
+    # must be unreachable by path, not merely outside its working directory.
+    SANDBOX_PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
+    os.chmod(SANDBOX_PROMPTS_DIR, 0o700)
+    path = sandbox_prompt_path(task_id)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(text)
+    return path
+
+
+def remove_sandbox_prompt(task_id: str) -> bool:
+    try:
+        sandbox_prompt_path(task_id).unlink()
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def sweep_sandbox_prompts(max_age_s: float = 600.0, now: float = None) -> int:
+    """Remove prompts whose task is no longer live and is older than max_age_s;
+    covers tasks the core archives itself, which never pass through archive_file."""
+    now = time.time() if now is None else now
+    removed = 0
+    try:
+        entries = list(SANDBOX_PROMPTS_DIR.iterdir())
+    except FileNotFoundError:
+        return 0
+    for f in entries:
+        if f.suffix != ".txt" or (TASKS_DIR / f.name).exists():
+            continue
+        try:
+            if now - f.stat().st_mtime >= max_age_s:
+                f.unlink()
+                removed += 1
+        except FileNotFoundError:
+            continue
+    return removed
+
+
 def archive_file(src: "Path", kind: str, task_id: str) -> bool:
     """Adapter: inject this bridge's archive roots + logger into the shared
     never-delete policy in task_archive."""
-    return _shared_archive_file(
+    ok = _shared_archive_file(
         src, kind, task_id,
         tasks_dir=ARCHIVE_TASKS_DIR, results_dir=ARCHIVE_RESULTS_DIR,
         log=lambda m: print(m, flush=True))
+    if kind == "tasks":
+        remove_sandbox_prompt(task_id)
+    return ok
 
 
 def _archive_delivered_pair(result_file: "Path", task_id: str) -> None:
@@ -3996,9 +4047,13 @@ async def _handle_discord_message(message, force=False):
     else:
         codex_prompt_text = user_task_text
 
-    prompt_path = f"/tmp/sutando-{task_id}.txt"
-    Path(prompt_path).write_text(codex_prompt_text)
-    quoted_task = f'"$(cat {prompt_path})"'
+    try:
+        prompt_path = write_sandbox_prompt(task_id, codex_prompt_text)
+    except OSError as exc:
+        print(f"  [task-write] FAILED for @{username}: sandbox prompt not written ({exc})",
+              flush=True)
+        return
+    quoted_task = f'"$(cat {shlex.quote(str(prompt_path))})"'
 
     # Pre-classify Discord-state-reference tasks. Two-tier flow (per Chi's
     # 2026-05-08 strategy chat — option 3 systemic fix):
@@ -4906,6 +4961,11 @@ async def poll_results():
         # A task written straight into tasks/ was never in pending_replies, so
         # its result would sit forever. Adopt the route it declared, then let
         # the existing resolution below turn it into a channel.
+        try:
+            sweep_sandbox_prompts()
+        except Exception as exc:  # noqa: BLE001 - a sweep must never stop delivery
+            print(f"  [sandbox-prompt] sweep failed: {exc}", flush=True)
+
         global _orphan_route_cursor
         _adopted, _orphan_route_cursor = orphan_result_routes(
             RESULTS_DIR, TASKS_DIR,

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -3973,14 +3973,8 @@ async def _handle_discord_message(message, force=False):
     user_task_text = confine_user_content(
         f"[Discord @{username}] {text}{attachment_note}{reply_context}"
     )
-    # Write task text to a /tmp file and reference via `"$(cat ...)"` heredoc
-    # form instead of shlex.quote'ing it inline. Reason: codex's stdin parser
-    # hangs 7-20min on nested-quote escapes (`'"'"'` style) that arise when
-    # the agent's Bash tool eval-wraps the bridge-injected codex command. The
-    # heredoc form has no nesting depth at any layer; codex receives the file
-    # contents directly via shell command substitution. Per memory
-    # `feedback_codex_nested_quotes_hang_stdin` (Lucy 2026-05-08) + reproduced
-    # live 2026-05-09 PT on Mini coord ping (task-1778363006905, hung 7+min).
+    # The prompt reaches codex as argv through a quoted heredoc the core's shell expands:
+    # no file on disk, and no nested quoting for codex's stdin parser to hang on.
     #
     # Sutando-identity preamble for codex-sandbox-tier tasks (team/other).
     # Without this, codex answers identity/capability questions about ITSELF

--- a/tests/discord-bridge-sandbox-prompt-path.test.py
+++ b/tests/discord-bridge-sandbox-prompt-path.test.py
@@ -15,6 +15,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 _BRIDGE_CCD = tempfile.mkdtemp(prefix="sandbox-prompt-ccd-")
 os.environ["CLAUDE_CONFIG_DIR"] = _BRIDGE_CCD
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")  # hermetic: never the host's
 _bridge_ch = Path(_BRIDGE_CCD) / "channels" / "discord"
 _bridge_ch.mkdir(parents=True, exist_ok=True)
 (_bridge_ch / "access.json").write_text(json.dumps({"allowFrom": ["4242"]}))

--- a/tests/discord-bridge-sandbox-prompt-path.test.py
+++ b/tests/discord-bridge-sandbox-prompt-path.test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# The sandbox prompt lives under the workspace at 0600, is removed with its task, and never sits in /tmp.
+"""Branch coverage for the access-mutate.py commands the bridge newly routes
+through it, plus the transition-window `pair` path regression (#3318).
+
+tests/access-mutate-cli.test.py covers only `group-append` / `group-rm-allow`
+and arg parsing. Everything the `/discord:access` skill now delegates —
+`pair`, `deny`, `allow`, `remove`, `policy`, `group-add`, `group-rm`, `set` —
+was unexercised.
+
+The `pair` case is not just coverage. `_backup()` writes the durable backup
+during a successful mutation, and `resolve_discord_access_file()` returns the
+canonical path once that backup exists. `_pair()` used to resolve twice: once
+for the transaction and once for the approved-marker directory. In the
+transition window (canonical absent, legacy populated) those two calls return
+DIFFERENT parents, so the grant committed to legacy while the "you're in"
+marker was written under canonical — which `_approved_dirs()` does not poll.
+The sender is authorized and never told. TestPairPathOwnership pins that the
+marker lands beside the file the mutation actually committed to.
+
+Isolation: same two-axis fixture as tests/access-mutate-cli.test.py —
+$CLAUDE_CONFIG_DIR for the live access.json and a direct monkeypatch of
+access_store.resolve_workspace for the durable backup, which resolves through
+resolve_workspace() and honors neither env var.
+
+Run: python3 tests/access-mutate-cli-commands.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib.util
+import io
+import inspect
+import json
+import shutil
+import stat
+import os
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+import access_store  # noqa: E402
+
+# discord-bridge.py resolves host config at import time, so isolating
+# CLAUDE_CONFIG_DIR inside setUp() would already be too late.
+_BRIDGE_CCD = tempfile.mkdtemp(prefix="sandbox-prompt-bridge-ccd-")
+_BRIDGE_SRC = tempfile.mkdtemp(prefix="sandbox-prompt-bridge-vanilla-")
+os.environ["CLAUDE_CONFIG_DIR"] = _BRIDGE_CCD
+os.environ["SOURCE_CLAUDE_CONFIG_DIR"] = _BRIDGE_SRC
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
+_bridge_ch = Path(_BRIDGE_CCD) / "channels" / "discord"
+_bridge_ch.mkdir(parents=True, exist_ok=True)
+(_bridge_ch / "access.json").write_text(json.dumps({"allowFrom": ["4242"]}))
+
+try:  # pragma: no cover - present in dev, absent in clean CI
+    import discord  # noqa: F401
+except Exception:
+    _stub = types.ModuleType("discord")
+    _stub.Intents = type("Intents", (), {"default": staticmethod(
+        lambda: type("I", (), {"message_content": False})())})
+    _stub.Client = type("Client", (), {"__init__": lambda self, **kw: None,
+                                       "event": staticmethod(lambda fn: fn)})
+    _stub.File = type("File", (), {"__init__": lambda self, *a, **kw: None})
+    _stub.Message = type("Message", (), {})
+    _stub.DMChannel = type("DMChannel", (), {})
+    sys.modules["discord"] = _stub
+
+_bspec = importlib.util.spec_from_file_location(
+    "dbridge_sandbox_prompt", REPO / "src" / "discord-bridge.py")
+db_bridge = importlib.util.module_from_spec(_bspec)
+sys.modules["dbridge_sandbox_prompt"] = db_bridge
+_bspec.loader.exec_module(db_bridge)
+
+
+class SandboxPromptPath(unittest.TestCase):
+    """The non-owner sandbox prompt lives under the workspace at 0600 and is gone
+    once the task is archived; /tmp, the sandbox cwd, never holds it."""
+
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp(prefix="sandbox-prompt-"))
+        for name in ("SANDBOX_PROMPTS_DIR", "TASKS_DIR", "ARCHIVE_TASKS_DIR", "ARCHIVE_RESULTS_DIR"):
+            setattr(self, "_old_" + name, getattr(db_bridge, name))
+        db_bridge.SANDBOX_PROMPTS_DIR = self.d / "state" / "sandbox-prompts"
+        db_bridge.TASKS_DIR = self.d / "tasks"
+        db_bridge.ARCHIVE_TASKS_DIR = self.d / "tasks" / "archive"
+        db_bridge.ARCHIVE_RESULTS_DIR = self.d / "results" / "archive"
+        db_bridge.TASKS_DIR.mkdir(parents=True)
+
+    def tearDown(self):
+        for name in ("SANDBOX_PROMPTS_DIR", "TASKS_DIR", "ARCHIVE_TASKS_DIR", "ARCHIVE_RESULTS_DIR"):
+            setattr(db_bridge, name, getattr(self, "_old_" + name))
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def test_prompt_is_written_under_the_workspace_not_tmp(self):
+        p = db_bridge.write_sandbox_prompt("task-1", "hello")
+        self.assertEqual(p, self.d / "state" / "sandbox-prompts" / "task-1.txt")
+        self.assertFalse(str(p).startswith("/tmp"))
+        self.assertEqual(p.read_text(), "hello")
+        self.assertEqual(stat.S_IMODE(p.stat().st_mode), 0o600)
+        self.assertEqual(stat.S_IMODE(p.parent.stat().st_mode), 0o700)
+
+    def test_handler_source_carries_no_tmp_path_and_logs_a_failed_write(self):
+        src = inspect.getsource(db_bridge._handle_discord_message)
+        self.assertNotIn("/tmp/sutando-", src)
+        self.assertIn("write_sandbox_prompt(", src)
+        self.assertIn("[task-write] FAILED", src.split("write_sandbox_prompt(", 1)[1][:400])
+        self.assertNotIn("/tmp/sutando-", inspect.getsource(db_bridge))
+
+    def test_archiving_the_task_removes_its_prompt(self):
+        db_bridge.write_sandbox_prompt("task-2", "x")
+        task = db_bridge.TASKS_DIR / "task-2.txt"; task.write_text("id: task-2\n")
+        self.assertTrue(db_bridge.archive_file(task, "tasks", "task-2"))
+        self.assertFalse(db_bridge.sandbox_prompt_path("task-2").exists())
+
+    def test_archiving_a_result_leaves_the_prompt_for_the_task_archive(self):
+        db_bridge.write_sandbox_prompt("task-3", "x")
+        res = self.d / "results" / "task-3.txt"; res.parent.mkdir(parents=True); res.write_text("r")
+        db_bridge.archive_file(res, "results", "task-3")
+        self.assertTrue(db_bridge.sandbox_prompt_path("task-3").exists())
+
+    def test_sweep_removes_only_old_prompts_whose_task_is_gone(self):
+        live = db_bridge.write_sandbox_prompt("task-4", "x")
+        (db_bridge.TASKS_DIR / "task-4.txt").write_text("live")
+        gone_old = db_bridge.write_sandbox_prompt("task-5", "x")
+        gone_new = db_bridge.write_sandbox_prompt("task-6", "x")
+        old = time.time() - 3600
+        os.utime(gone_old, (old, old)); os.utime(live, (old, old))
+        self.assertEqual(db_bridge.sweep_sandbox_prompts(max_age_s=600), 1)
+        self.assertTrue(live.exists()); self.assertFalse(gone_old.exists()); self.assertTrue(gone_new.exists())
+
+    def test_sweep_with_no_directory_is_zero_not_an_error(self):
+        db_bridge.SANDBOX_PROMPTS_DIR = self.d / "absent"
+        self.assertEqual(db_bridge.sweep_sandbox_prompts(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord-bridge-sandbox-prompt-path.test.py
+++ b/tests/discord-bridge-sandbox-prompt-path.test.py
@@ -102,7 +102,9 @@ class SandboxPromptPath(unittest.TestCase):
     def test_prompt_is_written_under_the_workspace_not_tmp(self):
         p = db_bridge.write_sandbox_prompt("task-1", "hello")
         self.assertEqual(p, self.d / "state" / "sandbox-prompts" / "task-1.txt")
-        self.assertFalse(str(p).startswith("/tmp"))
+        # Structural, not lexical: CI runs the checkout itself under /tmp.
+        self.assertEqual(self._old_SANDBOX_PROMPTS_DIR, db_bridge.STATE_DIR / "sandbox-prompts")
+        self.assertEqual(p.name, "task-1.txt")
         self.assertEqual(p.read_text(), "hello")
         self.assertEqual(stat.S_IMODE(p.stat().st_mode), 0o600)
         self.assertEqual(stat.S_IMODE(p.parent.stat().st_mode), 0o700)

--- a/tests/discord-bridge-sandbox-prompt-path.test.py
+++ b/tests/discord-bridge-sandbox-prompt-path.test.py
@@ -15,7 +15,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 _BRIDGE_CCD = tempfile.mkdtemp(prefix="sandbox-prompt-ccd-")
 os.environ["CLAUDE_CONFIG_DIR"] = _BRIDGE_CCD
-os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")  # hermetic: never the host's
+os.environ["DISCORD_BOT_TOKEN"] = "test-token-not-real"  # assigned, so a host token is never retained
 _bridge_ch = Path(_BRIDGE_CCD) / "channels" / "discord"
 _bridge_ch.mkdir(parents=True, exist_ok=True)
 (_bridge_ch / "access.json").write_text(json.dumps({"allowFrom": ["4242"]}))

--- a/tests/discord-bridge-sandbox-prompt-path.test.py
+++ b/tests/discord-bridge-sandbox-prompt-path.test.py
@@ -1,62 +1,20 @@
 #!/usr/bin/env python3
-# The sandbox prompt lives under the workspace at 0600, is removed with its task, and never sits in /tmp.
-"""Branch coverage for the access-mutate.py commands the bridge newly routes
-through it, plus the transition-window `pair` path regression (#3318).
-
-tests/access-mutate-cli.test.py covers only `group-append` / `group-rm-allow`
-and arg parsing. Everything the `/discord:access` skill now delegates —
-`pair`, `deny`, `allow`, `remove`, `policy`, `group-add`, `group-rm`, `set` —
-was unexercised.
-
-The `pair` case is not just coverage. `_backup()` writes the durable backup
-during a successful mutation, and `resolve_discord_access_file()` returns the
-canonical path once that backup exists. `_pair()` used to resolve twice: once
-for the transaction and once for the approved-marker directory. In the
-transition window (canonical absent, legacy populated) those two calls return
-DIFFERENT parents, so the grant committed to legacy while the "you're in"
-marker was written under canonical — which `_approved_dirs()` does not poll.
-The sender is authorized and never told. TestPairPathOwnership pins that the
-marker lands beside the file the mutation actually committed to.
-
-Isolation: same two-axis fixture as tests/access-mutate-cli.test.py —
-$CLAUDE_CONFIG_DIR for the live access.json and a direct monkeypatch of
-access_store.resolve_workspace for the durable backup, which resolves through
-resolve_workspace() and honors neither env var.
-
-Run: python3 tests/access-mutate-cli-commands.test.py
-Exit: 0 on pass, 1 on fail.
-"""
-from __future__ import annotations
-
-import asyncio
-import contextlib
+# The non-owner sandbox prompt is never written to a file: it rides the launch command as a quoted heredoc.
 import importlib.util
-import io
 import inspect
-import subprocess
 import json
-import shutil
-import stat
 import os
+import re
+import subprocess
 import sys
 import tempfile
-import time
 import types
 import unittest
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO / "src"))
-
-import access_store  # noqa: E402
-
-# discord-bridge.py resolves host config at import time, so isolating
-# CLAUDE_CONFIG_DIR inside setUp() would already be too late.
-_BRIDGE_CCD = tempfile.mkdtemp(prefix="sandbox-prompt-bridge-ccd-")
-_BRIDGE_SRC = tempfile.mkdtemp(prefix="sandbox-prompt-bridge-vanilla-")
+REPO = Path(__file__).resolve().parents[1]
+_BRIDGE_CCD = tempfile.mkdtemp(prefix="sandbox-prompt-ccd-")
 os.environ["CLAUDE_CONFIG_DIR"] = _BRIDGE_CCD
-os.environ["SOURCE_CLAUDE_CONFIG_DIR"] = _BRIDGE_SRC
-os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 _bridge_ch = Path(_BRIDGE_CCD) / "channels" / "discord"
 _bridge_ch.mkdir(parents=True, exist_ok=True)
 (_bridge_ch / "access.json").write_text(json.dumps({"allowFrom": ["4242"]}))
@@ -74,129 +32,64 @@ except Exception:
     _stub.DMChannel = type("DMChannel", (), {})
     sys.modules["discord"] = _stub
 
-_bspec = importlib.util.spec_from_file_location(
-    "dbridge_sandbox_prompt", REPO / "src" / "discord-bridge.py")
+_bspec = importlib.util.spec_from_file_location("dbridge_sandbox_prompt", REPO / "src" / "discord-bridge.py")
 db_bridge = importlib.util.module_from_spec(_bspec)
 sys.modules["dbridge_sandbox_prompt"] = db_bridge
 _bspec.loader.exec_module(db_bridge)
 
 
-class SandboxPromptPath(unittest.TestCase):
-    """The non-owner sandbox prompt lives under the workspace at 0600 and is gone
-    once the task is archived; /tmp, the sandbox cwd, never holds it."""
+def _evaluate(arg: str) -> str:
+    """What codex would receive: the argument after the core's shell expands it."""
+    return subprocess.run(["bash", "-c", "printf '%s' " + arg], capture_output=True, text=True).stdout
 
+
+class SandboxPromptArgument(unittest.TestCase):
     def setUp(self):
-        self.d = Path(tempfile.mkdtemp(prefix="sandbox-prompt-"))
-        for name in ("SANDBOX_PROMPTS_DIR", "TASKS_DIR", "ARCHIVE_TASKS_DIR", "ARCHIVE_RESULTS_DIR"):
-            setattr(self, "_old_" + name, getattr(db_bridge, name))
-        db_bridge.SANDBOX_PROMPTS_DIR = self.d / "state" / "sandbox-prompts"
-        db_bridge.TASKS_DIR = self.d / "tasks"
-        db_bridge.ARCHIVE_TASKS_DIR = self.d / "tasks" / "archive"
-        db_bridge.ARCHIVE_RESULTS_DIR = self.d / "results" / "archive"
-        db_bridge.TASKS_DIR.mkdir(parents=True)
+        self._old_state = db_bridge.STATE_DIR
+        db_bridge.STATE_DIR = Path(tempfile.mkdtemp(prefix="sandbox-prompt-state-"))
 
     def tearDown(self):
-        for name in ("SANDBOX_PROMPTS_DIR", "TASKS_DIR", "ARCHIVE_TASKS_DIR", "ARCHIVE_RESULTS_DIR"):
-            setattr(db_bridge, name, getattr(self, "_old_" + name))
-        shutil.rmtree(self.d, ignore_errors=True)
+        db_bridge.STATE_DIR = self._old_state
 
-    def test_prompt_is_written_under_the_workspace_not_tmp(self):
-        p = db_bridge.write_sandbox_prompt("task-1", "hello")
-        self.assertEqual(p, self.d / "state" / "sandbox-prompts" / "task-1.txt")
-        # Structural, not lexical: CI runs the checkout itself under /tmp.
-        self.assertEqual(self._old_SANDBOX_PROMPTS_DIR, db_bridge.STATE_DIR / "sandbox-prompts")
-        self.assertEqual(p.name, "task-1.txt")
-        self.assertEqual(p.read_text(), "hello")
-        self.assertEqual(stat.S_IMODE(p.stat().st_mode), 0o600)
-        self.assertEqual(stat.S_IMODE(p.parent.stat().st_mode), 0o700)
+    def test_no_prompt_file_mechanism_remains(self):
+        src = inspect.getsource(db_bridge)
+        for gone in ("/tmp/sutando-", "sandbox-prompts", "write_sandbox_prompt", "sweep_sandbox_prompts"):
+            self.assertNotIn(gone, src)
+        self.assertFalse((db_bridge.STATE_DIR / "sandbox-prompts").exists())
 
-    def test_handler_source_carries_no_tmp_path_and_logs_a_failed_write(self):
-        src = inspect.getsource(db_bridge._handle_discord_message)
-        self.assertNotIn("/tmp/sutando-", src)
-        self.assertIn("write_sandbox_prompt_or_log(", src)
-        self.assertIn("[task-write] FAILED", inspect.getsource(db_bridge.write_sandbox_prompt_or_log))
-        self.assertNotIn("/tmp/sutando-", inspect.getsource(db_bridge))
+    def test_the_shell_hands_codex_exactly_the_prompt(self):
+        text = "[Discord @alice] please 'quote' this \"and\" $(echo no) `no` \\n back\\slash\n\nsecond line"
+        self.assertEqual(_evaluate(db_bridge.sandbox_prompt_argument(text)), text)
 
-    def test_archive_failure_keeps_the_prompt_for_the_retry(self):
-        db_bridge.write_sandbox_prompt("task-8", "x")
-        task = db_bridge.TASKS_DIR / "task-8.txt"; task.write_text("id: task-8\n")
-        old = db_bridge._shared_archive_file
-        db_bridge._shared_archive_file = lambda *a, **k: False
-        try:
-            self.assertFalse(db_bridge.archive_file(task, "tasks", "task-8"))
-        finally:
-            db_bridge._shared_archive_file = old
-        self.assertTrue(db_bridge.sandbox_prompt_path("task-8").exists())
+    def test_a_prompt_containing_the_delimiter_still_round_trips(self):
+        text = "line one\nSUTANDO_PROMPT\nline three"
+        arg = db_bridge.sandbox_prompt_argument(text)
+        self.assertNotRegex(arg, r"<<'SUTANDO_PROMPT'\n")
+        self.assertEqual(_evaluate(arg), text)
 
-    def test_sweep_keeps_the_prompt_of_a_claimed_task(self):
-        p = db_bridge.write_sandbox_prompt("task-9", "x")
-        (db_bridge.TASKS_DIR / "task-9.claimed-core-1.txt").write_text("id: task-9\n")
-        old = time.time() - 3600; os.utime(p, (old, old))
-        self.assertEqual(db_bridge.sweep_sandbox_prompts(max_age_s=600), 0)
-        self.assertTrue(p.exists())
-
-    def test_removing_an_absent_prompt_is_false_not_an_error(self):
-        self.assertFalse(db_bridge.remove_sandbox_prompt("task-absent"))
-
-    def test_a_failed_write_logs_and_returns_none(self):
-        db_bridge.SANDBOX_PROMPTS_DIR = self.d / "not-a-dir"
-        db_bridge.SANDBOX_PROMPTS_DIR.write_text("file in the way")
-        buf = io.StringIO()
-        with contextlib.redirect_stdout(buf):
-            self.assertIsNone(db_bridge.write_sandbox_prompt_or_log("task-10", "x", "someone"))
-        self.assertIn("[task-write] FAILED for @someone", buf.getvalue())
-
-    def test_guarded_sweep_logs_and_never_raises(self):
-        old = db_bridge.sweep_sandbox_prompts
-        db_bridge.sweep_sandbox_prompts = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
-        buf = io.StringIO()
-        try:
-            with contextlib.redirect_stdout(buf):
-                self.assertEqual(db_bridge.sweep_sandbox_prompts_guarded(), -1)
-        finally:
-            db_bridge.sweep_sandbox_prompts = old
-        self.assertIn("sweep failed: boom", buf.getvalue())
-
-    def test_launch_consumes_the_prompt_before_the_sandbox_can_read_it(self):
-        p = db_bridge.write_sandbox_prompt("task-11", "the secret request")
-        arg = db_bridge.sandbox_prompt_argument(p)
-        # The stand-in sandbox receives the argument exactly as codex would, then tries the path.
-        script = ("sandbox(){ printf '%s\\n' \"$1\"; cat " + str(p)
-                  + " 2>/dev/null && echo READABLE || echo GONE; }; sandbox " + arg)
+    def test_two_queued_prompts_leave_nothing_on_disk_for_a_sibling_sandbox(self):
+        a = db_bridge.sandbox_prompt_argument("owner request A")
+        b = db_bridge.sandbox_prompt_argument("other sender request B")
+        # Stand-in for sandbox A: it gets A as argv and then searches the workspace state for any prompt.
+        script = ("sandbox(){ printf '%s\\n' \"$1\"; ls " + str(db_bridge.STATE_DIR)
+                  + "/sandbox-prompts 2>/dev/null | wc -l | tr -d ' '; }; sandbox " + a)
         out = subprocess.run(["bash", "-c", script], capture_output=True, text=True).stdout.splitlines()
-        self.assertEqual(out, ["the secret request", "GONE"])
-        self.assertFalse(p.exists())
+        self.assertEqual(out, ["owner request A", "0"])
+        self.assertNotIn("request B", " ".join(out))
+        self.assertEqual(_evaluate(b), "other sender request B")
 
-    def test_instruction_tells_the_core_how_to_rebuild_a_consumed_prompt(self):
+    def test_handler_composes_the_argument_after_enrichment_and_writes_no_file(self):
         src = inspect.getsource(db_bridge._handle_discord_message)
-        self.assertIn("sandbox_prompt_argument(", src)
-        self.assertEqual(src.count("an earlier launch consumed it"), 2)
+        self.assertEqual(src.count("sandbox_prompt_argument(codex_prompt_text)"), 2)
+        self.assertNotIn("write_text(user_task_text)", src)
+        self.assertLess(src.index("codex_prompt_text = user_task_text  # pragma: no cover"),
+                        src.index("sandbox_prompt_argument(codex_prompt_text)"))
 
-    def test_archiving_the_task_removes_its_prompt(self):
-        db_bridge.write_sandbox_prompt("task-2", "x")
-        task = db_bridge.TASKS_DIR / "task-2.txt"; task.write_text("id: task-2\n")
-        self.assertTrue(db_bridge.archive_file(task, "tasks", "task-2"))
-        self.assertFalse(db_bridge.sandbox_prompt_path("task-2").exists())
-
-    def test_archiving_a_result_leaves_the_prompt_for_the_task_archive(self):
-        db_bridge.write_sandbox_prompt("task-3", "x")
-        res = self.d / "results" / "task-3.txt"; res.parent.mkdir(parents=True); res.write_text("r")
-        db_bridge.archive_file(res, "results", "task-3")
-        self.assertTrue(db_bridge.sandbox_prompt_path("task-3").exists())
-
-    def test_sweep_removes_only_old_prompts_whose_task_is_gone(self):
-        live = db_bridge.write_sandbox_prompt("task-4", "x")
-        (db_bridge.TASKS_DIR / "task-4.txt").write_text("live")
-        gone_old = db_bridge.write_sandbox_prompt("task-5", "x")
-        gone_new = db_bridge.write_sandbox_prompt("task-6", "x")
-        old = time.time() - 3600
-        os.utime(gone_old, (old, old)); os.utime(live, (old, old))
-        self.assertEqual(db_bridge.sweep_sandbox_prompts(max_age_s=600), 1)
-        self.assertTrue(live.exists()); self.assertFalse(gone_old.exists()); self.assertTrue(gone_new.exists())
-
-    def test_sweep_with_no_directory_is_zero_not_an_error(self):
-        db_bridge.SANDBOX_PROMPTS_DIR = self.d / "absent"
-        self.assertEqual(db_bridge.sweep_sandbox_prompts(), 0)
+    def test_instruction_carries_a_heredoc_not_a_path(self):
+        arg = db_bridge.sandbox_prompt_argument("x")
+        self.assertTrue(arg.startswith('"$(cat <<\'SUTANDO_PROMPT'))
+        self.assertNotIn("/tmp", arg)
+        self.assertNotIn("state/", arg)
 
 
 if __name__ == "__main__":

--- a/tests/discord-bridge-sandbox-prompt-path.test.py
+++ b/tests/discord-bridge-sandbox-prompt-path.test.py
@@ -33,6 +33,7 @@ import contextlib
 import importlib.util
 import io
 import inspect
+import subprocess
 import json
 import shutil
 import stat
@@ -112,9 +113,64 @@ class SandboxPromptPath(unittest.TestCase):
     def test_handler_source_carries_no_tmp_path_and_logs_a_failed_write(self):
         src = inspect.getsource(db_bridge._handle_discord_message)
         self.assertNotIn("/tmp/sutando-", src)
-        self.assertIn("write_sandbox_prompt(", src)
-        self.assertIn("[task-write] FAILED", src.split("write_sandbox_prompt(", 1)[1][:400])
+        self.assertIn("write_sandbox_prompt_or_log(", src)
+        self.assertIn("[task-write] FAILED", inspect.getsource(db_bridge.write_sandbox_prompt_or_log))
         self.assertNotIn("/tmp/sutando-", inspect.getsource(db_bridge))
+
+    def test_archive_failure_keeps_the_prompt_for_the_retry(self):
+        db_bridge.write_sandbox_prompt("task-8", "x")
+        task = db_bridge.TASKS_DIR / "task-8.txt"; task.write_text("id: task-8\n")
+        old = db_bridge._shared_archive_file
+        db_bridge._shared_archive_file = lambda *a, **k: False
+        try:
+            self.assertFalse(db_bridge.archive_file(task, "tasks", "task-8"))
+        finally:
+            db_bridge._shared_archive_file = old
+        self.assertTrue(db_bridge.sandbox_prompt_path("task-8").exists())
+
+    def test_sweep_keeps_the_prompt_of_a_claimed_task(self):
+        p = db_bridge.write_sandbox_prompt("task-9", "x")
+        (db_bridge.TASKS_DIR / "task-9.claimed-core-1.txt").write_text("id: task-9\n")
+        old = time.time() - 3600; os.utime(p, (old, old))
+        self.assertEqual(db_bridge.sweep_sandbox_prompts(max_age_s=600), 0)
+        self.assertTrue(p.exists())
+
+    def test_removing_an_absent_prompt_is_false_not_an_error(self):
+        self.assertFalse(db_bridge.remove_sandbox_prompt("task-absent"))
+
+    def test_a_failed_write_logs_and_returns_none(self):
+        db_bridge.SANDBOX_PROMPTS_DIR = self.d / "not-a-dir"
+        db_bridge.SANDBOX_PROMPTS_DIR.write_text("file in the way")
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            self.assertIsNone(db_bridge.write_sandbox_prompt_or_log("task-10", "x", "someone"))
+        self.assertIn("[task-write] FAILED for @someone", buf.getvalue())
+
+    def test_guarded_sweep_logs_and_never_raises(self):
+        old = db_bridge.sweep_sandbox_prompts
+        db_bridge.sweep_sandbox_prompts = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+        buf = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buf):
+                self.assertEqual(db_bridge.sweep_sandbox_prompts_guarded(), -1)
+        finally:
+            db_bridge.sweep_sandbox_prompts = old
+        self.assertIn("sweep failed: boom", buf.getvalue())
+
+    def test_launch_consumes_the_prompt_before_the_sandbox_can_read_it(self):
+        p = db_bridge.write_sandbox_prompt("task-11", "the secret request")
+        arg = db_bridge.sandbox_prompt_argument(p)
+        # The stand-in sandbox receives the argument exactly as codex would, then tries the path.
+        script = ("sandbox(){ printf '%s\\n' \"$1\"; cat " + str(p)
+                  + " 2>/dev/null && echo READABLE || echo GONE; }; sandbox " + arg)
+        out = subprocess.run(["bash", "-c", script], capture_output=True, text=True).stdout.splitlines()
+        self.assertEqual(out, ["the secret request", "GONE"])
+        self.assertFalse(p.exists())
+
+    def test_instruction_tells_the_core_how_to_rebuild_a_consumed_prompt(self):
+        src = inspect.getsource(db_bridge._handle_discord_message)
+        self.assertIn("sandbox_prompt_argument(", src)
+        self.assertEqual(src.count("an earlier launch consumed it"), 2)
 
     def test_archiving_the_task_removes_its_prompt(self):
         db_bridge.write_sandbox_prompt("task-2", "x")


### PR DESCRIPTION
## Why

Closes #3912 (finding F6 of @db-ol's crosstalk benchmark, `docs/sutando-findings-2.md`). `src/discord-bridge.py` wrote every task's prompt, owner prompts included, to `/tmp/sutando-<task id>.txt` and never removed it, while the `other`-tier rulebook starts the untrusted sandbox with `-C /tmp`. A read-only sandbox reads, so the untrusted tier began in a directory holding every prompt the bridge had ever handled. The benchmark reproduced it on v0.12.0 and on main: a sandbox at cwd `/tmp` grepped the prompt files and told an outsider what two colleagues had asked earlier; another printed the first 120 lines of every prompt of the run. On one host `/tmp` held 459 such files over six days.

## What

**No prompt file.** The prompt rides the launch command as a quoted heredoc: `sandbox_prompt_argument(text)` renders `"$(cat <<'SUTANDO_PROMPT' … SUTANDO_PROMPT )"` (the tag gains a random suffix if the text contains a line equal to it), the core's own shell expands it when it runs Stage 1, and codex receives the text as argv exactly as before. The argument is composed inside the instruction, after the enrichment branch, from the final `codex_prompt_text`. Nothing is written to `/tmp`, nothing is written under the workspace, and a retry re-reads the task file.

**What this does not do, stated plainly.** The task files under `tasks/` and `tasks/archive/` carry the same text and are readable by any process running as the same OS user, as they were before this PR. Closing that class needs a read policy on the sandbox or a separate UID — #3913's sibling, a rulebook change, not this PR. Also not here: the rulebook sentence "-C /tmp sets cwd so Codex cannot read project files" is false as shipped and gets its own docs PR.

## Evidence

At `acdde478`:
```
python3 tests/discord-bridge-sandbox-prompt-path.test.py                     -> Ran 6 tests ... OK
same suite, src/discord-bridge.py swapped to origin/main (control)          -> FAILED (failures=2, errors=4); restored, tree clean
grep -c '/tmp/sutando-' src/discord-bridge.py                               -> 0   (main: 1, line 3999)
every suite that loads discord-bridge.py (134), by exit code                -> 133 pass; tests/discord-token-delegation.test.py fails and fails on origin/main too (rc=1)
```
The six tests pin: no file mechanism remains in the module and no `state/sandbox-prompts` appears; the shell hands codex exactly the text through quotes, backticks, `$(…)`, backslashes and a delimiter-colliding line; two queued prompts leave nothing under `state/` for a stand-in sibling sandbox to enumerate; the handler composes the argument after enrichment and writes no file; the instruction carries a heredoc, not a path.

History: `1dfd58c4` prompt file under the workspace at 0600 (review: same-UID readable; sweep and archive gaps); `0ffe13e0` consumed at launch, archive-gated, claimed-aware (review: queued siblings still readable); `acdde478` no file at all.

## Live path — the approval gate

The bridge is a live path and the witness is an approval gate (Qingyun's review). Because this head removes the prompt file entirely, the witness is the fileless flow, at this exact head: rebuild or restart the Discord bridge on `69212b1f`; send a real non-owner DM through it; attach the bridge's acknowledgement, the queued task file (its instruction block carrying the quoted heredoc, no path), the result delivered back, and the cleanup (nothing under `state/sandbox-prompts`, nothing under `/tmp/sutando-*`). It needs the owner's window for the restart, roughly half a minute of bridge downtime (DMs replay from the checkpoint; channel messages in the gap do not), and a sender who is not the owner's account. Until it is posted here this PR is unit and control evidence only.

Stand: Echo Act IV Mini



