### PR TITLE
feat(skills): wizard — the /wizard short tour (text + the desktop tour card)

### DIFF
--- a/skills/wizard/SKILL.md
+++ b/skills/wizard/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: wizard
+description: Give the owner a short tour of the important features — text plus, on the desktop, a local "tour" card whose buttons open the key pages. Triggered by the /wizard composer command.
+---
+
+# wizard
+
+**Usage**: `/wizard` — the owner types it in a room; the message arrives as the text `/wizard`.
+
+## What to do
+
+1. **Present the tour card first** (desktop only; the script is a no-op elsewhere):
+   ```bash
+   python3 skills/wizard/scripts/present-tour.py --room <room_id>
+   ```
+   It finds the app's local-card presenter beside the engine checkout and presents the shipped
+   `tour` card — six stops with buttons that open the page: who you are and who can reach you,
+   channels, runtime, the owner's notifications, all their agents, explore rooms. Without the
+   desktop presenter it prints `text-only` and exits 0; give the tour in text alone.
+2. **Then the text**, five or six sentences a newcomer needs in the first minute, in the owner's
+   language:
+   - You live on their Mac, do real work, and remember what you learn.
+   - Rooms are where they, other people and other agents meet; you are in the rooms they invite you to.
+   - @-mentioning you is how they reach you; the Attention panel in a room header collects what
+     needs them.
+   - Agent Settings holds your identity, channels and runtime; Room Settings › Agent-native sets
+     what you may read and how you respond in that room.
+   - Say the card is there: "tap any stop on the card to open it".
+3. **Stop there.** No feature list, no settings dump. If they ask about one stop, answer that one —
+   and present the matching card (see the local-cards guidance in the app's agent memory).
+
+Voice narration is a later addition to this skill; do not attempt it now.
+
+## Notes
+
+- The card directory and presenter belong to the desktop app (`engine/local-cards/`,
+  `engine/local-card.py` beside this checkout); this skill only calls them. A missing presenter is
+  the normal case on a non-desktop install, not an error.
+- The composer command is discoverability only: the client sends the bare text `/wizard`; nothing
+  is intercepted client-side.

--- a/skills/wizard/manifest.json
+++ b/skills/wizard/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "wizard",
+  "version": "0.1.0",
+  "owner": "github:sonichi/sutando",
+  "license": "MIT",
+  "stability": "experimental",
+  "description": "The /wizard short tour: five or six sentences on what matters most, plus the desktop app's tour card whose buttons open the key pages.",
+  "provenance": {
+    "source_repo": "https://github.com/sonichi/sutando"
+  }
+}

--- a/skills/wizard/scripts/present-tour.py
+++ b/skills/wizard/scripts/present-tour.py
@@ -10,9 +10,8 @@ from pathlib import Path
 
 
 def find_presenter(start: Path) -> Path | None:
-    # The desktop app ships local-card.py one level above the engine checkout
-    # (engine/local-card.py beside engine/sutando/); walk up so a symlinked or
-    # relocated checkout still finds it.
+    # The desktop app ships engine/local-card.py beside engine/sutando/; walking
+    # up finds it from a symlinked or relocated checkout as well.
     for parent in start.resolve().parents:
         candidate = parent / "local-card.py"
         if candidate.is_file():

--- a/skills/wizard/scripts/present-tour.py
+++ b/skills/wizard/scripts/present-tour.py
@@ -1,37 +1,37 @@
 #!/usr/bin/env python3
-"""Present the desktop app's `tour` local card, if the presenter is installed.
+# Presents the desktop app's `tour` local card; without a presenter beside any
+# ancestor of this checkout (a non-desktop install) it is text-only and exits 0.
+from __future__ import annotations
 
-The presenter (`local-card.py`) ships with the AG2 Space desktop app one level
-above the engine checkout; a non-desktop install has none, and that is the
-text-only case, not an error (exit 0, prints `text-only`).
-"""
-import os
+import argparse
 import subprocess
 import sys
 from pathlib import Path
 
-HERE = Path(__file__).resolve()
-REPO = HERE.parents[3]
 
