### PR TITLE
ci(eslint): a diff ESLint cannot read should not pay for a clean install

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -58,9 +58,9 @@ jobs:
             echo 'Scope undetermined (or push to main) — linting.'
             exit 0
           fi
-          # Everything ESLint reads: the sources its flat config matches, its own
-          # config, the workflow, tsconfig, and the lockfile that pins the rules.
-          if grep -qE '\.(ts|tsx|js|mjs|cjs)$|^eslint\.config\.mjs$|^package(-lock)?\.json$|^tsconfig[^/]*\.json$|^\.github/workflows/eslint\.yml$' /tmp/eslint-scope.txt; then
+          # Everything ESLint reads, plus every dependency input `npm ci` consults:
+          # package.json, package-lock.json, npm-shrinkwrap.json and .npmrc.
+          if grep -qE '\.(ts|tsx|js|mjs|cjs)$|^eslint\.config\.mjs$|^package(-lock)?\.json$|^npm-shrinkwrap\.json$|^\.npmrc$|^tsconfig[^/]*\.json$|^\.github/workflows/eslint\.yml$' /tmp/eslint-scope.txt; then
             echo 'run=true' >> "$GITHUB_OUTPUT"
           else
             echo 'run=false' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -40,14 +40,45 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # A workflow-level `paths:` filter would never report this REQUIRED context,
+      # stranding the PR — so the gate skips STEPS and the job still reports.
+      - name: Decide whether this diff has anything to lint
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+          # Unknown or empty scope lints: a lookup that failed is not evidence
+          # that no lintable file changed.
+          if [ "${{ github.event_name }}" != "pull_request" ] \
+             || ! gh pr diff "$PR" --name-only > /tmp/eslint-scope.txt \
+             || ! grep -q . /tmp/eslint-scope.txt; then
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+            echo 'Scope undetermined (or push to main) — linting.'
+            exit 0
+          fi
+          # Everything ESLint reads: the sources its flat config matches, its own
+          # config, the workflow, tsconfig, and the lockfile that pins the rules.
+          if grep -qE '\.(ts|tsx|js|mjs|cjs)$|^eslint\.config\.mjs$|^package(-lock)?\.json$|^tsconfig[^/]*\.json$|^\.github/workflows/eslint\.yml$' /tmp/eslint-scope.txt; then
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+            echo 'No file ESLint reads changed — nothing to lint. Changed files:'
+            cat /tmp/eslint-scope.txt
+          fi
+
       - name: Setup Node
+        if: steps.scope.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies (clean)
+        if: steps.scope.outputs.run == 'true'
         run: npm ci
 
       - name: Run ESLint
+        if: steps.scope.outputs.run == 'true'
         run: npm run lint

