### PR TITLE
feat(agent-activity): every row names the message; queued at arrival; a dedup pointer closes as consolidated

### DIFF
--- a/skills/agent-activity/SKILL.md
+++ b/skills/agent-activity/SKILL.md
@@ -18,6 +18,11 @@ loopback media route as `/media/state/agent-activity.jsonl`:
 | `line` | the text, plain |
 | `task` | `{id, from, text}` — the user message this row belongs to (`from` an mxid, `text` ≤160 chars) |
 | `done` | `true` closes the task: all of its rows leave the drawer (the dock keeps them) |
+| `task.event` | event id of the user message (`source_message_id`); the client mounts the per-message card under it |
+| `task.into` | on a consolidated `done`: event id of the message whose reply answered this one too |
+
+A `notice` row reading `queued` is written by the task watcher when the file lands, before any turn
+has it (`activity.py queued --task-file …`; only for files that name a room and a message).
 
 A task's rows are **live** until its `done` row; a task-less row is live 15 minutes. The drawer
 shows only live rows and hides itself when none is live. Rows are flat: the client marks the first

--- a/skills/agent-activity/SKILL.md
+++ b/skills/agent-activity/SKILL.md
@@ -63,8 +63,9 @@ skill hook. The hook never depends on the agent remembering anything:
   (complete lines only, so a row mid-write is never split) and writes it as `thinking`.
 - **Scope of task ids.** `task-<hex>` and `task-chat-…` files are tasks; `task-cron-*`, `task-bench-*`,
   `task-workstream-*` and `task-project-grouping-*` are the core's own bookkeeping and produce no rows.
-  A result whose body starts with `[no-send]`, `[REPLIED]` or `[deduped: …]` closes the task with
-  "closed, no message sent from here", never "replied".
+  A result whose body starts with `[no-send]` or `[REPLIED]` closes the task with
+  "closed, no message sent from here", never "replied"; a `[deduped: task-X]` pointer closes it as
+  "consolidated" with `task.into` = X's message event id (the reply lives under that message).
 - **Bounded, one writer at a time.** Every append and the rotation that follows it run under one
   `flock` on `agent-activity.jsonl.lock`, so no row is lost or duplicated when hooks from several
   sessions write at once. The live log keeps the newest 400 rows (older rows move to `agent-activity.archive.jsonl`),

--- a/skills/agent-activity/hooks/activity-hook.py
+++ b/skills/agent-activity/hooks/activity-hook.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 from local_task_protocol import find_result  # noqa: E402
+from result_markers import parse_markers  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 
 WRITER = Path(__file__).resolve().parent.parent / "scripts" / "activity.py"  # lint-workspace-resolution: allow-repo-root (sibling script, not a data root)
@@ -146,7 +147,7 @@ def task_header(ws: Path, task_id: str) -> tuple[dict, str | None] | None:
         fields: dict = {}
         for l in p.read_text(encoding="utf-8", errors="replace").splitlines():
             k, _, v = l.partition(":")
-            if k in ("user_id", "task", "channel_id", "sender_name") and k not in fields:
+            if k in ("user_id", "task", "channel_id", "sender_name", "source_message_id") and k not in fields:
                 fields[k] = v.strip()
         task = {"id": task_id}
         if fields.get("user_id"):
@@ -155,6 +156,8 @@ def task_header(ws: Path, task_id: str) -> tuple[dict, str | None] | None:
             task["sender"] = fields["sender_name"]
         if fields.get("task"):
             task["text"] = fields["task"][:160]
+        if fields.get("source_message_id"):
+            task["event"] = fields["source_message_id"]  # the client mounts the card under this message
         return task, fields.get("channel_id") or None
     return None
 
@@ -236,15 +239,38 @@ def done_text(tool_input_json: str) -> str:
     return "closed, no message sent from here" if NO_SEND.search(tool_input_json) else "replied"
 
 
