### PR TITLE
fix(warn-already-triaged): core memory is a parking location too

### DIFF
--- a/skills/proactive-loop/scripts/warn-already-triaged.py
+++ b/skills/proactive-loop/scripts/warn-already-triaged.py
@@ -22,11 +22,40 @@ import re
 import sys
 
 def parking_files():
-    """The per-host parking files, resolved by the repo's own `personal_path`."""
+    """Everywhere a triage is parked, resolved by the repo's own helpers.
+
+    Core memory is a parking location, not just a preference store: a chronic
+    warn whose decision is settled is written there rather than to a file that
+    waits on a human. Omitting it reported those as untriaged, which is the one
+    verdict that invites re-deriving a decision already made.
+    """
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "src"))
-    from util_paths import personal_path
-    return [p for p in (personal_path("pending-questions.md"),
-                        personal_path("current-track.md")) if p.exists()]
+    from util_paths import memory_dir, personal_path
+    files = [p for p in (personal_path("pending-questions.md"),
+                         personal_path("current-track.md")) if p.exists()]
+    mem = memory_dir()
+    if mem.is_dir():
+        files.extend(sorted(p for p in mem.glob("*.md") if p.is_file()))
+    return files
+
+
+def display(path):
+    """`memory/<name>` for a memory file, bare name otherwise.
+
+    A pending question waits on a human; a memory records a decision already
+    taken. The reader must be able to tell which one a hit is.
+    """
+    return f"memory/{path.name}" if path.parent.name == "memory" else path.name
+
+
+_LINES = {}
+
+def lines_of(path):
+    """Read once per run: the corpus is now dozens of files x tokens x warns."""
+    key = str(path)
+    if key not in _LINES:
+        _LINES[key] = path.read_text(errors="ignore").splitlines()
+    return _LINES[key]
 
 # entities worth searching for: paths, dotted filenames, backticked identifiers
 # Component count is unbounded; the 3..40 length check below is the only size
@@ -64,11 +93,11 @@ def report(name, text, files):
     hits, seen_at = [], set()
     for tok in toks:
         for f in files:
-            for i, line in enumerate(f.read_text(errors="ignore").splitlines(), 1):
+            for i, line in enumerate(lines_of(f), 1):
                 if tok.lower() in line.lower() and line.lstrip().startswith("#"):
-                    if (f.name, i) not in seen_at:
-                        seen_at.add((f.name, i))
-                        hits.append((tok, f.name, i, line.strip()[:92]))
+                    if (display(f), i) not in seen_at:
+                        seen_at.add((display(f), i))
+                        hits.append((tok, display(f), i, line.strip()[:92]))
                     break
     if hits:
         # ALL candidates, not just the first. A probe warns for SEVERAL distinct
@@ -80,9 +109,9 @@ def report(name, text, files):
     body = []
     for tok in toks:
         for f in files:
-            for i, line in enumerate(f.read_text(errors="ignore").splitlines(), 1):
+            for i, line in enumerate(lines_of(f), 1):
                 if tok.lower() in line.lower():
-                    body.append((tok, f.name, i)); break
+                    body.append((tok, display(f), i)); break
     if body:
         # "No heading" is NOT "nothing written" — material is often parked in a
         # BODY under a neighbouring heading.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -57,7 +57,7 @@ from git_binary import git_argv  # noqa: E402
 from git_binary import GitUnavailable  # noqa: E402
 from git_binary import developer_tools_installed  # noqa: E402
 from channel_token import token_from_vault  # noqa: E402
-from util_paths import _host_label, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, memory_dir, shared_personal_path  # noqa: E402
+from util_paths import _host_label, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, shared_personal_path  # noqa: E402
 import slack_access  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 from workspace_layout import inspect_layout  # noqa: E402
@@ -145,7 +145,7 @@ def _default_memory_dir() -> str:
 
 # SUTANDO_MEMORY_DIR is read via os.environ, not config_get: this check must
 # report on the same directory the runtime reads, so it opts out of #1724.
