### PR TITLE
feat(health-check): cli-wedge — an advisory CLI progress detector over the core pane

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -37,6 +37,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`check-pending-questions.py`** — Check pending questions and notify if unanswered.
 - **`check-pending-tasks.sh`** — Stop hook: blocks Claude from finishing when unprocessed tasks exist.
 - **`claude_config_dir.sh`** — Shared CLAUDE_CONFIG_DIR resolution for start-cli.sh and startup.sh.
+- **`cli_wedge.py`** — CLI progress detector for the core's tmux pane — advisory only.
 - **`context-drop.sh`** — Sutando context drop — triggered by macOS hotkey via Automator Quick Action.
 - **`context_resume.py`** — Extract recent conversation turns from a Claude Code transcript (.jsonl).
 - **`conversation-store-migrations.ts`** — Startup-only SQLite migration policy for the conversation store.

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -83,6 +83,9 @@ PROVISIONAL_THRESHOLDS = {
     "status_ttl_s": 900,
 }
 PROVIDER_LIMIT_PATTERNS = ("quota-limit",)
+# Exact session, window 0 — the launcher's core window. A bare `=name` is a pane
+# target and stops resolving once the session has a second window (the app adds `gateway`).
+DEFAULT_TARGET = "=sutando-core:0"
 
 def normalize(frame: str) -> str:
     """Strip volatile fields so two frames differing only in clocks, counters,
@@ -246,12 +249,13 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
 
 # ---- I/O edge -------------------------------------------------------------
 
-def capture_pane(socket_path: str, target: str, tmux_bin: str = "tmux",
-                 runner: Callable = subprocess.run) -> Optional[str]:
-    """One pane frame, or None when tmux cannot be read (absent = no reading)."""
+def capture_pane(socket_path: str, target: str = DEFAULT_TARGET, tmux_bin: str = "tmux",
+                 runner: Callable = subprocess.run, env: Optional[dict] = None) -> Optional[str]:
+    """One pane frame, or None when tmux cannot be read (absent = no reading).
+    The one capture implementation: health-check and the CLI both call this."""
     try:
         proc = runner([tmux_bin, "-S", socket_path, "capture-pane", "-p", "-t", target],
-                      capture_output=True, text=True, timeout=10)
+                      capture_output=True, text=True, timeout=10, env=env)
     except Exception:  # noqa: BLE001 — a failed probe is an absent reading, never a verdict
         return None
     if getattr(proc, "returncode", 1) != 0:
@@ -262,13 +266,13 @@ def capture_pane(socket_path: str, target: str, tmux_bin: str = "tmux",
 _PANE_ID = re.compile(r"^\d+:\d+$")
 
 
-def pane_identity(socket_path: str, target: str, tmux_bin: str = "tmux",
-                  runner: Callable = subprocess.run) -> Optional[str]:
+def pane_identity(socket_path: str, target: str = DEFAULT_TARGET, tmux_bin: str = "tmux",
+                  runner: Callable = subprocess.run, env: Optional[dict] = None) -> Optional[str]:
     """`pane_pid:session_created` for the target, or None when unknown. A new
     core process is a new observation run; None never resets anything."""
     try:
         proc = runner([tmux_bin, "-S", socket_path, "display-message", "-p", "-t", target,
-                       "#{pane_pid}:#{session_created}"], capture_output=True, text=True, timeout=10)
+                       "#{pane_pid}:#{session_created}"], capture_output=True, text=True, timeout=10, env=env)
     except Exception:  # noqa: BLE001 — identity unknown is not a reading
         return None
     out = (getattr(proc, "stdout", "") or "").strip()
@@ -417,6 +421,8 @@ def classify_window(entries: list, work: tuple, now: float, thresholds: Optional
     if len(run) < 2 and singletons >= 3:
         recent = sorted(b[0]["ts"] - a[0]["ts"] for a, b in zip(runs[-singletons:], runs[-singletons + 1:]))
         meta["recent_gap_s"] = round(recent[len(recent) // 2], 1)
+    # Singleton runs split by pane identity (rapid core restarts) are not a cadence.
+    if len(run) < 2 and singletons >= 3 and meta["recent_gap_s"] >= th["continuity_gap_s"]:
         v = classify_ids([], False, [], work[0], 0.0, work[1], th)
         return {**v, **meta, "kind": "cadence-too-sparse",
                 "reason": f"the last {singletons} samples arrived ~{meta['recent_gap_s']:.0f}s apart, past the {th['continuity_gap_s']}s continuity limit — a static pane cannot be observed at this rate"}
@@ -493,7 +499,7 @@ def main(argv: Optional[list] = None) -> int:
     for name in ("record", "probe"):
         p = sub.add_parser(name)
         p.add_argument("--socket", required=True)
-        p.add_argument("--target", default="sutando-core")
+        p.add_argument("--target", default=DEFAULT_TARGET)
         p.add_argument("--tmux", default="tmux")
         p.add_argument("--workspace", default=None, help="defaults to the configured workspace")
         if name == "record":

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -173,7 +173,7 @@ def classify(frames: list, work_outstanding: bool, duration_s: float,
              raw_static: Optional[bool] = None) -> dict:
     """Advisory verdict over a window of frames. kind ∈ idle | working |
     clock-only | static-with-work | retry-loop | provider-limit | low-novelty |
-    unknown; the four before unknown are warnings. `raw_static` is case 1's
+    unknown (or, from the window, cadence-too-sparse); the four before unknown are warnings. `raw_static` is case 1's
     input (frame-for-frame equality); when None it is computed from `frames`."""
     if raw_static is None:
         raw_static = len(frames) >= 2 and len({raw_state_id(f) for f in frames}) == 1
@@ -399,11 +399,20 @@ def classify_window(entries: list, work: tuple, now: float, thresholds: Optional
         return classify_ids([], False, [], work[0], 0.0, work[1], th)
     runs = observation_runs(entries, th["continuity_gap_s"])
     run = runs[-1]
+    all_gaps = sorted(b["ts"] - a["ts"] for a, b in zip(entries, entries[1:]))
     meta = {"observation_runs": len(runs), "run_started": run[0]["ts"], "run_samples": len(run),
             "window_samples": len(entries), "last_sample_age_s": round(max(0.0, now - run[-1]["ts"]), 1)}
+    if all_gaps:
+        meta["window_median_gap_s"] = round(all_gaps[len(all_gaps) // 2], 1)
     if now - run[-1]["ts"] > th["continuity_gap_s"]:
         v = classify_ids([], False, [], work[0], 0.0, work[1], th)
         return {**v, **meta, "reason": f"last sample {now - run[-1]['ts']:.0f}s ago — no current observation"}
+    # The caller's cadence decides whether a run ever reaches two samples. Sampled
+    # slower than the continuity limit, case 1 is unreachable: say so, do not say "nothing".
+    if len(run) < 2 and len(entries) >= 3 and meta.get("window_median_gap_s", 0) >= th["continuity_gap_s"]:
+        v = classify_ids([], False, [], work[0], 0.0, work[1], th)
+        return {**v, **meta, "kind": "cadence-too-sparse",
+                "reason": f"samples arrive every ~{meta['window_median_gap_s']:.0f}s, past the {th['continuity_gap_s']}s continuity limit — a static pane cannot be observed at this rate"}
     gaps = [b["ts"] - a["ts"] for a, b in zip(run, run[1:])]
     ids = [e["state"] for e in run]
     raws = [e.get("raw_state") for e in run]

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -308,9 +308,16 @@ def _pid_ancestors(pid: Optional[int] = None, runner: Callable = subprocess.run,
     return chain
 
 
+def _same_tmux_server(socket_path: str, tmux_env: str) -> bool:
+    """$TMUX is `socket_path,server_pid,session_index`; pane ids only mean anything on that server."""
+    sock = (tmux_env or "").split(",", 1)[0]
+    return bool(sock) and os.path.realpath(sock) == os.path.realpath(socket_path)
+
+
 def sampled_from_inside(socket_path: str, target: str, tmux_bin: str = "tmux",
                         runner: Callable = subprocess.run, env: Optional[dict] = None,
-                        tmux_pane: Optional[str] = None, ancestors: Optional[list] = None) -> Optional[str]:
+                        tmux_pane: Optional[str] = None, tmux_env: Optional[str] = None,
+                        ancestors: Optional[list] = None) -> Optional[str]:
     """Why the caller must NOT sample `target` (it runs inside that pane), else None.
     Own output always moves, so a self-sample can never accumulate the static case."""
     try:
@@ -324,8 +331,9 @@ def sampled_from_inside(socket_path: str, target: str, tmux_bin: str = "tmux",
         return None
     pane_id, pane_pid = m.group(1), int(m.group(2))
     tmux_pane = os.environ.get("TMUX_PANE") if tmux_pane is None else tmux_pane
-    if tmux_pane and tmux_pane == pane_id:
-        return f"TMUX_PANE {pane_id} is the target pane"
+    tmux_env = os.environ.get("TMUX", "") if tmux_env is None else tmux_env
+    if tmux_pane and tmux_pane == pane_id and _same_tmux_server(socket_path, tmux_env):
+        return f"TMUX_PANE {pane_id} is the target pane on this server"
     chain = _pid_ancestors() if ancestors is None else list(ancestors)
     if pane_pid in chain:
         return f"caller pid chain reaches the pane shell (pid {pane_pid})"

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -289,6 +289,47 @@ def capture_pane(socket_path: str, target: str, tmux_bin: str = "tmux",
 
 
 _PANE_ID = re.compile(r"^\d+:\d+$")
+_PANE_REF = re.compile(r"^(%\d+):(\d+)$")
+
+
+def _pid_ancestors(pid: Optional[int] = None, runner: Callable = subprocess.run, limit: int = 64) -> list:
+    """This process's pid and its parents, upward, stopping at pid 1 (never included)."""
+    pid = os.getpid() if pid is None else pid
+    chain, seen = [], set()
+    while pid and pid > 1 and pid not in seen and len(chain) < limit:
+        seen.add(pid)
+        chain.append(pid)
+        try:
+            proc = runner(["ps", "-o", "ppid=", "-p", str(pid)], capture_output=True, text=True, timeout=5)
+            out = (getattr(proc, "stdout", "") or "").strip()
+            pid = int(out) if out.isdigit() else 0
+        except Exception:  # noqa: BLE001 — an unreadable chain ends the walk, it does not invent one
+            break
+    return chain
+
+
+def sampled_from_inside(socket_path: str, target: str, tmux_bin: str = "tmux",
+                        runner: Callable = subprocess.run, env: Optional[dict] = None,
+                        tmux_pane: Optional[str] = None, ancestors: Optional[list] = None) -> Optional[str]:
+    """Why the caller must NOT sample `target` (it runs inside that pane), else None.
+    Own output always moves, so a self-sample can never accumulate the static case."""
+    try:
+        proc = runner([tmux_bin, "-S", socket_path, "display-message", "-p", "-t", target, "#{pane_id}:#{pane_pid}"],
+                      capture_output=True, text=True, timeout=10, env=env)
+    except Exception:  # noqa: BLE001 — unknown provenance is not a reason to skip
+        return None
+    out = (getattr(proc, "stdout", "") or "").strip()
+    m = _PANE_REF.match(out) if getattr(proc, "returncode", 1) == 0 else None
+    if not m:
+        return None
+    pane_id, pane_pid = m.group(1), int(m.group(2))
+    tmux_pane = os.environ.get("TMUX_PANE") if tmux_pane is None else tmux_pane
+    if tmux_pane and tmux_pane == pane_id:
+        return f"TMUX_PANE {pane_id} is the target pane"
+    chain = _pid_ancestors() if ancestors is None else list(ancestors)
+    if pane_pid in chain:
+        return f"caller pid chain reaches the pane shell (pid {pane_pid})"
+    return None
 
 
 def pane_identity(socket_path: str, target: str, tmux_bin: str = "tmux",

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -407,12 +407,20 @@ def classify_window(entries: list, work: tuple, now: float, thresholds: Optional
     if now - run[-1]["ts"] > th["continuity_gap_s"]:
         v = classify_ids([], False, [], work[0], 0.0, work[1], th)
         return {**v, **meta, "reason": f"last sample {now - run[-1]['ts']:.0f}s ago — no current observation"}
-    # The caller's cadence decides whether a run ever reaches two samples. Sampled
-    # slower than the continuity limit, case 1 is unreachable: say so, do not say "nothing".
-    if len(run) < 2 and len(entries) >= 3 and meta.get("window_median_gap_s", 0) >= th["continuity_gap_s"]:
+    # The caller's cadence decides whether a run ever reaches two samples. Judge the
+    # RECENT cadence — the gaps behind the trailing singleton runs — not the whole
+    # window, or a 30-min→hourly change stays "unknown" until the old gaps age out.
+    singletons = 0
+    for r in reversed(runs):
+        if len(r) != 1:
+            break
+        singletons += 1
+    if len(run) < 2 and singletons >= 3:
+        recent = sorted(b[0]["ts"] - a[0]["ts"] for a, b in zip(runs[-singletons:], runs[-singletons + 1:]))
+        meta["recent_gap_s"] = round(recent[len(recent) // 2], 1)
         v = classify_ids([], False, [], work[0], 0.0, work[1], th)
         return {**v, **meta, "kind": "cadence-too-sparse",
-                "reason": f"samples arrive every ~{meta['window_median_gap_s']:.0f}s, past the {th['continuity_gap_s']}s continuity limit — a static pane cannot be observed at this rate"}
+                "reason": f"the last {singletons} samples arrived ~{meta['recent_gap_s']:.0f}s apart, past the {th['continuity_gap_s']}s continuity limit — a static pane cannot be observed at this rate"}
     gaps = [b["ts"] - a["ts"] for a, b in zip(run, run[1:])]
     ids = [e["state"] for e in run]
     raws = [e.get("raw_state") for e in run]

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -49,9 +49,8 @@ RETRY_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
         ("reconnecting", r"\breconnect(ing)?\b"),
         ("connection-error", r"\bconnection (error|reset|refused)\b"),
         ("timeout", r"\btimed? ?out\b"),
-        # A CLI told to stop by its provider: every turn ends the same way while the
-        # clock keeps moving, so only the text tells this from real work.
-        # A limit HIT, not a limit mentioned: Codex's idle banner says "usage limit resets available".
+        # A CLI told to stop by its provider: every turn ends the same way while the clock
+        # moves; only text tells this from work — and it must be a limit HIT, not one mentioned.
         ("quota-limit", r"\b(hit|reached|exceeded)\b.{0,24}\b(session|usage|weekly|daily|plan) limit\b|\b(session|usage|weekly|daily|plan) limit (reached|exceeded|hit)\b|\bhit your\b.{0,24}\blimit\b|\busage-credits\b"),
     )
 )

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -48,6 +48,9 @@ RETRY_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
         ("reconnecting", r"\breconnect(ing)?\b"),
         ("connection-error", r"\bconnection (error|reset|refused)\b"),
         ("timeout", r"\btimed? ?out\b"),
+        # A CLI told to stop by its provider: every turn ends the same way while the
+        # clock keeps moving, so only the text tells this from real work.
+        ("quota-limit", r"\b(session|usage|weekly|daily|plan) limit\b|\bhit your\b.{0,24}\blimit\b|\busage-credits\b"),
     )
 )
 

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -6,7 +6,8 @@ static while work is outstanding — pure static, no normalization, per the
 spec; (2) the pane moves but revisits the same states (a retry loop), measured
 as novelty over NORMALIZED frames — clocks, durations, counters, spinners and
 token counts would fake novelty. A pane whose only motion is a clock is
-neither verdict: it is reported as `clock_only` so traces can settle it.
+ALIVE (Chi, from running these panes daily): reported as `clock-only`, never a
+warning, and kept in every trace so the observation can be re-checked.
 
 This reads the CLI, not the process. A green result here is not evidence the
 core is healthy; it complements `.alive` and the runtime probes, never replaces
@@ -161,9 +162,9 @@ def classify(frames: list, work_outstanding: bool, duration_s: float,
                     "reason": f"pane unchanged for {duration_s:.0f}s while work is outstanding ({work_detail or 'unspecified'})"}
         return {**base, "kind": "idle", "confidence": "high", "warn": False,
                 "reason": "pane unchanged and nothing outstanding"}
-    if clock_only and not work_outstanding:
-        return {**base, "kind": "clock-only", "confidence": "none", "warn": False,
-                "reason": "only volatile fields (clock/counters) change and nothing is outstanding — recorded for the harness, not judged"}
+    if clock_only:
+        return {**base, "kind": "clock-only", "confidence": "medium", "warn": False,
+                "reason": "only volatile fields (clock/counters) change — a live CLI, not a wedge (operator observation); recorded for the harness"}
     if work_outstanding and nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"]:
         return {**base, "kind": "low-novelty", "confidence": "low", "warn": True,
                 "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples with work outstanding, no retry text — repetitive, cause unknown"}

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -51,7 +51,8 @@ RETRY_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
         ("timeout", r"\btimed? ?out\b"),
         # A CLI told to stop by its provider: every turn ends the same way while the
         # clock keeps moving, so only the text tells this from real work.
-        ("quota-limit", r"\b(session|usage|weekly|daily|plan) limit\b|\bhit your\b.{0,24}\blimit\b|\busage-credits\b"),
+        # A limit HIT, not a limit mentioned: Codex's idle banner says "usage limit resets available".
+        ("quota-limit", r"\b(hit|reached|exceeded)\b.{0,24}\b(session|usage|weekly|daily|plan) limit\b|\b(session|usage|weekly|daily|plan) limit (reached|exceeded|hit)\b|\bhit your\b.{0,24}\blimit\b|\busage-credits\b"),
     )
 )
 
@@ -378,8 +379,12 @@ def work_outstanding(workspace: Path, now: Optional[float] = None, ttl_s: Option
     return (bool(reasons), "; ".join(reasons))
 
 
-def window_path(workspace: Path) -> Path:
-    return workspace / "state" / "cli-wedge" / "window.jsonl"
+def window_path(workspace: Path, slot: Optional[str] = None) -> Path:
+    """One rolling window per watched target: the core's own is `window.jsonl`; an explicit
+    target gets its own file, so probing a worker pane never resets the core's run."""
+    if not slot:
+        return workspace / "state" / "cli-wedge" / "window.jsonl"
+    return workspace / "state" / "cli-wedge" / f"window-{hashlib.sha256(slot.encode()).hexdigest()[:12]}.jsonl"
 
 
 def _private_dir(path: Path) -> None:
@@ -420,14 +425,14 @@ def load_window(path: Path) -> list:
     return entries
 
 
-def append_window(workspace: Path, frame: str, now: float, keep: int = 20, pane: Optional[str] = None) -> list:
+def append_window(workspace: Path, frame: str, now: float, keep: int = 20, pane: Optional[str] = None, slot: Optional[str] = None) -> list:
     """Persist one sample into the rolling window so the statistic spans
     health-check passes; returns the window (oldest first). `pane` is the pane's
     identity (pid:session-created) so a restarted core starts a new run.
     The whole load → append → truncate → replace runs under one lock: the app's
     health-check and the launchd fallback are independent writers, and an
     atomic replace alone lets the later loader overwrite the earlier append."""
-    path = window_path(workspace)
+    path = window_path(workspace, slot)
     _private_dir(path.parent)
     lock = path.with_name(path.name + ".lock")
     fd = os.open(lock, os.O_WRONLY | os.O_CREAT, 0o600)
@@ -611,8 +616,11 @@ def main(argv: Optional[list] = None) -> int:
         return 0
     ws = Path(a.workspace)
     now = time.time()
-    entries = append_window(ws, frame, now, pane=pane_identity(a.socket, target, a.tmux))
-    print(json.dumps(classify_window(entries, work_outstanding(ws, now), now), indent=1))
+    # An explicit target is not this core: its window is its own, and this core's queue says
+    # nothing about its work.
+    entries = append_window(ws, frame, now, pane=pane_identity(a.socket, target, a.tmux), slot=a.target)
+    work = (False, "no work signal for an explicit --target") if a.target else work_outstanding(ws, now)
+    print(json.dumps(classify_window(entries, work, now), indent=1))
     return 0
 
 

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -54,7 +54,8 @@ RETRY_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
     )
 )
 
