### PR TITLE
fix(tool-suites-check): a red run must not read green on the next call

### DIFF
--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -154,6 +154,10 @@ def should_run(state: dict, newest: float, max_age: float, now: float) -> "tuple
         return True, "no previous run recorded"
     if newest > state.get("tools_mtime", 0.0):
         return True, "a tool or suite changed since the last green run"
+    # The failure list is recorded on every run; without this it was written
+    # and never read, so one red pass reported and the next skipped it.
+    if state.get("failed"):
+        return True, f"previous run left {len(state['failed'])} suite(s) failing"
     age = now - state.get("ran_at", 0.0)
     if age > max_age:
         return True, f"last run was {age/3600:.1f}h ago (> {max_age/3600:.0f}h)"

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -126,6 +126,18 @@ check("no recorded run -> run", tsc.should_run({}, 0.0, 3600, 100.0)[0], True)
 check("unchanged and young -> fresh", tsc.should_run({"tools_mtime": 5.0, "ran_at": 90.0}, 5.0, 3600, 100.0)[0], False)
 go, why = tsc.should_run({"tools_mtime": 5.0, "ran_at": 0.0}, 5.0, 3600, 7200.0)
 check("unchanged but older than --max-age -> run", (go, "last run was" in why), (True, True))
+
+# A red run stamps `ran_at`/`tools_mtime` like any other, so without reading the
+# recorded failure list the next call reports fresh and exits 0 on a red tree.
+go, why = tsc.should_run(
+    {"tools_mtime": 5.0, "ran_at": 90.0, "failed": ["a.test.py"]}, 5.0, 3600, 100.0)
+check("a previous run with FAILURES re-runs, though nothing changed",
+      (go, "failing" in why), (True, True))
+check("CONTROL: the same state with an EMPTY failed list is fresh",
+      tsc.should_run({"tools_mtime": 5.0, "ran_at": 90.0, "failed": []},
+                     5.0, 3600, 100.0)[0], False)
+check("CONTROL: and with no `failed` key at all it is still fresh",
+      tsc.should_run({"tools_mtime": 5.0, "ran_at": 90.0}, 5.0, 3600, 100.0)[0], False)
 with tempfile.TemporaryDirectory() as td:
     check("no scripts/ dir -> exit 2", tsc.main(["--workspace", td]), 2)
     (Path(td) / "scripts").mkdir()


### PR DESCRIPTION
## The defect

`main()` stamps the sentinel unconditionally — `os.replace(tmp, sf)`, commented *"record even on failure: the run happened"* — and the payload it writes includes `"failed": [names]`. **`should_run()` never reads that key.**

So a failing run records `ran_at` and `tools_mtime` exactly like a green one, and the next call takes the fresh branch and exits 0 on a tree that is still red.

In the proactive loop this check runs **once per pass**, so a real suite failure is reported on ONE pass and silently skipped on every pass afterwards — until an unrelated edit or the 24h fallback happens to re-trigger it.

```
$ grep -n '"failed"' skills/proactive-loop/scripts/tool-suites-check.py
244:        "suites": len(results), "failed": [n for n, _, _ in bad],     # the write
```

One occurrence. Zero reads. *(Positive control: `tools_mtime` is written the same way and **is** read, in `should_run` — so the grep reaches the population.)*

## Measured end to end

On a real workspace, by breaking one tool that a suite guards:

```
before          run1  rc=1
                run2  "fresh — 13 suite(s) skipped"                rc=0   <- red reads GREEN
after           run1  rc=1
                run2  "recall-check.test.py (rc=1): FAILED: ..."   rc=1   <- stays red
tool restored   run   rc=0                                                <- green clears it
```

The last line matters: the fix does not latch. A genuinely green run clears the state, so this cannot wedge the check on.

## The fix

Read the key that was already being written:

```python
if state.get("failed"):
    return True, f"previous run left {len(state['failed'])} suite(s) failing"
```

## Tests

Three arms, two of them controls — because *"re-run when `failed` is truthy"* and *"re-run always"* are indistinguishable without them:

```
ok   a previous run with FAILURES re-runs, though nothing changed
ok   CONTROL: the same state with an EMPTY failed list is fresh
ok   CONTROL: and with no `failed` key at all it is still fresh
```

Mutation (delete the branch) fails the first and quotes the wrong value — `got (False, False) want (True, True)` — while both controls stay green, so the arm is not vacuous.

`PASS — tool-suites-check tests`. `review-checks: PASS`.

## One behaviour change, named explicitly

Raised by @john-the-dev in review and absent from this body until now. The three `return 2` paths (cannot-answer) sit **before** the stamp, so a host carrying a red `failed` **and** an unresolvable extras declaration will now re-run and exit 2 on every pass, where before it took the fresh branch and exited 0.

That is the intended conversion — a silent wrong-green becomes a loud repeated red — but it is a real change in how noisy that host is, and it should not have taken a reviewer to surface it.

A host whose tree is green sees identical behaviour; existing sentinels already carry the key, so there is no migration. A stale non-empty `failed` re-runs once and self-clears.

## Relationship to #3852

Touches `should_run()` only. #3852 is open on the same file but changes `tools_and_suites()` and `main()`'s candidate list — no overlap, and whichever lands first the other rebases cleanly. Worth noting the two are the same *family*: that one is a watched set that cannot see the tools, this one is a freshness gate that cannot see a failure. Both make the check exit 0 while something is wrong.
