### PR TITLE
docs(task-protocol): name the staging temp nothing reaps

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -777,7 +777,15 @@ def set_task_stamper(fn) -> None:
 def write_task_file(tasks_dir: "Path | str", task_id: str,
                     headers: "Iterable[tuple[str, str]]", task_body: str) -> Path:
     """Write `<tasks_dir>/<task_id>.txt` in the task-last shape. The task
-    enters the Durable Work Model's `pending` state the moment this returns."""
+    enters the Durable Work Model's `pending` state the moment this returns.
+
+    A hard kill between staging and publish leaves the `.<task_id>.*.tmp`
+    behind, and nothing reaps it: the dot and the missing `.txt` that keep it
+    out of the watcher keep it out of every sweep too, and `find_task_file`'s
+    `{task_id}.*` glob cannot match a leading-dot name either. Bounded — one
+    small file per hard kill inside a sub-millisecond window — and deliberately
+    not reaped, because a reaper would race a live writer for the same names.
+    """
     if not valid_task_id(task_id):
         raise ValueError(f"not a canonical task id: {task_id!r}")
     hdrs = list(headers)

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -777,7 +777,15 @@ def set_task_stamper(fn) -> None:
 def write_task_file(tasks_dir: "Path | str", task_id: str,
                     headers: "Iterable[tuple[str, str]]", task_body: str) -> Path:
     """Write `<tasks_dir>/<task_id>.txt` in the task-last shape. The task
-    enters the Durable Work Model's `pending` state the moment this returns."""
+    enters the Durable Work Model's `pending` state the moment this returns.
+
+    A hard kill between staging and publish leaves the `.<task_id>.*.tmp`
+    behind, and nothing reaps it: the dot and the missing `.txt` that keep it
+    out of the watcher keep it out of every sweep too, and `find_task_file`'s
+    `{task_id}.*` glob cannot match a leading-dot name either. Bounded — one
+    small file per hard kill inside a sub-millisecond window — and deliberately
+    not reaped, because a reaper would race a live writer for the same names.
+    """
     if not valid_task_id(task_id):
         raise ValueError(f"not a canonical task id: {task_id!r}")
     hdrs = list(headers)


### PR DESCRIPTION
## What this is

One docstring sentence on `write_task_file`, applied to both copies. **No behaviour change.**

## Why

https://github.com/sonichi/sutando/pull/3962 made `write_task_file` publish atomically — stage to `.<task_id>.*.tmp`, then `os.replace`. Reviewing it, @sutando-rui wrote:

> Crash-orphaned staging files have no reaper, and by construction cannot be found by one that looks like the others. […] The same two properties that keep staging files out of the watcher keep them out of every sweep. Bounded and cheap […] — but it is worth a sentence in the docstring so the next person doesn't discover it as a mystery.

They approved, and the PR merged at `c61900fa` without the sentence. This adds it.

The property earns a line because it is **self-concealing**: the leading dot and the missing `.txt` are what make the staging name safe, and they are the same two things that hide it from every sweep that could clean it up. So the absence of a reaper reads as an oversight rather than as a consequence — which is precisely the mystery rui was trying to prevent.

## Verified, not asserted

I checked rui's premise independently rather than quoting it, against the actual readers on `origin/main`, with a positive control so that a probe which cannot match anything is not mistaken for a clean result:

```
orphan: .task-1780000000000.zwo3rky9.tmp
  shell  *.txt   (watch-tasks-stream.sh:643)   matched=False
  glob   *.txt        (agent-api.py:374)       matched=False
  glob   {task_id}.*  (task_archive.py:108)    matched=False
  glob   task-*.txt   (friction-detector.py)   matched=False
  POSITIVE CONTROL: the real task IS matched by *.txt -> True
```

The `{task_id}.*` row is the interesting one — that glob is the closest thing in the tree to a reaper that *would* match, and the leading dot is what excludes it.

I also confirmed no reaper exists: searching `origin/main` for temp cleanup under a tasks dir returns only unrelated scripts removing their own temps.

## Checks

```
tests/ag2-sparrow-drift.test.py                  PASS — bundled utils in sync with src/
tests/local-task-protocol-atomic-write.test.py   OK (9 tests)
ruff                                             All checks passed
review-checks                                    PASS (hardcoded-paths + root-artifacts + prose-cap)
```

It is a docstring rather than a comment deliberately: the repo's prose-cap limits comment blocks to 2 lines, and this needs more than that to state the reason rather than just the fact.

## Deliberately NOT in this PR

**The missing directory fsync after `os.replace`.** @sutando-rui raised it on https://github.com/sonichi/sutando/pull/3962 and judged it the correct trade — losing the rename means the task never appeared, which is the safe direction — then approved on that reasoning and merged. That is a decision taken with the argument on the record, and re-opening it here would be re-litigating it rather than adding anything.

For completeness, one thing I looked at and am **not** proposing: if `os.fdopen(fd, ...)` itself raises, the raw descriptor from `mkstemp` is not closed (the handler unlinks the path only). Closing it correctly needs ownership tracking, because after `os.fdopen` succeeds the file object owns the fd and closing twice is itself a bug. For a path that is effectively unreachable with a valid fd and standard arguments, that restructure looked more likely to introduce a defect than to remove one. Naming it here so the judgement is visible rather than silent.