-# Order matters: composite tokens (timestamps, durations) before bare digits.
+# Context-specific only (owner review: no blanket digit stripping — "shard 17" vs
+# "shard 18" is progress). Composite tokens (timestamps, durations) come first.
 _VOLATILE: tuple[tuple[re.Pattern, str], ...] = (
     (re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?Z?"), "<ts>"),
     (re.compile(r"\b\d{1,2}:\d{2}(?::\d{2})?\s*(?:[AaPp][Mm])?\b"), "<clock>"),
@@ -62,16 +63,25 @@ _VOLATILE: tuple[tuple[re.Pattern, str], ...] = (
     (re.compile(r"\b\d+(?:\.\d+)?[kKmM]?\s*tokens?\b"), "<tokens>"),
     (re.compile(r"\b\d+\s*/\s*\d+\b"), "<count>"),
     (re.compile(r"\b\d+(?:\.\d+)?%"), "<pct>"),
+    (re.compile(r"\b(attempt|retry|retries|try|line|col|iteration|round|turn)\s+#?\d+\b", re.IGNORECASE), r"\1 #"),
     (re.compile(r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷◐◓◑◒◴◷◶◵]"), "<spin>"),
     (re.compile(r"(?:\.\s?){2,}|…+"), "<dots>"),
     (re.compile(r"[─━═]{2,}"), "<rule>"),
-    (re.compile(r"\d+"), "#"),
 )
 
-# Provisional: min samples before case 2 speaks; novel/samples at or below
-# which a window counts as repetitive; static seconds for high confidence.
-PROVISIONAL_THRESHOLDS = {"min_samples": 10, "low_novelty_rate": 0.25, "static_high_conf_s": 300}
-
+# Provisional (V1 is instrumentation; real traces tune these) and reported in every
+# verdict. status_ttl_s mirrors graceful-restart.sh busy() (GR_STATUS_TTL_S).
+PROVISIONAL_THRESHOLDS = {
+    "min_samples": 10,
+    "low_novelty_rate": 0.25,
+    "static_high_conf_s": 300,
+    "static_high_conf_samples": 3,
+    "pattern_min_consecutive": 2,
+    "pattern_min_rate": 0.5,
+    "continuity_gap_s": 2700,
+    "status_ttl_s": 900,
+}
+PROVIDER_LIMIT_PATTERNS = ("quota-limit",)
 
 def normalize(frame: str) -> str:
     """Strip volatile fields so two frames differing only in clocks, counters,
@@ -137,26 +147,55 @@ def novelty_of_ids(state_ids: list) -> Novelty:
     return Novelty(n, novel, (novel / n) if n else 0.0, n >= 2 and novel == 1, list(state_ids))
 
 
+def pattern_stats(pattern_samples: list, th: dict) -> dict:
+    """Retry text per SAMPLE, not a union over the window: a `timeout` in one old
+    frame must not colour ten idle frames after it. Recurrent = the trailing
+    samples all carry text, or enough of the run does; current = the newest does."""
+    n = len(pattern_samples)
+    current = sorted(set(pattern_samples[-1])) if pattern_samples else []
+    with_pat = sum(1 for ps in pattern_samples if ps)
+    consecutive = 0
+    for ps in reversed(pattern_samples):
+        if not ps:
+            break
+        consecutive += 1
+    rate = (with_pat / n) if n else 0.0
+    recurrent = bool(current) and (consecutive >= th["pattern_min_consecutive"]
+                                   or (n >= th["min_samples"] and rate >= th["pattern_min_rate"]))
+    return {"current_patterns": current, "pattern_sample_count": with_pat,
+            "pattern_rate": round(rate, 3), "consecutive_pattern_samples": consecutive,
+            "retry_current": recurrent}
+
+
 def classify(frames: list, work_outstanding: bool, duration_s: float,
              work_detail: str = "", thresholds: Optional[dict] = None,
              raw_static: Optional[bool] = None) -> dict:
     """Advisory verdict over a window of frames. kind ∈ idle | working |
-    clock-only | static-with-work | retry-loop | low-novelty | unknown; the
-    last three before unknown are warnings. `raw_static` is case 1's input
-    (frame-for-frame equality); when None it is computed from `frames`."""
+    clock-only | static-with-work | retry-loop | provider-limit | low-novelty |
+    unknown; the four before unknown are warnings. `raw_static` is case 1's
+    input (frame-for-frame equality); when None it is computed from `frames`."""
     if raw_static is None:
         raw_static = len(frames) >= 2 and len({raw_state_id(f) for f in frames}) == 1
-    return classify_ids([state_id(f) for f in frames], raw_static, matched_patterns(frames),
+    return classify_ids([state_id(f) for f in frames], raw_static, [matched_patterns([f]) for f in frames],
                         work_outstanding, duration_s, work_detail, thresholds)
 
 
-def classify_ids(state_ids: list, raw_static: bool, pats: list, work_outstanding: bool,
-                 duration_s: float, work_detail: str = "", thresholds: Optional[dict] = None) -> dict:
+def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool,
+                 duration_s: float, work_detail: str = "", thresholds: Optional[dict] = None,
+                 gaps: Optional[list] = None) -> dict:
     """The verdict from hashes and pattern names alone — what the persisted
-    window carries, so no pane text is needed (or stored) to classify."""
+    window carries, so no pane text is needed (or stored) to classify. `pats`
+    is one list of pattern names per sample (a flat list means every sample)."""
     th = {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}
     nov = novelty_of_ids(state_ids)
+    if pats and all(isinstance(x, str) for x in pats):
+        pats = [list(pats) for _ in state_ids]
+    ps = pattern_stats(list(pats or []), th)
     clock_only = (not raw_static) and nov.static
+    spacing = {}
+    if gaps:
+        g = sorted(gaps)
+        spacing = {"median_gap_s": round(g[len(g) // 2], 1), "max_gap_s": round(g[-1], 1)}
     base = {
         "advisory": True,
         "note": "CLI progress detector — reads the pane, not the process; not a health guarantee",
@@ -164,7 +203,9 @@ def classify_ids(state_ids: list, raw_static: bool, pats: list, work_outstanding
         "sample_count": nov.sample_count,
         "novel_state_count": nov.novel_state_count,
         "novelty_rate": round(nov.novelty_rate, 3),
-        "matched_patterns": pats,
+        "matched_patterns": sorted({p for s in (pats or []) for p in s}),
+        **ps,
+        **spacing,
         "work_outstanding": work_outstanding,
         "work_detail": work_detail,
         "raw_static": bool(raw_static),
@@ -173,29 +214,34 @@ def classify_ids(state_ids: list, raw_static: bool, pats: list, work_outstanding
     }
     if nov.sample_count < 2:
         return {**base, "kind": "unknown", "confidence": "none", "warn": False,
-                "reason": "fewer than 2 samples — nothing to compare"}
-    # Retry text decides first: a loop whose only motion is counters/clocks
-    # normalizes to ONE state and would otherwise read as merely static.
-    if pats and (raw_static or nov.static or (nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"])):
-        return {**base, "kind": "retry-loop", "confidence": "high" if nov.sample_count >= th["min_samples"] else "medium", "warn": True,
-                "reason": f"{nov.novel_state_count} distinct state(s) over {nov.sample_count} samples and retry text present ({', '.join(pats)})"}
+                "reason": "fewer than 2 samples in the current observation run — nothing to compare"}
+    enough = nov.sample_count >= th["min_samples"]
+    # A provider told the CLI to stop: not a retry loop, a blocked state of its own.
+    # The pane keeps moving (clock, verb), so only current, recurrent text tells.
+    if ps["retry_current"] and any(p in ps["current_patterns"] for p in PROVIDER_LIMIT_PATTERNS):
+        return {**base, "kind": "provider-limit", "confidence": "high" if ps["consecutive_pattern_samples"] >= 3 else "medium",
+                "warn": True, "reason": f"provider limit text on the last {ps['consecutive_pattern_samples']} sample(s) ({', '.join(ps['current_patterns'])})"}
+    low_novelty = enough and nov.novelty_rate <= th["low_novelty_rate"]
+    # Retry loop = low novelty AND retry text that is current and recurrent (not a stale residue).
+    if ps["retry_current"] and (raw_static or nov.static or low_novelty):
+        return {**base, "kind": "retry-loop", "confidence": "high" if enough else "medium", "warn": True,
+                "reason": f"{nov.novel_state_count} distinct state(s) over {nov.sample_count} samples; retry text on the last {ps['consecutive_pattern_samples']} ({', '.join(ps['current_patterns'])})"}
     # Case 1 is pure static on the RAW pane (spec): no normalization here.
     if raw_static:
         if work_outstanding:
-            high = duration_s >= th["static_high_conf_s"]
+            high = duration_s >= th["static_high_conf_s"] and nov.sample_count >= th["static_high_conf_samples"]
             return {**base, "kind": "static-with-work", "confidence": "high" if high else "low", "warn": True,
-                    "reason": f"pane unchanged for {duration_s:.0f}s while work is outstanding ({work_detail or 'unspecified'})"}
+                    "reason": f"pane unchanged across {nov.sample_count} samples over {duration_s:.0f}s while work is outstanding ({work_detail or 'unspecified'})"}
         return {**base, "kind": "idle", "confidence": "high", "warn": False,
                 "reason": "pane unchanged and nothing outstanding"}
     if clock_only:
         return {**base, "kind": "clock-only", "confidence": "medium", "warn": False,
                 "reason": "only volatile fields (clock/counters) change — a live CLI, not a wedge (operator observation); recorded for the harness"}
-    if work_outstanding and nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"]:
+    if work_outstanding and low_novelty:
         return {**base, "kind": "low-novelty", "confidence": "low", "warn": True,
-                "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples with work outstanding, no retry text — repetitive, cause unknown"}
+                "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples with work outstanding, no current retry text — repetitive, cause unknown"}
     return {**base, "kind": "working", "confidence": "medium" if nov.novelty_rate < 0.6 else "high", "warn": False,
             "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples"}
-
 
 # ---- I/O edge -------------------------------------------------------------
 
@@ -212,12 +258,39 @@ def capture_pane(socket_path: str, target: str, tmux_bin: str = "tmux",
     return proc.stdout
 
 
-def work_outstanding(workspace: Path) -> tuple:
-    """True when the core says it is running or a task file is queued."""
+_PANE_ID = re.compile(r"^\d+:\d+$")
+
+
+def pane_identity(socket_path: str, target: str, tmux_bin: str = "tmux",
+                  runner: Callable = subprocess.run) -> Optional[str]:
+    """`pane_pid:session_created` for the target, or None when unknown. A new
+    core process is a new observation run; None never resets anything."""
+    try:
+        proc = runner([tmux_bin, "-S", socket_path, "display-message", "-p", "-t", target,
+                       "#{pane_pid}:#{session_created}"], capture_output=True, text=True, timeout=10)
+    except Exception:  # noqa: BLE001 — identity unknown is not a reading
+        return None
+    out = (getattr(proc, "stdout", "") or "").strip()
+    return out if getattr(proc, "returncode", 1) == 0 and _PANE_ID.match(out) else None
+
+
+def work_outstanding(workspace: Path, now: Optional[float] = None, ttl_s: Optional[float] = None) -> tuple:
+    """True when the core says it is running AND said so recently, or a task file
+    is queued. Same contract as graceful-restart.sh busy(): a "running" older
+    than the TTL is a crashed core's last word, not work."""
+    now = time.time() if now is None else now
+    ttl = PROVISIONAL_THRESHOLDS["status_ttl_s"] if ttl_s is None else ttl_s
     reasons = []
     try:
-        if json.loads((workspace / "state" / "core-status.json").read_text()).get("status") == "running":
-            reasons.append("core-status running")
+        st = json.loads((workspace / "state" / "core-status.json").read_text())
+        if st.get("status") == "running":
+            ts = st.get("ts")
+            age = (now - ts) if isinstance(ts, (int, float)) else None
+            if age is not None and 0 <= age <= ttl:
+                reasons.append(f"core-status running ({age:.0f}s old)")
+            else:
+                # Not counted: a stale or unstamped "running" is not evidence of work.
+                pass
     except (OSError, ValueError, AttributeError):
         pass
     tasks = list((workspace / "tasks").glob("task-*.txt"))
@@ -249,7 +322,8 @@ def _write_private(path: Path, text: str) -> None:
 
 def _valid_entry(e) -> bool:
     return (isinstance(e, dict) and isinstance(e.get("ts"), (int, float))
-            and isinstance(e.get("state"), str) and isinstance(e.get("patterns", []), list))
+            and isinstance(e.get("state"), str) and isinstance(e.get("patterns", []), list)
+            and isinstance(e.get("pane", ""), str))
 
 
 def load_window(path: Path) -> list:
@@ -267,47 +341,81 @@ def load_window(path: Path) -> list:
     return entries
 
 
-def append_window(workspace: Path, frame: str, now: float, keep: int = 20) -> list:
+def append_window(workspace: Path, frame: str, now: float, keep: int = 20, pane: Optional[str] = None) -> list:
     """Persist one sample into the rolling window so the statistic spans
-    health-check passes; returns the window (oldest first)."""
+    health-check passes; returns the window (oldest first). `pane` is the pane's
+    identity (pid:session-created) so a restarted core starts a new run."""
     path = window_path(workspace)
     entries = load_window(path)
     # Hashes and pattern names only — no pane text is ever persisted here.
-    entries.append({"ts": now, "state": state_id(frame), "raw_state": raw_state_id(frame),
-                    "patterns": matched_patterns([frame])})
+    entry = {"ts": now, "state": state_id(frame), "raw_state": raw_state_id(frame),
+             "patterns": matched_patterns([frame])}
+    if pane:
+        entry["pane"] = pane
+    entries.append(entry)
     entries = entries[-keep:]
     _write_private(path, "".join(json.dumps(e) + "\n" for e in entries))
     return entries
 
 
-def classify_window(entries: list, work: tuple, now: float) -> dict:
-    """Classify persisted samples (hashes only). Case 2 looks at the whole
-    window; case 1 at the TRAILING run of one RAW state, since earlier
-    different frames only say the pane moved before it stopped."""
-    entries = [e for e in entries if _valid_entry(e)]
+def observation_runs(entries: list, gap_s: float) -> list:
+    """Split samples into runs of continuous observation: a gap longer than
+    `gap_s` (host asleep, health-check not running) or a different pane
+    identity starts a new run. Two identical frames eight hours apart are two
+    glimpses, not eight hours of watching."""
+    runs = []
+    for e in entries:
+        if runs:
+            prev = runs[-1][-1]
+            if e["ts"] - prev["ts"] > gap_s or (e.get("pane") and prev.get("pane") and e["pane"] != prev["pane"]):
+                runs.append([e])
+                continue
+            runs[-1].append(e)
+        else:
+            runs.append([e])
+    return runs
+
+
+def classify_window(entries: list, work: tuple, now: float, thresholds: Optional[dict] = None) -> dict:
+    """Classify the CURRENT observation run of persisted samples (hashes only).
+    Case 2 looks at the whole run; case 1 at the TRAILING stretch of one RAW
+    state, since earlier different frames only say the pane moved before it
+    stopped. Duration is measured inside the run, never across a gap."""
+    th = {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}
+    entries = sorted((e for e in entries if _valid_entry(e)), key=lambda e: e["ts"])
     if not entries:
-        return classify_ids([], False, [], work[0], 0.0, work[1])
-    ids = [e["state"] for e in entries]
-    raws = [e.get("raw_state") for e in entries]
-    pats = sorted({p for e in entries for p in e.get("patterns", []) if isinstance(p, str)})
-    whole_raw_static = len(entries) >= 2 and all(raws) and len(set(raws)) == 1
-    whole = classify_ids(ids, whole_raw_static, pats, work[0], max(0.0, now - entries[0]["ts"]), work[1])
-    if whole["kind"] in ("retry-loop", "low-novelty"):
-        return whole
-    last = entries[-1].get("raw_state")
-    run = []
-    for e in reversed(entries):
+        return classify_ids([], False, [], work[0], 0.0, work[1], th)
+    runs = observation_runs(entries, th["continuity_gap_s"])
+    run = runs[-1]
+    meta = {"observation_runs": len(runs), "run_started": run[0]["ts"], "run_samples": len(run),
+            "window_samples": len(entries), "last_sample_age_s": round(max(0.0, now - run[-1]["ts"]), 1)}
+    if now - run[-1]["ts"] > th["continuity_gap_s"]:
+        v = classify_ids([], False, [], work[0], 0.0, work[1], th)
+        return {**v, **meta, "reason": f"last sample {now - run[-1]['ts']:.0f}s ago — no current observation"}
+    gaps = [b["ts"] - a["ts"] for a, b in zip(run, run[1:])]
+    ids = [e["state"] for e in run]
+    raws = [e.get("raw_state") for e in run]
+    pats = [[p for p in e.get("patterns", []) if isinstance(p, str)] for e in run]
+    whole_raw_static = len(run) >= 2 and all(raws) and len(set(raws)) == 1
+    whole = classify_ids(ids, whole_raw_static, pats, work[0], max(0.0, now - run[0]["ts"]), work[1], th, gaps)
+    if whole["kind"] in ("retry-loop", "provider-limit", "low-novelty"):
+        return {**whole, **meta}
+    last = run[-1].get("raw_state")
+    tail = []
+    for e in reversed(run):
         if not last or e.get("raw_state") != last:
             break
-        run.append(e)
-    if len(run) >= 2:
-        run_pats = sorted({p for e in run for p in e.get("patterns", []) if isinstance(p, str)})
-        trailing = classify_ids([e["state"] for e in run], True, run_pats, work[0], max(0.0, now - run[-1]["ts"]), work[1])
+        tail.append(e)
+    if len(tail) >= 2:
+        tail = list(reversed(tail))
+        tail_gaps = [b["ts"] - a["ts"] for a, b in zip(tail, tail[1:])]
+        trailing = classify_ids([e["state"] for e in tail], True,
+                                [[p for p in e.get("patterns", []) if isinstance(p, str)] for e in tail],
+                                work[0], max(0.0, now - tail[0]["ts"]), work[1], th, tail_gaps)
         if trailing["kind"] in ("idle", "static-with-work"):
-            return {**trailing, "sample_count": whole["sample_count"], "novel_state_count": whole["novel_state_count"],
-                    "novelty_rate": whole["novelty_rate"], "clock_only": whole["clock_only"], "trailing_static_samples": len(run)}
-    return whole
-
+            return {**trailing, **meta, "sample_count": whole["sample_count"], "novel_state_count": whole["novel_state_count"],
+                    "novelty_rate": whole["novelty_rate"], "clock_only": whole["clock_only"], "trailing_static_samples": len(tail)}
+    return {**whole, **meta}
 
 # ---- CLI: record real traces / replay / one-shot probe ----------------------
 
@@ -388,8 +496,9 @@ def main(argv: Optional[list] = None) -> int:
         print(json.dumps({"kind": "unknown", "warn": False, "reason": "pane not readable"}))
         return 0
     ws = Path(a.workspace)
-    entries = append_window(ws, frame, time.time())
-    print(json.dumps(classify_window(entries, work_outstanding(ws), time.time()), indent=1))
+    now = time.time()
+    entries = append_window(ws, frame, now, pane=pane_identity(a.socket, a.target, a.tmux))
+    print(json.dumps(classify_window(entries, work_outstanding(ws, now), now), indent=1))
     return 0
 
 

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """CLI progress detector for the core's tmux pane — advisory only.
 
-Two cases a heartbeat and a liveness probe both miss: (1) the pane is static
-while work is outstanding; (2) the pane moves but revisits the same states (a
-retry loop). Frames are NORMALIZED before comparison — clocks, durations,
-counters, spinners and token counts are volatile and would fake novelty — so
-"static" means "nothing but volatile fields changed".
+Two cases a heartbeat and a liveness probe both miss: (1) the RAW pane is
+static while work is outstanding — pure static, no normalization, per the
+spec; (2) the pane moves but revisits the same states (a retry loop), measured
+as novelty over NORMALIZED frames — clocks, durations, counters, spinners and
+token counts would fake novelty. A pane whose only motion is a clock is
+neither verdict: it is reported as `clock_only` so traces can settle it.
 
 This reads the CLI, not the process. A green result here is not evidence the
 core is healthy; it complements `.alive` and the runtime probes, never replaces
@@ -82,6 +83,11 @@ def state_id(frame: str) -> str:
     return hashlib.sha1(normalize(frame).encode("utf-8")).hexdigest()[:12]
 
 
+def raw_state_id(frame: str) -> str:
+    """Identity of the frame as displayed — what case 1 compares."""
+    return hashlib.sha1(frame.encode("utf-8")).hexdigest()[:12]
+
+
 def matched_patterns(frames: list) -> list:
     text = "\n".join(frames)
     return [name for name, rx in RETRY_PATTERNS if rx.search(text)]
@@ -113,13 +119,18 @@ def novelty(frames: list) -> Novelty:
 
 
 def classify(frames: list, work_outstanding: bool, duration_s: float,
-             work_detail: str = "", thresholds: Optional[dict] = None) -> dict:
+             work_detail: str = "", thresholds: Optional[dict] = None,
+             raw_static: Optional[bool] = None) -> dict:
     """Advisory verdict over a window of frames. kind ∈ idle | working |
-    static-with-work | retry-loop | low-novelty | unknown; the last three
-    before unknown are warnings."""
+    clock-only | static-with-work | retry-loop | low-novelty | unknown; the
+    last three before unknown are warnings. `raw_static` is case 1's input
+    (frame-for-frame equality); when None it is computed from `frames`."""
     th = {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}
     nov = novelty(frames)
     pats = matched_patterns(frames)
+    if raw_static is None:
+        raw_static = len(frames) >= 2 and len({raw_state_id(f) for f in frames}) == 1
+    clock_only = (not raw_static) and nov.static
     base = {
         "advisory": True,
         "note": "CLI progress detector — reads the pane, not the process; not a health guarantee",
@@ -130,6 +141,8 @@ def classify(frames: list, work_outstanding: bool, duration_s: float,
         "matched_patterns": pats,
         "work_outstanding": work_outstanding,
         "work_detail": work_detail,
+        "raw_static": bool(raw_static),
+        "clock_only": clock_only,
         "thresholds": th,
     }
     if nov.sample_count < 2:
@@ -137,19 +150,23 @@ def classify(frames: list, work_outstanding: bool, duration_s: float,
                 "reason": "fewer than 2 samples — nothing to compare"}
     # Retry text decides first: a loop whose only motion is counters/clocks
     # normalizes to ONE state and would otherwise read as merely static.
-    if pats and (nov.static or (nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"])):
+    if pats and (raw_static or nov.static or (nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"])):
         return {**base, "kind": "retry-loop", "confidence": "high" if nov.sample_count >= th["min_samples"] else "medium", "warn": True,
                 "reason": f"{nov.novel_state_count} distinct state(s) over {nov.sample_count} samples and retry text present ({', '.join(pats)})"}
-    if nov.static:
+    # Case 1 is pure static on the RAW pane (spec): no normalization here.
+    if raw_static:
         if work_outstanding:
             high = duration_s >= th["static_high_conf_s"]
             return {**base, "kind": "static-with-work", "confidence": "high" if high else "low", "warn": True,
-                    "reason": f"pane unchanged (after normalization) for {duration_s:.0f}s while work is outstanding ({work_detail or 'unspecified'})"}
+                    "reason": f"pane unchanged for {duration_s:.0f}s while work is outstanding ({work_detail or 'unspecified'})"}
         return {**base, "kind": "idle", "confidence": "high", "warn": False,
                 "reason": "pane unchanged and nothing outstanding"}
-    if nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"]:
+    if clock_only and not work_outstanding:
+        return {**base, "kind": "clock-only", "confidence": "none", "warn": False,
+                "reason": "only volatile fields (clock/counters) change and nothing is outstanding — recorded for the harness, not judged"}
+    if work_outstanding and nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"]:
         return {**base, "kind": "low-novelty", "confidence": "low", "warn": True,
-                "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples, no retry text — repetitive, cause unknown"}
+                "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples with work outstanding, no retry text — repetitive, cause unknown"}
     return {**base, "kind": "working", "confidence": "medium" if nov.novelty_rate < 0.6 else "high", "warn": False,
             "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples"}
 
@@ -199,8 +216,8 @@ def append_window(workspace: Path, frame: str, now: float, keep: int = 20) -> li
                 entries.append(json.loads(line))
             except ValueError:
                 continue
-    entries.append({"ts": now, "state": state_id(frame), "normalized": normalize(frame),
-                    "patterns": matched_patterns([frame])})
+    entries.append({"ts": now, "state": state_id(frame), "raw_state": raw_state_id(frame),
+                    "normalized": normalize(frame), "patterns": matched_patterns([frame])})
     entries = entries[-keep:]
     tmp = path.with_suffix(".jsonl.tmp")
     tmp.write_text("".join(json.dumps(e) + "\n" for e in entries))
@@ -214,22 +231,24 @@ def classify_window(entries: list, work: tuple, now: float) -> dict:
     frames = [e.get("normalized", "") for e in entries]
     if not entries:
         return classify([], work[0], 0.0, work[1])
-    # Case 2 looks at the whole window; case 1 at the TRAILING run of one state,
-    # since earlier different frames only say the pane moved before it stopped.
-    whole = classify(frames, work[0], max(0.0, now - entries[0]["ts"]), work[1])
+    raws = [e.get("raw_state") for e in entries]
+    whole_raw_static = len(entries) >= 2 and all(raws) and len(set(raws)) == 1
+    # Case 2 looks at the whole window; case 1 at the TRAILING run of one RAW
+    # state, since earlier different frames only say the pane moved before it stopped.
+    whole = classify(frames, work[0], max(0.0, now - entries[0]["ts"]), work[1], raw_static=whole_raw_static)
     if whole["kind"] in ("retry-loop", "low-novelty"):
         return whole
-    last = entries[-1]["state"]
+    last = entries[-1].get("raw_state")
     run = []
     for e in reversed(entries):
-        if e["state"] != last:
+        if not last or e.get("raw_state") != last:
             break
         run.append(e)
     if len(run) >= 2:
-        trailing = classify([e.get("normalized", "") for e in run], work[0], max(0.0, now - run[-1]["ts"]), work[1])
+        trailing = classify([e.get("normalized", "") for e in run], work[0], max(0.0, now - run[-1]["ts"]), work[1], raw_static=True)
         if trailing["kind"] in ("idle", "static-with-work"):
             return {**trailing, "sample_count": whole["sample_count"], "novel_state_count": whole["novel_state_count"],
-                    "novelty_rate": whole["novelty_rate"], "trailing_static_samples": len(run)}
+                    "novelty_rate": whole["novelty_rate"], "clock_only": whole["clock_only"], "trailing_static_samples": len(run)}
     return whole
 
 
@@ -252,8 +271,8 @@ def record(args, sampler: Callable, clock=time.time, sleep=time.sleep) -> Path:
             frame = sampler()
             if frame is not None:
                 frames.append(frame)
-                entry = {"ts": clock(), "state": state_id(frame), "normalized": normalize(frame),
-                         "patterns": matched_patterns([frame])}
+                entry = {"ts": clock(), "state": state_id(frame), "raw_state": raw_state_id(frame),
+                         "normalized": normalize(frame), "patterns": matched_patterns([frame])}
                 if args.keep_raw:
                     entry["raw"] = frame
                 fh.write(json.dumps(entry) + "\n")
@@ -264,7 +283,7 @@ def record(args, sampler: Callable, clock=time.time, sleep=time.sleep) -> Path:
 
 
 def replay(path: Path, work: bool = False) -> dict:
-    frames, ts = [], []
+    frames, ts, raws = [], [], []
     for line in Path(path).read_text().splitlines():
         try:
             e = json.loads(line)
@@ -274,8 +293,10 @@ def replay(path: Path, work: bool = False) -> dict:
             continue
         frames.append(e.get("raw") or e.get("normalized", ""))
         ts.append(e.get("ts", 0))
+        raws.append(e.get("raw_state"))
     duration = (max(ts) - min(ts)) if len(ts) >= 2 else 0.0
-    return classify(frames, work, duration, "replay flag" if work else "")
+    raw_static = (len(raws) >= 2 and all(raws) and len(set(raws)) == 1) if any(raws) else None
+    return classify(frames, work, duration, "replay flag" if work else "", raw_static=raw_static)
 
 
 def main(argv: Optional[list] = None) -> int:

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -83,9 +83,7 @@ PROVISIONAL_THRESHOLDS = {
     "status_ttl_s": 900,
 }
 PROVIDER_LIMIT_PATTERNS = ("quota-limit",)
-# Exact session, window 0 — the launcher's core window. A bare `=name` is a pane
-# target and stops resolving once the session has a second window (the app adds `gateway`).
-DEFAULT_TARGET = "=sutando-core:0"
+DEFAULT_SESSION = "sutando-core"
 
 def normalize(frame: str) -> str:
     """Strip volatile fields so two frames differing only in clocks, counters,
@@ -249,7 +247,23 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
 
 # ---- I/O edge -------------------------------------------------------------
 
-def capture_pane(socket_path: str, target: str = DEFAULT_TARGET, tmux_bin: str = "tmux",
+def core_target(socket_path: str, session: str = DEFAULT_SESSION, tmux_bin: str = "tmux",
+                runner: Callable = subprocess.run, env: Optional[dict] = None) -> Optional[str]:
+    """`=<session>:<lowest window index>` — the launcher's core window, whatever
+    base-index says. A bare `=name` is a pane target and stops resolving once the
+    session has a second window; a fixed `:0` assumes base-index 0. None = no reading."""
+    try:
+        proc = runner([tmux_bin, "-S", socket_path, "list-windows", "-t", f"={session}", "-F", "#{window_index}"],
+                      capture_output=True, text=True, timeout=10, env=env)
+    except Exception:  # noqa: BLE001 — a failed probe is an absent reading, never a verdict
+        return None
+    if getattr(proc, "returncode", 1) != 0:
+        return None
+    idx = [int(x) for x in (getattr(proc, "stdout", "") or "").split() if x.isdigit()]
+    return f"={session}:{min(idx)}" if idx else None
+
+
+def capture_pane(socket_path: str, target: str, tmux_bin: str = "tmux",
                  runner: Callable = subprocess.run, env: Optional[dict] = None) -> Optional[str]:
     """One pane frame, or None when tmux cannot be read (absent = no reading).
     The one capture implementation: health-check and the CLI both call this."""
@@ -266,7 +280,7 @@ def capture_pane(socket_path: str, target: str = DEFAULT_TARGET, tmux_bin: str =
 _PANE_ID = re.compile(r"^\d+:\d+$")
 
 
-def pane_identity(socket_path: str, target: str = DEFAULT_TARGET, tmux_bin: str = "tmux",
+def pane_identity(socket_path: str, target: str, tmux_bin: str = "tmux",
                   runner: Callable = subprocess.run, env: Optional[dict] = None) -> Optional[str]:
     """`pane_pid:session_created` for the target, or None when unknown. A new
     core process is a new observation run; None never resets anything."""
@@ -499,7 +513,8 @@ def main(argv: Optional[list] = None) -> int:
     for name in ("record", "probe"):
         p = sub.add_parser(name)
         p.add_argument("--socket", required=True)
-        p.add_argument("--target", default=DEFAULT_TARGET)
+        p.add_argument("--session", default=os.environ.get("SUTANDO_TMUX_SESSION", DEFAULT_SESSION))
+        p.add_argument("--target", default=None, help="override the resolved =<session>:<window> target")
         p.add_argument("--tmux", default="tmux")
         p.add_argument("--workspace", default=None, help="defaults to the configured workspace")
         if name == "record":
@@ -517,8 +532,13 @@ def main(argv: Optional[list] = None) -> int:
         print(json.dumps(replay(Path(a.path), a.work_outstanding), indent=1))
         return 0
 
+    target = a.target or core_target(a.socket, a.session, a.tmux)
+    if target is None:
+        print(json.dumps({"kind": "unknown", "warn": False, "reason": f"session {a.session!r} not found on {a.socket}"}))
+        return 0
+
     def sampler():
-        return capture_pane(a.socket, a.target, a.tmux)
+        return capture_pane(a.socket, target, a.tmux)
 
     if a.workspace is None:
         a.workspace = str(_default_workspace())
@@ -531,7 +551,7 @@ def main(argv: Optional[list] = None) -> int:
         return 0
     ws = Path(a.workspace)
     now = time.time()
-    entries = append_window(ws, frame, now, pane=pane_identity(a.socket, a.target, a.tmux))
+    entries = append_window(ws, frame, now, pane=pane_identity(a.socket, target, a.tmux))
     print(json.dumps(classify_window(entries, work_outstanding(ws, now), now), indent=1))
     return 0
 

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -23,6 +23,7 @@ this module writes is owner-only from birth (0600 in a 0700 directory).
 from __future__ import annotations
 
 import argparse
+import fcntl
 import hashlib
 import json
 import os
@@ -344,17 +345,28 @@ def load_window(path: Path) -> list:
 def append_window(workspace: Path, frame: str, now: float, keep: int = 20, pane: Optional[str] = None) -> list:
     """Persist one sample into the rolling window so the statistic spans
     health-check passes; returns the window (oldest first). `pane` is the pane's
-    identity (pid:session-created) so a restarted core starts a new run."""
+    identity (pid:session-created) so a restarted core starts a new run.
+    The whole load → append → truncate → replace runs under one lock: the app's
+    health-check and the launchd fallback are independent writers, and an
+    atomic replace alone lets the later loader overwrite the earlier append."""
     path = window_path(workspace)
-    entries = load_window(path)
-    # Hashes and pattern names only — no pane text is ever persisted here.
-    entry = {"ts": now, "state": state_id(frame), "raw_state": raw_state_id(frame),
-             "patterns": matched_patterns([frame])}
-    if pane:
-        entry["pane"] = pane
-    entries.append(entry)
-    entries = entries[-keep:]
-    _write_private(path, "".join(json.dumps(e) + "\n" for e in entries))
+    _private_dir(path.parent)
+    lock = path.with_name(path.name + ".lock")
+    fd = os.open(lock, os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        entries = load_window(path)
+        # Hashes and pattern names only — no pane text is ever persisted here.
+        entry = {"ts": now, "state": state_id(frame), "raw_state": raw_state_id(frame),
+                 "patterns": matched_patterns([frame])}
+        if pane:
+            entry["pane"] = pane
+        entries.append(entry)
+        entries = entries[-keep:]
+        _write_private(path, "".join(json.dumps(e) + "\n" for e in entries))
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
     return entries
 
 

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -15,6 +15,10 @@ them. Nothing here restarts, kills or fails anything over: it warns.
 
 Thresholds are PROVISIONAL (V1 is instrumentation): `record` writes real traces
 under <workspace>/state/cli-wedge/traces/ so they can be tuned from behaviour.
+
+Privacy: the rolling window persists hashes and pattern names only, never pane
+text; traces carry text only with --keep-normalized / --keep-raw. Every file
+this module writes is owner-only from birth (0600 in a 0700 directory).
 """
 from __future__ import annotations
 
@@ -119,6 +123,17 @@ def novelty(frames: list) -> Novelty:
     return Novelty(n, novel, (novel / n) if n else 0.0, n >= 2 and novel == 1, ids)
 
 
+def novelty_of_ids(state_ids: list) -> Novelty:
+    seen = set()
+    novel = 0
+    for sid in state_ids:
+        if sid not in seen:
+            seen.add(sid)
+            novel += 1
+    n = len(state_ids)
+    return Novelty(n, novel, (novel / n) if n else 0.0, n >= 2 and novel == 1, list(state_ids))
+
+
 def classify(frames: list, work_outstanding: bool, duration_s: float,
              work_detail: str = "", thresholds: Optional[dict] = None,
              raw_static: Optional[bool] = None) -> dict:
@@ -126,11 +141,18 @@ def classify(frames: list, work_outstanding: bool, duration_s: float,
     clock-only | static-with-work | retry-loop | low-novelty | unknown; the
     last three before unknown are warnings. `raw_static` is case 1's input
     (frame-for-frame equality); when None it is computed from `frames`."""
-    th = {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}
-    nov = novelty(frames)
-    pats = matched_patterns(frames)
     if raw_static is None:
         raw_static = len(frames) >= 2 and len({raw_state_id(f) for f in frames}) == 1
+    return classify_ids([state_id(f) for f in frames], raw_static, matched_patterns(frames),
+                        work_outstanding, duration_s, work_detail, thresholds)
+
+
+def classify_ids(state_ids: list, raw_static: bool, pats: list, work_outstanding: bool,
+                 duration_s: float, work_detail: str = "", thresholds: Optional[dict] = None) -> dict:
+    """The verdict from hashes and pattern names alone — what the persisted
+    window carries, so no pane text is needed (or stored) to classify."""
+    th = {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}
+    nov = novelty_of_ids(state_ids)
     clock_only = (not raw_static) and nov.static
     base = {
         "advisory": True,
@@ -205,38 +227,68 @@ def window_path(workspace: Path) -> Path:
     return workspace / "state" / "cli-wedge" / "window.jsonl"
 
 
+def _private_dir(path: Path) -> None:
+    """Owner-only directory, created or normalized (a permissive umask must not widen it)."""
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, 0o700)
+
+
+def _write_private(path: Path, text: str) -> None:
+    """Atomic replace through an owner-only temp file; the target ends 0600."""
+    _private_dir(path.parent)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(text)
+    os.replace(tmp, path)
+    os.chmod(path, 0o600)
+
+
+def _valid_entry(e) -> bool:
+    return (isinstance(e, dict) and isinstance(e.get("ts"), (int, float))
+            and isinstance(e.get("state"), str) and isinstance(e.get("patterns", []), list))
+
+
+def load_window(path: Path) -> list:
+    """Persisted entries that pass validation; anything else is skipped, never raised."""
+    entries = []
+    if not path.exists():
+        return entries
+    for line in path.read_text().splitlines():
+        try:
+            e = json.loads(line)
+        except ValueError:
+            continue
+        if _valid_entry(e):
+            entries.append(e)
+    return entries
+
+
 def append_window(workspace: Path, frame: str, now: float, keep: int = 20) -> list:
     """Persist one sample into the rolling window so the statistic spans
     health-check passes; returns the window (oldest first)."""
     path = window_path(workspace)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    entries = []
-    if path.exists():
-        for line in path.read_text().splitlines():
-            try:
-                entries.append(json.loads(line))
-            except ValueError:
-                continue
+    entries = load_window(path)
+    # Hashes and pattern names only — no pane text is ever persisted here.
     entries.append({"ts": now, "state": state_id(frame), "raw_state": raw_state_id(frame),
-                    "normalized": normalize(frame), "patterns": matched_patterns([frame])})
+                    "patterns": matched_patterns([frame])})
     entries = entries[-keep:]
-    tmp = path.with_suffix(".jsonl.tmp")
-    tmp.write_text("".join(json.dumps(e) + "\n" for e in entries))
-    os.replace(tmp, path)
+    _write_private(path, "".join(json.dumps(e) + "\n" for e in entries))
     return entries
 
 
 def classify_window(entries: list, work: tuple, now: float) -> dict:
-    """Classify persisted samples; the duration is that of the trailing run of
-    one state, which is what "static for N seconds" means."""
-    frames = [e.get("normalized", "") for e in entries]
+    """Classify persisted samples (hashes only). Case 2 looks at the whole
+    window; case 1 at the TRAILING run of one RAW state, since earlier
+    different frames only say the pane moved before it stopped."""
+    entries = [e for e in entries if _valid_entry(e)]
     if not entries:
-        return classify([], work[0], 0.0, work[1])
+        return classify_ids([], False, [], work[0], 0.0, work[1])
+    ids = [e["state"] for e in entries]
     raws = [e.get("raw_state") for e in entries]
+    pats = sorted({p for e in entries for p in e.get("patterns", []) if isinstance(p, str)})
     whole_raw_static = len(entries) >= 2 and all(raws) and len(set(raws)) == 1
-    # Case 2 looks at the whole window; case 1 at the TRAILING run of one RAW
-    # state, since earlier different frames only say the pane moved before it stopped.
-    whole = classify(frames, work[0], max(0.0, now - entries[0]["ts"]), work[1], raw_static=whole_raw_static)
+    whole = classify_ids(ids, whole_raw_static, pats, work[0], max(0.0, now - entries[0]["ts"]), work[1])
     if whole["kind"] in ("retry-loop", "low-novelty"):
         return whole
     last = entries[-1].get("raw_state")
@@ -246,7 +298,8 @@ def classify_window(entries: list, work: tuple, now: float) -> dict:
             break
         run.append(e)
     if len(run) >= 2:
-        trailing = classify([e.get("normalized", "") for e in run], work[0], max(0.0, now - run[-1]["ts"]), work[1], raw_static=True)
+        run_pats = sorted({p for e in run for p in e.get("patterns", []) if isinstance(p, str)})
+        trailing = classify_ids([e["state"] for e in run], True, run_pats, work[0], max(0.0, now - run[-1]["ts"]), work[1])
         if trailing["kind"] in ("idle", "static-with-work"):
             return {**trailing, "sample_count": whole["sample_count"], "novel_state_count": whole["novel_state_count"],
                     "novelty_rate": whole["novelty_rate"], "clock_only": whole["clock_only"], "trailing_static_samples": len(run)}
@@ -263,18 +316,22 @@ def record(args, sampler: Callable, clock=time.time, sleep=time.sleep) -> Path:
     """Sample the pane every `interval` seconds for `seconds`, one JSON line per
     sample plus a summary line; the file is the tuning evidence."""
     out_dir = Path(args.workspace) / "state" / "cli-wedge" / "traces"
-    out_dir.mkdir(parents=True, exist_ok=True)
+    _private_dir(out_dir)
     started = clock()
     path = out_dir / f"{args.label}-{int(started)}.jsonl"
     frames = []
-    with path.open("w") as fh:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w") as fh:
         while clock() - started < args.seconds and len(frames) < args.max_samples:
             frame = sampler()
             if frame is not None:
                 frames.append(frame)
+                # Text is opt-in: hashes and pattern names are enough to tune thresholds.
                 entry = {"ts": clock(), "state": state_id(frame), "raw_state": raw_state_id(frame),
-                         "normalized": normalize(frame), "patterns": matched_patterns([frame])}
-                if args.keep_raw:
+                         "patterns": matched_patterns([frame])}
+                if getattr(args, "keep_normalized", False):
+                    entry["normalized"] = normalize(frame)
+                if getattr(args, "keep_raw", False):
                     entry["raw"] = frame
                 fh.write(json.dumps(entry) + "\n")
             sleep(args.interval)
@@ -284,20 +341,11 @@ def record(args, sampler: Callable, clock=time.time, sleep=time.sleep) -> Path:
 
 
 def replay(path: Path, work: bool = False) -> dict:
-    frames, ts, raws = [], [], []
-    for line in Path(path).read_text().splitlines():
-        try:
-            e = json.loads(line)
-        except ValueError:
-            continue
-        if e.get("summary"):
-            continue
-        frames.append(e.get("raw") or e.get("normalized", ""))
-        ts.append(e.get("ts", 0))
-        raws.append(e.get("raw_state"))
+    entries = [e for e in load_window(Path(path)) if not e.get("summary")]
+    ts = [e["ts"] for e in entries]
     duration = (max(ts) - min(ts)) if len(ts) >= 2 else 0.0
-    raw_static = (len(raws) >= 2 and all(raws) and len(set(raws)) == 1) if any(raws) else None
-    return classify(frames, work, duration, "replay flag" if work else "", raw_static=raw_static)
+    return classify_window(entries, (work, "replay flag" if work else ""), max(ts) if ts else 0.0) if entries else \
+        classify_ids([], False, [], work, 0.0, "replay flag" if work else "")
 
 
 def main(argv: Optional[list] = None) -> int:
@@ -314,7 +362,8 @@ def main(argv: Optional[list] = None) -> int:
             p.add_argument("--seconds", type=float, default=60)
             p.add_argument("--interval", type=float, default=3)
             p.add_argument("--max-samples", type=int, default=200)
-            p.add_argument("--keep-raw", action="store_true")
+            p.add_argument("--keep-normalized", action="store_true", help="also store normalized frame text (opt-in)")
+            p.add_argument("--keep-raw", action="store_true", help="also store the raw frame (opt-in)")
     r = sub.add_parser("replay")
     r.add_argument("path")
     r.add_argument("--work-outstanding", action="store_true")

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""CLI progress detector for the core's tmux pane — advisory only.
+
+Two cases a heartbeat and a liveness probe both miss: (1) the pane is static
+while work is outstanding; (2) the pane moves but revisits the same states (a
+retry loop). Frames are NORMALIZED before comparison — clocks, durations,
+counters, spinners and token counts are volatile and would fake novelty — so
+"static" means "nothing but volatile fields changed".
+
+This reads the CLI, not the process. A green result here is not evidence the
+core is healthy; it complements `.alive` and the runtime probes, never replaces
+them. Nothing here restarts, kills or fails anything over: it warns.
+
+Thresholds are PROVISIONAL (V1 is instrumentation): `record` writes real traces
+under <workspace>/state/cli-wedge/traces/ so they can be tuned from behaviour.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+RETRY_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
+    (name, re.compile(rx, re.IGNORECASE))
+    for name, rx in (
+        ("retrying", r"\bretry(ing)?\b"),
+        ("rate-limit", r"\brate[ -]?limit"),
+        ("overloaded", r"\boverloaded\b"),
+        ("http-429", r"\b429\b"),
+        ("http-529", r"\b529\b"),
+        ("reconnecting", r"\breconnect(ing)?\b"),
+        ("connection-error", r"\bconnection (error|reset|refused)\b"),
+        ("timeout", r"\btimed? ?out\b"),
+    )
+)
+
+# Order matters: composite tokens (timestamps, durations) before bare digits.
+_VOLATILE: tuple[tuple[re.Pattern, str], ...] = (
+    (re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?Z?"), "<ts>"),
+    (re.compile(r"\b\d{1,2}:\d{2}(?::\d{2})?\s*(?:[AaPp][Mm])?\b"), "<clock>"),
+    (re.compile(r"\b\d+(?:\.\d+)?\s*(?:ms|s|secs?|m|mins?|h|hrs?)\b"), "<dur>"),
+    (re.compile(r"\b\d+(?:\.\d+)?[kKmM]?\s*tokens?\b"), "<tokens>"),
+    (re.compile(r"\b\d+\s*/\s*\d+\b"), "<count>"),
+    (re.compile(r"\b\d+(?:\.\d+)?%"), "<pct>"),
+    (re.compile(r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷◐◓◑◒◴◷◶◵]"), "<spin>"),
+    (re.compile(r"(?:\.\s?){2,}|…+"), "<dots>"),
+    (re.compile(r"[─━═]{2,}"), "<rule>"),
+    (re.compile(r"\d+"), "#"),
+)
+
+# Provisional: min samples before case 2 speaks; novel/samples at or below
+# which a window counts as repetitive; static seconds for high confidence.
+PROVISIONAL_THRESHOLDS = {"min_samples": 10, "low_novelty_rate": 0.25, "static_high_conf_s": 300}
+
+
+def normalize(frame: str) -> str:
+    """Strip volatile fields so two frames differing only in clocks, counters,
+    durations or spinners compare equal."""
+    lines = []
+    for raw in frame.splitlines():
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+        for rx, token in _VOLATILE:
+            line = rx.sub(token, line)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def state_id(frame: str) -> str:
+    return hashlib.sha1(normalize(frame).encode("utf-8")).hexdigest()[:12]
+
+
+def matched_patterns(frames: list) -> list:
+    text = "\n".join(frames)
+    return [name for name, rx in RETRY_PATTERNS if rx.search(text)]
+
+
+@dataclass
+class Novelty:
+    sample_count: int
+    novel_state_count: int
+    novelty_rate: float
+    static: bool
+    states: list = field(default_factory=list)
+
+
+def novelty(frames: list) -> Novelty:
+    """A sample is novel when its normalized state was not seen earlier in the
+    window; the first sample is always novel."""
+    seen = set()
+    ids = []
+    novel = 0
+    for f in frames:
+        sid = state_id(f)
+        ids.append(sid)
+        if sid not in seen:
+            seen.add(sid)
+            novel += 1
+    n = len(frames)
+    return Novelty(n, novel, (novel / n) if n else 0.0, n >= 2 and novel == 1, ids)
+
+
+def classify(frames: list, work_outstanding: bool, duration_s: float,
+             work_detail: str = "", thresholds: Optional[dict] = None) -> dict:
+    """Advisory verdict over a window of frames. kind ∈ idle | working |
+    static-with-work | retry-loop | low-novelty | unknown; the last three
+    before unknown are warnings."""
+    th = {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}
+    nov = novelty(frames)
+    pats = matched_patterns(frames)
+    base = {
+        "advisory": True,
+        "note": "CLI progress detector — reads the pane, not the process; not a health guarantee",
+        "duration": round(duration_s, 1),
+        "sample_count": nov.sample_count,
+        "novel_state_count": nov.novel_state_count,
+        "novelty_rate": round(nov.novelty_rate, 3),
+        "matched_patterns": pats,
+        "work_outstanding": work_outstanding,
+        "work_detail": work_detail,
+        "thresholds": th,
+    }
+    if nov.sample_count < 2:
+        return {**base, "kind": "unknown", "confidence": "none", "warn": False,
+                "reason": "fewer than 2 samples — nothing to compare"}
+    # Retry text decides first: a loop whose only motion is counters/clocks
+    # normalizes to ONE state and would otherwise read as merely static.
+    if pats and (nov.static or (nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"])):
+        return {**base, "kind": "retry-loop", "confidence": "high" if nov.sample_count >= th["min_samples"] else "medium", "warn": True,
+                "reason": f"{nov.novel_state_count} distinct state(s) over {nov.sample_count} samples and retry text present ({', '.join(pats)})"}
+    if nov.static:
+        if work_outstanding:
+            high = duration_s >= th["static_high_conf_s"]
+            return {**base, "kind": "static-with-work", "confidence": "high" if high else "low", "warn": True,
+                    "reason": f"pane unchanged (after normalization) for {duration_s:.0f}s while work is outstanding ({work_detail or 'unspecified'})"}
+        return {**base, "kind": "idle", "confidence": "high", "warn": False,
+                "reason": "pane unchanged and nothing outstanding"}
+    if nov.sample_count >= th["min_samples"] and nov.novelty_rate <= th["low_novelty_rate"]:
+        return {**base, "kind": "low-novelty", "confidence": "low", "warn": True,
+                "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples, no retry text — repetitive, cause unknown"}
+    return {**base, "kind": "working", "confidence": "medium" if nov.novelty_rate < 0.6 else "high", "warn": False,
+            "reason": f"{nov.novel_state_count} distinct states over {nov.sample_count} samples"}
+
+
+# ---- I/O edge -------------------------------------------------------------
+
+def capture_pane(socket_path: str, target: str, tmux_bin: str = "tmux",
+                 runner: Callable = subprocess.run) -> Optional[str]:
+    """One pane frame, or None when tmux cannot be read (absent = no reading)."""
+    try:
+        proc = runner([tmux_bin, "-S", socket_path, "capture-pane", "-p", "-t", target],
+                      capture_output=True, text=True, timeout=10)
+    except Exception:  # noqa: BLE001 — a failed probe is an absent reading, never a verdict
+        return None
+    if getattr(proc, "returncode", 1) != 0:
+        return None
+    return proc.stdout
+
+
+def work_outstanding(workspace: Path) -> tuple:
+    """True when the core says it is running or a task file is queued."""
+    reasons = []
+    try:
+        if json.loads((workspace / "state" / "core-status.json").read_text()).get("status") == "running":
+            reasons.append("core-status running")
+    except (OSError, ValueError, AttributeError):
+        pass
+    tasks = list((workspace / "tasks").glob("task-*.txt"))
+    if tasks:
+        reasons.append(f"{len(tasks)} queued task(s)")
+    return (bool(reasons), "; ".join(reasons))
+
+
+def window_path(workspace: Path) -> Path:
+    return workspace / "state" / "cli-wedge" / "window.jsonl"
+
+
+def append_window(workspace: Path, frame: str, now: float, keep: int = 20) -> list:
+    """Persist one sample into the rolling window so the statistic spans
+    health-check passes; returns the window (oldest first)."""
+    path = window_path(workspace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entries = []
+    if path.exists():
+        for line in path.read_text().splitlines():
+            try:
+                entries.append(json.loads(line))
+            except ValueError:
+                continue
+    entries.append({"ts": now, "state": state_id(frame), "normalized": normalize(frame),
+                    "patterns": matched_patterns([frame])})
+    entries = entries[-keep:]
+    tmp = path.with_suffix(".jsonl.tmp")
+    tmp.write_text("".join(json.dumps(e) + "\n" for e in entries))
+    os.replace(tmp, path)
+    return entries
+
+
+def classify_window(entries: list, work: tuple, now: float) -> dict:
+    """Classify persisted samples; the duration is that of the trailing run of
+    one state, which is what "static for N seconds" means."""
+    frames = [e.get("normalized", "") for e in entries]
+    if not entries:
+        return classify([], work[0], 0.0, work[1])
+    # Case 2 looks at the whole window; case 1 at the TRAILING run of one state,
+    # since earlier different frames only say the pane moved before it stopped.
+    whole = classify(frames, work[0], max(0.0, now - entries[0]["ts"]), work[1])
+    if whole["kind"] in ("retry-loop", "low-novelty"):
+        return whole
+    last = entries[-1]["state"]
+    run = []
+    for e in reversed(entries):
+        if e["state"] != last:
+            break
+        run.append(e)
+    if len(run) >= 2:
+        trailing = classify([e.get("normalized", "") for e in run], work[0], max(0.0, now - run[-1]["ts"]), work[1])
+        if trailing["kind"] in ("idle", "static-with-work"):
+            return {**trailing, "sample_count": whole["sample_count"], "novel_state_count": whole["novel_state_count"],
+                    "novelty_rate": whole["novelty_rate"], "trailing_static_samples": len(run)}
+    return whole
+
+
+# ---- CLI: record real traces / replay / one-shot probe ----------------------
+
+def _default_workspace() -> Path:
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from workspace_default import resolve_workspace  # type: ignore
+        return Path(resolve_workspace())
+    except Exception:  # noqa: BLE001 — the CLI still works with --workspace
+        return Path(os.environ.get("SUTANDO_WORKSPACE_DIR", "workspace"))
+
+
+def record(args, sampler: Callable, clock=time.time, sleep=time.sleep) -> Path:
+    """Sample the pane every `interval` seconds for `seconds`, one JSON line per
+    sample plus a summary line; the file is the tuning evidence."""
+    out_dir = Path(args.workspace) / "state" / "cli-wedge" / "traces"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    started = clock()
+    path = out_dir / f"{args.label}-{int(started)}.jsonl"
+    frames = []
+    with path.open("w") as fh:
+        while clock() - started < args.seconds and len(frames) < args.max_samples:
+            frame = sampler()
+            if frame is not None:
+                frames.append(frame)
+                entry = {"ts": clock(), "state": state_id(frame), "normalized": normalize(frame),
+                         "patterns": matched_patterns([frame])}
+                if args.keep_raw:
+                    entry["raw"] = frame
+                fh.write(json.dumps(entry) + "\n")
+            sleep(args.interval)
+        verdict = classify(frames, False, clock() - started, "unknown (recording)")
+        fh.write(json.dumps({"summary": True, "label": args.label, **verdict}) + "\n")
+    return path
+
+
+def replay(path: Path, work: bool = False) -> dict:
+    frames, ts = [], []
+    for line in Path(path).read_text().splitlines():
+        try:
+            e = json.loads(line)
+        except ValueError:
+            continue
+        if e.get("summary"):
+            continue
+        frames.append(e.get("raw") or e.get("normalized", ""))
+        ts.append(e.get("ts", 0))
+    duration = (max(ts) - min(ts)) if len(ts) >= 2 else 0.0
+    return classify(frames, work, duration, "replay flag" if work else "")
+
+
+def main(argv: Optional[list] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    for name in ("record", "probe"):
+        p = sub.add_parser(name)
+        p.add_argument("--socket", required=True)
+        p.add_argument("--target", default="sutando-core")
+        p.add_argument("--tmux", default="tmux")
+        p.add_argument("--workspace", default=str(_default_workspace()))
+        if name == "record":
+            p.add_argument("--label", required=True, help="idle | build | retry | rate-limit | …")
+            p.add_argument("--seconds", type=float, default=60)
+            p.add_argument("--interval", type=float, default=3)
+            p.add_argument("--max-samples", type=int, default=200)
+            p.add_argument("--keep-raw", action="store_true")
+    r = sub.add_parser("replay")
+    r.add_argument("path")
+    r.add_argument("--work-outstanding", action="store_true")
+    a = ap.parse_args(argv)
+    if a.cmd == "replay":
+        print(json.dumps(replay(Path(a.path), a.work_outstanding), indent=1))
+        return 0
+
+    def sampler():
+        return capture_pane(a.socket, a.target, a.tmux)
+
+    if a.cmd == "record":
+        print(record(a, sampler))
+        return 0
+    frame = sampler()
+    if frame is None:
+        print(json.dumps({"kind": "unknown", "warn": False, "reason": "pane not readable"}))
+        return 0
+    ws = Path(a.workspace)
+    entries = append_window(ws, frame, time.time())
+    print(json.dumps(classify_window(entries, work_outstanding(ws), time.time()), indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -407,9 +407,8 @@ def classify_window(entries: list, work: tuple, now: float, thresholds: Optional
     if now - run[-1]["ts"] > th["continuity_gap_s"]:
         v = classify_ids([], False, [], work[0], 0.0, work[1], th)
         return {**v, **meta, "reason": f"last sample {now - run[-1]['ts']:.0f}s ago — no current observation"}
-    # The caller's cadence decides whether a run ever reaches two samples. Judge the
-    # RECENT cadence — the gaps behind the trailing singleton runs — not the whole
-    # window, or a 30-min→hourly change stays "unknown" until the old gaps age out.
+    # Judge the RECENT cadence (gaps behind the trailing singleton runs), not the
+    # whole window: a 30-min→hourly change must not stay "unknown" until old gaps age out.
     singletons = 0
     for r in reversed(runs):
         if len(r) != 1:

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -81,6 +81,7 @@ PROVISIONAL_THRESHOLDS = {
     "pattern_min_rate": 0.5,
     "continuity_gap_s": 2700,
     "status_ttl_s": 900,
+    "min_duration_s": 60,
 }
 PROVIDER_LIMIT_PATTERNS = ("quota-limit",)
 DEFAULT_SESSION = "sutando-core"
@@ -217,6 +218,16 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
     if nov.sample_count < 2:
         return {**base, "kind": "unknown", "confidence": "none", "warn": False,
                 "reason": "fewer than 2 samples in the current observation run — nothing to compare"}
+    verdict = _classify_run(base, nov, raw_static, ps, clock_only, work_outstanding, duration_s, work_detail, th)
+    # Two frames a second apart cannot establish a wedge: a WARNING needs the run to have lasted.
+    if verdict["warn"] and duration_s < th["min_duration_s"]:
+        return {**base, "kind": "unknown", "confidence": "none", "warn": False,
+                "reason": f"observation too short ({duration_s:.0f}s of {th['min_duration_s']}s) for a warning — nothing to conclude yet"}
+    return verdict
+
+
+def _classify_run(base: dict, nov: Novelty, raw_static: bool, ps: dict, clock_only: bool,
+                  work_outstanding: bool, duration_s: float, work_detail: str, th: dict) -> dict:
     enough = nov.sample_count >= th["min_samples"]
     # A provider told the CLI to stop: not a retry loop, a blocked state of its own.
     # The pane keeps moving (clock, verb), so only current, recurrent text tells.

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -28,6 +28,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Optional
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402 — the one sanctioned resolver
+
 RETRY_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
     (name, re.compile(rx, re.IGNORECASE))
     for name, rx in (
@@ -233,12 +236,7 @@ def classify_window(entries: list, work: tuple, now: float) -> dict:
 # ---- CLI: record real traces / replay / one-shot probe ----------------------
 
 def _default_workspace() -> Path:
-    try:
-        sys.path.insert(0, str(Path(__file__).resolve().parent))
-        from workspace_default import resolve_workspace  # type: ignore
-        return Path(resolve_workspace())
-    except Exception:  # noqa: BLE001 — the CLI still works with --workspace
-        return Path(os.environ.get("SUTANDO_WORKSPACE_DIR", "workspace"))
+    return Path(resolve_workspace())
 
 
 def record(args, sampler: Callable, clock=time.time, sleep=time.sleep) -> Path:
@@ -288,7 +286,7 @@ def main(argv: Optional[list] = None) -> int:
         p.add_argument("--socket", required=True)
         p.add_argument("--target", default="sutando-core")
         p.add_argument("--tmux", default="tmux")
-        p.add_argument("--workspace", default=str(_default_workspace()))
+        p.add_argument("--workspace", default=None, help="defaults to the configured workspace")
         if name == "record":
             p.add_argument("--label", required=True, help="idle | build | retry | rate-limit | …")
             p.add_argument("--seconds", type=float, default=60)
@@ -306,6 +304,8 @@ def main(argv: Optional[list] = None) -> int:
     def sampler():
         return capture_pane(a.socket, a.target, a.tmux)
 
+    if a.workspace is None:
+        a.workspace = str(_default_workspace())
     if a.cmd == "record":
         print(record(a, sampler))
         return 0

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -778,6 +778,11 @@ def check_cli_wedge() -> dict:
     tmux_bin, env = _resolve_tmux_bin(), _resolve_launch_env()
     session = record.get("session") or os.environ.get("SUTANDO_TMUX_SESSION", cli_wedge.DEFAULT_SESSION)
     target = cli_wedge.core_target(socket, session, tmux_bin=tmux_bin, env=env)
+    # A core sampling the pane it runs in sees its own output move; the static case could never accumulate.
+    inside = cli_wedge.sampled_from_inside(socket, target, tmux_bin=tmux_bin, env=env) if target else None
+    if inside:
+        check["detail"] = f"skipped — sampled from inside the pane it watches ({inside})"
+        return check
     frame = cli_wedge.capture_pane(socket, target, tmux_bin=tmux_bin, env=env) if target else None
     if frame is None:
         check["detail"] = f"pane not readable (session {session!r}) — no reading, not a verdict"

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -777,9 +777,15 @@ def check_cli_wedge() -> dict:
         check["detail"] = "pane not readable — no reading, not a verdict"
         return check
     now = time.time()
+    # Pane identity (pid:session-created) starts a new observation run after a core restart.
+    ident = _run_tmux(socket, "display-message", "-p", "-t", "=sutando-core", "#{pane_pid}:#{session_created}")
+    pane = None
+    if ident is not None and getattr(ident, "returncode", 1) == 0:
+        cand = (getattr(ident, "stdout", "") or "").strip()
+        pane = cand if re.match(r"^\d+:\d+$", cand) else None
     try:
-        entries = cli_wedge.append_window(WORKSPACE_DIR, res.stdout, now)
-        verdict = cli_wedge.classify_window(entries, cli_wedge.work_outstanding(WORKSPACE_DIR), now)
+        entries = cli_wedge.append_window(WORKSPACE_DIR, res.stdout, now, pane=pane)
+        verdict = cli_wedge.classify_window(entries, cli_wedge.work_outstanding(WORKSPACE_DIR, now), now)
     except Exception as e:  # noqa: BLE001 — an advisory check must never abort the run
         check["detail"] = f"no reading — window state unusable ({type(e).__name__}: {e})"
         return check
@@ -788,7 +794,8 @@ def check_cli_wedge() -> dict:
                        " — advisory; reads the pane, not the process")
     check["evidence"] = {k: verdict.get(k) for k in
                          ("duration", "sample_count", "novel_state_count", "novelty_rate",
-                          "matched_patterns", "work_outstanding")}
+                          "matched_patterns", "current_patterns", "consecutive_pattern_samples",
+                          "observation_runs", "median_gap_s", "work_outstanding", "work_detail")}
     return check
 
 def check_secret_scanner_mode() -> dict:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -768,14 +768,14 @@ def check_cli_wedge() -> dict:
     except Exception as e:  # noqa: BLE001 — a missing detector is a detail, not a failure
         check["detail"] = f"detector unavailable: {e}"
         return check
-    socket = _local_core_socket()
+    record = _local_core_record()
+    socket = record.get("socket") if record else None
     if not socket:
         check["detail"] = "no local core pane to read (no fresh heartbeat on this host)"
         return check
-    # The module's own capture/identity (one implementation, one target), through
-    # the same tmux binary and healed PATH every other probe here uses.
+    # Socket AND session from the SAME heartbeat record; the module's own
+    # capture/identity through the tmux binary and healed PATH every probe uses.
     tmux_bin, env = _resolve_tmux_bin(), _resolve_launch_env()
-    record = _fresh_local_core_record() or {}
     session = record.get("session") or os.environ.get("SUTANDO_TMUX_SESSION", cli_wedge.DEFAULT_SESSION)
     target = cli_wedge.core_target(socket, session, tmux_bin=tmux_bin, env=env)
     frame = cli_wedge.capture_pane(socket, target, tmux_bin=tmux_bin, env=env) if target else None
@@ -5088,6 +5088,14 @@ def _local_core_socket(workspace: Optional[Path] = None) -> Optional[str]:
     function). Returning None when this host has no fresh heartbeat is right:
     "no local core is running" is not evidence that a core bypasses the proxy.
     """
+    record = _local_core_record(workspace)
+    return record.get("socket") if record else None
+
+
+def _local_core_record(workspace: Optional[Path] = None) -> Optional[dict]:
+    """This HOST's freshest live heartbeat RECORD (multi-label, newest wins) — the
+    one object every consumer should take socket AND session from, so a probe
+    cannot pair one record's socket with another's session (or a default)."""
     if workspace is None:
         workspace = WORKSPACE_DIR
     cores_dir = workspace / "state" / "cores"
@@ -5095,7 +5103,7 @@ def _local_core_socket(workspace: Optional[Path] = None) -> Optional[str]:
         return None
     labels = _local_host_labels()
     now = time.time()
-    best_mtime, best_socket = None, None
+    best_mtime, best = None, None
     for alive_file in cores_dir.glob("*.alive"):
         if alive_file.stem not in labels:
             continue                      # another machine's heartbeat
@@ -5110,8 +5118,8 @@ def _local_core_socket(workspace: Optional[Path] = None) -> Optional[str]:
         except (OSError, ValueError):
             continue
         if isinstance(sock, str) and sock and (best_mtime is None or mtime > best_mtime):
-            best_mtime, best_socket = mtime, sock
-    return best_socket
+            best_mtime, best = mtime, payload
+    return best
 
 
 def core_env_has_proxy_url(

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -772,19 +772,17 @@ def check_cli_wedge() -> dict:
     if not socket:
         check["detail"] = "no local core pane to read (no fresh heartbeat on this host)"
         return check
-    res = _run_tmux(socket, "capture-pane", "-p", "-t", "=sutando-core")
-    if res is None or getattr(res, "returncode", 1) != 0:
+    # The module's own capture/identity (one implementation, one target), through
+    # the same tmux binary and healed PATH every other probe here uses.
+    tmux_bin, env = _resolve_tmux_bin(), _resolve_launch_env()
+    frame = cli_wedge.capture_pane(socket, cli_wedge.DEFAULT_TARGET, tmux_bin=tmux_bin, env=env)
+    if frame is None:
         check["detail"] = "pane not readable — no reading, not a verdict"
         return check
     now = time.time()
-    # Pane identity (pid:session-created) starts a new observation run after a core restart.
-    ident = _run_tmux(socket, "display-message", "-p", "-t", "=sutando-core", "#{pane_pid}:#{session_created}")
-    pane = None
-    if ident is not None and getattr(ident, "returncode", 1) == 0:
-        cand = (getattr(ident, "stdout", "") or "").strip()
-        pane = cand if re.match(r"^\d+:\d+$", cand) else None
+    pane = cli_wedge.pane_identity(socket, cli_wedge.DEFAULT_TARGET, tmux_bin=tmux_bin, env=env)
     try:
-        entries = cli_wedge.append_window(WORKSPACE_DIR, res.stdout, now, pane=pane)
+        entries = cli_wedge.append_window(WORKSPACE_DIR, frame, now, pane=pane)
         verdict = cli_wedge.classify_window(entries, cli_wedge.work_outstanding(WORKSPACE_DIR, now), now)
     except Exception as e:  # noqa: BLE001 — an advisory check must never abort the run
         check["detail"] = f"no reading — window state unusable ({type(e).__name__}: {e})"

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -752,6 +752,40 @@ def _live_bridge_interpreters(script: str, ps_output: "str | None" = None,
     return sorted(found)
 
 
+
+def check_cli_wedge() -> dict:
+    """Advisory CLI progress detector over the core's tmux pane (src/cli_wedge.py).
+
+    Case 1: normalized pane unchanged while work is outstanding. Case 2: the
+    pane moves but revisits states already seen (retry loop). It reads the
+    pane, not the process — a green here is not core health — and it only
+    ever warns: nothing keys recovery off this check.
+    """
+    check = {"name": "cli-wedge", "status": "ok", "detail": ""}
+    try:
+        import cli_wedge  # src/ is on sys.path (see the workspace_default import)
+    except Exception as e:  # noqa: BLE001 — a missing detector is a detail, not a failure
+        check["detail"] = f"detector unavailable: {e}"
+        return check
+    socket = _local_core_socket()
+    if not socket:
+        check["detail"] = "no local core pane to read (no fresh heartbeat on this host)"
+        return check
+    res = _run_tmux(socket, "capture-pane", "-p", "-t", "=sutando-core")
+    if res is None or getattr(res, "returncode", 1) != 0:
+        check["detail"] = "pane not readable — no reading, not a verdict"
+        return check
+    now = time.time()
+    entries = cli_wedge.append_window(WORKSPACE_DIR, res.stdout, now)
+    verdict = cli_wedge.classify_window(entries, cli_wedge.work_outstanding(WORKSPACE_DIR), now)
+    check["status"] = "warn" if verdict.get("warn") else "ok"
+    check["detail"] = (f"{verdict['kind']} ({verdict['confidence']}): {verdict['reason']}"
+                       " — advisory; reads the pane, not the process")
+    check["evidence"] = {k: verdict.get(k) for k in
+                         ("duration", "sample_count", "novel_state_count", "novelty_rate",
+                          "matched_patterns", "work_outstanding")}
+    return check
+
 def check_secret_scanner_mode() -> dict:
     """Report the secret scanner's DEGRADED mode as standing status.
 
@@ -11324,6 +11358,9 @@ def run_all_checks() -> list[dict]:
     checks.append(check_claude_hook_registration())
     checks.append(check_cron_runner())
     checks.append(check_session_cron_registration())
+    # Advisory CLI progress detector (pane static with work outstanding / retry
+    # loop); reads the pane, never the process, and drives no recovery.
+    checks.append(check_cli_wedge())
 
     # macOS TCC — must come before critical-file checks so if TCC is blocking
     # everything, the operator sees the root cause before the downstream failures.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -756,10 +756,11 @@ def _live_bridge_interpreters(script: str, ps_output: "str | None" = None,
 def check_cli_wedge() -> dict:
     """Advisory CLI progress detector over the core's tmux pane (src/cli_wedge.py).
 
-    Case 1: normalized pane unchanged while work is outstanding. Case 2: the
+    Case 1: the RAW pane unchanged while work is outstanding. Case 2: the
     pane moves but revisits states already seen (retry loop). It reads the
     pane, not the process — a green here is not core health — and it only
-    ever warns: nothing keys recovery off this check.
+    ever warns: nothing keys recovery off this check, and no failure inside
+    it may escape (an unwritable or corrupt window is "no reading").
     """
     check = {"name": "cli-wedge", "status": "ok", "detail": ""}
     try:
@@ -776,8 +777,12 @@ def check_cli_wedge() -> dict:
         check["detail"] = "pane not readable — no reading, not a verdict"
         return check
     now = time.time()
-    entries = cli_wedge.append_window(WORKSPACE_DIR, res.stdout, now)
-    verdict = cli_wedge.classify_window(entries, cli_wedge.work_outstanding(WORKSPACE_DIR), now)
+    try:
+        entries = cli_wedge.append_window(WORKSPACE_DIR, res.stdout, now)
+        verdict = cli_wedge.classify_window(entries, cli_wedge.work_outstanding(WORKSPACE_DIR), now)
+    except Exception as e:  # noqa: BLE001 — an advisory check must never abort the run
+        check["detail"] = f"no reading — window state unusable ({type(e).__name__}: {e})"
+        return check
     check["status"] = "warn" if verdict.get("warn") else "ok"
     check["detail"] = (f"{verdict['kind']} ({verdict['confidence']}): {verdict['reason']}"
                        " — advisory; reads the pane, not the process")

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -775,12 +775,15 @@ def check_cli_wedge() -> dict:
     # The module's own capture/identity (one implementation, one target), through
     # the same tmux binary and healed PATH every other probe here uses.
     tmux_bin, env = _resolve_tmux_bin(), _resolve_launch_env()
-    frame = cli_wedge.capture_pane(socket, cli_wedge.DEFAULT_TARGET, tmux_bin=tmux_bin, env=env)
+    record = _fresh_local_core_record() or {}
+    session = record.get("session") or os.environ.get("SUTANDO_TMUX_SESSION", cli_wedge.DEFAULT_SESSION)
+    target = cli_wedge.core_target(socket, session, tmux_bin=tmux_bin, env=env)
+    frame = cli_wedge.capture_pane(socket, target, tmux_bin=tmux_bin, env=env) if target else None
     if frame is None:
-        check["detail"] = "pane not readable — no reading, not a verdict"
+        check["detail"] = f"pane not readable (session {session!r}) — no reading, not a verdict"
         return check
     now = time.time()
-    pane = cli_wedge.pane_identity(socket, cli_wedge.DEFAULT_TARGET, tmux_bin=tmux_bin, env=env)
+    pane = cli_wedge.pane_identity(socket, target, tmux_bin=tmux_bin, env=env)
     try:
         entries = cli_wedge.append_window(WORKSPACE_DIR, frame, now, pane=pane)
         verdict = cli_wedge.classify_window(entries, cli_wedge.work_outstanding(WORKSPACE_DIR, now), now)

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -8,6 +8,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -43,8 +44,13 @@ class CliWedgeProbe(unittest.TestCase):
             "import sys, pathlib\n"
             "a = sys.argv\n"
             "t = a[a.index('-t') + 1] if '-t' in a else ''\n"
-            "if t == '=sutando-core':\n"
-            "    sys.stderr.write(\"can't find pane: =sutando-core\\n\"); sys.exit(1)\n"
+            "import os\n"
+            "sess = os.environ.get('FAKE_SESSION', 'sutando-core')\n"
+            "if 'list-windows' in a:\n"
+            "    ok = t == '=' + sess\n"
+            "    print('1\\n2') if ok else sys.stderr.write('no such session\\n'); sys.exit(0 if ok else 1)\n"
+            "if t != '=' + sess + ':1':\n"  # base-index 1: the core window is 1, and a bare =name is no pane
+            "    sys.stderr.write(\"can't find pane: \" + t + \"\\n\"); sys.exit(1)\n"
             "if 'display-message' in a:\n"
             "    print('4242:1788000000'); sys.exit(0)\n"
             f"ff = pathlib.Path({str(self.frames_file)!r}); idx = pathlib.Path({str(self.idx)!r})\n"
@@ -56,6 +62,8 @@ class CliWedgeProbe(unittest.TestCase):
         self.tmux.chmod(0o755)
         hc._resolve_tmux_bin = lambda *a, **k: str(self.tmux)
         hc._resolve_launch_env = lambda: dict(os.environ)
+        self._saved_record = hc._fresh_local_core_record
+        hc._fresh_local_core_record = lambda *a, **k: {"session": "sutando-core", "socket": "/tmp/fake.sock"}
 
     def _serve(self):
         self.frames_file.write_text("\n===\n".join(self.frames))
@@ -69,6 +77,7 @@ class CliWedgeProbe(unittest.TestCase):
 
     def tearDown(self):
         hc.WORKSPACE_DIR, hc._local_core_socket, hc._resolve_tmux_bin, hc._resolve_launch_env = self._saved
+        hc._fresh_local_core_record = self._saved_record
         self.tmp.cleanup()
 
     def test_missing_detector_module_is_a_detail_not_a_failure(self):
@@ -144,15 +153,30 @@ class CliWedgeProbe(unittest.TestCase):
         self.assertIn("idle", c["detail"])
         self.assertFalse(c["evidence"]["work_outstanding"])
 
-    def test_target_is_the_exact_session_window_not_a_bare_pane_name(self):
-        # With a second window in the session `-t =sutando-core` stops resolving and the probe
-        # was inert; the fake rejects that target exactly as tmux does — the check must still read.
-        import cli_wedge
-        self.assertEqual(cli_wedge.DEFAULT_TARGET, "=sutando-core:0")
+    def test_target_is_the_heartbeat_session_and_its_lowest_window_not_window_0(self):
+        # The fake server has base-index 1 (windows 1 and 2) and rejects both a bare `=name`
+        # and `:0`; the check must resolve `=sutando-core:1` from list-windows and read.
         for _ in range(3):
             c = self.check()
         self.assertNotIn("not readable", c["detail"])
         self.assertEqual(c["evidence"]["sample_count"], 3)
+
+    def test_session_name_comes_from_the_heartbeat_not_a_hardcode(self):
+        # Control for the adjacent hardcode: a core launched as `custom-core` (SUTANDO_TMUX_SESSION)
+        # is what the fresh heartbeat records; the fake server knows only that session.
+        hc._fresh_local_core_record = lambda *a, **k: {"session": "custom-core", "socket": "/tmp/fake.sock"}
+        with patch.dict(os.environ, {"FAKE_SESSION": "custom-core"}):
+            for _ in range(2):
+                c = self.check()
+        self.assertNotIn("not readable", c["detail"])
+        self.assertEqual(c["evidence"]["sample_count"], 2)
+        # …and with the heartbeat silent about the session, the default name is tried and misses
+        hc._fresh_local_core_record = lambda *a, **k: None
+        with patch.dict(os.environ, {"FAKE_SESSION": "custom-core"}, clear=False):
+            os.environ.pop("SUTANDO_TMUX_SESSION", None)
+            c2 = self.check()
+        self.assertIn("not readable", c2["detail"])
+        self.assertIn("sutando-core", c2["detail"])
 
     def test_working_pane_is_ok(self):
         self.frames = [f"● wrote {chr(97 + i)}.ts\n" for i in range(12)]

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -29,30 +29,53 @@ class CliWedgeProbe(unittest.TestCase):
         (ws / "state").mkdir()
         (ws / "tasks").mkdir()
         self.ws = ws
-        self._saved = (hc.WORKSPACE_DIR, hc._local_core_socket, hc._run_tmux)
+        self._saved = (hc.WORKSPACE_DIR, hc._local_core_socket, hc._resolve_tmux_bin, hc._resolve_launch_env)
         hc.WORKSPACE_DIR = ws
         hc._local_core_socket = lambda *a, **k: "/tmp/fake.sock"
         self.frames = [IDLE]
-        # capture-pane serves the next frame; the identity probe answers like a real pane
-        hc._run_tmux = lambda sock, *args: (
-            SimpleNamespace(returncode=0, stdout=self.frames[min(self.calls(), len(self.frames) - 1)])
-            if "capture-pane" in args else SimpleNamespace(returncode=0, stdout="4242:1788000000\n"))
-        self._n = 0
+        # A stand-in tmux BINARY drives the real capture/identity: next frame per capture,
+        # a real-looking identity, and — like tmux with two windows — no bare `=sutando-core`.
+        self.frames_file = ws / "frames.txt"
+        self.idx = ws / "frames.idx"
+        self.tmux = ws / "tmux"
+        self.tmux.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys, pathlib\n"
+            "a = sys.argv\n"
+            "t = a[a.index('-t') + 1] if '-t' in a else ''\n"
+            "if t == '=sutando-core':\n"
+            "    sys.stderr.write(\"can't find pane: =sutando-core\\n\"); sys.exit(1)\n"
+            "if 'display-message' in a:\n"
+            "    print('4242:1788000000'); sys.exit(0)\n"
+            f"ff = pathlib.Path({str(self.frames_file)!r}); idx = pathlib.Path({str(self.idx)!r})\n"
+            "frames = ff.read_text().split('\\n===\\n')\n"
+            "i = int(idx.read_text()) if idx.exists() else 0\n"
+            "idx.write_text(str(i + 1))\n"
+            "sys.stdout.write(frames[min(i, len(frames) - 1)])\n"
+        )
+        self.tmux.chmod(0o755)
+        hc._resolve_tmux_bin = lambda *a, **k: str(self.tmux)
+        hc._resolve_launch_env = lambda: dict(os.environ)
 
-    def calls(self):
-        n = self._n
-        self._n += 1
-        return n
+    def _serve(self):
+        self.frames_file.write_text("\n===\n".join(self.frames))
+        if self.idx.exists():
+            self.idx.unlink()
+
+    def check(self):
+        if not self.frames_file.exists():
+            self._serve()
+        return hc.check_cli_wedge()
 
     def tearDown(self):
-        hc.WORKSPACE_DIR, hc._local_core_socket, hc._run_tmux = self._saved
+        hc.WORKSPACE_DIR, hc._local_core_socket, hc._resolve_tmux_bin, hc._resolve_launch_env = self._saved
         self.tmp.cleanup()
 
     def test_missing_detector_module_is_a_detail_not_a_failure(self):
         saved = sys.modules.get("cli_wedge")
         sys.modules["cli_wedge"] = None  # makes `import cli_wedge` raise
         try:
-            c = hc.check_cli_wedge()
+            c = self.check()
         finally:
             if saved is None:
                 sys.modules.pop("cli_wedge", None)
@@ -63,32 +86,32 @@ class CliWedgeProbe(unittest.TestCase):
 
     def test_unwritable_window_is_no_reading_not_a_crash(self):
         (self.ws / "state" / "cli-wedge" / "window.jsonl").mkdir(parents=True)  # path occupied: the write must fail
-        c = hc.check_cli_wedge()
+        c = self.check()
         self.assertEqual(c["status"], "ok")
         self.assertIn("no reading", c["detail"])
 
     def test_malformed_window_lines_do_not_crash_the_check(self):
         (self.ws / "state" / "cli-wedge").mkdir()
         (self.ws / "state" / "cli-wedge" / "window.jsonl").write_text("[]\n" + json.dumps({"ts": "x", "state": "s"}) + "\n{bad\n")
-        c = hc.check_cli_wedge()
+        c = self.check()
         self.assertIn(c["status"], ("ok", "warn"))
         self.assertIn(c["name"], ("cli-wedge",))
 
     def test_no_local_core_is_ok_and_says_so(self):
         hc._local_core_socket = lambda *a, **k: None
-        c = hc.check_cli_wedge()
+        c = self.check()
         self.assertEqual((c["name"], c["status"]), ("cli-wedge", "ok"))
         self.assertIn("no local core pane", c["detail"])
 
     def test_unreadable_pane_is_ok_not_a_verdict(self):
-        hc._run_tmux = lambda *a: None
-        c = hc.check_cli_wedge()
+        hc._resolve_tmux_bin = lambda *a, **k: "/nonexistent/tmux"
+        c = self.check()
         self.assertEqual(c["status"], "ok")
         self.assertIn("not a verdict", c["detail"])
 
     def test_idle_pane_never_warns(self):
         for _ in range(3):
-            c = hc.check_cli_wedge()
+            c = self.check()
         self.assertEqual(c["status"], "ok")
         self.assertIn("idle", c["detail"])
         self.assertEqual(c["evidence"]["sample_count"], 3)
@@ -97,7 +120,7 @@ class CliWedgeProbe(unittest.TestCase):
         import time as _t
         (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": _t.time()}))
         for _ in range(3):
-            c = hc.check_cli_wedge()
+            c = self.check()
         self.assertEqual(c["status"], "warn")
         self.assertIn("static-with-work", c["detail"])
         self.assertTrue(c["evidence"]["work_outstanding"])
@@ -107,7 +130,7 @@ class CliWedgeProbe(unittest.TestCase):
         self.frames = [f"Connection error. Retrying in {3 * (i % 3)}s (attempt {i}/10) 04:2{i % 10}:11\n" for i in range(12)]
         (self.ws / "tasks" / "task-1.txt").write_text("task: x\n")
         for _ in range(12):
-            c = hc.check_cli_wedge()
+            c = self.check()
         self.assertEqual(c["status"], "warn")
         self.assertIn("retry-loop", c["detail"])
         self.assertIn("retrying", c["evidence"]["matched_patterns"])
@@ -116,15 +139,25 @@ class CliWedgeProbe(unittest.TestCase):
         # graceful-restart's contract: "running" stamped long ago is a crashed core, not work.
         (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": 1.0}))
         for _ in range(3):
-            c = hc.check_cli_wedge()
+            c = self.check()
         self.assertEqual(c["status"], "ok")
         self.assertIn("idle", c["detail"])
         self.assertFalse(c["evidence"]["work_outstanding"])
 
+    def test_target_is_the_exact_session_window_not_a_bare_pane_name(self):
+        # With a second window in the session `-t =sutando-core` stops resolving and the probe
+        # was inert; the fake rejects that target exactly as tmux does — the check must still read.
+        import cli_wedge
+        self.assertEqual(cli_wedge.DEFAULT_TARGET, "=sutando-core:0")
+        for _ in range(3):
+            c = self.check()
+        self.assertNotIn("not readable", c["detail"])
+        self.assertEqual(c["evidence"]["sample_count"], 3)
+
     def test_working_pane_is_ok(self):
         self.frames = [f"● wrote {chr(97 + i)}.ts\n" for i in range(12)]
         for _ in range(12):
-            c = hc.check_cli_wedge()
+            c = self.check()
         self.assertEqual(c["status"], "ok")
         self.assertIn("working", c["detail"])
 

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""health-check's cli-wedge probe: absent socket / unreadable pane are readings
+of nothing (ok), a static pane with work outstanding warns, a retry loop warns,
+and idle never does. The tmux and heartbeat seams are replaced with fakes."""
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+try:
+    spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+IDLE = "❯ \n⏵⏵ bypass permissions on · 12:01:05 PM · 1 monitor\n"
+
+
+class CliWedgeProbe(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        ws = Path(self.tmp.name)
+        (ws / "state").mkdir()
+        (ws / "tasks").mkdir()
+        self.ws = ws
+        self._saved = (hc.WORKSPACE_DIR, hc._local_core_socket, hc._run_tmux)
+        hc.WORKSPACE_DIR = ws
+        hc._local_core_socket = lambda *a, **k: "/tmp/fake.sock"
+        self.frames = [IDLE]
+        hc._run_tmux = lambda sock, *args: SimpleNamespace(returncode=0, stdout=self.frames[min(self.calls(), len(self.frames) - 1)])
+        self._n = 0
+
+    def calls(self):
+        n = self._n
+        self._n += 1
+        return n
+
+    def tearDown(self):
+        hc.WORKSPACE_DIR, hc._local_core_socket, hc._run_tmux = self._saved
+        self.tmp.cleanup()
+
+    def test_no_local_core_is_ok_and_says_so(self):
+        hc._local_core_socket = lambda *a, **k: None
+        c = hc.check_cli_wedge()
+        self.assertEqual((c["name"], c["status"]), ("cli-wedge", "ok"))
+        self.assertIn("no local core pane", c["detail"])
+
+    def test_unreadable_pane_is_ok_not_a_verdict(self):
+        hc._run_tmux = lambda *a: None
+        c = hc.check_cli_wedge()
+        self.assertEqual(c["status"], "ok")
+        self.assertIn("not a verdict", c["detail"])
+
+    def test_idle_pane_never_warns(self):
+        for _ in range(3):
+            c = hc.check_cli_wedge()
+        self.assertEqual(c["status"], "ok")
+        self.assertIn("idle", c["detail"])
+        self.assertEqual(c["evidence"]["sample_count"], 3)
+
+    def test_static_pane_with_work_outstanding_warns(self):
+        (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running"}))
+        for _ in range(3):
+            c = hc.check_cli_wedge()
+        self.assertEqual(c["status"], "warn")
+        self.assertIn("static-with-work", c["detail"])
+        self.assertTrue(c["evidence"]["work_outstanding"])
+        self.assertIn("reads the pane, not the process", c["detail"])
+
+    def test_retry_loop_warns_even_when_the_pane_moves(self):
+        self.frames = [f"Connection error. Retrying in {3 * (i % 3)}s (attempt {i}/10) 04:2{i % 10}:11\n" for i in range(12)]
+        (self.ws / "tasks" / "task-1.txt").write_text("task: x\n")
+        for _ in range(12):
+            c = hc.check_cli_wedge()
+        self.assertEqual(c["status"], "warn")
+        self.assertIn("retry-loop", c["detail"])
+        self.assertIn("retrying", c["evidence"]["matched_patterns"])
+
+    def test_working_pane_is_ok(self):
+        self.frames = [f"● wrote {chr(97 + i)}.ts\n" for i in range(12)]
+        for _ in range(12):
+            c = hc.check_cli_wedge()
+        self.assertEqual(c["status"], "ok")
+        self.assertIn("working", c["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -18,7 +18,7 @@ try:
 except SystemExit:
     pass
 
-IDLE = "❯ \n⏵⏵ bypass permissions on · 12:01:05 PM · 1 monitor\n"
+IDLE = "❯ \n⏵⏵ bypass permissions on · 1 monitor\n"
 
 
 class CliWedgeProbe(unittest.TestCase):

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -33,7 +33,10 @@ class CliWedgeProbe(unittest.TestCase):
         hc.WORKSPACE_DIR = ws
         hc._local_core_socket = lambda *a, **k: "/tmp/fake.sock"
         self.frames = [IDLE]
-        hc._run_tmux = lambda sock, *args: SimpleNamespace(returncode=0, stdout=self.frames[min(self.calls(), len(self.frames) - 1)])
+        # capture-pane serves the next frame; the identity probe answers like a real pane
+        hc._run_tmux = lambda sock, *args: (
+            SimpleNamespace(returncode=0, stdout=self.frames[min(self.calls(), len(self.frames) - 1)])
+            if "capture-pane" in args else SimpleNamespace(returncode=0, stdout="4242:1788000000\n"))
         self._n = 0
 
     def calls(self):
@@ -91,7 +94,8 @@ class CliWedgeProbe(unittest.TestCase):
         self.assertEqual(c["evidence"]["sample_count"], 3)
 
     def test_static_pane_with_work_outstanding_warns(self):
-        (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running"}))
+        import time as _t
+        (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": _t.time()}))
         for _ in range(3):
             c = hc.check_cli_wedge()
         self.assertEqual(c["status"], "warn")
@@ -107,6 +111,15 @@ class CliWedgeProbe(unittest.TestCase):
         self.assertEqual(c["status"], "warn")
         self.assertIn("retry-loop", c["detail"])
         self.assertIn("retrying", c["evidence"]["matched_patterns"])
+
+    def test_stale_running_status_is_not_work(self):
+        # graceful-restart's contract: "running" stamped long ago is a crashed core, not work.
+        (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": 1.0}))
+        for _ in range(3):
+            c = hc.check_cli_wedge()
+        self.assertEqual(c["status"], "ok")
+        self.assertIn("idle", c["detail"])
+        self.assertFalse(c["evidence"]["work_outstanding"])
 
     def test_working_pane_is_ok(self):
         self.frames = [f"● wrote {chr(97 + i)}.ts\n" for i in range(12)]

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -207,10 +207,25 @@ class CliWedgeProbe(unittest.TestCase):
         self.assertTrue(c["detail"].startswith("skipped — sampled from inside the pane it watches"), c["detail"])
         self.assertFalse((self.ws / "state" / "cli-wedge" / "window.jsonl").exists(), "a skipped sample must not be recorded")
 
-    def test_tmux_pane_naming_the_target_is_skipped(self):
-        with patch.dict(os.environ, {"TMUX_PANE": "%987654"}):
+    def test_tmux_pane_naming_the_target_on_the_core_server_is_skipped(self):
+        # $TMUX names the socket the pane id belongs to; here it is the core's own.
+        with patch.dict(os.environ, {"TMUX_PANE": "%987654", "TMUX": "/tmp/fake.sock,123,0"}):
             c = self.check()
         self.assertTrue(c["detail"].startswith("skipped — sampled from inside the pane it watches"), c["detail"])
+        self.assertFalse((self.ws / "state" / "cli-wedge" / "window.jsonl").exists())
+
+    def test_same_pane_id_on_another_tmux_server_still_samples(self):
+        # Pane ids are per server: %987654 on a different socket is not the core pane.
+        with patch.dict(os.environ, {"TMUX_PANE": "%987654", "TMUX": "/tmp/other.sock,999,0"}):
+            c = self.check()
+        self.assertFalse(c["detail"].startswith("skipped"), c["detail"])
+        self.assertTrue((self.ws / "state" / "cli-wedge" / "window.jsonl").exists())
+
+    def test_tmux_pane_without_a_server_binding_does_not_skip(self):
+        with patch.dict(os.environ, {"TMUX_PANE": "%987654"}, clear=False):
+            os.environ.pop("TMUX", None)
+            c = self.check()
+        self.assertFalse(c["detail"].startswith("skipped"), c["detail"])
 
     def test_an_outside_caller_still_samples(self):
         with patch.dict(os.environ, {"TMUX_PANE": "%1"}):

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -30,9 +30,21 @@ class CliWedgeProbe(unittest.TestCase):
         (ws / "state").mkdir()
         (ws / "tasks").mkdir()
         self.ws = ws
-        self._saved = (hc.WORKSPACE_DIR, hc._local_core_socket, hc._resolve_tmux_bin, hc._resolve_launch_env)
+        self._saved = (hc.WORKSPACE_DIR, hc._resolve_tmux_bin, hc._resolve_launch_env)
+        # The check reads time.time(); the fake clock advances 60 s per beat so runs last.
+        self._saved_time = hc.time
+        import time as _time
+        self._t = [_time.time()]
+        def _now():
+            self._t[0] += 60.0
+            return self._t[0]
+        hc.time = SimpleNamespace(time=_now)
         hc.WORKSPACE_DIR = ws
-        hc._local_core_socket = lambda *a, **k: "/tmp/fake.sock"
+        # A REAL fresh heartbeat under an accepted local label; socket and session both come from it.
+        (ws / "state" / "cores").mkdir()
+        self._saved_labels = hc._local_host_labels
+        hc._local_host_labels = lambda *a, **k: {"canon", "alias"}
+        self.write_alive("canon", "/tmp/fake.sock", "sutando-core")
         self.frames = [IDLE]
         # A stand-in tmux BINARY drives the real capture/identity: next frame per capture,
         # a real-looking identity, and — like tmux with two windows — no bare `=sutando-core`.
@@ -62,15 +74,13 @@ class CliWedgeProbe(unittest.TestCase):
         self.tmux.chmod(0o755)
         hc._resolve_tmux_bin = lambda *a, **k: str(self.tmux)
         hc._resolve_launch_env = lambda: dict(os.environ)
-        # The check reads time.time(); the fake clock advances 60 s per beat so runs last.
-        self._saved_time = hc.time
-        self._t = [1_000_000.0]
-        def _now():
-            self._t[0] += 60.0
-            return self._t[0]
-        hc.time = SimpleNamespace(time=_now)
-        self._saved_record = hc._fresh_local_core_record
-        hc._fresh_local_core_record = lambda *a, **k: {"session": "sutando-core", "socket": "/tmp/fake.sock"}
+
+    def write_alive(self, label, socket, session):
+        import time as _time
+        p = self.ws / "state" / "cores" / f"{label}.alive"
+        p.write_text(json.dumps({"host": label, "socket": socket, "session": session, "status": "running", "schema_version": 3}))
+        os.utime(p, (self._t[0] + 30, self._t[0] + 30))  # fresh on the fake clock
+        return p
 
     def _serve(self):
         self.frames_file.write_text("\n===\n".join(self.frames))
@@ -80,11 +90,14 @@ class CliWedgeProbe(unittest.TestCase):
     def check(self):
         if not self.frames_file.exists():
             self._serve()
+        # A live core beats between passes: keep every heartbeat file fresh on the fake clock.
+        for p in (self.ws / "state" / "cores").glob("*.alive"):
+            os.utime(p, (self._t[0] + 30, self._t[0] + 30))
         return hc.check_cli_wedge()
 
     def tearDown(self):
-        hc.WORKSPACE_DIR, hc._local_core_socket, hc._resolve_tmux_bin, hc._resolve_launch_env = self._saved
-        hc._fresh_local_core_record = self._saved_record
+        hc.WORKSPACE_DIR, hc._resolve_tmux_bin, hc._resolve_launch_env = self._saved
+        hc._local_host_labels = self._saved_labels
         hc.time = self._saved_time
         self.tmp.cleanup()
 
@@ -115,7 +128,7 @@ class CliWedgeProbe(unittest.TestCase):
         self.assertIn(c["name"], ("cli-wedge",))
 
     def test_no_local_core_is_ok_and_says_so(self):
-        hc._local_core_socket = lambda *a, **k: None
+        (self.ws / "state" / "cores" / "canon.alive").unlink()
         c = self.check()
         self.assertEqual((c["name"], c["status"]), ("cli-wedge", "ok"))
         self.assertIn("no local core pane", c["detail"])
@@ -168,22 +181,21 @@ class CliWedgeProbe(unittest.TestCase):
         self.assertNotIn("not readable", c["detail"])
         self.assertEqual(c["evidence"]["sample_count"], 3)
 
-    def test_session_name_comes_from_the_heartbeat_not_a_hardcode(self):
-        # Control for the adjacent hardcode: a core launched as `custom-core` (SUTANDO_TMUX_SESSION)
-        # is what the fresh heartbeat records; the fake server knows only that session.
-        hc._fresh_local_core_record = lambda *a, **k: {"session": "custom-core", "socket": "/tmp/fake.sock"}
+    def test_socket_and_session_come_from_the_same_record_even_under_an_alternate_label(self):
+        # The socket came from the multi-label resolver and the session from the canonical-label
+        # reader, so an ALIAS heartbeat gave the socket but not its session; one record feeds both.
+        (self.ws / "state" / "cores" / "canon.alive").unlink()
+        self.write_alive("alias", "/tmp/fake.sock", "custom-core")
         with patch.dict(os.environ, {"FAKE_SESSION": "custom-core"}):
             for _ in range(2):
                 c = self.check()
         self.assertNotIn("not readable", c["detail"])
         self.assertEqual(c["evidence"]["sample_count"], 2)
-        # …and with the heartbeat silent about the session, the default name is tried and misses
-        hc._fresh_local_core_record = lambda *a, **k: None
-        with patch.dict(os.environ, {"FAKE_SESSION": "custom-core"}, clear=False):
-            os.environ.pop("SUTANDO_TMUX_SESSION", None)
-            c2 = self.check()
-        self.assertIn("not readable", c2["detail"])
-        self.assertIn("sutando-core", c2["detail"])
+        # two fresh records: the NEWER one supplies both fields, never a mix
+        newer = self.write_alive("canon", "/tmp/newer.sock", "newer-core")
+        os.utime(newer, (self._t[0] + 35, self._t[0] + 35))
+        rec = hc._local_core_record()
+        self.assertEqual((rec["socket"], rec["session"]), ("/tmp/newer.sock", "newer-core"))
 
     def test_working_pane_is_ok(self):
         self.frames = [f"● wrote {chr(97 + i)}.ts\n" for i in range(12)]

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -62,6 +62,13 @@ class CliWedgeProbe(unittest.TestCase):
         self.tmux.chmod(0o755)
         hc._resolve_tmux_bin = lambda *a, **k: str(self.tmux)
         hc._resolve_launch_env = lambda: dict(os.environ)
+        # The check reads time.time(); the fake clock advances 60 s per beat so runs last.
+        self._saved_time = hc.time
+        self._t = [1_000_000.0]
+        def _now():
+            self._t[0] += 60.0
+            return self._t[0]
+        hc.time = SimpleNamespace(time=_now)
         self._saved_record = hc._fresh_local_core_record
         hc._fresh_local_core_record = lambda *a, **k: {"session": "sutando-core", "socket": "/tmp/fake.sock"}
 
@@ -78,6 +85,7 @@ class CliWedgeProbe(unittest.TestCase):
     def tearDown(self):
         hc.WORKSPACE_DIR, hc._local_core_socket, hc._resolve_tmux_bin, hc._resolve_launch_env = self._saved
         hc._fresh_local_core_record = self._saved_record
+        hc.time = self._saved_time
         self.tmp.cleanup()
 
     def test_missing_detector_module_is_a_detail_not_a_failure(self):
@@ -126,8 +134,7 @@ class CliWedgeProbe(unittest.TestCase):
         self.assertEqual(c["evidence"]["sample_count"], 3)
 
     def test_static_pane_with_work_outstanding_warns(self):
-        import time as _t
-        (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": _t.time()}))
+        (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": self._t[0] + 60.0}))
         for _ in range(3):
             c = self.check()
         self.assertEqual(c["status"], "warn")

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -64,7 +64,8 @@ class CliWedgeProbe(unittest.TestCase):
             "if t != '=' + sess + ':1':\n"  # base-index 1: the core window is 1, and a bare =name is no pane
             "    sys.stderr.write(\"can't find pane: \" + t + \"\\n\"); sys.exit(1)\n"
             "if 'display-message' in a:\n"
-            "    print('4242:1788000000'); sys.exit(0)\n"
+            "    fmt = a[-1]\n"
+            "    print(os.environ.get('FAKE_PANE_ID', '%987654') + ':' + os.environ.get('FAKE_PANE_PID', '4242')) if 'pane_id' in fmt else print('4242:1788000000'); sys.exit(0)\n"
             f"ff = pathlib.Path({str(self.frames_file)!r}); idx = pathlib.Path({str(self.idx)!r})\n"
             "frames = ff.read_text().split('\\n===\\n')\n"
             "i = int(idx.read_text()) if idx.exists() else 0\n"
@@ -196,6 +197,26 @@ class CliWedgeProbe(unittest.TestCase):
         os.utime(newer, (self._t[0] + 35, self._t[0] + 35))
         rec = hc._local_core_record()
         self.assertEqual((rec["socket"], rec["session"]), ("/tmp/newer.sock", "newer-core"))
+
+    def test_sampling_from_inside_the_watched_pane_is_skipped(self):
+        # The stand-in names THIS process as the pane shell: a core sampling its own pane must not.
+        self.frames = [IDLE] * 4
+        with patch.dict(os.environ, {"FAKE_PANE_PID": str(os.getpid()), "TMUX_PANE": "%1"}):
+            c = self.check()
+        self.assertEqual(c["status"], "ok")
+        self.assertTrue(c["detail"].startswith("skipped — sampled from inside the pane it watches"), c["detail"])
+        self.assertFalse((self.ws / "state" / "cli-wedge" / "window.jsonl").exists(), "a skipped sample must not be recorded")
+
+    def test_tmux_pane_naming_the_target_is_skipped(self):
+        with patch.dict(os.environ, {"TMUX_PANE": "%987654"}):
+            c = self.check()
+        self.assertTrue(c["detail"].startswith("skipped — sampled from inside the pane it watches"), c["detail"])
+
+    def test_an_outside_caller_still_samples(self):
+        with patch.dict(os.environ, {"TMUX_PANE": "%1"}):
+            c = self.check()
+        self.assertFalse(c["detail"].startswith("skipped"), c["detail"])
+        self.assertTrue((self.ws / "state" / "cli-wedge" / "window.jsonl").exists())
 
     def test_working_pane_is_ok(self):
         self.frames = [f"● wrote {chr(97 + i)}.ts\n" for i in range(12)]

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -4,6 +4,7 @@ of nothing (ok), a static pane with work outstanding warns, a retry loop warns,
 and idle never does. The tmux and heartbeat seams are replaced with fakes."""
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -56,6 +57,19 @@ class CliWedgeProbe(unittest.TestCase):
                 sys.modules["cli_wedge"] = saved
         self.assertEqual(c["status"], "ok")
         self.assertIn("detector unavailable", c["detail"])
+
+    def test_unwritable_window_is_no_reading_not_a_crash(self):
+        (self.ws / "state" / "cli-wedge" / "window.jsonl").mkdir(parents=True)  # path occupied: the write must fail
+        c = hc.check_cli_wedge()
+        self.assertEqual(c["status"], "ok")
+        self.assertIn("no reading", c["detail"])
+
+    def test_malformed_window_lines_do_not_crash_the_check(self):
+        (self.ws / "state" / "cli-wedge").mkdir()
+        (self.ws / "state" / "cli-wedge" / "window.jsonl").write_text("[]\n" + json.dumps({"ts": "x", "state": "s"}) + "\n{bad\n")
+        c = hc.check_cli_wedge()
+        self.assertIn(c["status"], ("ok", "warn"))
+        self.assertIn(c["name"], ("cli-wedge",))
 
     def test_no_local_core_is_ok_and_says_so(self):
         hc._local_core_socket = lambda *a, **k: None

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -44,6 +44,19 @@ class CliWedgeProbe(unittest.TestCase):
         hc.WORKSPACE_DIR, hc._local_core_socket, hc._run_tmux = self._saved
         self.tmp.cleanup()
 
+    def test_missing_detector_module_is_a_detail_not_a_failure(self):
+        saved = sys.modules.get("cli_wedge")
+        sys.modules["cli_wedge"] = None  # makes `import cli_wedge` raise
+        try:
+            c = hc.check_cli_wedge()
+        finally:
+            if saved is None:
+                sys.modules.pop("cli_wedge", None)
+            else:
+                sys.modules["cli_wedge"] = saved
+        self.assertEqual(c["status"], "ok")
+        self.assertIn("detector unavailable", c["detail"])
+
     def test_no_local_core_is_ok_and_says_so(self):
         hc._local_core_socket = lambda *a, **k: None
         c = hc.check_cli_wedge()

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -277,11 +277,27 @@ class IoEdge(unittest.TestCase):
         entries = [e(3600.0 * i) for i in range(6)]
         v = w.classify_window(entries, (True, "1 queued task(s)"), 3600.0 * 5 + 10)
         self.assertEqual((v["kind"], v["warn"], v["observation_runs"], v["run_samples"]), ("cadence-too-sparse", False, 6, 1))
-        self.assertEqual(v["window_median_gap_s"], 3600.0)
+        self.assertEqual((v["window_median_gap_s"], v["recent_gap_s"]), (3600.0, 3600.0))
         self.assertIn("cannot be observed at this rate", v["reason"])
         # the same pane sampled inside the limit is a plain case-1 warning
         dense = [e(1800.0 * i) for i in range(6)]
         self.assertEqual(w.classify_window(dense, (True, "x"), 1800.0 * 5 + 10)["kind"], "static-with-work")
+
+    def test_a_cadence_change_is_judged_on_the_recent_gaps_not_the_window_median(self):
+        # Codex on 8ada45a: 15 half-hourly samples then 5 hourly ones kept the window median
+        # at 1800 s, so the verdict stayed "unknown" for half the window. Recent gaps decide.
+        e = lambda ts: {"ts": ts, "state": "a", "raw_state": "a", "patterns": []}
+        dense = [e(1800.0 * i) for i in range(15)]
+        t0 = dense[-1]["ts"]
+        sparse = [e(t0 + 3600.0 * i) for i in range(1, 6)]
+        v = w.classify_window(dense + sparse, (True, "x"), sparse[-1]["ts"] + 10)
+        self.assertEqual(v["kind"], "cadence-too-sparse")
+        self.assertEqual(v["window_median_gap_s"], 1800.0)   # the window still remembers the dense era…
+        self.assertEqual(v["recent_gap_s"], 3600.0)          # …but the decision reads the recent one
+        self.assertEqual(v["observation_runs"], 6)
+        # two hourly samples after the dense era are not yet a cadence (one gap is a gap)
+        v2 = w.classify_window(dense + sparse[:2], (True, "x"), sparse[1]["ts"] + 10)
+        self.assertEqual(v2["kind"], "unknown")
 
     def test_a_new_pane_identity_starts_a_new_run(self):
         e = lambda ts, pane: {"ts": ts, "state": "a", "raw_state": "a", "patterns": [], "pane": pane}

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -271,7 +271,8 @@ class Cli(unittest.TestCase):
     def test_entry_point_runs_as_a_script(self):
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "t.jsonl"
-            p.write_text(json.dumps({"ts": 1, "normalized": "a"}) + "\n" + json.dumps({"ts": 2, "normalized": "b"}) + "\n")
+            p.write_text(json.dumps({"ts": 1, "state": "s1", "raw_state": "r1", "patterns": []}) + "\n"
+                         + json.dumps({"ts": 2, "state": "s2", "raw_state": "r2", "patterns": []}) + "\n")
             r = subprocess.run([sys.executable, str(REPO / "src" / "cli_wedge.py"), "replay", str(p)], capture_output=True, text=True)
             self.assertEqual(r.returncode, 0, r.stderr)
             self.assertEqual(json.loads(r.stdout)["kind"], "working")
@@ -294,8 +295,90 @@ class Cli(unittest.TestCase):
     def test_replay_skips_corrupt_lines(self):
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "t.jsonl"
-            p.write_text("{bad\n" + json.dumps({"ts": 1, "normalized": "a"}) + "\n")
+            p.write_text("{bad\n" + json.dumps({"ts": 1, "state": "s1", "patterns": []}) + "\n")
             self.assertEqual(w.replay(p)["kind"], "unknown")
+
+    def test_record_stores_no_text_unless_asked(self):
+        args = SimpleNamespace(workspace=tempfile.mkdtemp(), label="idle", seconds=3, interval=0, max_samples=3, keep_raw=False)
+        t = [0.0]
+
+        def clock():
+            t[0] += 1.0
+            return t[0]
+
+        path = w.record(args, lambda: IDLE, clock=clock, sleep=lambda s: None)
+        first = json.loads(path.read_text().splitlines()[0])
+        self.assertEqual(sorted(first), ["patterns", "raw_state", "state", "ts"])
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+        self.assertEqual(stat.S_IMODE(path.parent.stat().st_mode), 0o700)
+        args2 = SimpleNamespace(**{**vars(args), "keep_normalized": True})
+        path2 = w.record(args2, lambda: IDLE, clock=clock, sleep=lambda s: None)
+        self.assertIn("normalized", json.loads(path2.read_text().splitlines()[0]))
+
+    def test_replay_classifies_a_hash_only_trace(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "t.jsonl"
+            lines = [json.dumps({"ts": float(i), "state": "same", "raw_state": f"r{i}", "patterns": ["retrying"]}) for i in range(12)]
+            p.write_text("\n".join(lines) + "\n")
+            self.assertEqual(w.replay(p, work=True)["kind"], "retry-loop")
+
+
+class Confidentiality(unittest.TestCase):
+    """The rolling window never carries pane text and every file is owner-only."""
+
+    def test_window_entries_carry_hashes_and_patterns_only(self):
+        with tempfile.TemporaryDirectory() as d:
+            entries = w.append_window(Path(d), retry_frame(1), 1.0)
+            self.assertEqual(sorted(entries[-1]), ["patterns", "raw_state", "state", "ts"])
+            text = w.window_path(Path(d)).read_text()
+            self.assertNotIn("Retrying", text)
+            self.assertNotIn("attempt", text)
+
+    def test_files_are_owner_only_under_a_permissive_umask(self):
+        old = os.umask(0o022)
+        try:
+            with tempfile.TemporaryDirectory() as d:
+                w.append_window(Path(d), IDLE, 1.0)
+                path = w.window_path(Path(d))
+                self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+                self.assertEqual(stat.S_IMODE(path.parent.stat().st_mode), 0o700)
+                # a pre-existing wide mode is normalized on the next write
+                os.chmod(path, 0o644)
+                w.append_window(Path(d), IDLE, 2.0)
+                self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+        finally:
+            os.umask(old)
+
+    def test_classify_from_ids_matches_classify_from_frames(self):
+        frames = [retry_frame(i) for i in range(12)]
+        a = w.classify(frames, True, 60)
+        b = w.classify_ids([w.state_id(f) for f in frames], False, w.matched_patterns(frames), True, 60)
+        self.assertEqual((a["kind"], a["novel_state_count"], a["novelty_rate"]), (b["kind"], b["novel_state_count"], b["novelty_rate"]))
+
+
+class FailureBoundary(unittest.TestCase):
+    """Malformed persisted state is skipped, never raised; unwritable state raises at the
+    library edge (the health probe turns that into 'no reading')."""
+
+    def test_valid_json_but_malformed_entries_are_skipped(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = w.window_path(Path(d))
+            path.parent.mkdir(parents=True)
+            path.write_text("[]\n" + json.dumps({"ts": "not-a-number", "state": "s"}) + "\n" + json.dumps({"ts": 1.0, "state": 5}) + "\n"
+                            + json.dumps({"ts": 1.0, "state": "ok", "patterns": []}) + "\n" + "{bad\n")
+            entries = w.load_window(path)
+            self.assertEqual([e["state"] for e in entries], ["ok"])
+            v = w.classify_window([[], {"ts": "x", "state": "s"}, {"ts": 2.0, "state": "ok", "patterns": []}], (False, ""), 3.0)
+            self.assertEqual(v["kind"], "unknown")  # one valid entry: too few to compare, no crash
+
+    def test_unwritable_window_raises_at_the_library_edge(self):
+        # A read-only dir the process owns is simply re-opened (0700); what cannot be
+        # healed is the window path being occupied by a directory — the replace fails.
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d)
+            w.window_path(ws).mkdir(parents=True)
+            with self.assertRaises(OSError):
+                w.append_window(ws, IDLE, 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""cli_wedge: normalization, novelty, the advisory classifier, the persisted
+window, the I/O edge with fakes, and the record/replay/probe CLI end to end."""
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+import cli_wedge as w  # noqa: E402
+
+IDLE = "❯ \n⏵⏵ bypass permissions on · 1 monitor · esc to interrupt\n"
+
+
+def idle_with_clock(i):
+    return f"❯ \n⏵⏵ bypass permissions on · 12:0{i % 10}:0{i % 6} PM · 1 monitor\n"
+
+
+def retry_frame(i):
+    return f"Connection error. Retrying in {3 * (i % 3)}s… (attempt {i}/10) 04:2{i % 10}:11\n"
+
+
+def working_frame(i):
+    return f"● step: wrote {'abcdefghijklmnopqrstuvwxyz'[i]}.ts\n  editing hunk\n"
+
+
+class Normalization(unittest.TestCase):
+    def test_volatile_fields_collapse_to_one_state(self):
+        frames = [idle_with_clock(i) for i in range(12)]
+        self.assertEqual(len({w.state_id(f) for f in frames}), 1)
+
+    def test_each_volatile_class_is_replaced(self):
+        n = w.normalize("2026-09-05T04:20:01Z 12:34 PM took 3.5s 12.3k tokens 3/10 45% ⠋ loading... ───── run 42")
+        for token in ("<ts>", "<clock>", "<dur>", "<tokens>", "<count>", "<pct>", "<spin>", "<dots>", "<rule>", "#"):
+            self.assertIn(token, n, token)
+        self.assertNotRegex(n, r"\d")
+
+    def test_real_content_change_is_a_new_state(self):
+        self.assertNotEqual(w.state_id(working_frame(0)), w.state_id(working_frame(1)))
+
+    def test_blank_lines_and_trailing_space_do_not_count(self):
+        self.assertEqual(w.state_id("a  \n\n\nb\n"), w.state_id("a\nb"))
+
+
+class NoveltyStats(unittest.TestCase):
+    def test_static(self):
+        nov = w.novelty([IDLE] * 5)
+        self.assertEqual((nov.sample_count, nov.novel_state_count, nov.static), (5, 1, True))
+        self.assertAlmostEqual(nov.novelty_rate, 0.2)
+
+    def test_all_novel(self):
+        nov = w.novelty([working_frame(i) for i in range(10)])
+        self.assertEqual((nov.novel_state_count, nov.novelty_rate, nov.static), (10, 1.0, False))
+
+    def test_cycling_states_are_counted_once(self):
+        frames = [f"state {'ABC'[i % 3]}\n" for i in range(12)]
+        nov = w.novelty(frames)
+        self.assertEqual(nov.novel_state_count, 3)
+        self.assertAlmostEqual(nov.novelty_rate, 0.25)
+
+    def test_empty(self):
+        self.assertEqual(w.novelty([]).novelty_rate, 0.0)
+
+
+class Classifier(unittest.TestCase):
+    def test_idle_when_static_and_nothing_outstanding(self):
+        v = w.classify([idle_with_clock(i) for i in range(6)], False, 30)
+        self.assertEqual((v["kind"], v["warn"]), ("idle", False))
+
+    def test_case1_static_with_work_warns_low_then_high(self):
+        frames = [idle_with_clock(i) for i in range(6)]
+        low = w.classify(frames, True, 60, "core-status running")
+        high = w.classify(frames, True, 900, "core-status running")
+        self.assertEqual((low["kind"], low["warn"], low["confidence"]), ("static-with-work", True, "low"))
+        self.assertEqual(high["confidence"], "high")
+        self.assertIn("core-status running", high["reason"])
+
+    def test_case2_retry_loop_when_only_counters_move(self):
+        v = w.classify([retry_frame(i) for i in range(20)], True, 60)
+        self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("retry-loop", True, "high"))
+        self.assertIn("retrying", v["matched_patterns"])
+        self.assertEqual(v["novel_state_count"], 1)
+
+    def test_case2_retry_loop_over_cycling_states(self):
+        frames = [f"rate limit hit, backing off ({'ABC'[i % 3]})\n" for i in range(12)]
+        v = w.classify(frames, True, 60)
+        self.assertEqual(v["kind"], "retry-loop")
+        self.assertIn("rate-limit", v["matched_patterns"])
+
+    def test_retry_text_with_few_samples_is_medium_confidence(self):
+        v = w.classify([retry_frame(i) for i in range(4)], True, 10)
+        self.assertEqual((v["kind"], v["confidence"]), ("retry-loop", "medium"))
+
+    def test_low_novelty_without_retry_text_is_a_soft_warning(self):
+        frames = [f"state {'AB'[i % 2]}\n" for i in range(12)]
+        v = w.classify(frames, True, 60)
+        self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("low-novelty", True, "low"))
+
+    def test_working_is_not_a_warning(self):
+        v = w.classify([working_frame(i) for i in range(20)], True, 60)
+        self.assertEqual((v["kind"], v["warn"]), ("working", False))
+        v2 = w.classify([working_frame(i // 3) for i in range(12)], True, 60)
+        self.assertEqual((v2["kind"], v2["confidence"]), ("working", "medium"))
+
+    def test_too_few_samples_is_unknown_not_a_warning(self):
+        v = w.classify([IDLE], True, 5)
+        self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("unknown", False, "none"))
+
+    def test_thresholds_are_reported_and_overridable(self):
+        v = w.classify([f"state {'AB'[i % 2]}\n" for i in range(6)], True, 60,
+                       thresholds={"min_samples": 4, "low_novelty_rate": 0.5})
+        self.assertEqual(v["kind"], "low-novelty")
+        self.assertEqual(v["thresholds"]["min_samples"], 4)
+        # the same frames under the provisional thresholds read as working (2/6 = 0.33 > 0.25)
+        self.assertEqual(w.classify([f"state {'AB'[i % 2]}\n" for i in range(6)], True, 60)["kind"], "working")
+        self.assertTrue(v["advisory"])
+        self.assertIn("not a health guarantee", v["note"])
+
+
+class IoEdge(unittest.TestCase):
+    def test_capture_pane_returns_stdout_on_success_none_otherwise(self):
+        ok = w.capture_pane("/s", "core", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="frame\n"))
+        bad = w.capture_pane("/s", "core", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=1, stdout=""))
+
+        def boom(*a, **k):
+            raise OSError("no tmux")
+
+        self.assertEqual(ok, "frame\n")
+        self.assertIsNone(bad)
+        self.assertIsNone(w.capture_pane("/s", "core", "tmux", runner=boom))
+
+    def test_work_outstanding_reads_core_status_and_task_queue(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d)
+            (ws / "state").mkdir()
+            (ws / "tasks").mkdir()
+            self.assertEqual(w.work_outstanding(ws), (False, ""))
+            (ws / "state" / "core-status.json").write_text(json.dumps({"status": "running"}))
+            self.assertEqual(w.work_outstanding(ws), (True, "core-status running"))
+            (ws / "state" / "core-status.json").write_text("{not json")
+            (ws / "tasks" / "task-abc.txt").write_text("task: x\n")
+            self.assertEqual(w.work_outstanding(ws), (True, "1 queued task(s)"))
+
+    def test_window_persists_and_measures_the_static_run(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d)
+            (ws / "tasks").mkdir()
+            (ws / "state").mkdir()
+            (ws / "state" / "core-status.json").write_text(json.dumps({"status": "running"}))
+            entries = w.append_window(ws, working_frame(0), 1000.0)
+            entries = w.append_window(ws, idle_with_clock(1), 1100.0)
+            entries = w.append_window(ws, idle_with_clock(2), 1400.0)
+            self.assertEqual(len(entries), 3)
+            v = w.classify_window(entries, w.work_outstanding(ws), 1500.0)
+            # the static run started at 1100 (the working frame before it does not count)
+            self.assertEqual(v["duration"], 400.0)
+            self.assertEqual(v["kind"], "static-with-work")
+            self.assertEqual(v["trailing_static_samples"], 2)
+            self.assertEqual(v["sample_count"], 3)  # the window is still reported whole
+            # a corrupt line is skipped, not fatal; the cap holds
+            with w.window_path(ws).open("a") as fh:
+                fh.write("{not json\n")
+            for i in range(30):
+                entries = w.append_window(ws, working_frame(i % 26), 2000.0 + i, keep=20)
+            self.assertEqual(len(entries), 20)
+            self.assertEqual(w.classify_window([], (False, ""), 0.0)["kind"], "unknown")
+
+
+def fake_tmux(dir_: Path, frames_file: Path) -> Path:
+    """A stand-in tmux binary: each capture-pane prints the next frame from a file."""
+    script = dir_ / "tmux"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys, pathlib\n"
+        f"ff = pathlib.Path({str(frames_file)!r}); idx = pathlib.Path({str(frames_file)!r} + '.idx')\n"
+        "frames = ff.read_text().split('\\n===\\n')\n"
+        "i = int(idx.read_text()) if idx.exists() else 0\n"
+        "idx.write_text(str(i + 1))\n"
+        "sys.stdout.write(frames[min(i, len(frames) - 1)])\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return script
+
+
+class Cli(unittest.TestCase):
+    def run_cli(self, *args):
+        return subprocess.run([sys.executable, str(REPO / "src" / "cli_wedge.py"), *args], capture_output=True, text=True)
+
+    def test_record_then_replay_end_to_end(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d) / "ws"
+            frames = Path(d) / "frames.txt"
+            frames.write_text("\n===\n".join(retry_frame(i) for i in range(12)))
+            tmux = fake_tmux(Path(d), frames)
+            r = self.run_cli("record", "--socket", "/x", "--tmux", str(tmux), "--workspace", str(ws),
+                             "--label", "retry", "--seconds", "5", "--interval", "0", "--max-samples", "12", "--keep-raw")
+            self.assertEqual(r.returncode, 0, r.stderr)
+            trace = Path(r.stdout.strip())
+            self.assertTrue(trace.exists() and trace.name.startswith("retry-"))
+            lines = [json.loads(l) for l in trace.read_text().splitlines()]
+            self.assertEqual(len(lines), 13)  # 12 samples + summary
+            self.assertTrue(lines[-1]["summary"])
+            self.assertIn("raw", lines[0])
+            rep = self.run_cli("replay", str(trace), "--work-outstanding")
+            self.assertEqual(rep.returncode, 0, rep.stderr)
+            verdict = json.loads(rep.stdout)
+            self.assertEqual(verdict["kind"], "retry-loop")
+
+    def test_probe_persists_a_window_and_reports(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d) / "ws"
+            (ws / "tasks").mkdir(parents=True)
+            frames = Path(d) / "frames.txt"
+            frames.write_text("\n===\n".join([IDLE, IDLE, IDLE]))
+            tmux = fake_tmux(Path(d), frames)
+            out = None
+            for _ in range(3):
+                r = self.run_cli("probe", "--socket", "/x", "--tmux", str(tmux), "--workspace", str(ws))
+                self.assertEqual(r.returncode, 0, r.stderr)
+                out = json.loads(r.stdout)
+            self.assertEqual(out["kind"], "idle")
+            self.assertEqual(out["sample_count"], 3)
+            self.assertTrue(w.window_path(ws).exists())
+
+    def test_probe_with_unreadable_pane_is_unknown_not_a_warning(self):
+        with tempfile.TemporaryDirectory() as d:
+            r = self.run_cli("probe", "--socket", "/x", "--tmux", "/nonexistent/tmux", "--workspace", d)
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertEqual(json.loads(r.stdout)["kind"], "unknown")
+
+    def test_record_sampler_none_frames_are_skipped(self):
+        args = SimpleNamespace(workspace=tempfile.mkdtemp(), label="idle", seconds=3, interval=0, max_samples=5, keep_raw=False)
+        t = [0.0]
+
+        def clock():
+            t[0] += 1.0
+            return t[0]
+
+        calls = [None, IDLE, IDLE]
+        path = w.record(args, lambda: calls.pop(0) if calls else IDLE, clock=clock, sleep=lambda s: None)
+        lines = [json.loads(l) for l in path.read_text().splitlines()]
+        self.assertTrue(lines[-1]["summary"])
+        self.assertGreaterEqual(len(lines), 2)
+        self.assertNotIn("raw", lines[0])
+
+    def test_replay_skips_corrupt_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "t.jsonl"
+            p.write_text("{bad\n" + json.dumps({"ts": 1, "normalized": "a"}) + "\n")
+            self.assertEqual(w.replay(p)["kind"], "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -319,6 +319,14 @@ class IoEdge(unittest.TestCase):
         entries2 = [e(0.0, "100:1"), {"ts": 60.0, "state": "a", "raw_state": "a", "patterns": []}]
         self.assertEqual(len(w.observation_runs(entries2, 2700)), 1)
 
+    def test_core_target_uses_the_lowest_live_window_index(self):
+        run = lambda *a, **k: SimpleNamespace(returncode=0, stdout="1\n2\n")   # base-index 1
+        self.assertEqual(w.core_target("/s", "sutando-core", "tmux", runner=run), "=sutando-core:1")
+        run0 = lambda *a, **k: SimpleNamespace(returncode=0, stdout="0\n1\n")
+        self.assertEqual(w.core_target("/s", "custom", "tmux", runner=run0), "=custom:0")
+        self.assertIsNone(w.core_target("/s", "gone", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=1, stdout="")))
+        self.assertIsNone(w.core_target("/s", "s", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="")))
+
     def test_pane_identity_probe(self):
         ok = w.pane_identity("/s", "core", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="4242:1788000000\n"))
         self.assertEqual(ok, "4242:1788000000")
@@ -333,6 +341,8 @@ def fake_tmux(dir_: Path, frames_file: Path) -> Path:
     script.write_text(
         "#!/usr/bin/env python3\n"
         "import sys, pathlib\n"
+        "if 'list-windows' in sys.argv: print('0'); sys.exit(0)\n"
+        "if 'display-message' in sys.argv: print('4242:1788000000'); sys.exit(0)\n"
         f"ff = pathlib.Path({str(frames_file)!r}); idx = pathlib.Path({str(frames_file)!r} + '.idx')\n"
         "frames = ff.read_text().split('\\n===\\n')\n"
         "i = int(idx.read_text()) if idx.exists() else 0\n"

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -122,6 +122,27 @@ class Classifier(unittest.TestCase):
         self.assertIn("quota-limit", v["current_patterns"])
         self.assertFalse(v["raw_static"])  # the pane moved: this is case 2, not case 1
 
+    def test_codex_idle_banner_is_not_a_provider_limit(self):
+        # Codex CLI at its idle prompt (chi-air-blue, 2026-09-05): the banner mentions "usage limit"
+        # while nothing is limited. Only a HIT (hit / reached / exceeded / limit reached) is the pattern.
+        def frame(i):
+            return (
+                "OpenAI Codex (v0.42)\n"
+                "You have 3 usage limit resets available\n"
+                f"  {'⠋⠙⠹⠸'[i % 4]} model: gpt-5-codex · /status for details\n"
+                "› \n"
+            )
+        v = w.classify([frame(i) for i in range(20)], False, 60)
+        self.assertNotIn("quota-limit", v["matched_patterns"], v)
+        self.assertNotEqual(v["kind"], "provider-limit", v)
+        # Positive controls: the phrasings that DO mean a limit was hit still match.
+        for line in ("You've hit your usage limit · resets 6pm",
+                     "You have reached your weekly limit",
+                     "Session limit reached. Try again at 6pm",
+                     "usage limit exceeded for this plan",
+                     "/usage-credits to finish what you're working on."):
+            self.assertIn("quota-limit", w.matched_patterns([line]), line)
+
     def test_a_pattern_in_one_old_sample_does_not_colour_the_window(self):
         # Owner review P1: sample 1 says "command timed out", the rest is a finished, idle pane.
         frames = ["$ run tests\ncommand timed out after 30s\n"] + [IDLE] * 11
@@ -431,6 +452,25 @@ class Cli(unittest.TestCase):
             verdict = json.loads(out)
             self.assertEqual((verdict["kind"], verdict["sample_count"]), ("idle", 3))
             self.assertTrue(w.window_path(ws).exists())
+
+    def test_probe_targets_keep_separate_windows(self):
+        # Two worker panes probed alternately each keep their own run; the core's window is untouched.
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d) / "ws"
+            frames = Path(d) / "frames.txt"
+            frames.write_text("\n===\n".join(working_frame(i) for i in range(6)))
+            tmux = fake_tmux(Path(d), frames)
+            outs = []
+            for target in ("=worker-1:1", "=worker-2:1", "=worker-1:1", "=worker-2:1"):
+                rc, out = self.run_main("probe", "--socket", "/s", "--target", target, "--workspace", str(ws), "--tmux", str(tmux))
+                self.assertEqual(rc, 0)
+                outs.append(json.loads(out))
+            self.assertEqual([o["sample_count"] for o in outs], [1, 1, 2, 2], outs)
+            self.assertIn("no work signal", outs[0]["work_detail"])
+            self.assertFalse(w.window_path(ws).exists(), "an explicit target must not write the core's window")
+            self.assertTrue(w.window_path(ws, "=worker-1:1").exists())
+            self.assertNotEqual(w.window_path(ws, "=worker-1:1"), w.window_path(ws, "=worker-2:1"))
+            self.assertEqual(w.window_path(ws), w.window_path(ws, None))
 
     def test_probe_with_unreadable_pane_is_unknown_not_a_warning(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -413,6 +413,62 @@ class Cli(unittest.TestCase):
             self.assertEqual(w.replay(p, work=True)["kind"], "retry-loop")
 
 
+class ConcurrentWriters(unittest.TestCase):
+    """Two independent writers (the app's health-check and the launchd fallback) must
+    not lose each other's sample: the production append_window is the contract."""
+
+    def test_forked_writers_keep_every_sample(self):
+        import multiprocessing as mp
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d)
+            w.append_window(ws, IDLE, 1.0)
+            # Every worker holds the lock only inside append_window; a barrier lines them up
+            # at the door so they contend for the same read/modify/write.
+            n = 6
+            barrier = mp.Barrier(n)
+
+            def worker(i):
+                barrier.wait(timeout=20)
+                w.append_window(ws, working_frame(i), 10.0 + i)
+
+            ctx = mp.get_context("fork")
+            procs = [ctx.Process(target=worker, args=(i,)) for i in range(n)]
+            for pr in procs:
+                pr.start()
+            for pr in procs:
+                pr.join(30)
+            self.assertEqual([pr.exitcode for pr in procs], [0] * n)
+            entries = w.load_window(w.window_path(ws))
+            self.assertEqual(len(entries), 1 + n)
+            self.assertEqual(sorted(e["ts"] for e in entries), [1.0] + [10.0 + i for i in range(n)])
+            self.assertFalse((w.window_path(ws).with_name("window.jsonl.lock")).stat().st_mode & 0o077)
+
+    def test_without_the_lock_the_same_race_loses_a_sample(self):
+        # Negative control: the pre-fix shape — load, then append+replace after every
+        # sibling has loaded — drops all but one writer's sample.
+        import multiprocessing as mp
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d)
+            w.append_window(ws, IDLE, 1.0)
+            n = 3
+            barrier = mp.Barrier(n)
+
+            def racy(i):
+                path = w.window_path(ws)
+                entries = w.load_window(path)
+                barrier.wait(timeout=20)  # everyone has loaded the same 1 entry
+                entries.append({"ts": 10.0 + i, "state": "s", "raw_state": "r", "patterns": []})
+                w._write_private(path, "".join(json.dumps(e) + "\n" for e in entries))
+
+            ctx = mp.get_context("fork")
+            procs = [ctx.Process(target=racy, args=(i,)) for i in range(n)]
+            for pr in procs:
+                pr.start()
+            for pr in procs:
+                pr.join(30)
+            self.assertEqual(len(w.load_window(w.window_path(ws))), 2)  # 1 + one survivor, not 4
+
+
 class Confidentiality(unittest.TestCase):
     """The rolling window never carries pane text and every file is owner-only."""
 

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -71,17 +71,31 @@ class NoveltyStats(unittest.TestCase):
 
 
 class Classifier(unittest.TestCase):
-    def test_idle_when_static_and_nothing_outstanding(self):
-        v = w.classify([idle_with_clock(i) for i in range(6)], False, 30)
-        self.assertEqual((v["kind"], v["warn"]), ("idle", False))
+    def test_idle_when_raw_static_and_nothing_outstanding(self):
+        v = w.classify([IDLE] * 6, False, 30)
+        self.assertEqual((v["kind"], v["warn"], v["raw_static"]), ("idle", False, True))
 
-    def test_case1_static_with_work_warns_low_then_high(self):
-        frames = [idle_with_clock(i) for i in range(6)]
-        low = w.classify(frames, True, 60, "core-status running")
-        high = w.classify(frames, True, 900, "core-status running")
+    def test_case1_is_pure_raw_static_with_work(self):
+        low = w.classify([IDLE] * 6, True, 60, "core-status running")
+        high = w.classify([IDLE] * 6, True, 900, "core-status running")
         self.assertEqual((low["kind"], low["warn"], low["confidence"]), ("static-with-work", True, "low"))
         self.assertEqual(high["confidence"], "high")
         self.assertIn("core-status running", high["reason"])
+
+    def test_clock_only_pane_is_not_case1(self):
+        # Spec: case 1 is pure static, no normalization. A ticking clock is motion.
+        frames = [idle_with_clock(i) for i in range(6)]
+        v = w.classify(frames, True, 900)
+        self.assertNotEqual(v["kind"], "static-with-work")
+        self.assertFalse(v["raw_static"])
+        self.assertTrue(v["clock_only"])
+        # ...and without work it is recorded, not judged
+        q = w.classify(frames, False, 900)
+        self.assertEqual((q["kind"], q["warn"]), ("clock-only", False))
+        # with work, over enough samples, case 2's novelty statistic notices it softly
+        many = [idle_with_clock(i) for i in range(12)]
+        s = w.classify(many, True, 900)
+        self.assertEqual((s["kind"], s["warn"], s["confidence"]), ("low-novelty", True, "low"))
 
     def test_case2_retry_loop_when_only_counters_move(self):
         v = w.classify([retry_frame(i) for i in range(20)], True, 60)
@@ -99,10 +113,11 @@ class Classifier(unittest.TestCase):
         v = w.classify([retry_frame(i) for i in range(4)], True, 10)
         self.assertEqual((v["kind"], v["confidence"]), ("retry-loop", "medium"))
 
-    def test_low_novelty_without_retry_text_is_a_soft_warning(self):
+    def test_low_novelty_without_retry_text_is_a_soft_warning_only_with_work(self):
         frames = [f"state {'AB'[i % 2]}\n" for i in range(12)]
         v = w.classify(frames, True, 60)
         self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("low-novelty", True, "low"))
+        self.assertEqual(w.classify(frames, False, 60)["kind"], "working")
 
     def test_working_is_not_a_warning(self):
         v = w.classify([working_frame(i) for i in range(20)], True, 60)
@@ -113,6 +128,11 @@ class Classifier(unittest.TestCase):
     def test_too_few_samples_is_unknown_not_a_warning(self):
         v = w.classify([IDLE], True, 5)
         self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("unknown", False, "none"))
+
+    def test_raw_state_id_differs_where_normalized_does_not(self):
+        a, b = idle_with_clock(1), idle_with_clock(2)
+        self.assertEqual(w.state_id(a), w.state_id(b))
+        self.assertNotEqual(w.raw_state_id(a), w.raw_state_id(b))
 
     def test_thresholds_are_reported_and_overridable(self):
         v = w.classify([f"state {'AB'[i % 2]}\n" for i in range(6)], True, 60,
@@ -156,8 +176,8 @@ class IoEdge(unittest.TestCase):
             (ws / "state").mkdir()
             (ws / "state" / "core-status.json").write_text(json.dumps({"status": "running"}))
             entries = w.append_window(ws, working_frame(0), 1000.0)
-            entries = w.append_window(ws, idle_with_clock(1), 1100.0)
-            entries = w.append_window(ws, idle_with_clock(2), 1400.0)
+            entries = w.append_window(ws, IDLE, 1100.0)
+            entries = w.append_window(ws, IDLE, 1400.0)
             self.assertEqual(len(entries), 3)
             v = w.classify_window(entries, w.work_outstanding(ws), 1500.0)
             # the static run started at 1100 (the working frame before it does not count)
@@ -165,6 +185,10 @@ class IoEdge(unittest.TestCase):
             self.assertEqual(v["kind"], "static-with-work")
             self.assertEqual(v["trailing_static_samples"], 2)
             self.assertEqual(v["sample_count"], 3)  # the window is still reported whole
+            # a clock-only trailing run is NOT a static run (raw ids differ)
+            for i in range(3):
+                entries = w.append_window(ws, idle_with_clock(i), 1500.0 + i)
+            self.assertNotEqual(w.classify_window(entries, w.work_outstanding(ws), 1600.0)["kind"], "static-with-work")
             # a corrupt line is skipped, not fatal; the cap holds
             with w.window_path(ws).open("a") as fh:
                 fh.write("{not json\n")

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -350,6 +350,13 @@ class IoEdge(unittest.TestCase):
         self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%8", tmux_env="/s,1,0", ancestors=[99]))
         bad = lambda *a, **k: SimpleNamespace(returncode=1, stdout="")
         self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=bad, tmux_pane="%7", ancestors=[4242]))
+        # The error path must stay falsy: a raising tmux, or an unparsable answer, is unknown provenance, never a skip.
+        def boom(*a, **k):
+            raise OSError("no tmux")
+        self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=boom, tmux_pane="%7", tmux_env="/s,1,0", ancestors=[4242]))
+        junk = lambda *a, **k: SimpleNamespace(returncode=0, stdout="garbage\n")
+        self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=junk, tmux_pane="%7", tmux_env="/s,1,0", ancestors=[4242]))
+        self.assertEqual(w._pid_ancestors(pid=777, runner=boom), [777])
         self.assertIn(os.getppid(), w._pid_ancestors())
 
     def test_pane_identity_probe(self):

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -38,10 +38,18 @@ class Normalization(unittest.TestCase):
         self.assertEqual(len({w.state_id(f) for f in frames}), 1)
 
     def test_each_volatile_class_is_replaced(self):
-        n = w.normalize("2026-09-05T04:20:01Z 12:34 PM took 3.5s 12.3k tokens 3/10 45% ⠋ loading... ───── run 42")
-        for token in ("<ts>", "<clock>", "<dur>", "<tokens>", "<count>", "<pct>", "<spin>", "<dots>", "<rule>", "#"):
+        n = w.normalize("2026-09-05T04:20:01Z 12:34 PM took 3.5s 12.3k tokens 3/10 45% ⠋ loading... ───── attempt 4 run 42")
+        for token in ("<ts>", "<clock>", "<dur>", "<tokens>", "<count>", "<pct>", "<spin>", "<dots>", "<rule>", "attempt #"):
             self.assertIn(token, n, token)
-        self.assertNotRegex(n, r"\d")
+        # No blanket digit stripping (owner review): a bare number is content until a trace says otherwise.
+        self.assertIn("run 42", n)
+
+    def test_semantic_digits_are_progress_not_noise(self):
+        self.assertNotEqual(w.state_id("editing migration_41.sql\n"), w.state_id("editing migration_42.sql\n"))
+        self.assertNotEqual(w.state_id("processing shard 17\n"), w.state_id("processing shard 18\n"))
+        # …while counters that only say "again" still collapse
+        self.assertEqual(w.state_id("attempt 3 of the same call\n"), w.state_id("attempt 4 of the same call\n"))
+        self.assertEqual(w.state_id("error at line 183\n"), w.state_id("error at line 184\n"))
 
     def test_real_content_change_is_a_new_state(self):
         self.assertNotEqual(w.state_id(working_frame(0)), w.state_id(working_frame(1)))
@@ -109,9 +117,36 @@ class Classifier(unittest.TestCase):
                 f"* {verb} for 1s · done 5:{17 + i // 3:02d} PM · 1 monitor still running\n"
             )
         v = w.classify([frame(i) for i in range(12)], True, 300)
-        self.assertEqual((v["kind"], v["warn"]), ("retry-loop", True))
-        self.assertIn("quota-limit", v["matched_patterns"])
+        # A provider-blocked CLI is its own kind (owner review), not forced into "retry loop".
+        self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("provider-limit", True, "high"))
+        self.assertIn("quota-limit", v["current_patterns"])
         self.assertFalse(v["raw_static"])  # the pane moved: this is case 2, not case 1
+
+    def test_a_pattern_in_one_old_sample_does_not_colour_the_window(self):
+        # Owner review P1: sample 1 says "command timed out", the rest is a finished, idle pane.
+        frames = ["$ run tests\ncommand timed out after 30s\n"] + [IDLE] * 11
+        v = w.classify(frames, True, 600)
+        self.assertNotEqual(v["kind"], "retry-loop")
+        self.assertEqual(v["current_patterns"], [])
+        self.assertEqual((v["pattern_sample_count"], v["consecutive_pattern_samples"]), (1, 0))
+        self.assertIn("timeout", v["matched_patterns"])  # still reported as evidence, just not deciding
+        # the same residue through the persisted window: the trailing static run decides
+        entries = [{"ts": 0.0, "state": "t", "raw_state": "t", "patterns": ["timeout"]}] + \
+                  [{"ts": 60.0 * i, "state": "i", "raw_state": "i", "patterns": []} for i in range(1, 12)]
+        self.assertEqual(w.classify_window(entries, (False, ""), 660.0)["kind"], "idle")
+
+    def test_retry_text_must_be_current_and_recurrent(self):
+        # retry-loop = low novelty AND retry text that is current and recurrent
+        frames = [retry_frame(0), IDLE, IDLE] + [retry_frame(i) for i in range(9)]
+        v = w.classify(frames, True, 60)
+        self.assertEqual(v["kind"], "retry-loop")
+        self.assertEqual(v["consecutive_pattern_samples"], 9)
+        self.assertEqual(v["pattern_sample_count"], 10)
+        # a single current sample with retry text is not yet recurrent — low novelty alone
+        # is the softer, cause-unknown warning, never "retry loop"
+        v2 = w.classify([IDLE] * 11 + [retry_frame(0)], True, 60)
+        self.assertNotIn(v2["kind"], ("retry-loop", "provider-limit"))
+        self.assertEqual(v2["consecutive_pattern_samples"], 1)
 
     def test_case2_retry_loop_when_only_counters_move(self):
         v = w.classify([retry_frame(i) for i in range(20)], True, 60)
@@ -179,8 +214,12 @@ class IoEdge(unittest.TestCase):
             (ws / "state").mkdir()
             (ws / "tasks").mkdir()
             self.assertEqual(w.work_outstanding(ws), (False, ""))
-            (ws / "state" / "core-status.json").write_text(json.dumps({"status": "running"}))
-            self.assertEqual(w.work_outstanding(ws), (True, "core-status running"))
+            (ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": 1000.0}))
+            self.assertEqual(w.work_outstanding(ws, now=1012.0), (True, "core-status running (12s old)"))
+            # graceful-restart's contract: "running" older than the TTL is a crashed core's last word
+            self.assertEqual(w.work_outstanding(ws, now=1000.0 + 901), (False, ""))
+            (ws / "state" / "core-status.json").write_text(json.dumps({"status": "running"}))  # no ts: not counted
+            self.assertEqual(w.work_outstanding(ws, now=1000.0), (False, ""))
             (ws / "state" / "core-status.json").write_text("{not json")
             (ws / "tasks" / "task-abc.txt").write_text("task: x\n")
             self.assertEqual(w.work_outstanding(ws), (True, "1 queued task(s)"))
@@ -190,21 +229,23 @@ class IoEdge(unittest.TestCase):
             ws = Path(d)
             (ws / "tasks").mkdir()
             (ws / "state").mkdir()
-            (ws / "state" / "core-status.json").write_text(json.dumps({"status": "running"}))
+            (ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": 1490.0}))
             entries = w.append_window(ws, working_frame(0), 1000.0)
             entries = w.append_window(ws, IDLE, 1100.0)
             entries = w.append_window(ws, IDLE, 1400.0)
             self.assertEqual(len(entries), 3)
-            v = w.classify_window(entries, w.work_outstanding(ws), 1500.0)
+            v = w.classify_window(entries, w.work_outstanding(ws, now=1500.0), 1500.0)
             # the static run started at 1100 (the working frame before it does not count)
             self.assertEqual(v["duration"], 400.0)
             self.assertEqual(v["kind"], "static-with-work")
             self.assertEqual(v["trailing_static_samples"], 2)
-            self.assertEqual(v["sample_count"], 3)  # the window is still reported whole
+            self.assertEqual(v["sample_count"], 3)  # the run is still reported whole
+            self.assertEqual(v["confidence"], "low")  # 2 samples: one gap, however long (TustinOC)
+            self.assertEqual((v["observation_runs"], v["median_gap_s"]), (1, 300.0))
             # a clock-only trailing run is NOT a static run (raw ids differ)
             for i in range(3):
                 entries = w.append_window(ws, idle_with_clock(i), 1500.0 + i)
-            self.assertNotEqual(w.classify_window(entries, w.work_outstanding(ws), 1600.0)["kind"], "static-with-work")
+            self.assertNotEqual(w.classify_window(entries, w.work_outstanding(ws, now=1600.0), 1600.0)["kind"], "static-with-work")
             # a corrupt line is skipped, not fatal; the cap holds
             with w.window_path(ws).open("a") as fh:
                 fh.write("{not json\n")
@@ -212,6 +253,39 @@ class IoEdge(unittest.TestCase):
                 entries = w.append_window(ws, working_frame(i % 26), 2000.0 + i, keep=20)
             self.assertEqual(len(entries), 20)
             self.assertEqual(w.classify_window([], (False, ""), 0.0)["kind"], "unknown")
+
+    def test_a_gap_starts_a_new_observation_run(self):
+        # Owner review P1: 10:00 pane A, laptop asleep, 18:00 pane A — two glimpses, not 8 hours.
+        e = lambda ts: {"ts": ts, "state": "a", "raw_state": "a", "patterns": []}
+        entries = [e(36000.0), e(36000.0 + 8 * 3600)]
+        v = w.classify_window(entries, (True, "1 queued task(s)"), 36000.0 + 8 * 3600 + 5)
+        self.assertEqual((v["kind"], v["observation_runs"], v["run_samples"]), ("unknown", 2, 1))
+        self.assertNotEqual(v.get("confidence"), "high")
+        # three samples within the continuity limit ARE a run, and the duration is the run's
+        entries = [e(0.0), e(600.0), e(1200.0)]
+        v = w.classify_window(entries, (True, "1 queued task(s)"), 1230.0)
+        self.assertEqual((v["kind"], v["confidence"], v["duration"], v["observation_runs"]), ("static-with-work", "high", 1230.0, 1))
+        # a window whose newest sample is itself older than the limit has no current observation
+        v = w.classify_window(entries, (True, "1 queued task(s)"), 1200.0 + 5000)
+        self.assertEqual(v["kind"], "unknown")
+        self.assertIn("no current observation", v["reason"])
+
+    def test_a_new_pane_identity_starts_a_new_run(self):
+        e = lambda ts, pane: {"ts": ts, "state": "a", "raw_state": "a", "patterns": [], "pane": pane}
+        entries = [e(0.0, "100:1"), e(60.0, "100:1"), e(120.0, "200:2"), e(180.0, "200:2")]
+        v = w.classify_window(entries, (True, "x"), 200.0)
+        self.assertEqual((v["observation_runs"], v["run_samples"], v["duration"]), (2, 2, 80.0))
+        self.assertEqual(w.observation_runs(entries, 2700)[1][0]["pane"], "200:2")
+        # an unknown identity never resets
+        entries2 = [e(0.0, "100:1"), {"ts": 60.0, "state": "a", "raw_state": "a", "patterns": []}]
+        self.assertEqual(len(w.observation_runs(entries2, 2700)), 1)
+
+    def test_pane_identity_probe(self):
+        ok = w.pane_identity("/s", "core", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="4242:1788000000\n"))
+        self.assertEqual(ok, "4242:1788000000")
+        junk = w.pane_identity("/s", "core", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="❯ some pane text"))
+        self.assertIsNone(junk)
+        self.assertIsNone(w.pane_identity("/s", "core", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=1, stdout="")))
 
 
 def fake_tmux(dir_: Path, frames_file: Path) -> Path:

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -337,6 +337,15 @@ class IoEdge(unittest.TestCase):
         self.assertIsNone(w.core_target("/s", "gone", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=1, stdout="")))
         self.assertIsNone(w.core_target("/s", "s", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="")))
 
