### PR TITLE
docs: the prescribed result-write is non-atomic, and it truncated two agents' replies tonight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,11 +169,17 @@ EOF
 **Priority field**: `urgent` (voice/phone, sub-second latency target) | `normal` (chat/owner DM, default) | `low` (cron, health-check, non-owner DMs). When more than one task is pending, the consumer processes highest-priority first; tie-breaker is mtime FIFO. Defaults per source are encoded in `src/task_priority.py:default_priority_for_source`.
 
 **When done:**
-Write a result file using the same task ID (re-use the `WORKSPACE` from above):
+Write a result file using the same task ID (re-use the `WORKSPACE` from above).
+**Write it atomically** — a drain can claim `results/task-*.txt` the moment it appears, so a file
+built in place is published half-written:
 ```bash
-cat > "$WORKSPACE/results/task-chat-${_ts}.txt" << EOF
+_out="$WORKSPACE/results/task-chat-${_ts}.txt"
+_tmp="$(mktemp "$WORKSPACE/results/.task-chat-${_ts}.XXXXXX")"
+cat > "$_tmp" << EOF
 <result summary>
 EOF
+mv -f "$_tmp" "$_out"    # rename within one directory is atomic; the temp is
+                         # dot-prefixed and has no .txt, so no drain can claim it
 ```
 
 This ensures the dashboard, result-watcher, and timeout logic work the same regardless of entry path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,8 +178,8 @@ _tmp="$(mktemp "$WORKSPACE/results/.task-chat-${_ts}.XXXXXX")"
 cat > "$_tmp" << EOF
 <result summary>
 EOF
-mv -f "$_tmp" "$_out"    # rename within one directory is atomic; the temp is
-                         # dot-prefixed and has no .txt, so no drain can claim it
+mv -f "$_tmp" "$_out"    # rename within one directory is atomic; no drain's glob
+                         # matches a name without `.txt` (pathlib `*` sees dotfiles)
 ```
 
 This ensures the dashboard, result-watcher, and timeout logic work the same regardless of entry path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,11 +169,17 @@ EOF
 **Priority field**: `urgent` (voice/phone, sub-second latency target) | `normal` (chat/owner DM, default) | `low` (cron, health-check, non-owner DMs). When more than one task is pending, the consumer processes highest-priority first; tie-breaker is mtime FIFO. Defaults per source are encoded in `src/task_priority.py:default_priority_for_source`.
 
 **When done:**
-Write a result file using the same task ID (re-use the `WORKSPACE` from above):
+Write a result file using the same task ID (re-use the `WORKSPACE` from above).
+**Write it atomically** — a drain can claim `results/task-*.txt` the moment it appears, so a file
+built in place is published half-written:
 ```bash
-cat > "$WORKSPACE/results/task-chat-${_ts}.txt" << EOF
+_out="$WORKSPACE/results/task-chat-${_ts}.txt"
+_tmp="$(mktemp "$WORKSPACE/results/.task-chat-${_ts}.XXXXXX")"
+cat > "$_tmp" << EOF
 <result summary>
 EOF
+mv -f "$_tmp" "$_out"    # rename within one directory is atomic; the temp is
+                         # dot-prefixed and has no .txt, so no drain can claim it
 ```
 
 This ensures the dashboard, result-watcher, and timeout logic work the same regardless of entry path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,8 +178,8 @@ _tmp="$(mktemp "$WORKSPACE/results/.task-chat-${_ts}.XXXXXX")"
 cat > "$_tmp" << EOF
 <result summary>
 EOF
-mv -f "$_tmp" "$_out"    # rename within one directory is atomic; the temp is
-                         # dot-prefixed and has no .txt, so no drain can claim it
+mv -f "$_tmp" "$_out"    # rename within one directory is atomic; no drain's glob
+                         # matches a name without `.txt` (pathlib `*` sees dotfiles)
 ```
 
 This ensures the dashboard, result-watcher, and timeout logic work the same regardless of entry path.


### PR DESCRIPTION
## The defect is in the prescription, not in one agent's shell

`CLAUDE.md` tells you to close a task with:

```bash
cat > "$WORKSPACE/results/task-chat-${_ts}.txt" << EOF
<result summary>
EOF
```

That builds the file **in place**. Every drain globs `task-*.txt` and can claim it the instant it appears, so what gets published is whatever bytes existed at that moment.

## Measured, outcome first — the room, not a log

A 2,782 B reply to a collaborator reached their room as **207 characters**. The outbox item on disk:

```
payload  257 B total (body ~207 chars)
status   DELIVERED
```

The claimer did not error and did not retry. It published a prefix and recorded success, so nothing on the sending side looked wrong — it took reading the room to notice.

**It is not one agent's mistake.** A second agent answered the same request in the same minute and its message landed at **218 characters**, ending mid-sentence at `…answered by the sandboxed reviewer:`. Two different lengths, both cut at a paragraph boundary, is the signature of a partial read rather than any cap — the only body limit in that path is `_PROACTIVE_MAX_BODY_B = 48 * 1024`.

## Why the temp name is safe

Every consumer globs the same shape, so a dot-prefixed temp with no `.txt` cannot be claimed:

```
packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py:3466  RESULTS_DIR.glob("task-*.txt")
src/telegram-bridge.py:566                                      results_dir.glob("task-*.txt")
src/discord-bridge.py                                           task_id.startswith("task-")
```

Ran the new recipe and listed the directory:

```
wrote: 38 bytes
all entries       : ['task-chat-999.txt']
task-*.txt matches: ['task-chat-999.txt']
```

The temp is gone by the time anything can see it, and while it exists it matches nothing.

## Why a docs change rather than code

The repo already treats this class as settled where it has been hit before:

- `scripts/core-status.sh` writes via temp + `os.replace` precisely because "a reader polling in that window sees a zero-length file" (#3156);
- `src/` carries six private `_atomic_write*` helpers (`access_store.py`, `cron-runner.py`, `core-input-watch.py`, `discord-bridge.py` x2, `runtime-health.py`).

So the discipline exists and is understood. The prescribed recipe is the one place that still hands out the unsafe form, and it is the form agents actually follow.

I am deliberately **not** bundling a consolidation of those six helpers — they may not be semantically identical (owner-only permissions, JSON vs text), and CLAUDE.md says to centralize only writers that are. That is a separate change with its own measurement.

## Checks

- `scripts/agents-md-sync.sh` regenerates AGENTS.md from CLAUDE.md; `tests/agents-md-sync.test.py` passes 5/5.
- `review-checks`: PARTIAL — hardcoded-paths and root-artifacts clean; prose-cap reports no in-scope files because this diff is Markdown only.

## Provenance

Found by checking whether my own reply had actually arrived, after a peer flagged the same symptom independently. The peer reached the same diagnosis from their side and has fixed their writer; this is the shared cause neither fix removes.
