### PR TITLE
fix(health-check): the stale-proactive ok branch named a population it never measured

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8368,8 +8368,12 @@ def check_stale_proactive_backlog(threshold_age_sec: int = 3600,
     partial = f" ({unreadable} entr{'y' if unreadable == 1 else 'ies'} unreadable)" if unreadable else ""
     if not stale and not abandoned:
         status = "warn" if unreadable else "ok"
+        # Name the window, not an absolute absence: a body younger than the
+        # threshold is skipped above and is still undelivered.
         return {"name": name, "status": status,
-                "detail": f"no undelivered proactive bodies{partial}"}
+                "detail": f"no proactive body older than {threshold_age_sec // 60}m "
+                          f"and no claim older than {claim_threshold_age_sec // 60}m"
+                          f"{partial}"}
     parts = []
     if stale:
         stale.sort(key=lambda item: -item[1])

--- a/tests/health-check-stale-proactive-backlog.test.py
+++ b/tests/health-check-stale-proactive-backlog.test.py
@@ -179,6 +179,23 @@ class StaleProactiveBacklogTest(unittest.TestCase):
             "it cannot report on a real run",
         )
 
+    def test_the_ok_detail_names_its_window_not_an_absolute_absence(self) -> None:
+        # A body younger than the threshold is skipped by the age filter and is
+        # still undelivered, so "none undelivered" would be a wrong denominator.
+        self._write("results/proactive-1786480017.txt")
+        verdict = hc.check_stale_proactive_backlog()
+        self.assertEqual(verdict["status"], "ok")
+        self.assertNotIn("no undelivered proactive bodies", verdict["detail"])
+        self.assertIn("older than 60m", verdict["detail"])
+        self.assertIn("no claim older than 120m", verdict["detail"])
+
+    def test_the_ok_detail_tracks_the_thresholds_it_was_given(self) -> None:
+        verdict = hc.check_stale_proactive_backlog(threshold_age_sec=1800,
+                                                   claim_threshold_age_sec=5400)
+        self.assertEqual(verdict["status"], "ok")
+        self.assertIn("older than 30m", verdict["detail"])
+        self.assertIn("no claim older than 90m", verdict["detail"])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`check_stale_proactive_backlog` filters by age and then, on the ok path, claims an absolute absence:

```python
if age < limit:
    continue                      # young files are SKIPPED, never counted
...
return {"name": name, "status": status,
        "detail": f"no undelivered proactive bodies{partial}"}
```

The loop established *none older than the window*. The sentence says *none undelivered*. Those differ for exactly the file the probe just skipped — and this is the **ok** path, which is where a reader stops checking.

## Before / after — actual output, one undelivered body aged 0s

Repro (temp workspace, one `proactive-*.txt` written and left undrained):

**At the parent commit (`836ca600`):**
```
  files in results/: ['proactive-pending-q-78b8f5519a1bac8c.txt']
  status : ok
  detail : no undelivered proactive bodies
```

**At this HEAD:**
```
  files in results/: ['proactive-pending-q-78b8f5519a1bac8c.txt']
  status : ok
  detail : no proactive body older than 60m and no claim older than 120m
```

**The warn branch is untouched** — same repro with the body aged 2h, at this HEAD:
```
  status : warn
  detail : 1 proactive body(ies) nobody has delivered; oldest proactive-pending-q-78b8f5519a1bac8c.txt (2h0m); deliver or remove them — nothing clears these on its own
```

## Why it matters, from a live host

This morning the pending-questions cron rewrote its proactive body. `questions_key` was unchanged, so the write landed on the **same filename** via `os.replace` — no supersede, no unlink, only an mtime that moved below the 1h threshold. `stale-proactive-backlog` dropped out of the warn list and the probe reported `ok | no undelivered proactive bodies` while that body sat in `results/`, undelivered, as it had been for hours.

## Tests

Two added to the existing `tests/health-check-stale-proactive-backlog.test.py` (16 → 18, all green):

- the ok detail names its window and no longer claims an absolute absence, with a young undelivered body present
- the detail tracks non-default thresholds it is given (1800/5400 → `30m` / `90m`), so it cannot drift from the constants it reports

**Mutation verified red**: reverting only the detail string and re-running the suite gives `Ran 18 tests … FAILED (failures=2)` — both new tests, so they discriminate rather than pass by construction. Restoring gives `OK`.

`ruff` clean; `scripts/review-checks.sh` on this diff: `prose-cap: PASS`, `review-checks: PASS`.

## Scope

No behaviour change — identical inputs give identical `status`; only the ok branch's text changes.

Orthogonal to **#3685**, which is about the age *metric* being reset by the producer's own supersede path. That issue proposes changing **what is measured**; this changes only **what the ok branch claims to have measured**. Either can land without the other.