+    def test_sampled_from_inside_guard(self):
+        ok = lambda *a, **k: SimpleNamespace(returncode=0, stdout="%7:4242\n")
+        self.assertIn("TMUX_PANE", w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%7", ancestors=[1]))
+        self.assertIn("pid chain", w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="", ancestors=[99, 4242]))
+        self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%8", ancestors=[99]))
+        bad = lambda *a, **k: SimpleNamespace(returncode=1, stdout="")
+        self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=bad, tmux_pane="%7", ancestors=[4242]))
+        self.assertIn(os.getppid(), w._pid_ancestors())
+
     def test_pane_identity_probe(self):
         ok = w.pane_identity("/s", "core", "tmux", runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="4242:1788000000\n"))
         self.assertEqual(ok, "4242:1788000000")

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -161,8 +161,18 @@ class Classifier(unittest.TestCase):
         self.assertIn("rate-limit", v["matched_patterns"])
 
     def test_retry_text_with_few_samples_is_medium_confidence(self):
-        v = w.classify([retry_frame(i) for i in range(4)], True, 10)
+        v = w.classify([retry_frame(i) for i in range(4)], True, 90)
         self.assertEqual((v["kind"], v["confidence"]), ("retry-loop", "medium"))
+
+    def test_no_verdict_before_the_run_has_lasted(self):
+        # Live witness 2026-09-05: two identical frames one second apart with the word
+        # "timeout" in the operator's own shell text read as retry-loop. A second is not evidence.
+        v = w.classify([retry_frame(0), retry_frame(0)], True, 1)
+        self.assertEqual((v["kind"], v["warn"]), ("unknown", False))
+        self.assertIn("too short", v["reason"])
+        self.assertEqual(w.classify([IDLE] * 3, True, 30)["kind"], "unknown")          # would warn → too short
+        self.assertEqual(w.classify([IDLE] * 3, True, 60)["kind"], "static-with-work")
+        self.assertEqual(w.classify([IDLE] * 3, False, 1)["kind"], "idle")               # not a warning: stated
 
     def test_low_novelty_without_retry_text_is_a_soft_warning_only_with_work(self):
         frames = [f"state {'AB'[i % 2]}\n" for i in range(12)]
