### PR TITLE
fix(collab-intel): derive the caveat surface from the entry — authority_caveat reaches nobody

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -139,10 +139,12 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
             continue
         stand, room = entry.get("stand"), entry.get("room")
         why = stated_reason(entry)
-        # A caveat nobody prints is a note, not a step. Shared-login entries
-        # look like one actor from GitHub; surface it here, before the send.
-        if entry.get("identity_caveat"):
-            print(f"IDENTITY CAVEAT '{name}': {entry['identity_caveat']}", file=sys.stderr)
+        # A caveat nobody prints is a note, not a step. Derived from the entry:
+        # a named field list misses the next caveat silently.
+        for field in sorted(k for k in entry if k.endswith("_caveat")):
+            if entry.get(field):
+                label = field[: -len("_caveat")].upper().replace("_", " ")
+                print(f"{label} CAVEAT '{name}': {entry[field]}", file=sys.stderr)
         if not stand or not room:
             # a human id alone cannot be a target: person-mentions trigger no Stand
             print(f"UNUSABLE entry '{name}': needs both 'stand' and 'room' "

--- a/tests/notify-reviewers-human-shapes.test.py
+++ b/tests/notify-reviewers-human-shapes.test.py
@@ -108,6 +108,58 @@ class IdentityCaveatSurfaces(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual({t["name"] for t in targets}, {"a", "b"})
 
+    def test_authority_caveat_reaches_the_operator(self):
+        """The field that reached nobody (#3965).
+
+        It records a Stand's self-stated refusal to cast a formal vote on a
+        collaborator-routed ask — a routing constraint, and the one thing that
+        stops an unauthorized request going out.
+        """
+        roster = {"a": {"stand": "@a:ag2.space", "room": self.ROOM,
+                        "authority_caveat": "DECLINES a collaborator-routed vote"}}
+        _, rc, err = self._resolve(roster)
+        self.assertIn("AUTHORITY CAVEAT 'a'", err)
+        self.assertIn("DECLINES a collaborator-routed vote", err)
+        self.assertEqual(rc, 0)
+
+    def test_a_caveat_field_nobody_has_named_yet_still_prints(self):
+        """THE discriminating arm: this is what makes it derived rather than
+        enumerated. A hardcoded ('identity','authority') pair passes every
+        other arm here and fails only this one — which is precisely how
+        `authority_caveat` came to exist unread beside a field that was read.
+        """
+        roster = {"a": {"stand": "@a:ag2.space", "room": self.ROOM,
+                        "jurisdiction_caveat": "invented for this test"}}
+        _, rc, err = self._resolve(roster)
+        self.assertIn("JURISDICTION CAVEAT 'a'", err)
+        self.assertEqual(rc, 0)
+
+    def test_every_caveat_on_one_entry_prints(self):
+        roster = {"a": {"stand": "@a:ag2.space", "room": self.ROOM,
+                        "identity_caveat": "shared login",
+                        "authority_caveat": "declines the vote",
+                        "room_caveat": "wrong room"}}
+        _, _, err = self._resolve(roster)
+        for label in ("IDENTITY CAVEAT", "AUTHORITY CAVEAT", "ROOM CAVEAT"):
+            self.assertIn(label, err)
+
+    def test_a_non_caveat_field_is_not_printed(self):
+        """Control for the loop: matching too widely would dump the whole
+        entry to stderr, and 'everything is surfaced' is indistinguishable
+        from 'nothing is' once the operator stops reading it.
+        """
+        roster = {"a": {"stand": "@a:ag2.space", "room": self.ROOM,
+                        "note": "ordinary prose", "github": "someone"}}
+        _, _, err = self._resolve(roster)
+        self.assertNotIn("CAVEAT", err)
+
+    def test_an_empty_caveat_is_not_printed(self):
+        # An empty string is absence, not a caveat worth a line.
+        roster = {"a": {"stand": "@a:ag2.space", "room": self.ROOM,
+                        "authority_caveat": ""}}
+        _, _, err = self._resolve(roster)
+        self.assertNotIn("CAVEAT", err)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`resolve()` printed `identity_caveat` and no other caveat field. This derives the set from the entry instead.

## The bug

Measured across `skills/collaboration-intelligence/scripts/*.py` and the workspace tools (string-presence, so a zero is decisive even though a non-zero is not proof of a read):

```
authority_caveat           read by  0 file(s): NOBODY
authority_caveat_basis     read by  0 file(s): NOBODY
authority_caveat_observed  read by  0 file(s): NOBODY
room_caveat                read by  0 file(s): NOBODY
seat_caveat                read by  0 file(s): NOBODY
--- control, same grep shape ---
refusal                    read by 24 file(s)
can_execute_review         read by  4 file(s)
identity_caveat            read by  2 file(s)
```

`authority_caveat` is not decoration. It records a Stand's **self-stated refusal to cast a formal vote on a collaborator-routed ask** — the one field that stops an unauthorized request going out.

## Before / after

At the parent commit and at HEAD, same roster entry carrying `authority_caveat`:

```
BEFORE (parent):  stderr: ''                                                    AUTHORITY CAVEAT present: False
AFTER  (HEAD):    stderr: "AUTHORITY CAVEAT 'a': DECLINES a collaborator-routed formal vote"   present: True
```

## Why derived rather than a second named field

Adding `authority_caveat` beside `identity_caveat` fixes today's instance and re-arms the mechanism: a named list misses the next field silently, which is exactly how this one came to sit unread *beside* a field that was read. `roster-basis-check.py` already derives its checked-field set from the corpus for the same reason, so the precedent is in-repo.

The code's own comment already stated the principle — *"A caveat nobody prints is a note, not a step"* — and applied it to one field.

## Tests

Five arms added to the existing `IdentityCaveatSurfaces` class. The discriminating one is `test_a_caveat_field_nobody_has_named_yet_still_prints`, which uses an invented `jurisdiction_caveat`.

**Mutation-controlled.** Replacing the derivation with the hardcoded pair `("identity_caveat", "authority_caveat")`:

```
MUTANT rc=1
FAIL: test_a_caveat_field_nobody_has_named_yet_still_prints
FAIL: test_every_caveat_on_one_entry_prints
  failing arms: 2
restored rc=0 :: OK
```

Exactly the two arms that pin *derived* go red; the identity and authority arms stay green, which is the honest result — they pass under both versions and pin nothing about derivation. The mutation asserted its anchor count was 1 first, since a patch that never applies and a patch the tests catch are the same green from outside.

Two controls guard the other direction: a non-caveat field (`note`, `github`) must **not** print, and an empty caveat must not print. Without those, matching too widely would dump the entry to stderr, and "everything surfaced" is indistinguishable from "nothing is" once the reader stops looking.

Six sibling `notify_reviewers` suites pass unchanged. `review-checks.sh --diff` clean on the full PR diff.

## How I hit it

Chasing a second approver, I opened a roster entry by hand and printed the fields I judged relevant. That projection omitted `authority_caveat`; what I saw was a `note` saying the owner had named that Stand an alternative approver, so I concluded the pool was not exhausted and was about to send the ask. The unprinted field says the opposite. No wrong ask went out — but only because `widen-pool` is login-keyed and that Stand has no login, which is luck about which key the tool uses, not coverage of this field.

Closes #3965
