### PR TITLE
fix(health-check): a stalled lane that recorded a failure has a cause to read

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -68,6 +68,7 @@ from cron_entry_digest import digest_map, drifted  # noqa: E402
 from gateway_serving import (  # noqa: E402
     read_verdict as read_gateway_verdict,
     safe_num as _gateway_num,
+    verdict_from_record as _gateway_verdict_from_record,
 )
 from task_archive import find_task_file  # noqa: E402
 from sutando_config import config_get  # noqa: E402
@@ -6748,8 +6749,9 @@ def _gateway_stale_lanes(state_dir: "Path | None" = None,
 def _gateway_lane_record(lane: str, state_dir: "Path | None" = None) -> "dict | None":
     """The lane sidecar's last parsed record, or None when absent/unreadable.
 
-    Separate from `_gateway_stale_lanes`, whose (lane, age) contract several
-    callers and tests depend on; this answers what the record SAID, not when.
+    Raw only: `gateway_serving` owns what a record MEANS, so connectivity is
+    never interpreted here. Separate from `_gateway_stale_lanes`, whose
+    (lane, age) contract several callers and tests depend on.
     """
     root = (Path(state_dir) if state_dir is not None
             else Path(status_read_path("gateway-status.json", WORKSPACE_DIR)).parent)
@@ -6760,7 +6762,7 @@ def _gateway_lane_record(lane: str, state_dir: "Path | None" = None) -> "dict | 
     return rec if isinstance(rec, dict) else None
 
 
-def _gateway_ok_unless_lane_stalled(detail: str) -> dict:
+def _gateway_ok_unless_lane_stalled(detail: str, now: "float | None" = None) -> dict:
     """The ok verdict for the bridge, demoted to warn when any lane's sidecar
     has gone silent — the primary being healthy says nothing about a lane."""
     stalled = _gateway_stale_lanes()
@@ -6770,20 +6772,39 @@ def _gateway_ok_unless_lane_stalled(detail: str) -> dict:
         return (f"{ln} (last write {age:.0f}s ago)" if age < 3600
                 else f"{ln} (last write {age / 3600:.1f}h ago)")
 
-    # A lane that RECORDED a failure before stopping has a readable cause; saying
-    # "only the silence shows it" there sends the reader past the error message.
-    silent, failed = [], []
+    # Freshness is already decided, so ask the owner what the record MEANT.
+    # None is "no opinion" — never report that as the record saying connected.
+    import time as _time
+    _now = _time.time() if now is None else now
+    silent, failed, unknown, never = [], [], [], []
     for ln, age in stalled:
         rec = _gateway_lane_record(ln) or {}
         err = rec.get("error")
-        (failed if rec.get("connected") is False or err else silent).append(
-            (ln, age, err))
+        verdict = _gateway_verdict_from_record(rec, now=_now, max_age=float("inf"))
+        if verdict is None:
+            unknown.append((ln, age, err))
+        elif verdict.connected is False or err:
+            failed.append((ln, age, err))
+        elif verdict.never_polled:
+            never.append((ln, age, err))
+        else:
+            silent.append((ln, age, err))
     parts = []
     if silent:
         parts.append(
             f"lane {', '.join(_aged(ln, age) for ln, age, _ in silent)} stopped "
             "writing its sidecar — its last record still says connected, so only "
             "the silence shows it")
+    if never:
+        parts.append(
+            f"lane {', '.join(_aged(ln, age) for ln, age, _ in never)} stopped "
+            "while claiming connection it never completed a poll on — its record "
+            "has no successful poll to point at")
+    if unknown:
+        parts.append(
+            f"lane {', '.join(_aged(ln, age) for ln, age, _ in unknown)} stopped "
+            "writing its sidecar and its last record carries no usable "
+            "connectivity — read the file rather than trusting either state")
     for ln, age, err in failed:
         why = f": {str(err)[:120]}" if err else ""
         parts.append(f"lane {_aged(ln, age)} stopped after recording a "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6745,23 +6745,55 @@ def _gateway_stale_lanes(state_dir: "Path | None" = None,
     return out
 
 
+def _gateway_lane_record(lane: str, state_dir: "Path | None" = None) -> "dict | None":
+    """The lane sidecar's last parsed record, or None when absent/unreadable.
+
+    Separate from `_gateway_stale_lanes`, whose (lane, age) contract several
+    callers and tests depend on; this answers what the record SAID, not when.
+    """
+    root = (Path(state_dir) if state_dir is not None
+            else Path(status_read_path("gateway-status.json", WORKSPACE_DIR)).parent)
+    try:
+        rec = json.loads((root / f"gateway-status.{lane}.json").read_text())
+    except (OSError, ValueError):
+        return None
+    return rec if isinstance(rec, dict) else None
+
+
 def _gateway_ok_unless_lane_stalled(detail: str) -> dict:
     """The ok verdict for the bridge, demoted to warn when any lane's sidecar
     has gone silent — the primary being healthy says nothing about a lane."""
     stalled = _gateway_stale_lanes()
     if not stalled:
         return {"name": "gateway-bridge", "status": "ok", "detail": detail}
-    names = ", ".join(
-        f"{ln} (last write {age:.0f}s ago)" if age < 3600
-        else f"{ln} (last write {age / 3600:.1f}h ago)"
-        for ln, age in stalled)
+    def _aged(ln, age):
+        return (f"{ln} (last write {age:.0f}s ago)" if age < 3600
+                else f"{ln} (last write {age / 3600:.1f}h ago)")
+
+    # A lane that RECORDED a failure before stopping has a readable cause; saying
+    # "only the silence shows it" there sends the reader past the error message.
+    silent, failed = [], []
+    for ln, age in stalled:
+        rec = _gateway_lane_record(ln) or {}
+        err = rec.get("error")
+        (failed if rec.get("connected") is False or err else silent).append(
+            (ln, age, err))
+    parts = []
+    if silent:
+        parts.append(
+            f"lane {', '.join(_aged(ln, age) for ln, age, _ in silent)} stopped "
+            "writing its sidecar — its last record still says connected, so only "
+            "the silence shows it")
+    for ln, age, err in failed:
+        why = f": {str(err)[:120]}" if err else ""
+        parts.append(f"lane {_aged(ln, age)} stopped after recording a "
+                     f"failure{why} — read that, not the silence")
     return {
         "name": "gateway-bridge",
         "status": "warn",
         "detail": (
-            f"{detail}, but lane {names} stopped writing its sidecar — its last "
-            "record still says connected, so only the silence shows it; messages "
-            "on that lane are not being delivered (retired lane? remove "
+            f"{detail}, but " + "; ".join(parts) + "; messages on that lane are "
+            "not being delivered (retired lane? remove "
             "state/gateway-status.<lane>.json)"
         ),
     }

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -6800,11 +6800,13 @@ def _gateway_ok_unless_lane_stalled(detail: str, now: "float | None" = None) -> 
             f"lane {', '.join(_aged(ln, age) for ln, age, _ in never)} stopped "
             "while claiming connection it never completed a poll on — its record "
             "has no successful poll to point at")
-    if unknown:
-        parts.append(
-            f"lane {', '.join(_aged(ln, age) for ln, age, _ in unknown)} stopped "
-            "writing its sidecar and its last record carries no usable "
-            "connectivity — read the file rather than trusting either state")
+    for ln, age, err in unknown:
+        # Schema drift must not cost the operator the error string; `failed`
+        # prints it and this branch holds the same value.
+        why = f", but it recorded: {str(err)[:120]}" if err else ""
+        parts.append(f"lane {_aged(ln, age)} stopped writing its sidecar and its "
+                     "last record carries no usable connectivity"
+                     f"{why} — read the file rather than trusting either state")
     for ln, age, err in failed:
         why = f": {str(err)[:120]}" if err else ""
         parts.append(f"lane {_aged(ln, age)} stopped after recording a "

--- a/tests/health-check-gateway-stale-lane.test.py
+++ b/tests/health-check-gateway-stale-lane.test.py
@@ -152,7 +152,7 @@ class StalledLaneNamesItsCause(unittest.TestCase):
                                lambda: stale(state_dir=self.d, now=NOW)), \
              mock.patch.object(hc, "_gateway_lane_record",
                                lambda ln, state_dir=None: record(ln, state_dir=self.d)):
-            return hc._gateway_ok_unless_lane_stalled("running + connected")["detail"]
+            return hc._gateway_ok_unless_lane_stalled("running + connected", now=NOW)["detail"]
 
     def test_a_failed_lane_does_not_claim_the_record_says_connected(self):
         _write(self.d, "gateway-status.dlocal.json", connected=False,
@@ -167,15 +167,18 @@ class StalledLaneNamesItsCause(unittest.TestCase):
         self.assertIn("SSL CERTIFICATE_VERIFY_FAILED", self._detail())
 
     def test_a_silent_lane_keeps_the_original_wording(self):
-        # Green-on-purpose: the common case must not change.
+        # Green-on-purpose: the common case must not change. `last_ok_ts` is what
+        # makes it "was serving, went quiet" rather than never_polled.
         _write(self.d, "gateway-status.local.json", connected=True, error=None,
-               ts=NOW - STALE)
+               ts=NOW - STALE, last_ok_ts=NOW - STALE)
         d = self._detail()
         self.assertIn("still says connected", d)
         self.assertNotIn("recording a failure", d)
+        self.assertNotIn("no usable", d)
 
     def test_both_kinds_in_one_verdict_are_reported_separately(self):
-        _write(self.d, "gateway-status.local.json", connected=True, error=None, ts=NOW - STALE)
+        _write(self.d, "gateway-status.local.json", connected=True, error=None,
+               ts=NOW - STALE, last_ok_ts=NOW - STALE)
         _write(self.d, "gateway-status.dlocal.json", connected=False,
                error="boom", ts=NOW - STALE)
         d = self._detail()
@@ -190,15 +193,44 @@ class StalledLaneNamesItsCause(unittest.TestCase):
                error="relay 502", ts=NOW - STALE)
         self.assertIn("relay 502", self._detail())
 
-    def test_unreadable_lane_record_falls_back_to_the_silent_wording(self):
+    def test_unreadable_lane_record_is_reported_as_unknown_not_connected(self):
         (self.d / "gateway-status.broken.json").write_text("{not json")
         record = hc._gateway_lane_record
         with mock.patch.object(hc, "_gateway_stale_lanes", lambda: [("broken", STALE)]), \
              mock.patch.object(hc, "_gateway_lane_record",
                                lambda ln, state_dir=None: record(ln, state_dir=self.d)):
-            d = hc._gateway_ok_unless_lane_stalled("running + connected")["detail"]
-        self.assertIn("still says connected", d)
+            d = hc._gateway_ok_unless_lane_stalled("running + connected", now=NOW)["detail"]
+        self.assertNotIn("still says connected", d)
+        self.assertIn("no usable connectivity", d)
 
+
+    def test_a_record_with_no_connected_field_is_unknown_not_connected(self):
+        # The reviewers' P2: routing "no opinion" into the silent bucket asserted
+        # the record says something it does not say.
+        _write(self.d, "gateway-status.q.json", ts=NOW - STALE)
+        d = self._detail()
+        self.assertNotIn("still says connected", d)
+        self.assertIn("no usable connectivity", d)
+
+    def test_a_non_bool_connected_is_unknown_schema_drift(self):
+        _write(self.d, "gateway-status.q.json", connected="yes", ts=NOW - STALE)
+        d = self._detail()
+        self.assertNotIn("still says connected", d)
+        self.assertIn("no usable connectivity", d)
+
+    def test_connected_without_a_completed_poll_is_named_separately(self):
+        # gateway_serving.never_polled — connection claimed, no poll to point at.
+        _write(self.d, "gateway-status.np.json", connected=True, error=None,
+               ts=NOW - STALE)
+        d = self._detail()
+        self.assertIn("never completed a poll", d)
+        self.assertNotIn("still says connected", d)
+
+    def test_connectivity_is_interpreted_by_the_owner_not_here(self):
+        # Delegation pin: health-check must not re-derive the verdict inline.
+        src = (Path(__file__).resolve().parent.parent / "src" / "health-check.py").read_text()
+        fn = src.split("def _gateway_ok_unless_lane_stalled")[1].split("\ndef ")[0]
+        self.assertIn("_gateway_verdict_from_record(", fn)
 
 class LaneRecordAccessor(unittest.TestCase):
     def setUp(self):

--- a/tests/health-check-gateway-stale-lane.test.py
+++ b/tests/health-check-gateway-stale-lane.test.py
@@ -218,6 +218,21 @@ class StalledLaneNamesItsCause(unittest.TestCase):
         self.assertNotIn("still says connected", d)
         self.assertIn("no usable connectivity", d)
 
+    def test_an_unknown_record_still_surfaces_its_recorded_error(self):
+        # Tested APART before: the error arm wrote connected=False, the unknown
+        # arms wrote no error. Together, the formatter discarded the captured err.
+        _write(self.d, "gateway-status.drift.json", error="relay 502 upstream refused",
+               ts=NOW - STALE)                       # no `connected` at all
+        d = self._detail()
+        self.assertIn("no usable connectivity", d)
+        self.assertIn("relay 502 upstream refused", d)
+
+    def test_an_unknown_record_without_an_error_says_nothing_extra(self):
+        _write(self.d, "gateway-status.q2.json", ts=NOW - STALE)
+        d = self._detail()
+        self.assertIn("no usable connectivity", d)
+        self.assertNotIn("but it recorded", d)
+
     def test_connected_without_a_completed_poll_is_named_separately(self):
         # gateway_serving.never_polled — connection claimed, no poll to point at.
         _write(self.d, "gateway-status.np.json", connected=True, error=None,

--- a/tests/health-check-gateway-stale-lane.test.py
+++ b/tests/health-check-gateway-stale-lane.test.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import time
 import unittest
+from unittest import mock
 from pathlib import Path
 from unittest.mock import patch
 
@@ -132,6 +133,91 @@ class ShippedPathReadsTheRealSidecar(unittest.TestCase):
             r = hc.check_gateway_bridge()
         self.assertEqual(r["status"], "warn", r)
         self.assertIn("lane local", r["detail"])
+
+
+
+class StalledLaneNamesItsCause(unittest.TestCase):
+    """A stalled lane whose record says `connected: false` has a READABLE cause.
+    The old message hardcoded "its last record still says connected", which is the
+    docstring's own "almost always" promoted to always — it told the reader to look
+    for silence while an error sat in the file."""
+
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+
+    def _detail(self):
+        # Bind the ORIGINALS first: inside the patch, hc.<name> IS the lambda.
+        stale, record = hc._gateway_stale_lanes, hc._gateway_lane_record
+        with mock.patch.object(hc, "_gateway_stale_lanes",
+                               lambda: stale(state_dir=self.d, now=NOW)), \
+             mock.patch.object(hc, "_gateway_lane_record",
+                               lambda ln, state_dir=None: record(ln, state_dir=self.d)):
+            return hc._gateway_ok_unless_lane_stalled("running + connected")["detail"]
+
+    def test_a_failed_lane_does_not_claim_the_record_says_connected(self):
+        _write(self.d, "gateway-status.dlocal.json", connected=False,
+               error="network: SSL CERTIFICATE_VERIFY_FAILED", ts=NOW - STALE)
+        d = self._detail()
+        self.assertNotIn("still says connected", d)
+        self.assertIn("stopped after recording a failure", d)
+
+    def test_the_recorded_error_is_surfaced_verbatim(self):
+        _write(self.d, "gateway-status.dlocal.json", connected=False,
+               error="network: SSL CERTIFICATE_VERIFY_FAILED", ts=NOW - STALE)
+        self.assertIn("SSL CERTIFICATE_VERIFY_FAILED", self._detail())
+
+    def test_a_silent_lane_keeps_the_original_wording(self):
+        # Green-on-purpose: the common case must not change.
+        _write(self.d, "gateway-status.local.json", connected=True, error=None,
+               ts=NOW - STALE)
+        d = self._detail()
+        self.assertIn("still says connected", d)
+        self.assertNotIn("recording a failure", d)
+
+    def test_both_kinds_in_one_verdict_are_reported_separately(self):
+        _write(self.d, "gateway-status.local.json", connected=True, error=None, ts=NOW - STALE)
+        _write(self.d, "gateway-status.dlocal.json", connected=False,
+               error="boom", ts=NOW - STALE)
+        d = self._detail()
+        self.assertIn("still says connected", d)
+        self.assertIn("stopped after recording a failure", d)
+        self.assertIn("local", d)
+        self.assertIn("dlocal", d)
+
+    def test_an_error_with_connected_true_still_counts_as_a_failure(self):
+        # connected can lag; a recorded error is the discriminator that matters.
+        _write(self.d, "gateway-status.dlocal.json", connected=True,
+               error="relay 502", ts=NOW - STALE)
+        self.assertIn("relay 502", self._detail())
+
+    def test_unreadable_lane_record_falls_back_to_the_silent_wording(self):
+        (self.d / "gateway-status.broken.json").write_text("{not json")
+        record = hc._gateway_lane_record
+        with mock.patch.object(hc, "_gateway_stale_lanes", lambda: [("broken", STALE)]), \
+             mock.patch.object(hc, "_gateway_lane_record",
+                               lambda ln, state_dir=None: record(ln, state_dir=self.d)):
+            d = hc._gateway_ok_unless_lane_stalled("running + connected")["detail"]
+        self.assertIn("still says connected", d)
+
+
+class LaneRecordAccessor(unittest.TestCase):
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+
+    def test_reads_the_named_lane(self):
+        _write(self.d, "gateway-status.dlocal.json", connected=False, error="e", ts=NOW)
+        self.assertEqual(hc._gateway_lane_record("dlocal", state_dir=self.d).get("error"), "e")
+
+    def test_absent_is_none_not_an_exception(self):
+        self.assertIsNone(hc._gateway_lane_record("nope", state_dir=self.d))
+
+    def test_malformed_is_none(self):
+        (self.d / "gateway-status.bad.json").write_text("{{{")
+        self.assertIsNone(hc._gateway_lane_record("bad", state_dir=self.d))
+
+    def test_a_non_dict_payload_is_none(self):
+        (self.d / "gateway-status.arr.json").write_text("[1,2]")
+        self.assertIsNone(hc._gateway_lane_record("arr", state_dir=self.d))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

`_gateway_ok_unless_lane_stalled` gives every stalled lane the same sentence:

> its last record still says connected, so only the silence shows it

That is the enumerator's own docstring — *"a per-channel bridge that dies leaves its last record in place, and that record **almost always** says `connected: true`"* — promoted from *almost always* to *always* in the line the operator actually reads.

When it is wrong, it is wrong in the expensive direction: it tells the reader there is nothing to read.

## Measured on a live host

The sidecar for a stalled lane there says:

```json
{"connected": false,
 "error": "network: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate ...",
 "gateway": "https://localhost:9996/relay"}
```

`connected: false`, with an explicit cause. The warn pointed away from it.

**Nothing in the suite contradicted the clause** — every existing arm writes `connected=True`, and the test file's own docstring repeats the same "almost always". So the hardcoding was invisible from inside the tests.

## Before / after, same real sidecar

```
before  lane ag2space_dlocal (last write 190.1h ago) stopped writing its sidecar
        — its last record still says connected, so only the silence shows it

after   lane ag2space_dlocal (last write 190.7h ago) stopped after recording a
        failure: network: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]
        certificate verify failed: unable to get local issuer certifica —
        read that, not the silence
```

## The change

Split the stalled lanes at report time. A lane whose record says `connected: false` **or** carries an error is reported as having stopped after recording a failure, with the error quoted (truncated at 120 chars); the silent case keeps its wording **verbatim**.

A recorded error counts even when `connected` is true — that field can lag the failure that stopped the writer, so the error is the better discriminator.

**`_gateway_stale_lanes` is deliberately untouched.** Four existing arms depend on its `(lane, age)` tuple contract, and *when it stopped* is a different question from *what it said*. The new `_gateway_lane_record` answers the second and returns `None` for absent / unreadable / non-dict payloads, so an unusable record falls back to the silent wording rather than inventing a cause.

## Tests

Suite **13 → 23**. Three mutations, each applied to a restored copy, each red on a **named** arm:

| mutation | result |
|---|---|
| revert to the hardcoded "still says connected" sentence | `FAILED (failures=4)` — incl. `test_a_failed_lane_does_not_claim_the_record_says_connected` |
| classify on `connected` alone, ignoring a recorded error | `FAILED (failures=1)` — `test_an_error_with_connected_true_still_counts_as_a_failure` |
| accessor returns `{}` instead of `None` on malformed input | `FAILED (failures=3)` — incl. `test_a_non_dict_payload_is_none` |

One arm is **green-on-purpose**: `test_a_silent_lane_keeps_the_original_wording` pins the common path's exact text, so adding the new branch cannot quietly reword the case that was already right.

`ruff` clean; `review-checks` PASS (hardcoded-paths + root-artifacts + prose-cap).

## Note on the harness

My first version of the new arms produced 6 **errors**, not failures — the patch lambdas called `hc._gateway_stale_lanes`, which *is* the lambda once `mock.patch.object` is active. The originals are now bound before patching. Flagging it because an error and a caught regression look alike in a summary line, and the fix is one an unwary reader might re-introduce.
