### PR TITLE
feat(runtime-api): a stale host label is annotated, not a second machine

### DIFF
--- a/src/runtime-api/agents_view.py
+++ b/src/runtime-api/agents_view.py
@@ -44,8 +44,14 @@ class AgentsView:
     @staticmethod
     def _identity_key(entry: dict):
         # Absent start time is not evidence of sameness: pid alone recycles.
+        # Only the writer's scalar types qualify: an unhashable payload value
+        # must not reach a dict key and take enumeration down with it.
         pid, started = entry.get("pid"), entry.get("started_at")
-        return None if pid is None or started is None else (pid, started)
+        if isinstance(pid, bool) or isinstance(started, bool):
+            return None
+        if not isinstance(pid, int) or not isinstance(started, (int, float)):
+            return None
+        return (pid, started)
 
     def _annotate_superseded(self, agents: list) -> None:
         """A dead heartbeat whose (pid, started_at) matches a LIVE one is the

--- a/src/runtime-api/agents_view.py
+++ b/src/runtime-api/agents_view.py
@@ -44,8 +44,7 @@ class AgentsView:
     @staticmethod
     def _identity_key(entry: dict):
         # Absent start time is not evidence of sameness: pid alone recycles.
-        # Only the writer's scalar types qualify: an unhashable payload value
-        # must not reach a dict key and take enumeration down with it.
+        # Only the writer's scalar types qualify — others cannot key a dict.
         pid, started = entry.get("pid"), entry.get("started_at")
         if isinstance(pid, bool) or isinstance(started, bool):
             return None

--- a/src/runtime-api/agents_view.py
+++ b/src/runtime-api/agents_view.py
@@ -30,11 +30,38 @@ class AgentsView:
         self.cores_dir = Path(state_dir) / "cores"
 
     def list_agents(self) -> dict:
+        agents = self._entries()
+        return {"agents": agents}
+
+    def _entries(self) -> list:
         agents = []
         if self.cores_dir.is_dir():
             for f in sorted(self.cores_dir.glob("*.alive")):
                 agents.append(self._entry(f))
-        return {"agents": agents}
+        self._annotate_superseded(agents)
+        return agents
+
+    @staticmethod
+    def _identity_key(entry: dict):
+        # Absent start time is not evidence of sameness: pid alone recycles.
+        pid, started = entry.get("pid"), entry.get("started_at")
+        return None if pid is None or started is None else (pid, started)
+
+    def _annotate_superseded(self, agents: list) -> None:
+        """A dead heartbeat whose (pid, started_at) matches a LIVE one is the
+        same process under a stale host label — annotate, never hide or delete."""
+        live = {}
+        for a in agents:
+            k = self._identity_key(a)
+            if k is not None and a.get("alive"):
+                live.setdefault(k, a["agentId"])
+        for a in agents:
+            if a.get("alive"):
+                continue
+            k = self._identity_key(a)
+            holder = live.get(k) if k is not None else None
+            if holder is not None and holder != a["agentId"]:
+                a["supersededBy"] = holder
 
     def agent_status(self, agent_id: str) -> dict | None:
         """Status for one agent, or None if no heartbeat file matches.
@@ -42,11 +69,10 @@ class AgentsView:
         payload's self-reported host."""
         if not agent_id:
             return None
-        if self.cores_dir.is_dir():
-            for f in self.cores_dir.glob("*.alive"):
-                entry = self._entry(f)
-                if agent_id in (f.stem, entry.get("host")):
-                    return entry
+        # Built from the full set so a superseded entry reports it here too.
+        for entry in self._entries():
+            if agent_id in (entry.get("agentId"), entry.get("host")):
+                return entry
         return None
 
     def _entry(self, f: Path) -> dict:

--- a/tests/runtime-api-agents-view.test.py
+++ b/tests/runtime-api-agents-view.test.py
@@ -190,5 +190,55 @@ class ASupersededGhostIsAnnotatedNotHidden(unittest.TestCase):
         self.assertEqual(st.get("supersededBy"), "new-label")
 
 