@@ -379,7 +389,11 @@ class Cli(unittest.TestCase):
             self.assertIn("raw", lines[0])
             rc, out = self.run_main("replay", str(trace), "--work-outstanding")
             self.assertEqual(rc, 0)
-            self.assertEqual(json.loads(out)["kind"], "retry-loop")
+            # 12 samples at interval 0 span under a second: a warning needs the run to have lasted
+            v = json.loads(out)
+            self.assertEqual((v["kind"], v["warn"]), ("unknown", False))
+            self.assertIn("too short", v["reason"])
+            self.assertIn("retrying", v["matched_patterns"])  # the evidence is still there
 
     def test_probe_persists_a_window_and_reports(self):
         with tempfile.TemporaryDirectory() as d:
@@ -457,7 +471,7 @@ class Cli(unittest.TestCase):
     def test_replay_classifies_a_hash_only_trace(self):
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "t.jsonl"
-            lines = [json.dumps({"ts": float(i), "state": "same", "raw_state": f"r{i}", "patterns": ["retrying"]}) for i in range(12)]
+            lines = [json.dumps({"ts": 10.0 * i, "state": "same", "raw_state": f"r{i}", "patterns": ["retrying"]}) for i in range(12)]
             p.write_text("\n".join(lines) + "\n")
             self.assertEqual(w.replay(p, work=True)["kind"], "retry-loop")
 

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -89,13 +89,13 @@ class Classifier(unittest.TestCase):
         self.assertNotEqual(v["kind"], "static-with-work")
         self.assertFalse(v["raw_static"])
         self.assertTrue(v["clock_only"])
