### PR TITLE
fix(ci): PRs based on this branch trigger no workflows (port of #3353)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, staging-interaction-planes]
   push:
     branches: [main, staging-interaction-planes]
 


### PR DESCRIPTION
One line. Applies to this branch the same fix **@john-the-dev** already landed on `main` as **#3353** — *"fix(ci): PRs stacked on a feature branch trigger no workflows"* (`d296c54a0`, 2026-08-24), whose diff is exactly `-    branches: [main, staging-interaction-planes]`.

## Why this branch still has it

`feat/sutando-server`'s `ci.yml` was last touched **2026-08-22** and **does not contain #3353**:

```
git merge-base --is-ancestor d296c54a0 origin/feat/sutando-server  -> NO  (predates the fix)
git merge-base --is-ancestor d296c54a0 origin/main                 -> YES
```

So `on.pull_request.branches` is still `[main, staging-interaction-planes]`, and `feat/sutando-server` is not in that list — **`ci.yml` cannot fire for any PR based here.**

## Measured impact

```
open PRs on base=feat/sutando-server ....... 11
  checks each ............................... 2   (parse-on-the-floor, license/cla)
open PR on base=rescue/... (has #3353) ..... 20   (incl. python standalone tests, ruff, eslint, tsc)
```

Neither of the 2 runs a test. So every one of those 11 shows `MERGEABLE` + all-checks-green while **nothing was executed** — a green that is *unmeasured*, not passing.

Among the starved, with some irony: **#3513 — "fix: the two one-line CI failures this base had been hiding"**. A CI fix, on a base whose CI does not run.

## Scope

Deliberately one line. `on.push` still differs from main (#3357 dropped branch names that no longer exist); that is cosmetic, does not affect PR CI, and belongs in a separate change.

**Expect this to surface real failures on those 11 PRs.** That is the intent — they are currently untested, not passing.

Verified: `yaml.safe_load` parses; `on.pull_request` is now `None` (no filter, runs for any base); 3 jobs intact. `scripts/review-checks.sh --diff`: hardcoded-paths + root-artifacts clean (prose-cap has no in-scope files — the diff is YAML).
