### PR TITLE
fix(health-check): a completed job that published nothing is not an unconsumed task

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6851,7 +6851,8 @@ def _interpret_daily_punctuality(jobs: list) -> dict:
         # missed-today verdict would blame it for the probe's own blind spot.
         if j.get("naming_stale"):
             drifted.append((j["name"], j.get("newest_artifact") or "?",
-                            j.get("artifact_age_days")))
+                            j.get("artifact_age_days"),
+                            bool(j.get("completion_today"))))
             continue
         # Wrap to the NEAREST occurrence: 23:42 finishing 00:05 is +23 late, not
         # -1417 early. The filename date is logical, often a day off the mtime.
@@ -6919,12 +6920,20 @@ def _interpret_daily_punctuality(jobs: list) -> dict:
         bits.append(f"{n}: DISPATCHED {fired // 60:02d}:{fired % 60:02d} but produced "
                     f"no output {m} min past due — the schedule fired and the task was "
                     f"never consumed, so this is the consumer, not the cron")
-    for n, newest, age in sorted(drifted):
+    for n, newest, age, ran in sorted(drifted):
         age_txt = f", {age}d ago" if age is not None else ""
-        bits.append(f"{n}: UNCHECKED — artifacts stop at {newest}{age_txt}, so the "
-                    f"probe's filename match has drifted off this job's output; "
-                    f"punctuality cannot be scored and a missed-today verdict would "
-                    f"blame the job for the probe's own blind spot")
+        if ran:
+            # A completion record dates TODAY, so "the match drifted" cannot be
+            # asserted: this run holds evidence the job ran. Name both candidates.
+            bits.append(f"{n}: UNCHECKED — artifacts stop at {newest}{age_txt}, but a "
+                        f"task-cron completion record exists TODAY, so the job did run; "
+                        f"either the probe's filename match drifted off its output or it "
+                        f"published nothing. Punctuality cannot be scored either way")
+        else:
+            bits.append(f"{n}: UNCHECKED — artifacts stop at {newest}{age_txt}, so the "
+                        f"probe's filename match has drifted off this job's output; "
+                        f"punctuality cannot be scored and a missed-today verdict would "
+                        f"blame the job for the probe's own blind spot")
     for n, m, dm, c in sorted(trailing):
         bits.append(f"{n}: dispatches on time (median {dm:+g} min); output trails by "
                     f"median {m:+g} min over {c} run(s) — latency, not the schedule")

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6839,7 +6839,7 @@ def _interpret_daily_punctuality(jobs: list) -> dict:
     identical to one produced by a working schedule."""
     name = "daily-cron-punctuality"
     late, missed, unknown, drifted, quiet = [], [], [], [], []
-    unconsumed, trailing = [], []
+    unconsumed, trailing, unpublished = [], [], []
     for j in jobs:
         due = j["hour"] * 60 + j["minute"]
         if not j["artifacts"]:
@@ -6875,8 +6875,11 @@ def _interpret_daily_punctuality(jobs: list) -> dict:
             if fired is None:
                 missed.append((j["name"], j["minutes_since_due"]))
             else:
-                unconsumed.append((j["name"], fired, j["minutes_since_due"]))
-    if not late and not missed and not drifted and not unconsumed:
+                # A completion record means the consumer DID run; blaming it would
+                # send the reader to the wrong layer. Separate bucket, separate cause.
+                bucket = unpublished if j.get("completion_today") else unconsumed
+                bucket.append((j["name"], fired, j["minutes_since_due"]))
+    if not late and not missed and not drifted and not unconsumed and not unpublished:
         seen = len(jobs) - len(unknown) - len(quiet)
         detail = f"{seen} of {len(jobs)} daily job(s) observable"
         detail += ", all on schedule" if seen else ""
@@ -6908,6 +6911,10 @@ def _interpret_daily_punctuality(jobs: list) -> dict:
     for n, m in missed:
         bits.append(f"{n}: no output today, {m} min past due, and no task was "
                     f"dispatched — the schedule itself did not fire")
+    for n, fired, m in unpublished:
+        bits.append(f"{n}: DISPATCHED {fired // 60:02d}:{fired % 60:02d} and COMPLETED "
+                    f"(a task-cron result exists) but published no artifact {m} min past "
+                    f"due — the producer, not the consumer, and not the cron")
     for n, fired, m in unconsumed:
         bits.append(f"{n}: DISPATCHED {fired // 60:02d}:{fired % 60:02d} but produced "
                     f"no output {m} min past due — the schedule fired and the task was "
@@ -7094,8 +7101,12 @@ def check_daily_cron_punctuality() -> dict:
             used_artifact_lane = bool(arts) and launchd
         # Last resort, and the only lane needing no per-job config: a job that
         # publishes nothing dated still leaves a task-cron result when it finishes.
+        # Computed ALWAYS, not only as the no-artifact fallback below. A job that
+        # published artifacts and then lost its producer keeps its history, so the
+        # fallback never runs and its real completion record stays invisible.
+        completions = _daily_task_record_minutes(ws / "results", jname)
         if not arts:
-            arts = _daily_task_record_minutes(ws / "results", jname)
+            arts = completions
             used_artifact_lane = False
         # Staleness is computed HERE because `now` lives here; the interpret layer
         # reads it as an optional field so its fixtures stay clock-independent.
@@ -7112,6 +7123,9 @@ def check_daily_cron_punctuality() -> dict:
             "newest_artifact": newest, "artifact_age_days": age_days,
             "naming_stale": age_days is not None and age_days > DAILY_ARTIFACT_STALE_DAYS,
             "today_seen": any(d == now.strftime("%Y-%m-%d") for d, _ in arts),
+            # Consumption is a DIFFERENT fact from publication: a task can finish
+            # correctly and publish nothing (producer removed, [no-send] by design).
+            "completion_today": any(d == now.strftime("%Y-%m-%d") for d, _ in completions),
             "minutes_since_due": max(0, int((now - due).total_seconds() // 60)),
             # Dispatch is the schedule's own evidence: it is what "on time"
             # means, and it is what an output mtime cannot report.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -7101,9 +7101,8 @@ def check_daily_cron_punctuality() -> dict:
             used_artifact_lane = bool(arts) and launchd
         # Last resort, and the only lane needing no per-job config: a job that
         # publishes nothing dated still leaves a task-cron result when it finishes.
-        # Computed ALWAYS, not only as the no-artifact fallback below. A job that
-        # published artifacts and then lost its producer keeps its history, so the
-        # fallback never runs and its real completion record stays invisible.
+        # Unconditional, not the no-artifact fallback below: a job that published
+        # artifacts then lost its producer keeps history, hiding its completion.
         completions = _daily_task_record_minutes(ws / "results", jname)
         if not arts:
             arts = completions

--- a/tests/health-check-punctuality-completed-unpublished.test.py
+++ b/tests/health-check-punctuality-completed-unpublished.test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""A dispatched job that goes quiet has TWO causes, and one of them is not the consumer.
+
+`DISPATCHED ... never consumed, so this is the consumer` is a claim about the task
+bridge. It also fires when the consumer ran fine and the job simply published
+nothing — a removed producer, or a `[no-send]` result by design. Measured
+2026-09-05 on `daily-insight`: the task was consumed and a result archived, while
+the probe reported it as never consumed and pointed at the wrong layer.
+
+The fallback to task-cron results only runs when a job has NO dated artifacts, so
+a job that published artifacts and then lost its producer keeps its history, the
+fallback never fires, and its completion record stays invisible.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+_spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+sys.modules["hc"] = hc
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+DUE_H, DUE_M = 6, 50
+DUE = DUE_H * 60 + DUE_M
+HISTORY = [(f"2026-08-0{i}", DUE + 1) for i in range(1, 8)]
+
+
+def job(**over):
+    j = {"name": "daily-insight", "hour": DUE_H, "minute": DUE_M,
+         "artifacts": HISTORY, "today_seen": False, "minutes_since_due": 120,
+         "conditional": False, "stem_declared": True, "dispatched_today": DUE}
+    j.update(over)
+    return j
+
+
+class CompletedButUnpublished(unittest.TestCase):
+    def test_completion_record_blames_the_producer_not_the_consumer(self):
+        d = hc._interpret_daily_punctuality([job(completion_today=True)])
+        self.assertEqual(d["status"], "warn")
+        self.assertIn("COMPLETED", d["detail"])
+        self.assertIn("the producer, not the consumer", d["detail"])
+        self.assertNotIn("never consumed", d["detail"])
+
+    def test_no_completion_record_still_blames_the_consumer(self):
+        """The discriminating pair: same job, only completion_today differs."""
+        d = hc._interpret_daily_punctuality([job(completion_today=False)])
+        self.assertIn("never consumed", d["detail"])
+        self.assertNotIn("the producer, not the consumer", d["detail"])
+
+    def test_absent_key_keeps_the_old_verdict(self):
+        """Back-compat: fixtures predating the field must not change meaning."""
+        j = job()
+        j.pop("completion_today", None)
+        d = hc._interpret_daily_punctuality([j])
+        self.assertIn("never consumed", d["detail"])
+
+    def test_unpublished_alone_still_fails_the_green_gate(self):
+        """A job in the new bucket must not let the probe report ok."""
+        d = hc._interpret_daily_punctuality([job(completion_today=True)])
+        self.assertNotEqual(d["status"], "ok")
+
+    def test_a_healthy_job_is_still_ok(self):
+        """Deliberately GREEN: without it, an always-warn probe reads as vigilance."""
+        d = hc._interpret_daily_punctuality([job(today_seen=True, completion_today=True)])
+        self.assertEqual(d["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-punctuality-completed-unpublished.test.py
+++ b/tests/health-check-punctuality-completed-unpublished.test.py
@@ -67,6 +67,33 @@ class CompletedButUnpublished(unittest.TestCase):
         d = hc._interpret_daily_punctuality([job(completion_today=True)])
         self.assertNotEqual(d["status"], "ok")
 
+    def test_a_stale_corpus_does_not_assert_a_drift_it_has_evidence_against(self):
+        """The fix above has a SHELF LIFE without this arm (found by @TustinOC).
+
+        `naming_stale` is tested first and continues, so once the newest artifact
+        ages past DAILY_ARTIFACT_STALE_DAYS the corrected message is unreachable and
+        the drifted wording returns — asserting a filename drift while THIS RUN holds
+        a completion record saying the job ran. Measured at e3aad750: the
+        completion_today=True and =False details were byte-identical.
+        """
+        stale = dict(artifacts=[("2026-08-29", DUE + 1)],
+                     newest_artifact="2026-08-29", artifact_age_days=11,
+                     naming_stale=True)
+        ran = hc._interpret_daily_punctuality([job(completion_today=True, **stale)])["detail"]
+        not_ran = hc._interpret_daily_punctuality([job(completion_today=False, **stale)])["detail"]
+        self.assertNotEqual(ran, not_ran, "the completion record must change the message")
+        self.assertIn("did run", ran)
+        self.assertNotIn("has drifted off this job's output", ran)
+
+    def test_a_genuinely_drifted_job_keeps_the_drift_wording(self):
+        """Precision control: rerouting the bucket was the wrong fix. With no
+        completion record, `drifted` is exactly the right verdict and must survive."""
+        d = hc._interpret_daily_punctuality([job(
+            completion_today=False, artifacts=[("2026-08-29", DUE + 1)],
+            newest_artifact="2026-08-29", artifact_age_days=11, naming_stale=True)])
+        self.assertIn("has drifted off this job's output", d["detail"])
+        self.assertNotIn("did run", d["detail"])
+
     def test_a_healthy_job_is_still_ok(self):
         """Deliberately GREEN: without it, an always-warn probe reads as vigilance."""
         d = hc._interpret_daily_punctuality([job(today_seen=True, completion_today=True)])


### PR DESCRIPTION
## What it reports today, and why that is wrong

`daily-cron-punctuality` has been emitting this on my host:

```
daily-insight: DISPATCHED 06:50 but produced no output 349 min past due —
the schedule fired and the task was never consumed, so this is the consumer, not the cron
```

The task **was** consumed. Both files exist for today's run:

```
tasks/archive/2026-09/task-cron-daily-insight-1788616246380.txt
results/archive/2026-09/task-cron-daily-insight-1788616246380.txt   <- the result
```

and the result body reads `[no-send]` + *"script deleted upstream (#3393); no action taken"*. `src/daily-insight.py` is genuinely absent. So the consumer ran, the task completed, and the job published nothing because its producer is gone. The message sends the reader to the task bridge, which is the one layer that is working.

## The cause is structural, not wording

`_daily_task_record_minutes` — the lane that can see task-cron completion records — runs only inside `if not arts:`, i.e. only for a job with **no dated artifacts at all**. A job that published artifacts and then lost its producer keeps its history, so the fallback never fires and the completion record is invisible to the classifier.

Measured on this host: `daily-insight` has 4 dated `insight-*` artifacts, newest `2026-08-29`. With `DAILY_ARTIFACT_STALE_DAYS = 10` that is 7 days old — under the threshold, so it is not routed to `drifted` either. It therefore lands in `unconsumed` and blames the consumer.

**That yields a falsifiable prediction:** on **2026-09-08**, when the newest artifact turns 10 days old, this warn will change its own wording from *"never consumed"* to the `drifted` *"the probe's filename match has drifted"* — with nothing about the system having changed. Neither message names the producer.

## The change

- compute the completion lane **unconditionally** (it was only the no-artifact fallback) and expose `completion_today`
- split the dispatched-but-silent case: a completion record means the consumer ran, so report **"COMPLETED ... but published no artifact — the producer, not the consumer, and not the cron"**; with no completion record the existing "never consumed" verdict is untouched

`_interpret_daily_punctuality` takes plain dicts, so this is testable without a clock or filesystem.

## Evidence

**Before** (existing 4 suites, on this branch): all pass — a fixture lacking `completion_today` keeps its old verdict, so no existing meaning changes.

```
PASS daily-punctuality-completion-sentinels.test.py
PASS health-check-daily-punctuality.test.py
PASS health-check-punctuality-dispatch.test.py
PASS health-check-punctuality-scores-dispatch.test.py
```

**After**: new suite, 5 tests, including a **deliberately green** arm so an always-warn probe cannot read as vigilance, and the discriminating pair where only `completion_today` differs.

**Mutation-verified, not merely green.** Replacing the split with `bucket = unconsumed` (fix disabled) fails exactly one arm — the one asserting the new attribution — and restoring passes:

```
MUTANT rc=1   FAIL: test_completion_record_blames_the_producer_not_the_consumer
RESTORED rc=0
```

The other arms stay green under the mutant by design: they do not exercise the new branch, so a mutation that reddened all five would mean the arms were not independent.

`tests/ci-covers-every-python-test.test.py` passes, so the new suite is discovered.

## Scope

Only the dispatched-but-silent classification. Punctuality medians, the `missed` and `drifted` buckets, and the artifact lanes are untouched. I did not change `DAILY_ARTIFACT_STALE_DAYS`; the 10-day window above is described, not adjusted.