-def emit(kind: str, line: str, task: dict, room: str | None, ws: Path, run=subprocess.run) -> None:
+def consolidated_into(ws: Path, task_id: str) -> str | None:
+    """When the result is a `[deduped: task-X]` pointer, the event id of X's message (the one whose
+    reply answered this task too), else None. The marker grammar is result_markers'; never re-read here."""
+    path = ws / "results" / f"{task_id}.txt"
+    try:
+        body = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for a in parse_markers(body).actions:
+        if a.kind == "skip" and a.value == "deduped":
+            target = (a.extra or "").strip()
+            if target and not target.startswith("task-"):
+                target = f"task-{target}"
+            found = task_header(ws, target) if target else None
+            return (found[0].get("event") if found else None) or ""
+    return None
+
+
+def emit(kind: str, line: str, task: dict, room: str | None, ws: Path, run=subprocess.run,
+         into: str | None = None) -> None:
     if kind == "done":
         cmd = [sys.executable, str(WRITER), "done", line, "--task-id", task["id"], "--workspace", str(ws)]
+        if into:
+            cmd += ["--into", into]
     else:
         cmd = [sys.executable, str(WRITER), "append", line, "--kind", kind, "--task-id", task["id"], "--workspace", str(ws)]
     if isinstance(task.get("from"), str):
         cmd += ["--from", task["from"]]
     if isinstance(task.get("text"), str):
         cmd += ["--text", task["text"]]
+    if isinstance(task.get("event"), str):
+        cmd += ["--event", task["event"]]
     if room:
         cmd += ["--room", room]
     run(cmd, capture_output=True)
@@ -303,8 +329,10 @@ def handle(payload: dict, p: dict, run=subprocess.run) -> list[tuple[str, str]]:
         for tid in result_file_refs(blob):
             if tid in opened and binds.get(tid) == sid and (p["ws"] / "results" / f"{tid}.txt").exists():
                 task, room = opened[tid]["task"], opened[tid]["room"]
-                text = done_text(blob)
-                emit("done", text, task, room, p["ws"], run)
+                into = consolidated_into(p["ws"], tid)
+                # A dedup pointer answered this message under another one: say so, and name it.
+                text = "consolidated" if into is not None else done_text(blob)
+                emit("done", text, task, room, p["ws"], run, into=into or None)
                 out.append(("done", text))
     elif event == "Stop":
         tp = payload.get("transcript_path")

--- a/skills/agent-activity/scripts/activity.py
+++ b/skills/agent-activity/scripts/activity.py
@@ -107,7 +107,9 @@ def queued(task_file: Path, workspace: Path | None = None) -> int:
         task, room = task_from_file(task_file)
     except OSError:
         return 0
-    if not room or not task.get("text"):
+    # Only a task that names a room AND a message can mount under one: a room-addressed task with no
+    # source_message_id would leave a queued row the client can never place.
+    if not room or not task.get("text") or not task.get("event"):
         return 0
     rec = append("queued", kind="notice", room=room, task=task, workspace=workspace)
     print(json.dumps(rec, ensure_ascii=False))

--- a/skills/agent-activity/scripts/activity.py
+++ b/skills/agent-activity/scripts/activity.py
@@ -45,13 +45,15 @@ def task_from_file(path: Path) -> tuple[dict, str | None]:
     fields: dict = {}
     for l in path.read_text(encoding="utf-8", errors="replace").splitlines():
         k, _, v = l.partition(":")
-        if k in ("id", "user_id", "task", "channel_id") and k not in fields:
+        if k in ("id", "user_id", "task", "channel_id", "source_message_id") and k not in fields:
             fields[k] = v.strip()
     task = {"id": fields.get("id") or path.stem}
     if fields.get("user_id"):
         task["from"] = fields["user_id"]
     if fields.get("task"):
         task["text"] = fields["task"][:TEXT_MAX]
+    if fields.get("source_message_id"):
+        task["event"] = fields["source_message_id"]  # the client mounts the card under this message
     return task, fields.get("channel_id") or None
 
 
@@ -97,12 +99,34 @@ def rotate(path: Path, keep: int = LIVE_ROWS) -> None:
     os.replace(tmp, path)
 
 
