### PR TITLE
fix(agent-activity): a late touch never reopens an answered task; the pick-up row says who and what

### DIFF
--- a/skills/agent-activity/hooks/activity-hook.py
+++ b/skills/agent-activity/hooks/activity-hook.py
@@ -26,6 +26,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+from local_task_protocol import find_result  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 
 WRITER = Path(__file__).resolve().parent.parent / "scripts" / "activity.py"  # lint-workspace-resolution: allow-repo-root (sibling script, not a data root)
@@ -158,17 +159,28 @@ def task_header(ws: Path, task_id: str) -> tuple[dict, str | None] | None:
     return None
 
 
+def manifest_config(key: str) -> str:
+    """This skill's declared setting (manifest.json `config`), the source below an env override."""
+    try:
+        data = json.loads((Path(__file__).resolve().parents[1] / "manifest.json").read_text())
+        val = (data.get("config") or {}).get(key)
+        return val if isinstance(val, str) else ""
+    except (OSError, ValueError):
+        return ""
+
+
 def pickup_line(task: dict) -> str:
     """The lifecycle's first row as the owner reads it: which agent, whose message, its start."""
-    agent = os.environ.get("AGENT_DISPLAY_NAME") or "Your agent"
+    agent = os.environ.get("AGENT_DISPLAY_NAME") or manifest_config("AGENT_DISPLAY_NAME") or "Your agent"
     who = task.get("sender") or task.get("from") or "unknown"
     text = task.get("text") or ""
     return f"{agent} is working on a task from {who}: {text[:20]}{'…' if len(text) > 20 else ''}"
 
 
 def answered(ws: Path, task_id: str) -> bool:
-    """A result already exists: the task is finished, whatever the log says."""
-    return any((ws / d / f"{task_id}.txt").exists() for d in ("results", os.path.join("results", "archive")))
+    """A result exists — live, or archived in any shape the delivery paths write (the shared lookup
+    knows the epoch-suffixed, month-partitioned and retention layouts): the task is finished."""
+    return find_result(ws / "results", task_id) is not None
 
 
 def working_line(tool_name: str, tool_input) -> str | None:

--- a/skills/agent-activity/hooks/activity-hook.py
+++ b/skills/agent-activity/hooks/activity-hook.py
@@ -159,10 +159,11 @@ def task_header(ws: Path, task_id: str) -> tuple[dict, str | None] | None:
 
 
 def pickup_line(task: dict) -> str:
-    """The Processing row as the owner reads it: who asked, and the start of what."""
+    """The lifecycle's first row as the owner reads it: which agent, whose message, its start."""
+    agent = os.environ.get("AGENT_DISPLAY_NAME") or "Your agent"
     who = task.get("sender") or task.get("from") or "unknown"
     text = task.get("text") or ""
-    return f"working on a task from {who}: {text[:20]}{'…' if len(text) > 20 else ''}"
+    return f"{agent} is working on a task from {who}: {text[:20]}{'…' if len(text) > 20 else ''}"
 
 
 def answered(ws: Path, task_id: str) -> bool:

--- a/skills/agent-activity/hooks/activity-hook.py
+++ b/skills/agent-activity/hooks/activity-hook.py
@@ -145,15 +145,29 @@ def task_header(ws: Path, task_id: str) -> tuple[dict, str | None] | None:
         fields: dict = {}
         for l in p.read_text(encoding="utf-8", errors="replace").splitlines():
             k, _, v = l.partition(":")
-            if k in ("user_id", "task", "channel_id") and k not in fields:
+            if k in ("user_id", "task", "channel_id", "sender_name") and k not in fields:
                 fields[k] = v.strip()
         task = {"id": task_id}
         if fields.get("user_id"):
             task["from"] = fields["user_id"]
+        if fields.get("sender_name"):
+            task["sender"] = fields["sender_name"]
         if fields.get("task"):
             task["text"] = fields["task"][:160]
         return task, fields.get("channel_id") or None
     return None
+
+
+def pickup_line(task: dict) -> str:
+    """The Processing row as the owner reads it: who asked, and the start of what."""
+    who = task.get("sender") or task.get("from") or "unknown"
+    text = task.get("text") or ""
+    return f"working on a task from {who}: {text[:20]}{'…' if len(text) > 20 else ''}"
+
+
+def answered(ws: Path, task_id: str) -> bool:
+    """A result already exists: the task is finished, whatever the log says."""
+    return any((ws / d / f"{task_id}.txt").exists() for d in ("results", os.path.join("results", "archive")))
 
 
 def working_line(tool_name: str, tool_input) -> str | None:
