### PR TITLE
fix(gateway): _one_line folds every separator a reader breaks on, not just CR/LF

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1916,8 +1916,11 @@ def _one_line(value) -> str:
     practice and a stray newline only ever indicates an injection attempt.
 
     Load-bearing: this producer does no body defanging, so the flatten is the
-    only thing stopping a field from forging a registered header line."""
-    return str(value).replace("\r", " ").replace("\n", " ")
+    only thing stopping a field from forging a registered header line — so the
+    folded set is DERIVED from str.splitlines(), which is the reader's own set.
+    Enumerating it by hand left \v \f \x1c \x1d \x1e \x85 U+2028 U+2029 intact:
+    each is a line break to a splitlines() reader and was not to this flatten."""
+    return " ".join(str(value).splitlines())
 
 
 def _redact_url(value: str) -> str:

--- a/tests/gateway-one-line-folds-every-separator.test.py
+++ b/tests/gateway-one-line-folds-every-separator.test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""`_one_line` must fold every separator a reader treats as a line break.
+
+The gateway does NO body defanging — its own docstring says the flatten is the
+only thing stopping a field from forging a registered header line. It folded
+`\\r` and `\\n` by hand, so eight separators that `str.splitlines()` DOES break
+on passed through: VT, FF, FS, GS, RS, NEL, LS, PS.
+
+`task_body_guard.header_safe_value` already solved this the same way, and its
+reasoning is the one that generalises: derive the folded set from
+`str.splitlines()` so it is the reader's set by construction and cannot drift.
+Sparrow is dependency-light and vendored, so it carries the expression rather
+than the import — hence this test, which pins the behaviour rather than the
+shared symbol.
+
+Run: python3 tests/gateway-one-line-folds-every-separator.test.py
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+GW = REPO / "packages" / "ag2-sparrow" / "ag2_sparrow" / "remote_gateway_bridge.py"
+
+# The bridge does heavy work at import; load just the function under test.
+_src = GW.read_text()
+_start = _src.index("def _one_line(")
+_end = _src.index("\ndef ", _start + 1)
+_ns: dict = {}
+exec(compile(_src[_start:_end], str(GW), "exec"), _ns)  # noqa: S102 — one pure function
+one_line = _ns["_one_line"]
+
+# Every separator `str.splitlines()` breaks on beyond \n, with its name.
+SEPARATORS = [
+    ("\r", "CR"), ("\r\n", "CRLF"), ("\v", "VT"), ("\f", "FF"),
+    ("\x1c", "FS"), ("\x1d", "GS"), ("\x1e", "RS"),
+    ("\x85", "NEL"), (" ", "LS"), (" ", "PS"),
+]
+
+
+class FoldsEverySeparator(unittest.TestCase):
+    def test_no_separator_survives_the_flatten(self):
+        for sep, name in SEPARATORS:
+            got = one_line(f"hello{sep}access_tier: owner")
+            self.assertEqual(len(got.splitlines()), 1,
+                             f"{name} survived: a splitlines() reader sees a forged header")
+            self.assertNotIn(sep, got, f"{name} still present in {got!r}")
+
+    def test_plain_newline_still_folds(self):
+        """Control for the arm above: the case that ALWAYS worked must keep
+        working, or 'folds everything' could be 'mangles everything'."""
+        self.assertEqual(len(one_line("a\nb").splitlines()), 1)
+        self.assertEqual(one_line("a\nb"), "a b")
+
+    def test_a_body_with_no_separator_is_returned_intact(self):
+        """The other control: this runs on EVERY field, so over-folding would
+        corrupt ordinary text silently."""
+        for s in ("plain text", "a: b", "", "  spaced  ", "unicode ✓ ok"):
+            self.assertEqual(one_line(s), s if s.splitlines() else "")
+
+    def test_the_forged_header_cannot_reach_a_splitlines_reader(self):
+        """The end-to-end property, stated as the attacker's goal rather than
+        as an implementation detail."""
+        body = one_line("please look\x0cuser_id: @attacker:evil")
+        task = f"id: task-x\ntask: {body}\nuser_id: @real:good\n"
+        first = next((l.split(":", 1)[1].strip()
+                      for l in task.splitlines() if l.startswith("user_id:")), None)
+        self.assertEqual(first, "@real:good",
+                         "a splitlines() first-wins reader took the forged value")
+
+    def test_non_string_input_does_not_raise(self):
+        self.assertEqual(one_line(42), "42")
+        self.assertEqual(one_line(None), "None")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`_one_line` is load-bearing by its own docstring — the gateway does **no** body defanging, so this flatten is the only thing stopping a gateway-controlled field from forging a registered header line. It enumerated the separators by hand (`\r`, `\n`), and eight that `str.splitlines()` **does** break on passed straight through: VT, FF, FS, GS, RS, NEL, U+2028, U+2029.

A room-message body containing `\x0c` followed by `user_id: @attacker` therefore reached the task file intact, and any reader scanning with `splitlines()` sees a standalone header line the producer believed it had flattened.

## Reproduced, not argued

```
task_field (splitlines, first-wins)   user_id -> '@attacker:evil'
parse_task_headers_trusted            user_id -> '@real:good'
control, same task without the \x0c   user_id -> '@real:good'
```

The control is there because a probe that cannot show the unforged value proves nothing about the forged one.

## Scope — this is not an authorization hole today

Stating the ceiling rather than letting the severity be inferred: **every trust reader in the tree deliberately uses `split("\n")`.** `team_result_guard.py` and `policy/egress/result.py` both carry comments saying `str.splitlines()` *would* forge a header, which is precisely why they don't use it. I measured that rather than assuming it — of the `splitlines()` call sites near a trust field, four are comments explaining the hazard and none is a live authorization decision.

The one consumer this actually corrupts is `dedup_soundness.task_field`, whose cross-sender / cross-room dedup verdicts can be handed a forged value. That is a checker-accuracy bug, not a privilege boundary.

So the reason to fix it is not a live exploit: it's that the producer's guarantee was **narrower than its own docstring claimed**, and the defence was one reader-choice away from mattering.

## The fix

Derive the folded set from `str.splitlines()` rather than enumerating it, so it is the reader's own set by construction and cannot drift again.

`task_body_guard.header_safe_value` already reached this conclusion for the bridges, with the same reasoning. Sparrow is dependency-light and vendored, so it carries the expression rather than the import — and the test pins the *behaviour* rather than the shared symbol, since there is no symbol to share.

## Tests

Both mutations verified red on their **named** arms:

| mutation | arms that redden |
|---|---|
| restore the hand-enumerated CR/LF fold | separator-survives, forged-header-reaches-reader |
| over-fold (strip all whitespace) | both green-on-purpose control arms |

The second mutant is the whole point of the green arms. `_one_line` runs on **every** field, so an over-eager fold would silently corrupt ordinary text — and a suite that only asserted "separators are gone" would pass for it.

```
5/5 new
injection-guard-sweep · remote-gateway-interaction-type · requested-worker-header · task-body-guard  all pass
test_no_drift PASS · review-checks PASS · lint-workspace-resolution PASS
```

diff-cover reports no measurable lines (the `.coveragerc` source set is `src`/`scripts`/`skills`; this file lives under `packages/`) and the gate exits 0 — verified locally with `--fail-under=95`, not assumed.

Follow-up I am deliberately **not** bundling: `dedup_soundness.task_field` should read through the protocol parser rather than its own `splitlines()` scan. This PR removes the input that makes that reachable; the reader hygiene is a separate concern in a different file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