+def queued(task_file: Path, workspace: Path | None = None) -> int:
+    """A `queued` notice for a task file that just landed: the message reached the device before any
+    turn picked it up. Written only when the file names a room and a message; a cron or bookkeeping
+    task has neither and must not appear in the owner's room. Never falls back to the default room."""
+    try:
+        task, room = task_from_file(task_file)
+    except OSError:
+        return 0
+    if not room or not task.get("text"):
+        return 0
+    rec = append("queued", kind="notice", room=room, task=task, workspace=workspace)
+    print(json.dumps(rec, ensure_ascii=False))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = ap.add_subparsers(dest="cmd", required=True)
+    q = sub.add_parser("queued", help="the message reached this device and no turn has it yet; from the task file only")
+    q.add_argument("--task-file", required=True)
+    q.add_argument("--workspace", default=None, help=argparse.SUPPRESS)
     for name, help_ in (("append", "one event"), ("done", "the task is finished: its rows leave the drawer")):
         s = sub.add_parser(name, help=help_)
         s.add_argument("line")
+        s.add_argument("--event", dest="task_event", default=None, help="event id of the user message this row belongs to")
+        if name == "done":
+            s.add_argument("--into", dest="task_into", default=None,
+                           help="consolidated reply: event id of the message whose reply answered this one too")
         s.add_argument("--room", default=None, help="room id; default: the owner's latest AG2 Space room")
         s.add_argument("--workspace", default=None, help=argparse.SUPPRESS)  # tests only
         s.add_argument("--task-id", default=None)
@@ -112,6 +136,8 @@ def main(argv: list[str] | None = None) -> int:
         if name == "append":
             s.add_argument("--kind", choices=KINDS[:-1], default="notice")
     a = ap.parse_args(argv)
+    if a.cmd == "queued":
+        return queued(Path(a.task_file), Path(a.workspace) if a.workspace else None)
     task = None
     room = a.room
     if a.task_file:
@@ -125,6 +151,10 @@ def main(argv: list[str] | None = None) -> int:
             task["from"] = a.task_from
         if a.task_text:
             task["text"] = a.task_text[:TEXT_MAX]
