### PR TITLE
fix(health-check): name the workspace the report measured

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -13260,6 +13260,7 @@ def main():
     # Human-readable
     if not quiet:
         print("Sutando Health Check")
+        print(f"workspace: {WORKSPACE_DIR}")
         print("=" * 40)
 
         for c in checks:

--- a/tests/health-check-names-workspace.test.py
+++ b/tests/health-check-names-workspace.test.py
@@ -9,56 +9,137 @@ NOT a superset (nine names appear, two disappear). The dangerous cell was
 `task-watcher`: `⚠ ... wrote no PID sentinel` against one workspace and
 `✓ streaming watcher alive` against the other, for the SAME pid. The proactive
 loop reads that probe to decide whether to stop or start a watcher.
+
+Every assertion here reads RENDERED OUTPUT, never the source text. A source
+substring stays green when the line is present but unreachable — the reverted-
+source control at the bottom is what proves these tests can fail at all.
 """
+import contextlib
 import importlib.util
+import io
+import json
 import os
+import sys
+import tempfile
 import unittest
+from unittest import mock
 
 ROOT = os.path.join(os.path.dirname(__file__), "..")
 SRC = os.path.join(ROOT, "src", "health-check.py")
+EMITTED = 'print(f"workspace: {WORKSPACE_DIR}")'
+# Full line, indentation included: mutating a bare substring can nest the
+# statement inside itself, and a SyntaxError is not a demonstration.
+ANCHOR = '\n        ' + EMITTED + '\n'
 
 _spec = importlib.util.spec_from_file_location("health_check_ws_mod", SRC)
 hc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(hc)
 
+OK = {"name": "task-queue", "status": "ok", "detail": "empty"}
+OK2 = {"name": "memory-index", "status": "ok", "detail": "24k"}
+DOWN = {"name": "voice-agent", "status": "down", "detail": "port 9900"}
 
-class WorkspaceNamedTests(unittest.TestCase):
-    def test_module_resolves_a_concrete_workspace(self):
-        """WORKSPACE_DIR is what every probe reads; it must be a real path."""
-        self.assertTrue(str(hc.WORKSPACE_DIR))
-        self.assertTrue(os.path.isabs(str(hc.WORKSPACE_DIR)),
-                        f"not absolute: {hc.WORKSPACE_DIR!r}")
 
-    def test_header_prints_the_resolved_workspace(self):
-        """Structural, matching this file's sibling test for main()-glue: the
-        header must interpolate WORKSPACE_DIR, not a literal or a re-derivation."""
+def run_main(module, argv, checks):
+    """Invoke the real main() with the probes stubbed out — no I/O, no fixes."""
+    out, err = io.StringIO(), io.StringIO()
+    with mock.patch.object(module, "run_all_checks", lambda: [dict(c) for c in checks]), \
+            mock.patch.object(sys, "argv", ["health-check.py", *argv]), \
+            contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            module.main()
+            code = 0
+        except SystemExit as exc:
+            code = exc.code
+    return code, out.getvalue()
+
+
+class HumanReportTests(unittest.TestCase):
+    def test_human_report_names_the_resolved_workspace(self):
+        _, out = run_main(hc, [], [OK, OK2])
+        self.assertIn(f"workspace: {hc.WORKSPACE_DIR}", out.splitlines(),
+                      f"human report never printed the workspace:\n{out}")
+
+    def test_workspace_line_sits_above_the_probe_rows(self):
+        """Printed below the rows, a reader scanning the top still misses it."""
+        _, out = run_main(hc, [], [OK, OK2])
+        lines = out.splitlines()
+
+        def where(label, pred):
+            # index()/next() would RAISE on a missing line, and an error is not
+            # a demonstration: the mutation must report as a failure.
+            hit = [i for i, ln in enumerate(lines) if pred(ln)]
+            self.assertTrue(hit, f"no {label} line in the report:\n{out}")
+            return hit[0]
+
+        title = where("title", lambda ln: ln == "Sutando Health Check")
+        ws = where("workspace", lambda ln: ln == f"workspace: {hc.WORKSPACE_DIR}")
+        rule = where("divider", lambda ln: set(ln) == {"="})
+        first_row = where("probe row", lambda ln: "task-queue" in ln)
+        self.assertLess(title, ws, f"workspace line precedes the title:\n{out}")
+        self.assertLess(ws, rule, f"workspace line falls below the divider:\n{out}")
+        self.assertLess(ws, first_row, f"workspace line falls below the rows:\n{out}")
+
+    def test_json_payload_is_untouched(self):
+        """--json is a machine interface: prose on stdout breaks json.loads."""
+        _, out = run_main(hc, ["--json"], [OK, OK2])
+        payload = json.loads(out)
+        self.assertEqual(payload["total"], 2)
+        self.assertNotIn("workspace:", out)
+
+    def test_quiet_path_is_untouched(self):
+        """--quiet feeds cron callers; its issue list must stay bare."""
+        code, out = run_main(hc, ["--quiet"], [OK, DOWN])
+        self.assertEqual(code, 1)
+        self.assertNotIn("workspace:", out)
+        self.assertIn("voice-agent", out)
+
+
+class RevertedSourceControl(unittest.TestCase):
+    """Proves the tests above discriminate.
+
+    Deleting the line is the weak mutation — a source-substring test catches
+    that one too. This control also runs the `if False:` form, where the text
+    survives and only the BEHAVIOR is gone; that is the mutation a source
+    assertion cannot see, and it is why this file asserts on output.
+    """
+
+    def _import_mutant(self, source):
+        # Written beside the original so `Path(__file__).parent.parent` still
+        # resolves to the repo and the sibling imports keep working.
+        fd, path = tempfile.mkstemp(prefix=".hc-mutant-", suffix=".py",
+                                    dir=os.path.join(ROOT, "src"))
+        self.addCleanup(os.unlink, path)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(source)
+        spec = importlib.util.spec_from_file_location("health_check_mutant", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def _source(self):
         with open(SRC) as fh:
-            src = fh.read()
-        needle = 'print(f"workspace: {WORKSPACE_DIR}")'
-        self.assertTrue(needle in src, f"header does not print {needle}")
+            source = fh.read()
+        self.assertEqual(source.count(ANCHOR), 1,
+                         "mutation anchor is not unique — the control would be vacuous")
+        return source
 
-    def test_header_line_precedes_the_rule(self):
-        """It has to be inside the human-readable block, above the divider —
-        printed after it, a reader scanning the top of the report still misses it."""
-        with open(SRC) as fh:
-            src = fh.read()
-        ws = src.find('print(f"workspace: {WORKSPACE_DIR}")')
-        title = src.find('print("Sutando Health Check")')
-        self.assertNotEqual(ws, -1, "no workspace line to position")
-        self.assertNotEqual(title, -1, "no title line to position against")
-        rule = src.find('print("=" * 40)', title)
-        self.assertNotEqual(rule, -1, "no divider after the title")
-        self.assertLess(title, ws, "workspace line must follow the title")
-        self.assertLess(ws, rule, "workspace line must precede the divider")
+    def _assert_silent(self, source, why):
+        mod = self._import_mutant(source)
+        _, out = run_main(mod, [], [OK, OK2])
+        self.assertIn("Sutando Health Check", out,
+                      f"harness did not capture the human report ({why})")
+        self.assertNotIn("workspace:", out,
+                         f"{why}: emission is disabled yet the line appeared")
 
-    def test_control_the_probe_can_fail(self):
-        """A structural assertion that matches nothing scores 0 by construction."""
-        with open(SRC) as fh:
-            src = fh.read()
-        self.assertFalse('print(f"workspace: {NO_SUCH_NAME}")' in src,
-                         "the negative control matched — the probe is too loose")
-        self.assertTrue('print("Sutando Health Check")' in src,
-                        "the positive control missed — the probe cannot hit")
+    def test_removing_the_line_goes_silent(self):
+        source = self._source()
+        self._assert_silent(source.replace(ANCHOR, "\n"), "line removed")
+
+    def test_unreachable_line_goes_silent(self):
+        source = self._source()
+        self._assert_silent(source.replace(ANCHOR, f"\n        if False: {EMITTED}\n"),
+                            "line present but unreachable")
 
 
 if __name__ == "__main__":

--- a/tests/health-check-names-workspace.test.py
+++ b/tests/health-check-names-workspace.test.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
-"""The human report must name the workspace it measured.
-
-Assertions read rendered output, never source text: a source substring
-stays green when the line is present but unreachable.
-"""
+"""The human report must name the workspace it measured, asserted on rendered
+output: a source substring stays green when the line is present but unreachable."""
 import contextlib
 import importlib.util
 import io
@@ -86,15 +83,12 @@ class HumanReportTests(unittest.TestCase):
 
 
 class RevertedSourceControl(unittest.TestCase):
-    """Proves the tests above discriminate.
-
-    Both mutations, because deleting the line is the weak one: `if False:`
-    leaves the text intact and removes only the behavior.
-    """
+    """Both mutations, because deleting the line is the weak one: `if False:`
+    leaves the text intact and removes only the behavior."""
 
     def _import_mutant(self, source):
-        # No file on disk: a temp module under src/ is traced by coverage and then
-        # deleted, and the run fails with "No source for code" after the tests pass.
+        # In memory, never a file: coverage traces any module written under src/ and
+        # then fails the run with "No source for code" once cleanup removes it.
         mod = types.ModuleType("health_check_mutant")
         mod.__file__ = SRC
         exec(compile(source, "<hc-mutant>", "exec"), mod.__dict__)

--- a/tests/health-check-names-workspace.test.py
+++ b/tests/health-check-names-workspace.test.py
@@ -10,7 +10,7 @@ import io
 import json
 import os
 import sys
-import tempfile
+import types
 import unittest
 from unittest import mock
 
@@ -93,16 +93,11 @@ class RevertedSourceControl(unittest.TestCase):
     """
 
     def _import_mutant(self, source):
