### PR TITLE
fix(morning-briefing): a path or a decimal is not the end of the insight sentence

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -719,7 +719,9 @@ def synthesize(weather, events, reminders, discord_msgs, pending_qs, health_issu
 
     # Daily insight (closing thought) — take first sentence, skip if it's just raw data
     if insight:
-        first_sentence = insight.split('.')[0].strip()
+        # A sentence-ending period is followed by space or end; a bare `.`
+        # is a path (`.github/`) or a decimal, and must not end the sentence.
+        first_sentence = re.split(r"\.(?=\s|$)", insight, maxsplit=1)[0].strip()
         has_raw_data = '{' in first_sentence or first_sentence.count(':') > 2
         if not has_raw_data and len(first_sentence) > 20:
             parts.append(f"Insight: {first_sentence}.")

--- a/tests/morning-briefing-insight-sentence.test.py
+++ b/tests/morning-briefing-insight-sentence.test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+The briefing's closing Insight line must not be cut at a path or a decimal.
+
+`synthesize()` renders the insight as a "first sentence". It used to take
+`insight.split('.')[0]`, which ends the sentence at ANY period — including the
+one inside `.github/` or `1.4s`. Observed live 2026-09-06: daily-insight.py
+produced
+
+    "Sutando authored 2 commits in the last 24h, mostly in .github/, src/,
+     tests/ (branch work; landed count unavailable)."
+
+and the delivered briefing read "Insight: Sutando authored 2 commits in the
+last 24h, mostly in." — a broken half-sentence in the owner's daily message.
+
+A sentence-ending period is followed by whitespace or end-of-string; the
+period in a path or a decimal is not. Every case here drives the PRODUCTION
+`synthesize()`, because the defect was in what it renders, not in a helper.
+
+Run: python3 tests/morning-briefing-insight-sentence.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("mb", REPO / "src" / "morning-briefing.py")
+mb = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mb)
+
+FAILS = []
+
+
+def check(cond, msg):
+    print(("ok  " if cond else "FAIL") + " " + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def render(insight):
+    """The production path: synthesize() with every other source absent."""
+    return mb.synthesize(None, None, None, None, None, None, insight=insight)
+
+
+def main() -> int:
+    # a) the live 2026-09-06 case: a dotted path must not end the sentence
+    real = ("Sutando authored 2 commits in the last 24h, mostly in .github/, "
+            "src/, tests/ (branch work; landed count unavailable).")
+    out = render(real)
+    check("mostly in .github/, src/, tests/" in out,
+          "a dotted path does not truncate the Insight line")
+    check("mostly in." not in out,
+          "the broken half-sentence 'mostly in.' is not emitted")
+
+    # b) CONTROL — the intended behaviour is unchanged: still FIRST sentence only
+    two = "You shipped 5 PRs yesterday. That is double your weekly median."
+    out2 = render(two)
+    check("Insight: You shipped 5 PRs yesterday." in out2,
+          "a real sentence boundary still ends the Insight line")
+    check("double your weekly median" not in out2,
+          "the second sentence is still dropped (first-sentence rule intact)")
+
+    # c) a decimal is not a sentence end either
+    dec = "Median latency was 1.4s across 12 calls. Slower than usual."
+    out3 = render(dec)
+    check("1.4s across 12 calls" in out3, "a decimal does not truncate the Insight line")
+    check("Slower than usual" not in out3, "the second sentence is still dropped")
+
+    # d) CONTROL — the raw-data guard still suppresses, so this test cannot
+    #    pass merely because every insight is now emitted verbatim.
+    raw = 'insight {"commits": 2, "files": 9, "branch": "x", "extra": "y"}'
+    check("Insight:" not in render(raw), "raw-data insight is still suppressed")
+
+    print(("FAILED: %d" % len(FAILS)) if FAILS else "ALL PASS")
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What happened

Caught in **today's actually-delivered briefing**, not in review. `daily-insight.py` produced:

> Sutando authored 2 commits in the last 24h, mostly in .github/, src/, tests/ (branch work; landed count unavailable).

and the owner received:

> Insight: Sutando authored 2 commits in the last 24h, mostly in.

`synthesize()` took `insight.split('.')[0]`, which ends the sentence at **any** period — including the one inside `.github/`. A broken half-sentence shipped as the closing thought of the daily message.

The same split has a second latent case: a decimal. `"Median latency was 1.4s across 12 calls."` renders as `"Median latency was 1"`.

## The fix

A sentence-ending period is followed by whitespace or end-of-string; the period inside a path or a decimal is not. The split is anchored on that:

```python
first_sentence = re.split(r"\.(?=\s|$)", insight, maxsplit=1)[0].strip()
```

`re` is already imported. One line.

## What is deliberately unchanged

The first-sentence rule and the raw-data suppression keep their exact prior behaviour, and the test asserts that rather than only asserting the new case — a fix here could easily have degenerated into "emit the whole insight", which would break both.

## Evidence

Before / after, through the **production** `synthesize()`:

```
insight  "Sutando authored 2 commits in the last 24h, mostly in .github/, src/, tests/ (...)"
before   Insight: Sutando authored 2 commits in the last 24h, mostly in.
after    Insight: Sutando authored 2 commits in the last 24h, mostly in .github/, src/, tests/ (...).
```

**Mutation control** — restoring `insight.split('.')[0]`:

```
FAIL a dotted path does not truncate the Insight line
FAIL the broken half-sentence 'mostly in.' is not emitted
ok   a real sentence boundary still ends the Insight line
ok   the second sentence is still dropped (first-sentence rule intact)
FAIL a decimal does not truncate the Insight line
ok   the second sentence is still dropped
ok   raw-data insight is still suppressed
FAILED: 3
```

Exactly the three truncation assertions die; the four behaviour-preserving controls stay green. That is the split that matters — it shows the test detects the defect *and* that the intended behaviour is genuinely unchanged.

All 13 briefing/insight suites on this branch pass (`rc=0`), and `review-checks.sh --diff` is PASS on the cumulative diff.

## Base, stated plainly

This targets **`feat/sutando-server`** because that is the only branch where the code exists: `src/morning-briefing.py` on `main` has **0** occurrences of `insight` (positive control: `weather` counts 14 there), and `get_daily_insight` is absent from `main`'s `src/` entirely. The insight-in-briefing feature has never been on main.

That branch is behind main and PRs based on it inherit unrelated red checks, so **expect CI here to be red for reasons this diff does not touch** — the same inherited-failure pattern already recorded on #3442. I am not asking anyone to chase those; this is a one-line correctness fix parked where the code lives, and it will be right whenever the branch promotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)