### PR TITLE
fix(core-supervisor-relay): the one-line notice quotes the prompt, not the pane's first rule

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -122,6 +122,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`proactive_routing.py`** — Channel routing for proactive owner-notification messages.
 - **`process_pins.py`** — Process-side restart pins: which running pids must NOT be restarted, and why.
 - **`progress_stream.py`** — Progress-streaming helpers for the messaging bridges (issue: Hermes-style streaming tool output, 2026-06-05).
+- **`prompt_excerpt.py`** — What the owner must read from a blocked terminal pane: the prompt minus the chrome around it.
 - **`python-binary.ts`** — Resolve a python3 interpreter that will actually run.
 - **`quota_projection.py`** — Quota usage history + even-pace projection series for the dashboard chart.
 - **`reachability-endpoints.ts`** — Direct-reachability endpoint detection (US-10, Tier 2b) — "call your agent from another device and still reach YOUR core, directly, without routing through the cloud."

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -415,31 +415,7 @@ _TUI_SOURCE = "tui"
 DRIVE_SETTLE_S = 15.0
 
 
-# Footer tokens are anchored to their glyphs so a real prompt that merely contains the words
-# ("Bypass permissions for this tool? (y/n)") is not mistaken for the idle footer.
-_NOISE_LINE = re.compile(
-    r"https?://|%3A|code_challenge|[?&]state=|^\[[^\]\n]{0,40}\s\d+:\w+|⏵⏵ bypass permissions|← for agents",
-    re.I)
-_RULE_CHARS = set("─│┌┐└┘├┤┬┴┼╭╮╯╰═║ ")
-_HRULE = "─═"
-
-
-def prompt_excerpt(prompt, limit=6):
-    """The prompt lines the owner must read: the pane's tail minus the chrome around them —
-    box-drawing rules, URL fragments (an OAuth link wraps across lines), the tmux status bar and
-    the idle footer. When the filter leaves nothing, the raw tail is returned instead: this card is
-    the only thing that reaches the owner, so it must fail noisy, never silent."""
-    lines = [ln.strip() for ln in (prompt or "").splitlines() if ln.strip()]
-    out = []
-    for core in lines:
-        if set(core) <= _RULE_CHARS or core[0] in _HRULE:
-            continue  # a rule, with or without a label in it ("──── sutando-core ─")
-        if _NOISE_LINE.search(core):
-            continue
-        if len(core) > 80 and " " not in core:
-            continue
-        out.append(core.strip("─│ "))
-    return (out or lines)[-limit:]
+from prompt_excerpt import prompt_excerpt  # noqa: E402  (shared with core-supervisor-relay)
 
 
 def escalation_message(state, detail, kind, prompt):

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -172,8 +172,16 @@ def compose_message(signal: dict) -> str:
     detail = signal.get("detail") or signal.get("state") or "core needs attention"
     kind = signal.get("kind")
     prompt = (signal.get("prompt") or "").strip()
-    # First non-empty prompt line is the most informative single line.
-    excerpt = next((ln.strip() for ln in prompt.splitlines() if ln.strip()), "")
+    # The first READABLE line: on a login pane the first non-empty line is a box rule or an OAuth
+    # URL fragment. Same filter as the escalation card; a failure here must not drop the notice.
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        if here not in sys.path:
+            sys.path.insert(0, here)
+        from prompt_excerpt import first_readable_line
+        excerpt = first_readable_line(prompt)
+    except Exception:  # noqa: BLE001 - the owner's only channel: never crash the escalation
+        excerpt = next((ln.strip() for ln in prompt.splitlines() if ln.strip()), "")
     parts = [f"⚠️ Agent needs you — {detail}"]
     if kind and kind not in detail:
         parts.append(f"({kind})")