-        # Written beside the original so `Path(__file__).parent.parent` still
-        # resolves to the repo and the sibling imports keep working.
-        fd, path = tempfile.mkstemp(prefix=".hc-mutant-", suffix=".py",
-                                    dir=os.path.join(ROOT, "src"))
-        self.addCleanup(os.unlink, path)
-        with os.fdopen(fd, "w") as fh:
-            fh.write(source)
-        spec = importlib.util.spec_from_file_location("health_check_mutant", path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        # No file on disk: a temp module under src/ is traced by coverage and then
+        # deleted, and the run fails with "No source for code" after the tests pass.
+        mod = types.ModuleType("health_check_mutant")
+        mod.__file__ = SRC
+        exec(compile(source, "<hc-mutant>", "exec"), mod.__dict__)
         return mod
 
     def _source(self):

--- a/tests/health-check-names-workspace.test.py
+++ b/tests/health-check-names-workspace.test.py
@@ -1,18 +1,8 @@
 #!/usr/bin/env python3
-"""The report must name the workspace it measured.
+"""The human report must name the workspace it measured.
 
-Every probe resolves against `WORKSPACE_DIR`, which `resolve_workspace()`
-derives from the working directory. On a host with two checkouts the same
-command produces two different verdicts and says nothing about which tree it
-read — measured: 10 warnings from one, 19 from the other, seconds apart, and
-NOT a superset (nine names appear, two disappear). The dangerous cell was
-`task-watcher`: `⚠ ... wrote no PID sentinel` against one workspace and
-`✓ streaming watcher alive` against the other, for the SAME pid. The proactive
-loop reads that probe to decide whether to stop or start a watcher.
-
-Every assertion here reads RENDERED OUTPUT, never the source text. A source
-substring stays green when the line is present but unreachable — the reverted-
-source control at the bottom is what proves these tests can fail at all.
+Assertions read rendered output, never source text: a source substring
+stays green when the line is present but unreachable.
 """
 import contextlib
 import importlib.util
@@ -98,10 +88,8 @@ class HumanReportTests(unittest.TestCase):
 class RevertedSourceControl(unittest.TestCase):
     """Proves the tests above discriminate.
 
-    Deleting the line is the weak mutation — a source-substring test catches
-    that one too. This control also runs the `if False:` form, where the text
-    survives and only the BEHAVIOR is gone; that is the mutation a source
-    assertion cannot see, and it is why this file asserts on output.
+    Both mutations, because deleting the line is the weak one: `if False:`
+    leaves the text intact and removes only the behavior.
     """
 
     def _import_mutant(self, source):

--- a/tests/health-check-names-workspace.test.py
+++ b/tests/health-check-names-workspace.test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""The report must name the workspace it measured.
+
+Every probe resolves against `WORKSPACE_DIR`, which `resolve_workspace()`
+derives from the working directory. On a host with two checkouts the same
+command produces two different verdicts and says nothing about which tree it
+read — measured: 10 warnings from one, 19 from the other, seconds apart, and
+NOT a superset (nine names appear, two disappear). The dangerous cell was
+`task-watcher`: `⚠ ... wrote no PID sentinel` against one workspace and
+`✓ streaming watcher alive` against the other, for the SAME pid. The proactive
+loop reads that probe to decide whether to stop or start a watcher.
+"""
+import importlib.util
+import os
+import unittest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+SRC = os.path.join(ROOT, "src", "health-check.py")
+
+_spec = importlib.util.spec_from_file_location("health_check_ws_mod", SRC)
+hc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hc)
+
+
+class WorkspaceNamedTests(unittest.TestCase):
+    def test_module_resolves_a_concrete_workspace(self):
+        """WORKSPACE_DIR is what every probe reads; it must be a real path."""
+        self.assertTrue(str(hc.WORKSPACE_DIR))
+        self.assertTrue(os.path.isabs(str(hc.WORKSPACE_DIR)),
+                        f"not absolute: {hc.WORKSPACE_DIR!r}")
+
+    def test_header_prints_the_resolved_workspace(self):
+        """Structural, matching this file's sibling test for main()-glue: the
+        header must interpolate WORKSPACE_DIR, not a literal or a re-derivation."""
+        with open(SRC) as fh:
+            src = fh.read()
+        needle = 'print(f"workspace: {WORKSPACE_DIR}")'
+        self.assertTrue(needle in src, f"header does not print {needle}")
+
+    def test_header_line_precedes_the_rule(self):
+        """It has to be inside the human-readable block, above the divider —
+        printed after it, a reader scanning the top of the report still misses it."""
+        with open(SRC) as fh:
+            src = fh.read()
+        ws = src.find('print(f"workspace: {WORKSPACE_DIR}")')
+        title = src.find('print("Sutando Health Check")')
+        self.assertNotEqual(ws, -1, "no workspace line to position")
+        self.assertNotEqual(title, -1, "no title line to position against")
+        rule = src.find('print("=" * 40)', title)
+        self.assertNotEqual(rule, -1, "no divider after the title")
+        self.assertLess(title, ws, "workspace line must follow the title")
+        self.assertLess(ws, rule, "workspace line must precede the divider")
+
+    def test_control_the_probe_can_fail(self):
+        """A structural assertion that matches nothing scores 0 by construction."""
+        with open(SRC) as fh:
+            src = fh.read()
+        self.assertFalse('print(f"workspace: {NO_SUCH_NAME}")' in src,
+                         "the negative control matched — the probe is too loose")
+        self.assertTrue('print("Sutando Health Check")' in src,
+                        "the positive control missed — the probe cannot hit")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The gap