-MEMORY_DIR = memory_dir()
+MEMORY_DIR = Path(os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir()))
 
 # How much of MEMORY.md a session actually loads. These are the RUNTIME's
 # documented numbers, not this repo's guess:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -57,7 +57,7 @@ from git_binary import git_argv  # noqa: E402
 from git_binary import GitUnavailable  # noqa: E402
 from git_binary import developer_tools_installed  # noqa: E402
 from channel_token import token_from_vault  # noqa: E402
-from util_paths import _host_label, channel_access_path, claude_home_path, claude_project_slug, legacy_dotted_workspace, shared_personal_path  # noqa: E402
+from util_paths import _host_label, channel_access_path, claude_home_path, default_memory_dir, legacy_dotted_workspace, memory_dir, shared_personal_path  # noqa: E402
 import slack_access  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 from workspace_layout import inspect_layout  # noqa: E402
@@ -141,13 +141,11 @@ def _default_memory_dir() -> str:
     claude_home_path() honors CLAUDE_CONFIG_DIR, falling back to ~/.claude
     only when it is unset (preserving the old path for ad-hoc launches).
     """
-    repo = Path(__file__).parent.parent.resolve()
-    slug = claude_project_slug(repo)
-    return str(Path(claude_home_path()) / "projects" / slug / "memory")
+    return str(default_memory_dir())
 
 # SUTANDO_MEMORY_DIR is read via os.environ, not config_get: this check must
 # report on the same directory the runtime reads, so it opts out of #1724.
-MEMORY_DIR = Path(os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir()))
+MEMORY_DIR = memory_dir()
 
 # How much of MEMORY.md a session actually loads. These are the RUNTIME's
 # documented numbers, not this repo's guess:

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -372,12 +372,12 @@ def default_memory_dir() -> Path:
 def memory_dir() -> Path:
     """The core-memory dir a reader should actually read.
 
-    Reads `SUTANDO_MEMORY_DIR` from `os.environ` directly, NOT via
-    `_memory_dir_env()`: this deliberately does not honor the legacy
-    `SUTANDO_PRIVATE_DIR` alias, preserving the pre-existing behavior of the
-    readers that call it. Unifying the two is a separate change.
+    Resolves through `_memory_dir_env()`, exactly as `personal_path()` and
+    `shared_personal_path()` do, so a host on the legacy `SUTANDO_PRIVATE_DIR`
+    alias reads its real corpus instead of an empty default path.
     """
-    return Path(os.environ.get("SUTANDO_MEMORY_DIR", str(default_memory_dir())))
+    root = _memory_dir_env()
+    return Path(os.path.expanduser(root)) if root else default_memory_dir()
 
 
 def channel_access_path(source: str) -> Path:

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -359,6 +359,27 @@ def claude_project_slug(path: str | Path) -> str:
     return re.sub(r"[^A-Za-z0-9]", "-", str(path))
 
 
+def default_memory_dir() -> Path:
+    """Claude Code's memory dir for THIS checkout, ignoring any override.
+
+    Composed here so `SUTANDO_MEMORY_DIR`'s divergence check and every reader
+    of the corpus agree on what the un-overridden location is.
+    """
+    repo = Path(__file__).parent.parent.resolve()
+    return claude_home_path("projects", claude_project_slug(repo), "memory")
+
+
+def memory_dir() -> Path:
+    """The core-memory dir a reader should actually read.
+
+    Reads `SUTANDO_MEMORY_DIR` from `os.environ` directly, NOT via
+    `_memory_dir_env()`: this deliberately does not honor the legacy
+    `SUTANDO_PRIVATE_DIR` alias, preserving the pre-existing behavior of the
+    readers that call it. Unifying the two is a separate change.
+    """
+    return Path(os.environ.get("SUTANDO_MEMORY_DIR", str(default_memory_dir())))
+
+
 def channel_access_path(source: str) -> Path:
     """Resolve `channels/<source>/access.json` inside the configured Claude home.
 

--- a/tests/health-check-memory-dir-override.test.py
+++ b/tests/health-check-memory-dir-override.test.py
@@ -22,6 +22,8 @@ import unittest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+from util_paths import claude_project_slug  # noqa: E402
 
 
 def _load_health_check():
