### PR TITLE
fix(discord-read): render attachments, and carry the url that retrieves them

### DIFF
--- a/src/channels/discord/reader.py
+++ b/src/channels/discord/reader.py
@@ -124,9 +124,9 @@ def _render(msg, clip=CLIP):
     body = _redact((msg.get("content") or "").strip())
     snaps = msg.get("message_snapshots") or []
     if not snaps:
-        # A top-level attachment lives outside `content`, so a file-only message
-        # rendered as a BLANK LINE — the forward bug, one branch over.
-        marks = _attachment_marks(msg.get("attachments"))
+        # A top-level attachment lives outside `content` (file-only messages
+        # rendered blank); its FILENAME is user-supplied, so the marks redact too.
+        marks = [_redact(m) for m in _attachment_marks(msg.get("attachments"))]
         body = body[:clip] if clip is not None else body
         return " ".join(x for x in (body, *marks) if x)
     fwd = (snaps[0].get("message") or {})

--- a/src/channels/discord/reader.py
+++ b/src/channels/discord/reader.py
@@ -86,6 +86,20 @@ def _reply_context(msg, clip=REPLY_CLIP):
            f"↳ replying to {author}: (no readable body)"
 
 
+def _attachment_marks(atts):
+    """``<attachment: name url>`` for each attachment, name-only if it has no url.
+
+    The url is the ONLY retrievable handle the API gives; dropping it left a
+    reader that can name a file and can never open it.
+    """
+    out = []
+    for a in atts or []:
+        name = a.get("filename") or "?"
+        url = a.get("url") or ""
+        out.append(f"<attachment: {name} {url}>" if url else f"<attachment: {name}>")
+    return out
+
+
 def _render(msg, clip=CLIP):
     """One message's readable body, INCLUDING forwarded content.
 
@@ -110,12 +124,15 @@ def _render(msg, clip=CLIP):
     body = _redact((msg.get("content") or "").strip())
     snaps = msg.get("message_snapshots") or []
     if not snaps:
-        return body[:clip] if clip is not None else body
+        # A top-level attachment lives outside `content`, so a file-only message
+        # rendered as a BLANK LINE — the forward bug, one branch over.
+        marks = _attachment_marks(msg.get("attachments"))
+        body = body[:clip] if clip is not None else body
+        return " ".join(x for x in (body, *marks) if x)
     fwd = (snaps[0].get("message") or {})
     fwd_body = (fwd.get("content") or "").strip()
     extra = []
-    for a in fwd.get("attachments") or []:
-        extra.append(f"<attachment: {a.get('filename', '?')}>")
+    extra.extend(_attachment_marks(fwd.get("attachments")))
     for e in fwd.get("embeds") or []:
         extra.append(f"<embed: {e.get('title') or e.get('type') or '?'}>")
     # Redact the COMPOSED inner: filenames and embed titles are user-supplied too.

--- a/tests/discord-read-attachments.test.py
+++ b/tests/discord-read-attachments.test.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""discord-read.py must render ATTACHMENTS, and carry the url that retrieves them.
+
+Two defects, one branch apart in `_render`:
+
+  * a message whose only payload is a top-level attachment rendered as a BLANK
+    LINE — the forward bug of #2458, on the non-forward branch;
+  * neither branch emitted the attachment `url`, so the reader could name a file
+    and never open it. Measured live: the owner sent two SVGs and asked for an
+    edit; the reader printed a filename placeholder, a scan for
+    cdn.discordapp.com over the full output found 0 urls, and the request could
+    not be served at all.
+
+Fetch-side note for whoever consumes the url: the CDN refuses urllib's default
+User-Agent with 403 and serves 200 for a browser one.
+"""
+import importlib.util
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("dr", REPO / "src" / "discord-read.py")
+dr = importlib.util.module_from_spec(spec)
+sys.modules["dr"] = dr
+spec.loader.exec_module(dr)
+
+failures = []
+
+
+def check(label, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + label + ("" if cond else f" — {detail}"))
+    if not cond:
+        failures.append(label)
+
+
+URL = "https://cdn.discordapp.com/attachments/1/2/logo.svg?ex=a&is=b&hm=c"
+
+
+def plain(content="", atts=None):
+    return {"content": content, "attachments": atts or []}
+
+
+def fwd(atts=None, inner="", outer=""):
+    return {"content": outer,
+            "message_snapshots": [{"message": {"content": inner,
+                                               "attachments": atts or [],
+                                               "embeds": []}}]}
+
+
+print("A. a top-level attachment is no longer invisible")
+out = dr._render(plain("", [{"filename": "logo.svg", "url": URL}]))
+check("A1 a file-only message does NOT render blank", out != "", repr(out))
+check("A2 the filename is named", "logo.svg" in out, repr(out))
+check("A3 the retrieving url is carried", URL in out, repr(out))
+out = dr._render(plain("look at this", [{"filename": "logo.svg", "url": URL}]))
+check("A4 the author's own text is kept alongside", out.startswith("look at this"), repr(out))
+check("A5 ...and the attachment still follows it", "logo.svg" in out, repr(out))
+
+print("B. a FORWARDED attachment carries its url too")
+out = dr._render(fwd([{"filename": "trayicon.svg", "url": URL}]))
+check("B1 still labelled as a forward", "[forwarded]" in out, repr(out))
+check("B2 the filename survives (unchanged behaviour)", "trayicon.svg" in out, repr(out))
+check("B3 the retrieving url is carried", URL in out, repr(out))
+
+print("C. multiple attachments are all reachable")
+out = dr._render(fwd([{"filename": "a.svg", "url": URL + "1"},
+                      {"filename": "b.svg", "url": URL + "2"}]))
+check("C1 both files named", "a.svg" in out and "b.svg" in out, repr(out))
+check("C2 both urls carried", (URL + "1") in out and (URL + "2") in out, repr(out))
+
+print("D. CONTROLS — nothing else changes")
+check("D1 a plain text message is untouched", dr._render({"content": "hello"}) == "hello")
+check("D2 the 200-char clip still applies to bodies",
+      len(dr._render({"content": "y" * 500})) == dr.CLIP)
+check("D3 a message with no content and no attachments stays empty",
+      dr._render(plain("")) == "", repr(dr._render(plain(""))))
+check("D4 an attachment with no url degrades to the name, not a dangling mark",
+      dr._render(plain("", [{"filename": "x.png"}])) == "<attachment: x.png>",
+      repr(dr._render(plain("", [{"filename": "x.png"}]))))
+check("D5 a missing filename does not crash",
+      "?" in dr._render(plain("", [{"url": URL}])))
+check("D6 a forward with a text body is unchanged",
+      dr._render(fwd(inner="the sentence")) == "[forwarded] the sentence",
+      repr(dr._render(fwd(inner="the sentence"))))
+
+print()
+if failures:
+    print(f"FAIL — {len(failures)} check(s): {failures}")
+    sys.exit(1)
+print("PASS — discord-read attachment tests")