-
-def find_presenter() -> Path | None:
-    override = os.environ.get("LOCAL_CARD_BIN")
-    candidates = [Path(override)] if override else [REPO.parent / "local-card.py"]
-    return next((p for p in candidates if p.is_file()), None)
+def find_presenter(start: Path) -> Path | None:
+    # The desktop app ships local-card.py one level above the engine checkout
+    # (engine/local-card.py beside engine/sutando/); walk up so a symlinked or
+    # relocated checkout still finds it.
+    for parent in start.resolve().parents:
+        candidate = parent / "local-card.py"
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def main(argv: list[str]) -> int:
-    presenter = find_presenter()
-    if presenter is None:
+    ap = argparse.ArgumentParser(description="present the wizard tour card if the desktop presenter exists")
+    ap.add_argument("--room", help="room the tour is about (room-bound actions resolve here)")
+    ap.add_argument("--presenter", help="explicit path to local-card.py (tests; production walks up from here)")
+    a = ap.parse_args(argv)
+    presenter = Path(a.presenter) if a.presenter else find_presenter(Path(__file__))
+    if presenter is None or not presenter.is_file():
         print("text-only: no local-card presenter beside this checkout")
         return 0
     args = [sys.executable, str(presenter), "present", "tour", "--set", "body=Tap any stop to open it."]
-    if "--room" in argv:
-        i = argv.index("--room")
-        if i + 1 >= len(argv):
-            print("--room needs a room id", file=sys.stderr)
-            return 2
-        args += ["--room", argv[i + 1]]
+    if a.room:
+        args += ["--room", a.room]
     proc = subprocess.run(args, capture_output=True, text=True)
     sys.stdout.write(proc.stdout)
     sys.stderr.write(proc.stderr)

--- a/skills/wizard/scripts/present-tour.py
+++ b/skills/wizard/scripts/present-tour.py
@@ -9,12 +9,13 @@ from pathlib import Path
 
 
 def find_presenter(script: Path) -> Path | None:
-    # Only the two supported locations: engine/local-card.py beside engine/sutando/
-    # (the desktop layout), or the checkout root; never an arbitrary ancestor's file.
+    # A directory is trusted as the desktop presenter's home only if it also holds
+    # the app-owned card registry; a bare same-named file beside a checkout is not.
     repo = script.resolve().parents[3]
-    for candidate in (repo.parent / "local-card.py", repo / "local-card.py"):
-        if candidate.is_file():
-            return candidate
+    for home in (repo.parent, repo):
+        presenter = home / "local-card.py"
+        if presenter.is_file() and (home / "local-cards" / "page-anchors.json").is_file():
+            return presenter
     return None
 
 

--- a/skills/wizard/scripts/present-tour.py
+++ b/skills/wizard/scripts/present-tour.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Present the desktop app's `tour` local card, if the presenter is installed.
+
+The presenter (`local-card.py`) ships with the AG2 Space desktop app one level
+above the engine checkout; a non-desktop install has none, and that is the
+text-only case, not an error (exit 0, prints `text-only`).
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve()
+REPO = HERE.parents[3]
+
+
+def find_presenter() -> Path | None:
+    override = os.environ.get("LOCAL_CARD_BIN")
+    candidates = [Path(override)] if override else [REPO.parent / "local-card.py"]
+    return next((p for p in candidates if p.is_file()), None)
+
+
+def main(argv: list[str]) -> int:
+    presenter = find_presenter()
+    if presenter is None:
+        print("text-only: no local-card presenter beside this checkout")
+        return 0
+    args = [sys.executable, str(presenter), "present", "tour", "--set", "body=Tap any stop to open it."]
+    if "--room" in argv:
+        i = argv.index("--room")
+        if i + 1 >= len(argv):
+            print("--room needs a room id", file=sys.stderr)
+            return 2
+        args += ["--room", argv[i + 1]]
+    proc = subprocess.run(args, capture_output=True, text=True)
+    sys.stdout.write(proc.stdout)
+    sys.stderr.write(proc.stderr)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/wizard/scripts/present-tour.py
+++ b/skills/wizard/scripts/present-tour.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-# Presents the desktop app's `tour` local card; without a presenter beside any
-# ancestor of this checkout (a non-desktop install) it is text-only and exits 0.
+# Presents the desktop `tour` card; with no presenter above this checkout it is text-only (exit 0).
 from __future__ import annotations
 
 import argparse