@@ -245,15 +259,17 @@ def handle(payload: dict, p: dict, run=subprocess.run) -> list[tuple[str, str]]:
         # First touch of a task file by this session: bind it and write its processing row from the
         # task's own headers — the agent never has to remember to.
         for tid in task_file_refs(blob):
-            if tid in binds:
+            # A late touch of an answered task (a dedup check, a re-read) must not reopen it.
+            if tid in binds or answered(p["ws"], tid):
                 continue
             found = task_header(p["ws"], tid)
             if not found:
                 continue
             task, room = found
+            line = pickup_line(task)
             bind(p, tid, sid)
-            emit("processing", "picked up", task, room, p["ws"], run)
-            out.append(("processing", "picked up"))
+            emit("processing", line, task, room, p["ws"], run)
+            out.append(("processing", line))
         if out:
             return out
         if result_file_refs(blob):

--- a/skills/agent-activity/manifest.json
+++ b/skills/agent-activity/manifest.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "owner": "github:sonichi/sutando",
   "stability": "experimental",
-  "description": "The agent's live activity as rows the desktop renders in the room (events drawer) and the dock (Agent activity panel). Hooks produce the Working and Thinking rows; nothing depends on the agent remembering.",
+  "description": "The agent's live activity as rows the desktop renders in the room (events drawer) and the dock (Agent activity panel). Hooks produce the Working and Thinking rows; nothing depends on the agent remembering. Config: AGENT_DISPLAY_NAME names the agent in the first row (env override > this manifest > 'Your agent').",
   "permissions": {
     "network": false,
     "filesystem": "read-write",
@@ -22,5 +22,8 @@
       "event": "Stop",
       "command": "./hooks/activity-hook.py"
     }
-  ]
+  ],
+  "config": {
+    "AGENT_DISPLAY_NAME": ""
+  }
 }

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -294,6 +294,14 @@ class Hook(unittest.TestCase):
             self.assertTrue(hook.pickup_line({"sender": "q", "text": "x"}).startswith("env-air is working"))
         self.assertEqual(hook.manifest_config("AGENT_DISPLAY_NAME"), "")  # declared, unset by default
 
+    def test_an_unreadable_or_malformed_manifest_reads_as_unset_not_a_crash(self):
+        with mock.patch.object(hook.Path, "read_text", side_effect=OSError("gone")):
+            self.assertEqual(hook.manifest_config("AGENT_DISPLAY_NAME"), "")
+        with mock.patch.object(hook.Path, "read_text", return_value="{not json"):
+            self.assertEqual(hook.manifest_config("AGENT_DISPLAY_NAME"), "")
+        with mock.patch.object(hook.Path, "read_text", return_value='{"config": {"AGENT_DISPLAY_NAME": 7}}'):
+            self.assertEqual(hook.manifest_config("AGENT_DISPLAY_NAME"), "")  # non-string value is not a name
+
     def post(self, sid, tool, inp):
         return {"hook_event_name": "PostToolUse", "session_id": sid, "tool_name": tool, "tool_input": inp, "tool_response": {}}
 

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -242,9 +242,9 @@ class Hook(unittest.TestCase):
 
     def test_first_touch_of_a_task_file_binds_and_writes_processing_from_its_headers(self):
         (self.ws / "tasks" / "task-abc123.txt").write_text(
-            "id: task-abc123\nchannel_id: !team:s\nuser_id: @q:s\ntask: Read the latest discussion in this room.\nsource: ag2space\n")
+            "id: task-abc123\nchannel_id: !team:s\nuser_id: @q:s\nsender_name: qingyun\ntask: Read the latest discussion in this room.\nsource: ag2space\n")
         out = hook.handle(self.pre("S1", "Read", {"file_path": str(self.ws / "tasks" / "task-abc123.txt")}), self.p, self.run)
-        self.assertEqual(out, [("processing", "picked up")])
+        self.assertEqual(out, [("processing", "working on a task from qingyun: Read the latest disc…")])
         cmd = self.runs[-1]
         self.assertEqual((cmd[2], cmd[cmd.index("--task-id") + 1], cmd[cmd.index("--room") + 1], cmd[cmd.index("--from") + 1]), ("append", "task-abc123", "!team:s", "@q:s"))
         self.assertEqual(cmd[cmd.index("--text") + 1], "Read the latest discussion in this room.")