--- a/src/prompt_excerpt.py
+++ b/src/prompt_excerpt.py
@@ -1,0 +1,50 @@
+"""What the owner must read from a blocked terminal pane: the prompt minus the chrome around it.
+
+Two surfaces quote the pane — the escalation card (`core-input-watch`) and the one-line relay
+notice (`core-supervisor-relay`) — so the filter lives here once. It drops box-drawing rules,
+URL fragments (an OAuth link wraps across lines), the tmux status bar and the idle footer; when
+nothing readable is left it falls back to the raw lines, because these messages are the only
+thing that reaches the owner and must fail noisy, never silent.
+"""
+from __future__ import annotations
+
+import re
+
+# Footer tokens are anchored to their glyphs so a real prompt that merely contains the words
+# ("Bypass permissions for this tool? (y/n)") is not mistaken for the idle footer.
+_NOISE_LINE = re.compile(
+    r"https?://|%3A|code_challenge|[?&]state=|^\[[^\]\n]{0,40}\s\d+:\w+|⏵⏵ bypass permissions|← for agents",
+    re.I)
+_RULE_CHARS = set("─│┌┐└┘├┤┬┴┼╭╮╯╰═║ ")
+_RULE_START = "─═╭╮╰╯┌┐└┘"  # a horizontal rule or a box corner begins chrome, never a prompt
+
+
+def readable_lines(prompt: str | None) -> list[str]:
+    """Every readable line of the pane, in order; empty when the pane is all chrome."""
+    lines = [ln.strip() for ln in (prompt or "").splitlines() if ln.strip()]
+    out = []
+    for core in lines:
+        if set(core) <= _RULE_CHARS or core[0] in _RULE_START:
+            continue  # a rule, with or without a label in it ("──── sutando-core ─")
+        if _NOISE_LINE.search(core):
+            continue
+        if len(core) > 80 and " " not in core:
+            continue
+        out.append(core.strip("─│ "))
+    return out
+
+
+def prompt_excerpt(prompt: str | None, limit: int = 6) -> list[str]:
+    """The pane's tail for the card: the last `limit` readable lines, or the raw tail when the
+    filter leaves nothing."""
+    lines = [ln.strip() for ln in (prompt or "").splitlines() if ln.strip()]
+    return (readable_lines(prompt) or lines)[-limit:]
+
+
+def first_readable_line(prompt: str | None) -> str:
+    """The single most informative line for a one-line notice: the first readable one, else the
+    first non-empty raw line, else ''."""
+    readable = readable_lines(prompt)
+    if readable:
+        return readable[0]
+    return next((ln.strip() for ln in (prompt or "").splitlines() if ln.strip()), "")

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -181,6 +181,18 @@ class TestComposeMessage(unittest.TestCase):
         self.assertIn("Login", m)  # first prompt line
         self.assertIn("resolve", m)
 
+    def test_login_pane_excerpt_is_the_prompt_not_the_chrome(self):
+        # The pane's first non-empty line is a box rule and the next an OAuth URL fragment; the
+        # one-line notice must quote the prompt (same filter as the escalation card).
+        pane = ("╭──────────────── sutando-core ─╮\n"
+                "https://claude.ai/oauth/authorize?code=true&code_challenge=ncifI5jOgzI138TpX&state=uv\n"
+                "Browser didn't open? Use the url below to sign in:\n"
+                "Paste code here if prompted >\n")
+        m = compose_message(dict(_LOGIN, prompt=pane))
+        self.assertIn("Use the url below to sign in", m)
+        for noise in ("╭", "───", "https://", "code_challenge"):
+            self.assertNotIn(noise, m)
+
     def test_handles_no_prompt(self):
         m = compose_message(_LOGGED_OUT)
         self.assertIn("not authenticated", m)

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -193,6 +193,25 @@ class TestComposeMessage(unittest.TestCase):
         for noise in ("╭", "───", "https://", "code_challenge"):
             self.assertNotIn(noise, m)
 