Every probe resolves against `WORKSPACE_DIR`, which `resolve_workspace()` derives from the **working directory**. The report never says which one it read.

On a host with two checkouts that is not cosmetic. Same command, same host, seconds apart:

```
live checkout   10 warning(s)
dev checkout    19 warning(s)
```

**Not a superset** — nine names appear and two disappear. The dangerous cell, for the **same pid**:

```
live   ✓ task-watcher   streaming watcher alive (pid 90998)
dev    ⚠ task-watcher   pid 90998 ... wrote no PID sentinel
```

The proactive loop reads that probe to decide whether to **stop or start a watcher**, and its own instructions warn that restarting on a dead-looking sentinel *"is what produces the duplicates in the first place"*. Acting on the wrong tree's verdict there is an outage, not a wrong sentence.

## The change

```
 Sutando Health Check
+workspace: /Users/.../space.ag2.app/workspace
 ========================================
```

One line, in the human-readable header, above the divider so it is visible to anyone scanning the top of the report.

**`summary_line()` is untouched**, and the machine paths are now asserted rather than claimed: `--json` still parses with `json.loads()` and carries no prose, `--quiet` still prints only its issue rows. The sibling suite (`health-check-summary-warnings.test.py`, 12 tests) stays green.

## Tests — rewritten at `92313bfc` after @qingyun-wu's review