@@ -256,6 +256,16 @@ class Hook(unittest.TestCase):
         self.assertEqual(hook.task_file_refs("cat tasks/task-abc999.txt tasks/task-abc999.txt"), ["task-abc999"])
         # a task file that does not exist binds nothing
         self.assertEqual(hook.handle(self.pre("S1", "Read", {"file_path": "tasks/task-000000.txt"}), self.p, self.run), [])
+
+    def test_a_late_touch_of_an_answered_task_neither_binds_nor_reopens_it(self):
+        # The result exists (answered by a dedup or an earlier session): a re-read, a dedup check
+        # naming the file, or another session's touch must not write a Processing row after the Done.
+        (self.ws / "tasks" / "task-abc123.txt").write_text("id: task-abc123\nchannel_id: !dm:s\nuser_id: @q:s\ntask: hi\n")
+        (self.ws / "results").mkdir(exist_ok=True); (self.ws / "results" / "task-abc123.txt").write_text("[deduped: task-zzz]")
+        self.assertEqual(hook.handle(self.pre("S2", "Read", {"file_path": str(self.ws / "tasks" / "task-abc123.txt")}), self.p, self.run), [])
+        self.assertEqual(hook.load_json(self.p["bind"], {}), {})
+        self.assertEqual(self.runs, [])
+        self.assertEqual(hook.pickup_line({"from": "@q:s", "text": "x" * 30}), "working on a task from @q:s: " + "x" * 20 + "…")
 
     def post(self, sid, tool, inp):
         return {"hook_event_name": "PostToolUse", "session_id": sid, "tool_name": tool, "tool_input": inp, "tool_response": {}}

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -270,6 +270,30 @@ class Hook(unittest.TestCase):
         with mock.patch.dict(os.environ, {"AGENT_DISPLAY_NAME": "air"}):
             self.assertTrue(hook.pickup_line({"sender": "qingyun", "text": "hi"}).startswith("air is working on a task from qingyun: hi"))
 
+    def test_answered_sees_every_archive_shape_the_delivery_paths_write(self):
+        # Live, gateway (epoch suffix) and bridge (month dir) shapes; 0 of 400 live ids sat flat.
+        ws = self.ws; r = ws / "results"; r.mkdir(exist_ok=True)
+        shapes = {
+            "task-11111111111111": r / "task-11111111111111.txt",
+            "task-22222222222222": r / "archive" / "task-22222222222222-1788657562.txt",
+            "task-33333333333333": r / "archive" / "2026-06" / "task-33333333333333.txt",
+        }
+        for path in shapes.values():
+            path.parent.mkdir(parents=True, exist_ok=True); path.write_text("reply")
+        for tid in shapes:
+            self.assertTrue(hook.answered(ws, tid), tid)
+        self.assertFalse(hook.answered(ws, "task-99999999999999"))
+        self.assertFalse(hook.answered(ws, "../etc/passwd"))
+
+    def test_agent_name_comes_from_env_then_the_manifest_then_the_fallback(self):
+        with mock.patch.dict(os.environ, {"AGENT_DISPLAY_NAME": ""}), mock.patch.object(hook, "manifest_config", return_value=""):
+            self.assertTrue(hook.pickup_line({"sender": "q", "text": "x"}).startswith("Your agent is working"))
+        with mock.patch.dict(os.environ, {"AGENT_DISPLAY_NAME": ""}), mock.patch.object(hook, "manifest_config", return_value="air"):
+            self.assertTrue(hook.pickup_line({"sender": "q", "text": "x"}).startswith("air is working"))
+        with mock.patch.dict(os.environ, {"AGENT_DISPLAY_NAME": "env-air"}), mock.patch.object(hook, "manifest_config", return_value="air"):
+            self.assertTrue(hook.pickup_line({"sender": "q", "text": "x"}).startswith("env-air is working"))
+        self.assertEqual(hook.manifest_config("AGENT_DISPLAY_NAME"), "")  # declared, unset by default
+
     def post(self, sid, tool, inp):
         return {"hook_event_name": "PostToolUse", "session_id": sid, "tool_name": tool, "tool_input": inp, "tool_response": {}}
 

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 REPO = Path(__file__).parent.parent
@@ -244,7 +245,7 @@ class Hook(unittest.TestCase):
         (self.ws / "tasks" / "task-abc123.txt").write_text(
             "id: task-abc123\nchannel_id: !team:s\nuser_id: @q:s\nsender_name: qingyun\ntask: Read the latest discussion in this room.\nsource: ag2space\n")
         out = hook.handle(self.pre("S1", "Read", {"file_path": str(self.ws / "tasks" / "task-abc123.txt")}), self.p, self.run)