+    def test_the_excerpt_falls_back_to_the_first_line_when_the_filter_cannot_load(self):
+        # The notice is the owner's only channel: a missing filter module must not drop it.
+        pane = "╭─ rule ─╮\nBrowser didn't open? Use the url below to sign in:\n"
+        with patch.dict(sys.modules, {"prompt_excerpt": None}):
+            m = compose_message(dict(_LOGIN, prompt=pane))
+        self.assertIn("╭─ rule ─╮", m)  # the old first-non-empty line, degraded but delivered
+
+    def test_the_filter_is_found_from_the_relays_own_directory(self):
+        # Run as a script, sys.path[0] is not src/: the relay must add its own directory.
+        src_dir = os.path.dirname(_SRC)
+        saved = list(sys.path)
+        try:
+            sys.path[:] = [p for p in sys.path if os.path.abspath(p) != os.path.abspath(src_dir)]
+            sys.modules.pop("prompt_excerpt", None)
+            m = compose_message(dict(_LOGIN, prompt="╭─ rule ─╮\nUse the url below to sign in:\n"))
+        finally:
+            sys.path[:] = saved
+        self.assertIn("Use the url below to sign in", m)
+
     def test_handles_no_prompt(self):
         m = compose_message(_LOGGED_OUT)
         self.assertIn("not authenticated", m)

--- a/tests/prompt-excerpt.test.py
+++ b/tests/prompt-excerpt.test.py
@@ -52,8 +52,9 @@ class PromptExcerptTest(unittest.TestCase):
 
     def test_the_filter_has_one_home_and_both_adapters_delegate(self):
         # A private copy of the regex in either adapter is the defect this module removes.
-        watch = open(os.path.join(_SRC, "core-input-watch.py"), encoding="utf-8").read()
-        relay = open(os.path.join(_SRC, "core-supervisor-relay.py"), encoding="utf-8").read()
+        from pathlib import Path
+        watch = Path(_SRC, "core-input-watch.py").read_text(encoding="utf-8")
+        relay = Path(_SRC, "core-supervisor-relay.py").read_text(encoding="utf-8")
         for src, name in ((watch, "core-input-watch"), (relay, "core-supervisor-relay")):
             self.assertNotIn("code_challenge", src, f"{name} keeps a private copy of the filter")
             self.assertNotIn("_NOISE_LINE", src, f"{name} keeps a private copy of the filter")

--- a/tests/prompt-excerpt.test.py
+++ b/tests/prompt-excerpt.test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""The pane filter is one module; the card and the relay both read it, neither keeps a copy."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(_HERE, "..", "src")
+sys.path.insert(0, _SRC)
+from prompt_excerpt import first_readable_line, prompt_excerpt, readable_lines  # noqa: E402
+
+LOGIN_PANE = (
+    "╭──────────────────────────────────── sutando-core ─╮\n"
+    "Browser didn't open? Use the url below to sign in:\n"
+    "https://claude.ai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A65384%2Fcallback&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference&code_challenge=ncifI5jOgzI138TpX&state=uvUrUTS4WTI2FL\n"
+    "s%3Aclaude_code+user%3Amcp_servers&code_challenge=ncifI5jOgzI138TpX&state=uvUrUTS4WTI2FL\n"
+    "Paste code here if prompted >\n"
+    "Esc to cancel\n"
+    "──────────────────────────────────────────────────────\n"
+    "⏵⏵ bypass permissions on (shift+tab to cycle)\n"
+    "[sutando 2:monitor*                              ]\n"
+)
+NOISE = ("code_challenge", "%3A", "https://", "───", "bypass permissions", "2:monitor")
+
+
+class PromptExcerptTest(unittest.TestCase):
+    def test_readable_lines_keeps_the_prompt_and_drops_every_kind_of_chrome(self):
+        got = readable_lines(LOGIN_PANE)
+        self.assertEqual(got[0], "Browser didn't open? Use the url below to sign in:")
+        self.assertIn("Paste code here if prompted >", got)
+        self.assertIn("Esc to cancel", got)
+        for tok in NOISE:
+            self.assertFalse(any(tok in ln for ln in got), tok)
+
+    def test_first_readable_line_is_the_prompt_not_the_rule_above_it(self):
+        # The pane's first non-empty line is a box rule; the notice must not quote it.
+        self.assertEqual(first_readable_line(LOGIN_PANE),
+                         "Browser didn't open? Use the url below to sign in:")
+
+    def test_prompt_excerpt_is_the_readable_tail(self):
+        self.assertEqual(prompt_excerpt(LOGIN_PANE, limit=2),
+                         ["Paste code here if prompted >", "Esc to cancel"])
+
+    def test_all_chrome_falls_back_to_the_raw_lines_never_to_silence(self):
+        pane = "────────\n⏵⏵ bypass permissions on\n"
+        self.assertEqual(prompt_excerpt(pane), ["────────", "⏵⏵ bypass permissions on"])
+        self.assertEqual(first_readable_line(pane), "────────")
+        self.assertEqual(first_readable_line(""), "")
+        self.assertEqual(first_readable_line(None), "")
+
+    def test_the_filter_has_one_home_and_both_adapters_delegate(self):
+        # A private copy of the regex in either adapter is the defect this module removes.
+        watch = open(os.path.join(_SRC, "core-input-watch.py"), encoding="utf-8").read()
+        relay = open(os.path.join(_SRC, "core-supervisor-relay.py"), encoding="utf-8").read()
+        for src, name in ((watch, "core-input-watch"), (relay, "core-supervisor-relay")):
+            self.assertNotIn("code_challenge", src, f"{name} keeps a private copy of the filter")
+            self.assertNotIn("_NOISE_LINE", src, f"{name} keeps a private copy of the filter")
+            self.assertIn("from prompt_excerpt import", src, f"{name} does not delegate")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`compose_message()` in `src/core-supervisor-relay.py` quoted the **first non-empty** pane line as the one-line notice's excerpt. On a login pane that line is a box rule or an OAuth URL fragment — the same chrome #3969 filtered out of the escalation card. The card and the relay read the same pane text through two different policies, and the relay's was the wrong one.