--- a/tests/eslint-workflow-scope-gate.test.py
+++ b/tests/eslint-workflow-scope-gate.test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""The eslint workflow's docs-only skip must never strand its required check.
+
+`eslint over first-party TS + JS` is a required status check on `main`. A
+workflow-level `paths:` filter would leave it permanently unreported, so the
+skip has to live in step `if:` guards while the job itself always runs. These
+checks execute the gate's real shell, extracted from the workflow, rather than
+a restatement of it.
+"""
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / ".github" / "workflows" / "eslint.yml"
+TEXT = WORKFLOW.read_text()
+
+failures = []
+checks_run = 0
+
+
+def check(name: str, condition: bool) -> None:
+    global checks_run
+    checks_run += 1
+    print(("  ok  " if condition else "  FAIL ") + name)
+    if not condition:
+        failures.append(name)
+
+
+def scope_script():
+    """The `run:` body of the gate step, dedented, with GH expressions bound."""
+    lines = TEXT.splitlines()
+    # Anchored on the gate step: grabbing another step's script would make
+    # every behavioural check below vacuous rather than red.
+    step = next(i for i, ln in enumerate(lines) if ln.strip() == "id: scope")
+    start = next(i for i in range(step, len(lines)) if lines[i].strip() == "run: |")
+    indent = len(lines[start]) - len(lines[start].lstrip()) + 2
+    body = []
+    for ln in lines[start + 1:]:
+        if ln.strip() and len(ln) - len(ln.lstrip()) < indent:
+            break
+        body.append(ln[indent:] if len(ln) >= indent else "")
+    return "\n".join(body)
+
+
+def run_gate(script, changed, event="pull_request"):
+    """Run the gate with `gh pr diff` stubbed; return run=true / run=false."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        gh = tmp / "gh"
+        if changed is None:
+            gh.write_text("#!/bin/sh\nexit 1\n")
+        else:
+            gh.write_text("#!/bin/sh\ncat <<'EOF'\n" + changed + "\nEOF\n")
+        gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+        out = tmp / "gh_output"
+        out.touch()
+        env = dict(os.environ)
+        env["PATH"] = f"{tmp}:{env['PATH']}"
+        env["GITHUB_OUTPUT"] = str(out)
+        env["PR"] = "1"
+        env["GH_TOKEN"] = "stub"
+        subprocess.run(
+            ["bash", "-c", script.replace("${{ github.event_name }}", event)],
+            env=env, capture_output=True, text=True, timeout=30,
+        )
+        return out.read_text().strip()
+
+
+check("workflow carries no `paths:` filter (required check must always report)",
+      not re.search(r"^\s*paths(-ignore)?:", TEXT, re.M))
+
+check("every npm step is gated on the scope output",
+      TEXT.count("if: steps.scope.outputs.run == 'true'") == 3)
+
+if shutil.which("bash"):
+    script = scope_script()
+    check("the extracted script is the gate itself",
+          "GITHUB_OUTPUT" in script and "gh pr diff" in script and "run=false" in script)
+
+    check("docs-only diff skips the lint",
+          run_gate(script, "docs/README.md\ndocs/catalog.json\nCLAUDE.md") == "run=false")
+    check("a .ts change lints",
+          run_gate(script, "docs/README.md\nsrc/voice-agent.ts") == "run=true")
+    check("a .mjs change lints",
+          run_gate(script, "scripts/build-bundle.mjs") == "run=true")
+    check("a lockfile change lints",
+          run_gate(script, "package-lock.json") == "run=true")
+    check("an edit to this workflow lints",
+          run_gate(script, ".github/workflows/eslint.yml") == "run=true")
+    # The two ways the probe can break must both fail toward doing the work,
+    # never toward a silent pass.
+    check("a failed `gh pr diff` lints rather than skipping",
+          run_gate(script, None) == "run=true")
+    check("an empty file list lints rather than skipping",
+          run_gate(script, "") == "run=true")
+    check("a push to main lints unconditionally",
+          run_gate(script, "docs/README.md", event="push") == "run=true")
+    # A path merely CONTAINING a lintable extension is not a lintable file.
+    check("a .md path with a .ts substring does not force a lint",
+          run_gate(script, "docs/rewrite.ts.notes.md") == "run=false")
+
+if failures:
+    print(f"Results: {len(failures)} failed, {checks_run - len(failures)} passed")
+    raise SystemExit(1)
+
+print(f"Results: {checks_run} passed")

--- a/tests/eslint-workflow-scope-gate.test.py
+++ b/tests/eslint-workflow-scope-gate.test.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python3
-"""The eslint workflow's docs-only skip must never strand its required check.
-
-`eslint over first-party TS + JS` is a required status check on `main`. A
-workflow-level `paths:` filter would leave it permanently unreported, so the
-skip has to live in step `if:` guards while the job itself always runs. These
-checks execute the gate's real shell, extracted from the workflow, rather than
-a restatement of it.
-"""
+"""`eslint over first-party TS + JS` is a REQUIRED check: a `paths:` filter would
+leave it unreported, so the skip lives in step guards and the job always runs."""
 
 import os
 import re
@@ -91,6 +85,12 @@ if shutil.which("bash"):
           run_gate(script, "scripts/build-bundle.mjs") == "run=true")
     check("a lockfile change lints",
           run_gate(script, "package-lock.json") == "run=true")
+    # Every dependency input `npm ci` consults, not just the lockfile: a shrinkwrap
+    # takes precedence over it, and .npmrc can change what install even fetches.
+    check("a shrinkwrap change lints",
+          run_gate(script, "npm-shrinkwrap.json") == "run=true")
+    check("an .npmrc change lints",
+          run_gate(script, ".npmrc") == "run=true")
     check("an edit to this workflow lints",
           run_gate(script, ".github/workflows/eslint.yml") == "run=true")
     # The two ways the probe can break must both fail toward doing the work,


### PR DESCRIPTION
@sonichi

