### PR TITLE
fix(discord-bridge): the reply-context path was blind to a FORWARDED parent

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -163,7 +163,7 @@ from policy.egress.result import guard_result_for_tier, resolve_access_tier as _
 from delivery.readiness import read_ready_result  # noqa: E402
 from dedup_recovery import plan_dedup_recovery, report_disposition  # noqa: E402
 from discord_addressee import is_addressed_in_shared_channel, reference_is_reply  # noqa: E402  # pragma: no cover — bridge not unit-imported; addressee logic is covered in discord_addressee.py
-from reply_chain import format_parent_reference, format_reply_chain, format_reply_chain_ids, format_reply_chain_truncation, should_fetch_reply_context, walk_reply_chain  # noqa: E402  # pragma: no cover — bridge not unit-imported; chain formatting is covered in reply_chain.py
+from reply_chain import format_parent_reference, format_reply_chain, format_reply_chain_ids, format_reply_chain_truncation, readable_attachments, should_fetch_reply_context, walk_reply_chain  # noqa: E402  # pragma: no cover — bridge not unit-imported; chain formatting is covered in reply_chain.py
 
 # Cap the reply-chain CONTENT walk (a fetch per level; the immediate parent is
 # depth 0). Only the immediate parent is inlined, so beyond this there is no
@@ -3753,7 +3753,9 @@ async def _handle_discord_message(message, force=False):
                 # dropped — only the reply's own (often empty) attachment
                 # set was scanned above. Same save + sanitized-basename +
                 # image-vision pattern as the primary loop.
-                for att in getattr(ref_msg, "attachments", []):
+                # A forwarded parent keeps its files in message_snapshots, so
+                # a plain ref_msg.attachments read is empty for exactly that shape.
+                for att in readable_attachments(ref_msg):
                     p_path = INBOX_DIR / f"{int(time.time()*1000)}_{_safe_attachment_basename(att.filename)}"
                     try:
                         await att.save(p_path)

--- a/src/reply_chain.py
+++ b/src/reply_chain.py
@@ -66,6 +66,53 @@ def format_reply_chain_ids(ids: Sequence) -> str:
     return "reply_chain_ids: " + ",".join(reversed(clean)) + "\n"
 
 