-        # ...and without work it is recorded, not judged
-        q = w.classify(frames, False, 900)
-        self.assertEqual((q["kind"], q["warn"]), ("clock-only", False))
-        # with work, over enough samples, case 2's novelty statistic notices it softly
-        many = [idle_with_clock(i) for i in range(12)]
-        s = w.classify(many, True, 900)
-        self.assertEqual((s["kind"], s["warn"], s["confidence"]), ("low-novelty", True, "low"))
+        # A clock-only pane is ALIVE (Chi): never a warning, with or without work, however long
+        for work in (False, True):
+            q = w.classify([idle_with_clock(i) for i in range(12)], work, 900)
+            self.assertEqual((q["kind"], q["warn"]), ("clock-only", False), work)
+        # ...unless retry text says otherwise: counters-only motion WITH retry text is still case 2
+        r = w.classify([retry_frame(i) for i in range(12)], True, 60)
+        self.assertEqual(r["kind"], "retry-loop")
 
     def test_case2_retry_loop_when_only_counters_move(self):
         v = w.classify([retry_frame(i) for i in range(20)], True, 60)

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """cli_wedge: normalization, novelty, the advisory classifier, the persisted
 window, the I/O edge with fakes, and the record/replay/probe CLI end to end."""
+import contextlib
+import io
 import json
 import os
 import stat
