### PR TITLE
fix(memory-index-budget): the refusal advice named a script that never existed

### DIFF
--- a/docs/proactive-loop-rationale.md
+++ b/docs/proactive-loop-rationale.md
@@ -602,10 +602,12 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    will later condemn — the drift that made the dedup checker worse than no checker. 13 tests,
    4 mutations verified red, including one that installs exactly that silent fallback.
 
-   **On a refusal, free room FIRST — and run `scripts/memory-hub-containment.py` before trimming**,
-   so a row you remove is still carried by its hub. Which rows may go is the owner's call
-   (`pending-questions.md` -> "MEMORY.md byte budget"); the guard's job is only to stop the write
-   that would decide it by accident.
+   **On a refusal, free room FIRST — and check the row is still reachable from its hub before
+   removing it.** This used to name a `memory-hub-containment` script; that path has never existed
+   in the repo, so the advice was unrunnable at the one moment it is read. `health-check.py`'s
+   `memory-index` probe reports the loaded prefix and is the coverage that does exist — do not build
+   a duplicate. Which rows may go is the owner's call (`pending-questions.md` -> "MEMORY.md byte
+   budget"); the guard's job is only to stop the write that would decide it by accident.
 
 8. **If blocked, ask.** Write the question to the **per-host** `pending-questions.md` — `<workspace>/hosts/<hostname>/pending-questions.md` (`<hostname>` = `bash scripts/sutando-config.sh host-label`; create the `hosts/<hostname>/` dir if absent) — send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — apply the Pivot-on-block rule and pick another menu item.
 

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -90,8 +90,8 @@ caps this file and refuses date stamps in it).
    (a PR event, a resolved question, a lifted or new blocker, a judgment) — most passes owe none.
 7.5. **Memory index.** Before adding a row to `MEMORY.md`:
    `python3 skills/proactive-loop/scripts/memory-index-budget.py --adding "<row>"` (0 safe · 1 refuse,
-   casualty named · 2 cannot answer). On refusal run `scripts/memory-hub-containment.py` before trimming;
-   which rows go is the owner's call.
+   casualty named · 2 cannot answer). On refusal free room FIRST and check the row is still reachable
+   from its hub before removing it; which rows go is the owner's call.
 8. **Ask.** Insert the question ABOVE the `# Resolved` divider of the per-host `pending-questions.md`,
    placed by importance (only the top 5 render anywhere), and assert with the reader:
    `python3 -c "…src/check-pending-questions.py…get_waiting_questions()"` — count went up, title matches,

--- a/skills/proactive-loop/scripts/memory-index-budget.py
+++ b/skills/proactive-loop/scripts/memory-index-budget.py
@@ -137,8 +137,12 @@ def main(argv=None) -> int:
         print(f"\n✗ REFUSE — this addition drops {len(r['dropped'])} row(s) that load today:")
         for e in r["dropped"][:10]:
             print(f"    {e[:100]}")
-        print("\n  Free room FIRST. Run scripts/memory-hub-containment.py before trimming,")
-        print("  so a row you remove is still carried by its hub.")
+        # Names no containment script: the one this line used to cite has never
+        # existed in the repo or the workspace, so the advice was unrunnable at
+        # the exact moment it mattered — on a refusal.
+        print("\n  Free room FIRST, and check the row is still reachable from its hub")
+        print("  before removing it. health-check.py's memory-index probe reports the")
+        print("  loaded prefix; which rows go is the owner's call.")
     if r["addition_loads"] is False:
         bad = True
         print("\n✗ REFUSE — the addition itself lands past the cut and would never load.")

--- a/skills/proactive-loop/scripts/memory-index-budget.py
+++ b/skills/proactive-loop/scripts/memory-index-budget.py
@@ -137,9 +137,8 @@ def main(argv=None) -> int:
         print(f"\n✗ REFUSE — this addition drops {len(r['dropped'])} row(s) that load today:")
         for e in r["dropped"][:10]:
             print(f"    {e[:100]}")
-        # Names no containment script: the one this line used to cite has never
-        # existed in the repo or the workspace, so the advice was unrunnable at
-        # the exact moment it mattered — on a refusal.
+        # Names no containment script: the one previously cited never existed,
+        # so the advice was unrunnable at the one moment it is read — a refusal.
         print("\n  Free room FIRST, and check the row is still reachable from its hub")
         print("  before removing it. health-check.py's memory-index probe reports the")
         print("  loaded prefix; which rows go is the owner's call.")


### PR DESCRIPTION
## What

`memory-index-budget.py` refuses an addition that would silently drop a row already loading, then prints advice to run `scripts/memory-hub-containment.py` before trimming. **That script has never existed** — not in the repo, not in the workspace. So the guidance is unrunnable at exactly the moment it is read: on a refusal, with the index full and a decision to make.

Same dangling name appears twice: the printed advice, and step 7.5 of the proactive-loop SKILL.md.

## Evidence

The name resolves to nothing at `main`, and the same lookup finds a script that does exist:

```
$ git ls-tree -r origin/main --name-only | grep -c memory-hub-containment
0
$ git ls-tree -r origin/main --name-only | grep -c memory-index-budget.py     # control
1
```

**The advice branch, executed** — against a real 24,991 B index with 9 B of headroom, `--at-top` so the `r["dropped"]` branch fires:

BEFORE (`origin/main`):
```
✗ REFUSE — this addition drops 1 row(s) that load today:
    - [Reference lookups → **MEMORY-reference.md**](MEMORY-reference.md) — ...

  Free room FIRST. Run scripts/memory-hub-containment.py before trimming,
  so a row you remove is still carried by its hub.
```

AFTER (this branch), same command, same input:
```
✗ REFUSE — this addition drops 1 row(s) that load today:
    - [Reference lookups → **MEMORY-reference.md**](MEMORY-reference.md) — ...

  Free room FIRST, and check the row is still reachable from its hub
  before removing it. health-check.py's memory-index probe reports the
  loaded prefix; which rows go is the owner's call.
```

Both runs exit `1`. Same branch, same exit codes — only the text a human is asked to act on changes.

## Why this wording

`health-check.py`'s `memory-index` probe already reports the loaded prefix, so the coverage the dead script implied exists; naming it avoids inviting a duplicate implementation. The remaining advice ("free room first", "which rows go is the owner's call") is unchanged in substance.

## Scope

Two files, +8/−4. No behaviour change, no new dependency, no test changes — the modified lines are print statements inside an existing branch, exercised above.