@@ -52,10 +54,12 @@ class TestMemoryDirHonorsOverride(unittest.TestCase):
         """_default_memory_dir() must derive its slug through the shared
         claude_project_slug() helper, not a hand-rolled "/" -> "-" regex —
         the hand-rolled version silently resolved to a nonexistent dir on
-        any checkout path containing a space or dot."""
+        any checkout path containing a space or dot. The composition now
+        lives in util_paths.default_memory_dir(); this pins the result, so it
+        holds wherever the composition sits."""
         hc = _load_health_check()
         repo = Path(hc.__file__).parent.parent.resolve()
-        expected_slug = hc.claude_project_slug(repo)
+        expected_slug = claude_project_slug(repo)
         self.assertEqual(
             Path(hc._default_memory_dir()).parent.name, expected_slug)
 

--- a/tests/proactive-loop-warn-already-triaged.test.py
+++ b/tests/proactive-loop-warn-already-triaged.test.py
@@ -9,10 +9,12 @@ on 2026-09-01, with the answer already filed since 2026-08-28.
 
 import importlib.util
 import io
+import os
 import contextlib
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "proactive-loop" / "scripts"
 _s = importlib.util.spec_from_file_location("wat", str(SCRIPTS / "warn-already-triaged.py"))
@@ -224,6 +226,71 @@ class ParkingFiles(unittest.TestCase):
         files = wat.parking_files()
         self.assertIsInstance(files, list)
         self.assertTrue(all(p.exists() for p in files))
+
+
+class MemoryIsPartOfTheCorpus(unittest.TestCase):
+    """A settled decision is written to core memory, not to a file that waits on
+    a human. Omitting memory reported those warns as untriaged — the one verdict
+    that invites re-deriving a decision already taken."""
+
+    def _corpus(self, **files):
+        d = Path(tempfile.mkdtemp())
+        mem = d / "memory"
+        mem.mkdir()
+        for n, t in files.items():
+            (mem / n).write_text(t)
+        return d, mem
+
+    def test_memory_files_join_the_parking_corpus(self):
+        d, mem = self._corpus(**{"a-decision.md": "## zzz-probe is expected\n"})
+        with mock.patch.dict(os.environ, {"SUTANDO_MEMORY_DIR": str(mem)}):
+            names = [p.name for p in wat.parking_files()]
+        self.assertIn("a-decision.md", names)
+
+    def test_a_warn_parked_only_in_memory_is_not_reported_untriaged(self):
+        d, mem = self._corpus(**{"a-decision.md": "## zzz-probe is expected here\n"})
+        files = sorted(mem.glob("*.md"))
+        verdict, out = _report("zzz-probe", "condition persists", files)
+        self.assertEqual(verdict, "parked")
+        self.assertNotIn("NONE FOUND", out)
+
+    def test_a_memory_hit_is_labelled_so_it_is_not_read_as_a_pending_question(self):
+        # A pending question waits on a human; a memory records a decision
+        # already taken. Same word, opposite next action.
+        d, mem = self._corpus(**{"a-decision.md": "## zzz-probe is expected here\n"})
+        _, out = _report("zzz-probe", "condition persists", sorted(mem.glob("*.md")))
+        self.assertIn("memory/a-decision.md", out)
+
+    def test_a_non_memory_file_is_not_labelled_as_memory(self):
+        (f,) = _files("## zzz-probe is expected here\n")
+        _, out = _report("zzz-probe", "condition persists", [f])
+        self.assertNotIn("memory/", out)
+
+    def test_absent_memory_dir_degrades_to_the_per_host_files(self):
+        # Must not raise on a checkout that has no memory dir.
+        with mock.patch.dict(os.environ, {"SUTANDO_MEMORY_DIR": "/nonexistent-corpus-xyz"}):
+            files = wat.parking_files()
+        self.assertTrue(all(p.exists() for p in files))
+
+    def test_genuinely_absent_material_still_reports_untriaged_with_memory_present(self):
+        # Green-on-purpose: widening the corpus must not make everything parked.
+        d, mem = self._corpus(**{"a-decision.md": "## something entirely else\n"})
+        verdict, out = _report("zzz-probe", "condition persists", sorted(mem.glob("*.md")))
+        self.assertEqual(verdict, "untriaged")
+        self.assertIn("NONE FOUND", out)
+
+    def test_each_file_is_read_once_however_many_tokens_are_searched(self):
+        (f,) = _files("## nothing matching here\n")
+        wat._LINES.clear()
+        reads = []
+        real = Path.read_text
+        def counting(self_, *a, **k):
+            reads.append(str(self_))
+            return real(self_, *a, **k)
+        with mock.patch.object(Path, "read_text", counting):
+            _report("zzz-probe", "a `token.py` and another-token and a third_token", [f])
+        self.assertEqual(reads.count(str(f)), 1, f"read {reads.count(str(f))}x")
+
 
 
 if __name__ == "__main__":

--- a/tests/util-paths-memory-dir.test.py
+++ b/tests/util-paths-memory-dir.test.py
@@ -28,6 +28,7 @@ from util_paths import (  # noqa: E402
     _private_machine_dir,
     shared_personal_path,
 )
+import util_paths  # noqa: E402
 
 
 def clear_env():
@@ -161,6 +162,63 @@ class SharedPersonalPathTests(unittest.TestCase):
         with redirect_stderr(io.StringIO()):
             p = shared_personal_path("MEMORY.md", workspace=Path("/tmp/ws"))
         self.assertEqual(p, Path("/tmp/legacy-mem/MEMORY.md"))
+
+
+
+class MemoryDirResolver(unittest.TestCase):
+    """`memory_dir()` / `default_memory_dir()` — the one composition every
+    reader of the core-memory corpus shares."""
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in
+                       ("SUTANDO_MEMORY_DIR", "SUTANDO_PRIVATE_DIR")}
+        for k in self._saved:
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_default_is_claude_home_projects_slug_memory(self):
+        d = util_paths.default_memory_dir()
+        self.assertEqual(d.name, "memory")
+        self.assertEqual(d.parent.parent.name, "projects")
+        # the slug is derived, never a re-implemented regex
+        repo = Path(util_paths.__file__).parent.parent.resolve()
+        self.assertEqual(d.parent.name, util_paths.claude_project_slug(repo))
+
+    def test_override_wins_over_the_default(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/some-corpus"
+        self.assertEqual(util_paths.memory_dir(), Path("/tmp/some-corpus"))
+
+    def test_unset_falls_back_to_default(self):
+        self.assertEqual(util_paths.memory_dir(), util_paths.default_memory_dir())
+
+    def test_legacy_alias_is_deliberately_not_honored(self):
+        # Preserves the pre-existing reader behavior; `_memory_dir_env()` is the
+        # one that honors the alias. If this ever flips, it must flip on purpose.
+        os.environ["SUTANDO_PRIVATE_DIR"] = "/tmp/legacy-corpus"
+        self.assertEqual(util_paths.memory_dir(), util_paths.default_memory_dir())
+
+
+class HealthCheckDelegates(unittest.TestCase):
+    """health-check must not re-compose the path; a second copy is what drifts."""
+
+    def test_default_memory_dir_delegates(self):
+        src = (ROOT / "src" / "health-check.py").read_text()
+        body = src.split("def _default_memory_dir")[1].split("\ndef ")[0]
+        self.assertIn("default_memory_dir()", body)
+        for recomposed in ('"projects"', "claude_project_slug(repo)"):
+            self.assertNotIn(recomposed, body,
+                             f"health-check re-composes the memory path ({recomposed})")
+
+    def test_memory_dir_constant_delegates(self):
+        src = (ROOT / "src" / "health-check.py").read_text()
+        self.assertIn("MEMORY_DIR = memory_dir()", src)
+        self.assertNotIn('os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir())', src)
 
 
 if __name__ == "__main__":

--- a/tests/util-paths-memory-dir.test.py
+++ b/tests/util-paths-memory-dir.test.py
@@ -197,11 +197,17 @@ class MemoryDirResolver(unittest.TestCase):
     def test_unset_falls_back_to_default(self):
         self.assertEqual(util_paths.memory_dir(), util_paths.default_memory_dir())
 
-    def test_legacy_alias_is_deliberately_not_honored(self):
-        # Preserves the pre-existing reader behavior; `_memory_dir_env()` is the
-        # one that honors the alias. If this ever flips, it must flip on purpose.
+    def test_legacy_alias_is_honored_like_its_siblings(self):
+        # A legacy-alias host must not silently read an empty default path —
+        # that reproduces the very NONE-FOUND bug the corpus reader fixes.
         os.environ["SUTANDO_PRIVATE_DIR"] = "/tmp/legacy-corpus"
-        self.assertEqual(util_paths.memory_dir(), util_paths.default_memory_dir())
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(util_paths.memory_dir(), Path("/tmp/legacy-corpus"))
+
+    def test_canonical_var_still_wins_over_the_legacy_alias(self):
+        os.environ["SUTANDO_PRIVATE_DIR"] = "/tmp/legacy-corpus"
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/canonical-corpus"
+        self.assertEqual(util_paths.memory_dir(), Path("/tmp/canonical-corpus"))
 
 
 class HealthCheckDelegates(unittest.TestCase):
@@ -215,10 +221,11 @@ class HealthCheckDelegates(unittest.TestCase):
             self.assertNotIn(recomposed, body,
                              f"health-check re-composes the memory path ({recomposed})")
 
-    def test_memory_dir_constant_delegates(self):
+    def test_health_check_keeps_its_own_env_policy(self):
+        # health-check reads os.environ directly and does NOT honor the legacy
+        # alias. That divergence predates this change and is left untouched.
         src = (ROOT / "src" / "health-check.py").read_text()
-        self.assertIn("MEMORY_DIR = memory_dir()", src)
-        self.assertNotIn('os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir())', src)
+        self.assertIn('MEMORY_DIR = Path(os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir()))', src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

`warn-already-triaged.py` answers one question: is this health-check warn ALREADY triaged? Health-check warns are chronic by construction — they re-fire every pass until an owner decision lands — so the ones that survive are precisely the ones already investigated. `NONE FOUND` is the verdict that sends an agent to re-derive a decision that was already taken.

It searched two files: `pending-questions.md` and `current-track.md`.

But a warn whose decision is **settled** is not written to a file that waits on a human. It is written to core memory. Those warns therefore came back `NONE FOUND` — indistinguishable from genuinely untriaged.

## Evidence, at the parent commit

Live host, 9 warns, `python3 src/health-check.py | python3 skills/proactive-loop/scripts/warn-already-triaged.py`:

```
5 with candidate parkings, 4 with none: screen-capture, live-checkout-branch, engine-revision-drift, daily-cron-punctuality
```

All four of those have their triage in core memory. Probe name alone, on that host's memory corpus:

```
  screen-capture         -> 3 file(s)
  live-checkout-branch   -> 2 file(s)
  engine-revision-drift  -> 5 file(s)
  daily-cron-punctuality -> 6 file(s)
```

So 4 of 9 were reported untriaged while the decision was on disk the whole time. (Corpus contents are personal, so the reproducible before/after below uses a fixture instead.)

## Before / after, hermetic fixture

Fixture memory dir holding one file, `zz-fixture-probe-parked.md`, whose first line is `## zz-fixture-probe is parked`. Same input both runs.

**Parent commit `958ca777`:**

```
searching 1 parking file(s) for 1 warn(s)

  NONE FOUND zz-fixture-probe          — no heading, no body mention; genuinely untriaged, OR every token missed (try one from the warn text)

0 with candidate parkings, 1 with none: zz-fixture-probe
```

**This branch:**

```
searching 4 parking file(s) for 1 warn(s)

  CANDIDATES zz-fixture-probe          (1) — verify the CONDITION matches, not just the probe
             via 'zz-fixture-probe' -> memory/zz-fixture-probe-parked.md:1  ## zz-fixture-probe is parked

1 with candidate parkings, 0 with none
```

## The change

1. **`parking_files()` includes the core-memory corpus.**
2. **The memory-dir composition gets one owner.** `_default_memory_dir()` was private to `health-check.py`. Rather than adding a second copy in the script, it moves to `util_paths` as `default_memory_dir()` / `memory_dir()`, and health-check delegates — so the corpus reader and health-check's own divergence check cannot drift apart.
3. **Memory hits are labelled `memory/<name>`.** A pending question waits on a human; a memory records a decision already taken. Same word "parked", opposite next action, so the reader must be able to tell which one a hit is.
4. **Reads are cached.** The corpus went from 2 files to dozens, scanned per token per warn.

## The legacy memory-dir alias — CHANGED after review

**This section previously said the opposite.** It claimed `memory_dir()` deliberately did not honor
the legacy `SUTANDO_PRIVATE_DIR` alias, preserving health-check's behavior. @yixuan-ag2 pointed out
that this reproduces *this PR's own bug* for a different cohort: a host still on the legacy alias
resolves the default path, finds no corpus, and gets `NONE FOUND` — silently.

Fixed in `f66b729d`. `memory_dir()` now resolves through `_memory_dir_env()`, exactly as
`personal_path()` and `shared_personal_path()` already do. Consistency with its siblings in the same
module is the defensible position; mirroring health-check was not, because health-check opts out of
that lookup deliberately and for a probe-specific reason.

**health-check keeps its own env policy and is unchanged.** `MEMORY_DIR` is restored to its original
expression byte-for-byte, so this PR changes no path health-check resolves. It still delegates the
*composition* to `default_memory_dir()` — that is the part that was duplicated.

Legacy-alias host, same input:

```
before   NONE FOUND zz-legacy-probe    0 with candidate parkings, 1 with none
after    via 'zz-legacy-probe' -> memory/parked.md:1
         1 with candidate parkings, 0 with none
```

A canonical-var host is unaffected (control run, unchanged).

## Tests

`tests/util-paths-memory-dir.test.py` 13 -> 20, `tests/proactive-loop-warn-already-triaged.test.py` 22 -> 29.

Mutations, each run on a restored copy, each red on a NAMED arm:

| mutation | result |
|---|---|
| `parking_files()` drops the memory extension | `FAIL: test_memory_files_join_the_parking_corpus` |
| `display()` always returns the bare name | `FAIL: test_a_memory_hit_is_labelled_so_it_is_not_read_as_a_pending_question` |
| caching removed (read per token) | `FAIL: test_each_file_is_read_once_however_many_tokens_are_searched` |
| health-check re-composes the path itself | `FAIL: test_default_memory_dir_delegates` |
| `memory_dir()` stops honoring the legacy alias | `FAIL: test_legacy_alias_is_honored_like_its_siblings` |
| `memory_dir()` consults the legacy alias FIRST | `FAIL: test_canonical_var_still_wins_over_the_legacy_alias` |
| health-check adopts the reader's env policy | `FAIL: test_health_check_keeps_its_own_env_policy` |
| `report()` always returns `parked` | `FAILED (failures=6)` incl. `test_genuinely_absent_material_still_reports_untriaged_with_memory_present` |

The last is the green-on-purpose control: widening the corpus must not turn every warn into a hit, so a mutant that says "parked" for everything has to fail.

Full affected suite at HEAD `f66b729d`:

```
  util-paths-memory-dir.test.py                        OK   (20)
  util-paths-project-slug.test.py                      OK
  util-paths-hosts-resolution.test.py                  OK
  util-paths-write-private-text.test.py                OK
  util-paths-ccd-banner.test.py                        OK   (13/13)
  health-check-memory-dir-override.test.py             OK
  health-check-memory-dir-siblings.test.py             OK
  proactive-loop-warn-already-triaged.test.py          OK   (29)
  proactive-loop-check-dedup-targets.test.py           OK

review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## One test edited, and why

`tests/health-check-memory-dir-override.test.py::test_default_memory_dir_uses_shared_slug_helper` reached the slug helper through `hc.claude_project_slug` — health-check's own import list, which this change no longer needs. The test now imports `claude_project_slug` from `util_paths` directly. **The assertion is unchanged**: `_default_memory_dir()`'s parent dir must equal the shared helper's slug. It now holds wherever the composition lives, instead of depending on which names health-check happens to import.

## Relationship to #3958

#3958 (approved, awaiting merge) touches the same file. Different concern and disjoint regions — #3958 changes the `ENT` token regex; this changes `parking_files()` and the scan loops. Not stacked: both branch from `origin/main`. Whichever lands first, the other needs no rebase, but I will re-run the full suite on this branch after #3958 merges.