@@ -189,8 +191,13 @@ def fake_tmux(dir_: Path, frames_file: Path) -> Path:
 
 
 class Cli(unittest.TestCase):
-    def run_cli(self, *args):
-        return subprocess.run([sys.executable, str(REPO / "src" / "cli_wedge.py"), *args], capture_output=True, text=True)
+    """main() is driven IN-PROCESS so coverage sees it; one subprocess test keeps the entry point honest."""
+
+    def run_main(self, *args):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = w.main(list(args))
+        return rc, buf.getvalue()
 
     def test_record_then_replay_end_to_end(self):
         with tempfile.TemporaryDirectory() as d:
@@ -198,19 +205,18 @@ class Cli(unittest.TestCase):
             frames = Path(d) / "frames.txt"
             frames.write_text("\n===\n".join(retry_frame(i) for i in range(12)))
             tmux = fake_tmux(Path(d), frames)
-            r = self.run_cli("record", "--socket", "/x", "--tmux", str(tmux), "--workspace", str(ws),
-                             "--label", "retry", "--seconds", "5", "--interval", "0", "--max-samples", "12", "--keep-raw")
-            self.assertEqual(r.returncode, 0, r.stderr)
-            trace = Path(r.stdout.strip())
+            rc, out = self.run_main("record", "--socket", "/x", "--tmux", str(tmux), "--workspace", str(ws),
+                                    "--label", "retry", "--seconds", "5", "--interval", "0", "--max-samples", "12", "--keep-raw")
+            self.assertEqual(rc, 0)
+            trace = Path(out.strip())
             self.assertTrue(trace.exists() and trace.name.startswith("retry-"))
             lines = [json.loads(l) for l in trace.read_text().splitlines()]
             self.assertEqual(len(lines), 13)  # 12 samples + summary
             self.assertTrue(lines[-1]["summary"])
             self.assertIn("raw", lines[0])
