### PR TITLE
docs(claude-md): context state never grounds a decline or a deferral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ reason TO delegate, not to hand it back. If no mechanism is available, do it inl
 never report work as delegated when nothing was spawned.
 Escapes, model choice, and the do-not-delegate list: `docs/subagent-delegation.md`.
 
+**Context state never grounds a decline or a deferral** (Chi 2026-09-06). Compaction is automatic
+and the session continues from its summary; what carries work across it is the durable record
+(current-track, a detached mechanism), never an agent's estimate of its remaining window. Do not
+decline, park, or tell the owner to compact or restart a core because context is "near its end":
+write the record and proceed.
+
 ## Architecture rules
 
 Rationale + worked examples for every boundary rule below (quoted section names) live in [`docs/architecture-boundaries.md`](docs/architecture-boundaries.md) — read the named section before working on that boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,11 @@ never report work as delegated when nothing was spawned.
 Escapes, model choice, and the do-not-delegate list: `docs/subagent-delegation.md`.
 
 **Context state never grounds a decline or a deferral** (Chi 2026-09-06). Compaction is automatic
-and the session continues from its summary; what carries work across it is the durable record
-(current-track, a detached mechanism), never an agent's estimate of its remaining window. Do not
-decline, park, or tell the owner to compact or restart a core because context is "near its end":
-write the record and proceed.
+and the session continues from its summary; what carries work across it is a durable record, never
+an agent's estimate of its remaining window. Do not decline, park, or tell the owner to compact or
+restart a core because context is "near its end": write the record and proceed. The record is the
+one your role owns — the live core writes its per-host `current-track.md`; a guest or one-shot
+session (see "Chat-path task tracking") writes its own task checkpoint and never the core's anchor.
 
 ## Architecture rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,12 @@ reason TO delegate, not to hand it back. If no mechanism is available, do it inl
 never report work as delegated when nothing was spawned.
 Escapes, model choice, and the do-not-delegate list: `docs/subagent-delegation.md`.
 
+**Context state never grounds a decline or a deferral** (Chi 2026-09-06). Compaction is automatic
+and the session continues from its summary; what carries work across it is the durable record
+(current-track, a detached mechanism), never an agent's estimate of its remaining window. Do not
+decline, park, or tell the owner to compact or restart a core because context is "near its end":
+write the record and proceed.
+
 ## Architecture rules
 
 Rationale + worked examples for every boundary rule below (quoted section names) live in [`docs/architecture-boundaries.md`](docs/architecture-boundaries.md) — read the named section before working on that boundary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,11 @@ never report work as delegated when nothing was spawned.
 Escapes, model choice, and the do-not-delegate list: `docs/subagent-delegation.md`.
 
 **Context state never grounds a decline or a deferral** (Chi 2026-09-06). Compaction is automatic
-and the session continues from its summary; what carries work across it is the durable record
-(current-track, a detached mechanism), never an agent's estimate of its remaining window. Do not
-decline, park, or tell the owner to compact or restart a core because context is "near its end":
-write the record and proceed.
+and the session continues from its summary; what carries work across it is a durable record, never
+an agent's estimate of its remaining window. Do not decline, park, or tell the owner to compact or
+restart a core because context is "near its end": write the record and proceed. The record is the
+one your role owns — the live core writes its per-host `current-track.md`; a guest or one-shot
+session (see "Chat-path task tracking") writes its own task checkpoint and never the core's anchor.
 
 ## Architecture rules
 


### PR DESCRIPTION
## What

One paragraph under **Operating Style** in `CLAUDE.md`: context state never grounds a decline or a deferral. `AGENTS.md` regenerated by `scripts/agents-md-sync.sh` (the only change there is the mirrored paragraph).

## Why

Owner rule, 2026-09-06, after tonight's #3929 witness: a peer with a live gateway declined a granted run twice because its session was "at the end of its context", and the owner was told, wrongly, that the remedy was to compact or restart that core by hand. Owner: *"since when do we have to manually restart a core when it runs out of context? that doesn't make sense"* and *"I'm not supposed to worry about compact or do manual compact."*

Compaction is automatic and the session continues from its summary; what carries work across it is the durable record (current-track, a detached mechanism), not an agent's estimate of its remaining window. Nothing in `CLAUDE.md` or the loop said so, and the adjacent rule (*"Too large for your remaining context is the reason TO delegate, not to hand it back"*) covers delegation, not declining. This is the missing sentence.

## Evidence

```
$ bash scripts/agents-md-sync.sh && python3 tests/agents-md-sync.test.py
Results: 5 passed
$ python3 tests/claude-md-tier-summary.test.py
OK
$ git diff --stat origin/main...HEAD
 AGENTS.md | 6 ++++++
 CLAUDE.md | 6 ++++++
```

Companion PRs from the same owner "y": the per-pass read budget (current-track rotation + health probe) in this repo, and the pr-triage SKILL.md split in sutando-skills. This one is independent of both.
