### PR TITLE
feat(voice-config): a "latest-search" preset — the newest live model with Web grounding

### DIFF
--- a/src/voice-config-switch.ts
+++ b/src/voice-config-switch.ts
@@ -118,7 +118,7 @@ export const switchVoiceConfigTool: ToolDefinition = {
 		'requests — NEVER because the conversation merely mentions search/searching, and never on filler ' +
 		'or garbled speech; when unsure, fire nothing.',
 	parameters: z.object({
-		preset: z.enum(['search', 'no-search', 'latest-search']).describe('Which preset to switch to. "search" = 2.5+Web grounding. "no-search" = 3.1+no-Web.'),
+		preset: z.enum(['search', 'no-search', 'latest-search']).describe('Which preset to switch to. "search" = 2.5+Web grounding. "no-search" = 3.1+no-Web. "latest-search" = 3.1+Web grounding.'),
 	}),
 	execution: 'inline',
 	async execute(args) {

--- a/src/voice-config-switch.ts
+++ b/src/voice-config-switch.ts
@@ -15,6 +15,7 @@
  * Presets (named after the only knob that matters — Web grounding):
  *   - 'search'    → 2.5-flash-native-audio + googleSearch:true  (Web grounding ON)
  *   - 'no-search' → 3.1-flash-live-preview + googleSearch:false (newer model, no Web)
+ *   - 'latest-search' → 3.1-flash-live-preview + googleSearch:true (needs a paid-tier VOICE key)
  *
  * The tool returns BEFORE the restart fires (small setTimeout) so Gemini
  * can speak the ack before the transport closes. The guarded takeover kills
@@ -61,9 +62,11 @@ export function fireGuardedRestart(spawnImpl: typeof spawn = spawn): void {
 // owner_mode / channels are merged in from VOICE_CONFIG_DEFAULTS at write time.
 type VoiceConfigPreset = Pick<VoiceConfig, 'model' | 'googleSearch'>;
 
-const PRESETS: Record<'search' | 'no-search', VoiceConfigPreset> = {
+export const PRESETS: Record<'search' | 'no-search' | 'latest-search', VoiceConfigPreset> = {
 	search: { model: 'gemini-2.5-flash-native-audio-preview-12-2025', googleSearch: true },
 	'no-search': { model: 'gemini-3.1-flash-live-preview', googleSearch: false },
+	// 3.1 + search: a free-tier VOICE key closes with 1011; a paid-tier key holds.
+	'latest-search': { model: 'gemini-3.1-flash-live-preview', googleSearch: true },
 };
 
 const ts = () => new Date().toISOString().slice(11, 23);
@@ -108,20 +111,21 @@ export const switchVoiceConfigTool: ToolDefinition = {
 		'"switch to no-search mode", "use 2.5", "use 3.1", "turn search on", "turn search off". ' +
 		'Presets: ' +
 		'"search" = gemini-2.5-flash-native-audio + googleSearch:true (best for Q&A with Web grounding); ' +
-		'"no-search" = gemini-3.1-flash-live-preview + googleSearch:false (newer model, no Web grounding). ' +
+		'"no-search" = gemini-3.1-flash-live-preview + googleSearch:false (newer model, no Web grounding); ' +
+		'"latest-search" = gemini-3.1-flash-live-preview + googleSearch:true (newest model with Web grounding; needs a paid-tier VOICE key). ' +
 		'Restart takes ~2-3 seconds during which voice will be silent; the web client auto-reconnects. ' +
 		'HIGH-IMPACT: this restarts the whole voice session. Call it ONLY on one of those explicit switch ' +
 		'requests — NEVER because the conversation merely mentions search/searching, and never on filler ' +
 		'or garbled speech; when unsure, fire nothing.',
 	parameters: z.object({
-		preset: z.enum(['search', 'no-search']).describe('Which preset to switch to. "search" = 2.5+Web grounding. "no-search" = 3.1+no-Web.'),
+		preset: z.enum(['search', 'no-search', 'latest-search']).describe('Which preset to switch to. "search" = 2.5+Web grounding. "no-search" = 3.1+no-Web.'),
 	}),
 	execution: 'inline',
 	async execute(args) {
-		const { preset } = args as { preset: 'search' | 'no-search' };
+		const { preset } = args as { preset: 'search' | 'no-search' | 'latest-search' };
 		const cfg = PRESETS[preset];
 		if (!cfg) {
-			return { error: `Unknown preset "${preset}". Use "search" or "no-search".` };
+			return { error: `Unknown preset "${preset}". Use "search", "no-search" or "latest-search".` };
 		}
 
 		// The voice-agent config is per-user data — it lives in the workspace
@@ -153,7 +157,9 @@ export const switchVoiceConfigTool: ToolDefinition = {
 
 		const summary = preset === 'search'
 			? 'Switching to search mode: Gemini 2.5 with Web grounding. Restarting now…'
-			: 'Switching to no-search mode: Gemini 3.1, no Web grounding. Restarting now…';
+			: preset === 'latest-search'
+				? 'Switching to latest-search mode: Gemini 3.1 with Web grounding. Restarting now…'
+				: 'Switching to no-search mode: Gemini 3.1, no Web grounding. Restarting now…';
 		return {
 			ok: true,
 			preset,

--- a/tests/fixtures/voice-behavior-anchors.json
+++ b/tests/fixtures/voice-behavior-anchors.json
@@ -565,18 +565,18 @@
   },
   {
    "name": "switch_voice_config",
-   "description": "Switch voice-agent to a different model + googleSearch preset and restart. Use when the user explicitly asks to switch — e.g. \"switch to search mode\", \"switch to no-search mode\", \"use 2.5\", \"use 3.1\", \"turn search on\", \"turn search off\". Presets: \"search\" = gemini-2.5-flash-native-audio + googleSearch:true (best for Q&A with Web grounding); \"no-search\" = gemini-3.1-flash-live-preview + googleSearch:false (newer model, no Web grounding). Restart takes ~2-3 seconds during which voice will be silent; the web client auto-reconnects. HIGH-IMPACT: this restarts the whole voice session. Call it ONLY on one of those explicit switch requests — NEVER because the conversation merely mentions search/searching, and never on filler or garbled speech; when unsure, fire nothing.",
+   "description": "Switch voice-agent to a different model + googleSearch preset and restart. Use when the user explicitly asks to switch — e.g. \"switch to search mode\", \"switch to no-search mode\", \"use 2.5\", \"use 3.1\", \"turn search on\", \"turn search off\". Presets: \"search\" = gemini-2.5-flash-native-audio + googleSearch:true (best for Q&A with Web grounding); \"no-search\" = gemini-3.1-flash-live-preview + googleSearch:false (newer model, no Web grounding); \"latest-search\" = gemini-3.1-flash-live-preview + googleSearch:true (newest model with Web grounding; needs a paid-tier VOICE key). Restart takes ~2-3 seconds during which voice will be silent; the web client auto-reconnects. HIGH-IMPACT: this restarts the whole voice session. Call it ONLY on one of those explicit switch requests — NEVER because the conversation merely mentions search/searching, and never on filler or garbled speech; when unsure, fire nothing.",
    "execution": "inline",
    "params": {
-    "preset": "Which preset to switch to. \"search\" = 2.5+Web grounding. \"no-search\" = 3.1+no-Web."
+    "preset": "Which preset to switch to. \"search\" = 2.5+Web grounding. \"no-search\" = 3.1+no-Web. \"latest-search\" = 3.1+Web grounding."
    }
   },
   {
    "name": "switch_voice_config",
-   "description": "Switch voice-agent to a different model + googleSearch preset and restart. Use when the user explicitly asks to switch — e.g. \"switch to search mode\", \"switch to no-search mode\", \"use 2.5\", \"use 3.1\", \"turn search on\", \"turn search off\". Presets: \"search\" = gemini-2.5-flash-native-audio + googleSearch:true (best for Q&A with Web grounding); \"no-search\" = gemini-3.1-flash-live-preview + googleSearch:false (newer model, no Web grounding). Restart takes ~2-3 seconds during which voice will be silent; the web client auto-reconnects. HIGH-IMPACT: this restarts the whole voice session. Call it ONLY on one of those explicit switch requests — NEVER because the conversation merely mentions search/searching, and never on filler or garbled speech; when unsure, fire nothing.",
+   "description": "Switch voice-agent to a different model + googleSearch preset and restart. Use when the user explicitly asks to switch — e.g. \"switch to search mode\", \"switch to no-search mode\", \"use 2.5\", \"use 3.1\", \"turn search on\", \"turn search off\". Presets: \"search\" = gemini-2.5-flash-native-audio + googleSearch:true (best for Q&A with Web grounding); \"no-search\" = gemini-3.1-flash-live-preview + googleSearch:false (newer model, no Web grounding); \"latest-search\" = gemini-3.1-flash-live-preview + googleSearch:true (newest model with Web grounding; needs a paid-tier VOICE key). Restart takes ~2-3 seconds during which voice will be silent; the web client auto-reconnects. HIGH-IMPACT: this restarts the whole voice session. Call it ONLY on one of those explicit switch requests — NEVER because the conversation merely mentions search/searching, and never on filler or garbled speech; when unsure, fire nothing.",
    "execution": "inline",
    "params": {
-    "preset": "Which preset to switch to. \"search\" = 2.5+Web grounding. \"no-search\" = 3.1+no-Web."
+    "preset": "Which preset to switch to. \"search\" = 2.5+Web grounding. \"no-search\" = 3.1+no-Web. \"latest-search\" = 3.1+Web grounding."
    }
   },
   {

--- a/tests/voice-config-switch-latest-search.test.ts
+++ b/tests/voice-config-switch-latest-search.test.ts
@@ -1,0 +1,29 @@
+/**
+ * The "latest-search" preset pairs the newest live model with Web grounding and is
+ * reachable by name through the switch tool's schema.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PRESETS, switchVoiceConfigTool, nextSwitchConfig } from '../src/voice-config-switch.js';
+
+test('latest-search is the newest live model with googleSearch on', () => {
+	assert.deepEqual(PRESETS['latest-search'], { model: 'gemini-3.1-flash-live-preview', googleSearch: true });
+	assert.equal(PRESETS['no-search'].model, PRESETS['latest-search'].model, 'same model as no-search; the grounding knob differs');
+	assert.equal(PRESETS.search.googleSearch, true);
+});
+
+test('the tool schema accepts latest-search and still refuses an unknown name', () => {
+	const schema = (switchVoiceConfigTool as unknown as { parameters: { safeParse: (v: unknown) => { success: boolean } } }).parameters;
+	assert.equal(schema.safeParse({ preset: 'latest-search' }).success, true);
+	assert.equal(schema.safeParse({ preset: 'latest' }).success, false);
+});
+
+test('switching to latest-search overlays only model + googleSearch', () => {
+	const existing = { model: 'gemini-2.5-flash-native-audio-preview-12-2025', googleSearch: false, owner_mode: true, shadowStt: true };
+	const next = nextSwitchConfig(existing as never, PRESETS['latest-search']) as Record<string, unknown>;
+	assert.equal(next.model, 'gemini-3.1-flash-live-preview');
+	assert.equal(next.googleSearch, true);
+	assert.equal(next.owner_mode, true, 'unrelated knobs survive');
+	assert.equal(next.shadowStt, true);
+});


### PR DESCRIPTION
## What
The `switch_voice_config` tool gains a third preset, **`latest-search`** = `gemini-3.1-flash-live-preview` + `googleSearch: true`. The config file already allowed that combination; the tool could not name it, so a spoken "switch to latest-search" had no target. Owner ask 2026-09-06 (DM): "make a voice config preset that uses latest model plus google search and set that as active".

`PRESETS` is now exported so the mapping is pinned by a test instead of a doc comment. The 3.1 + search caveat is unchanged and stays where `voice-config.ts` documents it: a free-tier VOICE key closes with 1011, a paid-tier key holds.

## Evidence
Switch suites at HEAD (`npx tsx --test`): `tests 12 · pass 12 · fail 0` (3 new in `tests/voice-config-switch-latest-search.test.ts`: the mapping, the schema accepting `latest-search` and rejecting `latest`, the overlay preserving unrelated knobs).

`tsc --noEmit`: green in CI (`typecheck` and `typecheck:skills` both pass on the first run). A local run in the worktree had shown 8 errors in untouched files; CI proves those were a local environment artifact, not the tree.
Second push regenerates `tests/fixtures/voice-behavior-anchors.json` (the tool-table anchor moved with the schema text; `ANCHOR_UPDATE=1`, deliberately) — the first CI run's one red was that anchor.

`scripts/review-checks.sh --diff`: hardcoded-paths + root-artifacts clean (no Markdown in scope for prose-cap).

Not a live path (a tool-table entry + a data overlay); no service restart is exercised here. The active config on the owner's host was set by hand to the same values; this PR gives the tool a name for it.

Stand: Echo Act IV Pro