-            rep = self.run_cli("replay", str(trace), "--work-outstanding")
-            self.assertEqual(rep.returncode, 0, rep.stderr)
-            verdict = json.loads(rep.stdout)
-            self.assertEqual(verdict["kind"], "retry-loop")
+            rc, out = self.run_main("replay", str(trace), "--work-outstanding")
+            self.assertEqual(rc, 0)
+            self.assertEqual(json.loads(out)["kind"], "retry-loop")
 
     def test_probe_persists_a_window_and_reports(self):
         with tempfile.TemporaryDirectory() as d:
@@ -221,18 +227,30 @@ class Cli(unittest.TestCase):
             tmux = fake_tmux(Path(d), frames)
             out = None
             for _ in range(3):
-                r = self.run_cli("probe", "--socket", "/x", "--tmux", str(tmux), "--workspace", str(ws))
-                self.assertEqual(r.returncode, 0, r.stderr)
-                out = json.loads(r.stdout)
-            self.assertEqual(out["kind"], "idle")
-            self.assertEqual(out["sample_count"], 3)
+                rc, out = self.run_main("probe", "--socket", "/x", "--tmux", str(tmux), "--workspace", str(ws))
+                self.assertEqual(rc, 0)
+            verdict = json.loads(out)
+            self.assertEqual((verdict["kind"], verdict["sample_count"]), ("idle", 3))
             self.assertTrue(w.window_path(ws).exists())
 
     def test_probe_with_unreadable_pane_is_unknown_not_a_warning(self):
         with tempfile.TemporaryDirectory() as d:
