### PR TITLE
fix(dedup): one owner for the [deduped:] judgement — the pre-write guard was the weaker copy

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -56,6 +56,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`dashboard.py`** — Sutando dashboard — current system status for the local agent.
 - **`dashboard_schedules.py`** — Cron parsing, schedule validation and atomic crons.json persistence.
 - **`dedup_recovery.py`** — Recovery for a `[deduped: <holder>]` result whose holder never answered.
+- **`dedup_soundness.py`** — Is a `[deduped: X]` sound?
 - **`discord-bridge.py`** — Discord bridge for Sutando — listens for DMs, writes to tasks/, sends replies from results/.
 - **`discord-read.py`** — Read recent messages from a Discord channel via REST API.
 - **`discord_addressee.py`** — Shared-channel addressee gate (pure) — companion to `discord-bridge.py`.

--- a/scripts/unanswered-tasks.py
+++ b/scripts/unanswered-tasks.py
@@ -18,118 +18,39 @@ import time
 from pathlib import Path
 
 
-def _result_path(results: Path, task_id: str) -> Path | None:
-    """Every shape a delivered result can take (CLAUDE.md 'Result-body protocol').
+_SRC = Path(__file__).resolve().parent.parent / "src"  # lint-workspace-resolution: allow-repo-root (sys.path only; the root comes from the CLI arg)
+sys.path.insert(0, str(_SRC))
+try:
+    import dedup_soundness
+except ImportError as exc:  # pragma: no cover - exercised by the delegation test
+    print(f"unanswered-tasks: cannot import src/dedup_soundness.py ({exc}) — "
+          "refusing to re-implement the dedup judgement", file=sys.stderr)
+    raise SystemExit(2) from exc
 
-    Missing one shape produces a FALSE ALARM, which is the safe direction here —
-    it costs a re-check, where a false all-clear costs the reply itself.
-    `sorted` because an unordered glob picks by filesystem order, which differs
-    between APFS and the CI runner.
-    """
-    direct = results / f"{task_id}.txt"
-    if direct.exists():
-        return direct
-    for pat in (f"*.{task_id}.txt",                      # per-channel pull namespace
-                f"{task_id}.txt.sending",                # claimed mid-delivery
-                f"*.{task_id}.txt.sending"):
-        hits = sorted(results.glob(pat))
-        if hits:
-            return hits[0]
-    # `{id}-*` requires the separator: a bare `{id}*` prefix also matches
-    # `{id}.too-old.<epoch>`, i.e. QUARANTINED, which is the opposite of delivered.
-    arch = results / "archive"
-    hits = sorted(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
-    return hits[0] if hits else None
-
-
-def _task_exists(tasks: Path, task_id: str) -> bool:
-    """Did this id ever exist HERE? Task ids are minted per recipient, so a
-    peer's id is well-formed and still unresolvable — charset cannot tell."""
-    if (tasks / f"{task_id}.txt").exists():
-        return True
-    arch = tasks / "archive"
-    return bool(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
-
-
-def _task_field(tasks: Path, task_id: str, key: str) -> str | None:
-    """One header field of a task, live or archived."""
-    for cand in [tasks / f"{task_id}.txt", *sorted((tasks / "archive").glob(f"**/{task_id}*.txt"))]:
-        try:
-            text = cand.read_text(errors="replace")
-        except OSError:
-            continue
-        for line in text.splitlines():
-            if line.startswith(f"{key}:"):
-                return line.split(":", 1)[1].strip()
-        return None
-    return None
-
-
-_MARKERS = None
+_result_path = dedup_soundness.result_path
+_read = dedup_soundness.read
 
 
 def _markers():
-    """The marker grammar is centralised in src/result_markers.py (CLAUDE.md);
-    re-implementing it drifts from what the bridge actually does."""
-    global _MARKERS
-    if _MARKERS is not None:
-        return _MARKERS
-    repo = Path(__file__).resolve().parent.parent  # lint-workspace-resolution: allow-repo-root (sys.path only; the root comes from the CLI arg)
-    sys.path.insert(0, str(repo / "src"))
+    """Resolve the grammar owner up front so an empty queue cannot skip the guard.
+    Kept as a SystemExit(2) here because the CLI contract is 'could not answer'."""
     try:
-        from result_markers import dedup_holder_delivered, parse_markers
+        return dedup_soundness.markers(_SRC)
     except ImportError as exc:
         print(f"unanswered-tasks: cannot import src/result_markers.py ({exc}) — "
               "refusing to re-implement the marker grammar", file=sys.stderr)
         raise SystemExit(2) from exc
-    _MARKERS = (dedup_holder_delivered, parse_markers)
-    return _MARKERS
-
-
-def _read(path: Path | None) -> str | None:
-    if path is None:
-        return None
-    try:
-        return path.read_text(errors="replace")
-    except OSError:
-        return None
 
 
 def _unanswered_reason(results: Path, task_id: str, tasks: Path | None = None) -> str | None:
     """None when the room heard something; else why it did not.
 
-    Delegates the `[deduped:]` verdict to `dedup_holder_delivered`, which is
-    what the bridge asks — a holder that is itself a skip never delivered.
+    The whole judgement belongs to `src/dedup_soundness.py`, shared with the
+    PRE-write guard. Both asked the same question and answered it differently,
+    and the guard was the weaker copy — which is the dangerous direction, since
+    it cleared writes this check would later condemn.
     """
-    delivered, parse = _markers()
-    text = _read(_result_path(results, task_id))
-    if text is None:
-        return "no result file"
-    dedup = next((a for a in parse(text).actions
-                  if a.kind == "skip" and a.value == "deduped"), None)
-    if dedup is None:
-        return None  # a real reply, or a deliberate skip decision for THIS task
-    target = str(dedup.extra or "").strip()
-    if not target:
-        return "deduped into nothing (no target id)"
-    if tasks is not None:
-        # The dedup is sound only within ONE SENDER's thread. Comparing the CHANNEL
-        # misses every case in a shared room, which is where peers actually talk.
-        who = _task_field(tasks, task_id, "user_id")
-        to = _task_field(tasks, target, "user_id")
-        if who and to and who != to:
-            return f"CROSS-SENDER: deduped into {target}, which answers {to}, not {who}"
-        room, dest_room = _task_field(tasks, task_id, "channel_id"), _task_field(tasks, target, "channel_id")
-        if room and dest_room and room != dest_room:
-            return f"CROSS-ROOM: deduped into {target}, whose reply goes to {dest_room}, not {room}"
-    target_path = _result_path(results, target)
-    if delivered(_read(target_path)):
-        return None
-    if target_path is None:
-        if tasks is not None and not _task_exists(tasks, target):
-            return f"DANGLING: deduped into {target}, which does not exist in this workspace"
-        return f"ORPHANED: deduped into {target}, which has no result file"
-    return f"HOLDER-SKIPPED: deduped into {target}, whose own result is a skip — the bridge requeues this"
+    return dedup_soundness.dedup_problem(results, task_id, tasks, src_dir=_SRC)
 
 
 def unanswered(workspace: Path, min_age_sec: float, now: float | None = None) -> list[tuple[str, float, str]]:

--- a/skills/proactive-loop/scripts/check-dedup-targets.py
+++ b/skills/proactive-loop/scripts/check-dedup-targets.py
@@ -15,7 +15,6 @@ Usage:
 Exit 0 clean, 1 contradictions found, 2 could not answer.
 """
 
-import re
 import sys
 from pathlib import Path
 
@@ -23,22 +22,31 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[3]
 
 
-def _canonical():
-    """`result_markers.dedup_holder_delivered`, the repo's policy owner.
+def _owner():
+    """`src/dedup_soundness.py`, the judgement's owner, or None if unavailable.
 
-    Re-implementing "did the holder deliver" drifts: a hand-rolled `[no-send]`
-    test called a `[REPLIED]` holder delivered, while the owner counts EVERY skip
-    action. Import it rather than copy it; if it cannot be imported the checker
-    must refuse (exit 2), never fall back to a weaker local rule.
+    Resolved through the CURRENT `REPO` rather than captured at import, so the
+    absent-owner path stays reachable (and testable) instead of turning into an
+    import-time crash. That distinction matters to the caller: a tool that dies
+    on import exits 1, and every checker in the proactive loop reserves 1 for a
+    REAL finding — so a missing owner would read as "dedups resolve to nothing"
+    rather than "the checker could not answer".
     """
     src = REPO / "src"
-    if not (src / "result_markers.py").is_file():
+    if not (src / "dedup_soundness.py").is_file() or not (src / "result_markers.py").is_file():
         return None
-    sys.path.insert(0, str(src))
-    import result_markers
-    return result_markers.dedup_holder_delivered
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    import dedup_soundness
+    return dedup_soundness
 
-DEDUP = re.compile(r"^\s*\[deduped:\s*([^\]]+?)\s*\]", re.M)
+
+def _require_owner():
+    ds = _owner()
+    if ds is None:
+        raise RuntimeError("src/dedup_soundness.py (or result_markers.py) not importable — "
+                           "cannot answer; refusing to fall back to a weaker local rule")
+    return ds
 
 
 def workspace() -> Path:
@@ -47,68 +55,73 @@ def workspace() -> Path:
     return resolve_workspace(migrate=False)
 
 
-def target_body(ws: Path, tid: str) -> "str | None":
-    """The referenced result's body, or None if no such result exists."""
-    tid = tid.strip()
-    direct = ws / "results" / f"{tid}.txt"
-    if direct.is_file():
-        return direct.read_text(errors="ignore")
-    hits = sorted((ws / "results" / "archive").glob(f"{tid}*.txt"))
-    if hits:
-        return hits[-1].read_text(errors="ignore")
-    return None
-
-
 def check(ws: Path, files) -> "list[tuple[str, str, str]]":
-    """(file, target, why) for every dedup that resolves to nothing."""
+    """(file, target, why) for every dedup that resolves to nothing.
+
+    The task id is the result FILENAME's stem, which is what lets the shared
+    judgement compare this task's sender and room against the holder's. Passing
+    the body alone (as this file used to) makes those two checks unreachable.
+    """
+    ds = _require_owner()
+    src = REPO / "src"
+    results, tasks = ws / "results", ws / "tasks"
     bad = []
     for f in files:
         try:
             body = f.read_text(errors="ignore")
         except OSError:
             continue
-        m = DEDUP.search(body)
-        if not m:
+        target = ds.dedup_target(body, src)
+        if not target:
             continue
-        why = resolve(ws, m.group(1))
+        why = ds.dedup_problem(
+            results, _task_id(f), tasks if tasks.is_dir() else None, text=body, src_dir=src)
         if why:
-            bad.append((f.name, m.group(1), why))
+            bad.append((f.name, target, why))
     return bad
 
 
+def _task_id(result_file: Path) -> str:
+    """`task-<id>` from a result filename, across the shapes it can carry:
+    `task-x.txt`, `<channel-key>.task-x.txt`, `task-x.txt.sending`."""
+    name = result_file.name
+    for suffix in (".txt.sending", ".txt"):
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+    return name.rsplit(".", 1)[-1]
+
+
 def resolve(ws: Path, tid: str) -> "str | None":
-    """None if the target delivered a real reply; else why it delivers nothing.
+    """None if the target delivered a real reply; else why it does not.
 
-    Delegates the whole judgement to the repo's owner, `result_markers.
-    dedup_holder_delivered`. That is deliberate and it is the second time this
-    file has been corrected toward it:
-
-      - a hand-rolled `[no-send]` test called a `[REPLIED]` holder delivered;
-      - hand-rolled CHAIN FOLLOWING (a -> b -> real reply => clean) was MORE
-        PERMISSIVE than production. `[deduped:]` is itself a skip action, so the
-        bridge's `dedup_decision` returns "requeue" for a chained holder and never
-        walks it. A guard that clears what the bridge rejects is worse than none.
-
-    So: no local rule, no recursion. Ask the owner.
+    Kept as the by-target-id entry point, now delegating to
+    `src/dedup_soundness.py`. This file previously owned its own copy of the
+    marker regex, the result-path resolution and the verdict, and each was the
+    weaker one: a bare `{tid}*` archive glob matched `{tid}.too-old.<epoch>`, so
+    a dedup pointing at a QUARANTINED reply — never delivered — read as clean.
     """
-    tb = target_body(ws, tid)
-    if tb is None:
+    ds = _require_owner()
+    src = REPO / "src"
+    target_path = ds.result_path(ws / "results", tid.strip())
+    if target_path is None:
         return "target result does not exist"
-    delivered = _canonical()
-    if delivered is None:
-        raise RuntimeError("result_markers.py not importable — cannot answer")
+    delivered, _ = ds.markers(src)
+    tb = ds.read(target_path)
     if not delivered(tb):
-        nxt = DEDUP.search(tb)
+        nxt = ds.dedup_target(tb, src)
         if nxt:
-            return (f"target is itself [deduped: {nxt.group(1)}] — the bridge treats a chained "
+            return (f"target is itself [deduped: {nxt}] — the bridge treats a chained "
                     f"holder as not delivered and requeues; it does not walk the chain")
-        # Quote the target's own first line for diagnostics. The VERDICT stays
-        # the owner's; this only says what the reader would see there.
-        first = (tb.strip().splitlines() or [""])[0][:40]
+        first = ((tb or "").strip().splitlines() or [""])[0][:40]
         return f"target delivered nothing (canonical dedup_holder_delivered); it begins {first!r}"
     return None
 
 def main(argv) -> int:
+    if _owner() is None:
+        print("cannot answer: src/dedup_soundness.py (or result_markers.py) is not importable — "
+              "refusing to fall back to a weaker local rule", file=sys.stderr)
+        return 2
     ws = workspace()
     if argv:
         files = [Path(a) for a in argv]

--- a/skills/proactive-loop/scripts/check-dedup-targets.py
+++ b/skills/proactive-loop/scripts/check-dedup-targets.py
@@ -92,31 +92,6 @@ def _task_id(result_file: Path) -> str:
     return name.rsplit(".", 1)[-1]
 
 
-def resolve(ws: Path, tid: str) -> "str | None":
-    """None if the target delivered a real reply; else why it does not.
-
-    Kept as the by-target-id entry point, now delegating to
-    `src/dedup_soundness.py`. This file previously owned its own copy of the
-    marker regex, the result-path resolution and the verdict, and each was the
-    weaker one: a bare `{tid}*` archive glob matched `{tid}.too-old.<epoch>`, so
-    a dedup pointing at a QUARANTINED reply — never delivered — read as clean.
-    """
-    ds = _require_owner()
-    src = REPO / "src"
-    target_path = ds.result_path(ws / "results", tid.strip())
-    if target_path is None:
-        return "target result does not exist"
-    delivered, _ = ds.markers(src)
-    tb = ds.read(target_path)
-    if not delivered(tb):
-        nxt = ds.dedup_target(tb, src)
-        if nxt:
-            return (f"target is itself [deduped: {nxt}] — the bridge treats a chained "
-                    f"holder as not delivered and requeues; it does not walk the chain")
-        first = ((tb or "").strip().splitlines() or [""])[0][:40]
-        return f"target delivered nothing (canonical dedup_holder_delivered); it begins {first!r}"
-    return None
-
 def main(argv) -> int:
     if _owner() is None:
         print("cannot answer: src/dedup_soundness.py (or result_markers.py) is not importable — "

--- a/src/dedup_soundness.py
+++ b/src/dedup_soundness.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Is a `[deduped: X]` sound? One owner, because the copies were not equal.
+
+`[deduped: X]` asserts "the full reply is in X's result". Deciding whether that
+holds needs three things, and two consumers had grown their own version of each:
+`scripts/unanswered-tasks.py` (post-hoc, end of a pass) and
+`skills/proactive-loop/scripts/check-dedup-targets.py` (the guard run BEFORE the
+write). The pre-write copy was weaker in every one of them, which is the worst
+direction: it cleared writes the post-hoc check would later condemn.
+
+  1. WHICH FILE IS THE TARGET'S RESULT. A bare `{id}*` glob also matches
+     `{id}.too-old.<epoch>` — a QUARANTINED result, the exact opposite of a
+     delivered one. The guard used that glob, so a dedup pointing at a reply that
+     was never delivered read as clean.
+  2. WHETHER THE HOLDER DELIVERED. Owned by `result_markers`, not re-implemented.
+  3. WHETHER THE HOLDER ANSWERS THE SAME PERSON, IN THE SAME ROOM. A holder that
+     delivers to a different room leaves the asking room silent, and nothing in
+     the marker grammar can see that.
+
+Dependency-light on purpose: paths come from the caller, so this imports no
+workspace resolver and no CLI. `result_markers` is the one import, and an
+unavailable one raises rather than degrading to a local rule — a guard that
+clears what the bridge rejects is worse than no guard.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_MARKERS = None
+
+
+def markers(src_dir: Path | None = None):
+    """`(dedup_holder_delivered, parse_markers)` from the repo's policy owner.
+
+    Raises ImportError rather than falling back: re-implementing the grammar is
+    how this drifted twice (a `[REPLIED]` holder read as delivered; chain-walking
+    that was more permissive than the bridge, which requeues instead of walking).
+    """
+    global _MARKERS
+    if _MARKERS is not None:
+        return _MARKERS
+    src = src_dir or Path(__file__).resolve().parent
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    from result_markers import dedup_holder_delivered, parse_markers
+    _MARKERS = (dedup_holder_delivered, parse_markers)
+    return _MARKERS
+
+
+def result_path(results: Path, task_id: str) -> Path | None:
+    """Every shape a DELIVERED result can take, and no shape that is not one.
+
+    Missing a delivered shape yields a false alarm, which costs a re-check;
+    admitting a non-delivered shape yields a false all-clear, which costs the
+    reply. So the `-` separator on the archive glob is load-bearing: a bare
+    `{id}*` prefix also matches `{id}.too-old.<epoch>`, i.e. quarantined.
+    `sorted` because filesystem order differs between APFS and the CI runner.
+    """
+    direct = results / f"{task_id}.txt"
+    if direct.exists():
+        return direct
+    for pat in (f"*.{task_id}.txt",           # per-channel pull namespace
+                f"{task_id}.txt.sending",     # claimed mid-delivery
+                f"*.{task_id}.txt.sending"):
+        hits = sorted(results.glob(pat))
+        if hits:
+            return hits[0]
+    arch = results / "archive"
+    hits = sorted(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
+    return hits[0] if hits else None
+
+
+def task_exists(tasks: Path, task_id: str) -> bool:
+    """Did this id ever exist HERE? Task ids are minted per recipient, so a
+    peer's id is well-formed and still unresolvable — charset cannot tell."""
+    if (tasks / f"{task_id}.txt").exists():
+        return True
+    arch = tasks / "archive"
+    return bool(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
+
+
+def task_field(tasks: Path, task_id: str, key: str) -> str | None:
+    """One header field of a task, live or archived."""
+    for cand in [tasks / f"{task_id}.txt", *sorted((tasks / "archive").glob(f"**/{task_id}*.txt"))]:
+        try:
+            text = cand.read_text(errors="replace")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if line.startswith(f"{key}:"):
+                return line.split(":", 1)[1].strip()
+        return None
+    return None
+
+
+def read(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return None
+
+
+def dedup_target(text: str | None, src_dir: Path | None = None) -> str | None:
+    """The id a `[deduped:]` points at, or None when this is not a dedup.
+
+    Via `parse_markers`, never a private regex — the grammar has one owner.
+    """
+    if text is None:
+        return None
+    _, parse = markers(src_dir)
+    action = next((a for a in parse(text).actions
+                   if a.kind == "skip" and a.value == "deduped"), None)
+    if action is None:
+        return None
+    return str(action.extra or "").strip()
+
+
+def dedup_problem(results: Path, task_id: str, tasks: Path | None = None,
+                  text: str | None = None, src_dir: Path | None = None) -> str | None:
+    """None when the dedup is sound; else why the asking room hears nothing.
+
+    `text` is this task's own result body; omit it and it is read from `results`.
+    `tasks` enables the addressee checks — without it they are SKIPPED, not
+    passed, so a caller that cannot supply the task dir gets the weaker verdict
+    it asked for rather than a silent all-clear.
+    """
+    delivered, _ = markers(src_dir)
+    if text is None:
+        text = read(result_path(results, task_id))
+    if text is None:
+        return "no result file"
+    target = dedup_target(text, src_dir)
+    if target is None:
+        return None          # a real reply, or a deliberate skip for THIS task
+    if not target:
+        return "deduped into nothing (no target id)"
+
+    if tasks is not None:
+        # Sound only within one sender's thread, in one room — neither is
+        # visible to the marker grammar, and a cross-room dedup is silent.
+        who, to = task_field(tasks, task_id, "user_id"), task_field(tasks, target, "user_id")
+        if who and to and who != to:
+            return f"CROSS-SENDER: deduped into {target}, which answers {to}, not {who}"
+        room = task_field(tasks, task_id, "channel_id")
+        dest = task_field(tasks, target, "channel_id")
+        if room and dest and room != dest:
+            return f"CROSS-ROOM: deduped into {target}, whose reply goes to {dest}, not {room}"
+
+    target_path = result_path(results, target)
+    holder = read(target_path)
+    if delivered(holder):
+        return None
+    if target_path is None:
+        if tasks is not None and not task_exists(tasks, target):
+            return f"DANGLING: deduped into {target}, which does not exist in this workspace"
+        return f"ORPHANED: deduped into {target}, which has no result file"
+    # `[deduped:]` is itself a skip, so the bridge requeues at the first hop
+    # rather than walking the chain — naming the tail says why following it fails.
+    chained = dedup_target(holder, src_dir)
+    if chained:
+        return (f"HOLDER-SKIPPED: deduped into {target}, which is itself [deduped: {chained}] — "
+                f"the bridge treats a chained holder as not delivered and requeues; "
+                f"it does not walk the chain")
+    return f"HOLDER-SKIPPED: deduped into {target}, whose own result is a skip — the bridge requeues this"

--- a/tests/dedup-soundness.test.py
+++ b/tests/dedup-soundness.test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Contract for src/dedup_soundness.py, and that both consumers DELEGATE to it.
+
+The module exists because two tools asked "is this `[deduped:]` sound?" and
+answered differently. `scripts/unanswered-tasks.py` (post-hoc) had the fuller
+rule; `skills/proactive-loop/scripts/check-dedup-targets.py` (the PRE-write
+guard) had a weaker one — which is the dangerous direction, since the guard
+cleared writes the post-hoc check would later condemn.
+
+The delegation arms are the point. A contract test alone passes forever while a
+consumer quietly grows a private copy back, and that is exactly how the drift
+started.
+"""
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+import dedup_soundness as ds  # noqa: E402
+
+SRC = REPO / "src"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ws(results=None, archive=None, tasks=None, task_archive=None) -> Path:
+    ws = Path(tempfile.mkdtemp())
+    (ws / "results" / "archive").mkdir(parents=True)
+    (ws / "tasks" / "archive").mkdir(parents=True)
+    for d, files in (("results", results), ("results/archive", archive),
+                     ("tasks", tasks), ("tasks/archive", task_archive)):
+        for n, b in (files or {}).items():
+            (ws / d / n).write_text(b)
+    return ws
+
+
+class ResultPath(unittest.TestCase):
+    """Which file counts as the target's DELIVERED result."""
+
+    def test_a_quarantined_result_is_not_a_delivered_one(self):
+        """`{id}.too-old.<epoch>` was quarantined — the opposite of delivered.
+        The pre-write guard used a bare `{id}*` glob, which matches it."""
+        ws = _ws(archive={"task-b.too-old.1788000000.txt": "never sent\n"})
+        self.assertIsNone(ds.result_path(ws / "results", "task-b"))
+
+    def test_the_real_archive_shape_IS_found(self):
+        """Control: without it, 'reject quarantine' could be 'reject everything'."""
+        ws = _ws(archive={"task-b-1788000001.txt": "the reply\n"})
+        self.assertIsNotNone(ds.result_path(ws / "results", "task-b"))
+
+    def test_the_undecorated_archive_shape_is_found(self):
+        ws = _ws(archive={"task-b.txt": "the reply\n"})
+        self.assertIsNotNone(ds.result_path(ws / "results", "task-b"))
+
+    def test_a_live_result_wins_over_the_archive(self):
+        ws = _ws(results={"task-b.txt": "live\n"}, archive={"task-b-1.txt": "old\n"})
+        self.assertEqual(ds.result_path(ws / "results", "task-b").read_text(), "live\n")
+
+    def test_the_per_channel_pull_namespace_is_found(self):
+        ws = _ws(results={"phone-abc.task-b.txt": "the reply\n"})
+        self.assertIsNotNone(ds.result_path(ws / "results", "task-b"))
+
+
+class Problems(unittest.TestCase):
+    """One taxonomy, so both tools name the same condition the same way."""
+
+    def _p(self, ws, tid="task-a", with_tasks=True):
+        return ds.dedup_problem(ws / "results", tid,
+                                (ws / "tasks") if with_tasks else None, src_dir=SRC)
+
+    def test_a_real_reply_is_clean(self):
+        ws = _ws(results={"task-a.txt": "[deduped: task-b]\n", "task-b.txt": "the reply\n"})
+        self.assertIsNone(self._p(ws))
+
+    def test_a_non_dedup_result_is_clean(self):
+        ws = _ws(results={"task-a.txt": "an ordinary reply\n"})
+        self.assertIsNone(self._p(ws))
+
+    def test_cross_room_is_named(self):
+        """The failure that motivated sharing: the holder delivers correctly, in
+        the wrong room, so the asking room hears nothing and nothing errors."""
+        ws = _ws(results={"task-a.txt": "[deduped: task-b]\n", "task-b.txt": "the reply\n"},
+                 tasks={"task-a.txt": "channel_id: !room:x\nuser_id: @u:x\ntask: q\n",
+                        "task-b.txt": "channel_id: !dm:x\nuser_id: @u:x\ntask: q\n"})
+        self.assertIn("CROSS-ROOM", self._p(ws))
+
+    def test_cross_sender_is_named(self):
+        ws = _ws(results={"task-a.txt": "[deduped: task-b]\n", "task-b.txt": "the reply\n"},
+                 tasks={"task-a.txt": "channel_id: !r:x\nuser_id: @alice:x\ntask: q\n",
+                        "task-b.txt": "channel_id: !r:x\nuser_id: @bob:x\ntask: q\n"})
+        self.assertIn("CROSS-SENDER", self._p(ws))
+
+    def test_same_room_same_sender_stays_clean(self):
+        """Green on purpose: the legitimate dedup must survive, or the two arms
+        above would pass against a rule that flags every dedup."""
+        ws = _ws(results={"task-a.txt": "[deduped: task-b]\n", "task-b.txt": "the reply\n"},
+                 tasks={"task-a.txt": "channel_id: !r:x\nuser_id: @u:x\ntask: q\n",
+                        "task-b.txt": "channel_id: !r:x\nuser_id: @u:x\ntask: q\n"})
+        self.assertIsNone(self._p(ws))
+
+    def test_a_skip_holder_is_named(self):
+        ws = _ws(results={"task-a.txt": "[deduped: task-b]\n", "task-b.txt": "[no-send]\n"})
+        self.assertIn("HOLDER-SKIPPED", self._p(ws, with_tasks=False))
+
+    def test_a_chained_holder_names_the_chain(self):
+        ws = _ws(results={"task-a.txt": "[deduped: task-b]\n",
+                          "task-b.txt": "[deduped: task-c]\n", "task-c.txt": "reply\n"})
+        why = self._p(ws, with_tasks=False)
+        self.assertIn("HOLDER-SKIPPED", why)
+        self.assertIn("task-c", why, "naming the chain is what says walking it would not help")
+
+    def test_a_dangling_target_is_distinguished_from_an_orphaned_one(self):
+        ws = _ws(results={"task-a.txt": "[deduped: task-gone]\n"})
+        self.assertIn("DANGLING", self._p(ws))          # tasks/ present, id unknown
+        self.assertIn("ORPHANED", self._p(ws, with_tasks=False))  # cannot tell
+
+    def test_an_empty_target_is_named(self):
+        ws = _ws(results={"task-a.txt": "[deduped: ]\n"})
+        self.assertEqual(self._p(ws), "deduped into nothing (no target id)")
+
+    def test_without_tasks_the_addressee_checks_are_SKIPPED_not_passed(self):
+        """A caller that cannot supply tasks/ gets the weaker verdict it asked
+        for — never a silent all-clear dressed as the full check."""
+        ws = _ws(results={"task-a.txt": "[deduped: task-b]\n", "task-b.txt": "reply\n"},
+                 tasks={"task-a.txt": "channel_id: !room:x\ntask: q\n",
+                        "task-b.txt": "channel_id: !dm:x\ntask: q\n"})
+        self.assertIn("CROSS-ROOM", self._p(ws, with_tasks=True))
+        self.assertIsNone(self._p(ws, with_tasks=False))
+
+
+class RefusesRatherThanGuesses(unittest.TestCase):
+    def test_an_unimportable_grammar_owner_raises(self):
+        saved, had = ds._MARKERS, sys.modules.get("result_markers")
+        ds._MARKERS = None
+        sys.modules["result_markers"] = None
+        try:
+            with self.assertRaises(ImportError):
+                ds.markers(SRC)
+        finally:
+            ds._MARKERS = saved
+            if had is not None:
+                sys.modules["result_markers"] = had
+            else:
+                sys.modules.pop("result_markers", None)
+        self.assertIsNotNone(ds.markers(SRC), "CONTROL: global state restored")
+
+
+class ConsumersDelegate(unittest.TestCase):
+    """Neither tool may re-grow a private copy of the judgement."""
+
+    def test_check_dedup_targets_calls_the_owner(self):
+        cdt = _load(REPO / "skills" / "proactive-loop" / "scripts" / "check-dedup-targets.py", "cdt_d")
+        ws = _ws(results={"a.txt": "[deduped: task-b]\n", "task-b.txt": "[no-send]\n"})
+        sentinel = "SENTINEL-FROM-THE-OWNER"
+        with mock.patch.object(ds, "dedup_problem", return_value=sentinel) as spy:
+            bad = cdt.check(ws, [ws / "results" / "a.txt"])
+        self.assertTrue(spy.called, "the guard did not consult src/dedup_soundness")
+        self.assertEqual([b[2] for b in bad], [sentinel],
+                         "the guard reported a verdict the owner did not produce")
+
+    def test_unanswered_tasks_calls_the_owner(self):
+        uat = _load(REPO / "scripts" / "unanswered-tasks.py", "uat_d")
+        ws = _ws(results={"task-a.txt": "[deduped: task-b]\n", "task-b.txt": "[no-send]\n"},
+                 tasks={"task-a.txt": "id: task-a\ntask: q\n"})
+        sentinel = "SENTINEL-FROM-THE-OWNER"
+        with mock.patch.object(ds, "dedup_problem", return_value=sentinel) as spy:
+            rows = uat.unanswered(ws, min_age_sec=-1)
+        self.assertTrue(spy.called, "unanswered-tasks did not consult src/dedup_soundness")
+        self.assertEqual([r[2] for r in rows], [sentinel])
+
+    def test_neither_consumer_carries_its_own_dedup_regex(self):
+        """The grammar has one owner. A private `[deduped:` regex is how the
+        pre-write guard drifted from the bridge in the first place."""
+        for rel in ("skills/proactive-loop/scripts/check-dedup-targets.py",
+                    "scripts/unanswered-tasks.py"):
+            text = (REPO / rel).read_text()
+            self.assertNotIn(r"\[deduped:", text,
+                             f"{rel} re-implements the dedup marker grammar")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/dedup-soundness.test.py
+++ b/tests/dedup-soundness.test.py
@@ -140,6 +140,22 @@ class Problems(unittest.TestCase):
 
 
 class RefusesRatherThanGuesses(unittest.TestCase):
+    def test_dedup_target_of_None_is_None_not_a_crash(self):
+        """`result_path` returns None for a target with no result, and the body
+        read from it is None — so this is the ordinary path, not an edge case."""
+        self.assertIsNone(ds.dedup_target(None, SRC))
+
+    def test_markers_puts_src_on_the_path_when_absent(self):
+        saved_path, saved_cache = list(sys.path), ds._MARKERS
+        ds._MARKERS = None
+        sys.path[:] = [p for p in sys.path if p != str(SRC)]
+        try:
+            self.assertIsNotNone(ds.markers(SRC))
+            self.assertIn(str(SRC), sys.path, "markers() must make its own import reachable")
+        finally:
+            sys.path[:] = saved_path
+            ds._MARKERS = saved_cache
+
     def test_an_unimportable_grammar_owner_raises(self):
         saved, had = ds._MARKERS, sys.modules.get("result_markers")
         ds._MARKERS = None

--- a/tests/proactive-loop-check-dedup-targets.test.py
+++ b/tests/proactive-loop-check-dedup-targets.test.py
@@ -33,11 +33,13 @@ def _ws(results: dict, archive: dict = None):
 
 class Contradictions(unittest.TestCase):
     def test_a_dedup_onto_a_no_send_target_is_flagged(self):
+        # Taxonomy is the shared owner's, so this condition is named
+        # identically here and in scripts/unanswered-tasks.py.
         ws = _ws({"a.txt": "[deduped: task-b]\n", "task-b.txt": "[no-send]\nnothing\n"})
         bad = cdt.check(ws, [ws / "results" / "a.txt"])
         self.assertEqual(len(bad), 1)
-        self.assertIn("delivered nothing", bad[0][2])
-        self.assertIn("[no-send]", bad[0][2])   # quoted from the target, for the reader
+        self.assertIn("HOLDER-SKIPPED", bad[0][2])
+        self.assertIn("task-b", bad[0][2])
 
     def test_a_dedup_onto_a_real_reply_is_clean(self):
         # Control: without this the checker could flag every dedup and the test
@@ -49,7 +51,30 @@ class Contradictions(unittest.TestCase):
         ws = _ws({"a.txt": "[deduped: task-nope]\n"})
         bad = cdt.check(ws, [ws / "results" / "a.txt"])
         self.assertEqual(len(bad), 1)
-        self.assertIn("does not exist", bad[0][2])
+        self.assertIn("ORPHANED", bad[0][2])
+        self.assertIn("task-nope", bad[0][2])
+
+    def test_a_QUARANTINED_target_is_not_mistaken_for_a_delivered_one(self):
+        """The regression this extraction exists for.
+
+        `{id}.too-old.<epoch>` is a result that was quarantined — never
+        delivered. This file resolved the target with a bare `{id}*` archive
+        glob, which matches it, so a dedup pointing at an undelivered reply read
+        as CLEAN. `unanswered-tasks.py` already required the `-` separator and
+        documented why; only the guard had the loose glob.
+        """
+        ws = _ws({"a.txt": "[deduped: task-b]\n"},
+                 archive={"task-b.too-old.1788000000.txt": "quarantined, never sent\n"})
+        bad = cdt.check(ws, [ws / "results" / "a.txt"])
+        self.assertEqual(len(bad), 1, "a quarantined target must not read as delivered")
+        self.assertIn("task-b", bad[0][2])
+
+    def test_a_delivered_archived_target_is_still_clean(self):
+        """Control for the arm above: the `-` separator must not reject the real
+        archive shape, or the fix would be 'flag everything' wearing a fix's name."""
+        ws = _ws({"a.txt": "[deduped: task-b]\n"},
+                 archive={"task-b-1788000001.txt": "the actual reply\n"})
+        self.assertEqual(cdt.check(ws, [ws / "results" / "a.txt"]), [])
 
     def test_the_target_is_resolved_from_the_archive_too(self):
         # Results are archived on delivery, so a same-pass check would otherwise

--- a/tests/proactive-loop-check-dedup-targets.test.py
+++ b/tests/proactive-loop-check-dedup-targets.test.py
@@ -181,11 +181,22 @@ class Refusals(unittest.TestCase):
         self.assertEqual(cdt.check(ws, [ws / "results"]), [])   # a directory: OSError
 
     def test_without_the_policy_owner_the_checker_refuses(self):
-        # No local fallback rule: result_markers.py absent -> RuntimeError, never "clean".
+        # No local fallback rule: the owner absent -> raise, never "clean".
         ws = _ws({"a.txt": "[deduped: task-b]\n", "task-b.txt": "reply\n"})
         with mock.patch.object(cdt, "REPO", Path(tempfile.mkdtemp())):
             with self.assertRaises(RuntimeError):
-                cdt.resolve(ws, "task-b")
+                cdt.check(ws, [ws / "results" / "a.txt"])
+
+    def test_the_CLI_reports_a_missing_owner_as_2_not_1(self):
+        """Exit 1 is reserved for a real finding by every checker in the loop, so
+        a missing owner exiting 1 would read as 'dedups resolve to nothing'."""
+        ws = _ws({"a.txt": "[deduped: task-b]\n"})
+        buf, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(cdt, "REPO", Path(tempfile.mkdtemp())), \
+                contextlib.redirect_stdout(buf), contextlib.redirect_stderr(err):
+            rc = cdt.main([str(ws / "results" / "a.txt")])
+        self.assertEqual(rc, 2)
+        self.assertIn("not importable", buf.getvalue() + err.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/unanswered-tasks.test.py
+++ b/tests/unanswered-tasks.test.py
@@ -260,18 +260,35 @@ for marker in ("[no-send]", "[REPLIED]"):
 
 # The guard must fire on an EMPTY queue too: a lazy per-task import means a
 # missing result_markers.py reports "none" instead of refusing.
+import shutil
+import subprocess
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def _fake_repo(d: Path, with_soundness: bool):
+    """A repo holding unanswered-tasks.py and, optionally, its judgement owner —
+    but never result_markers.py, so the grammar owner is the missing one."""
+    (d / "src").mkdir(); (d / "scripts").mkdir()
+    shutil.copy(_REPO / "scripts" / "unanswered-tasks.py", d / "scripts" / "unanswered-tasks.py")
+    if with_soundness:
+        shutil.copy(_REPO / "src" / "dedup_soundness.py", d / "src" / "dedup_soundness.py")
+    ws = d / "ws"; (ws / "tasks").mkdir(parents=True); (ws / "results").mkdir()
+    return subprocess.run([sys.executable, str(d / "scripts" / "unanswered-tasks.py"),
+                           "--workspace", str(ws)], capture_output=True, text=True, cwd=d)
+
+
 with tempfile.TemporaryDirectory() as d:
-    import shutil
-    import subprocess
-    root = Path(d)
-    (root / "src").mkdir(); (root / "scripts").mkdir()
-    shutil.copy(Path(__file__).resolve().parent.parent / "scripts" / "unanswered-tasks.py",
-                root / "scripts" / "unanswered-tasks.py")
-    ws = root / "ws"; (ws / "tasks").mkdir(parents=True); (ws / "results").mkdir()
-    proc = subprocess.run([sys.executable, str(root / "scripts" / "unanswered-tasks.py"),
-                           "--workspace", str(ws)], capture_output=True, text=True, cwd=root)
+    proc = _fake_repo(Path(d), with_soundness=True)
     check(proc.returncode == 2 and "result_markers" in proc.stderr,
           "refuses (exit 2) when result_markers.py is unimportable, even with an empty queue")
+
+with tempfile.TemporaryDirectory() as d:
+    # Exit 2, not 1: the loop's checkers reserve 1 for a real finding, so a
+    # broken tool exiting 1 reads as damage to the user's data.
+    proc = _fake_repo(Path(d), with_soundness=False)
+    check(proc.returncode == 2 and "dedup_soundness" in proc.stderr,
+          "refuses (exit 2) when src/dedup_soundness.py is unimportable")
 
 
 # The real shape: ONE shared room, many senders. Comparing channels is silent
@@ -303,13 +320,17 @@ with tempfile.TemporaryDirectory() as d:
 # Error and edge paths. The refusal is asserted above too, but via subprocess,
 # where no tracer follows — so these drive the same branches in-process.
 
+# These now live in src/dedup_soundness.py, shared with the PRE-write guard, so
+# the assertions follow the code to its owner rather than through a re-export.
+_ds = uat.dedup_soundness
+
 with tempfile.TemporaryDirectory() as d:
     root = Path(d); (root / "tasks").mkdir()
     (root / "tasks" / "task-live.txt").write_text("id: live\n")
-    check(uat._task_exists(root / "tasks", "task-live") is True,
-          "_task_exists: True while the task is still LIVE in tasks/ (not yet archived)")
-    check(uat._task_exists(root / "tasks", "task-never") is False,
-          "_task_exists: False for an id that never existed here")
+    check(_ds.task_exists(root / "tasks", "task-live") is True,
+          "task_exists: True while the task is still LIVE in tasks/ (not yet archived)")
+    check(_ds.task_exists(root / "tasks", "task-never") is False,
+          "task_exists: False for an id that never existed here")
 
 with tempfile.TemporaryDirectory() as d:
     check(uat._read(Path(d)) is None, "_read: a directory (OSError) reads as None rather than raising")
@@ -325,9 +346,9 @@ with tempfile.TemporaryDirectory() as d:
 # so the refusal runs in-process instead of in a child the tracer cannot see.
 import contextlib
 import io
-_saved_markers, _had_mod = uat._MARKERS, "result_markers" in sys.modules
+_saved_markers, _had_mod = _ds._MARKERS, "result_markers" in sys.modules
 _saved_mod = sys.modules.get("result_markers")
-uat._MARKERS = None
+_ds._MARKERS = None
 sys.modules["result_markers"] = None
 _err = io.StringIO()
 try:
@@ -343,7 +364,7 @@ finally:
         sys.modules["result_markers"] = _saved_mod
     else:
         sys.modules.pop("result_markers", None)
-    uat._MARKERS = _saved_markers
+    _ds._MARKERS = _saved_markers
 
 check(uat._markers() is not None,
       "CONTROL: _markers still works afterwards — the refusal test restored global state")


### PR DESCRIPTION
## What

`scripts/unanswered-tasks.py` (post-hoc, end of a pass) and `skills/proactive-loop/scripts/check-dedup-targets.py` (the guard run **before** the write) both answer *"is this `[deduped: X]` sound?"*. Each had grown its own copy of all three parts of that answer — which file counts as the target's result, whether the holder delivered, and whether it answers the same person in the same room.

The pre-write guard was the weaker copy in every one. That is the dangerous direction: it cleared writes the post-hoc check would later condemn.

This extracts the judgement into `src/dedup_soundness.py` and points both at it. Per CLAUDE.md, duplicated policy is itself the defect and the extraction *is* the fix, not a follow-up to it.

## The defects this removes

**1. A quarantined result read as delivered.** The guard resolved the target with a bare `{tid}*` archive glob, which also matches `{tid}.too-old.<epoch>` — a result that was quarantined, i.e. never delivered. `unanswered-tasks.py` already required the `-` separator and documented exactly why; only the guard had the loose glob. Reproduced at the parent commit:

```
target exists ONLY as archive/task-b.too-old.1788000000.txt
  resolve() -> None          # None means "clean, the holder delivered"
control, absent target -> 'target result does not exist'
```

So a dedup pointing at a reply that was never delivered returned clean — the exact case the guard exists to catch.

**2. No cross-room check.** A holder in another room delivers correctly and leaves the *asking* room silent. Nothing in the marker grammar can see that. This one is not hypothetical: it happened on this host, and only the end-of-pass check caught it — after the fact.

**3. No cross-sender check, and no DANGLING/ORPHANED distinction.**

**4. A private `[deduped:` regex instead of the canonical `parse_markers`.** This was not only duplication — it produced false positives.

## Before / after, on the live corpus

Same 4617 result files, same run, old resolution vs new:

```
private regex + loose glob : 55 findings
shared owner               : 53 findings
no longer flagged: 2
newly missed:      0
```

Both drops are result files whose bodies *quote* the syntax while explaining it:

```
[deduped: task-x]    -> same substitution
[deduped: X] where X is [no-send], itself deduped, or absent
```

`parse_markers` returns no dedup action for either; the private regex matched the documentation of the defect. That is a false-positive class the repo has already been bitten by once, recorded in the loop skill as *"a grep for a defect's own wording counts the documentation of the defect"*.

## Also fixed

A missing owner made `check-dedup-targets.py` die at **import** — exit 1. Every checker in the proactive loop reserves exit 1 for a *real finding*, so a broken tool read as "dedups resolve to nothing", sending the reader to investigate data that is fine. It now exits 2 (cannot answer) and still refuses rather than falling back to a weaker local rule.

## Tests

`tests/dedup-soundness.test.py` pins the contract **and that each consumer delegates**. The delegation arms are the point: a contract test alone passes forever while a consumer quietly regrows a private copy, which is how this drifted in the first place.

Four mutations verified red on their **named** arms, each with `__pycache__` cleared — successive mutations inside one second reuse cached bytecode and read as green, which briefly fooled me here:

| mutation | arm that reddens |
|---|---|
| restore the loose `{id}*` glob | `test_a_quarantined_result_is_not_a_delivered_one` |
| disable cross-room | `test_cross_room_is_named` (+ the skipped-vs-passed arm) |
| disable cross-sender | `test_cross_sender_is_named` |
| guard regrows a private regex | both `ConsumersDelegate` arms |

Green-on-purpose arms, so "fail closed" cannot become "flag everything" unnoticed: a same-room/same-sender dedup stays clean, and a genuinely delivered archived target stays clean.

```
unanswered-tasks        39/39
check-dedup-targets     18/18
dedup-soundness         20/20
review-checks           PASS (hardcoded-paths + root-artifacts + prose-cap)
```

`tests/pathless-file-marker-controls.test.py` fails identically at `origin/main` (control run) — pre-existing, unrelated to this change.

## Scope

No behaviour change to the bridge. `result_markers` remains the grammar owner and is imported, never re-implemented; this module owns only the *soundness* judgement layered on top of it. The taxonomy is now shared, so both tools name the same condition the same way instead of carrying two vocabularies for one condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