## The problem, measured

A docs-shaped PR runs the whole suite. Measured on **PR #3860** (head `5bf83b7`), which
touches `docs/README.md`, `docs/catalog.json`, `docs/worker-pool-design.md` and one `.py`
test — no `src/` code. Real durations from that head's runs:

```
$ gh api "repos/sonichi/sutando/actions/runs?head_sha=5bf83b77...&per_page=50" \
    -q '.workflow_runs[] | "\(.name)\t\(.conclusion)\t\(.run_started_at)\t\(.updated_at)"'
CI                       success  03:15:32Z  03:29:02Z   (13m30s)
Coverage Gate            success  03:15:32Z  03:22:10Z   ( 6m38s)
eslint                   success  03:15:32Z  03:16:24Z   (   52s)
shellcheck               success  03:15:33Z  03:16:05Z   (   32s)
lint-agents-md-sync      success  03:15:33Z  03:15:44Z   (   11s)
lint-src-map             success  03:15:32Z  03:15:41Z   (    9s)
ruff / lint-* x7 / workspace-leak-check / cla-recheck  ~9-13s each
```

I re-measured the root-cause claim rather than taking it as given, and it is **partly
wrong**, which changes what is safe to do:

```
$ for f in $(git ls-tree --name-only origin/main .github/workflows/); do ... done
```
Three workflows carry `paths:` on `origin/main`, not one: `bundle-smoke.yml`,
`python39-compat.yml`, `publish-sparrow.yml`. **None of the three is a required status
check.** That is not a coincidence — it is the invariant this PR preserves.

`codeql.yml` also does not fire on PRs at all (`push: branches: [main]` + `schedule`), so
it contributes nothing to PR cost. `coverage-comment.yml` is `workflow_run`-triggered.

## The required-check problem, and the approach I chose

`main` is not protected by branch protection (`.../branches/main/protection` → 404) but by
ruleset **19110427**, which lists **15 required contexts**:

```
$ gh api repos/sonichi/sutando/rulesets/19110427 -q '.rules[] | select(.type=="required_status_checks")
    | .parameters.required_status_checks[].context'
diff coverage >= 95% (python)          refuse new hardcoded hotkey assertions
eslint over first-party TS + JS        refuse new inline CLAUDE_CONFIG_DIR fallback
license/cla                            refuse new inline ~/.sutando/ install-path literal
refuse AGENTS.md stale vs CLAUDE.md    refuse raw hostname-slug recipe in agent docs
refuse bridge tests that read host config   refuse workspace/ contents in commits
refuse docs/src-map.md stale vs src/   ruff over Python sources
refuse new direct workspace-path resolution   shellcheck over shell scripts
                                       tsc + tests (clean install)
```

Every heavy check named in the original brief is **required**. A workflow-level `paths:`
filter on any of them reports no status at all, so the PR sits on "Expected — waiting for
status to be reported" forever. So: **the job always runs and always reports; the skip
lives in step `if:` guards.** A skipped diff still produces a green required check, it just
produces it in ~10s instead of 44s. That is why this PR adds no `paths:` key anywhere.

## What I changed, and what I deliberately did not

**Changed: `eslint.yml` only.** ESLint's flat config lints `src/**/*.ts`, `skills/**/*.ts`,
`tests/**/*.ts` and `**/*.{js,mjs}`, with no type-aware preset (`eslint.config.mjs`:
"non-type-checked recommended set only"). A `.md` or `docs/*.json` change cannot alter its
output. This is the one job in the suite where the skip is *provable*.

**Left alone, with reasons:**

- **`ci.yml` — docs-sensitive by construction.** Its first job runs `python3
  skills/release/scripts/docs_audit.py`, which validates exactly `docs/README.md`,
  `docs/catalog.json` and repo-local Markdown links — the files #3860 touched. And the
  suites read docs: `grep -rlE "['\"](\.\./)*docs/|/docs/" tests/ | wc -l` → **23** test
  files read repo `docs/`, and **57** read a root Markdown file. Skipping tests on a docs
  diff would reduce coverage on work that IS relevant. Its 13m30s is dominated by
  `Run shell standalone tests` (11m03s), and `tests/review-checks.test.sh` /
  `tests/sutando-migrate-rules.test.sh` are among the docs readers.
