### PR TITLE
docs(review): review the window a newly-async path opens, not just the helper

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -434,6 +434,28 @@ and loads whichever repo it reviews.
     IN_PROGRESS run carries `conclusion == ""`, so a filter keyed only on it calls a running
     check failing.
 
+21. **When a diff makes a synchronous action asynchronous, review the WINDOW it opens, not
+    just the helper that opens it.** The new helper can be entirely correct — good retry
+    semantics, good error taxonomy, tested — while the defect lives in what the *caller*
+    still does at settle time with state it captured at call time. Lesson 2 covers the
+    unchanged code a diff newly *reaches*; this is the unchanged code a diff newly
+    *delays*. The question to ask is not "is the helper correct?" but "what else can
+    change between the call and the settle, and does the continuation re-read it?"
+    Two things make this easy to miss. The reviewable artifact is the helper, so attention
+    lands there; and the window's size is usually stated as a feature (a retry budget, a
+    backoff) rather than as a hazard, so the very sentence that should raise the question
+    reads as reassurance.
+    *Grounded by:* ag2-space/cinny-webclient#903, 2026-09-06. `writeToTerminal()` added an
+    attach-retry of up to 20 × 250ms — five seconds — and the composer's `.then()` called
+    `resetEditor(editor)` on success, having captured `editor` and the terminal-mode flag at
+    submit time. So a user who typed during the retry lost what they typed. The reviewer who
+    approved that head had read the caller and quoted those exact lines while flagging
+    something else in them; the P1 was filed against the same sha six minutes later. The fix
+    moved the decision into a pure `settleTerminalSend()` that re-reads the editor and the
+    mode *at settle time* — which is also what made it testable under node.
+    Cheap form: for each side effect in a newly-async continuation, name the state it
+    depends on and check the continuation re-reads it rather than closing over it.
+
 ## Checks (machine-readable — consumed by scripts/review-checks.sh)
 
 ```yaml


### PR DESCRIPTION
## What

Adds REVIEW.md lesson 21: when a diff makes a synchronous action asynchronous, review the **window** it opens, not just the helper that opens it.

Lesson 2 already covers the unchanged code a diff newly *reaches*. This is the unchanged code a diff newly *delays* — the caller's continuation acting at settle time on state it captured at call time. Distinct enough to need its own entry: I grepped REVIEW.md for `async|race|window|concurren|settle|await` and no existing lesson covers it (the five hits are a rolling-upgrade window, a Safari version, a service window, and a regex comment).

## Why now — a real miss, not a hypothetical

ag2-space/cinny-webclient#903, 2026-09-06. `writeToTerminal()` added an attach-retry of up to 20 × 250ms — five seconds — and the composer's `.then()` called `resetEditor(editor)` on success, having captured `editor` and the terminal-mode flag at submit time. A user who typed during the retry lost what they typed.

I approved that head at 09:27:04Z. The P1 was filed against the **same sha** at 09:33:09Z, naming `RoomInput.tsx:397-413` — lines I had quoted in my own review while flagging something else in them. So it was not code I skipped: I reviewed the helper as a contract (retry semantics, error taxonomy, an uncovered branch) and never asked what the caller does at settle time.

The two properties that make it easy to miss are in the lesson body: the reviewable artifact is the helper, so attention lands there; and the window's size is stated as a *feature* (a retry budget), so the sentence that should raise the question reads as reassurance.

The fix on that PR is also the lesson's cheap form — the decision moved into a pure `settleTerminalSend()` that re-reads the editor and the mode at settle time, which is what made it testable under node at all.

## Evidence

The point of putting this in REVIEW.md rather than a note is that `scripts/review-preflight.py` prints these unconditionally at review time. Verified on this branch:

```
$ python3 scripts/review-preflight.py 3969 | grep -c '^21\. '
1
$ python3 scripts/review-preflight.py 3969 | grep -c '^20\. '     # control: the probe can produce hits
1
```

Numbering is contiguous 1..21 after the insert (asserted, not eyeballed). Inserted immediately before the `## Checks` block, so the machine-readable YAML is untouched — `git diff --numstat` is `22 0` on `REVIEW.md` alone.

```
$ bash scripts/review-checks.sh --diff <full-pr-diff>
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
```
`PARTIAL` here is the expected shape for a docs-only diff — prose-cap scopes to `.py`.

## Scope

Docs only. No code, no behavior change. Per REVIEW.md's own note, adding a lesson is a PR to `REVIEW.md` only.