The first version asserted on `health-check.py` **as text**, and the review's mutation is the one that proves why that is not a regression proof: `if False: print(f"workspace: {WORKSPACE_DIR}")` leaves the token in the file, so all four arms passed while the report could no longer emit anything. Confirmed at that head before rewriting.

The suite now invokes the real `main()` with `run_all_checks` stubbed and stdout captured, and asserts on the **rendered lines**:

```
test_human_report_names_the_resolved_workspace ... ok
test_workspace_line_sits_above_the_probe_rows ... ok      # above the divider AND the first row
test_json_payload_is_untouched ... ok                     # json.loads() succeeds, no prose
test_quiet_path_is_untouched ... ok                       # rc=1, issue rows only
test_removing_the_line_goes_silent ... ok                 # reverted-source control
test_unreachable_line_goes_silent ... ok                  # `if False:` control
Ran 6 tests in 0.150s
OK
```

The reverted-source control is **in the suite**, not in this PR body: it writes a mutated copy of `health-check.py` beside the original (so `Path(__file__).parent.parent` still resolves), imports it, runs the same harness, and asserts no workspace line appears — for the deleted line and for the unreachable one.

### Both mutations, run against the production file at this head

```
### MUTATION: if False: print(f"workspace: {WORKSPACE_DIR}")
FAIL: test_human_report_names_the_resolved_workspace
FAIL: test_workspace_line_sits_above_the_probe_rows
FAIL: test_removing_the_line_goes_silent
FAIL: test_unreachable_line_goes_silent
Ran 6 tests in 0.002s
FAILED (failures=4)

### MUTATION: pass
FAIL: test_human_report_names_the_resolved_workspace
FAIL: test_workspace_line_sits_above_the_probe_rows
FAIL: test_removing_the_line_goes_silent
FAIL: test_unreachable_line_goes_silent
Ran 6 tests in 0.002s
FAILED (failures=4)
```

Compare with the previous head, where the `if False:` mutation printed `Ran 4 tests ... OK`. That is the whole delta.

**Failures, not errors.** Two smaller repairs came out of getting that output readable, and both are mistakes I have made before in this repo:

- ordering assertions collected indices instead of calling `index()`/`next()` — a missing line was raising `ValueError`/`StopIteration`, so the first mutation run reported `failures=2, errors=1`;
- the mutation anchor is the **full indented line**, not the bare call. Replacing a bare substring nests the statement inside itself (`if False: if False: print(...)`) and a `SyntaxError` is not a demonstration either.

## Provenance, and the honest scope

I hit this myself, running the check from the wrong checkout during an autonomous pass, and **I am the only case I know of**. I am filing it because the failure mode is silent and its worst outcome is stopping a live watcher — not because it is common. If you would rather this waited for a second sighting, say so and I will close it.

Adjacent but independent of #3918 (same repo, different file). The family is the same one #3852 is working: *a check that reads the wrong place and reports confidently.*