- **`coverage-gate.yml` — already short-circuits, for free.** `scripts/coverage-gate.sh`
  exits 0 on `git diff --name-only "$BASE"...HEAD -- '*.py'` being empty. Its 6m38s on
  #3860 is because a `.py` test *did* change. On a pure docs diff the job is
  checkout (4s) + pip (9s) + early exit. Nothing to win; a filter here would also starve
  `coverage-comment.yml` of its artifact.
- **`lint-agents-md-sync.yml`** (refuses AGENTS.md stale vs CLAUDE.md) and
  **`lint-src-map.yml`** (refuses docs/src-map.md stale vs src/) — these exist *to* catch a
  docs edit. Skipping them on docs is the exact inversion of their purpose.
- **`lint-host-label.yml`** — "refuse raw hostname-slug recipe **in agent docs**". Same.
- **`lint-claude-home-path` / `lint-sutando-home-path` / `lint-workspace-resolution` /
  `lint-hermetic-bridge-tests` / `lint-hotkey-assertions` / `workspace-leak-check` /
  `ruff` / `shellcheck`** — 9-32s each, several also scan docs. Gating them costs more
  complexity and review surface than it saves runner seconds.
- **`codeql.yml`** — does not run on PRs. Nothing to filter.

## After: what the shipped gate decides

The gate's shell, extracted from the workflow and run against real file lists:

```
$ python3 - <<'PY'  # execs scope_script()/run_gate() from the new test
--- PR #3860 actual changed files --> run=false
--- a pure docs edit                --> run=false
--- this PR (touches eslint.yml)    --> run=true
--- a typical src/ change           --> run=true
--- gh pr diff FAILED               --> run=true
```

So on #3860 the eslint job would have reported success without `npm ci`: **44s → ~10s per
push**, over ~8 pushes. #3880's comment on this same file records the cold-cache install at
~4 min, so the saved figure is a floor, not a ceiling.

Note this PR touches `.github/workflows/eslint.yml`, so its own eslint check runs the full
path — the change is exercised, not just asserted.

## Test, and proof it fails when broken

`tests/eslint-workflow-scope-gate.test.py` **extracts the gate's real `run:` body from the
workflow** (anchored on `id: scope`) and executes it with `gh` stubbed, so it exercises the
shipped script, not a restatement. 12 checks pass on both `python3` (3.13) and
`/usr/bin/python3` (3.9.6).

Each assertion was falsified by mutating the workflow and re-running:

```
MUTATION 1: add a workflow-level paths: filter
  FAIL workflow carries no `paths:` filter (required check must always report)
MUTATION 2: ungate the npm ci step
  FAIL every npm step is gated on the scope output
MUTATION 3: remove the empty-list fail-open
  FAIL an empty file list lints rather than skipping
MUTATION 4: broaden the regex to match markdown
  FAIL docs-only diff skips the lint
  FAIL a .md path with a .ts substring does not force a lint
MUTATION 6: gh-diff failure no longer forces a lint
  FAIL a failed `gh pr diff` lints rather than skipping
  FAIL an empty file list lints rather than skipping
  FAIL a push to main lints unconditionally
MUTATION 7: push-to-main no longer bypasses the gate
  FAIL a push to main lints unconditionally
RESTORED: Results: 12 passed
```

## Worst-case disruption

The gate's failure modes all resolve toward **doing the lint**, never toward a silent pass:
a failed or empty `gh pr diff`, or any non-`pull_request` event, lints unconditionally.
The worst case is therefore "eslint runs when it did not strictly need to" — today's
behaviour. The one way to make it harmful is a `paths:` filter on this workflow, and the
new test refuses that. Pushes to `main` are never gated, so `main` stays fully linted.

## Local gates

```
$ bash scripts/review-checks.sh --diff /tmp/ci-paths.diff
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
$ ruff check tests/eslint-workflow-scope-gate.test.py
All checks passed!
$ python3 skills/release/scripts/docs_audit.py
docs-audit: PASS (44 indexed docs; 47 Markdown files checked)
```

## Not verified

- I did not exercise the cold-npm-cache path; the ~4 min figure is quoted from #3880's
  in-file comment, not re-measured here.
- The 44s→~10s figure is the gate's decision plus this job's non-npm step timings from
  #3860; the post-merge number will land on a real docs-only PR.

Single concern: no other workflow, script or test is touched.

Stand: Echo Act IV Pro