+class AMalformedHeartbeatCannotBreakEnumeration(unittest.TestCase):
+    """`_entry()` passes payload values through verbatim, so a stale or hand-edited
+    .alive can carry any JSON type. Identity keying must not turn that into a
+    TypeError that takes down agent.list AND every agent.status lookup."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.cores = Path(self.tmp) / "cores"
+        self.cores.mkdir()
+
+    def _raw(self, label, payload, age_s):
+        f = self.cores / f"{label}.alive"
+        f.write_text(json.dumps(payload))
+        t = time.time() - age_s
+        os.utime(f, (t, t))
+        return f
+
+    def test_unhashable_started_at_does_not_raise(self):
+        # The exact payload from the review: (1, []) is an unhashable tuple.
+        self._raw("bad", {"pid": 1, "started_at": []}, 1)
+        self._raw("good", {"pid": 2, "started_at": 100.0}, 1)
+        got = {a["agentId"] for a in AgentsView(self.tmp).list_agents()["agents"]}
+        self.assertEqual(got, {"bad", "good"})
+
+    def test_unhashable_pid_does_not_raise(self):
+        self._raw("bad", {"pid": {"a": 1}, "started_at": 100.0}, 1)
+        self.assertEqual(len(AgentsView(self.tmp).list_agents()["agents"]), 1)
+
+    def test_agent_status_still_answers_when_a_sibling_is_malformed(self):
+        # status builds from the same _entries(); one bad file must not blind it.
+        self._raw("bad", {"pid": 1, "started_at": []}, 1)
+        self._raw("good", {"pid": 2, "started_at": 100.0}, 1)
+        self.assertIsNotNone(AgentsView(self.tmp).agent_status("good"))
+
+    def test_malformed_values_are_not_identity_evidence(self):
+        # A dead and a live file both carrying junk must NOT be collapsed:
+        # equal-but-invalid values are not proof of the same process.
+        self._raw("ghost", {"pid": "x", "started_at": "y"}, 10_000)
+        self._raw("live", {"pid": "x", "started_at": "y"}, 1)
+        by = {a["agentId"]: a for a in AgentsView(self.tmp).list_agents()["agents"]}
+        self.assertNotIn("supersededBy", by["ghost"])
+
+    def test_bool_pid_is_rejected_even_though_bool_is_an_int(self):
+        # isinstance(True, int) is True in Python; True must not key to pid 1.
+        self._raw("ghost", {"pid": True, "started_at": 100.0}, 10_000)
+        self._raw("live", {"pid": 1, "started_at": 100.0}, 1)
+        by = {a["agentId"]: a for a in AgentsView(self.tmp).list_agents()["agents"]}
+        self.assertNotIn("supersededBy", by["ghost"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/runtime-api-agents-view.test.py
+++ b/tests/runtime-api-agents-view.test.py
@@ -138,5 +138,57 @@ class DispatcherWiringTests(unittest.TestCase):
             asyncio.run(d.handle("agent.list", {}))
 
 
+class ASupersededGhostIsAnnotatedNotHidden(unittest.TestCase):
+    """A host-label change leaves stale .alive files describing a process that is
+    still running under a new label; agent.list must collapse them without lying."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.cores = Path(self.tmp) / "cores"
+        self.cores.mkdir()
+
+    def _beat(self, label, pid, started, age_s):
+        f = self.cores / f"{label}.alive"
+        payload = {"pid": pid}
+        if started is not None:
+            payload["started_at"] = started
+        f.write_text(json.dumps(payload))
+        t = time.time() - age_s
+        os.utime(f, (t, t))
+        return f
+
+    def _by_id(self):
+        return {a["agentId"]: a for a in AgentsView(self.tmp).list_agents()["agents"]}
+
+    def test_dead_label_sharing_pid_and_start_with_a_live_one_is_superseded(self):
+        self._beat("new-label", 8654, 1783220522.875356, 1)
+        self._beat("old-label", 8654, 1783220522.875356, 300000)
+        got = self._by_id()
+        self.assertEqual(got["old-label"].get("supersededBy"), "new-label")
+        self.assertFalse(got["old-label"]["alive"], "annotation must not revive a dead entry")
+        self.assertNotIn("supersededBy", got["new-label"], "the live holder is not superseded")
+
+    def test_same_pid_but_different_start_is_a_genuinely_distinct_host(self):
+        # pid recycles across reboots; started_at is what discriminates.
+        self._beat("live-host", 7449, 1783220522.875356, 1)
+        self._beat("old-real-host", 7449, 1781143903.3270772, 300000)
+        self.assertNotIn("supersededBy", self._by_id()["old-real-host"])
+
+    def test_absent_started_at_is_never_treated_as_evidence(self):
+        self._beat("live-nostart", 555, None, 1)
+        self._beat("dead-nostart", 555, None, 300000)
+        self.assertNotIn("supersededBy", self._by_id()["dead-nostart"])
+
+    def test_a_dead_entry_with_no_live_twin_is_left_alone(self):
+        self._beat("only-dead", 4242, 1783220522.5, 300000)
+        self.assertNotIn("supersededBy", self._by_id()["only-dead"])
+
+    def test_agent_status_reports_the_same_annotation_as_agent_list(self):
+        self._beat("new-label", 8654, 1783220522.875356, 1)
+        self._beat("old-label", 8654, 1783220522.875356, 300000)
+        st = AgentsView(self.tmp).agent_status("old-label")
+        self.assertEqual(st.get("supersededBy"), "new-label")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Roadmap **Track 10** (agent locality visibility), tier-1 slice.