--- a/skills/wizard/scripts/present-tour.py
+++ b/skills/wizard/scripts/present-tour.py
@@ -8,11 +8,11 @@ import sys
 from pathlib import Path
 
 
-def find_presenter(start: Path) -> Path | None:
-    # The desktop app ships engine/local-card.py beside engine/sutando/; walking
-    # up finds it from a symlinked or relocated checkout as well.
-    for parent in start.resolve().parents:
-        candidate = parent / "local-card.py"
+def find_presenter(script: Path) -> Path | None:
+    # Only the two supported locations: engine/local-card.py beside engine/sutando/
+    # (the desktop layout), or the checkout root; never an arbitrary ancestor's file.
+    repo = script.resolve().parents[3]
+    for candidate in (repo.parent / "local-card.py", repo / "local-card.py"):
         if candidate.is_file():
             return candidate
     return None

--- a/tests/wizard-present-tour.test.py
+++ b/tests/wizard-present-tour.test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-"""present-tour.py: text-only without a presenter; delegates with the right args when one exists."""
+"""present-tour.py: text-only without a presenter; finds the desktop presenter by the shipped layout
+with no override; delegates with the right args. Run under the floor interpreter too (3.9)."""
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -12,34 +14,48 @@ REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "skills" / "wizard" / "scripts" / "present-tour.py"
 
 
+def run(script, *args):
+    return subprocess.run([sys.executable, str(script), *args], capture_output=True, text=True)
+
+
+def stub_presenter(path: Path, log: Path):
+    path.write_text(f"import json,sys; json.dump(sys.argv[1:], open({str(log)!r},'w')); print('lc_stub')\n")
+
+
 class PresentTourTests(unittest.TestCase):
     def test_no_presenter_is_text_only_and_exit_0(self):
-        env = {**os.environ, "LOCAL_CARD_BIN": "/nonexistent/local-card.py"}
-        r = subprocess.run([sys.executable, str(SCRIPT), "--room", "!r:x"], env=env, capture_output=True, text=True)
+        r = run(SCRIPT, "--room", "!r:x", "--presenter", "/nonexistent/local-card.py")
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertIn("text-only", r.stdout)
 
-    def test_presenter_gets_present_tour_with_room(self):
+    def test_shipped_layout_is_found_without_any_override(self):
+        # engine/local-card.py beside engine/sutando/skills/wizard/scripts/present-tour.py
         with tempfile.TemporaryDirectory() as d:
-            stub = Path(d) / "local-card.py"
+            engine = Path(d) / "engine"
+            script = engine / "sutando" / "skills" / "wizard" / "scripts" / "present-tour.py"
+            script.parent.mkdir(parents=True)
+            shutil.copyfile(SCRIPT, script)
             log = Path(d) / "argv.json"
-            stub.write_text(f"import json,sys; json.dump(sys.argv[1:], open({str(log)!r},'w')); print('lc_stub')\n")
-            env = {**os.environ, "LOCAL_CARD_BIN": str(stub)}
-            r = subprocess.run([sys.executable, str(SCRIPT), "--room", "!r:x"], env=env, capture_output=True, text=True)
+            stub_presenter(engine / "local-card.py", log)
+            r = run(script, "--room", "!r:x")
             self.assertEqual(r.returncode, 0, r.stderr)
             self.assertIn("lc_stub", r.stdout)
             argv = json.loads(log.read_text())
             self.assertEqual(argv[:2], ["present", "tour"])
-            self.assertIn("--room", argv)
             self.assertEqual(argv[argv.index("--room") + 1], "!r:x")
 