-        self.assertEqual(out, [("processing", "working on a task from qingyun: Read the latest disc…")])
+        self.assertEqual(out, [("processing", "Your agent is working on a task from qingyun: Read the latest disc…")])
         cmd = self.runs[-1]
         self.assertEqual((cmd[2], cmd[cmd.index("--task-id") + 1], cmd[cmd.index("--room") + 1], cmd[cmd.index("--from") + 1]), ("append", "task-abc123", "!team:s", "@q:s"))
         self.assertEqual(cmd[cmd.index("--text") + 1], "Read the latest discussion in this room.")
@@ -265,7 +266,9 @@ class Hook(unittest.TestCase):
         self.assertEqual(hook.handle(self.pre("S2", "Read", {"file_path": str(self.ws / "tasks" / "task-abc123.txt")}), self.p, self.run), [])
         self.assertEqual(hook.load_json(self.p["bind"], {}), {})
         self.assertEqual(self.runs, [])
-        self.assertEqual(hook.pickup_line({"from": "@q:s", "text": "x" * 30}), "working on a task from @q:s: " + "x" * 20 + "…")
+        self.assertEqual(hook.pickup_line({"from": "@q:s", "text": "x" * 30}), "Your agent is working on a task from @q:s: " + "x" * 20 + "…")
+        with mock.patch.dict(os.environ, {"AGENT_DISPLAY_NAME": "air"}):
+            self.assertTrue(hook.pickup_line({"sender": "qingyun", "text": "hi"}).startswith("air is working on a task from qingyun: hi"))
 
     def post(self, sid, tool, inp):
         return {"hook_event_name": "PostToolUse", "session_id": sid, "tool_name": tool, "tool_input": inp, "tool_response": {}}


### PR DESCRIPTION
## What
Two lessons from the interim writer on the owner's machine, carried into the hook before her engine switches to it (owner ask 2026-09-06, from watching the card).

- **A late touch never reopens an answered task.** A task whose result exists in `results/` (or `results/archive/`) is finished. Before this, a later touch of its task file — a dedup check naming it, a re-read, another session — bound it and wrote a Processing row *after* its Done row. The client's open-task test is order-aware, so the task reopened and every later row of the agent attached to it; the owner saw a card titled with a long-answered message showing "Thinking · Pass complete" two hours later. The first-touch rule now asks `local_task_protocol.find_result()` — the production owner of every result layout: live, the gateway's `archive/<id>-<epoch>.txt`, the bridges' `archive/YYYY-MM/<id>.txt`, retention siblings (reviewers measured that a flat `archive/<id>.txt` check matched 0 of 400 answered ids).
- **The first row names the agent, the sender and the message.** `<agent> is working on a task from <sender>: <first 20 chars>…` (the owner's wording for the lifecycle's starting point) instead of `picked up`. `<agent>` is `AGENT_DISPLAY_NAME`, declared in the skill's `manifest.json` config block and read env → manifest → `Your agent` per `skills/MANIFEST.md`; `task_header` carries `sender_name`, so the display name is what she reads, with the mxid as the fallback.

## Files
`skills/agent-activity/hooks/activity-hook.py`, `skills/agent-activity/manifest.json`, `tests/agent-activity.test.py`

## Evidence
```
$ python3 tests/agent-activity.test.py → Ran 26 tests … OK   (25 at the parent)
red control, parent hook + new tests: FAIL test_a_late_touch_of_an_answered_task_neither_binds_nor_reopens_it (a bind and a Processing row appear)
                                        FAIL test_first_touch_of_a_task_file_binds_and_writes_processing_from_its_headers (wording)
$ git diff origin/main...HEAD | bash scripts/review-checks.sh → PASS
```
Head `cb296c91`: 28 tests OK (the archive-shape test writes live, epoch-suffixed and month-dir results; the precedence test pins env → manifest → fallback). The same two guards are live in the owner's interim tailer since 00:5xZ and stopped the recurrence there.

— sutando-qingyun-air


