### PR TITLE
fix(paths): channel_access_path never leaves the configured Claude home

### DIFF
--- a/src/access_store.py
+++ b/src/access_store.py
@@ -46,10 +46,9 @@ def resolve_discord_access_file() -> Path:
     so any writer (the bridge, or a skill-callable CLI in a separate process)
     resolves the identical file rather than duplicating the migration logic.
 
-    Before the first durable backup exists, preserve the transition-window
-    behavior: a missing canonical file may read/write the populated legacy
-    ``~/.claude`` file. Once the durable backup exists, a missing canonical
-    file is a wipe to restore — not a reason to resurrect legacy state.
+    A missing canonical file is a wipe to restore (durable backup) or a
+    migration to run — never a reason to reach the pre-migration home-directory file;
+    that fallback retired with its ~30-day window (shipped 2026-06-21).
     """
     if discord_access_backup_file().exists():
         return claude_home_path("channels", "discord", "access.json")

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -360,37 +360,16 @@ def claude_project_slug(path: str | Path) -> str:
 
 
 def channel_access_path(source: str) -> Path:
-    """Resolve `channels/<source>/access.json` with the ~30-day legacy fallback.
+    """Resolve `channels/<source>/access.json` inside the configured Claude home.
 
-    Prefer the canonical claude_home_path() location. If that file does NOT
-    exist but the pre-migration `~/.claude/channels/<source>/access.json`
-    does, return the legacy path and emit a one-line stderr deprecation
-    warning — per the CLAUDE.md migration policy (readers prefer canonical,
-    fall back to legacy for ~30 days).
-
-    Why this exists: bridges restarted under a fresh $CLAUDE_CONFIG_DIR
-    before the channel-bridge migrate step copies channels/ would otherwise
-    see no access.json at all — Telegram/Slack then re-arm TOFU onboarding
-    and the next DM sender auto-enrolls as owner. Falling back to the
-    populated legacy allowlist keeps access control continuous across the
-    migration window. Writers (TOFU onboarding, /discord:access) use the
-    same resolved path, so the legacy file stays the single source of truth
-    until it is actually migrated.
+    The pre-migration `~/.claude/channels/<source>/access.json` fallback shipped
+    2026-06-21 for a ~30-day window and is retired: it let any process whose
+    canonical file was absent — a bridge under a fresh $CLAUDE_CONFIG_DIR, or a
+    test that isolated one — read and WRITE the operator's real home. An absent
+    canonical file is now a migration to run (`scripts/sutando-migrate.sh`), not
+    a reason to reach outside the configured home.
     """
-    canonical = claude_home_path("channels", source, "access.json")
-    if canonical.exists():
-        return canonical
-    legacy = Path.home() / ".claude" / "channels" / source / "access.json"
-    if legacy != canonical and legacy.exists():
-        print(
-            f"[util_paths] DEPRECATION: using legacy {legacy} — canonical "
-            f"{canonical} missing. Run the channel-bridge migrate step "
-            f"(scripts/sutando-migrate.sh) to relocate; this fallback is "
-            f"removed ~30 days post-migration.",
-            file=sys.stderr,
-        )
-        return legacy
-    return canonical
+    return claude_home_path("channels", source, "access.json")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/channel-access-path-no-legacy-fallback.test.py
+++ b/tests/channel-access-path-no-legacy-fallback.test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""channel_access_path() never leaves the configured Claude home.
+
+The ~/.claude fallback shipped 2026-06-21 with a ~30-day life; past it, an
+isolated CLAUDE_CONFIG_DIR that lacks the file must resolve inside itself,
+never to the operator's real home (a test fixture wrote there, 2026-09-05).
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp = Path(tmp)
+    fake_home = tmp / "home"
+    legacy = fake_home / ".claude" / "channels" / "discord" / "access.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text('{"allowFrom": ["REAL-OPERATOR-ID"]}')
+    isolated = tmp / "ccd"
+    isolated.mkdir()
+    os.environ["HOME"] = str(fake_home)
+    os.environ["CLAUDE_CONFIG_DIR"] = str(isolated)
+    os.environ.pop("CLAUDE_HOME", None)
+    spec = importlib.util.spec_from_file_location("util_paths", ROOT / "src" / "util_paths.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(ROOT / "src"))
+    spec.loader.exec_module(mod)
+    got = mod.channel_access_path("discord")
+    want = isolated / "channels" / "discord" / "access.json"
+    ok = got == want
+    print(("ok  " if ok else "FAIL") + f" - an isolated CLAUDE_CONFIG_DIR resolves inside itself, not to HOME's legacy file (got {got})")
+    ok2 = not str(got).startswith(str(fake_home))
+    print(("ok  " if ok2 else "FAIL") + " - the resolved path is never under the operator's home")
+    sys.exit(0 if ok and ok2 else 1)


### PR DESCRIPTION
## What

`channel_access_path()` returns the canonical `channels/<source>/access.json` under the configured Claude home, unconditionally. The pre-migration home-directory fallback is removed, and `access_store.resolve_discord_access_file`'s docstring says the same.

## Why

The fallback shipped 2026-06-21 (#1454) for a ~30-day migration window and stayed 76 days. It let any process whose canonical file was absent resolve to the operator's real home and write it: on 2026-09-05 at 06:03Z, a test fixture for #3929 that had isolated `CLAUDE_CONFIG_DIR` (so the CI lint `lint-hermetic-bridge-tests` passed it) fell through to the operator's live legacy access file and overwrote it with three fake ids. The lint models isolation as `CLAUDE_CONFIG_DIR`; it cannot see a reach through `HOME`, and the resolver is the one place that reach exists. Owner's ask, practice thread 16:18Z: "Prevent such mistakes for future?"

## Evidence

New `tests/channel-access-path-no-legacy-fallback.test.py`: HOME holds a populated legacy file, `CLAUDE_CONFIG_DIR` is an isolated empty dir. At the parent (2de65c6c):

```
FAIL - an isolated CLAUDE_CONFIG_DIR resolves inside itself, not to HOME's legacy file (got <HOME>/.claude/channels/discord/access.json)
FAIL - the resolved path is never under the operator's home
```

At HEAD both read `ok`. Also green at HEAD: the six suites that name the legacy path (telegram-bridge-send-reply-markers, progress-stream, discord-bridge-heartbeat-offload, dm-result-multipart-upload, discord-bridge-mod-judge-buffer, discord-chunker), discord-access-backup, access-mutate-cli, lint-hermetic-bridge-tests.

## Cost to state

A host that never ran the channel-bridge migrate step and still has its access file only in the old home location will, after this, see an absent canonical file: Telegram/Slack re-arm TOFU onboarding there, which is exactly what the fallback existed to prevent during the window. The window is over; the remedy is `scripts/sutando-migrate.sh`, and the durable backup under `state/auth/` covers a wipe. Both hosts in this fleet have the canonical file (verified on this one).

@sonichi this is the prevention PR from the 16:18Z thread; the merge is yours.

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)