-    def test_room_flag_without_value_is_refused(self):
+    def test_explicit_presenter_is_used(self):
         with tempfile.TemporaryDirectory() as d:
             stub = Path(d) / "local-card.py"
-            stub.write_text("print('never')\n")
-            env = {**os.environ, "LOCAL_CARD_BIN": str(stub)}
-            r = subprocess.run([sys.executable, str(SCRIPT), "--room"], env=env, capture_output=True, text=True)
-            self.assertEqual(r.returncode, 2)
+            log = Path(d) / "argv.json"
+            stub_presenter(stub, log)
+            r = run(SCRIPT, "--presenter", str(stub))
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertNotIn("--room", json.loads(log.read_text()))
+
+    def test_room_flag_without_value_is_refused(self):
+        r = run(SCRIPT, "--room")
+        self.assertEqual(r.returncode, 2)
 
 
 if __name__ == "__main__":

--- a/tests/wizard-present-tour.test.py
+++ b/tests/wizard-present-tour.test.py
@@ -37,12 +37,27 @@ class PresentTourTests(unittest.TestCase):
             shutil.copyfile(SCRIPT, script)
             log = Path(d) / "argv.json"
             stub_presenter(engine / "local-card.py", log)
+            (engine / "local-cards").mkdir()
+            (engine / "local-cards" / "page-anchors.json").write_text("{}")  # the app-owned registry marks the home
             r = run(script, "--room", "!r:x")
             self.assertEqual(r.returncode, 0, r.stderr)
             self.assertIn("lc_stub", r.stdout)
             argv = json.loads(log.read_text())
             self.assertEqual(argv[:2], ["present", "tour"])
             self.assertEqual(argv[argv.index("--room") + 1], "!r:x")
+
+    def test_immediate_parent_without_the_registry_is_never_executed(self):
+        # <dir>/local-card.py beside <dir>/checkout is NOT the desktop presenter without the registry
+        with tempfile.TemporaryDirectory() as d:
+            script = Path(d) / "checkout" / "skills" / "wizard" / "scripts" / "present-tour.py"
+            script.parent.mkdir(parents=True)
+            shutil.copyfile(SCRIPT, script)
+            log = Path(d) / "argv.json"
+            stub_presenter(Path(d) / "local-card.py", log)
+            r = run(script)
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("text-only", r.stdout)
+            self.assertFalse(log.exists(), "the adjacent unrelated script was executed")
 
     def test_unrelated_higher_ancestor_is_never_executed(self):
         # a local-card.py two levels above the engine dir must not be picked up

--- a/tests/wizard-present-tour.test.py
+++ b/tests/wizard-present-tour.test.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """present-tour.py: text-only without a presenter; delegates with the right args when one exists."""
-import json, os, subprocess, sys, tempfile, unittest
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -30,7 +35,8 @@ class PresentTourTests(unittest.TestCase):
 
     def test_room_flag_without_value_is_refused(self):
         with tempfile.TemporaryDirectory() as d:
-            stub = Path(d) / "local-card.py"; stub.write_text("print('never')\n")
+            stub = Path(d) / "local-card.py"
+            stub.write_text("print('never')\n")
             env = {**os.environ, "LOCAL_CARD_BIN": str(stub)}
             r = subprocess.run([sys.executable, str(SCRIPT), "--room"], env=env, capture_output=True, text=True)
             self.assertEqual(r.returncode, 2)