+def forwarded_payload(msg):
+    """The forwarded message a Discord message carries, or ``None``.
+
+    A forward's body and attachments live in ``message_snapshots[0].message``,
+    never on the message itself, so reading the message directly sees an empty one.
+    """
+    snaps = getattr(msg, "message_snapshots", None) or []
+    if not snaps:
+        return None
+    first = snaps[0]
+    return getattr(first, "message", first)
+
+
+def readable_content(msg) -> str:
+    """``msg``'s body, including the forwarded payload it carries.
+
+    A forwarded PARENT rendered as an empty reply-context block: the bridge read
+    ``ref_msg.content``, which a forward leaves empty. Labelled rather than
+    inlined — attributing a quoted message to the forwarder is its own misreading.
+    """
+    own = (getattr(msg, "content", "") or "").strip()
+    snap = forwarded_payload(msg)
+    if snap is None:
+        return own
+    fwd = (getattr(snap, "content", "") or "").strip()
+    names = [f"<attachment: {getattr(a, 'filename', None) or '?'}>"
+             for a in (getattr(snap, "attachments", None) or [])]
+    inner = " ".join(x for x in (fwd, *names) if x)
+    if not inner:
+        return own
+    return f"{own} [forwarded] {inner}".strip()
+
+
+def readable_attachments(msg) -> list:
+    """``msg``'s attachments, including those inside a forwarded payload.
+
+    The parent-attachment download read ``ref_msg.attachments`` only, which is
+    empty for a forward — so a forwarded file acted on via an @-mention reply
+    reached no disk path at all.
+    """
+    atts = list(getattr(msg, "attachments", None) or [])
+    snap = forwarded_payload(msg)
+    if snap is not None:
+        atts.extend(getattr(snap, "attachments", None) or [])
+    return atts
+
+
 def should_fetch_reply_context(has_reference: bool, has_message_id: bool,
                                is_forward: bool) -> bool:
     """Whether the bridge should fetch the referenced message for reply context.
@@ -229,7 +276,7 @@ async def walk_reply_chain(
     while cur is not None and depth < max_ids_depth:
         cid = getattr(cur, "id", None)
         if depth < max_content_depth:
-            content = (getattr(cur, "content", "") or "").strip()
+            content = readable_content(cur)
             if strip_mention:
                 content = content.replace(strip_mention, "")
             created = getattr(cur, "created_at", None)

--- a/tests/reply-chain.test.py
+++ b/tests/reply-chain.test.py
@@ -279,6 +279,66 @@ check("the gate precedes the reply-context fetch it protects", 0 < _guard_i < _f
 check("no ungated `if message.reference and message.reference.message_id:` fetch remains",
       "if message.reference and message.reference.message_id:\n        try:" not in _bridge)
 
+
+# --- a FORWARDED parent keeps body and files in message_snapshots, so reading
+# --- ref_msg.content / .attachments saw an empty message and lost both.
+class _A:
+    def __init__(self, fn):
+        self.filename = fn
+
+
+class _M:
+    def __init__(self, content="", atts=(), snaps=()):
+        self.content, self.attachments, self.message_snapshots = content, list(atts), list(snaps)
+
+
+class _S:
+    def __init__(self, m):
+        self.message = m
+
+
+_inner = _M("", [_A("sutando-trayicon.svg"), _A("sutando-logo.svg")])
+_fwd = _M("", [], [_S(_inner)])
+
+check("forwarded parent: attachments are reachable",
+      [a.filename for a in rc.readable_attachments(_fwd)]
+      == ["sutando-trayicon.svg", "sutando-logo.svg"])
+check("forwarded parent: files are NAMED in the body, not blank",
+      rc.readable_content(_fwd)
+      == "[forwarded] <attachment: sutando-trayicon.svg> <attachment: sutando-logo.svg>")
+check("forwarded parent: the reply-context block is no longer empty",
+      "sutando-logo.svg" in rc.format_reply_chain([E("sonichi", "t", rc.readable_content(_fwd))]))
+
+# The forward is LABELLED, never inlined as the forwarder's own words.
+_txt = _M("", [], [_S(_M("the forwarded sentence"))])
+check("forwarded body is labelled, not attributed to the forwarder",
+      rc.readable_content(_txt) == "[forwarded] the forwarded sentence")
+check("the forwarder's own comment is kept alongside",
+      rc.readable_content(_M("my note", [], [_S(_M("inner body"))]))
+      == "my note [forwarded] inner body")
+
+# --- CONTROLS: an ordinary message must be untouched by all of the above ---
+_plain = _M("just text", [_A("own.png")])
+check("control: plain message content unchanged",
+      rc.readable_content(_plain) == "just text")
+check("control: plain message attachments unchanged",
+      [a.filename for a in rc.readable_attachments(_plain)] == ["own.png"])
+check("control: a message with neither body nor snapshot stays empty",
+      rc.readable_content(_M("")) == "" and rc.readable_attachments(_M("")) == [])
+check("control: an empty snapshot list is not a forward",
+      rc.forwarded_payload(_M("x")) is None)
+check("control: a forward with an empty payload falls back to the own body",
+      rc.readable_content(_M("only mine", [], [_S(_M(""))])) == "only mine")
+
+# The download loop is bridge glue (not unit-importable), so pin it by source:
+# it must iterate the forward-aware helper, never `ref_msg.attachments` raw.
+check("the bridge's parent-attachment loop is forward-aware",
+      "for att in readable_attachments(ref_msg):" in _bridge)
+check("no raw `ref_msg.attachments` iteration remains",
+      'for att in getattr(ref_msg, "attachments", [])' not in _bridge)
+check("the bridge imports the helper it calls",
+      "readable_attachments" in _bridge.split("async def")[0])
+
 print()
 if _fails:
     print(f"{len(_fails)} test(s) FAILED: {_fails}")


### PR DESCRIPTION
Closes half of #3945 (the Discord half). Owner-reported 2026-09-05 as "what broke it, it used to work".

## What the owner did, and what the bridge saw

He forwarded two SVGs into `#qw` (a `requireMention: true` channel), then `@`-mentioned the bot in a **reply** to that forward. The bridge log for those two messages:

```
[msg] #qw @sonichi:  (mentions: [], is_dm: False, embeds: 0, type: MessageType.default, ref: True)
[skip] not mentioned (requireMention=true)
[msg] #qw @sonichi: <@1509329143110565888> (mentions: ['Sutando-Pro#8185'], ... type: MessageType.reply, ref: True)
```

The forward is skipped — correctly, it carries no mention. The `@`-mention reply is the only message that reaches the handler, and it is exactly the one whose **parent** holds the files. The task it produced (`task-1788645802406`) carries neither a `[File attached...]` line nor a `[Replying to ...]` block:

```
task: [Discord @sonichi] <@1509329143110565888>
[reply chain truncated: ancestors older than id 1545917244998164630 were not walked ...]
```

Nothing landed on disk either — `/tmp/discord-inbox` holds no `.svg`, newest file `2026-09-01`.

## Root cause

A forward keeps its body and its attachments in `message_snapshots[0].message` and leaves the message itself empty. Both halves of the reply-context path read the message directly:

- `walk_reply_chain` → `(getattr(cur, "content", "") or "").strip()` → `""` → `format_reply_chain` returns `""`
- the parent-attachment loop → `getattr(ref_msg, "attachments", [])` → `[]`

So a forwarded parent contributes nothing, and the one shape that *has* files is the one that reads as empty. The bridge already understands `message_snapshots` in its own forward handler, and `discord-read.py` learned it in #2458 — this is the third site with the same blind spot.

## Before / after

Harness reproduces the live object shape (empty-content parent, files in the snapshot, `@`-mention reply referencing it) and runs against a clean `origin/main` tree (`git show origin/main:src/reply_chain.py`, blob `41dfb7d5`) and against this branch.

```
########## BEFORE — clean origin/main (d5c4b5a3) ##########
parent attachments the download loop iterates:
  readable_attachments MISSING; ref_msg.attachments -> []
reply-context block written into the task file:
  ''

########## AFTER — fix/reply-context-forwarded-parent ##########
parent attachments the download loop iterates:
  readable_attachments(parent) -> ['sutando-trayicon.svg', 'sutando-logo.svg']
reply-context block written into the task file:
  '\n\n[Replying to sonichi (): [forwarded] <attachment: sutando-trayicon.svg> <attachment: sutando-logo.svg>]'
```

## This is NOT a regression — stated plainly, because the report said it was

The owner remembers this working. For **this shape** it never did, and I could not find a commit that removed it:

```
commit    date        mention-gate  forward-handler  attach-download
ce909865  2026-03-30  L125          L179             L210
6ed66fee  2026-06-15  L2420         L2505            L2575
7a505429  2026-08-12  L3119         L3285            L3360
d5c4b5a3  2026-09-05  L3441         L3595            L3670
```

The mention gate has preceded the forward handler and the attachment download since forwarded-message support first landed (`ce909865`), so an unmentioned forward in a `requireMention` channel has never been downloaded. And the parent-attachment loop (`6ed66fee`, #1689, "download attachments from replied-to (parent) message") read `ref_msg.attachments` on the day it was written and has never read `message_snapshots` — `git log -S'from replied-to message'` returns those two commits and nothing else.

Searched: `git log -S` over `<attachment:`, `cdn.discordapp`, `message_snapshots`, `from replied-to message`, `File attached`, across all refs, plus merges. A positive would have been a commit whose diff *removed* a snapshot read or a URL/path emission from either path. None exists.

What he is likely remembering does still work, and the same log window proves it: on 2026-09-01 he forwarded `IMG_2803.jpg` into `#design` where the forward **itself** was ingested, and the bridge downloaded it (`[forward] downloaded: IMG_2803.jpg → /tmp/discord-inbox/1788299619664_IMG_2803.jpg`, task `task-1788299620157`). Attaching to the mentioning message, or DMing, works today. Forwarding *and then* mentioning in a reply is the gap, and it is the one path he happened to take.

## Design

Two pure helpers in `reply_chain.py` rather than inline glue, because the bridge is not unit-importable and this is the third copy of the same forward knowledge:

- `forwarded_payload(msg)` — the snapshot a message carries, or `None`
- `readable_content(msg)` — body incl. the forwarded payload, **labelled** `[forwarded]`
- `readable_attachments(msg)` — attachments incl. those inside the payload

The label follows the reader's existing convention (#2458): silently inlining a forward attributes a quoted message to the forwarder, which is its own misreading. The forwarder's own comment is kept alongside.

`walk_reply_chain` composes `readable_content`; the bridge loop iterates `readable_attachments`. A message with no snapshot takes the identical path it did before — pinned by 5 controls.

## Verification

- **21 new checks**: 5 forward pins, 5 controls, 3 bridge-delegation source pins, plus format composition. Suite 53 → 74.
- **Mutation-verified twice**, symbols kept so failures are logical, not `AttributeError`:
  - blinding `forwarded_payload` to snapshots → exactly the 5 forward pins fail (`suite exit 1`), all 5 controls still pass
  - reverting the bridge loop to `getattr(ref_msg, "attachments", [])` → exactly the 2 delegation pins fail (`suite exit 1`)
  - restored → `suite exit 0`
- **136 suites** matching `reply_chain|discord-bridge.py` under `tests/` run green (`136 suites run, 0 failing`).
- `py_compile -W error::SyntaxWarning`, `gen-src-map.py --check`, `git diff --check`, and `scripts/review-checks.sh --diff` (hardcoded-paths + root-artifacts + prose-cap) all clean.

## What this does NOT fix

The other half of #3945 stays open and I am not bundling it:

- **`discord-read.py`** renders `<attachment: name>` for a forward and **nothing at all** for a top-level attachment, and emits no `cdn.discordapp.com` URL in either case. So an agent reconstructing context still cannot retrieve a file it can see.
- **`room_ops` (AG2 Space)** is untouched — `read` emits no `mxc://`, `fetch` 400s on an event id. That is the original #3945 report and a separate concern in a separate skill.

Stand: Echo Act IV Pro