-            r = self.run_cli("probe", "--socket", "/x", "--tmux", "/nonexistent/tmux", "--workspace", d)
+            rc, out = self.run_main("probe", "--socket", "/x", "--tmux", "/nonexistent/tmux", "--workspace", d)
+            self.assertEqual(rc, 0)
+            self.assertEqual(json.loads(out)["kind"], "unknown")
+
+    def test_default_workspace_is_the_configured_one(self):
+        # No env fallback: the sanctioned resolver answers (lint-workspace-resolution).
+        self.assertIsInstance(w._default_workspace(), Path)
+        self.assertNotIn("SUTANDO_WORKSPACE_DIR", (REPO / "src" / "cli_wedge.py").read_text())
+
+    def test_entry_point_runs_as_a_script(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "t.jsonl"
+            p.write_text(json.dumps({"ts": 1, "normalized": "a"}) + "\n" + json.dumps({"ts": 2, "normalized": "b"}) + "\n")
+            r = subprocess.run([sys.executable, str(REPO / "src" / "cli_wedge.py"), "replay", str(p)], capture_output=True, text=True)
             self.assertEqual(r.returncode, 0, r.stderr)
-            self.assertEqual(json.loads(r.stdout)["kind"], "unknown")
+            self.assertEqual(json.loads(r.stdout)["kind"], "working")
 
     def test_record_sampler_none_frames_are_skipped(self):
         args = SimpleNamespace(workspace=tempfile.mkdtemp(), label="idle", seconds=3, interval=0, max_samples=5, keep_raw=False)

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -299,6 +299,16 @@ class IoEdge(unittest.TestCase):
         v2 = w.classify_window(dense + sparse[:2], (True, "x"), sparse[1]["ts"] + 10)
         self.assertEqual(v2["kind"], "unknown")
 
+    def test_rapid_pane_replacements_are_not_a_sparse_cadence(self):
+        # Codex on 07e56e5: three singleton runs split by pane identity, 10 s apart, must not
+        # read as "samples arrive every 10s, past the 2700s limit".
+        e = lambda ts, pane: {"ts": ts, "state": "a", "raw_state": "a", "patterns": [], "pane": pane}
+        entries = [e(0.0, "1:1"), e(10.0, "2:2"), e(20.0, "3:3"), e(30.0, "4:4")]
+        v = w.classify_window(entries, (True, "x"), 35.0)
+        self.assertEqual((v["kind"], v["observation_runs"], v["run_samples"]), ("unknown", 4, 1))
+        self.assertEqual(v["recent_gap_s"], 10.0)
+        self.assertIn("fewer than 2 samples", v["reason"])
+
     def test_a_new_pane_identity_starts_a_new_run(self):
         e = lambda ts, pane: {"ts": ts, "state": "a", "raw_state": "a", "patterns": [], "pane": pane}
         entries = [e(0.0, "100:1"), e(60.0, "100:1"), e(120.0, "200:2"), e(180.0, "200:2")]

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -270,6 +270,19 @@ class IoEdge(unittest.TestCase):
         self.assertEqual(v["kind"], "unknown")
         self.assertIn("no current observation", v["reason"])
 
+    def test_sampling_slower_than_the_continuity_limit_is_named_not_silent(self):
+        # TustinOC: at hourly sampling every sample is its own run and case 1 is unreachable;
+        # the verdict must say "undetectable here", not "nothing to report".
+        e = lambda ts: {"ts": ts, "state": "a", "raw_state": "a", "patterns": []}
+        entries = [e(3600.0 * i) for i in range(6)]
+        v = w.classify_window(entries, (True, "1 queued task(s)"), 3600.0 * 5 + 10)
+        self.assertEqual((v["kind"], v["warn"], v["observation_runs"], v["run_samples"]), ("cadence-too-sparse", False, 6, 1))
+        self.assertEqual(v["window_median_gap_s"], 3600.0)
+        self.assertIn("cannot be observed at this rate", v["reason"])
+        # the same pane sampled inside the limit is a plain case-1 warning
+        dense = [e(1800.0 * i) for i in range(6)]
+        self.assertEqual(w.classify_window(dense, (True, "x"), 1800.0 * 5 + 10)["kind"], "static-with-work")
+
     def test_a_new_pane_identity_starts_a_new_run(self):
         e = lambda ts, pane: {"ts": ts, "state": "a", "raw_state": "a", "patterns": [], "pane": pane}
         entries = [e(0.0, "100:1"), e(60.0, "100:1"), e(120.0, "200:2"), e(180.0, "200:2")]

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -97,6 +97,22 @@ class Classifier(unittest.TestCase):
         r = w.classify([retry_frame(i) for i in range(12)], True, 60)
         self.assertEqual(r["kind"], "retry-loop")
 
+    def test_quota_limited_pane_is_case2_even_though_it_moves(self):
+        # Owner screenshot 2026-09-05 (Claude Code): each scheduled turn ends at once
+        # with the same provider message; only the clock and the verb change.
+        def frame(i):
+            verb = ("Brewed", "Worked", "Sautéed")[i % 3]
+            return (
+                f"* Running scheduled task (Sep 4 5:{17 + i // 3:02d}pm)\n"
+                "  L You've hit your session limit · resets 6pm (America/Los_Angeles)\n"
+                "    /usage-credits to finish what you're working on.\n"
+                f"* {verb} for 1s · done 5:{17 + i // 3:02d} PM · 1 monitor still running\n"
+            )
+        v = w.classify([frame(i) for i in range(12)], True, 300)
+        self.assertEqual((v["kind"], v["warn"]), ("retry-loop", True))
+        self.assertIn("quota-limit", v["matched_patterns"])
+        self.assertFalse(v["raw_static"])  # the pane moved: this is case 2, not case 1
+
     def test_case2_retry_loop_when_only_counters_move(self):
         v = w.classify([retry_frame(i) for i in range(20)], True, 60)
         self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("retry-loop", True, "high"))

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -339,9 +339,15 @@ class IoEdge(unittest.TestCase):
 
     def test_sampled_from_inside_guard(self):
         ok = lambda *a, **k: SimpleNamespace(returncode=0, stdout="%7:4242\n")
-        self.assertIn("TMUX_PANE", w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%7", ancestors=[1]))
+        self.assertIn("TMUX_PANE", w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%7", tmux_env="/s,1,0", ancestors=[1]))
+        # Pane ids are per tmux server: the same %7 under another socket, or unbound, is not the target.
+        self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%7", tmux_env="/other,1,0", ancestors=[1]))
+        self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%7", tmux_env="", ancestors=[1]))
+        self.assertTrue(w._same_tmux_server("/tmp/s.sock", "/tmp/s.sock,4242,0"))
+        self.assertFalse(w._same_tmux_server("/tmp/s.sock", "/tmp/t.sock,4242,0"))
+        self.assertFalse(w._same_tmux_server("/tmp/s.sock", ""))
         self.assertIn("pid chain", w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="", ancestors=[99, 4242]))
-        self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%8", ancestors=[99]))
+        self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=ok, tmux_pane="%8", tmux_env="/s,1,0", ancestors=[99]))
         bad = lambda *a, **k: SimpleNamespace(returncode=1, stdout="")
         self.assertIsNone(w.sampled_from_inside("/s", "=c:1", "tmux", runner=bad, tmux_pane="%7", ancestors=[4242]))
         self.assertIn(os.getppid(), w._pid_ancestors())


### PR DESCRIPTION
## What
An advisory **CLI progress detector** for the core's tmux pane, as the owner specified after the thread with Chi and sonichi's Stand (2026-09-05). Two cases that a heartbeat and a liveness probe both miss:

1. **Static with work outstanding** — the **raw** pane is unchanged (frame-for-frame) while `core-status.json` says running or `tasks/` is non-empty. Pure static, no normalization, no tuned window, no slow-operation heuristic: per the spec and Chi's observation, a static pane means idle, and a pane with any motion is alive.
2. **Retry loop** — the pane moves but revisits states already seen. Measured as **novelty over time** on **normalized** frames (timestamps, clocks, elapsed durations, counters like `3/10`, percentages, spinner glyphs, token counts, progress dots, and `attempt/retry/line/col/iteration/round/turn N` stripped — context-specific only, no blanket digit stripping, so `migration_41` vs `_42` and `shard 17` vs `18` stay distinct progress), AND retry text that is **current and recurrent** (per-sample: `current_patterns`, `pattern_sample_count`, `pattern_rate`, `consecutive_pattern_samples`; a `timeout` in one old frame never colours the idle frames after it). A **provider quota message** (`session limit`, `hit your … limit`, `/usage-credits`) is its own kind, **provider-limit** — a blocked state, not a loop. Known retry text (`Retrying`, `rate limit`, `overloaded`, `429`/`529`, `reconnecting`, connection errors, timeout, provider quota messages such as `session limit` / `hit your … limit`s) deciding when present. Low novelty without retry text is a soft, low-confidence warning, and only with work outstanding.

**Clock-only panes** (raw motion, normalized unchanged) are **alive**, not wedged — Chi's answer to the thread's open question. They are a kind of their own, never a warning, and carried in every trace so the observation stays re-checkable.

> Correction history: the first head (a490e23) judged case 1 on normalized frames — sonichi's Stand flagged it after Chi's "case 1 is about pure static"; fixed at 9d6d572, and clock-only made a non-warning at a7ff84b. Codex + sonichi's Stand P1s (failure boundary, pane text at rest with ordinary modes) fixed at 19ed4bf. First real-world rate-limit example (a witnessed pane shape, not a recorded trace) — the owner's screenshot of a Claude Code pane ending every turn with "You've hit your session limit", which read clock-only/alive — added as the `quota-limit` pattern at b1fb70d, its own `provider-limit` kind at 2ad6c46 (warn; the negative control reproduces the miss). Owner review on b1fb70d (per-sample patterns, continuity boundary, no blanket digit stripping, core-status freshness) fixed at 2ad6c46.

**Observation continuity (2ad6c46).** The persisted window is split into *observation runs* at a gap longer than `continuity_gap_s` (2700 s) or a change of **pane identity** (`pane_pid:session_created`, recorded by the probe and by health-check), and only the current run is classified; `duration` is measured inside the run, and a window whose newest sample is itself past the limit is "no current observation". Two identical frames eight hours apart are two glimpses, not eight hours of watching. Case-1 **high** confidence needs `static_high_conf_s` (300) *and* `static_high_conf_samples` (3): two samples 30 minutes apart are one gap (TustinOC's cadence finding); `median_gap_s` / `max_gap_s` ride in the evidence so a dense 3 s trace and a half-hourly window read differently.

**Work outstanding** = a queued task, or core-status `running` whose `ts` is within `status_ttl_s` (900 s — the same contract as `graceful-restart.sh busy()`); a stale or unstamped `running` is a crashed core's last word, not work.

Every verdict carries `kind`, `confidence`, `duration`, `sample_count`, `novel_state_count`, `novelty_rate`, `matched_patterns`, `current_patterns`, `pattern_sample_count`, `pattern_rate`, `consecutive_pattern_samples`, `observation_runs`, `run_samples`, `median_gap_s`, `work_outstanding`, `work_detail`, a human-readable `reason`, and the thresholds it used.

**Advisory only.** The health-check probe only ever returns `ok` or `warn`; nothing in `--recover-core` or task emission keys off it. **It reads the pane, not the process**: a green result is not evidence the core is healthy; it complements `.alive` and the runtime probes.

## Measurement-driven V1
Thresholds are `PROVISIONAL_THRESHOLDS`, reported in every verdict, to be tuned from real traces rather than guessed:
```
python3 src/cli_wedge.py record --socket <core socket> --label idle|build|retry|rate-limit --seconds 60 --interval 3
python3 src/cli_wedge.py replay <trace.jsonl> [--work-outstanding]
python3 src/cli_wedge.py probe  --socket <core socket>   # one sample into the rolling window + verdict
```
`record` writes one JSON line per sample — **hashes and pattern names only** by default (`state`, `raw_state`, `ts`, `patterns`); pane text is opt-in per kind, `--keep-normalized` and/or `--keep-raw` — plus a summary. The rolling `probe` window holds the same hash-only records. For an idle pane the summary must show `novel_state_count: 1` — that is the normalizer validation sonichi's Stand asked to run first.

## Privacy and failure contract (19ed4bf)
- **No pane text at rest by default.** Window and trace records are state hashes + pattern names; `classify_ids` classifies from hashes, so text is never needed. Text only with the explicit `--keep-*` flags.
- **Owner-only files.** `_write_private`: `O_EXCL` temp at `0600` → `os.replace`, in a directory forced to `0700`; a wide pre-existing mode is normalized on the next write (tested under `umask 022`).
- **Cadence is named, not silent (8ada45a, recent gaps at the head after).** A window whose trailing samples each stand alone (three or more singleton runs) reports `kind: cadence-too-sparse` with `recent_gap_s` — "a static pane cannot be observed at this rate" — instead of `unknown`; `window_median_gap_s` is history only. Two hourly samples after a dense era stay unknown: one gap is a gap.
- **The health-check path reads the pane (f7889dc, ce3add7).** `check_cli_wedge()` calls the module's own `core_target` / `capture_pane` / `pane_identity`: the session comes from the fresh local heartbeat (env, then the default), the window is the session's lowest live index from `list-windows` — never a bare `=name` (a pane target that stops resolving with a second window) and never `:0` (base-index may be 1). The probe tests drive a stand-in tmux **binary** with base-index 1 that rejects the old targets; a `custom-core` session from the heartbeat is the control against a hardcoded name.
- **A warning needs the run to have lasted (ce3add7).** `min_duration_s` (60, provisional) gates warnings only: two identical frames a second apart cannot establish a wedge; idle/working/clock-only are stated as before.
- **One writer at a time (c75fe5f).** `append_window` holds an exclusive `flock` on `window.jsonl.lock` around load → append → truncate → replace; `ConcurrentWriters` forks six workers through a barrier (7 of 7 land) and replays the unlocked shape as the negative control (1 survivor of 3).
- **The core never samples its own pane (cd9b6de, 573c513).** `check_cli_wedge()` asks `cli_wedge.sampled_from_inside()` before capturing: when `$TMUX_PANE` equals the resolved target's `#{pane_id}` **and `$TMUX` names the core socket** (pane ids are per tmux server; a foreign or unbound `TMUX_PANE` falls through), or the caller's pid chain (walked with `ps -o ppid=`) reaches the target's `#{pane_pid}`, the check returns `ok` with detail `skipped — sampled from inside the pane it watches (<which signal>)` and records nothing. A core's own output always moves under its own health-check pass, so the static case could never accumulate from inside; the sample would be a confident "working" that measures nothing. Unknown provenance (tmux failure, unparsable answer) is never a reason to skip. The health-check pass that runs in the supervised pane is exactly this path; an outside caller (the desktop supervision loop, a peer core, a cron in another pane) still samples.
- **A limit mentioned is not a limit hit; one window per watched target (04c15e3).** Codex's idle banner ("You have 3 usage limit resets available") matched the quota pattern, so an idle Codex pane was a high-confidence `provider-limit` forever (chi-air-blue's live test). The pattern now requires a hit (hit / reached / exceeded) on a session, usage, weekly, daily or plan limit, or the `hit your … limit` / `usage-credits` phrasings; `rate limit hit` stays `rate-limit`. The rolling window was one file per workspace keyed to the last-probed pane, so probing a worker reset the core's run; an explicit `--target` now gets its own window file and the core's stays put, and for an explicit target the probe says `no work signal for an explicit --target` instead of reading this core's queue. Still single-target by design here: `check_cli_wedge()` samples the core only, and a per-worker work signal is the follow-up.
- **The probe cannot abort health-check.** `check_cli_wedge()` wraps state I/O and classification and answers `ok` / "no reading — window state unusable (<ExcName>)"; persisted entries are validated on read (`_valid_entry`: a `[]` line, a string `ts`, a non-dict are skipped, never raised).

## Files
- `src/cli_wedge.py` — normalizer, novelty statistic, classifier, rolling window, I/O edge, CLI.
- `src/health-check.py` — `check_cli_wedge()` (warn/ok only), appended after the cron probes.
- `tests/cli-wedge.test.py` (53) — normalization per volatile class, novelty stats, every classifier branch (incl. clock-only alive and the quota-limited pane), window persistence and the trailing static run, I/O with fakes and malformed entries, record→replay and probe end to end via a stand-in tmux (in-process `main()`), confidentiality (hashes only, `0600`/`0700` under `umask 022`, text opt-in), failure boundary (a window path occupied by a directory raises at the library edge only), the self-sample guard (both signals, the fail-open path, the real pid walk names this process's parent), the Codex idle banner as a pinned negative with the real hit phrasings as positives, two targets probed alternately keeping separate windows (1, 1, 2, 2) with the core's untouched.
- `tests/cli-wedge-health-probe.test.py` (17) — the probe with faked heartbeat/tmux seams: no core / unreadable → ok; static+work → warn; retry loop → warn; idle and working → ok; malformed window lines and an unwritable window → ok "no reading", never a crash; a missing detector module → a detail, not a failure; the stand-in tmux naming THIS test process as the pane shell → skipped, no window written; `TMUX_PANE` naming the target on the core's server → skipped; the same pane id under another `$TMUX` socket, or with no `$TMUX` → still samples; an outside caller → still samples (the control).
- `docs/src-map.md` regenerated.

## Evidence
```
$ python3 tests/cli-wedge.test.py                     → Ran 53 tests … OK   [head 04c15e3; red at 9af8ac5: provider-limit on the idle Codex pane, and 1,1,1,1 across alternating targets; the guard's error path — raising tmux, unparsable answer, failing ps — asserted falsy, mutation-checked]
$ python3 tests/cli-wedge-health-probe.test.py        → Ran 17 tests … OK
# red control for 573c513 — its tests against cd9b6de's src: probe suite FAIL test_same_pane_id_on_another_tmux_server_still_samples,
#   FAIL test_tmux_pane_without_a_server_binding_does_not_skip … Ran 17 tests … FAILED (failures=2); unit suite ERROR test_sampled_from_inside_guard
$ /usr/bin/python3 scripts/check-python39-compat.py   → python39-compat: 173 file(s) parse cleanly on 3.9.6
# red control — HEAD's tests against the parent commit's src (24f1b02):
$ python3 tests/cli-wedge.test.py                     → ERROR: test_sampled_from_inside_guard … Ran 51 tests … FAILED (errors=1)
$ python3 tests/cli-wedge-health-probe.test.py        → FAIL: test_sampling_from_inside_the_watched_pane_is_skipped
                                                        FAIL: test_tmux_pane_naming_the_target_is_skipped … Ran 15 tests … FAILED (failures=2)
$ BASE_REF=origin/main bash scripts/lint-workspace-resolution.sh --diff → ✓ no new workspace-resolution anti-patterns
$ bash scripts/review-checks.sh --diff <staged diff>  → PASS (hardcoded-paths + root-artifacts + prose-cap clean)
$ /usr/bin/python3 scripts/check-python39-compat.py --target src/cli_wedge.py → parse cleanly on 3.9.6
```
Live readings on this host (owner's core, session busy, 2 tasks queued):
```
record --label build (8 samples, 2 s apart): kind=working novel_state_count=7 novelty_rate=0.875
probe ×3 against the live window:            kind=working confidence=high novel=3/3 work_outstanding=True (2 queued task(s))
```
Health-check-path live witness at `24f1b02` (this host; the real `python3 src/health-check.py` twice, 70 s apart, from a checkout at this head with the engine's `workspace` symlink, against the live core): run 1 `unknown: fewer than 2 samples`, run 2 `working (high): 2 distinct states over 2 samples`; on-disk `state/cli-wedge/window.jsonl` holds 2 entries with keys `pane, patterns, raw_state, state, ts` (pane `16530:1788550525`, span 72.8 s, modes 0600/0700); the heartbeat record supplied both socket and session. sonichi's Stand re-verified the same head live on a 2-window app session (`working (high)`).

The recorded trace is kept locally under `state/cli-wedge/traces/` (it is a capture of the owner's session, so not committed). `matched_patterns` on that busy pane contained `timeout` from the session's own command text — which is why patterns only decide when novelty is already low or the pane is static. Idle / retry / rate-limit traces are still to be recorded from real behaviour before the thresholds move; the tests use synthetic frames for those shapes and say so.

— sutando-qingyun-air