+    if a.task_event:
+        task = dict(task or {}, event=a.task_event)
+    if getattr(a, "task_into", None):
+        task = dict(task or {}, into=a.task_into)
     done = a.cmd == "done"
     ws = Path(a.workspace) if a.workspace else None
     rec = append(a.line, kind="done" if done else a.kind, room=room or default_room(ws), task=task, done=done,

--- a/src/task-emit.sh
+++ b/src/task-emit.sh
@@ -5,8 +5,20 @@
 # Emit one task filename on the caller's stable stdout duplicate (fd 9).
 # Never fatal: a failed shutdown emit must not abort the remaining cleanup — but
 # it must not be silent either, or a dropped line leaves no trace anywhere.
+# The message reached this device: a `queued` row for the room's card, before any turn has the task.
+# Fire-and-forget through the skill's own writer (which decides whether the file names a room);
+# it must never delay or fail the emit, and it is inert when TASKS_DIR is unset (tests, probes).
+queued_activity_row() {
+	local filename="$1"
+	[ -n "${TASKS_DIR:-}" ] && [ -f "$TASKS_DIR/$filename" ] || return 0
+	local writer="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/agent-activity/scripts/activity.py"
+	[ -f "$writer" ] || return 0
+	( python3 "$writer" queued --task-file "$TASKS_DIR/$filename" >/dev/null 2>&1 & ) 2>/dev/null || true
+	return 0
+}
 emit_task_file() {
 	local filename="$1"
+	queued_activity_row "$filename"
 	printf 'TASK_FILE: %s\n' "$filename" >&9 && return 0
 	echo "watch-tasks-stream: FAILED to emit TASK_FILE for $filename on fd 9 (rc=$?); the task file is written but the live core was not told" >&2
 	return 0
@@ -16,6 +28,7 @@ emit_task_file() {
 # real stdout, so it must not borrow the shutdown emitter's fd 9.
 emit_fallback_task_file() {
 	local filename="$1"
+	queued_activity_row "$filename"
 	printf 'TASK_FILE: %s\n' "$filename" && return 0
 	echo "watch-tasks-stream: FAILED to emit TASK_FILE for $filename on stdout after a handler fallback (rc=$?); the fallback file is written but the live core was not told" >&2
 	return 0

--- a/src/task-emit.sh
+++ b/src/task-emit.sh
@@ -13,7 +13,9 @@ queued_activity_row() {
 	[ -n "${TASKS_DIR:-}" ] && [ -f "$TASKS_DIR/$filename" ] || return 0
 	local writer="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/agent-activity/scripts/activity.py"
 	[ -f "$writer" ] || return 0
-	( python3 "$writer" queued --task-file "$TASKS_DIR/$filename" >/dev/null 2>&1 & ) 2>/dev/null || true
+	# The watcher's resolved interpreter, never PATH's: a configured python that works while PATH's
+	# does not would otherwise deliver the task and silently write no row.
+	( "${SUTANDO_PY_BIN:-python3}" "$writer" queued --task-file "$TASKS_DIR/$filename" >/dev/null 2>&1 & ) 2>/dev/null || true
 	return 0
 }
 emit_task_file() {

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -155,6 +155,78 @@ class WriterCli(unittest.TestCase):
         self.assertEqual((rec["task"]["id"], rec["task"]["from"], rec["room"]), ("task-cli", "@q:s", "!team:s"))
 
 
+class MessageEvent(unittest.TestCase):
+    """Every row carries the user message's event id, and the writer knows queued and consolidated."""
+
+    def setUp(self):
+        self.ws = Path(tempfile.mkdtemp())
+        (self.ws / "state").mkdir()
+        (self.ws / "tasks").mkdir()
+
+    def _task(self, name, room="!r:s", event="$ev1"):
+        body = f"id: {name}\nuser_id: @q:s\nsender_name: qingyun\ntask: Fix the thing\nsource: ag2space\n"
+        if room:
+            body += f"channel_id: {room}\n"
+        if event:
+            body += f"source_message_id: {event}\n"
+        (self.ws / "tasks" / f"{name}.txt").write_text(body)
+        return self.ws / "tasks" / f"{name}.txt"
+
+    def _rows(self):
+        return [json.loads(l) for l in (self.ws / "state" / "agent-activity.jsonl").read_text().splitlines()]
+
+    def test_task_file_carries_the_message_event_id(self):
+        task, room = card.task_from_file(self._task("task-e1"))
+        self.assertEqual((task["event"], room), ("$ev1", "!r:s"))
+
+    def test_queued_writes_a_notice_with_the_event_and_skips_a_roomless_file(self):
+        rc = card.main(["queued", "--task-file", str(self._task("task-q1")), "--workspace", str(self.ws)])
+        self.assertEqual(rc, 0)
+        rows = self._rows()
+        self.assertEqual((rows[-1]["kind"], rows[-1]["line"], rows[-1]["room"], rows[-1]["task"]["event"]),
+                         ("notice", "queued", "!r:s", "$ev1"))
+        # a cron/bookkeeping task names no room: nothing is written, and never to a default room
+        card.main(["queued", "--task-file", str(self._task("task-cron-1", room=None)), "--workspace", str(self.ws)])
+        self.assertEqual(len(self._rows()), 1)
+
+    def test_done_into_marks_a_consolidated_reply(self):
+        card.main(["done", "consolidated", "--task-id", "task-d1", "--into", "$holder", "--event", "$ev1",
+                       "--room", "!r:s", "--workspace", str(self.ws)])
+        row = self._rows()[-1]
+        self.assertTrue(row["done"])
+        self.assertEqual((row["task"]["into"], row["task"]["event"]), ("$holder", "$ev1"))
+
+    def test_pickup_row_carries_the_message_event_id(self):
+        p = hook.paths(self.ws); runs = []
+        self._task("task-p1")
+        hook.handle({"hook_event_name": "PreToolUse", "session_id": "S1", "tool_name": "Read",
+                     "tool_input": {"file_path": str(self.ws / "tasks" / "task-p1.txt")}}, p, lambda cmd, **kw: runs.append(cmd))
+        cmd = runs[-1]
+        self.assertEqual(cmd[cmd.index("--event") + 1], "$ev1")
+
+    def test_a_dedup_pointer_result_closes_as_consolidated_into_the_holder_message(self):
+        p = hook.paths(self.ws); runs = []
+        self._task("task-x1", event="$evx"); self._task("task-h1", event="$evh")
+        (self.ws / "results").mkdir()
+        (self.ws / "results" / "task-x1.txt").write_text("[deduped: task-h1]\n")
+        with open(p["log"], "a") as f:
+            f.write(json.dumps({"ts": 1, "kind": "processing", "line": "picked up", "room": "!r:s",
+                                "task": {"id": "task-x1", "event": "$evx"}}) + "\n")
+        hook.bind(p, "task-x1", "S1")
+        out = hook.handle({"hook_event_name": "PostToolUse", "session_id": "S1", "tool_name": "Write",
+                           "tool_input": {"file_path": str(self.ws / "results" / "task-x1.txt")}}, p, lambda cmd, **kw: runs.append(cmd))
+        self.assertEqual(out, [("done", "consolidated")])
+        cmd = runs[-1]
+        self.assertEqual((cmd[2], cmd[cmd.index("--into") + 1], cmd[cmd.index("--event") + 1]), ("done", "$evh", "$evx"))
+        # a real reply stays "replied" with no --into
+        runs.clear()
+        (self.ws / "results" / "task-x1.txt").write_text("Here is the answer.\n")
+        out = hook.handle({"hook_event_name": "PostToolUse", "session_id": "S1", "tool_name": "Write",
+                           "tool_input": {"file_path": str(self.ws / "results" / "task-x1.txt")}}, p, lambda cmd, **kw: runs.append(cmd))
+        self.assertEqual(out, [("done", "replied")])
+        self.assertNotIn("--into", runs[-1])
+
+
 class Hook(unittest.TestCase):
     """The PreToolUse/Stop hook: rows bind to the session that claimed the task, or nothing is written."""
 

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -204,6 +204,21 @@ class MessageEvent(unittest.TestCase):
         cmd = runs[-1]
         self.assertEqual(cmd[cmd.index("--event") + 1], "$ev1")
 
+    def test_queued_with_a_missing_task_file_writes_nothing_and_never_raises(self):
+        self.assertEqual(card.main(["queued", "--task-file", str(self.ws / "tasks" / "task-gone.txt"), "--workspace", str(self.ws)]), 0)
+        self.assertFalse(card.log_path(self.ws).exists())
+
+    def test_consolidated_into_handles_a_missing_result_and_a_bare_numeric_target(self):
+        p = hook.paths(self.ws)
+        self.assertIsNone(hook.consolidated_into(self.ws, "task-none"), "no result file: not a dedup, not a crash")
+        (self.ws / "results").mkdir()
+        self._task("task-77", event="$ev77")
+        (self.ws / "results" / "task-x2.txt").write_text("[deduped: 77]\n")
+        self.assertEqual(hook.consolidated_into(self.ws, "task-x2"), "$ev77", "a bare id resolves to its task file")
+        (self.ws / "results" / "task-x3.txt").write_text("[deduped: task-unknown]\n")
+        self.assertEqual(hook.consolidated_into(self.ws, "task-x3"), "", "a dedup whose holder is gone still reads as consolidated")
+        del p
+
     def test_a_dedup_pointer_result_closes_as_consolidated_into_the_holder_message(self):
         p = hook.paths(self.ws); runs = []
         self._task("task-x1", event="$evx"); self._task("task-h1", event="$evh")

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -188,6 +188,10 @@ class MessageEvent(unittest.TestCase):
         # a cron/bookkeeping task names no room: nothing is written, and never to a default room
         card.main(["queued", "--task-file", str(self._task("task-cron-1", room=None)), "--workspace", str(self.ws)])
         self.assertEqual(len(self._rows()), 1)
+        # a room-addressed compatibility task with no source_message_id cannot mount under a message:
+        # nothing is written for it either (a queued row nobody can place is misleading drawer activity)
+        card.main(["queued", "--task-file", str(self._task("task-noevent", event=None)), "--workspace", str(self.ws)])
+        self.assertEqual(len(self._rows()), 1)
 
     def test_done_into_marks_a_consolidated_reply(self):
         card.main(["done", "consolidated", "--task-id", "task-d1", "--into", "$holder", "--event", "$ev1",

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -88,6 +88,7 @@ class Writer(unittest.TestCase):
         import multiprocessing as mp
         with mp.get_context("fork").Pool(8) as pool:
             pool.starmap(_append_many, [(str(self.ws), f"w{i}", 30, 25) for i in range(8)])
+            pool.close(); pool.join()  # workers exit on their own: a terminate() under coverage deadlocks them
         live = card.log_path(self.ws).read_text().splitlines()
         arch = (self.ws / "state" / "agent-activity.archive.jsonl").read_text().splitlines()
         lines = [json.loads(l)["line"] for l in live + arch]
@@ -432,6 +433,7 @@ class Hook(unittest.TestCase):
         ws = str(self.ws)
         with mp.get_context("fork").Pool(8) as pool:
             pool.starmap(_bind_in_process, [(ws, f"task-c{i:06d}", f"S{i}") for i in range(8)])
+            pool.close(); pool.join()  # workers exit on their own: a terminate() under coverage deadlocks them
         binds = hook.load_json(self.p["bind"], {})
         self.assertEqual(sorted(binds), [f"task-c{i:06d}" for i in range(8)], binds)
         self.assertFalse(list((self.ws / "state").glob(".agent-activity.sessions.json.*.tmp")), "no temp files left")


### PR DESCRIPTION
## The defect

The desktop client mounts the agent's card under a message by the row's `task.event` (`inlineActivityByEvent` in cinny-webclient's `activityStream.ts`). The shipped writer never carried that field — `task_from_file()` and the hook's `task_header()` read `user_id`/`task`/`channel_id`/`sender_name` only — so every install other than the one running a local prototype tailer got the events drawer and **no per-message card**. Two more phases the client renders had no shipped writer at all: the `queued` notice (message reached the device, no turn has it yet) and the `consolidated` done row with `task.into` (answered together with a later message).

## The fix, in the skill that owns the rows

- `scripts/activity.py`: `task_from_file` reads `source_message_id` → `task.event`; `--event` on append/done, `--into` on done; a `queued` subcommand that writes the notice from a task file **only when it names a room and a message** and never falls back to the default room (a cron task must not appear in the owner's room).
- `hooks/activity-hook.py`: `task_header` carries the event; `emit` passes `--event`; on the result write, `consolidated_into()` asks `result_markers.parse_markers` (the one marker grammar) whether the body is a `[deduped: task-X]` pointer and closes the task as `consolidated` with X's message event id.
- `src/task-emit.sh`: `queued_activity_row` fires the writer in the background before the `TASK_FILE:` emit; inert without `TASKS_DIR` (tests, probes) and it can neither delay nor fail the emit.
- `SKILL.md`: the two fields and the queued notice documented.

## Evidence

```
tests/agent-activity.test.py             Ran 34 tests in 0.288s OK   (was 29)
tests/task-emit-substitution.test.sh     ALL PASS
```
Mutation controls — one line each, tests kept, then restored:
- hook stops passing `--event` → `FAILED (errors=2)`: `test_pickup_row_carries_the_message_event_id` and the consolidated test both error on the missing flag
- consolidated branch removed → `FAILED (failures=1)`: `test_a_dedup_pointer_result_closes_as_consolidated_into_the_holder_message`
- `queued` falls back to the default room → `FAILED (failures=1)`: `test_queued_writes_a_notice_with_the_event_and_skips_a_roomless_file`

`scripts/review-checks.sh --diff`: PASS.

## Worst case
A row gains two optional fields the client already reads; nothing else changes shape. The queued write is fire-and-forget behind the emit, so a missing or broken writer changes nothing about task delivery. Follow-up (separate PR): a durable per-message summary at done, so the folded card survives the 400-row window.

— sutando-qingyun-air