## The defect, re-measured on this host today (not taken from the roadmap note)

`agent.list` enumerates `state/cores/*.alive`. A host-label change leaves the old file behind, so ONE process describes several machines:

```
label                          pid    started_at            beat_age
Mac-186                        8654   1783220522.875356       33.8d
Qingyuns-MacBook-Pro-2200      8654   1783220522.875356       0.00d   <- live
QingyunsMBP2200                8654   1783220522.875356        3.5d
Qingyuns-MacBook-Pro-2074      7449   1781143903.327...       85.5d   <- genuinely distinct
```

Identical pid **and** identical `started_at` to the microsecond is the same process. A Tailscale-style panel over this renders three devices for one machine.

## The change

A dead entry whose `(pid, started_at)` matches a **live** entry gains `supersededBy: <live agentId>`.

**Additive only** — nothing is hidden or deleted, `alive` is untouched, and mtime stays the sole trust signal, preserving `agents_view`'s stated design. Deleting stale `.alive` files is the tempting fix and the wrong one: it is destructive and would erase the genuine 2074 record.

**`started_at` is required for the match.** pid alone recycles across reboots, and five live heartbeats on this host (`core-1..4`, `pool-lead`) carry no `started_at` at all — those never group.

## Live E2E (real `state/cores`, 10 entries)

```
Mac-186                    alive=False  supersededBy=Qingyuns-MacBook-Pro-2200
QingyunsMBP2200            alive=False  supersededBy=Qingyuns-MacBook-Pro-2200
Qingyuns-MacBook-Pro-2200  alive=True   (not annotated — it is the holder)
Qingyuns-MacBook-Pro-2074  alive=False  NOT annotated (different started_at)
pool-lead / core-1..4                   NOT annotated (no started_at)
```

Three ghosts collapse to one machine; the distinct host and the evidence-poor entries are untouched.

## Mutation control — revert `agents_view.py` only, keep the tests

```
AT PARENT: FAILED (failures=2)
  test_dead_label_sharing_pid_and_start_with_a_live_one_is_superseded
  test_agent_status_reports_the_same_annotation_as_agent_list
AT HEAD:   Ran 16 tests — OK
```

**Being explicit about coverage:** the other three new tests assert *absence* of the annotation and pass at the parent by design. They guard against over-collapsing (`same pid different start`, `absent started_at`, `dead with no live twin`) — regression guards, not proof of the feature. Only the two above discriminate.

`agent.status` builds from the full set so a superseded entry reports it there too, rather than `list` and `status` disagreeing.

`scripts/review-checks.sh --diff` on the cumulative diff vs this base: **PASS**.