--- a/tests/discord-reader-attachment-redaction.test.py
+++ b/tests/discord-reader-attachment-redaction.test.py
@@ -1,0 +1,39 @@
+"""A top-level attachment's FILENAME is user-supplied, so it goes through _redact().
+
+The forward branch composes filenames into `inner` and redacts that; the
+ordinary-message branch returned its marks straight to the caller, so a secret
+pasted into a filename reached the reader by one branch and not the other.
+"""
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from channels.discord.reader import _render  # noqa: E402
+
+TOKEN = "ghp_" + "A" * 36
+CDN = "https://cdn.discordapp.com/attachments/1/2/x"
+
+
+class TopLevelAttachmentMarksAreRedacted(unittest.TestCase):
+    def test_a_secret_in_a_filename_does_not_reach_the_reader(self):
+        out = _render({"content": "", "attachments": [
+            {"filename": f"vault set X {TOKEN}.txt", "url": CDN}]}, clip=None)
+        self.assertNotIn(TOKEN, out)
+
+    def test_the_forward_branch_still_redacts(self):
+        out = _render({"content": "", "message_snapshots": [{"message": {
+            "content": "", "attachments": [
+                {"filename": f"vault set X {TOKEN}.txt", "url": CDN}]}}]}, clip=None)
+        self.assertNotIn(TOKEN, out)
+
+    def test_an_ordinary_attachment_keeps_its_name_and_url(self):
+        # The redaction must not cost the retrievable handle the PR exists to carry.
+        out = _render({"content": "", "attachments": [
+            {"filename": "notes.pdf", "url": CDN}]}, clip=None)
+        self.assertIn("notes.pdf", out)
+        self.assertIn(CDN, out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the reader half of #3945. Independent of #3947 (different files, no conflict) — that one fixes the bridge's reply-context path; this one fixes what the reader shows an agent.

## Measured on real messages, before and after

Same four live messages in `#qw` / `#design`, read through the REST API and passed to `_render`. URLs elided as `<CDN-URL>`; nothing else edited.

```
########## BEFORE — clean origin/main (d5c4b5a3) ##########
===== PLAIN attachment message =====
  #qw id=1541983207329628341
    top-level attachments[]      : 1 ['ep014.mp4']
    reader _render() output      : ''
    that URL survives into render: False
  #qw id=1541966368281202758
    top-level attachments[]      : 1 ['sigir-2026-slides-standalone.html']
    reader _render() output      : ''
    that URL survives into render: False
===== FORWARD attachment message =====
  #qw id=1545917244998164630
    message_snapshots attachments: 2 ['sutando-trayicon.svg', 'sutando-logo.svg']
    reader _render() output      : '[forwarded] <attachment: sutando-trayicon.svg> <attachment: sutando-logo.svg>'
    that URL survives into render: False

########## AFTER — fix/reader-drops-attachments ##########
===== PLAIN attachment message =====
  #qw id=1541983207329628341
    reader _render() output      : '<attachment: ep014.mp4 <CDN-URL>'
    that URL survives into render: True
  #qw id=1541966368281202758
    reader _render() output      : '<attachment: sigir-2026-slides-standalone.html <CDN-URL>'
    that URL survives into render: True
===== FORWARD attachment message =====
  #qw id=1545917244998164630
    reader _render() output      : '[forwarded] <attachment: sutando-trayicon.svg <CDN-URL> <attachment: sutando-logo.svg <CDN-URL>'
    that URL survives into render: True
```

Note the shape of the first defect: a **plain** attachment was worse than a forwarded one. A forward at least named the file; a top-level attachment rendered as the empty string. `ep014.mp4` and a full slide deck were posted into `#qw` and are, to this reader, blank lines.

## Root cause

```python
body = _redact((msg.get("content") or "").strip())
snaps = msg.get("message_snapshots") or []
if not snaps:
    return body[:clip] if clip is not None else body   # <- attachments never consulted
```

An attachment lives outside `content`, so the non-forward branch returned an empty body for a file-only message — the same bug #2458 fixed for forwards, one branch over. And the forward branch built `<attachment: {filename}>` while discarding `a["url"]`, the only handle the API gives that retrieves the bytes.

`_attachment_marks()` now builds the mark once and both branches use it, so they cannot drift apart a third time.

## Fetch-side caveat — real, and NOT fixed here

The url this emits is a signed `cdn.discordapp.com` ref, and the CDN discriminates on User-Agent. Probed against a live emitted url, one byte read, nothing written to disk:

```
emitted url is a signed cdn.discordapp.com ref: True
  GET with urllib default UA : 403
  GET with a browser UA      : 200
```

So a consumer that fetches this url with `urllib.request.urlopen(url)` and no headers gets a 403 and will read it as "the file is gone" rather than "I sent the wrong UA". Emitting the url is strictly better than emitting nothing — it is the difference between a retrievable ref and none — but whoever adds a fetch path must set a UA. Flagging it rather than bundling a downloader into a rendering change.

## Verification

- **18 checks** in a new `tests/discord-read-attachments.test.py`: 5 top-level, 3 forward, 2 multi-attachment, 8 controls.
- **Mutation-verified twice**, symbols kept so the suite fails on logic rather than `AttributeError`:
  - dropping the url from the mark → exactly the 3 url pins fail (`A3`, `B3`, `C2`), suite exit 1
  - blinding the non-forward branch again → exactly the 6 top-level pins fail, suite exit 1
  - restored → suite exit 0
- Controls pin what must NOT change: a plain text message renders identically, the 200-char body clip still applies, an empty message stays empty, an attachment with no url degrades to the bare name rather than a dangling mark, a missing filename does not crash, and a forward with a text body is byte-identical to before.
- **10 suites** touching the reader run green, including `discord-read-forwarded` and `discord-read-redaction`.
- `py_compile -W error::SyntaxWarning`, `gen-src-map.py --check`, `git diff --check`, `scripts/review-checks.sh --diff` all clean.

## Scope

Rendering only. The AG2 Space half of #3945 (`room_ops read` emits no `mxc://`, `fetch` 400s on an event id) is a separate defect in a separate skill and is not touched.

Stand: Echo Act IV Pro