--- a/tests/wizard-present-tour.test.py
+++ b/tests/wizard-present-tour.test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""present-tour.py: text-only without a presenter; delegates with the right args when one exists."""
+import json, os, subprocess, sys, tempfile, unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "skills" / "wizard" / "scripts" / "present-tour.py"
+
+
+class PresentTourTests(unittest.TestCase):
+    def test_no_presenter_is_text_only_and_exit_0(self):
+        env = {**os.environ, "LOCAL_CARD_BIN": "/nonexistent/local-card.py"}
+        r = subprocess.run([sys.executable, str(SCRIPT), "--room", "!r:x"], env=env, capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("text-only", r.stdout)
+
+    def test_presenter_gets_present_tour_with_room(self):
+        with tempfile.TemporaryDirectory() as d:
+            stub = Path(d) / "local-card.py"
+            log = Path(d) / "argv.json"
+            stub.write_text(f"import json,sys; json.dump(sys.argv[1:], open({str(log)!r},'w')); print('lc_stub')\n")
+            env = {**os.environ, "LOCAL_CARD_BIN": str(stub)}
+            r = subprocess.run([sys.executable, str(SCRIPT), "--room", "!r:x"], env=env, capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("lc_stub", r.stdout)
+            argv = json.loads(log.read_text())
+            self.assertEqual(argv[:2], ["present", "tour"])
+            self.assertIn("--room", argv)
+            self.assertEqual(argv[argv.index("--room") + 1], "!r:x")
+
+    def test_room_flag_without_value_is_refused(self):
+        with tempfile.TemporaryDirectory() as d:
+            stub = Path(d) / "local-card.py"; stub.write_text("print('never')\n")
+            env = {**os.environ, "LOCAL_CARD_BIN": str(stub)}
+            r = subprocess.run([sys.executable, str(SCRIPT), "--room"], env=env, capture_output=True, text=True)
+            self.assertEqual(r.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/wizard-present-tour.test.py
+++ b/tests/wizard-present-tour.test.py
@@ -44,6 +44,20 @@ class PresentTourTests(unittest.TestCase):
             self.assertEqual(argv[:2], ["present", "tour"])
             self.assertEqual(argv[argv.index("--room") + 1], "!r:x")
 
+    def test_unrelated_higher_ancestor_is_never_executed(self):
+        # a local-card.py two levels above the engine dir must not be picked up
+        with tempfile.TemporaryDirectory() as d:
+            engine = Path(d) / "somewhere" / "engine"
+            script = engine / "sutando" / "skills" / "wizard" / "scripts" / "present-tour.py"
+            script.parent.mkdir(parents=True)
+            shutil.copyfile(SCRIPT, script)
+            log = Path(d) / "argv.json"
+            stub_presenter(Path(d) / "local-card.py", log)  # unrelated, above the boundary
+            r = run(script, "--room", "!r:x")
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("text-only", r.stdout)
+            self.assertFalse(log.exists(), "the unrelated script was executed")
+
     def test_explicit_presenter_is_used(self):
         with tempfile.TemporaryDirectory() as d:
             stub = Path(d) / "local-card.py"


### PR DESCRIPTION
## What
A `wizard` skill (owner ask 2026-09-05): when the owner types `/wizard` in a room, the agent gives a short tour of the important features — five or six sentences — and, on the AG2 Space desktop, presents the app's shipped `tour` local card whose buttons open the key pages. Voice narration is a later addition to the same skill.

## Why here
The composer command (ag2-space/cinny-webclient#882) only sends the text `/wizard`; the card and its presenter ship with the desktop app (ag2-space/ag2space-cinny-desktop#515). The skill is the piece that belongs to the engine: what to say, in what order, and to call the presenter when it exists. It is optional and self-contained per the skills contract; without the desktop presenter it is text-only.

## Files
- `skills/wizard/SKILL.md`, `manifest.json` (config-only) — the tour outline and the rule to stop after it.
- `skills/wizard/scripts/present-tour.py` — finds `local-card.py` beside the checkout (the only override is `--presenter`), runs `present tour [--room <id>]`; prints `text-only` and exits 0 when absent.
- `tests/wizard-present-tour.test.py` — subprocess-level.

## Evidence
```
$ python3 tests/wizard-present-tour.test.py
Ran 6 tests ... OK      # no presenter → text-only/exit 0; stub presenter → ["present","tour",...,"--room","!r:x"]; bare --room → exit 2
$ python3 scripts/lint-skill.py skills/wizard
lint-skill: 1 manifest(s), 0 error(s), 0 warning(s)
$ bash scripts/review-checks.sh --diff <staged diff>   → no hardcoded host paths
```
No live path is touched (no bridge, network or startup change).

— sutando-qingyun-air