## The fix, where the policy lives

- `src/prompt_excerpt.py` (new, dependency-light): `readable_lines()`, `prompt_excerpt()` (the card's tail) and `first_readable_line()` (the relay's one line). The filter is #3969's, moved, plus one addition: a labelled rule that begins with a box **corner** (`╭─ sutando-core ─╮`) counts as chrome; before, only rules beginning with `─`/`═` did.
- `src/core-input-watch.py`: the private copy is gone; it imports `prompt_excerpt` from the module (the 40-test suite is unchanged and green).
- `src/core-supervisor-relay.py`: takes `first_readable_line(prompt)`, inside the same "the owner's only channel — never crash the escalation" guard the file already uses; on any failure it falls back to the old first-non-empty line.

## Before / after — the relay's actual output on a login pane

Parent (`eee17261`):
```
⚠️ Agent needs you — awaiting user: login: ╭──────────────── sutando-core ─╮ — needs GUI /login on <host>: …
```
This head:
```
⚠️ Agent needs you — awaiting user: login: Browser didn't open? Use the url below to sign in: — needs GUI /login on <host>: …
```

## Tests + controls (all at this head)

```
tests/prompt-excerpt.test.py                       Ran 5 tests in 0.003s OK
tests/core-supervisor-relay.test.py                Ran 67 tests in 0.208s OK   (was 66)
tests/core-input-watch-chat-escalation.test.py     Ran 40 tests in 0.036s OK   (unchanged)
```
Mutation controls, each reverting ONE line with the tests kept, then restored:
- relay back to first-non-empty → `FAILED (failures=1)`: `test_login_pane_excerpt_is_the_prompt_not_the_chrome`; restored → OK.
- both adapters back to their parent copies (via `git show`) → `FAILED (failures=1)`: `test_the_filter_has_one_home_and_both_adapters_delegate`; restored → OK.
- corner glyphs removed from the rule-start set → `FAILED (failures=2)` (the two pane tests); restored → OK.

`bash scripts/review-checks.sh --diff`: `prose-cap: PASS`, `review-checks: PASS`. `docs/src-map.md` regenerated with `scripts/gen-src-map.py` (one new row).

## Worst case
Both surfaces keep their fail-noisy fallback: an all-chrome pane still yields the raw lines, and the relay's guard still yields the old first-non-empty line if the import ever fails. No status, state or delivery path changes.

Follow-up to #3969. — sutando-qingyun-air
